### PR TITLE
Add L1 trigger changes to the Run 2 eras

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -243,22 +243,21 @@ def OptionsFromItems(items):
         from FWCore.ParameterSet.Config import Modifier, ModifierChain
         # Split the string by commas to check individual eras
         requestedEras = options.era.split(",")
-        # Warn the user if they are explicitly setting an era that should be set automatically by the
-        # ConfigBuilder.
-        internalUseEras=["bunchspacing25ns","bunchspacing50ns"]
-        for era in internalUseEras :
-            if requestedEras.count(era) > 0 :
-                print "WARNING: You have explicitly set '"+era+"' with the '--era' command. It is advised that you let ConfigBuilder decide whether to add that or not."
         # Check that the entry is a valid era
-        for era in requestedEras :
-            if not hasattr( eras, era ) : # Not valid, so print a helpful message
+        for eraName in requestedEras :
+            if not hasattr( eras, eraName ) : # Not valid, so print a helpful message
                 validOptions="" # Create a stringified list of valid options to print to the user
                 for key in eras.__dict__ :
-                    if internalUseEras.count(key) > 0 : continue # Don't tell the user about things they should leave alone
+                    if eras.internalUseEras.count(getattr(eras,key)) > 0 : continue # Don't tell the user about things they should leave alone
                     if isinstance( eras.__dict__[key], Modifier ) or isinstance( eras.__dict__[key], ModifierChain ) :
                         if validOptions!="" : validOptions+=", " 
                         validOptions+="'"+key+"'"
-                raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (era, validOptions) )
+                raise Exception( "'%s' is not a valid option for '--era'. Valid options are %s." % (eraName, validOptions) )
+        # Warn the user if they are explicitly setting an era that should be
+        # set automatically by the ConfigBuilder.
+        for eraName in requestedEras : # Same loop, but had to make sure all the names existed first
+            if eras.internalUseEras.count(getattr(eras,eraName)) > 0 :
+                print "WARNING: You have explicitly set '"+eraName+"' with the '--era' command. That is usually reserved for internal use only."
 
     return options
 

--- a/Configuration/StandardSequences/python/DigiToRaw_cff.py
+++ b/Configuration/StandardSequences/python/DigiToRaw_cff.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+# This object is used to make changes for different running scenarios. In
+# this case for Run 2
+from Configuration.StandardSequences.Eras import eras
+
 from EventFilter.CSCTFRawToDigi.csctfpacker_cfi import *
 from EventFilter.DTTFRawToDigi.dttfpacker_cfi import *
 from EventFilter.GctRawToDigi.gctDigiToRaw_cfi import *
@@ -25,6 +29,9 @@ dttfpacker.DTDigi_Source = 'simDtTriggerPrimitiveDigis'
 dttfpacker.DTTracks_Source = "simDttfDigis:DTTF"
 gctDigiToRaw.rctInputLabel = 'simRctDigis'
 gctDigiToRaw.gctInputLabel = 'simGctDigis'
+# Change only if using the Stage 1 trigger
+eras.stage1L1Trigger.toModify( gctDigiToRaw, gctInputLabel = 'simCaloStage1LegacyFormatDigis' )
+
 l1GtPack.DaqGtInputTag = 'simGtDigis'
 l1GtPack.MuGmtInputTag = 'simGmtDigis'
 l1GtEvmPack.EvmGtInputTag = 'simGtDigis'
@@ -34,3 +41,21 @@ ecalPacker.InstanceEE = 'eeDigis'
 ecalPacker.labelEBSRFlags = "simEcalDigis:ebSrFlags"
 ecalPacker.labelEESRFlags = "simEcalDigis:eeSrFlags"
 
+##
+## Make changes for Run 2
+##
+def _modifyDigiToRawForStage1L1Trigger( theProcess ) :
+    """
+    Modifies the DigiToRaw sequence for running in Run 2
+    """
+    theProcess.load("L1Trigger.L1TCommon.l1tDigiToRaw_cfi")
+    # Note that this function is applied before the objects in this file are added
+    # to the process. So things declared in this file should be used "bare", i.e.
+    # not with "theProcess." in front of them. l1tDigiToRaw is an exception because
+    # it is not declared in this file but loaded into the process in the "load"
+    # statement above.
+    l1tDigiToRawSeq = cms.Sequence( gctDigiToRaw + theProcess.l1tDigiToRaw )
+    DigiToRaw.replace( gctDigiToRaw, l1tDigiToRawSeq )
+
+# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
+modifyConfigurationStandardSequencesDigiToRawForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _modifyDigiToRawForStage1L1Trigger )

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -21,5 +21,14 @@ class Eras (object):
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
         self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
