### PR TITLE
Disable SingleJet HLT validation for HI to prevent crashes

### DIFF
--- a/Validation/RecoHI/python/HLTValidationHeavyIons_cff.py
+++ b/Validation/RecoHI/python/HLTValidationHeavyIons_cff.py
@@ -8,3 +8,5 @@ hltPrevalidationHI = cms.Sequence( hiEgammaPrevalidationSequence )
 hltValidationHI = cms.Sequence(hiSingleJetValidation
                                + hiEgammaValidationSequence
                                )
+
+hltValidationHI.remove(hiSingleJetValidation)


### PR DESCRIPTION
The HI RelVal workflows (for instance, 140.2) crash in CMSSW_7_4_0_pre7:

%MSG-e FatalSystemSignal:  HLTJetMETValidation:SingleJetPathVal35  17-Feb-2015 13:26:10 CET Run: 1 Event: 1
A fatal system signal has occurred: segmentation violation
%MSG

After a discussion with the HLT Jet developers in HIN, it turns out that the sequence causing the crash could be simply disabled for the time being, the HI Jet triggers are actively being re-worked for this year's PbPb run.

@BetterWang, @yetkinyilmaz, and @richard-cms probably want to follow this PR.
