### PR TITLE
Reduce HGC rechit memory footprint

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h
@@ -1,0 +1,56 @@
+#ifndef RecoParticleFlow_PFClusterProducer_HGCRecHitNavigator_h
+#define RecoParticleFlow_PFClusterProducer_HGCRecHitNavigator_h
+
+
+#include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitNavigatorBase.h"
+#include "DataFormats/ParticleFlowReco/interface/PFLayer.h"
+
+
+
+template <PFLayer::Layer D1, typename hgcee,
+          PFLayer::Layer D2, typename hgchef,
+          PFLayer::Layer D3, typename hgcheb>
+class HGCRecHitNavigator : public PFRecHitNavigatorBase {
+ public:
+  HGCRecHitNavigator() {
+  }
+
+
+
+  HGCRecHitNavigator(const edm::ParameterSet& iConfig){
+    eeNav_ = new hgcee(iConfig.getParameter<edm::ParameterSet>("hgcee"));
+    hefNav_ = new hgchef(iConfig.getParameter<edm::ParameterSet>("hgchef"));
+    hebNav_ = new hgcheb(iConfig.getParameter<edm::ParameterSet>("hgcheb"));
+  }
+
+  void beginEvent(const edm::EventSetup& iSetup) {
+    eeNav_->beginEvent(iSetup); 
+    hefNav_->beginEvent(iSetup);
+    hebNav_->beginEvent(iSetup);
+  }
+
+  void associateNeighbours(reco::PFRecHit& hit,std::auto_ptr<reco::PFRecHitCollection>& hits,edm::RefProd<reco::PFRecHitCollection>& refProd) {
+    switch( hit.layer() ) {
+    case D1:
+      eeNav_->associateNeighbours(hit,hits,refProd);
+      break;
+    case D2:
+      hefNav_->associateNeighbours(hit,hits,refProd);
+      break;
+    case D3:
+      hebNav_->associateNeighbours(hit,hits,refProd);
+      break;
+    default:
+      break;
+    }     
+  }
+
+ protected:
+      hgcee  *eeNav_;
+      hgchef *hefNav_;
+      hgcheb *hebNav_;
+};
+
+#endif
+
+

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -77,7 +77,7 @@ void
 
    iEvent.put(out,"");
    iEvent.put(cleaned,"Cleaned");
