### PR TITLE
Migrating TrigXMonitor to new DQM API

### DIFF
--- a/DQM/TrigXMonitor/interface/HLTScalers.h
+++ b/DQM/TrigXMonitor/interface/HLTScalers.h
@@ -1,9 +1,9 @@
 // -*-c++-*-
-// 
 //
-// Class to collect HLT scaler information 
+//
+// Class to collect HLT scaler information
 // for Trigger Cross Section Monitor
-// [wittich 11/07] 
+// [wittich 11/07]
 
 // Revision 1.19  2011/03/29 09:46:03  rekovic
 // clean vector pairPDPaths in beginRun and tidy up
@@ -57,58 +57,35 @@
 #define HLTSCALERS_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "DQMServices/Core/interface/DQMStore.h"
-
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
-
-class HLTScalers: public edm::EDAnalyzer
-{
-public:
-  /// Constructors
-  HLTScalers(const edm::ParameterSet& ps);
-  
-  /// Destructor
-  virtual ~HLTScalers() {};
-  
-  /// BeginJob
+class HLTScalers : public DQMEDAnalyzer {
+ public:
+  HLTScalers(const edm::ParameterSet &ps);
+  virtual ~HLTScalers(){};
   void beginJob(void);
+  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
+                      edm::EventSetup const &) override;
+  void beginLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
+                            const edm::EventSetup &c);
+  void analyze(const edm::Event &e, const edm::EventSetup &c);
+  /// DQM Client Diagnostic should be performed here:
+  void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
+                          const edm::EventSetup &c);
+  void endRun(const edm::Run &run, const edm::EventSetup &c);
 
-//   /// Endjob
-//   void endJob(void);
-  
-  /// BeginRun
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
-
-  /// EndRun
-  void endRun(const edm::Run& run, const edm::EventSetup& c);
-
-  
-  /// Begin LumiBlock
-  void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-			    const edm::EventSetup& c) ;
-
-  /// End LumiBlock
-  /// DQM Client Diagnostic should be performed here
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c);
-
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
-
-
-private:
-
+ private:
   HLTConfigProvider hltConfig_;
-  std::string folderName_; // dqm folder name
+  std::string folderName_;  // dqm folder name
   std::string processname_;
-  std::vector <std::pair<std::string, std::vector<std::string> > > pairPDPaths_;
+  std::vector<std::pair<std::string, std::vector<std::string> > > pairPDPaths_;
   edm::EDGetTokenT<edm::TriggerResults> trigResultsSource_;
 
-  DQMStore * dbe_;
   MonitorElement *scalersPD_;
   MonitorElement *scalers_;
   MonitorElement *scalersN_;
@@ -122,12 +99,11 @@ private:
   MonitorElement *hltOverallScalerN_;
   MonitorElement *diagnostic_;
 
-  bool resetMe_, sentPaths_, monitorDaemon_; 
+  bool resetMe_, sentPaths_, monitorDaemon_;
 
-  int nev_; // Number of events processed
-  int nLumi_; // number of lumi blocks
+  int nev_;    // Number of events processed
+  int nLumi_;  // number of lumi blocks
   int currentRun_;
-
 };
 
-#endif // HLTSCALERS_H
+#endif  // HLTSCALERS_H

--- a/DQM/TrigXMonitor/interface/HLTSeedL1LogicScalers.h
+++ b/DQM/TrigXMonitor/interface/HLTSeedL1LogicScalers.h
@@ -2,8 +2,9 @@
 //
 // Package:    HLTSeedL1LogicScalers
 // Class:      HLTSeedL1LogicScalers
-// 
-/**\class HLTSeedL1LogicScalers HLTSeedL1LogicScalers.cc DQM/HLTSeedL1LogicScalers/src/HLTSeedL1LogicScalers.cc
+//
+/**\class HLTSeedL1LogicScalers HLTSeedL1LogicScalers.cc
+ DQM/HLTSeedL1LogicScalers/src/HLTSeedL1LogicScalers.cc
 
  Description: [one line class summary]
 
@@ -24,69 +25,53 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
 
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
+
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h"
-
-
-#include "DQMServices/Core/interface/MonitorElement.h"
 
 //
 // class declaration
 //
+class HLTSeedL1LogicScalers : public DQMEDAnalyzer {
+ public:
+  explicit HLTSeedL1LogicScalers(const edm::ParameterSet&);
+  ~HLTSeedL1LogicScalers();
 
-class HLTSeedL1LogicScalers : public edm::EDAnalyzer {
-   public:
-      explicit HLTSeedL1LogicScalers(const edm::ParameterSet&);
-      ~HLTSeedL1LogicScalers();
+ private:
+  void dqmBeginRun(const edm::Run &run, const edm::EventSetup &c);
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
+                      edm::EventSetup const &) override;
+  virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
+  bool analyzeL1GtUtils(const edm::Event&, const edm::EventSetup&,
+                        const std::string&);
 
-   private:
-      virtual void beginJob() ;
-      virtual void analyze(const edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
-      virtual void beginRun(const edm::Run& run, const edm::EventSetup& c) ;
-      bool analyzeL1GtUtils(const edm::Event&, const edm::EventSetup&, const std::string &);
-      bool analyzeL1GtRecord(const edm::Event&, const edm::EventSetup&, std::string);
+  // ----------member data ---------------------------
+  bool fL1BeforeMask;
+  std::string fDQMFolder;
+  std::string fProcessname;
 
+  L1GtUtils m_l1GtUtils;
 
+  HLTConfigProvider fHLTConfig;
+  edm::InputTag fL1GtDaqReadoutRecordInputTag;
+  edm::InputTag fL1GtRecordInputTag;
 
-      // ----------member data ---------------------------
-
-      bool fL1BeforeMask;
-      std::string fDQMFolder;
-      std::string fProcessname;
-
-      DQMStore * fDbe;
-
-      L1GtUtils m_l1GtUtils;
-
-      HLTConfigProvider fHLTConfig;
-      /*
-      edm::Handle<edm::TriggerResults> fTriggerResults;
-
-      edm::InputTag fTriggerResultsLabel;
-      edm::InputTag fL1GtLabel;
-      */
-      edm::InputTag fL1GtDaqReadoutRecordInputTag;
-      edm::InputTag fL1GtRecordInputTag;
-
-
-      std::vector<std::string> fMonitorPaths;
-      std::vector<MonitorElement*> fMonitorPathsME;
-      std::vector<std::pair<MonitorElement*, std::vector<std::string> > > fMapMEL1Algos;
-
+  std::vector<std::string> fMonitorPaths;
+  std::vector<MonitorElement*> fMonitorPathsME;
+  std::vector<std::pair<MonitorElement*, std::vector<std::string> > >
+      fMapMEL1Algos;
 };
 
-#endif // HLTSEEDSCALERS_H
+#endif  // HLTSEEDSCALERS_H

--- a/DQM/TrigXMonitor/interface/L1Scalers.h
+++ b/DQM/TrigXMonitor/interface/L1Scalers.h
@@ -3,54 +3,31 @@
 #define L1Scalers_H
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "DQMServices/Core/interface/DQMStore.h"
-
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #define MAX_LUMI_SEG 2000
 #define MAX_LUMI_BIN 400
 
-class L1Scalers: public edm::EDAnalyzer
-{
-public:
-  /// Constructors
-  L1Scalers(const edm::ParameterSet& ps);
-  
-  /// Destructor
-  virtual ~L1Scalers() {};
-  
-  /// BeginJob
-  void beginJob(void);
+class L1Scalers : public DQMEDAnalyzer {
+ public:
+  L1Scalers(const edm::ParameterSet &ps);
+  virtual ~L1Scalers(){};
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
+                      edm::EventSetup const &) override;
+  void analyze(const edm::Event &e, const edm::EventSetup &c);
+  /// DQM Client Diagnostic should be performed here:
+  void endLuminosityBlock(const edm::LuminosityBlock &lumiSeg,
+                          const edm::EventSetup &c);
 
-   // Endjob
-   void endJob(void);
-  
-  /// BeginRun
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
-
-  /// EndRun
-  void endRun(const edm::Run& run, const edm::EventSetup& c);
-
-  
-
-  /// End LumiBlock
-  /// DQM Client Diagnostic should be performed here
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c);
-
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
-
-
-private:
-  DQMStore * dbe_;
-  int nev_; // Number of events processed
+ private:
+  int nev_;  // Number of events processed
 
   bool verbose_;
-  edm::InputTag l1GtDataSource_; // L1 Scalers
-  
+  edm::InputTag l1GtDataSource_;  // L1 Scalers
+
   bool denomIsTech_;
   unsigned int denomBit_;
   bool tfIsTech_;
@@ -58,29 +35,26 @@ private:
   std::vector<unsigned int> algoSelected_;
   std::vector<unsigned int> techSelected_;
 
-  std::string folderName_; // dqm folder name
+  std::string folderName_;  // dqm folder name
   MonitorElement *l1scalers_;
   MonitorElement *l1techScalers_;
   MonitorElement *l1Correlations_;
   MonitorElement *bxNum_;
 
-
   // 2d versions
   MonitorElement *l1scalersBx_;
   MonitorElement *l1techScalersBx_;
-//   MonitorElement *pixFedSizeBx_;
-//   MonitorElement *hfEnergyMaxTowerBx_;
 
   // Int
   MonitorElement *nLumiBlock_;
-  MonitorElement *l1AlgoCounter_;  //for total Algo Rate
-  MonitorElement *l1TtCounter_;    //for total TT Rate
+  MonitorElement *l1AlgoCounter_;  // for total Algo Rate
+  MonitorElement *l1TtCounter_;  // for total TT Rate
 
-  //timing plots
-  std::vector<MonitorElement* > algoBxDiff_;
-  std::vector<MonitorElement* > techBxDiff_;
-  std::vector<MonitorElement* > algoBxDiffLumi_;
-  std::vector<MonitorElement* > techBxDiffLumi_;
+  // timing plots
+  std::vector<MonitorElement *> algoBxDiff_;
+  std::vector<MonitorElement *> techBxDiff_;
+  std::vector<MonitorElement *> algoBxDiffLumi_;
+  std::vector<MonitorElement *> techBxDiffLumi_;
   MonitorElement *dtBxDiff_;
   MonitorElement *dtBxDiffLumi_;
   MonitorElement *cscBxDiff_;
@@ -90,27 +64,21 @@ private:
   MonitorElement *rpcfBxDiff_;
   MonitorElement *rpcfBxDiffLumi_;
 
-  // Hacks for early running
-//   MonitorElement *pixFedSize_;
-//   MonitorElement *hfEnergy_;
   // steal from HLTrigger/special
   unsigned int threshold_;
-  unsigned int fedStart_, fedStop_ ;
-  //total Rates
-  unsigned int rateAlgoCounter_;  //for total Algo Rate
-  unsigned int rateTtCounter_;     //for total TT Rate
- 
+  unsigned int fedStart_, fedStop_;
+  // total Rates
+  unsigned int rateAlgoCounter_;  // for total Algo Rate
+  unsigned int rateTtCounter_;  // for total TT Rate
 
   edm::InputTag fedRawCollection_;
 
   std::vector<int> maskedList_;
   edm::InputTag HcalRecHitCollection_;
-  // END HACK
 
   int earliestDenom_;
   std::vector<int> earliestTech_;
   std::vector<int> earliestAlgo_;
-
 };
 
-#endif // L1Scalers_H
+#endif  // L1Scalers_H

--- a/DQM/TrigXMonitor/interface/L1TScalersSCAL.h
+++ b/DQM/TrigXMonitor/interface/L1TScalersSCAL.h
@@ -1,128 +1,91 @@
 #ifndef L1TScalersSCAL_H
 #define L1TScalersSCAL_H
 
-#include<vector>
+#include <vector>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
-
 #include "DQMServices/Core/interface/DQMStore.h"
-
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-class L1TScalersSCAL: public edm::EDAnalyzer
-{
-public:
-
+class L1TScalersSCAL : public DQMEDAnalyzer {
+ public:
   enum { N_LUMISECTION_TIME = 93 };
-
-  /// Constructors
+  
   L1TScalersSCAL(const edm::ParameterSet& ps);
-      
-  /// Destructor
   virtual ~L1TScalersSCAL();
-            
-  /// BeginJob
-  void beginJob(void);
-                
-  /// Endjob
-  void endJob(void);
-                     
-  /// BeginRun
-  void beginRun(const edm::Run& run, const edm::EventSetup& c);
-                         
-  /// EndRun
-  void endRun(const edm::Run& run, const edm::EventSetup& c);
-                                                            
-//   /// Begin LumiBlock
-//   void beginLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-//                             const edm::EventSetup& c) ;
-                               
-  /// End LumiBlock
-  /// DQM Client Diagnostic should be performed here
-  void endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-                          const edm::EventSetup& c);
-                                  
-  void analyze(const edm::Event& e, const edm::EventSetup& c) ;
-
-
-private:
-  DQMStore * dbe_;
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &,
+                      edm::EventSetup const &) override;
+  void analyze(const edm::Event& e, const edm::EventSetup& c);
+ private:
   edm::InputTag scalersSource_;
-                                                                     
-  std::string outputFile_;	//file name for ROOT ouput
+
   bool verbose_, denomIsTech_, monitorDaemon_;
-  unsigned int denomBit_, muonBit_,egammaBit_,jetBit_;
-  int nev_; // Number of events processed
-  long reftime_,buffertime_;
+  unsigned int denomBit_, muonBit_, egammaBit_, jetBit_;
+  int nev_;  // Number of events processed
+  long reftime_, buffertime_;
   std::vector<double> algorithmRates_;
   std::vector<double> bufferAlgoRates_;
   std::vector<double> technicalRates_;
-  std::vector<double> bufferTechRates_;                                 
-  std::vector<double> integral_algo_;                                 
-  std::vector<double> integral_tech_;                                 
-  double   integral_tech_42_OR_43_;
+  std::vector<double> bufferTechRates_;
+  std::vector<double> integral_algo_;
+  std::vector<double> integral_tech_;
+  double integral_tech_42_OR_43_;
   unsigned int bufferLumi_;
 
-  MonitorElement * orbitNum;
-  MonitorElement * trigNum;
-  MonitorElement * eventNum;
-  MonitorElement * physTrig;
-  MonitorElement * randTrig;
-  MonitorElement * numberResets;
-  MonitorElement * deadTime;
-  MonitorElement * lostFinalTriggers;
-  MonitorElement * algoRate[128];
-  MonitorElement * techRate[64];
-  MonitorElement * integralAlgo[128];
-  MonitorElement * integralTech[64];
-  MonitorElement * integralTech_42_OR_43;
-  MonitorElement * techRateRatio_33_over_32;
-  MonitorElement * techRateRatio_8;
-  MonitorElement * techRateRatio_9;
-  MonitorElement * techRateRatio_10;
-  MonitorElement * techRateRatio_36;
-  MonitorElement * techRateRatio_37;
-  MonitorElement * techRateRatio_38;
-  MonitorElement * techRateRatio_39;
-  MonitorElement * techRateRatio_40;
-  MonitorElement * techRateRatio_41;
-  MonitorElement * techRateRatio_42;
-  MonitorElement * techRateRatio_43;
-  MonitorElement * rateRatio_mu;
-  MonitorElement * rateRatio_egamma;
-  MonitorElement * rateRatio_jet;
+  MonitorElement* orbitNum;
+  MonitorElement* trigNum;
+  MonitorElement* eventNum;
+  MonitorElement* physTrig;
+  MonitorElement* randTrig;
+  MonitorElement* numberResets;
+  MonitorElement* deadTime;
+  MonitorElement* lostFinalTriggers;
+  MonitorElement* algoRate[128];
+  MonitorElement* techRate[64];
+  MonitorElement* integralAlgo[128];
+  MonitorElement* integralTech[64];
+  MonitorElement* integralTech_42_OR_43;
+  MonitorElement* techRateRatio_33_over_32;
+  MonitorElement* techRateRatio_8;
+  MonitorElement* techRateRatio_9;
+  MonitorElement* techRateRatio_10;
+  MonitorElement* techRateRatio_36;
+  MonitorElement* techRateRatio_37;
+  MonitorElement* techRateRatio_38;
+  MonitorElement* techRateRatio_39;
+  MonitorElement* techRateRatio_40;
+  MonitorElement* techRateRatio_41;
+  MonitorElement* techRateRatio_42;
+  MonitorElement* techRateRatio_43;
+  MonitorElement* rateRatio_mu;
+  MonitorElement* rateRatio_egamma;
+  MonitorElement* rateRatio_jet;
 
