### PR TITLE
L1t run l1t famos bugfix 730

### DIFF
--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -15,6 +15,11 @@ def customiseSimL1EmulatorForPostLS1(process):
     #print "INFO:  loading RCT LUTs"
     #process.load("L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff")
 
+    if hasattr(process,'simulationWithFamos'):
+        print "INFO:  Fast Simulation Detected... no more L1 tigger post LS1 customizations will be made"
+        return(process)
+
+
     process.load("L1Trigger.L1TCommon.l1tDigiToRaw_cfi")
     process.load("L1Trigger.L1TCommon.l1tRawToDigi_cfi")
     process.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -15,28 +15,41 @@ def customiseSimL1EmulatorForPostLS1(process):
     #print "INFO:  loading RCT LUTs"
     #process.load("L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff")
 
-    if hasattr(process,'simulationWithFamos'):
-        print "INFO:  Fast Simulation Detected... no more L1 tigger post LS1 customizations will be made"
-        return(process)
+    #if hasattr(process,'simulationWithFamos'):
+    #    print "INFO:  Fast Simulation Detected... no more L1 tigger post LS1 customizations will be made"
+    #    return(process)
 
 
     process.load("L1Trigger.L1TCommon.l1tDigiToRaw_cfi")
     process.load("L1Trigger.L1TCommon.l1tRawToDigi_cfi")
     process.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")
 
+    process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
+    process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
 
-    if hasattr(process,'L1simulation_step'):
-        #print "INFO:  Removing GCT from simulation and adding new Stage 1"
-        process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
-        process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
-        process.L1simulation_step.replace(process.simGctDigis,process.L1TCaloStage1)
-        #process.rctUpgradeFormatDigis.regionTag = cms.InputTag("simRctDigis")
-        #process.rctUpgradeFormatDigis.emTag = cms.InputTag("simRctDigis")
-        #print "New L1 simulation step is:", process.L1simulation_step
+    if hasattr(process, 'simGctDigis'):
+        process.L1TCaloStage1PlusGct = cms.Sequence(
+            process.simGctDigis +
+            process.L1TCaloStage1
+            )
+    else:
+        process.L1TCaloStage1PlusGct = cms.Sequence(
+            process.L1TCaloStage1
+            )
+
+    if hasattr(process, 'simGtDigis'):
         process.simGtDigis.GmtInputTag = 'simGmtDigis'
         process.simGtDigis.GctInputTag = 'simCaloStage1LegacyFormatDigis'
         process.simGtDigis.TechnicalTriggersInputTags = cms.VInputTag( )
+    if hasattr(process, 'gctDigiToRaw'):
         process.gctDigiToRaw.gctInputLabel = 'simCaloStage1LegacyFormatDigis'
+
+    for path in process.paths:
+        #print "INFO:  checking path ", path
+        #print "BEFORE:  ", getattr(process,path)
+        getattr(process,path).replace(process.simGctDigis,process.L1TCaloStage1PlusGct)
+        #print "AFTER:  ", getattr(process,path)
+
     if hasattr(process, 'DigiToRaw'):
         #print "INFO:  customizing DigiToRaw for Stage 1"
         #print process.DigiToRaw
@@ -58,9 +71,6 @@ def customiseSimL1EmulatorForPostLS1(process):
         process.RawToDigi.replace(process.gctDigis, process.L1RawToDigiSeq)
         #print process.RawToDigi
 
-
-#hltGtDigis+hltGctDigis+hltL1GtObjectMap+hltL1extraParticles
-#csctfDigis+dttfDigis+gctDigis+caloStage1Digis+caloStage1LegacyFormatDigis+gtDigis+gtEvmDigis+siPixelDigis+siStripDigis+ecalDigis+ecalPreshowerDigis+hcalDigis+muonCSCDigis+muonDTDigis+muonRPCDigis+castorDigis+scalersRawToDigi+hltL1extraParticles
     if hasattr(process, 'HLTL1UnpackerSequence'):
         #print "INFO: customizing HLTL1UnpackerSequence for Stage 1"
         #print process.HLTL1UnpackerSequence
@@ -76,27 +86,6 @@ def customiseSimL1EmulatorForPostLS1(process):
         #process.hltL1RawToDigiSeq = cms.Sequence(process.hltGctDigis+process.hltCaloStage1 + process.hltCaloStage1LegacyFormatDigis)
         process.hltL1RawToDigiSeq = cms.Sequence(process.hltCaloStage1Digis + process.hltCaloStage1LegacyFormatDigis)
         process.HLTL1UnpackerSequence.replace(process.hltGctDigis, process.hltL1RawToDigiSeq)
