### PR TITLE
Make theVerboseLevel constexpr

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateSplit.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/SiPixelTemplateSplit.cc
@@ -47,7 +47,7 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #define LOGERROR(x) edm::LogError(x)
 #define LOGDEBUG(x) LogDebug(x)
-static int theVerboseLevel = 2;
+static constexpr int theVerboseLevel = 2;
 #define ENDL " "
 #else
 #include "SiPixelTemplateSplit.h"


### PR DESCRIPTION
The static analyzer was complaining about the file static
theVerboseLevel in SiPixelTemplateSplit. Since the value is never
changed at run time the variable was marked as constexpr.
