### PR TITLE
make muonisolation::IsolatorByNominalEfficiency::ConeSizes::cone_dr const 

### DIFF
--- a/RecoMuon/MuonIsolation/interface/IsolatorByNominalEfficiency.h
+++ b/RecoMuon/MuonIsolation/interface/IsolatorByNominalEfficiency.h
@@ -43,7 +43,7 @@ namespace muonisolation {
     class ConeSizes {
     private:
       enum  IsoDim { DIM = 15};
-      static float cone_dr[DIM];
+      static const float cone_dr[DIM];
     public:
       int dim() const { return DIM;}
       double size(int i) const;

--- a/RecoMuon/MuonIsolation/src/IsolatorByNominalEfficiency.cc
+++ b/RecoMuon/MuonIsolation/src/IsolatorByNominalEfficiency.cc
@@ -15,7 +15,7 @@ int IsolatorByNominalEfficiency::ConeSizes::index(float dr) const
  return 0;
 }
 
-float IsolatorByNominalEfficiency::ConeSizes::cone_dr[]=
+const float IsolatorByNominalEfficiency::ConeSizes::cone_dr[]=
 { 0.001, 0.02, 0.045, 0.09, 0.13, 0.17, 0.20, 0.24, 0.28, 0.32, 0.38, 0.45, 0.5, 0.6, 0.7};
 
 IsolatorByNominalEfficiency::IsolatorByNominalEfficiency(const string & thrFile, 


### PR DESCRIPTION
make `muonisolation::IsolatorByNominalEfficiency::ConeSizes::cone_dr` `static const` to avoid a false-positive multithreading report by the static analizer
