### PR TITLE
Fix handling of weights in generator interfaces

### DIFF
--- a/GeneratorInterface/Core/interface/HadronizerFilter.h
+++ b/GeneratorInterface/Core/interface/HadronizerFilter.h
@@ -263,12 +263,10 @@ namespace edm
       double multihadweight = double(naccept)/double(nAttempts_);
       
       //adjust weight for GenEventInfoProduct
-      std::vector<double> genEventInfoWeights = finalGenEventInfo->weights();
-      genEventInfoWeights.push_back(multihadweight);
-      finalGenEventInfo->setWeights(genEventInfoWeights);
+      finalGenEventInfo->weights()[0] *= multihadweight;
       
       //adjust weight for HepMC GenEvent (used e.g for RIVET)
-      finalEvent->weights().push_back(multihadweight);
+      finalEvent->weights()[0] *= multihadweight;
     }
     
     

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -517,7 +517,11 @@ bool Pythia8Hadronizer::hadronize()
 
   bool py8next = fMasterGen->next();
 
-  double mergeweight = fMasterGen.get()->info.mergingWeight();
+  double mergeweight = fMasterGen.get()->info.mergingWeightNLO();
+  if (fMergingHook) {
+    mergeweight *= fMergingHook->getNormFactor();
+  }
+  
   
   //protect against 0-weight from ckkw or similar
   if (!py8next || std::abs(mergeweight)==0.)
@@ -549,7 +553,7 @@ bool Pythia8Hadronizer::hadronize()
     return false;
   }
   
-  //add ckkw merging weight
+  //add ckkw/umeps/unlops merging weight
   if (mergeweight!=1.) {
     event()->weights()[0] *= mergeweight;
   }

--- a/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
+++ b/GeneratorInterface/Pythia8Interface/plugins/Pythia8Hadronizer.cc
@@ -551,7 +551,7 @@ bool Pythia8Hadronizer::hadronize()
   
   //add ckkw merging weight
   if (mergeweight!=1.) {
-    event()->weights().push_back(mergeweight);
+    event()->weights()[0] *= mergeweight;
   }
   
   if (fEmissionVetoHook) {

--- a/SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h
@@ -25,8 +25,12 @@ class GenEventInfoProduct {
 
 	// getters
 
+	std::vector<double> &weights() { return weights_; }
 	const std::vector<double> &weights() const { return weights_; }
-	double weight() const;
+	
+	double weight() const { return weights_.empty() ? 1.0 : weights_[0]; }
+	
+	double weightProduct() const;
 
 	unsigned int signalProcessID() const { return signalProcessID_; }
 

--- a/SimDataFormats/GeneratorProducts/src/GenEventInfoProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/GenEventInfoProduct.cc
@@ -74,7 +74,7 @@ GenEventInfoProduct &GenEventInfoProduct::operator = (GenEventInfoProduct const 
 	return *this;
 }
 
-double GenEventInfoProduct::weight() const
+double GenEventInfoProduct::weightProduct() const
 {
 	return std::accumulate(weights_.begin(), weights_.end(),
 	                       1., std::multiplies<double>());


### PR DESCRIPTION
Fix handling of weights to conform to HepMC specification.  Also fix event weights for UMEPS/UNLOPS merging.
