### PR TITLE
Added handling of special case of OTMB corrupted data to the CSC binary examiner (74X port)

### DIFF
--- a/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDCCExaminer.cc
@@ -822,6 +822,17 @@ int32_t CSCDCCExaminer::check(const uint16_t* &buffer, int32_t length)
 
       if( (buf0[0]&0xFFFF)==0xDB0C )
         {
+
+	  // =VB= Handles one of the OTMB corrupted data cases.
+	  //      Double TMB data block with 2nd TMB Header is found. 
+	  //      Set missing TMB Trailer error.
+	  if (fTMB_Header) {
+             fERROR[12]=true;        // TMB Trailer is missing
+             bERROR   |= 0x1000;
+             fCHAMB_ERR[12].insert(currentChamber);
+             bCHAMB_ERR[currentChamber] |= 0x1000;
+          }
+
           fTMB_Header              = true;
           fTMB_Format2007          = true;
           TMB_CRC                  = 0;


### PR DESCRIPTION
Added handling of special case of OTMB corrupted data to the CSC binary Examiner as part of the CSC Unpacker (port to 74X of  #7829).
- The issue was reported by RECO developers during processing of PromptReco MinimumBias job with the release CMSSW_7_3_2_patch1
- The assertion was triggered in CSC unpacker code for Run 234107 MinimumBias data
- Was caused by special case of corrupted data from OTMB board, which wasn't marked as bad by the CSC examiner
- Current fix is to detect and mark such data as bad and then reject such bad events from further unpacking
