### PR TITLE
force the online applications to run single thread

### DIFF
--- a/DQM/Integration/python/test/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/beam_dqm_sourceclient-live_cfg.py
@@ -112,6 +112,10 @@ if ( process.runType.getRunType() == process.runType.cosmic_run):
     process.dqmBeamSpotProblemMonitor.AlarmOFFThreshold = 5       #Should be < AlalrmONThreshold 
 #-----------------------------------------------------------
 
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)
+
 
 #--------------------------
 # Proton-Proton Stuff

--- a/DQM/Integration/python/test/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/beampixel_dqm_sourceclient-live_cfg.py
@@ -40,6 +40,9 @@ process.dqmmodules  = cms.Sequence(process.dqmEnv + process.dqmSaver)
 process.phystrigger = cms.Sequence(process.hltTriggerTypeFilter)
 
 
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)
 
 
 #----------------------------
@@ -191,3 +194,4 @@ if (process.runType.getRunType() == process.runType.hi_run):
     # Define Path
     #----------------------------
     process.p = cms.Path(process.phystrigger*process.reconstruction_step*process.pixelVertexDQM*process.dqmmodules)
+    

--- a/DQM/Integration/python/test/castor_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/castor_dqm_sourceclient-live_cfg.py
@@ -178,3 +178,8 @@ print "Running with run type = ", process.runType.getRunType()
 if (process.runType.getRunType() == process.runType.hi_run):
     process.castorDigis.InputLabel = cms.InputTag("rawDataRepacker")
     process.castorMonitor.rawLabel = cms.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/csc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/csc_dqm_sourceclient-live_cfg.py
@@ -212,3 +212,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.siStripDigis.ProductLabel = cms.InputTag("rawDataRepacker")
     process.cscMonitor.FEDRawDataCollectionTag = cms.InputTag("rawDataRepacker")
     process.dqmCSCClient.InputObjects = cms.untracked.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/dt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/dt_dqm_sourceclient-live_cfg.py
@@ -86,3 +86,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
 
     process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/dt_reference_hi.root'
 
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/ecal_dqm_sourceclient-live_cfg.py
@@ -197,3 +197,8 @@ elif runTypeName == runType.hi_run:
 elif runTypeName == runType.hpu_run:
     process.DQMStore.referenceFileName = referenceFileName.replace('.root', '_hpu.root')
     process.source.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('*'))
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/ecalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/ecalcalib_dqm_sourceclient-live_cfg.py
@@ -206,3 +206,7 @@ process.dqmOutputPath = cms.EndPath(process.dqmSaver)
 ### Schedule ###
 
 process.schedule = cms.Schedule(process.ecalLaserLedPath,process.ecalTestPulsePath,process.ecalPedestalPath,process.ecalClientPath,process.dqmEndPath,process.dqmOutputPath)
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/es_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/es_dqm_sourceclient-live_cfg.py
@@ -77,3 +77,8 @@ print "Running with run type = ", process.runType.getRunType()
 if (process.runType.getRunType() == process.runType.hi_run):
     process.esRawToDigi.sourceTag = cms.InputTag("rawDataRepacker")
     process.ecalPreshowerRawDataTask.FEDRawDataCollection = cms.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/fed_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/fed_dqm_sourceclient-live_cfg.py
@@ -35,3 +35,8 @@ process.pDQM = cms.Path(process.l1tsClient+
 			process.dqmFEDIntegrityClient+
 			process.dqmEnv+
 			process.dqmSaver)
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/fedtest_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/fedtest_dqm_sourceclient-live_cfg.py
@@ -167,3 +167,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.hcalDataIntegrityMonitor.RawDataLabel = cms.untracked.InputTag("rawDataRepacker")
     process.l1tfed.rawTag = cms.InputTag("rawDataRepacker")
     process.siStripFEDCheck.RawDataTag = cms.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hcal_dqm_sourceclient-live_cfg.py
@@ -342,3 +342,8 @@ if (HEAVYION):
     process.hcalRawDataMonitor.FEDRawDataCollection = cms.untracked.InputTag("rawDataRepacker")
     process.hcalDigiMonitor.FEDRawDataCollection = cms.untracked.InputTag("rawDataRepacker")
     process.zdcMonitor.FEDRawDataCollection = cms.untracked.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/hcalcalib_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hcalcalib_dqm_sourceclient-live_cfg.py
@@ -279,3 +279,8 @@ if (HEAVYION):
      process.hcalNoiseMonitor.RawDataLabel = cms.untracked.InputTag("rawDataRepacker")
      process.hcalDetDiagLaserMonitor.RawDataLabel = cms.untracked.InputTag("rawDataRepacker")
      process.hcalRawDataMonitor.FEDRawDataCollection = cms.untracked.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/hcaltiming_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hcaltiming_dqm_sourceclient-live_cfg.py
@@ -61,6 +61,10 @@ process.dqmEnv.subSystemFolder = 'HcalTiming'
 
 process.p = cms.Path(process.hcalDigis*process.l1GtUnpack*process.hcalTimingMonitor*process.dqmEnv*process.dqmSaver)
 
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)
+
 #--------------------------------------------------
 # Heavy Ion Specific Fed Raw Data Collection Label
 #--------------------------------------------------
