### PR TITLE
Fix cluster-TP association for TrajectorySeeds in QuickTrackAssociatorByHits

### DIFF
--- a/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
+++ b/SimTracker/TrackAssociation/src/QuickTrackAssociatorByHits.cc
@@ -613,7 +613,10 @@ QuickTrackAssociatorByHits::associateRecoToSim(edm::Handle<edm::View<TrajectoryS
   edm::LogVerbatim("TrackAssociator") << "Starting TrackAssociatorByHits::associateRecoToSim - #seeds="
                                       << pSeedCollectionHandle_->size()<<" #TPs="<<trackingParticleCollectionHandle->size();
 
-  initialiseHitAssociator( pEvent );
+  // get the Cluster2TPMap or initialize hit associator
+  if (useClusterTPAssociation_) prepareCluster2TPMap(pEvent);
+  else initialiseHitAssociator( pEvent );
+
   pTrackCollectionHandle_=NULL;
   pTrackingParticleCollectionHandle_=&trackingParticleCollectionHandle;
   pTrackCollection_=NULL;


### PR DESCRIPTION
When cluster-TrackingParticle association was introduced in QuickTrackAssociatorByHits, the necessary "preparation step" was not added for TrajectorySeeds. As a result the TrackerSeedValidator got no associations to TPs for TrajectorySeeds. This is fixed here by making the call to `prepareCluster2TPMap()`, as in the methods making the associations for Tracks.

Note: AFAICT 74X is not affected as it seems that the bug got fixed in #3639.

Tested in 620_SLHC20 (that the fix does what it should), and in 620_SLHC23_patch2 and wf 10239 that it doesn't affect standard workflows (as TrackerSeedValidator is not part of them).

@rovere @VinInn 
