### PR TITLE
Add most CSC changes to the run2 era

### DIFF
--- a/CalibMuon/CSCCalibration/python/CSCChannelMapper_cfi.py
+++ b/CalibMuon/CSCCalibration/python/CSCChannelMapper_cfi.py
@@ -9,3 +9,8 @@ CSCChannelMapperESProducer = cms.ESProducer("CSCChannelMapperESProducer",
   AlgoName = cms.string("CSCChannelMapperStartup")
 )
 
+#
+# Modify for running in run 2
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( CSCChannelMapperESProducer, AlgoName=cms.string("CSCChannelMapperPostls1") )

--- a/CalibMuon/CSCCalibration/python/CSCIndexer_cfi.py
+++ b/CalibMuon/CSCCalibration/python/CSCIndexer_cfi.py
@@ -9,3 +9,8 @@ CSCIndexerESProducer = cms.ESProducer("CSCIndexerESProducer",
   AlgoName = cms.string("CSCIndexerStartup")
 )
 
+#
+# Modify for running in run 2
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( CSCIndexerESProducer, AlgoName=cms.string("CSCIndexerPostls1") )

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -18,3 +18,11 @@ cscpacker = cms.EDProducer("CSCDigiToRawModule",
 )
 
 
+##
+## Make changes for running in Run 2
+##
+from Configuration.StandardSequences.Eras import eras
+# packer - simply get rid of it
+eras.run2.toModify( cscpacker, useFormatVersion = cms.uint32(2013) )
+eras.run2.toModify( cscpacker, usePreTriggers = cms.bool(False) )
+eras.run2.toModify( cscpacker, packEverything = cms.bool(True) )

--- a/Geometry/CSCGeometryBuilder/python/cscGeometryDB_cfi.py
+++ b/Geometry/CSCGeometryBuilder/python/cscGeometryDB_cfi.py
@@ -17,3 +17,9 @@ CSCGeometryESModule = cms.ESProducer("CSCGeometryESModule",
     applyAlignment = cms.bool(True), ## GF: to be abandoned
     useDDD = cms.bool(False)
 )
+
+#
+# Modify for running in run 2
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( CSCGeometryESModule, useGangedStripsInME1a=False )

--- a/Geometry/CSCGeometryBuilder/python/cscGeometry_cfi.py
+++ b/Geometry/CSCGeometryBuilder/python/cscGeometry_cfi.py
@@ -17,3 +17,9 @@ CSCGeometryESModule = cms.ESProducer("CSCGeometryESModule",
     applyAlignment = cms.bool(True), ## GF: to be abandoned
     useDDD = cms.bool(True)
 )
+
+#
+# Modify for running in run 2
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( CSCGeometryESModule, useGangedStripsInME1a=False )

--- a/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
+++ b/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# This object modifies the csc2DRecHits for running in Run 2
+from Configuration.StandardSequences.Eras import eras
+
 # parameters for CSC rechit building
 from RecoLocalMuon.CSCRecHitD.cscRecHitD_cff import *
 csc2DRecHits = cms.EDProducer("CSCRecHitDProducer",
@@ -60,4 +63,9 @@ csc2DRecHits = cms.EDProducer("CSCRecHitDProducer",
     CSCStripClusterSize = cms.untracked.int32(3)
 )
 
+##
+## Modify for running in Run 2
+##
+eras.run2.toModify( csc2DRecHits, readBadChannels = False )
+eras.run2.toModify( csc2DRecHits, CSCUseGasGainCorrections = False )
 

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -95,12 +95,6 @@ def customiseRun2EraExtras(process):
         process.cscpacker.usePreTriggers = cms.bool(False)
         process.cscpacker.packEverything = cms.bool(True)
 
-    # CSC RecHiti producer adjustments 
-    if hasattr(process, 'csc2DRecHits'):
-        # Turn off some flags for CSCRecHitD that are turned ON in default config
-        process.csc2DRecHits.readBadChannels = cms.bool(False)
-        process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
-
     # deal with L1 Emulation separately:
     # replace the L1 menu from the global tag with one of the following alternatives
     # the menu will be read from an XML file instead of the global tag - must copy the file in luminosityDirectory

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -83,10 +83,6 @@ def customiseRun2EraExtras(process):
 
     # digitizer
     if hasattr(process, 'simMuonCSCDigis'):
-        if hasattr(process,"CSCIndexerESProducer"):
-            process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
-        if hasattr(process,"CSCChannelMapperESProducer"):
-            process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
         ## Make sure there's no bad chambers/channels
         #process.simMuonCSCDigis.strips.readBadChambers = True
         #process.simMuonCSCDigis.wires.readBadChannels = True
@@ -100,11 +96,6 @@ def customiseRun2EraExtras(process):
 
     # L1 stub emulator upgrade algorithm
     if hasattr(process, 'simCscTriggerPrimitiveDigis'):
-        if hasattr(process,"CSCIndexerESProducer"):
-            process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
-        if hasattr(process,"CSCChannelMapperESProducer"):
-            process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
-    
         from L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigisPostLS1_cfi import cscTriggerPrimitiveDigisPostLS1
         process.simCscTriggerPrimitiveDigis = cscTriggerPrimitiveDigisPostLS1
         process.simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'simMuonCSCDigis', 'MuonCSCComparatorDigi')
