### PR TITLE
Tauola115 7 3 x

### DIFF
--- a/GeneratorInterface/TauolaInterface/interface/TauSpinnerCMS.h
+++ b/GeneratorInterface/TauolaInterface/interface/TauSpinnerCMS.h
@@ -73,7 +73,10 @@ private:
   edm::InputTag gensrc_;
   int MotherPDGID_,Ipol_,nonSM2_,nonSMN_;
   static bool isTauSpinnerConfigure;
-
+  double roundOff_;
+  bool doH0T, doZ0T;
+  double H0Rxx,H0Ryy,H0Rxy,H0Ryx,Z0Rxx,Z0Ryy,Z0Rxy,Z0Ryx;
+  
   // Additional funtionms for Reco (not provided by Tauola/TauSpinner authors)
   int readParticlesfromReco(edm::Event& e,
                             TauSpinner::SimpleParticle &X,
@@ -86,7 +89,6 @@ private:
                         std::vector<TauSpinner::SimpleParticle> &daughters,
                         int parentpdgid);
   bool isFirst(const reco::GenParticle *Particle);
-  double roundOff_;
 
   static CLHEP::HepRandomEngine* fRandomEngine;
   edm::EDGetTokenT<edm::HepMCProduct> hepmcCollectionToken_;

--- a/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
@@ -208,7 +208,7 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
             WTFlip=WTother/WT;
 	    double Rxx(0),Ryy(0),Rxy(0),Ryx(0);
 	    TauSpinner::getZgamParametersTR(Rxx,Ryy,Rxy,Ryx);
-	    std::cout << "Z R " << Rxx << " " << Ryy << " " << Rxy << " " << Ryx << std::endl;
+	    //std::cout << "Z R " << Rxx << " " << Ryy << " " << Rxy << " " << Ryx << std::endl;
           }
         }
       }
@@ -223,6 +223,7 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
   *TauSpinnerWeightisValid =isValid;
   e.put(TauSpinnerWeightisValid,"TauSpinnerWTisValid");
 
+  std::cout << WT << std::endl;
   // regular weight
   std::auto_ptr<double> TauSpinnerWeight(new double);
   *TauSpinnerWeight =WT;

--- a/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
@@ -12,6 +12,10 @@
 #include "FWCore/Utilities/interface/RandomNumberGenerator.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/ServiceRegistry/interface/RandomEngineSentry.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include <stdlib.h>
+#include <cstdlib> 
 
 using namespace edm;
 using namespace TauSpinner;
@@ -33,8 +37,16 @@ TauSpinnerCMS::TauSpinnerCMS( const ParameterSet& pset ) :
   ,nonSM2_(pset.getUntrackedParameter("nonSM2",(int)(0)))
   ,nonSMN_(pset.getUntrackedParameter("nonSMN",(int)(0)))
   ,roundOff_(pset.getUntrackedParameter("roundOff",(double)(0.01)))
+  ,doH0T(false), doZ0T(false)
+  ,H0Rxx(0)
+  ,H0Ryy(0)
+  ,H0Rxy(0)
+  ,H0Ryx(0)
+  ,Z0Rxx(0)
+  ,Z0Ryy(0)
+  ,Z0Rxy(0)
+  ,Z0Ryx(0)
 {
-  //usesResource(edm::uniqueSharedResourceName());
   usesResource(edm::SharedResourceNames::kTauola);
 
   produces<bool>("TauSpinnerWTisValid").setBranchAlias("TauSpinnerWTisValid");
@@ -49,6 +61,64 @@ TauSpinnerCMS::TauSpinnerCMS( const ParameterSet& pset ) :
   else{
     hepmcCollectionToken_=consumes<HepMCProduct>(gensrc_);
   }
+
+  ///////////////////////////////
+  // define dynamic parameters
+  //
+  if(pset.exists("parameterSets")){
+    std::vector<std::string> par = pset.getParameter< std::vector<std::string> >("parameterSets");
+    for (unsigned int ip=0; ip<par.size(); ++ip ){
+      std::string curSet = par[ip];
+      if(curSet=="ZTSpinCorr") {
+	std::vector<double> v = pset.getParameter< std::vector<double> >(curSet);
+	if(v.size()==0){
+	  doZ0T=true;
+	  Z0Rxx=1.0;
+	  Z0Ryy=1.0;
+	  Z0Rxy=1.0;
+	  Z0Ryx=1.0;
+	}
+	else if(v.size()==4){
+	  doZ0T=true;
+          Z0Rxx=v.at(0);
+          Z0Ryy=v.at(1);
+          Z0Rxy=v.at(2);
+          Z0Ryx=v.at(3);
+	}
+	else{
+	  edm::LogError("TauSpinnerCMS") << "Invalid size for ZTSpinCorr!!!! Please read instruction manual... ";
+	}
+      }
+      if(curSet=="HTSpinCorr") {
+	std::vector<double> v = pset.getParameter< std::vector<double> >(curSet);
+	if(v.size()==4){
+	  doH0T=true;
+	  H0Rxx=v.at(0);
+	  H0Ryy=v.at(1);
+	  H0Rxy=v.at(2);
+	  H0Ryx=v.at(3);
+	}
+	else if(v.size()==1){
+	  doH0T=true;
+	  double phi=v.at(0);
+	  H0Rxx=-cos(2*phi);
+          H0Ryy=cos(2*phi);
+          H0Rxy=-sin(2*phi);
+          H0Ryx=-sin(2*phi);
+	}
+	else{
+	  edm::LogError("TauSpinnerCMS") << "Invalid size for HTSpinCorr!!!! Please read instruction manual... ";
+	}
+      }
+    }
+  }
+
+  std::string Base= getenv ("TAUOLAPPDATA");
+  std::string cmd="cp ";
+  cmd+=Base;
+  cmd+="/* .";
+  system(cmd.data());
+
 }
 
 void TauSpinnerCMS::beginJob(){};
@@ -70,7 +140,11 @@ void TauSpinnerCMS::initialize(){
     //Ipol - polarization of input sample
     //nonSM2 - nonstandard model calculations
     //nonSMN
+   
     TauSpinner::initialize_spinner(Ipp,Ipol_,nonSM2_,nonSMN_,CMSEnergy_);
+
+    if(doH0T)TauSpinner::setHiggsParametersTR(H0Rxx,H0Ryy,H0Rxy,H0Ryx);
+    if(doZ0T)TauSpinner::setZgamMultipliersTR(Z0Rxx,Z0Ryy,Z0Rxy,Z0Ryx);
   }
   fInitialized=true;
 }
