### PR TITLE
Xrootd per site statistics

### DIFF
--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -1,9 +1,11 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 
 #include "Utilities/StorageFactory/interface/StorageMaker.h"
 #include "Utilities/StorageFactory/interface/StorageMakerFactory.h"
 #include "Utilities/StorageFactory/interface/StorageFactory.h"
+#include "Utilities/XrdAdaptor/src/XrdStatistics.h"
 #include "Utilities/XrdAdaptor/src/XrdFile.h"
 
 #include "XrdCl/XrdClDefaultEnv.hh"
@@ -141,3 +143,5 @@ private:
 };
 
 DEFINE_EDM_PLUGIN (StorageMakerFactory, XrdStorageMaker, "root");
+DEFINE_FWK_SERVICE (XrdAdaptor::XrdStatisticsService);
+

--- a/Utilities/XrdAdaptor/src/XrdRequest.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequest.cc
@@ -30,6 +30,8 @@ XrdAdaptor::ClientRequest::HandleResponse(XrdCl::XRootDStatus *stat, XrdCl::AnyO
         QualityMetricWatch qmw;
         m_qmw.swap(qmw);
     }
+    m_stats.reset();
+
     if ((!FAKE_ERROR_COUNTER || ((++g_fakeError % FAKE_ERROR_COUNTER) != 0)) && (status->IsOK() && resp))
     {
         if (m_into)

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -109,8 +109,6 @@ RequestManager::RequestManager(const std::string &filename, XrdCl::OpenFlags::Fl
       m_distribution(0,100),
       m_excluded_active_count(0)
 {
-    edm::Service<XrdStatisticsService> statsService;
-    if (statsService.isAvailable()) {m_stats = &(*statsService);}
 }
 
 
@@ -205,7 +203,7 @@ RequestManager::initialize(std::weak_ptr<RequestManager> self)
   timespec ts;
   GET_CLOCK_MONOTONIC(ts);
 
-  std::shared_ptr<Source> source(new Source(ts, std::move(file), excludeString, m_stats));
+  std::shared_ptr<Source> source(new Source(ts, std::move(file), excludeString));
   {
     std::lock_guard<std::recursive_mutex> sentry(m_source_mutex);
     m_activeSources.push_back(source);
@@ -912,7 +910,7 @@ XrdAdaptor::RequestManager::OpenHandler::HandleResponseWithHosts(XrdCl::XRootDSt
         std::string excludeString;
         Source::determineHostExcludeString(*m_file, hostList.get(), excludeString);
 
-        source.reset(new Source(now, std::move(m_file), excludeString, manager->m_stats));
+        source.reset(new Source(now, std::move(m_file), excludeString));
         m_promise.set_value(source);
     }
     else

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -169,6 +169,14 @@ private:
     void updateSiteInfo(std::string orig_site="");
 
     /**
+     * The service registry only functions on threads "owned" by CMSSW; unfortunately,
+     * the Xrootd callbacks occur in non-CMSSW threads.  Hence, using the service
+     * registry there aborts.  Instead, the RequestManager will cache a copy of the
+     * stats service (if it is available) in its constructor.
+     */
+    XrdStatisticsService *m_stats;
+
+    /**
      * Picks a single source for the next operation.
      */
     std::shared_ptr<Source> pickSingleSource();

--- a/Utilities/XrdAdaptor/src/XrdRequestManager.h
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.h
@@ -169,14 +169,6 @@ private:
     void updateSiteInfo(std::string orig_site="");
 
     /**
-     * The service registry only functions on threads "owned" by CMSSW; unfortunately,
-     * the Xrootd callbacks occur in non-CMSSW threads.  Hence, using the service
-     * registry there aborts.  Instead, the RequestManager will cache a copy of the
-     * stats service (if it is available) in its constructor.
-     */
-    XrdStatisticsService *m_stats;
-
-    /**
      * Picks a single source for the next operation.
      */
     std::shared_ptr<Source> pickSingleSource();

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -14,6 +14,7 @@
 #include "XrdSource.h"
 #include "XrdRequest.h"
 #include "QualityMetric.h"
+#include "XrdStatistics.h"
 
 #define MAX_REQUEST 256*1024
 #define XRD_CL_MAX_CHUNK 512*1024
@@ -75,12 +76,13 @@ private:
     std::string m_site;
 };
 
-Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string &exclude)
+Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string &exclude, XrdStatisticsService *statsService)
     : m_lastDowngrade({0, 0}),
       m_id("(unknown)"),
       m_exclude(exclude),
       m_fh(std::move(fh)),
