### PR TITLE
added missing pixel features from CVS-head

### DIFF
--- a/CalibFormats/SiPixelObjects/interface/PixelAliasList.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelAliasList.h
@@ -9,6 +9,7 @@
 #include "CalibFormats/SiPixelObjects/interface/PixelConfigAlias.h"
 #include "CalibFormats/SiPixelObjects/interface/PixelVersionAlias.h"
 
+#include <stdlib.h>
 
 namespace pos{
 /*! \class PixelAliasList PixelAliasList.h "interface/PixelAliasList.h"

--- a/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibBase.h
@@ -28,7 +28,7 @@ namespace pos{
     PixelCalibBase();
     virtual ~PixelCalibBase();
     virtual std::string mode() const {return mode_;}
-    virtual void writeXMLHeader(  pos::PixelConfigKey key,
+    virtual void writeXMLHeader(  pos::PixelConfigKey &key, 
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,

--- a/CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelCalibConfiguration.h
@@ -174,7 +174,7 @@ namespace pos{
 
     virtual void writeASCII(std::string dir="") const;
     void 	 writeXML(        pos::PixelConfigKey key, int version, std::string path) const {;}
-    virtual void writeXMLHeader(  pos::PixelConfigKey key,
+    virtual void writeXMLHeader(  pos::PixelConfigKey key, 
 				  int version, 
 				  std::string path, 
 				  std::ofstream *out,

--- a/CalibFormats/SiPixelObjects/interface/PixelConfigBase.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelConfigBase.h
@@ -66,7 +66,7 @@ namespace pos{
 				  std::ofstream *out2)  const {;}
     virtual void writeXML(      pos::PixelConfigKey key, int version, std::string path)                     const {;}
     virtual void writeXMLHeader(pos::PixelConfigKey key, int version, std::string path, std::ofstream *out) const {;}
-    virtual void writeXML(                                                              std::ofstream *out) const {;}
+    virtual void writeXML(                                                              std::ofstream *out) const {std::cout << __LINE__ << " " << __PRETTY_FUNCTION__ << "\tUnimplemented method" << std::endl ;;}
     virtual void writeXMLTrailer(                                                       std::ofstream *out) const {;}
 
     void setAuthor (std::string author)  {creator_ = author ;} 

--- a/CalibFormats/SiPixelObjects/interface/PixelConfigFile.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelConfigFile.h
@@ -271,13 +271,13 @@ namespace pos{
       assert(theKey<=getConfig().size());
     
       unsigned int last=path.find_last_of("/");
-      assert(last!=std::string::npos);
+      assert(last!=(unsigned int)std::string::npos);
     
       std::string base=path.substr(0,last);
       std::string ext=path.substr(last+1);
     
       unsigned int slashpos=base.find_last_of("/");
-      if (slashpos==std::string::npos) {
+      if (slashpos==(unsigned int)std::string::npos) {
 	std::cout << "[pos::PixelConfigFile::getPath()]\t\t\tOn path:"                <<path               <<std::endl;
 	std::cout << "[pos::PixelConfigFile::getPath()]\t\t\tRecall that you need a trailing /"            <<std::endl;
 	::abort();
@@ -324,13 +324,13 @@ namespace pos{
       assert(theKey<=configList().size());
     
       unsigned int last=path.find_last_of("/");
-      assert(last!=std::string::npos);
+      assert(last!=(unsigned int)std::string::npos);
     
       std::string base=path.substr(0,last);
       std::string ext=path.substr(last+1);
     
       unsigned int slashpos=base.find_last_of("/");
-      if (slashpos==std::string::npos) {
+      if (slashpos==(unsigned int)std::string::npos) {
 	std::cout << "[pos::PixelConfigFile::get()]\t\t\tAsking for data of type:"<<typeid(data).name()<<std::endl;
 	std::cout << "[pos::PixelConfigFile::get()]\t\t\tOn path:"                <<path               <<std::endl;
 	std::cout << "[pos::PixelConfigFile::get()]\t\t\tRecall that you need a trailing /"            <<std::endl;
@@ -343,7 +343,7 @@ namespace pos{
 //      std::cout << "[pos::PixelConfigFile::get()]\t\t\tExtracted base:"<<base<<std::endl;
 //      std::cout << "[pos::PixelConfigFile::get()]\t\t\tExtracted ext :"<<ext <<std::endl;
     
-      unsigned int version;
+      unsigned int version=0;
       int err=configList()[theKey].find(dir,version);   
       // assert(err==0);
       if(0!=err) 
@@ -508,13 +508,13 @@ namespace pos{
       
     
       unsigned int last=path.find_last_of("/");
-      assert(last!=std::string::npos);
+      assert(last!=(unsigned int)std::string::npos);
     
       std::string base=path.substr(0,last);
       std::string ext=path.substr(last+1);
     
       unsigned int slashpos=base.find_last_of("/");
-      if (slashpos==std::string::npos) {
+      if (slashpos==(unsigned int)std::string::npos) {
 	std::cout << __LINE__ << mthn << "Asking for data of type:"          << typeid(data).name() <<std::endl;
 	std::cout << __LINE__ << mthn << "On path:" 	                 << path		<<std::endl;
 	std::cout << __LINE__ << mthn << "Recall that you need a trailing /"	                <<std::endl;
@@ -527,7 +527,7 @@ namespace pos{
 //      std::cout << __LINE__ << mthn << "Extracted base:" << base <<std::endl;
 //      std::cout << __LINE__ << mthn << "Extracted ext :" << ext  <<std::endl;
     
-      unsigned int version;
+      unsigned int version=0;
       int err=configList()[theKey].find(dir,version);   
       // assert(err==0);
       if(0!=err) 
@@ -652,7 +652,7 @@ namespace pos{
       std::string mthn = "]\t[pos::PixelConfigFile::get()]\t\t\t\t    " ;
 
       unsigned int last=path.find_last_of("/");
-      assert(last!=std::string::npos);
+      assert(last!=(unsigned int)std::string::npos);
     
       std::string base=path.substr(0,last);
       std::string ext=path.substr(last+1);
@@ -880,7 +880,7 @@ namespace pos{
       static bool forceConfigReload = false; 
       return forceConfigReload;
     }
-  
+    
  };
 
 }

--- a/CalibFormats/SiPixelObjects/interface/PixelConfigList.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelConfigList.h
@@ -6,6 +6,8 @@
 *   A longer explanation will be placed here later
 */
 
+#include <stdlib.h>
+
 namespace pos{
 /*! \class PixelConfigList PixelConfigList.h "interface/PixelConfigList.h"
 *   \brief This class implements..

--- a/CalibFormats/SiPixelObjects/interface/PixelDelay25Calib.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelDelay25Calib.h
@@ -63,6 +63,9 @@ namespace pos{
     void writeFiles(int currentSDa, int currentRDa, int number);
     void closeFiles();
 
+    // Added by Dario April 28th, 2010
+    std::string getStreamedContent(void) const {return calibFileContent_;} ;
+
   private:
 
     std::set<std::string> portcardNames_;
@@ -71,6 +74,8 @@ namespace pos{
     std::ofstream graphout_;
     std::string graph_;
 
+    // Added by Dario April 28th, 2010
+    std::string calibFileContent_ ;
   };
 }
 /* @} */

--- a/CalibFormats/SiPixelObjects/interface/PixelFEDCard.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelFEDCard.h
@@ -11,6 +11,7 @@
 
 #include <vector>
 #include <string>
+#include <stdint.h>
 
 namespace pos{
 /*!  \ingroup ConfigurationObjects "Configuration Objects"
@@ -64,7 +65,7 @@ namespace pos{
     virtual void writeXMLTrailer(std::ofstream *fedstream,
 				 std::ofstream *recostream,
 				 std::ofstream *tbmstream) const ;
-    unsigned long long enabledChannels();  // returns 64-bit integer mask 35..0
+    uint64_t enabledChannels();  // returns 64-bit integer mask 35..0
 
 
     //Settable optical input parameters (one for each 12-receiver)
@@ -154,6 +155,26 @@ namespace pos{
     //VME base address 
     unsigned long FEDBASE_0, fedNumber;
 
+    // Most recent additions requested by Will and Danek (Dario)
+    int BusyHoldMin       ;
+    int BusyWhenBehind    ;
+    int FeatureRegister   ;
+    int FIFO2Limit    	  ;
+    int LastDacOff    	  ;
+    int SimHitsPerRoc 	  ;
+    int TimeoutOROOSLimit ;
+    int TriggerHoldoff    ;
+    int SPARE1  	  ;
+    int SPARE2  	  ;
+    int SPARE3  	  ;
+    int SPARE4  	  ;
+    int SPARE5  	  ;
+    int SPARE6  	  ;
+    int SPARE7  	  ;
+    int SPARE8  	  ;
+    int SPARE9  	  ;
+    int SPARE10 	  ;
+    
  private: 
  
     // Added by Dario (March 26th 2008)

--- a/CalibFormats/SiPixelObjects/interface/PixelROCDACSettings.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelROCDACSettings.h
@@ -29,6 +29,7 @@ namespace pos{
   public:
 
     PixelROCDACSettings();
+    virtual ~PixelROCDACSettings(){;};
 
     PixelROCDACSettings(const PixelROCName& rocid){rocid_= rocid;}
 

--- a/CalibFormats/SiPixelObjects/interface/PixelTBMSettings.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTBMSettings.h
@@ -38,7 +38,7 @@ namespace pos{
     //Generate the DAC settings
     void generateConfiguration(PixelFECConfigInterface* pixelFEC,
 	                       PixelNameTranslation* trans,
-			       bool physics=false) const; 
+			       bool physics=false, bool doResets=true) const; 
 
     void writeBinary(std::string filename) const;
 

--- a/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTimeFormatter.h
@@ -43,6 +43,13 @@ namespace pos{
      double stop  = endTime_.tv_sec   + endTime_.tv_usec/1000000. ;  
      std::cout << "[PixelTimeFormatter::stopTimer()]\t\t\t    Elapsed time: " << stop-start << " seconds for " << origin_ << std::endl ;
     }
+    
+    virtual void writeXMLHeader(pos::PixelConfigKey key,
+                                int version, std::string path,
+                                std::ofstream *out,
+                                std::ofstream *out1 = NULL,
+                                std::ofstream *out2 = NULL
+                                ) const {;}
 
     //---------------------------------------------------------------------------------
     static std::string getTime(void) 

--- a/CalibFormats/SiPixelObjects/interface/PixelTrimCommon.h
+++ b/CalibFormats/SiPixelObjects/interface/PixelTrimCommon.h
@@ -44,12 +44,7 @@ namespace pos{
 
     void         writeASCII(std::string filename)                                                           const  ;
     void         writeXML(      pos::PixelConfigKey key, int version, std::string path)                     const {;}
-    virtual void writeXMLHeader(pos::PixelConfigKey key,
-                                int version, std::string path,
-                                std::ofstream *out,
-                                std::ofstream *out1 = NULL,
-                                std::ofstream *out2 = NULL
-                                ) const {;}
+    virtual void writeXMLHeader(pos::PixelConfigKey key, int version, std::string path, std::ofstream *out) const {;}
     virtual void writeXML(                                                              std::ofstream *out) const {;}
     virtual void writeXMLTrailer(                                                       std::ofstream *out) const {;}
 

--- a/CalibFormats/SiPixelObjects/src/PixelBase64.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelBase64.cc
@@ -2,7 +2,7 @@
    base64.cpp and base64.h
 
    Copyright (C) 2004-2008 René Nyffenegger
- 
+
    This source code is provided 'as-is', without any express or implied
    warranty. In no event will the author be held liable for any damages
    arising from the use of this software.

--- a/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelCalibConfiguration.cc
@@ -81,7 +81,7 @@ PixelCalibConfiguration::PixelCalibConfiguration(std::vector< std::vector<std::s
   
   if (tmp=="Mode:"){
     in >> mode_;
-    std::cout << __LINE__ << "]\t" << mthn << "mode=" << mode_ << std::endl;
+//    std::cout << __LINE__ << "]\t" << mthn << "mode=" << mode_ << std::endl;
     in >>tmp;
   } else {
     mode_="FEDChannelOffsetPixel";
@@ -1673,7 +1673,7 @@ bool PixelCalibConfiguration::containsScan(std::string name) const
 }
 
 //=============================================================================================
-void PixelCalibConfiguration::writeXMLHeader(pos::PixelConfigKey key,
+void PixelCalibConfiguration::writeXMLHeader(pos::PixelConfigKey key, 
                                     	     int version, 
                                     	     std::string path, 
                                     	     std::ofstream *outstream,

--- a/CalibFormats/SiPixelObjects/src/PixelDelay25Calib.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelDelay25Calib.cc
@@ -22,7 +22,6 @@ PixelDelay25Calib::PixelDelay25Calib(vector< vector<string> > &tableMat) :
   PixelConfigBase("","","")
 {
   std::string mthn = "[PixelDelay25Calib::PixelDelay25Calib()]\t\t\t    " ;
-  std::cout << __LINE__ << "]\t" << mthn << std::endl;
   std::map<std::string , int > colM;
   std::vector<std::string > colNames;
   /**
@@ -47,7 +46,7 @@ PixelDelay25Calib::PixelDelay25Calib(vector< vector<string> > &tableMat) :
   colNames.push_back("CALIB_TYPE"  	  );
   colNames.push_back("CALIB_OBJ_DATA_FILE");
   colNames.push_back("CALIB_OBJ_DATA_CLOB");
-  
+ 
   for(unsigned int c = 0 ; c < tableMat[0].size() ; c++)
     {
       for(unsigned int n=0; n<colNames.size(); n++)
@@ -134,6 +133,12 @@ PixelDelay25Calib::PixelDelay25Calib(vector< vector<string> > &tableMat) :
 
   //Number of steps in the grid
   gridSteps_ = range_/gridSize_;
+
+  // Added by Dario as a temporary patch for Debbie (this will disappear in the future)
+  calibFileContent_ = in.str() ;
+  //cout << __LINE__ << "] " << __PRETTY_FUNCTION__ << "\tcalibFileContent_\n " << calibFileContent_ << endl ;  
+  // End of temporary patch
+  
 }
 
 
@@ -220,6 +225,18 @@ PixelDelay25Calib::PixelDelay25Calib(std::string filename) :
   //Number of steps in the grid
   gridSteps_ = range_/gridSize_;
 
+  // Added by Dario as a temporary patch for Debbie (this will disappear in the future)
+  std::ifstream inTmp(filename.c_str());
+  calibFileContent_ = "" ;
+  while(!inTmp.eof())
+  {
+   std::string tmpString ;
+   getline (inTmp, tmpString);
+   calibFileContent_ += tmpString + "\n";
+   //cout << __LINE__ << "]\t" << "[PixelCalibConfiguration::~PixelCalibConfiguration()]\t\t" << calibFileContent_ << endl ;
+  }
+  inTmp.close() ;
+  // End of temporary patch
 }
 
 PixelDelay25Calib::~PixelDelay25Calib() {
@@ -362,6 +379,7 @@ void PixelDelay25Calib::writeXML( std::ofstream *outstream,
 {
   std::string mthn = "[PixelDelay25Calib::writeXML()]\t\t\t    " ;
   
+  std::cout  << __LINE__ << "]\t" << mthn << "Writing.." << std::endl ;
 
   *outstream << " "                                                                                       << std::endl ;
   *outstream << "  <DATA>"                                                                                << std::endl ;

--- a/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelFEDCard.cc
@@ -34,163 +34,203 @@ PixelFEDCard::PixelFEDCard(vector<vector<string> > &tableMat):PixelConfigBase(" 
   /**
     EXTENSION_TABLE_NAME: FED_CONFIGURATION (VIEW: CONF_KEY_FED_CONFIGURATION_V)
     
-    Name                                        Null?    Type               POS variable
-    ----------------------------------------- -------- ---------------------------------------------------------------
+    Name                       Null?	Type		   POS variable
+    ------------------------ -------- ---------------------------------------------------------------
 
-    CONFIG_KEY  			      NOT NULL VARCHAR2(80)
-    KEY_TYPE				      NOT NULL VARCHAR2(80)
-    KEY_ALIAS				      NOT NULL VARCHAR2(80)
-    VERSION					       VARCHAR2(40)
-    KIND_OF_COND			      NOT NULL VARCHAR2(40)
-    CRATE_LABEL 				       VARCHAR2(200)
-    CRATE_NUMBER				       NUMBER(38)	     
-    SLOT_NUMBER 				       NUMBER(38)
-    VME_ADDRS_HEX			      NOT NULL VARCHAR2(200)
-    PIXEL_FED				      NOT NULL NUMBER(38)	     fedNumber
-    CHANNEL_ID  			      NOT NULL NUMBER(38)
-    NUM_ROCS				      NOT NULL NUMBER(38)	     NRocs[1-36]    index taken from CHANNEL_ID 
-    CHAN_OFFST_DAC			      NOT NULL NUMBER(38)	     offs_dac[1-36] index taken from CHANNEL_ID 
-    CHAN_DELAY  			      NOT NULL NUMBER(38)	     DelayCh[1-36]  index taken from CHANNEL_ID 
-    CHAN_BHIGH  			      NOT NULL NUMBER(38)	     BlackHi[1-36]  index taken from CHANNEL_ID 
-    CHAN_BLOW				      NOT NULL NUMBER(38)	     BlackLo[1-36]  index taken from CHANNEL_ID 
-    CHAN_UB				      NOT NULL NUMBER(38)	     Ublack[1-36]   index taken from CHANNEL_ID 
-    OPT1_CAP				      NOT NULL NUMBER(38)	     opt_cap[0] 				
-    OPT2_CAP				      NOT NULL NUMBER(38)	     opt_cap[1] 				
-    OPT3_CAP				      NOT NULL NUMBER(38)	     opt_cap[2] 				
-    OPT1_INP				      NOT NULL NUMBER(38)	     opt_inadj[0]				
-    OPT2_INP				      NOT NULL NUMBER(38)	     opt_inadj[1]				
-    OPT3_INP				      NOT NULL NUMBER(38)	     opt_inadj[2]				
-    OPT1_OUT				      NOT NULL NUMBER(38)	     opt_ouadj[0]			       
-    OPT2_OUT				      NOT NULL NUMBER(38)	     opt_ouadj[1]			       
-    OPT3_OUT				      NOT NULL NUMBER(38)	     opt_ouadj[2]			       
-    NORTH_CLKPHB			      NOT NULL NUMBER(38)	     clkphs1_9  				
-    NORTHCENTER_CLKPHB  		      NOT NULL NUMBER(38)	     clkphs10_18				
-    SOUTHCENTER_CLKPHB  		      NOT NULL NUMBER(38)	     clkphs19_27				
-    SOUTH_CLKPHB			      NOT NULL NUMBER(38)	     clkphs28_36				
-    NORTH_CTRL  			      NOT NULL NUMBER(38)	     Ncntrl					
-    NORTHCENTER_CTRL			      NOT NULL NUMBER(38)	     NCcntrl					
-    SOUTHCENTER_CTRL			      NOT NULL NUMBER(38)	     SCcntrl					
-    SOUTH_CTRL  			      NOT NULL NUMBER(38)	     Scntrl					
-    REG1_TTCRX_FDLA			      NOT NULL NUMBER(38)	     FineDes2Del				
-    REG2_TTCRX_CDLA			      NOT NULL NUMBER(38)	     CoarseDel  				
-    REG3_TTCRX_CLKD2			      NOT NULL NUMBER(38)	     ClkDes2					
-    CENTER_CTRL 			      NOT NULL NUMBER(38)	     Ccntrl					
-    CENTER_MODE 			      NOT NULL NUMBER(38)	     modeRegister				
-    B1_ADCGN				      NOT NULL NUMBER(38)	     Nadcg					
-    B2_ADCGN				      NOT NULL NUMBER(38)	     NCadcg					
-    B3_ADCGN				      NOT NULL NUMBER(38)	     SCadcg					
-    B4_ADCGN				      NOT NULL NUMBER(38)	     Sadcg					
-    NORTH_BADJ  			      NOT NULL NUMBER(38)	     Nbaseln					
-    NORTHCENTER_BADJ			      NOT NULL NUMBER(38)	     NCbaseln					
-    SOUTHCENTER_BADJ			      NOT NULL NUMBER(38)	     SCbaseln					
-    SOUTH_BADJ  			      NOT NULL NUMBER(38)	     Sbaseln					
-    NORTH_TBMMASK			      NOT NULL NUMBER(38)	     N_TBMmask  				
-    NORTHCENTER_TBMMASK 		      NOT NULL NUMBER(38)	     NC_TBMmask 				
-    SOUTHCENTER_TBMMASK 		      NOT NULL NUMBER(38)	     SC_TBMmask 				
-    SOUTH_TBMMASK			      NOT NULL NUMBER(38)	     S_TBMmask  				
-    NORTH_PWORD 			      NOT NULL NUMBER(38)	     N_Pword					
-    NORTHCENTER_PWORD			      NOT NULL NUMBER(38)	     NC_Pword					
-    SOUTH_PWORD 			      NOT NULL NUMBER(38)	     S_Pword					
-    SOUTHCENTER_PWORD			      NOT NULL NUMBER(38)	     SC_Pword					
-    SPECDAC				      NOT NULL NUMBER(38)	     SpecialDac 				
-    OOS_LVL				      NOT NULL NUMBER(38)	     Ooslvl					
-    ERR_LVL				      NOT NULL NUMBER(38)	     Errlvl					
-    NORTH_FIFO1_BZ_LVL  		      NOT NULL NUMBER(38)	     Nfifo1Bzlvl				
-    NORTHCENTER_FIFO1_BZ_LVL		      NOT NULL NUMBER(38)	     NCfifo1Bzlvl				
-    SOUTHCENTER_FIFO1_BZ_LVL		      NOT NULL NUMBER(38)	     SCfifo1Bzlvl				
-    SOUTH_FIFO1_BZ_LVL  		      NOT NULL NUMBER(38)	     Sfifo1Bzlvl				
-    FIFO3_WRN_LVL				       NUMBER(38)            fifo3Wrnlvl
-    FED_MASTER_DELAY				       NUMBER(38)            FedTTCDelay
-    NO_HITLIMIT 			               NUMBER(38)	     N_hitlimit 
-    NC_HITLIMIT 			               NUMBER(38)	     NC_hitlimit
-    SC_HITLIMIT 			               NUMBER(38)	     SC_hitlimit
-    SO_HITLIMIT 			               NUMBER(38)	     S_hitlimit 
-    NO_TESTREG				               NUMBER(38)	     N_testreg  
-    NC_TESTREG				               NUMBER(38)	     NC_testreg 
-    SC_TESTREG				               NUMBER(38)	     SC_testreg 
-    SO_TESTREG				               NUMBER(38)	     S_testreg  
-  */
-  colNames.push_back("CONFIG_KEY" 	       );
-  colNames.push_back("KEY_TYPE"   	       );
-  colNames.push_back("KEY_ALIAS"  	       );
-  colNames.push_back("VERSION"    	       );
-  colNames.push_back("KIND_OF_COND"	       );
-  colNames.push_back("CRATE_LABEL"	       );
-  colNames.push_back("CRATE_NUMBER"	       );
-  colNames.push_back("SLOT_NUMBER"	       );
-  colNames.push_back("VME_ADDRS_HEX"	       );
-  colNames.push_back("PIXEL_FED"  	       );
-  colNames.push_back("CHANNEL_ID" 	       );
-  colNames.push_back("NUM_ROCS"   	       );
-  colNames.push_back("CHAN_OFFST_DAC"	       );
-  colNames.push_back("CHAN_DELAY" 	       );
-  colNames.push_back("CHAN_BHIGH" 	       );
-  colNames.push_back("CHAN_BLOW"  	       );
-  colNames.push_back("CHAN_UB"    	       );
-  colNames.push_back("OPT1_CAP"   	       );
-  colNames.push_back("OPT2_CAP"   	       );
-  colNames.push_back("OPT3_CAP"   	       );
-  colNames.push_back("OPT1_INP"   	       );
-  colNames.push_back("OPT2_INP"   	       );
-  colNames.push_back("OPT3_INP"   	       );
-  colNames.push_back("OPT1_OUT"   	       );
-  colNames.push_back("OPT2_OUT"   	       );
-  colNames.push_back("OPT3_OUT"   	       );
-  colNames.push_back("NORTH_CLKPHB"	       );
-  colNames.push_back("NORTHCENTER_CLKPHB"      );
-  colNames.push_back("SOUTHCENTER_CLKPHB"      );
-  colNames.push_back("SOUTH_CLKPHB"	       );
-  colNames.push_back("NORTH_CTRL"	       );
-  colNames.push_back("NORTHCENTER_CTRL"        );
-  colNames.push_back("SOUTHCENTER_CTRL"        );
-  colNames.push_back("SOUTH_CTRL"	       );
-  colNames.push_back("REG0_TTCRX_FDLA"         );
-  colNames.push_back("REG1_TTCRX_FDLA"         );
-  colNames.push_back("REG2_TTCRX_CDLA"         );
-  colNames.push_back("REG3_TTCRX_CLKD2"        );
-  colNames.push_back("CENTER_CTRL"	       );
-  colNames.push_back("CENTER_MODE"	       );
-  colNames.push_back("B1_ADCGN"   	       );
-  colNames.push_back("B2_ADCGN"   	       );
-  colNames.push_back("B3_ADCGN"   	       );
-  colNames.push_back("B4_ADCGN"   	       );
-  colNames.push_back("NORTH_BADJ" 	       );
-  colNames.push_back("NORTHCENTER_BADJ"        );
-  colNames.push_back("SOUTHCENTER_BADJ"        );
-  colNames.push_back("SOUTH_BADJ"	       );
-  colNames.push_back("NORTH_TBMMASK"	       );
-  colNames.push_back("NORTHCENTER_TBMMASK"     );
-  colNames.push_back("SOUTHCENTER_TBMMASK"     );
-  colNames.push_back("SOUTH_TBMMASK"	       );
-  colNames.push_back("NORTH_PWORD"	       );
-  colNames.push_back("NORTHCENTER_PWORD"       );
-  colNames.push_back("SOUTH_PWORD"	       );
-  colNames.push_back("SOUTHCENTER_PWORD"       );
-  colNames.push_back("SPECDAC"    	       );
-  colNames.push_back("OOS_LVL"    	       );
-  colNames.push_back("ERR_LVL"    	       );
-  colNames.push_back("NORTH_FIFO1_BZ_LVL"      );
-  colNames.push_back("NORTHCENTER_FIFO1_BZ_LVL");
-  colNames.push_back("SOUTHCENTER_FIFO1_BZ_LVL");
-  colNames.push_back("SOUTH_FIFO1_BZ_LVL"      );
-  colNames.push_back("FIFO3_WRN_LVL"	       );
-  colNames.push_back("FED_MASTER_DELAY"        );
-  colNames.push_back("NO_HITLIMIT"	       );
-  colNames.push_back("NC_HITLIMIT"	       );
-  colNames.push_back("SC_HITLIMIT"	       );
-  colNames.push_back("SO_HITLIMIT"	       );
-  colNames.push_back("NO_TESTREG"	       );
-  colNames.push_back("NC_TESTREG"	       );
-  colNames.push_back("SC_TESTREG"	       );
-  colNames.push_back("SO_TESTREG"	       );
-
-  for(unsigned int c = 0 ; c < ins.size() ; c++)
-    {
+    BUSYWHENBEHIND      	       NUMBER(38)
+    FEATUREREGISTER     	       VARCHAR2(200)
+    FIFO2LIMIT	        	       VARCHAR2(200)
+    TIMEOUTOROOSLIMIT   	       NUMBER(38)
+    LASTDACOFF	        	       NUMBER(38)
+    SIMHITSPERROC       	       NUMBER(38)
+    BUSYHOLDMIN         	       NUMBER(38)
+    SPARE1	        	       NUMBER(38)
+    SPARE2	        	       NUMBER(38)
+    SPARE3	        	       NUMBER(38)
+    SPARE4	        	       NUMBER(38)
+    SPARE5	        	       NUMBER(38)
+    SPARE6	        	       NUMBER(38)
+    SPARE7	        	       NUMBER(38)
+    SPARE8	        	       NUMBER(38)
+    SPARE9	        	       NUMBER(38)
+    SPARE10                            NUMBER(38)
+    CONFIG_KEY  	      NOT NULL VARCHAR2(80)
+    KEY_TYPE		      NOT NULL VARCHAR2(80)
+    KEY_ALIAS_ID	   
+    KEY_ALIAS		      NOT NULL VARCHAR2(80)
+    VERSION		               VARCHAR2(40)
+    KIND_OF_COND	      NOT NULL VARCHAR2(40)
+    CRATE_LABEL 	               VARCHAR2(200)
+    CRATE_NUMBER	               NUMBER(38)	     
+    SLOT_NUMBER 	               NUMBER(38)
+    VME_ADDRS_HEX	      NOT NULL VARCHAR2(200)         FEDBASE_0
+    PIXEL_FED		      NOT NULL NUMBER(38)	     fedNumber
+    CHANNEL_ID  	      NOT NULL NUMBER(38)
+    NUM_ROCS		      NOT NULL NUMBER(38)	     NRocs[1-36]    index taken from CHANNEL_ID 
+    CHAN_OFFST_DAC	      NOT NULL NUMBER(38)	     offs_dac[1-36] index taken from CHANNEL_ID 
+    CHAN_DELAY  	      NOT NULL NUMBER(38)	     DelayCh[1-36]  index taken from CHANNEL_ID 
+    CHAN_BHIGH  	      NOT NULL NUMBER(38)	     BlackHi[1-36]  index taken from CHANNEL_ID 
+    CHAN_BLOW		      NOT NULL NUMBER(38)	     BlackLo[1-36]  index taken from CHANNEL_ID 
+    CHAN_UB		      NOT NULL NUMBER(38)	     Ublack[1-36]   index taken from CHANNEL_ID 
+    OPT1_CAP		      NOT NULL NUMBER(38)	     opt_cap[0] 				
+    OPT2_CAP		      NOT NULL NUMBER(38)	     opt_cap[1] 				
+    OPT3_CAP		      NOT NULL NUMBER(38)	     opt_cap[2] 				
+    OPT1_INP		      NOT NULL NUMBER(38)	     opt_inadj[0]				
+    OPT2_INP		      NOT NULL NUMBER(38)	     opt_inadj[1]				
+    OPT3_INP		      NOT NULL NUMBER(38)	     opt_inadj[2]				
+    OPT1_OUT		      NOT NULL NUMBER(38)	     opt_ouadj[0]			       
+    OPT2_OUT		      NOT NULL NUMBER(38)	     opt_ouadj[1]			       
+    OPT3_OUT		      NOT NULL NUMBER(38)	     opt_ouadj[2]			       
+    NORTH_CLKPHB	      NOT NULL NUMBER(38)	     clkphs1_9  				
+    NORTHCENTER_CLKPHB        NOT NULL NUMBER(38)	     clkphs10_18				
+    SOUTHCENTER_CLKPHB        NOT NULL NUMBER(38)	     clkphs19_27				
+    SOUTH_CLKPHB	      NOT NULL NUMBER(38)	     clkphs28_36				
+    NORTH_CTRL  	      NOT NULL NUMBER(38)	     Ncntrl					
+    NORTHCENTER_CTRL	      NOT NULL NUMBER(38)	     NCcntrl					
+    SOUTHCENTER_CTRL	      NOT NULL NUMBER(38)	     SCcntrl					
+    SOUTH_CTRL  	      NOT NULL NUMBER(38)	     Scntrl					
+    REG0_TTCRX_FDLA	                                     FineDes1Del
+    REG1_TTCRX_FDLA	      NOT NULL NUMBER(38)	     FineDes2Del				
+    REG2_TTCRX_CDLA	      NOT NULL NUMBER(38)	     CoarseDel  				
+    REG3_TTCRX_CLKD2	      NOT NULL NUMBER(38)	     ClkDes2					
+    CENTER_CTRL 	      NOT NULL NUMBER(38)	     Ccntrl					
+    CENTER_MODE 	      NOT NULL NUMBER(38)	     modeRegister				
+    B1_ADCGN		      NOT NULL NUMBER(38)	     Nadcg					
+    B2_ADCGN		      NOT NULL NUMBER(38)	     NCadcg					
+    B3_ADCGN		      NOT NULL NUMBER(38)	     SCadcg					
+    B4_ADCGN		      NOT NULL NUMBER(38)	     Sadcg					
+    NORTH_BADJ  	      NOT NULL NUMBER(38)	     Nbaseln					
+    NORTHCENTER_BADJ	      NOT NULL NUMBER(38)	     NCbaseln					
+    SOUTHCENTER_BADJ	      NOT NULL NUMBER(38)	     SCbaseln					
+    SOUTH_BADJ  	      NOT NULL NUMBER(38)	     Sbaseln					
+    NORTH_TBMMASK	      NOT NULL NUMBER(38)	     N_TBMmask  				
+    NORTHCENTER_TBMMASK       NOT NULL NUMBER(38)	     NC_TBMmask 				
+    SOUTHCENTER_TBMMASK       NOT NULL NUMBER(38)	     SC_TBMmask 				
+    SOUTH_TBMMASK	      NOT NULL NUMBER(38)	     S_TBMmask  				
+    NORTH_PWORD 	      NOT NULL NUMBER(38)	     N_Pword					
+    NORTHCENTER_PWORD	      NOT NULL NUMBER(38)	     NC_Pword					
+    SOUTH_PWORD 	      NOT NULL NUMBER(38)	     S_Pword					
+    SOUTHCENTER_PWORD	      NOT NULL NUMBER(38)	     SC_Pword					
+    SPECDAC		      NOT NULL NUMBER(38)	     SpecialDac 				
+    OOS_LVL		      NOT NULL NUMBER(38)	     Ooslvl					
+    ERR_LVL		      NOT NULL NUMBER(38)	     Errlvl					
+    NORTH_FIFO1_BZ_LVL        NOT NULL NUMBER(38)	     Nfifo1Bzlvl				
+    NORTHCENTER_FIFO1_BZ_LVL  NOT NULL NUMBER(38)	     NCfifo1Bzlvl				
+    SOUTHCENTER_FIFO1_BZ_LVL  NOT NULL NUMBER(38)	     SCfifo1Bzlvl				
+    SOUTH_FIFO1_BZ_LVL        NOT NULL NUMBER(38)	     Sfifo1Bzlvl				
+    FIFO3_WRN_LVL		       NUMBER(38)	     fifo3Wrnlvl
+    FED_MASTER_DELAY		       NUMBER(38)	     FedTTCDelay
+    NO_HITLIMIT 		       NUMBER(38)	     N_hitlimit 
+    NC_HITLIMIT 		       NUMBER(38)	     NC_hitlimit
+    SC_HITLIMIT 		       NUMBER(38)	     SC_hitlimit
+    SO_HITLIMIT 		       NUMBER(38)	     S_hitlimit 
+    NO_TESTREG  		       NUMBER(38)	     N_testreg  
+    NC_TESTREG  		       NUMBER(38)	     NC_testreg 
+    SC_TESTREG  		       NUMBER(38)	     SC_testreg 
+    SO_TESTREG  		       NUMBER(38)	     S_testreg  
+    TRIGGERHOLDOFF 
+				 
+*/	 
+  colNames.push_back("BUSYWHENBEHIND"          ); 
+  colNames.push_back("FEATUREREGISTER"         ); 
+  colNames.push_back("FIFO2LIMIT"              ); 
+  colNames.push_back("TIMEOUTOROOSLIMIT"       ); 
+  colNames.push_back("LASTDACOFF"              ); 
+  colNames.push_back("SIMHITSPERROC"           ); 
+  colNames.push_back("BUSYHOLDMIN"             ); 
+  colNames.push_back("SPARE1"	               ); 
+  colNames.push_back("SPARE2"	               ); 
+  colNames.push_back("SPARE3"	               ); 
+  colNames.push_back("SPARE4"	               ); 
+  colNames.push_back("SPARE5"	               ); 
+  colNames.push_back("SPARE6"	               ); 
+  colNames.push_back("SPARE7"	               ); 
+  colNames.push_back("SPARE8"	               ); 
+  colNames.push_back("SPARE9"	               ); 
+  colNames.push_back("SPARE10"	               ); 
+  colNames.push_back("CONFIG_KEY" 	       ); 
+  colNames.push_back("KEY_TYPE"   	       ); 
+  colNames.push_back("KEY_ALIAS_ID"            ); 
+  colNames.push_back("KEY_ALIAS"  	       ); 
+  colNames.push_back("VERSION"    	       ); 
+  colNames.push_back("KIND_OF_COND"	       ); 
+  colNames.push_back("CRATE_LABEL"	       ); 
+  colNames.push_back("CRATE_NUMBER"	       ); 
+  colNames.push_back("SLOT_NUMBER"	       ); 
+  colNames.push_back("VME_ADDRS_HEX"	       ); 
+  colNames.push_back("PIXEL_FED"  	       ); 
+  colNames.push_back("CHANNEL_ID" 	       ); 
+  colNames.push_back("NUM_ROCS"   	       ); 
+  colNames.push_back("CHAN_OFFST_DAC"	       ); 
+  colNames.push_back("CHAN_DELAY" 	       ); 
+  colNames.push_back("CHAN_BHIGH" 	       ); 
+  colNames.push_back("CHAN_BLOW"  	       ); 
+  colNames.push_back("CHAN_UB"    	       ); 
+  colNames.push_back("OPT1_CAP"   	       ); 
+  colNames.push_back("OPT2_CAP"   	       ); 
+  colNames.push_back("OPT3_CAP"   	       ); 
+  colNames.push_back("OPT1_INP"   	       ); 
+  colNames.push_back("OPT2_INP"   	       ); 
+  colNames.push_back("OPT3_INP"   	       ); 
+  colNames.push_back("OPT1_OUT"   	       ); 
+  colNames.push_back("OPT2_OUT"   	       ); 
+  colNames.push_back("OPT3_OUT"   	       ); 
+  colNames.push_back("NORTH_CLKPHB"	       ); 
+  colNames.push_back("NORTHCENTER_CLKPHB"      ); 
+  colNames.push_back("SOUTHCENTER_CLKPHB"      ); 
+  colNames.push_back("SOUTH_CLKPHB"	       ); 
+  colNames.push_back("NORTH_CTRL"	       ); 
+  colNames.push_back("NORTHCENTER_CTRL"        ); 
+  colNames.push_back("SOUTHCENTER_CTRL"        ); 
+  colNames.push_back("SOUTH_CTRL"	       ); 
+  colNames.push_back("REG0_TTCRX_FDLA"         ); 
+  colNames.push_back("REG1_TTCRX_FDLA"         ); 
+  colNames.push_back("REG2_TTCRX_CDLA"         ); 
+  colNames.push_back("REG3_TTCRX_CLKD2"        ); 
+  colNames.push_back("CENTER_CTRL"	       ); 
+  colNames.push_back("CENTER_MODE"	       ); 
+  colNames.push_back("B1_ADCGN"   	       ); 
+  colNames.push_back("B2_ADCGN"   	       ); 
+  colNames.push_back("B3_ADCGN"   	       ); 
+  colNames.push_back("B4_ADCGN"   	       ); 
+  colNames.push_back("NORTH_BADJ" 	       ); 
+  colNames.push_back("NORTHCENTER_BADJ"        ); 
+  colNames.push_back("SOUTHCENTER_BADJ"        ); 
+  colNames.push_back("SOUTH_BADJ"	       ); 
+  colNames.push_back("NORTH_TBMMASK"	       ); 
+  colNames.push_back("NORTHCENTER_TBMMASK"     ); 
+  colNames.push_back("SOUTHCENTER_TBMMASK"     ); 
+  colNames.push_back("SOUTH_TBMMASK"	       ); 
+  colNames.push_back("NORTH_PWORD"	       ); 
+  colNames.push_back("NORTHCENTER_PWORD"       ); 
+  colNames.push_back("SOUTH_PWORD"	       ); 
+  colNames.push_back("SOUTHCENTER_PWORD"       ); 
+  colNames.push_back("SPECDAC"    	       ); 
+  colNames.push_back("OOS_LVL"    	       ); 
+  colNames.push_back("ERR_LVL"    	       ); 
+  colNames.push_back("NORTH_FIFO1_BZ_LVL"      ); 
+  colNames.push_back("NORTHCENTER_FIFO1_BZ_LVL"); 
+  colNames.push_back("SOUTHCENTER_FIFO1_BZ_LVL"); 
+  colNames.push_back("SOUTH_FIFO1_BZ_LVL"      ); 
+  colNames.push_back("FIFO3_WRN_LVL"	       ); 
+  colNames.push_back("FED_MASTER_DELAY"        ); 
+  colNames.push_back("NO_HITLIMIT"	       ); 
+  colNames.push_back("NC_HITLIMIT"	       ); 
+  colNames.push_back("SC_HITLIMIT"	       ); 
+  colNames.push_back("SO_HITLIMIT"	       ); 
+  colNames.push_back("NO_TESTREG"	       ); 
+  colNames.push_back("NC_TESTREG"	       ); 
+  colNames.push_back("SC_TESTREG"	       ); 
+  colNames.push_back("SO_TESTREG"	       ); 
+  colNames.push_back("TRIGGERHOLDOFF"	       );    
+						   
+  for(unsigned int c = 0 ; c < ins.size() ; c++)   
+    {						   
       for(unsigned int n=0; n<colNames.size(); n++)
-        {
-          if(tableMat[0][c] == colNames[n]){
-            colM[colNames[n]] = c;
-            break;
+        {					   
+          if(tableMat[0][c] == colNames[n]){	   
+            colM[colNames[n]] = c;		   
+            break;				   
           }
         }
     }//end for
@@ -198,7 +238,7 @@ PixelFEDCard::PixelFEDCard(vector<vector<string> > &tableMat):PixelConfigBase(" 
     {
       if(colM.find(colNames[n]) == colM.end())
         {
-          std::cerr << "[PixelTBMSettings::PixelTBMSettings()]\tCouldn't find in the database the column with name " << colNames[n] << std::endl;
+          std::cerr << __LINE__ << "]\t[PixelFEDCard::PixelFEDCard]\tCouldn't find in the database the column with name " << colNames[n] << std::endl;
           assert(0);
         }
     }
@@ -228,87 +268,106 @@ PixelFEDCard::PixelFEDCard(vector<vector<string> > &tableMat):PixelConfigBase(" 
       first = false ;
       //VME base address 
       //Fed Base Address
-      sscanf(tableMat[1][colM["VME_ADDRS_HEX"]].c_str(),"%lx",&FEDBASE_0);
+      sscanf(                  tableMat[1][colM["VME_ADDRS_HEX"]           ].c_str(),"%lx",&FEDBASE_0);
       //      sscanf(tableMat[1][colM["PIXEL_FED"]].c_str(), "PxlFED_%ld",&fedNumber);
-      fedNumber    = atoi(tableMat[1][colM["PIXEL_FED"]].c_str()		) ;
-      //Settable optical input parameters (one for each 12-receiver)		
-      opt_cap[0]   = atoi(tableMat[1][colM["OPT1_CAP"]].c_str() 	  	) ;
-      opt_cap[1]   = atoi(tableMat[1][colM["OPT2_CAP"]].c_str() 	  	) ;
-      opt_cap[2]   = atoi(tableMat[1][colM["OPT3_CAP"]].c_str() 	  	) ;
-      opt_inadj[0] = atoi(tableMat[1][colM["OPT1_INP"]].c_str() 	  	) ;
-      opt_inadj[1] = atoi(tableMat[1][colM["OPT2_INP"]].c_str() 	  	) ;
-      opt_inadj[2] = atoi(tableMat[1][colM["OPT3_INP"]].c_str() 	  	) ;
-      opt_ouadj[0] = atoi(tableMat[1][colM["OPT1_OUT"]].c_str() 	  	) ;
-      opt_ouadj[1] = atoi(tableMat[1][colM["OPT2_OUT"]].c_str() 	  	) ;
-      opt_ouadj[2] = atoi(tableMat[1][colM["OPT3_OUT"]].c_str() 	  	) ;
+      fedNumber         = atoi(tableMat[1][colM["PIXEL_FED"]         	   ].c_str()) ;
+      //Settable optical input parameters (one for each 12-receiver) 	   	    
+      opt_cap[0]   	= atoi(tableMat[1][colM["OPT1_CAP"]	     	   ].c_str()) ;
+      opt_cap[1]   	= atoi(tableMat[1][colM["OPT2_CAP"]	     	   ].c_str()) ;
+      opt_cap[2]   	= atoi(tableMat[1][colM["OPT3_CAP"]	     	   ].c_str()) ;
+      opt_inadj[0] 	= atoi(tableMat[1][colM["OPT1_INP"]	     	   ].c_str()) ;
+      opt_inadj[1] 	= atoi(tableMat[1][colM["OPT2_INP"]	     	   ].c_str()) ;
+      opt_inadj[2] 	= atoi(tableMat[1][colM["OPT3_INP"]	     	   ].c_str()) ;
+      opt_ouadj[0] 	= atoi(tableMat[1][colM["OPT1_OUT"]	     	   ].c_str()) ;
+      opt_ouadj[1] 	= atoi(tableMat[1][colM["OPT2_OUT"]	     	   ].c_str()) ;
+      opt_ouadj[2] 	= atoi(tableMat[1][colM["OPT3_OUT"]	     	   ].c_str()) ;
 
-      //clock phases, use bits 0-8, select the clock edged			
-      clkphs1_9    = atoi(tableMat[1][colM["NORTH_CLKPHB"]].c_str()	  	) ; // TO BE VERIFIED
-      clkphs10_18  = atoi(tableMat[1][colM["NORTHCENTER_CLKPHB"]].c_str() 	) ; // TO BE VERIFIED
-      clkphs19_27  = atoi(tableMat[1][colM["SOUTHCENTER_CLKPHB"]].c_str() 	) ; // TO BE VERIFIED
-      clkphs28_36  = atoi(tableMat[1][colM["SOUTH_CLKPHB"]].c_str()	  	) ; // TO BE VERIFIED
+      //clock phases, use bits 0-8, select the clock edged		   	     
+      clkphs1_9    	= atoi(tableMat[1][colM["NORTH_CLKPHB"]      	   ].c_str()) ; // TO BE VERIFIED
+      clkphs10_18  	= atoi(tableMat[1][colM["NORTHCENTER_CLKPHB"]	   ].c_str()) ; // TO BE VERIFIED
+      clkphs19_27  	= atoi(tableMat[1][colM["SOUTHCENTER_CLKPHB"]	   ].c_str()) ; // TO BE VERIFIED
+      clkphs28_36  	= atoi(tableMat[1][colM["SOUTH_CLKPHB"]      	   ].c_str()) ; // TO BE VERIFIED
 
-      // Control register and delays for the TTCrx				
-      CoarseDel    = atoi(tableMat[1][colM["REG2_TTCRX_CDLA"]].c_str()    	) ;
-      ClkDes2      = atoi(tableMat[1][colM["REG3_TTCRX_CLKD2"]].c_str()   	) ;
-      FineDes2Del  = atoi(tableMat[1][colM["REG1_TTCRX_FDLA"]].c_str()    	) ;
-      FineDes1Del  = atoi(tableMat[1][colM["REG0_TTCRX_FDLA"]].c_str()    	) ;
+      // Control register and delays for the TTCrx			   	    
+      FineDes1Del  	= atoi(tableMat[1][colM["REG0_TTCRX_FDLA"]   	   ].c_str()) ;
+      FineDes2Del  	= atoi(tableMat[1][colM["REG1_TTCRX_FDLA"]   	   ].c_str()) ;
+      CoarseDel    	= atoi(tableMat[1][colM["REG2_TTCRX_CDLA"]   	   ].c_str()) ;
+      ClkDes2      	= atoi(tableMat[1][colM["REG3_TTCRX_CLKD2"]  	   ].c_str()) ;
 
-      Ccntrl       = atoi(tableMat[1][colM["CENTER_CTRL"]].c_str()  	  	) ;
-      modeRegister = atoi(tableMat[1][colM["CENTER_MODE"]].c_str()  	  	) ;
+      Ccntrl       	= atoi(tableMat[1][colM["CENTER_CTRL"]	     	   ].c_str()) ;
+      modeRegister 	= atoi(tableMat[1][colM["CENTER_MODE"]	     	   ].c_str()) ;
 
       //data Regs adjustable fifo Almost Full levels
-      Nfifo1Bzlvl  = atoi(tableMat[1][colM["NORTH_FIFO1_BZ_LVL"]].c_str()	) ;
-      NCfifo1Bzlvl = atoi(tableMat[1][colM["NORTHCENTER_FIFO1_BZ_LVL"]].c_str() ) ;
-      SCfifo1Bzlvl = atoi(tableMat[1][colM["SOUTHCENTER_FIFO1_BZ_LVL"]].c_str() ) ;
-      Sfifo1Bzlvl  = atoi(tableMat[1][colM["SOUTH_FIFO1_BZ_LVL"]].c_str()	) ;
+      Nfifo1Bzlvl  	= atoi(tableMat[1][colM["NORTH_FIFO1_BZ_LVL"]      ].c_str()) ;
+      NCfifo1Bzlvl 	= atoi(tableMat[1][colM["NORTHCENTER_FIFO1_BZ_LVL"]].c_str()) ;
+      SCfifo1Bzlvl 	= atoi(tableMat[1][colM["SOUTHCENTER_FIFO1_BZ_LVL"]].c_str()) ;
+      Sfifo1Bzlvl  	= atoi(tableMat[1][colM["SOUTH_FIFO1_BZ_LVL"]      ].c_str()) ;
 
       //Bits (1st 8) used to mask TBM trailer bits
-      N_TBMmask    = atoi(tableMat[1][colM["NORTH_TBMMASK"]].c_str()	     	) ;
-      NC_TBMmask   = atoi(tableMat[1][colM["NORTHCENTER_TBMMASK"]].c_str()   	) ;
-      SC_TBMmask   = atoi(tableMat[1][colM["SOUTHCENTER_TBMMASK"]].c_str()   	) ;
-      S_TBMmask    = atoi(tableMat[1][colM["SOUTH_TBMMASK"]].c_str()	     	) ;
+      N_TBMmask    	= atoi(tableMat[1][colM["NORTH_TBMMASK"]      	   ].c_str()) ;
+      NC_TBMmask   	= atoi(tableMat[1][colM["NORTHCENTER_TBMMASK"]	   ].c_str()) ;
+      SC_TBMmask   	= atoi(tableMat[1][colM["SOUTHCENTER_TBMMASK"]	   ].c_str()) ;
+      S_TBMmask    	= atoi(tableMat[1][colM["SOUTH_TBMMASK"]      	   ].c_str()) ;
       
       //Bits (1st 8) used to set the Private Word in the gap and filler words
-      N_Pword      = atoi(tableMat[1][colM["NORTH_PWORD"]].c_str()	     	) ;
-      NC_Pword     = atoi(tableMat[1][colM["NORTHCENTER_PWORD"]].c_str()     	) ;
-      SC_Pword     = atoi(tableMat[1][colM["SOUTHCENTER_PWORD"]].c_str()     	) ;
-      S_Pword      = atoi(tableMat[1][colM["SOUTH_PWORD"]].c_str()	     	) ;
+      N_Pword      	= atoi(tableMat[1][colM["NORTH_PWORD"]      	   ].c_str()) ;
+      NC_Pword     	= atoi(tableMat[1][colM["NORTHCENTER_PWORD"]	   ].c_str()) ;
+      SC_Pword     	= atoi(tableMat[1][colM["SOUTHCENTER_PWORD"]	   ].c_str()) ;
+      S_Pword      	= atoi(tableMat[1][colM["SOUTH_PWORD"]      	   ].c_str()) ;
       
-      Nbaseln      = atoi(tableMat[1][colM["NORTH_BADJ"]].c_str()	     	) ;
-      NCbaseln     = atoi(tableMat[1][colM["NORTHCENTER_BADJ"]].c_str()      	) ;
-      SCbaseln     = atoi(tableMat[1][colM["SOUTHCENTER_BADJ"]].c_str()      	) ;
-      Sbaseln      = atoi(tableMat[1][colM["SOUTH_BADJ"]].c_str()	     	) ;
+      Nbaseln      	= atoi(tableMat[1][colM["NORTH_BADJ"]       	   ].c_str()) ;
+      NCbaseln     	= atoi(tableMat[1][colM["NORTHCENTER_BADJ"] 	   ].c_str()) ;
+      SCbaseln     	= atoi(tableMat[1][colM["SOUTHCENTER_BADJ"] 	   ].c_str()) ;
+      Sbaseln      	= atoi(tableMat[1][colM["SOUTH_BADJ"]       	   ].c_str()) ;
 
-      Ncntrl       = atoi(tableMat[1][colM["NORTH_CTRL"]].c_str()	     	) ;
-      NCcntrl      = atoi(tableMat[1][colM["NORTHCENTER_CTRL"]].c_str()      	) ;
-      SCcntrl      = atoi(tableMat[1][colM["SOUTHCENTER_CTRL"]].c_str()      	) ;
-      Scntrl       = atoi(tableMat[1][colM["SOUTH_CTRL"]].c_str()	     	) ;
+      Ncntrl       	= atoi(tableMat[1][colM["NORTH_CTRL"]       	   ].c_str()) ;
+      NCcntrl      	= atoi(tableMat[1][colM["NORTHCENTER_CTRL"] 	   ].c_str()) ;
+      SCcntrl      	= atoi(tableMat[1][colM["SOUTHCENTER_CTRL"] 	   ].c_str()) ;
+      Scntrl       	= atoi(tableMat[1][colM["SOUTH_CTRL"]       	   ].c_str()) ;
       
 
        //These bit sets the special dac mode for random triggers 
-      SpecialDac   = atoi(tableMat[1][colM["SPECDAC"]].c_str()                  ) ;
+      SpecialDac        = atoi(tableMat[1][colM["SPECDAC"]          	   ].c_str()) ;
 
       //These bits set the number of Out of consecutive out of sync events until a TTs OOs 
-      Ooslvl       = atoi(tableMat[1][colM["OOS_LVL"]].c_str()                  ) ;
+      Ooslvl            = atoi(tableMat[1][colM["OOS_LVL"]          	   ].c_str()) ;
       //These bits set the number of Empty events until a TTs Error 
-      Errlvl       = atoi(tableMat[1][colM["ERR_LVL"]].c_str()                  ) ;
+      Errlvl            = atoi(tableMat[1][colM["ERR_LVL"]          	   ].c_str()) ;
 
       //Control Regs for setting ADC 1Vpp and 2Vpp
-      Nadcg  	   = atoi(tableMat[1][colM["B1_ADCGN"]].c_str() 		) ;
-      NCadcg 	   = atoi(tableMat[1][colM["B2_ADCGN"]].c_str() 		) ;
-      SCadcg 	   = atoi(tableMat[1][colM["B3_ADCGN"]].c_str() 		) ;
-      Sadcg  	   = atoi(tableMat[1][colM["B4_ADCGN"]].c_str() 		) ;
-      fifo3Wrnlvl  = atoi(tableMat[1][colM["FIFO3_WRN_LVL"]].c_str()		) ;
-      FedTTCDelay  = atoi(tableMat[1][colM["FED_MASTER_DELAY"]].c_str() 	) ;
-      N_hitlimit   = atoi(tableMat[1][colM["NO_HITLIMIT"]].c_str()	        ) ;
-      NC_hitlimit  = atoi(tableMat[1][colM["NC_HITLIMIT"]].c_str()	        ) ;
-      SC_hitlimit  = atoi(tableMat[1][colM["SC_HITLIMIT"]].c_str()	        ) ;
-      S_hitlimit   = atoi(tableMat[1][colM["SO_HITLIMIT"]].c_str()	        ) ;
-      N_testreg    = atoi(tableMat[1][colM["NO_TESTREG"]].c_str()	        ) ;
-      NC_testreg   = atoi(tableMat[1][colM["NC_TESTREG"]].c_str()	        ) ;
-      SC_testreg   = atoi(tableMat[1][colM["SC_TESTREG"]].c_str()	        ) ;
-      S_testreg    = atoi(tableMat[1][colM["SO_TESTREG"]].c_str()	        ) ;
+      Nadcg  	   	= atoi(tableMat[1][colM["B1_ADCGN"]	    	   ].c_str()) ;
+      NCadcg 	   	= atoi(tableMat[1][colM["B2_ADCGN"]	    	   ].c_str()) ;
+      SCadcg 	   	= atoi(tableMat[1][colM["B3_ADCGN"]	    	   ].c_str()) ;
+      Sadcg  	   	= atoi(tableMat[1][colM["B4_ADCGN"]	    	   ].c_str()) ;
+      fifo3Wrnlvl  	= atoi(tableMat[1][colM["FIFO3_WRN_LVL"]    	   ].c_str()) ;
+      FedTTCDelay  	= atoi(tableMat[1][colM["FED_MASTER_DELAY"] 	   ].c_str()) ;
+      N_hitlimit   	= atoi(tableMat[1][colM["NO_HITLIMIT"]	    	   ].c_str()) ;
+      NC_hitlimit  	= atoi(tableMat[1][colM["NC_HITLIMIT"]	    	   ].c_str()) ;
+      SC_hitlimit  	= atoi(tableMat[1][colM["SC_HITLIMIT"]	    	   ].c_str()) ;
+      S_hitlimit   	= atoi(tableMat[1][colM["SO_HITLIMIT"]	    	   ].c_str()) ;
+      N_testreg    	= atoi(tableMat[1][colM["NO_TESTREG"]	    	   ].c_str()) ;
+      NC_testreg   	= atoi(tableMat[1][colM["NC_TESTREG"]	    	   ].c_str()) ;
+      SC_testreg   	= atoi(tableMat[1][colM["SC_TESTREG"]	    	   ].c_str()) ;
+      S_testreg    	= atoi(tableMat[1][colM["SO_TESTREG"]	    	   ].c_str()) ;
+      BusyHoldMin       = atoi(tableMat[1][colM["BUSYHOLDMIN"]      	   ].c_str()) ;
+      BusyWhenBehind    = atoi(tableMat[1][colM["BUSYWHENBEHIND"]   	   ].c_str()) ;
+      FeatureRegister   = atoi(tableMat[1][colM["FEATUREREGISTER"]  	   ].c_str()) ;
+      FIFO2Limit        = atoi(tableMat[1][colM["FIFO2LIMIT"]       	   ].c_str()) ;
+      LastDacOff        = atoi(tableMat[1][colM["LASTDACOFF"]       	   ].c_str()) ;
+      SimHitsPerRoc     = atoi(tableMat[1][colM["SIMHITSPERROC"]    	   ].c_str()) ;
+      TimeoutOROOSLimit = atoi(tableMat[1][colM["TIMEOUTOROOSLIMIT"]	   ].c_str()) ;
+      TriggerHoldoff    = atoi(tableMat[1][colM["TRIGGERHOLDOFF"]	   ].c_str()) ;
+
+      SPARE1 		= atoi(tableMat[1][colM["SPARE1"]		   ].c_str()) ;
+      SPARE2 		= atoi(tableMat[1][colM["SPARE2"]		   ].c_str()) ;
+      SPARE3 		= atoi(tableMat[1][colM["SPARE3"]		   ].c_str()) ;
+      SPARE4 		= atoi(tableMat[1][colM["SPARE4"]		   ].c_str()) ;
+      SPARE5 		= atoi(tableMat[1][colM["SPARE5"]		   ].c_str()) ;
+      SPARE6 		= atoi(tableMat[1][colM["SPARE6"]		   ].c_str()) ;
+      SPARE7 		= atoi(tableMat[1][colM["SPARE7"]		   ].c_str()) ;
+      SPARE8 		= atoi(tableMat[1][colM["SPARE8"]		   ].c_str()) ;
+      SPARE9 		= atoi(tableMat[1][colM["SPARE9"]		   ].c_str()) ;
+      SPARE10		= atoi(tableMat[1][colM["SPARE10"]		   ].c_str()) ;
 
     } // end of 'first' condition
   for(int r = 1 ; r < size[0] ; r++)    //Goes to every row of the FIRST Matrix (MUST BE 36, one for each FED channel)
@@ -868,18 +927,18 @@ PixelFEDCard::PixelFEDCard(string fileName):
         int checkword=0;
   fscanf(infile,"Params FED file check word:%d\n",
                            &checkword);
-        if(checkword!=90508&&checkword!=91509) cout << __LINE__  << "]\t"                             << mthn 
+        if(checkword!=90508&&checkword!=91509&&checkword!=20211) cout << __LINE__  << "]\t"                             << mthn 
 	                          << "FEDID: "                                      << fedNumber 
 				  << " Params FED File read error. Checkword read " << checkword
-				  <<" check word expected 090508 or 91509"          << endl;
-        assert((checkword==90508)|(checkword==91509));
+				  <<" check word expected 090508 or 91509 or 20211"          << endl;
+        assert((checkword==90508)|(checkword==91509)|(checkword==20211));
 
         if(localDEBUG)
          cout << __LINE__  << "]\t" << mthn << "Params FED file check word: " << checkword << endl;
 
       //These bits set the hit limit in fifo-1 for an event
 
-	if(checkword==91509){
+				if(checkword==20211){
       //These bits set the hit limit in fifo-1 for an event
   fscanf(infile,"N fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",&N_hitlimit);
   if(localDEBUG)
@@ -907,6 +966,120 @@ PixelFEDCard::PixelFEDCard(string fileName):
   fscanf(infile,"Skip a ROC in ch 28-36, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",&S_testreg);
   if(localDEBUG)
     printf("Skip a ROC in ch 28-36, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",S_testreg);
+
+  fscanf(infile,"Set BUSYWHENBEHIND by this many triggers with timeouts:%d\n",&BusyWhenBehind);
+  if(localDEBUG)
+    printf("Set BUSYWHENBEHIND by this many triggers with timeouts:%d\n",BusyWhenBehind);
+				
+ fscanf(infile,"D[0]=1 enable fed-stuck reset D[1]=1 disable ev# protect(dont):%x\n",&FeatureRegister);
+	  if(localDEBUG)
+    printf("D[0]=1 enable fed-stuck reset D[1]=1 disable ev# protect(dont):%x\n",FeatureRegister);	 
+		 
+ fscanf(infile,"Limit for fifo-2 almost full (point for the TTS flag):%x\n",&FIFO2Limit);
+	  if(localDEBUG)
+    printf("Limit for fifo-2 almost full (point for the TTS flag):%x\n",FIFO2Limit);	 
+		 
+ fscanf(infile,"Limit for consecutive timeout OR OOSs:%d\n",&TimeoutOROOSLimit);
+	  if(localDEBUG)
+    printf("Limit for consecutive timeout OR OOSs:%d\n",TimeoutOROOSLimit);	 
+		 
+ fscanf(infile,"Turn off filling of lastdac fifos(exc 1st ROC):%d\n",&LastDacOff);
+	  if(localDEBUG)
+    printf("Turn off filling of lastdac fifos(exc 1st ROC):%d\n",LastDacOff);	 
+		 
+ fscanf(infile,"Number of simulated hits per ROC for internal generator:%d\n",&SimHitsPerRoc);
+	  if(localDEBUG)
+    printf("Number of simulated hits per ROC for internal generator:%d\n",SimHitsPerRoc);	 
+
+ fscanf(infile,"Miniumum hold time for busy (changing definition):%d\n",&BusyHoldMin);
+	  if(localDEBUG)
+    printf("Miniumum hold time for busy (changing definition):%d\n",BusyHoldMin);	 
+		 
+ fscanf(infile,"Trigger Holdoff in units of 25us(0=none):%d\n",&TriggerHoldoff);
+	  if(localDEBUG)
+    printf("Trigger Holdoff in units of 25us(0=none):%d\n",TriggerHoldoff);	 
+		 
+ fscanf(infile,"Spare fedcard input 1:%d\n",&SPARE1);
+	  if(localDEBUG)
+    printf("Spare fedcard input 1:%d\n",SPARE1);	 
+ fscanf(infile,"Spare fedcard input 2:%d\n",&SPARE2);
+	  if(localDEBUG)
+    printf("Spare fedcard input 2:%d\n",SPARE2);	 
+ fscanf(infile,"Spare fedcard input 3:%d\n",&SPARE3);
+	  if(localDEBUG)
+    printf("Spare fedcard input 3:%d\n",SPARE3);	 
+ fscanf(infile,"Spare fedcard input 4:%d\n",&SPARE4);
+	  if(localDEBUG)
+    printf("Spare fedcard input 4:%d\n",SPARE4);	 
+ fscanf(infile,"Spare fedcard input 5:%d\n",&SPARE5);
+	  if(localDEBUG)
+    printf("Spare fedcard input 5:%d\n",SPARE5);	 
+ fscanf(infile,"Spare fedcard input 6:%d\n",&SPARE6);
+	  if(localDEBUG)
+    printf("Spare fedcard input 6:%d\n",SPARE6);	 
+ fscanf(infile,"Spare fedcard input 7:%d\n",&SPARE7);
+	  if(localDEBUG)
+    printf("Spare fedcard input 7:%d\n",SPARE7);	 
+ fscanf(infile,"Spare fedcard input 8:%d\n",&SPARE8);
+	  if(localDEBUG)
+    printf("Spare fedcard input 8:%d\n",SPARE8);	 
+ fscanf(infile,"Spare fedcard input 9:%d\n",&SPARE9);
+	  if(localDEBUG)
+    printf("Spare fedcard input 9:%d\n",SPARE9);	 
+ fscanf(infile,"Spare fedcard input 10:%d\n",&SPARE10);
+	  if(localDEBUG)
+    printf("Spare fedcard input 10:%d\n",SPARE10);	 
+		 
+		 
+		 				
+				}else if(checkword==91509){
+      //These bits set the hit limit in fifo-1 for an event
+  fscanf(infile,"N fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",&N_hitlimit);
+  if(localDEBUG)
+    printf("N fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",N_hitlimit);    
+  fscanf(infile,"NC fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",&NC_hitlimit);
+  if(localDEBUG)
+    printf("NC fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",NC_hitlimit);
+  fscanf(infile,"SC fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",&SC_hitlimit);
+  if(localDEBUG)
+    printf("SC fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",SC_hitlimit);
+  fscanf(infile,"S fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",&S_hitlimit);
+  if(localDEBUG)
+    printf("S fifo-1 hit limit (max 1023 (hard) 900 (soft):%d\n",S_hitlimit);
+      //These bits allow a ROC to be skipped (1/fpga)
+      
+  fscanf(infile,"Skip a ROC in ch 1-9, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",&N_testreg);
+  if(localDEBUG)
+    printf("Skip a ROC in ch 1-9, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",N_testreg);
+  fscanf(infile,"Skip a ROC in ch 10-18, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",&NC_testreg);
+  if(localDEBUG)
+    printf("Skip a ROC in ch 10-18, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",NC_testreg);
+  fscanf(infile,"Skip a ROC in ch 19-27, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",&SC_testreg);
+  if(localDEBUG)
+    printf("Skip a ROC in ch 19-27, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",SC_testreg);
+  fscanf(infile,"Skip a ROC in ch 28-36, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",&S_testreg);
+  if(localDEBUG)
+    printf("Skip a ROC in ch 28-36, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",S_testreg);
+	
+	  BusyWhenBehind=8;
+    FeatureRegister=0x1;    	
+    FIFO2Limit=0x1C00;	        	
+    TimeoutOROOSLimit=200;   	
+    LastDacOff=0;	        	
+    SimHitsPerRoc=0;       	
+    BusyHoldMin=0;
+		TriggerHoldoff=0;         	
+    SPARE1=0; 	        	    
+    SPARE2=0; 	        	    
+    SPARE3=0;        	    
+    SPARE4=0; 	        	    
+    SPARE5=0; 	        	    
+    SPARE6=0; 	        	    
+    SPARE7=0; 	        	    
+    SPARE8=0; 	        	    
+    SPARE9=0; 	        	    
+    SPARE10=0;                
+  	
          } else {
     
     N_hitlimit=192;	
@@ -918,7 +1091,25 @@ PixelFEDCard::PixelFEDCard(string fileName):
     NC_testreg=0;
     SC_testreg=0;
     S_testreg=0;
-         }
+
+	  BusyWhenBehind=8;
+    FeatureRegister=0x1;    
+    FIFO2Limit=0x1c00;	       
+    TimeoutOROOSLimit=200;   
+    LastDacOff=0;	        	
+    SimHitsPerRoc=0;       	
+    BusyHoldMin=0;
+		TriggerHoldoff=0;         	
+    SPARE1=0; 	        	   
+    SPARE2=0; 	        	   
+    SPARE3=0;        	    
+    SPARE4=0; 	        	   
+    SPARE5=0; 	        	   
+    SPARE6=0; 	        	   
+    SPARE7=0; 	        	   
+    SPARE8=0; 	        	   
+    SPARE9=0; 	        	   
+    SPARE10=0; }
    
   fclose(infile);
 
@@ -975,47 +1166,67 @@ void PixelFEDCard::clear(void)
   
   for(int i=0;i<36;i++) {
     for(int j=0;j<26;j++) {
-      ROC_L0[i][j] = 0;
-      ROC_L1[i][j] = 0;
-      ROC_L2[i][j] = 0;
-      ROC_L3[i][j] = 0;
-      ROC_L4[i][j] = 0;
+      ROC_L0[i][j]  = 0;
+      ROC_L1[i][j]  = 0;
+      ROC_L2[i][j]  = 0;
+      ROC_L3[i][j]  = 0;
+      ROC_L4[i][j]  = 0;
     }
   }
-  Ncntrl       = 0;  
-  NCcntrl      = 0;  
-  SCcntrl      = 0;  
-  Scntrl       = 0;  
-  CoarseDel    = 0;
-  ClkDes2      = 0;
-  FineDes2Del  = 0;
-  FineDes1Del  = 0;
-  Ccntrl       = 0;
-  modeRegister = 0;
-  Nadcg        = 0;
-  NCadcg       = 0;
-  SCadcg       = 0;
-  Sadcg        = 0;
-  Nbaseln      = 0;
-  NCbaseln     = 0;
-  SCbaseln     = 0;
-  Sbaseln      = 0;
-  N_TBMmask    = 0;
-  NC_TBMmask   = 0;
-  SC_TBMmask   = 0;
-  S_TBMmask    = 0;
-  N_Pword      = 0;
-  NC_Pword     = 0;
-  SC_Pword     = 0;
-  S_Pword      = 0;
-  SpecialDac   = 0;
-  Ooslvl       = 0;
-  Errlvl       = 0;
-  Nfifo1Bzlvl  = 0;
-  NCfifo1Bzlvl = 0;
-  SCfifo1Bzlvl = 0;
-  Sfifo1Bzlvl  = 0;
-  fifo3Wrnlvl  = 0;
+  Ncntrl            = 0; 
+  NCcntrl           = 0; 
+  SCcntrl           = 0; 
+  Scntrl            = 0; 
+  CoarseDel         = 0;
+  ClkDes2           = 0;
+  FineDes2Del       = 0;
+  FineDes1Del       = 0;
+  Ccntrl            = 0;
+  modeRegister      = 0;
+  Nadcg             = 0;
+  NCadcg            = 0;
+  SCadcg            = 0;
+  Sadcg             = 0;
+  Nbaseln           = 0;
+  NCbaseln          = 0;
+  SCbaseln          = 0;
+  Sbaseln           = 0;
+  N_TBMmask         = 0;
+  NC_TBMmask        = 0;
+  SC_TBMmask        = 0;
+  S_TBMmask         = 0;
+  N_Pword           = 0;
+  NC_Pword          = 0;
+  SC_Pword          = 0;
+  S_Pword           = 0;
+  SpecialDac        = 0;
+  Ooslvl            = 0;
+  Errlvl            = 0;
+  Nfifo1Bzlvl       = 0;
+  NCfifo1Bzlvl      = 0;
+  SCfifo1Bzlvl      = 0;
+  Sfifo1Bzlvl       = 0;
+  fifo3Wrnlvl       = 0;
+  
+  BusyHoldMin	    = 0;
+  BusyWhenBehind    = 0;
+  FeatureRegister   = 0;
+  FIFO2Limit	    = 0;
+  LastDacOff	    = 0;
+  SimHitsPerRoc     = 0;
+  TimeoutOROOSLimit = 0;
+  TriggerHoldoff    = 0;
+
+  SPARE1	    = 0;
+  SPARE2	    = 0;
+  SPARE3	    = 0;
+  SPARE4	    = 0;
+  SPARE5	    = 0;
+  SPARE6	    = 0;
+  SPARE7	    = 0;
+  SPARE8	    = 0;
+  SPARE9	    = 0;
+  SPARE10	    = 0;
 }
 //==================================================================================
 
@@ -1210,7 +1421,7 @@ void PixelFEDCard::writeASCII(std::string dir) const{
   fprintf(outfile,"TTCrx Register 0 fine delay ClkDes1:%d\n",
           FineDes1Del);
 
-  int checkword=91509;
+  int checkword=20211;
 
   fprintf(outfile,"Params FED file check word:%d\n",
                            checkword);
@@ -1243,6 +1454,41 @@ void PixelFEDCard::writeASCII(std::string dir) const{
     fprintf(outfile,"Skip a ROC in ch 28-36, bits 10-5 chnl, bits 0-4 ROC-1:%d\n",
     S_testreg);
     
+    fprintf(outfile,"Set BUSYWHENBEHIND by this many triggers with timeouts:%d\n",
+		BusyWhenBehind);
+				
+    fprintf(outfile,"D[0]=1 enable fed-stuck reset D[1]=1 disable ev# protect(dont):0x%x\n",
+		FeatureRegister);	 
+		 
+    fprintf(outfile,"Limit for fifo-2 almost full (point for the TTS flag):0x%x\n",
+		FIFO2Limit);	 
+		 
+    fprintf(outfile,"Limit for consecutive timeout OR OOSs:%d\n",
+		TimeoutOROOSLimit);	 
+		 
+    fprintf(outfile,"Turn off filling of lastdac fifos(exc 1st ROC):%d\n",
+		LastDacOff);	 
+		 
+    fprintf(outfile,"Number of simulated hits per ROC for internal generator:%d\n",
+		SimHitsPerRoc);	 
+
+    fprintf(outfile,"Miniumum hold time for busy (changing definition):%d\n",
+		BusyHoldMin);	 
+		 
+    fprintf(outfile,"Trigger Holdoff in units of 25us(0=none):%d\n",
+		TriggerHoldoff);	 
+		 
+    fprintf(outfile,"Spare fedcard input 1:%d\n",SPARE1);	 
+    fprintf(outfile,"Spare fedcard input 2:%d\n",SPARE2);	 
+    fprintf(outfile,"Spare fedcard input 3:%d\n",SPARE3);	 
+    fprintf(outfile,"Spare fedcard input 4:%d\n",SPARE4);	 
+    fprintf(outfile,"Spare fedcard input 5:%d\n",SPARE5);	 
+    fprintf(outfile,"Spare fedcard input 6:%d\n",SPARE6);	 
+    fprintf(outfile,"Spare fedcard input 7:%d\n",SPARE7);	 
+    fprintf(outfile,"Spare fedcard input 8:%d\n",SPARE8);	 
+    fprintf(outfile,"Spare fedcard input 9:%d\n",SPARE9);	 
+    fprintf(outfile,"Spare fedcard input 10:%d\n",SPARE10);	 
+		 
 
 
   fclose(outfile);
@@ -1409,7 +1655,8 @@ void PixelFEDCard::writeXMLHeader(pos::PixelConfigKey key, int version, std::str
   *out << "  </PART>"                                                                             	  << std::endl ;
 }
 //=============================================================================================
-void PixelFEDCard::writeXML( std::ofstream *out) const {
+void PixelFEDCard::writeXML( std::ofstream *out) const 
+{
   std::string mthn = "[PixelFEDCard::writeXML()]\t\t\t    " ;
 
   *out << "  <DATA>"                                                                              	  << std::endl ;
@@ -1484,7 +1731,24 @@ void PixelFEDCard::writeXML( std::ofstream *out) const {
   *out << "   <NC_TESTREG>0</NC_TESTREG>"		  						  << std::endl ;
   *out << "   <SC_TESTREG>0</SC_TESTREG>"		  						  << std::endl ;
   *out << "   <SO_TESTREG>0</SO_TESTREG>"		  						  << std::endl ;
-  *out << " "                                                                                     	  << std::endl ;
+  *out << "   <BUSYWHENBEHIND>4</BUSYWHENBEHIND>"		  					  << std::endl ;
+  *out << "   <FEATUREREGISTER>0X1234</FEATUREREGISTER>"		  				  << std::endl ;
+  *out << "   <FIFO2LIMIT>0X1C00</FIFO2LIMIT>"		  						  << std::endl ;
+  *out << "   <TIMEOUTOROOSLIMIT>0</TIMEOUTOROOSLIMIT>"		  					  << std::endl ;
+  *out << "   <LASTDACOFF>0</LASTDACOFF>"		  						  << std::endl ;
+  *out << "   <SIMHITSPERROC>0</SIMHITSPERROC>"		  						  << std::endl ;
+  *out << "   <BUSYHOLDMIN>0</BUSYHOLDMIN>"		  						  << std::endl ;
+  *out << "   <SPARE1>0</SPARE1>"		  						  	  << std::endl ;
+  *out << "   <SPARE2>0</SPARE2>"		  						  	  << std::endl ;
+  *out << "   <SPARE3>0</SPARE3>"		  						  	  << std::endl ;
+  *out << "   <SPARE4>0</SPARE4>"		  						  	  << std::endl ;
+  *out << "   <SPARE5>0</SPARE5>"		  						  	  << std::endl ;
+  *out << "   <SPARE6>0</SPARE6>"		  						  	  << std::endl ;
+  *out << "   <SPARE7>0</SPARE7>"		  						  	  << std::endl ;
+  *out << "   <SPARE8>0</SPARE8>"		  						  	  << std::endl ;
+  *out << "   <SPARE9>0</SPARE9>"		  						  	  << std::endl ;
+  *out << "   <SPARE10>0</SPARE10>"		  						  	  << std::endl ;
+  *out << " "												  << std::endl ;
   *out << "  </DATA>"                                                                             	  << std::endl ;
   *out << " "                                                                                     	  << std::endl ;
 }
@@ -1569,7 +1833,24 @@ void PixelFEDCard::writeXML( std::ofstream *fedstream,
       *fedstream << "   <NC_TESTREG>"               << NC_testreg 	   << "</NC_TESTREG>"	            << std::endl ;
       *fedstream << "   <SC_TESTREG>"               << SC_testreg 	   << "</SC_TESTREG>"	            << std::endl ;
       *fedstream << "   <SO_TESTREG>"               << S_testreg 	   << "</SO_TESTREG>"	            << std::endl ;
-
+      *fedstream << "	<BUSYWHENBEHIND>"           << BusyWhenBehind	   << "</BUSYWHENBEHIND>"	    << std::endl ;
+      *fedstream << "	<BUSYHOLDMIN>"              << BusyHoldMin	   << "</BUSYHOLDMIN>"  	    << std::endl ;
+      *fedstream << "	<FEATUREREGISTER>"          << FeatureRegister	   << "</FEATUREREGISTER>"	    << std::endl ;
+      *fedstream << "	<FIFO2LIMIT>"               << FIFO2Limit	   << "</FIFO2LIMIT>"		    << std::endl ;
+      *fedstream << "	<LASTDACOFF>"               << LastDacOff	   << "</LASTDACOFF>"		    << std::endl ;
+      *fedstream << "	<SIMHITSPERROC>"	    << SimHitsPerRoc	   << "</SIMHITSPERROC>"	    << std::endl ;
+      *fedstream << "	<TIMEOUTOROOSLIMIT>"        << TimeoutOROOSLimit   << "</TIMEOUTOROOSLIMIT>"	    << std::endl ;
+      *fedstream << "	<TRIGGERHOLDOFF>"           << TriggerHoldoff	   << "</TRIGGERHOLDOFF>"           << std::endl ;
+      *fedstream << "	<SPARE1>"  	            << SPARE1	 	   << "</SPARE1>"		    << std::endl ;
+      *fedstream << "	<SPARE2>"  	            << SPARE2	 	   << "</SPARE2>"		    << std::endl ;
+      *fedstream << "	<SPARE3>"  	            << SPARE3	 	   << "</SPARE3>"		    << std::endl ;
+      *fedstream << "	<SPARE4>"  	            << SPARE4	 	   << "</SPARE4>"		    << std::endl ;
+      *fedstream << "	<SPARE5>"  	            << SPARE5	 	   << "</SPARE5>"		    << std::endl ;
+      *fedstream << "	<SPARE6>"  	            << SPARE6	 	   << "</SPARE6>"		    << std::endl ;
+      *fedstream << "	<SPARE7>"  	            << SPARE7	 	   << "</SPARE7>"		    << std::endl ;
+      *fedstream << "	<SPARE8>"  	            << SPARE8	 	   << "</SPARE8>"		    << std::endl ;
+      *fedstream << "	<SPARE9>"  	            << SPARE9	 	   << "</SPARE9>"		    << std::endl ;
+      *fedstream << "	<SPARE10>" 	            << SPARE10   	   << "</SPARE10>"	            << std::endl ;
       *fedstream << " "                                             	   				    << std::endl ;
       *fedstream << "  </DATA>"                                     	   				    << std::endl ;
       *fedstream << " "                                             	   				    << std::endl ;
@@ -1760,6 +2041,23 @@ void PixelFEDCard::writeXML(pos::PixelConfigKey key, int version, std::string pa
   out << "   <NC_TESTREG>0</NC_TESTREG>"							 << std::endl ;
   out << "   <SC_TESTREG>0</SC_TESTREG>"							 << std::endl ;
   out << "   <SO_TESTREG>0</SO_TESTREG>"							 << std::endl ;
+  out << "   <BUSYWHENBEHIND>4</BUSYWHENBEHIND>"						 << std::endl ;
+  out << "   <FEATUREREGISTER>0X1234</FEATUREREGISTER>" 					 << std::endl ;
+  out << "   <FIFO2LIMIT>0X1C00</FIFO2LIMIT>"							 << std::endl ;
+  out << "   <TIMEOUTOROOSLIMIT>0</TIMEOUTOROOSLIMIT>"  					 << std::endl ;
+  out << "   <LASTDACOFF>0</LASTDACOFF>"							 << std::endl ;
+  out << "   <SIMHITSPERROC>0</SIMHITSPERROC>"  						 << std::endl ;
+  out << "   <BUSYHOLDMIN>0</BUSYHOLDMIN>"							 << std::endl ;
+  out << "   <SPARE1>0</SPARE1>"								 << std::endl ;
+  out << "   <SPARE2>0</SPARE2>"								 << std::endl ;
+  out << "   <SPARE3>0</SPARE3>"								 << std::endl ;
+  out << "   <SPARE4>0</SPARE4>"								 << std::endl ;
+  out << "   <SPARE5>0</SPARE5>"								 << std::endl ;
+  out << "   <SPARE6>0</SPARE6>"								 << std::endl ;
+  out << "   <SPARE7>0</SPARE7>"								 << std::endl ;
+  out << "   <SPARE8>0</SPARE8>"								 << std::endl ;
+  out << "   <SPARE9>0</SPARE9>"								 << std::endl ;
+  out << "   <SPARE10>0</SPARE10>"								 << std::endl ;
   out << "  </DATA>"                                                                             << std::endl ;
 /*                                                                                              
   out<< "  <DATA>                                                                               
@@ -1821,8 +2119,8 @@ void PixelFEDCard::writeXML(pos::PixelConfigKey key, int version, std::string pa
 }
 
 //=============================================================================================
-unsigned long long PixelFEDCard::enabledChannels() {
-  unsigned long long channels=0;
+uint64_t PixelFEDCard::enabledChannels() {
+  uint64_t channels=0;
 // return a 64-bit word with low 36 bits set if a channel is enabled
 // if bits are set in the control registers, transfer of data from 
 // fifo1 to fifo 2 is not done, meaning the channel is disabled.
@@ -1850,13 +2148,13 @@ void PixelFEDCard::setChannel(unsigned int iChannel, bool mode){
     mask=mask&bit;
   }
   mask=~mask;
-  Ncntrl=mask & 0x1ffLL;
+  Ncntrl=(Ncntrl&  0xffff0000LL) | (mask&  0x1ffLL);
   mask=mask>>9;
-  NCcntrl=mask & 0x1ffLL;
+  NCcntrl=(NCcntrl&  0xffff0000LL) | (mask&  0x1ffLL);
   mask=mask>>9;
-  SCcntrl=mask & 0x1ffLL;
+  SCcntrl=(SCcntrl&  0xffff0000LL) | (mask&  0x1ffLL);
   mask=mask>>9;
-  Scntrl=mask & 0x1ffLL;
+  Scntrl=(Scntrl&  0xffff0000LL) | (mask&  0x1ffLL);
  
 }  
 

--- a/CalibFormats/SiPixelObjects/src/PixelPortCardConfig.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelPortCardConfig.cc
@@ -370,10 +370,10 @@ PixelPortCardConfig::PixelPortCardConfig(std::string filename):
 
   size_t portcardpos=filename.find(std::string("portcard_"));
   //std::cout << __LINE__ << "]\t" << mthn << "portcardpos:"<<portcardpos<<std::endl;
-  assert(portcardpos!=std::string::npos);
+  assert(portcardpos!=(unsigned int)std::string::npos);
   size_t datpos=filename.find(std::string(".dat"));
   //std::cout << __LINE__ << "]\t" << mthn << "datpos:"<<datpos<<std::endl;
-  assert(datpos!=std::string::npos);
+  assert(datpos!=(unsigned int)std::string::npos);
   assert(datpos>portcardpos);
   
   portcardname_=filename.substr(portcardpos+9,datpos-portcardpos-9);

--- a/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
+++ b/CalibFormats/SiPixelObjects/src/PixelTBMSettings.cc
@@ -253,7 +253,7 @@ void PixelTBMSettings::writeASCII(std::string dir) const {
 
 void PixelTBMSettings::generateConfiguration(PixelFECConfigInterface* pixelFEC,
 					     PixelNameTranslation* trans,
-					     bool physics) const{
+					     bool physics, bool doResets) const{
 
     PixelHdwAddress theROC=*(trans->getHdwAddress(rocid_));
 
@@ -264,8 +264,10 @@ void PixelTBMSettings::generateConfiguration(PixelFECConfigInterface* pixelFEC,
     int tbmchannelB=15; 
     int hubaddress=theROC.hubaddress();
 
-    pixelFEC->injectrsttbm(mfec, 1);
-    pixelFEC->injectrstroc(mfec,1);
+    if (doResets) {
+      pixelFEC->injectrsttbm(mfec, 1);
+      pixelFEC->injectrstroc(mfec,1);
+    }
     pixelFEC->enablecallatency(mfec,0);
     pixelFEC->disableexttrigger(mfec,0);
     pixelFEC->injecttrigger(mfec,0);
@@ -274,7 +276,7 @@ void PixelTBMSettings::generateConfiguration(PixelFECConfigInterface* pixelFEC,
     //pixelFEC->synccontrolregister(mfec);
 
     //Reset TBM and reset ROC
-    pixelFEC->tbmcmd(mfec, mfecchannel, tbmchannel, hubaddress, 4, 2, 0x14, 0);
+    if (doResets)    pixelFEC->tbmcmd(mfec, mfecchannel, tbmchannel, hubaddress, 4, 2, 0x14, 0);
     //setting speed to 40MHz
     pixelFEC->tbmcmd(mfec, mfecchannel, tbmchannel, hubaddress, 4, 0, 1, 0);
     // setting the mode, we should always stay in the CAL mode
@@ -303,7 +305,7 @@ void PixelTBMSettings::generateConfiguration(PixelFECConfigInterface* pixelFEC,
     //pre-calibration, stay always in this mode
     pixelFEC->tbmcmd(mfec, mfecchannel, tbmchannelB, hubaddress, 4, 1, 0xc0, 0);
     //Reset TBM and reset ROC
-    pixelFEC->tbmcmd(mfec, mfecchannel, tbmchannelB, hubaddress, 4, 2, 0x14, 0);
+    if (doResets)    pixelFEC->tbmcmd(mfec, mfecchannel, tbmchannelB, hubaddress, 4, 2, 0x14, 0);
     //Enable token and analog output
     if (singlemode_){
       pixelFEC->tbmcmd(mfec, mfecchannel, tbmchannelB, hubaddress, 4, 4, 0x3, 0);


### PR DESCRIPTION
This pull request is similar to the one for CMSSW_5_3_X here: https://github.com/cms-sw/cmssw/pull/7167

During the switch from CVS to git a large part of the pixel code additions which are needed for the pixel online software and also calibration of the pixel detector were forgotten to be added to a release and only ended up in the CVS head. These changes should be in CMSSW_7_3_X and later (pull requests will follow for CMSSW_7_4_Y once this one is accepted).
