### PR TITLE
bug fix to compute ES cluster shapes

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -34,6 +34,7 @@ class CaloSubdetectorTopology;
 class EcalClusterLazyToolsBase {
  public:
   EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2);
+  EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3);
   ~EcalClusterLazyToolsBase();
   
 
@@ -94,8 +95,12 @@ class EcalClusterLazyToolsBase {
 template<class EcalClusterToolsImpl> 
 class EcalClusterLazyToolsT : public EcalClusterLazyToolsBase {
     public:
-        EcalClusterLazyToolsT( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2):
-            EcalClusterLazyToolsBase(ev,es,token1,token2) {}
+
+ EcalClusterLazyToolsT( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2):
+  EcalClusterLazyToolsBase(ev,es,token1,token2) {}
+
+ EcalClusterLazyToolsT( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3):
+  EcalClusterLazyToolsBase(ev,es,token1,token2,token3) {}
         ~EcalClusterLazyToolsT() {}
 
         // various energies in the matrix nxn surrounding the maximum energy crystal of the input cluster  

--- a/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
+++ b/RecoEcal/EgammaCoreTools/src/EcalClusterLazyTools.cc
@@ -26,11 +26,27 @@ EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const 
 
   ebRHToken_ = token1;
   eeRHToken_ = token2;
+ 
+  getGeometry( es );
+  getTopology( es );
+  getEBRecHits( ev );
+  getEERecHits( ev );
+  getIntercalibConstants( es );
+  getADCToGeV ( es );
+  getLaserDbService ( es );
+}
+
+EcalClusterLazyToolsBase::EcalClusterLazyToolsBase( const edm::Event &ev, const edm::EventSetup &es, edm::EDGetTokenT<EcalRecHitCollection> token1, edm::EDGetTokenT<EcalRecHitCollection> token2, edm::EDGetTokenT<EcalRecHitCollection> token3) {
+
+  ebRHToken_ = token1;
+  eeRHToken_ = token2;
+  esRHToken_ = token3;
 
   getGeometry( es );
   getTopology( es );
   getEBRecHits( ev );
   getEERecHits( ev );
+  getESRecHits( ev );
   getIntercalibConstants( es );
   getADCToGeV ( es );
   getLaserDbService ( es );


### PR DESCRIPTION
Bug fix to EcalClusterTools to compute Preshower cluster shapes. Same as #6917 but for 73X.
