### PR TITLE
Update beampixel_dqm_sourceclient-live_cfg.py

### DIFF
--- a/DQM/Integration/rcms/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/rcms/beampixel_dqm_sourceclient-live_cfg.py
@@ -4,150 +4,190 @@ process = cms.Process("BeamPixel")
 
 
 #----------------------------
-# Event Source
+# Common for PP and HI running
 #----------------------------
 ### @@@@@@ Comment when running locally @@@@@@ ###
 process.load("DQM.Integration.test.inputsource_cfi")
-process.EventStreamHttpReader.consumerName = "Beam Pixel DQM Consumer"
-process.EventStreamHttpReader.SelectEvents = cms.untracked.PSet(SelectEvents = cms.vstring('HLT_L1*','HLT_TrackerCosmics','HLT_Jet*'))
-### @@@@@@ Comment when running locally @@@@@@ ###
 
 
-#----------------------------
-# Filters
 #----------------------------
 # HLT Filter
-process.load("HLTrigger.special.HLTTriggerTypeFilter_cfi")
+#----------------------------
 # 0=random, 1=physics, 2=calibration, 3=technical
-process.hltTriggerTypeFilter.SelectedTriggerType = 1
-process.physicsBitSelector = cms.EDFilter("PhysDecl",
-                                          applyfilter = cms.untracked.bool(True),
-                                          debugOn     = cms.untracked.bool(False))
-# L1 Filter
-process.load("L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMaskTechTrigConfig_cff")
-process.load("HLTrigger.HLTfilters.hltLevel1GTSeed_cfi")
-process.hltLevel1GTSeed.L1TechTriggerSeeding = cms.bool(True)
-process.hltLevel1GTSeed.L1SeedsLogicalExpression = cms.string("0 AND (40 OR 41) AND NOT (36 OR 37 OR 38 OR 39) AND (NOT 42 OR 43) AND (42 OR NOT 43)")
+process.hltTriggerTypeFilter = cms.EDFilter("HLTTriggerTypeFilter",SelectedTriggerType = cms.int32(1))
 
 
 #----------------------------
 # DQM Environment
 #----------------------------
 process.load("DQM.Integration.test.environment_cfi")
-### @@@@@@ Un-comment when running locally @@@@@@ ###
-#process.DQM.collectorHost = ''
-### @@@@@@ Un-comment when running locally @@@@@@ ###
 process.dqmEnv.subSystemFolder = "BeamPixel"
 
 
 #----------------------------
 # Sub-system Configuration
 #----------------------------
-### @@@@@@ Comment when running locally @@@@@@ ###
-process.load("DQM.Integration.test.FrontierCondition_GT_cfi")
-###########################################
-### TEMPORARY: using offline alignments ###
-###########################################
-process.GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_31X_GLOBALTAG"
-process.GlobalTag.globaltag = "GR10_E_V6::All"
-process.GlobalTag.pfnPrefix=cms.untracked.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/")
-### @@@@@@ Comment when running locally @@@@@@ ###
-process.load("FWCore.MessageService.MessageLogger_cfi")
-process.load("Configuration.StandardSequences.Services_cff")
-process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
+process.load("Configuration.StandardSequences.Geometry_cff")
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
 process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
