### PR TITLE
ROOT does not use u or l qualifiers for template paramaters in class nam...

### DIFF
--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -1,5 +1,6 @@
 #include <cxxabi.h>
 #include <cctype>
+#include <regex>
 #include <string>
 #include "FWCore/Utilities/interface/Exception.h"
 
@@ -24,6 +25,15 @@
 
 ********************************************************************/
 namespace {
+  void
+  reformatter(std::string& input, char const* exp, char const* format) {
+    std::regex regexp(exp, std::regex::egrep);
+    while(std::regex_match(input, regexp)) {
+      std::string newstring = std::regex_replace(input, regexp, format);
+      input.swap(newstring);
+    }
+  }
+
   void
   removeParameter(std::string& demangledName, std::string const& toRemove) {
     std::string::size_type const asize = toRemove.size();
@@ -113,6 +123,8 @@ namespace edm {
     constBeforeIdentifier(demangledName);
     // No two consecutive '>' 
     replaceString(demangledName, ">>", "> >");
+    // No u or l qualifiers for integers.
+    reformatter(demangledName, "(.*[<,][0-9]+)[ul]l*([,>].*)", "$1$2");
     // For ROOT 6 and beyond, replace 'unsigned long long' with 'ULong64_t'
     replaceString(demangledName, "unsigned long long", "ULong64_t");
     // For ROOT 6 and beyond, replace 'long long' with 'Long64_t'


### PR DESCRIPTION
This is a bug fix to allow putting a ROOT SMatrix in an event, as requested by Slava Krutelyov.  ROOT does not use u or l qualifiers for the names of integer template parameters in class names. Because of this, a missing dictionary error resulted when attempting put an SMatrix into an event.  This pull request adds stripping off the "u" or "l" qualifiers in class names containing integer template parameters, thereby correcting the error. 
This is the pull request for the CMSSW_7_4_ROOT6_X branch only.  The same fix was requested for 7_4_X in a different pull request, due to previous differences in the two branches.
Please merge this request as soon as convenient.
