### PR TITLE
DQM for HLT VBF Hbb

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -172,11 +172,34 @@ hltHiggsPostTTHbbej = hltHiggsPostProcessor.clone()
 hltHiggsPostTTHbbej.subDirs = ['HLT/Higgs/TTHbbej']
 hltHiggsPostTTHbbej.efficiencyProfile = efficiency_strings_TTHbbej
 
+#Specific plots for VBFHbb_2btag  
+#dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
+plot_types = []
+NminOneCuts = (_config.__getattribute__("VBFHbb_2btag")).__getattribute__("NminOneCuts")
+if NminOneCuts: 
+    for iCut in range(0,len(NminOneCuts)):
+        if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
+            if( NminOneCutNames[iCut] == "EffmaxCSV" ):
+                plot_types.pop()
+            plot_types.append(NminOneCutNames[iCut])
+
+efficiency_strings = []
+for type in plot_types:
+    for obj in ["Jet"]:
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
+
+efficiency_strings = get_reco_strings(efficiency_strings)
+
+hltHiggsPostVBFHbb_2btag = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb_2btag.subDirs = ['HLT/Higgs/VBFHbb_2btag']
+hltHiggsPostVBFHbb_2btag.efficiencyProfile = efficiency_strings
 
 #Specific plots for VBFHbb_1btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
 NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
