### PR TITLE
displaced muon validation

### DIFF
--- a/Validation/RecoMuon/python/associators_cff.py
+++ b/Validation/RecoMuon/python/associators_cff.py
@@ -169,8 +169,10 @@ tpToStaUpdMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssocia
 tpToGlbMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaRefitMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaRefitUpdMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
+tpToDisplacedTrkMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToDisplacedStaSeedAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToDisplacedStaMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
+tpToDisplacedGlbMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaSETMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToStaSETUpdMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
 tpToGlbSETMuonAssociation = SimMuon.MCTruth.MuonAssociatorByHits_cfi.muonAssociatorByHits.clone()
@@ -219,6 +221,11 @@ tpToStaRefitUpdMuonAssociation.tracksTag = 'refittedStandAloneMuons:UpdatedAtVtx
 tpToStaRefitUpdMuonAssociation.UseTracker = False
 tpToStaRefitUpdMuonAssociation.UseMuon = True
 
+tpToDisplacedTrkMuonAssociation.tpTag = 'mix:MergedTrackTruth'
+tpToDisplacedTrkMuonAssociation.tracksTag = 'displacedTracks'
+tpToDisplacedTrkMuonAssociation.UseTracker = True
+tpToDisplacedTrkMuonAssociation.UseMuon = False
+
 tpToDisplacedStaSeedAssociation.tpTag = 'mix:MergedTrackTruth'
 tpToDisplacedStaSeedAssociation.tracksTag = 'seedsOfDisplacedSTAmuons'
 tpToDisplacedStaSeedAssociation.UseTracker = False
@@ -228,6 +235,11 @@ tpToDisplacedStaMuonAssociation.tpTag = 'mix:MergedTrackTruth'
 tpToDisplacedStaMuonAssociation.tracksTag = 'displacedStandAloneMuons'
 tpToDisplacedStaMuonAssociation.UseTracker = False
 tpToDisplacedStaMuonAssociation.UseMuon = True
+
+tpToDisplacedGlbMuonAssociation.tpTag = 'mix:MergedTrackTruth'
+tpToDisplacedGlbMuonAssociation.tracksTag = 'displacedGlobalMuons'
+tpToDisplacedGlbMuonAssociation.UseTracker = True
+tpToDisplacedGlbMuonAssociation.UseMuon = True
 
 tpToStaSETMuonAssociation.tpTag = 'mix:MergedTrackTruth'
 tpToStaSETMuonAssociation.tracksTag = 'standAloneSETMuons'
