### PR TITLE
Upgraded a bunch of modules in DQM/DataScouting

### DIFF
--- a/DQM/DataScouting/interface/ScoutingAnalyzerBase.h
+++ b/DQM/DataScouting/interface/ScoutingAnalyzerBase.h
@@ -12,105 +12,106 @@ class DQMStore ;
 class MonitorElement ;
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include <Rtypes.h>
 
-class ScoutingAnalyzerBase : public edm::EDAnalyzer
- {
-
+class ScoutingAnalyzerBase : public DQMEDAnalyzer {
   protected:
-
-    explicit ScoutingAnalyzerBase( const edm::ParameterSet & conf ) ;
-    virtual ~ScoutingAnalyzerBase() ;
-
-    
-    void beginJob() ;
-    virtual void endRun( edm::Run const &, edm::EventSetup const & ){};
-    virtual void endLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & ) {}
-    virtual void endJob(){};
+    explicit ScoutingAnalyzerBase( const edm::ParameterSet & conf );
+    virtual ~ScoutingAnalyzerBase();
+    //virtual void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &);
     virtual void analyze( const edm::Event & e, const edm::EventSetup & c ) {}
+    virtual void endLuminosityBlock( edm::LuminosityBlock const &, edm::EventSetup const & ) {}
 
-    virtual void bookMEs() {}
-    
     std::string newName(const std::string & name);
+
+    void prepareBooking(DQMStore::IBooker &);
 
     // Members for ME booking
     MonitorElement * bookH1
-     ( const std::string & name, const std::string & title,
+     ( DQMStore::IBooker &,
+       const std::string & name, const std::string & title,
        int nchX, double lowX, double highX,
        const std::string & titleX ="", const std::string & titleY ="Events",
        Option_t * option = "E1 P" ) ;
 
     MonitorElement * bookH1withSumw2
-     ( const std::string & name, const std::string & title,
+     ( DQMStore::IBooker &,
+       const std::string & name, const std::string & title,
        int nchX, double lowX, double highX,
        const std::string & titleX ="", const std::string & titleY ="Events",
        Option_t * option = "E1 P"  ) ;
 
     MonitorElement * bookH1BinArray
-     ( const std::string & name, const std::string & title,
+     ( DQMStore::IBooker &,
+       const std::string & name, const std::string & title,
        int nchX, float *xbinsize,
        const std::string & titleX ="", const std::string & titleY ="Events",
        Option_t * option = "E1 P" ) ;
 
     MonitorElement * bookH1withSumw2BinArray
-     ( const std::string & name, const std::string & title,
+     ( DQMStore::IBooker &,
+       const std::string & name, const std::string & title,
        int nchX, float *xbinsize,
        const std::string & titleX ="", const std::string & titleY ="Events",
        Option_t * option = "E1 P"  ) ;
 
     MonitorElement * bookH2
-     ( const std::string & name, const std::string & title,
+     ( DQMStore::IBooker &,
+       const std::string & name, const std::string & title,
        int nchX, double lowX, double highX,
        int nchY, double lowY, double highY,
        const std::string & titleX ="", const std::string & titleY ="",
        Option_t * option = "COLZ"  ) ;
 
     MonitorElement * bookH2withSumw2
-     ( const std::string & name, const std::string & title,
+     ( DQMStore::IBooker &,
+       const std::string & name, const std::string & title,
        int nchX, double lowX, double highX,
        int nchY, double lowY, double highY,
        const std::string & titleX ="", const std::string & titleY ="",
        Option_t * option = "COLZ"  ) ;
 
     MonitorElement * bookP1
-     ( const std::string & name, const std::string & title,
+     ( DQMStore::IBooker &,
+       const std::string & name, const std::string & title,
        int nchX, double lowX, double highX,
                  double lowY, double highY,
        const std::string & titleX ="", const std::string & titleY ="",
        Option_t * option = "E1 P"  ) ;
 
     MonitorElement * bookH1andDivide
-     ( const std::string & name, MonitorElement * num, MonitorElement * denom,
+     ( DQMStore::IBooker &,
+       const std::string & name, MonitorElement * num, MonitorElement * denom,
        const std::string & titleX, const std::string & titleY,
        const std::string & title ="" ) ;
 
     MonitorElement * bookH2andDivide
-     ( const std::string & name, MonitorElement * num, MonitorElement * denom,
+     ( DQMStore::IBooker &,
+       const std::string & name, MonitorElement * num, MonitorElement * denom,
        const std::string & titleX, const std::string & titleY,
        const std::string & title ="" ) ;
     
     MonitorElement * profileX
-     ( MonitorElement * me2d,
+     ( DQMStore::IBooker &,
+       MonitorElement * me2d,
        const std::string & title ="", const std::string & titleX ="", const std::string & titleY ="",
        Double_t minimum = -1111, Double_t maximum = -1111 ) ;
 
     MonitorElement * profileY
-     ( MonitorElement * me2d,
+     ( DQMStore::IBooker &,
+       MonitorElement * me2d,
        const std::string & title ="", const std::string & titleX ="", const std::string & titleY ="",
        Double_t minimum = -1111, Double_t maximum = -1111 ) ;
-
 
   private: 
     std::string m_modulePath;
     std::string m_MEsPath;
     unsigned m_verbosityLevel;
-    DQMStore * m_store;
-
- } ;
+};
 
 #endif
 

--- a/DQM/DataScouting/plugins/AlphaTVarAnalyzer.cc
+++ b/DQM/DataScouting/plugins/AlphaTVarAnalyzer.cc
@@ -11,28 +11,47 @@
 
 #include <cmath>
 
-//------------------------------------------------------------------------------
-// A simple constructor which takes as inoput only the name of the PF jet collection
+// A simple constructor which takes as input only the name of the PF jet collection
 AlphaTVarAnalyzer::AlphaTVarAnalyzer( const edm::ParameterSet & conf ):
   ScoutingAnalyzerBase(conf),
   m_jetCollectionTag(conf.getUntrackedParameter<edm::InputTag>("jetCollectionName",edm::InputTag("hltCaloJetIDPassed"))),
-  m_alphaTVarCollectionTag(conf.getUntrackedParameter<edm::InputTag>("alphaTVarCollectionName")){
-
+  m_alphaTVarCollectionTag(conf.getUntrackedParameter<edm::InputTag>("alphaTVarCollectionName")) {
   //set Token(-s)
   m_alphaTVarCollectionTagToken_ = consumes<std::vector<double> >(conf.getUntrackedParameter<edm::InputTag>("alphaTVarCollectionName"));
 }
 
-//------------------------------------------------------------------------------
-// Nothing to destroy: the DQM service thinks about everything
-AlphaTVarAnalyzer::~AlphaTVarAnalyzer(){}
+AlphaTVarAnalyzer::~AlphaTVarAnalyzer() {}
 
-//------------------------------------------------------------------------------
+// Function to book the Monitoring Elements.
+void AlphaTVarAnalyzer::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &) {
+  ScoutingAnalyzerBase::prepareBooking(iBooker);
+  //the full inclusive histograms
+  m_HTAlphaT = bookH2withSumw2(
+      iBooker,
+      "HTvsAlphaT",
+      "H_{T} vs #alpha_{T} (All Events)",
+      400,0.,4000.,
+      50,0.,1.,
+      "H_{T} [GeV]",
+      "#alpha_{T}");
+  m_HTAlphaTg0p55 = bookH1withSumw2(
+      iBooker,
+      "HTvsAlphaTg0p55",
+      "H_{T} (#alpha_{T} > 0.55)",
+      400,0.,4000.,
+      "H_{T} [GeV]");
+  m_HTAlphaTg0p60 = bookH1withSumw2(
+      iBooker,
+      "HTvsAlphaTg0p60",
+      "H_{T} (#alpha_{T} > 0.60)",
+      400,0.,4000.,
+      "H_{T} [GeV]");
+} 
+
 // Usual analyze method
-void AlphaTVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ){
-  
+void AlphaTVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ) {
   edm::Handle<std::vector<double> > alphaTvar_handle;
   iEvent.getByToken(m_alphaTVarCollectionTagToken_, alphaTvar_handle);
-
 
   if(alphaTvar_handle->size() > 1){
     const double AlphaT = alphaTvar_handle->at(0);
@@ -40,33 +59,5 @@ void AlphaTVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetu
     m_HTAlphaT->Fill(HT,AlphaT);
     if(AlphaT > 0.55) m_HTAlphaTg0p55->Fill(HT);
     if(AlphaT > 0.60) m_HTAlphaTg0p60->Fill(HT);
-    
   }
-  
 }
-
-void AlphaTVarAnalyzer::endRun( edm::Run const &, edm::EventSetup const & ){
-}
-
-//------------------------------------------------------------------------------
-// Function to book the Monitoring Elements.
-void AlphaTVarAnalyzer::bookMEs(){
-  
-  //the full inclusive histograms
-  m_HTAlphaT = bookH2withSumw2("HTvsAlphaT",
-			       "H_{T} vs #alpha_{T} (All Events)",
-			       400,0.,4000.,
-			       50,0.,1.,
-			       "H_{T} [GeV]",
-			       "#alpha_{T}");
-  m_HTAlphaTg0p55 = bookH1withSumw2("HTvsAlphaTg0p55",
-				   "H_{T} (#alpha_{T} > 0.55)",
-				   400,0.,4000.,
-				   "H_{T} [GeV]");
-
-  m_HTAlphaTg0p60 = bookH1withSumw2("HTvsAlphaTg0p60",
-				   "H_{T} (#alpha_{T} > 0.60)",
-				   400,0.,4000.,
-				   "H_{T} [GeV]");
-}
-

--- a/DQM/DataScouting/plugins/AlphaTVarAnalyzer.h
+++ b/DQM/DataScouting/plugins/AlphaTVarAnalyzer.h
@@ -1,36 +1,22 @@
 #ifndef AlphaTVarAnalyzer_h
 #define AlphaTVarAnalyzer_h
 
-
 #include "DQM/DataScouting/interface/ScoutingAnalyzerBase.h"
 
-class AlphaTVarAnalyzer : public ScoutingAnalyzerBase
- {
-
+class AlphaTVarAnalyzer : public ScoutingAnalyzerBase {
   public:
-
     explicit AlphaTVarAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~AlphaTVarAnalyzer() ;
-
+    void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
     virtual void analyze( const edm::Event & , const edm::EventSetup &  );
-    
-    virtual void endRun( edm::Run const &, edm::EventSetup const & ) ;
-
-    virtual void bookMEs();
-
   private: 
-
     edm::InputTag m_jetCollectionTag;
     edm::InputTag m_alphaTVarCollectionTag;
-
     //inclusive histograms by jet number
     MonitorElement * m_HTAlphaT;
     MonitorElement * m_HTAlphaTg0p55;
     MonitorElement * m_HTAlphaTg0p60;
-
     //define Token(-s)
     edm::EDGetTokenT<std::vector<double> > m_alphaTVarCollectionTagToken_;
-
- } ;
-
+};
 #endif

--- a/DQM/DataScouting/plugins/DiJetVarAnalyzer.cc
+++ b/DQM/DataScouting/plugins/DiJetVarAnalyzer.cc
@@ -2,13 +2,10 @@
 
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
-
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
-
 #include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
-
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 
@@ -20,12 +17,10 @@
 
 #include <cmath>
 
-//------------------------------------------------------------------------------
 // A simple constructor which takes as inoput only the name of the PF jet collection
 DiJetVarAnalyzer::DiJetVarAnalyzer( const edm::ParameterSet & conf ):
   ScoutingAnalyzerBase(conf),
   jetCollectionTag_        (conf.getUntrackedParameter<edm::InputTag>("jetCollectionTag")),
-  //dijetVarCollectionTag_   (conf.getUntrackedParameter<edm::InputTag>("dijetVarCollectionTag")),
   widejetsCollectionTag_   (conf.getUntrackedParameter<edm::InputTag>("widejetsCollectionTag")),
   metCollectionTag_        (conf.getUntrackedParameter<edm::InputTag>("metCollectionTag")),
   metCleanCollectionTag_   (conf.getUntrackedParameter<edm::InputTag>("metCleanCollectionTag")),
@@ -38,8 +33,7 @@ DiJetVarAnalyzer::DiJetVarAnalyzer( const edm::ParameterSet & conf ):
   maxHADfraction_          (conf.getParameter<double>("maxHADfraction")),
   HLTpathMain_             (triggerExpression::parse( conf.getParameter<std::string>("HLTpathMain") )),
   HLTpathMonitor_          (triggerExpression::parse( conf.getParameter<std::string>("HLTpathMonitor") )),
-  triggerConfiguration_    (conf.getParameterSet("triggerConfiguration"),consumesCollector())
-{
+  triggerConfiguration_    (conf.getParameterSet("triggerConfiguration"),consumesCollector()) {
   //set Token(-s)
   jetCollectionTagToken_ = consumes<reco::CaloJetCollection>(conf.getUntrackedParameter<edm::InputTag>("jetCollectionTag"));
   widejetsCollectionTagToken_ = consumes<std::vector<math::PtEtaPhiMLorentzVector> >(conf.getUntrackedParameter<edm::InputTag>("widejetsCollectionTag"));
@@ -47,52 +41,411 @@ DiJetVarAnalyzer::DiJetVarAnalyzer( const edm::ParameterSet & conf ):
   metCleanCollectionTagToken_ = consumes<reco::CaloMETCollection>(conf.getUntrackedParameter<edm::InputTag>("metCleanCollectionTag"));
 }
 
-//------------------------------------------------------------------------------
-// Nothing to destroy: the DQM service thinks about everything
-DiJetVarAnalyzer::~DiJetVarAnalyzer(){
-  delete HLTpathMain_;
-  delete HLTpathMonitor_;
+DiJetVarAnalyzer::~DiJetVarAnalyzer() {} 
+
+// Function to book the Monitoring Elements.
+void DiJetVarAnalyzer::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &) {
+  ScoutingAnalyzerBase::prepareBooking(iBooker);
+  // ==> TO BE UPDATED FOR sqrt(s)=8 TeV
+  const int N_mass_bins=83;
+  float massBins[N_mass_bins+1] = {1, 3, 6, 10, 16, 23, 31, 40, 50, 61, 74, 88, 103, 119, 137, 156, 176, 197, 220, 244, 270, 296, 325, 354, 386, 419, 453, 489, 526, 565, 606, 649, 693, 740, 788, 838, 890, 944, 1000, 1058, 1118, 1181, 1246, 1313, 1383, 1455, 1530, 1607, 1687, 1770, 1856, 1945, 2037, 2132, 2231, 2332, 2438, 2546, 2659, 2775, 2895, 3019, 3147, 3279, 3416, 3558, 3704, 3854, 4010, 4171, 4337, 4509, 4686, 4869, 5058, 5253, 5455, 5663, 5877, 6099, 6328, 6564, 6808, 7000};
+
+  // 1D histograms
+  m_cutFlow = bookH1withSumw2(
+      iBooker,
+      "h1_cutFlow",
+      "Cut Flow",
+      7,0.,7.,
+      "Cut",
+      "Number of events"
+      );
+  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(1,"No cut");
+  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(2,"N(WideJets)>=2");
+  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(3,"|#eta|<2.5 , pT>30");
+  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(4,"|#Delta#eta|<1.3");
+  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(5,"JetID");
+  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(6,"|#Delta#phi|>#pi/3");
+  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(7,"|met-metClean|>0.1");
+
+  m_MjjWide_finalSel = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_finalSel",
+      "M_{jj} WideJets (final selection)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_finalSel_varbin = bookH1withSumw2BinArray(
+      iBooker,
+      "h1_MjjWide_finalSel_varbin",
+      "M_{jj} WideJets (final selection)",
+      N_mass_bins, massBins,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_finalSel_WithoutNoiseFilter = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_finalSel_WithoutNoiseFilter",
+      "M_{jj} WideJets (final selection, without noise filters)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_finalSel_WithoutNoiseFilter_varbin = bookH1withSumw2BinArray(
+      iBooker,
+      "h1_MjjWide_finalSel_WithoutNoiseFilter_varbin",
+      "M_{jj} WideJets (final selection, without noise filters)",
+      N_mass_bins, massBins,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_deta_0p0_0p5 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_deta_0p0_0p5",
+      "M_{jj} WideJets (0.0<=#Delta#eta<0.5)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_deta_0p5_1p0 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_deta_0p5_1p0",
+      "M_{jj} WideJets (0.5<=#Delta#eta<1.0)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_deta_1p0_1p5 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_deta_1p0_1p5",
+      "M_{jj} WideJets (1.0<=#Delta#eta<1.5)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_deta_1p5_2p0 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_deta_1p5_2p0",
+      "M_{jj} WideJets (1.5<=#Delta#eta<2.0)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_deta_2p0_2p5 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_deta_2p0_2p5",
+      "M_{jj} WideJets (2.0<=#Delta#eta<2.5)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_deta_2p5_3p0 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_deta_2p5_3p0",
+      "M_{jj} WideJets (2.5<=#Delta#eta<3.0)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_deta_3p0_inf = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_deta_3p0_inf",
+      "M_{jj} WideJets (#Delta#eta>=3.0)",
+      8000,0.,8000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_den_NOdeta = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_den_NOdeta",
+      "HLT Efficiency Studies (no deta cut)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_num_NOdeta = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_num_NOdeta",
+      "HLT Efficiency Studies (no deta cut)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_den_detaL4 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_den_detaL4",
+      "HLT Efficiency Studies (deta cut < 4.0)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_num_detaL4 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_num_detaL4",
+      "HLT Efficiency Studies (deta cut < 4.0)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_den_detaL3 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_den_detaL3",
+      "HLT Efficiency Studies (deta cut < 3.0)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_num_detaL3 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_num_detaL3",
+      "HLT Efficiency Studies (deta cut < 3.0)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_den_detaL2 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_den_detaL2",
+      "HLT Efficiency Studies (deta cut < 2.0)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_num_detaL2 = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_num_detaL2",
+      "HLT Efficiency Studies (deta cut < 2.0)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_den = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_den",
+      "HLT Efficiency Studies (default deta cut)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_MjjWide_num = bookH1withSumw2(
+      iBooker,
+      "h1_MjjWide_num",
+      "HLT Efficiency Studies (default deta cut)",
+      400,0.,2000.,
+      "M_{jj} WideJets [GeV]",
+      "Number of events"
+      );
+
+  m_DetajjWide_finalSel = bookH1withSumw2(
+      iBooker,
+      "h1_DetajjWide_finalSel",
+      "#Delta#eta_{jj} WideJets (final selection)",
+      100,0.,5.,
+      "#Delta#eta_{jj} WideJets",
+      "Number of events"
+      );
+
+  m_DetajjWide = bookH1withSumw2(
+      iBooker,
+      "h1_DetajjWide",
+      "#Delta#eta_{jj} WideJets (final selection except #Delta#eta cut)",
+      100,0.,5.,
+      "#Delta#eta_{jj} WideJets",
+      "Number of events"
+      );
+
+  m_DphijjWide_finalSel = bookH1withSumw2(
+      iBooker,
+      "h1_DphijjWide_finalSel",
+      "#Delta#phi_{jj} WideJets (final selection)",
+      100,0.,TMath::Pi()+0.0001,
+      "#Delta#phi_{jj} WideJets [rad.]",
+      "Number of events"
+      );
+
+
+  m_selJets_pt = bookH1withSumw2(
+      iBooker,
+      "h1_selJets_pt",
+      "Selected CaloJets",
+      500,0.,5000.,
+      "Jet Pt [GeV]",
+      "Number of events"
+      );
+
+  m_selJets_eta = bookH1withSumw2(
+      iBooker,
+      "h1_selJets_eta",
+      "Selected CaloJets",
+      100,-5.,5.,
+      "#eta",
+      "Number of events"
+      );
+
+  m_selJets_phi = bookH1withSumw2(
+      iBooker,
+      "h1_selJets_phi",
+      "Selected CaloJets",
+      100,-TMath::Pi(),TMath::Pi(),
+      "#phi (rad.)",
+      "Number of events"
+      );
+
+  m_selJets_hadEnergyFraction = bookH1withSumw2(
+      iBooker,
+      "h1_selJets_hadEnergyFraction",
+      "Selected CaloJets",
+      110,0.,1.1,
+      "HAD Energy Fraction",
+      "Number of events"
+      );
+
+  m_selJets_emEnergyFraction = bookH1withSumw2(
+      iBooker,
+      "h1_selJets_emEnergyFraction",
+      "Selected CaloJets",
+      110,0.,1.1,
+      "EM Energy Fraction",
+      "Number of events"
+      );
+
+  m_selJets_towersArea = bookH1withSumw2(
+      iBooker,
+      "h1_selJets_towersArea",
+      "Selected CaloJets",
+      200,0.,2.,
+      "towers area",
+      "Number of events"
+      );
+
+  m_metDiff = bookH1withSumw2(
+      iBooker,
+      "h1_metDiff",
+      "Met - MetCleaned",
+      500,-1000.,1000.,
+      "met - metcleaned [GeV]",
+      "Number of events"
+      );
+
+  m_metCases = bookH1withSumw2(
+      iBooker,
+      "h1_metCases",
+      "Met cases",
+      3,0.,3.,
+      "case",
+      "Number of events"
+      );
+  m_metCases->getTH1()->GetXaxis()->SetBinLabel(1,"met , metclean");
+  m_metCases->getTH1()->GetXaxis()->SetBinLabel(2,"met , !metclean");
+  m_metCases->getTH1()->GetXaxis()->SetBinLabel(3,"!met , metclean");
+
+  m_metCaseNoMetClean = bookH1withSumw2(
+      iBooker,
+      "h1_metCaseNoMetClean",
+      "Met - MetCleaned",
+      1000,0.,2000.,
+      "MET [GeV]",
+      "Number of events"
+      );  
+
+  m_HT_inclusive = bookH1withSumw2(
+      iBooker,
+      "h1_HT_inclusive",
+      "HT (inclusive)",
+      150,0.,15000.,
+      "HT [GeV]",
+      "Number of events"
+      );  
+
+  m_HT_finalSel = bookH1withSumw2(
+      iBooker,
+      "h1_HT_finalSel",
+      "HT (final selection)",
+      150,0.,15000.,
+      "HT [GeV]",
+      "Number of events"
+      );  
+
+  // 2D histograms
+  m_DetajjVsMjjWide = bookH2withSumw2(
+      iBooker,
+      "h2_DetajjVsMjjWide",
+      "#Delta#eta_{jj} vs M_{jj} WideJets",
+      8000,0.,8000.,
+      100,0.,5.,
+      "M_{jj} WideJets [GeV]",
+      "#Delta#eta_{jj} WideJets");
+
+  m_DetajjVsMjjWide_rebin = bookH2withSumw2(
+      iBooker,
+      "h2_DetajjVsMjjWide_rebin",
+      "#Delta#eta_{jj} vs M_{jj} WideJets",
+      400,0.,8000.,
+      50,0.,5.,
+      "M_{jj} WideJets [GeV]",
+      "#Delta#eta_{jj} WideJets");
+
+  m_metVSmetclean = bookH2withSumw2(
+      iBooker,
+      "h2_metVSmetclean",
+      "MET clean vs MET",
+      100,0.,2000.,
+      100,0.,2000.,
+      "MET [GeV]",
+      "MET clean [GeV]");
 }
 
-//------------------------------------------------------------------------------
-void DiJetVarAnalyzer::beginRun( const edm::Run & iRun, const edm::EventSetup & iSetup){
-}
-
-//------------------------------------------------------------------------------
 // Usual analyze method
-void DiJetVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ){
-  
+void DiJetVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ) {
   using namespace std;
   using namespace edm;
   using namespace reco;
-  
+
   // ## Get jet collection
   edm::Handle<reco::CaloJetCollection> calojets_handle;
   iEvent.getByToken(jetCollectionTagToken_,calojets_handle);
 
-
   // Loop over all the selected jets ( defined at DQM/DataScouting/python/dijetScouting_cff.py )  
   double thisHT = 0.;
   for(reco::CaloJetCollection::const_iterator it = calojets_handle->begin(); it != calojets_handle->end(); ++it)
-    {
-      //cout << "== jet: " << it->pt() << " " << it->eta() << " " << it->phi() << endl;
-      m_selJets_pt->Fill( it->pt() );
-      m_selJets_eta->Fill( it->eta() );
-      m_selJets_phi->Fill( it->phi() );
-      m_selJets_hadEnergyFraction->Fill( it->energyFractionHadronic() );
-      m_selJets_emEnergyFraction->Fill( it->emEnergyFraction() );
-      m_selJets_towersArea->Fill( it->towersArea() );
-
-      thisHT += it->pt();
-    }
+  {
+    //cout << "== jet: " << it->pt() << " " << it->eta() << " " << it->phi() << endl;
+    m_selJets_pt->Fill( it->pt() );
+    m_selJets_eta->Fill( it->eta() );
+    m_selJets_phi->Fill( it->phi() );
+    m_selJets_hadEnergyFraction->Fill( it->energyFractionHadronic() );
+    m_selJets_emEnergyFraction->Fill( it->emEnergyFraction() );
+    m_selJets_towersArea->Fill( it->towersArea() );
+    thisHT += it->pt();
+  }
 
   // HT
   m_HT_inclusive->Fill(thisHT);      
-  
+
   // ## Get widejets 
   edm::Handle< vector<math::PtEtaPhiMLorentzVector> > widejets_handle;
   iEvent.getByToken(widejetsCollectionTagToken_, widejets_handle);
-  
+
   TLorentzVector wj1;
   TLorentzVector wj2;
   TLorentzVector wdijet;
@@ -101,62 +454,50 @@ void DiJetVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
   double DeltaEtaJJWide = -1;
   double DeltaPhiJJWide = -1;
 
-  if( widejets_handle->size() >= 2 )
-    {
-      wj1.SetPtEtaPhiM(widejets_handle->at(0).pt(),
-		       widejets_handle->at(0).eta(),
-		       widejets_handle->at(0).phi(),
-		       widejets_handle->at(0).mass()
-		       );
-      wj2.SetPtEtaPhiM(widejets_handle->at(1).pt(),
-		       widejets_handle->at(1).eta(),
-		       widejets_handle->at(1).phi(),
-		       widejets_handle->at(1).mass()
-		       );
-
-      wdijet = wj1 + wj2;
-
-      MJJWide = wdijet.M();
-      DeltaEtaJJWide = fabs(wj1.Eta()-wj2.Eta());
-      DeltaPhiJJWide = fabs(wj1.DeltaPhi(wj2));
-
-      //       cout << "== j1 wide: " << wj1.Pt() << " " << wj1.Eta() << " " << wj1.Phi() << " " << wj1.M() << endl;
-      //       cout << "== j2 wide: " << wj2.Pt() << " " << wj2.Eta() << " " << wj2.Phi() << " " << wj2.M() << endl;
-      //       cout << "== MJJWide: " << MJJWide << endl;
-      //       cout << "== DeltaEtaJJWide: " << DeltaEtaJJWide << endl;
-      //       cout << "== DeltaPhiJJWide: " << DeltaPhiJJWide << endl;
-    }
+  if( widejets_handle->size() >= 2 ) {
+    wj1.SetPtEtaPhiM(widejets_handle->at(0).pt(),
+        widejets_handle->at(0).eta(),
+        widejets_handle->at(0).phi(),
+        widejets_handle->at(0).mass()
+        );
+    wj2.SetPtEtaPhiM(widejets_handle->at(1).pt(),
+        widejets_handle->at(1).eta(),
+        widejets_handle->at(1).phi(),
+        widejets_handle->at(1).mass()
+        );
+    wdijet = wj1 + wj2;
+    MJJWide = wdijet.M();
+    DeltaEtaJJWide = fabs(wj1.Eta()-wj2.Eta());
+    DeltaPhiJJWide = fabs(wj1.DeltaPhi(wj2));
+  }
 
   // ## Get met collection
-
   // met
   edm::Handle<reco::CaloMETCollection> calomet_handle;
   iEvent.getByToken(metCollectionTagToken_, calomet_handle);
-
   // met cleaned
   edm::Handle<reco::CaloMETCollection> calometClean_handle;
   iEvent.getByToken(metCleanCollectionTagToken_, calometClean_handle);
- 
-  if( calomet_handle.isValid() && calometClean_handle.isValid() )
-    {
-      //       std::cout << "---" << std::endl;
-      //       std::cout << "== calomet: " << (calomet_handle->front()).pt() << " " << (calomet_handle->front()).phi() << std::endl;
-      //       std::cout << "== calometClean: " << (calometClean_handle->front()).pt() << " " << (calometClean_handle->front()).phi() << std::endl;
-      //       std::cout << "== calomet - calometClean: " << (calomet_handle->front()).pt() - (calometClean_handle->front()).pt() << std::endl;
-      //       std::cout << "---" << std::endl;
-      m_metCases->Fill(0);
-      m_metDiff->Fill( (calomet_handle->front()).pt() - (calometClean_handle->front()).pt() );
-      m_metVSmetclean->Fill( (calomet_handle->front()).pt() , (calometClean_handle->front()).pt() );      
-    }
+
+  if( calomet_handle.isValid() && calometClean_handle.isValid() ) {
+    //       std::cout << "---" << std::endl;
+    //       std::cout << "== calomet: " << (calomet_handle->front()).pt() << " " << (calomet_handle->front()).phi() << std::endl;
+    //       std::cout << "== calometClean: " << (calometClean_handle->front()).pt() << " " << (calometClean_handle->front()).phi() << std::endl;
+    //       std::cout << "== calomet - calometClean: " << (calomet_handle->front()).pt() - (calometClean_handle->front()).pt() << std::endl;
+    //       std::cout << "---" << std::endl;
+    m_metCases->Fill(0);
+    m_metDiff->Fill( (calomet_handle->front()).pt() - (calometClean_handle->front()).pt() );
+    m_metVSmetclean->Fill( (calomet_handle->front()).pt() , (calometClean_handle->front()).pt() );      
+  }
   else if( calomet_handle.isValid() && !calometClean_handle.isValid() )
-    {
-      m_metCases->Fill(1);
-      m_metCaseNoMetClean->Fill((calomet_handle->front()).pt());
-    }
+  {
+    m_metCases->Fill(1);
+    m_metCaseNoMetClean->Fill((calomet_handle->front()).pt());
+  }
   else if( !calomet_handle.isValid() && calometClean_handle.isValid() )
-    {
-      m_metCases->Fill(2);
-    }
+  {
+    m_metCases->Fill(2);
+  }
 
   // ## Event Selection
   bool pass_nocut=false;
@@ -181,68 +522,60 @@ void DiJetVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
   pass_nocut=true;
 
   // Two wide jets
-  if( widejets_handle->size() >= numwidejets_ )
-    {
-      // Two wide jets
-      pass_twowidejets=true;
+  if( widejets_handle->size() >= numwidejets_ ) {
+    // Two wide jets
+    pass_twowidejets=true;
 
-      // Eta/pt cuts
-      if( fabs(wj1.Eta())<etawidejets_ && wj1.Pt()>ptwidejets_ 
-	  &&
-	  fabs(wj2.Eta())<etawidejets_ && wj2.Pt()>ptwidejets_
-	  )
-	{
-	  pass_etaptcuts=true;
-	}
-      
-      // Deta cut
-      if( DeltaEtaJJWide < detawidejets_ )
-	pass_deta=true;
-
-      // Dphi cut
-      if( DeltaPhiJJWide > dphiwidejets_ )
-	pass_dphi=true;
-
-      // Other Deta cuts
-      if( DeltaEtaJJWide < 4.0 )
-	pass_deta_L4=true;
-
-      if( DeltaEtaJJWide < 3.0 )
-	pass_deta_L3=true;
-
-      if( DeltaEtaJJWide < 2.0 )
-	pass_deta_L2=true;
-      
+    // Eta/pt cuts
+    if( fabs(wj1.Eta())<etawidejets_ && wj1.Pt()>ptwidejets_ 
+        &&
+        fabs(wj2.Eta())<etawidejets_ && wj2.Pt()>ptwidejets_
+      ) {
+      pass_etaptcuts=true;
     }
 
+    // Deta cut
+    if( DeltaEtaJJWide < detawidejets_ )
+      pass_deta=true;
+
+    // Dphi cut
+    if( DeltaPhiJJWide > dphiwidejets_ )
+      pass_dphi=true;
+
+    // Other Deta cuts
+    if( DeltaEtaJJWide < 4.0 )
+      pass_deta_L4=true;
+
+    if( DeltaEtaJJWide < 3.0 )
+      pass_deta_L3=true;
+
+    if( DeltaEtaJJWide < 2.0 )
+      pass_deta_L2=true;
+  }
   // Jet id two leading jets
-
   if( calojets_handle->size() >= numwidejets_ )
-    {
-      //   first jet
-      reco::CaloJetCollection::const_iterator thisJet = calojets_handle->begin();
-      //cout << "== thisJet1: " << thisJet->pt() << " " << thisJet->eta() << " " << thisJet->phi() << endl;
-      if( thisJet->energyFractionHadronic()>maxHADfraction_ || thisJet->emEnergyFraction()>maxEMfraction_ )
-	pass_JetIDtwojets=false;
+  {
+    //   first jet
+    reco::CaloJetCollection::const_iterator thisJet = calojets_handle->begin();
+    //cout << "== thisJet1: " << thisJet->pt() << " " << thisJet->eta() << " " << thisJet->phi() << endl;
+    if( thisJet->energyFractionHadronic()>maxHADfraction_ || thisJet->emEnergyFraction()>maxEMfraction_ )
+      pass_JetIDtwojets=false;
 
-      //   second jet
-      ++thisJet;
-      //cout << "== thisJet2: " << thisJet->pt() << " " << thisJet->eta() << " " << thisJet->phi() << endl;
-      if( thisJet->energyFractionHadronic()>maxHADfraction_ || thisJet->emEnergyFraction()>maxEMfraction_ )
-	pass_JetIDtwojets=false;
-    }      
-
+    //   second jet
+    ++thisJet;
+    //cout << "== thisJet2: " << thisJet->pt() << " " << thisJet->eta() << " " << thisJet->phi() << endl;
+    if( thisJet->energyFractionHadronic()>maxHADfraction_ || thisJet->emEnergyFraction()>maxEMfraction_ )
+      pass_JetIDtwojets=false;
+  }      
   // Met filter
   if( calomet_handle.isValid() && calometClean_handle.isValid() )
-    {
-      if( fabs ( (calomet_handle->front()).pt() - (calometClean_handle->front()).pt() ) > 0.1 )
-	pass_metFilter=false;
-    }
-  
+  {
+    if( fabs ( (calomet_handle->front()).pt() - (calometClean_handle->front()).pt() ) > 0.1 )
+      pass_metFilter=false;
+  }
   // Full selection (no deta cut)
   if( pass_nocut && pass_twowidejets && pass_etaptcuts && pass_JetIDtwojets && pass_dphi && pass_metFilter )
     pass_fullsel_NOdeta=true;
-
   // Full selection (various deta cuts)
   if( pass_nocut && pass_twowidejets && pass_etaptcuts && pass_JetIDtwojets && pass_dphi && pass_metFilter && pass_deta_L4 )
     pass_fullsel_detaL4=true;
@@ -250,13 +583,11 @@ void DiJetVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
     pass_fullsel_detaL3=true;
   if( pass_nocut && pass_twowidejets && pass_etaptcuts && pass_JetIDtwojets && pass_dphi && pass_metFilter && pass_deta_L2 )
     pass_fullsel_detaL2=true;
-
   // Full selection (default deta cut)
   if( pass_nocut && pass_twowidejets && pass_etaptcuts && pass_deta && pass_JetIDtwojets && pass_dphi && pass_metFilter )
     pass_fullsel=true;
-  
-  // ## Fill Histograms 
 
+  // ## Fill Histograms 
   // Cut-flow plot
   if( pass_nocut )
     m_cutFlow->Fill(0);
@@ -275,48 +606,44 @@ void DiJetVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
 
   // After full selection
   if( pass_fullsel ) 
-    {
-      // 1D histograms
-      m_MjjWide_finalSel->Fill(MJJWide);
-      m_MjjWide_finalSel_varbin->Fill(MJJWide);
-      m_DetajjWide_finalSel->Fill(DeltaEtaJJWide);
-      m_DphijjWide_finalSel->Fill(DeltaPhiJJWide);      
-      m_HT_finalSel->Fill(thisHT);      
-    }      
-
+  {
+    // 1D histograms
+    m_MjjWide_finalSel->Fill(MJJWide);
+    m_MjjWide_finalSel_varbin->Fill(MJJWide);
+    m_DetajjWide_finalSel->Fill(DeltaEtaJJWide);
+    m_DphijjWide_finalSel->Fill(DeltaPhiJJWide);      
+    m_HT_finalSel->Fill(thisHT);      
+  }      
   // After full selection (without "noise" filters)
   if( pass_nocut && pass_twowidejets && pass_etaptcuts && pass_deta )
-    {
-      m_MjjWide_finalSel_WithoutNoiseFilter->Fill(MJJWide);
-      m_MjjWide_finalSel_WithoutNoiseFilter_varbin->Fill(MJJWide);
-    }
-
+  {
+    m_MjjWide_finalSel_WithoutNoiseFilter->Fill(MJJWide);
+    m_MjjWide_finalSel_WithoutNoiseFilter_varbin->Fill(MJJWide);
+  }
   // After full selection (except DeltaEta cut)
   if( pass_fullsel_NOdeta )
-    {
-      // 1D histograms
-      m_DetajjWide->Fill(DeltaEtaJJWide);
+  {
+    // 1D histograms
+    m_DetajjWide->Fill(DeltaEtaJJWide);
+    if( DeltaEtaJJWide >= 0.0 && DeltaEtaJJWide < 0.5 )
+      m_MjjWide_deta_0p0_0p5->Fill(MJJWide);
+    if( DeltaEtaJJWide >= 0.5 && DeltaEtaJJWide < 1.0 )
+      m_MjjWide_deta_0p5_1p0->Fill(MJJWide);
+    if( DeltaEtaJJWide >= 1.0 && DeltaEtaJJWide < 1.5 )
+      m_MjjWide_deta_1p0_1p5->Fill(MJJWide);
+    if( DeltaEtaJJWide >= 1.5 && DeltaEtaJJWide < 2.0 )
+      m_MjjWide_deta_1p5_2p0->Fill(MJJWide);
+    if( DeltaEtaJJWide >= 2.0 && DeltaEtaJJWide < 2.5 )
+      m_MjjWide_deta_2p0_2p5->Fill(MJJWide);
+    if( DeltaEtaJJWide >= 2.5 && DeltaEtaJJWide < 3.0 )
+      m_MjjWide_deta_2p5_3p0->Fill(MJJWide);
+    if( DeltaEtaJJWide >= 3.0 )
+      m_MjjWide_deta_3p0_inf->Fill(MJJWide);
 
-      if( DeltaEtaJJWide >= 0.0 && DeltaEtaJJWide < 0.5 )
-	m_MjjWide_deta_0p0_0p5->Fill(MJJWide);
-      if( DeltaEtaJJWide >= 0.5 && DeltaEtaJJWide < 1.0 )
-	m_MjjWide_deta_0p5_1p0->Fill(MJJWide);
-      if( DeltaEtaJJWide >= 1.0 && DeltaEtaJJWide < 1.5 )
-	m_MjjWide_deta_1p0_1p5->Fill(MJJWide);
-      if( DeltaEtaJJWide >= 1.5 && DeltaEtaJJWide < 2.0 )
-	m_MjjWide_deta_1p5_2p0->Fill(MJJWide);
-      if( DeltaEtaJJWide >= 2.0 && DeltaEtaJJWide < 2.5 )
-	m_MjjWide_deta_2p0_2p5->Fill(MJJWide);
-      if( DeltaEtaJJWide >= 2.5 && DeltaEtaJJWide < 3.0 )
-	m_MjjWide_deta_2p5_3p0->Fill(MJJWide);
-      if( DeltaEtaJJWide >= 3.0 )
-	m_MjjWide_deta_3p0_inf->Fill(MJJWide);
-      
-      // 2D histograms
-      m_DetajjVsMjjWide->Fill(MJJWide,DeltaEtaJJWide);            
-      m_DetajjVsMjjWide_rebin->Fill(MJJWide,DeltaEtaJJWide);
-    }
-  
+    // 2D histograms
+    m_DetajjVsMjjWide->Fill(MJJWide,DeltaEtaJJWide);            
+    m_DetajjVsMjjWide_rebin->Fill(MJJWide,DeltaEtaJJWide);
+  }
 
   // ## Get Trigger Info
 
@@ -325,396 +652,88 @@ void DiJetVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
   //  DST_L1HTT_Or_L1MultiJet_v1
   //  DST_Mu5_HT250_v1
   //  DST_Ele8_CaloIdL_CaloIsoVL_TrkIdVL_TrkIsoVL_HT250_v1
-
   int HLTpathMain_fired    = -1;
   int HLTpathMonitor_fired = -1;
-  
-
   if (HLTpathMain_ and HLTpathMonitor_ and triggerConfiguration_.setEvent(iEvent, c)) {
     // invalid HLT configuration, skip the processing
-    
+
     // if the L1 or HLT configurations have changed, (re)initialize the filters (including during the first event)
     if (triggerConfiguration_.configurationUpdated()) {
       HLTpathMain_->init(triggerConfiguration_);
       HLTpathMonitor_->init(triggerConfiguration_);
-      
+
       // log the expanded configuration
       // std::cout << "HLT selector configurations updated" << std::endl;
       // std::cout << "HLTpathMain:    " << *HLTpathMain_    << std::endl;
       // std::cout << "HLTpathMonitor: " << *HLTpathMonitor_ << std::endl;
     }
-    
+
     HLTpathMain_fired    = (*HLTpathMain_)(triggerConfiguration_);
     HLTpathMonitor_fired = (*HLTpathMonitor_)(triggerConfiguration_);
-    
+
     // The OR of the two should always be "1"
     // std::cout << *HLTpathMain_ << ": " << HLTpathMain_fired << " -- " << *HLTpathMonitor_ << ": " << HLTpathMonitor_fired << std::endl;
   }
-  
+
   // ## Trigger Efficiency Curves
 
   //denominator - full sel NO deta cut
   if( pass_fullsel_NOdeta && HLTpathMonitor_fired == 1 )
-    {
-      m_MjjWide_den_NOdeta->Fill(MJJWide);
+  {
+    m_MjjWide_den_NOdeta->Fill(MJJWide);
 
-      //numerator  
-      if( HLTpathMain_fired == 1)
-	{
-	  m_MjjWide_num_NOdeta->Fill(MJJWide);
-	}
+    //numerator  
+    if( HLTpathMain_fired == 1)
+    {
+      m_MjjWide_num_NOdeta->Fill(MJJWide);
     }
+  }
 
   //denominator - full sel deta < 4.0
   if( pass_fullsel_detaL4 && HLTpathMonitor_fired == 1 )
-    {
-      m_MjjWide_den_detaL4->Fill(MJJWide);
+  {
+    m_MjjWide_den_detaL4->Fill(MJJWide);
 
-      //numerator  
-      if( HLTpathMain_fired == 1)
-	{
-	  m_MjjWide_num_detaL4->Fill(MJJWide);
-	}
+    //numerator  
+    if( HLTpathMain_fired == 1)
+    {
+      m_MjjWide_num_detaL4->Fill(MJJWide);
     }
+  }
 
   //denominator - full sel deta < 3.0
   if( pass_fullsel_detaL3 && HLTpathMonitor_fired == 1 )
-    {
-      m_MjjWide_den_detaL3->Fill(MJJWide);
+  {
+    m_MjjWide_den_detaL3->Fill(MJJWide);
 
-      //numerator  
-      if( HLTpathMain_fired == 1)
-	{
-	  m_MjjWide_num_detaL3->Fill(MJJWide);
-	}
+    //numerator  
+    if( HLTpathMain_fired == 1)
+    {
+      m_MjjWide_num_detaL3->Fill(MJJWide);
     }
+  }
 
   //denominator - full sel deta < 2.0
   if( pass_fullsel_detaL2 && HLTpathMonitor_fired == 1 )
-    {
-      m_MjjWide_den_detaL2->Fill(MJJWide);
+  {
+    m_MjjWide_den_detaL2->Fill(MJJWide);
 
-      //numerator  
-      if( HLTpathMain_fired == 1)
-	{
-	  m_MjjWide_num_detaL2->Fill(MJJWide);
-	}
+    //numerator  
+    if( HLTpathMain_fired == 1)
+    {
+      m_MjjWide_num_detaL2->Fill(MJJWide);
     }
-  
+  }
+
   //denominator - full sel default deta cut (typically 1.3)
   if( pass_fullsel && HLTpathMonitor_fired == 1 )
+  {
+    m_MjjWide_den->Fill(MJJWide);
+
+    //numerator  
+    if( HLTpathMain_fired == 1)
     {
-      m_MjjWide_den->Fill(MJJWide);
-
-      //numerator  
-      if( HLTpathMain_fired == 1)
-	{
-	  m_MjjWide_num->Fill(MJJWide);
-	}
+      m_MjjWide_num->Fill(MJJWide);
     }
-
-
+  }
 }
-
-void DiJetVarAnalyzer::endRun( edm::Run const &, edm::EventSetup const & ){
-}
-
-//------------------------------------------------------------------------------
-// Function to book the Monitoring Elements.
-void DiJetVarAnalyzer::bookMEs(){
-  
-  // ==> TO BE UPDATED FOR sqrt(s)=8 TeV
-  const int N_mass_bins=83;
-  float massBins[N_mass_bins+1] = {1, 3, 6, 10, 16, 23, 31, 40, 50, 61, 74, 88, 103, 119, 137, 156, 176, 197, 220, 244, 270, 296, 325, 354, 386, 419, 453, 489, 526, 565, 606, 649, 693, 740, 788, 838, 890, 944, 1000, 1058, 1118, 1181, 1246, 1313, 1383, 1455, 1530, 1607, 1687, 1770, 1856, 1945, 2037, 2132, 2231, 2332, 2438, 2546, 2659, 2775, 2895, 3019, 3147, 3279, 3416, 3558, 3704, 3854, 4010, 4171, 4337, 4509, 4686, 4869, 5058, 5253, 5455, 5663, 5877, 6099, 6328, 6564, 6808, 7000};
-
-  // 1D histograms
-  m_cutFlow = bookH1withSumw2( "h1_cutFlow",
-			       "Cut Flow",
-			       7,0.,7.,
-			       "Cut",
-			       "Number of events"
-			       );
-  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(1,"No cut");
-  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(2,"N(WideJets)>=2");
-  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(3,"|#eta|<2.5 , pT>30");
-  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(4,"|#Delta#eta|<1.3");
-  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(5,"JetID");
-  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(6,"|#Delta#phi|>#pi/3");
-  m_cutFlow->getTH1()->GetXaxis()->SetBinLabel(7,"|met-metClean|>0.1");
-
-  m_MjjWide_finalSel = bookH1withSumw2( "h1_MjjWide_finalSel",
-					"M_{jj} WideJets (final selection)",
-					8000,0.,8000.,
-					"M_{jj} WideJets [GeV]",
-					"Number of events"
-					);
-
-  m_MjjWide_finalSel_varbin = bookH1withSumw2BinArray( "h1_MjjWide_finalSel_varbin",
-						       "M_{jj} WideJets (final selection)",
-						       N_mass_bins, massBins,
-						       "M_{jj} WideJets [GeV]",
-						       "Number of events"
-						       );
-
-  m_MjjWide_finalSel_WithoutNoiseFilter = bookH1withSumw2( "h1_MjjWide_finalSel_WithoutNoiseFilter",
-							   "M_{jj} WideJets (final selection, without noise filters)",
-							   8000,0.,8000.,
-							   "M_{jj} WideJets [GeV]",
-							   "Number of events"
-							   );
-
-  m_MjjWide_finalSel_WithoutNoiseFilter_varbin = bookH1withSumw2BinArray( "h1_MjjWide_finalSel_WithoutNoiseFilter_varbin",
-									  "M_{jj} WideJets (final selection, without noise filters)",
-									  N_mass_bins, massBins,
-									  "M_{jj} WideJets [GeV]",
-									  "Number of events"
-									  );
-  
-  m_MjjWide_deta_0p0_0p5 = bookH1withSumw2( "h1_MjjWide_deta_0p0_0p5",
-					    "M_{jj} WideJets (0.0<=#Delta#eta<0.5)",
-					    8000,0.,8000.,
-					    "M_{jj} WideJets [GeV]",
-					    "Number of events"
-					    );
-
-  m_MjjWide_deta_0p5_1p0 = bookH1withSumw2( "h1_MjjWide_deta_0p5_1p0",
-					    "M_{jj} WideJets (0.5<=#Delta#eta<1.0)",
-					    8000,0.,8000.,
-					    "M_{jj} WideJets [GeV]",
-					    "Number of events"
-					    );
-
-  m_MjjWide_deta_1p0_1p5 = bookH1withSumw2( "h1_MjjWide_deta_1p0_1p5",
-					    "M_{jj} WideJets (1.0<=#Delta#eta<1.5)",
-					    8000,0.,8000.,
-					    "M_{jj} WideJets [GeV]",
-					    "Number of events"
-					    );
-
-  m_MjjWide_deta_1p5_2p0 = bookH1withSumw2( "h1_MjjWide_deta_1p5_2p0",
-					    "M_{jj} WideJets (1.5<=#Delta#eta<2.0)",
-					    8000,0.,8000.,
-					    "M_{jj} WideJets [GeV]",
-					    "Number of events"
-					    );
-
-  m_MjjWide_deta_2p0_2p5 = bookH1withSumw2( "h1_MjjWide_deta_2p0_2p5",
-					    "M_{jj} WideJets (2.0<=#Delta#eta<2.5)",
-					    8000,0.,8000.,
-					    "M_{jj} WideJets [GeV]",
-					    "Number of events"
-					    );
-
-  m_MjjWide_deta_2p5_3p0 = bookH1withSumw2( "h1_MjjWide_deta_2p5_3p0",
-					    "M_{jj} WideJets (2.5<=#Delta#eta<3.0)",
-					    8000,0.,8000.,
-					    "M_{jj} WideJets [GeV]",
-					    "Number of events"
-					    );
-
-  m_MjjWide_deta_3p0_inf = bookH1withSumw2( "h1_MjjWide_deta_3p0_inf",
-					    "M_{jj} WideJets (#Delta#eta>=3.0)",
-					    8000,0.,8000.,
-					    "M_{jj} WideJets [GeV]",
-					    "Number of events"
-					    );
-
-  m_MjjWide_den_NOdeta = bookH1withSumw2( "h1_MjjWide_den_NOdeta",
-					  "HLT Efficiency Studies (no deta cut)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-  
-  m_MjjWide_num_NOdeta = bookH1withSumw2( "h1_MjjWide_num_NOdeta",
-					  "HLT Efficiency Studies (no deta cut)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-
-  m_MjjWide_den_detaL4 = bookH1withSumw2( "h1_MjjWide_den_detaL4",
-					  "HLT Efficiency Studies (deta cut < 4.0)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-  
-  m_MjjWide_num_detaL4 = bookH1withSumw2( "h1_MjjWide_num_detaL4",
-					  "HLT Efficiency Studies (deta cut < 4.0)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-
-  m_MjjWide_den_detaL3 = bookH1withSumw2( "h1_MjjWide_den_detaL3",
-					  "HLT Efficiency Studies (deta cut < 3.0)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-  
-  m_MjjWide_num_detaL3 = bookH1withSumw2( "h1_MjjWide_num_detaL3",
-					  "HLT Efficiency Studies (deta cut < 3.0)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-
-  m_MjjWide_den_detaL2 = bookH1withSumw2( "h1_MjjWide_den_detaL2",
-					  "HLT Efficiency Studies (deta cut < 2.0)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-  
-  m_MjjWide_num_detaL2 = bookH1withSumw2( "h1_MjjWide_num_detaL2",
-					  "HLT Efficiency Studies (deta cut < 2.0)",
-					  400,0.,2000.,
-					  "M_{jj} WideJets [GeV]",
-					  "Number of events"
-					  );
-
-  m_MjjWide_den = bookH1withSumw2( "h1_MjjWide_den",
-				   "HLT Efficiency Studies (default deta cut)",
-				   400,0.,2000.,
-				   "M_{jj} WideJets [GeV]",
-				   "Number of events"
-				   );
-
-  m_MjjWide_num = bookH1withSumw2( "h1_MjjWide_num",
-				   "HLT Efficiency Studies (default deta cut)",
-				   400,0.,2000.,
-				   "M_{jj} WideJets [GeV]",
-				   "Number of events"
-				   );
-
-  m_DetajjWide_finalSel = bookH1withSumw2( "h1_DetajjWide_finalSel",
-					   "#Delta#eta_{jj} WideJets (final selection)",
-					   100,0.,5.,
-					   "#Delta#eta_{jj} WideJets",
-					   "Number of events"
-					   );
-
-  m_DetajjWide = bookH1withSumw2( "h1_DetajjWide",
-				  "#Delta#eta_{jj} WideJets (final selection except #Delta#eta cut)",
-				  100,0.,5.,
-				  "#Delta#eta_{jj} WideJets",
-				  "Number of events"
-				  );
-
-  m_DphijjWide_finalSel = bookH1withSumw2( "h1_DphijjWide_finalSel",
-					   "#Delta#phi_{jj} WideJets (final selection)",
-					   100,0.,TMath::Pi()+0.0001,
-					   "#Delta#phi_{jj} WideJets [rad.]",
-					   "Number of events"
-					   );
-
-
-  m_selJets_pt = bookH1withSumw2( "h1_selJets_pt",
-				  "Selected CaloJets",
-				  500,0.,5000.,
-				  "Jet Pt [GeV]",
-				  "Number of events"
-				  );
-
-  m_selJets_eta = bookH1withSumw2( "h1_selJets_eta",
-				  "Selected CaloJets",
-				  100,-5.,5.,
-				  "#eta",
-				  "Number of events"
-				  );
-
-  m_selJets_phi = bookH1withSumw2( "h1_selJets_phi",
-				  "Selected CaloJets",
-				   100,-TMath::Pi(),TMath::Pi(),
-				  "#phi (rad.)",
-				  "Number of events"
-				  );
-
-  m_selJets_hadEnergyFraction = bookH1withSumw2( "h1_selJets_hadEnergyFraction",
-						 "Selected CaloJets",
-						 110,0.,1.1,
-						 "HAD Energy Fraction",
-						 "Number of events"
-						 );
-
-  m_selJets_emEnergyFraction = bookH1withSumw2( "h1_selJets_emEnergyFraction",
-						 "Selected CaloJets",
-						 110,0.,1.1,
-						 "EM Energy Fraction",
-						 "Number of events"
-						 );
-
-  m_selJets_towersArea = bookH1withSumw2( "h1_selJets_towersArea",
-					  "Selected CaloJets",
-					  200,0.,2.,
-					  "towers area",
-					  "Number of events"
-					  );
-
-  m_metDiff = bookH1withSumw2( "h1_metDiff",
-			       "Met - MetCleaned",
-			       500,-1000.,1000.,
-			       "met - metcleaned [GeV]",
-			       "Number of events"
-			       );
-
-  m_metCases = bookH1withSumw2( "h1_metCases",
-				"Met cases",
-				3,0.,3.,
-				"case",
-				"Number of events"
-				);
-  m_metCases->getTH1()->GetXaxis()->SetBinLabel(1,"met , metclean");
-  m_metCases->getTH1()->GetXaxis()->SetBinLabel(2,"met , !metclean");
-  m_metCases->getTH1()->GetXaxis()->SetBinLabel(3,"!met , metclean");
-
-
-  m_metCaseNoMetClean = bookH1withSumw2( "h1_metCaseNoMetClean",
-					 "Met - MetCleaned",
-					 1000,0.,2000.,
-					 "MET [GeV]",
-					 "Number of events"
-					 );  
-
-  m_HT_inclusive = bookH1withSumw2( "h1_HT_inclusive",
-				    "HT (inclusive)",
-				    150,0.,15000.,
-				    "HT [GeV]",
-				    "Number of events"
-				    );  
-
-  m_HT_finalSel = bookH1withSumw2( "h1_HT_finalSel",
-				   "HT (final selection)",
-				   150,0.,15000.,
-				   "HT [GeV]",
-				   "Number of events"
-				   );  
-
-
-  // 2D histograms
-  m_DetajjVsMjjWide = bookH2withSumw2("h2_DetajjVsMjjWide",
-				      "#Delta#eta_{jj} vs M_{jj} WideJets",
-				      8000,0.,8000.,
-				      100,0.,5.,
-				      "M_{jj} WideJets [GeV]",
-				      "#Delta#eta_{jj} WideJets");
-
-  m_DetajjVsMjjWide_rebin = bookH2withSumw2("h2_DetajjVsMjjWide_rebin",
-					    "#Delta#eta_{jj} vs M_{jj} WideJets",
-					    400,0.,8000.,
-					    50,0.,5.,
-					    "M_{jj} WideJets [GeV]",
-					    "#Delta#eta_{jj} WideJets");
-
-  m_metVSmetclean = bookH2withSumw2("h2_metVSmetclean",
-				    "MET clean vs MET",
-				    100,0.,2000.,
-				    100,0.,2000.,
-				    "MET [GeV]",
-				    "MET clean [GeV]");
-
-
-}
-

--- a/DQM/DataScouting/plugins/DiJetVarAnalyzer.h
+++ b/DQM/DataScouting/plugins/DiJetVarAnalyzer.h
@@ -1,7 +1,6 @@
 #ifndef DiJetVarAnalyzer_h
 #define DiJetVarAnalyzer_h
 
-
 #include "DQM/DataScouting/interface/ScoutingAnalyzerBase.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionEvaluator.h"
@@ -12,24 +11,14 @@
 #include <vector>
 #include <cmath>
 
-class DiJetVarAnalyzer : public ScoutingAnalyzerBase
- {
-
+class DiJetVarAnalyzer : public ScoutingAnalyzerBase {
   public:
-
     explicit DiJetVarAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~DiJetVarAnalyzer() ;
-
+    void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
     virtual void analyze( const edm::Event & , const edm::EventSetup &  );
-    virtual void beginRun( const edm::Run &, const edm::EventSetup & );
-    virtual void endRun( edm::Run const &, edm::EventSetup const & ) ;
-
-    virtual void bookMEs();
-
   private: 
-
     edm::InputTag jetCollectionTag_;
-    //edm::InputTag dijetVarCollectionTag_;
     edm::InputTag widejetsCollectionTag_;
     edm::InputTag metCollectionTag_;
     edm::InputTag metCleanCollectionTag_;
@@ -46,13 +35,10 @@ class DiJetVarAnalyzer : public ScoutingAnalyzerBase
     // trigger conditions
     triggerExpression::Evaluator * HLTpathMain_;
     triggerExpression::Evaluator * HLTpathMonitor_;
-    
     // cache some data from the Event for faster access by the trigger conditions
     triggerExpression::Data triggerConfiguration_;
-    
     //1D histograms
     MonitorElement * m_cutFlow;
-
     MonitorElement * m_MjjWide_finalSel;
     MonitorElement * m_MjjWide_finalSel_varbin;
     MonitorElement * m_MjjWide_finalSel_WithoutNoiseFilter;
@@ -106,7 +92,5 @@ class DiJetVarAnalyzer : public ScoutingAnalyzerBase
     edm::EDGetTokenT<std::vector<math::PtEtaPhiMLorentzVector> > widejetsCollectionTagToken_;
     edm::EDGetTokenT<reco::CaloMETCollection> metCollectionTagToken_;
     edm::EDGetTokenT<reco::CaloMETCollection> metCleanCollectionTagToken_;
-
- } ;
-
+};
 #endif

--- a/DQM/DataScouting/plugins/RazorVarAnalyzer.cc
+++ b/DQM/DataScouting/plugins/RazorVarAnalyzer.cc
@@ -11,35 +11,166 @@
 
 #include <cmath>
 
-//------------------------------------------------------------------------------
 // A simple constructor which takes as inoput only the name of the PF jet collection
 RazorVarAnalyzer::RazorVarAnalyzer( const edm::ParameterSet & conf ):
   ScoutingAnalyzerBase(conf),
   m_eleCollectionTag(conf.getUntrackedParameter<edm::InputTag>("eleCollectionName",edm::InputTag("hltPixelMatchElectronsActivity"))),
   m_jetCollectionTag(conf.getUntrackedParameter<edm::InputTag>("jetCollectionName",edm::InputTag("hltCaloJetIDPassed"))),
   m_muCollectionTag(conf.getUntrackedParameter<edm::InputTag>("muCollectionName",edm::InputTag("hltL3MuonCandidates"))),
-  m_razorVarCollectionTag(conf.getUntrackedParameter<edm::InputTag>("razorVarCollectionName")){
-
-  //set Token(-s)
-  m_jetCollectionTagToken_ = consumes<reco::CaloJetCollection>(conf.getUntrackedParameter<edm::InputTag>("jetCollectionName",edm::InputTag("hltCaloJetIDPassed")));
-  m_muCollectionTagToken_ = consumes<std::vector<reco::RecoChargedCandidate> >(conf.getUntrackedParameter<edm::InputTag>("muCollectionName",edm::InputTag("hltL3MuonCandidates")));
-  m_eleCollectionTagToken_ = consumes<reco::ElectronCollection>(conf.getUntrackedParameter<edm::InputTag>("eleCollectionName",edm::InputTag("hltPixelMatchElectronsActivity")));
-  m_razorVarCollectionTagToken_ = consumes<std::vector<double> >(conf.getUntrackedParameter<edm::InputTag>("razorVarCollectionName"));
+  m_razorVarCollectionTag(conf.getUntrackedParameter<edm::InputTag>("razorVarCollectionName")) {
+    //set Token(-s)
+    m_jetCollectionTagToken_ = consumes<reco::CaloJetCollection>(conf.getUntrackedParameter<edm::InputTag>("jetCollectionName",edm::InputTag("hltCaloJetIDPassed")));
+    m_muCollectionTagToken_ = consumes<std::vector<reco::RecoChargedCandidate> >(conf.getUntrackedParameter<edm::InputTag>("muCollectionName",edm::InputTag("hltL3MuonCandidates")));
+    m_eleCollectionTagToken_ = consumes<reco::ElectronCollection>(conf.getUntrackedParameter<edm::InputTag>("eleCollectionName",edm::InputTag("hltPixelMatchElectronsActivity")));
+    m_razorVarCollectionTagToken_ = consumes<std::vector<double> >(conf.getUntrackedParameter<edm::InputTag>("razorVarCollectionName"));
 }
 
-//------------------------------------------------------------------------------
-// Nothing to destroy: the DQM service thinks about everything
-RazorVarAnalyzer::~RazorVarAnalyzer(){}
+RazorVarAnalyzer::~RazorVarAnalyzer() {}
 
-//------------------------------------------------------------------------------
+// Function to book the Monitoring Elements.
+void RazorVarAnalyzer::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &) {
+  ScoutingAnalyzerBase::prepareBooking(iBooker);
+  //the full inclusive histograms
+  m_rsqMRFullyInc = bookH2withSumw2(
+      iBooker,
+      "rsqMRFullyInc",
+      "M_{R} vs R^{2} (All Events)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRInc4J = bookH2withSumw2(
+      iBooker,
+      "rsqMRInc4J",
+      "M_{R} vs R^{2} (>= 4j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRInc6J = bookH2withSumw2(
+      iBooker,
+      "rsqMRInc6J",
+      "M_{R} vs R^{2} (>= 6j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRInc8J = bookH2withSumw2(
+      iBooker,
+      "rsqMRInc8J",
+      "M_{R} vs R^{2} (>= 8j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRInc10J = bookH2withSumw2(
+      iBooker,
+      "rsqMRInc10J",
+      "M_{R} vs R^{2} (>= 10j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRInc12J = bookH2withSumw2(
+      iBooker,
+      "rsqMRInc12J",
+      "M_{R} vs R^{2} (>= 12j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRInc14J = bookH2withSumw2(
+      iBooker,
+      "rsqMRInc14J",
+      "M_{R} vs R^{2} (>= 14j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+
+  //the by box histograms
+  m_rsqMREleMu = bookH2withSumw2(
+      iBooker,
+      "rsqMREleMu",
+      "M_{R} vs R^{2} (EleMu box)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRMuMu = bookH2withSumw2(
+      iBooker,
+      "rsqMRMuMu",
+      "M_{R} vs R^{2} (MuMu box)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMREleEle = bookH2withSumw2(
+      iBooker,
+      "rsqMREleEle",
+      "M_{R} vs R^{2} (EleEle box)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRMu = bookH2withSumw2(
+      iBooker,
+      "rsqMRMu",
+      "M_{R} vs R^{2} (Mu box)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMREle = bookH2withSumw2(
+      iBooker,
+      "rsqMREle",
+      "M_{R} vs R^{2} (Ele box)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRHad = bookH2withSumw2(
+      iBooker,
+      "rsqMRHad",
+      "M_{R} vs R^{2} (Had box)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+
+  //the by box histograms
+  m_rsqMRMuMJ = bookH2withSumw2(
+      iBooker,
+      "rsqMRMuMJ",
+      "M_{R} vs R^{2} (Mu box >= 4j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMREleMJ = bookH2withSumw2(
+      iBooker,
+      "rsqMREleMJ",
+      "M_{R} vs R^{2} (Ele box >= 5j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+  m_rsqMRHadMJ = bookH2withSumw2(
+      iBooker,
+      "rsqMRHadMJ",
+      "M_{R} vs R^{2} (Had box >= 6j)",
+      400,0.,4000.,
+      50,0.,1.,
+      "M_{R} [GeV]",
+      "R^{2}");
+}
+
 // Usual analyze method
-void RazorVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ){
-  
+void RazorVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ) {
   //count the number of jets with a minimal selection
   edm::Handle<reco::CaloJetCollection> calojets_handle;
   iEvent.getByToken(m_jetCollectionTagToken_, calojets_handle);
 
-  
   unsigned int njets = 0;
   for(reco::CaloJetCollection::const_iterator it = calojets_handle->begin(); it != calojets_handle->end(); ++it){
     if(it->pt() >= 30. && fabs(it->eta()) <= 3.0){
@@ -59,11 +190,11 @@ void RazorVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
       if(it->pt() >= 10 && fabs(it->eta()) <= 2.4) nmu_loose++;
     }
   }
-  
+
   //count the number of electrons
   edm::Handle<reco::ElectronCollection> ele_handle;
   iEvent.getByToken(m_eleCollectionTagToken_, ele_handle);
-  
+
   unsigned int nele_loose = 0;
   unsigned int nele_tight = 0;
   if(ele_handle.isValid()){
@@ -72,7 +203,7 @@ void RazorVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
       if(it->pt() >= 10 && fabs(it->eta()) <= 2.5) nele_loose++;
     }
   }
-  
+
   //now get the box number: {'MuEle':0,'MuMu':1,'EleEle':2,'Mu':3,'Ele':4,'Had':5}
   unsigned int box_num = 5;
   if(nmu_tight > 0 && nele_tight > 0){
@@ -89,7 +220,6 @@ void RazorVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
 
   edm::Handle<std::vector<double> > razorvar_handle;
   iEvent.getByToken(m_razorVarCollectionTagToken_, razorvar_handle);
-
   if(razorvar_handle->size() > 1){
     const double MR = razorvar_handle->at(0);
     const double R = razorvar_handle->at(1);
@@ -100,7 +230,7 @@ void RazorVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
     if(njets >= 10) m_rsqMRInc10J->Fill(MR,R*R);
     if(njets >= 12) m_rsqMRInc12J->Fill(MR,R*R);
     if(njets >= 14) m_rsqMRInc14J->Fill(MR,R*R);
-    
+
     //now fill the boxes
     if(box_num == 0) m_rsqMREleMu->Fill(MR,R*R);
     if(box_num == 1) m_rsqMRMuMu->Fill(MR,R*R);
@@ -117,118 +247,4 @@ void RazorVarAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup
     //fill the Had box
     else if( box_num == 5 && njets >= 6) m_rsqMRHadMJ->Fill(MR,R*R);
   }
-  
-}
-
-void RazorVarAnalyzer::endRun( edm::Run const &, edm::EventSetup const & ){
-}
-
-//------------------------------------------------------------------------------
-// Function to book the Monitoring Elements.
-void RazorVarAnalyzer::bookMEs(){
-  
-  //the full inclusive histograms
-  m_rsqMRFullyInc = bookH2withSumw2("rsqMRFullyInc",
-				    "M_{R} vs R^{2} (All Events)",
-				    400,0.,4000.,
-				    50,0.,1.,
-				    "M_{R} [GeV]",
-				    "R^{2}");
-  m_rsqMRInc4J = bookH2withSumw2("rsqMRInc4J",
-				    "M_{R} vs R^{2} (>= 4j)",
-				    400,0.,4000.,
-				    50,0.,1.,
-				    "M_{R} [GeV]",
-				    "R^{2}");
-  m_rsqMRInc6J = bookH2withSumw2("rsqMRInc6J",
-				    "M_{R} vs R^{2} (>= 6j)",
-				    400,0.,4000.,
-				    50,0.,1.,
-				    "M_{R} [GeV]",
-				    "R^{2}");
-  m_rsqMRInc8J = bookH2withSumw2("rsqMRInc8J",
-				    "M_{R} vs R^{2} (>= 8j)",
-				    400,0.,4000.,
-				    50,0.,1.,
-				    "M_{R} [GeV]",
-				    "R^{2}");
-  m_rsqMRInc10J = bookH2withSumw2("rsqMRInc10J",
-				    "M_{R} vs R^{2} (>= 10j)",
-				    400,0.,4000.,
-				    50,0.,1.,
-				    "M_{R} [GeV]",
-				    "R^{2}");
-  m_rsqMRInc12J = bookH2withSumw2("rsqMRInc12J",
-				    "M_{R} vs R^{2} (>= 12j)",
-				    400,0.,4000.,
-				    50,0.,1.,
-				    "M_{R} [GeV]",
-				    "R^{2}");
-  m_rsqMRInc14J = bookH2withSumw2("rsqMRInc14J",
-				    "M_{R} vs R^{2} (>= 14j)",
-				    400,0.,4000.,
-				    50,0.,1.,
-				    "M_{R} [GeV]",
-				    "R^{2}");
-
-  //the by box histograms
-  m_rsqMREleMu = bookH2withSumw2("rsqMREleMu",
-				 "M_{R} vs R^{2} (EleMu box)",
-				 400,0.,4000.,
-				 50,0.,1.,
-				 "M_{R} [GeV]",
-				 "R^{2}");
-  m_rsqMRMuMu = bookH2withSumw2("rsqMRMuMu",
-				"M_{R} vs R^{2} (MuMu box)",
-				400,0.,4000.,
-				50,0.,1.,
-				"M_{R} [GeV]",
-				"R^{2}");
-  m_rsqMREleEle = bookH2withSumw2("rsqMREleEle",
-				  "M_{R} vs R^{2} (EleEle box)",
-				  400,0.,4000.,
-				  50,0.,1.,
-				  "M_{R} [GeV]",
-				  "R^{2}");
-  m_rsqMRMu = bookH2withSumw2("rsqMRMu",
-			      "M_{R} vs R^{2} (Mu box)",
-			      400,0.,4000.,
-			      50,0.,1.,
-			      "M_{R} [GeV]",
-			      "R^{2}");
-  m_rsqMREle = bookH2withSumw2("rsqMREle",
-			       "M_{R} vs R^{2} (Ele box)",
-			       400,0.,4000.,
-			       50,0.,1.,
-			       "M_{R} [GeV]",
-			       "R^{2}");
-  m_rsqMRHad = bookH2withSumw2("rsqMRHad",
-				  "M_{R} vs R^{2} (Had box)",
-				  400,0.,4000.,
-				  50,0.,1.,
-				  "M_{R} [GeV]",
-				  "R^{2}");
-
-  //the by box histograms
-  m_rsqMRMuMJ = bookH2withSumw2("rsqMRMuMJ",
-			      "M_{R} vs R^{2} (Mu box >= 4j)",
-			      400,0.,4000.,
-			      50,0.,1.,
-			      "M_{R} [GeV]",
-			      "R^{2}");
-  m_rsqMREleMJ = bookH2withSumw2("rsqMREleMJ",
-			       "M_{R} vs R^{2} (Ele box >= 5j)",
-			       400,0.,4000.,
-			       50,0.,1.,
-			       "M_{R} [GeV]",
-			       "R^{2}");
-  m_rsqMRHadMJ = bookH2withSumw2("rsqMRHadMJ",
-				 "M_{R} vs R^{2} (Had box >= 6j)",
-				 400,0.,4000.,
-				 50,0.,1.,
-				 "M_{R} [GeV]",
-				 "R^{2}");
-
-
-}
-
+} 

--- a/DQM/DataScouting/plugins/RazorVarAnalyzer.h
+++ b/DQM/DataScouting/plugins/RazorVarAnalyzer.h
@@ -1,29 +1,19 @@
 #ifndef RazorVarAnalyzer_h
 #define RazorVarAnalyzer_h
 
-
 #include "DQM/DataScouting/interface/ScoutingAnalyzerBase.h"
 
 #include "DataFormats/EgammaCandidates/interface/ElectronFwd.h"
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 #include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
 
-class RazorVarAnalyzer : public ScoutingAnalyzerBase
- {
-
+class RazorVarAnalyzer : public ScoutingAnalyzerBase {
   public:
-
     explicit RazorVarAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~RazorVarAnalyzer() ;
-
+    void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
     virtual void analyze( const edm::Event & , const edm::EventSetup &  );
-    
-    virtual void endRun( edm::Run const &, edm::EventSetup const & ) ;
-
-    virtual void bookMEs();
-
   private: 
-
     edm::InputTag m_eleCollectionTag;    
     edm::InputTag m_jetCollectionTag;
     edm::InputTag m_muCollectionTag;
@@ -56,7 +46,5 @@ class RazorVarAnalyzer : public ScoutingAnalyzerBase
     edm::EDGetTokenT<std::vector<reco::RecoChargedCandidate> > m_muCollectionTagToken_;
     edm::EDGetTokenT<reco::ElectronCollection> m_eleCollectionTagToken_;
     edm::EDGetTokenT<std::vector<double> > m_razorVarCollectionTagToken_;
-
- } ;
-
+};
 #endif

--- a/DQM/DataScouting/plugins/ScoutingTestAnalyzer.cc
+++ b/DQM/DataScouting/plugins/ScoutingTestAnalyzer.cc
@@ -1,87 +1,75 @@
 // This class is used to test the functionalities of the package
 
 #include "DQM/DataScouting/plugins/ScoutingTestAnalyzer.h"
-
-
 #include "DataFormats/JetReco/interface/CaloJet.h"
 
-//------------------------------------------------------------------------------
 // A simple constructor which takes as inoput only the name of the PF jet collection
 ScoutingTestAnalyzer::ScoutingTestAnalyzer( const edm::ParameterSet & conf )
-   :ScoutingAnalyzerBase(conf){
+  :ScoutingAnalyzerBase(conf) {
   m_pfJetsCollectionTag = conf.getUntrackedParameter<edm::InputTag>("pfJetsCollectionName");
-
   //set Token(-s)
   m_pfJetsCollectionTagToken_ = consumes<reco::CaloJetCollection>(conf.getUntrackedParameter<edm::InputTag>("pfJetsCollectionName"));
-  }
+}
 
-//------------------------------------------------------------------------------
-// Nothing to destroy: the DQM service thinks about everything
 ScoutingTestAnalyzer::~ScoutingTestAnalyzer(){}
 
-//------------------------------------------------------------------------------
+// Function to book the Monitoring Elements.
+void ScoutingTestAnalyzer::bookHistograms(DQMStore::IBooker & iBooker, edm::Run const &, edm::EventSetup const &) {
+  ScoutingAnalyzerBase::prepareBooking(iBooker);
+  std::string collection_name = m_pfJetsCollectionTag.label();
+
+  /* This method allows us to book an Histogram in one line in a completely 
+   * transparent way. Take your time to put axis titles!!!!*/
+  m_jetPt = bookH1withSumw2(
+      iBooker,
+      collection_name+"_pt",
+      collection_name+" Jet P_{T}",
+      50,0.,500.,
+      "Jet P_{T} [GeV]");
+
+  m_jetEtaPhi = bookH2withSumw2(
+      iBooker,
+      collection_name+"_etaphi",
+      collection_name+" #eta #phi",
+      50,-5,5,
+      50,-3.1415,+3.1415,
+      "#eta^{Jet}",
+      "#phi^{Jet}");
+}
+
 // Usual analyze method
-void ScoutingTestAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ){
-  
-  
+void ScoutingTestAnalyzer::analyze( const edm::Event & iEvent, const edm::EventSetup & c ) {
   edm::Handle<reco::CaloJetCollection> calojets_handle ;
   iEvent.getByToken(m_pfJetsCollectionTagToken_, calojets_handle);
-
   /* This is an example of how C++11 can simplify or lifes. The auto keyword 
-   make the compiler figure out by itself which is the type of the pfjets object.
-   The qualifier const of course still apply.
-   Poor's man explaination: "compiler, make pfjets a const ref and figure out 
-   for me the type"*/
+     make the compiler figure out by itself which is the type of the pfjets object.
+     The qualifier const of course still apply.
+     Poor's man explaination: "compiler, make pfjets a const ref and figure out 
+     for me the type"*/
   auto const& calojets = *calojets_handle;
-  
+
   // Again, C++11. A loop on a std::vector becomes as simple as this!
   for (auto const & calojet: calojets){
     m_jetPt->Fill(calojet.pt());
     m_jetEtaPhi->Fill(calojet.eta(),calojet.phi());
   }
-  
-  
 }
 
-//------------------------------------------------------------------------------
 /* Method called at the end of the Run. Ideal to finalise stuff within the 
  * DQM infrastructure, which is entirely Run based. */
-void ScoutingTestAnalyzer::endRun( edm::Run const &, edm::EventSetup const & ){
-    
-    std::string collection_name = m_pfJetsCollectionTag.label();
-    /* This function is specific of this class and allows us to make a 
-     * projection in one line */
-    
-    profileX(m_jetEtaPhi,
-             collection_name+" Jets #eta (projection)",
-             "#eta^{Jet}");
-    
-    profileY(m_jetEtaPhi,
-             collection_name+" Jets phi (projection)",
-             "#phi^{Jet}");
-
-    
-}
-
-//------------------------------------------------------------------------------
-// Function to book the Monitoring Elements.
-void ScoutingTestAnalyzer::bookMEs(){
+void ScoutingTestAnalyzer::endRun( edm::Run const &, edm::EventSetup const & ) {
   std::string collection_name = m_pfJetsCollectionTag.label();
-
-  /* This method allows us to book an Histogram in one line in a completely 
-   * transparent way. Take your time to put axis titles!!!!*/
-  m_jetPt = bookH1withSumw2(collection_name+"_pt",
-                            collection_name+" Jet P_{T}",
-                            50,0.,500.,
-                            "Jet P_{T} [GeV]");
-
-  m_jetEtaPhi = bookH2withSumw2(collection_name+"_etaphi",
-                                collection_name+" #eta #phi",
-                                50,-5,5,
-                                50,-3.1415,+3.1415,
-                                "#eta^{Jet}",
-                                "#phi^{Jet}");
+  /* This function is specific of this class and allows us to make a 
+   * projection in one line 
+   * The following code form the original TestAnalyser tried to book histograms
+   * in the endRun step. This is not allowed anymore.
+   * Since this is just a test class, there is no point in trying to fix the impossible.
+   * The profileX and profileY methods are only used in this test class anyway.
+   * */ 
+  ////profileX(m_jetEtaPhi,
+  ////    collection_name+" Jets #eta (projection)",
+  ////    "#eta^{Jet}");
+  ////profileY(m_jetEtaPhi,
+  ////    collection_name+" Jets phi (projection)",
+  ////    "#phi^{Jet}");
 }
-
-//------------------------------------------------------------------------------
-

--- a/DQM/DataScouting/plugins/ScoutingTestAnalyzer.h
+++ b/DQM/DataScouting/plugins/ScoutingTestAnalyzer.h
@@ -2,35 +2,22 @@
 #define ScoutingTestAnalyzer_h
 
 // This class is used to test the functionalities of the package
-
 #include "DataFormats/JetReco/interface/CaloJet.h"
-
 #include "DQM/DataScouting/interface/ScoutingAnalyzerBase.h"
 
-class ScoutingTestAnalyzer : public ScoutingAnalyzerBase
- {
-
+class ScoutingTestAnalyzer : public ScoutingAnalyzerBase {
   public:
-
     explicit ScoutingTestAnalyzer( const edm::ParameterSet &  ) ;
     virtual ~ScoutingTestAnalyzer() ;
-
+    void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
     virtual void analyze( const edm::Event & , const edm::EventSetup &  );
-    
     virtual void endRun( edm::Run const &, edm::EventSetup const & ) ;
-
-    virtual void bookMEs();
-
   private: 
-    
     // histograms
     edm::InputTag m_pfJetsCollectionTag;
     MonitorElement * m_jetPt;
     MonitorElement * m_jetEtaPhi;
-
-  //define Token(-s)
-  edm::EDGetTokenT<reco::CaloJetCollection> m_pfJetsCollectionTagToken_;
- } ;
-
+    //define Token(-s)
+    edm::EDGetTokenT<reco::CaloJetCollection> m_pfJetsCollectionTagToken_;
+};
 #endif
-

--- a/DQM/DataScouting/src/ScoutingAnalyzerBase.cc
+++ b/DQM/DataScouting/src/ScoutingAnalyzerBase.cc
@@ -7,202 +7,168 @@
 #include <iostream>
 #include <sstream>
 
-//------------------------------------------------------------------------------
-
-ScoutingAnalyzerBase::ScoutingAnalyzerBase( const edm::ParameterSet& conf ){
+ScoutingAnalyzerBase::ScoutingAnalyzerBase( const edm::ParameterSet& conf ) {
   m_MEsPath = conf.getUntrackedParameter<std::string>("rootPath","DataScouting") ;
   m_modulePath = conf.getUntrackedParameter<std::string>("modulePath","DataScouting") ;
   m_verbosityLevel = conf.getUntrackedParameter<unsigned int>("verbosityLevel", 0) ;
-  if (m_modulePath.size() != 0)
-    m_MEsPath+="/"+m_modulePath; 
- }
- 
-//--------------------------------------------------------------------------
-
-ScoutingAnalyzerBase::~ScoutingAnalyzerBase(){}
-
-//------------------------------------------------------------------------------
-
-void ScoutingAnalyzerBase::beginJob(){
-  m_store = edm::Service<DQMStore>().operator->() ;
-  if (!m_store)
-   { edm::LogError("ScoutingAnalyzerBase::prepareStore")<<"No DQMStore found !" ; }
-  m_store->setVerbose(m_verbosityLevel) ;
-  m_store->setCurrentFolder(m_MEsPath) ;
-  bookMEs() ;
+  if (m_modulePath.size() != 0) {
+    m_MEsPath+="/"+m_modulePath;
   }
-
-//------------------------------------------------------------------------------
-
-inline std::string ScoutingAnalyzerBase::newName(const std::string & name) {  
-  // let's keep it in case we need massage
-  return name;  
 }
 
-//------------------------------------------------------------------------------
+ScoutingAnalyzerBase::~ScoutingAnalyzerBase() {}
+
+inline std::string ScoutingAnalyzerBase::newName(const std::string & name) {
+  // let's keep it in case we need massage
+  return name;
+}
+
+void ScoutingAnalyzerBase::prepareBooking(DQMStore::IBooker & iBooker) {
+  iBooker.setCurrentFolder(m_MEsPath);
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH1
- ( const std::string & name, const std::string & title,
-   int nchX, double lowX, double highX,
-   const std::string & titleX, const std::string & titleY,
-   Option_t * option )
- {
-  MonitorElement * me = m_store->book1DD(newName(name),title,nchX,lowX,highX) ;
+( DQMStore::IBooker & iBooker,
+  const std::string & name, const std::string & title,
+  int nchX, double lowX, double highX,
+  const std::string & titleX, const std::string & titleY,
+  Option_t * option ) {
+  MonitorElement * me = iBooker.book1DD(newName(name),title,nchX,lowX,highX) ;
   if (titleX!="") { me->getTH1()->GetXaxis()->SetTitle(titleX.c_str()) ; }
   if (titleY!="") { me->getTH1()->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (TString(option)!="") { me->getTH1()->SetOption(option) ; }
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH1withSumw2
- ( const std::string & name, const std::string & title,
-   int nchX, double lowX, double highX,
-   const std::string & titleX, const std::string & titleY,
-   Option_t * option )
- {
-   
+( DQMStore::IBooker & iBooker,
+  const std::string & name, const std::string & title,
+  int nchX, double lowX, double highX,
+  const std::string & titleX, const std::string & titleY,
+  Option_t * option ) {
   std::cout << newName(name) << std::endl;
-  MonitorElement * me = m_store->book1DD(newName(name),title,nchX,lowX,highX) ;
+  MonitorElement * me = iBooker.book1DD(newName(name),title,nchX,lowX,highX) ;
   me->getTH1()->Sumw2() ;
   if (titleX!="") { me->getTH1()->GetXaxis()->SetTitle(titleX.c_str()) ; }
   if (titleY!="") { me->getTH1()->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (TString(option)!="") { me->getTH1()->SetOption(option) ; }
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH1BinArray
- ( const std::string & name, const std::string & title,
-   int nchX, float *xbinsize,
-   const std::string & titleX, const std::string & titleY,
-   Option_t * option )
- {
-  MonitorElement * me = m_store->book1D(newName(name),title,nchX,xbinsize) ;
+( DQMStore::IBooker & iBooker,
+  const std::string & name, const std::string & title,
+  int nchX, float *xbinsize,
+  const std::string & titleX, const std::string & titleY,
+  Option_t * option ) {
+  MonitorElement * me = iBooker.book1D(newName(name),title,nchX,xbinsize) ;
   //book1DD not implemented in DQMServices/Core/src/DQMStore.cc
   if (titleX!="") { me->getTH1()->GetXaxis()->SetTitle(titleX.c_str()) ; }
   if (titleY!="") { me->getTH1()->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (TString(option)!="") { me->getTH1()->SetOption(option) ; }
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH1withSumw2BinArray
- ( const std::string & name, const std::string & title,
-   int nchX, float *xbinsize,
-   const std::string & titleX, const std::string & titleY,
-   Option_t * option )
- {
-   
+( DQMStore::IBooker & iBooker,
+  const std::string & name, const std::string & title,
+  int nchX, float *xbinsize,
+  const std::string & titleX, const std::string & titleY,
+  Option_t * option ) {
   std::cout << newName(name) << std::endl;
-  MonitorElement * me = m_store->book1D(newName(name),title,nchX,xbinsize) ;
+  MonitorElement * me = iBooker.book1D(newName(name),title,nchX,xbinsize) ;
   //book1DD not implemented in DQMServices/Core/src/DQMStore.cc
   me->getTH1()->Sumw2() ;
   if (titleX!="") { me->getTH1()->GetXaxis()->SetTitle(titleX.c_str()) ; }
   if (titleY!="") { me->getTH1()->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (TString(option)!="") { me->getTH1()->SetOption(option) ; }
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH2
- ( const std::string & name, const std::string & title,
-   int nchX, double lowX, double highX,
-   int nchY, double lowY, double highY,
-   const std::string & titleX, const std::string & titleY,
-   Option_t * option )
- {
-  MonitorElement * me = m_store->book2DD(newName(name),title,nchX,lowX,highX,nchY,lowY,highY) ;
+( DQMStore::IBooker & iBooker,
+  const std::string & name, const std::string & title,
+  int nchX, double lowX, double highX,
+  int nchY, double lowY, double highY,
+  const std::string & titleX, const std::string & titleY,
+  Option_t * option ) {
+  MonitorElement * me = iBooker.book2DD(newName(name),title,nchX,lowX,highX,nchY,lowY,highY) ;
   if (titleX!="") { me->getTH1()->GetXaxis()->SetTitle(titleX.c_str()) ; }
   if (titleY!="") { me->getTH1()->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (TString(option)!="") { me->getTH1()->SetOption(option) ; }
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH2withSumw2
- ( const std::string & name, const std::string & title,
-   int nchX, double lowX, double highX,
-   int nchY, double lowY, double highY,
-   const std::string & titleX, const std::string & titleY,
-   Option_t * option )
- {
-  MonitorElement * me = m_store->book2DD(newName(name),title,nchX,lowX,highX,nchY,lowY,highY) ;
+( DQMStore::IBooker & iBooker,
+  const std::string & name, const std::string & title,
+  int nchX, double lowX, double highX,
+  int nchY, double lowY, double highY,
+  const std::string & titleX, const std::string & titleY,
+  Option_t * option ) {
+  MonitorElement * me = iBooker.book2DD(newName(name),title,nchX,lowX,highX,nchY,lowY,highY) ;
   me->getTH1()->Sumw2() ;
   if (titleX!="") { me->getTH1()->GetXaxis()->SetTitle(titleX.c_str()) ; }
   if (titleY!="") { me->getTH1()->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (TString(option)!="") { me->getTH1()->SetOption(option) ; }
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookP1
- ( const std::string & name, const std::string & title,
-   int nchX, double lowX, double highX,
-             double lowY, double highY,
-   const std::string & titleX, const std::string & titleY,
-   Option_t * option )
- {
-  MonitorElement * me = m_store->bookProfile(newName(name),title,nchX,lowX,highX,lowY,highY," ") ;
+( DQMStore::IBooker & iBooker,
+  const std::string & name, const std::string & title,
+  int nchX, double lowX, double highX,
+  double lowY, double highY,
+  const std::string & titleX, const std::string & titleY,
+  Option_t * option ) {
+  MonitorElement * me = iBooker.bookProfile(newName(name),title,nchX,lowX,highX,lowY,highY," ") ;
   if (titleX!="") { me->getTProfile()->GetXaxis()->SetTitle(titleX.c_str()) ; }
   if (titleY!="") { me->getTProfile()->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (TString(option)!="") { me->getTProfile()->SetOption(option) ; }
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH1andDivide
- ( const std::string & name, MonitorElement * num, MonitorElement * denom,
-   const std::string & titleX, const std::string & titleY,
-   const std::string & title )
- {
+( DQMStore::IBooker & iBooker,
+  const std::string & name, MonitorElement * num, MonitorElement * denom,
+  const std::string & titleX, const std::string & titleY,
+  const std::string & title ) {
   std::string name2 = newName(name) ;
-  TH1D * h_temp = dynamic_cast<TH1D*>( num->getTH1()->Clone(name2.c_str()) );
+  TH1D * h_temp = dynamic_cast<TH1D*>(num->getTH1()->Clone(name2.c_str()) );
   h_temp->Reset() ;
   h_temp->Divide(num->getTH1(),denom->getTH1(),1,1,"b") ;
   h_temp->GetXaxis()->SetTitle(titleX.c_str()) ;
   h_temp->GetYaxis()->SetTitle(titleY.c_str()) ;
   if (title!="") { h_temp->SetTitle(title.c_str()) ; }
   if (m_verbosityLevel>0) { h_temp->Print() ; }
-  MonitorElement * me = m_store->book1DD(name2,h_temp) ;
+  MonitorElement * me = iBooker.book1DD(name2,h_temp) ;
   delete h_temp ;
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::bookH2andDivide
- ( const std::string & name, MonitorElement * num, MonitorElement * denom,
-   const std::string & titleX, const std::string & titleY,
-   const std::string & title )
- {
+( DQMStore::IBooker & iBooker,
+  const std::string & name, MonitorElement * num, MonitorElement * denom,
+  const std::string & titleX, const std::string & titleY,
+  const std::string & title ) {
   std::string name2 = newName(name) ;
-  TH2D * h_temp = dynamic_cast<TH2D*>( num->getTH1()->Clone(name2.c_str()) );
+  TH2D * h_temp = dynamic_cast<TH2D*>(num->getTH1()->Clone(name2.c_str()) );
   h_temp->Reset() ;
   h_temp->Divide(num->getTH1(),denom->getTH1(),1,1,"b") ;
   h_temp->GetXaxis()->SetTitle(titleX.c_str()) ;
   h_temp->GetYaxis()->SetTitle(titleY.c_str()) ;
   if (title!="") { h_temp->SetTitle(title.c_str()) ; }
   if (m_verbosityLevel>0) { h_temp->Print() ; }
-  MonitorElement * me = m_store->book2DD(name2,h_temp) ;
+  MonitorElement * me = iBooker.book2DD(name2,h_temp) ;
   delete h_temp ;
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::profileX
- ( MonitorElement * me2d,
-   const std::string & title, const std::string & titleX, const std::string & titleY,
-   Double_t minimum, Double_t maximum )
- {
+( DQMStore::IBooker & iBooker,
+  MonitorElement * me2d,
+  const std::string & title, const std::string & titleX, const std::string & titleY,
+  Double_t minimum, Double_t maximum ) {
   std::string name2 = me2d->getName()+"_pfx" ;
   TProfile * p1_temp = me2d->getTH2D()->ProfileX() ;
   if (title!="") { p1_temp->SetTitle(title.c_str()) ; }
@@ -210,18 +176,16 @@ MonitorElement * ScoutingAnalyzerBase::profileX
   if (titleY!="") { p1_temp->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (minimum!=-1111) { p1_temp->SetMinimum(minimum) ; }
   if (maximum!=-1111) { p1_temp->SetMaximum(maximum) ; }
-  MonitorElement * me = m_store->bookProfile(name2,p1_temp) ;
+  MonitorElement * me = iBooker.bookProfile(name2,p1_temp) ;
   delete p1_temp ;
   return me ;
- }
-
-//------------------------------------------------------------------------------
+}
 
 MonitorElement * ScoutingAnalyzerBase::profileY
- ( MonitorElement * me2d,
-   const std::string & title, const std::string & titleX, const std::string & titleY,
-   Double_t minimum, Double_t maximum )
- {
+( DQMStore::IBooker & iBooker,
+  MonitorElement * me2d,
+  const std::string & title, const std::string & titleX, const std::string & titleY,
+  Double_t minimum, Double_t maximum ) {
   std::string name2 = me2d->getName()+"_pfy" ;
   TProfile * p1_temp = me2d->getTH2D()->ProfileY() ;
   if (title!="") { p1_temp->SetTitle(title.c_str()) ; }
@@ -229,10 +193,7 @@ MonitorElement * ScoutingAnalyzerBase::profileY
   if (titleY!="") { p1_temp->GetYaxis()->SetTitle(titleY.c_str()) ; }
   if (minimum!=-1111) { p1_temp->SetMinimum(minimum) ; }
   if (maximum!=-1111) { p1_temp->SetMaximum(maximum) ; }
-  MonitorElement * me = m_store->bookProfile(name2,p1_temp) ;
+  MonitorElement * me = iBooker.bookProfile(name2,p1_temp) ;
   delete p1_temp ;
   return me ;
- }
-
-//------------------------------------------------------------------------------
- 
+}


### PR DESCRIPTION
The mission was to upgrade one module: DQM/DataScouting/interface/ScoutingAnalyzerBase.

As always it turned out to be a bit more than that, since this was just a common base class to:
AlphaTVarAnalyzer
DiJetVarAnalyzer
RazorVarAnalyzer
ScoutingTestAnalyzer

There were no big anomalies in this, except for ScoutingTestAnalyzer, which seems to be a test class and also tries to book histograms in the endRun method, which is not really allowed anymore.
Since this is only a test class, and the historgrams are never filled not referenced later, I removed this.
Up to the maintainers/users of DataScouting to shout if they disagree.
