### PR TITLE
Remove unnecessary type info calls

### DIFF
--- a/CommonTools/Utils/src/MethodArgumentStack.h
+++ b/CommonTools/Utils/src/MethodArgumentStack.h
@@ -1,21 +1,21 @@
 #ifndef CommonTools_Utils_MethodArgumentStack_h
 #define CommonTools_Utils_MethodArgumentStack_h
+
 /* \class reco::parser::MethodArgumentStack
  *
  * Stack of method arguments
  *
  * \author  Giovanni Petrucciani, SNS
  *
- * \version $Revision: 1.1 $
- *
  */
+
 #include "CommonTools/Utils/src/MethodInvoker.h"
 #include <vector>
 
 namespace reco {
-  namespace parser {
-    typedef std::vector<AnyMethodArgument> MethodArgumentStack;
-  }
-}
+namespace parser {
+typedef std::vector<AnyMethodArgument> MethodArgumentStack;
+} // namespace reco
+} // namespace parser
 
-#endif
+#endif // CommonTools_Utils_MethodArgumentStack_h

--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -1,114 +1,170 @@
 #include "CommonTools/Utils/src/MethodInvoker.h"
+
+#include "CommonTools/Utils/src/ExpressionVar.h"
+#include "CommonTools/Utils/src/MethodSetter.h"
 #include "CommonTools/Utils/src/findMethod.h"
 #include "CommonTools/Utils/src/returnType.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-#include "CommonTools/Utils/src/MethodSetter.h"
-#include "CommonTools/Utils/src/ExpressionVar.h"
 
 #include <algorithm>
 using namespace reco::parser;
 using namespace std;
 
-MethodInvoker::MethodInvoker(const edm::FunctionWithDict & method, const vector<AnyMethodArgument> & ints) :
-  method_(method), member_(), ints_(ints), isFunction_(true)
+MethodInvoker::
+MethodInvoker(const edm::FunctionWithDict& method,
+              const vector<AnyMethodArgument>& ints)
+  : method_(method)
+  , member_()
+  , ints_(ints)
+  , isFunction_(true)
 { 
   setArgs();
-  /*std::cout << "Booking " << methodName() 
-            << " from " << method_.declaringType().name() 
-            << " with " << args_.size() << " arguments"
-            << " (were " << ints.size() << ")"
-            << std::endl;*/
+  if (isFunction_) {
+    retTypeFinal_ = method_.finalReturnType();
+  }
+  //std::cout <<
+  //   "Booking " <<
+  //   methodName() <<
+  //   " from " <<
+  //   method_.declaringType().name() <<
+  //   " with " <<
+  //   args_.size() <<
+  //   " arguments" <<
+  //   " (were " <<
+  //   ints.size() <<
+  //   ")" <<
+  //   std::endl;
 }
 
-MethodInvoker::MethodInvoker(const edm::MemberWithDict & member) :
-  method_(), member_(member), ints_(), isFunction_(false)
+MethodInvoker::
+MethodInvoker(const edm::MemberWithDict& member)
+  : method_()
+  , member_(member)
+  , ints_()
+  , isFunction_(false)
 { 
   setArgs();
-  /*std::cout << "Booking " << methodName() 
-            << " from " << member_.declaringType().name() 
-            << " with " << args_.size() << " arguments"
-            << " (were " << ints.size() << ")"
-            << std::endl;*/
+  //std::cout <<
+  //  "Booking " <<
+  //  methodName() <<
+  //  " from " <<
+  //  member_.declaringType().name() <<
+  //  " with " <<
+  //  args_.size() <<
+  //  " arguments" <<
+  //  " (were " <<
+  //  ints.size() <<
+  //  ")" <<
+  //  std::endl;
 }
 
