### PR TITLE
Add HF 1x1 Trigger Primitives

### DIFF
--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -36,6 +36,8 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
    // TODO cms::Error log
   if (OUTPUT_LUT_SIZE != (unsigned int) 0x400) std::cout << "Error: Analytic compression expects 10-bit LUT; found LUT with " << OUTPUT_LUT_SIZE << " entries instead" << std::endl;
 
+  const HcalTopology& topo=theTrigTowerGeometry.topology();
+
   std::vector<unsigned int> analyticalLUT(OUTPUT_LUT_SIZE, 0);
   std::vector<unsigned int> identityLUT(OUTPUT_LUT_SIZE, 0);
 
@@ -44,11 +46,14 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 	analyticalLUT[i] = (unsigned int)(sqrt(14.94*log(1.+i/14.94)*i) + 0.5);
 	identityLUT[i] = min(i,0xffu);
   }
- 
+
+   // Version 0 loop
   for (int ieta=-32; ieta <= 32; ieta++){
+    //const int version_of_hcal_TPs = 0;
      for (int iphi = 1; iphi <= 72; iphi++){
-        if (!HTvalid(ieta,iphi)) continue;
-        int lutId = getOutputLUTId(ieta,iphi);
+        HcalTrigTowerDetId id(ieta, iphi);
+        if (!topo.validHT(id)) continue;
+        int lutId = topo.detId2denseIdHT(id);
         // TODO cms::Error log
         if (outputLUT_[lutId] != 0){
            std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
@@ -57,7 +62,6 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
 
         outputLUT_[lutId] = new LUT[OUTPUT_LUT_SIZE];
 
-        HcalTrigTowerDetId id(ieta, iphi);
         const HcalLutMetadatum *meta = lutMetadata.getValues(id);
         int threshold = meta->getOutputLutThreshold();
 
@@ -65,29 +69,60 @@ void CaloTPGTranscoderULUT::loadHCALCompress(HcalLutMetadata const& lutMetadata,
            outputLUT_[lutId][i] = 0;
 
         for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i)
-           outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry.firstHFTower()) ? analyticalLUT[i] : identityLUT[i];
+           outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry.firstHFTower(id.version())) ? analyticalLUT[i] : identityLUT[i];
      } //for iphi
+  } //for ieta
+   // Version 1 loop
+  for (int ieta=-41; ieta <= 41; ieta++){
+      const int version_of_hcal_TPs = 1;
+      for (int iphi = 1; iphi <= 72; iphi++){
+          HcalTrigTowerDetId id(ieta, iphi);
+          id.setVersion(version_of_hcal_TPs);
+
+          if (!topo.validHT(id)) continue;
+          int lutId = topo.detId2denseIdHT(id);
+          // TODO cms::Error log
+          if (outputLUT_[lutId] != 0){
+              std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
+              continue;
+          }
+
+          outputLUT_[lutId] = new LUT[OUTPUT_LUT_SIZE];
+
+          const HcalLutMetadatum *meta = lutMetadata.getValues(id);
+          int threshold = meta->getOutputLutThreshold();
+
+          for (int i = 0; i < threshold; ++i)
+              outputLUT_[lutId][i] = 0;
+
+          for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i)
+              outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry.firstHFTower(id.version())) ? analyticalLUT[i] : identityLUT[i];
+      } //for iphi
   } //for ieta
 }
 
 void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename, HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry) {
+  // TODO: Add Version 1 support
+  //  const int version_of_hcal_TPs = 0;
   int tool;
   std::ifstream userfile;
   std::vector< std::vector<LUT> > outputluts;
+  const HcalTopology& topo=theTrigTowerGeometry.topology();
 
   std::cout << "Initializing compression LUT's from " << (char *)filename.data() << std::endl;
   for (int i = 0; i < NOUTLUTS; i++) outputLUT_[i] = 0;
   int maxid = 0, minid = 0x7FFFFFFF, rawid = 0;
   for (int ieta=-32; ieta <= 32; ieta++) {
     for (int iphi = 1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta,iphi)) {
-          rawid = getOutputLUTId(ieta, iphi);
-          if (outputLUT_[rawid] != 0) std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
-          else outputLUT_[rawid] = new LUT[OUTPUT_LUT_SIZE];
-          if (rawid < minid) minid = rawid;
-          if (rawid > maxid) maxid = rawid;
-        }
-	}
+      HcalTrigTowerDetId id(ieta,iphi);
+      if (topo.validHT(id)) {
+        rawid = topo.detId2denseIdHT(id);
+        if (outputLUT_[rawid] != 0) std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
+        else outputLUT_[rawid] = new LUT[OUTPUT_LUT_SIZE];
+        if (rawid < minid) minid = rawid;
+        if (rawid > maxid) maxid = rawid;
+      }
+    }
   }
 
   userfile.open((char *)filename.data());
@@ -110,31 +145,31 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename, HcalLu
 	for (unsigned int i=0; i<=s.length(); i++) userfile.unget(); //rewind last line
     outputluts.resize(nluts);
     for (int i=0; i<nluts; i++) outputluts[i].resize(OUTPUT_LUT_SIZE);
-    
-    
+
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
       loieta.push_back(tool);
     }
-    
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
-      hiieta.push_back(tool);    
+      hiieta.push_back(tool);
     }
-   
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
       loiphi.push_back(tool);
-	
+
     }
-    
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
       hiiphi.push_back(tool);
-    
+
     }
-   	
-    for (unsigned int j=0; j<OUTPUT_LUT_SIZE; j++) { 
+
+    for (unsigned int j=0; j<OUTPUT_LUT_SIZE; j++) {
       for(int i=0; i <nluts; i++) {
 		userfile >> tool;
 		if (tool < 0) {
@@ -149,27 +184,25 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename, HcalLu
 	  }
     }
     userfile.close();
-	
+
 	HcalDetId cell;
 	int id, ntot = 0;
-	for (int i=0; i < nluts; i++) {
-		int nini = 0;
-     		for (int iphi = loiphi[i]; iphi <= hiiphi[i]; iphi++) {      
-       			for (int ieta=loieta[i]; ieta <= hiieta[i]; ieta++) {
-	 				if (HTvalid(ieta,iphi)) {  
-	   					id = getOutputLUTId(ieta,iphi);
-	   					if (outputLUT_[id] == 0) throw cms::Exception("PROBLEM: outputLUT_ has not been initialized for ieta, iphi, id = ") << ieta << ", " << iphi << ", " << id << std::endl;
-		    			for (int j = 0; j <= 0x3ff; j++) outputLUT_[id][j] = outputluts[i][j];
-						nini++;
-						ntot++;
-	 				}
-       			}
-       }
-	
+    for (int i=0; i < nluts; i++) {
+      int nini = 0;
+      for (int iphi = loiphi[i]; iphi <= hiiphi[i]; iphi++) {
+        for (int ieta=loieta[i]; ieta <= hiieta[i]; ieta++) {
+          HcalTrigTowerDetId detid(ieta,iphi);
+          if (topo.validHT(detid)) {
+            id = topo.detId2denseIdHT(detid);
+            if (outputLUT_[id] == 0) throw cms::Exception("PROBLEM: outputLUT_ has not been initialized for ieta, iphi, id = ") << ieta << ", " << iphi << ", " << id << std::endl;
+            for (int j = 0; j <= 0x3ff; j++) outputLUT_[id][j] = outputluts[i][j];
+            nini++;
+            ntot++;
+          }
+        }
+      }
     }
-	
   } else {
-    
     loadHCALCompress(lutMetadata,theTrigTowerGeometry);
   }
 }
@@ -181,81 +214,134 @@ void CaloTPGTranscoderULUT::loadHCALUncompress(HcalLutMetadata const& lutMetadat
       RCTdecompression decompressionTable(TPGMAX,0);
       hcaluncomp_.push_back(decompressionTable);
    }
-
+   const HcalTopology& topo=theTrigTowerGeometry.topology();
+   
+   // Version 0 loop
    for (int ieta = -32; ieta <= 32; ++ieta){
-
-      double eta_low = 0., eta_high = 0.;
-		theTrigTowerGeometry.towerEtaBounds(ieta,eta_low,eta_high); 
-      double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
-
-		for (int iphi = 1; iphi <= 72; iphi++) {
-         if (!HTvalid(ieta, iphi)) continue;
-
-			int lutId = getOutputLUTId(ieta,iphi);
-         HcalTrigTowerDetId id(ieta, iphi);
-
+     const int version_of_hcal_TPs = 0;
+     
+     double eta_low = 0., eta_high = 0.;
+     theTrigTowerGeometry.towerEtaBounds(ieta,version_of_hcal_TPs,eta_low,eta_high);
+     double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
+     
+     for (int iphi = 1; iphi <= 72; iphi++) {
+       HcalTrigTowerDetId id(ieta, iphi);
+       
+       if (!topo.validHT(id)) continue; 
+       int lutId = topo.detId2denseIdHT(id);
+       
+       double factor = 0.;
+       
+       // HF
+       if (abs(ieta) >= theTrigTowerGeometry.firstHFTower(version_of_hcal_TPs)) {
+         factor = rctlsb_factor_;
+       }
+       // HBHE
+       else {
          const HcalLutMetadatum *meta = lutMetadata.getValues(id);
-         double factor = 0.;
+         factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
+       }
+       
+       // tpg - compressed value
+       unsigned int tpg = outputLUT_[lutId][0];
+       int low = 0;
+       for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i){
+	 if (outputLUT_[lutId][i] != tpg){
+	   unsigned int mid = (low + i)/2;
+	   hcaluncomp_[lutId][tpg] = (tpg == 0 ? low : factor * mid);
+	   low = i;
+	   tpg = outputLUT_[lutId][i];
+	 }
+       }
+       hcaluncomp_[lutId][tpg] = factor * low;
+     } // for phi
+   } // for ieta
+   
+   // Version 1 loop
+   for (int ieta = -41; ieta <= 41; ++ieta) {
 
-         // HF
-         if (abs(ieta) >= theTrigTowerGeometry.firstHFTower())
-            factor = rctlsb_factor_;
-         // HBHE
-         else 
-            factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
+       const int version_of_hcal_TPs = 1;
+       if (abs(ieta) < 28) { continue; }
 
-         // tpg - compressed value
-         unsigned int tpg = outputLUT_[lutId][0];
-         int low = 0;
-         for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i){
-            if (outputLUT_[lutId][i] != tpg){
-               unsigned int mid = (low + i)/2;
-               hcaluncomp_[lutId][tpg] = (tpg == 0 ? low : factor * mid);
-               low = i;
-               tpg = outputLUT_[lutId][i];
-            }
-         }
-         hcaluncomp_[lutId][tpg] = factor * low;
-		} // for phi
-	} // for ieta
+       double eta_low = 0., eta_high = 0.;
+       theTrigTowerGeometry.towerEtaBounds(ieta, version_of_hcal_TPs, eta_low, eta_high);
+       double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
+
+       for (int iphi = 1; iphi <= 72; iphi++) {
+           HcalTrigTowerDetId id(ieta, iphi);
+           id.setVersion(version_of_hcal_TPs);
+           if (!topo.validHT(id)) continue; 
+           int lutId = topo.detId2denseIdHT(id);
+
+           double factor = 0.;
+           // HF
+           if (abs(ieta) >= theTrigTowerGeometry.firstHFTower(version_of_hcal_TPs)) {
+               factor = rctlsb_factor_;
+           }
+           // HBHE
+           else {
+               const HcalLutMetadatum *meta = lutMetadata.getValues(id);
+               factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
+           }
+
+           // tpg - compressed value
+           unsigned int tpg = outputLUT_[lutId][0];
+           int low = 0;
+           for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i) {
+               if (outputLUT_[lutId][i] != tpg) {
+                   unsigned int mid = (low + i)/2;
+                   if (tpg == 0) {
+                       hcaluncomp_[lutId][tpg] = low;
+                   } else {
+                       hcaluncomp_[lutId][tpg] = factor * mid;
+                   }
+                   low = i;
+                   tpg = outputLUT_[lutId][i];
+               }
+           }
+           hcaluncomp_[lutId][tpg] = factor * low;
+       }  // for phi
+   } // for ieta
 }
 
 void CaloTPGTranscoderULUT::loadHCALUncompress(const std::string& filename, HcalLutMetadata const& lutMetadata, HcalTrigTowerGeometry const& theTrigTowerGeometry)  {
+  // TODO: Add Version 1 support
+  //  const int version_of_hcal_TPs = 0;
   std::ifstream userfile;
   userfile.open(filename.c_str());
-  
+
   hcaluncomp_.resize(NOUTLUTS);
   for (int i = 0; i < NOUTLUTS; i++) hcaluncomp_[i].resize(TPGMAX);
-  
+
   static const int etabound = 32;
   if( userfile ) {
-	 double et;
-     for (int i=0; i<TPGMAX; i++) { 
+    double et;
+    for (int i=0; i<TPGMAX; i++) {
       for(int j = 1; j <=etabound; j++) {
-	    userfile >> et;
-		for (int iphi = 1; iphi <= 72; iphi++) {
-		  int itower = getOutputLUTId(j,iphi);
-		  if (itower >= 0) hcaluncomp_[itower][i] = et;
-		  itower = getOutputLUTId(-j,iphi);
-		  if (itower >= 0) hcaluncomp_[itower][i] = et;		  
-		}
-	  }
-	 }
-	 userfile.close();
+        userfile >> et;
+        for (int iphi = 1; iphi <= 72; iphi++) {
+          HcalTrigTowerDetId id(j,iphi);
+          int itower = theTrigTowerGeometry.topology().detId2denseIdHT(id);
+
+          if (itower >= 0) hcaluncomp_[itower][i] = et;
+          HcalTrigTowerDetId id2(-j,iphi);
+          itower = theTrigTowerGeometry.topology().detId2denseIdHT(id2);
+          if (itower >= 0) hcaluncomp_[itower][i] = et;
+        }
+      }
+    }
+    userfile.close();
   }
   else {
-
     loadHCALUncompress(lutMetadata,theTrigTowerGeometry);
   }
 }
 
-HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const {
-  int ieta = id.ieta();
-  int iphi = id.iphi();
-//  if (abs(ieta) > 28) iphi = iphi/4 + 1; // Changing iphi index from 1, 5, ..., 69 to 1, 2, ..., 18
-  int itower = getOutputLUTId(ieta,iphi);
+HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain, HcalTrigTowerGeometry const& theTrigTowerGeometry) const {
 
-  if (itower < 0) cms::Exception("Invalid Data") << "No trigger tower found for ieta, iphi = " << ieta << ", " << iphi;
+  int itower = theTrigTowerGeometry.topology().detId2denseIdHT(id);
+
+  if (itower < 0) cms::Exception("Invalid Data") << "No trigger tower found for ieta, iphi = " << id.ieta() << ", " << id.iphi() << " v"<<id.version();
   if (sample >= OUTPUT_LUT_SIZE) {
 
     throw cms::Exception("Out of Range") << "LUT has 1024 entries for " << itower << " but " << sample << " was requested.";
@@ -265,42 +351,10 @@ HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTow
   return HcalTriggerPrimitiveSample(outputLUT_[itower][sample],fineGrain,0,0);
 }
 
-double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, const int& compET) const {
-  double etvalue = 0.;
-  int itower = getOutputLUTId(ieta,iphi);
-  if (itower < 0) std::cout << "hcaletValue error: no decompression LUT found for ieta, iphi = " << ieta << ", " << iphi << std::endl;
-  else if (compET < 0 || compET > 0xff) std::cout << "hcaletValue error: compressed value out of range: eta, phi, cET = " << ieta << ", " << iphi << ", " << compET << std::endl;
-  else etvalue = hcaluncomp_[itower][compET];
-  return(etvalue);
-}
+double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc, HcalTrigTowerGeometry const& theTrigTowerGeometry) const {
 
-double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) const {
-// This is now an obsolete method; we return the AVERAGE over all the allowed iphi channels if it's invoked
-// The user is encouraged to use hcaletValue(const int& ieta, const int& iphi, const int& compET) instead
-
-  double etvalue = 0.;
-  if (compET < 0 || compET > 0xff) std::cout << "hcaletValue error: compressed value out of range: eta, cET = " << ieta << ", " << compET << std::endl;
-  else {
-	int nphi = 0;
-	for (int iphi=1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta,iphi)) {
-			nphi++;
-			int itower = getOutputLUTId(ieta,iphi);
-			etvalue += hcaluncomp_[itower][compET];
-		}
-	}
-	if (nphi > 0) etvalue /= nphi;
-	else std::cout << "hcaletValue error: no decompression LUTs found for any iphi for ieta = " << ieta << std::endl;
-  }
-  return(etvalue);
-}
-
-double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const {
-
-  int ieta = hid.ieta();			// No need to check the validity,
-  int iphi = hid.iphi();			// as the values are guaranteed
   int compET = hc.compressedEt();	// to be within the range by the class
-  int itower = getOutputLUTId(ieta,iphi);
+  int itower = theTrigTowerGeometry.topology().detId2denseIdHT(hid);
   double etvalue = hcaluncomp_[itower][compET];
   return(etvalue);
 }
@@ -310,50 +364,23 @@ EcalTriggerPrimitiveSample CaloTPGTranscoderULUT::ecalCompress(const EcalTrigTow
 }
 
 void CaloTPGTranscoderULUT::rctEGammaUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-						const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+						const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 						unsigned int& et, bool& egVecto, bool& activity) const {
   throw cms::Exception("Not Implemented") << "CaloTPGTranscoderULUT::rctEGammaUncompress";
 }
 void CaloTPGTranscoderULUT::rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-					     const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+					     const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 					     unsigned int& et) const {
   throw cms::Exception("Not Implemented") << "CaloTPGTranscoderULUT::rctJetUncompress";
 }
 
-bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin) const {
-	int iphi = iphiin;
-	if (iphi <= 0 || iphi > 72 || ieta == 0 || abs(ieta) > 32) return false;
-	if (abs(ieta) > 28) {
-	  if (newHFphi) {
-	    if ((iphi/4)*4 + 1 != iphi) return false;
-	    iphi = iphi/4 + 1;
-	  }
-	  if (iphi > 18) return false;
-	}
-	return true;
-}
-
-int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) const {
-	int iphi = iphiin;
-	if (HTvalid(ieta, iphi)) {
-		int offset = 0, ietaabs;
-		ietaabs = abs(ieta);
-		if (ieta < 0) offset = NOUTLUTS/2;
-		if (ietaabs < 29) return 72*(ietaabs - 1) + (iphi - 1) + offset;
-		else {
-		  if (newHFphi) iphi = iphi/4 + 1;
-		  return 18*(ietaabs - 29) + iphi + 2015 + offset;
-		}
-	} else return -1;	
-}
-
-std::vector<unsigned char> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowerDetId id) const {
+std::vector<unsigned char> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowerDetId id, HcalTopology const& topology) const {
    std::vector<unsigned char> lut;
-   int itower = getOutputLUTId(id.ieta(),id.iphi());
+   int itower = topology.detId2denseIdHT(id);
    if (itower >= 0) {
          lut.resize(OUTPUT_LUT_SIZE);
 	 for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; i++) lut[i]=outputLUT_[itower][i];
-   } 
+   }
    return lut;
 }
 
@@ -375,20 +402,3 @@ void CaloTPGTranscoderULUT::setup(HcalLutMetadata const& lutMetadata, HcalTrigTo
    }
    loadHCALUncompress(decompressionFile_, lutMetadata,theTrigTowerGeometry);
 }
-
-//int CaloTPGTranscoderULUT::getLutGranularity(const DetId& id) const{
-//   int ieta = id.ietaAbs();
-//   if (ieta < 18) return 1;
-//   else if (ieta < 27) return 2;
-//   else if (ieta < 29) return 5;
-//   return 0;
-//}
-//
-//int CaloTPGTranscoderULUT::getLutThreshold(const DetId& id) const{
-//   int ieta = id.ietaAbs();
-//   if (ieta < 18) return 4;
-//   else if (ieta < 27) return 2;
-//   else if (ieta < 29) return 1;
-//   return 0;
-//}
-//

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -42,11 +42,13 @@ void CaloTPGTranscoderULUT::loadHCALCompress() const{
 	analyticalLUT[i] = (unsigned int)(sqrt(14.94*log(1.+i/14.94)*i) + 0.5);
 	identityLUT[i] = min(i,0xffu);
   }
- 
+
+   // Version 0 loop
   for (int ieta=-32; ieta <= 32; ieta++){
+      const int version_of_hcal_TPs = 0;
      for (int iphi = 1; iphi <= 72; iphi++){
-        if (!HTvalid(ieta,iphi)) continue;
-        int lutId = getOutputLUTId(ieta,iphi);
+        if (!HTvalid(ieta, iphi, version_of_hcal_TPs)) continue;
+        int lutId = getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
         // TODO cms::Error log
         if (outputLUT_[lutId] != 0){
            std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
@@ -63,13 +65,40 @@ void CaloTPGTranscoderULUT::loadHCALCompress() const{
            outputLUT_[lutId][i] = 0;
 
         for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i)
-	  outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(id.version())) ? analyticalLUT[i] : identityLUT[i]; 
-	// TODO: UPDATE TO PRODUCE 1x1 output LUTs
+	  outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(id.version())) ? analyticalLUT[i] : identityLUT[i];
      } //for iphi
+  } //for ieta
+   // Version 1 loop
+  for (int ieta=-41; ieta <= 41; ieta++){
+      const int version_of_hcal_TPs = 1;
+      for (int iphi = 1; iphi <= 72; iphi++){
+          if (!HTvalid(ieta, iphi, version_of_hcal_TPs)) continue;
+          int lutId = getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
+          // TODO cms::Error log
+          if (outputLUT_[lutId] != 0){
+              std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
+              continue;
+          }
+
+          outputLUT_[lutId] = new LUT[OUTPUT_LUT_SIZE];
+
+          HcalTrigTowerDetId id(ieta, iphi);
+          id.setVersion(version_of_hcal_TPs);
+          const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
+          int threshold = meta->getOutputLutThreshold();
+
+          for (int i = 0; i < threshold; ++i)
+              outputLUT_[lutId][i] = 0;
+
+          for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i)
+              outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(id.version())) ? analyticalLUT[i] : identityLUT[i];
+      } //for iphi
   } //for ieta
 }
 
 void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
+  // TODO: Add Version 1 support
+  const int version_of_hcal_TPs = 0;
   int tool;
   std::ifstream userfile;
   std::vector< std::vector<LUT> > outputluts;
@@ -79,8 +108,8 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
   int maxid = 0, minid = 0x7FFFFFFF, rawid = 0;
   for (int ieta=-32; ieta <= 32; ieta++) {
     for (int iphi = 1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta,iphi)) {
-          rawid = getOutputLUTId(ieta, iphi);
+		if (HTvalid(ieta, iphi, version_of_hcal_TPs)) {
+          rawid = getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
           if (outputLUT_[rawid] != 0) std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
           else outputLUT_[rawid] = new LUT[OUTPUT_LUT_SIZE];
           if (rawid < minid) minid = rawid;
@@ -109,31 +138,31 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
 	for (unsigned int i=0; i<=s.length(); i++) userfile.unget(); //rewind last line
     outputluts.resize(nluts);
     for (int i=0; i<nluts; i++) outputluts[i].resize(OUTPUT_LUT_SIZE);
-    
-    
+
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
       loieta.push_back(tool);
     }
-    
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
-      hiieta.push_back(tool);    
+      hiieta.push_back(tool);
     }
-   
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
       loiphi.push_back(tool);
-	
+
     }
-    
+
     for (int i=0; i<nluts; i++) {
       userfile >> tool;
       hiiphi.push_back(tool);
-    
+
     }
-   	
-    for (unsigned int j=0; j<OUTPUT_LUT_SIZE; j++) { 
+
+    for (unsigned int j=0; j<OUTPUT_LUT_SIZE; j++) {
       for(int i=0; i <nluts; i++) {
 		userfile >> tool;
 		if (tool < 0) {
@@ -148,15 +177,15 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
 	  }
     }
     userfile.close();
-	
+
 	HcalDetId cell;
 	int id, ntot = 0;
 	for (int i=0; i < nluts; i++) {
 		int nini = 0;
-     		for (int iphi = loiphi[i]; iphi <= hiiphi[i]; iphi++) {      
+     		for (int iphi = loiphi[i]; iphi <= hiiphi[i]; iphi++) {
        			for (int ieta=loieta[i]; ieta <= hiieta[i]; ieta++) {
-	 				if (HTvalid(ieta,iphi)) {  
-	   					id = getOutputLUTId(ieta,iphi);
+	 				if (HTvalid(ieta, iphi, version_of_hcal_TPs)) {
+	   					id = getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
 	   					if (outputLUT_[id] == 0) throw cms::Exception("PROBLEM: outputLUT_ has not been initialized for ieta, iphi, id = ") << ieta << ", " << iphi << ", " << id << std::endl;
 		    			for (int j = 0; j <= 0x3ff; j++) outputLUT_[id][j] = outputluts[i][j];
 						nini++;
@@ -164,11 +193,11 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
 	 				}
        			}
        }
-	
+
     }
-	
+
   } else {
-    
+
 	loadHCALCompress();
   }
 }
@@ -180,29 +209,32 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
       hcaluncomp_.push_back(decompressionTable);
    }
 
+   // Version 0 loop
    for (int ieta = -32; ieta <= 32; ++ieta){
 
       const int version_of_hcal_TPs = 0;
 
       double eta_low = 0., eta_high = 0.;
-      theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs,eta_low,eta_high); 
+      theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs,eta_low,eta_high);
       double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
 		for (int iphi = 1; iphi <= 72; iphi++) {
-         if (!HTvalid(ieta, iphi)) continue;
+         if (!HTvalid(ieta, iphi, version_of_hcal_TPs)) continue;
 
-			int lutId = getOutputLUTId(ieta,iphi);
+         int lutId = getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
          HcalTrigTowerDetId id(ieta, iphi);
 
-         const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
          double factor = 0.;
 
          // HF
-         if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs))
-            factor = rctlsb_factor_;
+         if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs)) {
+             factor = rctlsb_factor_;
+         }
          // HBHE
-         else 
-            factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
+         else {
+             const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
+             factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
+         }
 
          // tpg - compressed value
          unsigned int tpg = outputLUT_[lutId][0];
@@ -218,26 +250,75 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
          hcaluncomp_[lutId][tpg] = factor * low;
 		} // for phi
 	} // for ieta
