### PR TITLE
Remove unused unneeded function

### DIFF
--- a/FWCore/Utilities/interface/FunctionWithDict.h
+++ b/FWCore/Utilities/interface/FunctionWithDict.h
@@ -50,43 +50,4 @@ public:
 
 } // namespace edm
 
-#include "FWCore/Utilities/interface/ObjectWithDict.h"
-#include "FWCore/Utilities/interface/TypeWithDict.h"
-
-namespace edm {
-
-/// Call a static function of class theType, with a return
-/// value of type T, by name with no arguments.
-template<typename T>
-inline
-void
-invokeByName(T& retval, TypeWithDict const& theType, std::string const& name)
-{
-  if (!bool(theType)) {
-    fprintf(stderr, "FunctionWithDict: invokeByName<%s>: "
-            "Passed type is invalid!\n", typeid(T).name());
-    abort();
-  }
-  FunctionWithDict func = theType.functionMemberByName(name);
-  if (!bool(func)) {
-    fprintf(stderr, "FunctionWithDict: invokeByName<%s>: "
-            "Could not find function named '%s' in type '%s'\n",
-            typeid(T).name(), name.c_str(), theType.name().c_str());
-    abort();
-  }
-  if (func.functionParameterSize(true) != 0) {
-    fprintf(stderr, "FunctionWithDict: invokeByName<%s>: "
-            "function '%s' in type '%s' should have zero "
-            "parameters, but has %lu parameters instead!\n",
-            typeid(T).name(), name.c_str(), theType.name().c_str(),
-            func.functionParameterSize(true));
-    abort();
-    return;
-  }
-  ObjectWithDict retobj(typeid(T), &retval);
-  func.invoke(&retobj);
-}
-
-} // namespace edm
-
 #endif // FWCore_Utilities_FunctionWithDict_h


### PR DESCRIPTION
The function "invokeByName()" is no longer used.  Also, it is not needed because it duplicates functionality provided by other functions. So, this pull request removes the function.
Please merge this trivial request as soon as convenient.
