### PR TITLE
MuonIdProducer with deltaEta matching

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -439,8 +439,7 @@ bool MuonIdProducer::isGoodTrack( const reco::Track& track )
    }
 
    // Eta requirement
-   const double absEta = std::abs(track.eta());
-   if ( absEta > maxAbsEta_ ){
+   if ( fabs(track.eta()) > maxAbsEta_ ){
       LogTrace("MuonIdentification") << "Skipped track with large pseudo rapidity (Eta: " << track.eta() << " )";
       return false;
    }
@@ -451,7 +450,7 @@ bool MuonIdProducer::isGoodTrack( const reco::Track& track )
       bool isInRange = false;
       for ( auto x : muonHitsEta_ )
       {
-        if ( std::abs(x-absEta) < muonTrackDeltaEta_ )
+        if ( std::abs(x-track.eta()) < muonTrackDeltaEta_ )
         {
           isInRange = true;
           break;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -395,7 +395,7 @@ void MuonIdProducer::calculateMuonHitEtaRanges(const edm::EventSetup& eventSetup
       for ( auto& dtSegment : *dtSegmentHandle_ )
       {
          const auto& detId = dtSegment.chamberId();
-         const auto ch = geom->chamber(detId);
+         const auto& ch = geom->chamber(detId);
          const double eta = ch->toGlobal(dtSegment.localPosition()).eta();
          muonHitsEta_.push_back(eta);
       }
@@ -408,7 +408,7 @@ void MuonIdProducer::calculateMuonHitEtaRanges(const edm::EventSetup& eventSetup
       for ( auto& cscSegment : *cscSegmentHandle_ )
       {
          const CSCDetId& detId = cscSegment.cscDetId();
-         const auto ch = geom->chamber(detId);
+         const auto& ch = geom->chamber(detId);
          const double eta = ch->toGlobal(cscSegment.localPosition()).eta();
          muonHitsEta_.push_back(eta);
       }
@@ -421,7 +421,7 @@ void MuonIdProducer::calculateMuonHitEtaRanges(const edm::EventSetup& eventSetup
       for ( auto& rpcRecHit : *rpcRecHitHandle_ )
       {
          const RPCDetId& detId = rpcRecHit.rpcId();
-         const auto ch = geom->roll(detId);
+         const auto& ch = geom->roll(detId);
          const double eta = ch->toGlobal(rpcRecHit.localPosition()).eta();
          muonHitsEta_.push_back(eta);
       }

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -439,7 +439,8 @@ bool MuonIdProducer::isGoodTrack( const reco::Track& track )
    }
 
    // Eta requirement
-   if ( fabs(track.eta()) > maxAbsEta_ ){
+   const double trackEta = track.eta();
+   if ( std::abs(trackEta) > maxAbsEta_ ){
       LogTrace("MuonIdentification") << "Skipped track with large pseudo rapidity (Eta: " << track.eta() << " )";
       return false;
    }
@@ -450,7 +451,7 @@ bool MuonIdProducer::isGoodTrack( const reco::Track& track )
       bool isInRange = false;
       for ( auto x : muonHitsEta_ )
       {
-        if ( std::abs(x-track.eta()) < muonTrackDeltaEta_ )
+        if ( std::abs(x-trackEta) < muonTrackDeltaEta_ )
         {
           isInRange = true;
           break;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -46,6 +46,10 @@
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
+#include "Geometry/DTGeometry/interface/DTGeometry.h"
+#include "Geometry/CSCGeometry/interface/CSCGeometry.h"
+#include "Geometry/RPCGeometry/interface/RPCGeometry.h"
+
 #include "RecoMuon/MuonIdentification/interface/MuonMesh.h"
 
 
@@ -59,6 +63,9 @@ muIsoExtractorCalo_(0),muIsoExtractorTrack_(0),muIsoExtractorJet_(0)
    produces<reco::MuonTimeExtraMap>("combined");
    produces<reco::MuonTimeExtraMap>("dt");
    produces<reco::MuonTimeExtraMap>("csc");
+
+   if ( !iConfig.existsAs<double>("muonTrackDeltaEta") ) muonTrackDeltaEta_ = -999;
+   else muonTrackDeltaEta_ = iConfig.getParameter<double>("muonTrackDeltaEta");
 
    minPt_                   = iConfig.getParameter<double>("minPt");
    minP_                    = iConfig.getParameter<double>("minP");
@@ -153,6 +160,9 @@ muIsoExtractorCalo_(0),muIsoExtractorTrack_(0),muIsoExtractorJet_(0)
    //create mesh holder
    meshAlgo_ = new MuonMesh(iConfig.getParameter<edm::ParameterSet>("arbitrationCleanerOptions"));
 
+   edm::ParameterSet trackAssocPSets = iConfig.getParameter<edm::ParameterSet>("TrackAssociatorParameters");
+   dtSegmentToken_ = consumes<DTRecSegment4DCollection>(trackAssocPSets.getParameter<edm::InputTag>("DTRecSegment4DCollectionLabel"));
+   cscSegmentToken_ = consumes<CSCSegmentCollection>(trackAssocPSets.getParameter<edm::InputTag>("CSCSegmentCollectionLabel"));
 
    edm::InputTag rpcHitTag("rpcRecHits");
    rpcHitToken_ = consumes<RPCRecHitCollection>(rpcHitTag);
@@ -281,6 +291,10 @@ void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup)
       }
       throw cms::Exception("FatalError") << "Unknown input collection type: " << inputCollectionTypes_[i];
    }
+
+   iEvent.getByToken(dtSegmentToken_, dtSegmentHandle_);
+   iEvent.getByToken(cscSegmentToken_, cscSegmentHandle_);
+   iEvent.getByToken(rpcHitToken_, rpcRecHitHandle_);
 }
 
 reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent, const edm::EventSetup& iSetup,
@@ -368,6 +382,52 @@ reco::Muon MuonIdProducer::makeMuon( const reco::MuonTrackLinks& links )
    return aMuon;
 }
 
+void MuonIdProducer::calculateMuonHitEtaRanges(const edm::EventSetup& eventSetup)
+{
+   if ( muonTrackDeltaEta_ <= 0 ) return;
+   muonHitsEta_.clear();
+
+   // Collect eta values from DT, CSC, segments and RPC hits
+   if ( dtSegmentHandle_.isValid() )
+   {
+      edm::ESHandle<DTGeometry> geom;
+      eventSetup.get<MuonGeometryRecord>().get(geom);
+      for ( auto& dtSegment : *dtSegmentHandle_ )
+      {
+         const auto& detId = dtSegment.chamberId();
+         const auto ch = geom->chamber(detId);
+         const double eta = ch->toGlobal(dtSegment.localPosition()).eta();
+         muonHitsEta_.push_back(eta);
+      }
+   }
+
+   if ( cscSegmentHandle_.isValid() )
+   {
+      edm::ESHandle<CSCGeometry> geom;
+      eventSetup.get<MuonGeometryRecord>().get(geom);
+      for ( auto& cscSegment : *cscSegmentHandle_ )
+      {
+         const CSCDetId& detId = cscSegment.cscDetId();
+         const auto ch = geom->chamber(detId);
+         const double eta = ch->toGlobal(cscSegment.localPosition()).eta();
+         muonHitsEta_.push_back(eta);
+      }
+   }
+
+   if ( rpcRecHitHandle_.isValid() )
+   {
+      edm::ESHandle<RPCGeometry> geom;
+      eventSetup.get<MuonGeometryRecord>().get(geom);
+      for ( auto& rpcRecHit : *rpcRecHitHandle_ )
+      {
+         const RPCDetId& detId = rpcRecHit.rpcId();
+         const auto ch = geom->roll(detId);
+         const double eta = ch->toGlobal(rpcRecHit.localPosition()).eta();
+         muonHitsEta_.push_back(eta);
+      }
+   }
+
+}
 
 bool MuonIdProducer::isGoodTrack( const reco::Track& track )
 {
@@ -379,10 +439,27 @@ bool MuonIdProducer::isGoodTrack( const reco::Track& track )
    }
 
    // Eta requirement
-   if ( fabs(track.eta()) > maxAbsEta_ ){
+   const double absEta = std::abs(track.eta());
+   if ( absEta > maxAbsEta_ ){
       LogTrace("MuonIdentification") << "Skipped track with large pseudo rapidity (Eta: " << track.eta() << " )";
       return false;
    }
+
+   // Additional Eta requirements
+   if ( muonTrackDeltaEta_ > 0 )
+   {
+      bool isInRange = false;
+      for ( auto x : muonHitsEta_ )
+      {
+        if ( std::abs(x-absEta) < muonTrackDeltaEta_ )
+        {
+          isInRange = true;
+          break;
+        }
+      }
+      if ( !isInRange ) return false;
+   }
+
    return true;
 }
 
@@ -570,6 +647,9 @@ void MuonIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    // tracker and calo muons are next
    if ( innerTrackCollectionHandle_.isValid() ) {
       LogTrace("MuonIdentification") << "Creating tracker muons";
+
+      calculateMuonHitEtaRanges(iSetup);
+
       for ( unsigned int i = 0; i < innerTrackCollectionHandle_->size(); ++i )
 	{
 	   const reco::Track& track = innerTrackCollectionHandle_->at(i);
@@ -857,16 +937,13 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
    }
    if ( ! fillMatching_ && ! aMuon.isTrackerMuon() && ! aMuon.isRPCMuon() ) return;
 
-  edm::Handle<RPCRecHitCollection> rpcRecHits;
-  iEvent.getByToken(rpcHitToken_, rpcRecHits);
-
    // fill muon match info
    std::vector<reco::MuonChamberMatch> muonChamberMatches;
    unsigned int nubmerOfMatchesAccordingToTrackAssociator = 0;
    for( std::vector<TAMuonChamberMatch>::const_iterator chamber=info.chambers.begin();
 	chamber!=info.chambers.end(); chamber++ )
      {
-       if  (chamber->id.subdetId() == 3 && rpcRecHits.isValid()  ) continue; // Skip RPC chambers, they are taken care of below)
+       if  (chamber->id.subdetId() == 3 && rpcRecHitHandle_.isValid()  ) continue; // Skip RPC chambers, they are taken care of below)
 	reco::MuonChamberMatch matchedChamber;
 
 	LocalError localError = chamber->tState.localError().positionError();
@@ -933,7 +1010,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
      }
 
   // Fill RPC info
-  if ( rpcRecHits.isValid() )
+  if ( rpcRecHitHandle_.isValid() )
   {
 
    for( std::vector<TAMuonChamberMatch>::const_iterator chamber=info.chambers.begin();
@@ -962,8 +1039,8 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
 
       matchedChamber.id = chamber->id;
 
-      for ( RPCRecHitCollection::const_iterator rpcRecHit = rpcRecHits->begin();
-            rpcRecHit != rpcRecHits->end(); ++rpcRecHit )
+      for ( RPCRecHitCollection::const_iterator rpcRecHit = rpcRecHitHandle_->begin();
+            rpcRecHit != rpcRecHitHandle_->end(); ++rpcRecHit )
       {
         reco::MuonRPCHitMatch rpcHitMatch;
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -114,6 +114,8 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    double phiOfMuonIneteractionRegion( const reco::Muon& muon ) const;
 
    bool checkLinks(const reco::MuonTrackLinks*) const ;
+
+   void calculateMuonHitEtaRanges(const edm::EventSetup& eventSetup);
      
    TrackDetectorAssociator trackAssociator_;
    TrackAssociatorParameters parameters_;
@@ -124,6 +126,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    MuonTimingFiller* theTimingFiller_;
 
    // selections
+   double muonTrackDeltaEta_;
    double minPt_;
    double minP_;
    double minPCaloMuon_;
@@ -164,9 +167,14 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    edm::EDGetTokenT<reco::TrackToTrackMap>             pickyCollectionToken_;
    edm::EDGetTokenT<reco::TrackToTrackMap>             dytCollectionToken_;
 
+   edm::EDGetTokenT<DTRecSegment4DCollection> dtSegmentToken_;
+   edm::EDGetTokenT<CSCSegmentCollection> cscSegmentToken_;
    edm::EDGetTokenT<RPCRecHitCollection> rpcHitToken_;
    edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > glbQualToken_;
 
+   edm::Handle<DTRecSegment4DCollection> dtSegmentHandle_;
+   edm::Handle<CSCSegmentCollection> cscSegmentHandle_;
+   edm::Handle<RPCRecHitCollection> rpcRecHitHandle_;
 
    
    MuonCaloCompatibility muonCaloCompatibility_;
@@ -190,6 +198,8 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    
    bool arbClean_;
    MuonMesh* meshAlgo_;
+
+   std::vector<double> muonHitsEta_;
 
 };
 #endif

--- a/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
+++ b/RecoMuon/MuonIdentification/python/earlyMuons_cfi.py
@@ -8,6 +8,7 @@ earlyMuons = muons1stStep.clone(
     minP         = 3.0, # was 2.5
     minPt        = 2.0, # was 0.5
     minPCaloMuon = 3.0, # was 1.0
+    muonTrackDeltaEta = cms.double(-999), # Negative value turns off dEta matching
     fillCaloCompatibility = False,
     fillEnergy = False,
     fillGlobalTrackQuality = False,

--- a/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
+++ b/RecoMuon/MuonIdentification/python/muons1stStep_cfi.py
@@ -25,6 +25,7 @@ muons1stStep = cms.EDProducer("MuonIdProducer",
 
     # Selection parameters
     minPt = cms.double(0.5),
+    muonTrackDeltaEta = cms.double(0.5),
     inputCollectionTypes = cms.vstring('inner tracks', 
                                        'links', 
                                        'outer tracks',


### PR DESCRIPTION
This is same one of the PR #6370 which was not merged in the previous release cycle.
deltaEta(track, muon segment) preselection in MuonIdProducer can reduce CPU time of tracker muon reconstruction.
The improvement of CPU performance depends on deltaEta value but usually we observe 60% of reduction in ttbar samples.

CaloMuons are dropped with this change since the new code explicitly requires muon segment before track extrapolation.
Survey have been made on the usage of CaloMuons, no one seem to be using it.
(https://hypernews.cern.ch/HyperNews/CMS/get/muon/1069.html)

Some muons are lost with new version, but they are mostly fake muons
An event display with JpsiMuMu sample is given below (left = old, right = new)
![screenshot](https://cloud.githubusercontent.com/assets/4388926/5807587/1a6e7736-a025-11e4-942f-91b9deeaf995.png)
In this event, a muon pt at 0.8 is dropped in new version but this is not matched to the genParticle with status=1, abs(pdgid)=13.
