### PR TITLE
Remove obsolete unused typedefs

### DIFF
--- a/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
+++ b/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
@@ -38,8 +38,6 @@ public:
   template<typename T>
   bool
   getByLabel(edm::InputTag const& tag, edm::Handle<T>& result) const {
-    typedef typename T::value_type ItemType;
-    typedef typename T::iterator iterator;
     edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr, mcc_);
     convert_handle(std::move(bh), result);
     return result.isValid();


### PR DESCRIPTION
Two function-scoped typedefs that are no longer used are removed by this trivial pull request.  They were inadvertently left behind when the code using them was removed more than a year ago.
The typedefs are actually harmful, because if PileUpEventPrincipal::getByLabel() is called for a type that is not a collection (e.g. HepMCProduct), the call will not compile, as the typdefs are not defined.
