### PR TITLE
remove fastsim wf 1200; 

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_production.py
+++ b/Configuration/PyReleaseValidation/python/relval_production.py
@@ -26,5 +26,5 @@ workflows[1102]=['RR', ['TTbar','DIGI','RECO','RECOFROMRECO','COPYPASTE']]
 #workflows[1104]=['',['OldGenSimINPUT','RESIM','DIGIPU','RERECOPU']]
 
 ## special fastsim test
-workflows[1200]=['TTbar',['TTbarSFS','RECOFS','HARVESTFS']]
+#workflows[1200]=['TTbar',['TTbarSFS','RECOFS','HARVESTFS']]
 workflows[1201]=['TTbar',['TTbarSFSA']]


### PR DESCRIPTION
running GEN-SIM separated from RECO currently not supported
breaks IB tests

as requested by @davidlange6  @ktf 
