### PR TITLE
Update of VBF HLT filter

### DIFF
--- a/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
@@ -23,7 +23,7 @@
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/Handle.h"
 namespace edm {
-  class ConfigurationDescriptions;
+	class ConfigurationDescriptions;
 }
 
 //
@@ -31,33 +31,34 @@ namespace edm {
 //
 template<typename T>
 class HLTJetSortedVBFFilter : public HLTFilter {
- public:
-  typedef std::pair<double,unsigned int> Jpair;
-  static bool comparator ( const Jpair& l, const Jpair& r) {
-    return l.first < r.first;
-  }
+	public:
+		typedef std::pair<double,unsigned int> Jpair;
+		static bool comparator ( const Jpair& l, const Jpair& r) {
+			return l.first < r.first;
+		}
 
-  explicit HLTJetSortedVBFFilter(const edm::ParameterSet&);
-  ~HLTJetSortedVBFFilter();
-  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
-  static float findCSV(const  typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection & jetTags);	
-  virtual bool hltFilter(edm::Event&, const edm::EventSetup&,trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
+		explicit HLTJetSortedVBFFilter(const edm::ParameterSet&);
+		~HLTJetSortedVBFFilter();
+		static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
+		static float findCSV(const  typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection & jetTags);	
+		virtual bool hltFilter(edm::Event&, const edm::EventSetup&,trigger::TriggerFilterObjectWithRefs& filterproduct) const override;
 
- private:
-  edm::EDGetTokenT<std::vector<T>> m_theJetsToken;
-  edm::EDGetTokenT<reco::JetTagCollection> m_theJetTagsToken;
-  edm::InputTag inputJets_;
-  edm::InputTag inputJetTags_;
-  double mqq_;
-  double detaqq_;
-  double detabb_;
-  double dphibb_;
-  double ptsqq_;
-  double ptsbb_;
-  double seta_;
-  double njets_;
-  std::string value_;
-  int triggerType_;
+	private:
+		edm::EDGetTokenT<std::vector<T>> m_theJetsToken;
+		edm::EDGetTokenT<reco::JetTagCollection> m_theJetTagsToken;
+		edm::InputTag inputJets_;
+		edm::InputTag inputJetTags_;
+		double mqq_;
+		double detaqq_;
+		double detabb_;
+		double dphibb_;
+		double ptsqq_;
+		double ptsbb_;
+		double seta_;
+		double njets_;
+		std::string value_;
+		int triggerType_;
 };
 
 #endif
+

--- a/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
@@ -36,9 +36,6 @@ class HLTJetSortedVBFFilter : public HLTFilter {
   static bool comparator ( const Jpair& l, const Jpair& r) {
     return l.first < r.first;
   }
-  static bool comparator_inv ( const Jpair& l, const Jpair& r) {
-    return l.first > r.first;
-  }
 
   explicit HLTJetSortedVBFFilter(const edm::ParameterSet&);
   ~HLTJetSortedVBFFilter();

--- a/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
@@ -18,8 +18,8 @@
 #include "DataFormats/BTauReco/interface/JetTag.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 #include "HLTrigger/HLTcore/interface/HLTFilter.h"
-#include<string>
-#include<vector>
+#include <string>
+#include <vector>
 #include "DataFormats/Common/interface/RefToBase.h"
 #include "DataFormats/Common/interface/Handle.h"
 namespace edm {
@@ -35,6 +35,9 @@ class HLTJetSortedVBFFilter : public HLTFilter {
   typedef std::pair<double,unsigned int> Jpair;
   static bool comparator ( const Jpair& l, const Jpair& r) {
     return l.first < r.first;
+  }
+  static bool comparator_inv ( const Jpair& l, const Jpair& r) {
+    return l.first > r.first;
   }
 
   explicit HLTJetSortedVBFFilter(const edm::ParameterSet&);
@@ -55,6 +58,8 @@ class HLTJetSortedVBFFilter : public HLTFilter {
   double ptsqq_;
   double ptsbb_;
   double seta_;
+  double njets_;
+  double csvloose_;
   std::string value_;
   int triggerType_;
 };

--- a/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
+++ b/HLTrigger/JetMET/interface/HLTJetSortedVBFFilter.h
@@ -59,7 +59,6 @@ class HLTJetSortedVBFFilter : public HLTFilter {
   double ptsbb_;
   double seta_;
   double njets_;
-  double csvloose_;
   std::string value_;
   int triggerType_;
 };

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -107,17 +107,16 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
 	typedef Ref<TCollection> TRef;
 
 	bool accept(false);
-	const unsigned int nMax(njets_);
-
-	if (saveTags()) filterproduct.addCollectionTag(inputJets_);
-
-	vector<Jpair> sorted(nMax);
-	vector<TRef> jetRefs(nMax);
-
+	
 	Handle<TCollection> jets;
 	event.getByToken(m_theJetsToken,jets);
 	Handle<JetTagCollection> jetTags;
+
 	if (jets->size()<4) return false;
+
+	const unsigned int nMax(njets_<jets->size()?njets_:jets->size());
+	vector<Jpair> sorted(nMax);
+	vector<TRef> jetRefs(nMax);
 
 	unsigned int nJet=0;
 	double value(0.0);

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -30,65 +30,65 @@ using namespace std;
 //
 template<typename T>
 HLTJetSortedVBFFilter<T>::HLTJetSortedVBFFilter(const edm::ParameterSet& iConfig) : HLTFilter(iConfig)
- ,inputJets_   (iConfig.getParameter<edm::InputTag>("inputJets"   ))
- ,inputJetTags_(iConfig.getParameter<edm::InputTag>("inputJetTags"))
- ,mqq_         (iConfig.getParameter<double>       ("Mqq"         ))
- ,detaqq_      (iConfig.getParameter<double>       ("Detaqq"      ))
- ,detabb_      (iConfig.getParameter<double>       ("Detabb"      ))
- ,dphibb_      (iConfig.getParameter<double>       ("Dphibb"      )) 	
- ,ptsqq_       (iConfig.getParameter<double>       ("Ptsumqq"     ))
- ,ptsbb_       (iConfig.getParameter<double>       ("Ptsumbb"     ))
- ,seta_        (iConfig.getParameter<double>       ("Etaq1Etaq2"  ))
- ,njets_       (iConfig.getParameter<int>          ("njets"       ))
- ,value_       (iConfig.getParameter<std::string>  ("value"       ))
- ,triggerType_ (iConfig.getParameter<int>          ("triggerType" ))
+,inputJets_   (iConfig.getParameter<edm::InputTag>("inputJets"   ))
+,inputJetTags_(iConfig.getParameter<edm::InputTag>("inputJetTags"))
+,mqq_         (iConfig.getParameter<double>       ("Mqq"         ))
+,detaqq_      (iConfig.getParameter<double>       ("Detaqq"      ))
+,detabb_      (iConfig.getParameter<double>       ("Detabb"      ))
+,dphibb_      (iConfig.getParameter<double>       ("Dphibb"      ))
+,ptsqq_       (iConfig.getParameter<double>       ("Ptsumqq"     ))
+,ptsbb_       (iConfig.getParameter<double>       ("Ptsumbb"     ))
+,seta_        (iConfig.getParameter<double>       ("Etaq1Etaq2"  ))
+,njets_       (iConfig.getParameter<int>          ("njets"       ))
+,value_       (iConfig.getParameter<std::string>  ("value"       ))
+,triggerType_ (iConfig.getParameter<int>          ("triggerType" ))
 {
-  m_theJetsToken = consumes<std::vector<T>>(inputJets_);
-  m_theJetTagsToken = consumes<reco::JetTagCollection>(inputJetTags_);
-  if(njets_<4) {
-  	edm::LogWarning("LowNJets")<< "njets="<<njets_<<" it must be >=4. Forced njets=4.";
-  	njets_=4;
-  }
+	m_theJetsToken = consumes<std::vector<T>>(inputJets_);
+	m_theJetTagsToken = consumes<reco::JetTagCollection>(inputJetTags_);
+	if(njets_<4) {
+		edm::LogWarning("LowNJets")<< "njets="<<njets_<<" it must be >=4. Forced njets=4.";
+		njets_=4;
+	}
 }
 
 
-template<typename T>
+	template<typename T>
 HLTJetSortedVBFFilter<T>::~HLTJetSortedVBFFilter()
 { }
 
 template<typename T>
 void
 HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc;
-  makeHLTFilterDescription(desc);
-  desc.add<edm::InputTag>("inputJets",edm::InputTag("hltJetCollection"));
-  desc.add<edm::InputTag>("inputJetTags",edm::InputTag(""));
-  desc.add<double>("Mqq",200);
-  desc.add<double>("Detaqq",2.5);
-  desc.add<double>("Detabb",10.);
-  desc.add<double>("Dphibb",10.);
-  desc.add<double>("Ptsumqq",0.);
-  desc.add<double>("Ptsumbb",0.);
-  desc.add<double>("Etaq1Etaq2",40.);
-  desc.add<std::string>("value","second");
-  desc.add<int>("triggerType",trigger::TriggerJet);
-  desc.add<int>("njets",4);
-  descriptions.add(string("hlt")+string(typeid(HLTJetSortedVBFFilter<T>).name()),desc);
+	edm::ParameterSetDescription desc;
+	makeHLTFilterDescription(desc);
+	desc.add<edm::InputTag>("inputJets",edm::InputTag("hltJetCollection"));
+	desc.add<edm::InputTag>("inputJetTags",edm::InputTag(""));
+	desc.add<double>("Mqq",200);
+	desc.add<double>("Detaqq",2.5);
+	desc.add<double>("Detabb",10.);
+	desc.add<double>("Dphibb",10.);
+	desc.add<double>("Ptsumqq",0.);
+	desc.add<double>("Ptsumbb",0.);
+	desc.add<double>("Etaq1Etaq2",40.);
+	desc.add<std::string>("value","second");
+	desc.add<int>("triggerType",trigger::TriggerJet);
+	desc.add<int>("njets",4);
+	descriptions.add(string("hlt")+string(typeid(HLTJetSortedVBFFilter<T>).name()),desc);
 }
 
 template<typename T> float HLTJetSortedVBFFilter<T>::findCSV(const typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection  & jetTags){
-        float minDr = 0.1;
-        float tmpCSV = -20 ;
-        for (reco::JetTagCollection::const_iterator jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
-        float tmpDr = reco::deltaR(*jet,*(jetb->first));
+	float minDr = 0.1;
+	float tmpCSV = -20 ;
+	for (reco::JetTagCollection::const_iterator jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
+		float tmpDr = reco::deltaR(*jet,*(jetb->first));
 
-        if (tmpDr < minDr) {
-                minDr = tmpDr ;
-                tmpCSV= jetb->second;
-                }
+		if (tmpDr < minDr) {
+			minDr = tmpDr ;
+			tmpCSV= jetb->second;
+		}
 
-        }
-        return tmpCSV;
+	}
+	return tmpCSV;
 
 }
 //
@@ -100,166 +100,167 @@ template<typename T>
 bool
 HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& setup,trigger::TriggerFilterObjectWithRefs& filterproduct) const
 {
-   using namespace std;
-   using namespace edm;
-   using namespace reco;
-   using namespace trigger;
+	using namespace std;
+	using namespace edm;
+	using namespace reco;
+	using namespace trigger;
 
-   typedef vector<T> TCollection;
-   typedef Ref<TCollection> TRef;
+	typedef vector<T> TCollection;
+	typedef Ref<TCollection> TRef;
 
-   bool accept(false);
-   const unsigned int nMax(njets_);
+	bool accept(false);
+	const unsigned int nMax(njets_);
 
-   if (saveTags()) filterproduct.addCollectionTag(inputJets_);
+	if (saveTags()) filterproduct.addCollectionTag(inputJets_);
 
-   vector<Jpair> sorted(nMax);
-   vector<TRef> jetRefs(nMax);
+	vector<Jpair> sorted(nMax);
+	vector<TRef> jetRefs(nMax);
 
-   Handle<TCollection> jets;
-   event.getByToken(m_theJetsToken,jets);
-   Handle<JetTagCollection> jetTags;
-   if (jets->size()<4) return false;
+	Handle<TCollection> jets;
+	event.getByToken(m_theJetsToken,jets);
+	Handle<JetTagCollection> jetTags;
+	if (jets->size()<4) return false;
 
-   unsigned int nJet=0;
-   double value(0.0);
+	unsigned int nJet=0;
+	double value(0.0);
 
-   Particle::LorentzVector b1,b2,q1,q2;
-   if (inputJetTags_.encode()=="") {
-     for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
-       if (value_=="Pt") {
-	 value=jet->pt();
-       } else if (value_=="Eta") {
-	 value=jet->eta();
-       } else if (value_=="Phi") {
-	 value=jet->phi();
-       } else {
-	 value = 0.0;
-       }
-       sorted[nJet] = make_pair(value,nJet);
-       ++nJet;
-     }
-     sort(sorted.begin(),sorted.end(),comparator);
-     for (unsigned int i=0; i<nMax; ++i) {
-       jetRefs[i]=TRef(jets,sorted[i].second);
-     }
-     q1 = jetRefs[3]->p4();
-     b1 = jetRefs[2]->p4();
-     b2 = jetRefs[1]->p4();
-     q2 = jetRefs[0]->p4();
-   } else if(value_=="1BTagAndEta"){
-     event.getByToken(m_theJetTagsToken,jetTags);
-     vector<Jpair> sorted;
-   	 unsigned int b1_idx=-1;
-   	 float csv_max=-999;
-   	 for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) { //fill "sorted" and get the most b-tagged jet with higher CSV (b1)
-   		value = findCSV(jet, *jetTags);
-   		if(value>csv_max) {
-   			csv_max=value;
-   			b1_idx=nJet;
-   		}
-   		sorted.push_back(make_pair(jet->eta(),nJet));
-   		nJet++;
-//   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
-   	}
-   	if(b1_idx>=sorted.size() || b1_idx<0) edm::LogError("OutOfRange")<< "b1 index out of range.";
-   	sorted.erase(sorted.begin()+b1_idx); //remove the most b-tagged jet from "sorted"
-   	sort(sorted.begin(),sorted.end(),comparator); //sort "sorted" by eta
+	Particle::LorentzVector b1,b2,q1,q2;
+	if (inputJetTags_.encode()=="") {
+		for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
+			if (value_=="Pt") {
+				value=jet->pt();
+			} else if (value_=="Eta") {
+				value=jet->eta();
+			} else if (value_=="Phi") {
+				value=jet->phi();
+			} else {
+				value = 0.0;
+			}
+			sorted[nJet] = make_pair(value,nJet);
+			++nJet;
+		}
+		sort(sorted.begin(),sorted.end(),comparator);
+		for (unsigned int i=0; i<nMax; ++i) {
+			jetRefs[i]=TRef(jets,sorted[i].second);
+		}
+		q1 = jetRefs[3]->p4();
+		b1 = jetRefs[2]->p4();
+		b2 = jetRefs[1]->p4();
+		q2 = jetRefs[0]->p4();
+	} else if(value_=="1BTagAndEta"){
+		event.getByToken(m_theJetTagsToken,jetTags);
+		vector<Jpair> sorted;
+		unsigned int b1_idx=-1;
+		float csv_max=-999;
+		for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) { //fill "sorted" and get the most b-tagged jet with higher CSV (b1)
+			value = findCSV(jet, *jetTags);
+			if(value>csv_max) {
+				csv_max=value;
+				b1_idx=nJet;
+			}
+			sorted.push_back(make_pair(jet->eta(),nJet));
+			nJet++;
+			//   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
+		}
+		if(b1_idx>=sorted.size() || b1_idx<0) edm::LogError("OutOfRange")<< "b1 index out of range.";
+		sorted.erase(sorted.begin()+b1_idx); //remove the most b-tagged jet from "sorted"
+		sort(sorted.begin(),sorted.end(),comparator); //sort "sorted" by eta
 
-   	unsigned int q1_idx=sorted.front().second;  //take the backward jet (q1)
-   	unsigned int q2_idx=sorted.back().second;  //take the forward jet (q2)
-   	
-    unsigned int i=0;
-   	while( (i==q1_idx) || (i==q2_idx) || (i==b1_idx) ) i++; //take jet with highest pT but q1,q2,b1 (q2)
-   	unsigned int b2_idx=i;
+		unsigned int q1_idx=sorted.front().second;  //take the backward jet (q1)
+		unsigned int q2_idx=sorted.back().second;  //take the forward jet (q2)
 
-   	if(q1_idx<jets->size()) q1 = jets->at(q1_idx).p4(); else edm::LogWarning("Something wrong with q1");
-   	if(q2_idx<jets->size()) q2 = jets->at(q2_idx).p4(); else edm::LogWarning("Something wrong with q2");
-   	if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
-   	if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
+		unsigned int i=0;
+		while( (i==q1_idx) || (i==q2_idx) || (i==b1_idx) ) i++; //take jet with highest pT but q1,q2,b1 (q2)
+		unsigned int b2_idx=i;
 
-//   	cout<<"\tPathB: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
-   } else if(value_=="2BTagAndPt"){
-     event.getByToken(m_theJetTagsToken,jetTags);
-     vector<Jpair> sorted;
+		if(q1_idx<jets->size()) q1 = jets->at(q1_idx).p4(); else edm::LogWarning("Something wrong with q1");
+		if(q2_idx<jets->size()) q2 = jets->at(q2_idx).p4(); else edm::LogWarning("Something wrong with q2");
+		if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
+		if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
 
-   	 unsigned int b1_idx=-1;
-   	 unsigned int b2_idx=-1;
-   	 float csv1=-999;
-   	 float csv2=-999;
-   	 for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) { //fill "sorted" and get the two most b-tagged jets (b1,b2)
-   		value = findCSV(jet, *jetTags);
-   		if(value>csv1) {
-   			csv2=csv1;
-   			b2_idx=b1_idx;
-   			csv1=value;
-   			b1_idx=nJet;
-   		} 
-   		else if(value>csv2){
-   			csv2=value;
-   			b2_idx=nJet;
-   		}
-   		sorted.push_back(make_pair(jet->eta(),nJet));
-   		nJet++;
-//   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
-   	}
-   	sorted.erase(sorted.begin()+b1_idx); //remove b1 and b2 from sorted
-   	sorted.erase(sorted.begin()+(b1_idx>b2_idx?b2_idx:b2_idx-1));
+		//   	cout<<"\tPathB: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
+	} else if(value_=="2BTagAndPt"){
+		event.getByToken(m_theJetTagsToken,jetTags);
+		vector<Jpair> sorted;
 
-   	unsigned int q1_idx=sorted.at(0).second;  //get q1 and q2 as the jets with highest pT, but b1 and b2.
-   	unsigned int q2_idx=sorted.at(1).second;
+		unsigned int b1_idx=-1;
+		unsigned int b2_idx=-1;
+		float csv1=-999;
+		float csv2=-999;
+		for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) { //fill "sorted" and get the two most b-tagged jets (b1,b2)
+			value = findCSV(jet, *jetTags);
+			if(value>csv1) {
+				csv2=csv1;
+				b2_idx=b1_idx;
+				csv1=value;
+				b1_idx=nJet;
+			} 
+			else if(value>csv2){
+				csv2=value;
+				b2_idx=nJet;
+			}
+			sorted.push_back(make_pair(jet->eta(),nJet));
+			nJet++;
+			//   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
+		}
+		sorted.erase(sorted.begin()+b1_idx); //remove b1 and b2 from sorted
+		sorted.erase(sorted.begin()+(b1_idx>b2_idx?b2_idx:b2_idx-1));
 
