### PR TITLE
Adding dxyError and dzError to Candidate

### DIFF
--- a/DataFormats/Candidate/interface/Candidate.h
+++ b/DataFormats/Candidate/interface/Candidate.h
@@ -263,6 +263,11 @@ namespace reco {
     }
 
     virtual const Track * bestTrack() const {return nullptr;}	
+ 
+    /// uncertainty on dz 
+    virtual float dzError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+    /// uncertainty on dxy
+    virtual float dxyError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
 
     virtual bool isElectron() const = 0;
     virtual bool isMuon() const = 0;

--- a/DataFormats/Candidate/interface/Candidate.h
+++ b/DataFormats/Candidate/interface/Candidate.h
@@ -28,7 +28,7 @@
 class OverlapChecker;
 
 namespace reco {
-  class Track; 
+  class Track;
   class Candidate {
   public:
     typedef size_t size_type;
@@ -265,9 +265,9 @@ namespace reco {
     virtual const Track * bestTrack() const {return nullptr;}	
  
     /// uncertainty on dz 
-    virtual float dzError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+    virtual float dzError() const {return 0;} // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
     /// uncertainty on dxy
-    virtual float dxyError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
+    virtual float dxyError() const {return 0;} // { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
 
     virtual bool isElectron() const = 0;
     virtual bool isMuon() const = 0;

--- a/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
+++ b/DataFormats/ParticleFlowCandidate/interface/PFCandidate.h
@@ -166,6 +166,10 @@ namespace reco {
       else
         return nullptr;
     }
+    /// uncertainty on dz 
+    virtual float dzError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+    /// uncertainty on dxy
+    virtual float dxyError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
 
     /// set gsftrack reference 
     void setGsfTrackRef(const reco::GsfTrackRef& ref);   

--- a/DataFormats/RecoCandidate/interface/RecoCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoCandidate.h
@@ -57,6 +57,12 @@ namespace reco {
     enum TrackType { noTrackType, recoTrackType, gsfTrackType };
     ///track type
     virtual TrackType bestTrackType() const;
+    /// uncertainty on dz 
+    virtual float dzError() const; 
+    /// uncertainty on dxy
+    virtual float dxyError() const; 
+
+
   protected:
     /// check if two components overlap
     template<typename R>

--- a/DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h
+++ b/DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h
@@ -31,6 +31,12 @@ namespace reco {
       else
         return nullptr;
     }
+
+    /// uncertainty on dz 
+    virtual float dzError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dzError(); else return 0; }
+    /// uncertainty on dxy
+    virtual float dxyError() const { const Track * tr=bestTrack(); if(tr!=nullptr) return tr->dxyError(); else return 0; }
+ 
   };
 }
 

--- a/DataFormats/RecoCandidate/src/RecoCandidate.cc
+++ b/DataFormats/RecoCandidate/src/RecoCandidate.cc
@@ -80,3 +80,20 @@ RecoCandidate::TrackType RecoCandidate::bestTrackType() const {
     return gsfTrackType;
   return noTrackType;
 }
+
+float RecoCandidate::dzError() const 
+{
+  const Track * tr=bestTrack(); 
+  if(tr!=nullptr) 
+    return tr->dzError(); 
+  else 
+    return 0; 
+}
+float RecoCandidate::dxyError() const 
+{
+  const Track * tr=bestTrack(); 
+  if(tr!=nullptr) 
+    return tr->dxyError(); 
+  else 
+    return 0; 
+}


### PR DESCRIPTION
As discussed in private thread, the DF/TrackReco is _not_ pull in Candidate so that the obvious implementation need to be repeated in derived classes (others have different implementation, such as PackedCandidates)

@gpetruc @VinInn 
