### PR TITLE
Updated GenXSecAnalyzer and GenLumiInfoProduct for combining files correctly

### DIFF
--- a/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
+++ b/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
@@ -1,3 +1,4 @@
+
 #ifndef GENXSECANALYZER_H
 #define GENXSECANALYZER_H
 
@@ -10,6 +11,7 @@
 // system include files
 #include <memory>
 #include <vector>
+#include <map>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -23,11 +25,12 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
+
 //
 // class declaration
 //
 
-class GenXSecAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchLuminosityBlocks> {
+class GenXSecAnalyzer : public edm::one::EDAnalyzer<edm::one::WatchRuns,edm::one::WatchLuminosityBlocks>{
 
 
 public:
@@ -39,11 +42,17 @@ public:
 private:
 
   virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+  virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endJob() override;
-  void compute();
+  // computation of cross section after matching (could be either before or after HepcFilter and GenFilter)
+  GenLumiInfoProduct::XSec compute(const GenLumiInfoProduct &);
+  // combination of cross section from different MCs after matching (could be either before or after HepcFilter and GenFilter)
+  void combine(GenLumiInfoProduct::XSec&, double&, const GenLumiInfoProduct::XSec&, const double&);
+  void combine(double&, double&, double&, const double&, const double&, const double &);
 
   edm::EDGetTokenT<GenFilterInfo> genFilterInfoToken_;
   edm::EDGetTokenT<GenFilterInfo> hepMCFilterInfoToken_;
@@ -51,28 +60,60 @@ private:
   
   // ----------member data --------------------------
 
-  int hepidwtup_;
-  unsigned int theProcesses_size;
-  bool           hasHepMCFilterInfo_;
+  int nMCs_;
 
-  // final cross sections
+  int hepidwtup_;
+
+  // for weight before GenFilter and HepMCFilter and before matching
+  double totalWeightPre_;
+  double thisRunWeightPre_;
+
+  // combined cross sections before HepMCFilter and GenFilter
+  GenLumiInfoProduct::XSec xsecPreFilter_;
+
+  // final combined cross sections
   GenLumiInfoProduct::XSec xsec_;
-  // statistics from additional generator filter
+
+  // GenLumiInfo before HepMCFilter and GenFilter, this is used 
+  // for computation
+  GenLumiInfoProduct product_; 
+
+  // statistics from additional generator filter, for computation
+  // reset for each run
+  GenFilterInfo  filterOnlyEffRun_;     
+
+  // statistics from HepMC filter, for computation
+  GenFilterInfo  hepMCFilterEffRun_;   
+
+  // statistics from additional generator filter, for print-out only
   GenFilterInfo  filterOnlyEffStat_;     
 
-  // statistics from HepMC filter
+  // statistics from HepMC filter, for print-out only
   GenFilterInfo  hepMCFilterEffStat_;   
 
-  // statistics for event level efficiency, the size is the number of processes + 1 
-  std::vector<GenFilterInfo>  eventEffStat_; 
-  // statistics from jet matching, the size is the number of processes + 1 
-  std::vector<GenFilterInfo>  jetMatchEffStat_; 
-  // uncertainty-averaged cross sections before matching, the size is the number of processes + 1
+
+  // the vector/map size is the number of LHE processes + 1
+  // needed only for printouts, not used for computation
+  // only printed out when combining the same physics process 
+  // uncertainty-averaged cross sections before matching
   std::vector<GenLumiInfoProduct::XSec> xsecBeforeMatching_;
-  // uncertainty-averaged cross sections after matching, the size is the number of processes + 1 
+  // uncertainty-averaged cross sections after matching
   std::vector<GenLumiInfoProduct::XSec> xsecAfterMatching_; 
-  // the size depends on the number of MC with different LHE information
-  std::vector<GenLumiInfoProduct> products_; 
+  // statistics from jet matching
+  std::map<int, GenFilterInfo>  jetMatchEffStat_; 
+
+
+  // the following vectors all have the same size
+  // LHE or Pythia/Herwig cross section of previous luminosity block
+  // vector size = number of processes, used for computation
+  std::map<int, GenLumiInfoProduct::XSec> previousLumiBlockLHEXSec_;
+
+ // LHE or Pythia/Herwig combined cross section of current luminosity block
+ // updated for each luminosity block, initialized in every run
+  // used for computation
+  std::map<int, GenLumiInfoProduct::XSec> currentLumiBlockLHEXSec_;
+
+
 
 };
 

--- a/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
+++ b/GeneratorInterface/Core/interface/GenXSecAnalyzer.h
@@ -48,7 +48,7 @@ private:
   virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
   virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
   virtual void endJob() override;
-  // computation of cross section after matching (could be either before or after HepcFilter and GenFilter)
+  // computation of cross section after matching and before HepcFilter and GenFilter
   GenLumiInfoProduct::XSec compute(const GenLumiInfoProduct &);
   // combination of cross section from different MCs after matching (could be either before or after HepcFilter and GenFilter)
   void combine(GenLumiInfoProduct::XSec&, double&, const GenLumiInfoProduct::XSec&, const double&);
@@ -67,6 +67,10 @@ private:
   // for weight before GenFilter and HepMCFilter and before matching
   double totalWeightPre_;
   double thisRunWeightPre_;
+
+  // for weight after GenFilter and HepMCFilter and after matching
+  double totalWeight_;
+  double thisRunWeight_;
 
   // combined cross sections before HepMCFilter and GenFilter
   GenLumiInfoProduct::XSec xsecPreFilter_;

--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -1,21 +1,29 @@
 #include "GeneratorInterface/Core/interface/GenXSecAnalyzer.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimDataFormats/GeneratorProducts/interface/LHERunInfoProduct.h"
+#include "TMath.h"
 #include <iostream>
 #include <iomanip>
 
 GenXSecAnalyzer::GenXSecAnalyzer(const edm::ParameterSet& iConfig):
-  hepidwtup_(-1),
-  theProcesses_size(0),
-  hasHepMCFilterInfo_(false),
-  xsec_(0,0),
+  nMCs_(0),
+  hepidwtup_(-9999),
+  totalWeightPre_(0),
+  thisRunWeightPre_(0),
+  xsecPreFilter_(-1,-1),
+  xsec_(-1,-1),
+  product_(GenLumiInfoProduct(-9999)),
+  filterOnlyEffRun_(0,0,0,0,0.,0.,0.,0.),
+  hepMCFilterEffRun_(0,0,0,0,0.,0.,0.,0.),
   filterOnlyEffStat_(0,0,0,0,0.,0.,0.,0.),
   hepMCFilterEffStat_(0,0,0,0,0.,0.,0.,0.)
 {
-  eventEffStat_.clear();
-  jetMatchEffStat_.clear();
   xsecBeforeMatching_.clear();
-  xsecAfterMatching_.clear();
-  products_.clear();
+  xsecAfterMatching_.clear(); 
+  jetMatchEffStat_.clear(); 
+  previousLumiBlockLHEXSec_.clear();
+  currentLumiBlockLHEXSec_.clear();
+
   genFilterInfoToken_ = consumes<GenFilterInfo,edm::InLumi>(edm::InputTag("genFilterEfficiencyProducer",""));
   hepMCFilterInfoToken_ = consumes<GenFilterInfo,edm::InLumi>(edm::InputTag("generator",""));
   genLumiInfoToken_ = consumes<GenLumiInfoProduct,edm::InLumi>(edm::InputTag("generator",""));
@@ -27,12 +35,47 @@ GenXSecAnalyzer::~GenXSecAnalyzer()
 
 void
 GenXSecAnalyzer::beginJob() {
-  eventEffStat_.clear();
-  jetMatchEffStat_.clear();
+
   xsecBeforeMatching_.clear();
-  xsecAfterMatching_.clear();
-  products_.clear();  
+  xsecAfterMatching_.clear(); 
+  jetMatchEffStat_.clear(); 
+  previousLumiBlockLHEXSec_.clear();
+  currentLumiBlockLHEXSec_.clear();
+
 }
+
+void 
+GenXSecAnalyzer::beginRun(edm::Run const& iRun, edm::EventSetup const&)
+{
+  // initialization for every different physics MC
+
+  nMCs_++;
+
+  thisRunWeightPre_ = 0;
+
+
+  product_ = GenLumiInfoProduct(-9999);
+
+  filterOnlyEffRun_ = GenFilterInfo(0,0,0,0,0.,0.,0.,0.);
+  hepMCFilterEffRun_ = GenFilterInfo(0,0,0,0,0.,0.,0.,0.);
+
+
+  xsecBeforeMatching_.clear();
+  xsecAfterMatching_.clear(); 
+  jetMatchEffStat_.clear(); 
+  previousLumiBlockLHEXSec_.clear();
+  currentLumiBlockLHEXSec_.clear();
+
+
+  return;
+}
+
+void
+GenXSecAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
+
+}
+
+
 
 void
 GenXSecAnalyzer::analyze(const edm::Event&, const edm::EventSetup&)
@@ -40,34 +83,20 @@ GenXSecAnalyzer::analyze(const edm::Event&, const edm::EventSetup&)
 }
 
 
