### PR TITLE
add new strip dQdx MEs

### DIFF
--- a/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
+++ b/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
@@ -60,6 +60,8 @@ class SiStripFolderOrganizer
       );
 
       std::pair<std::string,int32_t> GetSubDetAndLayer(const uint32_t& detid, const TrackerTopology* tTopo, bool ring_flag = 0);
+      std::pair<std::string,int32_t> GetSubDetAndLayerThickness(const uint32_t& detid, const TrackerTopology* tTopo, std::string & cThickness);
+      std::pair<std::string,int32_t> GetSubDetAndRing(const uint32_t& detid, const TrackerTopology* tTopo);
       // detector folders
       void setDetectorFolder(uint32_t rawdetid, const TrackerTopology* tTopo);
       void getFolderName(int32_t rawdetid, const TrackerTopology* tTopo, std::string& lokal_folder);
@@ -69,6 +71,9 @@ class SiStripFolderOrganizer
       void setLayerFolder(uint32_t rawdetid,const TrackerTopology* tTopo,int32_t layer=0,bool ring_flag = 0);
       void getLayerFolderName(std::stringstream& ss, uint32_t rawdetid, const TrackerTopology* tTopo, bool ring_flag = 0);
       void getSubDetLayerFolderName(std::stringstream& ss, SiStripDetId::SubDetector subDet, uint32_t layer, uint32_t side=0);
+      // ring folder
+      void setRingFolder(uint32_t rawdetid,const TrackerTopology* tTopo,int32_t layer=0) { setLayerFolder(rawdetid,tTopo,layer,true); }
+      void getRingFolderName(std::stringstream& ss, uint32_t rawdetid, const TrackerTopology* tTopo) { getLayerFolderName(ss,rawdetid,tTopo,true); }
       // SubDetector Folder
       void getSubDetFolder(const uint32_t& detid, const TrackerTopology* tTopo, std::string& folder_name);
       std::pair<std::string, std::string> getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo);

--- a/DQM/SiStripCommon/interface/SiStripHistoId.h
+++ b/DQM/SiStripCommon/interface/SiStripHistoId.h
@@ -31,6 +31,7 @@ class SiStripHistoId
       // generally: histoid = description + separator1 + id_type + separator2 + component_id
       std::string createHistoId(std::string description, std::string id_type, uint32_t component_id);
       std::string createHistoLayer(std::string description, std::string id_type,std::string path, std::string flag);
+      //      std::string getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring, bool flag_thickness = false);
       std::string getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring);
       // extract the component_id and the id_type from a histogram id
       uint32_t    getComponentId(std::string histoid);

--- a/DQM/SiStripCommon/src/SiStripFolderOrganizer.cc
+++ b/DQM/SiStripCommon/src/SiStripFolderOrganizer.cc
@@ -148,6 +148,64 @@ std::pair<std::string,int32_t> SiStripFolderOrganizer::GetSubDetAndLayer(const u
   return std::make_pair(cSubDet,layer);
 }
 
