### PR TITLE
csc geom kill const cast

### DIFF
--- a/Geometry/CSCGeometry/src/CSCGeometry.cc
+++ b/Geometry/CSCGeometry/src/CSCGeometry.cc
@@ -42,7 +42,7 @@ void CSCGeometry::addChamber(CSCChamber* ch){
 void CSCGeometry::addLayer(CSCLayer* l) {
   theDetUnits.push_back(l);
   theLayers.push_back(l);
-  theDetTypes.push_back(const_cast<GeomDetType*>(&(l->type()))); //@@ FIXME drop const_cast asap!
+  theDetTypes.push_back(l->chamber()->specs());
   theDetUnitIds.push_back(l->geographicalId());
   addDet(l);
 }


### PR DESCRIPTION
Replaced a long-standing const_cast embedded in CSCGeometry.cc 9 years ago. I think it was probably done because no const GeomDetType\* was available then? But a year or two later the organization of the GeomDetType's seemed to settle down and it could have been fixed as I have done here. I've run the runthematrix Reco tests in case of some astonishing feedthrough effects but they all pass just fine :)
