### PR TITLE
Add HO particle flow changes to the run2 era

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# Use this object to modify parameters specifically for Run 2
+from Configuration.StandardSequences.Eras import eras
+
 #### PF CLUSTER HO ####
 
 #cleaning
@@ -83,3 +86,24 @@ particleFlowClusterHO = cms.EDProducer(
     energyCorrector = cms.PSet()
 )
 
+#
+# Need to change the quality tests for Run 2
+#
+def _modifyParticleFlowClusterHOForRun2( object ) :
+    """
+    Customises PFClusterProducer for Run 2.
+    """
+    for p in object.seedFinder.thresholdsByDetector:
+        p.seedingThreshold = cms.double(0.08)
+
+    for p in object.initialClusteringStep.thresholdsByDetector:
+        p.gatheringThreshold = cms.double(0.05)
+
+    for p in object.pfClusterBuilder.recHitEnergyNorms:
+        p.recHitEnergyNorm = cms.double(0.05)
+
+    object.pfClusterBuilder.positionCalc.logWeightDenominator = cms.double(0.05)
+    object.pfClusterBuilder.allCellsPositionCalc.logWeightDenominator = cms.double(0.05)
+
+# Call the function above to modify particleFlowClusterHO only if the run2 era is active
+eras.run2.toModify( particleFlowClusterHO, func=_modifyParticleFlowClusterHOForRun2 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHO_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHO_cfi.py
@@ -29,3 +29,28 @@ particleFlowRecHitHO = cms.EDProducer("PFRecHitProducer",
 
 )
 
+#
+# Need to change the quality tests for Run 2
+#
+from Configuration.StandardSequences.Eras import eras
+
+def _modifyParticleFlowRecHitHOForRun2( object ) :
+    """
+    Customises PFRecHitProducer for Run 2 by lowering the
+    HO threshold for SiPM
+    """
+    for prod in object.producers:
+        prod.qualityTests = cms.VPSet(
+            cms.PSet(
+                name = cms.string("PFRecHitQTestThreshold"),
+                threshold = cms.double(0.05) # new threshold for SiPM HO
+            ),
+            cms.PSet(
+                name = cms.string("PFRecHitQTestHCALChannel"),
+                maxSeverities      = cms.vint32(11),
+                cleaningThresholds = cms.vdouble(0.0),
+                flags              = cms.vstring('Standard')
+            )
+        )
+
+eras.run2.toModify( particleFlowRecHitHO, func=_modifyParticleFlowRecHitHOForRun2 )


### PR DESCRIPTION
Adds the Run 2 customisations from customisePostLS1 relevant to the HO particle flow changes.  No changes are made unless the `run2` era is explicitly activated.

Testing has been limited. I just checked that the particular modules have the changes applied when the era is activated.  If it's not activated then there is no change.  I'll worry about ensuring identity between the two methods (customisation versus era) once all the pull requests are in.

I haven't taken the customisations out of the run2 helper function [customiseRun2EraExtras](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py#L250). The postLS1Customs.py file is being heavily modified by #7579, and this would likely cause a conflict. Applying the modification twice has no harm so I'll remove those lines in a later pull request.