+std::pair<std::string,int32_t> SiStripFolderOrganizer::GetSubDetAndLayerThickness(const uint32_t& detid, const TrackerTopology* tTopo, std::string & cThickness){
+  std::string cSubDet;
+  int32_t layer=0;
+  int32_t ring=0;
+  switch(StripSubdetector::SubDetector(StripSubdetector(detid).subdetId())) {
+  case StripSubdetector::TIB:
+    cSubDet="TIB";
+    layer=tTopo->tibLayer(detid);
+    cThickness = "THIN";
+    break;
+  case StripSubdetector::TOB:
+    cSubDet="TOB";
+    layer=tTopo->tobLayer(detid);
+    cThickness = "THICK";
+    break;
+  case StripSubdetector::TID:
+    cSubDet="TID";
+    layer=tTopo->tidWheel(detid) * ( tTopo->tidSide(detid)==1 ? -1 : +1);
+    cThickness = "THIN";
+    break;
+  case StripSubdetector::TEC:
+    cSubDet="TEC";
+    layer=tTopo->tecWheel(detid) * ( tTopo->tecSide(detid)==1 ? -1 : +1);
+    ring=tTopo->tecRing(detid) * ( tTopo->tecSide(detid)==1 ? -1 : +1);
+    if ( ring >= 1 && ring <= 4) cThickness = "THIN";
+    else cThickness = "THICK";
+    break;
+  default:
+    edm::LogWarning("SiStripMonitorTrack") << "WARNING!!! this detid does not belong to tracker" << std::endl;
+  }
+  return std::make_pair(cSubDet,layer);
+}
+
+std::pair<std::string,int32_t> SiStripFolderOrganizer::GetSubDetAndRing(const uint32_t& detid, const TrackerTopology* tTopo){
+  std::string cSubDet;
+  int32_t ring=0;
+  switch(StripSubdetector::SubDetector(StripSubdetector(detid).subdetId()))
+    {
+    case StripSubdetector::TIB:
+      cSubDet="TIB";
+      break;
+    case StripSubdetector::TOB:
+      cSubDet="TOB";
+      break;
+    case StripSubdetector::TID:
+      cSubDet="TID";
+      ring=tTopo->tidRing(detid) * ( tTopo->tidSide(detid)==1 ? -1 : +1);
+      break;
+    case StripSubdetector::TEC:
+      cSubDet="TEC";
+      ring=tTopo->tecRing(detid) * ( tTopo->tecSide(detid)==1 ? -1 : +1);
+      break;
+    default:
+      edm::LogWarning("SiStripMonitorTrack") << "WARNING!!! this detid does not belong to tracker" << std::endl;
+    }
+  return std::make_pair(cSubDet,ring);
+}
+
 
 void SiStripFolderOrganizer::setDetectorFolder(uint32_t rawdetid, const TrackerTopology* tTopo){
   std::string folder_name;
@@ -327,6 +385,7 @@ void SiStripFolderOrganizer::setLayerFolder(uint32_t rawdetid, const TrackerTopo
   }
 
   lokal_folder += rest.str();
+  std::cout << "[SiStripFolderOrganizer::setLayerFolder] lokal_folder: " << lokal_folder << "(used by dbe_->setCurrentFolder)" << std::endl;
   dbe_->setCurrentFolder(lokal_folder);
 }
 