-
-
-        # Alternate (possibly necessary approach) not yet debugged...
-        # redefine the HLTL1UnpackerSequence
-        #HLTL1UnpackerSequence = cms.Sequence( process.hltGtDigis+process.hltGctDigis+process.hltL1GtObjectMap+process.hltL1extraParticles + process.hltL1extraParticles )
-        #HLTL1UnpackerSequence = cms.Sequence( process.hltGtDigis++process.hltL1GtObjectMap+process.hltL1extraParticles + process.hltL1extraParticles )
-        #process.load("L1Trigger.L1TCommon.l1tRawToDigi_cfi")
-        #process.l1tRawToDigi.Setup = cms.string("stage1::CaloSetup")
-        #process.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")
-        #process.L1RawToDigiSeq = cms.Sequence(process.gctDigis+process.caloStage1Digis+process.caloStage1LegacyFormatDigis)
-        #for iterable in process.sequences.itervalues():
-        #    iterable.replace( process.HLTL1UnpackerSequence, HLTL1UnpackerSequence)
-
-        #for iterable in process.paths.itervalues():
-        #    iterable.replace( process.HLTL1UnpackerSequence, HLTL1UnpackerSequence)
-
-        #for iterable in process.endpaths.itervalues():
-        #    iterable.replace( process.HLTL1UnpackerSequence, HLTL1UnpackerSequence)
-
-        #process.HLTL1UnpackerSequence = HLTL1UnpackerSequence
-        #print process.HLTL1UnpackerSequence
 
     alist=['hltL1extraParticles']
     for a in alist:
@@ -120,29 +109,35 @@ def customiseSimL1EmulatorForPostLS1(process):
     for b in blist:
         #print "INFO: checking for", b, "in process."
         if hasattr(process,b):
-            #print "INFO:  customizing ", b, "to use new calo Stage 1 digis converted to legacy format"
-            getattr(process, b).etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis")
-            getattr(process, b).nonIsolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm")
-            getattr(process, b).etMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
-            getattr(process, b).htMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
-            getattr(process, b).forwardJetSource = cms.InputTag("caloStage1LegacyFormatDigis","forJets")
-            getattr(process, b).centralJetSource = cms.InputTag("caloStage1LegacyFormatDigis","cenJets")
-            getattr(process, b).tauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","tauJets")
-            getattr(process, b).isoTauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","isoTauJets")
-            getattr(process, b).isolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","isoEm")
-            getattr(process, b).etHadSource = cms.InputTag("caloStage1LegacyFormatDigis")
-            getattr(process, b).hfRingEtSumsSource = cms.InputTag("caloStage1LegacyFormatDigis")
-            getattr(process, b).hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis")
-
-
-#    # THIS IS A HACK FOR NOW, WHILE WE SORT OUT FED ID:
-#    clist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT']
-#    for c in clist:
-#        b=c+'output'
-#        if hasattr(process,b):
-#            getattr(process,b).outputCommands.append('keep *_l1tDigiToRaw_*_*')
-#            print "INFO:  keeping l1tDigiToRaw output in the event."
-
+            #print "BEFORE:  ", getattr(process, b).centralJetSource
+            if (getattr(process, b).centralJetSource == cms.InputTag("simGctDigis","cenJets")):
+                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","nonIsoEm")
+                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1FormatDigis","forJets")
+                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1FormatDigis","cenJets")
+                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1FormatDigis","tauJets")
+                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1FormatDigis","isoTauJets")
+                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","isoEm")
+                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1FormatDigis")
+            else:
+                #print "INFO:  customizing ", b, "to use new calo Stage 1 digis converted to legacy format"
+                getattr(process, b).etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).nonIsolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm")
+                getattr(process, b).etMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).htMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).forwardJetSource = cms.InputTag("caloStage1LegacyFormatDigis","forJets")
+                getattr(process, b).centralJetSource = cms.InputTag("caloStage1LegacyFormatDigis","cenJets")
+                getattr(process, b).tauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","tauJets")
+                getattr(process, b).isoTauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","isoTauJets")
+                getattr(process, b).isolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","isoEm")
+                getattr(process, b).etHadSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingEtSumsSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis")
+            #print "AFTER:  ", getattr(process, b).centralJetSource
 
 #    process.MessageLogger = cms.Service(
 #        "MessageLogger",
@@ -158,27 +153,5 @@ def customiseSimL1EmulatorForPostLS1(process):
 #            )
 #        )
 #    print process.HLTSchedule
+
     return process
