### PR TITLE
Reenable edmCheckClassVersion, and fail on missing base class dictionary

### DIFF
--- a/FWCore/Utilities/scripts/edmCheckClassVersion
+++ b/FWCore/Utilities/scripts/edmCheckClassVersion
@@ -1,6 +1,4 @@
 #!  /usr/bin/env python
-import sys
-sys.exit(0)
 import string
 from optparse import OptionParser
 
@@ -125,6 +123,10 @@ def checkClass(name,version,versionsToChecksums):
     c = ROOT.TClass.GetClass(name)
     if not c:
         raise RuntimeError("failed to load dictionary for class '"+name+"'")
+    temp = "checkTheClass.f(" + '"' + name + '"' + ");"
+    retval = ROOT.gROOT.ProcessLine(temp)
+    if retval == 0 :
+        raise RuntimeError("TClass::GetCheckSum: Failed to load dictionary for base class. See previous Error message")
     classChecksum = c.GetCheckSum()
     classVersion = c.GetClassVersion()
 
@@ -174,6 +176,9 @@ else:
         raise RuntimeError("failed to load library '"+options.library+"'")
 
 missingDict = 0
+
+ROOT.gROOT.ProcessLine("class checkclass {public: int f(char const* name) {TClass* cl = TClass::GetClass(name); bool b = false; cl->GetCheckSum(b); return (int)b;} };")
+ROOT.gROOT.ProcessLine("checkclass checkTheClass;")
 
 p = XmlParser(options.xmlfile)
 foundErrors = dict()


### PR DESCRIPTION
Re-enable edmCheckClassversion, and add code to raise an exception if attempting to calculate the checksum of a class when a base class is unavailable. This will prevent an incorrect checksum from being returned.
Pleas merge this pull request as soon as convenient.
