### PR TITLE
Added Dxy plots (only for electron/muon at this moment)

### DIFF
--- a/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
@@ -51,7 +51,8 @@ public:
     void plotterBookHistos(DQMStore::IBooker & iBooker, const edm::Run & iRun, const edm::EventSetup & iSetup);
     void analyze(const bool & isPassTrigger, const std::string & source,
                  const std::vector<reco::LeafCandidate> & matches,
-		 std::map<int,double> theSumEt);
+		 std::map<int,double> theSumEt,
+                 std::vector<float> & dxys);
 
     inline const std::string gethltpath() const
     {
@@ -74,6 +75,7 @@ private:
     std::vector<double> _parametersEta;
     std::vector<double> _parametersPhi;
     std::vector<double> _parametersTurnOn;
+    std::vector<double> _parametersDxy;
 
     std::map<std::string, MonitorElement *> _elements;
 };

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -37,6 +37,7 @@
 #include "DataFormats/METReco/interface/CaloMET.h"
 #include "DataFormats/METReco/interface/CaloMETCollection.h"
 #include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 #include "DataFormats/TauReco/interface/PFTau.h"
 #include "DataFormats/TauReco/interface/PFTauFwd.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
@@ -104,7 +105,9 @@ private:
     /// This function applies the selectors initialized previously to the objects,
     /// and matches the passing objects to HLT objects.
     void insertCandidates(const unsigned int & objtype, const EVTColContainer * col,
-                          std::vector<reco::LeafCandidate> * matches, std::map<int,double> & theSumEt);
+                          std::vector<reco::LeafCandidate> * matches, 
+                          std::map<int,double> & theSumEt,
+                          std::map<int, std::vector<const reco::Track*> > & trkObjs);
 
     /// The internal functions to book and fill histograms
     void bookHist(DQMStore::IBooker &iBooker, const std::string & source, const std::string & objType,
@@ -132,16 +135,19 @@ private:
     std::string _hltProcessName;
     edm::InputTag _genParticleLabel;
     edm::InputTag _trigResultsLabel;
+    edm::InputTag _beamSpotLabel;
     std::map<unsigned int, edm::InputTag> _recLabels;
     /// And also the tokens to get the object collections
     edm::EDGetTokenT<reco::GenParticleCollection> _genParticleToken;
     edm::EDGetTokenT<edm::TriggerResults> _trigResultsToken;
+    edm::EDGetTokenT<reco::BeamSpot> _bsToken;
     std::map<unsigned int, edm::EDGetToken> _tokens;
 
     /// Some kinematical parameters
     std::vector<double> _parametersEta;
     std::vector<double> _parametersPhi;
     std::vector<double> _parametersTurnOn;
+    std::vector<double> _parametersDxy;
 
     /// gen/rec objects cuts
     std::map<unsigned int, std::string> _genCut;

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -41,6 +41,10 @@ def efficiency_string(objtype,plot_type,triggerpath):
         title = "#phi Efficiency"
         xAxis = "#phi of Generated %s " % (objtype)
         input_type = "gen%sPhi" % (objtype)
+    if plot_type == "EffDxy":
+        title = "Dxy Efficiency"
+        xAxis = "Dxy of Generated %s " % (objtype)
+        input_type = "gen%sDxy" % (objtype)
 
     yAxis = "%s / %s" % (numer_description, denom_description)
     all_titles = "%s for trigger %s; %s; %s" % (title, triggerpath,
@@ -59,7 +63,7 @@ def add_reco_strings(strings):
     strings.extend(reco_strings)
 
 
-plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "EffEta", "EffPhi"]
+plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "EffEta", "EffPhi", "EffDxy"]
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
 obj_types  = ["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet"

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -76,6 +76,9 @@ hltExoticaValidator = cms.EDAnalyzer(
     # -- The instance name of the reco::GenParticles collection
     genParticleLabel = cms.string("genParticles"),
 
+    # -- The instance name of the reco::BeamSpot collection
+    beamSpotLabel = cms.string("offlineBeamSpot"),
+
     # -- The binning of the Pt efficiency plots
     # NOTICE: these DEFINITELY should be tuned for the different analyses.
     # What we have there is a generic, 0-100 GeV uniform binning.
@@ -89,6 +92,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     # -- (NBins, minVal, maxValue) for the Eta and Phi efficiency plots
     parametersEta      = cms.vdouble(48, -2.400, 2.400),
     parametersPhi      = cms.vdouble(50, -3.142, 3.142),
+    parametersDxy      = cms.vdouble(50, -0.015, 0.015),
 
     # Definition of generic cuts on generated and reconstructed objects (note that
     # these cuts can be overloaded inside a particular analysis)

--- a/HLTriggerOffline/Exotica/src/EVTColContainer.cc
+++ b/HLTriggerOffline/Exotica/src/EVTColContainer.cc
@@ -80,6 +80,7 @@ struct EVTColContainer {
     const std::vector<reco::PFJet>               * pfJets;
     const std::vector<reco::CaloJet>             * caloJets;
     const edm::TriggerResults                    * triggerResults ;
+    const reco::BeamSpot                         * bs;
 
     EVTColContainer():
         nOfCollections(6),
@@ -98,7 +99,8 @@ struct EVTColContainer {
         pfTaus(0),
         pfJets(0),
         caloJets(0),
-        triggerResults(0)
+        triggerResults(0),
+        bs(0)
     {
     }
     ///
@@ -131,6 +133,7 @@ struct EVTColContainer {
         pfJets = 0;
         caloJets = 0;
         triggerResults = 0;
+        bs = 0;
     }
 
     /// Setter: multiple overloaded function

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -34,9 +34,11 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,
     _hltProcessName(pset.getParameter<std::string>("hltProcessName")),
     _genParticleLabel(pset.getParameter<std::string>("genParticleLabel")),
     _trigResultsLabel("TriggerResults", "", _hltProcessName),
+    _beamSpotLabel(pset.getParameter<std::string>("beamSpotLabel")),
     _parametersEta(pset.getParameter<std::vector<double> >("parametersEta")),
     _parametersPhi(pset.getParameter<std::vector<double> >("parametersPhi")),
     _parametersTurnOn(pset.getParameter<std::vector<double> >("parametersTurnOn")),
+    _parametersDxy(pset.getParameter<std::vector<double> >("parametersDxy")),
     _recMuonSelector(0),
     _recMuonTrkSelector(0),
     _recTrackSelector(0),
@@ -208,6 +210,13 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(DQMStore::IBooker &iBooker,
               bookHist(iBooker, source, objStr, "MaxPt2");
               bookHist(iBooker, source, objStr, "Eta");
               bookHist(iBooker, source, objStr, "Phi");
+
+              // If the target is electron or muon,
+              // we will add Dxy plots.
+              if ( it->first == EVTColContainer::ELEC ||
+                   it->first == EVTColContainer::MUON    ) { 
+                 bookHist(iBooker, source, objStr, "Dxy");
+              }
             }
           } else { // reco
             if ( TString(objStr).Contains("MET") ||
@@ -219,6 +228,13 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(DQMStore::IBooker &iBooker,
               bookHist(iBooker, source, objStr, "MaxPt2");
               bookHist(iBooker, source, objStr, "Eta");
               bookHist(iBooker, source, objStr, "Phi");
+
+              // If the target is electron or muon,
+              // we will add Dxy plots.
+              if ( it->first == EVTColContainer::ELEC ||
+                   it->first == EVTColContainer::MUON    ) { 
+                 bookHist(iBooker, source, objStr, "Dxy");
+              }
             }
           }
 
@@ -365,6 +381,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
     std::vector<reco::LeafCandidate> matchesGen; matchesGen.clear();
     std::vector<reco::LeafCandidate> matchesReco; matchesReco.clear();
     std::map<int , double> theSumEt; // map< pdgId ; SumEt > in order to keep track of the MET type
+    std::map<int, std::vector<const reco::Track*> > trkObjs;
 
     // --- deal with GEN objects first.
     // Make each good GEN object into the base cand for a MatchStruct
@@ -426,7 +443,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
       // before or not) ### Thiago ---> Then why don't we put it in the beginRun???
       this->initSelector(it->first);
       // -- Storing the matchesReco
-      this->insertCandidates(it->first, cols, &matchesReco, theSumEt);
+      this->insertCandidates(it->first, cols, &matchesReco, theSumEt, trkObjs);
       if(verbose>0) std::cout << "--- " << EVTColContainer::getTypeString(it->first) 
 			      << " sumEt=" << theSumEt[it->first] << std::endl;
     }
@@ -487,6 +504,8 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
           break;
         }
       }
+ 
+      std::vector<float> dxys; dxys.clear();
 
       for (size_t j = 0; ( j != matchesGen.size() ) && isPassedLeadingCut; ++j) {
 	const unsigned int objType = matchesGen[j].pdgId();
@@ -522,6 +541,17 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	this->fillHist("gen", objTypeStr, "Eta", eta);
 	this->fillHist("gen", objTypeStr, "Phi", phi);
 
+        // If the target is electron or muon,
+        // we will add Dxy plots.
+        if ( objType == EVTColContainer::MUON ||
+             objType == EVTColContainer::ELEC   ) {
+          const math::XYZPoint & vtx = matchesGen[j].vertex();
+          float momphi = matchesGen[j].momentum().phi();
+          float dxyGen = (-(vtx.x()-cols->bs->x0())*sin(momphi)+(vtx.y()-cols->bs->y0())*cos(momphi));
+          dxys.push_back(dxyGen);
+          this->fillHist("gen", objTypeStr, "Dxy", dxyGen);
+        }
+
       } // Closes loop in gen
 	
       // Calling to the plotters analysis (where the evaluation of the different trigger paths are done)
@@ -530,7 +560,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	const std::string hltPath = _shortpath2long[an->gethltpath()];
 	const bool ispassTrigger =  cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
 	LogDebug("ExoticaValidation") << "                        preparing to call the plotters analysis";
-	an->analyze(ispassTrigger, "gen", matchesGen, theSumEt);
+        an->analyze(ispassTrigger, "gen", matchesGen, theSumEt, dxys);
 	LogDebug("ExoticaValidation") << "                        called the plotter";
       }
     } /// Close GEN case
