### PR TITLE
fix beamspot for wf for minbias pu events

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -607,14 +607,9 @@ step1FastUpg2015Defaults =merge([{'-s':'GEN,SIM,RECO,EI,HLT:@relval,VALIDATION',
                            '--relval':'27000,3000'},
                            step1Defaults])
 step1FastPUNewMixing =merge([{'-s':'GEN,SIM,RECO',
-                           '--fast':'',
-                           '--conditions'  :'auto:run2_mc',
-                           '--magField'    :'38T_PostLS1',
-                           '--customise'   :'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1',
                            '--eventcontent':'FASTPU',
-                           '--datatier':'GEN-SIM-RECO',
-                           '--relval':'27000,3000'},
-                           step1Defaults])
+                           '--datatier':'GEN-SIM-RECO'},
+                           step1FastUpg2015Defaults])
 
 
 #step1FastDefaults


### PR DESCRIPTION
I edited the FastSim wf for minbias events to be used as pileup input.

I changed the beamspot from 'Realistic8TeVCollision' to the more appropriate 'NominalCollision2015',
and while on it removed a couple of obsolete lines.
