### PR TITLE
Add "profile" to DQMGenericClient

### DIFF
--- a/DQMServices/ClientConfig/interface/DQMGenericClient.h
+++ b/DQMServices/ClientConfig/interface/DQMGenericClient.h
@@ -47,6 +47,12 @@ class DQMGenericClient : public DQMEDHarvester
     std::string srcName;
   };
 
+  struct ProfileOption
+  {
+    std::string name, title;
+    std::string srcName;
+  };
+
   struct NormOption
   {
     std::string name, normHistName;
@@ -71,6 +77,11 @@ class DQMGenericClient : public DQMEDHarvester
 			 const std::string& startDir, 
                          const std::string& fitMEPrefix, const std::string& fitMETitlePrefix, 
                          const std::string& srcMEName);
+  void computeProfile(DQMStore::IBooker& ibooker,
+                      DQMStore::IGetter& igetter,
+                      const std::string& startDir,
+                      const std::string& profileMEName, const std::string& profileMETitle,
+                      const std::string& srcMEName);
 
   void normalizeToEntries(DQMStore::IBooker& ibooker,
 			  DQMStore::IGetter& igetter,
@@ -95,6 +106,7 @@ class DQMGenericClient : public DQMEDHarvester
 
   std::vector<EfficOption> efficOptions_;
   std::vector<ResolOption> resolOptions_;
+  std::vector<ProfileOption> profileOptions_;
   std::vector<NormOption> normOptions_;
   std::vector<CDOption> cdOptions_;
 

--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -96,14 +96,14 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
     efficOptions_.push_back(opt);
   }
 
-  // Parse profiles
-  vstring profileCmds = pset.getUntrackedParameter<vstring>("efficiencyProfile", vstring());
-  for ( vstring::const_iterator profileCmd = profileCmds.begin();
-        profileCmd != profileCmds.end(); ++profileCmd )
+  // Parse efficiency profiles
+  vstring effProfileCmds = pset.getUntrackedParameter<vstring>("efficiencyProfile", vstring());
+  for ( vstring::const_iterator effProfileCmd = effProfileCmds.begin();
+        effProfileCmd != effProfileCmds.end(); ++effProfileCmd )
   {
-    if ( profileCmd->empty() ) continue;
+    if ( effProfileCmd->empty() ) continue;
 
-    boost::tokenizer<elsc> tokens(*profileCmd, commonEscapes);
+    boost::tokenizer<elsc> tokens(*effProfileCmd, commonEscapes);
 
     vector<string> args;
     for(boost::tokenizer<elsc>::const_iterator iToken = tokens.begin();
@@ -113,7 +113,7 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
     }
 
     if ( args.size() < 4 ) {
-      LogInfo("DQMGenericClient") << "Wrong input to profileCmds\n";
+      LogInfo("DQMGenericClient") << "Wrong input to effProfileCmds\n";
       continue;
     }
 
@@ -132,18 +132,18 @@ DQMGenericClient::DQMGenericClient(const ParameterSet& pset)
     efficOptions_.push_back(opt);
   }
 
