### PR TITLE
Fix missing link dependency

### DIFF
--- a/CondFormats/EgammaObjects/BuildFile.xml
+++ b/CondFormats/EgammaObjects/BuildFile.xml
@@ -3,6 +3,7 @@
 <use   name="CondFormats/Serialization"/>
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <use   name="boost_serialization"/>
+<use   name="roottmva"/>
 
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
Add missing link dependency to fix massive link errors in the ROOT6 IB.

Please merge this as soon as convenient, but in time for the next IB.
