### PR TITLE
Sort entries when doing dumpPython

### DIFF
--- a/FWCore/ParameterSet/python/Config.py
+++ b/FWCore/ParameterSet/python/Config.py
@@ -688,7 +688,7 @@ class Process(object):
         return returnValue
     def _dumpPython(self, d, options):
         result = ''
-        for name, value in d.iteritems():
+        for name, value in sorted(d.iteritems()):
            result += value.dumpPythonAs(name,options)+'\n'
         return result
     def dumpPython(self, options=PrintOptions()):

--- a/FWCore/ParameterSet/python/Mixins.py
+++ b/FWCore/ParameterSet/python/Mixins.py
@@ -231,7 +231,7 @@ class _Parameterizable(object):
     def dumpPython(self, options=PrintOptions()):
         others = []
         usings = []
-        for name in self.parameterNames_():
+        for name in sorted(self.parameterNames_()):
             param = self.__dict__[name]
             # we don't want minuses in names
             name2 = name.replace('-','_')
@@ -376,7 +376,7 @@ class _TypedParameterizable(_Parameterizable):
     def dumpPythonAttributes(self, myname, options):
         """ dumps the object with all attributes declared after the constructor"""
         result = ""
-        for name in self.parameterNames_():
+        for name in sorted(self.parameterNames_()):
             param = self.__dict__[name]
             result += options.indentation() + myname + "." + name + " = " + param.dumpPython(options) + "\n"
         return result

--- a/FWCore/ParameterSet/python/Modules.py
+++ b/FWCore/ParameterSet/python/Modules.py
@@ -254,7 +254,7 @@ if __name__ == "__main__":
             self.assertEqual(withParam.foo.value(), 1)
             self.assertEqual(withParam.bar.value(), "it")
             self.assertEqual(empty.dumpPython(), "cms.Service(\"Empty\")\n")
-            self.assertEqual(withParam.dumpPython(), "cms.Service(\"Parameterized\",\n    foo = cms.untracked.int32(1),\n    bar = cms.untracked.string(\'it\')\n)\n")
+            self.assertEqual(withParam.dumpPython(), "cms.Service(\"Parameterized\",\n    bar = cms.untracked.string(\'it\'),\n    foo = cms.untracked.int32(1)\n)\n")
         def testSequences(self):
             m = EDProducer("MProducer")
             n = EDProducer("NProducer")


### PR DESCRIPTION
In order to make it easier to compare different configurations, we now sort the named items used in the configuration.
