### PR TITLE
Removed the need for const_cast in SiStripObjects

### DIFF
--- a/CalibFormats/SiStripObjects/interface/SiStripCcu.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripCcu.h
@@ -20,9 +20,10 @@ class SiStripCcu {
   
   /** */
   ~SiStripCcu() {;}
-  
-  /** */
+ 
+   /** */
   inline const std::vector<SiStripModule>& modules() const;
+  inline std::vector<SiStripModule>& modules();
 
   /** */
   inline const uint16_t& ccuAddr() const;
@@ -46,6 +47,7 @@ class SiStripCcu {
 // ---------- inline methods ----------
 
 const std::vector<SiStripModule>& SiStripCcu::modules() const { return modules_; }
+std::vector<SiStripModule>& SiStripCcu::modules() { return modules_; }
 const uint16_t& SiStripCcu::ccuAddr() const { return ccuAddr_; }
 
 #endif // CalibTracker_SiStripObjects_SiStripCcu_H

--- a/CalibFormats/SiStripObjects/interface/SiStripFec.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripFec.h
@@ -23,6 +23,7 @@ class SiStripFec {
   
   /** */
   inline const std::vector<SiStripRing>& rings() const;
+  inline std::vector<SiStripRing>& rings();
 
   /** */
   inline const uint16_t& fecSlot() const;
@@ -46,6 +47,7 @@ class SiStripFec {
 // ---------- inline methods ----------
 
 const std::vector<SiStripRing>& SiStripFec::rings() const { return rings_; }
+std::vector<SiStripRing>& SiStripFec::rings() { return rings_; }
 const uint16_t& SiStripFec::fecSlot() const { return fecSlot_; }
 
 #endif // CalibTracker_SiStripObjects_SiStripFec_H

--- a/CalibFormats/SiStripObjects/interface/SiStripFecCabling.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripFecCabling.h
@@ -38,12 +38,14 @@ class SiStripFecCabling {
   
   /** */
   inline const std::vector<SiStripFecCrate>& crates() const;
+  inline std::vector<SiStripFecCrate>& crates();
   /** */
   inline const std::vector<SiStripFec>& fecs() const; //@@ TEMPORARY: to maintain backward compatibility!
   /** */
   void connections( std::vector<FedChannelConnection>& ) const;
   /** */
   const SiStripModule& module( const FedChannelConnection& conn ) const;
+  SiStripModule* module( const FedChannelConnection& conn );
   /** */
   const SiStripModule& module( const uint32_t& dcu_id ) const;
   /** */
@@ -76,6 +78,7 @@ class SiStripFecCabling {
 // ---------- Inline methods ----------
 
 const std::vector<SiStripFecCrate>& SiStripFecCabling::crates() const { return crates_; }
+std::vector<SiStripFecCrate>& SiStripFecCabling::crates() { return crates_; }
 
 // TEMPORARY method to maintain backward compatibility!
 const std::vector<SiStripFec>& SiStripFecCabling::fecs() const { 
@@ -85,15 +88,18 @@ const std::vector<SiStripFec>& SiStripFecCabling::fecs() const {
 }
 
 void SiStripFecCabling::dcuId( const FedChannelConnection& conn ) { 
-  const_cast<SiStripModule&>(module(conn)).dcuId(conn.dcuId()); 
+  auto m = module(conn);
+  if(m) {m->dcuId(conn.dcuId());}
 }
 
 void SiStripFecCabling::detId( const FedChannelConnection& conn ) { 
-  const_cast<SiStripModule&>(module(conn)).detId(conn.detId()); 
+  auto m = module(conn);
+  if(m) { m->detId(conn.detId()); }
 }
 
 void SiStripFecCabling::nApvPairs( const FedChannelConnection& conn ) { 
-  const_cast<SiStripModule&>(module(conn)).nApvPairs(conn.nApvPairs()); 
+  auto m = module(conn);
+  if(m) { m->nApvPairs(conn.nApvPairs()); }
 }
 
 #endif // CalibTracker_SiStripObjects_SiStripFecCabling_H

--- a/CalibFormats/SiStripObjects/interface/SiStripFecCrate.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripFecCrate.h
@@ -23,6 +23,7 @@ class SiStripFecCrate {
   
   /** */
   inline const std::vector<SiStripFec>& fecs() const;
+  inline std::vector<SiStripFec>& fecs();
   
   /** */
   inline const uint16_t& fecCrate() const;
@@ -46,6 +47,7 @@ class SiStripFecCrate {
 // ---------- inline methods ----------
 
 const std::vector<SiStripFec>& SiStripFecCrate::fecs() const { return fecs_; }
+std::vector<SiStripFec>& SiStripFecCrate::fecs() { return fecs_; }
 const uint16_t& SiStripFecCrate::fecCrate() const { return fecCrate_; }
 
 #endif // CalibTracker_SiStripObjects_SiStripFecCrate_H

--- a/CalibFormats/SiStripObjects/interface/SiStripRing.h
+++ b/CalibFormats/SiStripObjects/interface/SiStripRing.h
@@ -23,6 +23,7 @@ class SiStripRing {
 
   /** */
   inline const std::vector<SiStripCcu>& ccus() const;
+  inline std::vector<SiStripCcu>& ccus();
 
   /** */
   inline const uint16_t& fecRing() const;
@@ -46,6 +47,7 @@ class SiStripRing {
 // ---------- inline methods ----------
 
 const std::vector<SiStripCcu>& SiStripRing::ccus() const { return ccus_; }
+std::vector<SiStripCcu>& SiStripRing::ccus() { return ccus_; }
 const uint16_t& SiStripRing::fecRing() const { return fecRing_; }
 
 #endif // CalibTracker_SiStripObjects_SiStripRing_H

--- a/CalibFormats/SiStripObjects/src/SiStripCcu.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripCcu.cc
@@ -15,11 +15,11 @@ SiStripCcu::SiStripCcu( const FedChannelConnection& conn )
 // -----------------------------------------------------------------------------
 //
 void SiStripCcu::addDevices( const FedChannelConnection& conn ) {
-  std::vector<SiStripModule>::const_iterator imod = modules().begin();
-  while ( imod != modules().end() && (*imod).ccuChan() != conn.ccuChan() ) { imod++; }
-  if ( imod == modules().end() ) { 
+  auto imod = modules_.begin();
+  while ( imod != modules_.end() && (*imod).ccuChan() != conn.ccuChan() ) { imod++; }
+  if ( imod == modules_.end() ) { 
     modules_.push_back( SiStripModule( conn ) ); 
   } else { 
-    const_cast<SiStripModule&>(*imod).addDevices( conn ); 
+    imod->addDevices( conn ); 
   }
 }

--- a/CalibFormats/SiStripObjects/src/SiStripFec.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripFec.cc
@@ -15,11 +15,11 @@ SiStripFec::SiStripFec( const FedChannelConnection& conn )
 // -----------------------------------------------------------------------------
 //
 void SiStripFec::addDevices( const FedChannelConnection& conn ) {
-  std::vector<SiStripRing>::const_iterator iring = rings().begin();
-  while ( iring != rings().end() && (*iring).fecRing() != conn.fecRing() ) { iring++; }
-  if ( iring == rings().end() ) { 
+  auto iring = rings_.begin();
+  while ( iring != rings_.end() && (*iring).fecRing() != conn.fecRing() ) { iring++; }
+  if ( iring == rings_.end() ) { 
     rings_.push_back( SiStripRing( conn ) ); 
   } else { 
-    const_cast<SiStripRing&>(*iring).addDevices( conn ); 
+    iring->addDevices( conn ); 
   }
 }

--- a/CalibFormats/SiStripObjects/src/SiStripFecCrate.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripFecCrate.cc
@@ -15,12 +15,12 @@ SiStripFecCrate::SiStripFecCrate( const FedChannelConnection& conn )
 // -----------------------------------------------------------------------------
 //
 void SiStripFecCrate::addDevices( const FedChannelConnection& conn ) {
-  std::vector<SiStripFec>::const_iterator ifec = fecs().begin();
-  while ( ifec != fecs().end() && (*ifec).fecSlot() != conn.fecSlot() ) { ifec++; }
-  if ( ifec == fecs().end() ) { 
+  auto ifec = fecs_.begin();
+  while ( ifec != fecs_.end() && (*ifec).fecSlot() != conn.fecSlot() ) { ifec++; }
+  if ( ifec == fecs_.end() ) { 
     fecs_.push_back( SiStripFec( conn ) ); 
   } else { 
-    const_cast<SiStripFec&>(*ifec).addDevices( conn ); 
+    ifec->addDevices( conn ); 
   }
 }
 

--- a/CalibFormats/SiStripObjects/src/SiStripRing.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripRing.cc
@@ -15,12 +15,12 @@ SiStripRing::SiStripRing( const FedChannelConnection& conn )
 // -----------------------------------------------------------------------------
 //
 void SiStripRing::addDevices( const FedChannelConnection& conn ) {
-  std::vector<SiStripCcu>::const_iterator iccu = ccus().begin();
-  while ( iccu != ccus().end() && (*iccu).ccuAddr() != conn.ccuAddr() ) { iccu++; }
+  auto iccu = ccus_.begin();
+  while ( iccu != ccus_.end() && (*iccu).ccuAddr() != conn.ccuAddr() ) { iccu++; }
   if ( iccu == ccus().end() ) { 
     ccus_.push_back( SiStripCcu( conn ) ); 
   } else { 
-    const_cast<SiStripCcu&>(*iccu).addDevices( conn ); 
+    iccu->addDevices( conn ); 
   }
 }
 


### PR DESCRIPTION
The static analyzer was complaining about the use of const_cast on
member data. Even though these const_casts were in non-const member
functions it aids future maintenance to remove their use.
