### PR TITLE
Clean up likelihood algorithm (parts of code now executed before creation of database object) + updated DBWriter

### DIFF
--- a/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
+++ b/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
@@ -18,7 +18,7 @@ struct QGLikelihoodParameters{
   int QGIndex, VarIndex;
 };
 
-/// QGLikelihoodObject containing valid range and entries with category, histogram, mean and weight
+/// QGLikelihoodObject containing valid range and entries with category and histogram
 struct QGLikelihoodObject{
   typedef PhysicsTools::Calibration::HistogramF Histogram;
 

--- a/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
+++ b/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
@@ -25,7 +25,7 @@ struct QGLikelihoodObject{
   struct Entry{
     QGLikelihoodCategory category;
     Histogram histogram;
-    float mean
+    float mean;
     COND_SERIALIZABLE;
   };
 

--- a/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
+++ b/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
@@ -18,13 +18,14 @@ struct QGLikelihoodParameters{
   int QGIndex, VarIndex;
 };
 
-/// QGLikelihoodObject containing valid range and entries with category and histogram
+/// QGLikelihoodObject containing valid range and entries with category and histogram (mean is not used anymore, only for backward backward compatibility with older DB constructs)
 struct QGLikelihoodObject{
   typedef PhysicsTools::Calibration::HistogramF Histogram;
 
   struct Entry{
     QGLikelihoodCategory category;
     Histogram histogram;
+    float mean
     COND_SERIALIZABLE;
   };
 

--- a/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
+++ b/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
@@ -25,7 +25,6 @@ struct QGLikelihoodObject{
   struct Entry{
     QGLikelihoodCategory category;
     Histogram histogram;
-    float mean, weight;
     COND_SERIALIZABLE;
   };
 

--- a/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
+++ b/CondFormats/JetMETObjects/interface/QGLikelihoodObject.h
@@ -18,14 +18,14 @@ struct QGLikelihoodParameters{
   int QGIndex, VarIndex;
 };
 
-/// QGLikelihoodObject containing valid range and entries with category, histogram and mean
+/// QGLikelihoodObject containing valid range and entries with category, histogram, mean and weight
 struct QGLikelihoodObject{
   typedef PhysicsTools::Calibration::HistogramF Histogram;
 
   struct Entry{
     QGLikelihoodCategory category;
     Histogram histogram;
-    float mean;
+    float mean, weight;
     COND_SERIALIZABLE;
   };
 

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -160,6 +160,7 @@ void QGLikelihoodDBWriter::beginJob(){
     QGLikelihoodObject::Entry entry;
     entry.category  = category.second;
     entry.histogram = transformToHistogramObject(pdfs[category.first]);
+    entry.mean      = 0; // not used by the algorithm, is an old data member used in the past, but DB objects are not allowed to change
     payload->data.push_back(entry);
     
     char buff[1000];

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -31,6 +31,8 @@ class  QGLikelihoodDBWriter : public edm::EDAnalyzer{
 
  private:
   bool extractString(std::string, std::string&);
+  bool getVectorFromFile(TFile*, std::vector<float>&, const TString&);
+  QGLikelihoodObject::Histogram transformToHistogramObject(TH1* th1);
   std::string inputRootFile;
   std::string payloadTag;
 };
@@ -41,13 +43,25 @@ QGLikelihoodDBWriter::QGLikelihoodDBWriter(const edm::ParameterSet& pSet){
   payloadTag       = pSet.getParameter<std::string>("payload");
 }
 
-bool QGLikelihoodDBWriter::extractString(std::string mySubstring, std::string& myString){
-  size_t subStringPos = myString.find(mySubstring);
-  if(subStringPos != std::string::npos){
-    myString = myString.substr(subStringPos + mySubstring.length(), std::string::npos);
-    return true;
-  } else return false;
+
+// Translates the TVector with the bins to std::vector
+bool QGLikelihoodDBWriter::getVectorFromFile(TFile* f, std::vector<float>& v, const TString& name){
+  TVectorT<float> *tv = nullptr;
+  f->GetObject(name, tv);
+  if(!tv) return false;
+  for(int i = 0; i < tv->GetNoElements(); ++i) v.push_back((*tv)[i]);
+  return true;
 }
+
+// Transform ROOT TH1 to QGLikelihoodObject (same indexing)
+QGLikelihoodObject::Histogram QGLikelihoodDBWriter::transformToHistogramObject(TH1* th1){
+  QGLikelihoodObject::Histogram histogram(th1->GetNbinsX(), th1->GetXaxis()->GetBinLowEdge(1), th1->GetXaxis()->GetBinUpEdge(th1->GetNbinsX()));
+  for(int ibin = 0; ibin <= th1->GetNbinsX() + 1; ++ibin){
+    histogram.setBinContent(ibin, th1->GetBinContent(ibin));
+  }
+  return histogram;
+}
+
 
 // Begin Job
 void QGLikelihoodDBWriter::beginJob(){
@@ -55,100 +69,125 @@ void QGLikelihoodDBWriter::beginJob(){
   QGLikelihoodObject *payload = new QGLikelihoodObject();
   payload->data.clear();
 
-  // Get the ROOT file and the vectors with binning information
+  // Get the ROOT file
   TFile *f = TFile::Open(edm::FileInPath(inputRootFile.c_str()).fullPath().c_str());
-  TVectorT<float> *etaBins; 	f->GetObject("etaBins", etaBins);
-  TVectorT<float> *ptBinsC; 	f->GetObject("ptBinsC", ptBinsC);
-  TVectorT<float> *ptBinsF; 	f->GetObject("ptBinsF", ptBinsF);
-  TVectorT<float> *rhoBins; 	f->GetObject("rhoBins", rhoBins);
 
-  // Get keys to the histograms
-  TList *keys = f->GetListOfKeys();
-  if(!keys){
-    edm::LogError("NoKeys") << "There are no keys in the input file." << std::endl;
-    return;
-  }
- 
-  // Loop over directories/histograms
-  TIter nextdir(keys);
-  TKey *keydir;
-  while((keydir = (TKey*)nextdir())){
-    if(!keydir->IsFolder()) continue;
-    TDirectory *dir = (TDirectory*)keydir->ReadObj() ;
-    TIter nexthist(dir->GetListOfKeys());
-    TKey *keyhist;
-    while((keyhist = (TKey*)nexthist())){
-      std::string histname = keyhist->GetName();
-      int varIndex, qgIndex;
-
-      // First check the variable name, and use index in same order as RecoJets/JetProducers/plugins/QGTagger.cc:73
-      if(extractString("mult", histname)) varIndex = 0;
-      else if(extractString("ptD", histname)) varIndex = 1;
-      else if(extractString("axis2", histname)) varIndex = 2;
-      else continue;
-
-      // Check quark or gluon
-      if(extractString("quark", histname)) qgIndex = 0;
-      else if(extractString("gluon", histname)) qgIndex = 1;
-      else continue;
-
-      // Get eta, pt and rho ranges
-      extractString("eta-", histname);
-      int etaBin = std::atoi(histname.substr(0, histname.find("_")).c_str());
-      extractString("pt-", histname);
-      int ptBin = std::atoi(histname.substr(0, histname.find("_")).c_str());
-      extractString("rho-", histname);
-      int rhoBin = std::atoi(histname.substr(0, histname.find("_")).c_str());
-
-      float etaMin = (*etaBins)[etaBin];
-      float etaMax = (*etaBins)[etaBin+1];
-      TVectorT<float> *ptBins = (etaBin == 0? ptBinsC : ptBinsF);
-      float ptMin = (*ptBins)[ptBin];
-      float ptMax = (*ptBins)[ptBin+1];
-      float rhoMin = (*rhoBins)[rhoBin];
-      float rhoMax = (*rhoBins)[rhoBin+1];
-
-      // Print out for debugging      
-      char buff[1000];
-      sprintf(buff, "%50s : var=%1d, qg=%1d, etaMin=%6.2f, etaMax=%6.2f, ptMin=%8.2f, ptMax=%8.2f, rhoMin=%6.2f, rhoMax=%6.2f", keyhist->GetName(), varIndex, qgIndex, etaMin, etaMax, ptMin, ptMax, rhoMin, rhoMax );
-      edm::LogVerbatim("HistName") << buff << std::endl;
-
-      // Define category parameters
-      QGLikelihoodCategory category;
-      category.RhoMin = rhoMin;
-      category.RhoMax = rhoMax;
-      category.PtMin = ptMin;
-      category.PtMax = ptMax;
-      category.EtaMin = etaMin;
-      category.EtaMax = etaMax;
-      category.QGIndex = qgIndex;
-      category.VarIndex = varIndex;
-
-      // Get TH1 
-      TH1* th1hist = (TH1*) keyhist->ReadObj();
-
-      // Transform ROOT TH1 to QGLikelihoodObject (same indexing)
-      QGLikelihoodObject::Histogram histogram(th1hist->GetNbinsX(), th1hist->GetXaxis()->GetBinLowEdge(1), th1hist->GetXaxis()->GetBinUpEdge(th1hist->GetNbinsX()));
-      for(int ibin = 0; ibin <= th1hist->GetNbinsX() + 1; ++ibin){
-	histogram.setBinContent(ibin, th1hist->GetBinContent(ibin));
-      }
-
-      // Add this entry with its category parameters, histogram and mean
-      QGLikelihoodObject::Entry entry;
-      entry.category = category;
-      entry.histogram = histogram; 
-      entry.mean = th1hist->GetMean();
-      payload->data.push_back(entry);
+  // The ROOT file contains the binning for each variable, needed to set up the binning grid
+  std::map<TString, std::vector<float>> gridOfBins;
+  for(TString binVariable : {"eta", "pt", "rho"}){
+    if(!getVectorFromFile(f, gridOfBins[binVariable], binVariable + "Bins")){
+      edm::LogError("NoBins") << "Missing bin information for " << binVariable << " in input file" << std::endl;
+      return;
     }
   }
+
+  // Get pdf's from file and associate them to a QGLikelihoodCategory
+  // Some pdf's in the ROOT-file are copies from each other, with the same title: those are merged bins in pt and rho
+  // Here we do not store the copies, but extend the range of the category
+  std::map<std::vector<int>, TH1*> pdfs;
+  std::map<std::vector<int>, QGLikelihoodCategory> categories;
+  for(TString likelihoodVar : {"axis2","mult","ptD"}){
+    int varIndex = (likelihoodVar == "mult" ? 0 : (likelihoodVar == "axis2" ? 1 : 2));
+    for(TString type : {"quark","gluon"}){
+      int qgIndex = (type == "quark" ? 0 : 1);
+      for(int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i){
+        for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
+          for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
+            QGLikelihoodCategory category;
+            category.EtaMin   = gridOfBins["eta"][i];
+            category.EtaMax   = gridOfBins["eta"][i+1];
+            category.PtMin    = gridOfBins["pt"][j];
+            category.PtMax    = gridOfBins["pt"][j+1];
+            category.RhoMin   = gridOfBins["rho"][k];
+            category.RhoMax   = gridOfBins["rho"][k+1];
+            category.QGIndex  = qgIndex;
+            category.VarIndex = varIndex;
+
+            std::vector<int> binNumbers = {qgIndex, varIndex, i,j,k};
+            TString key = TString::Format(likelihoodVar + "/" + likelihoodVar + "_" + type + "_eta%d_pt%d_rho%d", i, j, k);
+            TH1* pdf = (TH1*) f->Get(key);
+            if(!pdf){
+              edm::LogError("NoPDF") << "Could not found pdf with key  " << key << " in input file" << std::endl;
+              return;
+            }
+
+            if(k > 0){											// If copy of neighbour rho category --> extend range of first one
+              std::vector<int> neighbour = {qgIndex, varIndex, i,j,k-1};
+              if(pdf->GetTitle() == pdfs[neighbour]->GetTitle()){
+                categories[neighbour].RhoMax = category.RhoMax;
+                continue;                
+              }
+            }
+            pdfs[binNumbers]       = pdf; 
+            categories[binNumbers] = category;
+          }
+          if(j > 0){											// If copy of neighbour pt category --> extend range of first one
+            for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){					// (also working after rho bins were already merged)
+              std::vector<int> cat1 = {qgIndex, varIndex, i,j-1,k};
+              std::vector<int> cat2 = {qgIndex, varIndex, i,j,k};
+              if(!pdfs.count(cat1) || !pdfs.count(cat2))             continue;
+              if(pdfs[cat1]->GetTitle() != pdfs[cat2]->GetTitle())   continue;
+              std::cout << pdfs[cat1]->GetTitle() << std::endl;
+              if(categories[cat1].RhoMin != categories[cat2].RhoMin) continue;
+              if(categories[cat1].RhoMax != categories[cat2].RhoMax) continue;
+              categories[cat1].PtMax = categories[cat2].PtMax;
+              categories.erase(cat2);
+              pdfs.erase(cat2);
+            }
+          }
+        }
+      }
+    }
+  }
+
+
+  // Get the weights from the file
+  std::map<std::vector<int>, float> weights;
+  for(int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i){
+    for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
+      for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
+        std::vector<float> weightsPerBin;
+        if(!getVectorFromFile(f, weightsPerBin, TString::Format("Weights/eta_%d_pt%d_rho%d", i, j, k))){
+          edm::LogError("NoWeights") << "Missing weights for bin eta" << i << "_pt" << j << "_rho" << k << "!" << std::endl;
+          weightsPerBin = {1,1,1};
+        }
+       
+        for(int varIndex = 0; varIndex < 3; ++varIndex){
+          std::vector<int> quarkCategory = {0, varIndex, i, j, k}; 
+          std::vector<int> gluonCategory = {1, varIndex, i, j, k}; 
+          weights[quarkCategory] = weightsPerBin[varIndex];
+          weights[gluonCategory] = weightsPerBin[varIndex];
+        }
+      }
+    }
+  }
+
+  // Write all categories with their histograms to file
+  int i = 0;
+  for(auto category : categories){
+
+    QGLikelihoodObject::Entry entry;
+    entry.category  = category.second;
+    entry.histogram = transformToHistogramObject(pdfs[category.first]);
+    entry.mean      = pdfs[category.first]->GetMean();
+    entry.weight    = weights[category.first];
+    payload->data.push_back(entry);
+    
+    char buff[1000];
+    sprintf(buff, "%6d) var=%1d, qg=%1d, eta={%6.2f, %6.2f}, pt={%8.2f, %8.2f}, rhoMin={%6.2f, %6.2f}, weight=%6.2f", i++,
+                        category.second.VarIndex, category.second.QGIndex, category.second.EtaMin, category.second.EtaMax, 
+                        category.second.PtMin,    category.second.PtMax,   category.second.RhoMin, category.second.RhoMax, entry.weight);
+    edm::LogVerbatim("HistName") << buff << std::endl;
+  }
+
   // Define the valid range, if no category is found within these bounds a warning will be thrown
-  payload->qgValidRange.RhoMin = rhoBins->Min();
-  payload->qgValidRange.RhoMax = rhoBins->Max();
-  payload->qgValidRange.EtaMin = etaBins->Min();
-  payload->qgValidRange.EtaMax = etaBins->Max();
-  payload->qgValidRange.PtMin  = ptBinsC->Min();
-  payload->qgValidRange.PtMax  = ptBinsC->Max();
-  payload->qgValidRange.QGIndex = -1;
+  payload->qgValidRange.EtaMin   = gridOfBins["eta"].front();
+  payload->qgValidRange.EtaMax   = gridOfBins["eta"].back();
+  payload->qgValidRange.PtMin    = gridOfBins["pt"].front();
+  payload->qgValidRange.PtMax    = gridOfBins["pt"].back();
+  payload->qgValidRange.RhoMin   = gridOfBins["rho"].front();
+  payload->qgValidRange.RhoMax   = gridOfBins["rho"].back();
+  payload->qgValidRange.QGIndex  = -1;
   payload->qgValidRange.VarIndex = -1;
 
   // Now write it into the DB

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -25,17 +25,17 @@ class  QGLikelihoodDBWriter : public edm::EDAnalyzer{
  public:
   QGLikelihoodDBWriter(const edm::ParameterSet&);
   virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
-  virtual void endJob() override {}
-  ~QGLikelihoodDBWriter() {}
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {};
+  virtual void endJob() override {};
+  ~QGLikelihoodDBWriter(){};
 
  private:
-  bool extractString(std::string, std::string&);
   bool getVectorFromFile(TFile*, std::vector<float>&, const TString&);
-  QGLikelihoodObject::Histogram transformToHistogramObject(TH1* th1);
-  std::string inputRootFile;
-  std::string payloadTag;
+  void tryToMerge(std::map<std::vector<int>, QGLikelihoodCategory>&, std::map<std::vector<int>, TH1*>&, std::vector<int>&, int);
+  QGLikelihoodObject::Histogram transformToHistogramObject(TH1*);
+  std::string inputRootFile, payloadTag;
 };
+
 
 // Constructor
 QGLikelihoodDBWriter::QGLikelihoodDBWriter(const edm::ParameterSet& pSet){
@@ -44,28 +44,49 @@ QGLikelihoodDBWriter::QGLikelihoodDBWriter(const edm::ParameterSet& pSet){
 }
 
 
-// Translates the TVector with the bins to std::vector
-bool QGLikelihoodDBWriter::getVectorFromFile(TFile* f, std::vector<float>& v, const TString& name){
-  TVectorT<float> *tv = nullptr;
-  f->GetObject(name, tv);
-  if(!tv) return false;
-  for(int i = 0; i < tv->GetNoElements(); ++i) v.push_back((*tv)[i]);
+// Get vector from input file (includes translating TVector to std::vector)
+bool QGLikelihoodDBWriter::getVectorFromFile(TFile* f, std::vector<float>& vector, const TString& name){
+  TVectorT<float> *tVector = nullptr;
+  f->GetObject(name, tVector);
+  if(!tVector) return false;
+  for(int i = 0; i < tVector->GetNoElements(); ++i) vector.push_back((*tVector)[i]);
   return true;
 }
+
 
 // Transform ROOT TH1 to QGLikelihoodObject (same indexing)
 QGLikelihoodObject::Histogram QGLikelihoodDBWriter::transformToHistogramObject(TH1* th1){
   QGLikelihoodObject::Histogram histogram(th1->GetNbinsX(), th1->GetXaxis()->GetBinLowEdge(1), th1->GetXaxis()->GetBinUpEdge(th1->GetNbinsX()));
-  for(int ibin = 0; ibin <= th1->GetNbinsX() + 1; ++ibin){
-    histogram.setBinContent(ibin, th1->GetBinContent(ibin));
-  }
+  for(int ibin = 0; ibin <= th1->GetNbinsX() + 1; ++ibin) histogram.setBinContent(ibin, th1->GetBinContent(ibin));
   return histogram;
+}
+
+
+// Try to merge bin with neighbouring bin (index = 2,3,4 for eta,pt,rho)
+void QGLikelihoodDBWriter::tryToMerge(std::map<std::vector<int>, QGLikelihoodCategory>& categories, std::map<std::vector<int>, TH1*>& pdfs, std::vector<int>& binNumbers, int index){
+  if(!pdfs[binNumbers]) return;
+  std::vector<int> neighbour = binNumbers;
+  do {
+    if(--(neighbour[index]) < 0) return;
+  } while (!pdfs[neighbour]);
+  if(TString(pdfs[binNumbers]->GetTitle()) != TString(pdfs[neighbour]->GetTitle())) return;
+  if(index != 4 && categories[neighbour].RhoMax != categories[binNumbers].RhoMax)   return;
+  if(index != 4 && categories[neighbour].RhoMin != categories[binNumbers].RhoMin)   return;
+  if(index != 3 && categories[neighbour].PtMax  != categories[binNumbers].PtMax)    return;
+  if(index != 3 && categories[neighbour].PtMin  != categories[binNumbers].PtMin)    return;
+  if(index != 2 && categories[neighbour].EtaMax != categories[binNumbers].EtaMax)   return;
+  if(index != 2 && categories[neighbour].EtaMin != categories[binNumbers].EtaMin)   return;
+
+  if(index == 4) categories[neighbour].RhoMax = categories[binNumbers].RhoMax;
+  if(index == 3) categories[neighbour].PtMax  = categories[binNumbers].PtMax;
+  if(index == 2) categories[neighbour].EtaMax = categories[binNumbers].EtaMax;
+  pdfs.erase(binNumbers);
+  categories.erase(binNumbers);
 }
 
 
 // Begin Job
 void QGLikelihoodDBWriter::beginJob(){
-
   QGLikelihoodObject *payload = new QGLikelihoodObject();
   payload->data.clear();
 
@@ -83,16 +104,17 @@ void QGLikelihoodDBWriter::beginJob(){
 
   // Get pdf's from file and associate them to a QGLikelihoodCategory
   // Some pdf's in the ROOT-file are copies from each other, with the same title: those are merged bins in pt and rho
-  // Here we do not store the copies, but extend the range of the category
+  // Here we do not store the copies, but try to extend the range of the neighbouring category (will result in less comparisons during application phase)
   std::map<std::vector<int>, TH1*> pdfs;
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
-  for(TString likelihoodVar : {"axis2","mult","ptD"}){
-    int varIndex = (likelihoodVar == "mult" ? 0 : (likelihoodVar == "axis2" ? 1 : 2));
-    for(TString type : {"quark","gluon"}){
-      int qgIndex = (type == "quark" ? 0 : 1);
+  for(TString type : {"gluon","quark"}){
+    int qgIndex = (type == "quark");
+    for(TString likelihoodVar : {"mult","axis2","ptD"}){
+      int varIndex = (likelihoodVar == "mult" ? 0 : (likelihoodVar == "axis2" ? 1 : 2));
       for(int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i){
         for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
           for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
+
             QGLikelihoodCategory category;
             category.EtaMin   = gridOfBins["eta"][i];
             category.EtaMax   = gridOfBins["eta"][i+1];
@@ -103,7 +125,6 @@ void QGLikelihoodDBWriter::beginJob(){
             category.QGIndex  = qgIndex;
             category.VarIndex = varIndex;
 
-            std::vector<int> binNumbers = {qgIndex, varIndex, i,j,k};
             TString key = TString::Format(likelihoodVar + "/" + likelihoodVar + "_" + type + "_eta%d_pt%d_rho%d", i, j, k);
             TH1* pdf = (TH1*) f->Get(key);
             if(!pdf){
@@ -111,29 +132,21 @@ void QGLikelihoodDBWriter::beginJob(){
               return;
             }
 
-            if(k > 0){											// If copy of neighbour rho category --> extend range of first one
-              std::vector<int> neighbour = {qgIndex, varIndex, i,j,k-1};
-              if(pdf->GetTitle() == pdfs[neighbour]->GetTitle()){
-                categories[neighbour].RhoMax = category.RhoMax;
-                continue;                
-              }
-            }
+            std::vector<int> binNumbers = {qgIndex, varIndex, i,j,k};
             pdfs[binNumbers]       = pdf; 
             categories[binNumbers] = category;
+
+            tryToMerge(categories, pdfs, binNumbers, 4);
           }
-          if(j > 0){											// If copy of neighbour pt category --> extend range of first one
-            for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){					// (also working after rho bins were already merged)
-              std::vector<int> cat1 = {qgIndex, varIndex, i,j-1,k};
-              std::vector<int> cat2 = {qgIndex, varIndex, i,j,k};
-              if(!pdfs.count(cat1) || !pdfs.count(cat2))             continue;
-              if(pdfs[cat1]->GetTitle() != pdfs[cat2]->GetTitle())   continue;
-              std::cout << pdfs[cat1]->GetTitle() << std::endl;
-              if(categories[cat1].RhoMin != categories[cat2].RhoMin) continue;
-              if(categories[cat1].RhoMax != categories[cat2].RhoMax) continue;
-              categories[cat1].PtMax = categories[cat2].PtMax;
-              categories.erase(cat2);
-              pdfs.erase(cat2);
-            }
+          for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
+            std::vector<int> binNumbers = {qgIndex, varIndex, i,j,k};
+            tryToMerge(categories, pdfs, binNumbers, 3);
+          }
+        }
+        for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
+          for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
+            std::vector<int> binNumbers = {qgIndex, varIndex, i,j,k};
+            tryToMerge(categories, pdfs, binNumbers, 2);
           }
         }
       }
@@ -147,17 +160,14 @@ void QGLikelihoodDBWriter::beginJob(){
     for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
       for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
         std::vector<float> weightsPerBin;
-        if(!getVectorFromFile(f, weightsPerBin, TString::Format("weights/Weights_eta%d_pt%d_rho%d", i, j, k))){
+        if(!getVectorFromFile(f, weightsPerBin, TString::Format("weights/eta%d_pt%d_rho%d", i, j, k))){
           edm::LogError("NoWeights") << "Missing weights for bin eta" << i << "_pt" << j << "_rho" << k << "!" << std::endl;
-          weightsPerBin = {1,1,1};
           return;
         }
        
         for(int varIndex = 0; varIndex < 3; ++varIndex){
-          std::vector<int> quarkCategory = {0, varIndex, i, j, k}; 
-          std::vector<int> gluonCategory = {1, varIndex, i, j, k}; 
-          weights[quarkCategory] = weightsPerBin[varIndex];
-          weights[gluonCategory] = weightsPerBin[varIndex];
+          weights[{0, varIndex, i, j, k}] = weightsPerBin[varIndex];
+          weights[{1, varIndex, i, j, k}] = weightsPerBin[varIndex];
         }
       }
     }
@@ -166,7 +176,6 @@ void QGLikelihoodDBWriter::beginJob(){
   // Write all categories with their histograms to file
   int i = 0;
   for(auto category : categories){
-
     QGLikelihoodObject::Entry entry;
     entry.category  = category.second;
     entry.histogram = transformToHistogramObject(pdfs[category.first]);
@@ -175,7 +184,7 @@ void QGLikelihoodDBWriter::beginJob(){
     payload->data.push_back(entry);
     
     char buff[1000];
-    sprintf(buff, "%6d) var=%1d, qg=%1d, eta={%6.2f, %6.2f}, pt={%8.2f, %8.2f}, rhoMin={%6.2f, %6.2f}, weight=%6.2f", i++,
+    sprintf(buff, "%6d) var=%1d\t\tqg=%1d\t\teta={%5.2f,%5.2f}\t\tpt={%8.2f,%8.2f}\t\trho={%6.2f,%8.2f}\t\tweight=%8.4f", i++,
                         category.second.VarIndex, category.second.QGIndex, category.second.EtaMin, category.second.EtaMax, 
                         category.second.PtMin,    category.second.PtMax,   category.second.RhoMin, category.second.RhoMax, entry.weight);
     edm::LogVerbatim("HistName") << buff << std::endl;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -154,39 +154,18 @@ void QGLikelihoodDBWriter::beginJob(){
   }
 
 
-  // Get the weights from the file
-  std::map<std::vector<int>, float> weights;
-  for(int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i){
-    for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
-      for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
-        std::vector<float> weightsPerBin;
-        if(!getVectorFromFile(f, weightsPerBin, TString::Format("weights/eta%d_pt%d_rho%d", i, j, k))){
-          edm::LogError("NoWeights") << "Missing weights for bin eta" << i << "_pt" << j << "_rho" << k << "!" << std::endl;
-          return;
-        }
-       
-        for(int varIndex = 0; varIndex < 3; ++varIndex){
-          weights[{0, varIndex, i, j, k}] = weightsPerBin[varIndex];
-          weights[{1, varIndex, i, j, k}] = weightsPerBin[varIndex];
-        }
-      }
-    }
-  }
-
   // Write all categories with their histograms to file
   int i = 0;
   for(auto category : categories){
     QGLikelihoodObject::Entry entry;
     entry.category  = category.second;
     entry.histogram = transformToHistogramObject(pdfs[category.first]);
-    entry.mean      = pdfs[category.first]->GetMean();
-    entry.weight    = weights[category.first];
     payload->data.push_back(entry);
     
     char buff[1000];
-    sprintf(buff, "%6d) var=%1d\t\tqg=%1d\t\teta={%5.2f,%5.2f}\t\tpt={%8.2f,%8.2f}\t\trho={%6.2f,%8.2f}\t\tweight=%8.4f", i++,
+    sprintf(buff, "%6d) var=%1d\t\tqg=%1d\t\teta={%5.2f,%5.2f}\t\tpt={%8.2f,%8.2f}\t\trho={%6.2f,%8.2f}", i++,
                         category.second.VarIndex, category.second.QGIndex, category.second.EtaMin, category.second.EtaMax, 
-                        category.second.PtMin,    category.second.PtMax,   category.second.RhoMin, category.second.RhoMax, entry.weight);
+                        category.second.PtMin,    category.second.PtMax,   category.second.RhoMin, category.second.RhoMax);
     edm::LogVerbatim("HistName") << buff << std::endl;
   }
 

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -25,9 +25,9 @@ class  QGLikelihoodDBWriter : public edm::EDAnalyzer{
  public:
   QGLikelihoodDBWriter(const edm::ParameterSet&);
   virtual void beginJob() override;
-  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {};
-  virtual void endJob() override {};
-  ~QGLikelihoodDBWriter(){};
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override {}
+  virtual void endJob() override {}
+  ~QGLikelihoodDBWriter(){}
 
  private:
   bool getVectorFromFile(TFile*, std::vector<float>&, const TString&);

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -147,7 +147,7 @@ void QGLikelihoodDBWriter::beginJob(){
     for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
       for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
         std::vector<float> weightsPerBin;
-        if(!getVectorFromFile(f, weightsPerBin, TString::Format("weights/Weights_eta_%d_pt%d_rho%d", i, j, k))){
+        if(!getVectorFromFile(f, weightsPerBin, TString::Format("weights/Weights_eta%d_pt%d_rho%d", i, j, k))){
           edm::LogError("NoWeights") << "Missing weights for bin eta" << i << "_pt" << j << "_rho" << k << "!" << std::endl;
           weightsPerBin = {1,1,1};
           return;

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -108,9 +108,9 @@ void QGLikelihoodDBWriter::beginJob(){
   std::map<std::vector<int>, TH1*> pdfs;
   std::map<std::vector<int>, QGLikelihoodCategory> categories;
   for(TString type : {"gluon","quark"}){
-    int qgIndex = (type == "quark");
-    for(TString likelihoodVar : {"mult","axis2","ptD"}){
-      int varIndex = (likelihoodVar == "mult" ? 0 : (likelihoodVar == "axis2" ? 1 : 2));
+    int qgIndex = (type == "gluon");									// Keep numbering same as in RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+    for(TString likelihoodVar : {"mult","ptD","axis2"}){
+      int varIndex = (likelihoodVar == "mult" ? 0 : (likelihoodVar == "ptD" ? 1 : 2));			// Keep order same as in RecoJets/JetProducers/plugins/QGTagger.cc
       for(int i = 0; i < (int)gridOfBins["eta"].size() - 1; ++i){
         for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
           for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){

--- a/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
+++ b/JetMETCorrections/Modules/plugins/QGLikelihoodDBWriter.cc
@@ -147,9 +147,10 @@ void QGLikelihoodDBWriter::beginJob(){
     for(int j = 0; j < (int)gridOfBins["pt"].size() - 1; ++j){
       for(int k = 0; k < (int)gridOfBins["rho"].size() - 1; ++k){
         std::vector<float> weightsPerBin;
-        if(!getVectorFromFile(f, weightsPerBin, TString::Format("Weights/eta_%d_pt%d_rho%d", i, j, k))){
+        if(!getVectorFromFile(f, weightsPerBin, TString::Format("weights/Weights_eta_%d_pt%d_rho%d", i, j, k))){
           edm::LogError("NoWeights") << "Missing weights for bin eta" << i << "_pt" << j << "_rho" << k << "!" << std::endl;
           weightsPerBin = {1,1,1};
+          return;
         }
        
         for(int varIndex = 0; varIndex < 3; ++varIndex){

--- a/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
@@ -10,7 +10,7 @@ process.MessageLogger = cms.Service("MessageLogger",
             ),
 )
 
-qgDatabaseVersion = 'v1.1'
+qgDatabaseVersion = 'v1'
 
 process.load('CondCore.DBCommon.CondDBCommon_cfi')
 process.CondDBCommon.connect = 'sqlite_file:QGL_'+qgDatabaseVersion+'.db'
@@ -19,21 +19,11 @@ process.source = cms.Source('EmptySource')
 process.PoolDBOutputService = cms.Service('PoolDBOutputService',
    process.CondDBCommon,
    toPut = cms.VPSet(
-      cms.PSet(
-         record = cms.string('QGL_AK5PF'),
-         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK5PF'),
-         label  = cms.string('QGL_AK5PF')
-      ),
-      cms.PSet(
-         record = cms.string('QGL_AK5PFchs'),
-         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK5PFchs'),
-         label  = cms.string('QGL_AK5PFchs')
-      ),
-      cms.PSet(
-         record = cms.string('QGL_AK4PF'),
-         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF'),
-         label  = cms.string('QGL_AK4PF')
-      ),
+#      cms.PSet(
+#         record = cms.string('QGL_AK4PF'),
+#         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF'),
+#         label  = cms.string('QGL_AK4PF')
+#      ),
       cms.PSet(
          record = cms.string('QGL_AK4PFchs'),
          tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PFchs'),
@@ -54,23 +44,14 @@ process.PoolDBOutputService = cms.Service('PoolDBOutputService',
 )
 
 srcDirectory = 'temp/'
-process.dbWriterAK4PF = cms.EDAnalyzer('QGLikelihoodDBWriter',
-   src    = cms.string(srcDirectory + 'pdfQG_AK4_13TeV.root'),
-   payload= cms.string('QGL_AK4PF')
-) 
+#process.dbWriterAK4PF = cms.EDAnalyzer('QGLikelihoodDBWriter',
+#   src    = cms.string(srcDirectory + 'pdfQG_AK4_13TeV.root'),
+#   payload= cms.string('QGL_AK4PF')
+#) 
 process.dbWriterAK4PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter',
-   src    = cms.string(srcDirectory + 'pdfQG_AK4chs_13TeV.root'),
+   src    = cms.string(srcDirectory + 'pdfQG_AK4chs_13TeV_smallEtaBinning_newTest.root'),
    payload= cms.string('QGL_AK4PFchs')
 ) 
-process.dbWriterAK5PF = cms.EDAnalyzer('QGLikelihoodDBWriter',
-   src    = cms.string(srcDirectory + 'pdfQG_AK5_13TeV.root'),
-   payload= cms.string('QGL_AK5PF')
-) 
-process.dbWriterAK5PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter',
-   src    = cms.string(srcDirectory + 'pdfQG_AK5chs_13TeV.root'),
-   payload= cms.string('QGL_AK5PFchs')
-)
-
 # ONLY AFTER FIRST DATA:
 #process.dbWriterSystPythia = cms.EDAnalyzer('QGLikelihoodSystematicsDBWriter',
 #   src    = cms.string(srcDirectory + 'SystDatabase.txt'),
@@ -82,4 +63,4 @@ process.dbWriterAK5PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter',
 #)
  
 
-process.p = cms.Path(process.dbWriterAK4PF*process.dbWriterAK5PF*process.dbWriterAK4PFchs*process.dbWriterAK5PFchs)
+process.p = cms.Path(process.dbWriterAK4PFchs)

--- a/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
+++ b/JetMETCorrections/Modules/test/QGLikelihoodDBWriter_cfg.py
@@ -19,15 +19,25 @@ process.source = cms.Source('EmptySource')
 process.PoolDBOutputService = cms.Service('PoolDBOutputService',
    process.CondDBCommon,
    toPut = cms.VPSet(
-#      cms.PSet(
-#         record = cms.string('QGL_AK4PF'),
-#         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF'),
-#         label  = cms.string('QGL_AK4PF')
-#      ),
+      cms.PSet(
+         record = cms.string('QGL_AK4PF'),
+         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF'),
+         label  = cms.string('QGL_AK4PF')
+      ),
       cms.PSet(
          record = cms.string('QGL_AK4PFchs'),
          tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PFchs'),
          label  = cms.string('QGL_AK4PFchs')
+      ),
+      cms.PSet(
+         record = cms.string('QGL_AK4PF_antib'),
+         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF_antib'),
+         label  = cms.string('QGL_AK4PF_antib')
+      ),
+      cms.PSet(
+         record = cms.string('QGL_AK4PFchs_antib'),
+         tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PFchs_antib'),
+         label  = cms.string('QGL_AK4PFchs_antib')
       ),
 # ONLY AFTER FIRST DATA
 #     cms.PSet(
@@ -43,15 +53,24 @@ process.PoolDBOutputService = cms.Service('PoolDBOutputService',
    )
 )
 
-srcDirectory = 'temp/'
-#process.dbWriterAK4PF = cms.EDAnalyzer('QGLikelihoodDBWriter',
-#   src    = cms.string(srcDirectory + 'pdfQG_AK4_13TeV.root'),
-#   payload= cms.string('QGL_AK4PF')
-#) 
+# The ROOT files of v1 are at /afs/cern.ch/user/t/tomc/public/qgTagger/QGLikelihoodDBFiles/QGL_v1
+srcDirectory = 'JetMETCorrections/Modules/test/' + qgDatabaseVersion + '/'
+process.dbWriterAK4PF = cms.EDAnalyzer('QGLikelihoodDBWriter',
+   src    = cms.string(srcDirectory + 'pdfQG_AK4_13TeV_' + qgDatabaseVersion + '.root'),
+   payload= cms.string('QGL_AK4PF')
+)
 process.dbWriterAK4PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter',
-   src    = cms.string(srcDirectory + 'pdfQG_AK4chs_13TeV_smallEtaBinning_newTest.root'),
+   src    = cms.string(srcDirectory + 'pdfQG_AK4chs_13TeV_' + qgDatabaseVersion + '.root'),
    payload= cms.string('QGL_AK4PFchs')
-) 
+)
+process.dbWriterAK4PF_antib = cms.EDAnalyzer('QGLikelihoodDBWriter',
+   src    = cms.string(srcDirectory + 'pdfQG_AK4_antib_13TeV_' + qgDatabaseVersion + '.root'),
+   payload= cms.string('QGL_AK4PF_antib')
+)
+process.dbWriterAK4PFchs_antib = cms.EDAnalyzer('QGLikelihoodDBWriter',
+   src    = cms.string(srcDirectory + 'pdfQG_AK4chs_antib_13TeV_' + qgDatabaseVersion + '.root'),
+   payload= cms.string('QGL_AK4PFchs_antib')
+)
 # ONLY AFTER FIRST DATA:
 #process.dbWriterSystPythia = cms.EDAnalyzer('QGLikelihoodSystematicsDBWriter',
 #   src    = cms.string(srcDirectory + 'SystDatabase.txt'),
@@ -63,4 +82,4 @@ process.dbWriterAK4PFchs = cms.EDAnalyzer('QGLikelihoodDBWriter',
 #)
  
 
-process.p = cms.Path(process.dbWriterAK4PFchs)
+process.p = cms.Path(process.dbWriterAK4PF * process.dbWriterAK4PFchs * process.dbWriterAK4PF_antib * process.dbWriterAK4PFchs_antib)

--- a/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+++ b/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
@@ -17,11 +17,11 @@ float QGLikelihoodCalculator::computeQGLikelihood(edm::ESHandle<QGLikelihoodObje
 
     int binQ = quarkEntry->histogram.findBin(vars[varIndex]);
     float Qi = quarkEntry->histogram.binContent(binQ);
-    float Qw = quarkEntry->histogram.binRange(binQ).width();
+    float Qw = (binQ == 0 || binQ == quarkEntry->histogram.numberOfBins()+1)? 1. : quarkEntry->histogram.binRange(binQ).width();
 
     int binG = gluonEntry->histogram.findBin(vars[varIndex]);
     float Gi = gluonEntry->histogram.binContent(binG);
-    float Gw = gluonEntry->histogram.binRange(binG).width();
+    float Gw = (binG == 0 || binQ == gluonEntry->histogram.numberOfBins()+1)? 1. : gluonEntry->histogram.binRange(binG).width();
 
     if(Qi <= 0 || Gi <= 0){	// If one of the two pdf's is empty for this value, look if we have some content in the neighbouring bins
       int q = 1, g = 1;

--- a/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+++ b/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
@@ -21,7 +21,7 @@ float QGLikelihoodCalculator::computeQGLikelihood(edm::ESHandle<QGLikelihoodObje
 
     int binG = gluonEntry->histogram.findBin(vars[varIndex]);
     float Gi = gluonEntry->histogram.binContent(binG);
-    float Gw = (binG == 0 || binQ == gluonEntry->histogram.numberOfBins()+1)? 1. : gluonEntry->histogram.binRange(binG).width();
+    float Gw = (binG == 0 || binG == gluonEntry->histogram.numberOfBins()+1)? 1. : gluonEntry->histogram.binRange(binG).width();
 
     if(Qi <= 0 || Gi <= 0){	// If one of the two pdf's is empty for this value, look if we have some content in the neighbouring bins
       int q = 1, g = 1;

--- a/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+++ b/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
@@ -42,7 +42,7 @@ float QGLikelihoodCalculator::computeQGLikelihood(edm::ESHandle<QGLikelihoodObje
     }
 
  
-    Q *= std::pow(Qi/Qw, quarkEntry->weight);
+    Q *= std::pow(Qi/Qw, quarkEntry->weight);	// Both quarkEntry and gluonEntry have always the same weight
     G *= std::pow(Gi/Gw, gluonEntry->weight);
   }
 

--- a/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
+++ b/RecoJets/JetAlgorithms/src/QGLikelihoodCalculator.cc
@@ -17,33 +17,12 @@ float QGLikelihoodCalculator::computeQGLikelihood(edm::ESHandle<QGLikelihoodObje
 
     int binQ = quarkEntry->histogram.findBin(vars[varIndex]);
     float Qi = quarkEntry->histogram.binContent(binQ);
-    float Qw = (binQ == 0 || binQ == quarkEntry->histogram.numberOfBins()+1)? 1. : quarkEntry->histogram.binRange(binQ).width();
 
     int binG = gluonEntry->histogram.findBin(vars[varIndex]);
     float Gi = gluonEntry->histogram.binContent(binG);
-    float Gw = (binG == 0 || binG == gluonEntry->histogram.numberOfBins()+1)? 1. : gluonEntry->histogram.binRange(binG).width();
 
-    if(Qi <= 0 || Gi <= 0){	// If one of the two pdf's is empty for this value, look if we have some content in the neighbouring bins
-      int q = 1, g = 1;
-      while(Qi <= 0 && binQ-q > 0 && binQ+q <= quarkEntry->histogram.numberOfBins()){
-        Qi += quarkEntry->histogram.binContent(binQ+q)       + quarkEntry->histogram.binContent(binQ-q);
-        Qw += quarkEntry->histogram.binRange(binQ+q).width() + quarkEntry->histogram.binRange(binQ-q).width();
-        ++q;
-      }
-      while(Gi <= 0 && binG-g > 0 && binG+g <= gluonEntry->histogram.numberOfBins()){
-        Gi += gluonEntry->histogram.binContent(binG+g)       + gluonEntry->histogram.binContent(binG-g);
-        Gw += gluonEntry->histogram.binRange(binG+g).width() + gluonEntry->histogram.binRange(binG-g).width();
-        ++g;
-      }
-      if(Qi <= 0 && Gi <= 0){	// If both are still completely zero, assign extreme value based on position of means
-        if(vars[varIndex] < quarkEntry->mean) 	if(quarkEntry->mean > gluonEntry->mean){ Qi = 0.999; Gi = 0.001;} else { Qi = 0.001; Gi = 0.999;}
-        else					if(quarkEntry->mean < gluonEntry->mean){ Qi = 0.001; Gi = 0.999;} else { Qi = 0.999; Gi = 0.001;}
-      }
-    }
-
- 
-    Q *= std::pow(Qi/Qw, quarkEntry->weight);	// Both quarkEntry and gluonEntry have always the same weight
-    G *= std::pow(Gi/Gw, gluonEntry->weight);
+    Q *= Qi;
+    G *= Gi;
   }
 
   if(Q==0) return 0;


### PR DESCRIPTION
This pull request includes:
- Introducing a weight for each likelihood variable, which will be used to get a better performance for high pt jets (see JMAR meeting 11 December 2014)
- Small optimization of the algorithm when dealing with empty bins in the tails of the pdf's
- Some clean-up and optimizations on the QGLikelihoodDBWriter code (the input src files and created QGL_v1.db file can be found at /afs/cern.ch/user/t/tomc/public/qgTagger/QGLikelihoodDBFiles)
