### PR TITLE
Ecalmultifit use DB inputs and retuning of spike flagging

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,27 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V2::All',
+    'run1_design'       :   'DESRUN1_74_V1::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V2::All',
+    'run1_mc'           :   'MCRUN1_74_V1::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V2::All',
+    'run1_mc_hi'        :   'MCHI1_74_V1::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V2::All',
+    'run1_mc_pa'        :   'MCPA1_74_V1::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V3::All',
+    'run2_design'       :   'DESRUN2_74_V1::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V6::All',
+    'run2_mc_50ns'      :   'MCRUN2_74_V2::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V7::All',
+    'run2_mc'           :   'MCRUN2_74_V3::All',
+    # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
+    'run2_mc_hi'        :   'MCHI2_74_V1::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_73_V0A::All',
+    'run1_data'         :   'GR_R_74_V2A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_73_V1A::All',
+    'run2_data'         :   'GR_R_74_V3A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V43A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V49A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V44A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V50A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,27 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_73_V2',
+    'run1_design'       :   'DESRUN1_74_V1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_73_V2',
+    'run1_mc'           :   'MCRUN1_74_V1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_73_V2',
+    'run1_mc_hi'        :   'MCHI1_74_V1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_73_V2',
+    'run1_mc_pa'        :   'MCPA1_74_V1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_73_V3',
+    'run2_design'       :   'DESRUN2_74_V1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_73_V6',
+    'run2_mc_50ns'      :   'MCRUN2_74_V2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_73_V7',
+    'run2_mc'           :   'MCRUN2_74_V3',
+    # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
+    'run2_mc_hi'        :   'MCHI2_74_V1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_73_V0A',
+    'run1_data'         :   'GR_R_74_V2A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_73_V1A',
+    'run2_data'         :   'GR_R_74_V3A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V43A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V49A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V44A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V50A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitMultiFitAlgo.h
@@ -27,10 +27,16 @@ class EcalUncalibRecHitMultiFitAlgo
   ~EcalUncalibRecHitMultiFitAlgo() { };
   EcalUncalibratedRecHit makeRecHit(const EcalDataFrame& dataFrame, const EcalPedestals::Item * aped, const EcalMGPAGainRatio * aGain, const SampleMatrix &noisecor, const FullSampleVector &fullpulse, const FullSampleMatrix &fullpulsecov, const BXVector &activeBX);
   void disableErrorCalculation() { _computeErrors = false; }
+  void setDoPrefit(bool b) { _doPrefit = b; }
+  void setPrefitMaxChiSq(double x) { _prefitMaxChiSq = x; }
   
  private:
    PulseChiSqSNNLS _pulsefunc;
+   PulseChiSqSNNLS _pulsefuncSingle;
    bool _computeErrors;
+   bool _doPrefit;
+   double _prefitMaxChiSq;
+   BXVector _singlebx;
 
 };
 

--- a/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h
@@ -11,3 +11,6 @@ typedef Eigen::Matrix<double,10,Eigen::Dynamic,0,10,10> SamplePulseMatrix;
 typedef Eigen::LLT<SampleMatrix> SampleDecompLLT;
 typedef Eigen::LLT<PulseMatrix> PulseDecompLLT;
 typedef Eigen::LDLT<PulseMatrix> PulseDecompLDLT;
+
+typedef Eigen::Matrix<double,1,1> SingleMatrix;
+typedef Eigen::Matrix<double,1,1> SingleVector;

