### PR TITLE
set the error of cross section for Pythia8

### DIFF
--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -466,7 +466,9 @@ void Pythia8Hadronizer::statistics()
 
   double xsec = fMasterGen->info.sigmaGen(); // cross section in mb
   xsec *= 1.0e9; // translate to pb (CMS/Gen "convention" as of May 2009)
-  runInfo().setInternalXSec(xsec);
+  double err  = fMasterGen->info.sigmaErr(); // cross section err in mb
+  err  *= 1.0e9; // translate to pb (CMS/Gen "convention" as of May 2009)
+  runInfo().setInternalXSec(GenRunInfoProduct::XSec(xsec,err));
 }
 
 


### PR DESCRIPTION
Make sure the cross section uncertainty is properly filled for pure-pythia8 processes.
