### PR TITLE
Option to use old CPE error if charge exceeds one MIP - 73X

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
@@ -20,6 +20,10 @@ private:
   //Set to true if we are using the old error parameterization
   const bool useLegacyError;
 
+  //Clusters with charge/path > this cut will use old error parameterization
+  // (overridden by useLegacyError; negative value disables the cut)
+  const float maxChgOneMIP;
+
 public:  
   StripClusterParameterEstimator::LocalValues
   localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const;
@@ -36,6 +40,7 @@ public:
 			  const SiStripLatency& latency) 
   : StripCPE(conf, mag, geom, lorentz, backPlaneCorrection, confObj, latency )
   , useLegacyError(conf.existsAs<bool>("useLegacyError") ? conf.getParameter<bool>("useLegacyError") : true)
+  , maxChgOneMIP(conf.existsAs<float>("maxChgOneMIP") ? conf.getParameter<double>("maxChgOneMIP") : -6000.)
   {
     mLC_P[0] = conf.existsAs<double>("mLC_P0") ? conf.getParameter<double>("mLC_P0") : -.326;
     mLC_P[1] = conf.existsAs<double>("mLC_P1") ? conf.getParameter<double>("mLC_P1") :  .618;

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
@@ -17,4 +17,5 @@ StripCPEfromTrackAngleESProducer.parameters    = cms.PSet(
    mTEC_P0        = cms.double(-1.885),
    mTEC_P1        = cms.double( .471),
    useLegacyError = cms.bool(True),
+   maxChgOneMIP   = cms.double(-6000.)
 )


### PR DESCRIPTION
Since nobody else seems doing it, here is a backport to 73X of #6831, already merged in 74X

If useLegacyCPE is false and a positive value is given for maxChgOneMIP, ignore the merged status of the cluster and set the CPE error to the new value if chargePerCM is < maxChgOneMIP, else set the old value. This cut is more robust against pileup than the sensor occupancy cut used to flag a cluster as merged. We set the cut to -6000 in the config, where 6000 is a reasonable choice to turn on this selection.