@@ -567,6 +597,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	/// Debugging.
 	//std::cout << "Our RECO vector has matchesReco.size() = " << matchesReco.size() << std::endl;
 
+        std::vector<float> dxys; dxys.clear();
 
         bool isPassedLeadingCut = true;
         // We will proceed only when cuts for the pt-leading are satisified.
@@ -621,6 +652,12 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	    else {
 	      this->fillHist("rec", objTypeStr, "SumEt", theSumEt[objType]);
 	    }
+          
+            if (trkObjs[objType].size()>=j+1) {
+              float dxyRec = trkObjs[objType].at(j)->dxy(cols->bs->position());
+              this->fillHist("rec", objTypeStr, "Dxy", dxyRec);
+              dxys.push_back(dxyRec);
+            }
 
 	} // Closes loop in reco
 
@@ -633,7 +670,7 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	    const std::string hltPath = _shortpath2long[an->gethltpath()];
 	    const bool ispassTrigger =  cols->triggerResults->accept(trigNames.triggerIndex(hltPath));
 	    LogDebug("ExoticaValidation") << "                        preparing to call the plotters analysis";
-	    an->analyze(ispassTrigger, "rec", matchesReco, theSumEt);
+            an->analyze(ispassTrigger, "rec", matchesReco, theSumEt, dxys);
 	    LogDebug("ExoticaValidation") << "                        called the plotter";
 	}
     } /// Close RECO case
