### PR TITLE
TriggerResultFilters: accept arbitrary Path names

### DIFF
--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -117,8 +117,7 @@ def getHighMultVPSet():
         ret.append(tracksCount)				
 
         tracksCountDenom = tracksCount.clone()
-        alwaysTrue = partialPathName+"*" + " OR NOT " + partialPathName+"*"
-        tracksCountDenom.triggerSelection = cms.string(alwaysTrue)
+        tracksCountDenom.triggerSelection = cms.string( "TRUE" )
         tracksCountDenom.combinedObjectDrawables =  cms.VPSet(
             cms.PSet (name = cms.string("count_denominator"), expression = cms.string("at(0)"),
                              bins = cms.int32(tracksBins), min = cms.double(tracksL), max = cms.double(tracksH))
@@ -338,9 +337,8 @@ def getPTAveVPSet():
             ret.append(recoPFtopology)
             recoPFtopologyDenom = recoPFtopology.clone()
             #recoPFtopologyDenom.triggerSelection = cms.string("HLTriggerFirstPath*")
-            alwaysTrue = partialPathName+"*" + " OR NOT " + partialPathName+"*"
             #recoPFtopologyDenom.triggerSelection = cms.string(partialPathName+"*")
-            recoPFtopologyDenom.triggerSelection = cms.string(alwaysTrue)
+            recoPFtopologyDenom.triggerSelection = cms.string( "TRUE" )
             recoPFtopologyDenom.combinedObjectDrawables =  cms.VPSet(
                 cms.PSet (name = cms.string("ptAve_denominator"), expression = cms.string("(at(0).pt+at(1).pt)/2"),
                              bins = cms.int32(ptBins), min = cms.double(ptBinLow), max = cms.double(ptBinHigh)  )

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -60,13 +60,14 @@ namespace FSQ {
 //################################################################################################
 class BaseHandler {
     public:
-        BaseHandler();
-        ~BaseHandler(){
-            delete m_expression;
-        }
+        virtual ~BaseHandler() { }
+
         BaseHandler(const edm::ParameterSet& iConfig,  triggerExpression::Data & eventCache):
               m_expression(triggerExpression::parse( iConfig.getParameter<std::string>("triggerSelection")))
          {
+              if (not m_expression)
+                  edm::LogError("FSQ::BaseHandler") << "Failed to parse TriggerResults expression '" << iConfig.getParameter<std::string>("triggerSelection") << "'";
+
               // extract list of used paths
               std::vector<std::string> strs;
               std::string triggerSelection = iConfig.getParameter<std::string>("triggerSelection");
@@ -92,7 +93,7 @@ class BaseHandler {
         virtual void book(DQMStore::IBooker & booker) = 0;
         virtual void getAndStoreTokens(edm::ConsumesCollector && iC) = 0;
 
-        triggerExpression::Evaluator * m_expression;
+        std::unique_ptr<triggerExpression::Evaluator> m_expression;
         triggerExpression::Data * m_eventCache;
         std::string m_dirname;
         std::map<std::string,  MonitorElement*> m_histos;
@@ -319,6 +320,8 @@ class HandlerTemplate: public BaseHandler {
                     return;
             }
 
+            if (not m_expression)
+                return;
             if (m_eventCache->configurationUpdated()) {
                 m_expression->init(*m_eventCache);
             }


### PR DESCRIPTION
- accept arbitrary Path names
- rename the internal classes for consistency
- update test files for the new functionality
- prevent segfault if an L1 trigger is used in the expression without passing the L1 results collection