--- a/DQM/SiStripCommon/src/SiStripHistoId.cc
+++ b/DQM/SiStripCommon/src/SiStripHistoId.cc
@@ -60,7 +60,7 @@ std::string SiStripHistoId::createHistoLayer(std::string description, std::strin
   size_t pos2 = description.find( "__", 0 ); // check if std::string 'description' contains by mistake the 'separator2'
   std::string local_histo_id;
   if ( pos1 == std::string::npos && pos2 == std::string::npos ){ // ok, not found either separator
-    if(id_type=="fed" || id_type=="det" || id_type=="fec"  || id_type=="layer"){ // ok! is one of the accepted id_type-s
+    if(id_type=="fed" || id_type=="det" || id_type=="fec"  || id_type=="layer" || id_type=="ring"){ // ok! is one of the accepted id_type-s
       if(flag.size() > 0)
 	local_histo_id = description + "__" + flag + "__" + path;
       else 
@@ -81,6 +81,7 @@ std::string SiStripHistoId::createHistoLayer(std::string description, std::strin
   return local_histo_id;
 }
 
+//std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring, bool flag_thickness){
 std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring){
   std::string rest1;
   
@@ -121,8 +122,19 @@ std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTop
 
     if (flag_ring) 
       snprintf(temp_str, buf_len, "TEC__%s__ring__%i",  side.c_str(), tTopo->tecRing(id) );
-    else 
+    else {
+      /*
+      if (flag_thickness) {
+	uint32_t ring = tTopo->tecRing(id);
+	if ( ring >= 1 && ring <= 4 )
+	  snprintf(temp_str, buf_len, "TEC__%s__wheel__%i__THIN", side.c_str(), tTopo->tecWheel(id));       
+	else 
+	  snprintf(temp_str, buf_len, "TEC__%s__wheel__%i__THICK", side.c_str(), tTopo->tecWheel(id));       
+      }
+      else
+*/
       snprintf(temp_str, buf_len, "TEC__%s__wheel__%i", side.c_str(), tTopo->tecWheel(id)); 
+    }
   }else{
     // ---------------------------  ???  --------------------------- //
     edm::LogError("SiStripTkDQM|WrongInput")<<"no such subdetector type :"<<subdet.subdetId()<<" no folder set!"<<std::endl;

--- a/DQM/SiStripMonitorTrack/BuildFile.xml
+++ b/DQM/SiStripMonitorTrack/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="DQM/SiStripCommon"/>
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>
+<use   name="DataFormats/SiStripCluster"/>
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/TrackerRecHit2D"/>
 <use   name="DataFormats/RecoCandidate"/>

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -89,7 +89,6 @@ private:
   void trackStudyFromTrack(edm::Handle<reco::TrackCollection > trackCollectionHandle, const edm::EventSetup& es);
   void trackStudyFromTrajectory(edm::Handle<TrajTrackAssociationCollection> TItkAssociatorCollection, const edm::EventSetup& es);
   void trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es);
-  //  void trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, reco::TrackRef trackref, const edm::EventSetup& es);
   void trackStudy(const edm::Event& ev, const edm::EventSetup& es);
   //  LocalPoint project(const GeomDet *det,const GeomDet* projdet,LocalPoint position,LocalVector trackdirection)const;
   void hitStudy(const edm::EventSetup& es,
@@ -102,8 +101,8 @@ private:
   template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&);
 
   // fill monitorables 
-  void fillModMEs(SiStripClusterInfo*,std::string,float);
-  void fillMEs(SiStripClusterInfo*,uint32_t detid, const TrackerTopology* tTopo, float,enum ClusterFlags);
+  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, uint32_t detid, const LocalVector LV);
+  void fillMEs(SiStripClusterInfo*,uint32_t detid, const TrackerTopology* tTopo, float,enum ClusterFlags,  const LocalVector LV);
   inline void fillME(MonitorElement* ME,float value1){if (ME!=0)ME->Fill(value1);}
   inline void fillME(MonitorElement* ME,float value1,float value2){if (ME!=0)ME->Fill(value1,value2);}
   inline void fillME(MonitorElement* ME,float value1,float value2,float value3){if (ME!=0)ME->Fill(value1,value2,value3);}
@@ -132,6 +131,8 @@ private:
     MonitorElement* ClusterWidth;
     MonitorElement* ClusterPos;
     MonitorElement* ClusterPGV;
+    MonitorElement* ClusterChargePerCMfromTrack;
+    MonitorElement* ClusterChargePerCMfromOrigin;
   };
 
   struct LayerMEs{
@@ -145,6 +146,8 @@ private:
     MonitorElement* ClusterWidthOffTrack;
     MonitorElement* ClusterPosOnTrack;
     MonitorElement* ClusterPosOffTrack;
+    MonitorElement* ClusterChargePerCMfromTrack;
+    MonitorElement* ClusterChargePerCMfromOrigin;
   };
   struct SubDetMEs{
     int totNClustersOnTrack;
@@ -157,7 +160,8 @@ private:
     MonitorElement* ClusterChargeOnTrack;
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterStoNOffTrack;
- 
+    MonitorElement* ClusterChargePerCMfromTrack;
+    MonitorElement* ClusterChargePerCMfromOrigin;
   };  
   std::map<std::string, ModMEs> ModMEsMap;
   std::map<std::string, LayerMEs> LayerMEsMap;

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -78,6 +78,9 @@ private:
   void book(DQMStore::IBooker &, const TrackerTopology* tTopo);
   void bookModMEs(DQMStore::IBooker &, const uint32_t& );
   void bookLayerMEs(DQMStore::IBooker &, const uint32_t&, std::string&);
+  void bookRing(DQMStore::IBooker &, const uint32_t&, std::string&);
+  MonitorElement* handleBookMEs(DQMStore::IBooker &, std::string&, std::string&, std::string&, std::string&);
+  void bookRingMEs(DQMStore::IBooker &, const uint32_t&, std::string&);
   void bookSubDetMEs(DQMStore::IBooker &, std::string& name);
   MonitorElement * bookME1D(DQMStore::IBooker & , const char*, const char*);
   MonitorElement * bookME2D(DQMStore::IBooker & , const char*, const char*);
@@ -147,7 +150,21 @@ private:
     MonitorElement* ClusterPosOnTrack;
     MonitorElement* ClusterPosOffTrack;
     MonitorElement* ClusterChargePerCMfromTrack;
-    MonitorElement* ClusterChargePerCMfromOrigin;
+    MonitorElement* ClusterChargePerCMfromOriginOnTrack;
+    MonitorElement* ClusterChargePerCMfromOriginOffTrack;
+  };
+  struct RingMEs{
+    MonitorElement* ClusterStoNCorrOnTrack;
+    MonitorElement* ClusterChargeCorrOnTrack;
+    MonitorElement* ClusterChargeOnTrack;
+    MonitorElement* ClusterChargeOffTrack;
+    MonitorElement* ClusterNoiseOnTrack;
+    MonitorElement* ClusterNoiseOffTrack;
+    MonitorElement* ClusterWidthOnTrack;
+    MonitorElement* ClusterWidthOffTrack;
+    MonitorElement* ClusterChargePerCMfromTrack;
+    MonitorElement* ClusterChargePerCMfromOriginOnTrack;
+    MonitorElement* ClusterChargePerCMfromOriginOffTrack;
   };
   struct SubDetMEs{
     int totNClustersOnTrack;
@@ -161,11 +178,13 @@ private:
     MonitorElement* ClusterChargeOffTrack;
     MonitorElement* ClusterStoNOffTrack;
     MonitorElement* ClusterChargePerCMfromTrack;
-    MonitorElement* ClusterChargePerCMfromOrigin;
+    MonitorElement* ClusterChargePerCMfromOriginOnTrack;
+    MonitorElement* ClusterChargePerCMfromOriginOffTrack;
   };  