--- a/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
+++ b/RecoLocalCalo/EcalRecAlgos/interface/PulseChiSqSNNLS.h
@@ -27,11 +27,14 @@ class PulseChiSqSNNLS {
     
     double ChiSq() const { return _chisq; }
     void disableErrorCalculation() { _computeErrors = false; }
+    void setMaxIters(int n) { _maxiters = n;}
+    void setMaxIterWarnings(bool b) { _maxiterwarnings = b;}
 
   protected:
     
     bool Minimize(const SampleMatrix &samplecor, double pederr, const FullSampleMatrix &fullpulsecov);
     bool NNLS();
+    bool OnePulseMinimize();
     bool updateCov(const SampleMatrix &samplecor, double pederr, const FullSampleMatrix &fullpulsecov);
     double ComputeChiSq();
     double ComputeApproxUncertainty(unsigned int ipulse);
@@ -64,6 +67,8 @@ class PulseChiSqSNNLS {
     
     double _chisq;
     bool _computeErrors;
+    int _maxiters;
+    bool _maxiterwarnings;
 };
 
 #endif

--- a/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
+++ b/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
@@ -21,10 +21,10 @@ cleaningAlgoConfig = cms.PSet(
   # near cracks raise the energy threshold by this factor
   tightenCrack_e1_single=cms.double(1),
   # near cracks, divide the e4e1 threshold by this factor
-  tightenCrack_e4e1_single=cms.double(1),
+  tightenCrack_e4e1_single=cms.double(2.5),
   # same as above for double spike
-  tightenCrack_e1_double=cms.double(1),
-  tightenCrack_e6e2_double=cms.double(1),
+  tightenCrack_e1_double=cms.double(2),
+  tightenCrack_e6e2_double=cms.double(3),
   # consider for double spikes if above this threshold
   cThreshold_double =cms.double(10),
   # mark double spike if e6e2< e6e2thresh

--- a/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
+++ b/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
@@ -8,8 +8,8 @@ cleaningAlgoConfig = cms.PSet(
   # apply cleaning in EE above this threshold in GeV 
   cThreshold_endcap=cms.double(15),
   # mark spike in EB if e4e1 <  e4e1_a_barrel_ * log10(e) + e4e1_b_barrel_
-  e4e1_a_barrel=cms.double(0.04),
-  e4e1_b_barrel=cms.double(-0.024),
+  e4e1_a_barrel=cms.double(0.02),
+  e4e1_b_barrel=cms.double(0.02),
   # ditto for EE
   e4e1_a_endcap=cms.double(0.02),
   e4e1_b_endcap=cms.double(-0.0125),
@@ -19,12 +19,12 @@ cleaningAlgoConfig = cms.PSet(
   e4e1Threshold_endcap= cms.double(0.300),
   
   # near cracks raise the energy threshold by this factor
-  tightenCrack_e1_single=cms.double(2),
+  tightenCrack_e1_single=cms.double(1),
   # near cracks, divide the e4e1 threshold by this factor
-  tightenCrack_e4e1_single=cms.double(3),
+  tightenCrack_e4e1_single=cms.double(1),
   # same as above for double spike
-  tightenCrack_e1_double=cms.double(2),
-  tightenCrack_e6e2_double=cms.double(3),
+  tightenCrack_e1_double=cms.double(1),
+  tightenCrack_e6e2_double=cms.double(1),
   # consider for double spikes if above this threshold
   cThreshold_double =cms.double(10),
   # mark double spike if e6e2< e6e2thresh

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -61,6 +61,21 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   EEtimeFitLimits_.second = ps.getParameter<double>("EEtimeFitLimits_Upper");
   EBtimeConstantTerm_=ps.getParameter<double>("EBtimeConstantTerm");
   EEtimeConstantTerm_=ps.getParameter<double>("EEtimeConstantTerm");
+  EBtimeNconst_=ps.getParameter<double>("EBtimeNconst");
+  EEtimeNconst_=ps.getParameter<double>("EEtimeNconst");
+  outOfTimeThreshG12pEB_ = ps.getParameter<double>("outOfTimeThresholdGain12pEB");
+  outOfTimeThreshG12mEB_ = ps.getParameter<double>("outOfTimeThresholdGain12mEB");
+  outOfTimeThreshG61pEB_ = ps.getParameter<double>("outOfTimeThresholdGain61pEB");
+  outOfTimeThreshG61mEB_ = ps.getParameter<double>("outOfTimeThresholdGain61mEB");
+  outOfTimeThreshG12pEE_ = ps.getParameter<double>("outOfTimeThresholdGain12pEE");
+  outOfTimeThreshG12mEE_ = ps.getParameter<double>("outOfTimeThresholdGain12mEE");
+  outOfTimeThreshG61pEE_ = ps.getParameter<double>("outOfTimeThresholdGain61pEE");
+  outOfTimeThreshG61mEE_ = ps.getParameter<double>("outOfTimeThresholdGain61mEE");
+  amplitudeThreshEB_ = ps.getParameter<double>("amplitudeThresholdEB");
+  amplitudeThreshEE_ = ps.getParameter<double>("amplitudeThresholdEE");
+
+  // spike threshold
+  ebSpikeThresh_ = ps.getParameter<double>("ebSpikeThreshold");
 
   // leading edge parameters
   ebPulseShape_ = ps.getParameter<std::vector<double> >("ebPulseShape");
@@ -73,39 +88,6 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   chi2ThreshEE_=ps.getParameter<double>("chi2ThreshEE_");
 
 }
-
-
-
-// EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::ParameterSet&ps) :
-//   EcalUncalibRecHitWorkerBaseClass(ps)
-// {
-//         // ratio method parameters
-//         EBtimeFitParameters_ = ps.getParameter<std::vector<double> >("EBtimeFitParameters"); 
-//         EEtimeFitParameters_ = ps.getParameter<std::vector<double> >("EEtimeFitParameters"); 
-//         EBamplitudeFitParameters_ = ps.getParameter<std::vector<double> >("EBamplitudeFitParameters");
-//         EEamplitudeFitParameters_ = ps.getParameter<std::vector<double> >("EEamplitudeFitParameters");
-//         EBtimeFitLimits_.first  = ps.getParameter<double>("EBtimeFitLimits_Lower");
-//         EBtimeFitLimits_.second = ps.getParameter<double>("EBtimeFitLimits_Upper");
-//         EEtimeFitLimits_.first  = ps.getParameter<double>("EEtimeFitLimits_Lower");
-//         EEtimeFitLimits_.second = ps.getParameter<double>("EEtimeFitLimits_Upper");
-//         EBtimeConstantTerm_=ps.getParameter<double>("EBtimeConstantTerm");
-//         EEtimeConstantTerm_=ps.getParameter<double>("EEtimeConstantTerm");
-// 
-//         // leading edge parameters
-//         ebPulseShape_ = ps.getParameter<std::vector<double> >("ebPulseShape");
-//         eePulseShape_ = ps.getParameter<std::vector<double> >("eePulseShape");
-// 
-// }
-
-
-
-
-
-
-
-
-
-
 
 
 
@@ -259,7 +241,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
         
         // intelligence for recHit computation
         EcalUncalibratedRecHit uncalibRecHit;
-        
+        float offsetTime = 0;
         
         const EcalPedestals::Item * aped = 0;
         const EcalMGPAGainRatio * aGain = 0;
@@ -276,6 +258,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 aPulseCov = &pulsecovariances->endcap(hashedIndex);
                 multiFitMethod_.setDoPrefit(doPrefitEE_);
 		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEE_);
+		offsetTime = offtime->getEEValue();
         } else {
                 unsigned int hashedIndex = EBDetId(detid).hashedIndex();
                 aped      = &peds->barrel(hashedIndex);
@@ -285,6 +268,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 aPulseCov = &pulsecovariances->barrel(hashedIndex);
                 multiFitMethod_.setDoPrefit(doPrefitEB_);
 		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB_);
+		offsetTime = offtime->getEBValue();
         }
 
         pedVec[0] = aped->mean_x12;
