### PR TITLE
Fix pile-up modules reconfiguration (CMSSW_7_4_X)

### DIFF
--- a/CommonTools/ParticleFlow/python/Isolation/electronPFIsolationDepositsPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/electronPFIsolationDepositsPFBRECO_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.tools_cfi import *
+
+#Now prepare the iso deposits
+elPFIsoDepositChargedPFBRECO=isoDepositReplace('pfSelectedElectronsPFBRECO','pfAllChargedHadronsPFBRECO')
+elPFIsoDepositChargedAllPFBRECO=isoDepositReplace('pfSelectedElectronsPFBRECO','pfAllChargedParticlesPFBRECO')
+elPFIsoDepositNeutralPFBRECO=isoDepositReplace('pfSelectedElectronsPFBRECO','pfAllNeutralHadronsPFBRECO')
+elPFIsoDepositPUPFBRECO=isoDepositReplace('pfSelectedElectronsPFBRECO','pfPileUpAllChargedParticlesPFBRECO')
+#elPFIsoDepositGammaPFBRECO=isoDepositReplace('pfSelectedElectronsPFBRECO','pfAllPhotonsPFBRECO')
+elPFIsoDepositGammaPFBRECO= cms.EDProducer("CandIsoDepositProducer",
+                                     src = cms.InputTag("pfSelectedElectronsPFBRECO"),
+                                     MultipleDepositsFlag = cms.bool(False),
+                                     trackType = cms.string('candidate'),
+                                     ExtractorPSet = cms.PSet(
+                                            Diff_z = cms.double(99999.99),
+                                            ComponentName = cms.string('PFCandWithSuperClusterExtractor'),
+                                            DR_Max = cms.double(1.0),
+                                            Diff_r = cms.double(99999.99),
+                                            inputCandView = cms.InputTag("pfAllPhotonsPFBRECO"),
+                                            DR_Veto = cms.double(0),
+                                            SCMatch_Veto = cms.bool(False),
+                                            MissHitSCMatch_Veto = cms.bool(True),
+                                            DepositLabel = cms.untracked.string('')
+                                            )
+                                    )
+elPFIsoDepositChargedPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+elPFIsoDepositChargedAllPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+elPFIsoDepositNeutralPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+elPFIsoDepositPUPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+
+
+electronPFIsolationDepositsPFBRECOSequence = cms.Sequence(
+    elPFIsoDepositChargedPFBRECO+
+    elPFIsoDepositChargedAllPFBRECO+
+    elPFIsoDepositGammaPFBRECO+
+    elPFIsoDepositNeutralPFBRECO+
+    elPFIsoDepositPUPFBRECO
+    )

--- a/CommonTools/ParticleFlow/python/Isolation/electronPFIsolationValuesPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/electronPFIsolationValuesPFBRECO_cff.py
@@ -1,0 +1,81 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoParticleFlow.PFProducer.electronPFIsolationValues_cff import *
+
+elPFIsoValueCharged03PFIdPFBRECO = elPFIsoValueCharged03PFId.clone()
+elPFIsoValueCharged03PFIdPFBRECO.deposits[0].src = 'elPFIsoDepositChargedPFBRECO'
+
+elPFIsoValueChargedAll03PFIdPFBRECO = elPFIsoValueChargedAll03PFId.clone()
+elPFIsoValueChargedAll03PFIdPFBRECO.deposits[0].src = 'elPFIsoDepositChargedAllPFBRECO'
+
+elPFIsoValueGamma03PFIdPFBRECO = elPFIsoValueGamma03PFId.clone()
+elPFIsoValueGamma03PFIdPFBRECO.deposits[0].src = 'elPFIsoDepositGammaPFBRECO'
+
+elPFIsoValueNeutral03PFIdPFBRECO = elPFIsoValueNeutral03PFId.clone()
+elPFIsoValueNeutral03PFIdPFBRECO.deposits[0].src = 'elPFIsoDepositNeutralPFBRECO'
+
+elPFIsoValuePU03PFIdPFBRECO = elPFIsoValuePU03PFId.clone()
+elPFIsoValuePU03PFIdPFBRECO.deposits[0].src = 'elPFIsoDepositPUPFBRECO'
+
+elPFIsoValueCharged04PFIdPFBRECO = elPFIsoValueCharged03PFIdPFBRECO.clone()
+elPFIsoValueCharged04PFIdPFBRECO.deposits[0].deltaR = cms.double(0.4)
+
+elPFIsoValueChargedAll04PFIdPFBRECO = elPFIsoValueChargedAll03PFIdPFBRECO.clone()
+elPFIsoValueChargedAll04PFIdPFBRECO.deposits[0].deltaR = cms.double(0.4)
+
+elPFIsoValueGamma04PFIdPFBRECO = elPFIsoValueGamma03PFIdPFBRECO.clone()
+elPFIsoValueGamma04PFIdPFBRECO.deposits[0].deltaR = cms.double(0.4)
+
+elPFIsoValueNeutral04PFIdPFBRECO = elPFIsoValueNeutral03PFIdPFBRECO.clone()
+elPFIsoValueNeutral04PFIdPFBRECO.deposits[0].deltaR = cms.double(0.4)
+
+elPFIsoValuePU04PFIdPFBRECO = elPFIsoValuePU03PFIdPFBRECO.clone()
+elPFIsoValuePU04PFIdPFBRECO.deposits[0].deltaR = cms.double(0.4)
+
+##########Now the PFNoId
+elPFIsoValueCharged03NoPFIdPFBRECO     =  elPFIsoValueCharged03PFIdPFBRECO.clone()
+elPFIsoValueChargedAll03NoPFIdPFBRECO  =  elPFIsoValueChargedAll03PFIdPFBRECO.clone()
+elPFIsoValueGamma03NoPFIdPFBRECO       =  elPFIsoValueGamma03PFIdPFBRECO.clone()
+elPFIsoValueNeutral03NoPFIdPFBRECO     =  elPFIsoValueNeutral03PFIdPFBRECO.clone()
+elPFIsoValuePU03NoPFIdPFBRECO          =  elPFIsoValuePU03PFIdPFBRECO.clone()
+# Customization - No longer needed with new recommendation
+#elPFIsoValueCharged03NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueChargedAll03NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValuePU03NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueGamma03NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:RectangularEtaPhiVeto(-0.02,0.02,-0.5,0.5)','EcalEndcaps:ConeVeto(0.08)')
+
+
+elPFIsoValueCharged04NoPFIdPFBRECO     =  elPFIsoValueCharged04PFIdPFBRECO.clone()
+elPFIsoValueChargedAll04NoPFIdPFBRECO  =  elPFIsoValueChargedAll04PFIdPFBRECO.clone()
+elPFIsoValueGamma04NoPFIdPFBRECO       =  elPFIsoValueGamma04PFIdPFBRECO.clone()
+elPFIsoValueNeutral04NoPFIdPFBRECO     =  elPFIsoValueNeutral04PFIdPFBRECO.clone()
+elPFIsoValuePU04NoPFIdPFBRECO          =  elPFIsoValuePU04PFIdPFBRECO.clone()
+#elPFIsoValueCharged04NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueChargedAll04NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValuePU04NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueGamma04NoPFIdPFBRECO.deposits[0].vetos = cms.vstring('EcalBarrel:RectangularEtaPhiVeto(-0.02,0.02,-0.5,0.5)','EcalEndcaps:ConeVeto(0.08)')
+
+electronPFIsolationValuesPFBRECOSequence = (
+    elPFIsoValueCharged03PFIdPFBRECO+
+    elPFIsoValueChargedAll03PFIdPFBRECO+
+    elPFIsoValueGamma03PFIdPFBRECO+
+    elPFIsoValueNeutral03PFIdPFBRECO+
+    elPFIsoValuePU03PFIdPFBRECO+
+    ##############################
+    elPFIsoValueCharged04PFIdPFBRECO+
+    elPFIsoValueChargedAll04PFIdPFBRECO+
+    elPFIsoValueGamma04PFIdPFBRECO+
+    elPFIsoValueNeutral04PFIdPFBRECO+
+    elPFIsoValuePU04PFIdPFBRECO+
+    ##############################
+    elPFIsoValueCharged03NoPFIdPFBRECO+
+    elPFIsoValueChargedAll03NoPFIdPFBRECO+
+    elPFIsoValueGamma03NoPFIdPFBRECO+
+    elPFIsoValueNeutral03NoPFIdPFBRECO+
+    elPFIsoValuePU03NoPFIdPFBRECO+
+    ##############################
+    elPFIsoValueCharged04NoPFIdPFBRECO+
+    elPFIsoValueChargedAll04NoPFIdPFBRECO+
+    elPFIsoValueGamma04NoPFIdPFBRECO+
+    elPFIsoValueNeutral04NoPFIdPFBRECO+
+    elPFIsoValuePU04NoPFIdPFBRECO)

--- a/CommonTools/ParticleFlow/python/Isolation/muonPFIsolationDepositsPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/muonPFIsolationDepositsPFBRECO_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.tools_cfi import *
+
+
+#Now prepare the iso deposits
+muPFIsoDepositChargedPFBRECO=isoDepositReplace('pfSelectedMuonsPFBRECO','pfAllChargedHadronsPFBRECO')
+muPFIsoDepositChargedAllPFBRECO=isoDepositReplace('pfSelectedMuonsPFBRECO','pfAllChargedParticlesPFBRECO')
+muPFIsoDepositNeutralPFBRECO=isoDepositReplace('pfSelectedMuonsPFBRECO','pfAllNeutralHadronsPFBRECO')
+muPFIsoDepositGammaPFBRECO=isoDepositReplace('pfSelectedMuonsPFBRECO','pfAllPhotonsPFBRECO')
+muPFIsoDepositPUPFBRECO=isoDepositReplace('pfSelectedMuonsPFBRECO','pfPileUpAllChargedParticlesPFBRECO')
+
+muonPFIsolationDepositsPFBRECOSequence = cms.Sequence(
+    muPFIsoDepositChargedPFBRECO+
+    muPFIsoDepositChargedAllPFBRECO+
+    muPFIsoDepositGammaPFBRECO+
+    muPFIsoDepositNeutralPFBRECO+
+    muPFIsoDepositPUPFBRECO
+    )

--- a/CommonTools/ParticleFlow/python/Isolation/muonPFIsolationValuesPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/muonPFIsolationValuesPFBRECO_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoMuon/MuonIsolation.muonPFIsolationValues_cff import *
+from RecoMuon.MuonIsolation.muonPFIsolationValues_cff import *
 
 muPFIsoValueCharged03PFBRECO = muPFIsoValueCharged03.clone()
 muPFIsoValueCharged03PFBRECO.deposits[0].src = 'muPFIsoDepositChargedPFBRECO'

--- a/CommonTools/ParticleFlow/python/Isolation/muonPFIsolationValuesPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/muonPFIsolationValuesPFBRECO_cff.py
@@ -1,0 +1,135 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoMuon/MuonIsolation.muonPFIsolationValues_cff import *
+
+muPFIsoValueCharged03PFBRECO = muPFIsoValueCharged03.clone()
+muPFIsoValueCharged03PFBRECO.deposits[0].src = 'muPFIsoDepositChargedPFBRECO'
+muPFMeanDRIsoValueCharged03PFBRECO = muPFMeanDRIsoValueCharged03.clone()
+muPFMeanDRIsoValueCharged03PFBRECO.deposits[0].src = 'muPFIsoDepositChargedPFBRECO'
+muPFSumDRIsoValueCharged03PFBRECO = muPFSumDRIsoValueCharged03.clone()
+muPFSumDRIsoValueCharged03PFBRECO.deposits[0].src = 'muPFIsoDepositChargedPFBRECO'
+muPFIsoValueChargedAll03PFBRECO = muPFIsoValueChargedAll03.clone()
+muPFIsoValueChargedAll03PFBRECO.deposits[0].src = 'muPFIsoDepositChargedAllPFBRECO'
+muPFMeanDRIsoValueChargedAll03PFBRECO = muPFMeanDRIsoValueChargedAll03.clone()
+muPFMeanDRIsoValueChargedAll03PFBRECO.deposits[0].src = 'muPFIsoDepositChargedAllPFBRECO'
+muPFSumDRIsoValueChargedAll03PFBRECO = muPFSumDRIsoValueChargedAll03.clone()
+muPFSumDRIsoValueChargedAll03PFBRECO.deposits[0].src = 'muPFIsoDepositChargedAllPFBRECO'
+muPFIsoValueGamma03PFBRECO = muPFIsoValueGamma03.clone()
+muPFIsoValueGamma03PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFMeanDRIsoValueGamma03PFBRECO = muPFMeanDRIsoValueGamma03.clone()
+muPFMeanDRIsoValueGamma03PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFSumDRIsoValueGamma03PFBRECO = muPFSumDRIsoValueGamma03.clone()
+muPFSumDRIsoValueGamma03PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFIsoValueNeutral03PFBRECO = muPFIsoValueNeutral03.clone()
+muPFIsoValueNeutral03PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFMeanDRIsoValueNeutral03PFBRECO = muPFMeanDRIsoValueNeutral03.clone()
+muPFMeanDRIsoValueNeutral03PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFSumDRIsoValueNeutral03PFBRECO = muPFSumDRIsoValueNeutral03.clone()
+muPFSumDRIsoValueNeutral03PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFIsoValueGammaHighThreshold03PFBRECO = muPFIsoValueGammaHighThreshold03.clone()
+muPFIsoValueGammaHighThreshold03PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFMeanDRIsoValueGammaHighThreshold03PFBRECO = muPFMeanDRIsoValueGammaHighThreshold03.clone()
+muPFMeanDRIsoValueGammaHighThreshold03PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFSumDRIsoValueGammaHighThreshold03PFBRECO = muPFSumDRIsoValueGammaHighThreshold03.clone()
+muPFSumDRIsoValueGammaHighThreshold03PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFIsoValueNeutralHighThreshold03PFBRECO = muPFIsoValueNeutralHighThreshold03.clone()
+muPFIsoValueNeutralHighThreshold03PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFMeanDRIsoValueNeutralHighThreshold03PFBRECO = muPFMeanDRIsoValueNeutralHighThreshold03.clone()
+muPFMeanDRIsoValueNeutralHighThreshold03PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFSumDRIsoValueNeutralHighThreshold03PFBRECO = muPFSumDRIsoValueNeutralHighThreshold03.clone()
+muPFSumDRIsoValueNeutralHighThreshold03PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFIsoValuePU03PFBRECO = muPFIsoValuePU03.clone()
+muPFIsoValuePU03PFBRECO.deposits[0].src = 'muPFIsoDepositPUPFBRECO'
+muPFMeanDRIsoValuePU03PFBRECO = muPFMeanDRIsoValuePU03.clone()
+muPFMeanDRIsoValuePU03PFBRECO.deposits[0].src = 'muPFIsoDepositPUPFBRECO'
+muPFSumDRIsoValuePU03PFBRECO = muPFSumDRIsoValuePU03.clone()
+muPFSumDRIsoValuePU03PFBRECO.deposits[0].src = 'muPFIsoDepositPUPFBRECO'
+##############################
+muPFIsoValueCharged04PFBRECO = muPFIsoValueCharged04.clone()
+muPFIsoValueCharged04PFBRECO.deposits[0].src = 'muPFIsoDepositChargedPFBRECO'
+muPFMeanDRIsoValueCharged04PFBRECO = muPFMeanDRIsoValueCharged04.clone()
+muPFMeanDRIsoValueCharged04PFBRECO.deposits[0].src = 'muPFIsoDepositChargedPFBRECO'
+muPFSumDRIsoValueCharged04PFBRECO = muPFSumDRIsoValueCharged04.clone()
+muPFSumDRIsoValueCharged04PFBRECO.deposits[0].src = 'muPFIsoDepositChargedPFBRECO'
+muPFIsoValueChargedAll04PFBRECO = muPFIsoValueChargedAll04.clone()
+muPFIsoValueChargedAll04PFBRECO.deposits[0].src = 'muPFIsoDepositChargedAllPFBRECO'
+muPFMeanDRIsoValueChargedAll04PFBRECO = muPFMeanDRIsoValueChargedAll04.clone()
+muPFMeanDRIsoValueChargedAll04PFBRECO.deposits[0].src = 'muPFIsoDepositChargedAllPFBRECO'
+muPFSumDRIsoValueChargedAll04PFBRECO = muPFSumDRIsoValueChargedAll04.clone()
+muPFSumDRIsoValueChargedAll04PFBRECO.deposits[0].src = 'muPFIsoDepositChargedAllPFBRECO'
+muPFIsoValueGamma04PFBRECO = muPFIsoValueGamma04.clone()
+muPFIsoValueGamma04PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFMeanDRIsoValueGamma04PFBRECO = muPFMeanDRIsoValueGamma04.clone()
+muPFMeanDRIsoValueGamma04PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFSumDRIsoValueGamma04PFBRECO = muPFSumDRIsoValueGamma04.clone()
+muPFSumDRIsoValueGamma04PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFIsoValueNeutral04PFBRECO = muPFIsoValueNeutral04.clone()
+muPFIsoValueNeutral04PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFMeanDRIsoValueNeutral04PFBRECO = muPFMeanDRIsoValueNeutral04.clone()
+muPFMeanDRIsoValueNeutral04PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFSumDRIsoValueNeutral04PFBRECO = muPFSumDRIsoValueNeutral04.clone()
+muPFSumDRIsoValueNeutral04PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFIsoValueGammaHighThreshold04PFBRECO = muPFIsoValueGammaHighThreshold04.clone()
+muPFIsoValueGammaHighThreshold04PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFMeanDRIsoValueGammaHighThreshold04PFBRECO = muPFMeanDRIsoValueGammaHighThreshold04.clone()
+muPFMeanDRIsoValueGammaHighThreshold04PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFSumDRIsoValueGammaHighThreshold04PFBRECO = muPFSumDRIsoValueGammaHighThreshold04.clone()
+muPFSumDRIsoValueGammaHighThreshold04PFBRECO.deposits[0].src = 'muPFIsoDepositGammaPFBRECO'
+muPFIsoValueNeutralHighThreshold04PFBRECO = muPFIsoValueNeutralHighThreshold04.clone()
+muPFIsoValueNeutralHighThreshold04PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFMeanDRIsoValueNeutralHighThreshold04PFBRECO = muPFMeanDRIsoValueNeutralHighThreshold04.clone()
+muPFMeanDRIsoValueNeutralHighThreshold04PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFSumDRIsoValueNeutralHighThreshold04PFBRECO = muPFSumDRIsoValueNeutralHighThreshold04.clone()
+muPFSumDRIsoValueNeutralHighThreshold04PFBRECO.deposits[0].src = 'muPFIsoDepositNeutralPFBRECO'
+muPFIsoValuePU04PFBRECO = muPFIsoValuePU04.clone()
+muPFIsoValuePU04PFBRECO.deposits[0].src = 'muPFIsoDepositPUPFBRECO'
+muPFMeanDRIsoValuePU04PFBRECO = muPFMeanDRIsoValuePU04.clone()
+muPFMeanDRIsoValuePU04PFBRECO.deposits[0].src = 'muPFIsoDepositPUPFBRECO'
+muPFSumDRIsoValuePU04PFBRECO = muPFSumDRIsoValuePU04.clone()
+muPFSumDRIsoValuePU04PFBRECO.deposits[0].src = 'muPFIsoDepositPUPFBRECO'
+
+muonPFIsolationValuesPFBRECOSequence = (
+    muPFIsoValueCharged03PFBRECO+
+    muPFMeanDRIsoValueCharged03PFBRECO+
+    muPFSumDRIsoValueCharged03PFBRECO+
+    muPFIsoValueChargedAll03PFBRECO+
+    muPFMeanDRIsoValueChargedAll03PFBRECO+
+    muPFSumDRIsoValueChargedAll03PFBRECO+
+    muPFIsoValueGamma03PFBRECO+
+    muPFMeanDRIsoValueGamma03PFBRECO+
+    muPFSumDRIsoValueGamma03PFBRECO+
+    muPFIsoValueNeutral03PFBRECO+
+    muPFMeanDRIsoValueNeutral03PFBRECO+
+    muPFSumDRIsoValueNeutral03PFBRECO+
+    muPFIsoValueGammaHighThreshold03PFBRECO+
+    muPFMeanDRIsoValueGammaHighThreshold03PFBRECO+
+    muPFSumDRIsoValueGammaHighThreshold03PFBRECO+
+    muPFIsoValueNeutralHighThreshold03PFBRECO+
+    muPFMeanDRIsoValueNeutralHighThreshold03PFBRECO+
+    muPFSumDRIsoValueNeutralHighThreshold03PFBRECO+
+    muPFIsoValuePU03PFBRECO+
+    muPFMeanDRIsoValuePU03PFBRECO+
+    muPFSumDRIsoValuePU03PFBRECO+
+    ##############################
+    muPFIsoValueCharged04PFBRECO+
+    muPFMeanDRIsoValueCharged04PFBRECO+
+    muPFSumDRIsoValueCharged04PFBRECO+
+    muPFIsoValueChargedAll04PFBRECO+
+    muPFMeanDRIsoValueChargedAll04PFBRECO+
+    muPFSumDRIsoValueChargedAll04PFBRECO+
+    muPFIsoValueGamma04PFBRECO+
+    muPFMeanDRIsoValueGamma04PFBRECO+
+    muPFSumDRIsoValueGamma04PFBRECO+
+    muPFIsoValueNeutral04PFBRECO+
+    muPFMeanDRIsoValueNeutral04PFBRECO+
+    muPFSumDRIsoValueNeutral04PFBRECO+
+    muPFIsoValueGammaHighThreshold04PFBRECO+
+    muPFMeanDRIsoValueGammaHighThreshold04PFBRECO+
+    muPFSumDRIsoValueGammaHighThreshold04PFBRECO+
+    muPFIsoValueNeutralHighThreshold04PFBRECO+
+    muPFMeanDRIsoValueNeutralHighThreshold04PFBRECO+
+    muPFSumDRIsoValueNeutralHighThreshold04PFBRECO+
+    muPFIsoValuePU04PFBRECO+
+    muPFMeanDRIsoValuePU04PFBRECO+
+    muPFSumDRIsoValuePU04PFBRECO
+    )

