### PR TITLE
Workaround ICC bug.

### DIFF
--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -35,9 +35,12 @@ namespace edm {
       
     public:
       EDAnalyzer() = default;
- #ifdef __INTEL_COMPILER
+// We do this only in the case of the intel compiler as this might
+// end up creating a lot of code bloat due to inline symbols being generated 
+// in each DSO which uses this header.
+#ifdef __INTEL_COMPILER
       virtual ~EDAnalyzer() {}
- #endif
+#endif
       // ---------- const member functions ---------------------
       
       // ---------- static member functions --------------------

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -35,8 +35,9 @@ namespace edm {
       
     public:
       EDAnalyzer() = default;
+ #ifdef __INTEL_COMPILER
       virtual ~EDAnalyzer() {}
-      
+ #endif
       // ---------- const member functions ---------------------
       
       // ---------- static member functions --------------------

--- a/FWCore/Framework/interface/global/EDAnalyzer.h
+++ b/FWCore/Framework/interface/global/EDAnalyzer.h
@@ -35,6 +35,7 @@ namespace edm {
       
     public:
       EDAnalyzer() = default;
+      virtual ~EDAnalyzer() {}
       
       // ---------- const member functions ---------------------
       

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -39,8 +39,12 @@ namespace edm {
       
     public:
       EDFilter() = default;
+// We do this only in the case of the intel compiler as this might
+// end up creating a lot of code bloat due to inline symbols being generated 
+// in each DSO which uses this header.
+#ifdef __INTEL_COMPILER
       virtual ~EDFilter() = default;
-      
+#endif
       // ---------- const member functions ---------------------
       
       // ---------- static member functions --------------------

--- a/FWCore/Framework/interface/global/EDFilter.h
+++ b/FWCore/Framework/interface/global/EDFilter.h
@@ -29,15 +29,17 @@
 namespace edm {
   namespace global {
     template< typename... T>
-    class EDFilter : public filter::SpecializeAbilityToImplementor<
+    class EDFilter : 
+              public virtual EDFilterBase,
+              public filter::SpecializeAbilityToImplementor<
         CheckAbility<edm::module::Abilities::kRunSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndRunProducer,T...>::kHasIt,
         CheckAbility<edm::module::Abilities::kLuminosityBlockSummaryCache,T...>::kHasIt & CheckAbility<edm::module::Abilities::kEndLuminosityBlockProducer,T...>::kHasIt,
-        T>::Type...,
-                       public virtual EDFilterBase
+        T>::Type...
     {
       
     public:
       EDFilter() = default;
+      virtual ~EDFilter() = default;
       
       // ---------- const member functions ---------------------
       


### PR DESCRIPTION
CMSSW compiled with ICC reports a bunch of link errors of the kind:

```
tmp/slc6_amd64_gcc491/src/HLTrigger/Egamma/src/HLTriggerEgamma/HLTDisplacedEgammaFilter.o:(.data._ZTVN3edm6global8EDFilterIIEEE9HLTFilter__24HLTDisplacedEgammaFilter[_ZTVN3edm6global8EDFilterIIEEE9HLTFilter__24HLTDisplacedEgammaFilter]+0x18):
undefined reference to `edm::global::EDFilter<>::~EDFilter()'
tmp/slc6_amd64_gcc491/src/HLTrigger/Egamma/src/HLTriggerEgamma/HLTDisplacedEgammaFilter.o:(.data._ZTVN3edm6global8EDFilterIIEEE9HLTFilter__24HLTDisplacedEgammaFilter[_ZTVN3edm6global8EDFilterIIEEE9HLTFilter__24HLTDisplacedEgammaFilter]+0x20):
undefined reference to `edm::global::EDFilter<>::~EDFilter()'
```

and similar for other `edm::global::EDFilter<>` derived classes.

Notice `edm::global::EDFilterBase`, one of the two parent classes of `edm::global::EDFilter<>`, does have a virtual destructor, so I do believe this is actually a wrong behavior in ICC.

Swapping the order of parent classes in `edm::global::EDFilter` and adding an explicit virtual destructor there makes the problem disappear.

This is clearly not an acceptable solution, but so far I could not find anything else. This PR is just to keep track of the issue.
