### PR TITLE
Add g4SimHits changes to the run2 era

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -292,8 +292,6 @@ def customiseRun2EraExtras(process):
             process.famosPileUp.PileUpSimulator.fileNames = fileNames_13TeV
 
     # all the rest:
-    if hasattr(process,'g4SimHits'):
-        process.g4SimHits.HFShowerLibrary.FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v3.root'
     if hasattr(process,'reconstruction'):
         #lowering HO threshold with SiPM
         for prod in process.particleFlowRecHitHO.producers:

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -247,18 +247,18 @@ def customiseRun2EraExtras(process):
         if hasattr(process,b):
             #print "BEFORE:  ", getattr(process, b).centralJetSource
             if (getattr(process, b).centralJetSource == cms.InputTag("simGctDigis","cenJets")):
-                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","nonIsoEm")
-                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1FormatDigis","forJets")
-                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1FormatDigis","cenJets")
-                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1FormatDigis","tauJets")
-                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1FormatDigis","isoTauJets")
-                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","isoEm")
-                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","nonIsoEm")
+                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","forJets")
+                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","cenJets")
+                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","tauJets")
+                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoTauJets")
+                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoEm")
+                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
             else:
                 #print "INFO:  customizing ", b, "to use new calo Stage 1 digis converted to legacy format"
                 getattr(process, b).etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis")
@@ -309,6 +309,20 @@ def customiseRun2EraExtras(process):
                     flags              = cms.vstring('Standard')
                 )
             )
+        #Lower Thresholds also for Clusters!!!    
+    
+        for p in process.particleFlowClusterHO.seedFinder.thresholdsByDetector:
+            p.seedingThreshold = cms.double(0.08)
+    
+        for p in process.particleFlowClusterHO.initialClusteringStep.thresholdsByDetector:
+            p.gatheringThreshold = cms.double(0.05)
+    
+        for p in process.particleFlowClusterHO.pfClusterBuilder.recHitEnergyNorms:
+            p.recHitEnergyNorm = cms.double(0.05)
+    
+        process.particleFlowClusterHO.pfClusterBuilder.positionCalc.logWeightDenominator = cms.double(0.05)
+        process.particleFlowClusterHO.pfClusterBuilder.allCellsPositionCalc.logWeightDenominator = cms.double(0.05)
+
     if hasattr(process,'digitisation_step'):
         alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT','PREMIX','PREMIXRAW']
         for a in alist:

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -2,6 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from SimG4Core.Application.hectorParameter_cfi import *
 
+## This object is used to customise g4SimHits for different running scenarios
+from Configuration.StandardSequences.Eras import eras
+
 common_heavy_suppression = cms.PSet(
     NeutronThreshold = cms.double(30.0),
     ProtonThreshold = cms.double(30.0),
@@ -412,4 +415,7 @@ g4SimHits = cms.EDProducer("OscarProducer",
 )
 
 
-
+##
+## Change the HFShowerLibrary file used for Run 2
+##
+eras.run2.toModify( g4SimHits.HFShowerLibrary, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v3.root' )


### PR DESCRIPTION
This is part of a split up #6784, along with #7500 and other already merged PRs.  #7500 and this are towards the same goal but can be merged separately.

This adds the postLS1 changes for g4SimHits to the `run2` era.  Note that none of these changes have any effect unless the `run2` era is explicitly used.  Details on how to do that are on #7500.

I haven't tested for equivalency between the postLS1 customisation and run2 era, it's getting far too time consuming to test each individual tranche.  I'll make sure the default is left unaffected and then apply incremental fixes as required once all tranches have been merged.

As mentioned on #7500, the changes in the first commit (22f41e2) are just to update for external changes to the customisations in the last week, and not strictly related to this change (but still required).
