### PR TITLE
Added WeightsCountProducer to common utilities

### DIFF
--- a/CommonTools/UtilAlgos/plugins/BuildFile.xml
+++ b/CommonTools/UtilAlgos/plugins/BuildFile.xml
@@ -6,4 +6,5 @@
   <use   name="CommonTools/UtilAlgos"/>
   <use   name="FWCore/ServiceRegistry"/>
   <use   name="DataFormats/Candidate"/>
+  <use   name="SimDataFormats/GeneratorProducts"/>
 </library>

--- a/CommonTools/UtilAlgos/plugins/WeightsCountProducer.cc
+++ b/CommonTools/UtilAlgos/plugins/WeightsCountProducer.cc
@@ -1,0 +1,202 @@
+// -*- C++ -*-
+//
+// Package:    WeightsCountProducer
+// Class:      WeightsCountProducer
+// 
+/**\class WeightsCountProducer WeightsCountProducer.cc CommonTools/UtilAlgos/plugins/WeightsCountProducer.cc
+
+Description: An event counter that can store the number of events in the lumi block 
+
+*/
+
+
+// system include files
+#include <memory>
+#include <vector>
+#include <algorithm>
+#include <iostream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/Event.h"
+
+#include "DataFormats/Common/interface/MergeableDouble.h"
+#include "DataFormats/Common/interface/MergeableHisto.h"
+
+
+class WeightsCountProducer : public edm::one::EDProducer<edm::one::WatchLuminosityBlocks,
+                                                       edm::EndLuminosityBlockProducer> {
+public:
+  explicit WeightsCountProducer(const edm::ParameterSet&);
+  ~WeightsCountProducer();
+
+private:
+  virtual void produce(edm::Event &, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock &, const edm::EventSetup&) override;
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, const edm::EventSetup&) override;
+  virtual void endLuminosityBlockProduce(edm::LuminosityBlock &, const edm::EventSetup&) override;
+      
+  // ----------member data ---------------------------
+  /// GenEventInfoProduct_generator__SIM.
+  edm::EDGetTokenT<GenEventInfoProduct> genInfoToken_;
+
+  bool doTruePileup_;
+  bool doObsPileup_;
+  edm::EDGetTokenT<std::vector<PileupSummaryInfo> >   puInfoToken_;
+  
+  int nbinsTruePileup_;
+  double minTruePileup_, maxTruePileup_, widthTruePileup_;
+  int nbinsObsPileup_;
+  double minObsPileup_, maxObsPileup_, widthObsPileup_;
+
+  double weightProcessedInLumi_;
+  typedef edm::MergeableHistoF hysto_type;
+  hysto_type::container_type truePileup_, obsPileup_, zeroTruePileup_, zeroObsPileup_;
+  
+};
+
+
+
+using namespace edm;
+using namespace std;
+
+
+
+WeightsCountProducer::WeightsCountProducer(const edm::ParameterSet& iConfig) :
+  genInfoToken_(consumes<GenEventInfoProduct>(iConfig.getParameter<InputTag> ("generator")))
+{
+  produces<edm::MergeableDouble, edm::InLumi>("totalWeight");
+  
+  doTruePileup_  = iConfig.getUntrackedParameter<bool>("doTruePileup",false);
+  doObsPileup_   = iConfig.getUntrackedParameter<bool>("doObsPileup",false);
+  if( doTruePileup_ || doObsPileup_ ) {
+    puInfoToken_ = consumes<std::vector<PileupSummaryInfo> >(iConfig.getParameter<InputTag> ("pileupInfo"));
+  }
+  
+  if( doTruePileup_ ) {
+    nbinsTruePileup_ = iConfig.getParameter<int>("nbinsTruePileup");
+    minTruePileup_ =  iConfig.getParameter<double>("minTruePileup");
+    maxTruePileup_ =  iConfig.getParameter<double>("maxTruePileup");
+    widthTruePileup_ = (maxTruePileup_-minTruePileup_)/(double)nbinsTruePileup_;
+    zeroTruePileup_.resize(nbinsTruePileup_+2,0.);  // add bins for overflow and underdflow
+    produces<hysto_type, edm::InLumi>("truePileup");
+  }
+
+  if( doObsPileup_ ) {
+    nbinsObsPileup_ = iConfig.getParameter<int>("nbinsObsPileup");
+    minObsPileup_ =  iConfig.getParameter<double>("minObsPileup");
+    maxObsPileup_ =  iConfig.getParameter<double>("maxObsPileup");
+    widthObsPileup_ = (maxObsPileup_-minObsPileup_)/(double)nbinsObsPileup_;
+    zeroObsPileup_.resize(nbinsObsPileup_+2,0.); // add bins for overflow and underdflow
+    produces<hysto_type, edm::InLumi>("obsPileup");
+  }
+
+}
+
+
+WeightsCountProducer::~WeightsCountProducer(){}
+
+
+void
+WeightsCountProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
+  edm::Handle<GenEventInfoProduct> genInfo;
+  edm::Handle<std::vector<PileupSummaryInfo> > puInfo;
+
+  if( ! iEvent.isRealData() ) {
+    iEvent.getByToken(genInfoToken_,genInfo);
+    
+    const auto & weights = genInfo->weights(); 
+    if( ! weights.empty() ) {
+      weightProcessedInLumi_ += weights[0];
+      
+      if( doTruePileup_ || doObsPileup_ ) {
+	iEvent.getByToken(puInfoToken_,puInfo);
+	hysto_type::value_type truePu=0., obsPu=0.;
+	for( auto & frame : *puInfo ) {
+	  /// std::cout << frame.getBunchCrossing() << std::endl;
+	  if( frame.getBunchCrossing() == 0 ) {
+	    truePu = frame.getTrueNumInteractions();
+	    obsPu = frame.getPU_NumInteractions();
+	    break;
+	  }
+	}
+	/// cout << truePu << " " << obsPu << endl; 
+      
+	if( doTruePileup_ ) {
+	  size_t bin = 0;
+	  if( truePu >= maxTruePileup_ ) { bin = truePileup_.size() - 1; }
+	  else if( truePu >= minTruePileup_ ) { bin = (size_t)std::floor( (truePu-minTruePileup_) / widthTruePileup_) + 1; }
+	  truePileup_[bin] += weights[0];
+	}
+	
+	if( doObsPileup_ ) {
+	  size_t bin = 0;
+	  if( obsPu >= maxObsPileup_ ) { bin = obsPileup_.size() - 1; }
+	  else if( obsPu >= minObsPileup_ ) { bin = (size_t)std::floor( (obsPu-minObsPileup_) / widthObsPileup_) + 1; }
+	  /// cout << bin << " " << std::floor( (obsPu-minObsPileup_) / widthObsPileup_) << endl;
+	  obsPileup_[bin] += weights[0];
+	}
+      }
+      
+    }
+  }  
+  
+  return;
+}
+
+
+void 
+WeightsCountProducer::beginLuminosityBlock(const LuminosityBlock & theLuminosityBlock, const EventSetup & theSetup) {
+  weightProcessedInLumi_ = 0.;
+  if( doTruePileup_ ) {
+    truePileup_ = zeroTruePileup_;
+  }
+  if( doObsPileup_ ) {
+    obsPileup_ = zeroObsPileup_;
+  }
+  
+  return;
+}
+
+void 
+WeightsCountProducer::endLuminosityBlock(LuminosityBlock const& theLuminosityBlock, const EventSetup & theSetup) {
+}
+
+void 
+WeightsCountProducer::endLuminosityBlockProduce(LuminosityBlock & theLuminosityBlock, const EventSetup & theSetup) {
+  LogTrace("WeightsCounting") << "endLumi: adding " << weightProcessedInLumi_ << " events" << endl;
+
+  auto_ptr<edm::MergeableDouble> numWeightssPtr(new edm::MergeableDouble);
+  numWeightssPtr->value = weightProcessedInLumi_;
+  theLuminosityBlock.put(numWeightssPtr,"totalWeight");
+  
+  if( doTruePileup_ ) {
+    auto_ptr<hysto_type> truePileup(new hysto_type);
+    truePileup->min = minTruePileup_;
+    truePileup->max = maxTruePileup_;
+    truePileup->values = truePileup_;
+    theLuminosityBlock.put(truePileup,"truePileup");
+  }
+  if( doObsPileup_ ) {
+    auto_ptr<hysto_type> obsPileup(new hysto_type);
+    obsPileup->min = minObsPileup_;
+    obsPileup->max = maxObsPileup_;
+    obsPileup->values = obsPileup_;
+    theLuminosityBlock.put(obsPileup,"obsPileup");
+  }
+  
+  return;
+}
+
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(WeightsCountProducer);

