### PR TITLE
Remove use of Cintex in ROOT6 macros

### DIFF
--- a/CommonTools/ParticleFlow/test/Macros/isolation.C
+++ b/CommonTools/ParticleFlow/test/Macros/isolation.C
@@ -3,8 +3,6 @@
 
 gSystem->Load("libFWCoreFWLite.so");
 AutoLibraryLoader::enable();
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 TFile f("testPFPAT.root");
 
 Events.Draw("recoIsolatedPFCandidates_pfPionsIsolation__PFPAT.obj.isolation_>>h2");

--- a/CommonTools/ParticleFlow/test/Macros/plotVertex.py
+++ b/CommonTools/ParticleFlow/test/Macros/plotVertex.py
@@ -8,8 +8,6 @@ def loadFWLite():
     gSystem.Load("libFWCoreFWLite")
     gROOT.ProcessLine('AutoLibraryLoader::enable();')
     gSystem.Load("libFWCoreFWLite")
-    gSystem.Load("libCintex")
-    gROOT.ProcessLine('ROOT::Cintex::Cintex::Enable();')
 
 
 

--- a/CommonTools/ParticleFlow/test/Macros/ptJets.C
+++ b/CommonTools/ParticleFlow/test/Macros/ptJets.C
@@ -3,8 +3,6 @@
 
   gSystem->Load("libFWCoreFWLite.so");
   AutoLibraryLoader::enable();
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
   TFile f("patTuple_PF2PAT.root");
   
   Events.Draw("patJets_selectedPatJets__PAT.obj.pt()>>h1");

--- a/CommonTools/ParticleFlow/test/Macros/ptMus.C
+++ b/CommonTools/ParticleFlow/test/Macros/ptMus.C
@@ -3,8 +3,6 @@
 
   gSystem->Load("libFWCoreFWLite.so");
   AutoLibraryLoader::enable();
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
   TFile f("patTuple_PF2PAT.root");
   
   Events.Draw("patMuons_selectedPatMuons__PAT.obj.pt()>>h1");

--- a/CommonTools/ParticleFlow/test/Macros/rootlogon.C
+++ b/CommonTools/ParticleFlow/test/Macros/rootlogon.C
@@ -10,8 +10,6 @@ void rootlogon() {
 void loadFWLite() {
   gSystem->Load("libFWCoreFWLite.so");
   AutoLibraryLoader::enable();
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
 }
 
 void initAOD(const char* process) {

--- a/CommonTools/ParticleFlow/test/Macros/testMuonTopProjection.C
+++ b/CommonTools/ParticleFlow/test/Macros/testMuonTopProjection.C
@@ -2,8 +2,6 @@
 
   gSystem->Load("libFWCoreFWLite.so");
   AutoLibraryLoader::enable();
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
 
   TFile fDisabled("tpDisabled.root");
   TTree *tDisabled = (TTree*) fDisabled.Get("Events");

--- a/DataFormats/ParticleFlowReco/test/init.C
+++ b/DataFormats/ParticleFlowReco/test/init.C
@@ -4,7 +4,5 @@
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libDataFormatsParticleFlowReco.so");
 AutoLibraryLoader::enable();
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 
 }

--- a/FastSimulation/MaterialEffects/test/init.C
+++ b/FastSimulation/MaterialEffects/test/init.C
@@ -5,7 +5,5 @@
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libFastSimulationMaterialEffects.so");
 AutoLibraryLoader::enable();
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 
 }

--- a/PhysicsTools/Heppy/python/loadlibs.py
+++ b/PhysicsTools/Heppy/python/loadlibs.py
@@ -6,8 +6,6 @@ def load_libs():
     gSystem.Load("libFWCoreFWLite")
     gROOT.ProcessLine('AutoLibraryLoader::enable();')
     gSystem.Load("libFWCoreFWLite")
