### PR TITLE
Changed to use track only isolation for PFmuon

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFMuonAlgo.cc
@@ -461,10 +461,8 @@ PFMuonAlgo::isIsolatedMuon( const reco::MuonRef& muonRef ){
     }
      
   double sumPtR03 = muonRef->isolationR03().sumPt;
-  double emEtR03 = muonRef->isolationR03().emEt;
-  double hadEtR03 = muonRef->isolationR03().hadEt;
   
-  double relIso = (sumPtR03 + emEtR03 + hadEtR03)/smallestMuPt;
+  double relIso = sumPtR03/smallestMuPt;
 
   if(relIso<0.1) return true;
   else return false;


### PR DESCRIPTION
This work is to improve the PFmuon quality in coming run2 data taking in which a huge track multiplicity is expected. Because of the good track granularity, many fake muons can be reconstructed as a good muon. In order to reduce the fake muon, a study is performed to use track only isolation in the PF muon algorithm. 