-process.load("Configuration.StandardSequences.Reconstruction_cff")
-process.load("Configuration.StandardSequences.EndOfProcess_cff")
-process.load("Configuration.EventContent.EventContent_cff")
-process.load("RecoTracker.TkTrackingRegions.GlobalTrackingRegion_cfi")
-process.load("RecoVertex.PrimaryVertexProducer.OfflinePixel3DPrimaryVertices_cfi")
-
-
-### @@@@@@ Un-comment when running locally @@@@@@ ###
-#process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-# RECO data taking february 18th 2010
-#process.GlobalTag.globaltag = "GR09_R_35X_V2::All"
-###### Which data ######
-#process.load("DataDec09_RecoMinBias_Feb18th_Skim_Run124120_cff")
-#process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
-###### DQM Saver ######
-#process.dqmSaver.dirName           = cms.untracked.string("/nfshome0/yumiceva/BeamMonitorDQM/")
-#process.dqmSaver.saveAtJobEnd      = cms.untracked.bool(False)
-#process.dqmSaver.saveByTime        = cms.untracked.int32(-1)
-#process.dqmSaver.saveByRun         = cms.untracked.int32(-1)
-#process.dqmSaver.forceRunNumber    = cms.untracked.int32(-1)
-#process.dqmSaver.saveByLumiSection = cms.untracked.int32(-1)
-#process.dqmSaver.saveByMinute      = cms.untracked.int32(-1)
-###### Output file ######
-#process.Output = cms.OutputModule("PoolOutputModule",
-#                                  fileName = cms.untracked.string( "/tmp/dinardo/BeamPixelResults.root" ),
-#                                  outputCommands = cms.untracked.vstring( "drop *",
-#                                                                          "keep *_*_*_BeamPixel"))
-### @@@@@@ Un-comment when running locally @@@@@@ ###
+process.load("DQM.Integration.test.FrontierCondition_GT_cfi")
 
 
 #----------------------------
-# pixelVertexDQM Configuration
+# Define Sequences
 #----------------------------
-process.pixelVertexDQM = cms.EDAnalyzer("Vx3DHLTAnalyzer",
-                                        vertexCollection = cms.InputTag("pixelVertices"),
-                                        debugMode        = cms.bool(True),
-                                        nLumiReset       = cms.uint32(1),
-                                        dataFromFit      = cms.bool(True),
-                                        minNentries      = cms.uint32(35),
-                                        # If the histogram has at least "minNentries" then extract Mean and RMS,
-                                        # or, if we are performing the fit, the number of vertices must be greater
-                                        # than minNentries otherwise it waits for other nLumiReset
-                                        xRange           = cms.double(2.0),
-                                        xStep            = cms.double(0.001),
-                                        yRange           = cms.double(2.0),
-                                        yStep            = cms.double(0.001),
-                                        zRange           = cms.double(30.0),
-                                        zStep            = cms.double(0.05),
-                                        VxErrCorr        = cms.double(1.5),
-                                        fileName         = cms.string("/nfshome0/yumiceva/BeamMonitorDQM/BeamPixelResults.txt"))
-if process.dqmSaver.producer.value() is "Playback":
-  process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt") 
-else:
-  process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt")
+process.dqmmodules  = cms.Sequence(process.dqmEnv + process.dqmSaver)
+process.phystrigger = cms.Sequence(process.hltTriggerTypeFilter)
+
+
 
 
 #----------------------------
-# Pixel-Tracks Configuration
+# Proton-Proton Specific Part
 #----------------------------