@@ -68,3 +72,4 @@ if (HEAVYION):
     process.hcalDigis.InputLabel = cms.InputTag("rawDataRepacker")
     process.l1GtUnpack.DaqGtInputTag = cms.InputTag("rawDataRepacker")
     
+

--- a/DQM/Integration/python/test/hlt_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hlt_dqm_sourceclient-live_cfg.py
@@ -43,3 +43,7 @@ process.pp = cms.Path(process.dqmEnv+process.dqmSaver)
 process.dqmEnv.subSystemFolder = 'HLT'
 #process.hltResults.plotAll = True
 
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/hltrates_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hltrates_dqm_sourceclient-live_cfg.py
@@ -116,3 +116,7 @@ process.pp = cms.Path(process.dqmEnv+process.dqmSaver)
 process.dqmEnv.subSystemFolder = 'HLT/TrigResults'
 #process.hltResults.plotAll = True
 
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/hlx_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hlx_dqm_sourceclient-live_cfg.py
@@ -46,3 +46,6 @@ process.p = cms.Path(process.hlxdqmsource*process.hlxQualityTester*process.dqmEn
 ##process.hlxdqmsource.outputDir = process.dqmSaver.dirName
 
 
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/info_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/info_dqm_sourceclient-live_cfg.py
@@ -115,3 +115,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataRepacker")
     process.siPixelDigis.InputLabel = cms.InputTag("rawDataRepacker")
     process.siStripDigis.ProductLabel = cms.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/l1t_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/l1t_dqm_sourceclient-live_cfg.py
@@ -206,3 +206,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.siStripDigis.ProductLabel = cms.InputTag("rawDataRepacker")
     process.bxTiming.FedSource = cms.untracked.InputTag("rawDataRepacker")
     process.l1s.fedRawData = cms.InputTag("rawDataRepacker")
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/l1temulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/l1temulator_dqm_sourceclient-live_cfg.py
@@ -209,3 +209,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.siStripDigis.ProductLabel = cms.InputTag("rawDataRepacker")
 
 
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/lumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/lumi_dqm_sourceclient-live_cfg.py
@@ -70,3 +70,7 @@ process.dqmmodules = cms.Sequence(process.dqmEnv
 process.p = cms.Path(process.reconstruction_step *
                      process.dqmmodules)
 
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/online_customizations_cfi.py
+++ b/DQM/Integration/python/test/online_customizations_cfi.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+def customise(process):
+    
+    if not hasattr(process, "options"):
+        process.options = cms.untracked.PSet()
+        
+    process.options.numberOfThreads = cms.untracked.uint32(1)
+    process.options.numberOfStreams = cms.untracked.uint32(1)
+    
+    return(process)

--- a/DQM/Integration/python/test/physics_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/physics_dqm_sourceclient-live_cfg.py
@@ -51,6 +51,11 @@ process.p = cms.Path(
 )
 
 process.siPixelDigis.InputLabel = cms.InputTag("rawDataCollector")
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)
+
 #--------------------------------------------------
 # Heavy Ion Specific Fed Raw Data Collection Label
 #--------------------------------------------------

--- a/DQM/Integration/python/test/pixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/pixel_dqm_sourceclient-live_cfg.py
@@ -137,8 +137,13 @@ process.SiPixelDigiSource.diskOn = True
 
 process.p = cms.Path(process.Reco*process.DQMmodules*process.SiPixelRawDataErrorSource*process.SiPixelDigiSource*process.SiPixelClusterSource*process.PixelP5DQMClientWithDataCertification)
 
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)
+
 #--------------------------------------------------
 # Heavy Ion Specific Fed Raw Data Collection Label
 #--------------------------------------------------
 
 print "Running with run type = ", process.runType.getRunType()
+

--- a/DQM/Integration/python/test/pixellumi_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/pixellumi_dqm_sourceclient-live_cfg.py
@@ -183,4 +183,9 @@ process.schedule = cms.Schedule(process.raw2digi_step,
                                 #process.plumdqm_alca_random_step,
                                 process.dqm_step)
 
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)
+
 ######################################################################

--- a/DQM/Integration/python/test/rpc_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/rpc_dqm_sourceclient-live_cfg.py
@@ -120,3 +120,8 @@ if (process.runType.getRunType() == process.runType.hi_run):
     process.rpcunpacker.InputLabel = cms.InputTag("rawDataRepacker")
     process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataRepacker")
     process.rpcEventSummary.MinimumRPCEvents  = cms.untracked.int32(100000)
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
@@ -597,3 +597,7 @@ if (process.runType.getRunType() == process.runType.hi_run):
                          process.TrackingClients
                          )
     
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)

--- a/DQM/Integration/python/test/sistriplas_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/sistriplas_dqm_sourceclient-live_cfg.py
@@ -62,3 +62,8 @@ print "Running with run type = ", process.runType.getRunType()
 
 if (process.runType.getRunType() == process.runType.hi_run):
     process.siStripDigis.ProductLabel = cms.InputTag("rawDataRepacker")
+
+
+### process customizations included here
+from DQM.Integration.test.online_customizations_cfi import *
+process = customise(process)


### PR DESCRIPTION
affecting the processes on the DQM cluster only.
there are use cases requiring this: the beam spot fit for example cannot be computed in parallel. the monitor element streaming to the online GUI for live mode also doesn't make much sense in parallel.
