### PR TITLE
fix to primary vertex in fastsim simevent

### DIFF
--- a/FastSimulation/Event/src/FBaseSimEvent.cc
+++ b/FastSimulation/Event/src/FBaseSimEvent.cc
@@ -370,23 +370,11 @@ FBaseSimEvent::addParticles(const HepMC::GenEvent& myGenEvent) {
   // Primary vertex
   HepMC::GenVertex* primaryVertex = *(myGenEvent.vertices_begin());
 
-  // Beginning of workaround a bug in pythia particle gun
-  // ??? what is happening here ??? may be becuase pythia guns can have some bogus particles at the start of the event ???
-  unsigned primaryMother = primaryVertex->particles_in_size();
-  if ( primaryMother ) {
-    unsigned partId = (*(primaryVertex->particles_in_const_begin()))->pdg_id();
-    if ( abs(partId) == 2212 ) primaryMother = 0;
-  }
-  // End of workaround a bug in pythia particle gun
-
+  // unit transformation (needs review)
   XYZTLorentzVector primaryVertexPosition(primaryVertex->position().x()/10.,
 					  primaryVertex->position().y()/10.,
 					  primaryVertex->position().z()/10.,
 					  primaryVertex->position().t()/10.);
-  // Actually this is the true end of the workaround
-  primaryVertexPosition *= (1-primaryMother);
-  // THE END.
-
 
   // Set the main vertex
   myFilter->setMainVertex(primaryVertexPosition);


### PR DESCRIPTION
I removed a line that looked rather harmful than useful,
produced bogus results when applying FastSim on events from the exhume generator,
and caused pythia8 evens to have sim-level primary vertices at (0,0,0).
