### PR TITLE
Add support for Boost 1.57

### DIFF
--- a/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_iarchive.hpp
@@ -89,7 +89,7 @@
 #include <boost/archive/basic_binary_iprimitive.hpp>
 #include <boost/archive/basic_binary_iarchive.hpp>
 
-#if BOOST_VERSION >= 103500
+#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 #include <boost/archive/shared_ptr_helper.hpp>
 #endif
 
@@ -188,7 +188,7 @@ namespace eos {
 		// load_override functions so we chose to stay one level higher
 		, public boost::archive::basic_binary_iarchive<portable_iarchive>
 
-	#if BOOST_VERSION >= 103500
+	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 		// mix-in helper class for serializing shared_ptr
 		, public boost::archive::detail::shared_ptr_helper
 	#endif

--- a/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
+++ b/CondFormats/Serialization/interface/eos/portable_oarchive.hpp
@@ -92,7 +92,7 @@
 #include <boost/archive/basic_binary_oprimitive.hpp>
 #include <boost/archive/basic_binary_oarchive.hpp>
 
-#if BOOST_VERSION >= 103500
+#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 #include <boost/archive/shared_ptr_helper.hpp>
 #endif
 
@@ -194,7 +194,7 @@ namespace eos {
 		// save_override functions so we chose to stay one level higher
 		, public boost::archive::basic_binary_oarchive<portable_oarchive>
 
-	#if BOOST_VERSION >= 103500
+	#if BOOST_VERSION >= 103500 && BOOST_VERSION <= 105500
 		// mix-in helper class for serializing shared_ptr
 		, public boost::archive::detail::shared_ptr_helper
 	#endif

--- a/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
+++ b/FWCore/ParameterSet/src/AllowedLabelsDescriptionBase.cc
@@ -5,8 +5,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ParameterSet/interface/DocFormatHelper.h"
 
-#include "boost/ref.hpp"
-
 #include <iomanip>
 #include <ostream>
 
@@ -54,7 +52,7 @@ namespace edm {
         allowedLabels = pset.getUntrackedParameter<std::vector<std::string> >(parameterHoldingLabels_.label());
       }
       for_all(allowedLabels, std::bind(&AllowedLabelsDescriptionBase::validateAllowedLabel_,
-                                         boost::cref(this),
+                                         this,
                                          std::placeholders::_1,
                                          std::ref(pset),
                                          std::ref(validatedLabels)));

--- a/FWCore/ParameterSet/src/ParameterWildcard.cc
+++ b/FWCore/ParameterSet/src/ParameterWildcard.cc
@@ -5,8 +5,6 @@
 #include "FWCore/ParameterSet/interface/VParameterSetEntry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 
-#include "boost/ref.hpp"
-
 #include <cassert>
 #include <iomanip>
 #include <ostream>
@@ -64,7 +62,7 @@ namespace edm {
     if(psetDesc_) {
       for_all(parameterNames,
               std::bind(&ParameterWildcard<ParameterSetDescription>::validateDescription,
-                          boost::cref(this),
+                          this,
                           std::placeholders::_1,
                           std::ref(pset)));
     }
@@ -181,7 +179,7 @@ namespace edm {
     if(psetDesc_) {
       for_all(parameterNames,
               std::bind(&ParameterWildcard<std::vector<ParameterSet> >::validatePSetVector,
-                          boost::cref(this),
+                          this,
                           std::placeholders::_1,
                           std::ref(pset)));
     }

--- a/Fireworks/Core/test/BuildFile.xml
+++ b/Fireworks/Core/test/BuildFile.xml
@@ -4,5 +4,5 @@
  <use name="boost"/>
  <use name="rootcintex"/>
  <use name="rootcore"/>
- <lib name="boost_unit_test_framework"/>
+ <use name="boost_test"/>
 </bin>

--- a/Mixing/Base/BuildFile.xml
+++ b/Mixing/Base/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="FWCore/Sources"/>
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Version"/>
-<use   name="boost"/>
 <use   name="clhep"/>
 <use   name="roothistmatrix"/>
 <use   name="CondFormats/RunInfo"/>

--- a/Mixing/Base/interface/BMixingModule.h
+++ b/Mixing/Base/interface/BMixingModule.h
@@ -16,8 +16,7 @@
  ************************************************************/
 
 #include <vector>
-
-#include "boost/shared_ptr.hpp"
+#include <memory>
 
 #include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -94,7 +93,7 @@ namespace edm {
       unsigned int eventId_;
 
       // input, cosmics, beamhalo_plus, beamhalo_minus
-      std::vector<boost::shared_ptr<PileUp> > inputSources_;
+      std::vector<std::shared_ptr<PileUp> > inputSources_;
 
       void update(edm::EventSetup const&);
       edm::ESWatcher<MixingRcd> parameterWatcher_;

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -4,7 +4,6 @@
 #include <memory>
 #include <string>
 #include <vector>
-//#include <boost/bind.hpp>
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
 #include "DataFormats/Provenance/interface/EventID.h"
@@ -183,22 +182,9 @@ namespace edm {
         read = input_->loopRandomWithID(*eventPrincipal_, lumi, pileEventCnt, recorder, randomEngine(streamID));
     } else {
       if (sequential_) {
-        // boost::bind creates a functor from recordEventForPlayback
-        // so that recordEventForPlayback can insert itself before
-        // the original eventOperator.
-
         read = input_->loopSequential(*eventPrincipal_, pileEventCnt, recorder);
-        //boost::bind(&PileUp::recordEventForPlayback<T>,
-        //                    boost::ref(*this), _1, boost::ref(ids),
-        //                             boost::ref(eventOperator))
-        //  );
-          
       } else  {
         read = input_->loopRandom(*eventPrincipal_, pileEventCnt, recorder, randomEngine(streamID));
-        //               boost::bind(&PileUp::recordEventForPlayback<T>,
-        //                             boost::ref(*this), _1, boost::ref(ids),
-        //                             boost::ref(eventOperator))
-        //                 );
       }
     }
     if (read != pileEventCnt)

--- a/Mixing/Base/src/BMixingModule.cc
+++ b/Mixing/Base/src/BMixingModule.cc
@@ -21,10 +21,10 @@ const unsigned int edm::BMixingModule::maxNbSources_ =4;
 
 namespace
 {
-  boost::shared_ptr<edm::PileUp>
+  std::shared_ptr<edm::PileUp>
   maybeMakePileUp(edm::ParameterSet const& ps,std::string sourceName, const int minb, const int maxb, const bool playback)
   { 
-    boost::shared_ptr<edm::PileUp> pileup; // value to be returned
+    std::shared_ptr<edm::PileUp> pileup; // value to be returned
     // Make sure we have a parameter named 'sourceName'
     if (ps.exists(sourceName))
       {

--- a/PhysicsTools/FWLite/src/classes_def.xml
+++ b/PhysicsTools/FWLite/src/classes_def.xml
@@ -1,20 +1,20 @@
 <lcgdict>
- <class name="reco::parser::ExpressionBase" persistent="false" />
- <class name="reco::parser::SelectorBase" persistent="false" />
- <class name="reco::parser::ExpressionPtr" persistent="false" />
- <class name="reco::parser::SelectorPtr" persistent="false" />
- <class name="reco::parser::ExpressionPtrs" persistent="false" />
- <class name="reco::parser::SelectorPtrs" persistent="false" />
- <class name="helper::Parser" persistent="false" />
- <class name="helper::ScannerBase" persistent="false" />
- <!--
- <class name="fwlite::helper::CandScanner" persistent="false" />
- <class name="CandidateSelector" persistent="false" />
- <class name="CandidateFunction" persistent="false" />
- <class name="std::vector<CandidateFunction>" persistent="false" />
-
- <class name="Selector" persistent="false" />
- <class name="CandidateSelector" persistent="false" />
- <class name="CandidateSelector" persistent="false" />
- -->
+  <selection>
+    <class name="reco::parser::ExpressionBase" persistent="false" />
+    <class name="reco::parser::SelectorBase" persistent="false" />
+    <class name="reco::parser::ExpressionPtr" persistent="false" />
+    <class name="reco::parser::SelectorPtr" persistent="false" />
+    <class name="reco::parser::ExpressionPtrs" persistent="false" />
+    <class name="reco::parser::SelectorPtrs" persistent="false" />
+    <class name="helper::Parser" persistent="false" />
+    <class name="helper::ScannerBase" persistent="false" />
+  </selection>
+  <exclusion>
+    <class name="boost::shared_ptr<reco::parser::ExpressionBase>">
+      <method name="[]" />
+    </class>
+    <class name="boost::shared_ptr<reco::parser::SelectorBase>">
+      <method name="[]" />
+    </class>
+  </exclusion>
 </lcgdict>

--- a/SimG4Core/Geometry/interface/DDG4Builder.h
+++ b/SimG4Core/Geometry/interface/DDG4Builder.h
@@ -12,8 +12,6 @@
 #include <vector>
 #include <string>
  
-#include "boost/signals.hpp"
-
 struct DDPosData;
 class DDG4SolidConverter;
 class G4LogicalVolume;

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -6,7 +6,9 @@
 
 #include <map>
 #include <iostream>
-#include <boost/bind.hpp>
+#include <memory>
+#include <functional>
+
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
@@ -463,6 +465,8 @@ namespace edm
   
   void DataMixingModule::doPileUp(edm::Event &e, const edm::EventSetup& ES)
   {
+    using namespace std::placeholders;
+
     std::vector<edm::EventID> recordEventID;
     std::vector<int> PileupList;
     PileupList.clear();
@@ -472,7 +476,7 @@ namespace edm
 
     for (int bunchCrossing=minBunch_;bunchCrossing<=maxBunch_;++bunchCrossing) {
       for (unsigned int isource=0;isource<maxNbSources_;++isource) {
-        boost::shared_ptr<PileUp> source = inputSources_[isource];
+        std::shared_ptr<PileUp> source = inputSources_[isource];
         if (not source or not source->doPileUp()) 
           continue;
 
@@ -490,8 +494,8 @@ namespace edm
         source->readPileUp(
                 e.id(),
                 recordEventID,
-                boost::bind(&DataMixingModule::pileWorker, boost::ref(*this),
-                            _1, bunchCrossing, _2, boost::cref(ES), mcc),
+                std::bind(&DataMixingModule::pileWorker, std::ref(*this),
+                            _1, bunchCrossing, _2, std::cref(ES), mcc),
 		NumPU_Events,
                 e.streamID()
                 );

--- a/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
+++ b/SimGeneral/MixingModule/plugins/SecSourceAnalyzer.cc
@@ -19,7 +19,7 @@
 
 // system include files
 #include <memory>
-#include <boost/bind.hpp>
+#include <functional>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -93,6 +93,7 @@ SecSourceAnalyzer::~SecSourceAnalyzer()
 void
 SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+   using namespace std::placeholders;
    vectorEventIDs_.resize(maxBunch_-minBunch_+1);
 
    int nevt = 0 ;
@@ -102,7 +103,7 @@ SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	 {
 	   input_->readPileUp( iEvent.id(),
                                vectorEventIDs_[ ibx-minBunch_ ],
-                               boost::bind(&SecSourceAnalyzer::getBranches,
+                               std::bind(&SecSourceAnalyzer::getBranches,
                                            this, _1, iEvent.moduleCallingContext()), ibx,
                                iEvent.streamID());
 	 }
@@ -110,7 +111,7 @@ SecSourceAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSet
 	 {
 	   input_->readPileUp( iEvent.id(),
                                vectorEventIDs_[ ibx-minBunch_ ],
-                               boost::bind(&SecSourceAnalyzer::dummyFunction,
+                               std::bind(&SecSourceAnalyzer::dummyFunction,
                                            this, _1),
                                ibx,
                                iEvent.streamID());


### PR DESCRIPTION
The following patchsets adds support for Boost 1.57 while still keeping compatibility with older Boost versions. This needs to go before or together with Boost 1.57.

These are the cherry-pick of various PRs done in CMSSW_7_3_X to support new boost.

https://github.com/cms-sw/cmssw/pull/6278
https://github.com/cms-sw/cmssw/pull/6289
https://github.com/cms-sw/cmssw/pull/6353
https://github.com/cms-sw/cmssw/pull/6399
https://github.com/cms-sw/cmssw/pull/6369
https://github.com/cms-sw/cmssw/pull/6356

(if not missing anything)

Compile tested in CMSSW_7_2_X_2015-02-10-1400 with GCC, but not tested yet with Boost 1.57.

Will try to add new Boost now and recompile again.
