### PR TITLE
Update to the AlphaT HLT Filter 73X

### DIFF
--- a/HLTrigger/JetMET/interface/AlphaT.h
+++ b/HLTrigger/JetMET/interface/AlphaT.h
@@ -9,10 +9,10 @@
 class AlphaT {
 public:
   template <class T>
-  AlphaT(std::vector<T const *> const & p4, bool use_et = true);
+  AlphaT(std::vector<T const *> const & p4, bool setDHtZero = false , bool use_et = true);
 
   template <class T>
-  AlphaT(std::vector<T> const & p4, bool use_et = true);
+  AlphaT(std::vector<T> const & p4, bool setDHtZero = false, bool use_et = true);
 
 private:
   std::vector<double> et_;
@@ -25,23 +25,26 @@ public:
 
 private:
   double value_(std::vector<bool> * jet_sign) const;
+  bool setDHtZero_;
 };
 
 
 // -----------------------------------------------------------------------------
 template<class T>
-AlphaT::AlphaT(std::vector<T const *> const & p4, bool use_et /* = true */) {
+AlphaT::AlphaT(std::vector<T const *> const & p4, bool setDHtZero, bool use_et /* = true */) {
   std::transform( p4.begin(), p4.end(), back_inserter(et_), ( use_et ? std::mem_fun(&T::Et) : std::mem_fun(&T::Pt) ) );
   std::transform( p4.begin(), p4.end(), back_inserter(px_), std::mem_fun(&T::Px) );
   std::transform( p4.begin(), p4.end(), back_inserter(py_), std::mem_fun(&T::Py) );
+  setDHtZero_ = setDHtZero;
 }
 
 // -----------------------------------------------------------------------------
 template<class T>
-AlphaT::AlphaT(std::vector<T> const & p4, bool use_et /* = true */) {
+AlphaT::AlphaT(std::vector<T> const & p4, bool setDHtZero, bool use_et /* = true */) {
   std::transform( p4.begin(), p4.end(), back_inserter(et_), std::mem_fun_ref( use_et ? &T::Et : &T::Pt ) );
   std::transform( p4.begin(), p4.end(), back_inserter(px_), std::mem_fun_ref(&T::Px) );
   std::transform( p4.begin(), p4.end(), back_inserter(py_), std::mem_fun_ref(&T::Py) );
+  setDHtZero_ = setDHtZero;
 }
 
 

--- a/HLTrigger/JetMET/interface/HLTAlphaTFilter.h
+++ b/HLTrigger/JetMET/interface/HLTAlphaTFilter.h
@@ -46,6 +46,7 @@ class HLTAlphaTFilter : public HLTFilter {
       double minAlphaT_;
       int triggerType_;
       bool dynamicAlphaT_;
+      bool setDHtZero_;
 };
 
 #endif // HLTrigger_JetMET_HLTAlphaTFilter_h

--- a/HLTrigger/JetMET/src/AlphaT.cc
+++ b/HLTrigger/JetMET/src/AlphaT.cc
@@ -15,7 +15,7 @@ double AlphaT::value_(std::vector<bool> * jet_sign) const {
 
   if (et_.size() > (unsigned int) std::numeric_limits<unsigned int>::digits)
     // too many jets, return AlphaT = a very large number
-    return std::numeric_limits<double>::max();
+    return std::numeric_limits<double>::max(); 
 
   // Momentum sums in transverse plane
   const double sum_et = std::accumulate( et_.begin(), et_.end(), 0. );

--- a/HLTrigger/JetMET/src/AlphaT.cc
+++ b/HLTrigger/JetMET/src/AlphaT.cc
@@ -25,24 +25,27 @@ double AlphaT::value_(std::vector<bool> * jet_sign) const {
   // Minimum Delta Et for two pseudo-jets
   double min_delta_sum_et = sum_et;
 
-  for (unsigned int i = 0; i < (1U << (et_.size() - 1)); i++) { //@@ iterate through different combinations
-    double delta_sum_et = 0.;
-    for (unsigned int j = 0; j < et_.size(); ++j) { //@@ iterate through jets
-      if (i & (1U << j))
-        delta_sum_et -= et_[j];
-      else
-        delta_sum_et += et_[j];
-    }
-    delta_sum_et = std::abs(delta_sum_et);
-    if (delta_sum_et < min_delta_sum_et) {
-      min_delta_sum_et = delta_sum_et;
-      if (jet_sign) {
-        for (unsigned int j = 0; j < et_.size(); ++j)
-          (*jet_sign)[j] = ((i & (1U << j)) == 0);
+  if(setDHtZero_){
+    min_delta_sum_et = 0.;
+  }else{
+    for (unsigned int i = 0; i < (1U << (et_.size() - 1)); i++) { //@@ iterate through different combinations
+      double delta_sum_et = 0.;
+      for (unsigned int j = 0; j < et_.size(); ++j) { //@@ iterate through jets
+        if (i & (1U << j))
+          delta_sum_et -= et_[j];
+        else
+          delta_sum_et += et_[j];
+      }
+      delta_sum_et = std::abs(delta_sum_et);
+      if (delta_sum_et < min_delta_sum_et) {
+        min_delta_sum_et = delta_sum_et;
+        if (jet_sign) {
+          for (unsigned int j = 0; j < et_.size(); ++j)
+            (*jet_sign)[j] = ((i & (1U << j)) == 0);
+        }
       }
     }
   }
-
   // Alpha_T
   return (0.5 * (sum_et - min_delta_sum_et) / sqrt( sum_et*sum_et - (sum_px*sum_px+sum_py*sum_py) ));  
 }

--- a/HLTrigger/JetMET/src/AlphaT.cc
+++ b/HLTrigger/JetMET/src/AlphaT.cc
@@ -25,6 +25,7 @@ double AlphaT::value_(std::vector<bool> * jet_sign) const {
   // Minimum Delta Et for two pseudo-jets
   double min_delta_sum_et = sum_et;
 
+  //If you want to turn off DHT
   if(setDHtZero_){
     min_delta_sum_et = 0.;
   }else{

--- a/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
+++ b/HLTrigger/JetMET/src/HLTAlphaTFilter.cc
@@ -42,6 +42,7 @@ HLTAlphaTFilter<T>::HLTAlphaTFilter(const edm::ParameterSet& iConfig) : HLTFilte
   minAlphaT_           = iConfig.getParameter<double> ("minAlphaT");
   triggerType_         = iConfig.getParameter<int>("triggerType");
   dynamicAlphaT_       = iConfig.getParameter<bool>("dynamicAlphaT");
+  setDHtZero_          = iConfig.getParameter<bool>("setDHtZero");
   // sanity checks
 
   if (       (minPtJet_.size()    !=  etaJet_.size())
@@ -86,6 +87,7 @@ void HLTAlphaTFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descri
   desc.add<double>("minAlphaT",0.0);
   desc.add<int>("triggerType",trigger::TriggerJet);
   desc.add<bool>("dynamicAlphaT",true); //Set to reproduce old behaviour
+  desc.add<bool>("setDHtZero",false); //Set to reproduce old behaviour
   descriptions.add(std::string("hlt")+std::string(typeid(HLTAlphaTFilter<T>).name()),desc);
 }
 
@@ -164,7 +166,7 @@ bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
           // Add to JetVector
           LorentzV JetLVec(ijet->pt(),ijet->eta(),ijet->phi(),ijet->mass());
           jets.push_back( JetLVec );
-          aT = AlphaT(jets).value();
+          aT = AlphaT(jets,setDHtZero_).value();
           if(htFast > minHt_ && aT > minAlphaT_){
             // set flat to one so that we don't carry on looping though the jets
             flag = 1;
@@ -237,7 +239,7 @@ bool HLTAlphaTFilter<T>::hltFilter(edm::Event& iEvent, const edm::EventSetup& iS
 
         if(flag!=1){ //Added for efficiency
           //Calculate the value for alphaT
-          float aT = AlphaT(jets).value();
+          float aT = AlphaT(jets,setDHtZero_).value();
 
           // Trigger decision!
           if(aT > minAlphaT_){


### PR DESCRIPTION
Added a configurable to the alphaT analysis HLT filter that allows deltaHT (used in the calculation of AlphaT) to be set to zero. This was found to improve HLT performance
Added a new option setDPhiZero, that is defaulted to reproduce old behaviour
