### PR TITLE
Cache function return types

### DIFF
--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -109,7 +109,7 @@ MethodInvoker::
 returnTypeName() const
 {
   if (isFunction_) {
-    return method_.finalReturnType().qualifiedName();
+    return method_.typeName();
   }
   return member_.typeOf().qualifiedName();
 }

--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -79,7 +79,7 @@ push(const string& name, const vector<AnyMethodArgument>& args,
           << "member \"" << mem.first.name()
           << "\" return type is invalid:\n"
           << "  return type: \""
-          << mem.first.finalReturnType().qualifiedName() << "\"\n";
+          << mem.first.typeName() << "\"\n";
     }
     typeStack_.push_back(retType);
     // check for edm::Ref, edm::RefToBase, edm::Ptr


### PR DESCRIPTION
relval 25 step 3 ran 20% slower per event in ROOT6 that in ROOT5.  Much of the problem was traced to FunctionWithDict::finalReturnType(), which constructed a TypeWithDict from the name of the function's  return type every time it was called.   Simply caching the return types in a concurrent_unordered_map reduced the run time of finalReturnType() by two orders of magnitude, and recovered most or all of the 20% performance deficit.
Please merge this pull request as soon as convenient.
