### PR TITLE
Adapt to PyROOT change

### DIFF
--- a/DataFormats/FWLite/python/__init__.py
+++ b/DataFormats/FWLite/python/__init__.py
@@ -71,7 +71,7 @@ class Handle:
             print "Not deleting wrapper"
             del kwargs['noDelete']
         else:
-            self._wrapper.IsA().Destructor( self._wrapper )
+             ROOT.TClass.GetClass("edm::Wrapper<"+self._type+">").Destructor( self._wrapper )
         # Since we deleted the options as we used them, that means
         # that kwargs should be empty.  If it's not, that means that
         # somebody passed in an argument that we're not using and we


### PR DESCRIPTION
A change to PyROOT between ROOT5 and ROOT6 is causing a unit test failure in package DataFormats/FWLite.
This fixes the observed failure, but the test still will fail later for a different reason.

Please merge this request as soon as convenient.
