### PR TITLE
MiniAOD extension for quark-gluon tagger

### DIFF
--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -1,5 +1,7 @@
 #ifndef JetProducers_QGTagger_h
 #define JetProducers_QGTagger_h
+#include <tuple>
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 
@@ -17,7 +19,7 @@ class QGTagger : public edm::EDProducer{
 
    private:
       virtual void produce(edm::Event&, const edm::EventSetup&);
-      void calcVariables(const reco::Jet*, int&, float&, float&, edm::Handle<reco::VertexCollection>&);
+      std::tuple<int, float, float> calcVariables(const reco::Jet*, edm::Handle<reco::VertexCollection>&);
       template <typename T> void putInEvent(std::string, const edm::Handle<edm::View<reco::Jet>>&, std::vector<T>*, edm::Event&);
       bool isPackedCandidate(const reco::Candidate* candidate);
 

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -19,6 +19,7 @@ class QGTagger : public edm::EDProducer{
       virtual void produce(edm::Event&, const edm::EventSetup&);
       void calcVariables(const reco::Jet*, int&, float&, float&, edm::Handle<reco::VertexCollection>&);
       template <typename T> void putInEvent(std::string, const edm::Handle<edm::View<reco::Jet>>&, std::vector<T>*, edm::Event&);
+      bool isPackedCandidate(const reco::Candidate* candidate);
 
       edm::EDGetTokenT<edm::View<reco::Jet>> 	jetsToken;
       edm::EDGetTokenT<reco::JetCorrector> 	jetCorrectorToken;
@@ -26,6 +27,7 @@ class QGTagger : public edm::EDProducer{
       edm::EDGetTokenT<double> 			rhoToken;
       std::string 				jetsLabel, systLabel;
       const bool 				useQC, useJetCorr, produceSyst;
+      bool					weStillNeedToCheckJetCandidates, weAreUsingPackedCandidates;
       QGLikelihoodCalculator *			qgLikelihood;
 };
 

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -9,20 +9,18 @@
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 #include "RecoJets/JetAlgorithms/interface/QGLikelihoodCalculator.h"
 
-template <class jetClass> class QGTagger : public edm::EDProducer{
+class QGTagger : public edm::EDProducer{
    public:
       explicit QGTagger(const edm::ParameterSet&);
       ~QGTagger(){ delete qgLikelihood;};
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      typedef std::vector<jetClass> jetCollection;
-
       virtual void produce(edm::Event&, const edm::EventSetup&);
-      void calcVariables(const jetClass*, int&, float&, float&, edm::Handle<reco::VertexCollection>&);
-      template <typename T> void putInEvent(std::string, const edm::Handle<jetCollection>&, std::vector<T>*, edm::Event&);
+      void calcVariables(const reco::Jet*, int&, float&, float&, edm::Handle<reco::VertexCollection>&);
+      template <typename T> void putInEvent(std::string, const edm::Handle<edm::View<reco::Jet>>&, std::vector<T>*, edm::Event&);
 
-      edm::EDGetTokenT<jetCollection> 		jetsToken;
+      edm::EDGetTokenT<edm::View<reco::Jet>> 	jetsToken;
       edm::EDGetTokenT<reco::JetCorrector> 	jetCorrectorToken;
       edm::EDGetTokenT<reco::VertexCollection> 	vertexToken;
       edm::EDGetTokenT<double> 			rhoToken;

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -11,23 +11,20 @@
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
-class QGTagger : public edm::EDProducer{
+template <class jetClass> class QGTagger : public edm::EDProducer{
    public:
       explicit QGTagger(const edm::ParameterSet&);
       ~QGTagger(){};
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
+      typedef std::vector<jetClass> jetCollection;
+
       virtual void produce(edm::Event&, const edm::EventSetup&);
-      template <class jetCollection> void produceForJetCollection(edm::Event& iEvent, const edm::EventSetup& iSetup, const jetCollection& jets);
-      template <class jetClass> void calcVariables(const jetClass *jet, edm::Handle<reco::VertexCollection> vC);
-      template <class jetCollection, typename T> void putInEvent(std::string, const jetCollection&, std::vector<T>*, edm::Event&);
+      void calcVariables(const jetClass *jet, edm::Handle<reco::VertexCollection> vC);
+      template <typename T> void putInEvent(std::string, const edm::Handle<jetCollection>&, std::vector<T>*, edm::Event&);
 
-
-      // member data
-      edm::InputTag jetsInputTag;
-      edm::EDGetTokenT<reco::PFJetCollection> jets_token;
-      edm::EDGetTokenT<pat::JetCollection> patJets_token;
+      edm::EDGetTokenT<jetCollection> jets_token;
       edm::EDGetTokenT<reco::JetCorrector> jetCorrector_token;
       edm::EDGetTokenT<reco::VertexCollection> vertex_token;
       edm::EDGetTokenT<double> rho_token;

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -8,32 +8,27 @@
 
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 #include "RecoJets/JetAlgorithms/interface/QGLikelihoodCalculator.h"
-#include "DataFormats/JetReco/interface/PFJetCollection.h"
-#include "DataFormats/PatCandidates/interface/Jet.h"
 
 template <class jetClass> class QGTagger : public edm::EDProducer{
    public:
       explicit QGTagger(const edm::ParameterSet&);
-      ~QGTagger(){};
+      ~QGTagger(){ delete qgLikelihood;};
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
       typedef std::vector<jetClass> jetCollection;
 
       virtual void produce(edm::Event&, const edm::EventSetup&);
-      void calcVariables(const jetClass *jet, edm::Handle<reco::VertexCollection> vC);
+      void calcVariables(const jetClass*, int&, float&, float&, edm::Handle<reco::VertexCollection>&);
       template <typename T> void putInEvent(std::string, const edm::Handle<jetCollection>&, std::vector<T>*, edm::Event&);
 
-      edm::EDGetTokenT<jetCollection> jets_token;
-      edm::EDGetTokenT<reco::JetCorrector> jetCorrector_token;
-      edm::EDGetTokenT<reco::VertexCollection> vertex_token;
-      edm::EDGetTokenT<double> rho_token;
-      edm::InputTag jetCorrector_inputTag;
-      std::string jetsLabel, systLabel;
-      bool useQC, usePatJets, useJetCorr, produceSyst;
-      QGLikelihoodCalculator *qgLikelihood;
-      float pt, axis2, ptD;
-      int mult;
+      edm::EDGetTokenT<jetCollection> 		jetsToken;
+      edm::EDGetTokenT<reco::JetCorrector> 	jetCorrectorToken;
+      edm::EDGetTokenT<reco::VertexCollection> 	vertexToken;
+      edm::EDGetTokenT<double> 			rhoToken;
+      std::string 				jetsLabel, systLabel;
+      const bool 				useQC, useJetCorr, produceSyst;
+      QGLikelihoodCalculator *			qgLikelihood;
 };
 
 #endif

--- a/RecoJets/JetProducers/interface/QGTagger.h
+++ b/RecoJets/JetProducers/interface/QGTagger.h
@@ -9,6 +9,7 @@
 #include "JetMETCorrections/JetCorrector/interface/JetCorrector.h"
 #include "RecoJets/JetAlgorithms/interface/QGLikelihoodCalculator.h"
 #include "DataFormats/JetReco/interface/PFJetCollection.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
 
 class QGTagger : public edm::EDProducer{
    public:
@@ -18,18 +19,21 @@ class QGTagger : public edm::EDProducer{
 
    private:
       virtual void produce(edm::Event&, const edm::EventSetup&);
+      template <class jetCollection> void produceForJetCollection(edm::Event& iEvent, const edm::EventSetup& iSetup, const jetCollection& jets);
       template <class jetClass> void calcVariables(const jetClass *jet, edm::Handle<reco::VertexCollection> vC);
-      template <typename T> void putInEvent(std::string, edm::Handle<reco::PFJetCollection>, std::vector<T>*, edm::Event&);
+      template <class jetCollection, typename T> void putInEvent(std::string, const jetCollection&, std::vector<T>*, edm::Event&);
 
 
       // member data
+      edm::InputTag jetsInputTag;
       edm::EDGetTokenT<reco::PFJetCollection> jets_token;
+      edm::EDGetTokenT<pat::JetCollection> patJets_token;
       edm::EDGetTokenT<reco::JetCorrector> jetCorrector_token;
       edm::EDGetTokenT<reco::VertexCollection> vertex_token;
       edm::EDGetTokenT<double> rho_token;
       edm::InputTag jetCorrector_inputTag;
       std::string jetsLabel, systLabel;
-      bool useQC, useJetCorr, produceSyst;
+      bool useQC, usePatJets, useJetCorr, produceSyst;
       QGLikelihoodCalculator *qgLikelihood;
       float pt, axis2, ptD;
       int mult;

--- a/RecoJets/JetProducers/plugins/BuildFile.xml
+++ b/RecoJets/JetProducers/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
   <use   name="Geometry/Records"/>
   <use   name="CommonTools/UtilAlgos"/>
   <use   name="CondFormats/JetMETObjects"/>
+  <use   name="PhysicsTools/UtilAlgos"/>
   <use   name="JetMETCorrections/Objects"/>
   <use   name="fastjet"/>
   <use   name="fastjet-contrib"/>

--- a/RecoJets/JetProducers/plugins/QGTagger.cc
+++ b/RecoJets/JetProducers/plugins/QGTagger.cc
@@ -135,9 +135,9 @@ std::tuple<int, float, float> QGTagger::calcVariables(const reco::Jet *jet, edm:
   int mult = 0;
 
   //Loop over the jet constituents
-  for(auto daughter = jet->begin(); daughter < jet->end(); ++daughter){
-    if(isPackedCandidate(&*daughter)){											//packed candidate situation
-      auto part = static_cast<const pat::PackedCandidate*> (&*daughter);
+  for(auto daughter : jet->getJetConstituentsQuick()){
+    if(isPackedCandidate(daughter)){											//packed candidate situation
+      auto part = static_cast<const pat::PackedCandidate*>(daughter);
 
       if(part->charge()){
         if(!(part->fromPV() > 1 && part->trackHighPurity())) continue;
@@ -150,7 +150,7 @@ std::tuple<int, float, float> QGTagger::calcVariables(const reco::Jet *jet, edm:
         ++mult;
       }
     } else {
-      auto part = static_cast<const reco::PFCandidate*> (&*daughter);
+      auto part = static_cast<const reco::PFCandidate*>(daughter);
 
       reco::TrackRef itrk = part->trackRef();
       if(itrk.isNonnull()){												//Track exists --> charged particle

--- a/RecoJets/JetProducers/plugins/QGTagger.cc
+++ b/RecoJets/JetProducers/plugins/QGTagger.cc
@@ -85,7 +85,6 @@ template <class jetClass> void QGTagger<jetClass>::produce(edm::Event& iEvent, c
     else 		pt = jet->pt();
     calcVariables(&*jet, mult, ptD, axis2, vertexCollection);
     float qgValue = qgLikelihood->computeQGLikelihood(QGLParamsColl, pt, jet->eta(), *rho, {(float) mult, ptD, -std::log(axis2)});
-    std::cout << axis2 << "\t" << mult << "\t" << ptD << std::endl;
 
     qgProduct->push_back(qgValue);
     if(produceSyst){

--- a/RecoJets/JetProducers/python/QGTagger_cfi.py
+++ b/RecoJets/JetProducers/python/QGTagger_cfi.py
@@ -27,12 +27,6 @@ QGTagger = cms.EDProducer('QGTagger',
   useQualityCuts	= cms.bool(False)
 )
 
-QGTaggerPatJets = cms.EDProducer('QGTagger',
-  srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
-  srcVertexCollection	= cms.InputTag('offlinePrimaryVerticesWithBS'),
-  useQualityCuts	= cms.bool(False)
-)
-
 QGTaggerMiniAOD = cms.EDProducer('QGTagger',
   srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
   srcVertexCollection	= cms.InputTag(''),

--- a/RecoJets/JetProducers/python/QGTagger_cfi.py
+++ b/RecoJets/JetProducers/python/QGTagger_cfi.py
@@ -21,19 +21,19 @@ QGPoolDBESSource = cms.ESSource("PoolDBESSource",
       connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),
 )
 
-QGTagger = cms.EDProducer('QGTaggerPFJets',
+QGTagger = cms.EDProducer('QGTagger',
   srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
   srcVertexCollection	= cms.InputTag('offlinePrimaryVerticesWithBS'),
   useQualityCuts	= cms.bool(False)
 )
 
-QGTaggerPatJets = cms.EDProducer('QGTaggerPatJets',
+QGTaggerPatJets = cms.EDProducer('QGTagger',
   srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
   srcVertexCollection	= cms.InputTag('offlinePrimaryVerticesWithBS'),
   useQualityCuts	= cms.bool(False)
 )
 
-QGTaggerMiniAOD = cms.EDProducer('QGTaggerPatJets',
+QGTaggerMiniAOD = cms.EDProducer('QGTagger',
   srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
   srcVertexCollection	= cms.InputTag(''),
   useQualityCuts	= cms.bool(False)

--- a/RecoJets/JetProducers/python/QGTagger_cfi.py
+++ b/RecoJets/JetProducers/python/QGTagger_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-# v0: only for tests (old PDFs retrieved with rho kt6PFJets binning, at 8TeV)
-qgDatabaseVersion = 'v0-test'
+# See https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
+qgDatabaseVersion = 'v1'
 
 from CondCore.DBCommon.CondDBSetup_cfi import *
 QGPoolDBESSource = cms.ESSource("PoolDBESSource",
@@ -17,24 +17,24 @@ QGPoolDBESSource = cms.ESSource("PoolDBESSource",
             tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF'),
             label  = cms.untracked.string('QGL_AK4PF')
         ),
-        cms.PSet(
-            record = cms.string('QGLikelihoodSystematicsRcd'),
-            tag    = cms.string('QGLikelihoodSystematicsObject_'+qgDatabaseVersion+'_Pythia'),
-            label  = cms.untracked.string('QGL_Syst_Pythia')
-        ),
-        cms.PSet(
-            record = cms.string('QGLikelihoodSystematicsRcd'),
-            tag    = cms.string('QGLikelihoodSystematicsObject_'+qgDatabaseVersion+'_Herwig++'),
-            label  = cms.untracked.string('QGL_Syst_Herwig++')
-        ),
       ),
       connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),
 )
 
-QGTagger = cms.EDProducer('QGTagger',
+QGTagger = cms.EDProducer('QGTaggerPFJets',
   srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
   srcVertexCollection	= cms.InputTag('offlinePrimaryVerticesWithBS'),
-  jec			= cms.InputTag(''),
-  systematicsLabel	= cms.string(''),
+  useQualityCuts	= cms.bool(False)
+)
+
+QGTaggerPatJets = cms.EDProducer('QGTaggerPatJets',
+  srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
+  srcVertexCollection	= cms.InputTag('offlinePrimaryVerticesWithBS'),
+  useQualityCuts	= cms.bool(False)
+)
+
+QGTaggerMiniAOD = cms.EDProducer('QGTaggerPatJets',
+  srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
+  srcVertexCollection	= cms.InputTag(''),
   useQualityCuts	= cms.bool(False)
 )


### PR DESCRIPTION
The QGTagger.cc plugin is updated to work also on pat::Jets and pat::PackedCandidate.
The QGTagger class is now a templated QGTagger<jetClass>, so that instead of the original QGTagger plugin, we have a QGTaggerPFJets and a QGTaggerPatJets defined.
The updated cfi fragment shows how it can be used in different situations.
The code is also a bit cleaned up to be more readable.
