### PR TITLE
Fix pPb RelVal workflow

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -394,7 +394,7 @@ steps['QCD_Pt_20_30']=genS('QCD_Pt_20_30_8TeV_cfi',K250by100)
 steps['QCD_Pt_170_230']=genS('QCD_Pt_170_230_8TeV_cfi',K250by100)
 
 ## pPb tests
-step1PPbDefaults={'--beamspot':'Realistic8TeVCollisionPPbBoost'}
+step1PPbDefaults={'--beamspot':'Realistic5TeVPPbBoost'}
 steps['AMPT_PPb_5020GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaults,genS('AMPT_PPb_5020GeV_MinimumBias_cfi',K9by100)])
                                              
 ## heavy ions tests


### PR DESCRIPTION
Changed the name of the pPb vertex smearing to Realistic5TeVPPbBoost instead of Realistic8TeVCollisionPPbBoost since the collisions are actually at 5TeV.
