### PR TITLE
Make verbose in HLTExoticaSubAnalysis static const

### DIFF
--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -22,7 +22,7 @@
 #include <set>
 #include <algorithm>
 
-int verbose=0;
+static constexpr int verbose=0;
 
 /// Constructor
 HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,


### PR DESCRIPTION
The static analyzer complained about the static verbose. Since the
value can not be changed at run time, the variable is now constexpr.
