### PR TITLE
put back RealisticHI2011Collision

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -26,6 +26,7 @@ VtxSmeared = {
     'Realistic2p76TeV2011Collision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic2p76TeV2011Collision_cfi',
     'Realistic2p76TeV2013Collision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic2p76TeV2013Collision_cfi',
     'Centered7TeV2011Collision':     'IOMC.EventVertexGenerators.VtxSmearedCentered7TeV2011Collision_cfi',
+    'RealisticHI2011Collision':      'IOMC.EventVertexGenerators.VtxSmearedRealisticHI2011Collision_cfi',
     'Realistic5TeVPPbBoost':         'GeneratorInterface.HiGenCommon.VtxSmearedRealistic5TeVPPbBoost_cff',
     'Realistic5TeVPPbBoostReversed': 'GeneratorInterface.HiGenCommon.VtxSmearedRealistic5TeVPPbBoostReversed_cff',
     'MatchHI':                       'GeneratorInterface.HiGenCommon.VtxSmearedMatchHI_cff',


### PR DESCRIPTION
- as the command says, restore consistency internally to VtxSmeared.py
- RealisticHI2011Collision is the beamspot for run2, as per HIN convenor @inugent
- agreed with @yetkinyilmaz that RealisticHI2011Collision needs to be put back, see #6982 
