### PR TITLE
Use rapidity instead of pseudo-rapidity in the packing of PackedGenParticles

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedGenParticle.h
+++ b/DataFormats/PatCandidates/interface/PackedGenParticle.h
@@ -294,7 +294,7 @@ namespace pat {
     virtual bool isJet() const;
 
   protected:
-    uint16_t packedPt_, packedEta_, packedPhi_, packedM_;
+    uint16_t packedPt_, packedY_, packedPhi_, packedM_;
     void pack(bool unpackAfterwards=true) ;
     void unpack() const ;
  

--- a/DataFormats/PatCandidates/interface/ioread_packedgen.h
+++ b/DataFormats/PatCandidates/interface/ioread_packedgen.h
@@ -1,0 +1,12 @@
+#include "DataFormats/PatCandidates/interface/libminifloat.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+int16_t convertPackedEtaToPackedY(int16_t packedPt_, int16_t packedEta_,int16_t packedM_)
+{
+ reco::Candidate::PolarLorentzVector p4(MiniFloatConverter::float16to32(packedPt_),
+                         int16_t(packedEta_)*6.0f/std::numeric_limits<int16_t>::max(),
+                         0,
+                         MiniFloatConverter::float16to32(packedM_));
+
+ return int16_t(p4.Rapidity()/6.0f*std::numeric_limits<int16_t>::max());
+}
+

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -6,7 +6,7 @@
 
 void pat::PackedGenParticle::pack(bool unpackAfterwards) {
     packedPt_  =  MiniFloatConverter::float32to16(p4_.Pt());
-    packedEta_ =  int16_t(p4_.Eta()/6.0f*std::numeric_limits<int16_t>::max());
+    packedY_ =  int16_t(p4_.Rapidity()/6.0f*std::numeric_limits<int16_t>::max());
     packedPhi_ =  int16_t(p4_.Phi()/3.2f*std::numeric_limits<int16_t>::max());
     packedM_   =  MiniFloatConverter::float32to16(p4_.M());
     if (unpackAfterwards) unpack(); // force the values to match with the packed ones
@@ -14,10 +14,12 @@ void pat::PackedGenParticle::pack(bool unpackAfterwards) {
 
 
 void pat::PackedGenParticle::unpack() const {
-    p4_ = PolarLorentzVector(MiniFloatConverter::float16to32(packedPt_),
-                             int16_t(packedEta_)*6.0f/std::numeric_limits<int16_t>::max(),
-                             int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max(),
-                             MiniFloatConverter::float16to32(packedM_));
+    float y = int16_t(packedY_)*6.0f/std::numeric_limits<int16_t>::max();
+    float pt=MiniFloatConverter::float16to32(packedPt_);
+    float m=MiniFloatConverter::float16to32(packedM_);
+    float pz = tanh(y)*sqrt((m*m+pt*pt)/(1.-tanh(y)*tanh(y)));
+    float eta = asinh(pz/pt);
+    p4_ = PolarLorentzVector(pt,eta,int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max(),m);
     p4c_ = p4_;
     unpacked_ = true;
 }

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -17,8 +17,8 @@ void pat::PackedGenParticle::unpack() const {
     float y = int16_t(packedY_)*6.0f/std::numeric_limits<int16_t>::max();
     float pt=MiniFloatConverter::float16to32(packedPt_);
     float m=MiniFloatConverter::float16to32(packedM_);
-    float pz = tanh(y)*sqrt((m*m+pt*pt)/(1.-tanh(y)*tanh(y)));
-    float eta = asinh(pz/pt);
+    float pz = std::tanh(y)*std::sqrt((m*m+pt*pt)/(1.-std::tanh(y)*std::tanh(y)));
+    float eta = std::asinh(pz/pt);
     p4_ = PolarLorentzVector(pt,eta,int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max(),m);
     p4c_ = p4_;
     unpacked_ = true;

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -229,11 +229,20 @@
     ]]>
   </ioread>
 
- <class name="pat::PackedGenParticle">
+  <class name="pat::PackedGenParticle" ClassVersion="11">
+    <version ClassVersion="11" checksum="1563245819"/>
+    <version ClassVersion="10" checksum="389883266"/>
     <field name="p4_" transient="true" />
     <field name="p4c_" transient="true" />
     <field name="unpacked_" transient="true" />
   </class>
+  <ioread sourceClass="pat::PackedGenParticle" source="int16_t packedEta_;int16_t packedPt_;int16_t packedM_;" version="[-10]" checksum="[389883266]" targetClass="pat::PackedGenParticle"
+  	 target="packedY_" embed="false" include="DataFormats/PatCandidates/interface/ioread_packedgen.h" >
+	<![CDATA[
+	packedY_ = convertPackedEtaToPackedY(onfile.packedPt_,onfile.packedEta_,onfile.packedM_);
+	]]>
+   </ioread>
+
   <ioread sourceClass="pat::PackedGenParticle"  version="[1-]" targetClass="pat::PackedGenParticle" source="" target="unpacked_">
     <![CDATA[unpacked_ = false;
     ]]>

--- a/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
@@ -50,7 +50,7 @@ namespace pat {
             edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> >    Asso_;
             edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> >    AssoOriginal_;
             edm::EDGetTokenT<reco::VertexCollection>         PVs_;
-            double maxEta_;
+            double maxRapidity_;
     };
 }
 
@@ -60,7 +60,7 @@ pat::PATPackedGenParticleProducer::PATPackedGenParticleProducer(const edm::Param
   Asso_(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>("map"))),
   AssoOriginal_(consumes<edm::Association<reco::GenParticleCollection> >(iConfig.getParameter<edm::InputTag>("inputCollection"))),
   PVs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("inputVertices"))),
