### PR TITLE
Do not call edm::RefVector<>::product in Associators

### DIFF
--- a/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHitsHelper.cc
@@ -89,7 +89,10 @@ MuonAssociatorByHitsHelper::associateRecoToSimIndices(const TrackHitsCollection 
   bool printRtS(true);
 
   TrackingParticleCollection tPC;
-  if (TPCollectionH.size()!=0) tPC = *(TPCollectionH.product());
+  tPC.reserve(TPCollectionH.size());
+  for(auto const& ref: TPCollectionH) {
+    tPC.push_back(*ref);
+  }
 
   if(resources.diagnostics_) {
     resources.diagnostics_(tC,tPC);
@@ -362,7 +365,10 @@ MuonAssociatorByHitsHelper::associateSimToRecoIndices( const TrackHitsCollection
   bool printRtS(true);
 
   TrackingParticleCollection tPC;
-  if (TPCollectionH.size()!=0) tPC = *(TPCollectionH.product());
+  tPC.reserve(TPCollectionH.size());
+  for(auto const& ref: TPCollectionH) {
+    tPC.push_back(*ref);
+  }
 
   bool any_trackingParticle_matched = false;
   

--- a/SimTracker/TrackAssociation/src/TrackAssociatorByChi2.cc
+++ b/SimTracker/TrackAssociation/src/TrackAssociatorByChi2.cc
@@ -129,7 +129,10 @@ RecoToSimCollection TrackAssociatorByChi2::associateRecoToSim(const edm::RefToBa
   RecoToSimCollection  outputCollection;
 
   TrackingParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tindex=0;
   for (RefToBaseVector<reco::Track>::const_iterator rt=tC.begin(); rt!=tC.end(); rt++, tindex++){
@@ -186,7 +189,10 @@ SimToRecoCollection TrackAssociatorByChi2::associateSimToReco(const edm::RefToBa
   SimToRecoCollection  outputCollection;
 
   TrackingParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tpindex =0;
   for (TrackingParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){

--- a/SimTracker/TrackAssociation/src/TrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/TrackAssociatorByHits.cc
@@ -84,8 +84,11 @@ TrackAssociatorByHits::associateRecoToSim(const edm::RefToBaseVector<reco::Track
   
   TrackerHitAssociator * associate = new TrackerHitAssociator(*e, conf_);
   
-  const TrackingParticleCollection emptyCollection;
-  const TrackingParticleCollection& tPC = ( TPCollectionH.size() != 0 ? *(TPCollectionH.product()) : emptyCollection); 
+  TrackingParticleCollection tPC;
+  tPC.reserve(TPCollectionH.size());
+  for(auto const& ref: TPCollectionH) {
+    tPC.push_back(*ref);
+  }
 
   //get the ID of the recotrack  by hits 
   int tindex=0;
@@ -165,8 +168,11 @@ TrackAssociatorByHits::associateSimToReco(const edm::RefToBaseVector<reco::Track
 
   TrackerHitAssociator * associate = new TrackerHitAssociator(*e, conf_);
   
-  const TrackingParticleCollection emptyCollection;
-  const TrackingParticleCollection& tPC = ( TPCollectionH.size() != 0 ? *(TPCollectionH.product()) : emptyCollection); 
+  TrackingParticleCollection tPC;
+  tPC.reserve(TPCollectionH.size());
+  for(auto const& ref: TPCollectionH) {
+    tPC.push_back(*ref);
+  }
 
   //for (TrackingParticleCollection::const_iterator t = tPC.begin(); t != tPC.end(); ++t) {
   //  LogTrace("TrackAssociator") << "NEW TP DUMP";

--- a/SimTracker/TrackAssociation/src/TrackGenAssociatorByChi2.cc
+++ b/SimTracker/TrackAssociation/src/TrackGenAssociatorByChi2.cc
@@ -29,7 +29,10 @@ RecoToGenCollection TrackGenAssociatorByChi2::associateRecoToGen(const edm::RefT
   RecoToGenCollection  outputCollection;
 
   GenParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tindex=0;
   for (RefToBaseVector<reco::Track>::const_iterator rt=tC.begin(); rt!=tC.end(); rt++, tindex++){
@@ -87,7 +90,10 @@ GenToRecoCollection TrackGenAssociatorByChi2::associateGenToReco(const edm::RefT
   GenToRecoCollection  outputCollection;
 
   GenParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tpindex =0;
   for (GenParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByChi2Impl.cc
@@ -126,7 +126,10 @@ RecoToSimCollection TrackAssociatorByChi2Impl::associateRecoToSim(const edm::Ref
   RecoToSimCollection  outputCollection;
 
   TrackingParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tindex=0;
   for (RefToBaseVector<reco::Track>::const_iterator rt=tC.begin(); rt!=tC.end(); rt++, tindex++){
@@ -179,7 +182,10 @@ SimToRecoCollection TrackAssociatorByChi2Impl::associateSimToReco(const edm::Ref
   SimToRecoCollection  outputCollection;
 
   TrackingParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tpindex =0;
   for (TrackingParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.cc
@@ -98,8 +98,11 @@ TrackAssociatorByHitsImpl::associateRecoToSim(const edm::RefToBaseVector<reco::T
   std::vector< SimHitIdpr> matchedIds; 
   RecoToSimCollection  outputCollection;
   
-  const TrackingParticleCollection emptyCollection;
-  const TrackingParticleCollection& tPC = ( TPCollectionH.size() != 0 ? *(TPCollectionH.product()) : emptyCollection); 
+  TrackingParticleCollection tPC;
+  tPC.reserve(tPC.size());
+  for(auto const& ref: TPCollectionH) {
+    tPC.push_back(*ref);
+  }
 
   //get the ID of the recotrack  by hits 
   int tindex=0;
@@ -174,8 +177,11 @@ TrackAssociatorByHitsImpl::associateSimToReco(const edm::RefToBaseVector<reco::T
   std::vector< SimHitIdpr> matchedIds; 
   SimToRecoCollection  outputCollection;
 
-  const TrackingParticleCollection emptyCollection;
-  const TrackingParticleCollection& tPC = ( TPCollectionH.size() != 0 ? *(TPCollectionH.product()) : emptyCollection); 
+  TrackingParticleCollection tPC;
+  tPC.reserve(tPC.size());
+  for(auto const& ref: TPCollectionH) {
+    tPC.push_back(*ref);
+  }
 
   //for (TrackingParticleCollection::const_iterator t = tPC.begin(); t != tPC.end(); ++t) {
   //  LogTrace("TrackAssociator") << "NEW TP DUMP";

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackGenAssociatorByChi2Impl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackGenAssociatorByChi2Impl.cc
@@ -25,7 +25,10 @@ RecoToGenCollection TrackGenAssociatorByChi2Impl::associateRecoToGen(const edm::
   RecoToGenCollection  outputCollection;
 
   GenParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tindex=0;
   for (RefToBaseVector<reco::Track>::const_iterator rt=tC.begin(); rt!=tC.end(); rt++, tindex++){
@@ -78,7 +81,10 @@ GenToRecoCollection TrackGenAssociatorByChi2Impl::associateGenToReco(const edm::
   GenToRecoCollection  outputCollection;
 
   GenParticleCollection tPC;
-  if (tPCH.size()!=0)  tPC = *tPCH.product();
+  tPC.reserve(tPCH.size());
+  for(auto const& ref: tPCH) {
+    tPC.push_back(*ref);
+  }
 
   int tpindex =0;
   for (GenParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){


### PR DESCRIPTION
The call to edm::RefVector<>::product is being deprecated. Instead
of getting the full container, we now loop over the RefVector and
fill a new container. This (argueably) better matches the API of
the function call anyway.
This may lead to differences is results because we might be looping
over a restricted set of entries. If this is a problem then the calling
module should pass in the full container and not a RefVector.
