### PR TITLE
Must handle ROOT5 name for strings in ROOT6

### DIFF
--- a/FWCore/Utilities/src/FriendlyName.cc
+++ b/FWCore/Utilities/src/FriendlyName.cc
@@ -40,7 +40,8 @@ namespace edm {
       return boost::regex_replace(iIn, reAllSpaces,emptyString);
     }
     static boost::regex const reWrapper("edm::Wrapper<(.*)>");
-    static boost::regex const reString("std::string");
+    static boost::regex const reString("std::basic_string<char>");
+    static boost::regex const reString2("std::string");
     static boost::regex const reSorted("edm::SortedCollection<(.*), *edm::StrictWeakOrdering<\\1 *> >");
     static boost::regex const reULongLong("ULong64_t");
     static boost::regex const reLongLong("Long64_t");
@@ -72,6 +73,7 @@ namespace edm {
        std::string name = regex_replace(iIn, reWrapper, "$1");
        name = regex_replace(name,reAIKR,"");
        name = regex_replace(name,reString,"String");
+       name = regex_replace(name,reString2,"String");
        name = regex_replace(name,reSorted,"sSorted<$1>");
        name = regex_replace(name,reULongLong,"ull");
        name = regex_replace(name,reLongLong,"ll");


### PR DESCRIPTION
In ROOT6, the normalized names of three data types were changed from what they were in ROOT5. (unsigned) long long was changed to (U)Long64_t, and std::basic_string was changed to std::string. Because these names affect branch names, this creates an incompatibility between ROOT5 and ROOT6. The backward compatibility issue (reading ROOT5 files in ROOT6) was fixed a long time ago. However, the fix was imperfect because the fix incorrectly removed the processing needed for the ROOT5 name for string from the algorithm.  This fix restores the improperly removed code, and will make this file identical with 7_4_X after PR#7736 is merged there.
Please merge as soon as convenient.
