### PR TITLE
Ecalmultifit use DB inputs and retuning of spike flagging

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_74_V0::All',
+    'run1_design'       :   'DESRUN1_74_V1::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_74_V0::All',
+    'run1_mc'           :   'MCRUN1_74_V1::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_74_V0::All',
+    'run1_mc_hi'        :   'MCHI1_74_V1::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_74_V0::All',
+    'run1_mc_pa'        :   'MCPA1_74_V1::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_74_V0::All',
+    'run2_design'       :   'DESRUN2_74_V1::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_74_V0::All',
+    'run2_mc_50ns'      :   'MCRUN2_74_V2::All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_74_V1::All',
+    'run2_mc'           :   'MCRUN2_74_V3::All',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   'MCHI2_74_V0::All',
+    'run2_mc_hi'        :   'MCHI2_74_V1::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_74_V0A::All',
+    'run1_data'         :   'GR_R_74_V2A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_74_V1A::All',
+    'run2_data'         :   'GR_R_74_V3A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V47A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V49A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V48A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V50A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_74_V0',
+    'run1_design'       :   'DESRUN1_74_V1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_74_V0',
+    'run1_mc'           :   'MCRUN1_74_V1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_74_V0',
+    'run1_mc_hi'        :   'MCHI1_74_V1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_74_V0',
+    'run1_mc_pa'        :   'MCPA1_74_V1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_74_V0',
+    'run2_design'       :   'DESRUN2_74_V1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_74_V0',
+    'run2_mc_50ns'      :   'MCRUN2_74_V2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_74_V1',
+    'run2_mc'           :   'MCRUN2_74_V3',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   'MCHI2_74_V0',
+    'run2_mc_hi'        :   'MCHI2_74_V1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_74_V0A',
+    'run1_data'         :   'GR_R_74_V2A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_74_V1A',
+    'run2_data'         :   'GR_R_74_V3A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V47A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V49A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V48A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V50A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
+++ b/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
@@ -21,10 +21,10 @@ cleaningAlgoConfig = cms.PSet(
   # near cracks raise the energy threshold by this factor
   tightenCrack_e1_single=cms.double(1),
   # near cracks, divide the e4e1 threshold by this factor
-  tightenCrack_e4e1_single=cms.double(1),
+  tightenCrack_e4e1_single=cms.double(2.5),
   # same as above for double spike
-  tightenCrack_e1_double=cms.double(1),
-  tightenCrack_e6e2_double=cms.double(1),
+  tightenCrack_e1_double=cms.double(2),
+  tightenCrack_e6e2_double=cms.double(3),
   # consider for double spikes if above this threshold
   cThreshold_double =cms.double(10),
   # mark double spike if e6e2< e6e2thresh

--- a/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
+++ b/RecoLocalCalo/EcalRecAlgos/python/ecalCleaningAlgo.py
@@ -8,8 +8,8 @@ cleaningAlgoConfig = cms.PSet(
   # apply cleaning in EE above this threshold in GeV 
   cThreshold_endcap=cms.double(15),
   # mark spike in EB if e4e1 <  e4e1_a_barrel_ * log10(e) + e4e1_b_barrel_
-  e4e1_a_barrel=cms.double(0.04),
-  e4e1_b_barrel=cms.double(-0.024),
+  e4e1_a_barrel=cms.double(0.02),
+  e4e1_b_barrel=cms.double(0.02),
   # ditto for EE
   e4e1_a_endcap=cms.double(0.02),
   e4e1_b_endcap=cms.double(-0.0125),
@@ -19,12 +19,12 @@ cleaningAlgoConfig = cms.PSet(
   e4e1Threshold_endcap= cms.double(0.300),
   
   # near cracks raise the energy threshold by this factor
-  tightenCrack_e1_single=cms.double(2),
+  tightenCrack_e1_single=cms.double(1),
   # near cracks, divide the e4e1 threshold by this factor
-  tightenCrack_e4e1_single=cms.double(3),
+  tightenCrack_e4e1_single=cms.double(1),
   # same as above for double spike
-  tightenCrack_e1_double=cms.double(2),
-  tightenCrack_e6e2_double=cms.double(3),
+  tightenCrack_e1_double=cms.double(1),
+  tightenCrack_e6e2_double=cms.double(1),
   # consider for double spikes if above this threshold
   cThreshold_double =cms.double(10),
   # mark double spike if e6e2< e6e2thresh

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -25,6 +25,9 @@
 #include "CondFormats/EcalObjects/interface/EcalTBWeights.h"
 #include "CondFormats/EcalObjects/interface/EcalSampleMask.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeBiasCorrections.h"
+#include "CondFormats/EcalObjects/interface/EcalSamplesCorrelation.h"
+#include "CondFormats/EcalObjects/interface/EcalPulseShapes.h"
+#include "CondFormats/EcalObjects/interface/EcalPulseCovariances.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EigenMatrixTypes.h"
 
 namespace edm {
@@ -46,14 +49,15 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
 
         protected:
 
-                edm::ParameterSet EcalPulseShapeParameters_;
-
                 double pedVec[3];
 		double pedRMSVec[3];
                 double gainRatios[3];
 
                 edm::ESHandle<EcalPedestals> peds;
                 edm::ESHandle<EcalGainRatios>  gains;
+                edm::ESHandle<EcalSamplesCorrelation> noisecovariances;
+                edm::ESHandle<EcalPulseShapes> pulseshapes;
+                edm::ESHandle<EcalPulseCovariances> pulsecovariances;
 
                 double timeCorrection(float ampli,
                     const std::vector<float>& amplitudeBins, const std::vector<float>& shiftBins);
@@ -108,6 +112,19 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
 
                 double EBtimeConstantTerm_;
                 double EEtimeConstantTerm_;
+                double EBtimeNconst_;
+                double EEtimeNconst_;
+                double outOfTimeThreshG12pEB_;
+                double outOfTimeThreshG12mEB_;
+                double outOfTimeThreshG61pEB_;
+                double outOfTimeThreshG61mEB_;
+                double outOfTimeThreshG12pEE_;
+                double outOfTimeThreshG12mEE_;
+                double outOfTimeThreshG61pEE_;
+                double outOfTimeThreshG61mEE_;
+                double amplitudeThreshEB_;
+                double amplitudeThreshEE_;
+                double ebSpikeThresh_;
 
                 edm::ESHandle<EcalTimeBiasCorrections> timeCorrBias_;
 
@@ -126,8 +143,6 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 double chi2ThreshEB_;
                 double chi2ThreshEE_;
 
- private:
-                void fillInputs(const edm::ParameterSet& params);
 
 };
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalGlobalUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalGlobalUncalibRecHit_cfi.py
@@ -24,10 +24,10 @@ ecalGlobalUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     outOfTimeThresholdGain12mEB    = cms.double(5),      # times estimated precision
     outOfTimeThresholdGain61pEB    = cms.double(5),      # times estimated precision
     outOfTimeThresholdGain61mEB    = cms.double(5),      # times estimated precision
-    outOfTimeThresholdGain12pEE    = cms.double(10),      # times estimated precision
-    outOfTimeThresholdGain12mEE    = cms.double(10),      # times estimated precision
-    outOfTimeThresholdGain61pEE    = cms.double(10),      # times estimated precision
-    outOfTimeThresholdGain61mEE    = cms.double(10),      # times estimated precision
+    outOfTimeThresholdGain12pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain12mEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61mEE    = cms.double(1000),   # times estimated precision
     amplitudeThresholdEB    = cms.double(10),
     amplitudeThresholdEE    = cms.double(10),
 

--- a/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
+++ b/RecoLocalCalo/EcalRecProducers/python/ecalMultiFitUncalibRecHit_cfi.py
@@ -13,12 +13,12 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4),
     ampErrorCalculation = cms.bool(True),
     useLumiInfoRunHeader = cms.bool(True),
-    
+
     doPrefitEB = cms.bool(False),
     doPrefitEE = cms.bool(False),
     prefitMaxChiSqEB = cms.double(25.),
     prefitMaxChiSqEE = cms.double(10.),
-    
+
     # decide which algorithm to be use to calculate the jitter
     timealgo = cms.string("RatioMethod"),
 
@@ -35,6 +35,23 @@ ecalMultiFitUncalibRecHit = cms.EDProducer("EcalUncalibRecHitProducer",
     EBtimeConstantTerm= cms.double(.6),
     EEtimeConstantTerm= cms.double(1.0),
    
+    # for kOutOfTime flag
+    EBtimeNconst      = cms.double(28.5),
+    EEtimeNconst      = cms.double(31.8),
+    outOfTimeThresholdGain12pEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain12mEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain61pEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain61mEB    = cms.double(5),      # times estimated precision
+    outOfTimeThresholdGain12pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain12mEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61pEE    = cms.double(1000),   # times estimated precision
+    outOfTimeThresholdGain61mEE    = cms.double(1000),   # times estimated precision
+    amplitudeThresholdEB    = cms.double(10),
+    amplitudeThresholdEE    = cms.double(10),
+
+    ebSpikeThreshold = cms.double(1.042),
+
+    # these are now taken from DB. Here the MC parameters for backward compatibility
     ebPulseShape = cms.vdouble( 5.2e-05,-5.26e-05 , 6.66e-05, 0.1168, 0.7575, 1.,  0.8876, 0.6732, 0.4741,  0.3194 ),
     eePulseShape = cms.vdouble( 5.2e-05,-5.26e-05 , 6.66e-05, 0.1168, 0.7575, 1.,  0.8876, 0.6732, 0.4741,  0.3194 ),   
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -23,7 +23,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
                   cleaningThreshold = cms.double(2.0),
-                  timingCleaning = cms.bool(True),
+                  timingCleaning = cms.bool(False),
                   topologicalCleaning = cms.bool(True),
                   skipTTRecoveredHits = cms.bool(True)
                   )
@@ -40,7 +40,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),
                  cleaningThreshold = cms.double(2.0),
-                 timingCleaning = cms.bool(True),
+                 timingCleaning = cms.bool(False),
                  topologicalCleaning = cms.bool(True),
                  skipTTRecoveredHits = cms.bool(True)
                  )


### PR DESCRIPTION
This pull request contains:

1) use of the DB inputs in the multifit local reconstruction. For the time being, the GT uses the MC conditions for both data and MC, so no change is expected wrt the previous one (python configuration with MC conditions)

2) re-introduction of the spike killing flags, kOutOfTime and kWeird. The cuts for the topological variables have been reoptimised. If those flags are used in the PF rechits, there could be some minimal change wrt previous version.

3) autocond files contain the GTs with the payloads (there should be the same commit by Salvatore @diguida on the AlCa DB side).

Adding @bendavid @argiro @cerminar @diguida to check this.

IMPORTANT: for @bachtis : this version has the kOutOfTime flag re-enabled (for spikes flagging). Please, if you want, disable it in the PF clustering filtering
