### PR TITLE
Add FastSim changes to the run2 era

### DIFF
--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# This is used to modify parameters for Run 2 (see bottom of file)
+from Configuration.StandardSequences.Eras import eras
+
 #Global fast calorimetry parameters
 from FastSimulation.Calorimetry.HcalResponse_cfi import *
 from FastSimulation.Calorimetry.HSParameters_cfi import *
@@ -287,3 +290,8 @@ FamosCalorimetryBlock = cms.PSet(
 
 FamosCalorimetryBlock.Calorimetry.ECAL.Digitizer = True
 FamosCalorimetryBlock.Calorimetry.HCAL.Digitizer = True
+
+#
+# Modify for running in Run 2
+#
+eras.run2.toModify( FamosCalorimetryBlock.Calorimetry.HFShowerLibrary, useShowerLibrary=True )

--- a/FastSimulation/Configuration/python/MixingModule_Full2Fast.py
+++ b/FastSimulation/Configuration/python/MixingModule_Full2Fast.py
@@ -65,8 +65,8 @@ def get_PileUpSimulatorPSet_PileUpProducer(_input):
         raise
 
     # minbias files
-    from FastSimulation.PileUpProducer.PileUpFiles_cff import fileNames_8TeV
-    PileUpSimulator.fileNames = fileNames_8TeV
+    from FastSimulation.PileUpProducer.PileUpFiles_cff import puFileNames
+    PileUpSimulator.fileNames = puFileNames.fileNames
     
     # a purely technical, but required, setting
     PileUpSimulator.inputFile = cms.untracked.string('PileUpInputFile.txt')
@@ -115,10 +115,6 @@ def prepareGenMixing(process):
     pos = process.simulationSequence.index(process.famosSimHits)
     process.simulationSequence.insert(pos,process.famosPileUp)
 
-    # Adapt pileup files if needed (usualy needed for postLS1 customisation)
-    if hasattr(process,"genMixPileUpFiles"):
-        process.famosPileUp.PileUpSimulator.fileNames = process.genMixPileUpFiles.fileNames
-        
     # No track mixing when Gen-mixing
     del process.mix.digitizers.tracker
     del process.mix.mixObjects.mixRecoTracks

--- a/FastSimulation/Event/python/ParticleFilter_cfi.py
+++ b/FastSimulation/Event/python/ParticleFilter_cfi.py
@@ -14,3 +14,9 @@ ParticleFilterBlock = cms.PSet(
     )
 )
 
+#
+# Modify for running in Run 2
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( ParticleFilterBlock.ParticleFilter, pTMin = 0.1 )
+eras.run2.toModify( ParticleFilterBlock.ParticleFilter, etaMax = 5.300 )

