### PR TITLE
Cluster cleaning bug fix, renamed hiSecond to hiLowPt

### DIFF
--- a/RecoHI/HiTracking/python/HiTracking_cff.py
+++ b/RecoHI/HiTracking/python/HiTracking_cff.py
@@ -1,7 +1,7 @@
 
 from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
 from RecoHI.HiTracking.LowPtTracking_PbPb_cff import *
-from RecoHI.HiTracking.hiSecondPixelTripletStep_cff import *
+from RecoHI.HiTracking.hiLowPtTripletStep_cff import *
 from RecoHI.HiTracking.hiMixedTripletStep_cff import *
 from RecoHI.HiTracking.hiPixelPairStep_cff import *
 from RecoHI.HiTracking.hiDetachedTripletStep_cff import *
@@ -12,7 +12,7 @@ from RecoHI.HiMuonAlgos.hiMuonIterativeTk_cff import *
 hiTracking_noRegitMu = cms.Sequence(
     hiBasicTracking
     *hiDetachedTripletStep
-    *hiSecondPixelTripletStep
+    *hiLowPtTripletStep
     *hiPixelPairStep
     )
 
@@ -25,7 +25,7 @@ hiTracking = cms.Sequence(
 hiTracking_wConformalPixel = cms.Sequence(
     hiBasicTracking
     *hiDetachedTripletStep
-    *hiSecondPixelTripletStep
+    *hiLowPtTripletStep
     *hiPixelPairStep
     *hiGeneralTracks
     *hiConformalPixelTracks    

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -4,14 +4,14 @@ import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiGeneralTracksNoRegitMu = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
                       cms.InputTag('hiDetachedTripletStepTracks'),
-                      cms.InputTag('hiSecondPixelTripletGlobalPrimTracks'),
+                      cms.InputTag('hiLowPtTripletStepTracks'),
                       cms.InputTag('hiPixelPairGlobalPrimTracks')
                      ),
     hasSelector=cms.vint32(1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
-    cms.InputTag("hiSecondPixelTripletStepSelector","hiSecondPixelTripletStep"),
+    cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
     cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
     ),                    
     setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3), pQual=cms.bool(True)),  # should this be False?
@@ -23,7 +23,7 @@ hiGeneralTracksNoRegitMu = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.t
 hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
                       cms.InputTag('hiDetachedTripletStepTracks'),
-                      cms.InputTag('hiSecondPixelTripletGlobalPrimTracks'),
+                      cms.InputTag('hiLowPtTripletStepTracks'),
                       cms.InputTag('hiPixelPairGlobalPrimTracks'),
                       cms.InputTag('hiRegitMuInitialStepTracks'),
                       cms.InputTag('hiRegitMuLowPtTripletStepTracks'),
@@ -37,7 +37,7 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
-    cms.InputTag("hiSecondPixelTripletStepSelector","hiSecondPixelTripletStep"),
+    cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
     cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
     cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
     cms.InputTag("hiRegitMuLowPtTripletStepSelector","hiRegitMuLowPtTripletStepLoose"),

--- a/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiDetachedTripletStep_cff.py
@@ -1,7 +1,6 @@
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import *
 from HIPixelTripletSeeds_cff import *
 from HIPixel3PrimTracks_cfi import *
-from hiSecondPixelTripletStep_cff import *
 
 hiDetachedTripletStepClusters = cms.EDProducer("HITrackClusterRemover",
      clusterLessSolution = cms.bool(True),

--- a/RecoHI/HiTracking/python/hiMixedTripletStep_cff.py
+++ b/RecoHI/HiTracking/python/hiMixedTripletStep_cff.py
@@ -3,9 +3,9 @@ import FWCore.ParameterSet.Config as cms
 # NEW CLUSTERS (remove previously used clusters)
 hiMixedTripletClusters = cms.EDProducer("HITrackClusterRemover",
                                         clusterLessSolution= cms.bool(True),
-                                        oldClusterRemovalInfo = cms.InputTag("hiSecondPixelTripletClusters"),
-                                        trajectories = cms.InputTag("hiSecondPixelTripletGlobalPrimTracks"),
-                                        overrideTrkQuals = cms.InputTag('hiSecondPixelTripletStepSelector','hiSecondPixelTripletStep'),
+                                        oldClusterRemovalInfo = cms.InputTag("hiLowPtTripletStepClusters"),
+                                        trajectories = cms.InputTag("hiLowPtTripletStepTracks"),
+                                        overrideTrkQuals = cms.InputTag('hiLowPtTripletStepSelector','hiLowPtTripletStep'),
                                         TrackQuality = cms.string('highPurity'),
                                         pixelClusters = cms.InputTag("siPixelClusters"),
                                         stripClusters = cms.InputTag("siStripClusters"),

--- a/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
@@ -5,9 +5,9 @@ import FWCore.ParameterSet.Config as cms
 # NEW CLUSTERS (remove previously used clusters)
 hiPixelPairClusters = cms.EDProducer("HITrackClusterRemover",
                                      clusterLessSolution= cms.bool(True),
-                                     oldClusterRemovalInfo = cms.InputTag("hiSecondPixelTripletClusters"),
-                                     trajectories = cms.InputTag("hiSecondPixelTripletGlobalPrimTracks"),
-                                     overrideTrkQuals = cms.InputTag('hiSecondPixelTripletStepSelector','hiSecondPixelTripletStep'),
+                                     oldClusterRemovalInfo = cms.InputTag("hiLowPtTripletStepClusters"),
+                                     trajectories = cms.InputTag("hiLowPtTripletStepTracks"),
+                                     overrideTrkQuals = cms.InputTag('hiLowPtTripletStepSelector','hiLowPtTripletStep'),
                                      TrackQuality = cms.string('highPurity'),
                                      minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),
                                      pixelClusters = cms.InputTag("siPixelClusters"),


### PR DESCRIPTION
One line bugfix to cluster cleaning between before low pT step of HI tracking sequence, introduced by recent addition of a detached triplet step.
The line:
oldClusterRemovalInfo = cms.InputTag("hiDetachedTripletStepClusters")
was missing from PR #7393 
The effect is that only clusters from the step immediately preceding the low pT step were removed (but not those from the intial step), leading to duplication of work.

We take advantage of the opportunity to change 'hiSecondPixelTriplet' to 'hiLowPtPixelTriplet', as the low pT step is no longer second (as promised in the comments of #7393).  This follows the style of the pp code.
