### PR TITLE
Fix PR #6576 (Me0 global reco)

### DIFF
--- a/DataFormats/MuonReco/BuildFile.xml
+++ b/DataFormats/MuonReco/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="DataFormats/VertexReco"/>
 <use   name="rootrflx"/>
 <use   name="rootmath"/>
+<use   name="DataFormats/GEMRecHit"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/MuonReco/interface/ME0Muon.h
+++ b/DataFormats/MuonReco/interface/ME0Muon.h
@@ -2,27 +2,22 @@
 #define MuonReco_ME0Muon_h
 /** \class reco::ME0Muon ME0Muon.h DataFormats/MuonReco/interface/ME0Muon.h
  *  
- * A lightweight reconstructed Muon to store low momentum muons without matches
- * in the muon detectors. Contains:
- *  - reference to a silicon tracker track
- *  - calorimeter energy deposition
- *  - calo compatibility variable
+ * \author David Nash NEU
  *
- * \author Dmytro Kovalskyi, UCSB
- *
- * \version $Id: ME0Muon.h,v 1.4 2009/03/15 03:33:32 dmytro Exp $
  *
  */
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
-#include <DataFormats/MuonReco/interface/EmulatedME0SegmentCollection.h>
+
+#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
 
 namespace reco {
  
   class ME0Muon {
   public:
     ME0Muon();
-    ME0Muon( const TrackRef & t, const EmulatedME0SegmentRef & s) { innerTrack_ = t; me0Segment_ = s;}
+    //ME0Muon( const TrackRef & t, const ME0Segment & s) { innerTrack_ = t; me0Segment_ = s;}
+    ME0Muon( const TrackRef & t, const ME0Segment & s, const int v) { innerTrack_ = t; me0Segment_ = s; me0segid_=v;}
     virtual ~ME0Muon(){}     
     
     /// reference to Track reconstructed in the tracker only
@@ -31,10 +26,14 @@ namespace reco {
     /// set reference to Track
     virtual void setInnerTrack( const TrackRef & t ) { innerTrack_ = t; }
     virtual void setTrack( const TrackRef & t ) { setInnerTrack(t); }
-    /// set reference to our new EmulatedME0Segment type
-    virtual void setEmulatedME0Segment( const EmulatedME0SegmentRef & s ) { me0Segment_ = s; }
+    /// set reference to our new ME0Segment type
+    virtual void setME0Segment( const ME0Segment & s ) { me0Segment_ = s; }
 
-    virtual EmulatedME0SegmentRef me0segment() const { return me0Segment_; }
+    virtual ME0Segment me0segment() const { return me0Segment_; }
+    
+    //Added for testing
+    virtual void setme0segid( const int v){me0segid_=v;}
+    virtual int me0segid() const {return me0segid_;}
 
     /// a bunch of useful accessors
     int charge() const { return innerTrack_.get()->charge(); }
@@ -58,7 +57,8 @@ namespace reco {
   private:
     /// reference to Track reconstructed in the tracker only
     TrackRef innerTrack_;
-    EmulatedME0SegmentRef me0Segment_;
+    ME0Segment me0Segment_;
+    int me0segid_;
   };
 
 }

--- a/DataFormats/MuonReco/interface/ME0MuonCollection.h
+++ b/DataFormats/MuonReco/interface/ME0MuonCollection.h
@@ -6,7 +6,7 @@
  * The collection of ME0Muon's. See \ref ME0MuonCollection.h for details.
  *
  *  $Date: 2010/03/12 13:08:15 $
- *  \author Matteo Sani
+ *  \author David Nash
  */
 
 #include "DataFormats/MuonReco/interface/ME0Muon.h"
@@ -17,5 +17,6 @@ typedef std::vector<reco::ME0Muon> ME0MuonCollection;
 
 /// persistent reference to a ME0Muon
 typedef edm::Ref<ME0MuonCollection> ME0MuonRef;
+
 	
 #endif

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -184,8 +184,8 @@
     <class name="edm::Ref<std::vector<EmulatedME0Segment>,EmulatedME0Segment,edm::refhelper::FindUsingAdvance<std::vector<EmulatedME0Segment>,EmulatedME0Segment> >"/>
     
     <class name="std::vector<reco::ME0Muon>"/>
-    <class name="reco::ME0Muon" ClassVersion="14">
-      <version ClassVersion="14" checksum="13864262"/>
+    <class name="reco::ME0Muon" ClassVersion="15">
+      <version ClassVersion="15" checksum="3167678990"/>
     </class>
     <class name="edm::Wrapper<std::vector<reco::ME0Muon> >"/>
     

--- a/FastSimulation/Configuration/test/BuildFile.xml
+++ b/FastSimulation/Configuration/test/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/GeometrySurface"/>
 <use   name="DataFormats/HepMCCandidate"/>
+<use   name="DataFormats/GEMRecHit"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>

--- a/FastSimulation/Configuration/test/TestAnalyzer_Final.cc
+++ b/FastSimulation/Configuration/test/TestAnalyzer_Final.cc
@@ -10,8 +10,8 @@
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 
-#include <DataFormats/MuonReco/interface/EmulatedME0Segment.h>
-#include <DataFormats/MuonReco/interface/EmulatedME0SegmentCollection.h>
+#include <DataFormats/GEMRecHit/interface/ME0Segment.h>
+#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
 
 #include <DataFormats/MuonReco/interface/ME0Muon.h>
 #include <DataFormats/MuonReco/interface/ME0MuonCollection.h>
@@ -135,8 +135,8 @@ TestAnalyzer_Final::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   Handle <std::vector<RecoChargedCandidate> > OurCandidates;
   iEvent.getByLabel <std::vector<RecoChargedCandidate> > ("me0MuonConverter", OurCandidates);
 
-  Handle<std::vector<EmulatedME0Segment> > OurSegments;
-  iEvent.getByLabel<std::vector<EmulatedME0Segment> >("me0SegmentProducer", OurSegments);
+  Handle<std::vector<ME0Segment> > OurSegments;
+  iEvent.getByLabel<std::vector<ME0Segment> >("me0SegmentProducer", OurSegments);
 
   Handle<GenParticleCollection> genParticles;
   iEvent.getByLabel<GenParticleCollection>("genParticles", genParticles);
@@ -176,7 +176,7 @@ TestAnalyzer_Final::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     }
   }
   //unsigned int recosize=OurCandidates->size();
