### PR TITLE
Adding Pythia8 capability to TopDecaySubset

### DIFF
--- a/TopQuarkAnalysis/Configuration/test/TestForTTGenEvents.py
+++ b/TopQuarkAnalysis/Configuration/test/TestForTTGenEvents.py
@@ -1,0 +1,88 @@
+import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.VarParsing as VarParsing
+import sys
+import os
+
+process = cms.Process("Analyzer")
+## enabling unscheduled mode for modules
+process.options = cms.untracked.PSet(
+    wantSummary = cms.untracked.bool(True),
+    allowUnscheduled = cms.untracked.bool(True),
+)
+options = VarParsing.VarParsing ('standard')
+options.register('runOnPythia8', True, 
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.bool, 
+                 "decide to run on Pythia8 or Pythia6")
+options.register('useRun2Code', True, 
+                 VarParsing.VarParsing.multiplicity.singleton, 
+                 VarParsing.VarParsing.varType.bool, 
+                 "decide to use Run1 or Run2 code")
+
+# Get and parse the command line arguments
+if( hasattr(sys, "argv") ):
+    for args in sys.argv :
+        arg = args.split(',')
+        for val in arg:
+            val = val.split('=')
+            if(len(val)==2):
+                setattr(options,val[0], val[1])
+
+if options.runOnPythia8:
+    print 'Running on Pythia8'
+else:
+    print 'Running on Pythia6'
+
+## configure message logger
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.threshold = 'INFO'
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+## define input
+if options.runOnPythia8:
+    process.source = cms.Source("PoolSource",
+       fileNames = cms.untracked.vstring(    
+         '/store/mc/Spring14dr/TTbarH_M-125_13TeV_amcatnlo-pythia8-tauola/AODSIM/PU20bx25_POSTLS170_V5-v1/00000/0E3D08A9-C610-E411-A862-0025B3E0657E.root',
+       ),
+       skipEvents = cms.untracked.uint32(0)
+    )
+else:
+    process.source = cms.Source("PoolSource",
+       fileNames = cms.untracked.vstring(
+        '/store/mc/Spring14dr/TTbarH_HToBB_M-125_13TeV_pythia6/AODSIM/PU20bx25_POSTLS170_V5-v1/00000/1CAB7E58-0BD0-E311-B688-00266CFFBC3C.root',
+       ),
+       skipEvents = cms.untracked.uint32(0)
+    )
+
+## define maximal number of events to loop over
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(1000)
+)
+
+####################################################################
+genParticleCollection = 'genParticles'
+
+process.load("TopQuarkAnalysis.TopEventProducers.sequences.ttGenEvent_cff")
+process.initSubset.src = genParticleCollection
+process.decaySubset.src = genParticleCollection
+process.decaySubset.fillMode = "kME" # Status3, use kStable for Status2
+runMode = "Run2"
+if options.useRun2Code:
+    runMode = "Run2"
+else:
+    runMode = "Run1"
+process.decaySubset.runMode = runMode
+process.ttGenEventSequence = cms.Sequence(process.makeGenEvt)
+
+## module to store raw output from the processed modules into the ROOT file
+output_file = 'output.root'
+if options.runOnPythia8:
+    output_file = 'Pythia8_' + runMode + '.root'
+else:
+    output_file = 'Pythia6_' + runMode + '.root'
+
+process.out = cms.OutputModule("PoolOutputModule",
+    fileName = cms.untracked.string(output_file),
+    outputCommands = cms.untracked.vstring('drop *', 'keep *_*_*_Analyzer')
+)
+process.outpath = cms.EndPath(process.out)

