### PR TITLE
Thread safety improvement BeamHaloProducer

### DIFF
--- a/GeneratorInterface/BeamHaloGenerator/interface/BeamHaloProducer.h
+++ b/GeneratorInterface/BeamHaloGenerator/interface/BeamHaloProducer.h
@@ -20,7 +20,7 @@ namespace CLHEP {
 
 namespace edm
 {
-  class BeamHaloProducer : public one::EDProducer<EndRunProducer, one::WatchLuminosityBlocks> {
+  class BeamHaloProducer : public one::EDProducer<EndRunProducer, one::WatchLuminosityBlocks, one::SharedResources> {
   public:
 
     /// Constructor

--- a/GeneratorInterface/BeamHaloGenerator/src/BeamHaloProducer.cc
+++ b/GeneratorInterface/BeamHaloGenerator/src/BeamHaloProducer.cc
@@ -87,6 +87,8 @@ BeamHaloProducer::BeamHaloProducer( const ParameterSet & pset) :
   produces<GenEventInfoProduct>();
   produces<GenRunInfoProduct, InRun>();
 
+  usesResource("BeamHaloProducer");
+
   cout << "BeamHaloProducer: starting event generation ... " << endl;
 }
 


### PR DESCRIPTION
This adds a declaration of a SharedResource to the
BeamHaloProducer. The shared resources are global
variables the module uses. This ensures thread safety
in the case where multiple BeamHaloProducers are run
in the same job (practically speaking this probably
never happens).

More importantly, the static code analyzer reported a
thread safety problem. A future version of the static
analyzer will not report the problem if
BeamHaloProducer is a one module with a shared resource.
So this should eliminate the warning.
Automatically ported from CMSSW_7_3_X #6414