@@ -130,9 +204,11 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
           if(X.pdgid()==25 || X.pdgid()==22 || X.pdgid()==23 ){
             if(X.pdgid()==25) X.setPdgid(23);
             if( X.pdgid()==22 || X.pdgid()==23 ) X.setPdgid(25);
-
             double WTother=TauSpinner::calculateWeightFromParticlesH(X, tau, tau2, tau_daughters,tau_daughters2);
             WTFlip=WTother/WT;
+	    double Rxx(0),Ryy(0),Rxy(0),Ryx(0);
+	    TauSpinner::getZgamParametersTR(Rxx,Ryy,Rxy,Ryx);
+	    std::cout << "Z R " << Rxx << " " << Ryy << " " << Rxy << " " << Ryx << std::endl;
           }
         }
       }

--- a/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/TauSpinner/TauSpinnerCMS.cc
@@ -223,7 +223,6 @@ void TauSpinnerCMS::produce( edm::Event& e, const edm::EventSetup& iSetup){
   *TauSpinnerWeightisValid =isValid;
   e.put(TauSpinnerWeightisValid,"TauSpinnerWTisValid");
 
-  std::cout << WT << std::endl;
   // regular weight
   std::auto_ptr<double> TauSpinnerWeight(new double);
   *TauSpinnerWeight =WT;

--- a/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
+++ b/GeneratorInterface/TauolaInterface/plugins/Tauolapp/TauolappInterface.cc
@@ -12,6 +12,10 @@
 #include "HepMC/IO_HEPEVT.h"
 #include "HepMC/HEPEVT_Wrapper.h"
 #include "SimGeneral/HepPDTRecord/interface/ParticleDataTable.h"
+
+#include <stdlib.h>
+#include <cstdlib>
+
 using namespace gen;
 using namespace edm;
 using namespace std;
@@ -37,7 +41,16 @@ TauolappInterface::TauolappInterface( const edm::ParameterSet& pset):
 {
   if ( fPSet != 0 ) throw cms::Exception("TauolappInterfaceError") << "Attempt to override Tauola an existing ParameterSet\n" << std::endl;
   fPSet = new ParameterSet(pset);
+
+  std::string Base= getenv ("TAUOLAPPDATA");
+  std::string cmd="cp ";
+  cmd+=Base;
+  cmd+="/* .";
+  std::cout << cmd.data() << std::endl;
+  system(cmd.data());
+
 }
+
 TauolappInterface::~TauolappInterface(){if ( fPSet != 0 ) delete fPSet;}
 void TauolappInterface::init( const edm::EventSetup& es ){
   if ( fIsInitialized ) return; // do init only once

--- a/GeneratorInterface/TauolaInterface/test/DYToLL_M_50_TuneZ2star_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/DYToLL_M_50_TuneZ2star_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -25,7 +25,7 @@ process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
 process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
 
 process.maxEvents = cms.untracked.PSet(
-    input = cms.untracked.int32(10000)
+    input = cms.untracked.int32(20000)
 )
 
 # Input source
@@ -78,63 +78,63 @@ process.generator = cms.EDFilter("Pythia6GeneratorFilter",
     ExternalDecays = cms.PSet(
         Tauola = cms.untracked.PSet(
             UseTauolaPolarization = cms.bool(False),
-parameterSets = cms.vstring(),
+            parameterSets = cms.vstring(),
             InputCards = cms.PSet(
                 mdtau = cms.int32(0),
                 pjak2 = cms.int32(3),
                 pjak1 = cms.int32(3)
-            )
-        ),
+                )
+            ),
         parameterSets = cms.vstring('Tauola')
-    ),
-    maxEventsToPrint = cms.untracked.int32(0),
-    pythiaPylistVerbosity = cms.untracked.int32(1),
+        ),
+                                 maxEventsToPrint = cms.untracked.int32(0),
+                                 pythiaPylistVerbosity = cms.untracked.int32(1),
     filterEfficiency = cms.untracked.double(1.0),