-    gSystem.Load("libCintex")
-    gROOT.ProcessLine('ROOT::Cintex::Cintex::Enable();')
         
     #now the RootTools stuff
     gSystem.Load("libPhysicsToolsHeppy")

--- a/PhysicsTools/MVAComputer/test/rootlogon.C
+++ b/PhysicsTools/MVAComputer/test/rootlogon.C
@@ -1,7 +1,5 @@
 void rootlogon()
 {
-	gSystem->Load("libCintex");
 	gSystem->Load("libPhysicsToolsMVAComputer");
 	gSystem->Load("libPhysicsToolsMVATrainer");
-	Cintex::Enable();
 }

--- a/PhysicsTools/MVATrainer/test/rootlogon.C
+++ b/PhysicsTools/MVATrainer/test/rootlogon.C
@@ -1,7 +1,5 @@
 void rootlogon()
 {
-	gSystem->Load("libCintex");
 	gSystem->Load("libPhysicsToolsMVAComputer");
 	gSystem->Load("libPhysicsToolsMVATrainer");
-	Cintex::Enable();
 }

--- a/RecoMuon/MuonIdentification/test/rootlogon.C
+++ b/RecoMuon/MuonIdentification/test/rootlogon.C
@@ -1,8 +1,6 @@
 {
    gROOT->SetStyle("Plain");
    cout << "loading..." <<endl;
-   gSystem->Load("libCintex");
-   Cintex::Enable();
    gSystem->Load("libFWCoreFWLite");
    AutoLibraryLoader::enable();
    gSystem->Load("libRooFit.so");

--- a/RecoParticleFlow/PFClusterProducer/test/init.C
+++ b/RecoParticleFlow/PFClusterProducer/test/init.C
@@ -2,7 +2,5 @@
 
 gSystem->Load("libFWCoreFWLite.so");
 AutoLibraryLoader::enable();
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 
 }

--- a/RecoParticleFlow/PFClusterTools/test/src/clusterCalibrate.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/clusterCalibrate.C
@@ -1,6 +1,4 @@
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	using namespace std;

--- a/RecoParticleFlow/PFClusterTools/test/src/clusterCalibrationExample.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/clusterCalibrationExample.C
@@ -1,7 +1,5 @@
 
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 
 	

--- a/RecoParticleFlow/PFClusterTools/test/src/compareCalib.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/compareCalib.C
@@ -1,7 +1,5 @@
 
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	using namespace std;

--- a/RecoParticleFlow/PFClusterTools/test/src/doCalib.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/doCalib.C
@@ -1,7 +1,5 @@
 
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	using namespace std;

--- a/RecoParticleFlow/PFClusterTools/test/src/doCalibTestbeam.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/doCalibTestbeam.C
@@ -1,7 +1,5 @@
 
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	using namespace std;

--- a/RecoParticleFlow/PFClusterTools/test/src/exportCSV.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/exportCSV.C
@@ -1,7 +1,5 @@
 
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	using namespace std;

--- a/RecoParticleFlow/PFClusterTools/test/src/init.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/init.C
@@ -3,8 +3,6 @@
  * 
  */
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	using namespace std;

