### PR TITLE
std::regex_replace not supported in gcc4.8.1

### DIFF
--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -1,7 +1,7 @@
 #include <cxxabi.h>
 #include <cctype>
-#include <regex>
 #include <string>
+#include "boost/regex.hpp"
 #include "FWCore/Utilities/interface/Exception.h"
 
 /********************************************************************
@@ -27,9 +27,9 @@
 namespace {
   void
   reformatter(std::string& input, char const* exp, char const* format) {
-    std::regex regexp(exp, std::regex::egrep);
-    while(std::regex_match(input, regexp)) {
-      std::string newstring = std::regex_replace(input, regexp, format);
+    boost::regex regexp(exp, boost::regex::egrep);
+    while(boost::regex_match(input, regexp)) {
+      std::string newstring = boost::regex_replace(input, regexp, format);
       input.swap(newstring);
     }
   }


### PR DESCRIPTION
A recent fix caused a compilation error in gcc4.8.1 because std::regex_replace() does not appear to be supported there.   This pull request simply replaces this use of std::regex with boost::regex.
