### PR TITLE
Calibration/IsolatedParticles: definite static const int members passed by a ref

### DIFF
--- a/Calibration/IsolatedParticles/plugins/IsolatedGenParticles.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedGenParticles.cc
@@ -41,6 +41,9 @@
 
 #include "Calibration/IsolatedParticles/plugins/IsolatedGenParticles.h"
 
+const int IsolatedGenParticles::PBins;
+const int IsolatedGenParticles::EtaBins;
+
 IsolatedGenParticles::IsolatedGenParticles(const edm::ParameterSet& iConfig) {
 
   genSrc_    = iConfig.getUntrackedParameter("GenSrc",std::string("generator"));


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard), 9.4.2/3

```
...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
```

`IsolatedGenParticles::BookHistograms()` was passing them by a
reference.

9.4.2/4 talks about how `const static` data members are being handled.

Also standard says that no diagnostic is required by compiler.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
