### PR TITLE
Allow reading of files written with ROOT6 in ROOT5

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -41,7 +41,10 @@ namespace edm {
     }
     static boost::regex const reWrapper("edm::Wrapper<(.*)>");
     static boost::regex const reString("std::basic_string<char>");
+    static boost::regex const reString2("std::string");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
+    static boost::regex const reULongLong("ULong64_t");
+    static boost::regex const reLongLong("Long64_t");
     static boost::regex const reUnsigned("unsigned ");
     static boost::regex const reLong("long ");
     static boost::regex const reVector("std::vector");
@@ -70,7 +73,10 @@ namespace edm {
        std::string name = regex_replace(iIn, reWrapper, "$1");
        name = regex_replace(name,reAIKR,"");
        name = regex_replace(name,reString,"String");
+       name = regex_replace(name,reString2,"String");
        name = regex_replace(name,reSorted,"sSorted<$1>");
+       name = regex_replace(name,reULongLong,"ull");
+       name = regex_replace(name,reLongLong,"ll");
        name = regex_replace(name,reUnsigned,"u");
        name = regex_replace(name,reLong,"l");
        name = regex_replace(name,reVector,"s");


### PR DESCRIPTION
Bug fix:   In ROOT6, the normalized names of three data types were changed from what they were in ROOT5.  (unsigned) long long was changed to (U)Long64_t, and std::basic_string<char> was changed to std::string.  Because these names affect branch names, this creates an incompatibility between ROOT5 and ROOT6.  The backward compatibility issue (reading ROOT5 files in ROOT6) was fixed a long time ago. However, at that time, I did not realize that ROOT provided the ability to read files written with ROOT6 in ROOT5.  So, the compatibility fix was needed in the ROOT5 release as well.
Without this fix, ROOT/EDM files written in ROOT6 that contain a top level data item of any of the three affected types, OR of any type templated over these types (e.g. a vector of one of them) cannot be read in ROOT5.
Note: This fix is already in CMSSW_7_4_ROOT6_X.
