### PR TITLE
M tbtag

### DIFF
--- a/HLTrigger/btau/src/HLTDisplacedmumuVtxProducer.h
+++ b/HLTrigger/btau/src/HLTDisplacedmumuVtxProducer.h
@@ -15,7 +15,7 @@
 
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -29,28 +29,28 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLTDisplacedmumuVtxProducer : public edm::EDProducer {
+class HLTDisplacedmumuVtxProducer : public edm::stream::EDProducer<> {
  public:
   explicit HLTDisplacedmumuVtxProducer(const edm::ParameterSet&);
   ~HLTDisplacedmumuVtxProducer();
   static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
-  virtual void beginJob() ;
+  virtual void beginJob();
   virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  virtual void endJob();
 
  private:  
   bool checkPreviousCand(const reco::TrackRef& trackref, std::vector<reco::RecoChargedCandidateRef>& ref2);
 
-  edm::InputTag                                          srcTag_;
-  edm::EDGetTokenT<reco::RecoChargedCandidateCollection> srcToken_;
-  edm::InputTag                                          previousCandTag_;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
-  double maxEta_;
-  double minPt_;
-  double minPtPair_;
-  double minInvMass_;
-  double maxInvMass_;
-  int chargeOpt_;
+  const edm::InputTag                                          srcTag_;
+  const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> srcToken_;
+  const edm::InputTag                                          previousCandTag_;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
+  const double maxEta_;
+  const double minPt_;
+  const double minPtPair_;
+  const double minInvMass_;
+  const double maxInvMass_;
+  const int chargeOpt_;
 };
 
 #endif

--- a/HLTrigger/btau/src/HLTmumutktkVtxProducer.h
+++ b/HLTrigger/btau/src/HLTmumutktkVtxProducer.h
@@ -10,7 +10,7 @@
 // system include files
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -34,7 +34,7 @@ namespace reco {
 class FreeTrajectoryState;
 class MagneticField;
     
-class HLTmumutktkVtxProducer : public edm::EDProducer {
+class HLTmumutktkVtxProducer : public edm::stream::EDProducer<> {
  public:
   explicit HLTmumutktkVtxProducer(const edm::ParameterSet&);
   ~HLTmumutktkVtxProducer();
@@ -47,12 +47,12 @@ class HLTmumutktkVtxProducer : public edm::EDProducer {
   static FreeTrajectoryState initialFreeState( const reco::Track&,const MagneticField*);
   bool checkPreviousCand(const reco::TrackRef& trackref, std::vector<reco::RecoChargedCandidateRef>& ref2);
 
-  edm::InputTag                                          muCandTag_;
-  edm::EDGetTokenT<reco::RecoChargedCandidateCollection> muCandToken_;
-  edm::InputTag                                          trkCandTag_;
-  edm::EDGetTokenT<reco::RecoChargedCandidateCollection> trkCandToken_;
-  edm::InputTag                                          previousCandTag_;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
+  const edm::InputTag                                          muCandTag_;
+  const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> muCandToken_;
+  const edm::InputTag                                          trkCandTag_;
+  const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> trkCandToken_;
+  const edm::InputTag                                          previousCandTag_;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
 
   const std::string mfName_;
   const double thirdTrackMass_;
@@ -64,10 +64,10 @@ class HLTmumutktkVtxProducer : public edm::EDProducer {
   const double minTrkTrkMass_;
   const double maxTrkTrkMass_;
   const double minD0Significance_;
-  bool         oppositeSign_;
+  const bool         oppositeSign_;
   const double overlapDR_;
-  edm::InputTag                    beamSpotTag_;
-  edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
+  const edm::InputTag                    beamSpotTag_;
+  const edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
 
 };
 #endif

--- a/RecoBTag/ImpactParameter/plugins/IPProducer.h
+++ b/RecoBTag/ImpactParameter/plugins/IPProducer.h
@@ -17,6 +17,8 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
@@ -140,6 +142,7 @@ class IPProducer : public edm::stream::EDProducer<> {
 
       explicit IPProducer(const edm::ParameterSet&);
       ~IPProducer();
+      static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
       virtual void produce(edm::Event&, const edm::EventSetup&);
    private:
@@ -457,5 +460,51 @@ template <class Container, class Base, class Helper> void IPProducer<Container,B
    m_calibrationCacheId2D=cacheId2D;
 }
 
+// Specialized templates used to fill 'descriptions'
+// ------------ method fills 'descriptions' with the allowed parameters for the module ------------
+template <>
+void IPProducer<reco::TrackRefVector, reco::JTATagInfo, IPProducerHelpers::FromJTA>::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<double>("maximumTransverseImpactParameter",0.2);
+  desc.add<int>("minimumNumberOfHits",8);
+  desc.add<double>("minimumTransverseMomentum",1.0);
+  desc.add<edm::InputTag>("primaryVertex",edm::InputTag("offlinePrimaryVertices"));
+  desc.add<double>("maximumLongitudinalImpactParameter",17.0);
+  desc.add<bool>("computeGhostTrack",true);
+  desc.add<double>("ghostTrackPriorDeltaR",0.03);
+  desc.add<edm::InputTag>("jetTracks",edm::InputTag("ak4JetTracksAssociatorAtVertexPF"));
+  desc.add<bool>("jetDirectionUsingGhostTrack",false);
+  desc.add<int>("minimumNumberOfPixelHits",2);
+  desc.add<bool>("jetDirectionUsingTracks",false);
+  desc.add<bool>("computeProbabilities",true);
+  desc.add<bool>("useTrackQuality",false);
+  desc.add<double>("maximumChiSquared",5.0);
+  descriptions.addDefault(desc);
+}
+
+template <>
+void IPProducer<std::vector<reco::CandidatePtr>,reco::JetTagInfo,  IPProducerHelpers::FromJetAndCands>::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<double>("maximumTransverseImpactParameter",0.2);
+  desc.add<int>("minimumNumberOfHits",8);
+  desc.add<double>("minimumTransverseMomentum",1.0);
+  desc.add<edm::InputTag>("primaryVertex",edm::InputTag("offlinePrimaryVertices"));
+  desc.add<double>("maximumLongitudinalImpactParameter",17.0);
+  desc.add<bool>("computeGhostTrack",true);
+  desc.add<double>("maxDeltaR",0.4);
+  desc.add<edm::InputTag>("candidates",edm::InputTag("particleFlow"));
+  desc.add<bool>("jetDirectionUsingGhostTrack",false);
+  desc.add<int>("minimumNumberOfPixelHits",2);
+  desc.add<bool>("jetDirectionUsingTracks",false);
+  desc.add<bool>("computeProbabilities",true);
+  desc.add<bool>("useTrackQuality",false);
+  desc.add<edm::InputTag>("jets",edm::InputTag("ak4PFJetsCHS"));
+  desc.add<double>("ghostTrackPriorDeltaR",0.03);
+  desc.add<double>("maximumChiSquared",5.0);
+  desc.addOptional<bool>("explicitJTA",false);
+  descriptions.addDefault(desc);
+}
 
 #endif

--- a/RecoBTag/ImpactParameter/python/negativeTrackCountingHighEffBJetTags_cfi.py
+++ b/RecoBTag/ImpactParameter/python/negativeTrackCountingHighEffBJetTags_cfi.py
@@ -2,6 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 negativeTrackCountingHighEffBJetTags = cms.EDProducer("JetTagProducer", 
      jetTagComputer = cms.string('negativeTrackCounting3D2ndComputer'),
-     tagInfos =  cms.VInputTag(cms.InputTag("impactParameterTagInfos")),
-     trackQualityClass = cms.string ( "any" )
+     tagInfos =  cms.VInputTag(cms.InputTag("impactParameterTagInfos"))
 )

--- a/RecoBTag/ImpactParameter/python/negativeTrackCountingHighPurBJetTags_cfi.py
+++ b/RecoBTag/ImpactParameter/python/negativeTrackCountingHighPurBJetTags_cfi.py
@@ -2,6 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 negativeTrackCountingHighPurBJetTags = cms.EDProducer("JetTagProducer",
      jetTagComputer = cms.string('negativeTrackCounting3D3rdComputer'),
-     tagInfos =  cms.VInputTag(cms.InputTag("impactParameterTagInfos")),
-     trackQualityClass = cms.string ( "any" )
+     tagInfos =  cms.VInputTag(cms.InputTag("impactParameterTagInfos"))
 )

--- a/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
+++ b/RecoBTag/SecondaryVertex/plugins/TemplatedSecondaryVertexProducer.cc
@@ -14,6 +14,9 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/IfExistsDescription.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/Exception.h"
@@ -103,6 +106,7 @@ class TemplatedSecondaryVertexProducer : public edm::stream::EDProducer<> {
     public:
 	explicit TemplatedSecondaryVertexProducer(const edm::ParameterSet &params);
 	~TemplatedSecondaryVertexProducer();
+	static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 	typedef std::vector<TemplatedSecondaryVertexTagInfo<IPTI,VTX> > Product;
 	typedef TemplatedSecondaryVertex<VTX> SecondaryVertex;
 	typedef typename IPTI::input_container input_container;
@@ -1068,6 +1072,102 @@ void TemplatedSecondaryVertexProducer<IPTI,VTX>::matchSubjets(const std::vector<
      else
        matchedIndices.push_back(subjetIndices);
    }
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module ------------
+template<class IPTI,class VTX>
+void TemplatedSecondaryVertexProducer<IPTI,VTX>::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<double>("extSVDeltaRToJet",0.3);
+  desc.add<edm::InputTag>("beamSpotTag",edm::InputTag("offlineBeamSpot"));
+  {
+    edm::ParameterSetDescription vertexReco;
+    vertexReco.add<double>("primcut",1.8);
+    vertexReco.add<double>("seccut",6.0);
+    vertexReco.add<std::string>("finder","avr");
+    vertexReco.addOptionalNode( edm::ParameterDescription<double>("minweight",0.5, true) and
+                                edm::ParameterDescription<double>("weightthreshold",0.001, true) and
+                                edm::ParameterDescription<bool>("smoothing",false, true), true );
+    vertexReco.addOptionalNode( edm::ParameterDescription<double>("maxFitChi2",10.0, true) and
+                                edm::ParameterDescription<double>("mergeThreshold",3.0, true) and
+                                edm::ParameterDescription<std::string>("fitType","RefitGhostTrackWithVertices", true), true );
+    desc.add<edm::ParameterSetDescription>("vertexReco",vertexReco);
+  }
+  {
+    edm::ParameterSetDescription vertexSelection;
+    vertexSelection.add<std::string>("sortCriterium","dist3dError");
+    desc.add<edm::ParameterSetDescription>("vertexSelection",vertexSelection);
+  }
+  desc.add<std::string>("constraint","BeamSpot");
+  desc.add<edm::InputTag>("trackIPTagInfos",edm::InputTag("impactParameterTagInfos"));
+  {
+    edm::ParameterSetDescription vertexCuts;
+    vertexCuts.add<double>("distSig3dMax",99999.9);
+    vertexCuts.add<double>("fracPV",0.65);
+    vertexCuts.add<double>("distVal2dMax",2.5);
+    vertexCuts.add<bool>("useTrackWeights",true);
+    vertexCuts.add<double>("maxDeltaRToJetAxis",0.4);
+    {
+      edm::ParameterSetDescription v0Filter;
+      v0Filter.add<double>("k0sMassWindow",0.05);
+      vertexCuts.add<edm::ParameterSetDescription>("v0Filter",v0Filter);
+    }
+    vertexCuts.add<double>("distSig2dMin",3.0);
+    vertexCuts.add<unsigned int>("multiplicityMin",2);
+    vertexCuts.add<double>("distVal2dMin",0.01);
+    vertexCuts.add<double>("distSig2dMax",99999.9);
+    vertexCuts.add<double>("distVal3dMax",99999.9);
+    vertexCuts.add<double>("minimumTrackWeight",0.5);
+    vertexCuts.add<double>("distVal3dMin",-99999.9);
+    vertexCuts.add<double>("massMax",6.5);
+    vertexCuts.add<double>("distSig3dMin",-99999.9);
+    desc.add<edm::ParameterSetDescription>("vertexCuts",vertexCuts);
+  }
+  desc.add<bool>("useExternalSV",false);
+  desc.add<double>("minimumTrackWeight",0.5);
+  desc.add<bool>("usePVError",true);
+  {
+    edm::ParameterSetDescription trackSelection;
+    trackSelection.add<double>("b_pT",0.3684);
+    trackSelection.add<double>("max_pT",500);
+    trackSelection.add<bool>("useVariableJTA",false);
+    trackSelection.add<double>("maxDecayLen",99999.9);
+    trackSelection.add<double>("sip3dValMin",-99999.9);
+    trackSelection.add<double>("max_pT_dRcut",0.1);
+    trackSelection.add<double>("a_pT",0.005263);
+    trackSelection.add<unsigned int>("totalHitsMin",8);
+    trackSelection.add<double>("jetDeltaRMax",0.3);
+    trackSelection.add<double>("a_dR",-0.001053);
+    trackSelection.add<double>("maxDistToAxis",0.2);
+    trackSelection.add<double>("ptMin",1.0);
+    trackSelection.add<std::string>("qualityClass","any");
+    trackSelection.add<unsigned int>("pixelHitsMin",2);
+    trackSelection.add<double>("sip2dValMax",99999.9);
+    trackSelection.add<double>("max_pT_trackPTcut",3);
+    trackSelection.add<double>("sip2dValMin",-99999.9);
+    trackSelection.add<double>("normChi2Max",99999.9);
+    trackSelection.add<double>("sip3dValMax",99999.9);
+    trackSelection.add<double>("sip3dSigMin",-99999.9);
+    trackSelection.add<double>("min_pT",120);
+    trackSelection.add<double>("min_pT_dRcut",0.5);
+    trackSelection.add<double>("sip2dSigMax",99999.9);
+    trackSelection.add<double>("sip3dSigMax",99999.9);
+    trackSelection.add<double>("sip2dSigMin",-99999.9);
+    trackSelection.add<double>("b_dR",0.6263);
+    desc.add<edm::ParameterSetDescription>("trackSelection",trackSelection);
+  }
+  desc.add<std::string>("trackSort","sip3dSig");
+  desc.add<edm::InputTag>("extSVCollection",edm::InputTag("secondaryVertices"));
+  desc.addOptionalNode( edm::ParameterDescription<bool>("useSVClustering",false, true) and
+                        edm::ParameterDescription<std::string>("jetAlgorithm", true) and
+                        edm::ParameterDescription<double>("rParam", true), true );
+  desc.addOptional<bool>("useSVMomentum",false);
+  desc.addOptional<double>("ghostRescaling",1e-18);
+  desc.addOptional<double>("relPtTolerance",1e-03);
+  desc.addOptional<edm::InputTag>("fatJets");
+  desc.addOptional<edm::InputTag>("groomedFatJets");
+  descriptions.addDefault(desc);
 }
 
 //define this as a plug-in

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.cc
@@ -20,6 +20,7 @@
 #include <cmath>
 
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 // ROOT::Math vectors (aka math::XYZVector)
 #include "DataFormats/Math/interface/LorentzVector.h"
@@ -397,4 +398,21 @@ double SoftLepton::boostedPPar(const math::XYZVector& vector, const math::XYZVec
   ROOT::Math::LorentzVector<ROOT::Math::PxPyPzM4D<double> > jet( axis.r(), 0., 0., jet_mass );
   ROOT::Math::BoostX boost( -jet.Beta() );
   return boost(lepton).x();
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module ------------
+void
+SoftLepton::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<unsigned int>("muonSelection",1);
+  desc.add<edm::InputTag>("leptons",edm::InputTag("muons"));
+  desc.add<edm::InputTag>("primaryVertex",edm::InputTag("offlinePrimaryVertices"));
+  desc.add<edm::InputTag>("leptonCands",edm::InputTag(""));
+  desc.add<edm::InputTag>("leptonId",edm::InputTag(""));
+  desc.add<unsigned int>("refineJetAxis",0);
+  desc.add<edm::InputTag>("jets",edm::InputTag("ak4PFJetsCHS"));
+  desc.add<double>("leptonDeltaRCut",0.4);
+  desc.add<double>("leptonChi2Cut",9999.0);
+  descriptions.addDefault(desc);
 }

--- a/RecoBTag/SoftLepton/plugins/SoftLepton.h
+++ b/RecoBTag/SoftLepton/plugins/SoftLepton.h
@@ -27,6 +27,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Math/interface/Vector3D.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
@@ -51,6 +52,7 @@ class SoftLepton : public edm::stream::EDProducer<> {
 public:
   explicit SoftLepton(const edm::ParameterSet& iConfig);
   ~SoftLepton();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
   struct TrackCompare :
     public std::binary_function<edm::RefToBase<reco::Track>,

--- a/RecoBTau/JetTagComputer/plugins/JetTagProducer.cc
+++ b/RecoBTau/JetTagComputer/plugins/JetTagProducer.cc
@@ -31,6 +31,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
@@ -148,6 +149,23 @@ JetTagProducer::produce(Event& iEvent, const EventSetup& iSetup)
   }
 
   iEvent.put(jetTagCollection);
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module ------------
+void
+JetTagProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
+
+  edm::ParameterSetDescription desc;
+  desc.add<std::string>("jetTagComputer","combinedMVAComputer");
+  {
+    std::vector<edm::InputTag> tagInfos;
+    tagInfos.push_back(edm::InputTag("impactParameterTagInfos"));
+    tagInfos.push_back(edm::InputTag("inclusiveSecondaryVertexFinderTagInfos"));
+    tagInfos.push_back(edm::InputTag("softPFMuonsTagInfos"));
+    tagInfos.push_back(edm::InputTag("softPFElectronsTagInfos"));
+    desc.add<std::vector<edm::InputTag> >("tagInfos",tagInfos);
+  }
+  descriptions.addDefault(desc);
 }
 
 // define it as plugin

--- a/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
+++ b/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
@@ -11,6 +11,7 @@
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
@@ -22,6 +23,7 @@ class JetTagProducer : public edm::stream::EDProducer<> {
     public:
 	explicit JetTagProducer(const edm::ParameterSet&);
 	~JetTagProducer();
+	static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
 
     private:
 	virtual void produce(edm::Event&, const edm::EventSetup&);

--- a/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
+++ b/RecoBTau/JetTagComputer/plugins/JetTagProducer.h
@@ -8,7 +8,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -18,7 +18,7 @@
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/BTauReco/interface/BaseTagInfo.h"
 
-class JetTagProducer : public edm::EDProducer {
+class JetTagProducer : public edm::stream::EDProducer<> {
     public:
 	explicit JetTagProducer(const edm::ParameterSet&);
 	~JetTagProducer();

--- a/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
+++ b/RecoPixelVertexing/PixelVertexFinding/src/FastPrimaryVertexWithWeightsProducer.cc
@@ -23,7 +23,7 @@
 #include <math.h>
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -53,7 +53,7 @@
 
 using namespace std;
 
-class FastPrimaryVertexWithWeightsProducer : public edm::EDProducer {
+class FastPrimaryVertexWithWeightsProducer : public edm::stream::EDProducer<> {
    public:
       explicit FastPrimaryVertexWithWeightsProducer(const edm::ParameterSet&);
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
@@ -63,117 +63,113 @@ class FastPrimaryVertexWithWeightsProducer : public edm::EDProducer {
 
 
 
-  double m_maxZ;		// Use only pixel clusters with |z| < maxZ
-  edm::InputTag m_clusters;	// PixelClusters InputTag
+  const double m_maxZ;		// Use only pixel clusters with |z| < maxZ
+  const edm::InputTag m_clusters;	// PixelClusters InputTag
   std::string m_pixelCPE; 	// PixelCPE (PixelClusterParameterEstimator)
-  edm::InputTag m_beamSpot;	// BeamSpot InputTag
-  edm::InputTag m_jets;		// Jet InputTag
   edm::EDGetTokenT<SiPixelClusterCollectionNew> clustersToken;
   edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
   edm::EDGetTokenT<edm::View<reco::Jet> > jetsToken;
 
 // PARAMETERS USED IN THE BARREL PIXEL CLUSTERS PROJECTION
-  int m_njets;			// Use only the first njets
-  double m_maxJetEta;		// Use only jets with |eta| < maxJetEta
-  double m_minJetPt;		// Use only jets with Pt > minJetPt
-  bool m_barrel;		// Use clusters from pixel endcap 
-  double m_maxSizeX;		// Use only pixel clusters with sizeX <= maxSizeX
-  double m_maxDeltaPhi;		// Use only pixel clusters with DeltaPhi(Jet,Cluster) < maxDeltaPhi
-  double m_weight_charge_down;	// Use only pixel clusters with ClusterCharge > weight_charge_down
-  double m_weight_charge_up;	// Use only pixel clusters with ClusterCharge < weight_charge_up
-  double m_PixelCellHeightOverWidth;//It is the ratio between pixel cell height and width along z coordinate about 285µm/150µm=1.9
-  double m_minSizeY_q;		// Use only pixel clusters with sizeY > PixelCellHeightOverWidth * |jetZOverRho| + minSizeY_q
-  double m_maxSizeY_q;		// Use only pixel clusters with sizeY < PixelCellHeightOverWidth * |jetZOverRho| + maxSizeY_q
+  const int m_njets;			// Use only the first njets
+  const double m_maxJetEta;		// Use only jets with |eta| < maxJetEta
+  const double m_minJetPt;		// Use only jets with Pt > minJetPt
+  const bool m_barrel;		// Use clusters from pixel endcap 
+  const double m_maxSizeX;		// Use only pixel clusters with sizeX <= maxSizeX
+  const double m_maxDeltaPhi;		// Use only pixel clusters with DeltaPhi(Jet,Cluster) < maxDeltaPhi
+  const double m_weight_charge_down;	// Use only pixel clusters with ClusterCharge > weight_charge_down
+  const double m_weight_charge_up;	// Use only pixel clusters with ClusterCharge < weight_charge_up
+  const double m_PixelCellHeightOverWidth;//It is the ratio between pixel cell height and width along z coordinate about 285µm/150µm=1.9
+  const double m_minSizeY_q;		// Use only pixel clusters with sizeY > PixelCellHeightOverWidth * |jetZOverRho| + minSizeY_q
+  const double m_maxSizeY_q;		// Use only pixel clusters with sizeY < PixelCellHeightOverWidth * |jetZOverRho| + maxSizeY_q
   
 // PARAMETERS USED TO WEIGHT THE BARREL PIXEL CLUSTERS   
   // The cluster weight is defined as weight = weight_dPhi * weight_sizeY  * weight_rho * weight_sizeX1 * weight_charge
 
-  double m_weight_dPhi;		// used in weight_dPhi = exp(-|DeltaPhi(JetCluster)|/m_weight_dPhi)    
-  double  m_weight_SizeX1;	// used in weight_SizeX1 = (ClusterSizeX==2)*1+(ClusterSizeX==1)*m_weight_SizeX1;    
-  double m_weight_rho_up; 	// used in weight_rho = (m_weight_rho_up - ClusterRho)/m_weight_rho_up 
-  double m_weight_charge_peak; 	// Give the maximum weight_charge for a cluster with Charge = m_weight_charge_peak
-  double m_peakSizeY_q;		// Give the maximum weight_sizeY for a cluster with sizeY = PixelCellHeightOverWidth * |jetZOverRho| + peakSizeY_q
+  const double m_weight_dPhi;		// used in weight_dPhi = exp(-|DeltaPhi(JetCluster)|/m_weight_dPhi)    
+  const double  m_weight_SizeX1;	// used in weight_SizeX1 = (ClusterSizeX==2)*1+(ClusterSizeX==1)*m_weight_SizeX1;    
+  const double m_weight_rho_up; 	// used in weight_rho = (m_weight_rho_up - ClusterRho)/m_weight_rho_up 
+  const double m_weight_charge_peak; 	// Give the maximum weight_charge for a cluster with Charge = m_weight_charge_peak
+  const double m_peakSizeY_q;		// Give the maximum weight_sizeY for a cluster with sizeY = PixelCellHeightOverWidth * |jetZOverRho| + peakSizeY_q
 
 // PARAMETERS USED IN THE ENDCAP PIXEL CLUSTERS PROJECTION
-  bool m_endCap;		// Use clusters from pixel endcap 
-  double m_minJetEta_EC;	// Use only jets with |eta| > minJetEta_EC
-  double m_maxJetEta_EC;	// Use only jets with |eta| < maxJetEta_EC
-  double m_maxDeltaPhi_EC;	// Use only pixel clusters with DeltaPhi(Jet,Cluster) < maxDeltaPhi_EC
+  const bool m_endCap;		// Use clusters from pixel endcap 
+  const double m_minJetEta_EC;	// Use only jets with |eta| > minJetEta_EC
+  const double m_maxJetEta_EC;	// Use only jets with |eta| < maxJetEta_EC
+  const double m_maxDeltaPhi_EC;	// Use only pixel clusters with DeltaPhi(Jet,Cluster) < maxDeltaPhi_EC
 
 // PARAMETERS USED TO WEIGHT THE ENDCAP PIXEL CLUSTERS
-  double m_EC_weight;		// In EndCap the weight is defined as weight = m_EC_weight*(weight_dPhi) 
-  double m_weight_dPhi_EC; 	// Used in weight_dPhi = exp(-|DeltaPhi|/m_weight_dPhi_EC )
+  const double m_EC_weight;		// In EndCap the weight is defined as weight = m_EC_weight*(weight_dPhi) 
+  const double m_weight_dPhi_EC; 	// Used in weight_dPhi = exp(-|DeltaPhi|/m_weight_dPhi_EC )
    
 // PARAMETERS USED TO FIND THE FASTPV AS PEAK IN THE Z-PROJECTIONS DISTRIBUTION
   // First Iteration: look for a cluster with a width = m_zClusterWidth_step1
-  double m_zClusterWidth_step1;          // cluster width in step1
+  const double m_zClusterWidth_step1;          // cluster width in step1
 
   // Second Iteration: use only z-projections with weight > weightCut_step2 and look for a cluster with a width = m_zClusterWidth_step2, within of weightCut_step2 of the previous result 
-  double m_zClusterWidth_step2; 	// cluster width in step2
-  double m_zClusterSearchArea_step2; 	// cluster width in step2
-  double m_weightCut_step2;		// minimum z-projections weight required in step2
+  const double m_zClusterWidth_step2; 	// cluster width in step2
+  const double m_zClusterSearchArea_step2; 	// cluster width in step2
+  const double m_weightCut_step2;		// minimum z-projections weight required in step2
 
   // Third Iteration: use only z-projections with weight > weightCut_step3 and look for a cluster with a width = m_zClusterWidth_step3, within of weightCut_step3 of the previous result 
-  double m_zClusterWidth_step3; 	// cluster width in step3
-  double m_zClusterSearchArea_step3;	// cluster width in step3
-  double m_weightCut_step3; 		// minimum z-projections weight required in step3
+  const double m_zClusterWidth_step3; 	// cluster width in step3
+  const double m_zClusterSearchArea_step3;	// cluster width in step3
+  const double m_weightCut_step3; 		// minimum z-projections weight required in step3
 
   // use the jetPt weighting
-  bool m_ptWeighting;				// use weight=weight*pt_weigth ?;
-  double m_ptWeighting_slope;		// pt_weigth= pt*ptWeighting_slope +m_ptWeighting_offset;
-  double m_ptWeighting_offset;		// 
+  const bool m_ptWeighting;				// use weight=weight*pt_weigth ?;
+  const double m_ptWeighting_slope;		// pt_weigth= pt*ptWeighting_slope +m_ptWeighting_offset;
+  const double m_ptWeighting_offset;		// 
 };
 
-FastPrimaryVertexWithWeightsProducer::FastPrimaryVertexWithWeightsProducer(const edm::ParameterSet& iConfig)
-{
-  m_maxZ	      		= iConfig.getParameter<double>("maxZ");
-  m_clusters          		= iConfig.getParameter<edm::InputTag>("clusters");
-  clustersToken                 = consumes<SiPixelClusterCollectionNew>(m_clusters);
-  m_pixelCPE          		= iConfig.getParameter<std::string>("pixelCPE");
-  m_beamSpot          		= iConfig.getParameter<edm::InputTag>("beamSpot");
-  beamSpotToken                 = consumes<reco::BeamSpot>(m_beamSpot);
-  m_jets              		= iConfig.getParameter<edm::InputTag>("jets");
-  jetsToken                     = consumes<edm::View<reco::Jet> >(m_jets);
+FastPrimaryVertexWithWeightsProducer::FastPrimaryVertexWithWeightsProducer(const edm::ParameterSet& iConfig):
+  m_maxZ(iConfig.getParameter<double>("maxZ")),
+  m_pixelCPE(iConfig.getParameter<std::string>("pixelCPE")),
 
-  m_njets     			= iConfig.getParameter<int>("njets");
-  m_maxJetEta     		= iConfig.getParameter<double>("maxJetEta");
-  m_minJetPt     		= iConfig.getParameter<double>("minJetPt");
+  m_njets(iConfig.getParameter<int>("njets")),
+  m_maxJetEta(iConfig.getParameter<double>("maxJetEta")),
+  m_minJetPt(iConfig.getParameter<double>("minJetPt")),
 
-  m_barrel     			= iConfig.getParameter<bool>("barrel");
-  m_maxSizeX	      		= iConfig.getParameter<double>("maxSizeX");
-  m_maxDeltaPhi       		= iConfig.getParameter<double>("maxDeltaPhi");
-  m_PixelCellHeightOverWidth    = iConfig.getParameter<double>("PixelCellHeightOverWidth");
-  m_weight_charge_down     	= iConfig.getParameter<double>("weight_charge_down");
-  m_weight_charge_up     	= iConfig.getParameter<double>("weight_charge_up");
-  m_minSizeY_q     		= iConfig.getParameter<double>("minSizeY_q");
-  m_maxSizeY_q     		= iConfig.getParameter<double>("maxSizeY_q");
+  m_barrel(iConfig.getParameter<bool>("barrel")),
+  m_maxSizeX(iConfig.getParameter<double>("maxSizeX")),
+  m_maxDeltaPhi(iConfig.getParameter<double>("maxDeltaPhi")),
+  m_weight_charge_down(iConfig.getParameter<double>("weight_charge_down")),
+  m_weight_charge_up(iConfig.getParameter<double>("weight_charge_up")),
+  m_PixelCellHeightOverWidth(iConfig.getParameter<double>("PixelCellHeightOverWidth")),
+  m_minSizeY_q(iConfig.getParameter<double>("minSizeY_q")),
+  m_maxSizeY_q(iConfig.getParameter<double>("maxSizeY_q")),
   
-  m_weight_dPhi     		= iConfig.getParameter<double>("weight_dPhi");
-  m_weight_SizeX1      		= iConfig.getParameter<double>("weight_SizeX1");
-  m_weight_rho_up      		= iConfig.getParameter<double>("weight_rho_up");
-  m_weight_charge_peak     	= iConfig.getParameter<double>("weight_charge_peak");
-  m_peakSizeY_q     		= iConfig.getParameter<double>("peakSizeY_q");
+  m_weight_dPhi(iConfig.getParameter<double>("weight_dPhi")),
+  m_weight_SizeX1(iConfig.getParameter<double>("weight_SizeX1")),
+  m_weight_rho_up(iConfig.getParameter<double>("weight_rho_up")),
+  m_weight_charge_peak(iConfig.getParameter<double>("weight_charge_peak")),
+  m_peakSizeY_q(iConfig.getParameter<double>("peakSizeY_q")),
 
-  m_endCap     			= iConfig.getParameter<bool>("endCap");
-  m_minJetEta_EC     		= iConfig.getParameter<double>("minJetEta_EC");
-  m_maxJetEta_EC     		= iConfig.getParameter<double>("maxJetEta_EC");
-  m_maxDeltaPhi_EC     		= iConfig.getParameter<double>("maxDeltaPhi_EC");
-  m_EC_weight     		= iConfig.getParameter<double>("EC_weight");
-  m_weight_dPhi_EC     		= iConfig.getParameter<double>("weight_dPhi_EC");
+  m_endCap(iConfig.getParameter<bool>("endCap")),
+  m_minJetEta_EC(iConfig.getParameter<double>("minJetEta_EC")),
+  m_maxJetEta_EC(iConfig.getParameter<double>("maxJetEta_EC")),
+  m_maxDeltaPhi_EC(iConfig.getParameter<double>("maxDeltaPhi_EC")),
+  m_EC_weight(iConfig.getParameter<double>("EC_weight")),
+  m_weight_dPhi_EC(iConfig.getParameter<double>("weight_dPhi_EC")),
 
-  m_zClusterWidth_step1      	= iConfig.getParameter<double>("zClusterWidth_step1");
+  m_zClusterWidth_step1(iConfig.getParameter<double>("zClusterWidth_step1")),
 
-  m_zClusterWidth_step2      	= iConfig.getParameter<double>("zClusterWidth_step2");
-  m_zClusterSearchArea_step2    = iConfig.getParameter<double>("zClusterSearchArea_step2");
-  m_weightCut_step2      	= iConfig.getParameter<double>("weightCut_step2");
+  m_zClusterWidth_step2(iConfig.getParameter<double>("zClusterWidth_step2")),
+  m_zClusterSearchArea_step2(iConfig.getParameter<double>("zClusterSearchArea_step2")),
+  m_weightCut_step2(iConfig.getParameter<double>("weightCut_step2")),
 
-  m_zClusterWidth_step3      	= iConfig.getParameter<double>("zClusterWidth_step3");
-  m_zClusterSearchArea_step3    = iConfig.getParameter<double>("zClusterSearchArea_step3");
-  m_weightCut_step3      	= iConfig.getParameter<double>("weightCut_step3");
+  m_zClusterWidth_step3(iConfig.getParameter<double>("zClusterWidth_step3")),
+  m_zClusterSearchArea_step3(iConfig.getParameter<double>("zClusterSearchArea_step3")),
+  m_weightCut_step3(iConfig.getParameter<double>("weightCut_step3")),
 
-  m_ptWeighting		      	= iConfig.getParameter<bool>("ptWeighting");
-  m_ptWeighting_slope	= iConfig.getParameter<double>("ptWeighting_slope");
-  m_ptWeighting_offset		= iConfig.getParameter<double>("ptWeighting_offset");
+  m_ptWeighting(iConfig.getParameter<bool>("ptWeighting")),
+  m_ptWeighting_slope(iConfig.getParameter<double>("ptWeighting_slope")),
+  m_ptWeighting_offset(iConfig.getParameter<double>("ptWeighting_offset"))
+{
+
+  clustersToken = consumes<SiPixelClusterCollectionNew>(iConfig.getParameter<edm::InputTag>("clusters"));
+  beamSpotToken = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpot"));
+  jetsToken = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("jets"));
 
   produces<reco::VertexCollection>();
   produces<float>();


### PR DESCRIPTION
This PR makes few b-tagging modules multi-thread friendly, as requested by HLT people (cc: @fwyzard).

With the PR:
"fillDescriptions" starts to be used in:
    -JetTagProducer
    -SecondaryVertexProducer
    -SoftLepton
    -TrackIPProducer

EDProducers are switched from legacy to edm::stream in:
    -JetTagProducer
    -FastPrimaryVertexWithWeightsProducer
    -HLTDisplacedmumuVtxProducer
    -HLTmumutkVtxProducer

The fillDescriptions have been filled following:
RecoBTag/SoftLepton/python/softMuonTagInfos_cfi.py

RecoBTag/SecondaryVertex/python/secondaryVertexTagInfos_cfi.py

ImpactParameter/​python/​impactParameterTagInfos_cfi.py

RecoBTau/JetTagComputer/python/ImpactParameter/​python/​ combinedMVABJetTags_cfi.py
RecoBTau/JetTagComputer/python/ImpactParameter/​python/​ positiveCombinedMVABJetTags_cfi.py
RecoBTau/JetTagComputer/python/ImpactParameter/​python/​ negativeCombinedMVABJetTags_cfi.py

cc: @aclebihan @arizzi @imarchesini @acaudron  @ferencek  @wddgit

Cheers,
Silvio.
