### PR TITLE
FastSim sampling of nuclear interation using Geant4 FTF model

### DIFF
--- a/FastSimulation/MaterialEffects/BuildFile.xml
+++ b/FastSimulation/MaterialEffects/BuildFile.xml
@@ -3,6 +3,8 @@
 <use   name="FastSimulation/Event"/>
 <use   name="FastSimulation/Utilities"/>
 <use   name="rootcore"/>
+<use   name="clhep"/>
+<use   name="geant4core"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FastSimulation/MaterialEffects/interface/CMSDummyDeexcitation.h
+++ b/FastSimulation/MaterialEffects/interface/CMSDummyDeexcitation.h
@@ -13,6 +13,9 @@
 #include "G4ReactionProductVector.hh"
 
 class G4Fragment;
+class G4HadFinalState;
+class G4HadProjectile;
+class G4Nucleus;
 
 class CMSDummyDeexcitation : public G4VPreCompoundModel
 { 
@@ -22,8 +25,7 @@ public:
 
   virtual ~CMSDummyDeexcitation() {};
 
-  //  virtual G4HadFinalState * ApplyYourself(const G4HadProjectile & thePrimary, 
-  //                                      G4Nucleus & theNucleus);
+  G4HadFinalState* ApplyYourself(const G4HadProjectile&, G4Nucleus&) { return 0; } 
 
   G4ReactionProductVector* DeExcite(G4Fragment&) { return new G4ReactionProductVector(); };
 

--- a/FastSimulation/MaterialEffects/interface/CMSDummyDeexitation.h
+++ b/FastSimulation/MaterialEffects/interface/CMSDummyDeexitation.h
@@ -1,0 +1,31 @@
+#ifndef FastSimulation_MaterialEffects_CMSDummyDeexcitation_H
+#define FastSimulation_MaterialEffects_CMSDummyDeexcitation_H
+
+/** 
+ * This class is needed as a dummy interface to Geant4  
+ * nuclear de-excitation module; no secondary produced
+ *
+ * \author Vladimir Ivanchenko
+ * $Date: 20-Jan-2015
+ */ 
+
+#include "G4VPreCompoundModel.hh"
+#include "G4ReactionProductVector.hh"
+
+class G4Fragment;
+
+class CMSDummyDeexcitation : public G4VPreCompoundModel
+{ 
+public:
+
+  CMSDummyDeexcitation() {}; 
+
+  virtual ~CMSDummyDeexcitation() {};
+
+  //  virtual G4HadFinalState * ApplyYourself(const G4HadProjectile & thePrimary, 
+  //                                      G4Nucleus & theNucleus);
+
+  G4ReactionProductVector* DeExcite(G4Fragment&) { return new G4ReactionProductVector(); };
+
+};
+#endif

--- a/FastSimulation/MaterialEffects/interface/MaterialEffects.h
+++ b/FastSimulation/MaterialEffects/interface/MaterialEffects.h
@@ -38,7 +38,8 @@ class ParticlePropagator;
 class PairProductionSimulator;
 class BremsstrahlungSimulator;
 class EnergyLossSimulator;
-class NuclearInteractionSimulator;
+//class NuclearInteractionSimulator;
+class MaterialEffectsSimulator;
 class MultipleScatteringSimulator;
 class MuonBremsstrahlungSimulator;
 class RandomEngineAndDistribution;
@@ -85,7 +86,7 @@ class MaterialEffects
     return EnergyLoss;
   }
 
-/// Return the Muon Bremsstrahlung engine
+  /// Return the Muon Bremsstrahlung engine
   inline MuonBremsstrahlungSimulator* muonBremsstrahlungSimulator() const {
     return MuonBremsstrahlung;
   }
@@ -104,11 +105,11 @@ class MaterialEffects
 
   PairProductionSimulator* PairProduction;
   BremsstrahlungSimulator* Bremsstrahlung;
