### PR TITLE
Add associateCluster method

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -76,6 +76,13 @@ class TrackerHitAssociator {
   void associateHitId(const TrackingRecHit & thit,std::vector<SimHitIdpr> &simhitid, std::vector<simhitAddr>* simhitCFPos=0) const;
   template<typename T>
     void associateSiStripRecHit(const T *simplerechit, std::vector<SimHitIdpr>& simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;
+
+  // Method for obtaining simTracks and simHits from a cluster
+  void associateCluster(const SiStripCluster* clust,
+			const DetId& detid,
+			std::vector<SimHitIdpr>& simtrackid, std::vector<PSimHit>& simhit) const;
+
+  // Obtain simTracks, and optionally simHit addresses, from a cluster 
   void associateSimpleRecHitCluster(const SiStripCluster* clust,
 				    const DetId& detid,
 				    std::vector<SimHitIdpr>& simtrackid, std::vector<simhitAddr>* simhitCFPos=0) const;

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -339,6 +339,32 @@ void TrackerHitAssociator::associateSiStripRecHit(const T *simplerechit, std::ve
   associateSimpleRecHitCluster(clust, simplerechit->geographicalId(), simtrackid, simhitCFPos);
 }
 
+//
+//  Method for obtaining simTracks and simHits from a cluster
+//
+void TrackerHitAssociator::associateCluster(const SiStripCluster* clust,
+					    const DetId& detid,
+					    std::vector<SimHitIdpr>& simtrackid,
+					    std::vector<PSimHit>& simhit) const {
+  std::vector<simhitAddr> simhitCFPos;
+  associateSimpleRecHitCluster(clust, detid, simtrackid, &simhitCFPos);
+
+  for(size_t i=0; i<simhitCFPos.size(); i++) {
+    simhitAddr theSimHitAddr = simhitCFPos[i];
+    simHitCollectionID theSimHitCollID = theSimHitAddr.first;
+    simhit_collectionMap::const_iterator it = SimHitCollMap.find(theSimHitCollID);
+    if (it!= SimHitCollMap.end()) {
+      unsigned int theSimHitIndex = theSimHitAddr.second;
+      if (theSimHitIndex < (it->second).size()) simhit.push_back((it->second)[theSimHitIndex]);
+      // const PSimHit& theSimHit = (it->second)[theSimHitIndex];
+      // std::cout << "For cluster, simHit detId =  " << theSimHit.detUnitId() << " address = (" << (theSimHitAddr.first).first
+      // 		<< ", " << (theSimHitAddr.first).second << ", " << theSimHitIndex
+      // 		<< "), process = " << theSimHit.processType() << " (" << theSimHit.eventId().bunchCrossing()
+      // 		<< ", " << theSimHit.eventId().event() << ", " << theSimHit.trackId() << ")" << std::endl;
+    }
+  }
+}
+
 void TrackerHitAssociator::associateSimpleRecHitCluster(const SiStripCluster* clust,
 							const DetId& detid,
 							std::vector<SimHitIdpr>& simtrackid,


### PR DESCRIPTION
This user method provides simTracks and simHits for a given strip or pixel cluster.  No affect on current production.