-
-#    #
-#    # Plan B:  (Not Needed if packing/unpacking of Stage 1 calo via legacy formats and GCT packer works)
-#    #
-#    process.digi2raw_step.remove(process.gctDigiToRaw)
-#   
-#    # Carry forward legacy format digis for now (keep rest of workflow working)
-#    alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT']
-#    for a in alist:
-#        b=a+'output'
-#        if hasattr(process,b):
-#            getattr(process,b).outputCommands.append('keep *_caloStage1LegacyFormatDigis_*_*')
-#            print "INFO:  keeping L1T legacy format digis in event."
-#    
-#
-#    # automatic replacements of "simGctDigis" instead of "hltGctDigis"
-#    for module in process.__dict__.itervalues():
-#        if isinstance(module, cms._Module):
-#            for parameter in module.__dict__.itervalues():
-#                if isinstance(parameter, cms.InputTag):
-#                    if parameter.moduleLabel == 'hltGctDigis':
-#                        parameter.moduleLabel = "simGctDigis"
-

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -27,15 +27,15 @@ def customiseSimL1EmulatorForPostLS1(process):
     process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
     process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
 
-    if hasattr(process, 'simGctDigis'):
-        process.L1TCaloStage1PlusGct = cms.Sequence(
-            process.simGctDigis +
-            process.L1TCaloStage1
-            )
-    else:
-        process.L1TCaloStage1PlusGct = cms.Sequence(
-            process.L1TCaloStage1
-            )
+    #if hasattr(process, 'simGctDigis'):
+    #    process.L1TCaloStage1PlusGct = cms.Sequence(
+    #        process.simGctDigis +
+    #        process.L1TCaloStage1
+    #        )
+    #else:
+    #    process.L1TCaloStage1PlusGct = cms.Sequence(
+    #        process.L1TCaloStage1
+    #        )
 
     if hasattr(process, 'simGtDigis'):
         process.simGtDigis.GmtInputTag = 'simGmtDigis'
@@ -47,7 +47,7 @@ def customiseSimL1EmulatorForPostLS1(process):
     for path in process.paths:
         #print "INFO:  checking path ", path
         #print "BEFORE:  ", getattr(process,path)
-        getattr(process,path).replace(process.simGctDigis,process.L1TCaloStage1PlusGct)
+        getattr(process,path).replace(process.simGctDigis,process.L1TCaloStage1)
         #print "AFTER:  ", getattr(process,path)
 
     if hasattr(process, 'DigiToRaw'):

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -44,11 +44,12 @@ def customiseSimL1EmulatorForPostLS1(process):
     if hasattr(process, 'gctDigiToRaw'):
         process.gctDigiToRaw.gctInputLabel = 'simCaloStage1LegacyFormatDigis'
 
-    for path in process.paths:
-        #print "INFO:  checking path ", path
-        #print "BEFORE:  ", getattr(process,path)
-        getattr(process,path).replace(process.simGctDigis,process.L1TCaloStage1)
-        #print "AFTER:  ", getattr(process,path)
+    if hasattr(process, 'simGctDigis'):
+        for path in process.paths:
+            #print "INFO:  checking path ", path
+            #print "BEFORE:  ", getattr(process,path)
+            getattr(process,path).replace(process.simGctDigis,process.L1TCaloStage1)
+            #print "AFTER:  ", getattr(process,path)
 
     if hasattr(process, 'DigiToRaw'):
         #print "INFO:  customizing DigiToRaw for Stage 1"

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -15,27 +15,12 @@ def customiseSimL1EmulatorForPostLS1(process):
     #print "INFO:  loading RCT LUTs"
     #process.load("L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff")
 
-    #if hasattr(process,'simulationWithFamos'):
-    #    print "INFO:  Fast Simulation Detected... no more L1 tigger post LS1 customizations will be made"
-    #    return(process)
-
-
     process.load("L1Trigger.L1TCommon.l1tDigiToRaw_cfi")
     process.load("L1Trigger.L1TCommon.l1tRawToDigi_cfi")
     process.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")
 
     process.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
     process.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
-
-    #if hasattr(process, 'simGctDigis'):
-    #    process.L1TCaloStage1PlusGct = cms.Sequence(
-    #        process.simGctDigis +
-    #        process.L1TCaloStage1
-    #        )
-    #else:
-    #    process.L1TCaloStage1PlusGct = cms.Sequence(
-    #        process.L1TCaloStage1
-    #        )
 
     if hasattr(process, 'simGtDigis'):
         process.simGtDigis.GmtInputTag = 'simGmtDigis'


### PR DESCRIPTION
This fixes a bug when running Fast Simulation in postLS1 scenario, where new L1T emulation was not run but inputs were expected downstream. This bug fix causes new L1T emulation to be run in all scenarios where legacy GCT emulation was run, if postLS1 customization is made. It also sets the l1extra producer to use simulated or unpacked digis based on context.