--- a/CommonTools/ParticleFlow/python/Isolation/pfElectronIsolationPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/pfElectronIsolationPFBRECO_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.electronPFIsolationDepositsPFBRECO_cff import *
+from CommonTools.ParticleFlow.Isolation.electronPFIsolationValuesPFBRECO_cff import *
+
+pfElectronIsolationPFBRECOSequence = cms.Sequence(
+    electronPFIsolationDepositsPFBRECOSequence +
+    electronPFIsolationValuesPFBRECOSequence
+    )
+

--- a/CommonTools/ParticleFlow/python/Isolation/pfMuonIsolationPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/pfMuonIsolationPFBRECO_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+# iso deposits and isolation values, defined by the Muon POG
+
+from CommonTools.ParticleFlow.Isolation.muonPFIsolationDepositsPFBRECO_cff import *
+from CommonTools.ParticleFlow.Isolation.muonPFIsolationValuesPFBRECO_cff import *
+
+muonPFIsolationPFBRECOSequence =  cms.Sequence(
+    muonPFIsolationDepositsPFBRECOSequence +
+    muonPFIsolationValuesPFBRECOSequence
+)

--- a/CommonTools/ParticleFlow/python/Isolation/pfPhotonIsolationPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/pfPhotonIsolationPFBRECO_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.photonPFIsolationDepositsPFBRECO_cff import *
+from CommonTools.ParticleFlow.Isolation.photonPFIsolationValuesPFBRECO_cff import *
+
+pfPhotonIsolationPFBRECOSequence = cms.Sequence(
+    photonPFIsolationDepositsPFBRECOSequence +
+    photonPFIsolationValuesPFBRECOSequence
+    )
+

--- a/CommonTools/ParticleFlow/python/Isolation/photonPFIsolationDepositsPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/photonPFIsolationDepositsPFBRECO_cff.py
@@ -1,0 +1,39 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.tools_cfi import *
+
+#Now prepare the iso deposits
+phPFIsoDepositChargedPFBRECO=isoDepositReplace('pfSelectedPhotonsPFBRECO','pfAllChargedHadronsPFBRECO')
+phPFIsoDepositChargedAllPFBRECO=isoDepositReplace('pfSelectedPhotonsPFBRECO','pfAllChargedParticlesPFBRECO')
+phPFIsoDepositNeutralPFBRECO=isoDepositReplace('pfSelectedPhotonsPFBRECO','pfAllNeutralHadronsPFBRECO')
+#phPFIsoDepositGammaPFBRECO=isoDepositReplace('pfSelectedPhotonsPFBRECO','pfAllPhotonsPFBRECO')
+phPFIsoDepositPUPFBRECO=isoDepositReplace('pfSelectedPhotonsPFBRECO','pfPileUpAllChargedParticlesPFBRECO')
+phPFIsoDepositGammaPFBRECO= cms.EDProducer("CandIsoDepositProducer",
+                                    src = cms.InputTag("pfSelectedPhotonsPFBRECO"),
+                                    MultipleDepositsFlag = cms.bool(False),
+                                    trackType = cms.string('candidate'),
+                                    ExtractorPSet = cms.PSet(
+                                        Diff_z = cms.double(99999.99),
+                                        ComponentName = cms.string('PFCandWithSuperClusterExtractor'),
+                                        DR_Max = cms.double(1.0),
+                                        Diff_r = cms.double(99999.99),
+                                        inputCandView = cms.InputTag("pfAllPhotonsPFBRECO"),
+                                        DR_Veto = cms.double(0),
+                                        SCMatch_Veto = cms.bool(True),
+                                        MissHitSCMatch_Veto = cms.bool(False),
+                                        DepositLabel = cms.untracked.string('')
+                                        )
+                            )
+
+phPFIsoDepositChargedPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+phPFIsoDepositChargedAllPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+phPFIsoDepositNeutralPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+phPFIsoDepositPUPFBRECO.ExtractorPSet.DR_Veto = cms.double(0)
+
+photonPFIsolationDepositsPFBRECOSequence = cms.Sequence(
+    phPFIsoDepositChargedPFBRECO+
+    phPFIsoDepositChargedAllPFBRECO+
+    phPFIsoDepositGammaPFBRECO+
+    phPFIsoDepositNeutralPFBRECO+
+    phPFIsoDepositPUPFBRECO
+    )

--- a/CommonTools/ParticleFlow/python/Isolation/photonPFIsolationValuesPFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/Isolation/photonPFIsolationValuesPFBRECO_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoParticleFlow.PFProducer.photonPFIsolationValues_cff import *
+
+phPFIsoValueCharged03PFIdPFBRECO = phPFIsoValueCharged03PFId.clone()
+phPFIsoValueCharged03PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositChargedPFBRECO'
+
+phPFIsoValueChargedAll03PFIdPFBRECO = phPFIsoValueChargedAll03PFId.clone()
+phPFIsoValueChargedAll03PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositChargedAllPFBRECO'
+
+phPFIsoValueGamma03PFIdPFBRECO = phPFIsoValueGamma03PFId.clone()
+phPFIsoValueGamma03PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositGammaPFBRECO'
+
+phPFIsoValueNeutral03PFIdPFBRECO = phPFIsoValueNeutral03PFId.clone()
+phPFIsoValueNeutral03PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositNeutralPFBRECO'
+
+phPFIsoValuePU03PFIdPFBRECO = phPFIsoValuePU03PFId.clone()
+phPFIsoValuePU03PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositPUPFBRECO'
+
+phPFIsoValueCharged04PFIdPFBRECO = phPFIsoValueCharged04PFId.clone()
+phPFIsoValueCharged04PFIdPFBRECO.deposits[0]. src = 'phPFIsoDepositChargedPFBRECO'
+
+phPFIsoValueChargedAll04PFIdPFBRECO = phPFIsoValueChargedAll04PFId.clone()
+phPFIsoValueChargedAll04PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositChargedAllPFBRECO'
+
+phPFIsoValueGamma04PFIdPFBRECO = phPFIsoValueGamma04PFId.clone()
+phPFIsoValueGamma04PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositGammaPFBRECO'
+
+phPFIsoValueNeutral04PFIdPFBRECO = phPFIsoValueNeutral04PFId.clone()
+phPFIsoValueNeutral04PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositNeutralPFBRECO'
+
+phPFIsoValuePU04PFIdPFBRECO = phPFIsoValuePU04PFId.clone()
+phPFIsoValuePU04PFIdPFBRECO.deposits[0].src = 'phPFIsoDepositPUPFBRECO'
+
+photonPFIsolationValuesPFBRECOSequence = (
+    phPFIsoValueCharged03PFIdPFBRECO+
+    phPFIsoValueChargedAll03PFIdPFBRECO+
+    phPFIsoValueGamma03PFIdPFBRECO+
+    phPFIsoValueNeutral03PFIdPFBRECO+
+    phPFIsoValuePU03PFIdPFBRECO+
+    ##############################
+    phPFIsoValueCharged04PFIdPFBRECO+
+    phPFIsoValueChargedAll04PFIdPFBRECO+
+    phPFIsoValueGamma04PFIdPFBRECO+
+    phPFIsoValueNeutral04PFIdPFBRECO+
+    phPFIsoValuePU04PFIdPFBRECO
+    )

