### PR TITLE
Bug fix. Properties of data member are not properties of containing clas...

### DIFF
--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -35,7 +35,7 @@ namespace edm {
 
   TypeWithDict
   MemberWithDict::declaringType() const {
-    return TypeWithDict(dataMember_->GetClass(), dataMember_->Property());
+    return TypeWithDict(dataMember_->GetClass());
   }
 
   bool


### PR DESCRIPTION
This is a bug fix for MemberWithDict::declaringType().  Given a data member of a class,  this function returns a TypeWithDict representing the type of the containing class.
The bug is that the property mask of the data member (e.g. kIsConstant, kIsPointer, etc.) is passed to the constructor of the TypeWithDict.  This is incorrect, because these are properties of the data member, not of the containing class.  This bug has existed in 6_2_X and every subsequent release cycle.  Although it is potentially serious, it is not likely to have caused problems in ROOT 5 releases because the function is called only in three places in CMSSW. In one of those places, the property mask does not matter, and in the other two places, both in CondCore/ORA, only kIsPointer matters, and there is no evidence that any of the data members there are pointers.
This pull request fixes the bug in 7_4_X.  David Lange or Chris Jones should indicate in which, if any, prior release cycles they want this fixed.
The fix is very low risk.
There is no need to port this to 7_4_ROOT6_X, because the fix has been requested there with a different pull request.
