### PR TITLE
Properly handle case where default number of threads requested

### DIFF
--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -19,7 +19,7 @@
   <use   name="FWCore/Framework"/>
   <use   name="FWCore/ParameterSet"/>
 </library>
-<library   file="stubs/TestTBBTasksAnalyzer.cc" name="TestTBBTasksAnalyzer">
+<library   file="stubs/TestTBBTasksAnalyzer.cc,stubs/TestNThreadsChecker.cc" name="TestTBBTasksAnalyzer">
   <flags   EDM_PLUGIN="1"/>
   <use   name="tbb"/>
   <use   name="DataFormats/Common"/>

--- a/FWCore/Framework/test/run_tbbTasks.sh
+++ b/FWCore/Framework/test/run_tbbTasks.sh
@@ -6,9 +6,10 @@ function die { echo $1: status $2 ;  exit $2; }
 F1=${LOCAL_TEST_DIR}/test_tbb_threads_cfg.py
 F2="-n 8 ${LOCAL_TEST_DIR}/test_tbb_threads_from_commandline_cfg.py"
 F3="--numThreads 8 ${LOCAL_TEST_DIR}/test_tbb_threads_from_commandline_cfg.py"
+F4=${LOCAL_TEST_DIR}/test_tbb_default_threads_cfg.py
 
 (cmsRun $F1 ) || die "Failure using cmsRun $F1" $?
 (cmsRun $F2 ) || die "Failure using cmsRun $F2" $?
 (cmsRun $F3 ) || die "Failure using cmsRun $F3" $?
-
+(cmsRun $F4 ) || die "Failure using cmsRun $F4" $?
 

--- a/FWCore/Framework/test/stubs/TestNThreadsChecker.cc
+++ b/FWCore/Framework/test/stubs/TestNThreadsChecker.cc
@@ -1,0 +1,76 @@
+// -*- C++ -*-
+//
+// Package:    Framework
+// Class:      TestNThreadsChecker
+// 
+/**\class TestNThreadsChecker TestNThreadsChecker.cc FWCore/Framework/test/stubs/TestNThreadsChecker.cc
+
+ Description: <one line class summary>
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Thu Jan 03 11:02:00 EST 2013
+//
+//
+
+
+// system include files
+#include <memory>
+#include <atomic>
+#include <unistd.h>
+#include "tbb/task_scheduler_init.h"
+
+// user include files
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+#include "FWCore/ServiceRegistry/interface/SystemBounds.h"
+
+#include "FWCore/Utilities/interface/Exception.h"
+
+//
+// class decleration
+//
+
+class TestNThreadsChecker {
+public:
+  explicit TestNThreadsChecker(const edm::ParameterSet&, edm::ActivityRegistry& );
+
+private:
+
+      // ----------member data ---------------------------
+  unsigned int m_nExpectedThreads;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+TestNThreadsChecker::TestNThreadsChecker(const edm::ParameterSet& iConfig, edm::ActivityRegistry& iReg) :
+m_nExpectedThreads(iConfig.getUntrackedParameter<unsigned int>("nExpectedThreads"))
+{
+   unsigned int expectedThreads =m_nExpectedThreads;
+   if(expectedThreads == 0 ) {
+      expectedThreads =tbb::task_scheduler_init::default_num_threads();
+   }
+   
+   //now do what ever initialization is needed
+   iReg.watchPreallocate([expectedThreads](edm::service::SystemBounds const& iBounds) {
+      if(expectedThreads != iBounds.maxNumberOfThreads()) {
+         throw cms::Exception("UnexpectedNumberOfThreads")<<"Expected "<<expectedThreads<<" threads but actual value is "<<iBounds.maxNumberOfThreads();
+      }
+   });
+}
+
+//define this as a plug-in
+DEFINE_FWK_SERVICE(TestNThreadsChecker);

--- a/FWCore/Framework/test/test_tbb_default_threads_cfg.py
+++ b/FWCore/Framework/test/test_tbb_default_threads_cfg.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("LONGTEST")
+
+process.source = cms.Source("EmptySource")
+
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+
+process.options = cms.untracked.PSet( numberOfThreads = cms.untracked.uint32(0))
+
+process.add_(cms.Service("TestNThreadsChecker", nExpectedThreads=cms.untracked.uint32(0)))

--- a/FWCore/Framework/test/test_tbb_threads_cfg.py
+++ b/FWCore/Framework/test/test_tbb_threads_cfg.py
@@ -13,3 +13,5 @@ process.tester = cms.EDAnalyzer("TestTBBTasksAnalyzer",
                                 nExpectedThreads = cms.untracked.uint32(8),
                                 usecondsToSleep=cms.untracked.uint32(100000))
 process.p = cms.Path(process.tester)
+
+process.add_(cms.Service("TestNThreadsChecker", nExpectedThreads=cms.untracked.uint32(8)))

--- a/FWCore/Framework/test/test_tbb_threads_from_commandline_cfg.py
+++ b/FWCore/Framework/test/test_tbb_threads_from_commandline_cfg.py
@@ -11,3 +11,5 @@ process.tester = cms.EDAnalyzer("TestTBBTasksAnalyzer",
                                 nExpectedThreads = cms.untracked.uint32(8),
                                 usecondsToSleep=cms.untracked.uint32(100000))
 process.p = cms.Path(process.tester)
+
+process.add_(cms.Service("TestNThreadsChecker", nExpectedThreads=cms.untracked.uint32(8)))


### PR DESCRIPTION
If a user requests the default number of threads by specifying '0' as the threads number, be sure to propagate the actual number of threads chosen by TBB to the rest of the system.
