### PR TITLE
Avoid segfault

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -401,7 +401,7 @@ namespace edm {
     if (*ti_ == typeid(invalidType)) {
       return false;
     }
-    return (name().back() == ']');
+    return (type_ != nullptr && name().back() == ']');
   }
 
   bool


### PR DESCRIPTION
Fix to bug in TypeWithDict::isArray() that can cause segfaults under rare circumstances.   The segfault only showed up (so far) in the unit test of PhysicsTools/PatAlgos.
Please merge this request as soon as convenient.