--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -66,12 +66,16 @@ pfParticleSelectionPFBRECOSequence = cms.Sequence(
 
 from CommonTools.ParticleFlow.ParticleSelectors.pfSelectedPhotons_cfi import *
 pfSelectedPhotonsPFBRECO = pfSelectedPhotons.clone( src = 'pfAllPhotonsPFBRECO' )
-from CommonTools.ParticleFlow.Isolation.pfPhotonIsolation_cff import *
+from CommonTools.ParticleFlow.Isolation.pfPhotonIsolationPFBRECO_cff import *
 from CommonTools.ParticleFlow.Isolation.pfIsolatedPhotons_cfi import *
-pfIsolatedPhotonsPFBRECO = pfIsolatedPhotons.clone( src = 'pfSelectedPhotonsPFBRECO' )
+pfIsolatedPhotonsPFBRECO = pfIsolatedPhotons.clone( src = 'pfSelectedPhotonsPFBRECO',
+                                                    isolationValueMapsCharged = cms.VInputTag( cms.InputTag("phPFIsoValueCharged04PFIdPFBRECO") ),
+                                                    isolationValueMapsNeutral = cms.VInputTag( cms.InputTag("phPFIsoValueNeutral04PFIdPFBRECO"),
+                                                                                               cms.InputTag("phPFIsoValueGamma04PFIdPFBRECO") ),
+                                                    deltaBetaIsolationValueMap = 'phPFIsoValuePU04PFIdPFBRECO' )
 pfPhotonPFBRECOSequence = cms.Sequence(
     pfSelectedPhotonsPFBRECO +
-    pfPhotonIsolationSequence +
+    pfPhotonIsolationPFBRECOSequence +
     # selecting isolated photons:
     pfIsolatedPhotonsPFBRECO
     )
@@ -84,7 +88,7 @@ pfMuonsPFBRECO = pfIsolatedMuonsPFBRECO.clone(cut = cms.string("pt > 5 & muonRef
 pfMuonPFBRECOSequence = cms.Sequence(
     pfAllMuonsPFBRECO +
     pfMuonsFromVertexPFBRECO +
-    pfIsolatedMuonPFBRECOs+
+    pfIsolatedMuonsPFBRECO+
     pfMuonsPFBRECO
     )
 
@@ -132,10 +136,10 @@ pfNoMuonPFBRECO = pfNoMuon.clone( topCollection = 'pfIsolatedMuonsPFBRECO',
                                   bottomCollection = 'pfNoPileUpPFBRECO' )
 pfNoMuonJMEPFBRECO = pfNoMuonJME.clone( topCollection = 'pfIsolatedMuonsPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoElectron_cfi import *
-pfNoElectronPFBRECO = pfNoMuon.clone( topCollection = 'pfIsolatedElectronPFBRECO',
-                                      bottomCollection = 'pfNoMuonPFBRECO' )
-pfNoElectroJMEPFBRECO = pfNoMuonJME.clone( topCollection = 'pfIsolatedElectronPFBRECO',
-                                        bottomCollection = 'pfNoMuonJMEPFBRECO' )
+pfNoElectronPFBRECO = pfNoElectron.clone( topCollection = 'pfIsolatedElectronPFBRECO',
+                                          bottomCollection = 'pfNoMuonPFBRECO' )
+pfNoElectronJMEPFBRECO = pfNoElectronJME.clone( topCollection = 'pfIsolatedElectronPFBRECO',
+                                                bottomCollection = 'pfNoMuonJMEPFBRECO' )
 pfNoElectronJMEClonesPFBRECO = pfNoElectronJMEClones.clone( src = 'pfNoElectronJMEPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cff import *
 pfNoJetPFBRECO = pfNoJet.clone( topCollection = 'pfJetsPtrsPFBRECO',

--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -106,7 +106,7 @@ pfElectronPFBRECOSequence = cms.Sequence(
 
 from CommonTools.ParticleFlow.Tools.jetTools import jetAlgo
 pfJets = jetAlgo('AK4')
-pfJetsPFBRECO = pfJets.clone( src = 'pfNoElectroJMEPFBRECO' )
+pfJetsPFBRECO = pfJets.clone( src = 'pfNoElectronJMEPFBRECO' )
 pfJetsPtrsPFBRECO = cms.EDProducer("PFJetFwdPtrProducer",
                                    src=cms.InputTag("pfJetsPFBRECO")
                                    )
@@ -136,14 +136,14 @@ pfNoMuonPFBRECO = pfNoMuon.clone( topCollection = 'pfIsolatedMuonsPFBRECO',
                                   bottomCollection = 'pfNoPileUpPFBRECO' )
 pfNoMuonJMEPFBRECO = pfNoMuonJME.clone( topCollection = 'pfIsolatedMuonsPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoElectron_cfi import *
-pfNoElectronPFBRECO = pfNoElectron.clone( topCollection = 'pfIsolatedElectronPFBRECO',
+pfNoElectronPFBRECO = pfNoElectron.clone( topCollection = 'pfIsolatedElectronsPFBRECO',
                                           bottomCollection = 'pfNoMuonPFBRECO' )
-pfNoElectronJMEPFBRECO = pfNoElectronJME.clone( topCollection = 'pfIsolatedElectronPFBRECO',
+pfNoElectronJMEPFBRECO = pfNoElectronJME.clone( topCollection = 'pfIsolatedElectronsPFBRECO',
                                                 bottomCollection = 'pfNoMuonJMEPFBRECO' )
 pfNoElectronJMEClonesPFBRECO = pfNoElectronJMEClones.clone( src = 'pfNoElectronJMEPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cff import *
 pfNoJetPFBRECO = pfNoJet.clone( topCollection = 'pfJetsPtrsPFBRECO',
-                                bottomCollection = 'pfNoElectroJMEPFBRECO' )
+                                bottomCollection = 'pfNoElectronJMEPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoTau_cff import *
 pfNoTauPFBRECO = pfNoTau.clone ( bottomCollection = 'pfJetsPtrsPFBRECO' )
 pfNoTauClonesPFBRECO = pfNoTauClones.clone ( src = 'pfNoTauPFBRECO' )

--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # getting the ptrs
 from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
 
-from CommonTools.ParticleFlow.pfPileUp_cfi  import *
+from CommonTools.ParticleFlow.pfPileUp_cfi import *
 from CommonTools.ParticleFlow.TopProjectors.pfNoPileUp_cfi import *
 pfPileUpIsoPFBRECO = pfPileUp.clone( PFCandidates = 'particleFlowPtrs' )
 pfNoPileUpIsoPFBRECO = pfNoPileUp.clone( topCollection = 'pfPileUpIsoPFBRECO',
@@ -13,7 +13,7 @@ pfNoPileUpIsoPFBRECOSequence = cms.Sequence(
     pfNoPileUpIsoPFBRECO
     )
 
-from CommonTools.ParticleFlow.pfNoPileUpJME_cff  import *
+from CommonTools.ParticleFlow.pfNoPileUpJME_cff import *
 
 pfPileUpPFBRECO = pfPileUp.clone( PFCandidates = 'particleFlowPtrs' )
 pfNoPileUpPFBRECO = pfNoPileUp.clone( topCollection = 'pfPileUpPFBRECO',
@@ -105,8 +105,8 @@ pfElectronPFBRECOSequence = cms.Sequence(
     )
 
 from CommonTools.ParticleFlow.Tools.jetTools import jetAlgo
-pfJets = jetAlgo('AK4')
-pfJetsPFBRECO = pfJets.clone( src = 'pfNoElectronJMEPFBRECO' )
+pfJetsPFBRECO = jetAlgo('AK4')
+pfJetsPFBRECO.src = 'pfNoElectronJMEPFBRECO'
 pfJetsPtrsPFBRECO = cms.EDProducer("PFJetFwdPtrProducer",
                                    src=cms.InputTag("pfJetsPFBRECO")
                                    )
@@ -117,7 +117,7 @@ pfJetPFBRECOSequence = cms.Sequence(
 
 from CommonTools.ParticleFlow.pfTaus_cff import *
 
-from CommonTools.ParticleFlow.pfMET_cfi  import *
+from CommonTools.ParticleFlow.pfMET_cfi import *
 pfMETPFBRECO = pfMET.clone( jets = 'pfJetsPFBRECO' )
 
 ##delta beta weighting

--- a/CommonTools/ParticleFlow/python/PFBRECO_cff.py
+++ b/CommonTools/ParticleFlow/python/PFBRECO_cff.py
@@ -1,56 +1,168 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.ParticleFlow.pfMET_cfi  import *
-from CommonTools.ParticleFlow.pfParticleSelection_cff import *
-from CommonTools.ParticleFlow.pfNoPileUp_cff  import *
-from CommonTools.ParticleFlow.pfPhotons_cff import *
-from CommonTools.ParticleFlow.pfElectrons_cff import *
-from CommonTools.ParticleFlow.pfMuons_cff import *
-from CommonTools.ParticleFlow.pfJets_cff import *
+# getting the ptrs
+from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
+
+from CommonTools.ParticleFlow.pfPileUp_cfi  import *
+from CommonTools.ParticleFlow.TopProjectors.pfNoPileUp_cfi import *
+pfPileUpIsoPFBRECO = pfPileUp.clone( PFCandidates = 'particleFlowPtrs' )
+pfNoPileUpIsoPFBRECO = pfNoPileUp.clone( topCollection = 'pfPileUpIsoPFBRECO',
+                                         bottomCollection = 'particleFlowPtrs')
+pfNoPileUpIsoPFBRECOSequence = cms.Sequence(
+    pfPileUpIsoPFBRECO +
+    pfNoPileUpIsoPFBRECO
+    )
+
+from CommonTools.ParticleFlow.pfNoPileUpJME_cff  import *
+
+pfPileUpPFBRECO = pfPileUp.clone( PFCandidates = 'particleFlowPtrs' )
+pfNoPileUpPFBRECO = pfNoPileUp.clone( topCollection = 'pfPileUpPFBRECO',
+                                      bottomCollection = 'particleFlowPtrs')
+pfNoPileUpPFBRECOSequence = cms.Sequence(
+    pfPileUpPFBRECO +
+    pfNoPileUpPFBRECO
+    )
+
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllNeutralHadrons_cfi import *
+pfAllNeutralHadronsPFBRECO = pfAllNeutralHadrons.clone( src = 'pfNoPileUpIsoPFBRECO' )
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllChargedHadrons_cfi import *
+pfAllChargedHadronsPFBRECO = pfAllChargedHadrons.clone( src = 'pfNoPileUpIsoPFBRECO' )
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllPhotons_cfi import *
+pfAllPhotonsPFBRECO = pfAllPhotons.clone( src = 'pfNoPileUpIsoPFBRECO' )
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllMuons_cfi import *
+pfAllMuonsPFBRECO = pfAllMuons.clone( src = 'pfNoPileUpPFBRECO' )
+pfAllMuonsClonesPFBRECO = pfAllMuonsClones.clone( src = 'pfAllMuonsPFBRECO' )
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllElectrons_cfi import *
+pfAllElectronsPFBRECO = pfAllElectrons.clone( src = 'pfNoMuonPFBRECO' )
+pfAllElectronsClonesPFBRECO = pfAllElectronsClones.clone( src = 'pfAllElectronsPFBRECO' )
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllChargedParticles_cfi import *
+pfAllChargedParticlesPFBRECO = pfAllChargedParticles.clone( src = 'pfNoPileUpIsoPFBRECO' )
+from CommonTools.ParticleFlow.ParticleSelectors.pfAllNeutralHadronsAndPhotons_cfi import *
+pfAllNeutralHadronsAndPhotonsPFBRECO = pfAllNeutralHadronsAndPhotons.clone( src = 'pfNoPileUpIsoPFBRECO' )
+pfPileUpAllChargedParticlesPFBRECO = pfAllChargedParticles.clone( src = 'pfPileUpIsoPFBRECO' )
+pfSortByTypePFBRECOSequence = cms.Sequence(
+    pfAllNeutralHadronsPFBRECO+
+    pfAllChargedHadronsPFBRECO+
+    pfAllPhotonsPFBRECO+
+    # charged hadrons + electrons + muons
+    pfAllChargedParticlesPFBRECO+
+    # same, but from pile up
+    pfPileUpAllChargedParticlesPFBRECO+
+    pfAllNeutralHadronsAndPhotonsPFBRECO
+#    +
+#    pfAllElectronsPFBRECO+
+#    pfAllMuonsPFBRECO
+    )
+
+pfParticleSelectionPFBRECOSequence = cms.Sequence(
+    pfNoPileUpIsoPFBRECOSequence +
+    # In principle JME sequence should go here, but this is used in RECO
+    # in addition to here, and is used in the "first-step" PF process
+    # so needs to go later.
+    #pfNoPileUpJMESequence +
+    pfNoPileUpPFBRECOSequence +
+    pfSortByTypePFBRECOSequence
+    )
+
+from CommonTools.ParticleFlow.ParticleSelectors.pfSelectedPhotons_cfi import *
+pfSelectedPhotonsPFBRECO = pfSelectedPhotons.clone( src = 'pfAllPhotonsPFBRECO' )
+from CommonTools.ParticleFlow.Isolation.pfPhotonIsolation_cff import *
+from CommonTools.ParticleFlow.Isolation.pfIsolatedPhotons_cfi import *
+pfIsolatedPhotonsPFBRECO = pfIsolatedPhotons.clone( src = 'pfSelectedPhotonsPFBRECO' )
+pfPhotonPFBRECOSequence = cms.Sequence(
+    pfSelectedPhotonsPFBRECO +
+    pfPhotonIsolationSequence +
+    # selecting isolated photons:
+    pfIsolatedPhotonsPFBRECO
+    )
+
+from CommonTools.ParticleFlow.ParticleSelectors.pfMuonsFromVertex_cfi import *
+pfMuonsFromVertexPFBRECO = pfMuonsFromVertex.clone( src = 'pfAllMuonsPFBRECO' )
+from CommonTools.ParticleFlow.Isolation.pfIsolatedMuons_cfi import *
+pfIsolatedMuonsPFBRECO = pfIsolatedMuons.clone( src = 'pfMuonsFromVertexPFBRECO' )
+pfMuonsPFBRECO = pfIsolatedMuonsPFBRECO.clone(cut = cms.string("pt > 5 & muonRef.isAvailable()"))
+pfMuonPFBRECOSequence = cms.Sequence(
+    pfAllMuonsPFBRECO +
+    pfMuonsFromVertexPFBRECO +
+    pfIsolatedMuonPFBRECOs+
+    pfMuonsPFBRECO
+    )
+
+from CommonTools.ParticleFlow.ParticleSelectors.pfElectronsFromVertex_cfi import *
+pfElectronsFromVertexPFBRECO = pfElectronsFromVertex.clone( src = 'pfAllElectronsPFBRECO' )
+from CommonTools.ParticleFlow.Isolation.pfIsolatedElectrons_cfi import *
+pfIsolatedElectronsPFBRECO = pfIsolatedElectrons.clone( src = 'pfElectronsFromVertexPFBRECO' )
+pfElectronsPFBRECO = pfIsolatedElectronsPFBRECO.clone( cut = cms.string(" pt > 5 & gsfElectronRef.isAvailable() & gsfTrackRef.hitPattern().numberOfLostHits('MISSING_INNER_HITS')<2"))
+pfElectronPFBRECOSequence = cms.Sequence(
+    pfAllElectronsPFBRECO +
+    pfElectronsFromVertexPFBRECO +
+    pfIsolatedElectronsPFBRECO +
+    pfElectronsPFBRECO
+    )
+
+from CommonTools.ParticleFlow.Tools.jetTools import jetAlgo
+pfJets = jetAlgo('AK4')
+pfJetsPFBRECO = pfJets.clone( src = 'pfNoElectroJMEPFBRECO' )
+pfJetsPtrsPFBRECO = cms.EDProducer("PFJetFwdPtrProducer",
+                                   src=cms.InputTag("pfJetsPFBRECO")
+                                   )
+pfJetPFBRECOSequence = cms.Sequence(
+    pfJetsPFBRECO +
+    pfJetsPtrsPFBRECO
+    )
+
 from CommonTools.ParticleFlow.pfTaus_cff import *
 
-#delta beta weighting
-#from CommonTools.ParticleFlow.deltaBetaWeights_cff  import *
+from CommonTools.ParticleFlow.pfMET_cfi  import *
+pfMETPFBRECO = pfMET.clone( jets = 'pfJetsPFBRECO' )
+
+##delta beta weighting
+#from CommonTools.ParticleFlow.deltaBetaWeights_cfi import *
+#pfWeightedPhotonsPFBRECO = pfWeightedPhotons.clone( src = 'pfAllPhotonsPFBRECO',
+                                                    #chargedFromPV = 'pfAllChargedParticlesPFBRECO',
+                                                    #chargedFromPU = 'pfPileUpAllChargedParticlesPFBRECO' )
+#pfWeightedNeutralHadronsPFBRECO = pfWeightedNeutralHadrons.clone( src = 'pfAllNeutralHadronsPFBRECO',
+                                                                  #chargedFromPV = 'pfAllChargedParticlesPFBRECO',
+                                                                  #chargedFromPU = 'pfPileUpAllChargedParticlesPFBRECO' )
+#pfDeltaBetaWeightingPFBRECOSequence = cms.Sequence(pfWeightedPhotonsPFBRECO+pfWeightedNeutralHadronsPFBRECO)
 
 # sequential top projection cleaning
 from CommonTools.ParticleFlow.TopProjectors.pfNoMuon_cfi import *
+pfNoMuonPFBRECO = pfNoMuon.clone( topCollection = 'pfIsolatedMuonsPFBRECO',
+                                  bottomCollection = 'pfNoPileUpPFBRECO' )
+pfNoMuonJMEPFBRECO = pfNoMuonJME.clone( topCollection = 'pfIsolatedMuonsPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoElectron_cfi import *
+pfNoElectronPFBRECO = pfNoMuon.clone( topCollection = 'pfIsolatedElectronPFBRECO',
+                                      bottomCollection = 'pfNoMuonPFBRECO' )
+pfNoElectroJMEPFBRECO = pfNoMuonJME.clone( topCollection = 'pfIsolatedElectronPFBRECO',
+                                        bottomCollection = 'pfNoMuonJMEPFBRECO' )
+pfNoElectronJMEClonesPFBRECO = pfNoElectronJMEClones.clone( src = 'pfNoElectronJMEPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoJet_cff import *
+pfNoJetPFBRECO = pfNoJet.clone( topCollection = 'pfJetsPtrsPFBRECO',
+                                bottomCollection = 'pfNoElectroJMEPFBRECO' )
 from CommonTools.ParticleFlow.TopProjectors.pfNoTau_cff import *
-
-# getting the ptrs
-from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
+pfNoTauPFBRECO = pfNoTau.clone ( bottomCollection = 'pfJetsPtrsPFBRECO' )
+pfNoTauClonesPFBRECO = pfNoTauClones.clone ( src = 'pfNoTauPFBRECO' )
 
 # generator tools
 from CommonTools.ParticleFlow.genForPF2PAT_cff import *
 
-# plugging PF2PAT on the collection of PFCandidates from RECO:
-#particleFlowPtrs.src = 'particleFlow'
-
-pfPileUp.PFCandidates = 'particleFlowPtrs'
-pfNoPileUp.bottomCollection = 'particleFlowPtrs'
-pfPileUpIso.PFCandidates = 'particleFlowPtrs'
-pfNoPileUpIso.bottomCollection='particleFlowPtrs'
-pfPileUpJME.PFCandidates = 'particleFlowPtrs'
-pfNoPileUpJME.bottomCollection='particleFlowPtrs'
-
 PFBRECO = cms.Sequence(
     particleFlowPtrs +
-    pfNoPileUpSequence +
+    pfParticleSelectionPFBRECOSequence +
     pfNoPileUpJMESequence +
-    pfParticleSelectionSequence +
-#    pfDeltaBetaWeightingSequence +
-    pfPhotonSequence +
-    pfMuonSequence +
-    pfNoMuon +
-    pfNoMuonJME +
-    pfElectronSequence +
-    pfNoElectron +
-    pfNoElectronJME +
-    pfNoElectronJMEClones+
-    pfJetSequence +
-    pfNoJet +
+#    pfDeltaBetaWeightingPFBRECOSequence +
+    pfPhotonPFBRECOSequence +
+    pfMuonPFBRECOSequence +
+    pfNoMuonPFBRECO +
+    pfNoMuonJMEPFBRECO +
+    pfElectronPFBRECOSequence +
+    pfNoElectronPFBRECO +
+    pfNoElectronJMEPFBRECO +
+    pfNoElectronJMEClonesPFBRECO+
+    pfJetPFBRECOSequence +
+    pfNoJetPFBRECO +
     pfTauSequence +
-    pfNoTau +
-    pfMET
+    pfNoTauPFBRECO +
+    pfMETPFBRECO
     )

--- a/CommonTools/ParticleFlow/python/Tools/jetTools.py
+++ b/CommonTools/ParticleFlow/python/Tools/jetTools.py
@@ -1,19 +1,18 @@
 import FWCore.ParameterSet.Config as cms
 
-import RecoJets.JetProducers.ak4PFJets_cfi
-import RecoJets.JetProducers.ic5PFJets_cfi
-
 def jetAlgo( algo ):
 
     # print 'PF2PAT: selecting jet algorithm ', algo
 
     if algo == 'IC5':
-#allPfJets = RecoJets.JetProducers.ic5PFJets_cfi.iterativeCone5PFJets.clone()
-        jetAlgo = RecoJets.JetProducers.ic5PFJets_cfi.iterativeCone5PFJets.clone()
+        import RecoJets.JetProducers.ic5PFJets_cfi as jetConfig
+        jetAlgo = jetConfig.iterativeCone5PFJets.clone()
     elif algo == 'AK4':
-        jetAlgo = RecoJets.JetProducers.ak4PFJets_cfi.ak4PFJets.clone()
+        import RecoJets.JetProducers.ak4PFJets_cfi as jetConfig
+        jetAlgo = jetConfig.ak4PFJets.clone()
     elif algo == 'AK7':
-        jetAlgo = RecoJets.JetProducers.ak4PFJets_cfi.ak4PFJets.clone()
+        import RecoJets.JetProducers.ak4PFJets_cfi as jetConfig
+        jetAlgo = jetConfig.ak4PFJets.clone()
         jetAlgo.rParam = cms.double(0.7)
         jetAlgo.doAreaFastjet = cms.bool(False)
 

--- a/CommonTools/ParticleFlow/python/genForPF2PAT_cff.py
+++ b/CommonTools/ParticleFlow/python/genForPF2PAT_cff.py
@@ -1,8 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # To reconstruct genjets without the neutrinos
-from RecoJets.Configuration.GenJetParticles_cff import *
-from RecoJets.Configuration.RecoGenJets_cff import *
+from RecoJets.Configuration.GenJetParticles_cff import genParticlesForJetsNoNu
+from RecoJets.Configuration.RecoGenJets_cff import iterativeCone5GenJetsNoNu, ak4GenJetsNoNu, ak8GenJetsNoNu
 
 
 genForPF2PATSequence = cms.Sequence(

--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -4,7 +4,8 @@ from RecoTauTag.Configuration.RecoPFTauTag_cff import *
 from RecoTauTag.TauTagTools.PFTauSelector_cfi  import pfTauSelector
 import RecoTauTag.RecoTau.RecoTauCleanerPlugins as cleaners
 #from CommonTools.ParticleFlow.pfJets_cff import pfJets
-from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+#from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+import RecoJets.JetProducers.ak4PFJets_cfi as jetConfig
 
 '''
 
@@ -40,7 +41,7 @@ pfTauPFJets08Region.pfSrc = cms.InputTag("particleFlow")
 pfTauPFJetsRecoTauChargedHadrons.jetRegionSrc = 'pfTauPFJets08Region'
 
 pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone()
-pfTauTagInfoProducer.PFCandidateProducer = ak4PFJets.src
+pfTauTagInfoProducer.PFCandidateProducer = jetConfig.ak4PFJets.src
 pfTauTagInfoProducer.PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVertex'
 
 # Clone tau producer
@@ -124,7 +125,7 @@ pfTauPileUpVertices = cms.EDFilter(
 
 
 pfTauTagInfoProducer = pfRecoTauTagInfoProducer.clone()
-pfTauTagInfoProducer.PFCandidateProducer = ak4PFJets.src
+pfTauTagInfoProducer.PFCandidateProducer = jetConfig.ak4PFJets.src
 pfTauTagInfoProducer.PFJetTracksAssociatorProducer = 'pfJetTracksAssociatorAtVertex'
 
 

--- a/CommonTools/ParticleFlow/python/pfTaus_cff.py
+++ b/CommonTools/ParticleFlow/python/pfTaus_cff.py
@@ -3,8 +3,6 @@ import FWCore.ParameterSet.Config as cms
 from RecoTauTag.Configuration.RecoPFTauTag_cff import *
 from RecoTauTag.TauTagTools.PFTauSelector_cfi  import pfTauSelector
 import RecoTauTag.RecoTau.RecoTauCleanerPlugins as cleaners
-#from CommonTools.ParticleFlow.pfJets_cff import pfJets
-#from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
 import RecoJets.JetProducers.ak4PFJets_cfi as jetConfig
 
 '''
@@ -112,7 +110,6 @@ pfTausBaseSequence = cms.Sequence(
     )
 
 # Associate track to pfJets
-#from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import *
 pfJetTracksAssociatorAtVertex = ak4PFJetTracksAssociatorAtVertex.clone()
 pfJetTracksAssociatorAtVertex.jets= cms.InputTag("ak4PFJets")
 

--- a/PhysicsTools/PatAlgos/python/patSequences_cff.py
+++ b/PhysicsTools/PatAlgos/python/patSequences_cff.py
@@ -13,10 +13,7 @@ from PhysicsTools.PatAlgos.cleaningLayer1.cleanPatCandidates_cff import *
 from PhysicsTools.PatAlgos.selectionLayer1.countPatCandidates_cff import *
 
 patDefaultSequence = cms.Sequence(
-# remove this (particleFlowPtrs) after we switch to unscheduled mode everywhere
-# too many places to change otherwise
-    particleFlowPtrs *
-    patCandidates * 
+    patCandidates *
     selectedPatCandidates *
     cleanPatCandidates *
     countPatCandidates

--- a/PhysicsTools/PatAlgos/python/producersLayer1/electronProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/electronProducer_cff.py
@@ -5,44 +5,44 @@ from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from PhysicsTools.PatAlgos.producersLayer1.electronProducer_cfi import *
 
 from PhysicsTools.PatAlgos.recoLayer0.pfParticleSelectionForIso_cff import *
-from CommonTools.ParticleFlow.Isolation.pfElectronIsolation_cff import *
+from PhysicsTools.PatAlgos.recoLayer0.pfElectronIsolationPAT_cff import *
 
 sourceElectrons = patElectrons.electronSource
 
-elPFIsoDepositCharged.src = sourceElectrons
-elPFIsoDepositChargedAll.src = sourceElectrons
-elPFIsoDepositNeutral.src = sourceElectrons
-elPFIsoDepositGamma.src = sourceElectrons
-elPFIsoDepositPU.src = sourceElectrons
+elPFIsoDepositChargedPAT.src = sourceElectrons
+elPFIsoDepositChargedAllPAT.src = sourceElectrons
+elPFIsoDepositNeutralPAT.src = sourceElectrons
+elPFIsoDepositGammaPAT.src = sourceElectrons
+elPFIsoDepositPUPAT.src = sourceElectrons
 
 patElectrons.isoDeposits = cms.PSet(
-    pfChargedHadrons = cms.InputTag("elPFIsoDepositCharged" ),
-    pfChargedAll = cms.InputTag("elPFIsoDepositChargedAll" ),
-    pfPUChargedHadrons = cms.InputTag("elPFIsoDepositPU" ),
-    pfNeutralHadrons = cms.InputTag("elPFIsoDepositNeutral" ),
-    pfPhotons = cms.InputTag("elPFIsoDepositGamma" ),
+    pfChargedHadrons = cms.InputTag("elPFIsoDepositChargedPAT" ),
+    pfChargedAll = cms.InputTag("elPFIsoDepositChargedAllPAT" ),
+    pfPUChargedHadrons = cms.InputTag("elPFIsoDepositPUPAT" ),
+    pfNeutralHadrons = cms.InputTag("elPFIsoDepositNeutralPAT" ),
+    pfPhotons = cms.InputTag("elPFIsoDepositGammaPAT" ),
     )
 
 patElectrons.isolationValues = cms.PSet(
-    pfChargedHadrons = cms.InputTag("elPFIsoValueCharged04PFId"),
-    pfChargedAll = cms.InputTag("elPFIsoValueChargedAll04PFId"),
-    pfPUChargedHadrons = cms.InputTag("elPFIsoValuePU04PFId" ),
-    pfNeutralHadrons = cms.InputTag("elPFIsoValueNeutral04PFId" ),
-    pfPhotons = cms.InputTag("elPFIsoValueGamma04PFId" ),
+    pfChargedHadrons = cms.InputTag("elPFIsoValueCharged04PFIdPAT"),
+    pfChargedAll = cms.InputTag("elPFIsoValueChargedAll04PFIdPAT"),
+    pfPUChargedHadrons = cms.InputTag("elPFIsoValuePU04PFIdPAT" ),
+    pfNeutralHadrons = cms.InputTag("elPFIsoValueNeutral04PFIdPAT" ),
+    pfPhotons = cms.InputTag("elPFIsoValueGamma04PFIdPAT" ),
     )
 
 patElectrons.isolationValuesNoPFId = cms.PSet(
-    pfChargedHadrons = cms.InputTag("elPFIsoValueCharged04NoPFId"),
-    pfChargedAll = cms.InputTag("elPFIsoValueChargedAll04NoPFId"),
-    pfPUChargedHadrons = cms.InputTag("elPFIsoValuePU04NoPFId" ),
-    pfNeutralHadrons = cms.InputTag("elPFIsoValueNeutral04NoPFId" ),
-    pfPhotons = cms.InputTag("elPFIsoValueGamma04NoPFId" )
+    pfChargedHadrons = cms.InputTag("elPFIsoValueCharged04NoPFIdPAT"),
+    pfChargedAll = cms.InputTag("elPFIsoValueChargedAll04NoPFIdPAT"),
+    pfPUChargedHadrons = cms.InputTag("elPFIsoValuePU04NoPFIdPAT" ),
+    pfNeutralHadrons = cms.InputTag("elPFIsoValueNeutral04NoPFIdPAT" ),
+    pfPhotons = cms.InputTag("elPFIsoValueGamma04NoPFIdPAT" )
     )
 
 ## for scheduled mode
 makePatElectrons = cms.Sequence(
     pfParticleSelectionForIsoSequence *
-    pfElectronIsolationSequence *
+    pfElectronIsolationPATSequence *
     electronMatch *
     patElectrons
     )

--- a/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/muonProducer_cff.py
@@ -5,36 +5,36 @@ from TrackingTools.TransientTrack.TransientTrackBuilder_cfi import *
 from PhysicsTools.PatAlgos.producersLayer1.muonProducer_cfi import *
 
 from PhysicsTools.PatAlgos.recoLayer0.pfParticleSelectionForIso_cff import *
-from CommonTools.ParticleFlow.Isolation.pfMuonIsolation_cff import *
+from PhysicsTools.PatAlgos.recoLayer0.pfMuonIsolationPAT_cff import *
 
 sourceMuons = patMuons.muonSource
 
-muPFIsoDepositCharged.src = sourceMuons
-muPFIsoDepositChargedAll.src = sourceMuons
-muPFIsoDepositNeutral.src = sourceMuons
-muPFIsoDepositGamma.src = sourceMuons
-muPFIsoDepositPU.src = sourceMuons
+muPFIsoDepositChargedPAT.src = sourceMuons
+muPFIsoDepositChargedAllPAT.src = sourceMuons
+muPFIsoDepositNeutralPAT.src = sourceMuons
+muPFIsoDepositGammaPAT.src = sourceMuons
+muPFIsoDepositPUPAT.src = sourceMuons
 
 patMuons.isoDeposits = cms.PSet(
-    pfChargedHadrons = cms.InputTag("muPFIsoDepositCharged" ),
-    pfChargedAll = cms.InputTag("muPFIsoDepositChargedAll" ),
-    pfPUChargedHadrons = cms.InputTag("muPFIsoDepositPU" ),
-    pfNeutralHadrons = cms.InputTag("muPFIsoDepositNeutral" ),
-    pfPhotons = cms.InputTag("muPFIsoDepositGamma" ),
+    pfChargedHadrons = cms.InputTag("muPFIsoDepositChargedPAT" ),
+    pfChargedAll = cms.InputTag("muPFIsoDepositChargedAllPAT" ),
+    pfPUChargedHadrons = cms.InputTag("muPFIsoDepositPUPAT" ),
+    pfNeutralHadrons = cms.InputTag("muPFIsoDepositNeutralPAT" ),
+    pfPhotons = cms.InputTag("muPFIsoDepositGammaPAT" ),
     )
 
 patMuons.isolationValues = cms.PSet(
-    pfChargedHadrons = cms.InputTag("muPFIsoValueCharged04"),
-    pfChargedAll = cms.InputTag("muPFIsoValueChargedAll04"),
-    pfPUChargedHadrons = cms.InputTag("muPFIsoValuePU04" ),
-    pfNeutralHadrons = cms.InputTag("muPFIsoValueNeutral04" ),
-    pfPhotons = cms.InputTag("muPFIsoValueGamma04" ),
+    pfChargedHadrons = cms.InputTag("muPFIsoValueCharged04PAT"),
+    pfChargedAll = cms.InputTag("muPFIsoValueChargedAll04PAT"),
+    pfPUChargedHadrons = cms.InputTag("muPFIsoValuePU04PAT" ),
+    pfNeutralHadrons = cms.InputTag("muPFIsoValueNeutral04PAT" ),
+    pfPhotons = cms.InputTag("muPFIsoValueGamma04PAT" ),
     )
 
 ## for scheduled mode
 makePatMuons = cms.Sequence(
     pfParticleSelectionForIsoSequence *
-    pfMuonIsolationSequence *
+    muonPFIsolationPATSequence *
     muonMatch *
     patMuons
     )

--- a/PhysicsTools/PatAlgos/python/producersLayer1/photonProducer_cff.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/photonProducer_cff.py
@@ -4,36 +4,36 @@ from PhysicsTools.PatAlgos.mcMatchLayer0.photonMatch_cfi import *
 from PhysicsTools.PatAlgos.producersLayer1.photonProducer_cfi import *
 
 from PhysicsTools.PatAlgos.recoLayer0.pfParticleSelectionForIso_cff import *
-from CommonTools.ParticleFlow.Isolation.pfPhotonIsolation_cff import *
+from PhysicsTools.PatAlgos.recoLayer0.pfPhotonIsolationPAT_cff import *
 
 sourcePhotons = patPhotons.photonSource
 
-phPFIsoDepositCharged.src = sourcePhotons
-phPFIsoDepositChargedAll.src = sourcePhotons
-phPFIsoDepositNeutral.src = sourcePhotons
-phPFIsoDepositGamma.src = sourcePhotons
-phPFIsoDepositPU.src = sourcePhotons
+phPFIsoDepositChargedPAT.src = sourcePhotons
+phPFIsoDepositChargedAllPAT.src = sourcePhotons
+phPFIsoDepositNeutralPAT.src = sourcePhotons
+phPFIsoDepositGammaPAT.src = sourcePhotons
+phPFIsoDepositPUPAT.src = sourcePhotons
 
 patPhotons.isoDeposits = cms.PSet(
-    pfChargedHadrons = cms.InputTag("phPFIsoDepositCharged" ),
-    pfChargedAll = cms.InputTag("phPFIsoDepositChargedAll" ),
-    pfPUChargedHadrons = cms.InputTag("phPFIsoDepositPU" ),
-    pfNeutralHadrons = cms.InputTag("phPFIsoDepositNeutral" ),
-    pfPhotons = cms.InputTag("phPFIsoDepositGamma" ),
+    pfChargedHadrons = cms.InputTag("phPFIsoDepositChargedPAT" ),
+    pfChargedAll = cms.InputTag("phPFIsoDepositChargedAllPAT" ),
+    pfPUChargedHadrons = cms.InputTag("phPFIsoDepositPUPAT" ),
+    pfNeutralHadrons = cms.InputTag("phPFIsoDepositNeutralPAT" ),
+    pfPhotons = cms.InputTag("phPFIsoDepositGammaPAT" ),
     )
 
 patPhotons.isolationValues = cms.PSet(
-    pfChargedHadrons = cms.InputTag("phPFIsoValueCharged04PFId"),
-    pfChargedAll = cms.InputTag("phPFIsoValueChargedAll04PFId"),
-    pfPUChargedHadrons = cms.InputTag("phPFIsoValuePU04PFId" ),
-    pfNeutralHadrons = cms.InputTag("phPFIsoValueNeutral04PFId" ),
-    pfPhotons = cms.InputTag("phPFIsoValueGamma04PFId" ),
+    pfChargedHadrons = cms.InputTag("phPFIsoValueCharged04PFIdPAT"),
+    pfChargedAll = cms.InputTag("phPFIsoValueChargedAll04PFIdPAT"),
+    pfPUChargedHadrons = cms.InputTag("phPFIsoValuePU04PFIdPAT" ),
+    pfNeutralHadrons = cms.InputTag("phPFIsoValueNeutral04PFIdPAT" ),
+    pfPhotons = cms.InputTag("phPFIsoValueGamma04PFIdPAT" ),
     )
 
 ## for scheduled mode
 makePatPhotons = cms.Sequence(
     pfParticleSelectionForIsoSequence *
-    pfPhotonIsolationSequence *
+    pfPhotonIsolationPATSequence *
     photonMatch *
     patPhotons
     )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -16,6 +16,8 @@ supportedBtagInfos = [
   , 'inclusiveSecondaryVertexFinderFilteredNegativeTagInfos'
   , 'caTopTagInfos'
   ]
+# extend for "internal use" in PAT/MINIAOD (renaming)
+supportedBtagInfos.append( 'caTopTagInfosPAT' )
 
 ## dictionary with all available btag discriminators and the btagInfos that they require
 supportedBtagDiscr = {

--- a/PhysicsTools/PatAlgos/python/recoLayer0/electronPFIsolationDepositsPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/electronPFIsolationDepositsPAT_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.electronPFIsolationDepositsPFBRECO_cff import *
+
+#Now prepare the iso deposits
+elPFIsoDepositChargedPAT    = elPFIsoDepositChargedPFBRECO.clone()
+elPFIsoDepositChargedAllPAT = elPFIsoDepositChargedAllPFBRECO.clone()
+elPFIsoDepositNeutralPAT    = elPFIsoDepositNeutralPFBRECO.clone()
+elPFIsoDepositPUPAT         = elPFIsoDepositPUPFBRECO.clone()
+#elPFIsoDepositGammaPAT      = #elPFIsoDepositGammaPFBRECO.clone()
+elPFIsoDepositGammaPAT      = elPFIsoDepositGammaPFBRECO.clone()
+
+electronPFIsolationDepositsPATSequence = cms.Sequence(
+    elPFIsoDepositChargedPAT+
+    elPFIsoDepositChargedAllPAT+
+    elPFIsoDepositGammaPAT+
+    elPFIsoDepositNeutralPAT+
+    elPFIsoDepositPUPAT
+    )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/electronPFIsolationValuesPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/electronPFIsolationValuesPAT_cff.py
@@ -1,0 +1,140 @@
+import FWCore.ParameterSet.Config as cms
+
+
+
+elPFIsoValueCharged03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("elPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.015)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+            )
+     )
+)
+
+elPFIsoValueChargedAll03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("elPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.015)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+     )
+   )
+)
+
+elPFIsoValueGamma03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("elPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.08)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+      )
+   )
+)
+
+elPFIsoValueNeutral03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("elPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+            )
+        )
+    )
+
+elPFIsoValuePU03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("elPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.015)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+            )
+   )
+)
+
+
+
+elPFIsoValueCharged04PFIdPAT = elPFIsoValueCharged03PFIdPAT.clone()
+elPFIsoValueCharged04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
+
+
+elPFIsoValueChargedAll04PFIdPAT = elPFIsoValueChargedAll03PFIdPAT.clone()
+elPFIsoValueChargedAll04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
+
+elPFIsoValueGamma04PFIdPAT = elPFIsoValueGamma03PFIdPAT.clone()
+elPFIsoValueGamma04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
+
+
+elPFIsoValueNeutral04PFIdPAT = elPFIsoValueNeutral03PFIdPAT.clone()
+elPFIsoValueNeutral04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
+
+elPFIsoValuePU04PFIdPAT = elPFIsoValuePU03PFIdPAT.clone()
+elPFIsoValuePU04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
+
+##########Now the PFNoId
+elPFIsoValueCharged03NoPFIdPAT     =  elPFIsoValueCharged03PFIdPAT.clone()
+elPFIsoValueChargedAll03NoPFIdPAT  =  elPFIsoValueChargedAll03PFIdPAT.clone()
+elPFIsoValueGamma03NoPFIdPAT       =  elPFIsoValueGamma03PFIdPAT.clone()
+elPFIsoValueNeutral03NoPFIdPAT     =  elPFIsoValueNeutral03PFIdPAT.clone()
+elPFIsoValuePU03NoPFIdPAT          =  elPFIsoValuePU03PFIdPAT.clone()
+# Customization - No longer needed with new recommendation
+#elPFIsoValueCharged03NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueChargedAll03NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValuePU03NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueGamma03NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:RectangularEtaPhiVeto(-0.02,0.02,-0.5,0.5)','EcalEndcaps:ConeVeto(0.08)')
+
+
+elPFIsoValueCharged04NoPFIdPAT     =  elPFIsoValueCharged04PFIdPAT.clone()
+elPFIsoValueChargedAll04NoPFIdPAT  =  elPFIsoValueChargedAll04PFIdPAT.clone()
+elPFIsoValueGamma04NoPFIdPAT       =  elPFIsoValueGamma04PFIdPAT.clone()
+elPFIsoValueNeutral04NoPFIdPAT     =  elPFIsoValueNeutral04PFIdPAT.clone()
+elPFIsoValuePU04NoPFIdPAT          =  elPFIsoValuePU04PFIdPAT.clone()
+#elPFIsoValueCharged04NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueChargedAll04NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValuePU04NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:ConeVeto(0.015)','EcalEndcaps:ConeVeto(0.015)')
+#elPFIsoValueGamma04NoPFIdPAT.deposits[0].vetos = cms.vstring('EcalBarrel:RectangularEtaPhiVeto(-0.02,0.02,-0.5,0.5)','EcalEndcaps:ConeVeto(0.08)')
+
+electronPFIsolationValuesPATSequence = (
+    elPFIsoValueCharged03PFIdPAT+
+    elPFIsoValueChargedAll03PFIdPAT+
+    elPFIsoValueGamma03PFIdPAT+
+    elPFIsoValueNeutral03PFIdPAT+
+    elPFIsoValuePU03PFIdPAT+
+    ##############################
+    elPFIsoValueCharged04PFIdPAT+
+    elPFIsoValueChargedAll04PFIdPAT+
+    elPFIsoValueGamma04PFIdPAT+
+    elPFIsoValueNeutral04PFIdPAT+
+    elPFIsoValuePU04PFIdPAT+
+    ##############################
+    elPFIsoValueCharged03NoPFIdPAT+
+    elPFIsoValueChargedAll03NoPFIdPAT+
+    elPFIsoValueGamma03NoPFIdPAT+
+    elPFIsoValueNeutral03NoPFIdPAT+
+    elPFIsoValuePU03NoPFIdPAT+
+    ##############################
+    elPFIsoValueCharged04NoPFIdPAT+
+    elPFIsoValueChargedAll04NoPFIdPAT+
+    elPFIsoValueGamma04NoPFIdPAT+
+    elPFIsoValueNeutral04NoPFIdPAT+
+    elPFIsoValuePU04NoPFIdPAT)

--- a/PhysicsTools/PatAlgos/python/recoLayer0/electronPFIsolationValuesPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/electronPFIsolationValuesPAT_cff.py
@@ -1,89 +1,30 @@
 import FWCore.ParameterSet.Config as cms
 
+from CommonTools.ParticleFlow.Isolation.electronPFIsolationValuesPFBRECO_cff import *
 
+elPFIsoValueCharged03PFIdPAT = elPFIsoValueCharged03PFIdPFBRECO.clone()
+elPFIsoValueCharged03PFIdPAT.deposits[0].src = 'elPFIsoDepositChargedPAT'
 
-elPFIsoValueCharged03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("elPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.015)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-            )
-     )
-)
+elPFIsoValueChargedAll03PFIdPAT = elPFIsoValueChargedAll03PFIdPFBRECO.clone()
+elPFIsoValueChargedAll03PFIdPAT.deposits[0].src = 'elPFIsoDepositChargedAllPAT'
 
-elPFIsoValueChargedAll03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("elPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.015)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-     )
-   )
-)
+elPFIsoValueGamma03PFIdPAT = elPFIsoValueGamma03PFIdPFBRECO.clone()
+elPFIsoValueGamma03PFIdPAT.deposits[0].src = 'elPFIsoDepositGammaPAT'
 
-elPFIsoValueGamma03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("elPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.08)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-      )
-   )
-)
+elPFIsoValueNeutral03PFIdPAT = elPFIsoValueNeutral03PFIdPFBRECO.clone()
+elPFIsoValueNeutral03PFIdPAT.deposits[0].src = 'elPFIsoDepositNeutralPAT'
 
-elPFIsoValueNeutral03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("elPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-            )
-        )
-    )
-
-elPFIsoValuePU03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("elPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.015)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-            )
-   )
-)
-
-
+elPFIsoValuePU03PFIdPAT = elPFIsoValuePU03PFIdPFBRECO.clone()
+elPFIsoValuePU03PFIdPAT.deposits[0].src = 'elPFIsoDepositPUPAT'
 
 elPFIsoValueCharged04PFIdPAT = elPFIsoValueCharged03PFIdPAT.clone()
 elPFIsoValueCharged04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
-
 
 elPFIsoValueChargedAll04PFIdPAT = elPFIsoValueChargedAll03PFIdPAT.clone()
 elPFIsoValueChargedAll04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
 
 elPFIsoValueGamma04PFIdPAT = elPFIsoValueGamma03PFIdPAT.clone()
 elPFIsoValueGamma04PFIdPAT.deposits[0].deltaR = cms.double(0.4)
-
 
 elPFIsoValueNeutral04PFIdPAT = elPFIsoValueNeutral03PFIdPAT.clone()
 elPFIsoValueNeutral04PFIdPAT.deposits[0].deltaR = cms.double(0.4)

--- a/PhysicsTools/PatAlgos/python/recoLayer0/muonPFIsolationDepositsPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/muonPFIsolationDepositsPAT_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.muonPFIsolationDepositsPFBRECO_cff import *
+
+#Now prepare the iso deposits
+muPFIsoDepositChargedPAT    = muPFIsoDepositChargedPFBRECO.clone()
+muPFIsoDepositChargedAllPAT = muPFIsoDepositChargedAllPFBRECO.clone()
+muPFIsoDepositNeutralPAT    = muPFIsoDepositNeutralPFBRECO.clone()
+muPFIsoDepositGammaPAT      = muPFIsoDepositGammaPFBRECO.clone()
+muPFIsoDepositPUPAT         = muPFIsoDepositPUPFBRECO.clone()
+
+muonPFIsolationDepositsPATSequence = cms.Sequence(
+    muPFIsoDepositChargedPAT+
+    muPFIsoDepositChargedAllPAT+
+    muPFIsoDepositGammaPAT+
+    muPFIsoDepositNeutralPAT+
+    muPFIsoDepositPUPAT
+    )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/muonPFIsolationValuesPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/muonPFIsolationValuesPAT_cff.py
@@ -1,0 +1,617 @@
+import FWCore.ParameterSet.Config as cms
+
+
+
+muPFIsoValueCharged03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+            )
+     )
+)
+
+
+muPFSumDRIsoValueCharged03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+            )
+     )
+)
+
+muPFMeanDRIsoValueCharged03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+            )
+     )
+)
+
+
+muPFIsoValueChargedAll03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+     )
+   )
+)
+
+muPFSumDRIsoValueChargedAll03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+     )
+   )
+)
+
+muPFMeanDRIsoValueChargedAll03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+     )
+   )
+)
+
+
+muPFIsoValueGamma03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+      )
+   )
+)
+muPFSumDRIsoValueGamma03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+      )
+   )
+)
+
+muPFMeanDRIsoValueGamma03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+      )
+   )
+)
+
+
+muPFIsoValueNeutral03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+    )
+ )
+)
+muPFSumDRIsoValueNeutral03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+    )
+ )
+)
+
+muPFMeanDRIsoValueNeutral03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+    )
+ )
+)
+
+
+
+muPFIsoValueGammaHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+      )
+   )
+)
+muPFSumDRIsoValueGammaHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+      )
+   )
+)
+
+muPFMeanDRIsoValueGammaHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+      )
+   )
+)
+
+
+muPFIsoValueNeutralHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+    )
+ )
+)
+
+muPFMeanDRIsoValueNeutralHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+    )
+ )
+)
+
+muPFSumDRIsoValueNeutralHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+    )
+ )
+)
+
+muPFIsoValuePU03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+      )
+   )
+)
+
+muPFSumDRIsoValuePU03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+      )
+   )
+)
+
+muPFMeanDRIsoValuePU03PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+      )
+   )
+)
+
+
+
+muPFIsoValueCharged04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+            )
+     )
+)
+
+muPFSumDRIsoValueCharged04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+            )
+     )
+)
+
+muPFMeanDRIsoValueCharged04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+            )
+     )
+)
+
+
+
+
+muPFIsoValueChargedAll04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+     )
+   )
+)
+
+muPFSumDRIsoValueChargedAll04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+     )
+   )
+)
+
+muPFMeanDRIsoValueChargedAll04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.0001','Threshold(0.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+     )
+   )
+)
+
+
+
+
+
+muPFIsoValueGamma04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+      )
+   )
+)
+
+muPFSumDRIsoValueGamma04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+      )
+   )
+)
+
+muPFMeanDRIsoValueGamma04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+      )
+   )
+)
+
+
+muPFIsoValueNeutral04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+    )
+ )
+
+)
+
+muPFSumDRIsoValueNeutral04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+    )
+ )
+
+)
+
+muPFMeanDRIsoValueNeutral04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+    )
+ )
+
+)
+
+
+muPFIsoValueGammaHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+      )
+   )
+)
+
+muPFMeanDRIsoValueGammaHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+      )
+   )
+)
+
+muPFSumDRIsoValueGammaHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+      )
+   )
+)
+
+
+muPFIsoValueNeutralHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+    )
+ )
+
+)
+
+muPFMeanDRIsoValueNeutralHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+    )
+ )
+
+)
+
+muPFSumDRIsoValueNeutralHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(1.0)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+    )
+ )
+
+)
+
+muPFIsoValuePU04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum')
+      )
+   )
+)
+
+muPFMeanDRIsoValuePU04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('meanDR')
+      )
+   )
+)
+
+muPFSumDRIsoValuePU04PAT = cms.EDProducer("CandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("muPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('0.01','Threshold(0.5)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sumDR')
+      )
+   )
+)
+
+muonPFIsolationValuesPATSequence = (
+    muPFIsoValueCharged03PAT+
+    muPFMeanDRIsoValueCharged03PAT+
+    muPFSumDRIsoValueCharged03PAT+
+    muPFIsoValueChargedAll03PAT+
+    muPFMeanDRIsoValueChargedAll03PAT+
+    muPFSumDRIsoValueChargedAll03PAT+
+    muPFIsoValueGamma03PAT+
+    muPFMeanDRIsoValueGamma03PAT+
+    muPFSumDRIsoValueGamma03PAT+
+    muPFIsoValueNeutral03PAT+
+    muPFMeanDRIsoValueNeutral03PAT+
+    muPFSumDRIsoValueNeutral03PAT+
+    muPFIsoValueGammaHighThreshold03PAT+
+    muPFMeanDRIsoValueGammaHighThreshold03PAT+
+    muPFSumDRIsoValueGammaHighThreshold03PAT+
+    muPFIsoValueNeutralHighThreshold03PAT+
+    muPFMeanDRIsoValueNeutralHighThreshold03PAT+
+    muPFSumDRIsoValueNeutralHighThreshold03PAT+
+    muPFIsoValuePU03PAT+
+    muPFMeanDRIsoValuePU03PAT+
+    muPFSumDRIsoValuePU03PAT+
+    ##############################
+    muPFIsoValueCharged04PAT+
+    muPFMeanDRIsoValueCharged04PAT+
+    muPFSumDRIsoValueCharged04PAT+
+    muPFIsoValueChargedAll04PAT+
+    muPFMeanDRIsoValueChargedAll04PAT+
+    muPFSumDRIsoValueChargedAll04PAT+
+    muPFIsoValueGamma04PAT+
+    muPFMeanDRIsoValueGamma04PAT+
+    muPFSumDRIsoValueGamma04PAT+
+    muPFIsoValueNeutral04PAT+
+    muPFMeanDRIsoValueNeutral04PAT+
+    muPFSumDRIsoValueNeutral04PAT+
+    muPFIsoValueGammaHighThreshold04PAT+
+    muPFMeanDRIsoValueGammaHighThreshold04PAT+
+    muPFSumDRIsoValueGammaHighThreshold04PAT+
+    muPFIsoValueNeutralHighThreshold04PAT+
+    muPFMeanDRIsoValueNeutralHighThreshold04PAT+
+    muPFSumDRIsoValueNeutralHighThreshold04PAT+
+    muPFIsoValuePU04PAT+
+    muPFMeanDRIsoValuePU04PAT+
+    muPFSumDRIsoValuePU04PAT
+    )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/muonPFIsolationValuesPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/muonPFIsolationValuesPAT_cff.py
@@ -1,574 +1,92 @@
 import FWCore.ParameterSet.Config as cms
 
