### PR TITLE
HeavyIons: switch photon tracking isolation collection to hiGeneralTracks

### DIFF
--- a/RecoHI/HiEgammaAlgos/python/HiIsolationCommonParameters_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiIsolationCommonParameters_cff.py
@@ -6,7 +6,6 @@ isolationInputParameters = cms.PSet(
    horeco = cms.InputTag("horeco"),
    hfreco = cms.InputTag("hfreco"),
    hbhereco = cms.InputTag("hbhereco"),
-   track = cms.InputTag("hiGoodTracks"),
+   track = cms.InputTag("hiGeneralTracks"),
    photons = cms.InputTag("cleanPhotons")
    )
-


### PR DESCRIPTION
With the 73X reconstruction improvements to HI, photon tracker isolation should be computed using the new tracking collection.

The previous tracking collection (hiGoodTracks) does not even exist anymore, so tracking isolation DQM histograms were just empty and we were re-running the isolation calculation at analysis level.
