### PR TITLE
Resolve Clang compile issues in FastSimulation/Tracking 

### DIFF
--- a/FastSimulation/Tracking/interface/TrackingLayer.h
+++ b/FastSimulation/Tracking/interface/TrackingLayer.h
@@ -8,24 +8,30 @@
 
 class TrackingLayer
 {
-    private:
-        
     public:
-        struct hashfct
-        {
-            inline size_t operator()(const TrackingLayer &layerSpec) const 
-            {
-                return layerSpec.getSubDetNumber()*10000+layerSpec.getLayerNumber()*100+layerSpec.getSideNumber()+1;
-            }
-        };
-        struct eqfct
-        {
-            static const hashfct gethash;
-            inline bool operator()(const TrackingLayer &l1, const TrackingLayer &l2) const 
-            {
-                return l1.getSubDetNumber()==l2.getSubDetNumber() and l1.getLayerNumber()==l2.getLayerNumber() and l1.getSideNumber()==l2.getSideNumber();
-            }
-        };
+	struct hashfct
+	{
+	    hashfct() { };
+
+	    inline size_t operator()(const TrackingLayer &layerSpec) const
+	    {
+		return (layerSpec.getSubDetNumber() * 10000
+			+ layerSpec.getLayerNumber() * 100
+			+ layerSpec.getSideNumber() + 1);
+	    }
+	};
+
+	struct eqfct
+	{
+	    eqfct() { };
+
+	    inline bool operator()(const TrackingLayer &l1, const TrackingLayer &l2) const
+	    {
+		return (l1.getSubDetNumber() == l2.getSubDetNumber()
+			&& l1.getLayerNumber() == l2.getLayerNumber()
+			&& l1.getSideNumber() == l2.getSideNumber());
+	    }
+	};
         
         enum class Det { 
             UNKNOWN, 

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -53,7 +53,6 @@ class TrajectorySeedProducer: public edm::stream::EDProducer <>
         edm::InputTag theBeamSpot;
 
         bool seedCleaning;
-        bool rejectOverlaps;
         unsigned int absMinRecHits;
         unsigned int numberOfHits;
         

--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -2,7 +2,6 @@
 
 const TrackingLayer::eqfct TrackingLayer::_eqfct;
 const TrackingLayer::hashfct TrackingLayer::_hashfct;
-const TrackingLayer::hashfct TrackingLayer::eqfct::gethash;
 
 TrackingLayer::TrackingLayer():
     _subDet(Det::UNKNOWN),

--- a/FastSimulation/Tracking/test/testGeneralTracks.cc
+++ b/FastSimulation/Tracking/test/testGeneralTracks.cc
@@ -50,7 +50,6 @@ private:
   // See RecoParticleFlow/PFProducer/interface/PFProducer.h
   edm::ParameterSet particleFilter_;
   std::vector<edm::InputTag> allTracks;
-  bool saveNU;
   std::vector<FSimEvent*> mySimEvent;
   std::string simModuleLabel_;
   // Histograms

--- a/FastSimulation/Tracking/test/testTrackingIterations.cc
+++ b/FastSimulation/Tracking/test/testTrackingIterations.cc
@@ -57,7 +57,6 @@ private:
   std::vector<edm::InputTag> thirdTracks;
   std::vector<edm::InputTag> fourthTracks;
   std::vector<edm::InputTag> fifthTracks;
-  bool saveNU;
   std::vector<FSimEvent*> mySimEvent;
   std::string simModuleLabel_;
   // Histograms


### PR DESCRIPTION
The following removes not used bits and adds default ctors for structs as required by C++11 standard.

This resolves the errors:

```
error: default initialization of an object of const type 'const TrackingLayer::eqfct' without a user-provided default constructor
error: default initialization of an object of const type 'const TrackingLayer::hashfct' without a user-provided default constructor
```

Compile tested with GCC and Clang.
