### PR TITLE
Minor documentation change to TrackingParticle

### DIFF
--- a/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
+++ b/SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h
@@ -88,9 +88,9 @@ public:
     tv_iterator decayVertices_end() const;
 
 
-    ///< @brief Electric charge. Note this is taken from the first SimTrack only.
+    /// @brief Electric charge. Note this is taken from the first SimTrack only.
     float charge() const { return g4Tracks_[0].charge(); }
-    ///< Gives charge in unit of quark charge (should be 3 time the abaove)
+    /// Gives charge in unit of quark charge (should be 3 times "charge()")
     int threeCharge() const { return lrintf(3.f*charge()); }
 
     const LorentzVector& p4() const; ///< @brief Four-momentum Lorentz vector. Note this is taken from the first SimTrack only.
@@ -116,7 +116,7 @@ public:
     double rapidity() const; ///< @brief Rapidity. Note this is taken from the first SimTrack only.
     double y() const; ///< @brief Same as rapidity().
 
-    ///< @brief Parent vertex position
+    /// @brief Parent vertex position
     Point vertex() const {
        const TrackingVertex::LorentzVector & p = (*parentVertex_).position();
        return Point(p.x(),p.y(),p.z());
@@ -134,7 +134,7 @@ public:
 
     static const unsigned int longLivedTag; ///< long lived flag
 
-    ///< is long lived?
+    /// is long lived?
     bool longLived() const { return status()&longLivedTag;}
 
    /** @brief Gives the total number of hits, including muon hits. Hits on overlaps in the same layer count separately.


### PR DESCRIPTION
No code is changed, only documentation comments.

During various commits some comments were moved from the end of a line to the proceeding line, but the "<" in the comment was kept.  This "<" tells doxygen that the comment refers to the identifier preceding the comment instead of the one after it, hence moving the comment line makes doxygen refer to the wrong identifier.

For example, in the [doxygen documentation](https://cmssdt.cern.ch/SDT/doxygen/CMSSW_7_3_1/doc/html/de/d44/classTrackingParticle.html) `decayVertices_end()` is described as "Electric charge".
