### PR TITLE
Don't expose TypeWithDict property mask

### DIFF
--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -159,7 +159,7 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
       // strip cv & ref flags
       // FIXME: This is only true if the propery passed to the constructor
       //       overrides the const and reference flags.
-      retType = edm::TypeWithDict(retType, 0L);
+      retType = retType.stripConstRef();
     }
     ret = edm::ObjectWithDict(retType, *static_cast<void**>(addr));
     //std::cout << "Now type is " << retType.qualifiedName() << std::endl;

--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -164,7 +164,7 @@ findMethod(const edm::TypeWithDict& t, /*class=in*/
     type = theType;
   }
   // strip const, volatile, c++ ref, ..
-  type = edm::TypeWithDict(type, 0L);
+  type = type.stripConstRef();;
   // Create our return value.
   pair<edm::FunctionWithDict, bool> mem;
   //FIXME: We must initialize mem.first!

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -37,6 +37,9 @@ class TypeDataMembers;
 class TypeFunctionMembers;
 
 class TypeWithDict {
+  friend class BaseWithDict;
+  friend class FunctionWithDict;
+  friend class MemberWithDict;
   friend class TypeBases;
   friend class TypeDataMembers;
   friend class TypeFunctionMembers;
@@ -51,18 +54,23 @@ private:
   TDataType* dataType_;
   long property_;
 public:
-  static TypeWithDict byName(std::string const& name, long property = 0L);
+  static TypeWithDict byName(std::string const& name);
+private:
+  static TypeWithDict byName(std::string const& name, long property);
 public:
   TypeWithDict();
-  TypeWithDict& operator=(TypeWithDict const&);
   TypeWithDict(TypeWithDict const&);
-  // This copy constructor is for clearing const and reference.
-  explicit TypeWithDict(TypeWithDict const&, long property);
-  explicit TypeWithDict(std::type_info const&, long property = 0L);
+  explicit TypeWithDict(std::type_info const&);
+  explicit TypeWithDict(TMethodArg* arg);
+private:
+  explicit TypeWithDict(std::type_info const&, long property);
   explicit TypeWithDict(TClass* type, long property = 0L);
   explicit TypeWithDict(TEnum* type, std::string const& name, long property = 0L);
-  explicit TypeWithDict(TMethodArg* arg, long property = 0L);
-  explicit TypeWithDict(TType* type, long property = 0L);
+  explicit TypeWithDict(TMethodArg* arg, long property);
+  explicit TypeWithDict(TType* type, long property);
+public:
+  TypeWithDict& operator=(TypeWithDict const&);
+  TypeWithDict& stripConstRef();
   explicit operator bool() const;
   std::type_info const& typeInfo() const;
   TClass* getClass() const;


### PR DESCRIPTION
In order to modify TypeWithDict so that it can handle types that are pointers or C-style arrays without header parsing, it is necessary to use additional bits in the property mask.
This means that user calls must not be allowed to arbitrarily set bits in the property mask.  The property mask is currently an argument to several public constructors of TypeWithDict.
For each such public constructor, this pull request either removes it or makes it private.  Only two lines of code outside the framework are affected.
Please merge this request as soon as convenient.
