### PR TITLE
Add mssing link dependency and fix checksum

### DIFF
--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/CaloRecHit"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/TrajectorySeed"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="DataFormats/Candidate"/>
 <use   name="FWCore/Utilities"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_1.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_1.xml
@@ -42,8 +42,9 @@
 <class name="edm::Ref<std::vector<reco::VertexCompositeCandidate>,reco::VertexCompositeCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::VertexCompositeCandidate>,reco::VertexCompositeCandidate> >" />
 
 
-  <class name="reco::ConvBremSeed" ClassVersion="10">
+  <class name="reco::ConvBremSeed" ClassVersion="11">
    <version ClassVersion="10" checksum="2980747190"/>
+   <version ClassVersion="11" checksum="637662266"/>
   </class>
   <class name="std::vector<reco::ConvBremSeed>"/>
   <class name="edm::Ref<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed> >"/>


### PR DESCRIPTION
If feasible, do not merge this pull request info CMSSW_7_4_ROOT6_X, as this needs to be fixed separately there.
In ROOT 5.34, and ROOT 6, checksums depend on the base class.
Because of a missing link dependency, DataFormats/ParticleFlowReco was built before DataFormats/TrajectorySeed.
Because of this, edmCheckClassVersion calculated the wrong checksum. The problem with edmClassVersion needs to be fixed separately, because the checksum it calculates can depend on build order of the packages.
This pull request supplies the missing dependency, and updates the checksum accordingly.
Please expedite this critical pull request, bypassing signatures if not signed in a timely manner.
However, do not bypass testing, comparisons, and all that!!
