### PR TITLE
Fix some obscure code in TrackingTruthAccumulator (still functionally identical)

### DIFF
--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -650,9 +650,7 @@ namespace // Unnamed namespace for things only used in this file
 
 		bool isInVolume=this->vectorIsInsideVolume( simVertex.position() );
 
-		// TODO - Still need to set the truth ID properly. I'm not sure what to set
-		// the second parameter of the EncodedTruthId constructor to.
-		TrackingVertex returnValue( simVertex.position(), isInVolume, EncodedTruthId( simVertex.eventId(), 0 ) );
+		TrackingVertex returnValue( simVertex.position(), isInVolume, simVertex.eventId() );
 		
 		// add the SimVertex to the TrackingVertex
 		returnValue.addG4Vertex(simVertex);


### PR DESCRIPTION
This should be functionally identical to the original, just makes the code clearer.

The TrackingVertex constructor takes an `EncodedEventId`.  Previously this section of code passed an `EncodedTruthId` which is a derived class, but with an additional parameter used as an object index.  In this code the object index is given a dummy value, which anyway is inaccessible when the class is resolved to the `EncodedEventId` base class passed to the constructor.  So I just removed the dummy value and passed the `EncodedEventId` directly which should make the intention of the code clearer.  Also removed the comment that shows uncertainty about what the dummy parameter should be.

I wrote this section of code originally but I can't remember why an `EncodedTruthId` was ever used.