--- a/RecoParticleFlow/PFClusterTools/test/src/testConversion.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/testConversion.C
@@ -1,6 +1,4 @@
 {
-	gSystem->Load("libCintex.so");
-	Cintex::Enable();
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	//TFile f("singleParticle.root");

--- a/RecoParticleFlow/PFClusterTools/test/src/testWrappers.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/testWrappers.C
@@ -3,10 +3,6 @@
  * 
  */
 {
-	gSystem->Load("libCintex.so");
- 
-	Cintex::Enable();
- 
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	
 	TFile f("TestWrappers.root", "recreate");

--- a/RecoTauTag/TauTagTools/test/trainMVA_template.C
+++ b/RecoTauTag/TauTagTools/test/trainMVA_template.C
@@ -9,12 +9,10 @@ void trainMVA()
              << "Example: if one of the inputs is 'NumberIsolationObjects' and this is always 0, " << endl
              << "(for whatever reason), this error will occur." << endl;
 
-	gSystem->Load("libCintex");
 	gSystem->Load("libPhysicsToolsMVAComputer");
 	gSystem->Load("libPhysicsToolsMVATrainer");
         gSystem->Load("pluginPhysicsToolsMVATrainerProcTMVA");
         gSystem->Load("pluginPhysicsToolsMVAComputerProcTMVA");
-	Cintex::Enable();
 
         using namespace PhysicsTools;
 

--- a/RecoTracker/TrackProducer/test/analyze_tracks.C
+++ b/RecoTracker/TrackProducer/test/analyze_tracks.C
@@ -1,6 +1,4 @@
 {
-gSystem->Load("libCintex");
-Cintex::Enable();
 gSystem->Load("libFWCoreFWLite.so");
 AutoLibraryLoader::enable();
 /////////SET THESE VALUES///////////////

--- a/TrackingTools/TrackAssociator/test/rootlogon.C
+++ b/TrackingTools/TrackAssociator/test/rootlogon.C
@@ -1,8 +1,6 @@
 {
    gROOT->SetStyle("Plain");
    cout << "loading..." <<endl;
-   gSystem->Load("libCintex");
-   Cintex::Enable();
    gSystem->Load("libFWCoreFWLite");
    AutoLibraryLoader::enable();
    gSystem->Load("libRooFit.so");

--- a/Validation/EcalHits/test/rootlogon.C
+++ b/Validation/EcalHits/test/rootlogon.C
@@ -1,6 +1,4 @@
 {
-gSystem->Load("libCintex");
-Cintex::Enable();
 cout << "Loading FWLite..." << endl;
 gSystem->Load("libFWCoreFWLite");
 AutoLibraryLoader::enable();

--- a/Validation/GlobalDigis/test/rootlogon.C
+++ b/Validation/GlobalDigis/test/rootlogon.C
@@ -1,6 +1,4 @@
 {
-gSystem->Load("libCintex");
-Cintex::Enable();
 cout << "Loading FWLite..." << endl;    // load CMSSW libraries
 gSystem->Load("libFWCoreFWLite");
 AutoLibraryLoader::enable();

--- a/Validation/GlobalHits/test/rootlogon.C
+++ b/Validation/GlobalHits/test/rootlogon.C
@@ -1,6 +1,4 @@
 {
-gSystem->Load("libCintex");
-Cintex::Enable();
 cout << "Loading FWLite..." << endl;    // load CMSSW libraries
 gSystem->Load("libFWCoreFWLite");
 AutoLibraryLoader::enable();

--- a/Validation/GlobalRecHits/test/rootlogon.C
+++ b/Validation/GlobalRecHits/test/rootlogon.C
@@ -1,6 +1,4 @@
 {
-gSystem->Load("libCintex");
-Cintex::Enable();
 cout << "Loading FWLite..." << endl;    // load CMSSW libraries
 gSystem->Load("libFWCoreFWLite");
 AutoLibraryLoader::enable();

--- a/Validation/MuonIdentification/test/rootlogon.C
+++ b/Validation/MuonIdentification/test/rootlogon.C
@@ -1,8 +1,6 @@
 {
    gROOT->SetStyle("Plain");
    cout << "loading..." <<endl;
-   gSystem->Load("libCintex");
-   Cintex::Enable();
    gSystem->Load("libFWCoreFWLite");
    AutoLibraryLoader::enable();
    gSystem->Load("libRooFit.so");

--- a/Validation/RecoParticleFlow/Benchmarks/ElectronBenchmarkGeneric/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/ElectronBenchmarkGeneric/plot.C
@@ -1,8 +1,6 @@
 {
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libValidationRecoParticleFlow.so");
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 
 //gROOT->LoadMacro("../Tools/NicePlot.C");
 //InitNicePlot();

--- a/Validation/RecoParticleFlow/Benchmarks/ElectronRejectionBenchmark/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/ElectronRejectionBenchmark/plot.C
@@ -1,8 +1,6 @@
 {
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libValidationRecoParticleFlow.so");
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 
 //gROOT->LoadMacro("../Tools/NicePlot.C");
 //InitNicePlot();

--- a/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/Fractions.C
+++ b/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/Fractions.C
@@ -29,8 +29,6 @@ void Fractions(const char* fileFast, const char* fileFull)
 
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libValidationRecoParticleFlow.so");
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 //gROOT->LoadMacro("../Tools/NicePlot.C");
 //InitNicePlot();
 

--- a/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/TrackMult.C
+++ b/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/TrackMult.C
@@ -25,8 +25,6 @@ void TrackMult(const char* fileFast, const char* fileFull)
 
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libValidationRecoParticleFlow.so");
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 //gROOT->LoadMacro("../Tools/NicePlot.C");
 //InitNicePlot();
 

--- a/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/plot.C
@@ -1,8 +1,6 @@
 {
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libValidationRecoParticleFlow.so");
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 
 //gROOT->LoadMacro("../Tools/NicePlot.C");
 //InitNicePlot();

--- a/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/compare.C
+++ b/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/compare.C
@@ -1,8 +1,6 @@
 {
   gSystem->Load("libFWCoreFWLite.so");
   gSystem->Load("libValidationRecoParticleFlow.so");
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
 
   gStyle->SetOptStat(1111);
 

--- a/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot.C
@@ -1,8 +1,6 @@
 {
   gSystem->Load("libFWCoreFWLite.so");
   gSystem->Load("libValidationRecoParticleFlow.so");
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
 
   gStyle->SetOptStat(1111);
 

--- a/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot_QCD.C
+++ b/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot_QCD.C
@@ -1,8 +1,6 @@
 {
   gSystem->Load("libFWCoreFWLite.so");
   gSystem->Load("libValidationRecoParticleFlow.so");
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
 
 //gStyle->SetOptStat(1111);
 

--- a/Validation/RecoParticleFlow/Benchmarks/PFCandidateBenchmark/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/PFCandidateBenchmark/plot.C
@@ -1,8 +1,6 @@
 {
   gSystem->Load("libFWCoreFWLite.so");
   gSystem->Load("libValidationRecoParticleFlow.so");
-  gSystem->Load("libCintex.so");
-  ROOT::Cintex::Cintex::Enable();
 
   gStyle->SetOptStat(1111);
 

--- a/Validation/RecoParticleFlow/test/testTH2Analyzer.C
+++ b/Validation/RecoParticleFlow/test/testTH2Analyzer.C
@@ -1,8 +1,6 @@
 {
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libValidationRecoParticleFlow.so");
-gSystem->Load("libCintex.so");
-ROOT::Cintex::Cintex::Enable();
 
 TF2 gaus2("gaus2", "[0]*exp(-0.5*((x-[1])/[2])**2)*exp(-0.5*((y-[3])/[4])**2)",0,10,0,10);
 gaus2.SetParameters( 100, 5, 5, 2, 2);

--- a/Validation/TrackerHits/test/rootlogon.C
+++ b/Validation/TrackerHits/test/rootlogon.C
@@ -1,6 +1,4 @@
 {
-gSystem->Load("libCintex");
-Cintex::Enable();
 cout << "Loading FWLite..." << endl;
 gSystem->Load("libFWCoreFWLite");
 AutoLibraryLoader::enable();


### PR DESCRIPTION
Cintex does not exist in ROOT6.  This pull request removes the loading of libCintex.so and the enabling of Cintex from ROOT macros in the ROOT6 IB, since libCintex.so does not exist in ROOT6.  The use of Cintex had previously been removed from other C++ code, but not from ROOT macros.
Please merge this request as soon as convenient.