--- a/TopQuarkAnalysis/TopEventProducers/python/producers/TopDecaySubset_cfi.py
+++ b/TopQuarkAnalysis/TopEventProducers/python/producers/TopDecaySubset_cfi.py
@@ -13,6 +13,10 @@ decaySubset = cms.EDProducer("TopDecaySubset",
   ## 'kME'     : status 3 particles (from matrix element, before
   ##             parton shower) are saved (as status 3 particles)
   fillMode = cms.string("kStable"),
+  ## define run mode. The following run modes are available:
+  ## 'Run1' : will run the same code as during Run1
+  ## 'Run2' : will run new code that can deal with Pythia8
+  runMode = cms.string("Run1"),
   ## choose whether to save additionally radiated gluons in the
   ## decay chain or not
   addRadiation = cms.bool(True)

--- a/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
@@ -4,11 +4,15 @@
 #include "AnalysisDataFormats/TopObjects/interface/TopGenEvent.h"
 #include "TopQuarkAnalysis/TopEventProducers/interface/TopDecaySubset.h"
 
+#include "FWCore/Common/interface/Provenance.h"
+
 /// default constructor
 TopDecaySubset::TopDecaySubset(const edm::ParameterSet& cfg):
   srcToken_         (consumes<reco::GenParticleCollection>(cfg.getParameter<edm::InputTag>("src"))),
+  genEventInfo_srcToken_ (mayConsume < GenEventInfoProduct > (edm::InputTag("generator"))),
   addRadiation_(cfg.getParameter<bool>("addRadiation")),
-  showerModel_ (kStart)
+  showerModel_ (kStart),
+  runMode_(kRun1)
 {
   // mapping of the corresponding fillMode; see FillMode
   // enumerator of TopDecaySubset for available modes
@@ -19,6 +23,14 @@ TopDecaySubset::TopDecaySubset(const edm::ParameterSet& cfg):
     fillMode_=kStable;
   else
     throw cms::Exception("Configuration") << mode << " is not a supported FillMode!\n";
+
+  mode = cfg.getParameter<std::string>( "runMode" );
+    if(mode=="Run1")
+      runMode_=kRun1;
+    else if(mode=="Run2")
+    	runMode_=kRun2;
+    else
+      throw cms::Exception("Configuration") << mode << " is not a supported RunMode!\n";
 
   // produces a set of GenParticles following
   // the decay branch of top quarks to the first level of
@@ -42,25 +54,47 @@ TopDecaySubset::produce(edm::Event& event, const edm::EventSetup& setup)
   edm::Handle<reco::GenParticleCollection> src;
   event.getByToken(srcToken_, src);
 
+  // find out what generator we are dealing with
+  if (showerModel_ == kStart && runMode_ == kRun2) {
+    showerModel_ = checkShowerModel(event);
+  }
+
   // find top quarks in list of input particles
-  std::vector<const reco::GenParticle*> tops = findTops(*src);
+  std::vector<const reco::GenParticle*> tops;
+  if(runMode_ == kRun1)
+	  tops = findTops(*src);
+  else
+	  tops = findPrimalTops(*src);
 
   // determine shower model (only in first event)
-  if(showerModel_==kStart)
+  if(showerModel_==kStart && runMode_ == kRun1)
     showerModel_=checkShowerModel(tops);
 
   if(showerModel_!=kNone) {
     // check sanity of W bosons
-    checkWBosons(tops);
+	if (runMode_ == kRun1)
+		checkWBosons(tops);
+	else {
+		// nothing for the moment
+	}
 
     // get ref product from the event
     const reco::GenParticleRefProd ref = event.getRefBeforePut<reco::GenParticleCollection>();
     // clear existing refs
     clearReferences();
-    // fill output
-    fillListing(tops, *target);
-    // fill references
-    fillReferences(ref, *target);
+    if (runMode_ == kRun1) {
+    	// fill output
+    	fillListing(tops, *target);
+    	// fill references
+    	fillReferences(ref, *target);
+    }
+    else {
+    	std::vector<const reco::GenParticle*> decaying_tops = findDecayingTops(*src);
+		// fill output
+		fillListing(tops, decaying_tops, *target);
+		// fill references
+		fillReferences(ref, *target);
+	}
   }
 
   // write vectors to the event
@@ -77,6 +111,107 @@ TopDecaySubset::findTops(const reco::GenParticleCollection& parts)
       tops.push_back( &(*t) );
   }
   return tops;
+}
+
+/// find primal top quarks (top quarks from the hard interaction)
+/// for Pythia6 this is identical to findDecayingTops
+std::vector<const reco::GenParticle*> TopDecaySubset::findPrimalTops(
+		const reco::GenParticleCollection& parts) {
+	std::vector<const reco::GenParticle*> tops;
+	for (reco::GenParticleCollection::const_iterator t = parts.begin();
+			t != parts.end(); ++t) {
+		if (std::abs(t->pdgId()) != TopDecayID::tID)
+			continue;
+
+		bool hasTopMother = false;
+		for (unsigned idx = 0; idx < t->numberOfMothers(); ++idx) {
+			if (std::abs(t->mother(idx)->pdgId()) == TopDecayID::tID)
+				hasTopMother = true;
+		}
+
+		if (hasTopMother)  // not a primal top
+			continue;
+		tops.push_back(&(*t));
+	}
+
+	return tops;
+}
+
+/// find decaying top quarks (quarks that decay to qW)
+/// for Pythia6 this is identical to findPrimalTops
+std::vector<const reco::GenParticle*> TopDecaySubset::findDecayingTops(
+		const reco::GenParticleCollection& parts) {
+	std::vector<const reco::GenParticle*> tops;
+	for (reco::GenParticleCollection::const_iterator t = parts.begin();
+			t != parts.end(); ++t) {
+		if (std::abs(t->pdgId()) != TopDecayID::tID)
+			continue;
+
+		bool hasTopDaughter = false;
+		for (unsigned idx = 0; idx < t->numberOfDaughters(); ++idx) {
+			if (std::abs(t->daughter(idx)->pdgId()) == TopDecayID::tID)
+				hasTopDaughter = true;
+		}
+
+		if (hasTopDaughter)  // not a decaying top
+			continue;
+		tops.push_back(&(*t));
+	}
+
+	return tops;
+}
+
+/// find W bosons that come from top quark decays
+/// for Pythia6 this is identical to findDecayingW
+const reco::GenParticle* TopDecaySubset::findPrimalW(
+		const reco::GenParticle* top) {
+	unsigned int w_index = 0;
+	for (unsigned idx = 0; idx < top->numberOfDaughters(); ++idx) {
+		if (std::abs(top->daughter(idx)->pdgId()) == TopDecayID::WID) {
+			w_index = idx;
+			break;
+		}
+	}
+	return (reco::GenParticle*)top->daughter(w_index);
+}
+
+/// find W bosons that come from top quark decays and decay themselves (end of the MC chain)
+/// for Pythia6 this is identical to findPrimalW
+//const reco::GenParticle* TopDecaySubset::findDecayingW(
+//		const reco::GenParticle* top) {
+//	const reco::GenParticle* decaying_W = findLastParticleInChain(findPrimalW(top));
+//	return findLastParticleInChain(findPrimalW(top));
+//}
+
+/// find the last particle in a (potentially) long chain of state transitions
+/// e.g. top[status==22]-> top[status==44 -> top[status==44] ->
+/// top[status==44] -> top[status==62]
+/// this function would pick the top with status 62
+const reco::GenParticle* TopDecaySubset::findLastParticleInChain(
+		const reco::GenParticle* p) {
+	unsigned int particleID = std::abs(p->pdgId());
+	bool containsItself = false;
+	unsigned int d_idx = 0;
+	for (unsigned idx = 0; idx < p->numberOfDaughters(); ++idx) {
+		if (std::abs(p->daughter(idx)->pdgId()) == particleID) {
+			containsItself = true;
+			d_idx = idx;
+		}
+	}
+
+	if (!containsItself)
+		return p;
+	else {
+    if (showerModel_ == kPythia){
+      // Pythia6 has a weird idea of W bosons (and maybe other particles)
+      // W (status == 3) -> q qbar' W. The new W is status 2 and has no daughters
+      if(p->status() == 3)
+        return p;
+    }
+    return findLastParticleInChain((reco::GenParticle*)p->daughter(d_idx));
+  }
+
+
 }
 
 /// check the decay chain for the exploited shower model
