### PR TITLE
Make time report sane for threading

### DIFF
--- a/FWCore/Framework/interface/TriggerTimingReport.h
+++ b/FWCore/Framework/interface/TriggerTimingReport.h
@@ -19,12 +19,12 @@ namespace edm {
     int totalEvents = 0;
     double cpuTime = 0.;
     double realTime =0.;
+    double sumStreamRealTime = 0.;
   };
 
   struct ModuleInPathTimingSummary
   {
     int timesVisited = 0;
-    double cpuTime = 0.;
     double realTime =0.;
 
     std::string moduleLabel;
@@ -35,7 +35,6 @@ namespace edm {
   {
     int bitPosition = 0;
     int timesRun = 0;
-    double cpuTime = 0.;
     double realTime =0.;
 
     std::string name;
@@ -46,7 +45,6 @@ namespace edm {
   {
     int timesVisited = 0;
     int timesRun = 0;
-    double cpuTime = 0.;
     double realTime =0.;
 
     std::string moduleLabel;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -645,6 +645,8 @@ namespace edm {
         c.call([this,i](){ this->subProcess_->doEndStream(i); } );
       }
     }
+    auto actReg = actReg_.get();
+    c.call([actReg](){actReg->preEndJobSignal_();});
     schedule_->endJob(c);
     if(hasSubProcess()) {
       c.call(std::bind(&SubProcess::doEndJob, subProcess_.get()));
@@ -653,7 +655,6 @@ namespace edm {
     if(looper_) {
       c.call(std::bind(&EDLooperBase::endOfJob, looper_));
     }
-    auto actReg = actReg_.get();
     c.call([actReg](){actReg->postEndJobSignal_();});
     if(c.hasThrown()) {
       c.rethrow();

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -583,7 +583,7 @@ namespace edm {
       LogVerbatim("FwkSummary") << "TrigReport " << "---------- Path   Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
       << std::right << std::setw(10) << "Trig Bit#" << " "
-      << std::right << std::setw(10) << "Run" << " "
+      << std::right << std::setw(10) << "Executed" << " "
       << std::right << std::setw(10) << "Passed" << " "
       << std::right << std::setw(10) << "Failed" << " "
       << std::right << std::setw(10) << "Error" << " "
@@ -620,7 +620,7 @@ namespace edm {
       LogVerbatim("FwkSummary") << "TrigReport " << "-------End-Path   Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
       << std::right << std::setw(10) << "Trig Bit#" << " "
-      << std::right << std::setw(10) << "Run" << " "
+      << std::right << std::setw(10) << "Executed" << " "
       << std::right << std::setw(10) << "Passed" << " "
       << std::right << std::setw(10) << "Failed" << " "
       << std::right << std::setw(10) << "Error" << " "
@@ -690,7 +690,7 @@ namespace edm {
       LogVerbatim("FwkSummary") << "TrigReport " << "---------- Module Summary ------------";
       LogVerbatim("FwkSummary") << "TrigReport "
       << std::right << std::setw(10) << "Visited" << " "
-      << std::right << std::setw(10) << "Run" << " "
+      << std::right << std::setw(10) << "Executed" << " "
       << std::right << std::setw(10) << "Passed" << " "
       << std::right << std::setw(10) << "Failed" << " "
       << std::right << std::setw(10) << "Error" << " "
@@ -726,147 +726,110 @@ namespace edm {
                               << std::setprecision(6) << std::fixed
                               << " efficiency CPU/Real/thread = " << tr.eventSummary.cpuTime/tr.eventSummary.realTime/preallocConfig_.numberOfThreads();
     
+    constexpr int kColumn1Size = 10;
+    constexpr int kColumn2Size = 12;
+    constexpr int kColumn3Size = 12;
     LogVerbatim("FwkSummary") << "";
-    LogVerbatim("FwkSummary") << "TimeReport " << "---------- Path   Summary ---[sec]----";
+    LogVerbatim("FwkSummary") << "TimeReport " << "---------- Path   Summary ---[Real sec]----";
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per path-run "
-                              << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
+                              << std::right << std::setw(kColumn1Size) << "per event"<<" "
+                              << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "  Name";
     for (auto const& p: tr.trigPathSummaries) {
       const int timesRun = std::max(1, p.timesRun);
       LogVerbatim("FwkSummary") << "TimeReport "
                                 << std::setprecision(6) << std::fixed
-                                << std::right << std::setw(10) << p.realTime/totalEvents << " "
-                                << std::right << std::setw(10) << p.realTime/timesRun << " "
+                                << std::right << std::setw(kColumn1Size) << p.realTime/totalEvents << " "
+                                << std::right << std::setw(kColumn2Size) << p.realTime/timesRun << "  "
                                 << p.name << "";
     }
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per path-run "
-                              << "";
+                              << std::right << std::setw(kColumn1Size) << "per event"<<" "
+                              << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "  Name" << "";
 
     LogVerbatim("FwkSummary") << "";
-    LogVerbatim("FwkSummary") << "TimeReport " << "-------End-Path   Summary ---[sec]----";
+    LogVerbatim("FwkSummary") << "TimeReport " << "-------End-Path   Summary ---[Real sec]----";
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per endpath-run "
-                              << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
+                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                              << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "  Name" << "";
     for (auto const& p: tr.endPathSummaries) {
       const int timesRun = std::max(1, p.timesRun);
 
       LogVerbatim("FwkSummary") << "TimeReport "
                                 << std::setprecision(6) << std::fixed
-                                << std::right << std::setw(10) << p.realTime/totalEvents << " "
-                                << std::right << std::setw(10) << p.realTime/timesRun << " "
+                                << std::right << std::setw(kColumn1Size) << p.realTime/totalEvents << " "
+                                << std::right << std::setw(kColumn2Size) << p.realTime/timesRun << "  "
                                 << p.name << "";
     }
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per endpath-run "
-                              << "";
+                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                              << std::right << std::setw(kColumn2Size) << "per exec"
+                              << "  Name" << "";
 
     for (auto const& p: tr.trigPathSummaries) {
       LogVerbatim("FwkSummary") << "";
-      LogVerbatim("FwkSummary") << "TimeReport " << "---------- Modules in Path: " << p.name << " ---[sec]----";
+      LogVerbatim("FwkSummary") << "TimeReport " << "---------- Modules in Path: " << p.name << " ---[Real sec]----";
       LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(8) << "per event "
-                                << std::right << std::setw(8) << "per module-visit "
-                                << "";
-      LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(10) << "Real" << " "
-                                << std::right << std::setw(10) << "Real" << " "
-                                << "Name" << "";
+                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                                << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name" << "";
       for (auto const& mod: p.moduleInPathSummaries) {
         LogVerbatim("FwkSummary") << "TimeReport "
                                   << std::setprecision(6) << std::fixed
-                                  << std::right << std::setw(10) << mod.realTime/totalEvents << " "
-                                  << std::right << std::setw(10) << mod.realTime/std::max(1, mod.timesVisited) << " "
+                                  << std::right << std::setw(kColumn1Size) << mod.realTime/totalEvents << " "
+                                  << std::right << std::setw(kColumn2Size) << mod.realTime/std::max(1, mod.timesVisited) << "  "
                                   << mod.moduleLabel << "";
       }
     }
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per module-visit "
-                              << "";
-
+    if(not tr.trigPathSummaries.empty()) {
+      LogVerbatim("FwkSummary") << "TimeReport "
+                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                                << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name" << "";
+    }
     for (auto const& p: tr.endPathSummaries) {
       LogVerbatim("FwkSummary") << "";
-      LogVerbatim("FwkSummary") << "TimeReport " << "------ Modules in End-Path: " << p.name << " ---[sec]----";
+      LogVerbatim("FwkSummary") << "TimeReport " << "------ Modules in End-Path: " << p.name << " ---[Real sec]----";
       LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(8) << "per event "
-                                << std::right << std::setw(8) << "per module-visit "
-                                << "";
-      LogVerbatim("FwkSummary") << "TimeReport "
-                                << std::right << std::setw(10) << "Real" << " "
-                                << std::right << std::setw(10) << "Real" << " "
-                                << "Name" << "";
+                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                                << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name" << "";
       for (auto const& mod: p.moduleInPathSummaries) {
         LogVerbatim("FwkSummary") << "TimeReport "
                                   << std::setprecision(6) << std::fixed
-                                  << std::right << std::setw(10) << mod.realTime/totalEvents << " "
-                                  << std::right << std::setw(10) << mod.realTime/std::max(1, mod.timesVisited) << " "
+                                  << std::right << std::setw(kColumn1Size) << mod.realTime/totalEvents << " "
+                                  << std::right << std::setw(kColumn2Size) << mod.realTime/std::max(1, mod.timesVisited) << "  "
                                   << mod.moduleLabel << "";
       }
     }
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per module-visit "
-                              << "";
-
+    if(not tr.endPathSummaries.empty()) {
+      LogVerbatim("FwkSummary") << "TimeReport "
+                                << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                                << std::right << std::setw(kColumn2Size) << "per visit"
+                                << "  Name" << "";
+    }
     LogVerbatim("FwkSummary") << "";
-    LogVerbatim("FwkSummary") << "TimeReport " << "---------- Module Summary ---[sec]----";
+    LogVerbatim("FwkSummary") << "TimeReport " << "---------- Module Summary ---[Real sec]----";
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per module-run "
-                              << std::right << std::setw(8) << "per module-visit "
-                              << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
+                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                              << std::right << std::setw(kColumn2Size) << "per exec" <<" "
+                              << std::right << std::setw(kColumn3Size) << "per visit"
+                              << "  Name" << "";
     for (auto const& worker : tr.workerSummaries) {
       LogVerbatim("FwkSummary") << "TimeReport "
                                 << std::setprecision(6) << std::fixed
-                                << std::right << std::setw(10) << worker.realTime/totalEvents << " "
-                                << std::right << std::setw(10) << worker.realTime/std::max(1, worker.timesRun) << " "
-                                << std::right << std::setw(10) << worker.realTime/std::max(1, worker.timesVisited) << " "
+                                << std::right << std::setw(kColumn1Size) << worker.realTime/totalEvents << " "
+                                << std::right << std::setw(kColumn2Size) << worker.realTime/std::max(1, worker.timesRun) << " "
+                                << std::right << std::setw(kColumn3Size) << worker.realTime/std::max(1, worker.timesVisited) << "  "
                                 << worker.moduleLabel << "";
     }
     LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << std::right << std::setw(10) << "Real" << " "
-                              << "Name" << "";
-    LogVerbatim("FwkSummary") << "TimeReport "
-                              << std::right << std::setw(8) << "per event "
-                              << std::right << std::setw(8) << "per module-run "
-                              << std::right << std::setw(8) << "per module-visit "
-                              << "";
+                              << std::right << std::setw(kColumn1Size) << "per event" <<" "
+                              << std::right << std::setw(kColumn2Size) << "per exec" <<" "
+                              << std::right << std::setw(kColumn3Size) << "per visit"
+                              << "  Name" << "";
 
     LogVerbatim("FwkSummary") << "";
     LogVerbatim("FwkSummary") << "T---Report end!" << "";

--- a/FWCore/Framework/src/SystemTimeKeeper.h
+++ b/FWCore/Framework/src/SystemTimeKeeper.h
@@ -26,6 +26,7 @@
 
 // user include files
 #include "FWCore/Utilities/interface/CPUTimer.h"
+#include "FWCore/Utilities/interface/WallclockTimer.h"
 
 // forward declarations
 
@@ -54,6 +55,9 @@ namespace edm {
     // ---------- static member functions --------------------
     
     // ---------- member functions ---------------------------
+    void startProcessingLoop();
+    void stopProcessingLoop();
+    
     void startEvent(StreamID);
     void stopEvent(StreamContext const&);
     
@@ -67,16 +71,15 @@ namespace edm {
     
     struct ModuleInPathTiming {
       double m_realTime = 0.;
-      double m_cpuTime = 0.;
       unsigned int m_timesVisited = 0;
     };
     struct PathTiming {
-      CPUTimer m_timer;
+      WallclockTimer m_timer;
       std::vector<ModuleInPathTiming> m_moduleTiming;
     };
 
     struct ModuleTiming {
-      CPUTimer m_timer;
+      WallclockTimer m_timer;
       unsigned int m_timesRun =0;
     };
 
@@ -89,7 +92,7 @@ namespace edm {
     PathTiming& pathTiming(StreamContext const&, PathContext const&);
     
     // ---------- member data --------------------------------
-    std::vector<CPUTimer> m_streamEventTimer;
+    std::vector<WallclockTimer> m_streamEventTimer;
     
     std::vector<std::vector<PathTiming>> m_streamPathTiming;
     
@@ -98,6 +101,8 @@ namespace edm {
     std::vector<const ModuleDescription*>  m_modules;
     std::vector<std::string> m_pathNames;
     std::vector<std::vector<std::string>> m_modulesOnPaths;
+
+    CPUTimer m_processingLoopTimer;
     
     unsigned int m_minModuleID;
     unsigned int m_endPathOffset;

--- a/FWCore/ServiceRegistry/interface/ActivityRegistry.h
+++ b/FWCore/ServiceRegistry/interface/ActivityRegistry.h
@@ -118,6 +118,14 @@ namespace edm {
       }
       AR_WATCH_USING_METHOD_0(watchPostBeginJob)
 
+      typedef signalslot::Signal<void()> PreEndJob;
+      ///signal is emitted before any modules have gotten their endJob called
+      PreEndJob preEndJobSignal_;
+      void watchPreEndJob(PreEndJob::slot_type const& iSlot) {
+         preEndJobSignal_.connect_front(iSlot);
+      }
+      AR_WATCH_USING_METHOD_0(watchPreEndJob)
+
       typedef signalslot::Signal<void()> PostEndJob;
       ///signal is emitted after all modules have gotten their endJob called
       PostEndJob postEndJobSignal_;

--- a/FWCore/ServiceRegistry/src/ActivityRegistry.cc
+++ b/FWCore/ServiceRegistry/src/ActivityRegistry.cc
@@ -96,6 +96,7 @@ namespace edm {
   ActivityRegistry::connectGlobals(ActivityRegistry& iOther) {
      preallocateSignal_.connect(std::cref(iOther.preallocateSignal_));
      postBeginJobSignal_.connect(std::cref(iOther.postBeginJobSignal_));
+     preEndJobSignal_.connect(std::cref(iOther.preEndJobSignal_));
      postEndJobSignal_.connect(std::cref(iOther.postEndJobSignal_));
 
      jobFailureSignal_.connect(std::cref(iOther.jobFailureSignal_));
@@ -271,6 +272,7 @@ namespace edm {
     copySlotsToFrom(preallocateSignal_,iOther.preallocateSignal_);
     copySlotsToFrom(preBeginJobSignal_, iOther.preBeginJobSignal_);
     copySlotsToFrom(postBeginJobSignal_, iOther.postBeginJobSignal_);
+    copySlotsToFromReverse(preEndJobSignal_, iOther.preEndJobSignal_);
     copySlotsToFromReverse(postEndJobSignal_, iOther.postEndJobSignal_);
 
     copySlotsToFromReverse(jobFailureSignal_, iOther.jobFailureSignal_);

--- a/FWCore/Services/interface/Timing.h
+++ b/FWCore/Services/interface/Timing.h
@@ -24,7 +24,7 @@ namespace edm {
   namespace service {
     class Timing : public TimingServiceBase {
     public:
-      Timing(ParameterSet const&,ActivityRegistry&);
+      Timing(ParameterSet const&, ActivityRegistry&);
       ~Timing();
 
       static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);
@@ -44,19 +44,19 @@ namespace edm {
 
       double curr_job_time_;    // seconds
       double curr_job_cpu_;     // seconds
+      //use last run time for determining end of processing
+      std::atomic<double> last_run_time_;
+      std::atomic<double> last_run_cpu_;
       std::vector<double> curr_events_time_;  // seconds
-      std::vector<double> curr_events_cpu_;   // seconds
-      std::vector<double> total_events_cpu_;  // seconds
       bool summary_only_;
       bool report_summary_;
 
       //
-      // Min Max and average event times for each Stream.
+      // Min Max and total event times for each Stream.
       //  Used for summary at end of job
       std::vector<double> max_events_time_; // seconds
-      std::vector<double> max_events_cpu_;  // seconds
       std::vector<double> min_events_time_; // seconds
-      std::vector<double> min_events_cpu_;  // seconds
+      std::vector<double> sum_events_time_;
       std::atomic<unsigned long> total_event_count_;
     };
   }

--- a/FWCore/Utilities/interface/WallclockTimer.h
+++ b/FWCore/Utilities/interface/WallclockTimer.h
@@ -1,0 +1,76 @@
+#ifndef FWCore_Utilities_WallclockTimer_h
+#define FWCore_Utilities_WallclockTimer_h
+// -*- C++ -*-
+//
+// Package:     Utilities
+// Class  :     WallclockTimer
+// 
+/**\class WallclockTimer WallclockTimer.h FWCore/Utilities/interface/WallclockTimer.h
+
+ Description: Timer which measures the CPU and wallclock time
+
+ Usage:
+    <usage>
+
+*/
+//
+// Original Author:  Chris Jones
+//         Created:  Sun Apr 16 20:32:13 EDT 2006
+//
+
+// system include files
+#ifdef __linux__
+//clock_gettime is not available on OS X
+#define USE_CLOCK_GETTIME
+#endif
+
+#ifdef USE_CLOCK_GETTIME
+#include <time.h>
+#else
+#include <sys/time.h>
+#endif
+
+// user include files
+
+// forward declarations
+namespace edm {
+  class WallclockTimer
+  {
+    
+  public:
+    WallclockTimer();
+    ~WallclockTimer();
+    WallclockTimer(WallclockTimer&&) = default;
+    
+    // ---------- const member functions ---------------------
+    double realTime() const ;
+    
+    // ---------- static member functions --------------------
+    
+    // ---------- member functions ---------------------------
+    void start();
+    double stop(); //returns delta time
+    void reset();
+    
+    void add(double t);
+  private:
+    WallclockTimer(const WallclockTimer&) = delete; // stop default
+    
+    const WallclockTimer& operator=(const WallclockTimer&) = delete; // stop default
+    
+    double calculateDeltaTime() const;
+    
+    // ---------- member data --------------------------------
+    enum State {kRunning, kStopped} state_;
+#ifdef USE_CLOCK_GETTIME
+    struct timespec startRealTime_;
+#else
+    struct timeval startRealTime_;
+#endif
+    
+    double accumulatedRealTime_;
+    
+  };
+}
+
+#endif

--- a/FWCore/Utilities/src/WallclockTimer.cc
+++ b/FWCore/Utilities/src/WallclockTimer.cc
@@ -1,0 +1,134 @@
+// -*- C++ -*-
+//
+// Package:     Utilities
+// Class  :     WallclockTimer
+//
+// Implementation:
+//     <Notes on implementation>
+//
+// Original Author:  Chris Jones
+//         Created:  Sun Apr 16 20:32:20 EDT 2006
+//
+
+// system include files
+#include <sys/resource.h>
+#include <errno.h>
+
+// user include files
+#include "FWCore/Utilities/interface/WallclockTimer.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+//
+// constants, enums and typedefs
+//
+using namespace edm;
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+WallclockTimer::WallclockTimer() :
+state_(kStopped),
+startRealTime_(),
+accumulatedRealTime_(0)
+{
+#ifdef USE_CLOCK_GETTIME
+  startRealTime_.tv_sec=0;
+  startRealTime_.tv_nsec=0;
+#else
+  startRealTime_.tv_sec=0;
+  startRealTime_.tv_usec=0;
+#endif
+}
+
+// WallclockTimer::WallclockTimer(WallclockTimer const& rhs) {
+//    // do actual copying here;
+// }
+
+WallclockTimer::~WallclockTimer() {
+}
+
+//
+// assignment operators
+//
+// WallclockTimer const& WallclockTimer::operator=(WallclockTimer const& rhs) {
+//   //An exception safe implementation is
+//   WallclockTimer temp(rhs);
+//   swap(rhs);
+//
+//   return *this;
+// }
+
+//
+// member functions
+//
+void
+WallclockTimer::start() {
+  if(kStopped == state_) {
+#ifdef USE_CLOCK_GETTIME
+    clock_gettime(CLOCK_MONOTONIC, &startRealTime_);
+#else
+    gettimeofday(&startRealTime_, 0);
+#endif
+    state_ = kRunning;
+  }
+}
+
+double
+WallclockTimer::stop() {
+  if(kRunning == state_) {
+    auto t = calculateDeltaTime();
+    accumulatedRealTime_ += t;
+
+    state_=kStopped;
+    return t;
+  }
+  return 0.;
+}
+
+void
+WallclockTimer::reset() {
+  accumulatedRealTime_ = 0;
+}
+
+void
+WallclockTimer::add(double t) {
+  accumulatedRealTime_ += t;
+}
+
+double
+WallclockTimer::calculateDeltaTime() const {
+  double returnValue;
+#ifdef USE_CLOCK_GETTIME
+  double const nanosecToSec = 1E-9;
+  struct timespec tp;
+
+  clock_gettime(CLOCK_MONOTONIC, &tp);
+  returnValue = tp.tv_sec - startRealTime_.tv_sec + nanosecToSec * (tp.tv_nsec - startRealTime_.tv_nsec);
+#else
+  double const microsecToSec = 1E-6;
+
+  struct timeval tp;
+  gettimeofday(&tp, 0);
+
+  returnValue = tp.tv_sec - startRealTime_.tv_sec + microsecToSec * (tp.tv_usec - startRealTime_.tv_usec);
+#endif
+  return returnValue;
+}
+//
+// const member functions
+//
+double
+WallclockTimer::realTime() const {
+  if(kStopped == state_) {
+    return accumulatedRealTime_;
+  }
+  return accumulatedRealTime_ + calculateDeltaTime();
+}
+
+//
+// static member functions
+//


### PR DESCRIPTION
The tools for measuring CPU time actually measure CPU time for all cores being used by the process. Therefore recording such information per Event, Path, and Module makes no sense when multiple threads are running. We now only record CPU time for the event loop as a whole and report only wall clock time for all other measurements. We also now report both the wall clock time for the entire event loop but also the sum of the time for each all Streams. The former allows throughput to be measured while the later is useful for determining the average time it takes one Event to be processed.
