### PR TITLE
Fix in TrackerTopology migration of TrackingTruthAccumulator

### DIFF
--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -620,14 +620,16 @@ namespace // Unnamed namespace for things only used in this file
 			if( processType==pSimHit->processType() && particleType==pSimHit->particleType() && pdgId==pSimHit->particleType() )
 			{
 				++numberOfHits;
-				if( newDetector.det() == DetId::Tracker ) ++numberOfTrackerHits;
-
 				oldLayer=newLayer;
-				newLayer=tTopo->layer( newDetector );
+                                newLayer=0;
+				if( newDetector.det() == DetId::Tracker ) {
+                                  ++numberOfTrackerHits;
 
-				// Count hits using layers for glued detectors
-				// newlayer !=0 excludes Muon layers set to 0 by LayerFromDetid
-				if( (oldLayer!=newLayer || (oldLayer==newLayer && oldDetector.subdetId()!=newDetector.subdetId())) && newLayer!=0 ) ++matchedHits;
+                                  newLayer=tTopo->layer( newDetector );
+
+                                  // Count hits using layers for glued detectors
+                                  if( (oldLayer!=newLayer || (oldLayer==newLayer && oldDetector.subdetId()!=newDetector.subdetId())) ) ++matchedHits;
+                                }
 			}
 		} // end of loop over the sim hits for this sim track
 


### PR DESCRIPTION
This PR adds the missing check for `newDetector.detId() == DetId::Tracker` before calling `TrackerTopology::layer()`. I took the liberty to restructure slitghly the surround code (do the check once instead of "essentially three times").

Tested on top of 740pre5. PR #7335+this shows no differences wrt. 740pre5 (also in the "Tracking Particle Matched Hits" plot).
