### PR TITLE
migration from EDProducer to stream::EDProducer (PixelVertexProducer)

### DIFF
--- a/RecoPixelVertexing/PixelVertexFinding/interface/PixelVertexProducer.h
+++ b/RecoPixelVertexing/PixelVertexFinding/interface/PixelVertexProducer.h
@@ -23,7 +23,7 @@
 //
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -32,23 +32,24 @@
 
 class DivisiveVertexFinder;
 
-class PixelVertexProducer : public edm::EDProducer {
+class PixelVertexProducer : public edm::stream::EDProducer<> {
  public:
   explicit PixelVertexProducer(const edm::ParameterSet&);
   ~PixelVertexProducer();
 
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
  private:
   // ----------member data ---------------------------
   // Turn on debug printing if verbose_ > 0
-  int verbose_;
-  DivisiveVertexFinder *dvf_;
+  const int verbose_;
   // Tracking cuts before sending tracks to vertex algo
-  double ptMin_;
-  edm::InputTag trackCollName;
-  edm::EDGetTokenT<reco::TrackCollection> token_Tracks;
-  edm::EDGetTokenT<reco::BeamSpot> token_BeamSpot;
-  bool method2;
+  const double ptMin_;
+  const bool method2;
+  const edm::InputTag trackCollName;
+  const edm::EDGetTokenT<reco::TrackCollection> token_Tracks;
+  const edm::EDGetTokenT<reco::BeamSpot> token_BeamSpot;
+
+  DivisiveVertexFinder *dvf_;
 
 };
 #endif

--- a/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/PixelVertexProducer.cc
@@ -11,13 +11,17 @@
 #include <cmath>
 
 PixelVertexProducer::PixelVertexProducer(const edm::ParameterSet& conf) 
-  : verbose_(0), dvf_(0), ptMin_(1.0)
+  : verbose_(conf.getParameter<int>("Verbosity") ) // 0 silent, 1 chatty, 2 loud
+  , ptMin_  (conf.getParameter<double>("PtMin")  ) // 1.0 GeV
+  , method2 ( conf.getParameter<bool>("Method2") )
+  , trackCollName  ( conf.getParameter<edm::InputTag>("TrackCollection") )
+  , token_Tracks   ( consumes<reco::TrackCollection>(trackCollName) )
+  , token_BeamSpot ( consumes<reco::BeamSpot>       (conf.getParameter<edm::InputTag>("beamSpot") ) )
 {
   // Register my product
   produces<reco::VertexCollection>();
 
   // Setup shop
-  verbose_           = conf.getParameter<int>("Verbosity"); // 0 silent, 1 chatty, 2 loud
   std::string finder = conf.getParameter<std::string>("Finder"); // DivisiveVertexFinder
   bool useError      = conf.getParameter<bool>("UseError"); // true
   bool wtAverage     = conf.getParameter<bool>("WtAverage"); // true
@@ -25,11 +29,7 @@ PixelVertexProducer::PixelVertexProducer(const edm::ParameterSet& conf)
   double zSeparation = conf.getParameter<double>("ZSeparation"); // 0.05 cm
   int ntrkMin        = conf.getParameter<int>("NTrkMin"); // 3
   // Tracking requirements before sending a track to be considered for vtx
-  ptMin_ = conf.getParameter<double>("PtMin"); // 1.0 GeV
-  trackCollName = conf.getParameter<edm::InputTag>("TrackCollection");
-  token_Tracks = consumes<reco::TrackCollection>(trackCollName);
-  token_BeamSpot = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpot"));
-  method2 = conf.getParameter<bool>("Method2");
+  
 
   double track_pt_min   = ptMin_;
   double track_pt_max   = 10.;


### PR DESCRIPTION
as reported by @fwyzard
https://docs.google.com/spreadsheets/d/1D9khDvOl05WEbznsUPCusEbrHeep9hh8cXedMXX09Gc/edit#gid=0
there are modules used @HLT which still need to be migrated and be multithread safe

this is the migration of the module PixelVertexProducer
