### PR TITLE
Bug fix so this will compile in debug mode

### DIFF
--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -1,6 +1,9 @@
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 
-     
+const TrackingLayer::eqfct TrackingLayer::_eqfct;
+const TrackingLayer::hashfct TrackingLayer::_hashfct;
+const TrackingLayer::hashfct TrackingLayer::eqfct::gethash;
+
 TrackingLayer::TrackingLayer():
     _subDet(Det::UNKNOWN),
     _side(Side::BARREL),


### PR DESCRIPTION
Define class statics so TrackingLayer will compile
in debug mode. The current version compiles successfully
when optimized because the missing things are optimized away.