+        
+        # The only thing this collection is used for is for cmsDriver to
+        # warn the user if they specify an era that is discouraged from being
+        # set directly. It also stops these eras being printed in the error
+        # message of available values when an invalid era is specified.
+        self.internalUseEras = [self.bunchspacing25ns, self.bunchspacing50ns,
+                                self.run2_common, self.run2_25ns_specific,
+                                self.run2_50ns_specific, self.run2_HI_specific,
+                                self.stage1L1Trigger]
 
 eras=Eras()

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -10,4 +10,16 @@ class Eras (object):
         self.bunchspacing25ns = cms.Modifier()
         self.bunchspacing50ns = cms.Modifier()
 
+        # These eras should not be set directly by the user.
+        self.run2_common = cms.Modifier()
+        self.run2_25ns_specific = cms.Modifier()
+        self.run2_50ns_specific = cms.Modifier()
+        self.run2_HI_specific = cms.Modifier()
+        self.stage1L1Trigger = cms.Modifier()
+        
+        # These are the eras that the user should specify
+        self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
+        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
+        self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
+
 eras=Eras()

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -1,5 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+# This object is used to selectively make changes for different running
+# scenarios. In this case it makes changes for Run 2.
+from Configuration.StandardSequences.Eras import eras
+
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 import EventFilter.CSCTFRawToDigi.csctfunpacker_cfi
@@ -92,4 +96,22 @@ muonRPCDigis.InputLabel = 'rawDataCollector'
 gtEvmDigis.EvmGtInputTag = 'rawDataCollector'
 castorDigis.InputLabel = 'rawDataCollector'
 
+##
+## Make changes for Run 2
+##
+def _modifyRawToDigiForStage1Trigger( theProcess ) :
+    """
+    Modifies the RawToDigi sequence if using the Stage 1 L1 trigger
+    """
+    theProcess.load("L1Trigger.L1TCommon.l1tRawToDigi_cfi")
+    theProcess.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")
+    # Note that this function is applied before the objects in this file are added
+    # to the process. So things declared in this file should be used "bare", i.e.
+    # not with "theProcess." in front of them. caloStage1Digis and caloStage1LegacyFormatDigis
+    # are an exception because they are not declared in this file but loaded into the
+    # process in the "load" statements above.
+    L1RawToDigiSeq = cms.Sequence( gctDigis + theProcess.caloStage1Digis + theProcess.caloStage1LegacyFormatDigis)
+    RawToDigi.replace( gctDigis, L1RawToDigiSeq )
 
+# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
+modifyConfigurationStandardSequencesRawToDigiForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _modifyRawToDigiForStage1Trigger )

--- a/DQM/L1TMonitor/python/L1ExtraDQM_cff.py
+++ b/DQM/L1TMonitor/python/L1ExtraDQM_cff.py
@@ -41,3 +41,22 @@ dqmL1ExtraParticles.hfRingEtSumsSource = 'dqmGctDigis'
 dqmL1ExtraParticles.hfRingBitCountsSource = 'dqmGctDigis'
 #
 dqmL1ExtraParticles.centralBxOnly = cms.bool(False)
+
+#
+# Modify for running with the Stage 1 trigger. Note that these changes are already
+# applied to l1extraParticles before it is cloned, but the changes are overwritten
+# in the commands above. So we need to write back the correct Run 2 values.
+#
+from Configuration.StandardSequences.Eras import eras
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, nonIsolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, etMissSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, htMissSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, forwardJetSource = cms.InputTag("caloStage1LegacyFormatDigis","forJets") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, centralJetSource = cms.InputTag("caloStage1LegacyFormatDigis","cenJets") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, tauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","tauJets") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, isoTauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","isoTauJets") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, isolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","isoEm") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, etHadSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, hfRingEtSumsSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( dqmL1ExtraParticles, hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis") )

--- a/EventFilter/RawDataCollector/python/rawDataCollectorByLabel_cfi.py
+++ b/EventFilter/RawDataCollector/python/rawDataCollectorByLabel_cfi.py
@@ -6,4 +6,8 @@ rawDataCollector = cms.EDProducer("RawDataCollectorByLabel",
                                        cms.InputTag('rawDataCollector'))
 )
 
