### PR TITLE
add preprocessor check on boost version

### DIFF
--- a/HLTrigger/HLTcore/interface/defaultModuleLabel.h
+++ b/HLTrigger/HLTcore/interface/defaultModuleLabel.h
@@ -5,12 +5,21 @@
 #include <string>
 
 // boost headers
+#include <boost/version.hpp>
+#if BOOST_VERSION < 105200
+#include <boost/units/detail/utility.hpp>
+#else
 #include <boost/core/demangle.hpp>
+#endif
 
 template <typename T>
 std::string defaultModuleLabel() {
   // start with the demangled name for T
+#if BOOST_VERSION < 105200
+  std::string name = boost::units::detail::demangle(typeid(T).name());
+#else
   std::string name = boost::core::demangle(typeid(T).name());
+#endif
 
   // expected size of the label
   unsigned int size = 0;


### PR DESCRIPTION
Hack to support boost 1.51 and 1.57 while we have to revert back to 1.51 (rebased)