+  MonitorElement* physRate;
+  MonitorElement* randRate;
+  MonitorElement* deadTimePercent;
+  MonitorElement* lostPhysRate;
+  MonitorElement* lostPhysRateBeamActive;
+  MonitorElement* instTrigRate;
+  MonitorElement* instEventRate;
 
-  MonitorElement * physRate;
-  MonitorElement * randRate;
-  MonitorElement * deadTimePercent;
-  MonitorElement * lostPhysRate;
-  MonitorElement * lostPhysRateBeamActive;
-  MonitorElement * instTrigRate;
-  MonitorElement * instEventRate;
-  
+  MonitorElement* instLumi;
+  MonitorElement* instLumiErr;
+  MonitorElement* instLumiQlty;
+  MonitorElement* instEtLumi;
+  MonitorElement* instEtLumiErr;
+  MonitorElement* instEtLumiQlty;
+  MonitorElement* sectionNum;
+  MonitorElement* startOrbit;
+  MonitorElement* numOrbits;
 
-  MonitorElement *  instLumi;
-  MonitorElement *  instLumiErr; 
-  MonitorElement *  instLumiQlty; 
-  MonitorElement *  instEtLumi; 
-  MonitorElement *  instEtLumiErr; 
-  MonitorElement *  instEtLumiQlty; 
-  MonitorElement *  sectionNum; 
-  MonitorElement *  startOrbit; 
-  MonitorElement *  numOrbits;   
-
- 
-  MonitorElement *  orbitNumL1A[4];
-  MonitorElement *  bunchCrossingL1A[4];
-  MonitorElement *  bunchCrossingCorr[3];
-  MonitorElement *  bunchCrossingDiff[3];
-  MonitorElement *  bunchCrossingDiff_small[3];
-
-
+  MonitorElement* orbitNumL1A[4];
+  MonitorElement* bunchCrossingL1A[4];
+  MonitorElement* bunchCrossingCorr[3];
+  MonitorElement* bunchCrossingDiff[3];
+  MonitorElement* bunchCrossingDiff_small[3];
 };
 
-#endif // L1TScalersSCAL_H
-
+#endif  // L1TScalersSCAL_H

--- a/DQM/TrigXMonitor/src/HLTSeedL1LogicScalers.cc
+++ b/DQM/TrigXMonitor/src/HLTSeedL1LogicScalers.cc
@@ -10,66 +10,144 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
 
-
-
 using namespace edm;
 using namespace std;
 using namespace trigger;
 
