### PR TITLE
Lowering of HO cluster Threshold in Particle Flow

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -371,6 +371,20 @@ def customise_Reco(process):
             )
         )
 
+    #Lower Thresholds also for Clusters!!!    
+
+    for p in process.particleFlowClusterHO.seedFinder.thresholdsByDetector:
+        p.seedingThreshold = cms.double(0.08)
+
+    for p in process.particleFlowClusterHO.initialClusteringStep.thresholdsByDetector:
+        p.gatheringThreshold = cms.double(0.05)
+
+    for p in process.particleFlowClusterHO.pfClusterBuilder.recHitEnergyNorms:
+        p.recHitEnergyNorm = cms.double(0.05)
+
+    process.particleFlowClusterHO.pfClusterBuilder.positionCalc.logWeightDenominator = cms.double(0.05)
+    process.particleFlowClusterHO.pfClusterBuilder.allCellsPositionCalc.logWeightDenominator = cms.double(0.05)
+
     return process
 
 


### PR DESCRIPTION
In the previous configurations for 74X the hit threshold was changed but not the cluster one.
This PR changes the cluster threshold to be compatible with the SiPMs

This is relevant for very high pt jets [leakage] and can be used in the future [using the filled hoEnergy]
for muon ID 

In the validation very small changes are expected with some possible small improvements in MET or jets
