### PR TITLE
Removed use of static from components method

### DIFF
--- a/RecoTracker/TkDetLayers/src/Phase2OTECRingedLayer.cc
+++ b/RecoTracker/TkDetLayers/src/Phase2OTECRingedLayer.cc
@@ -48,7 +48,9 @@ Phase2OTECRingedLayer::fillRingPars(int i) {
 
 
 Phase2OTECRingedLayer::Phase2OTECRingedLayer(vector<const Phase2OTECRing*>& rings):
-  RingedForwardLayer(true) {
+  RingedForwardLayer(true),
+  theComponents{nullptr}
+{
   //They should be already R-ordered. TO BE CHECKED!!
   //sort( theRings.begin(), theRings.end(), DetLessR());
 

--- a/RecoTracker/TkDetLayers/src/Phase2OTECRingedLayer.h
+++ b/RecoTracker/TkDetLayers/src/Phase2OTECRingedLayer.h
@@ -5,8 +5,8 @@
 
 #include "TrackingTools/DetLayers/interface/RingedForwardLayer.h"
 #include "Phase2OTECRing.h"
-#include<array>
-
+#include <array>
+#include <atomic>
 
 /** A concrete implementation for Phase 2 OT EC layer 
  *  built out of Phase2OTECRings
@@ -17,7 +17,11 @@ class Phase2OTECRingedLayer GCC11_FINAL : public RingedForwardLayer {
  public:
   Phase2OTECRingedLayer(std::vector<const Phase2OTECRing*>& rings)  __attribute__ ((cold));
   ~Phase2OTECRingedLayer()  __attribute__ ((cold));
-  
+
+  // Default implementations would not properly manage memory
+  Phase2OTECRingedLayer( const Phase2OTECRingedLayer& ) = delete;
+  Phase2OTECRingedLayer& operator=( const Phase2OTECRingedLayer&) = delete;
+
   // GeometricSearchDet interface
   
   virtual const std::vector<const GeomDet*>& basicComponents() const {return theBasicComps;}
@@ -56,6 +60,7 @@ class Phase2OTECRingedLayer GCC11_FINAL : public RingedForwardLayer {
 
  private:
   std::vector<GeomDet const*> theBasicComps;
+  mutable std::atomic<std::vector<const GeometricSearchDet*>*> theComponents;
   const Phase2OTECRing* theComps[NOTECRINGS];
   struct RingPar { float theRingR, thetaRingMin, thetaRingMax;};
   RingPar ringPars[NOTECRINGS];

--- a/RecoTracker/TkDetLayers/src/TIDLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.cc
@@ -121,7 +121,9 @@ TIDLayer::fillRingPars(int i) {
 
 
 TIDLayer::TIDLayer(vector<const TIDRing*>& rings) :
-  RingedForwardLayer(true) {
+  RingedForwardLayer(true),
+  theComponents{nullptr}
+{
   //They should be already R-ordered. TO BE CHECKED!!
   //sort( theRings.begin(), theRings.end(), DetLessR());
 

--- a/RecoTracker/TkDetLayers/src/TIDLayer.cc
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.cc
@@ -92,9 +92,18 @@ public:
 
 //hopefully is never called!
 const std::vector<const GeometricSearchDet*>& TIDLayer::components() const{
-  static std::vector<const GeometricSearchDet*> crap;
-  for ( auto c: theComps) crap.push_back(c);
-  return crap;
+  if( not theComponents) {
+    std::unique_ptr<std::vector<const GeometricSearchDet*>> temp( new std::vector<const GeometricSearchDet*>() );
+    temp->reserve(3);
+    for ( auto c: theComps) temp->push_back(c);
+    std::vector<const GeometricSearchDet*>* expected = nullptr;
+    if(theComponents.compare_exchange_strong(expected,temp.get())) {
+      //this thread set the value
+      temp.release();
+    }
+  }
+
+  return *theComponents;
  }
 
 
@@ -171,6 +180,8 @@ TIDLayer::computeDisk( const vector<const TIDRing*>& rings) const
 
 TIDLayer::~TIDLayer(){
   for (auto c : theComps) delete c;
+
+  delete theComponents.load();
 } 
 
   

--- a/RecoTracker/TkDetLayers/src/TIDLayer.h
+++ b/RecoTracker/TkDetLayers/src/TIDLayer.h
@@ -4,8 +4,8 @@
 
 #include "TrackingTools/DetLayers/interface/RingedForwardLayer.h"
 #include "TIDRing.h"
-#include<array>
-
+#include <array>
+#include <atomic>
 
 /** A concrete implementation for TID layer 
  *  built out of TIDRings
@@ -16,6 +16,10 @@ class TIDLayer GCC11_FINAL : public RingedForwardLayer {
  public:
   TIDLayer(std::vector<const TIDRing*>& rings)  __attribute__ ((cold));
   ~TIDLayer()  __attribute__ ((cold));
+
+  //default implementations would not manage memory correctly
+  TIDLayer(const TIDLayer&) = delete;
+  TIDLayer& operator=(const TIDLayer&) = delete;
   
   // GeometricSearchDet interface
   
@@ -57,6 +61,7 @@ class TIDLayer GCC11_FINAL : public RingedForwardLayer {
 
  private:
   std::vector<GeomDet const*> theBasicComps;
+  mutable std::atomic<std::vector<const GeometricSearchDet*>*> theComponents;
   const TIDRing* theComps[3];
   struct RingPar { float theRingR, thetaRingMin, thetaRingMax;};
   RingPar ringPars[3];


### PR DESCRIPTION
The components method was using a static variable to hold the return
value from the function. Comments on the function stated it was hoped
that the routine would never be called. To fix the thread safety problem
and minimize the memory usage, the code was changed to use an std::atomic
pointer to cache the return value if and only if components was called.

This problem was found by the static analyzer.
