### PR TITLE
Fixed thread problems in DQMOffline/Trigger

### DIFF
--- a/DQMOffline/Trigger/interface/EgHLTEgCutCodes.h
+++ b/DQMOffline/Trigger/interface/EgHLTEgCutCodes.h
@@ -57,7 +57,7 @@ namespace egHLT {
     };
 
   private:
-    static ComCodes codes_;
+    static const ComCodes codes_;
     
   private:
     EgCutCodes(){} //not going to allow instainitiation

--- a/DQMOffline/Trigger/interface/EgHLTOfflineSource.h
+++ b/DQMOffline/Trigger/interface/EgHLTOfflineSource.h
@@ -54,7 +54,7 @@ namespace egHLT {
 
 // }
 
-class EgHLTOfflineSource : public DQMEDAnalyzer {
+class EgHLTOfflineSource : public thread_unsafe::DQMEDAnalyzer {
  
  private:
   MonitorElement* dqmErrsMonElem_; //monitors DQM errors (ie failing to get trigger info, etc)

--- a/DQMOffline/Trigger/src/EgHLTEgCutCodes.cc
+++ b/DQMOffline/Trigger/src/EgHLTEgCutCodes.cc
@@ -2,7 +2,7 @@
 
 using namespace egHLT;
 
-ComCodes EgCutCodes::codes_(EgCutCodes::setCodes_());
+const ComCodes EgCutCodes::codes_(EgCutCodes::setCodes_());
 
 //horribly inefficient I know but its done once
 ComCodes EgCutCodes::setCodes_()


### PR DESCRIPTION
The module EgHLTOfflineSource accesses two statics. One was made const but the second had to be set at run time. Therefore EgHLTOfflineSource had to be switched to a thread_unsafe::DQMEDAnalyzer. 

My suggestion is the second static, egHLT::TrigCodes::trigBitSetMap_, should become attached to a member variable of EgHLTOfflineSource and then passed as an argument to the various helper classes.
