### PR TITLE
Avoid header parsing for arrays

### DIFF
--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -39,7 +39,7 @@ namespace edm {
 
   TypeWithDict
   MemberWithDict::declaringType() const {
-    return TypeWithDict(dataMember_->GetClass(), dataMember_->Property());
+    return TypeWithDict(dataMember_->GetClass());
   }
 
   bool


### PR DESCRIPTION
Modify TypeWithDict for ROOT6 so that it can represent C-style arrays without resorting to header parsing.
This is the last major step needed to get rid of the CMS specific ROOT6 patch, although some minor steps remain.
This pull request also fixes a long standing bug in MemberWithdict::declaringType() that was discovered when testing the above change.  The properties of the data member are not properties of the containing class, and should not be passed to the TypeWithDict constructor.  This part of the pull request is not ROOT6 specific, and will be fixed in 7_4_X in a separate pull request.
Please merge this request as soon as convenient.
