### PR TITLE
Qg small updates

### DIFF
--- a/RecoJets/JetProducers/plugins/QGTagger.cc
+++ b/RecoJets/JetProducers/plugins/QGTagger.cc
@@ -82,7 +82,9 @@ void QGTagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
     float ptD, axis2; int mult;
     std::tie(mult, ptD, axis2) = calcVariables(&*jet, vertexCollection);
 
-    float qgValue = qgLikelihood->computeQGLikelihood(QGLParamsColl, pt, jet->eta(), *rho, {(float) mult, ptD, -std::log(axis2)});
+    float qgValue;
+    if(mult > 2) qgValue = qgLikelihood->computeQGLikelihood(QGLParamsColl, pt, jet->eta(), *rho, {(float) mult, ptD, -std::log(axis2)});
+    else         qgValue = -1;
 
     qgProduct->push_back(qgValue);
     if(produceSyst){

--- a/RecoJets/JetProducers/plugins/QGTagger.cc
+++ b/RecoJets/JetProducers/plugins/QGTagger.cc
@@ -38,9 +38,9 @@ QGTagger::QGTagger(const edm::ParameterSet& iConfig) :
   produceSyst(							systLabel != "")
 {
   produces<edm::ValueMap<float>>("qgLikelihood");
-  produces<edm::ValueMap<float>>("axis2Likelihood");
-  produces<edm::ValueMap<int>>("multLikelihood");
-  produces<edm::ValueMap<float>>("ptDLikelihood");
+  produces<edm::ValueMap<float>>("axis2");
+  produces<edm::ValueMap<int>>("mult");
+  produces<edm::ValueMap<float>>("ptD");
   if(produceSyst){
     produces<edm::ValueMap<float>>("qgLikelihoodSmearedQuark");
     produces<edm::ValueMap<float>>("qgLikelihoodSmearedGluon");
@@ -95,10 +95,10 @@ void QGTagger::produce(edm::Event& iEvent, const edm::EventSetup& iSetup){
     ptDProduct->push_back(ptD);
   }
 
-  putInEvent("qgLikelihood", 	jets, qgProduct,    iEvent);
-  putInEvent("axis2Likelihood", jets, axis2Product, iEvent);
-  putInEvent("multLikelihood", 	jets, multProduct,  iEvent);
-  putInEvent("ptDLikelihood", 	jets, ptDProduct,   iEvent);
+  putInEvent("qgLikelihood", jets, qgProduct,    iEvent);
+  putInEvent("axis2",        jets, axis2Product, iEvent);
+  putInEvent("mult",         jets, multProduct,  iEvent);
+  putInEvent("ptD",          jets, ptDProduct,   iEvent);
   if(produceSyst){
     putInEvent("qgLikelihoodSmearedQuark", jets, smearedQuarkProduct, iEvent);
     putInEvent("qgLikelihoodSmearedGluon", jets, smearedGluonProduct, iEvent);

--- a/RecoJets/JetProducers/python/QGTagger_cfi.py
+++ b/RecoJets/JetProducers/python/QGTagger_cfi.py
@@ -6,29 +6,21 @@ qgDatabaseVersion = 'v1'
 from CondCore.DBCommon.CondDBSetup_cfi import *
 QGPoolDBESSource = cms.ESSource("PoolDBESSource",
       CondDBSetup,
-      toGet = cms.VPSet(
-        cms.PSet(
-            record = cms.string('QGLikelihoodRcd'),
-            tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PFchs'),
-            label  = cms.untracked.string('QGL_AK4PFchs')
-        ),
-        cms.PSet(
-            record = cms.string('QGLikelihoodRcd'),
-            tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_AK4PF'),
-            label  = cms.untracked.string('QGL_AK4PF')
-        ),
-      ),
+      toGet = cms.VPSet(),
       connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),
 )
 
+for type in ['AK4PF','AK4PFchs','AK4PF_antib','AK4PFchs_antib']:
+  QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
+    record = cms.string('QGLikelihoodRcd'),
+    tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
+    label  = cms.untracked.string('QGL_'+type)
+  )))
+
 QGTagger = cms.EDProducer('QGTagger',
+  srcJets		= cms.InputTag('ak4PFJetsCHS'),
+  jetsLabel		= cms.string('QGL_AK4PFchs'),
   srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
   srcVertexCollection	= cms.InputTag('offlinePrimaryVerticesWithBS'),
-  useQualityCuts	= cms.bool(False)
-)
-
-QGTaggerMiniAOD = cms.EDProducer('QGTagger',
-  srcRho 		= cms.InputTag('fixedGridRhoFastjetAll'),		
-  srcVertexCollection	= cms.InputTag(''),
   useQualityCuts	= cms.bool(False)
 )

--- a/RecoJets/JetProducers/test/jettoolbox_cfg.py
+++ b/RecoJets/JetProducers/test/jettoolbox_cfg.py
@@ -92,10 +92,6 @@ process.out.outputCommands += ['keep *_pileupJetIdEvaluator_*_*']
 #QGTagger
 
 process.load('RecoJets.JetProducers.QGTagger_cfi')
-
-process.QGTagger.srcJets = cms.InputTag("ak4PFJetsCHS")
-process.QGTagger.jetsLabel = cms.string('QGL_AK5PFchs')
-
 patJetsAK4.userData.userFloats.src += ['QGTagger:qgLikelihood']
 process.out.outputCommands += ['keep *_QGTagger_*_*']
 


### PR DESCRIPTION
These are a couple of small finalizing updates, following up to two bigger pull requests #7057 and #6931 
- Change the product names of QGTagger.cc from axis2Likelihood, ptDLikelihood and multLikelihood to simply axis2, ptD and mult, because the former could be confusing
- Skip (very rare) jets with 2 or less particles (we need to have at least 3 particles to calculate a non-zero axis2).
- Provide the cfi fragment with default fragments, as was requested. Also "cmsRun jettoolbox_cfg.py" will work perfectly once I have the payloads uploaded to the database.
