### PR TITLE
Bug fix so this will compile with -O0 -g

### DIFF
--- a/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
+++ b/TopQuarkAnalysis/TopEventProducers/src/TopDecaySubset.cc
@@ -189,7 +189,7 @@ const reco::GenParticle* TopDecaySubset::findPrimalW(
 /// this function would pick the top with status 62
 const reco::GenParticle* TopDecaySubset::findLastParticleInChain(
 		const reco::GenParticle* p) {
-	unsigned int particleID = std::abs(p->pdgId());
+	int particleID = std::abs(p->pdgId());
 	bool containsItself = false;
 	unsigned int d_idx = 0;
 	for (unsigned idx = 0; idx < p->numberOfDaughters(); ++idx) {


### PR DESCRIPTION
Without the fix it fails to compile with
-O0 0g because of a warning about comparing
signed and unsigned types.