-   	if(q1_idx<jets->size()) q1 = jets->at(q1_idx).p4(); else edm::LogWarning("Something wrong with q1");
-   	if(q2_idx<jets->size()) q2 = jets->at(q2_idx).p4(); else edm::LogWarning("Something wrong with q2");
-   	if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
-   	if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
+		unsigned int q1_idx=sorted.at(0).second;  //get q1 and q2 as the jets with highest pT, but b1 and b2.
+		unsigned int q2_idx=sorted.at(1).second;
 
-//   	cout<<"\tPathA: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
-   }
-   else {
-     event.getByToken(m_theJetTagsToken,jetTags);
-     for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
+		if(q1_idx<jets->size()) q1 = jets->at(q1_idx).p4(); else edm::LogWarning("Something wrong with q1");
+		if(q2_idx<jets->size()) q2 = jets->at(q2_idx).p4(); else edm::LogWarning("Something wrong with q2");
+		if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
+		if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
 
-       if (value_=="second") {
-	 value = findCSV(jet, *jetTags);
-       } else {
-	 value = 0.0;
-       }
-       sorted[nJet] = make_pair(value,nJet);
-       ++nJet;
-     }
-     sort(sorted.begin(),sorted.end(),comparator);
-     for (unsigned int i=0; i<nMax; ++i) {
-       jetRefs[i]= TRef(jets,(*jetTags)[sorted[i].second].first.key());
-     }
-     b1 = jetRefs[3]->p4();
-     b2 = jetRefs[2]->p4();
-     q1 = jetRefs[1]->p4();
-     q2 = jetRefs[0]->p4();
-   }
+		//   	cout<<"\tPathA: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
+	}
+	else {
+		event.getByToken(m_theJetTagsToken,jetTags);
+		for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
 
-   double mqq_bs     = (q1+q2).M();
-   double deltaetaqq = std::abs(q1.Eta()-q2.Eta());
-   double deltaetabb = std::abs(b1.Eta()-b2.Eta());
-   double deltaphibb = std::abs(reco::deltaPhi(b1.Phi(),b2.Phi()));
-   double ptsqq_bs   = (q1+q2).Pt();
-   double ptsbb_bs   = (b1+b2).Pt();
-   double signeta    = q1.Eta()*q2.Eta();
+			if (value_=="second") {
+				value = findCSV(jet, *jetTags);
+			} else {
+				value = 0.0;
+			}
+			sorted[nJet] = make_pair(value,nJet);
+			++nJet;
+		}
+		sort(sorted.begin(),sorted.end(),comparator);
+		for (unsigned int i=0; i<nMax; ++i) {
+			jetRefs[i]= TRef(jets,(*jetTags)[sorted[i].second].first.key());
+		}
+		b1 = jetRefs[3]->p4();
+		b2 = jetRefs[2]->p4();
+		q1 = jetRefs[1]->p4();
+		q2 = jetRefs[0]->p4();
+	}
 
