### PR TITLE
Implement postLS1 as an Era - core parts

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -687,6 +687,24 @@ class ConfigBuilder(object):
 			if len(mixingDict)!=0:
 				raise Exception('unused mixing specification: '+mixingDict.keys().__str__())
 
+			# Some config components need to know what the bunch spacing is to be
+			# able to configure themselves properly. To do this enable an era (aka
+			# cms.Modifier) for the particular bunch spacing.
+			if hasattr(self.process,"mix") and hasattr(self.process.mix,"bunchspace") :
+				# Extend the comma seperated list, but take care not to add erroneous commas
+				if self.process.mix.bunchspace == 25 :
+					if self._options.era : self._options.era+=",bunchspacing25ns"
+					#else : self._options.era="bunchspacing25ns" # see note below about why this is commented out
+				elif self.process.mix.bunchspace == 50 :
+					if self._options.era : self._options.era+=",bunchspacing50ns"
+					#else : self._options.era="bunchspacing50ns" # see note below about why this is commented out
+				# The two "else" statements above are commented out so that nothing is added to the eras
+				# unless another era has already been specified. Once eras are fully adopted it is expected
+				# that a bunchspacing era should always be added, and the "else"s can be uncommented. During
+				# the early stages of the adoption process however it is required that if an "--era" option
+				# is *not* specified then everything proceeds *exactly* as before. 
+
+
         # load the geometry file
         try:
 		if len(self.stepMap):

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2089,7 +2089,15 @@ class ConfigBuilder(object):
         self.pythonCfgCode += "# using: \n# "+__version__[1:-1]+"\n# "+__source__[1:-1]+'\n'
         self.pythonCfgCode += "# with command line options: "+self._options.arguments+'\n'
         self.pythonCfgCode += "import FWCore.ParameterSet.Config as cms\n\n"
-        self.pythonCfgCode += "process = cms.Process('"+self.process.name_()+"')\n\n"
+        if hasattr(self._options,"era") and self._options.era :
+            self.pythonCfgCode += "from Configuration.StandardSequences.Eras import eras\n\n"
+            self.pythonCfgCode += "process = cms.Process('"+self.process.name_()+"'" # Start of the line, finished after the loop
+            # Multiple eras can be specified in a comma seperated list
+            for requestedEra in self._options.era.split(",") :
+                self.pythonCfgCode += ",eras."+requestedEra
+            self.pythonCfgCode += ")\n\n" # end of the line
+        else :
+            self.pythonCfgCode += "process = cms.Process('"+self.process.name_()+"')\n\n"
 
         self.pythonCfgCode += "# import of standard configurations\n"
         for module in self.imports:

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -346,6 +346,11 @@ expertSettings.add_option("--slhc",
                           default=None,
                           dest="slhc")
 
+expertSettings.add_option("--era",
+                          help="Specify which era to use (e.g. \"run2\")",
+                          default=None,
+                          dest="era")
+
 expertSettings.add_option("--evt_type",
                           help="specify the gen fragment",
                           default=None,

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -237,5 +237,28 @@ def OptionsFromItems(items):
 
         options.prefix = "igprof -t cmsRun -%s" % profilerType
         
+    # If an "era" argument was supplied make sure it is one of the valid possibilities
+    if options.era :
+        from Configuration.StandardSequences.Eras import eras
+        from FWCore.ParameterSet.Config import Modifier, ModifierChain
+        # Split the string by commas to check individual eras
+        requestedEras = options.era.split(",")
+        # Warn the user if they are explicitly setting an era that should be set automatically by the
+        # ConfigBuilder.
+        internalUseEras=["bunchspacing25ns","bunchspacing50ns"]
+        for era in internalUseEras :
+            if requestedEras.count(era) > 0 :
+                print "WARNING: You have explicitly set '"+era+"' with the '--era' command. It is advised that you let ConfigBuilder decide whether to add that or not."
+        # Check that the entry is a valid era
+        for era in requestedEras :
+            if not hasattr( eras, era ) : # Not valid, so print a helpful message
+                validOptions="" # Create a stringified list of valid options to print to the user
+                for key in eras.__dict__ :
+                    if internalUseEras.count(key) > 0 : continue # Don't tell the user about things they should leave alone
+                    if isinstance( eras.__dict__[key], Modifier ) or isinstance( eras.__dict__[key], ModifierChain ) :
+                        if validOptions!="" : validOptions+=", " 
+                        validOptions+="'"+key+"'"
+                raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (era, validOptions) )
+
     return options
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+class Eras (object):
+    """
+    Dummy container for all the cms.Modifier instances that config fragments
+    can use to selectively configure depending on what scenario is active.
+    """
+    def __init__(self):
+        self.run2 = cms.Modifier()
+        self.bunchspacing25ns = cms.Modifier()
+        self.bunchspacing50ns = cms.Modifier()
+
+eras=Eras()

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -40,6 +40,51 @@ def customisePostLS1(process):
 
     return process
 