-void
-GenXSecAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
-}
 
 void
 GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::EventSetup const&) {
-  // add up information of GenFilterInfo from different luminosity blocks
-  edm::Handle<GenFilterInfo> genFilter;
-  iLumi.getByToken(genFilterInfoToken_,genFilter);
-  if(genFilter.isValid())
-    filterOnlyEffStat_.mergeProduct(*genFilter);
-
-
-  edm::Handle<GenFilterInfo> hepMCFilter;
-  iLumi.getByToken(hepMCFilterInfoToken_,hepMCFilter);
-  hasHepMCFilterInfo_ = hepMCFilter.isValid();
-  if(hasHepMCFilterInfo_)
-    hepMCFilterEffStat_.mergeProduct(*hepMCFilter);
 
 
   edm::Handle<GenLumiInfoProduct> genLumiInfo;
   iLumi.getByToken(genLumiInfoToken_,genLumiInfo);
   if (!genLumiInfo.isValid()) return;
-
   hepidwtup_ = genLumiInfo->getHEPIDWTUP();
 
   std::vector<GenLumiInfoProduct::ProcessInfo> theProcesses = genLumiInfo->getProcessInfos();
-  theProcesses_size = theProcesses.size();
+
+  unsigned int theProcesses_size = theProcesses.size();
+
   // if it's a pure parton-shower generator, check there should be only one element in thisProcessInfos
   // the error of lheXSec is -1
   if(hepidwtup_== -1)
@@ -76,287 +105,345 @@ GenXSecAnalyzer::endLuminosityBlock(edm::LuminosityBlock const& iLumi, edm::Even
 	edm::LogError("GenXSecAnalyzer::endLuminosityBlock") << "Pure parton shower has thisProcessInfos size!=1";
 	return;
       }
-      if(theProcesses[0].lheXSec().value()<1e-6){
-	edm::LogError("GenXSecAnalyzer::endLuminosityBlock") << "cross section value = "  << theProcesses[0].lheXSec().value();
+    }
+
+
+  for(unsigned int ip=0; ip < theProcesses_size; ip++)
+    {
+
+      if(theProcesses[ip].lheXSec().value()<0){
+	edm::LogError("GenXSecAnalyzer::endLuminosityBlock") << "cross section of process " << ip << " value = "  << theProcesses[ip].lheXSec().value();
 	return;
       }
     }
 
-  // now determine if this LuminosityBlock has the same lheXSec as existing products
-  bool sameMC = false;
-  for(unsigned int i=0; i < products_.size(); i++){
+  product_.mergeProduct(*genLumiInfo);
 
-    if(products_[i].mergeProduct(*genLumiInfo))
-      sameMC = true;
-    else if(!products_[i].samePhysics(*genLumiInfo))
-      {
-	edm::LogError("GenXSecAnalyzer::endLuminosityBlock") << "Merging samples that come from different physics processes";
-	return;
-      }
+  edm::Handle<GenFilterInfo> genFilter;
+  iLumi.getByToken(genFilterInfoToken_,genFilter);
+  if(genFilter.isValid())
+    {
+      filterOnlyEffStat_.mergeProduct(*genFilter);
+      filterOnlyEffRun_.mergeProduct(*genFilter);
+    }
 
-  }
+
+  edm::Handle<GenFilterInfo> hepMCFilter;
+  iLumi.getByToken(hepMCFilterInfoToken_,hepMCFilter);
+
+  if(hepMCFilter.isValid())
+    {
+      hepMCFilterEffStat_.mergeProduct(*hepMCFilter);
+      hepMCFilterEffRun_.mergeProduct(*hepMCFilter);
+    }
   
-  if(!sameMC)
-    products_.push_back(*genLumiInfo);
-
-
-  // initialize jetMatchEffStat with nprocess+1 elements
-  if(jetMatchEffStat_.size()==0){
-    
-    for(unsigned int ip=0; ip < theProcesses_size; ip++)
-      {
-	jetMatchEffStat_.push_back(GenFilterInfo(0,0,0,0,0.,0.,0.,0.));
-      }
-    jetMatchEffStat_.push_back(GenFilterInfo(0,0,0,0,0.,0.,0.,0.));
-  }
-
-  // initialize event-level statistics with nprocess+1 elements
-  if(eventEffStat_.size()==0){
-    
-    for(unsigned int ip=0; ip < theProcesses_size; ip++)
-      {
-	eventEffStat_.push_back(GenFilterInfo(0,0,0,0,0.,0.,0.,0.));
-      }
-    eventEffStat_.push_back(GenFilterInfo(0,0,0,0,0.,0.,0.,0.));
-  }
 
   // doing generic summing for jet matching statistics
+  // and computation of combined LHE information
   for(unsigned int ip=0; ip < theProcesses_size; ip++)
     {
+      int id = theProcesses[ip].process();
+      GenFilterInfo&x = jetMatchEffStat_[id];
+      GenLumiInfoProduct::XSec& y = currentLumiBlockLHEXSec_[id];
       GenLumiInfoProduct::FinalStat temp_killed   = theProcesses[ip].killed();
       GenLumiInfoProduct::FinalStat temp_selected = theProcesses[ip].selected();
       double passw  = temp_killed.sum();
       double passw2 = temp_killed.sum2();
       double totalw  = temp_selected.sum();
       double totalw2 = temp_selected.sum2();
-      // matching statistics for each process
-      jetMatchEffStat_[ip].mergeProduct(GenFilterInfo(
-						      theProcesses[ip].nPassPos(),
-						      theProcesses[ip].nPassNeg(),
-						      theProcesses[ip].nTotalPos(),
-						      theProcesses[ip].nTotalNeg(),
-						      passw,
-						      passw2,
-						      totalw,
-						      totalw2)
-					);
-      // matching statistics for all processes
-      jetMatchEffStat_[theProcesses_size].mergeProduct(GenFilterInfo(
-								     theProcesses[ip].nPassPos(),
-								     theProcesses[ip].nPassNeg(),
-								     theProcesses[ip].nTotalPos(),
-								     theProcesses[ip].nTotalNeg(),
-								     passw,
-								     passw2,
-								     totalw,
-								     totalw2)
-						       );
+      GenFilterInfo tempInfo(
+			     theProcesses[ip].nPassPos(),
+			     theProcesses[ip].nPassNeg(),
+			     theProcesses[ip].nTotalPos(),
+			     theProcesses[ip].nTotalNeg(),
+			     passw,
+			     passw2,
+			     totalw,
+			     totalw2);
+
+    // matching statistics for all processes
+      jetMatchEffStat_[10000].mergeProduct(tempInfo);
+      double currentValue  = theProcesses[ip].lheXSec().value();
+      double currentError  = theProcesses[ip].lheXSec().error();
 
 
+      // this process ID has occurred before
+      if(y.value()>0)
+	{
+	  x.mergeProduct(tempInfo);
+	  double previousValue = previousLumiBlockLHEXSec_[id].value();
 
-      // event-level statistics for each process
-      eventEffStat_[ip].mergeProduct(GenFilterInfo(
-						   theProcesses[ip].nPassPos()+theProcesses[ip].nPassNeg(),
-						   0,
-						   theProcesses[ip].nTotalPos()+theProcesses[ip].nTotalNeg(),
-						   0,
-						   theProcesses[ip].nPassPos()+theProcesses[ip].nPassNeg(),
-						   theProcesses[ip].nPassPos()+theProcesses[ip].nPassNeg(),
-						   theProcesses[ip].nTotalPos()+theProcesses[ip].nTotalNeg(),
-						   theProcesses[ip].nTotalPos()+theProcesses[ip].nTotalNeg())
-				     );
-      // event-level statistics for all processes
-      eventEffStat_[theProcesses_size].mergeProduct(GenFilterInfo(
-								  theProcesses[ip].nPassPos()+theProcesses[ip].nPassNeg(),
-								  0,
-								  theProcesses[ip].nTotalPos()+theProcesses[ip].nTotalNeg(),
-								  0,
-								  theProcesses[ip].nPassPos()+theProcesses[ip].nPassNeg(),
-								  theProcesses[ip].nPassPos()+theProcesses[ip].nPassNeg(),
-								  theProcesses[ip].nTotalPos()+theProcesses[ip].nTotalNeg(),
-								  theProcesses[ip].nTotalPos()+theProcesses[ip].nTotalNeg())
-						    );
-     
+	  if(currentValue != previousValue) // transition of cross section
+	    {
 
-    }
+	      double xsec = y.value();
+	      double err  = y.error();
+	      combine(xsec, err, thisRunWeightPre_, currentValue, currentError, totalw);
+	      y = GenLumiInfoProduct::XSec(xsec,err);
+	    }
+	  else // LHE cross section is the same as previous lumiblock
+	    thisRunWeightPre_ += totalw;
+	
+	}
+      // this process ID has never occurred before
+      else
+	{
+	  x = tempInfo;
+	  y = theProcesses[ip].lheXSec();	      
+	  thisRunWeightPre_ += totalw;
+	}
 
+      previousLumiBlockLHEXSec_[id]= theProcesses[ip].lheXSec();
+    } // end
+
+ 
 
   return;
   
 }
 
 void 
