### PR TITLE
PileupJetId falling back to Muon::bestTrack for PFCandidate muon without a trackRef

### DIFF
--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -392,6 +392,14 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 			  lLeadCh = icand;
 			
 			  const reco::Track* pfTrk = icand->bestTrack();
+			  if (lPF && std::abs(icand->pdgId()) == 13 && pfTrk == nullptr){
+			    reco::MuonRef lmuRef = lPF->muonRef();
+			    if (lmuRef.isNonnull()){
+			      const reco::Muon& lmu = *lmuRef.get();
+			      pfTrk = lmu.bestTrack();
+			      edm::LogWarning("BadMuon")<<"Found a PFCandidate muon without a trackRef: falling back to Muon::bestTrack ";
+			    }
+			  }
 			  if(pfTrk==nullptr) { //protection against empty pointers for the miniAOD case
 			    //To handle the electron case
 			    if(lPF!=nullptr) {


### PR DESCRIPTION
Fixes a crash in PileupJetId https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc491/CMSSW_7_4_X_2015-01-18-0200/pyRelValMatrixLogs/run/50202.0_TTbar_13+TTbar_13INPUT+DIGIUP15_PU50+RECOUP15_PU50+HARVESTUP15+MINIAODMCUP1550/step5_TTbar_13+TTbar_13INPUT+DIGIUP15_PU50+RECOUP15_PU50+HARVESTUP15+MINIAODMCUP1550.log

Recent change in 
https://github.com/cms-sw/cmssw/commit/ce1863b6512fb541506a1ed37bd17fc76b309a41#diff-34b721ce73bd0269273004088c8a715fL400

```
- reco::Track impactTrack = (lPack==nullptr)?(*pfTrk):(lPack->pseudoTrack());
+ const reco::Track& impactTrack = (lPack==nullptr)?(*pfTrk):(lPack->pseudoTrack());

```

exposed a problem with pfTrk being a nullptr and we
With the const ref used now we end up with an invalid reference and a segfault.

It's curious that the result of the following depends on optimization flags:

``` C++
#include  <iostream>

class AS {
public:
  float x;
};

int main(){
  AS* anullP = nullptr;
  AS anullV = *anullP;
  std::cout<<"Really: "<<anullV.x<<std::endl;

  return 0;
}

```

gives:

```
gcc -o a.exe test_null.cc -lstdc++ -std=c++11 -O0
~>./a.exe 
Segmentation fault: 11
gcc -o a.exe test_null.cc -lstdc++ -std=c++11 -O1
~>./a.exe 
Really: 0
```
