### PR TITLE
TriggerResultFilters: accept arbitrary Path names

### DIFF
--- a/HLTrigger/HLTcore/interface/TriggerExpressionL1AlgoReader.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionL1AlgoReader.h
@@ -1,5 +1,5 @@
-#ifndef HLTrigger_HLTfilters_TriggerExpressionL1Reader_h
-#define HLTrigger_HLTfilters_TriggerExpressionL1Reader_h
+#ifndef HLTrigger_HLTfilters_TriggerExpressionL1AlgoReader_h
+#define HLTrigger_HLTfilters_TriggerExpressionL1AlgoReader_h
 
 #include <vector>
 #include <string>
@@ -8,15 +8,15 @@
 
 namespace triggerExpression {
 
-class L1Reader : public Evaluator {
+class L1AlgoReader : public Evaluator {
 public:
-  L1Reader(const std::string & pattern) :
+  L1AlgoReader(const std::string & pattern) :
     m_pattern(pattern),
     m_triggers()
   { }
 
   bool operator()(const Data & data) const;
-  
+
   void init(const Data & data);
 
   void dump(std::ostream & out) const;
@@ -28,4 +28,4 @@ private:
 
 } // namespace triggerExpression
 
-#endif // HLTrigger_HLTfilters_TriggerExpressionL1Reader_h
+#endif // HLTrigger_HLTfilters_TriggerExpressionL1AlgoReader_h

--- a/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h
@@ -1,5 +1,5 @@
-#ifndef HLTrigger_HLTfilters_TriggerExpressionHLTReader_h
-#define HLTrigger_HLTfilters_TriggerExpressionHLTReader_h
+#ifndef HLTrigger_HLTfilters_TriggerExpressionPathReader_h
+#define HLTrigger_HLTfilters_TriggerExpressionPathReader_h
 
 #include <vector>
 #include <string>
@@ -8,15 +8,15 @@
 
 namespace triggerExpression {
 
-class HLTReader : public Evaluator {
+class PathReader : public Evaluator {
 public:
-  HLTReader(const std::string & pattern) :
+  PathReader(const std::string & pattern) :
     m_pattern(pattern),
     m_triggers()
   { }
 
   bool operator()(const Data & data) const;
-  
+
   void init(const Data & data);
 
   void dump(std::ostream & out) const;
@@ -28,4 +28,4 @@ private:
 
 } // namespace triggerExpression
 
-#endif // HLTrigger_HLTfilters_TriggerExpressionHLTReader_h
+#endif // HLTrigger_HLTfilters_TriggerExpressionPathReader_h

--- a/HLTrigger/HLTcore/src/TriggerExpressionL1AlgoReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionL1AlgoReader.cc
@@ -9,12 +9,12 @@
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
-#include "HLTrigger/HLTcore/interface/TriggerExpressionL1Reader.h"
+#include "HLTrigger/HLTcore/interface/TriggerExpressionL1AlgoReader.h"
 
 namespace triggerExpression {
 
 // define the result of the module from the L1 reults
-bool L1Reader::operator()(const Data & data) const {
+bool L1AlgoReader::operator()(const Data & data) const {
   if (not data.hasL1T())
     return false;
 
@@ -30,7 +30,7 @@ bool L1Reader::operator()(const Data & data) const {
   return false;
 }
 
-void L1Reader::dump(std::ostream & out) const {
+void L1AlgoReader::dump(std::ostream & out) const {
   if (m_triggers.size() == 0) {
     out << "FALSE";
   } else if (m_triggers.size() == 1) {
@@ -43,14 +43,17 @@ void L1Reader::dump(std::ostream & out) const {
   }
 }
 
-void L1Reader::init(const Data & data) {
+void L1AlgoReader::init(const Data & data) {
+  if (not data.hasL1T())
+    return;
+
   const L1GtTriggerMenu & menu = data.l1tMenu();
   const L1GtTriggerMask & mask = data.l1tAlgoMask();
 
   // clear the previous configuration
   m_triggers.clear();
 
-  // check if the pattern has is a glob expression, or a single trigger name 
+  // check if the pattern has is a glob expression, or a single trigger name
   if (not edm::is_glob(m_pattern)) {
     // no wildcard expression
     const AlgorithmMap & triggerMap = menu.gtAlgorithmAliasMap();
@@ -65,7 +68,7 @@ void L1Reader::init(const Data & data) {
       else
         edm::LogWarning("Configuration") << "requested L1 trigger \"" << m_pattern << "\" does not exist in the current L1 menu";
   } else {
-    // expand wildcards in the pattern 
+    // expand wildcards in the pattern
     bool match = false;
     boost::regex re(edm::glob2reg(m_pattern));
     const AlgorithmMap & triggerMap = menu.gtAlgorithmAliasMap();

--- a/HLTrigger/HLTcore/src/TriggerExpressionL1TechReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionL1TechReader.cc
@@ -59,6 +59,9 @@ void L1TechReader::dump(std::ostream & out) const {
 }
 
 void L1TechReader::init(const Data & data) {
+  if (not data.hasL1T())
+    return;
+
   const L1GtTriggerMenu & menu = data.l1tMenu();
   const L1GtTriggerMask & mask = data.l1tTechMask();
 

--- a/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionPathReader.cc
@@ -6,13 +6,13 @@
 #include "FWCore/Utilities/interface/RegexMatch.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
-#include "HLTrigger/HLTcore/interface/TriggerExpressionHLTReader.h"
+#include "HLTrigger/HLTcore/interface/TriggerExpressionPathReader.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 
 namespace triggerExpression {
 
 // define the result of the module from the HLT reults
-bool HLTReader::operator()(const Data & data) const {
+bool PathReader::operator()(const Data & data) const {
   if (not data.hasHLT())
     return false;
 
@@ -20,11 +20,11 @@ bool HLTReader::operator()(const Data & data) const {
   BOOST_FOREACH(const value_type & trigger, m_triggers)
     if (data.hltResults().accept(trigger.second))
       return true;
-  
+
   return false;
 }
 
-void HLTReader::dump(std::ostream & out) const {
+void PathReader::dump(std::ostream & out) const {
   if (m_triggers.size() == 0) {
     out << "FALSE";
   } else if (m_triggers.size() == 1) {
@@ -38,7 +38,7 @@ void HLTReader::dump(std::ostream & out) const {
 }
 
 // (re)initialize the module
-void HLTReader::init(const Data & data) {
+void PathReader::init(const Data & data) {
   // clear the previous configuration
   m_triggers.clear();
 

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter.py
@@ -6,12 +6,17 @@ process.options = cms.untracked.PSet(
     wantSummary = cms.untracked.bool(True)
 )
 process.load('FWCore.MessageService.MessageLogger_cfi')
-process.MessageLogger.cerr.INFO = cms.untracked.PSet(
-    reportEvery = cms.untracked.int32(1), # every!
-    limit = cms.untracked.int32(-1)       # no limit!
-    )
-process.MessageLogger.cerr.FwkReport.reportEvery = 10 # only report every 10th event start
-process.MessageLogger.cerr_stats.threshold = 'INFO' # also info in statistics
+#process.MessageLogger.cerr.INFO = cms.untracked.PSet(
+#    reportEvery = cms.untracked.int32(1), # every!
+#    limit = cms.untracked.int32(-1)       # no limit!
+#    )
+#process.MessageLogger.cerr.FwkReport.reportEvery = 10 # only report every 10th event start
+#process.MessageLogger.cerr_stats.threshold = 'INFO' # also info in statistics
+
+# load conditions from the global tag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 # read back the trigger decisions
 process.source = cms.Source('PoolSource',
@@ -20,65 +25,65 @@ process.source = cms.Source('PoolSource',
 
 import HLTrigger.HLTfilters.triggerResultsFilter_cfi as hlt
 
-# accept if 'HLT_Path_1' succeeds
+# accept if 'Path_1' succeeds
 process.filter_1 = hlt.triggerResultsFilter.clone(
-    triggerConditions =  ( 'HLT_Path_1', ),
+    triggerConditions =  ( 'Path_1', ),
     l1tResults = '',
     throw = False
     )
 
-# accept if 'HLT_Path_2' succeeds
+# accept if 'Path_2' succeeds
 process.filter_2 = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_Path_2', ),
+    triggerConditions = ( 'Path_2', ),
     l1tResults = '',
     throw = False
     )
 
-# accept if 'HLT_Path_3' succeeds
+# accept if 'Path_3' succeeds
 process.filter_3 = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_Path_3', ),
+    triggerConditions = ( 'Path_3', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds (explicit OR)
 process.filter_any_or = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_Path_1', 'HLT_Path_2', 'HLT_Path_3' ),
+    triggerConditions = ( 'Path_1', 'Path_2', 'Path_3' ),
     l1tResults = '',
     throw = False
     )
 
-# accept if 'HLT_Path_1' succeeds, prescaled by 2
+# accept if 'Path_1' succeeds, prescaled by 2
 process.filter_1_pre = hlt.triggerResultsFilter.clone(
-    triggerConditions =  ( '(HLT_Path_1) / 15', ),
+    triggerConditions =  ( '(Path_1) / 15', ),
     l1tResults = '',
     throw = False
     )
 
-# accept if 'HLT_Path_2' succeeds, prescaled by 10
+# accept if 'Path_2' succeeds, prescaled by 10
 process.filter_2_pre = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( '(HLT_Path_2 / 10)', ),
+    triggerConditions = ( '(Path_2 / 10)', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds, with different prescales (explicit OR, prescaled)
 process.filter_any_pre = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_Path_1 / 15', 'HLT_Path_2 / 10', 'HLT_Path_3 / 6', ),
+    triggerConditions = ( 'Path_1 / 15', 'Path_2 / 10', 'Path_3 / 6', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds (wildcard, '*')
 process.filter_any_star = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_*', ),
+    triggerConditions = ( '*', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if any path succeeds (wildcard, twice '*')
 process.filter_any_doublestar = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_*_*', ),
+    triggerConditions = ( '*_*', ),
     l1tResults = '',
     throw = False
     )
@@ -86,28 +91,28 @@ process.filter_any_doublestar = hlt.triggerResultsFilter.clone(
 
 # accept if any path succeeds (wildcard, '?')
 process.filter_any_question = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_Path_?', ),
+    triggerConditions = ( 'Path_?', ),
     l1tResults = '',
     throw = False
     )
 
 # accept if all path succeed (explicit AND)
 process.filter_all_explicit = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_Path_1 AND HLT_Path_2 AND HLT_Path_3', ),
+    triggerConditions = ( 'Path_1 AND Path_2 AND Path_3', ),
     l1tResults = '',
     throw = False
 )
 
 # wrong path name (explicit)
 process.filter_wrong_name = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_Wrong', ),
+    triggerConditions = ( 'Wrong', ),
     l1tResults = '',
     throw = False
 )
 
 # wrong path name (wildcard)
 process.filter_wrong_pattern = hlt.triggerResultsFilter.clone(
-    triggerConditions = ( 'HLT_*_Wrong', ),
+    triggerConditions = ( '*_Wrong', ),
     l1tResults = '',
     throw = False
 )
@@ -115,6 +120,20 @@ process.filter_wrong_pattern = hlt.triggerResultsFilter.clone(
 # empty path list
 process.filter_empty_pattern = hlt.triggerResultsFilter.clone(
     triggerConditions = ( ),
+    l1tResults = '',
+    throw = False
+)
+
+# L1-like path name
+process.filter_l1path_pattern = hlt.triggerResultsFilter.clone(
+    triggerConditions = ( 'L1_Path', ),
+    l1tResults = '',
+    throw = False
+)
+
+# real L1 trigger
+process.filter_l1singlemuopen_pattern = hlt.triggerResultsFilter.clone(
+    triggerConditions = ( 'L1_SingleMuOpen', ),
     l1tResults = '',
     throw = False
 )
@@ -153,6 +172,8 @@ process.path_wrong_name          = cms.Path( process.filter_wrong_name )
 process.path_wrong_pattern       = cms.Path( process.filter_wrong_pattern )
 process.path_not_wrong_pattern   = cms.Path( ~ process.filter_wrong_pattern )
 process.path_empty_pattern       = cms.Path( process.filter_empty_pattern )
+process.path_l1path_pattern      = cms.Path( process.filter_l1path_pattern )
+process.path_l1singlemuopen_pattern = cms.Path( process.filter_l1singlemuopen_pattern )
 process.path_true_pattern        = cms.Path( process.filter_true_pattern )
 process.path_false_pattern       = cms.Path( process.filter_false_pattern )
 

--- a/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py
+++ b/HLTrigger/HLTfilters/test/triggerResultsFilter_producer.py
@@ -6,21 +6,26 @@ process = cms.Process('HLT')
 process.PrescaleService = cms.Service('PrescaleService',
     prescaleTable = cms.VPSet(
         cms.PSet(
-            pathName  = cms.string('HLT_Path_1'),
+            pathName  = cms.string('Path_1'),
             prescales = cms.vuint32( 2 )
         ),
         cms.PSet(
-            pathName  = cms.string('HLT_Path_2'),
+            pathName  = cms.string('Path_2'),
             prescales = cms.vuint32( 3 )
         ),
         cms.PSet(
-            pathName  = cms.string('HLT_Path_3'),
+            pathName  = cms.string('Path_3'),
             prescales = cms.vuint32( 5 )
         )
     ),
     lvl1Labels = cms.vstring('any'),
-    lvl1DefaultLabel = cms.untracked.string('any')
+    lvl1DefaultLabel = cms.string('any')
 )    
+
+# load conditions from the global tag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 # define an empty source, and ask for 100 events
 process.source = cms.Source('EmptySource')
@@ -36,11 +41,12 @@ process.scale_3 = cms.EDFilter('HLTPrescaler')
 process.fail    = cms.EDFilter('HLTBool', result = cms.bool(False))
 process.success = cms.EDFilter('HLTBool', result = cms.bool(True))
 
-process.HLT_Path_1 = cms.Path(process.scale_1)
-process.HLT_Path_2 = cms.Path(process.scale_2)
-process.HLT_Path_3 = cms.Path(process.scale_3)
-process.HLT_True   = cms.Path(process.success)
-process.HLT_False  = cms.Path(process.fail)
+process.Path_1  = cms.Path(process.scale_1)
+process.Path_2  = cms.Path(process.scale_2)
+process.Path_3  = cms.Path(process.scale_3)
+process.True    = cms.Path(process.success)
+process.False   = cms.Path(process.fail)
+process.L1_Path = cms.Path(process.success)
 
 # define and EndPath to analyze all other path results
 process.hltTrigReport = cms.EDAnalyzer( 'HLTrigReport',


### PR DESCRIPTION
- accept arbitrary Path names
- rename the internal classes for consistency
- update test files for the new functionality
- prevent segfault if an L1 trigger is used in the expression without passing the L1 results collection
