### PR TITLE
MiniAOD improvements for PAT jets

### DIFF
--- a/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetMatch_cfi.py
+++ b/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetMatch_cfi.py
@@ -17,7 +17,7 @@ patJetPartonMatch = cms.EDProducer("MCMatcher",      # cut on deltaR, deltaPt/Pt
 
 patJetGenJetMatch = cms.EDProducer("GenJetMatcher",  # cut on deltaR; pick best by deltaR
     src         = cms.InputTag("ak4PFJetsCHS"),      # RECO jets (any View<Jet> is ok)
-    matched     = cms.InputTag("ak4GenJetsNoNu"),    # GEN jets  (must be GenJetCollection)
+    matched     = cms.InputTag("ak4GenJets"),        # GEN jets  (must be GenJetCollection)
     mcPdgId     = cms.vint32(),                      # n/a
     mcStatus    = cms.vint32(),                      # n/a
     checkCharge = cms.bool(False),                   # n/a

--- a/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetMatch_cfi.py
+++ b/PhysicsTools/PatAlgos/python/mcMatchLayer0/jetMatch_cfi.py
@@ -17,7 +17,7 @@ patJetPartonMatch = cms.EDProducer("MCMatcher",      # cut on deltaR, deltaPt/Pt
 
 patJetGenJetMatch = cms.EDProducer("GenJetMatcher",  # cut on deltaR; pick best by deltaR
     src         = cms.InputTag("ak4PFJetsCHS"),      # RECO jets (any View<Jet> is ok)
-    matched     = cms.InputTag("ak4GenJets"),        # GEN jets  (must be GenJetCollection)
+    matched     = cms.InputTag("ak4GenJetsNoNu"),    # GEN jets  (must be GenJetCollection)
     mcPdgId     = cms.vint32(),                      # n/a
     mcStatus    = cms.vint32(),                      # n/a
     checkCharge = cms.bool(False),                   # n/a

--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -1,74 +1,74 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 
-# /RelValTTbar_13/CMSSW_7_3_0_pre3-PU50ns_MCRUN2_73_V4-v1/MINIAODSIM
+# /RelValTTbar_13/CMSSW_7_4_0_pre5-PU25ns_MCRUN2_73_V7-v1/MINIAODSIM
 filesRelValProdTTbarPileUpMINIAODSIM = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_3_0_pre3'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
                         #, relVal        = 'RelValTTbar_13'
-                        #, globalTag     = 'PU50ns_MCRUN2_73_V4'
+                        #, globalTag     = 'PU25ns_MCRUN2_73_V7'
                         #, dataTier      = 'MINIAODSIM'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_3_0_pre3/RelValTTbar_13/MINIAODSIM/PU50ns_MCRUN2_73_V4-v1/00000/8202F53B-E876-E411-A45A-02163E010F0C.root'
+        '/store/relval/CMSSW_7_4_0_pre5/RelValTTbar_13/MINIAODSIM/PU25ns_MCRUN2_73_V7-v1/00000/B626832E-D6A0-E411-B0D9-0025905938A8.root'
     )
 
-# /RelValProdTTbar_13/CMSSW_7_3_0_pre3-MCRUN2_73_V5-v1/AODSIM
+# /RelValProdTTbar_13/CMSSW_7_4_0_pre5-MCRUN2_73_V7-v1/AODSIM
 filesRelValProdTTbarAODSIM = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_3_0_pre3'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
                         #, relVal        = 'RelValProdTTbar_13'
-                        #, globalTag     = 'MCRUN2_73_V5'
+                        #, globalTag     = 'MCRUN2_73_V7'
                         #, dataTier      = 'AODSIM'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_3_0_pre3/RelValProdTTbar_13/AODSIM/MCRUN2_73_V5-v1/00000/24901D70-7A76-E411-B2CE-02163E00FBB8.root'
+        '/store/relval/CMSSW_7_4_0_pre5/RelValProdTTbar_13/AODSIM/MCRUN2_73_V7-v1/00000/621B749D-F19D-E411-896C-003048FFCBA4.root'
     )
 
-# /RelValProdTTbar_13/CMSSW_7_3_0_pre3-MCRUN2_73_V5-v1/GEN-SIM-RECO
+# /RelValProdTTbar_13/CMSSW_7_4_0_pre5-MCRUN2_73_V7-v1/GEN-SIM-RECO
 filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_3_0_pre3'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
                         #, relVal        = 'RelValProdTTbar_13'
-                        #, globalTag     = 'MCRUN2_73_V5'
+                        #, globalTag     = 'MCRUN2_73_V7'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_3_0_pre3/RelValProdTTbar_13/GEN-SIM-RECO/MCRUN2_73_V5-v1/00000/6C790212-5976-E411-8B03-02163E00E617.root'
+        '/store/relval/CMSSW_7_4_0_pre5/RelValProdTTbar_13/GEN-SIM-RECO/MCRUN2_73_V7-v1/00000/4EBA2C0B-EB9D-E411-810A-002618FDA248.root'
     )
 
-# /RelValTTbar/CMSSW_7_3_0_pre3-PU_MCRUN1_73_V1_FastSim-v1/GEN-SIM-DIGI-RECO
+# /RelValTTbar/CMSSW_7_4_0_pre5-PU_MCRUN1_73_V2_FastSim-v1/GEN-SIM-DIGI-RECO
 filesRelValTTbarPileUpFastSimGENSIMDIGIRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_3_0_pre3'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
                         #, relVal        = 'RelValTTbar'
-                        #, globalTag     = 'PU_MCRUN1_73_V1_FastSim'
+                        #, globalTag     = 'PU_MCRUN1_73_V2_FastSim'
                         #, dataTier      = 'GEN-SIM-DIGI-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_3_0_pre3/RelValTTbar/GEN-SIM-DIGI-RECO/PU_MCRUN1_73_V1_FastSim-v1/00000/00062E1F-1976-E411-A031-02163E00F50C.root'
+        '/store/relval/CMSSW_7_4_0_pre5/RelValTTbar/GEN-SIM-DIGI-RECO/PU_MCRUN1_73_V2_FastSim-v1/00000/00024C55-D39D-E411-969A-0025905A60C6.root'
     )
 
