### PR TITLE
More ICC cleanups

### DIFF
--- a/DataFormats/GeometrySurface/interface/ReferenceCounted.h
+++ b/DataFormats/GeometrySurface/interface/ReferenceCounted.h
@@ -33,7 +33,7 @@ class BasicReferenceCounted
 
    public:
       BasicReferenceCounted() : referenceCount_(0) {}
-      BasicReferenceCounted( const BasicReferenceCounted& iRHS ) : referenceCount_(0) {}
+      BasicReferenceCounted( const BasicReferenceCounted& /* iRHS */) : referenceCount_(0) {}
 
       const BasicReferenceCounted& operator=( const BasicReferenceCounted& ) {
 	return *this;

--- a/DataFormats/Math/interface/SIMDVec.h
+++ b/DataFormats/Math/interface/SIMDVec.h
@@ -1,7 +1,7 @@
 #ifndef DataFormat_Math_SIMDVec_H
 #define DataFormat_Math_SIMDVec_H
 
-#if ( defined(IN_DICTBUILD) || defined(__REFLEX__) || defined(__CINT__) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16)
+#if ( defined(IN_DICTBUILD) || defined(__REFLEX__) || defined(__CINT__) || defined(__MIC__)) || (__BIGGEST_ALIGNMENT__<16) || defined(__INTEL_COMPILER)
 #elif defined(__GNUC__) || defined(__clang__)
 #  if defined(__x86_64__) && defined(__SSE__)
 #    define USE_SSEVECT

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -74,12 +74,12 @@ namespace edm {
          ObsoleteSignal() = default;
 
          template<typename U>
-         void connect(U iFunc) {
+         void connect(U /*  iFunc */) {
             throwObsoleteSignalException();
          }
          
          template<typename U>
-         void connect_front(U iFunc) {
+         void connect_front(U /*  iFunc*/) {
             throwObsoleteSignalException();
          }
 

--- a/FWCore/Utilities/interface/ConvertException.h
+++ b/FWCore/Utilities/interface/ConvertException.h
@@ -19,8 +19,8 @@ namespace edm {
       try {
         return iFunc();
       }
-      catch (cms::Exception& e) { throw; }
-      catch(std::bad_alloc& bda) { convertException::badAllocToEDM(); }
+      catch (cms::Exception&)  { throw; }
+      catch(std::bad_alloc&) { convertException::badAllocToEDM(); }
       catch (std::exception& e) { convertException::stdToEDM(e); }
       catch(std::string& s) { convertException::stringToEDM(s); }
       catch(char const* c) { convertException::charPtrToEDM(c); }

--- a/FWCore/Utilities/src/TypeID.cc
+++ b/FWCore/Utilities/src/TypeID.cc
@@ -14,7 +14,7 @@ namespace edm {
   TypeID::print(std::ostream& os) const {
     try {
       os << className();
-    } catch (cms::Exception const& e) {
+    } catch (cms::Exception const&) {
       os << typeInfo().name();
     }
   }

--- a/MagneticField/Engine/interface/MagneticField.h
+++ b/MagneticField/Engine/interface/MagneticField.h
@@ -42,7 +42,7 @@ class MagneticField
 
   /// True if the point is within the region where the concrete field
   // engine is defined.
-  virtual bool isDefined(const GlobalPoint& gp) const {
+  virtual bool isDefined(const GlobalPoint& /*gp*/) const {
     return true;
   }
   

--- a/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobian.cc
+++ b/TrackingTools/AnalyticalJacobians/src/AnalyticalCurvilinearJacobian.cc
@@ -314,7 +314,7 @@ void AnalyticalCurvilinearJacobian::computeInfinitesimalJacobian
 void
 AnalyticalCurvilinearJacobian::computeStraightLineJacobian
 (const GlobalTrajectoryParameters& globalParameters,
- const GlobalPoint& x, const GlobalVector& p, const double& s)
+ const GlobalPoint&, const GlobalVector&, const double& s)
 {
   //
   // matrix: elements =1 on diagonal and =0 are already set

--- a/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
+++ b/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
@@ -34,7 +34,7 @@ JacobianCurvilinearToLocal::
 JacobianCurvilinearToLocal(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
 			   const GlobalTrajectoryParameters& globalParameters,
-			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField&) : theJacobian(ROOT::Math::SMatrixNoInit()) {
  
   // GlobalPoint  x =  globalParameters.position();
   // GlobalVector h  = magField.inInverseGeV(x);

--- a/TrackingTools/AnalyticalJacobians/src/JacobianLocalToCurvilinear.cc
+++ b/TrackingTools/AnalyticalJacobians/src/JacobianLocalToCurvilinear.cc
@@ -30,7 +30,7 @@ JacobianLocalToCurvilinear::
 JacobianLocalToCurvilinear(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
 			   const GlobalTrajectoryParameters& globalParameters,
-			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField&) : theJacobian(ROOT::Math::SMatrixNoInit()) {
 
   // GlobalPoint  x =  globalParameters.position();
   // GlobalVector h  = magField.inInverseGeV(x);


### PR DESCRIPTION
This PR does two things:
- Comments out unused method arguments, which ICC complains about.
- Disables our "intrinsics" based math for ICC, and leaves to the compiler the task of optimising things.

`gcc` version should be completely unaffected by these changes. 
