### PR TITLE
assure no DS collision LHE relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_extendedgen.py
+++ b/Configuration/PyReleaseValidation/python/relval_extendedgen.py
@@ -24,21 +24,21 @@ workflows[510]=['',['SoftQCDinelastic_13TeV_pythia8','HARVESTGEN']]
 
 # Hadronization (Hadronization of LHE)
 workflows[514]=['',['GGToH_13TeV_pythia8','HARVESTGEN']]
-workflows[515]=['',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taupinu','HARVESTGEN2']]
+workflows[515]=['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_py8_taupinu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taupinu','HARVESTGEN2']]
 workflows[516]=['',['WJetsLNutaupinu_13TeV_madgraph-pythia8','HARVESTGEN']]
 
 workflows[517]=['',['GGToHtaupinu_13TeV_pythia8','HARVESTGEN']]
-workflows[518]=['',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taurhonu','HARVESTGEN2']]
+workflows[518]=['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_py8_taurhonu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taurhonu','HARVESTGEN2']]
 workflows[519]=['',['WJetsLNutaurhonu_13TeV_madgraph-pythia8','HARVESTGEN']]
 workflows[520]=['',['GGToHtaurhonu_13TeV_pythia8','HARVESTGEN']]
 
 # External Decays
 workflows[524]=['',['GGToH_13TeV_pythia8-tauola','HARVESTGEN']]
 workflows[525]=['',['WToLNutaupinu_13TeV_pythia8-tauola','HARVESTGEN']]
-workflows[526]=['',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taupinu','HARVESTGEN2']]
+workflows[526]=['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_Ta_taupinu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taupinu','HARVESTGEN2']]
 workflows[527]=['',['GGToHtaupinu_13TeV_pythia8-tauola','HARVESTGEN']]
 workflows[528]=['',['WToLNutaurhonu_13TeV_pythia8-tauola','HARVESTGEN']]
-workflows[529]=['',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taurhonu','HARVESTGEN2']]
+workflows[529]=['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_Ta_taurhonu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taurhonu','HARVESTGEN2']]
 workflows[530]=['',['GGToHtaurhonu_13TeV_pythia8-tauola','HARVESTGEN']]
 
 # Heavy Ion

--- a/Configuration/PyReleaseValidation/python/relval_generator.py
+++ b/Configuration/PyReleaseValidation/python/relval_generator.py
@@ -24,12 +24,12 @@ workflows[506]=['',['WToLNu_13TeV_pythia8','HARVESTGEN']]
 workflows[511]=['',['QCD_Pt-30_8TeV_herwigpp','HARVESTGEN']]
 
 # Matrix Element Generations & Hadronization (LHE Generation + Hadronization)
-workflows[512]=['',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]
+workflows[512]=['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_py8',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]
 workflows[513]=['',['WJetsLNu_13TeV_madgraph-pythia8','HARVESTGEN']]
 
 # External Decays
 workflows[521]=['',['TT_13TeV_pythia8-evtgen','HARVESTGEN']]
-workflows[522]=['',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]
+workflows[522]=['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_Ta',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]
 workflows[523]=['',['WToLNu_13TeV_pythia8-tauola','HARVESTGEN']]
 
 # Heavy Ion

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -677,8 +677,8 @@ def genvalid(fragment,d,suffix='all',fi='',dataSet=''):
 
 
 steps['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
-
-steps['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeVINPUT']={'INPUT':InputInfo(dataSet='/MinimumBias/Run2012B-v1/RAW',location='STD')}
+# all 6 workflows with root step 'DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV' will recycle the same dataset, from wf [512] of generator set
+steps['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeVINPUT']={'INPUT':InputInfo(dataSet='/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_py8/CMSSW_7_4_0_pre0-MCRUN2_73_V5-v1/GEN',location='STD')}
 
 steps['MinBias_TuneZ2star_13TeV_pythia6']=genvalid('MinBias_TuneZ2star_13TeV_pythia6_cff',step1GenDefaults)
 steps['QCD_Pt-30_TuneZ2star_13TeV_pythia6']=genvalid('QCD_Pt_30_TuneZ2star_13TeV_pythia6_cff',step1GenDefaults)


### PR DESCRIPTION
- needs to go on top of #6626 (already rebased on top of CMSSW_7_4_X)
- enforces that no LHE workflow can produce the same /GEN dataset
- /GEN recycling command all point to the same /GEN dataset
