### PR TITLE
Change the track associator in HI Track Validation

### DIFF
--- a/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 # track associator settings
 from Validation.RecoTrack.TrackValidation_cff import trackAssociatorByHitsRecoDenom
-trackAssociatorByHitsRecoDenom.SimToRecoDenominator = cms.string('reco')
 
 # reco track quality cuts
 from Validation.RecoTrack.cuts_cff import *

--- a/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/TrackValidationHeavyIons_cff.py
@@ -1,11 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 # track associator settings
-import SimTracker.TrackAssociatorProducers.trackAssociatorByHits_cfi
-trackAssociatorByHitsRecoDenom = SimTracker.TrackAssociatorProducers.trackAssociatorByHits_cfi.trackAssociatorByHits.clone(
-    SimToRecoDenominator = cms.string('reco'),
-    UseGrouped = cms.bool(False) 
-    )
+from Validation.RecoTrack.TrackValidation_cff import trackAssociatorByHitsRecoDenom
+trackAssociatorByHitsRecoDenom.SimToRecoDenominator = cms.string('reco')
 
 # reco track quality cuts
 from Validation.RecoTrack.cuts_cff import *


### PR DESCRIPTION
This PR is a workaround to the "RuntimeError: An entry in sequence tracksValidationFS has no label" error observed in recent IBs for HI Validation. That problem seems to be caused by PR #7175 (main authors are @Dr15Jones and @davidlange6). Please see other comments in that PR, PR #7175 .