-////// Muon Brem
+  ////// Muon Brem
   MuonBremsstrahlungSimulator* MuonBremsstrahlung;
   MultipleScatteringSimulator* MultipleScattering;
   EnergyLossSimulator* EnergyLoss;
-  NuclearInteractionSimulator* NuclearInteraction;
+  MaterialEffectsSimulator* NuclearInteraction;
 
   // Cuts for material effects
   double pTmin;

--- a/FastSimulation/MaterialEffects/interface/MaterialEffectsSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/MaterialEffectsSimulator.h
@@ -52,7 +52,6 @@ class MaterialEffectsSimulator
   ///Electron mass in GeV/c2
   inline double eMass() const { return 0.000510998902; }
 
-
   /// Compute the material effect (calls the sub class)
   void updateState(ParticlePropagator& myTrack, double radlen, RandomEngineAndDistribution const*);
   
@@ -74,6 +73,9 @@ class MaterialEffectsSimulator
   /// The id of the closest charged daughter (filled for nuclear interactions only)
   inline int closestDaughterId() { return theClosestChargedDaughterId; } 
 
+  /// Used by  NuclearInteractionSimulator to save last sampled event
+  virtual void save() {};
+
  private:
 
   /// Overloaded in all material effects updtators
@@ -81,7 +83,6 @@ class MaterialEffectsSimulator
 
   /// Returns the fraction of radiation lengths traversed
   inline double radiationLength() const {return radLengths;}
-
 
  protected:
 

--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
@@ -1,0 +1,83 @@
+#ifndef FastSimulation_MaterialEffects_NuclearInteractionFTFSimulator_H
+#define FastSimulation_MaterialEffects_NuclearInteractionFTFSimulator_H
+
+/** 
+ * This class computes the probability for hadrons to interact with a 
+ * nucleon of the tracker material (inelastically) and then sample
+ * nuclear interaction using FTF model of Geant4 
+ * The fraction of interaction lengths traversed by the particle in this 
+ * tracker layer is determined in MaterialEffectsSimulator as a fraction 
+ * the radiation lengths. 
+ *
+ * \author Vladimir Ivanchenko
+ * $Date: 20-Jan-2015
+ */ 
+
+#include "FastSimulation/MaterialEffects/interface/MaterialEffectsSimulator.h"
+
+#include "G4Nucleus.hh"
+#include "G4HadProjectile.hh"
+#include "G4LorentzVector.hh"
+#include "G4ThreeVector.hh"
+
+#include <vector>
+
+class ParticlePropagator;
+class RandomEngineAndDistribution;
+class G4ParticleDefinition;
+class G4Track;
+class G4Step;
+class G4TheoFSGenerator;
+class G4FTFModel;
+class G4ExcitedStringDecay;
+class G4LundStringFragmentation;
+class G4GeneratorPrecompoundInterface;
+
+class NuclearInteractionFTFSimulator : public MaterialEffectsSimulator
+{
+public:
+
+  /// Constructor
+  NuclearInteractionFTFSimulator(unsigned int distAlgo, double distCut);
+
+  /// Default Destructor
+  ~NuclearInteractionFTFSimulator();
+
+private:
+
+  /// Generate a nuclear interaction according to the probability that it happens
+  void compute(ParticlePropagator& Particle, RandomEngineAndDistribution const*);
+
+  void saveDaughter(ParticlePropagator& Particle, const G4LorentzVector& lv, int pdgid);
+
+  double distanceToPrimary(const RawParticle& Particle,
+			   const RawParticle& aDaughter) const;
+
+  std::vector<const G4ParticleDefinition*> theG4Hadron;
+  std::vector<double> theNuclIntLength;
+  std::vector<int> theId;
+
+  G4TheoFSGenerator* theHadronicModel;
+  G4FTFModel* theStringModel;
+  G4ExcitedStringDecay* theStringDecay; 
+  G4LundStringFragmentation* theLund;
+  G4GeneratorPrecompoundInterface* theCascade; 
+
+  G4Step* dummyStep;
+  G4Track* currTrack;
+  const G4ParticleDefinition* currParticle;
+  G4Nucleus targetNucleus;
+  G4HadProjectile theProjectile;
+  G4LorentzVector curr4Mom;
+  G4ThreeVector vectProj;
+  G4ThreeVector theBoost;
+
+  double theEnergyLimit;
+
+  int numHadrons;
+
+  unsigned int theDistAlgo;
+  double theDistCut;
+  double distMin;
+};
+#endif

