### PR TITLE
74 Fireworks:  support calo tower presentation for any reco::Candidate type

### DIFF
--- a/Fireworks/Candidates/interface/FWCandidateTowerSliceSelector.h
+++ b/Fireworks/Candidates/interface/FWCandidateTowerSliceSelector.h
@@ -2,16 +2,18 @@
 #define Fireworks_Calo_FWCandTowerSliceSelector_h
 
 #include "Fireworks/Calo/interface/FWHistSliceSelector.h"
+class FWSimpleProxyHelper;
 
 class FWCandidateTowerSliceSelector : public FWHistSliceSelector
 {
 public:
-   FWCandidateTowerSliceSelector(TH2F* h, const FWEventItem* i);
+   FWCandidateTowerSliceSelector(TH2F* h, const FWEventItem* i,  FWSimpleProxyHelper* m_helper);
    virtual ~FWCandidateTowerSliceSelector();
 
- virtual bool aggregatePhiCells() const { return false; }
+   virtual bool aggregatePhiCells() const { return false; }
  protected:
    virtual void getItemEntryEtaPhi(int itemIdx, float& eta, float& phi) const;
+   FWSimpleProxyHelper* m_helper;
 };
 
 #endif

--- a/Fireworks/Candidates/plugins/FWCandidateTowerProxyBuilder.cc
+++ b/Fireworks/Candidates/plugins/FWCandidateTowerProxyBuilder.cc
@@ -23,7 +23,7 @@
 // constructors , dectructors
 //
 FWCandidateTowerProxyBuilder::FWCandidateTowerProxyBuilder():
-m_towers(0)
+   m_helper(typeid(reco::Candidate))
 {
 }
 
@@ -36,14 +36,21 @@ FWCandidateTowerProxyBuilder::~FWCandidateTowerProxyBuilder()
 //
 
 
+void FWCandidateTowerProxyBuilder::itemChangedImp(const FWEventItem* iItem)
+{
+   if (iItem)
+   {
+      m_helper.itemChanged(iItem);
+   }
+}
 
 void
 FWCandidateTowerProxyBuilder::build(const FWEventItem* iItem, TEveElementList* el, const FWViewContext* ctx)
 {
-   m_towers=0;
-   if (iItem)
+   //  m_towers=0;
+   if (iItem )
    {
-      iItem->get(m_towers);
+      //      iItem->get(m_towers);
       FWCaloDataProxyBuilderBase::build(iItem, el, ctx);
    }
 }
