### PR TITLE
Pass address of iterators

### DIFF
--- a/CondCore/ORA/src/STLContainerHandler.cc
+++ b/CondCore/ORA/src/STLContainerHandler.cc
@@ -33,9 +33,9 @@ ora::STLContainerIteratorHandler::STLContainerIteratorHandler( void* address,
   }
 
   if (m_collProxy.HasPointers()) {
-    m_currentElement = m_Next(m_PtrIterators->fBegin,m_PtrIterators->fEnd);
+    m_currentElement = m_Next(&m_PtrIterators->fBegin, &m_PtrIterators->fEnd);
   } else {
-    m_currentElement = m_Next(m_Iterators->fBegin,m_Iterators->fEnd); 
+    m_currentElement = m_Next(&m_Iterators->fBegin, &m_Iterators->fEnd); 
   }
   //m_currentElement = m_collProxy.first_func(&m_collEnv);
 }
@@ -45,9 +45,9 @@ ora::STLContainerIteratorHandler::~STLContainerIteratorHandler(){}
 void
 ora::STLContainerIteratorHandler::increment(){
   if (m_collProxy.HasPointers())  {
-    m_currentElement = m_Next(m_PtrIterators->fBegin,m_PtrIterators->fEnd);
+    m_currentElement = m_Next(&m_PtrIterators->fBegin, &m_PtrIterators->fEnd);
   } else {
-    m_currentElement = m_Next(m_Iterators->fBegin,m_Iterators->fEnd); 
+    m_currentElement = m_Next(&m_Iterators->fBegin, &m_Iterators->fEnd); 
   }
   //m_currentElement = m_collProxy.next_func(&m_collEnv);
 }


### PR DESCRIPTION
Bitten again by the non type safe interface of ROOT.
A ROOT6 function called next() taking two void\* arguments is used by a proxy  to iterate over an STL collection.  The arguments should be the addresses of the begin and end iterators.
However, the ROOT6 specific conditions code was passing in the values of the iterators, rather than the addresses of the iterators.
This pull request fixes this problem, avoiding segfaults in several unit tests in CondCore packages.  Four of the fixed tests actually now will pass, but most will fail later due to other problems.
Please merge this pull request as soon as convenient.
