### PR TITLE
Activate all products needed by Sim/Reco-level mixing (Fast Simulation)  (7_2_X)

### DIFF
--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -99,6 +99,8 @@ namespace edm {
             std::string label;
 
             branchesActivate(TypeID(typeid(std::vector<reco::Track>)).friendlyClassName(),std::string(""),tag,label);
+            branchesActivate(TypeID(typeid(std::vector<reco::TrackExtra>)).friendlyClassName(),std::string(""),tag,label);
+            branchesActivate(TypeID(typeid(edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >)).friendlyClassName(),std::string(""),tag,label);
 	    // note: no crossing frame is foreseen to be used for this object type
 
 	    LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;


### PR DESCRIPTION
Mixing in pileup at the Sim/Reco level, as done in fast simulation, does not work, because, while three different product types are mixed, only one of these product types is kept on input.  This simple pull request adds one line of code to keep each of the other two needed product types.  Note: This mixing currently works accidentally if only one pileup file is specified, because the first pileup file is opened at construction time, before the list of product types to be dropped is activated.    So, Sim/Reco level mixing fails only if more than one pileup file is specified.   This pull request fixes the failure.
This problem was reported by Jason Gran.
