### PR TITLE
modify PFRecHitQTests to separate timing cut for HB and HE

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -266,7 +266,7 @@ class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
 	minTimes_.push_back(psets[i].getParameter<double>("minTime"));
 	maxTimes_.push_back(psets[i].getParameter<double>("maxTime"));
 	thresholds_.push_back(psets[i].getParameter<double>("threshold"));
-        endcap_.push_back(psets[i].getParameter<bool>("endcap"));
+	endcap_.push_back(psets[i].getParameter<bool>("endcap"));
       }
     }
 

--- a/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFRecHitQTests.h
@@ -266,6 +266,7 @@ class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
 	minTimes_.push_back(psets[i].getParameter<double>("minTime"));
 	maxTimes_.push_back(psets[i].getParameter<double>("maxTime"));
 	thresholds_.push_back(psets[i].getParameter<double>("threshold"));
+        endcap_.push_back(psets[i].getParameter<bool>("endcap"));
       }
     }
 
@@ -298,11 +299,12 @@ class PFRecHitQTestHCALTimeVsDepth : public PFRecHitQTestBase {
     std::vector<double> minTimes_;
     std::vector<double> maxTimes_;
     std::vector<double> thresholds_;
+    std::vector<bool> endcap_;
 
     bool test(unsigned DETID,double energy,double time,bool& clean) {
       HcalDetId detid(DETID);
       for (unsigned int i=0;i<depths_.size();++i) {
-	if (detid.depth() == depths_[i]) {
+	if (detid.depth() == depths_[i] && detid.subdet()==(endcap_[i]?2:1)) {
 	  if ((time <minTimes_[i] || time >maxTimes_[i] ) &&  energy>thresholds_[i])
 	    {
 	      clean=true;

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHBHE_cfi.py
@@ -38,32 +38,57 @@ particleFlowRecHitHBHE = cms.EDProducer("PFRecHitProducer",
                                  minTime = cms.double(-18.0),
                                  maxTime = cms.double(18.0),
                                  threshold = cms.double(0.0),
+                                 endcap = cms.bool(True),
                              ),
                              cms.PSet( 
                                  depth = cms.int32(2),
                                  minTime = cms.double(-18.0),
                                  maxTime = cms.double(18.0),
                                  threshold = cms.double(0.0),
+                                 endcap = cms.bool(True),
                              ),
                              cms.PSet( 
                                  depth = cms.int32(3),
                                  minTime = cms.double(-18.0),
                                  maxTime = cms.double(18.0),
                                  threshold = cms.double(0.0),
+                                 endcap = cms.bool(True),
                              ),
                              cms.PSet( 
                                  depth = cms.int32(4),
                                  minTime = cms.double(-18.0),
                                  maxTime = cms.double(18.0),
                                  threshold = cms.double(0.0),
+                                 endcap = cms.bool(True),
                              ),
                              cms.PSet( 
                                  depth = cms.int32(5),
                                  minTime = cms.double(-18.0),
                                  maxTime = cms.double(18.0),
                                  threshold = cms.double(0.0),
+                                 endcap = cms.bool(True),
                              ),
-
+                             cms.PSet(
+                                 depth = cms.int32(1),
+                                 minTime = cms.double(-18.0),
+                                 maxTime = cms.double(11.0),
+                                 threshold = cms.double(0.0),
+                                 endcap = cms.bool(False),
+                             ),
+                             cms.PSet(
+                                 depth = cms.int32(2),
+                                 minTime = cms.double(-18.0),
+                                 maxTime = cms.double(11.0),
+                                 threshold = cms.double(0.0),
+                                 endcap = cms.bool(False),
+                             ),
+                             cms.PSet(
+                                 depth = cms.int32(3),
+                                 minTime = cms.double(-18.0),
+                                 maxTime = cms.double(11.0),
+                                 threshold = cms.double(0.0),
+                                 endcap = cms.bool(False),
+                             ),
                       )
                   ) 
 


### PR DESCRIPTION
modify PFRecHitQTests to separate timing cut for HB and HE,
also lower the RecHit upper time cut from +18 to +11 ns