-
-
-muPFIsoValueCharged03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-            )
-     )
-)
-
-
-muPFSumDRIsoValueCharged03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-            )
-     )
-)
-
-muPFMeanDRIsoValueCharged03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-            )
-     )
-)
-
-
-muPFIsoValueChargedAll03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-     )
-   )
-)
-
-muPFSumDRIsoValueChargedAll03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-     )
-   )
-)
-
-muPFMeanDRIsoValueChargedAll03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-     )
-   )
-)
-
-
-muPFIsoValueGamma03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-      )
-   )
-)
-muPFSumDRIsoValueGamma03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-      )
-   )
-)
-
-muPFMeanDRIsoValueGamma03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-      )
-   )
-)
-
-
-muPFIsoValueNeutral03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-    )
- )
-)
-muPFSumDRIsoValueNeutral03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-    )
- )
-)
-
-muPFMeanDRIsoValueNeutral03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-    )
- )
-)
-
-
-
-muPFIsoValueGammaHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-      )
-   )
-)
-muPFSumDRIsoValueGammaHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-      )
-   )
-)
-
-muPFMeanDRIsoValueGammaHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-      )
-   )
-)
-
-
-muPFIsoValueNeutralHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-    )
- )
-)
-
-muPFMeanDRIsoValueNeutralHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-    )
- )
-)
-
-muPFSumDRIsoValueNeutralHighThreshold03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-    )
- )
-)
-
-muPFIsoValuePU03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-      )
-   )
-)
-
-muPFSumDRIsoValuePU03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-      )
-   )
-)
-
-muPFMeanDRIsoValuePU03PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-      )
-   )
-)
-
-
-
-muPFIsoValueCharged04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-            )
-     )
-)
-
-muPFSumDRIsoValueCharged04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-            )
-     )
-)
-
-muPFMeanDRIsoValueCharged04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-            )
-     )
-)
-
-
-
-
-muPFIsoValueChargedAll04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-     )
-   )
-)
-
-muPFSumDRIsoValueChargedAll04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-     )
-   )
-)
-
-muPFMeanDRIsoValueChargedAll04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.0001','Threshold(0.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-     )
-   )
-)
-
-
-
-
-
-muPFIsoValueGamma04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-      )
-   )
-)
-
-muPFSumDRIsoValueGamma04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-      )
-   )
-)
-
-muPFMeanDRIsoValueGamma04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-      )
-   )
-)
-
-
-muPFIsoValueNeutral04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-    )
- )
-
-)
-
-muPFSumDRIsoValueNeutral04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-    )
- )
-
-)
-
-muPFMeanDRIsoValueNeutral04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-    )
- )
-
-)
-
-
-muPFIsoValueGammaHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-      )
-   )
-)
-
-muPFMeanDRIsoValueGammaHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-      )
-   )
-)
-
-muPFSumDRIsoValueGammaHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-      )
-   )
-)
-
-
-muPFIsoValueNeutralHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-    )
- )
-
-)
-
-muPFMeanDRIsoValueNeutralHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-    )
- )
-
-)
-
-muPFSumDRIsoValueNeutralHighThreshold04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(1.0)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-    )
- )
-
-)
-
-muPFIsoValuePU04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum')
-      )
-   )
-)
-
-muPFMeanDRIsoValuePU04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('meanDR')
-      )
-   )
-)
-
-muPFSumDRIsoValuePU04PAT = cms.EDProducer("CandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("muPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('0.01','Threshold(0.5)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sumDR')
-      )
-   )
-)
+from CommonTools.ParticleFlow.Isolation.muonPFIsolationValuesPFBRECO_cff import *
+
+muPFIsoValueCharged03PAT = muPFIsoValueCharged03PFBRECO.clone()
+muPFIsoValueCharged03PAT.deposits[0].src = 'muPFIsoDepositChargedPAT'
+muPFMeanDRIsoValueCharged03PAT = muPFMeanDRIsoValueCharged03PFBRECO.clone()
+muPFMeanDRIsoValueCharged03PAT.deposits[0].src = 'muPFIsoDepositChargedPAT'
+muPFSumDRIsoValueCharged03PAT = muPFSumDRIsoValueCharged03PFBRECO.clone()
+muPFSumDRIsoValueCharged03PAT.deposits[0].src = 'muPFIsoDepositChargedPAT'
+muPFIsoValueChargedAll03PAT = muPFIsoValueChargedAll03PFBRECO.clone()
+muPFIsoValueChargedAll03PAT.deposits[0].src = 'muPFIsoDepositChargedAllPAT'
+muPFMeanDRIsoValueChargedAll03PAT = muPFMeanDRIsoValueChargedAll03PFBRECO.clone()
+muPFMeanDRIsoValueChargedAll03PAT.deposits[0].src = 'muPFIsoDepositChargedAllPAT'
+muPFSumDRIsoValueChargedAll03PAT = muPFSumDRIsoValueChargedAll03PFBRECO.clone()
+muPFSumDRIsoValueChargedAll03PAT.deposits[0].src = 'muPFIsoDepositChargedAllPAT'
+muPFIsoValueGamma03PAT = muPFIsoValueGamma03PFBRECO.clone()
+muPFIsoValueGamma03PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFMeanDRIsoValueGamma03PAT = muPFMeanDRIsoValueGamma03PFBRECO.clone()
+muPFMeanDRIsoValueGamma03PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFSumDRIsoValueGamma03PAT = muPFSumDRIsoValueGamma03PFBRECO.clone()
+muPFSumDRIsoValueGamma03PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFIsoValueNeutral03PAT = muPFIsoValueNeutral03PFBRECO.clone()
+muPFIsoValueNeutral03PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFMeanDRIsoValueNeutral03PAT = muPFMeanDRIsoValueNeutral03PFBRECO.clone()
+muPFMeanDRIsoValueNeutral03PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFSumDRIsoValueNeutral03PAT = muPFSumDRIsoValueNeutral03PFBRECO.clone()
+muPFSumDRIsoValueNeutral03PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFIsoValueGammaHighThreshold03PAT = muPFIsoValueGammaHighThreshold03PFBRECO.clone()
+muPFIsoValueGammaHighThreshold03PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFMeanDRIsoValueGammaHighThreshold03PAT = muPFMeanDRIsoValueGammaHighThreshold03PFBRECO.clone()
+muPFMeanDRIsoValueGammaHighThreshold03PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFSumDRIsoValueGammaHighThreshold03PAT = muPFSumDRIsoValueGammaHighThreshold03PFBRECO.clone()
+muPFSumDRIsoValueGammaHighThreshold03PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFIsoValueNeutralHighThreshold03PAT = muPFIsoValueNeutralHighThreshold03PFBRECO.clone()
+muPFIsoValueNeutralHighThreshold03PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFMeanDRIsoValueNeutralHighThreshold03PAT = muPFMeanDRIsoValueNeutralHighThreshold03PFBRECO.clone()
+muPFMeanDRIsoValueNeutralHighThreshold03PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFSumDRIsoValueNeutralHighThreshold03PAT = muPFSumDRIsoValueNeutralHighThreshold03PFBRECO.clone()
+muPFSumDRIsoValueNeutralHighThreshold03PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFIsoValuePU03PAT = muPFIsoValuePU03PFBRECO.clone()
+muPFIsoValuePU03PAT.deposits[0].src = 'muPFIsoDepositPUPAT'
+muPFMeanDRIsoValuePU03PAT = muPFMeanDRIsoValuePU03PFBRECO.clone()
+muPFMeanDRIsoValuePU03PAT.deposits[0].src = 'muPFIsoDepositPUPAT'
+muPFSumDRIsoValuePU03PAT = muPFSumDRIsoValuePU03PFBRECO.clone()
+muPFSumDRIsoValuePU03PAT.deposits[0].src = 'muPFIsoDepositPUPAT'
+##############################
+muPFIsoValueCharged04PAT = muPFIsoValueCharged04PFBRECO.clone()
+muPFIsoValueCharged04PAT.deposits[0].src = 'muPFIsoDepositChargedPAT'
+muPFMeanDRIsoValueCharged04PAT = muPFMeanDRIsoValueCharged04PFBRECO.clone()
+muPFMeanDRIsoValueCharged04PAT.deposits[0].src = 'muPFIsoDepositChargedPAT'
+muPFSumDRIsoValueCharged04PAT = muPFSumDRIsoValueCharged04PFBRECO.clone()
+muPFSumDRIsoValueCharged04PAT.deposits[0].src = 'muPFIsoDepositChargedPAT'
+muPFIsoValueChargedAll04PAT = muPFIsoValueChargedAll04PFBRECO.clone()
+muPFIsoValueChargedAll04PAT.deposits[0].src = 'muPFIsoDepositChargedAllPAT'
+muPFMeanDRIsoValueChargedAll04PAT = muPFMeanDRIsoValueChargedAll04PFBRECO.clone()
+muPFMeanDRIsoValueChargedAll04PAT.deposits[0].src = 'muPFIsoDepositChargedAllPAT'
+muPFSumDRIsoValueChargedAll04PAT = muPFSumDRIsoValueChargedAll04PFBRECO.clone()
+muPFSumDRIsoValueChargedAll04PAT.deposits[0].src = 'muPFIsoDepositChargedAllPAT'
+muPFIsoValueGamma04PAT = muPFIsoValueGamma04PFBRECO.clone()
+muPFIsoValueGamma04PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFMeanDRIsoValueGamma04PAT = muPFMeanDRIsoValueGamma04PFBRECO.clone()
+muPFMeanDRIsoValueGamma04PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFSumDRIsoValueGamma04PAT = muPFSumDRIsoValueGamma04PFBRECO.clone()
+muPFSumDRIsoValueGamma04PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFIsoValueNeutral04PAT = muPFIsoValueNeutral04PFBRECO.clone()
+muPFIsoValueNeutral04PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFMeanDRIsoValueNeutral04PAT = muPFMeanDRIsoValueNeutral04PFBRECO.clone()
+muPFMeanDRIsoValueNeutral04PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFSumDRIsoValueNeutral04PAT = muPFSumDRIsoValueNeutral04PFBRECO.clone()
+muPFSumDRIsoValueNeutral04PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFIsoValueGammaHighThreshold04PAT = muPFIsoValueGammaHighThreshold04PFBRECO.clone()
+muPFIsoValueGammaHighThreshold04PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFMeanDRIsoValueGammaHighThreshold04PAT = muPFMeanDRIsoValueGammaHighThreshold04PFBRECO.clone()
+muPFMeanDRIsoValueGammaHighThreshold04PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFSumDRIsoValueGammaHighThreshold04PAT = muPFSumDRIsoValueGammaHighThreshold04PFBRECO.clone()
+muPFSumDRIsoValueGammaHighThreshold04PAT.deposits[0].src = 'muPFIsoDepositGammaPAT'
+muPFIsoValueNeutralHighThreshold04PAT = muPFIsoValueNeutralHighThreshold04PFBRECO.clone()
+muPFIsoValueNeutralHighThreshold04PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFMeanDRIsoValueNeutralHighThreshold04PAT = muPFMeanDRIsoValueNeutralHighThreshold04PFBRECO.clone()
+muPFMeanDRIsoValueNeutralHighThreshold04PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFSumDRIsoValueNeutralHighThreshold04PAT = muPFSumDRIsoValueNeutralHighThreshold04PFBRECO.clone()
+muPFSumDRIsoValueNeutralHighThreshold04PAT.deposits[0].src = 'muPFIsoDepositNeutralPAT'
+muPFIsoValuePU04PAT = muPFIsoValuePU04PFBRECO.clone()
+muPFIsoValuePU04PAT.deposits[0].src = 'muPFIsoDepositPUPAT'
+muPFMeanDRIsoValuePU04PAT = muPFMeanDRIsoValuePU04PFBRECO.clone()
+muPFMeanDRIsoValuePU04PAT.deposits[0].src = 'muPFIsoDepositPUPAT'
+muPFSumDRIsoValuePU04PAT = muPFSumDRIsoValuePU04PFBRECO.clone()
+muPFSumDRIsoValuePU04PAT.deposits[0].src = 'muPFIsoDepositPUPAT'
 
 muonPFIsolationValuesPATSequence = (
     muPFIsoValueCharged03PAT+

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfCandidateIsoDepositSelection_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfCandidateIsoDepositSelection_cff.py
@@ -1,12 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.ParticleFlow.ParticleSelectors.pfSortByType_cff import *
-from CommonTools.ParticleFlow.pfNoPileUpIso_cff  import *
-
-pfPileUpIso.PFCandidates = 'particleFlowPtrs'
-pfNoPileUpIso.bottomCollection='particleFlowPtrs'
+from CommonTools.ParticleFlow.PFBRECO_cff  import *
 
 patPFCandidateIsoDepositSelection = cms.Sequence(
-       pfNoPileUpIsoSequence +
-       pfSortByTypeSequence
+       pfNoPileUpIsoPFBRECOSequence +
+       pfSortByTypePFBRECOSequence
        )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfCandidateIsoDepositSelection_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfCandidateIsoDepositSelection_cff.py
@@ -1,6 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from CommonTools.ParticleFlow.PFBRECO_cff  import *
+from CommonTools.ParticleFlow.PFBRECO_cff import pfPileUpIsoPFBRECO, pfNoPileUpIsoPFBRECO, pfNoPileUpIsoPFBRECOSequence
+from CommonTools.ParticleFlow.PFBRECO_cff import pfAllNeutralHadronsPFBRECO, pfAllChargedHadronsPFBRECO, pfAllPhotonsPFBRECO, pfAllChargedParticlesPFBRECO, pfPileUpAllChargedParticlesPFBRECO, pfAllNeutralHadronsAndPhotonsPFBRECO, pfSortByTypePFBRECOSequence
 
 patPFCandidateIsoDepositSelection = cms.Sequence(
        pfNoPileUpIsoPFBRECOSequence +

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfElectronIsolationPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfElectronIsolationPAT_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.PatAlgos.recoLayer0.electronPFIsolationDepositsPAT_cff import *
+from PhysicsTools.PatAlgos.recoLayer0.electronPFIsolationValuesPAT_cff import *
+
+pfElectronIsolationPATSequence = cms.Sequence(
+    electronPFIsolationDepositsPATSequence +
+    electronPFIsolationValuesPATSequence
+    )
+

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfMuonIsolationPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfMuonIsolationPAT_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+# iso deposits and isolation values, defined by the Muon POG
+
+from PhysicsTools.PatAlgos.recoLayer0.muonPFIsolationDepositsPAT_cff import *
+from PhysicsTools.PatAlgos.recoLayer0.muonPFIsolationValuesPAT_cff import *
+
+muonPFIsolationPATSequence =  cms.Sequence(
+    muonPFIsolationDepositsPATSequence +
+    muonPFIsolationValuesPATSequence
+)

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfParticleSelectionForIso_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfParticleSelectionForIso_cff.py
@@ -1,14 +1,6 @@
-from RecoParticleFlow.PFProducer.pfLinker_cff import particleFlowPtrs
-from CommonTools.ParticleFlow.pfParticleSelection_cff import *
-pfPileUp.PFCandidates = 'particleFlowPtrs'
-pfNoPileUp.bottomCollection = 'particleFlowPtrs'
-pfPileUpIso.PFCandidates = 'particleFlowPtrs'
-pfNoPileUpIso.bottomCollection='particleFlowPtrs'
-pfPileUpJME.PFCandidates = 'particleFlowPtrs'
-pfNoPileUpJME.bottomCollection='particleFlowPtrs'
+from CommonTools.ParticleFlow.PFBRECO_cff import *
 
 pfParticleSelectionForIsoSequence = cms.Sequence(
     particleFlowPtrs +
-    pfNoPileUpIsoSequence +
-    pfParticleSelectionSequence
+    pfParticleSelectionPFBRECOSequence
     )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfParticleSelectionForIso_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfParticleSelectionForIso_cff.py
@@ -1,4 +1,10 @@
-from CommonTools.ParticleFlow.PFBRECO_cff import *
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.PFBRECO_cff import particleFlowPtrs
+from CommonTools.ParticleFlow.PFBRECO_cff import pfPileUpIsoPFBRECO, pfNoPileUpIsoPFBRECO, pfNoPileUpIsoPFBRECOSequence
+from CommonTools.ParticleFlow.PFBRECO_cff import pfPileUpPFBRECO, pfNoPileUpPFBRECO, pfNoPileUpPFBRECOSequence
+from CommonTools.ParticleFlow.PFBRECO_cff import pfAllNeutralHadronsPFBRECO, pfAllChargedHadronsPFBRECO, pfAllPhotonsPFBRECO, pfAllChargedParticlesPFBRECO, pfPileUpAllChargedParticlesPFBRECO, pfAllNeutralHadronsAndPhotonsPFBRECO, pfSortByTypePFBRECOSequence
+from CommonTools.ParticleFlow.PFBRECO_cff import pfParticleSelectionPFBRECOSequence
 
 pfParticleSelectionForIsoSequence = cms.Sequence(
     particleFlowPtrs +

--- a/PhysicsTools/PatAlgos/python/recoLayer0/pfPhotonIsolationPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/pfPhotonIsolationPAT_cff.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.PatAlgos.recoLayer0.photonPFIsolationDepositsPAT_cff import *
+from PhysicsTools.PatAlgos.recoLayer0.photonPFIsolationValuesPAT_cff import *
+
+pfPhotonIsolationPATSequence = cms.Sequence(
+    photonPFIsolationDepositsPATSequence +
+    photonPFIsolationValuesPATSequence
+    )
+

--- a/PhysicsTools/PatAlgos/python/recoLayer0/photonPFIsolationDepositsPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/photonPFIsolationDepositsPAT_cff.py
@@ -1,0 +1,19 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.ParticleFlow.Isolation.photonPFIsolationDepositsPFBRECO_cff import *
+
+#Now prepare the iso deposits
+phPFIsoDepositChargedPAT    = phPFIsoDepositChargedPFBRECO.clone()
+phPFIsoDepositChargedAllPAT = phPFIsoDepositChargedAllPFBRECO.clone()
+phPFIsoDepositNeutralPAT    = phPFIsoDepositNeutralPFBRECO.clone()
+#phPFIsoDepositGammaPAT      = phPFIsoDepositGammaPFBRECO.clone()
+phPFIsoDepositPUPAT         = phPFIsoDepositPUPFBRECO.clone()
+phPFIsoDepositGammaPAT      = phPFIsoDepositGammaPFBRECO.clone()
+
+photonPFIsolationDepositsPATSequence = cms.Sequence(
+    phPFIsoDepositChargedPAT+
+    phPFIsoDepositChargedAllPAT+
+    phPFIsoDepositGammaPAT+
+    phPFIsoDepositNeutralPAT+
+    phPFIsoDepositPUPAT
+    )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/photonPFIsolationValuesPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/photonPFIsolationValuesPAT_cff.py
@@ -1,152 +1,36 @@
 import FWCore.ParameterSet.Config as cms
 
+from CommonTools.ParticleFlow.Isolation.photonPFIsolationValuesPFBRECO_cff import *
 
+phPFIsoValueCharged03PFIdPAT = phPFIsoValueCharged03PFIdPFBRECO.clone()
+phPFIsoValueCharged03PFIdPAT.deposits[0].src = 'phPFIsoDepositChargedPAT'
 
-phPFIsoValueCharged03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-            )
-     )
-)
+phPFIsoValueChargedAll03PFIdPAT = phPFIsoValueChargedAll03PFIdPFBRECO.clone()
+phPFIsoValueChargedAll03PFIdPAT.deposits[0].src = 'phPFIsoDepositChargedAllPAT'
 
