### PR TITLE
CalibFormats/CaloObjects: definite static const int members passed by a ref

### DIFF
--- a/CalibFormats/CaloObjects/src/CaloSamples.cc
+++ b/CalibFormats/CaloObjects/src/CaloSamples.cc
@@ -3,6 +3,8 @@
 #include <math.h>
 #include <iostream>
 
+const int CaloSamples::MAXSAMPLES;
+
 CaloSamples::CaloSamples() : id_(), size_(0), presamples_(0), preciseSize_(0), precisePresamples_(0) { setBlank() ; }
 
 CaloSamples::CaloSamples(const DetId& id, int size) :


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard), 9.4.2/3

```
...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
```

9.4.2/3 talks about how `const static` data members are being handled.

Also standard says that no diagnostic is required by compiler.

This is needed to compile `RecoLocalCalo/HcalRecAlgos
(HBHENegativeFlag.cc)`, which passes `CaloSamples::MAXSAMPLES` to `std::min`
(arguments are taken by a const ref).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
