### PR TITLE
Add service callback with path and consumes info

### DIFF
--- a/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
+++ b/DataFormats/Provenance/interface/ProductHolderIndexHelper.h
@@ -125,6 +125,8 @@ namespace edm {
       ProductHolderIndex index(unsigned int i) const;
       unsigned int numberOfMatches() const { return numberOfMatches_; }
       bool isFullyResolved(unsigned int i) const;
+      char const* moduleLabel(unsigned int i) const;
+      char const* processName(unsigned int i) const;
     private:
       ProductHolderIndexHelper const* productHolderIndexHelper_;
       unsigned int startInIndexAndNames_;

--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -20,6 +20,7 @@
 #include <iosfwd>
 #include <map>
 #include <string>
+#include <utility>
 #include <vector>
 #include "FWCore/Utilities/interface/HideStdSharedPtrFromRoot.h"
 
@@ -118,6 +119,10 @@ namespace edm {
       return transient_.missingDictionaries_;
     }
 
+    std::vector<std::pair<std::string, std::string> > const& aliasToOriginal() const {
+      return transient_.aliasToOriginal_;
+    }
+
     ProductHolderIndex const& getNextIndexValue(BranchType branchType) const;
 
     void initializeTransients() {transient_.reset();}
@@ -144,6 +149,8 @@ namespace edm {
       std::map<BranchID, ProductHolderIndex> branchIDToIndex_;
 
       std::vector<std::string> missingDictionaries_;
+
+      std::vector<std::pair<std::string, std::string> > aliasToOriginal_;
     };
 
   private:

--- a/DataFormats/Provenance/src/ProductHolderIndexHelper.cc
+++ b/DataFormats/Provenance/src/ProductHolderIndexHelper.cc
@@ -110,6 +110,26 @@ namespace edm {
     return (productHolderIndexHelper_->indexAndNames_[startInIndexAndNames_ + i].startInProcessNames() != 0U);
   }
 
+  char const*
+  ProductHolderIndexHelper::Matches::processName(unsigned int i) const {
+     if (i >= numberOfMatches_) {
+      throw Exception(errors::LogicError)
+        << "ProductHolderIndexHelper::Matches::processName - Argument is out of range.\n";
+     }
+     unsigned int startInProcessNames = productHolderIndexHelper_->indexAndNames_[startInIndexAndNames_ + i].startInProcessNames();
+     return &productHolderIndexHelper_->processNames_[startInProcessNames];
+  }
+
+  char const*
+  ProductHolderIndexHelper::Matches::moduleLabel(unsigned int i) const {
+     if (i >= numberOfMatches_) {
+      throw Exception(errors::LogicError)
+        << "ProductHolderIndexHelper::Matches::moduleLabel - Argument is out of range.\n";
+     }
+     unsigned int start = productHolderIndexHelper_->indexAndNames_[startInIndexAndNames_ + i].startInBigNamesContainer();
+     return &productHolderIndexHelper_->bigNamesContainer_[start];
+  }
+
   ProductHolderIndexHelper::Matches
   ProductHolderIndexHelper::relatedIndexes(KindOfType kindOfType,
                                            TypeID const& typeID,

--- a/DataFormats/Provenance/src/ProductRegistry.cc
+++ b/DataFormats/Provenance/src/ProductRegistry.cc
@@ -108,6 +108,8 @@ namespace edm {
     std::pair<ProductList::iterator, bool> ret =
          productList_.insert(std::make_pair(BranchKey(bd), bd));
     assert(ret.second);
+    transient_.aliasToOriginal_.emplace_back(labelAlias,
+                                             productDesc.moduleLabel());
     addCalled(bd, false);
   }
 
@@ -151,6 +153,7 @@ namespace edm {
     if(initializeLookupInfo) {
       initializeLookupTables();
     }
+    sort_all(transient_.aliasToOriginal_);
   }
 
   void

--- a/DataFormats/Provenance/test/productHolderIndexHelper_t.cppunit.cc
+++ b/DataFormats/Provenance/test/productHolderIndexHelper_t.cppunit.cc
@@ -214,6 +214,10 @@ void TestProductHolderIndexHelper::testManyEntries() {
   CPPUNIT_ASSERT(indexB2 == 18);
   CPPUNIT_ASSERT(indexB3 == 17);
 
+  CPPUNIT_ASSERT(std::string(matches.moduleLabel(4)) == "labelB");
+  CPPUNIT_ASSERT(std::string(matches.processName(4)) == "processB3");
+  CPPUNIT_ASSERT(std::string(matches.processName(0)) == "");
+
   matches = helper.relatedIndexes(ELEMENT_TYPE, typeID_Simple);
   CPPUNIT_ASSERT(matches.numberOfMatches() == 2);
   ProductHolderIndex indexC = matches.index(1);

--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -19,10 +19,13 @@
 //
 
 // system include files
+#include <map>
+#include <string>
 #include <vector>
 
 // user include files
 #include "FWCore/Framework/interface/ProductHolderIndexAndSkipBit.h"
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/TypeToGet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -36,7 +39,9 @@
 // forward declarations
 
 namespace edm {
+  class ModuleDescription;
   class ProductHolderIndexHelper;
+  class ProductRegistry;
   class ConsumesCollector;
   template<typename T> class WillGetIfMatch;
 
@@ -75,7 +80,14 @@ namespace edm {
     
     void modulesDependentUpon(const std::string& iProcessName,
                               std::vector<const char*>& oModuleLabels) const;
-    
+
+    void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                         ProductRegistry const& preg,
+                                         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                         std::string const& processName) const;
+
+    std::vector<ConsumesInfo> consumesInfo() const;
+
   protected:
     friend class ConsumesCollector;
     template<typename T> friend class WillGetIfMatch;
@@ -133,7 +145,7 @@ namespace edm {
     const EDConsumerBase& operator=(const EDConsumerBase&) = delete;
     
     unsigned int recordConsumes(BranchType iBranch, TypeToGet const& iType, edm::InputTag const& iTag, bool iAlwaysGets);
-    
+
     void throwTypeMismatch(edm::TypeID const&, EDGetToken) const;
     void throwBranchMismatch(BranchType, EDGetToken) const;
     void throwBadToken(edm::TypeID const& iType, EDGetToken iToken) const;

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -15,6 +15,7 @@ configured in the user's main() function, and is set running.
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/IEventProcessor.h"
 #include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/PathsAndConsumesOfModules.h"
 #include "FWCore/Framework/src/PrincipalCache.h"
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
@@ -264,6 +265,7 @@ namespace edm {
     std::unique_ptr<ExceptionToActionTable const>          act_table_;
     std::shared_ptr<ProcessConfiguration const>       processConfiguration_;
     ProcessContext                                processContext_;
+    PathsAndConsumesOfModules                     pathsAndConsumesOfModules_;
     std::auto_ptr<Schedule>                       schedule_;
     std::auto_ptr<SubProcess>                     subProcess_;
     std::unique_ptr<HistoryAppender>            historyAppender_;

--- a/FWCore/Framework/interface/PathsAndConsumesOfModules.h
+++ b/FWCore/Framework/interface/PathsAndConsumesOfModules.h
@@ -1,0 +1,72 @@
+#ifndef FWCore_Framework_PathsAndConsumesOfModules_h
+#define FWCore_Framework_PathsAndConsumesOfModules_h
+
+/**\class edm::PathsAndConsumesOfModules
+
+ Description: See comments in the base class
+
+ Usage:
+
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 11/5/2014
+
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
+#include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace edm {
+
+  class ModuleDescription;
+  class ProductRegistry;
+  class Schedule;
+
+  class PathsAndConsumesOfModules : public PathsAndConsumesOfModulesBase {
+  public:
+
+    virtual ~PathsAndConsumesOfModules();
+
+    void initialize(Schedule const*, std::shared_ptr<ProductRegistry const>);
+
+  private:
+
+    virtual std::vector<std::string> const& doPaths() const override { return paths_; }
+    virtual std::vector<std::string> const& doEndPaths() const override { return endPaths_; }
+
+    virtual std::vector<ModuleDescription const*> const& doAllModules() const override { return allModuleDescriptions_; }
+    virtual ModuleDescription const* doModuleDescription(unsigned int moduleID) const override;
+
+    virtual std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const override;
+    virtual std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const override;
+    virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(unsigned int moduleID) const override;
+
+    virtual std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const override;
+
+    unsigned int moduleIndex(unsigned int moduleID) const;
+
+    // data members
+
+    std::vector<std::string> paths_;
+    std::vector<std::string> endPaths_;
+
+    std::vector<ModuleDescription const*> allModuleDescriptions_;
+
+    std::vector<std::vector<ModuleDescription const*> > modulesOnPaths_;
+    std::vector<std::vector<ModuleDescription const*> > modulesOnEndPaths_;
+
+    // Gives a translation from the module ID to the index into the
+    // following data member
+    std::vector<std::pair<unsigned int, unsigned int> > moduleIDToIndex_;
+
+    std::vector<std::vector<ModuleDescription const*> > modulesWhoseProductsAreConsumedBy_;
+
+    Schedule const* schedule_;
+    std::shared_ptr<ProductRegistry const> preg_;
+  };
+}
+#endif

--- a/FWCore/Framework/interface/Schedule.h
+++ b/FWCore/Framework/interface/Schedule.h
@@ -88,6 +88,7 @@
 #include <string>
 #include <vector>
 #include <sstream>
+#include <utility>
 
 namespace edm {
 
@@ -100,6 +101,7 @@ namespace edm {
   class ExceptionCollector;
   class OutputModuleCommunicator;
   class ProcessContext;
+  class ProductRegistry;
   class PreallocationConfiguration;
   class StreamSchedule;
   class GlobalSchedule;
@@ -190,9 +192,34 @@ namespace edm {
     ///adds to oLabelsToFill the labels for all paths in the process
     void availablePaths(std::vector<std::string>& oLabelsToFill) const;
 
+    ///Adds to oLabelsToFill the labels for all trigger paths in the process.
+    ///This is different from availablePaths because it includes the
+    ///empty paths to match the entries in TriggerResults exactly.
+    void triggerPaths(std::vector<std::string>& oLabelsToFill) const;
+
+    ///adds to oLabelsToFill the labels for all end paths in the process
+    void endPaths(std::vector<std::string>& oLabelsToFill) const;
+
     ///adds to oLabelsToFill in execution order the labels of all modules in path iPathLabel
     void modulesInPath(std::string const& iPathLabel,
                        std::vector<std::string>& oLabelsToFill) const;
+
+    ///adds the ModuleDescriptions into the vector for the modules scheduled in path iPathLabel
+    ///hint is a performance optimization if you might know the position of the module in the path
+    void moduleDescriptionsInPath(std::string const& iPathLabel,
+                                  std::vector<ModuleDescription const*>& descriptions,
+                                  unsigned int hint) const;
+
+    ///adds the ModuleDescriptions into the vector for the modules scheduled in path iEndPathLabel
+    ///hint is a performance optimization if you might know the position of the module in the path
+    void moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
+                                     std::vector<ModuleDescription const*>& descriptions,
+                                     unsigned int hint) const;
+
+    void fillModuleAndConsumesInfo(std::vector<ModuleDescription const*>& allModuleDescriptions,
+                                   std::vector<std::pair<unsigned int, unsigned int> >& moduleIDToIndex,
+                                   std::vector<std::vector<ModuleDescription const*> >& modulesWhoseProductsAreConsumedBy,
+                                   ProductRegistry const& preg) const;
 
     /// Return the number of events this Schedule has tried to process
     /// (inclues both successes and failures, including failures due

--- a/FWCore/Framework/interface/SubProcess.h
+++ b/FWCore/Framework/interface/SubProcess.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "FWCore/Framework/interface/EventSetupProvider.h"
+#include "FWCore/Framework/interface/PathsAndConsumesOfModules.h"
 #include "FWCore/Framework/src/PrincipalCache.h"
 #include "FWCore/Framework/interface/ScheduleItems.h"
 #include "FWCore/Framework/interface/Schedule.h"
@@ -23,6 +24,7 @@
 #include <set>
 
 namespace edm {
+  class ActivityRegistry;
   class BranchDescription;
   class BranchIDListHelper;
   class HistoryAppender;
@@ -229,6 +231,7 @@ namespace edm {
     }
 
     
+    std::shared_ptr<ActivityRegistry>             actReg_;
     ServiceToken                                  serviceToken_;
     std::shared_ptr<ProductRegistry const>        parentPreg_;
     std::shared_ptr<ProductRegistry const>        preg_;
@@ -237,6 +240,7 @@ namespace edm {
     std::unique_ptr<ExceptionToActionTable const> act_table_;
     std::shared_ptr<ProcessConfiguration const>   processConfiguration_;
     ProcessContext                                processContext_;
+    PathsAndConsumesOfModules                     pathsAndConsumesOfModules_;
     //We require 1 history for each Run, Lumi and Stream
     // The vectors first hold Stream info, then Lumi then Run
     unsigned int                                  historyLumiOffset_;

--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -19,6 +19,8 @@
 //
 
 // system include files
+#include <map>
+#include <string>
 #include <vector>
 
 // user include files
@@ -27,6 +29,7 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/Utilities/interface/StreamID.h"
 #include "FWCore/Utilities/interface/RunIndex.h"
 #include "FWCore/Utilities/interface/LuminosityBlockIndex.h"
@@ -90,6 +93,14 @@ namespace edm {
       
       void modulesDependentUpon(const std::string& iProcessName,
                                 std::vector<const char*>& oModuleLabels) const;
+
+      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                           ProductRegistry const& preg,
+                                           std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                           std::string const& processName) const;
+
+      std::vector<ConsumesInfo> consumesInfo() const;
+
     private:
       EDAnalyzerAdaptorBase(const EDAnalyzerAdaptorBase&); // stop default
       

--- a/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h
@@ -19,6 +19,9 @@
 //
 
 // system include files
+#include <map>
+#include <string>
+#include <vector>
 
 // user include files
 #include "DataFormats/Provenance/interface/BranchType.h"
@@ -32,6 +35,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/Run.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 
 // forward declarations
 
@@ -81,6 +85,12 @@ namespace edm {
       void modulesDependentUpon(const std::string& iProcessName,
                                 std::vector<const char*>& oModuleLabels) const;
 
+      void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                           ProductRegistry const& preg,
+                                           std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                           std::string const& processName) const;
+
+      std::vector<ConsumesInfo> consumesInfo() const;
 
     protected:
       template<typename F> void createStreamModules(F iFunc) {

--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -11,16 +11,20 @@
 //
 
 // system include files
+#include <algorithm>
 #include <cassert>
-#include <utility>
 #include <cstring>
+#include <set>
+#include <utility>
 
 // user include files
 #include "FWCore/Framework/interface/EDConsumerBase.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/Likely.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "DataFormats/Provenance/interface/ProductHolderIndexHelper.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
 
 using namespace edm;
 
@@ -376,9 +380,7 @@ namespace {
 
 void
 EDConsumerBase::modulesDependentUpon(const std::string& iProcessName,
-                                     std::vector<const char*>& oModuleLabels
-                                     ) const
-{
+                                     std::vector<const char*>& oModuleLabels) const {
   std::set<const char*, CharStarComp> uniqueModules;
   for(unsigned int index=0, iEnd=m_tokenInfo.size();index <iEnd; ++index) {
     auto const& info = m_tokenInfo.get<kLookupInfo>(index);
@@ -396,6 +398,142 @@ EDConsumerBase::modulesDependentUpon(const std::string& iProcessName,
   oModuleLabels = std::vector<const char*>(uniqueModules.begin(),uniqueModules.end());
 }
 
-//
-// static member functions
-//
+
+namespace {
+  void
+  insertFoundModuleLabel(const char* consumedModuleLabel,
+                         std::vector<ModuleDescription const*>& modules,
+                         std::set<std::string>& alreadyFound,
+                         std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                         ProductRegistry const& preg) {
+    // Convert from label string to module description, eliminate duplicates,
+    // then insert into the vector of modules
+    auto it = labelsToDesc.find(consumedModuleLabel);
+    if(it != labelsToDesc.end()) {
+      if(alreadyFound.insert(consumedModuleLabel).second) {
+        modules.push_back(it->second);
+      }
+      return;
+    }
+    // Deal with EDAlias's by converting to the original module label first
+    std::vector<std::pair<std::string, std::string> > const& aliasToOriginal = preg.aliasToOriginal();
+    std::pair<std::string, std::string> target(consumedModuleLabel, std::string());
+    auto iter = std::lower_bound(aliasToOriginal.begin(), aliasToOriginal.end(), target);
+    if(iter != aliasToOriginal.end() && iter->first == consumedModuleLabel) {
+
+      std::string const& originalModuleLabel = iter->second;
+      auto iter2 = labelsToDesc.find(originalModuleLabel);
+      if(iter2 != labelsToDesc.end()) {
+        if(alreadyFound.insert(originalModuleLabel).second) {
+          modules.push_back(iter2->second);
+        }
+        return;
+      }
+    }
+    // Ignore the source products, we are only interested in module products.
+    // As far as I know, it should never be anything else so throw if something
+    // unknown gets passed in.
+    if(std::string(consumedModuleLabel) != "source") {
+      throw cms::Exception("EDConsumerBase", "insertFoundModuleLabel")
+        << "Couldn't find ModuleDescription for the consumed module label: "
+        << std::string(consumedModuleLabel) << "\n";
+    }
+  }
+}
+
+void
+EDConsumerBase::modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                                ProductRegistry const& preg,
+                                                std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                                std::string const& processName) const {
+
+  ProductHolderIndexHelper const& iHelper = *preg.productLookup(InEvent);
+
+  std::set<std::string> alreadyFound;
+
+  auto itKind = m_tokenInfo.begin<kKind>();
+  auto itLabels = m_tokenInfo.begin<kLabels>();
+  for(auto itInfo = m_tokenInfo.begin<kLookupInfo>(),itEnd = m_tokenInfo.end<kLookupInfo>();
+      itInfo != itEnd; ++itInfo,++itKind,++itLabels) {
+
+    if(itInfo->m_branchType == InEvent) {
+
+      const unsigned int labelStart = itLabels->m_startOfModuleLabel;
+      const char* consumedModuleLabel = &(m_tokenLabels[labelStart]);
+      const char* consumedProcessName = consumedModuleLabel+itLabels->m_deltaToProcessName;
+
+      if(*consumedModuleLabel != '\0') { // not a consumesMany
+        if(*consumedProcessName != '\0') { // process name is specified in consumes call
+          if (processName == consumedProcessName &&
+              iHelper.index(*itKind,
+                            itInfo->m_type,
+                            consumedModuleLabel,
+                            consumedModuleLabel+itLabels->m_deltaToProductInstance,
+                            consumedModuleLabel+itLabels->m_deltaToProcessName) != ProductHolderIndexInvalid) {
+            insertFoundModuleLabel(consumedModuleLabel, modules, alreadyFound, labelsToDesc, preg);
+          }
+        } else { // process name was empty
+          auto matches = iHelper.relatedIndexes(*itKind,
+                                                itInfo->m_type,
+                                                consumedModuleLabel,
+                                                consumedModuleLabel+itLabels->m_deltaToProductInstance);
+          for(unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
+            if(processName == matches.processName(j)) {
+              insertFoundModuleLabel(consumedModuleLabel, modules, alreadyFound, labelsToDesc, preg);
+            }
+          }
+        }
+      // consumesMany case
+      } else if(itInfo->m_index.productHolderIndex() == ProductHolderIndexInvalid) {
+        auto matches = iHelper.relatedIndexes(*itKind,
+                                              itInfo->m_type);
+        for(unsigned int j = 0; j < matches.numberOfMatches(); ++j) {
+          if(processName == matches.processName(j)) {
+            insertFoundModuleLabel(matches.moduleLabel(j), modules, alreadyFound, labelsToDesc, preg);
+          }
+        }
+      }
+    }
+  }
+}
+
+std::vector<ConsumesInfo>
+EDConsumerBase::consumesInfo() const {
+
+  // Use this to eliminate duplicate entries related
+  // to consumesMany items where only the type was specified
+  // and the there are multiple matches. In these cases the
+  // label, instance, and process will be empty.
+  std::set<edm::TypeID> alreadySeenTypes;
+
+  std::vector<ConsumesInfo> result;
+  auto itAlways = m_tokenInfo.begin<kAlwaysGets>();
+  auto itKind = m_tokenInfo.begin<kKind>();
+  auto itLabels = m_tokenInfo.begin<kLabels>();
+  for(auto itInfo = m_tokenInfo.begin<kLookupInfo>(),itEnd = m_tokenInfo.end<kLookupInfo>();
+      itInfo != itEnd; ++itInfo,++itKind,++itLabels, ++itAlways) {
+
+    const unsigned int labelStart = itLabels->m_startOfModuleLabel;
+    const char* consumedModuleLabel = &(m_tokenLabels[labelStart]);
+    const char* consumedInstance = consumedModuleLabel+itLabels->m_deltaToProductInstance;
+    const char* consumedProcessName = consumedModuleLabel+itLabels->m_deltaToProcessName;
+
+    // consumesMany case
+    if(*consumedModuleLabel == '\0') {
+      if(!alreadySeenTypes.insert(itInfo->m_type).second) {
+        continue;
+      }
+    }
+
+    // Just copy the information into the ConsumesInfo data structure
+    result.emplace_back(itInfo->m_type,
+                        consumedModuleLabel,
+                        consumedInstance,
+                        consumedProcessName,
+                        itInfo->m_branchType,
+                        *itKind,
+                        *itAlways,
+                        itInfo->m_index.skipCurrentProcess());
+  }
+  return result;
+}

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -593,6 +593,9 @@ namespace edm {
                                  preallocations_.numberOfRuns(),
                                  preallocations_.numberOfThreads());
     actReg_->preallocateSignal_(bounds);
+    pathsAndConsumesOfModules_.initialize(schedule_.get(), preg_);
+    actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
+
     //NOTE:  This implementation assumes 'Job' means one call
     // the EventProcessor::run
     // If it really means once per 'application' then this code will

--- a/FWCore/Framework/src/PathsAndConsumesOfModules.cc
+++ b/FWCore/Framework/src/PathsAndConsumesOfModules.cc
@@ -1,0 +1,95 @@
+#include "FWCore/Framework/interface/PathsAndConsumesOfModules.h"
+
+#include "FWCore/Framework/interface/Schedule.h"
+#include "FWCore/Framework/src/Worker.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+
+#include <algorithm>
+
+namespace edm {
+
+  PathsAndConsumesOfModules::~PathsAndConsumesOfModules() {
+  }
+
+  void PathsAndConsumesOfModules::initialize(Schedule const* schedule, std::shared_ptr<ProductRegistry const> preg) {
+
+    schedule_ = schedule;
+    preg_ = preg;
+
+    paths_.clear();
+    schedule->triggerPaths(paths_);
+
+    endPaths_.clear();
+    schedule->endPaths(endPaths_);
+
+    modulesOnPaths_.resize(paths_.size());
+    unsigned int i = 0;
+    unsigned int hint = 0;
+    for(auto const& path : paths_) {
+      schedule->moduleDescriptionsInPath(path, modulesOnPaths_.at(i), hint);
+      if(!modulesOnPaths_.at(i).empty()) ++hint;
+      ++i;
+    }
+
+    modulesOnEndPaths_.resize(endPaths_.size());
+    i = 0;
+    hint = 0;
+    for(auto const& endpath : endPaths_) {
+      schedule->moduleDescriptionsInEndPath(endpath, modulesOnEndPaths_.at(i), hint);
+      if(!modulesOnEndPaths_.at(i).empty()) ++hint;
+      ++i;
+    }
+
+    schedule->fillModuleAndConsumesInfo(allModuleDescriptions_,
+                                        moduleIDToIndex_,
+                                        modulesWhoseProductsAreConsumedBy_,
+                                        *preg);
+  }
+
+  ModuleDescription const*
+  PathsAndConsumesOfModules::doModuleDescription(unsigned int moduleID) const {
+    unsigned int dummy = 0;
+    auto target = std::make_pair(moduleID, dummy);
+    std::vector<std::pair<unsigned int, unsigned int> >::const_iterator iter =
+      std::lower_bound(moduleIDToIndex_.begin(), moduleIDToIndex_.end(), target);
+    if (iter == moduleIDToIndex_.end() || iter->first != moduleID) {
+      throw Exception(errors::LogicError)
+        << "PathsAndConsumesOfModules::moduleDescription: Unknown moduleID\n";
+    }
+    return allModuleDescriptions_.at(iter->second);
+  }
+
+  std::vector<ModuleDescription const*> const&
+  PathsAndConsumesOfModules::doModulesOnPath(unsigned int pathIndex) const {
+    return modulesOnPaths_.at(pathIndex);
+  }
+
+  std::vector<ModuleDescription const*> const&
+  PathsAndConsumesOfModules::doModulesOnEndPath(unsigned int endPathIndex) const {
+    return modulesOnEndPaths_.at(endPathIndex);
+  }
+
+  std::vector<ModuleDescription const*> const&
+  PathsAndConsumesOfModules::doModulesWhoseProductsAreConsumedBy(unsigned int moduleID) const {
+    return modulesWhoseProductsAreConsumedBy_.at(moduleIndex(moduleID));
+  }
+
+  std::vector<ConsumesInfo> 
+  PathsAndConsumesOfModules::doConsumesInfo(unsigned int moduleID) const {
+    Worker const* worker = schedule_->allWorkers().at(moduleIndex(moduleID));
+    return worker->consumesInfo();
+  }
+
+  unsigned int
+  PathsAndConsumesOfModules::moduleIndex(unsigned int moduleID) const {
+    unsigned int dummy = 0;
+    auto target = std::make_pair(moduleID, dummy);
+    std::vector<std::pair<unsigned int, unsigned int> >::const_iterator iter =
+      std::lower_bound(moduleIDToIndex_.begin(), moduleIDToIndex_.end(), target);
+    if (iter == moduleIDToIndex_.end() || iter->first != moduleID) {
+      throw Exception(errors::LogicError)
+        << "PathsAndConsumesOfModules::moduleIndex: Unknown moduleID\n";
+    }
+    return iter->second;
+  }
+}

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -1022,9 +1022,65 @@ namespace edm {
   }
 
   void
+  Schedule::triggerPaths(std::vector<std::string>& oLabelsToFill) const {
+    streamSchedules_[0]->triggerPaths(oLabelsToFill);
+  }
+
+  void
+  Schedule::endPaths(std::vector<std::string>& oLabelsToFill) const {
+    streamSchedules_[0]->endPaths(oLabelsToFill);
+  }
+
+  void
   Schedule::modulesInPath(std::string const& iPathLabel,
                           std::vector<std::string>& oLabelsToFill) const {
     streamSchedules_[0]->modulesInPath(iPathLabel,oLabelsToFill);
+  }
+
+  void
+  Schedule::moduleDescriptionsInPath(std::string const& iPathLabel,
+                                     std::vector<ModuleDescription const*>& descriptions,
+                                     unsigned int hint) const {
+    streamSchedules_[0]->moduleDescriptionsInPath(iPathLabel, descriptions, hint);
+  }
+
+  void
+  Schedule::moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
+                                        std::vector<ModuleDescription const*>& descriptions,
+                                        unsigned int hint) const {
+    streamSchedules_[0]->moduleDescriptionsInEndPath(iEndPathLabel, descriptions, hint);
+  }
+
+  void
+  Schedule::fillModuleAndConsumesInfo(std::vector<ModuleDescription const*>& allModuleDescriptions,
+                                      std::vector<std::pair<unsigned int, unsigned int> >& moduleIDToIndex,
+                                      std::vector<std::vector<ModuleDescription const*> >& modulesWhoseProductsAreConsumedBy,
+                                      ProductRegistry const& preg) const {
+    allModuleDescriptions.clear();
+    moduleIDToIndex.clear();
+    modulesWhoseProductsAreConsumedBy.clear();
+
+    allModuleDescriptions.reserve(allWorkers().size());
+    moduleIDToIndex.reserve(allWorkers().size());
+    modulesWhoseProductsAreConsumedBy.resize(allWorkers().size());
+
+    std::map<std::string, ModuleDescription const*> labelToDesc;
+    unsigned int i = 0;
+    for (auto const& worker : allWorkers()) {
+      ModuleDescription const* p = worker->descPtr();
+      allModuleDescriptions.push_back(p);
+      moduleIDToIndex.push_back(std::pair<unsigned int, unsigned int>(p->id(), i));
+      labelToDesc[p->moduleLabel()] = p;
+      ++i;
+    }
+    sort_all(moduleIDToIndex);
+
+    i = 0;
+    for (auto const& worker : allWorkers()) {
+      std::vector<ModuleDescription const*>& modules = modulesWhoseProductsAreConsumedBy.at(i);
+      worker->modulesWhoseProductsAreConsumed(modules, preg, labelToDesc);
+      ++i;
+    }
   }
 
   void

--- a/FWCore/Framework/src/StreamSchedule.cc
+++ b/FWCore/Framework/src/StreamSchedule.cc
@@ -551,6 +551,16 @@ namespace edm {
   }
 
   void
+  StreamSchedule::triggerPaths(std::vector<std::string>& oLabelsToFill) const {
+    oLabelsToFill = trig_name_list_;
+  }
+
+  void
+  StreamSchedule::endPaths(std::vector<std::string>& oLabelsToFill) const {
+    oLabelsToFill = end_path_name_list_;
+  }
+
+  void
   StreamSchedule::modulesInPath(std::string const& iPathLabel,
                           std::vector<std::string>& oLabelsToFill) const {
     TrigPaths::const_iterator itFound =
@@ -563,6 +573,64 @@ namespace edm {
       oLabelsToFill.reserve(itFound->size());
       for (size_t i = 0; i < itFound->size(); ++i) {
         oLabelsToFill.push_back(itFound->getWorker(i)->description().moduleLabel());
+      }
+    }
+  }
+
+  void
+  StreamSchedule::moduleDescriptionsInPath(std::string const& iPathLabel,
+                                           std::vector<ModuleDescription const*>& descriptions,
+                                           unsigned int hint) const {
+    descriptions.clear();
+    bool found = false;
+    TrigPaths::const_iterator itFound;
+
+    if(hint < trig_paths_.size()) {
+      itFound = trig_paths_.begin() + hint;
+      if(itFound->name() == iPathLabel) found = true;
+    }
+    if(!found) {
+      // if the hint did not work, do it the slow way
+      itFound = std::find_if (trig_paths_.begin(),
+                              trig_paths_.end(),
+                              std::bind(std::equal_to<std::string>(),
+                                        iPathLabel,
+                                        std::bind(&Path::name, std::placeholders::_1)));
+      if (itFound != trig_paths_.end()) found = true;
+    }
+    if (found) {
+      descriptions.reserve(itFound->size());
+      for (size_t i = 0; i < itFound->size(); ++i) {
+        descriptions.push_back(itFound->getWorker(i)->descPtr());
+      }
+    }
+  }
+
+  void
+  StreamSchedule::moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
+                                              std::vector<ModuleDescription const*>& descriptions,
+                                              unsigned int hint) const {
+    descriptions.clear();
+    bool found = false;
+    TrigPaths::const_iterator itFound;
+
+    if(hint < end_paths_.size()) {
+      itFound = end_paths_.begin() + hint;
+      if(itFound->name() == iEndPathLabel) found = true;
+    }
+    if(!found) {
+      // if the hint did not work, do it the slow way
+      itFound = std::find_if (end_paths_.begin(),
+                              end_paths_.end(),
+                              std::bind(std::equal_to<std::string>(),
+                                        iEndPathLabel,
+                                        std::bind(&Path::name, std::placeholders::_1)));
+      if (itFound != end_paths_.end()) found = true;
+    }
+    if (found) {
+      descriptions.reserve(itFound->size());
+      for (size_t i = 0; i < itFound->size(); ++i) {
+        descriptions.push_back(itFound->getWorker(i)->descPtr());
       }
     }
   }

--- a/FWCore/Framework/src/StreamSchedule.h
+++ b/FWCore/Framework/src/StreamSchedule.h
@@ -191,9 +191,25 @@ namespace edm {
     ///adds to oLabelsToFill the labels for all paths in the process
     void availablePaths(std::vector<std::string>& oLabelsToFill) const;
 
+    ///adds to oLabelsToFill the labels for all trigger paths in the process
+    ///this is different from availablePaths because it includes the
+    ///empty paths so matches the entries in TriggerResults exactly.
+    void triggerPaths(std::vector<std::string>& oLabelsToFill) const;
+
+    ///adds to oLabelsToFill the labels for all end paths in the process
+    void endPaths(std::vector<std::string>& oLabelsToFill) const;
+
     ///adds to oLabelsToFill in execution order the labels of all modules in path iPathLabel
     void modulesInPath(std::string const& iPathLabel,
                        std::vector<std::string>& oLabelsToFill) const;
+
+    void moduleDescriptionsInPath(std::string const& iPathLabel,
+                                  std::vector<ModuleDescription const*>& descriptions,
+                                  unsigned int hint) const;
+
+    void moduleDescriptionsInEndPath(std::string const& iEndPathLabel,
+                                     std::vector<ModuleDescription const*>& descriptions,
+                                     unsigned int hint) const;
 
     /// Return the number of events this StreamSchedule has tried to process
     /// (inclues both successes and failures, including failures due

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/src/PreallocationConfiguration.h"
 #include "FWCore/ParameterSet/interface/IllegalParameters.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
 
 #include <cassert>
@@ -110,6 +111,7 @@ namespace edm {
     std::shared_ptr<ParameterSet> subProcessParameterSet(popSubProcessParameterSet(*processParameterSet_).release());
   
     ScheduleItems items(*parentProductRegistry, *this);
+    actReg_ = items.actReg_;
 
     ParameterSet const& optionsPset(processParameterSet_->getUntrackedParameterSet("options", ParameterSet()));
     IllegalParameters::setThrowAnException(optionsPset.getUntrackedParameter<bool>("throwIfIllegalParameter", true));
@@ -197,6 +199,8 @@ namespace edm {
       fixBranchIDListsForEDAliases(droppedBranchIDToKeptBranchID());
     }
     ServiceRegistry::Operate operate(serviceToken_);
+    pathsAndConsumesOfModules_.initialize(schedule_.get(), preg_);
+    actReg_->preBeginJobSignal_(pathsAndConsumesOfModules_, processContext_);
     schedule_->beginJob(*preg_);
     if(subProcess_.get()) subProcess_->doBeginJob();
   }

--- a/FWCore/Framework/src/Worker.h
+++ b/FWCore/Framework/src/Worker.h
@@ -30,6 +30,7 @@ the worker is reset().
 #include "FWCore/Framework/interface/ProductHolderIndexAndSkipBit.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 #include "FWCore/ServiceRegistry/interface/InternalContext.h"
 #include "FWCore/ServiceRegistry/interface/ModuleCallingContext.h"
 #include "FWCore/ServiceRegistry/interface/ParentContext.h"
@@ -43,8 +44,10 @@ the worker is reset().
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 
+#include <map>
 #include <memory>
 #include <sstream>
+#include <string>
 #include <vector>
 
 namespace edm {
@@ -106,6 +109,12 @@ namespace edm {
                       ProductHolderIndexHelper const&) = 0;
 
     virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels) const = 0;
+
+    virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                                 ProductRegistry const& preg,
+                                                 std::map<std::string, ModuleDescription const*> const& labelsToDesc) const = 0;
+
+    virtual std::vector<ConsumesInfo> consumesInfo() const = 0;
 
     virtual Types moduleType() const =0;
 

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -11,12 +11,17 @@ WorkerT: Code common to all workers.
 #include "FWCore/Framework/interface/UnscheduledHandler.h"
 #include "FWCore/Framework/src/Worker.h"
 #include "FWCore/Framework/src/WorkerParams.h"
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
 
+#include <map>
 #include <memory>
+#include <string>
+#include <vector>
 
 namespace edm {
 
   class ModuleCallingContext;
+  class ModuleDescription;
   class ProductHolderIndexAndSkipBit;
   class ProductRegistry;
   class ThinnedAssociationsHelper;
@@ -103,6 +108,16 @@ namespace edm {
 
     virtual void modulesDependentUpon(std::vector<const char*>& oModuleLabels) const override {
       module_->modulesDependentUpon(module_->moduleDescription().processName(),oModuleLabels);
+    }
+
+    virtual void modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                                 ProductRegistry const& preg,
+                                                 std::map<std::string, ModuleDescription const*> const& labelsToDesc) const override {
+      module_->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, module_->moduleDescription().processName());
+    }
+
+    virtual std::vector<ConsumesInfo> consumesInfo() const override {
+      return module_->consumesInfo();
     }
 
     virtual void itemsToGet(BranchType branchType, std::vector<ProductHolderIndexAndSkipBit>& indexes) const override {

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <cassert>
 
 // user include files
 #include "FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h"
@@ -117,6 +118,21 @@ EDAnalyzerAdaptorBase::modulesDependentUpon(const std::string& iProcessName,
                                             std::vector<const char*>& oModuleLabels) const {
   assert(not m_streamModules.empty());
   return m_streamModules[0]->modulesDependentUpon(iProcessName, oModuleLabels);
+}
+
+void
+EDAnalyzerAdaptorBase::modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                                       ProductRegistry const& preg,
+                                                       std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                                       std::string const& processName) const {
+  assert(not m_streamModules.empty());
+  return m_streamModules[0]->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, processName);
+}
+
+std::vector<edm::ConsumesInfo>
+EDAnalyzerAdaptorBase::consumesInfo() const {
+  assert(not m_streamModules.empty());
+  return m_streamModules[0]->consumesInfo();
 }
 
 bool

--- a/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/ProducingModuleAdaptorBase.cc
@@ -11,6 +11,7 @@
 //
 
 // system include files
+#include <cassert>
 
 // user include files
 #include "FWCore/Framework/interface/stream/ProducingModuleAdaptorBase.h"
@@ -109,6 +110,23 @@ namespace edm {
                                                         std::vector<const char*>& oModuleLabels) const {
       assert(not m_streamModules.empty());
       return m_streamModules[0]->modulesDependentUpon(iProcessName, oModuleLabels);
+    }
+
+    template< typename T>
+    void
+    ProducingModuleAdaptorBase<T>::modulesWhoseProductsAreConsumed(std::vector<ModuleDescription const*>& modules,
+                                                                   ProductRegistry const& preg,
+                                                                   std::map<std::string, ModuleDescription const*> const& labelsToDesc,
+                                                                   std::string const& processName) const {
+      assert(not m_streamModules.empty());
+      return m_streamModules[0]->modulesWhoseProductsAreConsumed(modules, preg, labelsToDesc, processName);
+    }
+
+    template< typename T>
+    std::vector<edm::ConsumesInfo>
+    ProducingModuleAdaptorBase<T>::consumesInfo() const {
+      assert(not m_streamModules.empty());
+      return m_streamModules[0]->consumesInfo();
     }
 
     template< typename T>

--- a/FWCore/Framework/test/productregistry.cppunit.cc
+++ b/FWCore/Framework/test/productregistry.cppunit.cc
@@ -32,6 +32,7 @@ CPPUNIT_TEST(testWatch);
 CPPUNIT_TEST_EXCEPTION(testCircular,cms::Exception);
 
 CPPUNIT_TEST(testProductRegistration);
+CPPUNIT_TEST(testAddAlias);
 
 CPPUNIT_TEST_SUITE_END();
 
@@ -43,6 +44,7 @@ public:
   void testWatch();
   void testCircular();
   void testProductRegistration();
+  void testAddAlias();
 
  private:
   std::shared_ptr<edm::BranchDescription> intBranch_;
@@ -105,12 +107,12 @@ void testProductRegistry::setUp() {
 
   edm::ParameterSet pset;
   pset.registerIt();
-  intBranch_.reset(new edm::BranchDescription(edm::InEvent, "label", "PROD",
+  intBranch_.reset(new edm::BranchDescription(edm::InEvent, "labeli", "PROD",
                                           "int", "int", "int",
                                           "", pset.id(),
                                           edm::TypeWithDict(typeid(int))));
 
-  floatBranch_.reset(new edm::BranchDescription(edm::InEvent, "label", "PROD",
+  floatBranch_.reset(new edm::BranchDescription(edm::InEvent, "labelf", "PROD",
                                             "float", "float", "float",
                                             "", pset.id(),
                                             edm::TypeWithDict(typeid(float))));
@@ -214,4 +216,21 @@ void testProductRegistry:: testProductRegistration() {
     std::cout << "caught " << iException.explainSelf() << std::endl;
     throw;
   }
+}
+
+void testProductRegistry::testAddAlias() {
+  edm::ProductRegistry reg;
+
+  reg.addProduct(*intBranch_);
+  reg.addLabelAlias(*intBranch_, "aliasi", "instanceAlias");
+
+  reg.addProduct(*floatBranch_);
+  reg.addLabelAlias(*floatBranch_, "aliasf", "instanceAlias");
+
+  reg.setFrozen(false);
+  std::vector<std::pair<std::string, std::string> > const& v = reg.aliasToOriginal();
+  CPPUNIT_ASSERT(v.at(0).first == "aliasf" &&
+                 v.at(0).second == "labelf" &&
+                 v.at(1).first == "aliasi" &&
+                 v.at(1).second == "labeli");
 }

--- a/FWCore/Framework/test/stubs/ToyAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/ToyAnalyzers.cc
@@ -10,6 +10,7 @@ Toy EDAnalyzers for testing purposes only.
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 //
 #include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -52,6 +53,30 @@ namespace edmtest {
       value_(iPSet.getUntrackedParameter<int>("valueMustMatch")),
       moduleLabel_(iPSet.getUntrackedParameter<std::string>("moduleLabel"), "") {
       consumes<IntProduct>(moduleLabel_);
+    }
+
+    void analyze(edm::Event const& iEvent, edm::EventSetup const&) {
+      edm::Handle<IntProduct> handle;
+      iEvent.getByLabel(moduleLabel_, handle);
+      if(handle->value != value_) {
+        throw cms::Exception("ValueMissMatch")
+          << "The value for \"" << moduleLabel_ << "\" is "
+          << handle->value << " but it was supposed to be " << value_;
+      }
+    }
+  private:
+    int value_;
+    edm::InputTag moduleLabel_;
+  };
+
+  //--------------------------------------------------------------------
+  //
+  class ConsumingStreamAnalyzer : public edm::stream::EDAnalyzer<> {
+  public:
+    ConsumingStreamAnalyzer(edm::ParameterSet const& iPSet) :
+      value_(iPSet.getUntrackedParameter<int>("valueMustMatch")),
+      moduleLabel_(iPSet.getUntrackedParameter<std::string>("moduleLabel"), "") {
+      mayConsume<IntProduct>(moduleLabel_);
     }
 
     void analyze(edm::Event const& iEvent, edm::EventSetup const&) {
@@ -173,10 +198,12 @@ namespace edmtest {
 
 using edmtest::NonAnalyzer;
 using edmtest::IntTestAnalyzer;
+using edmtest::ConsumingStreamAnalyzer;
 using edmtest::SCSimpleAnalyzer;
 using edmtest::DSVAnalyzer;
 DEFINE_FWK_MODULE(NonAnalyzer);
 DEFINE_FWK_MODULE(IntTestAnalyzer);
+DEFINE_FWK_MODULE(ConsumingStreamAnalyzer);
 DEFINE_FWK_MODULE(SCSimpleAnalyzer);
 DEFINE_FWK_MODULE(DSVAnalyzer);
 

--- a/FWCore/Framework/test/stubs/ToyIntProducers.cc
+++ b/FWCore/Framework/test/stubs/ToyIntProducers.cc
@@ -6,6 +6,7 @@ Toy EDProducers of Ints for testing purposes only.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/TestObjects/interface/ToyProducts.h"
 //
 #include "FWCore/Framework/interface/EDProducer.h"
@@ -14,6 +15,7 @@ Toy EDProducers of Ints for testing purposes only.
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 //
 #include <cassert>
 #include <string>
@@ -87,9 +89,39 @@ namespace edmtest {
     int value_;
   };
 
+  //--------------------------------------------------------------------
+
   void
   IntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     // EventSetup is not used.
+    std::unique_ptr<IntProduct> p(new IntProduct(value_));
+    e.put(std::move(p));
+  }
+
+  class ConsumingIntProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit ConsumingIntProducer(edm::ParameterSet const& p) :
+      value_(p.getParameter<int>("ivalue")) {
+      produces<IntProduct>();
+      // not used, only exists to test PathAndConsumesOfModules
+      consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"));
+      consumesMany<edm::TriggerResults>();
+    }
+    explicit ConsumingIntProducer(int i) : value_(i) {
+      produces<IntProduct>();
+      // not used, only exists to test PathAndConsumesOfModules
+      consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"));
+      consumesMany<edm::TriggerResults>();
+    }
+    virtual ~ConsumingIntProducer() {}
+    virtual void produce(edm::Event& e, edm::EventSetup const& c);
+
+  private:
+    int value_;
+  };
+
+  void
+  ConsumingIntProducer::produce(edm::Event& e, edm::EventSetup const&) {
     std::unique_ptr<IntProduct> p(new IntProduct(value_));
     e.put(std::move(p));
   }
@@ -242,6 +274,7 @@ namespace edmtest {
 using edmtest::FailingProducer;
 using edmtest::NonProducer;
 using edmtest::IntProducer;
+using edmtest::ConsumingIntProducer;
 using edmtest::EventNumberIntProducer;
 using edmtest::TransientIntProducer;
 using edmtest::IntProducerFromTransient;
@@ -250,6 +283,7 @@ using edmtest::AddIntsProducer;
 DEFINE_FWK_MODULE(FailingProducer);
 DEFINE_FWK_MODULE(NonProducer);
 DEFINE_FWK_MODULE(IntProducer);
+DEFINE_FWK_MODULE(ConsumingIntProducer);
 DEFINE_FWK_MODULE(EventNumberIntProducer);
 DEFINE_FWK_MODULE(TransientIntProducer);
 DEFINE_FWK_MODULE(IntProducerFromTransient);

--- a/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
+++ b/FWCore/Framework/test/unit_test_outputs/test_deepCall_allowUnscheduled_true.log
@@ -15,6 +15,7 @@ Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f60
 ++++ starting: constructing module with label 'result4' id = 6
 ++++ finished: constructing module with label 'result4' id = 6
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
+++ starting: begin job
 ++++ starting: begin job for module with label 'one' id = 3
 Module type=IntProducer, Module label=one, Parameter Set ID=bece7daf7ab0166d4f6047cc887d46b8
 ++++ finished: begin job for module with label 'one' id = 3

--- a/FWCore/Integration/test/run_TestGetBy.sh
+++ b/FWCore/Integration/test/run_TestGetBy.sh
@@ -6,14 +6,24 @@ function die { echo Failure $1: status $2 ; exit $2 ; }
 
 pushd ${LOCAL_TMP_DIR}
 
-  cmsRun -p ${LOCAL_TEST_DIR}/${test}1_cfg.py > testGetBy1.log || die "cmsRun ${test}1_cfg.py" $?
+  echo "testGetBy1"
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}1_cfg.py > testGetBy1.log 2>/dev/null || die "cmsRun ${test}1_cfg.py" $?
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy1.log testGetBy1.log || die "comparing testGetBy1.log" $?
 
-  cmsRun -p ${LOCAL_TEST_DIR}/${test}2_cfg.py > testGetBy2.log || die "cmsRun ${test}2_cfg.py" $?
+  echo "testGetBy2"
+  cmsRun -p ${LOCAL_TEST_DIR}/${test}2_cfg.py > testGetBy2.log 2>/dev/null || die "cmsRun ${test}2_cfg.py" $?
   grep -v "Initiating request to open file" testGetBy2.log | grep -v "Successfully opened file" | grep -v "Closed file" > testGetBy2_1.log
   diff ${LOCAL_TEST_DIR}/unit_test_outputs/testGetBy2.log testGetBy2_1.log || die "comparing testGetBy2.log" $?
 
+  echo "testGetBy3"
   cmsRun -p ${LOCAL_TEST_DIR}/${test}3_cfg.py || die "cmsRun ${test}3_cfg.py" $?
+
+  echo "testConsumesInfo"
+  cmsRun -p ${LOCAL_TEST_DIR}/testConsumesInfo_cfg.py > testConsumesInfo.log 2>/dev/null || die "cmsRun testConsumesInfo_cfg.py" $?
+  grep -v "++" testConsumesInfo.log > testConsumesInfo_1.log
+  rm testConsumesInfo.log
+  rm testConsumesInfo.root
+  diff ${LOCAL_TEST_DIR}/unit_test_outputs/testConsumesInfo_1.log testConsumesInfo_1.log || die "comparing testConsumesInfo_1.log" $?
 
 popd
 

--- a/FWCore/Integration/test/testConsumesInfo_cfg.py
+++ b/FWCore/Integration/test/testConsumesInfo_cfg.py
@@ -1,0 +1,151 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("PROD1")
+
+process.Tracer = cms.Service('Tracer',
+    dumpPathsAndConsumes = cms.untracked.bool(True)
+)
+
+process.MessageLogger = cms.Service("MessageLogger",
+    destinations   = cms.untracked.vstring('cout',
+                                           'cerr'
+    ),
+    categories = cms.untracked.vstring(
+        'Tracer'
+    ),
+    cout = cms.untracked.PSet(
+        default = cms.untracked.PSet (
+            limit = cms.untracked.int32(0)
+        ),
+        Tracer = cms.untracked.PSet(
+            limit=cms.untracked.int32(100000000)
+        )
+    )
+)
+
+process.options = cms.untracked.PSet(
+    allowUnscheduled = cms.untracked.bool(True),
+    numberOfStreams = cms.untracked.uint32(1),
+    numberOfConcurrentRuns = cms.untracked.uint32(1),
+    numberOfConcurrentLuminosityBlocks = cms.untracked.uint32(1)
+)
+
+process.source = cms.Source("IntSource")
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(3)
+)
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string('testConsumesInfo.root'),
+    outputCommands = cms.untracked.vstring(
+        'keep *',
+        'drop *_intProducerA_*_*'
+    )
+)
+
+process.a1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("source") ),
+  expectedSum = cms.untracked.int32(12),
+  inputTagsNotFound = cms.untracked.VInputTag(
+    cms.InputTag("source", processName=cms.InputTag.skipCurrentProcess()),
+    cms.InputTag("intProducer", processName=cms.InputTag.skipCurrentProcess()),
+    cms.InputTag("intProducerU", processName=cms.InputTag.skipCurrentProcess())
+  )
+)
+
+process.a2 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("intProducerA") ),
+  expectedSum = cms.untracked.int32(300)
+)
+
+process.a3 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag( cms.InputTag("aliasForInt") ),
+  expectedSum = cms.untracked.int32(300)
+)
+
+process.intProducer = cms.EDProducer("IntProducer", ivalue = cms.int32(1))
+
+process.intProducerU = cms.EDProducer("IntProducer", ivalue = cms.int32(10))
+
+process.intProducerA = cms.EDProducer("IntProducer", ivalue = cms.int32(100))
+
+process.aliasForInt = cms.EDAlias(
+  intProducerA  = cms.VPSet(
+    cms.PSet(type = cms.string('edmtestIntProduct')
+    )
+  )
+)
+
+process.intVectorProducer = cms.EDProducer("IntVectorProducer",
+  count = cms.int32(9),
+  ivalue = cms.int32(11)
+)
+
+process.test = cms.EDAnalyzer("TestResultAnalyzer")
+
+process.testView1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(),
+  inputTagsView = cms.untracked.VInputTag( cms.InputTag("intVectorProducer", "", "PROD1") )
+)
+
+process.testStreamingProducer = cms.EDProducer("ConsumingIntProducer",
+  ivalue = cms.int32(111)
+)
+
+process.testStreamingAnalyzer = cms.EDAnalyzer("ConsumingStreamAnalyzer",
+  valueMustMatch = cms.untracked.int32(111),
+  moduleLabel = cms.untracked.string("testStreamingProducer")
+)
+
+process.p = cms.Path(process.intProducer * process.a1 * process.a2 * process.a3 *
+                     process.test * process.testView1 *
+                     process.testStreamingProducer * process.testStreamingAnalyzer)
+process.p2 = cms.Path(process.intProducer * process.a1 * process.a2 * process.a3)
+process.p11 = cms.Path()
+
+process.e = cms.EndPath(process.out)
+process.p1ep2 = cms.EndPath()
+
+copyProcess = cms.Process("COPY")
+process.subProcess = cms.SubProcess(copyProcess,
+    outputCommands = cms.untracked.vstring(
+        "keep *",
+        "drop *_intProducerA_*_*"
+    )
+)
+
+copyProcess.intVectorProducer = cms.EDProducer("IntVectorProducer",
+  count = cms.int32(9),
+  ivalue = cms.int32(11)
+)
+
+copyProcess.testView1 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(),
+  inputTagsView = cms.untracked.VInputTag( cms.InputTag("intVectorProducer", "", "PROD1") )
+)
+
+copyProcess.testView2 = cms.EDAnalyzer("TestFindProduct",
+  inputTags = cms.untracked.VInputTag(),
+  inputTagsView = cms.untracked.VInputTag( cms.InputTag("intVectorProducer", "", "COPY") )
+)
+
+copyProcess.test = cms.EDAnalyzer("TestResultAnalyzer")
+
+copyProcess.thingWithMergeProducer = cms.EDProducer("ThingWithMergeProducer")
+copyProcess.testMergeResults = cms.EDAnalyzer("TestMergeResults")
+
+copyProcess.testStreamingProducer = cms.EDProducer("ConsumingIntProducer",
+  ivalue = cms.int32(11)
+)
+
+copyProcess.testStreamingAnalyzer = cms.EDAnalyzer("ConsumingStreamAnalyzer",
+  valueMustMatch = cms.untracked.int32(11),
+  moduleLabel = cms.untracked.string("testStreamingProducer")
+)
+
+copyProcess.p3 = cms.Path(copyProcess.intVectorProducer * copyProcess.test * copyProcess.thingWithMergeProducer *
+                          copyProcess.testMergeResults * copyProcess.testView1 * copyProcess.testView2 *
+                          copyProcess.testStreamingProducer * copyProcess.testStreamingAnalyzer)
+
+copyProcess.ep1 = cms.EndPath(copyProcess.intVectorProducer)
+copyProcess.ep2 = cms.EndPath()

--- a/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testConsumesInfo_1.log
@@ -1,0 +1,167 @@
+Process name = PROD1
+paths:
+  p
+  p2
+  p11
+end paths:
+  e
+  p1ep2
+modules on path p:
+  intProducer
+  a1
+  a2
+  a3
+  test
+  testView1
+  testStreamingProducer
+  testStreamingAnalyzer
+modules on path p2:
+  intProducer
+  a1
+  a2
+  a3
+modules on path p11:
+modules on end path e:
+  out
+modules on end path p1ep2:
+All modules and modules in the current process whose products they consume:
+(This does not include modules from previous processes or the source)
+  IntProducer/'intProducerA'
+  IntProducer/'intProducerU'
+  IntVectorProducer/'intVectorProducer'
+  IntProducer/'intProducer'
+  TestFindProduct/'a1' consumes products from these modules:
+    IntProducer/'intProducer'
+    IntProducer/'intProducerU'
+  TestFindProduct/'a2' consumes products from these modules:
+    IntProducer/'intProducerA'
+  TestFindProduct/'a3' consumes products from these modules:
+    IntProducer/'intProducerA'
+  TestResultAnalyzer/'test' consumes products from these modules:
+    TriggerResultInserter/'TriggerResults'
+  TestFindProduct/'testView1' consumes products from these modules:
+    IntVectorProducer/'intVectorProducer'
+  ConsumingIntProducer/'testStreamingProducer' consumes products from these modules:
+    TriggerResultInserter/'TriggerResults'
+  ConsumingStreamAnalyzer/'testStreamingAnalyzer' consumes products from these modules:
+    ConsumingIntProducer/'testStreamingProducer'
+  PoolOutputModule/'out' consumes products from these modules:
+    TriggerResultInserter/'TriggerResults'
+    IntProducer/'intProducerA'
+    IntProducer/'intProducer'
+    IntProducer/'intProducerU'
+    ConsumingIntProducer/'testStreamingProducer'
+    IntVectorProducer/'intVectorProducer'
+  TriggerResultInserter/'TriggerResults'
+All modules (listed by class and label) and all their consumed products.
+Consumed products are listed by type, label, instance, process.
+For products not in the event, 'run' or 'lumi' is added to indicate the TTree they are from.
+For products that are declared with mayConsume, 'may consume' is added.
+For products consumed for Views, 'element type' is added
+For products only read from previous processes, 'skip current process' is added
+  IntProducer/'intProducerA'
+  IntProducer/'intProducerU'
+  IntVectorProducer/'intVectorProducer'
+  IntProducer/'intProducer'
+  TestFindProduct/'a1' consumes:
+    edmtest::IntProduct 'source' '' ''
+    edmtest::IntProduct 'source' '' '', skip current process
+    edmtest::IntProduct 'intProducer' '' '', skip current process
+    edmtest::IntProduct 'intProducerU' '' '', skip current process
+  TestFindProduct/'a2' consumes:
+    edmtest::IntProduct 'intProducerA' '' ''
+  TestFindProduct/'a3' consumes:
+    edmtest::IntProduct 'aliasForInt' '' ''
+  TestResultAnalyzer/'test' consumes:
+    edm::TriggerResults '' '' ''
+  TestFindProduct/'testView1' consumes:
+    int 'intVectorProducer' '' 'PROD1', element type
+  ConsumingIntProducer/'testStreamingProducer' consumes:
+    edm::TriggerResults 'TriggerResults' '' ''
+    edm::TriggerResults '' '' ''
+  ConsumingStreamAnalyzer/'testStreamingAnalyzer' consumes:
+    edmtest::IntProduct 'testStreamingProducer' '' '', may consume
+  PoolOutputModule/'out' consumes:
+    edm::TriggerResults 'TriggerResults' '' 'PROD1'
+    edmtest::IntProduct 'aliasForInt' '' 'PROD1'
+    edmtest::IntProduct 'intProducer' '' 'PROD1'
+    edmtest::IntProduct 'intProducerU' '' 'PROD1'
+    edmtest::IntProduct 'source' '' 'PROD1'
+    edmtest::IntProduct 'testStreamingProducer' '' 'PROD1'
+    std::vector<int> 'intVectorProducer' '' 'PROD1'
+  TriggerResultInserter/'TriggerResults'
+
+Process name = COPY
+paths:
+  p3
+end paths:
+  ep1
+  ep2
+modules on path p3:
+  intVectorProducer
+  test
+  thingWithMergeProducer
+  testMergeResults
+  testView1
+  testView2
+  testStreamingProducer
+  testStreamingAnalyzer
+modules on end path ep1:
+  intVectorProducer
+modules on end path ep2:
+All modules and modules in the current process whose products they consume:
+(This does not include modules from previous processes or the source)
+  IntVectorProducer/'intVectorProducer'
+  TestResultAnalyzer/'test' consumes products from these modules:
+    TriggerResultInserter/'TriggerResults'
+  ThingWithMergeProducer/'thingWithMergeProducer'
+  TestMergeResults/'testMergeResults'
+  TestFindProduct/'testView1'
+  TestFindProduct/'testView2' consumes products from these modules:
+    IntVectorProducer/'intVectorProducer'
+  ConsumingIntProducer/'testStreamingProducer' consumes products from these modules:
+    TriggerResultInserter/'TriggerResults'
+  ConsumingStreamAnalyzer/'testStreamingAnalyzer' consumes products from these modules:
+    ConsumingIntProducer/'testStreamingProducer'
+  TriggerResultInserter/'TriggerResults'
+All modules (listed by class and label) and all their consumed products.
+Consumed products are listed by type, label, instance, process.
+For products not in the event, 'run' or 'lumi' is added to indicate the TTree they are from.
+For products that are declared with mayConsume, 'may consume' is added.
+For products consumed for Views, 'element type' is added
+For products only read from previous processes, 'skip current process' is added
+  IntVectorProducer/'intVectorProducer'
+  TestResultAnalyzer/'test' consumes:
+    edm::TriggerResults '' '' ''
+  ThingWithMergeProducer/'thingWithMergeProducer'
+  TestMergeResults/'testMergeResults' consumes:
+    edmtest::Thing 'thingWithMergeProducer' 'event' 'PROD'
+    edmtest::Thing 'thingWithMergeProducer' 'endRun' 'PROD', run
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'endRun' 'PROD', run
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'endRun' 'PROD', run
+    edmtest::Thing 'thingWithMergeProducer' 'endRun' '', run
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'endRun' '', run
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'endRun' '', run
+    edmtest::Thing 'thingWithMergeProducer' 'endLumi' 'PROD', lumi
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'endLumi' 'PROD', lumi
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'endLumi' 'PROD', lumi
+    edmtest::Thing 'thingWithMergeProducer' 'endLumi' '', lumi
+    edmtest::ThingWithMerge 'thingWithMergeProducer' 'endLumi' '', lumi
+    edmtest::ThingWithIsEqual 'thingWithMergeProducer' 'endLumi' '', lumi
+  TestFindProduct/'testView1' consumes:
+    int 'intVectorProducer' '' 'PROD1', element type
+  TestFindProduct/'testView2' consumes:
+    int 'intVectorProducer' '' 'COPY', element type
+  ConsumingIntProducer/'testStreamingProducer' consumes:
+    edm::TriggerResults 'TriggerResults' '' ''
+    edm::TriggerResults '' '' ''
+  ConsumingStreamAnalyzer/'testStreamingAnalyzer' consumes:
+    edmtest::IntProduct 'testStreamingProducer' '' '', may consume
+  TriggerResultInserter/'TriggerResults'
+
+TestFindProduct sum = 12
+TestFindProduct sum = 300
+TestFindProduct sum = 300
+TestFindProduct sum = 33
+TestFindProduct sum = 33
+TestFindProduct sum = 33

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy1.log
@@ -23,6 +23,7 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 ++++ starting: constructing module with label 'intVectorProducer' id = 9
 ++++ finished: constructing module with label 'intVectorProducer' id = 9
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
+++ starting: begin job
 ++++ starting: begin job for module with label 'intProducerA' id = 7
 Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e8174cb2ccc12430661ba6d4
 ++++ finished: begin job for module with label 'intProducerA' id = 7
@@ -43,6 +44,7 @@ Module type=IntProducer, Module label=intProducerA, Parameter Set ID=38971365e81
 ++++ finished: begin job for module with label 'out' id = 6
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
+++ starting: begin job
 ++ finished: begin job
 ++++ starting: begin stream for module: stream = 0 label = 'intProducer' id = 2
 ++++ finished: begin stream for module: stream = 0 label = 'intProducer' id = 2

--- a/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
+++ b/FWCore/Integration/test/unit_test_outputs/testGetBy2.log
@@ -17,6 +17,7 @@ Module type=IntProducer, Module label=intProducer, Parameter Set ID=0e62dace196e
 ++++ starting: constructing module with label 'intVectorProducer' id = 5
 ++++ finished: constructing module with label 'intVectorProducer' id = 5
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
+++ starting: begin job
 ++++ starting: begin job for module with label 'intProducerU' id = 4
 ++++ finished: begin job for module with label 'intProducerU' id = 4
 ++++ starting: begin job for module with label 'intVectorProducer' id = 5

--- a/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
+++ b/FWCore/Integration/test/unit_test_outputs/testSubProcess.grep2.txt
@@ -33,6 +33,9 @@
 ++++ starting: constructing module with label 'out' id = 16
 ++++ finished: constructing module with label 'out' id = 16
 ++ preallocate: 1 concurrent runs, 1 concurrent luminosity sections, 1 streams
+++ starting: begin job
+++ starting: begin job
+++ starting: begin job
 ++++ starting: begin job for module with label 'thingWithMergeProducer' id = 2
 ++++ finished: begin job for module with label 'thingWithMergeProducer' id = 2
 ++++ starting: begin job for module with label 'get' id = 3
@@ -49,6 +52,8 @@
 ++++ finished: begin job for module with label 'noPut' id = 8
 ++++ starting: begin job for module with label 'TriggerResults' id = 1
 ++++ finished: begin job for module with label 'TriggerResults' id = 1
+++ starting: begin job
+++ starting: begin job
 ++++ starting: begin job for module with label 'thingWithMergeProducer' id = 10
 ++++ finished: begin job for module with label 'thingWithMergeProducer' id = 10
 ++++ starting: begin job for module with label 'test' id = 11

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -56,7 +56,9 @@ namespace edm {
    class GlobalContext;
    class StreamContext;
    class PathContext;
+   class ProcessContext;
    class ModuleCallingContext;
+   class PathsAndConsumesOfModulesBase;
    namespace service {
      class SystemBounds;
    }
@@ -97,7 +99,16 @@ namespace edm {
         preallocateSignal_.connect(iSlot);
       }
       AR_WATCH_USING_METHOD_1(watchPreallocate)
-     
+
+      typedef signalslot::Signal<void(PathsAndConsumesOfModulesBase const&, ProcessContext const&)> PreBeginJob;
+      ///signal is emitted before all modules have gotten their beginJob called
+      PreBeginJob preBeginJobSignal_;
+      ///convenience function for attaching to signal
+      void watchPreBeginJob(PreBeginJob::slot_type const& iSlot) {
+         preBeginJobSignal_.connect(iSlot);
+      }
+      AR_WATCH_USING_METHOD_2(watchPreBeginJob)
+
       typedef signalslot::Signal<void()> PostBeginJob;
       ///signal is emitted after all modules have gotten their beginJob called
       PostBeginJob postBeginJobSignal_;

--- a/FWCore/ServiceRegistry/interface/ConsumesInfo.h
+++ b/FWCore/ServiceRegistry/interface/ConsumesInfo.h
@@ -1,0 +1,66 @@
+#ifndef FWCore_ServiceRegistry_ConsumesInfo_h
+#define FWCore_ServiceRegistry_ConsumesInfo_h
+
+/**\class edm::ConsumesInfo
+
+   Description: Contains information about a product
+   a module will get (consume).
+
+   Usage: These are typically returned by the PathsAndConsumesOfModules
+   object obtained in the PreBeginJob callback for a service.
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 12/4/2014
+
+#include "FWCore/Utilities/interface/BranchType.h"
+#include "FWCore/Utilities/interface/ProductKindOfType.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
+#include <string>
+
+namespace edm {
+  class ConsumesInfo {
+  public:
+
+    ConsumesInfo(TypeID const& iType,
+                 char const* iLabel,
+                 char const* iInstance,
+                 char const* iProcess,
+                 BranchType iBranchType,
+                 KindOfType iKindOfType,
+                 bool iAlwaysGets,
+                 bool iSkipCurrentProcess_);
+
+    TypeID const& type() const { return type_; }
+    std::string const& label() const { return label_; }
+    std::string const& instance() const { return instance_; }
+    std::string const& process() const { return process_; }
+    BranchType branchType() const { return branchType_; }
+    KindOfType kindOfType() const { return kindOfType_; }
+    bool alwaysGets() const { return alwaysGets_; }
+    bool skipCurrentProcess() const { return skipCurrentProcess_; }
+
+    // This provides information from EDConsumerBase
+    // There a couple cases that need explanation.
+    //
+    // consumesMany
+    //    The label, instance and process are all empty.
+    //
+    // process is empty - A get will search over processes in reverse
+    //    time order (unknown which process the product will be gotten
+    //    from and it is possible for this to vary from event to event)
+
+  private:
+
+    TypeID type_;
+    std::string label_;
+    std::string instance_;
+    std::string process_;
+    BranchType branchType_;
+    KindOfType kindOfType_;
+    bool alwaysGets_;
+    bool skipCurrentProcess_;
+  };
+}
+#endif

--- a/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
+++ b/FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h
@@ -1,0 +1,95 @@
+#ifndef FWCore_ServiceRegistry_PathsAndConsumesOfModulesBase_h
+#define FWCore_ServiceRegistry_PathsAndConsumesOfModulesBase_h
+
+/**\class edm::PathsAndConsumesOfModulesBase
+
+ Description: Contains information about paths and end paths
+ as well as the modules on them. Also contains information
+ about all modules that might run. Also contains information
+ about the products a module is declared to consume and the
+ dependences between modules which can be derived from
+ those declarations.
+
+ Usage: This is typically passed as an argument to the
+ PreBeginJob callback for a service.
+
+ In a SubProcess job, an instance of this class this will
+ contain information about 1 Process/SubProcess, but a
+ service will be passed a separate object for its process
+ and each SubProcess descended from it.
+*/
+//
+// Original Author: W. David Dagenhart
+//         Created: 11/5/2014
+
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
+
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class ModuleDescription;
+
+  class PathsAndConsumesOfModulesBase {
+  public:
+
+    virtual ~PathsAndConsumesOfModulesBase();
+
+    std::vector<std::string> const& paths() const { return doPaths(); }
+    std::vector<std::string> const& endPaths() const { return doEndPaths(); }
+
+    std::vector<ModuleDescription const*> const& allModules() const {
+      return doAllModules();
+    }
+
+    ModuleDescription const* moduleDescription(unsigned int moduleID) const {
+      return doModuleDescription(moduleID);
+    }
+
+    std::vector<ModuleDescription const*> const& modulesOnPath(unsigned int pathIndex) const {
+      return doModulesOnPath(pathIndex);
+    }
+
+    std::vector<ModuleDescription const*> const& modulesOnEndPath(unsigned int endPathIndex) const {
+      return doModulesOnEndPath(endPathIndex);
+    }
+
+    // The modules in the returned vector will be from the current process
+    // (not the prior process, and it will never include the source even
+    // though the source can make products) and these modules will declare
+    // they produce (they might or might not really produce) at least one
+    // product in the event (not run, not lumi) that the module corresponding
+    // to the moduleID argument declares it consumes (includes declarations using
+    // consumes, maybeConsumes, or consumesMany). Note that if a module declares
+    // it consumes a module label that is an EDAlias, the corresponding module
+    // description will be included in the returned vector (but the label in the
+    // module description is not the EDAlias label).
+    std::vector<ModuleDescription const*> const& modulesWhoseProductsAreConsumedBy(unsigned int moduleID) const {
+      return doModulesWhoseProductsAreConsumedBy(moduleID);
+    }
+
+    // This returns the declared consumes information for a module.
+    // Note the other functions above return a reference to an object
+    // that is held in memory throughout the job, while the following
+    // function returns a newly created object each time.  We do not
+    // expect this to be called during a normal production job where
+    // performance and memory are important. These objects are bigger
+    // than just a pointer.
+    std::vector<ConsumesInfo> consumesInfo(unsigned int moduleID) const {
+      return doConsumesInfo(moduleID);
+    }
+
+  private:
+
+    virtual std::vector<std::string> const& doPaths() const = 0;
+    virtual std::vector<std::string> const& doEndPaths() const = 0;
+    virtual std::vector<ModuleDescription const*> const& doAllModules() const = 0;
+    virtual ModuleDescription const* doModuleDescription(unsigned int moduleID) const = 0;
+    virtual std::vector<ModuleDescription const*> const& doModulesOnPath(unsigned int pathIndex) const = 0;
+    virtual std::vector<ModuleDescription const*> const& doModulesOnEndPath(unsigned int endPathIndex) const = 0;
+    virtual std::vector<ModuleDescription const*> const& doModulesWhoseProductsAreConsumedBy(unsigned int moduleID) const = 0;
+    virtual std::vector<ConsumesInfo> doConsumesInfo(unsigned int moduleID) const = 0;
+  };
+}
+#endif

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -130,6 +130,8 @@ namespace edm {
   void
   ActivityRegistry::connectLocals(ActivityRegistry& iOther) {
 
+     preBeginJobSignal_.connect(std::cref(iOther.preBeginJobSignal_));
+
      preModuleBeginStreamSignal_.connect(std::cref(iOther.preModuleBeginStreamSignal_));
      postModuleBeginStreamSignal_.connect(std::cref(iOther.postModuleBeginStreamSignal_));
 
@@ -267,6 +269,7 @@ namespace edm {
   void
   ActivityRegistry::copySlotsFrom(ActivityRegistry& iOther) {
     copySlotsToFrom(preallocateSignal_,iOther.preallocateSignal_);
+    copySlotsToFrom(preBeginJobSignal_, iOther.preBeginJobSignal_);
     copySlotsToFrom(postBeginJobSignal_, iOther.postBeginJobSignal_);
     copySlotsToFromReverse(postEndJobSignal_, iOther.postEndJobSignal_);
 

--- a/FWCore/ServiceRegistry/src/ConsumesInfo.cc
+++ b/FWCore/ServiceRegistry/src/ConsumesInfo.cc
@@ -1,0 +1,22 @@
+#include "FWCore/ServiceRegistry/interface/ConsumesInfo.h"
+
+namespace edm {
+
+  ConsumesInfo::ConsumesInfo(TypeID const& iType,
+                             char const* iLabel,
+                             char const* iInstance,
+                             char const* iProcess,
+                             BranchType iBranchType,
+                             KindOfType iKindOfType,
+                             bool iAlwaysGets,
+                             bool iSkipCurrentProcess_) :
+    type_(iType),
+    label_(iLabel),
+    instance_(iInstance),
+    process_(iProcess),
+    branchType_(iBranchType),
+    kindOfType_(iKindOfType),
+    alwaysGets_(iAlwaysGets),
+    skipCurrentProcess_(iSkipCurrentProcess_) {
+  }
+}

--- a/FWCore/ServiceRegistry/src/PathsAndConsumesOfModulesBase.cc
+++ b/FWCore/ServiceRegistry/src/PathsAndConsumesOfModulesBase.cc
@@ -1,0 +1,7 @@
+#include "FWCore/ServiceRegistry/interface/PathsAndConsumesOfModulesBase.h"
+
+namespace edm {
+
+  PathsAndConsumesOfModulesBase::~PathsAndConsumesOfModulesBase() {
+  }
+}

--- a/FWCore/Services/src/Tracer.h
+++ b/FWCore/Services/src/Tracer.h
@@ -38,6 +38,8 @@ namespace edm {
    class ModuleCallingContext;
    class ModuleDescription;
    class PathContext;
+   class PathsAndConsumesOfModulesBase;
+   class ProcessContext;
    class Run;
    class StreamContext;
 
@@ -50,6 +52,7 @@ namespace edm {
 
          void preallocate(service::SystemBounds const&);
 
+         void preBeginJob(PathsAndConsumesOfModulesBase const&, ProcessContext const&);
          void postBeginJob();
          void postEndJob();
          
@@ -145,6 +148,7 @@ namespace edm {
          std::string indention_;
          std::set<std::string> dumpContextForLabels_;
          bool dumpNonModuleContext_;
+         bool dumpPathsAndConsumes_;
          bool printTimestamps_;
       };
    }


### PR DESCRIPTION
Add new callback that services can register for
that will deliver information about the paths,
end paths, and modules on them. It will also deliver
information about the dependencies between modules
in the current process based on the consumes information.
It also makes available the information in the
consumes declarations. Also includes a new configuration
option to the Tracer that will dump this information
and the Tracer code is an example of how a service
accesses this information. New and expanded unit
tests included.
