### PR TITLE
Trivial PF cluster timing cuts for the fixed local reco

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -1,4 +1,4 @@
-1;2802;0cimport FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms
 particleFlowClusterHBHETimeSelected = cms.EDProducer(
     "PFClusterTimeSelector",
     src = cms.InputTag('particleFlowClusterHBHE'),

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -1,4 +1,4 @@
-import FWCore.ParameterSet.Config as cms
+1;2802;0cimport FWCore.ParameterSet.Config as cms
 particleFlowClusterHBHETimeSelected = cms.EDProducer(
     "PFClusterTimeSelector",
     src = cms.InputTag('particleFlowClusterHBHE'),
@@ -10,7 +10,7 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
             minTime = cms.double(-22.),
-            maxTime = cms.double(5.)
+            maxTime = cms.double(22.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
@@ -18,15 +18,15 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
             minTime = cms.double(-22.),
-            maxTime = cms.double(5.)
+            maxTime = cms.double(22.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-22.),
+            maxTime = cms.double(22.)
         ),
         cms.PSet(
             depth=cms.double(1.0),
@@ -34,87 +34,87 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
             minTime = cms.double(-20.),
-            maxTime = cms.double(5.)
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-15.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(3.0),
-            minEnergy = cms.double(2.0),
-            maxEnergy = cms.double(5.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-15.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(1.0),
-            minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(1000000.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-10.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(2.0),
-            minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(1000000.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-8.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(3.0),
-            minEnergy = cms.double(5.0),
-            maxEnergy = cms.double(1000000.0),
-            endcap = cms.bool(False),
-            minTime = cms.double(-8.),
-            maxTime = cms.double(5.)
-        ),
-        cms.PSet(
-            depth=cms.double(1.0),
-            minEnergy = cms.double(0.0),
-            maxEnergy = cms.double(2.0),
-            endcap = cms.bool(True),
             minTime = cms.double(-20.),
-            maxTime = cms.double(10.)
+            maxTime = cms.double(20.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(2.0),
+            maxEnergy = cms.double(5.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
+        ),
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
+        ),
+        cms.PSet(
+            depth=cms.double(2.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
+        ),
+        cms.PSet(
+            depth=cms.double(3.0),
+            minEnergy = cms.double(5.0),
+            maxEnergy = cms.double(1000000.0),
+            endcap = cms.bool(False),
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
+        ),
+        cms.PSet(
+            depth=cms.double(1.0),
+            minEnergy = cms.double(0.0),
+            maxEnergy = cms.double(2.0),
+            endcap = cms.bool(True),
+            minTime = cms.double(-22.),
+            maxTime = cms.double(22.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-15.),
-            maxTime = cms.double(10.)
+            minTime = cms.double(-22.),
+            maxTime = cms.double(22.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-12.),
-            maxTime = cms.double(10.)
+            minTime = cms.double(-22.),
+            maxTime = cms.double(22.)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-12.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-22.),
+            maxTime = cms.double(22.)
         ),
         cms.PSet(
             depth=cms.double(5.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-12.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-22.),
+            maxTime = cms.double(22.)
         ),
 
         cms.PSet(
@@ -122,40 +122,40 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-15.),
-            maxTime = cms.double(10.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-12.),
-            maxTime = cms.double(10.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-12.),
-            maxTime = cms.double(10.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-12.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(5.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-12.),
-            maxTime = cms.double(5.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
 
         cms.PSet(
@@ -163,40 +163,40 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(35.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(35.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(35.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(35.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         ),
         cms.PSet(
             depth=cms.double(5.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-25.),
-            maxTime = cms.double(25.)
+            minTime = cms.double(-20.),
+            maxTime = cms.double(20.)
         )
 )
 


### PR DESCRIPTION
At the meting today we saw that the local reco needed a fix to allow three pulses
in the fit. In this PR I change the timing cuts to loose logical values so we can do some jet 
studies in the relvals with the fixed local reco. We will fine tune the cuts for the final production
when relvals are ready.
