### PR TITLE
reimplement edmConfigFromDB working directly with the Java code

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdb.py
+++ b/HLTrigger/Configuration/python/Tools/confdb.py
@@ -44,9 +44,9 @@ class HLTProcess(object):
     "HLT_GlobalRunHPDNoise_v*",
     "HLT_L1TrackerCosmics_v*",
     "HLT_HcalUTCA_v*",
-    
+
     # TODO: paths not supported by FastSim, but for which a recovery should be attempted
- 
+
     "HLT_DoubleMu33NoFiltersNoVtx_v*",
     "HLT_DoubleMu38NoFiltersNoVtx_v*",
     "HLT_Mu38NoFiltersNoVtx_Photon38_CaloIdL_v*",
@@ -93,6 +93,8 @@ class HLTProcess(object):
       self.labels['prescale'] = self.config.prescale
 
     # get the configuration from ConfdB
+    from confdbOfflineConverter import OfflineConverter
+    self.converter = OfflineConverter(database = self.config.menu.db)
     self.buildPathList()
     self.buildOptions()
     self.getRawConfigurationFromDB()
@@ -100,42 +102,48 @@ class HLTProcess(object):
 
 
   def getRawConfigurationFromDB(self):
-    url = 'http://cms-project-confdb-hltdev.web.cern.ch/cms-project-confdb-hltdev/get.jsp'
-    postdata = dict([ (key, ','.join(vals)) for key, vals in self.options.iteritems() if vals ])
-    postdata['noedsources'] = ''
-    if self.config.fragment:
-      postdata['cff'] = ''
     if self.config.menu.run:
-      postdata['runNumber'] = self.config.menu.run
+      args = ['--runNumber', self.config.menu.run]
     else:
-      postdata['dbName']    = self.config.menu.db
-      postdata['configName']= self.config.menu.name
+      args = ['--configName', self.config.menu.name ]
+    args.append('--noedsources')
+    if self.config.fragment:
+      args.append('--cff')
+    for key, vals in self.options.iteritems():
+      if vals:
+        args.extend(('--'+key, ','.join(vals)))
 
-    data = urllib2.urlopen(url, urllib.urlencode(postdata)).read()
-    if 'Exhausted Resultset' in data or 'CONFIG_NOT_FOUND' in data:
-      raise ImportError('%s is not a valid HLT menu' % self.config.menuConfig.value)
+    data, err = self.converter.query( *args )
+    if 'ERROR' in err or 'Exhausted Resultset' in err or 'CONFIG_NOT_FOUND' in err:
+        print "%s: error while retriving the HLT menu" % os.path.basename(sys.argv[0])
+        print
+        print err
+        print
+        sys.exit(1)
     self.data = data
 
 
   def getPathList(self):
-    url = 'http://cms-project-confdb-hltdev.web.cern.ch/cms-project-confdb-hltdev/get.jsp'
-    postdata = { 
-      'noedsources': '', 
-      'noes':        '',
-      'noservices':  '',
-      'nosequences': '',
-      'nomodules' :  '',
-      'cff':         '',
-    }
     if self.config.menu.run:
-      postdata['runNumber'] = self.config.menu.run
+      args = ['--runNumber', self.config.menu.run]
     else:
-      postdata['dbName']    = self.config.menu.db
-      postdata['configName']= self.config.menu.name
+      args = ['--configName', self.config.menu.name]
+    args.extend( (
+      '--cff',
+      '--noedsources',
+      '--noes',
+      '--noservices',
+      '--nosequences',
+      '--nomodules'
+    ) )
 
-    data = urllib2.urlopen(url, urllib.urlencode(postdata)).read()
-    if 'Exhausted Resultset' in data or 'CONFIG_NOT_FOUND' in data:
-      raise ImportError('%s is not a valid HLT menu' % self.config.menuConfig.value)
+    data, err = self.converter.query( *args )
+    if 'ERROR' in err or 'Exhausted Resultset' in err or 'CONFIG_NOT_FOUND' in err:
+        print "%s: error while retriving the list of paths from the HLT menu" % os.path.basename(sys.argv[0])
+        print
+        print err
+        print
+        sys.exit(1)
     filter = re.compile(r' *= *cms.(End)?Path.*')
     paths  = [ filter.sub('', line) for line in data.splitlines() if filter.search(line) ]
     return paths
@@ -256,7 +264,7 @@ cmsswVersion = os.environ['CMSSW_VERSION']
     self.releaseSpecificCustomize()
 
     if self.config.fragment:
