### PR TITLE
Avoid duplicate dataset names between lhe and hadronization step in gen-only relvals

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -660,7 +660,7 @@ steps['TTbarFS_13_ID']=identityFS(steps['TTbarFS_13'])
 step1GenDefaults=merge([{'-s':'GEN,VALIDATION:genvalid',
                          '--relval':'250000,20000',
                          '--eventcontent':'RAWSIM,DQM',
-                         '--datatier':'GEN,DQMIO',
+                         '--datatier':'GEN-SIM,DQMIO',
                          '--conditions':'auto:run2_mc_FULL'
                          },
                         step1Defaults])


### PR DESCRIPTION
Suffering here from a historically confusing use of "GEN" datatier for lhe event content.  Therefore we cannot use the "GEN" datatier for the gen-only output of the hadronization step.

Minimal solution is to use "GEN-SIM" datatier for gen-only output.

Addresses the issue reported by Alan here
https://hypernews.cern.ch/HyperNews/CMS/get/wmDevelopment/642/1/1/1/1/1/1/2/1/1/1/1/1/1/1/1/1/1/1/1/1/1.html