+
+   // Version 1 loop
+   for (int ieta = -41; ieta <= 41; ++ieta) {
+
+       const int version_of_hcal_TPs = 1;
+       if (abs(ieta) < 28) { continue; }
+
+       double eta_low = 0., eta_high = 0.;
+       theTrigTowerGeometry->towerEtaBounds(ieta, version_of_hcal_TPs, eta_low, eta_high);
+       double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
+
+       for (int iphi = 1; iphi <= 72; iphi++) {
+           if (!HTvalid(ieta, iphi, version_of_hcal_TPs)) { continue; }
+
+           int lutId = getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
+           HcalTrigTowerDetId id(ieta, iphi);
+           id.setVersion(version_of_hcal_TPs);
+
+           double factor = 0.;
+           // HF
+           if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs)) {
+               factor = rctlsb_factor_;
+           }
+           // HBHE
+           else {
+               const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
+               factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
+           }
+
+           // tpg - compressed value
+           unsigned int tpg = outputLUT_[lutId][0];
+           int low = 0;
+           for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; ++i) {
+               if (outputLUT_[lutId][i] != tpg) {
+                   unsigned int mid = (low + i)/2;
+                   if (tpg == 0) {
+                       hcaluncomp_[lutId][tpg] = low;
+                   } else {
+                       hcaluncomp_[lutId][tpg] = factor * mid;
+                   }
+                   low = i;
+                   tpg = outputLUT_[lutId][i];
+               }
+           }
+           hcaluncomp_[lutId][tpg] = factor * low;
+       }  // for phi
+   } // for ieta
 }
 
 void CaloTPGTranscoderULUT::loadHCALUncompress(const std::string& filename) const {
+  // TODO: Add Version 1 support
+  const int version_of_hcal_TPs = 0;
   std::ifstream userfile;
   userfile.open(filename.c_str());
-  
+
   hcaluncomp_.resize(NOUTLUTS);
   for (int i = 0; i < NOUTLUTS; i++) hcaluncomp_[i].resize(TPGMAX);
-  
+
   static const int etabound = 32;
   if( userfile ) {
 	 double et;
-     for (int i=0; i<TPGMAX; i++) { 
+     for (int i=0; i<TPGMAX; i++) {
       for(int j = 1; j <=etabound; j++) {
 	    userfile >> et;
 		for (int iphi = 1; iphi <= 72; iphi++) {
-		  int itower = getOutputLUTId(j,iphi);
+		  int itower = getOutputLUTId(j, iphi, version_of_hcal_TPs);
 		  if (itower >= 0) hcaluncomp_[itower][i] = et;
-		  itower = getOutputLUTId(-j,iphi);
-		  if (itower >= 0) hcaluncomp_[itower][i] = et;		  
+		  itower = getOutputLUTId(-j, iphi, version_of_hcal_TPs);
+		  if (itower >= 0) hcaluncomp_[itower][i] = et;
 		}
 	  }
 	 }
@@ -253,7 +334,7 @@ HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTow
   int ieta = id.ieta();
   int iphi = id.iphi();
 //  if (abs(ieta) > 28) iphi = iphi/4 + 1; // Changing iphi index from 1, 5, ..., 69 to 1, 2, ..., 18
-  int itower = getOutputLUTId(ieta,iphi);
+  int itower = getOutputLUTId(ieta, iphi, id.version());
 
   if (itower < 0) cms::Exception("Invalid Data") << "No trigger tower found for ieta, iphi = " << ieta << ", " << iphi;
   if (sample >= OUTPUT_LUT_SIZE) {
@@ -271,7 +352,7 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, cons
 	CaloTPGTranscoderULUT::loadHCALUncompress(decompressionFile_);
   }
   double etvalue = 0.;
-  int itower = getOutputLUTId(ieta,iphi);
+  int itower = getOutputLUTId(ieta, iphi);  // TODO Add version
   if (itower < 0) std::cout << "hcaletValue error: no decompression LUT found for ieta, iphi = " << ieta << ", " << iphi << std::endl;
   else if (compET < 0 || compET > 0xff) std::cout << "hcaletValue error: compressed value out of range: eta, phi, cET = " << ieta << ", " << iphi << ", " << compET << std::endl;
   else etvalue = hcaluncomp_[itower][compET];
@@ -292,9 +373,9 @@ double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) co
   else {
 	int nphi = 0;
 	for (int iphi=1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta,iphi)) {
+		if (HTvalid(ieta, iphi)) {  // TODO Add version
 			nphi++;
-			int itower = getOutputLUTId(ieta,iphi);
+			int itower = getOutputLUTId(ieta, iphi);  // TODO Add version
 			etvalue += hcaluncomp_[itower][compET];
 		}
 	}
@@ -310,7 +391,7 @@ double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const H
   int ieta = hid.ieta();			// No need to check the validity,
   int iphi = hid.iphi();			// as the values are guaranteed
   int compET = hc.compressedEt();	// to be within the range by the class
-  int itower = getOutputLUTId(ieta,iphi);
+  int itower = getOutputLUTId(ieta, iphi, hid.version());
   double etvalue = hcaluncomp_[itower][compET];
   return(etvalue);
 }
@@ -320,50 +401,71 @@ EcalTriggerPrimitiveSample CaloTPGTranscoderULUT::ecalCompress(const EcalTrigTow
 }
 
 void CaloTPGTranscoderULUT::rctEGammaUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-						const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+						const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 						unsigned int& et, bool& egVecto, bool& activity) const {
   throw cms::Exception("Not Implemented") << "CaloTPGTranscoderULUT::rctEGammaUncompress";
 }
 void CaloTPGTranscoderULUT::rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-					     const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+					     const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 					     unsigned int& et) const {
   throw cms::Exception("Not Implemented") << "CaloTPGTranscoderULUT::rctJetUncompress";
 }
 
-bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin) const {
+bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin, const int version) const {
 	int iphi = iphiin;
-	if (iphi <= 0 || iphi > 72 || ieta == 0 || abs(ieta) > 32) return false;
-	if (abs(ieta) > 28) {
+	if (iphi <= 0 || iphi > 72 || ieta == 0) return false;
+    if (version==0 && abs(ieta) > 32) return false;
+	if (version==0 && abs(ieta) > 28) {
 	  if (newHFphi) {
 	    if ((iphi/4)*4 + 1 != iphi) return false;
 	    iphi = iphi/4 + 1;
 	  }
 	  if (iphi > 18) return false;
 	}
-	return true;
+    if (version==1) {
+        if (abs(ieta)>41 || abs(ieta)<28) return false;
+        if (abs(ieta)>=30 && (iphi%2)==0) return false; // no evens!
+    }
+    return true;
 }
 
-int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin) const {
-	int iphi = iphiin;
-	if (HTvalid(ieta, iphi)) {
-		int offset = 0, ietaabs;
-		ietaabs = abs(ieta);
-		if (ieta < 0) offset = NOUTLUTS/2;
-		if (ietaabs < 29) return 72*(ietaabs - 1) + (iphi - 1) + offset;
-		else {
-		  if (newHFphi) iphi = iphi/4 + 1;
-		  return 18*(ietaabs - 29) + iphi + 2015 + offset;
-		}
-	} else return -1;	
+int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin, const int version) const {
+    int iphi = iphiin;
+    if (HTvalid(ieta, iphi, version)) {
+        int offset = 0;
+        int ietaabs = abs(ieta);
+        if (version == 0) {
+            if (ieta < 0) offset = NUM_V0_LUTS/2;
+            if (ietaabs < 29) return 72*(ietaabs - 1) + (iphi - 1) + offset;
+            else {
+                if (newHFphi) iphi = iphi/4 + 1;
+                return 18*(ietaabs - 29) + iphi + 2015 + offset;
+            }
+        } else if (version == 1) {
+            // The version 0 luts are stored at the start of the array, so we
+            // offset by that ammount to start
+            offset = NUM_V0_LUTS;
+            if (ieta < 0) {
+                offset += NUM_V1_LUTS/2;
+            }
+            if (abs(ieta) <= 28) {  // ieta 28, 29 have 72 iph
+                return 72 * (ietaabs - 28) + (iphi - 1) + offset;
+            } else {  // ieta 30-41 have 36 iphi (1,3,5,7,...)
+                offset += 2 * 72;  // Accounting for ieta 28, 29
+                // (iphi - 1)/2 takes 1,3,5... to 0,1,2...
+                return 36 * (ietaabs - 30) + ((iphi - 1)/2) + offset;
+            }
+        } else return -1;
+    } else return -1;
 }
 
 std::vector<unsigned char> CaloTPGTranscoderULUT::getCompressionLUT(HcalTrigTowerDetId id) const {
    std::vector<unsigned char> lut;
-   int itower = getOutputLUTId(id.ieta(),id.iphi());
+   int itower = getOutputLUTId(id.ieta(), id.iphi(), id.version());
    if (itower >= 0) {
          lut.resize(OUTPUT_LUT_SIZE);
 	 for (unsigned int i = 0; i < OUTPUT_LUT_SIZE; i++) lut[i]=outputLUT_[itower][i];
-   } 
+   }
    return lut;
 }
 
@@ -372,7 +474,7 @@ void CaloTPGTranscoderULUT::setup(const edm::EventSetup& es, Mode mode=All) cons
    // TODO Try/except
    es.get<HcalLutMetadataRcd>().get(lutMetadata_);
    es.get<CaloGeometryRecord>().get(theTrigTowerGeometry);
-   
+
    nominal_gain_ = lutMetadata_->getNominalGain();
    float rctlsb =lutMetadata_->getRctLsb();
    if (rctlsb != 0.25 && rctlsb != 0.5)
@@ -391,15 +493,15 @@ void CaloTPGTranscoderULUT::setup(const edm::EventSetup& es, Mode mode=All) cons
 }
 
 void CaloTPGTranscoderULUT::printDecompression() const{
-   std::cout << "RCT Decompression table" << std::endl;  
-   const int version_of_hcal_TPs = 0; // appropriate for RCT                       
-   for (int i=0; i < 256; i++) {                                                 
+   std::cout << "RCT Decompression table" << std::endl;
+   const int version_of_hcal_TPs = 0; // appropriate for RCT
+   for (int i=0; i < 256; i++) {
       for (int j=1; j <= theTrigTowerGeometry->nTowers(version_of_hcal_TPs); j++)
          std::cout << int(hcaletValue(j,i)*100. + 0.5)/100. << " ";
-      std::cout << std::endl;                                               
-      for (int j=1; j <= theTrigTowerGeometry->nTowers(version_of_hcal_TPs); j++)               
-         if (hcaletValue(j,i) != hcaletValue(-j,i))                    
-            cout << "Error: decompression table for ieta = +/- " << j << " disagree! " << hcaletValue(-j,i) << ", " << hcaletValue(j,i) << endl;        
+      std::cout << std::endl;
+      for (int j=1; j <= theTrigTowerGeometry->nTowers(version_of_hcal_TPs); j++)
+         if (hcaletValue(j,i) != hcaletValue(-j,i))
+            cout << "Error: decompression table for ieta = +/- " << j << " disagree! " << hcaletValue(-j,i) << ", " << hcaletValue(j,i) << endl;
    }
 }
 

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -377,10 +377,8 @@ bool CaloTPGTranscoderULUT::HTvalid(const int ieta, const int iphiin, const int 
 	if (iphi <= 0 || iphi > 72 || ieta == 0) return false;
     if (version==0 && abs(ieta) > 32) return false;
 	if (version==0 && abs(ieta) > 28) {
-	  if (newHFphi) {
-	    if ((iphi/4)*4 + 1 != iphi) return false;
-	    iphi = iphi/4 + 1;
-	  }
+	  if ((iphi/4)*4 + 1 != iphi) return false;
+	  iphi = iphi/4 + 1;	  
 	  if (iphi > 18) return false;
 	}
     if (version==1) {
@@ -399,7 +397,7 @@ int CaloTPGTranscoderULUT::getOutputLUTId(const int ieta, const int iphiin, cons
             if (ieta < 0) offset = NUM_V0_LUTS/2;
             if (ietaabs < 29) return 72*(ietaabs - 1) + (iphi - 1) + offset;
             else {
-                if (newHFphi) iphi = iphi/4 + 1;
+                iphi = iphi/4 + 1;
                 return 18*(ietaabs - 29) + iphi + 2015 + offset;
             }
         } else if (version == 1) {

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -51,7 +51,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress() const{
      for (int iphi = 1; iphi <= 72; iphi++){
         HcalTrigTowerDetId id(ieta, iphi);
         if (!topo.validHT(id)) continue;
-        int lutId = topo.detId2denseId(id);
+        int lutId = topo.detId2denseIdHT(id);
         // TODO cms::Error log
         if (outputLUT_[lutId] != 0){
            std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
@@ -78,7 +78,7 @@ void CaloTPGTranscoderULUT::loadHCALCompress() const{
           id.setVersion(version_of_hcal_TPs);
 
           if (!topo.validHT(id)) continue;
-          int lutId = topo.detId2denseId(id);
+          int lutId = topo.detId2denseIdHT(id);
           // TODO cms::Error log
           if (outputLUT_[lutId] != 0){
               std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
@@ -114,11 +114,11 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
     for (int iphi = 1; iphi <= 72; iphi++) {
       HcalTrigTowerDetId id(ieta,iphi);
       if (topo.validHT(id)) {
-	rawid = topo.detId2denseId(id);
-	if (outputLUT_[rawid] != 0) std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
-          else outputLUT_[rawid] = new LUT[OUTPUT_LUT_SIZE];
-	if (rawid < minid) minid = rawid;
-	if (rawid > maxid) maxid = rawid;
+        rawid = topo.detId2denseIdHT(id);
+        if (outputLUT_[rawid] != 0) std::cout << "Error: LUT with (ieta,iphi) = (" << ieta << "," << iphi << ") has been previously allocated!" << std::endl;
+        else outputLUT_[rawid] = new LUT[OUTPUT_LUT_SIZE];
+        if (rawid < minid) minid = rawid;
+        if (rawid > maxid) maxid = rawid;
       }
     }
   }
@@ -185,26 +185,23 @@ void CaloTPGTranscoderULUT::loadHCALCompress(const std::string& filename) const{
 
 	HcalDetId cell;
 	int id, ntot = 0;
-	for (int i=0; i < nluts; i++) {
-		int nini = 0;
-     		for (int iphi = loiphi[i]; iphi <= hiiphi[i]; iphi++) {
-       			for (int ieta=loieta[i]; ieta <= hiieta[i]; ieta++) {
-			  HcalTrigTowerDetId detid(ieta,iphi);
-			  if (topo.validHT(detid)) {
-			    id = topo.detId2denseId(detid);
-	   					if (outputLUT_[id] == 0) throw cms::Exception("PROBLEM: outputLUT_ has not been initialized for ieta, iphi, id = ") << ieta << ", " << iphi << ", " << id << std::endl;
-		    			for (int j = 0; j <= 0x3ff; j++) outputLUT_[id][j] = outputluts[i][j];
-						nini++;
-						ntot++;
-	 				}
-       			}
-       }
-
+    for (int i=0; i < nluts; i++) {
+      int nini = 0;
+      for (int iphi = loiphi[i]; iphi <= hiiphi[i]; iphi++) {
+        for (int ieta=loieta[i]; ieta <= hiieta[i]; ieta++) {
+          HcalTrigTowerDetId detid(ieta,iphi);
+          if (topo.validHT(detid)) {
+            id = topo.detId2denseIdHT(detid);
+            if (outputLUT_[id] == 0) throw cms::Exception("PROBLEM: outputLUT_ has not been initialized for ieta, iphi, id = ") << ieta << ", " << iphi << ", " << id << std::endl;
+            for (int j = 0; j <= 0x3ff; j++) outputLUT_[id][j] = outputluts[i][j];
+            nini++;
+            ntot++;
+          }
+        }
+      }
     }
-
   } else {
-
-	loadHCALCompress();
+      loadHCALCompress();
   }
 }
 
@@ -229,19 +226,18 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
        HcalTrigTowerDetId id(ieta, iphi);
        
        if (!topo.validHT(id)) continue; 
-       
-       int lutId = topo.detId2denseId(id);
+       int lutId = topo.detId2denseIdHT(id);
        
        double factor = 0.;
        
        // HF
        if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs)) {
-	 factor = rctlsb_factor_;
+         factor = rctlsb_factor_;
        }
        // HBHE
        else {
-	 const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
-	 factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
+         const HcalLutMetadatum *meta = lutMetadata_->getValues(id);
+         factor = nominal_gain_ / cosh_ieta * meta->getLutGranularity();
        }
        
        // tpg - compressed value
@@ -273,8 +269,7 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
            HcalTrigTowerDetId id(ieta, iphi);
            id.setVersion(version_of_hcal_TPs);
            if (!topo.validHT(id)) continue; 
-
-           int lutId = topo.detId2denseId(id);
+           int lutId = topo.detId2denseIdHT(id);
 
            double factor = 0.;
            // HF
@@ -318,32 +313,31 @@ void CaloTPGTranscoderULUT::loadHCALUncompress(const std::string& filename) cons
 
   static const int etabound = 32;
   if( userfile ) {
-	 double et;
-     for (int i=0; i<TPGMAX; i++) {
+    double et;
+    for (int i=0; i<TPGMAX; i++) {
       for(int j = 1; j <=etabound; j++) {
-	    userfile >> et;
-		for (int iphi = 1; iphi <= 72; iphi++) {
-		  HcalTrigTowerDetId id(j,iphi);
-		  int itower = theTrigTowerGeometry->topology().detId2denseId(id);
+        userfile >> et;
+        for (int iphi = 1; iphi <= 72; iphi++) {
+          HcalTrigTowerDetId id(j,iphi);
+          int itower = theTrigTowerGeometry->topology().detId2denseIdHT(id);
 
-		  if (itower >= 0) hcaluncomp_[itower][i] = et;
-		  HcalTrigTowerDetId id2(-j,iphi);
-		  itower = theTrigTowerGeometry->topology().detId2denseId(id2);
-		  		  if (itower >= 0) hcaluncomp_[itower][i] = et;
-		}
-	  }
-	 }
-	 userfile.close();
+          if (itower >= 0) hcaluncomp_[itower][i] = et;
+          HcalTrigTowerDetId id2(-j,iphi);
+          itower = theTrigTowerGeometry->topology().detId2denseIdHT(id2);
+          if (itower >= 0) hcaluncomp_[itower][i] = et;
+        }
+      }
+    }
+    userfile.close();
   }
   else {
-
-	loadHCALUncompress();
+    loadHCALUncompress();
   }
 }
 
 HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const {
 
-  int itower = theTrigTowerGeometry->topology().detId2denseId(id);
+  int itower = theTrigTowerGeometry->topology().detId2denseIdHT(id);
 
   if (itower < 0) cms::Exception("Invalid Data") << "No trigger tower found for ieta, iphi = " << id.ieta() << ", " << id.iphi() << " v"<<id.version();
   if (sample >= OUTPUT_LUT_SIZE) {
@@ -359,7 +353,7 @@ double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const H
   if (hcaluncomp_.empty()) loadHCALUncompress(decompressionFile_);
 
   int compET = hc.compressedEt();	// to be within the range by the class
-  int itower = theTrigTowerGeometry->topology().detId2denseId(hid);
+  int itower = theTrigTowerGeometry->topology().detId2denseIdHT(hid);
   double etvalue = hcaluncomp_[itower][compET];
   return(etvalue);
 }

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -346,45 +346,6 @@ HcalTriggerPrimitiveSample CaloTPGTranscoderULUT::hcalCompress(const HcalTrigTow
   return HcalTriggerPrimitiveSample(outputLUT_[itower][sample],fineGrain,0,0);
 }
 
-double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& iphi, const int& compET) const {
-  if (hcaluncomp_.empty()) {
-
-	CaloTPGTranscoderULUT::loadHCALUncompress(decompressionFile_);
-  }
-  double etvalue = 0.;
-  int itower = getOutputLUTId(ieta, iphi);  // TODO Add version
-  if (itower < 0) std::cout << "hcaletValue error: no decompression LUT found for ieta, iphi = " << ieta << ", " << iphi << std::endl;
-  else if (compET < 0 || compET > 0xff) std::cout << "hcaletValue error: compressed value out of range: eta, phi, cET = " << ieta << ", " << iphi << ", " << compET << std::endl;
-  else etvalue = hcaluncomp_[itower][compET];
-  return(etvalue);
-}
-
-double CaloTPGTranscoderULUT::hcaletValue(const int& ieta, const int& compET) const {
-// This is now an obsolete method; we return the AVERAGE over all the allowed iphi channels if it's invoked
-// The user is encouraged to use hcaletValue(const int& ieta, const int& iphi, const int& compET) instead
-
-  if (hcaluncomp_.empty()) {
-	std::cout << "Initializing the RCT decompression table from the file: " << decompressionFile_ << std::endl;
-	CaloTPGTranscoderULUT::loadHCALUncompress(decompressionFile_);
-  }
-
-  double etvalue = 0.;
-  if (compET < 0 || compET > 0xff) std::cout << "hcaletValue error: compressed value out of range: eta, cET = " << ieta << ", " << compET << std::endl;
-  else {
-	int nphi = 0;
-	for (int iphi=1; iphi <= 72; iphi++) {
-		if (HTvalid(ieta, iphi)) {  // TODO Add version
-			nphi++;
-			int itower = getOutputLUTId(ieta, iphi);  // TODO Add version
-			etvalue += hcaluncomp_[itower][compET];
-		}
-	}
-	if (nphi > 0) etvalue /= nphi;
-	else std::cout << "hcaletValue error: no decompression LUTs found for any iphi for ieta = " << ieta << std::endl;
-  }
-  return(etvalue);
-}
-
 double CaloTPGTranscoderULUT::hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const {
   if (hcaluncomp_.empty()) loadHCALUncompress(decompressionFile_);
 

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.cc
@@ -63,7 +63,8 @@ void CaloTPGTranscoderULUT::loadHCALCompress() const{
            outputLUT_[lutId][i] = 0;
 
         for (unsigned int i = threshold; i < OUTPUT_LUT_SIZE; ++i)
-           outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry->firstHFTower()) ? analyticalLUT[i] : identityLUT[i];
+	  outputLUT_[lutId][i] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(id.version())) ? analyticalLUT[i] : identityLUT[i]; 
+	// TODO: UPDATE TO PRODUCE 1x1 output LUTs
      } //for iphi
   } //for ieta
 }
@@ -181,8 +182,10 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
 
    for (int ieta = -32; ieta <= 32; ++ieta){
 
+      const int version_of_hcal_TPs = 0;
+
       double eta_low = 0., eta_high = 0.;
-		theTrigTowerGeometry->towerEtaBounds(ieta,eta_low,eta_high); 
+      theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs,eta_low,eta_high); 
       double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
 		for (int iphi = 1; iphi <= 72; iphi++) {
@@ -195,7 +198,7 @@ void CaloTPGTranscoderULUT::loadHCALUncompress() const {
          double factor = 0.;
 
          // HF
-         if (abs(ieta) >= theTrigTowerGeometry->firstHFTower())
+         if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs))
             factor = rctlsb_factor_;
          // HBHE
          else 
@@ -388,12 +391,13 @@ void CaloTPGTranscoderULUT::setup(const edm::EventSetup& es, Mode mode=All) cons
 }
 
 void CaloTPGTranscoderULUT::printDecompression() const{
-   std::cout << "RCT Decompression table" << std::endl;                          
+   std::cout << "RCT Decompression table" << std::endl;  
+   const int version_of_hcal_TPs = 0; // appropriate for RCT                       
    for (int i=0; i < 256; i++) {                                                 
-      for (int j=1; j <= theTrigTowerGeometry->nTowers(); j++)
+      for (int j=1; j <= theTrigTowerGeometry->nTowers(version_of_hcal_TPs); j++)
          std::cout << int(hcaletValue(j,i)*100. + 0.5)/100. << " ";
       std::cout << std::endl;                                               
-      for (int j=1; j <= theTrigTowerGeometry->nTowers(); j++)               
+      for (int j=1; j <= theTrigTowerGeometry->nTowers(version_of_hcal_TPs); j++)               
          if (hcaletValue(j,i) != hcaletValue(-j,i))                    
             cout << "Error: decompression table for ieta = +/- " << j << " disagree! " << hcaletValue(-j,i) << ", " << hcaletValue(j,i) << endl;        
    }

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -4,13 +4,15 @@
 #include <memory>
 #include <vector>
 #include "CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
+
 
 // tmp
 #include "CondFormats/HcalObjects/interface/HcalLutMetadata.h"
 
 
 /** \class CaloTPGTranscoderULUT
-  *  
+  *
   * \author J. Mans - Minnesota
   */
 
@@ -21,22 +23,19 @@ public:
   CaloTPGTranscoderULUT(const std::string& compressionFile="",
                         const std::string& decompressionFile="");
   virtual ~CaloTPGTranscoderULUT();
-  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const;
+  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain, HcalTrigTowerGeometry const&) const;
   virtual EcalTriggerPrimitiveSample ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const;
 
   virtual void rctEGammaUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 				   unsigned int& et, bool& egVecto, bool& activity) const;
   virtual void rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 				   unsigned int& et) const;
-  virtual double hcaletValue(const int& ieta, const int& compressedValue) const;
-  virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const;
-  virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
-  virtual bool HTvalid(const int ieta, const int iphi) const;
-  virtual std::vector<unsigned char> getCompressionLUT(HcalTrigTowerDetId id) const;
+  virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc, HcalTrigTowerGeometry const&) const;
+  virtual std::vector<unsigned char> getCompressionLUT(HcalTrigTowerDetId id, HcalTopology const&) const;
   virtual void setup(HcalLutMetadata const&, HcalTrigTowerGeometry const&);
-  virtual int getOutputLUTId(const int ieta, const int iphi) const;
+  //virtual int getOutputLUTId(const int ieta, const int iphi) const;
 
  private:
   // Typedef
@@ -45,10 +44,13 @@ public:
 
   // Constant
   // TODO prefix k
-  static const int NOUTLUTS = 4176;
+  // Version 0 LUTs: 72 phis * 28 towers for HB/HE, 18*4 for HF
+  static const int NUM_V0_LUTS = 2 * (72*28 + 18*4);
+  // Version 1 LUTs: 72 phis * 2 for split 28,29 in HE, full granularity in HF
+  static const int NUM_V1_LUTS = 2 * (72*2 + 36*12);
+  static const int NOUTLUTS = NUM_V0_LUTS + NUM_V1_LUTS;
   static const unsigned int OUTPUT_LUT_SIZE = 1024;
   static const int TPGMAX = 256;
-  static const bool newHFphi = true;
 
   // Member functions
   void loadHCALCompress(HcalLutMetadata const&, HcalTrigTowerGeometry const&) ; //Analytical compression tables

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -31,10 +31,8 @@ public:
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 				   unsigned int& et) const;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
-  bool HTvalid(const int ieta, const int iphi, const int version) const;
   virtual std::vector<unsigned char> getCompressionLUT(HcalTrigTowerDetId id) const;
   virtual void setup(const edm::EventSetup& es, Mode) const;
-  int getOutputLUTId(const int ieta, const int iphi, const int version) const;
   void printDecompression() const;
 
  private:

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -51,7 +51,6 @@ public:
   static const int NOUTLUTS = NUM_V0_LUTS + NUM_V1_LUTS;
   static const unsigned int OUTPUT_LUT_SIZE = 1024;
   static const int TPGMAX = 256;
-  static const bool newHFphi = true;
 
   // Member functions
   void loadHCALCompress(void) const; //Analytical compression tables

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -10,7 +10,7 @@
 
 
 /** \class CaloTPGTranscoderULUT
-  *  
+  *
   * \author J. Mans - Minnesota
   */
 
@@ -25,18 +25,18 @@ public:
   virtual EcalTriggerPrimitiveSample ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const;
 
   virtual void rctEGammaUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 				   unsigned int& et, bool& egVecto, bool& activity) const;
   virtual void rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
-				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
+				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 				   unsigned int& et) const;
   virtual double hcaletValue(const int& ieta, const int& compressedValue) const;
   virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
-  virtual bool HTvalid(const int ieta, const int iphi) const;
+  bool HTvalid(const int ieta, const int iphi, const int version) const;
   virtual std::vector<unsigned char> getCompressionLUT(HcalTrigTowerDetId id) const;
   virtual void setup(const edm::EventSetup& es, Mode) const;
-  virtual int getOutputLUTId(const int ieta, const int iphi) const;
+  int getOutputLUTId(const int ieta, const int iphi, const int version) const;
   void printDecompression() const;
 
  private:
@@ -46,7 +46,11 @@ public:
 
   // Constant
   // TODO prefix k
-  static const int NOUTLUTS = 4176;
+  // Version 0 LUTs: 72 phis * 28 towers for HB/HE, 18*4 for HF
+  static const int NUM_V0_LUTS = 2 * (72*28 + 18*4);
+  // Version 1 LUTs: 72 phis * 2 for split 28,29 in HE, full granularity in HF
+  static const int NUM_V1_LUTS = 2 * (72*2 + 36*12);
+  static const int NOUTLUTS = NUM_V0_LUTS + NUM_V1_LUTS;
   static const unsigned int OUTPUT_LUT_SIZE = 1024;
   static const int TPGMAX = 256;
   static const bool newHFphi = true;

