### PR TITLE
Prepare for taking MF configurations from DB

### DIFF
--- a/CondFormats/MFObjects/test/writeAllMagFieldConfigDB.py
+++ b/CondFormats/MFObjects/test/writeAllMagFieldConfigDB.py
@@ -1,0 +1,31 @@
+#!/usr/bin/python
+
+import os
+import sys
+
+SETUPS = ('71212',  '',           ('0T','2T','3T','3_5T','4T')), \
+         ('90322',  '2pi_scaled', (['3_8T'])), \
+         ('120812', 'Run1',       (['3_8T'])), \
+         ('120812', 'Run2',       (['3_8T'])), \
+         ('130503', 'Run1',       ('3_5T','3_8T')), \
+         ('130503', 'Run2',       ('3_5T','3_8T')),
+
+
+for SETUP in SETUPS :
+    SET = SETUP[0]
+    SUBSET = SETUP[1]
+    for B_NOM in SETUP[2] : 
+       print SET, SUBSET, B_NOM
+       sys.stdout.flush()
+       namespace = {'SET':SET, 'SUBSET':SUBSET, 'B_NOM':B_NOM}
+       execfile("writeMagFieldConfigDB.py",namespace)
+       process = namespace.get('process') 
+       cfgFile = open('run.py','w')       
+       cfgFile.write( process.dumpPython() )
+       cfgFile.write( '\n' )
+       cfgFile.close()
+       os.system("cmsRun run.py")
+       del namespace
+       del process
+       print ""
+       

--- a/CondFormats/MFObjects/test/writeMagFieldConfigDB.py
+++ b/CondFormats/MFObjects/test/writeMagFieldConfigDB.py
@@ -2,21 +2,21 @@ import FWCore.ParameterSet.Config as cms
 import os
 
 #SET = "71212"
-SET = "90322"
+#SET = "90322"
 #SET = "120812"
 #SET = "130503"
 
 #SUBSET = ""
-SUBSET = "2pi_scaled"
+#SUBSET = "2pi_scaled"
 #SUBSET = "Run1"
 #SUBSET = "Run2"
 
-# B_NOM = "0T"
-# B_NOM = "2T"
-# B_NOM = "3T"
-# B_NOM = "3_5T"
-B_NOM = "3.8T"
-# B_NOM = "4T"
+#B_NOM = "0T"
+#B_NOM = "2T"
+#B_NOM = "3T"
+#B_NOM = "3_5T"
+#B_NOM = "3.8T"
+#B_NOM = "4T"
 
 
 process = cms.Process("DumpToDB")
@@ -82,14 +82,20 @@ if SET=="71212" :
                 '3T':   'grid_1103l_071212_3t',
                 '3_5T': 'grid_1103l_071212_3_5t',
                 #'3.8T': 'grid_1103l_071212_3_8t', #Deprecated
-                '4T':   'grid_1103l_071212_4t'}
+                '4T':   'grid_1103l_071212_4t'} 
+    param    = {'0T':   0.,
+                '2T':   2.,
+                '3T':   3.,
+                '3_5T': 3.5,
+                #'3_8T': 3.8,
+                '4T':   4.}
     process.dumpToDB = cms.EDAnalyzer("MagFieldConfigDBWriter",
           scalingVolumes = cms.vint32(),
           scalingFactors = cms.vdouble(),
           version = cms.string(versions[B_NOM]),
           geometryVersion = cms.int32(90322),
           paramLabel = cms.string('OAE_1103l_071212'),
-          paramData = cms.vdouble(3.8),
+          paramData = cms.vdouble(param[B_NOM]),
           gridFiles = cms.VPSet(
             cms.PSet( # Default tables, replicate sector 1
                volumes   = cms.string('1-312'),
@@ -99,10 +105,12 @@ if SET=="71212" :
            )
          )
     )
-
+    if B_NOM == '0T' :
+        process.dumpToDB.paramLabel = 'Uniform'
+    
 
 if SET=="90322" :
