### PR TITLE
Integration of the new MET significance algorithm

### DIFF
--- a/RecoMET/METAlgorithms/BuildFile.xml
+++ b/RecoMET/METAlgorithms/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/METReco"/>
+<use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/CaloTowers"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/CSCRecHit"/>

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -1,0 +1,63 @@
+// -*- C++ -*-
+//
+// Package:    METAlgorithms
+// Class:      METSignificance
+// 
+/**\class METSignificance METSignificance.cc RecoMET/METAlgorithms/src/METSignificance.cc
+Description: [one line class summary]
+Implementation:
+[Notes on implementation]
+*/
+//
+// Original Author:  Nathan Mirman (Cornell University)
+//         Created:  Thu May 30 16:39:52 CDT 2013
+//
+//
+#ifndef METAlgorithms_METSignificance_h
+#define METAlgorithms_METSignificance_h
+//____________________________________________________________________________||
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "TMatrixD.h"
+
+//____________________________________________________________________________||
+class METSignificance {
+   public:
+      explicit METSignificance() {  };
+      ~METSignificance() {  };
+
+      TMatrixD getCovariance();
+      double getSignificance(TMatrixD&);
+
+      void addJets( const std::vector<reco::Jet>& );
+      void addLeptons( const std::vector<reco::Candidate::LorentzVector>& );
+      void addCandidates( const std::vector<reco::Candidate::LorentzVector>& );
+      void addMET( const reco::MET& );
+
+      void setThreshold( const double& );
+      void setJetEtaBins( const std::vector<double>& );
+      void setJetParams( const std::vector<double>& );
+      void setPJetParams( const std::vector<double>& );
+      void setResFiles( const std::string&, const std::string& );
+
+   private:
+      std::vector<reco::Jet> cleanJets(double, double);
+
+      std::vector<reco::Jet> jets;
+      std::vector<reco::Candidate::LorentzVector> leptons;
+      std::vector<reco::Candidate::LorentzVector> candidates;
+      reco::MET met;
+
+      double jetThreshold;
+      std::vector<double> jetetas;
+      std::vector<double> jetparams;
+      std::vector<double> pjetparams;
+
+      std::string ptResFileName;
+      std::string phiResFileName;
+
+};
+
+//____________________________________________________________________________||
+#endif // METAlgorithms_METSignificance_h

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -22,42 +22,45 @@ Implementation:
 #include "TMatrixD.h"
 
 //____________________________________________________________________________||
-class METSignificance {
-   public:
-      explicit METSignificance() {  };
-      ~METSignificance() {  };
+namespace metsig {
 
-      TMatrixD getCovariance();
-      double getSignificance(TMatrixD&);
+   class METSignificance {
+      public:
+         explicit METSignificance() {  };
+         ~METSignificance() {  };
 
-      void addJets( const std::vector<reco::Jet>& );
-      void addLeptons( const std::vector<reco::Candidate::LorentzVector>& );
-      void addCandidates( const std::vector<reco::Candidate::LorentzVector>& );
-      void addMET( const reco::MET& );
+         TMatrixD getCovariance();
+         double getSignificance(TMatrixD&);
 
-      void setThreshold( const double& );
-      void setJetEtaBins( const std::vector<double>& );
-      void setJetParams( const std::vector<double>& );
-      void setPJetParams( const std::vector<double>& );
-      void setResFiles( const std::string&, const std::string& );
+         void addJets( const std::vector<reco::Jet>& );
+         void addLeptons( const std::vector<reco::Candidate::LorentzVector>& );
+         void addCandidates( const std::vector<reco::Candidate::LorentzVector>& );
+         void addMET( const reco::MET& );
 
-   private:
-      std::vector<reco::Jet> cleanJets(double, double);
+         void setThreshold( const double& );
+         void setJetEtaBins( const std::vector<double>& );
+         void setJetParams( const std::vector<double>& );
+         void setPJetParams( const std::vector<double>& );
+         void setResFiles( const std::string&, const std::string& );
 
-      std::vector<reco::Jet> jets;
-      std::vector<reco::Candidate::LorentzVector> leptons;
-      std::vector<reco::Candidate::LorentzVector> candidates;
-      reco::MET met;
+      private:
+         std::vector<reco::Jet> cleanJets(double, double);
 
-      double jetThreshold;
-      std::vector<double> jetetas;
-      std::vector<double> jetparams;
-      std::vector<double> pjetparams;
+         std::vector<reco::Jet> jets;
+         std::vector<reco::Candidate::LorentzVector> leptons;
+         std::vector<reco::Candidate::LorentzVector> candidates;
+         reco::MET met;
 
-      std::string ptResFileName;
-      std::string phiResFileName;
+         double jetThreshold;
+         std::vector<double> jetetas;
+         std::vector<double> jetparams;
+         std::vector<double> pjetparams;
 
-};
+         std::string ptResFileName;
+         std::string phiResFileName;
+   };
+
+}
 
 //____________________________________________________________________________||
 #endif // METAlgorithms_METSignificance_h

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -16,48 +16,48 @@ Implementation:
 #ifndef METAlgorithms_METSignificance_h
 #define METAlgorithms_METSignificance_h
 //____________________________________________________________________________||
+#include "CondFormats/JetMETObjects/interface/JetResolution.h"
+
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/METReco/interface/MET.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-#include "TMatrixD.h"
+#include "DataFormats/Math/interface/deltaR.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "TF1.h"
 
 //____________________________________________________________________________||
 namespace metsig {
 
    class METSignificance {
       public:
-         explicit METSignificance() {  };
-         ~METSignificance() {  };
+         METSignificance(const edm::ParameterSet& iConfig);
+         ~METSignificance();
 
-         TMatrixD getCovariance();
-         double getSignificance(TMatrixD&);
-
-         void addJets( const std::vector<reco::Jet>& );
-         void addLeptons( const std::vector<reco::Candidate::LorentzVector>& );
-         void addCandidates( const std::vector<reco::Candidate::LorentzVector>& );
-         void addMET( const reco::MET& );
-
-         void setThreshold( const double& );
-         void setJetEtaBins( const std::vector<double>& );
-         void setJetParams( const std::vector<double>& );
-         void setPJetParams( const std::vector<double>& );
-         void setResFiles( const std::string&, const std::string& );
+         reco::METCovMatrix getCovariance(const edm::View<reco::Jet>& jets,
+					  const std::vector<reco::Candidate::LorentzVector>& leptons,
+					  const edm::View<reco::Candidate>& pfCandidates);
+     double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met ) const;
 
       private:
-         std::vector<reco::Jet> cleanJets(double, double);
+         std::vector<reco::Jet> cleanJets(const edm::View<reco::Jet>& jets, 
+					  const std::vector<reco::Candidate::LorentzVector>& leptons);
+         bool cleanJet(const reco::Jet& jet, 
+		   const std::vector<reco::Candidate::LorentzVector>& leptons);
 
-         std::vector<reco::Jet> jets;
-         std::vector<reco::Candidate::LorentzVector> leptons;
-         std::vector<reco::Candidate::LorentzVector> candidates;
-         reco::MET met;
+         double jetThreshold_;
+         double dR2match_;
+         std::vector<double> jetEtas_;
+         std::vector<double> jetParams_;
+         std::vector<double> pjetParams_;
 
-         double jetThreshold;
-         std::vector<double> jetetas;
-         std::vector<double> jetparams;
-         std::vector<double> pjetparams;
+         JetResolution* ptRes_;
+         JetResolution* phiRes_;
 
-         std::string ptResFileName;
-         std::string phiResFileName;
+         TF1* fPtEta_;
+         TF1* fPhiEta_;
+
    };
 
 }

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -51,7 +51,7 @@ Implementation:
 #include "RecoMET/METAlgorithms/interface/METSignificance.h"
 
 TMatrixD
