### PR TITLE
toType() must  strip off only one array dimension

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -664,9 +664,14 @@ namespace edm {
     }
     if(isArray()) {
       TypeWithDict newType = *this;
-      newType.property_ &= ~((long) kIsArray);
-      value_ptr<std::vector<size_t> > emptyVec;
-      newType.arrayDimensions_ = emptyVec;
+      size_t size = newType.arrayDimensions_->size();
+      if(size == 1) {
+        newType.property_ &= ~((long) kIsArray);
+        value_ptr<std::vector<size_t> > emptyVec;
+        newType.arrayDimensions_ = emptyVec;
+      } else {
+        newType.arrayDimensions_->resize(size - 1);
+      }
       return newType;
     }
     return *this;


### PR DESCRIPTION
Bug fix for error revealed by unit test in CondCore/CondDB.
TypeWithDict::toType() must strip only the last dimension from a multidimensional array, rather than all the dimensions,
Please merge this request as soon as convenient.
