### PR TITLE
Removed construction of RefProd from RefVector

### DIFF
--- a/DataFormats/PatCandidates/interface/Electron.h
+++ b/DataFormats/PatCandidates/interface/Electron.h
@@ -234,12 +234,19 @@ namespace pat {
       bool passConversionVeto() const { return passConversionVeto_; }
       void setPassConversionVeto( bool flag ) { passConversionVeto_ = flag; }
 
-      /// References to PFCandidates (e.g. to recompute isolation)
-      void setPackedPFCandidateCollection(const edm::RefProd<pat::PackedCandidateCollection> & refprod) ; 
       /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
       edm::RefVector<pat::PackedCandidateCollection> associatedPackedPFCandidates() const ;
       /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
-      void setAssociatedPackedPFCandidates(const edm::RefVector<pat::PackedCandidateCollection> &refvector) ;
+      template<typename T>
+      void setAssociatedPackedPFCandidates(const edm::RefProd<pat::PackedCandidateCollection> & refprod,
+                                           T beginIndexItr,
+                                           T endIndexItr) {
+        packedPFCandidates_ = refprod;
+        associatedPackedFCandidateIndices_.clear();
+        associatedPackedFCandidateIndices_.insert(associatedPackedFCandidateIndices_.end(),
+                                                  beginIndexItr,
+                                                  endIndexItr);
+      }
 
       friend class PATElectronSlimmer;
 

--- a/DataFormats/PatCandidates/interface/Photon.h
+++ b/DataFormats/PatCandidates/interface/Photon.h
@@ -296,13 +296,20 @@ namespace pat {
       /// pipe operator (introduced to use pat::Photon with PFTopProjectors)
       friend std::ostream& reco::operator<<(std::ostream& out, const pat::Photon& obj);
 
-      /// References to PFCandidates (e.g. to recompute isolation)
-      void setPackedPFCandidateCollection(const edm::RefProd<pat::PackedCandidateCollection> & refprod) ; 
       /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
       edm::RefVector<pat::PackedCandidateCollection> associatedPackedPFCandidates() const ;
       /// References to PFCandidates linked to this object (e.g. for isolation vetos or masking before jet reclustering)
-      void setAssociatedPackedPFCandidates(const edm::RefVector<pat::PackedCandidateCollection> &refvector) ;
-
+      template<typename T>
+      void setAssociatedPackedPFCandidates(const edm::RefProd<pat::PackedCandidateCollection> & refprod,
+                                           T beginIndexItr,
+                                           T endIndexItr) {
+        packedPFCandidates_ = refprod;
+        associatedPackedFCandidateIndices_.clear();
+        associatedPackedFCandidateIndices_.insert(associatedPackedFCandidateIndices_.begin(),
+                                                  beginIndexItr,
+                                                  endIndexItr);
+      }
+ 
       /// get the number of non-null PFCandidates
       size_t numberOfSourceCandidatePtrs() const { return associatedPackedFCandidateIndices_.size(); }
       /// get the source candidate pointer with index i

--- a/DataFormats/PatCandidates/src/Electron.cc
+++ b/DataFormats/PatCandidates/src/Electron.cc
@@ -474,11 +474,6 @@ void Electron::setMvaVariables( double sigmaIetaIphi, double ip3d){
   ip3d_ = ip3d;
 } 
 
-void Electron::setPackedPFCandidateCollection(const edm::RefProd<pat::PackedCandidateCollection> & refprod) {
-    if (!associatedPackedFCandidateIndices_.empty()) throw cms::Exception("Unsupported", "You can't call setPackedPFCandidateCollection _after_ having called setAssociatedPackedPFCandidates");
-    packedPFCandidates_ = refprod;
-}
-
 edm::RefVector<pat::PackedCandidateCollection> Electron::associatedPackedPFCandidates() const {
     edm::RefVector<pat::PackedCandidateCollection> ret(packedPFCandidates_.id());
     for (uint16_t idx : associatedPackedFCandidateIndices_) {
@@ -487,17 +482,4 @@ edm::RefVector<pat::PackedCandidateCollection> Electron::associatedPackedPFCandi
     return ret;
 }
 
-void Electron::setAssociatedPackedPFCandidates(const edm::RefVector<pat::PackedCandidateCollection> &refvector) {
-    if (packedPFCandidates_.isNonnull()) {
-        if (refvector.id().isValid() && refvector.id() != packedPFCandidates_.id()) {
-            throw cms::Exception("Unsupported", "setAssociatedPackedPFCandidates pointing to a collection other than the one from setPackedPFCandidateCollection");
-        }
-    } else {
-        packedPFCandidates_ = edm::RefProd<pat::PackedCandidateCollection>(refvector);
-    }
-    associatedPackedFCandidateIndices_.clear();
-    for (const edm::Ref<pat::PackedCandidateCollection> & ref : refvector) {
-        associatedPackedFCandidateIndices_.push_back(ref.key());
-    }
-}
 

--- a/DataFormats/PatCandidates/src/Photon.cc
+++ b/DataFormats/PatCandidates/src/Photon.cc
@@ -302,31 +302,12 @@ bool Photon::isPhotonIDAvailable(const std::string & name) const {
 }
 
 
-void Photon::setPackedPFCandidateCollection(const edm::RefProd<pat::PackedCandidateCollection> & refprod) {
-    if (!associatedPackedFCandidateIndices_.empty()) throw cms::Exception("Unsupported", "You can't call setPackedPFCandidateCollection _after_ having called setAssociatedPackedPFCandidates");
-    packedPFCandidates_ = refprod;
-}
-
 edm::RefVector<pat::PackedCandidateCollection> Photon::associatedPackedPFCandidates() const {
     edm::RefVector<pat::PackedCandidateCollection> ret(packedPFCandidates_.id());
     for (uint16_t idx : associatedPackedFCandidateIndices_) {
         ret.push_back(edm::Ref<pat::PackedCandidateCollection>(packedPFCandidates_, idx));
     }
     return ret;
-}
-
-void Photon::setAssociatedPackedPFCandidates(const edm::RefVector<pat::PackedCandidateCollection> &refvector) {
-    if (packedPFCandidates_.isNonnull()) {
-        if (refvector.id().isValid() && refvector.id() != packedPFCandidates_.id()) {
-            throw cms::Exception("Unsupported", "setAssociatedPackedPFCandidates pointing to a collection other than the one from setPackedPFCandidateCollection");
-        }
-    } else {
-        packedPFCandidates_ = edm::RefProd<pat::PackedCandidateCollection>(refvector);
-    }
-    associatedPackedFCandidateIndices_.clear();
-    for (const edm::Ref<pat::PackedCandidateCollection> & ref : refvector) {
-        associatedPackedFCandidateIndices_.push_back(ref.key());
-    }
 }
 
 /// Returns the reference to the parent PF candidate with index i.


### PR DESCRIPTION
Changes in the framework will remove the ability to create a RefProd
from a RefVector.
