### PR TITLE
Higgs validation update cmssw74x 19012015

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -192,6 +192,13 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         recMuonLabel  = cms.string("muons"),
         # -- Analysis specific cuts
         minCandidates = cms.uint32(2), 
+        parametersTurnOn = cms.vdouble(0,
+                                1, 8, 9, 10,
+                                11, 12, 13, 14, 15, 16, 17, 18, 19, 20,
+                                22, 24, 26, 28, 30, 32, 34, 36, 38, 40,
+                                45, 50, 55, 60, 65, 70, 
+                                80, 100, 120, 140, 160, 180, 200,
+                                ),
         ),
     H2tau  = cms.PSet( 
         hltPathsToCheck = cms.vstring(

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -191,7 +191,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         recCaloMETLabel = cms.string("caloMet"),
         recMuonLabel  = cms.string("muons"),
         # -- Analysis specific cuts
-        minCandidates = cms.uint32(2), 
+        minCandidates = cms.uint32(1), 
         parametersTurnOn = cms.vdouble(0,
                                 1, 8, 9, 10,
                                 11, 12, 13, 14, 15, 16, 17, 18, 19, 20,

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -178,8 +178,9 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
      Htaunu = cms.PSet(
         hltPathsToCheck = cms.vstring(
-            "HLT_LooseIsoPFTau35_Trk20_Prong1_MET70_v",
-            "HLT_LooseIsoPFTau35_Trk20_Prong1_MET75_v",
+#            "HLT_LooseIsoPFTau35_Trk20_Prong1_MET70_v",
+#            "HLT_LooseIsoPFTau35_Trk20_Prong1_MET75_v",
+            "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET80_v",
             "HLT_LooseIsoPFTau50_Trk30_eta2p1_MET120_v",
             # monitoring triggers for efficiency measurement
             "HLT_LooseIsoPFTau50_Trk30_eta2p1_v",

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -140,7 +140,8 @@ HLTHiggsSubAnalysis::HLTHiggsSubAnalysis(const edm::ParameterSet & pset,
             }
         }
     }
-    NptPlots = ( _useNminOneCuts ? _minCandidates : 2 );
+//    NptPlots = ( _useNminOneCuts ? _minCandidates : 2 );
+    NptPlots = _minCandidates;
 }
 
 HLTHiggsSubAnalysis::~HLTHiggsSubAnalysis()

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -63,6 +63,11 @@ HLTHiggsSubAnalysis::HLTHiggsSubAnalysis(const edm::ParameterSet & pset,
     edm::ParameterSet anpset = pset.getParameter<edm::ParameterSet>(analysisname);
     // Collections labels (but genparticles already initialized) 
     // initializing _recLabels data member)
+    if( anpset.exists("parametersTurnOn") )
+    {
+        _parametersTurnOn = anpset.getParameter<std::vector<double> >("parametersTurnOn");
+        _pset.addParameter("parametersTurnOn",_parametersTurnOn); 
+    }
     this->bookobjects( anpset, iC );
     // Generic objects: Initialization of cuts
     for(std::map<unsigned int,std::string>::const_iterator it = _recLabels.begin();


### PR DESCRIPTION
Higgs HLT validation updates for htaunu. Updated paths (added 1, removed 2), changed the htaunu pt binning from 0-100 to 0-200 and switched to using 1 pt plot only.
