### PR TITLE
Invalidate pset registration if needed

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -34,6 +34,7 @@ namespace edm {
 
   class ParameterSet {
   public:
+    template<typename T> friend class ParameterDescription;
     enum Bool {
       False = 0,
       True = 1,

--- a/FWCore/ParameterSet/src/ParameterDescription.cc
+++ b/FWCore/ParameterSet/src/ParameterDescription.cc
@@ -71,6 +71,9 @@ namespace edm {
     exists = pset.existsAs<ParameterSet>(label(), isTracked());
 
     if(exists) {
+      if(pset.isRegistered()) {
+         pset.invalidateRegistration("");
+      }
       ParameterSet * containedPSet = pset.getPSetForUpdate(label());
       psetDesc_->validate(*containedPSet);
     }


### PR DESCRIPTION
Relvals involving premixed samples were failing because copies of registered parameter sets were being validated in the SecondaryEventProvider.   A registered parameter set cannot be modified.  So, if the validation required update access to a parameter set, the test would fail due to an assert.  The fix is simply that if a copy of a registered parameter set needs modification, its registration is invalidated before update access is given to the parameter set.
Note, this request does not permit the modification of parameter sets in the parameter set registry.  It only allows the modification of _copies_ of these parameter sets.
