### PR TITLE
Pattern without wildcard is not a pattern

### DIFF
--- a/TrackingTools/TrajectoryState/src/classes_def.xml
+++ b/TrackingTools/TrajectoryState/src/classes_def.xml
@@ -19,5 +19,5 @@
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<TrackParamConstraint> > >"/>
   -->
 
-  <class pattern="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::TrackCollection,std::vector<TrackParamConstraint> > >"  persistent="false" />
+  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::TrackCollection,std::vector<TrackParamConstraint> > >"  persistent="false" />
 </lcgdict>


### PR DESCRIPTION
A build warning results from an XML selection pattern that does not contain a wild card, so it is not really a pattern, but just a class name.
Fix the build warning by changing "pattern" to "name".
