### PR TITLE
optimize memory usage in meantimer

### DIFF
--- a/RecoLocalMuon/DTSegment/src/DTHitPairForFit.cc
+++ b/RecoLocalMuon/DTSegment/src/DTHitPairForFit.cc
@@ -81,7 +81,7 @@ DTHitPairForFit::isCompatible(const LocalPoint& posIni,
 
 bool DTHitPairForFit::operator<(const DTHitPairForFit& hit) const {
   //SL if same layer use x() for strict ordering
-  if (id()==hit.id()) 
+  if (id()==hit.id())
     return (theLeftPos.x() < hit.localPosition(DTEnums::Left).x());
   return (id() < hit.id());
 }

--- a/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.h
+++ b/RecoLocalMuon/DTSegment/src/DTMeantimerPatternReco.h
@@ -83,23 +83,17 @@ class DTMeantimerPatternReco : public DTRecSegment2DBaseAlgo {
 					    const std::vector<std::shared_ptr<DTHitPairForFit>>& hits);
 
   // try adding more hits to a candidate
-  void addHits(const DTSuperLayer* sl, 
-               std::vector<DTSegmentCand::AssPoint>& assHits, 
-               const std::vector<std::shared_ptr<DTHitPairForFit>>& hits, 
+  void addHits(DTSegmentCand* segCand,
+               const std::vector<std::shared_ptr<DTHitPairForFit>>& hits,
                std::vector<DTSegmentCand*> &result);
 
   // fit a set of left/right hits, calculate t0 and chi^2
-  std::unique_ptr<DTSegmentCand> fitWithT0(const DTSuperLayer* sl,
-                                           const std::vector<DTSegmentCand::AssPoint> &assHits, 
-                                           double &chi2, 
-                                           double &t0_corr, 
-                                           const bool fitdebug);
+  DTSegmentCand* fitWithT0(DTSegmentCand* seg, const bool fitdebug);
 
   // check if two hist can be considered in one segment (come from different layers, not too far away etc.)
   bool geometryFilter( const DTWireId first, const DTWireId second ) const;
 
-  bool checkDoubleCandidates(std::vector<DTSegmentCand*>& segs,
-			     DTSegmentCand* seg);
+  bool checkDoubleCandidates(std::vector<DTSegmentCand*>& segs, DTSegmentCand* seg);
 
   void printPattern( std::vector<DTSegmentCand::AssPoint>& assHits, const DTHitPairForFit* hit);
 

--- a/RecoLocalMuon/DTSegment/src/DTSegmentCand.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentCand.cc
@@ -58,8 +58,13 @@ bool DTSegmentCand::operator<(const DTSegmentCand& seg){
   return (nHits()<seg.nHits());
 }
 
+void DTSegmentCand::add(AssPoint newHit) {
+  theHits.insert(newHit);
+}
+
 void DTSegmentCand::add(std::shared_ptr<DTHitPairForFit> hit, DTEnums::DTCellSide code) {
-  theHits.insert(AssPoint(hit,code));
+  AssPoint newHit(hit,code);
+  theHits.insert(newHit);
 }
 
 void DTSegmentCand::removeHit(AssPoint badHit) {
@@ -68,12 +73,11 @@ void DTSegmentCand::removeHit(AssPoint badHit) {
 
 int DTSegmentCand::nSharedHitPairs(const DTSegmentCand& seg) const{
   int result=0;
-  AssPointCont hitsCont = seg.hits();
 
   for (AssPointCont::const_iterator hit=theHits.begin(); 
        hit!=theHits.end() ; ++hit) {
-    for (AssPointCont::const_iterator hit2=hitsCont.begin();
-         hit2!=hitsCont.end() ; ++hit2) {
+    for (AssPointCont::const_iterator hit2=seg.hits().begin();
+         hit2!=seg.hits().end() ; ++hit2) {
       //  if(result) return result ; // TODO, uncomm this line or move it in another func
       if ((*(*hit).first)==(*(*hit2).first)) {
         ++result;
@@ -128,7 +132,6 @@ bool DTSegmentCand::hitsShareLayer() const
       assHit!=theHits.end(); ++assHit) {
     layerN[i]=(*assHit).first->id().layerId().layer()+10*(*assHit).first->id().superlayerId().superlayer();
     i++;
-//    std::cout << (*assHit).first->id().layerId().layer()+10*(*assHit).first->id().superlayerId().superlayer()) << std::endl;
   }
 
   for(int i=0;i<(int)theHits.size();i++){
@@ -196,7 +199,7 @@ DTSegmentCand::operator DTChamberRecSegment2D*() const{
     GlobalPoint hitGlobalPos =
       theSL->toGlobal( (*assHit).first->localPosition((*assHit).second) );
     
-    LocalPoint hitPosInLayer = 
+    LocalPoint hitPosInLayer =
       theSL->chamber()
       ->superLayer((*assHit).first->id().superlayerId())
       ->layer( (*assHit).first->id().layerId() )->toLocal(hitGlobalPos);

--- a/RecoLocalMuon/DTSegment/src/DTSegmentCand.h
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentCand.h
@@ -96,6 +96,7 @@ class DTSegmentCand{
     virtual void setDirection(LocalVector& dir) { theDirection = dir; }
 
     /// add hits to the hit list.
+    virtual void add(AssPoint newHit) ;
     virtual void add(std::shared_ptr<DTHitPairForFit> hit, DTEnums::DTCellSide code) ;
 
     /// remove hit from the candidate
@@ -119,9 +120,9 @@ class DTSegmentCand{
 
     /// number of different layers with hits
     virtual int nLayers() const ;
-    
+
     /// the used hits
-    virtual AssPointCont hits() const { return theHits;}
+    virtual const AssPointCont& hits() const { return theHits;}
 
     /// convert this DTSegmentCand into a DTRecSegment2D
     //  DTSLRecSegment2D* convert() const;

--- a/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
+++ b/RecoLocalMuon/DTSegment/src/DTSegmentUpdator.cc
@@ -227,15 +227,14 @@ bool DTSegmentUpdator::fit(DTSegmentCand* seg, bool allow3par, const bool fitdeb
   vector <int> lfit;
   vector <double> dist;
   int i=0;
-  
+
   x.reserve(8);
   y.reserve(8);
   sigy.reserve(8);
   lfit.reserve(8);
   dist.reserve(8);
 
-  DTSegmentCand::AssPointCont hits=seg->hits();
-  for (DTSegmentCand::AssPointCont::const_iterator iter=hits.begin(); iter!=hits.end(); ++iter) {
+  for (DTSegmentCand::AssPointCont::const_iterator iter=seg->hits().begin(); iter!=seg->hits().end(); ++iter) {
     LocalPoint pos = (*iter).first->localPosition((*iter).second);
     float xwire = (((*iter).first)->localPosition(DTEnums::Left).x() + ((*iter).first)->localPosition(DTEnums::Right).x()) /2.;
     float distance = pos.x() - xwire;
@@ -261,7 +260,8 @@ bool DTSegmentUpdator::fit(DTSegmentCand* seg, bool allow3par, const bool fitdeb
   fit(x,y,lfit,dist,sigy,pos,dir,cminf,vminf,covMat,chi2,allow3par);
   if (cminf!=0) t0_corr=-cminf/0.00543; // convert drift distance to time
 
-  if (debug && fitdebug) cout << "  DTcand chi2: " << chi2 << "/" << x.size() << "   t0: " << t0_corr << endl;
+  if (debug && fitdebug)
+    cout << "  DTcand chi2: " << chi2 << "/" << x.size() << "   t0: " << t0_corr << endl;
 
   seg->setPosition(pos);
   seg->setDirection(dir);


### PR DESCRIPTION
addressing the issue reported in https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1314.html
optimize memory usage in DT local reco (algorithm output unchanged)