-METSignificance::getCovariance()
+metsig::METSignificance::getCovariance()
 {
 
    edm::FileInPath fpt(ptResFileName);
@@ -161,7 +161,7 @@ METSignificance::getCovariance()
 }
 
 double
-METSignificance::getSignificance(TMatrixD& cov)
+metsig::METSignificance::getSignificance(TMatrixD& cov)
 {
    // covariance matrix determinant
    double det = cov(0,0)*cov(1,1) - cov(0,1)*cov(1,0);
@@ -178,7 +178,7 @@ METSignificance::getSignificance(TMatrixD& cov)
 }
 
 std::vector<reco::Jet>
-METSignificance::cleanJets(double ptThreshold, double dRmatch)
+metsig::METSignificance::cleanJets(double ptThreshold, double dRmatch)
 {
    double dR2match = dRmatch*dRmatch;
    std::vector<reco::Jet> retVal;
@@ -201,47 +201,47 @@ METSignificance::cleanJets(double ptThreshold, double dRmatch)
 }
 
 void
-METSignificance::addJets(const std::vector<reco::Jet>& inputJets){
+metsig::METSignificance::addJets(const std::vector<reco::Jet>& inputJets){
    jets = inputJets;
 }
 
 void
-METSignificance::addLeptons(const std::vector<reco::Candidate::LorentzVector>& inputLeptons){
+metsig::METSignificance::addLeptons(const std::vector<reco::Candidate::LorentzVector>& inputLeptons){
    leptons = inputLeptons;
 }
 
 void
-METSignificance::addCandidates(const std::vector<reco::Candidate::LorentzVector>& inputCandidates){
+metsig::METSignificance::addCandidates(const std::vector<reco::Candidate::LorentzVector>& inputCandidates){
    candidates = inputCandidates;
 }
 
 void
-METSignificance::addMET(const reco::MET& inputMET){
+metsig::METSignificance::addMET(const reco::MET& inputMET){
    met = inputMET;
 }
 
 void
-METSignificance::setThreshold(const double& inputThreshold){
+metsig::METSignificance::setThreshold(const double& inputThreshold){
    jetThreshold = inputThreshold;
 }
 
 void
-METSignificance::setJetEtaBins(const std::vector<double>& inputEtaBins){
+metsig::METSignificance::setJetEtaBins(const std::vector<double>& inputEtaBins){
    jetetas = inputEtaBins;
 }
 
 void
-METSignificance::setJetParams(const std::vector<double>& inputParams){
+metsig::METSignificance::setJetParams(const std::vector<double>& inputParams){
    jetparams = inputParams;
 }
 
 void
-METSignificance::setPJetParams(const std::vector<double>& inputParams){
+metsig::METSignificance::setPJetParams(const std::vector<double>& inputParams){
    pjetparams = inputParams;
 }
 
 void
-METSignificance::setResFiles(const std::string& inputPtFile, const std::string& inputPhiFile){
+metsig::METSignificance::setResFiles(const std::string& inputPtFile, const std::string& inputPhiFile){
    ptResFileName = inputPtFile;
    phiResFileName = inputPhiFile;
 }

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -78,7 +78,7 @@ metsig::METSignificance::getCovariance()
    // subtract leptons out of sumPt
    for ( std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin();
          lepton != leptons.end(); ++lepton ) {
-      sumPt -= lepton->Pt();
+      //sumPt -= lepton->Pt();
    }
 
    // add jets to metsig covariance matrix and subtract them from sumPt

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -1,0 +1,248 @@
+// -*- C++ -*-
+//
+// Package:    METAlgorithms
+// Class:      METSignificance
+// 
+/**\class METSignificance METSignificance.cc RecoMET/METAlgorithms/src/METSignificance.cc
+Description: [one line class summary]
+Implementation:
+[Notes on implementation]
+*/
+//
+// Original Author:  Nathan Mirman (Cornell University)
+//         Created:  Thu May 30 16:39:52 CDT 2013
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "CondFormats/JetMETObjects/interface/JetResolution.h"
+#include "JetMETCorrections/Objects/interface/JetCorrector.h"
+
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/JetReco/interface/Jet.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/MuonReco/interface/Muon.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+
+#include "TLorentzVector.h"
+#include "TFile.h"
+#include "TTree.h"
+#include "TMatrixD.h"
+
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+
+#include "RecoMET/METAlgorithms/interface/METSignificance.h"
+
+TMatrixD
+METSignificance::getCovariance()
+{
+
+   edm::FileInPath fpt(ptResFileName);
+   edm::FileInPath fphi(phiResFileName);
+
+   JetResolution *ptRes_  = new JetResolution(fpt.fullPath().c_str(),false);
+   JetResolution *phiRes_ = new JetResolution(fphi.fullPath().c_str(),false);
+
+   // disambiguate jets and leptons
+   std::vector<reco::Jet> cleanjets = cleanJets(jetThreshold, 0.4);
+
+   // metsig covariance
+   double cov_xx = 0;
+   double cov_xy = 0;
+   double cov_yy = 0;
+
+   // pseudo-jet initialization
+   double pjet_px = 0;
+   double pjet_py = 0;
+   double pjet_scalpt = 0;
+
+   // calculate sumPt
+   double sumPt = 0;
+   for( std::vector<reco::Candidate::LorentzVector>::const_iterator cand = candidates.begin();
+         cand != candidates.end(); ++cand){
+      sumPt += cand->Pt();
+   }
+
+   // subtract leptons out of sumPt
+   for ( std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin();
+         lepton != leptons.end(); ++lepton ) {
+      sumPt -= lepton->Pt();
+   }
+
+   // add jets to metsig covariance matrix and subtract them from sumPt
+   for(std::vector<reco::Jet>::const_iterator jet = cleanjets.begin(); jet != cleanjets.end(); ++jet) {
+      double jpt  = jet->pt();
+      double jeta = jet->eta();
+      double feta = fabs(jeta);
+      double c = cos(jet->phi());
+      double s = sin(jet->phi());
+
+      double jptL123 = jpt;
+      double jptT1 = jpt;
+
+      // jet energy resolutions
+      double jeta_res = (fabs(jeta) < 9.9) ? jeta : 9.89; // JetResolutions defined for |eta|<9.9
+      TF1* fPtEta    = ptRes_ -> parameterEta("sigma",jeta_res);
+      TF1* fPhiEta   = phiRes_-> parameterEta("sigma",jeta_res);
+      double sigmapt = fPtEta->Eval(jptL123);
+      double sigmaphi = fPhiEta->Eval(jptL123);
+      delete fPtEta;
+      delete fPhiEta;
+
+      // split into high-pt and low-pt sector
+      if( jptL123 > jetThreshold ){
+         // high-pt jets enter into the covariance matrix via JER
+
+         double scale = 0;
+         if(feta<jetetas[0]) scale = jetparams[0];
+         else if(feta<jetetas[1]) scale = jetparams[1];
+         else if(feta<jetetas[2]) scale = jetparams[2];
+         else if(feta<jetetas[3]) scale = jetparams[3];
+         else scale = jetparams[4];
+
+         double dpt = scale*jptT1*sigmapt;
+         double dph = jptT1*sigmaphi;
+
+         cov_xx += dpt*dpt*c*c + dph*dph*s*s;
+         cov_xy += (dpt*dpt-dph*dph)*c*s;
+         cov_yy += dph*dph*c*c + dpt*dpt*s*s;
+
+         // subtract the pf constituents in each jet out of the sumPt
+         for(unsigned int i=0; i < jet->numberOfDaughters(); i++){
+            sumPt -= jet->daughter(i)->pt();
+         }
+
+      }else{
+         // low-pt jets are lumped into the pseudo-jet
+
+         pjet_px += jptL123*c;
+         pjet_py += jptL123*s;
+         pjet_scalpt += jptL123;
+
+         // subtract the pf constituents in each jet out of the sumPt
+         for(unsigned int i=0; i < jet->numberOfDaughters(); i++){
+            sumPt -= jet->daughter(i)->pt();
+         }
+         // add the (corrected) jet to the sumPt
+         sumPt += jptL123;
+
+      }
+
+   }
+
+   // add pseudo-jet to metsig covariance matrix
+   cov_xx += pjetparams[0]*pjetparams[0] + pjetparams[1]*pjetparams[1]*sumPt;
+   cov_yy += pjetparams[0]*pjetparams[0] + pjetparams[1]*pjetparams[1]*sumPt;
+
+   TMatrixD cov(2,2);
+   cov(0,0) = cov_xx;
+   cov(1,0) = cov_xy;
+   cov(0,1) = cov_xy;
+   cov(1,1) = cov_yy;
+
+   return cov;
+}
+
+double
+METSignificance::getSignificance(TMatrixD& cov)
+{
+   // covariance matrix determinant
+   double det = cov(0,0)*cov(1,1) - cov(0,1)*cov(1,0);
+
+   // invert matrix
+   double ncov_xx = cov(1,1) / det;
+   double ncov_xy = -cov(1,0) / det;
+   double ncov_yy = cov(0,0) / det;
+
+   // product of met and inverse of covariance
+   double sig = met.px()*met.px()*ncov_xx + 2*met.px()*met.py()*ncov_xy + met.py()*met.py()*ncov_yy;
+
+   return sig;
+}
+
+std::vector<reco::Jet>
+METSignificance::cleanJets(double ptThreshold, double dRmatch)
+{
+   double dR2match = dRmatch*dRmatch;
+   std::vector<reco::Jet> retVal;
+   for ( std::vector<reco::Jet>::const_iterator jet = jets.begin();
+         jet != jets.end(); ++jet ) {
+      bool isOverlap = false;
+      for ( std::vector<reco::Candidate::LorentzVector>::const_iterator lepton = leptons.begin();
+            lepton != leptons.end(); ++lepton ) {
+         TLorentzVector ljet, llep;
+         ljet.SetPtEtaPhiE( jet->pt(), jet->eta(), jet->phi(), jet->energy() );
+         llep.SetPtEtaPhiE( lepton->pt(), lepton->eta(), lepton->phi(), lepton->energy() );
+         if ( pow(ljet.DeltaR( llep ),2) < dR2match ) isOverlap = true;  
+      }
+      if ( jet->pt() > ptThreshold && !isOverlap ){
+         retVal.push_back(*jet);
+      }
+   }
+
+   return retVal;
+}
+
+void
+METSignificance::addJets(const std::vector<reco::Jet>& inputJets){
+   jets = inputJets;
+}
+
+void
+METSignificance::addLeptons(const std::vector<reco::Candidate::LorentzVector>& inputLeptons){
+   leptons = inputLeptons;
+}
+
+void
+METSignificance::addCandidates(const std::vector<reco::Candidate::LorentzVector>& inputCandidates){
+   candidates = inputCandidates;
+}
+
+void
+METSignificance::addMET(const reco::MET& inputMET){
+   met = inputMET;
+}
+
+void
+METSignificance::setThreshold(const double& inputThreshold){
+   jetThreshold = inputThreshold;
+}
+
+void
+METSignificance::setJetEtaBins(const std::vector<double>& inputEtaBins){
+   jetetas = inputEtaBins;
+}
+
+void
+METSignificance::setJetParams(const std::vector<double>& inputParams){
+   jetparams = inputParams;
+}
+
+void
+METSignificance::setPJetParams(const std::vector<double>& inputParams){
+   pjetparams = inputParams;
+}
+
+void
+METSignificance::setResFiles(const std::string& inputPtFile, const std::string& inputPhiFile){
+   ptResFileName = inputPtFile;
+   phiResFileName = inputPhiFile;
+}
+

--- a/RecoMET/METProducers/interface/METSignificanceProducer.h
+++ b/RecoMET/METProducers/interface/METSignificanceProducer.h
@@ -21,14 +21,25 @@
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
-#include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/METReco/interface/METFwd.h"
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETFwd.h"
+#include "DataFormats/METReco/interface/CommonMETData.h"
+
+#include "RecoMET/METAlgorithms/src/METSignificance.cc"
+
+#include <string.h>
+
 
 //____________________________________________________________________________||
 namespace metsig
@@ -50,19 +61,12 @@ namespace cms
 
       // ----------member data ---------------------------
 
-      edm::InputTag pfjetsTag_;
-      edm::InputTag metTag_;
-      edm::InputTag pfcandidatesTag_;
-      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > srcLeptons_;
-      Int_t metsSize_;
-
-      double jetThreshold_;
-      std::vector<double> jetEtas_;
-      std::vector<double> jetParams_;
-      std::vector<double> pjetParams_;
-
-      std::string resAlg;
-      std::string resEra;
+      edm::EDGetTokenT<edm::View<reco::Jet> > pfjetsToken_;
+      edm::EDGetTokenT<edm::View<reco::MET> > metToken_;
+      edm::EDGetTokenT<edm::View<reco::Candidate> > pfCandidatesToken_;
+      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
+ 
+      metsig::METSignificance* metSigAlgo_;
 
     };
 }

--- a/RecoMET/METProducers/interface/METSignificanceProducer.h
+++ b/RecoMET/METProducers/interface/METSignificanceProducer.h
@@ -1,0 +1,71 @@
+// -*- C++ -*-
+//
+// Package:    METProducers
+// Class:      METSignificanceProducer
+//
+/**\class METSignificanceProducer
+
+ Description: An EDProducer for CaloMET
+
+ Implementation:
+
+*/
+//
+//
+//
+
+//____________________________________________________________________________||
+#ifndef METSignificanceProducer_h
+#define METSignificanceProducer_h
+
+//____________________________________________________________________________||
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "DataFormats/Common/interface/View.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+
+//____________________________________________________________________________||
+namespace metsig
+{
+    class SignAlgoResolutions;
+}
+
+//____________________________________________________________________________||
+namespace cms
+{
+  class METSignificanceProducer: public edm::stream::EDProducer<>
+    {
+    public:
+      explicit METSignificanceProducer(const edm::ParameterSet&);
+      virtual ~METSignificanceProducer() { }
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
+
+    private:
+
+      // ----------member data ---------------------------
+
+      edm::InputTag pfjetsTag_;
+      edm::InputTag metTag_;
+      edm::InputTag pfcandidatesTag_;
+      std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > srcLeptons_;
+      Int_t metsSize_;
+
+      double jetThreshold_;
+      std::vector<double> jetEtas_;
+      std::vector<double> jetParams_;
+      std::vector<double> pjetParams_;
+
+      std::string resAlg;
+      std::string resEra;
+
+    };
+}
+
+//____________________________________________________________________________||
+#endif // METSignificanceProducer_h

--- a/RecoMET/METProducers/interface/PFMETProducer.h
+++ b/RecoMET/METProducers/interface/PFMETProducer.h
@@ -21,14 +21,30 @@
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
-
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/METReco/interface/METFwd.h"
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETFwd.h"
+#include "DataFormats/METReco/interface/CommonMETData.h"
+
+#include "RecoMET/METAlgorithms/interface/METAlgo.h"
+#include "RecoMET/METAlgorithms/interface/SignAlgoResolutions.h"
+#include "RecoMET/METAlgorithms/interface/PFSpecificAlgo.h"
+#include "RecoMET/METAlgorithms/interface/SignPFSpecificAlgo.h"
+#include "RecoMET/METAlgorithms/interface/METSignificance.h"
+
+#include "TVector.h"
+
+#include <string.h>
+
 
 //____________________________________________________________________________||
 namespace metsig
@@ -48,24 +64,21 @@ namespace cms
 
     private:
 
+      reco::METCovMatrix getMETCovMatrix(const edm::Event& event, 
+					 const edm::View<reco::Candidate>& input) const;
+
+
       edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
 
       bool calculateSignificance_;
-      //metsig::SignAlgoResolutions *resolutions_;
+      metsig::METSignificance* metSigAlgo_;
 
       double globalThreshold_;
       double jetThreshold_;
 
       edm::EDGetTokenT<edm::View<reco::Jet> > jetToken_;
       std::vector< edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
-      std::string resAlg_;
-      std::string resEra_;
-
-      std::vector<double> jetEtas_;
-      std::vector<double> jetParams_;
-      std::vector<double> pjetParams_;
-
-    };
+  };
 }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/interface/PFMETProducer.h
+++ b/RecoMET/METProducers/interface/PFMETProducer.h
@@ -51,11 +51,19 @@ namespace cms
       edm::EDGetTokenT<edm::View<reco::Candidate> > inputToken_;
 
       bool calculateSignificance_;
-      metsig::SignAlgoResolutions *resolutions_;
+      //metsig::SignAlgoResolutions *resolutions_;
 
       double globalThreshold_;
+      double jetThreshold_;
 
-      edm::EDGetTokenT<edm::View<reco::PFJet> > jetToken_;
+      edm::EDGetTokenT<edm::View<reco::Jet> > jetToken_;
+      std::vector< edm::EDGetTokenT<edm::View<reco::Candidate> > > lepTokens_;
+      std::string resAlg_;
+      std::string resEra_;
+
+      std::vector<double> jetEtas_;
+      std::vector<double> jetParams_;
+      std::vector<double> pjetParams_;
 
     };
 }

--- a/RecoMET/METProducers/python/METSignificanceObjects_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceObjects_cfi.py
@@ -1,0 +1,73 @@
+import FWCore.ParameterSet.Config as cms
+
+##======================================
+## Muons
+##======================================
+
+selectedMuons = cms.EDFilter(
+      "MuonSelector",
+      src = cms.InputTag('muons'),
+      cut = cms.string(    "(isTrackerMuon) && pt > 5"
+         "&& isPFMuon"+
+         "&& globalTrack.isNonnull"+
+         "&& innerTrack.hitPattern.numberOfValidPixelHits > 0"+
+         "&& innerTrack.normalizedChi2 < 10"+
+         "&& numberOfMatches > 0"+
+         "&& innerTrack.hitPattern.numberOfValidTrackerHits>5"+
+         "&& globalTrack.hitPattern.numberOfValidHits>0"+
+         "&& (pfIsolationR03.sumChargedHadronPt+max(0.,pfIsolationR03.sumNeutralHadronEt+pfIsolationR03.sumPhotonEt - 0.5*pfIsolationR03.sumPUPt))/pt < 0.3"+
+         "&& abs(innerTrack().dxy)<2.0"
+         ),
+      filter = cms.bool(False)
+      )
+
+
+##======================================
+## Electrons
+##======================================
+
+selectedElectrons = cms.EDFilter(
+      "GsfElectronSelector",
+      src = cms.InputTag('gedGsfElectrons'),
+      cut = cms.string(
+         "abs(eta) < 2.5 && pt > 19.5"                              +
+         "&& (gsfTrack.hitPattern().numberOfHits(\'MISSING_INNER_HITS\')<=1 )" +
+         "&& (pfIsolationVariables.sumChargedHadronPt+max(0.,pfIsolationVariables.sumNeutralHadronEt+pfIsolationVariables.sumPhotonEt - 0.5*pfIsolationVariables.sumPUPt))/et     < 0.3"  +
+         "&& ((abs(eta) < 1.4442  "                                 +
+         "&& abs(deltaEtaSuperClusterTrackAtVtx)            < 0.007"+
+         "&& abs(deltaPhiSuperClusterTrackAtVtx)            < 0.8"  +
+         "&& sigmaIetaIeta                                  < 0.01" +
+         "&& hcalOverEcal                                   < 0.15" +
+         "&& abs(1./superCluster.energy - 1./p)             < 0.05)"+
+         "|| (abs(eta)  > 1.566 "+
+         "&& abs(deltaEtaSuperClusterTrackAtVtx)            < 0.009"+
+         "&& abs(deltaPhiSuperClusterTrackAtVtx)            < 0.10" +
+         "&& sigmaIetaIeta                                  < 0.03" +
+         "&& hcalOverEcal                                   < 0.10" +
+         "&& abs(1./superCluster.energy - 1./p)             < 0.05))" 
+         ),
+      filter = cms.bool(False)
+      )
+
+
+##======================================
+## Photons
+##======================================
+
+selectedPhotons = cms.EDFilter("PhotonSelector",
+      src = cms.InputTag("photons"),
+      cut = cms.string(
+         "abs(eta) < 2.5 && pt > 19.5" +
+         "&& sigmaIetaIeta < 0.03" +
+         "&& hadronicOverEm < 0.05" +
+         "&& hasPixelSeed == 0" +
+         "&& (chargedHadronIso + neutralHadronIso + photonIso)/pt < 0.2"
+         )
+      )
+
+
+selectionSequenceForMETSig = cms.Sequence(
+      selectedMuons+
+      selectedElectrons+
+      selectedPhotons
+      )

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+METSignificanceParams = cms.PSet(
+
+      # jet resolutions
+      jetResAlgo    = cms.string('AK5PF'),
+      jetResEra     = cms.string('Spring10'),
+      jetThreshold  = cms.double(20),
+
+      # eta bins for jet resolution tuning
+      jeta = cms.vdouble(0.5, 1.1, 1.7, 2.3),
+
+      # tuning parameters
+      jpar = cms.vdouble(1.15061, 1.07776, 1.04204, 1.12509, 1.56414, 0.0, 0.548758)
+
+      )

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -11,6 +11,7 @@ METSignificanceParams = cms.PSet(
       jeta = cms.vdouble(0.5, 1.1, 1.7, 2.3),
 
       # tuning parameters
-      jpar = cms.vdouble(1.15061, 1.07776, 1.04204, 1.12509, 1.56414, 0.0, 0.548758)
+      jpar = cms.vdouble(1.15061, 1.07776, 1.04204, 1.12509, 1.56414),
+      pjpar = cms.vdouble(0.0, 0.548758)
 
       )

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -3,9 +3,12 @@ import FWCore.ParameterSet.Config as cms
 METSignificanceParams = cms.PSet(
 
       # jet resolutions
-      jetResAlgo    = cms.string('AK5PF'),
-      jetResEra     = cms.string('Spring10'),
-      jetThreshold  = cms.double(20),
+      ptResFile    = cms.string('Spring10_PtResolution_AK5PF.txt'),
+      phiResFile   = cms.string('Spring10_PhiResolution_AK5PF.txt'),
+      jetThreshold = cms.double(20),
+      
+      #jet-lepton matching dR
+      dRMatch = cms.double(0.4),
 
       # eta bins for jet resolution tuning
       jeta = cms.vdouble(0.5, 1.1, 1.7, 2.3),

--- a/RecoMET/METProducers/python/METSignificance_cfi.py
+++ b/RecoMET/METProducers/python/METSignificance_cfi.py
@@ -1,0 +1,15 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+METSignificance = cms.EDProducer(
+    "METSignificanceProducer",
+    srcLeptons = cms.VInputTag(
+       'slimmedElectrons',
+       'slimmedMuons',
+       'slimmedPhotons'
+       ),
+    pfjetsTag            = cms.untracked.InputTag('slimmedJets'),
+    metTag               = cms.untracked.InputTag('slimmedMETs'),
+    pfcandidatesTag      = cms.untracked.InputTag('packedPFCandidates')
+    )
+##____________________________________________________________________________||

--- a/RecoMET/METProducers/python/METSignificance_cfi.py
+++ b/RecoMET/METProducers/python/METSignificance_cfi.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from RecoMET.METProducers.METSignificanceParams_cfi import METSignificanceParams
+
 ##____________________________________________________________________________||
 METSignificance = cms.EDProducer(
     "METSignificanceProducer",
@@ -8,8 +10,10 @@ METSignificance = cms.EDProducer(
        'slimmedMuons',
        'slimmedPhotons'
        ),
-    pfjetsTag            = cms.untracked.InputTag('slimmedJets'),
-    metTag               = cms.untracked.InputTag('slimmedMETs'),
-    pfcandidatesTag      = cms.untracked.InputTag('packedPFCandidates')
+    srcPfJets            = cms.InputTag('slimmedJets'),
+    srcMet               = cms.InputTag('slimmedMETs'),
+    srcPFCandidates      = cms.InputTag('packedPFCandidates'),
+    
+    parameters = METSignificanceParams
     )
 ##____________________________________________________________________________||

--- a/RecoMET/METProducers/src/CaloMETProducer.cc
+++ b/RecoMET/METProducers/src/CaloMETProducer.cc
@@ -64,6 +64,7 @@ namespace cms
     CaloSpecificAlgo calospecalgo;
     reco::CaloMET calomet = calospecalgo.addInfo(input, commonMETdata, noHF_, globalThreshold_);
 
+    /*
     if( calculateSignificance_ )
       {
 	SignCaloSpecificAlgo signcalospecalgo;
@@ -71,7 +72,7 @@ namespace cms
 	calomet.SetMetSignificance(signcalospecalgo.getSignificance());
 	calomet.setSignificanceMatrix(signcalospecalgo.getSignificanceMatrix());
       }
-
+*/
     std::auto_ptr<reco::CaloMETCollection> calometcoll;
     calometcoll.reset(new reco::CaloMETCollection);
     calometcoll->push_back(calomet);

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -1,0 +1,166 @@
+// -*- C++ -*-
+//
+// Package:    METProducers
+// Class:      METSignificanceProducer
+//
+//
+
+//____________________________________________________________________________||
+#include "RecoMET/METProducers/interface/METSignificanceProducer.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/METReco/interface/METFwd.h"
+#include "DataFormats/METReco/interface/PFMET.h"
+#include "DataFormats/METReco/interface/PFMETFwd.h"
+#include "DataFormats/METReco/interface/CommonMETData.h"
+
+#include "RecoMET/METAlgorithms/src/METSignificance.cc"
+
+#include <string.h>
+
+#include "TMatrixD.h"
+
+//____________________________________________________________________________||
+namespace cms
+{
+
+//____________________________________________________________________________||
+  METSignificanceProducer::METSignificanceProducer(const edm::ParameterSet& iConfig)
+  {
+
+   std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter< std::vector<edm::InputTag> >("srcLeptons");
+   for(std::vector<edm::InputTag>::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
+      srcLeptons_.push_back( consumes<edm::View<reco::Candidate> >( *it ) );
+   }
+
+   pfjetsTag_    = iConfig.getUntrackedParameter<edm::InputTag>("pfjetsTag");
+
+   metTag_ = iConfig.getUntrackedParameter<edm::InputTag>("metTag");
+   pfcandidatesTag_ = iConfig.getUntrackedParameter<edm::InputTag>("pfcandidatesTag");
+
+   jetThreshold_ = iConfig.getParameter<double>("jetThreshold");
+   jetEtas_ = iConfig.getParameter<std::vector<double>>("jeta");
+   jetParams_ = iConfig.getParameter<std::vector<double>>("jpar");
+   pjetParams_ = iConfig.getParameter<std::vector<double>>("pjpar");
+
+   resAlg  = iConfig.getParameter<std::string>("jetResAlgo");
+   resEra  = iConfig.getParameter<std::string>("jetResEra");
+
+   produces<double>("METSignificance");
+   produces<double>("CovarianceMatrix00");
+   produces<double>("CovarianceMatrix01");
+   produces<double>("CovarianceMatrix10");
+   produces<double>("CovarianceMatrix11");
+
+  }
+
+//____________________________________________________________________________||
+  void METSignificanceProducer::produce(edm::Event& event, const edm::EventSetup& setup)
+  {
+   using namespace edm;
+
+   //
+   // met
+   //
+
+   Handle<View<reco::MET> > metHandle;
+   event.getByLabel(metTag_, metHandle);
+   reco::MET met = (*metHandle)[0];
+
+   //
+   // candidates
+   //
+
+   Handle<reco::CandidateView> inputCandidates;
+   event.getByLabel( pfcandidatesTag_, inputCandidates );
+   std::vector<reco::Candidate::LorentzVector> candidates;
+   for(View<reco::Candidate>::const_iterator cand = inputCandidates->begin();
+         cand != inputCandidates->end(); ++cand) {
+      candidates.push_back( cand->p4() );
+   }
+
+   //
+   // leptons
+   //
+
+   std::vector<reco::Candidate::LorentzVector> leptons;
+   for ( std::vector<EDGetTokenT<View<reco::Candidate> > >::const_iterator srcLeptons_i = srcLeptons_.begin();
+         srcLeptons_i != srcLeptons_.end(); ++srcLeptons_i ) {
+
+      Handle<reco::CandidateView> leptons_i;
+      event.getByToken(*srcLeptons_i, leptons_i);
+      for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
+            lepton != leptons_i->end(); ++lepton ) {
+         leptons.push_back(lepton->p4());
+      }
+   }
+
+   //
+   // jets
+   //
+
+   Handle<View<reco::Jet>> inputJets;
+   event.getByLabel( pfjetsTag_, inputJets );
+   std::vector<reco::Jet> jets;
+   for(View<reco::Jet>::const_iterator jet = inputJets->begin(); jet != inputJets->end(); ++jet) {
+      jets.push_back( *jet );
+   }
+
+   //
+   // resolutions
+   //
+
+   std::string path = "CondFormats/JetMETObjects/data";
+   std::string ptFileName  = path + "/" + resEra + "_PtResolution_" +resAlg+".txt";
+   std::string phiFileName = path + "/" + resEra + "_PhiResolution_"+resAlg+".txt";
+
+   //
+   // compute the significance
+   //
+
+   METSignificance metsig;
+
+   metsig.addMET( met );
+   metsig.addJets( jets );
+   metsig.addLeptons( leptons );
+   metsig.addCandidates( candidates );
+
+   metsig.setThreshold( jetThreshold_ );
+   metsig.setJetEtaBins( jetEtas_ );
+   metsig.setJetParams( jetParams_ );
+   metsig.setPJetParams( pjetParams_ );
+
+   metsig.setResFiles( ptFileName, phiFileName );
+
+   TMatrixD cov = metsig.getCovariance();
+   double sig  = metsig.getSignificance(cov);
+
+   std::auto_ptr<double> significance (new double);
+   (*significance) = sig;
+
+   std::auto_ptr<double> sigmatrix_00 (new double);
+   (*sigmatrix_00) = cov(0,0);
+   std::auto_ptr<double> sigmatrix_01 (new double);
+   (*sigmatrix_01) = cov(1,0);
+   std::auto_ptr<double> sigmatrix_10 (new double);
+   (*sigmatrix_10) = cov(0,1);
+   std::auto_ptr<double> sigmatrix_11 (new double);
+   (*sigmatrix_11) = cov(1,1);
+
+   event.put( significance, "METSignificance" );
+   event.put( sigmatrix_00, "CovarianceMatrix00" );
+   event.put( sigmatrix_01, "CovarianceMatrix01" );
+   event.put( sigmatrix_10, "CovarianceMatrix10" );
+   event.put( sigmatrix_11, "CovarianceMatrix11" );
+
+
+  }
+
+//____________________________________________________________________________||
+  DEFINE_FWK_MODULE(METSignificanceProducer);
+}
+
+//____________________________________________________________________________||

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -121,7 +121,7 @@ namespace cms
    // compute the significance
    //
 
-   METSignificance metsig;
+   metsig::METSignificance metsig;
 
    metsig.addMET( met );
    metsig.addJets( jets );

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -23,6 +23,8 @@
 #include "RecoMET/METAlgorithms/interface/SignPFSpecificAlgo.h"
 #include "RecoMET/METAlgorithms/interface/METSignificance.h"
 
+#include "TVector.h"
+
 #include <string.h>
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -71,7 +71,7 @@ namespace cms
 	edm::Handle<edm::View<reco::PFJet> > jets;
 	event.getByToken(jetToken_, jets);
 	pfsignalgo.addPFJets(jets.product());
-	pfmet.setSignificanceMatrix(pfsignalgo.mkSignifMatrix(input));
+	//pfmet.setSignificanceMatrix(pfsignalgo.mkSignifMatrix(input));
       }
 
     std::auto_ptr<reco::PFMETCollection> pfmetcoll;

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -8,25 +8,6 @@
 //____________________________________________________________________________||
 #include "RecoMET/METProducers/interface/PFMETProducer.h"
 
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/METReco/interface/METFwd.h"
-#include "DataFormats/METReco/interface/PFMET.h"
-#include "DataFormats/METReco/interface/PFMETFwd.h"
-#include "DataFormats/METReco/interface/CommonMETData.h"
-
-#include "RecoMET/METAlgorithms/interface/METAlgo.h"
-#include "RecoMET/METAlgorithms/interface/SignAlgoResolutions.h"
-#include "RecoMET/METAlgorithms/interface/PFSpecificAlgo.h"
-#include "RecoMET/METAlgorithms/interface/SignPFSpecificAlgo.h"
-#include "RecoMET/METAlgorithms/interface/METSignificance.h"
-
-#include "TVector.h"
-
-#include <string.h>
-
 //____________________________________________________________________________||
 namespace cms
 {
@@ -39,17 +20,14 @@ namespace cms
   {
     if(calculateSignificance_)
       {
-	jetToken_ = consumes<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("jets"));
-   std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter< std::vector<edm::InputTag> >("leptons");
-   for(std::vector<edm::InputTag>::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
-      lepTokens_.push_back( consumes<edm::View<reco::Candidate> >( *it ) );
-   }
-   resAlg_ = iConfig.getParameter<std::string>("jetResAlgo");
-   resEra_ = iConfig.getParameter<std::string>("jetResEra");
-   jetThreshold_ = iConfig.getParameter<double>("jetThreshold");
-   jetEtas_ = iConfig.getParameter<std::vector<double>>("jeta");
-   jetParams_ = iConfig.getParameter<std::vector<double>>("jpar");
-   pjetParams_ = iConfig.getParameter<std::vector<double>>("pjpar");
+	metSigAlgo_ = new metsig::METSignificance(iConfig);
+	
+	jetToken_ = mayConsume<edm::View<reco::Jet> >(iConfig.getParameter<edm::InputTag>("srcJets"));
+	std::vector<edm::InputTag> srcLeptonsTags = iConfig.getParameter< std::vector<edm::InputTag> >("srcLeptons");
+	for(std::vector<edm::InputTag>::const_iterator it=srcLeptonsTags.begin();it!=srcLeptonsTags.end();it++) {
+	  lepTokens_.push_back( mayConsume<edm::View<reco::Candidate> >( *it ) );
+	}
+  
       }
 
     std::string alias = iConfig.exists("alias") ? iConfig.getParameter<std::string>("alias") : "";
@@ -76,59 +54,8 @@ namespace cms
 
     if(calculateSignificance_)
       {
-
-    // candidates
-    std::vector<reco::Candidate::LorentzVector> candidates;
-    for(edm::View<reco::Candidate>::const_iterator cand = input->begin();
-          cand != input->end(); ++cand) {
-       candidates.push_back( cand->p4() );
-    }
-
-    // leptons
-    std::vector<reco::Candidate::LorentzVector> leptons;
-    for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
-          srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
-       edm::Handle<reco::CandidateView> leptons_i;
-       event.getByToken(*srcLeptons_i, leptons_i);
-       for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
-             lepton != leptons_i->end(); ++lepton ) {
-          leptons.push_back(lepton->p4());
-       }
-    }
-
-    // jets
-    edm::Handle<edm::View<reco::Jet>> inputJets;
-    event.getByToken( jetToken_, inputJets );
-    std::vector<reco::Jet> jets;
-    for(edm::View<reco::Jet>::const_iterator jet = inputJets->begin(); jet != inputJets->end(); ++jet) {
-       jets.push_back( *jet );
-    }
-
-    // resolutions
-    std::string path = "CondFormats/JetMETObjects/data";
-    std::string ptFileName  = path + "/" + resEra_ + "_PtResolution_" +resAlg_+".txt";
-    std::string phiFileName = path + "/" + resEra_ + "_PhiResolution_"+resAlg_+".txt";
-
-    // calculate significance matrix
-    metsig::METSignificance metsig;
-    metsig.addJets( jets );
-    metsig.addLeptons( leptons );
-    metsig.addCandidates( candidates );
-
-    metsig.setThreshold( jetThreshold_ );
-    metsig.setJetEtaBins( jetEtas_ );
-    metsig.setJetParams( jetParams_ );
-    metsig.setPJetParams( pjetParams_ );
-
-    metsig.setResFiles( ptFileName, phiFileName );
-
-    TMatrixD cov = metsig.getCovariance();
-    reco::METCovMatrix sigcov;
-    sigcov(0,0) = cov(0,0);
-    sigcov(1,0) = cov(1,0);
-    sigcov(0,1) = cov(0,1);
-    sigcov(1,1) = cov(1,1);
-    pfmet.setSignificanceMatrix(sigcov);
+	reco::METCovMatrix sigcov = getMETCovMatrix(event, *input);
+	pfmet.setSignificanceMatrix(sigcov);
       }
 
     std::auto_ptr<reco::PFMETCollection> pfmetcoll;
