### PR TITLE
migration from EDProducer to stream::EDProducer (BeamSpotOnlineProducer)

### DIFF
--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
@@ -42,7 +42,7 @@ class BeamSpotOnlineProducer: public edm::stream::EDProducer<> {
 	const edm::EDGetTokenT<BeamSpotOnlineCollection> scalerToken_;
 	const edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> l1GtEvmReadoutRecordToken_;
 
-	const boost::uint16_t theBeamShoutMode;
+	const unsigned int theBeamShoutMode;
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
+++ b/RecoVertex/BeamSpotProducer/interface/BeamSpotOnlineProducer.h
@@ -12,7 +12,7 @@
 
 ________________________________________________________________**/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -21,7 +21,7 @@ ________________________________________________________________**/
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerEvmReadoutRecord.h"
 
 
-class BeamSpotOnlineProducer: public edm::EDProducer {
+class BeamSpotOnlineProducer: public edm::stream::EDProducer<> {
 
   public:
 	typedef std::vector<edm::ParameterSet> Parameters;
@@ -32,14 +32,17 @@ class BeamSpotOnlineProducer: public edm::EDProducer {
 	~BeamSpotOnlineProducer();
 	
 	/// produce a beam spot class
-	virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup);
+	virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 
   private:
 
-	bool changeFrame_;
-	double theMaxZ,theMaxR2,theSetSigmaZ;
-	edm::EDGetTokenT<BeamSpotOnlineCollection> scalerToken_;
-	edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> l1GtEvmReadoutRecordToken_;
+	const bool changeFrame_;
+	const double theMaxZ,theSetSigmaZ;
+	double theMaxR2;
+	const edm::EDGetTokenT<BeamSpotOnlineCollection> scalerToken_;
+	const edm::EDGetTokenT<L1GlobalTriggerEvmReadoutRecord> l1GtEvmReadoutRecordToken_;
+
+	const boost::uint16_t theBeamShoutMode;
 };
 
 #endif

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -20,7 +20,7 @@ BeamSpotOnlineProducer::BeamSpotOnlineProducer(const ParameterSet& iconf)
   , theSetSigmaZ ( iconf.getParameter<double>("setSigmaZ")              )
   , scalerToken_               ( consumes<BeamSpotOnlineCollection>       ( iconf.getParameter<InputTag>("src")       ) )
   , l1GtEvmReadoutRecordToken_ ( consumes<L1GlobalTriggerEvmReadoutRecord>( iconf.getParameter<InputTag>("gtEvmLabel")) )
-  , theBeamShoutMode ( iconf.getUntrackedParameter<int> ("beamMode",11) )
+  , theBeamShoutMode ( iconf.getUntrackedParameter<unsigned int> ("beamMode",11) )
 {
 
   theMaxR2 = iconf.getParameter<double>("maxRadius");
@@ -39,8 +39,7 @@ BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup)
   bool shoutMODE=false;
   edm::Handle<L1GlobalTriggerEvmReadoutRecord> gtEvmReadoutRecord;
   if (iEvent.getByToken(l1GtEvmReadoutRecordToken_, gtEvmReadoutRecord)){
-    const boost::uint16_t beamModeValue = (gtEvmReadoutRecord->gtfeWord()).beamMode();
-    if (beamModeValue == theBeamShoutMode) shoutMODE=true;
+    if (gtEvmReadoutRecord->gtfeWord().beamMode() == theBeamShoutMode) shoutMODE=true;
   }
   else{
     shoutMODE=true;

--- a/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
+++ b/RecoVertex/BeamSpotProducer/plugins/BeamSpotOnlineProducer.cc
@@ -15,21 +15,16 @@ using namespace edm;
 
 
 BeamSpotOnlineProducer::BeamSpotOnlineProducer(const ParameterSet& iconf)
+  : changeFrame_ ( iconf.getParameter<bool>  ("changeToCMSCoordinates") )
+  , theMaxZ      ( iconf.getParameter<double>("maxZ")                   )
+  , theSetSigmaZ ( iconf.getParameter<double>("setSigmaZ")              )
+  , scalerToken_               ( consumes<BeamSpotOnlineCollection>       ( iconf.getParameter<InputTag>("src")       ) )
+  , l1GtEvmReadoutRecordToken_ ( consumes<L1GlobalTriggerEvmReadoutRecord>( iconf.getParameter<InputTag>("gtEvmLabel")) )
+  , theBeamShoutMode ( iconf.getUntrackedParameter<int> ("beamMode",11) )
 {
-
-  scalerToken_ = consumes<BeamSpotOnlineCollection>(
-      iconf.getParameter<InputTag>("src"));
-
-  changeFrame_ = iconf.getParameter<bool>("changeToCMSCoordinates");
 
   theMaxR2 = iconf.getParameter<double>("maxRadius");
   theMaxR2*=theMaxR2;
-  theMaxZ = iconf.getParameter<double>("maxZ");
-
-  theSetSigmaZ = iconf.getParameter<double>("setSigmaZ");
-
-  l1GtEvmReadoutRecordToken_ = consumes<L1GlobalTriggerEvmReadoutRecord>(
-      iconf.getParameter<InputTag>("gtEvmLabel"));
 
   produces<reco::BeamSpot>();
 
@@ -45,7 +40,7 @@ BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup)
   edm::Handle<L1GlobalTriggerEvmReadoutRecord> gtEvmReadoutRecord;
   if (iEvent.getByToken(l1GtEvmReadoutRecordToken_, gtEvmReadoutRecord)){
     const boost::uint16_t beamModeValue = (gtEvmReadoutRecord->gtfeWord()).beamMode();
-    if (beamModeValue == 11) shoutMODE=true;
+    if (beamModeValue == theBeamShoutMode) shoutMODE=true;
   }
   else{
     shoutMODE=true;
@@ -87,7 +82,7 @@ BeamSpotOnlineProducer::produce(Event& iEvent, const EventSetup& iSetup)
     
     aSpot = reco::BeamSpot( apoint,
 			    sigmaZ,
-			  spotOnline.dxdz(),
+			    spotOnline.dxdz(),
 			    f* spotOnline.dydz(),
 			    spotOnline.width_x(),
 			    matrix);


### PR DESCRIPTION
as reported by @fwyzard
https://docs.google.com/spreadsheets/d/1D9khDvOl05WEbznsUPCusEbrHeep9hh8cXedMXX09Gc/edit#gid=0
there are modules used @HLT which still need to be migrated and be multithread safe

this is the migration of the module BeamSpotOnlineProducer
