### PR TITLE
FSQ DQM update for 7_4 series

### DIFF
--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
@@ -32,7 +32,7 @@ DQMOfflineHeavyIonsDPG = cms.Sequence( DQMOfflineHeavyIonsPreDPG *
 from DQMOffline.Muon.muonMonitors_cff import *
 from DQMOffline.JetMET.jetMETDQMOfflineSourceHI_cff import *
 from DQMOffline.EGamma.egammaDQMOffline_cff import *
-from DQMOffline.Trigger.DQMOffline_Trigger_cff import *
+from DQMOffline.Trigger.DQMOffline_Trigger_HI_cff import *
 #from DQMOffline.RecoB.PrimaryVertexMonitor_cff import *
 from DQM.Physics.DQMPhysics_cff import *
 from DQM.TrackingMonitorSource.TrackingSourceConfig_Tier0_HeavyIons_cff import *

--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
@@ -32,7 +32,7 @@ DQMOfflineHeavyIonsDPG = cms.Sequence( DQMOfflineHeavyIonsPreDPG *
 from DQMOffline.Muon.muonMonitors_cff import *
 from DQMOffline.JetMET.jetMETDQMOfflineSourceHI_cff import *
 from DQMOffline.EGamma.egammaDQMOffline_cff import *
-from DQMOffline.Trigger.DQMOffline_Trigger_HI_cff import *
+from DQMOffline.Trigger.DQMOffline_Trigger_cff import *
 #from DQMOffline.RecoB.PrimaryVertexMonitor_cff import *
 from DQM.Physics.DQMPhysics_cff import *
 from DQM.TrackingMonitorSource.TrackingSourceConfig_Tier0_HeavyIons_cff import *
@@ -44,6 +44,13 @@ egammaDQMOffline.remove(electronAnalyzerSequence)
 egammaDQMOffline.remove(zmumugammaAnalysis)
 egammaDQMOffline.remove(zmumugammaOldAnalysis)
 egammaDQMOffline.remove(photonAnalysis)
+
+triggerOfflineDQMSource.remove(ak4PFL1FastL2L3CorrectorChain)
+from DQMOffline.Trigger.FSQHLTOfflineSource_cfi import getFSQHI
+fsqHLTOfflineSource.todo = getFSQHI()
+
+
+
 stdPhotonAnalysis.isHeavyIon = True
 stdPhotonAnalysis.barrelRecHitProducer = cms.InputTag("ecalRecHit", "EcalRecHitsEB")
 stdPhotonAnalysis.endcapRecHitProducer = cms.InputTag("ecalRecHit", "EcalRecHitsEE")

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_HI_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_HI_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from DQMOffline.Trigger.DQMOffline_Trigger_cff import *
+
+# fix FSQ DQM - required products to calculate JEC not avaliable in HI workflow
+#   this turns off JEC calculation
+fsqHLTOfflineSourceSequence = cms.Sequence(fsqHLTOfflineSource)
+from DQMOffline.Trigger.FSQHLTOfflineSource_cfi import getFSQHI
+fsqHLTOfflineSource.todo = getFSQHI()

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_HI_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_HI_cff.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-from DQMOffline.Trigger.DQMOffline_Trigger_cff import *
-
-# fix FSQ DQM - required products to calculate JEC not avaliable in HI workflow
-#   this turns off JEC calculation
-fsqHLTOfflineSourceSequence = cms.Sequence(fsqHLTOfflineSource)
-from DQMOffline.Trigger.FSQHLTOfflineSource_cfi import getFSQHI
-fsqHLTOfflineSource.todo = getFSQHI()

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -78,7 +78,7 @@ offlineHLTSource = cms.Sequence(
     HLTTauDQMOffline *
     #jetMETHLTOfflineSource *
     jetMETHLTOfflineAnalyzer *
-    fsqHLTOfflineSource *
+    fsqHLTOfflineSourceSequence *
     #TnPEfficiency *
     hltInclusiveVBFSource *
     trackingMonitorHLT *

--- a/DQMOffline/Trigger/python/FSQHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineClient_cfi.py
@@ -1,14 +1,17 @@
 import FWCore.ParameterSet.Config as cms
 
 fsqClient = cms.EDAnalyzer("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/FSQ/HLT_DiPFJetAve*", "HLT/FSQ/HLT_PixelTracks_Multiplicity*"),
+    subDirs        = cms.untracked.vstring("HLT/FSQ/HLT_DiPFJetAve*", "HLT/FSQ/HLT_PixelTracks_Multiplicity*",\
+                                           "HLT/FSQ/HLT_ZeroBias_SinglePixelTrack*"  ),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     outputFileName = cms.untracked.string(''),
     commands       = cms.vstring(),
     resolution     = cms.vstring(),
     efficiency     = cms.vstring(
         "effVsRecoPtAve 'Trigger efficiency vs reco ptAve; average p_{T}^{reco}' recoPFJetsTopology_ptAve_nominator recoPFJetsTopology_ptAve_denominator",
-        "effVsRecoTracksCnt 'Trigger efficiency vs reco tracks count' recoTracks_count_nominator recoTracks_count_denominator"
+        "effVsRecoTracksCnt 'Trigger efficiency vs reco tracks count' recoTracks_count_nominator recoTracks_count_denominator",
+        "effVsAtLeastOneTrack 'Trigger efficiency for events with at least one offline track' zb_Eff_nominator zb_Eff_denominator"
+
     ),
 )
 

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -24,14 +24,14 @@ def getHighMultVPSet():
         bins = (binH-binL)/5
         tracksCount  =  cms.PSet(
                 triggerSelection = cms.string(partialPathName+"*"),
-                handlerType = cms.string("RecoTrackCounter"),
+                handlerType = cms.string("RecoTrackCounterWithVertexConstraint"),
                 inputCol = cms.InputTag("generalTracks"),
                 partialPathName = cms.string(partialPathName),
                 partialFilterName  = cms.string("hltL1sETT"),
                 #dqmhistolabel  = cms.string("hltPixelTracks"),
                 dqmhistolabel  = cms.string("recoTracks"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
-                singleObjectsPreselection = cms.string("1==1"), # add reco::Tracks selection criteria
+                singleObjectsPreselection = cms.string("pt > 0.4 && abs(eta) < 2.4"), 
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string('size()'),
                 combinedObjectDimension = cms.int32(1),
@@ -46,7 +46,7 @@ def getHighMultVPSet():
         tracksCountDenom.triggerSelection=cms.string("TRUE")
         tracksCountDenom.drawables =  cms.VPSet(
             cms.PSet (name = cms.string("count_denominator"), expression = cms.string("at(0)"),
-                             bins = cms.int32(30), min = cms.double(t), max = cms.double(t+t/2))
+                             bins = cms.int32(bins), min = cms.double(binL), max = cms.double(binH))
         )
         ret.append(tracksCountDenom)
 
@@ -292,7 +292,6 @@ def getFSQAll():
 
 fsqdirname = "HLT/FSQ/"
 
-#processName = "TTT"
 processName = "HLT"
 #processName = "TEST"
 

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -319,7 +319,6 @@ fsqdirname = "HLT/FSQ/"
 
 processName = "HLT"
 #processName = "TEST"
-processName = "TTT"
 
 fsqHLTOfflineSource = cms.EDAnalyzer("FSQDiJetAve",
     triggerConfiguration =  cms.PSet(

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -243,7 +243,8 @@ def getPTAveVPSet():
             recoThr = t/2
             recoPFtopology  =  cms.PSet(
                 triggerSelection = cms.string(partialPathName+"*"),
-                handlerType = cms.string("FromRecoCandidate"),
+                handlerType = cms.string("RecoPFJetWithJEC"),
+                PFJetCorLabel        = cms.InputTag("ak4PFL1FastL2L3Corrector"),
                 inputCol = cms.InputTag("ak4PFJetsCHS"),
                 partialPathName = cms.string(partialPathName),
                 partialFilterName  = cms.string("hltDiPFJetAve"),
@@ -318,6 +319,7 @@ fsqdirname = "HLT/FSQ/"
 
 processName = "HLT"
 #processName = "TEST"
+processName = "TTT"
 
 fsqHLTOfflineSource = cms.EDAnalyzer("FSQDiJetAve",
     triggerConfiguration =  cms.PSet(
@@ -338,3 +340,5 @@ fsqHLTOfflineSource = cms.EDAnalyzer("FSQDiJetAve",
     todo = cms.VPSet(getFSQAll())
 )
 
+from JetMETCorrections.Configuration.CorrectedJetProducers_cff import *
+fsqHLTOfflineSourceSequence = cms.Sequence(ak4PFL1FastL2L3CorrectorChain + fsqHLTOfflineSource)

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -72,14 +72,14 @@ def getHighMultVPSet():
             mainDQMDirname = cms.untracked.string(fsqdirname),
             singleObjectsPreselection = cms.string("1==1"),
             singleObjectDrawables =  cms.VPSet(
-                cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(20), min = cms.double(0), max = cms.double(10)),
+                cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(50), min = cms.double(0.4), max = cms.double(10)),
                 cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5))
             ),
             combinedObjectSelection =  cms.string("1==1"),
             combinedObjectSortCriteria = cms.string("at(0).pt"),
             combinedObjectDimension = cms.int32(1),
             combinedObjectDrawables =  cms.VPSet(
-                cms.PSet (name = cms.string("ptBest"), expression = cms.string("at(0).pt"), bins = cms.int32(20), min = cms.double(0), max = cms.double(10)),
+                cms.PSet (name = cms.string("ptBest"), expression = cms.string("at(0).pt"), bins = cms.int32(50), min = cms.double(0.4), max = cms.double(10)),
                 cms.PSet (name = cms.string("etaBest"), expression = cms.string("at(0).eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5))
 
             )

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -78,7 +78,11 @@ def getHighMultVPSet():
             combinedObjectSelection =  cms.string("1==1"),
             combinedObjectSortCriteria = cms.string("at(0).pt"),
             combinedObjectDimension = cms.int32(1),
-            combinedObjectDrawables =  cms.VPSet()
+            combinedObjectDrawables =  cms.VPSet(
+                cms.PSet (name = cms.string("ptBest"), expression = cms.string("at(0).pt"), bins = cms.int32(20), min = cms.double(0), max = cms.double(10)),
+                cms.PSet (name = cms.string("etaBest"), expression = cms.string("at(0).eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5))
+
+            )
         )
         ret.append(hltPixelTracks)
 

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -379,6 +379,11 @@ def getFSQAll():
     ret.extend(getZeroBias_SinglePixelTrackVPSet())
     return ret
 
+def getFSQHI():
+    ret = cms.VPSet()
+    ret.extend(getZeroBias_SinglePixelTrackVPSet())
+    #ret.extend(getHighMultVPSet())
+    return ret
 
 fsqdirname = "HLT/FSQ/"
 

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -14,6 +14,7 @@ import math
 #   other handlers read data from collection pointed by inputCol parameter 
 #       (partialFilterName, partialPathName params are ignored)
 #
+
 def getHighMultVPSet():
     ret=cms.VPSet()
     thresholds = [60, 85, 110, 135, 160]
@@ -26,6 +27,14 @@ def getHighMultVPSet():
                 triggerSelection = cms.string(partialPathName+"*"),
                 handlerType = cms.string("RecoTrackCounterWithVertexConstraint"),
                 inputCol = cms.InputTag("generalTracks"),
+                # l parameters
+                vtxCollection = cms.InputTag("offlinePrimaryVertices"),
+                minNDOF = cms.int32(7),
+                maxZ = cms.double(15),
+                maxDZ = cms.double(0.12),
+                maxDZ2dzsigma = cms.double(3),
+                maxDXY = cms.double(0.12),
+                maxDXY2dxysigma = cms.double(3),
                 partialPathName = cms.string(partialPathName),
                 partialFilterName  = cms.string("hltL1sETT"),
                 #dqmhistolabel  = cms.string("hltPixelTracks"),

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -73,18 +73,22 @@ def getHighMultVPSet():
             singleObjectsPreselection = cms.string("1==1"),
             singleObjectDrawables =  cms.VPSet(
                 cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(50), min = cms.double(0.4), max = cms.double(10)),
-                cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5))
+                cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5)),
+                cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
             ),
             combinedObjectSelection =  cms.string("1==1"),
             combinedObjectSortCriteria = cms.string("at(0).pt"),
             combinedObjectDimension = cms.int32(1),
-            combinedObjectDrawables =  cms.VPSet(
-                cms.PSet (name = cms.string("ptBest"), expression = cms.string("at(0).pt"), bins = cms.int32(50), min = cms.double(0.4), max = cms.double(10)),
-                cms.PSet (name = cms.string("etaBest"), expression = cms.string("at(0).eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5))
-
-            )
+            combinedObjectDrawables =  cms.VPSet()
         )
         ret.append(hltPixelTracks)
+
+        hltPixelTracksEta16to18 = hltPixelTracks.clone()
+        hltPixelTracksEta16to18.singleObjectsPreselection='abs(eta) > 1.6 && abs(eta) < 1.8'
+        hltPixelTracksEta16to18.dqmhistolabel  = cms.string("hltPixelTracksEta16to18")
+        ret.append(hltPixelTracksEta16to18)
+
+
 
         # FIXME: what variables it makes sense to plot in case of ETT seeds?
         l1 =  cms.PSet(

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -134,7 +134,7 @@ def getHighMultVPSet():
             mainDQMDirname = cms.untracked.string(fsqdirname),
             singleObjectsPreselection = cms.string("1==1"),
             singleObjectDrawables =  cms.VPSet(
-                cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(50), min = cms.double(0.4), max = cms.double(10)),
+                cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(200), min = cms.double(0.0), max = cms.double(10)),
                 cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5)),
                 cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
             ),
