### PR TITLE
Making FED used by HLTL1NumberFilter configurable

### DIFF
--- a/HLTrigger/special/interface/HLTL1NumberFilter.h
+++ b/HLTrigger/special/interface/HLTL1NumberFilter.h
@@ -54,7 +54,8 @@ private:
   unsigned int period_;
   /// if invert_=true, invert that event accept decision
   bool invert_;
-
+  //FED from which to get lv1ID number
+  int fedId_;
 };
 
 #endif

--- a/HLTrigger/special/src/HLTL1NumberFilter.cc
+++ b/HLTrigger/special/src/HLTL1NumberFilter.cc
@@ -27,6 +27,7 @@ Implementation:
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDHeader.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //
 // constructors and destructor
@@ -57,7 +58,7 @@ HLTL1NumberFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("rawInput",edm::InputTag("source"));
   desc.add<unsigned int>("period",4096);
   desc.add<bool>("invert",true);
-  desc.add<int>("fedId",813);
+  desc.add<int>("fedId",812);
   descriptions.add("hltL1NumberFilter",desc);
 }
 //
@@ -75,10 +76,15 @@ HLTL1NumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
     edm::Handle<FEDRawDataCollection> theRaw ;
     iEvent.getByToken(inputToken_,theRaw) ;
     const FEDRawData& data = theRaw->FEDData(fedId_) ;
-    FEDHeader header(data.data()) ;
-    if (period_!=0) accept = ( ( (header.lvl1ID())%period_ ) == 0 );
-    if (invert_) accept = !accept;
-    return accept;
+    if (data.data() && data.size() > 0){
+      FEDHeader header(data.data()) ;
+      if (period_!=0) accept = ( ( (header.lvl1ID())%period_ ) == 0 );
+      if (invert_) accept = !accept;
+      return accept;
+    } else{
+      LogWarning("HLTL1NumberFilter")<<"No valid data for FED "<<fedId_<<" used by HLTL1NumberFilter";
+      return false;
+    }
   } else {
     return true;
   }

--- a/HLTrigger/special/src/HLTL1NumberFilter.cc
+++ b/HLTrigger/special/src/HLTL1NumberFilter.cc
@@ -37,6 +37,7 @@ HLTL1NumberFilter::HLTL1NumberFilter(const edm::ParameterSet& iConfig)
   input_  = iConfig.getParameter<edm::InputTag>("rawInput") ;   
   period_ = iConfig.getParameter<unsigned int>("period") ;
   invert_ = iConfig.getParameter<bool>("invert") ;
+  fedId_  = iConfig.getParameter<int>("fedId") ;
   inputToken_ = consumes<FEDRawDataCollection>(input_);
 }
 
@@ -56,6 +57,7 @@ HLTL1NumberFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions
   desc.add<edm::InputTag>("rawInput",edm::InputTag("source"));
   desc.add<unsigned int>("period",4096);
   desc.add<bool>("invert",true);
+  desc.add<int>("fedId",813);
   descriptions.add("hltL1NumberFilter",desc);
 }
 //
@@ -72,7 +74,7 @@ HLTL1NumberFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
     bool accept(false);
     edm::Handle<FEDRawDataCollection> theRaw ;
     iEvent.getByToken(inputToken_,theRaw) ;
-    const FEDRawData& data = theRaw->FEDData(FEDNumbering::MINTriggerGTPFEDID) ;
+    const FEDRawData& data = theRaw->FEDData(fedId_) ;
     FEDHeader header(data.data()) ;
     if (period_!=0) accept = ( ( (header.lvl1ID())%period_ ) == 0 );
     if (invert_) accept = !accept;


### PR DESCRIPTION
This is the 73X version of PR #6706 which fixes the HLTL1NumberFilter. The description from the original PR is below:

This PR fixes the HLTL1NumberFilter used by paths from the HcalNZS primary dataset. The filter was relying on FED 812 always being in the event which is no longer the case since the advent of TCDS. Per Andrea Bocci's suggestion, the FED used has been made configurable with the default set to 813 in fillDescriptions (it's not a good idea to simply change the hardcoded value to 813 because it will break again after the L1 trigger upgrade).