-
+   hitmap.clear();
 }
 
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCEE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHGCEE_cfi.py
@@ -158,7 +158,7 @@ _HGCEE_ElectronEnergy = cms.PSet(
 
 particleFlowClusterHGCEE = cms.EDProducer(
     "PFClusterProducer",
-    recHitsSource = cms.InputTag("particleFlowRecHitHGCAll"),
+    recHitsSource = cms.InputTag("particleFlowRecHitHGCEE"),
     recHitCleaners = cms.VPSet(),
     seedFinder = _localmaxseeds_HGCEE,
     initialClusteringStep = _fromScratchHGCClusterizer_HGCEE,

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGCEE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGCEE_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 particleFlowRecHitHGCEE = cms.EDProducer("PFRecHitProducer",
     useHitMap = cms.untracked.bool(True),
-    navigator = cms.PSet(
+    navigator = cms.PSet(        
         name = cms.string("PFRecHitHGCEENavigator"),
         topologySource = cms.string("HGCalEESensitive")        
     ),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHGC_cff.py
@@ -2,15 +2,6 @@ from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGCEE_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGCHEF_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowRecHitHGCHEB_cfi import *
 
-particleFlowRecHitHGCAll = cms.EDProducer(
-    "PFRecHitMerger",
-    src = cms.VInputTag( cms.InputTag("particleFlowRecHitHGCEE")
-                         #cms.InputTag("particleFlowRecHitHGCHEF"),
-                         #cms.InputTag("particleFlowRecHitHGCHEB")
-                         )
-)
-
 particleFlowRecHitHGC = cms.Sequence( particleFlowRecHitHGCEE  +
                                       particleFlowRecHitHGCHEF +
-                                      particleFlowRecHitHGCHEB +
-                                      particleFlowRecHitHGCAll )
+                                      particleFlowRecHitHGCHEB )

--- a/RecoParticleFlow/PFClusterProducer/src/Navigators.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/Navigators.cc
@@ -11,6 +11,7 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigator.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFRecHitCaloNavigatorWithTime.h"
 #include "RecoParticleFlow/PFClusterProducer/interface/PFECALHashNavigator.h"
+#include "RecoParticleFlow/PFClusterProducer/interface/HGCRecHitNavigator.h"
 
 
 class PFRecHitEcalBarrelNavigatorWithTime : public PFRecHitCaloNavigatorWithTime<EBDetId,EcalBarrelTopology> {
@@ -205,10 +206,12 @@ public:
   }
 };
 
-typedef PFRecHitDualNavigator<PFLayer::HGC_ECAL,
-			      PFRecHitHGCEENavigator,
-			      PFLayer::HGC_HCALF,
-			      PFRecHitHGCHENavigator> PFRecHitHGCEEHEFNavigator;
+typedef HGCRecHitNavigator<PFLayer::HGC_ECAL,
+			   PFRecHitHGCEENavigator,
+			   PFLayer::HGC_HCALF,
+			   PFRecHitHGCHENavigator,
+			   PFLayer::HGC_HCALB,
+			   PFRecHitHGCHENavigator> PFRecHitHGCNavigator;
 
 EDM_REGISTER_PLUGINFACTORY(PFRecHitNavigationFactory, "PFRecHitNavigationFactory");
 
@@ -217,7 +220,7 @@ DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitEcalEndcapNavigator, "PFRec
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitShashlikNavigator, "PFRecHitShashlikNavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHGCEENavigator, "PFRecHitHGCEENavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHGCHENavigator, "PFRecHitHGCHENavigator");
-DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHGCEEHEFNavigator, "PFRecHitHGCEEHEFNavigator");
+DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitHGCNavigator, "PFRecHitHGCNavigator");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitEcalBarrelNavigatorWithTime, "PFRecHitEcalBarrelNavigatorWithTime");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitEcalEndcapNavigatorWithTime, "PFRecHitEcalEndcapNavigatorWithTime");
 DEFINE_EDM_PLUGIN(PFRecHitNavigationFactory, PFRecHitShashlikNavigatorWithTime, "PFRecHitShashlikNavigatorWithTime");

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -2,7 +2,7 @@
 
 #-c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc
 
-cmsShow -n --geom-file ~/work/public/xHGCAL/cmsRecoGeom-2023HGCalV5.root --sim-geom-file ~/work/public/xHGCAL/cmsSimGeom-2023HGCalV5.root -i ${CMSSW_BASE}/src/UserCode/HGCanalysis/test/single_electron_reco.root
+cmsShow -n --geom-file ~/work/public/xHGCAL/cmsRecoGeom-2023HGCalV5.root --sim-geom-file ~/work/public/xHGCAL/cmsSimGeom-2023HGCalV5.root -i ${CMSSW_BASE}/src/matrix_tests/12201_SingleElectronPt10+SingleElectronPt10_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon/step3.root
 
 
 #/afs/cern.ch/work/v/vandreev/public/pileup/SLHC18patch2/step3_v4_QCD_Pt_80_120_14TeV_PU.root


### PR DESCRIPTION
Remove a merging module that is un-necessary, should reduce HGC rechit memory footprint by 2x.

Trying to get a working rechit creator that can service all three HGC subcomponents at once, removing the need for a merging module. For some reason it will not let any rechits pass. I working on a fix since this is necessary to keep the memory use down once we start collection rechits in the whole detector at once.

This is a decent patch for now since the subcomponents are clustered separately in this version of HGC RECO.

Last commit should help reduce the retained memory by quite a bit.

@pfs @vandreev11
