### PR TITLE
Provide a mechanism so sites can prevent reporting of DNs to

### DIFF
--- a/FWCore/Catalog/interface/SiteLocalConfig.h
+++ b/FWCore/Catalog/interface/SiteLocalConfig.h
@@ -2,6 +2,7 @@
 #define FWCore_Catalog_SiteLocalConfig_h
 
 // INCLUDES
+# include <set>
 # include <string>
 # include <vector>
 # include <netdb.h>
@@ -40,6 +41,7 @@ namespace edm {
     virtual unsigned int debugLevel() const = 0;
     virtual std::vector<std::string> const* sourceNativeProtocols() const = 0;
     virtual struct addrinfo const * statisticsDestination() const = 0;
+    virtual std::set<std::string> const* statisticsInfo() const = 0;
     virtual std::string const& siteName (void) const = 0;
 
     // implicit copy constructor

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -133,6 +133,7 @@ namespace edm {
           m_nativeProtocolsPtr(nullptr),
           m_statisticsDestination(),
           m_statisticsAddrInfo(nullptr),
+          m_statisticsInfoAvail(false),
           m_siteName() {
 
         char* tmp = getenv("CMS_PATH");
@@ -156,6 +157,13 @@ namespace edm {
         const std::string * tmpStringPtr = NULL;
         overrideFromPSet("overrideStatisticsDestination", pset, m_statisticsDestination, tmpStringPtr);
         this->computeStatisticsDestination();
+        std::vector<std::string> tmpStatisticsInfo; std::vector<std::string> const *tmpStatisticsInfoPtr = NULL;
+        overrideFromPSet("overrideStatisticsInfo", pset, tmpStatisticsInfo, tmpStatisticsInfoPtr);
+        if (tmpStatisticsInfoPtr) {
+          m_statisticsInfoAvail = true;
+          m_statisticsInfo.clear();
+          for (auto &entry : tmpStatisticsInfo) {m_statisticsInfo.insert(std::move(entry));}
+        }
 
        if(pset.exists("debugLevel")) {
             m_debugLevel = pset.getUntrackedParameter<unsigned int>("debugLevel");
@@ -330,6 +338,11 @@ namespace edm {
        return m_statisticsAddrInfo;
     }
 
+    std::set<std::string> const*
+    SiteLocalConfigService::statisticsInfo() const {
+       return m_statisticsInfoAvail ? &m_statisticsInfo : nullptr;
+    }
+
     std::string const&
     SiteLocalConfigService::siteName() const {
        return m_siteName;
@@ -492,7 +505,13 @@ namespace edm {
 
               if (statsDestList->getLength() > 0) {
                 DOMElement *statsDest = static_cast<DOMElement *>(statsDestList->item(0));
-                m_statisticsDestination = _toString(statsDest->getAttribute(_toDOMS("name")));
+                m_statisticsDestination = _toString(statsDest->getAttribute(_toDOMS("endpoint")));
+                if (!m_statisticsDestination.size()) {
+                  m_statisticsDestination = _toString(statsDest->getAttribute(_toDOMS("name")));
+                }
+                std::string tmpStatisticsInfo = _toString(statsDest->getAttribute(_toDOMS("info")));
+                boost::split(m_statisticsInfo, tmpStatisticsInfo, boost::is_any_of("\t ,"));
+                m_statisticsInfoAvail = tmpStatisticsInfo.size();
               }
 
               DOMNodeList *prefetchingList = sourceConfig->getElementsByTagName(_toDOMS("prefetching"));
@@ -569,6 +588,8 @@ namespace edm {
         ->setComment("Request ROOT to asynchronously prefetch I/O during computation.");
       desc.addOptionalUntracked<std::string>("overrideStatisticsDestination")
         ->setComment("Provide an alternate network destination for I/O statistics (must be in the form of host:port).");
+      desc.addOptionalUntracked<std::vector<std::string> >("overrideStatisticsInfo")
+        ->setComment("Provide an alternate listing of statistics to send (comma separated list; current options are 'dn' or 'nodn').  If left blank, all information is snet (including DNs).");
 
       descriptions.add("SiteLocalConfigService", desc);
     }

--- a/FWCore/Services/src/SiteLocalConfigService.cc
+++ b/FWCore/Services/src/SiteLocalConfigService.cc
@@ -154,10 +154,10 @@ namespace edm {
         overrideFromPSet("overrideSourceTTreeCacheSize", pset, m_ttreeCacheSize, m_ttreeCacheSizePtr);
         overrideFromPSet("overrideSourceTimeout", pset, m_timeout, m_timeoutPtr);
         overrideFromPSet("overridePrefetching", pset, m_enablePrefetching, m_enablePrefetchingPtr);
-        const std::string * tmpStringPtr = NULL;
+        const std::string * tmpStringPtr = nullptr;
         overrideFromPSet("overrideStatisticsDestination", pset, m_statisticsDestination, tmpStringPtr);
         this->computeStatisticsDestination();
-        std::vector<std::string> tmpStatisticsInfo; std::vector<std::string> const *tmpStatisticsInfoPtr = NULL;
+        std::vector<std::string> tmpStatisticsInfo; std::vector<std::string> const *tmpStatisticsInfoPtr = nullptr;
         overrideFromPSet("overrideStatisticsInfo", pset, tmpStatisticsInfo, tmpStatisticsInfoPtr);
         if (tmpStatisticsInfoPtr) {
           m_statisticsInfoAvail = true;
@@ -511,7 +511,7 @@ namespace edm {
                 }
                 std::string tmpStatisticsInfo = _toString(statsDest->getAttribute(_toDOMS("info")));
                 boost::split(m_statisticsInfo, tmpStatisticsInfo, boost::is_any_of("\t ,"));
-                m_statisticsInfoAvail = tmpStatisticsInfo.size();
+                m_statisticsInfoAvail = !tmpStatisticsInfo.empty();
               }
 
               DOMNodeList *prefetchingList = sourceConfig->getElementsByTagName(_toDOMS("prefetching"));

--- a/FWCore/Services/src/SiteLocalConfigService.h
+++ b/FWCore/Services/src/SiteLocalConfigService.h
@@ -24,23 +24,24 @@ namespace edm {
         public:
             explicit SiteLocalConfigService(ParameterSet const& pset);
 
-            std::string const dataCatalog(void) const;
-            std::string const fallbackDataCatalog(void) const;
-            std::string const lookupCalibConnect(std::string const& input) const;
-            std::string const rfioType(void) const;
+            std::string const dataCatalog(void) const override;
+            std::string const fallbackDataCatalog(void) const override;
+            std::string const lookupCalibConnect(std::string const& input) const override;
+            std::string const rfioType(void) const override;
 
-            std::string const* sourceCacheTempDir() const;
-            double const* sourceCacheMinFree() const;
-            std::string const* sourceCacheHint() const;
+            std::string const* sourceCacheTempDir() const override;
+            double const* sourceCacheMinFree() const override;
+            std::string const* sourceCacheHint() const override;
             std::string const* sourceCloneCacheHint() const override;
-            std::string const* sourceReadHint() const;
-            unsigned int const* sourceTTreeCacheSize() const;
-            unsigned int const* sourceTimeout() const;
-            bool                enablePrefetching() const;
-            unsigned int        debugLevel() const;
-            std::vector<std::string> const* sourceNativeProtocols() const;
-            struct addrinfo const* statisticsDestination() const;
-            std::string const&  siteName() const;
+            std::string const* sourceReadHint() const override;
+            unsigned int const* sourceTTreeCacheSize() const override;
+            unsigned int const* sourceTimeout() const override;
+            bool                enablePrefetching() const override;
+            unsigned int        debugLevel() const override;
+            std::vector<std::string> const* sourceNativeProtocols() const override;
+            struct addrinfo const* statisticsDestination() const override;
+            std::set<std::string> const* statisticsInfo() const override;
+            std::string const&  siteName() const override;
 
             // implicit copy constructor
             // implicit assignment operator
@@ -80,6 +81,8 @@ namespace edm {
             std::string         m_statisticsDestination;
             struct addrinfo   * m_statisticsAddrInfo;
             static const std::string m_statisticsDefaultPort;
+            std::set<std::string> m_statisticsInfo;
+            bool m_statisticsInfoAvail;
             std::string         m_siteName;
          };
 

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -171,6 +171,15 @@ StatisticsSenderService::filePreCloseEvent(std::string const& lfn, bool usedFall
     return;
   }
 
+  std::set<std::string> const * info = pSLC->statisticsInfo();
+  if (info && info->size() && (m_userdn != "unknown") && (
+      (info->find("dn") == info->end()) ||
+      (info->find("nodn") != info->end()))
+     )
+  {
+    m_userdn = "not reported";
+  }
+
   std::string results;
   fillUDP(pSLC->siteName(), usedFallback, results);
 


### PR DESCRIPTION
central collector.

This changes the attribute name for the statistics destination
to "endpoint" instead of "name".  Further, DN information can be
suppressed by setting info="nodn" in the site local config.

This allows sites under stricter privacy laws to have the following:

<statistics-destination endpoint="foo.example.com" info="nodn"/>

This will prevent DNs from being sent over UDP on current and previous
software versions.

Other sites may continue with their previous settings.
