### PR TITLE
Remove unused member variable from CastorDbService

### DIFF
--- a/CalibFormats/CastorObjects/interface/CastorDbService.h
+++ b/CalibFormats/CastorObjects/interface/CastorDbService.h
@@ -58,7 +58,6 @@ class CastorDbService {
   bool makeCastorCalibrationWidth (const HcalGenericDetId& fId, CastorCalibrationWidths* fObject, 
 				 bool pedestalInADC) const;
   void buildCalibWidths();
-  mutable reco::castor::QieShape* mQieShapeCache;
   const CastorPedestals* mPedestals;
   const CastorPedestalWidths* mPedestalWidths;
   const CastorGains* mGains;

--- a/CalibFormats/CastorObjects/src/CastorDbService.cc
+++ b/CalibFormats/CastorObjects/src/CastorDbService.cc
@@ -15,7 +15,6 @@
 
 CastorDbService::CastorDbService (const edm::ParameterSet& cfg)
   : 
-  mQieShapeCache (0),
   mPedestals (0),
   mPedestalWidths (0),
   mGains (0),


### PR DESCRIPTION
An unused member variable was marked as mutable which was flagged
as a problem by the static analyzer.
