### PR TITLE
New Global Tags for Release Validation in all the supported scenarios.

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V2::All',
+    'run1_design'       :   'DESRUN1_74_V0::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V2::All',
+    'run1_mc'           :   'MCRUN1_74_V0::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V2::All',
+    'run1_mc_hi'        :   'MCHI1_74_V0::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V2::All',
+    'run1_mc_pa'        :   'MCPA1_74_V0::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V4::All',
+    'run2_design'       :   'DESRUN2_74_V0::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V8::All',
+    'run2_mc_50ns'      :   'MCRUN2_74_V0::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V9::All',
+    'run2_mc'           :   'MCRUN2_74_V1::All',
+    # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
+    'run2_mc_hi'        :   'MCHI2_74_V0::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_73_V0A::All',
+    'run1_data'         :   'GR_R_74_V0A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_73_V1A::All',
+    'run2_data'         :   'GR_R_74_V1A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V43A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V47A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V44A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V48A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,27 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V2',
+    'run1_design'       :   'DESRUN1_74_V0',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V2',
+    'run1_mc'           :   'MCRUN1_74_V0',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V2',
+    'run1_mc_hi'        :   'MCHI1_74_V0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V2',
+    'run1_mc_pa'        :   'MCPA1_74_V0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V4',
+    'run2_design'       :   'DESRUN2_74_V0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V8',
+    'run2_mc_50ns'      :   'MCRUN2_74_V0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V9',
+    'run2_mc'           :   'MCRUN2_74_V1',
+    # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
+    'run2_mc_hi'        :   'MCHI2_74_V0',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_73_V0A',
+    'run1_data'         :   'GR_R_74_V0A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_73_V1A',
+    'run2_data'         :   'GR_R_74_V1A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V43A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V47A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V44A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V48A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
The new key `run2_mc_hi` for validation of HI simulation in Run2 is added.
The new Global Tags contain new Records for Magnetic Field geometry and configuration, for extended Muon APE, and (in Run2 only) fixes the Ideal simulation geometry and adds new development scenarios.
