### PR TITLE
migration from EDProducer to stream::EDProducer (SeedGeneratorFromProtoTracksEDProducer)

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -47,18 +47,21 @@ void SeedGeneratorFromProtoTracksEDProducer::fillDescriptions(edm::Configuration
 }
 
 
-SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(const ParameterSet& cfg):theConfig(cfg)
-
+SeedGeneratorFromProtoTracksEDProducer::SeedGeneratorFromProtoTracksEDProducer(const ParameterSet& cfg)
+ : theConfig(cfg)
+ , originHalfLength        ( cfg.getParameter<double>("originHalfLength")      )
+ , originRadius            ( cfg.getParameter<double>("originRadius")          )
+ , useProtoTrackKinematics ( cfg.getParameter<bool>("useProtoTrackKinematics") )
+ , useEventsWithNoVertex   ( cfg.getParameter<bool>("useEventsWithNoVertex")   )
+ , builderName             ( cfg.getParameter<std::string>("TTRHBuilder")      )
+ , usePV_                  ( cfg.getParameter<bool>( "usePV" )                 )
+ , theInputCollectionTag       ( consumes<reco::TrackCollection> (cfg.getParameter<InputTag>("InputCollection"))       )
+ , theInputVertexCollectionTag ( consumes<reco::VertexCollection>(cfg.getParameter<InputTag>("InputVertexCollection")) )
 {
   produces<TrajectorySeedCollection>();
-  theInputCollectionTag       = consumes<reco::TrackCollection>(cfg.getParameter<InputTag>("InputCollection"));
-  theInputVertexCollectionTag = consumes<reco::VertexCollection>(cfg.getParameter<InputTag>("InputVertexCollection"));
-  originHalfLength            = cfg.getParameter<double>("originHalfLength");
-  originRadius                = cfg.getParameter<double>("originRadius");
-  useProtoTrackKinematics     = cfg.getParameter<bool>("useProtoTrackKinematics");
-  useEventsWithNoVertex       = cfg.getParameter<bool>("useEventsWithNoVertex");
-  builderName                 = cfg.getParameter<std::string>("TTRHBuilder");
-  usePV_                      = cfg.getParameter<bool>( "usePV" );
+  
+  
+  
 }
 
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -1,7 +1,8 @@
 #ifndef RecoTracker_TkSeedGenerator_SeedGeneratorFromProtoTracksEDProducer_H
 #define RecoTracker_TkSeedGenerator_SeedGeneratorFromProtoTracksEDProducer_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
+//#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
@@ -9,7 +10,8 @@
 namespace edm { class Event; class EventSetup; }
 
 
-class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::EDProducer {
+//class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::EDProducer {
+class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::stream::EDProducer<> {
 public:
   SeedGeneratorFromProtoTracksEDProducer(const edm::ParameterSet& cfg);
   virtual ~SeedGeneratorFromProtoTracksEDProducer(){}
@@ -17,15 +19,15 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
 private:
-  edm::ParameterSet theConfig;
-  edm::EDGetTokenT<reco::TrackCollection> theInputCollectionTag;
-  edm::EDGetTokenT<reco::VertexCollection> theInputVertexCollectionTag;
-  double originHalfLength;
-  double originRadius;
-  bool useProtoTrackKinematics;
-  bool useEventsWithNoVertex;
-  std::string builderName;
-  bool usePV_;
+  const edm::ParameterSet theConfig;
+  const double originHalfLength;
+  const double originRadius;
+  const bool useProtoTrackKinematics;
+  const bool useEventsWithNoVertex;
+  const std::string builderName;
+  const bool usePV_;
+  const edm::EDGetTokenT<reco::TrackCollection> theInputCollectionTag;
+  const edm::EDGetTokenT<reco::VertexCollection> theInputVertexCollectionTag;
 
 };
 #endif

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.h
@@ -1,7 +1,6 @@
 #ifndef RecoTracker_TkSeedGenerator_SeedGeneratorFromProtoTracksEDProducer_H
 #define RecoTracker_TkSeedGenerator_SeedGeneratorFromProtoTracksEDProducer_H
 
-//#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
@@ -10,7 +9,6 @@
 namespace edm { class Event; class EventSetup; }
 
 
-//class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::EDProducer {
 class dso_hidden SeedGeneratorFromProtoTracksEDProducer : public edm::stream::EDProducer<> {
 public:
   SeedGeneratorFromProtoTracksEDProducer(const edm::ParameterSet& cfg);


### PR DESCRIPTION
as reported by @fwyzard 
https://docs.google.com/spreadsheets/d/1D9khDvOl05WEbznsUPCusEbrHeep9hh8cXedMXX09Gc/edit#gid=0
there are modules used @HLT which still need to be migrated and be multithread safe

this is my first update
hope everything is fine

moreover, could you confirm me that it is not needed to back-port neither in 73x nor in 72x ?
thanks
