### PR TITLE
Resolve typedefs in unit test

### DIFF
--- a/CondCore/ORA/test/classes_def.xml
+++ b/CondCore/ORA/test/classes_def.xml
@@ -54,7 +54,7 @@
   <class name="ora::UniqueRef<testORA::IBase>"/>
   <class name="testORA::SG"/>
   <class name="testORA::D2"/>
-  <class pattern="std::vector<*>::iterator" rootmap="false"/> 
+  <class name="std::vector<short>::iterator"/>
   <class name="std::vector<ora::OId>"/>
   <class name="ora::PVector<ora::OId>"/>
   <class name="testORA::IOV"/>

--- a/CondCore/ORA/test/testORA_7.cc
+++ b/CondCore/ORA/test/testORA_7.cc
@@ -56,18 +56,18 @@ boost::shared_ptr<coral::Blob> PrimitiveContainerStreamingService::write( const 
   edm::FunctionWithDict beginMethod = type.functionMemberByName( "begin" );
   if ( ! beginMethod )
     throw std::runtime_error( "No begin method is defined for the container" );
-  edm::TypeWithDict iteratorType = beginMethod.typeOf(); //-ap??  .returnType();
+  edm::TypeWithDict iteratorType = beginMethod.finalReturnType();
   edm::FunctionWithDict dereferenceMethod = iteratorType.functionMemberByName( "operator*" );
   if ( ! dereferenceMethod )
     throw std::runtime_error( "Could not retrieve the dereference method of the container's iterator" );
-  size_t elementSize = dereferenceMethod.typeOf().size(); //-ap??  .returnType().size();
+  size_t elementSize = dereferenceMethod.finalReturnType().size();
 
   boost::shared_ptr<coral::Blob> blob( new coral::Blob( containerSize * elementSize ) );
   // allocate the blob
   void* startingAddress = blob->startingAddress();
 
   // Create an iterator
-  edm::TypeWithDict retType2 =  beginMethod.typeOf(); //-ap??  .returnType();
+  edm::TypeWithDict retType2 =  beginMethod.finalReturnType();
   char* retbuf2 = ::new char[retType2.size()];
   edm::ObjectWithDict iteratorObject(retType2, retbuf2);
   beginMethod.invoke( edm::ObjectWithDict( type, const_cast< void * > ( addressOfInputData ) ), &iteratorObject );
@@ -102,12 +102,12 @@ void PrimitiveContainerStreamingService::read( const coral::Blob& blobData,
   edm::FunctionWithDict beginMethod = type.functionMemberByName( "begin" );
   if ( ! beginMethod )
     throw std::runtime_error( "No begin method is defined for the container" );
-  edm::TypeWithDict iteratorType = beginMethod.typeOf(); //-ap?? .returnType();
+  edm::TypeWithDict iteratorType = beginMethod.finalReturnType();
   edm::FunctionWithDict dereferenceMethod = iteratorType.functionMemberByName( "operator*" );
   if ( ! dereferenceMethod )
     throw std::runtime_error( "Could not retrieve the dereference method of the container's iterator" );
 
-  size_t elementSize = dereferenceMethod.typeOf().size(); //-ap?? .returnType().size();
+  size_t elementSize = dereferenceMethod.finalReturnType().size();
 
   if( ! elementSize ) return;
 
@@ -138,7 +138,7 @@ void PrimitiveContainerStreamingService::read( const coral::Blob& blobData,
     std::vector< void* > args( 2 );
 
     // call container.end()
-    edm::TypeWithDict retType =  endMethod.typeOf(); //-ap?? .returnType();
+    edm::TypeWithDict retType =  endMethod.finalReturnType();
     char* retbuf = ::new char[retType.size()];
     edm::ObjectWithDict ret(retType, retbuf);
     endMethod.invoke(containerObject, &ret);


### PR DESCRIPTION
Unit test CondCore/ORA/test/testORA_7.cc will fail in ROOT6 after the CMS specific patch to ROOT (the TType class) is phased out, for two different reasons.
This ROOT6 specific pull request fixes both of these reasons.
1) The test should remove typedefs from function return types by calling FunctionWithDict::finalReturnType() instead of FunctionWithDict::typeOf().
2) A missing dictionary  is added to the XML selection file.
Please merge this request as soon as convenient.
