### PR TITLE
L3 update

### DIFF
--- a/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
@@ -17,6 +17,8 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/MuonReco/interface/MuonFwd.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/MuonReco/interface/MuonTrackLinks.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 namespace edm {
    class ConfigurationDescriptions;
@@ -32,7 +34,6 @@ class HLTMuonL3PreFilter : public HLTFilter {
 
    private:
       bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands) const;
-
       edm::InputTag                    beamspotTag_ ;
       edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;
       edm::InputTag                                          candTag_;   // input tag identifying product contains muons
@@ -49,15 +50,14 @@ class HLTMuonL3PreFilter : public HLTFilter {
       double min_Pt_;           // pt threshold in GeV
       double nsigma_Pt_;        // pt uncertainty margin (in number of sigmas)
       double max_NormalizedChi2_; // cutoff in normalized chi2
-      double max_DXYBeamSpot_; // cutoff in dxy from the beamspot
-      double min_DXYBeamSpot_; // minimum cut on dxy from the beamspot
-  int min_NmuonHits_; // cutoff in minumum number of chi2 hits
-  double max_PtDifference_; // cutoff in maximum different between global track and tracker track
-  double min_TrackPt_; //cutoff in tracker track pt
-
-  bool devDebug_;
-
-
+      double max_DXYBeamSpot_;    // cutoff in dxy from the beamspot
+      double min_DXYBeamSpot_;    // minimum cut on dxy from the beamspot
+      int min_NmuonHits_;         // cutoff in minumum number of chi2 hits
+      double max_PtDifference_;   // cutoff in maximum different between global track and tracker track
+      double min_TrackPt_;        // cutoff in tracker track pt
+      bool devDebug_;
+      edm::InputTag theL3LinksLabel;
+      edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
 };
 
 #endif //HLTMuonL3PreFilter_h

--- a/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
+++ b/HLTrigger/Muon/interface/HLTMuonL3PreFilter.h
@@ -34,30 +34,30 @@ class HLTMuonL3PreFilter : public HLTFilter {
 
    private:
       bool triggeredByLevel2(const reco::TrackRef& track,std::vector<reco::RecoChargedCandidateRef>& vcands) const;
-      edm::InputTag                    beamspotTag_ ;
-      edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;
-      edm::InputTag                                          candTag_;   // input tag identifying product contains muons
-      edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_; // token identifying product contains muons
-      edm::InputTag                                          previousCandTag_;   // input tag identifying product contains muons passing the previous level
-      edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_; // token identifying product contains muons passing the previous level
-      int    min_N_;            // minimum number of muons to fire the trigger
-      double max_Eta_;          // Eta cut
-      int    min_Nhits_;        // threshold on number of hits on muon
-      double max_Dr_;           // maximum impact parameter cut
-      double min_Dr_;           // minimum impact parameter cut
-      double max_Dz_;           // dz cut
-      double min_DxySig_;       // dxy significance cut
-      double min_Pt_;           // pt threshold in GeV
-      double nsigma_Pt_;        // pt uncertainty margin (in number of sigmas)
-      double max_NormalizedChi2_; // cutoff in normalized chi2
-      double max_DXYBeamSpot_;    // cutoff in dxy from the beamspot
-      double min_DXYBeamSpot_;    // minimum cut on dxy from the beamspot
-      int min_NmuonHits_;         // cutoff in minumum number of chi2 hits
-      double max_PtDifference_;   // cutoff in maximum different between global track and tracker track
-      double min_TrackPt_;        // cutoff in tracker track pt
-      bool devDebug_;
-      edm::InputTag theL3LinksLabel;
-      edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
+      const edm::InputTag                    beamspotTag_ ;
+      const edm::EDGetTokenT<reco::BeamSpot> beamspotToken_ ;
+      const edm::InputTag                                          candTag_;   // input tag identifying product contains muons
+      const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> candToken_; // token identifying product contains muons
+      const edm::InputTag                                          previousCandTag_;   // input tag identifying product contains muons passing the previous level
+      const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_; // token identifying product contains muons passing the previous level
+      const int    min_N_;            // minimum number of muons to fire the trigger
+      const double max_Eta_;          // Eta cut
+      const int    min_Nhits_;        // threshold on number of hits on muon
+      const double max_Dr_;           // maximum impact parameter cut
+      const double min_Dr_;           // minimum impact parameter cut
+      const double max_Dz_;           // dz cut
+      const double min_DxySig_;       // dxy significance cut
+      const double min_Pt_;           // pt threshold in GeV
+      const double nsigma_Pt_;        // pt uncertainty margin (in number of sigmas)
+      const double max_NormalizedChi2_; // cutoff in normalized chi2
+      const double max_DXYBeamSpot_;    // cutoff in dxy from the beamspot
+      const double min_DXYBeamSpot_;    // minimum cut on dxy from the beamspot
+      const int min_NmuonHits_;         // cutoff in minumum number of chi2 hits
+      const double max_PtDifference_;   // cutoff in maximum different between global track and tracker track
+      const double min_TrackPt_;        // cutoff in tracker track pt
+      const bool devDebug_;
+      const edm::InputTag theL3LinksLabel;
+      const edm::EDGetTokenT<reco::MuonTrackLinksCollection> linkToken_;
 };
 
 #endif //HLTMuonL3PreFilter_h

--- a/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
+++ b/HLTrigger/Muon/src/HLTMuonL3PreFilter.cc
@@ -22,6 +22,7 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
+#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -57,7 +58,9 @@ HLTMuonL3PreFilter::HLTMuonL3PreFilter(const ParameterSet& iConfig) : HLTFilter(
    min_NmuonHits_ (iConfig.getParameter<int> ("MinNmuonHits")),
    max_PtDifference_ (iConfig.getParameter<double> ("MaxPtDifference")),
    min_TrackPt_ (iConfig.getParameter<double> ("MinTrackPt")),
-   devDebug_ (false)
+   devDebug_ (false),
+   theL3LinksLabel (iConfig.getParameter<InputTag>("InputLinks")),
+   linkToken_ (consumes<reco::MuonTrackLinksCollection>(theL3LinksLabel))
 {
    LogDebug("HLTMuonL3PreFilter")
       << " CandTag/MinN/MaxEta/MinNhits/MaxDr/MinDr/MaxDz/MinDxySig/MinPt/NSigmaPt : "
@@ -100,6 +103,7 @@ HLTMuonL3PreFilter::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.add<int>("MinNmuonHits",0);
   desc.add<double>("MaxPtDifference",9999.0);
   desc.add<double>("MinTrackPt",0.0);
+  desc.add<edm::InputTag>("InputLinks",edm::InputTag(""));
   descriptions.add("hltMuonL3PreFilter",desc);
 }
 
@@ -108,131 +112,245 @@ HLTMuonL3PreFilter::fillDescriptions(edm::ConfigurationDescriptions& description
 //
 
 // ------------ method called to produce the data  ------------
-bool
-HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
-{
+bool HLTMuonL3PreFilter::hltFilter(Event& iEvent, const EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const{
 
    // All HLT filters must create and fill an HLT filter object,
    // recording any reconstructed physics objects satisfying (or not)
    // this HLT filter, and place it in the Event.
 
-   // get hold of trks
-   Handle<RecoChargedCandidateCollection> mucands;
    if (saveTags()) filterproduct.addCollectionTag(candTag_);
-   iEvent.getByToken(candToken_,mucands);
-   // sort them by L2Track
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > L2toL3s;
-   unsigned int maxI = mucands->size();
-   for (unsigned int i=0;i!=maxI;++i){
-     TrackRef tk = (*mucands)[i].track();
-     edm::Ref<L3MuonTrajectorySeedCollection> l3seedRef = tk->seedRef().castTo<edm::Ref<L3MuonTrajectorySeedCollection> >();
-     TrackRef staTrack = l3seedRef->l2Track();
-     LogDebug("HLTMuonL3PreFilter") <<"L2 from: "<<iEvent.getProvenance(staTrack.id()).moduleLabel() <<" index: "<<staTrack.key();
-     L2toL3s[staTrack].push_back(RecoChargedCandidateRef(mucands,i));
-   }
 
+   // Read RecoChargedCandidates from L3MuonCandidateProducer:
+   Handle<RecoChargedCandidateCollection> mucands;
+   iEvent.getByToken(candToken_,mucands);
+
+   // Read L2 triggered objects:
    Handle<TriggerFilterObjectWithRefs> previousLevelCands;
    iEvent.getByToken(previousCandToken_,previousLevelCands);
+   vector<RecoChargedCandidateRef> vl2cands;
+   previousLevelCands->getObjects(TriggerMuon,vl2cands);
+
+   // Read BeamSpot information:
    BeamSpot beamSpot;
    Handle<BeamSpot> recoBeamSpotHandle;
    iEvent.getByToken(beamspotToken_,recoBeamSpotHandle);
    beamSpot = *recoBeamSpotHandle;
 
-
-   //needed to compare to L2
-   vector<RecoChargedCandidateRef> vl2cands;
-   previousLevelCands->getObjects(TriggerMuon,vl2cands);
-
-   // look at all mucands,  check cuts and add to filter object
+   // Number of objects passing the L3 Trigger:
    int n = 0;
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it = L2toL3s.begin();
-   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_end = L2toL3s.end();
-   LogDebug("HLTMuonL3PreFilter")<<"looking at: "<<L2toL3s.size()<<" L2->L3s from: "<<mucands->size();
-   for (; L2toL3s_it!=L2toL3s_end; ++L2toL3s_it){
 
-     if (!triggeredByLevel2(L2toL3s_it->first,vl2cands)) continue;
-
-     //loop over the L3Tk reconstructed for this L2.
-     unsigned int iTk=0;
-     unsigned int maxItk=L2toL3s_it->second.size();
-     for (; iTk!=maxItk; iTk++){
-
-       RecoChargedCandidateRef & cand=L2toL3s_it->second[iTk];
-       TrackRef tk = cand->track();
-
-       LogDebug("HLTMuonL3PreFilter") << " Muon in loop, q*pt= " << tk->charge()*tk->pt() <<" (" << cand->charge()*cand->pt() << ") " << ", eta= " << tk->eta() << " (" << cand->eta() << ") " << ", hits= " << tk->numberOfValidHits() << ", d0= " << tk->d0() << ", dz= " << tk->dz();
-
-       // eta cut
-       if (fabs(cand->eta())>max_Eta_) continue;
-
-       // cut on number of hits
-       if (tk->numberOfValidHits()<min_Nhits_) continue;
-
-       //max dr cut
-       //if (fabs(tk->d0())>max_Dr_) continue;
-       if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) >max_Dr_) continue;
-
-       //min dr cut
-       if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) <min_Dr_) continue;
-
-       //dz cut
-       if (fabs((cand->vz()-beamSpot.z0()) - ((cand->vx()-beamSpot.x0())*cand->px()+(cand->vy()-beamSpot.y0())*cand->py())/cand->pt() * cand->pz()/cand->pt())>max_Dz_) continue;
-
-       // dxy significance cut (safeguard against bizarre values)
-       if (min_DxySig_ > 0 && (tk->dxyError() <= 0 || fabs(tk->dxy(beamSpot.position())/tk->dxyError()) < min_DxySig_)) continue;
-
-       //normalizedChi2 cut
-       if (tk->normalizedChi2() > max_NormalizedChi2_ ) continue;
-
-       //dxy beamspot cut
-       if (std::abs(tk->dxy(beamSpot.position())) > max_DXYBeamSpot_ || std::abs(tk->dxy(beamSpot.position())) < min_DXYBeamSpot_ ) continue;
-
-       //min muon hits cut
-       reco::HitPattern trackHits = tk->hitPattern();
-       if (trackHits.numberOfValidMuonHits() < min_NmuonHits_ ) continue;
-
-       //pt difference cut
-       double candPt = cand->pt();
-       double trackPt = tk->pt();
-
-       if (fabs(candPt - trackPt) > max_PtDifference_ ) continue;
-
-       //track pt cut
-       if (trackPt < min_TrackPt_ ) continue;
-
-       // Pt threshold cut
-       double pt = cand->pt();
-       double err0 = tk->error(0);
-       double abspar0 = fabs(tk->parameter(0));
-       double ptLx = pt;
-       // convert 50% efficiency threshold to 90% efficiency threshold
-       if (abspar0>0) ptLx += nsigma_Pt_*err0/abspar0*pt;
-       LogTrace("HLTMuonL3PreFilter") << " ...Muon in loop, trackkRef pt= "
-				      << tk->pt() << ", ptLx= " << ptLx
-				      << " cand pT " << cand->pt();
-      if (ptLx<min_Pt_) continue;
-
-      filterproduct.addObject(TriggerMuon,cand);
-      n++;
-      break; // and go on with the next L2 association
-     }
-   }////loop over L2s from L3 grouping
-
-   vector<RecoChargedCandidateRef> vref;
-   filterproduct.getObjects(TriggerMuon,vref);
-   for (unsigned int i=0; i<vref.size(); i++ ) {
-     RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
-     TrackRef tk = candref->get<TrackRef>();
-     LogDebug("HLTMuonL3PreFilter")
-       << " Track passing filter: trackRef pt= " << tk->pt() << " (" << candref->pt() << ") " << ", eta: " << tk->eta() << " (" << candref->eta() << ") ";
+   // sort them by L2Track
+   std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > L2toL3s;
+   
+   // Test to see if we can use L3MuonTrajectorySeeds:
+   if (mucands->size()<1) return false;
+   TrackRef tk = (*mucands)[0].track();
+   bool useL3MTS=false;
+   try{
+     edm::Ref<L3MuonTrajectorySeedCollection> test = tk->seedRef().castTo<edm::Ref<L3MuonTrajectorySeedCollection> >();
+     useL3MTS=true;
+   }
+   catch(...){
+     useL3MTS=false;
    }
 
-   // filter decision
-   const bool accept (n >= min_N_);
+   // If we can use L3MuonTrajectory seeds run the older code:
+   if (useL3MTS){
+     LogDebug("HLTMuonL3PreFilter") << "HLTMuonL3PreFilter::hltFilter is in mode: useL3MTS";
 
-   LogDebug("HLTMuonL3PreFilter") << " >>>>> Result of HLTMuonL3PreFilter is " << accept << ", number of muons passing thresholds= " << n;
+     unsigned int maxI = mucands->size();
+     for (unsigned int i=0;i!=maxI;++i){
+       TrackRef tk = (*mucands)[i].track();
+       edm::Ref<L3MuonTrajectorySeedCollection> l3seedRef = tk->seedRef().castTo<edm::Ref<L3MuonTrajectorySeedCollection> >();
+       TrackRef staTrack = l3seedRef->l2Track();
+       LogDebug("HLTMuonL3PreFilter") <<"L2 from: "<<iEvent.getProvenance(staTrack.id()).moduleLabel() <<" index: "<<staTrack.key();
+       L2toL3s[staTrack].push_back(RecoChargedCandidateRef(mucands,i));
+     }
 
-   return accept;
+     // look at all mucands,  check cuts and add to filter object
+     int n = 0;
+     std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_it = L2toL3s.begin();
+     std::map<reco::TrackRef, std::vector<RecoChargedCandidateRef> > ::iterator L2toL3s_end = L2toL3s.end();
+     LogDebug("HLTMuonL3PreFilter")<<"looking at: "<<L2toL3s.size()<<" L2->L3s from: "<<mucands->size();
+     for (; L2toL3s_it!=L2toL3s_end; ++L2toL3s_it){
+  
+       if (!triggeredByLevel2(L2toL3s_it->first,vl2cands)) continue;
+  
+       //loop over the L3Tk reconstructed for this L2.
+       unsigned int iTk=0;
+       unsigned int maxItk=L2toL3s_it->second.size();
+       for (; iTk!=maxItk; iTk++){
+  
+         RecoChargedCandidateRef & cand=L2toL3s_it->second[iTk];
+         TrackRef tk = cand->track();
+  
+         LogDebug("HLTMuonL3PreFilter") << " Muon in loop, q*pt= " << tk->charge()*tk->pt() <<" (" << cand->charge()*cand->pt() << ") " << ", eta= " << tk->eta() << " (" << cand->eta() << ") " << ", hits= " << tk->numberOfValidHits() << ", d0= " << tk->d0() << ", dz= " << tk->dz();
+  
+         // eta cut
+         if (fabs(cand->eta())>max_Eta_) continue;
+  
+         // cut on number of hits
+         if (tk->numberOfValidHits()<min_Nhits_) continue;
+  
+         //max dr cut
+         //if (fabs(tk->d0())>max_Dr_) continue;
+         if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) >max_Dr_) continue;
+  
+         //min dr cut
+         if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) <min_Dr_) continue;
+  
+         //dz cut
+         if (fabs((cand->vz()-beamSpot.z0()) - ((cand->vx()-beamSpot.x0())*cand->px()+(cand->vy()-beamSpot.y0())*cand->py())/cand->pt() * cand->pz()/cand->pt())>max_Dz_) continue;
+  
+         // dxy significance cut (safeguard against bizarre values)
+         if (min_DxySig_ > 0 && (tk->dxyError() <= 0 || fabs(tk->dxy(beamSpot.position())/tk->dxyError()) < min_DxySig_)) continue;
+  
+         //normalizedChi2 cut
+         if (tk->normalizedChi2() > max_NormalizedChi2_ ) continue;
+  
+         //dxy beamspot cut
+         if (std::abs(tk->dxy(beamSpot.position())) > max_DXYBeamSpot_ || std::abs(tk->dxy(beamSpot.position())) < min_DXYBeamSpot_ ) continue;
+  
+         //min muon hits cut
+         reco::HitPattern trackHits = tk->hitPattern();
+         if (trackHits.numberOfValidMuonHits() < min_NmuonHits_ ) continue;
+  
+         //pt difference cut
+         double candPt = cand->pt();
+         double trackPt = tk->pt();
+  
+         if (fabs(candPt - trackPt) > max_PtDifference_ ) continue;
+  
+         //track pt cut
+         if (trackPt < min_TrackPt_ ) continue;
+  
+         // Pt threshold cut
+         double pt = cand->pt();
+         double err0 = tk->error(0);
+         double abspar0 = fabs(tk->parameter(0));
+         double ptLx = pt;
+         // convert 50% efficiency threshold to 90% efficiency threshold
+         if (abspar0>0) ptLx += nsigma_Pt_*err0/abspar0*pt;
+         LogTrace("HLTMuonL3PreFilter") << " ...Muon in loop, trackkRef pt= "
+  				      << tk->pt() << ", ptLx= " << ptLx
+  				      << " cand pT " << cand->pt();
+        if (ptLx<min_Pt_) continue;
+  
+        filterproduct.addObject(TriggerMuon,cand);
+        n++;
+        break; // and go on with the next L2 association
+       }
+     }////loop over L2s from L3 grouping
+  
+     vector<RecoChargedCandidateRef> vref;
+     filterproduct.getObjects(TriggerMuon,vref);
+     for (unsigned int i=0; i<vref.size(); i++ ) {
+       RecoChargedCandidateRef candref =  RecoChargedCandidateRef(vref[i]);
+       TrackRef tk = candref->get<TrackRef>();
+       LogDebug("HLTMuonL3PreFilter")
+         << " Track passing filter: trackRef pt= " << tk->pt() << " (" << candref->pt() << ") " << ", eta: " << tk->eta() << " (" << candref->eta() << ") ";
+     }
+  
+     // filter decision
+     const bool accept (n >= min_N_);
+  
+     LogDebug("HLTMuonL3PreFilter") << " >>>>> Result of HLTMuonL3PreFilter is " << accept << ", number of muons passing thresholds= " << n;
+  
+     return accept;
+  } //end of useL3MTS
+
+  // Using normal TrajectorySeeds:
+  else{
+    LogDebug("HLTMuonL3PreFilter") << "HLTMuonL3PreFilter::hltFilter is in mode: not useL3MTS";
+
+    // Read Links collection:
+    edm::Handle<reco::MuonTrackLinksCollection> links;
+    iEvent.getByToken(linkToken_, links);
+
+    // Loop over RecoChargedCandidates:
+    for(unsigned int i(0); i < mucands->size(); ++i){
+      RecoChargedCandidateRef cand(mucands,i);
+      for(unsigned int l(0); l <links->size(); ++l){
+        const reco::MuonTrackLinks* link = &links->at(l);
+	bool useThisLink=false;
+	TrackRef tk = cand->track();
+	reco::TrackRef trkTrack = link->trackerTrack();
+
+	// Using the same method that was used to create the links
+	// ToDo: there should be a better way than dR,dPt matching
+	if (not link->globalTrack().isNull()){
+	  float dR  = deltaR(tk->eta(),tk->phi(),link->globalTrack()->eta(),link->globalTrack()->phi());
+	  float dPt = abs(tk->pt() - link->globalTrack()->pt())/tk->pt();
+	  if (dR < 0.02 and dPt < 0.001) {
+	    useThisLink=true;
+	  }
+	}
+
+	if (useThisLink){
+          const TrackRef staTrack = link->standAloneTrack();
+	  if (!triggeredByLevel2(staTrack,vl2cands)) continue;
+
+           // eta cut
+           if (fabs(cand->eta())>max_Eta_) continue;
+    
+           // cut on number of hits
+           if (tk->numberOfValidHits()<min_Nhits_) continue;
+    
+           //max dr cut
+           //if (fabs(tk->d0())>max_Dr_) continue;
+           if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) >max_Dr_) continue;
+    
+           //min dr cut
+           if (fabs( (- (cand->vx()-beamSpot.x0()) * cand->py() + (cand->vy()-beamSpot.y0()) * cand->px() ) / cand->pt() ) <min_Dr_) continue;
+    
+           //dz cut
+           if (fabs((cand->vz()-beamSpot.z0()) - ((cand->vx()-beamSpot.x0())*cand->px()+(cand->vy()-beamSpot.y0())*cand->py())/cand->pt() * cand->pz()/cand->pt())>max_Dz_) continue;
+    
+           // dxy significance cut (safeguard against bizarre values)
+           if (min_DxySig_ > 0 && (tk->dxyError() <= 0 || fabs(tk->dxy(beamSpot.position())/tk->dxyError()) < min_DxySig_)) continue;
+    
+           //normalizedChi2 cut
+           if (tk->normalizedChi2() > max_NormalizedChi2_ ) continue;
+    
+           //dxy beamspot cut
+           if (std::abs(tk->dxy(beamSpot.position())) > max_DXYBeamSpot_ || std::abs(tk->dxy(beamSpot.position())) < min_DXYBeamSpot_ ) continue;
+    
+           //min muon hits cut
+           reco::HitPattern trackHits = tk->hitPattern();
+           if (trackHits.numberOfValidMuonHits() < min_NmuonHits_ ) continue;
+    
+           //pt difference cut
+           double candPt = cand->pt();
+           double trackPt = tk->pt();
+    
+           if (fabs(candPt - trackPt) > max_PtDifference_ ) continue;
+    
+           //track pt cut
+           if (trackPt < min_TrackPt_ ) continue;
+    
+           // Pt threshold cut
+           double pt = cand->pt();
+           double err0 = tk->error(0);
+           double abspar0 = fabs(tk->parameter(0));
+           double ptLx = pt;
+           // convert 50% efficiency threshold to 90% efficiency threshold
+           if (abspar0>0) ptLx += nsigma_Pt_*err0/abspar0*pt;
+           LogTrace("HLTMuonL3PreFilter") << " ...Muon in loop, trackkRef pt= "
+    				      << tk->pt() << ", ptLx= " << ptLx
+    				      << " cand pT " << cand->pt();
+          if (ptLx<min_Pt_) continue;
+    
+          filterproduct.addObject(TriggerMuon,cand);
+          n++;
+          break; // and go on with the next L2 association
+	} //end of useThisLink
+      } //end of muons in links collection
+    } //end of RecoCand collection
+
+    // filter decision:
+    const bool accept (n >= min_N_);
+    return accept;
+  } //not useL3MTS
 }
 
 bool

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
@@ -13,18 +13,60 @@
  *   matching between the reconstructed tracks
  *   in the muon system and the tracker.
  *
