### PR TITLE
Fixed orbit number mask (74X)

### DIFF
--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -31,7 +31,7 @@ namespace evf{
                                    (edm::EventAuxiliary::ExperimentType)(FED_EVTY_EXTRACT(record->getFEDHeader().getData().header.eventid)),
 				   (int)record->getHeader().getData().header.bcid,
 				   edm::EventAuxiliary::invalidStoreNumber,
-				   (int)(orbitnr&0xefffffffU));//framework supports only 32-bit signed
+				   (int)(orbitnr&0x7fffffffU));//framework supports only 32-bit signed
       }
   }
 }


### PR DESCRIPTION
74X port of bugfix in PR #7739 (correct bitmask applied to the the orbit number taken from FED1024 in HLT jobs).