@@ -350,6 +362,7 @@ muonAssociationTEV_seq = cms.Sequence(
 )
 muonAssociationDisplaced_seq = cms.Sequence(seedsOfDisplacedSTAmuons_seq
  +(tpToDisplacedStaSeedAssociation+tpToDisplacedStaMuonAssociation)
+ +(tpToDisplacedTrkMuonAssociation+tpToDisplacedGlbMuonAssociation)
 )
 muonAssociationRefit_seq = cms.Sequence(
     (tpToStaRefitMuonAssociation+tpToStaRefitUpdMuonAssociation)

--- a/Validation/RecoMuon/python/muonValidation_cff.py
+++ b/Validation/RecoMuon/python/muonValidation_cff.py
@@ -148,12 +148,23 @@ staRefitUpdMuonTrackVMuonAssoc.label = ('refittedStandAloneMuons:UpdatedAtVtx',)
 staRefitUpdMuonTrackVMuonAssoc.usetracker = False
 staRefitUpdMuonTrackVMuonAssoc.usemuon = True
 
+displacedTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
+displacedTrackVMuonAssoc.associatormap = 'tpToDisplacedTrkMuonAssociation'
+displacedTrackVMuonAssoc.associators = ('MuonAssociationByHits',)
+displacedTrackVMuonAssoc.label = ('displacedTracks',)
+displacedTrackVMuonAssoc.usetracker = True
+displacedTrackVMuonAssoc.usemuon = False
+displacedTrackVMuonAssoc.tipTP = cms.double(85.)
+displacedTrackVMuonAssoc.lipTP = cms.double(210.)
+
 displacedStaSeedTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
 displacedStaSeedTrackVMuonAssoc.associatormap = 'tpToDisplacedStaSeedAssociation'
 displacedStaSeedTrackVMuonAssoc.associators = ('MuonAssociationByHits',)
 displacedStaSeedTrackVMuonAssoc.label = ('seedsOfDisplacedSTAmuons',)
 displacedStaSeedTrackVMuonAssoc.usetracker = False
 displacedStaSeedTrackVMuonAssoc.usemuon = True
+displacedStaSeedTrackVMuonAssoc.tipTP = cms.double(85.)
+displacedStaSeedTrackVMuonAssoc.lipTP = cms.double(210.)
 
 displacedStaMuonTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
 displacedStaMuonTrackVMuonAssoc.associatormap = 'tpToDisplacedStaMuonAssociation'
@@ -161,6 +172,17 @@ displacedStaMuonTrackVMuonAssoc.associators = ('MuonAssociationByHits',)
 displacedStaMuonTrackVMuonAssoc.label = ('displacedStandAloneMuons',)
 displacedStaMuonTrackVMuonAssoc.usetracker = False
 displacedStaMuonTrackVMuonAssoc.usemuon = True
+displacedStaMuonTrackVMuonAssoc.tipTP = cms.double(85.)
+displacedStaMuonTrackVMuonAssoc.lipTP = cms.double(210.)
+
+displacedGlbMuonTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
+displacedGlbMuonTrackVMuonAssoc.associatormap = 'tpToDisplacedGlbMuonAssociation'
+displacedGlbMuonTrackVMuonAssoc.associators = ('MuonAssociationByHits',)
+displacedGlbMuonTrackVMuonAssoc.label = ('displacedGlobalMuons',)
+displacedGlbMuonTrackVMuonAssoc.usetracker = True
+displacedGlbMuonTrackVMuonAssoc.usemuon = True
+displacedGlbMuonTrackVMuonAssoc.tipTP = cms.double(85.)
+displacedGlbMuonTrackVMuonAssoc.lipTP = cms.double(210.)
 
 staSETMuonTrackVMuonAssoc = Validation.RecoMuon.MuonTrackValidator_cfi.muonTrackValidator.clone()
 staSETMuonTrackVMuonAssoc.associatormap = 'tpToStaSETMuonAssociation'
@@ -333,8 +355,8 @@ muonValidationTEV_seq = cms.Sequence(tevMuonFirstTrackVMuonAssoc+tevMuonPickyTra
 
 muonValidationRefit_seq = cms.Sequence(staRefitMuonTrackVMuonAssoc+staRefitUpdMuonTrackVMuonAssoc)
 
-muonValidationDisplaced_seq = cms.Sequence(displacedStaSeedTrackVMuonAssoc+
- displacedStaMuonTrackVMuonAssoc)
+muonValidationDisplaced_seq = cms.Sequence(displacedStaSeedTrackVMuonAssoc+displacedStaMuonTrackVMuonAssoc
+                                          +displacedTrackVMuonAssoc+displacedGlbMuonTrackVMuonAssoc)
 
 muonValidationSET_seq = cms.Sequence(staSETMuonTrackVMuonAssoc+staSETUpdMuonTrackVMuonAssoc+glbSETMuonTrackVMuonAssoc)
 

--- a/Validation/RecoMuon/python/selectors_cff.py
+++ b/Validation/RecoMuon/python/selectors_cff.py
@@ -15,6 +15,20 @@ muonTPSet = cms.PSet(
     chargedOnly = cms.bool(True)
 )
 
+displacedMuonTPSet = cms.PSet(
+    src = cms.InputTag("mix", "MergedTrackTruth"),
+    pdgId = cms.vint32(13, -13),
+    tip = cms.double(85.),  # radius to have at least the 3 outermost TOB layers
+    lip = cms.double(210.), # z to have at least the 3 outermost TEC layers
+    minHit = cms.int32(0),
+    ptMin = cms.double(0.9),
+    minRapidity = cms.double(-2.4),
+    maxRapidity = cms.double(2.4),
+    signalOnly = cms.bool(True),
+    stableOnly = cms.bool(False),
+    chargedOnly = cms.bool(True)
+)
+
 #muonTP = cms.EDFilter("TrackingParticleSelector",
 #    muonTPSet
 #)


### PR DESCRIPTION
Add standard validation of the muon tracks for the new displaced (global) muons and fix to parameters of the existing configuration for displaced standalone muons.
