### PR TITLE
Misc ICC errors fixes.

### DIFF
--- a/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaDoubleLegCombFilter.cc
@@ -111,7 +111,7 @@ void  HLTEgammaDoubleLegCombFilter::matchCands(const std::vector<math::XYZPoint>
 
   for(size_t secondLegNr=0;secondLegNr<secondLegP3s.size();secondLegNr++){
     if(!std::binary_search(matched2ndLegs.begin(),matched2ndLegs.end(),secondLegNr)){ //wasnt matched already
-      matchedCands.push_back(std::make_pair<int,int>(-1,secondLegNr));
+      matchedCands.push_back(std::make_pair<int,int>(-1, static_cast<int>(secondLegNr)));
     }
   }
 }

--- a/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
@@ -51,7 +51,7 @@ EcalRecHit::ESFlags ESRecHitSimAlgo::evalAmplitude(float * results, const ESData
 
   // A from analytical formula:
   constexpr float t1 = 20.;
-  #ifdef __clang__
+  #if defined(__clang__) || defined(__INTEL_COMPILER)
   const float A_1 = 1./( std::pow(w/n*(t1),n) * std::exp(n-w*(t1)) );
   #else
   constexpr float A_1 = 1./( std::pow(w/n*(t1),n) * std::exp(n-w*(t1)) );


### PR DESCRIPTION
- ICC complains because we are trying to create a `std::pair<int, int>` from what is actually a `(int, size_t)` pair. This fix will workaround the problem by forcing a downcast of `size_t` to `int`, but it would result in a real issue if `secondLegNr` was > 2**32. However, I assume  we would have other problems in that case.
- Like clang, ICC does not have `constexpr` version for `std::exp` / `std::pow` and in general anything coming from `cmath`. I think this is actually more an unsupported gcc extension.
