### PR TITLE
Reduce fit errors in HCal local reco to a summary

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -73,7 +73,20 @@ public:
 		       double iTS4Min, double iTS4Max, double iPulseJitter,double iTimeMean,double iTimeSig,double iPedMean,double iPedSig,
 		       double iNoise,double iTMin,double iTMax,
 		       double its3Chi2,double its4Chi2,double its345Chi2,double iChargeThreshold, int iFitTimes); 
-  
+
+  /** @brief Returns a map of how many times each error code occurred in the fit.
+   *
+   * returnValue.first is the error code, returnValue.second is the number of times it occurred.
+   * This count is not reset with each call of "apply", only with "resetFitErrorFrequency".
+   */
+  const std::map<int,int> fitErrorCodeFrequency() const
+  {
+    if( psFitOOTpuCorr_.get() ) return psFitOOTpuCorr_->fitErrorCodeFrequency();
+    else return std::map<int,int>(); // Need to return something, just return empty map
+  }
+  /** @brief Resets the count of how many times each fit error occurred. */
+  void resetFitErrorFrequency() { if( psFitOOTpuCorr_.get() ) psFitOOTpuCorr_->resetFitErrorFrequency(); }
+
 private:
   bool correctForTimeslew_;
   bool correctForPulse_;

--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -95,6 +95,14 @@ public:
     void setPulseShapeTemplate  (const HcalPulseShapes::Shape& ps);
     void resetPulseShapeTemplate(const HcalPulseShapes::Shape& ps);
 
+    /** @brief Returns a map of how many times each error code occurred in the fit.
+     *
+     * returnValue.first is the error code, returnValue.second is the number of times it occurred.
+     * This count is not reset with each call of "apply", only with "resetFitErrorFrequency".
+     */
+    const std::map<int,int>& fitErrorCodeFrequency() const { return fitErrorCodes_; }
+    /** @brief Resets the count of how many times each fit error occurred. */
+    void resetFitErrorFrequency() { fitErrorCodes_.clear(); }
 private:
     int pulseShapeFit(const double * energyArr, const double * pedenArr, const double *chargeArr, 
 		      const double *pedArr, const double *gainArr, const double tsTOTen, std::vector<double> &fitParsVec) const;
@@ -131,6 +139,9 @@ private:
     double noise_;    
     HcalTimeSlew::BiasSetting slewFlavor_;    
     const double overlapLimit = 1.0;
+
+    /// Keeps track of how many times each error code is produced when trying fits.
+    mutable std::map<int,int> fitErrorCodes_;
 };
 
 #endif // PulseShapeFitOOTPileupCorrection_h

--- a/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.h
+++ b/RecoLocalCalo/HcalRecAlgos/src/HybridMinimizer.h
@@ -263,6 +263,12 @@ public:
 
    void SetMinimizerType( EMinimizerType type);
 
+   /** @brief Suppress all messages and warnings that would normally printed to stdout.
+    *
+    * This should be used with care, and only if the fit status is always checked with "Status()"
+    * to make sure no errors occurred.
+    */
+   void SuppressMessages( bool suppressMessages=true ) { suppressMessages_=suppressMessages; }
 protected: 
    
    // protected function for accessing the internal Minuit2 object. Needed for derived classes
@@ -288,7 +294,7 @@ private:
    ROOT::Minuit2::FunctionMinimum * fMinimum;
    mutable std::vector<double> fValues;
    mutable std::vector<double> fErrors;
-
+   bool suppressMessages_; ///< Whether or not to print messages and warnings
 }; 
 
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -179,7 +179,7 @@ PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPul
    hybridfitter = new PSFitter::HybridMinimizer(PSFitter::HybridMinimizer::kMigrad);
    // Suppress all output to stdout and assume that the calling code makes
    // use of the fitErrorCodeFrequency method to report errors.
