### PR TITLE
Run jet reco properly on miniAOD

### DIFF
--- a/CommonTools/RecoAlgos/plugins/BuildFile.xml
+++ b/CommonTools/RecoAlgos/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
   <use   name="DataFormats/MuonReco"/>
   <use   name="DataFormats/JetReco"/>
   <use   name="DataFormats/METReco"/>
+  <use   name="DataFormats/PatCandidates"/>
   <use   name="DataFormats/HcalRecHit"/>
   <use   name="SimDataFormats/TrackingAnalysis"/>
   <use   name="TrackingTools/PatternTools"/>

--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -20,19 +20,21 @@
 
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/PatCandidates/interface/Jet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "CommonTools/UtilAlgos/interface/StringCutObjectSelector.h"
 #include "FWCore/Framework/interface/Event.h"
 
-template < class T >
+template < class T, typename C = std::vector<typename T::ConstituentTypeFwdPtr> >
 class JetConstituentSelector : public edm::EDFilter {
 
 public:
 
   typedef std::vector<T> JetsOutput;
-  typedef std::vector<typename T::ConstituentTypeFwdPtr> ConstituentsOutput;
+  typedef C ConstituentsOutput;
 
   JetConstituentSelector ( edm::ParameterSet const & params ) :
       srcToken_( consumes< typename edm::View<T> >( params.getParameter<edm::InputTag>("src") ) ),
@@ -67,7 +69,7 @@ public:
 	  // Add the jets that pass to the output collection
 	  jets->push_back( *ijet );
 	  for ( unsigned int ida = 0; ida < ijet->numberOfDaughters(); ++ida ) {
-	    candsOut->push_back( typename ConstituentsOutput::value_type( ijet->getPFConstituent(ida), ijet->getPFConstituent(ida) ) );
+	    candsOut->push_back( typename ConstituentsOutput::value_type( ijet->daughterPtr(ida), ijet->daughterPtr(ida) ) );
 	  }
 	}
       }
@@ -93,5 +95,7 @@ public:
 };
 
 typedef JetConstituentSelector<reco::PFJet> PFJetConstituentSelector;
+typedef JetConstituentSelector<pat::Jet, std::vector< edm::FwdPtr<pat::PackedCandidate> > > PatJetConstituentSelector;
 
 DEFINE_FWK_MODULE( PFJetConstituentSelector );
+DEFINE_FWK_MODULE( PatJetConstituentSelector );

--- a/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/JetConstituentSelector.cc
@@ -96,6 +96,8 @@ public:
 
 typedef JetConstituentSelector<reco::PFJet> PFJetConstituentSelector;
 typedef JetConstituentSelector<pat::Jet, std::vector< edm::FwdPtr<pat::PackedCandidate> > > PatJetConstituentSelector;
+typedef JetConstituentSelector<reco::PFJet, std::vector< edm::FwdPtr<pat::PackedCandidate> > > MiniAODJetConstituentSelector;
 
 DEFINE_FWK_MODULE( PFJetConstituentSelector );
 DEFINE_FWK_MODULE( PatJetConstituentSelector );
+DEFINE_FWK_MODULE( MiniAODJetConstituentSelector );

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -223,6 +223,12 @@
   <class name="edm::Ptr<pat::MET>" />
   <class name="edm::Ptr<pat::Conversion>" />
 
+  <class name="edm::FwdPtr<pat::PackedCandidate>" />
+  <class name="std::vector<edm::FwdPtr<pat::PackedCandidate> >" />
+  <class name="edm::Wrapper<edm::FwdPtr<pat::PackedCandidate> >" />
+  <class name="edm::Wrapper<std::vector<edm::FwdPtr<pat::PackedCandidate> > >" />
+
+
   <!-- PAT Object Collections -->
   <class name="std::vector<pat::Electron>" />
   <class name="std::vector<pat::Muon>" />

--- a/DataFormats/PatCandidates/src/classes_objects.h
+++ b/DataFormats/PatCandidates/src/classes_objects.h
@@ -2,6 +2,7 @@
 #include "DataFormats/Common/interface/Association.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/FwdPtr.h"
 
 #include "DataFormats/PatCandidates/interface/Electron.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
@@ -164,6 +165,11 @@ namespace DataFormats_PatCandidates {
   edm::Ptr<pat::Conversion> ptr_Conversion;
   edm::Ptr<pat::Muon> ptr_Muon;
   edm::Ptr<pat::Tau> ptr_Tau;
+
+  edm::FwdPtr<pat::PackedCandidate> fwdptr_pc;
+  edm::Wrapper< edm::FwdPtr<pat::PackedCandidate> > w_fwdptr_pc;
+  std::vector< edm::FwdPtr<pat::PackedCandidate> > v_fwdptr_pc;
+  edm::Wrapper< std::vector< edm::FwdPtr<pat::PackedCandidate> > > wv_fwdptr_pc;
 
   edm::Wrapper<edm::Association<pat::PackedCandidateCollection > > w_asso_pc;
   edm::Wrapper<edm::Association<reco::PFCandidateCollection > >    w_asso_pfc;

--- a/DataFormats/PatCandidates/src/classes_user.h
+++ b/DataFormats/PatCandidates/src/classes_user.h
@@ -34,6 +34,7 @@ namespace DataFormats_PatCandidates {
   pat::UserHolder<AlgebraicVector5>              p_udh_vec_5;
   pat::UserHolder<reco::Track>                   p_udh_tk;
   pat::UserHolder<reco::Vertex>                  p_udh_vtx;
+  pat::UserHolder<std::vector<unsigned int> >    p_udh_vunit;
 
   };
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -33,6 +33,7 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include "fastjet/SISConePlugin.hh"
 #include "fastjet/CMSIterativeConePlugin.hh"
@@ -281,7 +282,7 @@ VirtualJetProducer::VirtualJetProducer(const edm::ParameterSet& iConfig)
 
   if (!srcPVs_.label().empty()) input_vertex_token_ = consumes<reco::VertexCollection>(srcPVs_);
   input_candidateview_token_ = consumes<reco::CandidateView>(src_);
-  input_candidatefwdptr_token_ = consumes<std::vector<edm::FwdPtr<reco::PFCandidate> > >(src_);
+  input_candidatefwdptr_token_ = consumes<std::vector<edm::FwdPtr<reco::Candidate> > >(src_);
   
 }
 
