### PR TITLE
ConfigDP new GT connection string functionality and PCL fixes (port from 72X)

### DIFF
--- a/Configuration/AlCa/python/autoPCL.py
+++ b/Configuration/AlCa/python/autoPCL.py
@@ -1,0 +1,5 @@
+autoPCL = {'PromptCalibProd' : 'BeamSpotByRun+BeamSpotByLumi+SiStripQuality',
+           'PromptCalibProdSiStrip' : 'SiStripQuality',
+           'PromptCalibProdSiStripGains' : 'SiStripGains'
+           }
+

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1960,6 +1960,12 @@ class ConfigBuilder(object):
 
         # decide which AlcaHARVESTING paths to use
         harvestingList = sequence.split("+")
+
+
+
+ 	from Configuration.AlCa.autoPCL import autoPCL
+ 	self.expandMapping(harvestingList,autoPCL)
+	
         for name in harvestingConfig.__dict__:
             harvestingstream = getattr(harvestingConfig,name)
             if name in harvestingList and isinstance(harvestingstream,cms.Path):

--- a/Configuration/DataProcessing/python/Impl/AlCa.py
+++ b/Configuration/DataProcessing/python/Impl/AlCa.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,dqmIOSource,harvestingMode,dictIO
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,dqmIOSource,harvestingMode,dictIO,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 
 class AlCa(Scenario):
@@ -35,7 +35,7 @@ class AlCa(Scenario):
         options.scenario = "pp"
         options.step = step
         dictIO(options,args)
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
         
         process = cms.Process('RECO')
         cb = ConfigBuilder(options, process = process, with_output = True)
@@ -60,6 +60,9 @@ class AlCa(Scenario):
         options.scenario = "pp"
         options.step = "ALCAOUTPUT:"+('+'.join(skims))
         options.conditions = args['globaltag'] if 'globaltag' in args else 'None'
+        if args.has_key('globalTagConnect') and args['globalTagConnect'] != '':
+            options.conditions += ','+args['globalTagConnect']
+
         options.triggerResultsProcess = 'RECO'
         
         process = cms.Process('ALCA')
@@ -87,7 +90,7 @@ class AlCa(Scenario):
         options.scenario = "pp"
         options.step = "HARVESTING:alcaHarvesting"
         options.name = "EDMtoMEConvert"
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
  
         process = cms.Process("HARVESTING")
         process.source = dqmIOSource(args)

--- a/Configuration/DataProcessing/python/Impl/DataScouting.py
+++ b/Configuration/DataProcessing/python/Impl/DataScouting.py
@@ -11,7 +11,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
@@ -38,7 +38,7 @@ class DataScouting(Scenario):
         options.__dict__.update(defaultOptions.__dict__)
         options.step = 'DQM:DQM/DataScouting/dataScouting_cff.dataScoutingDQMSequence,ENDJOB'
         dictIO(options,args)        
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
                 
         process = cms.Process('DataScouting')
         cb = ConfigBuilder(options, process = process, with_output = True)
@@ -62,7 +62,7 @@ class DataScouting(Scenario):
         options.scenario = 'pp'
         options.step = "HARVESTING"+dqmSeq(args,':DQMOffline')
         options.name = "EDMtoMEConvert"
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
  
         process = cms.Process("HARVESTING")
         process.source = dqmIOSource(args)

--- a/Configuration/DataProcessing/python/Impl/cosmics.py
+++ b/Configuration/DataProcessing/python/Impl/cosmics.py
@@ -74,7 +74,7 @@ class cosmics(Reco):
         Proton collisions data taking AlCa Harvesting
 
         """
-        if not 'skims' in args:
+        if not 'skims' in args and not 'alcapromptdataset' in args:
             args['skims']=['SiStripQuality']
             
         return Reco.alcaHarvesting(self, globalTag, datasetName, **args)

--- a/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
@@ -77,7 +77,8 @@ class cosmicsRun2(Reco):
         Proton collisions data taking AlCa Harvesting
 
         """
