### PR TITLE
Remove obsolete assert

### DIFF
--- a/CondCore/ORA/test/testORAIO.cc
+++ b/CondCore/ORA/test/testORAIO.cc
@@ -104,7 +104,6 @@ namespace ora {
 }
 
 int main(int argc, char** argv){
-  assert(0);  // Temporarily fail deliberately, as this test hogs memory.
   ora::TestORAIO test;
   test.run();
 }


### PR DESCRIPTION
A fatal assert was previously deliberately added to a unit test because the unit test hoarded memory to exhaustion.
The fix for the underlying problem has now been merged (PR #6739), so the assert can be removed.

Please merge this trivial pull request as soon as convenient.
