### PR TITLE
Setting the error of cross section for Pythia8

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -466,7 +466,9 @@ void Pythia8Hadronizer::statistics()
 
   double xsec = fMasterGen->info.sigmaGen(); // cross section in mb
   xsec *= 1.0e9; // translate to pb (CMS/Gen "convention" as of May 2009)
-  runInfo().setInternalXSec(xsec);
+  double err  = fMasterGen->info.sigmaErr(); // cross section err in mb
+  err  *= 1.0e9; // translate to pb (CMS/Gen "convention" as of May 2009)
+  runInfo().setInternalXSec(GenRunInfoProduct::XSec(xsec,err));
 }
 
 


### PR DESCRIPTION
Previous versions of Pythia8Hadronizer only set the value of cross section in GenRunInfoProduct, but left the error to -1.

The -1 error makes the combination of cross sections difficult (not possible to perform error weighted 
 average).

The fix sets errors in GenRunInfoProduct (Which will also be saved in GenLumiInfoProduct)
