### PR TITLE
Resolve Clang issues in DataFormats/Math

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -3,20 +3,46 @@
 
 #include<type_traits>
 
-typedef float  __attribute__( ( vector_size(  8 ) ) ) float32x2_t;
-typedef float  __attribute__( ( vector_size( 16 ) ) ) float32x4_t;
-typedef float  __attribute__( ( vector_size( 32 ) ) ) float32x8_t;
-typedef double __attribute__( ( vector_size( 16 ) ) ) float64x2_t;
-typedef double __attribute__( ( vector_size( 32 ) ) ) float64x4_t;
-typedef double __attribute__( ( vector_size( 64 ) ) ) float64x8_t;
+#ifdef __clang__
+#define VECTOR_EXT(N) __attribute__( ( ext_vector_type( N ) ) )
+#else
+#define VECTOR_EXT(N) __attribute__( ( vector_size( N ) ) )
+#endif
 
+typedef float  VECTOR_EXT(  8 ) float32x2_t;
+typedef float  VECTOR_EXT( 16 ) float32x4_t;
+typedef float  VECTOR_EXT( 32 ) float32x8_t;
+typedef double VECTOR_EXT( 16 ) float64x2_t;
+typedef double VECTOR_EXT( 32 ) float64x4_t;
+typedef double VECTOR_EXT( 64 ) float64x8_t;
 
 // template<typename T, int N> using ExtVec =  T __attribute__( ( vector_size( N*sizeof(T) ) ) );
 
 template<typename T, int N>
 struct ExtVecTraits {
-  typedef T __attribute__( ( vector_size( N*sizeof(T) ) ) ) type;
+//  typedef T __attribute__( ( vector_size( N*sizeof(T) ) ) ) type;
 };
+
+template<>
+struct ExtVecTraits<float, 2> {
+  typedef float VECTOR_EXT( 2*sizeof(float) ) type;
+};
+
+template<>
+struct ExtVecTraits<float, 4> {
+  typedef float VECTOR_EXT(4*sizeof(float)) type;
+};
+
+template<>
+struct ExtVecTraits<double, 2> {
+  typedef double VECTOR_EXT( 2*sizeof(double) ) type;
+};
+
+template<>
+struct ExtVecTraits<double, 4> {
+  typedef double VECTOR_EXT( 4*sizeof(double) ) type;
+};
+
 
 template<typename T, int N> using ExtVec =  typename ExtVecTraits<T,N>::type;
 
@@ -234,8 +260,8 @@ struct Rot2 {
 		 );
   }
 
-  constexpr Vec2<T> x() { return axis[0];}
-  constexpr Vec2<T> y() { return axis[1];}
+  constexpr Vec2<T> x() const { return axis[0];}
+  constexpr Vec2<T> y() const { return axis[1];}
   
   // toLocal...
   constexpr Vec2<T> rotate(Vec2<T> v) const {

--- a/DataFormats/Math/test/ExtVec_t.cpp
+++ b/DataFormats/Math/test/ExtVec_t.cpp
@@ -1,5 +1,5 @@
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
-#if GCC_PREREQUISITE(4,8,0) || defined(__clang__)
+#if GCC_PREREQUISITE(4,8,0)
 
 #include "DataFormats/Math/interface/ExtVec.h"
 

--- a/DataFormats/Math/test/eta_t.cpp
+++ b/DataFormats/Math/test/eta_t.cpp
@@ -1,7 +1,7 @@
 #pragma GCC diagnostic ignored "-Wformat"
 #include <iostream>
 #include <cmath>
-#include<cstdlib>
+#include <cstdlib>
 #include <cstdio>
 
 namespace almostEqualDetail {
@@ -28,7 +28,7 @@ inline int intDiff(float a, float b)
   // Make bInt lexicographically ordered as a twos-complement int
   fasi fb; fb.f = b;
   if (fb.i < 0) fb.i = 0x80000000 - fb.i;
-  return abs(fa.i - fb.i);
+  return std::abs(fa.i - fb.i);
 }
 
 
@@ -41,7 +41,7 @@ inline long long intDiff(double a, double b)
   // Make bInt lexicographically ordered as a twos-complement int
   dasi fb; fb.f = b;
   if (fb.i < 0) fb.i = 0x8000000000000000LL - fb.i;
-  return abs(fa.i - fb.i);
+  return std::abs(fa.i - fb.i);
 }
 
 template<typename T>
@@ -61,7 +61,6 @@ namespace {
 
   inline float eta3(float x, float y, float z) { float t(z/std::sqrt(x*x+y*y)); return ::asinhf(t);} 
   inline double eta3(double x, double y, double z) { double t(z/std::sqrt(x*x+y*y)); return ::asinh(t);} 
-  inline long double eta3(long double x, long double y, long double z) { long double t(z/std::sqrt(x*x+y*y)); return ::asinhl(t);} 
 
   
   void look(float x) {


### PR DESCRIPTION
This patchset resolves build errors and warnings with Clang compiler. Most of this was already available in CLANG IB (kudos to Giulio), but there was an issue where `Vec4F` and `Vec2D` were lowered to the same type. Most of this can be pulled out once Clang improves `vector_size` implementation.

The biggest issue is `constexpr` in the test. The test was disabled on Clang, but most likely will fail with GCC in future. C++ standard was updated and freedom to add `constexpr` to random functions in standard library were removed. Thus `constexpr double a = std::cos()` is not a valid code.

http://www.open-std.org/jtc1/sc22/wg21/docs/papers/2013/n3788.html#2013

Build tested with GCC 4.9.1 and Clang pre-3.6 (65d8b4c) in DEVEL IB. 
