### PR TITLE
Add pixel digitiser changes to the run2 era

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -341,25 +341,6 @@ def customiseRun2EraExtras(process):
                 process.mix.digitizers.hcal.hf1.samplingFactor = cms.double(0.60)
             if hasattr(process.mix.digitizers,'hcal') and hasattr(process.mix.digitizers.hcal,'hf2'):
                 process.mix.digitizers.hcal.hf2.samplingFactor = cms.double(0.60)
-            if hasattr(process.mix.digitizers,'pixel'):
-                # DynamicInefficency - 13TeV - 50ns case
-                if process.mix.bunchspace == 50:
-                    process.mix.digitizers.pixel.theInstLumiScaleFactor = cms.double(246.4)
-                    process.mix.digitizers.pixel.theLadderEfficiency_BPix1 = cms.vdouble( [0.979259,0.976677]*10 )
-                    process.mix.digitizers.pixel.theLadderEfficiency_BPix2 = cms.vdouble( [0.994321,0.993944]*16 )
-                    process.mix.digitizers.pixel.theLadderEfficiency_BPix3 = cms.vdouble( [0.996787,0.996945]*22 )
-                # DynamicInefficency - 13TeV - 25ns case
-                if process.mix.bunchspace == 25:
-                    process.mix.digitizers.pixel.theInstLumiScaleFactor = cms.double(364)
-                    process.mix.digitizers.pixel.theLadderEfficiency_BPix1 = cms.vdouble( [1]*20 )
-                    process.mix.digitizers.pixel.theLadderEfficiency_BPix2 = cms.vdouble( [1]*32 )
-                    process.mix.digitizers.pixel.theLadderEfficiency_BPix3 = cms.vdouble( [1]*44 )
-                    process.mix.digitizers.pixel.theModuleEfficiency_BPix1 = cms.vdouble( 1, 1, 1, 1, )
-                    process.mix.digitizers.pixel.theModuleEfficiency_BPix2 = cms.vdouble( 1, 1, 1, 1, )
-                    process.mix.digitizers.pixel.theModuleEfficiency_BPix3 = cms.vdouble( 1, 1, 1, 1 )
-                    process.mix.digitizers.pixel.thePUEfficiency_BPix1 = cms.vdouble( 1.00023, -3.18350e-06, 5.08503e-10, -6.79785e-14 )
-                    process.mix.digitizers.pixel.thePUEfficiency_BPix2 = cms.vdouble( 9.99974e-01, -8.91313e-07, 5.29196e-12, -2.28725e-15 )
-                    process.mix.digitizers.pixel.thePUEfficiency_BPix3 = cms.vdouble( 1.00005, -6.59249e-07, 2.75277e-11, -1.62683e-15 )
     if hasattr(process,'HLTSchedule'):
         process.CSCGeometryESModule.useGangedStripsInME1a = False
         process.hltCsc2DRecHits.readBadChannels = cms.bool(False)

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -247,18 +247,18 @@ def customiseRun2EraExtras(process):
         if hasattr(process,b):
             #print "BEFORE:  ", getattr(process, b).centralJetSource
             if (getattr(process, b).centralJetSource == cms.InputTag("simGctDigis","cenJets")):
-                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","nonIsoEm")
-                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1FormatDigis","forJets")
-                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1FormatDigis","cenJets")
-                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1FormatDigis","tauJets")
-                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1FormatDigis","isoTauJets")
-                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","isoEm")
-                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","nonIsoEm")
+                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","forJets")
+                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","cenJets")
+                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","tauJets")
+                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoTauJets")
+                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoEm")
+                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
             else:
                 #print "INFO:  customizing ", b, "to use new calo Stage 1 digis converted to legacy format"
                 getattr(process, b).etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis")
@@ -309,6 +309,20 @@ def customiseRun2EraExtras(process):
                     flags              = cms.vstring('Standard')
                 )
             )
+        #Lower Thresholds also for Clusters!!!    
+    
+        for p in process.particleFlowClusterHO.seedFinder.thresholdsByDetector:
+            p.seedingThreshold = cms.double(0.08)
+    
+        for p in process.particleFlowClusterHO.initialClusteringStep.thresholdsByDetector:
+            p.gatheringThreshold = cms.double(0.05)
+    
+        for p in process.particleFlowClusterHO.pfClusterBuilder.recHitEnergyNorms:
+            p.recHitEnergyNorm = cms.double(0.05)
+    
+        process.particleFlowClusterHO.pfClusterBuilder.positionCalc.logWeightDenominator = cms.double(0.05)
+        process.particleFlowClusterHO.pfClusterBuilder.allCellsPositionCalc.logWeightDenominator = cms.double(0.05)
+
     if hasattr(process,'digitisation_step'):
         alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT','PREMIX','PREMIXRAW']
         for a in alist:

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -286,6 +286,61 @@ DeadModules = cms.VPSet(
 ###    DeadModules = cms.VPSet()
 )
 