@@ -148,9 +148,11 @@ def getHighMultVPSet():
         hltPixelTracksEta16to18 = hltPixelTracks.clone()
         hltPixelTracksEta16to18.singleObjectsPreselection='abs(eta) > 1.6 && abs(eta) < 1.8'
         hltPixelTracksEta16to18.dqmhistolabel  = cms.string("hltPixelTracksEta16to18")
+        for i in hltPixelTracksEta16to18.singleObjectDrawables:
+            if i.name == "eta":
+                hltPixelTracksEta16to18.singleObjectDrawables.remove(i)
+
         ret.append(hltPixelTracksEta16to18)
-
-
 
         # FIXME: what variables it makes sense to plot in case of ETT seeds?
         l1 =  cms.PSet(
@@ -312,7 +314,7 @@ def getPTAveVPSet():
                 partialFilterName  = cms.string("hltDiPFJetAve"),
                 dqmhistolabel  = cms.string("recoPFJetsTopology"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
-                singleObjectsPreselection = cms.string("pt > + "+str(recoThr) +" && abs(eta)<1.4 || abs(eta) > 2.7 "),
+                singleObjectsPreselection = cms.string("pt > "+str(recoThr) +" && abs(eta)<1.4 || abs(eta) > 2.7 "),
                 singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("abs(at(0).eta())< 1.3 && abs(at(1).eta()) > 2.8 && abs(deltaPhi(at(0).phi, at(1).phi)) > 2.5"),
                 combinedObjectSortCriteria = cms.string("(at(0).pt+at(1).pt)/2"),
@@ -354,7 +356,7 @@ def getPTAveVPSet():
                 partialFilterName  = cms.string("hltDiPFJetAve"),
                 dqmhistolabel  = cms.string("recoPFJetsCnt"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
-                singleObjectsPreselection = cms.string("pt > + "+str(recoThr) +" && abs(eta)<1.4 || abs(eta) > 2.7 "),
+                singleObjectsPreselection = cms.string("pt >  "+str(recoThr) +" && abs(eta)<1.4 || abs(eta) > 2.7 "),
                 singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string('size()'),

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -20,9 +20,9 @@ def getHighMultVPSet():
     thresholds = [60, 85, 110, 135, 160]
     for t in thresholds:
         partialPathName = "HLT_PixelTracks_Multiplicity"+str(t)+"_v"
-        binL =  t/2
-        binH =  3*t
-        bins = (binH-binL)/5
+        tracksL = 0
+        tracksH = 200
+        tracksBins = (tracksH-tracksL)/5
         tracksCount  =  cms.PSet(
                 triggerSelection = cms.string(partialPathName+"*"),
                 handlerType = cms.string("RecoTrackCounterWithVertexConstraint"),
@@ -41,47 +41,44 @@ def getHighMultVPSet():
                 dqmhistolabel  = cms.string("recoTracks"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("pt > 0.4 && abs(eta) < 2.4"), 
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string('size()'),
                 combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("count_nominator"), expression = cms.string('at(0)'), 
-                             bins = cms.int32(bins), min = cms.double(binL), max = cms.double(binH))
+                             bins = cms.int32(tracksBins), min = cms.double(tracksL), max = cms.double(tracksH))
                 )
         )
         ret.append(tracksCount)				
 
         tracksCountDenom = tracksCount.clone()
-        tracksCountDenom.triggerSelection=cms.string("TRUE")
-        tracksCountDenom.drawables =  cms.VPSet(
+        tracksCountDenom.triggerSelection = cms.string("TRUE")
+        tracksCountDenom.combinedObjectDrawables =  cms.VPSet(
             cms.PSet (name = cms.string("count_denominator"), expression = cms.string("at(0)"),
-                             bins = cms.int32(bins), min = cms.double(binL), max = cms.double(binH))
+                             bins = cms.int32(tracksBins), min = cms.double(tracksL), max = cms.double(tracksH))
         )
         ret.append(tracksCountDenom)
 
 
-
-
-        ptEtaHardest  =  cms.PSet(
-                triggerSelection = cms.string(partialPathName+"*"),
-                handlerType = cms.string("RecoTrack"),
-                inputCol = cms.InputTag("hltPixelTracksForHighMult"),
-                partialPathName = cms.string(partialPathName),
-                partialFilterName  = cms.string("hltL1sETT"),
-                dqmhistolabel  = cms.string("hltPixelTracksPtEtaHardest"),
-                mainDQMDirname = cms.untracked.string(fsqdirname),
-                singleObjectsPreselection = cms.string(""),
-                combinedObjectSelection =  cms.string("1==1"),
-                combinedObjectSortCriteria = cms.string("at(0).pt"),
-                combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
-                    cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), 
-                            bins = cms.int32(50), min = cms.double(0), max = cms.double(50)),
-                    cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), 
-                            bins = cms.int32(50), min = cms.double(-2.5), max = cms.double(2.5))
-                )
+        hltPixelTracks =  cms.PSet(
+            triggerSelection = cms.string(partialPathName+"*"),
+            handlerType = cms.string("FromHLT"),
+            partialPathName = cms.string(partialPathName),
+            partialFilterName  = cms.string("hlt1HighMult"), # note: this matches to hltSingleCaloJetXXXForHFJECBase
+            dqmhistolabel  = cms.string("hltPixelTracks"),
+            mainDQMDirname = cms.untracked.string(fsqdirname),
+            singleObjectsPreselection = cms.string("1==1"),
+            singleObjectDrawables =  cms.VPSet(),
+            combinedObjectSelection =  cms.string("1==1"),
+            combinedObjectSortCriteria = cms.string("at(0).pt"),
+            combinedObjectDimension = cms.int32(1),
+            combinedObjectDrawables =  cms.VPSet(
+                cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), bins = cms.int32(10), min = cms.double(0), max = cms.double(10)),
+                cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), bins = cms.int32(104), min = cms.double(-5.2), max = cms.double(5.2))
+            )
         )
