### PR TITLE
Restored functionality to print geometry and weights

### DIFF
--- a/SimG4Core/PrintGeomInfo/src/PrintMaterialBudgetInfo.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintMaterialBudgetInfo.cc
@@ -26,6 +26,7 @@
 #include "G4UserLimits.hh"
 #include "G4TransportationManager.hh"
 #include "G4UnitsTable.hh"
+#include "Randomize.hh"
 
 #include <set>
 
@@ -53,6 +54,7 @@ PrintMaterialBudgetInfo::~PrintMaterialBudgetInfo() {}
 
 void PrintMaterialBudgetInfo::update(const BeginOfRun* run) {
   
+  G4Random::setTheEngine(new CLHEP::RanecuEngine);
   // Physical Volume
   theTopPV = G4TransportationManager::GetTransportationManager()->GetNavigatorForTracking()->GetWorldVolume();
   // Logical Volume
@@ -61,7 +63,7 @@ void PrintMaterialBudgetInfo::update(const BeginOfRun* run) {
   // the first time fill the vectors of elements
   if( elementNames.size()==0 && elementTotalWeight.size()==0 && elementWeightFraction.size()==0) {
     for(unsigned int iElement = 0;
-	iElement < lv->GetMaterial()->GetElement(iElement)->GetElementTable()->size();
+	iElement < G4Element::GetNumberOfElements();
 	iElement++) { // first element in table is 0
       elementNames.push_back("rr");
       elementTotalWeight.push_back(0);

--- a/SimG4Core/PrintGeomInfo/test/python/runSens_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/runSens_cfg.py
@@ -2,15 +2,11 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PrintGeom")
 
+process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("Geometry.CMSCommonData.cmsIdealGeometryXML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 
-process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    )
-)
+process.MessageLogger.destinations = cms.untracked.vstring("SensDet.txt")
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
@@ -38,12 +34,14 @@ process.generator = cms.EDProducer("FlatRandomPtGunProducer",
 process.EnableFloatingPointExceptions = cms.Service("EnableFloatingPointExceptions")
 
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
-    moduleSeeds = cms.PSet(
-        generator = cms.untracked.uint32(456789),
-        g4SimHits = cms.untracked.uint32(9876),
-        VtxSmeared = cms.untracked.uint32(98765432)
+    generator = cms.PSet(
+         initialSeed = cms.untracked.uint32(123456789),
+         engineName = cms.untracked.string('HepJamesRandom')
     ),
-    sourceSeed = cms.untracked.uint32(123456789)
+    g4SimHits = cms.PSet(
+         initialSeed = cms.untracked.uint32(11),
+         engineName = cms.untracked.string('HepJamesRandom')
+    )
 )
 
 process.load("SimG4Core.Application.g4SimHits_cfi")

--- a/SimG4Core/PrintGeomInfo/test/python/run_MaterialBudgeInfo_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/run_MaterialBudgeInfo_cfg.py
@@ -2,26 +2,12 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PrintMaterialBudget")
 
+process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("Geometry.CMSCommonData.trackerSimGeometryXML_cfi")
 process.load("Geometry.TrackerNumberingBuilder.trackerNumberingGeometry_cfi")
 process.load("Geometry.TrackerGeometryBuilder.trackerGeometry_cfi")
 
-process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    categories = cms.untracked.vstring('FwkJob'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    FrameworkJobReport = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        )
-    )
-)
+process.MessageLogger.destinations = cms.untracked.vstring("MatBudget.txt")
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
@@ -49,12 +35,14 @@ process.generator = cms.EDProducer("FlatRandomPtGunProducer",
 process.EnableFloatingPointExceptions = cms.Service("EnableFloatingPointExceptions")
 
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
-    moduleSeeds = cms.PSet(
-        generator = cms.untracked.uint32(456789),
-        g4SimHits = cms.untracked.uint32(9876),
-        VtxSmeared = cms.untracked.uint32(98765432)
+    generator = cms.PSet(
+         initialSeed = cms.untracked.uint32(123456789),
+         engineName = cms.untracked.string('HepJamesRandom')
     ),
-    sourceSeed = cms.untracked.uint32(123456789)
+    g4SimHits = cms.PSet(
+         initialSeed = cms.untracked.uint32(11),
+         engineName = cms.untracked.string('HepJamesRandom')
+    )
 )
 
 process.load("SimG4Core.Application.g4SimHits_cfi")

--- a/SimG4Core/PrintGeomInfo/test/python/run_cfg.py
+++ b/SimG4Core/PrintGeomInfo/test/python/run_cfg.py
@@ -2,24 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("PrintGeom")
 
+process.load('FWCore.MessageService.MessageLogger_cfi')
 process.load("SimG4Core.PrintGeomInfo.testTotemGeometryXML_cfi")
 
-process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout'),
-    categories = cms.untracked.vstring('FwkJob'),
-    fwkJobReports = cms.untracked.vstring('FrameworkJobReport'),
-    cout = cms.untracked.PSet(
-        threshold = cms.untracked.string('INFO')
-    ),
-    FrameworkJobReport = cms.untracked.PSet(
-        default = cms.untracked.PSet(
-            limit = cms.untracked.int32(0)
-        ),
-        FwkJob = cms.untracked.PSet(
-            limit = cms.untracked.int32(-1)
-        )
-    )
-)
+process.MessageLogger.destinations = cms.untracked.vstring("Totem.txt")
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
@@ -47,12 +33,14 @@ process.generator = cms.EDProducer("FlatRandomPtGunProducer",
 process.EnableFloatingPointExceptions = cms.Service("EnableFloatingPointExceptions")
 
 process.RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
-    moduleSeeds = cms.PSet(
-        generator = cms.untracked.uint32(456789),
-        g4SimHits = cms.untracked.uint32(9876),
-        VtxSmeared = cms.untracked.uint32(98765432)
+    generator = cms.PSet(
+         initialSeed = cms.untracked.uint32(123456789),
+         engineName = cms.untracked.string('HepJamesRandom')
     ),
-    sourceSeed = cms.untracked.uint32(123456789)
+    g4SimHits = cms.PSet(
+         initialSeed = cms.untracked.uint32(11),
+         engineName = cms.untracked.string('HepJamesRandom')
+    )
 )
 
 process.load("SimG4Core.Application.g4SimHits_cfi")


### PR DESCRIPTION
Due to migration to the thread safe randon engine geometry printing unit test did not work. These modifications restore these unit tests functionality.  
