### PR TITLE
Enable USE_SSEVECT only on x86_64 with SSE

### DIFF
--- a/DataFormats/Math/interface/SIMDVec.h
+++ b/DataFormats/Math/interface/SIMDVec.h
@@ -3,7 +3,11 @@
 
 #if ( defined(IN_DICTBUILD) || defined(__REFLEX__) || defined(__CINT__) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16)
 #elif defined(__GNUC__) || defined(__clang__)
-#define USE_SSEVECT
+#  if defined(__x86_64__) && defined(__SSE__)
+#    define USE_SSEVECT
+#  else
+#    define USE_EXTVECT
+#  endif
 #endif
 
 


### PR DESCRIPTION
Patch enables USE_SSEVECT (vector implementation based on SSE
intrinsics) only on a proper hardware, i.e, x86_64 with SSE.

For the rest of architectures (armv7hl, aarch64, power8, etc.) use
USE_EXTVECT.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