-phPFIsoValueChargedAll03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-     )
-   )
-)
+phPFIsoValueGamma03PFIdPAT = phPFIsoValueGamma03PFIdPFBRECO.clone()
+phPFIsoValueGamma03PFIdPAT.deposits[0].src = 'phPFIsoDepositGammaPAT'
 
-phPFIsoValueGamma03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.05)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-      )
-   )
-)
+phPFIsoValueNeutral03PFIdPAT = phPFIsoValueNeutral03PFIdPFBRECO.clone()
+phPFIsoValueNeutral03PFIdPAT.deposits[0].src = 'phPFIsoDepositNeutralPAT'
 
-phPFIsoValueNeutral03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-        )
-    )
-)
+phPFIsoValuePU03PFIdPAT = phPFIsoValuePU03PFIdPFBRECO.clone()
+phPFIsoValuePU03PFIdPAT.deposits[0].src = 'phPFIsoDepositPUPAT'
 
-phPFIsoValuePU03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.3),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-      )
-   )
-)
+phPFIsoValueCharged04PFIdPAT = phPFIsoValueCharged04PFIdPFBRECO.clone()
+phPFIsoValueCharged04PFIdPAT.deposits[0]. src = 'phPFIsoDepositChargedPAT'
 
+phPFIsoValueChargedAll04PFIdPAT = phPFIsoValueChargedAll04PFIdPFBRECO.clone()
+phPFIsoValueChargedAll04PFIdPAT.deposits[0].src = 'phPFIsoDepositChargedAllPAT'
 
