### PR TITLE
Get DDVector Names

### DIFF
--- a/DetectorDescription/Core/interface/DDVectorGetter.h
+++ b/DetectorDescription/Core/interface/DDVectorGetter.h
@@ -9,6 +9,7 @@ namespace DDVectorGetter
 {
   bool		      	check( const std::string & );
   std::vector<double>   get( const std::string & );
+  void                  beginWith( const std::string &, std::vector<std::string> & );
 
   inline bool
   check( const std::string & str )
@@ -51,6 +52,23 @@ namespace DDVectorGetter
     }
   
     throw cms::Exception( "DDException" ) << "DDVectorGetter: cannot get array " << str;
+  }
+
+  inline void
+  beginWith( const std::string & str, std::vector<std::string>& vstring )
+  {
+    DDVector::iterator<DDVector> vit;
+    DDVector::iterator<DDVector> ved( DDVector::end());
+
+    for(; vit != ved; ++vit )
+    {
+      if( vit->isDefined().second )
+      {
+	DDName vname( vit->name());
+	if( vname.name().compare( 0, str.size(), str ) == 0 )
+	  vstring.push_back( vname.name());
+      }
+    }
   }
 };
 

--- a/DetectorDescription/RegressionTest/test/configuration.xml
+++ b/DetectorDescription/RegressionTest/test/configuration.xml
@@ -16,7 +16,8 @@
         <File name="Geometry/CMSCommonData/data/cmsBeam.xml" url="."/> 
         <File name="Geometry/CMSCommonData/data/muonMB.xml" url="."/> 
         <File name="Geometry/CMSCommonData/data/muonMagnet.xml" url="."/> 
-        <File name="Geometry/TrackerCommonData/data/tracker.xml" url="."/> 
+        <File name="Geometry/TrackerCommonData/data/tracker.xml" url="."/>
+        <File name="Geometry/TrackerCommonData/data/trackerParameters.xml" url="."/>	
    </Include>
    <Root  fileName="cms.xml" logicalPartName="OCMS"/>
 </Configuration>

--- a/DetectorDescription/RegressionTest/test/const_dump.cpp
+++ b/DetectorDescription/RegressionTest/test/const_dump.cpp
@@ -6,6 +6,7 @@
 #include "DetectorDescription/Core/src/DDCheck.h"
 #include "DetectorDescription/Core/interface/DDConstant.h"
 #include "DetectorDescription/Core/interface/DDVector.h"
+#include "DetectorDescription/Core/interface/DDVectorGetter.h"
 #include "DetectorDescription/RegressionTest/interface/DDErrorDetection.h"
 
 using namespace std;
@@ -74,6 +75,14 @@ int main(int argc, char *argv[])
 	std::cout << std::endl;
       }
     }
+
+    std::vector<string> vnames;
+    DDVectorGetter::beginWith( "Subdetector", vnames );
+    for( std::vector<string>::const_iterator sit = vnames.begin(); sit != vnames.end(); ++sit )
+    {
+      std::cout << sit->c_str() << std::endl;
+    }
+    
     return 0;
   }
   //  Deal with any exceptions that may have been thrown.


### PR DESCRIPTION
- New API is needed to optimise new xml parameter vectors parsing defined for both Tracker and HCAL.