-        ret.append(ptEtaHardest) 
+        ret.append(hltPixelTracks)
 
         # FIXME: what variables it makes sense to plot in case of ETT seeds?
         l1 =  cms.PSet(
@@ -92,12 +89,12 @@ def getHighMultVPSet():
                 dqmhistolabel  = cms.string("l1"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("1==1"),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string("at(0).pt"),
                 combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), bins = cms.int32(256/4), min = cms.double(0), max = cms.double(256)),
-                    cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), bins = cms.int32(104/4), min = cms.double(-5.2), max = cms.double(5.2))
                 )
         )
         ret.append(l1) 
@@ -127,10 +124,11 @@ def getPTAveVPSet():
                 dqmhistolabel  = cms.string("hltCaloJets"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("abs(eta)<1.4 || abs(eta) > 2.7 "),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string("at(0).pt"),
                 combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), bins = cms.int32(ptBins), min = cms.double(ptBinLow), max = cms.double(ptBinHigh)),
                     cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), bins = cms.int32(104), min = cms.double(-5.2), max = cms.double(5.2))
                 )
@@ -145,10 +143,11 @@ def getPTAveVPSet():
                 dqmhistolabel  = cms.string("l1"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("1==1"),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string("at(0).pt"),
                 combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), bins = cms.int32(256/4), min = cms.double(0), max = cms.double(256)),
                     cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), bins = cms.int32(104/4), min = cms.double(-5.2), max = cms.double(5.2))
                 )
@@ -164,10 +163,11 @@ def getPTAveVPSet():
                 dqmhistolabel  = cms.string("hltpfsingle"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("abs(eta)<1.4 || abs(eta) > 2.7 "),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string("at(0).pt"),
                 combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), bins = cms.int32(ptBins), min = cms.double(ptBinLow), max = cms.double(ptBinHigh)),
                     cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), bins = cms.int32(104), min = cms.double(-5.2), max = cms.double(5.2))
                 )
@@ -184,10 +184,11 @@ def getPTAveVPSet():
                 dqmhistolabel  = cms.string("hltPFJetsTopology"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("abs(eta)<1.4 || abs(eta) > 2.7 "),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("abs(at(0).eta())< 1.4 && abs(at(1).eta()) > 2.7 && abs(deltaPhi(at(0).phi, at(1).phi)) > 2.5"),
                 combinedObjectSortCriteria = cms.string("(at(0).pt+at(1).pt)/2"),
                 combinedObjectDimension = cms.int32(2),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("deltaEta"), expression = cms.string("abs(at(0).eta-at(1).eta)"), 
                              bins = cms.int32(70), min = cms.double(0), max = cms.double(7)),
                     cms.PSet (name = cms.string("deltaPhi"), expression = cms.string("abs(deltaPhi(at(0).phi, at(1).phi))"), 
@@ -218,10 +219,11 @@ def getPTAveVPSet():
                 dqmhistolabel  = cms.string("recoJet"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("pt > + "+str(recoThr) +" && (abs(eta)<1.3 || abs(eta) > 2.8) "),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string("at(0).pt"),
                 combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), bins = cms.int32(ptBins), min = cms.double(ptBinLow), max = cms.double(ptBinHigh)),
                     cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), bins = cms.int32(52), min = cms.double(-5.2), max = cms.double(5.2))
                 )
