### PR TITLE
Ecalmultifit hlt from731patch1

### DIFF
--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -27,10 +27,16 @@ class EcalUncalibRecHitMultiFitAlgo
   ~EcalUncalibRecHitMultiFitAlgo() { };
   EcalUncalibratedRecHit makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrix &noisecor, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX);
   void disableErrorCalculation() { _computeErrors = false; }
+  void setDoPrefit(bool b) { _doPrefit = b; }
+  void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
   
  private:
    PulseChiSqSNNLS _pulsefunc;
+   PulseChiSqSNNLS _pulsefuncSingle;
    bool _computeErrors;
+   bool _doPrefit;
+   double _prefitMaxChiSq;
+   BXVector _singlebx;
 
 };
 

--- a/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
@@ -11,3 +11,6 @@ typedef Eigen::Matrix<double,10,Eigen::Dynamic,0,10,10> SamplePulseMatrix;
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 typedef Eigen::LLT<PulseMatrix> PulseDecompLLT;
 typedef Eigen::LDLT<PulseMatrix> PulseDecompLDLT;
+
+typedef Eigen::Matrix<double,1,1> SingleMatrix;
+typedef Eigen::Matrix<double,1,1> SingleVector;

--- a/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
@@ -27,11 +27,14 @@ class PulseChiSqSNNLS {
     
     double ChiSq() const { return _chisq; }
     void disableErrorCalculation() { _computeErrors = false; }
+    void setMaxIters(int n) { _maxiters = n;}
+    void setMaxIterWarnings(bool b) { _maxiterwarnings = b;}
 
   protected:
     
     bool Minimize(const SampleMatrix &samplecor, double pederr, const FullSampleMatrix &fullpulsecov);
     bool NNLS();
+    bool OnePulseMinimize();
     bool updateCov(const SampleMatrix &samplecor, double pederr, const FullSampleMatrix &fullpulsecov);
     double ComputeChiSq();
     double ComputeApproxUncertainty(unsigned int ipulse);
@@ -64,6 +67,8 @@ class PulseChiSqSNNLS {
     
     double _chisq;
     bool _computeErrors;
+    int _maxiters;
+    bool _maxiterwarnings;
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -43,8 +43,8 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
     bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
   }
   
-  bool doPrefit = ps.getParameter<bool>("doPrefit");
-  multiFitMethod_.setDoPrefit(doPrefit);
+  doPrefitEB_ = ps.getParameter<bool>("doPrefitEB");
+  doPrefitEE_ = ps.getParameter<bool>("doPrefitEE");
 
   prefitMaxChiSqEB_ = ps.getParameter<double>("prefitMaxChiSqEB");
   prefitMaxChiSqEE_ = ps.getParameter<double>("prefitMaxChiSqEE");
@@ -269,12 +269,14 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 aped  = &peds->endcap(hashedIndex);
                 aGain = &gains->endcap(hashedIndex);
                 gid   = &grps->endcap(hashedIndex);
+                multiFitMethod_.setDoPrefit(doPrefitEE_);
 		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEE_);
         } else {
                 unsigned int hashedIndex = EBDetId(detid).hashedIndex();
                 aped  = &peds->barrel(hashedIndex);
                 aGain = &gains->barrel(hashedIndex);
                 gid   = &grps->barrel(hashedIndex);
+                multiFitMethod_.setDoPrefit(doPrefitEB_);
 		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB_);
         }
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -42,7 +42,13 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   if (useLumiInfoRunHeader_) {
     bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
   }
+  
+  bool doPrefit = ps.getParameter<bool>("doPrefit");
+  multiFitMethod_.setDoPrefit(doPrefit);
 
+  double prefitMaxChiSq = ps.getParameter<double>("prefitMaxChiSq");
+  multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSq);
+  
   // algorithm to be used for timing
   timealgo_ = ps.getParameter<std::string>("timealgo");
   

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -48,7 +48,6 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
 
   prefitMaxChiSqEB_ = ps.getParameter<double>("prefitMaxChiSqEB");
   prefitMaxChiSqEE_ = ps.getParameter<double>("prefitMaxChiSqEE");
