### PR TITLE
RecoMET/METPUSubtraction: remove unused constants

### DIFF
--- a/RecoMET/METPUSubtraction/src/NoPileUpMEtAuxFunctions.cc
+++ b/RecoMET/METPUSubtraction/src/NoPileUpMEtAuxFunctions.cc
@@ -6,9 +6,6 @@
 #include <cmath>
 
 namespace noPuUtils{
-
-  const int minPFCandToVertexAssocQuality = noPuUtils::kChHSAssoc; // CV: value recommended by Matthias Geisler, representing "good" PFCandidate-vertex associations
-
   const double dR2Min=0.01*0.01;
 
   int isVertexAssociated(const reco::PFCandidatePtr& pfCandidate,


### PR DESCRIPTION
Remove unused `minPFCandToVertexAssocQuality`. If you believe that this needs to stay in the code, we can add extra protection around it, otherwise lest removed it. 

This is the last Clang related issue for compiling CMSSW (tested on `CMSSW_7_4_DEVEL_X_2015-01-18-0200`)

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
