### PR TITLE
fix in PFJetID calculation due to change in PFJet fraction calculation

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
+++ b/PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h
@@ -203,7 +203,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
     if ( patJet != 0 ) {
       if ( patJet->isPFJet() ) {
 	chf = patJet->chargedHadronEnergyFraction();
-	nhf = ( patJet->neutralHadronEnergy() + patJet->HFHadronEnergy() ) / patJet->energy();
+	nhf = patJet->neutralHadronEnergyFraction();
 	cef = patJet->chargedEmEnergyFraction();
 	nef = patJet->neutralEmEnergyFraction();
 	nch = patJet->chargedMultiplicity();
@@ -224,7 +224,7 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
 	      isub != iend; ++isub ) {
 	  reco::PFJet const * pfsub = dynamic_cast<reco::PFJet const *>( &*isub );
 	  e_chf += pfsub->chargedHadronEnergy();
-	  e_nhf += (pfsub->neutralHadronEnergy() + pfsub->HFHadronEnergy());
+	  e_nhf += pfsub->neutralHadronEnergy();
 	  e_cef += pfsub->chargedEmEnergy();
 	  e_nef += pfsub->neutralEmEnergy();
 	  nch += pfsub->chargedMultiplicity();
@@ -249,11 +249,10 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
        + pfJet->photonEnergy()
        + pfJet->electronEnergy()
        + pfJet->muonEnergy()
-       + pfJet->HFHadronEnergy()
        + pfJet->HFEMEnergy();
       if ( jetEnergyUncorrected > 0. ) {
 	chf = pfJet->chargedHadronEnergy() / jetEnergyUncorrected;
-        nhf = ( pfJet->neutralHadronEnergy() + pfJet->HFHadronEnergy() ) / jetEnergyUncorrected;
+        nhf = pfJet->neutralHadronEnergy() / jetEnergyUncorrected;
         cef = pfJet->chargedEmEnergy() / jetEnergyUncorrected;
         nef = pfJet->neutralEmEnergy() / jetEnergyUncorrected;
       }
@@ -269,13 +268,12 @@ class PFJetIDSelectionFunctor : public Selector<pat::Jet>  {
       double e_nef = 0.0;
       nch = 0;
       nconstituents = 0;
-
       for ( reco::Jet::const_iterator ibegin = basicJet->begin(),
 	      iend = patJet->end(), isub = ibegin;
 	    isub != iend; ++isub ) {
 	reco::PFJet const * pfsub = dynamic_cast<reco::PFJet const *>( &*isub );
 	e_chf += pfsub->chargedHadronEnergy();
-	e_nhf += (pfsub->neutralHadronEnergy() + pfsub->HFHadronEnergy());
+	e_nhf += pfsub->neutralHadronEnergy();
 	e_cef += pfsub->chargedEmEnergy();
 	e_nef += pfsub->neutralEmEnergy();
 	nch += pfsub->chargedMultiplicity();


### PR DESCRIPTION
In 7_3_0_pre1 the PFJet Fractions changed, from then on the NeutralHadronEnergy is the sum of the former NeutralHadronEnergy+HFHadronEnergy; same holds for the NeutralHadronEnergyFraction.

The PFJetIDSelectionFunctor has been now updated to accomodate this feature. The effects are especially prominent if we compare MiniAOD with RECO, since the calculation of the PFJetID is done in slightly different ways, more details can be found in 
https://indico.cern.ch/event/294180/contribution/4/material/slides/0.pdf

slide 9 before the fix.
slide 11 illustrates the feature 
slide 12 shows the expected agreement between RECO and MiniAOD formats, and the expected increase of the passFraction for forward Jets.
