### PR TITLE
Increase Method2 overlapping pulse limit

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/PulseShapeFitOOTPileupCorrection.h
@@ -138,7 +138,7 @@ private:
     double pedSig_;
     double noise_;    
     HcalTimeSlew::BiasSetting slewFlavor_;    
-    const double overlapLimit = 1.0;
+    const double overlapLimit = 10.0; // nano seconds
 
     /// Keeps track of how many times each error code is produced when trying fits.
     mutable std::map<int,int> fitErrorCodes_;


### PR DESCRIPTION
Increases the criterion for deciding whether two (or three) pulses are overlapping or not.  I think it would be better to have this user configurable but there will be a review of this fit code in the next few days anyway.

The reason for choosing 10 ns is discussed on #7174 with a plot.

@sabrandt, @hengne
