### PR TITLE
Update on muon NoBPTX path names

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py
@@ -2,10 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 MuonNoBptxPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_L2Mu20_NoVertex_3Sta_NoBPTX3BX_NoHalo_v", # Run2 proposal
+        "HLT_L2Mu35_NoVertex_3Sta_NoBPTX3BX_NoHalo_v", # Run2 proposal
         "HLT_L2Mu10_NoVertex_NoBPTX_v",
         "HLT_L2Mu10_NoVertex_NoBPTX3BX_NoHalo_v",
-        "HLT_L2Mu30_NoVertex_3Sta_NoBPTX3BX_NoHalo_v"
+        "HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_NoHalo_v"
         #"HLT_L2Mu20_NoVertex_2Cha_NoBPTX3BX_NoHalo_v"  # Run1 frozenHLT
         ),
     #recMuonLabel  = cms.InputTag("muons"),


### PR DESCRIPTION
Backport from 74X_PR

We changed the muon NoBPTX path names in
HLTriggerOffline/Exotica/python/analyses/hltExoticaMuonNoBptx_cff.py

paths added:
HLT_L2Mu35_NoVertex_3Sta_NoBPTX3BX_NoHalo
HLT_L2Mu40_NoVertex_3Sta_NoBPTX3BX_NoHalo
paths removed:
HLT_L2Mu20_NoVertex_3Sta_NoBPTX3BX_NoHalo
HLT_L2Mu30_NoVertex_3Sta_NoBPTX3BX_NoHalo
