### PR TITLE
Add SMatrix<double,2> used as return type for MET::getSignificanceMatrix

### DIFF
--- a/DataFormats/Math/src/classes.h
+++ b/DataFormats/Math/src/classes.h
@@ -225,6 +225,9 @@ namespace DataFormats_Math {
     ROOT::Math::MatRepStd<double, 10 , 10> smdcw;
     ROOT::Math::MatRepStd<double, 2 , 3> smdcw1;
 
+    //Used by MET Significance matrix
+    ROOT::Math::SMatrix<double,2> smat;
+
     //Used by TauReco
     std::pair<ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag>,float> calotti_ppf;
     std::vector<std::pair<ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag>,float> > vcalotti_ppf;


### PR DESCRIPTION
Add ROOT::Math::SMatrix<double,2> to DataFormats/Math.  This type is not stored but is used as the return type of MET::getSignificanceMatrix(), so a dictionary is needed for that function to be called from FWLite interpreted code (e.g., PyROOT).  For details see:

https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3312/1.html