-    pythiaHepMCVerbosity = cms.untracked.bool(False),
-    comEnergy = cms.double(13000.0),
-    crossSection = cms.untracked.double(762.0),
-    UseExternalGenerators = cms.untracked.bool(True),
-    PythiaParameters = cms.PSet(
+                                 pythiaHepMCVerbosity = cms.untracked.bool(False),
+                                 comEnergy = cms.double(13000.0),
+                                 crossSection = cms.untracked.double(762.0),
+                                 UseExternalGenerators = cms.untracked.bool(True),
+                                 PythiaParameters = cms.PSet(
         pythiaUESettings = cms.vstring('MSTU(21)=1 ! Check on possible errors during program execution',
-            'MSTJ(22)=2 ! Decay those unstable particles',
-            'PARJ(71)=10 . ! for which ctau 10 mm',
-            'MSTP(33)=0 ! no K factors in hard cross sections',
-            'MSTP(2)=1 ! which order running alphaS',
-            'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)',
-            'MSTP(52)=2 ! work with LHAPDF',
-            'PARP(82)=1.921 ! pt cutoff for multiparton interactions',
-            'PARP(89)=1800. ! sqrts for which PARP82 is set',
-            'PARP(90)=0.227 ! Multiple interactions: rescaling power',
-            'MSTP(95)=6 ! CR (color reconnection parameters)',
-            'PARP(77)=1.016 ! CR',
-            'PARP(78)=0.538 ! CR',
-            'PARP(80)=0.1 ! Prob. colored parton from BBR',
-            'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter',
-            'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter',
-            'PARP(62)=1.025 ! ISR cutoff',
-            'MSTP(91)=1 ! Gaussian primordial kT',
-            'PARP(93)=10.0 ! primordial kT-max',
-            'MSTP(81)=21 ! multiple parton interactions 1 is Pythia default',
-            'MSTP(82)=4 ! Defines the multi-parton model'),
+                                       'MSTJ(22)=2 ! Decay those unstable particles',
+                                       'PARJ(71)=10 . ! for which ctau 10 mm',
+                                       'MSTP(33)=0 ! no K factors in hard cross sections',
+                                       'MSTP(2)=1 ! which order running alphaS',
+                                       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)',
+                                       'MSTP(52)=2 ! work with LHAPDF',
+                                       'PARP(82)=1.921 ! pt cutoff for multiparton interactions',
+                                       'PARP(89)=1800. ! sqrts for which PARP82 is set',
+                                       'PARP(90)=0.227 ! Multiple interactions: rescaling power',
+                                       'MSTP(95)=6 ! CR (color reconnection parameters)',
+                                       'PARP(77)=1.016 ! CR',
+                                       'PARP(78)=0.538 ! CR',
+                                       'PARP(80)=0.1 ! Prob. colored parton from BBR',
+                                       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter',
+                                       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter',
+                                       'PARP(62)=1.025 ! ISR cutoff',
+                                       'MSTP(91)=1 ! Gaussian primordial kT',
+                                       'PARP(93)=10.0 ! primordial kT-max',
+                                       'MSTP(81)=21 ! multiple parton interactions 1 is Pythia default',
+                                       'MSTP(82)=4 ! Defines the multi-parton model'),
         processParameters = cms.vstring('MSEL=0 !User defined processes',
-            'MSUB(1)=1 !Incl Z0/gamma* production',
-            'MSTP(43)=3 !Both Z0 and gamma*',
-            'MDME(174,1)=0 !Z decay into d dbar',
-            'MDME(175,1)=0 !Z decay into u ubar',
-            'MDME(176,1)=0 !Z decay into s sbar',
-            'MDME(177,1)=0 !Z decay into c cbar',
-            'MDME(178,1)=0 !Z decay into b bbar',
-            'MDME(179,1)=0 !Z decay into t tbar',
-            'MDME(182,1)=1 !Z decay into e- e+',
-            'MDME(183,1)=0 !Z decay into nu_e nu_ebar',
-            'MDME(184,1)=1 !Z decay into mu- mu+',
-            'MDME(185,1)=0 !Z decay into nu_mu nu_mubar',
-            'MDME(186,1)=1 !Z decay into tau- tau+',
-            'MDME(187,1)=0 !Z decay into nu_tau nu_taubar',
-            'CKIN(1)=50. !Minimum sqrt(s_hat) value (=Z mass)'),
+                                        'MSUB(1)=1 !Incl Z0/gamma* production',
+                                        'MSTP(43)=3 !Both Z0 and gamma*',
+                                        'MDME(174,1)=0 !Z decay into d dbar',
+                                        'MDME(175,1)=0 !Z decay into u ubar',
+                                        'MDME(176,1)=0 !Z decay into s sbar',
+                                        'MDME(177,1)=0 !Z decay into c cbar',
+                                        'MDME(178,1)=0 !Z decay into b bbar',
+                                        'MDME(179,1)=0 !Z decay into t tbar',
+                                        'MDME(182,1)=1 !Z decay into e- e+',
+                                        'MDME(183,1)=0 !Z decay into nu_e nu_ebar',
+                                        'MDME(184,1)=1 !Z decay into mu- mu+',
+                                        'MDME(185,1)=0 !Z decay into nu_mu nu_mubar',
+                                        'MDME(186,1)=1 !Z decay into tau- tau+',
+                                        'MDME(187,1)=0 !Z decay into nu_tau nu_taubar',
+                                        'CKIN(1)=50. !Minimum sqrt(s_hat) value (=Z mass)'),
         parameterSets = cms.vstring('pythiaUESettings',
-            'processParameters')
-    )
+                                    'processParameters')
+        )
 )
 
 

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusion_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusion_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -147,6 +147,9 @@ process.generator = cms.EDFilter("Pythia6GeneratorFilter",
 				 )
 
 
