### PR TITLE
Changed static to std::atomic in MuonErrorMatrix

### DIFF
--- a/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
+++ b/RecoMuon/TrackingTools/src/MuonErrorMatrix.cc
@@ -8,6 +8,7 @@
 #include "TMath.h"
 
 #include <sstream>
+#include <atomic>
 
 using namespace std;
 
@@ -112,7 +113,7 @@ MuonErrorMatrix::MuonErrorMatrix(const edm::ParameterSet & iConfig):theD(0){
       theD = new TFile(fullpath.c_str());
       theD->SetWritable(false);
     }else{
-      static unsigned int neverTheSame=0;
+      static std::atomic<unsigned int> neverTheSame{0};
       std::stringstream dirName("MuonErrorMatrixDirectory");
       dirName<<neverTheSame++;
       edm::LogInfo(theCategory)<<"using an error matrix object from configuration file. putting memory histograms to: "<<dirName.str();


### PR DESCRIPTION
The MuonErrorMatrix wants a unique per job number. Given the code
is called by stream modules the count has to be done atomically.

Problem found by the static analyzer.
