### PR TITLE
Change all calls to TrackExtra::add to TrackExtra::setHits

### DIFF
--- a/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
+++ b/CommonTools/RecoAlgos/interface/GsfElectronSelector.h
@@ -62,10 +62,13 @@ namespace helper {
 						  trk.seedDirection() ) );
 	  selGsfTrackExtras_->push_back( GsfTrackExtra( *(trk.gsfExtra()) ) );
   	  TrackExtra & tx = selTrackExtras_->back();
+          unsigned int nHitsToAdd = 0;
 	  for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
 	    selHits_->push_back( (*hit)->clone() );
-	    tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
+            ++nHitsToAdd;
 	  }
+          tx.setHits( rHits, hidx, nHitsToAdd );
+          hidx += nHitsToAdd;
  	  trk.setGsfExtra( GsfTrackExtraRef( rGsfTrackExtras, tidx ) ); 
  	  trk.setExtra( TrackExtraRef( rTrackExtras, tidx ++ ) ); 
 	} 

--- a/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/TrackFullCloneSelectorBase.h
@@ -98,10 +98,12 @@ private:
           selTracks_->back().setExtra( TrackExtraRef( rTrackExtras, selTrackExtras_->size() - 1) );
           TrackExtra & tx = selTrackExtras_->back();
           // TrackingRecHits
+          auto const firstHitIndex = selHits_->size();
           for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
               selHits_->push_back( (*hit)->clone() );
-              tx.add( TrackingRecHitRef( rHits, selHits_->size() - 1) );
           }
+          tx.setHits( rHits, firstHitIndex, selHits_->size() - firstHitIndex );
+
           if (copyTrajectories_) {
               goodTracks[current] = reco::TrackRef(rTracks, selTracks_->size() - 1);
           }

--- a/CommonTools/RecoAlgos/src/MuonSelector.cc
+++ b/CommonTools/RecoAlgos/src/MuonSelector.cc
@@ -81,16 +81,19 @@ namespace helper
 
 	TrackExtra & tx = selTracksExtras_->back();
 
+        auto const firstHitIndex = hidx_;
+        unsigned int nHitsAdded = 0;
 	for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd();
 	     ++ hit, ++ hidx_) {
   	  selTracksHits_->push_back( (*hit)->clone() );
           TrackingRecHit * newHit = & (selTracksHits_->back());
-	  tx.add( TrackingRecHitRef( rHits_, hidx_ ) );
+          ++nHitsAdded;
 	  if (cloneClusters() && newHit->isValid()
 	      && ((*hit)->geographicalId().det() == DetId::Tracker)) {
 	    clusterStorer_.addCluster( *selTracksHits_, hidx_ );
 	  }
 	} // end of for loop over tracking rec hits on this track
+        tx.setHits( rHits_, firstHitIndex, nHitsAdded );
 	
 	trk.setExtra( TrackExtraRef( rTrackExtras_, idx_ ++ ) );
 
@@ -109,17 +112,21 @@ namespace helper
 						trk.outerStateCovariance(), trk.outerDetId(),
 						trk.innerStateCovariance(), trk.innerDetId(), trk.seedDirection() ) );
 	TrackExtra & tx = selGlobalMuonTracksExtras_->back();
+        auto const firstHitIndex = higbdx_;
+        unsigned int nHitsAdded = 0;
 	for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd();
 	     ++ hit, ++ higbdx_) {
             selGlobalMuonTracksHits_->push_back( (*hit)->clone() );
             TrackingRecHit * newHit = & (selGlobalMuonTracksHits_->back()); 
-            tx.add( TrackingRecHitRef( rGBHits_, higbdx_ ) );
+            ++nHitsAdded;
 	    if (cloneClusters() && newHit->isValid()
 		&& ((*hit)->geographicalId().det() == DetId::Tracker)) {
 	      clusterStorer_.addCluster( *selGlobalMuonTracksHits_, higbdx_ );
 	  }
 
 	}
+        tx.setHits( rGBHits_, firstHitIndex, nHitsAdded );
+
 	trk.setExtra( TrackExtraRef( rGBTrackExtras_, igbdx_ ++ ) );
 
 	} // GB trkRef.isNonnull()
