### PR TITLE
migration from EDProducer to stream::EDProducer (SiStripExcludedFEDListProducer)

### DIFF
--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
@@ -19,12 +19,12 @@
 
 namespace sistrip {
 
-  ExcludedFEDListProducer::ExcludedFEDListProducer( const edm::ParameterSet& pset ) :
-    runNumber_(0),
-    cabling_(0),
-    cacheId_(0)
-  {
-    token_ = consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("ProductLabel"));
+  ExcludedFEDListProducer::ExcludedFEDListProducer( const edm::ParameterSet& pset ) 
+    : runNumber_(0)
+    , cabling_(0)
+    , cacheId_(0)
+    , token_ ( consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("ProductLabel")) )
+  {    
     produces<DetIdCollection>();
   }
   

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
@@ -21,8 +21,8 @@ namespace sistrip {
 
   ExcludedFEDListProducer::ExcludedFEDListProducer( const edm::ParameterSet& pset ) 
     : runNumber_(0)
-    , cabling_(0)
     , cacheId_(0)
+    , cabling_(0)
     , token_ ( consumes<FEDRawDataCollection>(pset.getParameter<edm::InputTag>("ProductLabel")) )
   {    
     produces<DetIdCollection>();

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.cc
@@ -38,7 +38,9 @@ namespace sistrip {
     uint32_t cacheId = es.get<SiStripFedCablingRcd>().cacheIdentifier();
     
     if ( cacheId_ != cacheId ) {
-      
+
+      cacheId_ = cacheId;
+
       edm::ESHandle<SiStripFedCabling> c;
       es.get<SiStripFedCablingRcd>().get( c );
       cabling_ = c.product();

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
@@ -2,7 +2,7 @@
 #define EventFilter_SiStripRawToDigi_ExcludedFEDListProducer_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -22,7 +22,7 @@
 
 namespace sistrip {
 
-  class ExcludedFEDListProducer : public edm::EDProducer
+  class ExcludedFEDListProducer : public edm::stream::EDProducer<>
   {
   public:
     /// constructor
@@ -34,9 +34,10 @@ namespace sistrip {
     
   private:
     unsigned int runNumber_;
-    edm::EDGetTokenT<FEDRawDataCollection> token_;
     const SiStripFedCabling * cabling_;
-    uint32_t cacheId_;
+    const uint32_t cacheId_;
+    const edm::EDGetTokenT<FEDRawDataCollection> token_;
+
     DetIdCollection detids_;
   };
 }

--- a/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
+++ b/EventFilter/SiStripRawToDigi/plugins/ExcludedFEDListProducer.h
@@ -34,8 +34,8 @@ namespace sistrip {
     
   private:
     unsigned int runNumber_;
+    uint32_t cacheId_;
     const SiStripFedCabling * cabling_;
-    const uint32_t cacheId_;
     const edm::EDGetTokenT<FEDRawDataCollection> token_;
 
     DetIdCollection detids_;


### PR DESCRIPTION
as reported by @fwyzard
https://docs.google.com/spreadsheets/d/1D9khDvOl05WEbznsUPCusEbrHeep9hh8cXedMXX09Gc/edit#gid=0
there are modules used @HLT which still need to be migrated and be multithread safe

this is the migration of the module SiStripExcludedFEDListProducer
