### PR TITLE
avoid propagation of muons with zero momentum (fwd port of #7849 )

### DIFF
--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonSmoother.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonSmoother.cc
@@ -177,11 +177,15 @@ vector<Trajectory> CosmicMuonSmoother::fit(const TrajectorySeed& seed,
       LogTrace(category_)<< "Error: invalid hit.";
       continue;
     }
-   if (currTsos.isValid())  {
+    if (currTsos.isValid() && currTsos.globalMomentum().mag2() > 1e-18f)  {
      LogTrace(category_)<<"current pos "<<currTsos.globalPosition()
                        <<"mom "<<currTsos.globalMomentum();
     } else {
-      LogTrace(category_)<<"current state invalid";
+      LogTrace(category_)<<"current state invalid or momentum is too low";
+      //logically, there's no way out: can't expect a valid result out of an invalid state
+      LogTrace(category_)
+	<<"Input state is not valid. This loop over hits is doomed: breaking out";
+      break;
     }
 
     predTsos = propagatorAlong()->propagate(currTsos, (**ihit).det()->surface());

--- a/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
+++ b/TrackPropagation/SteppingHelixPropagator/src/SteppingHelixPropagator.cc
@@ -689,6 +689,11 @@ void SteppingHelixPropagator::loadState(SteppingHelixPropagator::StateInfo& svCu
     svCurrent.isValid_ = false;
     return;
   }
+  if (pmag2 < 1e-18f ) {
+    LogTrace(metname)<<"Initial momentum is too low";
+    svCurrent.isValid_ = false;
+    return;
+  }
   if (! (gpmag == gpmag) ) {
     LogTrace(metname)<<"Initial point is a nan";
     edm::LogWarning("SteppingHelixPropagatorNAN")<<"Initial point is a nan";


### PR DESCRIPTION
From #7849:
This fixes a crash reported in express in 732patch2 in run 234542.
The condition is fairly rare and has numerical precision/randomness nature.

The same change in code was tested in CMSSW_7_3_2_patch2 /test area crash732p2a-234542/
extended reco tests show no differences in monitored quantities.
The crash itself is gone.

this uses the same topic branch as #7850 
