### PR TITLE
Drop CA8 jets from RECO/AOD, switch to AK8 jets for jet substucture, add softdrop - rebase

### DIFF
--- a/DQM/Physics/python/B2GDQM_cfi.py
+++ b/DQM/Physics/python/B2GDQM_cfi.py
@@ -13,8 +13,8 @@ B2GDQM = cms.EDAnalyzer(
     jetLabels = cms.VInputTag(
         'ak4PFJets',
         'ak4PFJetsCHS',
-        'ca8PFJetsCHS',
-        'ca8PFJetsCHSPruned',
+        'ak8PFJetsCHS',
+        'ak8PFJetsCHSPruned',
         'cmsTopTagPFJetsCHS'
         ),
     jetPtMins = cms.vdouble(

--- a/DQM/Physics/python/B2GDQM_cfi.py
+++ b/DQM/Physics/python/B2GDQM_cfi.py
@@ -15,6 +15,7 @@ B2GDQM = cms.EDAnalyzer(
         'ak4PFJetsCHS',
         'ak8PFJetsCHS',
         'ak8PFJetsCHSPruned',
+        'ak8PFJetsCHSSoftDrop',
         'cmsTopTagPFJetsCHS'
         ),
     jetPtMins = cms.vdouble(

--- a/DQM/Physics/src/B2GDQM.cc
+++ b/DQM/Physics/src/B2GDQM.cc
@@ -382,7 +382,7 @@ void B2GDQM::analyzeJets(const Event& iEvent, const edm::EventSetup& iSetup) {
           }
 
           // For W-tagging, check the mass drop
-        } else if (jetLabels_[icoll].label() == "ca8PFJetsCHSPruned") {
+        } else if (jetLabels_[icoll].label() == "ak8PFJetsCHSPruned") {
           if (jet->numberOfDaughters() > 1) {
             reco::Candidate const* da0 = jet->daughter(0);
             reco::Candidate const* da1 = jet->daughter(1);
@@ -395,7 +395,7 @@ void B2GDQM::analyzeJets(const Event& iEvent, const edm::EventSetup& iSetup) {
             boostedJet_massDrop[icoll]->Fill(-1.0);
           }
 
-        }  // end if collection is CA8 PFJets CHS Pruned
+        }  // end if collection is AK8 PFJets CHS Pruned
 
       }  // end if basic jet != 0
       countJet++;

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -89,12 +89,13 @@ def miniAOD_customizeCommon(process):
     process.selectedPatJetsAK8.cut = cms.string("pt > 100")
     process.patJetGenJetMatchAK8.matched =  'slimmedGenJets'
     ## AK8 groomed masses
-    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed
+    from RecoJets.Configuration.RecoPFJets_cff import ak8PFJetsCHSPruned, ak8PFJetsCHSSoftDrop, ak8PFJetsCHSFiltered, ak8PFJetsCHSTrimmed 
     process.ak8PFJetsCHSPruned   = ak8PFJetsCHSPruned.clone()
+    process.ak8PFJetsCHSSoftDrop = ak8PFJetsCHSSoftDrop.clone()
     process.ak8PFJetsCHSTrimmed  = ak8PFJetsCHSTrimmed.clone()
     process.ak8PFJetsCHSFiltered = ak8PFJetsCHSFiltered.clone()
     process.load("RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi")
-    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedLinks','ak8PFJetsCHSTrimmedLinks','ak8PFJetsCHSFilteredLinks']
+    process.patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass','ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
 
     # Add AK8 top tagging variables
     process.patJetsAK8.tagInfoSources = cms.VInputTag(cms.InputTag("caTopTagInfosPAT"))

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -63,8 +63,8 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHSPruned_*_*',                                           
+                                           'keep *_ak8PFJetsCHS_*_*',
+                                           'keep *_ak8PFJetsCHSPruned_*_*',                                           
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
                                            #'keep *_hepTopTagPFJetsCHS_*_*',
                                            #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
@@ -118,8 +118,8 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHS_*_*',
-                                           'keep *_ca8PFJetsCHSPruned_*_*',
+                                           #'keep *_ca8PFJetsCHS_*_*',
+                                           'keep *_ak8PFJetsCHSPruned_*_*',
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
                                            #'keep *_hepTopTagPFJetsCHS_*_*',
                                            #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
@@ -164,7 +164,7 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_fixedGridRho*_*_*',
                                            'drop doubles_*Jets_rhos_*',
                                            'drop doubles_*Jets_sigmas_*',
-                                           'keep *_ca8PFJetsCHSPrunedLinks_*_*'                                           
+                                           'keep *_ak8PFJetsCHSPrunedLinks_*_*'                                           
                                            )
     )
 RecoGenJetsAOD = cms.PSet(

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -65,6 +65,7 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_ak8PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHSPruned_*_*',                                           
+                                           'keep *_ak8PFJetsCHSSoftDrop_*_*',                                           
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
                                            #'keep *_hepTopTagPFJetsCHS_*_*',
                                            #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
@@ -97,7 +98,8 @@ RecoJetsRECO = cms.PSet(
                                            'keep double_kt6PFJetsCentralNeutral_*_*',
                                            'keep double_kt6PFJetsCentralNeutralTight_*_*',
                                            'keep *_fixedGridRho*_*_*',
-                                           'keep *_ca8PFJetsCHSPrunedLinks_*_*'                                 
+                                           'keep *_ak8PFJetsCHSPrunedMass_*_*',                                 
+                                           'keep *_ak8PFJetsCHSSoftDropMass_*_*'                                 
                                            )
 )
 RecoGenJetsRECO = cms.PSet(
@@ -118,8 +120,8 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           #'keep *_ca8PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHSPruned_*_*',
+                                           'keep *_ak8PFJetsCHSSoftDrop_*_*',
                                            'keep *_cmsTopTagPFJetsCHS_*_*',
                                            #'keep *_hepTopTagPFJetsCHS_*_*',
                                            #'keep *_ca15PFJetsCHSMassDropFiltered_*_*',
@@ -164,7 +166,8 @@ RecoJetsAOD = cms.PSet(
                                            'keep *_fixedGridRho*_*_*',
                                            'drop doubles_*Jets_rhos_*',
                                            'drop doubles_*Jets_sigmas_*',
-                                           'keep *_ak8PFJetsCHSPrunedLinks_*_*'                                           
+                                           'keep *_ak8PFJetsCHSPrunedMass_*_*',                                 
+                                           'keep *_ak8PFJetsCHSSoftDropMass_*_*'                                 
                                            )
     )
 RecoGenJetsAOD = cms.PSet(

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -193,7 +193,7 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            ak5PFJetsCHS+
                            ak4PFJetsCHS+                           
                            ak8PFJetsCHS+
-                           ca8PFJetsCHS+
+                           #ca8PFJetsCHS+
                            ak8PFJetsCHSConstituents+
                            ak8PFJetsCHSPruned+
                            ak8PFJetsCHSPrunedLinks+

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -16,8 +16,8 @@ from RecoJets.JetProducers.ca4PFJets_cfi import ca4PFJets
 from RecoJets.JetProducers.fixedGridRhoProducer_cfi import fixedGridRhoAll
 from RecoJets.JetProducers.fixedGridRhoProducerFastjet_cfi import fixedGridRhoFastjetAll
 from RecoJets.JetProducers.caTopTaggers_cff import *
-from RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi import ak8PFJetsCHSPrunedLinks, ak8PFJetsCHSFilteredLinks, ak8PFJetsCHSTrimmedLinks, ak8PFJetsCHSSoftDropLinks
-from RecoJets.JetProducers.ca8PFJetsCHS_groomingValueMaps_cfi import ca8PFJetsCHSPrunedLinks, ca8PFJetsCHSFilteredLinks, ca8PFJetsCHSTrimmedLinks, ca8PFJetsCHSSoftDropLinks
+from RecoJets.JetProducers.ak8PFJetsCHS_groomingValueMaps_cfi import ak8PFJetsCHSPrunedMass, ak8PFJetsCHSFilteredMass, ak8PFJetsCHSTrimmedMass, ak8PFJetsCHSSoftDropMass
+from RecoJets.JetProducers.ca8PFJetsCHS_groomingValueMaps_cfi import ca8PFJetsCHSPrunedMass, ca8PFJetsCHSFilteredMass, ca8PFJetsCHSTrimmedMass, ca8PFJetsCHSSoftDropMass
 from CommonTools.PileupAlgos.Puppi_cff import puppi
 from CommonTools.PileupAlgos.softKiller_cfi import softKiller
 from RecoJets.JetProducers.ak4PFJetsPuppi_cfi import ak4PFJetsPuppi
@@ -196,7 +196,9 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            #ca8PFJetsCHS+
                            ak8PFJetsCHSConstituents+
                            ak8PFJetsCHSPruned+
-                           ak8PFJetsCHSPrunedLinks+
+                           ak8PFJetsCHSPrunedMass+
+                           ak8PFJetsCHSSoftDrop+
+                           ak8PFJetsCHSSoftDropMass+
                            cmsTopTagPFJetsCHS+
                            hepTopTagPFJetsCHS+
                            ca15PFJetsCHSMassDropFiltered+
@@ -230,15 +232,15 @@ recoAllPFJets=cms.Sequence(sisCone5PFJets+sisCone7PFJets+
                            ak8PFJetsCHSFiltered+
                            ak8PFJetsCHSTrimmed+
                            ak8PFJetsCHSSoftDrop+
+                           ak8PFJetsCHSPrunedMass+
+                           ak8PFJetsCHSTrimmedMass+
+                           ak8PFJetsCHSSoftDropMass+
+                           ak8PFJetsCHSFilteredMass+
                            ca8PFJetsCHS+
                            ca8PFJetsCHSPruned+
                            ca8PFJetsCHSFiltered+
                            ca8PFJetsCHSTrimmed+
                            ca8PFJetsCHSSoftDrop+
-                           ca8PFJetsCHSPrunedLinks+
-                           ca8PFJetsCHSTrimmedLinks+
-                           ca8PFJetsCHSSoftDropLinks+
-                           ca8PFJetsCHSFilteredLinks+
                            cmsTopTagPFJetsCHS+
                            hepTopTagPFJetsCHS+
                            ca15PFJetsCHSMassDropFiltered+
@@ -272,15 +274,15 @@ recoPFJetsWithSubstructure=cms.Sequence(
                            ak8PFJetsCHSTrimmed+
                            ak8PFJetsCHSSoftDrop+
                            ak8PFJetsCHSConstituents+
+                           ak8PFJetsCHSPrunedMass+
+                           ak8PFJetsCHSTrimmedMass+
+                           ak8PFJetsCHSSoftDropMass+
+                           ak8PFJetsCHSFilteredMass+
                            ca8PFJetsCHS+
                            ca8PFJetsCHSPruned+
                            ca8PFJetsCHSFiltered+
                            ca8PFJetsCHSTrimmed+
                            ca8PFJetsCHSSoftDrop+
-                           ca8PFJetsCHSPrunedLinks+
-                           ca8PFJetsCHSTrimmedLinks+
-                           ca8PFJetsCHSSoftDropLinks+
-                           ca8PFJetsCHSFilteredLinks+
                            cmsTopTagPFJetsCHS+
                            hepTopTagPFJetsCHS+
                            ca15PFJetsCHSMassDropFiltered+

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -195,8 +195,8 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            ak8PFJetsCHS+
                            ca8PFJetsCHS+
                            ak8PFJetsCHSConstituents+
-                           ca8PFJetsCHSPruned+
-                           ca8PFJetsCHSPrunedLinks+
+                           ak8PFJetsCHSPruned+
+                           ak8PFJetsCHSPrunedLinks+
                            cmsTopTagPFJetsCHS+
                            hepTopTagPFJetsCHS+
                            ca15PFJetsCHSMassDropFiltered+

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -399,7 +399,7 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
     fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
   }
 
-  if ( !(useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ || useTrimming_ || useFiltering_ || usePruning_ || useConstituentSubtraction_ ) ) {
+  if ( !(useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ || useTrimming_ || useFiltering_ || usePruning_ || useSoftDrop_ || useConstituentSubtraction_ ) ) {
     fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
   } else {
     fjJets_.clear();
@@ -434,12 +434,12 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       fastjet::Filter * trimmer = new fastjet::Filter(fastjet::JetDefinition(fastjet::kt_algorithm, rFilt_), fastjet::SelectorPtFractionMin(trimPtFracMin_));
       transformers.push_back( transformer_ptr(trimmer) );
     } 
-    if ( useFiltering_ ) {
+    if ( (useFiltering_) && (!useDynamicFiltering_) ) {
       fastjet::Filter * filter = new fastjet::Filter(fastjet::JetDefinition(fastjet::cambridge_algorithm, rFilt_), fastjet::SelectorNHardest(nFilt_));
       transformers.push_back( transformer_ptr(filter));
     } 
 
-    if ( usePruning_ ) {
+    if ( (usePruning_)  && (!useKtPruning_) ) {
       fastjet::Pruner * pruner = new fastjet::Pruner(fastjet::cambridge_algorithm, zCut_, RcutFactor_);
       transformers.push_back( transformer_ptr(pruner ));
     }

--- a/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
 
 ak4PFJetsSoftDrop = ak4PFJets.clone(
     useSoftDrop = cms.bool(True),
-    zcut = cms.double(0.2),
+    zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
     )

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.ak5PFJets_cfi import ak5PFJets
 
 ak5PFJetsSoftDrop = ak5PFJets.clone(
     useSoftDrop = cms.bool(True),
-    zcut = cms.double(0.2),
+    zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
     )

--- a/RecoJets/JetProducers/python/ak8PFJetsCHS_groomingValueMaps_cfi.py
+++ b/RecoJets/JetProducers/python/ak8PFJetsCHS_groomingValueMaps_cfi.py
@@ -3,21 +3,21 @@ import FWCore.ParameterSet.Config as cms
 
 # Delta-R matching value maps
 
-ak8PFJetsCHSPrunedLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ak8PFJetsCHSPrunedMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ak8PFJetsCHS"),
                                          matched = cms.InputTag("ak8PFJetsCHSPruned"),
                                          distMax = cms.double(0.8),
                                          value = cms.string('mass')
                         )
 
-ak8PFJetsCHSTrimmedLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ak8PFJetsCHSTrimmedMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ak8PFJetsCHS"),
                                          matched = cms.InputTag("ak8PFJetsCHSTrimmed"),                                         
                                          distMax = cms.double(0.8),
                                          value = cms.string('mass')
                         )
 
-ak8PFJetsCHSFilteredLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ak8PFJetsCHSFilteredMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ak8PFJetsCHS"),
                                          matched = cms.InputTag("ak8PFJetsCHSFiltered"),                                         
                                          distMax = cms.double(0.8),
@@ -25,7 +25,7 @@ ak8PFJetsCHSFilteredLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                         )
 
 
-ak8PFJetsCHSSoftDropLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ak8PFJetsCHSSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ak8PFJetsCHS"),
                                          matched = cms.InputTag("ak8PFJetsCHSSoftDrop"),                                         
                                          distMax = cms.double(0.8),

--- a/RecoJets/JetProducers/python/ca8PFJetsCHS_groomingValueMaps_cfi.py
+++ b/RecoJets/JetProducers/python/ca8PFJetsCHS_groomingValueMaps_cfi.py
@@ -3,28 +3,28 @@ import FWCore.ParameterSet.Config as cms
 
 # Delta-R matching value maps
 
-ca8PFJetsCHSPrunedLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ca8PFJetsCHSPrunedMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ca8PFJetsCHS"),
                                          matched = cms.InputTag("ca8PFJetsCHSPruned"),
                                          distMax = cms.double(0.8),
                                          value = cms.string('mass')
                         )
 
-ca8PFJetsCHSTrimmedLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ca8PFJetsCHSTrimmedMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ca8PFJetsCHS"),
                                          matched = cms.InputTag("ca8PFJetsCHSTrimmed"),                                         
                                          distMax = cms.double(0.8),
                                          value = cms.string('mass')
                         )
 
-ca8PFJetsCHSFilteredLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ca8PFJetsCHSFilteredMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ca8PFJetsCHS"),
                                          matched = cms.InputTag("ca8PFJetsCHSFiltered"),                                         
                                          distMax = cms.double(0.8),
                                          value = cms.string('mass')  
                         )
 
-ca8PFJetsCHSSoftDropLinks = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+ca8PFJetsCHSSoftDropMass = cms.EDProducer("RecoJetDeltaRValueMapProducer",
                                          src = cms.InputTag("ca8PFJetsCHS"),
                                          matched = cms.InputTag("ca8PFJetsCHSSoftDrop"),                                         
                                          distMax = cms.double(0.8),

--- a/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
+++ b/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
@@ -2,14 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 Njettiness = cms.EDProducer("NjettinessAdder",
                             src=cms.InputTag("ak8PFJetsCHS"),
-                            Njets=cms.vuint32(1,2,3),            # compute 1-, 2-, 3- subjettiness
+                            Njets=cms.vuint32(1,2,3,4),          # compute 1-, 2-, 3-, 4- subjettiness
                             # variables for measure definition : 
-                            measureDefinition = cms.uint32( 1 ), # default is unnormalized measure
-                            beta = cms.double(-999.0),           # not used by default
-                            R0 = cms.double( -999.0 ),           # not used by default
+                            measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
+                            beta = cms.double(1.0),              # CMS default is 1
+                            R0 = cms.double( 0.8 ),              # CMS default is jet cone size
                             Rcutoff = cms.double( -999.0),       # not used by default
                             # variables for axes definition :
-                            axesDefinition = cms.uint32( 6 ),    # default is 1-pass KT axes
+                            axesDefinition = cms.uint32( 6 ),    # CMS default is 1-pass KT axes
                             nPass = cms.int32(-999),             # not used by default
                             akAxesR0 = cms.double(-999.0)        # not used by default
                             )

--- a/RecoJets/JetProducers/python/qjetsadder_cfi.py
+++ b/RecoJets/JetProducers/python/qjetsadder_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 QJetsAdder = cms.EDProducer("QjetsAdder",
-                            src=cms.InputTag("ca8PFJetsCHS"),
+                            src=cms.InputTag("ak8PFJetsCHS"),
                             zcut=cms.double(0.1),
                             dcutfctr=cms.double(0.5),
                             expmin=cms.double(0.0),

--- a/RecoJets/JetProducers/test/jettoolbox_cfg.py
+++ b/RecoJets/JetProducers/test/jettoolbox_cfg.py
@@ -146,29 +146,31 @@ process.out.outputCommands += ['keep *_QJetsAdderAK8_*_*']
 
 process.load('RecoJets.Configuration.RecoPFJets_cff')
 
-patJetsCA8.userData.userFloats.src += ['ca8PFJetsCHSPrunedLinks','ca8PFJetsCHSTrimmedLinks','ca8PFJetsCHSFilteredLinks']
-process.out.outputCommands += ['keep *_ca8PFJetsCHSPrunedLinks_*_*',
-                               'keep *_ca8PFJetsCHSTrimmedLinks_*_*',
-                               'keep *_ca8PFJetsCHSFilteredLinks_*_*']
+patJetsCA8.userData.userFloats.src += ['ca8PFJetsCHSPrunedMass','ca8PFJetsCHSSoftDropMass','ca8PFJetsCHSTrimmedMass','ca8PFJetsCHSFilteredMass']
+process.out.outputCommands += ['keep *_ca8PFJetsCHSPrunedMass_*_*',
+                               'keep *_ca8PFJetsCHSSoftDropMass_*_*',
+                               'keep *_ca8PFJetsCHSTrimmedMass_*_*',
+                               'keep *_ca8PFJetsCHSFilteredMass_*_*']
 
-patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedLinks','ak8PFJetsCHSTrimmedLinks','ak8PFJetsCHSFilteredLinks']
-process.out.outputCommands += ['keep *_ak8PFJetsCHSPrunedLinks_*_*',
-                               'keep *_ak8PFJetsCHSTrimmedLinks_*_*',
-                               'keep *_ak8PFJetsCHSFilteredLinks_*_*']
+patJetsAK8.userData.userFloats.src += ['ak8PFJetsCHSPrunedMass','ak8PFJetsCHSSoftDropMass','ak8PFJetsCHSTrimmedMass','ak8PFJetsCHSFilteredMass']
+process.out.outputCommands += ['keep *_ak8PFJetsCHSPrunedMass_*_*',
+                               'keep *_ak8PFJetsCHSSoftDropMass_*_*',
+                               'keep *_ak8PFJetsCHSTrimmedMass_*_*',
+                               'keep *_ak8PFJetsCHSFilteredMass_*_*']
 
-process.cmsTopTagPFJetsCHSLinksCA8 = process.ca8PFJetsCHSPrunedLinks.clone()
-process.cmsTopTagPFJetsCHSLinksCA8.src = cms.InputTag("ca8PFJetsCHS")
-process.cmsTopTagPFJetsCHSLinksCA8.matched = cms.InputTag("cmsTopTagPFJetsCHS")
+process.cmsTopTagPFJetsCHSMassCA8 = process.ca8PFJetsCHSPrunedMass.clone()
+process.cmsTopTagPFJetsCHSMassCA8.src = cms.InputTag("ca8PFJetsCHS")
+process.cmsTopTagPFJetsCHSMassCA8.matched = cms.InputTag("cmsTopTagPFJetsCHS")
 
-patJetsCA8.userData.userFloats.src += ['cmsTopTagPFJetsCHSLinksCA8']
-process.out.outputCommands += ['keep *_cmsTopTagPFJetsCHSLinksCA8_*_*']
+patJetsCA8.userData.userFloats.src += ['cmsTopTagPFJetsCHSMassCA8']
+process.out.outputCommands += ['keep *_cmsTopTagPFJetsCHSMassCA8_*_*']
 
-process.cmsTopTagPFJetsCHSLinksAK8 = process.cmsTopTagPFJetsCHSLinksCA8.clone()
-process.cmsTopTagPFJetsCHSLinksAK8.src = cms.InputTag("ak8PFJetsCHS")
-process.cmsTopTagPFJetsCHSLinksAK8.matched = cms.InputTag("cmsTopTagPFJetsCHS")
+process.cmsTopTagPFJetsCHSMassAK8 = process.cmsTopTagPFJetsCHSMassCA8.clone()
+process.cmsTopTagPFJetsCHSMassAK8.src = cms.InputTag("ak8PFJetsCHS")
+process.cmsTopTagPFJetsCHSMassAK8.matched = cms.InputTag("cmsTopTagPFJetsCHS")
 
-patJetsAK8.userData.userFloats.src += ['cmsTopTagPFJetsCHSLinksAK8']
-process.out.outputCommands += ['keep *_cmsTopTagPFJetsCHSLinksAK8_*_*']
+patJetsAK8.userData.userFloats.src += ['cmsTopTagPFJetsCHSMassAK8']
+process.out.outputCommands += ['keep *_cmsTopTagPFJetsCHSMassAK8_*_*']
 
 ####################################################################################################
 


### PR DESCRIPTION
Rebase of #6621

This is a long outstanding issue to switch from CA8 to AK8 for jet substructure algorithms.
CA8 jets are obsolete for analyses and in fact one can remove one jet algorithm in RECO by this change.
Also pruning is recommended to be replaced by softdrop for the next Run, therefore add it to RECO.
Here are the changes:

```
drop ca8 collection from RECO/AOD, since ak8 jets are recommended instead
switch from ca8 to ak8 for substructure algorithms in RECO/AOD
add softdrop to RECO/AOD
update DQM accordingly
update default parameters for N-subjettiness and softdrop (these are not run in RECO)
fix softdrop jet producer
```

The documentation for AK8 based jet substructure and softdrop is in
http://cms.cern.ch/iCMS/analysisadmin/cadi?ancode=JME-14-002
It is an update on the document based on CA8 jets and pruning:
http://cms.cern.ch/iCMS/analysisadmin/cadi?ancode=JME-13-006

Validation of Softdrop performance against Pruning was shown in this talk:
https://indico.cern.ch/event/336245/contribution/4