--- a/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
+++ b/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
@@ -41,8 +41,10 @@ MaterialEffectsBlock = cms.PSet(
 	# Smallest pT for the Mutliple Scattering 
         pTmin = cms.double(0.2),
 	# Enable Nuclear Interactions
-        NuclearInteraction = cms.bool(False),  # temporary 12.01.14 until bug-fix for nuclear interactions
-	# The energies of the pions used in the above files (same order)
+        NuclearInteraction = cms.bool(False), # temporary 12.01.14 until bug-fix for nuclear interactions
+        #
+        G4NuclearInteraction = cms.bool(False), 	
+        # The energies of the pions used in the above files (same order)
         pionEnergies = cms.untracked.vdouble(
             1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 9.0, 12.0, 15.0, 20.0, 
             30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 700.0, 1000.0
@@ -180,6 +182,7 @@ MaterialEffectsForMuonsBlock = cms.PSet(
 	# Smallest pT for the Mutliple Scattering 
         pTmin = cms.double(0.3),
 	# Enable Nuclear Interactions
+        G4NuclearInteraction = cms.bool(False), 	
         NuclearInteraction = cms.bool(False)
 
     )
@@ -220,6 +223,7 @@ MaterialEffectsForMuonsInECALBlock = cms.PSet(
 	# Smallest pT for the Mutliple Scattering 
         pTmin = cms.double(0.3),
 	# Enable Nuclear Interactions
+        G4NuclearInteraction = cms.bool(False), 	
         NuclearInteraction = cms.bool(False)
     )
 )
@@ -259,6 +263,7 @@ MaterialEffectsForMuonsInHCALBlock = cms.PSet(
 	# Smallest pT for the Mutliple Scattering 
         pTmin = cms.double(0.3),
 	# Enable Nuclear Interactions
+        G4NuclearInteraction = cms.bool(False), 	
         NuclearInteraction = cms.bool(False)
 
     )

--- a/FastSimulation/MaterialEffects/src/MaterialEffects.cc
+++ b/FastSimulation/MaterialEffects/src/MaterialEffects.cc
@@ -16,6 +16,7 @@
 #include "FastSimulation/MaterialEffects/interface/BremsstrahlungSimulator.h"
 #include "FastSimulation/MaterialEffects/interface/EnergyLossSimulator.h"
 #include "FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h"
+#include "FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h"
 #include "FastSimulation/MaterialEffects/interface/MuonBremsstrahlungSimulator.h"
 
 #include <list>
@@ -37,6 +38,7 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
   bool doEnergyLoss         = matEff.getParameter<bool>("EnergyLoss");
   bool doMultipleScattering = matEff.getParameter<bool>("MultipleScattering");
   bool doNuclearInteraction = matEff.getParameter<bool>("NuclearInteraction");
+  bool doG4NuclInteraction  = matEff.getParameter<bool>("G4NuclearInteraction");
   bool doMuonBremsstrahlung = matEff.getParameter<bool>("MuonBremsstrahlung");
 
   double A = matEff.getParameter<double>("A");
@@ -59,8 +61,8 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
     Bremsstrahlung = new BremsstrahlungSimulator(bremEnergy,
 						 bremEnergyFraction);
   }
-//muon Brem+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
- if ( doMuonBremsstrahlung ) {
+  //muon Brem+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  if ( doMuonBremsstrahlung ) {
 
     double bremEnergy = matEff.getParameter<double>("bremEnergy");
     double bremEnergyFraction = matEff.getParameter<double>("bremEnergyFraction");
@@ -69,8 +71,7 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
 
   }
 
