### PR TITLE
Fix HLT cfg dumps for TrackerGeometricDetESModule (fallout of #6947)

### DIFF
--- a/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_Famos_cff.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/HLT/V36 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/HLT/V37 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 from FastSimulation.HighLevelTrigger.HLTSetup_cff import *
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V36')
+  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V37')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_FULL_cff.py
+++ b/HLTrigger/Configuration/python/HLT_FULL_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_3_0/HLT/V36 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/HLT/V37 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V36')
+  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V37')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_Fake_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake_Famos_cff.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/Fake/V4 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/Fake/V5 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 from FastSimulation.HighLevelTrigger.HLTSetup_cff import *
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V5')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_Fake_cff.py
+++ b/HLTrigger/Configuration/python/HLT_Fake_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_3_0/Fake/V4 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/Fake/V5 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V5')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_Famos_cff.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/GRun/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/GRun/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 from FastSimulation.HighLevelTrigger.HLTSetup_cff import *
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V17')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_GRun_cff.py
+++ b/HLTrigger/Configuration/python/HLT_GRun_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_3_0/GRun/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/GRun/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V17')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_HIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_HIon_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_3_0/HIon/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/HIon/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/HIon/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/HIon/V17')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/python/HLT_PIon_cff.py
+++ b/HLTrigger/Configuration/python/HLT_PIon_cff.py
@@ -1,10 +1,10 @@
-# /dev/CMSSW_7_3_0/PIon/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/PIon/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 
 HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/PIon/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/PIon/V17')
 )
 
 HLTIter4PSetTrajectoryFilterIT = cms.PSet( 

--- a/HLTrigger/Configuration/test/OnData_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_FULL.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/HLT/V36 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/HLT/V37 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFULL" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V36')
+  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V37')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -1141,9 +1141,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnData_HLT_Fake.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_Fake.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/Fake/V4 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/Fake/V5 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V5')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -957,9 +957,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnData_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_GRun.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/GRun/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/GRun/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTGRun" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V17')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -1099,9 +1099,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnData_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_HIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/HIon/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/HIon/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/HIon/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/HIon/V17')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -836,9 +836,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnData_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnData_HLT_PIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/PIon/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/PIon/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/PIon/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/PIon/V17')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -836,9 +836,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnMc_HLT_FULL.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_FULL.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/HLT/V36 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/HLT/V37 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFULL" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V36')
+  tableName = cms.string('/dev/CMSSW_7_3_0/HLT/V37')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -1141,9 +1141,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnMc_HLT_Fake.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_Fake.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/Fake/V4 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/Fake/V5 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTFake" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V4')
+  tableName = cms.string('/dev/CMSSW_7_3_0/Fake/V5')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -957,9 +957,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnMc_HLT_GRun.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_GRun.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/GRun/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/GRun/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTGRun" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/GRun/V17')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -1099,9 +1099,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnMc_HLT_HIon.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_HIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/HIon/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/HIon/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTHIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/HIon/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/HIon/V17')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -836,9 +836,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )

--- a/HLTrigger/Configuration/test/OnMc_HLT_PIon.py
+++ b/HLTrigger/Configuration/test/OnMc_HLT_PIon.py
@@ -1,11 +1,11 @@
-# /dev/CMSSW_7_3_0/PIon/V16 (CMSSW_7_3_0)
+# /dev/CMSSW_7_3_0/PIon/V17 (CMSSW_7_3_0_HLT1)
 
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process( "HLTPIon" )
 
 process.HLTConfigVersion = cms.PSet(
-  tableName = cms.string('/dev/CMSSW_7_3_0/PIon/V16')
+  tableName = cms.string('/dev/CMSSW_7_3_0/PIon/V17')
 )
 
 process.HLTIter4PSetTrajectoryFilterIT = cms.PSet( 
@@ -836,9 +836,7 @@ process.TrackerDigiGeometryESModule = cms.ESProducer( "TrackerDigiGeometryESModu
 )
 process.TrackerGeometricDetESModule = cms.ESProducer( "TrackerGeometricDetESModule",
   appendToDataLabel = cms.string( "" ),
-  fromDDD = cms.bool( False ),
-  layerNumberPXB = cms.uint32( 16 ),
-  totalBlade = cms.uint32( 24 )
+  fromDDD = cms.bool( False )
 )
 process.TransientTrackBuilderESProducer = cms.ESProducer( "TransientTrackBuilderESProducer",
   ComponentName = cms.string( "TransientTrackBuilder" )


### PR DESCRIPTION
Fix HLT cfg dumps for TrackerGeometricDetESModule (fallout of #6947)

Note: this change in ConfDB is backward compatible with the 73X CMSSW code base;
@perrotta #7032 could be updated as well if only to keep 73X and 74X in sync...
