### PR TITLE
New conditions objects for HI jet reconstruction

### DIFF
--- a/CondCore/HIPlugins/src/plugin.cc
+++ b/CondCore/HIPlugins/src/plugin.cc
@@ -1,8 +1,11 @@
 #include "CondCore/PluginSystem/interface/registration_macros.h"
 #include "CondFormats/DataRecord/interface/HeavyIonRcd.h"
 #include "CondFormats/DataRecord/interface/HeavyIonRPRcd.h"
+#include "CondFormats/DataRecord/interface/HeavyIonUERcd.h"
 #include "CondFormats/HIObjects/interface/CentralityTable.h"
+#include "CondFormats/HIObjects/interface/UETable.h"
 #include "CondFormats/HIObjects/interface/RPFlatParams.h"
 
 REGISTER_PLUGIN(HeavyIonRPRcd,RPFlatParams);
 REGISTER_PLUGIN(HeavyIonRcd,CentralityTable);
+REGISTER_PLUGIN(HeavyIonUERcd,UETable);

--- a/CondFormats/DataRecord/interface/HeavyIonUERcd.h
+++ b/CondFormats/DataRecord/interface/HeavyIonUERcd.h
@@ -1,0 +1,8 @@
+#ifndef DataRecord_HeavyIonUERcd_h
+#define DataRecord_HeavyIonUERcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HeavyIonUERcd : public edm::eventsetup::EventSetupRecordImplementation<HeavyIonUERcd> {};
+
+#endif

--- a/CondFormats/DataRecord/src/HeavyIonUERcd.cc
+++ b/CondFormats/DataRecord/src/HeavyIonUERcd.cc
@@ -1,0 +1,5 @@
+
+#include "CondFormats/DataRecord/interface/HeavyIonUERcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HeavyIonUERcd);

--- a/CondFormats/HIObjects/interface/UETable.h
+++ b/CondFormats/HIObjects/interface/UETable.h
@@ -7,9 +7,27 @@
 class UETable{
  public:
   UETable(){};
-  float get(int i){return values[i];}
-  void push(float v){values.push_back(v);}
+  float getUE(int i){return values[i];}
+  unsigned int getNp(int i){return np[i];}
+  unsigned int getNi0(int i){return ni0[i];}
+  unsigned int getNi1(int i){return ni1[i];}
+  unsigned int getNi2(int i){return ni2[i];}
+  float getEtaEdge(int i){return edgeEta[i];}
+
+
+  void pushUE(float v){values.push_back(v);}
+  void pushNp(unsigned int v){np.push_back(v);}
+  void pushNi0(unsigned int v){ni0.push_back(v);}
+  void pushNi1(unsigned int v){ni1.push_back(v);}
+  void pushNi2(unsigned int v){ni2.push_back(v);}
+  void pushEtaEdge(float v){edgeEta.push_back(v);}
+
   std::vector<float> values;
+  std::vector<unsigned int> np;
+  std::vector<unsigned int> ni0;
+  std::vector<unsigned int> ni1;
+  std::vector<unsigned int> ni2;
+  std::vector<float> edgeEta;
 
   COND_SERIALIZABLE;
 };

--- a/CondFormats/HIObjects/interface/UETable.h
+++ b/CondFormats/HIObjects/interface/UETable.h
@@ -1,0 +1,17 @@
+#ifndef __UETable_h__
+#define __UETable_h__
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include <vector>
+
+class UETable{
+ public:
+  UETable(){};
+  float get(int i){return values[i];}
+  void push(float v){values.push_back(v);}
+  std::vector<float> values;
+
+  COND_SERIALIZABLE;
+};
+
+#endif

--- a/CondFormats/HIObjects/src/T_EventSetup_CentralityCuts.cc
+++ b/CondFormats/HIObjects/src/T_EventSetup_CentralityCuts.cc
@@ -1,9 +1,11 @@
 #include "CondFormats/HIObjects/interface/CentralityTable.h" 
 #include "CondFormats/HIObjects/interface/RPFlatParams.h"
+#include "CondFormats/HIObjects/interface/UETable.h"
 
 #include "FWCore/Utilities/interface/typelookup.h"
 
 TYPELOOKUP_DATA_REG(CentralityTable);
 TYPELOOKUP_DATA_REG(RPFlatParams);
+TYPELOOKUP_DATA_REG(UETable);
 
 

--- a/CondFormats/HIObjects/src/classes.h
+++ b/CondFormats/HIObjects/src/classes.h
@@ -4,6 +4,7 @@ namespace CondFormats_HIObjects {
   struct dictionary{
     std::vector<CentralityTable::CBin> dummy;
     std::vector<RPFlatParams::EP> yummy;
+    UETable pred;
   };
 }
 

--- a/CondFormats/HIObjects/src/classes_def.xml
+++ b/CondFormats/HIObjects/src/classes_def.xml
@@ -8,5 +8,6 @@
    </class>
    <class name="RPFlatParams::EP"/>
    <class name="std::vector<RPFlatParams::EP>"/>
+   <class name="UETable"/>
 </lcgdict>
 

--- a/CondFormats/HIObjects/src/headers.h
+++ b/CondFormats/HIObjects/src/headers.h
@@ -1,4 +1,5 @@
 #include "CondFormats/HIObjects/interface/CentralityTable.h"
 #include "CondFormats/HIObjects/interface/RPFlatParams.h"
+#include "CondFormats/HIObjects/interface/UETable.h"
 
 #include <vector>


### PR DESCRIPTION
New conditions object for UE subtraction in voronoi-based HI jet reconstruction (currently txt files are being used).
@yslai is the main author and the responsible contact.
Discussed with @diguida and reported to @mmusich @rcastello 

The plan for updating reconstruction accordingly is:
- Review this pull-request and update in case of feedback
- Merge this PR into 7_4_0_pre6
- Upload the payloads into DB, produce globaltags for data and MC
- Make pull-request of the reconstruction part, aiming to merge into 7_4_0_pre7 
