### PR TITLE
New CPE for 1 MIP clusters (default off)

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/StripCPEfromTrackAngle.h
@@ -20,6 +20,10 @@ private:
   //Set to true if we are using the old error parameterization
   const bool useLegacyError;
 
+  //Clusters with charge/path > this cut will use old error parameterization
+  // (overridden by useLegacyError; negative value disables the cut)
+  const float maxChgOneMIP;
+
 public:  
   StripClusterParameterEstimator::LocalValues
   localParameters( const SiStripCluster&, const GeomDetUnit&, const LocalTrajectoryParameters&) const;
@@ -36,6 +40,7 @@ public:
 			  const SiStripLatency& latency) 
   : StripCPE(conf, mag, geom, lorentz, backPlaneCorrection, confObj, latency )
   , useLegacyError(conf.existsAs<bool>("useLegacyError") ? conf.getParameter<bool>("useLegacyError") : true)
+  , maxChgOneMIP(conf.existsAs<float>("maxChgOneMIP") ? conf.getParameter<double>("maxChgOneMIP") : -6000.)
   {
     mLC_P[0] = conf.existsAs<double>("mLC_P0") ? conf.getParameter<double>("mLC_P0") : -.326;
     mLC_P[1] = conf.existsAs<double>("mLC_P1") ? conf.getParameter<double>("mLC_P1") :  .618;

--- a/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/StripCPEfromTrackAngle_cfi.py
@@ -17,4 +17,5 @@ StripCPEfromTrackAngleESProducer.parameters    = cms.PSet(
    mTEC_P0        = cms.double(-1.885),
    mTEC_P1        = cms.double( .471),
    useLegacyError = cms.bool(True),
+   maxChgOneMIP   = cms.double(-6000.)
 )

--- a/RecoLocalTracker/SiStripRecHitConverter/python/customiseNewStripCPE.py
+++ b/RecoLocalTracker/SiStripRecHitConverter/python/customiseNewStripCPE.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseNewStripCPE(process):
+    process.StripCPEfromTrackAngleESProducer.parameters.useLegacyError = False
+    process.StripCPEfromTrackAngleESProducer.parameters.maxChgOneMIP = 6000.
+
+    return process


### PR DESCRIPTION
Back port to 7_3_X new CPE for clusters passing a cut on chargePerCM.  Default is not activated.  New customize py will activate.
