### PR TITLE
Move run2 era to run2_common

### DIFF
--- a/CalibMuon/CSCCalibration/python/CSCChannelMapper_cfi.py
+++ b/CalibMuon/CSCCalibration/python/CSCChannelMapper_cfi.py
@@ -13,4 +13,4 @@ CSCChannelMapperESProducer = cms.ESProducer("CSCChannelMapperESProducer",
 # Modify for running in run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( CSCChannelMapperESProducer, AlgoName=cms.string("CSCChannelMapperPostls1") )
+eras.run2_common.toModify( CSCChannelMapperESProducer, AlgoName=cms.string("CSCChannelMapperPostls1") )

--- a/CalibMuon/CSCCalibration/python/CSCIndexer_cfi.py
+++ b/CalibMuon/CSCCalibration/python/CSCIndexer_cfi.py
@@ -13,4 +13,4 @@ CSCIndexerESProducer = cms.ESProducer("CSCIndexerESProducer",
 # Modify for running in run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( CSCIndexerESProducer, AlgoName=cms.string("CSCIndexerPostls1") )
+eras.run2_common.toModify( CSCIndexerESProducer, AlgoName=cms.string("CSCIndexerPostls1") )

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -243,22 +243,21 @@ def OptionsFromItems(items):
         from FWCore.ParameterSet.Config import Modifier, ModifierChain
         # Split the string by commas to check individual eras
         requestedEras = options.era.split(",")
-        # Warn the user if they are explicitly setting an era that should be set automatically by the
-        # ConfigBuilder.
-        internalUseEras=["bunchspacing25ns","bunchspacing50ns"]
-        for era in internalUseEras :
-            if requestedEras.count(era) > 0 :
-                print "WARNING: You have explicitly set '"+era+"' with the '--era' command. It is advised that you let ConfigBuilder decide whether to add that or not."
         # Check that the entry is a valid era
-        for era in requestedEras :
-            if not hasattr( eras, era ) : # Not valid, so print a helpful message
+        for eraName in requestedEras :
+            if not hasattr( eras, eraName ) : # Not valid, so print a helpful message
                 validOptions="" # Create a stringified list of valid options to print to the user
                 for key in eras.__dict__ :
-                    if internalUseEras.count(key) > 0 : continue # Don't tell the user about things they should leave alone
+                    if eras.internalUseEras.count(getattr(eras,key)) > 0 : continue # Don't tell the user about things they should leave alone
                     if isinstance( eras.__dict__[key], Modifier ) or isinstance( eras.__dict__[key], ModifierChain ) :
                         if validOptions!="" : validOptions+=", " 
                         validOptions+="'"+key+"'"
-                raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (era, validOptions) )
+                raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (eraName, validOptions) )
+        # Warn the user if they are explicitly setting an era that should be
+        # set automatically by the ConfigBuilder.
+        for eraName in requestedEras : # Same loop, but had to make sure all the names existed first
+            if eras.internalUseEras.count(getattr(eras,eraName)) > 0 :
+                print "WARNING: You have explicitly set '"+eraName+"' with the '--era' command. That is usually reserved for internal use only."
 
     return options
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,5 +21,14 @@ class Eras (object):
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
         self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
