### PR TITLE
LeafCandidate needs a default constructor

### DIFF
--- a/DataFormats/Candidate/interface/LeafCandidate.h
+++ b/DataFormats/Candidate/interface/LeafCandidate.h
@@ -33,6 +33,8 @@ namespace reco {
 
     typedef unsigned int index;
 
+    LeafCandidate() {}
+
     // constructor from candidate 
     explicit LeafCandidate( const Candidate & c) : m_state(c.charge(),c.polarP4(), c.vertex(), c.pdgId(), c.status() ){}
 
@@ -49,7 +51,6 @@ namespace reco {
     LeafCandidate& operator=(LeafCandidate const&)=default;
 #else
     // for Reflex to parse...  (compilation will use the above)
-    LeafCandidate();
     LeafCandidate( Charge q, const PtEtaPhiMass & p4, const Point & vtx = Point( 0, 0, 0 ),
 		   int pdgId = 0, int status = 0, bool integerCharge = true );
     LeafCandidate( Charge q, const LorentzVector & p4, const Point & vtx = Point( 0, 0, 0 ),


### PR DESCRIPTION
LeafCandidate, a persistable class, needs a (public) default constructor. It does not really have one.  In ROOT6, this problem causes a unit tests failure.  In the CMSSW code for ROOT 5,  a public default constructor is declared (but not defined) for use by genreflex (CINT), but the compiler does not see one.  This doesn't cause any known problems at the moment, but is very bad practice.
This pull request gives LeafCandidate a real default constructor, and also provides commonality with the code in the ROOT6 IB.
