### PR TITLE
Add DQM modules for single lepton+HT SUSY triggers

### DIFF
--- a/HLTriggerOffline/SUSYBSM/BuildFile.xml
+++ b/HLTriggerOffline/SUSYBSM/BuildFile.xml
@@ -1,3 +1,5 @@
+<use   name="DataFormats/BeamSpot"/>
+<use   name="DataFormats/BTauReco"/>
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/EgammaCandidates"/>
@@ -6,14 +8,18 @@
 <use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/L1GlobalTrigger"/>
 <use   name="DataFormats/L1Trigger"/>
+<use   name="DataFormats/Math"/>
 <use   name="DataFormats/METReco"/>
 <use   name="DataFormats/MuonReco"/>
+<use   name="DataFormats/VertexReco"/>
 <use   name="DQMServices/Core"/>
+<use   name="FWCore/Common"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="HLTrigger/HLTcore"/>
 <use   name="HLTrigger/JetMET"/>
+<use   name="RecoEgamma/EgammaTools"/>
 <use   name="rootgraphics"/>
 <flags   EDM_PLUGIN="1"/>

--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_SingleLepton.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_SingleLepton.h
@@ -1,0 +1,136 @@
+#ifndef SUSY_HLT_SingleLepton_H
+#define SUSY_HLT_SingleLepton_H
+
+//event
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+//DQM
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+//Electron
+#include "DataFormats/EgammaCandidates/interface/Electron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+
+//Muon
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+
+//MET
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETCollection.h"
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/METReco/interface/METCollection.h"
+
+//Jets
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/BTauReco/interface/JetTag.h"
+
+//Trigger
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+#include "DataFormats/HLTReco/interface/TriggerEvent.h"
+#include "DataFormats/HLTReco/interface/TriggerEventWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerEventWithRefs.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+
+//Vertices
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+
+//Conversions
+#include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+
+//Beam spot
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+class SUSY_HLT_SingleLepton: public DQMEDAnalyzer{
+
+public:
+  SUSY_HLT_SingleLepton(const edm::ParameterSet& ps);
+  virtual ~SUSY_HLT_SingleLepton();
+
+protected:
+  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &e) override;
+  void bookHistograms(DQMStore::IBooker &ibooker, const edm::Run &, const edm::EventSetup &) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock &lumi, const edm::EventSetup &eSetup) ;
+  void analyze(const edm::Event &e, const edm::EventSetup &eSetup);
+  void endLuminosityBlock(const edm::LuminosityBlock &lumi, const edm::EventSetup &eSetup);
+  void endRun(const edm::Run &run, const edm::EventSetup &eSetup);
+
+private:
+  //variables from config file
+  edm::InputTag theElectronTag_;
+  edm::EDGetTokenT<reco::GsfElectronCollection> theElectronCollection_;
+  edm::InputTag theMuonTag_;
+  edm::EDGetTokenT<reco::MuonCollection> theMuonCollection_;
+  edm::InputTag thePfMETTag_;
+  edm::EDGetTokenT<reco::PFMETCollection> thePfMETCollection_;
+  edm::InputTag thePfJetTag_;
+  edm::EDGetTokenT<reco::PFJetCollection> thePfJetCollection_;
+  edm::InputTag theJetTagTag_;
+  edm::EDGetTokenT<reco::JetTagCollection> theJetTagCollection_;
+
+  edm::InputTag theVertexCollectionTag_;
+  edm::EDGetTokenT<reco::VertexCollection> theVertexCollection_;
+  edm::InputTag theConversionCollectionTag_;
+  edm::EDGetTokenT<reco::ConversionCollection> theConversionCollection_;
+  edm::InputTag theBeamSpotTag_;
+  edm::EDGetTokenT<reco::BeamSpot> theBeamSpot_;
+
+  edm::InputTag theLeptonFilterTag_;
+  edm::InputTag theHLTHTTag_;
+  edm::EDGetTokenT<reco::METCollection> theHLTHT_;
+  edm::InputTag theHLTMETTag_;
+  edm::EDGetTokenT<reco::METCollection> theHLTMET_;
+  edm::InputTag theHLTJetCollectionTag_;
+  edm::EDGetTokenT<reco::CaloJetCollection> theHLTJetCollection_;
+  edm::InputTag theHLTJetTagCollectionTag_;
+  edm::EDGetTokenT<reco::JetTagCollection> theHLTJetTagCollection_;
+
+  edm::InputTag theTriggerResultsTag_;
+  edm::EDGetTokenT<edm::TriggerResults> theTriggerResults_;
+  edm::InputTag theTrigSummaryTag_;
+  edm::EDGetTokenT<trigger::TriggerEvent> theTrigSummary_;
+
+  HLTConfigProvider fHltConfig_;
+
+  std::string HLTProcess_;
+
+  std::string triggerPath_;
+  std::string triggerPathAuxiliary_;
+  std::string triggerPathLeptonAuxiliary_;
+
+  double jetPtCut_;
+  double jetEtaCut_;
+  double metCut_;
+  double htCut_;
+
+  double lep_pt_threshold_;
+  double ht_threshold_;
+  double met_threshold_;
+  double csv_threshold_;
+
+  // Histograms
+  MonitorElement* h_triggerLepPt_;
+  MonitorElement* h_triggerLepEta_;
+  MonitorElement* h_triggerLepPhi_;
+  MonitorElement* h_HT_;
+  MonitorElement* h_MET_;
+  MonitorElement* h_maxCSV_;
+  MonitorElement* h_leptonTurnOn_num_;
+  MonitorElement* h_leptonTurnOn_den_;
+  MonitorElement* h_pfHTTurnOn_num_;
+  MonitorElement* h_pfHTTurnOn_den_;
+  MonitorElement* h_pfMetTurnOn_num_;
+  MonitorElement* h_pfMetTurnOn_den_;
+  MonitorElement* h_CSVTurnOn_num_;
+  MonitorElement* h_CSVTurnOn_den_;
+  MonitorElement* h_btagTurnOn_num_;
+  MonitorElement* h_btagTurnOn_den_;
+};
+
+#endif

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Ele_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                                   electronCollection = cms.InputTag('gedGsfElectrons'),
+                                                   muonCollection = cms.InputTag(''),
+                                                   pfMetCollection = cms.InputTag('pfMet'),
+                                                   pfJetCollection = cms.InputTag('ak4PFJets'),
+                                                   jetTagCollection = cms.InputTag('pfCombinedSecondaryVertexBJetTags'),
+
+                                                   vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                                   conversionCollection = cms.InputTag('conversions'),
+                                                   beamSpot = cms.InputTag('offlineBeamSpot'),
+
+                                                   leptonFilter = cms.InputTag('hltEle15VVVLGsfTrackIsoFilter','','reHLT'),
+                                                   hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                                   hltMet = cms.InputTag(''),
+                                                   hltJets = cms.InputTag('hltSelector4CentralJetsL1FastJet','','reHLT'),
+                                                   hltJetTags = cms.InputTag('hltL3CombinedSecondaryVertexBJetTags','','reHLT'),
+
+                                                   triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                                   trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                                   hltProcess = cms.string('reHLT'),
+
+                                                   triggerPath = cms.string('HLT_Ele15_IsoVVVL_BTagtop8CSV07_PFHT400'),
+                                                   triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP85_Gsf_v'),
+                                                   triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                                   jetPtCut = cms.untracked.double(40.0),
+                                                   jetEtaCut = cms.untracked.double(3.0),
+                                                   metCut = cms.untracked.double(250.0),
+                                                   htCut = cms.untracked.double(450.0),
+
+                                                   leptonPtThreshold = cms.untracked.double(25.0),
+                                                   htThreshold = cms.untracked.double(500.0),
+                                                   metThreshold = cms.untracked.double(-1.0),
+                                                   csvThreshold = cms.untracked.double(0.898)
+                                                   )
+
+SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                                  subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_BTagtop8CSV07_PFHT400'),
+                                                                  efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den",
+        "CSVTurnOn_eff ';Offline Max CSV Discriminant;#epsilon' CSVTurnOn_num CSVTurnOn_den",
+        "btagTurnOn_eff ';Offline CSV requirements;#epsilon' btagTurnOn_num btagTurnOn_den"
+        ),
+                                                                  resolution = cms.vstring('')
+                                                                  )
+
+SUSY_HLT_Ele_HT_BTag_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Ele_HT_BTag_SingleLepton)
+
+SUSY_HLT_Ele_HT_BTag_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Ele_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                              electronCollection = cms.InputTag('gedGsfElectrons'),
+                                              muonCollection = cms.InputTag(''),
+                                              pfMetCollection = cms.InputTag('pfMet'),
+                                              pfJetCollection = cms.InputTag('ak4PFJets'),
+                                              jetTagCollection = cms.InputTag(''),
+
+                                              vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                              conversionCollection = cms.InputTag('conversions'),
+                                              beamSpot = cms.InputTag('offlineBeamSpot'),
+
+                                              leptonFilter = cms.InputTag('hltEle15GsfDphiFilter','','reHLT'),
+                                              hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                              hltMet = cms.InputTag(''),
+                                              hltJets = cms.InputTag(''),
+                                              hltJetTags = cms.InputTag(''),
+
+                                              triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                              trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                              hltProcess = cms.string('reHLT'),
+
+                                              triggerPath = cms.string('HLT_Ele15_PFHT300'),
+                                              triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP85_Gsf_v'),
+                                              triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                              jetPtCut = cms.untracked.double(40.0),
+                                              jetEtaCut = cms.untracked.double(3.0),
+                                              metCut = cms.untracked.double(250.0),
+                                              htCut = cms.untracked.double(450.0),
+
+                                              leptonPtThreshold = cms.untracked.double(25.0),
+                                              htThreshold = cms.untracked.double(450.0),
+                                              metThreshold = cms.untracked.double(-1.0),
+                                              csvThreshold = cms.untracked.double(-1.0)
+                                              )
+
+SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_PFHT300'),
+                                                             efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                             resolution = cms.vstring('')
+                                                             )
+
+SUSY_HLT_Ele_HT_Control_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Ele_HT_Control_SingleLepton)
+
+SUSY_HLT_Ele_HT_Control_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
@@ -1,0 +1,53 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Ele_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                                  electronCollection = cms.InputTag('gedGsfElectrons'),
+                                                  muonCollection = cms.InputTag(''),
+                                                  pfMetCollection = cms.InputTag('pfMet'),
+                                                  pfJetCollection = cms.InputTag('ak4PFJets'),
+                                                  jetTagCollection = cms.InputTag(''),
+
+                                                  vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                                  conversionCollection = cms.InputTag('conversions'),
+                                                  beamSpot = cms.InputTag('offlineBeamSpot'),
+
+                                                  leptonFilter = cms.InputTag('hltEle15VVVLGsfTrackIsoFilter','','reHLT'),
+                                                  hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                                  hltMet = cms.InputTag('hltPFMETProducer','','reHLT'),
+                                                  hltJets = cms.InputTag(''),
+                                                  hltJetTags = cms.InputTag(''),
+
+                                                  triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                                  trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                                  hltProcess = cms.string('reHLT'),
+
+                                                  triggerPath = cms.string('HLT_Ele15_IsoVVVL_PFHT400_PFMET70'),
+                                                  triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP85_Gsf_v'),
+                                                  triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                                  jetPtCut = cms.untracked.double(40.0),
+                                                  jetEtaCut = cms.untracked.double(3.0),
+                                                  metCut = cms.untracked.double(250.0),
+                                                  htCut = cms.untracked.double(450.0),
+
+                                                  leptonPtThreshold = cms.untracked.double(25.0),
+                                                  htThreshold = cms.untracked.double(500.0),
+                                                  metThreshold = cms.untracked.double(250.0),
+                                                  csvThreshold = cms.untracked.double(-1.0)
+                                                  )
+
+SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT400_PFMET70'),
+                                                                 efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den",
+        "pfMetTurnOn_eff ';Offline PF MET [GeV];#epsilon' pfMetTurnOn_num pfMetTurnOn_den"
+        ),
+                                                                 resolution = cms.vstring('')
+                                                                 )
+
+SUSY_HLT_Ele_HT_MET_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Ele_HT_MET_SingleLepton)
+
+SUSY_HLT_Ele_HT_MET_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Ele_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                              electronCollection = cms.InputTag('gedGsfElectrons'),
+                                              muonCollection = cms.InputTag(''),
+                                              pfMetCollection = cms.InputTag('pfMet'),
+                                              pfJetCollection = cms.InputTag('ak4PFJets'),
+                                              jetTagCollection = cms.InputTag(''),
+
+                                              vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                              conversionCollection = cms.InputTag('conversions'),
+                                              beamSpot = cms.InputTag('offlineBeamSpot'),
+
+                                              leptonFilter = cms.InputTag('hltEle15VVVLGsfTrackIsoFilter','','reHLT'),
+                                              hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                              hltMet = cms.InputTag(''),
+                                              hltJets = cms.InputTag(''),
+                                              hltJetTags = cms.InputTag(''),
+
+                                              triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                              trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                              hltProcess = cms.string('reHLT'),
+
+                                              triggerPath = cms.string('HLT_Ele15_IsoVVVL_PFHT600'),
+                                              triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP85_Gsf_v'),
+                                              triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                              jetPtCut = cms.untracked.double(40.0),
+                                              jetEtaCut = cms.untracked.double(3.0),
+                                              metCut = cms.untracked.double(250.0),
+                                              htCut = cms.untracked.double(450.0),
+
+                                              leptonPtThreshold = cms.untracked.double(25.0),
+                                              htThreshold = cms.untracked.double(750.0),
+                                              metThreshold = cms.untracked.double(-1.0),
+                                              csvThreshold = cms.untracked.double(-1.0)
+                                              )
+
+SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                             subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Ele15_IsoVVVL_PFHT600'),
+                                                             efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Electron p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                             resolution = cms.vstring('')
+                                                             )
+
+SUSY_HLT_Ele_HT_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Ele_HT_SingleLepton)
+
+SUSY_HLT_Ele_HT_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Mu_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                                  electronCollection = cms.InputTag(''),
+                                                  muonCollection = cms.InputTag('muons'),
+                                                  pfMetCollection = cms.InputTag('pfMet'),
+                                                  pfJetCollection = cms.InputTag('ak4PFJets'),
+                                                  jetTagCollection = cms.InputTag('pfCombinedSecondaryVertexBJetTags'),
+
+                                                  vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                                  conversionCollection = cms.InputTag(''),
+                                                  beamSpot = cms.InputTag(''),
+
+                                                  leptonFilter = cms.InputTag('hltL3crIsoL1sMu5L1f0L2f3QL3f15QL3crIsoRhoFiltered0p15IterTrk02','','reHLT'),
+                                                  hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                                  hltMet = cms.InputTag(''),
+                                                  hltJets = cms.InputTag('hltSelector4CentralJetsL1FastJet','','reHLT'),
+                                                  hltJetTags = cms.InputTag('hltL3CombinedSecondaryVertexBJetTags','','reHLT'),
+
+                                                  triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                                  trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                                  hltProcess = cms.string('reHLT'),
+
+                                                  triggerPath = cms.string('HLT_Mu15_IsoVVVL_BTagCSV07_PFHT400'),
+                                                  triggerPathAuxiliary = cms.string('HLT_IsoMu24_v'),
+                                                  triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                                  jetPtCut = cms.untracked.double(40.0),
+                                                  jetEtaCut = cms.untracked.double(3.0),
+                                                  metCut = cms.untracked.double(250.0),
+                                                  htCut = cms.untracked.double(450.0),
+
+                                                  leptonPtThreshold = cms.untracked.double(25.0),
+                                                  htThreshold = cms.untracked.double(500.0),
+                                                  metThreshold = cms.untracked.double(-1.0),
+                                                  csvThreshold = cms.untracked.double(0.898)
+                                                  )
+
+SUSY_HLT_Mu_HT_BTag_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                                 subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_BTagCSV07_PFHT400'),
+                                                                 efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den",
+        "CSVTurnOn_eff ';Offline b-Tag Requirements;#epsilon' CSVTurnOn_num CSVTurnOn_den",
+        "btagTurnOn_eff ';Offline CSV Requirements;#epsilon' btagTurnOn_num btagTurnOn_den"
+        ),
+                                                                 resolution = cms.vstring('')
+                                                                 )
+
+SUSY_HLT_Mu_HT_BTag_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Mu_HT_BTag_SingleLepton)
+
+SUSY_HLT_Mu_HT_BTag_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Mu_HT_BTag_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Mu_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                             electronCollection = cms.InputTag(''),
+                                             muonCollection = cms.InputTag('muons'),
+                                             pfMetCollection = cms.InputTag('pfMet'),
+                                             pfJetCollection = cms.InputTag('ak4PFJets'),
+                                             jetTagCollection = cms.InputTag(''),
+
+                                             vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                             conversionCollection = cms.InputTag(''),
+                                             beamSpot = cms.InputTag(''),
+
+                                             leptonFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f3QL3Filtered15Q','','reHLT'),
+                                             hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                             hltMet = cms.InputTag(''),
+                                             hltJets = cms.InputTag(''),
+                                             hltJetTags = cms.InputTag(''),
+
+                                             triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                             trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                             hltProcess = cms.string('reHLT'),
+
+                                             triggerPath = cms.string('HLT_Mu15_PFHT300'),
+                                             triggerPathAuxiliary = cms.string('HLT_IsoMu24_v'),
+                                             triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                             jetPtCut = cms.untracked.double(40.0),
+                                             jetEtaCut = cms.untracked.double(3.0),
+                                             metCut = cms.untracked.double(250.0),
+                                             htCut = cms.untracked.double(450.0),
+
+                                             leptonPtThreshold = cms.untracked.double(25.0),
+                                             htThreshold = cms.untracked.double(450.0),
+                                             metThreshold = cms.untracked.double(-1.0),
+                                             csvThreshold = cms.untracked.double(-1.0)
+                                             )
+
+SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                            subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_PFHT300'),
+                                                            efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                            resolution = cms.vstring('')
+                                                            )
+
+SUSY_HLT_Mu_HT_Control_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Mu_HT_Control_SingleLepton)
+
+SUSY_HLT_Mu_HT_Control_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
@@ -1,0 +1,54 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Mu_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                                 electronCollection = cms.InputTag(''),
+                                                 muonCollection = cms.InputTag('muons'),
+                                                 pfMetCollection = cms.InputTag('pfMet'),
+                                                 pfJetCollection = cms.InputTag('ak4PFJets'),
+                                                 jetTagCollection = cms.InputTag(''),
+
+                                                 vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                                 conversionCollection = cms.InputTag(''),
+                                                 beamSpot = cms.InputTag(''),
+
+                                                 leptonFilter = cms.InputTag('hltL3crIsoL1sMu5L1f0L2f3QL3f15QL3crIsoRhoFiltered0p15IterTrk02','','reHLT'),
+                                                 hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                                 hltMet = cms.InputTag('hltPFMETProducer','','reHLT'),
+                                                 hltJets = cms.InputTag(''),
+                                                 hltJetTags = cms.InputTag(''),
+
+                                                 triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                                 trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                                 hltProcess = cms.string('reHLT'),
+
+                                                 triggerPath = cms.string('HLT_Mu15_IsoVVVL_PFHT400_PFMET70'),
+                                                 triggerPathAuxiliary = cms.string('HLT_IsoMu24_v'),
+                                                 triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                                 jetPtCut = cms.untracked.double(40.0),
+                                                 jetEtaCut = cms.untracked.double(3.0),
+                                                 metCut = cms.untracked.double(250.0),
+                                                 htCut = cms.untracked.double(450.0),
+
+                                                 leptonPtThreshold = cms.untracked.double(25.0),
+                                                 htThreshold = cms.untracked.double(500.0),
+                                                 metThreshold = cms.untracked.double(250.0),
+                                                 csvThreshold = cms.untracked.double(-1.0)
+                                                 )
+
+
+SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                                subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT400_PFMET70'),
+                                                                efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den",
+        "pfMetTurnOn_eff ';Offline PF MET [GeV];#epsilon' pfMetTurnOn_num pfMetTurnOn_den"
+        ),
+                                                                resolution = cms.vstring('')
+                                                                )
+
+SUSY_HLT_Mu_HT_MET_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Mu_HT_MET_SingleLepton)
+
+SUSY_HLT_Mu_HT_MET_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
@@ -1,0 +1,52 @@
+import FWCore.ParameterSet.Config as cms
+from copy import deepcopy
+
+SUSY_HLT_Mu_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
+                                             electronCollection = cms.InputTag(''),
+                                             muonCollection = cms.InputTag('muons'),
+                                             pfMetCollection = cms.InputTag('pfMet'),
+                                             pfJetCollection = cms.InputTag('ak4PFJets'),
+                                             jetTagCollection = cms.InputTag(''),
+
+                                             vertexCollection = cms.InputTag('goodOfflinePrimaryVertices'),
+                                             conversionCollection = cms.InputTag(''),
+                                             beamSpot = cms.InputTag(''),
+
+                                             leptonFilter = cms.InputTag('hltL3crIsoL1sMu5L1f0L2f3QL3f15QL3crIsoRhoFiltered0p15IterTrk02','','reHLT'),
+                                             hltHt = cms.InputTag('hltPFHT','','reHLT'),
+                                             hltMet = cms.InputTag(''),
+                                             hltJets = cms.InputTag(''),
+                                             hltJetTags = cms.InputTag(''),
+
+                                             triggerResults = cms.InputTag('TriggerResults','','reHLT'),
+                                             trigSummary = cms.InputTag('hltTriggerSummaryAOD','','reHLT'),
+
+                                             hltProcess = cms.string('reHLT'),
+
+                                             triggerPath = cms.string('HLT_Mu15_IsoVVVL_PFHT600'),
+                                             triggerPathAuxiliary = cms.string('HLT_IsoMu24_v'),
+                                             triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
+
+                                             jetPtCut = cms.untracked.double(40.0),
+                                             jetEtaCut = cms.untracked.double(3.0),
+                                             metCut = cms.untracked.double(250.0),
+                                             htCut = cms.untracked.double(450.0),
+
+                                             leptonPtThreshold = cms.untracked.double(25.0),
+                                             htThreshold = cms.untracked.double(750.0),
+                                             metThreshold = cms.untracked.double(-1.0),
+                                             csvThreshold = cms.untracked.double(-1.0)
+                                             )
+
+SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING = cms.EDAnalyzer('DQMGenericClient',
+                                                            subDirs = cms.untracked.vstring('HLT/SUSYBSM/HLT_Mu15_IsoVVVL_PFHT600'),
+                                                            efficiency = cms.vstring(
+        "leptonTurnOn_eff ';Offline Muon p_{T} [GeV];#epsilon' leptonTurnOn_num leptonTurnOn_den",
+        "pfHTTurnOn_eff ';Offline PF H_{T} [GeV];#epsilon' pfHTTurnOn_num pfHTTurnOn_den"
+        ),
+                                                            resolution = cms.vstring('')
+                                                            )
+
+SUSY_HLT_Mu_HT_SingleLepton_FASTSIM = deepcopy(SUSY_HLT_Mu_HT_SingleLepton)
+
+SUSY_HLT_Mu_HT_SingleLepton_FASTSIM_POSTPROCESSING = deepcopy(SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING)

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
@@ -5,6 +5,14 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_inclusiveMET_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_MUON_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_inclusiveHT_aux350_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_inclusiveHT_aux600_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_MET_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_BTag_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_Control_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_MET_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_BTag_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_Control_SingleLepton_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_MUON_ER_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_HT_MUON_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_HT_MUON_ER_cff import *
@@ -18,33 +26,47 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_MuEle_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Muon_BJet_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Electron_BJet_cff import *
 