+def customiseRun2EraExtras(process):
+    """
+    This function should be used in addition to the "--era run2" cmsDriver
+    option so that it can perform the last few changes that the era hasn't
+    implemented yet.
+    
+    As functionality is added to the run2 era the corresponding line will
+    be removed from this function until the whole function is removed.
+    
+    Currently does exactly the same as "customisePostLS1", since the run2
+    era doesn't make any changes yet (coming in later pull requests).
+    """
+    # deal with CSC separately:
+    process = customise_csc_PostLS1(process)
+
+    # deal with L1 Emulation separately:
+    customiseSimL1EmulatorForPostLS1(process)
+
+    # deal with FastSim separately:
+    process = customise_fastSimPostLS1(process)
+
+    # all the rest:
+    if hasattr(process,'g4SimHits'):
+        process=customise_Sim(process)
+    if hasattr(process,'DigiToRaw'):
+        process=customise_DigiToRaw(process)
+    if hasattr(process,'RawToDigi'):
+        process=customise_RawToDigi(process)
+    if hasattr(process,'reconstruction'):
+        process=customise_Reco(process)
+    if hasattr(process,'digitisation_step'):
+        process=customise_Digi(process)
+    if hasattr(process,'HLTSchedule'):
+        process=customise_HLT(process)
+    if hasattr(process,'L1simulation_step'):
+        process=customise_L1Emulator(process)
+    if hasattr(process,'dqmoffline_step'):
+        process=customise_DQM(process)
+    if hasattr(process,'dqmHarvesting'):
+        process=customise_harvesting(process)
+    if hasattr(process,'validation_step'):
+        process=customise_Validation(process)
+
+    return process
+    
 
 def digiEventContent(process):
     #extend the event content


### PR DESCRIPTION
This is the first part of a split down #6784.  The only thing it adds is
- an "--era" option to cmsDriver
- 3 blank eras (i.e. they don't do anything yet) - `run2`, `bunchspacing25ns` and `bunchspacing50ns`
- a new customise function `customiseRun2EraExtras` which currently is a direct copy of `customisePostLS1`

`bunchspacing25ns` and `bunchspacing50ns` are not intended to be specified by the user, ConfigBuilder adds them automatically depending on what pileup is requested.
`run2` will eventually be the `customisePostLS1` customisation implemented as an era.  Each portion will be added incrementally in further pull requests.  Until it is complete, the `customiseRun2EraExtras` customisation can be used to do the parts that haven't been implemented yet (currently everything).
So commands that originally had

```
--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1
```

can be tested using eras with:

```
--era run2 --customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customiseRun2EraExtras
```

Eventually when `run2` is fully implemented the customisation will not be required.

I tested the 1320.0 workflow (since it is one of the postLS1 ones) with and without the above replacement, then diff-ed the resulting configuration files and diff-ed the result of applying `edmConfigDump` on those files.  There is absolutely no difference in the dumps, for the files themselves there are small expected differences (different customisation name, run2 era specified).  Note that diff equivalency is not expected once `run2` actually does something, for reasons that will be explained in the relevant subsequent pull requests.

@davidlange6, @Dr15Jones

@franzoni - this is just the core parts, it doesn't show how to use the eras yet.  I'll ping you again when there is a good example (or you can look at #6784 but there's a lot in there to wade through).