@@ -52,7 +59,7 @@ FWCandidateTowerProxyBuilder::build(const FWEventItem* iItem, TEveElementList* e
 FWHistSliceSelector*
 FWCandidateTowerProxyBuilder::instantiateSliceSelector()
 {
-   FWCandidateTowerSliceSelector* ss = new FWCandidateTowerSliceSelector(m_hist, item());
+   FWCandidateTowerSliceSelector* ss = new FWCandidateTowerSliceSelector(m_hist, item(), &m_helper);
    return ss;
 }
 
@@ -61,14 +68,16 @@ FWCandidateTowerProxyBuilder::fillCaloData()
 {
     m_hist->Reset();
 
-    if (m_towers)
+    //  if (m_towers)
     {
         if(item()->defaultDisplayProperties().isVisible()) {
             // assert(item()->size() >= m_towers->size());
-            unsigned int index=0;
-            for( pat::PackedCandidateCollection::const_iterator tower = m_towers->begin(); tower != m_towers->end(); ++tower,++index) {
+           for (size_t index = 0; index < item()->size(); ++index) {
                 const FWEventItem::ModelInfo& info = item()->modelInfo(index);
                 if(info.displayProperties().isVisible()) {
+                   const void* modelData = item()->modelData((int)index);
+
+                   const reco::Candidate* tower = reinterpret_cast<const reco::Candidate*>(m_helper.offsetObject(modelData));
                    addEntryToTEveCaloData(tower->eta(), tower->phi(), getEt(*tower), info.isSelected());
                 }
             }
@@ -76,4 +85,7 @@ FWCandidateTowerProxyBuilder::fillCaloData()
     }
 }
 
-REGISTER_FWPROXYBUILDER(FWCandidateTowerProxyBuilder, pat::PackedCandidateCollection,"CaloTower",FWViewType::k3DBit|FWViewType::kAllRPZBits|FWViewType::kAllLegoBits);
+
+
+
+REGISTER_FWPROXYBUILDER(FWCandidateTowerProxyBuilder, reco::Candidate,"CaloTower",FWViewType::k3DBit|FWViewType::kAllRPZBits|FWViewType::kAllLegoBits);

--- a/Fireworks/Candidates/plugins/FWCandidateTowerProxyBuilder.h
+++ b/Fireworks/Candidates/plugins/FWCandidateTowerProxyBuilder.h
@@ -7,10 +7,11 @@
 #include <string>
 
 #include "Fireworks/Calo/interface/FWCaloDataHistProxyBuilder.h"
-//#include "DataFormats/Candidate/interface/CandidateFwd.h"
-//#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
 
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
+#include "Fireworks/Core/interface/FWSimpleProxyHelper.h"
 
 class FWHistSliceSelector;
 
@@ -19,8 +20,9 @@ class FWCandidateTowerProxyBuilder : public FWCaloDataHistProxyBuilder
 public:
    FWCandidateTowerProxyBuilder();
    virtual ~FWCandidateTowerProxyBuilder();
-
+   static std::string typeOfBuilder() { return std::string("simple#");}
    virtual double getEt(const reco::Candidate& cand) const { return cand.pt(); }
+
 
    REGISTER_PROXYBUILDER_METHODS();
 protected:
@@ -32,8 +34,9 @@ private:
    FWCandidateTowerProxyBuilder(const FWCandidateTowerProxyBuilder&); // stop default
    const FWCandidateTowerProxyBuilder& operator=(const FWCandidateTowerProxyBuilder&); // stop default
   
+   virtual void itemChangedImp(const FWEventItem*);
    // ---------- member data --------------------------------
-   const pat::PackedCandidateCollection* m_towers;
+   FWSimpleProxyHelper m_helper;
 };
 
 #endif

--- a/Fireworks/Candidates/src/FWCandidateTowerSliceSelector.cc
+++ b/Fireworks/Candidates/src/FWCandidateTowerSliceSelector.cc
@@ -1,15 +1,15 @@
 #include "Fireworks/Candidates/interface/FWCandidateTowerSliceSelector.h"
-//#include "DataFormats/Candidate/interface/CandidateFwd.h"
-//#include "DataFormats/Candidate/interface/Candidate.h"
 
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 
 #include "Fireworks/Core/interface/FWModelChangeManager.h"
 #include "Fireworks/Core/interface/FWEventItem.h"
+#include "Fireworks/Core/interface/FWSimpleProxyHelper.h"
 
 
-FWCandidateTowerSliceSelector::FWCandidateTowerSliceSelector(TH2F* h, const FWEventItem* i):
-   FWHistSliceSelector(h, i)
+FWCandidateTowerSliceSelector::FWCandidateTowerSliceSelector(TH2F* h, const FWEventItem* i, FWSimpleProxyHelper* helper):
+   FWHistSliceSelector(h, i),
+   m_helper(helper)
 {
 }
 
@@ -20,15 +20,12 @@ FWCandidateTowerSliceSelector::~FWCandidateTowerSliceSelector()
 void
 FWCandidateTowerSliceSelector::getItemEntryEtaPhi(int itemIdx, float& eta, float& phi) const
 {
-   
-   const pat::PackedCandidateCollection* towers=0;
-   m_item->get(towers);
-   assert(0!=towers);
-   pat::PackedCandidateCollection::const_iterator tower = towers->begin();
-   std::advance(tower, itemIdx);
-
-   eta = tower->eta();
-   phi = tower->phi(); 
+   const void* modelData = m_item->modelData(itemIdx);
+   if (modelData) {
+      const reco::Candidate* tower = reinterpret_cast<const reco::Candidate*>(m_helper->offsetObject(modelData));
+      eta = tower->eta();
+      phi = tower->phi();
+   }
 }
 
 

--- a/Fireworks/Core/interface/FWEveViewManager.h
+++ b/Fireworks/Core/interface/FWEveViewManager.h
@@ -48,6 +48,8 @@ public:
       std::string m_name;
       int         m_viewBit;
 
+      void classType(std::string& , bool&) const;
+
       BuilderInfo(std::string name, int viewBit) :
          m_name(name),
          m_viewBit(viewBit)

--- a/Fireworks/Core/interface/FWSimpleRepresentationChecker.h
+++ b/Fireworks/Core/interface/FWSimpleRepresentationChecker.h
@@ -42,7 +42,9 @@ public:
    // ---------- static member functions --------------------
 
    // ---------- member functions ---------------------------
-
+   static bool inheritsFrom(const edm::TypeWithDict& iChild,
+                            const std::string& iParentTypeName, unsigned int& distance);
+                                                
 private:
    FWSimpleRepresentationChecker(const FWSimpleRepresentationChecker&); // stop default
 
@@ -51,6 +53,5 @@ private:
    // ---------- member data --------------------------------
    const std::string m_typeidName;
 };
-
 
 #endif

--- a/Fireworks/Core/src/FWSimpleRepresentationChecker.cc
+++ b/Fireworks/Core/src/FWSimpleRepresentationChecker.cc
@@ -72,7 +72,7 @@ FWSimpleRepresentationChecker::~FWSimpleRepresentationChecker()
 //
 // const member functions
 //
-static bool inheritsFrom(const edm::TypeWithDict& iChild,
+bool FWSimpleRepresentationChecker::inheritsFrom(const edm::TypeWithDict& iChild,
                          const std::string& iParentTypeName,
                          unsigned int& distance) {
    if(iChild.typeInfo().name() == iParentTypeName) {


### PR DESCRIPTION
Open inheritance from FWCandidateTowerProxyBuilder to any class derived from reco::Candidate (before it supported only PackedCandidate).

Make additional type check before instantiating a  proxy builder.
