### PR TITLE
Add debug PF collections to Shashlik event content

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -236,6 +236,10 @@ def cust_2023SHCal(process):
         process.ecalEndcapClusterTaskExtras.EcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.ecalEndcapRecoSummary.recHitCollection_EE = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
+    if hasattr(process,'FEVTDEBUGHLTEventContent'):
+        process.FEVTDEBUGHLTEventContent.outputCommands.append('keep *_particleFlowRecHitHBHE_*_*')
+        process.FEVTDEBUGHLTEventContent.outputCommands.append('keep *_particleFlowClusterHBHE_*_*')
+
     return process
 
 def cust_2023SHCalNoExtPix(process):


### PR DESCRIPTION
Adds the collections `particleFlowRecHitHBHE` and `particleFlowClusterHBHE` to the Shashlik FEVTDEBUGHLTEventContent.

Note that this wasn't added to the Shashlik without extended pixel customisation, I wasn't sure if this is required long term.  This can be checked once the Shashlik relvals are underway.

Tested with 13861 and used edmDumpEventContent to make sure the reco output file had the collections.

@boudoul, @hengne, @bachtis 
