### PR TITLE
switch CCC on in Conversion Pattern recognition

### DIFF
--- a/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
+++ b/RecoTracker/ConversionSeedGenerators/python/ConversionStep_cff.py
@@ -223,7 +223,7 @@ convStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorESPro
     ComponentName = cms.string('convStepChi2Est'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(30.0),
-    minGoodStripCharge = cms.double(-2069.)
+    minGoodStripCharge = cms.double(2069.)
 )
 
 


### PR DESCRIPTION
 switch CCC on in Conversion Pattern recognition
For consistency with all other steps including Conversion Seeding itself.
At 50ns (Run2012C) the number of conversion candidates increases.
the regression becomes very small at electron/photon level

It was kept out of #5853 to disentangle technical changes from behavior modification