@@ -322,6 +306,17 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
           fullpulsecovEE(i+7,j+7) = aPulseCov->covval[i][j];
         }
         
+	// compute the right bin of the pulse shape using time calibration constants
+	EcalTimeCalibConstantMap::const_iterator it = itime->find( detid );
+	EcalTimeCalibConstant itimeconst = 0;
+	if( it != itime->end() ) {
+		  itimeconst = (*it);
+	} else {
+		  edm::LogError("EcalRecHitError") << "No time intercalib const found for xtal "
+		  << detid.rawId()
+		  << "! something wrong with EcalTimeCalibConstants in your DB? ";
+	}
+
         // === amplitude computation ===
         int leadingSample = ((EcalDataFrame)(*itdg)).lastUnsaturatedSample();
 
@@ -395,6 +390,32 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                     uncalibRecHit.setJitter( crh.timeMax - 5 + theTimeCorrectionEE);
                     uncalibRecHit.setJitterError( std::sqrt(pow(crh.timeError,2) + std::pow(EEtimeConstantTerm_,2)/std::pow(clockToNsConstant,2)) );
                     
+                    // consider flagging as kOutOfTime only if above noise
+                    if (uncalibRecHit.amplitude() > pedRMSVec[0] * amplitudeThreshEE_){
+                      float outOfTimeThreshP = outOfTimeThreshG12pEE_;
+                      float outOfTimeThreshM = outOfTimeThreshG12mEE_;
+                      // determine if gain has switched away from gainId==1 (x12 gain)
+                      // and determine cuts (number of 'sigmas') to ose for kOutOfTime
+                      // >3k ADC is necessasry condition for gain switch to occur
+                      if (uncalibRecHit.amplitude() > 3000.){
+                        for (int iSample = 0; iSample < EEDataFrame::MAXSAMPLES; iSample++) {
+                          int GainId = ((EcalDataFrame)(*itdg)).sample(iSample).gainId();
+                          if (GainId!=1) {
+                            outOfTimeThreshP = outOfTimeThreshG61pEE_;
+                            outOfTimeThreshM = outOfTimeThreshG61mEE_;
+                            break;
+                          }
+                        }}
+                      float correctedTime = (crh.timeMax-5) * clockToNsConstant + itimeconst + offsetTime;
+                      float cterm         = EEtimeConstantTerm_;
+                      float sigmaped      = pedRMSVec[0];  // approx for lower gains
+                      float nterm         = EEtimeNconst_*sigmaped/uncalibRecHit.amplitude();
+                      float sigmat        = std::sqrt( nterm*nterm  + cterm*cterm   );
+                      if ( ( correctedTime > sigmat*outOfTimeThreshP )   ||
+                           ( correctedTime < (-1.*sigmat*outOfTimeThreshM) )) 
+                        {  uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kOutOfTime ); }
+                    }
+
                   } else {
                     ratioMethod_barrel_.init( *itdg, *sampleMask_, pedVec, pedRMSVec, gainRatios );
                     ratioMethod_barrel_.fixMGPAslew(*itdg);
@@ -406,8 +427,33 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                                                                 timeCorrBias_->EBTimeCorrAmplitudeBins, timeCorrBias_->EBTimeCorrShiftBins);
                     
                     uncalibRecHit.setJitter( crh.timeMax - 5 + theTimeCorrectionEB);
