### PR TITLE
Add option to switch between hierarchy and averaging constraints in MP-b...

### DIFF
--- a/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
+++ b/Alignment/CommonAlignmentAlgorithm/interface/AlignmentParameterStore.h
@@ -152,11 +152,15 @@ protected:
   AlignmentCorrelationsStore* theCorrelationsStore;
 
 private:
+  enum TypeOfConstraints { NONE, HIERARCHY_CONSTRAINTS, APPROX_AVERAGING_CONSTRAINTS };
+
   // data members
 
   /// alignables 
   align::Alignables theAlignables;
 
+  /// type of constraints
+  TypeOfConstraints theTypeOfConstraints;  
 };
 
 #endif

--- a/Alignment/CommonAlignmentAlgorithm/python/AlignmentParameterStore_cfi.py
+++ b/Alignment/CommonAlignmentAlgorithm/python/AlignmentParameterStore_cfi.py
@@ -7,7 +7,8 @@ AlignmentParameterStore = cms.PSet(
             Weight = cms.double(0.5),
             MaxUpdates = cms.int32(5000)
         ),
-        UseExtendedCorrelations = cms.untracked.bool(False)
+        UseExtendedCorrelations = cms.untracked.bool(False),
+        TypeOfConstraints = cms.string('approximate_averaging'),
     )
 )
 

--- a/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
+++ b/Alignment/CommonAlignmentAlgorithm/src/AlignmentParameterStore.cc
@@ -36,6 +36,26 @@ AlignmentParameterStore::AlignmentParameterStore( const align::Alignables &alis,
 
   edm::LogInfo("Alignment") << "@SUB=AlignmentParameterStore"
                             << "Created with " << theAlignables.size() << " alignables.";
+
+  // set hierarchy vs averaging constraints
+  theTypeOfConstraints = NONE;
+  const std::string cfgStrTypeOfConstraints(config.getParameter<std::string>("TypeOfConstraints"));
+  if( cfgStrTypeOfConstraints == "hierarchy" ) {
+    theTypeOfConstraints = HIERARCHY_CONSTRAINTS;
+    edm::LogWarning("Alignment") << "@SUB=AlignmentParameterStore"
+				 << "\n\n\n******* WARNING ******************************************\n"
+				 << "Using hierarchy constraints that have a not-understood bug.\n"
+				 << "It is strongly recommended to use averaging constraints for\n"
+				 << "the time being!\n\n\n";
+    
+  } else if( cfgStrTypeOfConstraints == "approximate_averaging" ) {
+    theTypeOfConstraints = APPROX_AVERAGING_CONSTRAINTS;
+    edm::LogWarning("Alignment") << "@SUB=AlignmentParameterStore"
+				 << "Using approximate implementation of averaging constraints";
+  } else {
+    edm::LogError("BadArgument") << "@SUB=AlignmentParameterStore"
+				 << "Unknown type of hierarchy constraints '" << cfgStrTypeOfConstraints << "'"; 
+  }
 }
 
 //__________________________________________________________________________________________________
@@ -682,7 +702,15 @@ bool AlignmentParameterStore
       }
       for (unsigned int iParComp = 0; iParComp < aliCompSel.size(); ++iParComp) {
 	if (aliCompSel[iParComp]) {
-	  const double factor = p2pDerivs(iParMast, iParComp);
+	  double factor = 0.;
+	  if( theTypeOfConstraints == HIERARCHY_CONSTRAINTS ) {
+	    // hierachy constraints
+	    factor = p2pDerivs(iParMast, iParComp);
+	  } else if( theTypeOfConstraints == APPROX_AVERAGING_CONSTRAINTS ) {
+	    // CHK poor mans averaging constraints
+	    factor = p2pDerivs(iParMast, iParComp);
+	    if (iParMast < 3 && (iParComp % 9) >= 3) factor = 0.;
+	  }
 	  if (fabs(factor) > epsilon) {
 	    paramIdsVecOut[iParMastUsed].push_back(ParameterId(*iComp, iParComp));
 	    factorsVecOut[iParMastUsed].push_back(factor);


### PR DESCRIPTION
...ased tracker alignment

The default behaviour is now to use averaging constraints after
problems with the fit convergence have been found when using
hierarchy constraints. This is explained in more detail in this
presentation by C. Kleinwort,

https://indico.cern.ch/event/337178/session/0/contribution/5/material/slides/0.pdf

Note that the implementation of the averaging constraints is still
approximate for the time being, but adequate for current purposes
and superior to the current version of the hierarchy constraints.

This PR backports #6254 to 72X.
