### PR TITLE
Fix for consumes interface in SimGeneral/MixingModule

### DIFF
--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -88,8 +88,8 @@ namespace edm {
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimTrack>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
               produces<CrossingFrame<SimTrack> >(label);
-              consumes<std::vector<SimTrack> >(tag);
             }
+            consumes<std::vector<SimTrack> >(tag);
 
             LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;
             //            std::cout <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label<<std::endl;
@@ -118,8 +118,8 @@ namespace edm {
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimVertex>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
               produces<CrossingFrame<SimVertex> >(label);
-              consumes<std::vector<SimVertex> >(tag);
             }
+            consumes<std::vector<SimVertex> >(tag);
 
             LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag "<<tag.encode()<<", label will be "<<label;
             //            std::cout <<"Will mix "<<object<<"s with InputTag "<<tag.encode()<<", label will be "<<label<<std::endl;


### PR DESCRIPTION
SimGeneral/MixingModule will consume a vector of SimTrack or SimVertex whether or not it is producing a CrossingFrame.  So, the consumes calls for these are in the wrong place.   This is a fix for the bug, and allows the consumes interface to function properly.