-      m_qm(QualityMetricFactory::get(now, m_id))
+      m_qm(QualityMetricFactory::get(now, m_id)),
+      m_stats(nullptr)
 #ifdef XRD_FAKE_SLOW
     , m_slow(++g_delayCount % XRD_SLOW_RATE == 0)
     //, m_slow(++g_delayCount >= XRD_SLOW_RATE)
@@ -103,6 +105,10 @@ Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string 
     setXrootdSite();
     assert(m_qm.get());
     assert(m_fh.get());
+    if (statsService)
+    {
+        m_stats = statsService->getStatisticsForSite(m_site);
+    }
 }
 
 
@@ -306,6 +312,11 @@ Source::handle(std::shared_ptr<ClientRequest> c)
     c->m_source = shared_from_this();
     c->m_self_reference = c;
     m_qm->startWatch(c->m_qmw);
+    if (m_stats)
+    {
+        std::shared_ptr<XrdReadStatistics> readStats = XrdSiteStatistics::startRead(m_stats, c);
+        c->setStatistics(readStats);
+    }
 #ifdef XRD_FAKE_SLOW
     if (m_slow) std::this_thread::sleep_for(std::chrono::milliseconds(XRD_DELAY));
 #endif

--- a/Utilities/XrdAdaptor/src/XrdSource.cc
+++ b/Utilities/XrdAdaptor/src/XrdSource.cc
@@ -76,7 +76,7 @@ private:
     std::string m_site;
 };
 
-Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string &exclude, XrdStatisticsService *statsService)
+Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string &exclude)
     : m_lastDowngrade({0, 0}),
       m_id("(unknown)"),
       m_exclude(exclude),
