### PR TITLE
Removed poor use of Ref classes in PFTracking and fixed getByToken problem

### DIFF
--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -73,15 +73,15 @@ class PFElecTkProducer final : public edm::stream::EDProducer<> {
       float minTangDist(const reco::GsfPFRecTrack& primGsf,
 			const reco::GsfPFRecTrack& secGsf); 
       
-      bool isSameEgSC(const reco::ElectronSeedRef& nSeedRef,
-		      const reco::ElectronSeedRef& iSeedRef,
+      bool isSameEgSC(const reco::ElectronSeed& nSeed,
+		      const reco::ElectronSeed& iSeed,
 		      bool& bothGsfEcalDriven,
 		      float& SCEnergy);
 
       bool isSharingEcalEnergyWithEgSC(const reco::GsfPFRecTrack& nGsfPFRecTrack,
 				       const reco::GsfPFRecTrack& iGsfPFRecTrack,
-				       const reco::ElectronSeedRef& nSeedRef,
-				       const reco::ElectronSeedRef& iSeedRef,
+				       const reco::ElectronSeed& nSeed,
+				       const reco::ElectronSeed& iSeed,
 				       const reco::PFClusterCollection& theEClus,
 				       bool& bothGsfTrackerDriven,
 				       bool& nEcalDriven,

--- a/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFTrackProducer.h
@@ -12,6 +12,8 @@
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
+#include <memory>
+#include <vector>
 
 /// \brief Abstract
 /*!
@@ -20,6 +22,7 @@
   PFTrackTransformer transforms all the tracks in the PFRecTracks.
   NOTE the PFRecTrack collection is transient.  
 */
+class Trajectory;
 
 
 class PFTrackTransformer;
@@ -28,10 +31,7 @@ public:
   
   ///Constructor
   explicit PFTrackProducer(const edm::ParameterSet&);
-  
-  ///Destructor
-  ~PFTrackProducer();
-  
+    
 private:
   virtual void beginRun(const edm::Run&,const edm::EventSetup&) override;
   virtual void endRun(const edm::Run&,const edm::EventSetup&) override;
@@ -40,8 +40,9 @@ private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
   
   ///PFTrackTransformer
-  PFTrackTransformer *pfTransformer_; 
+  std::unique_ptr<PFTrackTransformer> pfTransformer_; 
   std::vector<edm::EDGetTokenT<reco::TrackCollection> > tracksContainers_;
+  std::vector<edm::EDGetTokenT<std::vector<Trajectory>>> trajContainers_;
   edm::EDGetTokenT<reco::GsfTrackCollection> gsfTrackLabel_;  
   edm::EDGetTokenT<reco::MuonCollection> muonColl_;
   edm::EDGetTokenT<reco::VertexCollection> vtx_h;

--- a/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/PFTrackProducer.cc
@@ -21,34 +21,37 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 PFTrackProducer::PFTrackProducer(const ParameterSet& iConfig):
-  pfTransformer_(0)
+  pfTransformer_()
 {
   produces<reco::PFRecTrackCollection>();
   
   
   std::vector<InputTag> tags=iConfig.getParameter< vector < InputTag > >("TkColList");
-  for( unsigned int i=0;i<tags.size();++i)
-    tracksContainers_.push_back(consumes<reco::TrackCollection>(tags[i]));
+  trajinev_ = iConfig.getParameter<bool>("TrajInEvents");
+  tracksContainers_.reserve(tags.size());
+  if(trajinev_) { trajContainers_.reserve(tags.size()); }
+  for( auto const& tag: tags) {
+    tracksContainers_.push_back(consumes<reco::TrackCollection>(tag));
+    if(trajinev_) {
+      trajContainers_.push_back(consumes<std::vector<Trajectory> >(tag));
+    }
+  }
 
   useQuality_   = iConfig.getParameter<bool>("UseQuality");
   
-  gsfTrackLabel_ = consumes<reco::GsfTrackCollection>(iConfig.getParameter<InputTag>
-						      ("GsfTrackModuleLabel"));  
+  gsfinev_ = iConfig.getParameter<bool>("GsfTracksInEvents");
+  if(gsfinev_) {
+    gsfTrackLabel_ = consumes<reco::GsfTrackCollection>(iConfig.getParameter<InputTag>
+                                                        ("GsfTrackModuleLabel"));  
+  }
 
   trackQuality_=reco::TrackBase::qualityByName(iConfig.getParameter<std::string>("TrackQuality"));
   
   muonColl_ = consumes<reco::MuonCollection>(iConfig.getParameter< InputTag >("MuColl"));
   
-  trajinev_ = iConfig.getParameter<bool>("TrajInEvents");
   
-  gsfinev_ = iConfig.getParameter<bool>("GsfTracksInEvents");
   vtx_h=consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("PrimaryVertexLabel"));
   
-}
-
-PFTrackProducer::~PFTrackProducer()
-{
-  delete pfTransformer_;
 }
 
 void
@@ -61,8 +64,11 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   //read track collection
   Handle<GsfTrackCollection> gsftrackcoll;
-  bool foundgsf = iEvent.getByToken(gsfTrackLabel_,gsftrackcoll);
-  GsfTrackCollection gsftracks;
+  bool foundgsf = false;
+  if(gsfinev_) {
+    foundgsf = iEvent.getByToken(gsfTrackLabel_,gsftrackcoll);
+  }
+
   //Get PV for STIP calculation, if there is none then take the dummy  
   Handle<reco::VertexCollection> vertex;
   iEvent.getByToken(vtx_h, vertex);
@@ -86,16 +92,12 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
   iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder", builder);
   TransientTrackBuilder thebuilder = *(builder.product());
   
-  
-  if(gsfinev_) {
-    if(foundgsf )
-      gsftracks  = *(gsftrackcoll.product());
-  }  
-  
   // read muon collection
   Handle< reco::MuonCollection > recMuons;
   iEvent.getByToken(muonColl_, recMuons);
   
+  //default value for when trajinev_ is false
+  const vector<Trajectory> dummyTj(0);
   
   for (unsigned int istr=0; istr<tracksContainers_.size();istr++){
     
@@ -104,13 +106,14 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
     iEvent.getByToken(tracksContainers_[istr], tkRefCollection);
     reco::TrackCollection  Tk=*(tkRefCollection.product());
     
-    vector<Trajectory> Tj(0);
+    //Use a pointer to aoid unnecessary copying of the collection
+    const vector<Trajectory>* Tj = &dummyTj;
     if(trajinev_) {
       //Trajectory collection
       Handle<vector<Trajectory> > tjCollection;
-      iEvent.getByToken(tracksContainers_[istr], tjCollection);
+      iEvent.getByToken(trajContainers_[istr], tjCollection);
 	
-	Tj =*(tjCollection.product());
+      Tj =tjCollection.product();
     }
     
     
@@ -146,12 +149,16 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
       // find the pre-id kf track
       bool preId = false;
       if(foundgsf) {
-	for (unsigned int igsf=0; igsf<gsftracks.size();igsf++) {
-	  GsfTrackRef gsfTrackRef(gsftrackcoll, igsf);
-	  if (gsfTrackRef->seedRef().isNull()) continue;
-	  ElectronSeedRef ElSeedRef= gsfTrackRef->extra()->seedRef().castTo<ElectronSeedRef>();
-	  if (ElSeedRef->ctfTrack().isNonnull()) {
-	    if(ElSeedRef->ctfTrack() == trackRef) preId = true;
+        //NOTE: foundgsf is only true if gsftrackcoll is valid
+	for (auto const& gsfTrack: *gsftrackcoll) {
+	  if (gsfTrack.seedRef().isNull()) continue;
+          auto const& seed = *(gsfTrack.extra()->seedRef());
+          auto const& ElSeed = dynamic_cast<ElectronSeed const&>(seed);
+	  if (ElSeed.ctfTrack().isNonnull()) {
+	    if(ElSeed.ctfTrack() == trackRef) {
+              preId = true;
+              break;
+            }
 	  }
 	}
       }
@@ -163,7 +170,7 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	
 	bool valid = false;
 	if(trajinev_) {
-	  valid = pfTransformer_->addPoints( pftrack, *trackRef, Tj[i]);
+	  valid = pfTransformer_->addPoints( pftrack, *trackRef, (*Tj)[i]);
 	}
 	else {
 	  Trajectory FakeTraj;
@@ -190,7 +197,7 @@ PFTrackProducer::produce(Event& iEvent, const EventSetup& iSetup)
 				  i, trackRef );
 	bool valid = false;
 	if(trajinev_) {
-	  valid = pfTransformer_->addPoints( pftrack, *trackRef, Tj[i]);
+	  valid = pfTransformer_->addPoints( pftrack, *trackRef, (*Tj)[i]);
 	}
 	else {
 	  Trajectory FakeTraj;
@@ -223,7 +230,7 @@ PFTrackProducer::beginRun(const edm::Run& run,
 {
   ESHandle<MagneticField> magneticField;
   iSetup.get<IdealMagneticFieldRecord>().get(magneticField);
-  pfTransformer_= new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0,0,0))));
+  pfTransformer_.reset( new PFTrackTransformer(math::XYZVector(magneticField->inTesla(GlobalPoint(0,0,0)))) );
   if(!trajinev_)
     pfTransformer_->OnlyProp();
 }
@@ -232,6 +239,5 @@ PFTrackProducer::beginRun(const edm::Run& run,
 void 
 PFTrackProducer::endRun(const edm::Run& run,
 			const EventSetup& iSetup) {
-  delete pfTransformer_;
-  pfTransformer_=nullptr;
+  pfTransformer_.reset();
 }


### PR DESCRIPTION
There were a number of uses of RefToBase::castTo where a dynamic_cast would be more appropriate. 
A getByToken was using tokens obtained from a 'consumes' call for a different type. This was probably due to the fact that in the past two getByLabels for the different types were sharing the same InputTag. This was probably not seen since the product is only optionally obtained.

These changes are a prequel to internal framework changes which can affect castTo.