-# /RelValTTbar_13/CMSSW_7_3_0_pre3-PU50ns_MCRUN2_73_V4-v1/GEN-SIM-RECO
+# /RelValTTbar_13/CMSSW_7_4_0_pre5-PU25ns_MCRUN2_73_V7-v1/GEN-SIM-RECO
 filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_3_0_pre3'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
                         #, relVal        = 'RelValTTbar_13'
-                        #, globalTag     = 'PU50ns_MCRUN2_73_V4'
+                        #, globalTag     = 'PU25ns_MCRUN2_73_V7'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_3_0_pre3/RelValTTbar_13/GEN-SIM-RECO/PU50ns_MCRUN2_73_V4-v1/00000/0A59D5ED-7276-E411-9BAD-02163E010EC2.root'
+        '/store/relval/CMSSW_7_4_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_73_V7-v1/00000/0A054268-C9A0-E411-8CE6-0025905A6134.root'
     )
 
-# /SingleMu/CMSSW_7_3_0_pre3-GR_R_73_V0A_RelVal_mu2012D-v1/MINIAOD
+# /SingleMu/CMSSW_7_4_0_pre5-GR_R_73_V0A_RelVal_mu2012D-v1/MINIAOD
 filesRelValSingleMuMINIAOD = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_3_0_pre3'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
                         #, relVal        = 'SingleMu'
                         #, globalTag     = 'GR_R_73_V0A_RelVal_mu2012D'
                         #, dataTier      = 'MINIAOD'
@@ -76,12 +76,12 @@ filesRelValSingleMuMINIAOD = cms.untracked.vstring(
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_3_0_pre3/SingleMu/MINIAOD/GR_R_73_V0A_RelVal_mu2012D-v1/00000/126DA110-DB76-E411-AD6F-02163E010DC1.root'
+        '/store/relval/CMSSW_7_4_0_pre5/SingleMu/MINIAOD/GR_R_73_V0A_RelVal_mu2012D-v1/00000/0855341F-5C9E-E411-9A51-0025905A60CA.root'
     )
 
