### PR TITLE
Add missing build dependencies and update checksums

### DIFF
--- a/DataFormats/CaloTowers/BuildFile.xml
+++ b/DataFormats/CaloTowers/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/DetId"/>
 <use   name="DataFormats/Math"/>
 <use   name="FWCore/Utilities"/>
 <use   name="DataFormats/Candidate"/>

--- a/DataFormats/CaloTowers/src/classes_def.xml
+++ b/DataFormats/CaloTowers/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="CaloTowerDetId" ClassVersion="10">
+  <class name="CaloTowerDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="4063982642"/>
    <version ClassVersion="10" checksum="2444816232"/>
   </class>
   <class name="CaloTower" ClassVersion="11">

--- a/DataFormats/EcalDetId/BuildFile.xml
+++ b/DataFormats/EcalDetId/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="rootrflx"/>

--- a/DataFormats/EcalDetId/src/classes_def.xml
+++ b/DataFormats/EcalDetId/src/classes_def.xml
@@ -1,25 +1,31 @@
 <lcgdict>
-  <class name="EBDetId" ClassVersion="11">
+  <class name="EBDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="1079888109"/>
    <version ClassVersion="11" checksum="55396465"/>
    <version ClassVersion="10" checksum="18462289"/>
   </class>
-  <class name="EEDetId" ClassVersion="11">
+  <class name="EEDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="1080419550"/>
    <version ClassVersion="11" checksum="55927906"/>
    <version ClassVersion="10" checksum="18639436"/>
   </class>
-  <class name="ESDetId" ClassVersion="11">
+  <class name="ESDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="1082899608"/>
    <version ClassVersion="11" checksum="58407964"/>
    <version ClassVersion="10" checksum="19466122"/>
   </class>
-  <class name="EcalTrigTowerDetId" ClassVersion="11">
+  <class name="EcalTrigTowerDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="2621916454"/>
    <version ClassVersion="11" checksum="1597424810"/>
    <version ClassVersion="10" checksum="3395783268"/>
   </class>
-  <class name="EcalScDetId" ClassVersion="11">
+  <class name="EcalScDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="1825107257"/>
    <version ClassVersion="11" checksum="800615613"/>
    <version ClassVersion="10" checksum="1698524437"/>
   </class>
-  <class name="EcalPnDiodeDetId" ClassVersion="11">
+  <class name="EcalPnDiodeDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="2410043118"/>
    <version ClassVersion="11" checksum="1385551474"/>
    <version ClassVersion="10" checksum="461847292"/>
   </class>

--- a/DataFormats/HcalDetId/BuildFile.xml
+++ b/DataFormats/HcalDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="rootrflx"/>

--- a/DataFormats/HcalDetId/src/classes_def.xml
+++ b/DataFormats/HcalDetId/src/classes_def.xml
@@ -5,27 +5,34 @@
   <class name="HcalFrontEndId" ClassVersion="10">
    <version ClassVersion="10" checksum="1241522245"/>
   </class>
-  <class name="HcalDetId" ClassVersion="10">
+  <class name="HcalDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1604420376"/>
    <version ClassVersion="10" checksum="193306378"/>
   </class>
-  <class name="HcalTrigTowerDetId" ClassVersion="10">
+  <class name="HcalTrigTowerDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1583611399"/>
    <version ClassVersion="10" checksum="3049681583"/>
   </class>
-  <class name="HcalCalibDetId" ClassVersion="11">
+  <class name="HcalCalibDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="958215579"/>
    <version ClassVersion="11" checksum="324201917"/>
    <version ClassVersion="10" checksum="173148569"/>
   </class>
-  <class name="HcalOtherDetId" ClassVersion="10">
+  <class name="HcalOtherDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="438769872"/>
    <version ClassVersion="10" checksum="4099723506"/>
   </class>
-  <class name="HcalDcsDetId" ClassVersion="11">
+  <class name="HcalDcsDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="49533732"/>
    <version ClassVersion="11" checksum="3710487366"/>
    <version ClassVersion="10" checksum="4165221916"/>
   </class>