@@ -136,10 +143,14 @@ namespace helper
 						trk.outerStateCovariance(), trk.outerDetId(),
 						trk.innerStateCovariance(), trk.innerDetId(), trk.seedDirection() ) );
 	TrackExtra & tx = selStandAloneTracksExtras_->back();
+        auto const firstHitIndex = hisadx_;
+        unsigned int nHitsAdded = 0;
 	for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
 	  selStandAloneTracksHits_->push_back( (*hit)->clone() );
-	  tx.add( TrackingRecHitRef( rSAHits_, hisadx_ ++ ) );
+          ++nHitsAdded;
+          hisadx_ ++;
 	}
+        tx.setHits( rSAHits_, firstHitIndex, nHitsAdded );
 	trk.setExtra( TrackExtraRef( rSATrackExtras_, isadx_ ++ ) );
 
 	} // SA trkRef.isNonnull()

--- a/CommonTools/RecoAlgos/src/TrackSelector.cc
+++ b/CommonTools/RecoAlgos/src/TrackSelector.cc
@@ -36,12 +36,14 @@ namespace helper
 					    trk.innerStateCovariance(), trk.innerDetId(),
 					    trk.seedDirection() ) );
     TrackExtra & tx = selTrackExtras_->back();
+    auto const firstHitIndex = hidx_;
+    unsigned int nHitsAdded = 0;
     for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd();
 	 ++ hit, ++ hidx_ ) {
 
         selHits_->push_back( (*hit)->clone() );
         TrackingRecHit * newHit = & (selHits_->back());
-        tx.add( TrackingRecHitRef( rHits_, hidx_ ) );
+        ++nHitsAdded;
 
         //--- Skip the rest for this hit if we don't want to clone the cluster.
         //--- The copy constructer in the rec hit will copy the link properly.
@@ -50,6 +52,8 @@ namespace helper
 	  clusterStorer_.addCluster( *selHits_, hidx_ );
         }
     } // end of for loop over tracking rec hits on this track
+    tx.setHits( rHits_, firstHitIndex, nHitsAdded );
+
   } // end of track, and function
 
 

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -30,17 +30,6 @@ public:
         m_firstHit =firstH;  m_nHits=nH;
     }
 
-    /// add a reference to a RecHit
-    void add(const TrackingRecHitRef &ref) {
-      m_hitCollection.pushBackItem(ref.refCore(), true);
-      if (m_nHits==0) {
-        m_firstHit = ref.key();
-      }
-      assert(m_nHits== ref.key()-m_firstHit);
-      ++m_nHits;   
-    }
-
-
     unsigned int firstRecHit() const {
       return m_firstHit;
     }

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -152,7 +152,8 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   }
   
   edm::OrphanHandle <TrackingRecHitCollection> ohRH = e.put( recHits );
-  
+  edm::RefProd<TrackingRecHitCollection> ohRHProd(ohRH);
+
   for (int k = 0; k < nTracks; ++k) {
 
     // reco::TrackExtra* theTrackExtra = new reco::TrackExtra();
@@ -160,12 +161,9 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     
     //fill the TrackExtra with TrackingRecHitRef
     // unsigned int nHits = tracks->at(k).numberOfValidHits();
-    unsigned nHits = 3; // We are dealing with triplets!
-    for(unsigned int i = 0; i < nHits; ++i) {
-      theTrackExtra.add(TrackingRecHitRef(ohRH,cc++));
-      //theTrackExtra->add(TrackingRecHitRef(ohRH,cc));
-      //cc++;
-    }
+    const unsigned nHits = 3; // We are dealing with triplets!
+    theTrackExtra.setHits( ohRHProd, cc, nHits);
+    cc += nHits;
     
     trackExtras->push_back(theTrackExtra);
     //trackExtras->push_back(*theTrackExtra);

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -97,10 +97,11 @@ template<class T> void RecoTrackAccumulator::accumulateEvent(const T& e, edm::Ev
       //tx.setResiduals(track.residuals());
       // rechits:
       auto & newExtra = NewTrackExtraList_->back();
+      auto const firstTrackIndex = NewHitList_->size();
       for( trackingRecHit_iterator hit = extra.recHitsBegin(); hit != extra.recHitsEnd(); ++ hit ) {
 	NewHitList_->push_back( **hit );
-	newExtra.add( TrackingRecHitRef( rHits, NewHitList_->size() - 1) );
       }
+      newExtra.setHits( rHits, firstTrackIndex, NewHitList_->size() - firstTrackIndex);
     }
   }
 

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -353,13 +353,15 @@ TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
     auto ih = selHits->size();
     assert(ih==hidx);
     t2t(*theTraj,*selHits,false);
