### PR TITLE
DQM/L1TMonitor: definite static const int members

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeGCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeGCT.cc
@@ -3,6 +3,9 @@
 
 using namespace dedefs;
 
+const int L1TdeGCT::nGctColl_;
+const int L1TdeGCT::nerr;
+
 L1TdeGCT::L1TdeGCT(const edm::ParameterSet& iConfig) {
 
   verbose_ = iConfig.getUntrackedParameter<int>("VerboseFlag",0);


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard), 9.4.2/3

```
...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
```

9.4.2/3 talks about how `const static` data members are being handled.

Also standard says that no diagnostic is required by compiler.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