+phPFIsoValueGamma04PFIdPAT = phPFIsoValueGamma04PFIdPFBRECO.clone()
+phPFIsoValueGamma04PFIdPAT.deposits[0].src = 'phPFIsoDepositGammaPAT'
 
-phPFIsoValueCharged04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositChargedPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-            )
-     )
-)
+phPFIsoValueNeutral04PFIdPAT = phPFIsoValueNeutral04PFIdPFBRECO.clone()
+phPFIsoValueNeutral04PFIdPAT.deposits[0].src = 'phPFIsoDepositNeutralPAT'
 
-
-
-
-phPFIsoValueChargedAll04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositChargedAllPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-     )
-   )
-)
-
-phPFIsoValueGamma04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositGammaPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.05)'),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-      )
-   )
-)
-
-
-phPFIsoValueNeutral04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositNeutralPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-    )
- )
-)
-
-phPFIsoValuePU04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
-    deposits = cms.VPSet(
-            cms.PSet(
-            src = cms.InputTag("phPFIsoDepositPUPAT"),
-            deltaR = cms.double(0.4),
-            weight = cms.string('1'),
-            vetos = cms.vstring(),
-            skipDefaultVeto = cms.bool(True),
-            mode = cms.string('sum'),
-            PivotCoordinatesForEBEE = cms.bool(True)
-      )
-   )
-)
+phPFIsoValuePU04PFIdPAT = phPFIsoValuePU04PFIdPFBRECO.clone()
+phPFIsoValuePU04PFIdPAT.deposits[0].src = 'phPFIsoDepositPUPAT'
 
 photonPFIsolationValuesPATSequence = (
     phPFIsoValueCharged03PFIdPAT+

--- a/PhysicsTools/PatAlgos/python/recoLayer0/photonPFIsolationValuesPAT_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/photonPFIsolationValuesPAT_cff.py
@@ -1,0 +1,163 @@
+import FWCore.ParameterSet.Config as cms
+
+
+
+phPFIsoValueCharged03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+            )
+     )
+)
+
+phPFIsoValueChargedAll03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+     )
+   )
+)
+
+phPFIsoValueGamma03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.05)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+      )
+   )
+)
+
+phPFIsoValueNeutral03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+        )
+    )
+)
+
+phPFIsoValuePU03PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.3),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+      )
+   )
+)
+
+
+
+phPFIsoValueCharged04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositChargedPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+            )
+     )
+)
+
+
+
+
+phPFIsoValueChargedAll04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositChargedAllPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+     )
+   )
+)
+
+phPFIsoValueGamma04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositGammaPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring('EcalEndcaps:ConeVeto(0.05)'),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+      )
+   )
+)
+
+
+phPFIsoValueNeutral04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositNeutralPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+    )
+ )
+)
+
+phPFIsoValuePU04PFIdPAT = cms.EDProducer("PFCandIsolatorFromDeposits",
+    deposits = cms.VPSet(
+            cms.PSet(
+            src = cms.InputTag("phPFIsoDepositPUPAT"),
+            deltaR = cms.double(0.4),
+            weight = cms.string('1'),
+            vetos = cms.vstring(),
+            skipDefaultVeto = cms.bool(True),
+            mode = cms.string('sum'),
+            PivotCoordinatesForEBEE = cms.bool(True)
+      )
+   )
+)
+
+photonPFIsolationValuesPATSequence = (
+    phPFIsoValueCharged03PFIdPAT+
+    phPFIsoValueChargedAll03PFIdPAT+
+    phPFIsoValueGamma03PFIdPAT+
+    phPFIsoValueNeutral03PFIdPAT+
+    phPFIsoValuePU03PFIdPAT+
+    ##############################
+    phPFIsoValueCharged04PFIdPAT+
+    phPFIsoValueChargedAll04PFIdPAT+
+    phPFIsoValueGamma04PFIdPAT+
+    phPFIsoValueNeutral04PFIdPAT+
+    phPFIsoValuePU04PFIdPAT
+    )