+process.TauSpinnerGen.parameterSets=cms.vstring("HTSpinCorr")
+process.TauSpinnerGen.HTSpinCorr = cms.vdouble(0.75)
+
 process.ProductionFilterSequence = cms.Sequence(process.generator)
 
 # Path and EndPath definitions

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -1,0 +1,167 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: H130GGgluonfusion_8TeV_tauola_cfi.py --conditions auto:startup -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 1000 --eventcontent RAWSIM
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
+process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('H130GGgluonfusion_8TeV_tauola_cfi.py nevts:1000'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+						   generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerGen  = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
+						   VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
+						   )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+
+process.generator = cms.EDFilter("Pythia6GeneratorFilter",
+				 ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(False),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(3),
+	pjak1 = cms.int32(3)
+	)
+        ),
+        parameterSets = cms.vstring('Tauola')
+	),
+				 maxEventsToPrint = cms.untracked.int32(3),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 crossSection = cms.untracked.double(0.05),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 PythiaParameters = cms.PSet(
+        pythiaUESettings = cms.vstring('MSTU(21)=1     ! Check on possible errors during program execution', 
+				       'MSTJ(22)=2     ! Decay those unstable particles', 
+				       'PARJ(71)=10 .  ! for which ctau  10 mm', 
+				       'MSTP(33)=0     ! no K factors in hard cross sections', 
+				       'MSTP(2)=1      ! which order running alphaS', 
+				       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)', 
+				       'MSTP(52)=2     ! work with LHAPDF', 
+				       'PARP(82)=1.921 ! pt cutoff for multiparton interactions', 
+				       'PARP(89)=1800. ! sqrts for which PARP82 is set', 
+				       'PARP(90)=0.227 ! Multiple interactions: rescaling power', 
+				       'MSTP(95)=6     ! CR (color reconnection parameters)', 
+				       'PARP(77)=1.016 ! CR', 
+				       'PARP(78)=0.538 ! CR', 
+				       'PARP(80)=0.1   ! Prob. colored parton from BBR', 
+				       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(62)=1.025 ! ISR cutoff', 
+				       'MSTP(91)=1     ! Gaussian primordial kT', 
+				       'PARP(93)=10.0  ! primordial kT-max', 
+				       'MSTP(81)=21    ! multiple parton interactions 1 is Pythia default', 
+				       'MSTP(82)=4     ! Defines the multi-parton model'),
+        processParameters = cms.vstring('PMAS(25,1)=130.0      !mass of Higgs', 
+					'MSEL=0                  ! user selection for process', 
+					'MSUB(102)=1             !ggH', 
+					'MSUB(123)=0             !ZZ fusion to H', 
+					'MSUB(124)=0             !WW fusion to H', 
+					'MSUB(24)=0              !ZH production', 
+					'MSUB(26)=0              !WH production', 
+					'MSUB(121)=0             !gg to ttH', 
+					'MSUB(122)=0             !qq to ttH', 
+					'MDME(210,1)=0           !Higgs decay into dd', 
+					'MDME(211,1)=0           !Higgs decay into uu', 
+					'MDME(212,1)=0           !Higgs decay into ss', 
+					'MDME(213,1)=0           !Higgs decay into cc', 
+					'MDME(214,1)=0           !Higgs decay into bb', 
+					'MDME(215,1)=0           !Higgs decay into tt', 
+					'MDME(216,1)=0           !Higgs decay into', 
+					'MDME(217,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(218,1)=0           !Higgs decay into e nu e', 
+					'MDME(219,1)=0           !Higgs decay into mu nu mu', 
+					'MDME(220,1)=1           !Higgs decay into tau nu tau', 
+					'MDME(221,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(222,1)=0           !Higgs decay into g g', 
+					'MDME(223,1)=0           !Higgs decay into gam gam', 
+					'MDME(224,1)=0           !Higgs decay into gam Z', 
+					'MDME(225,1)=0           !Higgs decay into Z Z', 
+					'MDME(226,1)=0           !Higgs decay into W W'),
+        parameterSets = cms.vstring('pythiaUESettings', 
+				    'processParameters')
+	)
+				 )
+
+
+process.TauSpinnerGen.parameterSets=cms.vstring("HTSpinCorr")
+process.TauSpinnerGen.HTSpinCorr = cms.vdouble(0.0)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen+process.TauSpinnerGen+process.TauSpinnerZHFilter)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -80,8 +80,8 @@ process.generator = cms.EDFilter("Pythia6GeneratorFilter",
 	UseTauolaPolarization = cms.bool(False),
 	InputCards = cms.PSet(
 	mdtau = cms.int32(0),
-	pjak2 = cms.int32(3),
-	pjak1 = cms.int32(3)
+	pjak2 = cms.int32(0),
+	pjak1 = cms.int32(0)
 	)
         ),
         parameterSets = cms.vstring('Tauola')

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_PhiHalfPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_PhiHalfPi_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -1,0 +1,167 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: H130GGgluonfusion_8TeV_tauola_cfi.py --conditions auto:startup -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 1000 --eventcontent RAWSIM
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
+process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('H130GGgluonfusion_8TeV_tauola_cfi.py nevts:1000'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+						   generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerGen  = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
+						   VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
+						   )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+
+process.generator = cms.EDFilter("Pythia6GeneratorFilter",
+				 ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(False),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(3),
+	pjak1 = cms.int32(3)
+	)
+        ),
+        parameterSets = cms.vstring('Tauola')
+	),
+				 maxEventsToPrint = cms.untracked.int32(3),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 crossSection = cms.untracked.double(0.05),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 PythiaParameters = cms.PSet(
+        pythiaUESettings = cms.vstring('MSTU(21)=1     ! Check on possible errors during program execution', 
+				       'MSTJ(22)=2     ! Decay those unstable particles', 
+				       'PARJ(71)=10 .  ! for which ctau  10 mm', 
+				       'MSTP(33)=0     ! no K factors in hard cross sections', 
+				       'MSTP(2)=1      ! which order running alphaS', 
+				       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)', 
+				       'MSTP(52)=2     ! work with LHAPDF', 
+				       'PARP(82)=1.921 ! pt cutoff for multiparton interactions', 
+				       'PARP(89)=1800. ! sqrts for which PARP82 is set', 
+				       'PARP(90)=0.227 ! Multiple interactions: rescaling power', 
+				       'MSTP(95)=6     ! CR (color reconnection parameters)', 
+				       'PARP(77)=1.016 ! CR', 
+				       'PARP(78)=0.538 ! CR', 
+				       'PARP(80)=0.1   ! Prob. colored parton from BBR', 
+				       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(62)=1.025 ! ISR cutoff', 
+				       'MSTP(91)=1     ! Gaussian primordial kT', 
+				       'PARP(93)=10.0  ! primordial kT-max', 
+				       'MSTP(81)=21    ! multiple parton interactions 1 is Pythia default', 
+				       'MSTP(82)=4     ! Defines the multi-parton model'),
+        processParameters = cms.vstring('PMAS(25,1)=130.0      !mass of Higgs', 
+					'MSEL=0                  ! user selection for process', 
+					'MSUB(102)=1             !ggH', 
+					'MSUB(123)=0             !ZZ fusion to H', 
+					'MSUB(124)=0             !WW fusion to H', 
+					'MSUB(24)=0              !ZH production', 
+					'MSUB(26)=0              !WH production', 
+					'MSUB(121)=0             !gg to ttH', 
+					'MSUB(122)=0             !qq to ttH', 
+					'MDME(210,1)=0           !Higgs decay into dd', 
+					'MDME(211,1)=0           !Higgs decay into uu', 
+					'MDME(212,1)=0           !Higgs decay into ss', 
+					'MDME(213,1)=0           !Higgs decay into cc', 
+					'MDME(214,1)=0           !Higgs decay into bb', 
+					'MDME(215,1)=0           !Higgs decay into tt', 
+					'MDME(216,1)=0           !Higgs decay into', 
+					'MDME(217,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(218,1)=0           !Higgs decay into e nu e', 
+					'MDME(219,1)=0           !Higgs decay into mu nu mu', 
+					'MDME(220,1)=1           !Higgs decay into tau nu tau', 
+					'MDME(221,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(222,1)=0           !Higgs decay into g g', 
+					'MDME(223,1)=0           !Higgs decay into gam gam', 
+					'MDME(224,1)=0           !Higgs decay into gam Z', 
+					'MDME(225,1)=0           !Higgs decay into Z Z', 
+					'MDME(226,1)=0           !Higgs decay into W W'),
+        parameterSets = cms.vstring('pythiaUESettings', 
+				    'processParameters')
+	)
+				 )
+
+
+process.TauSpinnerGen.parameterSets=cms.vstring("HTSpinCorr")
+process.TauSpinnerGen.HTSpinCorr = cms.vdouble(1.57)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen+process.TauSpinnerGen+process.TauSpinnerZHFilter)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_PhiQuarterPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaupinu_PhiQuarterPi_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -1,0 +1,167 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: H130GGgluonfusion_8TeV_tauola_cfi.py --conditions auto:startup -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 1000 --eventcontent RAWSIM
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
+process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('H130GGgluonfusion_8TeV_tauola_cfi.py nevts:1000'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+						   generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerGen  = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
+						   VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
+						   )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+
+process.generator = cms.EDFilter("Pythia6GeneratorFilter",
+				 ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(False),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(3),
+	pjak1 = cms.int32(3)
+	)
+        ),
+        parameterSets = cms.vstring('Tauola')
+	),
+				 maxEventsToPrint = cms.untracked.int32(3),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 crossSection = cms.untracked.double(0.05),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 PythiaParameters = cms.PSet(
+        pythiaUESettings = cms.vstring('MSTU(21)=1     ! Check on possible errors during program execution', 
+				       'MSTJ(22)=2     ! Decay those unstable particles', 
+				       'PARJ(71)=10 .  ! for which ctau  10 mm', 
+				       'MSTP(33)=0     ! no K factors in hard cross sections', 
+				       'MSTP(2)=1      ! which order running alphaS', 
+				       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)', 
+				       'MSTP(52)=2     ! work with LHAPDF', 
+				       'PARP(82)=1.921 ! pt cutoff for multiparton interactions', 
+				       'PARP(89)=1800. ! sqrts for which PARP82 is set', 
+				       'PARP(90)=0.227 ! Multiple interactions: rescaling power', 
+				       'MSTP(95)=6     ! CR (color reconnection parameters)', 
+				       'PARP(77)=1.016 ! CR', 
+				       'PARP(78)=0.538 ! CR', 
+				       'PARP(80)=0.1   ! Prob. colored parton from BBR', 
+				       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(62)=1.025 ! ISR cutoff', 
+				       'MSTP(91)=1     ! Gaussian primordial kT', 
+				       'PARP(93)=10.0  ! primordial kT-max', 
+				       'MSTP(81)=21    ! multiple parton interactions 1 is Pythia default', 
+				       'MSTP(82)=4     ! Defines the multi-parton model'),
+        processParameters = cms.vstring('PMAS(25,1)=130.0      !mass of Higgs', 
+					'MSEL=0                  ! user selection for process', 
+					'MSUB(102)=1             !ggH', 
+					'MSUB(123)=0             !ZZ fusion to H', 
+					'MSUB(124)=0             !WW fusion to H', 
+					'MSUB(24)=0              !ZH production', 
+					'MSUB(26)=0              !WH production', 
+					'MSUB(121)=0             !gg to ttH', 
+					'MSUB(122)=0             !qq to ttH', 
+					'MDME(210,1)=0           !Higgs decay into dd', 
+					'MDME(211,1)=0           !Higgs decay into uu', 
+					'MDME(212,1)=0           !Higgs decay into ss', 
+					'MDME(213,1)=0           !Higgs decay into cc', 
+					'MDME(214,1)=0           !Higgs decay into bb', 
+					'MDME(215,1)=0           !Higgs decay into tt', 
+					'MDME(216,1)=0           !Higgs decay into', 
+					'MDME(217,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(218,1)=0           !Higgs decay into e nu e', 
+					'MDME(219,1)=0           !Higgs decay into mu nu mu', 
+					'MDME(220,1)=1           !Higgs decay into tau nu tau', 
+					'MDME(221,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(222,1)=0           !Higgs decay into g g', 
+					'MDME(223,1)=0           !Higgs decay into gam gam', 
+					'MDME(224,1)=0           !Higgs decay into gam Z', 
+					'MDME(225,1)=0           !Higgs decay into Z Z', 
+					'MDME(226,1)=0           !Higgs decay into W W'),
+        parameterSets = cms.vstring('pythiaUESettings', 
+				    'processParameters')
+	)
+				 )
+
+
+process.TauSpinnerGen.parameterSets=cms.vstring("HTSpinCorr")
+process.TauSpinnerGen.HTSpinCorr = cms.vdouble(0.785)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen+process.TauSpinnerGen+process.TauSpinnerZHFilter)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaurhonu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaurhonu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -1,0 +1,167 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: H130GGgluonfusion_8TeV_tauola_cfi.py --conditions auto:startup -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 1000 --eventcontent RAWSIM
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
+process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('H130GGgluonfusion_8TeV_tauola_cfi.py nevts:1000'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+						   generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerGen  = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
+						   VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
+						   )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+
+process.generator = cms.EDFilter("Pythia6GeneratorFilter",
+				 ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(False),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(4),
+	pjak1 = cms.int32(4)
+	)
+        ),
+        parameterSets = cms.vstring('Tauola')
+	),
+				 maxEventsToPrint = cms.untracked.int32(3),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 crossSection = cms.untracked.double(0.05),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 PythiaParameters = cms.PSet(
+        pythiaUESettings = cms.vstring('MSTU(21)=1     ! Check on possible errors during program execution', 
+				       'MSTJ(22)=2     ! Decay those unstable particles', 
+				       'PARJ(71)=10 .  ! for which ctau  10 mm', 
+				       'MSTP(33)=0     ! no K factors in hard cross sections', 
+				       'MSTP(2)=1      ! which order running alphaS', 
+				       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)', 
+				       'MSTP(52)=2     ! work with LHAPDF', 
+				       'PARP(82)=1.921 ! pt cutoff for multiparton interactions', 
+				       'PARP(89)=1800. ! sqrts for which PARP82 is set', 
+				       'PARP(90)=0.227 ! Multiple interactions: rescaling power', 
+				       'MSTP(95)=6     ! CR (color reconnection parameters)', 
+				       'PARP(77)=1.016 ! CR', 
+				       'PARP(78)=0.538 ! CR', 
+				       'PARP(80)=0.1   ! Prob. colored parton from BBR', 
+				       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(62)=1.025 ! ISR cutoff', 
+				       'MSTP(91)=1     ! Gaussian primordial kT', 
+				       'PARP(93)=10.0  ! primordial kT-max', 
+				       'MSTP(81)=21    ! multiple parton interactions 1 is Pythia default', 
+				       'MSTP(82)=4     ! Defines the multi-parton model'),
+        processParameters = cms.vstring('PMAS(25,1)=130.0      !mass of Higgs', 
+					'MSEL=0                  ! user selection for process', 
+					'MSUB(102)=1             !ggH', 
+					'MSUB(123)=0             !ZZ fusion to H', 
+					'MSUB(124)=0             !WW fusion to H', 
+					'MSUB(24)=0              !ZH production', 
+					'MSUB(26)=0              !WH production', 
+					'MSUB(121)=0             !gg to ttH', 
+					'MSUB(122)=0             !qq to ttH', 
+					'MDME(210,1)=0           !Higgs decay into dd', 
+					'MDME(211,1)=0           !Higgs decay into uu', 
+					'MDME(212,1)=0           !Higgs decay into ss', 
+					'MDME(213,1)=0           !Higgs decay into cc', 
+					'MDME(214,1)=0           !Higgs decay into bb', 
+					'MDME(215,1)=0           !Higgs decay into tt', 
+					'MDME(216,1)=0           !Higgs decay into', 
+					'MDME(217,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(218,1)=0           !Higgs decay into e nu e', 
+					'MDME(219,1)=0           !Higgs decay into mu nu mu', 
+					'MDME(220,1)=1           !Higgs decay into tau nu tau', 
+					'MDME(221,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(222,1)=0           !Higgs decay into g g', 
+					'MDME(223,1)=0           !Higgs decay into gam gam', 
+					'MDME(224,1)=0           !Higgs decay into gam Z', 
+					'MDME(225,1)=0           !Higgs decay into Z Z', 
+					'MDME(226,1)=0           !Higgs decay into W W'),
+        parameterSets = cms.vstring('pythiaUESettings', 
+				    'processParameters')
+	)
+				 )
+
+
+process.TauSpinnerGen.parameterSets=cms.vstring("HTSpinCorr")
+process.TauSpinnerGen.HTSpinCorr = cms.vdouble(0.0)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen+process.TauSpinnerGen+process.TauSpinnerZHFilter)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaurhonu_PhiHalfPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaurhonu_PhiHalfPi_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -1,0 +1,167 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: H130GGgluonfusion_8TeV_tauola_cfi.py --conditions auto:startup -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 1000 --eventcontent RAWSIM
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
+process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('H130GGgluonfusion_8TeV_tauola_cfi.py nevts:1000'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+						   generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerGen  = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
+						   VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
+						   )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+
+process.generator = cms.EDFilter("Pythia6GeneratorFilter",
+				 ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(False),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(4),
+	pjak1 = cms.int32(4)
+	)
+        ),
+        parameterSets = cms.vstring('Tauola')
+	),
+				 maxEventsToPrint = cms.untracked.int32(3),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 crossSection = cms.untracked.double(0.05),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 PythiaParameters = cms.PSet(
+        pythiaUESettings = cms.vstring('MSTU(21)=1     ! Check on possible errors during program execution', 
+				       'MSTJ(22)=2     ! Decay those unstable particles', 
+				       'PARJ(71)=10 .  ! for which ctau  10 mm', 
+				       'MSTP(33)=0     ! no K factors in hard cross sections', 
+				       'MSTP(2)=1      ! which order running alphaS', 
+				       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)', 
+				       'MSTP(52)=2     ! work with LHAPDF', 
+				       'PARP(82)=1.921 ! pt cutoff for multiparton interactions', 
+				       'PARP(89)=1800. ! sqrts for which PARP82 is set', 
+				       'PARP(90)=0.227 ! Multiple interactions: rescaling power', 
+				       'MSTP(95)=6     ! CR (color reconnection parameters)', 
+				       'PARP(77)=1.016 ! CR', 
+				       'PARP(78)=0.538 ! CR', 
+				       'PARP(80)=0.1   ! Prob. colored parton from BBR', 
+				       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(62)=1.025 ! ISR cutoff', 
+				       'MSTP(91)=1     ! Gaussian primordial kT', 
+				       'PARP(93)=10.0  ! primordial kT-max', 
+				       'MSTP(81)=21    ! multiple parton interactions 1 is Pythia default', 
+				       'MSTP(82)=4     ! Defines the multi-parton model'),
+        processParameters = cms.vstring('PMAS(25,1)=130.0      !mass of Higgs', 
+					'MSEL=0                  ! user selection for process', 
+					'MSUB(102)=1             !ggH', 
+					'MSUB(123)=0             !ZZ fusion to H', 
+					'MSUB(124)=0             !WW fusion to H', 
+					'MSUB(24)=0              !ZH production', 
+					'MSUB(26)=0              !WH production', 
+					'MSUB(121)=0             !gg to ttH', 
+					'MSUB(122)=0             !qq to ttH', 
+					'MDME(210,1)=0           !Higgs decay into dd', 
+					'MDME(211,1)=0           !Higgs decay into uu', 
+					'MDME(212,1)=0           !Higgs decay into ss', 
+					'MDME(213,1)=0           !Higgs decay into cc', 
+					'MDME(214,1)=0           !Higgs decay into bb', 
+					'MDME(215,1)=0           !Higgs decay into tt', 
+					'MDME(216,1)=0           !Higgs decay into', 
+					'MDME(217,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(218,1)=0           !Higgs decay into e nu e', 
+					'MDME(219,1)=0           !Higgs decay into mu nu mu', 
+					'MDME(220,1)=1           !Higgs decay into tau nu tau', 
+					'MDME(221,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(222,1)=0           !Higgs decay into g g', 
+					'MDME(223,1)=0           !Higgs decay into gam gam', 
+					'MDME(224,1)=0           !Higgs decay into gam Z', 
+					'MDME(225,1)=0           !Higgs decay into Z Z', 
+					'MDME(226,1)=0           !Higgs decay into W W'),
+        parameterSets = cms.vstring('pythiaUESettings', 
+				    'processParameters')
+	)
+				 )
+
+
+process.TauSpinnerGen.parameterSets=cms.vstring("HTSpinCorr")
+process.TauSpinnerGen.HTSpinCorr = cms.vdouble(1.57)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen+process.TauSpinnerGen+process.TauSpinnerZHFilter)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaurhonu_PhiQuarterPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+++ b/GeneratorInterface/TauolaInterface/test/H130GGgluonfusiontaurhonu_PhiQuarterPi_8TeV_Tauola_TauSpinner_Example_cfi.py
@@ -1,0 +1,168 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.381.2.28 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/PyReleaseValidation/python/ConfigBuilder.py,v 
+# with command line options: H130GGgluonfusion_8TeV_tauola_cfi.py --conditions auto:startup -s GEN,VALIDATION:genvalid_all --datatier GEN --relval 1000000,20000 -n 1000 --eventcontent RAWSIM
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('VALIDATION')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('SimGeneral.MixingModule.mixNoPU_cfi')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_38T_cff')
+process.load('Configuration.StandardSequences.Generator_cff')
+process.load('IOMC.EventVertexGenerators.VtxSmearedRealistic8TeVCollision_cfi')
+process.load('GeneratorInterface.Core.genFilterSummary_cff')
+process.load('Configuration.StandardSequences.Validation_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("GeneratorInterface.TauolaInterface.TauSpinner_cfi")
+process.load("GeneratorInterface.TauolaInterface.TauSpinnerFilter_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(10000)
+)
+
+# Input source
+process.source = cms.Source("EmptySource")
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    version = cms.untracked.string('$Revision: 1.381.2.28 $'),
+    annotation = cms.untracked.string('H130GGgluonfusion_8TeV_tauola_cfi.py nevts:1000'),
+    name = cms.untracked.string('PyReleaseValidation')
+)
+
+# Output definition
+
+process.RAWSIMoutput = cms.OutputModule("PoolOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    outputCommands = process.RAWSIMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:step1.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('GEN')
+    ),
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('generation_step')
+    )
+)
+
+process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+						   generator = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerGen  = cms.PSet(initialSeed = cms.untracked.uint32(12345)),
+						   TauSpinnerZHFilter = cms.PSet(initialSeed = cms.untracked.uint32(429842)),
+						   VtxSmeared = cms.PSet(initialSeed = cms.untracked.uint32(275744))
+						   )
+
+
+
+# Other statements
+process.genstepfilter.triggerConditions=cms.vstring("generation_step")
+process.mix.playback = True
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:startup', '')
+
+
+process.generator = cms.EDFilter("Pythia6GeneratorFilter",
+				 ExternalDecays = cms.PSet(
+        Tauola = cms.untracked.PSet(
+	UseTauolaPolarization = cms.bool(False),
+	InputCards = cms.PSet(
+	mdtau = cms.int32(0),
+	pjak2 = cms.int32(4),
+	pjak1 = cms.int32(4)
+	)
+        ),
+        parameterSets = cms.vstring('Tauola')
+	),
+				 maxEventsToPrint = cms.untracked.int32(3),
+				 pythiaPylistVerbosity = cms.untracked.int32(1),
+				 filterEfficiency = cms.untracked.double(1.0),
+				 pythiaHepMCVerbosity = cms.untracked.bool(False),
+				 comEnergy = cms.double(13000.0),
+				 crossSection = cms.untracked.double(0.05),
+				 UseExternalGenerators = cms.untracked.bool(True),
+				 PythiaParameters = cms.PSet(
+        pythiaUESettings = cms.vstring('MSTU(21)=1     ! Check on possible errors during program execution', 
+				       'MSTJ(22)=2     ! Decay those unstable particles', 
+				       'PARJ(71)=10 .  ! for which ctau  10 mm', 
+				       'MSTP(33)=0     ! no K factors in hard cross sections', 
+				       'MSTP(2)=1      ! which order running alphaS', 
+				       'MSTP(51)=10042 ! structure function chosen (external PDF CTEQ6L1)', 
+				       'MSTP(52)=2     ! work with LHAPDF', 
+				       'PARP(82)=1.921 ! pt cutoff for multiparton interactions', 
+				       'PARP(89)=1800. ! sqrts for which PARP82 is set', 
+				       'PARP(90)=0.227 ! Multiple interactions: rescaling power', 
+				       'MSTP(95)=6     ! CR (color reconnection parameters)', 
+				       'PARP(77)=1.016 ! CR', 
+				       'PARP(78)=0.538 ! CR', 
+				       'PARP(80)=0.1   ! Prob. colored parton from BBR', 
+				       'PARP(83)=0.356 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(84)=0.651 ! Multiple interactions: matter distribution parameter', 
+				       'PARP(62)=1.025 ! ISR cutoff', 
+				       'MSTP(91)=1     ! Gaussian primordial kT', 
+				       'PARP(93)=10.0  ! primordial kT-max', 
+				       'MSTP(81)=21    ! multiple parton interactions 1 is Pythia default', 
+				       'MSTP(82)=4     ! Defines the multi-parton model'),
+        processParameters = cms.vstring('PMAS(25,1)=130.0      !mass of Higgs', 
+					'MSEL=0                  ! user selection for process', 
+					'MSUB(102)=1             !ggH', 
+					'MSUB(123)=0             !ZZ fusion to H', 
+					'MSUB(124)=0             !WW fusion to H', 
+					'MSUB(24)=0              !ZH production', 
+					'MSUB(26)=0              !WH production', 
+					'MSUB(121)=0             !gg to ttH', 
+					'MSUB(122)=0             !qq to ttH', 
+					'MDME(210,1)=0           !Higgs decay into dd', 
+					'MDME(211,1)=0           !Higgs decay into uu', 
+					'MDME(212,1)=0           !Higgs decay into ss', 
+					'MDME(213,1)=0           !Higgs decay into cc', 
+					'MDME(214,1)=0           !Higgs decay into bb', 
+					'MDME(215,1)=0           !Higgs decay into tt', 
+					'MDME(216,1)=0           !Higgs decay into', 
+					'MDME(217,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(218,1)=0           !Higgs decay into e nu e', 
+					'MDME(219,1)=0           !Higgs decay into mu nu mu', 
+					'MDME(220,1)=1           !Higgs decay into tau nu tau', 
+					'MDME(221,1)=0           !Higgs decay into Higgs decay', 
+					'MDME(222,1)=0           !Higgs decay into g g', 
+					'MDME(223,1)=0           !Higgs decay into gam gam', 
+					'MDME(224,1)=0           !Higgs decay into gam Z', 
+					'MDME(225,1)=0           !Higgs decay into Z Z', 
+					'MDME(226,1)=0           !Higgs decay into W W'),
+        parameterSets = cms.vstring('pythiaUESettings', 
+				    'processParameters')
+	)
+				 )
+
+process.writer = cms.EDAnalyzer("HepMCEventWriter", hepMCProduct = cms.InputTag("generator"))
+
+process.TauSpinnerGen.parameterSets=cms.vstring("HTSpinCorr")
+process.TauSpinnerGen.HTSpinCorr = cms.vdouble(0.785)
+
+process.ProductionFilterSequence = cms.Sequence(process.generator)
+
+# Path and EndPath definitions
+process.generation_step = cms.Path(process.pgen+process.TauSpinnerGen+process.TauSpinnerZHFilter+process.writer)
+process.genfiltersummary_step = cms.EndPath(process.genFilterSummary)
+process.validation_step = cms.EndPath(process.genstepfilter+process.genvalid_all)
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.RAWSIMoutput_step = cms.EndPath(process.RAWSIMoutput)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.generation_step,process.genfiltersummary_step,process.validation_step,process.endjob_step,process.RAWSIMoutput_step)
+# filter all path with the production filter sequence
+for path in process.paths:
+	getattr(process,path)._seq = process.ProductionFilterSequence * getattr(process,path)._seq 
+

