### PR TITLE
Fix pyroot FWLite getByLabel to reset Wrapper when branch not found

### DIFF
--- a/DataFormats/FWLite/test/pyroot_handle_reuse.py
+++ b/DataFormats/FWLite/test/pyroot_handle_reuse.py
@@ -1,0 +1,12 @@
+#! /usr/bin/env python
+import ROOT
+from DataFormats.FWLite import Events, Handle
+
+events = Events (['good_a.root'])
+
+handleGP  = Handle ("edmtest::Thing")
+labelGP = ("Thing")
+
+for event in events:
+    if event.getByLabel (labelGP, handleGP) :
+        prod = handleGP.product()

--- a/DataFormats/FWLite/test/run_all_t.sh
+++ b/DataFormats/FWLite/test/run_all_t.sh
@@ -22,6 +22,8 @@ root -b -n -q ${LOCAL_TEST_DIR}/triggerResultsByName_multi_cint.C || die 'Failed
 ${LOCAL_TEST_DIR}/VIPTest.sh || die 'Failed to create file' $?
 root -b -n -q ${LOCAL_TEST_DIR}/vector_int_cint.C || die 'Failed in vector_int_cint.C' $?
 
+python ${LOCAL_TEST_DIR}/pyroot_handle_reuse.py || die 'Failed in pyroot_handle_reuse.py' $?
+
 #NOTE: ROOT has a bug which keeps the AssociationVector from running its ioread rule and therefore it never clears its cache
 #test AssociationVector reading
 #rm -f ${LOCAL_TEST_DIR}/avtester.root


### PR DESCRIPTION
This fixes a bug in the FWLite python bindings, reported here:

https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3430.html

The bug comes about because the FWLite getByLabel nulls the wrapper when the requested branch isn't found (the comments imply this is intended behavior).  The fix is for the Python getByLabel to check if the wrapper has been nulled and reset it if necessary.  Unit test is included.
