### PR TITLE
exclude premix relvals from the MatrixReader (port 74x)

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -49,8 +49,8 @@ class MatrixReader(object):
                              'relval_upgrade':'upg-',
                              'relval_identity':'id-',
                              'relval_machine': 'mach-',
-                             'relval_unsch': 'unsch-',
-                             'relval_premix': 'premix-'
+                             'relval_unsch': 'unsch-'
+                             #, 'relval_premix': 'premix-'
                              }
 
         self.files = ['relval_standard' ,
@@ -63,8 +63,8 @@ class MatrixReader(object):
                       'relval_upgrade',
                       'relval_identity',
                       'relval_machine',
-                      'relval_unsch',
-                      'relval_premix'
+                      'relval_unsch'
+                      #, 'relval_premix'
                       ]
 
         self.relvalModule = None


### PR DESCRIPTION
- forward port of #6721
- exclude premix relvals from the MatrixReader
- as agreed here: https://hypernews.cern.ch/HyperNews/CMS/get/swReleases/4138/1/1.html
