### PR TITLE
Fix duplicate definitions in ROOT macros

### DIFF
--- a/DataFormats/FWLite/test/runlumi_looping_cint.C
+++ b/DataFormats/FWLite/test/runlumi_looping_cint.C
@@ -43,8 +43,8 @@ void runlumi_looping_cint()
         returnValue = 1;
     }
 
-    int i =0;
-    int returnValue = 0;
+    i =0;
+    returnValue = 0;
     for( ;l.isValid();++l,++i) {
         cout << l.id().run() << " " << l.id().luminosityBlock() << endl;
         fwlite::Handle<vector<edmtest::Thing> > pThing;

--- a/DataFormats/FWLite/test/triggerResultsByName_cint.C
+++ b/DataFormats/FWLite/test/triggerResultsByName_cint.C
@@ -43,7 +43,7 @@ void triggerResultsByName_cint()
 
     // Try again, but this time test what happens when the process does not
     // exist, the object should not be valid
-    edm::TriggerResultsByName resultsByName = ev.triggerResultsByName("DOESNOTEXIST");
+    resultsByName = ev.triggerResultsByName("DOESNOTEXIST");
     if (resultsByName.isValid()) {
       std::cout << "From TriggerResultsByName, accept = "
                 << resultsByName.accept("p") << "\n";

--- a/DataFormats/FWLite/test/triggerResultsByName_multi_cint.C
+++ b/DataFormats/FWLite/test/triggerResultsByName_multi_cint.C
@@ -45,7 +45,7 @@ void triggerResultsByName_multi_cint()
 
     // Try again, but this time test what happens when the process does not
     // exist, the object should not be valid
-    edm::TriggerResultsByName resultsByName = ev.triggerResultsByName("DOESNOTEXIST");
+    resultsByName = ev.triggerResultsByName("DOESNOTEXIST");
     if (resultsByName.isValid()) {
       std::cout << "From TriggerResultsByName, accept = "
                 << resultsByName.accept("p") << "\n";


### PR DESCRIPTION
This pull request affects only unit tests, and only those in packge DataFormats/FWLite.
The unit tests fails in ROOT6 (among other reasons) due to duplicate definitions of variables.  In ROOT5, the tests do not fail, because CINT, unlike cling, is not a real compiler, and is permissive of these errors.
This pull request fixes the macros so that each variable is defined only once.
Please merge this request as soon as convenient.