-   //hybridfitter->SuppressMessages();
+   hybridfitter->SuppressMessages();
 
    iniTimesArr = { {-100,-75,-50,-25,0,25,50,75,100,125} };
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/PulseShapeFitOOTPileupCorrection.cc
@@ -177,6 +177,10 @@ PulseShapeFitOOTPileupCorrection::PulseShapeFitOOTPileupCorrection() : cntsetPul
                                                                        ts4Min_(0), ts4Max_(0), pulseJitter_(0), timeMean_(0), timeSig_(0), pedMean_(0), pedSig_(0),
                                                                        noise_(0) {
    hybridfitter = new PSFitter::HybridMinimizer(PSFitter::HybridMinimizer::kMigrad);
+   // Suppress all output to stdout and assume that the calling code makes
+   // use of the fitErrorCodeFrequency method to report errors.
+   //hybridfitter->SuppressMessages();
+
    iniTimesArr = { {-100,-75,-50,-25,0,25,50,75,100,125} };
 }
 
@@ -393,6 +397,7 @@ void PulseShapeFitOOTPileupCorrection::fit(int iFit,float &timevalfit,float &cha
      if( fitTimes_ != 2 || tries !=1 ){
         hybridfitter->SetMinimizerType(PSFitter::HybridMinimizer::kMigrad);
         fitStatus = hybridfitter->Minimize();
+        ++fitErrorCodes_[hybridfitter->Status()];
      }
      double chi2valfit = hybridfitter->MinValue();
      const double *newresults = hybridfitter->X();
@@ -408,6 +413,7 @@ void PulseShapeFitOOTPileupCorrection::fit(int iFit,float &timevalfit,float &cha
        if(tries==0){
 	 hybridfitter->SetMinimizerType(PSFitter::HybridMinimizer::kScan);
 	 fitStatus = hybridfitter->Minimize();
+	 ++fitErrorCodes_[hybridfitter->Status()];
        } else if(tries==1){
 	 hybridfitter->SetStrategy(1);
        } else if(tries==2){

--- a/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalSimpleReconstructor.cc
@@ -10,6 +10,7 @@
 #include "CalibFormats/HcalObjects/interface/HcalDbService.h"
 #include "CalibFormats/HcalObjects/interface/HcalDbRecord.h"
 #include "Geometry/CaloTopology/interface/HcalTopology.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <iostream>
     
@@ -270,5 +271,21 @@ void HcalSimpleReconstructor::produce(edm::Event& e, const edm::EventSetup& even
     } else if (subdet_==HcalOther && subdetOther_==HcalCalibration) {
       process<HcalCalibDigiCollection, HcalCalibRecHitCollection>(e, eventSetup);
     }
-  } 
+  }
+
+  //
+  // Print a message stating how many fit errors occurred (rather than printing each error individually)
+  //
+  auto errorFrequency=reco_.fitErrorCodeFrequency();
+  if( !errorFrequency.empty() )
+  {
+    std::string message="Fit errors produced:\n";
+    for( const auto& codeFrequencyPair : errorFrequency )
+    {
+      if( codeFrequencyPair.first==0 ) message+="\t"+std::to_string(codeFrequencyPair.second)+ " successful fits.\n";
+      else message+="\tError "+std::to_string(codeFrequencyPair.first)+" occurred "+std::to_string(codeFrequencyPair.second)+ " times.\n";
+    }
+    edm::LogWarning( "HcalSimpleReconstructor" ) << message;
+  }
+  reco_.resetFitErrorFrequency(); // Now that data has been output, reset ready for the next event.
 }


### PR DESCRIPTION
Running HCal local reconstruction results in thousands of fit errors at 140 pileup.  Whilst the cause of this is investigated, this pull request suppresses each individual message and instead outputs a message once per event detailing how many times each error occurred.

So instead of ~16k occurrences of e.g.

```
%MSG-w HybridMinimizer:  HcalSimpleReconstructor:hbheUpgradeReco  16-Jan-2015 03:08:37 CET Run: 1 Event: 2002
HybridMinimizer::Minimize : Minimization did NOT converge, Edm is above max
%MSG
```

There is now one occurrence of

```
%MSG-w HcalSimpleReconstructor:  HcalSimpleReconstructor:hbheUpgradeReco  16-Jan-2015 03:08:37 CET Run: 1 Event: 2002
Fit errors produced:
    17501 successful fits.
    Error 1 occurred 176 times.
    Error 2 occurred 2446 times.
    Error 3 occurred 16455 times.
    Error 4 occurred 1701 times.

%MSG
```
