### PR TITLE
Customize fragment to enable new strip CPE

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/python/customiseNewStripCPE.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/customiseNewStripCPE.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseNewStripCPE(process):
+    process.StripCPEfromTrackAngleESProducer.parameters.useLegacyError = False
+    process.StripCPEfromTrackAngleESProducer.parameters.maxChgOneMIP = 6000.
+
+    return process


### PR DESCRIPTION
Add customize fragment to enable the currently inactive new strip CPE code merged in #6831. With this the new strip CPE can be enabled by adding `--customise RecoLocalTracker/SiStripRecHitConverter/customiseNewStripCPE.customiseNewStripCPE` to cmsDriver.py. Applying the customization results in the following changes
- https://indico.cern.ch/event/342236/session/5/contribution/10/material/slides/0.pdf (by @wmtford)
- https://mkortela.web.cern.ch/mkortela/tracking/validation/CMSSW_7_4_0_pre2_v3/index.html
