### PR TITLE
Utilities/StaticAnalyzers (ClassChecker.cpp): fix initialization order

### DIFF
--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -88,7 +88,8 @@ public:
     : Checker(checker),
       BR(br),
       AC(ac),
-      visitingCallExpr(0), AD(fd) {}
+      AD(fd),
+      visitingCallExpr(0) {}
 
   bool hasWork() const { return !WList.empty(); }
 


### PR DESCRIPTION
Clang is complaining with class member intialization order:

```
ClassChecker.cpp:91:7: error: field 'visitingCallExpr' will be
initialized after field 'AD' [-Werror,-Wreorder]
```

The patch resolves this issue.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
