### PR TITLE
Update to the alphaT HLT DQM 73X

### DIFF
--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
@@ -54,9 +54,7 @@ class SUSY_HLT_alphaT: public DQMEDAnalyzer{
   void bookHistos(DQMStore::IBooker &);
   
   //variables from config file
-  //edm::EDGetTokenT<reco::PFMETCollection> thePfMETCollection_;
-  edm::EDGetTokenT<reco::CaloMETCollection> theCaloMETCollection_;
-  //edm::EDGetTokenT<reco::PFJetCollection> thePfJetCollection_;
+  edm::EDGetTokenT<reco::PFJetCollection> thePfJetCollection_;
   edm::EDGetTokenT<reco::CaloJetCollection> theCaloJetCollection_;
   edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
   edm::EDGetTokenT<trigger::TriggerEvent> theTrigSummary_;
@@ -68,22 +66,31 @@ class SUSY_HLT_alphaT: public DQMEDAnalyzer{
   std::string triggerPath_;
   std::string triggerPathAuxiliaryForMuon_;
   std::string triggerPathAuxiliaryForHadronic_;
+  edm::InputTag triggerPreFilter_;
   edm::InputTag triggerFilter_;
   double ptThrJet_;
   double etaThrJet_;
-  double alphaTThrTurnon_;
-  double htThrTurnon_;
+  double pfAlphaTThrTurnon_;
+  double pfHtThrTurnon_;
+  double caloAlphaTThrTurnon_;
+  double caloHtThrTurnon_;
   
   // Histograms
-  MonitorElement* h_triggerHt;
-  //MonitorElement* h_triggerMht;
-  MonitorElement* h_triggerAlphaT;
-  MonitorElement* h_triggerAlphaT_triggerHt;
-  MonitorElement* h_alphaTTurnOn_num;
-  MonitorElement* h_alphaTTurnOn_den;
-  MonitorElement* h_htTurnOn_num;
-  MonitorElement* h_htTurnOn_den;
+  MonitorElement* h_triggerCaloHt;
+  MonitorElement* h_triggerCaloAlphaT;
+  MonitorElement* h_triggerCaloAlphaT_triggerCaloHt;
+  MonitorElement* h_caloAlphaTTurnOn_num;
+  MonitorElement* h_caloAlphaTTurnOn_den;
+  MonitorElement* h_caloHtTurnOn_num;
+  MonitorElement* h_caloHtTurnOn_den;
 
+  MonitorElement* h_triggerPfHt;
+  MonitorElement* h_triggerPfAlphaT;
+  MonitorElement* h_triggerPfAlphaT_triggerPfHt;
+  MonitorElement* h_pfAlphaTTurnOn_num;
+  MonitorElement* h_pfAlphaTTurnOn_den;
+  MonitorElement* h_pfHtTurnOn_num;
+  MonitorElement* h_pfHtTurnOn_den;
 };
 
 #endif

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
@@ -2,111 +2,108 @@ import FWCore.ParameterSet.Config as cms
 
 SUSY_HLT_HT200_alphaT0p57 = cms.EDAnalyzer("SUSY_HLT_alphaT",
   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
-  #trigSummary = cms.InputTag("hltTriggerSummaryAOD"),
-  #pfMETCollection = cms.InputTag("pfMet"),
   caloJetCollection = cms.InputTag("ak4CaloJets"),
-  #caloJetCollection = cms.InputTag("hltAK4CaloJets"),
-  #pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
-  #TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
-  TriggerPath = cms.string('HLT_HT200_DiJet90_AlphaT0p57_v'),
-  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoTkMu24_eta2p1_IterTrk02_v'),
-  TriggerFilter = cms.InputTag('hltHT200CaloAlphaT0p57', '', 'HLT'), #the last filter in the path
+  TriggerPath = cms.string('HLT_PFHT200_PFDiJet90_PFAlphaT0p57_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT150CaloAlphaT0p54', '', 'HLT'),
+  TriggerFilter = cms.InputTag('hltHT200PFAlphaT0p57', '', 'HLT'),
   PtThrJet = cms.untracked.double(40.0),
   EtaThrJet = cms.untracked.double(3.0),
-  alphaTThrTurnon = cms.untracked.double(0.59),
-  htThrTurnon = cms.untracked.double(225),
+  pfAlphaTThrTurnon = cms.untracked.double(0.59),
+  pfHtThrTurnon = cms.untracked.double(225),
+  caloAlphaTThrTurnon = cms.untracked.double(0.57),
+  caloHtThrTurnon = cms.untracked.double(200),
 )
 
 SUSY_HLT_HT250_alphaT0p55 = cms.EDAnalyzer("SUSY_HLT_alphaT",
   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
-  #trigSummary = cms.InputTag("hltTriggerSummaryAOD"),
-  #pfMETCollection = cms.InputTag("pfMet"),
-  #pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
   caloJetCollection = cms.InputTag("ak4CaloJets"),
-  #caloJetCollection = cms.InputTag("hltAK4CaloJets"),
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
-  #TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
-  TriggerPath = cms.string('HLT_HT250_DiJet90_AlphaT0p55_v'),
-  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoTkMu24_eta2p1_IterTrk02_v'),
-  TriggerFilter = cms.InputTag('hltHT250CaloAlphaT0p55', '', 'HLT'), #the last filter in the path
+  TriggerPath = cms.string('HLT_PFHT250_PFDiJet90_PFAlphaT0p55_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT200CaloAlphaT0p535', '', 'HLT'),
+  TriggerFilter = cms.InputTag('hltHT250PFAlphaT0p55', '', 'HLT'),
   PtThrJet = cms.untracked.double(40.0),
   EtaThrJet = cms.untracked.double(3.0),
-  alphaTThrTurnon = cms.untracked.double(0.57),
-  htThrTurnon = cms.untracked.double(275),
+  pfAlphaTThrTurnon = cms.untracked.double(0.57),
+  pfHtThrTurnon = cms.untracked.double(275),
+  caloAlphaTThrTurnon = cms.untracked.double(0.55),
+  caloHtThrTurnon = cms.untracked.double(200),
 )
 
 SUSY_HLT_HT300_alphaT0p53 = cms.EDAnalyzer("SUSY_HLT_alphaT",
   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
-  #trigSummary = cms.InputTag("hltTriggerSummaryAOD"),
-  #pfMETCollection = cms.InputTag("pfMet"),
-  #pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
   caloJetCollection = cms.InputTag("ak4CaloJets"),
-  #caloJetCollection = cms.InputTag("hltAK4CaloJets"),
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
-  #TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
-  TriggerPath = cms.string('HLT_HT300_DiJet90_AlphaT0p53_v'),
-  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoTkMu24_eta2p1_IterTrk02_v'),
-  TriggerFilter = cms.InputTag('hltHT300CaloAlphaT0p53', '', 'HLT'), #the last filter in the path
+  TriggerPath = cms.string('HLT_PFHT300_PFDiJet90_PFAlphaT0p53_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT250CaloAlphaT0p525', '', 'HLT'), 
+  TriggerFilter = cms.InputTag('hltHT300PFAlphaT0p53', '', 'HLT'),
   PtThrJet = cms.untracked.double(40.0),
   EtaThrJet = cms.untracked.double(3.0),
-  alphaTThrTurnon = cms.untracked.double(0.55),
-  htThrTurnon = cms.untracked.double(325),
+  pfAlphaTThrTurnon = cms.untracked.double(0.55),
+  pfHtThrTurnon = cms.untracked.double(325),
+  caloAlphaTThrTurnon = cms.untracked.double(0.53),
+  caloHtThrTurnon = cms.untracked.double(300),
 )
 
 SUSY_HLT_HT350_alphaT0p52 = cms.EDAnalyzer("SUSY_HLT_alphaT",
   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
-  #trigSummary = cms.InputTag("hltTriggerSummaryAOD"),
-  #pfMETCollection = cms.InputTag("pfMet"),
-  #pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),#ak4PFJetsCHS
   caloJetCollection = cms.InputTag("ak4CaloJets"),
-  #caloJetCollection = cms.InputTag("hltAK4CaloJets"),
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
-  #TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
-  TriggerPath = cms.string('HLT_HT350_DiJet90_AlphaT0p52_v'),
-  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoTkMu24_eta2p1_IterTrk02_v'),
-  TriggerFilter = cms.InputTag('hltHT350CaloAlphaT0p52', '', 'HLT'), #the last filter in the path
+  TriggerPath = cms.string('HLT_PFHT350_PFDiJet90_PFAlphaT0p52_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT300CaloAlphaT0p52', '', 'HLT'),
+  TriggerFilter = cms.InputTag('hltHT350PFAlphaT0p52', '', 'HLT'),
   PtThrJet = cms.untracked.double(40.0),
   EtaThrJet = cms.untracked.double(3.0),
-  alphaTThrTurnon = cms.untracked.double(0.54),
-  htThrTurnon = cms.untracked.double(375),
+  pfAlphaTThrTurnon = cms.untracked.double(0.54),
+  pfHtThrTurnon = cms.untracked.double(375),
+  caloAlphaTThrTurnon = cms.untracked.double(0.52),
+  caloHtThrTurnon = cms.untracked.double(350),
 )
 
 SUSY_HLT_HT400_alphaT0p51 = cms.EDAnalyzer("SUSY_HLT_alphaT",
   trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
-  #trigSummary = cms.InputTag("hltTriggerSummaryAOD"),
-  #pfMETCollection = cms.InputTag("pfMet"),
-  #pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
   caloJetCollection = cms.InputTag("ak4CaloJets"),
-  #caloJetCollection = cms.InputTag("hltAK4CaloJets"),
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
-  #TriggerResults = cms.InputTag('TriggerResults','','HLT'),
   HLTProcess = cms.string('HLT'),
-  TriggerPath = cms.string('HLT_HT400_DiJet90_AlphaT0p51_v'),
-  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoTkMu24_eta2p1_IterTrk02_v'),
-  TriggerFilter = cms.InputTag('hltHT400CaloAlphaT0p51', '', 'HLT'), #the last filter in the path
+  TriggerPath = cms.string('HLT_PFHT400_PFDiJet90_PFAlphaT0p51_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT375CaloAlphaT0p51', '', 'HLT'),
+  TriggerFilter = cms.InputTag('hltHT400PFAlphaT0p51', '', 'HLT'),
   PtThrJet = cms.untracked.double(40.0),
   EtaThrJet = cms.untracked.double(3.0),
-  alphaTThrTurnon = cms.untracked.double(0.53),
-  htThrTurnon = cms.untracked.double(425),
+  pfAlphaTThrTurnon = cms.untracked.double(0.53),
+  pfHtThrTurnon = cms.untracked.double(425),
+  caloAlphaTThrTurnon = cms.untracked.double(0.51),
+  caloHtThrTurnon = cms.untracked.double(400),
 )
 
 SUSY_HLT_alphaT_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_HT200_DiJet90_AlphaT0p57_v",
-        "HLT/SUSYBSM/HLT_HT250_DiJet90_AlphaT0p55",
-        "HLT/SUSYBSM/HLT_HT300_DiJet90_AlphaT0p53",
-        "HLT/SUSYBSM/HLT_HT350_DiJet90_AlphaT0p52",
-        "HLT/SUSYBSM/HLT_HT400_DiJet90_AlphaT0p51",
+    subDirs        = cms.untracked.vstring("HLT/SUSYBSM/HLT_PFHT200_PFDiJet90_PFAlphaT0p57_v",
+        "HLT/SUSYBSM/HLT_PFHT250_PFDiJet90_PFAlphaT0p55_v",
+        "HLT/SUSYBSM/HLT_PFHT300_PFDiJet90_PFAlphaT0p53_v",
+        "HLT/SUSYBSM/HLT_PFHT350_PFDiJet90_PFAlphaT0p52_v",
+        "HLT/SUSYBSM/HLT_PFHT400_PFDiJet90_PFAlphaT0p51_v",
         ),
     
     verbose        = cms.untracked.uint32(2), # Set to 2 for all messages
     resolution     = cms.vstring(""),
     efficiency     = cms.vstring(
-       "htTurnOn_eff 'Turn-on vs HT; HT (GeV); #epsilon' htTurnOn_num htTurnOn_den",
-       "alphaTTurnOn_eff 'Turn-on vs alpha T; AlphaT (GeV); #epsilon' alphaTTurnOn_num alphaTTurnOn_den",
+       "pfHtTurnOn_eff 'Turn-on vs PF HT; HT (GeV); #epsilon' pfHtTurnOn_num pfHtTurnOn_den",
+       "pfAlphaTTurnOn_eff 'Turn-on vs PF alpha T; AlphaT (GeV); #epsilon' pfAlphaTTurnOn_num pfAlphaTTurnOn_den",
+       "caloHtTurnOn_eff 'Turn-on vs Calo HT; HT (GeV); #epsilon' caloHtTurnOn_num caloHtTurnOn_den",
+       "caloAlphaTTurnOn_eff 'Turn-on vs Calo alpha T; AlphaT (GeV); #epsilon' caloAlphaTTurnOn_num caloAlphaTTurnOn_den",
     )
 )

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_postProcessor_cff.py
@@ -17,6 +17,7 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_DoubleElectron_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_MuEle_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Muon_BJet_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Electron_BJet_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_alphaT_cff import *
 
 
 SusyExoPostVal = cms.Sequence(SUSY_HLT_HT_MET_POSTPROCESSING +
@@ -37,7 +38,8 @@ SusyExoPostVal = cms.Sequence(SUSY_HLT_HT_MET_POSTPROCESSING +
                              SUSY_HLT_HT_DoubleEle_POSTPROCESSING +
                              SUSY_HLT_HT_MuEle_POSTPROCESSING +
                              SUSY_HLT_Muon_BJet_POSTPROCESSING +
-                             SUSY_HLT_Electron_BJet_POSTPROCESSING)
+                             SUSY_HLT_Electron_BJet_POSTPROCESSING +
+                             SUSY_HLT_alphaT_POSTPROCESSING )
 
 
 SusyExoPostVal_fastsim = cms.Sequence(SUSY_HLT_HT_MET_FASTSIM_POSTPROCESSING +

--- a/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
@@ -17,6 +17,7 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_DoubleElectron_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_MuEle_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Muon_BJet_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Electron_BJet_cff import *
+from HLTriggerOffline.SUSYBSM.SUSYBSM_alphaT_cff import *
 
 
 HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
@@ -43,7 +44,13 @@ HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_HT_DoubleEle +
                                 SUSY_HLT_HT_MuEle +
                                 SUSY_HLT_Muon_BJet +
-                                SUSY_HLT_Electron_BJet)
+                                SUSY_HLT_Electron_BJet +
+                                SUSY_HLT_HT200_alphaT0p57 +
+                                SUSY_HLT_HT250_alphaT0p55 +
+                                SUSY_HLT_HT300_alphaT0p53 +
+                                SUSY_HLT_HT350_alphaT0p52 +
+                                SUSY_HLT_HT400_alphaT0p51 
+                                )
 
 
 HLTSusyExoValSeq_FastSim = cms.Sequence(SUSY_HLT_HT_MET_FASTSIM + 

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_alphaT.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_alphaT.cc
@@ -13,20 +13,20 @@ SUSY_HLT_alphaT::SUSY_HLT_alphaT(const edm::ParameterSet& ps)
   edm::LogInfo("SUSY_HLT_alphaT") << "Constructor SUSY_HLT_alphaT::SUSY_HLT_alphaT " << std::endl;
   // Get parameters from configuration file
   theTrigSummary_ = consumes<trigger::TriggerEvent>(ps.getParameter<edm::InputTag>("trigSummary"));
-  //thePfMETCollection_ = consumes<reco::PFMETCollection>(ps.getParameter<edm::InputTag>("pfMETCollection"));
-  //theCaloMETCollection_ = consumes<reco::CaloMETCollection>(ps.getParameter<edm::InputTag>("caloMETCollection"));
-  //thePfJetCollection_ = consumes<reco::PFJetCollection>(ps.getParameter<edm::InputTag>("pfJetCollection"));
+  thePfJetCollection_ = consumes<reco::PFJetCollection>(ps.getParameter<edm::InputTag>("pfJetCollection"));
   theCaloJetCollection_ = consumes<reco::CaloJetCollection>(ps.getParameter<edm::InputTag>("caloJetCollection"));
   triggerResults_ = consumes<edm::TriggerResults>(ps.getParameter<edm::InputTag>("TriggerResults"));
   HLTProcess_ = ps.getParameter<std::string>("HLTProcess");
   triggerPath_ = ps.getParameter<std::string>("TriggerPath");
-  //triggerPathAuxiliaryForMuon_ = ps.getParameter<std::string>("TriggerPathAuxiliaryForMuon");
   triggerPathAuxiliaryForHadronic_ = ps.getParameter<std::string>("TriggerPathAuxiliaryForHadronic");
   triggerFilter_ = ps.getParameter<edm::InputTag>("TriggerFilter");
+  triggerPreFilter_ = ps.getParameter<edm::InputTag>("TriggerPreFilter");
   ptThrJet_ = ps.getUntrackedParameter<double>("PtThrJet");
   etaThrJet_ = ps.getUntrackedParameter<double>("EtaThrJet");
-  alphaTThrTurnon_ = ps.getUntrackedParameter<double>("alphaTThrTurnon");
-  htThrTurnon_ = ps.getUntrackedParameter<double>("htThrTurnon");
+  caloAlphaTThrTurnon_ = ps.getUntrackedParameter<double>("caloAlphaTThrTurnon");
+  caloHtThrTurnon_ = ps.getUntrackedParameter<double>("caloHtThrTurnon");
+  pfAlphaTThrTurnon_ = ps.getUntrackedParameter<double>("pfAlphaTThrTurnon");
+  pfHtThrTurnon_ = ps.getUntrackedParameter<double>("pfHtThrTurnon");
 }
 
 SUSY_HLT_alphaT::~SUSY_HLT_alphaT()
