### PR TITLE
Fix memory leak in ME0SegmentMatcher (again)

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
+++ b/RecoMuon/MuonIdentification/plugins/ME0SegmentMatcher.cc
@@ -81,7 +81,7 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
 
       float zValue = 526.75 * zSign;
 
-      Plane *plane = new Plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
+      Plane plane(Surface::PositionType(0,0,zValue),Surface::RotationType());
 
       //Getting the initial variables for propagation
 
@@ -105,7 +105,7 @@ void ME0SegmentMatcher::produce(edm::Event& ev, const edm::EventSetup& setup) {
       const SteppingHelixPropagator* ThisshProp = 
 	dynamic_cast<const SteppingHelixPropagator*>(&*shProp);
 	
-      lastrecostate = ThisshProp->propagate(startrecostate, *plane);
+      lastrecostate = ThisshProp->propagate(startrecostate, plane);
 	
       FreeTrajectoryState finalrecostate;
       lastrecostate.getFreeState(finalrecostate);


### PR DESCRIPTION
A memory leak was found and fixed in #5210, but later got overwritten by #6585.
More details are on #5210.
