### PR TITLE
removing duplication

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -471,8 +471,8 @@ def cust_2023HGCalV6Muon(process):
     exactly the same as the cust_2023HGCalMuon function but this could change in the
     future.
     """
-    process = cust_2023HGCal_common(process)
-    process = customise_me0(process)
+#    process = cust_2023HGCal_common(process)
+#    process = customise_me0(process)
     process=customisePostLS1(process)
     process=customiseBE5DPixel10D(process)
     process=customise_HcalPhase2(process)


### PR DESCRIPTION
Removing the duplication of customization for hgcalv6 scenario :  It still exactly the same as the cust_2023HGCalMuon , but the duplication introduced was crashing the digi step with a weird Tracker error.

Now the digi step is running , but with a lot of errors like [1] , the reco is still crashing though [2] , but I guess these will be fixed while develping the digi-reco software fro hgcal V6 .
Tested with  runTheMatrix.py --what upgrade -l 13200

[1]%MSG-w CaloHitResponse:  MixingModule:mix 12-Jan-2015 22:05:36 CET  Run: 1 Event: 1
No Calo cell found for ID1159746564 so no time-of-flight subtraction will be done
%MSG
[2] cmsRun: /build/cmsbuild/jenkins-workarea/workspace/build-any-ib/4433/w/tmp/BUILDROOT/
d0eedebecb65322da3bce05944630218/opt/cmssw/slc6_amd64_gcc472/cms/cmssw/CMSSW_6_2_X_SL
HC_2015-01-11-1400/src/Geometry/CaloGeometry/interface/EZMgrFL.h:26: EZMgrFL<T>::EZMg
rFL(EZMgrFL<T>::size_type, EZMgrFL<T>::size_type) [with T = Point3DBase<float, Global
Tag>; EZMgrFL<T>::size_type = long unsigned int]: Assertion `vecSize > 0' failed.

@pfs  @vandreev11 