-      
+
       self.data += """
 # dummyfy hltGetConditions in cff's
 if 'hltGetConditions' in %(dict)s and 'HLTriggerFirstPath' in %(dict)s :
@@ -526,7 +534,7 @@ if 'GlobalTag' in %(dict)s:
   iovIsRunNotTime = cms.bool(True),
   firstValid = cms.vuint32(1)
 )
-%%(process)ses_prefer_l1GtParameters = cms.ESPrefer('L1GtTriggerMenuXmlProducer','l1GtTriggerMenuXml') 
+%%(process)ses_prefer_l1GtParameters = cms.ESPrefer('L1GtTriggerMenuXmlProducer','l1GtTriggerMenuXml')
 """
       self.data += text % self.config.l1Xml.__dict__
 
@@ -907,7 +915,7 @@ if 'GlobalTag' in %%(dict)s:
       # 'full' removes all outputs (same as 'none') and then adds a single "keep *" output (see the overrideOutput method)
       if self.config.paths:
         # paths are removed by default
-        pass    
+        pass
       else:
         # drop all output endpaths
         paths.append( "-*Output" )
@@ -1073,7 +1081,7 @@ if 'GlobalTag' in %%(dict)s:
       self.options['modules'].append( "-hltCtfWithMaterialTracksJpsiTk" )
       self.options['modules'].append( "-hltMuTrackCkfTrackCandidatesOnia" )
       self.options['modules'].append( "-hltMuTrackCtfTracksOnia" )
-      
+
       self.options['modules'].append( "-hltFEDSelector" )
       self.options['modules'].append( "-hltL3TrajSeedOIHit" )
       self.options['modules'].append( "-hltL3TrajSeedIOHit" )
@@ -1102,13 +1110,13 @@ if 'GlobalTag' in %%(dict)s:
       # === hltFastJet
       self.options['modules'].append( "-hltDisplacedHT250L1FastJetRegionalPixelSeedGenerator" )
       self.options['modules'].append( "-hltDisplacedHT250L1FastJetRegionalCkfTrackCandidates" )
-      self.options['modules'].append( "-hltDisplacedHT250L1FastJetRegionalCtfWithMaterialTracks" )     
+      self.options['modules'].append( "-hltDisplacedHT250L1FastJetRegionalCtfWithMaterialTracks" )
       self.options['modules'].append( "-hltDisplacedHT300L1FastJetRegionalPixelSeedGenerator" )
       self.options['modules'].append( "-hltDisplacedHT300L1FastJetRegionalCkfTrackCandidates" )
-      self.options['modules'].append( "-hltDisplacedHT300L1FastJetRegionalCtfWithMaterialTracks" )     
+      self.options['modules'].append( "-hltDisplacedHT300L1FastJetRegionalCtfWithMaterialTracks" )
       self.options['modules'].append( "-hltBLifetimeRegionalPixelSeedGeneratorbbPhiL1FastJet" )
       self.options['modules'].append( "-hltBLifetimeRegionalCkfTrackCandidatesbbPhiL1FastJet" )
-      self.options['modules'].append( "-hltBLifetimeRegionalCtfWithMaterialTracksbbPhiL1FastJet" )     
+      self.options['modules'].append( "-hltBLifetimeRegionalCtfWithMaterialTracksbbPhiL1FastJet" )
       self.options['modules'].append( "-hltBLifetimeRegionalPixelSeedGeneratorHbbVBF" )
       self.options['modules'].append( "-hltBLifetimeRegionalCkfTrackCandidatesHbbVBF" )
       self.options['modules'].append( "-hltBLifetimeRegionalCtfWithMaterialTracksHbbVBF" )
@@ -1140,7 +1148,7 @@ if 'GlobalTag' in %%(dict)s:
       self.options['modules'].append( "-hltFastPixelBLifetimeRegionalPixelSeedGeneratorHbb" )
       self.options['modules'].append( "-hltFastPixelBLifetimeRegionalCkfTrackCandidatesHbb" )
       self.options['modules'].append( "-hltFastPixelBLifetimeRegionalCtfWithMaterialTracksHbb" )
-     
+
       self.options['modules'].append( "-hltPixelTracksForMinBias" )
       self.options['modules'].append( "-hltPixelTracksForHighMult" )
       self.options['modules'].append( "-hltRegionalPixelTracks" )
