### PR TITLE
Cleanup nuclear interaction for FastSim

### DIFF
--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -56,8 +56,8 @@ reducedRecHits = cms.Sequence ( reducedEcalRecHitsSequence * reducedHcalRecHitsS
 from RecoJets.Configuration.CaloTowersRec_cff import *
 
 # Particle Flow (all interactions with ParticleFlow are dealt with in the following configuration)
-from FastSimulation.ParticleFlow.ParticleFlowFastSim_cff import *
-#from FastSimulation.ParticleFlow.ParticleFlowFastSimNeutralHadron_cff import * # this is the famous "PF patch", see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFastSimFAQ#I_observe_a_discrepancy_in_energ
+#from FastSimulation.ParticleFlow.ParticleFlowFastSim_cff import *
+from FastSimulation.ParticleFlow.ParticleFlowFastSimNeutralHadron_cff import * # this is the famous "PF patch", see https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideFastSimFAQ#I_observe_a_discrepancy_in_energ
 
 from RecoTauTag.Configuration.RecoPFTauTag_cff import *
 

--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
@@ -66,7 +66,6 @@ private:
   G4Step* dummyStep;
   G4Track* currTrack;
   const G4ParticleDefinition* currParticle;
-  ParticlePropagator* currPrimary;
 
   G4Nucleus targetNucleus;
   G4HadProjectile theProjectile;
@@ -75,7 +74,6 @@ private:
   G4ThreeVector theBoost;
 
   double theEnergyLimit;
-  double currInteractionLength;
 
   double theDistCut;
   double distMin;

--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
@@ -66,6 +66,8 @@ private:
   G4Step* dummyStep;
   G4Track* currTrack;
   const G4ParticleDefinition* currParticle;
+  ParticlePropagator* currPrimary;
+
   G4Nucleus targetNucleus;
   G4HadProjectile theProjectile;
   G4LorentzVector curr4Mom;
@@ -73,11 +75,13 @@ private:
   G4ThreeVector theBoost;
 
   double theEnergyLimit;
+  double currInteractionLength;
 
-  int numHadrons;
-
-  unsigned int theDistAlgo;
   double theDistCut;
   double distMin;
+
+  int numHadrons;
+  int currIdx;
+  unsigned int theDistAlgo;
 };
 #endif

--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionSimulator.h
@@ -35,11 +35,11 @@ class NuclearInteractionSimulator : public MaterialEffectsSimulator
  public:
 
   /// Constructor
