### PR TITLE
PackedClusters for 74X to keep PFClusters in AOD

### DIFF
--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -15,6 +15,7 @@
 <use   name="CondFormats/L1TObjects"/>
 <use   name="DataFormats/L1Trigger"/>
 <use   name="DataFormats/HLTReco"/>
+<use   name="DataFormats/CaloRecHit"/>
 <use   name="boost"/>
 <use   name="rootrflx"/>
 <flags LCG_DICT_HEADER="classes_objects.h classes_trigger.h classes_user.h classes_other.h"/>

--- a/DataFormats/PatCandidates/interface/PackedCluster.h
+++ b/DataFormats/PatCandidates/interface/PackedCluster.h
@@ -1,0 +1,44 @@
+#ifndef __DataFormats_PatCandidates_PackedCluster_h__
+#define __DataFormats_PatCandidates_PackedCluster_h__
+
+
+//This class is designed to record basic information (et,eta,phi and seed detId about a CaloCluster
+//it has to be extremely lightweight for space reasons
+
+#include "DataFormats/DetId/interface/DetId.h"
+
+namespace reco {
+  class CaloCluster;
+}
+
+namespace pat {
+  class PackedCluster {
+    
+  public:
+    PackedCluster():
+      packedEt_(0),packedEta_(0),packedPhi_(0),
+      seedId_(0),
+      unpacked_(false),
+      unpackedEt_(0),unpackedEta_(0),unpackedPhi_(0){}
+    
+    PackedCluster(const reco::CaloCluster& clus);
+
+    void pack(bool unpackAfterwards=true);
+    void unpack()const;
+
+    float et()const{if(!unpacked_) unpack(); return unpackedEt_;}
+    float eta()const{if(!unpacked_) unpack(); return unpackedEta_;}
+    float phi()const{if(!unpacked_) unpack(); return unpackedPhi_;}
+    DetId seedId()const{return seedId_;}
+
+  private:
+    uint16_t packedEt_, packedEta_,packedPhi_;
+    DetId seedId_;
+    mutable bool unpacked_;
+    mutable float unpackedEt_, unpackedEta_,unpackedPhi_;
+
+   
+  };
+}
+
+#endif

--- a/DataFormats/PatCandidates/src/PackedCluster.cc
+++ b/DataFormats/PatCandidates/src/PackedCluster.cc
@@ -1,0 +1,33 @@
+
+#include "DataFormats/PatCandidates/interface/PackedCluster.h"
+
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/PatCandidates/interface/libminifloat.h"
+
+pat::PackedCluster::PackedCluster(const reco::CaloCluster& clus):
+  packedEt_(0),packedEta_(0),packedPhi_(0),
+  seedId_(clus.seed()),
+  unpacked_(true),
+  unpackedEt_(sin(clus.position().theta())*clus.energy()),
+  unpackedEta_(clus.eta()),
+  unpackedPhi_(clus.phi())
+{
+  pack();
+}
+
+void pat::PackedCluster::pack(bool unpackAfterwards)
+{  
+  packedEt_  =  MiniFloatConverter::float32to16(unpackedEt_);
+  packedEta_ =  int16_t(std::round(unpackedEta_/6.0f*std::numeric_limits<int16_t>::max()));
+  packedPhi_ =  int16_t(std::round(unpackedPhi_/3.2f*std::numeric_limits<int16_t>::max()));
+  if(unpackAfterwards) unpack();
+}
+
+void pat::PackedCluster::unpack()const
+{
+  unpackedEt_ = MiniFloatConverter::float16to32(packedEt_);
+  unpackedEta_ = int16_t(packedEta_)*6.0f/std::numeric_limits<int16_t>::max();
+  unpackedPhi_ = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max();
+  unpacked_=true;
+  
+}

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -239,6 +239,16 @@
     ]]>
   </ioread>
 
+ <class name="pat::PackedCluster">
+    <field name="unpackedEt_" transient="true" />
+    <field name="unpackedEta_" transient="true" />  
+    <field name="unpackedPhi_" transient="true" />
+    <field name="unpacked_" transient="true" />
+  </class>
+  <ioread sourceClass="pat::PackedCluster"  version="[1-]" targetClass="pat::PackedCluster" source="" target="unpacked_">
+    <![CDATA[unpacked_ = false;
+    ]]>
+  </ioread>
 
   <!-- PAT Object Ptrs  -->
   <class name="edm::Ptr<pat::Electron>" />
