### PR TITLE
Fix thread safety problem in PhysicsTools/MVAComputer

### DIFF
--- a/PhysicsTools/MVAComputer/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/BuildFile.xml
@@ -5,6 +5,7 @@
 <use name="rootcore"/>
 <use name="boost"/>
 <use name="zlib"/>
+<use name="tbb"/>
 <export>
    <lib name="1"/>
 </export>

--- a/PhysicsTools/MVAComputer/interface/MVAComputer.h
+++ b/PhysicsTools/MVAComputer/interface/MVAComputer.h
@@ -139,8 +139,9 @@ class MVAComputer {
 
 		inline void eval(const VarProcessor *proc, int *outConf,
 		                 double *output, int *loop,
+                                 VarProcessor::LoopCtx& ctx,
 		                 unsigned int offset, unsigned int out) const
-		{ proc->eval(values_, conf_, output, outConf, loop, offset); }
+                { proc->eval(values_, conf_, output, outConf, loop, ctx, offset); }
 
 		inline double output(unsigned int output) const
 		{ return values_[conf_[output]]; }
@@ -158,7 +159,8 @@ class MVAComputer {
 		DerivContext() : n_(0) {}
 
 		void eval(const VarProcessor *proc, int *outConf,
-		          double *output, int *loop,
+		          double *output, int *loop, 
+                          VarProcessor::LoopCtx& ctx,
 		          unsigned int offset, unsigned int out) const;
 
 		double output(unsigned int output,

--- a/PhysicsTools/MVAComputer/interface/ProcessRegistry.h
+++ b/PhysicsTools/MVAComputer/interface/ProcessRegistry.h
@@ -18,7 +18,7 @@
 
 
 #include <string>
-#include <map>
+#include "tbb/concurrent_unordered_map.h"
 
 
 
@@ -92,7 +92,7 @@ namespace PhysicsTools
 					const ProcessRegistry *process);
 	    static void unregisterProcess(const char *name);
 	    
-	    typedef std::map<std::string, const ProcessRegistry*> RegistryMap;
+	    typedef tbb::concurrent_unordered_map<std::string, const ProcessRegistry*> RegistryMap;
 	    
 	    /// return map of all registered processes, allocate if necessary
 	      static RegistryMap *getRegistry();

--- a/PhysicsTools/MVAComputer/interface/ProcessRegistry.icc
+++ b/PhysicsTools/MVAComputer/interface/ProcessRegistry.icc
@@ -24,10 +24,10 @@ Base_t *ProcessRegistry<Base_t, CalibBase_t, Parent_t>::Factory::create(
 { return ProcessRegistry::create(name, calib, parent); }
 
 template<class Base_t, class CalibBase_t, class Parent_t>
-std::map<std::string, const ProcessRegistry<Base_t, CalibBase_t, Parent_t>*>
+tbb::concurrent_unordered_map<std::string, const ProcessRegistry<Base_t, CalibBase_t, Parent_t>*>
 	*ProcessRegistry<Base_t, CalibBase_t, Parent_t>::getRegistry()
 {
-	static struct Sentinel {
+	[[cms::thread_safe]] static struct Sentinel {
 		Sentinel() : instance(new RegistryMap) {}
 		~Sentinel() { delete instance; instance = 0; }
 
@@ -57,7 +57,7 @@ void ProcessRegistry<Base_t, CalibBase_t, Parent_t>::registerProcess(
 template<class Base_t, class CalibBase_t, class Parent_t>
 void ProcessRegistry<Base_t, CalibBase_t, Parent_t>::unregisterProcess(
 							const char *name)
-{ RegistryMap *map = getRegistry(); if (map) map->erase(name); }
+{ RegistryMap *map = getRegistry(); if (map) map->unsafe_erase(name); }
 
 } // namespace PhysicsTools
 

--- a/PhysicsTools/MVAComputer/src/AtomicId.cc
+++ b/PhysicsTools/MVAComputer/src/AtomicId.cc
@@ -23,13 +23,11 @@ namespace { // anonymous
 	    private:
 		typedef std::multiset<const char *, StringLess> IdSet;
 
-		IdSet				idSet;
-		static std::allocator<char>	stringAllocator;
-		mutable std::mutex		mutex;
+		IdSet			idSet;
+		std::allocator<char>	stringAllocator;
+                std::mutex	        mutex;
 	};
 } // anonymous namespace
-
-std::allocator<char> IdCache::stringAllocator;
 
 IdCache::~IdCache()
 {

--- a/PhysicsTools/MVAComputer/src/MVAComputer.cc
+++ b/PhysicsTools/MVAComputer/src/MVAComputer.cc
@@ -176,6 +176,7 @@ void MVAComputer::evalInternal(T &ctx) const
 		int *loopOutConf = outConf;
 		int *loopStart = 0;
 		double *loopOutput = output;
+                VarProcessor::LoopCtx loopCtx;
 
 		VarProcessor::LoopStatus status = VarProcessor::kNext;
 		unsigned int offset = 0;
@@ -192,6 +193,7 @@ void MVAComputer::evalInternal(T &ctx) const
 			if (status != VarProcessor::kSkip)
 				ctx.eval(&*iter->processor, outConf, output,
 				         loopStart ? loopStart : loopOutConf,
+                                         loopCtx,
 				         offset, iter->nOutput);
 
 #ifdef DEBUG_EVAL
@@ -210,7 +212,7 @@ void MVAComputer::evalInternal(T &ctx) const
 #endif
 
 			status = loop->processor->loop(output, outConf,
-			                               nextOutput, offset);
+			                               nextOutput, loopCtx, offset);
 
 			if (status == VarProcessor::kReset) {
 				outConf = loopOutConf;
@@ -309,10 +311,11 @@ void MVAComputer::writeCalibration(std::ostream &os,
 
 void MVAComputer::DerivContext::eval(
 		const VarProcessor *proc, int *outConf, double *output,
-		int *loop, unsigned int offset, unsigned int out) const
+		int *loop, VarProcessor::LoopCtx& ctx, 
+                unsigned int offset, unsigned int out) const
 {
 	proc->deriv(values(), conf(), output, outConf,
-	            loop, offset, n(), out, deriv_);
+	            loop, ctx, offset, n(), out, deriv_);
 }
 
 double MVAComputer::DerivContext::output(unsigned int output,

--- a/PhysicsTools/MVAComputer/src/ProcForeach.cc
+++ b/PhysicsTools/MVAComputer/src/ProcForeach.cc
@@ -104,7 +104,7 @@ void ProcForeach::eval(ValueIterator iter, unsigned int n) const
         auto& loopSize = iter.loopCtx().size();
 	while(iter) {
 		unsigned int size = iter.size();
-		if (loopSize)
+		if (!loopSize)
 			loopSize = size;
 
 		double value = iter[offset];

--- a/PhysicsTools/MVAComputer/src/ProcForeach.cc
+++ b/PhysicsTools/MVAComputer/src/ProcForeach.cc
@@ -44,6 +44,7 @@ class ProcForeach : public VarProcessor {
 				ValueIterator iter, unsigned int n) const override;
 	virtual LoopStatus loop(double *output, int *conf,
 	                        unsigned int nOutput,
+                                LoopCtx& ctx,
 	                        unsigned int &nOffset) const override;
 
     private:
@@ -55,12 +56,6 @@ class ProcForeach : public VarProcessor {
 		unsigned int origin;
 		unsigned int count;
 	};
-
-	inline void reset() const { index = offset = size = 0; }
-
-	mutable unsigned int	index;
-	mutable unsigned int	offset;
-	mutable unsigned int	size;
 
 	unsigned int		count;
 };
@@ -77,7 +72,6 @@ ProcForeach::ProcForeach(const char *name,
 
 void ProcForeach::configure(ConfIterator iter, unsigned int n)
 {
-	reset();
 	iter << Variable::FLAG_NONE;
 	while(iter)
 		iter << iter++(Variable::FLAG_MULTIPLE);
@@ -104,12 +98,14 @@ ProcForeach::configureLoop(ConfigCtx::Context *ctx_, ConfigCtx::iterator begin,
 
 void ProcForeach::eval(ValueIterator iter, unsigned int n) const
 {
+        auto const offset = iter.loopCtx().offset();
 	iter(offset);
 
+        auto& loopSize = iter.loopCtx().size();
 	while(iter) {
 		unsigned int size = iter.size();
-		if (!this->size)
-			this->size = size;
+		if (loopSize)
+			loopSize = size;
 
 		double value = iter[offset];
 		iter(value);
@@ -120,6 +116,7 @@ void ProcForeach::eval(ValueIterator iter, unsigned int n) const
 std::vector<double> ProcForeach::deriv(
 				ValueIterator iter, unsigned int n) const
 {
+        auto const offset = iter.loopCtx().offset();
 	std::vector<unsigned int> offsets;
 	unsigned int in = 0, out = 0;
 	while(iter) {
@@ -137,13 +134,16 @@ std::vector<double> ProcForeach::deriv(
 
 VarProcessor::LoopStatus
 ProcForeach::loop(double *output, int *conf,
-                  unsigned int nOutput, unsigned int &nOffset) const
+                  unsigned int nOutput, LoopCtx& ctx, unsigned int &nOffset) const
 {
+        auto& index = ctx.index();
 	bool endIteration = false;
 	if (index++ == count) {
 		index = 0;
 		endIteration = true;
 	}
+        auto& offset = ctx.offset();
+        auto& size = ctx.size();
 
 	if (offset == 0 && !endIteration) {
 		for(int cur = *conf + size; nOutput--; cur += size)
@@ -152,7 +152,6 @@ ProcForeach::loop(double *output, int *conf,
 
 	if (endIteration) {
 		if (++offset >= size) {
-			reset();
 			return kStop;
 		} else
 			return kReset;

--- a/PhysicsTools/MVAComputer/src/VarProcessor.cc
+++ b/PhysicsTools/MVAComputer/src/VarProcessor.cc
@@ -119,12 +119,13 @@ VarProcessor *ProcessRegistry<VarProcessor, Calibration::VarProcessor,
 }
 
 void VarProcessor::deriv(double *input, int *conf, double *output,
-                         int *outConf, int *loop, unsigned int offset,
+                         int *outConf, int *loop, LoopCtx& ctx,
+                         unsigned int offset,
                          unsigned int in, unsigned int out_,
                          std::vector<double> &deriv) const
 {
 	ValueIterator iter(inputVars.iter(), input, conf,
-	                   output, outConf, loop, offset);
+	                   output, outConf, loop, ctx, offset);
 
 	eval(iter, nInputVars);
 

--- a/PhysicsTools/MVAComputer/test/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/test/BuildFile.xml
@@ -17,3 +17,6 @@
    <use name="CondCore/PluginSystem"/>
    <flags EDM_PLUGIN="1"/>
 </library>
+<bin   name="testPhysicsToolsMVAComputer" file="testMVAComputer.cppunit.cc">
+  <use   name="cppunit"/>
+</bin>

--- a/PhysicsTools/MVAComputer/test/testMVAComputer.cppunit.cc
+++ b/PhysicsTools/MVAComputer/test/testMVAComputer.cppunit.cc
@@ -1,0 +1,242 @@
+// -*- C++ -*-
+//
+// Package:     PhysicsTools/MVAComputer
+// Class  :     testMVAComputer.cppunit
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Original Author:  Christopher Jones
+//         Created:  Fri, 23 Jan 2015 18:54:27 GMT
+//
+
+// system include files
+
+// user include files
+#include <cppunit/extensions/HelperMacros.h>
+
+#include "CondFormats/PhysicsToolsObjects/interface/MVAComputer.h"
+
+#include "PhysicsTools/MVAComputer/interface/MVAComputer.h"
+
+class testMVAComputer: public CppUnit::TestFixture
+{
+  CPPUNIT_TEST_SUITE(testMVAComputer);
+  
+  CPPUNIT_TEST(multTest);
+  CPPUNIT_TEST(optionalTest);
+  CPPUNIT_TEST(foreachTest);
+  
+  CPPUNIT_TEST_SUITE_END();
+  
+public:
+  void setUp() {}
+  void tearDown() {}
+  
+  void multTest();
+  void optionalTest();
+  void foreachTest();
+  
+};
+
+///registration of the test so that the runner can find it
+CPPUNIT_TEST_SUITE_REGISTRATION(testMVAComputer);
+
+using namespace PhysicsTools;
+
+void
+testMVAComputer::multTest() 
+{
+  {
+    Calibration::MVAComputer calib;
+    //this will be assigned to 'bit' 0
+    calib.inputSet = {Calibration::Variable{AtomicId("x")}};
+    //want to read out bit '1'
+    calib.output = 1;
+    
+    //
+    Calibration::ProcMultiply square;
+    //we only want to read 1 input
+    square.in = 1;
+    //we will read bit '0' and multiply it by itself
+    square.out = std::vector<Calibration::ProcMultiply::Config>{{0,0}};
+    //input to use comes from bit '0' 
+    square.inputVars.store={0b1};
+    //number of bits stored in the last char (?)
+    square.inputVars.bitsInLast = 1;
+    
+    calib.addProcessor(&square);
+    
+    MVAComputer mva(&calib,false);
+
+    {
+      std::vector<Variable::Value> input;
+      input.emplace_back("x",2);
+
+      CPPUNIT_ASSERT( 4 == mva.eval(input));
+    }
+
+    {
+      std::vector<Variable::Value> input;
+      input.emplace_back("x",3);
+
+      CPPUNIT_ASSERT( 9 == mva.eval(input));
+    }
+  }
+
+  {
+    Calibration::MVAComputer calib;
+    //this will be assigned to 'bit' 0 and 1
+    calib.inputSet = {Calibration::Variable{AtomicId("x")}, Calibration::Variable{AtomicId("y")} };
+    //want to read out bit '1'
+    calib.output = 2;
+    
+    //
+    Calibration::ProcMultiply square;
+    //we only want to read 2 input
+    square.in = 2;
+    //we will read bit '0' and multiply it by bit '1'
+    square.out = std::vector<Calibration::ProcMultiply::Config>{{0,1}};
+    //input comes from bits '0' and '1'
+    square.inputVars.store={0b11};
+    //number of bits stored in the last char (?)
+    square.inputVars.bitsInLast = 2;
+    
+    calib.addProcessor(&square);
+    
+    MVAComputer mva(&calib,false);
+    
+    std::vector<Variable::Value> input;
+    input.emplace_back("x",2);
+    input.emplace_back("y",3);
+
+    CPPUNIT_ASSERT( 6 == mva.eval(input));
+  }
+
+}
+
+void
+testMVAComputer::optionalTest() 
+{
+  {
+    Calibration::MVAComputer calib;
+    //this will be assigned to 'bit' 0
+    calib.inputSet = {Calibration::Variable{AtomicId("x")}};
+    //want to read out bit '1'
+    calib.output = 1;
+    
+    //
+    Calibration::ProcOptional optional;
+    //default
+    optional.neutralPos = {1.};
+    //input to use comes from bit '0' 
+    optional.inputVars.store={0b1};
+    //number of bits stored in the last char (?)
+    optional.inputVars.bitsInLast = 1;
+    
+    calib.addProcessor(&optional);
+    
+    MVAComputer mva(&calib,false);
+
+    {
+      std::vector<Variable::Value> input;
+      input.emplace_back("x",2);
+
+      CPPUNIT_ASSERT( 2 == mva.eval(input));
+    }
+
+    {
+      std::vector<Variable::Value> input;
+
+      CPPUNIT_ASSERT( 1 == mva.eval(input));
+    }
+
+    {
+      std::vector<Variable::Value> input;
+      input.emplace_back("y",2);
+
+      CPPUNIT_ASSERT( 1 == mva.eval(input));
+    }
+
+  }
+}
+
+void
+testMVAComputer::foreachTest() 
+{
+  {
+    Calibration::MVAComputer calib;
+    //this will be assigned to 'bit' 0
+    calib.inputSet = {Calibration::Variable{AtomicId("x")}};
+    //want to read out bit '2'
+    calib.output = 6;
+    
+    //
+    Calibration::ProcForeach foreach;
+    //we only want to read 1 input
+    foreach.nProcs = 1;
+
+    //input to use comes from bit '0' 
+    foreach.inputVars.store={0b1};
+    //number of bits stored in the last char (?)
+    foreach.inputVars.bitsInLast = 1;
+    
+    calib.addProcessor(&foreach);
+    
+
+    //
+    Calibration::ProcMultiply square;
+    //we only want to read 1 input
+    square.in = 1;
+    //we will read bit '0' and multiply it by itself
+    square.out = std::vector<Calibration::ProcMultiply::Config>{{0,0}};
+    //input comes from bits '2' 
+    square.inputVars.store={0b100};
+    //number of bits stored in the last char (?)
+    square.inputVars.bitsInLast = 3;
+    
+    calib.addProcessor(&square);
+
+    //Need to break apart the output int different elements
+    Calibration::ProcSplitter splitter;
+    splitter.nFirst = 2;
+    //input comes from bits '3' 
+    splitter.inputVars.store={0b1000};
+    //number of bits stored in the last char (?)
+    splitter.inputVars.bitsInLast = 4;
+
+    calib.addProcessor(&splitter);
+
+    //
+    Calibration::ProcMultiply join;
+    //we only want to read 2 inputs
+    join.in = 2;
+    //we will read bit '4' and '5'
+    join.out = std::vector<Calibration::ProcMultiply::Config>{{0,1}};
+    //input comes from bits '4' and '5'
+    join.inputVars.store={0b110000};
+    //number of bits stored in the last char (?)
+    join.inputVars.bitsInLast = 7;
+    calib.addProcessor(&join);
+
+    MVAComputer mva(&calib,false);
+
+    {
+      std::vector<Variable::Value> input;
+      input.emplace_back("x",2);
+      input.emplace_back("x",2);
+
+      CPPUNIT_ASSERT( 4*4 == mva.eval(input));
+    }
+
+    {
+      std::vector<Variable::Value> input;
+      input.emplace_back("x",3);
+      input.emplace_back("x",3);
+
+      CPPUNIT_ASSERT( 9*9 == mva.eval(input));
+    }
+  }
+}
+
+#include <Utilities/Testing/interface/CppUnit_testdriver.icpp>


### PR DESCRIPTION
The CMSSW_7_4_THREADED_X IBs have been crashing due to MVA threading issues. The problem stemmed from the use of mutable in ProcForeach. These mutables were being read/written indirectly by GenericMVAJetTagComputer which is an EventSetup product. The simultaneous writes were causing the crashes.
The solution was to move the mutables to be external to the MVA class and instead be passed in as an argument to the functions. Encapsolating the loop state into variables that live on the stack allows each thread to have its own copy.