-                    
                     uncalibRecHit.setJitterError( std::sqrt(std::pow(crh.timeError,2) + std::pow(EBtimeConstantTerm_,2)/std::pow(clockToNsConstant,2)) );
+
+                    // consider flagging as kOutOfTime only if above noise
+                    if (uncalibRecHit.amplitude() > pedRMSVec[0] * amplitudeThreshEB_){
+                      float outOfTimeThreshP = outOfTimeThreshG12pEB_;
+                      float outOfTimeThreshM = outOfTimeThreshG12mEB_;
+                      // determine if gain has switched away from gainId==1 (x12 gain)
+                      // and determine cuts (number of 'sigmas') to ose for kOutOfTime
+                      // >3k ADC is necessasry condition for gain switch to occur
+                      if (uncalibRecHit.amplitude() > 3000.){
+                        for (int iSample = 0; iSample < EBDataFrame::MAXSAMPLES; iSample++) {
+                          int GainId = ((EcalDataFrame)(*itdg)).sample(iSample).gainId();
+                          if (GainId!=1) {
+                            outOfTimeThreshP = outOfTimeThreshG61pEB_;
+                            outOfTimeThreshM = outOfTimeThreshG61mEB_;
+                            break;}
+                        } }
+                      float correctedTime = (crh.timeMax-5) * clockToNsConstant + itimeconst + offsetTime;
+                      float cterm         = EBtimeConstantTerm_;
+                      float sigmaped      = pedRMSVec[0];  // approx for lower gains
+                      float nterm         = EBtimeNconst_*sigmaped/uncalibRecHit.amplitude();
+                      float sigmat        = std::sqrt( nterm*nterm  + cterm*cterm   );
+                      if ( ( correctedTime > sigmat*outOfTimeThreshP )   ||
+                           ( correctedTime < (-1.*sigmat*outOfTimeThreshM) )) 
+                        {   uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kOutOfTime );  }
+                    }
+
                   }
                 } else if(timealgo_.compare("WeightsMethod")==0) {
                   //  weights method on the PU subtracted pulse shape

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -41,6 +41,12 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
     bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
   }
 
