### PR TITLE
Move bool operator>(l1t::Jet&, l1t::Jet&) to l1t namespace

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage2Layer2JetAlgorithmFirmwareImp1.cc
@@ -16,12 +16,14 @@
 #include <algorithm>
 #include <math.h>
 
-bool operator > ( l1t::Jet& a, l1t::Jet& b )
-{
-  if ( a.hwPt() > b.hwPt() ){ 
-    return true;
-  } else {
-    return false;
+namespace l1t {
+  bool operator > ( l1t::Jet& a, l1t::Jet& b )
+  {
+    if ( a.hwPt() > b.hwPt() ) {
+      return true;
+    } else {
+      return false;
+    }
   }
 }
 


### PR DESCRIPTION
The following line in `BitonicSort.h`

```
bool lComp( *lFirst > *lSecond );
```

depends on template argument type. Thus argument-dependent lookup (ADL)
is being used here to find `bool operator>(l1t::Jet&, l1t::Jet&)`.

ADL is done once all argument types are known, i.e., in template
instantiation location. It this case it happens in a few places from
`BitonicSort.h` and `Stage2Layer2JetAlgorithmFirmwareImp1.cc`.
They all require template specialization: `BitonicSort<l1t::Jet>`.

The operator is not found on the first look up (unqualified lookup),
because it's delcared after template delcaration. It's also not found in
second look up (ADL), because it's not in a class's namespace, but in a
global namespace.

The patch adds `bool operator>(l1t::Jet&, l1t::Jet&)` to `l1t` namespace
to allow ADL to find the operator.

Resolves error with Clang.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
