### PR TITLE
Remove use of TType

### DIFF
--- a/CondCore/ORA/src/STLContainerStreamer.cc
+++ b/CondCore/ORA/src/STLContainerStreamer.cc
@@ -103,7 +103,7 @@ bool ora::STLContainerWriter::build( DataElement& offset,
   MappingElement::iterator iMe = m_mappingElement.find( valueName );
   if ( iMe == m_mappingElement.end() ) {
     // Try again with the name of a possible typedef
-    std::string valueName2 = valueType.unscopedNameWithTypedef();
+    std::string valueName2 = valueType.unscopedName();
     iMe = m_mappingElement.find( valueName2 );
     if ( iMe == m_mappingElement.end() ) {
       throwException( "Item for \"" + valueName + "\" not found in the mapping element",
@@ -316,7 +316,7 @@ bool ora::STLContainerReader::build( DataElement& offset, IRelationalData& ){
   MappingElement::iterator iMe = m_mappingElement.find( valueName );
   if ( iMe == m_mappingElement.end() ) {
     // Try again with the name of a possible typedef
-    std::string valueName2 = valueType.unscopedNameWithTypedef();
+    std::string valueName2 = valueType.unscopedName();
     iMe = m_mappingElement.find( valueName2 );
     if ( iMe == m_mappingElement.end() ) {
       throwException( "Item for \"" + valueName + "\" not found in the mapping element",

--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -25,8 +25,6 @@ persisted across invocations of the program.
 #include <typeinfo>
 #include <vector>
 
-class TType;
-
 namespace edm {
 
 class FunctionWithDict;
@@ -49,7 +47,6 @@ class TypeWithDict {
   typedef dummyType** invalidType; // Tag for invalid type
 private:
   std::type_info const* ti_;
-  TType* type_;
   TClass* class_;
   TEnum* enum_;
   TDataType* dataType_;
@@ -71,7 +68,6 @@ private:
   explicit TypeWithDict(TClass* type, long property);
   explicit TypeWithDict(TEnum* type, long property);
   explicit TypeWithDict(TMethodArg* arg, long property);
-  explicit TypeWithDict(TType* type, long property);
 public:
   TypeWithDict& operator=(TypeWithDict const&);
   TypeWithDict& stripConstRef();
@@ -95,7 +91,6 @@ public:
   std::string cppName() const;
   std::string unscopedName() const;
   std::string name() const;
-  std::string unscopedNameWithTypedef() const;
   std::string userClassName() const;
   std::string friendlyClassName() const;
   std::string templateName() const;


### PR DESCRIPTION
This pull request removes the use of the CMS specific ROOT6 class TType from class TypeWithDict.
This will, in principle, remove the need for the CMS specific ROOT6 patch.
Please merge this request as soon as convenient.