-MethodInvoker::MethodInvoker(const MethodInvoker & other) :
-  method_(other.method_), member_(other.member_), ints_(other.ints_), isFunction_(other.isFunction_) {
+MethodInvoker::
+MethodInvoker(const MethodInvoker& rhs)
+  : method_(rhs.method_)
+  , member_(rhs.member_)
+  , ints_(rhs.ints_)
+  , isFunction_(rhs.isFunction_)
+  , retTypeFinal_(rhs.retTypeFinal_)
+{
   setArgs();
 }
 
-MethodInvoker & MethodInvoker::operator=(const MethodInvoker & other) {
-  method_ = other.method_;
-  member_ = other.member_;
-  ints_ = other.ints_;
-  isFunction_ = other.isFunction_;
+MethodInvoker&
+MethodInvoker::
+operator=(const MethodInvoker& rhs)
+{
+  if (this != &rhs) {
+    method_ = rhs.method_;
+    member_ = rhs.member_;
+    ints_ = rhs.ints_;
+    isFunction_ = rhs.isFunction_;
+    retTypeFinal_ =rhs.retTypeFinal_;
+
   setArgs();
+  }
   return *this;
 }
 
-void MethodInvoker::setArgs() {
-  for(size_t i = 0; i < ints_.size(); ++i) {
-      args_.push_back( boost::apply_visitor( AnyMethodArgument2VoidPtr(), ints_[i] ) );
+void
+MethodInvoker::
+setArgs()
+{
+  for (size_t i = 0; i < ints_.size(); ++i) {
+    args_.push_back(boost::apply_visitor(AnyMethodArgument2VoidPtr(), ints_[i]));
   }
 }
 
 std::string
-MethodInvoker::methodName() const {
-  if(isFunction_) {
+MethodInvoker::
+methodName() const
+{
+  if (isFunction_) {
      return method_.name();
   }
   return member_.name();
 }
 
 std::string
-MethodInvoker::returnTypeName() const {
-  if(isFunction_) {
+MethodInvoker::
+returnTypeName() const
+{
+  if (isFunction_) {
      return method_.typeOf().qualifiedName();
   }
   return member_.typeOf().qualifiedName();
 }
 
 edm::ObjectWithDict
-MethodInvoker::invoke(const edm::ObjectWithDict & o, edm::ObjectWithDict &retstore) const {
+MethodInvoker::
+invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
+{
   edm::ObjectWithDict ret = retstore;
   edm::TypeWithDict retType;
-  if(isFunction_) {
-     /*std::cout << "Invoking " << methodName() 
-            << " from " << method_.declaringType().qualifiedName() 
-            << " on an instance of " << o.dynamicType().qualifiedName() 
-            << " at " << o.address()
-            << " with " << args_.size() << " arguments"
-            << std::endl; */
+  if (isFunction_) {
+    //std::cout << "Invoking " << methodName()
+    //  << " from " << method_.declaringType().qualifiedName()
+    //  << " on an instance of " << o.dynamicType().qualifiedName()
+    //  << " at " << o.address()
+    //  << " with " << args_.size() << " arguments"
+    //  << std::endl;
      method_.invoke(o, &ret, args_);
-     retType = method_.finalReturnType(); // this is correct, it takes pointers and refs into account
-  } else {
-     /*std::cout << "Invoking " << methodName() 
-            << " from " << member_.declaringType().qualifiedName() 
-            << " on an instance of " << o.dynamicType().qualifiedName() 
-            << " at " << o.address()
-            << " with " << args_.size() << " arguments"
-            << std::endl; */
+    // this is correct, it takes pointers and refs into account
+    retType = retTypeFinal_; 
+  }
+  else {
+    //std::cout << "Invoking " << methodName()
+    //  << " from " << member_.declaringType().qualifiedName()
+    //  << " on an instance of " << o.dynamicType().qualifiedName()
+    //  << " at " << o.address()
+    //  << " with " << args_.size() << " arguments"
+    //  << std::endl;
      ret = member_.get(o);
      retType = member_.typeOf();
   }
-  void * addr = ret.address(); 
-  //std::cout << "Stored result of " <<  methodName() << " (type " << returnTypeName() << ") at " << addr << std::endl;
-  if(addr==0) {
+  void* addr = ret.address();
+  //std::cout << "Stored result of " <<  methodName() << " (type " <<
+  //  returnTypeName() << ") at " << addr << std::endl;
+  if (addr == 0) {
     throw edm::Exception(edm::errors::InvalidReference)
       << "method \"" << methodName() << "\" called with " << args_.size() 
       << " arguments returned a null pointer ";   
   }
   //std::cout << "Return type is " << retType.qualifiedName() << std::endl;
-   
-  if(retType.isPointer() || retType.isReference()) { // both need (void **)->(void *) conversion
+  if (retType.isPointer() || retType.isReference()) {
+    // both need void** -> void* conversion
       if (retType.isPointer()) {
-        retType = retType.toType(); // for Pointers, I get the real type this way
-      } else {
-        retType = edm::TypeWithDict(retType, 0L); // strip cv & ref flags
+      retType = retType.toType();
       }
-      ret = edm::ObjectWithDict(retType, *static_cast<void **>(addr));
+    else {
+      // strip cv & ref flags
+      // FIXME: This is only true if the propery passed to the constructor
+      //       overrides the const and reference flags.
+      retType = edm::TypeWithDict(retType, 0L);
+    }
+    ret = edm::ObjectWithDict(retType, *static_cast<void**>(addr));
       //std::cout << "Now type is " << retType.qualifiedName() << std::endl;
   }
-  if(!ret) {
+  if (!bool(ret)) {
      throw edm::Exception(edm::errors::Configuration)
       << "method \"" << methodName()
       << "\" returned void invoked on object of type \"" 
@@ -117,9 +173,11 @@ MethodInvoker::invoke(const edm::ObjectWithDict & o, edm::ObjectWithDict &retsto
   return ret;
 }
 
-LazyInvoker::LazyInvoker(const std::string &name, const std::vector<AnyMethodArgument> & args) :
-    name_(name),
-    argsBeforeFixups_(args)
+LazyInvoker::
+LazyInvoker(const std::string& name,
+            const std::vector<AnyMethodArgument>& args)
+  : name_(name)
+  , argsBeforeFixups_(args)
 {
 }
 
@@ -127,85 +185,111 @@ LazyInvoker::~LazyInvoker()
 {
 }
 
-const SingleInvoker &
-LazyInvoker::invoker(const edm::TypeWithDict & type) const 
+const SingleInvoker&
+LazyInvoker::
+invoker(const edm::TypeWithDict& type) const
 {
-    //std::cout << "LazyInvoker for " << name_ << " called on type " << type.qualifiedName() << std::endl;
-    SingleInvokerPtr & invoker = invokers_[edm::TypeID(type.id())];
+  //std::cout << "LazyInvoker for " << name_ << " called on type " <<
+  //  type.qualifiedName() << std::endl;
+  SingleInvokerPtr& invoker = invokers_[edm::TypeID(type.typeInfo())];
     if (!invoker) {
-        //std::cout << "  Making new invoker for " << name_ << " on type " << type.qualifiedName() << std::endl;
+    //std::cout << "  Making new invoker for " << name_ << " on type " <<
+    //  type.qualifiedName() << std::endl;
         invoker.reset(new SingleInvoker(type, name_, argsBeforeFixups_));
     } 
-    return * invoker;
+  return *invoker;
 }
 
 edm::ObjectWithDict
-LazyInvoker::invoke(const edm::ObjectWithDict & o, std::vector<edm::ObjectWithDict> &v) const 
+LazyInvoker::
+invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
 {
-    pair<edm::ObjectWithDict, bool> ret(o,false);
+  pair<edm::ObjectWithDict, bool> ret(o, false);
     do {    
         edm::TypeWithDict type = ret.first.typeOf();
-        if (type.isClass()) type = ret.first.dynamicType();
+    if (type.isClass()) {
+      type = ret.first.dynamicType();
+    }
         ret = invoker(type).invoke(edm::ObjectWithDict(type, ret.first.address()), v);
-    } while (ret.second == false);
+  }
+  while (ret.second == false);
     return ret.first; 
 }
 
 double
-LazyInvoker::invokeLast(const edm::ObjectWithDict & o, std::vector<edm::ObjectWithDict> &v) const 
+LazyInvoker::
+invokeLast(const edm::ObjectWithDict& o,
+           std::vector<edm::ObjectWithDict>& v) const
 {
-    pair<edm::ObjectWithDict, bool> ret(o,false);
-    const SingleInvoker *i = 0;
+  pair<edm::ObjectWithDict, bool> ret(o, false);
+  const SingleInvoker* i = 0;
     do {    
         edm::TypeWithDict type = ret.first.typeOf();
-        if (type.isClass()) type = ret.first.dynamicType();
-        i = & invoker(type);
+    if (type.isClass()) {
+      type = ret.first.dynamicType();
+    }
+    i = &invoker(type);
         ret = i->invoke(edm::ObjectWithDict(type, ret.first.address()), v);
-    } while (ret.second == false);
+  }
+  while (ret.second == false);
     return i->retToDouble(ret.first);
 }
 
-SingleInvoker::SingleInvoker(const edm::TypeWithDict &type,
-        const std::string &name,
-        const std::vector<AnyMethodArgument> &args) 
+SingleInvoker::
+SingleInvoker(const edm::TypeWithDict& type, const std::string& name,
+              const std::vector<AnyMethodArgument>& args)
 {
     TypeStack typeStack(1, type);
     LazyMethodStack dummy;
     MethodArgumentStack dummy2;
     MethodSetter setter(invokers_, dummy, typeStack, dummy2, false);
     isRefGet_ = !setter.push(name, args, "LazyInvoker dynamic resolution", false);
-    //std::cerr  << "SingleInvoker on type " <<  type.qualifiedName() << ", name " << name << (isRefGet_ ? " is just a ref.get " : " is real") << std::endl;
-    if(invokers_.front().isFunction()) {
+  //std::cerr  << "SingleInvoker on type " <<  type.qualifiedName() <<
+  //  ", name " << name << (isRefGet_ ? " is just a ref.get " : " is real") <<
+  //  std::endl;
+  if (invokers_.front().isFunction()) {
        edm::TypeWithDict retType = invokers_.front().method().finalReturnType();
        storageNeedsDestructor_ = ExpressionVar::makeStorage(storage_, retType);
-    } else {
+  }
+  else {
        storage_ = edm::ObjectWithDict();
        storageNeedsDestructor_ = false;
     }
-    retType_ = reco::typeCode(typeStack[1]); // typeStack[0] = type of self, typeStack[1] = type of ret
+  // typeStack[0] = type of self
+  // typeStack[1] = type of ret
+  retType_ = reco::typeCode(typeStack[1]);
 }
 
-SingleInvoker::~SingleInvoker()
+SingleInvoker::
+~SingleInvoker()
 {
     ExpressionVar::delStorage(storage_);
 }
 
-pair<edm::ObjectWithDict,bool>
-SingleInvoker::invoke(const edm::ObjectWithDict & o, std::vector<edm::ObjectWithDict> &v) const 
+pair<edm::ObjectWithDict, bool>
+SingleInvoker::
+invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
 {
-    /* std::cerr << "[SingleInvoker::invoke] member " << invokers_.front().method().qualifiedName() << 
-                                       " of type " << o.typeOf().qualifiedName() <<
-                                       (!isRefGet_ ? " is one shot" : " needs another round") << std::endl; */
-    pair<edm::ObjectWithDict,bool> ret(invokers_.front().invoke(o, storage_), !isRefGet_);
+  // std::cerr << "[SingleInvoker::invoke] member " <<
+  //   invokers_.front().method().qualifiedName() <<
+  //   " of type " <<
+  //   o.typeOf().qualifiedName() <<
+  //   (!isRefGet_ ? " is one shot" : " needs another round") <<
+  //   std::endl;
+  pair<edm::ObjectWithDict, bool>
+  ret(invokers_.front().invoke(o, storage_), !isRefGet_);
     if (storageNeedsDestructor_) {
-        //std::cout << "Storage type: " << storage_.typeOf().qualifiedName() << ", I have to call the destructor." << std::endl;
+    //std::cerr << "Storage type: " << storage_.typeOf().qualifiedName() <<
+    //  ", I have to call the destructor." << std::endl;
         v.push_back(storage_);
     }
     return ret;
 }
 
 double
-SingleInvoker::retToDouble(const edm::ObjectWithDict & o) const {
+SingleInvoker::
+retToDouble(const edm::ObjectWithDict& o) const
+{
     if (!ExpressionVar::isValidReturnType(retType_)) {
         throwFailedConversion(o);
     }
@@ -213,10 +297,13 @@ SingleInvoker::retToDouble(const edm::ObjectWithDict & o) const {
 }
 
 void
-SingleInvoker::throwFailedConversion(const edm::ObjectWithDict & o) const {
+SingleInvoker::
+throwFailedConversion(const edm::ObjectWithDict& o) const
+{
     throw edm::Exception(edm::errors::Configuration)
         << "member \"" << invokers_.back().methodName()
         << "\" return type is \"" << invokers_.back().returnTypeName()
         << "\" retured a \"" << o.typeOf().qualifiedName()
         << "\" which is not convertible to double.";
 }
+

--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -1,95 +1,123 @@
 #ifndef CommonTools_Utils_MethodInvoker_h
 #define CommonTools_Utils_MethodInvoker_h
-#include "FWCore/Utilities/interface/ObjectWithDict.h"
-#include "FWCore/Utilities/interface/FunctionWithDict.h"
-#include "FWCore/Utilities/interface/MemberWithDict.h"
-#include "FWCore/Utilities/interface/TypeID.h"
+
 #include "CommonTools/Utils/src/AnyMethodArgument.h"
 #include "CommonTools/Utils/src/TypeCode.h"
-#include <boost/utility.hpp>
+#include "FWCore/Utilities/interface/FunctionWithDict.h"
+#include "FWCore/Utilities/interface/MemberWithDict.h"
+#include "FWCore/Utilities/interface/ObjectWithDict.h"
+#include "FWCore/Utilities/interface/TypeID.h"
+
 #include <boost/shared_ptr.hpp>
-#include <vector>
+#include <boost/utility.hpp>
+
 #include <map>
+#include <vector>
 
 namespace reco {
-  namespace parser {
+namespace parser {
 
-    struct MethodInvoker {
-      explicit MethodInvoker(const edm::FunctionWithDict & method,
-			     const std::vector<AnyMethodArgument>    & ints   = std::vector<AnyMethodArgument>() );
-      explicit MethodInvoker(const edm::MemberWithDict & member);
-      MethodInvoker(const MethodInvoker &); 
-
-      /// Invokes the method, putting the result in retval.
-      /// Returns the Object that points to the result value, after removing any "*" and "&" 
-      /// Caller code is responsible for allocating retstore before calling 'invoke', and of deallocating it afterwards
-      edm::ObjectWithDict
-      invoke(const edm::ObjectWithDict & o, edm::ObjectWithDict &retstore) const;
-      edm::FunctionWithDict const method() const {return method_;}
-      edm::MemberWithDict const member() const {return member_;}
-      MethodInvoker & operator=(const MethodInvoker &);
-      bool isFunction() const {return isFunction_;}
-      std::string methodName() const;
-      std::string returnTypeName() const;
-    private:
+class MethodInvoker {
+private: // Private Data Members
       edm::FunctionWithDict method_;
       edm::MemberWithDict member_;
       std::vector<AnyMethodArgument> ints_; // already fixed to the correct type
       std::vector<void*> args_;
+
       bool isFunction_;
+  edm::TypeWithDict retTypeFinal_;
+private: // Private Function Members
       void setArgs();
-    };
+public: // Public Function Members
+  explicit MethodInvoker(const edm::FunctionWithDict& method,
+                         const std::vector<AnyMethodArgument>& ints =
+                           std::vector<AnyMethodArgument>());
+  explicit MethodInvoker(const edm::MemberWithDict&);
+  MethodInvoker(const MethodInvoker&);
+  MethodInvoker& operator=(const MethodInvoker&);
 
-    /// A bigger brother of the MethodInvoker:
-    /// - it owns also the object in which to store the result
-    /// - it handles by itself the popping out of Refs and Ptrs
-    /// in this way, it can map 1-1 to a name and set of args
-    struct SingleInvoker : boost::noncopyable {
-        SingleInvoker(const edm::TypeWithDict &t,
-                      const std::string &name, 
-                      const std::vector<AnyMethodArgument> &args)  ;
-        ~SingleInvoker();
+  edm::FunctionWithDict const method() const { return method_; }
+  edm::MemberWithDict const member() const { return member_; }
+  bool isFunction() const { return isFunction_; }
+  std::string methodName() const;
+  std::string returnTypeName() const;
 
-        /// If the member is found in object o, evaluate and return (value,true)
-        /// If the member is not found but o is a Ref/RefToBase/Ptr, (return o.get(), false)
-        /// the actual edm::ObjectWithDict where the result is stored will be pushed in vector
-        /// so that, if needed, its destructor can be called
-        std::pair<edm::ObjectWithDict,bool> invoke(const edm::ObjectWithDict & o, std::vector<edm::ObjectWithDict> &v) const;
+  /// Invokes the method, putting the result in retval.
+  /// Returns the Object that points to the result value,
+  /// after removing any "*" and "&"
+  /// Caller code is responsible for allocating retstore
+  /// before calling 'invoke', and of deallocating it afterwards
+  edm::ObjectWithDict invoke(const edm::ObjectWithDict& obj,
+                             edm::ObjectWithDict& retstore) const;
+};
         
-        // convert the output of invoke to a double, if possible
-        double retToDouble(const edm::ObjectWithDict & o) const;
-        void   throwFailedConversion(const edm::ObjectWithDict & o) const;
-      private:
+/// A bigger brother of the MethodInvoker:
+/// - it owns also the object in which to store the result
+/// - it handles by itself the popping out of Refs and Ptrs
+/// in this way, it can map 1-1 to a name and set of args
+struct SingleInvoker : boost::noncopyable {
+private: // Private Data Members
         method::TypeCode            retType_;
         std::vector<MethodInvoker>  invokers_;
         mutable edm::ObjectWithDict      storage_;
         bool                        storageNeedsDestructor_;
         /// true if this invoker just pops out a ref and returns (ref.get(), false)
         bool isRefGet_;
-    };
+public:
+  SingleInvoker(const edm::TypeWithDict&, const std::string& name,
+                const std::vector<AnyMethodArgument>& args);
+  ~SingleInvoker();
+
+  /// If the member is found in object o, evaluate and
+  /// return (value,true)
+  /// If the member is not found but o is a Ref/RefToBase/Ptr,
+  /// (return o.get(), false)
+  /// the actual edm::ObjectWithDict where the result is stored
+  /// will be pushed in vector so that, if needed, its destructor
+  /// can be called
+  std::pair<edm::ObjectWithDict, bool>
+  invoke(const edm::ObjectWithDict& o,
+         std::vector<edm::ObjectWithDict>& v) const;
+
+  /// convert the output of invoke to a double, if possible
+  double retToDouble(const edm::ObjectWithDict&) const;
+
+  void throwFailedConversion(const edm::ObjectWithDict&) const;
+};
 
 
-    /// Keeps different SingleInvokers for each dynamic type of the objects passed to invoke()
-    struct LazyInvoker {
-      explicit LazyInvoker(const std::string &name,
-			   const std::vector<AnyMethodArgument> &args);
+/// Keeps different SingleInvokers for each dynamic type of the objects passed to invoke()
+struct LazyInvoker {
+private: // Private Data Members
+  std::string name_;
+  std::vector<AnyMethodArgument> argsBeforeFixups_;
+  // the shared ptr is only to make the code exception safe
+  // otherwise I think it could leak if the constructor of
+  // SingleInvoker throws an exception (which can happen)
+  typedef boost::shared_ptr<SingleInvoker> SingleInvokerPtr;
+  mutable std::map<edm::TypeID, SingleInvokerPtr> invokers_;
+private: // Private Function Members
+  const SingleInvoker& invoker(const edm::TypeWithDict&) const;
+public: // Public Function Members
+  explicit LazyInvoker(const std::string& name,
+                       const std::vector<AnyMethodArgument>& args);
       ~LazyInvoker();
-      /// invoke method, returns object that points to result (after stripping '*' and '&')
+
+  /// invoke method, returns object that points to result
+  /// (after stripping '*' and '&')
       /// the object is still owned by the LazyInvoker
-      /// the actual edm::ObjectWithDict where the result is stored will be pushed in vector
+  /// the actual edm::ObjectWithDict where the result is
+  /// stored will be pushed in vector
       /// so that, if needed, its destructor can be called
-      edm::ObjectWithDict invoke(const edm::ObjectWithDict & o, std::vector<edm::ObjectWithDict> &v) const;
+  edm::ObjectWithDict invoke(const edm::ObjectWithDict& o,
+                             std::vector<edm::ObjectWithDict>& v) const;
+
       /// invoke and coerce result to double
-      double invokeLast(const edm::ObjectWithDict & o, std::vector<edm::ObjectWithDict> &v) const;
-    private:
-      std::string name_;
-      std::vector<AnyMethodArgument> argsBeforeFixups_;
-      typedef boost::shared_ptr<SingleInvoker> SingleInvokerPtr; // the shared ptr is only to make the code exception safe
-      mutable std::map<edm::TypeID, SingleInvokerPtr> invokers_;        // otherwise I think it could leak if the constructor of
-      const SingleInvoker & invoker(const edm::TypeWithDict &t) const ; // SingleInvoker throws an exception (which can happen)
-    };
+  double invokeLast(const edm::ObjectWithDict& o,
+                    std::vector<edm::ObjectWithDict>& v) const;
+};
 
-  }
-}
+} // namesapce parser
+} // namespace reco
 
-#endif
+#endif // CommonTools_Utils_MethodInvoker_h

--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -1,129 +1,171 @@
 #include "CommonTools/Utils/src/MethodSetter.h"
-#include "CommonTools/Utils/src/returnType.h"
-#include "CommonTools/Utils/src/findMethod.h"
-#include "CommonTools/Utils/src/findDataMember.h"
-#include "CommonTools/Utils/src/ErrorCodes.h"
+
 #include "CommonTools/Utils/interface/Exception.h"
+#include "CommonTools/Utils/src/ErrorCodes.h"
+#include "CommonTools/Utils/src/MethodInvoker.h"
+#include "CommonTools/Utils/src/findDataMember.h"
+#include "CommonTools/Utils/src/findMethod.h"
+#include "CommonTools/Utils/src/returnType.h"
+
 #include <string>
+
 using namespace reco::parser;
 using namespace std;
 
-void MethodSetter::operator()(const char * begin, const char * end) const {
+void
+MethodSetter::
+operator()(const char* begin, const char* end) const
+{
   string name(begin, end);
   string::size_type parenthesis = name.find_first_of('(');
-  if (*begin == '[' || *begin == '(') {
+  if ((*begin == '[') || (*begin == '(')) {
     name.insert(0, "operator..");           // operator..[arg];
     parenthesis = 10;                       //           ^--- idx = 10
     name[8] = *begin;                       // operator[.[arg];
-    name[9] =  name[name.size()-1];         // operator[][arg];
+    name[9] = name[name.size() - 1]; // operator[][arg];
     name[10] = '(';                         // operator[](arg];
-    name[name.size()-1] = ')';              // operator[](arg);    
+    name[name.size() - 1] = ')';     // operator[](arg);
     // we don't actually need the last two, but just for extra care
-    //std::cout << "Transformed {" << string(begin,end) << "} into {"<< name <<"}" << std::endl;
+    //std::cout << "Transformed {" << string(begin,end) << "} into
+    //  {"<< name <<"}" << std::endl;
   }
   std::vector<AnyMethodArgument> args;
-  if(parenthesis != string::npos) {
+  if (parenthesis != string::npos) {
     name.erase(parenthesis, name.size());
-    if(intStack_.size()==0)
+    if (intStack_.size() == 0) {
       throw Exception(begin)
 	<< "expected method argument, but non given.";    
-    for(vector<AnyMethodArgument>::const_iterator i = intStack_.begin(); i != intStack_.end(); ++i)
+    }
+    for (vector<AnyMethodArgument>::const_iterator i = intStack_.begin();
+         i != intStack_.end(); ++i) {
       args.push_back(*i);
+    }
     intStack_.clear();
   }
   string::size_type endOfExpr = name.find_last_of(' ');
-  if(endOfExpr != string::npos)
+  if (endOfExpr != string::npos) {
     name.erase(endOfExpr, name.size());
-  //std::cerr << "Pushing [" << name << "] with " << args.size() << " args " << (lazy_ ? "(lazy)" : "(immediate)") << std::endl;
-  if (lazy_) lazyMethStack_.push_back(LazyInvoker(name, args)); // for lazy parsing we just push method name and arguments
-  else push(name, args,begin);  // otherwise we really have to resolve the method
-  //std::cerr << "Pushed [" << name << "] with " << args.size() << " args " << (lazy_ ? "(lazy)" : "(immediate)") << std::endl;
+  }
+  //std::cerr << "Pushing [" << name << "] with " << args.size()
+  //  << " args " << (lazy_ ? "(lazy)" : "(immediate)") << std::endl;
+  if (lazy_) {
+    // for lazy parsing we just push method name and arguments
+    lazyMethStack_.push_back(LazyInvoker(name, args));
+  }
+  else {
+    // otherwise we really have to resolve the method
+    push(name, args, begin);
+  }
+  //std::cerr << "Pushed [" << name << "] with " << args.size() <<
+  //  " args " << (lazy_ ? "(lazy)" : "(immediate)") << std::endl;
 }
 
-bool MethodSetter::push(const string & name, const vector<AnyMethodArgument> & args, const char* begin,bool deep) const {
+bool
+MethodSetter::
+push(const string& name, const vector<AnyMethodArgument>& args,
+     const char* begin, bool deep) const
+{
   edm::TypeWithDict type = typeStack_.back();
   vector<AnyMethodArgument> fixups;
-  int error;
-  pair<edm::FunctionWithDict, bool> mem = reco::findMethod(type, name, args, fixups,begin,error);
-  if(mem.first) {
+  int error = 0;
+  pair<edm::FunctionWithDict, bool> mem =
+    reco::findMethod(type, name, args, fixups, begin, error);
+  if (bool(mem.first)) {
+    // We found the method.
      edm::TypeWithDict retType = reco::returnType(mem.first);
-     if(!retType) {
+    if (!bool(retType)) {
+      // Invalid return type, fatal error, throw.
         throw Exception(begin)
-     	<< "member \"" << mem.first.name() << "\" return type is invalid:\n" 
-        << "  member type: \"" <<  mem.first.typeOf().qualifiedName() << "\"\n"
-     	<< "  return type: \"" << mem.first.returnType().qualifiedName() << "\"\n";
-        
+          << "member \"" << mem.first.name()
+          << "\" return type is invalid:\n"
+          << "  member type: \""
+          <<  mem.first.typeOf().qualifiedName() << "\"\n"
+          << "  return type: \""
+          << mem.first.returnType().qualifiedName() << "\"\n";
      }
      typeStack_.push_back(retType);
      // check for edm::Ref, edm::RefToBase, edm::Ptr
-     if(mem.second) {
-        //std::cout << "Mem.second, so book " << mem.first.name() << " without fixups." << std::endl;
+    if (mem.second) {
+      // Without fixups.
+      //std::cout << "Mem.second, so book " << mem.first.name() <<
+      //  " without fixups." << std::endl;
         methStack_.push_back(MethodInvoker(mem.first));
-        if (deep) push(name, args,begin); // note: we have not found the method, so we have not fixupped the arguments
-        else return false;
-      } else {
-        //std::cout << "Not mem.second, so book " << mem.first.name() << " with #args = " << fixups.size() << std::endl;
+      if (!deep) {
+        return false;
+      }
+      // note: we have not found the method, so we have not
+      // fixupped the arguments
+      push(name, args, begin);
+    }
+    else {
+      // With fixups.
+      //std::cout << "Not mem.second, so book " << mem.first.name()
+      //  << " with #args = " << fixups.size() << std::endl;
         methStack_.push_back(MethodInvoker(mem.first, fixups));
       }
-  } else {
-     if(error != reco::parser::kNameDoesNotExist) {
-        switch(error) {
+    return true;
+  }
+  if (error != reco::parser::kNameDoesNotExist) {
+    // Fatal error, throw.
+    switch (error) {
            case reco::parser::kIsNotPublic:
             throw Exception(begin)
               << "method named \"" << name << "\" for type \"" 
-              <<type.name() << "\" is not publically accessible.";
+            << type.name() << "\" is not publically accessible.";
             break;
            case reco::parser::kIsStatic:
              throw Exception(begin)
                << "method named \"" << name << "\" for type \"" 
-               <<type.name() << "\" is static.";
+            << type.name() << "\" is static.";
              break;
            case reco::parser::kIsNotConst:
               throw Exception(begin)
                 << "method named \"" << name << "\" for type \"" 
-                <<type.name() << "\" is not const.";
+            << type.name() << "\" is not const.";
               break;
            case reco::parser::kWrongNumberOfArguments:
                throw Exception(begin)
                  << "method named \"" << name << "\" for type \"" 
-                 <<type.name() << "\" was passed the wrong number of arguments.";
+            << type.name() << "\" was passed the wrong number of arguments.";
                break;
            case reco::parser::kWrongArgumentType:
                throw Exception(begin)
                      << "method named \"" << name << "\" for type \"" 
-                     <<type.name() << "\" was passed the wrong types of arguments.";
+            << type.name() << "\" was passed the wrong types of arguments.";
                break;
            default:  
             throw Exception(begin)
              << "method named \"" << name << "\" for type \"" 
-             <<type.name() << "\" is not usable in this context.";
+            << type.name() << "\" is not usable in this context.";
         }
      }
-     //see if it is a member data
-     int error;
-    edm::MemberWithDict member(reco::findDataMember(type,name,error));
-     if(!member) {
-        switch(error) {
+  // Not a method, check for a data member.
+  error = 0;
+  edm::MemberWithDict member(reco::findDataMember(type, name, error));
+  if (!bool(member)) {
+    // Not a data member either, fatal error, throw.
+    switch (error) {
            case reco::parser::kNameDoesNotExist:
             throw Exception(begin)
-               << "no method or data member named \"" << name << "\" found for type \"" 
-               <<type.name() << "\"";
+            << "no method or data member named \"" << name
+            << "\" found for type \""
+            << type.name() << "\"";
             break;
            case reco::parser::kIsNotPublic:
             throw Exception(begin)
               << "data member named \"" << name << "\" for type \"" 
-              <<type.name() << "\" is not publically accessible.";
+            << type.name() << "\" is not publically accessible.";
             break;
            default:
            throw Exception(begin)
              << "data member named \"" << name << "\" for type \"" 
-             <<type.name() << "\" is not usable in this context.";
+            << type.name() << "\" is not usable in this context.";
            break;
         }
      }
+  // Ok, it was a data member.
      typeStack_.push_back(member.typeOf());
      methStack_.push_back(MethodInvoker(member));
-  }
   return true;
 }
     

--- a/CommonTools/Utils/src/MethodSetter.h
+++ b/CommonTools/Utils/src/MethodSetter.h
@@ -1,45 +1,73 @@
 #ifndef CommonTools_Utils_MethodSetter_h
 #define CommonTools_Utils_MethodSetter_h
+
 /* \class reco::parser::MethodSetter
  *
  * \author Luca Lista, INFN
  *
- * \version $Id: MethodSetter.h,v 1.3 2010/02/20 00:44:40 gpetrucc Exp $
  */
+
 #include "CommonTools/Utils/src/MethodStack.h"
 #include "CommonTools/Utils/src/TypeStack.h"
 #include "CommonTools/Utils/src/MethodArgumentStack.h"
 
 namespace reco {
-  namespace parser {
-    struct MethodSetter {
-      explicit MethodSetter(MethodStack & methStack, LazyMethodStack & lazyMethStack, TypeStack & typeStack,
-			    MethodArgumentStack & intStack, bool lazy=false) : 
-	methStack_(methStack), lazyMethStack_(lazyMethStack), typeStack_(typeStack),
-	intStack_(intStack), lazy_(lazy) { }
-      void operator()(const char *, const char *) const;
-      /// Resolve the method, push a MethodInvoker on the MethodStack and it's return type to TypeStack (after stripping "*" and "&")
-      /// This method is used also by the LazyInvoker to perform the fetch once the final type is known
-      /// If the object is a Ref/Ptr/RefToBase and the method is not found in that class:
+namespace parser {
+
+class MethodSetter {
+private:
+  MethodStack& methStack_;
+  LazyMethodStack& lazyMethStack_;
+  TypeStack& typeStack_;
+  MethodArgumentStack& intStack_;
+  bool lazy_;
+public:
+  explicit
+  MethodSetter(MethodStack& methStack, LazyMethodStack& lazyMethStack,
+               TypeStack& typeStack, MethodArgumentStack& intStack,
+               bool lazy = false)
+    : methStack_(methStack)
+    , lazyMethStack_(lazyMethStack)
+    , typeStack_(typeStack)
+    , intStack_(intStack)
+    , lazy_(lazy)
+  {
+  }
+
+  void operator()(const char*, const char*) const;
+
+  /// Resolve the name to either a function member or a data member,
+  /// push a MethodInvoker on the MethodStack, and its return type to
+  /// the TypeStack (after stripping "*" and "&").
+  ///
+  /// This method is used also by the LazyInvoker to perform the fetch once
+  /// the final type is known.
+  ///
+  /// If the object is an edm::Ref/Ptr/RefToBase and the method is not
+  /// found in the class:
+  ///
       ///  1)  it pushes a no-argument 'get()' method
-      ///  2)  if deep = true, it attempts to resolve and push the method on the object to which the edm ref points to. 
-      ///         In that case, the MethodStack will contain two more items after this call instead of just one.
-      ///         This behaviour is what you want for non-lazy parsing
+  ///
+  ///  2)  if deep = true, it attempts to resolve and push the method on
+  ///      the object to which the edm ref points to.  In that case, the
+  ///      MethodStack will contain two more items after this call instead
+  ///      of just one.  This behaviour is what you want for non-lazy parsing.
+  ///
       ///  2b) if instead deep = false, it just pushes the 'get' on the stack.
-      ///      this will allow the LazyInvoker to then re-discover the runtime type of the pointee
+  ///      this will allow the LazyInvoker to then re-discover the runtime
+  ///      type of the pointee
+  ///
       ///  The method will:
       ///     - throw exception, if the member can't be resolved
-      ///     - return 'false' if deep = false and it only pushed a 'get' on the stack
+  ///     - return 'false' if deep = false and it only pushed
+  //        a 'get' on the stack
       ///     - return true otherwise
-      bool push(const std::string&, const std::vector<AnyMethodArgument>&,const char*,bool deep=true) const;
-    private:
-      MethodStack & methStack_;
-      LazyMethodStack & lazyMethStack_;
-      TypeStack & typeStack_;
-      MethodArgumentStack & intStack_;
-      bool lazy_;
-    };
-  }
-}
+  ///
+  bool push(const std::string&, const std::vector<AnyMethodArgument>&,
+            const char*, bool deep = true) const;
+};
 
-#endif
+} // namespace parser
+} // namespace reco
+
+#endif // CommonTools_Utils_MethodSetter_h

--- a/CommonTools/Utils/src/MethodStack.h
+++ b/CommonTools/Utils/src/MethodStack.h
@@ -1,22 +1,22 @@
 #ifndef CommonTools_Utils_MethodStack_h
 #define CommonTools_Utils_MethodStack_h
+
 /* \class reco::parser::MethodStack
  *
  * Stack of methods
  *
  * \author  Luca Lista, INFN
  *
- * \version $Revision: 1.3 $
- *
  */
+
 #include "CommonTools/Utils/src/MethodInvoker.h"
 #include <vector>
 
 namespace reco {
-  namespace parser {
-    typedef std::vector<MethodInvoker> MethodStack;
-    typedef std::vector<LazyInvoker>   LazyMethodStack;
-  }
-}
+namespace parser {
+typedef std::vector<MethodInvoker> MethodStack;
+typedef std::vector<LazyInvoker> LazyMethodStack;
+} // namespace parser
+} // namespace reco
 
-#endif
+#endif // CommonTools_Utils_MethodStack_h

--- a/CommonTools/Utils/src/returnType.cc
+++ b/CommonTools/Utils/src/returnType.cc
@@ -1,25 +1,31 @@
 #include "CommonTools/Utils/src/returnType.h"
-#include <vector>
+
+#include "FWCore/Utilities/interface/FunctionWithDict.h"
+#include "FWCore/Utilities/interface/TypeWithDict.h"
+
 #include <algorithm>
-#include <string>
 #include <cstring>
-using namespace std;
+#include <string>
+#include <vector>
+
 using namespace reco::method;
+using namespace std;
 
 namespace reco {
-  edm::TypeWithDict returnType(const edm::FunctionWithDict & mem) {
-    return mem.finalReturnType();
+
+  edm::TypeWithDict returnType(const edm::FunctionWithDict& func) {
+    return func.finalReturnType();
   }
 
-  TypeCode returnTypeCode(const edm::FunctionWithDict & mem) {
-    return typeCode(returnType(mem));
+  TypeCode returnTypeCode(const edm::FunctionWithDict& func) {
+    return typeCode(returnType(func));
   }
 
   //this is already alphabetized
-  static const std::vector<std::pair<char const * const, method::TypeCode> > retTypeVec {
-     {"bool",boolType},
-     {"char",charType},
-     {"double",doubleType},
+  static const std::vector<std::pair<char const* const, method::TypeCode> > retTypeVec {
+     {"bool", boolType},
+     {"char", charType},
+     {"double", doubleType},
      {"float", floatType},
      {"int", intType},
      {"long", longType},
@@ -30,21 +36,24 @@ namespace reco {
      {"unsigned char", uCharType},
      {"unsigned int", uIntType},
      {"unsigned long", uLongType},
-     {"unsigned long int",uLongType},
-     {"unsigned short",uShortType},
-     {"unsigned short int",uShortType}
+     {"unsigned long int", uLongType},
+     {"unsigned short", uShortType},
+     {"unsigned short int", uShortType}
   };
 
-  TypeCode typeCode(const edm::TypeWithDict & t) {
-
-    typedef std::pair<const char*const, method::TypeCode> Values;
-    std::string const theName(t.name());
-    char const* name = theName.c_str();
-    auto f = std::equal_range(retTypeVec.begin(),retTypeVec.end(),Values{name,enumType},
-                              [] ( Values const& iLHS, Values const& iRHS) -> bool{
-       return std::strcmp(iLHS.first,iRHS.first)<0;
+  TypeCode typeCode(const edm::TypeWithDict& t) {
+    typedef std::pair<const char* const, method::TypeCode> Values;
+    const char* name = t.name().c_str();
+    auto f = std::equal_range(retTypeVec.begin(), retTypeVec.end(),
+      Values{name, enumType},
+      [](const Values& iLHS, const Values& iRHS) -> bool {
+        return std::strcmp(iLHS.first, iRHS.first) < 0;
     });
-    if (f.first == f.second) return (t.isEnum() ? enumType : invalid);
-    else return f.first->second;
+    if (f.first == f.second) {
+      return t.isEnum() ? enumType : invalid;
   }
-}
+    return f.first->second;
+  }
+
+} // namespace reco
+

--- a/CommonTools/Utils/src/returnType.h
+++ b/CommonTools/Utils/src/returnType.h
@@ -1,20 +1,23 @@
 #ifndef CommonTools_Utils_returnType_h
 #define CommonTools_Utils_returnType_h
+
 /* \function returnType
  *
  * \author Luca Lista, INFN
  *
- * \version $Id: returnType.h,v 1.3 2012/08/03 18:08:11 wmtan Exp $
  */
 
 #include "CommonTools/Utils/src/TypeCode.h"
-#include "FWCore/Utilities/interface/FunctionWithDict.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 
-namespace reco {
-  edm::TypeWithDict returnType(const edm::FunctionWithDict &);
-  method::TypeCode returnTypeCode(const edm::FunctionWithDict &);
-  method::TypeCode typeCode(const edm::TypeWithDict &);
+namespace edm {
+class FunctionWithDict;
 }
 
-#endif
+namespace reco {
+  edm::TypeWithDict returnType(const edm::FunctionWithDict&);
+  method::TypeCode returnTypeCode(const edm::FunctionWithDict&);
+  method::TypeCode typeCode(const edm::TypeWithDict&);
+}
+
+#endif // CommonTools_Utils_returnType_h

--- a/DataFormats/Common/test/DictionaryTools_t.cpp
+++ b/DataFormats/Common/test/DictionaryTools_t.cpp
@@ -67,12 +67,15 @@ namespace {
       std::string demangledName(edm::typeDemangle(typeid(T).name()));
       CPPUNIT_ASSERT(type.name() == demangledName);
 
-      edm::TypeID tid(type.typeInfo());
+      edm::TypeID tid(typeid(T));
       CPPUNIT_ASSERT(tid.className() == demangledName);
 
       edm::TypeWithDict typeFromName = edm::TypeWithDict::byName(demangledName);
-      edm::TypeID tidFromName(typeFromName.typeInfo());
-      CPPUNIT_ASSERT(tidFromName.className() == demangledName);
+      CPPUNIT_ASSERT(typeFromName.name() == demangledName);
+      if (type.isClass()) {
+        edm::TypeID tidFromName(typeFromName.typeInfo());
+        CPPUNIT_ASSERT(tidFromName.className() == demangledName);
+      }
     }
   }
 

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -94,7 +94,7 @@ namespace edm {
       } else if(!desc.present() && !desc.produced()) {
         // else if the branch containing the product has been previously dropped,
         // output nothing
-      } else if(desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+      } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
         associationDescriptions.push_back(&desc);
       } else if(selected(desc)) {
         keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -234,7 +234,7 @@ namespace edm {
       } else if(!desc.present() && !desc.produced()) {
         // else if the branch containing the product has been previously dropped,
         // output nothing
-      } else if(desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+      } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
         associationDescriptions.push_back(&desc);
       } else if(productSelector_.selected(desc)) {
         keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -100,7 +100,7 @@ namespace edm {
         } else if(!desc.present() && !desc.produced()) {
           // else if the branch containing the product has been previously dropped,
           // output nothing
-        } else if(desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+        } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
           associationDescriptions.push_back(&desc);
         } else if(selected(desc)) {
           keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -176,11 +176,11 @@ namespace edm {
        ObjectWithDict sizeObj;
        try {
           size_t temp; //used to hold the memory for the return value
+          FunctionWithDict sizeFunc = iObject.typeOf().functionMemberByName("size");
+          assert(sizeFunc.returnType() == typeid(size_t));
           sizeObj = ObjectWithDict(TypeWithDict(typeid(size_t)), &temp);
-          iObject.typeOf().functionMemberByName("size").invoke(iObject, &sizeObj);
-          assert(iObject.typeOf().functionMemberByName("size").returnType().typeInfo() == typeid(size_t));
+          sizeFunc.invoke(iObject, &sizeObj);
           //std::cout << "size of type '" << sizeObj.name() << "' " << sizeObj.typeName() << std::endl;
-          assert(sizeObj.typeOf().typeInfo() == typeid(size_t));
           size_t size = *reinterpret_cast<size_t*>(sizeObj.address());
           FunctionWithDict atMember;
           try {

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -184,6 +184,14 @@ namespace edm {
     return !(a == b);
   }
 
+  inline bool operator==(TypeWithDict const& a, std::type_info const& b) {
+    return a.typeInfo() == b;
+  }
+
+  inline bool operator!=(TypeWithDict const& a, std::type_info const& b) {
+    return !(a == b);
+  }
+
   std::ostream& operator<<(std::ostream& os, TypeWithDict const& id);
 
   class TypeBases {

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -100,7 +100,7 @@ namespace edm {
         if(it->second.present()) {
           idsToReplace[it->second.branchType()].insert(it->second.branchID());
           if(it->second.branchType() == InEvent &&
-             it->second.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+             it->second.unwrappedType() == typeid(ThinnedAssociation)) {
             associationsFromSecondary.insert(it->second.branchID());
           }
           //now make sure this is marked as not dropped else the product will not be 'get'table from the Event

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1718,7 +1718,7 @@ namespace edm {
     for(auto const& product : prodList) {
       BranchDescription const& prod = product.second;
       // Special handling for ThinnedAssociations
-      if(prod.unwrappedType().typeInfo() == typeid(ThinnedAssociation) && prod.present()) {
+      if(prod.unwrappedType() == typeid(ThinnedAssociation) && prod.present()) {
         if(inputType != InputType::SecondarySource) {
           associationDescriptions.push_back(&prod);
         } else {
@@ -1777,7 +1777,7 @@ namespace edm {
       BranchDescription const& prod = it->second;
       bool drop = branchesToDrop.find(prod.branchID()) != branchesToDropEnd;
       if(drop) {
-        if(productSelector.selected(prod) && prod.unwrappedType().typeInfo() != typeid(ThinnedAssociation)) {
+        if(productSelector.selected(prod) && prod.unwrappedType() != typeid(ThinnedAssociation)) {
           LogWarning("RootFile")
             << "Branch '" << prod.branchName() << "' is being dropped from the input\n"
             << "of file '" << file_ << "' because it is dependent on a branch\n"


### PR DESCRIPTION
This pull request has two purposes:

1) In ROOT6, ROOT does not provide type_info information for non-class types, such as enums, pointers, and C-Style arrays.  This currently can cause TypeWithDict::typeInfo() to return incorrect information in the ROOT6 IB.  The first step to fixing this problem is to remove unnecessary calls to TypeWithDict::typeInfo().  This pull request does this in the framework and in
CommonTools/Utils/src/AnyMethodArgument.h. Since the changed code works equally well in ROOT5, this is being requested in the main 7_4_X branch (ROOT5) for code commonality.

2) I happened to notice that I had extensively edited several other source files in ComonTools/Utils in the ROOT6 branch to make them more readable (non-substantive formatting changes).  These changes should have been made in the main branch as well for code commonality.  This pull request makes the same changes in the main 7_4_X branch for code commonality with the ROOT6 IB.  All the changes in CommonTools/Utils, except for those in AnyMethodArgument.h, are essentially no-ops.

All unit tests in the affected packages pass and the short relval matrix tests still pass with these changes.

I request that this pull request not be merged into the 7_4_X_ROOT6 branch, because these changes will be made there independently.  This is not critical, because I can clean things up if merging this causes any problems in the 7_4_X_ROOT6 branch.
