### PR TITLE
Updated HBHENegativeFlag class to access a1 and a2 functions directly

### DIFF
--- a/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrData.h
@@ -87,6 +87,21 @@ public:
         }
     }
 
+    inline const OOTPileupCorrDataFcn& getCorrectionByID(const HcalDetId& id) const
+    {
+        const unsigned nLimits = iEtaLimits_.size();
+        unsigned which(0U);
+        if (nLimits)
+        {
+	    const uint32_t uEta = std::abs(id.ieta());
+	    const uint32_t* limits(&iEtaLimits_[0]);
+	    for (; which<nLimits; ++which)
+	        if (uEta < limits[which])
+	            break;
+        }
+        return corrs_.at(which);
+    }
+
 protected:
     // Comparison function must be implemented
     inline bool isEqual(const AbsOOTPileupCorrection& otherBase) const

--- a/CondFormats/HcalObjects/interface/OOTPileupCorrDataFcn.h
+++ b/CondFormats/HcalObjects/interface/OOTPileupCorrDataFcn.h
@@ -35,6 +35,12 @@ public:
         ts[tsTrig+1] = a1_(ts[tsTrig]);
     }
 
+    // Access the correction functions
+    inline const PiecewiseScalingPolynomial& getA1() const {return a1_;}
+    inline const PiecewiseScalingPolynomial& getA2() const {return a2_;}
+    inline const PiecewiseScalingPolynomial& getA3() const {return a3_;}
+    inline const ScalingExponential& getA_1() const {return a_1_;}
+
 private:
     PiecewiseScalingPolynomial a1_, a2_, a3_;
     ScalingExponential a_1_;

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
@@ -81,8 +81,8 @@ hbheprereco = cms.EDProducer(
                                   TS4TS5ChargeThreshold = cms.double(70),
                                   First = cms.int32(4),
                                   Last = cms.int32(6),
-                                  Threshold = cms.vdouble(100, 120, 160, 200, 300, 500),
-                                  Cut = cms.vdouble(-50, -100, -100, -100, -100, -100)),
+                                  Threshold = cms.vdouble(100, 120, 160, 200, 300, 500, 1.0e4),
+                                  Cut = cms.vdouble(-50, -100, -100, -100, -100, -100, -1.0e6)),
 
     # shaped cut parameters are triples of (energy, low time threshold, high time threshold) values.
     # The low and high thresholds must straddle zero (i.e., low<0, high>0); use win_offset to shift.


### PR DESCRIPTION
Made correction functions a1, a2, etc. accessible outside of OOTPileupCorrData.

Updated HBHENegativeFlag class so that it can be used together with current implementations of HCAL Method 1/Method 2.

The cuts are disabled beyond 500 fC (100 GeV). This should fix the problem found by Carl. The cuts are to be updated in the future.

This supersedes PR #7345. I was not able to update that PR because git cms-merge-topic failed on me. Compared to that PR, the only change is in the file HcalHitReconstructor_hbhe_cfi.py.