-  //multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB, prefitMaxChiSqEE);
   
   // algorithm to be used for timing
   timealgo_ = ps.getParameter<std::string>("timealgo");

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -46,8 +46,9 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   bool doPrefit = ps.getParameter<bool>("doPrefit");
   multiFitMethod_.setDoPrefit(doPrefit);
 
-  double prefitMaxChiSq = ps.getParameter<double>("prefitMaxChiSq");
-  multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSq);
+  prefitMaxChiSqEB_ = ps.getParameter<double>("prefitMaxChiSqEB");
+  prefitMaxChiSqEE_ = ps.getParameter<double>("prefitMaxChiSqEE");
+  //multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB, prefitMaxChiSqEE);
   
   // algorithm to be used for timing
   timealgo_ = ps.getParameter<std::string>("timealgo");
@@ -269,11 +270,13 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 aped  = &peds->endcap(hashedIndex);
                 aGain = &gains->endcap(hashedIndex);
                 gid   = &grps->endcap(hashedIndex);
+		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEE_);
         } else {
                 unsigned int hashedIndex = EBDetId(detid).hashedIndex();
                 aped  = &peds->barrel(hashedIndex);
                 aGain = &gains->barrel(hashedIndex);
                 gid   = &grps->barrel(hashedIndex);
+		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB_);
         }
 
         pedVec[0] = aped->mean_x12;
@@ -342,7 +345,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 const SampleMatrix &noisecormat = noisecor(barrel,gain);
                 const FullSampleVector &fullpulse = barrel ? fullpulseEB : fullpulseEE;
                 const FullSampleMatrix &fullpulsecov = barrel ? fullpulsecovEB : fullpulsecovEE;
-                                
+
                 uncalibRecHit = multiFitMethod_.makeRecHit(*itdg, aped, aGain, noisecormat,fullpulse,fullpulsecov,activeBX);
                 
                 // === time computation ===

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -121,6 +121,8 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 bool kPoorRecoFlagEE_;
                 double chi2ThreshEB_;
                 double chi2ThreshEE_;
+                bool doPrefitEB_;
+                bool doPrefitEE_;
 		double prefitMaxChiSqEB_;
 		double prefitMaxChiSqEE_;
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -121,7 +121,8 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 bool kPoorRecoFlagEE_;
                 double chi2ThreshEB_;
                 double chi2ThreshEE_;
-
+		double prefitMaxChiSqEB_;
+		double prefitMaxChiSqEE_;
 
  private:
                 void fillInputs(const edm::ParameterSet& params);

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -15,7 +15,8 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     useLumiInfoRunHeader = cms.bool(True),
     
     doPrefit = cms.bool(False),
-    prefitMaxChiSq = cms.double(25.),
+    prefitMaxChiSqEB = cms.double(25.),
+    prefitMaxChiSqEE = cms.double(10.),
     
     
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -13,6 +13,11 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
     ampErrorCalculation = cms.bool(True),
     useLumiInfoRunHeader = cms.bool(True),
+    
+    doPrefit = cms.bool(False),
+    prefitMaxChiSq = cms.double(25.),
+    
+    
 
     # decide which algorithm to be use to calculate the jitter
     timealgo = cms.string("RatioMethod"),

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -14,7 +14,8 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     ampErrorCalculation = cms.bool(True),
     useLumiInfoRunHeader = cms.bool(True),
     
-    doPrefit = cms.bool(False),
+    doPrefitEB = cms.bool(False),
+    doPrefitEE = cms.bool(False),
     prefitMaxChiSqEB = cms.double(25.),
     prefitMaxChiSqEE = cms.double(10.),
     


### PR DESCRIPTION
@argiro @bendavid @matteosan1 @fwyzard @gennai 

This includes fast version of multifit ECAL local reconstruction meant for HLT. 
Default parameters are for offline reconstruction (full multifit). 

The default behavior is the same as before, so no change is expected. The fast version of the local reconstruction will be triggered by changing the parameters doPrefitEB and doPrefitEE via the HLT menu.

These changes will be ported to 7.4.X branch also.
