### PR TITLE
add gridpack run script which untars tarball directly from cvmfs

### DIFF
--- a/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
+++ b/GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+#script to run generic lhe generation tarballs
+#kept as simply as possible to minimize need
+#to update the cmssw release
+#(all the logic goes in the run script inside the tarball
+# on frontier)
+#J.Bendavid
+
+echo "   ______________________________________     "
+echo "         Running Generic Tarball/Gridpack     "
+echo "   ______________________________________     "
+
+path=${1}
+echo "gridpack tarball path = $path"
+
+nevt=${2}
+echo "%MSG-MG5 number of events requested = $nevt"
+
+rnum=${3}
+echo "%MSG-MG5 random seed used for the run = $rnum"
+
+LHEWORKDIR=`pwd`
+
+if [[ -d lheevent ]]
+    then
+    echo 'lheevent directory found'
+    echo 'Setting up the environment'
+    rm -rf lheevent
+fi
+mkdir lheevent; cd lheevent
+
+#untar the tarball directly from cvmfs
+tar -xaf ${path} 
+
+#generate events (call for 1 core always for now until hooks to set number of cores are implemented upstream)
+./runcmsgrid.sh $nevt $rnum 1
+
+mv cmsgrid_final.lhe $LHEWORKDIR/
+
+cd $LHEWORKDIR
+
+#cleanup working directory (save space on worker node for edm output)
+rm -rf lheevent
+
+exit 0
+


### PR DESCRIPTION
Only change needed in CMSSW to migrate gridpacks to cvmfs.