@@ -119,6 +254,35 @@ TopDecaySubset::checkShowerModel(const std::vector<const reco::GenParticle*>& to
   return kNone;
 }
 
+/// check the embedded MC information for the shower model
+TopDecaySubset::ShowerModel TopDecaySubset::checkShowerModel(
+		edm::Event& event) {
+	edm::Handle < GenEventInfoProduct > genEvtInfoProduct;
+	event.getByToken(genEventInfo_srcToken_, genEvtInfoProduct);
+
+	std::string moduleName = "";
+	if (genEvtInfoProduct.isValid()) {
+		const edm::Provenance& prov = event.getProvenance(
+				genEvtInfoProduct.id());
+		moduleName = edm::moduleName(prov);
+	}
+
+	ShowerModel shower(kStart);
+	if (moduleName.find("Pythia6") != std::string::npos)
+		shower = kPythia;
+	else if (moduleName.find("Pythia8") != std::string::npos)
+		shower = kPythia8;
+	else if (moduleName.find("Herwig6") != std::string::npos)
+		shower = kHerwig;
+	else if (moduleName.find("ThePEG") != std::string::npos)
+		// Herwig++
+		shower = kHerwig;
+	else if (moduleName.find("Sherpa") != std::string::npos)
+		shower = kSherpa;
+	else
+		shower = kNone;
+	return shower;
+}
 /// check whether the W boson is contained in the original gen particle listing
 void
 TopDecaySubset::checkWBosons(std::vector<const reco::GenParticle*>& tops) const
