### PR TITLE
Fix old L1RePack file to cure 'unRunnable Schedule'

### DIFF
--- a/Configuration/StandardSequences/python/SimL1EmulatorRepack_GT_cff.py
+++ b/Configuration/StandardSequences/python/SimL1EmulatorRepack_GT_cff.py
@@ -16,7 +16,7 @@ unpackGtDigis = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.c
 
 import EventFilter.CastorRawToDigi.CastorRawToDigi_cfi
 unpackCastorDigis = EventFilter.CastorRawToDigi.CastorRawToDigi_cfi.castorDigis.clone(
-    InputLabel = cms.InputTag( 'rawDataCollector' )
+    InputLabel = cms.InputTag( 'rawDataCollector', processName=cms.InputTag.skipCurrentProcess())
 )
 
 ##


### PR DESCRIPTION
Fixes errors such as:

```
MSG-e UnrunnableSchedule:  AfterModConstruction 20-Jan-2015 10:30:12
CET  pre-eventsModule run order problem found: 
unpackCastorDigis consumes rawDataCollector, rawDataCollector consumes l1GtPack, l1GtPack consumes simGtDigis, simGtDigis after unpackCastorDigis [path L1RePack_step]
Running in the threaded framework would lead to indeterminate results.
Please change order of modules in mentioned Path(s) to avoid 
inconsistent module ordering.
```
