### PR TITLE
Find indirect data members

### DIFF
--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -7,7 +7,7 @@
 
 namespace edm {
 
-  MemberWithDict::MemberWithDict() : dataMember_() {
+  MemberWithDict::MemberWithDict() : dataMember_(nullptr) {
   }
 
   MemberWithDict::MemberWithDict(TDataMember* dataMember) : dataMember_(dataMember) {

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -16,6 +16,7 @@
 #include "TEnumConstant.h"
 #include "TInterpreter.h"
 #include "TMethodArg.h"
+#include "TRealData.h"
 #include "TROOT.h"
 
 #include "boost/thread/tss.hpp"
@@ -535,7 +536,15 @@ namespace edm {
   MemberWithDict
   TypeWithDict::dataMemberByName(std::string const& member) const {
     if (class_ != nullptr) {
-      return MemberWithDict(class_->GetDataMember(member.c_str()));
+      TDataMember* dataMember = class_->GetDataMember(member.c_str());
+      if(dataMember == nullptr) {
+        // Look for indirect data members
+        TRealData* realDataMember = class_->GetRealData(member.c_str());
+        if(realDataMember != nullptr) {
+          dataMember = realDataMember->GetDataMember();
+        }
+      }
+      return MemberWithDict(dataMember);
     }
     if (enum_ != nullptr) {
       TClass* cl = enum_->GetClass();


### PR DESCRIPTION
This pull request fixes the testNamedReference unit test in CondCore/ORA.  The problem was that TypeWithDict::dataMemberByName(name) would find only direct data members of a class.
This function was enhanced to also find indirect data members.
Also, I noticed that the default ctor of MemberWithDict() did not explicitly initialize its data member, a pointer.  So this request also explicitly initializes the pointer.

Please merge as soon as convenient.