@@ -1164,7 +1172,7 @@ if 'GlobalTag' in %%(dict)s:
       self.options['modules'].append( "-hltPixelLayerTripletsHITHB" )
       self.options['modules'].append( "-hltPixelLayerTripletsHITHE" )
       self.options['modules'].append( "-hltMixedLayerPairs" )
-      
+
       self.options['modules'].append( "-hltFastPrimaryVertexbbPhi")
       self.options['modules'].append( "-hltPixelTracksFastPVbbPhi")
       self.options['modules'].append( "-hltPixelTracksRecoverbbPhi" )

--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -1,0 +1,168 @@
+#! /usr/bin/env python
+import sys, os
+import os.path
+import tempfile
+import urllib
+import shutil
+import subprocess
+import atexit
+
+class OfflineConverter:
+
+    databases = {}
+    databases['orcoff'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch', '-d', 'cms_cond.cern.ch', '-u', 'cms_hlt_gui_r',     '-s', 'convertme!' )
+    databases['hltdev'] = ( '-t', 'oracle', '-h', 'cmsr1-s.cern.ch', '-d', 'cms_cond.cern.ch', '-u', 'cms_hltdev_reader', '-s', 'convertme!' )
+
+
+    @staticmethod
+    def CheckTempDirectory(dir):
+        dir = os.path.realpath(dir)
+        if not os.path.isdir(dir):
+            try:
+                os.makedirs(dir)
+            except:
+                return None
+        return dir
+
+
+    def __init__(self, database = 'hltdev', url = None, verbose = False):
+        self.verbose = verbose
+        self.baseDir = '/afs/cern.ch/user/c/confdb/www/lib'
+        self.baseUrl = 'http://confdb.web.cern.ch/confdb/lib'
+        self.jars = ( 'ojdbc6.jar', 'cmssw-evf-confdb-converter.jar' )
+        self.workDir = ''
+
+        # check the database
+        if database in self.databases:
+            # load the connection parameters for the given database
+            self.connect = self.databases[database]
+        else:
+            # unsupported database
+            sys.stderr.write( "ERROR: unknown database \"%s\"\n" % database)
+            sys.exit(1)
+
+        # check for a custom base URL
+        if url is not None:
+            self.baseUrl = url
+
+        # try to read the .jar files from AFS, or download them
+        if os.path.isdir(self.baseDir) and all(os.path.isfile(self.baseDir + '/' + jar) for jar in self.jars):
+            # read the .jar fles from AFS
+            self.workDir = self.baseDir
+        else:
+            # try to use $CMSSW_BASE/tmp
+            self.workDir = OfflineConverter.CheckTempDirectory(os.environ['CMSSW_BASE'] + '/tmp/confdb')
+            if not self.workDir:
+                # try to use $TMP
+                self.workDir = OfflineConverter.CheckTempDirectory(os.environ['TMP'] + '/confdb')
+            if not self.workDir:
+                # create a new temporary directory, and install a cleanup callback
+                self.workDir = tempfile.mkdtemp()
+                atexit.register(shutil.rmtree, self.workDir)
+            # download the .jar files
+            for jar in self.jars:
+                urllib.urlretrieve(self.baseUrl + '/' + jar, self.workDir + '/' + jar)
+
+        # setup the java command line and CLASSPATH
+        if self.verbose:
+            sys.stderr.write("workDir = %s\n" % self.workDir)
+        self.javaCmd = ( 'java', '-cp', ':'.join(self.workDir + '/' + jar for jar in self.jars), 'confdb.converter.BrowserConverter' )
+
+
+    def query(self, *args):
+        args = self.javaCmd + self.connect + args
+        if self.verbose:
+            sys.stderr.write("\n" + ' '.join(args) + "\n\n" )
+        sub = subprocess.Popen(
+            args,
+            stdin = None,
+            stdout = subprocess.PIPE,
+            stderr = subprocess.PIPE,
+            shell = False,
+            universal_newlines = True )
+        return sub.communicate()
+
+def help():
+    sys.stdout.write("""Usage: %s OPTIONS
+
+        --hltdev|--orcoff           (target db [default: hltdev])
+
+        --configId <id>             (specify configuration by id)
+        --configName <name>         (specify configuration by name)
+        --runNumber <run>           (specify configuration by run)
+          [exactly one of --configId OR --configName OR --runNumber is required]
+
+        --cff                       (retrieve configuration *fragment*)
+        --input <f1.root[,f2.root]> (insert PoolSource with specified fileNames)
+        --input <files.list>        (read a text file which lists input ROOT files)
+        --output <out.root>         (insert PoolOutputModule w/ specified fileName)
+        --nopsets                   (exclude all globale psets)
+        --noedsources               (exclude all edsources)
+        --noes                      (exclude all essources *and* esmodules)
+        --noessources               (exclude all essources)
+        --noesmodules               (exclude all esmodules)
+        --noservices                (exclude all services)
+        --nooutput                  (exclude all output modules)
+        --nopaths                   (exclude all paths [+=referenced seqs&mods])
+        --nosequences               (don't define sequences [+=referenced s&m])
+        --nomodules                 (don't define modules)
+        --psets <pset1[,pset2]>     (include only specified global psets)
+        --psets <-pset1[,-pset2]>   (include all global psets but the specified)
+        --essources <ess1[,ess2]>   (include only specified essources)
+        --essources <-ess1[,-ess2]> (include all essources but the specified)
+        --esmodules <esm1[,esm2]>   (include only specified esmodules)
+        --esmodules <-esm1[,-esm2]> (include all esmodules but the specified)
+        --services <svc1[,svc2]>    (include only specified services)
+        --services <-svc1[,-svc2]>  (include all services but the specified)
+        --paths <p1[,p2]>           (include only specified paths)
+        --paths <-p1[,-p2]>         (include all paths but the specified)
+        --streams <s1[,s2]>         (include only specified streams)
+        --datasets <d1[,d2]>        (include only specified datasets)
+        --sequences <s1[,s2]>       (include sequences, referenced or not!)
+        --modules <p1[,p2]>         (include modules, referenced or not!)
+        --blocks <m1::p1[,p2][,m2]> (generate parameter blocks)
+""")
+
+
+def main():
+    args = sys.argv[1:]
+    db = 'hltdev'
+
+    if not args:
+        help()
+        sys.exit(1)
+
+    if '--help' in args or '-h' in args:
+        help()
+        sys.exit(0)
+
+    if '--orcoff' in args and '--hltdev' in args:
+        sys.stderr.write( "ERROR: conflicting database specifications \"--hltdev\" and \"--orcoff\"\n" )
+        sys.exit(1)
+
+    if '--runNumber' in args and '--hltdev' in args:
+        sys.stderr.write( "ERROR: conflicting database specifications \"--hltdev\" and \"--runNumber\"\n" )
+        sys.exit(1)
+
+    if '--hltdev' in args:
+        db = 'hltdev'
+        args.remove('--hltdev')
+
+    if '--orcoff' in args:
+        db = 'orcoff'
+        args.remove('--orcoff')
+
+    if '--runNumber' in args:
+        db = 'orcoff'
+
+    converter = OfflineConverter(database = db)
+    out, err = converter.query( * args )
+    if 'ERROR' in err:
+        sys.stderr.write( "%s: error while retriving the HLT menu\n\n%s\n\n" % (sys.argv[0], err) )
+        sys.exit(1)
+    else:
+        sys.stdout.write( out )
+
+
+if __name__ == "__main__":
+    main()

--- a/HLTrigger/Configuration/python/Tools/options.py
+++ b/HLTrigger/Configuration/python/Tools/options.py
@@ -55,6 +55,7 @@ class ConnectionHLTMenu(object):
       if ':' in self.value:
         (db, name) = self.value.split(':')
         if db == 'run':
+          self.db   = 'orcoff'
           self.run  = name
         elif db in ('hltdev', 'orcoff'):
           self.db   = db

--- a/HLTrigger/Configuration/scripts/hltConfigFromDB
+++ b/HLTrigger/Configuration/scripts/hltConfigFromDB
@@ -1,0 +1,5 @@
+#! /usr/bin/env python
+
+from HLTrigger.Configuration.Tools.confdbOfflineConverter import main
+
+main()

--- a/HLTrigger/Configuration/scripts/hltIntegrationTests
+++ b/HLTrigger/Configuration/scripts/hltIntegrationTests
@@ -284,7 +284,7 @@ done
 # if a separate setup is requested, create the setup_cff.py file and patch all dumps to use it
 if [ "$SETUP" ]; then
   log "Extracting setup_cff dump"
-  edmConfigFromDB --cff --configName "$SETUP" --nopaths --services -FUShmDQMOutputService,-PrescaleService > setup_cff.py
+  hltConfigFromDB --cff --configName "$SETUP" --nopaths --services -FUShmDQMOutputService,-PrescaleService > setup_cff.py
   sed -i -e's/process = cms.Process(.*)/&\nprocess.load("setup_cff")/' hlt.py $(for TRIGGER in $TRIGGERS; do echo "$TRIGGER".py; done)
 fi
 

--- a/HLTrigger/Configuration/scripts/hltListPaths
+++ b/HLTrigger/Configuration/scripts/hltListPaths
@@ -18,7 +18,7 @@ def _build_query(menu):
     return '--%s --configName %s' % (menu.db, menu.name)
 
 def getPathList(menu, selection):
-  cmdline = 'edmConfigFromDB --cff %s --noedsources --noes --noservices --nosequences --nomodules' % _build_query(menu)
+  cmdline = 'hltConfigFromDB --cff %s --noedsources --noes --noservices --nosequences --nomodules' % _build_query(menu)
   data = pipe.pipe(cmdline)
   if 'Exhausted Resultset' in data or 'CONFIG_NOT_FOUND' in data:
     raise ImportError('%s is not a valid HLT menu' % menu.value)

--- a/HLTrigger/Configuration/tables/subtables.sh
+++ b/HLTrigger/Configuration/tables/subtables.sh
@@ -15,7 +15,7 @@ function cleanup() {
 }
 
 function getPathList() {
-  local DATA=$(edmConfigFromDB --cff --configName $MASTER --noedsources --noes --noservices --nosequences --nomodules)
+  local DATA=$(hltConfigFromDB --cff --configName $MASTER --noedsources --noes --noservices --nosequences --nomodules)
   if echo "$DATA" | grep -q 'Exhausted Resultset\|CONFIG_NOT_FOUND'; then
     echo "Error: $MASTER is not a valid HLT menu"
     exit 1

--- a/HLTrigger/Configuration/test/add/hltCheckPaths.mk
+++ b/HLTrigger/Configuration/test/add/hltCheckPaths.mk
@@ -38,7 +38,7 @@ HLT_1E31_SOURCE     := file:RelVal_DigiL1Raw_1E31.root
 
 # more configuration, useful to debug the Makefile itself
 CMSRUN    := cmsRun
-GETCONFIG := edmConfigFromDB
+GETCONFIG := hltConfigFromDB
 
 # check for cmsRun environmnt
 ifeq (,$(CMSSW_RELEASE_BASE))
@@ -63,17 +63,17 @@ LUMI = $(strip $(word 1, $(subst _, , $@)) )
 NAME = $(strip $(subst $(LUMI)_, , $(word 1, $(subst ., , $@))) )
 TYPE = $(strip $(word 2, $(subst ., , $@)) )
 
-LIST_OF_GRun_PATHS := $(shell edmConfigFromDB --configName $(HLT_GRun_CONFIG) --nopsets --noedsources --noes --noservices --nooutput --nosequences --nomodules --format python | gawk '/^process\..*(AlCa|HLT)_.* = cms.Path/ { print gensub(/^process\.(.*(AlCa|HLT)_.*) = cms.Path.*/, "\\1", 1) }' | sort)
+LIST_OF_GRun_PATHS := $(shell hltConfigFromDB --configName $(HLT_GRun_CONFIG) --nopsets --noedsources --noes --noservices --nooutput --nosequences --nomodules --format python | gawk '/^process\..*(AlCa|HLT)_.* = cms.Path/ { print gensub(/^process\.(.*(AlCa|HLT)_.*) = cms.Path.*/, "\\1", 1) }' | sort)
 LIST_OF_GRun_PYS   := $(patsubst %, GRun_%.py,   $(LIST_OF_GRun_PATHS))
 LIST_OF_GRun_LOGS  := $(patsubst %, GRun_%.log,  $(LIST_OF_GRun_PATHS))
 LIST_OF_GRun_DIFFS := $(patsubst %, GRun_%.diff, $(LIST_OF_GRun_PATHS))
 
-LIST_OF_8E29_PATHS := $(shell edmConfigFromDB --configName $(HLT_8E29_CONFIG) --nopsets --noedsources --noes --noservices --nooutput --nosequences --nomodules --format python | gawk '/^process\..*(AlCa|HLT)_.* = cms.Path/ { print gensub(/^process\.(.*(AlCa|HLT)_.*) = cms.Path.*/, "\\1", 1) }' | sort)
+LIST_OF_8E29_PATHS := $(shell hltConfigFromDB --configName $(HLT_8E29_CONFIG) --nopsets --noedsources --noes --noservices --nooutput --nosequences --nomodules --format python | gawk '/^process\..*(AlCa|HLT)_.* = cms.Path/ { print gensub(/^process\.(.*(AlCa|HLT)_.*) = cms.Path.*/, "\\1", 1) }' | sort)
 LIST_OF_8E29_PYS   := $(patsubst %, 8E29_%.py,   $(LIST_OF_8E29_PATHS))
 LIST_OF_8E29_LOGS  := $(patsubst %, 8E29_%.log,  $(LIST_OF_8E29_PATHS))
 LIST_OF_8E29_DIFFS := $(patsubst %, 8E29_%.diff, $(LIST_OF_8E29_PATHS))
 
-LIST_OF_1E31_PATHS := $(shell edmConfigFromDB --configName $(HLT_1E31_CONFIG) --nopsets --noedsources --noes --noservices --nooutput --nosequences --nomodules --format python | gawk '/^process\..*(AlCa|HLT)_.* = cms.Path/ { print gensub(/^process\.(.*(AlCa|HLT)_.*) = cms.Path.*/, "\\1", 1) }' | sort)
+LIST_OF_1E31_PATHS := $(shell hltConfigFromDB --configName $(HLT_1E31_CONFIG) --nopsets --noedsources --noes --noservices --nooutput --nosequences --nomodules --format python | gawk '/^process\..*(AlCa|HLT)_.* = cms.Path/ { print gensub(/^process\.(.*(AlCa|HLT)_.*) = cms.Path.*/, "\\1", 1) }' | sort)
 LIST_OF_1E31_PYS   := $(patsubst %, 1E31_%.py,   $(LIST_OF_1E31_PATHS))
 LIST_OF_1E31_LOGS  := $(patsubst %, 1E31_%.log,  $(LIST_OF_1E31_PATHS))
 LIST_OF_1E31_DIFFS := $(patsubst %, 1E31_%.diff, $(LIST_OF_1E31_PATHS))

--- a/HLTrigger/Configuration/test/getDatasets.py
+++ b/HLTrigger/Configuration/test/getDatasets.py
@@ -8,7 +8,7 @@ import FWCore.ParameterSet.Config as cms
 def extractDatasets(database, config):
   # dump the Streams and Datasets from the HLT configuration
   proc = subprocess.Popen(
-    "edmConfigFromDB --%s --configName %s --nopsets --noedsources --noes --noservices --nooutput --nopaths" % (database, config),
+    "hltConfigFromDB --%s --configName %s --nopsets --noedsources --noes --noservices --nooutput --nopaths" % (database, config),
     shell  = True,
     stdin  = None,
     stdout = subprocess.PIPE,

--- a/HLTrigger/Configuration/test/getEventContent.py
+++ b/HLTrigger/Configuration/test/getEventContent.py
@@ -13,7 +13,7 @@ def extractBlock(config, blocks, target):
   #print
   commands = ','.join( block + '::outputCommands' for block in blocks )
   proc = subprocess.Popen(
-    "edmConfigFromDB --configName %s --noedsources --nopaths --noes --nopsets --noservices --cff --blocks %s --format python | sed -e'/^streams/,/^)/d' -e'/^datasets/,/^)/d' > %s" % (config, commands, target),
+    "hltConfigFromDB --configName %s --noedsources --nopaths --noes --nopsets --noservices --cff --blocks %s --format python | sed -e'/^streams/,/^)/d' -e'/^datasets/,/^)/d' > %s" % (config, commands, target),
     shell  = True,
     stdin  = None,
     stdout = None,

--- a/HLTrigger/Configuration/test/getOnline.sh
+++ b/HLTrigger/Configuration/test/getOnline.sh
@@ -27,5 +27,5 @@ hltGetConfiguration $HLT --process HLTGRun --globaltag auto:startup_GRun   --ful
   DB=$(echo $HLT | cut -d: -f1 -s)
   true ${DB:=hltdev}
 
-  edmConfigFromDB --$DB --configName $TABLE | hltDumpStream 
+  hltConfigFromDB --$DB --configName $TABLE | hltDumpStream 
 } > streams.txt


### PR DESCRIPTION
- run the BrowserConverter locally, instead of relying on the web interface
- read the .jar files from the 'confdb' public area, either directly
  via AFS, or downloading them to a temporary directory first
- hltConfigFromDB reimplements most of the interface of edmConfigFromDB
