### PR TITLE
temporarily remove premix relval from those executed by the bare matrix

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -50,7 +50,7 @@ class MatrixReader(object):
                              'relval_identity':'id-',
                              'relval_machine': 'mach-',
                              'relval_unsch': 'unsch-'
-                             , 'relval_premix': 'premix-'
+                             #, 'relval_premix': 'premix-'
                              }
 
         self.files = ['relval_standard' ,
@@ -64,7 +64,7 @@ class MatrixReader(object):
                       'relval_identity',
                       'relval_machine',
                       'relval_unsch'
-                      , 'relval_premix'
+                      #, 'relval_premix'
                       ]
 
         self.relvalModule = None


### PR DESCRIPTION
@ktf @davidlange6 @mdhildreth 
in light of: https://hypernews.cern.ch/HyperNews/CMS/get/swReleases/4150/1/1/1/1/1/2/1/1/1/1/1/1/1.html , premixing input samples for relval workflows won't appear before pre6.
This is a hook to remove 14 failing workflows in all IB's for the next few days, to be re-brought back as soon as it makes sense. NOTE: single workflows remain runnable, selected explicitly by -l 
I sign this one, up to you wether merging or not.
