### PR TITLE
fixed a bug picking up gen particle (electron) of status==3.

### DIFF
--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -106,7 +106,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     refittedStandAloneMuons_recCut  = cms.string("pt > 10 && abs(eta) < 2.4"), 
 
     # --- Electrons
-    Ele_genCut      = cms.string("pt > 10 && (abs(eta)<1.444 || abs(eta)>1.566) && abs(eta)<2.5 && abs(pdgId) == 11 && status==3 "),
+    Ele_genCut      = cms.string("pt > 10 && (abs(eta)<1.444 || abs(eta)>1.566) && abs(eta)<2.5 && abs(pdgId) == 11 && status==1 "),
     Ele_recCut      = cms.string(
         "pt > 10 && (abs(eta)<1.444 || abs(eta)>1.566) && abs(eta)< 2.5 "+
         " && hadronicOverEm < 0.05 "+ #&& eSuperClusterOverP > 0.5 && eSuperClusterOverP < 1.5 "+


### PR DESCRIPTION
We had a problem that we didn't see any entries in the release monitor plots that is for analyses related to electron. We found that this was because we could not find any matched particle due to the wrong requirement of "status==3" for gen particle. This change fixes the problem.
