### PR TITLE
Drop CA8 jets from RECO/AOD and switch to AK8 jets for jet substucture

### DIFF
--- a/DQM/Physics/python/B2GDQM_cfi.py
+++ b/DQM/Physics/python/B2GDQM_cfi.py
@@ -13,8 +13,8 @@ B2GDQM = cms.EDAnalyzer(
     jetLabels = cms.VInputTag(
         'ak4PFJets',
         'ak4PFJetsCHS',
-        'ca8PFJetsCHS',
-        'ca8PFJetsCHSPruned',
+        'ak8PFJetsCHS',
+        'ak8PFJetsCHSPruned',
         'cmsTopTagPFJetsCHS'
         ),
     jetPtMins = cms.vdouble(

--- a/DQM/Physics/src/B2GDQM.cc
+++ b/DQM/Physics/src/B2GDQM.cc
@@ -382,7 +382,7 @@ void B2GDQM::analyzeJets(const Event& iEvent, const edm::EventSetup& iSetup) {
           }
 
           // For W-tagging, check the mass drop
-        } else if (jetLabels_[icoll].label() == "ca8PFJetsCHSPruned") {
+        } else if (jetLabels_[icoll].label() == "ak8PFJetsCHSPruned") {
           if (jet->numberOfDaughters() > 1) {
             reco::Candidate const* da0 = jet->daughter(0);
             reco::Candidate const* da1 = jet->daughter(1);
@@ -395,7 +395,7 @@ void B2GDQM::analyzeJets(const Event& iEvent, const edm::EventSetup& iSetup) {
             boostedJet_massDrop[icoll]->Fill(-1.0);
           }
 
-        }  // end if collection is CA8 PFJets CHS Pruned
+        }  // end if collection is AK8 PFJets CHS Pruned
 
       }  // end if basic jet != 0
       countJet++;

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -89,21 +89,21 @@ addJetCollection(
 )
 process.patJetsAK4PF.addTagInfos = True
 
-# uncomment the following lines to add subjets of pruned ca8PFJetsCHS with new b-tags to your PAT output
+# uncomment the following lines to add subjets of pruned ak8PFJetsCHS with new b-tags to your PAT output
 addJetCollection(
    process,
-   labelName = 'CA8PFCHSPrunedSubjets',
-   jetSource = cms.InputTag('ca8PFJetsCHSPruned','SubJets'),
+   labelName = 'AK8PFCHSPrunedSubjets',
+   jetSource = cms.InputTag('ak8PFJetsCHSPruned','SubJets'),
    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'), # FIXME: Use proper JECs, as soon as available
-   algo = 'CA',
+   algo = 'AK',
    rParam = 0.8,
    btagDiscriminators = btagDiscriminators,
    explicitJTA = True,
    svClustering = True,
-   fatJets = cms.InputTag("ca8PFJetsCHS"),
-   groomedFatJets = cms.InputTag("ca8PFJetsCHSPruned"),
+   fatJets = cms.InputTag("ak8PFJetsCHS"),
+   groomedFatJets = cms.InputTag("ak8PFJetsCHSPruned"),
 )
