### PR TITLE
Allow for more than 3 skipped LHE files.

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/LHESource.cc
+++ b/GeneratorInterface/LHEInterface/plugins/LHESource.cc
@@ -64,8 +64,11 @@ void LHESource::nextEvent()
 		return;
         }
 
-	bool newFileOpened = false;
-	partonLevel = reader->next(&newFileOpened);
+	bool newFileOpened;
+	do {
+		newFileOpened = false;
+		partonLevel = reader->next(&newFileOpened);
+	} while (newFileOpened && !partonLevel);
 
 	if (!partonLevel) {
 		return;


### PR DESCRIPTION
Currently, the LHESource reads by calling nextEvent(), which in turn
calls LHEReader::next().  The latter method returns an empty reference
at the end of a file [1](http://cmslxr.fnal.gov/lxr/source/GeneratorInterface/LHEInterface/src/LHEReader.cc#0491).

When reading an event in a fourth file, nextEvent() is first called in
the constructor of LHESource [2](http://cmslxr.fnal.gov/lxr/source/GeneratorInterface/LHEInterface/plugins/LHESource.cc#0042), returning an empty reference at the
end of the fist file.  The other calls to nextEvent(), [3](http://cmslxr.fnal.gov/lxr/source/GeneratorInterface/LHEInterface/plugins/LHESource.cc?v=CMSSW_7_4_0_pre5#0166) and [4](http://cmslxr.fnal.gov/lxr/source/GeneratorInterface/LHEInterface/plugins/LHESource.cc?v=CMSSW_7_4_0_pre5#0169),
return an empty reference at the end of the second and third file.
But there is a check after [4](http://cmslxr.fnal.gov/lxr/source/GeneratorInterface/LHEInterface/plugins/LHESource.cc?v=CMSSW_7_4_0_pre5#0169), and LHESource quits reading files
without attempting to open the fourth file.

Try to address the situation by keeping reading files as long as new
files are opened and empty events are returned.  This potentially also
removes the need for the check after [4](http://cmslxr.fnal.gov/lxr/source/GeneratorInterface/LHEInterface/plugins/LHESource.cc?v=CMSSW_7_4_0_pre5#0169).

Also pertains to dmwm/CRABServer#4659.
