### PR TITLE
Fix soft drop jet producer

### DIFF
--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -399,7 +399,7 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
     fjClusterSeq_ = ClusterSequencePtr( new fastjet::ClusterSequenceVoronoiArea( fjInputs_, *fjJetDefinition_ , fastjet::VoronoiAreaSpec(voronoiRfact_) ) );
   }
 
-  if ( !(useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ || useTrimming_ || useFiltering_ || usePruning_ || useConstituentSubtraction_ ) ) {
+  if ( !(useMassDropTagger_ || useCMSBoostedTauSeedingAlgorithm_ || useTrimming_ || useFiltering_ || usePruning_ || useSoftDrop_ || useConstituentSubtraction_ ) ) {
     fjJets_ = fastjet::sorted_by_pt(fjClusterSeq_->inclusive_jets(jetPtMin_));
   } else {
     fjJets_.clear();
@@ -434,12 +434,12 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
       fastjet::Filter * trimmer = new fastjet::Filter(fastjet::JetDefinition(fastjet::kt_algorithm, rFilt_), fastjet::SelectorPtFractionMin(trimPtFracMin_));
       transformers.push_back( transformer_ptr(trimmer) );
     } 
-    if ( useFiltering_ ) {
+    if ( (useFiltering_) && (!useDynamicFiltering_) ) {
       fastjet::Filter * filter = new fastjet::Filter(fastjet::JetDefinition(fastjet::cambridge_algorithm, rFilt_), fastjet::SelectorNHardest(nFilt_));
       transformers.push_back( transformer_ptr(filter));
     } 
 
-    if ( usePruning_ ) {
+    if ( (usePruning_)  && (!useKtPruning_) ) {
       fastjet::Pruner * pruner = new fastjet::Pruner(fastjet::cambridge_algorithm, zCut_, RcutFactor_);
       transformers.push_back( transformer_ptr(pruner ));
     }

--- a/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
 
 ak4PFJetsSoftDrop = ak4PFJets.clone(
     useSoftDrop = cms.bool(True),
-    zcut = cms.double(0.2),
+    zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
     )

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -6,7 +6,7 @@ from RecoJets.JetProducers.ak5PFJets_cfi import ak5PFJets
 
 ak5PFJetsSoftDrop = ak5PFJets.clone(
     useSoftDrop = cms.bool(True),
-    zcut = cms.double(0.2),
+    zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
     )

--- a/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
+++ b/RecoJets/JetProducers/python/nJettinessAdder_cfi.py
@@ -2,14 +2,14 @@ import FWCore.ParameterSet.Config as cms
 
 Njettiness = cms.EDProducer("NjettinessAdder",
                             src=cms.InputTag("ak8PFJetsCHS"),
-                            Njets=cms.vuint32(1,2,3),            # compute 1-, 2-, 3- subjettiness
+                            Njets=cms.vuint32(1,2,3,4),          # compute 1-, 2-, 3-, 4- subjettiness
                             # variables for measure definition : 
-                            measureDefinition = cms.uint32( 1 ), # default is unnormalized measure
-                            beta = cms.double(-999.0),           # not used by default
-                            R0 = cms.double( -999.0 ),           # not used by default
+                            measureDefinition = cms.uint32( 0 ), # CMS default is normalized measure
+                            beta = cms.double(1.0),              # CMS default is 1
+                            R0 = cms.double( 0.8 ),              # CMS default is jet cone size
                             Rcutoff = cms.double( -999.0),       # not used by default
                             # variables for axes definition :
-                            axesDefinition = cms.uint32( 6 ),    # default is 1-pass KT axes
+                            axesDefinition = cms.uint32( 6 ),    # CMS default is 1-pass KT axes
                             nPass = cms.int32(-999),             # not used by default
                             akAxesR0 = cms.double(-999.0)        # not used by default
                             )


### PR DESCRIPTION
Fix for the softdrop jet producer.
This is not run in 7_3_X RECO, but will be ran in analyses, so needs to be fixed.
The same fix has been requested for 7_4_X in #6654.
