### PR TITLE
Remove/modify superfluous member functions of FunctionWithDict.

### DIFF
--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -109,7 +109,7 @@ MethodInvoker::
 returnTypeName() const
 {
   if (isFunction_) {
-    return method_.typeOf().qualifiedName();
+    return method_.finalReturnType().qualifiedName();
   }
   return member_.typeOf().qualifiedName();
 }

--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -78,10 +78,8 @@ push(const string& name, const vector<AnyMethodArgument>& args,
       throw Exception(begin)
           << "member \"" << mem.first.name()
           << "\" return type is invalid:\n"
-          << "  member type: \""
-          <<  mem.first.typeOf().qualifiedName() << "\"\n"
           << "  return type: \""
-          << mem.first.returnType().qualifiedName() << "\"\n";
+          << mem.first.finalReturnType().qualifiedName() << "\"\n";
     }
     typeStack_.push_back(retType);
     // check for edm::Ref, edm::RefToBase, edm::Ptr

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -177,7 +177,7 @@ namespace edm {
        try {
           size_t temp; //used to hold the memory for the return value
           FunctionWithDict sizeFunc = iObject.typeOf().functionMemberByName("size");
-          assert(sizeFunc.returnType() == typeid(size_t));
+          assert(sizeFunc.finalReturnType() == typeid(size_t));
           sizeObj = ObjectWithDict(TypeWithDict(typeid(size_t)), &temp);
           sizeFunc.invoke(iObject, &sizeObj);
           //std::cout << "size of type '" << sizeObj.name() << "' " << sizeObj.typeName() << std::endl;
@@ -192,7 +192,7 @@ namespace edm {
           LogAbsolute("EventContent") << iIndent << iName << kNameValueSep << "[size=" << size << "]";//"\n";
           ObjectWithDict contained;
           std::string indexIndent = iIndent + iIndentDelta;
-          TypeWithDict atReturnType(atMember.returnType());
+          TypeWithDict atReturnType(atMember.finalReturnType());
           //std::cout << "return type " << atReturnType.name() << " size of " << atReturnType.SizeOf()
           // << " pointer? " << atReturnType.isPointer() << " ref? " << atReturnType.isReference() << std::endl;
 

--- a/FWCore/Utilities/interface/FunctionWithDict.h
+++ b/FWCore/Utilities/interface/FunctionWithDict.h
@@ -32,8 +32,6 @@ public:
   explicit operator bool() const;
   std::string name() const;
   std::string typeName() const;
-  TypeWithDict typeOf() const;
-  TypeWithDict returnType() const;
   TypeWithDict finalReturnType() const;
   bool isConst() const;
   bool isConstructor() const;

--- a/FWCore/Utilities/src/FunctionWithDict.cc
+++ b/FWCore/Utilities/src/FunctionWithDict.cc
@@ -29,17 +29,7 @@ namespace edm {
 
   std::string
   FunctionWithDict::typeName() const {
-    return function_->GetReturnTypeName();
-  }
-
-  TypeWithDict
-  FunctionWithDict::typeOf() const {
-    return TypeWithDict::byName(function_->GetReturnTypeName());
-  }
-
-  TypeWithDict
-  FunctionWithDict::returnType() const {
-    return TypeWithDict::byName(function_->GetReturnTypeName());
+    return function_->GetReturnTypeNormalizedName();
   }
 
   TypeWithDict

--- a/Fireworks/Core/src/FWTableViewManager.cc
+++ b/Fireworks/Core/src/FWTableViewManager.cc
@@ -290,13 +290,13 @@ FWTableViewManager::tableFormats(const edm::TypeWithDict &key)
          continue;
       if (!m.isConst())
          continue;
-      if (m.returnType().name() == isint)
+      if (m.finalReturnType().name() == isint)
          handle.column(m.name().c_str(), TableEntry::INT);
-      else if (m.returnType().name() == isbool)
+      else if (m.finalReturnType().name() == isbool)
          handle.column(m.name().c_str(), TableEntry::BOOL);
-      else if (m.returnType().name() == isdouble)
+      else if (m.finalReturnType().name() == isdouble)
          handle.column(m.name().c_str(), 5);
-      else if (m.returnType().name() == isfloat)
+      else if (m.finalReturnType().name() == isfloat)
          handle.column(m.name().c_str(), 3);
    }
    edm::TypeDataMembers dataMembers(key);


### PR DESCRIPTION
For historical reasons, FunctionWithDict in the ROOT 6 IB has multiple member functions that return the return type of the function.
Remove the duplicate/superfluous functions, and make sure the remaining functions resolve typedefs before returning the return type.
Please merge this request as soon as convenient.
