### PR TITLE
Upgrade time cuts

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.cc
@@ -1,0 +1,85 @@
+#include "RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.h"
+#include <memory>
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+
+using namespace std;
+using namespace edm;
+
+
+PFClusterTimeSelector::PFClusterTimeSelector(const edm::ParameterSet& iConfig):
+  clusters_(consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("src")))
+{
+
+  std::vector<edm::ParameterSet> cuts = iConfig.getParameter<std::vector<edm::ParameterSet> >("cuts");
+  for (const auto& cut :cuts ) {
+    CutInfo info;
+    info.depth   = cut.getParameter<double>("depth");
+    info.minE    = cut.getParameter<double>("minEnergy");
+    info.maxE    = cut.getParameter<double>("maxEnergy");
+    info.minTime = cut.getParameter<double>("minTime");
+    info.maxTime = cut.getParameter<double>("maxTime");
+    info.endcap  = cut.getParameter<bool>("endcap");
+    cutInfo_.push_back(info);
+  }
+
+
+  produces<reco::PFClusterCollection>();
+  produces<reco::PFClusterCollection>("OOT");
+}
+
+
+void PFClusterTimeSelector::produce(edm::Event& iEvent, 
+			       const edm::EventSetup& iSetup) {
+
+  edm::Handle<reco::PFClusterCollection> clusters; 
+  iEvent.getByToken(clusters_,clusters);
+  std::auto_ptr<reco::PFClusterCollection> out(new reco::PFClusterCollection);
+  std::auto_ptr<reco::PFClusterCollection> outOOT(new reco::PFClusterCollection);
+
+  for(const auto& cluster : *clusters ) {    
+    const double energy = cluster.energy();
+    const double time = cluster.time();    
+    const double depth = cluster.depth();    
+    const PFLayer::Layer  layer = cluster.layer();    
+    for (const auto& info : cutInfo_) {
+      if (energy<info.minE || energy>info.maxE)
+	continue;
+      if (depth<0.9*info.depth || depth>1.1*info.depth)
+	continue;
+      if ((info.endcap && (layer==PFLayer::ECAL_BARREL || layer==PFLayer::HCAL_BARREL1 || layer==PFLayer::HCAL_BARREL2))||
+	  (((!info.endcap) && (layer==PFLayer::ECAL_ENDCAP || layer==PFLayer::HCAL_ENDCAP))))
+	continue;
+      
+      if (time>info.minTime && time<info.maxTime)
+	out->push_back(cluster);
+      else
+	outOOT->push_back(cluster);
+
+      break;
+
+    }
+    
+  }    
+
+
+
+  iEvent.put( out);
+  iEvent.put( outOOT,"OOT");
+
+}
+
+PFClusterTimeSelector::~PFClusterTimeSelector() {}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+PFClusterTimeSelector::beginRun(const edm::Run& run,
+			   const EventSetup& es) {
+
+ 
+}
+
+

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.h
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterTimeSelector.h
@@ -1,0 +1,50 @@
+#ifndef RecoParticleFlow_PFClusterProducer_PFClusterTimeSelector_h_
+#define RecoParticleFlow_PFClusterProducer_PFClusterTimeSelector_h_
+
+// system include files
+#include <memory>
+#include <vector>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+
+class PFClusterTimeSelector : public edm::EDProducer {
+ public:
+  explicit PFClusterTimeSelector(const edm::ParameterSet&);
+  ~PFClusterTimeSelector();
+
+  virtual void beginRun(const edm::Run& run, const edm::EventSetup & es);
+  
+  void produce(edm::Event& iEvent, 
+	       const edm::EventSetup& iSetup);
+
+
+ protected:
+
+  struct CutInfo {
+    double depth;
+    double minE;
+    double maxE;
+    double minTime;
+    double maxTime;
+    bool endcap;
+
+  };
+
+  // ----------access to event data
+  edm::EDGetTokenT<reco::PFClusterCollection> clusters_;
+  std::vector<CutInfo> cutInfo_;
+
+};
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PFClusterTimeSelector);
+
+#endif

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -1,0 +1,207 @@
+import FWCore.ParameterSet.Config as cms
+particleFlowClusterHBHETimeSelected = cms.EDProducer(
+    "PFClusterTimeSelector",
+    src = cms.InputTag('particleFlowClusterHBHE'),
+
+    cuts = cms.VPSet(
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(4.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(5.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-25.),
+            maxTime = cms.double(5.)
+        ),
+
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(4.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(5.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(5.)
+        ),
+
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(4.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(5.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        )
+)
+
+
+
+)
+
+    

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -9,7 +9,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
+            minTime = cms.double(-22.),
             maxTime = cms.double(5.)
         ),
         cms.PSet(
@@ -17,7 +17,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
+            minTime = cms.double(-22.),
             maxTime = cms.double(5.)
         ),
         cms.PSet(
@@ -25,7 +25,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-25.),
+            minTime = cms.double(-20.),
             maxTime = cms.double(5.)
         ),
         cms.PSet(
@@ -41,7 +41,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
+            minTime = cms.double(-15.),
             maxTime = cms.double(5.)
         ),
         cms.PSet(
@@ -49,63 +49,63 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
+            minTime = cms.double(-15.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-10.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-8.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-8.),
+            maxTime = cms.double(5.)
+        ),
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(True),
             minTime = cms.double(-20.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(1.0),
-            minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(1000000.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(2.0),
-            minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(1000000.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(3.0),
-            minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(1000000.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(1.0),
-            minEnergy = cms.double(0.0),
-            maxEnergy = cms.double(2.0),
-            endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(5.)
+            maxTime = cms.double(10.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-15.),
+            maxTime = cms.double(10.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-12.),
+            maxTime = cms.double(10.)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
+            minTime = cms.double(-12.),
             maxTime = cms.double(5.)
         ),
         cms.PSet(
@@ -113,7 +113,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
+            minTime = cms.double(-12.),
             maxTime = cms.double(5.)
         ),
 
@@ -122,31 +122,31 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-15.),
+            maxTime = cms.double(10.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-12.),
+            maxTime = cms.double(10.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-12.),
+            maxTime = cms.double(10.)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
+            minTime = cms.double(-12.),
             maxTime = cms.double(5.)
         ),
         cms.PSet(
@@ -154,7 +154,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
+            minTime = cms.double(-12.),
             maxTime = cms.double(5.)
         ),
 
@@ -163,40 +163,40 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-25.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-25.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-25.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-25.),
+            maxTime = cms.double(25.)
         ),
         cms.PSet(
             depth=cms.double(5.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-25.),
+            maxTime = cms.double(25.)
         )
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -164,7 +164,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
             minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            maxTime = cms.double(35.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
@@ -172,7 +172,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
             minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            maxTime = cms.double(35.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
@@ -180,7 +180,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
             minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            maxTime = cms.double(35.)
         ),
         cms.PSet(
             depth=cms.double(4.0),
@@ -188,7 +188,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
             minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            maxTime = cms.double(35.)
         ),
         cms.PSet(
             depth=cms.double(5.0),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHCAL_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 particleFlowClusterHCAL = cms.EDProducer('PFMultiDepthClusterProducer',
-       clustersSource = cms.InputTag("particleFlowClusterHBHE"),
+       clustersSource = cms.InputTag("particleFlowClusterHBHETimeSelected"),
        pfClusterBuilder =cms.PSet(
            algoName = cms.string("PFMultiDepthClusterizer"),
            nSigmaEta = cms.double(2.),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowCluster_cff.py
@@ -19,7 +19,7 @@ from RecoParticleFlow.PFClusterProducer.particleFlowClusterECAL_cfi import *
 
 
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHE_cfi import *
-#from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHEMaxSampleTimeSelected_cfi import *
+from RecoParticleFlow.PFClusterProducer.particleFlowClusterHBHETimeSelected_cfi import *
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHF_cfi import *
 
 from RecoParticleFlow.PFClusterProducer.particleFlowClusterHCAL_cfi import *
@@ -84,7 +84,7 @@ pfClusteringPS = cms.Sequence(particleFlowRecHitPS*particleFlowClusterPS)
 
 
 #pfClusteringHBHEHF = cms.Sequence(towerMakerPF*particleFlowRecHitHCAL*particleFlowClusterHCAL+particleFlowClusterHFHAD+particleFlowClusterHFEM)
-pfClusteringHBHEHF = cms.Sequence(offlinePrimaryVertices*particleFlowRecHitHBHE*particleFlowRecHitHF*particleFlowClusterHBHE*particleFlowClusterHF*particleFlowClusterHCAL)
+pfClusteringHBHEHF = cms.Sequence(offlinePrimaryVertices*particleFlowRecHitHBHE*particleFlowRecHitHF*particleFlowClusterHBHE*particleFlowClusterHBHETimeSelected+particleFlowClusterHF*particleFlowClusterHCAL)
 pfClusteringHO = cms.Sequence(particleFlowRecHitHO*particleFlowClusterHO)
 
 


### PR DESCRIPTION
PR with the timing cuts on HCAL on Method II reconstruction
At the endcap for E>5 geV the cuts are loose since the cluster time is displaced 
as Stephanie had reported.
Hengne made the plots 
@mark-grimes this should be  in Phase I as well. I think the way I did it it works for both.
I hope the customizations dont override it
