### PR TITLE
EventFilter/EcalRawToDigi (EcalDumpRaw.cc): remove unused fppaGainFactors

### DIFF
--- a/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
+++ b/EventFilter/EcalRawToDigi/plugins/EcalDumpRaw.cc
@@ -124,7 +124,6 @@ static const char* const ttsNames[] = {
 //          gain setting:  1(sat)     12      6        1
 //index 0->saturation
 static const double mgpaGainFactors[] = {10.63, 1., 10.63/5.43, 10.63};
-static const double fppaGainFactors[] = {0, 1., 16./1.,  0.};
 
 EcalDumpRaw::EcalDumpRaw(const edm::ParameterSet& ps):
   iEvent_(0),


### PR DESCRIPTION
The patch removes `fppaGainFactors` detected by Clang pre-3.6.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