@@ -238,10 +240,11 @@ def getPTAveVPSet():
                 dqmhistolabel  = cms.string("recoPFJetsTopology"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("pt > + "+str(recoThr) +" && abs(eta)<1.4 || abs(eta) > 2.7 "),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("abs(at(0).eta())< 1.3 && abs(at(1).eta()) > 2.8 && abs(deltaPhi(at(0).phi, at(1).phi)) > 2.5"),
                 combinedObjectSortCriteria = cms.string("(at(0).pt+at(1).pt)/2"),
                 combinedObjectDimension = cms.int32(2),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("deltaEta"), expression = cms.string("abs(at(0).eta-at(1).eta)"), 
                              bins = cms.int32(70), min = cms.double(0), max = cms.double(7)),
                     cms.PSet (name = cms.string("deltaPhi"), expression = cms.string("abs(deltaPhi(at(0).phi, at(1).phi))"), 
@@ -259,8 +262,9 @@ def getPTAveVPSet():
             ret.append(recoPFtopology)
             recoPFtopologyDenom = recoPFtopology.clone()
             #recoPFtopologyDenom.triggerSelection = cms.string("HLTriggerFirstPath*")
+            #recoPFtopologyDenom.triggerSelection = cms.string(partialPathName+"*")
             recoPFtopologyDenom.triggerSelection = cms.string("TRUE")
-            recoPFtopologyDenom.drawables =  cms.VPSet(
+            recoPFtopologyDenom.combinedObjectDrawables =  cms.VPSet(
                 cms.PSet (name = cms.string("ptAve_denominator"), expression = cms.string("(at(0).pt+at(1).pt)/2"),
                              bins = cms.int32(ptBins), min = cms.double(ptBinLow), max = cms.double(ptBinHigh)  )
             )
@@ -278,10 +282,11 @@ def getPTAveVPSet():
                 dqmhistolabel  = cms.string("recoPFJetsCnt"),
                 mainDQMDirname = cms.untracked.string(fsqdirname),
                 singleObjectsPreselection = cms.string("pt > + "+str(recoThr) +" && abs(eta)<1.4 || abs(eta) > 2.7 "),
+                singleObjectDrawables =  cms.VPSet(),
                 combinedObjectSelection =  cms.string("1==1"),
                 combinedObjectSortCriteria = cms.string('size()'),
                 combinedObjectDimension = cms.int32(1),
-                drawables =  cms.VPSet(
+                combinedObjectDrawables =  cms.VPSet(
                     cms.PSet (name = cms.string("count"), expression = cms.string('at(0)'), 
                              bins = cms.int32(30), min = cms.double(0), max = cms.double(30))
                 )

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -14,7 +14,9 @@ import math
 #   other handlers read data from collection pointed by inputCol parameter 
 #       (partialFilterName, partialPathName params are ignored)
 #
-
+#   note: be extra carefull when using singleObject and combinedObject drawables in same
+#          handler definition. Histo names may be the same, currently there is no protection against it
+#
 def getHighMultVPSet():
     ret=cms.VPSet()
     thresholds = [60, 85, 110, 135, 160]
@@ -65,18 +67,18 @@ def getHighMultVPSet():
             triggerSelection = cms.string(partialPathName+"*"),
             handlerType = cms.string("FromHLT"),
             partialPathName = cms.string(partialPathName),
-            partialFilterName  = cms.string("hlt1HighMult"), # note: this matches to hltSingleCaloJetXXXForHFJECBase
+            partialFilterName  = cms.string("hlt1HighMult"),
             dqmhistolabel  = cms.string("hltPixelTracks"),
             mainDQMDirname = cms.untracked.string(fsqdirname),
             singleObjectsPreselection = cms.string("1==1"),
-            singleObjectDrawables =  cms.VPSet(),
+            singleObjectDrawables =  cms.VPSet(
+                cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(20), min = cms.double(0), max = cms.double(10)),
+                cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-2.5), max = cms.double(2.5))
+            ),
             combinedObjectSelection =  cms.string("1==1"),
             combinedObjectSortCriteria = cms.string("at(0).pt"),
             combinedObjectDimension = cms.int32(1),
-            combinedObjectDrawables =  cms.VPSet(
-                cms.PSet (name = cms.string("pt"), expression = cms.string("at(0).pt"), bins = cms.int32(10), min = cms.double(0), max = cms.double(10)),
-                cms.PSet (name = cms.string("eta"), expression = cms.string("at(0).eta"), bins = cms.int32(104), min = cms.double(-5.2), max = cms.double(5.2))
-            )
+            combinedObjectDrawables =  cms.VPSet()
         )
         ret.append(hltPixelTracks)
 

--- a/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/FSQHLTOfflineSource_cfi.py
@@ -19,10 +19,12 @@ def getHighMultVPSet():
     thresholds = [60, 85, 110, 135, 160]
     for t in thresholds:
         partialPathName = "HLT_PixelTracks_Multiplicity"+str(t)+"_v"
