### PR TITLE
Retrieve collections from LazyTools

### DIFF
--- a/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
+++ b/RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h
@@ -90,6 +90,13 @@ class EcalClusterLazyToolsBase {
   //  std::vector<int> flagsexcl_;
   //  std::vector<int> severitiesexcl_;
 
+ public:
+  inline const EcalRecHitCollection *getEcalEBRecHitCollection(void){return ebRecHits_;};
+  inline const EcalRecHitCollection *getEcalEERecHitCollection(void){return eeRecHits_;};
+  inline const EcalRecHitCollection *getEcalESRecHitCollection(void){return esRecHits_;};
+  inline const EcalIntercalibConstants& getEcalIntercalibConstants(void){return icalMap;};
+  inline const edm::ESHandle<EcalLaserDbService>& getLaserHandle(void){return laser;};
+  
 }; // class EcalClusterLazyToolsBase
 
 template<class EcalClusterToolsImpl> 


### PR DESCRIPTION
EcalClusterLazyTools are widely used in many analysis.
Once the object is built, it has as private members the handles to many collections.
With this modification, it is also possible to retrieve the collections from the object, instead of declaring handles separately.