-
 SusyExoPostVal = cms.Sequence(SUSY_HLT_HT_MET_POSTPROCESSING +
-                             SUSY_HLT_InclusiveHT_POSTPROCESSING +
-                             SUSY_HLT_InclusiveMET_POSTPROCESSING +
-                             SUSY_HLT_MET_BTAG_POSTPROCESSING + 
-                             SUSY_HLT_MET_MUON_POSTPROCESSING +
-                             SUSY_HLT_InclusiveHT_aux350_POSTPROCESSING +
-                             SUSY_HLT_InclusiveHT_aux600_POSTPROCESSING +
-                             SUSY_HLT_MET_MUON_ER_POSTPROCESSING +
-                             SUSY_HLT_MET_HT_MUON_POSTPROCESSING +
-                             SUSY_HLT_MET_HT_MUON_ER_POSTPROCESSING +
-                             SUSY_HLT_MET_HT_MUON_BTAG_POSTPROCESSING + 
-                             SUSY_HLT_Razor_PostVal_POSTPROCESSING + 
-                             SUSY_HLT_CaloHT_POSTPROCESSING + 
-                             SUSY_HLT_PhotonHT_POSTPROCESSING +                             
-                             SUSY_HLT_HT_DoubleMuon_POSTPROCESSING +
-                             SUSY_HLT_HT_DoubleEle_POSTPROCESSING +
-                             SUSY_HLT_HT_MuEle_POSTPROCESSING +
-                             SUSY_HLT_Muon_BJet_POSTPROCESSING +
-                             SUSY_HLT_Electron_BJet_POSTPROCESSING)
-
+                              SUSY_HLT_InclusiveHT_POSTPROCESSING +
+                              SUSY_HLT_InclusiveMET_POSTPROCESSING +
+                              SUSY_HLT_MET_BTAG_POSTPROCESSING + 
+                              SUSY_HLT_MET_MUON_POSTPROCESSING +
+                              SUSY_HLT_InclusiveHT_aux350_POSTPROCESSING +
+                              SUSY_HLT_InclusiveHT_aux600_POSTPROCESSING +
+                              SUSY_HLT_MET_MUON_ER_POSTPROCESSING +
+                              SUSY_HLT_MET_HT_MUON_POSTPROCESSING +
+                              SUSY_HLT_MET_HT_MUON_ER_POSTPROCESSING +
+                              SUSY_HLT_MET_HT_MUON_BTAG_POSTPROCESSING + 
+                              SUSY_HLT_Razor_PostVal_POSTPROCESSING + 
+                              SUSY_HLT_CaloHT_POSTPROCESSING + 
+                              SUSY_HLT_PhotonHT_POSTPROCESSING +                             
+                              SUSY_HLT_HT_DoubleMuon_POSTPROCESSING +
+                              SUSY_HLT_HT_DoubleEle_POSTPROCESSING +
+                              SUSY_HLT_HT_MuEle_POSTPROCESSING +
+                              SUSY_HLT_Muon_BJet_POSTPROCESSING +
+                              SUSY_HLT_Electron_BJet_POSTPROCESSING +
+                              SUSY_HLT_Mu_HT_SingleLepton_POSTPROCESSING +
+                              SUSY_HLT_Mu_HT_MET_SingleLepton_POSTPROCESSING +
+                              SUSY_HLT_Mu_HT_BTag_SingleLepton_POSTPROCESSING +
+                              SUSY_HLT_Mu_HT_Control_SingleLepton_POSTPROCESSING +
+                              SUSY_HLT_Ele_HT_SingleLepton_POSTPROCESSING +
+                              SUSY_HLT_Ele_HT_MET_SingleLepton_POSTPROCESSING +
+                              SUSY_HLT_Ele_HT_BTag_SingleLepton_POSTPROCESSING +
+                              SUSY_HLT_Ele_HT_Control_SingleLepton_POSTPROCESSING)
 
 SusyExoPostVal_fastsim = cms.Sequence(SUSY_HLT_HT_MET_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_InclusiveHT_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_InclusiveMET_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_MET_BTAG_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_MET_MUON_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Mu_HT_SingleLepton_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Mu_HT_MET_SingleLepton_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Mu_HT_BTag_SingleLepton_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Mu_HT_Control_SingleLepton_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Ele_HT_SingleLepton_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Ele_HT_MET_SingleLepton_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Ele_HT_BTag_SingleLepton_FASTSIM_POSTPROCESSING +
+                                      SUSY_HLT_Ele_HT_Control_SingleLepton_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_InclusiveHT_aux350_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_InclusiveHT_aux600_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_MET_MUON_ER_FASTSIM_POSTPROCESSING +
@@ -59,4 +81,3 @@ SusyExoPostVal_fastsim = cms.Sequence(SUSY_HLT_HT_MET_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_HT_MuEle_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_Muon_BJet_FASTSIM_POSTPROCESSING +
                                       SUSY_HLT_Electron_BJet_FASTSIM_POSTPROCESSING)
-

--- a/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
@@ -5,6 +5,14 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_inclusiveMET_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_MUON_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_inclusiveHT_aux350_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_inclusiveHT_aux600_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_MET_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_BTag_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Mu_HT_Control_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_MET_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_BTag_SingleLepton_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_Ele_HT_Control_SingleLepton_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_MUON_ER_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_HT_MUON_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_MET_HT_MUON_ER_cff import *
@@ -18,7 +26,6 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_MuEle_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Muon_BJet_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Electron_BJet_cff import *
 
-
 HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_InclusiveHT +
                                 SUSY_HLT_InclusiveMET +
@@ -26,6 +33,14 @@ HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_MET_MUON +
                                 SUSY_HLT_InclusiveHT_aux350 + 
                                 SUSY_HLT_InclusiveHT_aux600 +
+                                SUSY_HLT_Mu_HT_SingleLepton +
+                                SUSY_HLT_Mu_HT_MET_SingleLepton +
+                                SUSY_HLT_Mu_HT_BTag_SingleLepton +
+                                SUSY_HLT_Mu_HT_Control_SingleLepton +
+                                SUSY_HLT_Ele_HT_SingleLepton +
+                                SUSY_HLT_Ele_HT_MET_SingleLepton +
+                                SUSY_HLT_Ele_HT_BTag_SingleLepton +
+                                SUSY_HLT_Ele_HT_Control_SingleLepton +
                                 SUSY_HLT_MET_MUON_ER +
                                 SUSY_HLT_MET_HT_MUON +
                                 SUSY_HLT_MET_HT_MUON_ER +
@@ -45,12 +60,19 @@ HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_Muon_BJet +
                                 SUSY_HLT_Electron_BJet)
 
