### PR TITLE
Correcting L1 trigger printout and multithreading

### DIFF
--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -1,16 +1,16 @@
 #ifndef JSONMonitoring_TriggerJSONMonitoring_h
 #define JSONMonitoring_TriggerJSONMonitoring_h
 
-/** \class TriggerJSONMonitoring                                                                                                       
- *                                                                                                                                     
- *                                                                                                                                     
- *  Description: This class prints JSON files with trigger info.                                                                       
- *                                                                                                                                     
- *  Created:  Wed, 09 Jul 2014                                                                                                         
- *                                                                                                                                     
- *  \author Aram Avetisyan                                                                                                             
- *  \author Daniel Salerno                                                                                                             
- *                                                                                                                                     
+/** \class TriggerJSONMonitoring         
+ *     
+ *  
+ *  Description: This class prints JSON files with trigger info.
+ *          
+ *  Created:  Wed, 09 Jul 2014     
+ *       
+ *  \author Aram Avetisyan   
+ *  \author Daniel Salerno  
+ * 
  */
 
 #include "FWCore/Framework/interface/Event.h"
@@ -31,49 +31,47 @@
 
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
-#include "FWCore/Framework/interface/ESHandle.h" //DS                                                                                  
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h" //DS                                                                     
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h" //DS                                                                  
-//#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h" //DS                                                 
-
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h" //DS                                                 
+#include "FWCore/Framework/interface/ESHandle.h" //DS         
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h" //DS 
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h" //DS 
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h" //DS 
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
+#include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
+#include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
 
 #include <atomic>
 
 namespace hltJson {
-  //Struct for storing variables that must be written and reset every lumi section                                                     
+  //Struct for storing variables that must be written and reset every lumi section 
   struct lumiVars {
-    HistoJ<unsigned int> *processed; // # of events processed                                                                          
+    HistoJ<unsigned int> *processed; // # of events processed
+    HistoJ<unsigned int> *hltWasRun; // # of events where HLT[i] was run 
+    HistoJ<unsigned int> *hltL1s;    // # of events after L1 seed
+    HistoJ<unsigned int> *hltPre;    // # of events after HLT prescale 
+    HistoJ<unsigned int> *hltAccept; // # of events accepted by HLT[i]
+    HistoJ<unsigned int> *hltReject; // # of events rejected by HLT[i] 
+    HistoJ<unsigned int> *hltErrors; // # of events with error in HLT[i]
+    HistoJ<unsigned int> *hltDatasets; // # of events accepted by each dataset 
 
-    HistoJ<unsigned int> *hltWasRun; // # of events where HLT[i] was run                                                               
-    HistoJ<unsigned int> *hltL1s;    // # of events after L1 seed                                                                      
-    HistoJ<unsigned int> *hltPre;    // # of events after HLT prescale                                                                 
-    HistoJ<unsigned int> *hltAccept; // # of events accepted by HLT[i]                                                                 
-    HistoJ<unsigned int> *hltReject; // # of events rejected by HLT[i]                                                                 
-    HistoJ<unsigned int> *hltErrors; // # of events with error in HLT[i]                                                               
+    std::string baseRunDir;        //Base directory from EvFDaqDirector 
+    std::string stHltJsd;   //Definition file name for JSON with rates  
 
-    HistoJ<unsigned int> *hltDatasets; // # of events accepted by each dataset                                                         
-
-
-    std::string baseRunDir;        //Base directory from EvFDaqDirector                                                                
-    std::string stHltJsd;   //Definition file name for JSON with rates                                                          
-
-    HistoJ<unsigned int> *L1Global;     // Global # of Phyics, Cailibration and Random L1 triggers //DS  
-    HistoJ<unsigned int> *L1Accept;     // # of events accepted by L1T[i] //DS                                                         
-    HistoJ<unsigned int> *L1TechAccept; // # of events accepted by L1 Technical Triggers[i] //DS                                       
+    HistoJ<unsigned int> *L1Global;     // Global # of Phyics, Cailibration and Random L1 triggers //DS
+    HistoJ<unsigned int> *L1Accept;     // # of events accepted by L1T[i] //DS 
+    HistoJ<unsigned int> *L1TechAccept; // # of events accepted by L1 Technical Triggers[i] //DS 
     
-    std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            //DS                                  
+    std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            //DS
   };
   //End lumi struct
   //Struct for storing variable written once per run
   struct runVars{
     mutable std::atomic<bool> wroteFiles;
   };
-}//End hltJson namespace                                                                                                               
+}//End hltJson namespace   
 
