### PR TITLE
Don't pass property mask

### DIFF
--- a/FWCore/Utilities/interface/TypeWithDict.h
+++ b/FWCore/Utilities/interface/TypeWithDict.h
@@ -36,9 +36,6 @@ class TypeDataMembers;
 class TypeFunctionMembers;
 
 class TypeWithDict {
-  friend class BaseWithDict;
-  friend class FunctionWithDict;
-  friend class MemberWithDict;
   friend class TypeBases;
   friend class TypeDataMembers;
   friend class TypeFunctionMembers;

--- a/FWCore/Utilities/src/BaseWithDict.cc
+++ b/FWCore/Utilities/src/BaseWithDict.cc
@@ -24,7 +24,7 @@ namespace edm {
 
   TypeWithDict
   BaseWithDict::typeOf() const {
-    return TypeWithDict(baseClass_->GetClassPointer(), baseClass_->Property());
+    return TypeWithDict(baseClass_->GetClassPointer());
   }
 
   size_t

--- a/FWCore/Utilities/src/MemberWithDict.cc
+++ b/FWCore/Utilities/src/MemberWithDict.cc
@@ -26,15 +26,15 @@ namespace edm {
   MemberWithDict::typeOf() const {
     if(isArray()) {
       std::ostringstream name;
-      name << dataMember_->GetTypeName();
+      name << dataMember_->GetTrueTypeName();
       for(int i = 0; i < dataMember_->GetArrayDim(); ++i) {
         name << '[';
         name << dataMember_->GetMaxIndex(i);
         name << ']';
       }
-      return TypeWithDict::byName(name.str(), dataMember_->Property());
+      return TypeWithDict::byName(name.str());
     } 
-    return TypeWithDict::byName(dataMember_->GetTypeName(), dataMember_->Property());
+    return TypeWithDict::byName(dataMember_->GetTrueTypeName());
   }
 
   TypeWithDict


### PR DESCRIPTION
Optimization for better design.
Member functions of MemberWithDict and BaseWithDict do not need to pass a property mask to TypeWithDict constructors.  The information is already encoded in the name.
This makes the property mask local to TypeWithDict, and means that BaseWithDict and MemberWithDict no longer need to be friends of TypeWithDict.
Please merge this request as soon as convenient.
