### PR TITLE
workaround for possible ROOT bug

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -166,6 +166,13 @@ namespace edm {
       return TypeWithDict(typeid(void), property);
     }
 
+    // For a reason not understood, TClass::GetClass sometimes cannot find std::type_info
+    // by name.  This simple workaround bypasses the problem.
+    // The problem really should be debugged.  (testORA12)
+    if(name == "std::type_info") {
+      return TypeWithDict(typeid(std::type_info), property);
+    }
+
     // std::cerr << "DEBUG BY NAME: " << name << std::endl;
     TType* type = gInterpreter->Type_Factory(name);
     if (!gInterpreter->Type_IsValid(type)) {


### PR DESCRIPTION
In a unit test testORA_12 in package CondCore/ORA, in the ROOT6 IB, a call of TClass::GetClass("std::type_info") fails to find the class.  This is very strange, because this call works fine from the ROOT command line.  This may or may not be a ROOT bug.  I will write a JIRA ticket against ROOT for this issue.   In the meantime, this simple workaround avoids the problem, because TClass::GetClass(typeid(std::type_info)) works fine in the unit test.  Without this fix/workaround, this unit test will fail when the CMS specific ROOT patch (the TType class) is removed.

Please merge this request as soon as convenient.
