### PR TITLE
Concurrent with root6 interface change

### DIFF
--- a/CondCore/DBCommon/test/testMultipleConnection.cc
+++ b/CondCore/DBCommon/test/testMultipleConnection.cc
@@ -9,7 +9,6 @@
 #include <string>
 #include <iostream>
 int main(){
-  assert(0); // Fail deliberately to avoid infinite loop.
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   cond::DbConnection connection;

--- a/CondCore/DBCommon/test/testSingleConnection.cc
+++ b/CondCore/DBCommon/test/testSingleConnection.cc
@@ -17,7 +17,6 @@ void wait ( int seconds )
   while (clock() < endwait) {}
 }
 int main(){
-  assert(0); //Fail deliberately to avoid invfinite loop.
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
   cond::DbConnection connection;

--- a/CondCore/ORA/src/STLContainerHandler.cc
+++ b/CondCore/ORA/src/STLContainerHandler.cc
@@ -13,43 +13,17 @@ ora::STLContainerIteratorHandler::STLContainerIteratorHandler( void* address,
                                                                const edm::TypeWithDict& iteratorReturnType ):
   m_returnType(iteratorReturnType),
   m_collProxy(collProxy),
-  m_currentElement(0),
-  m_Iterators(nullptr),
-  m_PtrIterators(nullptr),
-  m_Next()
+  m_currentElement(nullptr),
+  m_Iterators(TGenericCollectionIterator::New(address, &collProxy))
 {
-
-  if (m_collProxy.HasPointers()) {
-    m_PtrIterators = new TVirtualCollectionPtrIterators(&m_collProxy);
-  } else {
-    m_Iterators = new TVirtualCollectionIterators(&m_collProxy, false);
-  }
-  m_Next = m_collProxy.GetFunctionNext(false);
-
-  if (m_collProxy.HasPointers()) {
-    m_PtrIterators->CreateIterators(address, &m_collProxy);
-  } else {
-    m_Iterators->CreateIterators(address, &m_collProxy);
-  }
-
-  if (m_collProxy.HasPointers()) {
-    m_currentElement = m_Next(&m_PtrIterators->fBegin, &m_PtrIterators->fEnd);
-  } else {
-    m_currentElement = m_Next(&m_Iterators->fBegin, &m_Iterators->fEnd); 
-  }
-  //m_currentElement = m_collProxy.first_func(&m_collEnv);
+    m_currentElement = m_Iterators->Next();
 }
 
 ora::STLContainerIteratorHandler::~STLContainerIteratorHandler(){}
 
 void
 ora::STLContainerIteratorHandler::increment(){
-  if (m_collProxy.HasPointers())  {
-    m_currentElement = m_Next(&m_PtrIterators->fBegin, &m_PtrIterators->fEnd);
-  } else {
-    m_currentElement = m_Next(&m_Iterators->fBegin, &m_Iterators->fEnd); 
-  }
-  //m_currentElement = m_collProxy.next_func(&m_collEnv);
+  m_currentElement = m_Iterators->Next();
 }
 
 void*

--- a/CondCore/ORA/src/STLContainerHandler.h
+++ b/CondCore/ORA/src/STLContainerHandler.h
@@ -43,14 +43,9 @@ namespace ora {
       /// Current element object pointer
       void* m_currentElement;
 
-      // holds the iterators when the branch is of fType==4.
-      TVirtualCollectionIterators *m_Iterators;
+      // holds the iterator when the branch is of fType==4.
+      TGenericCollectionIterator *m_Iterators;
 
-      // holds the iterators when the branch is of fType==4 and it is a split collection of pointers.
-      TVirtualCollectionPtrIterators *m_PtrIterators;
-
-      // See TVirtualCollectionProxy::GetFunctionNext();
-      TVirtualCollectionProxy::Next_t m_Next;
     };
 
 

--- a/CondCore/ORA/test/testORAIO.cc
+++ b/CondCore/ORA/test/testORAIO.cc
@@ -104,6 +104,7 @@ namespace ora {
 }
 
 int main(int argc, char** argv){
+  assert(0);  // Temporarily fail deliberately, as this test hogs memory.
   ora::TestORAIO test;
   test.run();
 }


### PR DESCRIPTION
This critical fix must be picked up concurrently with advancing ROOT6 to the head of the v6-02-00 patches branch.
This pull request does three things:
1) Adapts to a new interface in ROOT6 from Philippe Canal.  This reduces the number of CondCore unit tests that fail from 20 to 11.
2) Two unit tests that are fixed by this change have an assert removed.  This assert previously aborted the tests to avoid an infinite loop that otherwise occurred.
3) One unit test (testORAIO) has an assert added to fail the test immediately.  The new ROOT interface fixed the previous failure of this test, but this test now hoards memory to toe point of exhaustion. So, we fail deliberately to avoid this for now.
Please merge this request in the same IB as ROOT6 is updated to the HEAD of the v6-02-00-patches branch, as they are mutually dependent.
