### PR TITLE
Anonymous namespace here can cause build warnings

### DIFF
--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -27,7 +27,8 @@ for testing purposes only.
 namespace edmtest {
 namespace stream {
 
-namespace {
+// anonymous namespace here causes build warnings
+namespace cache {
 struct Cache { 
    Cache():value(0),run(0),lumi(0) {}
    //Using mutable since we want to update the value.
@@ -35,10 +36,9 @@ struct Cache {
    mutable std::atomic<unsigned int> run;
    mutable std::atomic<unsigned int> lumi;
 };
-} //end anonymous namespace
+} //end cache namespace
 
-
-
+  using Cache = cache::Cache;
 
   class GlobalIntAnalyzer : public edm::stream::EDAnalyzer<edm::GlobalCache<Cache>> {
   public:

--- a/FWCore/Framework/test/stubs/TestStreamFilters.cc
+++ b/FWCore/Framework/test/stubs/TestStreamFilters.cc
@@ -27,8 +27,9 @@ for testing purposes only.
 namespace edmtest {
 namespace stream {
 
-namespace {
-struct Cache { 
+// anonymous namespace here causes build warnings
+namespace cache {
+struct Cache {
    Cache():value(0),run(0),lumi(0) {}
    //Using mutable since we want to update the value.
    mutable std::atomic<unsigned int> value;
@@ -36,9 +37,9 @@ struct Cache {
    mutable std::atomic<unsigned int> lumi;
 };
 
-} //end anonymous namespace
+} //end cache namespace
 
-
+  using Cache = cache::Cache;
 
   class GlobalIntFilter : public edm::stream::EDFilter<edm::GlobalCache<Cache>> {
   public:

--- a/FWCore/Framework/test/stubs/TestStreamProducers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamProducers.cc
@@ -27,7 +27,8 @@ for testing purposes only.
 namespace edmtest {
 namespace stream {
 
-namespace {
+// anonymous namespace here causes build warnings
+namespace cache {
 struct Cache { 
    Cache():value(0),run(0),lumi(0) {}
    //Using mutable since we want to update the value.
@@ -43,8 +44,10 @@ struct UnsafeCache {
    unsigned int lumi;
 };
 
-} //end anonymous namespace
+} //end cache namespace
 
+  using Cache = cache::Cache;
+  using UnsafeCache = cache::UnsafeCache;
 
   class GlobalIntProducer : public edm::stream::EDProducer<edm::GlobalCache<Cache>> {
   public:


### PR DESCRIPTION
This pull request affects only unit tests, namely three in FWCore/Framework.
The use of an anonymous namespace in these tests has caused compilation warnings in 4.9.1 because the anonymous namespace is used in the type of a data member (as a typename parameter of a template).
This simple pull request simply replaces the anonymous namespace with a named namespace.