@@ -137,6 +64,36 @@ namespace cms
     pfmetcoll->push_back(pfmet);
     event.put(pfmetcoll);
   }
+
+
+
+  reco::METCovMatrix PFMETProducer::getMETCovMatrix(const edm::Event& event, const edm::View<reco::Candidate>& candInput) const {
+
+	// leptons
+	std::vector<reco::Candidate::LorentzVector> leptons;
+	for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
+	      srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
+	  edm::Handle<reco::CandidateView> leptons_i;
+	  event.getByToken(*srcLeptons_i, leptons_i);
+	  for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
+		lepton != leptons_i->end(); ++lepton ) {
+	    leptons.push_back(lepton->p4());
+	  }
+	}
+
+	// jets
+	edm::Handle<edm::View<reco::Jet> > inputJets;
+	event.getByToken( jetToken_, inputJets );
+
+	//Compute the covariance matrix and fill it
+	reco::METCovMatrix cov = metSigAlgo_->getCovariance( *inputJets, leptons, candInput);
+
+	return cov;
+  }
+
+
+
+
 
 //____________________________________________________________________________||
   DEFINE_FWK_MODULE(PFMETProducer);

--- a/RecoMET/METProducers/test/recoMET_METSignificance_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_METSignificance_cfg.py
@@ -1,0 +1,56 @@
+import FWCore.ParameterSet.Config as cms
+
+##____________________________________________________________________________||
+process = cms.Process("TEST")
+
+##____________________________________________________________________________||
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+
+##____________________________________________________________________________||
+process.load("RecoMET/METProducers.METSignificance_cfi")
+process.load("RecoMET/METProducers.METSignificanceParams_cfi")
+
+##____________________________________________________________________________||
+from RecoMET.METProducers.testInputFiles_cff import recoMETtestInputFiles
+process.source = cms.Source(
+    "PoolSource",
+    fileNames = cms.untracked.vstring(
+       ### MINIAODSIM
+       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/MINIAODSIM/PU25ns_PRE_LS172_V15-v1/00000//A652D13A-335F-E411-90BA-02163E008D01.root'
+       )
+    )
+
+##____________________________________________________________________________||
+process.out = cms.OutputModule(
+    "PoolOutputModule",
+    fileName = cms.untracked.string('recoMET_METSignificance.root'),
+    SelectEvents   = cms.untracked.PSet( SelectEvents = cms.vstring('p') ),
+    outputCommands = cms.untracked.vstring(
+        'drop *',
+        'keep *_*_*_TEST'
+        )
+    )
+
+##____________________________________________________________________________||
+process.options   = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
+process.MessageLogger.cerr.FwkReport.reportEvery = 50
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+
+##____________________________________________________________________________||
+process.METSignificance.jeta = process.METSignificanceParams.jeta
+process.METSignificance.jpar = process.METSignificanceParams.jpar
+process.METSignificance.pjpar = process.METSignificanceParams.pjpar
+process.METSignificance.jetResAlgo = process.METSignificanceParams.jetResAlgo
+process.METSignificance.jetResEra = process.METSignificanceParams.jetResEra
+process.METSignificance.jetThreshold = process.METSignificanceParams.jetThreshold
+
+##____________________________________________________________________________||
+process.p = cms.Path(
+    process.METSignificance
+    )
+
+process.e1 = cms.EndPath(
+    process.out
+    )
+
+##____________________________________________________________________________||