- *
- *
- *  \author N. Neumeister 	 Purdue University
- *  \author C. Liu 		 Purdue University
- *  \author A. Everett 		 Purdue University
+ *  \author N. Neumeister   Purdue University
+ *  \author C. Liu          Purdue University
+ *  \author A. Everett      Purdue University
  */
 
+#include <iostream>
+#include <algorithm>
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
+#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
+#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TkTrackingRegionsMargin.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "TrackingTools/TrackFitters/interface/RecHitLessByDet.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
 
 class RectangularEtaPhiTrackingRegion;
 class TrajectoryStateOnSurface;
@@ -42,28 +84,20 @@ class TrackerTopology;
 namespace edm {class ParameterSet; class Event;}
 namespace reco {class TransientTrack;}
 
-//              ---------------------
-//              -- Class Interface --
-//              ---------------------
-
 class GlobalTrajectoryBuilderBase : public MuonTrajectoryBuilder {
-
+    
   public:
 
     typedef TransientTrackingRecHit::RecHitContainer RecHitContainer;
     typedef TransientTrackingRecHit::ConstRecHitContainer ConstRecHitContainer;
     typedef TransientTrackingRecHit::RecHitPointer RecHitPointer;
     typedef TransientTrackingRecHit::ConstRecHitPointer ConstRecHitPointer;
-
     typedef MuonTransientTrackingRecHit::MuonRecHitPointer MuonRecHitPointer;
     typedef MuonTransientTrackingRecHit::ConstMuonRecHitPointer ConstMuonRecHitPointer;
     typedef MuonTransientTrackingRecHit::MuonRecHitContainer MuonRecHitContainer;
     typedef MuonTransientTrackingRecHit::ConstMuonRecHitContainer ConstMuonRecHitContainer;
-
     typedef std::vector<Trajectory> TC;
     typedef TC::const_iterator TI;
-
-  public:
 
     /// constructor with Parameter Set and MuonServiceProxy
     GlobalTrajectoryBuilderBase(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
@@ -78,7 +112,7 @@ class GlobalTrajectoryBuilderBase : public MuonTrajectoryBuilder {
     virtual void setEvent(const edm::Event&);
 
   protected:
-
+    
     enum RefitDirection{inToOut,outToIn,undetermined};
 
     /// build combined trajectory from sta Track and tracker RecHits
@@ -153,19 +187,17 @@ class GlobalTrajectoryBuilderBase : public MuonTrajectoryBuilder {
 	else if ( !barrel_a && !barrel_b ) return  fabs(a->globalPosition().z()) < fabs(b->globalPosition().z());
 	else if ( barrel_a && !barrel_b  ) return true;
 	else if ( !barrel_a && barrel_b  ) return false;
-	 //shouldn;t really get here in any case (there's some sense to throw here )
+	 //shouldn't really get here in any case (there's some sense to throw here )
 	 return false;
       }
     };
-
-  protected:
 
     std::string theCategory;
     float thePtCut;
     float thePCut;
 
   private:
-
+    
     GlobalMuonTrackMatcher* theTrackMatcher;
     MuonDetLayerMeasurements* theLayerMeasurements;
     TrackTransformer* theTrackTransformer;
@@ -173,21 +205,18 @@ class GlobalTrajectoryBuilderBase : public MuonTrajectoryBuilder {
     const MuonServiceProxy* theService;
     GlobalMuonRefitter* theGlbRefitter;
     unsigned long long theCacheId_TRH;
-    bool theRPCInTheFit;
-  
+    bool  theRPCInTheFit;
+    bool  theRefitFlag;
     int   theMuonHitsOption;
     float theTECxScale;
     float theTECyScale;
     std::string theTrackerPropagatorName;
- 
     const edm::Event* theEvent;
-
     std::string theTrackerRecHitBuilderName;
     edm::ESHandle<TransientTrackingRecHitBuilder> theTrackerRecHitBuilder;
-    
     std::string theMuonRecHitBuilderName;
     edm::ESHandle<TransientTrackingRecHitBuilder> theMuonRecHitBuilder;
-
-    const TrackerTopology *tTopo_;
+    const TrackerTopology* theTopo;
+    
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
+++ b/RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h
@@ -18,55 +18,11 @@
  *  \author A. Everett      Purdue University
  */
 
-#include <iostream>
-#include <algorithm>
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-
-#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-
-#include "DataFormats/Math/interface/deltaR.h"
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/MuonDetId/interface/DTChamberId.h"
-#include "DataFormats/MuonDetId/interface/CSCDetId.h"
-#include "DataFormats/MuonDetId/interface/RPCDetId.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-
-#include "Geometry/CommonTopologies/interface/StripTopology.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-
-#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
-#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
-#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h"
-#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
-#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 #include "RecoMuon/TrackingTools/interface/MuonTrajectoryBuilder.h"
 #include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
-
-#include "RecoTracker/TkTrackingRegions/interface/TkTrackingRegionsMargin.h"
-#include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
-#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
-#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-#include "TrackingTools/TrackFitters/interface/RecHitLessByDet.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 class RectangularEtaPhiTrackingRegion;
 class TrajectoryStateOnSurface;

--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
@@ -5,83 +5,107 @@
  *
  *  Build a TrackingRegion around a standalone muon
  *
+ * Options:
+ *  Beamspot : Origin is defined by primary vertex
+ *  Vertex   : Origin is defined by primary vertex (first valid vertex in the VertexCollection)
+ *             if no vertex is found the beamspot is used instead
+ *  DynamicZError           
+ *  DynamicEtaError
+ *  DynamicphiError
  *
- *
- *  \author A. Everett - Purdue University
- *  \author A. Grelli -  Purdue University, Pavia University 
+ *  \author N. Neumeister   Purdue University
+ *  \author A. Everett      Purdue University
  */
 
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
 
 class MuonServiceProxy;
 class MeasurementTrackerEvent;
 
 namespace edm {class ParameterSet; class Event;}
 
-//              ---------------------
-//              -- Class Interface --
-//              ---------------------
-
-class MuonTrackingRegionBuilder {
+class MuonTrackingRegionBuilder : public TrackingRegionProducer {
   
   public:
  
-    /// constructor
-    MuonTrackingRegionBuilder(const edm::ParameterSet&, edm::ConsumesCollector&);
-    MuonTrackingRegionBuilder(const edm::ParameterSet&par,
-			      const MuonServiceProxy*service,
-			      edm::ConsumesCollector& iC){ build(par, iC);init(service);}
-    void init(const MuonServiceProxy*);
-  
-    /// destructor
+    /// Constructor
+    explicit MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector& iC) { build(par, iC); }
+    explicit MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector&& iC) { build(par, iC); }
+
+    /// Destructor
     virtual ~MuonTrackingRegionBuilder() {}
+
+    /// Create Region of Interest
+    virtual std::vector<TrackingRegion* > regions(const edm::Event&, const edm::EventSetup&) const override;
   
-    /// define tracking region
+    /// Define tracking region
     RectangularEtaPhiTrackingRegion* region(const reco::TrackRef&) const;
+    RectangularEtaPhiTrackingRegion* region(const reco::Track& t) const { return region(t,*theEvent); }
+    RectangularEtaPhiTrackingRegion* region(const reco::Track&, const edm::Event&) const;
 
-    /// define tracking region
-    RectangularEtaPhiTrackingRegion* region(const reco::Track&) const;
-
-    /// pass the Event to the algo at each event
+    /// Pass the Event to the algo at each event
     virtual void setEvent(const edm::Event&);
 
+    /// Set the Fill Descriptions
+    static void fillDescriptions(edm::ParameterSetDescription& descriptions);
+
   private:
+    
     void build(const edm::ParameterSet&, edm::ConsumesCollector&);
 
-    edm::InputTag theBeamSpotTag;   // beam spot
-    edm::InputTag theVertexCollTag; // vertex collection
-
     const edm::Event* theEvent;
-    const MuonServiceProxy* theService;
 
-    bool useFixedRegion;
     bool useVertex;
+    bool useFixedZ;
+    bool useFixedPt;
+    bool useFixedPhi;
+    bool useFixedEta;
+    bool thePrecise;
 
-    double theTkEscapePt;
-    double theNsigmaEta,theNsigmaDz,theNsigmaPhi;
+    int theMaxRegions;
+
+    double theNsigmaEta;
+    double theNsigmaPhi;
+    double theNsigmaDz;
   
     double theEtaRegionPar1; 
     double theEtaRegionPar2;
     double thePhiRegionPar1;
     double thePhiRegionPar2;
 
+    double thePtMin;
     double thePhiMin;
     double theEtaMin;
-    double theDeltaR,theHalfZ;
-    double thePhiFixed,theEtaFixed;
-
-    GlobalPoint theVertexPos;
+    double theDeltaR;
+    double theHalfZ;
+    double theDeltaPhi;
+    double theDeltaEta;
 
     RectangularEtaPhiTrackingRegion::UseMeasurementTracker theOnDemand;
     edm::EDGetTokenT<MeasurementTrackerEvent> theMeasurementTrackerToken;
-    edm::EDGetTokenT<reco::BeamSpot> bsHandleToken;
+    edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
     edm::EDGetTokenT<reco::VertexCollection> vertexCollectionToken;
+    edm::EDGetTokenT<reco::TrackCollection> inputCollectionToken;
 };
 #endif

--- a/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
+++ b/RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h
@@ -21,24 +21,16 @@
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/Common/interface/Handle.h"
 
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
-#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
-#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
 class MuonServiceProxy;
 class MeasurementTrackerEvent;
@@ -67,7 +59,7 @@ class MuonTrackingRegionBuilder : public TrackingRegionProducer {
     /// Pass the Event to the algo at each event
     virtual void setEvent(const edm::Event&);
 
-    /// Set the Fill Descriptions
+    /// Add Fill Desciptions
     static void fillDescriptions(edm::ParameterSetDescription& descriptions);
 
   private:

--- a/RecoMuon/GlobalTrackingTools/plugins/Module.cc
+++ b/RecoMuon/GlobalTrackingTools/plugins/Module.cc
@@ -6,3 +6,9 @@
 
 
 DEFINE_FWK_MODULE(GlobalTrackQualityProducer);
+
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducerFactory.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
+DEFINE_EDM_PLUGIN(TrackingRegionProducerFactory, MuonTrackingRegionBuilder, "MuonTrackingRegionBuilder");
+

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -19,6 +19,62 @@
 
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h"
 
+//---------------
+// C++ Headers --
+//---------------
+
+#include <iostream>
+#include <algorithm>
+
+//-------------------------------
+// Collaborating Class Headers --
+//-------------------------------
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
+#include "TrackingTools/TrackFitters/interface/RecHitLessByDet.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/MuonDetId/interface/DTChamberId.h"
+#include "DataFormats/MuonDetId/interface/CSCDetId.h"
+#include "DataFormats/MuonDetId/interface/RPCDetId.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+
+#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
+#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h"
+#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
+#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
+#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/TkTrackingRegionsMargin.h"
+#include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
+
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
+#include "Geometry/CommonTopologies/interface/StripTopology.h"
+
 using namespace std;
 using namespace edm;
 

--- a/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalTrajectoryBuilderBase.cc
@@ -11,8 +11,6 @@
  *   matching between the reconstructed tracks
  *   in the muon system and the tracker.
  *
- *
- *
  *  \author N. Neumeister        Purdue University
  *  \author C. Liu               Purdue University
  *  \author A. Everett           Purdue University
@@ -20,62 +18,6 @@
  **/
 
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h"
-
-//---------------
-// C++ Headers --
-//---------------
-
-#include <iostream>
-#include <algorithm>
-
-//-------------------------------
-// Collaborating Class Headers --
-//-------------------------------
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "CommonTools/Statistics/interface/ChiSquaredProbability.h"
-#include "TrackingTools/TrackFitters/interface/RecHitLessByDet.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
-
-#include "DataFormats/Math/interface/deltaR.h"
-
-#include "DataFormats/DetId/interface/DetId.h"
-#include "DataFormats/MuonDetId/interface/DTChamberId.h"
-#include "DataFormats/MuonDetId/interface/CSCDetId.h"
-#include "DataFormats/MuonDetId/interface/RPCDetId.h"
-
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-
-#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-
-#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
-#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonRefitter.h"
-#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHitBuilder.h"
-#include "RecoMuon/TransientTrackingRecHit/interface/MuonTransientTrackingRecHit.h"
-#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-
-#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include "TrackingTools/Records/interface/TransientRecHitRecord.h"
-#include "TrackingTools/TrackFitters/interface/TrajectoryFitter.h"
-#include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
-#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
-
-#include "RecoTracker/TkTrackingRegions/interface/TkTrackingRegionsMargin.h"
-#include "RecoTracker/TkMSParametrization/interface/PixelRecoRange.h"
-
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h"
-#include "Geometry/CommonTopologies/interface/StripTopology.h"
 
 using namespace std;
 using namespace edm;
@@ -101,13 +43,14 @@ GlobalTrajectoryBuilderBase::GlobalTrajectoryBuilderBase(const edm::ParameterSet
 
   ParameterSet regionBuilderPSet = par.getParameter<ParameterSet>("MuonTrackingRegionBuilder");
 
-  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet,theService,iC);
+  theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet,iC);
 
   // TrackRefitter parameters
   ParameterSet refitterParameters = par.getParameter<ParameterSet>("GlbRefitterParameters");
   theGlbRefitter = new GlobalMuonRefitter(refitterParameters, theService, iC);
 
   theMuonHitsOption = refitterParameters.getParameter<int>("MuonHitsOption");
+  theRefitFlag = refitterParameters.getParameter<bool>("RefitFlag");
 
   theTrackerRecHitBuilderName = par.getParameter<string>("TrackerRecHitBuilder");
   theMuonRecHitBuilderName = par.getParameter<string>("MuonRecHitBuilder");  
@@ -160,7 +103,7 @@ void GlobalTrajectoryBuilderBase::setEvent(const edm::Event& event) {
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   theService->eventSetup().get<IdealGeometryRecord>().get(tTopoHand);
-  tTopo_=tTopoHand.product();
+  theTopo = tTopoHand.product();
 
 }
 
@@ -184,7 +127,7 @@ GlobalTrajectoryBuilderBase::build(const TrackCand& staCand,
   // check order of muon measurements
   if ( (muonRecHits.size() > 1) &&
        ( muonRecHits.front()->globalPosition().mag() >
-	 muonRecHits.back()->globalPosition().mag() ) ) {
+	     muonRecHits.back()->globalPosition().mag() ) ) {
     LogTrace(theCategory)<< "   reverse order: ";
   }
 
@@ -192,71 +135,94 @@ GlobalTrajectoryBuilderBase::build(const TrackCand& staCand,
 
     // cut on tracks with low momenta
     LogTrace(theCategory)<< "   Track p and pT " << (*it)->trackerTrack()->p() << " " << (*it)->trackerTrack()->pt();
-    if(  (*it)->trackerTrack()->p() < thePCut || (*it)->trackerTrack()->pt() < thePtCut  ) continue;
+    if ( (*it)->trackerTrack()->p() < thePCut || (*it)->trackerTrack()->pt() < thePtCut ) continue;
 
-    ConstRecHitContainer trackerRecHits;
-    if ((*it)->trackerTrack().isNonnull()) {
-      trackerRecHits = getTransientRecHits(*(*it)->trackerTrack());
-    } else {
-      LogDebug(theCategory)<<"     NEED HITS FROM TRAJ";
-      //trackerRecHits = (*it)->trackerTrajectory()->recHits();
-    }
+//		If true we will run theGlbRefitter->refit from all hits
+        if (theRefitFlag){
+			ConstRecHitContainer trackerRecHits;
+			if ((*it)->trackerTrack().isNonnull()) {
+			  trackerRecHits = getTransientRecHits(*(*it)->trackerTrack());
+			} else {
+			  LogDebug(theCategory)<<"     NEED HITS FROM TRAJ";
+			  //trackerRecHits = (*it)->trackerTrajectory()->recHits();
+			}
 
-    // check for single TEC RecHits in trajectories in the overalp region
-    if ( fabs((*it)->trackerTrack()->eta()) > 0.95 && fabs((*it)->trackerTrack()->eta()) < 1.15 && (*it)->trackerTrack()->pt() < 60 ) {
-      if ( theTECxScale < 0 || theTECyScale < 0 )
-        trackerRecHits = selectTrackerHits(trackerRecHits);
-      else
-        fixTEC(trackerRecHits,theTECxScale,theTECyScale);
-    }
-		  
-    RefitDirection recHitDir = checkRecHitsOrdering(trackerRecHits);
-    if ( recHitDir == outToIn ) reverse(trackerRecHits.begin(),trackerRecHits.end());
+			// check for single TEC RecHits in trajectories in the overalp region
+			if ( fabs((*it)->trackerTrack()->eta()) > 0.95 && fabs((*it)->trackerTrack()->eta()) < 1.15 && (*it)->trackerTrack()->pt() < 60 ) {
+			  if ( theTECxScale < 0 || theTECyScale < 0 )
+				trackerRecHits = selectTrackerHits(trackerRecHits);
+			  else
+				fixTEC(trackerRecHits,theTECxScale,theTECyScale);
+			}
 
-    reco::TransientTrack tTT((*it)->trackerTrack(),&*theService->magneticField(),theService->trackingGeometry());
-    TrajectoryStateOnSurface innerTsos = tTT.innermostMeasurementState();
+			RefitDirection recHitDir = checkRecHitsOrdering(trackerRecHits);
+			if ( recHitDir == outToIn ) reverse(trackerRecHits.begin(),trackerRecHits.end());
 
-    edm::RefToBase<TrajectorySeed> tmpSeed;
-    if((*it)->trackerTrack()->seedRef().isAvailable()) tmpSeed = (*it)->trackerTrack()->seedRef();
+			reco::TransientTrack tTT((*it)->trackerTrack(),&*theService->magneticField(),theService->trackingGeometry());
+			TrajectoryStateOnSurface innerTsos = tTT.innermostMeasurementState();
 
-    if ( !innerTsos.isValid() ) {
-      LogTrace(theCategory) << "     inner Trajectory State is invalid. ";
-      continue;
-    }
-  
-    innerTsos.rescaleError(100.);
-                  
-    TC refitted0,refitted1;
-    MuonCandidate* finalTrajectory = 0;
-    Trajectory *tkTrajectory = 0;
+			edm::RefToBase<TrajectorySeed> tmpSeed;
+			if((*it)->trackerTrack()->seedRef().isAvailable()) tmpSeed = (*it)->trackerTrack()->seedRef();
 
-    // tracker only track
-    if ( ! ((*it)->trackerTrajectory() && (*it)->trackerTrajectory()->isValid()) ) { 
-      refitted0 = theTrackTransformer->transform((*it)->trackerTrack()) ;
-      if (!refitted0.empty()) tkTrajectory = new Trajectory(*(refitted0.begin())); 
-      else LogWarning(theCategory)<< "     Failed to load tracker track trajectory";
-    } else tkTrajectory = (*it)->trackerTrajectory();
-    if (tkTrajectory) tkTrajectory->setSeedRef(tmpSeed);
+			if ( !innerTsos.isValid() ) {
+			  LogTrace(theCategory) << "     inner Trajectory State is invalid. ";
+			  continue;
+			}
 
-    // full track with all muon hits using theGlbRefitter    
-    ConstRecHitContainer allRecHits = trackerRecHits;
-    allRecHits.insert(allRecHits.end(), muonRecHits.begin(),muonRecHits.end());
-    refitted1 = theGlbRefitter->refit( *(*it)->trackerTrack(), tTT, allRecHits,theMuonHitsOption, tTopo_);
-    LogTrace(theCategory)<<"     This track-sta refitted to " << refitted1.size() << " trajectories";
+			innerTsos.rescaleError(100.);
 
-    Trajectory *glbTrajectory1 = 0;
-    if (!refitted1.empty()) glbTrajectory1 = new Trajectory(*(refitted1.begin()));
-    else LogDebug(theCategory)<< "     Failed to load global track trajectory 1"; 
-    if (glbTrajectory1) glbTrajectory1->setSeedRef(tmpSeed);
-    
-    finalTrajectory = 0;
-    if(glbTrajectory1 && tkTrajectory) finalTrajectory = new MuonCandidate(glbTrajectory1, (*it)->muonTrack(), (*it)->trackerTrack(), 
-					tkTrajectory? new Trajectory(*tkTrajectory) : 0);
+			TC refitted0,refitted1;
+			MuonCandidate* finalTrajectory = 0;
+			Trajectory *tkTrajectory = 0;
 
-    if ( finalTrajectory ) 
-      refittedResult.push_back(finalTrajectory);
-     
-    if(tkTrajectory) delete tkTrajectory;
+			// tracker only track
+			if ( ! ((*it)->trackerTrajectory() && (*it)->trackerTrajectory()->isValid()) ) {
+			  refitted0 = theTrackTransformer->transform((*it)->trackerTrack()) ;
+			  if (!refitted0.empty()) tkTrajectory = new Trajectory(*(refitted0.begin()));
+			  else LogWarning(theCategory)<< "     Failed to load tracker track trajectory";
+			} else tkTrajectory = (*it)->trackerTrajectory();
+			if (tkTrajectory) tkTrajectory->setSeedRef(tmpSeed);
+	
+			// full track with all muon hits using theGlbRefitter
+			ConstRecHitContainer allRecHits = trackerRecHits;
+			allRecHits.insert(allRecHits.end(), muonRecHits.begin(),muonRecHits.end());
+			refitted1 = theGlbRefitter->refit( *(*it)->trackerTrack(), tTT, allRecHits,theMuonHitsOption, theTopo);
+			LogTrace(theCategory)<<"     This track-sta refitted to " << refitted1.size() << " trajectories";
+
+			Trajectory *glbTrajectory1 = 0;
+			if (!refitted1.empty()) glbTrajectory1 = new Trajectory(*(refitted1.begin()));
+			else LogDebug(theCategory)<< "     Failed to load global track trajectory 1";
+			if (glbTrajectory1) glbTrajectory1->setSeedRef(tmpSeed);
+
+			finalTrajectory = 0;
+			if(glbTrajectory1 && tkTrajectory) finalTrajectory = new MuonCandidate(glbTrajectory1, (*it)->muonTrack(), (*it)->trackerTrack(),
+							tkTrajectory? new Trajectory(*tkTrajectory) : 0);
+			if (finalTrajectory) refittedResult.push_back(finalTrajectory);
+			if(tkTrajectory) delete tkTrajectory;
+        }
+//		Otherwise we just use the tracker trajectory:
+        else {
+			MuonCandidate* finalTrajectory = 0;
+			edm::RefToBase<TrajectorySeed> tmpSeed;
+			if((*it)->trackerTrack()->seedRef().isAvailable()) tmpSeed = (*it)->trackerTrack()->seedRef();
+
+			TC refitted0;
+			Trajectory *tkTrajectory = 0;
+			if ( ! ((*it)->trackerTrajectory() && (*it)->trackerTrajectory()->isValid()) ) {
+				refitted0 = theTrackTransformer->transform((*it)->trackerTrack());
+				if (!refitted0.empty()){
+					 tkTrajectory = new Trajectory(*(refitted0.begin()));
+				}
+				else LogWarning(theCategory)<< "     Failed to load tracker track trajectory";
+			}
+			else tkTrajectory = (*it)->trackerTrajectory();
+			if (tkTrajectory) tkTrajectory->setSeedRef(tmpSeed);
+//			Creating MuonCandidate using only the tracker trajectory:
+			finalTrajectory = new MuonCandidate(new Trajectory(*tkTrajectory), (*it)->muonTrack(), (*it)->trackerTrack(),new Trajectory(*tkTrajectory));
+			if (finalTrajectory){
+				refittedResult.push_back(finalTrajectory);
+			}
+        }
   }
 
   // choose the best global fit for this Standalone Muon based on the track probability
@@ -395,6 +361,7 @@ void GlobalTrajectoryBuilderBase::printHits(const ConstRecHitContainer& hits) co
 
 }
 
+
 //
 // check order of RechIts on a trajectory
 //
@@ -421,6 +388,7 @@ GlobalTrajectoryBuilderBase::checkRecHitsOrdering(const TransientTrackingRecHit:
     LogError(theCategory) << "Impossible to determine the rechits order" << endl;
     return undetermined;
   }
+
 }
 
 
