### PR TITLE
Fix memory leak in ME0RecHitProducer

### DIFF
--- a/RecoLocalMuon/GEMRecHit/src/ME0RecHitBaseAlgo.cc
+++ b/RecoLocalMuon/GEMRecHit/src/ME0RecHitBaseAlgo.cc
@@ -34,9 +34,10 @@ const ME0DigiPreRecoCollection::Range& digiRange){
     bool OK = this->compute(*digi, point, tmpErr);
     if (!OK) continue;
 
-    ME0RecHit* recHit = new ME0RecHit(me0Id,digi->tof(),point,tmpErr);
-
-    if (std::abs(digi->pdgid()) == 13) result.push_back(recHit);
+    if (std::abs(digi->pdgid()) == 13) {
+      ME0RecHit* recHit = new ME0RecHit(me0Id,digi->tof(),point,tmpErr);
+      result.push_back(recHit);
+    }
   }
   return result;
 }


### PR DESCRIPTION
Fixes a memory leak in ME0RecHitBaseAlgo, which is called by ME0RecHitProducer.  A product is `new`ed but only added to an `OwnVector` if an `if` condition is met.  If the condition is not met, the memory is leaked.  The effect for ttbar at 200 pileup is about 0.26 Mb an event (see plot).

Plot attached for the memory retained by select modules at 200 pileup.  This pull request _should_ fix the leak shown by the green line "me0RecHits".  Note that this plot also shows a leak for ME0SegmentProducer (light purple line "me0Segments") but I can't find it in the code.  I'll put this pull request in and keep looking.

![potentiallyleakingmodules200pu](https://cloud.githubusercontent.com/assets/6480160/6211110/f0c923be-b5d6-11e4-89d7-19afea21633a.png)