-  std::map<std::string, ModMEs> ModMEsMap;
-  std::map<std::string, LayerMEs> LayerMEsMap;
-  std::map<std::string, SubDetMEs> SubDetMEsMap;  
+  std::map<std::string, ModMEs>       ModMEsMap;
+  std::map<std::string, LayerMEs>     LayerMEsMap;
+  std::map<std::string, RingMEs>      RingMEsMap;
+  std::map<std::string, SubDetMEs>    SubDetMEsMap;  
   
   edm::ESHandle<TrackerGeometry> tkgeom_;
   edm::ESHandle<SiStripDetCabling> SiStripDetCabling_;
@@ -191,7 +210,6 @@ private:
   std::unordered_set<const SiStripCluster*> vPSiStripCluster;
   bool tracksCollection_in_EventTree;
   bool trackAssociatorCollection_in_EventTree;
-  bool flag_ring;
   edm::EventNumber_t eventNb;
   int firstEvent;
 

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_StandAlone_cff.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_StandAlone_cff.py
@@ -12,7 +12,6 @@ SiStripMonitorTrack.OffHisto_On   = True
 SiStripMonitorTrack.HistoFlag_On  = False
 SiStripMonitorTrack.Trend_On      = False
 #SiStripMonitorTrack.CCAnalysis_On = False
-#SiStripMonitorTrack.RingFlag_On   = False
 
 #TrackRefitter With Material
 from RecoTracker.TrackProducer.TrackRefitters_cff import *

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -25,7 +25,6 @@ SiStripMonitorTrack = cms.EDAnalyzer(
     OffHisto_On   = cms.bool(True),
     Trend_On      = cms.bool(False),
     HistoFlag_On  = cms.bool(False),
-    RingFlag_On   = cms.bool(False),
     TkHistoMap_On = cms.bool(True),   
     
     ClusterConditions = cms.PSet( On       = cms.bool(False),
@@ -45,39 +44,59 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                              xmax  = cms.double(3999.5)
                              ),
     
-    TH1ClusterCharge = cms.PSet( Nbinx = cms.int32(100),
-                                 xmin  = cms.double(-0.5),
-                                 xmax  = cms.double(999.5)
-                                 ),
+    TH1ClusterCharge = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),        
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(999.5)
+    ),
     