--- a/DataFormats/Common/interface/MergeableDouble.h
+++ b/DataFormats/Common/interface/MergeableDouble.h
@@ -1,0 +1,14 @@
+#ifndef Common_MergeableDouble_h
+#define Common_MergeableDouble_h
+
+namespace edm {
+
+  struct MergeableDouble {
+    ~MergeableDouble() {}
+    bool mergeProduct(MergeableDouble const & newThing);
+    double value;
+  };
+
+}
+
+#endif

--- a/DataFormats/Common/interface/MergeableHisto.h
+++ b/DataFormats/Common/interface/MergeableHisto.h
@@ -1,0 +1,35 @@
+#ifndef Common_MergeableHisto_h
+#define Common_MergeableHisto_h
+
+#include <vector>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace edm {
+  
+  template<class T>
+    struct MergeableHisto {
+      typedef T value_type;
+      typedef typename std::vector<T> container_type;
+      ~MergeableHisto() {}
+      bool mergeProduct(MergeableHisto<T> const & a) {
+	if(a.min != min || a.max != max || a.values.size() != values.size() ){
+	  edm::LogWarning("MergeabloHisto|ProductsNotMergeable")
+	    << "Trying to merge histograms with different binnings\n";
+	  return false;
+	}
+	
+	for(size_t ib=0; ib<values.size(); ++ib) {  values[ib]+=a.values[ib]; }
+	return true;
+      }
+  
+      value_type min, max;
+      container_type values;
+    };
+
+  typedef MergeableHisto<float> MergeableHistoF;
+  typedef MergeableHisto<int>   MergeableHistoI;
+  typedef MergeableHisto<double> MergeableHistoD;
+
+}
+
+#endif

