### PR TITLE
fix clang errors and warnings in RecoTracker/TkDetLayers

### DIFF
--- a/RecoTracker/TkDetLayers/src/DiskSectorBounds.h
+++ b/RecoTracker/TkDetLayers/src/DiskSectorBounds.h
@@ -25,13 +25,15 @@ public:
    virtual float width()     const { return 2.f*theRmax*std::sin(thePhiExtH);}
    virtual float thickness() const { return theZmax-theZmin;}
  
+   
+   
    virtual bool inside( const Local3DPoint& p) const;
      
    virtual bool inside( const Local3DPoint& p, const LocalError& err, float scale) const;
  
-   virtual bool inside( const Local2DPoint& p, const LocalError& err) const {
-     return Bounds::inside(p,err);
-   }
+   //virtual bool inside( const Local2DPoint& p, const LocalError& err, float scale=1.f) const {
+   //  return Bounds::inside(p,err,scale);
+   //}
  
    virtual Bounds* clone() const { 
      return new DiskSectorBounds(*this);

--- a/RecoTracker/TkDetLayers/src/DiskSectorBounds.h
+++ b/RecoTracker/TkDetLayers/src/DiskSectorBounds.h
@@ -31,10 +31,6 @@ public:
      
    virtual bool inside( const Local3DPoint& p, const LocalError& err, float scale) const;
  
-   //virtual bool inside( const Local2DPoint& p, const LocalError& err, float scale=1.f) const {
-   //  return Bounds::inside(p,err,scale);
-   //}
- 
    virtual Bounds* clone() const { 
      return new DiskSectorBounds(*this);
    }

--- a/RecoTracker/TkDetLayers/src/PixelBladeBuilder.h
+++ b/RecoTracker/TkDetLayers/src/PixelBladeBuilder.h
@@ -17,6 +17,7 @@
  */
 
 
+template <class T>
 class PixelBladeBuilder {  
  public:
   PixelBladeBuilder(){};

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayerBuilder.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayerBuilder.h
@@ -17,6 +17,7 @@
  */
 
 
+template <class T1, class T2>
 class PixelForwardLayerBuilder {  
  public:
   PixelForwardLayerBuilder(){};
@@ -27,7 +28,7 @@ class PixelForwardLayerBuilder {
 };
 
 template <class T1, class T2>
-  ForwardDetLayer* PixelForwardLayerBuilder<T1,T2>::build(const GeometricDet* aPixelForwardLayer,
+ForwardDetLayer* PixelForwardLayerBuilder<T1,T2>::build(const GeometricDet* aPixelForwardLayer,
 							  const TrackerGeometry* theGeomDetGeometry) {
   std::vector<const GeometricDet*>  theGeometricPanels = aPixelForwardLayer->components();
   int panelsSize = theGeometricPanels.size();

--- a/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.h
+++ b/RecoTracker/TkDetLayers/src/PixelForwardLayerPhase1.h
@@ -12,6 +12,8 @@
  */
 
 
+#pragma GCC visibility push(hidden)
+
 class PixelForwardLayerPhase1 GCC11_FINAL : public ForwardDetLayer {
  public:
   PixelForwardLayerPhase1(std::vector<const Phase1PixelBlade*>& blades);
@@ -75,7 +77,7 @@ class PixelForwardLayerPhase1 GCC11_FINAL : public ForwardDetLayer {
   std::vector<float> theBinFinder_byR;
   std::vector<unsigned int> theBinFinder_byR_index;
   std::vector<unsigned int> theBinFinder_byR_nextindex;
-  bool useR;
+  // bool useR;
   std::vector<const GeometricSearchDet*> theComps;
   std::vector<const GeomDet*> theBasicComps;
 };


### PR DESCRIPTION
No clue how it was compiling under gcc
