### PR TITLE
Add more muon changes to the run2 era

### DIFF
--- a/L1Trigger/CSCTrackFinder/python/csctfTrackDigis_cfi.py
+++ b/L1Trigger/CSCTrackFinder/python/csctfTrackDigis_cfi.py
@@ -1,5 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
+# This function makes all the changes to csctfTrackDigis required for it to work
+# in Run 2. It is declared here to be obvious when this file is opened, but not
+# applied until after csctfTrackDigis is declared (and then only if the "run2"
+# era is active).
+def _modifyCsctfTrackDigisForRun2( object ) :
+	object.SectorProcessor.PTLUT.PtMethod = 34
+	object.SectorProcessor.gangedME1a = False
+	object.SectorProcessor.firmwareSP = 20140515
+	object.SectorProcessor.initializeFromPSet = False 
+
+
 from L1Trigger.CSCCommonTrigger.CSCCommonTrigger_cfi import *
 csctfTrackDigis = cms.EDProducer("CSCTFTrackProducer",
 	DTproducer = cms.untracked.InputTag("dtTriggerPrimitiveDigis"),
@@ -112,4 +123,9 @@ csctfTrackDigis = cms.EDProducer("CSCTFTrackProducer",
 	readDtDirect = cms.bool(False),
 )
 
+#
+# If the run2 era is active, make the required changes
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( csctfTrackDigis, _modifyCsctfTrackDigisForRun2 )
 

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -1,5 +1,28 @@
 import FWCore.ParameterSet.Config as cms
 
+
+# This function makes all the changes to cscTriggerPrimitiveDigis required
+# for it to work in Run 2. It is declared here to be obvious when this file
+# is opened, but not applied until after cscTriggerPrimitiveDigis is
+# declared (and then only if the "run2" era is active).
+def _modifyCscTriggerPrimitiveDigisForRun2( object ) :
+    """
+    Modifies cscTriggerPrimitiveDigis for Run 2
+    """
+    object.debugParameters = True
+    object.checkBadChambers_ = False
+    object.commonParam.isSLHC = True
+    object.commonParam.smartME1aME1b = True
+    object.commonParam.gangedME1a = False
+    object.alctParam07.alctNarrowMaskForR1 = True
+    object.alctGhostCancellationBxDepth = cms.untracked.int32(1)
+    object.alctGhostCancellationSideQuality = cms.untracked.bool(True)
+    object.alctPretrigDeadtime = cms.untracked.uint32(4)
+    object.clctParam07.clctPidThreshPretrig = 4
+    object.clctParam07.clctMinSeparation = 5
+    object.tmbParam.matchTrigWindowSize = 3
+
+
 from L1Trigger.CSCCommonTrigger.CSCCommonTrigger_cfi import *
 # Default parameters for CSCTriggerPrimitives generator
 # =====================================================
@@ -310,3 +333,9 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
         mpcMaxStubs = cms.untracked.uint32(3)
     )
 )
+
+#
+# If the run2 era is active, make the required changes
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2 )

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -90,9 +90,6 @@ def customiseRun2EraExtras(process):
     from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_25ns
     process = customiseSimL1EmulatorForPostLS1_25ns(process)
 
-    if hasattr(process,'dqmoffline_step'):
-        process.l1tCsctf.gangedME11a = cms.untracked.bool(False)
-
     return process
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -86,31 +86,10 @@ def customiseRun2EraExtras(process):
             print "         This path has the following modules:"
             print "         ", getattr(process, path_name).moduleNames(),"\n"
 
-    # L1 stub emulator upgrade algorithm
-    if hasattr(process, 'simCscTriggerPrimitiveDigis'):
-        from L1Trigger.CSCTriggerPrimitives.cscTriggerPrimitiveDigisPostLS1_cfi import cscTriggerPrimitiveDigisPostLS1
-        process.simCscTriggerPrimitiveDigis = cscTriggerPrimitiveDigisPostLS1
-        process.simCscTriggerPrimitiveDigis.CSCComparatorDigiProducer = cms.InputTag( 'simMuonCSCDigis', 'MuonCSCComparatorDigi')
-        process.simCscTriggerPrimitiveDigis.CSCWireDigiProducer = cms.InputTag( 'simMuonCSCDigis', 'MuonCSCWireDigi')
-
-    # CSCTF that can deal with unganged ME1a
-    if hasattr(process, 'simCsctfTrackDigis'):
-        from L1Trigger.CSCTrackFinder.csctfTrackDigisUngangedME1a_cfi import csctfTrackDigisUngangedME1a
-        process.simCsctfTrackDigis = csctfTrackDigisUngangedME1a
-        process.simCsctfTrackDigis.DTproducer = cms.untracked.InputTag("simDtTriggerPrimitiveDigis")
-        process.simCsctfTrackDigis.SectorReceiverInput = cms.untracked.InputTag("simCscTriggerPrimitiveDigis", "MPCSORTED")
-
     # deal with L1 Emulation separately:
     from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_25ns
     process = customiseSimL1EmulatorForPostLS1_25ns(process)
 
-    if hasattr(process,'digitisation_step'):
-        alist=['RAWSIM','RAWDEBUG','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT','PREMIX','PREMIXRAW']
-        for a in alist:
-            b = a + 'output'
-            if hasattr(process,b):
-                getattr(process,b).outputCommands.append('keep *_simMuonCSCDigis_*_*')
-                getattr(process,b).outputCommands.append('keep *_simMuonRPCDigis_*_*')
     if hasattr(process,'dqmoffline_step'):
         process.l1tCsctf.gangedME11a = cms.untracked.bool(False)
 

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -6,6 +6,9 @@
 
 import FWCore.ParameterSet.Config as cms
 
+# Used to make conditional changes for different running scenarios
+from Configuration.StandardSequences.Eras import eras
+
 #Full Event content with DIGI
 SimMuonFEVTDEBUG = cms.PSet(
     outputCommands = cms.untracked.vstring('keep *_simMuonCSCDigis_*_*', 
@@ -19,6 +22,12 @@ SimMuonRAW = cms.PSet(
         'keep DTLayerIdDTDigiSimLinkMuonDigiCollection_simMuonDTDigis_*_*', 
         'keep RPCDigiSimLinkedmDetSetVector_simMuonRPCDigis_*_*')
 )
+# Add extra collections if running in Run 2. Not sure why but these
+# collections were added to pretty much all event content in the old
+# customisation function.
+eras.run2.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonCSCDigis_*_*') )
+eras.run2.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonRPCDigis_*_*') )
+
 #RECO content
 SimMuonRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep StripDigiSimLinkedmDetSetVector_simMuonCSCDigis_*_*', 


### PR DESCRIPTION
Moves the last of the CSC configuration changes for Run 2 from the helper function to the `run2` era.

Changes to `cscTriggerPrimitiveDigis` and `csctfTrackDigis` (and by extension `simCscTriggerPrimitiveDigis` and `simCsctfTrackDigis`) are made in the files themselves rather than the sister files

```
L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigisPostLS1_cfi.py
L1Trigger/CSCTrackFinder/python/csctfTrackDigisUngangedME1a_cfi.py
```

(i.e. those files are not used for the era).  Once the era has been fully validated and workflows switched to using it I recommend deleting the above two files.
