### PR TITLE
CondFormats/DTObjects: fix std::atomic usage with Clang

### DIFF
--- a/CondFormats/DTObjects/src/DTRecoConditions.cc
+++ b/CondFormats/DTObjects/src/DTRecoConditions.cc
@@ -20,7 +20,7 @@ using std::endl;
 
 
 DTRecoConditions::DTRecoConditions() : 
-  formula(0), 
+  formula(nullptr),
   formulaType(0),  
   expression("[0]")
 {}
@@ -43,7 +43,7 @@ DTRecoConditions::operator=(const DTRecoConditions& iOther)
 
 
 DTRecoConditions::~DTRecoConditions(){
-  delete formula;
+  delete formula.load();
 }
 
 


### PR DESCRIPTION
The patch makes code be a bit more consistent and resolves issue with
Clang compiler. Looking at libstdc++ implemention:

```
 292   /// Partial specialization for pointer types.
 293   template<typename _Tp>
 294     struct atomic<_Tp*>

 308       operator __pointer_type() const noexcept
 309       { return __pointer_type(_M_b); }
 310
 311       operator __pointer_type() const volatile noexcept
 312       { return __pointer_type(_M_b); }
```

There are two conversion functions from `std::atomic<T*>` which causes
ambiguity in implicit conversion to a pointer type.

Use `std::atomic<T*>.load()` as in above function to avoid this issue.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