@@ -105,6 +105,7 @@ Source::Source(timespec now, std::unique_ptr<XrdCl::File> fh, const std::string 
     setXrootdSite();
     assert(m_qm.get());
     assert(m_fh.get());
+    XrdSiteStatisticsInformation *statsService = XrdSiteStatisticsInformation::getInstance();
     if (statsService)
     {
         m_stats = statsService->getStatisticsForSite(m_site);

--- a/Utilities/XrdAdaptor/src/XrdSource.h
+++ b/Utilities/XrdAdaptor/src/XrdSource.h
@@ -16,11 +16,13 @@ namespace XrdAdaptor {
 
 class RequestList;
 class ClientRequest;
+class XrdSiteStatistics;
+class XrdStatisticsService;
 
 class Source : public std::enable_shared_from_this<Source>, boost::noncopyable {
 
 public:
-    Source(timespec now, std::unique_ptr<XrdCl::File> fileHandle, const std::string &exclude);
+    Source(timespec now, std::unique_ptr<XrdCl::File> fileHandle, const std::string &exclude, XrdStatisticsService*);
 
     ~Source();
 
@@ -69,6 +71,7 @@ private:
     std::shared_ptr<XrdCl::File> m_fh;
 
     std::unique_ptr<QualityMetricSource> m_qm;
+    std::shared_ptr<XrdSiteStatistics> m_stats;
 
 #ifdef XRD_FAKE_SLOW
     bool m_slow;

--- a/Utilities/XrdAdaptor/src/XrdSource.h
+++ b/Utilities/XrdAdaptor/src/XrdSource.h
@@ -22,7 +22,7 @@ class XrdStatisticsService;
 class Source : public std::enable_shared_from_this<Source>, boost::noncopyable {
 
 public:
-    Source(timespec now, std::unique_ptr<XrdCl::File> fileHandle, const std::string &exclude, XrdStatisticsService*);
+    Source(timespec now, std::unique_ptr<XrdCl::File> fileHandle, const std::string &exclude);
 
     ~Source();
 

--- a/Utilities/XrdAdaptor/src/XrdStatistics.cc
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.cc
@@ -1,0 +1,147 @@
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/MessageLogger/interface/JobReport.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+
+#include "XrdRequest.h"
+#include "XrdStatistics.h"
+
+#include <chrono>
+
+using namespace XrdAdaptor;
+
+
+XrdStatisticsService::XrdStatisticsService(const edm::ParameterSet &iPS, edm::ActivityRegistry &iRegistry)
+{
+    iRegistry.watchPostEndJob(this, &XrdStatisticsService::postEndJob);
+}
+
+
+void XrdStatisticsService::postEndJob()
+{
+    edm::Service<edm::JobReport> reportSvc;
+    if (!reportSvc.isAvailable()) {return;}
+
+    for (std::shared_ptr<XrdSiteStatistics> const &stats : m_sites)
+    {
+        stats->recomputeProperties();
+        reportSvc->reportPerformanceForModule(stats->site(), "XrdSiteStatistics", stats->fjrProperties());
+    }
+}
+
+
+std::shared_ptr<XrdSiteStatistics>
+XrdStatisticsService::getStatisticsForSite(std::string const &site)
+{
+    for (std::shared_ptr<XrdSiteStatistics> &stats : m_sites)
+    {
+        if (stats->site() == site) {return stats;}
+    }
+    m_sites.emplace_back(new XrdSiteStatistics(site));
+    return m_sites.back();
+}
+
+
+void XrdStatisticsService::fillDescriptions(edm::ConfigurationDescriptions &descriptions)
+{
+    edm::ParameterSetDescription desc;
+    desc.setComment("Report Xrootd-related statistics centrally.");
+    desc.addUntracked<bool>("reportToFJR", true)
+        ->setComment("True: Add per-site Xrootd statistics to the framework job report.\n"
+                     "False: Collect no site-specific statistics.\n");
+    descriptions.add("XrdAdaptor::XrdStatisticsService", desc);
+}
+
+
+XrdSiteStatistics::XrdSiteStatistics(std::string const &site) :
+    m_site(site),
+    m_readvCount(0),
+    m_chunkCount(0),
+    m_readvSize(0),
+    m_readvNS(0.0),
+    m_readCount(0),
+    m_readSize(0),
+    m_readNS(0)
+{
+}
+
+std::shared_ptr<XrdReadStatistics>
+XrdSiteStatistics::startRead(std::shared_ptr<XrdSiteStatistics> parent, std::shared_ptr<ClientRequest> req)
+{
+    std::shared_ptr<XrdReadStatistics> readStats(new XrdReadStatistics(parent, req->getSize(), req->getCount()));
+    return readStats;
+}
+
+
+static std::string
+i2str(int input)
+{
+    std::ostringstream formatter;
+    formatter << input;
+    return formatter.str();
+}
+
+
+static std::string
+d2str(double input)
+{
+    std::ostringstream formatter;
+    formatter << std::setw(4) << input;
+    return formatter.str();
+}
+
+
+void
+XrdSiteStatistics::recomputeProperties()
+{
+    m_props.clear();
+
+    m_props["readv-numOperations"] = i2str(m_readvCount);
+    m_props["readv-numChunks"] = i2str(m_chunkCount);
+    m_props["readv-totalMegabytes"] = d2str(static_cast<float>(m_readvSize)/(1024.0*1024.0));
+    m_props["readv-totalMsecs"] = d2str(m_readvNS/1e6);
+
+    m_props["read-numOperations"] = i2str(m_readCount);
+    m_props["read-totalMegabytes"] = d2str(static_cast<float>(m_readSize)/(1024.0*1024.0));
+    m_props["read-totalMsecs"] = d2str(static_cast<float>(m_readNS)/1e6);
+}
+
+
+void
+XrdSiteStatistics::finishRead(XrdReadStatistics const &readStats)
+{
+    if (readStats.readCount() > 1)
+    {
+        m_readvCount ++;
+        m_chunkCount += readStats.readCount();
+        m_readvSize += readStats.size();
+        m_readvNS += readStats.elapsedNS();
+    }
+    else
+    {
+        m_readCount ++;
+        m_readSize += readStats.size();
+        m_readNS += readStats.elapsedNS();
+    }
+}
+
+
+XrdReadStatistics::XrdReadStatistics(std::shared_ptr<XrdSiteStatistics> parent, IOSize size, size_t count) :
+    m_size(size),
+    m_count(count),
+    m_parent(parent),
+    m_start(std::chrono::high_resolution_clock::now())
+{
+}
+
+
+float
+XrdReadStatistics::elapsedNS() const
+{
+    std::chrono::time_point<std::chrono::high_resolution_clock> end = std::chrono::high_resolution_clock::now();
+    return static_cast<int>(std::chrono::duration_cast<std::chrono::nanoseconds>(end-m_start).count());
+}
+

--- a/Utilities/XrdAdaptor/src/XrdStatistics.cc
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.cc
@@ -36,10 +36,11 @@ void XrdStatisticsService::postEndJob()
     XrdSiteStatisticsInformation *instance = XrdSiteStatisticsInformation::getInstance();
     if (!instance) {return;}
 
+    std::map<std::string, std::string> props;
     for (std::shared_ptr<XrdSiteStatistics> const &stats : instance->m_sites)
     {
-        stats->recomputeProperties();
-        reportSvc->reportPerformanceForModule(stats->site(), "XrdSiteStatistics", stats->fjrProperties());
+        stats->recomputeProperties(props);
+        reportSvc->reportPerformanceForModule(stats->site(), "XrdSiteStatistics", props);
     }
 }
 
@@ -127,18 +128,18 @@ d2str(double input)
 
 
 void
-XrdSiteStatistics::recomputeProperties()
+XrdSiteStatistics::recomputeProperties(std::map<std::string, std::string> &props)
 {
-    m_props.clear();
+    props.clear();
 
-    m_props["readv-numOperations"] = i2str(m_readvCount);
-    m_props["readv-numChunks"] = i2str(m_chunkCount);
-    m_props["readv-totalMegabytes"] = d2str(static_cast<float>(m_readvSize)/(1024.0*1024.0));
-    m_props["readv-totalMsecs"] = d2str(m_readvNS/1e6);
+    props["readv-numOperations"] = i2str(m_readvCount);
+    props["readv-numChunks"] = i2str(m_chunkCount);
+    props["readv-totalMegabytes"] = d2str(static_cast<float>(m_readvSize)/(1024.0*1024.0));
+    props["readv-totalMsecs"] = d2str(m_readvNS/1e6);
 
-    m_props["read-numOperations"] = i2str(m_readCount);
-    m_props["read-totalMegabytes"] = d2str(static_cast<float>(m_readSize)/(1024.0*1024.0));
-    m_props["read-totalMsecs"] = d2str(static_cast<float>(m_readNS)/1e6);
+    props["read-numOperations"] = i2str(m_readCount);
+    props["read-totalMegabytes"] = d2str(static_cast<float>(m_readSize)/(1024.0*1024.0));
+    props["read-totalMsecs"] = d2str(static_cast<float>(m_readNS)/1e6);
 }
 
 

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -68,17 +68,17 @@ public:
     XrdSiteStatistics &operator=(const XrdSiteStatistics&) = delete;
 
     std::string const &site() const {return m_site;}
-    std::map<std::string, std::string> const &fjrProperties() const {return m_props;}
 
-    void recomputeProperties();
+    // Note that, while this function is thread-safe, the numbers are only consistent if no other
+    // thread is reading data.
+    void recomputeProperties(std::map<std::string, std::string> &props);
 
     static std::shared_ptr<XrdReadStatistics> startRead(std::shared_ptr<XrdSiteStatistics> parent, std::shared_ptr<ClientRequest> req);
 
     void finishRead(XrdReadStatistics const &);
 
 private:
-    std::string m_site = "Unknown";
-    std::map<std::string, std::string> m_props;
+    const std::string m_site = "Unknown";
 
     std::atomic<unsigned> m_readvCount;
     std::atomic<unsigned> m_chunkCount;

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -54,7 +54,7 @@ private:
     static void createInstance();
 
     static std::atomic<XrdSiteStatisticsInformation*> m_instance;
-    static std::mutex m_mutex;
+    std::mutex m_mutex;
     std::vector<std::shared_ptr<XrdSiteStatistics>> m_sites;
 };
 

--- a/Utilities/XrdAdaptor/src/XrdStatistics.h
+++ b/Utilities/XrdAdaptor/src/XrdStatistics.h
@@ -1,0 +1,94 @@
+#ifndef __XRD_STATISTICS_SERVICE_H_
+#define __XRD_STATISTICS_SERVICE_H_
+
+#include "Utilities/StorageFactory/interface/IOTypes.h"
+
+#include <chrono>
+
+namespace edm
+{
+    class ParameterSet;
+    class ActivityRegistry;
+    class ConfigurationDescriptions;
+}
+
+namespace XrdAdaptor
+{
+
+class ClientRequest;
+class XrdReadStatistics;
+class XrdSiteStatistics;
+
+class XrdStatisticsService
+{
+public:
+
+    XrdStatisticsService(const edm::ParameterSet& iPS, edm::ActivityRegistry &iRegistry);
+
+    void postEndJob();
+
+    void fillDescriptions(edm::ConfigurationDescriptions &descriptions);
+
+    std::shared_ptr<XrdSiteStatistics> getStatisticsForSite(std::string const &site);
+
+private:
+
+    std::vector<std::shared_ptr<XrdSiteStatistics>> m_sites;
+};
+
+class XrdSiteStatistics
+{
+friend class XrdReadStatistics;
+
+public:
+    XrdSiteStatistics(std::string const &site);
+    XrdSiteStatistics(const XrdSiteStatistics&) = delete;
+    XrdSiteStatistics &operator=(const XrdSiteStatistics&) = delete;
+
+    std::string const &site() const {return m_site;}
+    std::map<std::string, std::string> const &fjrProperties() const {return m_props;}
+
+    void recomputeProperties();
+
+    static std::shared_ptr<XrdReadStatistics> startRead(std::shared_ptr<XrdSiteStatistics> parent, std::shared_ptr<ClientRequest> req);
+
+    void finishRead(XrdReadStatistics const &);
+
+private:
+    std::string m_site = "Unknown";
+    std::map<std::string, std::string> m_props;
+
+    std::atomic<unsigned> m_readvCount;
+    std::atomic<unsigned> m_chunkCount;
+    std::atomic<uint64_t> m_readvSize;
+    std::atomic<uint64_t> m_readvNS;
+    std::atomic<unsigned> m_readCount;
+    std::atomic<uint64_t> m_readSize;
+    std::atomic<uint64_t> m_readNS;
+};
+
+class XrdReadStatistics
+{
+friend class XrdSiteStatistics;
+
+public:
+    ~XrdReadStatistics() {m_parent->finishRead(*this);}
+    XrdReadStatistics(const XrdReadStatistics&) = delete;
+    XrdReadStatistics &operator=(const XrdReadStatistics&) = delete;
+
+private:
+    XrdReadStatistics(std::shared_ptr<XrdSiteStatistics> parent, IOSize size, size_t count);
+
+    float elapsedNS() const;
+    int readCount() const {return m_count;}
+    int size() const {return m_size;}
+
+    size_t m_size;
+    IOSize m_count;
+    std::shared_ptr<XrdSiteStatistics> m_parent;
+    std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
+};
+
+}
+
+#endif


### PR DESCRIPTION
```
Add new storage statistics service for Xrootd.

This service keeps per-site statistics from the Xrootd layer.
Previously, the IO statistics were kept by the StatisticsSenderService
on a per-file level.  These are less-useful now that Xrootd reads
from multiple servers (and possibly multiple sites) at a time!

Currently, this has to be enabled manually and only outputs
to the FJR.  Long-term, we plan on adding additional statistics
and additional output mechanisms (correcting the now-broken
StatisticsSenderService reports we send to the Dashboard).

NOTE: there is some trickery here due to the fact that the service
registry is only available on CMSSW-managed threads.  In order to
make the service available from the callback threads, the service
pointer is cached by the request manager object.
```
