### PR TITLE
Copy back detailed pede exit code file (backport)

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
@@ -31,6 +31,7 @@ clean_up () {
     cp -p *.log.gz $RUNDIR
     cp -p millePedeMonitor*root $RUNDIR
     cp -p millepede.res* $RUNDIR
+    cp -p millepede.end $RUNDIR
     cp -p millepede.his* $RUNDIR
     cp -p *.db $RUNDIR
     exit

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
@@ -190,6 +190,7 @@ ls -lh
 cp -p *.root $RUNDIR
 cp -p *.gz $RUNDIR
 cp -p *.db $RUNDIR
+cp -p *.end $RUNDIR
 
 if [ -f chi2ndfperbinary.eps ]; then
     gzip -f chi2ndfperbinary.eps

--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_save.pl
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_save.pl
@@ -78,7 +78,7 @@ if (@JOBSTATUS[$i] eq "FETCH"
 
   @FILENAMES = ("treeFile_merge.root","histograms_merge.root","millePedeMonitor_merge.root",
 		"alignment_merge.py","alignment.log*","millepede.log*",
-		"millepede.res*","millepede.his*","pede.dump*",
+		"millepede.res*","millepede.his*","pede.dump*", "millepede.end",
 		"alignments_MP.db","pedeSteer*.txt*","theScript.sh");
 
   while ($theFile = shift @FILENAMES) {


### PR DESCRIPTION
Backport of #7758

Changed mps scripts to copy back the millepede.end file. This file contains the detailed exit status of pede, which es very useful for debugging (and would have saved us some time in finding a troublemaker in currently running CRUZET alignment).

This patch needs to be backported to all releases we use in alignment :( ...