--- a/GeneratorInterface/TauolaInterface/test/Test_Hspin.sh
+++ b/GeneratorInterface/TauolaInterface/test/Test_Hspin.sh
@@ -1,0 +1,25 @@
+#! /bin/bash
+
+cmsRun H130GGgluonfusiontaupinu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root  H130GGgluonfusiontaupinu_Phi0.root
+
+cmsRun H130GGgluonfusiontaupinu_PhiHalfPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root H130GGgluonfusiontaupinu_PhiHalfPi.root
+
+cmsRun H130GGgluonfusiontaupinu_PhiQuarterPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root H130GGgluonfusiontaupinu_PhiQuarterPi.root
+
+cmsRun H130GGgluonfusiontaurhonu_Phi0_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root  H130GGgluonfusiontaurhonu_Phi0.root
+
+cmsRun H130GGgluonfusiontaurhonu_PhiHalfPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root H130GGgluonfusiontaurhonu_PhiHalfPi.root
+
+cmsRun H130GGgluonfusiontaurhonu_PhiQuarterPi_8TeV_Tauola_TauSpinner_Example_cfi.py
+cmsDriver.py step3 -s HARVESTING:genHarvesting --harvesting AtJobEnd --conditions auto:mc  --mc --filein file:step1.root
+cp DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO.root H130GGgluonfusiontaurhonu_PhiQuarterPi.root

