### PR TITLE
Fix of HLT path name in validation code

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -242,7 +242,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     ZnnHbb = cms.PSet( 
         hltPathsToCheck = cms.vstring(
             "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_BTagCSV0p7_v",
-            "HLT_PFMET110_PFMHT110_IDLoose_v",
+            "HLT_PFMET120_PFMHT120_IDLoose_v",
             "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_v"
             ),
         Jet_recCut   = cms.string("pt > 10 && abs(eta) < 2.6"),


### PR DESCRIPTION
The trigger HLT_PFMET110_PFMHT110_IDLoose_v1
has been changed in HLT_PFMET120_PFMHT120_IDLoose_v1.
(https://its.cern.ch/jira/browse/CMSHLT-186)

This PR fixes the new name in the validation code accordingly.

cc: @arizzi