-# /SingleMu/CMSSW_7_3_0_pre3-GR_R_73_V0A_RelVal_mu2012D-v1/RECO # not at CERN
+# /SingleMu/CMSSW_7_4_0_pre5-GR_R_73_V0A_RelVal_mu2012D-v1/RECO
 filesSingleMuRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_3_0_pre3'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
                         #, relVal        = 'SingleMu'
                         #, dataTier      = 'RECO'
                         #, globalTag     = 'GR_R_73_V0A_RelVal_mu2012D'
@@ -89,5 +89,5 @@ filesSingleMuRECO = cms.untracked.vstring(
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_3_0_pre3/SingleMu/RECO/GR_R_73_V0A_RelVal_mu2012D-v1/00000/00544682-1376-E411-8004-02163E00E66B.root'
+        '/store/relval/CMSSW_7_4_0_pre5/SingleMu/RECO/GR_R_73_V0A_RelVal_mu2012D-v1/00000/00005DA8-EE9D-E411-A0B2-002618FDA277.root'
     )

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -36,15 +36,14 @@ patJets = cms.EDProducer("PATJetProducer",
     addBTagInfo          = cms.bool(True),   ## master switch
     addDiscriminators    = cms.bool(True),   ## addition btag discriminators
     discriminatorSources = cms.VInputTag(
-        cms.InputTag("jetBProbabilityBJetTags"),
-        cms.InputTag("jetProbabilityBJetTags"),
-        cms.InputTag("trackCountingHighPurBJetTags"),
-        cms.InputTag("trackCountingHighEffBJetTags"),
-        cms.InputTag("simpleSecondaryVertexHighEffBJetTags"),
-        cms.InputTag("simpleSecondaryVertexHighPurBJetTags"),
-        cms.InputTag("combinedInclusiveSecondaryVertexV2BJetTags"),
-        cms.InputTag("pfCombinedSecondaryVertexBJetTags"),
-        cms.InputTag("combinedMVABJetTags")
+        cms.InputTag("pfJetBProbabilityBJetTags"),
+        cms.InputTag("pfJetProbabilityBJetTags"),
+        cms.InputTag("pfTrackCountingHighPurBJetTags"),
+        cms.InputTag("pfTrackCountingHighEffBJetTags"),
+        cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
+        cms.InputTag("pfSimpleSecondaryVertexHighPurBJetTags"),
+        cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
+        cms.InputTag("pfCombinedMVABJetTags")
     ),
     # clone tag infos ATTENTION: these take lots of space!
     # usually the discriminators from the default algos

--- a/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
+++ b/PhysicsTools/PatAlgos/python/recoLayer0/bTagging_cff.py
@@ -1,6 +1,7 @@
 ## list of all available btagInfos
 supportedBtagInfos = [
     'None'
+    # legacy framework (not supported with MiniAOD)
   , 'impactParameterTagInfos'
   , 'secondaryVertexTagInfos'
   , 'secondaryVertexNegativeTagInfos'
@@ -11,7 +12,7 @@ supportedBtagInfos = [
   , 'inclusiveSecondaryVertexFinderNegativeTagInfos'
   , 'inclusiveSecondaryVertexFinderFilteredTagInfos'
   , 'inclusiveSecondaryVertexFinderFilteredNegativeTagInfos'
-  # new candidate-based fwk
+     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfImpactParameterTagInfos'
   , 'pfSecondaryVertexTagInfos'
   , 'pfSecondaryVertexNegativeTagInfos'
@@ -25,6 +26,7 @@ supportedBtagInfos.append( 'caTopTagInfosPAT' )
 ## dictionary with all available btag discriminators and the btagInfos that they require
 supportedBtagDiscr = {
     'None'                                                  : []
+    # legacy framework (not supported with MiniAOD)
   , 'jetBProbabilityBJetTags'                               : ['impactParameterTagInfos']
   , 'jetProbabilityBJetTags'                                : ['impactParameterTagInfos']
   , 'positiveOnlyJetBProbabilityBJetTags'                   : ['impactParameterTagInfos']
@@ -81,7 +83,7 @@ supportedBtagDiscr = {
   , 'combinedMVABJetTags'                                   : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'positiveCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
   , 'negativeCombinedMVABJetTags'                           : ['impactParameterTagInfos', 'inclusiveSecondaryVertexFinderNegativeTagInfos', 'softPFMuonsTagInfos', 'softPFElectronsTagInfos']
-  # new candidate-based fwk
+    # new candidate-based framework (supported with RECO/AOD/MiniAOD)
   , 'pfJetBProbabilityBJetTags'                             : ['pfImpactParameterTagInfos']
   , 'pfJetProbabilityBJetTags'                              : ['pfImpactParameterTagInfos']
   , 'pfPositiveOnlyJetBProbabilityBJetTags'                 : ['pfImpactParameterTagInfos']

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_addJet.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_addJet.py
@@ -1,47 +1,50 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("S2")
+
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring("file:patTuple_mini.root")
 )
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1000) )
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarPileUpMINIAODSIM
+process.source.fileNames = filesRelValProdTTbarPileUpMINIAODSIM
 
-from RecoJets.JetProducers.ak5PFJets_cfi import ak5PFJets
-from RecoJets.JetProducers.ak5GenJets_cfi import ak5GenJets
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+
+from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
+from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
 
 process.chs = cms.EDFilter("CandPtrSelector", src = cms.InputTag("packedPFCandidates"), cut = cms.string("fromPV"))
 
-process.ak5PFJets = ak5PFJets.clone(src = 'packedPFCandidates', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
-process.ak5PFJetsCHS = ak5PFJets.clone(src = 'chs', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
-process.ak5GenJets = ak5GenJets.clone(src = 'packedGenParticles')
+process.ak4PFJets = ak4PFJets.clone(src = 'packedPFCandidates', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
+process.ak4PFJetsCHS = ak4PFJets.clone(src = 'chs', doAreaFastjet = True) # no idea while doArea is false by default, but it's True in RECO so we have to set it
+process.ak4GenJets = ak4GenJets.clone(src = 'packedGenParticles')
 
 process.load("PhysicsTools.PatAlgos.producersLayer1.patCandidates_cff")
 process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.Geometry_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag = 'START70_V6::All'
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
 
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 addJetCollection(
    process,
    postfix   = "",
-   labelName = 'AK5PFCHS',
-   jetSource = cms.InputTag('ak5PFJetsCHS'),
-   trackSource = cms.InputTag('unpackedTracksAndVertices'), 	
-   pvSource = cms.InputTag('unpackedTracksAndVertices'), 
-   jetCorrections = ('AK5PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   btagDiscriminators = [      'combinedSecondaryVertexBJetTags'     ]
+   labelName = 'AK4PFCHS',
+   jetSource = cms.InputTag('ak4PFJetsCHS'),
+   pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+   pfCandidates = cms.InputTag('packedPFCandidates'),
+   svSource = cms.InputTag('slimmedSecondaryVertices'),
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
+   btagDiscriminators = [ 'pfCombinedSecondaryVertexBJetTags', 'pfCombinedInclusiveSecondaryVertexV2BJetTags' ],
+   genJetCollection=cms.InputTag('ak4GenJets'),
+   genParticles=cms.InputTag('prunedGenParticles')
    )
-process.patJetPartonMatchAK5PFCHS.matched = "prunedGenParticles"
-process.patJetPartons.particles = "prunedGenParticles"
-process.patJetPartonsLegacy.src = "prunedGenParticles" # if using legacy jet flavour (not used by default)
+# if using legacy jet flavour (not used by default)
 process.patJetPartonsLegacy.skipFirstN = cms.uint32(0) # do not skip first 6 particles, we already pruned some!
 process.patJetPartonsLegacy.acceptNoDaughters = cms.bool(True) # as we drop intermediate stuff, we need to accept quarks with no siblings
-process.patJetCorrFactorsAK5PFCHS.primaryVertices = "offlineSlimmedPrimaryVertices"
 
-#recreate tracks and pv for btagging
-process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
@@ -49,7 +52,7 @@ process.options.allowUnscheduled = cms.untracked.bool(True)
 
 process.OUT = cms.OutputModule("PoolOutputModule",
     fileName = cms.untracked.string('test.root'),
-    outputCommands = cms.untracked.vstring(['drop *','keep patJets_patJetsAK5PFCHS_*_*','keep *_*_*_PAT'])
+    outputCommands = cms.untracked.vstring(['drop *','keep patJets_patJetsAK4PFCHS_*_*','keep *_*_*_PAT'])
 )
 process.endpath= cms.EndPath(process.OUT)
 

--- a/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
+++ b/PhysicsTools/PatAlgos/test/miniAOD/example_ei.py
@@ -4,6 +4,9 @@ process = cms.Process("S2")
 process.source = cms.Source("PoolSource",
     fileNames = cms.untracked.vstring("file:patTuple_mini.root")
 )
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarPileUpMINIAODSIM
+process.source.fileNames = filesRelValProdTTbarPileUpMINIAODSIM
+
 process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
 from RecoJets.JetProducers.ak4PFJets_cfi import ak4PFJets
@@ -46,7 +49,8 @@ process.load("Configuration.EventContent.EventContent_cff")
 process.load('Configuration.StandardSequences.Geometry_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_cff')
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
-process.GlobalTag.globaltag =  'POSTLS172_V3::All'
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
 
 
 from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
@@ -55,42 +59,31 @@ addJetCollection(
    postfix   = "",
    labelName = 'AK4PFCHS',
    jetSource = cms.InputTag('ak4PFJetsCHS'),
-   trackSource = cms.InputTag('unpackedTracksAndVertices'), 
-   pfCandidates = cms.InputTag('packedPFCandidates'), 
-   pvSource = cms.InputTag('unpackedTracksAndVertices'), 
+   pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+   pfCandidates = cms.InputTag('packedPFCandidates'),
+   svSource = cms.InputTag('slimmedSecondaryVertices'),
    jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ],
-   genJetCollection=cms.InputTag('ak4GenJets')
+   btagDiscriminators = [ 'pfCombinedSecondaryVertexBJetTags', 'pfCombinedInclusiveSecondaryVertexV2BJetTags' ],
+   genJetCollection=cms.InputTag('ak4GenJets'),
+   genParticles=cms.InputTag('prunedGenParticles')
    )
 addJetCollection(
    process,
    postfix   = "",
    labelName = 'AK4PF',
    jetSource = cms.InputTag('ak4PFJets'),
-   trackSource = cms.InputTag('unpackedTracksAndVertices'),
-   pfCandidates = cms.InputTag('packedPFCandidates'), 
-   pvSource = cms.InputTag('unpackedTracksAndVertices'), 
+   pvSource = cms.InputTag('offlineSlimmedPrimaryVertices'),
+   pfCandidates = cms.InputTag('packedPFCandidates'),
+   svSource = cms.InputTag('slimmedSecondaryVertices'),
    jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
-   btagDiscriminators = [      'pfCombinedSecondaryVertexBJetTags'     ],
-   genJetCollection=cms.InputTag('ak4GenJets')
+   btagDiscriminators = [ 'pfCombinedSecondaryVertexBJetTags', 'pfCombinedInclusiveSecondaryVertexV2BJetTags' ],
+   genJetCollection=cms.InputTag('ak4GenJets'),
+   genParticles=cms.InputTag('prunedGenParticles')
    )
 
-#adjust MC matching
-process.patJetGenJetMatchAK4PF.matched = "slimmedGenJets"
-process.patJetGenJetMatchAK4PFCHS.matched = "slimmedGenJets"
-process.patJetPartonMatchAK4PFCHS.matched = "prunedGenParticles"
-process.patJetPartonMatchAK4PF.matched = "prunedGenParticles"
-process.patJetPartons.particles = "prunedGenParticles"
-process.patJetPartonsLegacy.src = "prunedGenParticles" # if using legacy jet flavour (not used by default)
+# if using legacy jet flavour (not used by default)
 process.patJetPartonsLegacy.skipFirstN = cms.uint32(0) # do not skip first 6 particles, we already pruned some!
 process.patJetPartonsLegacy.acceptNoDaughters = cms.bool(True) # as we drop intermediate stuff, we need to accept quarks with no siblings
-
-#adjust PV
-process.patJetCorrFactorsAK4PFCHS.primaryVertices = "offlineSlimmedPrimaryVertices"
-process.patJetCorrFactorsAK4PF.primaryVertices = "offlineSlimmedPrimaryVertices"
-
-#recreate tracks and pv for btagging
-process.load('PhysicsTools.PatAlgos.slimming.unpackedTracksAndVertices_cfi')
 
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -13,27 +13,21 @@ from PhysicsTools.PatAlgos.tools.jetTools import addJetCollection
 
 # b-tag discriminators
 btagDiscriminators = [
-     'pfJetBProbabilityBJetTags'
-    ,'pfJetProbabilityBJetTags'
-    ,'jetBProbabilityBJetTags'
+     # legacy framework (not supported with MiniAOD)
+     'jetBProbabilityBJetTags'
     ,'jetProbabilityBJetTags'
     ,'positiveOnlyJetBProbabilityBJetTags'
     ,'positiveOnlyJetProbabilityBJetTags'
     ,'negativeOnlyJetBProbabilityBJetTags'
     ,'negativeOnlyJetProbabilityBJetTags'
-    ,'pfTrackCountingHighPurBJetTags'
-    ,'pfTrackCountingHighEffBJetTags'
     ,'trackCountingHighPurBJetTags'
     ,'trackCountingHighEffBJetTags'
     ,'negativeTrackCountingHighEffBJetTags'
     ,'negativeTrackCountingHighPurBJetTags'
-    ,'pfSimpleSecondaryVertexHighEffBJetTags'
-    ,'pfSimpleSecondaryVertexHighPurBJetTags'
     ,'simpleSecondaryVertexHighEffBJetTags'
     ,'simpleSecondaryVertexHighPurBJetTags'
     ,'negativeSimpleSecondaryVertexHighEffBJetTags'
     ,'negativeSimpleSecondaryVertexHighPurBJetTags'
-    ,'pfCombinedSecondaryVertexBJetTags'
     ,'combinedSecondaryVertexBJetTags'
     ,'positiveCombinedSecondaryVertexBJetTags'
     ,'negativeCombinedSecondaryVertexBJetTags'
@@ -45,7 +39,6 @@ btagDiscriminators = [
     ,'combinedInclusiveSecondaryVertexBJetTags'
     ,'positiveCombinedInclusiveSecondaryVertexBJetTags'
     ,'negativeCombinedInclusiveSecondaryVertexBJetTags'
-    ,'pfCombinedInclusiveSecondaryVertexV2BJetTags'
     ,'combinedInclusiveSecondaryVertexV2BJetTags'
     ,'positiveCombinedInclusiveSecondaryVertexV2BJetTags'
     ,'negativeCombinedInclusiveSecondaryVertexV2BJetTags'
@@ -77,7 +70,7 @@ btagDiscriminators = [
     ,'combinedMVABJetTags'
     ,'positiveCombinedMVABJetTags'
     ,'negativeCombinedMVABJetTags'
-    # new candidate-based fwk
+     # new candidate-based framework (supported with RECO/AOD/MiniAOD)
     ,'pfJetBProbabilityBJetTags'
     ,'pfJetProbabilityBJetTags'
     ,'pfPositiveOnlyJetBProbabilityBJetTags'
@@ -111,7 +104,7 @@ addJetCollection(
    process,
    labelName = 'AK4PF',
    jetSource = cms.InputTag('ak4PFJets'),
-   jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'), # FIXME: Use proper JECs, as soon as available
+   jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'),
    btagDiscriminators = btagDiscriminators
 )
 process.patJetsAK4PF.addTagInfos = True
@@ -119,18 +112,18 @@ process.patJetsAK4PF.addTagInfos = True
 # uncomment the following lines to add subjets of pruned ca8PFJetsCHS with new b-tags to your PAT output
 addJetCollection(
    process,
-   labelName = 'CA8PFCHSPrunedSubjets',
-   jetSource = cms.InputTag('ca8PFJetsCHSPruned','SubJets'),
-   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'), # FIXME: Use proper JECs, as soon as available
-   algo = 'CA',
-   rParam = 0.8,
+   labelName = 'AK8PFCHSSoftDropSubjets',
+   jetSource = cms.InputTag('ak8PFJetsCHSSoftDrop','SubJets'),
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'), # Use AK4 JECs for subjets which might not be completely appropriate
+   algo = 'AK',  # needed for subjet flavor clustering
+   rParam = 0.8, # needed for subjet flavor clustering
    btagDiscriminators = btagDiscriminators,
-   explicitJTA = True,
-   svClustering = True,
-   fatJets = cms.InputTag("ca8PFJetsCHS"),
-   groomedFatJets = cms.InputTag("ca8PFJetsCHSPruned"),
+   explicitJTA = True,  # needed for subjet b tagging
+   svClustering = True, # needed for subjet b tagging
+   fatJets = cms.InputTag("ak8PFJetsCHS"),               # needed for subjet flavor clustering
+   groomedFatJets = cms.InputTag("ak8PFJetsCHSSoftDrop") # needed for subjet flavor clustering
 )
-process.patJetsCA8PFCHSPrunedSubjets.addTagInfos = True
+process.patJetsAK8PFCHSSoftDropSubjets.addTagInfos = True
 
 ## JetID works only with RECO input for the CaloTowers (s. below for 'process.source.fileNames')
 #process.patJets.addJetID=True

--- a/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addBTagging_cfg.py
@@ -109,12 +109,12 @@ addJetCollection(
 )
 process.patJetsAK4PF.addTagInfos = True
 
-# uncomment the following lines to add subjets of pruned ca8PFJetsCHS with new b-tags to your PAT output
+# uncomment the following lines to add subjets of ak8PFJetsCHSSoftDrop with new b-tags to your PAT output
 addJetCollection(
    process,
    labelName = 'AK8PFCHSSoftDropSubjets',
    jetSource = cms.InputTag('ak8PFJetsCHSSoftDrop','SubJets'),
-   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'), # Use AK4 JECs for subjets which might not be completely appropriate
+   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-2'), # Using AK4 JECs for subjets which might not be completely appropriate
    algo = 'AK',  # needed for subjet flavor clustering
    rParam = 0.8, # needed for subjet flavor clustering
    btagDiscriminators = btagDiscriminators,

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -46,23 +46,21 @@ switchJetCollection(
    )
 process.out.outputCommands.append( 'drop *_selectedPatJets_caloTowers_*' )
 
-# uncomment the following lines to add ak4PFJets to your PAT output
-labelCA8PFCHSPruned = 'CA8PFCHSPruned'
+# uncomment the following lines to add ak8PFJetsCHSSoftDrop to your PAT output
+labelAK8PFCHSSoftDrop = 'AK8PFCHSSoftDrop'
 addJetCollection(
    process,
-   labelName = labelCA8PFCHSPruned,
-   jetSource = cms.InputTag('ca8PFJetsCHSPruned',''),
-   algo = 'CA8',
+   labelName = labelAK8PFCHSSoftDrop,
+   jetSource = cms.InputTag('ak8PFJetsCHSSoftDrop',''),
+   algo = 'AK',
    rParam = 0.8,
-   #genJetCollection = cms.InputTag('ak8GenJets'), # not in used SIM yet
-   genJetCollection = cms.InputTag('ak4GenJets'),
-   jetCorrections = ('AK4PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'), # FIXME: Use proper JECs, as soon as available
-   btagDiscriminators = [
-       'combinedSecondaryVertexBJetTags'
-     ],
+   genJetCollection = cms.InputTag('ak8GenJets'),
+   jetCorrections = ('AK8PFchs', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'None'),
+   btagDiscriminators = ['None'], # turn-off b tagging
+   getJetMCFlavour = False # jet flavor needs to be disabled for groomed fat jets
    )
-process.out.outputCommands.append( 'keep *_selectedPatJets%s_pfCandidates_*'%( labelCA8PFCHSPruned ) )
-process.out.outputCommands.append( 'drop *_selectedPatJets%s_caloTowers_*'%( labelCA8PFCHSPruned ) )
+process.out.outputCommands.append( 'keep *_selectedPatJets%s_pfCandidates_*'%( labelAK8PFCHSSoftDrop ) )
+process.out.outputCommands.append( 'drop *_selectedPatJets%s_caloTowers_*'%( labelAK8PFCHSSoftDrop ) )
 
 # uncomment the following lines to switch to ak4CaloJets in your PAT output
 labelAK4Calo = 'AK4Calo'

--- a/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_addJets_cfg.py
@@ -35,14 +35,14 @@ switchJetCollection(
    jetSource = cms.InputTag('ak4PFJets'),
    jetCorrections = ('AK4PF', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-1'),
    btagDiscriminators = [
-       'jetBProbabilityBJetTags'
-     , 'jetProbabilityBJetTags'
-     , 'trackCountingHighPurBJetTags'
-     , 'trackCountingHighEffBJetTags'
-     , 'simpleSecondaryVertexHighEffBJetTags'
-     , 'simpleSecondaryVertexHighPurBJetTags'
-     , 'combinedSecondaryVertexBJetTags'
-     ],
+       'pfJetBProbabilityBJetTags'
+     , 'pfJetProbabilityBJetTags'
+     , 'pfTrackCountingHighPurBJetTags'
+     , 'pfTrackCountingHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighPurBJetTags'
+     , 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
+     ]
    )
 process.out.outputCommands.append( 'drop *_selectedPatJets_caloTowers_*' )
 
@@ -70,14 +70,14 @@ addJetCollection(
    jetSource = cms.InputTag('ak4CaloJets'),
    jetCorrections = ('AK7Calo', cms.vstring(['L1FastJet', 'L2Relative', 'L3Absolute']), 'Type-1'), # FIXME: Use proper JECs, as soon as available
    btagDiscriminators = [
-       'jetBProbabilityBJetTags'
-     , 'jetProbabilityBJetTags'
-     , 'trackCountingHighPurBJetTags'
-     , 'trackCountingHighEffBJetTags'
-     , 'simpleSecondaryVertexHighEffBJetTags'
-     , 'simpleSecondaryVertexHighPurBJetTags'
-     , 'combinedSecondaryVertexBJetTags'
-     ],
+       'pfJetBProbabilityBJetTags'
+     , 'pfJetProbabilityBJetTags'
+     , 'pfTrackCountingHighPurBJetTags'
+     , 'pfTrackCountingHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighEffBJetTags'
+     , 'pfSimpleSecondaryVertexHighPurBJetTags'
+     , 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
+     ]
    )
 process.out.outputCommands.append( 'drop *_selectedPatJets%s_pfCandidates_*'%( labelAK4Calo ) )
 ## JetID works only with RECO input for the CaloTowers (s. below for 'process.source.fileNames')


### PR DESCRIPTION
This PR includes the following updates:
- default GenJets in PAT switched from `ak4GenJets` to `ak4GenJetsNoNu`
- PF-based btag discriminator as a new default
- improved MiniAOD support for PAT jets
- updated MiniAOD example configs
- switched from CA8 pruned to AK8 soft drop jets in the b-tagging example config
- Update RelVal input from CMSSW_7_3_0_pre3 to CMSSW_7_4_0_pre5

**Update:**
-  **reverted** default GenJets in PAT switched from `ak4GenJets` to `ak4GenJetsNoNu`
- switched from CA8 pruned to AK8 soft drop jets in the "addJet" example config
