### PR TITLE
Fix of VertexFromTrackProducer module

### DIFF
--- a/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
+++ b/RecoTauTag/HLTProducers/interface/VertexFromTrackProducer.h
@@ -49,8 +49,6 @@ public:
   virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
 private:
-  // access to config
-  const edm::ParameterSet& config() const { return theConfig; }
   // tokens
   const edm::EDGetTokenT<edm::View<reco::Track> > trackToken;
   const edm::EDGetTokenT<edm::View<reco::RecoCandidate> > candidateToken;
@@ -64,6 +62,5 @@ private:
   const bool fUseBeamSpot;
   const bool fUseVertex;
   const bool fUseTriggerFilterElectrons, fUseTriggerFilterMuons;
-  const edm::ParameterSet theConfig;
   const bool fVerbose;
 };

--- a/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
+++ b/RecoTauTag/HLTProducers/src/VertexFromTrackProducer.cc
@@ -36,7 +36,6 @@ VertexFromTrackProducer::VertexFromTrackProducer(const edm::ParameterSet& conf) 
   fUseVertex( conf.getParameter<bool>("useVertex") ),
   fUseTriggerFilterElectrons( conf.getParameter<bool>("useTriggerFilterElectrons") ),
   fUseTriggerFilterMuons( conf.getParameter<bool>("useTriggerFilterMuons") ),
-  theConfig( conf ),
   fVerbose( conf.getUntrackedParameter<bool>("verbose", false) )
 {
   edm::LogInfo("PVDebugInfo") 


### PR DESCRIPTION
This is a small fix to VertexFromTrackProducer module used at HLT, namely an unused data member and corresponiding getter are removed.
