### PR TITLE
Add consumes interface for CSCTFTrackProducer

### DIFF
--- a/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.cc
+++ b/L1Trigger/CSCTrackFinder/plugins/CSCTFTrackProducer.cc
@@ -37,6 +37,8 @@ CSCTFTrackProducer::CSCTFTrackProducer(const edm::ParameterSet& pset)
   my_builder = 0 ;
   produces<L1CSCTrackCollection>();
   produces<CSCTriggerContainer<csctf::TrackStub> >();
+  consumes<CSCCorrelatedLCTDigiCollection>(input_module);
+  consumes<L1MuDTChambPhContainer>(dt_producer);
 }
 
 CSCTFTrackProducer::~CSCTFTrackProducer()


### PR DESCRIPTION
Add consumes interface to CSCTFTrackProducer in package L1Trigger/CSCTrackFinder