@@ -526,8 +494,7 @@ GlobalTrajectoryBuilderBase::getTransientRecHits(const reco::Track& track) const
 
   TrajectoryStateOnSurface currTsos = trajectoryStateTransform::innerStateOnSurface(track, *theService->trackingGeometry(), &*theService->magneticField());
 
-  auto tkbuilder = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product());
-  auto hitCloner = tkbuilder->cloner(); 
+  auto hitCloner = static_cast<TkTransientTrackingRecHitBuilder const *>(theTrackerRecHitBuilder.product())->cloner(); 
   for (trackingRecHit_iterator hit = track.recHitsBegin(); hit != track.recHitsEnd(); ++hit) {
     if((*hit)->isValid()) {
       DetId recoid = (*hit)->geographicalId();
@@ -541,8 +508,7 @@ GlobalTrajectoryBuilderBase::getTransientRecHits(const reco::Track& track) const
 	    continue; 
 	  }
 	  currTsos = predTsos;
-          auto h = (**hit).cloneForFit(*tkbuilder->geometry()->idToDet( (**hit).geographicalId() ) );
-	  result.emplace_back(hitCloner.makeShared(h,predTsos));
+	  result.emplace_back(hitCloner(**hit,predTsos));
 	}else{
 	  result.push_back((*hit)->cloneSH());
 	}
@@ -557,4 +523,5 @@ GlobalTrajectoryBuilderBase::getTransientRecHits(const reco::Track& track) const
   }
   
   return result;
+
 }

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
@@ -9,6 +9,23 @@
 
 #include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 
+//-------------------------------
+// Collaborating Class Headers --
+//-------------------------------
+
+#include "DataFormats/Common/interface/Handle.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
+#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
+
 //
 // constructor
 //

--- a/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
+++ b/RecoMuon/GlobalTrackingTools/src/MuonTrackingRegionBuilder.cc
@@ -3,267 +3,216 @@
  *
  *  Build a TrackingRegion around a standalone muon 
  *
- *
- *  \author A. Everett - Purdue University
- *  \author A. Grelli -  Purdue University, Pavia University
+ *  \author N. Neumeister   Purdue University
+ *  \author A. Everett      Purdue University
  */
 
 #include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 
-//---------------
-// C++ Headers --
-//---------------
-
-
-//-------------------------------
-// Collaborating Class Headers --
-//-------------------------------
-
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/PatternTools/interface/TSCPBuilderNoMaterial.h"
-#include "TrackingTools/PatternTools/interface/TSCBLBuilderNoMaterial.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-using namespace std;
-
 //
 // constructor
 //
