### PR TITLE
turn on pat in unscheduled, remove miniaod products coming into the aod

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -935,8 +935,9 @@ step3Up2015Hal = {'-s'            :'RAW2DIGI,L1Reco,RECO,EI,VALIDATION,DQM',
                  '--customise'    :'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1'
                  }
 
-step3Up2015DefaultsUnsch = merge([{'--runUnscheduled':''},step3Up2015Defaults])
-step3DefaultsUnsch = merge([{'--runUnscheduled':''},step3Defaults])
+unSchOverrides={'--runUnscheduled':'','-s':'RAW2DIGI,L1Reco,RECO,EI,PAT,VALIDATION,DQM','--eventcontent':'RECOSIM,MINIAODSIM,DQM','--datatier':'GEN-SIM-RECO,MINIAODSIM,DQMIO'}
+step3Up2015DefaultsUnsch = merge([unSchOverrides,step3Up2015Defaults])
+step3DefaultsUnsch = merge([unSchOverrides,step3Defaults])
 
                              
 steps['RECOUP15']=merge([step3Up2015Defaults]) # todo: remove UP from label

--- a/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
+++ b/RecoEgamma/Configuration/python/RecoEgamma_EventContent_cff.py
@@ -13,7 +13,7 @@ RecoEgammaFEVT = cms.PSet(
         'keep *_eidLoose_*_*',
         'keep *_eidTight_*_*',
         'keep *_egmGedGsfElectronPF*Isolation_*_*',
-        'keep *_egmGsfElectronIDs_*_*',
+        'keep *_egmGsfElectronIDs_*_*', 
         'keep *_conversions_*_*',
         'keep *_mustacheConversions_*_*',
         'drop *_conversions_uncleanedConversions_*',
@@ -104,7 +104,7 @@ RecoEgammaAOD = cms.PSet(
         'keep floatedmValueMap_eidLoose_*_*',
         'keep floatedmValueMap_eidTight_*_*',
         'keep *_egmGedGsfElectronPFIsolation_*_*',
-        'keep *_egmGsfElectronIDs_*_*',
+#        'keep *_egmGsfElectronIDs_*_*', #these are in the miniAOD
         'keep recoPhotonCores_gedPhotonCore_*_*',
         'keep recoPhotons_gedPhotons_*_*',
         'keep *_particleBasedIsolation_*_*',


### PR DESCRIPTION
reco+pat work together now (at least well enough for testing). Adding this to the unscheduled workflows. 

Along the way , noticed some miniAOD products that were added to AOD -I removed these for consistency.
