### PR TITLE
Fix clang build problem in AdaptiveVertexFitter

### DIFF
--- a/RecoVertex/AdaptiveVertexFit/src/AdaptiveVertexFitter.cc
+++ b/RecoVertex/AdaptiveVertexFit/src/AdaptiveVertexFitter.cc
@@ -22,7 +22,9 @@ namespace {
       auto s = cont.size();
       float pt2[s]; int ind[s]; int i=0; 
       for (auto const & tk : cont) { ind[i]=i; pt2[i++] = tk.impactPointState().globalMomentum().perp2();}
-      std::sort(ind,ind+s, [&](int i, int j){return pt2[i]>pt2[j];} ); 
+      //clang can not handle lambdas with variable length arrays
+      auto * p_pt2 = pt2;
+      std::sort(ind,ind+s, [p_pt2](int i, int j){return p_pt2[i]>p_pt2[j];} ); 
       std::vector<reco::TransientTrack> tmp; tmp.reserve(s);
       for (auto i=0U; i<s; ++i) tmp.emplace_back(std::move( cont[ind[i]] ) );
       cont.swap(tmp);
@@ -63,7 +65,9 @@ namespace {
       auto s = cont.size();
       float d2[s]; int ind[s]; int i=0;
       for (auto const & tk : cont) { ind[i]=i; d2[i++] = (tk->linearizedTrack()->track().initialFreeState().position() - ref ).mag2();}
-      std::sort(ind,ind+s, [&](int i, int j){return d2[i]<d2[j];} );
+      //clang can not handle lambdas with variable length arrays
+      auto * p_d2=d2;
+      std::sort(ind,ind+s, [p_d2](int i, int j){return p_d2[i]<p_d2[j];} );
       std::vector<RefCountedVertexTrack> tmp; tmp.reserve(s);
       for (auto i=0U; i<s; ++i) tmp.emplace_back(std::move( cont[ind[i]] ) );
       cont.swap(tmp);


### PR DESCRIPTION
clang does not permit a variable sized array to be passed to a lambda.
So instead we pass a pointer to the first element of the array. An
optimizing compiler should make the two implementations into the same
machine code.
