### PR TITLE
bump to v3 of both hf SL

### DIFF
--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -257,7 +257,7 @@ FamosCalorimetryBlock = cms.PSet(
             ),
             HFShowerLibrary    = cms.PSet(
               useShowerLibrary = cms.untracked.bool(False),
-              FileName = cms.FileInPath('SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v2.root'),
+              FileName = cms.FileInPath('SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v3.root'),
               ProbMax          = cms.double(1.0),
               BackProbability  = cms.double(0.2),
               CFibre           = cms.double(0.5),

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -72,7 +72,7 @@ def customise_Validation(process):
 
 def customise_Sim(process):
     # enable 2015 HF shower library
-    process.g4SimHits.HFShowerLibrary.FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v2.root'
+    process.g4SimHits.HFShowerLibrary.FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v3.root'
     return process
 
 

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -306,7 +306,7 @@ g4SimHits = cms.EDProducer("OscarProducer",
         ParametrizeLast   = cms.untracked.bool(False)
     ),
     HFShowerLibrary = cms.PSet(
-        FileName        = cms.FileInPath('SimG4CMS/Calo/data/HFShowerLibrary_oldpmt_noatt_eta4_16en_v2.root'),
+        FileName        = cms.FileInPath('SimG4CMS/Calo/data/HFShowerLibrary_oldpmt_noatt_eta4_16en_v3.root'),
         BackProbability = cms.double(0.2),
         TreeEMID        = cms.string('emParticles'),
         TreeHadID       = cms.string('hadParticles'),


### PR DESCRIPTION
there is no physics difference between v2 and v3 - just a technical performance one. This PR needs a corresponding CMSDIST change to go in first

New configuration for the shower libraries:
compressed with lzma level 4
on output, baskets are flushed every 50 events.

This unfortunately gives back the size improvement realized with v2, but does improve by a factor of 3 the speed of the v1 libraries which is of particular benefit to fastsim.