@@ -763,6 +800,10 @@ void HLTExoticaSubAnalysis::registerConsumes(edm::ConsumesCollector & iC)
    
     // Register that we are getting the trigger results
     _trigResultsToken = iC.consumes<edm::TriggerResults>(_trigResultsLabel);
+
+    // Register beamspot 
+    _bsToken = iC.consumes<reco::BeamSpot>(_beamSpotLabel);
+
     // Loop over _recLabels, see what we need, and register.
     // Then save the registered token in _tokens.
     // Remember: _recLabels is a map<uint, edm::InputTag>
@@ -868,6 +909,13 @@ void HLTExoticaSubAnalysis::getHandlesToObjects(const edm::Event & iEvent, EVTCo
         if (genPart.isValid()) {
             col->genParticles = genPart.product();
 	    LogDebug("ExoticaValidation") << "Added handle to genParticles";
+        }
+
+        // BeamSpot for dxy 
+        edm::Handle<reco::BeamSpot> bsHandle;
+        iEvent.getByToken(_bsToken, bsHandle);
+        if (bsHandle.isValid()) {
+            col->bs = bsHandle.product();
         }
     }
 
@@ -975,6 +1023,14 @@ void HLTExoticaSubAnalysis::bookHist(DQMStore::IBooker & iBooker,
       delete[] edges;
     }
 
