### PR TITLE
Add array dimension information

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -10,6 +10,7 @@ persisted across invocations of the program.
 
 ----------------------------------------------------------------------*/
 #include "FWCore/Utilities/interface/IterWithDict.h"
+#include "FWCore/Utilities/interface/value_ptr.h"
 
 #include "TBaseClass.h"
 #include "TClass.h"
@@ -52,6 +53,7 @@ private:
   TClass* class_;
   TEnum* enum_;
   TDataType* dataType_;
+  value_ptr<std::vector<size_t> > arrayDimensions_;
   long property_;
 public:
   static TypeWithDict byName(std::string const& name);

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -182,6 +182,7 @@ namespace edm {
     class_(nullptr),
     enum_(nullptr),
     dataType_(nullptr),
+    arrayDimensions_(nullptr),
     property_(0L) {
   }
 
@@ -191,6 +192,7 @@ namespace edm {
     class_(rhs.class_),
     enum_(rhs.enum_),
     dataType_(rhs.dataType_),
+    arrayDimensions_(rhs.arrayDimensions_),
     property_(rhs.property_) {
   }
 
@@ -212,6 +214,7 @@ namespace edm {
       class_ = rhs.class_;
       enum_ = rhs.enum_;
       dataType_ = rhs.dataType_;
+      arrayDimensions_ = rhs.arrayDimensions_;
       property_ = rhs.property_;
     }
     return *this;
@@ -226,6 +229,7 @@ namespace edm {
     class_(TClass::GetClass(ti)),
     enum_(nullptr),
     dataType_(TDataType::GetDataType(TDataType::GetType(ti))),
+    arrayDimensions_(nullptr),
     property_(property) {
 
     if(class_ != nullptr) {
@@ -268,6 +272,7 @@ namespace edm {
     class_(cl),
     enum_(nullptr),
     dataType_(nullptr),
+    arrayDimensions_(nullptr),
     property_(property) {
   }
 
@@ -277,6 +282,7 @@ namespace edm {
     class_(nullptr),
     enum_(enm),
     dataType_(nullptr),
+    arrayDimensions_(nullptr),
     property_(property) {
   }
 
@@ -293,6 +299,7 @@ namespace edm {
     class_(nullptr),
     enum_(nullptr),
     dataType_(nullptr),
+    arrayDimensions_(nullptr),
     property_(property) {
 
     if (!ttype) {


### PR DESCRIPTION
In order to update TypeWithDict so that it can handle C-style arrays without resorting to header parsing, it is necessary to add the array dimension information to TypeWithDict.  This pull request simply adds the new data member.  It does not actually use it yet.
It is convenient to add the data member separately, because modifying TypeWithDict.h here causes over 820 packages to rebuild.  Once this request is in an IB, the feature can then be developed and tested without further modifying a header file.
Please merge this tivial request as soon as convenient.
