### PR TITLE
Resolve Clang issues in DQMOffline/Trigger

### DIFF
--- a/DQMOffline/Trigger/interface/FSQDiJetAve.h
+++ b/DQMOffline/Trigger/interface/FSQDiJetAve.h
@@ -75,7 +75,6 @@ class FSQDiJetAve : public DQMEDAnalyzer {
       // ----------member data ---------------------------
       //
       triggerExpression::Data m_eventCache;
-      bool m_isSetup;
       bool m_useGenWeight;
       HLTConfigProvider m_hltConfig;
 

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -154,11 +154,14 @@ class HandlerTemplate: public BaseHandler {
                 booker.setCurrentFolder(m_dirname);
                 m_isSetup = true;
                 for (size_t i = 0; i < m_drawables.size(); ++i){
-                    std::string histoName = m_dqmhistolabel + "_" +m_drawables.at(i).getParameter<std::string>("name");
-                    std::string expression = m_drawables.at(i).getParameter<std::string>("expression");
-                    int bins =  m_drawables.at(i).getParameter<int>("bins");
-                    double rangeLow  =  m_drawables.at(i).getParameter<double>("min");
-                    double rangeHigh =  m_drawables.at(i).getParameter<double>("max");
+                    // XXX 'template' keyword (in 5 lines below) is required for LLVM/Clang (< pre-3.6, 65d8b4c)
+                    // The keyword informs the compiler name getParameter<>() should be looked up as a template
+                    // See PR22247: http://llvm.org/bugs/show_bug.cgi?id=22247
+                    std::string histoName = m_dqmhistolabel + "_" +m_drawables.at(i).template getParameter<std::string>("name");
+                    std::string expression = m_drawables.at(i).template getParameter<std::string>("expression");
+                    int bins =  m_drawables.at(i).template getParameter<int>("bins");
+                    double rangeLow  =  m_drawables.at(i).template getParameter<double>("min");
+                    double rangeHigh =  m_drawables.at(i).template getParameter<double>("max");
 
                     m_histos[histoName] =  booker.book1D(histoName, histoName, bins, rangeLow, rangeHigh);
                     StringObjectFunction<std::vector<TOutputCandidateType> > * func 

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -638,10 +638,9 @@ FSQDiJetAve::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   }
   
   //---------- triggerResults ----------
-  if(&m_triggerResults) {  
+  if(m_triggerResults.isValid()) {
     m_triggerNames = iEvent.triggerNames(*m_triggerResults);
-  } 
-  else {
+  } else {
     edm::LogError("FSQDiJetAve") << "TriggerResults not found";
     return;
   } 

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -564,8 +564,7 @@ typedef HandlerTemplate<reco::Track, int > RecoTrackCounter;
 //
 //################################################################################################
 FSQDiJetAve::FSQDiJetAve(const edm::ParameterSet& iConfig):
-  m_eventCache(iConfig.getParameterSet("triggerConfiguration") , consumesCollector()),
-  m_isSetup(false)
+  m_eventCache(iConfig.getParameterSet("triggerConfiguration") , consumesCollector())
 {
   m_useGenWeight = iConfig.getParameter<bool>("useGenWeight");
   if (m_useGenWeight) {


### PR DESCRIPTION
This is another round of fixes for `DQMOffline/Trigger`. Note that this package was already building fine under Clang at the end of November. Also fixing the package resulted in a bug report for Clang (details in commit and diff).

Build tested with GCC 4.9.1 and Clang pre-3.6 (`65d8b4c`) in DEVEL IB. 
