### PR TITLE
migration from EDFilter to stream::EDFilter (DetectorStateFilter)

### DIFF
--- a/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
+++ b/DQM/TrackerCommon/plugins/DetectorStateFilter.cc
@@ -12,14 +12,14 @@
 //
 // -- Constructor
 //
-DetectorStateFilter::DetectorStateFilter( const edm::ParameterSet & pset ) {
-   verbose_        = pset.getUntrackedParameter<bool>( "DebugOn", false );
-   detectorType_   = pset.getUntrackedParameter<std::string>( "DetectorType", "sistrip");
-   dcsStatusLabel_ = consumes<DcsStatusCollection>(pset.getUntrackedParameter<edm::InputTag>( "DcsStatusLabel", edm::InputTag("scalersRawToDigi")));
-
-   nEvents_         = 0;
-   nSelectedEvents_ = 0;
-   detectorOn_  = false;
+DetectorStateFilter::DetectorStateFilter( const edm::ParameterSet & pset ) 
+  : verbose_      ( pset.getUntrackedParameter<bool>       ( "DebugOn",      false )    )
+  , detectorType_ ( pset.getUntrackedParameter<std::string>( "DetectorType", "sistrip") )
+  , dcsStatusLabel_ ( consumes<DcsStatusCollection>( pset.getUntrackedParameter<edm::InputTag>( "DcsStatusLabel", edm::InputTag("scalersRawToDigi")) ) )
+{
+  nEvents_         = 0;
+  nSelectedEvents_ = 0;
+  detectorOn_      = false;
 }
 //
 // -- Destructor

--- a/DQM/TrackerCommon/plugins/DetectorStateFilter.h
+++ b/DQM/TrackerCommon/plugins/DetectorStateFilter.h
@@ -1,23 +1,23 @@
 #ifndef DetectorStateFilter_H
 #define DetectorStateFilter_H
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 
  
-class DetectorStateFilter : public edm::EDFilter {
+class DetectorStateFilter : public edm::stream::EDFilter<> {
  public:
  DetectorStateFilter( const edm::ParameterSet & );
  ~DetectorStateFilter();
   private:
-  bool filter( edm::Event &, edm::EventSetup const& );
+  bool filter( edm::Event &, edm::EventSetup const& ) override;
 
+  const bool verbose_;
   uint64_t nEvents_, nSelectedEvents_;
-  bool verbose_;
   bool detectorOn_;
-  std::string detectorType_;
-  edm::EDGetTokenT<DcsStatusCollection> dcsStatusLabel_;
+  const std::string detectorType_;
+  const edm::EDGetTokenT<DcsStatusCollection> dcsStatusLabel_;
 };
 
 #endif


### PR DESCRIPTION
as reported by @fwyzard
https://docs.google.com/spreadsheets/d/1D9khDvOl05WEbznsUPCusEbrHeep9hh8cXedMXX09Gc/edit#gid=0
there are modules used @HLT which still need to be migrated and be multithread safe

this is the migration of the module DetectorStateFilter