-process.patJetsCA8PFCHSPrunedSubjets.addTagInfos = True
+process.patJetsAK8PFCHSPrunedSubjets.addTagInfos = True
 
 ## JetID works only with RECO input for the CaloTowers (s. below for 'process.source.fileNames')
 #process.patJets.addJetID=True

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -47,12 +47,12 @@ switchJetCollection(
 process.out.outputCommands.append( 'drop *_selectedPatJets_caloTowers_*' )
 
 # uncomment the following lines to add ak4PFJets to your PAT output
-labelCA8PFCHSPruned = 'CA8PFCHSPruned'
+labelAK8PFCHSPruned = 'AK8PFCHSPruned'
 addJetCollection(
    process,
-   labelName = labelCA8PFCHSPruned,
-   jetSource = cms.InputTag('ca8PFJetsCHSPruned',''),
-   algo = 'CA8',
+   labelName = labelAK8PFCHSPruned,
+   jetSource = cms.InputTag('ak8PFJetsCHSPruned',''),
+   algo = 'AK8',
    rParam = 0.8,
    #genJetCollection = cms.InputTag('ak8GenJets'), # not in used SIM yet
    genJetCollection = cms.InputTag('ak4GenJets'),
@@ -61,8 +61,8 @@ addJetCollection(
        'combinedSecondaryVertexBJetTags'
      ],
    )
-process.out.outputCommands.append( 'keep *_selectedPatJets%s_pfCandidates_*'%( labelCA8PFCHSPruned ) )
-process.out.outputCommands.append( 'drop *_selectedPatJets%s_caloTowers_*'%( labelCA8PFCHSPruned ) )
+process.out.outputCommands.append( 'keep *_selectedPatJets%s_pfCandidates_*'%( labelAK8PFCHSPruned ) )
+process.out.outputCommands.append( 'drop *_selectedPatJets%s_caloTowers_*'%( labelAK8PFCHSPruned ) )
 
 # uncomment the following lines to switch to ak4CaloJets in your PAT output
 labelAK4Calo = 'AK4Calo'

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -63,8 +63,8 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHSPruned_*_*',                                           
+                                           'keep *_ak8PFJetsCHS_*_*',
+                                           'keep *_ak8PFJetsCHSPruned_*_*',                                           
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
                                            #'keep *_hepTopTagPFJetsCHS_*_*',
                                            #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
@@ -118,8 +118,8 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHSPruned_*_*',
+                                           #'keep *_ca8PFJetsCHS_*_*',
+                                           'keep *_ak8PFJetsCHSPruned_*_*',
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
                                            #'keep *_hepTopTagPFJetsCHS_*_*',
                                            #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
@@ -164,7 +164,7 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_fixedGridRho*_*_*',
                                            'drop doubles_*Jets_rhos_*',
                                            'drop doubles_*Jets_sigmas_*',
-                                           'keep *_ca8PFJetsCHSPrunedLinks_*_*'                                           
+                                           'keep *_ak8PFJetsCHSPrunedLinks_*_*'                                           
                                            )
     )
 RecoGenJetsAOD = cms.PSet(

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -193,7 +193,7 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            ak5PFJetsCHS+
                            ak4PFJetsCHS+                           
                            ak8PFJetsCHS+
-                           ca8PFJetsCHS+
+                           #ca8PFJetsCHS+
                            ak8PFJetsCHSConstituents+
                            ak8PFJetsCHSPruned+
                            ak8PFJetsCHSPrunedLinks+

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -195,8 +195,8 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            ak8PFJetsCHS+
                            ca8PFJetsCHS+
                            ak8PFJetsCHSConstituents+
-                           ca8PFJetsCHSPruned+
-                           ca8PFJetsCHSPrunedLinks+
+                           ak8PFJetsCHSPruned+
+                           ak8PFJetsCHSPrunedLinks+
                            cmsTopTagPFJetsCHS+
                            hepTopTagPFJetsCHS+
                            ca15PFJetsCHSMassDropFiltered+

--- a/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
 
 ak4PFJetsSoftDrop = ak4PFJets.clone(
     useSoftDrop = cms.bool(True),
-    zcut = cms.double(0.2),
+    zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
     )

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.ak5PFJets_cfi import ak5PFJets
 
 ak5PFJetsSoftDrop = ak5PFJets.clone(
     useSoftDrop = cms.bool(True),
-    zcut = cms.double(0.2),
+    zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
     )

--- a/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
+++ b/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
@@ -2,14 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 Njettiness = cms.EDProducer("NjettinessAdder",
                             src=cms.InputTag("ak8PFJetsCHS"),
-                            Njets=cms.vuint32(1,2,3),            # compute 1-, 2-, 3- subjettiness
+                            Njets=cms.vuint32(1,2,3,4),          # compute 1-, 2-, 3-, 4- subjettiness
                             # variables for measure definition : 
-                            measureDefinition = cms.uint32( 1 ), # default is unnormalized measure
-                            beta = cms.double(-999.0),           # not used by default
-                            R0 = cms.double( -999.0 ),           # not used by default
+                            measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
+                            beta = cms.double(1.0),              # CMS default is 1
+                            R0 = cms.double( 0.8 ),              # CMS default is jet cone size
                             Rcutoff = cms.double( -999.0),       # not used by default
                             # variables for axes definition :
-                            axesDefinition = cms.uint32( 6 ),    # default is 1-pass KT axes
+                            axesDefinition = cms.uint32( 6 ),    # CMS default is 1-pass KT axes
                             nPass = cms.int32(-999),             # not used by default
                             akAxesR0 = cms.double(-999.0)        # not used by default
                             )

--- a/RecoJets/JetProducers/python/qjetsadder_cfi.py
+++ b/RecoJets/JetProducers/python/qjetsadder_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 QJetsAdder = cms.EDProducer("QjetsAdder",
-                            src=cms.InputTag("ca8PFJetsCHS"),
+                            src=cms.InputTag("ak8PFJetsCHS"),
                             zcut=cms.double(0.1),
                             dcutfctr=cms.double(0.5),
                             expmin=cms.double(0.0),


### PR DESCRIPTION
This is a long outstanding issue to switch from CA8 to AK8 for jet substructure algorithms.
It would have resulted in merge conflicts with #6542 which went in only this weekend.
Though this is after the 730_pre3 deadline, we would very much like to switch this as CA8 jets are obsolete for analyses and in fact one can remove one jet algorithm in RECO by this change.
Here are the changes:
- drop ca8 collection from RECO/AOD, since ak8 jets are recommended instead
- switch from ca8 to ak8 for substructure algorithms in RECO/AOD
- update PAT and DQM accordingly
- update default parameters for N-subjettiness and softdrop (these are not run in RECO)
