### PR TITLE
Resolve Clang issues in HLTrigger/btau

### DIFF
--- a/HLTrigger/btau/src/ConeIsolationAlgorithm.h
+++ b/HLTrigger/btau/src/ConeIsolationAlgorithm.h
@@ -33,12 +33,10 @@ public:
 
  private:
   // algorithm parameters
-  int    m_nthTrack;
   int    m_cutPixelHits;
   int    m_cutTotalHits;
   double m_cutMaxTIP;
   double m_cutMinPt;
-  double m_cutMaxDecayLen;
   double m_cutMaxChiSquared;
   double matching_cone;
   double signal_cone;

--- a/HLTrigger/btau/src/HLTJetTagWithMatching.cc
+++ b/HLTrigger/btau/src/HLTJetTagWithMatching.cc
@@ -55,7 +55,7 @@ HLTJetTagWithMatching<T>::~HLTJetTagWithMatching()
 {
 }
 
-template<typename T> float HLTJetTagWithMatching<T>::findCSV(const typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection  & jetTags, float minDr=0.1 ){
+template<typename T> float HLTJetTagWithMatching<T>::findCSV(const typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection  & jetTags, float minDr){
          float tmpCSV = -20 ;
          for (reco::JetTagCollection::const_iterator jetb = jetTags.begin(); (jetb!=jetTags.end()); ++jetb) {
          float tmpDr = reco::deltaR(*jet,*(jetb->first));

--- a/HLTrigger/btau/src/HLTJetTagWithMatching.h
+++ b/HLTrigger/btau/src/HLTJetTagWithMatching.h
@@ -32,7 +32,7 @@ class HLTJetTagWithMatching : public HLTFilter {
   public:
     explicit HLTJetTagWithMatching(const edm::ParameterSet & config);
     ~HLTJetTagWithMatching();
-    static float findCSV(const  typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection & jetTags, float minDr);   
+    static float findCSV(const  typename std::vector<T>::const_iterator & jet, const reco::JetTagCollection & jetTags, float minDr=0.1);
     static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
     virtual bool hltFilter(edm::Event & event, const edm::EventSetup & setup, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
 


### PR DESCRIPTION
The patchset resolves 1 error and another 2 warnings while building with Clang.

Build tested with GCC 4.9.1 and Clang pre-3.6 (65d8b4c) in DEVEL IB. 
