### PR TITLE
RecoTracker/TkDetLayers: resolve link issue with Clang

### DIFF
--- a/RecoTracker/TkDetLayers/src/TkDetUtil.h
+++ b/RecoTracker/TkDetLayers/src/TkDetUtil.h
@@ -7,11 +7,11 @@
 #include "TrackingTools/DetLayers/interface/PhiLess.h"
 #include "TrackingTools/DetLayers/interface/rangesIntersect.h"
 
-#pragma GCC visibility push(hidden)
-
 class GeomDet;
 class Plane;
 class TrajectoryStateOnSurface;
+
+#pragma GCC visibility push(hidden)
 
 namespace tkDetUtil {
 


### PR DESCRIPTION
The following fix is required due to a behavior difference between Clang
and GCC. Clan does not correctly emulate GCC visibility pragma.

See PR22254: http://llvm.org/bugs/show_bug.cgi?id=22254

The link error involved the following two symbols:
- `Plane::tangentPlane(Point3DBase<float, LocalTag> const&) const`
- `Plane::tangentPlane(Point3DBase<float, GlobalTag> const&) const`

On link command we have `libTrackingToolsDetLayers.so` and
`libTrackingToolsGeomPropagators.so`, which have undefined references
for above two symbols. These are usually resolved on dynamic loading.

On Clang `TECLayer.o` marked these particular symbols as HIDDEN.

**Clang:**

```
  182: 0000000000000000     0 NOTYPE  GLOBAL HIDDEN   UND
_ZNK5Plane12tangentPlaneERK11Point3DBaseIf8LocalTagE
  183: 0000000000000000     0 NOTYPE  GLOBAL HIDDEN   UND
_ZNK5Plane12tangentPlaneERK11Point3DBaseIf9GlobalTagE
```

**GCC:**

```
  261: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND
_ZNK5Plane12tangentPlaneERK11Point3DBaseIf9GlobalTagE
  262: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  UND
_ZNK5Plane12tangentPlaneERK11Point3DBaseIf8LocalTagE
```

`TkDetUtil.h` inside visibility pragma section has forward declaration
of class `Plane`. Thus Clang marked it as HIDDEN. Then linker was
complaining that two libraries mentioned above reference a HIDDEN
symbols, which is not allowed as these sybmols are not public API.

In GCC `Plane` is with DEFAULT visbility, because the first declaration
wins, thus the DEFAULT visibility. You cannot modify it later on.

Lesson here: do not add forward declaration for publicly available
classes in pragma visibility hidden section.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