+  doPrefitEB_ = ps.getParameter<bool>("doPrefitEB");
+  doPrefitEE_ = ps.getParameter<bool>("doPrefitEE");
+
+  prefitMaxChiSqEB_ = ps.getParameter<double>("prefitMaxChiSqEB");
+  prefitMaxChiSqEE_ = ps.getParameter<double>("prefitMaxChiSqEE");
+
   // algorithm to be used for timing
   timealgo_ = ps.getParameter<std::string>("timealgo");
   
@@ -268,6 +274,8 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 gid       = &grps->endcap(hashedIndex);
                 aPulse    = &pulseshapes->endcap(hashedIndex);
                 aPulseCov = &pulsecovariances->endcap(hashedIndex);
+                multiFitMethod_.setDoPrefit(doPrefitEE_);
+		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEE_);
         } else {
                 unsigned int hashedIndex = EBDetId(detid).hashedIndex();
                 aped      = &peds->barrel(hashedIndex);
@@ -275,6 +283,8 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
                 gid       = &grps->barrel(hashedIndex);
                 aPulse    = &pulseshapes->barrel(hashedIndex);
                 aPulseCov = &pulsecovariances->barrel(hashedIndex);
+                multiFitMethod_.setDoPrefit(doPrefitEB_);
+		multiFitMethod_.setPrefitMaxChiSq(prefitMaxChiSqEB_);
         }
 
         pedVec[0] = aped->mean_x12;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -94,6 +94,10 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 const EcalWeightSet::EcalWeightMatrix* weights[2];
                 EcalUncalibRecHitTimeWeightsAlgo<EBDataFrame> weightsMethod_barrel_;
                 EcalUncalibRecHitTimeWeightsAlgo<EEDataFrame> weightsMethod_endcap_;
+                bool doPrefitEB_;
+                bool doPrefitEE_;
+		double prefitMaxChiSqEB_;
+		double prefitMaxChiSqEE_;
 
                 // ratio method
                 std::vector<double> EBtimeFitParameters_; 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -112,6 +112,19 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
 
                 double EBtimeConstantTerm_;
                 double EEtimeConstantTerm_;
+                double EBtimeNconst_;
+                double EEtimeNconst_;
+                double outOfTimeThreshG12pEB_;
+                double outOfTimeThreshG12mEB_;
+                double outOfTimeThreshG61pEB_;
+                double outOfTimeThreshG61mEB_;
+                double outOfTimeThreshG12pEE_;
+                double outOfTimeThreshG12mEE_;
+                double outOfTimeThreshG61pEE_;
+                double outOfTimeThreshG61mEE_;
+                double amplitudeThreshEB_;
+                double amplitudeThreshEE_;
+                double ebSpikeThresh_;
 
                 edm::ESHandle<EcalTimeBiasCorrections> timeCorrBias_;
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -25,6 +25,9 @@
 #include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
 #include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
