### PR TITLE
bug fix phi meson in heavy flavor HLT offline DQM

### DIFF
--- a/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidation_cfi.py
+++ b/HLTriggerOffline/HeavyFlavor/python/heavyFlavorValidation_cfi.py
@@ -9,8 +9,8 @@ heavyFlavorValidation = cms.EDAnalyzer("HeavyFlavorValidation",
     TriggerResults = cms.untracked.string("TriggerResults"),
     RecoMuons = cms.InputTag("muons"),
     GenParticles = cms.InputTag("genParticles"),
-# list IDs of muon mothers, -1:don't check, 0:particle gun, 23:Z, 443:J/psi, 553:Upsilon, 531:Bs
-    MotherIDs = cms.untracked.vint32(23,443,553,531,0),
+# list IDs of muon mothers, -1:don't check, 0:particle gun, 23:Z, 443:J/psi, 553:Upsilon, 531:Bs, 333:Phi
+    MotherIDs = cms.untracked.vint32(23,443,553,531,333,0),
     GenGlobDeltaRMatchingCut = cms.untracked.double(0.1),
     GlobL1DeltaRMatchingCut = cms.untracked.double(0.3),
     GlobL2DeltaRMatchingCut = cms.untracked.double(0.3),


### PR DESCRIPTION
added phi meson pdgId, needed for DQM validation of HLT_Dimuon0_Phi_Barrel_v1 and HLT_Mu16_TkMu0_dEta18_Phi_v1:
https://its.cern.ch/jira/browse/CMSHLT-211
