### PR TITLE
Ecal PFCluster corrections (74x)

### DIFF
--- a/DataFormats/CaloRecHit/interface/CaloCluster.h
+++ b/DataFormats/CaloRecHit/interface/CaloCluster.h
@@ -40,18 +40,18 @@ namespace reco {
  
    /// default constructor. Sets energy and position to zero
     CaloCluster() : 
-      energy_(0), correctedEnergy_(-1.0), 
+      energy_(0), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), 
       algoID_( undefined ), flags_(0) {}
 
     /// constructor with algoId, to be used in all child classes
     CaloCluster(AlgoID algoID) : 
-      energy_(0), correctedEnergy_(-1.0), 
+      energy_(0), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0),
       algoID_( algoID ), flags_(0) {}
 
     CaloCluster( double energy,
                  const math::XYZPoint& position,
                  const CaloID& caloID) :
-      energy_ (energy), correctedEnergy_(-1.0), position_ (position), caloID_(caloID),algoID_( undefined ), flags_(0) {}
+      energy_ (energy), correctedEnergy_(-1.0), correctedEnergyUncertainty_(-1.0), position_ (position), caloID_(caloID),algoID_( undefined ), flags_(0) {}
 
 
     /// resets the CaloCluster (position, energy, hitsAndFractions)
