### PR TITLE
fill lhe weights manually for herwig++

### DIFF
--- a/GeneratorInterface/ThePEGInterface/plugins/ThePEGHadronizer.cc
+++ b/GeneratorInterface/ThePEGInterface/plugins/ThePEGHadronizer.cc
@@ -176,6 +176,9 @@ bool ThePEGHadronizer::hadronize()
                 lheEvent()->count( lhef::LHERunInfo::kSelected, 1.0, mergeweight );
 		return false;
 	}
+	
+	//Fill LHE weight (since it's not otherwise propagated)
+	event()->weights()[0] *= lheEvent()->getHEPEUP()->XWGTUP;
 
 	HepMC::PdfInfo pdf;
 	clearAuxiliary(event().get(), &pdf);

--- a/GeneratorInterface/ThePEGInterface/plugins/ThePEGLesHouchesInterface.cc
+++ b/GeneratorInterface/ThePEGInterface/plugins/ThePEGLesHouchesInterface.cc
@@ -160,10 +160,14 @@ bool LesHouchesInterface::doReadEvent()
 
 	hepeup.NUP	= orig.NUP;
 	hepeup.IDPRUP	= orig.IDPRUP;
-	hepeup.XWGTUP	= orig.XWGTUP;
 	hepeup.SCALUP	= orig.SCALUP;
 	hepeup.AQEDUP	= orig.AQEDUP;
 	hepeup.AQCDUP	= orig.AQCDUP;
+        
+        //workaround, since Herwig++ is not passing LHE weights to the hepmc product anyways
+        //as currently run in CMSSW
+        hepeup.XWGTUP   = 1.0;
+        
 	hepeup.resize();
 
 	std::copy(orig.IDUP.begin(), orig.IDUP.end(), hepeup.IDUP.begin());


### PR DESCRIPTION
To work around existing interface and/or herwig++ limitations.
