### PR TITLE
Add HCal digitisation changes to the run2 era

### DIFF
--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# This object modifies the event content for different scenarios
+from Configuration.StandardSequences.Eras import eras
+
 SimCalorimetryFEVTDEBUG = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_simEcalDigis_*_*', 
         'keep *_simEcalPreshowerDigis_*_*', 
@@ -20,3 +23,8 @@ SimCalorimetryAOD = cms.PSet(
     outputCommands = cms.untracked.vstring()
 )
 
+#
+# Add extra event content if running in Run 2
+#
+eras.run2.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
+eras.run2.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
+# This object modifies hcalSimParameters for different scenarios
+from Configuration.StandardSequences.Eras import eras
+
 hcalSimParameters = cms.PSet(
     #  In HF, the SimHits energy is actually
     # the number of photoelectrons from the shower
@@ -97,3 +100,19 @@ hcalSimParameters.hoZecotek.photoelectronsToAnalog = [3.0]*16
 hcalSimParameters.hoHamamatsu = hcalSimParameters.ho.clone()
 hcalSimParameters.hoHamamatsu.pixels = cms.int32(960)
 hcalSimParameters.hoHamamatsu.photoelectronsToAnalog = [3.0]*16
+
+#
+# Need to change the HO parameters for post LS1 running
+#
+def _modifyHcalSimParametersForPostLS1( object ) :
+    """
+    Customises the HCal digitiser for post LS1 running
+    """
+    object.ho.photoelectronsToAnalog = cms.vdouble([4.0]*16)
+    object.ho.siPMCode = cms.int32(1)
+    object.ho.pixels = cms.int32(2500)
+    object.ho.doSiPMSmearing = cms.bool(False)
+    object.hf1.samplingFactor = cms.double(0.60)
+    object.hf2.samplingFactor = cms.double(0.60)
+
+eras.run2.toModify( hcalSimParameters, func=_modifyHcalSimParametersForPostLS1 )


### PR DESCRIPTION
Adds the Run 2 customisations from customisePostLS1 relevant to the HCal digitisation (the ten or so [lines starting here](https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py#L286)) to the `run2` era. No changes are made unless the `run2` era is explicitly activated.

Testing has been limited. I just checked that the particular modules have the changes applied when the era is activated. If it's not activated then there is no change. I'll worry about confirming identity between the two methods (customisation versus era) once all the pull requests are in.

I haven't taken the customisations out of the run2 helper function `customiseRun2EraExtras`. The postLS1Customs.py file is being heavily modified by #7579, and this would likely cause a conflict. Applying the modification twice has no harm (well, event content commands are added twice but I think that's harmless) so I'll remove those lines in a later pull request.  It's only temporary anyway.
