### PR TITLE
removed lumi producer from HI reco

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -110,7 +110,10 @@ def customisePromptHI(process):
 
     import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
     process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
-    
+
+     #add the lumi producer in the prompt reco only configuration
+    process.reconstruction_step+=process.lumiProducer
+
     return process
 
 ##############################################################################

--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -23,8 +23,6 @@ from RecoLocalCalo.CastorReco.CastorSimpleReconstructor_cfi import *
 # Muons
 from RecoLocalMuon.Configuration.RecoLocalMuon_cff import *
 
-from RecoLuminosity.LumiProducer.lumiProducer_cff import *
-
 #--------------------------------------------------------------------------
 # HIGH LEVEL RECO
 
@@ -38,7 +36,7 @@ from RecoHI.HiEgammaAlgos.HiElectronSequence_cff import *
 caloReco = cms.Sequence(ecalLocalRecoSequence*hcalLocalRecoSequence)
 hbhereco = hbheprereco.clone()
 hcalLocalRecoSequence.replace(hbheprereco,hbhereco)
-muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEvent+siPixelClusterShapeCache+muonlocalreco+lumiProducer)
+muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEvent+siPixelClusterShapeCache+muonlocalreco)
 localReco = cms.Sequence(offlineBeamSpot*muonReco*caloReco*castorreco)
 
 #hbherecoMB = hbheprerecoMB.clone()

--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -30,7 +30,7 @@ from RecoHI.Configuration.Reconstruction_HI_cff import *
 from RecoHI.Configuration.Reconstruction_hiPF_cff import *
 from RecoLocalCalo.Castor.Castor_cff import *
 from RecoHI.HiEgammaAlgos.HiElectronSequence_cff import *
-
+from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 #--------------------------------------------------------------------------
 
 caloReco = cms.Sequence(ecalLocalRecoSequence*hcalLocalRecoSequence)


### PR DESCRIPTION
The lumi producer appears to have been removed from the pp reconstruction since 42X, but this change was never propagated to HI reco.
Now it appears to be causing a crash, at least at one site, and we were advised on the luminosity hypernews to remove it:
https://hypernews.cern.ch/HyperNews/CMS/get/luminosity/440/1.html