--- a/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
+++ b/CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h
@@ -30,8 +30,6 @@ public:
   virtual void rctJetUncompress(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc,
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec,
 				   unsigned int& et) const;
-  virtual double hcaletValue(const int& ieta, const int& compressedValue) const;
-  virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const;
   bool HTvalid(const int ieta, const int iphi, const int version) const;
   virtual std::vector<unsigned char> getCompressionLUT(HcalTrigTowerDetId id) const;

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -29,7 +29,7 @@ using namespace cms;
 
 namespace {
 
-  std::vector<HcalGenericDetId> allCells (const HcalTopology& hcaltopology) {
+std::vector<HcalGenericDetId> allCells (const HcalTopology& hcaltopology) {
   static std::vector<HcalGenericDetId> result;
   int maxDepthHB=hcaltopology.maxDepthHB();
   int maxDepthHE=hcaltopology.maxDepthHE();
@@ -81,31 +81,25 @@ namespace {
       if(zdctopology.valid(zcell)) result.push_back(zcell);     
     }
 
-    // HcalGenTriggerTower (HcalGenericSubdetector = 5) 
-    // NASTY HACK !!!
-    // - As no valid(cell) check found for HcalTrigTowerDetId 
-    // to create HT cells (ieta=1-28, iphi=1-72)&(ieta=29-32, iphi=1,5,... 69)
-
-    for (int eta = -32; eta <= 32; eta++) {
-      if(abs(eta) <= 28 && (eta != 0)) {
-	for (int phi = 1; phi <= 72; phi++) {
-	  HcalTrigTowerDetId cell(eta, phi);       
-	  result.push_back (cell);
-	}
-      }
-      else if (abs(eta) > 28) {
- 	for (int phi = 1; phi <= 69;) {
-	  HcalTrigTowerDetId cell(eta, phi);       
-	  result.push_back (cell);
-          phi += 4;
-	}
+    // We loop over all possible ieta, iphi, and versions and let validHT
+    // protect us from the cases that do not correspond to a part of the
+    // detector.
+    for (int version = 0; version <= 1; ++version) {
+      for (int ieta = -41; ieta <= 41; ++ieta) {
+        for (int iphi = 1; iphi <= 72; ++iphi) {
+          const int depth = 0;
+          HcalTrigTowerDetId cell(ieta, iphi, depth, version);
+          if (hcaltopology.validHT(cell)) {
+            result.push_back (cell);
+          }
+        }
       }
     }
   }
   return result;
 }
 
-}
+}  // namespace
 
 HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iConfig ): he_recalibration(0), hf_recalibration(0)
 {

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -29,7 +29,7 @@ using namespace cms;
 
 namespace {
 
-  std::vector<HcalGenericDetId> allCells (const HcalTopology& hcaltopology) {
+std::vector<HcalGenericDetId> allCells (const HcalTopology& hcaltopology) {
   static std::vector<HcalGenericDetId> result;
   int maxDepthHB=hcaltopology.maxDepthHB();
   int maxDepthHE=hcaltopology.maxDepthHE();
@@ -81,31 +81,25 @@ namespace {
       if(zdctopology.valid(zcell)) result.push_back(zcell);     
     }
 
-    // HcalGenTriggerTower (HcalGenericSubdetector = 5) 
-    // NASTY HACK !!!
-    // - As no valid(cell) check found for HcalTrigTowerDetId 
-    // to create HT cells (ieta=1-28, iphi=1-72)&(ieta=29-32, iphi=1,5,... 69)
-
-    for (int eta = -32; eta <= 32; eta++) {
-      if(abs(eta) <= 28 && (eta != 0)) {
-	for (int phi = 1; phi <= 72; phi++) {
-	  HcalTrigTowerDetId cell(eta, phi);       
-	  result.push_back (cell);
-	}
-      }
-      else if (abs(eta) > 28) {
- 	for (int phi = 1; phi <= 69;) {
-	  HcalTrigTowerDetId cell(eta, phi);       
-	  result.push_back (cell);
-          phi += 4;
-	}
+    // We loop over all possible ieta, iphi, and versions and let validHT
+    // protect us from the cases that do not correspond to a part of the
+    // detector.
+    for (int version = 0; version <= 1; ++version) {
+      for (int ieta = -41; ieta <= 41; ++ieta) {
+        for (int iphi = 1; iphi <= 72; ++iphi) {
+          const int depth = 0;
+          HcalTrigTowerDetId cell(ieta, iphi, depth, version);
+          if (!hcaltopology.validHT(cell)) {
+            result.push_back (cell);
+          }
+        }
       }
     }
   }
   return result;
 }
 
-}
+}  // namespace
 
 HcalHardcodeCalibrations::HcalHardcodeCalibrations ( const edm::ParameterSet& iConfig ): he_recalibration(0), hf_recalibration(0)
 {

--- a/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalHardcodeCalibrations.cc
@@ -89,7 +89,7 @@ std::vector<HcalGenericDetId> allCells (const HcalTopology& hcaltopology) {
         for (int iphi = 1; iphi <= 72; ++iphi) {
           const int depth = 0;
           HcalTrigTowerDetId cell(ieta, iphi, depth, version);
-          if (!hcaltopology.validHT(cell)) {
+          if (hcaltopology.validHT(cell)) {
             result.push_back (cell);
           }
         }

--- a/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
+++ b/CalibCalorimetry/HcalTPGAlgos/src/HcaluLUTTPGCoder.cc
@@ -236,9 +236,9 @@ void HcaluLUTTPGCoder::update(const HcalDbService& conditions) {
                } // LUTGenerationMode_
 
                ped_[lutId] = ped;
-               gain_[lutId] = gain;
                bool isMasked = ( (status & bitToMask_) > 0 );
                float rcalib = meta->getRCalib();
+               gain_[lutId] = gain * rcalib;
 
                // Input LUT for HB/HE/HF
                if (subdet == HcalBarrel || subdet == HcalEndcap){

--- a/CalibCalorimetry/HcalTPGIO/BuildFile.xml
+++ b/CalibCalorimetry/HcalTPGIO/BuildFile.xml
@@ -6,3 +6,4 @@
 <use   name="CalibFormats/HcalObjects"/>
 <use   name="CalibFormats/CaloTPG"/>
 <use   name="DataFormats/HcalDigi"/>
+<use   name="Geometry/HcalTowerAlgo"/>

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -44,8 +44,6 @@ public:
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
 				   unsigned int& et) const = 0;
 
-  virtual double hcaletValue(const int& ieta, const int& compET) const = 0;  
-  virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const = 0;
   virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const = 0; 
   boost::shared_ptr<HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }
   boost::shared_ptr<EcalTPGCompressor> getEcalCompressor() const { return eccompress_; }

--- a/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
+++ b/CalibFormats/CaloTPG/interface/CaloTPGTranscoder.h
@@ -6,6 +6,8 @@
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 #include "DataFormats/HcalDigi/interface/HcalTriggerPrimitiveSample.h"
 #include "DataFormats/EcalDigi/interface/EcalTriggerPrimitiveSample.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+
 
 class HcalTPGCompressor;
 class EcalTPGCompressor;
@@ -28,7 +30,7 @@ public:
 
   enum Mode { All=0, RCT=1, HcalTPG=2, EcalTPG=3 };
   /** \brief Compression from linear samples+fine grain in the HTR */
-  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const = 0;
+  virtual HcalTriggerPrimitiveSample hcalCompress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain, HcalTrigTowerGeometry const&) const = 0;
   /** \brief Compression from linear samples+fine grain in the ECAL */
   virtual EcalTriggerPrimitiveSample ecalCompress(const EcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const = 0;
   /** \brief Uncompression for the Electron/Photon path in the RCT */
@@ -40,9 +42,7 @@ public:
 				   const EcalTrigTowerDetId& eid, const EcalTriggerPrimitiveSample& ec, 
 				   unsigned int& et) const = 0;
 
-  virtual double hcaletValue(const int& ieta, const int& compET) const = 0;  
-  virtual double hcaletValue(const int& ieta, const int& iphi, const int& compressedValue) const = 0;
-  virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc) const = 0; 
+  virtual double hcaletValue(const HcalTrigTowerDetId& hid, const HcalTriggerPrimitiveSample& hc, HcalTrigTowerGeometry const& httg) const = 0; 
   boost::shared_ptr<const HcalTPGCompressor> getHcalCompressor() const { return hccompress_; }
   boost::shared_ptr<const EcalTPGCompressor> getEcalCompressor() const { return eccompress_; }
 private:

--- a/CalibFormats/CaloTPG/interface/HcalTPGCompressor.h
+++ b/CalibFormats/CaloTPG/interface/HcalTPGCompressor.h
@@ -3,6 +3,8 @@
 
 #include "CalibFormats/CaloObjects/interface/IntegerCaloSamples.h"
 #include "DataFormats/HcalDigi/interface/HcalTriggerPrimitiveDigi.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+
 class CaloTPGTranscoder;
 
 /** \class HcalTPGCompressor
@@ -12,8 +14,8 @@ class CaloTPGTranscoder;
 class HcalTPGCompressor {
 public:
   HcalTPGCompressor(const CaloTPGTranscoder* coder);
-  void compress(const IntegerCaloSamples& ics, const std::vector<bool>& fineGrain, HcalTriggerPrimitiveDigi& digi) const;
-  HcalTriggerPrimitiveSample compress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const;
+  void compress(const IntegerCaloSamples& ics, const std::vector<bool>& fineGrain, HcalTriggerPrimitiveDigi& digi, HcalTrigTowerGeometry const& httg) const;
+  HcalTriggerPrimitiveSample compress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain, HcalTrigTowerGeometry const& httg) const;
 private:
   const CaloTPGTranscoder* coder_;
 };

--- a/CalibFormats/CaloTPG/src/HcalTPGCompressor.cc
+++ b/CalibFormats/CaloTPG/src/HcalTPGCompressor.cc
@@ -4,13 +4,13 @@
 HcalTPGCompressor::HcalTPGCompressor(const CaloTPGTranscoder* coder) : coder_(coder) {
 }
   
-void HcalTPGCompressor::compress(const IntegerCaloSamples& ics, const std::vector<bool>& fineGrain, HcalTriggerPrimitiveDigi& digi) const {
+void HcalTPGCompressor::compress(const IntegerCaloSamples& ics, const std::vector<bool>& fineGrain, HcalTriggerPrimitiveDigi& digi, HcalTrigTowerGeometry const& httg) const {
   digi.setSize(ics.size());
   digi.setPresamples(ics.presamples());
   for (int i=0; i<ics.size(); i++)
-    digi.setSample(i,coder_->hcalCompress(ics.id(),ics[i],fineGrain[i]));
+    digi.setSample(i,coder_->hcalCompress(ics.id(),ics[i],fineGrain[i], httg));
 }
 
-HcalTriggerPrimitiveSample HcalTPGCompressor::compress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain) const {
-  return coder_->hcalCompress(id, sample, fineGrain);
+HcalTriggerPrimitiveSample HcalTPGCompressor::compress(const HcalTrigTowerDetId& id, unsigned int sample, bool fineGrain, HcalTrigTowerGeometry const& httg) const {
+  return coder_->hcalCompress(id, sample, fineGrain, httg);
 }

--- a/CaloOnlineTools/HcalOnlineDb/interface/HcalLutManager.h
+++ b/CaloOnlineTools/HcalOnlineDb/interface/HcalLutManager.h
@@ -25,7 +25,7 @@
 #include "CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalAssistant.h"
 #include "CaloOnlineTools/HcalOnlineDb/interface/HcalChannelIterator.h"
-
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 
 
 class XMLDOMBlock;
@@ -43,9 +43,8 @@ class HcalLutSet{
 class HcalLutManager{
  public:
   
-  HcalLutManager( );
-  HcalLutManager(std::vector<HcalGenericDetId> & map);
-  HcalLutManager(const HcalElectronicsMap * _emap,
+  HcalLutManager(const HcalTopology* _topo,
+		 const HcalElectronicsMap * _emap,
 		 const HcalChannelQuality * _cq = 0,
 		 uint32_t _status_word_to_mask = 0x0000);
   ~HcalLutManager( );
@@ -152,6 +151,7 @@ class HcalLutManager{
   LutXml * lut_xml;
   XMLDOMBlock * lut_checksums_xml;
   HCALConfigDB * db;
+  const HcalTopology* topo_;
   LMap * lmap;
   HcalChannelIterator _iter;
   HcalAssistant _ass;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutGenerator.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutGenerator.cc
@@ -108,7 +108,8 @@ void HcalLutGenerator::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   //
   //HcalLutManager * manager = new HcalLutManager(); // old ways
   //HcalLutManager * manager = new HcalLutManager(&(*hEmap));
-  HcalLutManager * manager = new HcalLutManager(&(*hEmap), _cq, _status_word_to_mask);
+  HcalTopology aHorribleHack(HcalTopologyMode::LHC,2,3);
+  HcalLutManager * manager = new HcalLutManager(&aHorribleHack,&(*hEmap), _cq, _status_word_to_mask);
   bool split_by_crate = true;
   std::cout << " tag name: " << _tag << std::endl;
   std::cout << " HO master file: " << _lin_file << std::endl;

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -555,13 +555,14 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
     // higher LUT numbers have priority in case of overlapping
     int lut_index=-1;
     for ( int i=0; i<lut_set_size; i++ ){
+      const int detid_version = 0;  // 0 is pre-2013, 1 is post
       if ( row->subdet . find("HT") != std::string::npos &&
 	   (row->crate == _crate || _crate == -1) && // -1 stands for all crates
 	   _set.eta_min[i] <= row->ieta &&
 	   _set.eta_max[i] >= row->ieta &&
 	   _set.phi_min[i] <= row->iphi &&
 	   _set.phi_max[i] >= row->iphi &&
-	   _coder.HTvalid(row->ieta, row->iphi) ){
+	   _coder.HTvalid(row->ieta, row->iphi, detid_version) ){
 	lut_index=i;
       }
     }
@@ -806,7 +807,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
 
     // only trigger tower channels
     // and valid (ieta,iphi)
-    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi) ){
+    const int detid_version = 0;  // 0 is pre-2013, 1 is post
+    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi, detid_version) ){
       if ( _xml.count(row->crate) == 0 && split_by_crate ){
 	_xml.insert( std::pair<int,boost::shared_ptr<LutXml> >(row->crate,boost::shared_ptr<LutXml>(new LutXml())) );
       }
@@ -891,7 +893,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
 
     // only trigger tower channels
     // and valid (ieta,iphi)
-    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi) ){
+    const int detid_version = 0;  // 0 is pre-2013, 1 is post
+    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi, detid_version) ){
       if ( _xml.count(row->crate) == 0 && split_by_crate ){
 	_xml.insert( std::pair<int,boost::shared_ptr<LutXml> >(row->crate,boost::shared_ptr<LutXml>(new LutXml())) );
       }

--- a/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
+++ b/CaloOnlineTools/HcalOnlineDb/src/HcalLutManager.cc
@@ -40,23 +40,12 @@ using namespace hcal;
 
 */
 
-HcalLutManager::HcalLutManager( void )
-{    
-  init();
-}
-
-
-HcalLutManager::HcalLutManager(std::vector<HcalGenericDetId> & map)
-{
-  init();
-  _iter . init(map);
-}
-
-
-HcalLutManager::HcalLutManager(const HcalElectronicsMap * _emap,
+HcalLutManager::HcalLutManager(const HcalTopology* topo,
+			       const HcalElectronicsMap * _emap,
 			       const HcalChannelQuality * _cq,
 			       uint32_t _status_word_to_mask)
 {
+  topo_=topo;
   init();
   emap = _emap;
   cq   = _cq;
@@ -134,6 +123,8 @@ HcalSubdetector HcalLutManager::get_subdetector( std::string _det )
 
 int HcalLutManager_test::getLutSetFromFile_test( std::string _filename )
 {
+  /*
+    This code is now non-functional and should be replaced with something that understands topologies
   HcalLutManager _manager;
   HcalLutSet _set = _manager . getLutSetFromFile( _filename );
   std::cout << "===> Test of HcalLutSet HcalLutManager::getLutSetFromFile( std::string _filename )" << std::endl << std::endl;
@@ -158,6 +149,7 @@ int HcalLutManager_test::getLutSetFromFile_test( std::string _filename )
     }
     std::cout << "---> " << j << std::endl;
   }
+  */
   return 0;
 }
 
@@ -533,7 +525,6 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
   std::map<int, boost::shared_ptr<LutXml> > _xml; // index - crate number
 
   std::cout << "instantiating CaloTPGTranscoderULUT in order to check the validity of (ieta,iphi)..." << std::endl;
-  CaloTPGTranscoderULUT _coder;
 
   //EMap _emap("../../../CondFormats/HcalObjects/data/official_emap_v6.03_080817.txt");
   //EMap _emap("../../../CondFormats/HcalObjects/data/official_emap_v6.04_080905.txt");
@@ -556,13 +547,14 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
     int lut_index=-1;
     for ( int i=0; i<lut_set_size; i++ ){
       const int detid_version = 0;  // 0 is pre-2013, 1 is post
+      HcalTrigTowerDetId detid(row->ieta,row->iphi,0,detid_version);
       if ( row->subdet . find("HT") != std::string::npos &&
 	   (row->crate == _crate || _crate == -1) && // -1 stands for all crates
 	   _set.eta_min[i] <= row->ieta &&
 	   _set.eta_max[i] >= row->ieta &&
 	   _set.phi_min[i] <= row->iphi &&
 	   _set.phi_max[i] >= row->iphi &&
-	   _coder.HTvalid(row->ieta, row->iphi, detid_version) ){
+	   topo_->validHT(detid)) {
 	lut_index=i;
       }
     }
@@ -808,7 +800,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
     // only trigger tower channels
     // and valid (ieta,iphi)
     const int detid_version = 0;  // 0 is pre-2013, 1 is post
-    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi, detid_version) ){
+    HcalTrigTowerDetId detid(row->ieta, row->iphi, 0, detid_version);
+    if ( row->subdet . find("HT") != std::string::npos && topo_->validHT(detid) ){
       if ( _xml.count(row->crate) == 0 && split_by_crate ){
 	_xml.insert( std::pair<int,boost::shared_ptr<LutXml> >(row->crate,boost::shared_ptr<LutXml>(new LutXml())) );
       }
@@ -884,8 +877,6 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
   //HcalLutSet _set = getLutSetFromFile( _filename, 2 );
   //int lut_set_size = _set.lut.size(); // number of different luts
 
-  CaloTPGTranscoderULUT _coder;
-
   //loop over all EMap channels
   RooGKCounter _counter;
   for( std::vector<EMap::EMapRow>::const_iterator row=_map.begin(); row!=_map.end(); row++ ){
@@ -894,7 +885,8 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
     // only trigger tower channels
     // and valid (ieta,iphi)
     const int detid_version = 0;  // 0 is pre-2013, 1 is post
-    if ( row->subdet . find("HT") != std::string::npos && _coder.HTvalid(row->ieta, row->iphi, detid_version) ){
+    HcalTrigTowerDetId detid(row->ieta,row->iphi,0,detid_version);
+    if ( row->subdet . find("HT") != std::string::npos && topo_->validHT(detid)) {
       if ( _xml.count(row->crate) == 0 && split_by_crate ){
 	_xml.insert( std::pair<int,boost::shared_ptr<LutXml> >(row->crate,boost::shared_ptr<LutXml>(new LutXml())) );
       }
@@ -926,8 +918,9 @@ std::map<int, boost::shared_ptr<LutXml> > HcalLutManager::getCompressionLutXmlFr
       // FIXME: work around bug in emap v6: rawId wasn't filled
       //HcalTrigTowerDetId _detid(row->rawId);
       HcalTrigTowerDetId _detid(row->ieta, row->iphi);
-      
-      std::vector<unsigned char> coder_lut = _coder.getCompressionLUT(_detid);
+
+     
+      std::vector<unsigned char> coder_lut(1024,0);// = _coder.getCompressionLUT(_detid);
       for (std::vector<unsigned char>::const_iterator _i=coder_lut.begin(); _i!=coder_lut.end();_i++){
 	unsigned int _temp = (unsigned int)(*_i);
 	//if (_temp!=0) std::cout << "DEBUG non-zero LUT!!!!!!!!!!!!!!!" << (*_i) << "     " << _temp << std::endl;

--- a/CaloOnlineTools/HcalOnlineDb/test/xmlTools.cc
+++ b/CaloOnlineTools/HcalOnlineDb/test/xmlTools.cc
@@ -194,8 +194,11 @@ int main( int argc, char **argv )
       test . test_read( _accessor, _type);
       return 0;
     }
+
     
     if (vm.count("test-emap")) {
+      std::cout << "Broken without topology...\n";
+      /*
       std::cout << "Testing emap stuff..." << "\n";
       std::string _accessor = vm["test-emap"].as<std::string>();
       std::cout << "Electronic map accessor string: " << _accessor << "\n";
@@ -204,6 +207,7 @@ int main( int argc, char **argv )
       //
       HcalLutManager _m;
       _m . test_emap();
+      */
       return 0;
     }
     
@@ -217,14 +221,19 @@ int main( int argc, char **argv )
     }
     
     if (vm.count("test-lut-manager")) {
+      std::cout << "Broken without topology...\n";
+      /*
       std::cout << "Testing LUT manager stuff..." << "\n";
       std::string _accessor = vm["test-lut-manager"].as<std::string>();
       std::cout << "LUT ascii file: " << _accessor << "\n";
       HcalLutManager_test::getLutSetFromFile_test( _accessor );
+      */
       return 0;
     }
     
     if (vm.count("test-lut-xml-access")) {
+      std::cout << "Broken without topology...\n";
+      /*
       std::cout << "Testing reading LUTs from local XML file..." << "\n";
       std::string in_ = vm["input-file"].as<std::string>();
       std::cout << "LUT XML file: " << in_ << "\n";
@@ -232,10 +241,13 @@ int main( int argc, char **argv )
       std::cout << "Tag: " << tag_ << "\n";
       HcalLutManager manager;
       manager . test_xml_access( tag_, in_ );
+      */
       return 0;
     }
     
     if (vm.count("test-lut-checksum")) {
+      std::cout << "Broken without topology...\n";
+      /*
       std::cout << "Testing evaluation of LUT MD5 checksums..." << "\n";
       std::string in_ = vm["input-file"].as<std::string>();
       std::cout << "LUT XML file: " << in_ << "\n";
@@ -243,6 +255,7 @@ int main( int argc, char **argv )
       std::cout << "Tag: " << tag_ << "\n";
       HcalLutManager manager;
       manager . test_xml_access( tag_, in_ );
+      */
       return 0;
     }
     
@@ -277,6 +290,8 @@ int main( int argc, char **argv )
     
     if (vm.count("create-lin-lut-xml")) {
       while(1){
+	std::cout << "Broken without topology...\n";
+	/*
 	cout << "Creating XML with LUTs for all channels..." << "\n";
 	//int _cr = vm["crate"].as<int>();
 	string lin_master_file, comp_master_file;
@@ -294,6 +309,7 @@ int main( int argc, char **argv )
 	string _tag = vm["tag-name"].as<std::string>();
 	HcalLutManager manager;
 	manager . createLinLutXmlFiles( _tag, lin_master_file, !vm.count("do-not-split-by-crate") );
+	*/
 	break;
       }
       return 0;
@@ -301,6 +317,8 @@ int main( int argc, char **argv )
 
     if (vm.count("create-lut-xml")) {
       while(1){
+	std::cout << "Broken without topology...\n";
+	/*
 	cout << "Creating XML with LUTs for all channels..." << "\n";
 	//int _cr = vm["crate"].as<int>();
 	string lin_master_file, comp_master_file;
@@ -330,12 +348,15 @@ int main( int argc, char **argv )
 	else{
 	  manager . createLinLutXmlFiles( _tag, lin_master_file, !vm.count("do-not-split-by-crate") );
 	}
+	*/
 	break;
       }
       return 0;
     }
 
     if (vm.count("create-lut-xml-from-coder")) {
+      std::cout << "Broken without topology...\n";
+      /*
       std::cout << "Creating XML with LUTs for all channels from TPG coder..." << "\n";
       if (!vm.count("tag-name")){
 	cout << "tag name is not specified...exiting" << std::endl;
@@ -344,6 +365,7 @@ int main( int argc, char **argv )
       std::string _tag = vm["tag-name"].as<std::string>();
       HcalLutManager manager;
       manager . createCompLutXmlFilesFromCoder( _tag, !vm.count("do-not-split-by-crate") );
+      */
       return 0;
     }
     
@@ -351,6 +373,8 @@ int main( int argc, char **argv )
 
     if (vm.count("create-lut-xml-lin-ascii-comp-coder")) {
       while(1){
+      std::cout << "Broken without topology...\n";
+      /*
 	cout << "Creating XML with LUTs for all channels..." << "\n";
 	//int _cr = vm["crate"].as<int>();
 	string lin_master_file, comp_master_file;
@@ -368,6 +392,7 @@ int main( int argc, char **argv )
 	string _tag = vm["tag-name"].as<std::string>();
 	HcalLutManager manager;
 	manager . createAllLutXmlFilesLinAsciiCompCoder( _tag, lin_master_file, !vm.count("do-not-split-by-crate") );
+      */
 	break;
       }
       return 0;
@@ -394,6 +419,8 @@ int main( int argc, char **argv )
     }
     
     if (vm.count("get-lut-xml-from-oracle")) {
+      std::cout << "Broken without topology...\n";
+      /*
       std::cout << "Getting LUTs from Oracle database..." << "\n";
       if (!vm.count("tag-name")){
 	cout << "tag name is not specified...exiting" << std::endl;
@@ -406,11 +433,14 @@ int main( int argc, char **argv )
       std::cout << "Accessing the database as " << _accessor << std::endl;
       std::cout << "Tag name: " << _tag << std::endl;
       manager . get_xml_files_from_db( _tag, _accessor, !vm.count("do-not-split-by-crate") );
+      */
       return 0;
     }
 
 
     if (vm.count("create-lut-loader")){
+      std::cout << "Broken without topology...\n";
+      /*
       std::cout << "===> Processing LUT XML files, creating the database loader..." << "\n";
       std::cout << "prefix: ";
       std::string _prefix = vm["prefix-name"].as<std::string>();
@@ -430,6 +460,7 @@ int main( int argc, char **argv )
       std::string _file_list = vm["file-list"].as<std::string>();
       HcalLutManager manager;
       manager . create_lut_loader( _file_list, _prefix, _tag, _comment, _version, _subversion );
+*/
       return 0;
     }
 
@@ -1612,6 +1643,8 @@ std::vector <std::string> splitString (const std::string& fLine) {
 
 void test_lut_gen( void )
 {
+      std::cout << "Broken without topology...\n";
+      /*
   HcalLutManager _manager;
   std::vector<unsigned int> _l;
   _l.push_back(0);
@@ -1620,4 +1653,5 @@ void test_lut_gen( void )
   _l.push_back(1);
   _l.push_back(2);
   std::cout << _manager . getLutXml( _l );
+      */
 }

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,11 +10,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   'MCPA1_73_V0::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V0::All',
+    'run2_design'       :   'DESRUN2_73_V1::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V0::All',
+    'run2_mc_50ns'      :   'MCRUN2_73_V2::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V1::All',
+    'run2_mc'           :   'MCRUN2_73_V3::All',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A::All',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,23 +2,23 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_72_V0::All',
+    'run1_design'       :   'DESRUN1_73_V0::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_72_V0::All',
+    'run1_mc'           :   'MCRUN1_73_V0::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_72_V0::All',
+    'run1_mc_hi'        :   'MCHI1_73_V0::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_72_V0::All',
+    'run1_mc_pa'        :   'MCPA1_73_V0::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_72_V0::All',
+    'run2_design'       :   'DESRUN2_73_V0::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_72_V0::All',
+    'run2_mc_50ns'      :   'MCRUN2_73_V0::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_72_V1::All',
+    'run2_mc'           :   'MCRUN2_73_V1::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V12A::All',
+    'run1_data'         :   'GR_R_73_V0A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V13A::All',
+    'run2_data'         :   'GR_R_73_V1A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run1_hlt'          :   'GR_H_V43A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,19 +2,19 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V0::All',
+    'run1_design'       :   'DESRUN1_73_V1::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V0::All',
+    'run1_mc'           :   'MCRUN1_73_V1::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V0::All',
+    'run1_mc_hi'        :   'MCHI1_73_V1::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V0::All',
+    'run1_mc_pa'        :   'MCPA1_73_V1::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V1::All',
+    'run2_design'       :   'DESRUN2_73_V2::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V2::All',
+    'run2_mc_50ns'      :   'MCRUN2_73_V4::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V3::All',
+    'run2_mc'           :   'MCRUN2_73_V5::All',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A::All',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,23 +2,23 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_72_V0',
+    'run1_design'       :   'DESRUN1_73_V0',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_72_V0',
+    'run1_mc'           :   'MCRUN1_73_V0',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_72_V0',
+    'run1_mc_hi'        :   'MCHI1_73_V0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_72_V0',
+    'run1_mc_pa'        :   'MCPA1_73_V0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_72_V0',
+    'run2_design'       :   'DESRUN2_73_V0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_72_V0',
+    'run2_mc_50ns'      :   'MCRUN2_73_V0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_72_V1',
+    'run2_mc'           :   'MCRUN2_73_V1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_72_V12A',
+    'run1_data'         :   'GR_R_73_V0A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_72_V13A',
+    'run2_data'         :   'GR_R_73_V1A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run1_hlt'          :   'GR_H_V43A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -10,11 +10,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   'MCPA1_73_V0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V0',
+    'run2_design'       :   'DESRUN2_73_V1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V0',
+    'run2_mc_50ns'      :   'MCRUN2_73_V2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V1',
+    'run2_mc'           :   'MCRUN2_73_V3',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,19 +2,19 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V0',
+    'run1_design'       :   'DESRUN1_73_V1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V0',
+    'run1_mc'           :   'MCRUN1_73_V1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V0',
+    'run1_mc_hi'        :   'MCHI1_73_V1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V0',
+    'run1_mc_pa'        :   'MCPA1_73_V1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V1',
+    'run2_design'       :   'DESRUN2_73_V2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V2',
+    'run2_mc_50ns'      :   'MCRUN2_73_V4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V3',
+    'run2_mc'           :   'MCRUN2_73_V5',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A',
     # GlobalTag for Run2 data reprocessing

--- a/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
@@ -23,11 +23,16 @@ public:
   /** \brief Constructor from signed ieta, iphi, depth
   */
   HcalTrigTowerDetId(int ieta, int iphi, int depth);
+  /** \brief Constructor from signed ieta, iphi, depth, version
+  */
+  HcalTrigTowerDetId(int ieta, int iphi, int depth, int version);
 
   /** Constructor from a generic cell id */
   HcalTrigTowerDetId(const DetId& id);
   /** Assignment from a generic cell id */
   HcalTrigTowerDetId& operator=(const DetId& id);
+
+  void setVersion(int version);
 
   /// get the subdetector
   HcalSubdetector subdet() const { return (HcalSubdetector)(subdetId()); }
@@ -39,8 +44,10 @@ public:
   int ieta() const { return zside()*ietaAbs(); }
   /// get the tower iphi
   int iphi() const { return id_&0x7F; }
-  /// get the depth (zero for LHC, may be nonzero for SuperCMS)
+  /// get the depth (zero for LHC Run 1, may be nonzero for later runs)
   int depth() const { return (id_>>14)&0x7; }
+  /// get the version code for the trigger tower
+  int version() const { return (id_>>17)&0x7; }
 
   static const HcalTrigTowerDetId Undefined;
 

--- a/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
@@ -23,6 +23,9 @@ public:
   /** \brief Constructor from signed ieta, iphi, depth
   */
   HcalTrigTowerDetId(int ieta, int iphi, int depth);
+  /** \brief Constructor from signed ieta, iphi, depth, version
+  */
+  HcalTrigTowerDetId(int ieta, int iphi, int depth, int version);
 
   /** Constructor from a generic cell id */
   HcalTrigTowerDetId(const DetId& id);

--- a/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
@@ -29,6 +29,8 @@ public:
   /** Assignment from a generic cell id */
   HcalTrigTowerDetId& operator=(const DetId& id);
 
+  void setVersion(int version);
+
   /// get the subdetector
   HcalSubdetector subdet() const { return (HcalSubdetector)(subdetId()); }
   /// get the z-side of the tower (1/-1)
@@ -39,8 +41,10 @@ public:
   int ieta() const { return zside()*ietaAbs(); }
   /// get the tower iphi
   int iphi() const { return id_&0x7F; }
-  /// get the depth (zero for LHC, may be nonzero for SuperCMS)
+  /// get the depth (zero for LHC Run 1, may be nonzero for later runs)
   int depth() const { return (id_>>14)&0x7; }
+  /// get the version code for the trigger tower
+  int version() const { return (id_>>17)&0x7; }
 
   static const HcalTrigTowerDetId Undefined;
 

--- a/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
@@ -28,6 +28,10 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(const DetId& gen) {
   id_=gen.rawId();
 }
 
+void HcalTrigTowerDetId::setVersion(int version) {
+  id_|=((version&0x7)<<17);
+}
+
 HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
   if (!gen.null() && (gen.det()!=Hcal || gen.subdetId()!=HcalTriggerTower)) {
     throw cms::Exception("Invalid DetId") << "Cannot assign HcalTrigTowerDetId from " << std::hex << gen.rawId() << std::dec; 
@@ -37,7 +41,7 @@ HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
 }
 
 std::ostream& operator<<(std::ostream& s,const HcalTrigTowerDetId& id) {
-  s << "(HcalTrigTower " << id.ieta() << ',' << id.iphi();
+  s << "(HcalTrigTower v" << id.version() << ": " << id.ieta() << ',' << id.iphi();
   if (id.depth()>0) s << ',' << id.depth();
   
   return s << ')';

--- a/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
@@ -21,11 +21,22 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth) : DetId(Hc
     (iphi&0x7F);
 }
 
+HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth, int version) : DetId(Hcal,HcalTriggerTower) {
+  id_|=((depth&0x7)<<14) |
+    ((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
+    (iphi&0x7F);
+  id_|=((version&0x7)<<17);
+}
+
 HcalTrigTowerDetId::HcalTrigTowerDetId(const DetId& gen) {
   if (!gen.null() && (gen.det()!=Hcal || gen.subdetId()!=HcalTriggerTower)) {
     throw cms::Exception("Invalid DetId") << "Cannot initialize HcalTrigTowerDetId from " << std::hex << gen.rawId() << std::dec; 
   }
   id_=gen.rawId();
+}
+
+void HcalTrigTowerDetId::setVersion(int version) {
+  id_|=((version&0x7)<<17);
 }
 
 HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
@@ -37,7 +48,7 @@ HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
 }
 
 std::ostream& operator<<(std::ostream& s,const HcalTrigTowerDetId& id) {
-  s << "(HcalTrigTower " << id.ieta() << ',' << id.iphi();
+  s << "(HcalTrigTower v" << id.version() << ": " << id.ieta() << ',' << id.iphi();
   if (id.depth()>0) s << ',' << id.depth();
   
   return s << ')';

--- a/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
@@ -21,6 +21,13 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth) : DetId(Hc
     (iphi&0x7F);
 }
 
+HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth, int version) : DetId(Hcal,HcalTriggerTower) {
+  id_|=((depth&0x7)<<14) |
+    ((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
+    (iphi&0x7F);
+  id_|=((version&0x7)<<17);
+}
+
 HcalTrigTowerDetId::HcalTrigTowerDetId(const DetId& gen) {
   if (!gen.null() && (gen.det()!=Hcal || gen.subdetId()!=HcalTriggerTower)) {
     throw cms::Exception("Invalid DetId") << "Cannot initialize HcalTrigTowerDetId from " << std::hex << gen.rawId() << std::dec; 

--- a/EventFilter/HcalRawToDigi/interface/HcalHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalHTRData.h
@@ -100,7 +100,8 @@ class HcalHTRData {
 	    do_capid=false);
   /** \brief pack header and trailer (call _after_ pack)*/
   void packHeaderTrailer(int L1Anumber, int bcn, int submodule, int
-			 orbitn, int pipeline, int ndd, int nps, int firmwareRev=0);
+			 orbitn, int pipeline, int ndd, int nps, int firmwareRev=0,
+			 int firmwareFlav=0);
 
   /** \brief pack trailer with Mark and Pass bits */
   void packUnsuppressed(const bool* mp);

--- a/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
@@ -235,7 +235,7 @@ void HcalHTRData::pack(unsigned char* daq_lengths, unsigned short* daq_samples,
   unsigned short* ptr=m_ownData+headerLen;
   if (tp_samples!=0 && tp_lengths!=0) {
     for (ichan=0; ichan<24; ichan++) {
-      unsigned short chanid=((ichan%3)+((ichan/3)<<2))<<11;
+      unsigned short chanid=((ichan%4)+(((ichan/4)+1)<<2))<<11;
       for (isample=0; isample<tp_lengths[ichan] && isample<MAXIMUM_SAMPLES_PER_CHANNEL; isample++) {
 	ptr[tp_words_total]=chanid|(tp_samples[ichan*MAXIMUM_SAMPLES_PER_CHANNEL+isample]&0x3FF);
 	tp_words_total++;
@@ -280,7 +280,7 @@ void HcalHTRData::pack(unsigned char* daq_lengths, unsigned short* daq_samples,
 
 }
 
-void HcalHTRData::packHeaderTrailer(int L1Anumber, int bcn, int submodule, int orbitn, int pipeline, int ndd, int nps, int firmwareRev) {
+void HcalHTRData::packHeaderTrailer(int L1Anumber, int bcn, int submodule, int orbitn, int pipeline, int ndd, int nps, int firmwareRev, int firmwareFlav) {
   m_ownData[0]=L1Anumber&0xFF;
   m_ownData[1]=(L1Anumber&0xFFFF00)>>8;
   if (m_formatVersion==-1) {
@@ -297,7 +297,7 @@ void HcalHTRData::packHeaderTrailer(int L1Anumber, int bcn, int submodule, int o
     m_ownData[4]=((m_formatVersion&0xF)<<12)|(bcn&0xFFF);
     m_ownData[5]|=((nps&0x1F)<<3)|0x1;
     m_ownData[6]=((firmwareRev&0x70000)>>3)|(firmwareRev&0x1FFF);
-    m_ownData[7]=pipeline&0xFF;
+    m_ownData[7]=(pipeline&0xFF)|((firmwareFlav&0x3F)<<8);
     m_ownData[m_rawLength-4]&=0x7FF;
     m_ownData[m_rawLength-4]|=(ndd&0x1F)<<11;
   }

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -38,9 +38,9 @@ static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const Hca
   HcalTrigPrimDigiCollection::const_iterator i=pt->find(tid);
   if (i!=pt->end()) {
     int presamples=i->presamples();
-    int samples=i->size();
+    size=i->size();
 
-    for (int j=0; j<samples; j++) {
+    for (int j=0; j<size; j++) {
        buffer[j]=(*i)[j].raw();
        if (j==presamples) buffer[j]|=0x0200;
     }

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -180,7 +180,8 @@ void HcalPacker::pack(int fedid, int dccnumber,
 					pipeline,
 					samples,
 					presamples,
-					firmwareRev);
+					firmwareRev,
+					1);  // need non-zero falvor
       if (haveUnsuppressed) {
 	spigots[spigot].packUnsuppressed(channelIsMP);
       }

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -156,11 +156,18 @@ void HcalPacker::pack(int fedid, int dccnumber,
           
 	// finally, what about a trigger channel?
 	if (!tid.null()) {
+      if (presamples < 0) {
+        exampleEId = fullEid;
+      }
 	  unsigned short* trigbase=&(trigdata[linear*HcalHTRData::MAXIMUM_SAMPLES_PER_CHANNEL]);
 	  triglen[linear]=processTrig(inputs.tpCont,tid,trigbase);
+      if (triglen[linear]) {
+        npresent++;
+      }
 	  
 	  for (unsigned char q=0; q<triglen[linear]; q++)
 	    trigbase[q]=(trigbase[q]&0x7FF)|chanid;
+
 	}
       }
     /// pack into HcalHTRData
@@ -173,6 +180,14 @@ void HcalPacker::pack(int fedid, int dccnumber,
       int submodule=exampleEId.htrTopBottom()&0x1;
       submodule|=(exampleEId.htrSlot()&0x1F)<<1;
       submodule|=(exampleEId.readoutVMECrateId()&0x1f)<<6;
+      // Samples and Presamples can't be negative, or the HeaderTrailer will
+      // generate a large large number using them (unsigned int roll over)
+      if (samples < 0) {
+        samples = 0;
+      }
+      if (presamples < 0) {
+        presamples = 0;
+      }
       spigots[spigot].packHeaderTrailer(nl1a,
 					bcn,
 					submodule,

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -18,7 +18,7 @@ HcalPacker::Collections::Collections() {
 template <class Coll, class DetIdClass> 
 int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presamples,bool& isUS, bool& isMP) {
   isUS=false; isMP=false;
-  if (pt==0) return 0;
+  if (pt==0) { return 0; }
   int size=0;
   typename Coll::const_iterator i=pt->find(DetIdClass(did));
   if (i!=pt->end()) {
@@ -26,23 +26,24 @@ int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presa
     isMP=i->zsMarkAndPass();
     presamples=i->presamples();
     size=i->size();
-    for (int j=0; j<size; j++) 
+    for (int j=0; j<size; j++) {
       buffer[j]=(*i)[j].raw();
+    }
   }
   return size;
 }
 
 static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const HcalTrigTowerDetId& tid, unsigned short* buffer) {
-  if (pt==0) return 0;
+  if (pt==0) { return 0; }
   int size=0;
   HcalTrigPrimDigiCollection::const_iterator i=pt->find(tid);
   if (i!=pt->end()) {
     int presamples=i->presamples();
-    int samples=i->size();
+    size=i->size();
 
-    for (int j=0; j<samples; j++) {
+    for (int j=0; j<size; j++) {
        buffer[j]=(*i)[j].raw();
-       if (j==presamples) buffer[j]|=0x0200;
+       if (j==presamples) { buffer[j]|=0x0200; }
     }
   }
   return size;
@@ -50,7 +51,7 @@ static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const Hca
 
 int HcalPacker::findSamples(const DetId& did, const Collections& inputs,
 			    unsigned short* buffer, int &presamples, bool& isUS, bool& isMP) {
-  if (!(did.det()==DetId::Hcal || (did.det()== DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId)) ) return 0;
+  if (!(did.det()==DetId::Hcal || (did.det()== DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId)) ) { return 0; }
   int size=0;
   HcalGenericDetId genId(did);
   
@@ -96,7 +97,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
     int npresent=0;
     int presamples=-1, samples=-1;
     bool haveUnsuppressed=false;
-    for (int fiber=1; fiber<=8; fiber++) 
+    for (int fiber=1; fiber<=8; fiber++) {
       for (int fiberchan=0; fiberchan<3; fiberchan++) {
 	int linear=(fiber-1)*3+fiberchan;
 	HcalQIESample chanSample(0,0,fiber,fiberchan,false,false);
@@ -120,7 +121,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
 	channelIsMP[linear]=isMP;
 
 	if (mysamples>0) {
-	  if (samples<0) samples=mysamples;
+	  if (samples<0) { samples=mysamples; }
 	  else if (samples!=mysamples) {
 	    edm::LogError("HCAL") << "Mismatch of samples in a single HTR (unsupported) " << mysamples << " != " << samples;
 	    continue;
@@ -132,13 +133,15 @@ void HcalPacker::pack(int fedid, int dccnumber,
 	    edm::LogError("HCAL") << "Mismatch of presamples in a single HTR (unsupported) " << mypresamples << " != " << presamples;
 	    continue;	    
 	  }
-	  for (int ii=0; ii<samples; ii++)
+	  for (int ii=0; ii<samples; ii++) {
 	    database[ii]=(database[ii]&0x7FF)|chanid;
+      }
 	  preclen[linear]=(unsigned char)(samples);
 	  npresent++;
 	}	
       }
-    for (int slb=1; slb<=6; slb++) 
+    }
+    for (int slb=1; slb<=6; slb++) {
       for (int slbchan=0; slbchan<=3; slbchan++) {
 	int linear=(slb-1)*4+slbchan;
 	HcalTriggerPrimitiveSample idCvt(0,0,slb,slbchan);
@@ -156,13 +159,22 @@ void HcalPacker::pack(int fedid, int dccnumber,
           
 	// finally, what about a trigger channel?
 	if (!tid.null()) {
+      if (presamples < 0) {
+        exampleEId = fullEid;
+      }
 	  unsigned short* trigbase=&(trigdata[linear*HcalHTRData::MAXIMUM_SAMPLES_PER_CHANNEL]);
 	  triglen[linear]=processTrig(inputs.tpCont,tid,trigbase);
+      if (triglen[linear]) {
+        npresent++;
+      }
 	  
-	  for (unsigned char q=0; q<triglen[linear]; q++)
+	  for (unsigned char q=0; q<triglen[linear]; q++) {
 	    trigbase[q]=(trigbase[q]&0x7FF)|chanid;
+      }
+
 	}
       }
+    }
     /// pack into HcalHTRData
     if (npresent>0) {
       spigots[spigot].pack(&(preclen[0]),&(precdata[0]),
@@ -173,6 +185,14 @@ void HcalPacker::pack(int fedid, int dccnumber,
       int submodule=exampleEId.htrTopBottom()&0x1;
       submodule|=(exampleEId.htrSlot()&0x1F)<<1;
       submodule|=(exampleEId.readoutVMECrateId()&0x1f)<<6;
+      // Samples and Presamples can't be negative, or the HeaderTrailer will
+      // generate a large large number using them (unsigned int roll over)
+      if (samples < 0) {
+        samples = 0;
+      }
+      if (presamples < 0) {
+        presamples = 0;
+      }
       spigots[spigot].packHeaderTrailer(nl1a,
 					bcn,
 					submodule,
@@ -180,7 +200,8 @@ void HcalPacker::pack(int fedid, int dccnumber,
 					pipeline,
 					samples,
 					presamples,
-					firmwareRev);
+					firmwareRev,
+					1);  // need non-zero falvor
       if (haveUnsuppressed) {
 	spigots[spigot].packUnsuppressed(channelIsMP);
       }

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -18,7 +18,7 @@ HcalPacker::Collections::Collections() {
 template <class Coll, class DetIdClass> 
 int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presamples,bool& isUS, bool& isMP) {
   isUS=false; isMP=false;
-  if (pt==0) return 0;
+  if (pt==0) { return 0; }
   int size=0;
   typename Coll::const_iterator i=pt->find(DetIdClass(did));
   if (i!=pt->end()) {
@@ -26,14 +26,15 @@ int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presa
     isMP=i->zsMarkAndPass();
     presamples=i->presamples();
     size=i->size();
-    for (int j=0; j<size; j++) 
+    for (int j=0; j<size; j++) {
       buffer[j]=(*i)[j].raw();
+    }
   }
   return size;
 }
 
 static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const HcalTrigTowerDetId& tid, unsigned short* buffer) {
-  if (pt==0) return 0;
+  if (pt==0) { return 0; }
   int size=0;
   HcalTrigPrimDigiCollection::const_iterator i=pt->find(tid);
   if (i!=pt->end()) {
@@ -42,7 +43,7 @@ static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const Hca
 
     for (int j=0; j<size; j++) {
        buffer[j]=(*i)[j].raw();
-       if (j==presamples) buffer[j]|=0x0200;
+       if (j==presamples) { buffer[j]|=0x0200; }
     }
   }
   return size;
@@ -50,7 +51,7 @@ static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const Hca
 
 int HcalPacker::findSamples(const DetId& did, const Collections& inputs,
 			    unsigned short* buffer, int &presamples, bool& isUS, bool& isMP) {
-  if (!(did.det()==DetId::Hcal || (did.det()== DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId)) ) return 0;
+  if (!(did.det()==DetId::Hcal || (did.det()== DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId)) ) { return 0; }
   int size=0;
   HcalGenericDetId genId(did);
   
@@ -96,7 +97,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
     int npresent=0;
     int presamples=-1, samples=-1;
     bool haveUnsuppressed=false;
-    for (int fiber=1; fiber<=8; fiber++) 
+    for (int fiber=1; fiber<=8; fiber++) {
       for (int fiberchan=0; fiberchan<3; fiberchan++) {
 	int linear=(fiber-1)*3+fiberchan;
 	HcalQIESample chanSample(0,0,fiber,fiberchan,false,false);
@@ -120,7 +121,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
 	channelIsMP[linear]=isMP;
 
 	if (mysamples>0) {
-	  if (samples<0) samples=mysamples;
+	  if (samples<0) { samples=mysamples; }
 	  else if (samples!=mysamples) {
 	    edm::LogError("HCAL") << "Mismatch of samples in a single HTR (unsupported) " << mysamples << " != " << samples;
 	    continue;
@@ -132,13 +133,15 @@ void HcalPacker::pack(int fedid, int dccnumber,
 	    edm::LogError("HCAL") << "Mismatch of presamples in a single HTR (unsupported) " << mypresamples << " != " << presamples;
 	    continue;	    
 	  }
-	  for (int ii=0; ii<samples; ii++)
+	  for (int ii=0; ii<samples; ii++) {
 	    database[ii]=(database[ii]&0x7FF)|chanid;
+      }
 	  preclen[linear]=(unsigned char)(samples);
 	  npresent++;
 	}	
       }
-    for (int slb=1; slb<=6; slb++) 
+    }
+    for (int slb=1; slb<=6; slb++) {
       for (int slbchan=0; slbchan<=3; slbchan++) {
 	int linear=(slb-1)*4+slbchan;
 	HcalTriggerPrimitiveSample idCvt(0,0,slb,slbchan);
@@ -165,11 +168,13 @@ void HcalPacker::pack(int fedid, int dccnumber,
         npresent++;
       }
 	  
-	  for (unsigned char q=0; q<triglen[linear]; q++)
+	  for (unsigned char q=0; q<triglen[linear]; q++) {
 	    trigbase[q]=(trigbase[q]&0x7FF)|chanid;
+      }
 
 	}
       }
+    }
     /// pack into HcalHTRData
     if (npresent>0) {
       spigots[spigot].pack(&(preclen[0]),&(precdata[0]),

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloTopology/interface/HcalTopologyMode.h"
 
@@ -25,7 +26,7 @@
 class HcalTopology : public CaloSubdetectorTopology {
 public:
 
-  HcalTopology( HcalTopologyMode::Mode mode, int maxDepthHB, int maxDepthHE, HcalTopologyMode::TriggerMode tmode=HcalTopologyMode::tm_LHC_PreLS1);
+  HcalTopology( HcalTopologyMode::Mode mode, int maxDepthHB, int maxDepthHE, HcalTopologyMode::TriggerMode tmode=HcalTopologyMode::tm_LHC_RCT_and_1x1);
 	
   HcalTopologyMode::Mode mode() const {return mode_;}
   HcalTopologyMode::TriggerMode triggerMode() const { return triggerMode_; }
@@ -50,6 +51,8 @@ public:
   virtual bool valid(const DetId& id) const;
   /** Is this a valid cell id? */
   bool validHcal(const HcalDetId& id) const;
+  /** Is this a valid hcal trigger cell id? */
+  bool validHT(const HcalTrigTowerDetId& id) const;
   /** Get the neighbors of the given cell in east direction*/
   virtual std::vector<DetId> east(const DetId& id) const;
   /** Get the neighbors of the given cell in west direction*/
@@ -140,9 +143,9 @@ private:
   int decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const;
 
   /** Is this a valid cell id, ignoring the exclusion list */
-  bool validDetIdPreLS1(const HcalDetId& id) const;
+  bool validDetIdPhase0(const HcalDetId& id) const;
   bool validRaw(const HcalDetId& id) const;
-  unsigned int detId2denseIdPreLS1 (const DetId& id) const;
+  unsigned int detId2denseIdPhase0 (const DetId& id) const;
 
   std::vector<HcalDetId> exclusionList_;
   bool excludeHB_, excludeHE_, excludeHO_, excludeHF_;
@@ -185,19 +188,22 @@ private:
   enum { kHBhalf = 1296 ,
 	 kHEhalf = 1296 ,
 	 kHOhalf = 1080 ,
-	 kHFhalf = 864  ,
-	 kHThalf = 2088,
+	 kHFhalfPhase0 = 864,
+	 kHFhalfPhase1 = 1728,
+	 kHThalfPhase0 = 28*72+4*18,
+	 kHThalfPhase1 = kHThalfPhase0+2*72+12*36,
 	 kZDChalf = 11,
 	 kCASTORhalf = 224,
 	 kCALIBhalf = 693,
-	 kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf } ;
-  enum { kSizeForDenseIndexingPreLS1 = 2*kHcalhalf } ;
-  enum { kHBSizePreLS1 = 2*kHBhalf } ;
-  enum { kHESizePreLS1 = 2*kHEhalf } ;
-  enum { kHOSizePreLS1 = 2*kHOhalf } ;
-  enum { kHFSizePreLS1 = 2*kHFhalf } ;
-  enum { kHTSizePreLS1 = 2*kHThalf };
-  enum { kCALIBSizePreLS1 = 2*kCALIBhalf };
+	 kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalfPhase0 } ;
+  enum { kSizeForDenseIndexingPhase0 = 2*kHcalhalf } ;
+  enum { kHBSizePhase0 = 2*kHBhalf } ;
+  enum { kHESizePhase0 = 2*kHEhalf } ;
+  enum { kHOSizePhase0 = 2*kHOhalf } ;
+  enum { kHFSizePhase0 = 2*kHFhalfPhase0 } ;
+  enum { kHTSizePhase0 = 2*kHThalfPhase0 };
+  enum { kHTSizePhase1 = 2*kHThalfPhase1 };
+  enum { kCALIBSizePhase0 = 2*kCALIBhalf };
 };
 
 

--- a/Geometry/CaloTopology/interface/HcalTopology.h
+++ b/Geometry/CaloTopology/interface/HcalTopology.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <map>
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h"
 #include "Geometry/CaloTopology/interface/CaloSubdetectorTopology.h"
 #include "Geometry/CaloTopology/interface/HcalTopologyMode.h"
 
@@ -25,7 +26,7 @@
 class HcalTopology : public CaloSubdetectorTopology {
 public:
 
-  HcalTopology( HcalTopologyMode::Mode mode, int maxDepthHB, int maxDepthHE, HcalTopologyMode::TriggerMode tmode=HcalTopologyMode::tm_LHC_PreLS1);
+  HcalTopology( HcalTopologyMode::Mode mode, int maxDepthHB, int maxDepthHE, HcalTopologyMode::TriggerMode tmode=HcalTopologyMode::tm_LHC_RCT_and_1x1);
 	
   HcalTopologyMode::Mode mode() const {return mode_;}
   HcalTopologyMode::TriggerMode triggerMode() const { return triggerMode_; }
@@ -50,6 +51,8 @@ public:
   virtual bool valid(const DetId& id) const;
   /** Is this a valid cell id? */
   bool validHcal(const HcalDetId& id) const;
+  /** Is this a valid hcal trigger cell id? */
+  bool validHT(const HcalTrigTowerDetId& id) const;
   /** Get the neighbors of the given cell in east direction*/
   virtual std::vector<DetId> east(const DetId& id) const;
   /** Get the neighbors of the given cell in west direction*/
@@ -138,9 +141,9 @@ private:
   int decAIEta(const HcalDetId& id, HcalDetId neighbors[2]) const;
 
   /** Is this a valid cell id, ignoring the exclusion list */
-  bool validDetIdPreLS1(const HcalDetId& id) const;
+  bool validDetIdPhase0(const HcalDetId& id) const;
   bool validRaw(const HcalDetId& id) const;
-  unsigned int detId2denseIdPreLS1 (const DetId& id) const;
+  unsigned int detId2denseIdPhase0 (const DetId& id) const;
 
   std::vector<HcalDetId> exclusionList_;
   bool excludeHB_, excludeHE_, excludeHO_, excludeHF_;
@@ -183,19 +186,22 @@ private:
   enum { kHBhalf = 1296 ,
 	 kHEhalf = 1296 ,
 	 kHOhalf = 1080 ,
-	 kHFhalf = 864  ,
-	 kHThalf = 2088,
+	 kHFhalfPhase0 = 864,
+	 kHFhalfPhase1 = 1728,
+	 kHThalfPhase0 = 28*72+4*18,
+	 kHThalfPhase1 = kHThalfPhase0+2*72+12*36,
 	 kZDChalf = 11,
 	 kCASTORhalf = 224,
 	 kCALIBhalf = 693,
-	 kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalf } ;
-  enum { kSizeForDenseIndexingPreLS1 = 2*kHcalhalf } ;
-  enum { kHBSizePreLS1 = 2*kHBhalf } ;
-  enum { kHESizePreLS1 = 2*kHEhalf } ;
-  enum { kHOSizePreLS1 = 2*kHOhalf } ;
-  enum { kHFSizePreLS1 = 2*kHFhalf } ;
-  enum { kHTSizePreLS1 = 2*kHThalf };
-  enum { kCALIBSizePreLS1 = 2*kCALIBhalf };
+	 kHcalhalf = kHBhalf + kHEhalf + kHOhalf + kHFhalfPhase0 } ;
+  enum { kSizeForDenseIndexingPhase0 = 2*kHcalhalf } ;
+  enum { kHBSizePhase0 = 2*kHBhalf } ;
+  enum { kHESizePhase0 = 2*kHEhalf } ;
+  enum { kHOSizePhase0 = 2*kHOhalf } ;
+  enum { kHFSizePhase0 = 2*kHFhalfPhase0 } ;
+  enum { kHTSizePhase0 = 2*kHThalfPhase0 };
+  enum { kHTSizePhase1 = 2*kHThalfPhase1 };
+  enum { kCALIBSizePhase0 = 2*kCALIBhalf };
 };
 
 

--- a/Geometry/CaloTopology/interface/HcalTopologyMode.h
+++ b/Geometry/CaloTopology/interface/HcalTopologyMode.h
@@ -30,7 +30,9 @@ namespace HcalTopologyMode {
 	LHC=0, H2=1, SLHC=2, H2HE=3 };
 
     enum TriggerMode {
-      tm_LHC_PreLS1=0  // HF is summed in 3x2 regions
+      tm_LHC_RCT=0, // HF is summed in 3x2 regions
+      tm_LHC_RCT_and_1x1=1, // HF is summed in both 3x2 and 1x1 regions (simultaneously)
+      tm_LHC_1x1=2  // HF is summed in 1x1 regions
     };
 }
 

--- a/Geometry/CaloTopology/interface/HcalTopologyMode.h
+++ b/Geometry/CaloTopology/interface/HcalTopologyMode.h
@@ -30,8 +30,8 @@ namespace HcalTopologyMode {
 	LHC=0, H2=1, SLHC=2, H2HE=3 };
 
     enum TriggerMode {
-      tm_LHC_PreLS1=0, // HF is summed in 3x2 regions
-      tm_LHC_PreLS1_and_1x1=1, // HF is summed in both 3x2 and 1x1 regions (simultaneously)
+      tm_LHC_RCT=0, // HF is summed in 3x2 regions
+      tm_LHC_RCT_and_1x1=1, // HF is summed in both 3x2 and 1x1 regions (simultaneously)
       tm_LHC_1x1=2  // HF is summed in 1x1 regions
     };
 }

--- a/Geometry/CaloTopology/interface/HcalTopologyMode.h
+++ b/Geometry/CaloTopology/interface/HcalTopologyMode.h
@@ -30,7 +30,9 @@ namespace HcalTopologyMode {
 	LHC=0, H2=1, SLHC=2, H2HE=3 };
 
     enum TriggerMode {
-      tm_LHC_PreLS1=0  // HF is summed in 3x2 regions
+      tm_LHC_PreLS1=0, // HF is summed in 3x2 regions
+      tm_LHC_PreLS1_and_1x1=1, // HF is summed in both 3x2 and 1x1 regions (simultaneously)
+      tm_LHC_1x1=2  // HF is summed in 1x1 regions
     };
 }
 

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -82,6 +82,7 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
     if (triggerMode_==HcalTopologyMode::tm_LHC_RCT) return false;
     if (id.ietaAbs()<28 || id.ietaAbs()>41) return false;
     if (id.ietaAbs()>29 && ((id.iphi()%2)==0)) return false;
+    if (id.ietaAbs()>39 && ((id.iphi()%4)!=3)) return false;
   }
   return true;
 

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -32,18 +32,18 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode, int maxDepthHB, int maxD
   doublePhiBins_(36),
   maxDepthHB_(maxDepthHB),
   maxDepthHE_(maxDepthHE),
-  HBSize_(kHBSizePreLS1),
-  HESize_(kHESizePreLS1),
-  HOSize_(kHOSizePreLS1),
-  HFSize_(kHFSizePreLS1),
+  HBSize_(kHBSizePhase0),
+  HESize_(kHESizePhase0),
+  HOSize_(kHOSizePhase0),
+  HFSize_(kHFSizePhase0),
   numberOfShapes_(( mode==HcalTopologyMode::SLHC ) ? 500 : 87 ) {
 
   if (mode_==HcalTopologyMode::LHC) {
     topoVersion_=0; //DL
-    HBSize_= kHBSizePreLS1; // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
-    HESize_= kHESizePreLS1; // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
-    HOSize_= kHOSizePreLS1; // ieta * iphi * 2
-    HFSize_= kHFSizePreLS1; // phi * eta * depth * pm 
+    HBSize_= kHBSizePhase0; // qie-per-fiber * fiber/rm * rm/rbx * rbx/barrel * barrel/hcal
+    HESize_= kHESizePhase0; // qie-per-fiber * fiber/rm * rm/rbx * rbx/endcap * endcap/hcal
+    HOSize_= kHOSizePhase0; // ieta * iphi * 2
+    HFSize_= kHFSizePhase0; // phi * eta * depth * pm 
   } else if (mode_==HcalTopologyMode::SLHC) { // need to know more eventually
     HBSize_= maxDepthHB*16*72*2;
     HESize_= maxDepthHE*(29-16+1)*72*2;
@@ -52,12 +52,39 @@ HcalTopology::HcalTopology(HcalTopologyMode::Mode mode, int maxDepthHB, int maxD
 
     topoVersion_=10;
   }
+
+  if (triggerMode_==HcalTopologyMode::tm_LHC_RCT) {
+    HTSize_=kHTSizePhase0;
+  } else {
+    HTSize_=kHTSizePhase1;
+  }
     
 }
 
 bool HcalTopology::valid(const DetId& id) const {
   assert(id.det()==DetId::Hcal);
+  if (HcalSubdetector(id.subdetId())==HcalTriggerTower) return validHT(id);
   return validHcal(id);
+}
+
+bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
+  
+  if (id.iphi()<1 || id.iphi()>72 || id.ieta()==0) return false;
+  if (id.version()==0) {
+    if (id.ietaAbs()>32 || (triggerMode_==HcalTopologyMode::tm_LHC_1x1 && id.ietaAbs()>27)) return false;
+    if (id.ietaAbs()>28) {
+      int iphi=id.iphi();
+      if ((iphi/4)*4 + 1 != iphi) return false;
+      iphi = iphi/4 + 1;	  
+      if (iphi > 18) return false;
+    }
+  } else { // version==1
+    if (triggerMode_==HcalTopologyMode::tm_LHC_RCT) return false;
+    if (id.ietaAbs()<27 || id.ietaAbs()>41) return false;
+    if (id.ietaAbs()>29 && ((id.iphi()%2)==0)) return false;
+  }
+  return true;
+
 }
 
 bool HcalTopology::validHcal(const HcalDetId& id) const {
@@ -213,7 +240,7 @@ int HcalTopology::exclude(HcalSubdetector subdet, int ieta1, int ieta2, int iphi
 
   */
 
-bool HcalTopology::validDetIdPreLS1(const HcalDetId& id) const {
+bool HcalTopology::validDetIdPhase0(const HcalDetId& id) const {
   const HcalSubdetector sd (id.subdet());
   const int             ie (id.ietaAbs());
   const int             ip (id.iphi());
@@ -562,7 +589,7 @@ std::pair<int, int> HcalTopology::segmentBoundaries(unsigned ring, unsigned dept
   return std::pair<int, int>(d1, d2);
 }
 
-unsigned int HcalTopology::detId2denseIdPreLS1 (const DetId& id) const {
+unsigned int HcalTopology::detId2denseIdPhase0 (const DetId& id) const {
 
   HcalDetId hid(id);
   const HcalSubdetector sd (hid.subdet()  ) ;
@@ -584,7 +611,7 @@ unsigned int HcalTopology::detId2denseIdPreLS1 (const DetId& id) const {
 			       ( ( sd == HcalForward ) ?
 				 2*kHBhalf + 2*kHEhalf + 2*kHOhalf + 
 				 ( ( ip - 1 )/4 )*4 + ( ( ip - 1 )/2 )*22 + 
-				 2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalf : 0xFFFFFFFFu ) ) ) ) ; 
+				 2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalfPhase0 : 0xFFFFFFFFu ) ) ) ) ; 
   return retval;
 }
 
@@ -649,10 +676,10 @@ unsigned int HcalTopology::detId2denseIdHF(const DetId& id) const {
   unsigned int  retval = 0xFFFFFFFFu;
   if (topoVersion_==0) {
     retval = ( ( ip - 1 )/4 )*4 + ( ( ip - 1 )/2 )*22 + 
-      2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalf;
+      2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalfPhase0;
   } else if (topoVersion_==10) {
     retval = ( ( ip - 1 )/4 )*4 + ( ( ip - 1 )/2 )*22 + 
-      2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalf;
+      2*( ie - 29 ) + ( dp - 1 ) + zn*kHFhalfPhase0;
   }
   return retval;
 }
@@ -667,7 +694,7 @@ unsigned int HcalTopology::detId2denseIdHT(const DetId& id) const {
   if ((iphi-1)%4==0) index = (iphi-1)*32 + (ietaAbs-1) - (12*((iphi-1)/4));
   else               index = (iphi-1)*28 + (ietaAbs-1) + (4*(((iphi-1)/4)+1));
   
-  if (zside == -1) index += kHThalf;
+  if (zside == -1) index += kHThalfPhase0;
 
   return index;
 }
@@ -734,7 +761,7 @@ unsigned int HcalTopology::detId2denseIdCALIB(const DetId& id) const {
 unsigned int HcalTopology::detId2denseId(const DetId& id) const {
   unsigned int retval(0);
   if (topoVersion_==0) { // pre-LS1
-    retval = detId2denseIdPreLS1(id);
+    retval = detId2denseIdPhase0(id);
   } else if (topoVersion_==10) {
     HcalDetId hid(id);
     if (hid.subdet()==HcalBarrel) {
@@ -777,12 +804,12 @@ DetId HcalTopology::denseId2detId(unsigned int denseid) const {
   int in ( denseid ) ;
   int iz ( 1 ) ;
   if (topoVersion_==0) { //DL// pre-LS1
-    if (denseid < kSizeForDenseIndexingPreLS1) {
+    if (denseid < kSizeForDenseIndexingPhase0) {
       if ( in > 2*( kHBhalf + kHEhalf + kHOhalf ) - 1 ) { // HF
 	sd  = HcalForward ;
 	in -= 2*( kHBhalf + kHEhalf + kHOhalf ) ; 
-	iz  = ( in<kHFhalf ? 1 : -1 ) ;
-	in %= kHFhalf ; 
+	iz  = ( in<kHFhalfPhase0 ? 1 : -1 ) ;
+	in %= kHFhalfPhase0 ; 
 	ip  = 4*( in/48 ) ;
 	in %= 48 ;
 	ip += 1 + ( in>21 ? 2 : 0 ) ;
@@ -871,8 +898,7 @@ DetId HcalTopology::denseId2detId(unsigned int denseid) const {
   return HcalDetId( sd, iz*int(ie), ip, dp );
 }
 
-unsigned int HcalTopology::ncells() const {
-  return HBSize_+HESize_+HOSize_+HFSize_;
+unsigned int HcalTopology::ncells() const {  return HBSize_+HESize_+HOSize_+HFSize_;
 }
 
 int HcalTopology::topoVersion() const {

--- a/Geometry/CaloTopology/src/HcalTopology.cc
+++ b/Geometry/CaloTopology/src/HcalTopology.cc
@@ -80,7 +80,7 @@ bool HcalTopology::validHT(const HcalTrigTowerDetId& id) const {
     }
   } else { // version==1
     if (triggerMode_==HcalTopologyMode::tm_LHC_RCT) return false;
-    if (id.ietaAbs()<27 || id.ietaAbs()>41) return false;
+    if (id.ietaAbs()<28 || id.ietaAbs()>41) return false;
     if (id.ietaAbs()>29 && ((id.iphi()%2)==0)) return false;
   }
   return true;
@@ -706,14 +706,14 @@ unsigned int HcalTopology::detId2denseIdHT(const DetId& id) const {
   }
   // HF 1x1 summing and LHC Run 1 simultaneously
   else if (tid.version() == 1) {
-    int offset = kHThalfPhase0;
+    int offset = kHTSizePhase0;
     if (zside == -1) {
       // The negative ieta values are stored on the back half of the part of
-      // the array reserved for the new segmentation. kHThalfPhase1 is
-      // kHThalfPhase0 + the size of the Version 1 bit on the end, so we
-      // subtract off kHThalfPhase0 and then divid by 2 to find the halfway
+      // the array reserved for the new segmentation. kHTSizePhase1 is
+      // kHTSizePhase0 + the size of the Version 1 bit on the end, so we
+      // subtract off kHTSizePhase0 and then divid by 2 to find the halfway
       // point.
-      offset += (kHThalfPhase1 - kHThalfPhase0) / 2; 
+      offset += (kHTSizePhase1 - kHTSizePhase0) / 2;
     }
     // ieta 28, 29 have 72 iph
     if (28 <= ietaAbs && ietaAbs <= 29) {

--- a/Geometry/CaloTopology/src/HcalTopologyMode.cc
+++ b/Geometry/CaloTopology/src/HcalTopologyMode.cc
@@ -8,3 +8,12 @@ StringToEnumParser<HcalTopologyMode::Mode>::StringToEnumParser()
     enumMap["HcalTopologyMode::SLHC"] = HcalTopologyMode::SLHC;
     enumMap["HcalTopologyMode::H2HE"] = HcalTopologyMode::H2HE;
 }
+
+template<>
+StringToEnumParser<HcalTopologyMode::TriggerMode>::StringToEnumParser()
+{
+    enumMap["HcalTopologyMode::tm_LHC_RCT"] = HcalTopologyMode::tm_LHC_RCT;
+    enumMap["HcalTopologyMode::tm_LHC_RCT_and_1x1"] = HcalTopologyMode::tm_LHC_RCT_and_1x1;
+    enumMap["HcalTopologyMode::tm_LHC_1x1"] = HcalTopologyMode::tm_LHC_1x1;
+
+}

--- a/Geometry/HcalEventSetup/python/hcalSLHCTopologyConstants_cfi.py
+++ b/Geometry/HcalEventSetup/python/hcalSLHCTopologyConstants_cfi.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 hcalTopologyConstants = cms.PSet(
     mode = cms.string('HcalTopologyMode::SLHC'),
     maxDepthHB = cms.int32(4),
-    maxDepthHE = cms.int32(5)
+    maxDepthHE = cms.int32(5),
+    triggerMode = cms.string('HcalTopologyMode::tm_LHC_1x1')
 )

--- a/Geometry/HcalEventSetup/python/hcalTopologyConstants_cfi.py
+++ b/Geometry/HcalEventSetup/python/hcalTopologyConstants_cfi.py
@@ -3,5 +3,6 @@ import FWCore.ParameterSet.Config as cms
 hcalTopologyConstants = cms.PSet(
     mode = cms.string('HcalTopologyMode::LHC'),
     maxDepthHB = cms.int32(2),
-    maxDepthHE = cms.int32(3)
+    maxDepthHE = cms.int32(3),
+    triggerMode = cms.string('HcalTopologyMode::tm_LHC_RCT_and_1x1')
 )

--- a/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
+++ b/Geometry/HcalEventSetup/src/HcalTopologyIdealEP.cc
@@ -69,11 +69,13 @@ HcalTopologyIdealEP::fillDescriptions( edm::ConfigurationDescriptions & descript
   hcalTopologyConstants.add<std::string>( "mode", "HcalTopologyMode::LHC" );
   hcalTopologyConstants.add<int>( "maxDepthHB", 2 );
   hcalTopologyConstants.add<int>( "maxDepthHE", 3 );  
+  hcalTopologyConstants.add<std::string>( "triggerMode", "HcalTopologyMode::tm_LHC_RCT_and_1x1" );
 
   edm::ParameterSetDescription hcalSLHCTopologyConstants;
   hcalSLHCTopologyConstants.add<std::string>( "mode", "HcalTopologyMode::SLHC" );
   hcalSLHCTopologyConstants.add<int>( "maxDepthHB", 7 );
   hcalSLHCTopologyConstants.add<int>( "maxDepthHE", 7 );
+  hcalSLHCTopologyConstants.add<std::string>( "triggerMode", "HcalTopologyMode::tm_LHC_1x1" );
 
   edm::ParameterSetDescription desc;
   desc.addUntracked<std::string>( "Exclude", "" );
@@ -102,6 +104,7 @@ HcalTopologyIdealEP::produce(const IdealGeometryRecord& iRecord)
   HcalTopologyMode::Mode mode = HcalTopologyMode::LHC;
   int maxDepthHB = 2;
   int maxDepthHE = 3;
+  HcalTopologyMode::TriggerMode tmode = HcalTopologyMode::tm_LHC_RCT_and_1x1;
   if( m_pSet.exists( "hcalTopologyConstants" ))
   {
     const edm::ParameterSet hcalTopoConsts( m_pSet.getParameter<edm::ParameterSet>( "hcalTopologyConstants" ));
@@ -109,11 +112,14 @@ HcalTopologyIdealEP::produce(const IdealGeometryRecord& iRecord)
     mode = (HcalTopologyMode::Mode) eparser.parseString(hcalTopoConsts.getParameter<std::string>("mode"));
     maxDepthHB = hcalTopoConsts.getParameter<int>("maxDepthHB");
     maxDepthHE = hcalTopoConsts.getParameter<int>("maxDepthHE");
+    StringToEnumParser<HcalTopologyMode::TriggerMode> tparser;
+    tmode = (HcalTopologyMode::TriggerMode) tparser.parseString(hcalTopoConsts.getParameter<std::string>("triggerMode"));
+
   }
   //  std::cout << "mode = " << mode << ", maxDepthHB = " << maxDepthHB << ", maxDepthHE = " << maxDepthHE << std::endl;
-  edm::LogInfo("HCAL") << "mode = " << mode << ", maxDepthHB = " << maxDepthHB << ", maxDepthHE = " << maxDepthHE;
+  edm::LogInfo("HCAL") << "mode = " << mode << ", maxDepthHB = " << maxDepthHB << ", maxDepthHE = " << maxDepthHE << "trigger mode=" << tmode;
 
-  ReturnType myTopo(new HcalTopology( mode, maxDepthHB, maxDepthHE ));
+  ReturnType myTopo(new HcalTopology( mode, maxDepthHB, maxDepthHE, tmode ));
 
   HcalTopologyRestrictionParser parser(*myTopo);
   if (!m_restrictions.empty()) {

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -12,23 +12,33 @@ public:
 
   HcalTrigTowerGeometry( const HcalTopology* topology );
 
-  void setupHF(bool useShortFibers, bool useQuadRings);
-  
   /// the mapping to and from DetIds
   std::vector<HcalTrigTowerDetId> towerIds(const HcalDetId & cellId) const;
   std::vector<HcalDetId> detIds(const HcalTrigTowerDetId &) const;
 
-  /// an interface for CaloSubdetectorGeometry
-  //std::vector<DetId> getValidDetIds(DetId::Detector det, int subdet) const;
-
-  /// the number of phi bins in this eta ring
-  int nPhiBins(int ieta) const {
-    int nPhiBinsHF = ( useUpgradeConfigurationHFTowers_ ? 36 : 18 );   
-    return (abs(ieta) < firstHFTower()) ? 72 : nPhiBinsHF;
+  void setupHFTowers(bool enableRCT, bool enable1x1) {
+    useRCT_=enableRCT;
+    use1x1_=enable1x1;
   }
 
-  int firstHFTower() const {return 29;} 
-  int nTowers() const {return 32;}
+  int firstHFTower(int version) const {return (version==0)?(29):(30);} 
+
+  /// where this tower begins and ends in eta
+  void towerEtaBounds(int ieta, int version, double & eta1, double & eta2) const;
+
+  /// number of towers (version dependent)
+  int nTowers(int version) const {return (version==0)?(32):(41);}
+
+  // get the topology pointer
+  const HcalTopology& topology() const { return *theTopology; }
+
+ private:
+
+  /// the number of phi bins in this eta ring
+  int nPhiBins(int ieta, int version) const {
+    int nPhiBinsHF = ( 18 );   
+    return (abs(ieta) < firstHFTower(version)) ? 72 : nPhiBinsHF;
+  }
 
   /// the number of HF eta rings in this trigger tower
   /// ieta starts at firstHFTower()
@@ -37,18 +47,10 @@ public:
   /// since the towers are irregular in eta in HF
   int firstHFRingInTower(int ietaTower) const;
 
-  /// where this tower begins and ends in eta
-  void towerEtaBounds(int ieta, double & eta1, double & eta2) const;
-
-  void setUpgradeConfigurationHFTowers(bool value) {
-    useUpgradeConfigurationHFTowers_ = value;
-  }
-
-private:
+ private:
   const HcalTopology* theTopology;
-  bool useShortFibers_;
-  bool useHFQuadPhiRings_;
-  bool useUpgradeConfigurationHFTowers_;
+  bool useRCT_;
+  bool use1x1_;
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -32,6 +32,10 @@ public:
   // get the topology pointer
   const HcalTopology& topology() const { return *theTopology; }
 
+  // Get the useRCT and use1x1 values
+  bool useRCT() const { return useRCT_; }
+  bool use1x1() const { return use1x1_; }
+
  private:
 
   /// the number of phi bins in this eta ring

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -12,22 +12,25 @@ public:
 
   HcalTrigTowerGeometry( const HcalTopology* topology );
 
-  void setupHF(bool useShortFibers, bool useQuadRings);
-  
   /// the mapping to and from DetIds
   std::vector<HcalTrigTowerDetId> towerIds(const HcalDetId & cellId) const;
   std::vector<HcalDetId> detIds(const HcalTrigTowerDetId &) const;
 
-  /// an interface for CaloSubdetectorGeometry
-  //std::vector<DetId> getValidDetIds(DetId::Detector det, int subdet) const;
-
-  /// the number of phi bins in this eta ring
-  int nPhiBins(int ieta) const {
-    int nPhiBinsHF = ( useUpgradeConfigurationHFTowers_ ? 36 : 18 );   
-    return (abs(ieta) < firstHFTower()) ? 72 : nPhiBinsHF;
+  void setupHFTowers(bool enableRCT, bool enable1x1) {
+    useRCT_=enableRCT;
+    use1x1_=enable1x1;
   }
 
   int firstHFTower() const {return 29;} 
+
+ private:
+
+  /// the number of phi bins in this eta ring
+  int nPhiBins(int ieta) const {
+    int nPhiBinsHF = ( 18 );   
+    return (abs(ieta) < firstHFTower()) ? 72 : nPhiBinsHF;
+  }
+
   int nTowers() const {return 32;}
 
   /// the number of HF eta rings in this trigger tower
@@ -40,15 +43,11 @@ public:
   /// where this tower begins and ends in eta
   void towerEtaBounds(int ieta, double & eta1, double & eta2) const;
 
-  void setUpgradeConfigurationHFTowers(bool value) {
-    useUpgradeConfigurationHFTowers_ = value;
-  }
 
-private:
+ private:
   const HcalTopology* theTopology;
-  bool useShortFibers_;
-  bool useHFQuadPhiRings_;
-  bool useUpgradeConfigurationHFTowers_;
+  bool useRCT_;
+  bool use1x1_;
 };
 
 #endif

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -29,7 +29,8 @@ public:
   /// number of towers (version dependent)
   int nTowers(int version) const {return (version==0)?(32):(41);}
 
-
+  // get the topology pointer
+  const HcalTopology& topology() const { return *theTopology; }
 
  private:
 

--- a/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
+++ b/Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h
@@ -21,17 +21,23 @@ public:
     use1x1_=enable1x1;
   }
 
-  int firstHFTower() const {return 29;} 
+  int firstHFTower(int version) const {return (version==0)?(29):(30);} 
+
+  /// where this tower begins and ends in eta
+  void towerEtaBounds(int ieta, int version, double & eta1, double & eta2) const;
+
+  /// number of towers (version dependent)
+  int nTowers(int version) const {return (version==0)?(32):(41);}
+
+
 
  private:
 
   /// the number of phi bins in this eta ring
-  int nPhiBins(int ieta) const {
+  int nPhiBins(int ieta, int version) const {
     int nPhiBinsHF = ( 18 );   
-    return (abs(ieta) < firstHFTower()) ? 72 : nPhiBinsHF;
+    return (abs(ieta) < firstHFTower(version)) ? 72 : nPhiBinsHF;
   }
-
-  int nTowers() const {return 32;}
 
   /// the number of HF eta rings in this trigger tower
   /// ieta starts at firstHFTower()
@@ -39,10 +45,6 @@ public:
 
   /// since the towers are irregular in eta in HF
   int firstHFRingInTower(int ietaTower) const;
-
-  /// where this tower begins and ends in eta
-  void towerEtaBounds(int ieta, double & eta1, double & eta2) const;
-
 
  private:
   const HcalTopology* theTopology;

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -6,8 +6,6 @@
 
 HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::ParameterSet & config )
 {
-  useFullGranularityHF_=config.getParameter<bool>("useFullGranularityHF");
-
   setWhatProduced( this );
 }
 
@@ -22,14 +20,16 @@ HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
 
     m_hcalTrigTowerGeom =
 	boost::shared_ptr<HcalTrigTowerGeometry>( new HcalTrigTowerGeometry( &*hcalTopology));
-    m_hcalTrigTowerGeom->setUpgradeConfigurationHFTowers(useFullGranularityHF_);
+    HcalTopologyMode::TriggerMode tmode=hcalTopology->triggerMode();
+    bool enableRCTHF=(tmode==HcalTopologyMode::tm_LHC_RCT || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);
+    bool enable1x1HF=(tmode==HcalTopologyMode::tm_LHC_1x1 || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);
+    m_hcalTrigTowerGeom->setupHFTowers(enableRCTHF,enable1x1HF);
 
     return m_hcalTrigTowerGeom;
 }
 
 void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
    edm::ParameterSetDescription desc;
-   desc.add<bool>("useFullGranularityHF", false);
    descriptions.add("HcalTrigTowerGeometryESProducer", desc);
 }
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -6,7 +6,8 @@
 
 HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::ParameterSet & config )
 {
-  useFullGranularityHF_=config.getParameter<bool>("useFullGranularityHF");
+  enable1x1HF_=config.getParameter<bool>("enableHF1x1");
+  enableRCTHF_=config.getParameter<bool>("enableHFRCT");
 
   setWhatProduced( this );
 }
@@ -22,14 +23,15 @@ HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
 
     m_hcalTrigTowerGeom =
 	boost::shared_ptr<HcalTrigTowerGeometry>( new HcalTrigTowerGeometry( &*hcalTopology));
-    m_hcalTrigTowerGeom->setUpgradeConfigurationHFTowers(useFullGranularityHF_);
+    m_hcalTrigTowerGeom->setupHFTowers(enableRCTHF_,enable1x1HF_);
 
     return m_hcalTrigTowerGeom;
 }
 
 void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
    edm::ParameterSetDescription desc;
-   desc.add<bool>("useFullGranularityHF", false);
+   desc.add<bool>("enableHF1x1", true);
+   desc.add<bool>("enableHFRCT", true);
    descriptions.add("HcalTrigTowerGeometryESProducer", desc);
 }
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.cc
@@ -6,9 +6,6 @@
 
 HcalTrigTowerGeometryESProducer::HcalTrigTowerGeometryESProducer( const edm::ParameterSet & config )
 {
-  enable1x1HF_=config.getParameter<bool>("enableHF1x1");
-  enableRCTHF_=config.getParameter<bool>("enableHFRCT");
-
   setWhatProduced( this );
 }
 
@@ -23,15 +20,16 @@ HcalTrigTowerGeometryESProducer::produce( const CaloGeometryRecord & iRecord )
 
     m_hcalTrigTowerGeom =
 	boost::shared_ptr<HcalTrigTowerGeometry>( new HcalTrigTowerGeometry( &*hcalTopology));
-    m_hcalTrigTowerGeom->setupHFTowers(enableRCTHF_,enable1x1HF_);
+    HcalTopologyMode::TriggerMode tmode=hcalTopology->triggerMode();
+    bool enableRCTHF=(tmode==HcalTopologyMode::tm_LHC_RCT || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);
+    bool enable1x1HF=(tmode==HcalTopologyMode::tm_LHC_1x1 || tmode==HcalTopologyMode::tm_LHC_RCT_and_1x1);
+    m_hcalTrigTowerGeom->setupHFTowers(enableRCTHF,enable1x1HF);
 
     return m_hcalTrigTowerGeom;
 }
 
 void HcalTrigTowerGeometryESProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
    edm::ParameterSetDescription desc;
-   desc.add<bool>("enableHF1x1", true);
-   desc.add<bool>("enableHFRCT", true);
    descriptions.add("HcalTrigTowerGeometryESProducer", desc);
 }
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -22,7 +22,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  bool useFullGranularityHF_;
   boost::shared_ptr<HcalTrigTowerGeometry> m_hcalTrigTowerGeom;
 };
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -22,7 +22,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  bool useFullGranularityHF_;
+  bool enable1x1HF_,enableRCTHF_;
   boost::shared_ptr<HcalTrigTowerGeometry> m_hcalTrigTowerGeom;
 };
 

--- a/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
+++ b/Geometry/HcalTowerAlgo/plugins/HcalTrigTowerGeometryESProducer.h
@@ -22,7 +22,6 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  bool enable1x1HF_,enableRCTHF_;
   boost::shared_ptr<HcalTrigTowerGeometry> m_hcalTrigTowerGeom;
 };
 

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -9,14 +9,8 @@
 HcalTrigTowerGeometry::HcalTrigTowerGeometry( const HcalTopology* topology )
     : theTopology( topology ) 
 {
-  useShortFibers_=true;
-  useHFQuadPhiRings_=true;
-  useUpgradeConfigurationHFTowers_=!true;
-}
-
-void HcalTrigTowerGeometry::setupHF(bool useShortFibers, bool useQuadRings) {
-  useShortFibers_=useShortFibers;
-  useHFQuadPhiRings_=useQuadRings;
+  useRCT_=true;
+  use1x1_=true;
 }
 
 std::vector<HcalTrigTowerDetId> 
@@ -24,39 +18,36 @@ HcalTrigTowerGeometry::towerIds(const HcalDetId & cellId) const {
 
   std::vector<HcalTrigTowerDetId> results;
 
-  int HfTowerPhiSize, shift;
-  if ( useUpgradeConfigurationHFTowers_ ) { 
-    HfTowerPhiSize = 1;
-    shift = 0;
-  } else {
-    HfTowerPhiSize = 4;
-    shift = 1;
-  }
-  
   if(cellId.subdet() == HcalForward) {
-    // short fibers don't count
-    if(cellId.depth() == 1 || useShortFibers_) {
+
+    if (useRCT_) { 
       // first do eta
       int hfRing = cellId.ietaAbs();
-      int ieta = firstHFTower(); 
+      int ieta = firstHFTower(0); 
       // find the tower that contains this ring
       while(hfRing >= firstHFRingInTower(ieta+1)) {
-        ++ieta;
+	++ieta;
       }
       
-      if ( useUpgradeConfigurationHFTowers_ && ieta == 29) {
-	ieta = 30; 
-      }
-
       ieta *= cellId.zside();
-
+      
       // now for phi
       // HF towers are quad, 18 in phi.
       // go two cells per trigger tower.
+      
+      int iphi = (((cellId.iphi()+1)/4) * 4 + 1)%72; // 71+1 --> 1, 3+5 --> 5
+      results.push_back( HcalTrigTowerDetId(ieta, iphi) );
+    } 
+    if (use1x1_) {
+      int hfRing = cellId.ietaAbs();
+      if (hfRing==29) hfRing=30; // sum 29 into 30.
 
-      int iphi = (((cellId.iphi()+shift)/HfTowerPhiSize) * HfTowerPhiSize + shift)%72; // 71+1 --> 1, 3+5 --> 5
-      if (useHFQuadPhiRings_ || cellId.ietaAbs() < theTopology->firstHFQuadPhiRing())
-        results.push_back( HcalTrigTowerDetId(ieta, iphi) );
+      int ieta = hfRing*cellId.zside();      
+      int iphi = cellId.iphi();
+
+      HcalTrigTowerDetId id(ieta,iphi);
+      id.setVersion(1); // version 1 for 1x1 HF granularity
+      results.push_back(id);
     }
       
   } else {
@@ -138,63 +129,72 @@ HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId & hcalTrigTowerDetId) con
 
   if (abs(cell_ieta) >= theTopology->firstHFRing()){  
 
-    int HfTowerPhiSize;
-    if   ( useUpgradeConfigurationHFTowers_ ) HfTowerPhiSize = 1;
-    else                                      HfTowerPhiSize = 72 / nPhiBins(tower_ieta);
+    if (hcalTrigTowerDetId.version()==0) {
     
-    int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
-    int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
+      int HfTowerPhiSize =  72 / nPhiBins(tower_ieta,0);
 
-    for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++){      
+      int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
+      int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
+
+      for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++){      
             
-      cell_iphi =  (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize; // Find the minimum phi segment
-      if ( !useUpgradeConfigurationHFTowers_ ) cell_iphi -= 2; // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
-      cell_iphi += iHFTowerPhiSegment;       // Get all of the HCAL iphi values in this trigger tower
-      cell_iphi += 72;                       // Don't want to take the mod of a negative number
-      cell_iphi =  cell_iphi % 72;           // There are, at most, 72 cells.
-      if ( !useUpgradeConfigurationHFTowers_) cell_iphi += 1;// There is no cell at iphi = 0
+	cell_iphi =  (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize; // Find the minimum phi segment
+	cell_iphi -= 2; // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
+	cell_iphi += iHFTowerPhiSegment;       // Get all of the HCAL iphi values in this trigger tower
+	cell_iphi += 72;                       // Don't want to take the mod of a negative number
+	cell_iphi =  cell_iphi % 72;           // There are, at most, 72 cells.
+	cell_iphi += 1;// There is no cell at iphi = 0
       
-      if (cell_iphi%2 == 0) continue;        // These cells don't exist.
+	if (cell_iphi%2 == 0) continue;        // These cells don't exist.
 
-      for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++){
+	for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++){
 		
-	cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
+	  cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
 
-	if (cell_ieta >= 40 && cell_iphi%4 == 1) continue;  // These cells don't exist.
+	  if (cell_ieta >= 40 && cell_iphi%4 == 1) continue;  // These cells don't exist.
 
-	theTopology->depthBinInformation(HcalForward, cell_ieta, n_depths, min_depth);  
+	  theTopology->depthBinInformation(HcalForward, cell_ieta, n_depths, min_depth);  
+	  
+	  // Negative tower_ieta -> negative cell_ieta
+	  int zside = 1;
+	  if (tower_ieta < 0) zside = -1;
 
-	// Negative tower_ieta -> negative cell_ieta
-	int zside = 1;
-	if (tower_ieta < 0) zside = -1;
+	  cell_ieta *= zside;	       
 
-	cell_ieta *= zside;	       
-
-	for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
-	  results.push_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
+	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	    results.push_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
 	
-	if ( zside * cell_ieta == 30 ) {
-	  theTopology->depthBinInformation(HcalForward, 29 * zside, n_depths, min_depth);  
-	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) 
-	    results.push_back(HcalDetId(HcalForward, 29 * zside , cell_iphi, cell_depth));
+	  if ( zside * cell_ieta == 30 ) {
+	    theTopology->depthBinInformation(HcalForward, 29 * zside, n_depths, min_depth);  
+	    for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) 
+	      results.push_back(HcalDetId(HcalForward, 29 * zside , cell_iphi, cell_depth));
+	  }
 	}
-	
-      }    
+      }  
+    } else if (hcalTrigTowerDetId.version()==1) {
+      theTopology->depthBinInformation(HcalForward, tower_ieta, n_depths, min_depth);  
+      for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	results.push_back(HcalDetId(HcalForward, tower_ieta, tower_iphi, cell_depth));      
+      if (abs(tower_ieta)==30) {
+	int i29 = 29;
+	  if (tower_ieta < 0) i29 = -29;
+	  theTopology->depthBinInformation(HcalForward, i29, n_depths, min_depth);  
+	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	    results.push_back(HcalDetId(HcalForward, i29, tower_iphi, cell_depth));      
+      }
     }
   }
-
+  
   return results;
 }
 
 
 int HcalTrigTowerGeometry::hfTowerEtaSize(int ieta) const {
   
-  if ( useUpgradeConfigurationHFTowers_ ) return 1;
-  
   int ietaAbs = abs(ieta); 
-  assert(ietaAbs >= firstHFTower() && ietaAbs <= nTowers());
+  assert(ietaAbs >= firstHFTower(0) && ietaAbs <= nTowers(0));
   // the first three come from rings 29-31, 32-34, 35-37. The last has 4 rings: 38-41
-  return (ietaAbs == nTowers()) ? 4 : 3;
+  return (ietaAbs == nTowers(0)) ? 4 : 3;
   
 }
 
@@ -203,7 +203,7 @@ int HcalTrigTowerGeometry::firstHFRingInTower(int ietaTower) const {
   // count up to the correct HF ring
   int inputTower = abs(ietaTower);
   int result = theTopology->firstHFRing();
-  for(int iTower = firstHFTower(); iTower != inputTower; ++iTower) {
+  for(int iTower = firstHFTower(0); iTower != inputTower; ++iTower) {
     result += hfTowerEtaSize(iTower);
   }
   
@@ -213,20 +213,27 @@ int HcalTrigTowerGeometry::firstHFRingInTower(int ietaTower) const {
 }
 
 
-void HcalTrigTowerGeometry::towerEtaBounds(int ieta, double & eta1, double & eta2) const {
+void HcalTrigTowerGeometry::towerEtaBounds(int ieta, int version, double & eta1, double & eta2) const {
   int ietaAbs = abs(ieta);
-  if(ietaAbs < firstHFTower()) {
+  if(ietaAbs < firstHFTower(version)) {
     eta1 = theHBHEEtaBounds[ietaAbs-1];
     eta2 = theHBHEEtaBounds[ietaAbs];
-    // the last tower is split, so get tower 29, too
-    if(ietaAbs == theTopology->lastHERing()-1) {
+    // the last tower is split, so get tower 29, too (in version 0!)
+    if(ietaAbs == theTopology->lastHERing()-1 && version==0) {
       eta2 = theHBHEEtaBounds[ietaAbs+1];
     } 
   } else {
-    // count from 0
-    int hfIndex = firstHFRingInTower(ietaAbs) - theTopology->firstHFRing();
-    eta1 = theHFEtaBounds[hfIndex];
-    eta2 = theHFEtaBounds[hfIndex + hfTowerEtaSize(ieta)];
+    if (version==0) {
+      int hfIndex = firstHFRingInTower(ietaAbs) - theTopology->firstHFRing();
+      // count from 0
+      eta1 = theHFEtaBounds[hfIndex];
+      eta2 = theHFEtaBounds[hfIndex + hfTowerEtaSize(ieta)];
+    } else { // 1x1 towers
+      if (ietaAbs==29) ietaAbs=30; // HF 29 is a tail catcher/guard-ring.  should not define eta for TT
+      int hfIndex = ietaAbs - 29;
+      eta1 = theHFEtaBounds[hfIndex];
+      eta2 = theHFEtaBounds[hfIndex+1];
+    }
   }
 
   // get the signs and order right

--- a/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalTrigTowerGeometry.cc
@@ -9,14 +9,8 @@
 HcalTrigTowerGeometry::HcalTrigTowerGeometry( const HcalTopology* topology )
     : theTopology( topology ) 
 {
-  useShortFibers_=true;
-  useHFQuadPhiRings_=true;
-  useUpgradeConfigurationHFTowers_=!true;
-}
-
-void HcalTrigTowerGeometry::setupHF(bool useShortFibers, bool useQuadRings) {
-  useShortFibers_=useShortFibers;
-  useHFQuadPhiRings_=useQuadRings;
+  useRCT_=true;
+  use1x1_=true;
 }
 
 std::vector<HcalTrigTowerDetId> 
@@ -24,39 +18,36 @@ HcalTrigTowerGeometry::towerIds(const HcalDetId & cellId) const {
 
   std::vector<HcalTrigTowerDetId> results;
 
-  int HfTowerPhiSize, shift;
-  if ( useUpgradeConfigurationHFTowers_ ) { 
-    HfTowerPhiSize = 1;
-    shift = 0;
-  } else {
-    HfTowerPhiSize = 4;
-    shift = 1;
-  }
-  
   if(cellId.subdet() == HcalForward) {
-    // short fibers don't count
-    if(cellId.depth() == 1 || useShortFibers_) {
+
+    if (useRCT_) { 
       // first do eta
       int hfRing = cellId.ietaAbs();
       int ieta = firstHFTower(); 
       // find the tower that contains this ring
       while(hfRing >= firstHFRingInTower(ieta+1)) {
-        ++ieta;
+	++ieta;
       }
       
-      if ( useUpgradeConfigurationHFTowers_ && ieta == 29) {
-	ieta = 30; 
-      }
-
       ieta *= cellId.zside();
-
+      
       // now for phi
       // HF towers are quad, 18 in phi.
       // go two cells per trigger tower.
+      
+      int iphi = (((cellId.iphi()+1)/4) * 4 + 1)%72; // 71+1 --> 1, 3+5 --> 5
+      results.push_back( HcalTrigTowerDetId(ieta, iphi) );
+    } 
+    if (use1x1_) {
+      int hfRing = cellId.ietaAbs();
+      if (hfRing==29) hfRing=30; // sum 29 into 30.
 
-      int iphi = (((cellId.iphi()+shift)/HfTowerPhiSize) * HfTowerPhiSize + shift)%72; // 71+1 --> 1, 3+5 --> 5
-      if (useHFQuadPhiRings_ || cellId.ietaAbs() < theTopology->firstHFQuadPhiRing())
-        results.push_back( HcalTrigTowerDetId(ieta, iphi) );
+      int ieta = hfRing*cellId.zside();      
+      int iphi = cellId.iphi();
+
+      HcalTrigTowerDetId id(ieta,iphi);
+      id.setVersion(1); // version 1 for 1x1 HF granularity
+      results.push_back(id);
     }
       
   } else {
@@ -138,58 +129,67 @@ HcalTrigTowerGeometry::detIds(const HcalTrigTowerDetId & hcalTrigTowerDetId) con
 
   if (abs(cell_ieta) >= theTopology->firstHFRing()){  
 
-    int HfTowerPhiSize;
-    if   ( useUpgradeConfigurationHFTowers_ ) HfTowerPhiSize = 1;
-    else                                      HfTowerPhiSize = 72 / nPhiBins(tower_ieta);
+    if (hcalTrigTowerDetId.version()==0) {
     
-    int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
-    int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
+      int HfTowerPhiSize =  72 / nPhiBins(tower_ieta);
 
-    for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++){      
+      int HfTowerEtaSize     = hfTowerEtaSize(tower_ieta);
+      int FirstHFRingInTower = firstHFRingInTower(abs(tower_ieta));
+
+      for (int iHFTowerPhiSegment = 0; iHFTowerPhiSegment < HfTowerPhiSize; iHFTowerPhiSegment++){      
             
-      cell_iphi =  (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize; // Find the minimum phi segment
-      if ( !useUpgradeConfigurationHFTowers_ ) cell_iphi -= 2; // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
-      cell_iphi += iHFTowerPhiSegment;       // Get all of the HCAL iphi values in this trigger tower
-      cell_iphi += 72;                       // Don't want to take the mod of a negative number
-      cell_iphi =  cell_iphi % 72;           // There are, at most, 72 cells.
-      if ( !useUpgradeConfigurationHFTowers_) cell_iphi += 1;// There is no cell at iphi = 0
+	cell_iphi =  (tower_iphi / HfTowerPhiSize) * HfTowerPhiSize; // Find the minimum phi segment
+	cell_iphi -= 2; // The first trigger tower starts at HCAL iphi = 71, not HCAL iphi = 1
+	cell_iphi += iHFTowerPhiSegment;       // Get all of the HCAL iphi values in this trigger tower
+	cell_iphi += 72;                       // Don't want to take the mod of a negative number
+	cell_iphi =  cell_iphi % 72;           // There are, at most, 72 cells.
+	cell_iphi += 1;// There is no cell at iphi = 0
       
-      if (cell_iphi%2 == 0) continue;        // These cells don't exist.
+	if (cell_iphi%2 == 0) continue;        // These cells don't exist.
 
-      for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++){
+	for (int iHFTowerEtaSegment = 0; iHFTowerEtaSegment < HfTowerEtaSize; iHFTowerEtaSegment++){
 		
-	cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
+	  cell_ieta = FirstHFRingInTower + iHFTowerEtaSegment;
 
-	if (cell_ieta >= 40 && cell_iphi%4 == 1) continue;  // These cells don't exist.
+	  if (cell_ieta >= 40 && cell_iphi%4 == 1) continue;  // These cells don't exist.
 
-	theTopology->depthBinInformation(HcalForward, cell_ieta, n_depths, min_depth);  
+	  theTopology->depthBinInformation(HcalForward, cell_ieta, n_depths, min_depth);  
+	  
+	  // Negative tower_ieta -> negative cell_ieta
+	  int zside = 1;
+	  if (tower_ieta < 0) zside = -1;
 
-	// Negative tower_ieta -> negative cell_ieta
-	int zside = 1;
-	if (tower_ieta < 0) zside = -1;
+	  cell_ieta *= zside;	       
 
-	cell_ieta *= zside;	       
-
-	for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
-	  results.push_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
+	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	    results.push_back(HcalDetId(HcalForward, cell_ieta, cell_iphi, cell_depth));
 	
-	if ( zside * cell_ieta == 30 ) {
-	  theTopology->depthBinInformation(HcalForward, 29 * zside, n_depths, min_depth);  
-	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) 
-	    results.push_back(HcalDetId(HcalForward, 29 * zside , cell_iphi, cell_depth));
+	  if ( zside * cell_ieta == 30 ) {
+	    theTopology->depthBinInformation(HcalForward, 29 * zside, n_depths, min_depth);  
+	    for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++) 
+	      results.push_back(HcalDetId(HcalForward, 29 * zside , cell_iphi, cell_depth));
+	  }
 	}
-	
-      }    
+      }  
+    } else if (hcalTrigTowerDetId.version()==1) {
+      theTopology->depthBinInformation(HcalForward, tower_ieta, n_depths, min_depth);  
+      for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	results.push_back(HcalDetId(HcalForward, tower_ieta, tower_iphi, cell_depth));      
+      if (abs(tower_ieta)==30) {
+	int i29 = 29;
+	  if (tower_ieta < 0) i29 = -29;
+	  theTopology->depthBinInformation(HcalForward, i29, n_depths, min_depth);  
+	  for (int cell_depth = min_depth; cell_depth <= min_depth + n_depths - 1; cell_depth++)
+	    results.push_back(HcalDetId(HcalForward, i29, tower_iphi, cell_depth));      
+      }
     }
   }
-
+  
   return results;
 }
 
 
 int HcalTrigTowerGeometry::hfTowerEtaSize(int ieta) const {
-  
-  if ( useUpgradeConfigurationHFTowers_ ) return 1;
   
   int ietaAbs = abs(ieta); 
   assert(ietaAbs >= firstHFTower() && ietaAbs <= nTowers());

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
@@ -15,10 +15,18 @@
 void testTriggerGeometry( HcalTopology& topology ) {
 
   HcalTrigTowerGeometry trigTowers( &topology );
-  std::cout << "HCAL trigger tower eta bounds " << std::endl;
+
+  std::cout << "HCAL trigger tower eta bounds (version 0)" << std::endl;
   for(int ieta = 1; ieta <= 32; ++ieta) {
     double eta1, eta2;
-    trigTowers.towerEtaBounds(ieta, eta1, eta2);
+    trigTowers.towerEtaBounds(ieta, 0, eta1, eta2);
+    std::cout << ieta << " "  << eta1 << " " << eta2 << std::endl;
+  }
+
+  std::cout << "HCAL trigger tower eta bounds (version 1)" << std::endl;
+  for(int ieta = 1; ieta <= 41; ++ieta) {
+    double eta1, eta2;
+    trigTowers.towerEtaBounds(ieta, 1, eta1, eta2);
     std::cout << ieta << " "  << eta1 << " " << eta2 << std::endl;
   }
 

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
@@ -44,11 +44,17 @@ void testTriggerGeometry( HcalTopology& topology ) {
   TowerDets forwardTowers2 = trigTowers.towerIds(forwardDet2);
   TowerDets forwardTowers3 = trigTowers.towerIds(forwardDet3);
 
+  // Each version of the HF Trigger Towers will add an additional item to the
+  // vector returned by trigTowers.towerIds() for forward towers.
+  size_t foward_det_count = 0;
+  if (trigTowers.useRCT()) { foward_det_count++; }
+  if (trigTowers.use1x1()) { foward_det_count++; }
+
   assert(barrelTowers.size() ==1);
   assert(endcapTowers.size() ==2);
-  assert(forwardTowers1.size() ==1);
-  assert(forwardTowers2.size() ==1);
-  assert(forwardTowers3.size() ==1);
+  assert(forwardTowers1.size() == foward_det_count);
+  assert(forwardTowers2.size() == foward_det_count);
+  assert(forwardTowers3.size() == foward_det_count);
 
   std::cout << barrelTowers[0] << std::endl;
   std::cout << endcapTowers[0] << std::endl;

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
@@ -15,14 +15,21 @@
 void testTriggerGeometry( HcalTopology& topology ) {
 
   HcalTrigTowerGeometry trigTowers( &topology );
-/*
-  std::cout << "HCAL trigger tower eta bounds " << std::endl;
+
+  std::cout << "HCAL trigger tower eta bounds (version 0)" << std::endl;
   for(int ieta = 1; ieta <= 32; ++ieta) {
     double eta1, eta2;
-    trigTowers.towerEtaBounds(ieta, eta1, eta2);
+    trigTowers.towerEtaBounds(ieta, 0, eta1, eta2);
     std::cout << ieta << " "  << eta1 << " " << eta2 << std::endl;
   }
-*/
+
+  std::cout << "HCAL trigger tower eta bounds (version 1)" << std::endl;
+  for(int ieta = 1; ieta <= 41; ++ieta) {
+    double eta1, eta2;
+    trigTowers.towerEtaBounds(ieta, 1, eta1, eta2);
+    std::cout << ieta << " "  << eta1 << " " << eta2 << std::endl;
+  }
+
   // now test some cell mappings
   HcalDetId barrelDet(HcalBarrel, 1, 1, 1);
   HcalDetId endcapDet(HcalEndcap, 29, 1, 1);

--- a/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
+++ b/Geometry/HcalTowerAlgo/test/HcalGeometryTest.cpp
@@ -15,13 +15,14 @@
 void testTriggerGeometry( HcalTopology& topology ) {
 
   HcalTrigTowerGeometry trigTowers( &topology );
+/*
   std::cout << "HCAL trigger tower eta bounds " << std::endl;
   for(int ieta = 1; ieta <= 32; ++ieta) {
     double eta1, eta2;
     trigTowers.towerEtaBounds(ieta, eta1, eta2);
     std::cout << ieta << " "  << eta1 << " " << eta2 << std::endl;
   }
-
+*/
   // now test some cell mappings
   HcalDetId barrelDet(HcalBarrel, 1, 1, 1);
   HcalDetId endcapDet(HcalEndcap, 29, 1, 1);

--- a/L1Trigger/RegionalCaloTrigger/BuildFile.xml
+++ b/L1Trigger/RegionalCaloTrigger/BuildFile.xml
@@ -18,6 +18,8 @@
 <use   name="DataFormats/HepMCCandidate"/>
 <use   name="CalibFormats/HcalObjects"/>
 <use   name="CondFormats/RunInfo"/>
+<use   name="Geometry/Records"/>
+<use   name="Geometry/HcalTowerAlgo"/>
 <use   name="root"/>
 <export>
   <lib   name="1"/>

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTLutWriter.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTLutWriter.cc
@@ -23,6 +23,9 @@
 #include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
 #include "CondFormats/L1TObjects/interface/L1CaloEtScale.h"
 
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+
 //
 // constants, enums and typedefs
 //
@@ -175,11 +178,13 @@ L1RCTLutWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	}
 
       // HCAL
+      edm::ESHandle<HcalTrigTowerGeometry> theTrigTowerGeometry;
+      iSetup.get<CaloGeometryRecord>().get(theTrigTowerGeometry);
       for( unsigned short ieta = 1 ; ieta <= L1CaloHcalScale::nBinEta; ++ieta )
 	{
 	  for( unsigned short irank = 0 ; irank < L1CaloHcalScale::nBinRank; ++irank )
 	    {
-	      double etGeV = h_tpg->hcaletValue( ieta, irank ) ;
+	      double etGeV = h_tpg->hcaletValue( ieta, irank, *theTrigTowerGeometry ) ;
 
 	      hcalScale->setBin( irank, ieta, 1, etGeV ) ;
 	      hcalScale->setBin( irank, ieta, -1, etGeV ) ;

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTSaveInput.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTSaveInput.cc
@@ -42,6 +42,9 @@ using std::endl;
 #include "L1Trigger/RegionalCaloTrigger/interface/L1RCT.h"
 #include "L1Trigger/RegionalCaloTrigger/interface/L1RCTLookupTables.h" 
 
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
+
 L1RCTSaveInput::L1RCTSaveInput(const edm::ParameterSet& conf) :
   fileName(conf.getUntrackedParameter<std::string>("rctTestInputFile")),
   rctLookupTables(new L1RCTLookupTables),
@@ -142,12 +145,14 @@ L1RCTSaveInput::analyze(const edm::Event& event,
       std::cout << std::endl ;
 
       // HCAL
+      edm::ESHandle<HcalTrigTowerGeometry> theTrigTowerGeometry;
+      eventSetup.get<CaloGeometryRecord>().get(theTrigTowerGeometry);
       std::cout << "HCAL" << std::endl ;
       for( unsigned short ieta = 1 ; ieta <= L1CaloHcalScale::nBinEta; ++ieta )
         {
           for( unsigned short irank = 0 ; irank < L1CaloHcalScale::nBinRank; ++irank )
             {
-              double etGeV = h_tpg->hcaletValue( ieta, irank ) ;
+              double etGeV = h_tpg->hcaletValue( ieta, irank, *theTrigTowerGeometry ) ;
 
               hcalScale->setBin( irank, ieta, 1, etGeV ) ;
               hcalScale->setBin( irank, ieta, -1, etGeV ) ;

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCT.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCT.cc
@@ -164,6 +164,9 @@ void L1RCT::digiInput(const EcalTrigPrimDigiCollection& ecalCollection,
   //if (nHcalDigi != 4176){ std::cout << "L1RCT: Warning: There are " << nHcalDigi << "hcal digis instead of 4176!" << std::endl;}
   // incl HF 4032 + 144 = 4176
   for (int i = 0; i < nHcalDigi; i++){
+    if (hcalCollection[i].id().version() != 0) {
+      continue;
+    }
     short ieta = (short) hcalCollection[i].id().ieta(); 
     unsigned short absIeta = (unsigned short) abs(ieta);
     unsigned short cal_iphi = (unsigned short) hcalCollection[i].id().iphi();

--- a/L1TriggerConfig/L1ScalesProducers/BuildFile.xml
+++ b/L1TriggerConfig/L1ScalesProducers/BuildFile.xml
@@ -9,4 +9,5 @@
 <use   name="CondTools/L1Trigger"/>
 <use   name="Geometry/EcalMapping"/>
 <use   name="Geometry/HcalTowerAlgo"/>
+<use   name="Geometry/Records"/>
 <flags   EDM_PLUGIN="1"/>

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -108,6 +108,9 @@ boost::shared_ptr< L1CaloHcalScale >
 L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
+     // Version 0 of the hcal TPs is the 2012 and before running state.
+     // TODO: Add version 1 support if desired.
+	 const int version_of_hcal_TPs = 0;
  
      std:: cout << "object Key " << objectKey <<std::endl <<std::flush;
 
@@ -266,15 +269,14 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 
 	 unsigned int outputLut[1024];
 
-	 uint32_t lutId = caloTPG->getOutputLUTId(ieta,iphi);
+	 uint32_t lutId = caloTPG->getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
 
 	 double eta_low = 0., eta_high = 0.;
-	 const int version_of_hcal_TPs = 0;
 	 theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs, eta_low,eta_high); 
 	 double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
 
-	 if (!caloTPG->HTvalid(ieta, iphi)) continue;
+	 if (!caloTPG->HTvalid(ieta, iphi, version_of_hcal_TPs)) continue;
 	 double factor = 0.;
 	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs))
 	   factor = rctlsb;
@@ -318,9 +320,9 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   
 
 	   for(int iphi = 1; iphi<=72; iphi++){
-	     if(!caloTPG->HTvalid(ieta, iphi))
+	     if(!caloTPG->HTvalid(ieta, iphi, version_of_hcal_TPs))
 	       continue;
-	     uint32_t lutId = caloTPG->getOutputLUTId(ieta,iphi);
+	     uint32_t lutId = caloTPG->getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
 	     nphi++;
 	     etvalue += (double) hcaluncomp[lutId][irank];
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -269,13 +269,14 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	 uint32_t lutId = caloTPG->getOutputLUTId(ieta,iphi);
 
 	 double eta_low = 0., eta_high = 0.;
-	 theTrigTowerGeometry->towerEtaBounds(ieta,eta_low,eta_high); 
+	 const int version_of_hcal_TPs = 0;
+	 theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs, eta_low,eta_high); 
 	 double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
 
 	 if (!caloTPG->HTvalid(ieta, iphi)) continue;
 	 double factor = 0.;
-	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower())
+	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs))
 	   factor = rctlsb;
 	 else 
 	   factor = nominal_gain / cosh_ieta * lutGranularity;
@@ -283,7 +284,7 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   outputLut[k] = 0;
 	 
          for (unsigned int k = threshold; k < 1024; ++k)
-	   outputLut[k] = (abs(ieta) < theTrigTowerGeometry->firstHFTower()) ? analyticalLUT[k] : identityLUT[k];
+	   outputLut[k] = (abs(ieta) < theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs)) ? analyticalLUT[k] : identityLUT[k];
 	 
 
 	   // tpg - compressed value

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloHcalScaleConfigOnlineProd.cc
@@ -23,9 +23,9 @@
 #include "CondTools/L1Trigger/interface/L1ConfigOnlineProdBase.h"
 #include "CondFormats/L1TObjects/interface/L1CaloHcalScale.h"
 #include "CondFormats/DataRecord/interface/L1CaloHcalScaleRcd.h"
-#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
-#include "CalibCalorimetry/CaloTPG/src/CaloTPGTranscoderULUT.h"
+#include "Geometry/CaloTopology/interface/HcalTopology.h"
 #include "CondTools/L1Trigger/interface/OMDSReader.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 
 #include <cmath>
 #include <iostream>
@@ -48,16 +48,10 @@ class L1CaloHcalScaleConfigOnlineProd :
    private:
  
   L1CaloHcalScale* hcalScale;
+  HcalTopology* theTopo;
   HcalTrigTowerGeometry* theTrigTowerGeometry;
-  CaloTPGTranscoderULUT* caloTPG;
   typedef std::vector<double> RCTdecompression;
   std::vector<RCTdecompression> hcaluncomp;
-
-  //  HcaluLUTTPGCoder* tpgCoder;// = new	 HcaluLUTTPGCoder();
-
-
-  HcalTrigTowerDetId* ttDetId;
-
       // ----------member data ---------------------------
 };
 
@@ -77,11 +71,12 @@ L1CaloHcalScaleConfigOnlineProd::L1CaloHcalScaleConfigOnlineProd(
   : L1ConfigOnlineProdBase< L1CaloHcalScaleRcd, L1CaloHcalScale >( iConfig )
 {
   hcalScale = new L1CaloHcalScale(0);
-  caloTPG = new CaloTPGTranscoderULUT();
   
   HcalTopologyMode::Mode mode = HcalTopologyMode::LHC;
   int maxDepthHB = 2;
   int maxDepthHE = 3;
+  HcalTopologyMode::TriggerMode tmode = HcalTopologyMode::tm_LHC_RCT_and_1x1;
+
   if( iConfig.exists( "hcalTopologyConstants" ))
   {
     const edm::ParameterSet hcalTopoConsts = iConfig.getParameter<edm::ParameterSet>( "hcalTopologyConstants" );
@@ -89,9 +84,12 @@ L1CaloHcalScaleConfigOnlineProd::L1CaloHcalScaleConfigOnlineProd(
     mode = (HcalTopologyMode::Mode) parser.parseString(hcalTopoConsts.getParameter<std::string>("mode"));
     maxDepthHB = hcalTopoConsts.getParameter<int>("maxDepthHB");
     maxDepthHE = hcalTopoConsts.getParameter<int>("maxDepthHE");
+    StringToEnumParser<HcalTopologyMode::TriggerMode> tparser;
+    tmode = (HcalTopologyMode::TriggerMode) tparser.parseString(hcalTopoConsts.getParameter<std::string>("triggerMode"));
   }
   
-  theTrigTowerGeometry = new HcalTrigTowerGeometry( new HcalTopology( mode, maxDepthHB, maxDepthHE ));
+  theTopo = new HcalTopology( mode, maxDepthHB, maxDepthHE, tmode);
+  theTrigTowerGeometry = new HcalTrigTowerGeometry(theTopo);
 }
 
 
@@ -100,8 +98,9 @@ L1CaloHcalScaleConfigOnlineProd::~L1CaloHcalScaleConfigOnlineProd()
   // do anything here that needs to be done at desctruction time
   // (e.g. close files, deallocate resources etc.)
 
-  if(caloTPG != 0)
-    delete caloTPG;
+  if (theTopo!=0)
+    delete theTopo;
+  if (theTrigTowerGeometry!=0) delete theTrigTowerGeometry;
 }
 
 boost::shared_ptr< L1CaloHcalScale >
@@ -109,8 +108,8 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 {
      using namespace edm::es;
      // Version 0 of the hcal TPs is the 2012 and before running state.
-     // TODO: Add version 1 support if desired.
-	 const int version_of_hcal_TPs = 0;
+     // TODO: Add version 1 support 
+     const int version_of_hcal_TPs = 0;
  
      std:: cout << "object Key " << objectKey <<std::endl <<std::flush;
 
@@ -154,18 +153,18 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
      metaStrings.push_back("NOMINAL_GAIN");  
    
  
-    l1t::OMDSReader::QueryResults paramResults =
+     l1t::OMDSReader::QueryResults paramResults =
        m_omdsReader.basicQueryView( metaStrings,
                                 "CMS_HCL_HCAL_COND",
-                                "V_HCAL_LUT_METADATA_V1",
-                                "V_HCAL_LUT_METADATA_V1.TAG_NAME",
-				m_omdsReader.basicQuery(
-							"HCAL_LUT_METADATA",
-							"CMS_RCT",
-							"HCAL_SCALE_KEY",
-							"HCAL_SCALE_KEY.HCAL_TAG",
-							m_omdsReader.singleAttribute(objectKey)));
-    
+				    "V_HCAL_LUT_METADATA_V1",
+				    "V_HCAL_LUT_METADATA_V1.TAG_NAME",
+				    m_omdsReader.basicQuery(
+							    "HCAL_LUT_METADATA",
+							    "CMS_RCT",
+							    "HCAL_SCALE_KEY",
+							    "HCAL_SCALE_KEY.HCAL_TAG",
+							    m_omdsReader.singleAttribute(objectKey)));
+     
 
     
     
@@ -209,13 +208,13 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 
 		 
    
-     std::vector< std::string >::const_iterator it = channelStrings.begin() ;
-     std::vector< std::string >::const_iterator end = channelStrings.end() ;
-     for( ; it != end ; ++it )
-       {
-         query->addToOutputList( *it ) ;
-       }
-
+    std::vector< std::string >::const_iterator it = channelStrings.begin() ;
+    std::vector< std::string >::const_iterator end = channelStrings.end() ;
+    for( ; it != end ; ++it )
+      {
+	query->addToOutputList( *it ) ;
+      }
+    
     std::string ob = "OBJECTNAME";
     coral::AttributeList myresult; 
     myresult.extend("IPHI", typeid(int)); 
@@ -268,15 +267,17 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	 
 
 	 unsigned int outputLut[1024];
+	 HcalTrigTowerDetId detid(ieta,iphi);
+	 detid.setVersion(version_of_hcal_TPs);
 
-	 uint32_t lutId = caloTPG->getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
+	 if (!theTopo->validHT(detid)) continue;
+	 
+	 uint32_t lutId = theTopo->detId2denseId(detid);
 
 	 double eta_low = 0., eta_high = 0.;
 	 theTrigTowerGeometry->towerEtaBounds(ieta,version_of_hcal_TPs, eta_low,eta_high); 
 	 double cosh_ieta = fabs(cosh((eta_low + eta_high)/2.));
 
-
-	 if (!caloTPG->HTvalid(ieta, iphi, version_of_hcal_TPs)) continue;
 	 double factor = 0.;
 	 if (abs(ieta) >= theTrigTowerGeometry->firstHFTower(version_of_hcal_TPs))
 	   factor = rctlsb;
@@ -320,9 +321,11 @@ L1CaloHcalScaleConfigOnlineProd::newObject( const std::string& objectKey )
 	   
 
 	   for(int iphi = 1; iphi<=72; iphi++){
-	     if(!caloTPG->HTvalid(ieta, iphi, version_of_hcal_TPs))
+	     HcalTrigTowerDetId id;
+	     id.setVersion(version_of_hcal_TPs);
+	     if(!theTopo->validHT(id))
 	       continue;
-	     uint32_t lutId = caloTPG->getOutputLUTId(ieta, iphi, version_of_hcal_TPs);
+	     uint32_t lutId = theTopo->detId2denseId(id);
 	     nphi++;
 	     etvalue += (double) hcaluncomp[lutId][irank];
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScaleTester.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScaleTester.cc
@@ -26,6 +26,8 @@ using std::setprecision;
 #include "CondFormats/DataRecord/interface/L1CaloHcalScaleRcd.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 
 //
 // constants, enums and typedefs
@@ -189,14 +191,17 @@ L1CaloInputScaleTester::analyze(const edm::Event& iEvent, const edm::EventSetup&
 
    // compare the hcal scales
 
+
+   edm::ESHandle<HcalTrigTowerGeometry> theTrigTowerGeometry;
+   iSetup.get<CaloGeometryRecord>().get(theTrigTowerGeometry);
    for (unsigned short input = 0; input <= 0xFF; input++)
      {
        // loop over ietas
        for (unsigned short absIeta = 1; absIeta <= 32; absIeta++)
 	 {
-	   hcal1 = caloTPGTranscoder->hcaletValue(absIeta, input); // no eta-
+	   hcal1 = caloTPGTranscoder->hcaletValue(absIeta, input, *theTrigTowerGeometry); // no eta-
 	   hcal2 = caloHcalScale->et(input, absIeta, 1); // sign in transcoder
-	   hcal3 = caloTPGTranscoder->hcaletValue(-absIeta, input); // no eta-
+	   hcal3 = caloTPGTranscoder->hcaletValue(-absIeta, input, *theTrigTowerGeometry); // no eta-
 	   hcal4 = caloHcalScale->et(input, absIeta,-1); // sign in transcoder
 
 

--- a/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesGenerator.cc
+++ b/L1TriggerConfig/L1ScalesProducers/src/L1CaloInputScalesGenerator.cc
@@ -25,6 +25,8 @@ using std::ofstream;
 #include "CalibCalorimetry/EcalTPGTools/interface/EcalTPGScale.h"
 #include "DataFormats/EcalDetId/interface/EcalTrigTowerDetId.h"
 
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 
 //
 // constants, enums and typedefs
@@ -161,13 +163,14 @@ L1CaloInputScalesGenerator::analyze(const edm::Event& iEvent, const edm::EventSe
      scalesFile << endl << "\tL1HcalEtThresholdsPositiveEta = cms.vdouble(" << endl;
 
    // loop over ietas
-
+   edm::ESHandle<HcalTrigTowerGeometry> theTrigTowerGeometry;
+   iSetup.get<CaloGeometryRecord>().get(theTrigTowerGeometry);
      nEntries=0;
    for (unsigned short absIeta = 1; absIeta <= 32; absIeta++)
      {
        for (unsigned short input = 0; input <= 0xFF; input++)
 	 {
-	   output = caloTPGTranscoder->hcaletValue(absIeta, input); 
+	   output = caloTPGTranscoder->hcaletValue(absIeta, input, *theTrigTowerGeometry); 
 	   scalesFile << setprecision (8) << output ;
 	   nEntries++;
 
@@ -199,7 +202,7 @@ L1CaloInputScalesGenerator::analyze(const edm::Event& iEvent, const edm::EventSe
      {
        for (unsigned short input = 0; input <= 0xFF; input++)
 	 {
-	   output = caloTPGTranscoder->hcaletValue(-absIeta, input); 
+	   output = caloTPGTranscoder->hcaletValue(-absIeta, input, *theTrigTowerGeometry); 
 	   scalesFile << setprecision (8) << output ;
 	   nEntries++;
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
@@ -1,0 +1,15 @@
+#ifndef SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureBit_h_included
+#define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureBit_h_included 1
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+class HcalFeatureBit {
+	public:
+		HcalFeatureBit(){}
+		virtual ~HcalFeatureBit(){} //the virutal function is responcible for applying a cut based on a linear relationship of the energy
+        //deposited in the short vers long fibers.
+		virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const {return false;}
+		
+};
+#endif
+

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
@@ -6,8 +6,9 @@
 class HcalFeatureBit {
 	public:
 		HcalFeatureBit(){}
-		virtual ~HcalFeatureBit(){} // needs to be virtual to avoid memory leaks
-		virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int ADCLong, HcalDetId Lid ){return false;}
+		virtual ~HcalFeatureBit(){} //the virutal function is responcible for applying a cut based on a linear relationship of the energy
+        //deposited in the short vers long fibers.
+		virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const {return false;}
 		
 };
 #endif

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h
@@ -1,0 +1,14 @@
+#ifndef SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureBit_h_included
+#define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureBit_h_included 1
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+class HcalFeatureBit {
+	public:
+		HcalFeatureBit(){}
+		virtual ~HcalFeatureBit(){} // needs to be virtual to avoid memory leaks
+		virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int ADCLong, HcalDetId Lid ){return false;}
+		
+};
+#endif
+

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -1,0 +1,18 @@
+#ifndef SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included
+#define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included 1
+
+
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+
+class HcalFeatureHFEMBit : public HcalFeatureBit {
+public:    
+    HcalFeatureHFEMBit(double ShortMinE, double LongMinE, double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions);
+    ~HcalFeatureHFEMBit();
+    virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const;//cuts based on energy 
+    //depoisted in the long and short fibers
+private:
+    double ShortMinE_, LongMinE_, ShortLongCutSlope_, ShortLongCutOffset_;
+    const HcalDbService& conditions_;
+};
+#endif

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -6,10 +6,10 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 
 class HcalFeatureHFEMBit : public HcalFeatureBit {
-public:
+public:    
     HcalFeatureHFEMBit(double ShortMinE, double LongMinE, double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions);
     ~HcalFeatureHFEMBit();
-    virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const;//cuts based on energy
+    virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const;//cuts based on energy 
     //depoisted in the long and short fibers
 private:
     double ShortMinE_, LongMinE_, ShortLongCutSlope_, ShortLongCutOffset_;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h
@@ -1,0 +1,18 @@
+#ifndef SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included
+#define SimCalorimetry_HcalTPGAlgos_interface_HcalFeatureHFEMBit_h_included 1
+
+
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureBit.h"
+#include "CalibFormats/HcalObjects/interface/HcalDbService.h"
+
+class HcalFeatureHFEMBit : public HcalFeatureBit {
+public:
+    HcalFeatureHFEMBit(double ShortMinE, double LongMinE, double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions);
+    ~HcalFeatureHFEMBit();
+    virtual bool fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const;//cuts based on energy
+    //depoisted in the long and short fibers
+private:
+    double ShortMinE_, LongMinE_, ShortLongCutSlope_, ShortLongCutOffset_;
+    const HcalDbService& conditions_;
+};
+#endif

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -49,7 +49,10 @@ public:
 
   /// adds the actual RecHits
   void analyze(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result);
+  // Version 0: RCT
   void analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, float rctlsb);
+  // Version 1: 1x1
+  void analyzeHFV1(const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);
 
    // Member initialized by constructor
   const HcaluLUTTPGCoder* incoder_;
@@ -79,6 +82,13 @@ public:
 
   typedef std::map<HcalTrigTowerDetId, IntegerCaloSamples> SumMap;
   SumMap theSumMap;  
+
+  struct HFDetails {
+      IntegerCaloSamples long_fiber;
+      IntegerCaloSamples short_fiber;
+  };
+  typedef std::map<HcalTrigTowerDetId, HFDetails> HFDetailMap;
+  HFDetailMap theHFDetailMap;
   
   typedef std::vector<IntegerCaloSamples> SumFGContainer;
   typedef std::map< HcalTrigTowerDetId, SumFGContainer > TowerMapFGSum;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -50,9 +50,13 @@ public:
   /// adds the actual RecHits
   void analyze(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result);
   // Version 0: RCT
-  void analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, float rctlsb);
+  void analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, const int hf_lumi_shift);
   // Version 1: 1x1
-  void analyzeHFV1(const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result);
+  void analyzeHFV1(
+          const IntegerCaloSamples& SAMPLES,
+          HcalTriggerPrimitiveDigi& result,
+          const int HF_LUMI_SHIFT
+          );
 
    // Member initialized by constructor
   const HcaluLUTTPGCoder* incoder_;

--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -6,11 +6,12 @@
 #include "Geometry/HcalTowerAlgo/interface/HcalTrigTowerGeometry.h"
 #include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 #include "CalibFormats/CaloObjects/interface/IntegerCaloSamples.h"
-//#include "CalibFormats/HcalObjects/interface/HcalTPGCoder.h"
+
 #include "CalibCalorimetry/HcalTPGAlgos/interface/HcaluLUTTPGCoder.h"
 #include "CalibFormats/CaloTPG/interface/HcalTPGCompressor.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"//cuts based on short and long energy deposited.
 
 #include <map>
 #include <vector>
@@ -32,7 +33,7 @@ public:
            const HFDigiCollection& hfDigis,
            HcalTrigPrimDigiCollection& result,
 	   const HcalTrigTowerGeometry* trigTowerGeometry,
-           float rctlsb);
+           float rctlsb, const HcalFeatureBit* LongvrsShortCut=0);
 
   void runZS(HcalTrigPrimDigiCollection& tp);
   void runFEFormatError(const FEDRawDataCollection* rawraw,
@@ -55,7 +56,8 @@ public:
   void analyzeHFV1(
           const IntegerCaloSamples& SAMPLES,
           HcalTriggerPrimitiveDigi& result,
-          const int HF_LUMI_SHIFT
+          const int HF_LUMI_SHIFT,
+          const HcalFeatureBit* HCALFEM
           );
 
    // Member initialized by constructor
@@ -90,6 +92,8 @@ public:
   struct HFDetails {
       IntegerCaloSamples long_fiber;
       IntegerCaloSamples short_fiber;
+      HFDataFrame ShortDigi;
+      HFDataFrame LongDigi;
   };
   typedef std::map<HcalTrigTowerDetId, HFDetails> HFDetailMap;
   HFDetailMap theHFDetailMap;
@@ -107,6 +111,7 @@ public:
   //  else VetoedSum = Sum; 
   // ==============================
   // Map from FG id to veto booleans
+  HcalFeatureBit* LongvrsShortCut;
   typedef std::map<uint32_t, std::vector<bool> > TowerMapVeto;
   TowerMapVeto HF_Veto;
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
@@ -1,0 +1,68 @@
+
+//HcalFeatureHFEMBit
+//version 2.0
+
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"
+#include "CondFormats/HcalObjects/interface/HcalQIECoder.h"
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+
+
+HcalFeatureHFEMBit::HcalFeatureHFEMBit(double ShortMinE, double LongMinE,
+        double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions) : conditions_(conditions)
+{
+    ShortMinE_ = ShortMinE; //minimum energy deposited
+    LongMinE_ = LongMinE;
+    ShortLongCutSlope_ = ShortLongCutSlope; // this is a the slope of the cut line related to energy deposited in short fibers vrs long fibers
+    ShortLongCutOffset_ = ShortLongCutOffset; // this is the offset of said line.
+
+
+
+}
+
+HcalFeatureHFEMBit::~HcalFeatureHFEMBit() { }
+
+bool HcalFeatureHFEMBit::fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const//pass det id
+{
+
+    float ShortE = 0; //holds deposited energy
+    float LongE = 0;
+
+
+    HcalQIESample sQIESample(ADCShort, CapIdS, 1, 1);
+    //makes a QIE sample for the short fiber.
+    HFDataFrame shortf(Sid);
+    shortf.setSize(1); //not planning on there being anything else here at this point in time so setting the size to 1 shouldn't matter
+    shortf.setSample(0, sQIESample); //inputs data into digi.
+    const HcalCalibrations& calibrations = conditions_.getHcalCalibrations(Sid);
+    const HcalQIECoder* channelCoderS = conditions_.getHcalCoder(Sid);
+    const HcalQIEShape* shapeS = conditions_.getHcalShape(channelCoderS);
+
+    HcalCoderDb coders(*channelCoderS, *shapeS);
+
+    CaloSamples tools;
+    coders.adc2fC(shortf, tools);
+    ShortE = (tools[0] - calibrations.pedestal(CapIdS)) * calibrations.respcorrgain(CapIdS);
+
+    HcalQIESample lQIESample(ADCLong, CapIdL, 1, 1);
+    HFDataFrame longf(Lid);
+    longf.setSize(1);
+    longf.setSample(0, lQIESample);
+    const HcalCalibrations& calibrationL = conditions_.getHcalCalibrations(Lid);
+
+    CaloSamples tool_l;
+
+    const HcalQIECoder* channelCoderL = conditions_.getHcalCoder(Lid);
+    const HcalQIEShape* shapeL = conditions_.getHcalShape(channelCoderL);
+
+    HcalCoderDb coderL(*channelCoderL, *shapeL);
+
+    coderL.adc2fC(longf, tool_l); // this fills tool_l[0] with linearized adc
+    LongE = (tool_l[0] - calibrationL.pedestal(CapIdL)) * calibrationL.respcorrgain(CapIdL);
+
+    
+    // this actually does the cut
+    if((ShortE < ((LongE)-(ShortLongCutOffset_)) * ShortLongCutSlope_) && LongE > LongMinE_ && ShortE > ShortMinE_) return true;
+    else return false;
+}
+
+

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
@@ -7,6 +7,7 @@
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 
 
+
 HcalFeatureHFEMBit::HcalFeatureHFEMBit(double ShortMinE, double LongMinE,
                                        double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions) : conditions_(conditions)
 {

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
@@ -7,9 +7,8 @@
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
 
 
-
 HcalFeatureHFEMBit::HcalFeatureHFEMBit(double ShortMinE, double LongMinE,
-                                       double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions) : conditions_(conditions)
+        double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions) : conditions_(conditions)
 {
     ShortMinE_ = ShortMinE; //minimum energy deposited
     LongMinE_ = LongMinE;
@@ -60,7 +59,7 @@ bool HcalFeatureHFEMBit::fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, i
     coderL.adc2fC(longf, tool_l); // this fills tool_l[0] with linearized adc
     LongE = (tool_l[0] - calibrationL.pedestal(CapIdL)) * calibrationL.respcorrgain(CapIdL);
 
-
+    
     // this actually does the cut
     if((ShortE < ((LongE)-(ShortLongCutOffset_)) * ShortLongCutSlope_) && LongE > LongMinE_ && ShortE > ShortMinE_) return true;
     else return false;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalFeatureHFEMBit.cc
@@ -1,0 +1,68 @@
+
+//HcalFeatureHFEMBit
+//version 2.0
+
+#include "SimCalorimetry/HcalTrigPrimAlgos/interface/HcalFeatureHFEMBit.h"
+#include "CondFormats/HcalObjects/interface/HcalQIECoder.h"
+#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
+
+
+HcalFeatureHFEMBit::HcalFeatureHFEMBit(double ShortMinE, double LongMinE,
+                                       double ShortLongCutSlope, double ShortLongCutOffset, const HcalDbService& conditions) : conditions_(conditions)
+{
+    ShortMinE_ = ShortMinE; //minimum energy deposited
+    LongMinE_ = LongMinE;
+    ShortLongCutSlope_ = ShortLongCutSlope; // this is a the slope of the cut line related to energy deposited in short fibers vrs long fibers
+    ShortLongCutOffset_ = ShortLongCutOffset; // this is the offset of said line.
+
+
+
+}
+
+HcalFeatureHFEMBit::~HcalFeatureHFEMBit() { }
+
+bool HcalFeatureHFEMBit::fineGrainbit(int ADCShort, HcalDetId Sid, int CapIdS, int ADCLong, HcalDetId Lid, int CapIdL) const//pass det id
+{
+
+    float ShortE = 0; //holds deposited energy
+    float LongE = 0;
+
+
+    HcalQIESample sQIESample(ADCShort, CapIdS, 1, 1);
+    //makes a QIE sample for the short fiber.
+    HFDataFrame shortf(Sid);
+    shortf.setSize(1); //not planning on there being anything else here at this point in time so setting the size to 1 shouldn't matter
+    shortf.setSample(0, sQIESample); //inputs data into digi.
+    const HcalCalibrations& calibrations = conditions_.getHcalCalibrations(Sid);
+    const HcalQIECoder* channelCoderS = conditions_.getHcalCoder(Sid);
+    const HcalQIEShape* shapeS = conditions_.getHcalShape(channelCoderS);
+
+    HcalCoderDb coders(*channelCoderS, *shapeS);
+
+    CaloSamples tools;
+    coders.adc2fC(shortf, tools);
+    ShortE = (tools[0] - calibrations.pedestal(CapIdS)) * calibrations.respcorrgain(CapIdS);
+
+    HcalQIESample lQIESample(ADCLong, CapIdL, 1, 1);
+    HFDataFrame longf(Lid);
+    longf.setSize(1);
+    longf.setSample(0, lQIESample);
+    const HcalCalibrations& calibrationL = conditions_.getHcalCalibrations(Lid);
+
+    CaloSamples tool_l;
+
+    const HcalQIECoder* channelCoderL = conditions_.getHcalCoder(Lid);
+    const HcalQIEShape* shapeL = conditions_.getHcalShape(channelCoderL);
+
+    HcalCoderDb coderL(*channelCoderL, *shapeL);
+
+    coderL.adc2fC(longf, tool_l); // this fills tool_l[0] with linearized adc
+    LongE = (tool_l[0] - calibrationL.pedestal(CapIdL)) * calibrationL.respcorrgain(CapIdL);
+
+
+    // this actually does the cut
+    if((ShortE < ((LongE)-(ShortLongCutOffset_)) * ShortLongCutSlope_) && LongE > LongMinE_ && ShortE > ShortMinE_) return true;
+    else return false;
+}
+
+

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -401,10 +401,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHFV1(
 
         if(HCALFEM != 0)
         {
-
-           
             finegrain[ibin] = HCALFEM->fineGrainbit(ADCShort, HF_DETAILS->ShortDigi.id(), HF_DETAILS->ShortDigi[ibin].capid(), ADCLong, HF_DETAILS->LongDigi.id(), HF_DETAILS->LongDigi[ibin].capid());
-            
         }
     }
     outcoder_->compress(output, finegrain, result);

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -72,8 +72,8 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
    for(SumMap::iterator mapItr = theSumMap.begin(); mapItr != theSumMap.end(); ++mapItr) {
       result.push_back(HcalTriggerPrimitiveDigi(mapItr->first));
       HcalTrigTowerDetId detId(mapItr->second.id());
-      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower())
-         { analyzeHF(mapItr->second, result.back(), rctlsb);}
+      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower(detId.version()))
+	{ analyzeHF(mapItr->second, result.back(), rctlsb);} // need to add version-dependency here!
          else{analyze(mapItr->second, result.back());}
    }
    return;

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -405,6 +405,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHFV1(
         }
     }
     outcoder_->compress(output, finegrain, result);
+    
 }
 
 void HcalTriggerPrimitiveAlgo::runZS(HcalTrigPrimDigiCollection & result){

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -55,6 +55,7 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
    theTowerMapFGSum.clear();
    HF_Veto.clear();
    fgMap_.clear();
+   theHFDetailMap.clear();
 
    // do the HB/HE digis
    for(HBHEDigiCollection::const_iterator hbheItr = hbheDigis.begin();
@@ -72,15 +73,33 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
    for(SumMap::iterator mapItr = theSumMap.begin(); mapItr != theSumMap.end(); ++mapItr) {
       result.push_back(HcalTriggerPrimitiveDigi(mapItr->first));
       HcalTrigTowerDetId detId(mapItr->second.id());
-      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower(detId.version()))
-	{ analyzeHF(mapItr->second, result.back(), rctlsb);} // need to add version-dependency here!
-         else{analyze(mapItr->second, result.back());}
+      if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower(detId.version())) { 
+         if (detId.version() == 0) {
+            analyzeHF(mapItr->second, result.back(), rctlsb);
+         } else if (detId.version() == 1) {
+            analyzeHFV1(mapItr->second, result.back());
+         } else {
+            // Things are going to go poorly
+         }
+      }
+      else { 
+         analyze(mapItr->second, result.back());
+      }
    }
+
+   // Free up some memory
+   theSumMap.clear();
+   theTowerMapFGSum.clear();
+   HF_Veto.clear();
+   fgMap_.clear();
+   theHFDetailMap.clear();
+
    return;
 }
 
 
 void HcalTriggerPrimitiveAlgo::addSignal(const HBHEDataFrame & frame) {
+   // TODO: Need to add support for seperate 28, 29 in HE
    //Hack for 300_pre10, should be removed.
    if (frame.id().depth()==5) return;
 
@@ -113,53 +132,85 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HBHEDataFrame & frame) {
 void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
    if(frame.id().depth() == 1 || frame.id().depth() == 2) {
       std::vector<HcalTrigTowerDetId> ids = theTrigTowerGeometry->towerIds(frame.id());
-      assert(ids.size() == 1);
-      IntegerCaloSamples samples(ids[0], frame.size());
-      samples.setPresamples(frame.presamples());
-      incoder_->adc2Linear(frame, samples);
+      std::vector<HcalTrigTowerDetId>::const_iterator it;
+      for (it = ids.begin(); it != ids.end(); ++it) {
+         HcalTrigTowerDetId trig_tower_id = *it;
+         IntegerCaloSamples samples(trig_tower_id, frame.size());
+         samples.setPresamples(frame.presamples());
+         incoder_->adc2Linear(frame, samples);
 
-      // Don't add to final collection yet
-      // HF PMT veto sum is calculated in analyzerHF()
-      IntegerCaloSamples zero_samples(ids[0], frame.size());
-      zero_samples.setPresamples(frame.presamples());
-      addSignal(zero_samples);
+         // Don't add to final collection yet
+         // HF PMT veto sum is calculated in analyzerHF()
+         IntegerCaloSamples zero_samples(trig_tower_id, frame.size());
+         zero_samples.setPresamples(frame.presamples());
+         addSignal(zero_samples);
 
-      // Mask off depths: fgid is the same for both depths
-      const uint32_t FGID_MASK = 0x1c000;  // Binary: 11100000000000000
-      uint32_t fgid = (frame.id().rawId() | FGID_MASK);
+         // Pre-LS1 Configuration
+         if (trig_tower_id.version() == 0) {
+            // Mask off depths: fgid is the same for both depths
+            const uint32_t FGID_MASK = 0x1c000;  // Binary: 11100000000000000
+            uint32_t fgid = (frame.id().rawId() | FGID_MASK);
 
-      if ( theTowerMapFGSum.find(ids[0]) == theTowerMapFGSum.end() ) {
-         SumFGContainer sumFG;
-         theTowerMapFGSum.insert(std::pair<HcalTrigTowerDetId, SumFGContainer>(ids[0], sumFG));
-      }
+            if ( theTowerMapFGSum.find(trig_tower_id) == theTowerMapFGSum.end() ) {
+               SumFGContainer sumFG;
+               theTowerMapFGSum.insert(std::pair<HcalTrigTowerDetId, SumFGContainer>(trig_tower_id, sumFG));
+            }
 
-      SumFGContainer& sumFG = theTowerMapFGSum[ids[0]];
-      SumFGContainer::iterator sumFGItr;
-      for ( sumFGItr = sumFG.begin(); sumFGItr != sumFG.end(); ++sumFGItr) {
-         if (sumFGItr->id() == fgid) { break; }
-      }
-      // If find
-      if (sumFGItr != sumFG.end()) {
-         for (int i=0; i<samples.size(); ++i) {
-            (*sumFGItr)[i] += samples[i];
+            SumFGContainer& sumFG = theTowerMapFGSum[trig_tower_id];
+            SumFGContainer::iterator sumFGItr;
+            for ( sumFGItr = sumFG.begin(); sumFGItr != sumFG.end(); ++sumFGItr) {
+               if (sumFGItr->id() == fgid) { break; }
+            }
+            // If find
+            if (sumFGItr != sumFG.end()) {
+               for (int i=0; i<samples.size(); ++i) {
+                  (*sumFGItr)[i] += samples[i];
+               }
+            }
+            else {
+               //Copy samples (change to fgid)
+               IntegerCaloSamples sumFGSamples(DetId(fgid), samples.size());
+               sumFGSamples.setPresamples(samples.presamples());
+               for (int i=0; i<samples.size(); ++i) {
+                  sumFGSamples[i] = samples[i];
+               }
+               sumFG.push_back(sumFGSamples);
+            }
+
+            // set veto to true if Long or Short less than threshold
+            if (HF_Veto.find(fgid) == HF_Veto.end()) {
+               vector<bool> vetoBits(samples.size(), false);
+               HF_Veto[fgid] = vetoBits;
+            }
+            for (int i=0; i<samples.size(); ++i) {
+               if (samples[i] < minSignalThreshold_) {
+                  HF_Veto[fgid][i] = true;
+               }
+            }
          }
-      }
-      else {
-         //Copy samples (change to fgid)
-         IntegerCaloSamples sumFGSamples(DetId(fgid), samples.size());
-         sumFGSamples.setPresamples(samples.presamples());
-         for (int i=0; i<samples.size(); ++i) sumFGSamples[i] = samples[i];
-         sumFG.push_back(sumFGSamples);
-      }
+         // HF 1x1
+         else if (trig_tower_id.version() == 1) {
+            // Check if the entry exists, if not add
+            HFDetailMap::iterator dit = theHFDetailMap.find(trig_tower_id);
+            if ( dit == theHFDetailMap.end() ) {
+               HFDetails hf_detail;
+               theHFDetailMap.insert(std::make_pair(trig_tower_id, hf_detail));
+               dit = theHFDetailMap.find(trig_tower_id);
+            }
 
-      // set veto to true if Long or Short less than threshold
-      if (HF_Veto.find(fgid) == HF_Veto.end()) {
-         vector<bool> vetoBits(samples.size(), false);
-         HF_Veto[fgid] = vetoBits;
-      }
-      for (int i=0; i<samples.size(); ++i) {
-         if (samples[i] < minSignalThreshold_) {
-            HF_Veto[fgid][i] = true;
+            // Check the frame type to determine long vs short
+            if (frame.id().depth() == 1) { // Long
+               dit->second.long_fiber = samples;
+            } else if (frame.id().depth() == 2) { // Short
+               dit->second.short_fiber = samples;
+            } else {
+                // Neither long nor short... So we have no idea what to do
+                return;
+            }
+         }
+         // Uh oh, we are in a bad/unknown state! Things will start crashing.
+         else {
+             return;
          }
       }
    }
@@ -288,6 +339,42 @@ void HcalTriggerPrimitiveAlgo::analyzeHF(IntegerCaloSamples & samples, HcalTrigg
       if (output[ibin] > 0x3FF) output[ibin] = 0x3FF;
    }
    outcoder_->compress(output, finegrain, result);
+}
+
+void HcalTriggerPrimitiveAlgo::analyzeHFV1(const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result) {
+    // Align digis and TP
+    const int SHIFT = samples.presamples() - numberOfPresamples_;
+    assert(SHIFT >= 0);
+    assert((SHIFT + numberOfSamples_) <= samples.size());
+
+    // Try to find the HFDetails from the map corresponding to our samples
+    const HcalTrigTowerDetId detId(samples.id());
+    HFDetailMap::const_iterator it = theHFDetailMap.find(detId);
+    // Missing values will give an empty digi
+    if (it == theHFDetailMap.end()) {
+        return;
+    }
+    const HFDetails* HF_DETAILS = &(it->second);
+
+    std::vector<bool> finegrain(numberOfSamples_, false);
+
+    // Set up out output of IntergerCaloSamples
+    IntegerCaloSamples output(samples.id(), numberOfSamples_);
+    output.setPresamples(numberOfPresamples_);
+    for (int ibin = 0; ibin < numberOfSamples_; ++ibin) {
+        const int IDX = ibin + SHIFT;
+        int long_fiber_val = 0;
+        if (IDX < HF_DETAILS->long_fiber.size()) {
+            long_fiber_val = HF_DETAILS->long_fiber[IDX];
+        }
+        int short_fiber_val = 0;
+        if (IDX < HF_DETAILS->short_fiber.size()) {
+            short_fiber_val = HF_DETAILS->long_fiber[IDX];
+        }
+        output[ibin] = long_fiber_val + short_fiber_val;
+        // TODO: Do EM fine grain bit algo (still in development)
+    }
+    outcoder_->compress(output, finegrain, result);
 }
 
 void HcalTriggerPrimitiveAlgo::runZS(HcalTrigPrimDigiCollection & result){

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -70,14 +70,22 @@ void HcalTriggerPrimitiveAlgo::run(const HcalTPGCoder* incoder,
 
    }
 
+   // VME produces additional bits on the front used by lumi but not the
+   // trigger, this shift corrects those out by right shifting over them.
+   int hf_lumi_shift = 0;
+   if (0.2 <= rctlsb && rctlsb < 0.3) {
+      hf_lumi_shift = 2;
+   } else if (0.3 <= rctlsb) {
+      hf_lumi_shift = 3;
+   }
    for(SumMap::iterator mapItr = theSumMap.begin(); mapItr != theSumMap.end(); ++mapItr) {
       result.push_back(HcalTriggerPrimitiveDigi(mapItr->first));
       HcalTrigTowerDetId detId(mapItr->second.id());
       if(detId.ietaAbs() >= theTrigTowerGeometry->firstHFTower(detId.version())) { 
          if (detId.version() == 0) {
-            analyzeHF(mapItr->second, result.back(), rctlsb);
+            analyzeHF(mapItr->second, result.back(), hf_lumi_shift);
          } else if (detId.version() == 1) {
-            analyzeHFV1(mapItr->second, result.back());
+            analyzeHFV1(mapItr->second, result.back(), hf_lumi_shift);
          } else {
             // Things are going to go poorly
          }
@@ -303,7 +311,7 @@ void HcalTriggerPrimitiveAlgo::analyze(IntegerCaloSamples & samples, HcalTrigger
 }
 
 
-void HcalTriggerPrimitiveAlgo::analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, float rctlsb) {
+void HcalTriggerPrimitiveAlgo::analyzeHF(IntegerCaloSamples & samples, HcalTriggerPrimitiveDigi & result, const int hf_lumi_shift) {
    std::vector<bool> finegrain(numberOfSamples_, false);
    HcalTrigTowerDetId detId(samples.id());
 
@@ -335,20 +343,25 @@ void HcalTriggerPrimitiveAlgo::analyzeHF(IntegerCaloSamples & samples, HcalTrigg
 
    for (int ibin = 0; ibin < numberOfSamples_; ++ibin) {
       int idx = ibin + shift;
-      output[ibin] = samples[idx] / (rctlsb == 0.25 ? 4 : 8);
-      if (output[ibin] > 0x3FF) output[ibin] = 0x3FF;
+      output[ibin] = samples[idx] >> hf_lumi_shift;
+      static const int MAX_OUTPUT = 0x3FF;  // 0x3FF = 1023
+      if (output[ibin] > MAX_OUTPUT) output[ibin] = MAX_OUTPUT;
    }
    outcoder_->compress(output, finegrain, result);
 }
 
-void HcalTriggerPrimitiveAlgo::analyzeHFV1(const IntegerCaloSamples& samples, HcalTriggerPrimitiveDigi& result) {
+void HcalTriggerPrimitiveAlgo::analyzeHFV1(
+        const IntegerCaloSamples& SAMPLES,
+        HcalTriggerPrimitiveDigi& result,
+        const int HF_LUMI_SHIFT
+        ) {
     // Align digis and TP
-    const int SHIFT = samples.presamples() - numberOfPresamples_;
+    const int SHIFT = SAMPLES.presamples() - numberOfPresamples_;
     assert(SHIFT >= 0);
-    assert((SHIFT + numberOfSamples_) <= samples.size());
+    assert((SHIFT + numberOfSamples_) <= SAMPLES.size());
 
     // Try to find the HFDetails from the map corresponding to our samples
-    const HcalTrigTowerDetId detId(samples.id());
+    const HcalTrigTowerDetId detId(SAMPLES.id());
     HFDetailMap::const_iterator it = theHFDetailMap.find(detId);
     // Missing values will give an empty digi
     if (it == theHFDetailMap.end()) {
@@ -359,7 +372,7 @@ void HcalTriggerPrimitiveAlgo::analyzeHFV1(const IntegerCaloSamples& samples, Hc
     std::vector<bool> finegrain(numberOfSamples_, false);
 
     // Set up out output of IntergerCaloSamples
-    IntegerCaloSamples output(samples.id(), numberOfSamples_);
+    IntegerCaloSamples output(SAMPLES.id(), numberOfSamples_);
     output.setPresamples(numberOfPresamples_);
     for (int ibin = 0; ibin < numberOfSamples_; ++ibin) {
         const int IDX = ibin + SHIFT;
@@ -371,8 +384,12 @@ void HcalTriggerPrimitiveAlgo::analyzeHFV1(const IntegerCaloSamples& samples, Hc
         if (IDX < HF_DETAILS->short_fiber.size()) {
             short_fiber_val = HF_DETAILS->long_fiber[IDX];
         }
-        output[ibin] = long_fiber_val + short_fiber_val;
-        // TODO: Do EM fine grain bit algo (still in development)
+        output[ibin] = (long_fiber_val + short_fiber_val) >> HF_LUMI_SHIFT;
+        static const int MAX_OUTPUT = 0x3FF;  // 0x3FF = 1023
+        if (output[ibin] > MAX_OUTPUT) {
+            output[ibin] = MAX_OUTPUT;
+        }
+        // TODO for Lesko: Do EM fine grain bit algo
     }
     outcoder_->compress(output, finegrain, result);
 }

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -111,7 +111,6 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HBHEDataFrame & frame) {
 
 
 void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
-
    if(frame.id().depth() == 1 || frame.id().depth() == 2) {
       std::vector<HcalTrigTowerDetId> ids = theTrigTowerGeometry->towerIds(frame.id());
       assert(ids.size() == 1);
@@ -126,21 +125,24 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
       addSignal(zero_samples);
 
       // Mask off depths: fgid is the same for both depths
-      uint32_t fgid = (frame.id().rawId() | 0x1c000) ;
+      const uint32_t FGID_MASK = 0x1c000;  // Binary: 11100000000000000
+      uint32_t fgid = (frame.id().rawId() | FGID_MASK);
 
       if ( theTowerMapFGSum.find(ids[0]) == theTowerMapFGSum.end() ) {
          SumFGContainer sumFG;
-         theTowerMapFGSum.insert(std::pair<HcalTrigTowerDetId, SumFGContainer >(ids[0], sumFG));
+         theTowerMapFGSum.insert(std::pair<HcalTrigTowerDetId, SumFGContainer>(ids[0], sumFG));
       }
 
       SumFGContainer& sumFG = theTowerMapFGSum[ids[0]];
       SumFGContainer::iterator sumFGItr;
       for ( sumFGItr = sumFG.begin(); sumFGItr != sumFG.end(); ++sumFGItr) {
-         if (sumFGItr->id() == fgid) break;
+         if (sumFGItr->id() == fgid) { break; }
       }
       // If find
       if (sumFGItr != sumFG.end()) {
-         for (int i=0; i<samples.size(); ++i) (*sumFGItr)[i] += samples[i];
+         for (int i=0; i<samples.size(); ++i) {
+            (*sumFGItr)[i] += samples[i];
+         }
       }
       else {
          //Copy samples (change to fgid)
@@ -155,9 +157,11 @@ void HcalTriggerPrimitiveAlgo::addSignal(const HFDataFrame & frame) {
          vector<bool> vetoBits(samples.size(), false);
          HF_Veto[fgid] = vetoBits;
       }
-      for (int i=0; i<samples.size(); ++i)
-         if (samples[i] < minSignalThreshold_)
+      for (int i=0; i<samples.size(); ++i) {
+         if (samples[i] < minSignalThreshold_) {
             HF_Veto[fgid][i] = true;
+         }
+      }
    }
 }
 

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -1,5 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+LSParameter =cms.untracked.PSet(
+HcalFeatureHFEMBit= cms.bool(False),
+Min_Long_Energy= cms.double(10),#makes a cut based on energy deposited in short vrs long
+    Min_Short_Energy= cms.double(10),
+    Long_vrs_Short_Slope= cms.double(100.2),
+    Long_Short_Offset= cms.double(10.1))
+
+
 simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     peakFilter = cms.bool(True),
     weights = cms.vdouble(1.0, 1.0), ##hardware algo        
@@ -10,6 +18,9 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     numberOfPresamples = cms.int32(2),
     MinSignalThreshold = cms.uint32(0), # For HF PMT veto
     PMTNoiseThreshold = cms.uint32(0),  # For HF PMT veto
+    LSConfig=LSParameter,
+    
+    
 #
     #vdouble weights = { -1, -1, 1, 1} //low lumi algo
     # Input digi label (_must_ be without zero-suppression!)

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 LSParameter =cms.untracked.PSet(
-HcalFeatureHFEMBit= cms.bool(True),
+HcalFeatureHFEMBit= cms.bool(False),
 Min_Long_Energy= cms.double(10),#makes a cut based on energy deposited in short vrs long
     Min_Short_Energy= cms.double(10),
     Long_vrs_Short_Slope= cms.double(100.2),

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -1,5 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
+LSParameter =cms.untracked.PSet(
+HcalFeatureHFEMBit= cms.bool(True),
+Min_Long_Energy= cms.double(10),#makes a cut based on energy deposited in short vrs long
+    Min_Short_Energy= cms.double(10),
+    Long_vrs_Short_Slope= cms.double(100.2),
+    Long_Short_Offset= cms.double(10.1))
+
+
 simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     peakFilter = cms.bool(True),
     weights = cms.vdouble(1.0, 1.0), ##hardware algo        
@@ -10,11 +18,8 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     numberOfPresamples = cms.int32(2),
     MinSignalThreshold = cms.uint32(0), # For HF PMT veto
     PMTNoiseThreshold = cms.uint32(0),  # For HF PMT veto
+    LSConfig=LSParameter,
     
-    Min_Long_EnergyInput= cms.double(10),
-    Min_Short_EnergyInput= cms.double(11),
-    Long_vrs_Short_SlopeInput= cms.double(1.2),
-    Long_Short_OffsetInput= cms.double(1.1),
     
 #
     #vdouble weights = { -1, -1, 1, 1} //low lumi algo

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -10,6 +10,12 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     numberOfPresamples = cms.int32(2),
     MinSignalThreshold = cms.uint32(0), # For HF PMT veto
     PMTNoiseThreshold = cms.uint32(0),  # For HF PMT veto
+    
+    Min_Long_EnergyInput= cms.double(10),
+    Min_Short_EnergyInput= cms.double(11),
+    Long_vrs_Short_SlopeInput= cms.double(1.2),
+    Long_Short_OffsetInput= cms.double(1.1),
+    
 #
     #vdouble weights = { -1, -1, 1, 1} //low lumi algo
     # Input digi label (_must_ be without zero-suppression!)

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -22,6 +22,9 @@
 
 #include <algorithm>
 
+
+
+
 HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 : 
   theAlgo_(ps.getParameter<bool>("peakFilter"),
@@ -39,6 +42,16 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
   runZS_(ps.getParameter<bool>("RunZS")),
   runFrontEndFormatError_(ps.getParameter<bool>("FrontEndFormatError"))
 {
+    HFEMB_ = false;
+    if(ps.exists("LSConfig"))
+    {
+        LongShortCut_ = ps.getUntrackedParameter<edm::ParameterSet>("LSConfig");
+        HFEMB_ = LongShortCut_.getParameter<bool>("HcalFeatureHFEMBit");
+        MinLongEnergy_ = LongShortCut_.getParameter<double>("Min_Long_Energy"); //minimum long energy
+        MinShortEnergy_ = LongShortCut_.getParameter<double>("Min_Short_Energy"); //minimum short energy
+        LongShortSlope_ = LongShortCut_.getParameter<double>("Long_vrs_Short_Slope"); //slope of the line that cuts are based on
+        LongShortOffset_ = LongShortCut_.getParameter<double>("Long_Short_Offset"); //offset of line
+    }
   // register for data access
   tok_raw_ = consumes<FEDRawDataCollection>(inputTagFEDRaw_);
   tok_hbhe_ = consumes<HBHEDigiCollection>(inputLabel_[0]);
@@ -104,15 +117,31 @@ void HcalTrigPrimDigiProducer::produce(edm::Event& iEvent, const edm::EventSetup
   }
 
 
+    edm::ESHandle < HcalDbService > pSetup;
+    eventSetup.get<HcalDbRecord> ().get(pSetup);
+
+    HcalFeatureBit* hfembit = 0;
+
+    if(HFEMB_)
+    {
+        hfembit = new HcalFeatureHFEMBit(MinShortEnergy_, MinLongEnergy_, LongShortSlope_, LongShortOffset_, *pSetup); //inputs values that cut will be based on
+        theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+                *hbheDigis, *hfDigis, *result, &(*pG), rctlsb, hfembit);
+
+    }// Step C: Invoke the algorithm, passing in inputs and getting back outputs.
+    else
+    {
+        theAlgo_.run(inputCoder.product(), outTranscoder->getHcalCompressor().get(),
+                *hbheDigis, *hfDigis, *result, &(*pG), rctlsb);
+    }
+
   // Step C: Invoke the algorithm, passing in inputs and getting back outputs.
-  theAlgo_.run(inputCoder.product(),outTranscoder->getHcalCompressor().get(),
-	       *hbheDigis,  *hfDigis, *result, &(*pG), rctlsb);
+ 
 
   // Step C.1: Run FE Format Error / ZS for real data.
   if (runFrontEndFormatError_) {
 
-        edm::ESHandle < HcalDbService > pSetup;
-        eventSetup.get<HcalDbRecord> ().get(pSetup);
+       
         const HcalElectronicsMap *emap = pSetup->getHcalMapping();
 
         edm::Handle < FEDRawDataCollection > fedHandle;

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
@@ -32,11 +32,14 @@ private:
   /// input tag for FEDRawDataCollection
   edm::InputTag inputTagFEDRaw_;
   edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
-
+  double MinLongEnergy_, MinShortEnergy_, LongShortSlope_, LongShortOffset_;
+  
   bool runZS_;
 
   bool runFrontEndFormatError_;
 
+  bool HFEMB_;
+  edm::ParameterSet LongShortCut_;
 };
 
 #endif

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
@@ -32,7 +32,8 @@ private:
   /// input tag for FEDRawDataCollection
   edm::InputTag inputTagFEDRaw_;
   edm::EDGetTokenT<FEDRawDataCollection> tok_raw_;
-
+  double MinLongEnergy_, MinShortEnergy_, LongShortSlope_, LongShortOffset_;
+  
   bool runZS_;
 
   bool runFrontEndFormatError_;

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.h
@@ -38,6 +38,8 @@ private:
 
   bool runFrontEndFormatError_;
 
+  bool HFEMB_;
+  edm::ParameterSet LongShortCut_;
 };
 
 #endif


### PR DESCRIPTION
This pull request adds HF 1x1 Trigger Primitives (TPs) while still providing the RCT-style TPs for backwards compatibility. Additionally HcalPacker was fixed to properly pack the trigger digis into the RAW.

This will require a new global tag: HcalLutMetadata_v3.00_mc (on CMS_COND_31X_HCAL)
Automatically ported from CMSSW_7_3_X #6257
