### PR TITLE
Avoid some unnecessary memory allocations

### DIFF
--- a/DataFormats/Common/interface/RefVectorIterator.h
+++ b/DataFormats/Common/interface/RefVectorIterator.h
@@ -38,9 +38,18 @@ namespace edm {
       key_type const& key = iter_[n];
       return value_type(product_, key);
     }
-    std::auto_ptr<value_type> operator->() const {
+
+    class RefProxy {
+    public:
+      RefProxy(value_type const& ref) : ref_(ref) { }
+      value_type* operator->() { return &ref_; }
+    private:
+      value_type ref_;
+    };
+
+    RefProxy operator->() const {
       key_type const& key = *iter_;
-      return std::auto_ptr<value_type>(new value_type(product_, key));
+      return RefProxy(value_type(product_, key));
     }
     iterator & operator++() {++iter_; return *this;}
     iterator & operator--() {--iter_; return *this;}

--- a/DataFormats/Common/interface/RefVectorIterator.h
+++ b/DataFormats/Common/interface/RefVectorIterator.h
@@ -42,7 +42,7 @@ namespace edm {
     class RefProxy {
     public:
       RefProxy(value_type const& ref) : ref_(ref) { }
-      value_type* operator->() { return &ref_; }
+      value_type const* operator->() const { return &ref_; }
     private:
       value_type ref_;
     };

--- a/DataFormats/Common/test/RefVector_t.cpp
+++ b/DataFormats/Common/test/RefVector_t.cpp
@@ -1,5 +1,4 @@
-#include <map>
-#include <string>
+#include <vector>
 
 #include "Utilities/Testing/interface/CppUnit_testdriver.icpp"
 #include "cppunit/extensions/HelperMacros.h"
@@ -10,7 +9,7 @@
 class TestRefVector: public CppUnit::TestFixture
 {
   CPPUNIT_TEST_SUITE(TestRefVector);
-  CPPUNIT_TEST(map_string_to_double);
+  CPPUNIT_TEST(testIteration);
   CPPUNIT_TEST_SUITE_END();
 
  public:
@@ -19,30 +18,47 @@ class TestRefVector: public CppUnit::TestFixture
   void setUp() {}
   void tearDown() {}
 
-  void map_string_to_double();
+  void testIteration();
 
  private:
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(TestRefVector);
 
-void TestRefVector::map_string_to_double()
+void TestRefVector::testIteration()
 {
-  typedef std::map<std::string, double> product_t;
-  typedef edm::Ref<product_t>           ref_t;
-  typedef edm::RefVector<product_t>     refvec_t;
+  typedef std::vector<double> product_t;
+  typedef edm::Ref<product_t> ref_t;
+  typedef edm::RefVector<product_t> refvec_t;
   
   product_t  product;
-  product["one"]  = 1.0;
-  product["half"] = 0.5;
-  product["two"]  = 2.0;
-  CPPUNIT_ASSERT(product.size() == 3);
-
-  ref_t    ref;
+  product.push_back(1.0);
+  product.push_back(0.5);
+  product.push_back(2.0);
 
   refvec_t  refvec;
   CPPUNIT_ASSERT(refvec.size() == 0);
   CPPUNIT_ASSERT(refvec.empty());
 
+  ref_t    ref0(edm::ProductID(1, 1), &product[0], 0, &product);
+  refvec.push_back(ref0);
 
+  ref_t    ref1(edm::ProductID(1, 1), &product[1], 1, &product);
+  refvec.push_back(ref1);
+
+  ref_t    ref2(edm::ProductID(1, 1), &product[2], 2, &product);
+  refvec.push_back(ref2);
+
+  auto iter = refvec.begin();
+
+  CPPUNIT_ASSERT(iter->id() == edm::ProductID(1,1) && iter->key() == 0 && *(iter->get()) == 1.0);
+  ++iter;
+
+  CPPUNIT_ASSERT(iter->id() == edm::ProductID(1,1) && iter->key() == 1 && *(iter->get()) == 0.5);
+  ++iter;
+
+  CPPUNIT_ASSERT(iter->id() == edm::ProductID(1,1) && iter->key() == 2 && *(iter->get()) == 2.0);
+  ++iter;
+
+  CPPUNIT_ASSERT(iter == refvec.end());
 }


### PR DESCRIPTION
In RefVectorIterator::operator->() avoid
some unnecessary calls to new that allocate
memory by returning by value a proxy to
a Ref instead of an auto_ptr to a Ref.