-  for (std::vector<EmulatedME0Segment>::const_iterator thisSegment = OurSegments->begin();
+  for (std::vector<ME0Segment>::const_iterator thisSegment = OurSegments->begin();
        thisSegment != OurSegments->end();++thisSegment){
     // double theta = atan(thisSegment->localDirection().y()/ thisSegment->localDirection().x());
     // double tempeta = -log(tan (theta/2.));
@@ -196,16 +196,16 @@ TestAnalyzer_Final::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   // std::vector<int> UniqueIdList;
   // std::vector<int> Ids;
   std::vector<Double_t> SegmentEta;
-  std::vector<const EmulatedME0Segment*> Ids;
-  std::vector<const EmulatedME0Segment*> UniqueIdList;
+  std::vector<const ME0Segment*> Ids;
+  std::vector<const ME0Segment*> UniqueIdList;
 
   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
        thisMuon != OurMuons->end(); ++thisMuon){
     TrackRef tkRef = thisMuon->innerTrack();
-    EmulatedME0SegmentRef segRef = thisMuon->me0segment();
+    ME0Segment segment = thisMuon->me0segment();
     //int SegId = thisMuon->segRefId();
     //int SegId = segRef.get();
-    const EmulatedME0Segment* SegId = segRef.get();
+    const ME0Segment* SegId = &segment;
     //PointersVector.push_back(segRef.get());
     bool IsNew = true;
     for (unsigned int i =0; i < Ids.size(); i++){
@@ -214,7 +214,7 @@ TestAnalyzer_Final::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     if (IsNew) {
       std::cout<<"Found: "<<SegId<<std::endl;
       UniqueIdList.push_back(SegId);
-      LocalVector TempVect(segRef->localDirection().x(),segRef->localDirection().y(),segRef->localDirection().z());
+      LocalVector TempVect(segment.localDirection().x(),segment.localDirection().y(),segment.localDirection().z());
       SegmentEta.push_back(TempVect.eta());
     }
     Ids.push_back(SegId);

--- a/RecoMuon/MuonIdentification/BuildFile.xml
+++ b/RecoMuon/MuonIdentification/BuildFile.xml
@@ -28,6 +28,8 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/CSCGeometry"/>
+<use   name="Geometry/GEMGeometry"/>
+<use   name="DataFormats/GEMRecHit"/>
 <use   name="Geometry/Records"/>
 <use   name="SimDataFormats/Track"/>
 <use   name="SimDataFormats/TrackingHit"/>
@@ -35,6 +37,9 @@
 <use   name="RecoMuon/TrackingTools"/>
 <use   name="DataFormats/CSCRecHit"/>
 <use   name="RecoLocalCalo/HcalRecAlgos"/>
+<use   name="SimTracker/TrackAssociation"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
@@ -52,8 +52,7 @@ void ME0MuonConverter::produce(edm::Event& ev, const edm::EventSetup& setup) {
   using namespace reco;
 
   Handle <std::vector<ME0Muon> > OurMuons;
-  ev.getByLabel <std::vector<ME0Muon> > ("me0SegmentMatcher", OurMuons);
-  
+  ev.getByLabel <std::vector<ME0Muon> > ("me0SegmentMatching", OurMuons);
   std::auto_ptr<RecoChargedCandidateCollection> oc( new RecoChargedCandidateCollection());
 
   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
@@ -68,7 +67,6 @@ void ME0MuonConverter::produce(edm::Event& ev, const edm::EventSetup& setup) {
     if(abs(q)==1) pid = q < 0 ? 13 : -13;
     reco::RecoChargedCandidate cand(q, p4, vtx, pid);
     cand.setTrack(thisMuon->innerTrack());
-
     oc->push_back(cand);
   }
     

--- a/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.cc
@@ -14,10 +14,11 @@
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 
-#include <DataFormats/MuonReco/interface/EmulatedME0Segment.h>
-#include <DataFormats/MuonReco/interface/EmulatedME0SegmentCollection.h>
+
+
 #include <DataFormats/MuonReco/interface/ME0Muon.h>
 #include <DataFormats/MuonReco/interface/ME0MuonCollection.h>
+
 
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
@@ -31,6 +32,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+
 
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
@@ -56,7 +58,6 @@ void ME0MuonConverter::produce(edm::Event& ev, const edm::EventSetup& setup) {
 
   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
        thisMuon != OurMuons->end(); ++thisMuon){
-
     TrackRef tkRef = thisMuon->innerTrack();
     
     Particle::Charge q = tkRef->charge();

--- a/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.h
+++ b/RecoMuon/MuonIdentification/plugins/ME0MuonConverter.h
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
+#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
 
 
 class ME0MuonConverter : public edm::EDProducer {

--- a/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
@@ -9,7 +9,6 @@
 #include <FWCore/Framework/interface/MakerMacros.h>
 
 #include <DataFormats/Common/interface/Handle.h>
-#include <FWCore/Framework/interface/ESHandle.h>
 #include <FWCore/MessageLogger/interface/MessageLogger.h> 
 
 #include <DataFormats/MuonReco/interface/ME0Muon.h>
@@ -27,9 +26,20 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 
+#include "DataFormats/GeometrySurface/interface/LocalError.h"
+
+
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "TLorentzVector.h"
+
+#include "DataFormats/TrajectoryState/interface/LocalTrajectoryParameters.h"
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianCartesianToLocal.h"
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCartesian.h"
+
+
 ME0SegmentMatcher::ME0SegmentMatcher(const edm::ParameterSet& pas) : iev(0){
 	
-  produces<std::vector<reco::ME0Muon> >();  //May have to later change this to something that makes more sense, OwnVector, RefVector, etc
+  produces<std::vector<reco::ME0Muon> >();  
 
 }
 
@@ -41,33 +51,42 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
 
     //Getting the objects we'll need
     using namespace edm;
+
     ESHandle<MagneticField> bField;
     setup.get<IdealMagneticFieldRecord>().get(bField);
     ESHandle<Propagator> shProp;
     setup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAlong", shProp);
-   
+
     using namespace reco;
 
-    Handle<std::vector<EmulatedME0Segment> > OurSegments;
-    ev.getByLabel<std::vector<EmulatedME0Segment> >("me0SegmentProducer", OurSegments);
+    Handle<ME0SegmentCollection> OurSegments;
+    ev.getByLabel("me0Segments","",OurSegments);
 
-    Handle <TrackCollection > generalTracks;
-    ev.getByLabel <TrackCollection> ("generalTracks", generalTracks);
 
     std::auto_ptr<std::vector<ME0Muon> > oc( new std::vector<ME0Muon> ); 
     std::vector<ME0Muon> TempStore; 
 
+    Handle <TrackCollection > generalTracks;
+    ev.getByLabel <TrackCollection> ("generalTracks", generalTracks);
+
+
     int TrackNumber = 0;
-    std::vector<int> TkMuonNumbers, TkIndex, TkToKeep;
-    std::vector<GlobalVector>FinalTrackPosition;
-    //std::cout<<"generalTracks = "<<generalTracks->size()<<std::endl;
+    
     for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
 	 thisTrack != generalTracks->end(); ++thisTrack,++TrackNumber){
       //Initializing our plane
+
+      //Remove later
+      if (fabs(thisTrack->eta()) < 1.8) continue;
+
       float zSign  = thisTrack->pz()/fabs(thisTrack->pz());
-      float zValue = 560. * zSign;
-      Plane plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
+
+      float zValue = 526.75 * zSign;
+
+      Plane *plane = new Plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
+
       //Getting the initial variables for propagation
+
       int chargeReco = thisTrack->charge(); 
       GlobalVector p3reco, r3reco;
 
@@ -88,141 +107,97 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
       const SteppingHelixPropagator* ThisshProp = 
 	dynamic_cast<const SteppingHelixPropagator*>(&*shProp);
 	
-      lastrecostate = ThisshProp->propagate(startrecostate, plane);
+      lastrecostate = ThisshProp->propagate(startrecostate, *plane);
 	
       FreeTrajectoryState finalrecostate;
       lastrecostate.getFreeState(finalrecostate);
 
       AlgebraicSymMatrix66 covFinalReco;
-      GlobalVector p3FinalReco, r3FinalReco;
-      getFromFTS(finalrecostate, p3FinalReco, r3FinalReco, chargeReco, covFinalReco);
-    
-      FinalTrackPosition.push_back(r3FinalReco);
+      GlobalVector p3FinalReco_glob, r3FinalReco_globv;
+      getFromFTS(finalrecostate, p3FinalReco_glob, r3FinalReco_globv, chargeReco, covFinalReco);
+
+
+      //To transform the global propagated track to local coordinates
       int SegmentNumber = 0;
-      for (std::vector<EmulatedME0Segment>::const_iterator thisSegment = OurSegments->begin();
-	   thisSegment != OurSegments->end(); ++thisSegment,++SegmentNumber){
-	//EmulatedME0Segments actually have globally initialized positions and directions, so we cast them as global points and vectors
-	GlobalPoint thisPosition(thisSegment->localPosition().x(),thisSegment->localPosition().y(),thisSegment->localPosition().z());
-	GlobalVector thisDirection(thisSegment->localDirection().x(),thisSegment->localDirection().y(),thisSegment->localDirection().z());
+
+      reco::ME0Muon MuonCandidate;
+      double ClosestDelR = 999.;
+
+      for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
+	   ++thisSegment,++SegmentNumber){
+	ME0DetId id = thisSegment->me0DetId();
+
+	auto roll = me0Geom->etaPartition(id); 
+
+	if ( zSign * roll->toGlobal(thisSegment->localPosition()).z() < 0 ) continue;
+
+	GlobalPoint r3FinalReco_glob(r3FinalReco_globv.x(),r3FinalReco_globv.y(),r3FinalReco_globv.z());
+
+	LocalPoint r3FinalReco = roll->toLocal(r3FinalReco_glob);
+	LocalVector p3FinalReco=roll->toLocal(p3FinalReco_glob);
+
+	LocalPoint thisPosition(thisSegment->localPosition());
+	LocalVector thisDirection(thisSegment->localDirection().x(),thisSegment->localDirection().y(),thisSegment->localDirection().z());  //FIXME
+
 	//The same goes for the error
 	AlgebraicMatrix thisCov(4,4,0);   
-
 	for (int i = 1; i <=4; i++){
 	  for (int j = 1; j <=4; j++){
 	    thisCov(i,j) = thisSegment->parametersError()(i,j);
 	  }
 	}
 
-	//Computing the sigma for the track
-	Double_t rho_track = r3FinalReco.perp();
-	Double_t phi_track = r3FinalReco.phi();
+	/////////////////////////////////////////////////////////////////////////////////////////
 
-	//std::cout<<r3FinalReco.eta()<<", "<<thisTrack->eta()<<std::endl;
-	Double_t drhodx_track = r3FinalReco.x()/rho_track;
-	Double_t drhody_track = r3FinalReco.y()/rho_track;
-	Double_t dphidx_track = -r3FinalReco.y()/(rho_track*rho_track);
-	Double_t dphidy_track = r3FinalReco.x()/(rho_track*rho_track);
-      
-	Double_t sigmarho_track = sqrt( drhodx_track*drhodx_track*covFinalReco(0,0)+
-					drhody_track*drhody_track*covFinalReco(1,1)+
-					drhodx_track*drhody_track*2*covFinalReco(0,1) );
-      
-	Double_t sigmaphi_track = sqrt( dphidx_track*dphidx_track*covFinalReco(0,0)+
-					dphidy_track*dphidy_track*covFinalReco(1,1)+
-					dphidx_track*dphidy_track*2*covFinalReco(0,1) );
 
-	//Computing the sigma for the hit
-	Double_t rho_hit = thisPosition.perp();
-	Double_t phi_hit = thisPosition.phi();
+	LocalTrajectoryParameters ltp(r3FinalReco,p3FinalReco,chargeReco);
+	JacobianCartesianToLocal jctl(roll->surface(),ltp);
+	AlgebraicMatrix56 jacobGlbToLoc = jctl.jacobian(); 
 
-	Double_t drhodx_hit = thisPosition.x()/rho_hit;
-	Double_t drhody_hit = thisPosition.y()/rho_hit;
-	Double_t dphidx_hit = -thisPosition.y()/(rho_hit*rho_hit);
-	Double_t dphidy_hit = thisPosition.x()/(rho_hit*rho_hit);
-      
-	Double_t sigmarho_hit = sqrt( drhodx_hit*drhodx_hit*thisCov(2,2)+
-				      drhody_hit*drhody_hit*thisCov(3,3)+
-				      drhodx_hit*drhody_hit*2*thisCov(2,3) );
-      
-	Double_t sigmaphi_hit = sqrt( dphidx_hit*dphidx_hit*thisCov(2,2)+
-				      dphidy_hit*dphidy_hit*thisCov(3,3)+
-				      dphidx_hit*dphidy_hit*2*thisCov(2,3) );
+	AlgebraicMatrix55 Ctmp =  (jacobGlbToLoc * covFinalReco) * ROOT::Math::Transpose(jacobGlbToLoc); 
+	AlgebraicSymMatrix55 C;  // I couldn't find any other way, so I resort to the brute force
+	for(int i=0; i<5; ++i) {
+	  for(int j=0; j<5; ++j) {
+	    C[i][j] = Ctmp[i][j]; 
 
-	//Adding the sigmas
-	Double_t sigmarho = sqrt(sigmarho_track*sigmarho_track + sigmarho_hit*sigmarho_hit);
-	Double_t sigmaphi = sqrt(sigmaphi_track*sigmaphi_track + sigmaphi_hit*sigmaphi_hit);
-
-	//Checking if there is a match in rho and in phi, assuming they are pointing in the same direction
-
-	// std::cout<<"rho_hit = "<<rho_hit<<std::endl;
-	// std::cout<<"rho_track = "<<rho_track<<std::endl;
-	// std::cout<<"phi_hit = "<<phi_hit<<std::endl;
-	// std::cout<<"phi_track = "<<phi_track<<std::endl;
-
-	bool R_MatchFound = false, Phi_MatchFound = false;
-	//std::cout<<zSign<<", "<<thisPosition.z()<<std::endl;
-	if ( zSign * thisPosition.z() > 0 ) {             
-	  if ( fabs(rho_hit-rho_track) < 3.0 * sigmarho) R_MatchFound = true;
-	  if ( fabs(phi_hit-phi_track) < 3.0 * sigmaphi) Phi_MatchFound = true;
-	}
-
-	if (R_MatchFound && Phi_MatchFound) {
-	  //std::cout<<"FOUND ONE"<<std::endl;             
-	  TrackRef thisTrackRef(generalTracks,TrackNumber);
-	  EmulatedME0SegmentRef thisEmulatedME0SegmentRef(OurSegments,SegmentNumber);
-	  TempStore.push_back(reco::ME0Muon(thisTrackRef,thisEmulatedME0SegmentRef));
-	  TkIndex.push_back(TrackNumber);
-	}
-      }
-    }
-
-    for (unsigned int i = 0; i < TkIndex.size(); ++i){     //Now we construct a vector of unique TrackNumbers of tracks that have been stored
-      bool AlreadyStoredInTkMuonNumbers = false;
-      for (unsigned int j = 0; j < TkMuonNumbers.size(); ++j){
-	if (TkMuonNumbers[j]==TkIndex[i]) AlreadyStoredInTkMuonNumbers = true;
-      }
-      if (!AlreadyStoredInTkMuonNumbers) TkMuonNumbers.push_back(TkIndex[i]);
-    }
-
-    for (unsigned int i = 0; i < TkMuonNumbers.size(); ++i){            //Now we loop over each TrackNumber that has been stored
-      int ReferenceMuonNumber = TkMuonNumbers[i];          // The muon number of the track, starts at 0 and increments
-      double RefDelR = 99999.9, ComparisonIndex = 0;
-      int WhichTrackToKeep=-1;
-      for (std::vector<ME0Muon>::const_iterator thisMuon = TempStore.begin();    //Now we have the second nested loop, over the ME0Muons
-	   thisMuon != TempStore.end(); ++thisMuon, ++ComparisonIndex){
-	
-	int thisMuonNumber = TkIndex[ComparisonIndex];    //The track number of the muon we are currently looking at
-	if (thisMuonNumber == ReferenceMuonNumber){        //This means we're looking at one track
-
-	  EmulatedME0SegmentRef SegRef = thisMuon->me0segment();
-	  TrackRef TkRef = thisMuon->innerTrack();
-	  //Here LocalPoint is used, although the local frame and global frame coincide, hence all calculations are made in global coordinates
-	  //  NOTE: Correct this when making the change to "real" EmulatedME0Segments, since these will be in real local coordinates
-	  LocalPoint SegPos(SegRef->localPosition().x(),SegRef->localPosition().y(),SegRef->localPosition().z());
-	  //LocalPoint TkPos(TkRef->vx(),TkRef->vy(),TkRef->vz());
-	  LocalPoint TkPos(FinalTrackPosition[thisMuonNumber].x(),FinalTrackPosition[thisMuonNumber].y(),FinalTrackPosition[thisMuonNumber].z());
-	  double delR = reco::deltaR(SegPos,TkPos);
-
-	  //std::cout<<"delR = "<<delR<<std::endl;
-
-	  if (delR < RefDelR) {
-	    WhichTrackToKeep = ComparisonIndex;  //Storing a list of the vector indices of tracks to keep
-	                                         //Note: These are not the same as the "Track Numbers"
-	    RefDelR=delR;
 	  }
-	}
+	}  
+
+	Double_t sigmax = sqrt(C[3][3]+thisSegment->localPositionError().xx() );      
+	Double_t sigmay = sqrt(C[4][4]+thisSegment->localPositionError().yy() );
+
+	bool X_MatchFound = false, Y_MatchFound = false, Dir_MatchFound = false;
+	
+
+	 if ( (fabs(thisPosition.x()-r3FinalReco.x()) < (3.0 * sigmax)) || (fabs(thisPosition.x()-r3FinalReco.x()) < 2.0 ) ) X_MatchFound = true;
+	 if ( (fabs(thisPosition.y()-r3FinalReco.y()) < (3.0 * sigmay)) || (fabs(thisPosition.y()-r3FinalReco.y()) < 2.0 ) ) Y_MatchFound = true;
+
+	 if ( fabs(p3FinalReco_glob.phi()-roll->toGlobal(thisSegment->localDirection()).phi()) < 0.15) Dir_MatchFound = true;
+
+	 //Check for a Match, and if there is a match, check the delR from the segment, keeping only the closest in MuonCandidate
+	 if (X_MatchFound && Y_MatchFound && Dir_MatchFound) {
+	   
+	   TrackRef thisTrackRef(generalTracks,TrackNumber);
+	   
+	   GlobalPoint SegPos(roll->toGlobal(thisSegment->localPosition()));
+	   GlobalPoint TkPos(r3FinalReco_globv.x(),r3FinalReco_globv.y(),r3FinalReco_globv.z());
+	   
+	   double thisDelR = reco::deltaR(SegPos,TkPos);
+	   if (thisDelR < ClosestDelR){
+	     ClosestDelR = thisDelR;
+	     MuonCandidate = reco::ME0Muon(thisTrackRef,(*thisSegment),SegmentNumber);
+	   }
+	 }
+      }//End loop for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); ++thisSegment,++SegmentNumber)
+
+      //As long as the delR of the MuonCandidate is sensible, store the track-segment pair
+      if (ClosestDelR < 500.) {
+	oc->push_back(MuonCandidate);
       }
-      if (WhichTrackToKeep != -1) TkToKeep.push_back(WhichTrackToKeep);
     }
 
-    for (unsigned int i = 0; i < TkToKeep.size(); ++i){
-      int thisKeepIndex = TkToKeep[i];
-      oc->push_back(TempStore[thisKeepIndex]);    //Filling the collection
-    }
-  	
     // put collection in event
     ev.put(oc);
-
 }
 
 FreeTrajectoryState
@@ -262,13 +237,19 @@ void ME0SegmentMatcher::getFromFTS(const FreeTrajectoryState& fts,
   GlobalVector p3T(p3GV.x(), p3GV.y(), p3GV.z());
   GlobalVector r3T(r3GP.x(), r3GP.y(), r3GP.z());
   p3 = p3T;
-  r3 = r3T;  //Yikes, was setting this to p3T instead of r3T!?!
+  r3 = r3T;  
   // p3.set(p3GV.x(), p3GV.y(), p3GV.z());
   // r3.set(r3GP.x(), r3GP.y(), r3GP.z());
   
   charge = fts.charge();
   cov = fts.hasError() ? fts.cartesianError().matrix() : AlgebraicSymMatrix66();
 
+}
+
+
+void ME0SegmentMatcher::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup)
+{
+  iSetup.get<MuonGeometryRecord>().get(me0Geom);
 }
 
 

--- a/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
@@ -38,9 +38,7 @@
 
 
 ME0SegmentMatcher::ME0SegmentMatcher(const edm::ParameterSet& pas) : iev(0){
-	
   produces<std::vector<reco::ME0Muon> >();  
-
 }
 
 ME0SegmentMatcher::~ME0SegmentMatcher() {}
@@ -197,6 +195,7 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
     }
 
     // put collection in event
+
     ev.put(oc);
 }
 

--- a/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.h
+++ b/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.h
@@ -1,10 +1,7 @@
-#ifndef EmulatedME0Segment_ME0SegmentMatcher_h
-#define EmulatedME0Segment_ME0SegmentMatcher_h
+#ifndef ME0Segment_ME0SegmentMatcher_h
+#define ME0Segment_ME0SegmentMatcher_h
 
 /** \class ME0SegmentMatcher 
- * Produces a collection of ME0Segment's in endcap muon ME0s. 
- *
- * $Date: 2010/03/11 23:48:11 $
  *
  * \author David Nash
  */
@@ -18,6 +15,27 @@
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 
 #include "DataFormats/Math/interface/AlgebraicROOTObjects.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "Geometry/GEMGeometry/interface/ME0Geometry.h"
+#include <Geometry/GEMGeometry/interface/ME0EtaPartition.h>
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include <DataFormats/MuonDetId/interface/ME0DetId.h>
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
+#include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
+
+//For Debugging
+
+#include "TH1.h" 
+#include <TH2.h>
+#include "TFile.h"
+#include <TProfile.h>
+#include "TStyle.h"
+#include <TCanvas.h>
+
 
 class FreeTrajectoryState;
 class MagneticField;
@@ -29,6 +47,11 @@ public:
     ~ME0SegmentMatcher();
     /// Produce the ME0Segment collection
     virtual void produce(edm::Event&, const edm::EventSetup&);
+
+    
+    virtual void beginRun(edm::Run const&, edm::EventSetup const&);
+
+
 
     FreeTrajectoryState getFTS(const GlobalVector& , const GlobalVector& , 
 				   int , const AlgebraicSymMatrix66& ,
@@ -45,7 +68,10 @@ public:
 private:
 
     int iev; // events through
-    
+
+    edm::ESHandle<ME0Geometry> me0Geom;
+
+  
 };
 
 #endif

--- a/RecoMuon/MuonIdentification/python/me0MuonConverter_cfi.py
+++ b/RecoMuon/MuonIdentification/python/me0MuonConverter_cfi.py
@@ -3,4 +3,4 @@ import FWCore.ParameterSet.Config as cms
 #process = cms.Process("ME0MuonConversion")
 #process.me0MuonConverter = cms.EDProducer("ME0MuonConverter")
 
-me0MuonConverter = cms.EDProducer("ME0MuonConverter")
+me0MuonConverting = cms.EDProducer("ME0MuonConverter")

--- a/RecoMuon/MuonIdentification/python/me0MuonReco_cff.py
+++ b/RecoMuon/MuonIdentification/python/me0MuonReco_cff.py
@@ -1,7 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from FastSimulation.Muons.me0SegmentProducer_cfi import *
+#from FastSimulation.Muons.me0SegmentProducer_cfi import *
 from RecoMuon.MuonIdentification.me0SegmentMatcher_cfi import *
 from RecoMuon.MuonIdentification.me0MuonConverter_cfi import *
 
-me0MuonReco = cms.Sequence(me0SegmentProducer*me0SegmentMatcher*me0MuonConverter)
+#me0MuonReco = cms.Sequence(me0SegmentProducer*me0SegmentMatcher*me0MuonConverter)
+me0MuonReco = cms.Sequence(me0SegmentMatching*me0MuonConverting)

--- a/RecoMuon/MuonIdentification/python/me0SegmentMatcher_cfi.py
+++ b/RecoMuon/MuonIdentification/python/me0SegmentMatcher_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
 
-me0SegmentMatcher = cms.EDProducer("ME0SegmentMatcher")
+me0SegmentMatching = cms.EDProducer("ME0SegmentMatcher")

--- a/RecoMuon/MuonIdentification/test/BuildFile.xml
+++ b/RecoMuon/MuonIdentification/test/BuildFile.xml
@@ -11,6 +11,9 @@
 <use   name="DataFormats/RecoCandidate"/>
 <use   name="PhysicsTools/UtilAlgos"/>
 <use   name="CommonTools/Utils"/>
+<use   name="SimTracker/TrackAssociation"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
+<use   name="SimTracker/Records"/>
 <library   file="*.cc" name="TestMuonMuonIdentificationPlugins">
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoMuon/MuonIdentification/test/ME0MuonAnalyzer.cc
+++ b/RecoMuon/MuonIdentification/test/ME0MuonAnalyzer.cc
@@ -1,10 +1,13 @@
 #include "FWCore/Framework/interface/Event.h"
+
 #include <FWCore/PluginManager/interface/ModuleDef.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include <FWCore/MessageLogger/interface/MessageLogger.h> 
-#include <FWCore/Framework/interface/ESHandle.h>
+
 #include <DataFormats/Common/interface/Handle.h>
+#include <FWCore/Framework/interface/ESHandle.h>
+#include <FWCore/MessageLogger/interface/MessageLogger.h> 
+#include "FWCore/Utilities/interface/InputTag.h"
 
 #include <Geometry/Records/interface/MuonGeometryRecord.h>
 
@@ -14,26 +17,52 @@
 #include <DataFormats/MuonReco/interface/ME0Muon.h>
 #include <DataFormats/MuonReco/interface/ME0MuonCollection.h>
 
+// #include "CLHEP/Matrix/SymMatrix.h"
+// #include "CLHEP/Matrix/Matrix.h"
+// #include "CLHEP/Vector/ThreeVector.h"
+
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
 #include "DataFormats/TrajectorySeed/interface/PropagationDirection.h"
+//#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 
+#include "TLorentzVector.h"
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
+//#include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+//#include "TRandom3.h"
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixPropagator.h"
 #include "TrackPropagation/SteppingHelixPropagator/interface/SteppingHelixStateInfo.h"
 
 #include "DataFormats/Math/interface/deltaR.h"
+//#include "DataFormats/Math/interface/deltaPhi.h"
+//#include <deltaR.h>
+#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
 
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+
+
+//Associator for chi2: Including header files
+#include "SimTracker/TrackAssociation/interface/TrackAssociatorByChi2.h"
+#include "SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+#include "SimTracker/Records/interface/TrackAssociatorRecord.h"
+
+#include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
+#include "SimTracker/TrackAssociation/plugins/CosmicParametersDefinerForTPESProducer.h"
+
+#include "CommonTools/CandAlgos/interface/GenParticleCustomSelector.h"
+
+#include "Fit/FitResult.h"
+#include "TF1.h" 
+
 
 #include "TMath.h"
 #include "TLorentzVector.h"
@@ -42,238 +71,1361 @@
 #include <TH2.h>
 #include "TFile.h"
 #include <TProfile.h>
+#include "TStyle.h"
+#include <TCanvas.h>
+#include <TLatex.h>
+//#include "CMSStyle.C"
+//#include "tdrstyle.C"
+//#include "lumi.C"
+#include <DataFormats/GEMRecHit/interface/ME0SegmentCollection.h>
 
-class ME0MuonAnalyzer : public edm::EDAnalyzer 
-{
+#include "Geometry/GEMGeometry/interface/ME0Geometry.h"
+#include <Geometry/GEMGeometry/interface/ME0EtaPartition.h>
+#include <Geometry/Records/interface/MuonGeometryRecord.h>
+#include <DataFormats/MuonDetId/interface/ME0DetId.h>
+
+
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianCartesianToLocal.h"
+#include "TrackingTools/AnalyticalJacobians/interface/JacobianLocalToCartesian.h"
+#include "TGraph.h"
+
+#include <sstream>    
+
+#include <iostream>
+#include <fstream>
+
+class ME0MuonAnalyzer : public edm::EDAnalyzer {
 public:
-
   explicit ME0MuonAnalyzer(const edm::ParameterSet&);
   ~ME0MuonAnalyzer();
+  FreeTrajectoryState getFTS(const GlobalVector& , const GlobalVector& , 
+			     int , const AlgebraicSymMatrix66& ,
+			     const MagneticField* );
 
-  void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
+  FreeTrajectoryState getFTS(const GlobalVector& , const GlobalVector& , 
+			     int , const AlgebraicSymMatrix55& ,
+			     const MagneticField* );
+    void getFromFTS(const FreeTrajectoryState& ,
+		  GlobalVector& , GlobalVector& , 
+		  int& , AlgebraicSymMatrix66& );
+
+
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
   virtual void endJob();
+  //virtual void beginJob(const edm::EventSetup&);
+  void beginJob();
 
-private:
+  //For Track Association
 
-  TFile* histoFile;
-  TH1F *Candidate_Eta;  TH1F *Mass_h;  int NumCands; int NumSegs;
-  TH1F *Segment_Eta;  TH1F *Track_Eta; TH1F *Track_Pt;  TH1F *ME0Muon_Eta; TH1F *ME0Muon_Pt; 
-  TH1F *UnmatchedME0Muon_Eta; TH1F *UnmatchedME0Muon_Pt; 
+
+
+  //protected:
+  
+  private:
+  //Associator for chi2: objects
+  //edm::InputTag associatormap;
+  bool UseAssociators;
+  bool RejectEndcapMuons;
+  const TrackAssociatorByChi2* associatorByChi2;
+  std::vector<std::string> associators;
+  std::vector<const TrackAssociatorBase*> associator;
+  std::vector<edm::InputTag> label;
+  GenParticleCustomSelector gpSelector;	
+  //std::string parametersDefiner;
+
+
+  TString histoFolder;
+  TFile* histoFile; 
+  TH1F *Candidate_Eta;  TH1F *Mass_h; 
+  TH1F *Segment_Eta;    TH1F *Segment_Phi;    TH1F *Segment_R;  TH2F *Segment_Pos;  
+  TH1F *Rechit_Eta;    TH1F *Rechit_Phi;    TH1F *Rechit_R;  TH2F *Rechit_Pos;  
+  TH1F *GenMuon_Phi;    TH1F *GenMuon_R;  TH2F *GenMuon_Pos;  
+  TH1F *Track_Eta; TH1F *Track_Pt;  TH1F *ME0Muon_Eta; TH1F *ME0Muon_Pt;  TH1F *CheckME0Muon_Eta; 
+  TH1F *ME0Muon_Cuts_Eta_5_10; TH1F *ME0Muon_Cuts_Eta_10_20; TH1F *ME0Muon_Cuts_Eta_20_40; TH1F *ME0Muon_Cuts_Eta_40; 
+  TH1F *UnmatchedME0Muon_Eta; TH1F *UnmatchedME0Muon_Pt;    TH1F *Chi2UnmatchedME0Muon_Eta; 
+  TH1F *UnmatchedME0Muon_Cuts_Eta_5_10;  TH1F *UnmatchedME0Muon_Cuts_Eta_10_20;  TH1F *UnmatchedME0Muon_Cuts_Eta_20_40;  TH1F *UnmatchedME0Muon_Cuts_Eta_40;
   TH1F *TracksPerSegment_h;  TH2F *TracksPerSegment_s;  TProfile *TracksPerSegment_p;
-  TH1F *GenMuon_Eta; TH1F *GenMuon_Pt;   TH1F *MatchedME0Muon_Eta; TH1F *MatchedME0Muon_Pt; 
-  TH1F *MuonRecoEff_Eta;  TH1F *MuonRecoEff_Pt;
+  TH2F *ClosestDelR_s; TProfile *ClosestDelR_p;
+  TH2F *PtDiff_s; TProfile *PtDiff_p; TH1F *PtDiff_h; TH1F *QOverPtDiff_h; TH1F *PtDiff_rms; TH1F *PtDiff_gaus_narrow; TH1F *PtDiff_gaus_wide;
+  TH1F *PtDiff_gaus_5_10;  TH1F *PtDiff_gaus_10_20;  TH1F *PtDiff_gaus_20_40; TH1F *PtDiff_gaus_40;
+  TH1F *VertexDiff_h;
+  TH2F *PDiff_s; TProfile *PDiff_p; TH1F *PDiff_h;
+  TH2F *PtDiff_s_5_10;    TH2F *PtDiff_s_10_20;    TH2F *PtDiff_s_20_40;    TH2F *PtDiff_s_40;
+  TH1F *FakeTracksPerSegment_h;  TH2F *FakeTracksPerSegment_s;  TProfile *FakeTracksPerSegment_p;
+  TH1F *FakeTracksPerAssociatedSegment_h;  TH2F *FakeTracksPerAssociatedSegment_s;  TProfile *FakeTracksPerAssociatedSegment_p;
+  TH1F *GenMuon_Eta; TH1F *GenMuon_Pt;   TH1F *MatchedME0Muon_Eta; TH1F *MatchedME0Muon_Pt; TH1F *Chi2MatchedME0Muon_Eta; TH1F *Chi2MatchedME0Muon_Pt; 
+  TH1F *MatchedME0Muon_Eta_5_10;  TH1F *MatchedME0Muon_Eta_10_20;  TH1F *MatchedME0Muon_Eta_20_40;  TH1F *MatchedME0Muon_Eta_40;
+  TH1F *GenMuon_Eta_5_10;  TH1F *GenMuon_Eta_10_20;  TH1F *GenMuon_Eta_20_40;  TH1F *GenMuon_Eta_40;
+  TH1F *MuonRecoEff_Eta;  TH1F *MuonRecoEff_Pt;   TH1F *Chi2MuonRecoEff_Eta;  
+  TH1F *MuonRecoEff_Eta_5_10;  TH1F *MuonRecoEff_Eta_10_20;  TH1F *MuonRecoEff_Eta_20_40;  TH1F *MuonRecoEff_Eta_40;
+  TH1F *FakeRate_Eta;  TH1F *FakeRate_Pt;  TH1F *FakeRate_Eta_PerEvent;    TH1F *Chi2FakeRate_Eta;  
+  TH1F *FakeRate_Eta_5_10;  TH1F *FakeRate_Eta_10_20;  TH1F *FakeRate_Eta_20_40;  TH1F *FakeRate_Eta_40;
   TH1F *MuonAllTracksEff_Eta;  TH1F *MuonAllTracksEff_Pt;
-  TH1F *MuonUnmatchedTracksEff_Eta;  TH1F *MuonUnmatchedTracksEff_Pt;
-  int TrackCount;
-};
+  TH1F *MuonUnmatchedTracksEff_Eta;  TH1F *MuonUnmatchedTracksEff_Pt; TH1F *FractionMatched_Eta;
 
+  TH1F *UnmatchedME0Muon_Cuts_Eta;TH1F *ME0Muon_Cuts_Eta;
+
+  TH1F *DelR_Segment_GenMuon;
+
+  TH1F *SegPosDirPhiDiff_True_h;    TH1F *SegPosDirEtaDiff_True_h;     TH1F *SegPosDirPhiDiff_All_h;    TH1F *SegPosDirEtaDiff_All_h;   
+  TH1F *SegTrackDirPhiDiff_True_h;    TH1F *SegTrackDirEtaDiff_True_h;     TH1F *SegTrackDirPhiDiff_All_h;    TH1F *SegTrackDirEtaDiff_All_h;   TH1F *SegTrackDirPhiPull_True_h;   TH1F *SegTrackDirPhiPull_All_h;   
+
+  TH1F *SegGenDirPhiDiff_True_h;    TH1F *SegGenDirEtaDiff_True_h;     TH1F *SegGenDirPhiDiff_All_h;    TH1F *SegGenDirEtaDiff_All_h;   TH1F *SegGenDirPhiPull_True_h;   TH1F *SegGenDirPhiPull_All_h;   
+
+  TH1F *XDiff_h;   TH1F *YDiff_h;   TH1F *XPull_h;   TH1F *YPull_h;
+
+
+
+  TH1F *NormChi2_h;    TH1F *NormChi2Prob_h; TH2F *NormChi2VsHits_h;	TH2F *chi2_vs_eta_h;  TH1F *AssociatedChi2_h;  TH1F *AssociatedChi2_Prob_h;
+
+  double  FakeRatePtCut, MatchingWindowDelR;
+
+  double Nevents;
+
+
+//Removing this
+};
 
 ME0MuonAnalyzer::ME0MuonAnalyzer(const edm::ParameterSet& iConfig) 
 {
   histoFile = new TFile(iConfig.getParameter<std::string>("HistoFile").c_str(), "recreate");
-  NumCands = 0;
-  NumSegs = 0;
-  TrackCount = 0;
+  histoFolder = iConfig.getParameter<std::string>("HistoFolder").c_str();
+  RejectEndcapMuons = iConfig.getParameter< bool >("RejectEndcapMuons");
+  UseAssociators = iConfig.getParameter< bool >("UseAssociators");
+
+  FakeRatePtCut   = iConfig.getParameter<double>("FakeRatePtCut");
+  MatchingWindowDelR   = iConfig.getParameter<double>("MatchingWindowDelR");
+
+  //Associator for chi2: getting parametters
+  //associatormap = iConfig.getParameter< edm::InputTag >("associatormap");
+  UseAssociators = iConfig.getParameter< bool >("UseAssociators");
+  associators = iConfig.getParameter< std::vector<std::string> >("associators");
+
+  label = iConfig.getParameter< std::vector<edm::InputTag> >("label"),
+
+  gpSelector = GenParticleCustomSelector(iConfig.getParameter<double>("ptMinGP"),
+					 iConfig.getParameter<double>("minRapidityGP"),
+					 iConfig.getParameter<double>("maxRapidityGP"),
+					 iConfig.getParameter<double>("tipGP"),
+					 iConfig.getParameter<double>("lipGP"),
+					 iConfig.getParameter<bool>("chargedOnlyGP"),
+					 iConfig.getParameter<int>("statusGP"),
+					 iConfig.getParameter<std::vector<int> >("pdgIdGP"));
+  //parametersDefiner =iConfig.getParameter<std::string>("parametersDefiner");
+
+
 }
 
 
+
+//void ME0MuonAnalyzer::beginJob(const edm::EventSetup& iSetup)
 void ME0MuonAnalyzer::beginJob()
 {
-  Candidate_Eta = new TH1F("Candidate_Eta"      , "Candidate #eta"   , 40, 2.2, 4.2 );
+  
+  Candidate_Eta = new TH1F("Candidate_Eta"      , "Candidate #eta"   , 4, 2.0, 2.8 );
 
-  Track_Eta = new TH1F("Track_Eta"      , "Track #eta"   , 40, 2.2, 4.2 );
-  Track_Pt = new TH1F("Track_Pt"      , "Muon p_{T}"   , 40,0 , 40 );
+  Track_Eta = new TH1F("Track_Eta"      , "Track #eta"   , 4, 2.0, 2.8 );
+  Track_Pt = new TH1F("Track_Pt"      , "Muon p_{T}"   , 120,0 , 120. );
 
-  Segment_Eta = new TH1F("Segment_Eta"      , "Segment #eta"   , 40, 2.2, 4.2 );
+  Segment_Eta = new TH1F("Segment_Eta"      , "Segment #eta"   , 4, 2.0, 2.8 );
+  Segment_Phi = new TH1F("Segment_Phi"      , "Segment #phi"   , 60, -3, 3. );
+  Segment_R = new TH1F("Segment_R"      , "Segment r"   , 30, 0, 150 );
+  Segment_Pos = new TH2F("Segment_Pos"      , "Segment x,y"   ,100,-100.,100., 100,-100.,100. );
 
-  ME0Muon_Eta = new TH1F("ME0Muon_Eta"      , "Muon #eta"   , 40, 2.2, 4.2 );
-  ME0Muon_Pt = new TH1F("ME0Muon_Pt"      , "Muon p_{T}"   , 40,0 , 40 );
+  Rechit_Eta = new TH1F("Rechit_Eta"      , "Rechit #eta"   , 4, 2.0, 2.8 );
+  Rechit_Phi = new TH1F("Rechit_Phi"      , "Rechit #phi"   , 60, -3, 3. );
+  Rechit_R = new TH1F("Rechit_R"      , "Rechit r"   , 30, 0, 150 );
+  Rechit_Pos = new TH2F("Rechit_Pos"      , "Rechit x,y"   ,100,-100.,100., 100,-100.,100. );
 
-  GenMuon_Eta = new TH1F("GenMuon_Eta"      , "Muon #eta"   , 80, 0, 4.2 );
-  GenMuon_Pt = new TH1F("GenMuon_Pt"      , "Muon p_{T}"   , 40,0 , 40 );
+  //  GenMuon_Eta = new TH1F("GenMuon_Eta"      , "GenMuon #eta"   , 4, 2.0, 2.8 );
+  GenMuon_Phi = new TH1F("GenMuon_Phi"      , "GenMuon #phi"   , 60, -3, 3. );
+  GenMuon_R = new TH1F("GenMuon_R"      , "GenMuon r"   , 30, 0, 150 );
+  GenMuon_Pos = new TH2F("GenMuon_Pos"      , "GenMuon x,y"   ,100,-100.,100., 100,-100.,100. );
 
-  MatchedME0Muon_Eta = new TH1F("MatchedME0Muon_Eta"      , "Muon #eta"   , 80, 0, 4.2 );
-  MatchedME0Muon_Pt = new TH1F("MatchedME0Muon_Pt"      , "Muon p_{T}"   , 40,0 , 40 );
+  ME0Muon_Eta = new TH1F("ME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  ME0Muon_Cuts_Eta_5_10 = new TH1F("ME0Muon_Cuts_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  ME0Muon_Cuts_Eta_10_20 = new TH1F("ME0Muon_Cuts_Eta_10_20"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  ME0Muon_Cuts_Eta_20_40 = new TH1F("ME0Muon_Cuts_Eta_20_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  ME0Muon_Cuts_Eta_40 = new TH1F("ME0Muon_Cuts_Eta_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
 
-  UnmatchedME0Muon_Eta = new TH1F("UnmatchedME0Muon_Eta"      , "Muon #eta"   , 40, 2.2, 4.2 );
-  UnmatchedME0Muon_Pt = new TH1F("UnmatchedME0Muon_Pt"      , "Muon p_{T}"   , 40,0 , 40 );
+  CheckME0Muon_Eta = new TH1F("CheckME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  ME0Muon_Pt = new TH1F("ME0Muon_Pt"      , "Muon p_{T}"   , 120,0 , 120. );
+
+  GenMuon_Eta = new TH1F("GenMuon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  GenMuon_Eta_5_10 = new TH1F("GenMuon_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  GenMuon_Eta_10_20 = new TH1F("GenMuon_Eta_10_20"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  GenMuon_Eta_20_40 = new TH1F("GenMuon_Eta_20_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  GenMuon_Eta_40 = new TH1F("GenMuon_Eta_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
+
+  GenMuon_Pt = new TH1F("GenMuon_Pt"      , "Muon p_{T}"   , 120,0 , 120. );
+
+  MatchedME0Muon_Eta = new TH1F("MatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  MatchedME0Muon_Eta_5_10 = new TH1F("MatchedME0Muon_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  MatchedME0Muon_Eta_10_20 = new TH1F("MatchedME0Muon_Eta_10_20"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  MatchedME0Muon_Eta_20_40 = new TH1F("MatchedME0Muon_Eta_20_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  MatchedME0Muon_Eta_40 = new TH1F("MatchedME0Muon_Eta_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
+
+  MatchedME0Muon_Pt = new TH1F("MatchedME0Muon_Pt"      , "Muon p_{T}"   , 40,0 , 20 );
+
+  Chi2MatchedME0Muon_Eta = new TH1F("Chi2MatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  Chi2MatchedME0Muon_Pt = new TH1F("Chi2MatchedME0Muon_Pt"      , "Muon p_{T}"   , 40,0 , 20 );
+
+  Chi2UnmatchedME0Muon_Eta = new TH1F("Chi2UnmatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+
+  UnmatchedME0Muon_Eta = new TH1F("UnmatchedME0Muon_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  UnmatchedME0Muon_Cuts_Eta_5_10 = new TH1F("UnmatchedME0Muon_Cuts_Eta_5_10"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  UnmatchedME0Muon_Cuts_Eta_10_20 = new TH1F("UnmatchedME0Muon_Cuts_Eta_10_20"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  UnmatchedME0Muon_Cuts_Eta_20_40 = new TH1F("UnmatchedME0Muon_Cuts_Eta_20_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  UnmatchedME0Muon_Cuts_Eta_40 = new TH1F("UnmatchedME0Muon_Cuts_Eta_40"      , "Muon #eta"   , 4, 2.0, 2.8 );
+
+  UnmatchedME0Muon_Pt = new TH1F("UnmatchedME0Muon_Pt"      , "Muon p_{T}"   , 500,0 , 50 );
+
+  UnmatchedME0Muon_Cuts_Eta = new TH1F("UnmatchedME0Muon_Cuts_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
+  ME0Muon_Cuts_Eta = new TH1F("ME0Muon_Cuts_Eta"      , "Muon #eta"   , 4, 2.0, 2.8 );
 
   Mass_h = new TH1F("Mass_h"      , "Mass"   , 100, 0., 200 );
 
-  MuonRecoEff_Eta = new TH1F("MuonRecoEff_Eta"      , "Reco Efficiency"   ,80, 0, 4.2  );
-  MuonRecoEff_Pt = new TH1F("MuonRecoEff_Pt"      , "Reco Efficiency"   ,40, 0,40  );
+  MuonRecoEff_Eta = new TH1F("MuonRecoEff_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
 
-  MuonAllTracksEff_Eta = new TH1F("MuonAllTracksEff_Eta"      , "All ME0Muons over all tracks"   ,40, 2.2, 4.2  );
-  MuonAllTracksEff_Pt = new TH1F("MuonAllTracksEff_Pt"      , "All ME0Muons over all tracks"   ,40, 0,40  );
+  MuonRecoEff_Eta_5_10 = new TH1F("MuonRecoEff_Eta_5_10"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
+  MuonRecoEff_Eta_10_20 = new TH1F("MuonRecoEff_Eta_10_20"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
+  MuonRecoEff_Eta_20_40 = new TH1F("MuonRecoEff_Eta_20_40"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
+  MuonRecoEff_Eta_40 = new TH1F("MuonRecoEff_Eta_40"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
+  Chi2MuonRecoEff_Eta = new TH1F("Chi2MuonRecoEff_Eta"      , "Fraction of ME0Muons matched to gen muons"   ,4, 2.0, 2.8  );
+  MuonRecoEff_Pt = new TH1F("MuonRecoEff_Pt"      , "Fraction of ME0Muons matched to gen muons"   ,8, 0,40  );
 
-  MuonUnmatchedTracksEff_Eta = new TH1F("MuonUnmatchedTracksEff_Eta"      , "Unmatched ME0Muons over all ME0Muons"   ,40, 2.2, 4.2  );
-  MuonUnmatchedTracksEff_Pt = new TH1F("MuonUnmatchedTracksEff_Pt"      , "Unmatched ME0Muons over all ME0Muons"   ,40, 0,40  );
+  FakeRate_Eta = new TH1F("FakeRate_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
+  FakeRate_Eta_5_10 = new TH1F("FakeRate_Eta_5_10"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
+  FakeRate_Eta_10_20 = new TH1F("FakeRate_Eta_10_20"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
+  FakeRate_Eta_20_40 = new TH1F("FakeRate_Eta_20_40"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
+  FakeRate_Eta_40 = new TH1F("FakeRate_Eta_40"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
 
-  TracksPerSegment_h = new TH1F("TracksPerSegment_h", "Number of tracks", 5,0.,5.);
-  TracksPerSegment_s = new TH2F("TracksPerSegment_s" , "Tracks per segment vs |#eta|, z = 560 cm", 40, 2.4, 4.0, 5,0.,5.);
-  TracksPerSegment_p = new TProfile("TracksPerSegment_p" , "Tracks per segment vs |#eta|, z = 560 cm", 40, 2.4, 4.0, 0.,5.);
+  Chi2FakeRate_Eta = new TH1F("Chi2FakeRate_Eta"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,4, 2.0, 2.8  );
+
+  FakeRate_Eta_PerEvent = new TH1F("FakeRate_Eta_PerEvent"      , "PU140, unmatched ME0Muons/all ME0Muons normalized by N_{events}"   ,4, 2.0, 2.8  );
+  FakeRate_Pt = new TH1F("FakeRate_Pt"      , "PU140, unmatched ME0Muons/all ME0Muons"   ,8, 0,40  );
+
+  MuonAllTracksEff_Eta = new TH1F("MuonAllTracksEff_Eta"      , "All ME0Muons over all tracks"   ,4, 2.0, 2.8  );
+  MuonAllTracksEff_Pt = new TH1F("MuonAllTracksEff_Pt"      , "All ME0Muons over all tracks"   ,8, 0,40  );
+
+  MuonUnmatchedTracksEff_Eta = new TH1F("MuonUnmatchedTracksEff_Eta"      , "Unmatched ME0Muons over all ME0Muons"   ,4, 2.0, 2.8  );
+  MuonUnmatchedTracksEff_Pt = new TH1F("MuonUnmatchedTracksEff_Pt"      , "Unmatched ME0Muons over all ME0Muons"   ,8, 0,40  );
+
+  TracksPerSegment_h = new TH1F("TracksPerSegment_h", "Number of tracks", 60,0.,60.);
+  TracksPerSegment_s = new TH2F("TracksPerSegment_s" , "Tracks per segment vs |#eta|", 4, 2.0, 2.8, 60,0.,60.);
+  TracksPerSegment_p = new TProfile("TracksPerSegment_p" , "Tracks per segment vs |#eta|", 4, 2.0, 2.8, 0.,60.);
+
+  FakeTracksPerSegment_h = new TH1F("FakeTracksPerSegment_h", "Number of fake tracks", 60,0.,60.);
+  FakeTracksPerSegment_s = new TH2F("FakeTracksPerSegment_s" , "Fake tracks per segment", 10, 2.4, 4.0, 100,0.,60.);
+  FakeTracksPerSegment_p = new TProfile("FakeTracksPerSegment_p" , "Average N_{tracks}/segment not matched to genmuons", 10, 2.4, 4.0, 0.,60.);
+
+  FakeTracksPerAssociatedSegment_h = new TH1F("FakeTracksPerAssociatedSegment_h", "Number of fake tracks", 60,0.,60.);
+  FakeTracksPerAssociatedSegment_s = new TH2F("FakeTracksPerAssociatedSegment_s" , "Fake tracks per segment", 10, 2.4, 4.0, 100,0.,60.);
+  FakeTracksPerAssociatedSegment_p = new TProfile("FakeTracksPerAssociatedSegment_p" , "Average N_{tracks}/segment not matched to genmuons", 10, 2.4, 4.0, 0.,60.);
+
+  ClosestDelR_s = new TH2F("ClosestDelR_s" , "#Delta R", 4, 2.0, 2.8, 15,0.,0.15);
+  ClosestDelR_p = new TProfile("ClosestDelR_p" , "#Delta R", 4, 2.0, 2.8, 0.,0.15);
   
+  DelR_Segment_GenMuon = new TH1F("DelR_Segment_GenMuon", "#Delta R between me0segment and gen muon",200,0,2);
+  FractionMatched_Eta = new TH1F("FractionMatched_Eta"      , "Fraction of ME0Muons that end up successfully matched (matched/all)"   ,4, 2.0, 2.8  );
+
+  PtDiff_s = new TH2F("PtDiff_s" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
+
+  PtDiff_s_5_10 = new TH2F("PtDiff_s_5_10" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
+  PtDiff_s_10_20 = new TH2F("PtDiff_s_10_20" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
+  PtDiff_s_20_40 = new TH2F("PtDiff_s_20_40" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
+  PtDiff_s_40 = new TH2F("PtDiff_s_40" , "Relative pt difference", 4, 2.0, 2.8, 200,-1,1.0);
+
+  PtDiff_h = new TH1F("PtDiff_h" , "pt resolution", 100,-0.5,0.5);
+  QOverPtDiff_h = new TH1F("QOverPtDiff_h" , "q/pt resolution", 100,-0.5,0.5);
+  PtDiff_p = new TProfile("PtDiff_p" , "pt resolution vs. #eta", 4, 2.0, 2.8, -1.0,1.0,"s");
+
+  PtDiff_rms    = new TH1F( "PtDiff_rms",    "RMS", 4, 2.0, 2.8 ); 
+  PtDiff_gaus_wide    = new TH1F( "PtDiff_gaus_wide",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
+  PtDiff_gaus_narrow    = new TH1F( "PtDiff_gaus_narrow",    "GAUS_NARROW", 4, 2.0, 2.8 ); 
+
+  PtDiff_gaus_5_10    = new TH1F( "PtDiff_gaus_5_10",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
+  PtDiff_gaus_10_20    = new TH1F( "PtDiff_gaus_10_20",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
+  PtDiff_gaus_20_40    = new TH1F( "PtDiff_gaus_20_40",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
+  PtDiff_gaus_40    = new TH1F( "PtDiff_gaus_40",    "GAUS_WIDE", 4, 2.0, 2.8 ); 
+
+  PDiff_s = new TH2F("PDiff_s" , "Relative p difference", 4, 2.0, 2.8, 50,0.,0.5);
+  PDiff_h = new TH1F("PDiff_s" , "Relative p difference", 50,0.,0.5);
+  PDiff_p = new TProfile("PDiff_p" , "Relative p difference", 4, 2.0, 2.8, 0.,1.0,"s");
+
+  VertexDiff_h = new TH1F("VertexDiff_h", "Difference in vertex Z", 50, 0, 0.2);
+
+  SegPosDirPhiDiff_True_h = new TH1F("SegPosDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2,2);
+  SegPosDirEtaDiff_True_h = new TH1F("SegPosDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2,2);
+
+  SegPosDirPhiDiff_All_h = new TH1F("SegPosDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3,3);
+  SegPosDirEtaDiff_All_h = new TH1F("SegPosDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3,3);
+
+  SegTrackDirPhiDiff_True_h = new TH1F("SegTrackDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2,2);
+  SegTrackDirEtaDiff_True_h = new TH1F("SegTrackDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2,2);
+
+  SegTrackDirPhiPull_True_h = new TH1F("SegTrackDirPhiPull_True_h", "#phi Dir. Pull. Real Muons", 50, -3,3);
+  SegTrackDirPhiPull_All_h = new TH1F("SegTrackDirPhiPull_True_h", "#phi Dir. Pull. All Muons", 50, -3,3);
+
+  SegTrackDirPhiDiff_All_h = new TH1F("SegTrackDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3,3);
+  SegTrackDirEtaDiff_All_h = new TH1F("SegTrackDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3,3);
+
+  SegGenDirPhiDiff_True_h = new TH1F("SegGenDirPhiDiff_True_h", "#phi Dir. Diff. Real Muons", 50, -2,2);
+  SegGenDirEtaDiff_True_h = new TH1F("SegGenDirEtaDiff_True_h", "#eta Dir. Diff. Real Muons", 50, -2,2);
+
+  SegGenDirPhiPull_True_h = new TH1F("SegGenDirPhiPull_True_h", "#phi Dir. Pull. Real Muons", 50, -3,3);
+  SegGenDirPhiPull_All_h = new TH1F("SegGenDirPhiPull_True_h", "#phi Dir. Pull. All Muons", 50, -3,3);
+
+  SegGenDirPhiDiff_All_h = new TH1F("SegGenDirPhiDiff_All_h", "#phi Dir. Diff. All Muons", 50, -3,3);
+  SegGenDirEtaDiff_All_h = new TH1F("SegGenDirEtaDiff_All_h", "#eta Dir. Diff. All Muons", 50, -3,3);
+
+
+
+  XDiff_h = new TH1F("XDiff_h", "X Diff", 100, -10.0, 10.0 );
+  YDiff_h = new TH1F("YDiff_h", "Y Diff", 100, -50.0, 50.0 ); 
+  XPull_h = new TH1F("XPull_h", "X Pull", 100, -5.0, 5.0 );
+  YPull_h = new TH1F("YPull_h", "Y Pull", 40, -50.0, 50.0 );
+
+  AssociatedChi2_h = new TH1F("AssociatedChi2_h","Associated #chi^{2}",50,0,50);
+  AssociatedChi2_Prob_h = new TH1F("AssociatedChi2_h","Associated #chi^{2}",50,0,1);
+  NormChi2_h = new TH1F("NormChi2_h","normalized #chi^{2}", 200, 0, 20);
+  NormChi2Prob_h = new TH1F("NormChi2Prob_h","normalized #chi^{2} probability", 100, 0, 1);
+  NormChi2VsHits_h = new TH2F("NormChi2VsHits_h","#chi^{2} vs nhits",25,0,25,100,0,10);
+  chi2_vs_eta_h = new TH2F("chi2_vs_eta_h","#chi^{2} vs #eta",4, 2.0, 2.8 , 200, 0, 20);
+
+  Nevents=0;
+
+
 }
 
 
 ME0MuonAnalyzer::~ME0MuonAnalyzer(){}
 
-
 void
 ME0MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+
 {
+
+  //std::cout<<"ANALYZER"<<std::endl;
+  
   using namespace edm;
+
+  //run_ = (int)iEvent.id().run();
+  //event_ = (int)iEvent.id().event();
+
+
+    //David's functionality
+
 
   using namespace reco;
 
-  edm::Handle <std::vector<RecoChargedCandidate> > OurCandidates;
+  // Handle <ME0MuonCollection > OurMuons;
+  // iEvent.getByLabel <ME0MuonCollection> ("me0SegmentMatcher", OurMuons);
+
+  Handle <std::vector<RecoChargedCandidate> > OurCandidates;
   iEvent.getByLabel <std::vector<RecoChargedCandidate> > ("me0MuonConverter", OurCandidates);
 
-  edm::Handle<std::vector<EmulatedME0Segment> > OurSegments;
-  iEvent.getByLabel<std::vector<EmulatedME0Segment> >("me0SegmentProducer", OurSegments);
+  //Handle<std::vector<EmulatedME0Segment> > OurSegments;
+  //iEvent.getByLabel<std::vector<EmulatedME0Segment> >("me0SegmentProducer", OurSegments);
 
-  edm::Handle<GenParticleCollection> genParticles;
+  Handle<GenParticleCollection> genParticles;
+
   iEvent.getByLabel<GenParticleCollection>("genParticles", genParticles);
+  const GenParticleCollection genParticlesForChi2 = *(genParticles.product());
 
-  edm::Handle <TrackCollection > generalTracks;
+  unsigned int gensize=genParticles->size();
+
+  if (RejectEndcapMuons){
+    //Section to turn off signal muons in the endcaps, to approximate a nu gun
+    for(unsigned int i=0; i<gensize; ++i) {
+      const reco::GenParticle& CurrentParticle=(*genParticles)[i];
+      if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
+	if (fabs(CurrentParticle.eta()) > 1.9 ) {
+	  std::cout<<"Found a signal muon outside the barrel, exiting the function"<<std::endl;
+	  return;
+	}
+      }
+    }      
+  }
+
+
+
+  Nevents++;
+
+
+  Handle <TrackCollection > generalTracks;
   iEvent.getByLabel <TrackCollection> ("generalTracks", generalTracks);
 
-  edm::Handle <std::vector<ME0Muon> > OurMuons;
+  Handle <std::vector<ME0Muon> > OurMuons;
   iEvent.getByLabel <std::vector<ME0Muon> > ("me0SegmentMatcher", OurMuons);
+
+  Handle<ME0SegmentCollection> OurSegments;
+  iEvent.getByLabel("me0Segments","",OurSegments);
+
+
+  edm::ESHandle<ME0Geometry> me0Geom;
+  iSetup.get<MuonGeometryRecord>().get(me0Geom);
+
+  ESHandle<MagneticField> bField;
+  iSetup.get<IdealMagneticFieldRecord>().get(bField);
+  ESHandle<Propagator> shProp;
+  iSetup.get<TrackingComponentsRecord>().get("SteppingHelixPropagatorAlong", shProp);
+  
+
+
+  //For Track Association:
+
+  //std::cout<<"ON BEGIN JOB:"<<std::endl;
+  if (UseAssociators) {
+    //std::cout<<"Inside if:"<<std::endl;
+    edm::ESHandle<TrackAssociatorBase> theAssociator;
+    //std::cout<<"associators size = "<<associators.size()<<std::endl;
+    for (unsigned int w=0;w<associators.size();w++) {
+      //std::cout<<"On step "<<w<<std::endl;
+      iSetup.get<TrackAssociatorRecord>().get(associators[w],theAssociator);
+      //std::cout<<"On step "<<w<<std::endl;
+      associator.push_back( theAssociator.product() );
+      //std::cout<<"On step "<<w<<std::endl;
+    }
+    //std::cout<<"Got this many associators: "<<associator.size()<<std::endl;
+  }
+
+  //For Track Association:
+  //edm::ESHandle<ParametersDefinerForTP> parametersDefinerTP; 
+  //iSetup.get<TrackAssociatorRecord>().get(parametersDefiner,parametersDefinerTP);
 
 
   //=====Finding ME0Muons that match gen muons, plotting the closest of those
   //    -----First, make a vector of bools for each ME0Muon
 
   std::vector<bool> IsMatched;
+  std::vector<int> SegIdForMatch;
   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
        thisMuon != OurMuons->end(); ++thisMuon){
     IsMatched.push_back(false);
+    SegIdForMatch.push_back(-1);
   }
+  //std::cout<<IsMatched.size()<<" total me0muons"<<std::endl;
   //   -----Now, loop over each gen muon to compare it to each ME0Muon
   //   -----For each gen muon, take the closest ME0Muon that is a match within delR 0.15
   //   -----Each time a match on an ME0Muon is made, change the IsMatched bool corresponding to it to true
   //   -----Also, each time a match on an ME0Muon is made, we plot the pt and eta of the gen muon it was matched to
-  unsigned int gensize=genParticles->size();
+
+  // unsigned int gensize=genParticles->size();
+  // for(unsigned int i=0; i<gensize; ++i) {
+  //   const reco::GenParticle& CurrentParticle=(*genParticles)[i];
+  //   if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
+  //     for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
+  // 	   thisTrack != generalTracks->end();++thisTrack){
+  // 	VertexDiff_h->Fill(fabs(thisTrack->vz()-CurrentParticle.vz()));
+  // 	PtDiff_h->Fill(fabs(thisTrack->pt() - CurrentParticle.pt())/CurrentParticle.pt());
+  // 	PtDiff_s->Fill(CurrentParticle.eta(),fabs(thisTrack->pt() - CurrentParticle.pt())/CurrentParticle.pt());
+  // 	PtDiff_p->Fill(CurrentParticle.eta(),fabs(thisTrack->pt() - CurrentParticle.pt())/CurrentParticle.pt());
+  // 	PDiff_h->Fill(fabs(thisTrack->p() - CurrentParticle.p())/CurrentParticle.p());
+  // 	PDiff_s->Fill(CurrentParticle.eta(),fabs(thisTrack->p() - CurrentParticle.p())/CurrentParticle.p());
+  // 	PDiff_p->Fill(CurrentParticle.eta(),fabs(thisTrack->p() - CurrentParticle.p())/CurrentParticle.p());
+  //     }
+  //   }
+  // }
+  //--------------------------------------------------------------
+
+
+  //============================Debugging
+  //  bool FoundRightMuon = false;
+
+  // for(unsigned int i=0; i<gensize; ++i) {
+  //    const reco::GenParticle& CurrentParticle=(*genParticles)[i];
+  //    if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
+  //      if ((fabs(CurrentParticle.eta()) < 2.0 ) ||(fabs(CurrentParticle.eta()) > 2.8 )) continue;
+  //      std::cout<<"Current Particle = "<<CurrentParticle.eta()<<", "<<CurrentParticle.phi()<<std::endl;
+  //      for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
+  // 	   thisMuon != OurMuons->end(); ++thisMuon){
+  // 	TrackRef tkRef = thisMuon->innerTrack();
+  // 	double thisDelR = reco::deltaR(CurrentParticle,*tkRef);
+
+  // 	ME0Segment Seg = thisMuon->me0segment();
+  // 	ME0DetId id =Seg.me0DetId();
+  // 	auto roll = me0Geom->etaPartition(id); 
+  // 	auto GlobVect(roll->toGlobal(Seg.localPosition()));
+
+  // 	if (thisDelR < 0.15){
+
+  // 	  std::cout<<"ME0Muon = "<<tkRef->pt()<<", "<<tkRef->eta()<<", "<<tkRef->phi()<<std::endl;
+  // 	  std::cout<<"Segment = "<<GlobVect.eta()<<", "<<GlobVect.phi()<<std::endl;
+
+	  
+  // 	}
+  // 	else if (tkRef->pt() > 8.0){
+  // 	  std::cout<<"Out of range = "<<tkRef->pt()<<", "<<tkRef->eta()<<", "<<tkRef->phi()<<std::endl;
+  // 	  std::cout<<"Segment = "<<GlobVect.eta()<<", "<<GlobVect.phi()<<std::endl;
+  // 	}
+  // 	if (fabs(tkRef->pt()-10.0) < 1.0) FoundRightMuon=true;
+	
+  //      }
+  //    }
+  // }
+
+
+      
+    
+  // if (!FoundRightMuon){
+  // std::cout<<"Current Particle = "<<CurrentParticle.eta()<<", "<<CurrentParticle.phi()<<std::endl;
+  // std::cout<<"Pos:"<<std::endl;
+  // std::cout<<r3Final.eta()<<", "<<r3Final.phi()<<std::endl;
+  // 	}
+  // for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
+  // 	   ++thisSegment){
+  // 	ME0DetId id = thisSegment->me0DetId();
+  // 	//std::cout<<"ME0DetId =  "<<id<<std::endl;
+  // 	auto roll = me0Geom->etaPartition(id); 
+  // 	auto GlobVect(roll->toGlobal(thisSegment->localPosition()));
+
+  // 	double thisDelR = reco::deltaR(r3Final,GlobVect);
+  // 	if (!FoundRightMuon){
+  // 	if (thisDelR < 0.3){
+  // 	  std::cout<<"Segment = "<<GlobVect.eta()<<", "<<GlobVect.phi()<<std::endl;
+  // 	  std::cout<<"local errors = "<<thisSegment->localPositionError().xx()<<", "<<thisSegment->localPositionError().yy()<<std::endl;
+  // 	}
+  // 	}
+
+
+  // for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
+  // 	   thisTrack != generalTracks->end();++thisTrack){
+
+  // //Remove later
+  // if (fabs(thisTrack->eta()) < 1.8) continue;
+  // //if (fabs(thisTrack->pt()) < 0.6) continue;
+
+  // //std::cout<<"Track pt = "<<thisTrack->pt();
+  // float zSign  = thisTrack->pz()/fabs(thisTrack->pz());
+
+  // //float zValue = 560. * zSign;
+  // float zValue = 526.75 * zSign;
+  // Plane *plane = new Plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
+  // //Getting the initial variables for propagation
+  // int chargeReco = thisTrack->charge(); 
+  // GlobalVector p3reco, r3reco;
+
+  // p3reco = GlobalVector(thisTrack->outerPx(), thisTrack->outerPy(), thisTrack->outerPz());
+  // r3reco = GlobalVector(thisTrack->outerX(), thisTrack->outerY(), thisTrack->outerZ());
+
+  // AlgebraicSymMatrix66 covReco;
+  // //This is to fill the cov matrix correctly
+  // AlgebraicSymMatrix55 covReco_curv;
+  // covReco_curv = thisTrack->outerStateCovariance();
+  // FreeTrajectoryState initrecostate = getFTS(p3reco, r3reco, chargeReco, covReco_curv, &*bField);
+  // getFromFTS(initrecostate, p3reco, r3reco, chargeReco, covReco);
+
+  // //Now we propagate and get the propagated variables from the propagated state
+  // SteppingHelixStateInfo startrecostate(initrecostate);
+  // SteppingHelixStateInfo lastrecostate;
+
+  // const SteppingHelixPropagator* ThisshProp = 
+  // 	dynamic_cast<const SteppingHelixPropagator*>(&*shProp);
+	
+  // lastrecostate = ThisshProp->propagate(startrecostate, *plane);
+	
+  // FreeTrajectoryState finalrecostate;
+  // lastrecostate.getFreeState(finalrecostate);
+      
+  // AlgebraicSymMatrix66 covFinalReco;
+  // GlobalVector p3FinalReco_glob, r3FinalReco_globv;
+  // getFromFTS(finalrecostate, p3FinalReco_glob, r3FinalReco_globv, chargeReco, covFinalReco);
+      
+  // GlobalPoint r3FinalReco_glob(r3FinalReco_globv.x(),r3FinalReco_globv.y(),r3FinalReco_globv.z());
+
+  // for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
+  // 	   ++thisSegment){
+  // 	ME0DetId id = thisSegment->me0DetId();
+  // 	auto roll = me0Geom->etaPartition(id); 
+  // 	//auto GlobVect(roll->toGlobal(thisSegment->localPosition()));
+	
+  // 	LocalPoint r3FinalReco = roll->toLocal(r3FinalReco_glob);
+  // 	LocalVector p3FinalReco=roll->toLocal(p3FinalReco_glob);
+  // 	LocalTrajectoryParameters ltp(r3FinalReco,p3FinalReco,chargeReco);
+  // 	JacobianCartesianToLocal jctl(roll->surface(),ltp);
+  // 	AlgebraicMatrix56 jacobGlbToLoc = jctl.jacobian(); 
+
+  // 	AlgebraicMatrix55 Ctmp =  (jacobGlbToLoc * covFinalReco) * ROOT::Math::Transpose(jacobGlbToLoc); 
+  // 	AlgebraicSymMatrix55 C;  // I couldn't find any other way, so I resort to the brute force
+  // 	for(int i=0; i<5; ++i) {
+  // 	  for(int j=0; j<5; ++j) {
+  // 	    C[i][j] = Ctmp[i][j]; 
+
+  // 	  }
+  // 	}  
+
+  // 	Double_t sigmax = sqrt(C[3][3]+thisSegment->localPositionError().xx() );      
+  // 	Double_t sigmay = sqrt(C[4][4]+thisSegment->localPositionError().yy() );
+
+
+
+  // 	XPull_h->Fill((Seg->localPosition().x()-r3FinalReco.x())/sigmax);
+  // 	YPull_h->Fill((Seg->localPosition().y()-r3FinalReco.y())/sigmay);
+
+  // 	XDiff_h->Fill((Seg->localPosition().x()-r3FinalReco.x()));
+  // 	YDiff_h->Fill((Seg->localPosition().y()-r3FinalReco.y()));
+	
+
+  // }
+  // // double thisDelR = reco::deltaR(CurrentParticle,*thisTrack);
+  // // if (false){
+
+	
+  // // }
+  // //       if (!FoundRightMuon){
+  // //  	if (thisDelR < 0.15){
+
+  // //  	  std::cout<<"Track = "<<thisTrack->pt()<<", "<<thisTrack->eta()<<", "<<thisTrack->phi()<<std::endl;
+  // //  	  std::cout<<"Pos:"<<std::endl;
+  // //  	  std::cout<<r3FinalReco_globv.eta()<<", "<<r3FinalReco_globv.phi()<<std::endl;
+
+  // //  	  std::cout<<"Err:"<<std::endl;
+  // //  	  std::cout<<covFinalReco(0,0)<<", "<<covFinalReco(1,1)<<std::endl;
+  // //  	}
+  // //       }
+  // //       }
+  // // }
+  // }
+
+  //Track Association by Chi2:
+
+  //int w=0;
+  //std::cout<<"associators size = "<<associators.size()<<std::endl;
+  for (unsigned int ww=0;ww<associators.size();ww++){
+
+    //std::cout<<associator[ww]<<std::endl;
+    //std::cout<<"Starting loop over associators (only 1 I think)"<<std::endl;
+
+    associatorByChi2 = dynamic_cast<const TrackAssociatorByChi2*>(associator[ww]);
+
+    //associatorByChi2 = associator[ww];
+    //std::cout<<"here now"<<std::endl;
+    //std::cout<<"associatorByChi2 = "<<associatorByChi2<<std::endl;
+
+    if (associatorByChi2==0) continue;
+    //if (associator[ww]==0) continue;
+    //std::cout<<"here now"<<std::endl;
+
+    //std::cout<<"label size = "<<label.size()<<std::endl;
+    for (unsigned int www=0;www<label.size();www++){
+      //
+      reco::RecoToGenCollection recSimColl;
+      reco::GenToRecoCollection simRecColl;
+      edm::Handle<View<Track> >  trackCollection;
+
+
+
+      unsigned int trackCollectionSize = 0;
+
+      //      if(!event.getByLabel(label[www], trackCollection)&&ignoremissingtkcollection_) continue;
+      //std::cout<<label[www].process()<<", "<<label[www].label()<<", "<<label[www].instance()<<std::endl;
+      if(!iEvent.getByLabel(label[www], trackCollection)) {
+	//std::cout<<"Inserting, since no label"<<std::endl;
+	recSimColl.post_insert();
+	simRecColl.post_insert();
+
+      }
+
+      else {
+	trackCollectionSize = trackCollection->size();
+	recSimColl=associatorByChi2->associateRecoToGen(trackCollection,
+							genParticles,
+							&iEvent,
+							&iSetup);
+	//std::cout<<"here now"<<std::endl;
+	simRecColl=associatorByChi2->associateGenToReco(trackCollection,
+							genParticles,
+							&iEvent,
+							&iSetup);
+      }
+      //std::cout<<"here now"<<std::endl;
+      //int ats = 0;
+      //std::cout<<"genParticlesForChi2.size() = "<<genParticlesForChi2.size()<<std::endl;
+      for (GenParticleCollection::size_type i=0; i<genParticlesForChi2.size(); i++){
+	//bool TP_is_matched = false;
+	double quality = 0.;
+	//bool Quality05  = false;
+	//bool Quality075 = false;
+
+	GenParticleRef tpr(genParticles, i);
+	GenParticle* tp=const_cast<GenParticle*>(tpr.get());
+	TrackingParticle::Vector momentumTP; 
+	TrackingParticle::Point vertexTP;
+	//double dxySim = 0;
+	//double dzSim = 0;
+
+	//Collision like particle
+	if(! gpSelector(*tp)) continue;
+	momentumTP = tp->momentum();
+	vertexTP = tp->vertex();
+	
+	std::vector<std::pair<RefToBase<Track>, double> > rt;
+
+	//Check if the gen particle has been associated to any reco track
+	if(simRecColl.find(tpr) != simRecColl.end()){
+	  rt = (std::vector<std::pair<RefToBase<Track>, double> >) simRecColl[tpr];
+	  //It has, so we check that the pair TrackRef/double pair collection (vector of pairs) is not empty
+	  if (rt.size()!=0) {
+	    //It is not empty, so there is at least one real track that the gen particle is matched to
+	    
+	    //We take the first element of the vector, .begin(), and the trackRef from it, ->first, this is our best possible track match
+	    RefToBase<Track> assoc_recoTrack = rt.begin()->first;
+	    std::cout<<"-----------------------------associated Track #"<<assoc_recoTrack.key()<<std::endl;
+
+	    quality = rt.begin()->second;
+	    std::cout << "TrackingParticle #" <<tpr.key()  
+		      << " with pt=" << sqrt(momentumTP.perp2()) 
+		      << " associated with quality:" << quality <<std::endl;
+
+	    //Also, seeing as we have found a gen particle that is matched to a track, it is efficient, so we put it in the numerator of the efficiency plot
+	    //if (( sqrt(momentumTP.perp2()) > FakeRatePtCut) && (TMath::Abs(tp->eta()) < 2.8) )Chi2MatchedME0Muon_Eta->Fill(tp->eta());
+	    //if ( ( assoc_recoTrack->pt() > FakeRatePtCut) && (TMath::Abs(tp->eta()) < 2.8) )Chi2MatchedME0Muon_Eta->Fill(tp->eta());
+
+	  }
+
+	}//END if(simRecColl.find(tpr) != simRecColl.end())
+      }//END for (GenParticleCollection::size_type i=0; i<genParticlesForChi2.size(); i++)
+
+      
+      for(View<Track>::size_type i=0; i<trackCollectionSize; ++i){
+	//bool Track_is_matched = false; 
+	RefToBase<Track> track(trackCollection, i);
+
+	//std::vector<std::pair<TrackingParticleRef, double> > tp;
+	std::vector<std::pair<GenParticleRef, double> > tp;
+	std::vector<std::pair<GenParticleRef, double> > tpforfake;
+	//TrackingParticleRef tpr;
+	GenParticleRef tpr;
+	GenParticleRef tprforfake;
+
+	//Check if the track is associated to any gen particle
+	if(recSimColl.find(track) != recSimColl.end()){
+	  
+	  tp = recSimColl[track];
+	  if (tp.size()!=0) {
+	    //Track_is_matched = true;
+	    tpr = tp.begin()->first;
+
+	    double assocChi2 = -(tp.begin()->second);
+	   
+	    //So this track is matched to a gen particle, lets get that gen particle now
+	    if (  (simRecColl.find(tpr) != simRecColl.end())    ){
+	      std::vector<std::pair<RefToBase<Track>, double> > rt;
+	      std::cout<<"Comparing gen and reco tracks"<<std::endl;
+	      if  (simRecColl[tpr].size() > 0){
+		rt=simRecColl[tpr];
+		RefToBase<Track> bestrecotrackforeff = rt.begin()->first;
+		//Only fill the efficiency histo if the track found matches up to a gen particle's best choice
+		if (bestrecotrackforeff == track) {
+		  if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) )Chi2MatchedME0Muon_Eta->Fill(fabs(tpr->eta()));
+		  if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) )AssociatedChi2_h->Fill(assocChi2);
+		  if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) )AssociatedChi2_Prob_h->Fill(TMath::Prob((assocChi2)*5,5));
+		  std::cout<<"assocChi2 = "<<assocChi2<<std::endl;
+		}
+	      }
+	    }
+	  }
+	}
+	//End checking of Efficient muons
+
+	//For Fakes --------------------------------------------
+
+	
+	//Check if finding a track associated to a gen particle fails, or if there is no track in the collection at all
+
+	if( (recSimColl.find(track) == recSimColl.end() ) || ( recSimColl[track].size() == 0  ) ){
+	  //So we've now determined that this track is not associated to any gen, and fill our histo of fakes:
+	  if ((track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) ) Chi2UnmatchedME0Muon_Eta->Fill(fabs(track->eta()));
+	}
+	
+	//Its possible that the track is associated to a gen particle, but isn't the best match and would still fail
+	//In that case, we go to the gen particle...
+	else if (recSimColl[track].size() > 0){
+	  tpforfake = recSimColl[track];
+	  tprforfake=tpforfake.begin()->first;
+	  //We now have the gen particle, to check
+
+	  //If for some crazy reason we can't find the gen particle, that means its a fake
+	  if (  (simRecColl.find(tprforfake) == simRecColl.end())  ||  (simRecColl[tprforfake].size() == 0)  ) {
+	    if ((track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8))  Chi2UnmatchedME0Muon_Eta->Fill(fabs(track->eta()));
+	  }
+	  //We can probably find the gen particle
+	  else if(simRecColl[tprforfake].size() > 0)  {
+	    //We can now access the best possible track for the gen particle that this track was matched to
+	    std::vector<std::pair<RefToBase<Track>, double> > rtforfake;
+	    rtforfake=simRecColl[tprforfake];
+	   
+	    RefToBase<Track> bestrecotrack = rtforfake.begin()->first;
+	    //if the best reco track is NOT the track that we're looking at, we know we have a fake, that was within the cut, but not the closest
+	    if (bestrecotrack != track) {
+	      if ( (track->pt() > FakeRatePtCut) && (TMath::Abs(track->eta()) < 2.8) ) Chi2UnmatchedME0Muon_Eta->Fill(fabs(track->eta()));
+	    }
+
+	  }
+	}
+
+	//End For Fakes --------------------------------------------
+
+	
+	if (TMath::Abs(track->eta()) < 2.8) CheckME0Muon_Eta->Fill(fabs(track->eta()));	
+
+	NormChi2_h->Fill(track->normalizedChi2());
+	NormChi2Prob_h->Fill(TMath::Prob(track->chi2(),(int)track->ndof()));
+	NormChi2VsHits_h->Fill(track->numberOfValidHits(),track->normalizedChi2());
+
+
+	chi2_vs_eta_h->Fill((track->eta()),track->normalizedChi2());
+
+	//nhits_vs_eta_h->Fill((track->eta()),track->numberOfValidHits());
+
+
+      }//END for(View<Track>::size_type i=0; i<trackCollectionSize; ++i){
+    }//END for (unsigned int www=0;www<label.size();www++)
+  }// END for (unsigned int www=0;www<label.size();www++)
+  std::cout<<"Finished chi2 stuff"<<std::endl;
+  std::vector<int> MatchedSegIds;
+
   for(unsigned int i=0; i<gensize; ++i) {
     const reco::GenParticle& CurrentParticle=(*genParticles)[i];
     if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
-    //if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) && ((TMath::Abs(CurrentParticle.eta())>2.4) && (TMath::Abs(CurrentParticle.eta()) < 4.0))){  
-    //if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) && ((TMath::Abs(CurrentParticle.eta())<2.4) && (TMath::Abs(CurrentParticle.eta()) > 4.0))){  
-      GenMuon_Eta->Fill(CurrentParticle.eta());
-      if ( (TMath::Abs(CurrentParticle.eta()) > 2.4) && (TMath::Abs(CurrentParticle.eta()) < 4.0) ) GenMuon_Pt->Fill(CurrentParticle.pt());
 
+      //if ( (fabs(CurrentParticle.eta()) > 2.0) && (fabs(CurrentParticle.eta()) < 2.8) )  GenMuon_Eta->Fill(CurrentParticle.eta());
+      //std::cout<<"Mother's ID is: "<<CurrentParticle.motherId()<<std::endl;
+     
       double LowestDelR = 9999;
       double thisDelR = 9999;
       int MatchedID = -1;
       int ME0MuonID = 0;
 
+      std::vector<double> ReferenceTrackPt;
+
+      double VertexDiff=-1,PtDiff=-1,QOverPtDiff=-1,PDiff=-1;
+
+      std::cout<<"Size = "<<OurMuons->size()<<std::endl;
       for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
 	   thisMuon != OurMuons->end(); ++thisMuon){
 	TrackRef tkRef = thisMuon->innerTrack();
-	
+	SegIdForMatch.push_back(thisMuon->me0segid());
 	thisDelR = reco::deltaR(CurrentParticle,*tkRef);
-	if (thisDelR < 0.15){
-	  if (thisDelR < LowestDelR){
-	    LowestDelR = thisDelR;
-	    MatchedID = ME0MuonID;
+	ReferenceTrackPt.push_back(tkRef->pt());
+	if (tkRef->pt() > FakeRatePtCut ) {
+	  if (thisDelR < MatchingWindowDelR ){
+	    if (thisDelR < LowestDelR){
+	      LowestDelR = thisDelR;
+	      //if (fabs(tkRef->pt() - CurrentParticle.pt())/CurrentParticle.pt() < 0.50) MatchedID = ME0MuonID;
+	      MatchedID = ME0MuonID;
+	      VertexDiff = fabs(tkRef->vz()-CurrentParticle.vz());
+	      QOverPtDiff = ( (tkRef->charge() /tkRef->pt()) - (CurrentParticle.charge()/CurrentParticle.pt() ) )/  (CurrentParticle.charge()/CurrentParticle.pt() );
+	      PtDiff = (tkRef->pt() - CurrentParticle.pt())/CurrentParticle.pt();
+	      PDiff = (tkRef->p() - CurrentParticle.p())/CurrentParticle.p();
+	    }
 	  }
 	}
+	
 	ME0MuonID++;
+
       }
+
       if (MatchedID != -1){
 	IsMatched[MatchedID] = true;
-	MatchedME0Muon_Eta->Fill(CurrentParticle.eta());
-	if ( (TMath::Abs(CurrentParticle.eta()) > 2.4) && (TMath::Abs(CurrentParticle.eta()) < 4.0) ) MatchedME0Muon_Pt->Fill(CurrentParticle.pt());
+	if (CurrentParticle.pt() >FakeRatePtCut) {
+	  MatchedME0Muon_Eta->Fill(fabs(CurrentParticle.eta()));
+	  if ( (CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0) )  	MatchedME0Muon_Eta_5_10->Fill(fabs(CurrentParticle.eta()));
+	  if ( (CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 20.0) )	MatchedME0Muon_Eta_10_20->Fill(fabs(CurrentParticle.eta()));
+	  if ( (CurrentParticle.pt() > 20.0) && (CurrentParticle.pt() <= 40.0) )	MatchedME0Muon_Eta_20_40->Fill(fabs(CurrentParticle.eta()));
+	  if ( CurrentParticle.pt() > 40.0) 		MatchedME0Muon_Eta_40->Fill(fabs(CurrentParticle.eta()));
+	
+
+
+	  VertexDiff_h->Fill(VertexDiff);
+	  PtDiff_h->Fill(PtDiff);	
+	  QOverPtDiff_h->Fill(QOverPtDiff);
+	  PtDiff_s->Fill(CurrentParticle.eta(),PtDiff);
+	  if ( (CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0) ) 	PtDiff_s_5_10->Fill(CurrentParticle.eta(),PtDiff);
+	  if ( (CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 20.0) )	PtDiff_s_10_20->Fill(CurrentParticle.eta(),PtDiff);
+	  if ( (CurrentParticle.pt() > 20.0) && (CurrentParticle.pt() <= 40.0) )	PtDiff_s_20_40->Fill(CurrentParticle.eta(),PtDiff);
+	  if ( CurrentParticle.pt() > 40.0) 	PtDiff_s_40->Fill(CurrentParticle.eta(),PtDiff);
+	  PtDiff_p->Fill(CurrentParticle.eta(),PtDiff);
+	
+	  PDiff_h->Fill(PDiff);
+	  PDiff_s->Fill(CurrentParticle.eta(),PDiff);
+	  PDiff_p->Fill(CurrentParticle.eta(),PDiff);
+	}
+	MatchedSegIds.push_back(SegIdForMatch[MatchedID]);
+
+	// if ( ((CurrentParticle.eta()) > 2.4) && ((CurrentParticle.eta()) < 3.8) ) {
+	//   //MatchedME0Muon_Pt->Fill(CurrentParticle.pt());
+	//   //MatchedME0Muon_Pt->Fill(.pt());
+	  
+	// }
       }
+	if (CurrentParticle.pt() >FakeRatePtCut) {
+	  GenMuon_Eta->Fill(fabs(CurrentParticle.eta()));
+	  if ( (CurrentParticle.pt() > 5.0) && (CurrentParticle.pt() <= 10.0) )  	GenMuon_Eta_5_10->Fill(fabs(CurrentParticle.eta()));
+	  if ( (CurrentParticle.pt() > 10.0) && (CurrentParticle.pt() <= 20.0) )	GenMuon_Eta_10_20->Fill(fabs(CurrentParticle.eta()));
+	  if ( (CurrentParticle.pt() > 20.0) && (CurrentParticle.pt() <= 40.0) )	GenMuon_Eta_20_40->Fill(fabs(CurrentParticle.eta()));
+	  if ( CurrentParticle.pt() > 40.0) 		GenMuon_Eta_40->Fill(fabs(CurrentParticle.eta()));
+	  GenMuon_Phi->Fill(CurrentParticle.phi());
+	  if ( ((CurrentParticle.eta()) > 2.0) && ((CurrentParticle.eta()) < 2.8) ) GenMuon_Pt->Fill(CurrentParticle.pt());
+	}
+
     }
   }
+
+
+//Diff studies for gen matching
+
+  std::cout<<"Doing first propagation"<<std::endl;
+ for(unsigned int i=0; i<gensize; ++i) {
+    const reco::GenParticle& CurrentParticle=(*genParticles)[i];
+    if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
+      if ((fabs(CurrentParticle.eta()) < 2.0 ) ||(fabs(CurrentParticle.eta()) > 2.8 )) continue;
+
+      float zSign  = CurrentParticle.pz()/fabs(CurrentParticle.pz());
+
+    	float zValue = 526.75 * zSign;
+    	Plane *plane = new Plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
+    	TLorentzVector Momentum;
+    	Momentum.SetPtEtaPhiM(CurrentParticle.pt()
+    			      ,CurrentParticle.eta()
+    			      ,CurrentParticle.phi()
+    			      ,CurrentParticle.mass());
+    	GlobalVector p3gen(Momentum.Px(), Momentum.Py(), Momentum.Pz());
+    	GlobalVector r3gen = GlobalVector(CurrentParticle.vertex().x()
+    					  ,CurrentParticle.vertex().y()
+    					  ,CurrentParticle.vertex().z());
+
+    	AlgebraicSymMatrix66 covGen = AlgebraicMatrixID(); 
+    	covGen *= 1e-20; // initialize to sigma=1e-10 .. should get overwhelmed by MULS
+    	AlgebraicSymMatrix66 covFinal;
+    	int chargeGen =  CurrentParticle.charge(); 
+
+    	//Propagation
+    	FreeTrajectoryState initstate = getFTS(p3gen, r3gen, chargeGen, covGen, &*bField);
+	
+    	SteppingHelixStateInfo startstate(initstate);
+    	SteppingHelixStateInfo laststate;
+
+    	const SteppingHelixPropagator* ThisshProp = 
+    	  dynamic_cast<const SteppingHelixPropagator*>(&*shProp);
+
+    	laststate = ThisshProp->propagate(startstate, *plane);
+
+    	FreeTrajectoryState finalstate;
+    	laststate.getFreeState(finalstate);
+	
+    	GlobalVector p3Final, r3Final;
+    	getFromFTS(finalstate, p3Final, r3Final, chargeGen, covFinal);
+
+
+	int ME0MuonID = 0;
+
+	for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
+	   thisMuon != OurMuons->end(); ++thisMuon){
+
+	TrackRef tkRef = thisMuon->innerTrack();
+	SegIdForMatch.push_back(thisMuon->me0segid());
+
+	ME0Segment Seg = thisMuon->me0segment();
+	ME0DetId id =Seg.me0DetId();
+	auto roll = me0Geom->etaPartition(id); 
+
+	double DirectionPull, DirectionPullNum, DirectionPullDenom;
+
+	//Computing the sigma for the track direction
+	Double_t mag_track = p3Final.perp();
+	//Double_t phi_track = p3Final.phi();
+
+	//Double_t dmagdx_track = p3Final.x()/mag_track;
+	//Double_t dmagdy_track = p3Final.y()/mag_track;
+	Double_t dphidx_track = -p3Final.y()/(mag_track*mag_track);
+	Double_t dphidy_track = p3Final.x()/(mag_track*mag_track);
+	Double_t sigmaphi_track = sqrt( dphidx_track*dphidx_track*covFinal(3,3)+
+					dphidy_track*dphidy_track*covFinal(4,4)+
+					dphidx_track*dphidy_track*2*covFinal(3,4) );
+
+	DirectionPullNum = p3Final.phi()-roll->toGlobal(Seg.localDirection()).phi();
+	DirectionPullDenom = sqrt( pow(roll->toGlobal(Seg.localPosition()).phi(),2) + pow(sigmaphi_track,2) );
+	DirectionPull = DirectionPullNum / DirectionPullDenom;
+	
+
+	if (IsMatched[ME0MuonID]){
+	  SegGenDirPhiDiff_True_h->Fill(p3Final.phi()-roll->toGlobal(Seg.localDirection()).phi() );
+	  SegGenDirEtaDiff_True_h->Fill(p3Final.eta()-roll->toGlobal(Seg.localDirection()).eta() );
+	  SegGenDirPhiPull_True_h->Fill(DirectionPull);
+	}
+
+	if ((zSign * roll->toGlobal(Seg.localDirection()).z()) > 0 ){
+	  SegGenDirPhiDiff_All_h->Fill(p3Final.phi()-roll->toGlobal(Seg.localDirection()).phi() );
+	  SegGenDirPhiPull_All_h->Fill(DirectionPull);
+    
+	  SegGenDirEtaDiff_All_h->Fill(p3Final.eta()-roll->toGlobal(Seg.localDirection()).eta() );
+	}
+	ME0MuonID++;
+	}
+    }
+ }
+
+  //Del R study ===========================
+  for(unsigned int i=0; i<gensize; ++i) {
+    const reco::GenParticle& CurrentParticle=(*genParticles)[i];
+    if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
+
+      double LowestDelR = 9999;
+      double thisDelR = 9999;
+
+      for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
+	   thisMuon != OurMuons->end(); ++thisMuon){
+	TrackRef tkRef = thisMuon->innerTrack();
+	thisDelR = reco::deltaR(CurrentParticle,*tkRef);
+	if (thisDelR < LowestDelR) LowestDelR = thisDelR;
+      }
+    
+    ClosestDelR_s->Fill(CurrentParticle.eta(), LowestDelR);
+    ClosestDelR_p->Fill(CurrentParticle.eta(), LowestDelR);
+    }
+  }
+
+  //====================================
+
   //   -----Finally, we loop over all the ME0Muons in the event
   //   -----Before, we plotted the gen muon pt and eta for the efficiency plot of matches
   //   -----Now, each time a match failed, we plot the ME0Muon pt and eta
   int ME0MuonID = 0;
   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
        thisMuon != OurMuons->end(); ++thisMuon){
-    if (!IsMatched[ME0MuonID]){
-      TrackRef tkRef = thisMuon->innerTrack();
-      UnmatchedME0Muon_Eta->Fill(tkRef->eta());
-      if ( (TMath::Abs(tkRef->eta()) > 2.4) && (TMath::Abs(tkRef->eta()) < 4.0) ) UnmatchedME0Muon_Pt->Fill(tkRef->pt());
-    }
-      ME0MuonID++;
-  }
+    TrackRef tkRef = thisMuon->innerTrack();
 
-  //unsigned int recosize=OurCandidates->size();
-  for (std::vector<EmulatedME0Segment>::const_iterator thisSegment = OurSegments->begin();
-       thisSegment != OurSegments->end();++thisSegment){
-    // double theta = atan(thisSegment->localDirection().y()/ thisSegment->localDirection().x());
-    // double tempeta = -log(tan (theta/2.));
-    LocalVector TempVect(thisSegment->localDirection().x(),thisSegment->localDirection().y(),thisSegment->localDirection().z());
-    Segment_Eta->Fill(TempVect.eta());
-    NumSegs++;
+
+    if (IsMatched[ME0MuonID]) {
+      if ( (TMath::Abs(tkRef->eta()) > 2.0) && (TMath::Abs(tkRef->eta()) < 2.8) )  MatchedME0Muon_Pt->Fill(tkRef->pt());
+
+      //Moved resolution stuff here, only calculate resolutions for matched muons!
+
+
+    }
+
+    if (!IsMatched[ME0MuonID]){
+
+      UnmatchedME0Muon_Eta->Fill(fabs(tkRef->eta()));
+      if ((tkRef->pt() > FakeRatePtCut) && (TMath::Abs(tkRef->eta()) < 2.8) )  {
+	if ( (tkRef->pt() > 5.0) && (tkRef->pt() <= 10.0) )  	UnmatchedME0Muon_Cuts_Eta_5_10->Fill(fabs(tkRef->eta()));
+	if ( (tkRef->pt() > 10.0) && (tkRef->pt() <= 20.0) )	UnmatchedME0Muon_Cuts_Eta_10_20->Fill(fabs(tkRef->eta()));
+	if ( (tkRef->pt() > 20.0) && (tkRef->pt() <= 40.0) )	UnmatchedME0Muon_Cuts_Eta_20_40->Fill(fabs(tkRef->eta()));
+	if ( tkRef->pt() > 40.0) 		UnmatchedME0Muon_Cuts_Eta_40->Fill(fabs(tkRef->eta()));
+
+	UnmatchedME0Muon_Cuts_Eta->Fill(fabs(tkRef->eta()));
+      }
+      //if ( (TMath::Abs(tkRef->eta()) > 2.0) && (TMath::Abs(tkRef->eta()) < 3.4) ) UnmatchedME0Muon_Pt->Fill(tkRef->pt());
+      if ( (TMath::Abs(tkRef->eta()) < 2.8) ) UnmatchedME0Muon_Pt->Fill(tkRef->pt());
+    }
+    ME0MuonID++;
   }
+  
+
+
+  // for (std::vector<ME0Segment>::const_iterator thisSegment = OurSegments->begin();
+  //      thisSegment != OurSegments->end();++thisSegment){
+  //   LocalVector TempVect(thisSegment->localDirection().x(),thisSegment->localDirection().y(),thisSegment->localDirection().z());
+  //   Segment_Eta->Fill(TempVect.eta());
+  // }
 
   
   for (std::vector<Track>::const_iterator thisTrack = generalTracks->begin();
        thisTrack != generalTracks->end();++thisTrack){
-    Track_Eta->Fill(thisTrack->eta());
-    if ( (TMath::Abs(thisTrack->eta()) > 2.4) && (TMath::Abs(thisTrack->eta()) < 4.0) ) Track_Pt->Fill(thisTrack->pt());
-    if ( (thisTrack->eta() > 2.4) && (thisTrack->eta() < 4.0)) TrackCount++;
-    //std::cout<<thisTrack->eta()<<std::endl;
+    Track_Eta->Fill(fabs(thisTrack->eta()));
+    if ( (TMath::Abs(thisTrack->eta()) > 2.0) && (TMath::Abs(thisTrack->eta()) < 2.8) ) Track_Pt->Fill(thisTrack->pt());
+
+    
+
+    
   }
 
-  // std::vector<int> UniqueIdList;
-  // std::vector<int> Ids;
-  std::vector<Double_t> SegmentEta;
-  std::vector<const EmulatedME0Segment*> Ids;
-  std::vector<const EmulatedME0Segment*> UniqueIdList;
+  // for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
+  //      thisMuon != OurMuons->end(); ++thisMuon){
+  //   TrackRef tkRef = thisMuon->innerTrack();
+  //   ME0Muon_Eta->Fill(tkRef->eta());
+  //   if ( (TMath::Abs(tkRef->eta()) > 2.4) && (TMath::Abs(tkRef->eta()) < 4.0) ) ME0Muon_Pt->Fill(tkRef->pt());
+  // }
+  
+  std::vector<double> SegmentEta, SegmentPhi, SegmentR, SegmentX, SegmentY;
+  // std::vector<const ME0Segment*> Ids;
+  // std::vector<const ME0Segment*> Ids_NonGenMuons;
+  // std::vector<const ME0Segment*> UniqueIdList;
+   std::vector<int> Ids;
+   std::vector<int> Ids_NonGenMuons;
+   std::vector<int> UniqueIdList;
+   int TrackID=0;
 
-  for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
-       thisMuon != OurMuons->end(); ++thisMuon){
+   std::cout<<"Doing some propagation"<<std::endl;
+   int MuID = 0;
+   for (std::vector<ME0Muon>::const_iterator thisMuon = OurMuons->begin();
+	thisMuon != OurMuons->end(); ++thisMuon){
     TrackRef tkRef = thisMuon->innerTrack();
-    EmulatedME0SegmentRef segRef = thisMuon->me0segment();
-    //int SegId = thisMuon->segRefId();
-    //int SegId = segRef.get();
-    const EmulatedME0Segment* SegId = segRef.get();
-    //PointersVector.push_back(segRef.get());
+    //ME0Segment segRef = thisMuon->me0segment();
+    //const ME0Segment* SegId = segRef->get();
+
+    ME0Segment Seg = thisMuon->me0segment();
+    ME0DetId id =Seg.me0DetId();
+    auto roll = me0Geom->etaPartition(id); 
+    auto GlobVect(roll->toGlobal(Seg.localPosition()));
+
+    int SegId=thisMuon->me0segid();
+
+    //std::cout<<SegId<<std::endl;
+
+
+    //For a direction study...
+    if ( (tkRef->pt() > 5.0) && (IsMatched[MuID]) ){
+      SegPosDirPhiDiff_True_h->Fill(roll->toGlobal(Seg.localPosition()).phi()-roll->toGlobal(Seg.localDirection()).phi() );
+      SegPosDirEtaDiff_True_h->Fill(roll->toGlobal(Seg.localPosition()).eta()-roll->toGlobal(Seg.localDirection()).eta() );
+    }
+
+    SegPosDirPhiDiff_All_h->Fill(roll->toGlobal(Seg.localPosition()).phi()-roll->toGlobal(Seg.localDirection()).phi() );
+    SegPosDirEtaDiff_All_h->Fill(roll->toGlobal(Seg.localPosition()).eta()-roll->toGlobal(Seg.localDirection()).eta() );
+
+    // For another direction study...
+    float zSign  = tkRef->pz()/fabs(tkRef->pz());
+
+    //float zValue = 560. * zSign;
+    float zValue = 526.75 * zSign;
+    Plane *plane = new Plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
+    //Getting the initial variables for propagation
+    int chargeReco = tkRef->charge(); 
+    GlobalVector p3reco, r3reco;
+
+    p3reco = GlobalVector(tkRef->outerPx(), tkRef->outerPy(), tkRef->outerPz());
+    r3reco = GlobalVector(tkRef->outerX(), tkRef->outerY(), tkRef->outerZ());
+
+    AlgebraicSymMatrix66 covReco;
+    //This is to fill the cov matrix correctly
+    AlgebraicSymMatrix55 covReco_curv;
+    covReco_curv = tkRef->outerStateCovariance();
+    FreeTrajectoryState initrecostate = getFTS(p3reco, r3reco, chargeReco, covReco_curv, &*bField);
+    getFromFTS(initrecostate, p3reco, r3reco, chargeReco, covReco);
+
+    //Now we propagate and get the propagated variables from the propagated state
+    SteppingHelixStateInfo startrecostate(initrecostate);
+    SteppingHelixStateInfo lastrecostate;
+
+    const SteppingHelixPropagator* ThisshProp = 
+      dynamic_cast<const SteppingHelixPropagator*>(&*shProp);
+	
+    lastrecostate = ThisshProp->propagate(startrecostate, *plane);
+	
+    FreeTrajectoryState finalrecostate;
+    lastrecostate.getFreeState(finalrecostate);
+      
+    AlgebraicSymMatrix66 covFinalReco;
+    GlobalVector p3FinalReco_glob, r3FinalReco_globv;
+    getFromFTS(finalrecostate, p3FinalReco_glob, r3FinalReco_globv, chargeReco, covFinalReco);
+    GlobalPoint r3FinalReco_glob(r3FinalReco_globv.x(),r3FinalReco_globv.y(),r3FinalReco_globv.z());
+
+    double DirectionPull, DirectionPullNum, DirectionPullDenom;
+
+    //Computing the sigma for the track direction
+    Double_t mag_track = p3FinalReco_glob.perp();
+    //Double_t phi_track = p3FinalReco_glob.phi();
+
+    //Double_t dmagdx_track = p3FinalReco_glob.x()/mag_track;
+    //Double_t dmagdy_track = p3FinalReco_glob.y()/mag_track;
+    Double_t dphidx_track = -p3FinalReco_glob.y()/(mag_track*mag_track);
+    Double_t dphidy_track = p3FinalReco_glob.x()/(mag_track*mag_track);
+    Double_t sigmaphi_track = sqrt( dphidx_track*dphidx_track*covFinalReco(3,3)+
+    				dphidy_track*dphidy_track*covFinalReco(4,4)+
+    				dphidx_track*dphidy_track*2*covFinalReco(3,4) );
+
+    DirectionPullNum = p3FinalReco_glob.phi()-roll->toGlobal(Seg.localDirection()).phi();
+    DirectionPullDenom = sqrt( pow(roll->toGlobal(Seg.localPosition()).phi(),2) + pow(sigmaphi_track,2) );
+    DirectionPull = DirectionPullNum / DirectionPullDenom;
+
+    if ( (tkRef->pt() > 5.0)&& (IsMatched[MuID]) ){
+      SegTrackDirPhiDiff_True_h->Fill(p3FinalReco_glob.phi()-roll->toGlobal(Seg.localDirection()).phi() );
+      SegTrackDirEtaDiff_True_h->Fill(p3FinalReco_glob.eta()-roll->toGlobal(Seg.localDirection()).eta() );
+      SegTrackDirPhiPull_True_h->Fill(DirectionPull);
+    }
+    SegTrackDirPhiDiff_All_h->Fill(p3FinalReco_glob.phi()-roll->toGlobal(Seg.localDirection()).phi() );
+    SegTrackDirPhiPull_All_h->Fill(DirectionPull);
+    
+    SegTrackDirEtaDiff_All_h->Fill(p3FinalReco_glob.eta()-roll->toGlobal(Seg.localDirection()).eta() );
+
+
+    LocalPoint r3FinalReco = roll->toLocal(r3FinalReco_glob);
+    LocalVector p3FinalReco=roll->toLocal(p3FinalReco_glob);
+    LocalTrajectoryParameters ltp(r3FinalReco,p3FinalReco,chargeReco);
+    JacobianCartesianToLocal jctl(roll->surface(),ltp);
+    AlgebraicMatrix56 jacobGlbToLoc = jctl.jacobian(); 
+
+    AlgebraicMatrix55 Ctmp =  (jacobGlbToLoc * covFinalReco) * ROOT::Math::Transpose(jacobGlbToLoc); 
+    AlgebraicSymMatrix55 C;  // I couldn't find any other way, so I resort to the brute force
+    for(int i=0; i<5; ++i) {
+      for(int j=0; j<5; ++j) {
+	C[i][j] = Ctmp[i][j]; 
+
+      }
+    }  
+
+    LocalPoint thisPosition(Seg.localPosition());
+
+    Double_t sigmax = sqrt(C[3][3]+Seg.localPositionError().xx() );      
+    Double_t sigmay = sqrt(C[4][4]+Seg.localPositionError().yy() );
+
+    XPull_h->Fill((thisPosition.x()-r3FinalReco.x())/sigmax);
+    YPull_h->Fill((thisPosition.y()-r3FinalReco.y())/sigmay);
+    
+    XDiff_h->Fill((thisPosition.x()-r3FinalReco.x()));
+    YDiff_h->Fill((thisPosition.y()-r3FinalReco.y()));
+
+    //std::cout<<"AM HERE"<<std::endl;
+    if ( (tkRef->pt() > FakeRatePtCut)&& (IsMatched[MuID]) ){
+      
+
+
+      //std::cout<<"thisPosition = "<<thisPosition<<std::endl;
+      //std::cout<<"r3FinalReco = "<<r3FinalReco<<std::endl;
+    }
+
+    //End Direction studies
+
+
     bool IsNew = true;
     for (unsigned int i =0; i < Ids.size(); i++){
       if (SegId == Ids[i]) IsNew=false;
     }
+
     if (IsNew) {
-      std::cout<<"Found: "<<SegId<<std::endl;
       UniqueIdList.push_back(SegId);
-      LocalVector TempVect(segRef->localDirection().x(),segRef->localDirection().y(),segRef->localDirection().z());
-      SegmentEta.push_back(TempVect.eta());
+      //std::cout<<"New SegId = "<<SegId<<std::endl;
+      //std::cout<<GlobVect<<std::endl;
+      SegmentEta.push_back(GlobVect.eta());
+      SegmentPhi.push_back(GlobVect.phi());
+      SegmentR.push_back(GlobVect.perp());
+      SegmentX.push_back(GlobVect.x());
+      SegmentY.push_back(GlobVect.y());
     }
     Ids.push_back(SegId);
+    if (!IsMatched[TrackID]) Ids_NonGenMuons.push_back(SegId);
 
-    //LocalVector TempVect(tkRef->px(),tkRef->py(),tkRef->pz());
-    ME0Muon_Eta->Fill(tkRef->eta());
-    if ( (TMath::Abs(tkRef->eta()) > 2.4) && (TMath::Abs(tkRef->eta()) < 4.0) ) ME0Muon_Pt->Fill(tkRef->pt());
+    ME0Muon_Eta->Fill(fabs(tkRef->eta()));
+
+
+    if ((tkRef->pt() > FakeRatePtCut) && (TMath::Abs(tkRef->eta()) < 2.8)){
+      ME0Muon_Cuts_Eta->Fill(fabs(tkRef->eta()));
+      if ( (tkRef->pt() > 5.0) && (tkRef->pt() <= 10.0) )  	ME0Muon_Cuts_Eta_5_10->Fill(fabs(tkRef->eta()));
+      if ( (tkRef->pt() > 10.0) && (tkRef->pt() <= 20.0) )	ME0Muon_Cuts_Eta_10_20->Fill(fabs(tkRef->eta()));
+      if ( (tkRef->pt() > 20.0) && (tkRef->pt() <= 40.0) )	ME0Muon_Cuts_Eta_20_40->Fill(fabs(tkRef->eta()));
+      if ( tkRef->pt() > 40.0) 		ME0Muon_Cuts_Eta_40->Fill(fabs(tkRef->eta()));
+    }
+    
+
+
+    if ( (TMath::Abs(tkRef->eta()) > 2.0) && (TMath::Abs(tkRef->eta()) < 2.8) ) ME0Muon_Pt->Fill(tkRef->pt());
+
+    TrackID++;
+    MuID++;
   }
   
+   std::cout<<UniqueIdList.size()<<" unique segments per event"<<std::endl;
   for (unsigned int i = 0; i < UniqueIdList.size(); i++){
-    int Num=0;
+    int Num_Total=0, Num_Fake = 0, Num_Fake_Associated = 0;
     for (unsigned int j = 0; j < Ids.size(); j++){
-      if (Ids[j] == UniqueIdList[i]) Num++;
+      if (Ids[j] == UniqueIdList[i]) Num_Total++;
     }
-    std::cout<<Num<<std::endl;
-    TracksPerSegment_h->Fill((double)Num);
-    TracksPerSegment_s->Fill(SegmentEta[i], (double)Num);
-    TracksPerSegment_p->Fill(SegmentEta[i], (double)Num);
+
+    for (unsigned int j = 0; j < Ids_NonGenMuons.size(); j++){
+      if (Ids_NonGenMuons[j] == UniqueIdList[i]) Num_Fake++;
+      bool AssociatedWithMatchedSegment = false;
+      for (unsigned int isegid=0;isegid < MatchedSegIds.size();isegid++){
+	if (MatchedSegIds[isegid]==Ids_NonGenMuons[j]) AssociatedWithMatchedSegment=true;
+      }
+      if (AssociatedWithMatchedSegment) Num_Fake_Associated++;
+    }
+
+    TracksPerSegment_h->Fill((double)Num_Total);
+    TracksPerSegment_s->Fill(SegmentEta[i], (double)Num_Total);
+    TracksPerSegment_p->Fill(SegmentEta[i], (double)Num_Total);
+
+    FakeTracksPerSegment_h->Fill((double)Num_Fake);
+    FakeTracksPerSegment_s->Fill(SegmentEta[i], (double)Num_Fake);
+    FakeTracksPerSegment_p->Fill(SegmentEta[i], (double)Num_Fake);
+
+    FakeTracksPerAssociatedSegment_h->Fill((double)Num_Fake_Associated);
+    FakeTracksPerAssociatedSegment_s->Fill(SegmentEta[i], (double)Num_Fake_Associated);
+    FakeTracksPerAssociatedSegment_p->Fill(SegmentEta[i], (double)Num_Fake_Associated);
+
+    // if (SegmentEta[i] > 2.4){
+    //   Segment_Eta->Fill(SegmentEta[i]);
+    //   Segment_Phi->Fill(SegmentPhi[i]);
+    //   Segment_R->Fill(SegmentR[i]);
+    //   Segment_Pos->Fill(SegmentX[i],SegmentY[i]);
+    // }
   }
+
+  //================  For Segment Plotting
+  for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
+       ++thisSegment){
+    ME0DetId id = thisSegment->me0DetId();
+    //std::cout<<"ME0DetId =  "<<id<<std::endl;
+    auto roll = me0Geom->etaPartition(id); 
+    auto GlobVect(roll->toGlobal(thisSegment->localPosition()));
+    Segment_Eta->Fill(fabs(GlobVect.eta()));
+    Segment_Phi->Fill(GlobVect.phi());
+    Segment_R->Fill(GlobVect.perp());
+    Segment_Pos->Fill(GlobVect.x(),GlobVect.y());
+
+
+
+    auto theseRecHits = thisSegment->specificRecHits();
+    //std::cout <<"ME0 Ensemble Det Id "<<id<<"  Number of RecHits "<<theseRecHits.size()<<std::endl;
+    
+    for (auto thisRecHit = theseRecHits.begin(); thisRecHit!= theseRecHits.end(); thisRecHit++){
+      auto me0id = thisRecHit->me0Id();
+      auto rollForRechit = me0Geom->etaPartition(me0id);
+      
+      auto thisRecHitGlobalPoint = rollForRechit->toGlobal(thisRecHit->localPosition()); 
+      
+      Rechit_Eta->Fill(fabs(thisRecHitGlobalPoint.eta()));
+      Rechit_Phi->Fill(thisRecHitGlobalPoint.phi());
+      Rechit_R->Fill(thisRecHitGlobalPoint.perp());
+      Rechit_Pos->Fill(thisRecHitGlobalPoint.x(),thisRecHitGlobalPoint.y());
+      
+    }
+  }
+  //==================
+
+    for(unsigned int i=0; i<gensize; ++i) {
+      const reco::GenParticle& CurrentParticle=(*genParticles)[i];
+      if ( (CurrentParticle.status()==1) && ( (CurrentParticle.pdgId()==13)  || (CurrentParticle.pdgId()==-13) ) ){  
+	double SmallestDelR = 999.;
+	for (auto thisSegment = OurSegments->begin(); thisSegment != OurSegments->end(); 
+	     ++thisSegment){
+	  ME0DetId id = thisSegment->me0DetId();
+	  //std::cout<<"ME0DetId =  "<<id<<std::endl;
+	  auto roll = me0Geom->etaPartition(id); 
+	  auto GlobVect(roll->toGlobal(thisSegment->localPosition()));
+	  Segment_Eta->Fill(fabs(GlobVect.eta()));
+	  Segment_Phi->Fill(GlobVect.phi());
+	  Segment_R->Fill(GlobVect.perp());
+	  Segment_Pos->Fill(GlobVect.x(),GlobVect.y());
+	  
+	  if (reco::deltaR(CurrentParticle,GlobVect) < SmallestDelR) SmallestDelR = reco::deltaR(CurrentParticle,GlobVect);
+
+	}
+	if ((fabs(CurrentParticle.eta()) < 2.0 ) ||(fabs(CurrentParticle.eta()) > 2.8 )) continue;
+	DelR_Segment_GenMuon->Fill(SmallestDelR);
+      }
+    }
   
 
   //std::cout<<recosize<<std::endl;
   for (std::vector<RecoChargedCandidate>::const_iterator thisCandidate = OurCandidates->begin();
        thisCandidate != OurCandidates->end(); ++thisCandidate){
-    NumCands++;
     TLorentzVector CandidateVector;
     CandidateVector.SetPtEtaPhiM(thisCandidate->pt(),thisCandidate->eta(),thisCandidate->phi(),0);
     //std::cout<<"On a muon"<<std::endl;
     //std::cout<<thisCandidate->eta()<<std::endl;
-    Candidate_Eta->Fill(thisCandidate->eta());
+    Candidate_Eta->Fill(fabs(thisCandidate->eta()));
   }
 
   if (OurCandidates->size() == 2){
@@ -283,37 +1435,239 @@ ME0MuonAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup
     Double_t Mass = (CandidateVector1+CandidateVector2).M();
     Mass_h->Fill(Mass);
   }
+  
+  
 }
-
 
 void ME0MuonAnalyzer::endJob() 
 {
+
+  std::cout<<"Nevents = "<<Nevents<<std::endl;
+  //TString cmsText     = "CMS Prelim.";
+  //TString cmsText     = "#splitline{CMS PhaseII Simulation}{Prelim}";
+  TString cmsText     = "CMS PhaseII Simulation Prelim.";
+
+  TString lumiText = "PU 140, 14 TeV";
+  float cmsTextFont   = 61;  // default is helvetic-bold
+
+ 
+  //float extraTextFont = 52;  // default is helvetica-italics
+  float lumiTextSize     = 0.05;
+
+  float lumiTextOffset   = 0.2;
+  float cmsTextSize      = 0.05;
+  //float cmsTextOffset    = 0.1;  // only used in outOfFrame version
+
+  // float relPosX    = 0.045;
+  // float relPosY    = 0.035;
+  // float relExtraDY = 1.2;
+
+  // //ratio of "CMS" and extra text size
+  // float extraOverCmsTextSize  = 0.76;
+
+
   histoFile->cd();
-  Candidate_Eta->Write();
-  Track_Eta->Write();
-  Track_Pt->Write();
-  Segment_Eta->Write();
 
-  ME0Muon_Eta->Write();
-  ME0Muon_Pt->Write();
+  TCanvas *c1 = new TCanvas("c1", "canvas" );
 
-  GenMuon_Eta->Write();
-  GenMuon_Pt->Write();
 
-  MatchedME0Muon_Eta->Write();
-  MatchedME0Muon_Pt->Write();
+  gStyle->SetOptStat(0);
+  gStyle->SetOptTitle(0);
 
-  UnmatchedME0Muon_Eta->Write();
-  UnmatchedME0Muon_Pt->Write();
+  //setTDRStyle();
 
-  Mass_h->Write();
+  gStyle->SetOptStat(1);     
+  //XPull_h->Fit("gaus","","",-1.,1.);
+  XPull_h->Draw(); 
+  XPull_h->GetXaxis()->SetTitle("Local pulls: X");
+  XPull_h->GetXaxis()->SetTitleSize(0.05);
+  c1->Print("PullX.png");
+
+  //YPull_h->Fit("gaus");
+  YPull_h->Draw(); 
+  YPull_h->GetXaxis()->SetTitle("Local pulls: Y");
+  YPull_h->GetXaxis()->SetTitleSize(0.05);
+  c1->Print("PullY.png");
+
+  gStyle->SetOptStat(1);
+  //  XDiff_h->Fit("gaus","","",-1.,1.);
+  XDiff_h->Draw(); 
+  XDiff_h->GetXaxis()->SetTitle("Local residuals : X");
+  XDiff_h->GetXaxis()->SetTitleSize(0.05);
+  c1->Print("DiffX.png");
+
+  //  YDiff_h->Fit("gaus");
+  YDiff_h->Draw(); 
+  YDiff_h->GetXaxis()->SetTitle("Local residuals : Y");
+  YDiff_h->GetXaxis()->SetTitleSize(0.05);
+  c1->Print("DiffY.png");
+
+  gStyle->SetOptStat(0);
+
+  SegPosDirPhiDiff_True_h->Write();   SegPosDirPhiDiff_True_h->Draw();  c1->Print(histoFolder+"/SegPosDirPhiDiff_True_h.png");
+  SegPosDirEtaDiff_True_h->Write();   SegPosDirEtaDiff_True_h->Draw();  c1->Print(histoFolder+"/SegPosDirEtaDiff_True_h.png");
+
+  c1->SetLogy();
+  SegPosDirPhiDiff_All_h->Write();   SegPosDirPhiDiff_All_h->Draw();  c1->Print(histoFolder+"/SegPosDirPhiDiff_All_h.png");
+  c1->SetLogy();
+  SegPosDirEtaDiff_All_h->Write();   SegPosDirEtaDiff_All_h->Draw();  c1->Print(histoFolder+"/SegPosDirEtaDiff_All_h.png");
+
+  SegTrackDirPhiDiff_True_h->Write();   SegTrackDirPhiDiff_True_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiDiff_True_h.png");
+  SegTrackDirEtaDiff_True_h->Write();   SegTrackDirEtaDiff_True_h->Draw();  c1->Print(histoFolder+"/SegTrackDirEtaDiff_True_h.png");
+
+  SegTrackDirPhiPull_True_h->Write();   SegTrackDirPhiPull_True_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiPull_True_h.png");
+  SegTrackDirPhiPull_All_h->Write();   SegTrackDirPhiPull_All_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiPull_All_h.png");
+
+  c1->SetLogy();
+  SegTrackDirPhiDiff_All_h->Write();   SegTrackDirPhiDiff_All_h->Draw();  c1->Print(histoFolder+"/SegTrackDirPhiDiff_All_h.png");
+  c1->SetLogy();
+  SegTrackDirEtaDiff_All_h->Write();   SegTrackDirEtaDiff_All_h->Draw();  c1->Print(histoFolder+"/SegTrackDirEtaDiff_All_h.png");
+
+
+  SegGenDirPhiDiff_True_h->Write();   SegGenDirPhiDiff_True_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiDiff_True_h.png");
+  SegGenDirEtaDiff_True_h->Write();   SegGenDirEtaDiff_True_h->Draw();  c1->Print(histoFolder+"/SegGenDirEtaDiff_True_h.png");
+
+  SegGenDirPhiPull_True_h->Write();   SegGenDirPhiPull_True_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiPull_True_h.png");
+  SegGenDirPhiPull_All_h->Write();   SegGenDirPhiPull_All_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiPull_All_h.png");
+
+  c1->SetLogy();
+  SegGenDirPhiDiff_All_h->Write();   SegGenDirPhiDiff_All_h->Draw();  c1->Print(histoFolder+"/SegGenDirPhiDiff_All_h.png");
+  c1->SetLogy();
+  SegGenDirEtaDiff_All_h->Write();   SegGenDirEtaDiff_All_h->Draw();  c1->Print(histoFolder+"/SegGenDirEtaDiff_All_h.png");
+
+  Candidate_Eta->Write();   Candidate_Eta->Draw();  c1->Print(histoFolder+"/Candidate_Eta.png");
+  Track_Eta->Write();   Track_Eta->Draw();  c1->Print(histoFolder+"/Track_Eta.png");
+  Track_Pt->Write();   Track_Pt->Draw();  c1->Print(histoFolder+"/Track_Pt.png");
+
+  Segment_Eta->GetXaxis()->SetTitle("me0segment |#eta|");
+  Segment_Eta->GetYaxis()->SetTitle(" \# of Segments");
+  Segment_Eta->Write();   Segment_Eta->Draw();  
+  //GenMuon_Eta->SetLineColor(2);GenMuon_Eta->Draw("SAME"); 
+  c1->Print(histoFolder+"/Segment_Eta.png");
+
+  Segment_Phi->Write();   Segment_Phi->Draw();  c1->Print(histoFolder+"/Segment_Phi.png");
+  Segment_R->Write();   Segment_R->Draw();  c1->Print(histoFolder+"/Segment_R.png");
+  Segment_Pos->Write();   Segment_Pos->Draw();  c1->Print(histoFolder+"/Segment_Pos.png");
+
+  Rechit_Eta->Write();   Rechit_Eta->Draw();   c1->Print(histoFolder+"/Rechit_Eta.png");
+  Rechit_Phi->Write();   Rechit_Phi->Draw();  c1->Print(histoFolder+"/Rechit_Phi.png");
+  Rechit_R->Write();   Rechit_R->Draw();  c1->Print(histoFolder+"/Rechit_R.png");
+  Rechit_Pos->Write();   Rechit_Pos->Draw();  c1->Print(histoFolder+"/Rechit_Pos.png");
+
+  ME0Muon_Eta->Write();   ME0Muon_Eta->Draw();  
+  ME0Muon_Eta->GetXaxis()->SetTitle("ME0Muon |#eta|");
+  ME0Muon_Eta->GetXaxis()->SetTitleSize(0.05);
+  c1->Print(histoFolder+"/ME0Muon_Eta.png");
+
+  CheckME0Muon_Eta->Write();   CheckME0Muon_Eta->Draw();  
+  CheckME0Muon_Eta->GetXaxis()->SetTitle("CheckME0Muon |#eta|");
+  CheckME0Muon_Eta->GetXaxis()->SetTitleSize(0.05);
+  c1->Print(histoFolder+"/CheckME0Muon_Eta.png");
+
+  ME0Muon_Cuts_Eta->Write();   ME0Muon_Cuts_Eta->Draw();  c1->Print(histoFolder+"/ME0Muon_Cuts_Eta.png");
+  //c1->SetLogy();
+  ME0Muon_Pt->Write();   ME0Muon_Pt->Draw();  
+  ME0Muon_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
+  ME0Muon_Pt->GetXaxis()->SetTitleSize(0.05);
+  c1->Print(histoFolder+"/ME0Muon_Pt.png");
+
+  GenMuon_Eta->Write();   GenMuon_Eta->Draw();  c1->Print(histoFolder+"/GenMuon_Eta.png");
+
+  GenMuon_Pt->Write();   GenMuon_Pt->Draw();  c1->Print(histoFolder+"/GenMuon_Pt.png");
+
+  MatchedME0Muon_Eta->Write();   MatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_Eta.png");
+
+  Chi2MatchedME0Muon_Eta->Write();   Chi2MatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/Chi2MatchedME0Muon_Eta.png");
+  Chi2UnmatchedME0Muon_Eta->Write();   Chi2UnmatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/Chi2UnmatchedME0Muon_Eta.png");
+
+  gStyle->SetOptStat(1);
+  MatchedME0Muon_Pt->GetXaxis()->SetTitle("ME0Muon p_{T}");
+  //MatchedME0Muon_Pt->GetYaxis()->SetTitle(" \# of Se");
+
+  MatchedME0Muon_Pt->Write();   MatchedME0Muon_Pt->Draw();  c1->Print(histoFolder+"/MatchedME0Muon_Pt.png");
+  gStyle->SetOptStat(0);
+
+  UnmatchedME0Muon_Eta->Write();   UnmatchedME0Muon_Eta->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Eta.png");
+  UnmatchedME0Muon_Cuts_Eta->Write();   UnmatchedME0Muon_Cuts_Eta->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Cuts_Eta.png");
+  //gStyle->SetOptStat('oue');
+  c1->SetLogy();
+  UnmatchedME0Muon_Pt->Write();   UnmatchedME0Muon_Pt->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Pt.png");
+  gStyle->SetOptStat(0);
+  c1->SetLogy(0);
+  TH1F *UnmatchedME0Muon_Cuts_Eta_PerEvent;
+  UnmatchedME0Muon_Cuts_Eta_PerEvent = new TH1F("UnmatchedME0Muon_Cuts_Eta_PerEvent"      , "Muon |#eta|"   , 4, 2.0, 2.8 );
+  //UnmatchedME0Muon_Cuts_Eta_PerEvent->Sumw2();
+  for (int i=1; i<=UnmatchedME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i){
+    UnmatchedME0Muon_Cuts_Eta_PerEvent->SetBinContent(i,(UnmatchedME0Muon_Cuts_Eta->GetBinContent(i)));
+  }
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->Scale(1/Nevents);
+
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->GetXaxis()->SetTitle("ME0Muon |#eta|");
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->GetXaxis()->SetTitleSize(0.05);
+  
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->GetYaxis()->SetTitle("Average \# ME0Muons per event");
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->GetYaxis()->SetTitleSize(0.05);
+
+  UnmatchedME0Muon_Cuts_Eta_PerEvent->Write();   UnmatchedME0Muon_Cuts_Eta_PerEvent->Draw();  c1->Print(histoFolder+"/UnmatchedME0Muon_Cuts_Eta_PerEvent.png");
+
+  TH1F *ME0Muon_Cuts_Eta_PerEvent;
+  ME0Muon_Cuts_Eta_PerEvent = new TH1F("ME0Muon_Cuts_Eta_PerEvent"      , "Muon |#eta|"   , 4, 2.0, 2.8 );
+
+  for (int i=1; i<=ME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i){
+    ME0Muon_Cuts_Eta_PerEvent->SetBinContent(i,(ME0Muon_Cuts_Eta->GetBinContent(i)));
+  }
+  ME0Muon_Cuts_Eta_PerEvent->Scale(1/Nevents);
+
+  ME0Muon_Cuts_Eta_PerEvent->Write();   ME0Muon_Cuts_Eta_PerEvent->Draw();  c1->Print(histoFolder+"/ME0Muon_Cuts_Eta_PerEvent.png");
+
+  
+
+  Mass_h->Write();   Mass_h->Draw();  c1->Print(histoFolder+"/Mass_h.png");
   TracksPerSegment_s->SetMarkerStyle(1);
   TracksPerSegment_s->SetMarkerSize(3.0);
-  TracksPerSegment_s->Write();  
+  TracksPerSegment_s->Write();     TracksPerSegment_s->Draw();  c1->Print(histoFolder+"/TracksPerSegment_s.png");
 
-  TracksPerSegment_h->Write();  TracksPerSegment_p->Write();
+  TracksPerSegment_h->Write();     TracksPerSegment_h->Draw();  c1->Print(histoFolder+"/TracksPerSegment_h.png");
 
-  GenMuon_Eta->Sumw2();  MatchedME0Muon_Eta->Sumw2();
+  TracksPerSegment_p->GetXaxis()->SetTitle("Gen Muon #eta");
+  TracksPerSegment_p->GetYaxis()->SetTitle("Average N_{Tracks} per segment");
+  TracksPerSegment_p->Write();     TracksPerSegment_p->Draw();  c1->Print(histoFolder+"/TracksPerSegment_p.png");
+
+  ClosestDelR_s->SetMarkerStyle(1);
+  ClosestDelR_s->SetMarkerSize(3.0);
+  ClosestDelR_s->Write();     ClosestDelR_s->Draw();  c1->Print(histoFolder+"/ClosestDelR_s.png");
+
+  DelR_Segment_GenMuon->Write();   DelR_Segment_GenMuon->Draw();  c1->Print(histoFolder+"/DelR_Segment_GenMuon.png");
+
+  ClosestDelR_p->GetXaxis()->SetTitle("Gen Muon #eta");
+  ClosestDelR_p->GetYaxis()->SetTitle("Average closest #Delta R track");
+  std::cout<<"  ClosestDelR_p values:"<<std::endl;
+  for (int i=1; i<=ClosestDelR_p->GetNbinsX(); ++i){
+    std::cout<<2.4+(double)i*((4.0-2.4)/40.)<<","<<ClosestDelR_p->GetBinContent(i)<<std::endl;
+  }
+  ClosestDelR_p->Write();     ClosestDelR_p->Draw();  c1->Print(histoFolder+"/ClosestDelR_p.png");
+
+  FakeTracksPerSegment_s->SetMarkerStyle(1);
+  FakeTracksPerSegment_s->SetMarkerSize(3.0);
+  FakeTracksPerSegment_s->Write();     FakeTracksPerSegment_s->Draw();  c1->Print(histoFolder+"/FakeTracksPerSegment_s.png");
+
+  FakeTracksPerSegment_h->Write();     FakeTracksPerSegment_h->Draw();  c1->Print(histoFolder+"/FakeTracksPerSegment_h.png");
+
+  FakeTracksPerSegment_p->GetXaxis()->SetTitle("Gen Muon #eta");
+  FakeTracksPerSegment_p->GetYaxis()->SetTitle("Average N_{Tracks} per segment");
+  FakeTracksPerSegment_p->Write();     FakeTracksPerSegment_p->Draw();  c1->Print(histoFolder+"/FakeTracksPerSegment_p.png");
+
+  FakeTracksPerAssociatedSegment_s->SetMarkerStyle(1);
+  FakeTracksPerAssociatedSegment_s->SetMarkerSize(3.0);
+  FakeTracksPerAssociatedSegment_s->Write();     FakeTracksPerAssociatedSegment_s->Draw();  c1->Print(histoFolder+"/FakeTracksPerAssociatedSegment_s.png");
+
+  FakeTracksPerAssociatedSegment_h->Write();     FakeTracksPerAssociatedSegment_h->Draw();  c1->Print(histoFolder+"/FakeTracksPerAssociatedSegment_h.png");
+
+  FakeTracksPerAssociatedSegment_p->GetXaxis()->SetTitle("Gen Muon #eta");
+  FakeTracksPerAssociatedSegment_p->GetYaxis()->SetTitle("Average N_{Tracks} per segment");
+  FakeTracksPerAssociatedSegment_p->Write();     FakeTracksPerAssociatedSegment_p->Draw();  c1->Print(histoFolder+"/FakeTracksPerAssociatedSegment_p.png");
+
+  GenMuon_Eta->Sumw2();  MatchedME0Muon_Eta->Sumw2();  Chi2MatchedME0Muon_Eta->Sumw2();   Chi2UnmatchedME0Muon_Eta->Sumw2();
   GenMuon_Pt->Sumw2();  MatchedME0Muon_Pt->Sumw2();
 
   Track_Eta->Sumw2();  ME0Muon_Eta->Sumw2();
@@ -322,28 +1676,750 @@ void ME0MuonAnalyzer::endJob()
   UnmatchedME0Muon_Eta->Sumw2();
   UnmatchedME0Muon_Pt->Sumw2();
   
-  MuonRecoEff_Eta->Divide(MatchedME0Muon_Eta, GenMuon_Eta, 1, 1, "B");
-  MuonRecoEff_Eta->Write();
+  UnmatchedME0Muon_Cuts_Eta->Sumw2();    ME0Muon_Cuts_Eta->Sumw2();
 
-  MuonRecoEff_Pt->Divide(MatchedME0Muon_Pt, GenMuon_Pt, 1, 1, "B");
-  MuonRecoEff_Pt->Write();
+  ME0Muon_Cuts_Eta_5_10->Sumw2();  ME0Muon_Cuts_Eta_10_20->Sumw2();  ME0Muon_Cuts_Eta_20_40->Sumw2();  ME0Muon_Cuts_Eta_40->Sumw2();
+  UnmatchedME0Muon_Cuts_Eta_5_10->Sumw2();  UnmatchedME0Muon_Cuts_Eta_10_20->Sumw2();  UnmatchedME0Muon_Cuts_Eta_20_40->Sumw2();  UnmatchedME0Muon_Cuts_Eta_40->Sumw2();
+  GenMuon_Eta_5_10->Sumw2();  GenMuon_Eta_10_20->Sumw2();  GenMuon_Eta_20_40->Sumw2();  GenMuon_Eta_40->Sumw2();
+  MatchedME0Muon_Eta_5_10->Sumw2();  MatchedME0Muon_Eta_10_20->Sumw2();  MatchedME0Muon_Eta_20_40->Sumw2();  MatchedME0Muon_Eta_40->Sumw2();
+  //Captions/labels
+  std::stringstream PtCutString;
+
+  PtCutString<<"#splitline{DY }{Reco Track p_{T} > "<<FakeRatePtCut<<" GeV}";
+  const std::string& ptmp = PtCutString.str();
+  const char* pcstr = ptmp.c_str();
+
+
+  TLatex* txt =new TLatex;
+  //txt->SetTextAlign(12);
+  //txt->SetTextFont(42);
+  txt->SetNDC();
+  //txt->SetTextSize(0.05);
+  txt->SetTextFont(132);
+  txt->SetTextSize(0.05);
+
+
+  float t = c1->GetTopMargin();
+  float r = c1->GetRightMargin();
+
+  TLatex* latex1 = new TLatex;
+  latex1->SetNDC();
+  latex1->SetTextAngle(0);
+  latex1->SetTextColor(kBlack);    
+
+
+  latex1->SetTextFont(42);
+  latex1->SetTextAlign(31); 
+  //latex1->SetTextSize(lumiTextSize*t);    
+  latex1->SetTextSize(lumiTextSize);    
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  TLatex* latex = new TLatex;
+  latex->SetTextFont(cmsTextFont);
+  latex->SetNDC();
+  latex->SetTextSize(cmsTextSize);
+  //latex->SetTextAlign(align_);
+
+  //End captions/labels
+  std::cout<<"GenMuon_Eta =  "<<GenMuon_Eta->Integral()<<std::endl;
+  std::cout<<"MatchedME0Muon_Eta =  "<<MatchedME0Muon_Eta->Integral()<<std::endl;
+
+  MuonRecoEff_Eta->Divide(MatchedME0Muon_Eta, GenMuon_Eta, 1, 1, "B");
+  MuonRecoEff_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  MuonRecoEff_Eta->GetXaxis()->SetTitleSize(0.05);
+  MuonRecoEff_Eta->GetYaxis()->SetTitle("ME0Muon Efficiency");
+  MuonRecoEff_Eta->GetYaxis()->SetTitleSize(0.05);
+  //MuonRecoEff_Eta->SetMinimum(MuonRecoEff_Eta->GetMinimum()-0.1);
+  MuonRecoEff_Eta->SetMinimum(0);
+  //MuonRecoEff_Eta->SetMaximum(MuonRecoEff_Eta->GetMaximum()+0.1);
+  MuonRecoEff_Eta->SetMaximum(1.2);
+  //CMS_lumi( c1, 7, 11 );
+  MuonRecoEff_Eta->Write();   MuonRecoEff_Eta->Draw();  
+  txt->DrawLatex(0.15,0.2,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+
+  //c1->SaveAs("TestMuonRecoEff_Eta.png");
+  c1->Print(histoFolder+"/MuonRecoEff_Eta.png");
+
+
+  MuonRecoEff_Eta_5_10->Divide(MatchedME0Muon_Eta_5_10, GenMuon_Eta_5_10, 1, 1, "B");
+  MuonRecoEff_Eta_5_10->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  MuonRecoEff_Eta_5_10->GetXaxis()->SetTitleSize(0.05);
+  MuonRecoEff_Eta_5_10->GetYaxis()->SetTitle("ME0Muon Efficiency");
+  MuonRecoEff_Eta_5_10->GetYaxis()->SetTitleSize(0.05);
+  //MuonRecoEff_Eta_5_10->SetMinimum(MuonRecoEff_Eta_5_10->GetMinimum()-0.1);
+  MuonRecoEff_Eta_5_10->SetMinimum(0);
+  //MuonRecoEff_Eta_5_10->SetMaximum(MuonRecoEff_Eta_5_10->GetMaximum()+0.1);
+  MuonRecoEff_Eta_5_10->SetMaximum(1.2);
+  //CMS_lumi( c1, 7, 11 );
+  MuonRecoEff_Eta_5_10->Write();   MuonRecoEff_Eta_5_10->Draw();  
+  txt->DrawLatex(0.15,0.2,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+
+  //c1->SaveAs("TestMuonRecoEff_Eta_5_10.png");
+  c1->Print(histoFolder+"/MuonRecoEff_Eta_5_10.png");
+
+  MuonRecoEff_Eta_10_20->Divide(MatchedME0Muon_Eta_10_20, GenMuon_Eta_10_20, 1, 1, "B");
+  MuonRecoEff_Eta_10_20->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  MuonRecoEff_Eta_10_20->GetXaxis()->SetTitleSize(0.05);
+  MuonRecoEff_Eta_10_20->GetYaxis()->SetTitle("ME0Muon Efficiency");
+  MuonRecoEff_Eta_10_20->GetYaxis()->SetTitleSize(0.05);
+  //MuonRecoEff_Eta_10_20->SetMinimum(MuonRecoEff_Eta_10_20->GetMinimum()-0.1);
+  MuonRecoEff_Eta_10_20->SetMinimum(0);
+  //MuonRecoEff_Eta_10_20->SetMaximum(MuonRecoEff_Eta_10_20->GetMaximum()+0.1);
+  MuonRecoEff_Eta_10_20->SetMaximum(1.2);
+  //CMS_lumi( c1, 7, 11 );
+  MuonRecoEff_Eta_10_20->Write();   MuonRecoEff_Eta_10_20->Draw();  
+  txt->DrawLatex(0.15,0.2,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+
+  //c1->SaveAs("TestMuonRecoEff_Eta_10_20.png");
+  c1->Print(histoFolder+"/MuonRecoEff_Eta_10_20.png");
+
+
+  MuonRecoEff_Eta_20_40->Divide(MatchedME0Muon_Eta_20_40, GenMuon_Eta_20_40, 1, 1, "B");
+  MuonRecoEff_Eta_20_40->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  MuonRecoEff_Eta_20_40->GetXaxis()->SetTitleSize(0.05);
+  MuonRecoEff_Eta_20_40->GetYaxis()->SetTitle("ME0Muon Efficiency");
+  MuonRecoEff_Eta_20_40->GetYaxis()->SetTitleSize(0.05);
+  //MuonRecoEff_Eta_20_40->SetMinimum(MuonRecoEff_Eta_20_40->GetMinimum()-0.1);
+  MuonRecoEff_Eta_20_40->SetMinimum(0);
+  //MuonRecoEff_Eta_20_40->SetMaximum(MuonRecoEff_Eta_20_40->GetMaximum()+0.1);
+  MuonRecoEff_Eta_20_40->SetMaximum(1.2);
+  //CMS_lumi( c1, 7, 11 );
+  MuonRecoEff_Eta_20_40->Write();   MuonRecoEff_Eta_20_40->Draw();  
+  txt->DrawLatex(0.15,0.2,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+
+  //c1->SaveAs("TestMuonRecoEff_Eta_20_40.png");
+  c1->Print(histoFolder+"/MuonRecoEff_Eta_20_40.png");
+
+
+  MuonRecoEff_Eta_40->Divide(MatchedME0Muon_Eta_40, GenMuon_Eta_40, 1, 1, "B");
+  MuonRecoEff_Eta_40->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  MuonRecoEff_Eta_40->GetXaxis()->SetTitleSize(0.05);
+  MuonRecoEff_Eta_40->GetYaxis()->SetTitle("ME0Muon Efficiency");
+  MuonRecoEff_Eta_40->GetYaxis()->SetTitleSize(0.05);
+  //MuonRecoEff_Eta_40->SetMinimum(MuonRecoEff_Eta_40->GetMinimum()-0.1);
+  MuonRecoEff_Eta_40->SetMinimum(0);
+  //MuonRecoEff_Eta_40->SetMaximum(MuonRecoEff_Eta_40->GetMaximum()+0.1);
+  MuonRecoEff_Eta_40->SetMaximum(1.2);
+  //CMS_lumi( c1, 7, 11 );
+  MuonRecoEff_Eta_40->Write();   MuonRecoEff_Eta_40->Draw();  
+  txt->DrawLatex(0.15,0.2,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+
+  //c1->SaveAs("TestMuonRecoEff_Eta_40.png");
+  c1->Print(histoFolder+"/MuonRecoEff_Eta_40.png");
+
+
+  Chi2MuonRecoEff_Eta->Divide(Chi2MatchedME0Muon_Eta, GenMuon_Eta, 1, 1, "B");
+  std::cout<<"GenMuon_Eta =  "<<GenMuon_Eta->Integral()<<std::endl;
+  std::cout<<"Chi2MatchedME0Muon_Eta =  "<<Chi2MatchedME0Muon_Eta->Integral()<<std::endl;
+  Chi2MuonRecoEff_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  Chi2MuonRecoEff_Eta->GetXaxis()->SetTitleSize(0.05);
+  
+  Chi2MuonRecoEff_Eta->GetYaxis()->SetTitle("ME0Muon Efficiency");
+  Chi2MuonRecoEff_Eta->GetYaxis()->SetTitleSize(0.05);
+  Chi2MuonRecoEff_Eta->SetMinimum(0);
+  Chi2MuonRecoEff_Eta->SetMaximum(1.2);
+
+  Chi2MuonRecoEff_Eta->Write();   Chi2MuonRecoEff_Eta->Draw();  
+
+  txt->DrawLatex(0.15,0.2,pcstr);
+
+   
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //latex->SetTextAlign(align_);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+
+  c1->Print(histoFolder+"/Chi2MuonRecoEff_Eta.png");
+
+  std::cout<<"  MuonRecoEff_Eta values:"<<std::endl;
+  //MuonRecoEff_Eta->Sumw2();
+  for (int i=1; i<=MuonRecoEff_Eta->GetNbinsX(); ++i){
+    std::cout<<2.4+(double)i*((4.0-2.4)/40.)<<","<<MuonRecoEff_Eta->GetBinContent(i)<<","<<MuonRecoEff_Eta->GetBinError(i)<<std::endl;
+    
+  }
+  
+
+  // MuonRecoEff_Pt->Divide(MatchedME0Muon_Pt, GenMuon_Pt, 1, 1, "B");
+  // MuonRecoEff_Pt->GetXaxis()->SetTitle("Gen Muon p_{T}");
+  // MuonRecoEff_Pt->GetYaxis()->SetTitle("Matching Efficiency");
+  // MuonRecoEff_Pt->SetMinimum(.85);
+  // MuonRecoEff_Pt->Write();   MuonRecoEff_Pt->Draw();  c1->Print(histoFolder+"/MuonRecoEff_Pt.png");
+
+  std::cout<<"UnmatchedME0Muon_Eta =  "<<UnmatchedME0Muon_Cuts_Eta->Integral()<<std::endl;
+  std::cout<<"ME0Muon_Eta =  "<<ME0Muon_Cuts_Eta->Integral()<<std::endl;
+
+
+  FakeRate_Eta->Divide(UnmatchedME0Muon_Cuts_Eta, ME0Muon_Cuts_Eta, 1, 1, "B");
+  FakeRate_Eta->GetXaxis()->SetTitle("Reconstructed track |#eta|");
+  FakeRate_Eta->GetXaxis()->SetTitleSize(0.05);
+  FakeRate_Eta->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
+  FakeRate_Eta->GetYaxis()->SetTitleSize(0.05);
+  //FakeRate_Eta->SetMinimum(FakeRate_Eta->GetMinimum()-0.1);
+  FakeRate_Eta->SetMinimum(0);
+  //FakeRate_Eta->SetMaximum(FakeRate_Eta->GetMaximum()+0.1);
+  FakeRate_Eta->SetMaximum(1.2);
+  FakeRate_Eta->Write();   FakeRate_Eta->Draw();  
+
+  txt->DrawLatex(0.15,0.4,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //c1->SaveAs('TestFakeRate_Eta.png');
+  c1->Print(histoFolder+"/FakeRate_Eta.png");
+
+
+
+  FakeRate_Eta_5_10->Divide(UnmatchedME0Muon_Cuts_Eta_5_10, ME0Muon_Cuts_Eta_5_10, 1, 1, "B");
+  FakeRate_Eta_5_10->GetXaxis()->SetTitle("Reconstructed track |#eta|");
+  FakeRate_Eta_5_10->GetXaxis()->SetTitleSize(0.05);
+  FakeRate_Eta_5_10->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
+  FakeRate_Eta_5_10->GetYaxis()->SetTitleSize(0.05);
+  //FakeRate_Eta_5_10->SetMinimum(FakeRate_Eta_5_10->GetMinimum()-0.1);
+  FakeRate_Eta_5_10->SetMinimum(0);
+  //FakeRate_Eta_5_10->SetMaximum(FakeRate_Eta_5_10->GetMaximum()+0.1);
+  FakeRate_Eta_5_10->SetMaximum(1.2);
+  FakeRate_Eta_5_10->Write();   FakeRate_Eta_5_10->Draw();  
+
+  txt->DrawLatex(0.15,0.4,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //c1->SaveAs('TestFakeRate_Eta_5_10.png');
+  c1->Print(histoFolder+"/FakeRate_Eta_5_10.png");
+
+
+
+  FakeRate_Eta_10_20->Divide(UnmatchedME0Muon_Cuts_Eta_10_20, ME0Muon_Cuts_Eta_10_20, 1, 1, "B");
+  FakeRate_Eta_10_20->GetXaxis()->SetTitle("Reconstructed track |#eta|");
+  FakeRate_Eta_10_20->GetXaxis()->SetTitleSize(0.05);
+  FakeRate_Eta_10_20->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
+  FakeRate_Eta_10_20->GetYaxis()->SetTitleSize(0.05);
+  //FakeRate_Eta_10_20->SetMinimum(FakeRate_Eta_10_20->GetMinimum()-0.1);
+  FakeRate_Eta_10_20->SetMinimum(0);
+  //FakeRate_Eta_10_20->SetMaximum(FakeRate_Eta_10_20->GetMaximum()+0.1);
+  FakeRate_Eta_10_20->SetMaximum(1.2);
+  FakeRate_Eta_10_20->Write();   FakeRate_Eta_10_20->Draw();  
+
+  txt->DrawLatex(0.15,0.4,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //c1->SaveAs('TestFakeRate_Eta_10_20.png');
+  c1->Print(histoFolder+"/FakeRate_Eta_10_20.png");
+
+
+
+  FakeRate_Eta_20_40->Divide(UnmatchedME0Muon_Cuts_Eta_20_40, ME0Muon_Cuts_Eta_20_40, 1, 1, "B");
+  FakeRate_Eta_20_40->GetXaxis()->SetTitle("Reconstructed track |#eta|");
+  FakeRate_Eta_20_40->GetXaxis()->SetTitleSize(0.05);
+  FakeRate_Eta_20_40->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
+  FakeRate_Eta_20_40->GetYaxis()->SetTitleSize(0.05);
+  //FakeRate_Eta_20_40->SetMinimum(FakeRate_Eta_20_40->GetMinimum()-0.1);
+  FakeRate_Eta_20_40->SetMinimum(0);
+  //FakeRate_Eta_20_40->SetMaximum(FakeRate_Eta_20_40->GetMaximum()+0.1);
+  FakeRate_Eta_20_40->SetMaximum(1.2);
+  FakeRate_Eta_20_40->Write();   FakeRate_Eta_20_40->Draw();  
+
+  txt->DrawLatex(0.15,0.4,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //c1->SaveAs('TestFakeRate_Eta_20_40.png');
+  c1->Print(histoFolder+"/FakeRate_Eta_20_40.png");
+
+
+
+  FakeRate_Eta_40->Divide(UnmatchedME0Muon_Cuts_Eta_40, ME0Muon_Cuts_Eta_40, 1, 1, "B");
+  FakeRate_Eta_40->GetXaxis()->SetTitle("Reconstructed track |#eta|");
+  FakeRate_Eta_40->GetXaxis()->SetTitleSize(0.05);
+  FakeRate_Eta_40->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
+  FakeRate_Eta_40->GetYaxis()->SetTitleSize(0.05);
+  //FakeRate_Eta_40->SetMinimum(FakeRate_Eta_40->GetMinimum()-0.1);
+  FakeRate_Eta_40->SetMinimum(0);
+  //FakeRate_Eta_40->SetMaximum(FakeRate_Eta_40->GetMaximum()+0.1);
+  FakeRate_Eta_40->SetMaximum(1.2);
+  FakeRate_Eta_40->Write();   FakeRate_Eta_40->Draw();  
+
+  txt->DrawLatex(0.15,0.4,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //c1->SaveAs('TestFakeRate_Eta_40.png');
+  c1->Print(histoFolder+"/FakeRate_Eta_40.png");
+
+
+
+  Chi2FakeRate_Eta->Divide(Chi2UnmatchedME0Muon_Eta, ME0Muon_Cuts_Eta, 1, 1, "B");
+  std::cout<<"Chi2UnmatchedME0Muon_Eta =  "<<Chi2UnmatchedME0Muon_Eta->Integral()<<std::endl;
+  std::cout<<"UnmatchedME0Muon_Eta =  "<<UnmatchedME0Muon_Eta->Integral()<<std::endl;
+  std::cout<<"ME0Muon_Eta =  "<<ME0Muon_Cuts_Eta->Integral()<<std::endl;
+  std::cout<<"ME0Muon_Eta without cuts =  "<<ME0Muon_Eta->Integral()<<std::endl;
+
+  Chi2FakeRate_Eta->GetXaxis()->SetTitle("Reconstructed track |#eta|");
+  Chi2FakeRate_Eta->GetXaxis()->SetTitleSize(0.05);
+  Chi2FakeRate_Eta->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
+  Chi2FakeRate_Eta->GetYaxis()->SetTitleSize(0.05);
+  Chi2FakeRate_Eta->SetMinimum(0);
+  Chi2FakeRate_Eta->SetMaximum(1.2);
+  Chi2FakeRate_Eta->Write();   Chi2FakeRate_Eta->Draw();  
+  txt->DrawLatex(0.15,0.2,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //c1->SaveAs('TestChi2FakeRate_Eta.png');
+  c1->Print(histoFolder+"/Chi2FakeRate_Eta.png");
+
+  //Fake Rate per Event:
+
+  FakeRate_Eta_PerEvent->Divide(UnmatchedME0Muon_Cuts_Eta_PerEvent, ME0Muon_Cuts_Eta_PerEvent, 1, 1, "B");
+  std::cout<<"UnmatchedME0Muon_Eta_PerEvent =  "<<UnmatchedME0Muon_Cuts_Eta_PerEvent->Integral()<<std::endl;
+  std::cout<<"ME0Muon_Eta_PerEvent =  "<<ME0Muon_Cuts_Eta_PerEvent->Integral()<<std::endl;
+
+  FakeRate_Eta_PerEvent->GetXaxis()->SetTitle("Reconstructed track |#eta|");
+  FakeRate_Eta_PerEvent->GetXaxis()->SetTitleSize(0.05);
+  FakeRate_Eta_PerEvent->GetYaxis()->SetTitle("ME0 Muon Fake Rate");
+  FakeRate_Eta_PerEvent->GetYaxis()->SetTitleSize(0.05);
+  FakeRate_Eta_PerEvent->SetMinimum(0);
+  FakeRate_Eta_PerEvent->SetMaximum(1.2);
+  FakeRate_Eta_PerEvent->Write();   FakeRate_Eta_PerEvent->Draw();  
+  txt->DrawLatex(0.15,0.2,pcstr);
+  latex->DrawLatex(0.4, 0.85, cmsText);
+  latex1->DrawLatex(1-r,1-t+lumiTextOffset*t,lumiText);
+
+  //c1->SaveAs('TestFakeRate_Eta_PerEvent.png');
+  c1->Print(histoFolder+"/FakeRate_Eta_PerEvent.png");
+
+  std::cout<<"  FakeRate_Eta values:"<<std::endl;
+  for (int i=1; i<=FakeRate_Eta->GetNbinsX(); ++i){
+    std::cout<<2.4+(double)i*((4.0-2.4)/40.)<<","<<FakeRate_Eta->GetBinContent(i)<<std::endl;
+  }
+  
+
+  // FakeRate_Pt->Divide(MatchedME0Muon_Pt, GenMuon_Pt, 1, 1, "B");
+  // FakeRate_Pt->GetXaxis()->SetTitle("Gen Muon p_{T}");
+  // FakeRate_Pt->GetYaxis()->SetTitle("Matching Efficiency");
+  // FakeRate_Pt->SetMinimum(.85);
+  // FakeRate_Pt->Write();   FakeRate_Pt->Draw();  c1->Print(histoFolder+"/FakeRate_Pt.png");
 
   MuonAllTracksEff_Eta->Divide(ME0Muon_Eta, Track_Eta, 1, 1, "B");
-  MuonAllTracksEff_Eta->Write();
+  MuonAllTracksEff_Eta->Write();   MuonAllTracksEff_Eta->Draw();  c1->Print(histoFolder+"/MuonAllTracksEff_Eta.png");
 
-  MuonAllTracksEff_Pt->Divide(ME0Muon_Pt, Track_Pt, 1, 1, "B");
-  MuonAllTracksEff_Pt->Write();
+  // MuonAllTracksEff_Pt->Divide(ME0Muon_Pt, Track_Pt, 1, 1, "B");
+  // MuonAllTracksEff_Pt->Write();   MuonAllTracksEff_Pt->Draw();  c1->Print(histoFolder+"/MuonAllTracksEff_Pt.png");
 
-  MuonUnmatchedTracksEff_Eta->Divide(UnmatchedME0Muon_Eta, ME0Muon_Eta, 1, 1, "B");
-  MuonUnmatchedTracksEff_Eta->Write();
+  // MuonUnmatchedTracksEff_Eta->Divide(UnmatchedME0Muon_Eta, ME0Muon_Eta, 1, 1, "B");
+  // MuonUnmatchedTracksEff_Eta->Write();   Candidate_Eta->Draw();  c1->Print(histoFolder+"/Candidate_Eta.png");
 
-  MuonUnmatchedTracksEff_Pt->Divide(UnmatchedME0Muon_Pt, ME0Muon_Pt, 1, 1, "B");
-  MuonUnmatchedTracksEff_Pt->Write();
+  // MuonUnmatchedTracksEff_Pt->Divide(UnmatchedME0Muon_Pt, ME0Muon_Pt, 1, 1, "B");
+  // MuonUnmatchedTracksEff_Pt->Write();   Candidate_Eta->Draw();  c1->Print(histoFolder+"/Candidate_Eta.png");
+  FractionMatched_Eta->Divide(MatchedME0Muon_Eta, ME0Muon_Eta, 1, 1, "B");
+  FractionMatched_Eta->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  FractionMatched_Eta->GetYaxis()->SetTitle("Matched/All ME0Muons");
+  FractionMatched_Eta->Write();   FractionMatched_Eta->Draw();  c1->Print(histoFolder+"/FractionMatched_Eta.png");
 
-  //std::cout<<NumCands<<std::endl;
-  //std::cout<<NumSegs<<std::endl;
-  //std::cout<<TrackCount<<std::endl;
+  gStyle->SetOptStat(1);
+  PtDiff_h->GetXaxis()->SetTitle("(pt track-ptgen)/ptgen");
+  PtDiff_h->Write();     PtDiff_h->Draw();  c1->Print(histoFolder+"/PtDiff_h.png");
+
+  QOverPtDiff_h->GetXaxis()->SetTitle("(q/pt track-q/ptgen)/(q/ptgen)");
+  QOverPtDiff_h->Write();     QOverPtDiff_h->Draw();  c1->Print(histoFolder+"/QOverPtDiff_h.png");
+
+  gStyle->SetOptStat(0);
+  PtDiff_s->SetMarkerStyle(1);
+  PtDiff_s->SetMarkerSize(3.0);
+  PtDiff_s->GetXaxis()->SetTitle("Gen Muon #eta");
+  PtDiff_s->GetYaxis()->SetTitle("|(pt track-ptgen)/ptgen|");
+  PtDiff_s->Write();     PtDiff_s->Draw();  c1->Print(histoFolder+"/PtDiff_s.png");
+  
+  for(int i=1; i<=PtDiff_p->GetNbinsX(); ++i) {
+    PtDiff_rms->SetBinContent(i, PtDiff_p->GetBinError(i)); 
+    std::cout<<"Pt_rms = "<<PtDiff_p->GetBinError(i)<<std::endl;
+  }
+
+    TH1D *test;
+    test= new TH1D("test"   , "pt resolution"   , 200, -1.0, 1.0 );  
+  
+    for(Int_t i=1; i<=PtDiff_s->GetNbinsX(); ++i) {
+    
+    std::stringstream tempstore;
+    tempstore<<i;
+    const std::string& thistemp = tempstore.str();
+    test->Draw();
+
+
+    PtDiff_s->ProjectionY("test",i,i,"");
+    if (test->Integral() < 1.0) continue;
+
+    // TF1 *gaus_narrow = new TF1("gaus_narrow","gaus",-.1,.1);
+    // test->Fit(gaus_narrow,"R");
+
+    // Double_t n0  = gaus_narrow->GetParameter(0);
+    // Double_t n1  = gaus_narrow->GetParameter(1);
+    // Double_t n2  = gaus_narrow->GetParameter(2);
+
+    // //Double_t e_n0  = gaus_narrow->GetParameterError(0);
+    // //Double_t e_n1  = gaus_narrow->GetParameterError(1);
+    // Double_t e_n2  = gaus_narrow->GetParError(2);
+
+    // std::cout<<n0<<", "<<n1<<", "<<n2<<std::endl;
+
+    TF1 *gaus_wide = new TF1("gaus_wide","gaus",-.2,.2);
+    test->Fit(gaus_wide,"R");
+
+    Double_t w2  = gaus_wide->GetParameter(2);
+
+    Double_t e_w2  = gaus_wide->GetParError(2);
+
+    // PtDiff_gaus_narrow->SetBinContent(i, n2); 
+    // PtDiff_gaus_narrow->SetBinError(i, e_n2); 
+    PtDiff_gaus_wide->SetBinContent(i, w2); 
+    PtDiff_gaus_wide->SetBinError(i, e_w2); 
+    
+    test->Write();
+    TString FileName = "Bin"+thistemp+"Fit.png";
+    c1->Print(histoFolder+"/"+FileName);
+
+    test->Draw();
+
+    delete test;
+    // Redoing for pt 5 to 10
+    PtDiff_s_5_10->ProjectionY("test",i,i,"");
+    if (test->Integral() < 1.0) continue;
+
+    TF1 *gaus_5_10 = new TF1("gaus_5_10","gaus",-.2,.2);
+    test->Fit(gaus_5_10,"R");
+
+     w2  = gaus_5_10->GetParameter(2);
+     e_w2  = gaus_5_10->GetParError(2);
+
+    PtDiff_gaus_5_10->SetBinContent(i, w2); 
+    PtDiff_gaus_5_10->SetBinError(i, e_w2); 
+
+    test->Draw();
+    FileName = "Bin"+thistemp+"Fit_5_10.png";
+    c1->Print(histoFolder+"/"+FileName);
+
+    delete test;
+    // Redoing for pt 10 to 20
+    PtDiff_s_10_20->ProjectionY("test",i,i,"");
+    if (test->Integral() < 1.0) continue;
+
+    TF1 *gaus_10_20 = new TF1("gaus_10_20","gaus",-.2,.2);
+    test->Fit(gaus_10_20,"R");
+
+     w2  = gaus_10_20->GetParameter(2);
+     e_w2  = gaus_10_20->GetParError(2);
+
+    PtDiff_gaus_10_20->SetBinContent(i, w2); 
+    PtDiff_gaus_10_20->SetBinError(i, e_w2); 
+
+    test->Draw();
+    FileName = "Bin"+thistemp+"Fit_10_20.png";
+    c1->Print(histoFolder+"/"+FileName);
+
+    delete test;
+    // Redoing for pt 20 to 40
+    PtDiff_s_20_40->ProjectionY("test",i,i,"");
+    if (test->Integral() < 1.0) continue;
+
+    TF1 *gaus_20_40 = new TF1("gaus_20_40","gaus",-.2,.2);
+    test->Fit(gaus_20_40,"R");
+
+     w2  = gaus_20_40->GetParameter(2);
+     e_w2  = gaus_20_40->GetParError(2);
+
+    PtDiff_gaus_20_40->SetBinContent(i, w2); 
+    PtDiff_gaus_20_40->SetBinError(i, e_w2); 
+
+    test->Draw();
+    FileName = "Bin"+thistemp+"Fit_20_40.png";
+    c1->Print(histoFolder+"/"+FileName);
+
+    delete test;
+    // Redoing for pt 40+
+    PtDiff_s_40->ProjectionY("test",i,i,"");
+    if (test->Integral() < 1.0) continue;
+
+    TF1 *gaus_40 = new TF1("gaus_40","gaus",-.2,.2);
+    test->Fit(gaus_40,"R");
+
+     w2  = gaus_40->GetParameter(2);
+     e_w2  = gaus_40->GetParError(2);
+
+    PtDiff_gaus_40->SetBinContent(i, w2); 
+    PtDiff_gaus_40->SetBinError(i, e_w2); 
+
+    test->Draw();
+    FileName = "Bin"+thistemp+"Fit_40.png";
+    c1->Print(histoFolder+"/"+FileName);
+
+    delete test;
+    //test->Clear();
+  }
+  // PtDiff_gaus_narrow->SetMarkerStyle(22); 
+  // PtDiff_gaus_narrow->SetMarkerSize(1.2); 
+  // PtDiff_gaus_narrow->SetMarkerColor(kRed); 
+  // //PtDiff_gaus_narrow->SetLineColor(kRed); 
+  
+  // //PtDiff_gaus_narrow->Draw("PL"); 
+
+  // PtDiff_gaus_narrow->GetXaxis()->SetTitle("Gen Muon #eta");
+  // PtDiff_gaus_narrow->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
+  // PtDiff_gaus_narrow->Write();     PtDiff_gaus_narrow->Draw("PE");
+
+  PtDiff_gaus_wide->SetMarkerStyle(22); 
+  PtDiff_gaus_wide->SetMarkerSize(1.2); 
+  PtDiff_gaus_wide->SetMarkerColor(kBlue); 
+  //PtDiff_gaus_wide->SetLineColor(kRed); 
+  
+  //PtDiff_gaus_wide->Draw("PL"); 
+
+  PtDiff_gaus_wide->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PtDiff_gaus_wide->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
+  PtDiff_gaus_wide->GetYaxis()->SetTitleSize(.04);
+  PtDiff_gaus_wide->Write();     PtDiff_gaus_wide->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus.png");
+
+  PtDiff_gaus_5_10->SetMarkerStyle(22); 
+  PtDiff_gaus_5_10->SetMarkerSize(1.2); 
+  PtDiff_gaus_5_10->SetMarkerColor(kBlue); 
+  //PtDiff_gaus_5_10->SetLineColor(kRed); 
+  
+  //PtDiff_gaus_5_10->Draw("PL"); 
+
+  PtDiff_gaus_5_10->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PtDiff_gaus_5_10->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
+  PtDiff_gaus_5_10->Write();     PtDiff_gaus_5_10->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_5_10.png");
+
+  PtDiff_gaus_10_20->SetMarkerStyle(22); 
+  PtDiff_gaus_10_20->SetMarkerSize(1.2); 
+  PtDiff_gaus_10_20->SetMarkerColor(kBlue); 
+  //PtDiff_gaus_10_20->SetLineColor(kRed); 
+  
+  //PtDiff_gaus_10_20->Draw("PL"); 
+
+  PtDiff_gaus_10_20->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PtDiff_gaus_10_20->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
+  PtDiff_gaus_10_20->Write();     PtDiff_gaus_10_20->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_10_20.png");
+
+  PtDiff_gaus_20_40->SetMarkerStyle(22); 
+  PtDiff_gaus_20_40->SetMarkerSize(1.2); 
+  PtDiff_gaus_20_40->SetMarkerColor(kBlue); 
+  //PtDiff_gaus_20_40->SetLineColor(kRed); 
+  
+  //PtDiff_gaus_20_40->Draw("PL"); 
+
+  PtDiff_gaus_20_40->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PtDiff_gaus_20_40->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
+  PtDiff_gaus_20_40->Write();     PtDiff_gaus_20_40->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_20_40.png");
+
+  PtDiff_gaus_40->SetMarkerStyle(22); 
+  PtDiff_gaus_40->SetMarkerSize(1.2); 
+  PtDiff_gaus_40->SetMarkerColor(kBlue); 
+  //PtDiff_gaus_40->SetLineColor(kRed); 
+  
+  //PtDiff_gaus_40->Draw("PL"); 
+
+  PtDiff_gaus_40->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PtDiff_gaus_40->GetYaxis()->SetTitle("Gaussian width of (pt track-ptgen)/ptgen");
+  PtDiff_gaus_40->Write();     PtDiff_gaus_40->Draw("PE");  c1->Print(histoFolder+"/PtDiff_gaus_40.png");
+
+
+  PtDiff_p->SetMarkerStyle(1);
+  PtDiff_p->SetMarkerSize(3.0);
+  PtDiff_p->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PtDiff_p->GetYaxis()->SetTitle("Average (pt track-ptgen)/ptgen");
+  PtDiff_p->Write();     PtDiff_p->Draw();  c1->Print(histoFolder+"/PtDiff_p.png");
+
+  //PtDiff_rms->SetMarkerStyle(1);
+  //PtDiff_rms->SetMarkerSize(3.0);
+
+  PtDiff_rms->SetMarkerStyle(22); 
+  PtDiff_rms->SetMarkerSize(1.2); 
+  PtDiff_rms->SetMarkerColor(kBlue); 
+  //PtDiff_rms->SetLineColor(kRed); 
+  
+  //PtDiff_rms->Draw("PL"); 
+
+  PtDiff_rms->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PtDiff_rms->GetYaxis()->SetTitle("RMS of (pt track-ptgen)/ptgen");
+  PtDiff_rms->Write();     PtDiff_rms->Draw("P");  c1->Print(histoFolder+"/PtDiff_rms.png");
+
+  PDiff_h->GetXaxis()->SetTitle("|(p track-pgen)/pgen|");
+  PDiff_h->Write();     PDiff_h->Draw();  c1->Print(histoFolder+"/PDiff_h.png");
+
+  PDiff_s->SetMarkerStyle(1);
+  PDiff_s->SetMarkerSize(3.0);
+  PDiff_s->GetXaxis()->SetTitle("Gen Muon |#eta|");
+  PDiff_s->GetYaxis()->SetTitle("|(p track-pgen)/pgen|");
+  PDiff_s->Write();     PDiff_s->Draw();  c1->Print(histoFolder+"/PDiff_s.png");
+  
+  PDiff_p->SetMarkerStyle(1);
+  PDiff_p->SetMarkerSize(3.0);
+  PDiff_p->GetXaxis()->SetTitle("Gen Muon #eta");
+  PDiff_p->GetYaxis()->SetTitle("Average |(p track-pgen)/pgen|");
+  PDiff_p->Write();     PDiff_p->Draw();  c1->Print(histoFolder+"/PDiff_p.png");
+
+  VertexDiff_h->Write();     VertexDiff_h->Draw();  c1->Print(histoFolder+"/VertexDiff_h.png");
+
+
+
+  NormChi2_h->Write();       NormChi2_h->Draw();          c1->Print(histoFolder+"/NormChi2_h.png");
+  NormChi2Prob_h->Write();    NormChi2Prob_h->Draw();      c1->Print(histoFolder+"/NormChi2Prob_h.png");
+  NormChi2VsHits_h->Write();    NormChi2VsHits_h->Draw(); c1->Print(histoFolder+"/NormChi2VsHits_h.png");
+  chi2_vs_eta_h->Write();      chi2_vs_eta_h->Draw();     c1->Print(histoFolder+"/chi2_vs_eta_h.png");
+
+  c1->SetLogy(0);
+  AssociatedChi2_h->Write();    AssociatedChi2_h->Draw();   c1->Print(histoFolder+"/AssociatedChi2_h.png");
+  AssociatedChi2_Prob_h->Write();    AssociatedChi2_Prob_h->Draw();   c1->Print(histoFolder+"/AssociatedChi2_Prob_h.png");
+
+  //Printing needing values to an output log file
+  using namespace std;
+  ofstream logout;
+  logout.open (histoFolder+"/Log.txt");
+
+  logout<<"Efficiencies and errors:\n";
+  for (int i=1; i<=MuonRecoEff_Eta->GetNbinsX(); ++i){
+    logout<<MuonRecoEff_Eta->GetBinContent(i)<<","<<MuonRecoEff_Eta->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Fake Rate:\n";
+  for (int i=1; i<=FakeRate_Eta->GetNbinsX(); ++i){
+    logout<<FakeRate_Eta->GetBinContent(i)<<","<<FakeRate_Eta->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Resolution vs eta:\n";
+  for (int i=1; i<=PtDiff_gaus_wide->GetNbinsX(); ++i){
+    logout<<PtDiff_gaus_wide->GetBinContent(i)<<","<<PtDiff_gaus_wide->GetBinError(i)<<"\n";
+  }    
+
+
+  logout<<"Efficiencies and errors 5_10:\n";
+  for (int i=1; i<=MuonRecoEff_Eta_5_10->GetNbinsX(); ++i){
+    logout<<MuonRecoEff_Eta_5_10->GetBinContent(i)<<","<<MuonRecoEff_Eta_5_10->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Fake Rate 5_10:\n";
+  for (int i=1; i<=FakeRate_Eta_5_10->GetNbinsX(); ++i){
+    logout<<FakeRate_Eta_5_10->GetBinContent(i)<<","<<FakeRate_Eta_5_10->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Resolution vs eta 5_10:\n";
+  for (int i=1; i<=PtDiff_gaus_5_10->GetNbinsX(); ++i){
+    logout<<PtDiff_gaus_5_10->GetBinContent(i)<<","<<PtDiff_gaus_5_10->GetBinError(i)<<"\n";
+  }    
+
+
+  logout<<"Efficiencies and errors 10_20:\n";
+  for (int i=1; i<=MuonRecoEff_Eta_10_20->GetNbinsX(); ++i){
+    logout<<MuonRecoEff_Eta_10_20->GetBinContent(i)<<","<<MuonRecoEff_Eta_10_20->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Fake Rate 10_20:\n";
+  for (int i=1; i<=FakeRate_Eta_10_20->GetNbinsX(); ++i){
+    logout<<FakeRate_Eta_10_20->GetBinContent(i)<<","<<FakeRate_Eta_10_20->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Resolution vs eta 10_20:\n";
+  for (int i=1; i<=PtDiff_gaus_10_20->GetNbinsX(); ++i){
+    logout<<PtDiff_gaus_10_20->GetBinContent(i)<<","<<PtDiff_gaus_10_20->GetBinError(i)<<"\n";
+  }    
+
+
+  logout<<"Efficiencies and errors 20_40:\n";
+  for (int i=1; i<=MuonRecoEff_Eta_20_40->GetNbinsX(); ++i){
+    logout<<MuonRecoEff_Eta_20_40->GetBinContent(i)<<","<<MuonRecoEff_Eta_20_40->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Fake Rate 20_40:\n";
+  for (int i=1; i<=FakeRate_Eta_20_40->GetNbinsX(); ++i){
+    logout<<FakeRate_Eta_20_40->GetBinContent(i)<<","<<FakeRate_Eta_20_40->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Resolution vs eta 20_40:\n";
+  for (int i=1; i<=PtDiff_gaus_20_40->GetNbinsX(); ++i){
+    logout<<PtDiff_gaus_20_40->GetBinContent(i)<<","<<PtDiff_gaus_20_40->GetBinError(i)<<"\n";
+  }    
+
+
+  logout<<"Efficiencies and errors 40:\n";
+  for (int i=1; i<=MuonRecoEff_Eta_40->GetNbinsX(); ++i){
+    logout<<MuonRecoEff_Eta_40->GetBinContent(i)<<","<<MuonRecoEff_Eta_40->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Fake Rate 40:\n";
+  for (int i=1; i<=FakeRate_Eta_40->GetNbinsX(); ++i){
+    logout<<FakeRate_Eta_40->GetBinContent(i)<<","<<FakeRate_Eta_40->GetBinError(i)<<"\n";
+  }    
+
+  logout<<"Resolution vs eta 40:\n";
+  for (int i=1; i<=PtDiff_gaus_40->GetNbinsX(); ++i){
+    logout<<PtDiff_gaus_40->GetBinContent(i)<<","<<PtDiff_gaus_40->GetBinError(i)<<"\n";
+  }    
+
+
+  logout<<"Background yield:\n";
+  for (int i=1; i<=UnmatchedME0Muon_Cuts_Eta_PerEvent->GetNbinsX(); ++i){
+    logout<<UnmatchedME0Muon_Cuts_Eta_PerEvent->GetBinContent(i)<<","<<UnmatchedME0Muon_Cuts_Eta_PerEvent->GetBinError(i)<<"\n";
+  }    
+
+  
+  //logout << "Writing this to a file.\n";
+  logout.close();
+
   delete histoFile; histoFile = 0;
+}
+
+
+
+FreeTrajectoryState
+ME0MuonAnalyzer::getFTS(const GlobalVector& p3, const GlobalVector& r3, 
+			   int charge, const AlgebraicSymMatrix55& cov,
+			   const MagneticField* field){
+
+  GlobalVector p3GV(p3.x(), p3.y(), p3.z());
+  GlobalPoint r3GP(r3.x(), r3.y(), r3.z());
+  GlobalTrajectoryParameters tPars(r3GP, p3GV, charge, field);
+
+  CurvilinearTrajectoryError tCov(cov);
+  
+  return cov.kRows == 5 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars) ;
+}
+
+FreeTrajectoryState
+ME0MuonAnalyzer::getFTS(const GlobalVector& p3, const GlobalVector& r3, 
+			   int charge, const AlgebraicSymMatrix66& cov,
+			   const MagneticField* field){
+
+  GlobalVector p3GV(p3.x(), p3.y(), p3.z());
+  GlobalPoint r3GP(r3.x(), r3.y(), r3.z());
+  GlobalTrajectoryParameters tPars(r3GP, p3GV, charge, field);
+
+  CartesianTrajectoryError tCov(cov);
+  
+  return cov.kRows == 6 ? FreeTrajectoryState(tPars, tCov) : FreeTrajectoryState(tPars) ;
+}
+
+void ME0MuonAnalyzer::getFromFTS(const FreeTrajectoryState& fts,
+				    GlobalVector& p3, GlobalVector& r3, 
+				    int& charge, AlgebraicSymMatrix66& cov){
+  GlobalVector p3GV = fts.momentum();
+  GlobalPoint r3GP = fts.position();
+
+  GlobalVector p3T(p3GV.x(), p3GV.y(), p3GV.z());
+  GlobalVector r3T(r3GP.x(), r3GP.y(), r3GP.z());
+  p3 = p3T;
+  r3 = r3T;  //Yikes, was setting this to p3T instead of r3T!?!
+  // p3.set(p3GV.x(), p3GV.y(), p3GV.z());
+  // r3.set(r3GP.x(), r3GP.y(), r3GP.z());
+  
+  charge = fts.charge();
+  cov = fts.hasError() ? fts.cartesianError().matrix() : AlgebraicSymMatrix66();
+
 }
 
 DEFINE_FWK_MODULE(ME0MuonAnalyzer);

--- a/RecoMuon/MuonIdentification/test/testME0MuonAnalyzer_cfg.py
+++ b/RecoMuon/MuonIdentification/test/testME0MuonAnalyzer_cfg.py
@@ -30,7 +30,7 @@ from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(-1)
+    input = cms.untracked.int32(50)
 )
 
 
@@ -60,7 +60,7 @@ from SimMuon.MCTruth.MuonAssociatorByHits_cfi import muonAssociatorByHitsCommonP
 process.TrackAssociatorByChi2ESProducer = Validation.RecoMuon.associators_cff.TrackAssociatorByChi2ESProducer.clone(chi2cut = 6.0,ComponentName = 'TrackAssociatorByChi2')
 
 process.recoMuonValidation = cms.Sequence(#probeTracks_seq*
-    (selectedVertices * selectedFirstPrimaryVertex) * 
+    #(selectedVertices * selectedFirstPrimaryVertex) * 
     #bestMuonTuneP_seq*
     #muonColl_seq*trackColl_seq*extractedMuonTracks_seq*bestMuon_seq*trackerMuon_seq*
     me0muonColl_seq
@@ -68,8 +68,8 @@ process.recoMuonValidation = cms.Sequence(#probeTracks_seq*
     )
 
 process.Test = cms.EDAnalyzer("ME0MuonAnalyzer",
-                              HistoFile = cms.string('OutputTestHistos_TestLocal_LargeRun_TighterChi2.root'),
-                              HistoFolder = cms.string('Output_Dir0p15_LargeRun_TighterChi2'),
+                              HistoFile = cms.string('ME0MuonAnalyzerOutput.root'),
+                              HistoFolder = cms.string('ME0MuonAnalyzerOutput'),
                               FakeRatePtCut = cms.double(5.0),
                               MatchingWindowDelR = cms.double (.15),
                               RejectEndcapMuons = cms.bool(False),
@@ -97,121 +97,5 @@ process.p = cms.Path(process.recoMuonValidation*process.Test)
 
 
 process.PoolSource.fileNames = [
-
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_11_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_13_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_15_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_16_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_20_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_10_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_1_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_2_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_3_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_4_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_6_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_7_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_8_dEta0p05_dPhi0p02_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_9_dEta0p05_dPhi0p02_Dir0p15.root',
-
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_10_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_11_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_12_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_13_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_14_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_15_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_16_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_17_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_18_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_19_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_1_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_20_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_21_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_22_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_23_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_24_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_25_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_26_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_27_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_28_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_29_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_2_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_30_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_31_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_32_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_33_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_34_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_35_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_36_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_37_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_38_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_39_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_3_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_40_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_41_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_42_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_43_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_44_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_45_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_46_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_47_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_48_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_49_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_4_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_50_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_5_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_6_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_7_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_8_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_9_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_100_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_51_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_52_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_53_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_54_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-#'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_55_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_56_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_57_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_58_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_59_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_60_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_61_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_62_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_63_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_64_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_65_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_66_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_67_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_68_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_69_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_70_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_71_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_72_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_73_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_74_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_75_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_76_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_77_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_78_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_79_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_80_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_81_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_82_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_83_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_84_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_85_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_86_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_87_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_88_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_89_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_90_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_91_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_92_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_93_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_94_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_95_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_96_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_97_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_98_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_99_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
-
+'file:out_me0_test.root'
 ]

--- a/RecoMuon/MuonIdentification/test/testME0MuonAnalyzer_cfg.py
+++ b/RecoMuon/MuonIdentification/test/testME0MuonAnalyzer_cfg.py
@@ -1,26 +1,217 @@
 import FWCore.ParameterSet.Config as cms
 
-process = cms.Process("ME0MuonAna")
+process = cms.Process("Test")
 
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+
+process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023Muon_cff')
+
+
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi")
+
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi")
+
 process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi")
+
+process.load( "DQMServices/Core/DQMStore_cfg" )
+
+process.load('Validation.RecoMuon.associators_cff')
+process.load('Validation.RecoMuon.selectors_cff')
+process.load('Validation.RecoMuon.MuonTrackValidator_cfi')
+process.load('Validation.RecoMuon.RecoMuonValidator_cfi')
+
+
 
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 from Configuration.AlCa.GlobalTag import GlobalTag
+
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
+
+
+
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:out_me0_test.root') 
+    fileNames = cms.untracked.vstring('file:///somewhere/simevent.root') ##/somewhere/simevent.root" }
+
+
 )
 
-process.me0MuonAnalyzer = cms.EDAnalyzer("ME0MuonAnalyzer",
-    HistoFile = cms.string('OutputTestHistos_TestLocal.root'),
+
+
+from Validation.RecoMuon.selectors_cff import *
+from Validation.RecoMuon.associators_cff import *
+# Configurations for MuonTrackValidators
+import Validation.RecoMuon.MuonTrackValidator_cfi
+
+
+# Configurations for RecoMuonValidators
+from RecoMuon.TrackingTools.MuonServiceProxy_cff import *
+from Validation.RecoMuon.RecoMuonValidator_cfi import *
+
+#import SimGeneral.MixingModule.mixNoPU_cfi
+from SimMuon.MCTruth.MuonAssociatorByHitsESProducer_NoSimHits_cfi import *
+from SimMuon.MCTruth.MuonAssociatorByHits_cfi import muonAssociatorByHitsCommonParameters
+
+process.TrackAssociatorByChi2ESProducer = Validation.RecoMuon.associators_cff.TrackAssociatorByChi2ESProducer.clone(chi2cut = 6.0,ComponentName = 'TrackAssociatorByChi2')
+
+process.recoMuonValidation = cms.Sequence(#probeTracks_seq*
+    (selectedVertices * selectedFirstPrimaryVertex) * 
+    #bestMuonTuneP_seq*
+    #muonColl_seq*trackColl_seq*extractedMuonTracks_seq*bestMuon_seq*trackerMuon_seq*
+    me0muonColl_seq
+    #((process.muonValidation_seq))
+    )
+
+process.Test = cms.EDAnalyzer("ME0MuonAnalyzer",
+                              HistoFile = cms.string('OutputTestHistos_TestLocal_LargeRun_TighterChi2.root'),
+                              HistoFolder = cms.string('Output_Dir0p15_LargeRun_TighterChi2'),
+                              FakeRatePtCut = cms.double(5.0),
+                              MatchingWindowDelR = cms.double (.15),
+                              RejectEndcapMuons = cms.bool(False),
+                              UseAssociators = cms.bool(True),
+                              associators = cms.vstring('TrackAssociatorByChi2'),
+                              #label = cms.VInputTag('bestMuon'),
+                              label = cms.VInputTag('me0muon'),
+                              #associatormap = cms.InputTag("tpToMuonTrackAssociation"),
+
+                              # selection of GP for evaluation of efficiency
+                              ptMinGP = cms.double(0.9),
+                              minRapidityGP = cms.double(-2.5),
+                              maxRapidityGP = cms.double(2.5),
+                              tipGP = cms.double(3.5),
+                              lipGP = cms.double(30.0),
+                              chargedOnlyGP = cms.bool(True),
+                              statusGP = cms.int32(1),
+                              pdgIdGP = cms.vint32(13, -13),
+                              #parametersDefiner = cms.string('LhcParametersDefinerForTP')
+                              
 )
 
-process.p = cms.Path(process.me0MuonAnalyzer)
+process.p = cms.Path(process.recoMuonValidation*process.Test)
+
+
+
+process.PoolSource.fileNames = [
+
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_11_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_13_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_15_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_16_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_20_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_10_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_1_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_2_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_3_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_4_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_6_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_7_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_8_dEta0p05_dPhi0p02_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_9_dEta0p05_dPhi0p02_Dir0p15.root',
+
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_10_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_11_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_12_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_13_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_14_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_15_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_16_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_17_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_18_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_19_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_1_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_20_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_21_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_22_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_23_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_24_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_25_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_26_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_27_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_28_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_29_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_2_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_30_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_31_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_32_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_33_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_34_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_35_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_36_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_37_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_38_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_39_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_3_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_40_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_41_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_42_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_43_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_44_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_45_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_46_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_47_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_48_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_49_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_4_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_50_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_5_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_6_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_7_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_8_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muminus_Pt10-gun_9_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_100_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_51_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_52_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_53_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_54_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+#'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_55_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_56_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_57_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_58_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_59_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_60_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_61_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_62_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_63_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_64_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_65_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_66_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_67_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_68_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_69_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_70_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_71_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_72_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_73_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_74_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_75_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_76_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_77_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_78_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_79_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_80_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_81_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_82_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_83_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_84_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_85_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_86_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_87_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_88_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_89_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_90_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_91_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_92_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_93_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_94_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_95_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_96_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_97_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_98_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Matched_Muplus_Pt10-gun_99_dEta0p05_dPhi0p02_secondrun_Dir0p15.root',
+
+]

--- a/RecoMuon/MuonIdentification/test/testME0MuonConverter_cfg.py
+++ b/RecoMuon/MuonIdentification/test/testME0MuonConverter_cfg.py
@@ -1,22 +1,60 @@
 import FWCore.ParameterSet.Config as cms
-
-process = cms.Process("ME0SegmentMatching")
+#process = cms.Process("ME0SegmentMatching")
+process = cms.Process("ME0SegmentMatchingLocalTest")
 
 #process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 
-process.load("Configuration.StandardSequences.MagneticField_38T_cff")
+#process.load("Configuration.StandardSequences.MagneticField_38T_cff")
 
-process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi")
+#process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi")
 
-process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi")
+#process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi")
 
-process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi")
+#process.load("TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAny_cfi")
 
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-from Configuration.AlCa.GlobalTag import GlobalTag
+#process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+#from Configuration.AlCa.GlobalTag import GlobalTag
 #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
 #process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
+
+
+#process.load('Configuration.Geometry.GeometryExtended2023HGCalMuonReco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023HGCalMuon_cff')
+#process.load("Geometry.MuonNumbering.muonNumberingInitialization_cfi")
+#process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+
+
+
+#process.load('Geometry.GEMGeometry.cmsExtendedGeometryPostLS1plusGEMr08v01XML_cfi')
+
+
+## Standard sequence
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023HGCalReco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023HGCal_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023Muon4EtaReco_cff')
+#process.load('Configuration.Geometry.GeometryExtended2023Muon4Eta_cff')
+
+process.load('Configuration.Geometry.GeometryExtended2023MuonReco_cff')
+process.load('Configuration.Geometry.GeometryExtended2023Muon_cff')
+
+process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+
+## TrackingComponentsRecord required for matchers
+process.load('TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorOpposite_cfi')
+process.load('TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi')
+
+## global tag for 2019 upgrade studies
+from Configuration.AlCa.GlobalTag import GlobalTag
+#process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
+
+
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(10)
@@ -30,17 +68,22 @@ process.p = cms.Path(process.me0MuonReco)
 
 process.PoolSource.fileNames = [
     
-    '/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/1EA3C245-00A1-E311-A693-003048FEB9F6.root',
-    '/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/3658CD74-F9A0-E311-A114-002590494C22.root',
-    '/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/58ABCE86-FDA0-E311-B83D-02163E00E93E.root',
-    '/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/8605BDCA-10A1-E311-9FDC-02163E00E805.root',
-    '/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/A00B7D25-1CA1-E311-B7FD-02163E00E72D.root'
-    
+    #'/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/1EA3C245-00A1-E311-A693-003048FEB9F6.root',
+    #'/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/3658CD74-F9A0-E311-A114-002590494C22.root',
+    #'/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/58ABCE86-FDA0-E311-B83D-02163E00E93E.root',
+    #'/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/8605BDCA-10A1-E311-9FDC-02163E00E805.root',
+    #'/store/relval/CMSSW_6_2_0_SLHC8/RelValTTbarLepton_8TeV/GEN-SIM-RECO/DES19_62_V8_UPG2019-v3/00000/A00B7D25-1CA1-E311-B7FD-02163E00E72D.root'
+    #'/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Muplus_Pt10-gun_98_dEta0p05_dPhi0p02_secondrun_Dir0p15.root'
+    '/store/group/upgrade/muon/ME0GlobalReco/PU_ParallelRun/Muplus_Pt10-gun_98_dEta0p05_dPhi0p02.root'
+    #'file:13007_SingleMuPt10+SingleMuPt10_Extended2023Muon_GenSimFull+DigiFull_Extended2023Muon+RecoFull_Extended2023Muon+HARVESTFull_Extended2023Muon/step3.root'
 ]
 
 
 process.o1 = cms.OutputModule("PoolOutputModule",
-    outputCommands = cms.untracked.vstring('keep *'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_me0SegmentMatcher_*_*'
+        ),
 #                              process.AODSIMEventContent,
                               fileName = cms.untracked.string('out_me0_test.root')
 )

--- a/SLHCUpgradeSimulations/Configuration/python/me0Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/me0Customs.py
@@ -99,6 +99,8 @@ def outputCustoms(process):
             getattr(process,b).outputCommands.append('keep *_me0RecHits_*_*')
             getattr(process,b).outputCommands.append('keep *_me0Segments_*_*')
             getattr(process,b).outputCommands.append('keep *_me0SegmentProducer_*_*')
-            getattr(process,b).outputCommands.append('keep *_me0SegmentMatcher_*_*')
-            getattr(process,b).outputCommands.append('keep *_me0MuonConverter_*_*')
+            getattr(process,b).outputCommands.append('drop *_me0SegmentMatcher_*_*')
+            getattr(process,b).outputCommands.append('drop *_me0MuonConverter_*_*')
+            getattr(process,b).outputCommands.append('keep *_me0SegmentMatching_*_*')
+            getattr(process,b).outputCommands.append('keep *_me0MuonConverting_*_*')
     return process

--- a/Validation/RecoMuon/plugins/ME0MuonTrackCollProducer.cc
+++ b/Validation/RecoMuon/plugins/ME0MuonTrackCollProducer.cc
@@ -1,0 +1,102 @@
+
+#include "Validation/RecoMuon/plugins/ME0MuonTrackCollProducer.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
+#include "DataFormats/MuonReco/interface/MuonSelectors.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h" 
+#include <sstream>
+
+// std::vector<double> ME0MuonTrackCollProducer::findSimVtx(edm::Event& iEvent){
+
+//   edm::Handle<reco::GenParticleCollection> genParticles;
+//   iEvent.getByLabel("genParticles", genParticles);
+//   std::vector<double> vtxCoord;
+//   vtxCoord.push_back(0);
+
+//   if(genParticles.isValid()){
+
+//   	for(reco::GenParticleCollection::const_iterator itg = genParticles->begin(); itg != genParticles->end(); ++itg ){
+
+// 		int id = itg->pdgId();
+// 		int status = itg->status();
+// 		//std::cout<<"Id = "<<id<<std::endl;
+// 		//int nDaughters = itg->numberOfDaughters();
+// 		//double phiGen = itg->phi();
+// 		//double etaGen = itg->eta();
+// 		//std::cout<<"id "<<id<<" "<<phiGen<<" "<<etaGen<<std::endl;
+
+// 		if(fabs(id) == 23 && status == 3) vtxCoord[0] = 1;
+
+// 		if(fabs(id) == 13 && status == 3){
+
+// 			vtxCoord.push_back(itg->vx()); 
+// 			vtxCoord.push_back(itg->vy());
+// 			vtxCoord.push_back(itg->vz());
+
+// 		}
+
+// 	}
+
+//   }
+
+
+//   //std::cout<<vtxCoord.size()<<" "<<vtxCoord[0]<<std::endl;
+//   return vtxCoord;
+
+// }
+
+
+ME0MuonTrackCollProducer::ME0MuonTrackCollProducer(const edm::ParameterSet& parset) :
+  muonsTag(parset.getParameter< edm::InputTag >("muonsTag")),
+  vxtTag(parset.getParameter< edm::InputTag >("vxtTag")),
+  useIPxy(parset.getUntrackedParameter< bool >("useIPxy", true)),
+  useIPz(parset.getUntrackedParameter< bool >("useIPz", true)),
+  selectionTags(parset.getParameter< std::vector<std::string> >("selectionTags")),
+  trackType(parset.getParameter< std::string >("trackType")),
+  parset_(parset)
+{
+  produces<reco::TrackCollection>();
+}
+
+ME0MuonTrackCollProducer::~ME0MuonTrackCollProducer() {
+}
+
+void ME0MuonTrackCollProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  //iEvent.getByLabel(muonsTag,muonCollectionH);
+
+
+  iEvent.getByLabel <std::vector<reco::ME0Muon> > ("me0SegmentMatching", OurMuons);
+
+  
+  std::auto_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
+ 
+  reco::TrackRefProd rTracks = iEvent.getRefBeforePut<reco::TrackCollection>();
+  
+
+
+  for(std::vector<reco::ME0Muon>::const_iterator muon = OurMuons->begin();
+       muon != OurMuons->end(); ++muon) {
+
+    reco::TrackRef trackref;    
+    if (muon->innerTrack().isNonnull()) trackref = muon->innerTrack();
+
+      const reco::Track* trk = &(*trackref);
+      // pointer to old track:
+      reco::Track* newTrk = new reco::Track(*trk);
+
+      selectedTracks->push_back( *newTrk );
+      //selectedTrackExtras->push_back( *newExtra );
+  }
+  iEvent.put(selectedTracks);
+  //iEvent.put(selectedTrackExtras);
+  //iEvent.put(selectedTrackHits);
+}

--- a/Validation/RecoMuon/plugins/ME0MuonTrackCollProducer.h
+++ b/Validation/RecoMuon/plugins/ME0MuonTrackCollProducer.h
@@ -1,0 +1,34 @@
+
+#ifndef RecoMuon_ME0MuonTrackCollProducer_h
+#define RecoMuon_ME0MuonTrackCollProducer_h
+
+#include <memory>
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/ME0Muon.h"
+#include "DataFormats/MuonReco/interface/ME0MuonCollection.h"
+#include "DataFormats/CSCRecHit/interface/CSCSegmentCollection.h"
+#include "DataFormats/DTRecHit/interface/DTRecSegment4DCollection.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+
+class ME0MuonTrackCollProducer : public edm::EDProducer {
+  public:
+    explicit ME0MuonTrackCollProducer(const edm::ParameterSet&);
+    //std::vector<double> findSimVtx(edm::Event& iEvent);
+    ~ME0MuonTrackCollProducer();
+
+  private:
+    virtual void produce(edm::Event&, const edm::EventSetup&);
+    edm::Handle <std::vector<reco::ME0Muon> > OurMuons;
+    //edm::Handle<reco::ME0MuonCollection> muonCollectionH;
+    edm::InputTag muonsTag;
+    edm::InputTag vxtTag;
+    bool useIPxy, useIPz;
+    std::vector<std::string> selectionTags;
+    std::string trackType;
+    const edm::ParameterSet parset_;
+};
+
+#endif

--- a/Validation/RecoMuon/plugins/SealModule.cc
+++ b/Validation/RecoMuon/plugins/SealModule.cc
@@ -1,8 +1,8 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
+#include "Validation/RecoMuon/plugins/ME0MuonTrackCollProducer.h"
 #include "Validation/RecoMuon/plugins/MuonTrackValidator.h"
 
 DEFINE_FWK_MODULE(MuonTrackValidator);
-
+DEFINE_FWK_MODULE(ME0MuonTrackCollProducer);
 


### PR DESCRIPTION
Pull request #6576 switched from using EmulatedME0Segment to ME0Segment. This just updates

```
FastSimulation/Configuration/test/TestAnalyzer_Final.cc
```

for the change.  Note that I only fixed the compiler error, I haven't done any testing yet.  I'll run the standard upgrade matrix tests after this has been submitted, but they won't test TestAnalyzer_Final.cc.

@dnash86
