### PR TITLE
Make ctors public, and remove unused argument

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -62,12 +62,14 @@ private:
 public:
   TypeWithDict();
   TypeWithDict(TypeWithDict const&);
+  explicit TypeWithDict(TClass* type);
+  explicit TypeWithDict(TEnum* type);
   explicit TypeWithDict(std::type_info const&);
   explicit TypeWithDict(TMethodArg* arg);
 private:
   explicit TypeWithDict(std::type_info const&, long property);
-  explicit TypeWithDict(TClass* type, long property = 0L);
-  explicit TypeWithDict(TEnum* type, std::string const& name, long property = 0L);
+  explicit TypeWithDict(TClass* type, long property);
+  explicit TypeWithDict(TEnum* type, long property);
   explicit TypeWithDict(TMethodArg* arg, long property);
   explicit TypeWithDict(TType* type, long property);
 public:

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -155,7 +155,7 @@ namespace edm {
     // Handle enums
     TEnum* theEnum = TEnum::GetEnum(name.c_str(), TEnum::kAutoload);
     if(theEnum) {
-      return TypeWithDict(theEnum, name, property);
+      return TypeWithDict(theEnum, property);
     }
 
     // Handle built-ins
@@ -313,7 +313,10 @@ namespace edm {
     }
   }
 
-  TypeWithDict::TypeWithDict(TClass* cl, long property /*= 0L*/) :
+  TypeWithDict::TypeWithDict(TClass *cl) : TypeWithDict(cl, 0L) {
+  }
+
+  TypeWithDict::TypeWithDict(TClass* cl, long property) :
     ti_(cl->GetTypeInfo()),
     type_(nullptr),
     class_(cl),
@@ -323,7 +326,10 @@ namespace edm {
     property_(property) {
   }
 
-  TypeWithDict::TypeWithDict(TEnum* enm, std::string const& name, long property /*= 0L*/) :
+  TypeWithDict::TypeWithDict(TEnum *enm) : TypeWithDict(enm, 0L) {
+  }
+
+  TypeWithDict::TypeWithDict(TEnum* enm, long property) :
     ti_(&typeid(TypeWithDict::dummyType)),
     type_(nullptr),
     class_(nullptr),


### PR DESCRIPTION
Two constructors of TypeWithDict that should have been public were in fact private, just because they were not invoked from outside the class.
A carryover from 7_4_X in fireworks added the use of one of these ctor's, causing a compilation error and many link errors in fireworks.
Since there is no good reason for these ctor's not to be public, this pull request makes them public, thereby fixing the build errors.
The  constructor not invoked from outside the class also had an unused argument removed, and the calls modified accordingly.
Please merge this pull request as soon as convenient.
