### PR TITLE
 Change the way total cross section is computed in GenXSecAnalzyer and fix the print out in LHERunInfo.cc

### DIFF
--- a/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
+++ b/GeneratorInterface/Core/plugins/GenXSecAnalyzer.cc
@@ -442,7 +442,15 @@ GenXSecAnalyzer::compute(const GenLumiInfoProduct& iLumiInfo)
 
   } // end of loop over different processes
   tempVector_before.push_back(GenLumiInfoProduct::XSec(sigSelSum, sqrt(err2SelSum)));
-  GenLumiInfoProduct::XSec result(sigSum,std::sqrt(err2Sum));
+
+  double total_matcheff = jetMatchEffStat_[10000].filterEfficiency(hepidwtup_);
+  double total_matcherr = jetMatchEffStat_[10000].filterEfficiencyError(hepidwtup_);
+
+  double xsec_after     = sigSelSum*total_matcheff;
+  double xsecerr_after  = (total_matcheff > 0 && sigSelSum > 0)? xsec_after*sqrt(err2SelSum/sigSelSum/sigSelSum + 
+										 total_matcherr*total_matcherr/total_matcheff/total_matcheff):0;
+
+  GenLumiInfoProduct::XSec result(xsec_after,xsecerr_after);
   tempVector_after.push_back(result);
 
   xsecBeforeMatching_ =tempVector_before;
@@ -502,28 +510,19 @@ GenXSecAnalyzer::endJob() {
 						     );
 
 
+      jetmatch_eff = thisJetMatchStat.filterEfficiency(hepidwtup_);
+      jetmatch_err = thisJetMatchStat.filterEfficiencyError(hepidwtup_);
+
       if(i==last)
   	{
   	  title[i] = "Total";
 
   	  edm::LogPrint("GenXSecAnalyzer") 
-  	    << "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- ";
- 	
-  	  double n1 = xsecBeforeMatching_[i].value();
-  	  double e1 = xsecBeforeMatching_[i].error();
-  	  double n2 = xsecAfterMatching_[i].value();
-  	  double e2 = xsecAfterMatching_[i].error();
-
-  	  jetmatch_eff = n1>0? n2/n1 : 0;
-  	  jetmatch_err = (n1>0 && n2>0 && pow(e2/n2,2)>pow(e1/n1,2))?
-  	    jetmatch_eff*sqrt( pow(e2/n2,2) - pow(e1/n1,2)):-1;
- 	  
+  	    << "-------------------------------------------------------------------------------------------------------------------------------------------------------------------------- "; 	 	  
   	}
       else
   	{
   	  title[i] = Form("%d",i);      
-  	  jetmatch_eff = thisJetMatchStat.filterEfficiency(hepidwtup_);
-  	  jetmatch_err = thisJetMatchStat.filterEfficiencyError(hepidwtup_);
 
   	}
 

--- a/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
+++ b/GeneratorInterface/LHEInterface/src/LHERunInfo.cc
@@ -233,11 +233,10 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 
 		double fracBr = proc->accepted().sum() > 0.0 ?
 		                proc->acceptedBr().sum() / proc->accepted().sum() : 1;
-		double sigmaFin = sigmaAvg * fracAcc * fracBr;
+		double sigmaFin = sigmaAvg * fracAcc ;
 		double sigmaFinBr = sigmaFin * fracBr;
 
 		double relErr = 1.0;
-		if (proc->killed().n() > 1) {
 
 			double efferr2=0;
 			switch(idwtup) {
@@ -279,7 +278,7 @@ LHERunInfo::XSec LHERunInfo::xsec() const
 			                   + sigma2Err / sigma2Sum;
 			relErr = (delta2Sum > 0.0 ?
 					std::sqrt(delta2Sum) : 0.0);
-		}
+
 		double deltaFin = sigmaFin * relErr;
 		double deltaFinBr = sigmaFinBr * relErr;
 
@@ -346,18 +345,17 @@ void LHERunInfo::statistics() const
 		  break;
 		}
 
-		if(fracAcc<1e-6)continue;
 
 		double fracBr = proc->accepted().sum() > 0.0 ?
 		                proc->acceptedBr().sum() / proc->accepted().sum() : 1;
-		double sigmaFin = sigmaAvg * fracAcc;
+		double sigmaFin = fracAcc < 1e-6? 0: sigmaAvg * fracAcc;
 		double sigmaFinBr = sigmaFin * fracBr;
 
 		double relErr = 1.0;
 		double relAccErr = 1.0;
 		double efferr2=0;
 
-		if (proc->killed().n() > 1) {
+		if (proc->killed().n() > 0 && fracAcc>1e-6) {
 			switch(idwtup) {
 			case 3: case -3:
 			  {


### PR DESCRIPTION
GenXSecAnalyzer: when computing the total cross section after jet matching, instead of multiplying the 
jet matching efficiency with individual cross section first and adding up the cross section from each process 
later, now we add the cross section before matching first and multiply this cross section with the total jet matching efficiency.

LHERunInfo.cc: previous version did not include the process that has zero jet matching efficiency when computing the total jet matching efficiency. It is fixed now.
