### PR TITLE
Remove improper call to edm::Ref constructor call

### DIFF
--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -203,7 +203,7 @@ MuonAssociatorByHits::associateRecoToSim( const edm::RefToBaseVector<reco::Track
   auto bareAssoc = helper_.associateRecoToSimIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {
     for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma; ++itma) {
-        outputCollection.insert(tC[it->first], std::make_pair(edm::Ref<TrackingParticleCollection>(TPCollectionH, itma->idx), itma->quality));
+        outputCollection.insert(tC[it->first], std::make_pair(TPCollectionH[itma->idx], itma->quality));
     }
   }
 
@@ -242,7 +242,7 @@ MuonAssociatorByHits::associateSimToReco( const edm::RefToBaseVector<reco::Track
   auto bareAssoc = helper_.associateSimToRecoIndices(tH, TPCollectionH, resources);
   for (auto it = bareAssoc.begin(), ed = bareAssoc.end(); it != ed; ++it) {
     for (auto itma = it->second.begin(), edma = it->second.end(); itma != edma; ++itma) {
-        outputCollection.insert(edm::Ref<TrackingParticleCollection>(TPCollectionH, it->first),
+        outputCollection.insert(TPCollectionH[ it->first],
                                 std::make_pair(tC[itma->idx], itma->quality));
     }
   }

--- a/SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h
+++ b/SimTracker/TrackAssociation/interface/TrackAssociatorByHits.h
@@ -82,10 +82,10 @@ class TrackAssociatorByHits : public TrackAssociatorBase {
   
   int getShared(std::vector<SimHitIdpr>&, 
 		std::vector<SimHitIdpr>&,
-		TrackingParticleCollection::const_iterator) const;
+		TrackingParticle const& ) const;
 
   template<typename iter>
-  int getDoubleCount(iter,iter,TrackerHitAssociator*,TrackingParticleCollection::const_iterator) const;
+  int getDoubleCount(iter,iter,TrackerHitAssociator*,TrackingParticle const&) const;
 
  private:
   // ----- member data

--- a/SimTracker/TrackAssociation/src/TrackAssociatorByChi2.cc
+++ b/SimTracker/TrackAssociation/src/TrackAssociatorByChi2.cc
@@ -128,10 +128,11 @@ RecoToSimCollection TrackAssociatorByChi2::associateRecoToSim(const edm::RefToBa
 
   RecoToSimCollection  outputCollection;
 
-  TrackingParticleCollection tPC;
+  //dereference the edm::Ref only once
+  std::vector<const TrackingParticle*> tPC;
   tPC.reserve(tPCH.size());
   for(auto const& ref: tPCH) {
-    tPC.push_back(*ref);
+    tPC.push_back(&(*ref));
   }
 
   int tindex=0;
@@ -155,20 +156,21 @@ RecoToSimCollection TrackAssociatorByChi2::associateRecoToSim(const edm::RefToBa
     recoTrackCovMatrix.Invert();
 
     int tpindex =0;
-    for (TrackingParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
+    for (auto tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
 	
       //skip tps with a very small pt
-      //if (sqrt(tp->momentum().perp2())<0.5) continue;
-      int charge = tp->charge();
+      //if (sqrt((*tp)->momentum().perp2())<0.5) continue;
+      int charge = (*tp)->charge();
       if (charge==0) continue;
-      Basic3DVector<double> momAtVtx(tp->momentum().x(),tp->momentum().y(),tp->momentum().z());
-      Basic3DVector<double> vert=(Basic3DVector<double>) tp->vertex();
+      Basic3DVector<double> momAtVtx((*tp)->momentum().x(),(*tp)->momentum().y(),(*tp)->momentum().z());
+      Basic3DVector<double> vert=(Basic3DVector<double>) (*tp)->vertex();
 
       double chi2 = getChi2(rParameters,recoTrackCovMatrix,momAtVtx,vert,charge,bs);
       
       if (chi2<chi2cut) {
+        //NOTE: tPCH and tPC have the same index for the same object
 	outputCollection.insert(tC[tindex], 
-				std::make_pair(edm::Ref<TrackingParticleCollection>(tPCH, tpindex),
+				std::make_pair(tPCH[tpindex],
 					       -chi2));//-chi2 because the Association Map is ordered using std::greater
       }
     }
@@ -188,26 +190,27 @@ SimToRecoCollection TrackAssociatorByChi2::associateSimToReco(const edm::RefToBa
 
   SimToRecoCollection  outputCollection;
 
-  TrackingParticleCollection tPC;
+  //dereference the edm::Ref only once
+  std::vector<const TrackingParticle*> tPC;
   tPC.reserve(tPCH.size());
   for(auto const& ref: tPCH) {
-    tPC.push_back(*ref);
+    tPC.push_back(&(*ref));
   }
 
   int tpindex =0;
-  for (TrackingParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
+  for (auto tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
     
     //skip tps with a very small pt
-    //if (sqrt(tp->momentum().perp2())<0.5) continue;
-    int charge = tp->charge();
+    //if (sqrt((*tp)->momentum().perp2())<0.5) continue;
+    int charge = (*tp)->charge();
     if (charge==0) continue;
     
     LogDebug("TrackAssociator") << "=========LOOKING FOR ASSOCIATION===========" << "\n"
-				<< "TrackingParticle #"<<tpindex<<" with pt=" << sqrt(tp->momentum().perp2()) << "\n"
+				<< "TrackingParticle #"<<tpindex<<" with pt=" << sqrt((*tp)->momentum().perp2()) << "\n"
 				<< "===========================================" << "\n";
     
-    Basic3DVector<double> momAtVtx(tp->momentum().x(),tp->momentum().y(),tp->momentum().z());
-    Basic3DVector<double> vert(tp->vertex().x(),tp->vertex().y(),tp->vertex().z());
+    Basic3DVector<double> momAtVtx((*tp)->momentum().x(),(*tp)->momentum().y(),(*tp)->momentum().z());
+    Basic3DVector<double> vert((*tp)->vertex().x(),(*tp)->vertex().y(),(*tp)->vertex().z());
       
     int tindex=0;
     for (RefToBaseVector<reco::Track>::const_iterator rt=tC.begin(); rt!=tC.end(); rt++, tindex++){
@@ -226,7 +229,8 @@ SimToRecoCollection TrackAssociatorByChi2::associateSimToReco(const edm::RefToBa
       double chi2 = getChi2(rParameters,recoTrackCovMatrix,momAtVtx,vert,charge,bs);
       
       if (chi2<chi2cut) {
-	outputCollection.insert(edm::Ref<TrackingParticleCollection>(tPCH, tpindex),
+        //NOTE: tPCH and tPC have the same index for the same object
+	outputCollection.insert(tPCH[tpindex],
 				std::make_pair(tC[tindex],
 					       -chi2));//-chi2 because the Association Map is ordered using std::greater
       }

--- a/SimTracker/TrackAssociation/src/TrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/TrackAssociatorByHits.cc
@@ -82,12 +82,13 @@ TrackAssociatorByHits::associateRecoToSim(const edm::RefToBaseVector<reco::Track
   std::vector< SimHitIdpr> matchedIds; 
   RecoToSimCollection  outputCollection;
   
-  TrackerHitAssociator * associate = new TrackerHitAssociator(*e, conf_);
+  TrackerHitAssociator associate{ *e, conf_ };
   
-  TrackingParticleCollection tPC;
+  //dereference the edm::Refs only once
+  std::vector<TrackingParticle const*> tPC;
   tPC.reserve(TPCollectionH.size());
   for(auto const& ref: TPCollectionH) {
-    tPC.push_back(*ref);
+    tPC.push_back(&(*ref));
   }
 
   //get the ID of the recotrack  by hits 
@@ -96,7 +97,7 @@ TrackAssociatorByHits::associateRecoToSim(const edm::RefToBaseVector<reco::Track
     matchedIds.clear();
     int ri=0;//valid rechits
     //LogTrace("TrackAssociator") << "\nNEW TRACK - track number " << tindex <<" with pt =" << (*track)->pt() << " # valid=" << (*track)->found(); 
-    getMatchedIds<trackingRecHit_iterator>(matchedIds, SimTrackIds, ri, (*track)->recHitsBegin(), (*track)->recHitsEnd(), associate);
+    getMatchedIds<trackingRecHit_iterator>(matchedIds, SimTrackIds, ri, (*track)->recHitsBegin(), (*track)->recHitsEnd(), &associate);
 
     //LogTrace("TrackAssociator") << "MATCHED IDS LIST BEGIN" ;
     //for(size_t j=0; j<matchedIds.size(); j++){
@@ -110,15 +111,15 @@ TrackAssociatorByHits::associateRecoToSim(const edm::RefToBaseVector<reco::Track
     if(!matchedIds.empty()){
 
       int tpindex =0;
-      for (TrackingParticleCollection::const_iterator t = tPC.begin(); t != tPC.end(); ++t, ++tpindex) {
+      for (auto t = tPC.begin(); t != tPC.end(); ++t, ++tpindex) {
         //int nsimhit = t->trackPSimHit(DetId::Tracker).size(); 
 	//LogTrace("TrackAssociator") << "TP number " << tpindex << " pdgId=" << t->pdgId() << " with number of PSimHits: "  << nsimhit;
 	idcachev.clear();
-	nshared = getShared(matchedIds, idcachev, t);
+	nshared = getShared(matchedIds, idcachev, **t);
 
 	//if electron subtract double counting
-	if (abs(t->pdgId())==11&&(t->g4Track_end()-t->g4Track_begin())>1){
-	  nshared-=getDoubleCount<trackingRecHit_iterator>((*track)->recHitsBegin(), (*track)->recHitsEnd(), associate, t);
+	if (abs((*t)->pdgId())==11&&((*t)->g4Track_end()-(*t)->g4Track_begin())>1){
+	  nshared-=getDoubleCount<trackingRecHit_iterator>((*track)->recHitsBegin(), (*track)->recHitsEnd(), &associate, **t);
 	}
 
 	if (AbsoluteNumberOfHits) quality = static_cast<double>(nshared);
@@ -129,7 +130,7 @@ TrackAssociatorByHits::associateRecoToSim(const edm::RefToBaseVector<reco::Track
 	if(quality > cut_RecoToSim && !(ThreeHitTracksAreSpecial && ri==3 && nshared<3)){
 	  //if a track has just 3 hits we require that all 3 hits are shared
 	  outputCollection.insert(tC[tindex],
-				  std::make_pair(edm::Ref<TrackingParticleCollection>(TPCollectionH, tpindex),
+				  std::make_pair(TPCollectionH[tpindex],
 						 quality));
 //          LogTrace("TrackAssociator") << "reco::Track number " << tindex  << " with #hits=" << ri <<" pt=" << (*track)->pt() 
 //                                      << " associated to TP (pdgId, nb segments, p) = " 
@@ -144,7 +145,6 @@ TrackAssociatorByHits::associateRecoToSim(const edm::RefToBaseVector<reco::Track
     }
   }
   //LogTrace("TrackAssociator") << "% of Assoc Tracks=" << ((double)outputCollection.size())/((double)tC.size());
-  delete associate;
   outputCollection.post_insert();
   return outputCollection;
 }
@@ -166,12 +166,13 @@ TrackAssociatorByHits::associateSimToReco(const edm::RefToBaseVector<reco::Track
   std::vector< SimHitIdpr> matchedIds; 
   SimToRecoCollection  outputCollection;
 
-  TrackerHitAssociator * associate = new TrackerHitAssociator(*e, conf_);
+  TrackerHitAssociator associate(*e, conf_);
   
-  TrackingParticleCollection tPC;
+  //dereference the edm::Refs only once
+  std::vector<TrackingParticle const*> tPC;
   tPC.reserve(TPCollectionH.size());
   for(auto const& ref: TPCollectionH) {
-    tPC.push_back(*ref);
+    tPC.push_back(&(*ref));
   }
 
   //for (TrackingParticleCollection::const_iterator t = tPC.begin(); t != tPC.end(); ++t) {
@@ -190,28 +191,28 @@ TrackAssociatorByHits::associateSimToReco(const edm::RefToBaseVector<reco::Track
   for (edm::RefToBaseVector<reco::Track>::const_iterator track=tC.begin(); track!=tC.end(); track++, tindex++){
     //LogTrace("TrackAssociator") << "\nNEW TRACK - hits of track number " << tindex <<" with pt =" << (*track)->pt() << " # valid=" << (*track)->found(); 
     int ri=0;//valid rechits
-    getMatchedIds<trackingRecHit_iterator>(matchedIds, SimTrackIds, ri, (*track)->recHitsBegin(), (*track)->recHitsEnd(), associate);
+    getMatchedIds<trackingRecHit_iterator>(matchedIds, SimTrackIds, ri, (*track)->recHitsBegin(), (*track)->recHitsEnd(), &associate);
 
     //save id for the track
     std::vector<SimHitIdpr> idcachev;
     if(!matchedIds.empty()){
 	
       int tpindex =0;
-      for (TrackingParticleCollection::const_iterator t = tPC.begin(); t != tPC.end(); ++t, ++tpindex) {
+      for (auto t = tPC.begin(); t != tPC.end(); ++t, ++tpindex) {
 	idcachev.clear();
 	float totsimhit = 0; 
 	const TrackerTopology *tTopo=tTopoHand.product();
 
         //int nsimhit = trackerPSimHit.size();
 	std::vector<PSimHit> tphits;
-	//LogTrace("TrackAssociator") << "TP number " << tpindex << " pdgId=" << t->pdgId() << " with number of PSimHits: "  << nsimhit;
+	//LogTrace("TrackAssociator") << "TP number " << tpindex << " pdgId=" << (*t)->pdgId() << " with number of PSimHits: "  << nsimhit;
 
-	nshared = getShared(matchedIds, idcachev, t);
+	nshared = getShared(matchedIds, idcachev, **t);
 
-	//for(std::vector<PSimHit>::const_iterator TPhit = t->trackerPSimHit_begin(); TPhit != t->trackerPSimHit_end(); TPhit++){
-	//  unsigned int detid = TPhit->detUnitId();
-	//  DetId detId = DetId(TPhit->detUnitId());
-	//  LogTrace("TrackAssociator") <<  " hit trackId= " << TPhit->trackId() << " det ID = " << detid 
+	//for(std::vector<PSimHit>::const_iterator TPhit = (*t)->trackerPSimHit_begin(); TPhit != (*t)->trackerPSimHit_end(); TPhit++){
+	//  unsigned int detid = TPhi(*t)->detUnitId();
+	//  DetId detId = DetId(TPhi(*t)->detUnitId());
+	//  LogTrace("TrackAssociator") <<  " hit trackId= " << TPhi(*t)->trackId() << " det ID = " << detid 
 	//				      << " SUBDET = " << detId.subdetId() << " layer = " << LayerFromDetid(detId); 
 	//}
 
@@ -221,7 +222,7 @@ TrackAssociatorByHits::associateSimToReco(const edm::RefToBaseVector<reco::Track
 	  //LogTrace("TrackAssociator") << "recounting of tp hits";
 
 	  std::pair<TrackingParticleRef, TrackPSimHitRef> 
-	    clusterTPpairWithDummyTP(TrackingParticleRef(TPCollectionH,t-tPC.begin()),TrackPSimHitRef());//SimHit is dummy: for simHitTPAssociationListGreater 
+	    clusterTPpairWithDummyTP(TPCollectionH[tpindex],TrackPSimHitRef());//SimHit is dummy: for simHitTPAssociationListGreater 
 	                                                                                                 // sorting only the cluster is needed
 	  auto range = std::equal_range(simHitsTPAssoc->begin(), simHitsTPAssoc->end(), 
 					clusterTPpairWithDummyTP, SimHitTPAssociationProducer::simHitTPAssociationListGreater);
@@ -288,7 +289,7 @@ TrackAssociatorByHits::associateSimToReco(const edm::RefToBaseVector<reco::Track
 	float purity = 1.0*nshared/ri;
 	if (quality>quality_SimToReco && !(ThreeHitTracksAreSpecial && totsimhit==3 && nshared<3) && (AbsoluteNumberOfHits||(purity>purity_SimToReco))) {
 	  //if a track has just 3 hits we require that all 3 hits are shared
-	  outputCollection.insert(edm::Ref<TrackingParticleCollection>(TPCollectionH, tpindex), 
+	  outputCollection.insert(TPCollectionH[tpindex], 
 				  std::make_pair(tC[tindex],quality));
 //          LogTrace("TrackAssociator") << "TrackingParticle number " << tpindex << " with #hits=" << nsimhit 
 //                                      << " re-counted = "  << totsimhit << " nshared = " << nshared 
@@ -303,7 +304,6 @@ TrackAssociatorByHits::associateSimToReco(const edm::RefToBaseVector<reco::Track
     }
   }
   //LogTrace("TrackAssociator") << "% of Assoc TPs=" << ((double)outputCollection.size())/((double)TPCollectionH.size());
-  delete associate;
   outputCollection.post_insert();
   return outputCollection;
 }
@@ -323,7 +323,7 @@ TrackAssociatorByHits::associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> 
   std::vector< SimHitIdpr> matchedIds; 
   RecoToSimCollectionSeed  outputCollection;
   
-  TrackerHitAssociator * associate = new TrackerHitAssociator(*e, conf_);
+  TrackerHitAssociator associate(*e, conf_);
   
   const TrackingParticleCollection& tPC   = *(TPCollectionH.product());
 
@@ -336,7 +336,7 @@ TrackAssociatorByHits::associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> 
     int ri=0;//valid rechits
     int nsimhit = seed->recHits().second-seed->recHits().first;
     LogTrace("TrackAssociator") << "\nNEW SEED - seed number " << tindex << " # valid=" << nsimhit;
-    getMatchedIds<edm::OwnVector<TrackingRecHit>::const_iterator>(matchedIds, SimTrackIds, ri, seed->recHits().first, seed->recHits().second, associate );
+    getMatchedIds<edm::OwnVector<TrackingRecHit>::const_iterator>(matchedIds, SimTrackIds, ri, seed->recHits().first, seed->recHits().second, &associate );
 
     //save id for the track
     std::vector<SimHitIdpr> idcachev;
@@ -346,11 +346,11 @@ TrackAssociatorByHits::associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> 
       for (TrackingParticleCollection::const_iterator t = tPC.begin(); t != tPC.end(); ++t, ++tpindex) {
 	LogTrace("TrackAssociator") << "TP number " << tpindex << " pdgId=" << t->pdgId() << " with number of PSimHits: "  << nsimhit;
 	idcachev.clear();
-	nshared = getShared(matchedIds, idcachev, t);
+	nshared = getShared(matchedIds, idcachev, *t);
 
 	//if electron subtract double counting
 	if (abs(t->pdgId())==11&&(t->g4Track_end()-t->g4Track_begin())>1){
-	  nshared-=getDoubleCount<edm::OwnVector<TrackingRecHit>::const_iterator>(seed->recHits().first, seed->recHits().second, associate, t);
+	  nshared-=getDoubleCount<edm::OwnVector<TrackingRecHit>::const_iterator>(seed->recHits().first, seed->recHits().second, &associate, *t);
 	}
 	
 	if (AbsoluteNumberOfHits) quality = static_cast<double>(nshared);
@@ -372,7 +372,6 @@ TrackAssociatorByHits::associateRecoToSim(edm::Handle<edm::View<TrajectorySeed> 
     }
   }
   LogTrace("TrackAssociator") << "% of Assoc Seeds=" << ((double)outputCollection.size())/((double)seedCollectionH->size());
-  delete associate;
   outputCollection.post_insert();
   return outputCollection;
 }
@@ -392,7 +391,7 @@ TrackAssociatorByHits::associateSimToReco(edm::Handle<edm::View<TrajectorySeed> 
   std::vector< SimHitIdpr> matchedIds; 
   SimToRecoCollectionSeed  outputCollection;
 
-  TrackerHitAssociator * associate = new TrackerHitAssociator(*e, conf_);
+  TrackerHitAssociator associate(*e, conf_);
   
   const TrackingParticleCollection& tPC =*TPCollectionH.product();
 
@@ -403,7 +402,7 @@ TrackAssociatorByHits::associateSimToReco(edm::Handle<edm::View<TrajectorySeed> 
   for (edm::View<TrajectorySeed>::const_iterator seed=sC.begin(); seed!=sC.end(); seed++, tindex++) {
     int ri=0;//valid rechits
     LogTrace("TrackAssociator") << "\nNEW SEED - seed number " << tindex << " # valid=" << seed->recHits().second-seed->recHits().first;
-    getMatchedIds<edm::OwnVector<TrackingRecHit>::const_iterator>(matchedIds, SimTrackIds, ri, seed->recHits().first, seed->recHits().second, associate );
+    getMatchedIds<edm::OwnVector<TrackingRecHit>::const_iterator>(matchedIds, SimTrackIds, ri, seed->recHits().first, seed->recHits().second, &associate );
 
     //save id for the track
     std::vector<SimHitIdpr> idcachev;
@@ -413,7 +412,7 @@ TrackAssociatorByHits::associateSimToReco(edm::Handle<edm::View<TrajectorySeed> 
 	idcachev.clear();
         int nsimhit = t->numberOfTrackerHits();
 	LogTrace("TrackAssociator") << "TP number " << tpindex << " pdgId=" << t->pdgId() << " with number of PSimHits: "  << nsimhit;
-	nshared = getShared(matchedIds, idcachev, t);
+	nshared = getShared(matchedIds, idcachev, *t);
 	
 	if (AbsoluteNumberOfHits) quality = static_cast<double>(nshared);
 	else if(ri!=0) quality = ((double) nshared)/((double)ri);
@@ -435,7 +434,6 @@ TrackAssociatorByHits::associateSimToReco(edm::Handle<edm::View<TrajectorySeed> 
     }
   }
   LogTrace("TrackAssociator") << "% of Assoc TPs=" << ((double)outputCollection.size())/((double)TPCollectionH->size());
-  delete associate;
   outputCollection.post_insert();
   return outputCollection;
 }
@@ -491,9 +489,9 @@ void TrackAssociatorByHits::getMatchedIds(std::vector<SimHitIdpr>& matchedIds,
 
 int TrackAssociatorByHits::getShared(std::vector<SimHitIdpr>& matchedIds, 
 				     std::vector<SimHitIdpr>& idcachev,
-				     TrackingParticleCollection::const_iterator t) const {
+				     TrackingParticle const& t) const {
   int nshared = 0;
-  if (t->numberOfHits()==0) return nshared;//should use trackerPSimHit but is not const
+  if (t.numberOfHits()==0) return nshared;//should use trackerPSimHit but is not const
 
   for(size_t j=0; j<matchedIds.size(); j++){
     //LogTrace("TrackAssociator") << "now matchedId=" << matchedIds[j].first;
@@ -501,15 +499,15 @@ int TrackAssociatorByHits::getShared(std::vector<SimHitIdpr>& matchedIds,
       //only the first time we see this ID 
       idcachev.push_back(matchedIds[j]);
       
-      for (TrackingParticle::g4t_iterator g4T = t -> g4Track_begin(); g4T !=  t -> g4Track_end(); ++g4T) {
+      for (TrackingParticle::g4t_iterator g4T = t . g4Track_begin(); g4T !=  t . g4Track_end(); ++g4T) {
 //	LogTrace("TrackAssociator") << " TP   (ID, Ev, BC) = " << (*g4T).trackId() 
-//				    << ", " << t->eventId().event() << ", "<< t->eventId().bunchCrossing()
+//				    << ", " << t.eventId().event() << ", "<< t.eventId().bunchCrossing()
 //				    << " Match(ID, Ev, BC) = " <<  matchedIds[j].first
 //				    << ", " << matchedIds[j].second.event() << ", "
 //				    << matchedIds[j].second.bunchCrossing() ;
 	                            //<< "\t G4  Track Momentum " << (*g4T).momentum() 
 	                            //<< " \t reco Track Momentum " << track->momentum();  	      
-	if((*g4T).trackId() == matchedIds[j].first && t->eventId() == matchedIds[j].second){
+	if((*g4T).trackId() == matchedIds[j].first && t.eventId() == matchedIds[j].second){
 		int countedhits = std::count(matchedIds.begin(), matchedIds.end(), matchedIds[j]);
 		nshared += countedhits;
 
@@ -527,7 +525,7 @@ template<typename iter>
 int TrackAssociatorByHits::getDoubleCount(iter begin,
 					  iter end,
 					  TrackerHitAssociator* associate,
-					  TrackingParticleCollection::const_iterator t) const {
+					  TrackingParticle const& t) const {
   int doublecount = 0 ;
   std::vector<SimHitIdpr> SimTrackIdsDC;
   //  cout<<begin-end<<endl;
@@ -537,8 +535,8 @@ int TrackAssociatorByHits::getDoubleCount(iter begin,
     associate->associateHitId(*getHitPtr(it), SimTrackIdsDC);
     //    cout<<SimTrackIdsDC.size()<<endl;
     if(SimTrackIdsDC.size()>1){
-      //     cout<<(t->g4Track_end()-t->g4Track_begin())<<endl;
-      for (TrackingParticle::g4t_iterator g4T = t -> g4Track_begin(); g4T !=  t -> g4Track_end(); ++g4T) {
+      //     cout<<(t.g4Track_end()-t.g4Track_begin())<<endl;
+      for (TrackingParticle::g4t_iterator g4T = t . g4Track_begin(); g4T !=  t . g4Track_end(); ++g4T) {
 	if(find(SimTrackIdsDC.begin(), SimTrackIdsDC.end(),SimHitIdpr((*g4T).trackId(), SimTrackIdsDC.begin()->second)) != SimTrackIdsDC.end() ){
 	  idcount++;
 	}

--- a/SimTracker/TrackAssociation/src/TrackAssociatorByPosition.cc
+++ b/SimTracker/TrackAssociation/src/TrackAssociatorByPosition.cc
@@ -142,7 +142,7 @@ RecoToSimCollection TrackAssociatorByPosition::associateRecoToSim(const edm::Ref
       if (dQ < theQCut){
 	atLeastOne=true;
 	outputCollection.insert(tCH[Ti],
-				std::make_pair(edm::Ref<TrackingParticleCollection>(tPCH,TPi),-dQ));//association map with quality, is order greater-first
+				std::make_pair(tPCH[TPi],-dQ));//association map with quality, is order greater-first
 	edm::LogVerbatim("TrackAssociatorByPosition")<<"track number: "<<Ti
 						     <<" associated with dQ: "<<dQ
 						     <<" to TrackingParticle number: " <<TPi;}
@@ -152,7 +152,7 @@ RecoToSimCollection TrackAssociatorByPosition::associateRecoToSim(const edm::Ref
     }//loop over tracking particles
     if (theMinIfNoMatch && !atLeastOne && dQmin!=dQmin_default){
       outputCollection.insert(tCH[minPair.first],
-			      std::make_pair(edm::Ref<TrackingParticleCollection>(tPCH,minPair.second),-dQmin));}
+			      std::make_pair(tPCH[minPair.second],-dQmin));}
   }//loop over tracks
   outputCollection.post_insert();
   return outputCollection;
@@ -196,7 +196,7 @@ SimToRecoCollection TrackAssociatorByPosition::associateSimToReco(const edm::Ref
       double dQ= quality(trackReferenceState, simReferenceState);
       if (dQ < theQCut){
 	atLeastOne=true;
-	outputCollection.insert(edm::Ref<TrackingParticleCollection>(tPCH,TPi),
+	outputCollection.insert(tPCH[TPi],
 				std::make_pair(tCH[Ti],-dQ));//association map with quality, is order greater-first
 	edm::LogVerbatim("TrackAssociatorByPosition")<<"TrackingParticle number: "<<TPi
 						     <<" associated with dQ: "<<dQ
@@ -206,7 +206,7 @@ SimToRecoCollection TrackAssociatorByPosition::associateSimToReco(const edm::Ref
 	minPair = std::make_pair(TPi,Ti);}
     }//loop over tracks
     if (theMinIfNoMatch && !atLeastOne && dQmin!=dQmin_default){
-      outputCollection.insert(edm::Ref<TrackingParticleCollection>(tPCH,minPair.first),
+      outputCollection.insert(tPCH[minPair.first],
 			      std::make_pair(tCH[minPair.second],-dQmin));}
   }//loop over tracking particles
   

--- a/SimTracker/TrackAssociation/src/TrackGenAssociatorByChi2.cc
+++ b/SimTracker/TrackAssociation/src/TrackGenAssociatorByChi2.cc
@@ -28,10 +28,11 @@ RecoToGenCollection TrackGenAssociatorByChi2::associateRecoToGen(const edm::RefT
 
   RecoToGenCollection  outputCollection;
 
-  GenParticleCollection tPC;
+  //dereference the edm::Ref's only once
+  std::vector<const GenParticle*> tPC;
   tPC.reserve(tPCH.size());
   for(auto const& ref: tPCH) {
-    tPC.push_back(*ref);
+    tPC.push_back(&(*ref));
   }
 
   int tindex=0;
@@ -55,20 +56,21 @@ RecoToGenCollection TrackGenAssociatorByChi2::associateRecoToGen(const edm::RefT
     recoTrackCovMatrix.Invert();
 
     int tpindex =0;
-    for (GenParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
+    for (auto tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
 	
       //skip tps with a very small pt
-      //if (sqrt(tp->momentum().perp2())<0.5) continue;
-      int charge = tp->charge();
+      //if (sqrt((*tp)->momentum().perp2())<0.5) continue;
+      int charge = (*tp)->charge();
       if (charge==0) continue;
-      Basic3DVector<double> momAtVtx(tp->momentum().x(),tp->momentum().y(),tp->momentum().z());
-      Basic3DVector<double> vert=(Basic3DVector<double>) tp->vertex();
+      Basic3DVector<double> momAtVtx((*tp)->momentum().x(),(*tp)->momentum().y(),(*tp)->momentum().z());
+      Basic3DVector<double> vert=(Basic3DVector<double>) (*tp)->vertex();
 
       double chi2 = getChi2(rParameters,recoTrackCovMatrix,momAtVtx,vert,charge,bs);
       
       if (chi2<chi2cut) {
+        //NOTE: tPCH and tPC have the same index for the same object
 	outputCollection.insert(tC[tindex], 
-				std::make_pair(edm::Ref<GenParticleCollection>(tPCH, tpindex),
+				std::make_pair(tPCH[tpindex],
 					       -chi2));//-chi2 because the Association Map is ordered using std::greater
       }
     }
@@ -89,26 +91,27 @@ GenToRecoCollection TrackGenAssociatorByChi2::associateGenToReco(const edm::RefT
 
   GenToRecoCollection  outputCollection;
 
-  GenParticleCollection tPC;
+  //dereference the edm::Refs only once
+  std::vector<GenParticle const*> tPC;
   tPC.reserve(tPCH.size());
   for(auto const& ref: tPCH) {
-    tPC.push_back(*ref);
+    tPC.push_back(&(*ref));
   }
 
   int tpindex =0;
-  for (GenParticleCollection::const_iterator tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
+  for (auto tp=tPC.begin(); tp!=tPC.end(); tp++, ++tpindex){
     
     //skip tps with a very small pt
-    //if (sqrt(tp->momentum().perp2())<0.5) continue;
-    int charge = tp->charge();
+    //if (sqrt((*tp)->momentum().perp2())<0.5) continue;
+    int charge = (*tp)->charge();
     if (charge==0) continue;
     
     LogDebug("TrackAssociator") << "=========LOOKING FOR ASSOCIATION===========" << "\n"
-				<< "TrackingParticle #"<<tpindex<<" with pt=" << sqrt(tp->momentum().perp2()) << "\n"
+				<< "TrackingParticle #"<<tpindex<<" with pt=" << sqrt((*tp)->momentum().perp2()) << "\n"
 				<< "===========================================" << "\n";
     
-    Basic3DVector<double> momAtVtx(tp->momentum().x(),tp->momentum().y(),tp->momentum().z());
-    Basic3DVector<double> vert(tp->vertex().x(),tp->vertex().y(),tp->vertex().z());
+    Basic3DVector<double> momAtVtx((*tp)->momentum().x(),(*tp)->momentum().y(),(*tp)->momentum().z());
+    Basic3DVector<double> vert((*tp)->vertex().x(),(*tp)->vertex().y(),(*tp)->vertex().z());
       
     int tindex=0;
     for (RefToBaseVector<reco::Track>::const_iterator rt=tC.begin(); rt!=tC.end(); rt++, tindex++){
@@ -127,7 +130,8 @@ GenToRecoCollection TrackGenAssociatorByChi2::associateGenToReco(const edm::RefT
       double chi2 = getChi2(rParameters,recoTrackCovMatrix,momAtVtx,vert,charge,bs);
       
       if (chi2<chi2cut) {
-	outputCollection.insert(edm::Ref<GenParticleCollection>(tPCH, tpindex),
+        //NOTE: tPCH and tPC have the same index for the same object
+	outputCollection.insert(tPCH[tpindex],
 				std::make_pair(tC[tindex],
 					       -chi2));//-chi2 because the Association Map is ordered using std::greater
       }

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsImpl.h
@@ -86,10 +86,10 @@ class TrackAssociatorByHitsImpl : public reco::TrackToTrackingParticleAssociator
   
   int getShared(std::vector<SimHitIdpr>&, 
 		std::vector<SimHitIdpr>&,
-		TrackingParticleCollection::const_iterator) const;
+		TrackingParticle const&) const;
 
   template<typename iter>
-  int getDoubleCount(iter,iter,TrackerHitAssociator*,TrackingParticleCollection::const_iterator) const;
+  int getDoubleCount(iter,iter,TrackerHitAssociator*,TrackingParticle const&) const;
 
 
   // ----- member data

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByPositionImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByPositionImpl.cc
@@ -143,7 +143,7 @@ RecoToSimCollection TrackAssociatorByPositionImpl::associateRecoToSim(const edm:
       if (dQ < theQCut){
 	atLeastOne=true;
 	outputCollection.insert(tCH[Ti],
-				std::make_pair(edm::Ref<TrackingParticleCollection>(tPCH,TPi),-dQ));//association map with quality, is order greater-first
+				std::make_pair(tPCH[TPi],-dQ));//association map with quality, is order greater-first
 	edm::LogVerbatim("TrackAssociatorByPositionImpl")<<"track number: "<<Ti
 						     <<" associated with dQ: "<<dQ
 						     <<" to TrackingParticle number: " <<TPi;}
@@ -153,7 +153,7 @@ RecoToSimCollection TrackAssociatorByPositionImpl::associateRecoToSim(const edm:
     }//loop over tracking particles
     if (theMinIfNoMatch && !atLeastOne && dQmin!=dQmin_default){
       outputCollection.insert(tCH[minPair.first],
-			      std::make_pair(edm::Ref<TrackingParticleCollection>(tPCH,minPair.second),-dQmin));}
+			      std::make_pair(tPCH[minPair.second],-dQmin));}
   }//loop over tracks
   outputCollection.post_insert();
   return outputCollection;
@@ -195,7 +195,7 @@ SimToRecoCollection TrackAssociatorByPositionImpl::associateSimToReco(const edm:
       double dQ= quality(trackReferenceState, simReferenceState);
       if (dQ < theQCut){
 	atLeastOne=true;
-	outputCollection.insert(edm::Ref<TrackingParticleCollection>(tPCH,TPi),
+	outputCollection.insert(tPCH[TPi],
 				std::make_pair(tCH[Ti],-dQ));//association map with quality, is order greater-first
 	edm::LogVerbatim("TrackAssociatorByPositionImpl")<<"TrackingParticle number: "<<TPi
 						     <<" associated with dQ: "<<dQ
@@ -205,7 +205,7 @@ SimToRecoCollection TrackAssociatorByPositionImpl::associateSimToReco(const edm:
 	minPair = std::make_pair(TPi,Ti);}
     }//loop over tracks
     if (theMinIfNoMatch && !atLeastOne && dQmin!=dQmin_default){
-      outputCollection.insert(edm::Ref<TrackingParticleCollection>(tPCH,minPair.first),
+      outputCollection.insert(tPCH[minPair.first],
 			      std::make_pair(tCH[minPair.second],-dQmin));}
   }//loop over tracking particles
   


### PR DESCRIPTION
The associator was constructing an edm::Ref by passing it an
edm::RefVector and an index. However, the index used was one into
the edm::RefVector but the constructor requires the index to be back
to the original collection to which the edm::RefVector associates.
The only way the associator ever worked correctly was when the edm::RefVector
used contained entries for every item in the original collection.
The problematic edm::Ref constructor will be removed in another commit.
This problem was found by David Dagenhart.
