### PR TITLE
Make GeometrySurface code fully const correct

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/GlobalTrackerMuonAlignment.cc
@@ -758,10 +758,10 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
 
     if( isolatedMuonMode_ ){      //------------------------------- Isolated Muon -----
       const Surface& refSurface = innerMuTSOS.surface(); 
-      ReferenceCountingPointer<TangentPlane> 
+      ConstReferenceCountingPointer<TangentPlane> 
 	tpMuLocal(refSurface.tangentPlane(innerMuTSOS.localPosition()));
       Nl = tpMuLocal->normalVector();
-      ReferenceCountingPointer<TangentPlane> 
+      ConstReferenceCountingPointer<TangentPlane> 
       tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
       GlobalVector Ng = tpMuGlobal->normalVector();
       Surface* surf = (Surface*)&refSurface;
@@ -819,7 +819,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
 	if(debug_) std::cout<<" -----    Out - In -----"<<std::endl;
 
         const Surface& refSurface = innerMuTSOS.surface(); 
-	ReferenceCountingPointer<TangentPlane> 
+	ConstReferenceCountingPointer<TangentPlane> 
 	  tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
 	Nl = tpMuGlobal->normalVector();
 
@@ -876,7 +876,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
 	if(debug_) std::cout<<" -----    In - Out -----"<<std::endl;
 
 	const Surface& refSurface = outerMuTSOS.surface(); 
-	ReferenceCountingPointer<TangentPlane> 
+	ConstReferenceCountingPointer<TangentPlane> 
 	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
 	Nl = tpMuGlobal->normalVector();
 		
@@ -934,7 +934,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrack
 	continue;
 
 	const Surface& refSurface = outerMuTSOS.surface(); 
-	ReferenceCountingPointer<TangentPlane> 
+	ConstReferenceCountingPointer<TangentPlane> 
 	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
 	Nl = tpMuGlobal->normalVector();
 		
@@ -1477,10 +1477,10 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
     if( isolatedMuonMode_ ){      //------------------------------- Isolated Muon --- Out-In --
       if(debug_) std::cout<<" ------ Isolated (out-in) ----- "<<std::endl;
       const Surface& refSurface = innerMuTSOS.surface(); 
-      ReferenceCountingPointer<TangentPlane> 
+      ConstReferenceCountingPointer<TangentPlane> 
 	tpMuLocal(refSurface.tangentPlane(innerMuTSOS.localPosition()));
       Nl = tpMuLocal->normalVector();
-      ReferenceCountingPointer<TangentPlane> 
+      ConstReferenceCountingPointer<TangentPlane> 
       tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
       GlobalVector Ng = tpMuGlobal->normalVector();
       Surface* surf = (Surface*)&refSurface;
@@ -1550,7 +1550,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
 	if(debug_) std::cout<<" -----    Out - In -----"<<std::endl;
 
         const Surface& refSurface = innerMuTSOS.surface(); 
-	ReferenceCountingPointer<TangentPlane> 
+	ConstReferenceCountingPointer<TangentPlane> 
 	  tpMuGlobal(refSurface.tangentPlane(innerMuTSOS.globalPosition()));
 	Nl = tpMuGlobal->normalVector();
 
@@ -1617,7 +1617,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
 	if(debug_) std::cout<<" -----    In - Out -----"<<std::endl;
 
 	const Surface& refSurface = outerMuTSOS.surface(); 
-	ReferenceCountingPointer<TangentPlane> 
+	ConstReferenceCountingPointer<TangentPlane> 
 	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
 	Nl = tpMuGlobal->normalVector();
 		
@@ -1686,7 +1686,7 @@ void GlobalTrackerMuonAlignment::analyzeTrackTrajectory
 	continue;
 
 	const Surface& refSurface = outerMuTSOS.surface(); 
-	ReferenceCountingPointer<TangentPlane> 
+	ConstReferenceCountingPointer<TangentPlane> 
 	  tpMuGlobal(refSurface.tangentPlane(outerMuTSOS.globalPosition()));
 	Nl = tpMuGlobal->normalVector();
 		

--- a/DataFormats/GeometrySurface/interface/Cone.h
+++ b/DataFormats/GeometrySurface/interface/Cone.h
@@ -64,9 +64,9 @@ public:
   virtual Side side( const GlobalPoint& p, Scalar tolerance) const;
 
   // Tangent plane to surface from global point
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const;
   // Tangent plane to surface from local point
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const;
 
 
 private:

--- a/DataFormats/GeometrySurface/interface/Cylinder.h
+++ b/DataFormats/GeometrySurface/interface/Cylinder.h
@@ -72,9 +72,9 @@ public:
   virtual Side side( const LocalPoint& p, Scalar toler) const;
 
   /// tangent plane to surface from global point
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const;
   /// tangent plane to surface from local point
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const;
 
   /// tangent plane to surface from global point
   Plane fastTangent(const GlobalPoint& aPoint) const{

--- a/DataFormats/GeometrySurface/interface/Plane.h
+++ b/DataFormats/GeometrySurface/interface/Plane.h
@@ -82,10 +82,10 @@ public:
   }
 
   /// tangent plane to surface from global point
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const GCC11_FINAL;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const GCC11_FINAL;
 
   /// tangent plane to surface from local point
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const GCC11_FINAL;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const GCC11_FINAL;
 
 private:
   void setPosPrec() {

--- a/DataFormats/GeometrySurface/interface/Surface.h
+++ b/DataFormats/GeometrySurface/interface/Surface.h
@@ -139,10 +139,10 @@ public:
    * The return type is a ReferenceCountingPointer, so the plane 
    * will be deleted automatically when no longer needed.
    */
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const = 0;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const GlobalPoint&) const = 0;
   /** Tangent plane to surface from local point.
    */
-  virtual ReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const = 0;
+  virtual ConstReferenceCountingPointer<TangentPlane> tangentPlane (const LocalPoint&) const = 0;
 
 protected:
   MediumProperties theMediumProperties;

--- a/DataFormats/GeometrySurface/src/Cone.cc
+++ b/DataFormats/GeometrySurface/src/Cone.cc
@@ -5,18 +5,18 @@
 
 #include <iostream>
 
-ReferenceCountingPointer<TangentPlane> Cone::tangentPlane (const GlobalPoint&) const {
+ConstReferenceCountingPointer<TangentPlane> Cone::tangentPlane (const GlobalPoint&) const {
   // FIXME: to be implemented...
   std::cout << "*** WARNING: Cone::tangentPlane not implemented." <<std::endl;
   abort();
-  return ReferenceCountingPointer<TangentPlane>();
+  return ConstReferenceCountingPointer<TangentPlane>();
 }
 
-ReferenceCountingPointer<TangentPlane> Cone::tangentPlane (const LocalPoint&) const {
+ConstReferenceCountingPointer<TangentPlane> Cone::tangentPlane (const LocalPoint&) const {
   // FIXME: to be implemented...
   std::cout << "*** WARNING: Cone::tangentPlane not implemented." <<std::endl;
   abort();
-  return ReferenceCountingPointer<TangentPlane>();
+  return ConstReferenceCountingPointer<TangentPlane>();
 }
 
 Surface::Side Cone::side( const GlobalPoint& p, Scalar tolerance) const {

--- a/DataFormats/GeometrySurface/src/Cylinder.cc
+++ b/DataFormats/GeometrySurface/src/Cylinder.cc
@@ -13,13 +13,13 @@ Surface::Side Cylinder::side( const LocalPoint& p, Scalar toler) const
 	  (lz>0 ? SurfaceOrientation::positiveSide : SurfaceOrientation::negativeSide));
 }
 
-ReferenceCountingPointer<TangentPlane> 
+ConstReferenceCountingPointer<TangentPlane> 
 Cylinder::tangentPlane (const LocalPoint& aPoint) const
 {
   return tangentPlane(toGlobal(aPoint));
 }
 
-ReferenceCountingPointer<TangentPlane> 
+ConstReferenceCountingPointer<TangentPlane> 
 Cylinder::tangentPlane (const GlobalPoint& aPoint) const
 {
   //
@@ -38,7 +38,7 @@ Cylinder::tangentPlane (const GlobalPoint& aPoint) const
 //   // local z defined by x and y (should point outwards from axis)
 //   GlobalVector zPlane(xPlane.cross(yPlane));
   // rotation constructor will normalize...
-  return ReferenceCountingPointer<TangentPlane>(new TangentPlane(aPoint,
+  return ConstReferenceCountingPointer<TangentPlane>(new TangentPlane(aPoint,
 								 RotationType(xPlane,
 									      yPlane)
 								 ));

--- a/DataFormats/GeometrySurface/src/Plane.cc
+++ b/DataFormats/GeometrySurface/src/Plane.cc
@@ -2,14 +2,14 @@
 #include "DataFormats/GeometrySurface/interface/TangentPlane.h"
 
 
-ReferenceCountingPointer<TangentPlane> 
+ConstReferenceCountingPointer<TangentPlane> 
 Plane::tangentPlane (const GlobalPoint&) const
 {
-  return ReferenceCountingPointer<TangentPlane>(const_cast<Plane*>(this));
+  return ConstReferenceCountingPointer<TangentPlane>(this);
 }
 
-ReferenceCountingPointer<TangentPlane> 
+ConstReferenceCountingPointer<TangentPlane> 
 Plane::tangentPlane (const LocalPoint&) const
 {
-  return ReferenceCountingPointer<TangentPlane>(const_cast<Plane*>(this));
+  return ConstReferenceCountingPointer<TangentPlane>(this);
 }

--- a/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
+++ b/FastSimulation/TrajectoryManager/src/TrajectoryManager.cc
@@ -593,7 +593,7 @@ TrajectoryManager::makeTrajectoryState( const DetLayer* layer,
 {
   GlobalPoint  pos( pp.X(), pp.Y(), pp.Z());
   GlobalVector mom( pp.Px(), pp.Py(), pp.Pz());
-  ReferenceCountingPointer<TangentPlane> plane = layer->surface().tangentPlane(pos);
+  auto plane = layer->surface().tangentPlane(pos);
   return TrajectoryStateOnSurface
     (GlobalTrajectoryParameters( pos, mom, TrackCharge( pp.charge()), field), *plane);
 }

--- a/RecoMuon/GlobalTrackingTools/src/GlobalMuonTrackMatcher.cc
+++ b/RecoMuon/GlobalTrackingTools/src/GlobalMuonTrackMatcher.cc
@@ -522,8 +522,8 @@ GlobalMuonTrackMatcher::samePlane(const TrajectoryStateOnSurface& tsos1,
   const float maxtilt = 0.999;
   const float maxdist = 0.01; // in cm
 
-  ReferenceCountingPointer<TangentPlane> p1(tsos1.surface().tangentPlane(tsos1.localPosition()));
-  ReferenceCountingPointer<TangentPlane> p2(tsos2.surface().tangentPlane(tsos2.localPosition()));
+  auto p1(tsos1.surface().tangentPlane(tsos1.localPosition()));
+  auto p2(tsos2.surface().tangentPlane(tsos2.localPosition()));
 
   bool returnValue = ( (fabs(p1->normalVector().dot(p2->normalVector())) > maxtilt) || (fabs((p1->toLocal(p2->position())).z()) < maxdist) ) ? true : false;
 

--- a/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
+++ b/RecoParticleFlow/PFSimProducer/plugins/ConvBremSeedProducer.cc
@@ -544,7 +544,7 @@ ConvBremSeedProducer::makeTrajectoryState( const DetLayer* layer,
   GlobalPoint  pos( pp.X(), pp.Y(), pp.Z());
   GlobalVector mom( pp.Px(), pp.Py(), pp.Pz());
 
-  ReferenceCountingPointer<TangentPlane> plane = layer->surface().tangentPlane(pos);
+  auto plane = layer->surface().tangentPlane(pos);
 
   return TrajectoryStateOnSurface
     (GlobalTrajectoryParameters( pos, mom, TrackCharge( pp.charge()), field), *plane);

--- a/TrackingTools/GeomPropagators/src/AnalyticalPropagator.cc
+++ b/TrackingTools/GeomPropagators/src/AnalyticalPropagator.cc
@@ -95,7 +95,7 @@ AnalyticalPropagator::propagateWithPath(const FreeTrajectoryState& fts,
   //
 
   //try {
-    ReferenceCountingPointer<TangentPlane> plane(cylinder.tangentPlane(x));  // need to be here until tsos is created!
+    ConstReferenceCountingPointer<TangentPlane> plane(cylinder.tangentPlane(x));  // need to be here until tsos is created!
     return propagatedStateWithPath(fts,*plane,gtp,s);
   /*
   } catch(...) {


### PR DESCRIPTION
Changed the return value of tangentPlane to be a 'const' smart pointer.
This avoids accidently changing internals data of the surface classes.

This problem was found by the static analyzer.
