### PR TITLE
Add missing dictionaries

### DIFF
--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -21,6 +21,9 @@
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+
 namespace DataFormats_TestObjects {
 struct dictionary {
   edm::Wrapper<edmtest::DummyProduct> dummyw12;
@@ -82,5 +85,7 @@ struct dictionary {
   edm::reftobase::VectorHolder<edmtest::Thing, edm::RefVector<std::vector<edmtest::Thing> > > vectorHolderThing;
 
   edm::Wrapper<edmtest::DeleteEarly> wrapperDeleteEarly;
+  edm::Wrapper<edm::EventID> wrapperEventID;
+  edm::Wrapper<edm::ProductID> wrapperProductID;
 };
 }

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -147,6 +147,8 @@
  <class name="edm::Wrapper<edmtestprod::X0123456789012345678901234567890123456789012345678901234567890123456789012345678901>"/>
  <class name="edmtest::DeleteEarly" ClassVersion="3">
    <version ClassVersion="3" checksum="1338867524"/>
-</class>   
+ </class>
  <class name="edm::Wrapper<edmtest::DeleteEarly>"/>
+ <class name="edm::Wrapper<edm::EventID>"/>
+ <class name="edm::Wrapper<edm::ProductID>"/>
 </lcgdict>


### PR DESCRIPTION
There are two dictionaries needed by some framework unit tests that are missing.  This does not now cause unit test failures in ROOT6 because of a workaround in place (the use of TType), but the tests will fail when TType is removed.
This pull request simply adds the missing dictionaries to avoid this problem.
Please merge this trivial request as soon as convenient.
