### PR TITLE
TopQuarkAnalysis/TopEventProducers (TopDecaySubset.cc): fix type mismatch

### DIFF
--- a/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
@@ -189,7 +189,7 @@ const reco::GenParticle* TopDecaySubset::findPrimalW(
 /// this function would pick the top with status 62
 const reco::GenParticle* TopDecaySubset::findLastParticleInChain(
 		const reco::GenParticle* p) {
-	unsigned int particleID = std::abs(p->pdgId());
+	int particleID = std::abs(p->pdgId());
 	bool containsItself = false;
 	unsigned int d_idx = 0;
 	for (unsigned idx = 0; idx < p->numberOfDaughters(); ++idx) {


### PR DESCRIPTION
`pdgId()` from `reco::GenParticle` returns `int`. `std::abs(int)` will
never change the type and will return `int`. There is no need to change
the type to `unsigned int` as later on you only compare `particleID` to
`int` (again returned by `std::abs(int)`.

This is trivial technical change, which does not change the current
behavior.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
