### PR TITLE
Forward-port three simple tracking PRs from 620_SLHC

### DIFF
--- a/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerWrapper.h
+++ b/RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackCleanerWrapper.h
@@ -36,7 +36,10 @@ public:
        const std::vector<const TrackingRecHit *> & trhs = it->second;
        assert(!(trhs.size()<2));
        if (trhs.size()<2) continue;
-       SeedingHitSet ttrhs( hitMap[trhs[0]], hitMap[trhs[1]], trhs.size()>2 ? hitMap[trhs[2]] : SeedingHitSet::nullPtr()); 
+       SeedingHitSet ttrhs( hitMap[trhs[0]], hitMap[trhs[1]], 
+               trhs.size()>2 ? hitMap[trhs[2]] : SeedingHitSet::nullPtr(),
+               trhs.size()>3 ? hitMap[trhs[3]] : SeedingHitSet::nullPtr() ); 
+
        finalT_TTRHs.push_back( pixeltrackfitting::TrackWithTTRHs(it->first, ttrhs));
     }
     return finalT_TTRHs;

--- a/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.cc
+++ b/RecoTracker/TkDetLayers/src/BladeShapeBuilderFromDet.cc
@@ -63,7 +63,7 @@ namespace {
     float rmed = (rmin+rmax)/2.;
     if ( phiWin < 0. ) {
       if ( (phimin < Geom::pi() / 2.) || (phimax > -Geom::pi()/2.) ){
-	edm::LogError("TkDetLayers") << " something strange going on, please check " ;
+	edm::LogError("TkDetLayers") << " something strange going on, please check " << phimin << " " << phimax << " " << phiWin ;
       }
       //edm::LogInfo(TkDetLayers) << " Wedge at pi: phi " << phimin << " " << phimax << " " << phiWin 
       //	 << " " << 2.*Geom::pi()+phiWin << " " ;

--- a/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
+++ b/RecoTracker/TkSeedGenerator/src/SeedGeneratorFromRegionHits.cc
@@ -21,8 +21,11 @@ void SeedGeneratorFromRegionHits::run(TrajectorySeedCollection & seedCollection,
   const OrderedSeedingHits & hitss = theHitsGenerator->run(region, ev, es);
 
   unsigned int nHitss =  hitss.size();
-  if (seedCollection.empty()) seedCollection.reserve(nHitss); // don't do multiple reserves in the case of multiple regions: it would make things even worse
-                                                              // as it will cause N re-allocations instead of the normal log(N)/log(2)
+  // Modified 10/Jun/2014 Mark Grimes - At 140 pileup this reserve massively overestimates
+  // the amount of memory required. Removing it doesn't appear to slow down the algorithm
+  // noticeably.
+  //if (seedCollection.empty()) seedCollection.reserve(nHitss); // don't do multiple reserves in the case of multiple regions: it would make things even worse
+  //                                                            // as it will cause N re-allocations instead of the normal log(N)/log(2)
   for (unsigned int iHits = 0; iHits < nHitss; ++iHits) { 
     const SeedingHitSet & hits =  hitss[iHits];
     if (!theComparitor || theComparitor->compatible(hits, region) ) {


### PR DESCRIPTION
This PR is a forward-port of the following PRs in 620_SLHC branch that are not yet in 74X
- #4372: Fix PixelTrackCleanerWrapper for quadruplet SeedingHitSet
- #3921: Fpix navigation allfixed newdetid
  - Everything else of it is already included except small enhancement in LogError message that looks possibly useful
- #4180: Remove vector reserve in SeedGeneratorFromRegionHits

No regression expected, no regression observed (tested with RelValTTbar_13 in 740pre6).

@rovere @VinInn @boudoul @venturia @davidlange6, please review