-process.PixelTrackReconstructionBlock.RegionFactoryPSet.ComponentName = "GlobalRegionProducer"
+if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.hpu_run):
+    print "[beampixel_dqm_sourceclient-live_cfg]::running pp"
+
+    process.castorDigis.InputLabel           = cms.InputTag("rawDataCollector")
+    process.csctfDigis.producer              = cms.InputTag("rawDataCollector")
+    process.dttfDigis.DTTF_FED_Source        = cms.InputTag("rawDataCollector")
+    process.ecalDigis.InputLabel             = cms.InputTag("rawDataCollector")
+    process.ecalPreshowerDigis.sourceTag     = cms.InputTag("rawDataCollector")
+    process.gctDigis.inputLabel              = cms.InputTag("rawDataCollector")
+    process.gtDigis.DaqGtInputTag            = cms.InputTag("rawDataCollector")
+    process.gtEvmDigis.EvmGtInputTag         = cms.InputTag("rawDataCollector")
+    process.hcalDigis.InputLabel             = cms.InputTag("rawDataCollector")
+    process.muonCSCDigis.InputObjects        = cms.InputTag("rawDataCollector")
+    process.muonDTDigis.inputLabel           = cms.InputTag("rawDataCollector")
+    process.muonRPCDigis.InputLabel          = cms.InputTag("rawDataCollector")
+    process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataCollector")
+    process.siPixelDigis.InputLabel          = cms.InputTag("rawDataCollector")
+    process.siStripDigis.ProductLabel        = cms.InputTag("rawDataCollector")
+
+    process.load("Configuration.StandardSequences.Reconstruction_cff")
+
+
+    #----------------------------
+    # pixelVertexDQM Configuration
+    #----------------------------
+    process.pixelVertexDQM = cms.EDAnalyzer("Vx3DHLTAnalyzer",
+                                            vertexCollection   = cms.untracked.InputTag("pixelVertices"),
+                                            pixelHitCollection = cms.untracked.InputTag("siPixelRecHits"),
+                                            debugMode          = cms.bool(True),
+                                            nLumiReset         = cms.uint32(2),
+                                            dataFromFit        = cms.bool(True),
+                                            minNentries        = cms.uint32(20),
+                                            # If the histogram has at least "minNentries" then extract Mean and RMS,
+                                            # or, if we are performing the fit, the number of vertices must be greater
+                                            # than minNentries otherwise it waits for other nLumiReset
+                                            xRange             = cms.double(2.0),
+                                            xStep              = cms.double(0.001),
+                                            yRange             = cms.double(2.0),
+                                            yStep              = cms.double(0.001),
+                                            zRange             = cms.double(30.0),
+                                            zStep              = cms.double(0.05),
+                                            VxErrCorr          = cms.double(1.3), # Keep checking this with later release
+                                            fileName           = cms.string("/nfshome0/yumiceva/BeamMonitorDQM/BeamPixelResults.txt"))
+    if process.dqmSaver.producer.value() is "Playback":
+       process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
+    else:
+       process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt")
+
+
+    #----------------------------
+    # Pixel-Tracks Configuration
+    #----------------------------
+    process.pixelVertices.TkFilterParameters.minPt = process.pixelTracks.RegionFactoryPSet.RegionPSet.ptMin
+
+
+    #----------------------------
+    # Pixel-Vertices Configuration
+    #----------------------------
+    process.reconstruction_step = cms.Sequence(process.siPixelDigis*
+                                               process.offlineBeamSpot*
+                                               process.siPixelClusters*
+                                               process.siPixelRecHits*
+                                               process.siPixelClusterShapeCache*
+                                               process.PixelLayerTriplets*
+                                               process.pixelTracks*
+                                               process.pixelVertices)
+
+
+    #----------------------------
+    # Define Path
+    #----------------------------
+    process.p = cms.Path(process.phystrigger*process.reconstruction_step*process.pixelVertexDQM*process.dqmmodules)
+
+
 
 
 #----------------------------
-# Pixel-Vertices Configuration
+# Heavy Ion Specific Part
 #----------------------------