-        if not 'skims' in args:
+
+        if not 'skims' in args and not 'alcapromptdataset' in args:
             args['skims']=['SiStripQuality']
             
         return Reco.alcaHarvesting(self, globalTag, datasetName, **args)

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -75,7 +75,8 @@ class pp(Reco):
         Proton collisions data taking AlCa Harvesting
 
         """
-        if not 'skims' in args:
+
+        if not 'skims' in args and not 'alcapromptdataset' in args:
             args['skims']=['BeamSpotByRun',
                            'BeamSpotByLumi',
                            'SiStripQuality']

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -78,7 +78,9 @@ class ppRun2(Reco):
         Proton collisions data taking AlCa Harvesting
 
         """
-        if not 'skims' in args:
+
+
+        if not 'skims' in args and not 'alcapromptdataset' in args:
             args['skims']=['BeamSpotByRun',
                            'BeamSpotByLumi',
                            'SiStripQuality']

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -147,12 +147,11 @@ class Reco(Scenario):
 
         step = ""
         pclWflws = [x for x in skims if "PromptCalibProd" in x]
+        skims = filter(lambda x: x not in pclWflws, skims)
+
         if len(pclWflws):
-            step = 'ALCA:'
-        for wfl in pclWflws:
-            step += wfl
-            skims.remove(wfl)
-        
+            step += 'ALCA:'+('+'.join(pclWflws))
+
         if len( skims ) > 0:
             if step != "":
                 step += ","

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
@@ -40,7 +40,7 @@ class Reco(Scenario):
         options.scenario = self.cbSc
         options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+step+',DQM'+dqmStep+',ENDJOB'
         dictIO(options,args)
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
         
         process = cms.Process('RECO')
         cb = ConfigBuilder(options, process = process, with_output = True)
@@ -76,7 +76,7 @@ class Reco(Scenario):
         options.scenario = self.cbSc
         options.step = 'RAW2DIGI,L1Reco,RECO'+step+',DQM'+dqmStep+',ENDJOB'
         dictIO(options,args)
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
         options.filein = 'tobeoverwritten.xyz'
         if 'inputSource' in args:
             options.filetype = args['inputSource']
@@ -108,7 +108,7 @@ class Reco(Scenario):
 
 
         dictIO(options,args)
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
         options.timeoutOutput = True
         # FIXME: maybe can go...maybe not
         options.filein = 'tobeoverwritten.xyz'
@@ -162,6 +162,9 @@ class Reco(Scenario):
         options.scenario = self.cbSc
         options.step = step
         options.conditions = args['globaltag'] if 'globaltag' in args else 'None'
+        if args.has_key('globalTagConnect'):
+            options.conditions += ','+args['globalTagConnect']
+
         options.triggerResultsProcess = 'RECO'
         
         process = cms.Process('ALCA')
@@ -195,7 +198,7 @@ class Reco(Scenario):
         options.scenario = self.cbSc
         options.step = "HARVESTING"+dqmSeq(args,':dqmHarvesting')
         options.name = "EDMtoMEConvert"
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
  
         process = cms.Process("HARVESTING")
         process.source = dqmIOSource(args)
@@ -227,7 +230,7 @@ class Reco(Scenario):
         options.scenario = self.cbSc if hasattr(self,'cbSc') else self.__class__.__name__ 
         options.step = "ALCAHARVEST:"+('+'.join(skims))
         options.name = "ALCAHARVEST"
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
  
         process = cms.Process("ALCAHARVEST")
         process.source = cms.Source("PoolSource")
@@ -255,7 +258,7 @@ class Reco(Scenario):
         options.scenario = self.cbSc if hasattr(self,'cbSc') else self.__class__.__name__
         options.step = "SKIM:"+('+'.join(skims))
         options.name = "SKIM"