+    else if (variable.find("Dxy") != std::string::npos) {
+      std::string title = "Dxy " + sourceUpper + " " + objType;
+      int    nBins = _parametersDxy[0];
+      double min   = _parametersDxy[1];
+      double max   = _parametersDxy[2];
+      h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
+    }
+
     else if (variable.find("MaxPt") != std::string::npos) {
       std::string desc = (variable == "MaxPt1") ? "Leading" : "Next-to-Leading";
       std::string title = "pT of " + desc + " " + sourceUpper + " " + objType;
@@ -1062,7 +1118,8 @@ void HLTExoticaSubAnalysis::initSelector(const unsigned int & objtype)
 }
 
 // Insert the HLT candidates
-void HLTExoticaSubAnalysis::insertCandidates(const unsigned int & objType, const EVTColContainer * cols, std::vector<reco::LeafCandidate> * matches, std::map<int,double> & theSumEt)
+void HLTExoticaSubAnalysis::insertCandidates(const unsigned int & objType, const EVTColContainer * cols, std::vector<reco::LeafCandidate> * matches, 
+                                             std::map<int,double> & theSumEt, std::map<int,std::vector<const reco::Track*> > & trkObjs )
 {
     
     LogDebug("ExoticaValidation") << "In HLTExoticaSubAnalysis::insertCandidates()"; 
@@ -1075,6 +1132,9 @@ void HLTExoticaSubAnalysis::insertCandidates(const unsigned int & objType, const
 	    if (_recMuonSelector->operator()(cols->muons->at(i))) {
 		reco::LeafCandidate m(0, cols->muons->at(i).p4(), cols->muons->at(i).vertex(), objType, 0, true);
 		matches->push_back(m);
+        
+                // for making dxy plots
+                trkObjs[objType].push_back(cols->muons->at(i).bestTrack());
 	    }
         }
     } else if (objType == EVTColContainer::MUTRK) {
@@ -1105,6 +1165,9 @@ void HLTExoticaSubAnalysis::insertCandidates(const unsigned int & objType, const
             if (_recElecSelector->operator()(cols->electrons->at(i))) {
 		reco::LeafCandidate m(0, cols->electrons->at(i).p4(), cols->electrons->at(i).vertex(), objType, 0, true);
 		matches->push_back(m);
+
+                // for making dxy plots
+                trkObjs[objType].push_back(cols->electrons->at(i).bestTrack());
 	    }
         }
     } else if (objType == EVTColContainer::PHOTON) {


### PR DESCRIPTION
Here is the "dxy" definitions used in the code:

(I modified variable names from the actual names just for explanation.)
1) gen dxy :
const math::XYZPoint & vtx = genParticle.vertex();
float phi = genParticle.momentum().phi();
float dxyGen = ( - ( vtx.x() - beamspot->x0())_sin(phi) + (vtx.y() - beamspot->y0())_cos(phi));
2) reco dxy:
float dxyRec = (electron/muon bestTrack)->dxy(beamspot->position());
