### PR TITLE
Revert "remove the rechit analyzer as it hangs root6"

### DIFF
--- a/DQMOffline/Hcal/python/HcalDQMOfflinePostProcessor_cff.py
+++ b/DQMOffline/Hcal/python/HcalDQMOfflinePostProcessor_cff.py
@@ -4,6 +4,6 @@ from DQMOffline.Hcal.HcalRecHitsDQMClient_cfi import *
 from DQMOffline.Hcal.HcalNoiseRatesClient_cfi import *
 from DQMOffline.Hcal.CaloTowersDQMClient_cfi import *
 
-#HcalDQMOfflinePostProcessor = cms.Sequence(hcalNoiseRatesClient*hcalRecHitsDQMClient*calotowersDQMClient)
-HcalDQMOfflinePostProcessor = cms.Sequence(hcalNoiseRatesClient*calotowersDQMClient)
+HcalDQMOfflinePostProcessor = cms.Sequence(hcalNoiseRatesClient*hcalRecHitsDQMClient*calotowersDQMClient)
+#HcalDQMOfflinePostProcessor = cms.Sequence(hcalNoiseRatesClient*calotowersDQMClient)
 


### PR DESCRIPTION
Reverts cms-sw/cmssw#7710 - root6 has provided a work around for this issue
