### PR TITLE
Make DTRecoConditions thread safe

### DIFF
--- a/CondFormats/DTObjects/interface/DTRecoConditions.h
+++ b/CondFormats/DTObjects/interface/DTRecoConditions.h
@@ -19,6 +19,9 @@
 #include <vector>
 #include <string>
 #include <stdint.h>
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include <atomic>
+#endif
 
 class DTWireId;
 class TFormula;
@@ -29,6 +32,8 @@ public:
 
   /// Constructor
   DTRecoConditions();
+  DTRecoConditions(const DTRecoConditions&);
+  const DTRecoConditions& operator=(const DTRecoConditions&);
 
   /// Destructor
   virtual ~DTRecoConditions();
@@ -65,10 +70,18 @@ public:
 private:
 
   // The formula used for parametrization (transient pointer)
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+  mutable std::atomic<TFormula*> formula COND_TRANSIENT;
+#else
   mutable TFormula* formula COND_TRANSIENT;
+#endif
   
   // Formula evalaution strategy, derived from expression and cached for efficiency reasons
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+  mutable std::atomic<int> formulaType COND_TRANSIENT;
+#else
   mutable int formulaType COND_TRANSIENT;
+#endif
 
   // String with the expression representing the formula used for parametrization
   std::string expression;

--- a/CondFormats/DTObjects/src/DTRecoConditions.cc
+++ b/CondFormats/DTObjects/src/DTRecoConditions.cc
@@ -25,6 +25,23 @@ DTRecoConditions::DTRecoConditions() :
   expression("[0]")
 {}
 
+DTRecoConditions::DTRecoConditions(const DTRecoConditions& iOther):
+  formula(nullptr),
+  formulaType(0),
+  expression(iOther.expression)
+{}
+
+const DTRecoConditions& 
+DTRecoConditions::operator=(const DTRecoConditions& iOther)
+{
+  delete formula.load();
+  formula=nullptr;
+  formulaType =0;
+  expression = iOther.expression;
+  return *this;
+}
+
+
 DTRecoConditions::~DTRecoConditions(){
   delete formula;
 }
@@ -45,8 +62,13 @@ float DTRecoConditions::get(const DTWireId& wireid, double* x) const {
     } else if  (expression=="par[step]") {
       formulaType = 2;
     } else { 
+      std::unique_ptr<TFormula> temp{new TFormula("DTExpr",expression.c_str())};
+      TFormula* expected = nullptr;
+      if(formula.compare_exchange_strong(expected,temp.get())) {
+        //This thread set the value
+        temp.release();
+      }
       formulaType = 99;
-      formula  = new TFormula("DTExpr",expression.c_str());
     }
   }
   
@@ -58,7 +80,7 @@ float DTRecoConditions::get(const DTWireId& wireid, double* x) const {
     return par[unsigned (x[0])];
   } else {
     // Use the formula corresponding to expression. 
-    return formula->EvalPar(x,par.data());
+    return (*formula).EvalPar(x,par.data());
   }
 }
 


### PR DESCRIPTION
The delayed caching of the formula results has been changed to be
thread safe.
