### PR TITLE
Remove calls to Ref::product from Fireworks

### DIFF
--- a/DataFormats/FWLite/interface/ChainEvent.h
+++ b/DataFormats/FWLite/interface/ChainEvent.h
@@ -72,6 +72,8 @@ namespace fwlite {
                                                  char const*,
                                                  char const*) const;
 
+      using fwlite::EventBase::getByLabel;
+
       // This function should only be called by fwlite::Handle<>
       virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const;
       //void getByBranchName(std::type_info const&, char const*, void*&) const;
@@ -115,7 +117,7 @@ namespace fwlite {
 
       // ---------- member functions ---------------------------
 
-      edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
       edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
 
       void getThinnedProducts(edm::ProductID const& pid,

--- a/DataFormats/FWLite/interface/Event.h
+++ b/DataFormats/FWLite/interface/Event.h
@@ -144,7 +144,7 @@ namespace fwlite {
             return branchMap_.getFile();
          }
 
-         edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+         virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
          edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
          void getThinnedProducts(edm::ProductID const& pid,
                                  std::vector<edm::WrapperBase const*>& foundContainers,

--- a/DataFormats/FWLite/interface/EventBase.h
+++ b/DataFormats/FWLite/interface/EventBase.h
@@ -27,6 +27,12 @@
 
 #include "Rtypes.h"
 
+namespace edm {
+   class BasicHandle;
+   class ProductID;
+   class WrapperBase;
+}
+
 namespace fwlite
 {
    class EventBase : public edm::EventBase
@@ -42,6 +48,8 @@ namespace fwlite
                                   char const*,
                                   char const*,
                                   void*) const = 0;
+
+         virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const = 0;
 
          using edm::EventBase::getByLabel;
 
@@ -62,6 +70,7 @@ namespace fwlite
       private:
 
          virtual edm::BasicHandle getByLabelImpl(std::type_info const&, std::type_info const&, const edm::InputTag&) const;
+         virtual edm::BasicHandle getImpl(std::type_info const&, edm::ProductID const&) const;
    };
 } // fwlite namespace
 

--- a/DataFormats/FWLite/interface/MultiChainEvent.h
+++ b/DataFormats/FWLite/interface/MultiChainEvent.h
@@ -82,6 +82,8 @@ class MultiChainEvent: public EventBase
                                                  char const*,
                                                  char const*) const;
 
+      using fwlite::EventBase::getByLabel;
+
       /** This function should only be called by fwlite::Handle<>*/
       virtual bool getByLabel(std::type_info const&, char const*, char const*, char const*, void*) const;
       //void getByBranchName(std::type_info const&, char const*, void*&) const;
@@ -133,7 +135,7 @@ class MultiChainEvent: public EventBase
 
       // ---------- member functions ---------------------------
 
-      edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
+      virtual edm::WrapperBase const* getByProductID(edm::ProductID const&) const;
 
       edm::WrapperBase const* getThinnedProduct(edm::ProductID const& pid, unsigned int& key) const;
 

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -17,9 +17,12 @@ Test program for edm::Ref use in ROOT.
 #include "FWCore/Utilities/interface/TestHelper.h"
 
 #include "DataFormats/FWLite/interface/ChainEvent.h"
+#include "DataFormats/FWLite/interface/EventBase.h"
 #include "DataFormats/FWLite/interface/MultiChainEvent.h"
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+
 static char* gArgV = 0;
 
 extern "C" char** environ;
@@ -165,6 +168,7 @@ void testRefInROOT::testEventBase()
    edm::InputTag tagFull("OtherThing","testUserTag","TEST");
    edm::InputTag tag("OtherThing","testUserTag");
    edm::InputTag tagNotHere("NotHereOtherThing");
