### PR TITLE
Do not add new chunks to already-large splits.

### DIFF
--- a/Utilities/XrdAdaptor/src/XrdRequestManager.cc
+++ b/Utilities/XrdAdaptor/src/XrdRequestManager.cc
@@ -846,6 +846,7 @@ static IOSize validateList(const std::vector<IOPosBuffer> req)
         assert(it.size() <= XRD_CL_MAX_CHUNK);
         assert(it.offset() < 0x1ffffffffff);
     }
+    assert(req.size() <= 1024);
     return total;
 }
 
@@ -858,24 +859,45 @@ XrdAdaptor::RequestManager::splitClientRequest(const std::vector<IOPosBuffer> &i
     req2.reserve(iolist.size()/2+1);
     size_t front=0;
 
-    float q1 = static_cast<float>(m_activeSources[0]->getQuality());
-    float q2 = static_cast<float>(m_activeSources[1]->getQuality());
+        // The quality of both is increased by 5 to prevent strange effects if quality is 0 for one source.
+    float q1 = static_cast<float>(m_activeSources[0]->getQuality())+5;
+    float q2 = static_cast<float>(m_activeSources[1]->getQuality())+5;
     IOSize chunk1, chunk2;
     chunk1 = static_cast<float>(XRD_CL_MAX_CHUNK)*(q2*q2/(q1*q1+q2*q2));
     chunk2 = static_cast<float>(XRD_CL_MAX_CHUNK)*(q1*q1/(q1*q1+q2*q2));
 
+    IOSize size_orig = 0;
+    for (const auto & it : iolist) size_orig += it.size();
+
     while (tmp_iolist.size()-front > 0)
     {
-        consumeChunkFront(front, tmp_iolist, req1, chunk1);
-        consumeChunkBack(front, tmp_iolist, req2, chunk2);
+        if ((req1.size() >= 1000) && (req2.size() >= 1000))
+        {   // The XrdFile::readv implementation should guarantee that no more than approximately 1024 chunks
+            // are passed to the request manager.  However, because we have a max chunk size, we increase
+            // the total number slightly.  Theoretically, it's possible an individual readv of total size >2GB where
+            // each individual chunk is >1MB could result in this firing.  However, within the context of CMSSW,
+            // this cannot happen (ROOT uses readv for TTreeCache; TTreeCache size is 20MB).
+            edm::Exception ex(edm::errors::FileReadError);
+            ex << "XrdAdaptor::RequestManager::splitClientRequest(name='" << m_name
+               << "', flags=0x" << std::hex << m_flags
+               << ", permissions=0" << std::oct << m_perms << std::dec
+               << ") => Unable to split request between active servers.  This is an unexpected internal error and should be reported to CMSSW developers.";
+            ex.addContext("In XrdAdaptor::RequestManager::requestFailure()");
+            addConnections(ex);
+            std::stringstream ss; ss << "Original request size " << iolist.size() << "(" << size_orig << " bytes)";
+            ex.addAdditionalInfo(ss.str());
+            std::stringstream ss2; ss2 << "Quality source 1 " << q1-5 << ", quality source 2: " << q2-5;
+            ex.addAdditionalInfo(ss2.str());
+            throw ex;
+        }
+        if (req1.size() < 1000) {consumeChunkFront(front, tmp_iolist, req1, chunk1);}
+        if (req2.size() < 1000) {consumeChunkBack(front, tmp_iolist, req2, chunk2);}
     }
     std::sort(req1.begin(), req1.end(), [](const IOPosBuffer & left, const IOPosBuffer & right){return left.offset() < right.offset();});
     std::sort(req2.begin(), req2.end(), [](const IOPosBuffer & left, const IOPosBuffer & right){return left.offset() < right.offset();});
 
     IOSize size1 = validateList(req1);
     IOSize size2 = validateList(req2);
-    IOSize size_orig = 0;
-    for (const auto & it : iolist) size_orig += it.size();
 
     assert(size_orig == size1 + size2);
 


### PR DESCRIPTION
With this, we refuse to add new entries to a chunk list that is
already 1000 entries.  If both splits are above 1000 entries, then
an exception is thrown.

As the upper layers of CMSSW guarantee this shouldn't happen, I
feel throwing an exception is the correct behavior (compared to
error recovery).