-    if B_NOM!="3.8T" or SUBSET!="2pi_scaled":  raise NameError("configuration invalid: "+SET)
+    if B_NOM!="3_8T" or SUBSET!="2pi_scaled":  raise NameError("configuration invalid: "+SET)
 
     from MagneticField.Engine.ScalingFactors_090322_2pi_090520_cfi import *
     
@@ -155,7 +163,7 @@ if SET=="90322" :
       
 
 elif SET=="120812" :
-  if B_NOM!="3.8T" :  raise NameError("B_NOM invalid for SET "+SET)
+  if B_NOM!="3_8T" :  raise NameError("B_NOM invalid for SET "+SET)
   if    SUBSET=="Run1" : VERSION = 'grid_120812_3_8t_v7_small'
   elif  SUBSET=="Run2" : VERSION = 'grid_120812_3_8t_v7_large'
   else : raise NameError("invalid SUBSET: "+SUBSET+ " for "+TAG )
@@ -216,7 +224,9 @@ elif SET=="120812" :
     
 elif SET=="130503" :
   versions = {'3_5T': 'grid_130503_3_5t_v9',
-              '3.8T': 'grid_130503_3_8t_v9'}
+              '3_8T': 'grid_130503_3_8t_v9'}
+  param    = {'3_5T': 3.5,
+              '3_8T': 3.8}
   
   if    SUBSET=="Run1" : VERSION = versions[B_NOM]+'_small'
   elif  SUBSET=="Run2" : VERSION = versions[B_NOM]+'_large'
@@ -228,7 +238,7 @@ elif SET=="130503" :
       version = cms.string(VERSION),
       geometryVersion = cms.int32(130503),
       paramLabel = cms.string('OAE_1103l_071212'),