-
+#
+# Make changes if using the Stage 1 trigger
+#
+from Configuration.StandardSequences.Eras import eras
+eras.stage1L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("l1tDigiToRaw")) )

--- a/EventFilter/RawDataCollector/python/rawDataCollector_cfi.py
+++ b/EventFilter/RawDataCollector/python/rawDataCollector_cfi.py
@@ -19,3 +19,8 @@ rawDataCollector = cms.EDProducer("RawDataCollectorByLabel",
     ),
 )
 
+#
+# Make changes if using the Stage 1 trigger
+#
+from Configuration.StandardSequences.Eras import eras
+eras.stage1L1Trigger.toModify( rawDataCollector.RawCollectionList, func = lambda list: list.append(cms.InputTag("l1tDigiToRaw")) )

--- a/FastSimulation/HighLevelTrigger/python/HLTFastReco_cff.py
+++ b/FastSimulation/HighLevelTrigger/python/HLTFastReco_cff.py
@@ -47,6 +47,24 @@ L1Emulator = cms.Sequence(simRctDigis +
                           simRpcTriggerDigis + 
                           simGmtDigis +
                           simGtDigis)
+##
+## Make changes for Run 2
+##
+def _extendForStage1Trigger( theProcess ) :
+    """
+    ProcessModifier that loads config fragments required for Run 2 into the process object.
+    Also switches the GCT digis for the Stage1 digis in the SimL1Emulator sequence
+    """
+    theProcess.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
+    # Note that this function is applied before the objects in this file are added
+    # to the process. So things declared in this file should be used "bare", i.e.
+    # not with "theProcess." in front of them. L1TCaloStage1 is an exception because
+    # it is not declared in this file but loaded into the process in one of the "load"
+    # statements above.
+    L1Emulator.replace( simGctDigis, theProcess.L1TCaloStage1 )
+
+# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
+modifyFastSimulationHighLevelTriggerHLTFastRecoForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _extendForStage1Trigger )
 
 # L1Extra - provides 4-vector representation of L1 trigger objects - not needed by HLT
 # The muon extra particles are done here, but could be done also by L1ParamMuons.

--- a/L1Trigger/Configuration/python/L1Reco_cff.py
+++ b/L1Trigger/Configuration/python/L1Reco_cff.py
@@ -18,6 +18,22 @@ from EventFilter.L1GlobalTriggerRawToDigi.l1GtRecord_cfi import *
 
 # L1GtTriggerMenuLite
 from EventFilter.L1GlobalTriggerRawToDigi.l1GtTriggerMenuLite_cfi import *
+#
+# If this is Run 2 then the trigger menu needs to be loaded from XML
+# instead of using l1GtTriggerMenuLite
+#
+def _loadMenuFromXML( processObject ) :
+    """
+    Imports the required producer to load the L1 menu from XML and creates an
+    ESPrefer to prefer that. The actual filename of the menu is specified in
+    era customisations within these imports.
+    """
+    processObject.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
+    processObject.load( 'L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMenuConfig_cff' )
+    processObject.es_prefer_l1GtParameters = cms.ESPrefer( 'L1GtTriggerMenuXmlProducer', 'l1GtTriggerMenuXml' )
+from Configuration.StandardSequences.Eras import eras
+# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
+modifyL1TriggerConfigurationL1RecoForRun2_ = eras.run2_common.makeProcessModifier( _loadMenuFromXML )
 
 # conditions in edm
 import EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -6,6 +6,11 @@ import FWCore.ParameterSet.Config as cms
 # Jim Brooke, 24 April 2008
 # Vasile Mihai Ghete, 2009
 
+
+# This object is used to make changes for different running scenarios. In
+# this case for Run 2
+from Configuration.StandardSequences.Eras import eras
+
 # ECAL TPG emulator and HCAL TPG run in the simulation sequence in order to be able 
 # to use unsuppressed digis produced by ECAL and HCAL simulation, respectively
 # in Configuration/StandardSequences/python/Digi_cff.py
@@ -120,7 +125,11 @@ simGtDigis.TechnicalTriggersInputTags = cms.VInputTag(
     cms.InputTag( 'simHcalTechTrigDigis' ),
     cms.InputTag( 'simCastorTechTrigDigis' )
     )
-
+#
+# Make some changes if using the Stage 1 trigger
+#
+eras.stage1L1Trigger.toModify( simGtDigis, GctInputTag = 'simCaloStage1LegacyFormatDigis' )
+eras.stage1L1Trigger.toModify( simGtDigis, TechnicalTriggersInputTags = cms.VInputTag() )
 
 ### L1 Trigger sequences
 