@@ -275,6 +439,123 @@ TopDecaySubset::fillListing(const std::vector<const reco::GenParticle*>& tops, r
   }
 }
 
+void TopDecaySubset::fillListing(
+		const std::vector<const reco::GenParticle*>& primalTops,
+		const std::vector<const reco::GenParticle*>& decayingTops,
+		reco::GenParticleCollection& target) {
+  std::vector<const reco::GenParticle*>::const_iterator top_start;
+  std::vector<const reco::GenParticle*>::const_iterator top_end;
+  if (fillMode_ == kME) {
+    top_start = primalTops.begin();
+    top_end = primalTops.end();
+  } else {
+    top_start = decayingTops.begin();
+    top_end = decayingTops.end();
+  }
+	for (std::vector<const reco::GenParticle*>::const_iterator it =
+	    top_start; it != top_end; ++it) {
+		const reco::GenParticle* t = *it;
+		// summation might happen here
+		std::auto_ptr < reco::GenParticle
+				> topPtr(
+						new reco::GenParticle(t->threeCharge(), t->p4(),
+								t->vertex(), t->pdgId(), t->status(), false));
+		target.push_back(*topPtr);
+		++motherPartIdx_;
+
+		// keep the top index for the map to manage the daughter refs
+		int iTop = motherPartIdx_;
+		std::vector<int> topDaughters;
+		// define the W boson index (to be set later) for the map to
+		// manage the daughter refs
+		int iW = 0;
+		std::vector<int> wDaughters;
+		const reco::GenParticle* final_top = findLastParticleInChain(t);
+
+		//iterate over top daughters
+		for (reco::GenParticle::const_iterator td = final_top->begin();
+				td != final_top->end(); ++td) {
+			if (std::abs(td->pdgId()) <= TopDecayID::bID) {
+				// if particle is beauty or other quark
+				std::auto_ptr < reco::GenParticle
+						> qPtr(
+								new reco::GenParticle(td->threeCharge(),
+										td->p4(), td->vertex(), td->pdgId(),
+										td->status(), false));
+				target.push_back(*qPtr);
+				// increment & push index of the top daughter
+				topDaughters.push_back(++motherPartIdx_);
+				if (addRadiation_) {
+					// for radation to be added we first need to
+					// pick the last quark in the MC chain
+					const reco::GenParticle* last_q = findLastParticleInChain(
+							(reco::GenParticle*) &*td);
+					addRadiation(motherPartIdx_, last_q, target);
+				}
+			} else if (std::abs(td->pdgId()) == TopDecayID::WID) {
+				// ladies and gentleman, we have a W boson
+				std::auto_ptr < reco::GenParticle
+						> WPtr(
+								new reco::GenParticle(td->threeCharge(),
+										td->p4(), td->vertex(), td->pdgId(),
+										td->status(), false));
+				target.push_back(*WPtr);
+				// increment & push index of the top daughter
+				topDaughters.push_back(++motherPartIdx_);
+				iW = motherPartIdx_;
+
+				// next are the daughers of our W boson
+        // for Pythia 6 this is wrong as the last W has no daughters at all!
+        // instead the status 3 W has 3 daughters: q qbar' and W (WTF??!)
+				const reco::GenParticle* decaying_W = findLastParticleInChain(
+						(reco::GenParticle*) &*td);
+				for (reco::GenParticle::const_iterator wd = decaying_W->begin();
+						wd != decaying_W->end(); ++wd) {
+					if (!(std::abs(wd->pdgId()) == TopDecayID::WID)) {
+						std::auto_ptr < reco::GenParticle
+								> qPtr(
+										new reco::GenParticle(wd->threeCharge(),
+												wd->p4(), wd->vertex(),
+												wd->pdgId(), wd->status(),
+												false));
+						target.push_back(*qPtr);
+						// increment & push index of the top daughter
+						wDaughters.push_back(++motherPartIdx_);
+						const reco::GenParticle* last_q = findLastParticleInChain(
+													(reco::GenParticle*) &*wd);
+						addRadiation(motherPartIdx_, last_q, target);
+						if (std::abs(wd->pdgId()) == TopDecayID::tauID) {
+							// add tau daughters
+							// currently it adds k-mesons etc as well, which
+							// is not what we want.
+							addDaughters(motherPartIdx_, wd, target);
+						}
+					}
+				}
+
+			} else {
+        if(addRadiation_ && ( td->pdgId()==TopDecayID::glueID ||
+            std::abs(td->pdgId())<TopDecayID::bID)){
+          // collect additional radiation from the top
+          std::auto_ptr<reco::GenParticle> radPtr(
+            new reco::GenParticle( td->threeCharge(),
+            td->p4(), td->vertex(), td->pdgId(), td->status(), false ) );
+          target.push_back( *radPtr );
+        }
+				//other top daughters like Zq for FCNC
+        // for pythia 6 many gluons end up here
+				//std::cout << "other top daughters: to be implemented"
+				//		<< std::endl;
+			}
+		}
+
+		// fill the map for the administration
+		// of daughter indices
+		refs_[iTop] = topDaughters;
+		refs_[iW] = wDaughters;
+	}
+}
+
 /// calculate lorentz vector from input
 reco::Particle::LorentzVector
 TopDecaySubset::p4(const std::vector<const reco::GenParticle*>::const_iterator top, int statusFlag)
