### PR TITLE
 fix occasional crash in PulseShapeFitOOTPileupCorrection for zero processed events in a job (as in #6646 )

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -170,7 +170,12 @@ namespace FitterFuncs{
   
 }
 
-PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPulseShape(0), chargeThreshold_(6.) {
+PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPulseShape(0), chargeThreshold_(6.),
+								       psfPtr_(nullptr), spfunctor_(nullptr), dpfunctor_(nullptr), tpfunctor_(nullptr),
+								       TSMin_(0), TSMax_(0), ts4Chi2_(0), ts3Chi2_(0), ts345Chi2_(0), pedestalConstraint_(0),
+								       timeConstraint_(0), addPulseJitter_(0), unConstrainedFit_(0), applyTimeSlew_(0),
+								       ts4Min_(0), ts4Max_(0), pulseJitter_(0), timeMean_(0), timeSig_(0), pedMean_(0), pedSig_(0),
+								       noise_(0) {
    hybridfitter = new PSFitter::HybridMinimizer(PSFitter::HybridMinimizer::kMigrad);
    iniTimesArr = { {-100,-75,-50,-25,0,25,50,75,100,125} };
 }

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -237,7 +237,7 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
     subdetOther_=HcalCalibration;
     produces<HcalCalibRecHitCollection>();
   } else {
-     std::cout << "HcalHitReconstructor is not associated with a specific subdetector!" << std::endl;
+    edm::LogWarning("Configuration") << "HcalHitReconstructor is not associated with a specific subdetector!" << std::endl;
   }
 
   // If no valid OOT pileup correction name specified,


### PR DESCRIPTION
Initialized data members

the crash in e.g. 106.0 is gone.

The crash in the original code can be more reliably reproduced with the malloc magic

```
export MALLOC_CHECK_=3 
export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))
cmsRunGlibC config.py

```