-  maxEta_(iConfig.getParameter<double>("maxEta"))
+  maxRapidity_(iConfig.getParameter<double>("maxRapidity"))
 {
   produces< std::vector<pat::PackedGenParticle> > ();
   produces< edm::Association< std::vector<pat::PackedGenParticle> > >();
@@ -110,7 +110,7 @@ void pat::PATPackedGenParticleProducer::produce(edm::Event& iEvent, const edm::E
     unsigned int packed=0;
     for(unsigned int ic=0, nc = cands->size(); ic < nc; ++ic) {
         const reco::GenParticle &cand=(*cands)[ic];
-	if(cand.status() ==1 && std::abs(cand.eta()) < maxEta_)
+	if(cand.status() ==1 && std::abs(cand.y()) < maxRapidity_)
         {
 		// Obtain original gen particle collection reference from input reference and map
 		edm::Ref<reco::GenParticleCollection> inputRef = edm::Ref<reco::GenParticleCollection>(cands,ic);

--- a/PhysicsTools/PatAlgos/python/slimming/packedGenParticles_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedGenParticles_cfi.py
@@ -4,5 +4,5 @@ packedGenParticles = cms.EDProducer("PATPackedGenParticleProducer",
     map = cms.InputTag("genParticles"),
     inputOriginal = cms.InputTag("genParticles"),
     inputVertices = cms.InputTag("offlineSlimmedPrimaryVertices"),
-    maxEta = cms.double(6)
+    maxRapidity = cms.double(6)
 )


### PR DESCRIPTION
It was noted that in existing miniAOD some GenJets have invalid refs to PackedGenParticles that extend in eta beyond 6. These particles cannot be saved because the range for eta in the packing is restricted to [-6,6]. 
On the other hand while eta of a GenJet constituent can extend beyond 6, the "rapidity" (used in jet clustering) cannot extend beyond GenJetEta + JetDRparameter. Considering relevant jets up to eta 5, the constituents should never exceed 6 (even for AK8 GenJets we should get up to 5.8).

The PackedGenCandidates are then fixed by storing persistently the "rapidity" in range [-6,6] rather than the pseudorapidity.
An ioread function is provided to keep compatibility (i.e. be able to read 72X MINIAOD)

Speed at read-time should be checked to see if this introduces any regression.

@gpetruc 