--- a/Validation/EventGenerator/plugins/TauValidation.cc
+++ b/Validation/EventGenerator/plugins/TauValidation.cc
@@ -35,7 +35,7 @@ void TauValidation::dqmBeginRun(const edm::Run& r, const edm::EventSetup& c) {
 }
 
 void TauValidation::bookHistograms(DQMStore::IBooker &i, edm::Run const &, edm::EventSetup const &){
-    ///Setting the DQM top directories
+  ///Setting the DQM top directories
     i.setCurrentFolder("Generator/Tau");
     
     // Number of analyzed events
@@ -464,9 +464,10 @@ void TauValidation::spinEffectsZH(const reco::GenParticle* boson, double weight)
   int ntau(0);
   for(unsigned int i = 0; i <boson->numberOfDaughters(); i++){
     const reco::GenParticle *dau=static_cast<const reco::GenParticle*>(boson->daughter(i));
+    if(ntau==1 && dau->pdgId() == 15)return;
     if(boson->pdgId()!= 15 && abs(dau->pdgId()) == 15)ntau++;
   }
-  if(ntau!=2) return;
+  if(ntau!=2) return; 
   if(abs(boson->pdgId())==PdtPdgMini::Z0 || abs(boson->pdgId())==PdtPdgMini::Higgs0){
     TLorentzVector tautau(0,0,0,0);
     TLorentzVector pipi(0,0,0,0);
@@ -535,7 +536,7 @@ void TauValidation::spinEffectsZH(const reco::GenParticle* boson, double weight)
 	  if(jak_id==TauDecay::JAK_PION){
 	    for(unsigned int i=0; i<part.size();i++){
 	      int pid_d = part.at(i)->pdgId();
-	      if(abs(pid_d)==211 || abs(pid_d)==111){
+	      if(abs(pid_d)==211 ){
 		TLorentzVector LV(part.at(i)->px(),part.at(i)->py(),part.at(i)->pz(),part.at(i)->energy());
 		if(pid==15){
 		  haspi_minus=true;
@@ -564,15 +565,15 @@ void TauValidation::spinEffectsZH(const reco::GenParticle* boson, double weight)
       TLorentzVector pi0_rhoplusb=pi0_rhoplus;   pi0_rhoplusb.Boost(-1*rhorho.BoostVector());
       TLorentzVector pi_rhominusb=pi_rhominus;   pi_rhominusb.Boost(-1*rhorho.BoostVector());
       TLorentzVector pi0_rhominusb=pi0_rhominus; pi0_rhominusb.Boost(-1*rhorho.BoostVector());
-      
+  
       // compute n+/-
       TVector3 n_plus=pi_rhoplusb.Vect().Cross(pi0_rhoplusb.Vect());
       TVector3 n_minus=pi_rhominusb.Vect().Cross(pi0_rhominusb.Vect());
       
       // compute the acoplanarity
       double Acoplanarity=acos(n_plus.Dot(n_minus)/(n_plus.Mag()*n_minus.Mag()));
-      if(pi_rhominus.Vect().Dot(n_plus)>0){Acoplanarity*=-1;Acoplanarity+=2*TMath::Pi();}
-      
+      if(pi_rhominusb.Vect().Dot(n_plus)>0){Acoplanarity*=-1;Acoplanarity+=2*TMath::Pi();}
+  
       // now boost to tau frame
       pi_rhoplus.Boost(-1*taup.BoostVector());
       pi0_rhoplus.Boost(-1*taup.BoostVector());
@@ -603,7 +604,7 @@ void TauValidation::spinEffectsZH(const reco::GenParticle* boson, double weight)
 	TauSpinEffectsH_pipiAcollinearityzoom->Fill(acos(pi_plus.Vect().Dot(pi_minus.Vect())/(pi_plus.P()*pi_minus.P())));
       }
       
-      double proj_m=taum.Vect().Dot(pi_minus.Vect())/(taum.P()*taup.P());
+      double proj_m=taum.Vect().Dot(pi_minus.Vect())/(taum.P()*taum.P());
       double proj_p=taup.Vect().Dot(pi_plus.Vect())/(taup.P()*taup.P());
       TVector3 Tau_m=taum.Vect();
       TVector3 Tau_p=taup.Vect();


### PR DESCRIPTION
Update to include SANC files for longitudinal polarization in Z->tautau decays and update to TauSpinner to allow easy modification of scalar/pseudo-scalar mixing for CP analyses.
Automatically ported from CMSSW_7_3_X #6421
