### PR TITLE
Add new eras to support different Run 2 configurations

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -243,22 +243,21 @@ def OptionsFromItems(items):
         from FWCore.ParameterSet.Config import Modifier, ModifierChain
         # Split the string by commas to check individual eras
         requestedEras = options.era.split(",")
-        # Warn the user if they are explicitly setting an era that should be set automatically by the
-        # ConfigBuilder.
-        internalUseEras=["bunchspacing25ns","bunchspacing50ns"]
-        for era in internalUseEras :
-            if requestedEras.count(era) > 0 :
-                print "WARNING: You have explicitly set '"+era+"' with the '--era' command. It is advised that you let ConfigBuilder decide whether to add that or not."
         # Check that the entry is a valid era
-        for era in requestedEras :
-            if not hasattr( eras, era ) : # Not valid, so print a helpful message
+        for eraName in requestedEras :
+            if not hasattr( eras, eraName ) : # Not valid, so print a helpful message
                 validOptions="" # Create a stringified list of valid options to print to the user
                 for key in eras.__dict__ :
-                    if internalUseEras.count(key) > 0 : continue # Don't tell the user about things they should leave alone
+                    if eras.internalUseEras.count(getattr(eras,key)) > 0 : continue # Don't tell the user about things they should leave alone
                     if isinstance( eras.__dict__[key], Modifier ) or isinstance( eras.__dict__[key], ModifierChain ) :
                         if validOptions!="" : validOptions+=", " 
                         validOptions+="'"+key+"'"
-                raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (era, validOptions) )
+                raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (eraName, validOptions) )
+        # Warn the user if they are explicitly setting an era that should be
+        # set automatically by the ConfigBuilder.
+        for eraName in requestedEras : # Same loop, but had to make sure all the names existed first
+            if eras.internalUseEras.count(getattr(eras,eraName)) > 0 :
+                print "WARNING: You have explicitly set '"+eraName+"' with the '--era' command. That is usually reserved for internal use only."
 
     return options
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,5 +21,14 @@ class Eras (object):
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
         self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
+        
+        # The only thing this collection is used for is for cmsDriver to
+        # warn the user if they specify an era that is discouraged from being
+        # set directly. It also stops these eras being printed in the error
+        # message of available values when an invalid era is specified.
+        self.internalUseEras = [self.bunchspacing25ns, self.bunchspacing50ns,
+                                self.run2_common, self.run2_25ns_specific,
+                                self.run2_50ns_specific, self.run2_HI_specific,
+                                self.stage1L1Trigger]
 
 eras=Eras()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -10,4 +10,16 @@ class Eras (object):
         self.bunchspacing25ns = cms.Modifier()
         self.bunchspacing50ns = cms.Modifier()
 
+        # These eras should not be set directly by the user.
+        self.run2_common = cms.Modifier()
+        self.run2_25ns_specific = cms.Modifier()
+        self.run2_50ns_specific = cms.Modifier()
+        self.run2_HI_specific = cms.Modifier()
+        self.stage1L1Trigger = cms.Modifier()
+        
+        # These are the eras that the user should specify
+        self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
+        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
+        self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
+
 eras=Eras()


### PR DESCRIPTION
This creates new sub-eras to aid with the Run 2 divergence between 25ns, 50ns and HI.  The user will specify one of `Run2_25ns`, `Run2_50ns` or `Run2_HI` (as discussed in the 17th Feb ORP) but these are actually chains of the new modifiers created here.

I also changed the way cmsDriver checks whether one of the eras specified is one of the internal use sub-eras, so that it can warn the user.

**I propose getting rid of the eras `run2`, `bunchspacing25ns` and `bunchspacing50ns`**, but this isn't done in this pull request.  Everything so far configured as `run2` will be changed to `run2_common` which is added here, then `run2` removed.  This will be a big (but simple) change in many packages so I wanted this idea reviewed here first.  The bunchspacing ones will be changed to `run2_25ns_specific` or `run2_50ns_specific` then removed.

Current road map for eras is a bit different to that discussed in the 17th Feb ORP:
- This pull request
- Change all `run2` modifications to `run2_common` and remove `run2` [EDIT implemented in #7841]
- L1 trigger changes (the 1 pull request mentioned in the ORP) [EDIT implemented in #7860]
- potentially another L1T for FastSim pull request, once I get an answer to a question
- Validation, then any pull requests to fix errors found

@fwyzard, you asked to be kept informed
@Dr15Jones, in case you have any comments on the choice of chaining