-      paramData = cms.vdouble(3.8),
+      paramData = cms.vdouble(param[B_NOM]),
     
       gridFiles = cms.VPSet(
           # Volumes for which specific tables are used for each sector

--- a/CondFormats/MFObjects/test/writeMagFieldConfigDB.py
+++ b/CondFormats/MFObjects/test/writeMagFieldConfigDB.py
@@ -62,7 +62,7 @@ def createMetadata(aTag,aComment):
     txtfile.write('{\n')
     txtfile.write('   "destinationDatabase": "oracle://cms_orcoff_prep/CMS_COND_GEOMETRY",\n')
     txtfile.write('   "destinationTags": {\n')
-    txtfile.write('      '+TAG+'": {\n')
+    txtfile.write('      "'+TAG+'": {\n')
     txtfile.write('         "dependencies": {},\n')
     txtfile.write('         "synchronizeTo": "offline"\n')
     txtfile.write('        }\n')

--- a/MagneticField/Engine/test/testMagneticFieldDB.py
+++ b/MagneticField/Engine/test/testMagneticFieldDB.py
@@ -20,18 +20,24 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')
 process.GlobalTag.toGet = cms.VPSet(
     # Geometries
     cms.PSet(record = cms.string("MFGeometryFileRcd"),
-             tag = cms.string("MagneticFieldGeometry_90322"),
-             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_90322.db"),
+#             tag = cms.string("MagneticFieldGeometry_90322"),
+#             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_90322.db"),
+             tag = cms.string("MFGeometry_90322"),
+             connect = cms.untracked.string("frontier://FrontierPrep/CMS_COND_GEOMETRY"),
              label = cms.untracked.string("90322")
              ),
     cms.PSet(record = cms.string("MFGeometryFileRcd"),
-             tag = cms.string("MagneticFieldGeometry_120812"),
-             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_120812.db"),
+#             tag = cms.string("MagneticFieldGeometry_120812"),
+#             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_120812.db"),
+             tag = cms.string("MFGeometry_120812"),
+             connect = cms.untracked.string("frontier://FrontierPrep/CMS_COND_GEOMETRY"),
              label = cms.untracked.string("120812")
              ),
     cms.PSet(record = cms.string("MFGeometryFileRcd"),
-             tag = cms.string("MagneticFieldGeometry_130503"),
-             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_130503.db"),
+#             tag = cms.string("MagneticFieldGeometry_130503"),
+#             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_130503.db"),
+             tag = cms.string("MFGeometry_130503"),
+             connect = cms.untracked.string("frontier://FrontierPrep/CMS_COND_GEOMETRY"),
              label = cms.untracked.string("130503")
              ),
 

--- a/MagneticField/Engine/test/testMagneticFieldDB.py
+++ b/MagneticField/Engine/test/testMagneticFieldDB.py
@@ -1,0 +1,117 @@
+#
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("MAGNETICFIELDTEST")
+
+process.source = cms.Source("EmptySource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+)
+
+process.load("MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi")
+
+process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:mc', '')
+
+
+
+process.GlobalTag.toGet = cms.VPSet(
+    # Geometries
+    cms.PSet(record = cms.string("MFGeometryFileRcd"),
+             tag = cms.string("MagneticFieldGeometry_90322"),
+             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_90322.db"),
+             label = cms.untracked.string("90322")
+             ),
+    cms.PSet(record = cms.string("MFGeometryFileRcd"),
+             tag = cms.string("MagneticFieldGeometry_120812"),
+             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_120812.db"),
+             label = cms.untracked.string("120812")
+             ),
+    cms.PSet(record = cms.string("MFGeometryFileRcd"),
+             tag = cms.string("MagneticFieldGeometry_130503"),
+             connect = cms.untracked.string("sqlite_file:DB_Geom/mfGeometry_130503.db"),
+             label = cms.untracked.string("130503")
+             ),
+
+    # Configurations
+    cms.PSet(record = cms.string("MagFieldConfigRcd"),
+             tag = cms.string("MagFieldConfig"),
+             connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_71212_0T.db"),
+             label = cms.untracked.string("0T")
+             ),
+    cms.PSet(record = cms.string("MagFieldConfigRcd"),
+             tag = cms.string("MagFieldConfig"),
+             connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_71212_2T.db"),
+             label = cms.untracked.string("2T")
+             ),
+    cms.PSet(record = cms.string("MagFieldConfigRcd"),
+             tag = cms.string("MagFieldConfig"),
+             connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_71212_3T.db"),
+             label = cms.untracked.string("3T")
+             ),
+    cms.PSet(record = cms.string("MagFieldConfigRcd"),
+             tag = cms.string("MagFieldConfig"),
+             connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_71212_3_5T.db"),
+             label = cms.untracked.string("3.5T")
+             ),
+#     cms.PSet(record = cms.string("MagFieldConfigRcd"), # Run 2, new version (130503)
+#              tag = cms.string("MagFieldConfig"),
+#              connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_130503_Run2_3_5T.db"),
+#              label = cms.untracked.string("3.5T")
+#              ),    
+    cms.PSet(record = cms.string("MagFieldConfigRcd"), #Run 1 default
+             tag = cms.string("MagFieldConfig"),
+             connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_90322_2pi_scaled_3_8T.db"),
+             label = cms.untracked.string("3.8T")
+             ),
+#     cms.PSet(record = cms.string("MagFieldConfigRcd"), #Run 2 default
+#              tag = cms.string("MagFieldConfig"),
+#              connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_120812_Run2_3_8T.db"),
+#              label = cms.untracked.string("3.8T")
+#              ),
+#     cms.PSet(record = cms.string("MagFieldConfigRcd"), #Run 1, version 120812
+#              tag = cms.string("MagFieldConfig"),
+#              connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_120812_Run1_3_8T.db"),
+#              label = cms.untracked.string("3.8T")
+#              ),
+#     cms.PSet(record = cms.string("MagFieldConfigRcd"), #Run 1, version 130503
+#              tag = cms.string("MagFieldConfig"),
+#              connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_130503_Run1_3_8T.db"),
+#              label = cms.untracked.string("3.8T")
+#              ),
+#     cms.PSet(record = cms.string("MagFieldConfigRcd"), #Run 2, new version (130503)
+#              tag = cms.string("MagFieldConfig"),
+#              connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_130503_Run2_3_8T.db"),
+#              label = cms.untracked.string("3.8T")
+#              ),
+    cms.PSet(record = cms.string("MagFieldConfigRcd"),
+             tag = cms.string("MagFieldConfig"),
+             connect = cms.untracked.string("sqlite_file:DB_Conf/MFConfig_71212_4T.db"),
+             label = cms.untracked.string("4T")
+             ),
+
+
+)
+
+# process.VolumeBasedMagneticFieldESProducer.valueOverride =  17000 
+
+process.MessageLogger = cms.Service("MessageLogger",
+    categories   = cms.untracked.vstring("MagneticField"),
+    destinations = cms.untracked.vstring("cout"),
+    cout = cms.untracked.PSet(  
+    noLineBreaks = cms.untracked.bool(True),
+    threshold = cms.untracked.string("WARNING"),
+    WARNING = cms.untracked.PSet(
+      limit = cms.untracked.int32(0)
+    ),
+    MagneticField = cms.untracked.PSet(
+     limit = cms.untracked.int32(10000000)
+    )
+  )
+)
+
+process.testField  = cms.EDAnalyzer("testMagneticField")
+process.p1 = cms.Path(process.testField)
+

--- a/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc
+++ b/MagneticField/GeomBuilder/plugins/VolumeBasedMagneticFieldESProducerFromDB.cc
@@ -95,17 +95,16 @@ std::auto_ptr<MagneticField> VolumeBasedMagneticFieldESProducerFromDB::produce(c
     message = " (from valueOverride card)";
   }
   string configLabel  = closerNominalLabel(current);
-  edm::LogInfo("MagneticField|AutoMagneticField") << "Current: " << current << message << "; using map configuration with label: " << configLabel;
 
   // Get configuration
   ESHandle<MagFieldConfig> confESH;
   iRecord.getRecord<MagFieldConfigRcd>().get(configLabel, confESH);
   const MagFieldConfig* conf = &*confESH;
 
-  if (debug) {
-    cout << "VolumeBasedMagneticFieldESProducerFromDB::produce() " << conf->version << endl;
-  }
-
+  edm::LogInfo("MagneticField|AutoMagneticField") << "Current: " << current << message << "; using map configuration with label: " << configLabel << endl
+						  << "Version: " << conf->version 
+						  << " geometryVersion: " << conf->geometryVersion
+						  << " slaveFieldVersion: " << conf->slaveFieldVersion;
 
   // Get the parametrized field
   std::auto_ptr<MagneticField> paramField = ParametrizedMagneticFieldFactory::get(conf->slaveFieldVersion, conf->slaveFieldParameters);

--- a/MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.cc
+++ b/MagneticField/GeomBuilder/src/MagGeoBuilderFromDDD.cc
@@ -346,13 +346,34 @@ void MagGeoBuilderFromDDD::build(const DDCompactView & cpva)
 
   //Sort in phi
   precomputed_value_sort(eVolumes.begin(), eVolumes.end(), ExtractPhi());
+  
+  // Handle the -pi/pi boundary: volumes crossing it could be half at the begin and half at end of the sorted list. 
+  // So, check if any of the volumes that should belong to the first bin (at -phi) are at the end of the list:
+  float lastBinPhi = phiClust.back();
+  handles::reverse_iterator ri = eVolumes.rbegin();
+  while ((*ri)->center().phi()>lastBinPhi) {++ri;}
+  if (ri!=eVolumes.rbegin()) {
+    // ri points to the first element that is within the last bin.
+    // We need to move the following element (ie ri.base()) to the beginning of the list,
+    handles::iterator newbeg = ri.base();
+    rotate(eVolumes.begin(),newbeg, eVolumes.end());
+  }  
 
   //Group volumes in sectors
+  int offset = eVolumes.size()/nESectors;
   for (int i = 0; i<nESectors; ++i) {
-    int offset = eVolumes.size()/nESectors;
-    if (debug) cout << " Sector at phi = "
-		    << (*(eVolumes.begin()+((i)*offset)))->center().phi()
-		    << endl;
+    if (debug) {
+      cout << " Sector at phi = "
+	   << (*(eVolumes.begin()+((i)*offset)))->center().phi()
+	   << endl;
+      // Additional x-check: sectors are expected to be made by volumes with the same copyno
+      int secCopyNo = -1;
+      for (handles::const_iterator iv=eVolumes.begin()+((i)*offset); iv!=eVolumes.begin()+((i+1)*offset); ++iv){
+	if (secCopyNo>=0&& (*iv)->copyno!=secCopyNo) cout << "ERROR: volume copyno" << (*iv)->name << ":" << (*iv)->copyno << " differs from others in same sectors " << secCopyNo << endl;
+	secCopyNo = (*iv)->copyno;
+      }
+    }
+
     sectors.push_back(eSector(eVolumes.begin()+((i)*offset),
 			      eVolumes.begin()+((i+1)*offset)));
   }

--- a/MagneticField/GeomBuilder/src/volumeHandle.cc
+++ b/MagneticField/GeomBuilder/src/volumeHandle.cc
@@ -461,19 +461,24 @@ MagGeoBuilderFromDDD::volumeHandle::sides() const{
   return result;
 }
 
-void MagGeoBuilderFromDDD::volumeHandle::printUniqueNames(handles::const_iterator begin, handles::const_iterator end ) {
+void MagGeoBuilderFromDDD::volumeHandle::printUniqueNames(handles::const_iterator begin, handles::const_iterator end, bool uniq) {
     std::vector<std::string> names;
     for (handles::const_iterator i = begin; 
 	 i != end; ++i){
-      names.push_back((*i)->name);
+      if (uniq) names.push_back((*i)->name);
+      else names.push_back((*i)->name+":"+boost::lexical_cast<string>((*i)->copyno));
     }
      
     sort(names.begin(),names.end());
-    std::vector<std::string>::iterator i = unique(names.begin(),names.end());
-    int nvols = int(i - names.begin());
-    cout << nvols << " ";
-    copy(names.begin(), i, ostream_iterator<std::string>(cout, " "));
-     
+    if (uniq) {
+      std::vector<std::string>::iterator i = unique(names.begin(),names.end());
+      int nvols = int(i - names.begin());
+      cout << nvols << " ";
+      copy(names.begin(), i, ostream_iterator<std::string>(cout, " "));
+    } else {
+      cout << names.size() << " ";
+      copy(names.begin(), names.end(), ostream_iterator<std::string>(cout, " "));
+    }
     cout << endl;
 }
 

--- a/MagneticField/GeomBuilder/src/volumeHandle.h
+++ b/MagneticField/GeomBuilder/src/volumeHandle.h
@@ -63,7 +63,7 @@ public:
 
   /// Just for debugging...
   static void printUniqueNames(handles::const_iterator begin,
-			       handles::const_iterator end);
+			       handles::const_iterator end, bool uniq=true);
 
 
   // Phi ranges: Used by: LessDPhiMax; bSector; bSlab::[min|max]Phi();

--- a/MagneticField/Layers/interface/MagVerbosity.h
+++ b/MagneticField/Layers/interface/MagVerbosity.h
@@ -7,9 +7,15 @@
  *  \author N. Amapane - INFN Torino
  */
 
+//#DEFINE MF_DEBUG
 
+// Old debug control switch, being phased out
 struct verbose {
+#ifdef MF_DEBUG
+  static constexpr bool debugOut = true;
+#else
   static constexpr bool debugOut = false;
+#endif
 };
 
 #endif

--- a/MagneticField/Layers/src/MagELayer.cc
+++ b/MagneticField/Layers/src/MagELayer.cc
@@ -10,7 +10,7 @@
 #include "MagneticField/VolumeGeometry/interface/MagVolume.h"
 #include "MagneticField/VolumeGeometry/interface/MagVolume6Faces.h"
 
-// #include "MagneticField/MagLayers/interface/MagVerbosity.h"
+#include "MagneticField/Layers/interface/MagVerbosity.h"
 #include <iostream>
 
 using namespace std;
@@ -35,9 +35,12 @@ MagELayer::findVolume(const GlobalPoint & gp, double tolerance) const {
   for(vector<MagVolume*>::const_iterator ivol = theVolumes.begin();
 	ivol != theVolumes.end(); ++ivol) {
     // FIXME : use a binfinder
-    // TOFIX
-//     if (verbose.debugOut) cout << "        Trying volume "
-// 		    << (static_cast<MagVolume6Faces*> (*ivol))->name << endl;
+#ifdef MF_DEBUG
+    {
+      MagVolume6Faces* mv = static_cast<MagVolume6Faces*> (*ivol);
+      cout << "        Trying volume " << mv->volumeNo << " " << int(mv->copyno) << endl;
+    }
+#endif
     if ( (*ivol)->inside(gp,tolerance) ) return (*ivol);
   }
 

--- a/MagneticField/Layers/src/MagESector.cc
+++ b/MagneticField/Layers/src/MagESector.cc
@@ -9,7 +9,7 @@
 #include "MagneticField/Layers/interface/MagESector.h"
 #include "MagneticField/Layers/interface/MagELayer.h"
 
-// #include "MagneticField/MagLayers/interface/MagVerbosity.h"
+#include "MagneticField/Layers/interface/MagVerbosity.h"
 
 #include <iostream>
 
@@ -33,22 +33,19 @@ MagVolume * MagESector::findVolume(const GlobalPoint & gp, double tolerance) con
   MagVolume * result = 0;
   float Z = gp.z();
 
-  //  int count = 0;
-
   // FIXME : use a binfinder
   for(vector<MagELayer*>::const_reverse_iterator ilay = theLayers.rbegin();
 	ilay != theLayers.rend(); ++ilay) {
 
     if (Z+tolerance>(*ilay)->minZ()) {
       if (Z-tolerance<(*ilay)->maxZ()) {
-// 	if (verbose.debugOut) cout << "  Trying layer at Z " << (*ilay)->minZ()
-// 			<< " " << Z << endl ;
-	result = (*ilay)->findVolume(gp, tolerance);
-// 	if (verbose.debugOut) {
-// 	  cout << "***In elayer " << count << " " 
-// 	       << (result==0? " failed " : " OK ") <<endl;
-// 	  ++count;
-// 	}
+#ifdef MF_DEBUG
+	cout << "  Trying elayer at Z " << (*ilay)->minZ() << " " << Z << endl ;
+#endif
+      	result = (*ilay)->findVolume(gp, tolerance);
+#ifdef MF_DEBUG
+	cout << "***In elayer " << (result==0? " failed " : " OK ") << endl;
+#endif
       } else {
 	// break;  // FIXME: OK if sorted by maxZ
       }


### PR DESCRIPTION
Includes:
-Tools to create .db files for standard configurations 
-Fix for one numerical stability problem with geometries imported to DB. The problem did not affect existing configurations (with geometry coming from xml), and the fix was regression-tested.

This fix is needed to be able to finally switch to reading MF geometry and configuration from DB, which will happen in a future (pre)release once a GT with all required payloads becomes available.

This is the same as #6514, but for CMSSW_7_4_X. Will be merged automatically since the former is fully signed.