--- a/FastSimulation/PileUpProducer/python/PileUpFiles_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpFiles_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-fileNames_7TeV = cms.untracked.vstring(
+puFileNames_7TeV = cms.untracked.vstring(
     'MinBias7TeV_001.root', 
     'MinBias7TeV_002.root', 
     'MinBias7TeV_003.root', 
@@ -13,7 +13,7 @@ fileNames_7TeV = cms.untracked.vstring(
     'MinBias7TeV_010.root'
     )
 
-fileNames_8TeV = cms.untracked.vstring(
+puFileNames_8TeV = cms.untracked.vstring(
     'MinBias8TeV_001.root', 
     'MinBias8TeV_002.root', 
     'MinBias8TeV_003.root', 
@@ -26,7 +26,7 @@ fileNames_8TeV = cms.untracked.vstring(
     'MinBias8TeV_010.root'
     )
 
-fileNames_10TeV = cms.untracked.vstring(
+puFileNames_10TeV = cms.untracked.vstring(
     'MinBias10TeV_001.root', 
     'MinBias10TeV_002.root', 
     'MinBias10TeV_003.root', 
@@ -39,7 +39,7 @@ fileNames_10TeV = cms.untracked.vstring(
     'MinBias10TeV_010.root'
     )
 
-fileNames_13TeV = cms.untracked.vstring(
+puFileNames_13TeV = cms.untracked.vstring(
     'MinBias13TeV_001.root', 
     'MinBias13TeV_002.root', 
     'MinBias13TeV_003.root', 
@@ -52,7 +52,7 @@ fileNames_13TeV = cms.untracked.vstring(
     'MinBias13TeV_010.root'
     )
 
-fileNames_14TeV = cms.untracked.vstring(
+puFileNames_14TeV = cms.untracked.vstring(
     'MinBias14TeV_001.root', 
     'MinBias14TeV_002.root', 
     'MinBias14TeV_003.root', 
@@ -64,3 +64,12 @@ fileNames_14TeV = cms.untracked.vstring(
     'MinBias14TeV_009.root', 
     'MinBias14TeV_010.root'
     )
+
+puFileNames = cms.PSet(fileNames = puFileNames_8TeV)
+
+#
+# Modify for running in Run 2
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify(puFileNames,fileNames=puFileNames_13TeV)
+

--- a/FastSimulation/PileUpProducer/python/PileUpProducer_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpProducer_cff.py
@@ -42,8 +42,10 @@ famosPileUp = cms.EDProducer(
 # Modify for running in Run 2
 #
 from Configuration.StandardSequences.Eras import eras
-def _modifyFamosPileUpForRun2( module ) :
+def _modifyFamosPileUpForRun2( processObject ) :
     from FastSimulation.PileUpProducer.PileUpFiles_cff import fileNames_13TeV
-    module.fileNames = fileNames_13TeV
+    processObject.genMixPileUpFiles = cms.PSet(fileNames = fileNames_13TeV)
+    processObject.famosPileUp.PileUpSimulatorBlock.PileUpSimulator.fileNames = fileNames_13TeV
 
-eras.run2.toModify( famosPileUp.PileUpSimulatorBlock.PileUpSimulator, func = _modifyFamosPileUpForRun2 )
+# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
+modifyFastSimulationPileUpProducerPileUpProducerForRun2_ = eras.run2.makeProcessModifier( _modifyFamosPileUpForRun2 )

--- a/FastSimulation/PileUpProducer/python/PileUpProducer_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpProducer_cff.py
@@ -1,5 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
+from FastSimulation.PileUpProducer.PileUpFiles_cff import puFileNames
+
 famosPileUp = cms.EDProducer(
     "PileUpProducer",
     # The conditions for pile-up event generation
@@ -10,17 +12,7 @@ famosPileUp = cms.EDProducer(
             inputFile = cms.untracked.string('PileUpInputFile.txt'),
             # Special files of minimum bias events (generated with 
             # cmsRun FastSimulation/PileUpProducer/test/producePileUpEvents_cfg.py)
-            fileNames = cms.untracked.vstring(
-                'MinBias14TeV_001.root', 
-                'MinBias14TeV_002.root', 
-                'MinBias14TeV_003.root', 
-                'MinBias14TeV_004.root', 
-                'MinBias14TeV_005.root', 
-                'MinBias14TeV_006.root', 
-                'MinBias14TeV_007.root', 
-                'MinBias14TeV_008.root', 
-                'MinBias14TeV_009.root', 
-                'MinBias14TeV_010.root'),
+            fileNames = puFileNames.fileNames,
             averageNumber = cms.double(0.0)
             )
         ),
@@ -38,14 +30,3 @@ famosPileUp = cms.EDProducer(
         )
     )
 
-#
-# Modify for running in Run 2
-#
-from Configuration.StandardSequences.Eras import eras
-def _modifyFamosPileUpForRun2( processObject ) :
-    from FastSimulation.PileUpProducer.PileUpFiles_cff import fileNames_13TeV
-    processObject.genMixPileUpFiles = cms.PSet(fileNames = fileNames_13TeV)
-    processObject.famosPileUp.PileUpSimulatorBlock.PileUpSimulator.fileNames = fileNames_13TeV
-
-# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
-modifyFastSimulationPileUpProducerPileUpProducerForRun2_ = eras.run2.makeProcessModifier( _modifyFamosPileUpForRun2 )

--- a/FastSimulation/PileUpProducer/python/PileUpProducer_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpProducer_cff.py
@@ -37,3 +37,13 @@ famosPileUp = cms.EDProducer(
         Z0 = cms.double(0.4145)
         )
     )
+
+#
+# Modify for running in Run 2
+#
+from Configuration.StandardSequences.Eras import eras
+def _modifyFamosPileUpForRun2( module ) :
+    from FastSimulation.PileUpProducer.PileUpFiles_cff import fileNames_13TeV
+    module.fileNames = fileNames_13TeV
+
+eras.run2.toModify( famosPileUp.PileUpSimulatorBlock.PileUpSimulator, func = _modifyFamosPileUpForRun2 )

--- a/FastSimulation/TrajectoryManager/python/TrackerSimHits_cfi.py
+++ b/FastSimulation/TrajectoryManager/python/TrackerSimHits_cfi.py
@@ -9,3 +9,8 @@ TrackerSimHitsBlock = cms.PSet(
     )
 )
 
+#
+# Modify for running in Run 2
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( TrackerSimHitsBlock.TrackerSimHits, pTmin = 0.1 )

--- a/SLHCUpgradeSimulations/Configuration/python/fastSimCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/fastSimCustoms.py
@@ -5,11 +5,11 @@ def customise_fastSimPostLS1(process):
     if hasattr(process,'famosSimHits'):
        process=customise_fastSimProducer(process)
        
-    from FastSimulation.PileUpProducer.PileUpFiles_cff import fileNames_13TeV
-    process.genMixPileUpFiles = cms.PSet(fileNames = fileNames_13TeV)
+    from FastSimulation.PileUpProducer.PileUpFiles_cff import puFileNames_13TeV
+    process.genMixPileUpFiles = cms.PSet(fileNames = puFileNames_13TeV)
     if hasattr(process,'famosPileUp'):
         if hasattr(process.famosPileUp,"PileUpSimulator"):
-            process.famosPileUp.PileUpSimulator.fileNames = fileNames_13TeV
+            process.famosPileUp.PileUpSimulator.fileNames = puFileNames_13TeV
     
     return process
 


### PR DESCRIPTION
This adds the customisations present in `SLHCUpgradeSimulations.Configuration.fastSimCustoms.customise_fastSimPostLS1` to the `run2` era.  Nothing is changed unless the `run2` era is explicitly activated.

Two points:
- [EDIT - this point no longer relevant] `process.genMixPileUpFiles` is not created. It's not easy to create brand new parameters with an era and I couldn't see it used anywhere.  Is it definitely required?
- I think there's a bug in the original customisation.  The line [SLHCUpgradeSimulations/Configuration/python/fastSimCustoms.py#L11](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/SLHCUpgradeSimulations/Configuration/python/fastSimCustoms.py#L11) doesn't do anything.  The correct path is `famosPileUp.PileUpSimulatorBlock.PileUpSimulator` not `famosPileUp.PileUpSimulator` (see [PileUpProducer_cff.py](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/FastSimulation/PileUpProducer/python/PileUpProducer_cff.py)).  The (what I consider) correct path is used here.

Testing has been limited.  I just made sure the files can be parsed properly since nothing is changed if the era is not active.  I'll worry about ensuring identity between the two methods (customisation versus era) once all the pull requests are in.

Also, I haven't taken the customisations out of the run2 helper function [customiseRun2EraExtras](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py#L233). The postLS1Customs.py file is being heavily modified by #7579, and this would likely cause a conflict.  Applying the modification twice has no harm so I'll remove those lines in a later pull request.