@@ -125,11 +116,6 @@ def customiseRun2EraExtras(process):
 
     # CSC RecHiti producer adjustments 
     if hasattr(process, 'csc2DRecHits'):
-        if hasattr(process,"CSCIndexerESProducer"):
-            process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
-        if hasattr(process,"CSCChannelMapperESProducer"):
-            process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
-    
         # Turn off some flags for CSCRecHitD that are turned ON in default config
         process.csc2DRecHits.readBadChannels = cms.bool(False)
         process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -247,18 +247,18 @@ def customiseRun2EraExtras(process):
         if hasattr(process,b):
             #print "BEFORE:  ", getattr(process, b).centralJetSource
             if (getattr(process, b).centralJetSource == cms.InputTag("simGctDigis","cenJets")):
-                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","nonIsoEm")
-                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1FormatDigis","forJets")
-                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1FormatDigis","cenJets")
-                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1FormatDigis","tauJets")
-                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1FormatDigis","isoTauJets")
-                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1FormatDigis","isoEm")
-                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1FormatDigis")
-                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1FormatDigis")
+                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","nonIsoEm")
+                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","forJets")
+                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","cenJets")
+                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","tauJets")
+                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoTauJets")
+                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoEm")
+                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
             else:
                 #print "INFO:  customizing ", b, "to use new calo Stage 1 digis converted to legacy format"
                 getattr(process, b).etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis")
@@ -309,6 +309,20 @@ def customiseRun2EraExtras(process):
                     flags              = cms.vstring('Standard')
                 )
             )
+        #Lower Thresholds also for Clusters!!!    
+    
+        for p in process.particleFlowClusterHO.seedFinder.thresholdsByDetector:
+            p.seedingThreshold = cms.double(0.08)
+    
+        for p in process.particleFlowClusterHO.initialClusteringStep.thresholdsByDetector:
+            p.gatheringThreshold = cms.double(0.05)
+    
+        for p in process.particleFlowClusterHO.pfClusterBuilder.recHitEnergyNorms:
+            p.recHitEnergyNorm = cms.double(0.05)
+    
+        process.particleFlowClusterHO.pfClusterBuilder.positionCalc.logWeightDenominator = cms.double(0.05)
+        process.particleFlowClusterHO.pfClusterBuilder.allCellsPositionCalc.logWeightDenominator = cms.double(0.05)
+
     if hasattr(process,'digitisation_step'):
         alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT','PREMIX','PREMIXRAW']
         for a in alist:

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -75,12 +75,6 @@ def customiseRun2EraExtras(process):
             print "         This path has the following modules:"
             print "         ", getattr(process, path_name).moduleNames(),"\n"
 
-    # use unganged geometry
-    if hasattr(process,"CSCGeometryESModule"):
-        process.CSCGeometryESModule.useGangedStripsInME1a = False
-    if hasattr(process,"idealForDigiCSCGeometry"):
-        process.idealForDigiCSCGeometry.useGangedStripsInME1a = False
-
     # digitizer
     if hasattr(process, 'simMuonCSCDigis'):
         ## Make sure there's no bad chambers/channels
@@ -347,7 +341,6 @@ def customiseRun2EraExtras(process):
                     process.mix.digitizers.pixel.thePUEfficiency_BPix2 = cms.vdouble( 9.99974e-01, -8.91313e-07, 5.29196e-12, -2.28725e-15 )
                     process.mix.digitizers.pixel.thePUEfficiency_BPix3 = cms.vdouble( 1.00005, -6.59249e-07, 2.75277e-11, -1.62683e-15 )
     if hasattr(process,'HLTSchedule'):