@@ -107,6 +107,7 @@ namespace reco {
 
     void setEnergy(double energy){energy_ = energy;}
     void setCorrectedEnergy(double cenergy){correctedEnergy_ = cenergy;}
+    void setCorrectedEnergyUncertainty(float energyerr) { correctedEnergyUncertainty_ = energyerr; }
     
     void setPosition(const math::XYZPoint& p){position_ = p;}
 
@@ -119,6 +120,7 @@ namespace reco {
     /// cluster energy
     double energy() const { return energy_; }
     double correctedEnergy() const { return correctedEnergy_; }
+    float correctedEnergyUncertainty() const { return correctedEnergyUncertainty_; }
 
     /// cluster centroid position
     const math::XYZPoint & position() const { return position_; }
@@ -204,6 +206,7 @@ namespace reco {
     /// cluster energy
     double              energy_;
     double              correctedEnergy_;
+    float               correctedEnergyUncertainty_;
 
     /// cluster centroid position
     math::XYZPoint      position_;

--- a/DataFormats/CaloRecHit/src/classes_def.xml
+++ b/DataFormats/CaloRecHit/src/classes_def.xml
@@ -2,9 +2,10 @@
   <class name="CaloRecHit" ClassVersion="10">
    <version ClassVersion="10" checksum="582597904"/>
   </class>
-  <class name="reco::CaloCluster" ClassVersion="11">
+  <class name="reco::CaloCluster" ClassVersion="12">
    <version ClassVersion="10" checksum="3936140"/>
    <version ClassVersion="11" checksum="2938838489"/>
+   <version ClassVersion="12" checksum="4229965835"/>
   </class>
   <class name="edm::Wrapper<std::vector<std::pair<unsigned long,edm::Ptr<reco::CaloCluster> > > >"/>
   <class name="std::vector<std::pair<unsigned long,edm::Ptr<reco::CaloCluster> > >"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -17,7 +17,8 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
-  <class name="reco::SuperCluster" ClassVersion="13">
+  <class name="reco::SuperCluster" ClassVersion="14">
+   <version ClassVersion="14" checksum="3716250139"/>
    <version ClassVersion="13" checksum="1878352437"/>
    <version ClassVersion="12" checksum="83023066"/>
    <version ClassVersion="11" checksum="83023066"/>
@@ -100,7 +101,8 @@
   <class name="edm::reftobase::Holder<reco::ElectronSeed,edm::Ref<std::vector<reco::ElectronSeed>,reco::ElectronSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ElectronSeed>,reco::ElectronSeed> > >"/>
 
 
-  <class name="reco::PreshowerCluster" ClassVersion="12">
+  <class name="reco::PreshowerCluster" ClassVersion="13">
+   <version ClassVersion="13" checksum="2894694325"/>
    <version ClassVersion="12" checksum="1992137647"/>
    <version ClassVersion="11" checksum="469230288"/>
    <version ClassVersion="10" checksum="469230288"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -1,7 +1,8 @@
 <lcgdict>
 <selection>
 
-  <class name="reco::PFCluster" ClassVersion="14">
+  <class name="reco::PFCluster" ClassVersion="15">
+   <version ClassVersion="15" checksum="1837961152"/>
    <version ClassVersion="14" checksum="3610074122"/>
    <version ClassVersion="13" checksum="1305770681"/>
    <version ClassVersion="12" checksum="1218979136"/>

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -22,6 +22,8 @@ gedGsfElectronsTmp.maxHOverEEndcaps = cms.double(0.25)
 
 from RecoParticleFlow.Configuration.RecoParticleFlow_cff import *
 
+particleFlowClusterECAL.energyCorrector.verticesLabel = cms.InputTag('hiPixelAdaptiveVertex')
+
 mvaElectrons.vertexTag = cms.InputTag("hiSelectedVertex")
 
 particleFlowBlock.elementImporters = cms.VPSet(

--- a/RecoParticleFlow/PFClusterProducer/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterProducer/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="CondFormats/HcalObjects"/>
 <use   name="CondFormats/EcalObjects"/>
+<use   name="CondFormats/EgammaObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/ParticleFlowReco"/>

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -1,44 +1,42 @@
 #ifndef __PFClusterEMEnergyCorrector_H__
 #define __PFClusterEMEnergyCorrector_H__
 
-#include "RecoParticleFlow/PFClusterProducer/interface/PFClusterEnergyCorrectorBase.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+
+#include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
+#include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHitFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFRecHit.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
+#include "DataFormats/EcalRecHit/interface/EcalRecHitCollections.h"
 
-class PFClusterEMEnergyCorrector : public PFClusterEnergyCorrectorBase {
+class PFClusterEMEnergyCorrector {
  public:
-  PFClusterEMEnergyCorrector(const edm::ParameterSet& conf) :
-    PFClusterEnergyCorrectorBase(conf),
-    _applyCrackCorrections(conf.getParameter<bool>("applyCrackCorrections")),
-    _assoc(NULL),
-    _idx(0),
-    _calibrator(new PFEnergyCalibration) { }
+  PFClusterEMEnergyCorrector(const edm::ParameterSet& conf, edm::ConsumesCollector &&cc);
   PFClusterEMEnergyCorrector(const PFClusterEMEnergyCorrector&) = delete;
   PFClusterEMEnergyCorrector& operator=(const PFClusterEMEnergyCorrector&) = delete;
 
-  void setEEtoPSAssociation(const reco::PFCluster::EEtoPSAssociation& assoc) {
-    _assoc = &assoc;
-  }
-  void setClusterIndex(const unsigned i) { _idx = i; }
+  void correctEnergies(const edm::Event &evt, const edm::EventSetup &es, const reco::PFCluster::EEtoPSAssociation &assoc, reco::PFClusterCollection& cs);
 
-  void correctEnergy(reco::PFCluster& c) { correctEnergyActual(c,_idx); }
-  void correctEnergies(reco::PFClusterCollection& cs) {
-    for( unsigned i = 0; i < cs.size(); ++i ) correctEnergyActual(cs[i],i);
-  }
-
- private:  
-  const bool _applyCrackCorrections;
-  const reco::PFCluster::EEtoPSAssociation* _assoc;
-  unsigned _idx;
-  std::unique_ptr<PFEnergyCalibration> _calibrator;
+ private:    
+  bool autoDetectBunchSpacing_;
+  int bunchSpacingManual_;
   
-  void correctEnergyActual(reco::PFCluster&, const unsigned) const;
+  edm::EDGetTokenT<int> bunchSpacing_; 
+  
+  edm::EDGetTokenT<EcalRecHitCollection> _recHitsEB;
+  edm::EDGetTokenT<EcalRecHitCollection> _recHitsEE;  
+  edm::EDGetTokenT<reco::VertexCollection> _vertices;
+  
+  std::vector<std::string> _condnames_mean_50ns;
+  std::vector<std::string> _condnames_sigma_50ns;
+  std::vector<std::string> _condnames_mean_25ns;
+  std::vector<std::string> _condnames_sigma_25ns;  
   
 };
-
-DEFINE_EDM_PLUGIN(PFClusterEnergyCorrectorFactory,
-		  PFClusterEMEnergyCorrector,
-		  "PFClusterEMEnergyCorrector");
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -23,6 +23,9 @@ class PFClusterEMEnergyCorrector {
   void correctEnergies(const edm::Event &evt, const edm::EventSetup &es, const reco::PFCluster::EEtoPSAssociation &assoc, reco::PFClusterCollection& cs);
 
  private:    
+  bool _applyCrackCorrections;
+  bool _applyMVACorrections;
+   
   bool autoDetectBunchSpacing_;
   int bunchSpacingManual_;
   
@@ -36,6 +39,8 @@ class PFClusterEMEnergyCorrector {
   std::vector<std::string> _condnames_sigma_50ns;
   std::vector<std::string> _condnames_mean_25ns;
   std::vector<std::string> _condnames_sigma_25ns;  
+  
+   std::unique_ptr<PFEnergyCalibration> _calibrator;
   
 };
 

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -141,6 +141,8 @@ void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescript
   desc.add<edm::InputTag>("inputPS",edm::InputTag("particleFlowClusterPS"));
   {
     edm::ParameterSetDescription psd0;
+    psd0.add<bool>("applyCrackCorrections",false);
+    psd0.add<bool>("applyMVACorrections",false);
     psd0.add<std::string>("algoName","PFClusterEMEnergyCorrector");
     psd0.add<edm::InputTag>("recHitsEBLabel",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
     psd0.add<edm::InputTag>("recHitsEELabel",edm::InputTag("ecalRecHit","EcalRecHitsEE"));

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
@@ -169,6 +169,8 @@ pfclusprefer = cms.ESPrefer(
 #energy corrector for corrected cluster producer
 _emEnergyCorrector = cms.PSet(
     algoName = cms.string("PFClusterEMEnergyCorrector"),
+    applyCrackCorrections = cms.bool(False),
+    applyMVACorrections = cms.bool(True),
     recHitsEBLabel = cms.InputTag('ecalRecHit', 'EcalRecHitsEB'),
     recHitsEELabel = cms.InputTag('ecalRecHit', 'EcalRecHitsEE'),
     verticesLabel = cms.InputTag('offlinePrimaryVertices'),    

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
@@ -1,11 +1,178 @@
 import FWCore.ParameterSet.Config as cms
 
+#temporarily load regression weights with esprefer
+from CondCore.DBCommon.CondDBCommon_cfi import *
+
+pfcluscorsource = cms.ESSource("PoolDBESSource",
+    CondDBCommon,
+    DumpStat=cms.untracked.bool(False),
+    toGet = cms.VPSet(
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_50ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_50ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_25ns')
+      ),
+      cms.PSet(
+        record = cms.string('GBRDWrapperRcd'),
+        label = cms.untracked.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_25ns'),
+        tag = cms.string('GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_25ns')
+      ),
+    )
+)
+
+pfcluscorsource.connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000')
+
+pfclusprefer = cms.ESPrefer(
+    'PoolDBESSource',
+    'pfcluscorsource',
+    GBRDWrapperRcd = cms.vstring(
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_50ns',     
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_50ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_50ns',     
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_25ns',     
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_25ns',
+                                'GBRForestD/GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_25ns',                                  
+                                )
+)
+
+
 #### PF CLUSTER ECAL ####
 
 #energy corrector for corrected cluster producer
 _emEnergyCorrector = cms.PSet(
     algoName = cms.string("PFClusterEMEnergyCorrector"),
-    applyCrackCorrections = cms.bool(False)
+    recHitsEBLabel = cms.InputTag('ecalRecHit', 'EcalRecHitsEB'),
+    recHitsEELabel = cms.InputTag('ecalRecHit', 'EcalRecHitsEE'),
+    verticesLabel = cms.InputTag('offlinePrimaryVertices'),    
+    autoDetectBunchSpacing = cms.bool(True),
 )
 
 particleFlowClusterECAL = cms.EDProducer(

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -1,4 +1,10 @@
 #include "RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
+#include "CondFormats/DataRecord/interface/GBRDWrapperRcd.h"
+#include "CondFormats/EgammaObjects/interface/GBRForestD.h"
+#include "vdt/vdtMath.h"
+#include <array>
 
 namespace {
   typedef reco::PFCluster::EEtoPSAssociation::value_type EEPSPair;
@@ -7,33 +13,219 @@ namespace {
   } 
 }
 
-void PFClusterEMEnergyCorrector::
-correctEnergyActual(reco::PFCluster& cluster, unsigned idx) const {
-  std::vector<double> ps1_energies,ps2_energies;
-  double ePS1=0, ePS2=0;
-  if( cluster.layer() == PFLayer::ECAL_ENDCAP && _assoc ) {
-    auto ee_key_val = std::make_pair(idx,edm::Ptr<reco::PFCluster>());
-    const auto clustops = std::equal_range(_assoc->begin(),
-					   _assoc->end(),
-					   ee_key_val,
-					   sortByKey);
-    for( auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
-      edm::Ptr<reco::PFCluster> psclus(i_ps->second);
-      switch( psclus->layer() ) {
-      case PFLayer::PS1:
-	ps1_energies.push_back(psclus->energy());
-	break;
-      case PFLayer::PS2:
-	ps2_energies.push_back(psclus->energy());
-	break;
-      default:
-	break;
+PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet& conf, edm::ConsumesCollector &&cc) {
+
+  _recHitsEB = cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsEBLabel"));
+  _recHitsEE = cc.consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("recHitsEELabel"));
+  _vertices  = cc.consumes<reco::VertexCollection>(conf.getParameter<edm::InputTag>("verticesLabel"));
+  
+  autoDetectBunchSpacing_ = conf.getParameter<bool>("autoDetectBunchSpacing");
+
+  if (autoDetectBunchSpacing_) {
+    bunchSpacing_ = cc.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+    bunchSpacingManual_ = 0;
+  }
+  else {
+    bunchSpacingManual_ = conf.getParameter<int>("bunchSpacing");
+  }
+  
+  _condnames_mean_50ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_50ns");
+  _condnames_mean_50ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_50ns");
+  _condnames_mean_50ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_50ns");
+  _condnames_mean_50ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_50ns");
+  _condnames_mean_50ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_50ns");
+  _condnames_mean_50ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_50ns");
+
+  _condnames_sigma_50ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_50ns");
+  _condnames_sigma_50ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_50ns");
+  _condnames_sigma_50ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_50ns");
+  _condnames_sigma_50ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_50ns");
+  _condnames_sigma_50ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_50ns");
+  _condnames_sigma_50ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_50ns");
+  
+  _condnames_mean_25ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize1_mean_25ns");
+  _condnames_mean_25ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize2_mean_25ns");
+  _condnames_mean_25ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize3_mean_25ns");
+  _condnames_mean_25ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize1_mean_25ns");
+  _condnames_mean_25ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize2_mean_25ns");
+  _condnames_mean_25ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize3_mean_25ns");
+
+  _condnames_sigma_25ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize1_sigma_25ns");
+  _condnames_sigma_25ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize2_sigma_25ns");
+  _condnames_sigma_25ns.push_back("GBRForestD_ecalPFClusterCor_EB_pfSize3_sigma_25ns");
+  _condnames_sigma_25ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize1_sigma_25ns");
+  _condnames_sigma_25ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize2_sigma_25ns");
+  _condnames_sigma_25ns.push_back("GBRForestD_ecalPFClusterCor_EE_pfSize3_sigma_25ns");  
+  
+}
+
+
+void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const edm::EventSetup &es, const reco::PFCluster::EEtoPSAssociation &assoc, reco::PFClusterCollection& cs) {
+
+  int bunchspacing = 450;  
+  
+  if (autoDetectBunchSpacing_) {
+    if (evt.isRealData()) {
+      edm::RunNumber_t run = evt.run();
+      if (run == 178003 ||
+          run == 178004 ||
+          run == 209089 ||
+          run == 209106 ||
+          run == 209109 ||
+          run == 209146 ||
+          run == 209148 ||
+          run == 209151) {
+        bunchspacing = 25;
+      }
+      else {
+        bunchspacing = 50;
       }
     }
+    else {
+      edm::Handle<int> bunchSpacingH;
+      evt.getByToken(bunchSpacing_,bunchSpacingH);
+      bunchspacing = *bunchSpacingH;
+    }
   }
-  const double eCorr= _calibrator->energyEm(cluster,
-					    ps1_energies,ps2_energies,
-					    ePS1,ePS2,
-					    _applyCrackCorrections);
-  cluster.setCorrectedEnergy(eCorr);
+  
+  const unsigned int ncor = 6;
+  
+  std::vector<edm::ESHandle<GBRForestD> > forestH_mean(ncor);
+  std::vector<edm::ESHandle<GBRForestD> > forestH_sigma(ncor);
+  
+  const std::vector<std::string> condnames_mean = (bunchspacing == 25) ? _condnames_mean_25ns : _condnames_mean_50ns;
+  const std::vector<std::string> condnames_sigma = (bunchspacing == 25) ? _condnames_sigma_25ns : _condnames_sigma_50ns;
+  
+  for (unsigned int icor=0; icor<ncor; ++icor) {
+    es.get<GBRDWrapperRcd>().get(condnames_mean[icor],forestH_mean[icor]);
+    es.get<GBRDWrapperRcd>().get(condnames_sigma[icor],forestH_sigma[icor]);
+  }
+  
+  std::array<float,11> eval;
+    
+  EcalClusterLazyTools lazyTool(evt, es, _recHitsEB, _recHitsEE);
+
+  //count number of primary vertices for pileup correction
+  edm::Handle<reco::VertexCollection> vtxH;
+  evt.getByToken(_vertices,vtxH);
+  int nvtx = 0;
+  for (const reco::Vertex &vtx : *vtxH) {
+    if (!vtx.isFake()) {
+      ++nvtx;  
+    }
+  }
+  
+  //magic numbers for MINUIT-like transformation of BDT output onto limited range
+  //(These should be stored inside the conditions object in the future as well)
+  const double meanlimlow = 1./1.4;
+  const double meanlimhigh = 1./0.4;
+  const double meanoffset = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
+  const double meanscale = 0.5*(meanlimhigh-meanlimlow);
+  
+//   const double sigmalimlow = 0.003;
+//   const double sigmalimhigh = 0.5;
+//   const double sigmaoffset = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
+//   const double sigmascale = 0.5*(sigmalimhigh-sigmalimlow);  
+  
+  for (unsigned int idx = 0; idx<cs.size(); ++idx) {
+    
+    reco::PFCluster &cluster = cs[idx];
+    
+    double e = cluster.energy();
+    double eta = cluster.eta();
+    double phi = cluster.phi();    
+    
+    int size = lazyTool.n5x5(cluster);
+    
+    bool iseb = cluster.layer() == PFLayer::ECAL_BARREL;
+
+    //find index of corrections (0-2 for EB, 3-5 for EE, depending on cluster size)
+    int coridx = std::min(size,3)-1;
+    if (!iseb) {
+      coridx += 3;
+    }
+    
+    const GBRForestD &meanforest = *forestH_mean[coridx].product();
+    const GBRForestD &sigmaforest = *forestH_sigma[coridx].product();
+    
+    double e1x3    = lazyTool.e1x3(cluster);
+    double e2x2    = lazyTool.e2x2(cluster);
+    double e2x5max = lazyTool.e2x5Max(cluster);    
+    double e3x3    = lazyTool.e3x3(cluster);
+    double e5x5    = lazyTool.e5x5(cluster);    
+    
+    
+    //compute preshower energies for endcap clusters
+    double ePS1=0, ePS2=0;
+    if(!iseb) {
+      auto ee_key_val = std::make_pair(idx,edm::Ptr<reco::PFCluster>());
+      const auto clustops = std::equal_range(assoc.begin(),
+                                            assoc.end(),
+                                            ee_key_val,
+                                            sortByKey);
+      for( auto i_ps = clustops.first; i_ps != clustops.second; ++i_ps) {
+        edm::Ptr<reco::PFCluster> psclus(i_ps->second);
+        switch( psclus->layer() ) {
+        case PFLayer::PS1:
+          ePS1 += psclus->energy();
+          break;
+        case PFLayer::PS2:
+          ePS2 += psclus->energy();
+          break;
+        default:
+          break;
+        }
+      }
+    }
+    
+    //fill array for forest evaluation
+    eval[0] = e;
+    eval[1] = eta;
+    eval[2] = phi;
+    
+    if (size==1) {
+      eval[3] = nvtx;
+      if (!iseb) {
+        eval[4] = ePS1/e;
+        eval[5] = ePS2/e;
+      }
+    }
+    else if (size==2) {
+      eval[3] = e1x3/e;
+      eval[4] = nvtx;
+      if (!iseb) {
+        eval[5] = ePS1/e;
+        eval[6] = ePS2/e;
+      }
+    }
+    else if (size>2) {
+      eval[3] = e1x3/e;
+      eval[4] = e2x2/e;
+      eval[5] = e2x5max/e;
+      eval[6] = e3x3/e;
+      eval[7] = e5x5/e;
+      eval[8] = nvtx;
+      if (!iseb) {
+        eval[9] = ePS1/e;
+        eval[10] = ePS2/e;
+      }
+    }
+    
+    //these are the actual BDT responses
+    double rawmean = meanforest.GetResponse(eval.data());
+//     double rawsigma = sigmaforest.GetResponse(eval.data());
+    
+    //apply transformation to limited output range (matching the training)
+    double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
+//     double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+    
+    cluster.setCorrectedEnergy(mean*e);
+    //cluster.setCorrectedEnergyUncertainty(sigma*e);
+    
+//     printf("energy = %e, eta = %5f, size = %i, cor = %5e, sigmacor = %5e\n",e,eta,int(size),mean, sigma/mean);
+  }
+  
 }
+
+
+

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -122,10 +122,10 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
   const double meanoffset = meanlimlow + 0.5*(meanlimhigh-meanlimlow);
   const double meanscale = 0.5*(meanlimhigh-meanlimlow);
   
-//   const double sigmalimlow = 0.003;
-//   const double sigmalimhigh = 0.5;
-//   const double sigmaoffset = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
-//   const double sigmascale = 0.5*(sigmalimhigh-sigmalimlow);  
+  const double sigmalimlow = 0.003;
+  const double sigmalimhigh = 0.5;
+  const double sigmaoffset = sigmalimlow + 0.5*(sigmalimhigh-sigmalimlow);
+  const double sigmascale = 0.5*(sigmalimhigh-sigmalimlow);  
   
   for (unsigned int idx = 0; idx<cs.size(); ++idx) {
     
@@ -213,16 +213,15 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
     
     //these are the actual BDT responses
     double rawmean = meanforest.GetResponse(eval.data());
-//     double rawsigma = sigmaforest.GetResponse(eval.data());
+    double rawsigma = sigmaforest.GetResponse(eval.data());
     
     //apply transformation to limited output range (matching the training)
     double mean = meanoffset + meanscale*vdt::fast_sin(rawmean);
-//     double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
+    double sigma = sigmaoffset + sigmascale*vdt::fast_sin(rawsigma);
     
     cluster.setCorrectedEnergy(mean*e);
-    //cluster.setCorrectedEnergyUncertainty(sigma*e);
+    cluster.setCorrectedEnergyUncertainty(sigma*e);
     
-//     printf("energy = %e, eta = %5f, size = %i, cor = %5e, sigmacor = %5e\n",e,eta,int(size),mean, sigma/mean);
   }
   
 }

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -1333,16 +1333,16 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	}
 	*/ 
 
-	// Check the presence of preshower clusters in the vicinity
-	// Preshower cluster closer to another ECAL cluster are ignored.
-	vector<double> ps1Ene(1,static_cast<double>(0.));
-	associatePSClusters(index, reco::PFBlockElement::PS1, block, elements, linkData, active, ps1Ene);
-	vector<double> ps2Ene(1,static_cast<double>(0.));
-	associatePSClusters(index, reco::PFBlockElement::PS2, block, elements, linkData, active, ps2Ene);
-	
-	// Get the energy calibrated (for photons)
-	bool crackCorrection = false;
-	double ecalEnergy = calibration_->energyEm(*clusterRef,ps1Ene,ps2Ene,crackCorrection);
+        // Check the presence of preshower clusters in the vicinity
+        // Preshower cluster closer to another ECAL cluster are ignored.
+        //JOSH: This should use the association map already produced by the cluster corrector for consistency,
+        //but should be ok for now
+        vector<double> ps1Ene(1,static_cast<double>(0.));
+        associatePSClusters(index, reco::PFBlockElement::PS1, block, elements, linkData, active, ps1Ene);
+        vector<double> ps2Ene(1,static_cast<double>(0.));
+        associatePSClusters(index, reco::PFBlockElement::PS2, block, elements, linkData, active, ps2Ene);        
+        
+	double ecalEnergy = clusterRef->correctedEnergy();
 	if ( debug_ )
 	  std::cout << "Corrected ECAL(+PS) energy = " << ecalEnergy << std::endl;
 
@@ -2020,23 +2020,8 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 	    // totalEcal += eclusterref->energy();
 	    // float ecalEnergyUnCalibrated = eclusterref->energy();
 	    //std::cout << "Ecal Uncalibrated " << ecalEnergyUnCalibrated << std::endl;
-	    
-	    // check the presence of preshower clusters in the vicinity
-	    vector<double> ps1Ene(1,static_cast<double>(0.));
-	    associatePSClusters(iEcal, reco::PFBlockElement::PS1, 
-				block, elements, linkData, active, 
-				ps1Ene);
-	    vector<double> ps2Ene(1,static_cast<double>(0.));
-	    associatePSClusters(iEcal, reco::PFBlockElement::PS2, 
-				block, elements, linkData, active, 
-				ps2Ene); 
-	    std::pair<double,double> psEnes = make_pair(ps1Ene[0],
-							ps2Ene[0]);
-	    associatedPSs.insert(make_pair(iEcal,psEnes));
-	      
-	    // Calibrate the ECAL energy for photons
-	    bool crackCorrection = false;
-	    float ecalEnergyCalibrated = calibration_->energyEm(*eclusterref,ps1Ene,ps2Ene,crackCorrection);
+
+	    float ecalEnergyCalibrated = eclusterref->correctedEnergy();
 	    ::math::XYZVector photonDirection(eclusterref->position().X(),
 					    eclusterref->position().Y(),
 					    eclusterref->position().Z());
@@ -2977,13 +2962,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
       reco::PFClusterRef eclusterRef = elements[iEcal].clusterRef();
       assert( !eclusterRef.isNull() );
 
-      // Check the presence of ps clusters in the vicinity
-      vector<double> ps1Ene(1,static_cast<double>(0.));
-      associatePSClusters(iEcal, reco::PFBlockElement::PS1, block, elements, linkData, active, ps1Ene);
-      vector<double> ps2Ene(1,static_cast<double>(0.));
-      associatePSClusters(iEcal, reco::PFBlockElement::PS2, block, elements, linkData, active, ps2Ene);
-      bool crackCorrection = false;
-      double ecalEnergy = calibration_->energyEm(*eclusterRef,ps1Ene,ps2Ene,crackCorrection);
+      double ecalEnergy = eclusterRef->correctedEnergy();
       
       //std::cout << "EcalEnergy, ps1, ps2 = " << ecalEnergy 
       //          << ", " << ps1Ene[0] << ", " << ps2Ene[0] << std::endl;
@@ -3163,13 +3142,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
 
     active[iEcal] = false;
 
-    // Check the presence of ps clusters in the vicinity
-    vector<double> ps1Ene(1,static_cast<double>(0.));
-    associatePSClusters(iEcal, reco::PFBlockElement::PS1, block, elements, linkData, active, ps1Ene);
-    vector<double> ps2Ene(1,static_cast<double>(0.));
-    associatePSClusters(iEcal, reco::PFBlockElement::PS2, block, elements, linkData, active, ps2Ene);
-    bool crackCorrection = false;
-    float ecalEnergy = calibration_->energyEm(*clusterref,ps1Ene,ps2Ene,crackCorrection);
+    float ecalEnergy = clusterref->correctedEnergy();
     // float ecalEnergy = calibration_->energyEm( clusterref->energy() );
     double particleEnergy = ecalEnergy;
     


### PR DESCRIPTION
Adapt PFCluster energy correction code to use new regression weights in the conditions database (current implementation is using ESPrefer until this is available in a GT)

The PFAlgo also needed to be modified since it was still using hardcoded inlined corrections (taking the old corrections) instead of taking the corrected energy filled by the more modular correction scheme which @lgray added a while back.

The DataFormat change to CaloCluster adds just an additional float to store the uncertainty associated with the corrected energy (which is a new feature of the regression-based corrections which is not currently used anywhere, but intended to be used as input to the higher level electron and photon corrections)

Two caveats:
1) The dataformat change introduces some potential issues with checksum and class version divergences and incompatibility once we try to backport this to 73x.  See https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3433/1.html

2) I am still running some internal closure tests against the standalone validation code for the regression training (to make sure there are no trivial mistakes like variables being defined in a way which doesn't match the training, or passed in the wrong order to the BDT's in the CMSSW class).  Assuming that these checks will be positive, physics checks of this pull request can already start in principle.  (but would maybe hold off merging it until the outcome of those tests is confirmed)
