### PR TITLE
Refactor  and split up Wrapper.h for maintainability, as it has become unwieldy

### DIFF
--- a/DataFormats/Common/interface/Wrapper.h
+++ b/DataFormats/Common/interface/Wrapper.h
@@ -8,28 +8,24 @@ Wrapper: A template wrapper around EDProducts to hold the product ID.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/WrapperBase.h"
-#include "DataFormats/Common/interface/fwd_fillPtrVector.h"
-#include "DataFormats/Common/interface/fwd_setPtr.h"
-#include "DataFormats/Common/interface/PtrVector.h"
-#include "DataFormats/Common/interface/RefVectorHolder.h"
-#include "DataFormats/Common/interface/traits.h"
+#include "DataFormats/Common/interface/WrapperDetail.h"
+#include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
-#include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include "FWCore/Utilities/interface/Visibility.h"
-#include "boost/mpl/if.hpp"
 
 #include <algorithm>
+#include <cassert>
 #include <memory>
 #include <string>
 #include <typeinfo>
 
 namespace edm {
-  template <typename T>
+  template<typename T>
   class Wrapper : public WrapperBase {
   public:
     typedef T value_type;
-    typedef T wrapped_type;  // used with the dictionary to identify Wrappers
+    typedef T wrapped_type; // used with the dictionary to identify Wrappers
     Wrapper() : WrapperBase(), present(false), obj() {}
 #ifndef __GCCXML__
     explicit Wrapper(std::unique_ptr<T> ptr);
@@ -42,7 +38,7 @@ namespace edm {
     static std::type_info const& productTypeInfo() {return typeid(T);}
     static std::type_info const& typeInfo() {return typeid(Wrapper<T>);}
 
-    //  the constructor takes ownership of T*
+    // the constructor takes ownership of T*
     Wrapper(T*);
 
     //Used by ROOT storage
@@ -79,242 +75,17 @@ private:
     Wrapper<T>& operator=(Wrapper<T> const&); // disallow assignment
 
     bool present;
-    //   T const obj;
     T obj;
   };
 
-} //namespace edm
-
-#include "DataFormats/Common/interface/Ref.h"
-
-namespace edm {
-
-  template <typename T>
-  struct DoFillView {
-    void operator()(T const& obj,
-                    ProductID const& id,
-                    std::vector<void const*>& pointers,
-                    helper_vector_ptr & helpers) const;
-  };
-
-  template <typename T>
-  struct DoNotFillView {
-    void operator()(T const&,
-                    ProductID const&,
-                    std::vector<void const*>&,
-                    helper_vector_ptr&) const {
-      Exception::throwThis(errors::ProductDoesNotSupportViews,
-        "The product type ",
-        typeid(T).name(),
-        "\ndoes not support Views\n");
-    }
-  };
-
-  template <typename T>
+#ifndef __GCCXML__
+  template<typename T>
   inline
-  void Wrapper<T>::do_fillView(ProductID const& id,
-                               std::vector<void const*>& pointers,
-                               helper_vector_ptr& helpers) const {
-    typename boost::mpl::if_c<has_fillView<T>::value,
-    DoFillView<T>,
-    DoNotFillView<T> >::type maybe_filler;
-    maybe_filler(obj, id, pointers, helpers);
-  }
+  void swap_or_assign(T& a, T& b) {
+    detail::doSwapOrAssign<T>()(a, b);
+  } 
 
-
-  template <typename T>
-  struct DoSetPtr {
-    void operator()(T const& obj,
-                    std::type_info const& iToType,
-                    unsigned long iIndex,
-                    void const*& oPtr) const;
-    void operator()(T const& obj,
-                    std::type_info const& iToType,
-                    std::vector<unsigned long> const& iIndex,
-                    std::vector<void const*>& oPtr) const;
-  };
-
-  template <typename T>
-  struct DoNotSetPtr {
-    void operator()(T const& /*obj*/,
-                    std::type_info const& /*iToType*/,
-                    unsigned long /*iIndex*/,
-                    void const*& /*oPtr*/) const {
-      Exception::throwThis(errors::ProductDoesNotSupportPtr,
-        "The product type ",
-        typeid(T).name(),
-        "\ndoes not support edm::Ptr\n");
-    }
-    void operator()(T const& /*obj*/,
-                    std::type_info const& /*iToType*/,
-                    std::vector<unsigned long> const& /*iIndexes*/,
-                    std::vector<void const*>& /*oPtrs*/) const {
-      Exception::throwThis(errors::ProductDoesNotSupportPtr,
-        "The product type ",
-        typeid(T).name(),
-        "\ndoes not support edm::PtrVector\n");
-    }
-  };
-
-  template <typename T>
-  inline
-  void Wrapper<T>::do_setPtr(std::type_info const& iToType,
-                             unsigned long iIndex,
-                             void const*& oPtr) const {
-    typename boost::mpl::if_c<has_setPtr<T>::value,
-    DoSetPtr<T>,
-    DoNotSetPtr<T> >::type maybe_filler;
-    maybe_filler(this->obj, iToType, iIndex, oPtr);
-  }
-
-  template <typename T>
-  void Wrapper<T>::do_fillPtrVector(std::type_info const& iToType,
-                                       std::vector<unsigned long> const& iIndices,
-                                       std::vector<void const*>& oPtr) const {
-    typename boost::mpl::if_c<has_setPtr<T>::value,
-    DoSetPtr<T>,
-    DoNotSetPtr<T> >::type maybe_filler;
-    maybe_filler(this->obj, iToType, iIndices, oPtr);
-  }
-
-  // This is an attempt to optimize for speed, by avoiding the copying
-  // of large objects of type T. In this initial version, we assume
-  // that for any class having a 'swap' member function should call
-  // 'swap' rather than copying the object.
-
-  template <typename T>
-  struct DoSwap {
-    void operator()(T& a, T& b) { a.swap(b); }
-  };
-
-  template <typename T>
-  struct DoAssign {
-    void operator()(T& a, T& b) { a = b; }
-  };
-
-#ifndef __GCCXML__
-  template <typename T>
-  struct IsMergeable {
-    bool operator()(T const&) const { return true; }
-  };
-
-  template <typename T>
-  struct IsNotMergeable {
-    bool operator()(T const&) const { return false; }
-  };
-
-  template <typename T>
-  struct DoMergeProduct {
-    bool operator()(T& a, T const& b) { return a.mergeProduct(b); }
-  };
-
-  template <typename T>
-  struct DoNotMergeProduct {
-    bool operator()(T&, T const&) { return true; }
-  };
-
-  template <typename T>
-  struct DoHasIsProductEqual {
-    bool operator()(T const&) const { return true; }
-  };
-
-  template <typename T>
-  struct DoNotHasIsProductEqual {
-    bool operator()(T const&) const { return false; }
-  };
-
-  template <typename T>
-  struct DoIsProductEqual {
-    bool operator()(T const& a, T const& b) const { return a.isProductEqual(b); }
-  };
-
-  template <typename T>
-  struct DoNotIsProductEqual {
-    bool operator()(T const&, T const&) const { return true; }
-  };
-#endif
-
-  //------------------------------------------------------------
-  // Metafunction support for compile-time selection of code used in
-  // Wrapper constructor
-  //
-
-  namespace detail {
-    typedef char (& no_tag)[1]; // type indicating FALSE
-    typedef char (& yes_tag)[2]; // type indicating TRUE
-
-    // Definitions for the following struct and function templates are
-    // not needed; we only require the declarations.
-    template <typename T, void (T::*)(T&)>  struct swap_function;
-    template <typename T> no_tag  has_swap_helper(...);
-    template <typename T> yes_tag has_swap_helper(swap_function<T, &T::swap> * dummy);
-
-    template<typename T>
-    struct has_swap_function {
-      static bool const value =
-        sizeof(has_swap_helper<T>(0)) == sizeof(yes_tag);
-    };
-
-#ifndef __GCCXML__
-
-    template <typename T> static yes_tag& has_value_type(typename T::value_type*);
-    template <typename T> static no_tag& has_value_type(...);
-    template <typename T> struct has_typedef_value_type {
-      static const bool value = sizeof(has_value_type<T>(nullptr)) == sizeof(yes_tag);
-    };
-    template <typename T, bool = has_typedef_value_type<T>::value> struct getValueType;
-    template <typename T> struct getValueType<T, true> {
-      std::type_info const& operator()() {
-        return typeid(typename T::value_type);
-      }
-    };
-    template <typename T> struct getValueType<T, false> {
-      std::type_info const& operator()() {
-        return typeid(void);
-      }
-    };
-
-    template <typename T> static yes_tag& has_member_type(typename T::member_type*);
-    template <typename T> static no_tag& has_member_type(...);
-    template <typename T> struct has_typedef_member_type {
-      static const bool value = sizeof(has_member_type<T>(nullptr)) == sizeof(yes_tag);
-    };
-    template <typename T, bool = has_typedef_member_type<T>::value> struct getMemberType;
-    template <typename T> struct getMemberType<T, true> {
-      std::type_info const& operator()() {
-        return typeid(typename T::member_type);
-      }
-    };
-    template <typename T> struct getMemberType<T, false> {
-      std::type_info const& operator()() {
-        return typeid(void);
-      }
-    };
-
-    template <typename T, bool (T::*)(T const&)>  struct mergeProduct_function;
-    template <typename T> no_tag  has_mergeProduct_helper(...);
-    template <typename T> yes_tag has_mergeProduct_helper(mergeProduct_function<T, &T::mergeProduct> * dummy);
-
-    template<typename T>
-    struct has_mergeProduct_function {
-      static bool const value =
-        sizeof(has_mergeProduct_helper<T>(0)) == sizeof(yes_tag);
-    };
-
-    template <typename T, bool (T::*)(T const&) const> struct isProductEqual_function;
-    template <typename T> no_tag  has_isProductEqual_helper(...);
-    template <typename T> yes_tag has_isProductEqual_helper(isProductEqual_function<T, &T::isProductEqual> * dummy);
-
-    template<typename T>
-    struct has_isProductEqual_function {
-      static bool const value =
-        sizeof(has_isProductEqual_helper<T>(0)) == sizeof(yes_tag);
-    };
-#endif
-  }
-
-#ifndef __GCCXML__
-  template <typename T>
+  template<typename T>
   Wrapper<T>::Wrapper(std::unique_ptr<T> ptr) :
     WrapperBase(),
     present(ptr.get() != 0),
@@ -322,14 +93,11 @@ namespace edm {
     if (present) {
       // The following will call swap if T has such a function,
       // and use assignment if T has no such function.
-      typename boost::mpl::if_c<detail::has_swap_function<T>::value,
-        DoSwap<T>,
-        DoAssign<T> >::type swap_or_assign;
       swap_or_assign(obj, *ptr);
     }
   }
 
-  template <typename T>
+  template<typename T>
   Wrapper<T>::Wrapper(T* ptr) :
   WrapperBase(),
   present(ptr != 0),
@@ -338,178 +106,50 @@ namespace edm {
      if (present) {
         // The following will call swap if T has such a function,
         // and use assignment if T has no such function.
-        typename boost::mpl::if_c<detail::has_swap_function<T>::value,
-        DoSwap<T>,
-        DoAssign<T> >::type swap_or_assign;
         swap_or_assign(obj, *ptr);
      }
-
   }
-#endif
 
-#ifndef __GCCXML__
-  template <typename T>
+  template<typename T>
+  inline
   std::type_info const& Wrapper<T>::valueTypeInfo_() const {
     return detail::getValueType<T>()();
   }
 
-  template <typename T>
+  template<typename T>
+  inline
   std::type_info const& Wrapper<T>::memberTypeInfo_() const {
     return detail::getMemberType<T>()();
   }
-#endif
 
-#ifndef __GCCXML__
-  template <typename T>
+  template<typename T>
+  inline 
   bool Wrapper<T>::isMergeable_() const {
-    typename boost::mpl::if_c<detail::has_mergeProduct_function<T>::value,
-      IsMergeable<T>,
-      IsNotMergeable<T> >::type is_mergeable;
-    return is_mergeable(obj);
+    return detail::getHasMergeFunction<T>()();
   }
 
-  template <typename T>
+  template<typename T>
+  inline
   bool Wrapper<T>::mergeProduct_(WrapperBase const* newProduct) {
     Wrapper<T> const* wrappedNewProduct = dynamic_cast<Wrapper<T> const*>(newProduct);
     assert(wrappedNewProduct != nullptr);
-    typename boost::mpl::if_c<detail::has_mergeProduct_function<T>::value,
-      DoMergeProduct<T>,
-      DoNotMergeProduct<T> >::type merge_product;
-    return merge_product(obj, wrappedNewProduct->obj);
+    return detail::doMergeProduct<T>()(obj, wrappedNewProduct->obj);
   }
 
-  template <typename T>
+  template<typename T>
+  inline
   bool Wrapper<T>::hasIsProductEqual_() const {
-    typename boost::mpl::if_c<detail::has_isProductEqual_function<T>::value,
-      DoHasIsProductEqual<T>,
-      DoNotHasIsProductEqual<T> >::type has_is_equal;
-    return has_is_equal(obj);
+    return detail::getHasIsProductEqual<T>()();
   }
 
-  template <typename T>
+  template<typename T>
+  inline
   bool Wrapper<T>::isProductEqual_(WrapperBase const* newProduct) const {
     Wrapper<T> const* wrappedNewProduct = dynamic_cast<Wrapper<T> const*>(newProduct);
     assert(wrappedNewProduct != nullptr);
-    typename boost::mpl::if_c<detail::has_isProductEqual_function<T>::value,
-      DoIsProductEqual<T>,
-      DoNotIsProductEqual<T> >::type is_equal;
-    return is_equal(obj, wrappedNewProduct->obj);
+    return detail::doIsProductEqual<T>()(obj, wrappedNewProduct->obj);
   }
 #endif
 }
-
-#include "DataFormats/Common/interface/RefVector.h"
-#include "DataFormats/Common/interface/RefToBaseVector.h"
-
-namespace edm {
-  namespace helpers {
-    template<typename T>
-    struct ViewFiller {
-      static void fill(T const& obj,
-                       ProductID const& id,
-                       std::vector<void const*>& pointers,
-                       helper_vector_ptr & helpers) {
-        /// the following shoudl work also if T is a RefVector<C>
-        typedef Ref<T> ref;
-        typedef RefVector<T, typename ref::value_type, typename ref::finder_type> ref_vector;
-        helpers = helper_vector_ptr(new reftobase::RefVectorHolder<ref_vector>);
-        // fillView is the name of an overload set; each concrete
-        // collection T should supply a fillView function, in the same
-        // namespace at that in which T is defined, or in the 'edm'
-        // namespace.
-        fillView(obj, id, pointers, * helpers);
-        assert(pointers.size() == helpers->size());
-     }
-    };
-
-    template<typename T>
-    struct ViewFiller<RefToBaseVector<T> > {
-      static void fill(RefToBaseVector<T> const& obj,
-                       ProductID const&,
-                       std::vector<void const*>& pointers,
-                       helper_vector_ptr & helpers) {
-        std::auto_ptr<helper_vector> h = obj.vectorHolder();
-        if(h.get() != 0) {
-          pointers.reserve(h->size());
-          // NOTE: the following implementation has unusual signature!
-          fillView(obj, pointers);
-          helpers = helper_vector_ptr(h.release());
-        }
-      }
-    };
-
-    template<typename T>
-    struct ViewFiller<PtrVector<T> > {
-      static void fill(PtrVector<T> const& obj,
-                       ProductID const&,
-                       std::vector<void const*>& pointers,
-                       helper_vector_ptr & helpers) {
-        std::auto_ptr<helper_vector> h(new reftobase::RefVectorHolder<PtrVector<T> >(obj));
-        if(h.get() != 0) {
-          pointers.reserve(obj.size());
-          // NOTE: the following implementation has unusual signature!
-          fillView(obj, pointers);
-          helpers = helper_vector_ptr(h.release());
-        }
-      }
-    };
-
-    template<typename T>
-      struct PtrSetter {
-        static void set(T const& obj,
-                         std::type_info const& iToType,
-                         unsigned long iIndex,
-                         void const*& oPtr) {
-          // setPtr is the name of an overload set; each concrete
-          // collection T should supply a fillView function, in the same
-          // namespace at that in which T is defined, or in the 'edm'
-          // namespace.
-          setPtr(obj, iToType, iIndex, oPtr);
-        }
-
-        static void fill(T const& obj,
-                         std::type_info const& iToType,
-                         std::vector<unsigned long> const& iIndex,
-                         std::vector<void const*>& oPtr) {
-          // fillPtrVector is the name of an overload set; each concrete
-          // collection T should supply a fillPtrVector function, in the same
-          // namespace at that in which T is defined, or in the 'edm'
-          // namespace.
-          fillPtrVector(obj, iToType, iIndex, oPtr);
-        }
-      };
-  }
-
-#ifndef __GCCXML__
-  template <typename T>
-  void DoFillView<T>::operator()(T const& obj,
-                                 ProductID const& id,
-                                 std::vector<void const*>& pointers,
-                                 helper_vector_ptr& helpers) const {
-    helpers::ViewFiller<T>::fill(obj, id, pointers, helpers);
-  }
-#endif
-
-  template <typename T>
-  void DoSetPtr<T>::operator()(T const& obj,
-                               std::type_info const& iToType,
-                               unsigned long iIndex,
-                               void const*& oPtr) const {
-    helpers::PtrSetter<T>::set(obj, iToType, iIndex, oPtr);
-  }
-
-  template <typename T>
-  void DoSetPtr<T>::operator()(T const& obj,
-                               std::type_info const& iToType,
-                               std::vector<unsigned long> const& iIndices,
-                               std::vector<void const*>& oPtr) const {
-    helpers::PtrSetter<T>::fill(obj, iToType, iIndices, oPtr);
-  }
-
-}
-
-#include "DataFormats/Common/interface/FillView.h"
-#include "DataFormats/Common/interface/setPtr.h"
-#include "DataFormats/Common/interface/fillPtrVector.h"
-
+#include "DataFormats/Common/interface/WrapperView.icc"
 #endif

--- a/DataFormats/Common/interface/WrapperBase.h
+++ b/DataFormats/Common/interface/WrapperBase.h
@@ -60,10 +60,10 @@ namespace edm {
     virtual bool isPresent_() const {return true;}
 
 #ifndef __GCCXML__
-    virtual bool isMergeable_() const { return true; }
-    virtual bool mergeProduct_(WrapperBase const* /* newProduct */) { return true; }
-    virtual bool hasIsProductEqual_() const { return true; }
-    virtual bool isProductEqual_(WrapperBase const* /* newProduct */) const { return true; }
+    virtual bool isMergeable_() const = 0;
+    virtual bool mergeProduct_(WrapperBase const* newProduct ) = 0;
+    virtual bool hasIsProductEqual_() const = 0;
+    virtual bool isProductEqual_(WrapperBase const* newProduct) const = 0;
 #endif
 
     virtual void do_fillView(ProductID const& id,

--- a/DataFormats/Common/interface/WrapperDetail.h
+++ b/DataFormats/Common/interface/WrapperDetail.h
@@ -1,0 +1,154 @@
+#ifndef DataFormats_Common_WrapperDetail_h
+#define DataFormats_Common_WrapperDetail_h
+
+/*----------------------------------------------------------------------
+
+WrapperDetail: Metafunction support for compile-time selection of code.
+
+----------------------------------------------------------------------*/
+
+#include <typeinfo>
+namespace edm {
+  namespace detail {
+    typedef char (& no_tag)[1]; // type indicating FALSE
+    typedef char (& yes_tag)[2]; // type indicating TRUE
+
+    // void swap_or_assign(T& a, T& b) will swap if T::swap(T&) is defined and assign otherwise
+    // Definitions for the following struct and function templates are not needed; we only require the declarations.
+    template<typename T, void (T::*)(T&)> struct swap_function;
+    template<typename T> static yes_tag has_swap(swap_function<T, &T::swap>* dummy);
+    template<typename T> static no_tag has_swap(...);
+
+    template<typename T>
+    struct has_swap_function {
+      static bool const value = sizeof(has_swap<T>(0)) == sizeof(yes_tag);
+    };
+
+    template<typename T, bool = has_swap_function<T>::value> struct doSwapOrAssign;
+    template<typename T> struct doSwapOrAssign<T, true> {
+      void operator()(T& thisProduct, T& otherProduct) {
+        thisProduct.swap(otherProduct);
+      }
+    };
+    template<typename T> struct doSwapOrAssign<T, false> {
+      void operator()(T& thisProduct, T& otherProduct) {
+        thisProduct = otherProduct;
+      }
+    };
+
+#ifndef __GCCXML__
+    // valueTypeInfo_() will return typeid(T::value_type) if T::value_type is declared and typeid(void) otherwise.
+    // Definitions for the following struct and function templates are not needed; we only require the declarations.
+    template<typename T> static yes_tag& has_value_type(typename T::value_type*);
+    template<typename T> static no_tag& has_value_type(...);
+
+    template<typename T> struct has_typedef_value_type {
+      static const bool value = sizeof(has_value_type<T>(nullptr)) == sizeof(yes_tag);
+    };
+    template<typename T, bool = has_typedef_value_type<T>::value> struct getValueType;
+    template<typename T> struct getValueType<T, true> {
+      std::type_info const& operator()() {
+        return typeid(typename T::value_type);
+      }
+    };
+    template<typename T> struct getValueType<T, false> {
+      std::type_info const& operator()() {
+        return typeid(void);
+      }
+    };
+
+    // memberTypeInfo_() will return typeid(T::member_type) if T::member_type is declared and typeid(void) otherwise.
+    // Definitions for the following struct and function templates are not needed; we only require the declarations.
+    template<typename T> static yes_tag& has_member_type(typename T::member_type*);
+    template<typename T> static no_tag& has_member_type(...);
+
+    template<typename T> struct has_typedef_member_type {
+      static const bool value = sizeof(has_member_type<T>(nullptr)) == sizeof(yes_tag);
+    };
+    template<typename T, bool = has_typedef_member_type<T>::value> struct getMemberType;
+    template<typename T> struct getMemberType<T, true> {
+      std::type_info const& operator()() {
+        return typeid(typename T::member_type);
+      }
+    };
+    template<typename T> struct getMemberType<T, false> {
+      std::type_info const& operator()() {
+        return typeid(void);
+      }
+    };
+
+    // bool isMergeable_() will return true if T::mergeProduct(T const&) is declared and false otherwise
+    // bool mergeProduct_(WrapperBase const*) will merge products if T::mergeProduct(T const&) is defined
+    // Definitions for the following struct and function templates are not needed; we only require the declarations.
+    template<typename T, bool (T::*)(T const&)> struct mergeProduct_function;
+    template<typename T> static yes_tag has_mergeProduct(mergeProduct_function<T, &T::mergeProduct>* dummy);
+    template<typename T> static no_tag has_mergeProduct(...);
+
+    template<typename T>
+    struct has_mergeProduct_function {
+      static bool const value =
+        sizeof(has_mergeProduct<T>(0)) == sizeof(yes_tag);
+    };
+
+    template<typename T, bool = has_mergeProduct_function<T>::value> struct getHasMergeFunction;
+    template<typename T> struct getHasMergeFunction<T, true> {
+      bool operator()() {
+        return true;
+      }
+    };
+    template<typename T> struct getHasMergeFunction<T, false> {
+      bool operator()() {
+        return false;
+      }
+    };
+    template<typename T, bool = has_mergeProduct_function<T>::value> struct doMergeProduct;
+    template<typename T> struct doMergeProduct<T, true> {
+      bool operator()(T& thisProduct, T const& newProduct) {
+        return thisProduct.mergeProduct(newProduct);
+      }
+    };
+    template<typename T> struct doMergeProduct<T, false> {
+      bool operator()(T& thisProduct, T const& newProduct) {
+        return true; // Should never be called
+      }
+    };
+
+    // bool hasIsProductEqual_() will return true if T::isProductEqual(T const&) const is declared and false otherwise
+    // bool isProductEqual _(WrapperBase const*) will call T::isProductEqual(T const&) if it is defined
+    // Definitions for the following struct and function templates are not needed; we only require the declarations.
+    template<typename T, bool (T::*)(T const&) const> struct isProductEqual_function;
+    template<typename T> static yes_tag has_isProductEqual(isProductEqual_function<T, &T::isProductEqual>* dummy);
+    template<typename T> static no_tag has_isProductEqual(...);
+
+    template<typename T>
+    struct has_isProductEqual_function {
+      static bool const value =
+        sizeof(has_isProductEqual<T>(0)) == sizeof(yes_tag);
+    };
+
+    template<typename T, bool = has_isProductEqual_function<T>::value> struct getHasIsProductEqual;
+    template<typename T> struct getHasIsProductEqual<T, true> {
+      bool operator()() {
+        return true;
+      }
+    };
+    template<typename T> struct getHasIsProductEqual<T, false> {
+      bool operator()() {
+        return false;
+      }
+    };
+    template<typename T, bool = has_isProductEqual_function<T>::value> struct doIsProductEqual;
+    template<typename T> struct doIsProductEqual<T, true> {
+      bool operator()(T const& thisProduct, T const& newProduct) {
+        return thisProduct.isProductEqual(newProduct);
+      }
+    };
+    template<typename T> struct doIsProductEqual<T, false> {
+      bool operator()(T const& thisProduct, T const& newProduct) {
+        return true; // Should never be called
+      }
+    };
+#endif
+  }
+}
+#endif

--- a/DataFormats/Common/interface/WrapperView.icc
+++ b/DataFormats/Common/interface/WrapperView.icc
@@ -1,0 +1,161 @@
+#ifndef DataFormats_Common_WrapperView_icc
+#define DataFormats_Common_WrapperView_icc
+
+/*----------------------------------------------------------------------
+
+Code from Wrapper.h supporting Views
+
+----------------------------------------------------------------------*/
+
+#include "DataFormats/Common/interface/fwd_fillPtrVector.h"
+#include "DataFormats/Common/interface/fwd_setPtr.h"
+#include "DataFormats/Common/interface/Ref.h"
+#include "DataFormats/Common/interface/PtrVector.h"
+#include "DataFormats/Common/interface/RefVectorHolder.h"
+#include "DataFormats/Common/interface/traits.h"
+#include "FWCore/Utilities/interface/EDMException.h"
+#include "boost/mpl/if.hpp"
+
+namespace edm {
+
+  template<typename T>
+  struct DoFillView {
+    void operator()(T const& obj, ProductID const& id, std::vector<void const*>& pointers, helper_vector_ptr & helpers) const;
+  };
+
+  template<typename T>
+  struct DoNotFillView {
+    void operator()(T const&, ProductID const&, std::vector<void const*>&, helper_vector_ptr&) const {
+      Exception::throwThis(errors::ProductDoesNotSupportViews, "The product type ", typeid(T).name(), "\ndoes not support Views\n");
+    }
+  };
+
+  template<typename T>
+  inline
+  void Wrapper<T>::do_fillView(ProductID const& id, std::vector<void const*>& pointers, helper_vector_ptr& helpers) const {
+    typename boost::mpl::if_c<has_fillView<T>::value,
+    DoFillView<T>,
+    DoNotFillView<T> >::type maybe_filler;
+    maybe_filler(obj, id, pointers, helpers);
+  }
+
+
+  template<typename T>
+  struct DoSetPtr {
+    void operator()(T const& obj, std::type_info const& iToType, unsigned long iIndex, void const*& oPtr) const;
+    void operator()(T const& obj, std::type_info const& iToType, std::vector<unsigned long> const& iIndex, std::vector<void const*>& oPtr) const;
+  };
+
+  template<typename T>
+  struct DoNotSetPtr {
+    void operator()(T const& /*obj*/, std::type_info const& iToType, unsigned long iIndex, void const*& oPtr) const {
+      Exception::throwThis(errors::ProductDoesNotSupportPtr, "The product type ", typeid(T).name(), "\ndoes not support edm::Ptr\n");
+    }
+    void operator()(T const& obj, std::type_info const& iToType, std::vector<unsigned long> const& iIndexes, std::vector<void const*>& oPtrs) const {
+      Exception::throwThis(errors::ProductDoesNotSupportPtr, "The product type ", typeid(T).name(), "\ndoes not support edm::PtrVector\n");
+    }
+  };
+
+  template<typename T>
+  inline
+  void Wrapper<T>::do_setPtr(std::type_info const& iToType, unsigned long iIndex, void const*& oPtr) const {
+    typename boost::mpl::if_c<has_setPtr<T>::value,
+    DoSetPtr<T>,
+    DoNotSetPtr<T> >::type maybe_filler;
+    maybe_filler(this->obj, iToType, iIndex, oPtr);
+  }
+
+  template<typename T>
+  void Wrapper<T>::do_fillPtrVector(std::type_info const& iToType, std::vector<unsigned long> const& iIndices, std::vector<void const*>& oPtr) const {
+    typename boost::mpl::if_c<has_setPtr<T>::value,
+    DoSetPtr<T>,
+    DoNotSetPtr<T> >::type maybe_filler;
+    maybe_filler(this->obj, iToType, iIndices, oPtr);
+  }
+}
+
+#include "DataFormats/Common/interface/RefVector.h"
+#include "DataFormats/Common/interface/RefToBaseVector.h"
+
+namespace edm {
+  namespace helpers {
+    template<typename T>
+    struct ViewFiller {
+      static void fill(T const& obj, ProductID const& id, std::vector<void const*>& pointers, helper_vector_ptr & helpers) {
+        /// the following shoudl work also if T is a RefVector<C>
+        typedef Ref<T> ref;
+        typedef RefVector<T, typename ref::value_type, typename ref::finder_type> ref_vector;
+        helpers = helper_vector_ptr(new reftobase::RefVectorHolder<ref_vector>);
+        // fillView is the name of an overload set; each concrete collection T should supply a fillView function,
+        // in the same namespace at that in which T is defined, or in the 'edm' namespace.
+        fillView(obj, id, pointers, * helpers);
+        assert(pointers.size() == helpers->size());
+     }
+    };
+
+    template<typename T>
+    struct ViewFiller<RefToBaseVector<T> > {
+      static void fill(RefToBaseVector<T> const& obj, ProductID const&, std::vector<void const*>& pointers, helper_vector_ptr & helpers) {
+        std::auto_ptr<helper_vector> h = obj.vectorHolder();
+        if(h.get() != 0) {
+          pointers.reserve(h->size());
+          // NOTE: the following implementation has unusual signature!
+          fillView(obj, pointers);
+          helpers = helper_vector_ptr(h.release());
+        }
+      }
+    };
+
+    template<typename T>
+    struct ViewFiller<PtrVector<T> > {
+      static void fill(PtrVector<T> const& obj, ProductID const&, std::vector<void const*>& pointers, helper_vector_ptr & helpers) {
+        std::auto_ptr<helper_vector> h(new reftobase::RefVectorHolder<PtrVector<T> >(obj));
+        if(h.get() != 0) {
+          pointers.reserve(obj.size());
+          // NOTE: the following implementation has unusual signature!
+          fillView(obj, pointers);
+          helpers = helper_vector_ptr(h.release());
+        }
+      }
+    };
+
+    template<typename T>
+      struct PtrSetter {
+        static void set(T const& obj, std::type_info const& iToType, unsigned long iIndex, void const*& oPtr) {
+          // setPtr is the name of an overload set; each concrete collection T should supply a fillView function, in the same
+          // namespace at that in which T is defined, or in the 'edm' namespace.
+          setPtr(obj, iToType, iIndex, oPtr);
+        }
+
+        static void fill(T const& obj, std::type_info const& iToType, std::vector<unsigned long> const& iIndex, std::vector<void const*>& oPtr) {
+          // fillPtrVector is the name of an overload set; each concrete collection T should supply a fillPtrVector function,
+          // in the same namespace at that in which T is defined, or in the 'edm'  namespace.
+          fillPtrVector(obj, iToType, iIndex, oPtr);
+        }
+      };
+  }
+
+#ifndef __GCCXML__
+  template<typename T>
+  void DoFillView<T>::operator()(T const& obj, ProductID const& id, std::vector<void const*>& pointers, helper_vector_ptr& helpers) const {
+    helpers::ViewFiller<T>::fill(obj, id, pointers, helpers);
+  }
+#endif
+
+  template<typename T>
+  void DoSetPtr<T>::operator()(T const& obj, std::type_info const& iToType, unsigned long iIndex, void const*& oPtr) const {
+    helpers::PtrSetter<T>::set(obj, iToType, iIndex, oPtr);
+  }
+
+  template<typename T>
+  void DoSetPtr<T>::operator()(T const& obj, std::type_info const& iToType, std::vector<unsigned long> const& iIndices, std::vector<void const*>& oPtr) const {
+    helpers::PtrSetter<T>::fill(obj, iToType, iIndices, oPtr);
+  }
+
+}
+
+#include "DataFormats/Common/interface/FillView.h"
+#include "DataFormats/Common/interface/setPtr.h"
+#include "DataFormats/Common/interface/fillPtrVector.h"
+
+#endif


### PR DESCRIPTION
The header file Wrapper.h is difficult to maintain, as it is very long and has heterogeneous content, with inconsistent formatting.  This pull request is primarily a physical reorganization of this file.  It splits Wrapper.h into three separate, more coherent files.  One new file, WrapperView.icc contains the member function definitions for functions that support views, and associated helpers, with absolutely no changes to the implementation  A second new file, WrapperDetail.h, now contains the low level detailed code for supporting SFINAE metaprogramming so functions (other than view related functions) can act differently based on the member functions or data of the wrapped class. Also, the formatting of the remaining content of Wrapper.h is standardized to make it easier to read.  There are also two minor substantive internal improvements, neither of which impacts functionality.  One is that in WrapperBase.h, four functions that should have been declared as pure virtual are now so declared.  Secondly, the SFINAE code that was moved to WrapperDetail.h used two different implementations for SFINAE for historical reasons, which makes maintainability more difficult.  This pull request standardizes the SFINAE code in WrapperDetail.h  to use the same implementation throughout. No  API is modified by this pull request.  All framework unit tests and the short set of relval tests pass with this PR.