-//
-// constants, enums and typedefs
-//
-
-//
-// static data member definitions
-//
-
-//
-// constructors and destructor
-//
-HLTSeedL1LogicScalers::HLTSeedL1LogicScalers(const edm::ParameterSet& iConfig)
-
-{
-   //now do what ever initialization is needed
-  LogDebug("HLTSeedL1LogicScalers") << "constructor" ;
+HLTSeedL1LogicScalers::HLTSeedL1LogicScalers(const edm::ParameterSet& iConfig) {
+  // now do what ever initialization is needed
+  LogDebug("HLTSeedL1LogicScalers") << "constructor";
 
   // get untracked parameters
   ///////////////////////////
   fL1BeforeMask = iConfig.getParameter<bool>("l1BeforeMask");
-  fProcessname  = iConfig.getParameter<std::string>("processname");
+  fProcessname = iConfig.getParameter<std::string>("processname");
 
   // input tag for GT DAQ product
-  fL1GtDaqReadoutRecordInputTag  = iConfig.getParameter<edm::InputTag>("L1GtDaqReadoutRecordInputTag");
+  fL1GtDaqReadoutRecordInputTag =
+      iConfig.getParameter<edm::InputTag>("L1GtDaqReadoutRecordInputTag");
 
   // input tag for GT lite product
-  fL1GtRecordInputTag = iConfig.getParameter<edm::InputTag>("L1GtRecordInputTag");
+  fL1GtRecordInputTag =
+      iConfig.getParameter<edm::InputTag>("L1GtRecordInputTag");
 
   // get untracked parameters
-  ///////////////////////////
-  fDQMFolder    = iConfig.getUntrackedParameter("DQMFolder", string("HLT/HLTSeedL1LogicScalers/HLT_LogicL1"));
-  fMonitorPaths = iConfig.getUntrackedParameter<std::vector<std::string > >("monitorPaths");
-
-  fDbe = Service < DQMStore > ().operator->();
-
-  if ( ! fDbe ) {
-    LogInfo("HLTSeedL1LogicScalers") << "unable to get DQMStore service?";
-  }
-  else {
-    fDbe->setCurrentFolder(fDQMFolder);
-  }
-  
+  fDQMFolder = iConfig.getUntrackedParameter(
+      "DQMFolder", string("HLT/HLTSeedL1LogicScalers/HLT_LogicL1"));
+  fMonitorPaths =
+      iConfig.getUntrackedParameter<std::vector<std::string> >("monitorPaths");
 }
 
+HLTSeedL1LogicScalers::~HLTSeedL1LogicScalers() {}
 
-HLTSeedL1LogicScalers::~HLTSeedL1LogicScalers()
-{
+void HLTSeedL1LogicScalers::dqmBeginRun(const edm::Run& run,
+                                        const edm::EventSetup& iSetup) {
+  // HLT config does not change within runs!
+  bool changed = false;
+  if (!fHLTConfig.init(run, iSetup, fProcessname, changed)) {
+    LogDebug("HLTSeedL1LogicScalers")
+        << "HLTConfigProvider failed to initialize.";
+    return;
+  }
+
+  const unsigned int n(fHLTConfig.size());
+  for (unsigned int j = 0; j != n; ++j) {
+    LogTrace("HLTSeedL1LogicScalers") << "HLTConfig path "
+                                      << fHLTConfig.triggerName(j) << endl;
+  }
 }
 
-void
-HLTSeedL1LogicScalers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void HLTSeedL1LogicScalers::bookHistograms(DQMStore::IBooker& iBooker,
+                                           edm::Run const&,
+                                           edm::EventSetup const&) {
+  // book histos for L1 logic of specificified HLT paths
+  LogTrace("HLTSeedL1LogicScalers")
+      << "size of vector of paths to monitor = " << fMonitorPaths.size()
+      << endl;
+  for (unsigned int iPath = 0; iPath < fMonitorPaths.size(); iPath++) {
+    string monPath = fMonitorPaths[iPath];
+    LogTrace("HLTSeedL1LogicScalers") << "monPath = " << monPath << endl;
 
-  LogDebug("HLTSeedL1LogicScalers") << "HLTSeedL1LogicScalers::analyze  event " ;
+    string folderName = fDQMFolder + "/" + monPath;
+    iBooker.setCurrentFolder(folderName);
+
+    // do nothing if monPath is not in the HLT menu
+    if (fHLTConfig.triggerIndex(monPath) == fHLTConfig.size()) continue;
+    // get L1SeedLogicalExpression of this path
+    vector<pair<bool, string> > hltL1GTSeed = fHLTConfig.hltL1GTSeeds(monPath);
+    LogTrace("HLTSeedL1LogicScalers")
+        << endl << "size of vector of GTSeedL1LogicalExpression = "
+        << hltL1GTSeed.size() << endl;
+
+    // each GT Seed of each path contains l1Algos
+    for (unsigned int iSeed = 0; iSeed < hltL1GTSeed.size(); iSeed++) {
+      LogTrace("HLTSeedL1LogicScalers")
+          << "  TechBit_flag = " << hltL1GTSeed[iSeed].first
+          << "  GTSeedL1LogicalExpression = " << hltL1GTSeed[iSeed].second
+          << endl;
+
+      istringstream totalSString(hltL1GTSeed[iSeed].second);
+      string temp_string;
+
+      vector<string> l1Algos;
+
+      // only if not TechBit flag
+      while (!hltL1GTSeed[iSeed].first) {
+        totalSString >> temp_string;
+
+        if (!l1Algos.empty()) {
+          if (temp_string.compare(l1Algos.back()) == 0) break;
+        }
+        if (temp_string != "OR" && temp_string != "AND" &&
+            temp_string != "NOT" && temp_string != "(" && temp_string != ")" &&
+            temp_string != "") {
+          l1Algos.push_back(temp_string);
+        }
+      }
+
+      int nL1Algo = l1Algos.size();
+
+      // put an upper limit on the size of l1Algos
+      if (nL1Algo > 32) {
+        LogWarning("HLTSeedL1LogicScalers")
+            << "  number of l1 Algos grater than 32. Using only the first 32."
+            << endl;
+        l1Algos.resize(32);
+      }
+      int nBins = 1 << nL1Algo;
+
+      for (unsigned int k = 0; k < l1Algos.size(); k++) {
+        LogTrace("HLTSeedL1LogicScalers") << "  l1 Algo = " << l1Algos[k]
+                                          << endl;
+      }  // end for k
+
+      std::stringstream title;
+      std::stringstream name;
+
+      name << monPath << "_Seed_" << iSeed << "_L1BitLogic";
+      title << monPath << "  BitPacked L1Algos of GTSeed " << iSeed << ": '"
+            << hltL1GTSeed[iSeed].second << "'";
+
+      LogTrace("HLTSeedL1LogicScalers") << "  MonitorElement name = " << name
+                                        << endl;
+      LogTrace("HLTSeedL1LogicScalers") << "  MonitorElement title = " << title
+                                        << endl;
+      LogTrace("HLTSeedL1LogicScalers") << "  MonitorElement nBins = " << nBins
+                                        << endl << endl;
+
+      MonitorElement* me = iBooker.book1D(name.str().c_str(), title.str().c_str(),
+                                        nBins, 0, nBins);
+      me->setAxisTitle("bit-packed word L1 Algorithms");
+      fMonitorPathsME.push_back(me);
+
+      fMapMEL1Algos.push_back(make_pair(me, l1Algos));
+    }  // end for Seeds
+  }  // end for monitoring paths
+}
+
+void HLTSeedL1LogicScalers::analyze(const edm::Event& iEvent,
+                                    const edm::EventSetup& iSetup) {
+  LogDebug("HLTSeedL1LogicScalers") << "HLTSeedL1LogicScalers::analyze  event ";
 
   // before accessing any result from L1GtUtils, one must retrieve and cache
   // the L1 trigger event setup
@@ -79,231 +157,73 @@ HLTSeedL1LogicScalers::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   m_l1GtUtils.retrieveL1EventSetup(iSetup);
 
   // loop over maps of ME-L1Algos
-  for (unsigned int i=0;i<fMapMEL1Algos.size();i++) {
-
+  for (unsigned int i = 0; i < fMapMEL1Algos.size(); i++) {
     MonitorElement* me = fMapMEL1Algos[i].first;
     LogTrace("HLTSeedL1LogicScalers") << "ME = " << me->getName() << endl;
-    
+
     const vector<string>& l1Algos = fMapMEL1Algos[i].second;
 
     // word to bit-pack decisions of l1Algos
     unsigned int myL1Word = 0;
 
-    // loop over l1Algos 
-    for (unsigned int j=0;j<l1Algos.size();j++) {
-
+    // loop over l1Algos
+    for (unsigned int j = 0; j < l1Algos.size(); j++) {
       // check if this l1Algo passed
       bool l1Pass = analyzeL1GtUtils(iEvent, iSetup, l1Algos[j]);
-      LogTrace("HLTSeedL1LogicScalers") << "l1Algo = " << l1Algos[j] << "  l1Pass = " <<  l1Pass << endl;
-      if(l1Pass) {
-        
+      LogTrace("HLTSeedL1LogicScalers") << "l1Algo = " << l1Algos[j]
+                                        << "  l1Pass = " << l1Pass << endl;
+      if (l1Pass) {
         // bit-wise pack
-        myL1Word |= (1<<j);
-
+        myL1Word |= (1 << j);
       }
-/*
-*/
-
-    } 
-
+    }
     me->Fill(myL1Word);
-
-  } // end for i maps
-
+  }  // end for i maps
 }
 
-
-
-void 
-HLTSeedL1LogicScalers::beginRun(const edm::Run& run, const edm::EventSetup& iSetup)
-{
-
-  // Get configuration of HLT menu used in this run
-  LogTrace("HLTSeedL1LogicScalers") << "beginRun, run " << run.id();
-  fDbe->setCurrentFolder(fDQMFolder);
-  
-  // HLT config does not change within runs!
-
-  bool changed = false;
- 
-  if (!fHLTConfig.init(run, iSetup, fProcessname, changed)) {
-
-    LogDebug("HLTSeedL1LogicScalers") << "HLTConfigProvider failed to initialize.";
-    return;
-
-    // check if trigger name in (new) config
-    //  cout << "Available TriggerNames are: " << endl;
-    //  fHLTConfig.dump("Triggers");
-
-  }
-
-  const unsigned int n(fHLTConfig.size());
-
-  for (unsigned int j=0; j!=n; ++j) {
-  
-    LogTrace("HLTSeedL1LogicScalers") << "HLTConfig path " << fHLTConfig.triggerName(j) << endl;
-
-  }
-
-  // book histos for L1 logic of specificified HLT paths
-  LogTrace("HLTSeedL1LogicScalers") << "size of vector of paths to monitor = " << fMonitorPaths.size() << endl;
-  for (unsigned int iPath=0;iPath<fMonitorPaths.size();iPath++) {
-
-    string monPath = fMonitorPaths[iPath];
-    LogTrace("HLTSeedL1LogicScalers") << "monPath = " << monPath << endl;
-
-    string folderName = fDQMFolder + "/" + monPath;
-    fDbe->setCurrentFolder(folderName);
-    
-    // do nothing if monPath is not in the HLT menu
-    if(fHLTConfig.triggerIndex(monPath) == fHLTConfig.size()) continue;
-    // get L1SeedLogicalExpression of this path
-    vector<pair<bool,string> > hltL1GTSeed = fHLTConfig.hltL1GTSeeds(monPath);
-    LogTrace("HLTSeedL1LogicScalers") << endl << "size of vector of GTSeedL1LogicalExpression = " << hltL1GTSeed.size() << endl;
-
-    // each GT Seed of each path contains l1Algos
-    for (unsigned int iSeed=0;iSeed<hltL1GTSeed.size();iSeed++) {
-
-      LogTrace("HLTSeedL1LogicScalers") << "  TechBit_flag = " << hltL1GTSeed[iSeed].first << "  GTSeedL1LogicalExpression = " << hltL1GTSeed[iSeed].second << endl;;
-
-      istringstream totalSString( hltL1GTSeed[iSeed].second );
-      string temp_string;
-
-      vector<string> l1Algos;
-
-      // only if not TechBit flag
-      while(! hltL1GTSeed[iSeed].first) {
-
-        totalSString >> temp_string;
-
-        if(! l1Algos.empty()) {
-          
-          if(temp_string.compare(l1Algos.back()) == 0) break;
-
-        }
-        if(temp_string != "OR" && temp_string != "AND" && temp_string != "NOT" && temp_string != "(" && temp_string != ")" && temp_string != ""){
-
-          l1Algos.push_back(temp_string);
-
-        }
-      }
-
-      int nL1Algo = l1Algos.size();
-
-      // put an upper limit on the size of l1Algos
-      if(nL1Algo > 32) {
-
-        LogWarning("HLTSeedL1LogicScalers") << "  number of l1 Algos grater than 32. Using only the first 32." << endl ;
-        l1Algos.resize(32);
-
-      }
-      int nBins = 1 << nL1Algo;
-
-      for (unsigned int k=0;k< l1Algos.size();k++) {
-
-        LogTrace("HLTSeedL1LogicScalers") << "  l1 Algo = " << l1Algos[k] << endl;
-
-
-      } // end for k
-
-      //char title[100];
-      //char name[100];
-
-      std::stringstream title;
-      std::stringstream name;
-
-      name << monPath << "_Seed_" << iSeed << "_L1BitLogic";
-      title << monPath << "  BitPacked L1Algos of GTSeed " << iSeed << ": '" << hltL1GTSeed[iSeed].second << "'";
-
-      //sprintf(name,"%s_Seed_%d_L1BitLogic",monPath.c_str(),iSeed);
-      //sprintf(title,"%s BitPacked L1Algos of GTSeed %d: '%s'",monPath.c_str(), iSeed, hltL1GTSeed[iSeed].second.c_str());
-
-      LogTrace("HLTSeedL1LogicScalers") << "  MonitorElement name = " << name << endl;
-      LogTrace("HLTSeedL1LogicScalers") << "  MonitorElement title = " << title << endl;
-      LogTrace("HLTSeedL1LogicScalers") << "  MonitorElement nBins = " << nBins << endl << endl;
-
-      MonitorElement* me = fDbe->book1D(name.str().c_str(), title.str().c_str(), nBins,0,nBins);
-      me->setAxisTitle("bit-packed word L1 Algorithms");
-      fMonitorPathsME.push_back(me);
-
-      // pair of 1D hisotgram and vector of l1Algos
-      //pair<MonitorElement*, vector<string> > pairMEL1Algo;
-      //pairMEL1Algo.first = me;
-      //pairMEL1Algo.second = l1Algos;
-      //fMapMEL1Algos.push_back(pairMEL1Algo);
-      fMapMEL1Algos.push_back(make_pair(me, l1Algos));
-
-   } // end for Seeds
-
-
-
-  } // end for monitoring paths
-
-}
-
-void 
-HLTSeedL1LogicScalers::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-HLTSeedL1LogicScalers::endJob() {
-}
-
-bool HLTSeedL1LogicScalers::analyzeL1GtUtils(const edm::Event& iEvent, const edm::EventSetup& evSetup, const string & l1AlgoName)
-{
-
+bool HLTSeedL1LogicScalers::analyzeL1GtUtils(const edm::Event& iEvent,
+                                             const edm::EventSetup& evSetup,
+                                             const string& l1AlgoName) {
   LogTrace("HLTSeedL1LogicScalers") << "analyzeL1GtUtils..." << endl;
 
-    // access L1 trigger results using public methods from L1GtUtils
-    // always check on error code returned by that method
+  // access L1 trigger results using public methods from L1GtUtils
+  // always check on error code returned by that method
 
-    int iErrorCode = -1;
+  int iErrorCode = -1;
 
-    
-    LogTrace("HLTSeedL1LogicScalers") << "l1AlgoName = " << l1AlgoName << endl;
+  LogTrace("HLTSeedL1LogicScalers") << "l1AlgoName = " << l1AlgoName << endl;
 
-    bool decisionAlgTechTrig = false;
+  bool decisionAlgTechTrig = false;
 
-    // check flag L1BeforeMask
-    if (fL1BeforeMask) {
-      
-      decisionAlgTechTrig = m_l1GtUtils.decisionBeforeMask(iEvent, fL1GtRecordInputTag, fL1GtDaqReadoutRecordInputTag, l1AlgoName, iErrorCode);
+  // check flag L1BeforeMask
+  if (fL1BeforeMask) {
+    decisionAlgTechTrig = m_l1GtUtils.decisionBeforeMask(
+        iEvent, fL1GtRecordInputTag, fL1GtDaqReadoutRecordInputTag, l1AlgoName,
+        iErrorCode);
+  } else {
+    decisionAlgTechTrig = m_l1GtUtils.decisionAfterMask(
+        iEvent, fL1GtRecordInputTag, fL1GtDaqReadoutRecordInputTag, l1AlgoName,
+        iErrorCode);
+  }
 
-    } 
-    else {
+  LogTrace("HLTSeedL1LogicScalers")
+      << "bool L1BeforeMask = " << fL1BeforeMask
+      << "  decisionAlgTechTrig = " << decisionAlgTechTrig << endl;
 
-     decisionAlgTechTrig = m_l1GtUtils.decisionAfterMask(iEvent, fL1GtRecordInputTag, fL1GtDaqReadoutRecordInputTag, l1AlgoName, iErrorCode);
-
-    }
-
-    LogTrace("HLTSeedL1LogicScalers") << "bool L1BeforeMask = " << fL1BeforeMask << "  decisionAlgTechTrig = " << decisionAlgTechTrig << endl;
-
-    if (iErrorCode == 0) {
- 
-      return decisionAlgTechTrig; 
-
-    } else if (iErrorCode == 1) {
-        
-      // algorithm / technical trigger  does not exist in the L1 menu
-      LogWarning("HLTSeedL1LogicScalers") << "L1 algorithm " << l1AlgoName << " not in L1 menu, but HLTConfigProvider found it in L1SeedsLogicalExpression of at least one HLT path of the HLT menu." << endl;
-      return false;
-
-    } else {
-
-      // error - see error code
-      // do whatever needed
-      return false;
-
-    }
-
+  if (iErrorCode == 0) {
+    return decisionAlgTechTrig;
+  } else if (iErrorCode == 1) {
+    // algorithm / technical trigger  does not exist in the L1 menu
+    LogWarning("HLTSeedL1LogicScalers")
+        << "L1 algorithm " << l1AlgoName
+        << " not in L1 menu, but HLTConfigProvider found it in "
+           "L1SeedsLogicalExpression of at least one HLT path of the HLT menu."
+        << endl;
     return false;
-
-}
-
-bool HLTSeedL1LogicScalers::analyzeL1GtRecord(const edm::Event& iEvent, const edm::EventSetup& evSetup, string l1AlgoName)
-{
-  LogTrace("HLTSeedL1LogicScalers") << "analyzeL1GtRecord.. " << endl;
+  } else {
+    // error - see error code
+    // do whatever needed
+    return false;
+  }
   return false;
 }

--- a/DQM/TrigXMonitor/src/L1Scalers.cc
+++ b/DQM/TrigXMonitor/src/L1Scalers.cc
@@ -1,6 +1,5 @@
 #include <iostream>
 
-
 // FW
 #include "FWCore/Framework/interface/Event.h"
 
@@ -18,9 +17,7 @@
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTExtendedCand.h"
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTReadoutCollection.h"
 
-
 #include "FWCore/Framework/interface/LuminosityBlock.h"
-
 
 #include "DataFormats/Scalers/interface/L1TriggerScalers.h"
 #include "DataFormats/Scalers/interface/L1TriggerRates.h"
@@ -37,413 +34,354 @@
 
 using namespace edm;
 
+L1Scalers::L1Scalers(const edm::ParameterSet& ps)
+    : nev_(0),
+      verbose_(ps.getUntrackedParameter<bool>("verbose", false)),
+      l1GtDataSource_(ps.getParameter<edm::InputTag>("l1GtData")),
+      denomIsTech_(ps.getUntrackedParameter<bool>("denomIsTech", true)),
+      denomBit_(ps.getUntrackedParameter<unsigned int>("denomBit", 40)),
+      tfIsTech_(ps.getUntrackedParameter<bool>("tfIsTech", true)),
+      tfBit_(ps.getUntrackedParameter<unsigned int>("tfBit", 41)),
+      algoSelected_(ps.getUntrackedParameter<std::vector<unsigned int> >(
+          "algoMonitorBits", std::vector<unsigned int>())),
+      techSelected_(ps.getUntrackedParameter<std::vector<unsigned int> >(
+          "techMonitorBits", std::vector<unsigned int>())),
+      folderName_(ps.getUntrackedParameter<std::string>(
+          "dqmFolder", std::string("L1T/L1Scalers_EvF"))),
+      l1scalers_(0),
+      l1techScalers_(0),
+      l1Correlations_(0),
+      bxNum_(0),
+      l1scalersBx_(0),
+      l1techScalersBx_(0),
+      nLumiBlock_(0),
+      l1AlgoCounter_(0),
+      l1TtCounter_(0),
+      fedStart_(ps.getUntrackedParameter<unsigned int>("firstFED", 0)),
+      fedStop_(ps.getUntrackedParameter<unsigned int>("lastFED", 931)),
+      rateAlgoCounter_(0),
+      rateTtCounter_(0),
+      fedRawCollection_(ps.getParameter<edm::InputTag>("fedRawData")),
+      maskedList_(ps.getUntrackedParameter<std::vector<int> >(
+          "maskedChannels",
+          std::vector<int>())),  // this is using the ashed index
+      HcalRecHitCollection_(
+          ps.getParameter<edm::InputTag>("HFRecHitCollection")) {
+  LogDebug("Status") << "constructor";
+}
 
+void L1Scalers::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&,
+                               edm::EventSetup const&) {
+  iBooker.setCurrentFolder(folderName_);
+  l1scalers_ =
+      iBooker.book1D("l1AlgoBits", "L1 Algorithm Bits", 128, -0.5, 127.5);
+  l1scalersBx_ = iBooker.book2D("l1AlgoBits_Vs_Bx",
+                              "L1 Algorithm Bits vs "
+                              "Bunch Number",
+                              3600, -0.5, 3599.5, 128, -0.5, 127.5);
+  l1Correlations_ = iBooker.book2D("l1Correlations",
+                                 "L1 Algorithm Bits "
+                                 "Correlations",
+                                 128, -0.5, 127.5, 128, -0.5, 127.5);
+  l1techScalers_ =
+      iBooker.book1D("l1TechBits", "L1 Tech. Trigger Bits", 64, -0.5, 63.5);
+  l1techScalersBx_ = iBooker.book2D("l1TechBits_Vs_Bx",
+                                  "L1 Technical "
+                                  "Trigger "
+                                  "Bits vs Bunch Number",
+                                  3600, -0.5, 3599.5, 64, -0.5, 63.5);
+  bxNum_ = iBooker.book1D("bxNum", "Bunch number from GTFE", 3600, -0.5, 3599.5);
 
-L1Scalers::L1Scalers(const edm::ParameterSet &ps):
-  dbe_(0), nev_(0),
-  verbose_(ps.getUntrackedParameter < bool > ("verbose", false)),
-  l1GtDataSource_( ps.getParameter< edm::InputTag >("l1GtData")),
-  denomIsTech_(ps.getUntrackedParameter <bool> ("denomIsTech", true)),
-  denomBit_(ps.getUntrackedParameter <unsigned int> ("denomBit", 40)),
-  tfIsTech_(ps.getUntrackedParameter <bool> ("tfIsTech", true)),
-  tfBit_(ps.getUntrackedParameter <unsigned int> ("tfBit", 41)),
-  algoSelected_(ps.getUntrackedParameter<std::vector<unsigned int> >("algoMonitorBits", std::vector<unsigned int>())),
-  techSelected_(ps.getUntrackedParameter<std::vector<unsigned int> >("techMonitorBits", std::vector<unsigned int>())),
-  folderName_( ps.getUntrackedParameter< std::string>("dqmFolder", 
-					  std::string("L1T/L1Scalers_EvF"))),
-  l1scalers_(0),
-  l1techScalers_(0),
-  l1Correlations_(0),
-  bxNum_(0),
-  l1scalersBx_(0),
-  l1techScalersBx_(0),
-//   pixFedSizeBx_(0),
-//   hfEnergyMaxTowerBx_(0),
-  nLumiBlock_(0),
-  l1AlgoCounter_(0),
-  l1TtCounter_(0),
-//   pixFedSize_(0),
-//   hfEnergy_(0),
-  fedStart_(ps.getUntrackedParameter<unsigned int>("firstFED", 0)),
-  fedStop_(ps.getUntrackedParameter<unsigned int>("lastFED", 931)), 
-  rateAlgoCounter_(0),					  
-  rateTtCounter_(0),					  
-  fedRawCollection_(ps.getParameter<edm::InputTag>("fedRawData")),
-  maskedList_(ps.getUntrackedParameter<std::vector<int> >("maskedChannels", std::vector<int>())), //this is using the ashed index
-  HcalRecHitCollection_(ps.getParameter<edm::InputTag>("HFRecHitCollection"))
-{
-  LogDebug("Status") << "constructor" ;
-} 
+  nLumiBlock_ = iBooker.bookInt("nLumiBlock");
 
+  //  l1 total rate
+  l1AlgoCounter_ = iBooker.bookInt("l1AlgoCounter");
+  l1TtCounter_ = iBooker.bookInt("l1TtCounter");
 
+  // timing plots
+  std::stringstream sdenom;
+  if (denomIsTech_)
+    sdenom << "tech";
+  else
+    sdenom << "algo";
 
-
-void L1Scalers::beginJob(void)
-{
-  LogDebug("Status") << "L1Scalers::beginJob()...";
-
-  dbe_ = Service<DQMStore>().operator->();
-  if (dbe_ ) {
-    dbe_->setVerbose(0);
-    dbe_->setCurrentFolder(folderName_);
-
-
-    l1scalers_ = dbe_->book1D("l1AlgoBits", "L1 Algorithm Bits",
-			      128, -0.5, 127.5);
-    l1scalersBx_ = dbe_->book2D("l1AlgoBits_Vs_Bx", "L1 Algorithm Bits vs "
-				"Bunch Number",
-				3600, -0.5, 3599.5,
-				128, -0.5, 127.5);
-    l1Correlations_ = dbe_->book2D("l1Correlations", "L1 Algorithm Bits " 
-                                    "Correlations",
-				   128, -0.5, 127.5,
-				   128, -0.5, 127.5);
-    l1techScalers_ = dbe_->book1D("l1TechBits", "L1 Tech. Trigger Bits",
-				  64, -0.5, 63.5);
-    l1techScalersBx_ = dbe_->book2D("l1TechBits_Vs_Bx", "L1 Technical "
-				    "Trigger "
-				    "Bits vs Bunch Number",
-				    3600, -0.5, 3599.5, 64, -0.5, 63.5);
-//     pixFedSizeBx_ = dbe_->book2D("pixFedSize_Vs_Bx", "Size of Pixel FED data vs "
-// 				"Bunch Number",
-// 				3600, -0.5, 3599.5,
-// 				200, 0., 20000.);
-//     hfEnergyMaxTowerBx_ = dbe_->book2D("hfEnergyMaxTower_Vs_Bx", "HF Energy Max Tower vs "
-// 				"Bunch Number",
-// 				3600, -0.5, 3599.5,
-// 				100, 0., 500.);
-    bxNum_ = dbe_->book1D("bxNum", "Bunch number from GTFE",
-			  3600, -0.5, 3599.5);
-
-    nLumiBlock_ = dbe_->bookInt("nLumiBlock");
-
-//  l1 total rate
-    
-    l1AlgoCounter_ = dbe_->bookInt("l1AlgoCounter");
-    l1TtCounter_ = dbe_->bookInt("l1TtCounter");
-
-
-    //int maxNbins = 200;
-    //int maxLumi = 2000;
-
-    //timing plots
-    std::stringstream sdenom;
-    if(denomIsTech_) sdenom << "tech" ;
-    else sdenom << "algo" ;
-
-    dbe_->setCurrentFolder(folderName_ + "/Synch");
-    algoBxDiff_.clear();
-    algoBxDiff_.clear();
-    algoBxDiffLumi_.clear();
-    techBxDiffLumi_.clear();
-    for(uint ibit = 0; ibit < algoSelected_.size(); ibit++){
-      std::stringstream ss;
-      ss << algoSelected_[ibit] << "_" << sdenom.str() << denomBit_;
-      algoBxDiff_.push_back(dbe_->book1D("BX_diff_algo"+ ss.str(),"BX_diff_algo"+ ss.str(),9,-4,5));
-      algoBxDiffLumi_.push_back(dbe_->book2D("BX_diffvslumi_algo"+ ss.str(),"BX_diff_algo"+ss.str(),MAX_LUMI_BIN,-0.5,double(MAX_LUMI_SEG)-0.5,9,-4,5));
-      //algoBxDiffLumi_[ibit]->setAxisTitle("Lumi Section", 1);
-    }
-    for(uint ibit = 0; ibit < techSelected_.size(); ibit++){
-      std::stringstream ss;
-      ss << techSelected_[ibit] << "_" << sdenom.str() << denomBit_;
-      techBxDiff_.push_back(dbe_->book1D("BX_diff_tech"+ ss.str(),"BX_diff_tech"+ ss.str(),9,-4,5));
-      techBxDiffLumi_.push_back(dbe_->book2D("BX_diffvslumi_tech"+ ss.str(),"BX_diff_tech"+ss.str(),MAX_LUMI_BIN,-0.5,double(MAX_LUMI_SEG)-0.5,9,-4,5));
-      //techBxDiffLumi_[ibit]->setAxisTitle("Lumi Section", 1);
-    }
-
-    //GMT timing plots
-    std::stringstream ss1;
-    ss1 << "_" << sdenom.str() << denomBit_;
-    dtBxDiff_ = dbe_->book1D("BX_diff_DT" + ss1.str(),"BX_diff_DT" + ss1.str(),9,-4,5);
-    dtBxDiffLumi_ = dbe_->book2D("BX_diffvslumi_DT" + ss1.str(),"BX_diffvslumi_DT" + ss1.str(),MAX_LUMI_BIN,-0.5,double(MAX_LUMI_SEG)-0.5,9,-4,5);
-    cscBxDiff_ = dbe_->book1D("BX_diff_CSC" + ss1.str(),"BX_diff_CSC" + ss1.str(),9,-4,5);
-    cscBxDiffLumi_ = dbe_->book2D("BX_diffvslumi_CSC" + ss1.str(),"BX_diffvslumi_CSC" + ss1.str(),MAX_LUMI_BIN,-0.5,double(MAX_LUMI_SEG)-0.5,9,-4,5);
-    rpcbBxDiff_ = dbe_->book1D("BX_diff_RPCb" + ss1.str(),"BX_diff_RPCb" + ss1.str(),9,-4,5);
-    rpcbBxDiffLumi_ = dbe_->book2D("BX_diffvslumi_RPCb" + ss1.str(),"BX_diffvslumi_RPCb" + ss1.str(),MAX_LUMI_BIN,-0.5,double(MAX_LUMI_SEG)-0.5,9,-4,5);
-    rpcfBxDiff_ = dbe_->book1D("BX_diff_RPCf" + ss1.str(),"BX_diff_RPCf" + ss1.str(),9,-4,5);
-    rpcfBxDiffLumi_ = dbe_->book2D("BX_diffvslumi_RPCf" + ss1.str(),"BX_diffvslumi_RPCf" + ss1.str(),MAX_LUMI_BIN,-0.5,double(MAX_LUMI_SEG)-0.5,9,-4,5);
-
-
-    // early triggers
-//     pixFedSize_ = dbe_->book1D("pixFedSize", "Size of Pixel FED data",
-// 			       200, 0., 20000.);
-//     hfEnergy_   = dbe_->book1D("hfEnergy", "HF energy",
-// 			       100, 0., 500.);
-
+  iBooker.setCurrentFolder(folderName_ + "/Synch");
+  algoBxDiff_.clear();
+  algoBxDiff_.clear();
+  algoBxDiffLumi_.clear();
+  techBxDiffLumi_.clear();
+  for (uint ibit = 0; ibit < algoSelected_.size(); ibit++) {
+    std::stringstream ss;
+    ss << algoSelected_[ibit] << "_" << sdenom.str() << denomBit_;
+    algoBxDiff_.push_back(iBooker.book1D("BX_diff_algo" + ss.str(),
+                                       "BX_diff_algo" + ss.str(), 9, -4, 5));
+    algoBxDiffLumi_.push_back(
+        iBooker.book2D("BX_diffvslumi_algo" + ss.str(), "BX_diff_algo" + ss.str(),
+                     MAX_LUMI_BIN, -0.5, double(MAX_LUMI_SEG) - 0.5, 9, -4, 5));
+    // algoBxDiffLumi_[ibit]->setAxisTitle("Lumi Section", 1);
   }
-  
-  
-  return;
+  for (uint ibit = 0; ibit < techSelected_.size(); ibit++) {
+    std::stringstream ss;
+    ss << techSelected_[ibit] << "_" << sdenom.str() << denomBit_;
+    techBxDiff_.push_back(iBooker.book1D("BX_diff_tech" + ss.str(),
+                                       "BX_diff_tech" + ss.str(), 9, -4, 5));
+    techBxDiffLumi_.push_back(
+        iBooker.book2D("BX_diffvslumi_tech" + ss.str(), "BX_diff_tech" + ss.str(),
+                     MAX_LUMI_BIN, -0.5, double(MAX_LUMI_SEG) - 0.5, 9, -4, 5));
+    // techBxDiffLumi_[ibit]->setAxisTitle("Lumi Section", 1);
+  }
+
+  // GMT timing plots
+  std::stringstream ss1;
+  ss1 << "_" << sdenom.str() << denomBit_;
+  dtBxDiff_ = iBooker.book1D("BX_diff_DT" + ss1.str(), "BX_diff_DT" + ss1.str(),
+                           9, -4, 5);
+  dtBxDiffLumi_ = iBooker.book2D("BX_diffvslumi_DT" + ss1.str(),
+                               "BX_diffvslumi_DT" + ss1.str(), MAX_LUMI_BIN,
+                               -0.5, double(MAX_LUMI_SEG) - 0.5, 9, -4, 5);
+  cscBxDiff_ = iBooker.book1D("BX_diff_CSC" + ss1.str(),
+                            "BX_diff_CSC" + ss1.str(), 9, -4, 5);
+  cscBxDiffLumi_ = iBooker.book2D("BX_diffvslumi_CSC" + ss1.str(),
+                                "BX_diffvslumi_CSC" + ss1.str(), MAX_LUMI_BIN,
+                                -0.5, double(MAX_LUMI_SEG) - 0.5, 9, -4, 5);
+  rpcbBxDiff_ = iBooker.book1D("BX_diff_RPCb" + ss1.str(),
+                             "BX_diff_RPCb" + ss1.str(), 9, -4, 5);
+  rpcbBxDiffLumi_ = iBooker.book2D("BX_diffvslumi_RPCb" + ss1.str(),
+                                 "BX_diffvslumi_RPCb" + ss1.str(), MAX_LUMI_BIN,
+                                 -0.5, double(MAX_LUMI_SEG) - 0.5, 9, -4, 5);
+  rpcfBxDiff_ = iBooker.book1D("BX_diff_RPCf" + ss1.str(),
+                             "BX_diff_RPCf" + ss1.str(), 9, -4, 5);
+  rpcfBxDiffLumi_ = iBooker.book2D("BX_diffvslumi_RPCf" + ss1.str(),
+                                 "BX_diffvslumi_RPCf" + ss1.str(), MAX_LUMI_BIN,
+                                 -0.5, double(MAX_LUMI_SEG) - 0.5, 9, -4, 5);
 }
 
-void L1Scalers::endJob(void)
-{
-}
-
-void L1Scalers::analyze(const edm::Event &e, const edm::EventSetup &iSetup)
-{
+void L1Scalers::analyze(const edm::Event& e, const edm::EventSetup& iSetup) {
   nev_++;
 
-  LogDebug("Status") << "L1Scalers::analyze  event " << nev_ ;
+  LogDebug("Status") << "L1Scalers::analyze  event " << nev_;
 
   // int myGTFEbx = -1;
   // get Global Trigger decision and the decision word
   // these are locally derived
   edm::Handle<L1GlobalTriggerReadoutRecord> gtRecord;
-  bool t = e.getByLabel(l1GtDataSource_,gtRecord);
+  bool t = e.getByLabel(l1GtDataSource_, gtRecord);
 
-  if ( ! t ) {
+  if (!t) {
     LogDebug("Product") << "can't find L1GlobalTriggerReadoutRecord "
-			<< "with label " << l1GtDataSource_.label() ;
-  }
-  else {
-
-    // DEBUG
-    //gtRecord->print(std::cout);
-    // DEBUG
-    
+                        << "with label " << l1GtDataSource_.label();
+  } else {
     L1GtfeWord gtfeWord = gtRecord->gtfeWord();
     int gtfeBx = gtfeWord.bxNr();
     bxNum_->Fill(gtfeBx);
-    // myGTFEbx = gtfeBx;
-    
+
     bool tfBitGood = false;
 
     // First, the default
     // vector of bool
-    for(int iebx=0; iebx<=4; iebx++) {
-
-      //Algorithm Bits
-      DecisionWord gtDecisionWord = gtRecord->decisionWord(iebx-2);
+    for (int iebx = 0; iebx <= 4; iebx++) {
+      // Algorithm Bits
+      DecisionWord gtDecisionWord = gtRecord->decisionWord(iebx - 2);
       //    DecisionWord gtDecisionWord = gtRecord->decisionWord();
-      if ( ! gtDecisionWord.empty() ) { // if board not there this is zero
-	// loop over dec. bit to get total rate (no overlap)
-	for ( uint i = 0; i < gtDecisionWord.size(); ++i ) {
-	  if ( gtDecisionWord[i] ) {
-	    rateAlgoCounter_++;
-	    l1AlgoCounter_->Fill(rateAlgoCounter_);
-	    break;
-	  }
-	}
-	// loop over decision bits
-	for ( uint i = 0; i < gtDecisionWord.size(); ++i ) {
-	  if ( gtDecisionWord[i] ) {
-	    l1scalers_->Fill(i);
-	    l1scalersBx_->Fill(gtfeBx-2+iebx,i);
-	    for ( uint j = i + 1; j < gtDecisionWord.size(); ++j ) {
-	      if ( gtDecisionWord[j] ) {
-		l1Correlations_->Fill(i,j);
-		l1Correlations_->Fill(j,i);
-	      }
-	    }
-	  }
-	}
-      }//!empty DecisionWord
- 
+      if (!gtDecisionWord.empty()) {  // if board not there this is zero
+        // loop over dec. bit to get total rate (no overlap)
+        for (uint i = 0; i < gtDecisionWord.size(); ++i) {
+          if (gtDecisionWord[i]) {
+            rateAlgoCounter_++;
+            l1AlgoCounter_->Fill(rateAlgoCounter_);
+            break;
+          }
+        }
+        // loop over decision bits
+        for (uint i = 0; i < gtDecisionWord.size(); ++i) {
+          if (gtDecisionWord[i]) {
+            l1scalers_->Fill(i);
+            l1scalersBx_->Fill(gtfeBx - 2 + iebx, i);
+            for (uint j = i + 1; j < gtDecisionWord.size(); ++j) {
+              if (gtDecisionWord[j]) {
+                l1Correlations_->Fill(i, j);
+                l1Correlations_->Fill(j, i);
+              }
+            }
+          }
+        }
+      }  //!empty DecisionWord
 
       // loop over technical triggers
-      // vector of bool again. 
-      TechnicalTriggerWord tw = gtRecord->technicalTriggerWord(iebx-2);
+      // vector of bool again.
+      TechnicalTriggerWord tw = gtRecord->technicalTriggerWord(iebx - 2);
       //    TechnicalTriggerWord tw = gtRecord->technicalTriggerWord();
-      if ( ! tw.empty() ) {
-	// loop over dec. bit to get total rate (no overlap)
-	for ( uint i = 0; i < tw.size(); ++i ) {
-	  if ( tw[i] ) {
-	    rateTtCounter_++;
-	    l1TtCounter_->Fill(rateTtCounter_);
-	    break;
-	  }
-	}	 
-	for ( uint i = 0; i < tw.size(); ++i ) {
-	  if ( tw[i] ) {
-	    l1techScalers_->Fill(i);
-	    l1techScalersBx_->Fill(gtfeBx-2+iebx, i);
-	  }
-	} 
+      if (!tw.empty()) {
+        // loop over dec. bit to get total rate (no overlap)
+        for (uint i = 0; i < tw.size(); ++i) {
+          if (tw[i]) {
+            rateTtCounter_++;
+            l1TtCounter_->Fill(rateTtCounter_);
+            break;
+          }
+        }
+        for (uint i = 0; i < tw.size(); ++i) {
+          if (tw[i]) {
+            l1techScalers_->Fill(i);
+            l1techScalersBx_->Fill(gtfeBx - 2 + iebx, i);
+          }
+        }
 
-	// check if bit used to filter timing plots fired in this event 
-	// (anywhere in the bx window)
-	if(tfIsTech_){
-	  if(tfBit_ < tw.size()){
-	    if( tw[tfBit_] ) tfBitGood = true;
-	  }
-	}
-      } // ! tw.empty
+        // check if bit used to filter timing plots fired in this event
+        // (anywhere in the bx window)
+        if (tfIsTech_) {
+          if (tfBit_ < tw.size()) {
+            if (tw[tfBit_]) tfBitGood = true;
+          }
+        }
+      }  // ! tw.empty
 
-    }//bx
+    }  // bx
 
-
-    //timing plots
+    // timing plots
     earliestDenom_ = 9;
     earliestAlgo_.clear();
     earliestTech_.clear();
-    for(uint i=0; i < techSelected_.size(); i++) earliestTech_.push_back(9);
-    for(uint i=0; i < algoSelected_.size(); i++) earliestAlgo_.push_back(9);
+    for (uint i = 0; i < techSelected_.size(); i++) earliestTech_.push_back(9);
+    for (uint i = 0; i < algoSelected_.size(); i++) earliestAlgo_.push_back(9);
 
-    //GMT information
+    // GMT information
     edm::Handle<L1MuGMTReadoutCollection> gmtCollection;
-    e.getByLabel(l1GtDataSource_,gmtCollection);
-    
+    e.getByLabel(l1GtDataSource_, gmtCollection);
 
     if (!gmtCollection.isValid()) {
-      edm::LogInfo("DataNotFound") << "can't find L1MuGMTReadoutCollection with label "
-				   << l1GtDataSource_.label() ;
+      edm::LogInfo("DataNotFound")
+          << "can't find L1MuGMTReadoutCollection with label "
+          << l1GtDataSource_.label();
     }
 
     // remember the bx of 1st candidate of each system (9=none)
     int bx1st[4] = {9, 9, 9, 9};
-      
-    if(tfBitGood){//to avoid single BSC hits
 
-      for(int iebx=0; iebx<=4; iebx++) {
-	TechnicalTriggerWord tw = gtRecord->technicalTriggerWord(iebx-2);
-	DecisionWord gtDecisionWord = gtRecord->decisionWord(iebx-2);
+    if (tfBitGood) {  // to avoid single BSC hits
 
-	bool denomBitGood = false;
+      for (int iebx = 0; iebx <= 4; iebx++) {
+        TechnicalTriggerWord tw = gtRecord->technicalTriggerWord(iebx - 2);
+        DecisionWord gtDecisionWord = gtRecord->decisionWord(iebx - 2);
 
-	//check if reference bit is valid
-	if(denomIsTech_){
-	  if ( ! tw.empty() ) {
-	    if( denomBit_ < tw.size() ){
-	      denomBitGood = true;
-	      if( tw[denomBit_] && earliestDenom_==9 ) earliestDenom_ = iebx; 
-	    }
-	  }
-	}
-	else{
-	  if ( ! gtDecisionWord.empty() ) { 
-	    if( denomBit_ < gtDecisionWord.size() ){
-	      denomBitGood = true;
-	      if( gtDecisionWord[denomBit_] && earliestDenom_==9 ) earliestDenom_ = iebx; 
-	    }
-	  }
-	}
+        bool denomBitGood = false;
 
-	if(denomBitGood){
+        // check if reference bit is valid
+        if (denomIsTech_) {
+          if (!tw.empty()) {
+            if (denomBit_ < tw.size()) {
+              denomBitGood = true;
+              if (tw[denomBit_] && earliestDenom_ == 9) earliestDenom_ = iebx;
+            }
+          }
+        } else {
+          if (!gtDecisionWord.empty()) {
+            if (denomBit_ < gtDecisionWord.size()) {
+              denomBitGood = true;
+              if (gtDecisionWord[denomBit_] && earliestDenom_ == 9)
+                earliestDenom_ = iebx;
+            }
+          }
+        }
 
-	  //get earliest tech bx's
-	  if ( ! tw.empty() ) {
-	    for(uint ibit = 0; ibit < techSelected_.size(); ibit++){	  
-	      if(techSelected_[ibit] < tw.size()){
-		if(tw[techSelected_[ibit]] && earliestTech_[ibit] == 9) earliestTech_[ibit] = iebx;
-	      }
-	    }
-	  }
+        if (denomBitGood) {
+          // get earliest tech bx's
+          if (!tw.empty()) {
+            for (uint ibit = 0; ibit < techSelected_.size(); ibit++) {
+              if (techSelected_[ibit] < tw.size()) {
+                if (tw[techSelected_[ibit]] && earliestTech_[ibit] == 9)
+                  earliestTech_[ibit] = iebx;
+              }
+            }
+          }
 
-	  //get earliest algo bx's
-	  if(!gtDecisionWord.empty()){	    
-	    for(uint ibit = 0; ibit < algoSelected_.size(); ibit++){	  
-	      if(algoSelected_[ibit] < gtDecisionWord.size()){
-		if(gtDecisionWord[algoSelected_[ibit]] && earliestAlgo_[ibit] == 9) earliestAlgo_[ibit] = iebx;
-	      }
-	    }
-	  }
+          // get earliest algo bx's
+          if (!gtDecisionWord.empty()) {
+            for (uint ibit = 0; ibit < algoSelected_.size(); ibit++) {
+              if (algoSelected_[ibit] < gtDecisionWord.size()) {
+                if (gtDecisionWord[algoSelected_[ibit]] &&
+                    earliestAlgo_[ibit] == 9)
+                  earliestAlgo_[ibit] = iebx;
+              }
+            }
+          }
+        }  // denomBitGood
+      }    // bx
 
-	}//denomBitGood
-
-      }//bx
-
-
-      //get earliest single muon trigger system bx's
+      // get earliest single muon trigger system bx's
       if (gmtCollection.isValid()) {
+        // get GMT readout collection
+        L1MuGMTReadoutCollection const* gmtrc = gmtCollection.product();
+        // get record vector
+        std::vector<L1MuGMTReadoutRecord> gmt_records = gmtrc->getRecords();
+        // loop over records of individual bx's
+        std::vector<L1MuGMTReadoutRecord>::const_iterator RRItr;
 
-	// get GMT readout collection
-	L1MuGMTReadoutCollection const* gmtrc = gmtCollection.product();
-	// get record vector
-	std::vector<L1MuGMTReadoutRecord> gmt_records = gmtrc->getRecords();
-	// loop over records of individual bx's
-	std::vector<L1MuGMTReadoutRecord>::const_iterator RRItr;
+        for (RRItr = gmt_records.begin(); RRItr != gmt_records.end();
+             RRItr++) {  // loop from BX=-2 to BX=2
+          std::vector<L1MuRegionalCand> INPCands[4] = {
+              RRItr->getDTBXCands(), RRItr->getBrlRPCCands(),
+              RRItr->getCSCCands(), RRItr->getFwdRPCCands()};
+          std::vector<L1MuRegionalCand>::const_iterator INPItr;
+          int BxInEvent = RRItr->getBxInEvent();
 
-	for( RRItr = gmt_records.begin(); RRItr != gmt_records.end(); RRItr++ ) {//loop from BX=-2 to BX=2
-	  std::vector<L1MuRegionalCand> INPCands[4] = {
-	    RRItr->getDTBXCands(),
-	    RRItr->getBrlRPCCands(),
-	    RRItr->getCSCCands(),
-	    RRItr->getFwdRPCCands()
-	  };
-	  std::vector<L1MuRegionalCand>::const_iterator INPItr;
-	  int BxInEvent = RRItr->getBxInEvent();
-	  
-	  // find the first non-empty candidate in this bx
-	  for(int i=0; i<4; i++) {//for each single muon trigger system
-	    for( INPItr = INPCands[i].begin(); INPItr != INPCands[i].end(); ++INPItr ) {
-	      if(!INPItr->empty()) {
-		if(bx1st[i]==9) bx1st[i]=BxInEvent+2;//must go from 0 to 4 (consistent with above)
-	      }
-	    }      
-	  }
-	  //for(int i=0; i<4; i++) 
-	  //	std::cout << "bx1st[" << i << "] = " << bx1st[i];
-	  //std::cout << std::endl;
-	}
+          // find the first non-empty candidate in this bx
+          for (int i = 0; i < 4; i++) {  // for each single muon trigger system
+            for (INPItr = INPCands[i].begin(); INPItr != INPCands[i].end();
+                 ++INPItr) {
+              if (!INPItr->empty()) {
+                if (bx1st[i] == 9)
+                  bx1st[i] = BxInEvent +
+                             2;  // must go from 0 to 4 (consistent with above)
+              }
+            }
+          }
+        }
+      }  // gmtCollection.isValid
+      // calculated bx difference
+      if (earliestDenom_ != 9) {
+        for (uint ibit = 0; ibit < techSelected_.size(); ibit++) {
+          if (earliestTech_[ibit] != 9) {
+            int diff = earliestTech_[ibit] - earliestDenom_;
+            techBxDiff_[ibit]->Fill(diff);
+            techBxDiffLumi_[ibit]->Fill(e.luminosityBlock(), diff);
+          }
+        }
+        for (uint ibit = 0; ibit < algoSelected_.size(); ibit++) {
+          if (earliestAlgo_[ibit] != 9) {
+            int diff = earliestAlgo_[ibit] - earliestDenom_;
+            algoBxDiff_[ibit]->Fill(diff);
+            algoBxDiffLumi_[ibit]->Fill(e.luminosityBlock(), diff);
+          }
+        }
 
-      }//gmtCollection.isValid
-
-
-      //calculated bx difference
-      if(earliestDenom_ != 9){
-	for(uint ibit = 0; ibit < techSelected_.size(); ibit++){	  
-	  if(earliestTech_[ibit] != 9){
-	    int diff = earliestTech_[ibit] - earliestDenom_ ;
-	    techBxDiff_[ibit]->Fill(diff);
-	    techBxDiffLumi_[ibit]->Fill(e.luminosityBlock(), diff);
-	  }
-	}
-	for(uint ibit = 0; ibit < algoSelected_.size(); ibit++){	  
-	  if(earliestAlgo_[ibit] != 9){
-	    int diff = earliestAlgo_[ibit] - earliestDenom_ ;
-	    algoBxDiff_[ibit]->Fill(diff);
-	    algoBxDiffLumi_[ibit]->Fill(e.luminosityBlock(), diff);
-	  }
-	}
-
-	if(bx1st[0] != 9){
-	  int diff = bx1st[0] - earliestDenom_;
-	  dtBxDiff_->Fill(diff);
-	  dtBxDiffLumi_->Fill(e.luminosityBlock(), diff);
-	}
-	if(bx1st[1] != 9){
-	  int diff = bx1st[1] - earliestDenom_;
-	  rpcbBxDiff_->Fill(diff);
-	  rpcbBxDiffLumi_->Fill(e.luminosityBlock(), diff);
-	}
-	if(bx1st[2] != 9){
-	  int diff = bx1st[2] - earliestDenom_;
-	  cscBxDiff_->Fill(diff);
-	  cscBxDiffLumi_->Fill(e.luminosityBlock(), diff);
-	}
-	if(bx1st[3] != 9){
-	  int diff = bx1st[3] - earliestDenom_;
-	  rpcfBxDiff_->Fill(diff);
-	  rpcfBxDiffLumi_->Fill(e.luminosityBlock(), diff);
-	}
-
+        if (bx1st[0] != 9) {
+          int diff = bx1st[0] - earliestDenom_;
+          dtBxDiff_->Fill(diff);
+          dtBxDiffLumi_->Fill(e.luminosityBlock(), diff);
+        }
+        if (bx1st[1] != 9) {
+          int diff = bx1st[1] - earliestDenom_;
+          rpcbBxDiff_->Fill(diff);
+          rpcbBxDiffLumi_->Fill(e.luminosityBlock(), diff);
+        }
+        if (bx1st[2] != 9) {
+          int diff = bx1st[2] - earliestDenom_;
+          cscBxDiff_->Fill(diff);
+          cscBxDiffLumi_->Fill(e.luminosityBlock(), diff);
+        }
+        if (bx1st[3] != 9) {
+          int diff = bx1st[3] - earliestDenom_;
+          rpcfBxDiff_->Fill(diff);
+          rpcfBxDiffLumi_->Fill(e.luminosityBlock(), diff);
+        }
       }
-
-    }//tt41Good
-
+    }  // tt41Good
   }
-  
   return;
- 
 }
 
-void L1Scalers::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-				    const edm::EventSetup& iSetup)
-{
+void L1Scalers::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg,
+                                   const edm::EventSetup& iSetup) {
   nLumiBlock_->Fill(lumiSeg.id().luminosityBlock());
-
 }
-
-
-/// BeginRun
-void L1Scalers::beginRun(const edm::Run& run, const edm::EventSetup& iSetup)
-{
-}
-
-/// EndRun
-void L1Scalers::endRun(const edm::Run& run, const edm::EventSetup& iSetup)
-{
-}
-
-

--- a/DQM/TrigXMonitor/src/L1TScalersSCAL.cc
+++ b/DQM/TrigXMonitor/src/L1TScalersSCAL.cc
@@ -21,562 +21,454 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
-
 const double SECS_PER_LUMI = 23.31040958083832;
-
 
 using namespace edm;
 using namespace std;
 
+L1TScalersSCAL::L1TScalersSCAL(const edm::ParameterSet& ps)
+    : scalersSource_(ps.getParameter<edm::InputTag>("scalersResults")),
+      verbose_(ps.getUntrackedParameter<bool>("verbose", false)),
+      denomIsTech_(ps.getUntrackedParameter<bool>("denomIsTech", true)),
+      denomBit_(ps.getUntrackedParameter<unsigned int>("denomBit", 40)),
+      muonBit_(ps.getUntrackedParameter<unsigned int>("muonBit", 55)),
+      egammaBit_(ps.getUntrackedParameter<unsigned int>("egammaBit", 46)),
+      jetBit_(ps.getUntrackedParameter<unsigned int>("jetBit", 15)) {
+  LogDebug("Status") << "constructor";
 
-L1TScalersSCAL::L1TScalersSCAL(const edm::ParameterSet& ps):
-  dbe_(0),
-  scalersSource_( ps.getParameter< edm::InputTag >("scalersResults")),
-  verbose_(ps.getUntrackedParameter <bool> ("verbose", false)),
-  denomIsTech_(ps.getUntrackedParameter <bool> ("denomIsTech", true)),
-  denomBit_(ps.getUntrackedParameter <unsigned int> ("denomBit", 40)),
-  muonBit_(ps.getUntrackedParameter <unsigned int> ("muonBit", 55)),
-  egammaBit_(ps.getUntrackedParameter <unsigned int> ("egammaBit", 46)),
-  jetBit_(ps.getUntrackedParameter <unsigned int> ("jetBit", 15))
-{
-  LogDebug("Status") << "constructor" ;
-
-  for ( int i=0; i<Level1TriggerScalers::nLevel1Triggers; i++) 
-    { bufferAlgoRates_.push_back(0); algorithmRates_.push_back(0); integral_algo_.push_back(0.);}
-  for ( int i=0; i<Level1TriggerScalers::nLevel1TestTriggers; i++) 
-    { bufferTechRates_.push_back(0); technicalRates_.push_back(0); integral_tech_.push_back(0.);}
+  for (int i = 0; i < Level1TriggerScalers::nLevel1Triggers; i++) {
+    bufferAlgoRates_.push_back(0);
+    algorithmRates_.push_back(0);
+    integral_algo_.push_back(0.);
+  }
+  for (int i = 0; i < Level1TriggerScalers::nLevel1TestTriggers; i++) {
+    bufferTechRates_.push_back(0);
+    technicalRates_.push_back(0);
+    integral_tech_.push_back(0.);
+  }
 
   buffertime_ = 0;
   reftime_ = 0;
   nev_ = 0;
   integral_tech_42_OR_43_ = 0;
   bufferLumi_ = 0;
+}
 
+L1TScalersSCAL::~L1TScalersSCAL() {}
+
+void L1TScalersSCAL::bookHistograms(DQMStore::IBooker& iBooker, edm::Run const&,
+                                    edm::EventSetup const&) {
   int maxNbins = 2001;
+  iBooker.setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerScalers");
+  orbitNum = iBooker.book1D("Orbit_Number", "Orbit_Number", maxNbins, -0.5,
+                            double(maxNbins) - 0.5);
+  trigNum =
+      iBooker.book1D("Number_of_Triggers", "Number_of_Triggers", 1000, 0, 4E4);
+  trigNum->setAxisTitle("Time [sec]", 1);
+  eventNum = iBooker.book1D("Number_of_Events", "Number_of_Events", maxNbins,
+                            -0.5, double(maxNbins) - 0.5);
 
-  dbe_ = Service<DQMStore>().operator->();
-  if(dbe_) {
-    dbe_->setVerbose(0);
-        
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerScalers");
-        
-    //orbitNum = dbe_->book1D("Orbit_Number","Orbit_Number", 1000,0,10E8);
-    orbitNum = dbe_->book1D("Orbit_Number","Orbit_Number", maxNbins,-0.5,double(maxNbins)-0.5);
+  physTrig = iBooker.book1D("Physics_Triggers", "Physics_Triggers", maxNbins,
+                            -0.5, double(maxNbins) - 0.5);
+  physTrig->setAxisTitle("Lumi Section", 1);
 
-    trigNum = dbe_->book1D("Number_of_Triggers","Number_of_Triggers",1000,0,4E4);
-    trigNum->setAxisTitle("Time [sec]", 1);
+  randTrig = iBooker.book1D("Random_Triggers", "Random_Triggers", maxNbins,
+                            -0.5, double(maxNbins) - 0.5);
+  randTrig->setAxisTitle("Lumi Section", 1);
+  numberResets = iBooker.book1D("Number_Resets", "Number_Resets", maxNbins,
+                                -0.5, double(maxNbins) - 0.5);
+  deadTime = iBooker.book1D("DeadTime", "DeadTime", maxNbins, -0.5,
+                            double(maxNbins) - 0.5);
+  lostFinalTriggers = iBooker.book1D("Lost_Final_Trigger", "Lost_Final_Trigger",
+                                     maxNbins, -0.5, double(maxNbins) - 0.5);
+  
+  iBooker.setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates");
+  physRate = iBooker.book1D("Physics_Trigger_Rate", "Physics_Trigger_Rate",
+                            maxNbins, -0.5, double(maxNbins) - 0.5);
+  randRate = iBooker.book1D("Random_Trigger_Rate", "Random_Trigger_Rate",
+                            maxNbins, -0.5, double(maxNbins) - 0.5);
+  deadTimePercent = iBooker.book1D("Deadtime_Percent", "Deadtime_Percent",
+                                   maxNbins, -0.5, double(maxNbins) - 0.5);
+  lostPhysRate =
+      iBooker.book1D("Lost_Physics_Trigger_Rate", "Lost_Physics_Trigger_Rate",
+                     maxNbins, -0.5, double(maxNbins) - 0.5);
+  lostPhysRateBeamActive =
+      iBooker.book1D("Lost_Physics_Trigger_Rate_Beam_Active",
+                     "Lost_Physics_Trigger_Rate_Beam_Active", maxNbins, -0.5,
+                     double(maxNbins) - 0.5);
+  instTrigRate = iBooker.book1D("instTrigRate", "instTrigRate", 1000, 0, 4E4);
+  instTrigRate->setAxisTitle("Time [sec]", 1);
+  instEventRate =
+      iBooker.book1D("instEventRate", "instEventRate", 1000, 0, 4E4);
+  instEventRate->setAxisTitle("Time [sec]", 1);
 
-    //eventNum = dbe_->book1D("Number_of_Events","Number_of_Events", 1000,0,1E7);
-    eventNum = dbe_->book1D("Number_of_Events","Number_of_Events", maxNbins,-0.5,double(maxNbins)-0.5);
+  char hname[40];   // histo name
+  char mename[40];  // ME name
 
-    physTrig = dbe_->book1D("Physics_Triggers","Physics_Triggers", maxNbins,-0.5,double(maxNbins)-0.5);
-    physTrig->setAxisTitle("Lumi Section", 1);
+  iBooker.setCurrentFolder(
+      "L1T/L1TScalersSCAL/Level1TriggerRates/AlgorithmRates");
+  for (int i = 0; i < Level1TriggerScalers::nLevel1Triggers; i++) {
+    sprintf(hname, "Rate_AlgoBit_%03d", i);
+    sprintf(mename, "Rate_AlgoBit _%03d", i);
+    algoRate[i] =
+        iBooker.book1D(hname, mename, maxNbins, -0.5, double(maxNbins) - 0.5);
+    algoRate[i]->setAxisTitle("Lumi Section", 1);
+  }
 
-    randTrig = dbe_->book1D("Random_Triggers","Random_Triggers", maxNbins,-0.5,double(maxNbins)-0.5);
-    randTrig->setAxisTitle("Lumi Section", 1);
+  iBooker.setCurrentFolder(
+      "L1T/L1TScalersSCAL/Level1TriggerRates/AlgorithmRates/Integrated");
+  for (int i = 0; i < Level1TriggerScalers::nLevel1Triggers; i++) {
+    sprintf(hname, "Integral_AlgoBit_%03d", i);
+    sprintf(mename, "Integral_AlgoBit _%03d", i);
+    integralAlgo[i] =
+        iBooker.book1D(hname, mename, maxNbins, -0.5, double(maxNbins) - 0.5);
+    integralAlgo[i]->setAxisTitle("Lumi Section", 1);
+  }
 
-    //numberResets = dbe_->book1D("Number_Resets","Number_Resets", 1000,0,1000);
-    numberResets = dbe_->book1D("Number_Resets","Number_Resets", maxNbins,-0.5,double(maxNbins)-0.5);
-   
-    //deadTime = dbe_->book1D("DeadTime","DeadTime", 1000,0,1E9);
-    deadTime = dbe_->book1D("DeadTime","DeadTime", maxNbins,-0.5,double(maxNbins)-0.5);
-    
-    //lostFinalTriggers = dbe_->book1D("Lost_Final_Trigger","Lost_Final_Trigger", 1000,0,1E6);
-    lostFinalTriggers = dbe_->book1D("Lost_Final_Trigger","Lost_Final_Trigger", maxNbins,-0.5,double(maxNbins)-0.5);
-   
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates");
+  iBooker.setCurrentFolder(
+      "L1T/L1TScalersSCAL/Level1TriggerRates/TechnicalRates");
+  for (int i = 0; i < Level1TriggerScalers::nLevel1TestTriggers; i++) {
+    sprintf(hname, "Rate_TechBit_%03d", i);
+    sprintf(mename, "Rate_TechBit _%03d", i);
+    techRate[i] =
+        iBooker.book1D(hname, mename, maxNbins, -0.5, double(maxNbins) - 0.5);
+    techRate[i]->setAxisTitle("Lumi Section", 1);
+  }
 
-    physRate = dbe_->book1D("Physics_Trigger_Rate","Physics_Trigger_Rate", 
-			    maxNbins,-0.5,double(maxNbins)-0.5);
-    //physRate->setAxisTitle("Lumi Section", 1);
+  iBooker.setCurrentFolder(
+      "L1T/L1TScalersSCAL/Level1TriggerRates/TechnicalRates/Integrated");
+  for (int i = 0; i < Level1TriggerScalers::nLevel1TestTriggers; i++) {
+    sprintf(hname, "Integral_TechBit_%03d", i);
+    sprintf(mename, "Integral_TechBit _%03d", i);
+    integralTech[i] =
+        iBooker.book1D(hname, mename, maxNbins, -0.5, double(maxNbins) - 0.5);
+    integralTech[i]->setAxisTitle("Lumi Section", 1);
+  }
+  integralTech_42_OR_43 = iBooker.book1D(
+      "Integral_TechBit_042_OR_043", "Integral_TechBit _042_OR_043", maxNbins,
+      -0.5, double(maxNbins) - 0.5);
+  integralTech_42_OR_43->setAxisTitle("Lumi Section", 1);
 
-    randRate = dbe_->book1D("Random_Trigger_Rate","Random_Trigger_Rate", 
-			    maxNbins,-0.5,double(maxNbins)-0.5);
-    //randRate->setAxisTitle("Lumi Section", 1);
+  iBooker.setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates/Ratios");
+  std::stringstream smu, seg, sjet, sdenom;
+  // denominator string
+  if (denomIsTech_)
+    sdenom << "_TechBit_";
+  else
+    sdenom << "_AlgoBit_";
+  sdenom << denomBit_;
+  // Muon ratio
+  smu << muonBit_;
+  rateRatio_mu =
+      iBooker.book1D("Rate_Ratio_mu_PhysBit_" + smu.str() + sdenom.str(),
+                     "Rate_Ratio_mu_PhysBit_" + smu.str() + sdenom.str(),
+                     maxNbins, -0.5, double(maxNbins) - 0.5);
+  // rateRatio_mu->setAxisTitle("Lumi Section" , 1);
+  // Egamma ratio
+  seg << egammaBit_;
+  rateRatio_egamma =
+      iBooker.book1D("Rate_Ratio_egamma_PhysBit_" + seg.str() + sdenom.str(),
+                     "Rate_Ratio_egamma_PhysBit_" + seg.str() + sdenom.str(),
+                     maxNbins, -0.5, double(maxNbins) - 0.5);
+  // rateRatio_egamma->setAxisTitle("Lumi Section" , 1);
+  // Jet ratio
+  sjet << jetBit_;
+  rateRatio_jet =
+      iBooker.book1D("Rate_Ratio_jet_PhysBit_" + sjet.str() + sdenom.str(),
+                     "Rate_Ratio_jet_PhysBit_" + sjet.str() + sdenom.str(),
+                     maxNbins, -0.5, double(maxNbins) - 0.5);
+  // rateRatio_jet->setAxisTitle("Lumi Section" , 1);
 
-    deadTimePercent = dbe_->book1D("Deadtime_Percent","Deadtime_Percent", 
-    				   maxNbins,-0.5,double(maxNbins)-0.5);
-    //deadTimePercent->setAxisTitle("Lumi Section", 1);
+  // HF bit ratios
+  techRateRatio_8 = iBooker.book1D("Rate_Ratio_TechBit_8" + sdenom.str(),
+                                   "Rate_Ratio_TechBit_8" + sdenom.str(),
+                                   maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_9 = iBooker.book1D("Rate_Ratio_TechBit_9" + sdenom.str(),
+                                   "Rate_Ratio_TechBit_9" + sdenom.str(),
+                                   maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_10 = iBooker.book1D("Rate_Ratio_TechBit_10" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_10" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  // Other tech bit ratios
+  techRateRatio_33_over_32 = iBooker.book1D(
+      "Rate_Ratio_TechBits_33_over_32", "Rate_Ratio_TechBits_33_over_32",
+      maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_36 = iBooker.book1D("Rate_Ratio_TechBit_36" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_36" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_37 = iBooker.book1D("Rate_Ratio_TechBit_37" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_37" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_38 = iBooker.book1D("Rate_Ratio_TechBit_38" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_38" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_39 = iBooker.book1D("Rate_Ratio_TechBit_39" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_39" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_40 = iBooker.book1D("Rate_Ratio_TechBit_40" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_40" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_41 = iBooker.book1D("Rate_Ratio_TechBit_41" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_41" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_42 = iBooker.book1D("Rate_Ratio_TechBit_42" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_42" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
+  techRateRatio_43 = iBooker.book1D("Rate_Ratio_TechBit_43" + sdenom.str(),
+                                    "Rate_Ratio_TechBit_43" + sdenom.str(),
+                                    maxNbins, -0.5, double(maxNbins) - 0.5);
 
-    lostPhysRate = dbe_->book1D("Lost_Physics_Trigger_Rate","Lost_Physics_Trigger_Rate", 
-				maxNbins,-0.5,double(maxNbins)-0.5);
-    //lostPhysRate->setAxisTitle("Lumi Section", 1);
+  iBooker.setCurrentFolder("L1T/L1TScalersSCAL/LumiScalers");
+  instLumi = iBooker.book1D("Instant_Lumi", "Instant_Lumi", maxNbins, -0.5,
+                            double(maxNbins) - 0.5);
+  instLumiErr = iBooker.book1D("Instant_Lumi_Err", "Instant_Lumi_Err", maxNbins,
+                               -0.5, double(maxNbins) - 0.5);
+  instLumiQlty = iBooker.book1D("Instant_Lumi_Qlty", "Instant_Lumi_Qlty",
+                                maxNbins, -0.5, double(maxNbins) - 0.5);
+  instEtLumi = iBooker.book1D("Instant_Et_Lumi", "Instant_Et_Lumi", maxNbins,
+                              -0.5, double(maxNbins) - 0.5);
+  instEtLumiErr = iBooker.book1D("Instant_Et_Lumi_Err", "Instant_Et_Lumi_Err",
+                                 maxNbins, -0.5, double(maxNbins) - 0.5);
+  instEtLumiQlty =
+      iBooker.book1D("Instant_Et_Lumi_Qlty", "Instant_Et_Lumi_Qlty", maxNbins,
+                     -0.5, double(maxNbins) - 0.5);
+  startOrbit = iBooker.book1D("Start_Orbit", "Start_Orbit", maxNbins, -0.5,
+                              double(maxNbins) - 0.5);
+  numOrbits = iBooker.book1D("Num_Orbits", "Num_Orbits", maxNbins, -0.5,
+                             double(maxNbins) - 0.5);
 
-    lostPhysRateBeamActive = dbe_->book1D("Lost_Physics_Trigger_Rate_Beam_Active",
-					  "Lost_Physics_Trigger_Rate_Beam_Active", 
-					  maxNbins,-0.5,double(maxNbins)-0.5);
-    //lostPhysRateBeamActive->setAxisTitle("Lumi Section", 1);
+  iBooker.setCurrentFolder("L1T/L1TScalersSCAL/L1AcceptBunchCrossing");
+  for (int i = 0; i < 4; i++) {
+    sprintf(hname, "OrbitNumber_L1A_%d", i + 1);
+    sprintf(mename, "OrbitNumber_L1A_%d", i + 1);
+    orbitNumL1A[i] = iBooker.book1D(hname, mename, 200, 0, 10E8);
+    sprintf(hname, "Bunch_Crossing_L1A_%d", i + 1);
+    sprintf(mename, "Bunch_Crossing_L1A_%d", i + 1);
+    bunchCrossingL1A[i] = iBooker.book1D(hname, mename, 3564, -0.5, 3563.5);
+  }
+  orbitNumL1A[0]->setAxisTitle("Current BX", 1);
+  orbitNumL1A[1]->setAxisTitle("Previous BX", 1);
+  orbitNumL1A[2]->setAxisTitle("Second Previous BX", 1);
+  orbitNumL1A[3]->setAxisTitle("Third Previous BX", 1);
 
-    
-    instTrigRate = dbe_->book1D("instTrigRate","instTrigRate",1000,0,4E4);
-    instTrigRate->setAxisTitle("Time [sec]", 1);
+  bunchCrossingL1A[0]->setAxisTitle("Current BX", 1);
+  bunchCrossingL1A[1]->setAxisTitle("Previous BX", 1);
+  bunchCrossingL1A[2]->setAxisTitle("Second Previous BX", 1);
+  bunchCrossingL1A[3]->setAxisTitle("Third Previous BX", 1);
 
-    instEventRate = dbe_->book1D("instEventRate","instEventRate",1000,0,4E4);
-    instEventRate->setAxisTitle("Time [sec]", 1);
+  for (int j = 0; j < 3; j++) {
+    sprintf(hname, "BX_Correlation_%d", j + 1);
+    sprintf(mename, "BX_Correlation_%d", j + 1);
+    bunchCrossingCorr[j] =
+        iBooker.book2D(hname, mename, 99, -0.5, 3563.5, 99, -0.5, 3563.5);
+    bunchCrossingCorr[j]->setAxisTitle("Current Event", 1);
+    sprintf(hname, "Bunch_Crossing_Diff_%d", j + 1);
+    sprintf(mename, "Bunch_Crossing_Diff_%d", j + 1);
+    bunchCrossingDiff[j] = iBooker.book1D(hname, mename, 1000, 0, 1E6);
+    sprintf(hname, "Bunch_Crossing_Diff_small_%d", j + 1);
+    sprintf(mename, "Bunch_Crossing_Diff_small_%d", j + 1);
+    bunchCrossingDiff_small[j] = iBooker.book1D(hname, mename, 1000, 0, 1000);
+  }
+  bunchCrossingCorr[0]->setAxisTitle("Previous Event", 2);
+  bunchCrossingCorr[1]->setAxisTitle("Second Previous Event", 2);
+  bunchCrossingCorr[2]->setAxisTitle("Third Previous Event", 2);
 
-    char hname[40];//histo name
-    char mename[40];//ME name
+  bunchCrossingDiff[0]->setAxisTitle("BX_Current - BX_Previous", 1);
+  bunchCrossingDiff[1]->setAxisTitle("BX_Current - BX_SecondPrevious", 1);
+  bunchCrossingDiff[2]->setAxisTitle("BX_Current - BX_ThirdPrevious", 1);
 
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates/AlgorithmRates");
-
-    for(int i=0; i<Level1TriggerScalers::nLevel1Triggers; i++) {
-      sprintf(hname, "Rate_AlgoBit_%03d", i);
-      sprintf(mename, "Rate_AlgoBit _%03d", i);
-
-      algoRate[i] = dbe_->book1D(hname, mename,maxNbins,-0.5,double(maxNbins)-0.5);
-      algoRate[i]->setAxisTitle("Lumi Section" ,1);
-    }    
-    				     
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates/AlgorithmRates/Integrated");
-
-    for(int i=0; i<Level1TriggerScalers::nLevel1Triggers; i++) {
-      sprintf(hname, "Integral_AlgoBit_%03d", i);
-      sprintf(mename, "Integral_AlgoBit _%03d", i);
-
-      integralAlgo[i] = dbe_->book1D(hname, mename,maxNbins,-0.5,double(maxNbins)-0.5);
-      integralAlgo[i]->setAxisTitle("Lumi Section" ,1);
-    }    				     
-
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates/TechnicalRates");
-
-    for(int i=0; i<Level1TriggerScalers::nLevel1TestTriggers; i++) {
-      sprintf(hname, "Rate_TechBit_%03d", i);
-      sprintf(mename, "Rate_TechBit _%03d", i);
-
-      techRate[i] = dbe_->book1D(hname, mename,maxNbins,-0.5,double(maxNbins)-0.5);
-      techRate[i]->setAxisTitle("Lumi Section" ,1);
-    }
-
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates/TechnicalRates/Integrated");
-
-    for(int i=0; i<Level1TriggerScalers::nLevel1TestTriggers; i++) {
-      sprintf(hname, "Integral_TechBit_%03d", i);
-      sprintf(mename, "Integral_TechBit _%03d", i);
-
-      integralTech[i] = dbe_->book1D(hname, mename,maxNbins,-0.5,double(maxNbins)-0.5);
-      integralTech[i]->setAxisTitle("Lumi Section" ,1);
-    }    				     
-    integralTech_42_OR_43 = dbe_->book1D("Integral_TechBit_042_OR_043","Integral_TechBit _042_OR_043",maxNbins,-0.5,double(maxNbins)-0.5);
-    integralTech_42_OR_43->setAxisTitle("Lumi Section" ,1);
-
-
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/Level1TriggerRates/Ratios");
-
-    std::stringstream smu,seg,sjet,sdenom;
-    //denominator string
-    if(denomIsTech_) sdenom << "_TechBit_";
-    else sdenom << "_AlgoBit_";
-    sdenom << denomBit_;
-    //Muon ratio
-    smu << muonBit_;
-    rateRatio_mu = dbe_->book1D("Rate_Ratio_mu_PhysBit_"+ smu.str()+sdenom.str(), "Rate_Ratio_mu_PhysBit_" + smu.str()+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    //rateRatio_mu->setAxisTitle("Lumi Section" , 1);
-    //Egamma ratio
-    seg << egammaBit_;
-    rateRatio_egamma = dbe_->book1D("Rate_Ratio_egamma_PhysBit_"+ seg.str()+sdenom.str(), "Rate_Ratio_egamma_PhysBit_" + seg.str()+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    //rateRatio_egamma->setAxisTitle("Lumi Section" , 1);
-    //Jet ratio
-    sjet << jetBit_;
-    rateRatio_jet = dbe_->book1D("Rate_Ratio_jet_PhysBit_" + sjet.str()+sdenom.str(), "Rate_Ratio_jet_PhysBit_" + sjet.str()+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    //rateRatio_jet->setAxisTitle("Lumi Section" , 1);
-
-    //HF bit ratios
-    techRateRatio_8 = dbe_->book1D("Rate_Ratio_TechBit_8"+sdenom.str(), "Rate_Ratio_TechBit_8"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    //techRateRatio_8->setAxisTitle("Lumi Section" ,1);
-    techRateRatio_9 = dbe_->book1D("Rate_Ratio_TechBit_9"+sdenom.str(), "Rate_Ratio_TechBit_9"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    //techRateRatio_9->setAxisTitle("Lumi Section" ,1);
-    techRateRatio_10 = dbe_->book1D("Rate_Ratio_TechBit_10"+sdenom.str(), "Rate_Ratio_TechBit_10"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    //techRateRatio_10->setAxisTitle("Lumi Section" ,1);
-
-    //Other tech bit ratios
-    techRateRatio_33_over_32 = dbe_->book1D("Rate_Ratio_TechBits_33_over_32", "Rate_Ratio_TechBits_33_over_32",maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_36 = dbe_->book1D("Rate_Ratio_TechBit_36"+sdenom.str(), "Rate_Ratio_TechBit_36"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_37 = dbe_->book1D("Rate_Ratio_TechBit_37"+sdenom.str(), "Rate_Ratio_TechBit_37"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_38 = dbe_->book1D("Rate_Ratio_TechBit_38"+sdenom.str(), "Rate_Ratio_TechBit_38"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_39 = dbe_->book1D("Rate_Ratio_TechBit_39"+sdenom.str(), "Rate_Ratio_TechBit_39"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_40 = dbe_->book1D("Rate_Ratio_TechBit_40"+sdenom.str(), "Rate_Ratio_TechBit_40"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_41 = dbe_->book1D("Rate_Ratio_TechBit_41"+sdenom.str(), "Rate_Ratio_TechBit_41"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_42 = dbe_->book1D("Rate_Ratio_TechBit_42"+sdenom.str(), "Rate_Ratio_TechBit_42"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-    techRateRatio_43 = dbe_->book1D("Rate_Ratio_TechBit_43"+sdenom.str(), "Rate_Ratio_TechBit_43"+sdenom.str(),maxNbins,-0.5,double(maxNbins)-0.5);
-
-    				
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/LumiScalers");
-    //instLumi = dbe_->book1D("Instant Lumi","Instant Lumi",100,0,100);
-    instLumi = dbe_->book1D("Instant_Lumi","Instant_Lumi", maxNbins,-0.5,double(maxNbins)-0.5);
-    //instLumiErr = dbe_->book1D("Instant Lumi Err","Instant Lumi Err",100,
-    //			       0,100);
-    instLumiErr = dbe_->book1D("Instant_Lumi_Err","Instant_Lumi_Err",maxNbins,-0.5,double(maxNbins)-0.5);
-    //instLumiQlty = dbe_->book1D("Instant Lumi Qlty","Instant Lumi Qlty",100,
-    //				0,100);
-    instLumiQlty = dbe_->book1D("Instant_Lumi_Qlty","Instant_Lumi_Qlty",maxNbins,-0.5,double(maxNbins)-0.5);
-    //instEtLumi = dbe_->book1D("Instant Et Lumi","Instant Et Lumi",100,0,100);
-    instEtLumi = dbe_->book1D("Instant_Et_Lumi","Instant_Et_Lumi",maxNbins,-0.5,double(maxNbins)-0.5);
-    //instEtLumiErr = dbe_->book1D("Instant Et Lumi Err","Instant Et Lumi Err",
-    //				 100,0,100);
-    instEtLumiErr = dbe_->book1D("Instant_Et_Lumi_Err","Instant_Et_Lumi_Err",maxNbins,-0.5,double(maxNbins)-0.5);
-    //instEtLumiQlty = dbe_->book1D("Instant Et Lumi Qlty",
-    //				  "Instant Et Lumi Qlty",100,0,100);
-    instEtLumiQlty = dbe_->book1D("Instant_Et_Lumi_Qlty",
-				  "Instant_Et_Lumi_Qlty",maxNbins,-0.5,double(maxNbins)-0.5);
-    //sectionNum = dbe_->book1D("Section Number","Section Number",100,0,100);
-    //startOrbit = dbe_->book1D("Start Orbit","Start Orbit",100,0,100);
-    startOrbit = dbe_->book1D("Start_Orbit","Start_Orbit", maxNbins,-0.5,double(maxNbins)-0.5);
-    //numOrbits = dbe_->book1D("Num Orbits","Num Orbits",100,0,100);
-    numOrbits = dbe_->book1D("Num_Orbits","Num_Orbits", maxNbins,-0.5,double(maxNbins)-0.5);
-        
-    
-    dbe_->setCurrentFolder("L1T/L1TScalersSCAL/L1AcceptBunchCrossing");
-       
-    for(int i=0; i<4; i++){
-
-      sprintf(hname, "OrbitNumber_L1A_%d", i+1);
-      sprintf(mename, "OrbitNumber_L1A_%d", i+1);
-      orbitNumL1A[i] = dbe_->book1D(hname,mename,200,0,10E8);          
-
-      sprintf(hname, "Bunch_Crossing_L1A_%d", i+1);
-      sprintf(mename, "Bunch_Crossing_L1A_%d", i+1);
-      bunchCrossingL1A[i]= dbe_->book1D(hname, mename, 3564, -0.5, 3563.5);
-    }
-    orbitNumL1A[0]->setAxisTitle("Current BX",1);
-    orbitNumL1A[1]->setAxisTitle("Previous BX",1);
-    orbitNumL1A[2]->setAxisTitle("Second Previous BX",1);
-    orbitNumL1A[3]->setAxisTitle("Third Previous BX",1);
-
-    bunchCrossingL1A[0]->setAxisTitle("Current BX",1);
-    bunchCrossingL1A[1]->setAxisTitle("Previous BX",1);
-    bunchCrossingL1A[2]->setAxisTitle("Second Previous BX",1);
-    bunchCrossingL1A[3]->setAxisTitle("Third Previous BX",1);
-
-
-    for(int j=0; j<3; j++) {
-      sprintf(hname, "BX_Correlation_%d", j+1);
-      sprintf(mename, "BX_Correlation_%d", j+1);
-
-      bunchCrossingCorr[j] = dbe_->book2D(hname, mename, 99,-0.5,3563.5, 99,-0.5,3563.5);
-      bunchCrossingCorr[j]->setAxisTitle("Current Event", 1);
-
-      sprintf(hname, "Bunch_Crossing_Diff_%d", j+1);
-      sprintf(mename, "Bunch_Crossing_Diff_%d", j+1);
-      
-      bunchCrossingDiff[j] = dbe_->book1D(hname, mename, 1000,0,1E6);
-
-      sprintf(hname, "Bunch_Crossing_Diff_small_%d", j+1);
-      sprintf(mename, "Bunch_Crossing_Diff_small_%d", j+1);
-      
-      bunchCrossingDiff_small[j] = dbe_->book1D(hname, mename, 1000,0,1000);
-
-    }    				     
-    bunchCrossingCorr[0]->setAxisTitle("Previous Event" , 2);
-    bunchCrossingCorr[1]->setAxisTitle("Second Previous Event" , 2);
-    bunchCrossingCorr[2]->setAxisTitle("Third Previous Event" , 2);
-
-    bunchCrossingDiff[0]->setAxisTitle("BX_Current - BX_Previous" , 1);
-    bunchCrossingDiff[1]->setAxisTitle("BX_Current - BX_SecondPrevious" , 1);
-    bunchCrossingDiff[2]->setAxisTitle("BX_Current - BX_ThirdPrevious" , 1);
-
-    bunchCrossingDiff_small[0]->setAxisTitle("BX_Current - BX_Previous" , 1);
-    bunchCrossingDiff_small[1]->setAxisTitle("BX_Current - BX_SecondPrevious" , 1);
-    bunchCrossingDiff_small[2]->setAxisTitle("BX_Current - BX_ThirdPrevious" , 1);
-
-  }    
-
+  bunchCrossingDiff_small[0]->setAxisTitle("BX_Current - BX_Previous", 1);
+  bunchCrossingDiff_small[1]->setAxisTitle("BX_Current - BX_SecondPrevious", 1);
+  bunchCrossingDiff_small[2]->setAxisTitle("BX_Current - BX_ThirdPrevious", 1);
 }
 
-
-L1TScalersSCAL::~L1TScalersSCAL()
-{
-   // do anything here that needs to be done at destruction time
-   // (e.g. close files, deallocate resources etc.)
-}
-
-
-//
-// member functions
-//
-
-// ------------ method called to for each event  ------------
-void
-L1TScalersSCAL::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+void L1TScalersSCAL::analyze(const edm::Event& iEvent,
+                             const edm::EventSetup& iSetup) {
   nev_++;
-
-  //access SCAL info
+  // access SCAL info
   edm::Handle<Level1TriggerScalersCollection> triggerScalers;
   bool a = iEvent.getByLabel(scalersSource_, triggerScalers);
-  //edm::Handle<L1TriggerRatesCollection> triggerRates;
-  //edm::Handle<Level1TriggerRatesCollection> triggerRates;
-  //bool b = iEvent.getByLabel(scalersSource_, triggerRates);
   edm::Handle<LumiScalersCollection> lumiScalers;
   bool c = iEvent.getByLabel(scalersSource_, lumiScalers);
   edm::Handle<L1AcceptBunchCrossingCollection> bunchCrossings;
   bool d = iEvent.getByLabel(scalersSource_, bunchCrossings);
-  
+
   double evtLumi = iEvent.luminosityBlock();
   int run = iEvent.id().run();
 
-
-  if ( ! (a && c && d) ) {
-    LogInfo("Status") << "getByLabel failed with label " 
-		      << scalersSource_;
-  }
-        		        
-  else { // we have the data 
-    
+  if (!(a && c && d)) {
+    LogInfo("Status") << "getByLabel failed with label " << scalersSource_;
+  } else {  // we have the data
     Level1TriggerScalersCollection::const_iterator it = triggerScalers->begin();
-    if(triggerScalers->size()){ 
-
-      //for(L1TriggerScalersCollection::const_iterator it = triggerScalers->begin();
-      //it != triggerScalers->end();
-      //++it){
-       
+    if (triggerScalers->size()) {
       unsigned int lumisection = it->lumiSegmentNr();
       struct timespec thetime = it->collectionTime();
       long currenttime;
-      //cout << "lumisection = " << lumisection << endl;
-      if(nev_ == 1) reftime_ = thetime.tv_sec; 
-      //cout << "reftime = " << reftime_ << endl;
-      if(lumisection){
+      // cout << "lumisection = " << lumisection << endl;
+      if (nev_ == 1) reftime_ = thetime.tv_sec;
+      // cout << "reftime = " << reftime_ << endl;
+      if (lumisection) {
+        orbitNum->setBinContent(lumisection + 1, it->orbitNr());
+        eventNum->setBinContent(lumisection + 1, it->gtEvents());
+        physTrig->setBinContent(lumisection + 1, it->l1AsPhysics());
+        randTrig->setBinContent(lumisection + 1, it->l1AsRandom());
+        numberResets->setBinContent(lumisection + 1, it->gtResets());
+        deadTime->setBinContent(lumisection + 1, it->deadtime());
+        lostFinalTriggers->setBinContent(lumisection + 1,
+                                         it->triggersPhysicsLost());
 
-	//orbitNum->Fill(it->orbitNr());
-	orbitNum->setBinContent(lumisection+1,it->orbitNr());
+        if (buffertime_ < thetime.tv_sec) {
+          buffertime_ = thetime.tv_sec;
+          currenttime = thetime.tv_sec - reftime_;
+          int timebin = (int)(currenttime / 30) + 1;
+          trigNum->setBinContent((int)timebin, it->gtTriggers());
+          instTrigRate->setBinContent((int)timebin, it->gtTriggersRate());
+          instEventRate->setBinContent((int)timebin, it->gtEventsRate());
+        }
 
-	//trigNum ->Fill(it->gtTriggers());
-	//trigNum->setBinContent(lumisection+1, it->gtTriggers()); 
+        Level1TriggerRates trigRates(*it, run);
+        Level1TriggerRates* triggerRates = &trigRates;
+        if (triggerRates) {
+          algorithmRates_ = triggerRates->gtAlgoCountsRate();
+          technicalRates_ = triggerRates->gtTechCountsRate();
+          if (((bufferLumi_ != lumisection) && (bufferLumi_ < lumisection) &&
+               (evtLumi > 1 || evtLumi == lumisection + 1))) {
+            bufferLumi_ = lumisection;
+            if (bufferAlgoRates_ != algorithmRates_) {
+              bufferAlgoRates_ = algorithmRates_;
+              for (unsigned int i = 0; i < algorithmRates_.size(); i++) {
+                integral_algo_[i] += (algorithmRates_[i] * SECS_PER_LUMI);
+                algoRate[i]->setBinContent(lumisection + 1, algorithmRates_[i]);
+                integralAlgo[i]->setBinContent(lumisection + 1,
+                                               integral_algo_[i]);
+              }
+            }
+            if (bufferTechRates_ != technicalRates_) {
+              bufferTechRates_ = technicalRates_;
+              for (unsigned int i = 0; i < technicalRates_.size(); i++) {
+                integral_tech_[i] += (technicalRates_[i] * SECS_PER_LUMI);
+                techRate[i]->setBinContent(lumisection + 1, technicalRates_[i]);
+                integralTech[i]->setBinContent(lumisection + 1,
+                                               integral_tech_[i]);
+                if ((i == 42 || i == 43))
+                  integral_tech_42_OR_43_ +=
+                      (technicalRates_[i] * SECS_PER_LUMI);
+              }
+              // fill rate ratio plots
+              if (denomIsTech_) {
+                if (denomBit_ < technicalRates_.size()) {
+                  if (technicalRates_[denomBit_]) {
+                    if (muonBit_ < algorithmRates_.size())
+                      rateRatio_mu->setBinContent(
+                          lumisection + 1, algorithmRates_[muonBit_] /
+                                               technicalRates_[denomBit_]);
+                    if (egammaBit_ < algorithmRates_.size())
+                      rateRatio_egamma->setBinContent(
+                          lumisection + 1, algorithmRates_[egammaBit_] /
+                                               technicalRates_[denomBit_]);
+                    if (jetBit_ < algorithmRates_.size())
+                      rateRatio_jet->setBinContent(
+                          lumisection + 1, algorithmRates_[jetBit_] /
+                                               technicalRates_[denomBit_]);
 
-	//eventNum->Fill(it->gtEvents());
-	eventNum->setBinContent(lumisection+1,it->gtEvents());
+                    techRateRatio_8->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[8] / technicalRates_[denomBit_]);
+                    techRateRatio_9->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[9] / technicalRates_[denomBit_]);
+                    techRateRatio_10->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[10] / technicalRates_[denomBit_]);
 
-	//physTrig ->Fill(it->l1AsPhysics());
-	physTrig->setBinContent(lumisection+1, it->l1AsPhysics()); 
+                    techRateRatio_36->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[36] / technicalRates_[denomBit_]);
+                    techRateRatio_37->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[37] / technicalRates_[denomBit_]);
+                    techRateRatio_38->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[38] / technicalRates_[denomBit_]);
+                    techRateRatio_39->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[39] / technicalRates_[denomBit_]);
+                    techRateRatio_40->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[40] / technicalRates_[denomBit_]);
+                    techRateRatio_41->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[41] / technicalRates_[denomBit_]);
+                    techRateRatio_42->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[42] / technicalRates_[denomBit_]);
+                    techRateRatio_43->setBinContent(
+                        lumisection + 1,
+                        technicalRates_[43] / technicalRates_[denomBit_]);
+                  }
+                }
+              }
+              if (technicalRates_[32] != 0)
+                techRateRatio_33_over_32->setBinContent(
+                    lumisection + 1, technicalRates_[33] / technicalRates_[32]);
+              integralTech_42_OR_43->setBinContent(lumisection + 1,
+                                                   integral_tech_42_OR_43_);
+            }
 
-	//randTrig ->Fill(it->l1AsRandom());
-	randTrig->setBinContent(lumisection+1, it->l1AsRandom()); 
+            physRate->setBinContent(lumisection + 1,
+                                    triggerRates->l1AsPhysicsRate());
+            randRate->setBinContent(lumisection + 1,
+                                    triggerRates->l1AsRandomRate());
+            lostPhysRate->setBinContent(
+                lumisection + 1, triggerRates->triggersPhysicsLostRate());
+            lostPhysRateBeamActive->setBinContent(
+                lumisection + 1,
+                triggerRates->triggersPhysicsLostBeamActiveRate());
+            deadTimePercent->setBinContent(lumisection + 1,
+                                           triggerRates->deadtimePercent());
+          }  // bufferLumi test
+        }    // triggerRates
+      }      // lumisection
+    }        // triggerScalers->size()
 
-	//numberResets ->Fill(it->gtResets());	 
-	numberResets->setBinContent(lumisection+1, it->gtResets());	 
-
-	//deadTime ->Fill(it->deadtime());
-	deadTime->setBinContent(lumisection+1, it->deadtime());
-
-	//lostFinalTriggers ->Fill(it->triggersPhysicsLost());                       
-	lostFinalTriggers->setBinContent(lumisection+1, it->triggersPhysicsLost());
-	 
-	//cout << "lumisection = " << lumisection << " , orbitNum = " 
-	//     << it->orbitNr() << ", lumiSegmentOrbits = " << it->lumiSegmentOrbits() 
-	//     << ", l1AsPhys = " << it->l1AsPhysics() << endl;
-	//cout << "gtTriggersRate = " << it->gtTriggersRate() << endl;
-
-	if(buffertime_ < thetime.tv_sec){
-	  buffertime_ = thetime.tv_sec;
-	  currenttime = thetime.tv_sec - reftime_ ;
-	  int timebin = (int)(currenttime/30) + 1;
-	  //cout << "time bin = " << timebin << endl;
-	  trigNum->setBinContent((int)timebin ,it->gtTriggers());
-	  instTrigRate->setBinContent((int)timebin ,it->gtTriggersRate());
-	  instEventRate->setBinContent((int)timebin ,it->gtEventsRate());
-	}
-	
-	//cout << "tv_sec = " << thetime.tv_sec << endl;
-
-	//std::vector<unsigned int> algoBits = it->gtAlgoCounts();
-	//std::vector<unsigned int> techBits = it->gtTechCounts();
-	/*         
-		   int length = algoBits.size() / 4;
-		   char line[128];
-		   for ( int i=0; i<length; i++)
-		   {
-		   sprintf(line," %3.3d: %10u    %3.3d: %10u    %3.3d: %10u    %3.3d: %10u",
-		   i,              algoBits[i], 
-		   (i+length),     algoBits[i+length], 
-		   (i+(length*2)), algoBits[i+(length*2)], 
-		   (i+(length*3)), algoBits[i+(length*3)]);
-		   std::cout << line << std::endl;
-		   }
-	*/
-	//sprintf(line,
-	//        " LuminositySection: %15d  BunchCrossingErrors:      %15d",
-	//        it->luminositySection(), it->bunchCrossingErrors());
-	//std::cout << line << std::endl;
-         
-	//Level1TriggerRatesCollection::const_iterator it2 = triggerRates->begin();
-
-	Level1TriggerRates trigRates(*it,run);
-	Level1TriggerRates *triggerRates = &trigRates;
-	if(triggerRates){
-	  algorithmRates_ = triggerRates->gtAlgoCountsRate();
-	  technicalRates_ = triggerRates->gtTechCountsRate();
-	  
-	  if( ((bufferLumi_!=lumisection) && (bufferLumi_<lumisection) && (evtLumi>1 || evtLumi==lumisection+1)) ){
-	    bufferLumi_ = lumisection;
- 
-	    if(bufferAlgoRates_ != algorithmRates_){ 
-	      bufferAlgoRates_ = algorithmRates_;
-	      for (unsigned int i=0; i< algorithmRates_.size(); i++){ 
-		integral_algo_[i]+=(algorithmRates_[i]*SECS_PER_LUMI);
-		algoRate[i]->setBinContent(lumisection+1, algorithmRates_[i]); 
-		integralAlgo[i]->setBinContent(lumisection+1,integral_algo_[i]); 
-	      } 	   
-	    }
-	    if(bufferTechRates_ != technicalRates_){ 
-	      bufferTechRates_ = technicalRates_;
-	      for (unsigned int i=0; i< technicalRates_.size(); i++){ 
-		integral_tech_[i]+=(technicalRates_[i]*SECS_PER_LUMI);
-		techRate[i]->setBinContent(lumisection+1, technicalRates_[i]); 
-		integralTech[i]->setBinContent(lumisection+1, integral_tech_[i]); 
-		if( (i==42 || i==43) ) integral_tech_42_OR_43_+=(technicalRates_[i]*SECS_PER_LUMI);
-	      } 
-
-	      //fill rate ratio plots
-	      if(denomIsTech_){
-		if( denomBit_ < technicalRates_.size() ){
-		  if(technicalRates_[denomBit_]){
-
-		    if( muonBit_ < algorithmRates_.size() )
-		      rateRatio_mu->setBinContent(lumisection+1, algorithmRates_[muonBit_]/technicalRates_[denomBit_]);
-		    if( egammaBit_ < algorithmRates_.size() )
-		      rateRatio_egamma->setBinContent(lumisection+1, algorithmRates_[egammaBit_]/technicalRates_[denomBit_]);
-		    if( jetBit_ < algorithmRates_.size() )
-		      rateRatio_jet->setBinContent(lumisection+1, algorithmRates_[jetBit_]/technicalRates_[denomBit_]);
-
-		    techRateRatio_8->setBinContent(lumisection+1, technicalRates_[8]/technicalRates_[denomBit_]);
-		    techRateRatio_9->setBinContent(lumisection+1, technicalRates_[9]/technicalRates_[denomBit_]);
-		    techRateRatio_10->setBinContent(lumisection+1, technicalRates_[10]/technicalRates_[denomBit_]);
-
-		    techRateRatio_36->setBinContent(lumisection+1, technicalRates_[36]/technicalRates_[denomBit_]);
-		    techRateRatio_37->setBinContent(lumisection+1, technicalRates_[37]/technicalRates_[denomBit_]);
-		    techRateRatio_38->setBinContent(lumisection+1, technicalRates_[38]/technicalRates_[denomBit_]);
-		    techRateRatio_39->setBinContent(lumisection+1, technicalRates_[39]/technicalRates_[denomBit_]);
-		    techRateRatio_40->setBinContent(lumisection+1, technicalRates_[40]/technicalRates_[denomBit_]);
-		    techRateRatio_41->setBinContent(lumisection+1, technicalRates_[41]/technicalRates_[denomBit_]);
-		    techRateRatio_42->setBinContent(lumisection+1, technicalRates_[42]/technicalRates_[denomBit_]);
-		    techRateRatio_43->setBinContent(lumisection+1, technicalRates_[43]/technicalRates_[denomBit_]);
-		  }
-		}
-	      }
-	      if( technicalRates_[32]!=0 ) techRateRatio_33_over_32->setBinContent(lumisection+1, technicalRates_[33]/technicalRates_[32]);
-	      integralTech_42_OR_43->setBinContent(lumisection+1, integral_tech_42_OR_43_);	   
-
-	    }
-
-	    physRate->setBinContent(lumisection+1, 
-				    triggerRates->l1AsPhysicsRate()); 
-	    randRate->setBinContent(lumisection+1, 
-				    triggerRates->l1AsRandomRate());
-	    lostPhysRate->setBinContent(lumisection+1, 
-					triggerRates->triggersPhysicsLostRate()); 
-	    lostPhysRateBeamActive->setBinContent(lumisection+1, 
-						  triggerRates->triggersPhysicsLostBeamActiveRate()); 
-	    deadTimePercent->setBinContent(lumisection+1, 
-					   triggerRates->deadtimePercent()); 
-	   
-	  }//bufferLumi test
-	}//triggerRates	 
-      }//lumisection
-    }//triggerScalers->size()
-
-     
     LumiScalersCollection::const_iterator it3 = lumiScalers->begin();
-    if(lumiScalers->size()){ 
-    
-      //for(LumiScalersCollection::const_iterator it3 = lumiScalers->begin();
-      //it3 != lumiScalers->end();
-      //++it3){
+    if (lumiScalers->size()) {
       unsigned int lumisection = it3->sectionNumber();
-      if(lumisection){
-       
-	instLumi->setBinContent(lumisection+1, it3->instantLumi());
-	instLumiErr->setBinContent(lumisection+1, it3->instantLumiErr()); 
-	instLumiQlty->setBinContent(lumisection+1, it3->instantLumiQlty()); 
-	instEtLumi->setBinContent(lumisection+1, it3->instantETLumi()); 
-	instEtLumiErr->setBinContent(lumisection+1, it3->instantETLumiErr()); 
-	instEtLumiQlty->setBinContent(lumisection+1, it3->instantETLumiQlty()); 
-	//sectionNum->Fill(it3->sectionNumber()); 
-	startOrbit->setBinContent(lumisection+1, it3->startOrbit()); 
-	numOrbits->setBinContent(lumisection+1, it3->numOrbits()); 
-
-      }       
-      /*
-	char line2[128];
-	sprintf(line2," InstantLumi:       %e  Err: %e  Qlty: %d",
-	it3->instantLumi(), it3->instantLumiErr(), it3->instantLumiQlty());
-	std::cout << line2 << std::endl;
-
-	sprintf(line2," SectionNumber: %10d   StartOrbit: %10d  NumOrbits: %10d",
-	it3->sectionNumber(), it3->startOrbit(), it3->numOrbits());
-	std::cout << line2 << std::endl;
-      */
+      if (lumisection) {
+        instLumi->setBinContent(lumisection + 1, it3->instantLumi());
+        instLumiErr->setBinContent(lumisection + 1, it3->instantLumiErr());
+        instLumiQlty->setBinContent(lumisection + 1, it3->instantLumiQlty());
+        instEtLumi->setBinContent(lumisection + 1, it3->instantETLumi());
+        instEtLumiErr->setBinContent(lumisection + 1, it3->instantETLumiErr());
+        instEtLumiQlty->setBinContent(lumisection + 1,
+                                      it3->instantETLumiQlty());
+        startOrbit->setBinContent(lumisection + 1, it3->startOrbit());
+        numOrbits->setBinContent(lumisection + 1, it3->numOrbits());
+      }
     }
 
-    //     L1AcceptBunchCrossingCollection::const_iterator it4 = bunchCrossings->begin();
-    //if(bunchCrossings->size()){
-    //int counttest=0;
-    int l1accept; 
+    int l1accept;
     unsigned int bx_current = 0, orbitnumber_current = 0, bxdiff = 0;
 
-    for(L1AcceptBunchCrossingCollection::const_iterator it4 = bunchCrossings->begin();
-	it4 != bunchCrossings->end();
-	++it4){
-      //counttest++;
-      //cout << "counttest = " << counttest << endl;
-      //cout << "bunchCrossing = "  << it4->bunchCrossing() << endl;
-      //cout << "l1AcceptOffset = " << it4->l1AcceptOffset() << endl;
+    for (L1AcceptBunchCrossingCollection::const_iterator it4 =
+             bunchCrossings->begin();
+         it4 != bunchCrossings->end(); ++it4) {
+      l1accept = std::abs(it4->l1AcceptOffset());
+      if (l1accept == 0) {
+        orbitnumber_current = it4->orbitNumber();
+        orbitNumL1A[l1accept]->Fill(orbitnumber_current);
 
-      l1accept = std::abs(it4->l1AcceptOffset());   
-
-      //cout << "l1a orbit number (before if)= " << it4->orbitNumber() << endl;
-      //cout << "l1a bunch crossing = " << it4->bunchCrossing() << endl;
-
-      if(l1accept == 0){
-	orbitnumber_current = it4->orbitNumber();
-	orbitNumL1A[l1accept]->Fill(orbitnumber_current);
-
-	bx_current = it4->bunchCrossing();
-	bunchCrossingL1A[l1accept]->Fill(bx_current);
-
+        bx_current = it4->bunchCrossing();
+        bunchCrossingL1A[l1accept]->Fill(bx_current);
+      } else if (l1accept == 1 || l1accept == 2 || l1accept == 3) {
+        orbitNumL1A[l1accept]->Fill(it4->orbitNumber());
+        bunchCrossingL1A[l1accept]->Fill(it4->bunchCrossing());
+        bunchCrossingCorr[l1accept - 1]->Fill(bx_current, it4->bunchCrossing());
+        bxdiff = 3564 * (orbitnumber_current - it4->orbitNumber()) +
+                 bx_current - it4->bunchCrossing();
+        bunchCrossingDiff[l1accept - 1]->Fill(bxdiff);
+        bunchCrossingDiff_small[l1accept - 1]->Fill(bxdiff);
       }
-      else if (l1accept==1 || l1accept==2 || l1accept==3){
-	orbitNumL1A[l1accept]->Fill(it4->orbitNumber());
-	bunchCrossingL1A[l1accept]->Fill(it4->bunchCrossing());
-	//cout << "l1accept = " << l1accept << ", bx_current = " << bx_current << ", it4->bunchCrossing() = " << it4->bunchCrossing() << endl;
-	bunchCrossingCorr[l1accept-1]->Fill(bx_current, it4->bunchCrossing());
-	bxdiff = 3564*(orbitnumber_current-it4->orbitNumber()) + bx_current - it4->bunchCrossing();
-	bunchCrossingDiff[l1accept-1]->Fill(bxdiff);
-	bunchCrossingDiff_small[l1accept-1]->Fill(bxdiff);
-      }
-
     }
-   
-  } // getByLabel succeeds for scalers
-       
-
-
+  }  // getByLabel succeeds for scalers
 }
-
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-L1TScalersSCAL::beginJob(void)
-{
-
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-L1TScalersSCAL::endJob() {
-}
-
-
-void L1TScalersSCAL::endLuminosityBlock(const edm::LuminosityBlock& lumiSeg, 
-				   const edm::EventSetup& iSetup)
-{				    
-}		    
-/// BeginRun
-void L1TScalersSCAL::beginRun(const edm::Run& run, const edm::EventSetup& iSetup)
-{
-}
-				    
-/// EndRun
-void L1TScalersSCAL::endRun(const edm::Run& run, const edm::EventSetup& iSetup)
-{
-}
-				    


### PR DESCRIPTION
Migrated the following 4 modules to the new DQM api:
DQM/TrigXMonitor/interface/HLTScalers
DQM/TrigXMonitor/interface/HLTSeedL1LogicScalers
DQM/TrigXMonitor/interface/L1Scalers
DQM/TrigXMonitor/interface/L1TScalersSCAL

The only problem we encountered was that HLTScalers was waiting to book some histograms up to the moment it was analyzing the first event in a run. Because it was using the size of the hltResult to book the histograms.
We solved this by using the size of the hltConfig instead at booking time.
This was explicitly tested by comparing the resulting numbers from both methods.
