### PR TITLE
combine all test plugins in to one

### DIFF
--- a/OnlineDB/CSCCondDB/test/BuildFile.xml
+++ b/OnlineDB/CSCCondDB/test/BuildFile.xml
@@ -4,21 +4,6 @@
 <use   name="CondFormats/CSCObjects"/>
 <use   name="CondCore/DBCommon"/>
 <use   name="OnlineDB/Oracle"/>
-<lib   name="occi"/>
-<lib   name="Minuit2"/>
-<flags   EDM_PLUGIN="1"/>
-<library   name="CSCChamberIndexPopConAnalyzer" file="../src/CSCMap1.cc,stubs/CSCChamberIndexHandler.cc,stubs/CSCChamberIndexPopConAnalyzer.cc">
-  <flags   EDM_PLUGIN="1"/>
-</library>
-<library   name="CSCChamberMapPopConAnalyzer" file="../src/CSCMap1.cc,stubs/CSCChamberMapHandler.cc,stubs/CSCChamberMapPopConAnalyzer.cc">
-  <flags   EDM_PLUGIN="1"/>
-</library>
-<library   name="CSCCrateMapPopConAnalyzer" file="../src/CSCMap1.cc,stubs/CSCCrateMapHandler.cc,stubs/CSCCrateMapPopConAnalyzer.cc">
-  <flags   EDM_PLUGIN="1"/>
-</library>
-<library   name="CSCDDUMapPopConAnalyzer" file="../src/CSCMap1.cc,stubs/CSCDDUMapHandler.cc,stubs/CSCDDUMapPopConAnalyzer.cc">
-  <flags   EDM_PLUGIN="1"/>
-</library>
-<library   name="CSCChamberTimeCorrectionsPopConAnalyzer" file="../src/CSCCableRead.cc,stubs/CSCChamberTimeCorrectionsHandler.cc,stubs/CSCChamberTimeCorrectionsPopConAnalyzer.cc">
+<library   name="OnlineDBCSCCondDB_TestPlugins" file="../src/CSCMap1.cc,../src/CSCCableRead.cc,stubs/*.cc">
   <flags   EDM_PLUGIN="1"/>
 </library>


### PR DESCRIPTION
Do we need all these separate plugins or can live with one?
One problem here is that each of these plugins use ../src/CSCMap1.cc file and generate 
tmp_path/pluginnameX/../src/CSCMap1.o
so basically the output object file for all these are same which can cause problem while compiler with -j n.

If having separate plugins is required then we can do something like
`<library name="CSCMap1" file="../src/CSCMap1.cc"/>`

and then link it in each plugin but I would prefer to have one plugin.