-   if (
-	(mqq_bs     > mqq_    ) &&
-	(deltaetaqq > detaqq_ ) &&
-	(deltaetabb < detabb_ ) &&
-	(deltaphibb < dphibb_ ) &&
-	(ptsqq_bs   > ptsqq_  ) &&
-	(ptsbb_bs   > ptsbb_  ) &&
-	(signeta    < seta_   )
-	) {
-     accept=true;
-     for (unsigned int i=0; i<nMax; ++i) {
-       filterproduct.addObject(triggerType_,jetRefs[i]);
-     }
-   }
+	double mqq_bs     = (q1+q2).M();
+	double deltaetaqq = std::abs(q1.Eta()-q2.Eta());
+	double deltaetabb = std::abs(b1.Eta()-b2.Eta());
+	double deltaphibb = std::abs(reco::deltaPhi(b1.Phi(),b2.Phi()));
+	double ptsqq_bs   = (q1+q2).Pt();
+	double ptsbb_bs   = (b1+b2).Pt();
+	double signeta    = q1.Eta()*q2.Eta();
 
-   return accept;
+	if (
+			(mqq_bs     > mqq_    ) &&
+			(deltaetaqq > detaqq_ ) &&
+			(deltaetabb < detabb_ ) &&
+			(deltaphibb < dphibb_ ) &&
+			(ptsqq_bs   > ptsqq_  ) &&
+			(ptsbb_bs   > ptsbb_  ) &&
+			(signeta    < seta_   )
+	   ) {
+		accept=true;
+		for (unsigned int i=0; i<nMax; ++i) {
+			filterproduct.addObject(triggerType_,jetRefs[i]);
+		}
+	}
+
+	return accept;
 }