-  <class name="HcalZDCDetId" ClassVersion="10">
+  <class name="HcalZDCDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="3806242743"/>
    <version ClassVersion="10" checksum="927247167"/>
   </class>
-  <class name="HcalCastorDetId" ClassVersion="10">
+  <class name="HcalCastorDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="2854161010"/>
    <version ClassVersion="10" checksum="3473198120"/>
   </class>
   <class name="CastorElectronicsId" ClassVersion="10">

--- a/DataFormats/L1CaloTrigger/BuildFile.xml
+++ b/DataFormats/L1CaloTrigger/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/DetId"/>
 <use   name="rootrflx"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/L1CaloTrigger/src/classes_def.xml
+++ b/DataFormats/L1CaloTrigger/src/classes_def.xml
@@ -2,7 +2,8 @@
   <class name="L1CaloEmCand" ClassVersion="10">
    <version ClassVersion="10" checksum="2666522574"/>
   </class>
-  <class name="L1CaloRegionDetId" ClassVersion="10">
+  <class name="L1CaloRegionDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="3966998228"/>
    <version ClassVersion="10" checksum="2412488094"/>
   </class>
   <class name="L1CaloRegion" ClassVersion="10">

--- a/DataFormats/MuonDetId/BuildFile.xml
+++ b/DataFormats/MuonDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <use   name="rootrflx"/>
 <export>

--- a/DataFormats/MuonDetId/src/classes_def.xml
+++ b/DataFormats/MuonDetId/src/classes_def.xml
@@ -1,26 +1,33 @@
 <lcgdict>
-  <class name="DTChamberId" ClassVersion="10">
+  <class name="DTChamberId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1427930561"/>
    <version ClassVersion="10" checksum="1566132205"/>
   </class>
-  <class name="DTSuperLayerId" ClassVersion="11">
+  <class name="DTSuperLayerId" ClassVersion="12">
+   <version ClassVersion="12" checksum="4252195609"/>
    <version ClassVersion="11" checksum="95429957"/>
    <version ClassVersion="10" checksum="2373077448"/>
   </class>
-  <class name="DTLayerId" ClassVersion="11">
+  <class name="DTLayerId" ClassVersion="12">
+   <version ClassVersion="12" checksum="2452289092"/>
    <version ClassVersion="11" checksum="2590490736"/>
    <version ClassVersion="10" checksum="3694998457"/>
   </class>
-  <class name="DTWireId" ClassVersion="11">
+  <class name="DTWireId" ClassVersion="12">
+   <version ClassVersion="12" checksum="3971842612"/>
    <version ClassVersion="11" checksum="4110044256"/>
     <version ClassVersion="10" checksum="506517840"/>
   </class>
-  <class name="CSCDetId" ClassVersion="10">
+  <class name="CSCDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1194325071"/>
    <version ClassVersion="10" checksum="56607943"/>
   </class>
-  <class name="RPCDetId" ClassVersion="10">
+  <class name="RPCDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="2362875019"/>
    <version ClassVersion="10" checksum="3608243239"/>
   </class>
-  <class name="RPCCompDetId" ClassVersion="-1">
+  <class name="RPCCompDetId" ClassVersion="0">
+   <version ClassVersion="0" checksum="2407084845"/>
    <version ClassVersion="-1" checksum="2042478999"/>
   </class>
   <class name="DTBtiId" ClassVersion="10">
@@ -32,10 +39,12 @@
   <class name="DTSectCollId" ClassVersion="10">
    <version ClassVersion="10" checksum="1624682691"/>
   </class>
-  <class name="GEMDetId" ClassVersion="10">
+  <class name="GEMDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="2300896813"/>
    <version ClassVersion="10" checksum="3587583837"/>
   </class>
-  <class name="ME0DetId" ClassVersion="10">
+  <class name="ME0DetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1292662416"/>
    <version ClassVersion="10" checksum="388194174"/>
   </class>
 </lcgdict>

