### PR TITLE
New Run2 simulation GT for HCal.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -10,11 +10,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   'MCPA1_73_V1::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V2::All',
+    'run2_design'       :   'DESRUN2_73_V3::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V4::All',
+    'run2_mc_50ns'      :   'MCRUN2_73_V6::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V5::All',
+    'run2_mc'           :   'MCRUN2_73_V7::All',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A::All',
     # GlobalTag for Run2 data reprocessing

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -10,11 +10,11 @@ autoCond = {
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
     'run1_mc_pa'        :   'MCPA1_73_V1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V2',
+    'run2_design'       :   'DESRUN2_73_V3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V4',
+    'run2_mc_50ns'      :   'MCRUN2_73_V6',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V5',
+    'run2_mc'           :   'MCRUN2_73_V7',
     # GlobalTag for Run1 data reprocessing
     'run1_data'         :   'GR_R_73_V0A',
     # GlobalTag for Run2 data reprocessing


### PR DESCRIPTION
New Global Tags for Run2 simulations (ideal, startup, asymptotic) with the following change:
- updating HCal response corrections restoring the energy scale in HB and HE after introduction of TimeSlew simulation (DIGI) + Method 2 (RECO).