+

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -71,7 +71,7 @@ HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descr
 	desc.add<std::string>("value","second");
 	desc.add<int>("triggerType",trigger::TriggerJet);
 	desc.add<int>("njets",4);
-	descriptions.add(string("hlt")+string(typeid(HLTJetSortedVBFFilter<T>).name()),desc);
+        descriptions.add(defaultModuleLabel<HLTJetSortedVBFFilter<T>>(), desc);
 }
 
 template<typename T> float HLTJetSortedVBFFilter<T>::findCSV(const typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection  & jetTags){

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -112,6 +112,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
 	event.getByToken(m_theJetsToken,jets);
 	Handle<JetTagCollection> jetTags;
 
+	if (saveTags()) filterproduct.addCollectionTag(inputJets_);
 	if (jets->size()<4) return false;
 
 	const unsigned int nMax(njets_<jets->size()?njets_:jets->size());
@@ -227,7 +228,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
 		}
 		sort(sorted.begin(),sorted.end(),comparator);
 		for (unsigned int i=0; i<nMax; ++i) {
-			jetRefs[i]= TRef(jets,(*jetTags)[sorted[i].second].first.key());
+			jetRefs[i]= TRef(jets,sorted[i].second);
 		}
 		b1 = jetRefs[3]->p4();
 		b2 = jetRefs[2]->p4();

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -160,7 +160,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    		}
    		sorted.push_back(make_pair(jet->eta(),nJet));
    		nJet++;