@@ -264,6 +274,7 @@
   <class name="std::vector<pat::Conversion>" />
   <class name="std::vector<pat::PackedCandidate>"/>
   <class name="std::vector<pat::PackedGenParticle>"/>
+  <class name="std::vector<pat::PackedCluster>"/>
 
   <!-- PAT Object Collection Iterators -->
   <class name="std::vector<pat::Electron>::const_iterator" />
@@ -298,7 +309,7 @@
   <class name="edm::Wrapper<std::vector<pat::Conversion> >" />
   <class name="edm::Wrapper<std::vector<pat::PackedCandidate> >"/>
   <class name="edm::Wrapper<std::vector<pat::PackedGenParticle> >"/>
-
+  <class name="edm::Wrapper<std::vector<pat::PackedCluster> >"/>
   <!-- PAT Object References -->
   <class name="pat::ElectronRef" />
   <class name="pat::MuonRef" />

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -18,6 +18,7 @@
 #include "DataFormats/PatCandidates/interface/Conversion.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
+#include "DataFormats/PatCandidates/interface/PackedCluster.h"
 
 namespace DataFormats_PatCandidates {
   struct dictionaryobjects {
@@ -38,6 +39,7 @@ namespace DataFormats_PatCandidates {
   std::vector<pat::Conversion>::const_iterator      v_p_c_ci;
   std::vector<pat::PackedCandidate>::const_iterator      v_p_pc_ci;
   std::vector<pat::PackedGenParticle>::const_iterator      v_p_pgc_ci;
+  std::vector<pat::PackedCluster>::const_iterator      v_p_pcl_ci;
 
   /*   PAT Object Collection Wrappers   */
   edm::Wrapper<std::vector<pat::Electron> >	    w_v_p_e;
@@ -55,7 +57,8 @@ namespace DataFormats_PatCandidates {
   edm::Wrapper<std::vector<pat::Conversion> >       w_v_p_c;
   edm::Wrapper<std::vector<pat::PackedCandidate> >       w_v_pc_c;
   edm::Wrapper<std::vector<pat::PackedGenParticle> >       w_v_pgc_c;
-
+  edm::Wrapper<std::vector<pat::PackedCluster> >  w_v_pcl_c;
+  
   /*   PAT Object References   */
   pat::ElectronRef	    p_r_e;
   pat::MuonRef	            p_r_mu;
@@ -87,6 +90,7 @@ namespace DataFormats_PatCandidates {
   edm::Wrapper<pat::ConversionRefVector>        p_rv_c;
   edm::Wrapper<pat::PackedCandidateRefVector>        p_rv_pc;
   edm::Wrapper<pat::PackedGenParticleRefVector>        p_rv_pcg;
+
 
   /*   RefToBase<Candidate> from PATObjects   */
     /*   With direct Holder   */

--- a/PhysicsTools/PatAlgos/plugins/PATPackedClusterProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedClusterProducer.cc
@@ -68,9 +68,7 @@ void pat::PATPackedClusterProducer::produce(edm::Event& iEvent, const edm::Event
   std::auto_ptr< std::vector<pat::PackedCluster> > outputClustersPtr( new std::vector<pat::PackedCluster> );
   if(inputPFClusters.isValid()){
     for(const auto& clus : *inputPFClusters){
-      //     std::cout <<"clus before "<<clus.energy()*sin(clus.position().theta())<<" eta "<<clus.eta()<<" phi "<<clus.phi()<<std::endl;
       if(passSelection_(clus,eles,phos)) outputClustersPtr->push_back(clus);
-      //  std::cout <<"clus after "<<outputClustersPtr->back().et()<<" eta "<<outputClustersPtr->back().eta()<<" phi "<<outputClustersPtr->back().phi()<<std::endl;
     }
   }else{
     for(const auto& clus : *inputCaloClusters){

--- a/PhysicsTools/PatAlgos/plugins/PATPackedClusterProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedClusterProducer.cc
@@ -11,6 +11,11 @@
 #include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+#include "DataFormats/EgammaCandidates/interface/Photon.h"
+#include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
+#include "DataFormats/Math/interface/deltaR.h"
 
 namespace pat {
   class PATPackedClusterProducer : public edm::EDProducer {
@@ -21,14 +26,23 @@ namespace pat {
     virtual void produce(edm::Event&, const edm::EventSetup&);
  
   private:
+    bool passSelection_(const reco::CaloCluster& clus,edm::Handle<reco::GsfElectronCollection> eles,edm::Handle<reco::PhotonCollection> phos);
+    
     edm::EDGetTokenT<reco::PFClusterCollection>  inputPFClustersToken_;
     edm::EDGetTokenT<reco::CaloClusterCollection>  inputCaloClustersToken_;
+    edm::EDGetTokenT<reco::PhotonCollection>  phoToken_;
+    edm::EDGetTokenT<reco::GsfElectronCollection>  eleToken_;
+    const float maxDeltaR_;
+
   };
 }
 
 pat::PATPackedClusterProducer::PATPackedClusterProducer(const edm::ParameterSet& iConfig) :
   inputPFClustersToken_(consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("inputClusters"))),
-  inputCaloClustersToken_(consumes<reco::CaloClusterCollection>(iConfig.getParameter<edm::InputTag>("inputClusters")))  
+  inputCaloClustersToken_(consumes<reco::CaloClusterCollection>(iConfig.getParameter<edm::InputTag>("inputClusters"))),
+  phoToken_(consumes<reco::PhotonCollection>(iConfig.getParameter<edm::InputTag>("phos"))),
+  eleToken_(consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("eles"))),
+  maxDeltaR_(iConfig.getParameter<double>("maxDR"))
 {
   produces< std::vector<pat::PackedCluster> > ();
 }
@@ -44,12 +58,24 @@ void pat::PATPackedClusterProducer::produce(edm::Event& iEvent, const edm::Event
 
   edm::Handle<reco::CaloClusterCollection> inputCaloClusters;
   iEvent.getByToken(inputCaloClustersToken_,inputCaloClusters);
-  
+
+  edm::Handle<reco::PhotonCollection> phos;
+  iEvent.getByToken(phoToken_,phos);
+ 
+  edm::Handle<reco::GsfElectronCollection> eles;
+  iEvent.getByToken(eleToken_,eles);
+
   std::auto_ptr< std::vector<pat::PackedCluster> > outputClustersPtr( new std::vector<pat::PackedCluster> );
   if(inputPFClusters.isValid()){
-    for(const auto& clus : *inputPFClusters) outputClustersPtr->push_back(clus);
+    for(const auto& clus : *inputPFClusters){
+      //     std::cout <<"clus before "<<clus.energy()*sin(clus.position().theta())<<" eta "<<clus.eta()<<" phi "<<clus.phi()<<std::endl;
+      if(passSelection_(clus,eles,phos)) outputClustersPtr->push_back(clus);
+      //  std::cout <<"clus after "<<outputClustersPtr->back().et()<<" eta "<<outputClustersPtr->back().eta()<<" phi "<<outputClustersPtr->back().phi()<<std::endl;
+    }
   }else{
-    for(const auto& clus : *inputCaloClusters) outputClustersPtr->push_back(clus);
+    for(const auto& clus : *inputCaloClusters){
+      if(passSelection_(clus,eles,phos)) outputClustersPtr->push_back(clus);
+    } 
   }
  
   iEvent.put(outputClustersPtr);
@@ -57,7 +83,24 @@ void pat::PATPackedClusterProducer::produce(edm::Event& iEvent, const edm::Event
 
 }
 
-
+bool pat::PATPackedClusterProducer::passSelection_(const reco::CaloCluster& clus,edm::Handle<reco::GsfElectronCollection> eles,edm::Handle<reco::PhotonCollection> phos)
+{
+  if(maxDeltaR_<0) return true;
+  const float maxDR2 =maxDeltaR_*maxDeltaR_;
+  const float clusEta = clus.eta();
+  const float clusPhi = clus.phi();
+  if(eles.isValid()){
+    for(const auto& ele : *eles){
+      if(reco::deltaR2(ele.superCluster()->eta(),ele.superCluster()->phi(),clusEta,clusPhi)< maxDR2) return true;
+    }
+  }
+  if(phos.isValid()){
+    for(const auto& pho : *phos){
+      if(reco::deltaR2(pho.superCluster()->eta(),pho.superCluster()->phi(),clusEta,clusPhi)< maxDR2) return true;
+    }
+  }
+  return false;
+}
 
 using pat::PATPackedClusterProducer;
 #include "FWCore/Framework/interface/MakerMacros.h"

--- a/PhysicsTools/PatAlgos/plugins/PATPackedClusterProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedClusterProducer.cc
@@ -1,0 +1,64 @@
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+
+#include "DataFormats/PatCandidates/interface/PackedCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloCluster.h"
+#include "DataFormats/CaloRecHit/interface/CaloClusterFwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+
+namespace pat {
+  class PATPackedClusterProducer : public edm::EDProducer {
+  public:
+    explicit PATPackedClusterProducer(const edm::ParameterSet&);
+    ~PATPackedClusterProducer();
+    
+    virtual void produce(edm::Event&, const edm::EventSetup&);
+ 
+  private:
+    edm::EDGetTokenT<reco::PFClusterCollection>  inputPFClustersToken_;
+    edm::EDGetTokenT<reco::CaloClusterCollection>  inputCaloClustersToken_;
+  };
+}
+
+pat::PATPackedClusterProducer::PATPackedClusterProducer(const edm::ParameterSet& iConfig) :
+  inputPFClustersToken_(consumes<reco::PFClusterCollection>(iConfig.getParameter<edm::InputTag>("inputClusters"))),
+  inputCaloClustersToken_(consumes<reco::CaloClusterCollection>(iConfig.getParameter<edm::InputTag>("inputClusters")))  
+{
+  produces< std::vector<pat::PackedCluster> > ();
+}
+
+pat::PATPackedClusterProducer::~PATPackedClusterProducer() {}
+
+void pat::PATPackedClusterProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  
+  edm::Handle<reco::PFClusterCollection> inputPFClusters;
+  iEvent.getByToken(inputPFClustersToken_,inputPFClusters);
+
+  edm::Handle<reco::CaloClusterCollection> inputCaloClusters;
+  iEvent.getByToken(inputCaloClustersToken_,inputCaloClusters);
+  
+  std::auto_ptr< std::vector<pat::PackedCluster> > outputClustersPtr( new std::vector<pat::PackedCluster> );
+  if(inputPFClusters.isValid()){
+    for(const auto& clus : *inputPFClusters) outputClustersPtr->push_back(clus);
+  }else{
+    for(const auto& clus : *inputCaloClusters) outputClustersPtr->push_back(clus);
+  }
+ 
+  iEvent.put(outputClustersPtr);
+ 
+
+}
+
+
+
+using pat::PATPackedClusterProducer;
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PATPackedClusterProducer);


### PR DESCRIPTION
Dear All, 

@lgray  @matteosan1 

I decided the best way to alert folks with via this pull request rather than emailing as it ensures I get the right people. E/gamma is already aware about this. Currently in the AOD, my understanding is that we do not save CaloTowers or HcalRecHits. Nor do we store the PFClusters. Therefore we have no unbiased or minimally biased HCAL collection. There is a need to have this in place for studies. 

Right now, I would like the PFClusters accessable at the AOD level. This is useful for isolation development and debugging. Indications are that PF cluster based isolation is promising (https://indico.cern.ch/event/305124/contribution/3/material/slides/1.pdf). It is also what is used for the HLT. To continue to develop isolation and also to understand the HLT isolation, we need PFClusters in the AOD.  It is also useful for H/E studies.  

I understand that these were dropped due to space. For isolation studies and H/E , we can get away with just having the et/eta/phi and detId of the seed cluster. So I have developed a packed format ala the mini-aod (not this is for AOD not miniAOD) for Clusters. I put it in with the pat::PackedCandidate as it reuses the packer they use which is in that package. 

I then tested the size on ttbar events (/store/relval/CMSSW_7_4_0_pre2/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_73_V7-v1/00000/12EFC87E-C29A-E411-ABAA-003048FFD79C.root) and found following sizes in bytes from edmEventSize:
patPackedClusters_packedPFClustersECAL__AODTest. 6896.77 4042.27
patPackedClusters_packedPFClustersHCAL__AODTest. 3433.81 1911.33

So we can store all PF clusters in 6Kb per event. If this is a problem, we can filter based on gedGsfElectrons and gedPhotons with DR<0.5. This reduces the event size to 
patPackedClusters_packedPFClustersECAL__AODTest. 1092.29 662.26
patPackedClusters_packedPFClustersHCAL__AODTest. 398.37 253.17

which is less than a 1kb compressed.  Note, I think the ECAL ones might even be already in the AOD but its not quite clear to me if they are. Any clarifications from experts would be useful here. Regardless, I'm almost fully certain HCAL are not. 

I would like to have this information in the AOD, what steps should I take to ensure that this happens

Thanks,
Sam