-    TH1ClusterStoN = cms.PSet( Nbinx = cms.int32(100),
-                               xmin  = cms.double(-0.5),
-                               xmax  = cms.double(299.5)
-                               ),
+    TH1ClusterStoN = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(299.5)
+    ),
     
-    TH1ClusterChargeCorr = cms.PSet( Nbinx = cms.int32(100),
-                                     xmin  = cms.double(-0.5),
-                                     xmax  = cms.double(399.5)
-                                     ),
+    TH1ClusterChargeCorr = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(399.5)
+    ),
     
-    TH1ClusterStoNCorr = cms.PSet( Nbinx = cms.int32(200),
-                                   xmin  = cms.double(-0.5),
-                                   xmax  = cms.double(199.5)
-                                   ),
-    TH1ClusterStoNCorrMod = cms.PSet( Nbinx = cms.int32(50),
-                                   xmin  = cms.double(-0.5),
-                                   xmax  = cms.double(199.5)
-                                   ),
+    TH1ClusterStoNCorr = cms.PSet( 
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(200),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(199.5)
+     ),
+
+    TH1ClusterStoNCorrMod = cms.PSet(
+        Nbinx = cms.int32(50),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(199.5)
+    ),
     
-    TH1ClusterNoise = cms.PSet( Nbinx = cms.int32(20),
-                                xmin  = cms.double(-0.5),
-                                xmax  = cms.double(9.5)
-                                ),
+    TH1ClusterNoise = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(20),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(9.5)
+    ),
     
-    TH1ClusterWidth = cms.PSet( Nbinx = cms.int32(20),
-                                xmin  = cms.double(-0.5),
-                                xmax  = cms.double(19.5)
-                                ),
+    TH1ClusterWidth = cms.PSet(
+        layerView = cms.bool(True),
+        ringView  = cms.bool(False),
+        Nbinx = cms.int32(20),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(19.5)
+    ),
     
     TH1ClusterSymmEtaCC = cms.PSet( Nbinx = cms.int32(120),
                                     xmin  = cms.double(-0.1),
@@ -107,9 +126,12 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                          UpdateMode = cms.int32(1)
                          ),
 
-    TH1ClusterChargePerCM = cms.PSet( Nbinx = cms.int32(100),
-                                      xmin  = cms.double(-0.5),
-                                      xmax  = cms.double(9999.5)
+    TH1ClusterChargePerCM = cms.PSet(
+        layerView = cms.bool(False),
+        ringView  = cms.bool(True),
+        Nbinx = cms.int32(100),
+        xmin  = cms.double(-0.5),
+        xmax  = cms.double(9999.5)
     ),
     
     UseDCSFiltering = cms.bool(True)

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -107,7 +107,7 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                          UpdateMode = cms.int32(1)
                          ),
 
-    TH1ClusterChargePerCM = cms.PSet( Nbinx = cms.int32(250),
+    TH1ClusterChargePerCM = cms.PSet( Nbinx = cms.int32(100),
                                       xmin  = cms.double(-0.5),
                                       xmax  = cms.double(9999.5)
     ),

--- a/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
+++ b/DQM/SiStripMonitorTrack/python/SiStripMonitorTrack_cfi.py
@@ -107,6 +107,11 @@ SiStripMonitorTrack = cms.EDAnalyzer(
                          UpdateMode = cms.int32(1)
                          ),
 
+    TH1ClusterChargePerCM = cms.PSet( Nbinx = cms.int32(250),
+                                      xmin  = cms.double(-0.5),
+                                      xmax  = cms.double(9999.5)
+    ),
+    
     UseDCSFiltering = cms.bool(True)
     
     )

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -906,12 +906,12 @@ void SiStripMonitorTrack::fillModMEs(SiStripClusterInfo* cluster,std::string nam
 
     // new dE/dx (chargePerCM)
     // https://indico.cern.ch/event/342236/session/5/contribution/10/material/slides/0.pdf
-    float dQdx_fromTrack = siStripClusterTools::chargePerCM(detid, cluster, LV);
+    float dQdx_fromTrack = siStripClusterTools::chargePerCM(detid, *cluster, LV);
     // from straigth line origin-sensor centre
     const StripGeomDetUnit* DetUnit = (const StripGeomDetUnit*) tkgeom_->idToDetUnit(DetId(detid));
     LocalPoint locVtx = DetUnit->toLocal(GlobalPoint(0.0, 0.0, 0.0));
     LocalVector locDir(locVtx.x(), locVtx.y(), locVtx.z());
-    float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, cluster, locDir);
+    float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, *cluster, locDir);
     
     float noise = cluster->noiseRescaledByGain();
     if(noise > 0.0) fillME(iModME->second.ClusterStoNCorr ,StoN*cos);
