### PR TITLE
Fix typo in DQMHelper

### DIFF
--- a/Validation/EventGenerator/src/DQMHelper.cc
+++ b/Validation/EventGenerator/src/DQMHelper.cc
@@ -10,13 +10,13 @@ DQMHelper::~DQMHelper(){
 }
 
 MonitorElement* DQMHelper::book1dHisto(const std::string &name,const std::string &title,int n,double xmin,double xmax){
-  MonitorElement* dqm=ibooker->book1D(name,title,n,xmax,xmax);
+  MonitorElement* dqm=ibooker->book1D(name,title,n,xmin,xmax);
   dqm->getTH1()->Sumw2();
   return dqm;
 }
 
 MonitorElement* DQMHelper::book2dHisto(const std::string &name,const std::string &title,int nx,double xmin,double xmax,int ny,double ymin,double ymax){
-  MonitorElement* dqm=ibooker->book2D(name,title,nx,xmax,xmax,ny,ymax,ymax);
+  MonitorElement* dqm=ibooker->book2D(name,title,nx,xmin,xmax,ny,ymin,ymax);
   dqm->getTH1()->Sumw2();
   return dqm;
 }


### PR DESCRIPTION
The DQMHelper was using xmax instead of xmin so that the histograms
had no range. This lead to failures when the DQMStore tried to merge
histograms while running in the threaded framework.
