### PR TITLE
addition of D0 and Dstar hadronic decays to evtgen

### DIFF
--- a/GeneratorInterface/ExternalDecays/data/D0_Kpi.dec
+++ b/GeneratorInterface/ExternalDecays/data/D0_Kpi.dec
@@ -1,0 +1,11 @@
+# This is the decay file for the decay D0 -> Kaon Pion
+Alias myD0      D0
+Alias myanti-D0 anti-D0
+ChargeConj myanti-D0 myD0
+#
+Decay myD0
+1.000   K- pi+  PHSP;
+Enddecay
+CDecay myanti-D0
+
+End

--- a/GeneratorInterface/ExternalDecays/data/Dstar_VSSD0pi_Kpipi.dec
+++ b/GeneratorInterface/ExternalDecays/data/Dstar_VSSD0pi_Kpipi.dec
@@ -1,0 +1,19 @@
+# This is the decay file for the decay Dstar -> D0 Pion -> Kaon Pion Pion
+Alias myD*+   D*+
+Alias myD*-   D*-
+ChargeConj myD*- myD*+
+Alias myD0      D0
+Alias myanti-D0 anti-D0
+ChargeConj myanti-D0 myD0
+#
+Decay myD*+
+  1.0000   myD0  pi+  VSS;
+Enddecay
+CDecay myD*-
+
+Decay myD0
+  1.000   K- pi+  PHSP;
+Enddecay
+CDecay myanti-D0
+
+End


### PR DESCRIPTION
Adding new EvtGen decay configuration files for the hadronic decays of D\* and D0 mesons for MC analysis.  Requesting in 53X for future HI MC production in release 5_3_20
