### PR TITLE
Made FFTJetCorrector thread safe

### DIFF
--- a/JetMETCorrections/FFTJetModules/interface/FFTJetESParameterParser.h
+++ b/JetMETCorrections/FFTJetModules/interface/FFTJetESParameterParser.h
@@ -102,14 +102,14 @@ Corrector parseFFTJetCorrector(const edm::ParameterSet& ps,
 
     // "adjuster" is a PSet
     const edm::ParameterSet& adjuster = ps.getParameter<edm::ParameterSet>("adjuster");
-    boost::shared_ptr<AbsFFTJetAdjuster<MyJet,Adjustable> > adj = 
+    boost::shared_ptr<const AbsFFTJetAdjuster<MyJet,Adjustable> > adj = 
         parseFFTJetAdjuster<MyJet,Adjustable>(adjuster, verbose);
 
     // "scalers" is a VPSet
     const std::vector<edm::ParameterSet>& scalers = 
         ps.getParameter<std::vector<edm::ParameterSet> >("scalers");
     const unsigned nScalers = scalers.size();
-    std::vector<boost::shared_ptr<AbsFFTJetScaleCalculator<MyJet,Adjustable> > > sVec;
+    std::vector<boost::shared_ptr<const AbsFFTJetScaleCalculator<MyJet,Adjustable> > > sVec;
     sVec.reserve(nScalers);
     for (unsigned i=0; i<nScalers; ++i)
     {


### PR DESCRIPTION
The FFTJetCorrector is accessible via the EventSetup and therefore
all its const methods must be thread safe. Previously, the const
method 'correct' was using a member data for a temporary buffer
which was being changes on each call to 'correct'. To make the
routine thread safe we now use a buffer on the stack if only a small
buffer is needed and use a std::vector if a larger buffer is needed.

This problem was caught by the static analyzer.
Automatically ported from CMSSW_7_4_X #7682
