### PR TITLE
add new CaloConfig table and support to L1T CondFormats

### DIFF
--- a/CondCore/L1TPlugins/src/plugin.cc
+++ b/CondCore/L1TPlugins/src/plugin.cc
@@ -199,5 +199,8 @@ REGISTER_PLUGIN(L1CaloGeometryRecord, L1CaloGeometry);
 
 #include "CondFormats/L1TObjects/interface/CaloParams.h"
 #include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
+#include "CondFormats/DataRecord/interface/L1TCaloConfigRcd.h"
 using namespace l1t;
 REGISTER_PLUGIN(L1TCaloParamsRcd, CaloParams);
+REGISTER_PLUGIN(L1TCaloConfigRcd, CaloConfig);

--- a/CondFormats/DataRecord/interface/L1TCaloConfigRcd.h
+++ b/CondFormats/DataRecord/interface/L1TCaloConfigRcd.h
@@ -1,0 +1,24 @@
+///
+/// \class L1TCaloConfigRcd
+///
+/// Description: Record for CaloConfig
+///
+/// Implementation:
+///    
+///
+/// \author: Jim Brooke, University of Bristol
+///
+#ifndef CondFormatsDataRecord_L1TCaloConfigRcd_h
+#define CondFormatsDataRecord_L1TCaloConfigRcd_h
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class L1TCaloConfigRcd : public edm::eventsetup::EventSetupRecordImplementation<L1TCaloConfigRcd> {};
+
+// Dependent record implmentation:
+//#include "FWCore/Framework/interface/DependentRecordImplementation.h"
+//#include "CondFormats/DataRecord/interface/L1TriggerKeyListRcd.h"
+//#include "CondFormats/DataRecord/interface/L1TriggerKeyRcd.h"
+//class L1TCaloConfigRcd : public edm::eventsetup::DependentRecordImplementation<L1TCaloConfigRcd, boost::mpl::vector<L1TriggerKeyListRcd,L1TriggerKeyRcd> > {};
+
+#endif

--- a/CondFormats/DataRecord/src/L1TCaloConfigRcd.cc
+++ b/CondFormats/DataRecord/src/L1TCaloConfigRcd.cc
@@ -1,0 +1,13 @@
+///                                                                                                   
+/// \class L1TCaloConfigRcd
+///
+/// Description: see header file
+///
+/// Implementation:
+///
+
+
+#include "CondFormats/DataRecord/interface/L1TCaloConfigRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(L1TCaloConfigRcd);