-  NuclearInteractionSimulator(std::vector<double>& pionEnergies,
-			      std::vector<int>& pionTypes,
-			      std::vector<std::string>& pionNames,
-			      std::vector<double>& pionMasses,
-			      std::vector<double>& pionPMin,
+  NuclearInteractionSimulator(std::vector<double>& hadronEnergies,
+			      std::vector<int>& hadronTypes,
+			      std::vector<std::string>& hadronNames,
+			      std::vector<double>& hadronMasses,
+			      std::vector<double>& hadronPMin,
 			      double pionEnergy,
 			      std::vector<double>& lengthRatio,
 			      std::vector< std::vector<double> >& ratios,

--- a/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
+++ b/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
@@ -41,7 +41,7 @@ MaterialEffectsBlock = cms.PSet(
 	# Smallest pT for the Mutliple Scattering 
         pTmin = cms.double(0.2),
 	# Enable Nuclear Interactions
-        NuclearInteraction = cms.bool(False), # temporary 12.01.14 until bug-fix for nuclear interactions
+        NuclearInteraction = cms.bool(True), # buggy, should be removed on long term
         #
         G4NuclearInteraction = cms.bool(False), 	
         # The energies of the pions used in the above files (same order)

--- a/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
+++ b/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
@@ -1,8 +1,3 @@
-# The following comments couldn't be translated into the new config version:
-
-#        pi+      pi-    K0L      K+      K-      p      pbar     n      nbar
-#	0.2508, 0.2549, 0.3380, 0.2879, 0.3171, 0.3282, 0.5371, 0.3859, 0.5086 # before 170 tuning
-
 import FWCore.ParameterSet.Config as cms
 
 # Material effects to be simulated in the tracker material and associated cuts
@@ -45,25 +40,25 @@ MaterialEffectsBlock = cms.PSet(
         #
         G4NuclearInteraction = cms.bool(False), 	
         # The energies of the pions used in the above files (same order)
-        pionEnergies = cms.untracked.vdouble(
+        hadronEnergies = cms.untracked.vdouble(
             1.0, 2.0, 3.0, 4.0, 5.0, 7.0, 9.0, 12.0, 15.0, 20.0, 
             30.0, 50.0, 100.0, 200.0, 300.0, 500.0, 700.0, 1000.0
         ),
 	# The particle types simulated
-        pionTypes = cms.untracked.vint32(
+        hadronTypes = cms.untracked.vint32(
             211, -211, 130, 321, -321, 2212, -2212, 2112, -2112
         ),
 	# The corresponding particle names
-        pionNames = cms.untracked.vstring(
+        hadronNames = cms.untracked.vstring(
             'piplus', 'piminus', 'K0L', 'Kplus', 'Kminus', 'p', 'pbar', 'n', 'nbar'
         ),
 	# The corresponding particle masses
-        pionMasses = cms.untracked.vdouble(
+        hadronMasses = cms.untracked.vdouble(
             0.13957, 0.13957, 0.497648, 0.493677, 0.493677, 
 	    0.93827, 0.93827, 0.939565, 0.939565 
 	),
 	# The corresponding smallest momenta for which an inleatic interaction may occur
-        pionMinP = cms.untracked.vdouble( 
+        hadronMinP = cms.untracked.vdouble( 
 	    0.7, 0.0, 1.0, 1.0, 0.0, 1.1, 0.0, 1.1, 0.0 
 	),
 

--- a/FastSimulation/MaterialEffects/src/MaterialEffects.cc
+++ b/FastSimulation/MaterialEffects/src/MaterialEffects.cc
@@ -90,31 +90,31 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
   if ( doNuclearInteraction ) { 
 
     // The energies simulated
-    std::vector<double> pionEnergies 
-      = matEff.getUntrackedParameter<std::vector<double> >("pionEnergies");
+    std::vector<double> hadronEnergies 
+      = matEff.getUntrackedParameter<std::vector<double> >("hadronEnergies");
 
     // The particle types simulated
-    std::vector<int> pionTypes 
-      = matEff.getUntrackedParameter<std::vector<int> >("pionTypes");
+    std::vector<int> hadronTypes 
+      = matEff.getUntrackedParameter<std::vector<int> >("hadronTypes");
 
     // The corresponding particle names
-    std::vector<std::string> pionNames 
-      = matEff.getUntrackedParameter<std::vector<std::string> >("pionNames");
+    std::vector<std::string> hadronNames 
+      = matEff.getUntrackedParameter<std::vector<std::string> >("hadronNames");
 
     // The corresponding particle masses
-    std::vector<double> pionMasses 
-      = matEff.getUntrackedParameter<std::vector<double> >("pionMasses");
+    std::vector<double> hadronMasses 
+      = matEff.getUntrackedParameter<std::vector<double> >("hadronMasses");
 
     // The smallest momentum for inelastic interactions
-    std::vector<double> pionPMin 
-      = matEff.getUntrackedParameter<std::vector<double> >("pionMinP");
+    std::vector<double> hadronPMin 
+      = matEff.getUntrackedParameter<std::vector<double> >("hadronMinP");
 
     // The interaction length / radiation length ratio for each particle type
     std::vector<double> lengthRatio 
       = matEff.getParameter<std::vector<double> >("lengthRatio");
     //    std::map<int,double> lengthRatio;
     //    for ( unsigned i=0; i<theLengthRatio.size(); ++i )
-    //      lengthRatio[ pionTypes[i] ] = theLengthRatio[i];
+    //      lengthRatio[ hadronTypes[i] ] = theLengthRatio[i];
 
     // A global fudge factor for TEC layers (which apparently do not react to 
     // hadrons the same way as all other layers...
@@ -124,16 +124,16 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
     std::vector<double> theRatios  
       = matEff.getUntrackedParameter<std::vector<double> >("ratios");
     //std::map<int,std::vector<double> > ratios;
-    //for ( unsigned i=0; i<pionTypes.size(); ++i ) { 
-    //  for ( unsigned j=0; j<pionEnergies.size(); ++j ) { 
-    //	ratios[ pionTypes[i] ].push_back(theRatios[ i*pionEnergies.size() + j ]);
+    //for ( unsigned i=0; i<hadronTypes.size(); ++i ) { 
+    //  for ( unsigned j=0; j<hadronEnergies.size(); ++j ) { 
+    //	ratios[ hadronTypes[i] ].push_back(theRatios[ i*hadronEnergies.size() + j ]);
     //  }
     //}
     std::vector< std::vector<double> > ratios;
-    ratios.resize(pionTypes.size());
-    for ( unsigned i=0; i<pionTypes.size(); ++i ) { 
-      for ( unsigned j=0; j<pionEnergies.size(); ++j ) { 
-	ratios[i].push_back(theRatios[ i*pionEnergies.size() + j ]);
+    ratios.resize(hadronTypes.size());
+    for ( unsigned i=0; i<hadronTypes.size(); ++i ) { 
+      for ( unsigned j=0; j<hadronEnergies.size(); ++j ) { 
+	ratios[i].push_back(theRatios[ i*hadronEnergies.size() + j ]);
       }
     }
 
@@ -206,8 +206,8 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
       NuclearInteraction = new NuclearInteractionFTFSimulator(distAlgo, distCut); 
     } else {
       NuclearInteraction = 
-	new NuclearInteractionSimulator(pionEnergies, pionTypes, pionNames, 
-					pionMasses, pionPMin, pionEnergy, 
+	new NuclearInteractionSimulator(hadronEnergies, hadronTypes, hadronNames, 
+					hadronMasses, hadronPMin, pionEnergy, 
 					lengthRatio, ratios, idMap, 
 					inputFile, distAlgo, distCut);
     }

--- a/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
+++ b/FastSimulation/MaterialEffects/src/NuclearInteractionSimulator.cc
@@ -17,12 +17,16 @@
 #include "TTree.h"
 #include "TROOT.h"
 
+// Internal variable and vectors with name started frm "thePion" means
+// vectors/variable not only for pions but for all type of hadrons
+// treated inside this code
+
 NuclearInteractionSimulator::NuclearInteractionSimulator(
-  std::vector<double>& pionEnergies,
-  std::vector<int>& pionTypes,
-  std::vector<std::string>& pionNames,
-  std::vector<double>& pionMasses,
-  std::vector<double>& pionPMin,
+  std::vector<double>& hadronEnergies,
+  std::vector<int>& hadronTypes,
+  std::vector<std::string>& hadronNames,
+  std::vector<double>& hadronMasses,
+  std::vector<double>& hadronPMin,
   double pionEnergy,
   std::vector<double>& lengthRatio,
   std::vector< std::vector<double> >& ratios,
@@ -32,11 +36,11 @@ NuclearInteractionSimulator::NuclearInteractionSimulator(
   double distCut)
   :
   MaterialEffectsSimulator(),
-  thePionEN(pionEnergies),
-  thePionID(pionTypes),
-  thePionNA(pionNames),
-  thePionMA(pionMasses),
-  thePionPMin(pionPMin),
+  thePionEN(hadronEnergies),
+  thePionID(hadronTypes),
+  thePionNA(hadronNames),
+  thePionMA(hadronMasses),
+  thePionPMin(hadronPMin),
   thePionEnergy(pionEnergy),
   theLengthRatio(lengthRatio),
   theRatios(ratios),


### PR DESCRIPTION
This PR includes #7546 which is already integrated.
Clean-up of parameters and variables names is done to avoid later confusions.
For FTF nuclear interactions hyperons and anti-particle interactions are added.
Some code optimisation for FTF nuclear interaction introduced.
By default FTF nuclear is still disabled.