--- a/DataFormats/Common/src/MergeableDouble.cc
+++ b/DataFormats/Common/src/MergeableDouble.cc
@@ -1,0 +1,18 @@
+#include "DataFormats/Common/interface/MergeableDouble.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+namespace edm 
+{
+
+  bool MergeableDouble::mergeProduct(MergeableDouble const& a) 
+  {
+    if (a.value > 0 && value+a.value < a.value){
+      edm::LogWarning("MergeableDouble|ProductsNotMergeable")
+	<< "The merge would lead to an overflow of the counter" << std::endl;
+      return false;
+    }
+    value += a.value;
+    return true;
+  }
+
+}

--- a/DataFormats/Common/src/MergeableHisto.cc
+++ b/DataFormats/Common/src/MergeableHisto.cc
@@ -1,0 +1,2 @@
+#include "DataFormats/Common/interface/MergeableHisto.h"
+

--- a/DataFormats/Common/src/classes.h
+++ b/DataFormats/Common/src/classes.h
@@ -20,6 +20,8 @@
 #include "DataFormats/Common/interface/PtrVectorBase.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/Common/interface/MergeableCounter.h"
+#include "DataFormats/Common/interface/MergeableDouble.h"
+#include "DataFormats/Common/interface/MergeableHisto.h"
 #include "DataFormats/Common/interface/ConditionsInEdm.h"
 #include "DataFormats/Common/interface/RefCore.h"
 #include "DataFormats/Common/interface/RefCoreWithIndex.h"
@@ -66,6 +68,10 @@ namespace DataFormats_Common {
     edm::Wrapper<std::vector<edm::EventAuxiliary> > wvea;
     edm::Wrapper<std::vector<edm::ErrorSummaryEntry> > wves;
     edm::Wrapper<edm::MergeableCounter> mc;
+    edm::Wrapper<edm::MergeableDouble> md;
+    edm::Wrapper<edm::MergeableHistoD> mhD;
+    edm::Wrapper<edm::MergeableHistoF> mhF;
+    edm::Wrapper<edm::MergeableHistoI> mhI;
 
     edm::Wrapper<edm::ConditionsInLumiBlock> dum11;
     edm::Wrapper<edm::ConditionsInRunBlock> dum21;

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -135,6 +135,14 @@
   <version ClassVersion="10" checksum="3792606006"/>
  </class>
  <class name="edm::Wrapper<edm::MergeableCounter>"/>
+ <class name="edm::MergeableDouble"/>
+ <class name="edm::Wrapper<edm::MergeableDouble>"/>
+ <class name="edm::MergeableHistoD"/>
+ <class name="edm::Wrapper<edm::MergeableHistoD>"/>
+ <class name="edm::MergeableHistoF"/>
+ <class name="edm::Wrapper<edm::MergeableHistoF>"/>
+ <class name="edm::MergeableHistoI"/>
+ <class name="edm::Wrapper<edm::MergeableHistoI>"/>
 
  <class name="edm::ConditionsInEventBlock" ClassVersion="10">
   <version ClassVersion="10" checksum="28865621"/>


### PR DESCRIPTION
The purpose of the class is to integrate the total weight of processed events.
The WeightsCountProducer generalizes the EventsCountProducer, allowing the use of event weights provided by the latest generation of MC producers. In addition, the pile-up distribution of of the events can be constructed.
The results are stored as lumi-products and can be used at analysis level to compute event weights for MC samples.
These integrations are performed routinely on MC samples in order to properly weight events according to the cross section and pile-up distribution. Having a central tool to achieve the goal should be useful for many people in the collaboration.

Note: I am making this pull request for 7_4_X, even though it would be useful to also back-port this to 7_2.  I hope I am following the right procedure.