@@ -956,12 +956,12 @@ void SiStripMonitorTrack::fillMEs(SiStripClusterInfo* cluster,uint32_t detid, co
 
   // new dE/dx (chargePerCM)
   // https://indico.cern.ch/event/342236/session/5/contribution/10/material/slides/0.pdf
-  float dQdx_fromTrack = siStripClusterTools::chargePerCM(detid, cluster, LV);
+  float dQdx_fromTrack = siStripClusterTools::chargePerCM(detid, *cluster, LV);
   // from straigth line origin-sensor centre
   const StripGeomDetUnit* DetUnit = (const StripGeomDetUnit*) tkgeom_->idToDetUnit(DetId(detid));
   LocalPoint locVtx = DetUnit->toLocal(GlobalPoint(0.0, 0.0, 0.0));
   LocalVector locDir(locVtx.x(), locVtx.y(), locVtx.z());
-  float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, cluster, locDir);
+  float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, *cluster, locDir);
   
   std::map<std::string, LayerMEs>::iterator iLayer  = LayerMEsMap.find(layer_id);
   if (iLayer != LayerMEsMap.end()) {

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -307,10 +307,10 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint3
   hname = hidmanager.createHistoLayer("Summary_ClusterPosition",name,layer_id,"OffTrack");
   theLayerMEs.ClusterPosOffTrack = ibooker.book1D(hname, hname, total_nr_strips, 0.5,total_nr_strips+0.5);
 
-  hname = hidmanager.createHistoLayer("Summary_ClusterPerCM",name,layer_id,"fromTrack");
+  hname = hidmanager.createHistoLayer("Summary_ClusterChargePerCM",name,layer_id,"fromTrack");
   theLayerMEs.ClusterChargePerCMfromTrack = bookME1D(ibooker , "TH1ClusterChargePerCM", hname.c_str());
 
-  hname = hidmanager.createHistoLayer("Summary_ClusterPerCM",name,layer_id,"fromOrigin");
+  hname = hidmanager.createHistoLayer("Summary_ClusterChargePerCM",name,layer_id,"fromOrigin");
   theLayerMEs.ClusterChargePerCMfromOrigin = bookME1D(ibooker , "TH1ClusterChargePerCM", hname.c_str());
 
   //bookeeping

--- a/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
+++ b/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
@@ -29,7 +29,7 @@ namespace siStripClusterTools {
 
   template<typename Clus>
   float chargePerCM(DetId detid, Clus const & cl) {
-    return cl->charge()*sensorThicknessInverse(detid);
+    return cl.charge()*sensorThicknessInverse(detid);
   }
 
 

--- a/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
+++ b/DataFormats/SiStripCluster/interface/SiStripClusterTools.h
@@ -29,7 +29,7 @@ namespace siStripClusterTools {
 
   template<typename Clus>
   float chargePerCM(DetId detid, Clus const & cl) {
-    return cl.charge()*sensorThicknessInverse(detid);
+    return cl->charge()*sensorThicknessInverse(detid);
   }
 
 


### PR DESCRIPTION
as well described by Bill in one of his recent presentation
https://indico.cern.ch/event/342236/session/5/contribution/10/material/slides/0.pdf

a new quantity, dQ/dx, will be used by the tracking in order to mitigate the effect of the PU
it is therefore necessary to have this new quantity w/in the list of the strip MEs

![dqdx_fromorigin_pu25](https://cloud.githubusercontent.com/assets/4946419/5682376/d70f351e-981f-11e4-9a73-8823e34617f0.png)
this plot comes from runTheMatrix -l 25202.0 [TTbar_13+DIGIUP15_PU25+RECOUP15_PU25+HARVESTUP15+MINIAODMCUP15]
