### PR TITLE
Migrating ClusterCount in SiStripCommissioningSources to new DQM API

### DIFF
--- a/DQM/SiStripCommissioningSources/plugins/BuildFile.xml
+++ b/DQM/SiStripCommissioningSources/plugins/BuildFile.xml
@@ -18,5 +18,6 @@
   <use   name="DataFormats/SiStripCluster"/>
   <use   name="TrackingTools/MaterialEffects"/>
   <use   name="TrackingTools/KalmanUpdators"/>
+  <use   name="DQMServices/Core"/>
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/DQM/SiStripCommissioningSources/plugins/tracking/ClusterCount.cc
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/ClusterCount.cc
@@ -21,6 +21,10 @@ ClusterCount::~ClusterCount()
 
 }
 
+void ClusterCount::bookHistograms(DQMStore::IBooker & iBooker,
+                                  edm::Run const &,
+                                  edm::EventSetup const &) {
+}
 
 //
 // member functions

--- a/DQM/SiStripCommissioningSources/plugins/tracking/ClusterCount.h
+++ b/DQM/SiStripCommissioningSources/plugins/tracking/ClusterCount.h
@@ -25,7 +25,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -41,7 +41,7 @@
 // class decleration
 //
 
-class ClusterCount : public edm::EDAnalyzer {
+class ClusterCount : public DQMEDAnalyzer {
 
    public:
 
@@ -50,7 +50,8 @@ class ClusterCount : public edm::EDAnalyzer {
 
 
    private:
-
+      void bookHistograms(DQMStore::IBooker&, edm::Run const&,
+                          edm::EventSetup const&) override;
       virtual void analyze(const edm::Event&, const edm::EventSetup&);
 
       // ----------member data ---------------------------


### PR DESCRIPTION
ClusterCount now using DQMEDAnalyzer instead of EDAnalyzer

This was the TRIVIAL part of the migration.