-process.pixelVertices.useBeamConstraint = False
-process.pixelVertices.TkFilterParameters.minPt = process.pixelTracks.RegionFactoryPSet.RegionPSet.ptMin
+if (process.runType.getRunType() == process.runType.hi_run):
+    print "[beampixel_dqm_sourceclient-live_cfg]::running HI"
+
+    process.castorDigis.InputLabel           = cms.InputTag("rawDataRepacker")
+    process.csctfDigis.producer              = cms.InputTag("rawDataRepacker")
+    process.dttfDigis.DTTF_FED_Source        = cms.InputTag("rawDataRepacker")
+    process.ecalDigis.InputLabel             = cms.InputTag("rawDataRepacker")
+    process.ecalPreshowerDigis.sourceTag     = cms.InputTag("rawDataRepacker")
+    process.gctDigis.inputLabel              = cms.InputTag("rawDataRepacker")
+    process.gtDigis.DaqGtInputTag            = cms.InputTag("rawDataRepacker")
+    process.gtEvmDigis.EvmGtInputTag         = cms.InputTag("rawDataRepacker")
+    process.hcalDigis.InputLabel             = cms.InputTag("rawDataRepacker")
+    process.muonCSCDigis.InputObjects        = cms.InputTag("rawDataRepacker")
+    process.muonDTDigis.inputLabel           = cms.InputTag("rawDataRepacker")
+    process.muonRPCDigis.InputLabel          = cms.InputTag("rawDataRepacker")
+    process.scalersRawToDigi.scalersInputTag = cms.InputTag("rawDataRepacker")
+    process.siPixelDigis.InputLabel          = cms.InputTag("rawDataRepacker")
+    process.siStripDigis.ProductLabel        = cms.InputTag("rawDataRepacker")
+
+    process.load("Configuration.StandardSequences.ReconstructionHeavyIons_cff")
 
 
-#----------------------------
-# Define Sequence
-#----------------------------
-process.dqmmodules = cms.Sequence(process.dqmEnv + process.dqmSaver)
+    #----------------------------
+    # pixelVertexDQM Configuration
+    #----------------------------
+    process.pixelVertexDQM = cms.EDAnalyzer("Vx3DHLTAnalyzer",
+                                            vertexCollection   = cms.untracked.InputTag("hiSelectedVertex"),
+                                            pixelHitCollection = cms.untracked.InputTag("siPixelRecHits"),
+                                            debugMode          = cms.bool(True),
+                                            nLumiReset         = cms.uint32(5),
+                                            dataFromFit        = cms.bool(True),
+                                            minNentries        = cms.uint32(20),
+                                            # If the histogram has at least "minNentries" then extract Mean and RMS,
+                                            # or, if we are performing the fit, the number of vertices must be greater
+                                            # than minNentries otherwise it waits for other nLumiReset
+                                            xRange             = cms.double(2.0),
+                                            xStep              = cms.double(0.001),
+                                            yRange             = cms.double(2.0),
+                                            yStep              = cms.double(0.001),
+                                            zRange             = cms.double(30.0),
+                                            zStep              = cms.double(0.05),
+                                            VxErrCorr          = cms.double(1.3), # Keep checking this with later release
+                                            fileName           = cms.string("/nfshome0/yumiceva/BeamMonitorDQM/BeamPixelResults.txt"))
+    if process.dqmSaver.producer.value() is "Playback":
+       process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmdev/BeamMonitorDQM/BeamPixelResults.txt")
+    else:
+       process.pixelVertexDQM.fileName = cms.string("/nfshome0/dqmpro/BeamMonitorDQM/BeamPixelResults.txt")
 
-process.phystrigger = cms.Sequence(
-  process.hltTriggerTypeFilter
-#  process.gtDigis*
-#  process.hltLevel1GTSeed
-  )
 
-process.reconstruction_step = cms.Sequence(
-    process.siPixelDigis*
-    process.offlineBeamSpot*
-    process.siPixelClusters*
-    process.siPixelRecHits*
-    process.pixelTracks*
-    process.pixelVertices*
-    process.pixelVertexDQM)
+    #----------------------------
+    # Pixel-Vertices Configuration
+    #----------------------------
+    process.reconstruction_step = cms.Sequence(process.siPixelDigis*
+                                               process.offlineBeamSpot*
+                                               process.siPixelClusters*
+                                               process.siPixelRecHits*
+                                               process.siPixelClusterShapeCache*
+                                               process.PixelLayerTriplets*
+                                               process.pixelTracks*
+                                               process.pixelVertices)
 
 
-#----------------------------
-# Define Path
-#----------------------------
-process.p = cms.Path(process.phystrigger * process.reconstruction_step * process.dqmmodules)
+    #----------------------------
+    # Define Path
+    #----------------------------
+    process.p = cms.Path(process.phystrigger*process.reconstruction_step*process.pixelVertexDQM*process.dqmmodules)
+    


### PR DESCRIPTION
Re-establish configuration simular to Run-1: distinguishing between pp and HI collisions.
I don't know why it was modified in the way it is. Maybe there is as good reason but as I don't know it.
Automatically ported from CMSSW_7_4_X #7757