-//                                                                                                                                     
-// class declaration                                                                                                                   
-//                                                                                                                                     
+// 
+// class declaration
+// 
 class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJson::runVars>, edm::LuminosityBlockSummaryCache<hltJson::lumiVars>>
 {
  public:
@@ -95,7 +93,6 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
   
   static void globalEndRun(edm::Run const& iRun, edm::EventSetup const&, RunContext const* iContext){ } 
 
-
   void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
 
   static std::shared_ptr<hltJson::lumiVars> globalBeginLuminosityBlockSummary(edm::LuminosityBlock const&,
@@ -112,61 +109,65 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
                                               LuminosityBlockContext const*,
                                               hltJson::lumiVars*);
 
-  void resetRun(bool changed);   //Reset run-related info                                                                              
-  void resetLumi();              //Reset all counters                                                                                  
+  void resetRun(bool changed);   //Reset run-related info
+  void resetLumi();              //Reset all counters 
 
   void writeDefJson(std::string path);
 
-  void writeL1DefJson(std::string path);       //DS                                                                                    
+  void writeL1DefJson(std::string path);       //DS
 
-  //Variables from cfg and associated tokens                                                                                           
-  edm::InputTag triggerResults_;                               // Input tag for TriggerResults                                         
-  edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;  // Token for TriggerResults                                             
+  //Variables from cfg and associated tokens 
+  edm::InputTag triggerResults_;                               // Input tag for TriggerResults 
+  edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;  // Token for TriggerResults
 
-  edm::InputTag m_l1GtObjectMapTag;                            // input tag for L1 GT Object Maps //DS                                 
-  edm::EDGetTokenT<L1GlobalTriggerObjectMapRecord> m_l1GtObjectMapToken; //Token forL1 GT Object Maps //DS                             
+  edm::InputTag level1Results_;                                 // Input tag for L1 GT Readout Record //DS  
+  edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1t_results; // Token for L1 GT Readout Record
 
-  //Variables that change at most once per run                                                                                         
-  HLTConfigProvider hltConfig_;         // to get configuration for HLT    
+  //Variables that change at most once per run 
+  HLTConfigProvider hltConfig_;         // to get configuration for HLT
+  const L1GtTriggerMenu* m_l1GtMenu;    // L1 trigger menu  //DS 
+  AlgorithmMap algorithmMap;            // L1 algorithm map //DS 
+  AlgorithmMap technicalMap;            // L1 technical triggeral map //DS
 
-  const L1GtTriggerMenu* m_l1GtMenu;    // L1 trigger menu  //DS                                                                       
-  AlgorithmMap algorithmMap;            // L1 algorithm map //DS                                                                       
-  AlgorithmMap technicalMap;            // L1 technical triggeral map //DS                                                             
+  const L1GtTriggerMask* m_l1tAlgoMask;
+  const L1GtTriggerMask* m_l1tTechMask;
 
-  std::string baseRunDir_; //Base directory from EvFDaqDirector                                                                        
+  std::string baseRunDir_; //Base directory from EvFDaqDirector
 
-  // hltIndex_[ds][p] stores the hltNames_ index of the p-th path of the ds-th dataset                                                 
+  // hltIndex_[ds][p] stores the hltNames_ index of the p-th path of the ds-th dataset 
   std::vector<std::vector<unsigned int> > hltIndex_;
-  std::vector<std::string> hltNames_;                      // list of HLT path names                                                   
-  std::vector<std::string> datasetNames_;                  // list of dataset names                                                    
-  std::vector<std::vector<std::string> > datasetContents_; // list of path names for each dataset                                      
+  std::vector<std::string> hltNames_;                      // list of HLT path names 
+  std::vector<std::string> datasetNames_;                  // list of dataset names 
+  std::vector<std::vector<std::string> > datasetContents_; // list of path names for each dataset 
 
-  std::vector<int> posL1s_;               // pos # of last L1 seed                                                                       
-  std::vector<int> posPre_;               // pos # of last HLT prescale                                                                  
+  std::vector<int> posL1s_;               // pos # of last L1 seed
+  std::vector<int> posPre_;               // pos # of last HLT prescale
 
-  std::string stHltJsd_;                  //Definition file name for JSON with rates                                                     
+  std::string stHltJsd_;                  //Definition file name for JSON with rates
 
-  std::vector<std::string> L1Names_;      // name of each L1 algorithm trigger      //DS                                                
-  std::vector<std::string> L1TechNames_;  // name of each L1 technical trigger      //DS                                                
-  std::vector<std::string> L1GlobalType_; // experimentType: Physics, Calibration, Random  //DS                                         
+  std::vector<std::string> L1AlgoNames_;  // name of each L1 algorithm trigger      //DS
+  std::vector<int> L1AlgoBitNumber_;      // bit number of each L1 algo trigger     //DS
+  std::vector<std::string> L1TechNames_;  // name of each L1 technical trigger      //DS
+  std::vector<int> L1TechBitNumber_;      // bit number of each L1 tech trigger     //DS
+  std::vector<std::string> L1GlobalType_; // experimentType: Physics, Calibration, Random  //DS
 
-  std::string stL1Jsd_;                   //Definition file name for JSON with L1 rates           //DS                                   
+  std::string stL1Jsd_;                   //Definition file name for JSON with L1 rates           //DS
 
-  //Variables that need to be reset at lumi section boundaries                                                                         
-  unsigned int              processed_; // # of events processed                                                                       
+  //Variables that need to be reset at lumi section boundaries 
+  unsigned int              processed_; // # of events processed 
 
   std::vector<unsigned int> hltWasRun_; // # of events where HLT[i] was run   
-  std::vector<unsigned int> hltL1s_;    // # of events after L1 seed                                                                   
-  std::vector<unsigned int> hltPre_;    // # of events after HLT prescale                                                              
-  std::vector<unsigned int> hltAccept_; // # of events accepted by HLT[i]                                                              
-  std::vector<unsigned int> hltReject_; // # of events rejected by HLT[i]                                                              
-  std::vector<unsigned int> hltErrors_; // # of events with error in HLT[i]                                                            
+  std::vector<unsigned int> hltL1s_;    // # of events after L1 seed
+  std::vector<unsigned int> hltPre_;    // # of events after HLT prescale 
+  std::vector<unsigned int> hltAccept_; // # of events accepted by HLT[i]
+  std::vector<unsigned int> hltReject_; // # of events rejected by HLT[i]
+  std::vector<unsigned int> hltErrors_; // # of events with error in HLT[i]
 
-  std::vector<unsigned int> hltDatasets_; // # of events accepted by each dataset                                                      
+  std::vector<unsigned int> hltDatasets_; // # of events accepted by each dataset 
 
-  std::vector<unsigned int> L1Global_;     // Global # of Phyics, Cailibration and Random L1 triggers //DS                             
-  std::vector<unsigned int> L1Accept_;     // # of events accepted by L1T[i]  //DS                                                     
-  std::vector<unsigned int> L1TechAccept_; // # of events accepted by L1 Technical Triggers[i]  //DS                                   
+  std::vector<unsigned int> L1Global_;     // Global # of Physics, Calibration and Random L1 triggers //DS
+  std::vector<unsigned int> L1AlgoAccept_; // # of events accepted by L1T[i]  //DS
+  std::vector<unsigned int> L1TechAccept_; // # of events accepted by L1 Technical Triggers[i]  //DS
 
  private:
 

--- a/HLTrigger/JSONMonitoring/test/TriggerJSONMonitoring.py
+++ b/HLTrigger/JSONMonitoring/test/TriggerJSONMonitoring.py
@@ -4,7 +4,7 @@ process = cms.Process("HLTM")
 
 process.load("FWCore.MessageService.MessageLogger_cfi")
 
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
 
 process.EvFDaqDirector = cms.Service( "EvFDaqDirector",
     buBaseDir = cms.untracked.string( "." ),
@@ -20,7 +20,7 @@ process.FastMonitoringService = cms.Service( "FastMonitoringService",
 
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
-        'file:../../../../../Commissioning2014_Run224380_1000Events.root'
+        'file:../../../../../Commissioning2014_Run22913_Cosmics.root'
     )
 )
 
@@ -28,9 +28,16 @@ process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.GlobalTag import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:hltonline_2014', '')
 
-process.hltm = cms.EDAnalyzer('TriggerJSONMonitoring',
-    triggerResults = cms.InputTag( 'TriggerResults','','HLT')
+process.hltGtDigis = cms.EDProducer( "L1GlobalTriggerRawToDigi",
+    DaqGtFedId = cms.untracked.int32( 813 ),
+    DaqGtInputTag = cms.InputTag( "rawDataCollector" ),
+    UnpackBxInEvent = cms.int32( 5 ),
+    ActiveBoardsMask = cms.uint32( 0xffff )
 )
 
+process.hltm = cms.EDAnalyzer('TriggerJSONMonitoring',
+    triggerResults = cms.InputTag( 'TriggerResults','','HLT'),
+    L1Results = cms.InputTag( "hltGtDigis" )
+)
 
-process.p = cms.Path(process.hltm)
+process.p = cms.Path(process.hltGtDigis + process.hltm)


### PR DESCRIPTION
This PR modifies the output format of the L1 JSON by making sure that unassigned trigger bits (i.e. those without names) are included in the JSON file. This is necessary because the database expects vectors of a fixed size (even if the information in some entries is meaningless) whereas with the old approach the size could vary.

There is also a very small fix to the multithreading. A more thorough revision of the latter will be done after the mid-week global run.
