### PR TITLE
New cpe for 1mip

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
@@ -16,6 +16,6 @@ StripCPEfromTrackAngleESProducer.parameters    = cms.PSet(
    mTID_P1        = cms.double( .433),
    mTEC_P0        = cms.double(-1.885),
    mTEC_P1        = cms.double( .471),
-   useLegacyError = cms.bool(True),
-   maxChgOneMIP   = cms.double(-6000.)
+   useLegacyError = cms.bool(False),
+   maxChgOneMIP   = cms.double(6000.)
 )

--- a/RecoLocalTracker/SiStripRecHitConverter/python/customiseNewStripCPE.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/customiseNewStripCPE.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseNewStripCPE(process):
+    process.StripCPEfromTrackAngleESProducer.parameters.useLegacyError = True
+    process.StripCPEfromTrackAngleESProducer.parameters.maxChgOneMIP = -6000.
+
+    return process


### PR DESCRIPTION
This is an alternative option to PR  #7082.  This version sets the new CPE on by default, with the customization option to turn it off.  Reviewers can decide which version is preferred.
