### PR TITLE
Guard the nPho histograms from double counting, should fix HI issues

### DIFF
--- a/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/PhotonAnalyzer.cc
@@ -887,8 +887,11 @@ void PhotonAnalyzer::analyze( const edm::Event& e, const edm::EventSetup& esup )
   	//filling photon histograms
 	nPho[cut][0][0]++;
 	nPho[cut][0][part]++;
-	nPho[cut][type][0]++;
-	nPho[cut][type][part]++;
+	if(type != 0)
+	{
+	  nPho[cut][type][0]++;
+	  nPho[cut][type][part]++;
+	}
 
 	//energy variables
 


### PR DESCRIPTION
In HI reco DQM, photons are being double-counted because in HI RECO we do not pre-select at the RECO level for isolated photons. Since most HI photons are not isolated according to the default cuts they have type==0 and get double-counted.

Forward port of #6574 into CMSSW_7_4_X. Will merge automatically since the former is fully signed in CMSSW_7_3_X.
