### PR TITLE
DQMOffline/Trigger (EgHLTTrigCodes.cc): definite static const int member

### DIFF
--- a/DQMOffline/Trigger/src/EgHLTTrigCodes.cc
+++ b/DQMOffline/Trigger/src/EgHLTTrigCodes.cc
@@ -2,6 +2,8 @@
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
+const int egHLT::TrigCodes::maxNrBits_;
+
 using namespace egHLT;
 
 TrigCodes* TrigCodes::makeCodes(std::vector<std::string>& filterNames)


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard), 9.4.2/3

```
...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
```

9.4.2/3 talks about how `const static` data members are being handled.

Also standard says that no diagnostic is required by compiler.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
