### PR TITLE
RecoHI/HiJetAlgos: resolve GCC warnings about unknown pragma

### DIFF
--- a/RecoHI/HiJetAlgos/BuildFile.xml
+++ b/RecoHI/HiJetAlgos/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="RecoJets/JetProducers"/>
 <use   name="DataFormats/HeavyIonEvent"/>
-<Flags CXXFLAGS="-frounding-math"/>
+<Flags CXXFLAGS="-frounding-math -Wno-unknown-pragmas"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
GCC correctly ignores unknown (Clang) pragma. These warnings needs to be
disabled in command line and not via #pragma GCC diagnostic, which does
not correctly work with GCC (a long standing bug in C++ preprocessor).

Marking #pragma as GCC will not help as warning is Clang specific, not
yet supported in GCC.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
