### PR TITLE
ROOT6 needs to know about enumerations

### DIFF
--- a/CondFormats/L1TObjects/src/classes_def.xml
+++ b/CondFormats/L1TObjects/src/classes_def.xml
@@ -166,6 +166,8 @@
   <class name="std::map<int, std::vector<L1GtObject> >"/>  
   <class name="std::map<int, std::vector<L1GtObject> >::value_type"/>  
   <class name="L1GtCondition"/>
+  <enum name="L1GtConditionCategory"/>
+  <enum name="L1GtConditionType"/>
   <class name="L1GtMuonTemplate"/>
   <class name="L1GtMuonTemplate::ObjectParameter"/>
   <class name="std::vector<L1GtMuonTemplate::ObjectParameter>"/>


### PR DESCRIPTION
A recent change to CondFormats/L1TObjects added a dictionary for class L1GTCondition without adding a specification for two enums that are data members of this class.  This causes most release validation tests in ROOT6 to fail.  This pull request adds a specification for the two enumerations.  The relvals will still fail for a different reason, but that does not remove the need for this absolutely critical fix.
Please merge this pull request before the next IB if at all possible.
