### PR TITLE
Use thread safe container for EventSetup type lookup

### DIFF
--- a/FWCore/Utilities/src/typelookup.cc
+++ b/FWCore/Utilities/src/typelookup.cc
@@ -12,7 +12,7 @@
 
 // system include files
 #include <cstring>
-#include <map>
+#include "tbb/concurrent_unordered_map.h"
 
 // user include files
 #include "FWCore/Utilities/interface/typelookup.h"
@@ -27,16 +27,41 @@
 //
 //This class hides the use of map from all classes that use HCTypeTag
 namespace {
-   struct StringCompare {
-      bool operator()(const char* iLHS, const char* iRHS) const {
-         return (std::strcmp(iLHS, iRHS) < 0);
-      }
+  struct StringEqual {
+      bool operator()(const char* iLHS, const char* iRHS)   const {
+         return (std::strcmp(iLHS, iRHS) == 0);
+       }
+
    };
    
+   //NOTE: The following hash calculation was taken from
+   // the hash calculation for std::string in tbb
+
+   //! A template to select either 32-bit or 64-bit constant as compile time, depending on machine word size.
+   template <unsigned u, unsigned long long ull >
+   struct select_size_t_constant {
+      //Explicit cast is needed to avoid compiler warnings about possible truncation.
+      //The value of the right size,   which is selected by ?:, is anyway not truncated or promoted.
+      static constexpr size_t value = (size_t)((sizeof(size_t)==sizeof(u)) ? u : ull);
+   };
+   
+   constexpr size_t hash_multiplier = select_size_t_constant<2654435769U, 11400714819323198485ULL>::value;
+
+   struct StringHash {
+      inline size_t operator()( const char* s) const {
+         size_t h = 0;
+         for( const char* c = s; *c; ++c )
+            h = static_cast<size_t>(*c) ^ (h * hash_multiplier);
+         return h;
+      }
+   };
+
    //NOTE: the use of const char* does not lead to a memory leak because the data
    // for the strings are assigned at compile time via a macro call
-   static std::map< const char*, const std::type_info*, StringCompare>& typeNameToValueMap() {
-      static std::map<const char*, const std::type_info*,StringCompare> s_map;
+   using TypeNameToValueMap = tbb::concurrent_unordered_map<const char*, const std::type_info*, StringHash, StringEqual>;
+
+   static TypeNameToValueMap& typeNameToValueMap() {
+      static TypeNameToValueMap s_map;
       return s_map;
    }
 }
@@ -50,7 +75,7 @@ edm::typelookup::NameRegistrar::NameRegistrar(const char* iTypeName,const std::t
 std::pair<const char*, const std::type_info*> 
 edm::typelookup::findType(const char* iTypeName) {
 
-   std::map<const char*, const std::type_info*,StringCompare>::iterator itFind = typeNameToValueMap().find(iTypeName);
+   auto itFind = typeNameToValueMap().find(iTypeName);
    
    if(itFind == typeNameToValueMap().end()) {
       return std::make_pair(static_cast<const char*>(0), static_cast<std::type_info*> (0));


### PR DESCRIPTION
The static analyzer discovered that the type lookup function was being called at event loop time. If a shared library was loaded during the event loop it could lead to a data race. Switching to a tbb thread safe container avoids the race condition.