+        
+        # The only thing this collection is used for is for cmsDriver to
+        # warn the user if they specify an era that is discouraged from being
+        # set directly. It also stops these eras being printed in the error
+        # message of available values when an invalid era is specified.
+        self.internalUseEras = [self.bunchspacing25ns, self.bunchspacing50ns,
+                                self.run2_common, self.run2_25ns_specific,
+                                self.run2_50ns_specific, self.run2_HI_specific,
+                                self.stage1L1Trigger]
 
 eras=Eras()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -6,7 +6,6 @@ class Eras (object):
     can use to selectively configure depending on what scenario is active.
     """
     def __init__(self):
-        self.run2 = cms.Modifier()
         self.bunchspacing25ns = cms.Modifier()
         self.bunchspacing50ns = cms.Modifier()
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -10,4 +10,16 @@ class Eras (object):
         self.bunchspacing25ns = cms.Modifier()
         self.bunchspacing50ns = cms.Modifier()
 
+        # These eras should not be set directly by the user.
+        self.run2_common = cms.Modifier()
+        self.run2_25ns_specific = cms.Modifier()
+        self.run2_50ns_specific = cms.Modifier()
+        self.run2_HI_specific = cms.Modifier()
+        self.stage1L1Trigger = cms.Modifier()
+        
+        # These are the eras that the user should specify
+        self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
+        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
+        self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
+
 eras=Eras()

--- a/DQM/L1TMonitor/python/L1TCSCTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TCSCTF_cfi.py
@@ -18,4 +18,4 @@ l1tCsctf = cms.EDAnalyzer("L1TCSCTF",
 # Make changes for running in Run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( l1tCsctf, gangedME11a = False )
+eras.run2_common.toModify( l1tCsctf, gangedME11a = False )

--- a/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
+++ b/EventFilter/CSCRawToDigi/python/cscPacker_cfi.py
@@ -23,6 +23,6 @@ cscpacker = cms.EDProducer("CSCDigiToRawModule",
 ##
 from Configuration.StandardSequences.Eras import eras
 # packer - simply get rid of it
-eras.run2.toModify( cscpacker, useFormatVersion = cms.uint32(2013) )
-eras.run2.toModify( cscpacker, usePreTriggers = cms.bool(False) )
-eras.run2.toModify( cscpacker, packEverything = cms.bool(True) )
+eras.run2_common.toModify( cscpacker, useFormatVersion = cms.uint32(2013) )
+eras.run2_common.toModify( cscpacker, usePreTriggers = cms.bool(False) )
+eras.run2_common.toModify( cscpacker, packEverything = cms.bool(True) )

--- a/FastSimulation/Calorimetry/python/Calorimetry_cff.py
+++ b/FastSimulation/Calorimetry/python/Calorimetry_cff.py
@@ -294,4 +294,4 @@ FamosCalorimetryBlock.Calorimetry.HCAL.Digitizer = True
 #
 # Modify for running in Run 2
 #
-eras.run2.toModify( FamosCalorimetryBlock.Calorimetry.HFShowerLibrary, useShowerLibrary=True )
+eras.run2_common.toModify( FamosCalorimetryBlock.Calorimetry.HFShowerLibrary, useShowerLibrary=True )

--- a/FastSimulation/Event/python/ParticleFilter_cfi.py
+++ b/FastSimulation/Event/python/ParticleFilter_cfi.py
@@ -18,5 +18,5 @@ ParticleFilterBlock = cms.PSet(
 # Modify for running in Run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( ParticleFilterBlock.ParticleFilter, pTMin = 0.1 )
-eras.run2.toModify( ParticleFilterBlock.ParticleFilter, etaMax = 5.300 )
+eras.run2_common.toModify( ParticleFilterBlock.ParticleFilter, pTMin = 0.1 )
+eras.run2_common.toModify( ParticleFilterBlock.ParticleFilter, etaMax = 5.300 )

--- a/FastSimulation/PileUpProducer/python/PileUpFiles_cff.py
+++ b/FastSimulation/PileUpProducer/python/PileUpFiles_cff.py
@@ -71,5 +71,5 @@ puFileNames = cms.PSet(fileNames = puFileNames_8TeV)
 # Modify for running in Run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify(puFileNames,fileNames=puFileNames_13TeV)
+eras.run2_common.toModify(puFileNames,fileNames=puFileNames_13TeV)
 

--- a/FastSimulation/TrajectoryManager/python/TrackerSimHits_cfi.py
+++ b/FastSimulation/TrajectoryManager/python/TrackerSimHits_cfi.py
@@ -13,4 +13,4 @@ TrackerSimHitsBlock = cms.PSet(
 # Modify for running in Run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( TrackerSimHitsBlock.TrackerSimHits, pTmin = 0.1 )
+eras.run2_common.toModify( TrackerSimHitsBlock.TrackerSimHits, pTmin = 0.1 )

--- a/Geometry/CSCGeometryBuilder/python/cscGeometryDB_cfi.py
+++ b/Geometry/CSCGeometryBuilder/python/cscGeometryDB_cfi.py
@@ -22,4 +22,4 @@ CSCGeometryESModule = cms.ESProducer("CSCGeometryESModule",
 # Modify for running in run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( CSCGeometryESModule, useGangedStripsInME1a=False )
+eras.run2_common.toModify( CSCGeometryESModule, useGangedStripsInME1a=False )

--- a/Geometry/CSCGeometryBuilder/python/cscGeometry_cfi.py
+++ b/Geometry/CSCGeometryBuilder/python/cscGeometry_cfi.py
@@ -22,4 +22,4 @@ CSCGeometryESModule = cms.ESProducer("CSCGeometryESModule",
 # Modify for running in run 2
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( CSCGeometryESModule, useGangedStripsInME1a=False )
+eras.run2_common.toModify( CSCGeometryESModule, useGangedStripsInME1a=False )

--- a/L1Trigger/CSCTrackFinder/python/csctfTrackDigis_cfi.py
+++ b/L1Trigger/CSCTrackFinder/python/csctfTrackDigis_cfi.py
@@ -127,5 +127,5 @@ csctfTrackDigis = cms.EDProducer("CSCTFTrackProducer",
 # If the run2 era is active, make the required changes
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( csctfTrackDigis, _modifyCsctfTrackDigisForRun2 )
+eras.run2_common.toModify( csctfTrackDigis, _modifyCsctfTrackDigisForRun2 )
 

--- a/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
+++ b/L1Trigger/CSCTriggerPrimitives/python/cscTriggerPrimitiveDigis_cfi.py
@@ -338,4 +338,4 @@ cscTriggerPrimitiveDigis = cms.EDProducer("CSCTriggerPrimitivesProducer",
 # If the run2 era is active, make the required changes
 #
 from Configuration.StandardSequences.Eras import eras
-eras.run2.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2 )
+eras.run2_common.toModify( cscTriggerPrimitiveDigis, _modifyCscTriggerPrimitiveDigisForRun2 )

--- a/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
+++ b/RecoLocalMuon/CSCRecHitD/python/cscRecHitD_cfi.py
@@ -66,6 +66,6 @@ csc2DRecHits = cms.EDProducer("CSCRecHitDProducer",
 ##
 ## Modify for running in Run 2
 ##
-eras.run2.toModify( csc2DRecHits, readBadChannels = False )
-eras.run2.toModify( csc2DRecHits, CSCUseGasGainCorrections = False )
+eras.run2_common.toModify( csc2DRecHits, readBadChannels = False )
+eras.run2_common.toModify( csc2DRecHits, CSCUseGasGainCorrections = False )
 

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterHO_cfi.py
@@ -106,4 +106,4 @@ def _modifyParticleFlowClusterHOForRun2( object ) :
     object.pfClusterBuilder.allCellsPositionCalc.logWeightDenominator = cms.double(0.05)
 
 # Call the function above to modify particleFlowClusterHO only if the run2 era is active
-eras.run2.toModify( particleFlowClusterHO, func=_modifyParticleFlowClusterHOForRun2 )
+eras.run2_common.toModify( particleFlowClusterHO, func=_modifyParticleFlowClusterHOForRun2 )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHO_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitHO_cfi.py
@@ -53,4 +53,4 @@ def _modifyParticleFlowRecHitHOForRun2( object ) :
             )
         )
 
-eras.run2.toModify( particleFlowRecHitHO, func=_modifyParticleFlowRecHitHOForRun2 )
+eras.run2_common.toModify( particleFlowRecHitHO, func=_modifyParticleFlowRecHitHOForRun2 )

--- a/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
+++ b/SimCalorimetry/Configuration/python/SimCalorimetry_EventContent_cff.py
@@ -26,5 +26,5 @@ SimCalorimetryAOD = cms.PSet(
 #
 # Add extra event content if running in Run 2
 #
-eras.run2.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
-eras.run2.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
+eras.run2_common.toModify( SimCalorimetryFEVTDEBUG.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )
+eras.run2_common.toModify( SimCalorimetryRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simHcalUnsuppressedDigis_*_*') )

--- a/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
+++ b/SimCalorimetry/HcalSimProducers/python/hcalSimParameters_cfi.py
@@ -115,4 +115,4 @@ def _modifyHcalSimParametersForPostLS1( object ) :
     object.hf1.samplingFactor = cms.double(0.60)
     object.hf2.samplingFactor = cms.double(0.60)
 
-eras.run2.toModify( hcalSimParameters, func=_modifyHcalSimParametersForPostLS1 )
+eras.run2_common.toModify( hcalSimParameters, func=_modifyHcalSimParametersForPostLS1 )

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -418,4 +418,4 @@ g4SimHits = cms.EDProducer("OscarProducer",
 ##
 ## Change the HFShowerLibrary file used for Run 2
 ##
-eras.run2.toModify( g4SimHits.HFShowerLibrary, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v3.root' )
+eras.run2_common.toModify( g4SimHits.HFShowerLibrary, FileName = 'SimG4CMS/Calo/data/HFShowerLibrary_npmt_noatt_eta4_16en_v3.root' )

--- a/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pixelDigitizer_cfi.py
@@ -338,7 +338,7 @@ def _modifyPixelDigitizerForRun2( digitiserInstance ) :
     elif eras.bunchspacing50ns.isChosen() :
         modifyPixelDigitizerForRun2Bunchspacing50( digitiserInstance )
 
-eras.run2.toModify( pixelDigitizer, func=_modifyPixelDigitizerForRun2 )
+eras.run2_common.toModify( pixelDigitizer, func=_modifyPixelDigitizerForRun2 )
 
 
 # Threshold in electrons are the Official CRAFT09 numbers:

--- a/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
+++ b/SimMuon/CSCDigitizer/python/muonCSCDigis_cfi.py
@@ -84,6 +84,6 @@ simMuonCSCDigis = cms.EDProducer("CSCDigiProducer",
 ##
 ## Change the the bunch timing offsets if running in Run 2
 ##
-eras.run2.toModify( simMuonCSCDigis.strips, bunchTimingOffsets=[0.0, 37.53, 37.66, 55.4, 48.2, 54.45, 53.78, 53.38, 54.12, 51.98, 51.28] )
-eras.run2.toModify( simMuonCSCDigis.wires, bunchTimingOffsets=[0.0, 22.88, 22.55, 29.28, 30.0, 30.0, 30.5, 31.0, 29.5, 29.1, 29.88] )
+eras.run2_common.toModify( simMuonCSCDigis.strips, bunchTimingOffsets=[0.0, 37.53, 37.66, 55.4, 48.2, 54.45, 53.78, 53.38, 54.12, 51.98, 51.28] )
+eras.run2_common.toModify( simMuonCSCDigis.wires, bunchTimingOffsets=[0.0, 22.88, 22.55, 29.28, 30.0, 30.0, 30.5, 31.0, 29.5, 29.1, 29.88] )
 

--- a/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
+++ b/SimMuon/Configuration/python/SimMuon_EventContent_cff.py
@@ -25,8 +25,8 @@ SimMuonRAW = cms.PSet(
 # Add extra collections if running in Run 2. Not sure why but these
 # collections were added to pretty much all event content in the old
 # customisation function.
-eras.run2.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonCSCDigis_*_*') )
-eras.run2.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonRPCDigis_*_*') )
+eras.run2_common.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonCSCDigis_*_*') )
+eras.run2_common.toModify( SimMuonRAW.outputCommands, func=lambda outputCommands: outputCommands.append('keep *_simMuonRPCDigis_*_*') )
 
 #RECO content
 SimMuonRECO = cms.PSet(


### PR DESCRIPTION
This is on top of #7839 which is most of the changes, so I guess most of the discussion should be on there.

I put this in a separate pull request so that the changes are clear (although at the moment the #7839 changes are also shown here).  This pull request changes all of the `run2` era modifications to `run2_common` then removes the `run2` era.  Users should specify `Run2_25ns`, `Run2_50ns` or `Run2_HI` instead, all of which include any `run2_common` changes.

This touches a lot of packages but the changes are trivial.
