### PR TITLE
HI paths added to muon HLT DQM

### DIFF
--- a/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
+++ b/DQMOffline/Trigger/python/HLTMuonOfflineAnalyzer_cfi.py
@@ -28,7 +28,17 @@ hltMuonOfflineAnalyzer = cms.EDAnalyzer("HLTMuonOfflineAnalyzer",
       "HLT_IsoMu27_IterTrk02_v",
       "HLT_IsoTkMu27_IterTrk02_v",
       "HLT_Mu27_v",
-      "HLT_TkMu27_v"
+      "HLT_TkMu27_v",
+      "HLT_HIL1DoubleMuOpen", #for HI
+      "HLT_HIL2Mu3", #for HI
+      "HLT_HIL2Mu7", #for HI
+      "HLT_HIL2Mu15", #for HI
+      "HLT_HIL2Mu3_NHitQ", #for HI
+      "HLT_HIL2DoubleMu0", #for HI
+      "HLT_HIL2DoubleMu0_NHitQ", #for HI
+      "HLT_HIL2DoubleMu3", #for HI
+      "HLT_HIL3Mu3", #for HI
+      "HLT_HIL3DoubleMuOpen" #for HI
     ),
 
 #HLT_Mu15_eta2p1_TriCentral_40_20_20_BTagIP3D1stTrack_v3 matches HLT_Mu15_eta2p1_v


### PR DESCRIPTION
The purpose of this PR is to update the list of HLT paths the muon HLT DQM takes as input. The extended list allows the monitoring of the Heavy Ion HLT muon paths. The possibility of extending this list was discussed with Hugues Brun several weeks ago. Checking the resulting HI DQM figures will be HI responsibility.