-
 HLTSusyExoValSeq_FastSim = cms.Sequence(SUSY_HLT_HT_MET_FASTSIM + 
                                         SUSY_HLT_InclusiveHT_FASTSIM + 
                                         SUSY_HLT_InclusiveMET_FASTSIM + 
                                         SUSY_HLT_MET_BTAG_FASTSIM +
                                         SUSY_HLT_MET_MUON_FASTSIM +
+                                        SUSY_HLT_Mu_HT_SingleLepton_FASTSIM +
+                                        SUSY_HLT_Mu_HT_MET_SingleLepton_FASTSIM +
+                                        SUSY_HLT_Mu_HT_BTag_SingleLepton_FASTSIM +
+                                        SUSY_HLT_Mu_HT_Control_SingleLepton_FASTSIM +
+                                        SUSY_HLT_Ele_HT_SingleLepton_FASTSIM +
+                                        SUSY_HLT_Ele_HT_MET_SingleLepton_FASTSIM +
+                                        SUSY_HLT_Ele_HT_BTag_SingleLepton_FASTSIM +
+                                        SUSY_HLT_Ele_HT_Control_SingleLepton_FASTSIM +
                                         SUSY_HLT_InclusiveHT_aux350_FASTSIM + 
                                         SUSY_HLT_InclusiveHT_aux600_FASTSIM +
                                         SUSY_HLT_MET_MUON_ER_FASTSIM +
@@ -71,4 +93,3 @@ HLTSusyExoValSeq_FastSim = cms.Sequence(SUSY_HLT_HT_MET_FASTSIM +
                                         SUSY_HLT_HT_MuEle_FASTSIM +
                                         SUSY_HLT_Muon_BJet_FASTSIM +
                                         SUSY_HLT_Electron_BJet_FASTSIM)
-

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_SingleLepton.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_SingleLepton.cc
@@ -1,0 +1,706 @@
+#include "HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_SingleLepton.h"
+
+#include <limits>
+#include <algorithm>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/Common/interface/TriggerNames.h"
+
+#include "DataFormats/HLTReco/interface/TriggerObject.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "DataFormats/EgammaCandidates/interface/ConversionFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Conversion.h"
+#include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
+
+namespace{
+  bool Contains(const std::string &text,
+		const std::string &pattern){
+    return text.find(pattern)!=std::string::npos;
+  }
+
+  void SetBinLabels(MonitorElement * const me){
+    if(!me) return;
+    me->setBinLabel(1, "No CSV Reqs.");
+    me->setBinLabel(2, "N_{CSVL} >= 1");
+    me->setBinLabel(3, "N_{CSVL} >= 2");
+    me->setBinLabel(4, "N_{CSVL} >= 3");
+    me->setBinLabel(5, "N_{CSVL} >= 4");
+    me->setBinLabel(6, "N_{CSVM} >= 1");
+    me->setBinLabel(7, "N_{CSVM} >= 2");
+    me->setBinLabel(8, "N_{CSVM} >= 3");
+    me->setBinLabel(9, "N_{CSVM} >= 4");
+    me->setBinLabel(10, "N_{CSVT} >= 1");
+    me->setBinLabel(11, "N_{CSVT} >= 2");
+    me->setBinLabel(12, "N_{CSVT} >= 3");
+    me->setBinLabel(13, "N_{CSVT} >= 4");
+  }
+
+  double GetMass(const double E, const double px, const double py, const double pz){
+    const double rx=px/E;
+    const double ry=py/E;
+    const double rz=pz/E;
+    return E*sqrt(1.0-rx*rx-ry*ry-rz*rz);
+  }
+
+  bool IsGood(const reco::GsfElectron &el, const reco::Vertex::Point &pv_position,
+              const reco::BeamSpot::Point &bs_position,
+              const edm::Handle<reco::ConversionCollection> &convs){
+    const float dEtaIn = el.deltaEtaSuperClusterTrackAtVtx();
+    const float dPhiIn = el.deltaPhiSuperClusterTrackAtVtx();
+    const float sigmaietaieta = el.full5x5_sigmaIetaIeta();
+    const float hOverE = el.hcalOverEcal();
+    float d0 = 0.0, dz=0.0;
+    try{
+      d0=-(el.gsfTrack()->dxy(pv_position));
+      dz = el.gsfTrack()->dz(pv_position);
+    }catch(...){
+      edm::LogError("SUSY_HLT_SingleLepton") << "Could not read electron.gsfTrack().\n";
+      return false;
+    }
+    float ooemoop = 1e30;
+    if(el.ecalEnergy()>0.0 && std::isfinite(el.ecalEnergy())){
+      ooemoop = fabs(1.0/el.ecalEnergy() - el.eSuperClusterOverP()/el.ecalEnergy());
+    }
+    const auto &iso = el.pfIsolationVariables();
+    const float absiso = iso.sumChargedHadronPt
+      + std::max(0.0, iso.sumNeutralHadronEt + iso.sumPhotonEt -0.5 * iso.sumPUPt);
+    const float relisowithdb = absiso/el.pt();
+
+    bool pass_conversion = false;
+    if(convs.isValid()){
+      try{
+        pass_conversion = !ConversionTools::hasMatchedConversion(el, convs, bs_position);
+      }catch(...){
+        edm::LogError("SUSY_HLT_SingleLepton") << "Electron conversion matching failed.\n";
+        return false;
+      }
+    }
+
+    float etasc = 0.0;
+    try{
+      etasc = el.superCluster()->eta();
+    }catch(...){
+      edm::LogError("SUSY_HLT_SingleLepton") << "Could not read electron.superCluster().\n";
+      return false;
+    }
+    if(fabs(etasc)>2.5){
+      return false;
+    }else if(fabs(etasc)>1.479){
+      if(fabs(dEtaIn)>0.0106) return false;
+      if(fabs(dPhiIn)>0.0359) return false;
+      if(sigmaietaieta>0.0305) return false;
+      if(hOverE>0.0835) return false;
+      if(fabs(d0)>0.0163) return false;
+      if(fabs(dz)>0.5999) return false;
+      if(fabs(ooemoop)>0.1126) return false;
+      if(relisowithdb>0.2075) return false;
+      if(!pass_conversion) return false;
+    }else{
+      if(fabs(dEtaIn)>0.0091) return false;
+      if(fabs(dPhiIn)>0.031) return false;
+      if(sigmaietaieta>0.0106) return false;
+      if(hOverE>0.0532) return false;
+      if(fabs(d0)>0.0126) return false;
+      if(fabs(dz)>0.0116) return false;
+      if(fabs(ooemoop)>0.0609) return false;
+      if(relisowithdb>0.1649) return false;
+      if(!pass_conversion) return false;
+    }
+    return true;
+  }
+
+  bool IsGood(const reco::Muon &mu, const reco::Vertex::Point &pv_position){
+    if(!mu.isGlobalMuon()) return false;
+    if(!mu.isPFMuon()) return false;
+    try{
+      if(mu.globalTrack()->normalizedChi2()>=10.) return false;
+      if(mu.globalTrack()->hitPattern().numberOfValidMuonHits()<=0) return false;
+    }catch(...){
+      edm::LogWarning("SUSY_HLT_SingleLepton") << "Could not read muon.globalTrack().\n";
+      return false;
+    }
+    if(mu.numberOfMatchedStations()<=1) return false;
+    try{
+      if(fabs(mu.muonBestTrack()->dxy(pv_position))>=0.2) return false;
+      if(fabs(mu.muonBestTrack()->dz(pv_position))>=0.5) return false;
+    }catch(...){
+      edm::LogWarning("SUSY_HLT_SingleLepton") << "Could not read muon.muonBestTrack().\n";
+      return false;
+    }
+    try{
+      if(mu.innerTrack()->hitPattern().numberOfValidPixelHits()<=0) return false;
+      if(mu.innerTrack()->hitPattern().trackerLayersWithMeasurement()<=5) return false;
+    }catch(...){
+      edm::LogWarning("SUSY_HLT_SingleLepton") << "Could not read muon.innerTrack().\n";
+      return false;
+    }
+    return true;
+  }
+}
+
+SUSY_HLT_SingleLepton::SUSY_HLT_SingleLepton(const edm::ParameterSet &ps):
+  theElectronTag_(ps.getParameter<edm::InputTag>("electronCollection")),
+  theElectronCollection_(consumes<reco::GsfElectronCollection>(theElectronTag_)),
+  theMuonTag_(ps.getParameter<edm::InputTag>("muonCollection")),
+  theMuonCollection_(consumes<reco::MuonCollection>(theMuonTag_)),
+  thePfMETTag_(ps.getParameter<edm::InputTag>("pfMetCollection")),
+  thePfMETCollection_(consumes<reco::PFMETCollection>(thePfMETTag_)),
+  thePfJetTag_(ps.getParameter<edm::InputTag>("pfJetCollection")),
+  thePfJetCollection_(consumes<reco::PFJetCollection>(thePfJetTag_)),
+  theJetTagTag_(ps.getParameter<edm::InputTag>("jetTagCollection")),
+  theJetTagCollection_(consumes<reco::JetTagCollection>(theJetTagTag_)),
+
+  theVertexCollectionTag_(ps.getParameter<edm::InputTag>("vertexCollection")),
+  theVertexCollection_(consumes<reco::VertexCollection>(theVertexCollectionTag_)),
+  theConversionCollectionTag_(ps.getParameter<edm::InputTag>("conversionCollection")),
+  theConversionCollection_(consumes<reco::ConversionCollection>(theConversionCollectionTag_)),
+  theBeamSpotTag_(ps.getParameter<edm::InputTag>("beamSpot")),
+  theBeamSpot_(consumes<reco::BeamSpot>(theBeamSpotTag_)),
+
+  theLeptonFilterTag_(ps.getParameter<edm::InputTag>("leptonFilter")),
+  theHLTHTTag_(ps.getParameter<edm::InputTag>("hltHt")),
+  theHLTHT_(consumes<reco::METCollection>(theHLTHTTag_)),
+  theHLTMETTag_(ps.getParameter<edm::InputTag>("hltMet")),
+  theHLTMET_(consumes<reco::METCollection>(theHLTMETTag_)),
+  theHLTJetCollectionTag_(ps.getParameter<edm::InputTag>("hltJets")),
+  theHLTJetCollection_(consumes<reco::CaloJetCollection>(theHLTJetCollectionTag_)),
+  theHLTJetTagCollectionTag_(ps.getParameter<edm::InputTag>("hltJetTags")),
+  theHLTJetTagCollection_(consumes<reco::JetTagCollection>(theHLTJetTagCollectionTag_)),
+
+  theTriggerResultsTag_(ps.getParameter<edm::InputTag>("triggerResults")),
+  theTriggerResults_(consumes<edm::TriggerResults>(theTriggerResultsTag_)),
+  theTrigSummaryTag_(ps.getParameter<edm::InputTag>("trigSummary")),
+  theTrigSummary_(consumes<trigger::TriggerEvent>(theTrigSummaryTag_)),
+
+  fHltConfig_(),
+
+  HLTProcess_(ps.getParameter<std::string>("hltProcess")),
+
+  triggerPath_(ps.getParameter<std::string>("triggerPath")),
+  triggerPathAuxiliary_(ps.getParameter<std::string>("triggerPathAuxiliary")),
+  triggerPathLeptonAuxiliary_(ps.getParameter<std::string>("triggerPathLeptonAuxiliary")),
+
+  jetPtCut_(ps.getUntrackedParameter<double>("jetPtCut")),
+  jetEtaCut_(ps.getUntrackedParameter<double>("jetEtaCut")),
+  metCut_(ps.getUntrackedParameter<double>("metCut")),
+  htCut_(ps.getUntrackedParameter<double>("htCut")),
+
+  lep_pt_threshold_(ps.getUntrackedParameter<double>("leptonPtThreshold")),
+  ht_threshold_(ps.getUntrackedParameter<double>("htThreshold")),
+  met_threshold_(ps.getUntrackedParameter<double>("metThreshold")),
+  csv_threshold_(ps.getUntrackedParameter<double>("csvThreshold")),
+
+  h_triggerLepPt_(nullptr),
+  h_triggerLepEta_(nullptr),
+  h_triggerLepPhi_(nullptr),
+  h_HT_(nullptr),
+  h_MET_(nullptr),
+  h_maxCSV_(nullptr),
+  h_leptonTurnOn_num_(nullptr),
+  h_leptonTurnOn_den_(nullptr),
+  h_pfHTTurnOn_num_(nullptr),
+  h_pfHTTurnOn_den_(nullptr),
+  h_pfMetTurnOn_num_(nullptr),
+  h_pfMetTurnOn_den_(nullptr),
+  h_CSVTurnOn_num_(nullptr),
+  h_CSVTurnOn_den_(nullptr),
+  h_btagTurnOn_num_(nullptr),
+  h_btagTurnOn_den_(nullptr){
+  edm::LogInfo("SUSY_HLT_SingleLepton")
+    << "Constructor SUSY_HLT_SingleLepton::SUSY_HLT_SingleLepton\n";
+  }
+
+SUSY_HLT_SingleLepton::~SUSY_HLT_SingleLepton(){
+  edm::LogInfo("SUSY_HLT_SingleLepton")
+    << "Destructor SUSY_HLT_SingleLepton::~SUSY_HLT_SingleLepton\n";
+}
+
+void SUSY_HLT_SingleLepton::dqmBeginRun(const edm::Run &run, const edm::EventSetup &e){
+  bool changed;
+
+  if(!fHltConfig_.init(run, e, HLTProcess_, changed)){
+    edm::LogError("SUSY_HLT_SingleLepton")
+      << "Initialization of HLTConfigProvider failed!!\n";
+    return;
+  }
+
+  bool pathFound = false;
+  for(const auto &trig_name: fHltConfig_.triggerNames()){
+    if(Contains(trig_name, triggerPath_)) pathFound = true;
+  }
+
+  if(!pathFound){
+    edm::LogError ("SUSY_HLT_SingleLepton") << "Path not found: " << triggerPath_ << '\n';
+    return;
+  }
+
+  edm::LogInfo("SUSY_HLT_SingleLepton") << "SUSY_HLT_SingleLepton::beginRun\n";
+}
+
+void SUSY_HLT_SingleLepton::bookHistograms(DQMStore::IBooker &ibooker,
+                                           const edm::Run &, const edm::EventSetup &){
+  edm::LogInfo("SUSY_HLT_SingleLepton") << "SUSY_HLT_SingleLepton::bookHistograms\n";
+  //book at beginRun
+  ibooker.cd();
+  ibooker.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);
+
+  bool is_mu = false;
+  bool is_ele = false;
+  if(theElectronTag_.label() == "" && theMuonTag_.label() != ""){
+    is_mu=true;
+  }else if(theElectronTag_.label() != "" && theMuonTag_.label() == ""){
+    is_ele=true;
+  }
+  std::string lepton="lepton", Lepton="Lepton";
+  if(is_mu && !is_ele){
+    lepton="muon";
+    Lepton="Muon";
+  }else if(is_ele && !is_mu){
+    lepton="electron";
+    Lepton="Electron";
+  }
+
+  //online quantities
+  h_triggerLepPt_ = ibooker.book1D("triggerLepPt",
+                                   (";"+Lepton+" p_{T} [GeV];").c_str(),
+                                   20, 0.0, 500.0);
+  h_triggerLepEta_ = ibooker.book1D("triggerLepEta",
+                                    (";"+Lepton+" #eta;").c_str(),
+                                    20, -3.0, 3.0);
+  h_triggerLepPhi_ = ibooker.book1D("triggerLepPhi",
+                                    (";"+Lepton+" #phi;").c_str(),
+                                    20, -3.5, 3.5);
+
+  if(theHLTHTTag_.label()!=""){
+    h_HT_ = ibooker.book1D("HT",
+                           ";HLT HT [GeV];",
+                           40, 0.0, 1000.0);
+  }
+
+  if(theHLTMETTag_.label()!=""){
+    h_MET_ = ibooker.book1D("MET",
+                            ";HLT MET [GeV];",
+                            40, 0.0, 1000.0);
+  }
+
+  if(theHLTJetCollectionTag_.label()!="" && theHLTJetTagCollectionTag_.label()!=""){
+    h_maxCSV_ = ibooker.book1D("maxCSV",
+                               ";Max HLT CSV;",
+                               20, 0.0, 1.0);
+  }
+
+  //num and den hists to be divided in harvesting step to make turn on curves
+  h_leptonTurnOn_num_ = ibooker.book1D("leptonTurnOn_num",
+                                       ("Numerator;Offline "+lepton+" p_{T} [GeV];").c_str(),
+                                       30, 0.0, 150);
+  h_leptonTurnOn_den_ = ibooker.book1D("leptonTurnOn_den",
+                                       ("Denominator;Offline "+lepton+" p_{T} [GeV];").c_str(),
+                                       30, 0.0, 150.0);
+  h_pfHTTurnOn_num_ = ibooker.book1D("pfHTTurnOn_num",
+                                     "Numerator;Offline H_{T} [GeV];",
+                                     30, 0.0, 1500.0 );
+  h_pfHTTurnOn_den_ = ibooker.book1D("pfHTTurnOn_den",
+                                     "Denominator;Offline H_{T} [GeV];",
+                                     30, 0.0, 1500.0 );
+
+  if(theHLTMETTag_.label()!=""){
+    h_pfMetTurnOn_num_ = ibooker.book1D("pfMetTurnOn_num",
+                                        "Numerator;Offline MET [GeV];",
+                                        20, 0.0, 500.0 );
+    h_pfMetTurnOn_den_ = ibooker.book1D("pfMetTurnOn_den",
+                                        "Denominator;Offline MET [GeV];",
+                                        20, 0.0, 500.0 );
+  }
+
+  if(theHLTJetCollectionTag_.label()!="" && theHLTJetTagCollectionTag_.label()!=""){
+    h_CSVTurnOn_num_ = ibooker.book1D("CSVTurnOn_num",
+                                      "Numerator;Offline Max CSV Discriminant;",
+                                      20, 0.0, 1.0);
+    h_CSVTurnOn_den_ = ibooker.book1D("CSVTurnOn_den",
+                                      "Denominator;Offline Max CSV Discriminant;",
+                                      20, 0.0, 1.0);
+
+    h_btagTurnOn_num_ = ibooker.book1D("btagTurnOn_num",
+                                       "Numerator;Offline CSV Requirement;",
+                                       13, -0.5, 12.5);
+    h_btagTurnOn_den_ = ibooker.book1D("btagTurnOn_den",
+                                       "Denominator;Offline CSV Requirements;",
+                                       13, -0.5, 12.5);
+
+    SetBinLabels(h_btagTurnOn_num_);
+    SetBinLabels(h_btagTurnOn_den_);
+  }
+  ibooker.cd();
+}
+
+void SUSY_HLT_SingleLepton::beginLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
+                                                 const edm::EventSetup &context){
+  edm::LogInfo("SUSY_HLT_SingleLepton") << "SUSY_HLT_SingleLepton::beginLuminosityBlock\n";
+}
+
+void SUSY_HLT_SingleLepton::analyze(const edm::Event &e, const edm::EventSetup &eSetup){
+  edm::LogInfo("SUSY_HLT_SingleLepton") << "SUSY_HLT_SingleLepton::analyze\n";
+
+
+  //HLT HT
+  edm::Handle<reco::METCollection> HLTHT;
+  if(theHLTHTTag_.label() != ""){
+    e.getByToken(theHLTHT_, HLTHT);
+    if( !HLTHT.isValid() ){
+      edm::LogInfo("SUSY_HLT_SingleLepton")
+        << "Invalid METCollection: " << theHLTHTTag_.label() << '\n';
+    }
+  }
+
+  //HLT MET
+  edm::Handle<reco::METCollection> HLTMET;
+  if(theHLTMETTag_.label() != ""){
+    e.getByToken(theHLTMET_, HLTMET);
+    if( !HLTMET.isValid() ){
+      edm::LogInfo("SUSY_HLT_SingleLepton")
+        << "Invalid METCollection: " << theHLTMETTag_.label() << '\n';
+    }
+  }
+
+  //HLT Jets
+  edm::Handle<reco::CaloJetCollection> HLTJetCollection;
+  if(theHLTJetCollectionTag_.label() != ""){
+    e.getByToken(theHLTJetCollection_, HLTJetCollection);
+    if( !HLTJetCollection.isValid() ){
+      edm::LogInfo("SUSY_HLT_SingleLepton")
+        << "Invalid CaloJetCollection: " << theHLTJetCollectionTag_.label() << '\n';
+    }
+  }
+
+  //HLT Jet Tags
+  edm::Handle<reco::JetTagCollection> HLTJetTagCollection;
+  if(theHLTJetTagCollectionTag_.label() != ""){
+    e.getByToken(theHLTJetTagCollection_, HLTJetTagCollection);
+    if( !HLTJetTagCollection.isValid() ){
+      edm::LogInfo("SUSY_HLT_SingleLepton")
+        << "Invalid JetTagCollection: " << theHLTJetTagCollectionTag_.label() << '\n';
+    }
+  }
+
+  //Vertex
+  edm::Handle<reco::VertexCollection> VertexCollection;
+  if(theVertexCollectionTag_.label() != ""){
+    e.getByToken(theVertexCollection_, VertexCollection);
+    if( !VertexCollection.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid VertexCollection: " << theVertexCollectionTag_.label() << '\n';
+    }
+  }
+
+  //Conversions
+  edm::Handle<reco::ConversionCollection> ConversionCollection;
+  if(theConversionCollectionTag_.label() != ""){
+    e.getByToken(theConversionCollection_, ConversionCollection);
+    if( !ConversionCollection.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid ConversionCollection: " << theConversionCollectionTag_.label() << '\n';
+    }
+  }
+
+  //Beam Spot
+  edm::Handle<reco::BeamSpot> BeamSpot;
+  if(theBeamSpotTag_.label() != ""){
+    e.getByToken(theBeamSpot_, BeamSpot);
+    if( !BeamSpot.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid BeamSpot: " << theBeamSpotTag_.label() << '\n';
+    }
+  }
+
+  //MET
+  edm::Handle<reco::PFMETCollection> pfMETCollection;
+  if(thePfMETTag_.label() != ""){
+    e.getByToken(thePfMETCollection_, pfMETCollection);
+    if( !pfMETCollection.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid PFMETCollection: " << thePfMETTag_.label() << '\n';
+    }
+  }
+
+  //Jets
+  edm::Handle<reco::PFJetCollection> pfJetCollection;
+  if(thePfJetTag_.label() != ""){
+    e.getByToken (thePfJetCollection_,pfJetCollection);
+    if( !pfJetCollection.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid PFJetCollection: " << thePfJetTag_.label() << '\n';
+    }
+  }
+
+  //b-tags
+  edm::Handle<reco::JetTagCollection> jetTagCollection;
+  if(theJetTagTag_.label() != ""){
+    e.getByToken(theJetTagCollection_, jetTagCollection);
+    if( !jetTagCollection.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid JetTagCollection: " << theJetTagTag_.label() << '\n';
+    }
+  }
+
+  //Electron
+  edm::Handle<reco::GsfElectronCollection> ElectronCollection;
+  if(theElectronTag_.label() != ""){
+    e.getByToken (theElectronCollection_, ElectronCollection);
+    if( !ElectronCollection.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid GsfElectronCollection: " << theElectronTag_.label() << '\n';
+    }
+  }
+
+  //Muon
+  edm::Handle<reco::MuonCollection> MuonCollection;
+  if(theMuonTag_.label() != ""){
+    e.getByToken (theMuonCollection_, MuonCollection);
+    if( !MuonCollection.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid MuonCollection: " << theMuonTag_.label() << '\n';
+    }
+  }
+
+  //Trigger
+  edm::Handle<edm::TriggerResults> hltresults;
+  if(theTriggerResultsTag_.label() != ""){
+    e.getByToken(theTriggerResults_, hltresults);
+    if( !hltresults.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid TriggerResults: " << theTriggerResultsTag_.label() << '\n';
+    }
+  }
+  edm::Handle<trigger::TriggerEvent> triggerSummary;
+  if(theTrigSummaryTag_.label() != ""){
+    e.getByToken(theTrigSummary_, triggerSummary);
+    if( !triggerSummary.isValid() ){
+      edm::LogWarning("SUSY_HLT_SingleLepton")
+        << "Invalid TriggerEvent: " << theTrigSummaryTag_.label() << '\n';
+    }
+  }
+
+  //Get online leptons
+  std::vector<float> ptLepton, etaLepton, phiLepton;
+  if(triggerSummary.isValid()){
+    //Leptons
+    size_t filterIndex = triggerSummary->filterIndex(theLeptonFilterTag_);
+    trigger::TriggerObjectCollection triggerObjects = triggerSummary->getObjects();
+    if( !(filterIndex >= triggerSummary->sizeFilters()) ){
+      for(const auto &key: triggerSummary->filterKeys(filterIndex)){
+        const trigger::TriggerObject &foundObject = triggerObjects[key];
+
+        if(h_triggerLepPt_) h_triggerLepPt_->Fill(foundObject.pt());
+        if(h_triggerLepEta_) h_triggerLepEta_->Fill(foundObject.eta());
+        if(h_triggerLepPhi_) h_triggerLepPhi_->Fill(foundObject.phi());
+
+        ptLepton.push_back(foundObject.pt());
+        etaLepton.push_back(foundObject.eta());
+        phiLepton.push_back(foundObject.phi());
+      }
+    }
+  }
+
+  //Get online ht and met
+  const float hlt_ht = ((HLTHT.isValid() && HLTHT->size())?HLTHT->front().sumEt():-1.0);
+  if(h_HT_) h_HT_->Fill(hlt_ht);
+  const float hlt_met = ((HLTMET.isValid() && HLTMET->size())?HLTMET->front().pt():-1.0);
+  if(h_MET_) h_MET_->Fill(hlt_met);
+
+  //Get online csv and fill plot
+  float hlt_csv = -1.0;
+  if(HLTJetCollection.isValid() && HLTJetTagCollection.isValid()){
+    for(const auto &jet: *HLTJetTagCollection){
+      if(jet.second>hlt_csv) hlt_csv = jet.second;
+    }
+  }
+  if(h_maxCSV_) h_maxCSV_->Fill(hlt_csv);
+
+  //Test whether main and auxilliary triggers fired
+  bool hasFired = false;
+  bool hasFiredAuxiliary = false;
+  bool hasFiredLeptonAuxiliary = false;
+  if(hltresults.isValid()){
+    const edm::TriggerNames &trigNames = e.triggerNames(*hltresults);
+    for( unsigned int hltIndex = 0; hltIndex < trigNames.size(); ++hltIndex ){
+      if(hltresults->wasrun(hltIndex) && hltresults->accept(hltIndex)){
+        const std::string& name = trigNames.triggerName(hltIndex);
+        if(Contains(name, triggerPath_)) hasFired=true;
+        if(Contains(name, triggerPathAuxiliary_)) hasFiredAuxiliary=true;
+	if(Contains(name, triggerPathLeptonAuxiliary_)) hasFiredLeptonAuxiliary=true;
+      }
+    }
+  }
+
+  //Get offline HT
+  double pfHT = -1.0;
+  if(pfJetCollection.isValid()){
+    pfHT=0.0;
+    for(const auto &pfjet: *pfJetCollection){
+      if(pfjet.pt() < jetPtCut_) continue;
+      if(fabs(pfjet.eta()) > jetEtaCut_) continue;
+      pfHT += pfjet.pt();
+    }
+  }
+
+  //Get offline MET
+  double pfMET = -1.0;
+  if(pfMETCollection.isValid() && pfMETCollection->size()){
+    pfMET = pfMETCollection->front().et();
+  }
+
+  //Get offline b-tagging info
+  float maxCSV = -1.0;
+  unsigned num_csvl = 0;
+  unsigned num_csvm = 0;
+  unsigned num_csvt = 0;
+  if(jetTagCollection.isValid()){
+    for(const auto &jet: *jetTagCollection){
+      const float CSV = jet.second;
+      if(jet.first->pt()>jetPtCut_){
+        if(CSV>maxCSV){
+          maxCSV=CSV;
+        }
+        if(CSV>0.244){
+          ++num_csvl;
+          if(CSV>0.679){
+            ++num_csvm;
+            if(CSV>0.898){
+              ++num_csvt;
+            }
+          }
+        }
+      }
+    }
+  }
+  if(h_maxCSV_) h_maxCSV_->Fill(maxCSV);
+
+  //Fill lepton pt efficiency plot
+  double lep_max_pt = -1.0;
+  if(VertexCollection.isValid() && VertexCollection->size()){//for quality checks
+    //Try to find a reco electron
+    if(ElectronCollection.isValid()
+       && ConversionCollection.isValid()
+       && BeamSpot.isValid()){
+      for(const auto &electron: *ElectronCollection){
+        if(IsGood(electron, VertexCollection->front().position(),
+                  BeamSpot->position(), ConversionCollection)){
+          if(electron.pt()>lep_max_pt) lep_max_pt=electron.pt();
+        }
+      }
+    }
+
+    //Try to find a reco muon
+    if(MuonCollection.isValid()){
+      for(const auto &muon: *MuonCollection){
+        if(IsGood(muon, VertexCollection->front().position())){
+          if(muon.pt()>lep_max_pt){
+            lep_max_pt=muon.pt();
+          }
+        }
+      }
+    }
+  }
+
+  const bool lep_plateau = lep_max_pt>lep_pt_threshold_ || lep_pt_threshold_<0.0;
+  const bool ht_plateau = pfHT>ht_threshold_ || ht_threshold_<0.0;
+  const bool met_plateau = pfMET>met_threshold_ || met_threshold_<0.0;
+  const bool csv_plateau = maxCSV>csv_threshold_ || csv_threshold_<0.0;
+
+  //Fill lepton turn-on histograms
+  if(hasFiredLeptonAuxiliary || triggerPathLeptonAuxiliary_=="" || !e.isRealData()){
+    //Fill histograms using highest pt reco lepton
+    if(ht_plateau && met_plateau && csv_plateau
+       && (pfMET>metCut_ || metCut_<0.0)
+       && (pfHT>htCut_ || htCut_<0.0)){
+      if(h_leptonTurnOn_den_) h_leptonTurnOn_den_->Fill(lep_max_pt);
+      if(h_leptonTurnOn_num_ && hasFired) h_leptonTurnOn_num_->Fill(lep_max_pt);
+    }
+  }
+
+  //Fill remaining turn-on histograms
+  if(hasFiredAuxiliary || triggerPathAuxiliary_=="" || !e.isRealData()){
+    //Fill HT efficiency plot
+    if(lep_plateau && met_plateau && csv_plateau){
+      if(h_pfHTTurnOn_den_) h_pfHTTurnOn_den_->Fill(pfHT);
+      if(h_pfHTTurnOn_num_ && hasFired) h_pfHTTurnOn_num_->Fill(pfHT);
+    }
+
+    //Fill MET efficiency plot
+    if(lep_plateau && ht_plateau && csv_plateau){
+      if(h_pfMetTurnOn_den_) h_pfMetTurnOn_den_->Fill(pfMET);
+      if(h_pfMetTurnOn_num_ && hasFired) h_pfMetTurnOn_num_->Fill(pfMET);
+    }
+
+    //Fill CSV efficiency plot
+    if(lep_plateau && ht_plateau && met_plateau){
+      if(h_CSVTurnOn_den_) h_CSVTurnOn_den_->Fill(maxCSV);
+      if(h_CSVTurnOn_num_ && hasFired) h_CSVTurnOn_num_->Fill(maxCSV);
+
+      if(h_btagTurnOn_den_){
+        switch(num_csvl){
+        default: h_btagTurnOn_den_->Fill(4);
+        case 3 : h_btagTurnOn_den_->Fill(3);
+        case 2 : h_btagTurnOn_den_->Fill(2);
+        case 1 : h_btagTurnOn_den_->Fill(1);
+        case 0 : h_btagTurnOn_den_->Fill(0);
+        }
+        switch(num_csvm){
+        default: h_btagTurnOn_den_->Fill(8);
+        case 3 : h_btagTurnOn_den_->Fill(7);
+        case 2 : h_btagTurnOn_den_->Fill(6);
+        case 1 : h_btagTurnOn_den_->Fill(5);
+        case 0 : break;//Don't double count in the no tag bin
+        }
+        switch(num_csvt){
+        default: h_btagTurnOn_den_->Fill(12);
+        case 3 : h_btagTurnOn_den_->Fill(11);
+        case 2 : h_btagTurnOn_den_->Fill(10);
+        case 1 : h_btagTurnOn_den_->Fill(9);
+        case 0 : break;//Don't double count in the no tag bin
+        }
+      }
+      if(h_btagTurnOn_num_ && hasFired){
+        switch(num_csvl){
+        default: h_btagTurnOn_num_->Fill(4);
+        case 3 : h_btagTurnOn_num_->Fill(3);
+        case 2 : h_btagTurnOn_num_->Fill(2);
+        case 1 : h_btagTurnOn_num_->Fill(1);
+        case 0 : h_btagTurnOn_num_->Fill(0);
+        }
+        switch(num_csvm){
+        default: h_btagTurnOn_num_->Fill(8);
+        case 3 : h_btagTurnOn_num_->Fill(7);
+        case 2 : h_btagTurnOn_num_->Fill(6);
+        case 1 : h_btagTurnOn_num_->Fill(5);
+        case 0 : break;//Don't double count in the no tag bin
+        }
+        switch(num_csvt){
+        default: h_btagTurnOn_num_->Fill(12);
+        case 3 : h_btagTurnOn_num_->Fill(11);
+        case 2 : h_btagTurnOn_num_->Fill(10);
+        case 1 : h_btagTurnOn_num_->Fill(9);
+        case 0 : break;//Don't double count in the no tag bin
+        }
+      }
+    }
+  }
+}
+
+void SUSY_HLT_SingleLepton::endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
+                                               const edm::EventSetup &eSetup){
+  edm::LogInfo("SUSY_HLT_SingleLepton")
+    << "SUSY_HLT_SingleLepton::endLuminosityBlock\n";
+}
+
+void SUSY_HLT_SingleLepton::endRun(const edm::Run &run, const edm::EventSetup &eSetup){
+  edm::LogInfo("SUSY_HLT_SingleLepton") << "SUSY_HLT_SingleLepton::endRun\n";
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(SUSY_HLT_SingleLepton);


### PR DESCRIPTION
PR adds DQM modules for single lepton+HT SUSY triggers not included in #6255:
HLT_Ele15_IsoVVVL_BTagtop8CSV07_PFHT400
HLT_Ele15_IsoVVVL_PFHT400_PFMET70
HLT_Ele15_IsoVVVL_PFHT600
HLT_Ele15_PFHT300
HLT_Mu15_IsoVVVL_BTagCSV07_PFHT400
HLT_Mu15_IsoVVVL_PFHT400_PFMET70
HLT_Mu15_IsoVVVL_PFHT600
HLT_Mu15_PFHT300

Forward port of #6520 to CMSSW_7_4_X. Merging directly since the latter is fully signed.