@@ -81,24 +81,6 @@ void SUSY_HLT_alphaT::beginLuminosityBlock(edm::LuminosityBlock const& lumiSeg,
 void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup){
   edm::LogInfo("SUSY_HLT_alphaT") << "SUSY_HLT_alphaT::analyze" << std::endl;
 
-
-  //-------------------------------
-  //--- MET
-  //-------------------------------
- // edm::Handle<reco::PFMETCollection> pfMETCollection;
- // e.getByToken(thePfMETCollection_, pfMETCollection);
- // if ( !pfMETCollection.isValid() ){
- //   edm::LogError ("SUSY_HLT_alphaT") << "invalid collection: PFMET" << "\n";
- //  return;
- // }
- // edm::Handle<reco::CaloMETCollection> caloMETCollection;
- // e.getByToken(theCaloMETCollection_, caloMETCollection);
- // if ( !caloMETCollection.isValid() ){
- //   edm::LogError ("SUSY_HLT_alphaT") << "invalid collection: CaloMET" << "\n";
- //   return;
- // }
-    
-
   //-------------------------------
   //--- Trigger
   //-------------------------------
@@ -118,12 +100,12 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
   //-------------------------------
   //--- Jets
   //-------------------------------
-  //edm::Handle<reco::PFJetCollection> pfJetCollection;
-  //e.getByToken (thePfJetCollection_,pfJetCollection);
-  //if ( !pfJetCollection.isValid() ){
-  //  edm::LogError ("SUSY_HLT_alphaT") << "invalid collection: PFJets" << "\n";
-  //  return;
-  //}
+  edm::Handle<reco::PFJetCollection> pfJetCollection;
+  e.getByToken (thePfJetCollection_,pfJetCollection);
+  if ( !pfJetCollection.isValid() ){
+   edm::LogWarning ("SUSY_HLT_alphaT") << "invalid collection: PFJets" << "\n";
+   return;
+  }
   edm::Handle<reco::CaloJetCollection> caloJetCollection;
   e.getByToken (theCaloJetCollection_,caloJetCollection);
   if ( !caloJetCollection.isValid() ){
@@ -134,10 +116,12 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
   //get online objects
   //For now just get the jets and recalculate ht and alphaT
   size_t filterIndex = triggerSummary->filterIndex( triggerFilter_ );
+  size_t preFilterIndex = triggerSummary->filterIndex( triggerPreFilter_ );
   trigger::TriggerObjectCollection triggerObjects = triggerSummary->getObjects();
 
-  double hltHt=0.;
-  std::vector<LorentzV> hltJets;
+  //Get the PF objects from the filter
+  double hltPfHt=0.;
+  std::vector<LorentzV> hltPfJets;
   if( !(filterIndex >= triggerSummary->sizeFilters()) ){
       const trigger::Keys& keys = triggerSummary->filterKeys( filterIndex );
 
@@ -146,20 +130,46 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
 
           //  if(foundObject.id() == 85){ //It's a jet 
           if(foundObject.pt()>ptThrJet_ && fabs(foundObject.eta()) < etaThrJet_){
-              hltHt += foundObject.pt();
+              hltPfHt += foundObject.pt();
               LorentzV JetLVec(foundObject.pt(),foundObject.eta(),foundObject.phi(),foundObject.mass());
-              hltJets.push_back(JetLVec);
+              hltPfJets.push_back(JetLVec);
+          }
+          //   }
+      }
+  }
+  
+  //Get the Calo objects from the prefilter
+  double hltCaloHt=0.;
+  std::vector<LorentzV> hltCaloJets;
+  if( !(preFilterIndex >= triggerSummary->sizeFilters()) ){
+      const trigger::Keys& keys = triggerSummary->filterKeys( preFilterIndex );
+
+      for( size_t j = 0; j < keys.size(); ++j ){
+          trigger::TriggerObject foundObject = triggerObjects[keys[j]];
+
+          //  if(foundObject.id() == 85){ //It's a jet 
+          if(foundObject.pt()>ptThrJet_ && fabs(foundObject.eta()) < etaThrJet_){
+              hltCaloHt += foundObject.pt();
+              LorentzV JetLVec(foundObject.pt(),foundObject.eta(),foundObject.phi(),foundObject.mass());
+              hltCaloJets.push_back(JetLVec);
           }
           //   }
       }
   }
 
   //Fill the alphaT and HT histograms
-  if(hltJets.size()>0){
-      double hltAlphaT = AlphaT(hltJets).value();
-      h_triggerAlphaT->Fill(hltAlphaT);
-      h_triggerHt->Fill(hltHt);
-      h_triggerAlphaT_triggerHt->Fill(hltHt, hltAlphaT);
+  if(hltPfJets.size()>0){
+      double hltPfAlphaT = AlphaT(hltPfJets,true).value();
+      h_triggerPfAlphaT->Fill(hltPfAlphaT);
+      h_triggerPfHt->Fill(hltPfHt);
+      h_triggerPfAlphaT_triggerPfHt->Fill(hltPfHt, hltPfAlphaT);
+  }
+
+  if(hltCaloJets.size()>0){
+      double hltCaloAlphaT = AlphaT(hltCaloJets,true).value();
+      h_triggerCaloAlphaT->Fill(hltCaloAlphaT);
+      h_triggerCaloHt->Fill(hltCaloHt);
+      h_triggerCaloAlphaT_triggerCaloHt->Fill(hltCaloHt, hltCaloAlphaT);
   }
 
   bool hasFired = false;
@@ -174,70 +184,87 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
 
   if(hasFiredAuxiliaryForHadronicLeg) {
 
-      float caloHT = 0.0;
-      //float pfHT = 0.0;
-      //for (reco::PFJetCollection::const_iterator i_pfjet = pfJetCollection->begin(); i_pfjet != pfJetCollection->end(); ++i_pfjet){
-      //  if (i_pfjet->pt() < ptThrJet_) continue;
-      //  if (fabs(i_pfjet->eta()) > etaThrJet_) continue;
-      //  pfHT += i_pfjet->pt();
-      //}
+      float pfHT = 0.0;
+      std::vector<LorentzV> pfJets;
+      for (reco::PFJetCollection::const_iterator i_pfjet = pfJetCollection->begin(); i_pfjet != pfJetCollection->end(); ++i_pfjet){
+       if (i_pfjet->pt() < ptThrJet_) continue;
+       if (fabs(i_pfjet->eta()) > etaThrJet_) continue;
+       pfHT += i_pfjet->pt();
+       LorentzV JetLVec(i_pfjet->pt(),i_pfjet->eta(),i_pfjet->phi(),i_pfjet->mass());
+       pfJets.push_back(JetLVec);
+      }
 
       //Make the gen Calo HT and AlphaT
-      std::vector<LorentzV> jets;
+      float caloHT = 0.0;
+      std::vector<LorentzV> caloJets;
       for (reco::CaloJetCollection::const_iterator i_calojet = caloJetCollection->begin(); i_calojet != caloJetCollection->end(); ++i_calojet){
-          if (i_calojet->pt() < ptThrJet_) continue;
-          if (fabs(i_calojet->eta()) > etaThrJet_) continue;
-          caloHT += i_calojet->pt();
-          LorentzV JetLVec(i_calojet->pt(),i_calojet->eta(),i_calojet->phi(),i_calojet->mass());
-          jets.push_back(JetLVec);
+        if (i_calojet->pt() < ptThrJet_) continue;
+        if (fabs(i_calojet->eta()) > etaThrJet_) continue;
+        caloHT += i_calojet->pt();
+        LorentzV JetLVec(i_calojet->pt(),i_calojet->eta(),i_calojet->phi(),i_calojet->mass());
+        caloJets.push_back(JetLVec);
       }
 
       //AlphaT aT = AlphaT(jets);
-      double caloAlphaT = AlphaT(jets).value();
+      double caloAlphaT = AlphaT(caloJets).value();
+      double pfAlphaT = AlphaT(pfJets).value();
 
       //Fill the turnons
       if(hasFired) {
-          if(caloHT>htThrTurnon_) h_alphaTTurnOn_num-> Fill(caloAlphaT);
-          if(caloAlphaT>alphaTThrTurnon_) h_htTurnOn_num-> Fill(caloHT);
+        if(caloHT>caloHtThrTurnon_) h_caloAlphaTTurnOn_num-> Fill(caloAlphaT);
+        if(caloAlphaT>caloAlphaTThrTurnon_) h_caloHtTurnOn_num-> Fill(caloHT);
+
+        if(pfHT>pfHtThrTurnon_) h_pfAlphaTTurnOn_num-> Fill(pfAlphaT);
+        if(pfAlphaT>pfAlphaTThrTurnon_) h_pfHtTurnOn_num-> Fill(pfHT);
       } 
-      if(caloHT>htThrTurnon_) h_alphaTTurnOn_den-> Fill(caloAlphaT);
-      if(caloAlphaT>alphaTThrTurnon_) h_htTurnOn_den-> Fill(caloHT);
+      if(caloHT>caloHtThrTurnon_) h_caloAlphaTTurnOn_den-> Fill(caloAlphaT);
+      if(caloAlphaT>caloAlphaTThrTurnon_) h_caloHtTurnOn_den-> Fill(caloHT);
+
+      if(pfHT>pfHtThrTurnon_) h_pfAlphaTTurnOn_den-> Fill(pfAlphaT);
+      if(pfAlphaT>pfAlphaTThrTurnon_) h_pfHtTurnOn_den-> Fill(pfHT);
   }
 }
 
 
 void SUSY_HLT_alphaT::endLuminosityBlock(edm::LuminosityBlock const& lumiSeg, edm::EventSetup const& eSetup)
 {
-    edm::LogInfo("SUSY_HLT_alphaT") << "SUSY_HLT_alphaT::endLuminosityBlock" << std::endl;
+  edm::LogInfo("SUSY_HLT_alphaT") << "SUSY_HLT_alphaT::endLuminosityBlock" << std::endl;
 }
 
 
 void SUSY_HLT_alphaT::endRun(edm::Run const& run, edm::EventSetup const& eSetup)
 {
-    edm::LogInfo("SUSY_HLT_alphaT") << "SUSY_HLT_alphaT::endRun" << std::endl;
+  edm::LogInfo("SUSY_HLT_alphaT") << "SUSY_HLT_alphaT::endRun" << std::endl;
 }
 
 void SUSY_HLT_alphaT::bookHistos(DQMStore::IBooker & ibooker_)
 {
-    ibooker_.cd();
-    ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);
+  ibooker_.cd();
+  ibooker_.setCurrentFolder("HLT/SUSYBSM/" + triggerPath_);
 
-    //offline quantities
+  //offline quantities
 
-    //online quantities 
-    h_triggerHt = ibooker_.book1D("triggerHt", "Trigger Ht; HT (GeV)", 60, 0.0, 1500.0);
-    h_triggerAlphaT = ibooker_.book1D("triggerAlphaT", "Trigger AlphaT; AlphaT", 80, 0., 1.0);
-    h_triggerAlphaT_triggerHt = ibooker_.book2D("triggerAlphaT_triggerHt","Trigger HT vs Trigger AlphaT; HT (GeV); AlphaT", 60,0.0,1500.,80,0.,1.0);
-    
-    //h_triggerMht = ibooker_.book1D("triggerMht", "Trigger Mht", 20, -3.5, 3.5);
+  //online quantities 
+  h_triggerCaloHt = ibooker_.book1D("triggerCaloHt", "Trigger Calo Ht; HT (GeV)", 60, 0.0, 1500.0);
+  h_triggerCaloAlphaT = ibooker_.book1D("triggerCaloAlphaT", "Trigger Calo AlphaT; AlphaT", 80, 0., 1.0);
+  h_triggerCaloAlphaT_triggerCaloHt = ibooker_.book2D("triggerCaloAlphaT_triggerCaloHt","Trigger Calo HT vs Trigger Calo AlphaT; HT (GeV); AlphaT", 60,0.0,1500.,80,0.,1.0);
+  h_triggerPfHt = ibooker_.book1D("triggerPfHt", "Trigger PF Ht; HT (GeV)", 60, 0.0, 1500.0);
+  h_triggerPfAlphaT = ibooker_.book1D("triggerPfAlphaT", "Trigger PF AlphaT; AlphaT", 80, 0., 1.0);
+  h_triggerPfAlphaT_triggerPfHt = ibooker_.book2D("triggerPfAlphaT_triggerPfHt","Trigger PF HT vs Trigger PF AlphaT; HT (GeV); AlphaT", 60,0.0,1500.,80,0.,1.0);
 
-    //num and den hists to be divided in harvesting step to make turn on curves
-    h_alphaTTurnOn_num = ibooker_.book1D("alphaTTurnOn_num", "AlphaT Turn On Numerator; AlphaT", 40, 0.0, 1.0 );
-    h_alphaTTurnOn_den = ibooker_.book1D("alphaTTurnOn_den", "AlphaT Turn OnDenominator; AlphaT", 40, 0.0, 1.0 );
-    h_htTurnOn_num = ibooker_.book1D("htTurnOn_num", "HT Turn On Numerator; HT (GeV)", 30, 0.0, 1500.0 );
-    h_htTurnOn_den = ibooker_.book1D("htTurnOn_den", "HT Turn On Denominator; HT (GeV)", 30, 0.0, 1500.0 );
 
-    ibooker_.cd();
+  //num and den hists to be divided in harvesting step to make turn on curves
+  h_caloAlphaTTurnOn_num = ibooker_.book1D("caloAlphaTTurnOn_num", "Calo AlphaT Turn On Numerator; AlphaT", 40, 0.0, 1.0 );
+  h_caloAlphaTTurnOn_den = ibooker_.book1D("caloAlphaTTurnOn_den", "Calo AlphaT Turn OnDenominator; AlphaT", 40, 0.0, 1.0 );
+  h_caloHtTurnOn_num = ibooker_.book1D("caloHtTurnOn_num", "Calo HT Turn On Numerator; HT (GeV)", 30, 0.0, 1500.0 );
+  h_caloHtTurnOn_den = ibooker_.book1D("caloHtTurnOn_den", "Calo HT Turn On Denominator; HT (GeV)", 30, 0.0, 1500.0 );
+
+  h_pfAlphaTTurnOn_num = ibooker_.book1D("pfAlphaTTurnOn_num", "PF AlphaT Turn On Numerator; AlphaT", 40, 0.0, 1.0 );
+  h_pfAlphaTTurnOn_den = ibooker_.book1D("pfAlphaTTurnOn_den", "PF AlphaT Turn OnDenominator; AlphaT", 40, 0.0, 1.0 );
+  h_pfHtTurnOn_num = ibooker_.book1D("pfHtTurnOn_num", "PF HT Turn On Numerator; HT (GeV)", 30, 0.0, 1500.0 );
+  h_pfHtTurnOn_den = ibooker_.book1D("pfHtTurnOn_den", "PF HT Turn On Denominator; HT (GeV)", 30, 0.0, 1500.0 );
+
+  ibooker_.cd();
 }
 
 //define this as a plug-in


### PR DESCRIPTION
Updated the alphaT DQM module to make plots for PF and Calo Jets, in line with the inclusion of PF Jets with a Calo prefilter for the alphaT HLT paths. ( /users/aelwood/alphaT/alphaTRun2PF/V6 ). 