--- a/DataFormats/MuonDetId/src/classes_def.xml
+++ b/DataFormats/MuonDetId/src/classes_def.xml
@@ -26,8 +26,8 @@
    <version ClassVersion="11" checksum="2362875019"/>
    <version ClassVersion="10" checksum="3608243239"/>
   </class>
-  <class name="RPCCompDetId" ClassVersion="0">
-   <version ClassVersion="0" checksum="2407084845"/>
+  <class name="RPCCompDetId" ClassVersion="10">
+   <version ClassVersion="10" checksum="2407084845"/>
    <version ClassVersion="-1" checksum="2042478999"/>
   </class>
   <class name="DTBtiId" ClassVersion="10">

--- a/DataFormats/SiPixelDetId/BuildFile.xml
+++ b/DataFormats/SiPixelDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="rootrflx"/>
 <export>

--- a/DataFormats/SiPixelDetId/src/classes_def.xml
+++ b/DataFormats/SiPixelDetId/src/classes_def.xml
@@ -1,8 +1,10 @@
 <lcgdict>
-  <class name="PXBDetId" ClassVersion="10">
+  <class name="PXBDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1217531328"/>
    <version ClassVersion="10" checksum="64343362"/>
   </class>
-  <class name="PXFDetId" ClassVersion="10">
+  <class name="PXFDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1218239916"/>
    <version ClassVersion="10" checksum="64579558"/>
   </class>
 </lcgdict>

--- a/DataFormats/SiStripDetId/BuildFile.xml
+++ b/DataFormats/SiStripDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/DetId"/>
 <use   name="rootrflx"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/SiStripDetId/src/classes_def.xml
+++ b/DataFormats/SiStripDetId/src/classes_def.xml
@@ -1,20 +1,25 @@
 <lcgdict>
-  <class name="SiStripDetId" ClassVersion="10">
+  <class name="SiStripDetId" ClassVersion="11">
+   <version ClassVersion="11" checksum="1093375304"/>
    <version ClassVersion="10" checksum="1454613786"/>
   </class>
-  <class name="TIBDetId" ClassVersion="11">
+  <class name="TIBDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="3159571159"/>
    <version ClassVersion="11" checksum="3520809641"/>
    <version ClassVersion="10" checksum="2120387717"/>
   </class>
-  <class name="TIDDetId" ClassVersion="11">
+  <class name="TIDDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="3934412137"/>
    <version ClassVersion="11" checksum="683323"/>
    <version ClassVersion="10" checksum="2378668043"/>
   </class>
-  <class name="TOBDetId" ClassVersion="11">
+  <class name="TOBDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="1543205369"/>
    <version ClassVersion="11" checksum="1904443851"/>
    <version ClassVersion="10" checksum="149943355"/>
   </class>
-  <class name="TECDetId" ClassVersion="11">
+  <class name="TECDetId" ClassVersion="12">
+   <version ClassVersion="12" checksum="3192913076"/>
    <version ClassVersion="11" checksum="3554151558"/>
    <version ClassVersion="10" checksum="699845924"/>
   </class>


### PR DESCRIPTION
Do not port this request to CMSSW_7_4_ROOT6_X.  This problem will be fixed separately there.
Many DataFormats packages containing classes inheriting from DetId were missing declared link dependencies on DataFormats/DetID.
In ROOT 5.34, and ROOT 6, checksums depend on the base class.
Because of the missing link dependency, the other packages were built before DataFormats/DetId.
Because of this, edmCheckClassVersion calculated the wrong checksum.  The problem with edmClassVersion needs to be fixed separately, because the checksum it calculates can depend on build order of the packages.
This pull request supplies the missing dependencies, and updates the checksums accordingly, using scram b updateclassversion.
Please expedite this critical pull request, bypassing signatures if not signed in a timely manner.
However, do not bypass testing, comparisons, and all that!!
