### PR TITLE
Important BUG FIX in parameter assignment of millepede-based tracker alignment

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentAlgorithmBase.h
@@ -27,8 +27,9 @@ class Trajectory;
 #include "Alignment/LaserAlignment/interface/TsosVectorCollection.h"
 #include "DataFormats/Alignment/interface/TkFittedLasBeamCollectionFwd.h"
 #include "DataFormats/Alignment/interface/AliClusterValueMapFwd.h"
+#include "FWCore/Framework/interface/Event.h"
 
-namespace edm { class EventID; class RunID; class EventSetup; class ParameterSet; }
+namespace edm { class EventSetup; class ParameterSet; }
 namespace reco { class Track; class BeamSpot; }
 
 class AlignmentAlgorithmBase
@@ -42,25 +43,41 @@ public:
   typedef std::pair<RunNumber,RunNumber> RunRange;
 
   /// define event information passed to algorithms
-  struct EventInfo {
-    EventInfo(const edm::EventID &eventId, 
-	      const ConstTrajTrackPairCollection &trajTrackPairs,
-	      const reco::BeamSpot &beamSpot,
-	      const AliClusterValueMap *clusterValueMap) 
-      : eventId_(eventId), trajTrackPairs_(trajTrackPairs), beamSpot_(beamSpot), clusterValueMap_(clusterValueMap) {}
+  class EventInfo {
+  public:
+    EventInfo(const edm::EventID &theEventId, 
+	      const ConstTrajTrackPairCollection &theTrajTrackPairs,
+	      const reco::BeamSpot &theBeamSpot,
+	      const AliClusterValueMap *theClusterValueMap) 
+      : eventId_(theEventId), trajTrackPairs_(theTrajTrackPairs), beamSpot_(theBeamSpot), clusterValueMap_(theClusterValueMap) {}
 
-    const edm::EventID                 &eventId_;
+    const edm::EventID eventId() const { return eventId_; }
+    const ConstTrajTrackPairCollection& trajTrackPairs() const { return trajTrackPairs_; }
+    const reco::BeamSpot& beamSpot() const { return beamSpot_; }
+    const AliClusterValueMap* clusterValueMap() const { return clusterValueMap_; }///might be null!
+    
+
+  private:
+    const edm::EventID                 eventId_;
     const ConstTrajTrackPairCollection &trajTrackPairs_;
     const reco::BeamSpot               &beamSpot_;
     const AliClusterValueMap           *clusterValueMap_;///might be null!
   };
   
   /// define run information passed to algorithms (in endRun)
-  struct EndRunInfo {
-    EndRunInfo(const edm::RunID &runId, const TkFittedLasBeamCollection *tkLasBeams,
-	       const TsosVectorCollection *tkLasBeamTsoses)
-      : runId_(runId), tkLasBeams_(tkLasBeams), tkLasBeamTsoses_(tkLasBeamTsoses) {}
-    const edm::RunID &runId_;
+  class EndRunInfo {
+  public:
+    EndRunInfo(const edm::RunID &theRunId, const TkFittedLasBeamCollection *theTkLasBeams,
+	       const TsosVectorCollection *theTkLasBeamTsoses)
+      : runId_(theRunId), tkLasBeams_(theTkLasBeams), tkLasBeamTsoses_(theTkLasBeamTsoses) {}
+
+    const edm::RunID runId() const { return runId_; }
+    const TkFittedLasBeamCollection* tkLasBeams() const { return tkLasBeams_; } /// might be null!
+    const TsosVectorCollection* tkLasBeamTsoses() const { return tkLasBeamTsoses_; } /// might be null!
+
+
+  private:
+    const edm::RunID runId_;
     const TkFittedLasBeamCollection *tkLasBeams_; /// might be null!
     const TsosVectorCollection *tkLasBeamTsoses_; /// might be null!
   };

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiPixelLorentzAngleCalibration.cc
@@ -187,7 +187,7 @@ SiPixelLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
   if (hit.det()) { // otherwise 'constraint hit' or whatever
     
     const int index = moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(),
-                                                                       eventInfo.eventId_.run());
+                                                                       eventInfo.eventId().run());
     if (index >= 0) { // otherwise not treated
       edm::ESHandle<MagneticField> magneticField;
       setup.get<IdealMagneticFieldRecord>().get(magneticField);
@@ -360,7 +360,7 @@ bool SiPixelLorentzAngleCalibration::checkLorentzAngleInput(const edm::EventSetu
 	// 'floating point comparison' problems (FIXME?)
 	throw cms::Exception("BadInput")
 	  << "SiPixelLorentzAngleCalibration::checkLorentzAngleInput:\n"
-	  << "Content of SiPixelLorentzAngle changed at run " << eventInfo.eventId_.run()
+	  << "Content of SiPixelLorentzAngle changed at run " << eventInfo.eventId().run()
 	  << ", but algorithm expects constant input!\n";
 	return false; // not reached...
       }

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripBackplaneCalibration.cc
@@ -208,7 +208,7 @@ SiStripBackplaneCalibration::derivatives(std::vector<ValuesIndexPair> &outDerivI
     if (hit.det()) { // otherwise 'constraint hit' or whatever
       
       const int index = moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(),
-                                                                    eventInfo.eventId_.run());
+									 eventInfo.eventId().run());
       if (index >= 0) { // otherwise not treated
         edm::ESHandle<MagneticField> magneticField;
         setup.get<IdealMagneticFieldRecord>().get(magneticField);
@@ -432,7 +432,7 @@ bool SiStripBackplaneCalibration::checkBackPlaneCorrectionInput(const edm::Event
 	// 'floating point comparison' problems (FIXME?)
 	throw cms::Exception("BadInput")
 	  << "SiStripBackplaneCalibration::checkBackPlaneCorrectionInput:\n"
-	  << "Content of SiStripBackPlaneCorrection changed at run " << eventInfo.eventId_.run()
+	  << "Content of SiStripBackPlaneCorrection changed at run " << eventInfo.eventId().run()
 	  << ", but algorithm expects constant input!\n";
 	return false; // not reached...
       }

--- a/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
+++ b/Alignment/CommonAlignmentAlgorithm/plugins/SiStripLorentzAngleCalibration.cc
@@ -207,7 +207,7 @@ SiStripLorentzAngleCalibration::derivatives(std::vector<ValuesIndexPair> &outDer
     if (hit.det()) { // otherwise 'constraint hit' or whatever
       
       const int index = moduleGroupSelector_->getParameterIndexFromDetId(hit.det()->geographicalId(),
-                                                                    eventInfo.eventId_.run());
+									 eventInfo.eventId().run());
       if (index >= 0) { // otherwise not treated
         edm::ESHandle<MagneticField> magneticField;
         setup.get<IdealMagneticFieldRecord>().get(magneticField);
@@ -398,7 +398,7 @@ bool SiStripLorentzAngleCalibration::checkLorentzAngleInput(const edm::EventSetu
 	// 'floating point comparison' problems (FIXME?)
 	throw cms::Exception("BadInput")
 	  << "SiStripLorentzAngleCalibration::checkLorentzAngleInput:\n"
-	  << "Content of SiStripLorentzAngle changed at run " << eventInfo.eventId_.run()
+	  << "Content of SiStripLorentzAngle changed at run " << eventInfo.eventId().run()
 	  << ", but algorithm expects constant input!\n";
 	return false; // not reached...
       }

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -704,7 +704,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
   theFile->cd();
 	
   // loop over tracks  
-  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs_;
+  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs();
   for (ConstTrajTrackPairCollection::const_iterator it=tracks.begin();
        it!=tracks.end();
        ++it) {
@@ -778,7 +778,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	
 	//////////Hit prescaling part 	 
 	bool skiphit = false; 	 
-	if (eventInfo.clusterValueMap_) { 	 
+	if (eventInfo.clusterValueMap()) { 	 
 	  // check from the PrescalingMap if the hit was taken. 	 
 	  // If not skip to the next TM 	 
 	  // bool hitTaken=false; 	 
@@ -796,7 +796,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	      if (stripHit1D) { 	 
 		SiStripRecHit1D::ClusterRef stripclust(stripHit1D->cluster()); 	 
 		// myflag=PrescMap[stripclust]; 	 
-		myflag = (*eventInfo.clusterValueMap_)[stripclust]; 	 
+		myflag = (*eventInfo.clusterValueMap())[stripclust]; 	 
 	      } else { 	 
 		edm::LogError("HIPAlignmentAlgorithm") 
 		  << "ERROR in <HIPAlignmentAlgorithm::run>: Dynamic cast of Strip RecHit failed! "
@@ -810,7 +810,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	      if (stripHit2D) { 	 
 		SiStripRecHit2D::ClusterRef stripclust(stripHit2D->cluster()); 	 
 		// myflag=PrescMap[stripclust]; 	 
-		myflag = (*eventInfo.clusterValueMap_)[stripclust]; 	 
+		myflag = (*eventInfo.clusterValueMap())[stripclust]; 	 
 	      } else { 	 
 		edm::LogError("HIPAlignmentAlgorithm") 
 		  << "ERROR in <HIPAlignmentAlgorithm::run>: Dynamic cast of Strip RecHit failed! "
@@ -824,7 +824,7 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 	    if (pixelhit) { 	 
 	      SiPixelClusterRefNew  pixelclust(pixelhit->cluster()); 	 
 	      // myflag=PrescMap[pixelclust]; 	 
-	      myflag = (*eventInfo.clusterValueMap_)[pixelclust]; 	 
+	      myflag = (*eventInfo.clusterValueMap())[pixelclust]; 	 
 	    }
 	    else { 	 
 	      edm::LogError("HIPAlignmentAlgorithm")

--- a/Alignment/KalmanAlignmentAlgorithm/plugins/KalmanAlignmentAlgorithm.cc
+++ b/Alignment/KalmanAlignmentAlgorithm/plugins/KalmanAlignmentAlgorithm.cc
@@ -160,8 +160,8 @@ void KalmanAlignmentAlgorithm::run( const edm::EventSetup & setup, const EventIn
   try
   {
     // Run the refitter algorithm
-    const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs_;
-    const reco::BeamSpot &beamSpot = eventInfo.beamSpot_;
+    const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs();
+    const reco::BeamSpot &beamSpot = eventInfo.beamSpot();
     TrackletCollection refittedTracklets = theRefitter->refitTracks( setup, theAlignmentSetups, tracks, &beamSpot );
 
     // Associate tracklets to alignment setups
@@ -186,7 +186,7 @@ void KalmanAlignmentAlgorithm::run( const edm::EventSetup & setup, const EventIn
 
       // Construct reference trajectories
       ReferenceTrajectoryCollection trajectories =
-	itMap->first->trajectoryFactory()->trajectories( setup, tracklets, external, eventInfo.beamSpot_ );
+	itMap->first->trajectoryFactory()->trajectories( setup, tracklets, external, eventInfo.beamSpot() );
 
       ReferenceTrajectoryCollection::iterator itTrajectories;
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeAlignmentAlgorithm.cc
@@ -307,7 +307,7 @@ void MillePedeAlignmentAlgorithm::terminate(const edm::EventSetup& iSetup)
 void MillePedeAlignmentAlgorithm::run(const edm::EventSetup &setup, const EventInfo &eventInfo)
 {
   if (!this->isMode(myMilleBit)) return; // no theMille created...
-  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs_;
+  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs();
 
   if (theMonitor) { // monitor input tracks
     for (ConstTrajTrackPairCollection::const_iterator iTrajTrack = tracks.begin();
@@ -316,7 +316,7 @@ void MillePedeAlignmentAlgorithm::run(const edm::EventSetup &setup, const EventI
     }
   }
 
-  const RefTrajColl trajectories(theTrajectoryFactory->trajectories(setup, tracks, eventInfo.beamSpot_));
+  const RefTrajColl trajectories(theTrajectoryFactory->trajectories(setup, tracks, eventInfo.beamSpot()));
 
   // Now loop over ReferenceTrajectoryCollection
   unsigned int refTrajCount = 0; // counter for track monitoring if 1 track per trajectory
@@ -422,9 +422,9 @@ MillePedeAlignmentAlgorithm::addHitCount(const std::vector<AlignmentParameters*>
 void MillePedeAlignmentAlgorithm::endRun(const EventInfo &eventInfo, const EndRunInfo &runInfo,
 					 const edm::EventSetup &setup)
 {
-  if(runInfo.tkLasBeams_ && runInfo.tkLasBeamTsoses_){
+  if(runInfo.tkLasBeams() && runInfo.tkLasBeamTsoses()){
     // LAS beam treatment
-    this->addLaserData(eventInfo, *(runInfo.tkLasBeams_), *(runInfo.tkLasBeamTsoses_));
+    this->addLaserData(eventInfo, *(runInfo.tkLasBeams()), *(runInfo.tkLasBeamTsoses()));
   }
 }
 

--- a/Alignment/MillePedeAlignmentAlgorithm/src/RunRangeDependentPedeLabeler.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/RunRangeDependentPedeLabeler.cc
@@ -162,8 +162,8 @@ unsigned int RunRangeDependentPedeLabeler::parameterLabel(Alignable *alignable, 
 	for (RunRangeVector::const_iterator iRunRange = runRanges.begin();
 	     iRunRange != runRanges.end();
 	     ++iRunRange) {
-	  if (eventInfo.eventId_.run() >= iRunRange->first &&
-	      eventInfo.eventId_.run() <= iRunRange->second) {
+	  if (eventInfo.eventId().run() >= iRunRange->first &&
+	      eventInfo.eventId().run() <= iRunRange->second) {
 	    return position->second + offset * theParamInstanceOffset + parNum;
 	  }
  	  offset++;
@@ -173,7 +173,7 @@ unsigned int RunRangeDependentPedeLabeler::parameterLabel(Alignable *alignable, 
 	  << "@SUB=RunRangeDependentPedeLabeler::parameterLabel" << "Instance for Alignable "
 	  << typeid(*alignable).name() << " not in map, det/subdet/alignableStructureType = "
 	  << detId.det() << "/" << detId.subdetId() << "/" << alignable->alignableObjectId()
-	  << " for run " << eventInfo.eventId_.run();
+	  << " for run " << eventInfo.eventId().run();
 	return 0;
       } else {
 	return position->second + parNum;

--- a/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/CSCOverlapsAlignmentAlgorithm.cc
@@ -243,7 +243,7 @@ void CSCOverlapsAlignmentAlgorithm::run(const edm::EventSetup& iSetup, const Eve
 
   if (m_trackTransformer != NULL) m_trackTransformer->setServices(iSetup);
 
-  const ConstTrajTrackPairCollection &trajtracks = eventInfo.trajTrackPairs_;
+  const ConstTrajTrackPairCollection &trajtracks = eventInfo.trajTrackPairs();
   for (ConstTrajTrackPairCollection::const_iterator trajtrack = trajtracks.begin();  trajtrack != trajtracks.end();  ++trajtrack) {
     const Trajectory* traj = (*trajtrack).first;
     const reco::Track* track = (*trajtrack).second;

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonAlignmentFromReference.cc
@@ -627,7 +627,7 @@ void MuonAlignmentFromReference::run(const edm::EventSetup& iSetup, const EventI
 
   if (m_muonCollectionTag.label().empty()) // use trajectories
   {
-    const ConstTrajTrackPairCollection &trajtracks = eventInfo.trajTrackPairs_;
+    const ConstTrajTrackPairCollection &trajtracks = eventInfo.trajTrackPairs();
     for (ConstTrajTrackPairCollection::const_iterator trajtrack = trajtracks.begin();  trajtrack != trajtracks.end();  ++trajtrack)
     {
       m_counter_tracks++;
@@ -639,7 +639,7 @@ void MuonAlignmentFromReference::run(const edm::EventSetup& iSetup, const EventI
       {
         m_counter_trackmomentum++;
 
-        if ( fabs(track->dxy(eventInfo.beamSpot_.position())) < m_maxDxy )
+        if ( fabs(track->dxy(eventInfo.beamSpot().position())) < m_maxDxy )
         {
           m_counter_trackdxy++;
 

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonDTLocalMillepedeAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonDTLocalMillepedeAlgorithm.cc
@@ -136,7 +136,7 @@ void MuonDTLocalMillepedeAlgorithm::run(const edm::EventSetup& setup, const Even
   //Only important in the production mode
   if(workingmode != 0) return;
  
-  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs_;
+  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs();
   for( ConstTrajTrackPairCollection::const_iterator it=tracks.begin();
        it!=tracks.end();it++) {
 

--- a/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
+++ b/Alignment/MuonAlignmentAlgorithms/plugins/MuonMillepedeAlgorithm.cc
@@ -240,7 +240,7 @@
 
 	  // loop over tracks  
 	  //int t_counter = 0;
-	  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs_;
+	  const ConstTrajTrackPairCollection &tracks = eventInfo.trajTrackPairs();
 	  for( ConstTrajTrackPairCollection::const_iterator it=tracks.begin();
 	       it!=tracks.end();it++) {
 


### PR DESCRIPTION
The bug corrupts the IOV-dependent alignment in releases compiled with
slc6_amd64_gcc472 and later. It is caused by using a dangling reference to
an edm::EventID object to determine the run number. At least with the gcc
versions in SLC6, this results in an incorrect determination of the current
IOV. Details are given in this presentation at the tracker-alignment meeting:

https://indico.cern.ch/event/342234/session/0/contribution/8/0/material/slides/0.pdf

The implementation is the outcome of a discussion of #6515 .

This PR supersedes #6517  .
