### PR TITLE
Resolve Clang issues in RecoHI/HiJetAlgos

### DIFF
--- a/RecoHI/HiJetAlgos/interface/UEParameters.h
+++ b/RecoHI/HiJetAlgos/interface/UEParameters.h
@@ -8,8 +8,6 @@ class UEParameters {
 private:
 	static const size_t nreduced_particle_flow_id = 3;
 	const std::vector<float> *v_;
-	int nn_;
-	int neta_;
 	boost::const_multi_array_ref<float, 4> *parameters_;
 
 public:

--- a/RecoHI/HiJetAlgos/src/UEParameters.cc
+++ b/RecoHI/HiJetAlgos/src/UEParameters.cc
@@ -1,7 +1,7 @@
 
 #include "RecoHI/HiJetAlgos/interface/UEParameters.h"
 
-UEParameters::UEParameters(const std::vector<float> *v, int nn, int neta) : v_(v), nn_(nn), neta_(neta){
+UEParameters::UEParameters(const std::vector<float> *v, int nn, int neta) : v_(v) {
   parameters_ = new boost::const_multi_array_ref<float, 4>(&(*v)[0], boost::extents[neta][nreduced_particle_flow_id][nn][2]);
 }
 

--- a/RecoHI/HiJetAlgos/src/VoronoiAlgorithm.cc
+++ b/RecoHI/HiJetAlgos/src/VoronoiAlgorithm.cc
@@ -174,6 +174,8 @@ namespace {
 
 	class problem_t {
 	public:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
 		static constexpr double infinity	= INFINITY;
 		// These are equivalent to the constants used by IBM ILOG
 		// CPLEX
@@ -183,6 +185,7 @@ namespace {
 		static const char equal			= 'E';
 		static const char greater_equal	= 'G';
 		static const char range			= 'R';
+#pragma clang diagnostic pop
 	protected:
 		bool _optimized;
 		bool _variable_named;
@@ -470,7 +473,10 @@ namespace {
 
 	class bpmpd_problem_t : public problem_t {
 	public:
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunused-const-variable"
 		static constexpr double infinity	= BPMPD_INFINITY_BOUND;
+#pragma clang diagnostic pop
 	protected:
 		double _objective_sense;
 		double _objective_value;

--- a/RecoHI/HiJetAlgos/src/VoronoiAlgorithm.cc
+++ b/RecoHI/HiJetAlgos/src/VoronoiAlgorithm.cc
@@ -1192,7 +1192,7 @@ namespace {
 						}
 					}
 
-					double interp;
+					double interp = 0;
 
 #ifdef STANDALONE
 					if (j == 0) {


### PR DESCRIPTION
The following patchset resolves a few Clang errors and warnings. Details are in commit messages.

In particularly give a look to 0b7b1d5b8e8d03f04d97958b3d89493b9d9f7361

Build tested with GCC 4.9.1 and Clang pre-3.6 (65d8b4c) in DEVEL IB. 
