### PR TITLE
Check for valid pointers in Jet Constituents

### DIFF
--- a/DataFormats/JetReco/src/Jet.cc
+++ b/DataFormats/JetReco/src/Jet.cc
@@ -43,26 +43,26 @@ namespace {
   class CaloPointZ: private CaloPoint{
   public:
     CaloPointZ (double fZ, double fEta){
-      
+
       static const double ETA_MAX = 5.2;
-      
+
       if (fZ > Z_ENDCAP) fZ = Z_ENDCAP-1.;
       if (fZ < -Z_ENDCAP) fZ = -Z_ENDCAP+1; // sanity check
-      
+
       double tanThetaAbs = std::sqrt (std::cosh(fEta)*std::cosh(fEta) - 1.);
       double tanTheta = fEta >= 0 ? tanThetaAbs : -tanThetaAbs;
-      
-      double rEndcap = tanTheta == 0 ? 1.e10 : 
+
+      double rEndcap = tanTheta == 0 ? 1.e10 :
 	fEta > 0 ? (Z_ENDCAP - fZ) / tanTheta : (-Z_ENDCAP - fZ) / tanTheta;
       if (rEndcap > R_BARREL) { // barrel
 	mR = R_BARREL;
-	mZ = fZ + R_BARREL * tanTheta; 
+	mZ = fZ + R_BARREL * tanTheta;
       }
       else {
 	double zRef = Z_BIG; // very forward;
 	if (rEndcap > R_FORWARD) zRef = Z_ENDCAP; // endcap
 	else if (std::fabs (fEta) < ETA_MAX) zRef = Z_FORWARD; // forward
-	
+
 	mZ = fEta > 0 ? zRef : -zRef;
 	mR = std::fabs ((mZ - fZ) / tanTheta);
       }
@@ -85,7 +85,7 @@ namespace {
     double mR;
   };
 
-  //new implementation to derive CaloPoint for free 3d vertex. 
+  //new implementation to derive CaloPoint for free 3d vertex.
   //code provided thanks to Christophe Saout
   template<typename Point>
   class CaloPoint3D : private CaloPoint {
@@ -158,8 +158,8 @@ namespace {
 
 }
 
-Jet::Jet (const LorentzVector& fP4, 
-	  const Point& fVertex, 
+Jet::Jet (const LorentzVector& fP4,
+	  const Point& fVertex,
 	  const Constituents& fConstituents)
   :  CompositePtrCandidate (0, fP4, fVertex),
      mJetArea (0),
@@ -169,10 +169,10 @@ Jet::Jet (const LorentzVector& fP4,
   for (unsigned i = 0; i < fConstituents.size (); i++) {
     addDaughter (fConstituents [i]);
   }
-}  
+}
 
-Jet::Jet (const LorentzVector& fP4, 
-	  const Point& fVertex) 
+Jet::Jet (const LorentzVector& fP4,
+	  const Point& fVertex)
   :  CompositePtrCandidate (0, fP4, fVertex),
      mJetArea (0),
      mPileupEnergy (0),
@@ -358,7 +358,12 @@ Jet::Constituents Jet::getJetConstituents () const {
 std::vector<const Candidate*> Jet::getJetConstituentsQuick () const {
   std::vector<const Candidate*> result;
   int nDaughters = numberOfDaughters();
-  for (int i = 0; i < nDaughters; ++i) { 
+  for (int i = 0; i < nDaughters; ++i) {
+    if(!(this->sourceCandidatePtr(i).isNonnull() && this->sourceCandidatePtr(i).isAvailable()))
+    {
+        std::cerr << "Bad pointer to jet constituent found.  Check for possible dropped particle." << std::endl;
+        continue;
+    }
     result.push_back (daughter (i));
   }
   return result;
@@ -430,9 +435,9 @@ std::string Jet::print () const {
   for (unsigned index = 0; index < numberOfDaughters(); index++) {
     Constituent constituent = daughterPtr (index); // deref
     if (constituent.isNonnull()) {
-      out << "      #" << index << " p/pt/eta/phi: " 
-	  << constituent->p() << '/' << constituent->pt() << '/' << constituent->eta() << '/' << constituent->phi() 
-	  << "    productId/index: " << constituent.id() << '/' << constituent.key() << std::endl; 
+      out << "      #" << index << " p/pt/eta/phi: "
+	  << constituent->p() << '/' << constituent->pt() << '/' << constituent->eta() << '/' << constituent->phi()
+	  << "    productId/index: " << constituent.id() << '/' << constituent.key() << std::endl;
     }
     else {
       out << "      #" << index << " constituent is not available in the event"  << std::endl;

--- a/DataFormats/JetReco/src/Jet.cc
+++ b/DataFormats/JetReco/src/Jet.cc
@@ -6,6 +6,7 @@
 
 #include "DataFormats/Math/interface/deltaR.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 //Own header file
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -361,7 +362,7 @@ std::vector<const Candidate*> Jet::getJetConstituentsQuick () const {
   for (int i = 0; i < nDaughters; ++i) {
     if(!(this->sourceCandidatePtr(i).isNonnull() && this->sourceCandidatePtr(i).isAvailable()))
     {
-        std::cerr << "Bad pointer to jet constituent found.  Check for possible dropped particle." << std::endl;
+        edm::LogInfo("JetConstituentPointer") << "Bad pointer to jet constituent found.  Check for possible dropped particle.";
         continue;
     }
     result.push_back (daughter (i));

--- a/DataFormats/JetReco/src/Jet.cc
+++ b/DataFormats/JetReco/src/Jet.cc
@@ -362,11 +362,7 @@ std::vector<const Candidate*> Jet::getJetConstituentsQuick () const {
   for (int i = 0; i < nDaughters; ++i) {
     if(!(this->sourceCandidatePtr(i).isNonnull() && this->sourceCandidatePtr(i).isAvailable()))
     {
-<<<<<<< HEAD
         edm::LogInfo("JetConstituentPointer") << "Bad pointer to jet constituent found.  Check for possible dropped particle.";
-=======
-        std::cerr << "Bad pointer to jet constituent found.  Check for possible dropped particle." << std::endl;
->>>>>>> 6173104247ae9bb5d166e7f12418d93789a5d8ee
         continue;
     }
     result.push_back (daughter (i));


### PR DESCRIPTION
This fix is a quick check for candidatePtr Validity before the Jet is passed to the return statement of the function getJetConstituentsQuick() in reco::Jet and fixes a runtime error due to some Jet constituent particles being dropped from miniAOD.  The error was due to the references to the dropped particle still being in the Jet after slimming as they are created during reconstruction.  