+##
+## Make changes for running in the Run 2 scenario
+##
+from Configuration.StandardSequences.Eras import eras
+
+def modifyPixelDigitizerForRun2Bunchspacing25( digitizer ) :
+    """
+    Function that modifies the pixel digitiser for Run 2 with 25ns bunchspacing.
+    First argument is the pixelDigitizer object (generally
+    "process.mix.digitizers.pixel" when this function is called).
+    """
+    # DynamicInefficency - 13TeV - 25ns case
+    digitizer.theInstLumiScaleFactor = cms.double(364)
+    digitizer.theLadderEfficiency_BPix1 = cms.vdouble( [1]*20 ) # this syntax makes an array with 20 copies of "1"
+    digitizer.theLadderEfficiency_BPix2 = cms.vdouble( [1]*32 )
+    digitizer.theLadderEfficiency_BPix3 = cms.vdouble( [1]*44 )
+    digitizer.theModuleEfficiency_BPix1 = cms.vdouble( 1, 1, 1, 1, )
+    digitizer.theModuleEfficiency_BPix2 = cms.vdouble( 1, 1, 1, 1, )
+    digitizer.theModuleEfficiency_BPix3 = cms.vdouble( 1, 1, 1, 1 )
+    digitizer.thePUEfficiency_BPix1 = cms.vdouble( 1.00023, -3.18350e-06, 5.08503e-10, -6.79785e-14 )
+    digitizer.thePUEfficiency_BPix2 = cms.vdouble( 9.99974e-01, -8.91313e-07, 5.29196e-12, -2.28725e-15 )
+    digitizer.thePUEfficiency_BPix3 = cms.vdouble( 1.00005, -6.59249e-07, 2.75277e-11, -1.62683e-15 )
+
+def modifyPixelDigitizerForRun2Bunchspacing50( digitizer ) :
+    """
+    Function that modifies the pixel digitiser for Run 2 with 50ns bunchspacing.
+    
+    First argument is the pixelDigitizer object (generally
+    "process.mix.digitizers.pixel" when this function is called).
+    """
+    # DynamicInefficency - 13TeV - 50ns case
+    digitizer.theInstLumiScaleFactor = cms.double(246.4)
+    digitizer.theLadderEfficiency_BPix1 = cms.vdouble( [0.979259,0.976677]*10 ) # This syntax makes a 20 element array of alternating numbers
+    digitizer.theLadderEfficiency_BPix2 = cms.vdouble( [0.994321,0.993944]*16 )
+    digitizer.theLadderEfficiency_BPix3 = cms.vdouble( [0.996787,0.996945]*22 )
+
+def _modifyPixelDigitizerForRun2( digitiserInstance ) :
+    """
+    Either delegates to modifyPixelDigitizerForRun2Bunchspacing25 or
+    modifyPixelDigitizerForRun2Bunchspacing50 depending on which bunch
+    spacing era is active.
+    Can't simply use the bunchspacing era because I only want it enacted
+    if this is also Run 2 (i.e. eras.run2 AND eras.bunchspacingXns active). 
+    """
+    if eras.bunchspacing25ns.isChosen() and eras.bunchspacing50ns.isChosen() :
+        raise Exception( "ERROR: both the 25ns and 50ns bunch crossing eras are active. Take one of them out of the cms.Process constructor.")
+
+    if eras.bunchspacing25ns.isChosen() :
+        modifyPixelDigitizerForRun2Bunchspacing25( digitiserInstance )
+    elif eras.bunchspacing50ns.isChosen() :
+        modifyPixelDigitizerForRun2Bunchspacing50( digitiserInstance )
+
+eras.run2.toModify( pixelDigitizer, func=_modifyPixelDigitizerForRun2 )
+
+
 # Threshold in electrons are the Official CRAFT09 numbers:
 # FPix(smearing)/BPix(smearing) = 2480(160)/2730(200)
 


### PR DESCRIPTION
This moves the post LS1 customs for the pixels out of the `customiseRun2EraExtras` customisation function and into the `run2` era.  This follows on from #7419.

Note that this doesn't affect the normal postLS1Customs function which is used by default for all post LS1 workflows.  None of these changes have any affect unless the `run2` era is explicitly used.

To use the `run2` era replace

```
--customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1
```

with:

```
--era run2 --customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customiseRun2EraExtras
```

for any postLS1 workflow (the `customiseRun2EraExtras` customisation is just to do the bits still left to be implemented in the `run2` era).  Note that to test this particular change a pileup should also be specified, since the modifications are dependant on the bunch spacing.

The changes in the first commit (22f41e2) are just to update for external changes to the customisations in the last week, and not strictly related to this change (but still required).

First tested by comparing the config files after `edmConfigDump` of 1320.0 with `--pileup AVE_20_BX_25ns` added with and without this pull request - i.e. to make sure the default is unchanged.  No differences whatsoever as expected.
Next tested the same way but with the replacement mentioned above to activate the `run2` era, and compared against when the `customisePostLS1` customisation is used.  Several differences are reported by diff but all can be explained.
- Using the customisation function, customisations are only applied `if hasattr(process,'digitisation_step')`; hence the process.mix for any step other than digi doesn't have the changes.  Using the era the changes are always applied.
- Using the customisation function changes only the copy in `process.mix.digitisers`.  Using the era changes the top level object before it is copied into `process.mix.digitisers` (or anywhere else).  Hence using the era the changes are in all copies.
