### PR TITLE
Workaround for ROOT6 bug

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -195,7 +195,16 @@ namespace edm {
       return TypeWithDict(typeid(std::type_info), property);
     }
 
-    // std::cerr << "DEBUG BY NAME: " << name << std::endl;
+    // For a reason not understood, TClass::GetClass sometimes cannot find std::vector<T>::value_type
+    // when T is a nested class.
+    if(stripNamespace(name) == "value_type") {
+      size_t begin = name.find('<');
+      size_t end = name.rfind('>');
+      if(begin != std::string::npos && end != std::string::npos && end > ++begin) {
+        return TypeWithDict::byName(name.substr(begin, end - begin), property);
+      }
+    }
+    //std::cerr << "DEBUG BY NAME: " << name << std::endl;
     return TypeWithDict();
   }
 


### PR DESCRIPTION
In ROOT6, TClass::GetClass("std::vector<<T>>::value_type") apparently fails when T is a nested class.  I will write a JIRA ticket against ROOT6 for this issue.  Now that header parsing is no longer used by TypeWithDict, this causes several unit test failures and one add-on test failure.
This pull request works around the problem by using the fact that std::vector<<T>>::value_type is just T.  This fixes the broken tests.
Please merge this request as soon as convenient.