--- a/PhysicsTools/PatAlgos/python/recoLayer0/tauIsolation_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/tauIsolation_cff.py
@@ -39,17 +39,17 @@ tauIsoDepositPFCandidates = cms.EDProducer("CandIsoDepositProducer",
 # compute IsoDeposits from PFChargedHadrons
 # (enable cut on z and x-y distance between tau and PFCandidate production vertex)
 tauIsoDepositPFChargedHadrons = copy.deepcopy(tauIsoDepositPFCandidates)
-tauIsoDepositPFChargedHadrons.ExtractorPSet.candidateSource = cms.InputTag("pfAllChargedHadrons")
+tauIsoDepositPFChargedHadrons.ExtractorPSet.candidateSource = cms.InputTag("pfAllChargedHadronsPFBRECO")
 tauIsoDepositPFChargedHadrons.ExtractorPSet.Diff_z = cms.double(0.2)
 tauIsoDepositPFChargedHadrons.ExtractorPSet.Diff_r = cms.double(0.1)
 
 # compute IsoDeposits from PFNeutralHadrons
 tauIsoDepositPFNeutralHadrons = copy.deepcopy(tauIsoDepositPFCandidates)
-tauIsoDepositPFNeutralHadrons.ExtractorPSet.candidateSource = cms.InputTag("pfAllNeutralHadrons")
+tauIsoDepositPFNeutralHadrons.ExtractorPSet.candidateSource = cms.InputTag("pfAllNeutralHadronsPFBRECO")
 
 # compute IsoDeposits from PFGammas
 tauIsoDepositPFGammas = copy.deepcopy(tauIsoDepositPFCandidates)
-tauIsoDepositPFGammas.ExtractorPSet.candidateSource = cms.InputTag("pfAllPhotons")
+tauIsoDepositPFGammas.ExtractorPSet.candidateSource = cms.InputTag("pfAllPhotonsPFBRECO")
 
 patPFTauIsolation = cms.Sequence( tauIsoDepositPFCandidates
                                  * tauIsoDepositPFChargedHadrons

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -20,12 +20,12 @@ def miniAOD_customizeCommon(process):
     process.patElectrons.embedGsfElectronCore = False  ## process.patElectrons.embed in AOD externally stored gsf electron core
     process.patElectrons.embedSuperCluster    = False  ## process.patElectrons.embed in AOD externally stored supercluster
     process.patElectrons.embedPflowSuperCluster         = False  ## process.patElectrons.embed in AOD externally stored supercluster
-    process.patElectrons.embedSeedCluster               = False  ## process.patElectrons.embed in AOD externally stored the electron's seedcluster 
-    process.patElectrons.embedBasicClusters             = False  ## process.patElectrons.embed in AOD externally stored the electron's basic clusters 
-    process.patElectrons.embedPreshowerClusters         = False  ## process.patElectrons.embed in AOD externally stored the electron's preshower clusters 
-    process.patElectrons.embedPflowBasicClusters        = False  ## process.patElectrons.embed in AOD externally stored the electron's pflow basic clusters 
-    process.patElectrons.embedPflowPreshowerClusters    = False  ## process.patElectrons.embed in AOD externally stored the electron's pflow preshower clusters 
-    process.patElectrons.embedRecHits         = False  ## process.patElectrons.embed in AOD externally stored the RecHits - can be called from the PATElectronProducer 
+    process.patElectrons.embedSeedCluster               = False  ## process.patElectrons.embed in AOD externally stored the electron's seedcluster
+    process.patElectrons.embedBasicClusters             = False  ## process.patElectrons.embed in AOD externally stored the electron's basic clusters
+    process.patElectrons.embedPreshowerClusters         = False  ## process.patElectrons.embed in AOD externally stored the electron's preshower clusters
+    process.patElectrons.embedPflowBasicClusters        = False  ## process.patElectrons.embed in AOD externally stored the electron's pflow basic clusters
+    process.patElectrons.embedPflowPreshowerClusters    = False  ## process.patElectrons.embed in AOD externally stored the electron's pflow preshower clusters
+    process.patElectrons.embedRecHits         = False  ## process.patElectrons.embed in AOD externally stored the RecHits - can be called from the PATElectronProducer
     process.patElectrons.electronSource = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
     process.patElectrons.electronIDSources = cms.PSet(
             # configure many IDs as InputTag <someName> = <someTag> you
@@ -36,17 +36,17 @@ def miniAOD_customizeCommon(process):
             eidTight            = cms.InputTag("reducedEgamma","eidTight"),
             eidRobustHighEnergy = cms.InputTag("reducedEgamma","eidRobustHighEnergy"),
         )
-    process.elPFIsoDepositCharged.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
-    process.elPFIsoDepositChargedAll.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
-    process.elPFIsoDepositNeutral.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
-    process.elPFIsoDepositGamma.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
-    process.elPFIsoDepositPU.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositChargedPAT.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositChargedAllPAT.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositNeutralPAT.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositGammaPAT.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
+    process.elPFIsoDepositPUPAT.src = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
     #
     process.patPhotons.embedSuperCluster = False ## whether to process.patPhotons.embed in AOD externally stored supercluster
-    process.patPhotons.embedSeedCluster               = False  ## process.patPhotons.embed in AOD externally stored the photon's seedcluster 
-    process.patPhotons.embedBasicClusters             = False  ## process.patPhotons.embed in AOD externally stored the photon's basic clusters 
-    process.patPhotons.embedPreshowerClusters         = False  ## process.patPhotons.embed in AOD externally stored the photon's preshower clusters 
-    process.patPhotons.embedRecHits         = False  ## process.patPhotons.embed in AOD externally stored the RecHits - can be called from the PATPhotonProducer 
+    process.patPhotons.embedSeedCluster               = False  ## process.patPhotons.embed in AOD externally stored the photon's seedcluster
+    process.patPhotons.embedBasicClusters             = False  ## process.patPhotons.embed in AOD externally stored the photon's basic clusters
+    process.patPhotons.embedPreshowerClusters         = False  ## process.patPhotons.embed in AOD externally stored the photon's preshower clusters
+    process.patPhotons.embedRecHits         = False  ## process.patPhotons.embed in AOD externally stored the RecHits - can be called from the PATPhotonProducer
     process.patPhotons.photonSource = cms.InputTag("reducedEgamma","reducedGedPhotons")
     process.patPhotons.photonIDSources = cms.PSet(
                 PhotonCutBasedIDLoose = cms.InputTag('reducedEgamma',
@@ -55,41 +55,41 @@ def miniAOD_customizeCommon(process):
                                                       'PhotonCutBasedIDTight')
               )
 
-    process.phPFIsoDepositCharged.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
-    process.phPFIsoDepositChargedAll.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
-    process.phPFIsoDepositNeutral.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
-    process.phPFIsoDepositGamma.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
-    process.phPFIsoDepositPU.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositChargedPAT.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositChargedAllPAT.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositNeutralPAT.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositGammaPAT.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.phPFIsoDepositPUPAT.src = cms.InputTag("reducedEgamma","reducedGedPhotons")
     #
     process.selectedPatJets.cut = cms.string("pt > 10")
-    process.selectedPatMuons.cut = cms.string("pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose')))") 
-    process.selectedPatElectrons.cut = cms.string("") 
+    process.selectedPatMuons.cut = cms.string("pt > 5 || isPFMuon || (pt > 3 && (isGlobalMuon || isStandAloneMuon || numberOfMatches > 0 || muonID('RPCMuLoose')))")
+    process.selectedPatElectrons.cut = cms.string("")
     process.selectedPatTaus.cut = cms.string("pt > 18. && tauID('decayModeFinding')> 0.5")
     process.selectedPatPhotons.cut = cms.string("")
 
     # add CMS top tagger
-    from RecoJets.JetProducers.caTopTaggers_cff import caTopTagInfos as toptag
-    process.cmsttRaw = toptag.clone()
-    process.caTopTagInfos = cms.EDProducer("RecoJetDeltaRTagInfoValueMapProducer",
+    from RecoJets.JetProducers.caTopTaggers_cff import caTopTagInfos
+    process.caTopTagInfos = caTopTagInfos.clone()
+    process.caTopTagInfosPAT = cms.EDProducer("RecoJetDeltaRTagInfoValueMapProducer",
                                     src = cms.InputTag("ak8PFJetsCHS"),
                                     matched = cms.InputTag("cmsTopTagPFJetsCHS"),
-                                    matchedTagInfos = cms.InputTag("cmsttRaw"),
+                                    matchedTagInfos = cms.InputTag("caTopTagInfos"),
                                     distMax = cms.double(0.8)
                         )
-    
+
     #add AK8
     from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
-    addJetCollection(process, labelName = 'AK8',                     
+    addJetCollection(process, labelName = 'AK8',
                      jetSource = cms.InputTag('ak8PFJetsCHS'),
                      algo= 'AK', rParam = 0.8,
                      jetCorrections = ('AK8PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
-                     btagInfos = ['caTopTagInfos']
+                     btagInfos = ['caTopTagInfosPAT']
                      )
     process.patJetsAK8.userData.userFloats.src = [] # start with empty list of user floats
     process.selectedPatJetsAK8.cut = cms.string("pt > 100")
     process.patJetGenJetMatchAK8.matched =  'slimmedGenJets'
     ## AK8 groomed masses
-    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed 
+    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
     process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
     process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
@@ -97,8 +97,8 @@ def miniAOD_customizeCommon(process):
     process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedLinks','ak8PFJetsCHSTrimmedLinks','ak8PFJetsCHSFilteredLinks']
 
     # Add AK8 top tagging variables
-    process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("caTopTagInfos"))
-    process.patJetsAK8.addTagInfos = cms.bool(True) 
+    process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("caTopTagInfosPAT"))
+    process.patJetsAK8.addTagInfos = cms.bool(True)
 
 
 
@@ -109,8 +109,8 @@ def miniAOD_customizeCommon(process):
     process.NjettinessAK8.cone = cms.double(0.8)
     process.patJetsAK8.userData.userFloats.src += ['NjettinessAK8:tau1','NjettinessAK8:tau2','NjettinessAK8:tau3']
 
-            
-    
+
+
     #
     from PhysicsTools.PatAlgos.tools.trigTools import switchOnTriggerStandAlone
     switchOnTriggerStandAlone( process, outputModule = '' )
@@ -130,7 +130,7 @@ def miniAOD_customizeCommon(process):
                                tauCollection="selectedPatTaus",
                                makeType1p2corrPFMEt=True,
                                outputModule=None)
- 
+
 
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars
@@ -167,12 +167,12 @@ def miniAOD_customizeCommon(process):
     process.electronIDValueMapProducer.ebReducedRecHitCollection = \
         cms.InputTag("reducedEgamma","reducedEBRecHits")
     process.electronIDValueMapProducer.eeReducedRecHitCollection = \
-        cms.InputTag("reducedEgamma","reducedEERecHits") 
+        cms.InputTag("reducedEgamma","reducedEERecHits")
     process.electronIDValueMapProducer.esReducedRecHitCollection = \
         cms.InputTag("reducedEgamma","reducedESRecHits")
     for idmod in electron_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
-    
+
 
 
 def miniAOD_customizeMC(process):

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cff.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+from PhysicsTools.PatAlgos.slimming.packedPFCandidates_cfi import *
+from CommonTools.ParticleFlow.pfNoPileUpJME_cff import *
+from CommonTools.ParticleFlow.PFBRECO_cff import pfPileUpPFBRECO, pfNoPileUpPFBRECO

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -3,9 +3,9 @@ import FWCore.ParameterSet.Config as cms
 packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     inputCollection = cms.InputTag("particleFlow"),
     inputCollectionFromPVLoose = cms.InputTag("pfNoPileUpJME"),
-    inputCollectionFromPVTight = cms.InputTag("pfNoPileUp"),
+    inputCollectionFromPVTight = cms.InputTag("pfNoPileUpPFBRECO"),
     inputVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
     originalVertices = cms.InputTag("offlinePrimaryVertices"),
     originalTracks = cms.InputTag("generalTracks"),
-    minPtForTrackProperties = cms.double(0.95)	
+    minPtForTrackProperties = cms.double(0.95)
 )

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -34,7 +34,7 @@ MicroEventContent = cms.PSet(
         'keep recoSuperClusters_reducedEgamma_*_*',
         'keep recoCaloClusters_reducedEgamma_*_*',
         'keep EcalRecHitsSorted_reducedEgamma_*_*',
-        
+
 
         'drop *_*_caloTowers_*',
         'drop *_*_pfCandidates_*',
@@ -44,7 +44,7 @@ MicroEventContent = cms.PSet(
         'keep *_offlineSlimmedPrimaryVertices_*_*',
         'keep patPackedCandidates_packedPFCandidates_*_*',
 
-        'keep double_fixedGridRho*__*', 
+        'keep double_fixedGridRho*__*',
 
         'keep *_selectedPatTrigger_*_*',
         'keep patPackedTriggerPrescales_patTrigger__*',
@@ -54,7 +54,7 @@ MicroEventContent = cms.PSet(
         'keep *_TriggerResults_*_PAT', # for MET filters
 	'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
-        'keep *_caTopTagInfos_*_*'
+        'keep *_caTopTagInfosPAT_*_*'
     )
 )
 MicroEventContentMC = cms.PSet(

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from PhysicsTools.PatAlgos.slimming.packedPFCandidates_cfi import *
+from PhysicsTools.PatAlgos.slimming.packedPFCandidates_cff import *
 from PhysicsTools.PatAlgos.slimming.lostTracks_cfi import *
 from PhysicsTools.PatAlgos.slimming.offlineSlimmedPrimaryVertices_cfi import *
 from PhysicsTools.PatAlgos.slimming.genParticles_cff import *

--- a/PhysicsTools/PatAlgos/python/tools/pfTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/pfTools.py
@@ -11,47 +11,6 @@ from copy import deepcopy
 def warningIsolation():
     print "WARNING: particle based isolation must be studied"
 
-def adaptPFIsoElectrons(process,module, postfix = "PFIso", dR = "04"):
-    #FIXME: adaptPFElectrons can use this function.
-    module.isoDeposits = cms.PSet(
-        pfChargedHadrons = cms.InputTag("elPFIsoDepositCharged" + postfix),
-        pfChargedAll = cms.InputTag("elPFIsoDepositChargedAll" + postfix),
-        pfPUChargedHadrons = cms.InputTag("elPFIsoDepositPU" + postfix),
-        pfNeutralHadrons = cms.InputTag("elPFIsoDepositNeutral" + postfix),
-        pfPhotons = cms.InputTag("elPFIsoDepositGamma" + postfix)
-        )
-    module.isolationValues = cms.PSet(
-        pfChargedHadrons = cms.InputTag("elPFIsoValueCharged"+dR+"PFId"+ postfix),
-        pfChargedAll = cms.InputTag("elPFIsoValueChargedAll"+dR+"PFId"+ postfix),
-        pfPUChargedHadrons = cms.InputTag("elPFIsoValuePU"+dR+"PFId" + postfix),
-        pfNeutralHadrons = cms.InputTag("elPFIsoValueNeutral"+dR+"PFId" + postfix),
-        pfPhotons = cms.InputTag("elPFIsoValueGamma"+dR+"PFId" + postfix)
-        )
-    module.isolationValuesNoPFId = cms.PSet(
-        pfChargedHadrons = cms.InputTag("elPFIsoValueCharged"+dR+"NoPFId"+ postfix),
-        pfChargedAll = cms.InputTag("elPFIsoValueChargedAll"+dR+"NoPFId"+ postfix),
-        pfPUChargedHadrons = cms.InputTag("elPFIsoValuePU"+dR+"NoPFId" + postfix),
-        pfNeutralHadrons = cms.InputTag("elPFIsoValueNeutral"+dR+"NoPFId" + postfix),
-        pfPhotons = cms.InputTag("elPFIsoValueGamma"+dR+"NoPFId" + postfix)
-        )
-
-def adaptPFIsoMuons(process,module, postfix = "PFIso", dR = "04"):
-    #FIXME: adaptPFMuons can use this function.
-    module.isoDeposits = cms.PSet(
-        pfChargedHadrons = cms.InputTag("muPFIsoDepositCharged" + postfix),
-        pfChargedAll = cms.InputTag("muPFIsoDepositChargedAll" + postfix),
-        pfPUChargedHadrons = cms.InputTag("muPFIsoDepositPU" + postfix),
-        pfNeutralHadrons = cms.InputTag("muPFIsoDepositNeutral" + postfix),
-        pfPhotons = cms.InputTag("muPFIsoDepositGamma" + postfix)
-        )
-    module.isolationValues = cms.PSet(
-        pfChargedHadrons = cms.InputTag("muPFIsoValueCharged" + dR + postfix),
-        pfChargedAll = cms.InputTag("muPFIsoValueChargedAll" + dR + postfix),
-        pfPUChargedHadrons = cms.InputTag("muPFIsoValuePU" + dR + postfix),
-        pfNeutralHadrons = cms.InputTag("muPFIsoValueNeutral" + dR + postfix),
-        pfPhotons = cms.InputTag("muPFIsoValueGamma" + dR + postfix)
-        )
-
 def adaptPFMuons(process,module,postfix="", muonMatchModule=None ):
     print "Adapting PF Muons "
     print "***************** "
@@ -194,9 +153,9 @@ def reconfigurePF2PATTaus(process,
    #newTau.builders[0].pfCandSrc = oldTau.builders[0].pfCandSrc
    #newTau.jetRegionSrc = oldTau.jetRegionSrc
    #newTau.jetSrc = oldTau.jetSrc
-   #newTau.builders[0].pfCandSrc = cms.InputTag("pfNoElectronJMEPFlow")
-   #newTau.jetRegionSrc = cms.InputTag("pfTauPFJets08RegionPFlow")
-   #newTau.jetSrc = cms.InputTag("pfJetsPFlow")
+   #newTau.builders[0].pfCandSrc = cms.InputTag("pfNoElectronJME" + postfix)
+   #newTau.jetRegionSrc = cms.InputTag("pfTauPFJets08Region" + postfix)
+   #newTau.jetSrc = cms.InputTag("pfJetsPFBRECO" + postfix)
    # replace old tau producer by new one put it into baseSequence
    setattr(process,"pfTausBase"+postfix,newTau)
    if tauType=='shrinkingConePFTau':
@@ -368,9 +327,9 @@ def switchToPFJets(process, input=cms.InputTag('pfNoTauClones'), algo='AK4', pos
 
     # changing the jet collection in PF2PAT:
     from CommonTools.ParticleFlow.Tools.jetTools import jetAlgo
-    inputCollection = getattr(process,"pfJets"+postfix).src
-    setattr(process,"pfJets"+postfix,jetAlgo(algo)) # problem for cfgBrowser
-    getattr(process,"pfJets"+postfix).src = inputCollection
+    inputCollection = getattr(process,"pfJetsPFBRECO"+postfix).src
+    setattr(process,"pfJetsPFBRECO"+postfix,jetAlgo(algo)) # problem for cfgBrowser
+    getattr(process,"pfJetsPFBRECO"+postfix).src = inputCollection
     inputJetCorrLabel=jetCorrections
 
     switchJetCollection(process,
@@ -389,7 +348,7 @@ def switchToPFJets(process, input=cms.InputTag('pfNoTauClones'), algo='AK4', pos
     for corr in inputJetCorrLabel[1]:
         if corr == 'L1FastJet':
             applyPostfix(process, "patJetCorrFactors", postfix).useRho = True
-            applyPostfix(process, "pfJets", postfix).doAreaFastjet = True
+            applyPostfix(process, "pfJetsPFBRECO", postfix).doAreaFastjet = True
             # do correct treatment for TypeI MET corrections
 	    #type1=True
             if type1:

--- a/PhysicsTools/PatAlgos/python/tools/pfTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/pfTools.py
@@ -58,7 +58,7 @@ def adaptPFMuons(process,module,postfix="", muonMatchModule=None ):
     #warningIsolation()
     print
     module.useParticleFlow = True
-    module.pfMuonSource    = cms.InputTag("pfIsolatedMuons" + postfix)
+    module.pfMuonSource    = cms.InputTag("pfIsolatedMuonsPFBRECO" + postfix)
     module.userIsolation   = cms.PSet()
     ## module.isoDeposits = cms.PSet(
     ##     pfChargedHadrons = cms.InputTag("muPFIsoDepositCharged" + postfix),
@@ -75,7 +75,7 @@ def adaptPFMuons(process,module,postfix="", muonMatchModule=None ):
     ##     pfPhotons = cms.InputTag("muPFIsoValueGamma04" + postfix)
     ##     )
     # matching the pfMuons, not the standard muons.
-    if muonMatchModule == None : 
+    if muonMatchModule == None :
         applyPostfix(process,"muonMatch",postfix).src = module.pfMuonSource
     else :
         muonMatchModule.src = module.pfMuonSource
@@ -95,7 +95,7 @@ def adaptPFElectrons(process,module, postfix):
     #warningIsolation()
     print
     module.useParticleFlow = True
-    module.pfElectronSource = cms.InputTag("pfIsolatedElectrons" + postfix)
+    module.pfElectronSource = cms.InputTag("pfIsolatedElectronsPFBRECO" + postfix)
     module.userIsolation   = cms.PSet()
     ## module.isoDeposits = cms.PSet(
     ##     pfChargedHadrons = cms.InputTag("elPFIsoDepositCharged" + postfix),
@@ -334,7 +334,7 @@ def addPFCandidates(process,src,patLabel='PFParticles',cut="",postfix=""):
     applyPostfix(process, "selectedPatCandidateSummary", postfix).candidates.append(cms.InputTag('selectedPat' + patLabel))
 
 
-def switchToPFMET(process,input=cms.InputTag('pfMET'), type1=False, postfix=""):
+def switchToPFMET(process,input=cms.InputTag('pfMETPFBRECO'), type1=False, postfix=""):
     print 'MET: using ', input
     if( not type1 ):
         oldMETSource = applyPostfix(process, "patMETs",postfix).metSource
@@ -452,7 +452,7 @@ def usePF2PAT(process,runPF2PAT=True, jetAlgo='AK4', runOnMC=True, postfix="", j
     from PhysicsTools.PatAlgos.tools.helpers import loadWithPostfix
     if runPF2PAT:
 	loadWithPostfix(process,'PhysicsTools.PatAlgos.patSequences_cff',postfix)
-	loadWithPostfix(process,"CommonTools.ParticleFlow.PF2PAT_cff",postfix)
+	loadWithPostfix(process,"CommonTools.ParticleFlow.PFBRECO_cff",postfix)
     else:
 	loadWithPostfix(process,'PhysicsTools.PatAlgos.patSequences_cff',postfix)
 
@@ -479,7 +479,7 @@ def usePF2PAT(process,runPF2PAT=True, jetAlgo='AK4', runOnMC=True, postfix="", j
 
     # Jets
     if runOnMC :
-        switchToPFJets( process, cms.InputTag('pfNoTauClones'+postfix), jetAlgo, postfix=postfix,
+        switchToPFJets( process, cms.InputTag('pfNoTauClonesPFBRECO'+postfix), jetAlgo, postfix=postfix,
                         jetCorrections=jetCorrections, type1=typeIMetCorrections, outputModules=outputModules )
 
     else :
@@ -489,14 +489,14 @@ def usePF2PAT(process,runPF2PAT=True, jetAlgo='AK4', runOnMC=True, postfix="", j
             print 'WARNING! Not using L2L3Residual but this is data.'
             print 'If this is okay with you, disregard this message.'
             print '#################################################'
-        switchToPFJets( process, cms.InputTag('pfNoTauClones'+postfix), jetAlgo, postfix=postfix,
+        switchToPFJets( process, cms.InputTag('pfNoTauClonesPFBRECO'+postfix), jetAlgo, postfix=postfix,
                         jetCorrections=jetCorrections, type1=typeIMetCorrections, outputModules=outputModules )
     # Taus
     #adaptPFTaus( process, tauType='shrinkingConePFTau', postfix=postfix )
     #adaptPFTaus( process, tauType='fixedConePFTau', postfix=postfix )
     adaptPFTaus( process, tauType='hpsPFTau', postfix=postfix )
     # MET
-    switchToPFMET(process, cms.InputTag('pfMET'+postfix), type1=typeIMetCorrections, postfix=postfix)
+    switchToPFMET(process, cms.InputTag('pfMETPFBRECO'+postfix), type1=typeIMetCorrections, postfix=postfix)
 
     # Unmasked PFCandidates
     addPFCandidates(process,cms.InputTag('pfNoJetClones'+postfix),patLabel='PFParticles'+postfix,cut="",postfix=postfix)
@@ -509,16 +509,16 @@ def usePF2PAT(process,runPF2PAT=True, jetAlgo='AK4', runOnMC=True, postfix="", j
 
     # Configure Top Projections
     getattr(process,"pfNoPileUpJME"+postfix).enable = True
-    getattr(process,"pfNoMuonJME"+postfix).enable = True
-    getattr(process,"pfNoElectronJME"+postfix).enable = True
-    getattr(process,"pfNoTau"+postfix).enable = False
-    getattr(process,"pfNoJet"+postfix).enable = True
+    getattr(process,"pfNoMuonJMEPFBRECO"+postfix).enable = True
+    getattr(process,"pfNoElectronJMEPFBRECO"+postfix).enable = True
+    getattr(process,"pfNoTauPFBRECO"+postfix).enable = False
+    getattr(process,"pfNoJetPFBRECO"+postfix).enable = True
     exclusionList = ''
     for object in excludeFromTopProjection:
         jme = ''
         if object in ['Muon','Electron']:
             jme = 'JME'
-        getattr(process,"pfNo"+object+jme+postfix).enable = False
+        getattr(process,"pfNo"+object+jme+'PFBRECO'+postfix).enable = False
         exclusionList=exclusionList+object+','
     exclusionList=exclusionList.rstrip(',')
-    print "Done: PF2PAT interfaced to PAT, postfix=", postfix,", Excluded from Top Projection:",exclusionList
+    print "Done: PFBRECO interfaced to PAT, postfix=", postfix,", Excluded from Top Projection:",exclusionList


### PR DESCRIPTION
The following issues discussed in https://indico.cern.ch/event/344151/session/4/contribution/10/material/slides/0.pdf are addressed:
- clone pile-up modules rather then re-configure them for use after RECO;
- clone isolation modules rather than re-configure them in miniAOD;
- resolve naming circle around top tagger in miniAOD.

Forward port of #6522 to CMSSW_7_4_X. Merging directly since the former is fully approved.
