### PR TITLE
Fix bug chosing closest simHit

### DIFF
--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -352,7 +352,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 
 		  if ( dist < closest ) 
 		    {
-		      closest = x_res;
+		      closest = dist;
 		      closestit = m;
 		    }
 		} // end sim hit loop


### PR DESCRIPTION
This fixes a bug in SiPixelRecHitsValid noticed by Danek.  It's in the logic that chooses the best simHit among those that match a recHit.  It is relevant for only about 10% of recHits.  The effect is undetectable in the matching residual plots with 500 3-TeV-jet events (no PU).  I made a test filling the histograms only for the recHits with multiple simHits, and find that fixing the bug makes some improvement in some of the residual plots.
![screen shot 2015-01-25 at 11 22 11 pm](https://cloud.githubusercontent.com/assets/4702771/5895919/1dc8cb7a-a4e9-11e4-91ca-0e0d2aacfcc7.png)
.
