### PR TITLE
Move G4Event to TLS in RunManagerMTWorker

### DIFF
--- a/SimG4Core/Application/interface/RunManagerMTWorker.h
+++ b/SimG4Core/Application/interface/RunManagerMTWorker.h
@@ -88,7 +88,6 @@ private:
   struct TLSData;
   static thread_local TLSData *m_tls;
 
-  std::unique_ptr<G4Event> m_currentEvent;
   std::unique_ptr<G4SimEvent> m_simEvent;
 };
 

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -119,6 +119,7 @@ struct RunManagerMTWorker::TLSData {
   std::vector<std::shared_ptr<SimProducer> > producers;
   std::unique_ptr<sim::FieldBuilder> fieldBuilder;
   std::unique_ptr<G4Run> currentRun;
+  std::unique_ptr<G4Event> currentEvent;
   edm::RunNumber_t currentRunNumber = 0;
   bool threadInitialized = false;
   bool runTerminated = false;
@@ -364,7 +365,7 @@ void RunManagerMTWorker::terminateRun() {
 
   G4RunManagerKernel *kernel = G4WorkerRunManagerKernel::GetRunManagerKernel();
   if(!kernel && !m_tls->runTerminated) {
-    m_currentEvent.reset();
+    m_tls->currentEvent.reset();
     m_simEvent.reset();
     kernel->RunTermination();
     m_tls->runTerminated = true;
@@ -397,7 +398,7 @@ void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup
   m_tls->runInterface->setRunManagerMTWorker(this); // For UserActions
 
 
-  m_currentEvent.reset(generateEvent(inpevt));
+  m_tls->currentEvent.reset(generateEvent(inpevt));
 
   m_simEvent.reset(new G4SimEvent());
   m_simEvent->hepEvent(m_generator.genEvent());
@@ -410,7 +411,7 @@ void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup
 			       genVertex->z()/centimeter,
 			       genVertex->t()/second));
   }
-  if (m_currentEvent->GetNumberOfPrimaryVertex()==0) {
+  if (m_tls->currentEvent->GetNumberOfPrimaryVertex()==0) {
     edm::LogError("SimG4CoreApplication") 
       << " RunManagerMT::produce event " << inpevt.id().event()
       << " with no G4PrimaryVertices \n  Aborting Run" ;
@@ -423,7 +424,7 @@ void RunManagerMTWorker::produce(const edm::Event& inpevt, const edm::EventSetup
       ss << "No G4WorkerRunManagerKernel yet for thread index" << getThreadIndex() << ", id " << std::hex << std::this_thread::get_id();
       throw SimG4Exception(ss.str());
     }
-    kernel->GetEventManager()->ProcessOneEvent(m_currentEvent.get());
+    kernel->GetEventManager()->ProcessOneEvent(m_tls->currentEvent.get());
   }
     
   edm::LogInfo("SimG4CoreApplication")
@@ -448,7 +449,7 @@ void RunManagerMTWorker::abortEvent() {
     static_cast<TrackingAction *>(kernel->GetEventManager()->GetUserTrackingAction());
   uta->PostUserTrackingAction(t) ;
 
-  m_currentEvent->SetEventAborted();
+  m_tls->currentEvent->SetEventAborted();
 
   // do NOT call this method for now
   // because it'll set abortRequested=true (withing G4EventManager)
@@ -475,7 +476,7 @@ void RunManagerMTWorker::abortRun(bool softAbort) {
 }
 
 G4Event * RunManagerMTWorker::generateEvent(const edm::Event& inpevt) {
-  m_currentEvent.reset();
+  m_tls->currentEvent.reset();
   m_simEvent.reset();
 
   // 64 bits event ID in CMSSW converted into Geant4 event ID


### PR DESCRIPTION
Fix the segfault in workflow 122.0 in THREADED build.

The segfault originates from the destruction of G4Event, which is a unique_ptr member of RunManagerMTWorker. It turns out that G4Event holds thread-local stuff, including effectively G4Allocator (via G4PrimaryParticle). In wf 122.0 it happens (usually) that G4Event (and the G4PrimaryPartifle-related G4Allocator) get
- destructed in a different thread they were constructed, and
- destructed twice in this thread.

In this case it is the dual-destruction that causes the segfault (G4Allocator being nullptr in the second destruction), but the first point needs to be fixed too.

A straightforward fix is to move G4Event to thread-local storage (among other thread-oriented stuff).

In addition to 122.0, tested with 2.0 in CMSSW_7_4_THREADED_X_2015-01-19-1400 giving identical results.

@civanch @Dr15Jones 
