### PR TITLE
Add lines dropped in bad git merge to fix massive compilation errors

### DIFF
--- a/DataFormats/Provenance/interface/ProductRegistry.h
+++ b/DataFormats/Provenance/interface/ProductRegistry.h
@@ -149,6 +149,8 @@ namespace edm {
       std::map<BranchID, ProductHolderIndex> branchIDToIndex_;
 
       std::vector<TypeID> missingDictionaries_;
+
+      std::vector<std::pair<std::string, std::string> > aliasToOriginal_;
     };
 
   private:


### PR DESCRIPTION
The automatic git merge of pull request #6845 into CMSSW_7_4_ROOT6_X incorrectly dropped two lines of the change.  The blank line dropped did not matter, but the other missing line caused massive compilation errors.
This pull request fixes the bad merge.
Please merge this obvious  request as soon as convenient, but preferably in time for the next IB.