-   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
+//   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
    	}
    	if(b1_idx>=sorted.size() || b1_idx<0) edm::LogError("OutOfRange")<< "b1 index out of range.";
    	sorted.erase(sorted.begin()+b1_idx); //remove the most b-tagged jet from "sorted"
@@ -178,7 +178,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    	if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
    	if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
 
-   	cout<<"\tPathB: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
+//   	cout<<"\tPathB: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
    } else if(value_=="2BTagAndPt"){
      event.getByToken(m_theJetTagsToken,jetTags);
      vector<Jpair> sorted;
@@ -201,7 +201,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    		}
    		sorted.push_back(make_pair(jet->eta(),nJet));
    		nJet++;
-   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
+//   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
    	}
    	sorted.erase(sorted.begin()+b1_idx); //remove b1 and b2 from sorted
    	sorted.erase(sorted.begin()+(b1_idx>b2_idx?b2_idx:b2_idx-1));
@@ -214,7 +214,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    	if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
    	if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
 
-   	cout<<"\tPathA: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
+//   	cout<<"\tPathA: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
    }
    else {
      event.getByToken(m_theJetTagsToken,jetTags);

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -45,6 +45,10 @@ HLTJetSortedVBFFilter<T>::HLTJetSortedVBFFilter(const edm::ParameterSet& iConfig
 {
   m_theJetsToken = consumes<std::vector<T>>(inputJets_);
   m_theJetTagsToken = consumes<reco::JetTagCollection>(inputJetTags_);
+  if(njets_<4) {
+  	edm::LogWarning("LowNJets")<< "njets="<<njets_<<" it must be >=4. Forced njets=4.";
+  	njets_=4;
+  }
 }
 
 
@@ -115,13 +119,13 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    Handle<TCollection> jets;
    event.getByToken(m_theJetsToken,jets);
    Handle<JetTagCollection> jetTags;
+   if (jets->size()<4) return false;
 
    unsigned int nJet=0;
    double value(0.0);
 
    Particle::LorentzVector b1,b2,q1,q2;
    if (inputJetTags_.encode()=="") {
-     if (jets->size()<nMax) return false;
      for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
        if (value_=="Pt") {
 	 value=jet->pt();
@@ -214,7 +218,6 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    }
    else {
      event.getByToken(m_theJetTagsToken,jetTags);
-     if (jetTags->size()<nMax) return false;
      for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
 
        if (value_=="second") {

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -40,7 +40,6 @@ HLTJetSortedVBFFilter<T>::HLTJetSortedVBFFilter(const edm::ParameterSet& iConfig
  ,ptsbb_       (iConfig.getParameter<double>       ("Ptsumbb"     ))
  ,seta_        (iConfig.getParameter<double>       ("Etaq1Etaq2"  ))
  ,njets_       (iConfig.getParameter<int>          ("njets"       ))
- ,csvloose_     (iConfig.getParameter<double>      ("CSVLoose"    ))
  ,value_       (iConfig.getParameter<std::string>  ("value"       ))
  ,triggerType_ (iConfig.getParameter<int>          ("triggerType" ))
 {
@@ -67,7 +66,6 @@ HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<double>("Ptsumqq",0.);
   desc.add<double>("Ptsumbb",0.);
   desc.add<double>("Etaq1Etaq2",40.);
-  desc.add<double>("CSVLoose",0.4);
   desc.add<std::string>("value","second");
   desc.add<int>("triggerType",trigger::TriggerJet);
   desc.add<int>("njets",4);

--- a/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
+++ b/HLTrigger/JetMET/src/HLTJetSortedVBFFilter.cc
@@ -39,6 +39,8 @@ HLTJetSortedVBFFilter<T>::HLTJetSortedVBFFilter(const edm::ParameterSet& iConfig
  ,ptsqq_       (iConfig.getParameter<double>       ("Ptsumqq"     ))
  ,ptsbb_       (iConfig.getParameter<double>       ("Ptsumbb"     ))
  ,seta_        (iConfig.getParameter<double>       ("Etaq1Etaq2"  ))
+ ,njets_       (iConfig.getParameter<int>          ("njets"       ))
+ ,csvloose_     (iConfig.getParameter<double>      ("CSVLoose"    ))
  ,value_       (iConfig.getParameter<std::string>  ("value"       ))
  ,triggerType_ (iConfig.getParameter<int>          ("triggerType" ))
 {
@@ -65,8 +67,10 @@ HLTJetSortedVBFFilter<T>::fillDescriptions(edm::ConfigurationDescriptions& descr
   desc.add<double>("Ptsumqq",0.);
   desc.add<double>("Ptsumbb",0.);
   desc.add<double>("Etaq1Etaq2",40.);
+  desc.add<double>("CSVLoose",0.4);
   desc.add<std::string>("value","second");
   desc.add<int>("triggerType",trigger::TriggerJet);
+  desc.add<int>("njets",4);
   descriptions.add(string("hlt")+string(typeid(HLTJetSortedVBFFilter<T>).name()),desc);
 }
 
@@ -104,7 +108,7 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
    typedef Ref<TCollection> TRef;
 
    bool accept(false);
-   const unsigned int nMax(4);
+   const unsigned int nMax(njets_);
 
    if (saveTags()) filterproduct.addCollectionTag(inputJets_);
 
@@ -143,10 +147,78 @@ HLTJetSortedVBFFilter<T>::hltFilter(edm::Event& event, const edm::EventSetup& se
      b1 = jetRefs[2]->p4();
      b2 = jetRefs[1]->p4();
      q2 = jetRefs[0]->p4();
-   } else {
+   } else if(value_=="1BTagAndEta"){
      event.getByToken(m_theJetTagsToken,jetTags);
+     vector<Jpair> sorted;
 
+   	 unsigned int b1_idx=-1;
+   	 float csv_max=-999;
+   	 for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
+   		value = findCSV(jet, *jetTags);
+   		if(value>csv_max) {
+   			csv_max=value;
+   			b1_idx=nJet;
+   		}
+   		sorted.push_back(make_pair(jet->eta(),nJet));
+   		nJet++;
+   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
+   	}
+   	sorted.erase(sorted.begin()+b1_idx);
+   	sort(sorted.begin(),sorted.end(),comparator);
 
+   	unsigned int q1_idx=sorted.front().second;
+   	unsigned int q2_idx=sorted.back().second;
+   	
+    unsigned int i=0;
+   	while( (i==q1_idx) || (i==q2_idx) || (i==b1_idx) ) i++;
+   	unsigned int b2_idx=i;
+
+   	q1 = jets->at(q1_idx).p4();
+   	q2 = jets->at(q2_idx).p4();
+   	if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
+   	if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
+
+   	cout<<"\tPathB: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
+   } else if(value_=="2BTagAndPt"){
+     event.getByToken(m_theJetTagsToken,jetTags);
+     vector<Jpair> sorted;
+
+   	 unsigned int b1_idx=-1;
+   	 unsigned int b2_idx=-1;
+   	 float csv1=-999;
+   	 float csv2=-999;
+   	 for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
+   		value = findCSV(jet, *jetTags);
+   		if(value>csv1) {
+   			csv2=csv1;
+   			b2_idx=b1_idx;
+   			csv1=value;
+   			b1_idx=nJet;
+   		} 
+   		else if(value>csv2){
+   			csv2=value;
+   			b2_idx=nJet;
+   		}
+   		sorted.push_back(make_pair(jet->eta(),nJet));
+   		nJet++;
+   		cout << "jetPt=" << jet->pt() << "\tjetEta=" << jet->eta() << "\tjetCSV=" << value << endl;
+   	}
+   	if(b1_idx>b2_idx) {sorted.erase(sorted.begin()+b1_idx); sorted.erase(sorted.begin()+b2_idx);}
+   	else {sorted.erase(sorted.begin()+b2_idx);sorted.erase(sorted.begin()+b1_idx); }
+//   	sort(sorted.begin(),sorted.end(),comparator);
+
+   	unsigned int q1_idx=sorted.at(0).second;
+   	unsigned int q2_idx=sorted.at(1).second;
+
+   	q1 = jets->at(q1_idx).p4();
+   	q2 = jets->at(q2_idx).p4();
+   	if(b1_idx<jets->size()) b1 = jets->at(b1_idx).p4(); else edm::LogWarning("Something wrong with b1");
+   	if(b2_idx<jets->size()) b2 = jets->at(b2_idx).p4(); else edm::LogWarning("Something wrong with b2");
+
+   	cout<<"\tPathA: b1="<<b1.pt()<<" b2="<<b2.pt()<<" q1="<<q1.pt()<<" q2="<<q2.pt()<<endl; 
+   }
+   else {
+     event.getByToken(m_theJetTagsToken,jetTags);
      if (jetTags->size()<nMax) return false;
      for (typename TCollection::const_iterator jet=jets->begin(); (jet!=jets->end()&& nJet<nMax); ++jet) {
 


### PR DESCRIPTION
In order to implement the new VBF trigger strategy ( https://indico.cern.ch/event/351559/contribution/1/11/material/slides/6.pdf ), we need to update the HLTJetSortedVBFFilter.

This PR add "1BTagAndEta" and "2BTagAndPt" modes to use HLTJetSortedVBFFilter.

The "1BTagAndEta"  defines as:
- b1, the most b-tagged jet
- q1,q1, the most forward and backward remaining jets
- b2, the remaining jet with higher pT

The "2BTagAndPt"  defines as:
- b1, b2 the two most b-tagged jets
- q1, q2 the remaining jets with higher pT

cc: @grauco , @pazzurri