-        process.CSCGeometryESModule.useGangedStripsInME1a = False
         process.hltCsc2DRecHits.readBadChannels = cms.bool(False)
         process.hltCsc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
         if hasattr(process,"CSCIndexerESProducer"):

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -89,12 +89,6 @@ def customiseRun2EraExtras(process):
         process.simCsctfTrackDigis.DTproducer = cms.untracked.InputTag("simDtTriggerPrimitiveDigis")
         process.simCsctfTrackDigis.SectorReceiverInput = cms.untracked.InputTag("simCscTriggerPrimitiveDigis", "MPCSORTED")
 
-    # packer - simply get rid of it
-    if hasattr(process, 'cscpacker') or hasattr(process, 'csctfpacker'):
-        process.cscpacker.useFormatVersion = cms.uint32(2013)
-        process.cscpacker.usePreTriggers = cms.bool(False)
-        process.cscpacker.packEverything = cms.bool(True)
-
     # deal with L1 Emulation separately:
     # replace the L1 menu from the global tag with one of the following alternatives
     # the menu will be read from an XML file instead of the global tag - must copy the file in luminosityDirectory

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -75,19 +75,6 @@ def customiseRun2EraExtras(process):
             print "         This path has the following modules:"
             print "         ", getattr(process, path_name).moduleNames(),"\n"
 
-    # digitizer
-    if hasattr(process, 'simMuonCSCDigis'):
-        ## Make sure there's no bad chambers/channels
-        #process.simMuonCSCDigis.strips.readBadChambers = True
-        #process.simMuonCSCDigis.wires.readBadChannels = True
-        #process.simMuonCSCDigis.digitizeBadChambers = True
-    
-        ## Customised timing offsets so that ALCTs and CLCTs times are centered in signal BX. 
-        ## These offsets below were tuned for the case of 3 layer pretriggering 
-        ## and median stub timing algorithm.
-        process.simMuonCSCDigis.strips.bunchTimingOffsets = cms.vdouble(0.0, 37.53, 37.66, 55.4, 48.2, 54.45, 53.78, 53.38, 54.12, 51.98, 51.28)
-        process.simMuonCSCDigis.wires.bunchTimingOffsets = cms.vdouble(0.0, 22.88, 22.55, 29.28, 30.0, 30.0, 30.5, 31.0, 29.5, 29.1, 29.88)
-
     # L1 stub emulator upgrade algorithm
     if hasattr(process, 'simCscTriggerPrimitiveDigis'):
         from L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigisPostLS1_cfi import cscTriggerPrimitiveDigisPostLS1

--- a/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
+++ b/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# This object is used to customise for different running scenarios, e.g. run2
+from Configuration.StandardSequences.Eras import eras
+
 simMuonCSCDigis = cms.EDProducer("CSCDigiProducer",
     strips = cms.PSet(
         peakTimeSigma = cms.double(3.0),
@@ -78,5 +81,9 @@ simMuonCSCDigis = cms.EDProducer("CSCDigiProducer",
     layersNeeded = cms.uint32(3)
 )
 
-
+##
+## Change the the bunch timing offsets if running in Run 2
+##
+eras.run2.toModify( simMuonCSCDigis.strips, bunchTimingOffsets=[0.0, 37.53, 37.66, 55.4, 48.2, 54.45, 53.78, 53.38, 54.12, 51.98, 51.28] )
+eras.run2.toModify( simMuonCSCDigis.wires, bunchTimingOffsets=[0.0, 22.88, 22.55, 29.28, 30.0, 30.0, 30.5, 31.0, 29.5, 29.1, 29.88] )
 


### PR DESCRIPTION
This is another pull request to split up #6784 and apply it incrementally.  This part deals with most of the CSC customisations.  #7500 and #7503 are associated but are for different packages.  Each of these pull requests can be merged individually.

Note that none of these changes have any effect unless the run2 era is explicitly used. Details on how to do that are on #7500.

There are still some CSC customisations to move from the helper customisation to the era.  I need to check the overlap with trigger code and I'll move those in a subsequent pull request.  As mentioned on #7500, the changes in the first commit (22f41e2) are just to update for external changes to the customisations in the last week, and not strictly related to this change (but still required).
