### PR TITLE
Fixing HIP Algorithm Configuration V2

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
@@ -114,7 +114,7 @@ class HIPAlignmentAlgorithm : public AlignmentAlgorithmBase
   // variables for event-wise tree
   static const int MAXREC = 99;
   //int m_Run,m_Event;
-  int m_Ntracks,m_Nhits[MAXREC],m_nhPXB[MAXREC],m_nhPXF[MAXREC];
+  int m_Ntracks,m_Nhits[MAXREC],m_nhPXB[MAXREC],m_nhPXF[MAXREC],m_nhTIB[MAXREC],m_nhTOB[MAXREC],m_nhTID[MAXREC],m_nhTEC[MAXREC];
   float m_Pt[MAXREC],m_Eta[MAXREC],m_Phi[MAXREC],m_Chi2n[MAXREC],m_P[MAXREC],m_d0[MAXREC],m_dz[MAXREC];
 
   // variables for alignable-wise tree

--- a/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
+++ b/Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h
@@ -46,7 +46,7 @@ class HIPAlignmentAlgorithm : public AlignmentAlgorithmBase
  private:
 
   // private member functions
-
+  
   bool processHit1D(const AlignableDetOrUnitPtr& alidet,
 		    const Alignable* ali,
 		    const TrajectoryStateOnSurface & tsos,

--- a/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlCosmicsCTF0TTrackSelection_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlCosmicsCTF0TTrackSelection_cff_py.txt
@@ -31,7 +31,6 @@ process.ctfProducerCustomised.src = 'TrackerTrackHitFilter'
 process.ctfProducerCustomised.TTRHBuilder = 'WithAngleAndTemplate'
 process.ctfProducerCustomised.TrajectoryInEvent = False
 
-
 # parameters for TrackSelector
 ###process.AlignmentTrackSelector.src = '<SKIM>'
 process.AlignmentTrackSelector.src = 'ctfProducerCustomised'

--- a/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlCosmicsCTF0TTrackSelection_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlCosmicsCTF0TTrackSelection_cff_py.txt
@@ -30,6 +30,7 @@ process.ctfProducerCustomised = RecoTracker.TrackProducer.CTFFinalFitWithMateria
 process.ctfProducerCustomised.src = 'TrackerTrackHitFilter'
 process.ctfProducerCustomised.TTRHBuilder = 'WithAngleAndTemplate'
 process.ctfProducerCustomised.TrajectoryInEvent = False
+process.ctfProducerCustomised.NavigationSchool = ''
 
 # parameters for TrackSelector
 ###process.AlignmentTrackSelector.src = '<SKIM>'

--- a/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlMinBiasTrackSelection_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlMinBiasTrackSelection_cff_py.txt
@@ -50,7 +50,6 @@ process.ctfProducerCustomised.src = 'TrackerTrackHitFilter'
 process.ctfProducerCustomised.TTRHBuilder = 'WithAngleAndTemplate'
 process.ctfProducerCustomised.TrajectoryInEvent = True
 
-
 # parameters for TrackSelector
 ###process.AlignmentTrackSelector.src = '<SKIM>'
 process.AlignmentTrackSelector.src = 'ctfProducerCustomised'

--- a/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlMinBiasTrackSelection_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/ALCARECOTkAlMinBiasTrackSelection_cff_py.txt
@@ -26,7 +26,6 @@ process.initialAlignmentTrackSelector.applyMultiplicityFilter = True
 process.initialAlignmentTrackSelector.maxMultiplicity = 1000
 process.initialAlignmentTrackSelector.applyNHighestPt = False
 
-
 # parameters for alignmentHitFilter
 process.TrackerTrackHitFilter.src = 'TrackRefitter1'
 process.TrackerTrackHitFilter.commands = cms.vstring("keep PXB","keep PXE","keep TIB","keep TID","keep TOB","keep TEC")
@@ -49,6 +48,7 @@ process.ctfProducerCustomised.src = 'TrackerTrackHitFilter'
 ##process.ctfProducerCustomised.beamspot='offlineBeamSpot'
 process.ctfProducerCustomised.TTRHBuilder = 'WithAngleAndTemplate'
 process.ctfProducerCustomised.TrajectoryInEvent = True
+process.ctfProducerCustomised.NavigationSchool = ''
 
 # parameters for TrackSelector
 ###process.AlignmentTrackSelector.src = '<SKIM>'

--- a/Alignment/HIPAlignmentAlgorithm/python/align_tpl_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/align_tpl_py.txt
@@ -126,7 +126,7 @@ process.skimming = cms.EDFilter("PhysDecl",
 if 'MBVertex'=='<FLAG>':
    process.p = cms.Path(process.initialAlignmentTrackSelector*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 elif 'COSMICS' =='<FLAG>':
-    process.p = cms.Path(process.skimming*process.offlineBeamSpot*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
+    process.p = cms.Path(process.offlineBeamSpot*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 else :
     process.p = cms.Path(process.hltLevel1GTSeed*process.skimming*process.offlineBeamSpot*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 

--- a/Alignment/HIPAlignmentAlgorithm/python/align_tpl_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/align_tpl_py.txt
@@ -124,9 +124,9 @@ process.skimming = cms.EDFilter("PhysDecl",
                                 )
 
 if 'MBVertex'=='<FLAG>':
-   process.p = cms.Path(process.initialAlignmentTrackSelector*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
+   process.p = cms.Path(process.initialAlignmentTrackSelector*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 elif 'COSMICS' =='<FLAG>':
     process.p = cms.Path(process.offlineBeamSpot*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 else :
-    process.p = cms.Path(process.hltLevel1GTSeed*process.skimming*process.offlineBeamSpot*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
+    process.p = cms.Path(process.hltLevel1GTSeed*process.skimming*process.offlineBeamSpot*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 

--- a/Alignment/HIPAlignmentAlgorithm/python/align_tpl_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/align_tpl_py.txt
@@ -124,9 +124,9 @@ process.skimming = cms.EDFilter("PhysDecl",
                                 )
 
 if 'MBVertex'=='<FLAG>':
-   process.p = cms.Path(process.initialAlignmentTrackSelector*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
+   process.p = cms.Path(process.initialAlignmentTrackSelector*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 elif 'COSMICS' =='<FLAG>':
-    process.p = cms.Path(process.skimming*process.offlineBeamSpot*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
+    process.p = cms.Path(process.skimming*process.offlineBeamSpot*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 else :
-    process.p = cms.Path(process.hltLevel1GTSeed*process.skimming*process.offlineBeamSpot*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
+    process.p = cms.Path(process.hltLevel1GTSeed*process.skimming*process.offlineBeamSpot*process.MeasurementTrackerEvent*process.TrackRefitter1*process.TrackerTrackHitFilter*process.ctfProducerCustomised*process.AlignmentTrackSelector*process.TrackRefitter2)
 

--- a/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
@@ -1,7 +1,8 @@
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 # loading magnetic field and geometry
-process.load('Configuration.StandardSequences.GeometryExtended_cff')
+#process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load("Configuration.StandardSequences.GeometryIdeal_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 # loading the alignment producer
@@ -26,61 +27,27 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 10000
 # configure the database file - use survey one for default
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
-#### for ideal geometry
-## process.trackerAlignment = cms.ESSource("PoolDBESSource",
-##                                         CondDBSetup,
-##                                         timetype = cms.string('runnumber'),
-##                                         toGet = cms.VPSet(cms.PSet(
-##                                                 record = cms.string('TrackerAlignmentRcd'),
-##                                                 tag = cms.string('TrackerIdealGeometry210_mc')
-##                                                 )),
-##                                         connect = cms.string('frontier://FrontierProd/CMS_COND_31X_FROM21X')
-##                                         )
+# for global tag geometry 
+process.GlobalTag.toGet = cms.VPSet(
+   cms.PSet(record = cms.string('TrackerAlignmentRcd'),
+            tag = cms.string('TrackerAlignment_2015StartupPessimisticScenario_mc'),
+            connect = cms.untracked.string('frontier://FrontierProd/CMS_COND_31X_ALIGNMENT')
+            ),
+   cms.PSet(record = cms.string('TrackerSurfaceDeformationRcd'),
+            tag = cms.string('TrackerSurfaceDeformations_2011Realistic_v2_mc'),
+            connect = cms.untracked.string('frontier://FrontierProd/CMS_COND_310X_ALIGN')
+            ),
+   cms.PSet(record = cms.string('TrackerAlignmentErrorRcd'),
+            tag = cms.string('TrackerAlignmentErrors_2015StartupPessimisticScenario_mc'),
+            connect = cms.untracked.string('frontier://FrontierProd/CMS_COND_31X_ALIGNMENT')
+            ),
+   )
 
-### end for ideal geometry
-
-### for global tag geometry 
-process.trackerAlignment = cms.ESSource("PoolDBESSource",
-                                        CondDBSetup,
-                                        timetype = cms.string('runnumber'),
-                                        toGet = cms.VPSet(cms.PSet(
-                                                record = cms.string('TrackerAlignmentRcd'),
-                                                tag = cms.string('Alignments')
-                                                )),
-
-					connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN2/HIP/covarell/CMSSW_4_2_2/src/Alignment/HIPAlignmentAlgorithm/payloads/GR_42.db')
-                                        )
-
-process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
-
-
-############ Load APE separately
-
-######## Zero APE
-from CondCore.DBCommon.CondDBSetup_cfi import *
-process.ZeroAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
-                                        connect = cms.string('frontier://FrontierProd/CMS_COND_31X_FROM21X'),
-                                        timetype = cms.string("runnumber"),
-                                        toGet = cms.VPSet(
-                                                          cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-                                                                   tag = cms.string('TrackerIdealGeometryErrors210_mc')
-                                                                   ))
-                                        )
-process.es_prefer_ZeroAPE = cms.ESPrefer("PoolDBESSource", "ZeroAPE")
-
-
-####### CRAFT10 APE
-# process.trackerAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
-# 		                  connect = cms.string('sqlite_file:/afs/cern.ch/cms/CAF/CMSALCA/ALCA_TRACKERALIGN/PayLoads/CRAFT09/TrackerAlignmentErr_2009_v2_prompt/131425-infty/TrackerAlignmentErr_2009_v2_prompt.db'),
-# 
-#                                   timetype = cms.string("runnumber"),
-#                                   toGet = cms.VPSet(
-#                                         cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
-#                                                  tag = cms.string('AlignmentErrorsExtended')
-#                                                 ))
-#                                         )
-# process.es_prefer_TrackerAPE = cms.ESPrefer("PoolDBESSource", "trackerAPE")
-
+process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi") 
+process.MeasurementTrackerEvent.pixelClusterProducer = 'ALCARECOTkAlMinBias'
+process.MeasurementTrackerEvent.stripClusterProducer = 'ALCARECOTkAlMinBias'
+process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
+process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag()
 
 process.AlignmentProducer.applyDbAlignment = True
 

--- a/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
@@ -13,9 +13,9 @@ process.load("Alignment.CommonAlignmentProducer.AlignmentProducer_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 
 if 'COSMICS'=='<FLAG>':
-   process.GlobalTag.globaltag='GR_R_42_V21::All'
+   process.GlobalTag.globaltag='MCRUN2_71_V0::All'
 else :
-   process.GlobalTag.globaltag='GR_R_42_V21::All'
+   process.GlobalTag.globaltag='MCRUN2_71_V0::All'
  
 process.load("FWCore.MessageService.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 10000
@@ -44,7 +44,7 @@ from CondCore.DBCommon.CondDBSetup_cfi import *
 # process.ZeroAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
 #                                connect = cms.string('frontier://FrontierProd/CMS_COND_31X_FROM21X'),
 #                                timetype = cms.string("runnumber"),
-#                                toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentErrorRcd'),
+#                                toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
 #                                                           tag = cms.string('TrackerIdealGeometryErrors210_mc')
 #                                                           )
 #                                                  )
@@ -65,17 +65,11 @@ process.GlobalTag.toGet = cms.VPSet(
             tag = cms.string('TrackerSurfaceDeformations_2011Realistic_v2_mc'),
             connect = cms.untracked.string('frontier://FrontierProd/CMS_COND_310X_ALIGN')
             ),
-   cms.PSet(record = cms.string('TrackerAlignmentErrorRcd'),
+   cms.PSet(record = cms.string('TrackerAlignmentErrorExtendedRcd'),
             tag = cms.string('TrackerAlignmentErrors_2015StartupPessimisticScenario_mc'),
             connect = cms.untracked.string('frontier://FrontierProd/CMS_COND_31X_ALIGNMENT')
             ),
    )
-
-process.load("RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi") 
-process.MeasurementTrackerEvent.pixelClusterProducer = 'ALCARECOTkAlMinBias'
-process.MeasurementTrackerEvent.stripClusterProducer = 'ALCARECOTkAlMinBias'
-process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
-process.MeasurementTrackerEvent.inactiveStripDetectorLabels = cms.VInputTag()
 
 process.AlignmentProducer.applyDbAlignment = True
 

--- a/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
@@ -1,9 +1,8 @@
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 # loading magnetic field and geometry
-process.load("Configuration.StandardSequences.GeometryIdeal_cff")
-#process.load("Configuration.Geometry.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 # loading the alignment producer
 process.load("Alignment.CommonAlignmentProducer.AlignmentProducer_cff")

--- a/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
@@ -1,8 +1,8 @@
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 # loading magnetic field and geometry
-#process.load('Configuration.StandardSequences.GeometryExtended_cff')
 process.load("Configuration.StandardSequences.GeometryIdeal_cff")
+#process.load("Configuration.Geometry.GeometryDB_cff")
 process.load("Configuration.StandardSequences.MagneticField_cff")
 
 # loading the alignment producer
@@ -26,6 +26,32 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 10000
 
 # configure the database file - use survey one for default
 from CondCore.DBCommon.CondDBSetup_cfi import *
+
+# ########## Ideal Alignment 
+# process.trackerAlignment = cms.ESSource("PoolDBESSource",
+#                                         CondDBSetup,	
+#                                         timetype = cms.string('runnumber'),
+#                                         toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentRcd'),
+#                                                                    tag = cms.string('TrackerIdealGeometry210_mc')
+#                                                                    )
+#                                                           ),
+#                                         connect = cms.string('frontier://FrontierProd/CMS_COND_31X_FROM21X')
+#                                         )
+
+# process.es_prefer_trackerAlignment = cms.ESPrefer("PoolDBESSource", "trackerAlignment")
+
+# ########## Zero APE
+# from CondCore.DBCommon.CondDBSetup_cfi import *
+# process.ZeroAPE = cms.ESSource("PoolDBESSource",CondDBSetup,
+#                                connect = cms.string('frontier://FrontierProd/CMS_COND_31X_FROM21X'),
+#                                timetype = cms.string("runnumber"),
+#                                toGet = cms.VPSet(cms.PSet(record = cms.string('TrackerAlignmentErrorRcd'),
+#                                                           tag = cms.string('TrackerIdealGeometryErrors210_mc')
+#                                                           )
+#                                                  )
+#                                )
+
+# process.es_prefer_ZeroAPE = cms.ESPrefer("PoolDBESSource", "ZeroAPE")
 
 # for global tag geometry 
 process.GlobalTag.toGet = cms.VPSet(

--- a/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
@@ -53,7 +53,10 @@ from CondCore.DBCommon.CondDBSetup_cfi import *
 
 # process.es_prefer_ZeroAPE = cms.ESPrefer("PoolDBESSource", "ZeroAPE")
 
-# for global tag geometry 
+# For global tag geometry 
+# !!!! Pass only  "unlimited Interval Of Validity (IOV)" DB objects for
+# conditions as described in https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideHIPAlgorithm#Run_HIP
+
 process.GlobalTag.toGet = cms.VPSet(
    cms.PSet(record = cms.string('TrackerAlignmentRcd'),
             tag = cms.string('TrackerAlignment_2015StartupPessimisticScenario_mc'),

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -28,6 +28,12 @@
 #include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 
+#include "CondFormats/AlignmentRecord/interface/GlobalPositionRcd.h"
+#include "FWCore/Framework/interface/ValidityInterval.h"
+#include "FWCore/Framework/interface/ESTransientHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+
+
 #include "Alignment/HIPAlignmentAlgorithm/interface/HIPAlignmentAlgorithm.h"
 
 // using namespace std;
@@ -98,6 +104,17 @@ HIPAlignmentAlgorithm::initialize( const edm::EventSetup& setup,
 				   AlignmentParameterStore* store )
 {
   edm::LogWarning("Alignment") << "[HIPAlignmentAlgorithm] Initializing...";
+
+  edm::ESHandle<Alignments> globalPositionRcd;
+  edm::ValidityInterval iov(setup.get<GlobalPositionRcd>().validityInterval() );
+  if (iov.first().eventID().run()!=1 || iov.last().eventID().run()!=4294967295) {
+    throw cms::Exception("DatabaseError")
+      << "@SUB=AlignmentProducer::applyDB"
+      << "\nTrying to apply "<< setup.get<GlobalPositionRcd>().key().name()
+      << " with multiple IOVs in tag.\n"
+      << "Validity range is "
+      << iov.first().eventID().run() << " - " << iov.last().eventID().run();
+  }
 	
   // accessor Det->AlignableDet
   if ( !muon )

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -106,8 +106,9 @@ HIPAlignmentAlgorithm::initialize( const edm::EventSetup& setup,
   edm::LogWarning("Alignment") << "[HIPAlignmentAlgorithm] Initializing...";
 
   edm::ESHandle<Alignments> globalPositionRcd;
+  const unsigned int MAX_VAL(std::numeric_limits<unsigned int>::max());
   edm::ValidityInterval iov(setup.get<GlobalPositionRcd>().validityInterval() );
-  if (iov.first().eventID().run()!=1 || iov.last().eventID().run()!=4294967295) {
+  if (iov.first().eventID().run()!=1 || iov.last().eventID().run()!=MAX_VAL) {
     throw cms::Exception("DatabaseError")
       << "@SUB=AlignmentProducer::applyDB"
       << "\nTrying to apply "<< setup.get<GlobalPositionRcd>().key().name()

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -106,6 +106,7 @@ HIPAlignmentAlgorithm::initialize( const edm::EventSetup& setup,
   edm::LogWarning("Alignment") << "[HIPAlignmentAlgorithm] Initializing...";
 
   edm::ESHandle<Alignments> globalPositionRcd;
+  // FIXME! temporary solution to get highest possible run number
   const unsigned int MAX_VAL(std::numeric_limits<unsigned int>::max());
   edm::ValidityInterval iov(setup.get<GlobalPositionRcd>().validityInterval() );
   if (iov.first().eventID().run()!=1 || iov.last().eventID().run()!=MAX_VAL) {

--- a/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
+++ b/Alignment/HIPAlignmentAlgorithm/src/HIPAlignmentAlgorithm.cc
@@ -709,6 +709,10 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
     m_P[itr]=-5.0;
     m_nhPXB[itr]=0;
     m_nhPXF[itr]=0;
+    m_nhTIB[itr]=0;
+    m_nhTOB[itr]=0;
+    m_nhTIB[itr]=0;
+    m_nhTEC[itr]=0;
     m_Eta[itr]=-99.0;
     m_Phi[itr]=-4.0;
     m_Chi2n[itr]=-11.0;
@@ -740,6 +744,10 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
 
     int nhpxb   = track->hitPattern().numberOfValidPixelBarrelHits();
     int nhpxf   = track->hitPattern().numberOfValidPixelEndcapHits();
+    int nhtib   = track->hitPattern().numberOfValidStripTIBHits();
+    int nhtob   = track->hitPattern().numberOfValidStripTOBHits();
+    int nhtid   = track->hitPattern().numberOfValidStripTIDHits();
+    int nhtec   = track->hitPattern().numberOfValidStripTECHits();
 
     if (verbose) edm::LogInfo("Alignment") << "New track pt,eta,phi,chi2n,hits: "
 					   << pt << ","
@@ -764,6 +772,10 @@ void HIPAlignmentAlgorithm::run(const edm::EventSetup& setup, const EventInfo &e
       m_Chi2n[itr]=chi2n;
       m_nhPXB[itr]=nhpxb;
       m_nhPXF[itr]=nhpxf;
+      m_nhTIB[itr]=nhtib;
+      m_nhTOB[itr]=nhtob;
+      m_nhTID[itr]=nhtid;
+      m_nhTEC[itr]=nhtec;
       m_d0[itr]=d0;
       m_dz[itr]=dz;
       itr++;
@@ -1064,7 +1076,11 @@ void HIPAlignmentAlgorithm::bookRoot(void)
   theTree->Branch("Ntracks", &m_Ntracks, "Ntracks/I");
   theTree->Branch("Nhits",    m_Nhits,   "Nhits[Ntracks]/I");       
   theTree->Branch("nhPXB",    m_nhPXB,   "nhPXB[Ntracks]/I");       
-  theTree->Branch("nhPXF",    m_nhPXF,   "nhPXF[Ntracks]/I");       
+  theTree->Branch("nhPXF",    m_nhPXF,   "nhPXF[Ntracks]/I");    
+  theTree->Branch("nhTIB",    m_nhTIB,   "nhTIB[Ntracks]/I");       
+  theTree->Branch("nhTOB",    m_nhTOB,   "nhTOB[Ntracks]/I");    
+  theTree->Branch("nhTID",    m_nhTID,   "nhTID[Ntracks]/I");       
+  theTree->Branch("nhTEC",    m_nhTEC,   "nhTEC[Ntracks]/I");  
   theTree->Branch("Pt",       m_Pt,      "Pt[Ntracks]/F");
   theTree->Branch("P",        m_P,       "P[Ntracks]/F");
   theTree->Branch("Eta",      m_Eta,     "Eta[Ntracks]/F");
@@ -1387,7 +1403,7 @@ int HIPAlignmentAlgorithm::fillEventwiseTree(const char* filename, int iter, int
   TTree *jobtree = (TTree*)jobfile->Get(treeName);
   //address and read the variables 
   static const int nmaxtrackperevent = 1000;
-  int jobNtracks, jobNhitspertrack[nmaxtrackperevent], jobnhPXB[nmaxtrackperevent], jobnhPXF[nmaxtrackperevent];
+  int jobNtracks, jobNhitspertrack[nmaxtrackperevent], jobnhPXB[nmaxtrackperevent], jobnhPXF[nmaxtrackperevent],jobnhTIB[nmaxtrackperevent], jobnhTOB[nmaxtrackperevent],jobnhTID[nmaxtrackperevent], jobnhTEC[nmaxtrackperevent];
   float jobP[nmaxtrackperevent], jobPt[nmaxtrackperevent], jobEta[nmaxtrackperevent] , jobPhi[nmaxtrackperevent];
   float jobd0[nmaxtrackperevent], jobdz[nmaxtrackperevent] , jobChi2n[nmaxtrackperevent];
 	
@@ -1395,6 +1411,10 @@ int HIPAlignmentAlgorithm::fillEventwiseTree(const char* filename, int iter, int
   jobtree->SetBranchAddress("Nhits",   jobNhitspertrack);
   jobtree->SetBranchAddress("nhPXB",   jobnhPXB);
   jobtree->SetBranchAddress("nhPXF",   jobnhPXF);
+  jobtree->SetBranchAddress("nhTIB",   jobnhTIB);
+  jobtree->SetBranchAddress("nhTOB",   jobnhTOB);
+  jobtree->SetBranchAddress("nhTID",   jobnhTID);
+  jobtree->SetBranchAddress("nhTEC",   jobnhTEC);
   jobtree->SetBranchAddress("Pt",      jobPt);
   jobtree->SetBranchAddress("P",       jobP);
   jobtree->SetBranchAddress("d0",      jobd0);
@@ -1419,6 +1439,10 @@ int HIPAlignmentAlgorithm::fillEventwiseTree(const char* filename, int iter, int
 	m_P[ntrk] = jobP[ntrk];
 	m_nhPXB[ntrk] = jobnhPXB[ntrk];
 	m_nhPXF[ntrk] = jobnhPXF[ntrk];
+	m_nhTIB[ntrk] = jobnhTIB[ntrk];
+	m_nhTOB[ntrk] = jobnhTOB[ntrk];
+	m_nhTID[ntrk] = jobnhTID[ntrk];
+	m_nhTEC[ntrk] = jobnhTEC[ntrk];
 	m_Eta[ntrk] = jobEta[ntrk];
 	m_Phi[ntrk] = jobPhi[ntrk];
 	m_Chi2n[ntrk] = jobChi2n[ntrk];


### PR DESCRIPTION
Fixing track-refitting sequences to avoid MeasurementTrackerEvent issues as discussed in other PRs such as #6244 and #6233. Cleanup of the Cosmic data selection and introduction of the exception when using starting conditions for the Global Position Record with multiple IOVs as in V00-28-00 cvs tag (never entered in release). To be fixed in a second time: how to get highest possible run number for the starting conditions check