--- a/RecoMET/METProducers/test/recoMET_METSignificance_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_METSignificance_cfg.py
@@ -34,15 +34,7 @@ process.out = cms.OutputModule(
 ##____________________________________________________________________________||
 process.options   = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 process.MessageLogger.cerr.FwkReport.reportEvery = 50
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
-
-##____________________________________________________________________________||
-process.METSignificance.jeta = process.METSignificanceParams.jeta
-process.METSignificance.jpar = process.METSignificanceParams.jpar
-process.METSignificance.pjpar = process.METSignificanceParams.pjpar
-process.METSignificance.jetResAlgo = process.METSignificanceParams.jetResAlgo
-process.METSignificance.jetResEra = process.METSignificanceParams.jetResEra
-process.METSignificance.jetThreshold = process.METSignificanceParams.jetThreshold
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 ##____________________________________________________________________________||
 process.p = cms.Path(

--- a/RecoMET/METProducers/test/recoMET_pfMet_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_pfMet_cfg.py
@@ -15,7 +15,18 @@ process.load("RecoMET/METProducers.METSignificanceObjects_cfi")
 #from RecoMET.METProducers.testInputFiles_cff import recoMETtestInputFiles
 process.source = cms.Source(
     "PoolSource",
-    fileNames = cms.untracked.vstring("/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/CE7E8152-FE59-E411-91D5-0025905A60F2.root")
+    fileNames = cms.untracked.vstring(
+       #"/store/relval/CMSSW_7_3_0_pre1/RelValZpMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/A8782A3D-0A5A-E411-A5FF-0025905AA9F0.root",
+       #"/store/relval/CMSSW_7_3_0_pre1/RelValZpMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/BA64CF78-085A-E411-B4A1-0025905964C2.root"
+       #"/store/relval/CMSSW_7_3_0_pre1/RelValMinBias_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/22256348-FF59-E411-A2AE-0025905A6090.root",
+       #"/store/relval/CMSSW_7_3_0_pre1/RelValMinBias_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/3C4078FF-F359-E411-BB95-0025905A48D8.root",
+       #"/store/relval/CMSSW_7_3_0_pre1/RelValMinBias_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/5097130F-FC59-E411-9613-0025905A60D2.root"
+       #"/store/relval/CMSSW_7_3_0_pre1/RelValZMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/3AC25AA2-075A-E411-A24B-002618FDA265.root",
+       #"/store/relval/CMSSW_7_3_0_pre1/RelValZMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/98214EA1-075A-E411-9F19-0025905A609A.root"
+       #"root://xrootd.unl.edu//store/data/Run2012A/DoubleMu/AOD/22Jan2013-v1/20000/001AE30A-BA81-E211-BBE7-003048FFD770.root"
+       "/store/relval/CMSSW_7_3_0_pre1/RelValZEE_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/C2212C6F-EB59-E411-AB78-0025905B85EE.root",
+       "/store/relval/CMSSW_7_3_0_pre1/RelValZEE_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/F0DAE66D-EB59-E411-95AF-0025905A6088.root"
+       )
     )
 
 ##____________________________________________________________________________||
@@ -32,7 +43,7 @@ process.out = cms.OutputModule(
 ##____________________________________________________________________________||
 process.options   = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 process.MessageLogger.cerr.FwkReport.reportEvery = 50
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
 
 ##____________________________________________________________________________||
 process.pfMetWithSignificance = process.pfMet.clone(

--- a/RecoMET/METProducers/test/recoMET_pfMet_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_pfMet_cfg.py
@@ -8,13 +8,14 @@ process.load("FWCore.MessageLogger.MessageLogger_cfi")
 
 ##____________________________________________________________________________||
 process.load("RecoMET/METProducers.PFMET_cfi")
-process.load("RecoMET/METProducers.METSigParams_cfi")
+process.load("RecoMET/METProducers.METSignificanceParams_cfi")
+process.load("RecoMET/METProducers.METSignificanceObjects_cfi")
 
 ##____________________________________________________________________________||
-from RecoMET.METProducers.testInputFiles_cff import recoMETtestInputFiles
+#from RecoMET.METProducers.testInputFiles_cff import recoMETtestInputFiles
 process.source = cms.Source(
     "PoolSource",
-    fileNames = cms.untracked.vstring(recoMETtestInputFiles)
+    fileNames = cms.untracked.vstring("/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/CE7E8152-FE59-E411-91D5-0025905A60F2.root")
     )
 
 ##____________________________________________________________________________||
@@ -35,13 +36,15 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 ##____________________________________________________________________________||
 process.pfMetWithSignificance = process.pfMet.clone(
-    process.METSignificance_params,
+    process.METSignificanceParams,
     calculateSignificance = cms.bool(True),
-    jets = cms.InputTag("ak5PFJets")
+    jets = cms.InputTag("ak4PFJets"),
+    leptons = cms.VInputTag("selectedElectrons", "selectedMuons", "selectedPhotons")
     )
 
 ##____________________________________________________________________________||
 process.p = cms.Path(
+    process.selectionSequenceForMETSig *
     process.pfMetWithSignificance *
     process.pfMet
     )

--- a/RecoMET/METProducers/test/recoMET_pfMet_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_pfMet_cfg.py
@@ -12,18 +12,9 @@ process.load("RecoMET/METProducers.METSignificanceParams_cfi")
 process.load("RecoMET/METProducers.METSignificanceObjects_cfi")
 
 ##____________________________________________________________________________||
-#from RecoMET.METProducers.testInputFiles_cff import recoMETtestInputFiles
 process.source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
-       #"/store/relval/CMSSW_7_3_0_pre1/RelValZpMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/A8782A3D-0A5A-E411-A5FF-0025905AA9F0.root",
-       #"/store/relval/CMSSW_7_3_0_pre1/RelValZpMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/BA64CF78-085A-E411-B4A1-0025905964C2.root"
-       #"/store/relval/CMSSW_7_3_0_pre1/RelValMinBias_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/22256348-FF59-E411-A2AE-0025905A6090.root",
-       #"/store/relval/CMSSW_7_3_0_pre1/RelValMinBias_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/3C4078FF-F359-E411-BB95-0025905A48D8.root",
-       #"/store/relval/CMSSW_7_3_0_pre1/RelValMinBias_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/5097130F-FC59-E411-9613-0025905A60D2.root"
-       #"/store/relval/CMSSW_7_3_0_pre1/RelValZMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/3AC25AA2-075A-E411-A24B-002618FDA265.root",
-       #"/store/relval/CMSSW_7_3_0_pre1/RelValZMM_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/98214EA1-075A-E411-9F19-0025905A609A.root"
-       #"root://xrootd.unl.edu//store/data/Run2012A/DoubleMu/AOD/22Jan2013-v1/20000/001AE30A-BA81-E211-BBE7-003048FFD770.root"
        "/store/relval/CMSSW_7_3_0_pre1/RelValZEE_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/C2212C6F-EB59-E411-AB78-0025905B85EE.root",
        "/store/relval/CMSSW_7_3_0_pre1/RelValZEE_13/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/F0DAE66D-EB59-E411-95AF-0025905A6088.root"
        )
@@ -43,14 +34,14 @@ process.out = cms.OutputModule(
 ##____________________________________________________________________________||
 process.options   = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 process.MessageLogger.cerr.FwkReport.reportEvery = 50
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 ##____________________________________________________________________________||
 process.pfMetWithSignificance = process.pfMet.clone(
-    process.METSignificanceParams,
     calculateSignificance = cms.bool(True),
-    jets = cms.InputTag("ak4PFJets"),
-    leptons = cms.VInputTag("selectedElectrons", "selectedMuons", "selectedPhotons")
+    srcJets = cms.InputTag("ak4PFJets"),
+    srcLeptons = cms.VInputTag("selectedElectrons", "selectedMuons", "selectedPhotons"),
+    parameters = process.METSignificanceParams
     )
 
 ##____________________________________________________________________________||


### PR DESCRIPTION
This PR adds the new MET significance algorithm developed and validated in JME-13-003 in the CMSSW 74X release.

Packages Involved : 
- RecoMET/METAlgorithms : addition of the new MVA algorithm
- RecoMET/METProducers : definition of a MET significance standalone producer able to work on linear MET algorithm (i.e. all but MVA MET); modification of the PF MET producer in order to compute the new MET covariance matrix instead of the 2010 algorithm one.
  Both producers (standalone and PFMET) works on miniAOD and on RECO.

NB : tuning is still the 8TeV one, will be retuned right before the data taking.

Reco sequence : no change so far, the new MET Significance computation is still disabled for the moment, depending of the RECO/AT limits, the MET would like to make the computation enabled per default, to be discussed in RECO/AT meeting.
Event content : transparent

runthematrix test : passed successfully
