### PR TITLE
L1Trigger/CSCTrackFinder: disable optimizer on Clang

### DIFF
--- a/L1Trigger/CSCTrackFinder/BuildFile.xml
+++ b/L1Trigger/CSCTrackFinder/BuildFile.xml
@@ -16,3 +16,8 @@
 <flags ADD_SUBDIR="1"/>
 <flags CXXFLAGS="-O1"/>
 <flags REM_CXXFLAGS="-flto"/>
+<!-- Disable optimizer due to high memory usage by Clang
+     (3.6 RC1 and trunk, 2015 Jan 28) -->
+<release name=".*_CLANG_.*">
+  <flags CXXFLAGS="-O0"/>
+</release>


### PR DESCRIPTION
Clang is causing issues (not only to CMS) with high memory usage in
some scenarios. vpp_\* generates files require 12.5GB of RSS with Clang,
while only using 0.5GB with GCC. This was tested from Clang 3.3 to Clang
3.6 and trunk (2015 Jan 28).

This is reported upstream and few people already looking into it. Also
causes issue to KDE/QT people.

Also this causes machine building CMSSW with Clang to go offline in Jenkins.
The job continues to run on build machine, but Jenkins looses the state. Then 
Jenkins assumes that machine is free and could launch another CMSSW build
job causing more stress on machine.

Tested with GCC and Clang. Bypassing.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
