### PR TITLE
Fail deliberately to avoid infinite loop

### DIFF
--- a/CondCore/DBCommon/test/testMultipleConnection.cc
+++ b/CondCore/DBCommon/test/testMultipleConnection.cc
@@ -9,6 +9,7 @@
 #include <string>
 #include <iostream>
 int main(){
+  assert(0); // Fail deliberately to avoid infinite loop.
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   cond::DbConnection connection;

--- a/CondCore/DBCommon/test/testSingleConnection.cc
+++ b/CondCore/DBCommon/test/testSingleConnection.cc
@@ -17,6 +17,7 @@ void wait ( int seconds )
   while (clock() < endwait) {}
 }
 int main(){
+  assert(0); //Fail deliberately to avoid invfinite loop.
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   cond::DbConnection connection;


### PR DESCRIPTION
Although just merged pull request #6578 is totally correct, it only partially fixes some unit tests.  In particular, two unit tests will now go into infinite loops.
This temporary workaround inserts asserts to cause these two tests to fail immediately, to avoid infinite loops, which are not good for system resources.
Please merge this request as soon as you can.