@@ -339,7 +340,8 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   // get inputs and convert them to the fastjet format (fastjet::PeudoJet)
   edm::Handle<reco::CandidateView> inputsHandle;
   
-  edm::Handle< std::vector<edm::FwdPtr<reco::PFCandidate> > > pfinputsHandleAsFwdPtr; 
+  edm::Handle< std::vector<edm::FwdPtr<reco::Candidate> > > pfinputsHandleAsFwdPtr; 
+  // edm::Handle< std::vector<edm::FwdPtr<pat::PackedCandidate> > > patinputsHandleAsFwdPtr; 
   
   bool isView = iEvent.getByToken(input_candidateview_token_, inputsHandle);
   if ( isView ) {
@@ -347,15 +349,28 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
       inputs_.push_back(inputsHandle->ptrAt(i));
     }
   } else {
-    iEvent.getByToken(input_candidatefwdptr_token_, pfinputsHandleAsFwdPtr);
-    for (size_t i = 0; i < pfinputsHandleAsFwdPtr->size(); ++i) {
-      if ( (*pfinputsHandleAsFwdPtr)[i].ptr().isAvailable() ) {
-	inputs_.push_back( (*pfinputsHandleAsFwdPtr)[i].ptr() );
-      }
-      else if ( (*pfinputsHandleAsFwdPtr)[i].backPtr().isAvailable() ) {
-	inputs_.push_back( (*pfinputsHandleAsFwdPtr)[i].backPtr() );
+    bool isPF = iEvent.getByToken(input_candidatefwdptr_token_, pfinputsHandleAsFwdPtr);
+    if ( isPF ) {
+      for (size_t i = 0; i < pfinputsHandleAsFwdPtr->size(); ++i) {
+	if ( (*pfinputsHandleAsFwdPtr)[i].ptr().isAvailable() ) {
+	  inputs_.push_back( (*pfinputsHandleAsFwdPtr)[i].ptr() );
+	}
+	else if ( (*pfinputsHandleAsFwdPtr)[i].backPtr().isAvailable() ) {
+	  inputs_.push_back( (*pfinputsHandleAsFwdPtr)[i].backPtr() );
+	}
       }
     }
+    //  else {
+    //   iEvent.getByToken(input_candidatefwdptr_token_, patinputsHandleAsFwdPtr);
+    //   for (size_t i = 0; i < patinputsHandleAsFwdPtr->size(); ++i) {
+    // 	if ( (*patinputsHandleAsFwdPtr)[i].ptr().isAvailable() ) {
+    // 	  inputs_.push_back( (*patinputsHandleAsFwdPtr)[i].ptr() );
+    // 	}
+    // 	else if ( (*patinputsHandleAsFwdPtr)[i].backPtr().isAvailable() ) {
+    // 	  inputs_.push_back( (*patinputsHandleAsFwdPtr)[i].backPtr() );
+    // 	}
+    //   }      
+    // }
   }
   LogDebug("VirtualJetProducer") << "Got inputs\n";
   

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -12,6 +12,7 @@
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "DataFormats/JetReco/interface/BasicJet.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include "RecoJets/JetProducers/interface/PileUpSubtractor.h"
 #include "RecoJets/JetProducers/interface/AnomalousTower.h"
@@ -208,6 +209,7 @@ protected:
   // tokens for the data access
   edm::EDGetTokenT<reco::CandidateView> input_candidateview_token_;
   edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::PFCandidate> > > input_candidatefwdptr_token_;
+  edm::EDGetTokenT<std::vector<edm::FwdPtr<pat::PackedCandidate> > > input_packedcandidatefwdptr_token_;
 
  protected:
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -207,7 +207,7 @@ protected:
 
   // tokens for the data access
   edm::EDGetTokenT<reco::CandidateView> input_candidateview_token_;
-  edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::Candidate> > > input_candidatefwdptr_token_;
+  edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::PFCandidate> > > input_candidatefwdptr_token_;
 
  protected:
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -207,7 +207,7 @@ protected:
 
   // tokens for the data access
   edm::EDGetTokenT<reco::CandidateView> input_candidateview_token_;
-  edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::PFCandidate> > > input_candidatefwdptr_token_;
+  edm::EDGetTokenT<std::vector<edm::FwdPtr<reco::Candidate> > > input_candidatefwdptr_token_;
 
  protected:
   edm::EDGetTokenT<reco::VertexCollection> input_vertex_token_;


### PR DESCRIPTION
This PR adds a bunch of changes necessary to run jet reco properly on miniAOD. There are a number of small changes related to using pat::Jets instead of reco::PFJets, and also generalized the input of PFCandidate to simply Candidate into the jet software to allow for pat::PackedCandidates. 

Tests with the matrix worked for "-l limited" and "-l 1341.0". Also checked "scram b runtests" and that was also successful. 
