### PR TITLE
add a customisation fragment to check EventSetup usage

### DIFF
--- a/FWCore/Modules/python/customiseCheckEventSetup.py
+++ b/FWCore/Modules/python/customiseCheckEventSetup.py
@@ -1,0 +1,21 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+    process.escontent = cms.EDAnalyzer("PrintEventSetupContent",
+        compact = cms.untracked.bool(True),
+        printProviders = cms.untracked.bool(True)
+    )
+    process.esretrieval = cms.EDAnalyzer("PrintEventSetupDataRetrieval",
+        printProviders = cms.untracked.bool(True)
+    )
+    process.esout = cms.EndPath(process.escontent + process.esretrieval)
+
+    if process.schedule_() is not None:
+        process.schedule_().append(process.esout)
+
+    for name, module in process.es_sources_().iteritems():
+        print "ESModules> provider:%s '%s'" % (name, module.type_())
+    for name, module in process.es_producers_().iteritems():
+        print "ESModules> provider:%s '%s'" % (name, module.type_())
+
+    return process


### PR DESCRIPTION
customiseCheckEventSetup:
customise a process to
- print the list of ESSources and ESProducers
- add a module to print all available EventSetup data
- add a module to print all the used EventSetup data

PrintEventSetupContent:
- migrate from legacy to 'one' module
- reduce the number of LogSystem calls
- add an option to make the output format consistent with that
  of PrintEventSetupDataRetrieval

PrintEventSetupDataRetrieval:
- reduce the number of LogSystem calls
