### PR TITLE
Made Reflection::solid a const member function

### DIFF
--- a/DetectorDescription/Core/src/Reflection.h
+++ b/DetectorDescription/Core/src/Reflection.h
@@ -13,7 +13,7 @@ namespace DDI {
     Reflection(const DDSolid & s);
     double volume() const;
     void stream(std::ostream &) const;
-    const DDSolid & solid() { return s_; } 
+    const DDSolid & solid() const { return s_; } 
   private:
     DDSolid s_;  
   };      


### PR DESCRIPTION
The static analyzer complained that a class which held a Reflection
object by pointer was calling a non-const function, 'solid', of
Reflection from a const function of the holding class. Since 'solid'
never actually changed the state of a Reflection it was trivial
to change to be const.
