### PR TITLE
Add missing build dependencies

### DIFF
--- a/DataFormats/CaloTowers/BuildFile.xml
+++ b/DataFormats/CaloTowers/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/DetId"/>
 <use   name="DataFormats/Math"/>
 <use   name="FWCore/Utilities"/>
 <use   name="DataFormats/Candidate"/>

--- a/DataFormats/EcalDetId/BuildFile.xml
+++ b/DataFormats/EcalDetId/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 

--- a/DataFormats/HcalDetId/BuildFile.xml
+++ b/DataFormats/HcalDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 

--- a/DataFormats/L1CaloTrigger/BuildFile.xml
+++ b/DataFormats/L1CaloTrigger/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/DetId"/>
 
 <export>
   <lib   name="1"/>

--- a/DataFormats/MuonDetId/BuildFile.xml
+++ b/DataFormats/MuonDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 
 <export>

--- a/DataFormats/SiPixelDetId/BuildFile.xml
+++ b/DataFormats/SiPixelDetId/BuildFile.xml
@@ -1,3 +1,4 @@
+<use   name="DataFormats/DetId"/>
 <use   name="FWCore/MessageLogger"/>
 
 <export>

--- a/DataFormats/SiStripDetId/BuildFile.xml
+++ b/DataFormats/SiStripDetId/BuildFile.xml
@@ -1,4 +1,5 @@
-<use name="rootcore"/>
+<use   name="DataFormats/DetId"/>
+
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
Add missing build dependencies.  Without these dependencies edmCheckClassVersion can return the wrong checksum.  Also, one unnecesary build dependency was removed.
This problem is being fixed in 7_4_X with a different pull request.
Please merge this request in time for the next IB if possible.
