### PR TITLE
73x:: Fixes in Fireworks standalone  version for Yosemite OSX

### DIFF
--- a/Fireworks/Core/scripts/cmsShow
+++ b/Fireworks/Core/scripts/cmsShow
@@ -95,7 +95,7 @@ setupEnv()
      export CMSSW_DATA_PATH="."
      export ROOTSYS=$CMSSW_BASE/external/root 
      export LD_LIBRARY_PATH=${CMSSW_BASE}/external/gcc/lib64:${ROOTSYS}/lib:${CMSSW_BASE}/external/lib:${CMSSW_BASE}/lib:$LD_LIBRARY_PATH
-     export DYLD_FALLBACK_LIBRARY_PATH=${LD_LIBRARY_PATH}
+     export DYLD_FALLBACK_LIBRARY_PATH=/opt/X11/lib:${LD_LIBRARY_PATH}
 
      if [ -n "$DYLD_LIBRARY_PATH" ]; then
         echo "Warning: DYLD_LIBRARY_PATH not empty. Unsetting DYLD_LIBRARY_PATH." 


### PR DESCRIPTION
Location of X11 libraries has changed.