-GenXSecAnalyzer::compute()
+GenXSecAnalyzer::endRun(edm::Run const& iRun, edm::EventSetup const&)
 {
-  // for pure parton shower generator
+  //xsection before matching
+  edm::Handle<LHERunInfoProduct> run;
 
-  if(hepidwtup_== -1)
+  if(iRun.getByLabel("externalLHEProducer", run ))
     {
-      double sigSum = 0.0;
-      double totalN = 0.0;
-      for(unsigned int i=0; i < products_.size(); i++){
+      const lhef::HEPRUP thisHeprup_ = run->heprup();
 
-	GenLumiInfoProduct::ProcessInfo proc = products_[i].getProcessInfos()[0];	  
-	double hepxsec_value = proc.lheXSec().value();
-	sigSum += proc.tried().sum() * hepxsec_value;
-	totalN += proc.tried().sum();
+      for ( unsigned int iSize = 0 ; iSize < thisHeprup_.XSECUP.size() ; iSize++ ) {
+	std::cout  << std::setw(14) << std::fixed << thisHeprup_.XSECUP[iSize]
+		   << std::setw(14) << std::fixed << thisHeprup_.XERRUP[iSize]
+		   << std::setw(14) << std::fixed << thisHeprup_.XMAXUP[iSize]
+		   << std::setw(14) << std::fixed << thisHeprup_.LPRUP[iSize] 
+		   << std::endl;
       }
-      // average over number of events since the cross sections have no errors
-      double sigAve = totalN>1e-6? sigSum/totalN: 0;
-      xsecBeforeMatching_.push_back(GenLumiInfoProduct::XSec(sigAve,-1));
-      xsecAfterMatching_.push_back(GenLumiInfoProduct::XSec(sigAve,-1));
+      std::cout << " " << std::endl;
     }
-  // for ME+parton shower MC
-  else{
+        
 
-    const unsigned int sizeOfInfos= theProcesses_size+1;
-    // for computing cross sectiona before matching
-    double sum_numerator_before[sizeOfInfos]; 
-    double sum_denominator_before[sizeOfInfos];
+ 
+  // compute cross section for this run first
+  // set the correct combined LHE+filter cross sections
+  unsigned int i = 0;
+  std::vector<GenLumiInfoProduct::ProcessInfo> newInfos;
+  for(std::map<int, GenLumiInfoProduct::XSec>::const_iterator iter = currentLumiBlockLHEXSec_.begin();
+      iter!=currentLumiBlockLHEXSec_.end(); ++iter, i++)
+    {
+      GenLumiInfoProduct::ProcessInfo temp = product_.getProcessInfos()[i];
+      temp.setLheXSec(iter->second.value(),iter->second.error());
+      newInfos.push_back(temp);
+    }
+  product_.setProcessInfo(newInfos);
 
-    // for computing cross sectiona after matching
-    double sum_numerator_after[sizeOfInfos];
-    double sum_denominator_after[sizeOfInfos];
+  const GenLumiInfoProduct::XSec thisRunXSecPre     = compute(product_);
+ // xsection after matching before filters
+  combine(xsecPreFilter_, totalWeightPre_, thisRunXSecPre, thisRunWeightPre_);
 
-    // initialize every element with zero
-    for(unsigned int i=0; i < sizeOfInfos; i++)
-      {
-	sum_numerator_before[i]=0; 
-	sum_denominator_before[i]=0;
-	sum_numerator_after[i]=0;
-	sum_denominator_after[i]=0;
-      }
-  
-    // loop over different MC samples
-    for(unsigned int i=0; i < products_.size(); i++){
+  double thisHepFilterEff = 1; 
+  double thisHepFilterErr = 0; 
 
-      // sum of cross sections and errors over different processes
-      double sigSelSum = 0.0;
-      double errSel2Sum = 0.0;
-      double sigSum = 0.0;
-      double err2Sum = 0.0;
-
-      // loop over different processes for each sample
-      unsigned int vectorSize = products_[i].getProcessInfos().size();
-      for(unsigned int ip=0; ip < vectorSize; ip++){
-	GenLumiInfoProduct::ProcessInfo proc = products_[i].getProcessInfos()[ip];	  
-	double hepxsec_value = proc.lheXSec().value();
-	double hepxsec_error = proc.lheXSec().error();
-
-	// skips computation if jet matching efficiency=0
-	if (proc.killed().n()<1)
-	  continue;
-
-	// computing jet matching efficiency for this process
-	double fracAcc = 0;
-	double ntotal = proc.nTotalPos()-proc.nTotalNeg();
-	double npass  = proc.nPassPos() -proc.nPassNeg();
-	switch(hepidwtup_){
-	case 3: case -3:
-	  fracAcc = ntotal > 1e-6? npass/ntotal: -1;
-	    break;
-	default:
-	  fracAcc = proc.selected().sum() > 1e-6? proc.killed().sum() / proc.selected().sum():-1;
-	  break;
+  if(hepMCFilterEffRun_.sumWeights2()>0)
+    {
+      thisHepFilterEff = hepMCFilterEffRun_.filterEfficiency(hepidwtup_);
+      thisHepFilterErr = hepMCFilterEffRun_.filterEfficiencyError(hepidwtup_);
+      if(thisHepFilterEff<0)
+	{
+	  thisHepFilterEff = 1; 
+	  thisHepFilterErr = 0; 
 	}
 
-	if(fracAcc<1e-6)continue;
+    }
 
-	// cross section after matching for this particular process
-	double sigmaFin = hepxsec_value * fracAcc;
+  double thisGenFilterEff = 1; 
+  double thisGenFilterErr = 0; 
 
-	// computing error on jet matching efficiency
-	double relErr = 1.0;
-	double efferr2=0;
-	switch(hepidwtup_) {
-	case 3: case -3:
-	  {
-	    double ntotal_pos = proc.nTotalPos();
-	    double effp  = ntotal_pos > 1e-6?
-	      (double)proc.nPassPos()/ntotal_pos:0;
-	    double effp_err2 = ntotal_pos > 1e-6?
-	      (1-effp)*effp/ntotal_pos: 0;
-
-	    double ntotal_neg = proc.nTotalNeg();
-	    double effn  = ntotal_neg > 1e-6?
-	      (double)proc.nPassNeg()/ntotal_neg:0;
-	    double effn_err2 = ntotal_neg > 1e-6?
-	      (1-effn)*effn/ntotal_neg: 0;
-
-	    efferr2 = ntotal > 0 ? 
-	      (ntotal_pos*ntotal_pos*effp_err2 +
-	       ntotal_neg*ntotal_neg*effn_err2)/ntotal/ntotal:0;
-	    break;
-	  }
-	default:
-	  {
-	    double denominator = pow(proc.selected().sum(),4);
-	    double passw       = proc.killed().sum();
-	    double passw2      = proc.killed().sum2();
-	    double failw       = proc.selected().sum() - passw;
-	    double failw2      = proc.selected().sum2() - passw2;
-	    double numerator   = (passw2*failw*failw + failw2*passw*passw); 
-			    
-	    efferr2 = denominator>1e-6?
-	      numerator/denominator:0;
-	    break;
-	  }
+  if(filterOnlyEffRun_.sumWeights2()>0)
+    {
+      thisGenFilterEff = filterOnlyEffRun_.filterEfficiency(hepidwtup_);
+      thisGenFilterErr = filterOnlyEffRun_.filterEfficiencyError(hepidwtup_);
+      if(thisGenFilterEff<0)
+	{
+	  thisGenFilterEff = 1; 
+	  thisGenFilterErr = 0; 
 	}
-	double delta2Veto = efferr2/fracAcc/fracAcc;
-	
-	// computing total error on cross section after matching efficiency
 
-	double sigma2Sum, sigma2Err;
-	sigma2Sum = hepxsec_value * hepxsec_value;
-	sigma2Err = hepxsec_error * hepxsec_error;
+    }
+  double finalXsec = xsecPreFilter_.value() > 0 ? thisHepFilterEff*thisGenFilterEff*xsecPreFilter_.value() : 0;
+  double finalErr = xsecPreFilter_.value() > 0 ? finalXsec*
+    sqrt(pow(TMath::Max(xsecPreFilter_.error(),(double)0)/xsecPreFilter_.value(),2)+
+	 pow(thisHepFilterErr/thisHepFilterEff,2)+
+	 pow(thisGenFilterErr/thisGenFilterEff,2)) : 0;
+  xsec_ = GenLumiInfoProduct::XSec(finalXsec,finalErr);
 
-	// sum of cross sections before matching and errors over different samples for each process
-	sum_denominator_before[ip]  +=  (sigma2Err > 0)? 1/sigma2Err: 0;
-	sum_numerator_before[ip]    +=  (sigma2Err > 0)?  hepxsec_value/sigma2Err: 0;
-
-
-	double delta2Sum = delta2Veto
-	  + sigma2Err / sigma2Sum;
-	relErr = (delta2Sum > 0.0 ?
-		  std::sqrt(delta2Sum) : 0.0);
-	double deltaFin = sigmaFin * relErr;
-
-	// sum of cross sections and errors over different processes
-	sigSelSum += hepxsec_value;
-	errSel2Sum += sigma2Err;
-	sigSum += sigmaFin;
-	err2Sum += deltaFin * deltaFin;
-	
-	// sum of cross sections after matching and errors over different samples for each process
-	sum_denominator_after[ip]  +=  (deltaFin > 0)? 1/(deltaFin * deltaFin): 0;
-	sum_numerator_after[ip]    +=  (deltaFin > 0)? sigmaFin/(deltaFin * deltaFin): 0;
+}
 
 
-      } // end of loop over different processes
 
-      sum_denominator_before[sizeOfInfos-1]  +=  (errSel2Sum> 0)? 1/errSel2Sum: 0;
-      sum_numerator_before[sizeOfInfos-1]    +=  (errSel2Sum> 0)? sigSelSum/errSel2Sum: 0;
-      
-      sum_denominator_after[sizeOfInfos-1]  +=  (err2Sum>0)? 1/err2Sum: 0;
-      sum_numerator_after[sizeOfInfos-1]    +=  (err2Sum>0)? sigSum/err2Sum: 0;
+void 
+GenXSecAnalyzer::combine(double& finalValue, double& finalError, double& finalWeight, const double& currentValue, const double& currentError, const double & currentWeight)
+{
 
-
-    } // end of loop over different samples
-  
-    
-    for(unsigned int i=0; i<sizeOfInfos; i++)
-      {
-	double final_value = (sum_denominator_before[i]>0) ? (sum_numerator_before[i]/sum_denominator_before[i]):0;
-	double final_error = (sum_denominator_before[i]>0) ? (1/sqrt(sum_denominator_before[i])):-1;
-	xsecBeforeMatching_.push_back(GenLumiInfoProduct::XSec(final_value, final_error));
-	
-	double final_value2 = (sum_denominator_after[i]>0) ? (sum_numerator_after[i]/sum_denominator_after[i]):0;
-        double final_error2 = (sum_denominator_after[i]>0) ? 1/sqrt(sum_denominator_after[i]):-1;
-        xsecAfterMatching_.push_back(GenLumiInfoProduct::XSec(final_value2, final_error2));
-      }
-  	
-  }
+  if(finalValue<1e-10)
+    {
+      finalValue = currentValue;
+      finalError = currentError;
+      finalWeight += currentWeight;
+    }
+  else
+    {
+      double wgt1 = (finalError < 1e-10 || currentError<1e-10)?
+  	finalWeight :
+  	1/(finalError*finalError);
+      double wgt2 = (finalError < 1e-10 || currentError<1e-10)?
+	currentWeight:
+  	1/(currentError*currentError);
+      double xsec = (wgt1 * finalValue + wgt2 * currentValue) /(wgt1 + wgt2);
+      double err  = (finalError < 1e-10 || currentError<1e-10)? 0 : 
+  	1.0 / std::sqrt(wgt1 + wgt2);
+      finalValue = xsec;
+      finalError = err;
+      finalWeight += currentWeight;
+    }
   return;
+    
+}
+
+void 
+GenXSecAnalyzer::combine(GenLumiInfoProduct::XSec& finalXSec, double &totalw, const GenLumiInfoProduct::XSec& thisRunXSec, const double& thisw)
+{
+  double value = finalXSec.value();
+  double error = finalXSec.error();
+  double thisValue = thisRunXSec.value();
+  double thisError = thisRunXSec.error();
+  combine(value,error,totalw,thisValue,thisError,thisw);
+  finalXSec = GenLumiInfoProduct::XSec(value,error);
+  return;
+}
+
+
+GenLumiInfoProduct::XSec 
+GenXSecAnalyzer::compute(const GenLumiInfoProduct& iLumiInfo)
+{
+  // sum of cross sections and errors over different processes
+  double sigSelSum = 0.0;
+  double err2SelSum = 0.0;
+  double sigSum = 0.0;
+  double err2Sum = 0.0;
+
+  std::vector<GenLumiInfoProduct::XSec> tempVector_before;
+  std::vector<GenLumiInfoProduct::XSec> tempVector_after;
+
+  // loop over different processes for each sample
+  unsigned int vectorSize = iLumiInfo.getProcessInfos().size();
+  for(unsigned int ip=0; ip < vectorSize; ip++){
+    GenLumiInfoProduct::ProcessInfo proc = iLumiInfo.getProcessInfos()[ip];	  
+    double hepxsec_value = proc.lheXSec().value();
+    double hepxsec_error = proc.lheXSec().error() < 1e-10? 0:proc.lheXSec().error();
+    tempVector_before.push_back(GenLumiInfoProduct::XSec(hepxsec_value,hepxsec_error));
+
+    sigSelSum += hepxsec_value;
+    err2SelSum += hepxsec_error*hepxsec_error;
+
+    // skips computation if jet matching efficiency=0
+    if (proc.killed().n()<1)
+      {
+	tempVector_after.push_back(GenLumiInfoProduct::XSec(0.0,0.0));
+	continue;
+      }
+
+    // computing jet matching efficiency for this process
+    double fracAcc = 0;
+    double ntotal = proc.nTotalPos()-proc.nTotalNeg();
+    double npass  = proc.nPassPos() -proc.nPassNeg();
+    switch(hepidwtup_){
+    case 3: case -3:
+      fracAcc = ntotal > 1e-6? npass/ntotal: -1;
+	break;
+    default:
+      fracAcc = proc.selected().sum() > 1e-6? proc.killed().sum() / proc.selected().sum():-1;
+      break;
+    }
+    
+    if(fracAcc<1e-6)
+      {
+	tempVector_after.push_back(GenLumiInfoProduct::XSec(0.0,0.0));
+	continue;
+      }
+    
+    // cross section after matching for this particular process
+    double sigmaFin = hepxsec_value * fracAcc;
+
+    // computing error on jet matching efficiency
+    double relErr = 1.0;
+    double efferr2=0;
+    switch(hepidwtup_) {
+    case 3: case -3:
+      {
+	double ntotal_pos = proc.nTotalPos();
+	double effp  = ntotal_pos > 1e-6?
+	  (double)proc.nPassPos()/ntotal_pos:0;
+	double effp_err2 = ntotal_pos > 1e-6?
+	  (1-effp)*effp/ntotal_pos: 0;
+	
+	double ntotal_neg = proc.nTotalNeg();
+	double effn  = ntotal_neg > 1e-6?
+	  (double)proc.nPassNeg()/ntotal_neg:0;
+	double effn_err2 = ntotal_neg > 1e-6?
+	  (1-effn)*effn/ntotal_neg: 0;
+
+	efferr2 = ntotal > 0 ? 
+	  (ntotal_pos*ntotal_pos*effp_err2 +
+	   ntotal_neg*ntotal_neg*effn_err2)/ntotal/ntotal:0;
+	break;
+      }
+    default:
+      {
+	double denominator = pow(proc.selected().sum(),4);
+	double passw       = proc.killed().sum();
+	double passw2      = proc.killed().sum2();
+	double failw       = proc.selected().sum() - passw;
+	double failw2      = proc.selected().sum2() - passw2;
+	double numerator   = (passw2*failw*failw + failw2*passw*passw); 
+			    
+	efferr2 = denominator>0?
+	  numerator/denominator:0;
+	break;
+      }
+    }
+    double delta2Veto = efferr2/fracAcc/fracAcc;
+	
+    // computing total error on cross section after matching efficiency
+    
+    double sigma2Sum, sigma2Err;
+    sigma2Sum = hepxsec_value * hepxsec_value;
+    sigma2Err = hepxsec_error * hepxsec_error;
+ 
+
+    double delta2Sum = delta2Veto
+      + sigma2Err / sigma2Sum;
+    relErr = (delta2Sum > 0.0 ?
+	      std::sqrt(delta2Sum) : 0.0);
+    double deltaFin = sigmaFin * relErr;
+
+    tempVector_after.push_back(GenLumiInfoProduct::XSec(sigmaFin,deltaFin));
+
+    // sum of cross sections and errors over different processes
+    sigSum += sigmaFin;
+    err2Sum += deltaFin * deltaFin;
+
+	
+
+  } // end of loop over different processes
+  tempVector_before.push_back(GenLumiInfoProduct::XSec(sigSelSum, sqrt(err2SelSum)));
+  GenLumiInfoProduct::XSec result(sigSum,std::sqrt(err2Sum));
+  tempVector_after.push_back(result);
+
+  xsecBeforeMatching_ =tempVector_before;
+  xsecAfterMatching_  =tempVector_after;
+
+  return result;
 }
 
 
@@ -364,104 +451,126 @@ void
 GenXSecAnalyzer::endJob() {
 
   edm::LogPrint("GenXSecAnalyzer") << "\n"
-  << "------------------------------------" << "\n"
-  << "GenXsecAnalyzer:" << "\n"
-  << "------------------------------------";
-  
-  if(!products_.size()) {
+				   << "------------------------------------" << "\n"
+				   << "GenXsecAnalyzer:" << "\n"
+				   << "------------------------------------";
+ 
+  if(!jetMatchEffStat_.size()) {
     edm::LogPrint("GenXSecAnalyzer") << "------------------------------------" << "\n"
-    << "Cross-section summary not available" << "\n"
-    << "------------------------------------";
+				     << "Cross-section summary not available" << "\n"
+				     << "------------------------------------";
     return;
   }
-  
-  
-  compute();
 
+ 
+  // below print out is only for combination of same physics MC samples and ME+Pythia MCs
+ 
+  if(nMCs_==1 && hepidwtup_!=-1){
 
-  edm::LogPrint("GenXSecAnalyzer") 
-    << "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- \n"
-    << "Overall cross-section summary:" << "\n"
-    << "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
-  edm::LogPrint("GenXSecAnalyzer")  
-    << "Process\t\txsec_before [pb]\t\tpassed\tnposw\tnnegw\ttried\tnposw\tnnegw \txsec_match [pb]\t\t\taccepted [%]\t event_eff [%]";
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- \n"
+      << "Overall cross-section summary \n"
+      << "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
+    edm::LogPrint("GenXSecAnalyzer")  
+      << "Process\t\txsec_before [pb]\t\tpassed\tnposw\tnnegw\ttried\tnposw\tnnegw \txsec_match [pb]\t\t\taccepted [%]\t event_eff [%]";
 
-  const int sizeOfInfos= theProcesses_size+1;
-  const int last = sizeOfInfos-1;
-  std::string * title = new std::string[sizeOfInfos];
-
-  for(int i=0; i < sizeOfInfos; i++){
-
+    const unsigned sizeOfInfos = jetMatchEffStat_.size();
+    const unsigned last = sizeOfInfos-1;
+    std::string * title = new std::string[sizeOfInfos];
+    unsigned int i = 0;
     double jetmatch_eff=0;
     double jetmatch_err=0;
 
-    if(i==last)
-      {
-	title[i] = "Total";
+    for(std::map<int, GenFilterInfo>::const_iterator iter = jetMatchEffStat_.begin();
+  	iter!=jetMatchEffStat_.end(); ++iter, i++){ 
 
-	edm::LogPrint("GenXSecAnalyzer") 
-	  << "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- ";
-	jetmatch_eff = xsecBeforeMatching_[i].value()>0? xsecAfterMatching_[i].value()/xsecBeforeMatching_[i].value(): 0;
-	jetmatch_err = (xsecBeforeMatching_[i].value()>0 && xsecAfterMatching_[i].value()>0 && 
-			pow(xsecAfterMatching_[i].error()/xsecAfterMatching_[i].value(),2)>pow(xsecBeforeMatching_[i].error()/xsecBeforeMatching_[i].value(),2)
-			)? jetmatch_eff*sqrt(pow(xsecAfterMatching_[i].error()/xsecAfterMatching_[i].value(),2)-
-					     pow(xsecBeforeMatching_[i].error()/xsecBeforeMatching_[i].value(),2)):-1;
-      }
-    else
-      {
-	title[i] = Form("%d",i);      
-	jetmatch_eff = jetMatchEffStat_[i].filterEfficiency(hepidwtup_);
-	jetmatch_err = jetMatchEffStat_[i].filterEfficiencyError(hepidwtup_);
-      }
+      GenFilterInfo thisJetMatchStat = iter->second;
+      GenFilterInfo thisEventEffStat = GenFilterInfo(
+						     thisJetMatchStat.numPassPositiveEvents()+thisJetMatchStat.numPassNegativeEvents(),
+						     0,
+						     thisJetMatchStat.numTotalPositiveEvents()+thisJetMatchStat.numTotalNegativeEvents(),
+						     0,
+						     thisJetMatchStat.numPassPositiveEvents()+thisJetMatchStat.numPassNegativeEvents(),
+						     thisJetMatchStat.numPassPositiveEvents()+thisJetMatchStat.numPassNegativeEvents(),
+						     thisJetMatchStat.numTotalPositiveEvents()+thisJetMatchStat.numTotalNegativeEvents(),
+						     thisJetMatchStat.numTotalPositiveEvents()+thisJetMatchStat.numTotalNegativeEvents()
+						     );
 
+
+      if(i==last)
+  	{
+  	  title[i] = "Total";
+
+  	  edm::LogPrint("GenXSecAnalyzer") 
+  	    << "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- ";
+ 	
+  	  double n1 = xsecBeforeMatching_[i].value();
+  	  double e1 = xsecBeforeMatching_[i].error();
+  	  double n2 = xsecAfterMatching_[i].value();
+  	  double e2 = xsecAfterMatching_[i].error();
+
+  	  jetmatch_eff = n1>0? n2/n1 : 0;
+  	  jetmatch_err = (n1>0 && n2>0 && pow(e2/n2,2)>pow(e1/n1,2))?
+  	    jetmatch_eff*sqrt( pow(e2/n2,2) - pow(e1/n1,2)):-1;
+ 	  
+  	}
+      else
+  	{
+  	  title[i] = Form("%d",i);      
+  	  jetmatch_eff = thisJetMatchStat.filterEfficiency(hepidwtup_);
+  	  jetmatch_err = thisJetMatchStat.filterEfficiencyError(hepidwtup_);
+
+  	}
+
+ 
+      edm::LogPrint("GenXSecAnalyzer") 
+  	<< title[i] << "\t\t"
+  	<< std::scientific << std::setprecision(3)
+  	<< xsecBeforeMatching_[i].value()  << " +/- " 
+  	<< xsecBeforeMatching_[i].error()  << "\t\t"
+  	<< thisEventEffStat.numEventsPassed() << "\t"
+  	<< thisJetMatchStat.numPassPositiveEvents() << "\t"
+  	<< thisJetMatchStat.numPassNegativeEvents() << "\t"
+  	<< thisEventEffStat.numEventsTotal() << "\t"
+  	<< thisJetMatchStat.numTotalPositiveEvents() << "\t"
+  	<< thisJetMatchStat.numTotalNegativeEvents() << "\t"
+  	<< std::scientific << std::setprecision(3)
+  	<< xsecAfterMatching_[i].value() << " +/- "
+  	<< xsecAfterMatching_[i].error() << "\t\t"
+  	<< std::fixed << std::setprecision(1)
+  	<< (jetmatch_eff*100)  << " +/- " << (jetmatch_err*100) << "\t"
+  	<< std::fixed << std::setprecision(1)
+  	<< (thisEventEffStat.filterEfficiency(+3) * 100) << " +/- " 
+  	<< ( thisEventEffStat.filterEfficiencyError(+3) * 100);
+
+    }
+    delete [] title;
 
     edm::LogPrint("GenXSecAnalyzer") 
-      << title[i] << "\t\t"
-      << std::scientific << std::setprecision(3)
-      << xsecBeforeMatching_[i].value()  << " +/- " 
-      << xsecBeforeMatching_[i].error()  << "\t\t"
-      << eventEffStat_[i].numEventsPassed() << "\t"
-      << jetMatchEffStat_[i].numPassPositiveEvents() << "\t"
-      << jetMatchEffStat_[i].numPassNegativeEvents() << "\t"
-      << eventEffStat_[i].numEventsTotal() << "\t"
-      << jetMatchEffStat_[i].numTotalPositiveEvents() << "\t"
-      << jetMatchEffStat_[i].numTotalNegativeEvents() << "\t"
-      << std::scientific << std::setprecision(3)
-      << xsecAfterMatching_[i].value() << " +/- "
-      << xsecAfterMatching_[i].error() << "\t\t"
-      << std::fixed << std::setprecision(1)
-      << (jetmatch_eff*100)  << " +/- " << (jetmatch_err*100) << "\t"
-      << std::fixed << std::setprecision(1)
-      << (eventEffStat_[i].filterEfficiency(+3) * 100) << " +/- " << ( eventEffStat_[i].filterEfficiencyError(+3) * 100);
+      << "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
 
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "Before matching: total cross section = " 
+      << std::scientific << std::setprecision(3)  
+      << xsecBeforeMatching_[last].value() << " +- " << xsecBeforeMatching_[last].error() <<  " pb";
 
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "After matching: total cross section = " 
+      << std::scientific << std::setprecision(3)  
+      << xsecAfterMatching_[last].value() << " +- " << xsecAfterMatching_[last].error() <<  " pb";
   }
-  delete [] title;
-
-  edm::LogPrint("GenXSecAnalyzer") 
-    << "--------------------------------------------------------------------------------------------------------------------------------------------------------------------------";
-
-  edm::LogPrint("GenXSecAnalyzer") 
-    << "Before matching: total cross section = " 
-    << std::scientific << std::setprecision(3)  
-    << xsecBeforeMatching_[last].value() << " +- " << xsecBeforeMatching_[last].error() <<  " pb";
-  
-  double xsec_match  = xsecAfterMatching_[last].value();
-  double error_match = xsecAfterMatching_[last].error();
-
-  edm::LogPrint("GenXSecAnalyzer") 
-    << "After matching: total cross section = " 
-    << std::scientific << std::setprecision(3)  
-    << xsec_match << " +- " << error_match <<  " pb";
-
+  else if(hepidwtup_ == -1 )
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "Before Filtrer: total cross section = " 
+      << std::scientific << std::setprecision(3)  
+      << xsecPreFilter_.value() << " +- " << xsecPreFilter_.error() <<  " pb";
 
   // hepMC filter efficiency
   double hepMCFilter_eff = 1.0;
   double hepMCFilter_err = 0.0;
-  if( hasHepMCFilterInfo_){
-    hepMCFilter_eff = hepMCFilterEffStat_.filterEfficiency(hepidwtup_);
-    hepMCFilter_err = hepMCFilterEffStat_.filterEfficiencyError(hepidwtup_);
-
+  if(hepMCFilterEffStat_.sumWeights2()>0){
+    hepMCFilter_eff = hepMCFilterEffStat_.filterEfficiency(-1);
+    hepMCFilter_err = hepMCFilterEffStat_.filterEfficiencyError(-1);
     edm::LogPrint("GenXSecAnalyzer") 
       << "HepMC filter efficiency (taking into account weights)= "
       << "(" << hepMCFilterEffStat_.sumPassWeights() << ")"
@@ -487,45 +596,40 @@ GenXSecAnalyzer::endJob() {
   }
 
   // gen-particle filter efficiency
-  double filterOnly_eff = filterOnlyEffStat_.filterEfficiency(hepidwtup_);
-  double filterOnly_err = filterOnlyEffStat_.filterEfficiencyError(hepidwtup_);
+  if(filterOnlyEffStat_.sumWeights2()>0){
+    double filterOnly_eff = filterOnlyEffStat_.filterEfficiency(-1);
+    double filterOnly_err = filterOnlyEffStat_.filterEfficiencyError(-1);
 
-  edm::LogPrint("GenXSecAnalyzer") 
-    << "Filter efficiency (taking into account weights)= "
-    << "(" << filterOnlyEffStat_.sumPassWeights() << ")"
-    << " / "
-    << "(" << filterOnlyEffStat_.sumWeights() << ")"
-    << " = " 
-    <<  std::scientific << std::setprecision(3) 
-    << filterOnly_eff << " +- " << filterOnly_err;
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "Filter efficiency (taking into account weights)= "
+      << "(" << filterOnlyEffStat_.sumPassWeights() << ")"
+      << " / "
+      << "(" << filterOnlyEffStat_.sumWeights() << ")"
+      << " = " 
+      <<  std::scientific << std::setprecision(3) 
+      << filterOnly_eff << " +- " << filterOnly_err;
 
-  double filterOnly_event_total = filterOnlyEffStat_.numTotalPositiveEvents() + filterOnlyEffStat_.numTotalNegativeEvents();
-  double filterOnly_event_pass  = filterOnlyEffStat_.numPassPositiveEvents() + filterOnlyEffStat_.numPassNegativeEvents();
-  double filterOnly_event_eff   = filterOnly_event_total > 0 ? filterOnly_event_pass/filterOnly_event_total : 0;
-  double filterOnly_event_err   = filterOnly_event_total > 0 ?  
-    sqrt((1-filterOnly_event_eff)*filterOnly_event_eff/filterOnly_event_total): -1;
-  edm::LogPrint("GenXSecAnalyzer") 
-    << "Filter efficiency (event-level)= " 
-    << "(" << filterOnly_event_pass << ")"
-    << " / "
-    << "(" << filterOnly_event_total << ")"
-    << " = " 
-    <<  std::scientific << std::setprecision(3) 
-    << filterOnly_event_eff << " +- " << filterOnly_event_err;
+    double filterOnly_event_total = filterOnlyEffStat_.numTotalPositiveEvents() + filterOnlyEffStat_.numTotalNegativeEvents();
+    double filterOnly_event_pass  = filterOnlyEffStat_.numPassPositiveEvents() + filterOnlyEffStat_.numPassNegativeEvents();
+    double filterOnly_event_eff   = filterOnly_event_total > 0 ? filterOnly_event_pass/filterOnly_event_total : 0;
+    double filterOnly_event_err   = filterOnly_event_total > 0 ?  
+      sqrt((1-filterOnly_event_eff)*filterOnly_event_eff/filterOnly_event_total): -1;
+    edm::LogPrint("GenXSecAnalyzer") 
+      << "Filter efficiency (event-level)= " 
+      << "(" << filterOnly_event_pass << ")"
+      << " / "
+      << "(" << filterOnly_event_total << ")"
+      << " = " 
+      <<  std::scientific << std::setprecision(3) 
+      << filterOnly_event_eff << " +- " << filterOnly_event_err;
 
-
-  double xsec_final  = xsec_match*filterOnly_eff*hepMCFilter_eff;
-  double error_final = xsec_final*sqrt(error_match*error_match/xsec_match/xsec_match+
-				       filterOnly_err*filterOnly_err/filterOnly_eff/filterOnly_eff + 
-				       hepMCFilter_err*hepMCFilter_err/hepMCFilter_eff/hepMCFilter_eff
-				       );
+  }
 
   edm::LogPrint("GenXSecAnalyzer") 
     << "After filter: final cross section = " 
     << std::scientific << std::setprecision(3)  
-    << xsec_final << " +- " << error_final << " pb";
+    << xsec_.value() << " +- " << xsec_.error() << " pb";
 
-  xsec_ = GenLumiInfoProduct::XSec(xsec_final,error_final);
 
 
 }

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -203,7 +203,7 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 	double sigBrSum = 0.0;
 	double err2Sum = 0.0;
 	double errBr2Sum = 0.0;
-	int idwtup = std::abs(heprup.IDWTUP);
+	int idwtup = heprup.IDWTUP;
 	for(std::vector<Process>::const_iterator proc = processes.begin();
 	    proc != processes.end(); ++proc) {
 	  unsigned int idx = proc->heprupIndex();
@@ -310,7 +310,7 @@ void LHERunInfo::statistics() const
 	unsigned long nTried_pos = 0;
 	unsigned long nAccepted_neg = 0;
 	unsigned long nTried_neg = 0;
-	int idwtup = std::abs(heprup.IDWTUP);
+	int idwtup = heprup.IDWTUP;
 
 	std::cout << std::endl;
 	std::cout << "Process and cross-section statistics" << std::endl;

--- a/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h
@@ -147,7 +147,6 @@ class GenLumiInfoProduct {
   // methods used by EDM
   virtual bool mergeProduct(const GenLumiInfoProduct &other);
   virtual bool isProductEqual(const GenLumiInfoProduct &other) const;
-  virtual bool samePhysics(const GenLumiInfoProduct &other) const;
  private:
   // cross sections
   int     hepidwtup_;


### PR DESCRIPTION
Previous version could only combine files with exactly the same number of LHE processes or when the samples are pure parton-shower MC. For pure parton shower MC, given that the uncertainty of cross section was set to -1, the weighted average was computed by assigning weight = number of events.

However, we could have two files that come from the same physics, and contain different number of LHE processes (for example, one contains process 0 and 1 and the other contains process 0, 1, 2).

In order to take this into account properly, there is a minor change in GenLumiInfoProduct, 
and a major change in GenXSecAnalyzer. 

In addition, there is an update regarding the combination of parton-shower MC samples. Previous version computes the combined cross section before GenFilter and multiply the combined cross sections with overall GenFilter efficiency. The updated version obtains the product of GenFilter efficiency and cross section first, then, do an weighted average to get the combined cross section.

There is also a dummy change in LHERunInfo.cc (which gives the same result as before). 