+        binL =  t/2
+        binH =  3*t
+        bins = (binH-binL)/5
         tracksCount  =  cms.PSet(
                 triggerSelection = cms.string(partialPathName+"*"),
                 handlerType = cms.string("RecoTrackCounter"),
-                #inputCol = cms.InputTag("hltPixelTracksForHighMult"),
                 inputCol = cms.InputTag("generalTracks"),
                 partialPathName = cms.string(partialPathName),
                 partialFilterName  = cms.string("hltL1sETT"),
@@ -35,7 +37,7 @@ def getHighMultVPSet():
                 combinedObjectDimension = cms.int32(1),
                 drawables =  cms.VPSet(
                     cms.PSet (name = cms.string("count_nominator"), expression = cms.string('at(0)'), 
-                             bins = cms.int32(30), min = cms.double(t), max = cms.double(t+t/2))
+                             bins = cms.int32(bins), min = cms.double(binL), max = cms.double(binH))
                 )
         )
         ret.append(tracksCount)				

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -156,18 +156,12 @@ class HandlerTemplate: public BaseHandler {
                 todo[CombinedObjectPlotter]=&m_combinedObjectDrawables;
                 todo[SingleObjectPlotter]=&m_singleObjectDrawables;
                 for (size_t ti =0; ti<todo.size();++ti){
-                    for (unsigned int i = 0; i < todo[ti]->size(); ++i){
-                        //std::string histoName = m_dqmhistolabel + "_" + todo[ti]->at(i).getParameter<std::string>("name");
+                    for (size_t i = 0; i < todo[ti]->size(); ++i){
                         std::string histoName = m_dqmhistolabel + "_" + todo[ti]->at(i).template getParameter<std::string>("name");
-                        //std::string expression = todo[ti]->at(i).getParameter<std::string>("expression");
                         std::string expression =   todo[ti]->at(i).template getParameter<std::string>("expression");
-                        //int bins =  todo[ti]->at(i).getParameter<int>("bins");
                         int bins =    todo[ti]->at(i).template getParameter<int>("bins");
-                        //double rangeLow  =  todo[ti]->at(i).getParameter<double>("min");
                         double rangeLow  =  todo[ti]->at(i).template getParameter<double>("min");
-                        //double rangeHigh =  todo[ti]->at(i).getParameter<double>("max");
                         double rangeHigh =  todo[ti]->at(i).template getParameter<double>("max");
-
                         m_histos[histoName] =  booker.book1D(histoName, histoName, bins, rangeLow, rangeHigh);
                         m_plotterType[histoName] = ti;
                         if (ti == CombinedObjectPlotter){
@@ -202,7 +196,7 @@ class HandlerTemplate: public BaseHandler {
               edm::LogError("FSQDiJetAve") << "product not found: "<<  input.encode();
               return -1;  // return nonsense value
            }
-           for (unsigned int i = 0; i<hIn->size(); ++i) {
+           for (size_t i = 0; i<hIn->size(); ++i) {
                 bool preselection = sel(hIn->at(i));
                 if (preselection){
                     fillSingleObjectPlots(hIn->at(i), weight);
@@ -210,10 +204,6 @@ class HandlerTemplate: public BaseHandler {
                 }
            }
            return ret;
-        }
-        void getAndStoreTokens(edm::ConsumesCollector && iC){
-                edm::EDGetTokenT<std::vector<TInputCandidateType>  > tok =  iC.consumes<std::vector<TInputCandidateType> > (m_input);
-                m_tokens[m_input.encode()] = edm::EDGetToken(tok);
         }
 
         // FIXME (?): code duplication
@@ -493,7 +483,7 @@ void HandlerTemplate<reco::GenParticle, int >::getFilteredCands(
              reco::GenParticle *, // pass a dummy pointer, makes possible to select correct getFilteredCands
              std::vector<int > & cands, // output collection
              const edm::Event& iEvent, const edm::EventSetup& iSetup,
-             const HLTConfigProvider&  hltConfig, const trigger::TriggerEvent& trgEvent)
+             const HLTConfigProvider&  hltConfig, const trigger::TriggerEvent& trgEvent, float weight)
 {
    cands.clear();
    cands.push_back(count<reco::GenParticle>(iEvent, m_input, m_singleObjectSelection, weight) );
@@ -525,7 +515,7 @@ void HandlerTemplate<reco::Track, int, BestVertexMatching>::getFilteredCands(
              const edm::Event& iEvent,  
              const edm::EventSetup& iSetup,
              const HLTConfigProvider&  hltConfig,
-             const trigger::TriggerEvent& trgEvent)
+             const trigger::TriggerEvent& trgEvent, float weight)
 {  
     // this is not elegant, but should be thread safe
     static const edm::InputTag lVerticesTag = m_pset.getParameter<edm::InputTag>("vtxCollection");
@@ -571,7 +561,7 @@ void HandlerTemplate<reco::Track, int, BestVertexMatching>::getFilteredCands(
       return;
    }
 
-   for (unsigned int i = 0; i<hIn->size(); ++i) {
+   for (size_t i = 0; i<hIn->size(); ++i) {
         if (!m_singleObjectSelection(hIn->at(i))) continue;
         dxy=0.0, dz=0.0, dxysigma=0.0, dzsigma=0.0;
         dxy = -1.*hIn->at(i).dxy(vtxPoint);

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -5,18 +5,15 @@
 // 
 /**\class FSQDiJetAve FSQDiJetAve.cc DQMOffline/FSQDiJetAve/plugins/FSQDiJetAve.cc
 
- Description: [one line class summary]
+ Description: DQM source for FSQ triggers
 
  Implementation:
-     [Notes on implementation]
 */
 //
 // Original Author:  Tomasz Fruboes
 //         Created:  Tue, 04 Nov 2014 11:36:27 GMT
 //
 //
-
-
 // system include files
 #include <memory>
 
@@ -41,11 +38,9 @@
 
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
-
 #include <DataFormats/TrackReco/interface/Track.h>
 #include <DataFormats/EgammaCandidates/interface/Photon.h>
 #include <DataFormats/MuonReco/interface/Muon.h>
-
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
@@ -106,8 +101,6 @@ class BaseHandler {
 // Handle objects saved into hlt event by hlt filters
 //
 //################################################################################################
-//
-//
 enum SpecialFilters { None, BestVertexMatching  };
 template <class TInputCandidateType, class TOutputCandidateType, SpecialFilters filter = None>
 class HandlerTemplate: public BaseHandler {
@@ -307,9 +300,7 @@ class HandlerTemplate: public BaseHandler {
                 float val = (*m_plotters[it->first])(bestCombinationFromCands);
                 it->second->Fill(val, weight);
             }
-
         }
-
 
         std::vector<TOutputCandidateType> getBestCombination(std::vector<TOutputCandidateType> & cands ){
             int columnSize = cands.size();
@@ -335,7 +326,6 @@ class HandlerTemplate: public BaseHandler {
                 it = std::unique(currentCombinationCopy.begin(), currentCombinationCopy.end());
                 currentCombinationCopy.resize( std::distance(currentCombinationCopy.begin(),it) );
                 bool duplicatesPresent = currentCombination.size() != currentCombinationCopy.size();
-
 
                 // 2. If no duplicates found - 
                 //          - check if current combination passes the cut
@@ -588,7 +578,6 @@ void HandlerTemplate<trigger::TriggerObject, trigger::TriggerObject>::getFiltere
              const HLTConfigProvider&  hltConfig,
              const trigger::TriggerEvent& trgEvent)
 {
-    
     // 1. Find matching path. Inside matchin path find matching filter
     std::string filterFullName = findPathAndFilter(hltConfig)[1];
     if (filterFullName == "") {
@@ -620,22 +609,16 @@ void HandlerTemplate<trigger::TriggerObject, trigger::TriggerObject>::getFiltere
 
 }
 
-
-
 typedef HandlerTemplate<trigger::TriggerObject, trigger::TriggerObject> HLTHandler;
 typedef HandlerTemplate<reco::Candidate::LorentzVector, reco::Candidate::LorentzVector> RecoCandidateHandler;// in fact reco::Candidate, reco::Candidate::LorentzVector
 typedef HandlerTemplate<reco::PFJet, reco::PFJet> RecoPFJetHandler;
 typedef HandlerTemplate<reco::Track, reco::Track> RecoTrackHandler;
 typedef HandlerTemplate<reco::Photon, reco::Photon> RecoPhotonHandler;
 typedef HandlerTemplate<reco::Muon, reco::Muon> RecoMuonHandler;
-
 typedef HandlerTemplate<reco::Candidate::LorentzVector, int > RecoCandidateCounter;
 typedef HandlerTemplate<reco::Track, int > RecoTrackCounter;
 typedef HandlerTemplate<reco::Track, int, BestVertexMatching> RecoTrackCounterWithVertexConstraint;
-
-// muon, genPart
 }
-
 //################################################################################################
 //
 // Plugin functions
@@ -699,7 +682,6 @@ FSQDiJetAve::FSQDiJetAve(const edm::ParameterSet& iConfig):
 
 }
 
-
 FSQDiJetAve::~FSQDiJetAve()
 {}
 
@@ -751,39 +733,26 @@ FSQDiJetAve::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
         m_handlers.at(i)->analyze(iEvent, iSetup, m_hltConfig, *m_trgEvent.product(), *m_triggerResults.product(), m_triggerNames, weight);
   }
 
-
-
 }
-
 // ------------ method called when starting to processes a run  ------------
 //*
 void 
 FSQDiJetAve::dqmBeginRun(edm::Run const& run, edm::EventSetup const& c)
 {
-
     bool changed(true);
     std::string processName = triggerResultsLabel_.process();
     if (m_hltConfig.init(run, c, processName, changed)) {
         LogDebug("FSQDiJetAve") << "HLTConfigProvider failed to initialize.";
     }
 
-
-
 }
 void FSQDiJetAve::bookHistograms(DQMStore::IBooker & booker, edm::Run const & run, edm::EventSetup const & c){
     for (size_t i = 0; i < m_handlers.size(); ++i) {
         m_handlers.at(i)->book(booker);
     }
-
-
-
 }
 
-
-
-
 //*/
-
 // ------------ method called when ending the processing of a run  ------------
 /*
 void 
@@ -817,5 +786,3 @@ FSQDiJetAve::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   descriptions.addDefault(desc);
 }
 
-//define this as a plug-in
-//DEFINE_FWK_MODULE(FSQDiJetAve);

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -190,7 +190,8 @@ class HandlerTemplate: public BaseHandler {
                      const edm::Event& iEvent,
                      const edm::EventSetup& iSetup,
                      const HLTConfigProvider&  hltConfig,
-                     const trigger::TriggerEvent& trgEvent)
+                     const trigger::TriggerEvent& trgEvent,
+                     float weight)
         {
                Handle<std::vector<TInputCandidateType> > hIn;
                iEvent.getByToken(m_tokens[m_input.encode()], hIn);
@@ -294,7 +295,7 @@ class HandlerTemplate: public BaseHandler {
             if (!triggerResults.accept(indexNum)) return;*/
 
             std::vector<TOutputCandidateType> cands;
-            getFilteredCands((TInputCandidateType *)0, cands, iEvent, iSetup, hltConfig, trgEvent);
+            getFilteredCands((TInputCandidateType *)0, cands, iEvent, iSetup, hltConfig, trgEvent, weight);
 
             if (cands.size()==0) return;
 
@@ -411,7 +412,8 @@ void HandlerTemplate<reco::Candidate::LorentzVector, reco::Candidate::LorentzVec
              const edm::Event& iEvent,  
              const edm::EventSetup& iSetup,
              const HLTConfigProvider&  hltConfig,
-             const trigger::TriggerEvent& trgEvent)
+             const trigger::TriggerEvent& trgEvent,
+             float weight)
 {  
    Handle<View<reco::Candidate> > hIn;
    iEvent.getByToken(m_tokens[m_input.encode()], hIn);
@@ -461,8 +463,11 @@ template<>
 void HandlerTemplate<reco::Track, int >::getFilteredCands(
              reco::Track *, // pass a dummy pointer, makes possible to select correct getFilteredCands
              std::vector<int > & cands, // output collection
-             const edm::Event& iEvent, const edm::EventSetup& iSetup,
-             const HLTConfigProvider&  hltConfig,  const trigger::TriggerEvent& trgEvent)
+             const edm::Event& iEvent,  
+             const edm::EventSetup& iSetup,
+             const HLTConfigProvider&  hltConfig,
+             const trigger::TriggerEvent& trgEvent,
+             float weight)
 {  
    cands.clear();
    cands.push_back(0);
@@ -588,7 +593,8 @@ void HandlerTemplate<reco::Candidate::LorentzVector, int >::getFilteredCands(
              const edm::Event& iEvent,  
              const edm::EventSetup& iSetup,
              const HLTConfigProvider&  hltConfig,
-             const trigger::TriggerEvent& trgEvent)
+             const trigger::TriggerEvent& trgEvent,
+             float weight)
 {  
    cands.clear();
    cands.push_back(0);
@@ -618,7 +624,8 @@ void HandlerTemplate<trigger::TriggerObject, trigger::TriggerObject>::getFiltere
              const edm::Event& iEvent,  
              const edm::EventSetup& iSetup,
              const HLTConfigProvider&  hltConfig,
-             const trigger::TriggerEvent& trgEvent)
+             const trigger::TriggerEvent& trgEvent,
+             float weight)
 {
     // 1. Find matching path. Inside matchin path find matching filter
     std::string filterFullName = findPathAndFilter(hltConfig)[1];

--- a/DQMOffline/Trigger/src/FSQDiJetAve.cc
+++ b/DQMOffline/Trigger/src/FSQDiJetAve.cc
@@ -115,8 +115,12 @@ class HandlerTemplate: public BaseHandler {
         StringCutObjectSelector<TInputCandidateType>  m_singleObjectSelection;
         StringCutObjectSelector<std::vector<TOutputCandidateType> >  m_combinedObjectSelection;
         StringObjectFunction<std::vector<TOutputCandidateType> >     m_combinedObjectSortFunction;
-        // TODO: auto ptr
-        std::map<std::string, std::shared_ptr<StringObjectFunction<std::vector<TOutputCandidateType> > > > m_plotters;
+        std::map<std::string, std::shared_ptr<StringObjectFunction<std::vector<TOutputCandidateType> > > > m_plottersCombinedObject;
+        std::map<std::string, std::shared_ptr<StringObjectFunction<TInputCandidateType > > > m_plottersSingleObject;
+        /// xxx
+        static const int SingleObjectPlotter = 0;
+        static const int CombinedObjectPlotter = 1;
+        std::map<std::string, int > m_plotterType;
         std::vector< edm::ParameterSet > m_combinedObjectDrawables;
         std::vector< edm::ParameterSet > m_singleObjectDrawables; // for all single objects passing preselection
         bool m_isSetup;
@@ -148,9 +152,9 @@ class HandlerTemplate: public BaseHandler {
             if(!m_isSetup){
                 booker.setCurrentFolder(m_dirname);
                 m_isSetup = true;
-                std::vector< std::vector< edm::ParameterSet > * > todo;
-                todo.push_back(&m_combinedObjectDrawables);
-                todo.push_back(&m_singleObjectDrawables);
+                std::vector< std::vector< edm::ParameterSet > * > todo(2, (std::vector< edm::ParameterSet > * )0);
+                todo[CombinedObjectPlotter]=&m_combinedObjectDrawables;
+                todo[SingleObjectPlotter]=&m_singleObjectDrawables;
                 for (size_t ti =0; ti<todo.size();++ti){
                     for (unsigned int i = 0; i < todo[ti]->size(); ++i){
                         //std::string histoName = m_dqmhistolabel + "_" + todo[ti]->at(i).getParameter<std::string>("name");
@@ -165,9 +169,16 @@ class HandlerTemplate: public BaseHandler {
                         double rangeHigh =  todo[ti]->at(i).template getParameter<double>("max");
 
                         m_histos[histoName] =  booker.book1D(histoName, histoName, bins, rangeLow, rangeHigh);
-                        StringObjectFunction<std::vector<TOutputCandidateType> > * func 
-                                = new StringObjectFunction<std::vector<TOutputCandidateType> >(expression);
-                        m_plotters[histoName] =  std::shared_ptr<StringObjectFunction<std::vector<TOutputCandidateType> > >(func);
+                        m_plotterType[histoName] = ti;
+                        if (ti == CombinedObjectPlotter){
+                            StringObjectFunction<std::vector<TOutputCandidateType> > * func 
+                                    = new StringObjectFunction<std::vector<TOutputCandidateType> >(expression);
+                            m_plottersCombinedObject[histoName] =  std::shared_ptr<StringObjectFunction<std::vector<TOutputCandidateType> > >(func);
+                        } else {
+                            StringObjectFunction< TInputCandidateType>  * func 
+                                    = new StringObjectFunction< TInputCandidateType> (expression);
+                            m_plottersSingleObject[histoName] =  std::shared_ptr<StringObjectFunction<TInputCandidateType> > (func);
+                        }
                     }   
                 }
             }
@@ -177,15 +188,51 @@ class HandlerTemplate: public BaseHandler {
                 m_tokens[m_input.encode()] = edm::EDGetToken(tok);
         }
 
+        //#############################################################################
+        // Count objects. To avoid code duplication we do it in a separate template -
+        //  - partial specialization not easy...:
+        // http://stackoverflow.com/questions/21182729/specializing-single-method-in-a-big-template-class
+        //#############################################################################
+        template <class T>
+        int count(const edm::Event& iEvent, InputTag &input, StringCutObjectSelector<T> & sel, float weight){
+           int ret = 0;
+           Handle<std::vector< T > > hIn;
+           iEvent.getByLabel(InputTag(input), hIn);
+           if(!hIn.isValid()) {
+              edm::LogError("FSQDiJetAve") << "product not found: "<<  input.encode();
+              return -1;  // return nonsense value
+           }
+           for (unsigned int i = 0; i<hIn->size(); ++i) {
+                bool preselection = sel(hIn->at(i));
+                if (preselection){
+                    fillSingleObjectPlots(hIn->at(i), weight);
+                    ret+=1;
+                }
+           }
+           return ret;
+        }
 
+        // FIXME (?): code duplication
+        void fillSingleObjectPlots(const TInputCandidateType & cand, float weight){
+            std::map<std::string,  MonitorElement*>::iterator it, itE;
+            it = m_histos.begin();
+            itE = m_histos.end();
+            for (;it!=itE;++it){
+                if (m_plotterType[it->first]!=SingleObjectPlotter) continue;
+                float val = (*m_plottersSingleObject[it->first])(cand);
+                it->second->Fill(val, weight);
+            }
+        }
         // Notes:
+        //  - this function (and specialized versions) are responsible for calling
+        //     fillSingleObjectPlots for all single objects passing the single
+        //     object preselection criteria
         //  - FIXME this function should take only event/ event setup (?)
         //  - FIXME responsibility to apply preselection should be elsewhere
         //          hard to fix, since we dont want to copy all objects due to
         //          performance reasons
-        //
-        //           implementation below working when in/out types are equal
-        //           in other cases you must provide specialized version (see below)
+        //  - note: implementation below working when in/out types are equal
+        //          in other cases you must provide specialized version (see below)
         void getFilteredCands(TInputCandidateType *, std::vector<TOutputCandidateType> & cands,
                      const edm::Event& iEvent,
                      const edm::EventSetup& iSetup,
@@ -201,10 +248,10 @@ class HandlerTemplate: public BaseHandler {
                   return;  
                }
 
-
                for (size_t i = 0; i<hIn->size(); ++i) {
                     bool preselection = m_singleObjectSelection(hIn->at(i));
                     if (preselection){
+                        fillSingleObjectPlots(hIn->at(i), weight);
                         cands.push_back(hIn->at(i));
                     }
                }
@@ -280,7 +327,6 @@ class HandlerTemplate: public BaseHandler {
             }
             if (not (*m_expression)(*m_eventCache)) return;
 
-
             /*
             std::vector<std::string> pathAndFilter = findPathAndFilter(hltConfig);
 
@@ -307,7 +353,8 @@ class HandlerTemplate: public BaseHandler {
             it = m_histos.begin();
             itE = m_histos.end();
             for (;it!=itE;++it){
-                float val = (*m_plotters[it->first])(bestCombinationFromCands);
+                if (m_plotterType[it->first]!=CombinedObjectPlotter) continue;
+                float val = (*m_plottersCombinedObject[it->first])(bestCombinationFromCands);
                 it->second->Fill(val, weight);
             }
         }
@@ -336,18 +383,10 @@ class HandlerTemplate: public BaseHandler {
                 it = std::unique(currentCombinationCopy.begin(), currentCombinationCopy.end());
                 currentCombinationCopy.resize( std::distance(currentCombinationCopy.begin(),it) );
                 bool duplicatesPresent = currentCombination.size() != currentCombinationCopy.size();
-
                 // 2. If no duplicates found - 
                 //          - check if current combination passes the cut
                 //          - rank current combination
                 if (!duplicatesPresent) { // no duplicates, we can consider this combined object
-                    /*
-                    std::cout << cnt << " " << duplicatesPresent << " ";
-                    for (int i = 0; i< dimension; ++i){
-                        std::cout << cands.at(currentCombination.at(i));
-                    }
-                    std::cout << std::endl;
-                    // */
                     std::vector<TOutputCandidateType > currentCombinationFromCands;
                     for (int i = 0; i<m_combinedObjectDimension;++i){
                         currentCombinationFromCands.push_back( cands.at(currentCombination.at(i)));
@@ -365,7 +404,6 @@ class HandlerTemplate: public BaseHandler {
                         }
                     }
                 }
-
                 // 3. Prepare next combination to test
                 //    note to future self: less error prone method with modulo
                 currentCombination.at(m_combinedObjectDimension-1)+=1; // increase last number
@@ -388,15 +426,12 @@ class HandlerTemplate: public BaseHandler {
             }
             return bestCombinationFromCands;
         }
-
 };
 //#############################################################################
-//
 // Read any object inheriting from reco::Candidate. Save p4
 //
 //  problem: for reco::Candidate there is no reflex dictionary, so selector
 //  wont work
-//
 //#############################################################################
 template<>
 void HandlerTemplate<reco::Candidate::LorentzVector, reco::Candidate::LorentzVector>::getAndStoreTokens(
@@ -424,33 +459,10 @@ void HandlerTemplate<reco::Candidate::LorentzVector, reco::Candidate::LorentzVec
    for (size_t i = 0; i<hIn->size(); ++i) {
         bool preselection = m_singleObjectSelection(hIn->at(i).p4());
         if (preselection){
+            fillSingleObjectPlots(hIn->at(i).p4(), weight);
             cands.push_back(hIn->at(i).p4());
         }
    }
-}
-//#############################################################################
-//
-// Count objects. To avoid code duplication we do it in a separate template -
-//  - partial specialization not easy...:
-// http://stackoverflow.com/questions/21182729/specializing-single-method-in-a-big-template-class
-//
-//#############################################################################
-template <class TInputClass>
-int count(const edm::Event& iEvent, InputTag &input, StringCutObjectSelector<TInputClass> & sel){
-   int ret = 0;
-   Handle<std::vector< TInputClass > > hIn;
-   iEvent.getByLabel(InputTag(input), hIn);
-   if(!hIn.isValid()) {
-      edm::LogError("FSQDiJetAve") << "product not found: "<<  input.encode();
-      return -1;  // return nonsense value
-   }
-   for (unsigned int i = 0; i<hIn->size(); ++i) {
-        bool preselection = sel(hIn->at(i));
-        if (preselection){
-            ret+=1;
-        }
-   }
-   return ret;
 }
 //#############################################################################
 //
@@ -470,21 +482,7 @@ void HandlerTemplate<reco::Track, int >::getFilteredCands(
              float weight)
 {  
    cands.clear();
-   cands.push_back(0);
-
-   Handle<std::vector<reco::Track > > hIn;
-   iEvent.getByToken(m_tokens[m_input.encode()], hIn);
-   if(!hIn.isValid()) {
-      edm::LogError("FSQDiJetAve") << "product not found: "<<  m_input.encode();
-      return;
-   }
-   for (size_t i = 0; i<hIn->size(); ++i) {
-        bool preselection = m_singleObjectSelection(hIn->at(i));
-        if (preselection){
-            cands.at(0)+=1;
-        }
-   }
-   cands.push_back(count<reco::Track>(iEvent, m_input, m_singleObjectSelection) );
+   cands.push_back(count<reco::Track>(iEvent, m_input, m_singleObjectSelection, weight) );
 }
 template<>
 void HandlerTemplate<reco::GenParticle, int >::getFilteredCands(
@@ -494,7 +492,7 @@ void HandlerTemplate<reco::GenParticle, int >::getFilteredCands(
              const HLTConfigProvider&  hltConfig, const trigger::TriggerEvent& trgEvent)
 {
    cands.clear();
-   cands.push_back(count<reco::GenParticle>(iEvent, m_input, m_singleObjectSelection) );
+   cands.push_back(count<reco::GenParticle>(iEvent, m_input, m_singleObjectSelection, weight) );
 }
 //#############################################################################
 //
@@ -608,6 +606,7 @@ void HandlerTemplate<reco::Candidate::LorentzVector, int >::getFilteredCands(
    for (size_t i = 0; i<hIn->size(); ++i) {
         bool preselection = m_singleObjectSelection(hIn->at(i).p4());
         if (preselection){
+            fillSingleObjectPlots(hIn->at(i).p4(), weight);
             cands.at(0)+=1;
         }
    }
@@ -652,6 +651,7 @@ void HandlerTemplate<trigger::TriggerObject, trigger::TriggerObject>::getFiltere
     for(;kj != khlt.end(); ++kj){
         bool preselection = m_singleObjectSelection(toc[*kj]);
         if (preselection){
+            fillSingleObjectPlots(toc[*kj], weight);
             cands.push_back( toc[*kj]);
         }
     }

--- a/DQMOffline/Trigger/test/FSQtestDQM.py
+++ b/DQMOffline/Trigger/test/FSQtestDQM.py
@@ -26,7 +26,7 @@ f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/output
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='fromMaxim/events.root'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
-f='./fromMax/events.root'
+#f='./fromMax/events.root'
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         'file:'+f
@@ -45,7 +45,8 @@ process.load('DQMServices.Components.DQMFileSaver_cfi')
 process.dqmSaver.workflow = "/HLT/FSQ/All"
 
 
-process.p = cms.Path(process.fsqHLTOfflineSource*process.fsqClient *process.dqmEnv*process.dqmSaver)
+#process.p = cms.Path(process.fsqHLTOfflineSource*process.fsqClient *process.dqmEnv*process.dqmSaver)
+process.p = cms.Path(process.fsqHLTOfflineSourceSequence*process.fsqClient *process.dqmEnv*process.dqmSaver)
 #process.MessageLogger.threshold = cms.untracked.string( "INFO" )
 #process.MessageLogger.categories.append("FSQDiJetAve")
 

--- a/DQMOffline/Trigger/test/FSQtestDQM.py
+++ b/DQMOffline/Trigger/test/FSQtestDQM.py
@@ -22,11 +22,12 @@ process.load( "Configuration.StandardSequences.FrontierConditions_GlobalTag_cff"
 process.GlobalTag.globaltag = 'MCRUN2_72_V1::All'
 
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL.root'
-f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
+#f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='fromMaxim/events.root'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='./fromMax/events.root'
+f='fromTomasz/events_hlt_singletrack_v3.root'
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         'file:'+f

--- a/DQMOffline/Trigger/test/FSQtestDQM.py
+++ b/DQMOffline/Trigger/test/FSQtestDQM.py
@@ -19,7 +19,8 @@ process.dqmEnv.subSystemFolder = 'HLT'
 process.load("DQMServices.Components.DQMEnvironment_cfi")
 
 process.load( "Configuration.StandardSequences.FrontierConditions_GlobalTag_cff" )
-process.GlobalTag.globaltag = 'MCRUN2_72_V1::All'
+#process.GlobalTag.globaltag = 'MCRUN2_72_V1::All'
+process.GlobalTag.globaltag = 'PHYS14_25_V2::All'
 
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL.root'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
@@ -28,6 +29,7 @@ process.GlobalTag.globaltag = 'MCRUN2_72_V1::All'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 f='./fromMax/events.root'
 #f='fromTomasz/events_hlt_singletrack_v3.root'
+f='/afs/cern.ch/work/m/mazarkin/public/forTomasz/events.root'
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         'file:'+f
@@ -39,6 +41,7 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-200)
 )
 
+'''
 process.load("DQMOffline.Trigger.FSQHLTOfflineSource_cfi")
 process.load("DQMOffline.Trigger.FSQHLTOfflineClient_cfi")
 
@@ -46,13 +49,22 @@ process.load('DQMServices.Components.DQMFileSaver_cfi')
 process.dqmSaver.workflow = "/HLT/FSQ/All"
 
 
-#process.p = cms.Path(process.fsqHLTOfflineSource*process.fsqClient *process.dqmEnv*process.dqmSaver)
-process.p = cms.Path(process.fsqHLTOfflineSourceSequence*process.fsqClient *process.dqmEnv*process.dqmSaver)
+process.p = cms.Path(process.fsqHLTOfflineSource*process.fsqClient *process.dqmEnv*process.dqmSaver)
+#process.p = cms.Path(process.fsqHLTOfflineSourceSequence*process.fsqClient *process.dqmEnv*process.dqmSaver)
 #process.MessageLogger.threshold = cms.untracked.string( "INFO" )
 #process.MessageLogger.categories.append("FSQDiJetAve")
+'''
+process.load("DQMOffline.Trigger.DQMOffline_Trigger_cff")
+process.load("DQMOffline.Trigger.FSQHLTOfflineClient_cfi")
+process.load('DQMServices.Components.DQMFileSaver_cfi')
+process.dqmSaver.workflow = "/HLT/FSQ/All"
+process.p = cms.Path(process.fsqHLTOfflineSourceSequence*process.fsqClient *process.dqmEnv*process.dqmSaver)
+#'''
+
+
+
 
 # TODO
 # - apply jet callibration to offline jets
 # - Fix efficiency histos - add a check, that both reference and tested path simultaneusly
 #    went beyond the hlt prescale module
-

--- a/DQMOffline/Trigger/test/FSQtestDQM.py
+++ b/DQMOffline/Trigger/test/FSQtestDQM.py
@@ -25,7 +25,8 @@ process.GlobalTag.globaltag = 'MCRUN2_72_V1::All'
 f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='fromMaxim/events.root'
-f='fromMax/events.root'
+#f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
+f='./fromMax/events.root'
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         'file:'+f

--- a/DQMOffline/Trigger/test/FSQtestDQM.py
+++ b/DQMOffline/Trigger/test/FSQtestDQM.py
@@ -26,8 +26,8 @@ process.GlobalTag.globaltag = 'MCRUN2_72_V1::All'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='fromMaxim/events.root'
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
-#f='./fromMax/events.root'
-f='fromTomasz/events_hlt_singletrack_v3.root'
+f='./fromMax/events.root'
+#f='fromTomasz/events_hlt_singletrack_v3.root'
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         'file:'+f

--- a/DQMOffline/Trigger/test/FSQtestDQM.py
+++ b/DQMOffline/Trigger/test/FSQtestDQM.py
@@ -23,7 +23,9 @@ process.GlobalTag.globaltag = 'MCRUN2_72_V1::All'
 
 #f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL.root'
 f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
+#f='/nfs/dust/cms/user/fruboest/2014.11.HLTJec721p1/CMSSW_7_2_1_patch1/src/outputFULL_big.root'
 #f='fromMaxim/events.root'
+f='fromMax/events.root'
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring(
         'file:'+f


### PR DESCRIPTION
Contains the following changes:
- All development from https://github.com/cms-sw/cmssw/pull/6942 (reverted PR)
- Fixes from https://github.com/cms-sw/cmssw/pull/7108 (reverted PR)
- Fix for a crash in HI workflow (missing products needed to apply JEC). Fix disables corrected jets production and most of FSQ trigger DQM histograms. The only histograms left (or planned to be added in the future in FSQ trigger DQM) for the HI workflow are for minbias like paths (currently ZeroBias+ single pixel track trigger)

Testing was done in a normall (non-HI) workflow with edm file missing the same product as in HI case.
