### PR TITLE
move Spline to single precision 

### DIFF
--- a/PhysicsTools/MVAComputer/interface/Spline.h
+++ b/PhysicsTools/MVAComputer/interface/Spline.h
@@ -37,16 +37,16 @@ class Spline {
 	void set(unsigned int n, const double *vals);
 
 	/// compute y coordinate at x coordinate \a x
-	double eval(double x) const;
+	float eval(float x) const;
 
 	/// compute the derivate at x coordinate \a x
-	double deriv(double x) const;
+	float deriv(float x) const;
 
 	/// compute integral under curve between 0 and \a x
-	double integral(double x) const;
+	float integral(float x) const;
 
 	/// total area (integral between 0 and 1) under curve
-	double getArea() const { return area; }
+	float getArea() const { return area; }
 
 	/// return the number of entries
 	inline unsigned int numberOfEntries() const { return n + 1; }
@@ -54,17 +54,17 @@ class Spline {
     private:
 	/// internal class describing a "segment" (between two x points)
 	struct Segment {
-		double coeffs[4];
-		double area;
+		float coeffs[4];
+		float area;
 
-		double eval(double x) const;
-		double deriv(double x) const;
-		double integral(double x) const;
+		float eval(float x) const;
+		float deriv(float x) const;
+		float integral(float x) const;
 	};
 
 	unsigned int	n;
 	Segment		*segments;
-	double		area;
+	float		area;
 };
 
 } // namespace PhysicsTools

--- a/PhysicsTools/MVAComputer/src/Spline.cc
+++ b/PhysicsTools/MVAComputer/src/Spline.cc
@@ -18,10 +18,10 @@
 
 namespace PhysicsTools {
 
-double Spline::Segment::eval(double x) const
+float Spline::Segment::eval(float x) const
 {
-	double tmp;
-	double y = 0.0;
+	float tmp;
+	float y = 0.0;
 	y += coeffs[0];		tmp = x;
 	y += coeffs[1] * tmp;	tmp *= x;
 	y += coeffs[2] * tmp;	tmp *= x;
@@ -29,20 +29,20 @@ double Spline::Segment::eval(double x) const
 	return y;
 }
 
-double Spline::Segment::deriv(double x) const
+float Spline::Segment::deriv(float x) const
 {
-	double tmp;
-	double d = 0.0;
+	float tmp;
+	float d = 0.0;
 	d += coeffs[1];			tmp = x;
 	d += coeffs[2] * tmp * 2.0;	tmp *= x;
 	d += coeffs[3] * tmp * 3.0;
 	return d;
 }
 
-double Spline::Segment::integral(double x) const
+float Spline::Segment::integral(float x) const
 {
-	double tmp = x;
-	double area = this->area;
+	float tmp = x;
+	float area = this->area;
 	area += coeffs[0] * tmp;	       tmp *= x;
 	area += coeffs[1] * tmp * (1.0 / 2.0); tmp *= x;
 	area += coeffs[2] * tmp * (1.0 / 3.0); tmp *= x;
@@ -82,7 +82,7 @@ void Spline::set(unsigned int n_, const double *vals)
 		return;
 	}
 
-	double m0, m1;
+	float m0, m1;
 	Segment *seg = &segments[0];
 	m0 = 0.0, m1 = 0.5 * (vals[2] - vals[0]);
 	seg->coeffs[0] = vals[0];
@@ -128,20 +128,20 @@ Spline &Spline::operator = (const Spline &orig)
 	return *this;
 }
 
-double Spline::eval(double x) const
+float Spline::eval(float x) const
 {
 	if (x <= 0.0)
 		return segments[0].eval(0.0);
 	if (x >= 1.0)
 		return segments[n - 1].eval(1.0);
 
-	double total;
-	double rest = std::modf(x * n, &total);
+	float total;
+	float rest = std::modf(x * n, &total);
 
 	return segments[(unsigned int)total].eval(rest);
 }
 
-double Spline::deriv(double x) const
+float Spline::deriv(float x) const
 {
 	if (x < 0.0 || x > 1.0)
 		return 0.0;
@@ -150,13 +150,13 @@ double Spline::deriv(double x) const
 	else if (x == 1.0)
 		return segments[n - 1].deriv(1.0);
 
-	double total;
-	double rest = std::modf(x * n, &total);
+	float total;
+	float rest = std::modf(x * n, &total);
 
 	return segments[(unsigned int)total].deriv(rest);
 }
 
-double Spline::integral(double x) const
+float Spline::integral(float x) const
 {
 	if (x <= 0.0)
 		return 0.0;
@@ -166,8 +166,8 @@ double Spline::integral(double x) const
 	if (area < 1.0e-9)
 		return 0.0;
 
-	double total;
-	double rest = std::modf(x * n, &total);
+	float total;
+	float rest = std::modf(x * n, &total);
 
 	return segments[(unsigned int)total].integral(rest) / area;
 }


### PR DESCRIPTION
to save 50MB in reco (we should also understand why we have 50MB of splines)
Thanks to Danilo for noticing this.

[I didn't check the physics changes - please do before signing]