-        options.conditions = globalTag
+        options.conditions = gtNameAndConnect(globalTag, args)
         process = cms.Process("SKIM")
         process.source = cms.Source("PoolSource")
         configBuilder = ConfigBuilder(options, process = process)

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -213,10 +213,19 @@ class Reco(Scenario):
         Proton collisions data taking AlCa Harvesting
 
         """
-        if not 'skims' in args: return None
+        skims = []
+        if 'skims' in args:
+            print 'here'
+            skims = args['skims']
+
+
+        if 'alcapromptdataset' in args:
+            skims.append('@'+args['alcapromptdataset'])
+
+        if len(skims) == 0: return None
         options = defaultOptions
         options.scenario = self.cbSc if hasattr(self,'cbSc') else self.__class__.__name__ 
-        options.step = "ALCAHARVEST:"+('+'.join(args['skims']))
+        options.step = "ALCAHARVEST:"+('+'.join(skims))
         options.name = "ALCAHARVEST"
         options.conditions = globalTag
  

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -162,7 +162,7 @@ class Reco(Scenario):
         options.scenario = self.cbSc
         options.step = step
         options.conditions = args['globaltag'] if 'globaltag' in args else 'None'
-        if args.has_key('globalTagConnect'):
+        if args.has_key('globalTagConnect') and args['globalTagConnect'] != '':
             options.conditions += ','+args['globalTagConnect']
 
         options.triggerResultsProcess = 'RECO'

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -120,6 +120,6 @@ def dqmSeq(args,default):
         return default
             
 def gtNameAndConnect(globalTag, args):
-    if args.has_key('globalTagConnect'):
+    if args.has_key('globalTagConnect') and args['globalTagConnect'] != '':
         return globalTag + ','+args['globalTagConnect']
     return globalTag

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -119,3 +119,7 @@ def dqmSeq(args,default):
     else:
         return default
             
+def gtNameAndConnect(globalTag, args):
+    if args.has_key('globalTagConnect'):
+        return globalTag + ','+args['globalTagConnect']
+    return globalTag

--- a/Configuration/DataProcessing/test/RunAlcaHarvesting.py
+++ b/Configuration/DataProcessing/test/RunAlcaHarvesting.py
@@ -23,7 +23,7 @@ class RunAlcaHarvesting:
         self.globalTag = None
         self.inputLFN = None
         self.workflows = None
-
+        self.alcapromptdataset = None
 
     def __call__(self):
         if self.scenario == None:
@@ -64,6 +64,8 @@ class RunAlcaHarvesting:
             kwds = {}
             if not self.workflows is None:
                 kwds['skims'] = self.workflows
+            if not self.alcapromptdataset is None:
+                kwds['alcapromptdataset'] = self.alcapromptdataset
             process = scenario.alcaHarvesting(self.globalTag, self.dataset, **kwds)
             
         except Exception, ex:
@@ -84,7 +86,7 @@ class RunAlcaHarvesting:
 
 
 if __name__ == '__main__':
-    valid = ["scenario=", "global-tag=", "lfn=", "dataset=","workflows="]
+    valid = ["scenario=", "global-tag=", "lfn=", "dataset=","workflows=","alcapromptdataset="]
     usage = """RunAlcaHarvesting.py <options>"""
     try:
         opts, args = getopt.getopt(sys.argv[1:], "", valid)
@@ -107,5 +109,8 @@ if __name__ == '__main__':
             harvester.dataset = arg
         if opt == "--workflows":
             harvester.workflows = [ x for x in arg.split(',') if len(x) > 0 ]
+        if opt == "--alcapromptdataset":
+            harvester.alcapromptdataset = arg
+
 
     harvester()


### PR DESCRIPTION
This PR addresses the following issues:
- add optional parameter "globalTagConnect" to allow dinamic configuration of GT connection string @ Tier0 (this is needed to run 73X with CondDBv1 @ Tier0)
- fixes a problem in handling multiple ALCAPROMPT datasets 
- introduces mapping of PCL workflows on the basis of the ALCAPROMPT dataset passed through the parameter "alcapromptdataset"

All this functionality has already been used @ Tier0 in 72X but for some reason never ported in 73X and needs to be integrated for the data taking in MWGRs.
