### PR TITLE
updated HBHENegativeFlag class to access a1 and a2 functions directly

### DIFF
--- a/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
@@ -87,6 +87,21 @@ public:
         }
     }
 
+    inline const OOTPileupCorrDataFcn& getCorrectionByID(const HcalDetId& id) const
+    {
+        const unsigned nLimits = iEtaLimits_.size();
+        unsigned which(0U);
+        if (nLimits)
+        {
+	    const uint32_t uEta = std::abs(id.ieta());
+	    const uint32_t* limits(&iEtaLimits_[0]);
+	    for (; which<nLimits; ++which)
+	        if (uEta < limits[which])
+	            break;
+        }
+        return corrs_.at(which);
+    }
+
 protected:
     // Comparison function must be implemented
     inline bool isEqual(const AbsOOTPileupCorrection& otherBase) const

--- a/CondFormats/HcalObjects/interface/OOTPileupCorrDataFcn.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrDataFcn.h
@@ -35,6 +35,12 @@ public:
         ts[tsTrig+1] = a1_(ts[tsTrig]);
     }
 
+    // Access the correction functions
+    inline const PiecewiseScalingPolynomial& getA1() const {return a1_;}
+    inline const PiecewiseScalingPolynomial& getA2() const {return a2_;}
+    inline const PiecewiseScalingPolynomial& getA3() const {return a3_;}
+    inline const ScalingExponential& getA_1() const {return a_1_;}
+
 private:
     PiecewiseScalingPolynomial a1_, a2_, a3_;
     ScalingExponential a_1_;


### PR DESCRIPTION
Made correction functions a1, a2, etc. accessible outside of OOTPileupCorrData.

Updated HBHENegativeFlag class so that it can be used together with current implementations of HCAL Method 1/Method 2.