+   edm::InputTag tagThing("Thing");
    edm::EventBase* eventBase = &events;
    
    for(events.toBegin(); not events.atEnd(); ++events) {
@@ -173,7 +177,19 @@ void testRefInROOT::testEventBase()
          edm::Handle<edmtest::OtherThingCollection> pOthers;
          eventBase->getByLabel(tagFull,pOthers);
          CPPUNIT_ASSERT(pOthers.isValid());
-         pOthers->size();
+
+         // Test that the get function that takes a ProductID works
+         // by getting a ProductID from a Ref stored in the OtherThingCollection
+         // and testing that one can retrieve the ThingCollection with it.
+         CPPUNIT_ASSERT(pOthers->size() > 0 );
+         edmtest::OtherThingCollection::const_iterator itOther = pOthers->begin();
+         edm::ProductID thingProductID = itOther->ref.id();
+         edm::Handle<edmtest::ThingCollection> thingCollectionHandle;
+         eventBase->get(thingProductID, thingCollectionHandle);
+         edm::Handle<edmtest::ThingCollection> thingCollectionHandle2;
+         eventBase->getByLabel(tagThing, thingCollectionHandle2);
+         CPPUNIT_ASSERT(thingCollectionHandle.product() == thingCollectionHandle2.product() &&
+                        thingCollectionHandle.product()->begin()->a == thingCollectionHandle2.product()->begin()->a);
       }
       {
          edm::Handle<edmtest::OtherThingCollection> pOthers;

--- a/FWCore/Common/interface/EventBase.h
+++ b/FWCore/Common/interface/EventBase.h
@@ -39,6 +39,7 @@
 namespace edm {
 
    class ProcessHistory;
+   class ProductID;
    class TriggerResults;
    class TriggerNames;
 
@@ -51,6 +52,9 @@ namespace edm {
       // ---------- const member functions ---------------------
       template<typename T>
       bool getByLabel(InputTag const&, Handle<T>&) const;
+
+      template<typename T>
+      bool get(ProductID const&, Handle<T>&) const;
 
       // AUX functions.
       edm::EventID id() const {return eventAuxiliary().id();}
@@ -77,6 +81,7 @@ namespace edm {
       //EventBase const& operator=(EventBase const&); // allow default
 
       virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const = 0;
+      virtual BasicHandle getImpl(std::type_info const& iProductType, ProductID const& iTag) const = 0;
       // ---------- member data --------------------------------
 
    };
@@ -88,6 +93,18 @@ namespace edm {
       result.clear();
       BasicHandle bh = this->getByLabelImpl(typeid(edm::Wrapper<T>), typeid(T), tag);
      convert_handle(std::move(bh), result);  // throws on conversion error
+      if (result.failedToGet()) {
+         return false;
+      }
+      return true;
+   }
+
+   template<typename T>
+   bool
+   EventBase::get(ProductID const& pid, Handle<T>& result) const {
+      result.clear();
+      BasicHandle bh = this->getImpl(typeid(T), pid);
+      convert_handle(std::move(bh), result);  // throws on conversion error
       if (result.failedToGet()) {
          return false;
       }

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -231,6 +231,9 @@ namespace edm {
     //override used by EventBase class
     virtual BasicHandle getByLabelImpl(std::type_info const& iWrapperType, std::type_info const& iProductType, InputTag const& iTag) const;
 
+    //override used by EventBase class
+    virtual BasicHandle getImpl(std::type_info const& iProductType, ProductID const& pid) const;
+
     // commit_() is called to complete the transaction represented by
     // this PrincipalGetAdapter. The friendships required seems gross, but any
     // alternative is not great either.  Putting it into the

--- a/FWCore/Framework/src/Event.cc
+++ b/FWCore/Framework/src/Event.cc
@@ -195,6 +195,15 @@ namespace edm {
     return h;
   }
 
+  BasicHandle
+  Event::getImpl(std::type_info const&, ProductID const& pid) const {
+    BasicHandle h = this->getByProductID_(pid);
+    if(h.isValid()) {
+      addToGotBranchIDs(*(h.provenance()));
+    }
+    return h;
+  }
+
   TriggerNames const&
   Event::triggerNames(edm::TriggerResults const& triggerResults) const {
     edm::TriggerNames const* names = triggerNames_(triggerResults);

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -481,6 +481,20 @@ void testEvent::getByProductID() {
   CPPUNIT_ASSERT(!h.isValid());
   CPPUNIT_ASSERT(h.failedToGet());
   CPPUNIT_ASSERT_THROW(*h, cms::Exception);
+
+  edm::EventBase* baseEvent = currentEvent_.get();
+  handle_t h1;
+  baseEvent->get(wanted, h1);
+  CPPUNIT_ASSERT(h1.isValid());
+  CPPUNIT_ASSERT(h1.id() == wanted);
+  CPPUNIT_ASSERT(h1->value == 1);
+
+  CPPUNIT_ASSERT_THROW(baseEvent->get(invalid, h1), cms::Exception);
+  CPPUNIT_ASSERT(!h1.isValid());
+  CPPUNIT_ASSERT(!baseEvent->get(notpresent, h1));
+  CPPUNIT_ASSERT(!h1.isValid());
+  CPPUNIT_ASSERT(h1.failedToGet());
+  CPPUNIT_ASSERT_THROW(*h1, cms::Exception);
 }
 
 void testEvent::transaction() {

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -18,6 +18,8 @@
 #include "Fireworks/Core/interface/TEveElementIter.h"
 #include "Fireworks/Core/interface/fwLog.h"
 
+#include "DataFormats/Common/interface/Handle.h"
+
 #include "DataFormats/TrackReco/interface/Track.h"
 
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
@@ -51,6 +53,8 @@
 
 #include "DataFormats/HcalDetId/interface/HcalSubdetector.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
+
+#include "FWCore/Common/interface/EventBase.h"
 
 namespace fireworks {
 
@@ -393,7 +397,9 @@ addSiStripClusters( const FWEventItem* iItem, const reco::Track &t, class TEveEl
             const SiStripRecHit2D &hit = static_cast<const SiStripRecHit2D &>( **it );
             if( hit.cluster().isNonnull() && hit.cluster().isAvailable())
 	    {
-               allClusters = hit.cluster().product();
+               edm::Handle<edmNew::DetSetVector<SiStripCluster> > allClustersHandle;
+               iItem->getEvent()->get(hit.cluster().id(), allClustersHandle);
+               allClusters = allClustersHandle.product();
                break;
             }
          }
@@ -402,7 +408,9 @@ addSiStripClusters( const FWEventItem* iItem, const reco::Track &t, class TEveEl
             const SiStripRecHit1D &hit = static_cast<const SiStripRecHit1D &>( **it );
             if( hit.cluster().isNonnull() && hit.cluster().isAvailable())
 	    {
-               allClusters = hit.cluster().product();
+               edm::Handle<edmNew::DetSetVector<SiStripCluster> > allClustersHandle;
+               iItem->getEvent()->get(hit.cluster().id(), allClustersHandle);
+               allClusters = allClustersHandle.product();
                break;
             }
          }
@@ -550,8 +558,10 @@ pushNearbyPixelHits( std::vector<TVector3> &pixelPoints, const FWEventItem &iIte
          const SiPixelRecHit &hit = static_cast<const SiPixelRecHit &>(**it);
          if( hit.cluster().isNonnull() && hit.cluster().isAvailable())
 	 {
-	    allClusters = hit.cluster().product();
-	    break;
+            edm::Handle<edmNew::DetSetVector<SiPixelCluster> > allClustersHandle;
+            iItem.getEvent()->get(hit.cluster().id(), allClustersHandle);
+            allClusters = allClustersHandle.product();
+            break;
 	 }
       }
    }


### PR DESCRIPTION
Remove the calls to Ref::product from Fireworks.
This is motivated by changes in the Ref needed
to support the miniAOD format. The removed calls
are replaced by adding a function to the EventBase
interface that allows getting a product using the
ProductID. After the change we explicitly get the
ProductID from the Ref and then use the new function
in EventBase to get the container product instead
of getting the container product directly from the
Ref.

I extended the unit tests for the Core part of this,
but have not tested the Fireworks part of this beyond
checking that it compiles (expecting the Fireworks
experts to test that, Matevz agreed to do that).
