### PR TITLE
Change static 'debug' to constexpr

### DIFF
--- a/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
+++ b/FastSimulation/CaloHitMakers/src/EcalHitMaker.cc
@@ -1359,7 +1359,7 @@ EcalHitMaker::gapsLifting(std::vector<neighbour>& gaps,unsigned iq)
   //  std::cout << " Entering gapsLifting "  << std::endl;
   CrystalPad & myPad = padsatdepth_[iq];
   unsigned ngaps=gaps.size();
-  static bool debug=false;
+  constexpr bool debug=false;
   if(ngaps==1)
     {
       if(debug)


### PR DESCRIPTION
The static analyzer was complaining about the non-const static 'debug'.
Given the value is set once and never changes, it was changed to be a
constexpr.
