### PR TITLE
Temporarily disable edmCheckClassVersion

### DIFF
--- a/FWCore/Utilities/scripts/edmCheckClassVersion
+++ b/FWCore/Utilities/scripts/edmCheckClassVersion
@@ -1,4 +1,6 @@
 #!  /usr/bin/env python
+import sys
+sys.exit(0)
 import string
 from optparse import OptionParser
 


### PR DESCRIPTION
We would like to advance the ROOT6 tag to 6.2.03.  However, this badly breaks edmCheckClassVersion, and the fix is not trivial.
So this pull request disables edmCheckClassVersion, so that we can now go to 6.2.03.
The intent is to update and re-enable edmCheckClassVersion as soon as feasible.
Please merge this pull request as soon as convenient.
