### PR TITLE
ROOT does not use u or l qualifiers for integer template parameters in na...

### DIFF
--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -1,5 +1,6 @@
 #include <cxxabi.h>
 #include <cctype>
+#include <regex>
 #include <string>
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -25,6 +26,15 @@
 ********************************************************************/
 namespace {
   void
+  reformatter(std::string& input, char const* exp, char const* format) {
+    std::regex regexp(exp, std::regex::egrep);
+    while(std::regex_match(input, regexp)) {
+      std::string newstring = std::regex_replace(input, regexp, format);
+      input.swap(newstring);
+    }
+  }
+
+  void
   removeParameter(std::string& demangledName, std::string const& toRemove) {
     std::string::size_type const asize = toRemove.size();
     char const* const delimiters = "<>";
@@ -48,37 +58,6 @@ namespace {
         ++inx;
       }
     } 
-  }
-
-  bool isAlnumOrUnderscore(char c) {
-    return c == '_' || std::isalnum(c);
-  }
-
-  void
-  replaceDelimitedString(std::string& demangledName, std::string const& from, std::string const& to) {
-    // from must not be a substring of to.
-    std::string::size_type length = from.size(); 
-    std::string::size_type pos = 0;
-    while((pos = demangledName.find(from, pos)) != std::string::npos) {
-      // replace 'from', unless preceded or followed by a letter, digit, or unsderscore.
-      if(pos != 0 && isAlnumOrUnderscore(demangledName[pos - 1])) {
-        ++pos;
-      } else if(pos + length < demangledName.size() && isAlnumOrUnderscore(demangledName[pos + length])) {
-        ++pos;
-      } else {
-        demangledName.replace(pos, length, to); 
-      }
-    }
-  } 
-
-  void
-  replaceString(std::string& demangledName, std::string const& from, std::string const& to) {
-    // from must not be a substring of to.
-    std::string::size_type length = from.size(); 
-    std::string::size_type pos = 0;
-    while((pos = demangledName.find(from, pos)) != std::string::npos) {
-       demangledName.replace(pos, length, to); 
-    }
   }
 
   void
@@ -121,7 +100,7 @@ namespace edm {
     // We must use the same conventions used by REFLEX.
     // The order of these is important.
     // No space after comma
-    replaceString(demangledName, ", ", ",");
+    reformatter(demangledName, "(.*), (.*)", "$1,$2");
     // Strip default allocator
     std::string const allocator(",std::allocator<");
     removeParameter(demangledName, allocator);
@@ -129,11 +108,13 @@ namespace edm {
     std::string const comparator(",std::less<");
     removeParameter(demangledName, comparator);
     // Replace 'std::string' with 'std::basic_string<char>'.
-    replaceDelimitedString(demangledName, "std::string", "std::basic_string<char>");
+    reformatter(demangledName, "(.*[^0-9A-Za-z_])std::string([^0-9A-Za-z_].*)", "$1std::basic_string<char>$2");
     // Put const qualifier before identifier.
     constBeforeIdentifier(demangledName);
     // No two consecutive '>' 
-    replaceString(demangledName, ">>", "> >");
+    reformatter(demangledName, "(.*)>>(.*)", "$1> >$2");
+    // No u or l qualifiers for integers.
+    reformatter(demangledName, "(.*[<,][0-9]+)[ul]l*([,>].*)", "$1$2");
     return demangledName;
   }
 }


### PR DESCRIPTION
This is a bug fix to allow putting a ROOT SMatrix in an event, as requested by Slava Krutelyov.
ROOT does not use u or l qualifiers for the names of integer template parameters in class names.   Because of this, a missing dictionary error resulted when attempting put an SMatrix into an event.
This pull request adds stripping off the "u" or "l" qualifiers in class names containing integer template parameters, thereby correcting the error.
This fix required the use of std::regex_replace().  Since we need regex_replace() anyway, two other existing CMSSW functions currently used to normalize class names were removed, as their usage is here being replaced by calls to std::regex_replace().  The usage of these functions was local to the one modified source file.