-plot_types = ["EffEta", "EffPhi"]
+plot_types = []
 NminOneCuts = (_config.__getattribute__("VBFHbb_1btag")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
@@ -185,41 +208,23 @@ if NminOneCuts:
                 plot_types.pop()
             plot_types.append(NminOneCutNames[iCut])
     
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-        
-efficiency_strings = get_reco_strings(efficiency_strings)
-    
 hltHiggsPostVBFHbb_1btag = hltHiggsPostProcessor.clone()
 hltHiggsPostVBFHbb_1btag.subDirs = ['HLT/Higgs/VBFHbb_1btag']
 hltHiggsPostVBFHbb_1btag.efficiencyProfile = efficiency_strings
 
-#Specific plots for VBFHbb_2btag  
+#Specific plots for VBFHbb_0btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
 NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
-plot_types = ["EffEta", "EffPhi"]
-NminOneCuts = (_config.__getattribute__("VBFHbb_2btag")).__getattribute__("NminOneCuts")
+plot_types = []
+NminOneCuts = (_config.__getattribute__("VBFHbb_0btag")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
-            if( NminOneCutNames[iCut] == "EffmaxCSV" ):
-                plot_types.pop()
             plot_types.append(NminOneCutNames[iCut])
-    
-efficiency_strings = []
-for type in plot_types:
-    for obj in ["Jet"]:
-        for trig in triggers:
-            efficiency_strings.append(efficiency_string(obj,type,trig))
-        
-efficiency_strings = get_reco_strings(efficiency_strings)
-    
-hltHiggsPostVBFHbb_2btag = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb_2btag.subDirs = ['HLT/Higgs/VBFHbb_2btag']
-hltHiggsPostVBFHbb_2btag.efficiencyProfile = efficiency_strings
+
+hltHiggsPostVBFHbb_0btag = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb_0btag.subDirs = ['HLT/Higgs/VBFHbb_0btag']
+hltHiggsPostVBFHbb_0btag.efficiencyProfile = efficiency_strings
 
 
 
@@ -285,6 +290,7 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHtaunu+
         hltHiggsPostH2tau+
         hltHiggsPostTTHbbej+
+        hltHiggsPostVBFHbb_0btag+
         hltHiggsPostVBFHbb_1btag+
         hltHiggsPostVBFHbb_2btag+
         hltHiggsPostZnnHbb+

--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -173,11 +173,11 @@ hltHiggsPostTTHbbej.subDirs = ['HLT/Higgs/TTHbbej']
 hltHiggsPostTTHbbej.efficiencyProfile = efficiency_strings_TTHbbej
 
 
-#Specific plots for VBFHbb  
+#Specific plots for VBFHbb_1btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
 NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
 plot_types = ["EffEta", "EffPhi"]
-NminOneCuts = (_config.__getattribute__("VBFHbb")).__getattribute__("NminOneCuts")
+NminOneCuts = (_config.__getattribute__("VBFHbb_1btag")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
@@ -193,9 +193,34 @@ for type in plot_types:
         
 efficiency_strings = get_reco_strings(efficiency_strings)
     
-hltHiggsPostVBFHbb = hltHiggsPostProcessor.clone()
-hltHiggsPostVBFHbb.subDirs = ['HLT/Higgs/VBFHbb']
-hltHiggsPostVBFHbb.efficiencyProfile = efficiency_strings
+hltHiggsPostVBFHbb_1btag = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb_1btag.subDirs = ['HLT/Higgs/VBFHbb_1btag']
+hltHiggsPostVBFHbb_1btag.efficiencyProfile = efficiency_strings
+
+#Specific plots for VBFHbb_2btag  
+#dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
+plot_types = ["EffEta", "EffPhi"]
+NminOneCuts = (_config.__getattribute__("VBFHbb_2btag")).__getattribute__("NminOneCuts")
+if NminOneCuts: 
+    for iCut in range(0,len(NminOneCuts)):
+        if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
+            if( NminOneCutNames[iCut] == "EffmaxCSV" ):
+                plot_types.pop()
+            plot_types.append(NminOneCutNames[iCut])
+    
+efficiency_strings = []
+for type in plot_types:
+    for obj in ["Jet"]:
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
+        
+efficiency_strings = get_reco_strings(efficiency_strings)
+    
+hltHiggsPostVBFHbb_2btag = hltHiggsPostProcessor.clone()
+hltHiggsPostVBFHbb_2btag.subDirs = ['HLT/Higgs/VBFHbb_2btag']
+hltHiggsPostVBFHbb_2btag.efficiencyProfile = efficiency_strings
+
 
 
 #Specific plots for ZnnHbb
@@ -260,7 +285,8 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHtaunu+
         hltHiggsPostH2tau+
         hltHiggsPostTTHbbej+
-        hltHiggsPostVBFHbb+
+        hltHiggsPostVBFHbb_1btag+
+        hltHiggsPostVBFHbb_2btag+
         hltHiggsPostZnnHbb+
         hltHiggsPostDoubleHinTaus+
         hltHiggsPostHiggsDalitz+

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -229,7 +229,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     VBFHbb_0btag  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_QuadPFJet_VBF_Common_v",
+            "HLT_QuadPFJet_VBF_v",
             "HLT_L1_TripleJet_VBF_v"
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb", "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej"), 
+    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb_2btag", "VBFHbb_1btag", "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej"), 
     histDirectory  = cms.string("HLT/Higgs"),
     
     # -- The instance name of the reco::GenParticles collection
@@ -227,9 +227,12 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         # -- Analysis specific cuts
         minCandidates = cms.uint32(2), 
         ),
-    VBFHbb  = cms.PSet( 
+    VBFHbb_2btag  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_QuadPFJet_BTagCSV_VBF_v",
+            "HLT_QuadPFJet_DoubleBTagCSV_VBF_Mqq200_v",
+            "HLT_QuadPFJet_DoubleBTagCSV_VBF_Mqq240_v",
+            "HLT_QuadPFJet_VBF_Mqq200_v",
+            "HLT_QuadPFJet_VBF_Mqq240_v",
             "HLT_QuadPFJet_VBF_v",
             "HLT_L1_TripleJet_VBF_v"
             ),
@@ -237,7 +240,22 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
         # -- Analysis specific cuts
         minCandidates = cms.uint32(4), 
-        NminOneCuts = cms.untracked.vdouble(2.6, 350, 2.6, 0.8, 0, 0, 0, 0, 0, 95, 85, 70, 40), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+        NminOneCuts = cms.untracked.vdouble(2.5, 240, 2.1, 0.8, 0.5, 0, 0, 0, 0, 95, 85, 70, 40), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+        ),
+    VBFHbb_1btag  = cms.PSet( 
+        hltPathsToCheck = cms.vstring(
+            "HLT_QuadPFJet_SingleBTagCSV_VBF_Mqq460_v",
+            "HLT_QuadPFJet_SingleBTagCSV_VBF_Mqq500_v",
+            "HLT_QuadPFJet_VBF_Mqq460_v",
+            "HLT_QuadPFJet_VBF_Mqq500_v",
+            "HLT_QuadPFJet_VBF_v",
+            "HLT_L1_TripleJet_VBF_v"
+            ),
+        recJetLabel  = cms.string("ak4PFJetsCHS"),
+        jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
+        # -- Analysis specific cuts
+        minCandidates = cms.uint32(4), 
+        NminOneCuts = cms.untracked.vdouble(5, 550, 1.0, 0.8, 0, 0, 0, 0, 0, 95, 85, 70, 40), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
         ),
     ZnnHbb = cms.PSet( 
         hltPathsToCheck = cms.vstring(
@@ -251,7 +269,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         recPFMETLabel = cms.string("pfMet"),  
         # -- Analysis specific cuts
         minCandidates = cms.uint32(1), 
-        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.9, 0, 0, 8, 30, 100, 70), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1
+        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.9, 0, 0, 8, 30, 100, 70), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
         ),
     X4b  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
