### PR TITLE
forcing full declaration of HEScintillator as HE rebuild SD

### DIFF
--- a/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalSimNumbering.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalSimNumbering.xml
@@ -80,7 +80,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//.*HEScintillator.*"/>
     <PartSelector path="//HVQF"/>
     <Parameter name="OnlyForHcalSimNumbering" value="HCAL" eval="false"/>
   </SpecPar>

--- a/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalsenspmf.xml
+++ b/Geometry/HcalCommonData/data/PhaseII/HGCal/hcalsenspmf.xml
@@ -5,7 +5,7 @@
   <SpecPar name="hcal">
     <PartSelector path="//HBS.*"/>
     <PartSelector path="//HTS.*"/>
-    <PartSelector path="//.*HES.*"/>
+    <PartSelector path="//.*HEScintillator.*"/>
     <PartSelector path="//HVQX"/>
     <PartSelector path="//VcalElecCathode"/>
     <PartSelector path="//FibreBundle.*"/>


### PR DESCRIPTION
@bsunanda @vandreev11 In principle this resolves the ambiguity between HEScintillator (HE-rebuild) and HESilicon (HGC-FH) when declaring these as sensitive detectors. HCAL experts should comment if this breaks anything. In the generation of events I observe HGCHESiliconHits and also HcalHits.
@lgray fyi
