### PR TITLE
Apply the cuts on the HCAL RecHit timing on the -7.5 and +17.5 ns edges ...

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHBHETimeSelected_cfi.py
@@ -9,112 +9,112 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(False),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(1.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(5.0),
             minEnergy = cms.double(0.0),
             maxEnergy = cms.double(2.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-22.),
-            maxTime = cms.double(22.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
 
         cms.PSet(
@@ -122,40 +122,40 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(5.0),
             minEnergy = cms.double(2.0),
             maxEnergy = cms.double(5.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
 
         cms.PSet(
@@ -163,40 +163,40 @@ particleFlowClusterHBHETimeSelected = cms.EDProducer(
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(2.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(3.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(4.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         ),
         cms.PSet(
             depth=cms.double(5.0),
             minEnergy = cms.double(5.0),
             maxEnergy = cms.double(1000000.0),
             endcap = cms.bool(True),
-            minTime = cms.double(-20.),
-            maxTime = cms.double(20.)
+            minTime = cms.double(-7.6),
+            maxTime = cms.double(17.4)
         )
 )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -29,8 +29,43 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
                       maxSeverities      = cms.vint32(11),
                       cleaningThresholds = cms.vdouble(0.0),
                       flags              = cms.vstring('Standard')
-                  )
-                  
+                  ),
+                  cms.PSet(
+                      name = cms.string("PFRecHitQTestHCALTimeVsDepth"),
+                      cuts = cms.VPSet(
+                             cms.PSet( 
+                                 depth = cms.int32(1),
+                                 minTime = cms.double(-7.6),
+                                 maxTime = cms.double(17.4),
+                                 threshold = cms.double(0.0),
+                             ),
+                             cms.PSet( 
+                                 depth = cms.int32(2),
+                                 minTime = cms.double(-7.6),
+                                 maxTime = cms.double(17.4),
+                                 threshold = cms.double(0.0),
+                             ),
+                             cms.PSet( 
+                                 depth = cms.int32(3),
+                                 minTime = cms.double(-7.6),
+                                 maxTime = cms.double(17.4),
+                                 threshold = cms.double(0.0),
+                             ),
+                             cms.PSet( 
+                                 depth = cms.int32(4),
+                                 minTime = cms.double(-7.6),
+                                 maxTime = cms.double(17.4),
+                                 threshold = cms.double(0.0),
+                             ),
+                             cms.PSet( 
+                                 depth = cms.int32(5),
+                                 minTime = cms.double(-7.6),
+                                 maxTime = cms.double(17.4),
+                                 threshold = cms.double(0.0),
+                             ),
+
+                      )
+                  ) 
 
              )
            ),


### PR DESCRIPTION
Apply the cuts on the HCAL RecHit timing on the -7.5 and +17.5 ns edges to remove these two spurious spikes, before throw hits into the PF clustering, also same cuts for PFClusters.