-
- //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+  //++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
   if ( doEnergyLoss ) { 
 
@@ -84,6 +85,7 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
     MultipleScattering = new MultipleScatteringSimulator(A,Z,density,radLen);
 
   }
+
 
   if ( doNuclearInteraction ) { 
 
@@ -200,11 +202,15 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
       idMap[idPiminusses[i]] = -211;
 
     // Construction
-    NuclearInteraction = 
-      new NuclearInteractionSimulator(pionEnergies, pionTypes, pionNames, 
-				      pionMasses, pionPMin, pionEnergy, 
-				      lengthRatio, ratios, idMap, 
-				      inputFile, distAlgo, distCut);
+    if ( doG4NuclInteraction ) { 
+      NuclearInteraction = new NuclearInteractionFTFSimulator(distAlgo, distCut); 
+    } else {
+      NuclearInteraction = 
+	new NuclearInteractionSimulator(pionEnergies, pionTypes, pionNames, 
+					pionMasses, pionPMin, pionEnergy, 
+					lengthRatio, ratios, idMap, 
+					inputFile, distAlgo, distCut);
+    }
   }
 }
 
@@ -215,7 +221,7 @@ MaterialEffects::~MaterialEffects() {
   if ( EnergyLoss ) delete EnergyLoss;
   if ( MultipleScattering ) delete MultipleScattering;
   if ( NuclearInteraction ) delete NuclearInteraction;
-//Muon Brem
+  //Muon Brem
   if ( MuonBremsstrahlung ) delete MuonBremsstrahlung;
 }
 
