### PR TITLE
Protect against inaccurate type_info information

### DIFF
--- a/CommonTools/Utils/src/AnyMethodArgument.h
+++ b/CommonTools/Utils/src/AnyMethodArgument.h
@@ -52,7 +52,6 @@ namespace reco {
     class AnyMethodArgumentFixup : public boost::static_visitor<std::pair<AnyMethodArgument, int> > {
         private:
             edm::TypeWithDict dataType_;
-            const std::type_info & type_;
             template<typename From, typename To>
             std::pair<AnyMethodArgument, int> retOk_(const From &f, int cast) const {
                 return std::pair<AnyMethodArgument,int>(AnyMethodArgument(static_cast<To>(f)), cast);
@@ -60,23 +59,22 @@ namespace reco {
 
             // correct return for each int output type
             std::pair<AnyMethodArgument,int> doInt(int t) const {
-                if (type_ == typeid(int8_t))   { return retOk_<int,int8_t>  (t,0); }
-                if (type_ == typeid(uint8_t))  { return retOk_<int,uint8_t> (t,0); }
-                if (type_ == typeid(int16_t))  { return retOk_<int,int16_t> (t,0); }
-                if (type_ == typeid(uint16_t)) { return retOk_<int,uint16_t>(t,0); }
-                if (type_ == typeid(int32_t))  { return retOk_<int,int32_t> (t,0); }
-                if (type_ == typeid(uint32_t)) { return retOk_<int,uint32_t>(t,0); }
-                if (type_ == typeid(int64_t))  { return retOk_<int,int64_t> (t,0); }
-                if (type_ == typeid(uint64_t)) { return retOk_<int,uint64_t>(t,0); }
-                if (type_ == typeid(unsigned long)) { return retOk_<int,unsigned long>  (t,0); } // harmless if unsigned long matches another type
-                if (type_ == typeid(double))   { return retOk_<int,double>  (t,1); }
-                if (type_ == typeid(float))    { return retOk_<int,float>   (t,1); }
+                if (dataType_ == typeid(int8_t))   { return retOk_<int,int8_t>  (t,0); }
+                if (dataType_ == typeid(uint8_t))  { return retOk_<int,uint8_t> (t,0); }
+                if (dataType_ == typeid(int16_t))  { return retOk_<int,int16_t> (t,0); }
+                if (dataType_ == typeid(uint16_t)) { return retOk_<int,uint16_t>(t,0); }
+                if (dataType_ == typeid(int32_t))  { return retOk_<int,int32_t> (t,0); }
+                if (dataType_ == typeid(uint32_t)) { return retOk_<int,uint32_t>(t,0); }
+                if (dataType_ == typeid(int64_t))  { return retOk_<int,int64_t> (t,0); }
+                if (dataType_ == typeid(uint64_t)) { return retOk_<int,uint64_t>(t,0); }
+                if (dataType_ == typeid(unsigned long)) { return retOk_<int,unsigned long>  (t,0); } // harmless if unsigned long matches another type
+                if (dataType_ == typeid(double))   { return retOk_<int,double>  (t,1); }
+                if (dataType_ == typeid(float))    { return retOk_<int,float>   (t,1); }
                 return std::pair<AnyMethodArgument,int>(t,-1);
             }
         public:
             AnyMethodArgumentFixup(const edm::TypeWithDict& type) : 
-                dataType_(type),
-                type_(type.typeInfo())
+                dataType_(type)
             {
             }
 
@@ -88,8 +86,8 @@ namespace reco {
             template<typename F>
             typename boost::enable_if<boost::is_floating_point<F>, std::pair<AnyMethodArgument,int> >::type
             operator()(const F &t) const { 
-                if (type_ == typeid(double)) { return retOk_<F,double>(t,0); }
-                if (type_ == typeid(float))  { return retOk_<F,float> (t,0); }
+                if (dataType_ == typeid(double)) { return retOk_<F,double>(t,0); }
+                if (dataType_ == typeid(float))  { return retOk_<F,float> (t,0); }
                 return std::pair<AnyMethodArgument,int>(t,-1);
             }
 
@@ -102,7 +100,7 @@ namespace reco {
                     // std::cerr << "  value is = " << dataType_.stringToEnumValue(t) << std::endl;
                     return std::pair<AnyMethodArgument,int>(ival,1);
                 }
-                if (type_ == typeid(std::string)) { return std::pair<AnyMethodArgument,int>(t,0); }
+                if (dataType_ == typeid(std::string)) { return std::pair<AnyMethodArgument,int>(t,0); }
                 return std::pair<AnyMethodArgument,int>(t,-1);
             }
 

--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -191,7 +191,7 @@ invoker(const edm::TypeWithDict& type) const
 {
   //std::cout << "LazyInvoker for " << name_ << " called on type " <<
   //  type.qualifiedName() << std::endl;
-  SingleInvokerPtr& invoker = invokers_[edm::TypeID(type.id())];
+  SingleInvokerPtr& invoker = invokers_[edm::TypeID(type.typeInfo())];
   if (!invoker) {
     //std::cout << "  Making new invoker for " << name_ << " on type " <<
     //  type.qualifiedName() << std::endl;

--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -55,7 +55,7 @@ checkMethod(const edm::FunctionWithDict& mem,
   if (mem.name().substr(0, 2) == "__") {
     return -1 * parser::kIsFunctionAddedByROOT;
   }
-  if (mem.declaringType().id() != type.id()) {
+  if (mem.declaringType() != type) {
     //std::cerr <<
     //  "\nMETHOD OVERLOAD " <<
     //  mem.name() <<

--- a/CondCore/DBCommon/plugins/BlobStreamingService.cc
+++ b/CondCore/DBCommon/plugins/BlobStreamingService.cc
@@ -164,10 +164,9 @@ namespace cond {
   };
   
   
-  int BlobStreamingService::isVectorChar(edm::TypeWithDict const & classDictionary) {
-    std::type_info const & t = classDictionary.typeInfo();
-    if (t==typeid(std::vector<unsigned char>) ) return 1;
-    if (t==typeid(std::vector<char>) ) return 2;
+  int BlobStreamingService::isVectorChar(edm::TypeWithDict const& classDictionary) {
+    if (classDictionary == typeid(std::vector<unsigned char>)) return 1;
+    if (classDictionary == typeid(std::vector<char>)) return 2;
     return 0;
   }
   

--- a/CondCore/ORA/src/PrimitiveStreamer.cc
+++ b/CondCore/ORA/src/PrimitiveStreamer.cc
@@ -27,8 +27,7 @@ bool ora::PrimitiveStreamerBase::buildDataElement(DataElement& dataElement,
                     "PrimitiveStreamerBase::buildDataElement");
   }
 
-  const std::type_info* attrType = &m_objectType.typeInfo();
-  if(m_objectType.isEnum()) attrType = &typeid(int);
+  const std::type_info* attrType = m_objectType.isEnum() ? &typeid(int) : &m_objectType.typeInfo();
   if(ClassUtils::isTypeString( m_objectType )) attrType = &typeid(std::string);
   std::string columnName = m_mapping.columnNames()[0];
   m_columnIndex = relationalData.addData( columnName, *attrType );

--- a/CondCore/ORA/src/RelationalMapping.cc
+++ b/CondCore/ORA/src/RelationalMapping.cc
@@ -45,7 +45,7 @@ ora::RelationalMapping::_sizeInColumns(const edm::TypeWithDict& topLevelClassTyp
     _sizeInColumnsForCArray( typ,arraySize, hasDependencies );
     if( arraySize < MappingRules::MaxColumnsForInlineCArray ) sz += arraySize;
     else hasDependencies = true;
-  } else if (typ.typeInfo() == typeid(ora::Reference) ||
+  } else if (typ == typeid(ora::Reference) ||
              typ.hasBase( edm::TypeWithDict( typeid(ora::Reference) ) )){
     sz += 2;
   } else {
@@ -126,11 +126,11 @@ ora::IRelationalMapping* ora::RelationalMappingFactory::newProcessor( const edm:
   else if ( ora::ClassUtils::isTypeUniqueReference( resType )){
     return new UniqueReferenceMapping( attributeType, m_tableRegister );
   }
-  else if ( resType.typeInfo() == typeid(ora::Reference) ||
+  else if ( resType == typeid(ora::Reference) ||
             resType.hasBase( edm::TypeWithDict( typeid(ora::Reference) ) ) ){
     return new OraReferenceMapping( attributeType, m_tableRegister );
   }
-  else if ( resType.typeInfo() == typeid(ora::NamedReference) ||
+  else if ( resType == typeid(ora::NamedReference) ||
             resType.hasBase( edm::TypeWithDict( typeid(ora::NamedReference) ) ) ){
     return new NamedRefMapping( attributeType, m_tableRegister );
   }
@@ -185,8 +185,7 @@ void ora::PrimitiveMapping::process( MappingElement& parentElement,
                                      const std::string& attributeNameForSchema,
                                      const std::string& scopeNameForSchema ){
   edm::TypeWithDict t = ClassUtils::resolvedType( m_type );
-  const std::type_info* attrType = &t.typeInfo();
-  if(t.isEnum()) attrType = &typeid(int);
+  const std::type_info* attrType = t.isEnum() ? &typeid(int) : &t.typeInfo();
   //std::string tn = ClassUtils::demangledName(*attrType);
   if(ClassUtils::isTypeString( t )) attrType = &typeid(std::string);
   std::string typeName = coral::AttributeSpecification::typeNameForId(*attrType);

--- a/DataFormats/Common/test/DictionaryTools_t.cpp
+++ b/DataFormats/Common/test/DictionaryTools_t.cpp
@@ -65,12 +65,15 @@ namespace {
       std::string demangledName(edm::typeDemangle(typeid(T).name()));
       CPPUNIT_ASSERT(type.name() == demangledName);
 
-      edm::TypeID tid(type.typeInfo());
+      edm::TypeID tid(typeid(T));
       CPPUNIT_ASSERT(tid.className() == demangledName);
 
       edm::TypeWithDict typeFromName = edm::TypeWithDict::byName(demangledName);
-      edm::TypeID tidFromName(typeFromName.typeInfo());
-      CPPUNIT_ASSERT(tidFromName.className() == demangledName);
+      CPPUNIT_ASSERT(typeFromName.name() == demangledName);
+      if (type.isClass()) {
+        edm::TypeID tidFromName(typeFromName.typeInfo());
+        CPPUNIT_ASSERT(tidFromName.className() == demangledName);
+      }
     }
   }
 

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -94,7 +94,7 @@ namespace edm {
       } else if(!desc.present() && !desc.produced()) {
         // else if the branch containing the product has been previously dropped,
         // output nothing
-      } else if(desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+      } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
         associationDescriptions.push_back(&desc);
       } else if(selected(desc)) {
         keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -234,7 +234,7 @@ namespace edm {
       } else if(!desc.present() && !desc.produced()) {
         // else if the branch containing the product has been previously dropped,
         // output nothing
-      } else if(desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+      } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
         associationDescriptions.push_back(&desc);
       } else if(productSelector_.selected(desc)) {
         keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -100,7 +100,7 @@ namespace edm {
         } else if(!desc.present() && !desc.produced()) {
           // else if the branch containing the product has been previously dropped,
           // output nothing
-        } else if(desc.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+        } else if(desc.unwrappedType() == typeid(ThinnedAssociation)) {
           associationDescriptions.push_back(&desc);
         } else if(selected(desc)) {
           keepThisBranch(desc, trueBranchIDToKeptBranchDesc, keptProductsInEvent);

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -176,11 +176,11 @@ namespace edm {
        ObjectWithDict sizeObj;
        try {
           size_t temp; //used to hold the memory for the return value
+          FunctionWithDict sizeFunc = iObject.typeOf().functionMemberByName("size");
+          assert(sizeFunc.returnType() == typeid(size_t));
           sizeObj = ObjectWithDict(TypeWithDict(typeid(size_t)), &temp);
-          iObject.typeOf().functionMemberByName("size").invoke(iObject, &sizeObj);
-          assert(iObject.typeOf().functionMemberByName("size").returnType().typeInfo() == typeid(size_t));
+          sizeFunc.invoke(iObject, &sizeObj);
           //std::cout << "size of type '" << sizeObj.name() << "' " << sizeObj.typeName() << std::endl;
-          assert(sizeObj.typeOf().typeInfo() == typeid(size_t));
           size_t size = *reinterpret_cast<size_t*>(sizeObj.address());
           FunctionWithDict atMember;
           try {

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -40,6 +40,8 @@ class TypeWithDict {
   friend class TypeBases;
   friend class TypeDataMembers;
   friend class TypeFunctionMembers;
+  friend bool operator==(TypeWithDict const&, std::type_info const&);
+  typedef enum{} dummyEnum;
 private:
   std::type_info const* ti_;
   TType* type_;
@@ -62,7 +64,6 @@ public:
   explicit TypeWithDict(TType* type, long property = 0L);
   explicit operator bool() const;
   std::type_info const& typeInfo() const;
-  std::type_info const& id() const;
   TClass* getClass() const;
   TEnum* getEnum() const;
   TDataType* getDataType() const;
@@ -127,6 +128,20 @@ bool operator==(TypeWithDict const& a, TypeWithDict const& b);
 
 inline bool operator!=(TypeWithDict const& a, TypeWithDict const& b) {
   return !(a == b);
+}
+
+bool operator==(TypeWithDict const& a, std::type_info const& b);
+
+inline bool operator!=(TypeWithDict const& a, std::type_info const& b) {
+  return !(a == b);
+}
+
+inline bool operator==(std::type_info const& a, TypeWithDict const& b) {
+  return b == a;
+}
+
+inline bool operator!=(std::type_info const& a, TypeWithDict const& b) {
+  return !(b == a);
 }
 
 std::ostream& operator<<(std::ostream& os, TypeWithDict const& id);

--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -141,10 +141,10 @@ namespace edm {
   void
   public_base_classes(TypeWithDict const& typeID,
                       std::vector<TypeWithDict>& baseTypes) {
-    TypeWithDict type(typeID.typeInfo());
-    if (!type.isClass()) {
+    if (!typeID.isClass()) {
       return;
     }
+    TypeWithDict type(typeID.typeInfo());
     TypeBases bases(type);
     for (auto const& basex : bases) {
       BaseWithDict base(basex);
@@ -157,7 +157,7 @@ namespace edm {
       }
       TypeWithDict baseType(baseRflxType.typeInfo());
       // Check to make sure this base appears only once in the
-      // inheritance heirarchy.
+      // inheritance hierarchy.
       if (!search_all(baseTypes, baseType)) {
         // Save the type and recursive look for its base types
         baseTypes.push_back(baseType);

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -100,7 +100,7 @@ namespace edm {
         if(it->second.present()) {
           idsToReplace[it->second.branchType()].insert(it->second.branchID());
           if(it->second.branchType() == InEvent &&
-             it->second.unwrappedType().typeInfo() == typeid(ThinnedAssociation)) {
+             it->second.unwrappedType() == typeid(ThinnedAssociation)) {
             associationsFromSecondary.insert(it->second.branchID());
           }
           //now make sure this is marked as not dropped else the product will not be 'get'table from the Event

--- a/IOPool/Input/src/RootFile.cc
+++ b/IOPool/Input/src/RootFile.cc
@@ -1718,7 +1718,7 @@ namespace edm {
     for(auto const& product : prodList) {
       BranchDescription const& prod = product.second;
       // Special handling for ThinnedAssociations
-      if(prod.unwrappedType().typeInfo() == typeid(ThinnedAssociation) && prod.present()) {
+      if(prod.unwrappedType() == typeid(ThinnedAssociation) && prod.present()) {
         if(inputType != InputType::SecondarySource) {
           associationDescriptions.push_back(&prod);
         } else {
@@ -1777,7 +1777,7 @@ namespace edm {
       BranchDescription const& prod = it->second;
       bool drop = branchesToDrop.find(prod.branchID()) != branchesToDropEnd;
       if(drop) {
-        if(productSelector.selected(prod) && prod.unwrappedType().typeInfo() != typeid(ThinnedAssociation)) {
+        if(productSelector.selected(prod) && prod.unwrappedType() != typeid(ThinnedAssociation)) {
           LogWarning("RootFile")
             << "Branch '" << prod.branchName() << "' is being dropped from the input\n"
             << "of file '" << file_ << "' because it is dependent on a branch\n"


### PR DESCRIPTION
ROOT 6 does not supply type_info information for types that are not classes (e.g. enums, C-style arrays, pointers).  We can get the type_info information for built-in types (e.g int) by other means.  However, TypeWithDict::typeInfo() can return incorrect information for enums, C-style arrays, or pointers.  This pull request protects against this.  If TypeWithDict::typeInfo() is called, and the correct type_info information is not available, an assert will occur, rather than returning incorrect information.
This is not a common case, as no asserts were encountered in unit tests for these packages or for any relval tests in the short relval matrix.
Any such asserts encountered in the future will be fixed in a case by case basis, as there is no clear general solution for this problem in CMSSW.
Please merge this pull request as soon as convenient.