@@ -264,7 +282,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
         # -- Analysis specific cuts
         minCandidates = cms.uint32(4), 
-        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.5, 0.5 , 0.5, 0, 0, 0, 0, 90, 0, 45), #dEtaqq, mqq, dPhibb, CSV1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+        NminOneCuts = cms.untracked.vdouble(0, 0, 0, 0.5, 0.5 , 0.5, 0, 0, 0, 0, 90, 0, 45), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
         ),
     TTHbbej  = cms.PSet( 
         hltPathsToCheck = cms.vstring(

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
-    hltProcessName = cms.string("HLTX"),
+    hltProcessName = cms.string("HLT"),
     analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej"), 
     histDirectory  = cms.string("HLT/Higgs"),
     

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -3,8 +3,8 @@ import FWCore.ParameterSet.Config as cms
 
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
-    hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb_2btag", "VBFHbb_1btag", "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej"), 
+    hltProcessName = cms.string("HLTX"),
+    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej"), 
     histDirectory  = cms.string("HLT/Higgs"),
     
     # -- The instance name of the reco::GenParticles collection
@@ -227,14 +227,21 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         # -- Analysis specific cuts
         minCandidates = cms.uint32(2), 
         ),
+    VBFHbb_0btag  = cms.PSet( 
+        hltPathsToCheck = cms.vstring(
+            "HLT_QuadPFJet_VBF_Common_v",
+            "HLT_L1_TripleJet_VBF_v"
+            ),
+        recJetLabel  = cms.string("ak4PFJetsCHS"),
+        jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
+        # -- Analysis specific cuts
+        minCandidates = cms.uint32(4), 
+        NminOneCuts = cms.untracked.vdouble(2.5, 240, 2.1, 0, 0, 0, 0, 0, 0, 95, 85, 70, 40), #dEtaqq, mqq, dPhibb, CSV1, CSV2, CSV3, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
+        ),
     VBFHbb_2btag  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
             "HLT_QuadPFJet_DoubleBTagCSV_VBF_Mqq200_v",
             "HLT_QuadPFJet_DoubleBTagCSV_VBF_Mqq240_v",
-            "HLT_QuadPFJet_VBF_Mqq200_v",
-            "HLT_QuadPFJet_VBF_Mqq240_v",
-            "HLT_QuadPFJet_VBF_v",
-            "HLT_L1_TripleJet_VBF_v"
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
@@ -246,10 +253,6 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         hltPathsToCheck = cms.vstring(
             "HLT_QuadPFJet_SingleBTagCSV_VBF_Mqq460_v",
             "HLT_QuadPFJet_SingleBTagCSV_VBF_Mqq500_v",
-            "HLT_QuadPFJet_VBF_Mqq460_v",
-            "HLT_QuadPFJet_VBF_Mqq500_v",
-            "HLT_QuadPFJet_VBF_v",
-            "HLT_L1_TripleJet_VBF_v"
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),


### PR DESCRIPTION
This PR updates the DQM for HLT VBF Hbb paths, according to https://its.cern.ch/jira/browse/CMSHLT-234 .
Here the VBFHbb folder is splitted in:
- VBFHbb_0btag
- VBFHbb_1btag
- VBFHbb_2btag
  in order to:
- have more statistic for trigger that doesn't use b-tagging
- remove useless plots (eg. turn-on vs CSV1 for a trigger path with no b-tag).
