### PR TITLE
ElectronAnalyzer.cc  : false lines removed - setBookPrefix and setBookIndex

### DIFF
--- a/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
@@ -162,9 +162,6 @@ void ElectronAnalyzer::bookHistograms( DQMStore::IBooker & iBooker, edm::Run con
   iBooker.setCurrentFolder(outputInternalPath_) ;
 
   nEvents_ = 0 ;
-  setBookIndex(-1) ;
-  setBookPrefix("h") ;
-//  setBookStatOverflowFlag( set_StatOverflowFlag ) ;
 
   // basic quantities
   h1_vertexPt_barrel = bookH1(iBooker, "vertexPt_barrel","ele transverse momentum in barrel",nbinpt,0.,ptmax,"p_{T vertex} (GeV/c)");


### PR DESCRIPTION
2 lines were added by mistake with multithreading. They are removed. 
"ele" prefix came back with increment.