-    auto ie = selHits->size();
+    auto const ie = selHits->size();
+    unsigned int nHitsAdded = 0;
     for (;ih<ie; ++ih) {
       auto const & hit = (*selHits)[ih];
       track.appendHitPattern(hit);
-      tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
+      ++nHitsAdded;
     }
-
+    tx.setHits( rHits, hidx, nHitsAdded);
+    hidx +=nHitsAdded;
     /*
     if (theTraj->direction() == alongMomentum) {
       for( TrajectoryFitter::RecHitContainer::const_iterator j = transHits.begin();

--- a/RecoHI/HiTracking/src/HICaloCompatibleTrackSelector.cc
+++ b/RecoHI/HiTracking/src/HICaloCompatibleTrackSelector.cc
@@ -148,10 +148,11 @@ void HICaloCompatibleTrackSelector::produce( edm::Event& evt, const edm::EventSe
       TrackExtra & tx = selTrackExtras_->back();
       tx.setResiduals(trk.residuals());
       // TrackingRecHits
+      auto const firstHitIndex = selHits_->size();
       for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
 	selHits_->push_back( (*hit)->clone() );
-	tx.add( TrackingRecHitRef( rHits_, selHits_->size() - 1) );
       }
+      tx.setHits( rHits_, firstHitIndex, selHits_->size() - firstHitIndex );
     }
     if (copyTrajectories_) {
       trackRefs_[current] = TrackRef(rTracks_, selTracks_->size() - 1);

--- a/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3TkMuonProducer.cc
@@ -226,8 +226,8 @@ void L3TkMuonProducer::produce(Event& event, const EventSetup& eventSetup){
     unsigned int iRH=0;
     for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit,++iRH ) {
       outRecHits->push_back((*hit)->clone());
-      (*outTrackExtras)[i].add( TrackingRecHitRef( rHits, iRH));
     }
+    (*outTrackExtras)[i].setHits( rHits, 0, iRH);
   }
   
   LogDebug(metname)<<"made: "<<outTracks->size()<<" tracks, "<<outTrackExtras->size()<<" extras and "<<outRecHits->size()<<" rechits.";

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
@@ -139,6 +139,7 @@ bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track & recotrack_orig,
 				       TrackingRecHitCollection& RHcol){
   //loop over the hits of the original track
   trackingRecHit_iterator recHit = recotrack_orig.recHitsBegin();
+  auto const firstHitIndex = theRHi;
   for (; recHit!=recotrack_orig.recHitsEnd();++recHit){
     //clone it. this is meandatory
     TrackingRecHit * hit = (*recHit)->clone();
@@ -147,10 +148,11 @@ bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track & recotrack_orig,
     recotrack.appendHitPattern(*hit);
     //copy them in the new collection
     RHcol.push_back(hit);
-    //do something with the trackextra 
-    trackextra.add(TrackingRecHitRef( theRefprodRH, theRHi++));
+    ++theRHi;
 
   }//loop over original rechits
+  //do something with the trackextra 
+  trackextra.setHits(theRefprodRH, firstHitIndex, theRHi-firstHitIndex);
   
   return true; //if nothing fails
 }

--- a/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
@@ -284,6 +284,7 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
     }
     
     // Fill the track extra with the rec hit (persistent-)reference
+    unsigned int nHitsAdded = 0;
     for (Trajectory::RecHitContainer::const_iterator recHit = transHits.begin(); recHit != transHits.end(); ++recHit) {
       TrackingRecHit *singleHit = (**recHit).hit()->clone();
       std::vector<const TrackingRecHit*> hits = MuonTrackLoader::unpackHit(*singleHit);
@@ -302,9 +303,11 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
           }
       }
       recHitCollection->push_back( singleHit );  
-      // set the TrackingRecHitRef (persitent reference of the tracking rec hits)
-      trackExtra.add(TrackingRecHitRef(recHitCollectionRefProd, recHitsIndex++ ));
+      ++nHitsAdded;
     }
+    // set the TrackingRecHitRef (persitent reference of the tracking rec hits)
+    trackExtra.setHits(recHitCollectionRefProd, recHitsIndex, nHitsAdded);
+    recHitsIndex +=nHitsAdded;
 
     // fill the TrackExtraCollection
     trackExtraCollection->push_back(trackExtra);
@@ -617,6 +620,7 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
     pair<bool,reco::Track> updateResult(false,reco::Track());
             
     // Fill the track extra with the rec hit (persistent-)reference
+    unsigned int nHitsAdded = 0;
     for (Trajectory::RecHitContainer::const_iterator recHit = transHits.begin();
 	 recHit != transHits.end(); ++recHit) {
 	TrackingRecHit *singleHit = (**recHit).hit()->clone();
@@ -635,11 +639,13 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
                 break;
             }
         }
-	}
-	recHitCollection->push_back( singleHit );  
-	// set the TrackingRecHitRef (persitent reference of the tracking rec hits)
-	trackExtra.add(TrackingRecHitRef(recHitCollectionRefProd, recHitsIndex++ ));
     }
+    recHitCollection->push_back( singleHit );
+    ++nHitsAdded;
+    }
+    // set the TrackingRecHitRef (persitent reference of the tracking rec hits)
+    trackExtra.setHits(recHitCollectionRefProd, recHitsIndex, nHitsAdded);
+    recHitsIndex += nHitsAdded;
 
     // fill the TrackExtraCollection
     trackExtraCollection->push_back(trackExtra);

--- a/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/plugins/TrackListCombiner.cc
@@ -116,6 +116,7 @@ void TrackListCombiner::produce(edm::Event& ev, const edm::EventSetup& es)
   // Save the tracking recHits
   edm::OrphanHandle<TrackingRecHitCollection> theRecoHits = ev.put(recoHits);
   
+  edm::RefProd<TrackingRecHitCollection> theRecoHitsProd(theRecoHits);
   // Create the track extras and add the references to the rechits
   unsigned hits = 0;
   unsigned nTracks = recoTracks->size();
@@ -137,8 +138,9 @@ void TrackListCombiner::produce(edm::Event& ev, const edm::EventSetup& es)
                                  aTrack.seedRef());
     
     unsigned nHits = aTrack.recHitsSize();
-    for ( unsigned int ih=0; ih<nHits; ++ih)
-      aTrackExtra.add(TrackingRecHitRef(theRecoHits,hits++));
+    aTrackExtra.setHits(theRecoHitsProd,hits,nHits);
+    hits +=nHits;
+
     recoTrackExtras->push_back(aTrackExtra);
   }
   

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -75,20 +75,16 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
   LogDebug("TrackProducer") << "put the collection of TrackingRecHit in the event" << "\n";
   edm::OrphanHandle <TrackingRecHitCollection> ohRH = ev.put( recHits );
 
-
+  edm::RefProd<TrackingRecHitCollection> hitCollProd(ohRH);
   for (int k = 0; k < nTracks; k++)
   {
-    reco::TrackExtra* theTrackExtra = new reco::TrackExtra();
+    reco::TrackExtra theTrackExtra{};
 
     //fill the TrackExtra with TrackingRecHitRef
     unsigned int nHits = tracks->at(k).numberOfValidHits();
-    for(unsigned int i = 0; i < nHits; ++i) {
-      theTrackExtra->add(TrackingRecHitRef(ohRH,cc));
-      cc++;
-    }
-
-    trackExtras->push_back(*theTrackExtra);
-    delete theTrackExtra;
+    theTrackExtra.setHits(hitCollProd, cc, nHits);
+    cc +=nHits;
+    trackExtras->push_back(theTrackExtra);
   }
 
   LogDebug("TrackProducer") << "put the collection of TrackExtra in the event" << "\n";

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -323,10 +323,11 @@ void AnalyticalTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) 
       TrackExtra & tx = selTrackExtras_->back();
       tx.setResiduals(trk.residuals());
       // TrackingRecHits
+      auto const firstHitIndex = selHits_->size();
       for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
 	selHits_->push_back( (*hit)->clone() );
-	tx.add( TrackingRecHitRef( rHits_, selHits_->size() - 1) );
       }
+      tx.setHits( rHits_, firstHitIndex, selHits_->size() - firstHitIndex);
     }
     if (copyTrajectories_) {
       trackRefs_[current] = TrackRef(rTracks_, selTracks_->size() - 1);

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSelector.cc
@@ -206,10 +206,11 @@ void CosmicTrackSelector::produce( edm::Event& evt, const edm::EventSetup& es )
       TrackExtra & tx = selTrackExtras_->back();
       tx.setResiduals(trk.residuals());
       // TrackingRecHits
+      auto const firstHitIndex = selHits_->size();
       for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
 	selHits_->push_back( (*hit)->clone() );
-	tx.add( TrackingRecHitRef( rHits_, selHits_->size() - 1) );
       }
+      tx.setHits( rHits_, firstHitIndex, selHits_->size() - firstHitIndex );
     }
     if (copyTrajectories_) {
       trackRefs_[current] = TrackRef(rTracks_, selTracks_->size() - 1);

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateListMerger.cc
@@ -339,11 +339,12 @@ void DuplicateListMerger::produce(edm::Event& iEvent, const edm::EventSetup& iSe
       tx.setResiduals(track.residuals());
       // fill TrackingRecHits
       unsigned nh1=track.recHitsSize();
+      auto const firstTrackIndex = outputTrkHits->size();
       for ( unsigned ih=0; ih<nh1; ++ih ) { 
 	  //const TrackingRecHit*hit=&((*(track->recHit(ih))));
 	outputTrkHits->push_back( track.recHit(ih)->clone() );
-	tx.add( TrackingRecHitRef( refTrkHits, outputTrkHits->size() - 1) );
       }
+      tx.setHits(  refTrkHits, firstTrackIndex, outputTrkHits->size() - firstTrackIndex );
     }
     edm::Ref< std::vector<Trajectory> > trajRef(mergedTrajHandle, (*matchIter0).first);
     TrajTrackAssociationCollection::const_iterator match = mergedTrajTrackHandle->find(trajRef);

--- a/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/SimpleTrackListMerger.cc
@@ -496,12 +496,13 @@ namespace {
           // fill TrackingRecHits
           std::vector<const TrackingRecHit*>& iHits = rh1[track];
           unsigned nh1 = iHits.size();
+          auto const firstHitIndex = outputTrkHits->size();
           for ( unsigned ih=0; ih<nh1; ++ih ) {
             const TrackingRecHit* hit = iHits[ih];
             //for( trackingRecHit_iterator hit = itB; hit != itE; ++hit ) {
             outputTrkHits->push_back( hit->clone() );
-            tx.add( TrackingRecHitRef( refTrkHits, outputTrkHits->size() - 1) );
           }
+          tx.setHits( refTrkHits, firstHitIndex, nh1 );
       }
       trackRefs[current] = reco::TrackRef(refTrks, outputTrks->size() - 1);
 
@@ -614,11 +615,12 @@ namespace {
           // fill TrackingRecHits
           std::vector<const TrackingRecHit*>& jHits = rh2[track];
           unsigned nh2 = jHits.size();
+          auto const firstHitIndex2 = outputTrkHits->size();
           for ( unsigned jh=0; jh<nh2; ++jh ) {
             const TrackingRecHit* hit = jHits[jh];
             outputTrkHits->push_back( hit->clone() );
-            tx.add( TrackingRecHitRef( refTrkHits, outputTrkHits->size() - 1) );
           }
+          tx.setHits( refTrkHits, firstHitIndex2, nh2 );
       }
       trackRefs[current] = reco::TrackRef(refTrks, outputTrks->size() - 1);
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackMultiSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackMultiSelector.cc
@@ -256,10 +256,13 @@ void TrackMultiSelector::produce( edm::Event& evt, const edm::EventSetup& es )
         TrackExtra & tx = selTrackExtras_[where]->back();
 	tx.setResiduals(trk.residuals());
         // TrackingRecHits
+        auto& selHitsWhere = selHits_[where];
+        auto const firstHitIndex = selHitsWhere->size();
         for( trackingRecHit_iterator hit = trk.recHitsBegin(); hit != trk.recHitsEnd(); ++ hit ) {
-            selHits_[where]->push_back( (*hit)->clone() );
-            tx.add( TrackingRecHitRef( rHits_[where], selHits_[where]->size() - 1) );
+            selHitsWhere->push_back( (*hit)->clone() );
         }
+        tx.setHits( rHits_[where], firstHitIndex, selHitsWhere->size() - firstHitIndex);
+
         if (copyTrajectories_) {
             whereItWent_[current] = std::pair<short, reco::TrackRef>(where, TrackRef(rTracks_[where], selTracks_[where]->size() - 1));
         }

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -123,10 +123,11 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
                                 alongMomentum) );
         out->back().setExtra( reco::TrackExtraRef( rTrackExtras, outEx->size()-1 ) );
         reco::TrackExtra &ex = outEx->back();    
+        auto const firstHitIndex = outHits->size();
         for (OwnVector<TrackingRecHit>::const_iterator it2 = hits.first; it2 != hits.second; ++it2) {
             outHits->push_back(*it2);
-            ex.add( TrackingRecHitRef( rHits, outHits->size()-1 ) );
         } 
+        ex.setHits( rHits, firstHitIndex, outHits->size()-firstHitIndex);
     }
 
     iEvent.put(out);

--- a/RecoTracker/TrackProducer/plugins/QualityFilter.cc
+++ b/RecoTracker/TrackProducer/plugins/QualityFilter.cc
@@ -131,7 +131,8 @@ QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   if (copyExtras_) {
       //PUT TRACKING HITS IN THE EVENT
       OrphanHandle<TrackingRecHitCollection> theRecoHits = iEvent.put(selHits );
-  
+      edm::RefProd<TrackingRecHitCollection> theRecoHitsProd(theRecoHits);
+
       //PUT TRACK EXTRA IN THE EVENT
       selTrackExtras->reserve(nTracks);
       unsigned hits=0;
@@ -155,9 +156,8 @@ QualityFilter::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         auto & aTrackExtra = selTrackExtras->back();
         //unsigned nHits = aTrack.numberOfValidHits();
         auto nHits = aTrack.recHitsSize();
-        for ( unsigned int ih=0; ih<nHits; ++ih) {
-          aTrackExtra.add(TrackingRecHitRef(theRecoHits,hits++));
-        }
+        aTrackExtra.setHits(theRecoHitsProd, hits, nHits);
+        hits += nHits;
         selTrackExtras->push_back(aTrackExtra);
       }
 

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -128,12 +128,14 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
     assert(ih==hidx);
     t2t(*theTraj,*selHits,useSplitting);
     auto ie = selHits->size();
+    unsigned int nHitsAdded = 0;
     for (;ih<ie; ++ih) {
       auto const & hit = (*selHits)[ih];
       track.appendHitPattern(hit);
-      tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
+      ++nHitsAdded;
     }
-
+    tx.setHits(rHits, hidx, nHitsAdded);
+    hidx += nHitsAdded;
 
     /*
     TrajectoryFitter::RecHitContainer transHits; theTraj->recHitsV(transHits,useSplitting);

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -165,13 +165,14 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
       
       //      edm::LogVerbatim("MuonTrackProducer")<<"\n printing initial hit_pattern";
       //      trk->hitPattern().print();
-	
+      unsigned int nHitsToAdd = 0;
       for (trackingRecHit_iterator iHit = trk->recHitsBegin(); iHit != trk->recHitsEnd(); iHit++) {
         TrackingRecHit* hit = (*iHit)->clone();
         selectedTrackHits->push_back( hit );
-        newExtra->add( TrackingRecHitRef( rHits, hidx++ ) );
+        ++nHitsToAdd;
       }
-
+      newExtra->setHits( rHits, hidx, nHitsToAdd );
+      hidx += nHitsToAdd;
       if (trackType == "innerTrackPlusSegments") { 
 	
 	int wheel, station, sector;
@@ -247,6 +248,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		if(segment->hasPhi()) {
 		  const DTChamberRecSegment2D* phiSeg = segment->phiSegment();
 		  std::vector<const TrackingRecHit*> phiHits = phiSeg->recHits();
+                  unsigned int nHitsAdded = 0;
 		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = phiHits.begin();
 		      ihit != phiHits.end(); ++ihit) {
 		    TrackingRecHit* seghit = (*ihit)->clone();
@@ -254,13 +256,16 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		    selectedTrackHits->push_back( seghit );
-		    newExtra->add( TrackingRecHitRef( rHits, hidx ++ ) );
+                    ++nHitsAdded;
 		  }
+                  newExtra->setHits( rHits, hidx, nHitsAdded );
+                  hidx += nHitsAdded;
 		}
 		
 		if(segment->hasZed()) {
 		  const DTSLRecSegment2D* zSeg = (*segment).zSegment();
 		  std::vector<const TrackingRecHit*> zedHits = zSeg->recHits();
+                  unsigned int nHitsAdded = 0;
 		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = zedHits.begin();
 		      ihit != zedHits.end(); ++ihit) {
 		    TrackingRecHit* seghit = (*ihit)->clone();
@@ -268,8 +273,10 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		    selectedTrackHits->push_back( seghit );
-		    newExtra->add( TrackingRecHitRef( rHits, hidx ++ ) );
+                    ++nHitsAdded;
 		  }
+                  newExtra->setHits( rHits, hidx, nHitsAdded );
+                  hidx += nHitsAdded;
 		}
 	      } else edm::LogWarning("MuonTrackProducer")<<"\n***WARNING: UNMATCHED DT segment ! \n";
 	    } // if (subdet == MuonSubdetId::DT)
@@ -288,6 +295,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		edm::LogVerbatim("MuonTrackProducer")<<"\t ===> MATCHING with CSC segment with index = "<<segmentCSC.key();
 		
 		std::vector<const TrackingRecHit*> hits = segment->recHits();
+                unsigned int nHitsAdded = 0;
 		for(std::vector<const TrackingRecHit*>::const_iterator ihit = hits.begin();
 		    ihit != hits.end(); ++ihit) {
 		  TrackingRecHit* seghit = (*ihit)->clone();
@@ -295,8 +303,10 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		  //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		  //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		  selectedTrackHits->push_back( seghit );
-		  newExtra->add( TrackingRecHitRef( rHits, hidx ++ ) );		  
+                  ++nHitsAdded;
 		}
+                newExtra->setHits( rHits, hidx, nHitsAdded );
+                hidx += nHitsAdded;
 	      } else edm::LogWarning("MuonTrackProducer")<<"\n***WARNING: UNMATCHED CSC segment ! \n";
 	    }  //  else if (subdet == MuonSubdetId::CSC)
 

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
@@ -141,14 +141,15 @@ SeedToTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         edm::LogVerbatim("SeedToTrackProducer") << "trackPtError=" << theTrack.ptError() << "trackPhiError=" << theTrack.phiError() << endl;
  
         //fill the seed segments in the track
-        unsigned int index_hit = 0;
+        unsigned int nHitsAdded = 0;
         for(TrajectorySeed::recHitContainer::const_iterator itRecHits=(L2seeds->at(i)).recHits().first; itRecHits!=(L2seeds->at(i)).recHits().second; ++itRecHits, ++countRH) {
             TrackingRecHit* hit = (itRecHits)->clone();
             theTrack.appendHitPattern(*hit);
             selectedTrackHits->push_back(hit);
-            index_hit++;
-            theTrackExtra.add(TrackingRecHitRef( rHits, hidx ++ ) );
+            nHitsAdded++;
         }
+        theTrackExtra.setHits( rHits, hidx, nHitsAdded );
+        hidx += nHitsAdded;
         selectedTracks->push_back(theTrack);
         selectedTrackExtras->push_back(theTrackExtra);
 


### PR DESCRIPTION
TrackExtra::add was removed from the TrackExtra api.
Calls TrackExtra::add required to caller to pass edm::Ref's which
come from sequential entries in the same container. The callers always
created a temporary edm::Ref which was then discarded.
The TrackExtra::setHits API better enforces the requirements by taking
an edm:RefProd to the container and then a starting index and number of
entries into that container for the hits. Not only is setHits safer
than calling add it is also faster.

TrackExtra::add had to go away anway because of work being done in
the framework which will no longer allow an edm::RefProd to be constructed
from an edm::Ref.
