### PR TITLE
Migration to multithread friendly modules

### DIFF
--- a/HLTrigger/btau/src/HLTCollectionProducer.h
+++ b/HLTrigger/btau/src/HLTCollectionProducer.h
@@ -16,7 +16,7 @@
 //
 
 // user include files
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
@@ -33,18 +33,18 @@
 //
 
 template <typename T> 
-class HLTCollectionProducer : public edm::EDProducer {
+class HLTCollectionProducer : public edm::global::EDProducer<> {
 
   public:
     explicit HLTCollectionProducer(const edm::ParameterSet&);
     virtual ~HLTCollectionProducer();
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-    virtual void produce(edm::Event&, const edm::EventSetup&);
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
   private:
-    edm::InputTag                                          hltObjectTag_;
-    edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> hltObjectToken_;
-    std::vector<int> triggerTypes_;
+    const edm::InputTag                                          hltObjectTag_;
+    const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> hltObjectToken_;
+    const std::vector<int> triggerTypes_;
 };
 
 
@@ -80,7 +80,7 @@ HLTCollectionProducer<T>::fillDescriptions(edm::ConfigurationDescriptions& descr
 // ------------ method called to produce the data  ------------
 template <typename T>
 void
-HLTCollectionProducer<T>::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+HLTCollectionProducer<T>::produce(edm::StreamID iStreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
 
   std::auto_ptr<std::vector<T> > collection ( new std::vector<T>() );

--- a/RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h
+++ b/RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h
@@ -16,7 +16,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/CaloTowers/interface/CaloTower.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
@@ -26,7 +26,7 @@ namespace edm {
   class ParameterSet;
 }
 
-class CaloTowerCreatorForTauHLT : public edm::EDProducer {
+class CaloTowerCreatorForTauHLT : public edm::global::EDProducer<> {
  public:
   /// constructor from parameter set
   CaloTowerCreatorForTauHLT( const edm::ParameterSet & );
@@ -35,24 +35,24 @@ class CaloTowerCreatorForTauHLT : public edm::EDProducer {
 
  private:
   /// process one event
-  void produce( edm::Event& e, const edm::EventSetup& ) override;
+  void produce( edm::StreamID sid, edm::Event& evt, const edm::EventSetup& stp ) const override;
   /// verbosity
-  int mVerbose;
+  const int mVerbose;
   /// label of source collection
-  edm::EDGetTokenT<CaloTowerCollection> mtowers_token;
+  const edm::EDGetTokenT<CaloTowerCollection> mtowers_token;
   /// use only towers in cone mCone around L1 candidate for regional jet reco
-  double mCone;
+  const double mCone;
   /// label of tau trigger type analysis
-  edm::EDGetTokenT<l1extra::L1JetParticleCollection> mTauTrigger_token;
+  const edm::EDGetTokenT<l1extra::L1JetParticleCollection> mTauTrigger_token;
   /// imitator of L1 seeds
   //edm::InputTag ml1seeds;
   /// ET threshold
-  double mEtThreshold;
+  const double mEtThreshold;
   /// E threshold
-  double mEThreshold;
+  const double mEThreshold;
 
   //
-  int mTauId;
+  const int mTauId;
 
 };
 

--- a/RecoTauTag/HLTProducers/interface/L1HLTTauMatching.h
+++ b/RecoTauTag/HLTProducers/interface/L1HLTTauMatching.h
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -18,20 +18,17 @@
 
 #include <map>
 #include <vector>
-class L1HLTTauMatching: public edm::EDProducer {
+class L1HLTTauMatching: public edm::global::EDProducer<> {
  public:
   explicit L1HLTTauMatching(const edm::ParameterSet&);
   ~L1HLTTauMatching();
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
  private:
-  std::vector<l1extra::L1JetParticleRef> tauCandRefVec;
-  std::vector<l1extra::L1JetParticleRef> jetCandRefVec;
-  std::vector<l1extra::L1JetParticleRef> objL1CandRefVec;
-  l1extra::L1JetParticleRef tauCandRef;
     
-  edm::EDGetTokenT<reco::PFTauCollection> jetSrc;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauTrigger;
-  double mEt_Min;
+  const edm::EDGetTokenT<reco::PFTauCollection> jetSrc;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tauTrigger;
+  const double mEt_Min;
+
 };
 #endif

--- a/RecoTauTag/HLTProducers/interface/L2TauJetsMerger.h
+++ b/RecoTauTag/HLTProducers/interface/L2TauJetsMerger.h
@@ -4,7 +4,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,20 +16,19 @@
 #include <map>
 #include <vector>
 
-class L2TauJetsMerger: public edm::EDProducer {
+class L2TauJetsMerger: public edm::global::EDProducer<> {
  public:
   explicit L2TauJetsMerger(const edm::ParameterSet&);
   ~L2TauJetsMerger();
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
  private:
     
   typedef std::vector<edm::InputTag> vtag;
   typedef std::vector<edm::EDGetTokenT<reco::CaloJetCollection> > vtoken_cjets;
-  vtag jetSrc;
+  const vtag jetSrc;
   vtoken_cjets jetSrc_token;
-  double mEt_Min;
-  std::map<int, const reco::CaloJet> myL2L1JetsMap; //first is # L1Tau , second is L2 jets
+  const double mEt_Min;
 
 
       class SorterByPt {

--- a/RecoTauTag/HLTProducers/interface/L2TauPixelIsoTagProducer.h
+++ b/RecoTauTag/HLTProducers/interface/L2TauPixelIsoTagProducer.h
@@ -2,7 +2,7 @@
 #define L2TauPixelIsoTagProducer_h__
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
@@ -20,7 +20,7 @@
  *
  * \author Vadim Khotilovich
  */
-class L2TauPixelIsoTagProducer : public edm::EDProducer
+class L2TauPixelIsoTagProducer : public edm::global::EDProducer<>
 {
 public:
 
@@ -28,25 +28,25 @@ public:
 
   ~L2TauPixelIsoTagProducer() {};
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
 
-  edm::EDGetTokenT<edm::View<reco::Jet> > m_jetSrc_token;
-  edm::EDGetTokenT<reco::VertexCollection> m_vertexSrc_token;
-  edm::EDGetTokenT<reco::TrackCollection> m_trackSrc_token;
-  edm::EDGetTokenT<reco::BeamSpot> m_beamSpotSrc_token;
+  const edm::EDGetTokenT<edm::View<reco::Jet> > m_jetSrc_token;
+  const edm::EDGetTokenT<reco::VertexCollection> m_vertexSrc_token;
+  const edm::EDGetTokenT<reco::TrackCollection> m_trackSrc_token;
+  const edm::EDGetTokenT<reco::BeamSpot> m_beamSpotSrc_token;
 
-  int m_maxNumberPV;
+  const int m_maxNumberPV;
 
-  float m_trackMinPt;
-  float m_trackMaxDxy;
-  float m_trackMaxNChi2;
-  int   m_trackMinNHits;
-  float m_trackPVMaxDZ;
+  const float m_trackMinPt;
+  const float m_trackMaxDxy;
+  const float m_trackMaxNChi2;
+  const int   m_trackMinNHits;
+  const float m_trackPVMaxDZ;
 
-  float m_isoCone2Min;
-  float m_isoCone2Max;
+  const float m_isoCone2Min;
+  const float m_isoCone2Max;
 };
 
 #endif

--- a/RecoTauTag/HLTProducers/interface/TauJetSelectorForHLTTrackSeeding.h
+++ b/RecoTauTag/HLTProducers/interface/TauJetSelectorForHLTTrackSeeding.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -21,7 +21,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
-class TauJetSelectorForHLTTrackSeeding : public edm::EDProducer {
+class TauJetSelectorForHLTTrackSeeding : public edm::global::EDProducer<> {
 
 public:
   explicit TauJetSelectorForHLTTrackSeeding(const edm::ParameterSet&);
@@ -29,7 +29,7 @@ public:
 
 private:
   virtual void beginJob() ;
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   virtual void endJob() ;
       
   // ----------member data ---------------------------

--- a/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
+++ b/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -41,29 +41,29 @@
 // class declaration
 //
 
-class VertexFromTrackProducer : public edm::EDProducer {
+class VertexFromTrackProducer : public edm::global::EDProducer<> {
 public:
   explicit VertexFromTrackProducer(const edm::ParameterSet&);
   ~VertexFromTrackProducer();
   
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
   // access to config
-  edm::ParameterSet config() const { return theConfig; }
-  edm::InputTag trackLabel;
-  edm::EDGetTokenT<edm::View<reco::Track> > trackToken;
-  edm::EDGetTokenT<edm::View<reco::RecoCandidate> > candidateToken;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> triggerFilterElectronsSrc;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> triggerFilterMuonsSrc;
-  edm::EDGetTokenT<edm::View<reco::Vertex> > vertexLabel;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotLabel;
+  const edm::ParameterSet config() const { return theConfig; }
+  // tokens
+  const edm::EDGetTokenT<edm::View<reco::Track> > trackToken;
+  const edm::EDGetTokenT<edm::View<reco::RecoCandidate> > candidateToken;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> triggerFilterElectronsSrc;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> triggerFilterMuonsSrc;
+  const edm::EDGetTokenT<edm::View<reco::Vertex> > vertexLabel;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotLabel;
   
 private:
   // ----------member data ---------------------------
-  bool fIsRecoCandidate;
-  bool fUseBeamSpot;
-  bool fUseVertex;
-  bool fUseTriggerFilterElectrons, fUseTriggerFilterMuons;
-  edm::ParameterSet theConfig;
-  bool fVerbose;
+  const bool fIsRecoCandidate;
+  const bool fUseBeamSpot;
+  const bool fUseVertex;
+  const bool fUseTriggerFilterElectrons, fUseTriggerFilterMuons;
+  const edm::ParameterSet theConfig;
+  const bool fVerbose;
 };

--- a/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
+++ b/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
@@ -48,8 +48,7 @@ public:
   
   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-  // access to config
-  const edm::ParameterSet config() const { return theConfig; }
+private:
   // tokens
   const edm::EDGetTokenT<edm::View<reco::Track> > trackToken;
   const edm::EDGetTokenT<edm::View<reco::RecoCandidate> > candidateToken;
@@ -58,12 +57,10 @@ public:
   const edm::EDGetTokenT<edm::View<reco::Vertex> > vertexLabel;
   const edm::EDGetTokenT<reco::BeamSpot> beamSpotLabel;
   
-private:
   // ----------member data ---------------------------
   const bool fIsRecoCandidate;
   const bool fUseBeamSpot;
   const bool fUseVertex;
   const bool fUseTriggerFilterElectrons, fUseTriggerFilterMuons;
-  const edm::ParameterSet theConfig;
   const bool fVerbose;
 };

--- a/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
+++ b/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
@@ -20,21 +20,20 @@ using namespace l1extra ;
 CaloTowerCreatorForTauHLT::CaloTowerCreatorForTauHLT( const ParameterSet & p ) 
   :
   mVerbose (p.getUntrackedParameter<int> ("verbose", 0)),
+  mtowers_token (consumes<CaloTowerCollection>(p.getParameter<InputTag>("towers") ) ),
   mCone (p.getParameter<double> ("UseTowersInCone")),
+  mTauTrigger_token (consumes<L1JetParticleCollection>(p.getParameter<InputTag>("TauTrigger") ) ),
   mEtThreshold (p.getParameter<double> ("minimumEt")),
   mEThreshold (p.getParameter<double> ("minimumE")),
   mTauId (p.getParameter<int> ("TauId"))
 {
-  mtowers_token = consumes<CaloTowerCollection>(p.getParameter<InputTag>("towers") );
-  mTauTrigger_token = consumes<L1JetParticleCollection>(p.getParameter<InputTag>("TauTrigger") );
-
   produces<CaloTowerCollection>();
 }
 
 CaloTowerCreatorForTauHLT::~CaloTowerCreatorForTauHLT() {
 }
 
-void CaloTowerCreatorForTauHLT::produce( Event& evt, const EventSetup& ) {
+void CaloTowerCreatorForTauHLT::produce( StreamID sid, Event& evt, const EventSetup& stp ) const {
   edm::Handle<CaloTowerCollection> caloTowers;
   evt.getByToken( mtowers_token, caloTowers );
 

--- a/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
+++ b/RecoTauTag/HLTProducers/src/CaloTowerCreatorForTauHLT.cc
@@ -7,6 +7,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "RecoTauTag/HLTProducers/interface/CaloTowerCreatorForTauHLT.h"
 // Math
 #include "Math/GenVector/VectorUtil.h"
@@ -55,8 +56,9 @@ void CaloTowerCreatorForTauHLT::produce( StreamID sid, Event& evt, const EventSe
 	  unsigned idx = 0;
 	  for (; idx < caloTowers->size(); idx++) {
 	    const CaloTower* cal = &((*caloTowers) [idx]);
+	    bool isAccepted = false;
 	    if (mVerbose == 2) {
-	      std::cout << "CaloTowerCreatorForTauHLT::produce-> " << idx << " tower et/eta/phi/e: " 
+	      edm::LogInfo("JetDebugInfo") << "CaloTowerCreatorForTauHLT::produce-> " << idx << " tower et/eta/phi/e: " 
 			<< cal->et() << '/' << cal->eta() << '/' << cal->phi() << '/' << cal->energy() << " is...";
 	    }
 	    if (cal->et() >= mEtThreshold && cal->energy() >= mEThreshold ) {
@@ -64,12 +66,14 @@ void CaloTowerCreatorForTauHLT::produce( StreamID sid, Event& evt, const EventSe
   	      double delta  = ROOT::Math::VectorUtil::DeltaR((*myL1Jet).p4().Vect(), p);
 	      
 	      if(delta < mCone) {
+		isAccepted = true;
 		Sum08 += cal->et(); 
 		cands->push_back( *cal );
 	      }
 	    }
-	    else {
-	      if (mVerbose == 2) std::cout << "rejected " << std::endl;
+	    if (mVerbose == 2){
+	      if (isAccepted) edm::LogInfo("JetDebugInfo") << "accepted \n";
+	      else edm::LogInfo("JetDebugInfo") << "rejected \n";
 	    }
 	  }
 

--- a/RecoTauTag/HLTProducers/src/L1HLTTauMatching.cc
+++ b/RecoTauTag/HLTProducers/src/L1HLTTauMatching.cc
@@ -14,17 +14,16 @@ using namespace std;
 using namespace edm;
 using namespace l1extra;
 
-L1HLTTauMatching::L1HLTTauMatching(const edm::ParameterSet& iConfig)
-{
-  jetSrc = consumes<PFTauCollection>(iConfig.getParameter<InputTag>("JetSrc") );
-  tauTrigger = consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("L1TauTrigger") );
-  mEt_Min = iConfig.getParameter<double>("EtMin");
-  
+L1HLTTauMatching::L1HLTTauMatching(const edm::ParameterSet& iConfig):
+  jetSrc( consumes<PFTauCollection>(iConfig.getParameter<InputTag>("JetSrc") ) ),
+  tauTrigger( consumes<trigger::TriggerFilterObjectWithRefs>(iConfig.getParameter<InputTag>("L1TauTrigger") ) ),
+  mEt_Min( iConfig.getParameter<double>("EtMin") )
+{  
   produces<PFTauCollection>();
 }
 L1HLTTauMatching::~L1HLTTauMatching(){ }
 
-void L1HLTTauMatching::produce(edm::Event& iEvent, const edm::EventSetup& iES)
+void L1HLTTauMatching::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
 {
 	
   using namespace edm;
@@ -45,13 +44,12 @@ void L1HLTTauMatching::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 		
   edm::Handle<trigger::TriggerFilterObjectWithRefs> l1TriggeredTaus;
   iEvent.getByToken(tauTrigger,l1TriggeredTaus);
-		
-		
-  tauCandRefVec.clear();
-  jetCandRefVec.clear();
-  
+				
+  vector<l1extra::L1JetParticleRef> tauCandRefVec;                                                
+  vector<l1extra::L1JetParticleRef> jetCandRefVec;
   l1TriggeredTaus->getObjects( trigger::TriggerL1TauJet,tauCandRefVec);
   l1TriggeredTaus->getObjects( trigger::TriggerL1CenJet,jetCandRefVec);
+
   math::XYZPoint a(0.,0.,0.);
   CaloJet::Specific f;
 		
@@ -92,7 +90,7 @@ void L1HLTTauMatching::produce(edm::Event& iEvent, const edm::EventSetup& iES)
             
 	    PFTau myPFTau(std::numeric_limits<int>::quiet_NaN(), myJet.p4(),a);
 	    if(myJet.pt() > mEt_Min) {
-	      //tauL2LC->push_back(myLC);
+	      //	      tauL2LC->push_back(myLC);
 	      tauL2jets->push_back(myPFTau);
 	    }
 	    break;

--- a/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
@@ -9,33 +9,29 @@ using namespace reco;
 using namespace std;
 using namespace edm;
 
-L2TauJetsMerger::L2TauJetsMerger(const edm::ParameterSet& iConfig)
+L2TauJetsMerger::L2TauJetsMerger(const edm::ParameterSet& iConfig):
+  jetSrc( iConfig.getParameter<vtag>("JetSrc") ),
+  mEt_Min( iConfig.getParameter<double>("EtMin") )
 {
-  jetSrc = iConfig.getParameter<vtag>("JetSrc");
-  for(vtag::const_iterator it = jetSrc.begin(); it != jetSrc.end(); ++it) {
+   for(vtag::const_iterator it = jetSrc.begin(); it != jetSrc.end(); ++it) {
     edm::EDGetTokenT<CaloJetCollection> aToken = consumes<CaloJetCollection>(*it);
     jetSrc_token.push_back(aToken);
   }
-  mEt_Min = iConfig.getParameter<double>("EtMin");
   
   produces<CaloJetCollection>();
 }
 
 L2TauJetsMerger::~L2TauJetsMerger(){ }
 
-void L2TauJetsMerger::produce(edm::Event& iEvent, const edm::EventSetup& iES)
+void L2TauJetsMerger::produce(edm::StreamID iSId, edm::Event& iEvent, const edm::EventSetup& iES) const
 {
 
  using namespace edm;
  using namespace std;
  using namespace reco;
 
- //Getting all the L1Seeds
-
- 
  //Getting the Collections of L2ReconstructedJets from L1Seeds
  //and removing the collinear jets
- myL2L1JetsMap.clear();
  CaloJetCollection myTmpJets;
  myTmpJets.clear();
 
@@ -45,7 +41,6 @@ void L2TauJetsMerger::produce(edm::Event& iEvent, const edm::EventSetup& iES)
    iEvent.getByToken( * s, tauJets );
    for(CaloJetCollection::const_iterator iTau = tauJets->begin(); iTau !=tauJets->end(); ++iTau)
      { 
-     //Create a Map to associate to every Jet its L1SeedId, i.e. 0,1,2 or 3
        if(iTau->et() > mEt_Min) {
 
 	 //Add the Pdg Id here 
@@ -60,25 +55,24 @@ void L2TauJetsMerger::produce(edm::Event& iEvent, const edm::EventSetup& iES)
  std::auto_ptr<CaloJetCollection> tauL2jets(new CaloJetCollection); 
 
  //Removing the collinear jets correctly!
-
+ 
  //First sort the jets you have merged
  SorterByPt sorter;
  std::sort(myTmpJets.begin(),myTmpJets.end(),sorter);
  
-//Remove Collinear Jets by prefering the highest ones!
-
-   while(myTmpJets.size()>0) {
-     tauL2jets->push_back(myTmpJets.at(0));
-     CaloJetCollection tmp;
-     for(unsigned int i=1 ;i<myTmpJets.size();++i) {
-       double DR = ROOT::Math::VectorUtil::DeltaR(myTmpJets.at(0).p4(),myTmpJets.at(i).p4());
-       if(DR>0.1) 
-	 tmp.push_back(myTmpJets.at(i));
-     }
-     myTmpJets.swap(tmp);
-     tmp.clear();
+ //Remove Collinear Jets by prefering the highest ones!
+ while(myTmpJets.size()>0) {
+   tauL2jets->push_back(myTmpJets.at(0));
+   CaloJetCollection tmp;
+   for(unsigned int i=1 ;i<myTmpJets.size();++i) {
+     double DR = ROOT::Math::VectorUtil::DeltaR(myTmpJets.at(0).p4(),myTmpJets.at(i).p4());
+     if(DR>0.1) 
+       tmp.push_back(myTmpJets.at(i));
    }
-
+   myTmpJets.swap(tmp);
+   tmp.clear();
+ }
+ 
 
   iEvent.put(tauL2jets);
 

--- a/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauJetsMerger.cc
@@ -33,7 +33,6 @@ void L2TauJetsMerger::produce(edm::StreamID iSId, edm::Event& iEvent, const edm:
  //Getting the Collections of L2ReconstructedJets from L1Seeds
  //and removing the collinear jets
  CaloJetCollection myTmpJets;
- myTmpJets.clear();
 
  int iL1Jet = 0;
  for( vtoken_cjets::const_iterator s = jetSrc_token.begin(); s != jetSrc_token.end(); ++ s ) {
@@ -62,15 +61,14 @@ void L2TauJetsMerger::produce(edm::StreamID iSId, edm::Event& iEvent, const edm:
  
  //Remove Collinear Jets by prefering the highest ones!
  while(myTmpJets.size()>0) {
-   tauL2jets->push_back(myTmpJets.at(0));
+   tauL2jets->push_back(myTmpJets[0]);
    CaloJetCollection tmp;
    for(unsigned int i=1 ;i<myTmpJets.size();++i) {
-     double DR = ROOT::Math::VectorUtil::DeltaR(myTmpJets.at(0).p4(),myTmpJets.at(i).p4());
+     double DR = ROOT::Math::VectorUtil::DeltaR(myTmpJets[0].p4(),myTmpJets[i].p4());
      if(DR>0.1) 
-       tmp.push_back(myTmpJets.at(i));
+       tmp.push_back(myTmpJets[i]);
    }
    myTmpJets.swap(tmp);
-   tmp.clear();
  }
  
 

--- a/RecoTauTag/HLTProducers/src/L2TauPixelIsoTagProducer.cc
+++ b/RecoTauTag/HLTProducers/src/L2TauPixelIsoTagProducer.cc
@@ -14,29 +14,25 @@
 #include "DataFormats/BTauReco/interface/JetTag.h"
 
 
-L2TauPixelIsoTagProducer::L2TauPixelIsoTagProducer(const edm::ParameterSet& conf)
+L2TauPixelIsoTagProducer::L2TauPixelIsoTagProducer(const edm::ParameterSet& conf):
+  m_jetSrc_token( consumes<edm::View<reco::Jet> >(conf.getParameter<edm::InputTag>("JetSrc") ) ),
+  m_vertexSrc_token( consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("VertexSrc") ) ),
+  m_trackSrc_token( consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("TrackSrc") ) ),  // for future use (now tracks are taken directly from PV)
+  m_beamSpotSrc_token( consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("BeamSpotSrc") ) ),
+  m_maxNumberPV( conf.getParameter<int>("MaxNumberPV") ), // for future use, now is assumed to be = 1
+  m_trackMinPt( conf.getParameter<double>("TrackMinPt") ),
+  m_trackMaxDxy( conf.getParameter<double>("TrackMaxDxy") ),
+  m_trackMaxNChi2( conf.getParameter<double>("TrackMaxNChi2") ),
+  m_trackMinNHits( conf.getParameter<int>("TrackMinNHits") ),
+  m_trackPVMaxDZ( conf.getParameter<double>("TrackPVMaxDZ") ), // for future use with tracks not from PV
+  m_isoCone2Min( std::pow(conf.getParameter<double>("IsoConeMin"), 2) ),
+  m_isoCone2Max( std::pow(conf.getParameter<double>("IsoConeMax"), 2) )
 {
-  m_jetSrc_token      = consumes<edm::View<reco::Jet> >(conf.getParameter<edm::InputTag>("JetSrc") );
-  m_vertexSrc_token   = consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("VertexSrc") );
-  m_trackSrc_token    = consumes<reco::TrackCollection>(conf.getParameter<edm::InputTag>("TrackSrc") );  // for future use (now tracks are taken directly from PV)
-  m_beamSpotSrc_token = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("BeamSpotSrc") );
-
-  m_maxNumberPV = conf.getParameter<int>("MaxNumberPV"); // for future use, now is assumed to be = 1
-
-  m_trackMinPt    = conf.getParameter<double>("TrackMinPt");
-  m_trackMaxDxy   = conf.getParameter<double>("TrackMaxDxy");
-  m_trackMaxNChi2 = conf.getParameter<double>("TrackMaxNChi2");
-  m_trackMinNHits = conf.getParameter<int>("TrackMinNHits");
-  m_trackPVMaxDZ  = conf.getParameter<double>("TrackPVMaxDZ"); // for future use with tracks not from PV
-
-  m_isoCone2Min  = std::pow(conf.getParameter<double>("IsoConeMin"), 2);
-  m_isoCone2Max  = std::pow(conf.getParameter<double>("IsoConeMax"), 2);
-
   produces<reco::JetTagCollection>(); 
 }
 
 
-void L2TauPixelIsoTagProducer::produce(edm::Event& ev, const edm::EventSetup& es)
+void L2TauPixelIsoTagProducer::produce(edm::StreamID sid, edm::Event& ev, const edm::EventSetup& es) const
 {
   using namespace reco;
   using namespace std;

--- a/RecoTauTag/HLTProducers/src/TauJetSelectorForHLTTrackSeeding.cc
+++ b/RecoTauTag/HLTProducers/src/TauJetSelectorForHLTTrackSeeding.cc
@@ -38,7 +38,7 @@ TauJetSelectorForHLTTrackSeeding::~TauJetSelectorForHLTTrackSeeding()
 
 // ------------ method called on each new Event  ------------
 void
-TauJetSelectorForHLTTrackSeeding::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+TauJetSelectorForHLTTrackSeeding::produce(edm::StreamID iStreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
    std::auto_ptr< reco::TrackJetCollection > augmentedTrackJets (new reco::TrackJetCollection);
 

--- a/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
+++ b/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
@@ -24,25 +24,24 @@
 //
 // constructors and destructor
 //
-VertexFromTrackProducer::VertexFromTrackProducer(const edm::ParameterSet& conf)
-  : theConfig(conf)
+VertexFromTrackProducer::VertexFromTrackProducer(const edm::ParameterSet& conf) : 
+  trackToken( consumes<edm::View<reco::Track> >(conf.getParameter<edm::InputTag>("trackLabel")) ),
+  candidateToken( consumes<edm::View<reco::RecoCandidate> >(conf.getParameter<edm::InputTag>("trackLabel")) ),
+  triggerFilterElectronsSrc( consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("triggerFilterElectronsSrc")) ),
+  triggerFilterMuonsSrc( consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("triggerFilterMuonsSrc")) ),
+  vertexLabel( consumes<edm::View<reco::Vertex> >(conf.getParameter<edm::InputTag>("vertexLabel")) ),
+  beamSpotLabel( consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpotLabel")) ),
+  fIsRecoCandidate( conf.getParameter<bool>("isRecoCandidate") ),
+  fUseBeamSpot( conf.getParameter<bool>("useBeamSpot") ),
+  fUseVertex( conf.getParameter<bool>("useVertex") ),
+  fUseTriggerFilterElectrons( conf.getParameter<bool>("useTriggerFilterElectrons") ),
+  fUseTriggerFilterMuons( conf.getParameter<bool>("useTriggerFilterMuons") ),
+  theConfig( conf ),
+  fVerbose( conf.getUntrackedParameter<bool>("verbose", false) )
 {
   edm::LogInfo("PVDebugInfo") 
     << "Initializing  VertexFromTrackProducer" << "\n";
-  fVerbose = conf.getUntrackedParameter<bool>("verbose", false);
-  trackLabel = conf.getParameter<edm::InputTag>("trackLabel");
-  trackToken = consumes<edm::View<reco::Track> >(trackLabel);
-  candidateToken = consumes<edm::View<reco::RecoCandidate> >(trackLabel);
-  fIsRecoCandidate = conf.getParameter<bool>("isRecoCandidate");
-  fUseBeamSpot = conf.getParameter<bool>("useBeamSpot");
-  fUseVertex = conf.getParameter<bool>("useVertex");
-  fUseTriggerFilterElectrons = conf.getParameter<bool>("useTriggerFilterElectrons");
-  fUseTriggerFilterMuons = conf.getParameter<bool>("useTriggerFilterMuons");
-  triggerFilterElectronsSrc = consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("triggerFilterElectronsSrc"));
-  triggerFilterMuonsSrc = consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("triggerFilterMuonsSrc"));
-  vertexLabel = consumes<edm::View<reco::Vertex> >(conf.getParameter<edm::InputTag>("vertexLabel"));
-  beamSpotLabel = consumes<reco::BeamSpot>(conf.getParameter<edm::InputTag>("beamSpotLabel"));
- 
+
   produces<reco::VertexCollection>();
 
 }
@@ -56,7 +55,7 @@ VertexFromTrackProducer::~VertexFromTrackProducer() {}
 
 // ------------ method called to produce the data  ------------
 void
-VertexFromTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+VertexFromTrackProducer::produce(edm::StreamID iStreamId, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
   using namespace edm;
 

--- a/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
+++ b/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
@@ -36,7 +36,6 @@ VertexFromTrackProducer::VertexFromTrackProducer(const edm::ParameterSet& conf) 
   fUseVertex( conf.getParameter<bool>("useVertex") ),
   fUseTriggerFilterElectrons( conf.getParameter<bool>("useTriggerFilterElectrons") ),
   fUseTriggerFilterMuons( conf.getParameter<bool>("useTriggerFilterMuons") ),
-  theConfig( conf ),
   fVerbose( conf.getUntrackedParameter<bool>("verbose", false) )
 {
   edm::LogInfo("PVDebugInfo") 
@@ -187,16 +186,18 @@ VertexFromTrackProducer::produce(edm::StreamID iStreamId, edm::Event& iEvent, co
 
   if(fVerbose){
     int ivtx=0;
+    edm::LogInfo("PVDebugInfo")<< "Vertices by VertexFromTrackProducer: \n"; 
     for(reco::VertexCollection::const_iterator v=vColl.begin(); 
 	v!=vColl.end(); ++v){
-      std::cout << "recvtx "<< ivtx++ 
-		<< " x "  << std::setw(6) << v->position().x() 
-		<< " dx " << std::setw(6) << v->xError()
-		<< " y "  << std::setw(6) << v->position().y() 
-		<< " dy " << std::setw(6) << v->yError()
-		<< " z "  << std::setw(6) << v->position().z() 
-		<< " dz " << std::setw(6) << v->zError()
-		<< std::endl;
+      edm::LogInfo("PVDebugInfo")<< "\t" 
+				 << "recvtx "<< ivtx++ 
+				 << " x "  << std::setw(6) << v->position().x() 
+				 << " dx " << std::setw(6) << v->xError()
+				 << " y "  << std::setw(6) << v->position().y() 
+				 << " dy " << std::setw(6) << v->yError()
+				 << " z "  << std::setw(6) << v->position().z() 
+				 << " dz " << std::setw(6) << v->zError()
+				 << " \n ";
     }
   }
 

--- a/RecoTauTag/TauTagTools/plugins/PFTauSelector.cc
+++ b/RecoTauTag/TauTagTools/plugins/PFTauSelector.cc
@@ -1,9 +1,9 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "RecoTauTag/TauTagTools/plugins/PFTauSelectorDefinition.h"
 
-typedef ObjectSelector<PFTauSelectorDefinition> PFTauSelector;
+typedef ObjectSelectorStream<PFTauSelectorDefinition> PFTauSelector;
 
 DEFINE_FWK_MODULE(PFTauSelector);


### PR DESCRIPTION
In this pull request modules used by HLT paths with taus are migrated to multithread friendly modules - in most to edm::global::EDProducer. 
In addition const data members of many of the modules explicitely defined as const.
The pull request should be also forwardported to 74X release series.
