### PR TITLE
Fix RPC Validation Tests

### DIFF
--- a/Geometry/RPCGeometry/test/testRPCGeometryFromDB_cfg.py
+++ b/Geometry/RPCGeometry/test/testRPCGeometryFromDB_cfg.py
@@ -2,9 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Demo")
 
-process.load('Configuration/StandardSequences/GeometryDB_cff')
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
 from Configuration.AlCa.autoCond import autoCond
 process.GlobalTag.globaltag = autoCond['mc']

--- a/Geometry/RPCGeometry/test/testRPCGeometryFromLocalDB_cfg.py
+++ b/Geometry/RPCGeometry/test/testRPCGeometryFromLocalDB_cfg.py
@@ -2,11 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Demo")
 
-process.load('Configuration/StandardSequences/GeometryDB_cff')
-process.load("CondCore.DBCommon.CondDBSetup_cfi")
-process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
 
-process.GlobalTag.globaltag = 'MC_31X_V8::All'
+process.GlobalTag.globaltag = 'POSTLS172_V6::All'
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)

--- a/Geometry/RPCGeometry/test/testRPCGeometry_cfg.py
+++ b/Geometry/RPCGeometry/test/testRPCGeometry_cfg.py
@@ -1,14 +1,10 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("Demo")
-process.load('Configuration.Geometry.GeometryExtended2023HGCalMuon_cff')
-process.load('Configuration.Geometry.GeometryExtended2023HGCalMuonReco_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.Geometry.GeometryExtended_cff')
+process.load('Configuration.Geometry.GeometryExtendedReco_cff')
 
 process.load('FWCore.MessageLogger.MessageLogger_cfi')
-
-from Configuration.AlCa.GlobalTag import GlobalTag
-process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgrade2019', '')
 
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)


### PR DESCRIPTION
- Configuration files should never be changed for a specific (or non-existing) scenario. They are run by a validation script which substitutes a "default" scenario and a "default" GT to a specific one taken from a command line.
