### PR TITLE
postLs1 custom miniaod

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1206,6 +1206,7 @@ steps['COPYPASTE']={'-s':'NONE',
 #miniaod
 stepMiniAODDefaults = { '-s'              : 'PAT',
                         '--runUnscheduled': '',
+                        '--customise'     : 'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1',
                         '-n'              : '100'
                         }
 stepMiniAODData = merge([{'--conditions'   : 'auto:run1_data',


### PR DESCRIPTION
- include the postLs1 customize in the miniaod - across the board, both Dat and MC
- https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3288.html
