### PR TITLE
Remove unused variables from test module

### DIFF
--- a/SimTracker/TrackAssociation/test/testTrackAssociator.cc
+++ b/SimTracker/TrackAssociation/test/testTrackAssociator.cc
@@ -53,11 +53,9 @@ void testTrackAssociator::analyze(const edm::Event& event, const edm::EventSetup
   
   Handle<SimVertexContainer> simVertexCollection;
   event.getByLabel(simvtxTag, simVertexCollection);
-  const SimVertexContainer& simVC = *(simVertexCollection.product());
 
   edm::Handle<TrackingParticleCollection>  TPCollectionH ;
   event.getByLabel(tpTag,TPCollectionH);
-  const TrackingParticleCollection& tPC   = *(TPCollectionH.product());
 
   cout << "\nEvent ID = "<< event.id() << endl ;
 


### PR DESCRIPTION
The unused variables were causing the gcc 4.8.1 build to fail.
