### PR TITLE
Add subjets to softdrop

### DIFF
--- a/DQM/Physics/src/B2GDQM.cc
+++ b/DQM/Physics/src/B2GDQM.cc
@@ -382,7 +382,7 @@ void B2GDQM::analyzeJets(const Event& iEvent, const edm::EventSetup& iSetup) {
           }
 
           // For W-tagging, check the mass drop
-        } else if (jetLabels_[icoll].label() == "ak8PFJetsCHSPruned") {
+        } else if ((jetLabels_[icoll].label() == "ak8PFJetsCHSPruned")||(jetLabels_[icoll].label() == "ak8PFJetsCHSSoftdrop")) {
           if (jet->numberOfDaughters() > 1) {
             reco::Candidate const* da0 = jet->daughter(0);
             reco::Candidate const* da1 = jet->daughter(1);

--- a/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
+++ b/RecoJets/Configuration/python/RecoJets_EventContent_cff.py
@@ -63,7 +63,6 @@ RecoJetsRECO = cms.PSet(
                                            'keep *_ak4PFJetsCHS_*_*',
                                            'keep *_ak5PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHS_*_*',
-                                           'keep *_ak8PFJetsCHS_*_*',
                                            'keep *_ak8PFJetsCHSPruned_*_*',                                           
                                            'keep *_ak8PFJetsCHSSoftDrop_*_*',                                           
                                            'keep *_cmsTopTagPFJetsCHS_*_*',

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -117,22 +117,22 @@ ak8PFJetsCHS = ak5PFJetsCHS.clone(
 
 ak8PFJetsCHSPruned = ak5PFJetsCHSPruned.clone(
     rParam = 0.8,
-    jetPtMin = 15.0
+    jetPtMin = 100.0
     )
 
 ak8PFJetsCHSFiltered = ak5PFJetsCHSFiltered.clone(
     rParam = 0.8,
-    jetPtMin = 15.0
+    jetPtMin = 100.0
     )
 
 ak8PFJetsCHSTrimmed = ak5PFJetsCHSTrimmed.clone(
     rParam = 0.8,
-    jetPtMin = 15.0
+    jetPtMin = 100.0
     )
 
 ak8PFJetsCHSSoftDrop = ak5PFJetsCHSSoftDrop.clone(
     rParam = 0.8,
-    jetPtMin = 15.0
+    jetPtMin = 100.0
     )
 
 

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -117,22 +117,22 @@ ak8PFJetsCHS = ak5PFJetsCHS.clone(
 
 ak8PFJetsCHSPruned = ak5PFJetsCHSPruned.clone(
     rParam = 0.8,
-    jetPtMin = 100.0
+    jetPtMin = 15.0
     )
 
 ak8PFJetsCHSFiltered = ak5PFJetsCHSFiltered.clone(
     rParam = 0.8,
-    jetPtMin = 100.0
+    jetPtMin = 15.0
     )
 
 ak8PFJetsCHSTrimmed = ak5PFJetsCHSTrimmed.clone(
     rParam = 0.8,
-    jetPtMin = 100.0
+    jetPtMin = 15.0
     )
 
 ak8PFJetsCHSSoftDrop = ak5PFJetsCHSSoftDrop.clone(
     rParam = 0.8,
-    jetPtMin = 100.0
+    jetPtMin = 15.0
     )
 
 

--- a/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
@@ -9,5 +9,7 @@ ak4PFJetsSoftDrop = ak4PFJets.clone(
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
+    writeCompound = cms.bool(True),
+    jetCollInstanceName=cms.string("SubJets")
     )
 

--- a/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
@@ -8,7 +8,7 @@ ak4PFJetsSoftDrop = ak4PFJets.clone(
     useSoftDrop = cms.bool(True),
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
-    useExplicitGhosts = cms.bool(True)
+    useExplicitGhosts = cms.bool(True),
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")
     )

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -8,11 +8,7 @@ ak5PFJetsSoftDrop = ak5PFJets.clone(
     useSoftDrop = cms.bool(True),
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
-<<<<<<< HEAD
     useExplicitGhosts = cms.bool(True),
-=======
-    useExplicitGhosts = cms.bool(True)
->>>>>>> 1e04e02... add subjets to ak5 softdrop
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")
     )

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -8,7 +8,7 @@ ak5PFJetsSoftDrop = ak5PFJets.clone(
     useSoftDrop = cms.bool(True),
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
-    useExplicitGhosts = cms.bool(True)
+    useExplicitGhosts = cms.bool(True),
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")
     )

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -9,5 +9,7 @@ ak5PFJetsSoftDrop = ak5PFJets.clone(
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
     useExplicitGhosts = cms.bool(True)
+    writeCompound = cms.bool(True),
+    jetCollInstanceName=cms.string("SubJets")
     )
 

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -8,7 +8,11 @@ ak5PFJetsSoftDrop = ak5PFJets.clone(
     useSoftDrop = cms.bool(True),
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
+<<<<<<< HEAD
     useExplicitGhosts = cms.bool(True),
+=======
+    useExplicitGhosts = cms.bool(True)
+>>>>>>> 1e04e02... add subjets to ak5 softdrop
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")
     )


### PR DESCRIPTION
Followup of #6654.
In order to fully replace pruning, enable subjet calculation for softdrop algorithm.

Adaption of the jet collections and jet pT thresholds will come in a separate request after discussion.
