### PR TITLE
Fix checksums in framework

### DIFF
--- a/DataFormats/Common/interface/EDProductGetter.h
+++ b/DataFormats/Common/interface/EDProductGetter.h
@@ -31,12 +31,16 @@ namespace edm {
    class ProductID;
    class WrapperBase;
 
-   class EDProductGetter : private boost::noncopyable {
+   class EDProductGetter {
 
    public:
 
      EDProductGetter();
      virtual ~EDProductGetter();
+
+     EDProductGetter(EDProductGetter const&) = delete; // stop default
+
+     EDProductGetter const& operator=(EDProductGetter const&) = delete; // stop default
 
      // ---------- const member functions ---------------------
      virtual WrapperBase const* getIt(ProductID const&) const = 0;

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -4,7 +4,8 @@
   <version ClassVersion="2" checksum="2150796830"/>
   <version ClassVersion="3" checksum="1936948526"/>
  </class>
- <class name="edm::EDProductGetter" ClassVersion="10">
+ <class name="edm::EDProductGetter" ClassVersion="11">
+  <version ClassVersion="11" checksum="2247759761"/>
   <version ClassVersion="10" checksum="2702412727"/>
  </class>
  <class name="edm::RefCore" ClassVersion="11">
@@ -87,7 +88,8 @@
 <class name="std::vector<edmNew::dstvdetails::DetSetVectorTrans::Item>"/>
 
 
-<class name="edm::DataFrame" ClassVersion="10">
+<class name="edm::DataFrame" ClassVersion="11">
+ <version ClassVersion="11" checksum="3066866109"/>
  <version ClassVersion="10" checksum="1632285442"/>
 </class>
 <class name="edm::DataFrameContainer" ClassVersion="10">

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -3,20 +3,18 @@
  <class name="edm::ViewTypeChecker" ClassVersion="2">
   <version ClassVersion="2" checksum="2398868528"/>
  </class>
- <class name="edm::ProductID" ClassVersion="11">
-  <version ClassVersion="11" checksum="3913437934"/>
+ <class name="edm::ProductID" ClassVersion="10">
   <version ClassVersion="10" checksum="1501211476"/>
  </class>
- <class name="edm::BranchID" ClassVersion="11">
-  <version ClassVersion="11" checksum="3553120494"/>
+ <class name="edm::BranchID" ClassVersion="10">
   <version ClassVersion="10" checksum="21214741"/>
  </class>
- <class name="edm::EventID" ClassVersion="11">
-  <version ClassVersion="11" checksum="2520320096"/>
+ <class name="edm::EventID" ClassVersion="12">
+  <version ClassVersion="12" checksum="1501865997"/>
+  <version ClassVersion="11" checksum="341254076"/>
   <version ClassVersion="10" checksum="1903450811"/>
  </class>
- <class name="edm::LuminosityBlockID" ClassVersion="11">
-  <version ClassVersion="11" checksum="2129649415"/>
+ <class name="edm::LuminosityBlockID" ClassVersion="10">
   <version ClassVersion="10" checksum="918278812"/>
  </class>
  <class name="edm::LuminosityBlockRange" ClassVersion="10">
@@ -25,8 +23,7 @@
  <class name="edm::EventRange" ClassVersion="10">
   <version ClassVersion="10" checksum="3006383254"/>
  </class>
- <class name="edm::RunID" ClassVersion="11">
-  <version ClassVersion="11" checksum="2033791231"/>
+ <class name="edm::RunID" ClassVersion="10">
   <version ClassVersion="10" checksum="1831898368"/>
  </class>
  <class name="edm::FileID" ClassVersion="10">
@@ -36,23 +33,19 @@
   <version ClassVersion="10" checksum="959162848"/>
  </class>
  <class name="edm::EventAuxiliary" ClassVersion="11">
-  <version ClassVersion="11" checksum="245121115"/>
+  <version ClassVersion="11" checksum="3721392547"/>
   <version ClassVersion="10" checksum="580036702"/>
  </class>
- <class name="edm::History" ClassVersion="11">
-  <version ClassVersion="11" checksum="1235131490"/>
+ <class name="edm::History" ClassVersion="10">
   <version ClassVersion="10" checksum="1454435212"/>
  </class>
- <class name="edm::LuminosityBlockAuxiliary" ClassVersion="11">
-  <version ClassVersion="11" checksum="1386771278"/>
+ <class name="edm::LuminosityBlockAuxiliary" ClassVersion="10">
   <version ClassVersion="10" checksum="2062229246"/>
  </class>
- <class name="edm::RunAuxiliary" ClassVersion="11">
-  <version ClassVersion="11" checksum="599750972"/>
+ <class name="edm::RunAuxiliary" ClassVersion="10">
   <version ClassVersion="10" checksum="2799925914"/>
  </class>
- <class name="edm::ProductRegistry" ClassVersion="12">
-  <version ClassVersion="12" checksum="1440471219"/>
+ <class name="edm::ProductRegistry" ClassVersion="11">
   <version ClassVersion="11" checksum="3792450677"/>
   <field name="transient_" transient="true"/>
   <version ClassVersion="10" checksum="1206383924"/>
@@ -73,12 +66,10 @@
  <class name="std::vector<edm::EventID>"/>
  <class name="std::vector<std::vector<edm::EventID> >"/>
  <class name="std::vector<std::vector<std::vector<edm::EventID> > > "/>
- <class name="edm::BranchChildren" ClassVersion="11">
-  <version ClassVersion="11" checksum="2964266542"/>
+ <class name="edm::BranchChildren" ClassVersion="10">
   <version ClassVersion="10" checksum="137742168"/>
  </class>
- <class name="edm::ProductProvenance" ClassVersion="12">
-  <version ClassVersion="12" checksum="3368371276"/>
+ <class name="edm::ProductProvenance" ClassVersion="11">
   <version ClassVersion="11" checksum="3594205707"/>
   <field name="transient_" transient="true"/>
   <version ClassVersion="10" checksum="3685381930"/>
@@ -100,20 +91,17 @@
   <field name="wrappedType_" transient="true"/>
   <field name="unwrappedType_" transient="true"/>
  </class>
- <class name="edm::ParameterSetBlob" ClassVersion="11">
-  <version ClassVersion="11" checksum="2950494595"/>
+ <class name="edm::ParameterSetBlob" ClassVersion="10">
   <version ClassVersion="10" checksum="474063030"/>
  </class>
- <class name="edm::ProcessConfiguration" ClassVersion="12">
-  <version ClassVersion="12" checksum="2430156158"/>
+ <class name="edm::ProcessConfiguration" ClassVersion="11">
   <version ClassVersion="11" checksum="4233199054"/>
   <field name="transient_" transient="true"/>
   <version ClassVersion="10" checksum="2299978496"/>
  </class>
  <class name="edm::ProcessConfiguration::Transients" ClassVersion="0"/>
  <class name="std::vector<edm::ProcessConfiguration>"/>
- <class name="edm::ProcessHistory" ClassVersion="12">
-  <version ClassVersion="12" checksum="3227687046"/>
+ <class name="edm::ProcessHistory" ClassVersion="11">
   <version ClassVersion="11" checksum="3777891716"/>
   <field name="transient_" transient="true"/>
   <version ClassVersion="10" checksum="1389462568"/>
@@ -122,8 +110,9 @@
  <class name="edm::FileFormatVersion" ClassVersion="10">
   <version ClassVersion="10" checksum="2078548510"/>
  </class>
- <class name="edm::FileIndex::Element" ClassVersion="11">
-  <version ClassVersion="11" checksum="3344031769"/>
+ <class name="edm::FileIndex::Element" ClassVersion="12">
+  <version ClassVersion="12" checksum="3292924581"/>
+  <version ClassVersion="11" checksum="1881476699"/>
   <version ClassVersion="10" checksum="1310120368"/>
  </class>
  <class name="std::vector<edm::FileIndex::Element>"/>
@@ -134,12 +123,11 @@
  </class>
  <class name="edm::FileIndex::Transients" ClassVersion="0"/>
  <class name="edm::IndexIntoFile::RunOrLumiEntry" ClassVersion="11">
-  <version ClassVersion="11" checksum="1579925732"/>
+  <version ClassVersion="11" checksum="3032727456"/>
   <version ClassVersion="10" checksum="447201247"/>
  </class>
  <class name="std::vector<edm::IndexIntoFile::RunOrLumiEntry>"/>
- <class name="edm::IndexIntoFile" ClassVersion="12">
-  <version ClassVersion="12" checksum="3244091291"/>
+ <class name="edm::IndexIntoFile" ClassVersion="11">
   <version ClassVersion="11" checksum="676493977"/>
   <field name="transient_" transient="true"/>
   <version ClassVersion="10" checksum="262935904"/>
@@ -166,20 +154,16 @@
 
  <class name="std::map<edm::ProcessHistoryID,edm::ProcessHistory>"/>
  <class name="std::pair<edm::ProcessHistoryID,edm::ProcessHistory>"/>
- <class name="edm::EventAux" ClassVersion="11">
-  <version ClassVersion="11" checksum="2671646394"/>
+ <class name="edm::EventAux" ClassVersion="10">
   <version ClassVersion="10" checksum="549403294"/>
  </class>
- <class name="edm::LuminosityBlockAux" ClassVersion="11">
-  <version ClassVersion="11" checksum="1693594815"/>
+ <class name="edm::LuminosityBlockAux" ClassVersion="10">
   <version ClassVersion="10" checksum="2742465224"/>
  </class>
- <class name="edm::RunAux" ClassVersion="11">
-  <version ClassVersion="11" checksum="3194082649"/>
+ <class name="edm::RunAux" ClassVersion="10">
   <version ClassVersion="10" checksum="2689473100"/>
  </class>
- <class name="edm::EventEntryInfo" ClassVersion="11">
-  <version ClassVersion="11" checksum="2026692123"/>
+ <class name="edm::EventEntryInfo" ClassVersion="10">
   <version ClassVersion="10" checksum="199135386"/>
  </class>
  <class name="edm::RunLumiEntryInfo" ClassVersion="10">
@@ -188,19 +172,16 @@
  <class name="std::vector<edm::EventEntryInfo>"/>
  <class name="std::vector<edm::RunLumiEntryInfo>"/>
  <class name="edm::EntryDescriptionID"/>
- <class name="edm::EventEntryDescription" ClassVersion="11">
-  <version ClassVersion="11" checksum="3335188412"/>
+ <class name="edm::EventEntryDescription" ClassVersion="10">
   <version ClassVersion="10" checksum="2543392650"/>
  </class>
- <class name="edm::EventProcessHistoryID" ClassVersion="11">
-  <version ClassVersion="11" checksum="2217432984"/>
+ <class name="edm::EventProcessHistoryID" ClassVersion="10">
   <version ClassVersion="10" checksum="2047538258"/>
  </class>
  <class name="std::vector<edm::EventProcessHistoryID>"/>
  <class name="edm::ModuleDescriptionID"/>
 
- <class name="edm::ModuleDescription" ClassVersion="11">
-  <version ClassVersion="11" checksum="1178202156"/>
+ <class name="edm::ModuleDescription" ClassVersion="10">
   <version ClassVersion="10" checksum="2128621099"/>
    <field name="id_" transient="true"/>
    <field name="processConfigurationPtr_" transient="true"/>
@@ -211,8 +192,7 @@
   <version ClassVersion="10" checksum="2903606143"/>
  </class>
 
- <class name="ROOT::TSchemaHelper" ClassVersion="11">
-  <version ClassVersion="11" checksum="2623337955"/>
+ <class name="ROOT::TSchemaHelper" ClassVersion="10">
   <version ClassVersion="10" checksum="3064700282"/>
  </class>
  <class name="std::vector<ROOT::TSchemaHelper>"/>

--- a/DataFormats/Streamer/src/classes_def.xml
+++ b/DataFormats/Streamer/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
- <class name="edm::StreamedProduct" ClassVersion="11">
+ <class name="edm::StreamedProduct" ClassVersion="12">
+  <version ClassVersion="12" checksum="855998814"/>
   <version ClassVersion="10" checksum="512531612"/>
   <version ClassVersion="11" checksum="1146084488"/>
  </class>

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -9,7 +9,8 @@
   <version ClassVersion="11" checksum="3240540910"/>
   <version ClassVersion="10" checksum="380152127"/>
  </class>
- <class name="edmtest::EnumProduct" ClassVersion="10">
+ <class name="edmtest::EnumProduct" ClassVersion="11">
+  <version ClassVersion="11" checksum="3817882977"/>
   <version ClassVersion="10" checksum="3025325436"/>
  </class>
  <enum name="edmtest::TheEnumProduct"/>
@@ -117,10 +118,10 @@
  <class name="edm::PtrVector<edmtest::Thing>"/>
  <class name="edm::Ref<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
  <class name="edm::RefVector<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
- <class name="edmtest::TrackOfThings"/>
- <class name="std::vector<edmtest::TrackOfThings>" ClassVersion="10">
-  <version ClassVersion="10" checksum="1189167006"/>
+ <class name="edmtest::TrackOfThings" ClassVersion="6">
+  <version ClassVersion="6" checksum="545056495"/>
  </class>
+ <class name="std::vector<edmtest::TrackOfThings>"/>
  <class name="edm::Wrapper<std::vector<edmtest::TrackOfThings> >"/>
  <class name="edm::Wrapper<edmtest::Thing>"/>
  <class name="edm::Wrapper<edmtest::ThingWithMerge>"/>

--- a/FWCore/Common/src/classes_def.xml
+++ b/FWCore/Common/src/classes_def.xml
@@ -11,7 +11,8 @@
   <class name="edm::TriggerNames" ClassVersion="10">
    <version ClassVersion="10" checksum="2872088986"/>
   </class>
-  <class name="edm::TriggerResultsByName" ClassVersion="10">
+  <class name="edm::TriggerResultsByName" ClassVersion="11">
+   <version ClassVersion="11" checksum="3334716878"/>
    <version ClassVersion="10" checksum="1282053882"/>
   </class>
 </lcgdict>

--- a/IOPool/TFileAdaptor/src/classes_def.xml
+++ b/IOPool/TFileAdaptor/src/classes_def.xml
@@ -1,5 +1,7 @@
 <lcgdict>
- <class name="TStorageFactoryFile" ClassVersion="10"/>
- <class name="TStorageFactorySystem" ClassVersion="10"/>
- <class name="TFileAdaptorUI" ClassVersion="10"/>
+ <class name="TStorageFactoryFile" ClassVersion="0"/>
+ <class name="TStorageFactorySystem" ClassVersion="0"/>
+ <class name="TFileAdaptorUI" ClassVersion="3">
+   <version ClassVersion="3" checksum="818216219"/>
+ </class>
 </lcgdict>


### PR DESCRIPTION
In preparation for later re-enabling edmCheckClassVersion in the ROOT6 branch, this pull request corrects the checksums for classes in the framework.
One minor complication is that the inheritance of EDProductGetter on boost::noncopyable caused a problem, and is being replaced by the C++11 mechanism for disabling copy constructing and assignment.
A second complication is that many months ago I attempted to do this by hand for DataFormatsProvenance.  That change is being  backed out and the specification file of DataFormats/Provenance is being resynched with the ROOT5 branch before updating for ROOT6.
Please merge this request as soon as convenient.