@@ -230,6 +236,10 @@ void MaterialEffects::interact(FSimEvent& mySimEvent,
   theEnergyLoss = 0;
   theNormalVector = normalVector(layer,myTrack);
   radlen = radLengths(layer,myTrack);
+
+  //std::cout << "### MaterialEffects: for Track= " <<  itrack << " in layer #"
+  //	    << layer.layerNumber() <<  std::endl;
+  //std::cout << myTrack << std::endl;
 
 //-------------------
 //  Photon Conversion
@@ -283,12 +293,15 @@ void MaterialEffects::interact(FSimEvent& mySimEvent,
     }
     NuclearInteraction->updateState(myTrack, radlen*factor, random);
 
+    //std::cout << "MaterialEffects: nDaughters= " 
+    //	      << NuclearInteraction->nDaughters() << std::endl;
     if ( NuclearInteraction->nDaughters() ) { 
 
       //add a end vertex to the mother particle
       int ivertex = mySimEvent.addSimVertex(myTrack.vertex(),itrack,
 					    FSimVertexType::NUCL_VERTEX);
-      
+      //std::cout << "ivertex= " << ivertex << " nDaughters= " 
+      //	<< NuclearInteraction->nDaughters() << std::endl;
       // Check if it is a valid vertex first:
       if (ivertex>=0) {
 	// This was a hadron that interacted inelastically
@@ -301,11 +314,11 @@ void MaterialEffects::interact(FSimEvent& mySimEvent,
 	  int daughId = mySimEvent.addSimTrack(&(*DaughterIter), ivertex);
 	  
 	  // Store the closest daughter in the mother info (for later tracking purposes)
-	  if ( NuclearInteraction->closestDaughterId() == idaugh++ ) {
+	  if ( NuclearInteraction->closestDaughterId() == idaugh ) {
 	    if ( mySimEvent.track(itrack).vertex().position().Pt() < 4.0 ) 
 	      mySimEvent.track(itrack).setClosestDaughterId(daughId);
 	  }
-	  
+	  ++idaugh;
 	}
 	// The hadron is destroyed. Return.
 	return;

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionFTFSimulator.cc
@@ -1,0 +1,279 @@
+// Framework Headers
+#include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+// Fast Sim headers
+#include "FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h"
+#include "FastSimulation/MaterialEffects/interface/CMSDummyDeexcitation.h"
+#include "FastSimulation/Utilities/interface/RandomEngineAndDistribution.h"
+#include "FastSimulation/ParticlePropagator/interface/ParticlePropagator.h"
+
+// Geant4 headers
+#include "G4ParticleDefinition.hh"
+#include "G4DynamicParticle.hh"
+#include "G4Track.hh"
+#include "G4Step.hh"
+#include "G4StepPoint.hh"
+#include "G4TheoFSGenerator.hh"
+#include "G4FTFModel.hh"
+#include "G4ExcitedStringDecay.hh"
+#include "G4LundStringFragmentation.hh"
+#include "G4GeneratorPrecompoundInterface.hh"
+
+#include "G4Proton.hh"
+#include "G4Neutron.hh"
+#include "G4PionPlus.hh"
+#include "G4PionMinus.hh"
+#include "G4AntiProton.hh"
+#include "G4KaonPlus.hh"
+#include "G4KaonMinus.hh"
+#include "G4KaonZeroLong.hh"
+#include "G4KaonZeroShort.hh"
+#include "G4KaonZero.hh"
+#include "G4AntiKaonZero.hh"
+#include "G4GenericIon.hh"
+
+#include "G4Material.hh"
+#include "G4DecayPhysics.hh"
+#include "G4ParticleTable.hh"
+#include "G4SystemOfUnits.hh"
+
+const double fact = 1.0/CLHEP::GeV;
+
+NuclearInteractionFTFSimulator::NuclearInteractionFTFSimulator(  
+  unsigned int distAlgo, 
+  double distCut) :
+  theDistAlgo(distAlgo),
+  theDistCut(distCut),
+  distMin(1E99)
+{
+  theEnergyLimit = 1*CLHEP::GeV;
+
+  // FTF model
+  theHadronicModel = new G4TheoFSGenerator("FTF");
+  theStringModel = new G4FTFModel();
+  G4GeneratorPrecompoundInterface* cascade 
+    = new G4GeneratorPrecompoundInterface(new CMSDummyDeexcitation());
+  theLund = new G4LundStringFragmentation();
+  theStringDecay = new G4ExcitedStringDecay(theLund);
+  theStringModel->SetFragmentationModel(theStringDecay);
+
+  theHadronicModel->SetTransport(cascade);
+  theHadronicModel->SetHighEnergyGenerator(theStringModel);
+  theHadronicModel->SetMinEnergy(theEnergyLimit);
+
+  // Geant4 particles
+  numHadrons = 11;
+  theG4Hadron.resize(numHadrons,0);
+  theG4Hadron[0] = G4Proton::Proton();
+  theG4Hadron[1] = G4Neutron::Neutron();
+  theG4Hadron[2] = G4PionPlus::PionPlus();
+  theG4Hadron[3] = G4PionMinus::PionMinus();
+  theG4Hadron[4] = G4AntiProton::AntiProton();
+  theG4Hadron[5] = G4KaonPlus::KaonPlus();
+  theG4Hadron[6] = G4KaonMinus::KaonMinus();
+  theG4Hadron[7] = G4KaonZeroLong::KaonZeroLong();
+  theG4Hadron[8] = G4KaonZeroShort::KaonZeroShort();
+  theG4Hadron[9] = G4KaonZero::KaonZero();
+  theG4Hadron[10]= G4AntiKaonZero::AntiKaonZero();
+
+  G4GenericIon::GenericIon();
+  G4DecayPhysics decays;
+  decays.ConstructParticle();  
+  G4ParticleTable* partTable = G4ParticleTable::GetParticleTable();
+  partTable->SetReadiness();
+
+  // interaction length in units of radiation length 
+  // computed for 5 GeV projectile energy, default value for K0_L
+  theNuclIntLength.resize(numHadrons,6.46);
+  theNuclIntLength[0] = 4.528;
+  theNuclIntLength[1] = 4.524;
+  theNuclIntLength[2] = 4.493;
+  theNuclIntLength[3] = 4.493;
+  theNuclIntLength[4] = 3.593;
+  theNuclIntLength[5] = 7.154;
+  theNuclIntLength[6] = 5.889;
+
+  // list of PDG codes
+  theId.resize(numHadrons,0);
+
+  // local objects
+  currTrack = 0;
+  currParticle = 0;
+  vectProj.set(0.0,0.0,1.0);  
+  theBoost.set(0.0,0.0,1.0);  
+
+  // fill projectile particle definitions
+  dummyStep = new G4Step();
+  dummyStep->SetPreStepPoint(new G4StepPoint());
+  for(int i=0; i<numHadrons; ++i) {
+    theId[i] = theG4Hadron[i]->GetPDGEncoding();
+  }
+
+  // target is always Silicon
+  targetNucleus.SetParameters(28, 14);
+}
+
+NuclearInteractionFTFSimulator::~NuclearInteractionFTFSimulator() {
+
+  delete theStringDecay;
+  delete theStringModel;
+  delete theLund;
+}
+
+void NuclearInteractionFTFSimulator::compute(ParticlePropagator& Particle, 
+					     RandomEngineAndDistribution const* random)
+{
+  // check if primary particle is in the local list
+  int thePid = Particle.pid(); 
+  currParticle = 0;
+  int i = 0;
+  for(; i<numHadrons-2; ++i) {
+    if(theId[i] == thePid) {
+      currParticle = theG4Hadron[i];
+      // neutral kaons
+      if(7 == i || 8 == i) {
+	currParticle = theG4Hadron[9];
+	if(random->flatShoot() > 0.5) { currParticle = theG4Hadron[10]; }
+      }
+      break;
+    }
+  }
+  if(!currParticle) { return; }
+
+  //std::cout << "*NuclearInteractionFTFSimulator::compute: R(X0)= " << radLengths
+  //	    << " Rnuc(X0)= " <<  theNuclIntLength[i] << std::endl;
+
+  // Check random position of nuclear interaction
+  if ( -G4Log(random->flatShoot())*theNuclIntLength[i] > radLengths ) { return; }
+
+  // fill projectile for Geant4
+  double e  = CLHEP::GeV*Particle.momentum().e();
+  double mass = currParticle->GetPDGMass();
+
+  //std::cout << " Primary " <<  currParticle->GetParticleName() 
+  //	    << "  E(GeV)= " << e*fact << std::endl;
+
+  if(e <= theEnergyLimit + mass) { return; }
+
+  double px = Particle.momentum().px();
+  double py = Particle.momentum().py();
+  double pz = Particle.momentum().pz();
+  double norm = 1.0/sqrt(px*px + py*py + pz*pz);
+  G4ThreeVector dir(px*norm, py*norm, pz*norm);
+  /*
+  std::cout << " Primary " <<  currParticle->GetParticleName() 
+	    << "  E(GeV)= " << e*fact << "  P(GeV/c)= (" 
+	    << px << " " << py << " " << pz << ")" << std::endl;
+  */
+
+  G4DynamicParticle* dynParticle = new G4DynamicParticle(theG4Hadron[i],dir,e-mass);
+  currTrack = new G4Track(dynParticle, 0.0, vectProj);
+  currTrack->SetStep(dummyStep);
+
+  theProjectile.Initialise(*currTrack); 
+  delete currTrack;
+
+  G4HadFinalState* result = theHadronicModel->ApplyYourself(theProjectile, targetNucleus);
+
+  if(result) {
+
+    int nsec = result->GetNumberOfSecondaries();
+    if(0 < nsec) {
+
+      result->SetTrafoToLab(theProjectile.GetTrafoToLab());
+      _theUpdatedState.clear();
+
+      // std::cout << "   " << nsec << " secondaries" << std::endl;
+      // Generate angle
+      double phi = random->flatShoot()*CLHEP::twopi;
+      theClosestChargedDaughterId = -1;
+      distMin = 1e99;
+
+      // rotate and store secondaries
+      for (int j=0; j<nsec; ++j) {
+
+        const G4DynamicParticle* dp = result->GetSecondary(j)->GetParticle();
+        int thePid = dp->GetParticleDefinition()->GetPDGEncoding();
+
+	// rotate around primary direction
+	curr4Mom = dp->Get4Momentum();
+	curr4Mom.rotate(phi, vectProj);
+	curr4Mom *= result->GetTrafoToLab();
+	/*
+	std::cout << j << ". " << dp->GetParticleDefinition()->GetParticleName() 
+		  << "  " << thePid
+		  << "  " << curr4Mom*fact << std::endl;
+	*/
+	// prompt 2-gamma decay for pi0, eta, eta'p
+        if(111 == thePid || 221 == thePid || 331 == thePid) {
+          theBoost = curr4Mom.boostVector();
+          double e = 0.5*dp->GetParticleDefinition()->GetPDGMass();
+          double fi  = random->flatShoot()*CLHEP::twopi; 
+          double cth = 2*random->flatShoot() - 1.0;
+          double sth = sqrt((1.0 - cth)*(1.0 + cth)); 
+          G4LorentzVector lv(e*sth*cos(fi),e*sth*sin(fi),e*cth,e);
+          lv.boost(theBoost);
+	  saveDaughter(Particle, lv, 22); 
+          curr4Mom -= lv;
+	  saveDaughter(Particle, curr4Mom, 22); 
+	} else {
+	  saveDaughter(Particle, curr4Mom, thePid); 
+	}
+      }
+    }
+  }
+}
+
+void NuclearInteractionFTFSimulator::saveDaughter(ParticlePropagator& Particle, 
+						  const G4LorentzVector& lv, int pdgid)
+{
+  unsigned int idx = _theUpdatedState.size();   
+  _theUpdatedState.push_back(Particle);
+  _theUpdatedState[idx].SetXYZT(lv.px()*fact,lv.py()*fact,lv.pz()*fact,lv.e()*fact);
+  _theUpdatedState[idx].setID(pdgid);
+
+  // Store the closest daughter index (for later tracking purposes, so charged particles only) 
+  double distance = distanceToPrimary(Particle,_theUpdatedState[idx]);
+  // Find the closest daughter, if closer than a given upper limit.
+  if ( distance < distMin && distance < theDistCut ) {
+    distMin = distance;
+    theClosestChargedDaughterId = idx;
+  }
+  // std::cout << _theUpdatedState[idx] << std::endl;
+}
+
+double 
+NuclearInteractionFTFSimulator::distanceToPrimary(const RawParticle& Particle,
+						  const RawParticle& aDaughter) const 
+{
+  double distance = 2E99;
+  // Compute the distance only for charged primaries
+  if ( fabs(Particle.charge()) > 1E-6 ) { 
+
+    // The secondary must have the same charge
+    double chargeDiff = fabs(aDaughter.charge()-Particle.charge());
+    if ( fabs(chargeDiff) < 1E-6 ) {
+
+      // Here are two distance definitions * to be tuned *
+      switch ( theDistAlgo ) { 
+	
+      case 1:
+	// sin(theta12)
+	distance = (aDaughter.Vect().Unit().Cross(Particle.Vect().Unit())).R();
+	break;
+	
+      case 2: 
+	// sin(theta12) * p1/p2
+	distance = (aDaughter.Vect().Cross(Particle.Vect())).R()
+	  /aDaughter.Vect().Mag2();
+	break;
+	
+      default:
+	// Should not happen
+	break;	
+      }
+    }
+  } 
+  return distance;
+}


### PR DESCRIPTION
An alternative method to sample nuclear interaction inside tracker is introduced. Geant4 FTF model is used. New option is disabled by default, so current FastSim results should be unchanged.

Extra dependences of FastSim on clhep and Geant4 are added. 
