### PR TITLE
Revert "Fix fillDescriptions in ESRawToDigi.cc"

### DIFF
--- a/EventFilter/ESRawToDigi/src/ESRawToDigi.cc
+++ b/EventFilter/ESRawToDigi/src/ESRawToDigi.cc
@@ -42,13 +42,10 @@ ESRawToDigi::~ESRawToDigi(){
 void ESRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("sourceTag",edm::InputTag("rawDataCollector"));
-  desc.add<std::string>("ESdigiCollection","");
-  desc.addUntracked<bool>("DoRegional",false);
-  desc.addUntracked<edm::InputTag>("ESFedsListLabel", edm::InputTag(":esfedslist"));
   desc.addUntracked<bool>("debugMode",false);
-  desc.addOptional<std::string>("InstanceES");
-  desc.addOptional<edm::FileInPath>("LookupTable");
-//desc.add<edm::FileInPath>("LookupTable",edm::FileInPath("EventFilter/ESDigiToRaw/data/ES_lookup_table.dat"));
+  desc.add<std::string>("InstanceES","");
+  desc.add<edm::FileInPath>("LookupTable",edm::FileInPath("EventFilter/ESDigiToRaw/data/ES_lookup_table.dat"));
+  desc.add<std::string>("ESdigiCollection","");
   descriptions.add("esRawToDigi",desc);
 }
 


### PR DESCRIPTION
Reverts cms-sw/cmssw#7113

lookup table is used in the PSet - just not in ESRawToDigi.cc it setup but rather ESUnpacker.
