### PR TITLE
CondTools/Ecal: drop VLA of non-POD type

### DIFF
--- a/CondTools/Ecal/src/EcalPulseCovariancesXMLTranslator.cc
+++ b/CondTools/Ecal/src/EcalPulseCovariancesXMLTranslator.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <sstream>
 #include <fstream>
+#include <vector>
 #include <xercesc/dom/DOMNode.hpp>
 #include <xercesc/dom/DOM.hpp>
 #include <xercesc/parsers/XercesDOMParser.hpp>
@@ -53,7 +54,7 @@ int  EcalPulseCovariancesXMLTranslator::readXML(const std::string& filename,
     DetId detid = readCellId(dynamic_cast<DOMElement*>(cellnode));
     //    std::cout << " readCell Id Channel " << chan << " tag " << mean12_tag << std::endl;
 
-    std::string pulsecov_tag[int(std::pow(EcalPulseShape::TEMPLATESAMPLES,2))];
+    std::vector<std::string> pulsecov_tag(static_cast<size_t>(std::pow(EcalPulseShape::TEMPLATESAMPLES,2)));
     for(int k=0; k<std::pow(EcalPulseShape::TEMPLATESAMPLES,2); ++k) {
       int i = k/EcalPulseShape::TEMPLATESAMPLES;
       int j = k%EcalPulseShape::TEMPLATESAMPLES;
@@ -107,7 +108,7 @@ std::string EcalPulseCovariancesXMLTranslator::dumpXML(const EcalCondHeader& hea
     
   DOMElement* root = doc->getDocumentElement();
 
-  std::string pulsecov_tag[int(std::pow(EcalPulseShape::TEMPLATESAMPLES,2))];
+  std::vector<std::string> pulsecov_tag(static_cast<size_t>(std::pow(EcalPulseShape::TEMPLATESAMPLES,2)));
   for(int k=0; k<std::pow(EcalPulseShape::TEMPLATESAMPLES,2); ++k) {
     int i = k/EcalPulseShape::TEMPLATESAMPLES;
     int j = k%EcalPulseShape::TEMPLATESAMPLES;


### PR DESCRIPTION
This is required for Clang. This GCC and C99 extension is not allowed in
C++. Clang has only minimal support.

From Clang documentation:

```
The element type of a variable length array must be a POD ("plain old
data") type, which means that it cannot have any user-declared
constructors or destructors, any base classes, or any members of non-POD
type. All C types are POD types.
```

The patch replaces non-POD VLAs with `std::vector` with default-inserted
`std::string` instances.

We also could create an array in heap. That would work also.

Please review and test the changes.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
