### PR TITLE
Fix memory leak in MuonTagger

### DIFF
--- a/RecoBTag/SoftLepton/interface/MuonTagger.h
+++ b/RecoBTag/SoftLepton/interface/MuonTagger.h
@@ -5,6 +5,7 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
 #include "RecoBTag/SoftLepton/src/MuonTaggerMLP.h"
+#include "TRandom3.h"
 
 /**  \class MuonTagger
  *
@@ -22,7 +23,8 @@ public:
   /// explicit ctor 
   explicit MuonTagger(const edm::ParameterSet & configuration) : 
     theNet(),
-    m_selector(configuration)
+    m_selector(configuration),
+    randomNumberGenerator_(0)
   { 
     uses("smTagInfos"); 
   }
@@ -38,7 +40,7 @@ private:
   mutable MuonTaggerMLP theNet;
 
   btag::LeptonSelector m_selector;
-
+  mutable TRandom3 randomNumberGenerator_;
 };
 
 #endif // RecoBTag_SoftLepton_MuonTagger_h

--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -15,8 +15,7 @@ float MuonTagger::discriminator(const TagInfoHelper & tagInfo) const {
   for (unsigned int i = 0; i < info.leptons(); i++) {
     const reco::SoftLeptonProperties & properties = info.properties(i);
     if (m_selector(properties)) {
-			TRandom3 *r = new TRandom3(0);
-			float rndm = r->Uniform(0,1);
+			float rndm = randomNumberGenerator_.Uniform(0,1);
 			//for negative tagger, flip 50% of the negative signs to positive value
 			float sip3d = (m_selector.isNegative() && rndm<0.5) ? -properties.sip3d : properties.sip3d;
       float tag = theNet.Value(0, properties.ptRel, sip3d, properties.deltaR, properties.ratioRel);


### PR DESCRIPTION
This pull request was originally to fix a memory leak seen in the JetTagProducer softPFMuonBJetTags when running at 200 pileup, the smallest line seen here (light green):

![potentiallyleakingmodules200pu](https://cloud.githubusercontent.com/assets/6480160/6211110/f0c923be-b5d6-11e4-89d7-19afea21633a.png)

On inspection it looks like the random number generator wasn't behaving as expected though, since it was created new each time with the same seed.  Hence (presumably) that section of code will always give the same random number.  I changed to have it as a member so that the full sequence of numbers would be used.

I've had to add it as a mutable member because the method where it's used is const.  6_2_X_SLHC has no multithreading so this shouldn't be an issue.  In 7_4_X this class appears to have had an overhaul (where incidentally the generator is a member too), so this fix will never go into a multithreaded branch.
