### PR TITLE
Removed unnecessary mutable keyword from PerformancePayloadFromTFormula

### DIFF
--- a/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h
+++ b/CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h
@@ -86,7 +86,7 @@ class PerformancePayloadFromTFormula : public PerformancePayload {
   //
   // the transient part
   //
-  mutable   std::vector< boost::shared_ptr<TFormula> > compiledFormulas_ COND_TRANSIENT;
+  std::vector< boost::shared_ptr<TFormula> > compiledFormulas_ COND_TRANSIENT;
 
  COND_SERIALIZABLE;
 };


### PR DESCRIPTION
The static analyzer complained about the existence of a non-thread
safe class being used as a mutable. Since the mutable keyword was
not necessary (the variable is never changed in a const member function)
it was removed.
