### PR TITLE
Minor improvements to TypeWithDict

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -41,7 +41,8 @@ class TypeWithDict {
   friend class TypeDataMembers;
   friend class TypeFunctionMembers;
   friend bool operator==(TypeWithDict const&, std::type_info const&);
-  typedef enum{} dummyEnum;
+  typedef enum{} dummyType; // Tag for valid type, but no type_info information
+  typedef dummyType** invalidType; // Tag for invalid type
 private:
   std::type_info const* ti_;
   TType* type_;


### PR DESCRIPTION
Some ROOT6 specific improvements to TypeWithDict.

1) Define a new dummy type to be used as the type for an invalid TypeWithDict.  "void" was being used, but this is no good since there can be a valid TypeWithDict for type "void".
The type used here is a pointer to a pointer to an empty enum{}.  This is an arbitrary type that will never be used otherwise.

2) The typedef for the dummy type being used for the type_info field of a valid TypeWithDict with no type_info information was renamed from dummyEnum to dummyType, because in the future it will be used for types other than enums.

3) To check if a valid TypeWithDict has valid type_info information, simply check that the type-info field is not dummyType.  Remove the current unnecessarily complex check for this.

4) (A fix) When constructing a TypeWithDict from a TType, explicitly check that the type is not an array or a pointer before creating a TClass for the type.  I happened to notice that in some rare cases an array of classes was being treated as a class by TType.   This will all be moot after TType is removed entirely, but, for now, the code should be correct.

5) Add some statements useful in debugging, but comment them out.  This makes it easy to add them when needed.

Please merge this request as soon as convenient.
