### PR TITLE
fix for icc compiler: added the missing pat:: namespace

### DIFF
--- a/DataFormats/PatCandidates/interface/Jet.h
+++ b/DataFormats/PatCandidates/interface/Jet.h
@@ -479,7 +479,7 @@ namespace pat {
       }
 
       /// pipe operator (introduced to use pat::Jet with PFTopProjectors)
-      friend std::ostream& reco::operator<<(std::ostream& out, const Jet& obj);
+      friend std::ostream& reco::operator<<(std::ostream& out, const pat::Jet& obj);
 
     protected:
 

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -235,7 +235,7 @@ namespace pat {
       double segmentCompatibility(reco::Muon::ArbitrationType arbitrationType = reco::Muon::SegmentAndTrackArbitration) const ;
 
       /// pipe operator (introduced to use pat::Muon with PFTopProjectors)
-      friend std::ostream& reco::operator<<(std::ostream& out, const Muon& obj);
+      friend std::ostream& reco::operator<<(std::ostream& out, const pat::Muon& obj);
 
       friend class PATMuonSlimmer;
 


### PR DESCRIPTION
This should fix the following compilation errors for ICC builds
`DataFormats/PatCandidates/interface/Jet.h(482): error: no instance of overloaded function "reco::operator<<" matches the specified type
        friend std::ostream& reco::operator<<(std::ostream& out, const Jet& obj);`
`DataFormats/PatCandidates/interface/Muon.h(238): error: no instance of overloaded function "reco::operator<<" matches the specified type
        friend std::ostream& reco::operator<<(std::ostream& out, const Muon& obj);`
