### PR TITLE
Return a const MagVolume from findVolume

### DIFF
--- a/MagneticField/Layers/interface/MagBLayer.h
+++ b/MagneticField/Layers/interface/MagBLayer.h
@@ -32,7 +32,7 @@ public:
   virtual ~MagBLayer();
 
   /// Find the volume containing a point, with a given tolerance
-  MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
+  const MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
   
   /// Lowest radius of the layer
   double minR() const {return theRMin;}

--- a/MagneticField/Layers/interface/MagBRod.h
+++ b/MagneticField/Layers/interface/MagBRod.h
@@ -31,7 +31,7 @@ public:
   virtual ~MagBRod();
 
   /// Find the volume containing a point, with a given tolerance
-  MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
+  const MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
 
   /// Phi of rod start
   Geom::Phi<float> minPhi() const {return thePhiMin;}

--- a/MagneticField/Layers/interface/MagBSector.h
+++ b/MagneticField/Layers/interface/MagBSector.h
@@ -30,7 +30,7 @@ public:
   virtual ~MagBSector();  
 
   /// Find the volume containing a point, with a given tolerance
-  MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
+  const MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
 
   /// Phi of sector start
   Geom::Phi<float> minPhi() const {return thePhiMin;}

--- a/MagneticField/Layers/interface/MagBSlab.h
+++ b/MagneticField/Layers/interface/MagBSlab.h
@@ -29,7 +29,7 @@ public:
   virtual ~MagBSlab();
 
   /// Find the volume containing a point, with a given tolerance
-  MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
+  const MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
 
   /// Lower Z bound
   double minZ() const { return theZMin;}

--- a/MagneticField/Layers/interface/MagELayer.h
+++ b/MagneticField/Layers/interface/MagELayer.h
@@ -22,7 +22,7 @@ public:
   virtual ~MagELayer();
 
   /// Find the volume containing a point, with a given tolerance
-  MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
+  const MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
 
   /// Lower Z bound
   double minZ() const {return theZMin;}

--- a/MagneticField/Layers/interface/MagESector.h
+++ b/MagneticField/Layers/interface/MagESector.h
@@ -24,7 +24,7 @@ public:
   virtual ~MagESector();
 
   /// Find the volume containing a point, with a given tolerance
-  MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
+  const MagVolume * findVolume(const GlobalPoint & gp, double tolerance) const;
 
   /// Phi of sector start
   Geom::Phi<float> minPhi() const {return thePhiMin;}

--- a/MagneticField/Layers/src/MagBLayer.cc
+++ b/MagneticField/Layers/src/MagBLayer.cc
@@ -57,8 +57,8 @@ MagBLayer::~MagBLayer() {
 }
 
 
-MagVolume* MagBLayer::findVolume(const GlobalPoint & gp, double tolerance) const {
-  MagVolume * result = 0;
+const MagVolume* MagBLayer::findVolume(const GlobalPoint & gp, double tolerance) const {
+  const MagVolume * result = 0;
 
   //In case the layer is composed of a single volume...
   if (theSingleVolume) {

--- a/MagneticField/Layers/src/MagBRod.cc
+++ b/MagneticField/Layers/src/MagBRod.cc
@@ -46,8 +46,8 @@ MagBRod::~MagBRod() {
   }
 }
 
-MagVolume * MagBRod::findVolume(const GlobalPoint & gp, double tolerance) const {
-  MagVolume * result = 0;
+const MagVolume * MagBRod::findVolume(const GlobalPoint & gp, double tolerance) const {
+  const MagVolume * result = 0;
   float Z = gp.z();
 
   int bin = 0;

--- a/MagneticField/Layers/src/MagBSector.cc
+++ b/MagneticField/Layers/src/MagBSector.cc
@@ -27,8 +27,8 @@ MagBSector::~MagBSector(){
   }
 }
 
-MagVolume * MagBSector::findVolume(const GlobalPoint & gp, double tolerance) const {
-  MagVolume * result = 0;
+const MagVolume * MagBSector::findVolume(const GlobalPoint & gp, double tolerance) const {
+  const MagVolume * result = 0;
   Geom::Phi<float> phi = gp.phi();
 
   // FIXME : use a binfinder

--- a/MagneticField/Layers/src/MagBSlab.cc
+++ b/MagneticField/Layers/src/MagBSlab.cc
@@ -28,7 +28,7 @@ MagBSlab::~MagBSlab(){
 }
 
 
-MagVolume* MagBSlab::findVolume(const GlobalPoint & gp, double tolerance) const {
+const MagVolume* MagBSlab::findVolume(const GlobalPoint & gp, double tolerance) const {
   for(vector<MagVolume*>::const_iterator ivol = theVolumes.begin();
 	ivol != theVolumes.end(); ++ivol) {
     // FIXME : use a binfinder

--- a/MagneticField/Layers/src/MagELayer.cc
+++ b/MagneticField/Layers/src/MagELayer.cc
@@ -30,7 +30,7 @@ MagELayer::~MagELayer(){
 }
 
 
-MagVolume * 
+const MagVolume * 
 MagELayer::findVolume(const GlobalPoint & gp, double tolerance) const {
   for(vector<MagVolume*>::const_iterator ivol = theVolumes.begin();
 	ivol != theVolumes.end(); ++ivol) {

--- a/MagneticField/Layers/src/MagESector.cc
+++ b/MagneticField/Layers/src/MagESector.cc
@@ -29,8 +29,8 @@ MagESector::~MagESector(){
 }
 
 
-MagVolume * MagESector::findVolume(const GlobalPoint & gp, double tolerance) const {
-  MagVolume * result = 0;
+const MagVolume * MagESector::findVolume(const GlobalPoint & gp, double tolerance) const {
+  const MagVolume * result = 0;
   float Z = gp.z();
 
   // FIXME : use a binfinder


### PR DESCRIPTION
The static analyzer complained that the const function, findVolume,
was returning a non-const pointer to data being held by the object.
Although no code was found which altered the returned value, making
the return be const avoids possible problems in the future.
