### PR TITLE
Significant improvements to HGC Jet Energy Response/Resolution and linking

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/src/HGCAllLayersEnergyCalculator.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/HGCAllLayersEnergyCalculator.cc
@@ -139,7 +139,7 @@ correctEnergyActual(reco::PFCluster& cluster) const {
       zside_layer = getlayer<HGCHEDetId>(hit.detId());
       mip_value = _mipValueInGeV_heb;
       mip2gev = effMIP_to_InvGeV;
-      e_heb += ((*weights)[zside_layer.second-1])*hit.energy()/(mip_value*std::tanh(abs_eta));
+      e_heb += ((*weights)[zside_layer.second-1])*hit.energy()/(mip_value*std::tanh(abs_eta))/2.0;
       break;
     default:
       throw cms::Exception("BadRecHit")

--- a/RecoParticleFlow/PFClusterProducer/src/HGCClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/HGCClusterizer.cc
@@ -411,17 +411,25 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
     const double hadEnergy = cluster.energy();
     cluster.setEmEnergy(emEnergy);
     cluster.setHadEnergy(hadEnergy);
-    if( cluster.recHitFractions().size() < 5 ) continue;
+    if( cluster.recHitFractions().size() < 5 ) continue; // kill noise
     if( i >= usable_clusters.size() ) {
       // by definition these are non-EM-like clusters
       cluster.setEnergy(hadEnergy);
       output.push_back(cluster);
     } else if( i < usable_clusters.size() && 
 	       (usable_clusters[i] || em_ID_clusters[i]) ) {
-      if( !em_ID_clusters[i] ) {
-	cluster.setEnergy(hadEnergy);
-      } else {
-	cluster.setEnergy(emEnergy);
+      if( cluster.size() > 20 ) {
+	if( !em_ID_clusters[i] ) {
+	  cluster.setEnergy(hadEnergy);
+	} else {
+	  cluster.setEnergy(emEnergy);
+	}
+      } else { // the calibrations at present do not extend well to low energy
+	if( cluster.layer() == PFLayer::HGC_ECAL ) {
+	  cluster.setEnergy(emEnergy);
+	} else {
+	  cluster.setEnergy(hadEnergy);
+	}
       }
       output.push_back(cluster);
     }

--- a/RecoParticleFlow/PFClusterProducer/test/run_display.sh
+++ b/RecoParticleFlow/PFClusterProducer/test/run_display.sh
@@ -2,7 +2,7 @@
 
 #-c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc
 
-cmsShow -n --geom-file ~/work/public/xHGCAL/cmsRecoGeom-2023HGCalV5.root --sim-geom-file ~/work/public/xHGCAL/cmsSimGeom-2023HGCalV5.root -i ${CMSSW_BASE}/src/matrix_tests/low_energy_chargedpi/step3.root
+cmsShow -c ${CMSSW_BASE}/src/RecoParticleFlow/PFClusterProducer/test/hgcal_rechits.fwc --geom-file ~/work/public/xHGCAL/cmsRecoGeom-2023HGCalV5.root --sim-geom-file ~/work/public/xHGCAL/cmsSimGeom-2023HGCalV5.root -i ${CMSSW_BASE}/src/matrix_tests/low_energy_chargedpi/step3.root
 
 
 #${CMSSW_BASE}/src/matrix_tests/12202_SingleElectronPt10+SingleElectronPt10_Extended2023HGCalMuon_GenSimFull+DigiFull_Extended2023HGCalMuon+RecoFull_Extended2023HGCalMuon+HARVESTFull_Extended2023HGCalMuon/step3.root


### PR DESCRIPTION
Refinement of the linking strategy for HGC clusters and overrides to the energy assignment of small clusters where the ID was not behaving correctly and thus causing improper calibration of clusters.

Jet energy scale for the HGC is ~1.04 @ 200 GeV, resolution is ~13-14%

@pfs @vandreev11
