### PR TITLE
make setting of shower scales from lhe input configurable for pythia8

### DIFF
--- a/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
@@ -4,6 +4,7 @@ pythia8CommonSettingsBlock = cms.PSet(
     pythia8CommonSettings = cms.vstring(
       'Main:timesAllowErrors = 10000',
       'Check:epTolErr = 0.01',
+      'Beams:setProductionScalesFromLHEF = on',
       'SLHA:keepSM = on',
       'SLHA:minMassSM = 1000.',
       'ParticleDecays:limitTau0 = on',

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.cc
@@ -74,7 +74,7 @@ bool LHAupLesHouches::setEvent(int inProcId, double mRecalculate)
     
     //handle clustering scales if present,
     //applies to outgoing partons only
-    if (scales.size()>0 && hepeup.ISTUP[i]==1) {
+    if (setScalesFromLHEF_ && scales.size()>0 && hepeup.ISTUP[i]==1) {
       if (iscale>=scales.size()) {
         edm::LogError("InvalidLHEInput") << "Pythia8 requires"
                                     << "cluster scales for all outgoing partons or for none" 

--- a/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
+++ b/GeneratorInterface/Pythia8Interface/plugins/LHAupLesHouches.h
@@ -21,7 +21,7 @@
 
 class LHAupLesHouches : public Pythia8::LHAup {
   public:
-    LHAupLesHouches() {;}
+    LHAupLesHouches() : setScalesFromLHEF_(false) {;}
 
     //void loadRunInfo(const boost::shared_ptr<lhef::LHERunInfo> &runInfo)
     void loadRunInfo(lhef::LHERunInfo* runInfo)
@@ -30,6 +30,8 @@ class LHAupLesHouches : public Pythia8::LHAup {
     //void loadEvent(const boost::shared_ptr<lhef::LHEEvent> &event)
     void loadEvent(lhef::LHEEvent* event)
       { this->event = event; }
+      
+    void setScalesFromLHEF(bool b) { setScalesFromLHEF_ = b; }
 
   private:
 
@@ -40,4 +42,8 @@ class LHAupLesHouches : public Pythia8::LHAup {
     lhef::LHERunInfo* runInfo;
     //boost::shared_ptr<lhef::LHEEvent>	event;
     lhef::LHEEvent* event;
+    
+    // Flag to set particle production scales or not.
+    bool setScalesFromLHEF_;
+
 };

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -414,6 +414,7 @@ bool Pythia8Hadronizer::initializeForExternalPartons()
   } else {
 
     lhaUP.reset(new LHAupLesHouches());
+    lhaUP->setScalesFromLHEF(fMasterGen->settings.flag("Beams:setProductionScalesFromLHEF"));
     lhaUP->loadRunInfo(lheRunInfo());
     
     if ( fJetMatchingHook )


### PR DESCRIPTION
 as for standalone pythia8 (and enable by default to preserve old behaviour)
