### PR TITLE
New Run1 simulation GT for HCAL response corrections.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V1::All',
+    'run1_design'       :   'DESRUN1_73_V2::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V1::All',
+    'run1_mc'           :   'MCRUN1_73_V2::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V1::All',
+    'run1_mc_hi'        :   'MCHI1_73_V2::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V1::All',
+    'run1_mc_pa'        :   'MCPA1_73_V2::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   'DESRUN2_73_V3::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,13 +2,13 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V1',
+    'run1_design'       :   'DESRUN1_73_V2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V1',
+    'run1_mc'           :   'MCRUN1_73_V2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V1',
+    'run1_mc_hi'        :   'MCHI1_73_V2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V1',
+    'run1_mc_pa'        :   'MCPA1_73_V2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
     'run2_design'       :   'DESRUN2_73_V3',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2


### PR DESCRIPTION
New Global Tags for Run1 simulations (ideal, pp, HI, pPb) with the following change:
- updating HCal response corrections restoring the energy scale in HB and HE after introduction of TimeSlew simulation (DIGI) + Method 2 (RECO).

Given that the Method 2 will be used in all reconstruction scenarios, this synchronises the conditions to the reconstruction setup. The OOT PU corrections in Run1 GT being different than Run2 is not an issue: they were consumed by Method 1 (while method 2 does not require any new condition input), so they are now deprecated. As soon as method 1 will be dismissed, we will remove them: so please keep us informed about this change.
See the discussion in #6642 for more details