+void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par, edm::ConsumesCollector& iC) {
 
-void MuonTrackingRegionBuilder::init(const MuonServiceProxy* service) { theService= service;}
-MuonTrackingRegionBuilder::MuonTrackingRegionBuilder(const edm::ParameterSet& par, edm::ConsumesCollector& iC)
-{
-  build(par, iC);
-}
-void MuonTrackingRegionBuilder::build(const edm::ParameterSet& par, edm::ConsumesCollector& iC){
-  // vertex Collection and Beam Spot
-  theBeamSpotTag = par.getParameter<edm::InputTag>("beamSpot");
-  theVertexCollTag = par.getParameter<edm::InputTag>("vertexCollection");
-
-  // parmeters
+  // Adjust errors on Eta, Phi, Z
   theNsigmaEta  = par.getParameter<double>("Rescale_eta");
   theNsigmaPhi  = par.getParameter<double>("Rescale_phi");
   theNsigmaDz   = par.getParameter<double>("Rescale_Dz");
-  theTkEscapePt = par.getParameter<double>("EscapePt");
 
-  // upper limits parameters   
+  // Upper limits parameters
   theEtaRegionPar1 = par.getParameter<double>("EtaR_UpperLimit_Par1"); 
   theEtaRegionPar2 = par.getParameter<double>("EtaR_UpperLimit_Par2");
   thePhiRegionPar1 = par.getParameter<double>("PhiR_UpperLimit_Par1");
   thePhiRegionPar2 = par.getParameter<double>("PhiR_UpperLimit_Par2");
 
+  // Flag to switch to use Vertices instead of BeamSpot
   useVertex = par.getParameter<bool>("UseVertex");
-  useFixedRegion = par.getParameter<bool>("UseFixedRegion");
 
-  // fixed limits
-  thePhiFixed = par.getParameter<double>("Phi_fixed");
-  theEtaFixed = par.getParameter<double>("Eta_fixed");
+  // Flag to use fixed limits for Eta, Phi, Z, pT
+  useFixedZ = par.getParameter<bool>("Z_fixed");
+  useFixedPt = par.getParameter<bool>("Pt_fixed");
+  useFixedPhi = par.getParameter<bool>("Phi_fixed");
+  useFixedEta = par.getParameter<bool>("Eta_fixed");
 
+  // Minimum value for pT
+  thePtMin = par.getParameter<double>("Pt_min");
+
+  // Minimum value for Phi
   thePhiMin = par.getParameter<double>("Phi_min");
+
+  // Minimum value for Eta
   theEtaMin = par.getParameter<double>("Eta_min");
-  theHalfZ  = par.getParameter<double>("DeltaZ_Region");
+
+  // The static region size along the Z direction
+  theHalfZ  = par.getParameter<double>("DeltaZ");
+
+  // The transverse distance of the region from the BS/PV
   theDeltaR = par.getParameter<double>("DeltaR");
 
-  // perigee reference point
-  // FIXME: when next time altering the configuration of this
-  // class, please change the types of the following parameters:
-  // - OnDemand to at least int32 or to a string
-  //   corresponding to the UseMeasurementTracker enumeration
-  // - MeasurementTrackerName to InputTag
-  theOnDemand = RectangularEtaPhiTrackingRegion::doubleToUseMeasurementTracker(par.getParameter<double>("OnDemand"));
-  if(theOnDemand != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
-    theMeasurementTrackerToken = iC.consumes<MeasurementTrackerEvent>(par.getParameter<std::string>("MeasurementTrackerName"));
+  // The static region size in Eta
+  theDeltaEta = par.getParameter<double>("DeltaEta");
+
+  // The static region size in Phi
+  theDeltaPhi = par.getParameter<double>("DeltaPhi");
+
+  // Maximum number of regions to build when looping over Muons
+  theMaxRegions = par.getParameter<int>("maxRegions");
+
+  // Flag to use precise??
+  thePrecise = par.getParameter<bool>("precise"); 
+
+  // perigee reference point ToDo: Check this
+  theOnDemand = RectangularEtaPhiTrackingRegion::intToUseMeasurementTracker(par.getParameter<int>("OnDemand"));
+  if (theOnDemand != RectangularEtaPhiTrackingRegion::UseMeasurementTracker::kNever) {
+    theMeasurementTrackerToken = iC.consumes<MeasurementTrackerEvent>(par.getParameter<edm::InputTag>("MeasurementTrackerName"));
   }
 
-  bsHandleToken=iC.consumes<reco::BeamSpot>(theBeamSpotTag);
-  vertexCollectionToken=iC.consumes<reco::VertexCollection>(theVertexCollTag);
+  // Vertex collection and Beam Spot
+  beamSpotToken = iC.consumes<reco::BeamSpot>(par.getParameter<edm::InputTag>("beamSpot"));
+  vertexCollectionToken = iC.consumes<reco::VertexCollection>(par.getParameter<edm::InputTag>("vertexCollection"));
+
+  // Input muon collection
+  inputCollectionToken = iC.consumes<reco::TrackCollection>(par.getParameter<edm::InputTag>("input"));
 }
 
 
 //
+// Member function to be compatible with TrackingRegionProducerFactory: create many ROI for many tracks
 //
-//
-RectangularEtaPhiTrackingRegion* 
-MuonTrackingRegionBuilder::region(const reco::TrackRef& track) const {
+std::vector<TrackingRegion*> MuonTrackingRegionBuilder::regions(const edm::Event& ev, const edm::EventSetup& es) const {
+	
+  std::vector<TrackingRegion*> result;
 
+  edm::Handle<reco::TrackCollection> tracks;
+  ev.getByToken(inputCollectionToken, tracks);
+
+  int nRegions = 0;
+  for (auto it = tracks->cbegin(), ed = tracks->cend(); it != ed && nRegions < theMaxRegions; ++it) {
+    result.push_back(region(*it,ev));
+    nRegions++; 
+  }
+
+  return result;
+
+}
+
+
+//
+// Call region on Track from TrackRef
+//
+RectangularEtaPhiTrackingRegion* MuonTrackingRegionBuilder::region(const reco::TrackRef& track) const {
   return region(*track);
-
 }
 
 
 //
-//
+// ToDo: Not sure if this is needed?
 //
 void MuonTrackingRegionBuilder::setEvent(const edm::Event& event) {
-  
   theEvent = &event;
-
 }
 
 
 //
+//	Main member function called to create the ROI
 //
-//
-RectangularEtaPhiTrackingRegion* 
-MuonTrackingRegionBuilder::region(const reco::Track& staTrack) const {
+RectangularEtaPhiTrackingRegion* MuonTrackingRegionBuilder::region(const reco::Track& staTrack, const edm::Event& ev) const {
 
-  // get the free trajectory state of the muon updated at vertex
-  TSCPBuilderNoMaterial tscpBuilder; 
-  
-  FreeTrajectoryState muFTS = trajectoryStateTransform::initialFreeState(staTrack,&*theService->magneticField());
+  // get track momentum/direction at vertex
+  const math::XYZVector& mom = staTrack.momentum();
+  GlobalVector dirVector(mom.x(),mom.y(),mom.z());
+  double pt = staTrack.pt();
 
-  LogDebug("MuonTrackingRegionBuilder")<<"from state: "<<muFTS;
-
-  // get track direction at vertex
-  GlobalVector dirVector(muFTS.momentum());
-
-  // get track momentum
-  const math::XYZVector& mo = staTrack.innerMomentum();
-  GlobalVector mom(mo.x(),mo.y(),mo.z());
-  if ( staTrack.p() > 1.5 ) {
-    mom = dirVector; 
-  }
-
-  // initial vertex position -  in the following it is replaced with beam spot/vertexing
+  // initial vertex position - in the following it is replaced with beamspot/vertexing
   GlobalPoint vertexPos(0.0,0.0,0.0);
-  double deltaZatVTX = 0.0;
+  // standard 15.9, if useVertex than use error from  vertex
+  double deltaZ = theHalfZ;
 
   // retrieve beam spot information
-  edm::Handle<reco::BeamSpot> bsHandle;
-  bool bsHandleFlag = theEvent->getByToken(bsHandleToken, bsHandle);
-  // check the validity, otherwise vertexing
-  // inizialization of BS
+  edm::Handle<reco::BeamSpot> bs;
+  bool bsHandleFlag = ev.getByToken(beamSpotToken, bs);
 
-  if ( bsHandleFlag && !useVertex ) {
-    const reco::BeamSpot& bs =  *bsHandle;
-    vertexPos = GlobalPoint(bs.x0(), bs.y0(), bs.z0());
+  // check the validity, otherwise vertexing
+  if ( bsHandleFlag && bs.isValid() && !useVertex ) {
+    vertexPos = GlobalPoint(bs->x0(), bs->y0(), bs->z0());
+    deltaZ = useFixedZ ? theHalfZ : bs->sigmaZ() * theNsigmaDz;
   } else {
     // get originZPos from list of reconstructed vertices (first or all)
     edm::Handle<reco::VertexCollection> vertexCollection;
-    bool vtxHandleFlag = theEvent->getByToken(vertexCollectionToken, vertexCollection);
+    bool vtxHandleFlag = ev.getByToken(vertexCollectionToken, vertexCollection);
     // check if there exists at least one reconstructed vertex
     if ( vtxHandleFlag && !vertexCollection->empty() ) {
       // use the first vertex in the collection and assume it is the primary event vertex 
       reco::VertexCollection::const_iterator vtx = vertexCollection->begin();
-      vertexPos = GlobalPoint(vtx->x(),vtx->y(),vtx->z());
-      // delta Z from vertex error
-      deltaZatVTX = vtx->zError() * theNsigmaDz;
+      if (!vtx->isFake() && vtx->isValid() ) {
+        vertexPos = GlobalPoint(vtx->x(),vtx->y(),vtx->z());
+        deltaZ = useFixedZ ? theHalfZ : vtx->zError() * theNsigmaDz;
+      }
     }
   }
 
-
- // inizialize to the maximum possible value to avoit 
- // problems with TSCBL
-
+  // inizialize to the maximum possible value
   double deta = 0.4;
   double dphi = 0.6;
 
-  // take into account the correct beanspot rotation
-  if ( bsHandleFlag ) {
+  // evaluate the dynamical region if possible
+  deta = theNsigmaEta*(staTrack.etaError());
+  dphi = theNsigmaPhi*(staTrack.phiError());
 
-  const reco::BeamSpot& bs =  *bsHandle;
-
-  TSCBLBuilderNoMaterial tscblBuilder;
-  TrajectoryStateClosestToBeamLine tscbl = tscblBuilder(muFTS,bs);
-
- 
-    // evaluate the dynamical region if possible
-    if(tscbl.isValid()){
-
-      PerigeeTrajectoryError trackPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tscbl.trackStateAtPCA());
-      GlobalVector pTrack = tscbl.trackStateAtPCA().momentum();
-
-    // calculate deltaEta from deltaTheta
-      double deltaTheta = trackPerigeeErrors.thetaError();
-      double theta      = pTrack.theta();
-      double sin_theta  = sin(theta);
-
-    // get dEta and dPhi
-      deta = theNsigmaEta*(1/fabs(sin_theta))*deltaTheta;
-      dphi = theNsigmaPhi*(trackPerigeeErrors.phiError());
-
-    }
- }
-
-  /* Region_Parametrizations to take into account possible 
-     L2 error matrix inconsistencies. Detailed Explanation in TWIKI
-     page.
-  */
+  // Region_Parametrizations to take into account possible L2 error matrix inconsistencies
   double region_dEta = 0;
   double region_dPhi = 0;
-  double eta=0; double phi=0;
+  double eta = 0;
+  double phi = 0;
 
-  // eta, pt parametrization from MC study
-  float pt = fabs(mom.perp());
-
+  // eta, pt parametrization from MC study (circa 2009?)
   if ( pt <= 10. ) {
      // angular coefficients
      float acoeff_Phi = (thePhiRegionPar2 - thePhiRegionPar1)/5;
      float acoeff_Eta = (theEtaRegionPar2 - theEtaRegionPar1)/5;
 
-     eta = theEtaRegionPar1 + (acoeff_Eta)*(mom.perp()-5.);
-     phi = thePhiRegionPar1 + (acoeff_Phi)*(mom.perp()-5.) ;
-   }
-   // parametrization 2nd bin in pt from MC study  
-   if ( pt > 10. && pt < 100. ) {
+     eta = theEtaRegionPar1 + (acoeff_Eta)*(pt-5.);
+     phi = thePhiRegionPar1 + (acoeff_Phi)*(pt-5.) ;
+  }
+  // parametrization 2nd bin in pt from MC study  
+  if ( pt > 10. && pt < 100. ) {
      eta = theEtaRegionPar2;
      phi = thePhiRegionPar2;
-   }
-   // parametrization 3rd bin in pt from MC study
-   if ( pt >= 100. ) {
+  }
+  // parametrization 3rd bin in pt from MC study
+  if ( pt >= 100. ) {
      // angular coefficients
      float acoeff_Phi = (thePhiRegionPar1 - thePhiRegionPar2)/900;
      float acoeff_Eta = (theEtaRegionPar1 - theEtaRegionPar2)/900;
 
-     eta = theEtaRegionPar2 + (acoeff_Eta)*(mom.perp()-100.);
-     phi = thePhiRegionPar2 + (acoeff_Phi)*(mom.perp()-100.);
-   }
+     eta = theEtaRegionPar2 + (acoeff_Eta)*(pt-100.);
+     phi = thePhiRegionPar2 + (acoeff_Phi)*(pt-100.);
+  }
+
+  double region_dPhi1 = std::min(phi,dphi);
+  double region_dEta1 = std::min(eta,deta);
 
   // decide to use either a parametrization or a dynamical region
-  double region_dPhi1 = min(phi,dphi);
-  double region_dEta1 = min(eta,deta);
-
-  // minimum size
-  region_dPhi = max(thePhiMin,region_dPhi1);
-  region_dEta = max(theEtaMin,region_dEta1);
-
-  float deltaZ = 0.0;
-  // standard 15.9 is useVertex than region from vertexing
-  if ( useVertex ) {
-    deltaZ = max(theHalfZ,deltaZatVTX);
-  } else { 
-    deltaZ = theHalfZ;
-  }
+  region_dPhi = useFixedPhi ? theDeltaPhi : std::max(thePhiMin,region_dPhi1);
+  region_dEta = useFixedEta ? theDeltaEta : std::max(theEtaMin,region_dEta1);
 
   float deltaR = theDeltaR;
-  double minPt = max(theTkEscapePt,mom.perp()*0.6);
+  double minPt = useFixedPt ? thePtMin : std::max(thePtMin,pt*0.6);
 
-  RectangularEtaPhiTrackingRegion* region = 0;  
 
-  if (useFixedRegion) {
-     region_dEta = theEtaFixed;
-     region_dPhi = thePhiFixed;
-  }
-
-  const MeasurementTrackerEvent *measurementTracker = nullptr;
-  if(!theMeasurementTrackerToken.isUninitialized()) {
+  const MeasurementTrackerEvent* measurementTracker = nullptr;
+  if (!theMeasurementTrackerToken.isUninitialized()) {
     edm::Handle<MeasurementTrackerEvent> hmte;
-    theEvent->getByToken(theMeasurementTrackerToken, hmte);
+    ev.getByToken(theMeasurementTrackerToken, hmte);
     measurementTracker = hmte.product();
   }
 
-  region = new RectangularEtaPhiTrackingRegion(dirVector, vertexPos,
+  RectangularEtaPhiTrackingRegion* region = new RectangularEtaPhiTrackingRegion(dirVector, vertexPos,
                                                minPt, deltaR,
                                                deltaZ, region_dEta, region_dPhi,
-					       theOnDemand,
-					       true,/*default in the header*/
-					       measurementTracker);
+                                               theOnDemand,
+                                               thePrecise,
+                                               measurementTracker);
 
   LogDebug("MuonTrackingRegionBuilder")<<"the region parameters are:\n"
 				       <<"\n dirVector: "<<dirVector
@@ -274,8 +223,42 @@ MuonTrackingRegionBuilder::region(const reco::Track& staTrack) const {
 				       <<"\n region_dEta:"<<region_dEta
 				       <<"\n region_dPhi:"<<region_dPhi
 				       <<"\n on demand parameter: "<<static_cast<int>(theOnDemand);
-
   
   return region;
-  
+
+}
+
+void MuonTrackingRegionBuilder::fillDescriptions(edm::ParameterSetDescription& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<double>("EtaR_UpperLimit_Par1",0.25);
+  desc.add<double>("DeltaR",0.2);
+  desc.add<edm::InputTag>("beamSpot",edm::InputTag("hltOnlineBeamSpot"));
+  desc.add<int>("OnDemand",-1);
+  desc.add<edm::InputTag>("vertexCollection",edm::InputTag("pixelVertices"));
+  desc.add<double>("Rescale_phi",3.0);
+  desc.add<bool>("Eta_fixed",false);
+  desc.add<double>("DeltaZ_Region",15.9);
+  desc.add<double>("Rescale_eta",3.0);
+  desc.add<double>("PhiR_UpperLimit_Par2",0.2);
+  desc.add<double>("Eta_min",0.05);
+  desc.add<bool>("Phi_fixed",false);
+  desc.add<double>("Phi_min",0.05);
+  desc.add<double>("EscapePt",1.5);
+  desc.add<bool>("UseFixedRegion",false);
+  desc.add<double>("PhiR_UpperLimit_Par1",0.6);
+  desc.add<double>("EtaR_UpperLimit_Par2",0.15);
+  desc.add<edm::InputTag>("MeasurementTrackerName",edm::InputTag("hltESPMeasurementTracker"));
+  desc.add<bool>("UseVertex",false);
+  desc.add<double>("Rescale_Dz",3.0);
+  desc.add<bool>("Pt_fixed",false);
+  desc.add<bool>("Z_fixed",true);
+  desc.add<double>("Pt_min",0.0);
+  desc.add<double>("DeltaZ",15.9);
+  desc.add<double>("DeltaEta",0.2);
+  desc.add<double>("DeltaPhi",0.2);
+  desc.add<int>("maxRegions",1);
+  desc.add<bool>("precise",true);
+  desc.add<edm::InputTag>("input",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
+  descriptions.setComment("Build a TrackingRegion around a standalone muon. Options to define region around beamspot or primary vertex and dynamic regions are included.");
+  descriptions.add("MuonTrackingRegionBuilder",desc);
 }

--- a/RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h
+++ b/RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h
@@ -1,8 +1,6 @@
 #ifndef RecoMuon_HLTMuonL2SelectorForL3IO_HLTMuonL2SelectorForL3IO_H
 #define RecoMuon_HLTMuonL2SelectorForL3IO_HLTMuonL2SelectorForL3IO_H
 
-//-------------------------------------------------
-//
 /**  \class HLTMuonL2SelectorForL3IO
  * 
  *   L2 muon selector for L3 IO:
@@ -10,56 +8,14 @@
  *
  *   \author  Benjamin Radburn-Smith - Purdue University
  */
-//
-//--------------------------------------------------
-
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-//#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
 
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-
 #include "DataFormats/TrackReco/interface/Track.h"
-#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
-#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
-#include "MagneticField/Engine/interface/MagneticField.h"
-#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
-#include "TrackingTools/GeomPropagators/interface/Propagator.h"
-#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
-#include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryStateUpdator.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
-#include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
-#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
-#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-
-#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
-#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
-#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
-
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/Math/interface/deltaR.h"
-
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 
-//class MuonTrackFinder;
-//class MuonServiceProxy;
-
-class HLTMuonL2SelectorForL3IO : public edm::EDProducer {
+class HLTMuonL2SelectorForL3IO : public edm::stream::EDProducer<> {
   public:
   /// constructor with config
   HLTMuonL2SelectorForL3IO(const edm::ParameterSet&);
@@ -71,10 +27,8 @@ class HLTMuonL2SelectorForL3IO : public edm::EDProducer {
   virtual void produce(edm::Event&, const edm::EventSetup&);
     
  private:
-  // MuonSeed Collection Label
-	edm::EDGetTokenT<reco::TrackCollection> l2Src_;
-	edm::EDGetTokenT<reco::TrackCollection> l3OISrc_;
-
+	const edm::EDGetTokenT<reco::TrackCollection> l2Src_;
+	const edm::EDGetTokenT<reco::TrackCollection> l3OISrc_;
 };
 
 #endif

--- a/RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h
+++ b/RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h
@@ -1,0 +1,80 @@
+#ifndef RecoMuon_HLTMuonL2SelectorForL3IO_HLTMuonL2SelectorForL3IO_H
+#define RecoMuon_HLTMuonL2SelectorForL3IO_HLTMuonL2SelectorForL3IO_H
+
+//-------------------------------------------------
+//
+/**  \class HLTMuonL2SelectorForL3IO
+ * 
+ *   L2 muon selector for L3 IO:
+ *   finds L2 muons not previous converted into L3 muons
+ *
+ *   \author  Benjamin Radburn-Smith - Purdue University
+ */
+//
+//--------------------------------------------------
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+//#include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryStateUpdator.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
+#include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+
+#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+
+namespace edm {class ParameterSet; class Event; class EventSetup;}
+
+//class MuonTrackFinder;
+//class MuonServiceProxy;
+
+class HLTMuonL2SelectorForL3IO : public edm::EDProducer {
+  public:
+  /// constructor with config
+  HLTMuonL2SelectorForL3IO(const edm::ParameterSet&);
+  
+  /// destructor
+  virtual ~HLTMuonL2SelectorForL3IO(); 
+  
+  /// select muons
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+    
+ private:
+  // MuonSeed Collection Label
+	edm::EDGetTokenT<reco::TrackCollection> l2Src_;
+	edm::EDGetTokenT<reco::TrackCollection> l3OISrc_;
+
+};
+
+#endif

--- a/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
@@ -10,36 +10,17 @@
  */
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
-#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
 #include "RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h"
-
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
-#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-
-#include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerBySharedHits.h"
 #include "TrackingTools/PatternTools/interface/TrajectoryBuilder.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "TrackingTools/DetLayers/interface/NavigationSchool.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
-#include <iostream>
-#include <iomanip>
-#include <algorithm>
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 

--- a/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
+++ b/RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h
@@ -4,22 +4,42 @@
 /** \class L3MuonTrajectoryBuilder
  *  class to build muon trajectory
  *
- *
- *  \author N. Neumeister 	 Purdue University
- *  \author C. Liu 		 Purdue University
- *  \author A. Everett 		 Purdue University
+ *  \author N. Neumeister   Purdue University
+ *  \author C. Liu          Purdue University
+ *  \author A. Everett      Purdue University
  */
 
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
-#include "RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryBuilder.h"
-#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-#include "TrackingTools/DetLayers/interface/NavigationSchool.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
+#include "RecoMuon/GlobalTrackingTools/interface/GlobalTrajectoryBuilderBase.h"
+
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+
+#include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerBySharedHits.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryBuilder.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+#include "TrackingTools/DetLayers/interface/NavigationSchool.h"
+
+#include <iostream>
+#include <iomanip>
+#include <algorithm>
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
 
@@ -28,36 +48,42 @@ class Trajectory;
 class TrajectoryCleaner;
 
 class L3MuonTrajectoryBuilder : public GlobalTrajectoryBuilderBase {
+
   public:
-    /// constructor with Parameter Set and MuonServiceProxy
-  L3MuonTrajectoryBuilder(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
-          
-    /// destructor
+
+    /// Constructor with Parameter Set and MuonServiceProxy
+	L3MuonTrajectoryBuilder(const edm::ParameterSet&, const MuonServiceProxy*, edm::ConsumesCollector&);
+
+    /// Destructor
     ~L3MuonTrajectoryBuilder();
-    /// reconstruct trajectories from standalone and tracker only Tracks    
+
+    /// Reconstruct trajectories from standalone and tracker only Tracks
     using GlobalTrajectoryBuilderBase::trajectories;
     MuonTrajectoryBuilder::CandidateContainer trajectories(const TrackCand&);
-    /// pass the Event to the algo at each event
+
+    /// Pass the Event to the algo at each event
     virtual void setEvent(const edm::Event&);
+
+    /// Add default values for fillDescriptions
+    static void fillDescriptions(edm::ParameterSetDescription& descriptions);
+
   private:
-    /// make a TrackCand collection using tracker Track, Trajectory information
+
+    /// Make a TrackCand collection using tracker Track, Trajectory information
     std::vector<TrackCand> makeTkCandCollection(const TrackCand&);
-  private:
+
     TrajectoryCleaner* theTrajectoryCleaner;
     edm::InputTag theTkCollName;
     edm::Handle<reco::TrackCollection> allTrackerTracks;
     reco::BeamSpot beamSpot;
     edm::Handle<reco::BeamSpot> beamSpotHandle;
     edm::InputTag theBeamSpotInputTag;
-
     reco::Vertex vtx;
     edm::Handle<reco::VertexCollection> pvHandle;
     edm::InputTag theVertexCollInputTag;
-
     bool theUseVertex;
     double theMaxChi2;
     double theDXYBeamSpot;
-    edm::EDGetTokenT<reco::TrackCollection> trackToken_;
-
+    edm::EDGetTokenT<reco::TrackCollection> theTrackToken;
 };
 #endif

--- a/RecoMuon/L3TrackFinder/plugins/SealModules.cc
+++ b/RecoMuon/L3TrackFinder/plugins/SealModules.cc
@@ -2,5 +2,8 @@
 
 #include "RecoMuon/L3TrackFinder/interface/MuonCkfTrajectoryBuilder.h"
 #include "RecoTracker/CkfPattern/interface/BaseCkfTrajectoryBuilderFactory.h"
+#include "RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h"
 
 DEFINE_EDM_PLUGIN(BaseCkfTrajectoryBuilderFactory, MuonCkfTrajectoryBuilder, "MuonCkfTrajectoryBuilder");
+DEFINE_FWK_MODULE(HLTMuonL2SelectorForL3IO);
+

--- a/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
+++ b/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
@@ -15,110 +15,58 @@
 //--------------------------------------------------
 
 #include "RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h"
-
-// Framework
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-// TrackFinder and Specific STA/L2 Trajectory Builder
-//#include "RecoMuon/StandAloneTrackFinder/interface/StandAloneTrajectoryBuilder.h"
-//#include "RecoMuon/StandAloneTrackFinder/interface/ExhaustiveMuonTrajectoryBuilder.h"
-//#include "RecoMuon/TrackingTools/interface/MuonTrackFinder.h"
-//#include "RecoMuon/TrackingTools/interface/MuonTrackLoader.h"
-//#include "RecoMuon/TrackingTools/interface/MuonTrajectoryCleaner.h"
-//#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-//
-//#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
-
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/Common/interface/View.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-//#include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
-//#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
-
-#include <string>
-
-using namespace edm;
-using namespace std;
+#include "DataFormats/Math/interface/deltaR.h"
+//#include <string>
 
 /// constructor with config
-HLTMuonL2SelectorForL3IO::HLTMuonL2SelectorForL3IO(const ParameterSet& iConfig):
+HLTMuonL2SelectorForL3IO::HLTMuonL2SelectorForL3IO(const edm::ParameterSet& iConfig):
 		l2Src_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l2Src"))),
 		l3OISrc_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l3OISrc"))){
-
-	LogTrace("Muon|RecoMuon|HLTMuonL2SelectorForL3IO")<<"constructor called"<<endl;
-
-//  edm::ConsumesCollector  iC = consumesCollector();
-  
-  produces<reco::TrackCollection>();
-//  produces<reco::TrackCollection>("UpdatedAtVtx");
-//  produces<TrackingRecHitCollection>();
-//  produces<reco::TrackExtraCollection>();
-//  produces<reco::TrackToTrackMap>();
-//
-//  produces<std::vector<Trajectory> >();
-//  produces<TrajTrackAssociationCollection>();
-//
-//  produces<edm::AssociationMap<edm::OneToMany<std::vector<L2MuonTrajectorySeed>, std::vector<L2MuonTrajectorySeed> > > >();
+	LogTrace("Muon|RecoMuon|HLTMuonL2SelectorForL3IO")<<"constructor called";
+	produces<reco::TrackCollection>();
 }
   
 /// destructor
 HLTMuonL2SelectorForL3IO::~HLTMuonL2SelectorForL3IO(){}
 
 /// reconstruct muons
-void HLTMuonL2SelectorForL3IO::produce(Event& iEvent, const EventSetup& iSetup){
-  
- const std::string metname = "Muon|RecoMuon|HLTMuonL2SelectorForL3IO";
-//    LogTrace(metname)
- 	 std::cout <<"L2 Selection for L3IO Started"<<endl;
+void HLTMuonL2SelectorForL3IO::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+	const std::string metname = "Muon|RecoMuon|HLTMuonL2SelectorForL3IO";
   
 //  IN:
 	edm::Handle<reco::TrackCollection> l2TrackCol;
 	iEvent.getByToken(l2Src_, l2TrackCol);
-	std::cout <<"l2TrackCol->size(): " << l2TrackCol->size() << std::endl;
 
 	edm::Handle<reco::TrackCollection> l3TrackCol;
-
 	try{
 		iEvent.getByToken(l3OISrc_, l3TrackCol);
-		std::cout <<"l3TrackCol->size(): " << l3TrackCol->size() << std::endl;
 	}
 	catch (...) {
-		std::cout << "no L3 available" << std::endl;
+		LogTrace(metname) << "no L3 available";
 	}
-	 std::cout <<"L2 Selection: In collected"<< std::endl;
-
 
 //	OUT:
 	std::auto_ptr<std::vector<reco::Track> > result(new std::vector<reco::Track>());
 
-	 std::cout <<"L2 Selection: Out created"<<endl;
-
 	for (unsigned int l2TrackColIndex(0);l2TrackColIndex!=l2TrackCol->size();++l2TrackColIndex){
-		std::cout << "L2 #: " << l2TrackColIndex << std::endl;
 		const reco::TrackRef l2(l2TrackCol, l2TrackColIndex);
-		std::cout <<"L2 reference made"<< std::endl;
 		bool l2found=false;
 		try{
 			for (unsigned int l3TrackColIndex(0);l3TrackColIndex!=l3TrackCol->size();++l3TrackColIndex){
-				std::cout << "\tL3 #: " << l3TrackColIndex << std::endl;
 				const reco::TrackRef l3(l3TrackCol, l3TrackColIndex);
-				std::cout <<"L3 reference made"<< std::endl;
-
-				std::cout << "\t(deltaR(*l3,*l2): " << deltaR(*l3,*l2) << std::endl;
+				LogTrace(metname) << "\t(deltaR(*l3,*l2): " << deltaR(*l3,*l2);
 				if (deltaR(*l3,*l2)<0.01) l2found=true;
+				// ToDo: try with the shared hits between the objects
 			}
 		}
 		catch (...) {
-			std::cout << "no L3 available" << std::endl;
+			LogTrace(metname) << "Cannot match between L2 and L3 due to missing L3 collection";
 		}
 		if (!l2found) result->push_back(*l2);
 	}
 
   iEvent.put(result);
-  
-  LogTrace(metname)<<"Event loaded"<<"================================"<<endl;
 }
 

--- a/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
+++ b/RecoMuon/L3TrackFinder/src/HLTMuonL2SelectorForL3IO.cc
@@ -1,0 +1,124 @@
+//-------------------------------------------------
+//
+/**  \class HLTMuonL2SelectorForL3IO
+ * 
+ *   Level-2 muon reconstructor:
+ *   reconstructs muons using DT, CSC and RPC
+ *   information,<BR>
+ *   starting from Level-1 trigger seeds.
+ *
+ *
+ *
+ *   \author  R.Bellan - INFN TO
+ */
+//
+//--------------------------------------------------
+
+#include "RecoMuon/L3TrackFinder/interface/HLTMuonL2SelectorForL3IO.h"
+
+// Framework
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// TrackFinder and Specific STA/L2 Trajectory Builder
+//#include "RecoMuon/StandAloneTrackFinder/interface/StandAloneTrajectoryBuilder.h"
+//#include "RecoMuon/StandAloneTrackFinder/interface/ExhaustiveMuonTrajectoryBuilder.h"
+//#include "RecoMuon/TrackingTools/interface/MuonTrackFinder.h"
+//#include "RecoMuon/TrackingTools/interface/MuonTrackLoader.h"
+//#include "RecoMuon/TrackingTools/interface/MuonTrajectoryCleaner.h"
+//#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+//
+//#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+//#include "DataFormats/TrackReco/interface/TrackToTrackMap.h"
+//#include "DataFormats/MuonSeed/interface/L2MuonTrajectorySeedCollection.h"
+
+#include <string>
+
+using namespace edm;
+using namespace std;
+
+/// constructor with config
+HLTMuonL2SelectorForL3IO::HLTMuonL2SelectorForL3IO(const ParameterSet& iConfig):
+		l2Src_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l2Src"))),
+		l3OISrc_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("l3OISrc"))){
+
+	LogTrace("Muon|RecoMuon|HLTMuonL2SelectorForL3IO")<<"constructor called"<<endl;
+
+//  edm::ConsumesCollector  iC = consumesCollector();
+  
+  produces<reco::TrackCollection>();
+//  produces<reco::TrackCollection>("UpdatedAtVtx");
+//  produces<TrackingRecHitCollection>();
+//  produces<reco::TrackExtraCollection>();
+//  produces<reco::TrackToTrackMap>();
+//
+//  produces<std::vector<Trajectory> >();
+//  produces<TrajTrackAssociationCollection>();
+//
+//  produces<edm::AssociationMap<edm::OneToMany<std::vector<L2MuonTrajectorySeed>, std::vector<L2MuonTrajectorySeed> > > >();
+}
+  
+/// destructor
+HLTMuonL2SelectorForL3IO::~HLTMuonL2SelectorForL3IO(){}
+
+/// reconstruct muons
+void HLTMuonL2SelectorForL3IO::produce(Event& iEvent, const EventSetup& iSetup){
+  
+ const std::string metname = "Muon|RecoMuon|HLTMuonL2SelectorForL3IO";
+//    LogTrace(metname)
+ 	 std::cout <<"L2 Selection for L3IO Started"<<endl;
+  
+//  IN:
+	edm::Handle<reco::TrackCollection> l2TrackCol;
+	iEvent.getByToken(l2Src_, l2TrackCol);
+	std::cout <<"l2TrackCol->size(): " << l2TrackCol->size() << std::endl;
+
+	edm::Handle<reco::TrackCollection> l3TrackCol;
+
+	try{
+		iEvent.getByToken(l3OISrc_, l3TrackCol);
+		std::cout <<"l3TrackCol->size(): " << l3TrackCol->size() << std::endl;
+	}
+	catch (...) {
+		std::cout << "no L3 available" << std::endl;
+	}
+	 std::cout <<"L2 Selection: In collected"<< std::endl;
+
+
+//	OUT:
+	std::auto_ptr<std::vector<reco::Track> > result(new std::vector<reco::Track>());
+
+	 std::cout <<"L2 Selection: Out created"<<endl;
+
+	for (unsigned int l2TrackColIndex(0);l2TrackColIndex!=l2TrackCol->size();++l2TrackColIndex){
+		std::cout << "L2 #: " << l2TrackColIndex << std::endl;
+		const reco::TrackRef l2(l2TrackCol, l2TrackColIndex);
+		std::cout <<"L2 reference made"<< std::endl;
+		bool l2found=false;
+		try{
+			for (unsigned int l3TrackColIndex(0);l3TrackColIndex!=l3TrackCol->size();++l3TrackColIndex){
+				std::cout << "\tL3 #: " << l3TrackColIndex << std::endl;
+				const reco::TrackRef l3(l3TrackCol, l3TrackColIndex);
+				std::cout <<"L3 reference made"<< std::endl;
+
+				std::cout << "\t(deltaR(*l3,*l2): " << deltaR(*l3,*l2) << std::endl;
+				if (deltaR(*l3,*l2)<0.01) l2found=true;
+			}
+		}
+		catch (...) {
+			std::cout << "no L3 available" << std::endl;
+		}
+		if (!l2found) result->push_back(*l2);
+	}
+
+  iEvent.put(result);
+  
+  LogTrace(metname)<<"Event loaded"<<"================================"<<endl;
+}
+

--- a/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
@@ -22,6 +22,32 @@
 
 #include "RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h"
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
+#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
+
+#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
+#include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerBySharedHits.h"
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
+
+
 //----------------
 // Constructors --
 //----------------

--- a/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
+++ b/RecoMuon/L3TrackFinder/src/L3MuonTrajectoryBuilder.cc
@@ -12,7 +12,6 @@
  *   in the muon system and the tracker.
  *
  *
- *
  *  Authors :
  *  N. Neumeister            Purdue University
  *  C. Liu                   Purdue University
@@ -23,85 +22,45 @@
 
 #include "RecoMuon/L3TrackFinder/interface/L3MuonTrajectoryBuilder.h"
 
-
-//---------------
-// C++ Headers --
-//---------------
-
-#include <iostream>
-#include <iomanip>
-#include <algorithm>
-
-//-------------------------------
-// Collaborating Class Headers --
-//-------------------------------
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/Event.h"
-
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
-
-#include "RecoMuon/TrackingTools/interface/MuonCandidate.h"
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "RecoMuon/GlobalTrackingTools/interface/GlobalMuonTrackMatcher.h"
-
-#include "FWCore/ServiceRegistry/interface/Service.h"
-
-#include "RecoTracker/Record/interface/CkfComponentsRecord.h"
-#include "RecoTracker/Record/interface/NavigationSchoolRecord.h"
-
-#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-#include "TrackingTools/TrajectoryCleaning/interface/TrajectoryCleanerBySharedHits.h"
-
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
-
-using namespace std;
-using namespace edm;
-
 //----------------
 // Constructors --
 //----------------
-
 L3MuonTrajectoryBuilder::L3MuonTrajectoryBuilder(const edm::ParameterSet& par,
 						 const MuonServiceProxy* service,
 						 edm::ConsumesCollector& iC) : GlobalTrajectoryBuilderBase(par, service, iC) {
-
   theTrajectoryCleaner = new TrajectoryCleanerBySharedHits();    
-
   theTkCollName = par.getParameter<edm::InputTag>("tkTrajLabel");
   theBeamSpotInputTag = par.getParameter<edm::InputTag>("tkTrajBeamSpot");
   theMaxChi2 = par.getParameter<double>("tkTrajMaxChi2");
   theDXYBeamSpot = par.getParameter<double>("tkTrajMaxDXYBeamSpot");
   theUseVertex = par.getParameter<bool>("tkTrajUseVertex");
   theVertexCollInputTag = par.getParameter<edm::InputTag>("tkTrajVertex");
-  trackToken_ = iC.consumes<reco::TrackCollection>(theTkCollName);
+  theTrackToken = iC.consumes<reco::TrackCollection>(theTkCollName);
 }
-
 
 //--------------
 // Destructor --
 //--------------
-
 L3MuonTrajectoryBuilder::~L3MuonTrajectoryBuilder() {
   if (theTrajectoryCleaner) delete theTrajectoryCleaner;
 }
 
+void L3MuonTrajectoryBuilder::fillDescriptions(edm::ParameterSetDescription& desc) {
+   edm::ParameterSetDescription descTRB;
+   MuonTrackingRegionBuilder::fillDescriptions(descTRB);
+   desc.add("MuonTrackingRegionBuilder",descTRB);
+}
+
 //
-// get information from event
+// Get information from event
 //
 void L3MuonTrajectoryBuilder::setEvent(const edm::Event& event) {
-  
   const std::string category = "Muon|RecoMuon|L3MuonTrajectoryBuilder|setEvent";
   
   GlobalTrajectoryBuilderBase::setEvent(event);
       
   // get tracker TrackCollection from Event
-  event.getByToken(trackToken_,allTrackerTracks);
+  event.getByToken(theTrackToken,allTrackerTracks);
   LogDebug(category) 
       << "Found " << allTrackerTracks->size() 
       << " tracker Tracks with label "<< theTkCollName;  
@@ -113,8 +72,7 @@ void L3MuonTrajectoryBuilder::setEvent(const edm::Event& event) {
       vtx = pvHandle->front();
     } 
     else {
-      edm::LogInfo(category)
-      << "No Primary Vertex available from EventSetup \n";
+      edm::LogInfo(category) << "No Primary Vertex available from EventSetup \n";
     }
   }
   else {
@@ -124,11 +82,11 @@ void L3MuonTrajectoryBuilder::setEvent(const edm::Event& event) {
       beamSpot = *beamSpotHandle;
     }
     else {
-      edm::LogInfo(category)
-      << "No beam spot available from EventSetup \n";
+      edm::LogInfo(category) << "No beam spot available from EventSetup \n";
     }
   }
 }
+
 
 //
 // reconstruct trajectories
@@ -143,9 +101,9 @@ MuonCandidate::CandidateContainer L3MuonTrajectoryBuilder::trajectories(const Tr
   // convert the STA track into a Trajectory if Trajectory not already present
   TrackCand staCand(staCandIn);
   
-  vector<TrackCand> trackerTracks;
+  std::vector<TrackCand> trackerTracks;
   
-  vector<TrackCand> regionalTkTracks = makeTkCandCollection(staCand);
+  std::vector<TrackCand> regionalTkTracks = makeTkCandCollection(staCand);
   LogDebug(category) << "Found " << regionalTkTracks.size() << " tracks within region of interest";  
   
   // match tracker tracks to muon track
@@ -155,18 +113,13 @@ MuonCandidate::CandidateContainer L3MuonTrajectoryBuilder::trajectories(const Tr
   if ( trackerTracks.empty() ) return CandidateContainer();
   
   // build a combined tracker-muon MuonCandidate
-  //
   // turn tkMatchedTracks into MuonCandidates
-  //
   LogDebug(category) << "turn tkMatchedTracks into MuonCandidates";
   CandidateContainer tkTrajs;
-  for (vector<TrackCand>::const_iterator tkt = trackerTracks.begin(); tkt != trackerTracks.end(); tkt++) {
+  for (std::vector<TrackCand>::const_iterator tkt = trackerTracks.begin(); tkt != trackerTracks.end(); tkt++) {
     if ((*tkt).first != 0 && (*tkt).first->isValid()) {
-      //
       MuonCandidate* muonCand = new MuonCandidate( 0 ,staCand.second,(*tkt).second, new Trajectory(*(*tkt).first));
       tkTrajs.push_back(muonCand);
-      //      LogTrace(category) << "tpush";
-      //
     } else {
       MuonCandidate* muonCand = new MuonCandidate( 0 ,staCand.second,(*tkt).second, 0);
       tkTrajs.push_back(muonCand);
@@ -191,24 +144,21 @@ MuonCandidate::CandidateContainer L3MuonTrajectoryBuilder::trajectories(const Tr
   }
   tkTrajs.clear();  
 
-  for ( vector<TrackCand>::const_iterator is = regionalTkTracks.begin(); is != regionalTkTracks.end(); ++is) {
+  for ( std::vector<TrackCand>::const_iterator is = regionalTkTracks.begin(); is != regionalTkTracks.end(); ++is) {
     delete (*is).first;   
   }
   
   return result;
-  
 }
+
 
 //
 // make a TrackCand collection using tracker Track, Trajectory information
 //
-vector<L3MuonTrajectoryBuilder::TrackCand> L3MuonTrajectoryBuilder::makeTkCandCollection(const TrackCand& staCand) {
-
+std::vector<L3MuonTrajectoryBuilder::TrackCand> L3MuonTrajectoryBuilder::makeTkCandCollection(const TrackCand& staCand) {
   const std::string category = "Muon|RecoMuon|L3MuonTrajectoryBuilder|makeTkCandCollection";
-
-  vector<TrackCand> tkCandColl;
-  
-  vector<TrackCand> tkTrackCands;
+  std::vector<TrackCand> tkCandColl;
+  std::vector<TrackCand> tkTrackCands;
   
   for ( unsigned int position = 0; position != allTrackerTracks->size(); ++position ) {
     reco::TrackRef tkTrackRef(allTrackerTracks,position);
@@ -216,22 +166,41 @@ vector<L3MuonTrajectoryBuilder::TrackCand> L3MuonTrajectoryBuilder::makeTkCandCo
     tkCandColl.push_back(tkCand);
   }
 
-  for(vector<TrackCand>::const_iterator tk = tkCandColl.begin(); tk != tkCandColl.end() ; ++tk) { 
-    edm::Ref<L3MuonTrajectorySeedCollection> l3seedRef = (*tk).second->seedRef().castTo<edm::Ref<L3MuonTrajectorySeedCollection> >() ;
-    reco::TrackRef staTrack = l3seedRef->l2Track();
-    if( staTrack == (staCand.second) ) {
-      // apply a filter (dxy, chi2 cut)
-      double tk_vtx;
-      if( theUseVertex ) tk_vtx = (*tk).second->dxy(vtx.position());
-      else tk_vtx = (*tk).second->dxy(beamSpot.position());
+  //Loop over TrackCand collection made from allTrackerTracks in previous step
+  for(std::vector<TrackCand>::const_iterator tk = tkCandColl.begin(); tk != tkCandColl.end() ; ++tk) {
+	  bool canUseL3MTS = false;
+	  try{
+		  edm::Ref<L3MuonTrajectorySeedCollection> test = (*tk).second->seedRef().castTo<edm::Ref<L3MuonTrajectorySeedCollection> >() ;
+		  canUseL3MTS=true;
+		  LogDebug(category) << "Converterted TS into L3MTS";
 
-      if( fabs(tk_vtx) > theDXYBeamSpot || (*tk).second->normalizedChi2() > theMaxChi2 ) continue;
-
-      tkTrackCands.push_back(*tk);
+	  }
+	  catch(...){
+		  LogDebug(category) << "Failed to convert TS into L3MTS: using all tracker tracks for L3 matching";
+	  }
+    if (canUseL3MTS){
+    	edm::Ref<L3MuonTrajectorySeedCollection> l3seedRef = (*tk).second->seedRef().castTo<edm::Ref<L3MuonTrajectorySeedCollection> >() ;
+    	reco::TrackRef staTrack = l3seedRef->l2Track();
+    	if( staTrack == (staCand.second) ) {
+    		// apply a filter (dxy, chi2 cut)
+    		double tk_vtx;
+    		if( theUseVertex ) tk_vtx = (*tk).second->dxy(vtx.position());
+    		else tk_vtx = (*tk).second->dxy(beamSpot.position());
+    		if( fabs(tk_vtx) > theDXYBeamSpot || (*tk).second->normalizedChi2() > theMaxChi2 ) continue;
+    		tkTrackCands.push_back(*tk);
+    	}
     }
+    else{
+//    	We will try to match all tracker tracks with the muon:
+        double tk_vtx;
+        if( theUseVertex ) tk_vtx = (*tk).second->dxy(vtx.position());
+        else tk_vtx = (*tk).second->dxy(beamSpot.position());
+        if( fabs(tk_vtx) > theDXYBeamSpot || (*tk).second->normalizedChi2() > theMaxChi2 ) continue;
+        tkTrackCands.push_back(*tk);
+    }
+
   }
 
   return tkTrackCands;
-  
 }
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -289,7 +289,7 @@ void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("src",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
   desc.add<int>("layersToTry",1);
-  desc.add<double>("fixedErrorRescaleFactorForHitless",5.0);
+  desc.add<double>("fixedErrorRescaleFactorForHitless",2.0);
   desc.add<int>("hitsToTry",1);
   desc.add<bool>("adjustErrorsDyanmicallyForHits",false);
   desc.add<bool>("adjustErrorsDyanmicallyForHitless",false);
@@ -301,7 +301,7 @@ void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   desc.addUntracked<bool>("debug",true);
   desc.add<double>("fixedErrorRescaleFactorForHits",2.0);
   desc.add<unsigned int>("maxSeeds",1);
-  descriptions.add("test",desc);
+  descriptions.add("TSGForOI",desc);
 }
 
 DEFINE_FWK_MODULE(TSGForOI);

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.cc
@@ -1,0 +1,307 @@
+/**
+  \class    TSGForOI
+  \brief    Create L3MuonTrajectorySeeds from L2 Muons updated at vertex in an outside in manner
+  \author   Benjamin Radburn-Smith
+ */
+
+#include "RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h"
+
+TSGForOI::TSGForOI(const edm::ParameterSet & iConfig) :
+			src_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+			numOfMaxSeeds_(iConfig.getParameter<uint32_t>("maxSeeds")),
+			numOfLayersToTry_(iConfig.getParameter<int32_t>("layersToTry")),
+			numOfHitsToTry_(iConfig.getParameter<int32_t>("hitsToTry")),
+			fixedErrorRescalingForHits_(iConfig.getParameter<double>("fixedErrorRescaleFactorForHits")),
+			fixedErrorRescalingForHitless_(iConfig.getParameter<double>("fixedErrorRescaleFactorForHitless")),
+			adjustErrorsDyanmicallyForHits_(iConfig.getParameter<bool>("adjustErrorsDyanmicallyForHits")),
+			adjustErrorsDyanmicallyForHitless_(iConfig.getParameter<bool>("adjustErrorsDyanmicallyForHitless")),
+		    estimatorName_(iConfig.getParameter<std::string>("estimator")),
+			measurementTrackerTag_(consumes<MeasurementTrackerEvent>(iConfig.getParameter<edm::InputTag>("MeasurementTrackerEvent"))),
+			minEtaForTEC_(iConfig.getParameter<double>("minEtaForTEC")),
+			maxEtaForTOB_(iConfig.getParameter<double>("maxEtaForTOB")),
+			useHitlessSeeds_(iConfig.getParameter<bool>("UseHitlessSeeds")),
+			dummyPlane_(Plane::build(Plane::PositionType(), Plane::RotationType())){
+	produces<std::vector<TrajectorySeed> >();
+	updator_ = new KFUpdator();
+	foundCompatibleDet_=false;
+	numSeedsMade_=0;
+	theCategory = "Muon|RecoMuon|TSGForOI";
+}
+
+
+TSGForOI::~TSGForOI(){
+	if(updator_) delete updator_;
+}
+
+
+void TSGForOI::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+	iSetup.get<IdealMagneticFieldRecord>().get(magfield_);
+	iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorOpposite_);
+	iSetup.get<TrackingComponentsRecord>().get("PropagatorWithMaterial", propagatorAlong_);
+	iSetup.get<GlobalTrackingGeometryRecord>().get(geometry_);
+    iSetup.get<TrackingComponentsRecord>().get(estimatorName_,estimator_);
+	iEvent.getByToken(measurementTrackerTag_, measurementTracker_);
+	edm::Handle<reco::TrackCollection> l2TrackCol;					iEvent.getByToken(src_, l2TrackCol);
+
+//	The product:
+	std::auto_ptr<std::vector<TrajectorySeed> > result(new std::vector<TrajectorySeed>());
+
+//	Get vector of Detector layers once:
+	std::vector<BarrelDetLayer const*> const& tob = measurementTracker_->geometricSearchTracker()->tobLayers();
+	std::vector<ForwardDetLayer const*> const& tecPositive = measurementTracker_->geometricSearchTracker()->posTecLayers();
+	std::vector<ForwardDetLayer const*> const& tecNegative = measurementTracker_->geometricSearchTracker()->negTecLayers();
+
+//	Get the suitable propagators:
+	std::unique_ptr<Propagator> propagatorAlong = SetPropagationDirection(*propagatorAlong_,alongMomentum);
+	std::unique_ptr<Propagator> propagatorOpposite = SetPropagationDirection(*propagatorOpposite_,oppositeToMomentum);
+
+//	Loop over the L2's and making seeds for all of them:
+//	edm::LogDebug(theCategory) << "TSGForOI::produce: Number of L2's: " << l2TrackCol->size();
+	for (unsigned int l2TrackColIndex(0);l2TrackColIndex!=l2TrackCol->size();++l2TrackColIndex){
+		const reco::TrackRef l2(l2TrackCol, l2TrackColIndex);
+		std::auto_ptr<std::vector<TrajectorySeed> > out(new std::vector<TrajectorySeed>());
+
+		FreeTrajectoryState fts = trajectoryStateTransform::initialFreeState(*l2, magfield_.product());
+		dummyPlane_->move(fts.position() - dummyPlane_->position());
+		TrajectoryStateOnSurface tsosAtIP = TrajectoryStateOnSurface(fts, *dummyPlane_);
+
+		FreeTrajectoryState notUpdatedFts = trajectoryStateTransform::innerFreeState(*l2,magfield_.product());
+		dummyPlane_->move(notUpdatedFts.position() - dummyPlane_->position());
+		TrajectoryStateOnSurface tsosAtMuonSystem = TrajectoryStateOnSurface(notUpdatedFts, *dummyPlane_);
+
+		numSeedsMade_=0;
+		foundCompatibleDet_=false;
+		analysedL2_ = false;
+
+//		BARREL
+		if (fabs(l2->eta()) < maxEtaForTOB_) {
+			layerCount_ = 0;
+			for (auto it=tob.rbegin(); it!=tob.rend(); ++it) {	//This goes from outermost to innermost layer
+				findSeedsOnLayer(**it, tsosAtIP, tsosAtMuonSystem, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+			}
+		}
+
+//		Reset Number of seeds if in overlap region:
+		if (fabs(l2->eta())>minEtaForTEC_ && fabs(l2->eta())<maxEtaForTOB_){
+			numSeedsMade_=0;
+		}
+
+//		ENDCAP+
+		if (l2->eta() > minEtaForTEC_) {
+			layerCount_ = 0;
+			for (auto it=tecPositive.rbegin(); it!=tecPositive.rend(); ++it) {
+				findSeedsOnLayer(**it, tsosAtIP, tsosAtMuonSystem, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+			}
+		}
+
+//		ENDCAP-
+		if (l2->eta() < -minEtaForTEC_) {
+			layerCount_ = 0;
+			for (auto it=tecNegative.rbegin(); it!=tecNegative.rend(); ++it) {
+				findSeedsOnLayer(**it, tsosAtIP, tsosAtMuonSystem, *(propagatorAlong.get()), *(propagatorOpposite.get()), l2, out);
+			}
+		}
+
+		for (std::vector<TrajectorySeed>::iterator it=out->begin(); it!=out->end(); ++it){
+			result->push_back(*it);
+		}
+
+	} //L2Collection
+//	edm::LogDebug(theCategory) << "TSGForOI::produce: number of seeds made: " << result->size();
+
+	iEvent.put(result);
+}
+
+void TSGForOI::findSeedsOnLayer(const GeometricSearchDet &layer,
+		const TrajectoryStateOnSurface &tsosAtIP,
+		const TrajectoryStateOnSurface &tsosAtMuonSystem,
+		const Propagator& propagatorAlong,
+		const Propagator& propagatorOpposite,
+		const reco::TrackRef l2,
+		std::auto_ptr<std::vector<TrajectorySeed> >& out) {
+
+	if (numSeedsMade_<numOfMaxSeeds_){
+		double errorSFHits_=1.0;
+		double errorSFHitless_=1.0;
+		if (!adjustErrorsDyanmicallyForHits_) errorSFHits_ = fixedErrorRescalingForHits_;
+		if (!adjustErrorsDyanmicallyForHitless_) errorSFHitless_ = fixedErrorRescalingForHitless_;
+
+//		Hitless:
+		std::vector< GeometricSearchDet::DetWithState > dets;
+		layer.compatibleDetsV(tsosAtIP, propagatorAlong, *estimator_, dets);
+		// See if we need to adjust the Error Scale Factors:
+		if (!analysedL2_ && adjustErrorsDyanmicallyForHitless_ && dets.size()>0){
+			if (!dets.front().second.isValid()){
+				edm::LogError(theCategory) << "ERROR!: TSOS for SF is not valid!";
+			}
+			else{
+				const TrajectoryStateOnSurface tsosOnLayer = dets.front().second;
+				errorSFHitless_=calculateSFFromL2(layer,tsosAtMuonSystem,tsosOnLayer,propagatorOpposite,l2);
+				analysedL2_=true;
+			}
+		}
+		if (useHitlessSeeds_){
+			// Fill first seed from L2 using only state information:
+			if (!foundCompatibleDet_ && dets.size()>0){
+				if (!dets.front().second.isValid()){
+					edm::LogError(theCategory) << "ERROR!: Hitless TSOS is not valid!";
+				}
+				else{
+					dets.front().second.rescaleError(errorSFHitless_);
+					PTrajectoryStateOnDet const& PTSOD = trajectoryStateTransform::persistentState(dets.front().second,dets.front().first->geographicalId().rawId());
+					TrajectorySeed::recHitContainer rHC;
+					out->push_back(TrajectorySeed(PTSOD,rHC,oppositeToMomentum));
+					foundCompatibleDet_=true;
+				}
+			}
+			numSeedsMade_=out->size();
+		}
+
+//		Hits:
+		if (numSeedsMade_<numOfMaxSeeds_ && layerCount_<numOfLayersToTry_){
+			if (makeSeedsFromHits(layer, tsosAtIP, *out, propagatorAlong, *measurementTracker_, errorSFHits_)) {
+				++layerCount_; //Sucessfully made seeds from hits using this layer
+			}
+		}
+		numSeedsMade_=out->size();
+	}
+
+}
+
+double TSGForOI::calculateSFFromL2(const GeometricSearchDet& layer,
+		const TrajectoryStateOnSurface& tsosAtMuonSystem,
+		const TrajectoryStateOnSurface& tsosOnLayer,
+		const Propagator& propagatorOpposite,
+		const reco::TrackRef track){
+
+//    std::cout << "calculateSFFromL2" << std::endl;
+	double theSF=1.0;
+
+//	L2 direction vs pT blowup - as was previously done:
+	if (track->pt()<13) theSF=3.0;
+	if (track->pt()>13 && track->pt()<30){
+		if (fabs(track->eta())<1.0) theSF=5.0;
+		if (fabs(track->eta())>1.0 && fabs(track->eta())<1.4) theSF=4.0;
+		if (fabs(track->eta())>1.4) theSF=5.0;
+	}
+	if (track->pt()>30 && track->pt()<70){
+		if (fabs(track->eta())<1.0) theSF=10.0;
+		if (fabs(track->eta())>1.0 && fabs(track->eta())<1.4) theSF=7.0;
+		if (fabs(track->eta())>1.4) theSF=10.0;
+	}
+	if (track->pt()>70) theSF=10.0;
+
+////	L2 TSOS Comparison blowup:
+////	For this particular layer find the DetWithState using a propagation directly from the Muon system of a L2 without updating at vetex:
+//	std::vector< GeometricSearchDet::DetWithState > detsFromNotUpdated;
+//	layer.compatibleDetsV(tsosAtMuonSystem, propagatorOpposite, *estimator_, detsFromNotUpdated);
+//
+//    std::cout << "calculateSFFromL2:: test tsosOnLayer" << std::endl;
+//
+//	std::cout << "tsosOnLayer isValid: " << tsosOnLayer.isValid()
+//			<< " x(): " << tsosOnLayer.globalPosition().x()
+//			<< " y(): " << tsosOnLayer.globalPosition().y()
+//			<< " z(): " << tsosOnLayer.globalPosition().z()
+//			<< std::endl;
+//
+//
+//	if (detsFromNotUpdated.size()>0){ //XXX Warning: check to see if on same det -> this prop rarely works, maybe due to estimator?
+//		const TrajectoryStateOnSurface TSOSNU = detsFromNotUpdated.front().second;
+//
+//		std::cout << "TSOSNU isValid: " << TSOSNU.isValid()
+//				<< " x(): " << TSOSNU.globalPosition().x()
+//				<< " y(): " << TSOSNU.globalPosition().y()
+//				<< " z(): " << TSOSNU.globalPosition().z()
+//				<< std::endl;
+//
+//		double diffDeltaR = deltaR(tsosOnLayer.globalMomentum(),TSOSNU.globalMomentum());
+//		double diffEta = fabs(tsosOnLayer.globalMomentum().eta()-TSOSNU.globalMomentum().eta());
+//		double diffPhi = fabs(tsosOnLayer.globalMomentum().phi()-TSOSNU.globalMomentum().phi());
+//		double diffPositionX = fabs(tsosOnLayer.globalPosition().x()-TSOSNU.globalPosition().x());
+//		double diffPositionY = fabs(tsosOnLayer.globalPosition().y()-TSOSNU.globalPosition().y());
+//		double diffPositionZ = fabs(tsosOnLayer.globalPosition().z()-TSOSNU.globalPosition().z());
+//		std::cout << "Difference in dR: " << diffDeltaR
+//				<< " diffEta: " << diffEta
+//				<< " diffPhi: " << diffPhi
+//				<< " x diff: " << diffPositionX
+//				<< " y diff: " << diffPositionY
+//				<< " z diff: " << diffPositionZ
+//				<< std::endl;
+//		if (diffDeltaR>0.03){
+//			theSF=theSF*5.0;
+//		}
+//	}
+
+//    std::cout << "calculateSFFromL2 theSF = " << theSF << std::endl;
+	return theSF;
+}
+
+
+int TSGForOI::makeSeedsFromHits(const GeometricSearchDet &layer,
+		const TrajectoryStateOnSurface &tsosAtIP,
+		std::vector<TrajectorySeed> &out,
+		const Propagator& propagatorAlong,
+		const MeasurementTrackerEvent &measurementTracker,
+		const double errorSF) {
+
+	std::vector< GeometricSearchDet::DetWithState > dets;
+	layer.compatibleDetsV(tsosAtIP, propagatorAlong, *estimator_, dets);
+
+//	Find Measurements on each DetWithState:
+	std::vector<TrajectoryMeasurement> meas;
+	for (std::vector<GeometricSearchDet::DetWithState>::iterator it=dets.begin(); it!=dets.end(); ++it) {
+		MeasurementDetWithData det = measurementTracker.idToDet(it->first->geographicalId());
+		if (det.isNull()) {
+			edm::LogError(theCategory) << "In makeSeedsFromHits: det.isNull() " << it->first->geographicalId().rawId();
+			continue;
+		}
+		if (!it->second.isValid()) continue;	//Skip if TSOS is not valid
+
+//		Error Rescaling:
+		it->second.rescaleError(errorSF);
+
+		std::vector < TrajectoryMeasurement > mymeas = det.fastMeasurements(it->second, tsosAtIP, propagatorAlong, *estimator_);	//Second TSOS is not used
+		for (std::vector<TrajectoryMeasurement>::const_iterator it2 = mymeas.begin(), ed2 = mymeas.end(); it2 != ed2; ++it2) {
+			if (it2->recHit()->isValid()) meas.push_back(*it2);	//Only save those which are valid
+		}
+	}
+
+//	Update TSOS using TMs after sorting, then create Trajectory Seed and put into vector:
+	unsigned int found = 0;
+	std::sort(meas.begin(), meas.end(), TrajMeasLessEstim());
+	for (std::vector<TrajectoryMeasurement>::const_iterator it=meas.begin(); it!=meas.end(); ++it) {
+		TrajectoryStateOnSurface updatedTSOS = updator_->update(it->forwardPredictedState(), *it->recHit());
+		if (updatedTSOS.isValid()) {
+			edm::OwnVector<TrackingRecHit> seedHits;
+			seedHits.push_back(*it->recHit()->hit());
+			PTrajectoryStateOnDet const& pstate = trajectoryStateTransform::persistentState(updatedTSOS, it->recHit()->geographicalId().rawId());
+			TrajectorySeed seed(pstate, std::move(seedHits), oppositeToMomentum);
+			out.push_back(seed);
+			found++;
+			if (found == numOfHitsToTry_) break;
+		}
+	}
+	return found;
+}
+
+
+void TSGForOI::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("src",edm::InputTag("hltL2Muons","UpdatedAtVtx"));
+  desc.add<int>("layersToTry",1);
+  desc.add<double>("fixedErrorRescaleFactorForHitless",5.0);
+  desc.add<int>("hitsToTry",1);
+  desc.add<bool>("adjustErrorsDyanmicallyForHits",false);
+  desc.add<bool>("adjustErrorsDyanmicallyForHitless",false);
+  desc.add<edm::InputTag>("MeasurementTrackerEvent",edm::InputTag("hltSiStripClusters"));
+  desc.add<bool>("UseHitlessSeeds",true);
+  desc.add<std::string>("estimator","hltESPChi2MeasurementEstimator100");
+  desc.add<double>("maxEtaForTOB",1.2);
+  desc.add<double>("minEtaForTEC",0.8);
+  desc.addUntracked<bool>("debug",true);
+  desc.add<double>("fixedErrorRescaleFactorForHits",2.0);
+  desc.add<unsigned int>("maxSeeds",1);
+  descriptions.add("test",desc);
+}
+
+DEFINE_FWK_MODULE(TSGForOI);

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -1,0 +1,130 @@
+/**
+  \class    TSGForOI
+  \brief    Create L3MuonTrajectorySeeds from L2 Muons updated at vertex in an outside in manner
+  \author   Benjamin Radburn-Smith
+ */
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
+#include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+
+#include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
+#include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryStateUpdator.h"
+#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
+#include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
+#include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
+#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
+#include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
+
+#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
+#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
+
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+
+class TSGForOI : public edm::stream::EDProducer<> {
+public:
+	explicit TSGForOI(const edm::ParameterSet & iConfig);
+	virtual ~TSGForOI();
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+	virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+private:
+	/// Labels for input collections
+	edm::EDGetTokenT<reco::TrackCollection> src_;
+
+	/// Maximum number of seeds for each L2
+	unsigned int numOfMaxSeeds_;
+
+	/// How many layers to try
+	unsigned int numOfLayersToTry_;
+
+	/// How many hits to try on same layer
+	unsigned int numOfHitsToTry_;
+
+	/// How much to rescale errors from STA for fixed option
+	double fixedErrorRescalingForHits_;
+	double fixedErrorRescalingForHitless_;
+
+	/// Whether or not to use an automatically calculated SF value
+	bool adjustErrorsDyanmicallyForHits_;
+	bool adjustErrorsDyanmicallyForHitless_;
+
+	///Estimator used to find dets and TrajectoryMeasurements
+	std::string estimatorName_;
+
+	std::string trackerPropagatorName_;
+	std::string muonPropagatorName_;
+	edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
+	std::string measurementTrackerName_;
+
+	double minEtaForTEC_, maxEtaForTOB_;
+
+	/// Switch to use hitless seeds or not
+	bool useHitlessSeeds_;
+
+	/// Surface used to make a TSOS at the PCA to the beamline
+	Plane::PlanePointer dummyPlane_;
+
+	/// KFUpdator defined in constructor
+	const TrajectoryStateUpdator* updator_;
+
+	bool foundCompatibleDet_;
+	bool analysedL2_;
+
+	unsigned int numSeedsMade_;
+	unsigned int layerCount_;
+
+	std::string theCategory;
+
+	edm::ESHandle<MagneticField>          magfield_;
+	edm::ESHandle<Propagator>             propagatorAlong_;
+	edm::ESHandle<Propagator>             propagatorOpposite_;
+	edm::ESHandle<GlobalTrackingGeometry> geometry_;
+	edm::Handle<MeasurementTrackerEvent> measurementTracker_;
+
+	/// Function to find seeds on a given layer
+	void findSeedsOnLayer(const GeometricSearchDet &layer,
+			const TrajectoryStateOnSurface &tsosAtIP,
+			const TrajectoryStateOnSurface &tsosAtMuonSystem,
+			const Propagator& propagatorAlong,
+			const Propagator& propagatorOpposite,
+			const reco::TrackRef l2,
+			std::auto_ptr<std::vector<TrajectorySeed> >& seeds);
+
+	/// Function used to calculate the dynamic error SF by analysing the L2
+	double calculateSFFromL2(const GeometricSearchDet& layer,
+			const TrajectoryStateOnSurface &tsosAtMuonSystem,
+			const TrajectoryStateOnSurface &tsosOnLayer,
+			const Propagator& propagatorOpposite,
+//			const reco::Track& track);
+			const reco::TrackRef track);
+
+	/// Function to find hits on layers and create seeds from updated TSOS
+	int makeSeedsFromHits(const GeometricSearchDet &layer,
+			const TrajectoryStateOnSurface &state,
+			std::vector<TrajectorySeed> &out,
+			const Propagator& propagatorAlong,
+			const MeasurementTrackerEvent &mte,
+			double errorSF);
+
+	edm::ESHandle<Chi2MeasurementEstimatorBase>   estimator_;
+};

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGForOI.h
@@ -4,82 +4,70 @@
   \author   Benjamin Radburn-Smith
  */
 
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/Math/interface/deltaR.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
-
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "Geometry/CommonDetUnit/interface/GlobalTrackingGeometry.h"
 #include "Geometry/Records/interface/GlobalTrackingGeometryRecord.h"
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
-
+#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
+#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
 #include "TrackingTools/KalmanUpdators/interface/KFUpdator.h"
 #include "TrackingTools/MeasurementDet/interface/MeasurementDet.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryStateUpdator.h"
-#include "TrackingTools/PatternTools/interface/TrajectoryMeasurement.h"
 #include "TrackingTools/PatternTools/interface/TrajMeasLessEstim.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-#include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
-
-#include "RecoTracker/MeasurementDet/interface/MeasurementTracker.h"
-#include "RecoTracker/MeasurementDet/interface/MeasurementTrackerEvent.h"
-#include "RecoTracker/TkDetLayers/interface/GeometricSearchTracker.h"
-
-#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "TrackingTools/KalmanUpdators/interface/Chi2MeasurementEstimator.h"
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include "DataFormats/Math/interface/deltaR.h"
 
 
 class TSGForOI : public edm::stream::EDProducer<> {
 public:
 	explicit TSGForOI(const edm::ParameterSet & iConfig);
 	virtual ~TSGForOI();
-    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-	virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+	virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override;
 private:
 	/// Labels for input collections
-	edm::EDGetTokenT<reco::TrackCollection> src_;
+	const edm::EDGetTokenT<reco::TrackCollection> src_;
 
 	/// Maximum number of seeds for each L2
-	unsigned int numOfMaxSeeds_;
+	const unsigned int numOfMaxSeeds_;
 
 	/// How many layers to try
-	unsigned int numOfLayersToTry_;
+	const unsigned int numOfLayersToTry_;
 
 	/// How many hits to try on same layer
-	unsigned int numOfHitsToTry_;
+	const unsigned int numOfHitsToTry_;
 
 	/// How much to rescale errors from STA for fixed option
-	double fixedErrorRescalingForHits_;
-	double fixedErrorRescalingForHitless_;
+	const double fixedErrorRescalingForHits_;
+	const double fixedErrorRescalingForHitless_;
 
 	/// Whether or not to use an automatically calculated SF value
-	bool adjustErrorsDyanmicallyForHits_;
-	bool adjustErrorsDyanmicallyForHitless_;
+	const bool adjustErrorsDyanmicallyForHits_;
+	const bool adjustErrorsDyanmicallyForHitless_;
 
 	///Estimator used to find dets and TrajectoryMeasurements
-	std::string estimatorName_;
+	const std::string estimatorName_;
 
-	std::string trackerPropagatorName_;
-	std::string muonPropagatorName_;
-	edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
-	std::string measurementTrackerName_;
+	const edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerTag_;
 
-	double minEtaForTEC_, maxEtaForTOB_;
+	/// Minimum eta value to activate searching in the TEC
+	const double minEtaForTEC_;
+
+	/// Maximum eta value to activate searching in the TOB
+	const double maxEtaForTOB_;
 
 	/// Switch to use hitless seeds or not
-	bool useHitlessSeeds_;
+	const bool useHitlessSeeds_;
 
 	/// Surface used to make a TSOS at the PCA to the beamline
 	Plane::PlanePointer dummyPlane_;
@@ -87,9 +75,9 @@ private:
 	/// KFUpdator defined in constructor
 	const TrajectoryStateUpdator* updator_;
 
+	/// Counters and flags for the implementation
 	bool foundCompatibleDet_;
 	bool analysedL2_;
-
 	unsigned int numSeedsMade_;
 	unsigned int layerCount_;
 
@@ -99,7 +87,7 @@ private:
 	edm::ESHandle<Propagator>             propagatorAlong_;
 	edm::ESHandle<Propagator>             propagatorOpposite_;
 	edm::ESHandle<GlobalTrackingGeometry> geometry_;
-	edm::Handle<MeasurementTrackerEvent> measurementTracker_;
+	edm::Handle<MeasurementTrackerEvent>  measurementTracker_;
 
 	/// Function to find seeds on a given layer
 	void findSeedsOnLayer(const GeometricSearchDet &layer,
@@ -115,7 +103,6 @@ private:
 			const TrajectoryStateOnSurface &tsosAtMuonSystem,
 			const TrajectoryStateOnSurface &tsosOnLayer,
 			const Propagator& propagatorOpposite,
-//			const reco::Track& track);
 			const reco::TrackRef track);
 
 	/// Function to find hits on layers and create seeds from updated TSOS

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -1,74 +1,68 @@
 #include "TSGFromL2Muon.h"
 
 TSGFromL2Muon::TSGFromL2Muon(const edm::ParameterSet& cfg)
-  : theConfig(cfg), theService(0), theRegionBuilder(0), theTkSeedGenerator(0), theSeedCleaner(0)
-{
+  : theConfig(cfg), theService(0), theRegionBuilder(0), theTkSeedGenerator(0), theSeedCleaner(0) {
   produces<L3MuonTrajectorySeedCollection>();
+
+  edm::ConsumesCollector iC  = consumesCollector();
 
   edm::ParameterSet serviceParameters = cfg.getParameter<edm::ParameterSet>("ServiceParameters");
   theService = new MuonServiceProxy(serviceParameters);
 
+  //Pt and P cuts
   thePtCut = cfg.getParameter<double>("PtCut");
   thePCut = cfg.getParameter<double>("PCut");
 
-  theL2CollectionLabel = cfg.getParameter<edm::InputTag>("MuonCollectionLabel");
-
-  edm::ConsumesCollector iC  = consumesCollector();
-
-  //region builder
+  //Region builder
   edm::ParameterSet regionBuilderPSet = theConfig.getParameter<edm::ParameterSet>("MuonTrackingRegionBuilder");
   //ability to no define a region
   if (!regionBuilderPSet.empty()){
     theRegionBuilder = new MuonTrackingRegionBuilder(regionBuilderPSet, iC);
   }
 
-  //seed generator
-  //std::string seedGenPSetLabel = theConfig.getParameter<std::string>("tkSeedGenerator");
-  //edm::ParameterSet seedGenPSet = theConfig.getParameter<edm::ParameterSet>(seedGenPSetLabel);
+  //Seed generator
   edm::ParameterSet seedGenPSet = theConfig.getParameter<edm::ParameterSet>("TkSeedGenerator");
   std::string seedGenName = seedGenPSet.getParameter<std::string>("ComponentName");
-
   theTkSeedGenerator = TrackerSeedGeneratorFactory::get()->create(seedGenName, seedGenPSet,iC);  
   
-  //seed cleaner
+  //Seed cleaner
   edm::ParameterSet trackerSeedCleanerPSet = theConfig.getParameter<edm::ParameterSet>("TrackerSeedCleaner");
-  //to activate or not the cleaner
+
+  //To activate or not the cleaner
   if (!trackerSeedCleanerPSet.empty()){
     theSeedCleaner = new TrackerSeedCleaner(trackerSeedCleanerPSet,iC);
   }
 
-
+  //L2 collection
+  theL2CollectionLabel = cfg.getParameter<edm::InputTag>("MuonCollectionLabel");
   l2muonToken = consumes<reco::TrackCollection>(theL2CollectionLabel);
+
 }
 
-TSGFromL2Muon::~TSGFromL2Muon()
-{
+
+TSGFromL2Muon::~TSGFromL2Muon(){
   delete theService;
   if (theSeedCleaner) delete theSeedCleaner;
   delete theTkSeedGenerator;
   if (theRegionBuilder) delete theRegionBuilder;
 }
 
-void TSGFromL2Muon::beginRun(const edm::Run & run, const edm::EventSetup&es)
-{
+
+void TSGFromL2Muon::beginRun(const edm::Run & run, const edm::EventSetup&es){
   //update muon proxy service
   theService->update(es);
-  
-  if (theRegionBuilder) theRegionBuilder->init(theService);
   theTkSeedGenerator->init(theService);
   if (theSeedCleaner) theSeedCleaner->init(theService);
-
 }
 
-void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es)
-{
+
+void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es){
   std::auto_ptr<L3MuonTrajectorySeedCollection> result(new L3MuonTrajectorySeedCollection());
 
   //Retrieve tracker topology from geometry
   edm::ESHandle<TrackerTopology> tTopoHand;
   es.get<IdealGeometryRecord>().get(tTopoHand);
-  const TrackerTopology *tTopo=tTopoHand.product();
-
+  const TrackerTopology* tTopo=tTopoHand.product();
 
   //intialize tools
   theService->update(es);
@@ -80,12 +74,10 @@ void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es)
   edm::Handle<reco::TrackCollection> l2muonH;
   ev.getByToken(l2muonToken ,l2muonH); 
 
-  // produce trajectoryseed collection
-  unsigned int imu=0;
-  unsigned int imuMax=l2muonH->size();
-  LogDebug("TSGFromL2Muon")<<imuMax<<" l2 tracks.";
+  // produce trajectory seed collection
+  LogDebug("TSGFromL2Muon")<<l2muonH->size()<<" l2 tracks.";
 
-  for (;imu!=imuMax;++imu){
+  for (unsigned int imu=0; imu!=l2muonH->size(); ++imu){
     //make a ref to l2 muon
     reco::TrackRef muRef(l2muonH, imu);
     
@@ -96,39 +88,37 @@ void TSGFromL2Muon::produce(edm::Event& ev, const edm::EventSetup& es)
     
     //define the region of interest
     std::unique_ptr<RectangularEtaPhiTrackingRegion> region;
-    if(theRegionBuilder){
+    if (theRegionBuilder) {
       region.reset(theRegionBuilder->region(muRef));
     }
     
-    //get the seeds
+    //Make seeds container
     std::vector<TrajectorySeed> tkSeeds;
-    //make this stupid TrackCand
+
+    //Make TrackCands
     std::pair<const Trajectory*,reco::TrackRef> staCand((Trajectory*)(0), muRef);
+
+    //Run seed generator to fill seed container
     theTkSeedGenerator->trackerSeeds(staCand, *region, tTopo,tkSeeds);
 
     //Seed Cleaner From Direction
-    //clean them internatly
-    if(theSeedCleaner){
-       theSeedCleaner->clean(muRef,*region,tkSeeds);
-       LogDebug("TSGFromL2Muon") << tkSeeds.size() << " seeds for this L2 afther cleaning.";
+    if (theSeedCleaner) {
+      theSeedCleaner->clean(muRef,*region,tkSeeds);
     }
 
-    unsigned int is=0;
-    unsigned int isMax=tkSeeds.size();
-    LogDebug("TSGFromL2Muon")<<isMax<<" seeds for this L2.";
-    for (;is!=isMax;++is){
+    LogDebug("TSGFromL2Muon")<<tkSeeds.size()<<" seeds for this L2.";
+    for (unsigned int is=0; is != tkSeeds.size(); ++is){
       result->push_back( L3MuonTrajectorySeed(tkSeeds[is], muRef));
-    }//tkseed loop
+    }
     
-  }//l2muon loop
+  }
   
-
-  //ADDME
-  //remove seed duplicate, keeping the ref to L2
+  //ADDME: remove seed duplicate, keeping the ref to L2
 
   LogDebug("TSGFromL2Muon")<<result->size()<<" trajectory seeds to the events";
 
   //put in the event
   ev.put(result);
+
 }
 

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.cc
@@ -1,5 +1,13 @@
 #include "TSGFromL2Muon.h"
 
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
+#include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h"
+#include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGeneratorFactory.h"
+#include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedCleaner.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
+
 TSGFromL2Muon::TSGFromL2Muon(const edm::ParameterSet& cfg)
   : theConfig(cfg), theService(0), theRegionBuilder(0), theTkSeedGenerator(0), theSeedCleaner(0) {
   produces<L3MuonTrajectorySeedCollection>();

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
@@ -1,31 +1,24 @@
 #ifndef RecoMuon_TrackerSeedGenerator_TSGFromL2Muon_H
 #define RecoMuon_TrackerSeedGenerator_TSGFromL2Muon_H
 
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "RecoTracker/TkTrackingRegions/interface/RectangularEtaPhiTrackingRegion.h"
-
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
 #include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-#include <vector>
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGeneratorFactory.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedCleaner.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
+#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
 
-
+#include <vector>
 
 namespace edm { class ParameterSet; class Event; class EventSetup; }
 
@@ -35,29 +28,26 @@ class MuonTrackingRegionBuilder;
 class TrackerSeedCleaner;
 
 //
-// generate seeds corresponding to L2 muons
+// Generate tracker seeds from L2 muons
 //
-
 class TSGFromL2Muon : public edm::EDProducer {
-public:
-  TSGFromL2Muon(const edm::ParameterSet& cfg);
-  virtual ~TSGFromL2Muon();
-  virtual void beginRun(const edm::Run & run, const edm::EventSetup&es) override;
-  virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
- 
-private:
-  edm::ParameterSet theConfig;
-  edm::InputTag theL2CollectionLabel;
+    
+  public:
 
-  MuonServiceProxy* theService;
-  double thePtCut,thePCut;
-  MuonTrackingRegionBuilder* theRegionBuilder;
-  TrackerSeedGenerator* theTkSeedGenerator;
-  TrackerSeedCleaner* theSeedCleaner;
+    TSGFromL2Muon(const edm::ParameterSet& cfg);
+    virtual ~TSGFromL2Muon();
+    virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
+  private:
 
-  edm::EDGetTokenT<reco::TrackCollection> l2muonToken;
-
-
+    edm::ParameterSet theConfig;
+    edm::InputTag theL2CollectionLabel;
+    MuonServiceProxy* theService;
+    double thePtCut,thePCut;
+    MuonTrackingRegionBuilder* theRegionBuilder;
+    TrackerSeedGenerator* theTkSeedGenerator;
+    TrackerSeedCleaner* theSeedCleaner;
+    edm::EDGetTokenT<reco::TrackCollection> l2muonToken;
 };
 #endif

--- a/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
+++ b/RecoMuon/TrackerSeedGenerator/plugins/TSGFromL2Muon.h
@@ -1,23 +1,15 @@
 #ifndef RecoMuon_TrackerSeedGenerator_TSGFromL2Muon_H
 #define RecoMuon_TrackerSeedGenerator_TSGFromL2Muon_H
 
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
-#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
-#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
-
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeed.h"
+#include "DataFormats/MuonSeed/interface/L3MuonTrajectorySeedCollection.h"
 #include "RecoMuon/TrackingTools/interface/MuonServiceProxy.h"
-#include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGenerator.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedGeneratorFactory.h"
 #include "RecoMuon/TrackerSeedGenerator/interface/TrackerSeedCleaner.h"
-#include "RecoMuon/GlobalTrackingTools/interface/MuonTrackingRegionBuilder.h"
-
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include <vector>
 
 namespace edm { class ParameterSet; class Event; class EventSetup; }
@@ -30,17 +22,15 @@ class TrackerSeedCleaner;
 //
 // Generate tracker seeds from L2 muons
 //
-class TSGFromL2Muon : public edm::EDProducer {
+class TSGFromL2Muon : public edm::stream::EDProducer<> {
     
   public:
-
     TSGFromL2Muon(const edm::ParameterSet& cfg);
     virtual ~TSGFromL2Muon();
     virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
     virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
   private:
-
     edm::ParameterSet theConfig;
     edm::InputTag theL2CollectionLabel;
     MuonServiceProxy* theService;


### PR DESCRIPTION
Here is the updated Muon HLT L3 reconstruction code. It contains a number of classes which have been modified that the current Cascade algorithm uses in addition to new classes. The modifications and new code can be used as part of a new algorithm which will replace the Cascade algorithm. However, the current Cascade algorithm can still be used.

Relevant presentations include: https://indico.cern.ch/event/297801 and https://indico.cern.ch/event/351559

The code has been updated for multithreading and updated with fillDescriptions() also.