--- a/CondFormats/L1TObjects/interface/CaloConfig.h
+++ b/CondFormats/L1TObjects/interface/CaloConfig.h
@@ -30,7 +30,9 @@ namespace l1t {
 
     CaloConfig() { version_=Version; }
     ~CaloConfig() {}
+    friend class CaloConfigHelper;
 
+  private:
     unsigned version_;
     std::vector<unsigned> uconfig_;
     std::vector<std::string> sconfig_;

--- a/CondFormats/L1TObjects/interface/CaloConfig.h
+++ b/CondFormats/L1TObjects/interface/CaloConfig.h
@@ -1,0 +1,42 @@
+///
+/// \class l1t::CaloConfig
+///
+/// Description: Placeholder for calorimeter trigger runtime configuration
+///
+/// Implementation:
+///
+///
+
+#ifndef CaloConfig_h
+#define CaloConfig_h
+
+#include <memory>
+#include <iostream>
+#include <vector>
+#include <string>
+#include <cmath>
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/L1TObjects/interface/LUT.h"
+
+namespace l1t {
+
+
+  class CaloConfig {
+
+  public:
+
+    enum { Version = 1 };
+
+    CaloConfig() { version_=Version; }
+    ~CaloConfig() {}
+
+    unsigned version_;
+    std::vector<unsigned> uconfig_;
+    std::vector<std::string> sconfig_;
+
+    COND_SERIALIZABLE;
+  };
+
+}// namespace
+#endif

--- a/CondFormats/L1TObjects/interface/CaloConfig.h
+++ b/CondFormats/L1TObjects/interface/CaloConfig.h
@@ -28,7 +28,7 @@ namespace l1t {
 
     enum { Version = 1 };
 
-    CaloConfig() { version_= (int) Version; }
+    CaloConfig() { version_= (unsigned) Version; }
     ~CaloConfig() {}
     friend class CaloConfigHelper;
 

--- a/CondFormats/L1TObjects/interface/CaloConfig.h
+++ b/CondFormats/L1TObjects/interface/CaloConfig.h
@@ -28,7 +28,7 @@ namespace l1t {
 
     enum { Version = 1 };
 
-    CaloConfig() { version_=Version; }
+    CaloConfig() { version_= (int) Version; }
     ~CaloConfig() {}
     friend class CaloConfigHelper;
 

--- a/CondFormats/L1TObjects/src/CaloConfig.cc
+++ b/CondFormats/L1TObjects/src/CaloConfig.cc
@@ -1,0 +1,3 @@
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
+
+

--- a/CondFormats/L1TObjects/src/T_EventSetup_CaloConfig.cc
+++ b/CondFormats/L1TObjects/src/T_EventSetup_CaloConfig.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(l1t::CaloConfig);

--- a/CondFormats/L1TObjects/src/classes.h
+++ b/CondFormats/L1TObjects/src/classes.h
@@ -46,6 +46,7 @@
 
 #include "CondFormats/L1TObjects/interface/LUT.h"
 #include "CondFormats/L1TObjects/interface/CaloParams.h"
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
 
 
 namespace CondFormats_L1TObjects {
@@ -53,6 +54,8 @@ namespace CondFormats_L1TObjects {
     std::vector<l1t::CaloParams::Node> dummy1a;
     l1t::CaloParams dummy1b;
     l1t::LUT dummy1c;
+
+    l1t::CaloConfig dummy2;
 
     std::vector<L1MuDTExtLut::LUT> dummy3 ;
     std::vector<L1GtMuonTemplate> dummy4 ;

--- a/CondFormats/L1TObjects/src/classes_def.xml
+++ b/CondFormats/L1TObjects/src/classes_def.xml
@@ -19,6 +19,7 @@
   <class name="l1t::CaloParams::EgParams"/>
   <class name="l1t::CaloParams::JetParams"/>
   <class name="l1t::CaloParams::TauParams"/>
+  <class name="l1t::CaloConfig"/>
   <class name="L1MuScale"/>
   <class name="L1MuBinnedScale">
     <field name="m_Scale" mapping="blob" />

--- a/CondFormats/L1TObjects/test/testSerializationL1TObjects.cpp
+++ b/CondFormats/L1TObjects/test/testSerializationL1TObjects.cpp
@@ -4,6 +4,8 @@
 
 int main()
 {
+  testSerialization<l1t::CaloParams>();
+  testSerialization<l1t::CaloConfig>();
     testSerialization<L1CaloEcalScale>();
     testSerialization<L1CaloEtScale>();
     testSerialization<L1CaloGeometry>();

--- a/CondTools/L1Trigger/plugins/SealModule.cc
+++ b/CondTools/L1Trigger/plugins/SealModule.cc
@@ -217,5 +217,8 @@ REGISTER_L1_WRITER(L1CaloGeometryRecord, L1CaloGeometry);
 
 #include "CondFormats/L1TObjects/interface/CaloParams.h"
 #include "CondFormats/DataRecord/interface/L1TCaloParamsRcd.h"
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
+#include "CondFormats/DataRecord/interface/L1TCaloConfigRcd.h"
 using namespace l1t;
 REGISTER_L1_WRITER(L1TCaloParamsRcd, CaloParams);
+REGISTER_L1_WRITER(L1TCaloConfigRcd, CaloConfig);

--- a/L1Trigger/L1TCalorimeter/interface/CaloConfigHelper.h
+++ b/L1Trigger/L1TCalorimeter/interface/CaloConfigHelper.h
@@ -1,0 +1,22 @@
+// CaloConfigHelper.h
+//
+// Wrapper class for CaloConfig
+
+#ifndef CALO_CONFIG_HELPER_H__
+#define CALO_CONFIG_HELPER_H__
+
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
+
+namespace l1t {
+
+  class CaloConfigHelper {
+  public:
+    CaloConfigHelper(CaloConfig & db, unsigned fwv, std::string epoch);
+    CaloConfigHelper(CaloConfig & db);
+    unsigned fwv(){ return db_.uconfig_[0]; }
+  private:
+    CaloConfig & db_;
+  };
+}
+
+#endif

--- a/L1Trigger/L1TCalorimeter/plugins/CaloConfigWriter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/CaloConfigWriter.cc
@@ -1,0 +1,52 @@
+// CaloConfigWriter
+//
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "CondFormats/DataRecord/interface/L1TCaloConfigRcd.h"
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CondCore/DBOutputService/interface/PoolDBOutputService.h"
+#include "CondTools/L1Trigger/interface/DataWriter.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/MessageLogger/interface/MessageDrop.h"
+
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include <iostream>
+
+#include <iostream>
+
+//
+// class declaration
+//
+
+class CaloConfigWriter : public edm::EDAnalyzer {
+public:
+  explicit CaloConfigWriter(const edm::ParameterSet&) {}
+  virtual  ~CaloConfigWriter() {}
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;  
+
+};
+
+
+
+void CaloConfigWriter::analyze(const edm::Event& iEvent, const edm::EventSetup& evSetup)
+{
+  l1t::DataWriter dataWriter;  
+  std::string token = dataWriter.writePayload(evSetup, "L1TCaloConfigRcd@CaloConfig");
+  if ( dataWriter.updateIOV("L1TCaloConfigRcd", token, 1, false) ) std::cout << "IOV updated!" << std::endl;
+  std::cout << "Payload token = " << token << std::endl;
+}
+
+DEFINE_FWK_MODULE(CaloConfigWriter);
+
+
+

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloConfigESProducer.cc
@@ -1,0 +1,102 @@
+///
+/// \class L1TCaloConfigESProducer
+///
+/// Description: Produces configuration of Calo Trigger
+///
+/// Implementation:
+///    Dummy producer for L1 calo upgrade runtime configuration
+///
+
+
+// system include files
+#include <memory>
+#include "boost/shared_ptr.hpp"
+#include <iostream>
+#include <fstream>
+
+// user include files
+#include "FWCore/Framework/interface/ModuleFactory.h"
+#include "FWCore/Framework/interface/ESProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESProducts.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "FWCore/ParameterSet/interface/FileInPath.h"
+
+#include "CondFormats/L1TObjects/interface/CaloConfig.h"
+#include "L1Trigger/L1TCalorimeter/interface/CaloConfigHelper.h"
+#include "CondFormats/DataRecord/interface/L1TCaloConfigRcd.h"
+
+using namespace std;
+
+//
+// class declaration
+//
+
+using namespace l1t;
+
+class L1TCaloConfigESProducer : public edm::ESProducer {
+public:
+  L1TCaloConfigESProducer(const edm::ParameterSet&);
+  ~L1TCaloConfigESProducer();
+
+  typedef boost::shared_ptr<CaloConfig> ReturnType;
+
+  ReturnType produce(const L1TCaloConfigRcd&);
+
+private:
+  CaloConfig  m_params;
+  std::string m_label;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+L1TCaloConfigESProducer::L1TCaloConfigESProducer(const edm::ParameterSet& conf)
+{
+  //the following line is needed to tell the framework what
+  // data is being produced
+  setWhatProduced(this);
+  //setWhatProduced(this, conf.getParameter<std::string>("label"));
+
+  std::string l1epoch = conf.getParameter<string>("l1Epoch");
+  unsigned fwv = conf.getParameter<unsigned>("fwVersionLayer2");
+  CaloConfigHelper h(m_params, fwv, l1epoch);
+}
+
+
+L1TCaloConfigESProducer::~L1TCaloConfigESProducer()
+{
+
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+L1TCaloConfigESProducer::ReturnType
+L1TCaloConfigESProducer::produce(const L1TCaloConfigRcd& iRecord)
+{
+   using namespace edm::es;
+   boost::shared_ptr<CaloConfig> pCaloConfig ;
+   pCaloConfig = boost::shared_ptr< CaloConfig >(new CaloConfig(m_params));
+   return pCaloConfig;
+}
+
+
+
+//define this as a plug-in
+DEFINE_FWK_EVENTSETUP_MODULE(L1TCaloConfigESProducer);

--- a/L1Trigger/L1TCalorimeter/python/caloConfigStage1PP_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloConfigStage1PP_cfi.py
@@ -1,0 +1,14 @@
+import FWCore.ParameterSet.Config as cms
+
+caloConfigSource = cms.ESSource(
+    "EmptyESSource",
+    recordName = cms.string('L1TCaloConfigRcd'),
+    iovIsRunNotTime = cms.bool(True),
+    firstValid = cms.vuint32(1)
+)
+
+caloConfig = cms.ESProducer(
+    "L1TCaloConfigESProducer",
+    l1Epoch         = cms.string("Stage1"),
+    fwVersionLayer2 = cms.uint32(1)
+)

--- a/L1Trigger/L1TCalorimeter/python/testWriteCaloConfigTag.py
+++ b/L1Trigger/L1TCalorimeter/python/testWriteCaloConfigTag.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('L1TEST')
+
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.MessageLogger.cout.threshold = cms.untracked.string('DEBUG')
+process.MessageLogger.debugModules = cms.untracked.vstring('L1-O2O')
+process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.load('Configuration.EventContent.EventContent_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1)
+    )
+
+process.source = cms.Source('EmptySource')
+
+# Other statements
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag.connect = cms.string('frontier://FrontierProd/CMS_COND_31X_GLOBALTAG')
+process.GlobalTag.globaltag = cms.string('POSTLS162_V2::All')
+
+# New parameters
+process.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
+process.caloConfigWriter = cms.EDAnalyzer("CaloConfigWriter")
+
+process.p = cms.Path(
+    process.caloConfigWriter
+)
+
+from CondCore.DBCommon.CondDBSetup_cfi import CondDBSetup
+process.PoolDBOutputService = cms.Service("PoolDBOutputService",
+    CondDBSetup,
+    connect = cms.string('sqlite_file:l1config.db'),
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(
+        cms.PSet(
+            record = cms.string('L1TCaloConfigRcd'),
+            tag = cms.string('L1TCaloConfigRcd_Testing')
+        )
+    )
+)

--- a/L1Trigger/L1TCalorimeter/src/CaloConfigHelper.cc
+++ b/L1Trigger/L1TCalorimeter/src/CaloConfigHelper.cc
@@ -1,0 +1,14 @@
+// CaloConfigHelper.cc
+
+#include "L1Trigger/L1TCalorimeter/interface/CaloConfigHelper.h"
+
+namespace l1t {
+  
+  CaloConfigHelper::CaloConfigHelper(CaloConfig & db, unsigned fwv, std::string epoch) : db_(db) {
+    db_.uconfig_.push_back(fwv);
+    db_.sconfig_.push_back(epoch);
+  }
+  CaloConfigHelper::CaloConfigHelper(CaloConfig & db) : db_(db) {
+    
+  }
+}


### PR DESCRIPTION
This adds a new table to CondFormats/L1Trigger to contain firmware version information.  This is a pure addition, which does not yet effect any of the existing code.  This table will be needed to wean L1T off of customizations!
