### PR TITLE
remove spurious assert

### DIFF
--- a/CondCore/ORA/src/PVectorHandler.cc
+++ b/CondCore/ORA/src/PVectorHandler.cc
@@ -61,7 +61,6 @@ ora::PVectorHandler::PVectorHandler( const edm::TypeWithDict& dictionary ):
 {
   edm::MemberWithDict privateVectorAttribute = m_type.dataMemberByName("m_vec");
   if(privateVectorAttribute){
-    assert(!strcmp("ora::PVector<cond::IOVElement>",m_type.cppName().c_str()));
     m_vecAttributeOffset = privateVectorAttribute.offset();
     ROOT::TCollectionProxyInfo* collProxyPtr = ROOT::TCollectionProxyInfo::Generate(ROOT::TCollectionProxyInfo::Pushback<std::vector<cond::IOVElement> >());
     m_collProxy.reset( collProxyPtr );


### PR DESCRIPTION
Two unit tests in CondCore/ORA were failing due to a spurious (and invalid) assert that was inadvertently left behind from debugging.
This pull request removes the incorrect assert.  The two unit tests will still fail later due to a different problem, which still needs to be debugged.
Please merge this pull request as soon as convenient.
