### PR TITLE
Renamed pfJetsEI to ak4PFJetsCHSEI

### DIFF
--- a/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
@@ -8,7 +8,7 @@ EITopPAGEventContent = cms.PSet(
     'keep *_pfIsolatedElectronsEI_*_*',
     'keep *_pfIsolatedMuonsEI_*_*',
     # jets
-    'keep recoPFJets_pfJetsEI_*_*',
+    'keep recoPFJets_ak4PFJetsCHSEI_*_*',
     # btags
     'keep *_pfJetTrackAssociatorEI_*_*',
     'keep *_impactParameterTagInfosEI_*_*',

--- a/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_EventContent_cff.py
@@ -10,7 +10,7 @@ EITopPAGEventContent = cms.PSet(
     # jets
     'keep recoPFJets_ak4PFJetsCHSEI_*_*',
     # btags
-    'keep *_pfJetTrackAssociatorEI_*_*',
+    'keep *_ak4JetTracksAssociatorAtVertexPFEI_*_*',
     'keep *_impactParameterTagInfosEI_*_*',
     'keep *_secondaryVertexTagInfosEI_*_*',
     'keep *_combinedSecondaryVertexBJetTagsEI_*_*',

--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -17,7 +17,7 @@ from CommonTools.ParticleFlow.TopProjectors.pfNoTau_cfi import *
 
 
 # b-tagging
-from RecoJets.JetAssociationProducers.ak4JTA_cff import ak4JetTracksAssociatorAtVertex
+from RecoJets.JetAssociationProducers.ak4JTA_cff import ak4JetTracksAssociatorAtVertexPF
 from RecoBTag.ImpactParameter.impactParameterTagInfos_cfi import impactParameterTagInfos
 from RecoBTag.SecondaryVertex.secondaryVertexTagInfos_cfi import secondaryVertexTagInfos
 from RecoBTag.SecondaryVertex.combinedSecondaryVertexBJetTags_cfi import combinedSecondaryVertexBJetTags
@@ -108,13 +108,13 @@ pfNoElectronJME.bottomCollection = 'pfNoMuonJME'
 
 #### Jets ####
 
-ak4PFJetsCHSEI = pfJets.clone()
-pfJetsPtrsEI = pfJetsPtrs.clone(src=cms.InputTag("ak4PFJetsCHSEI"))
+ak4PFJetsCHSEI = jetAlgo('AK4')
+ak4PFJetsCHSEIPtrs = pfJetsPtrs.clone(src=cms.InputTag("ak4PFJetsCHSEI"))
 
-pfJetSequenceEI = cms.Sequence( ak4PFJetsCHSEI+ pfJetsPtrsEI )
+ak4PFJetsCHSEISequence = cms.Sequence( ak4PFJetsCHSEI + ak4PFJetsCHSEIPtrs )
 
 pfNoJetEI = pfNoJet.clone(
-    topCollection = 'pfJetsPtrsEI',
+    topCollection = 'ak4PFJetsCHSEIPtrs',
     bottomCollection = 'pfNoElectronJME'
     )
 
@@ -123,7 +123,7 @@ pfTausEI = pfTaus.clone()
 pfTausPtrsEI = pfTausPtrs.clone(src=cms.InputTag("pfTausEI") )
 pfNoTauEI = pfNoTau.clone(
     topCollection = cms.InputTag('pfTausPtrsEI'),
-    bottomCollection = cms.InputTag('pfJetsPtrsEI')
+    bottomCollection = cms.InputTag('ak4PFJetsCHSEIPtrs')
     )
 
 pfTauEISequence = cms.Sequence(
@@ -134,11 +134,11 @@ pfTauEISequence = cms.Sequence(
     )
 
 #### B-tagging ####
-pfJetTrackAssociatorEI = ak4JetTracksAssociatorAtVertex.clone (
+ak4JetTracksAssociatorAtVertexPFEI = ak4JetTracksAssociatorAtVertexPF.clone (
     src = cms.InputTag("ak4PFJetsCHSEI")
     )
 impactParameterTagInfosEI = impactParameterTagInfos.clone(
-    jetTracks = cms.InputTag( 'pfJetTrackAssociatorEI' )
+    jetTracks = cms.InputTag( 'ak4JetTracksAssociatorAtVertexPFEI' )
     )
 secondaryVertexTagInfosEI = secondaryVertexTagInfos.clone(
     trackIPTagInfos = cms.InputTag( 'impactParameterTagInfosEI' )
@@ -169,12 +169,12 @@ EIsequence = cms.Sequence(
     pfIsolatedElectronsEI +
     pfNoElectron +
     pfNoElectronJME +
-    pfJetSequenceEI +
+    ak4PFJetsCHSEISequence +
     pfNoJetEI +
     pfTauEISequence +
     pfNoTauEI +
     pfMetEI+
-    pfJetTrackAssociatorEI+
+    ak4JetTracksAssociatorAtVertexPFEI+
     impactParameterTagInfosEI+
     secondaryVertexTagInfosEI+
     combinedSecondaryVertexBJetTagsEI

--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -108,10 +108,10 @@ pfNoElectronJME.bottomCollection = 'pfNoMuonJME'
 
 #### Jets ####
 
-pfJetsEI = pfJets.clone()
-pfJetsPtrsEI = pfJetsPtrs.clone(src=cms.InputTag("pfJetsEI"))
+ak4PFJetsCHSEI = pfJets.clone()
+pfJetsPtrsEI = pfJetsPtrs.clone(src=cms.InputTag("ak4PFJetsCHSEI"))
 
-pfJetSequenceEI = cms.Sequence( pfJetsEI+ pfJetsPtrsEI )
+pfJetSequenceEI = cms.Sequence( ak4PFJetsCHSEI+ pfJetsPtrsEI )
 
 pfNoJetEI = pfNoJet.clone(
     topCollection = 'pfJetsPtrsEI',
@@ -135,7 +135,7 @@ pfTauEISequence = cms.Sequence(
 
 #### B-tagging ####
 pfJetTrackAssociatorEI = ak4JetTracksAssociatorAtVertex.clone (
-    src = cms.InputTag("pfJetsEI")
+    src = cms.InputTag("ak4PFJetsCHSEI")
     )
 impactParameterTagInfosEI = impactParameterTagInfos.clone(
     jetTracks = cms.InputTag( 'pfJetTrackAssociatorEI' )
@@ -151,7 +151,7 @@ combinedSecondaryVertexBJetTagsEI = combinedSecondaryVertexBJetTags.clone(
 
 
 #### MET ####
-pfMetEI = pfMET.clone(jets=cms.InputTag("pfJetsEI"))
+pfMetEI = pfMET.clone(jets=cms.InputTag("ak4PFJetsCHSEI"))
 
 #EITopPAG = cms.Sequence(
 EIsequence = cms.Sequence(

--- a/CommonTools/ParticleFlow/python/EITopPAG_cff.py
+++ b/CommonTools/ParticleFlow/python/EITopPAG_cff.py
@@ -135,7 +135,7 @@ pfTauEISequence = cms.Sequence(
 
 #### B-tagging ####
 ak4JetTracksAssociatorAtVertexPFEI = ak4JetTracksAssociatorAtVertexPF.clone (
-    src = cms.InputTag("ak4PFJetsCHSEI")
+    jets = cms.InputTag("ak4PFJetsCHSEI")
     )
 impactParameterTagInfosEI = impactParameterTagInfos.clone(
     jetTracks = cms.InputTag( 'ak4JetTracksAssociatorAtVertexPFEI' )

--- a/TopQuarkAnalysis/TopPairBSM/test/anaTrain_cfg.py
+++ b/TopQuarkAnalysis/TopPairBSM/test/anaTrain_cfg.py
@@ -305,7 +305,7 @@ addJetCollection(
 addJetCollection(
    process,
    labelName = 'EI',
-   jetSource = cms.InputTag('pfJetsEI'),
+   jetSource = cms.InputTag('ak4PFJetsCHSEI'),
    algo='ak',
    rParam=0.4,
    jetCorrections = ('AK5PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-1'),


### PR DESCRIPTION
Renamed `pfJetsEI` to `ak4PFJetsCHSEI` to make the collection name a bit more descriptive.

@deguio `pfJetsEI` also appears in https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_0_pre1/DQMServices/Components/test/FrameworkJobReport_9_a_2.xml but I wasn't sure what this file is used for and whether I should update it since `runTheMatrix.py -s --useInput all` had no failed tests