+#include "CondFormats/EcalObjects/interface/EcalSamplesCorrelation.h"
+#include "CondFormats/EcalObjects/interface/EcalPulseShapes.h"
+#include "CondFormats/EcalObjects/interface/EcalPulseCovariances.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
 
 namespace edm {
@@ -46,14 +49,15 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
 
         protected:
 
-                edm::ParameterSet EcalPulseShapeParameters_;
-
                 double pedVec[3];
 		double pedRMSVec[3];
                 double gainRatios[3];
 
                 edm::ESHandle<EcalPedestals> peds;
                 edm::ESHandle<EcalGainRatios>  gains;
+                edm::ESHandle<EcalSamplesCorrelation> noisecovariances;
+                edm::ESHandle<EcalPulseShapes> pulseshapes;
+                edm::ESHandle<EcalPulseCovariances> pulsecovariances;
 
                 double timeCorrection(float ampli,
                     const std::vector<float>& amplitudeBins, const std::vector<float>& shiftBins);
@@ -122,9 +126,6 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 double chi2ThreshEB_;
                 double chi2ThreshEE_;
 
-
- private:
-                void fillInputs(const edm::ParameterSet& params);
 
 };
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalGlobalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalGlobalUncalibRecHit_cfi.py
@@ -24,10 +24,10 @@ ecalGlobalUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     outOfTimeThresholdGain12mEB    = cms.double(5),      # times estimated precision
     outOfTimeThresholdGain61pEB    = cms.double(5),      # times estimated precision
     outOfTimeThresholdGain61mEB    = cms.double(5),      # times estimated precision
-    outOfTimeThresholdGain12pEE    = cms.double(10),      # times estimated precision
-    outOfTimeThresholdGain12mEE    = cms.double(10),      # times estimated precision
-    outOfTimeThresholdGain61pEE    = cms.double(10),      # times estimated precision
-    outOfTimeThresholdGain61mEE    = cms.double(10),      # times estimated precision
+    outOfTimeThresholdGain12pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain12mEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61mEE    = cms.double(1000),   # times estimated precision
     amplitudeThresholdEB    = cms.double(10),
     amplitudeThresholdEE    = cms.double(10),
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -35,6 +35,23 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     EBtimeConstantTerm= cms.double(.6),
     EEtimeConstantTerm= cms.double(1.0),
    
+    # for kOutOfTime flag
+    EBtimeNconst      = cms.double(28.5),
+    EEtimeNconst      = cms.double(31.8),
+    outOfTimeThresholdGain12pEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain12mEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain61pEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain61mEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain12pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain12mEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61mEE    = cms.double(1000),   # times estimated precision
+    amplitudeThresholdEB    = cms.double(10),
+    amplitudeThresholdEE    = cms.double(10),
+
+    ebSpikeThreshold = cms.double(1.042),
+
+    # these are now taken from DB. Here the MC parameters for backward compatibility
     ebPulseShape = cms.vdouble( 5.2e-05,-5.26e-05 , 6.66e-05, 0.1168, 0.7575, 1.,  0.8876, 0.6732, 0.4741,  0.3194 ),
     eePulseShape = cms.vdouble( 5.2e-05,-5.26e-05 , 6.66e-05, 0.1168, 0.7575, 1.,  0.8876, 0.6732, 0.4741,  0.3194 ),   
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -14,6 +14,11 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     ampErrorCalculation = cms.bool(True),
     useLumiInfoRunHeader = cms.bool(True),
 
+    doPrefitEB = cms.bool(False),
+    doPrefitEE = cms.bool(False),
+    prefitMaxChiSqEB = cms.double(25.),
+    prefitMaxChiSqEE = cms.double(10.),
+
     # decide which algorithm to be use to calculate the jitter
     timealgo = cms.string("RatioMethod"),
 


### PR DESCRIPTION
This pull request contains:

1) use of the DB inputs in the multifit local reconstruction. For the time being, the GT uses the MC conditions for both data and MC, so no change is expected wrt the previous one (python configuration with MC conditions)

2) re-introduction of the spike killing flags, kOutOfTime and kWeird. The cuts for the topological variables have been reoptimised. If those flags are used in the PF rechits, there could be some minimal change wrt previous version. 

3) autocond files contain the GTs with the payloads (there should be the same commit by Salvatore @diguida on the AlCa DB side).