@@ -359,7 +640,7 @@ TopDecaySubset::addRadiation(int& idx, const reco::GenParticle::const_iterator p
     if(daughter->status()<=TopDecayID::stable && daughter->pdgId()!=part->pdgId()){
       // skip comment lines and make sure that
       // the particle is not double counted as
-      // dasughter of itself
+      // daughter of itself
       std::auto_ptr<reco::GenParticle> ptr(  new reco::GenParticle( daughter->threeCharge(), daughter->p4(), daughter->vertex(), daughter->pdgId(), daughter->status(), false) );
       target.push_back( *ptr );
       daughters.push_back( ++idx ); //push index of daughter
@@ -368,6 +649,30 @@ TopDecaySubset::addRadiation(int& idx, const reco::GenParticle::const_iterator p
   if(daughters.size()) {
     refs_[ idxBuffer ] = daughters;
   }
+}
+
+void TopDecaySubset::addRadiation(int& idx, const reco::GenParticle* part,
+		reco::GenParticleCollection& target) {
+	std::vector<int> daughters;
+	int idxBuffer = idx;
+	for (reco::GenParticle::const_iterator daughter = part->begin();
+			daughter != part->end(); ++daughter) {
+		// either pick daughters as long as they are different
+		// to the initial particle
+		if (daughter->pdgId() != part->pdgId()) {
+			std::auto_ptr < reco::GenParticle
+					> ptr(
+							new reco::GenParticle(daughter->threeCharge(),
+									daughter->p4(), daughter->vertex(),
+									daughter->pdgId(), daughter->status(),
+									false));
+			target.push_back(*ptr);
+			daughters.push_back(++idx); //push index of daughter
+		}
+	}
+	if (daughters.size()) {
+		refs_[idxBuffer] = daughters;
+	}
 }
 
 /// recursively fill vector for all further decay particles of a given particle


### PR DESCRIPTION
This pull request is for the TopQuarkAnalysis package and enables TopDecaySubset to process the new Pythia8 genparticles.
Since it was requested to preserve the previous functionality, the new code is only used if the new parameter, `runMode` is set to 'Run2'.

The changes were rebased upon the current master (CMSSW_7_4_X) but also work on CMSSW_7_0_9, CMSSW_7_2_X and CMSSW_7_3_X.
The code has been tested by two independent analysis groups on Spring14 (AOD) and Phys14 (miniAOD) samples.

Since this is my first CMSSW contribution since the github migration, please let me know if I am missing any steps in the procedure.