@@ -148,3 +157,21 @@ SimL1Emulator = cms.Sequence(
     simGmtDigis + 
     SimL1TechnicalTriggers + 
     simGtDigis )
+##
+## Make changes for Run 2
+##
+def _extendForStage1Trigger( theProcess ) :
+    """
+    ProcessModifier that loads config fragments required for Run 2 into the process object.
+    Also switches the GCT digis for the Stage1 digis in the SimL1Emulator sequence
+    """
+    theProcess.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
+    # Note that this function is applied before the objects in this file are added
+    # to the process. So things declared in this file should be used "bare", i.e.
+    # not with "theProcess." in front of them. L1TCaloStage1 is an exception because
+    # it is not declared in this file but loaded into the process in one of the "load"
+    # statements above.
+    SimL1Emulator.replace( simGctDigis, theProcess.L1TCaloStage1 )
+
+# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
+modifyL1TriggerConfigurationSimL1EmulatorForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _extendForStage1Trigger )

--- a/L1Trigger/L1ExtraFromDigis/python/l1extraParticles_cfi.py
+++ b/L1Trigger/L1ExtraFromDigis/python/l1extraParticles_cfi.py
@@ -20,4 +20,19 @@ l1extraParticles = cms.EDProducer("L1ExtraParticlesProd",
     ignoreHtMiss = cms.bool(False)
 )
 
