### PR TITLE
Remove link dependencies obsolete in ROOT 6

### DIFF
--- a/CommonTools/PileupAlgos/BuildFile.xml
+++ b/CommonTools/PileupAlgos/BuildFile.xml
@@ -2,7 +2,6 @@
 <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
 <use   name="rootcore"/>
 <use   name="fastjet"/>
 <export>

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags   GENREFLEX_ARGS="--"/>
-<use   name="rootrflx"/>
 <use   name="CondCore/CondDB"/>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>

--- a/CondFormats/MFObjects/BuildFile.xml
+++ b/CondFormats/MFObjects/BuildFile.xml
@@ -4,7 +4,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CondCore/DBCommon"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DQM/Integration/BuildFile.xml
+++ b/DQM/Integration/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="RelationalAccess"/>
-<use   name="rootrflx"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DQMServices/StreamerIO/BuildFile.xml
+++ b/DQMServices/StreamerIO/BuildFile.xml
@@ -14,7 +14,6 @@
 <use   name="Utilities/StorageFactory"/>
 <use   name="HLTrigger/HLTanalyzers"/>
 <use   name="boost"/>
-<use   name="rootcintex"/>
 <use   name="rootcore"/>
 <use   name="zlib"/>
 

--- a/DataFormats/L1TCalorimeter/BuildFile.xml
+++ b/DataFormats/L1TCalorimeter/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1Trigger"/>
-<use   name="rootrflx"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1TGlobal/BuildFile.xml
+++ b/DataFormats/L1TGlobal/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1Trigger"/>
-<use   name="rootrflx"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/Phase2TrackerDigi/BuildFile.xml
+++ b/DataFormats/Phase2TrackerDigi/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FWCore/Skeletons/scripts/mkTemplates/DataPkg/BuildFile.xml
+++ b/FWCore/Skeletons/scripts/mkTemplates/DataPkg/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/Common"/>
-<use name="rootrflx"/>
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
+++ b/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
@@ -1,7 +1,5 @@
 <use name=DataFormats/Common>
-<use name=rootrflx>
 <export>
   <lib name=__subsys__xxxEventHypothesis>
   <use name=DataFormats/Common>
-  <use name=rootrflx>
 </export>

--- a/GeneratorInterface/Hydjet2Interface/BuildFile.xml
+++ b/GeneratorInterface/Hydjet2Interface/BuildFile.xml
@@ -19,7 +19,6 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="root"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
 <use   name="rootcore"/>
 <export> 
   <lib   name="1"/>

--- a/PhysicsTools/Heppy/BuildFile.xml
+++ b/PhysicsTools/Heppy/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="root"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
-<use name="rootrflx"/>
 <use name="rootpy"/>
 <use name="clhepheader"/>
 <use name="DataFormats/Candidate"/>

--- a/PhysicsTools/HeppyCore/BuildFile.xml
+++ b/PhysicsTools/HeppyCore/BuildFile.xml
@@ -1,7 +1,6 @@
 <use name="root"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
-<use name="rootrflx"/>
 <use name="rootpy"/>
 <export>
 <lib name="1"/>

--- a/RecoEgamma/ElectronIdentification/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="MagneticField/Engine"/>
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="PhysicsTools/SelectorUtils"/>
-<use name="rootrflx"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoTauTag/ImpactParameter/plugins/BuildFile.xml
+++ b/RecoTauTag/ImpactParameter/plugins/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/BTauReco"/>
 <use   name="DataFormats/VertexReco"/>
-<use   name="rootrflx"/>
 <use   name="DataFormats/Math"/>
 <use   name="boost"/>
 <use   name="root"/>

--- a/RecoTracker/MeasurementDet/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/BuildFile.xml
@@ -23,4 +23,3 @@
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>
 <use   name="RecoTracker/TkDetLayers"/>
-<use   name="rootrflx"/>


### PR DESCRIPTION
Remove link depedencies on "rootrflx" and "rootcintex" from build files.  These are obsolete in ROOT6.
such dependencies were removed a long time ago, but these few have crept back in due to merges.
Please merge this request as soon as convenient.
