### PR TITLE
Check immediate return status from XrdClFile::Open call.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdHostHandler.hh
+++ b/Utilities/XrdAdaptor/src/XrdHostHandler.hh
@@ -39,7 +39,7 @@ public:
 
   virtual void HandleResponseWithHosts(XrdCl::XRootDStatus *status,
                                        XrdCl::AnyObject    *response,
-                                       XrdCl::HostList     *hostList)
+                                       XrdCl::HostList     *hostList) override
   {
     pStatus.reset(status);
     pResponse.reset(response);


### PR DESCRIPTION
This catches a case where the return status from XrdClFile::Open
is not checked.  Previously, oversight this was OK -- no failure
could happen immediately.  However, in bdbec57a we introduced a
query to the redirector prior to the first file open.  If the query
failed with a fatal error, then the open may fail immediately.

As the open status is not checked, we proceed to waiting for the
callback - which hangs indefinitely.