-
+#
+# Modify for running with the Stage 1 trigger
+#
+from Configuration.StandardSequences.Eras import eras
+eras.stage1L1Trigger.toModify( l1extraParticles, etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( l1extraParticles, nonIsolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm") )
+eras.stage1L1Trigger.toModify( l1extraParticles, etMissSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( l1extraParticles, htMissSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( l1extraParticles, forwardJetSource = cms.InputTag("caloStage1LegacyFormatDigis","forJets") )
+eras.stage1L1Trigger.toModify( l1extraParticles, centralJetSource = cms.InputTag("caloStage1LegacyFormatDigis","cenJets") )
+eras.stage1L1Trigger.toModify( l1extraParticles, tauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","tauJets") )
+eras.stage1L1Trigger.toModify( l1extraParticles, isoTauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","isoTauJets") )
+eras.stage1L1Trigger.toModify( l1extraParticles, isolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","isoEm") )
+eras.stage1L1Trigger.toModify( l1extraParticles, etHadSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( l1extraParticles, hfRingEtSumsSource = cms.InputTag("caloStage1LegacyFormatDigis") )
+eras.stage1L1Trigger.toModify( l1extraParticles, hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis") )

--- a/L1Trigger/L1TCalorimeter/python/simCaloStage1Digis_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/simCaloStage1Digis_cfi.py
@@ -11,5 +11,8 @@ simCaloStage1Digis = cms.EDProducer(
     conditionsLabel = cms.string("")
 )
 
-
-
+#
+# Make changes for Run 2 Heavy Ions
+#
+from Configuration.StandardSequences.Eras import eras
+eras.run2_HI_specific.toModify( simCaloStage1Digis, FirmwareVersion = 1 )

--- a/L1Trigger/L1TCommon/python/l1tDigiToRaw_cfi.py
+++ b/L1Trigger/L1TCommon/python/l1tDigiToRaw_cfi.py
@@ -7,3 +7,13 @@ l1tDigiToRaw = cms.EDProducer(
     FedId = cms.int32(1352),
     FWId = cms.uint32(2)
 )
+
+#
+# Make some changes if running with the Stage 1 trigger
+#
+from Configuration.StandardSequences.Eras import eras
+eras.stage1L1Trigger.toModify( l1tDigiToRaw, InputLabel = cms.InputTag("simCaloStage1FinalDigis", "") )
+eras.stage1L1Trigger.toModify( l1tDigiToRaw, TauInputLabel = cms.InputTag("simCaloStage1FinalDigis", "rlxTaus") )
+eras.stage1L1Trigger.toModify( l1tDigiToRaw, IsoTauInputLabel = cms.InputTag("simCaloStage1FinalDigis", "isoTaus") )
+eras.stage1L1Trigger.toModify( l1tDigiToRaw, HFBitCountsInputLabel = cms.InputTag("simCaloStage1FinalDigis", "HFBitCounts") )
+eras.stage1L1Trigger.toModify( l1tDigiToRaw, HFRingSumsInputLabel = cms.InputTag("simCaloStage1FinalDigis", "HFRingSums") )

--- a/L1TriggerConfig/L1GtConfigProducers/python/l1GtTriggerMenuXml_cfi.py
+++ b/L1TriggerConfig/L1GtConfigProducers/python/l1GtTriggerMenuXml_cfi.py
@@ -14,4 +14,17 @@ l1GtTriggerMenuXml = cms.ESProducer("L1GtTriggerMenuXmlProducer",
     VmeXmlFile = cms.string('')
 )
 
+#
+# Make changes for Run 2
+#
+from Configuration.StandardSequences.Eras import eras
+# Change the trigger menu depending on whether this is 25ns, 50ns or HI running
+eras.run2_25ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030.xml' )
 
+## The following two menus haven't been implemented yet, so until then use
+## the same menu as for 25ns.
+#eras.run2_50ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_50ns_v0_L1T_Scales_20141121_Imp0_0x1031.xml' )
+#eras.run2_HI_specific.toModify( l1GtTriggerMenuXml,   DefXmlFile = 'L1Menu_CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1.xml' )
+## FIXME - take out these lines and uncomment the ones above once the menus are implemented.
+eras.run2_50ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030.xml' )
+eras.run2_HI_specific.toModify( l1GtTriggerMenuXml,   DefXmlFile = 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030.xml' )

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -51,48 +51,6 @@ def customisePostLS1(process):
     return process
 
 
-def customiseRun2EraExtras(process):
-    """
-    This function should be used in addition to the "--era run2" cmsDriver
-    option so that it can perform the last few changes that the era hasn't
-    implemented yet.
-
-    As functionality is added to the run2 era the corresponding line will
-    be removed from this function until the whole function is removed.
-
-    Currently does exactly the same as "customisePostLS1", since the run2
-    era doesn't make any changes yet (coming in later pull requests).
-    """
-    # deal with CSC separately:
-    # a simple sanity check first
-    # list of (pathName, expected moduleName) tuples:
-    paths_modules = [
-        ('digitisation_step', 'simMuonCSCDigis'),
-        ('L1simulation_step', 'simCscTriggerPrimitiveDigis'),
-        ('L1simulation_step', 'simCsctfTrackDigis'),
-        ('raw2digi_step', 'muonCSCDigis'),
-        ('raw2digi_step', 'csctfDigis'),
-        ('digi2raw_step', 'cscpacker'),
-        ('digi2raw_step', 'csctfpacker'),
-        ('reconstruction', 'csc2DRecHits'),
-        ('dqmoffline_step', 'muonAnalyzer'),
-        #('dqmHarvesting', ''),
-        ('validation_step', 'relvalMuonBits')
-    ]
-    # verify:
-    for path_name, module_name in paths_modules:
-        if hasattr(process, path_name) and not hasattr(process, module_name):
-            print "WARNING: module %s is not in %s path!!!" % (module_name, path_name)
-            print "         This path has the following modules:"
-            print "         ", getattr(process, path_name).moduleNames(),"\n"
-
-    # deal with L1 Emulation separately:
-    from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_25ns
-    process = customiseSimL1EmulatorForPostLS1_25ns(process)
-
-    return process
-
-
 def customisePostLS1_50ns(process):
 
     # deal with L1 Emulation separately


### PR DESCRIPTION
This adds the final customisations to the various Run 2 eras.  In principal these are the final changes (besides 1 more clean up pull request) but there will likely be further PRs to fix problems when I properly go through the validation.

This is on top of #7839 since it uses the eras added there.  #7841 is also in the queue but largely orthogonal to this, other than sharing #7839 as a base.  Until #7841 is merged you need to also use `run2` to fully configure an era though, e.g.

```
--era Run2_25ns,run2
```

Once #7841 is merged one of `Run2_25ns`, `Run2_50ns` or `Run2_HI` will be sufficient.  However, I wouldn't recommend using the eras for real use until I've completed the validation.
The helper customisation function has also been removed, so there's no need to add that anymore.

To clarify, the roadmap for eras is now
- #7839 to add support for 25ns, 50ns or HI eras.
- #7841 to move the old `run2` era to `run2_common`.
- one clean up pull request on top of #7841 to move the old `bunchspace25ns` to `run2_25ns_specific` (and the same for 50ns) - ready to go but holding off since the changes from #7841 will require loads of signatures.
- This pull request to add the final changes and take out the helper function
- Valdiation and pull requests for any fixes required.

@fwyzard
