### PR TITLE
Modify test so it is OK if class already loaded (rootmap)

### DIFF
--- a/FWCore/FWLite/test/autoload_with_missing_std.C
+++ b/FWCore/FWLite/test/autoload_with_missing_std.C
@@ -3,7 +3,7 @@
 // edmtest is unknown at this point
 //if( TClass::GetClass("vector<edmtest::Thing>") ) {
 //   cout <<"class already exists!"<<endl;
-//   exit(1);
+//   exit(0);
 //}
 //cout <<"class not present yet"<<endl;
 gSystem->Load("libFWCoreFWLite");

--- a/FWCore/FWLite/test/autoload_with_namespace.C
+++ b/FWCore/FWLite/test/autoload_with_namespace.C
@@ -1,7 +1,7 @@
 {
 if( TClass::GetClass("edmtest::Thing") ) {
    cout <<"class already exists!"<<endl;
-   exit(1);
+   exit(0);
 }
 cout <<"class not present yet"<<endl;
 

--- a/FWCore/FWLite/test/autoload_with_std.C
+++ b/FWCore/FWLite/test/autoload_with_std.C
@@ -3,7 +3,7 @@
 // edmtest is unknown at this point
 //if( TClass::GetClass("std::vector<edmtest::Thing>") ) {
 //   cout <<"class already exists!"<<endl;
-//   exit(1);
+//   exit(0);
 //}
 //cout <<"class not present yet"<<endl;
 gSystem->Load("libFWCoreFWLite");


### PR DESCRIPTION
A FWCore/FWLite unit test fails because, in a test of the loader, the test fails if the class is already loaded before the loader is invoked.  Since the introduction of rootmap files in CMS, it is expected that the class will already be loaded.  So this pull request simply modifies the test to return success in this case.
This test still has utility in ROOT 6 because it will still fail if the class is not loaded, so it serves as a test of the functionality of rootmap files.
Please merge this pull request as soon as convenient.