-  VPSet profileSets = pset.getUntrackedParameter<VPSet>("efficiencyProfileSets", VPSet());
-  for ( VPSet::const_iterator profileSet = profileSets.begin();
-        profileSet != profileSets.end(); ++profileSet )
+  VPSet effProfileSets = pset.getUntrackedParameter<VPSet>("efficiencyProfileSets", VPSet());
+  for ( VPSet::const_iterator effProfileSet = effProfileSets.begin();
+        effProfileSet != effProfileSets.end(); ++effProfileSet )
   {
     EfficOption opt;
-    opt.name = profileSet->getUntrackedParameter<string>("name");
-    opt.title = profileSet->getUntrackedParameter<string>("title");
-    opt.numerator = profileSet->getUntrackedParameter<string>("numerator");
-    opt.denominator = profileSet->getUntrackedParameter<string>("denominator");
+    opt.name = effProfileSet->getUntrackedParameter<string>("name");
+    opt.title = effProfileSet->getUntrackedParameter<string>("title");
+    opt.numerator = effProfileSet->getUntrackedParameter<string>("numerator");
+    opt.denominator = effProfileSet->getUntrackedParameter<string>("denominator");
     opt.isProfile = true;
 
-    const string typeName = profileSet->getUntrackedParameter<string>("typeName", "eff");
+    const string typeName = effProfileSet->getUntrackedParameter<string>("typeName", "eff");
     if ( typeName == "eff" ) opt.type = 1;
     else if ( typeName == "fake" ) opt.type = 2;
     else opt.type = 0;

--- a/SLHCUpgradeSimulations/Geometry/test/Harvesting_cfg.py
+++ b/SLHCUpgradeSimulations/Geometry/test/Harvesting_cfg.py
@@ -63,7 +63,6 @@ process.schedule = cms.Schedule(process.edmtome_step,process.dqmHarvesting,proce
 # For some reason a seed harvester isn't included in the standard sequences. If this next processor isn't
 # run then things like efficiencies are just added together instead of recalculated.
 process.postProcessorSeed = cms.EDAnalyzer("DQMGenericClient",
-	profile = cms.vstring(),
 	resolution = cms.vstring(),
 	efficiency = cms.vstring("effic \'Efficiency vs #eta\' num_assoc(simToReco)_eta num_simul_eta", 
 		"efficPt \'Efficiency vs p_{T}\' num_assoc(simToReco)_pT num_simul_pT", 

--- a/Validation/RecoTrack/python/HLTpostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/HLTpostProcessorTracker_cfi.py
@@ -66,7 +66,7 @@ postProcessorHLTtracking = cms.EDAnalyzer("DQMGenericClient",
                              "h_thetapulleta '#theta Pull vs #eta' thetapull_vs_eta",
                              "h_thetapullphi '#theta Pull vs #phi' thetapull_vs_phi"
                              ),
-    profile= cms.vstring(
+    profile= cms.untracked.vstring(
                          "chi2mean 'mean #chi^{2} vs #eta' chi2_vs_eta",
                          "chi2mean_vs_phi 'mean #chi^{2} vs #phi' chi2_vs_phi",
                          "chi2mean_vs_nhits 'mean #chi^{2} vs n. hits' chi2_vs_nhits",

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -72,7 +72,7 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
                              "h_thetapulleta '#theta Pull vs #eta' thetapull_vs_eta",
                              "h_thetapullphi '#theta Pull vs #phi' thetapull_vs_phi"
                              ),
-    profile= cms.vstring(
+    profile= cms.untracked.vstring(
                          "chi2mean 'mean #chi^{2} vs #eta' chi2_vs_eta",
                          "chi2mean_vs_phi 'mean #chi^{2} vs #phi' chi2_vs_phi",
                          "chi2mean_vs_nhits 'mean #chi^{2} vs n. hits' chi2_vs_nhits",

--- a/Validation/RecoVertex/python/PostProcessorV0_cfi.py
+++ b/Validation/RecoVertex/python/PostProcessorV0_cfi.py
@@ -31,6 +31,5 @@ postProcessorV0 = cms.EDAnalyzer("DQMGenericClient",
        "LamTkFakeVsPt '#Lambda tracking fake rate vs p{T}' LamTkFakeVsPt_num LamFakeVsPt_denom"
    ),
    resolution = cms.vstring(),
-   profile = cms.vstring(),
    outputFileName = cms.untracked.string("")
 )

--- a/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
+++ b/Validation/RecoVertex/python/PrimaryVertexAnalyzer4PUSlimmed_Client_cfi.py
@@ -40,7 +40,6 @@ postProcessorVertex = cms.EDAnalyzer("DQMGenericClient",
                                          "duplicate_vs_ClosestVertexInZ 'Duplicate vs ClosestsVtx In Z' RecoAllAssoc2MultiMatchedGen_ClosestDistanceZ RecoAllAssoc2Gen_ClosestDistanceZ"
                                      ),
                                      resolution = cms.vstring(),
-                                     profile= cms.vstring(),
                                      outputFileName = cms.untracked.string(""),
                                      verbose = cms.untracked.uint32(5)
 )


### PR DESCRIPTION
The MultiTrackValidator harvesting configuration `Validation/RecoTrack/python/PostProcessorTracker_cfi.py` defined `profile = cms.vstring(...)` parameter for DQMGenericClient (since ~2009), but as far as I can tell this option has never been supported by DQMGenericClient.

This PR adds the "profile" functionality to DQMGenericClient (it is essentially just `TH2::ProfileX()`), and changes the parameter type to `untracked` (following the `efficiencyProfile`). I also migrated the other configuration I found with a simple `git grep`, and removed empty definitions.

Passes short matrix, the only impact should be that the profiles defined in

```
Validation/RecoTrack/python/PostProcessorTracker_cfi.py
Validation/RecoTrack/python/HLTpostProcessorTracker_cfi.py
```

appear in the workflows using these.

FYI @rovere @cerati @VinInn 
