### PR TITLE
Remove occupancy-based flagging of merged clusters

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
@@ -25,10 +25,7 @@ produce(edm::Event& event, const edm::EventSetup& es)  {
   algorithm->initialize(es);  
 
   BOOST_FOREACH( const edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> >& token, inputTokens) {
-    if(      findInput( token, inputOld, event) ) {
-      algorithm->clusterize(*inputOld, *output);
-      refineCluster(inputOld, output);
-    } 
+    if(      findInput( token, inputOld, event) ) algorithm->clusterize(*inputOld, *output); 
 //     else if( findInput( tag, inputNew, event) ) algorithm->clusterize(*inputNew, *output);
     else edm::LogError("Input Not Found") << "[SiStripClusterizer::produce] ";// << tag;
   }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
@@ -4,19 +4,13 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/transform.h"
 #include "boost/foreach.hpp"
-#include "CalibFormats/SiStripObjects/interface/SiStripQuality.h"
-#include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 
 SiStripClusterizer::
 SiStripClusterizer(const edm::ParameterSet& conf) 
-  : confClusterizer_(conf.getParameter<edm::ParameterSet>("Clusterizer")),
-    inputTags( conf.getParameter<std::vector<edm::InputTag> >("DigiProducersList") ),
+  : inputTags( conf.getParameter<std::vector<edm::InputTag> >("DigiProducersList") ),
     algorithm( StripClusterizerAlgorithmFactory::create(conf.getParameter<edm::ParameterSet>("Clusterizer")) ) {
   produces< edmNew::DetSetVector<SiStripCluster> > ();
   inputTokens = edm::vector_transform( inputTags, [this](edm::InputTag const & tag) { return consumes< edm::DetSetVector<SiStripDigi> >(tag);} );
-  doRefineCluster_ = confClusterizer_.existsAs<bool>("doRefineCluster") ? confClusterizer_.getParameter<bool>("doRefineCluster") : false;
-  occupancyThreshold_ = confClusterizer_.existsAs<double>("occupancyThreshold") ? confClusterizer_.getParameter<double>("occupancyThreshold") : 0.05;
-  widthThreshold_ = confClusterizer_.existsAs<unsigned>("widthThreshold") ? confClusterizer_.getParameter<unsigned>("widthThreshold") : 4;
 }
 
 void SiStripClusterizer::
@@ -33,7 +27,7 @@ produce(edm::Event& event, const edm::EventSetup& es)  {
   BOOST_FOREACH( const edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> >& token, inputTokens) {
     if(      findInput( token, inputOld, event) ) {
       algorithm->clusterize(*inputOld, *output);
-      if (doRefineCluster_) refineCluster(inputOld, output);
+      refineCluster(inputOld, output);
     } 
 //     else if( findInput( tag, inputNew, event) ) algorithm->clusterize(*inputNew, *output);
     else edm::LogError("Input Not Found") << "[SiStripClusterizer::produce] ";// << tag;
@@ -51,39 +45,4 @@ bool SiStripClusterizer::
 findInput(const edm::EDGetTokenT<T>& tag, edm::Handle<T>& handle, const edm::Event& e) {
     e.getByToken( tag, handle);
     return handle.isValid();
-}
-
-void SiStripClusterizer::
-refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
-	      std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output) {
-  if (input->size() == 0) return;
-
-  // Flag merge-prone clusters for relaxed CPE errors
-  // Criterion is sensor occupancy and cluster width exceeding thresholds
-
-  for (edmNew::DetSetVector<SiStripCluster>::const_iterator det=output->begin(); det!=output->end(); det++) {
-    uint32_t detId = det->id();
-    // Find the number of good strips in this sensor
-    int nchannideal = SiStripDetCabling_->nApvPairs(detId) * 2 * 128;
-    int nchannreal = 0;
-    for(int strip = 0; strip < nchannideal; ++strip)
-      if(!quality_->IsStripBad(detId,strip)) ++nchannreal;
-
-    edm::DetSetVector<SiStripDigi>::const_iterator digis = input->find(detId);
-    if (digis != input->end()) {
-      int ndigi = digis->size();
-      for (edmNew::DetSet<SiStripCluster>::iterator clust = det->begin(); clust != det->end(); clust++) {
-	if (ndigi > occupancyThreshold_*nchannreal && clust->amplitudes().size() >= widthThreshold_) clust->setMerged(true);
-	else clust->setMerged(false);
-      }
-      // std::cout << "Sensor:strips_occStrips_clust " << nchannreal << " " << ndigi << " " << det->size() << std::endl;
-    }
-  }  // traverse sensors
-}
-
-void SiStripClusterizer::beginRun(const edm::Run& run, const edm::EventSetup& es ) {
-  if (doRefineCluster_) {
-    es.get<SiStripDetCablingRcd>().get( SiStripDetCabling_);
-    es.get<SiStripQualityRcd>().get("", quality_);
-  }
 }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -6,8 +6,6 @@
 #include "RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
-#include "CalibTracker/Records/interface/SiStripQualityRcd.h"
 
 #include <vector>
 #include <memory>
@@ -17,26 +15,19 @@ class SiStripClusterizer : public edm::stream::EDProducer<>  {
 public:
 
   explicit SiStripClusterizer(const edm::ParameterSet& conf);
-  void beginRun(const edm::Run& run, const edm::EventSetup& es) override;
   virtual void produce(edm::Event&, const edm::EventSetup&);
 
 private:
 
-  edm::ParameterSet confClusterizer_;
-  bool doRefineCluster_;
-  float occupancyThreshold_;
-  unsigned widthThreshold_;
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
   std::auto_ptr<StripClusterizerAlgorithm> algorithm;
   void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
-		     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output);
+			     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output) {};
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;
   token_v inputTokens;
 
-  edm::ESHandle<SiStripDetCabling> SiStripDetCabling_;
-  edm::ESHandle<SiStripQuality> quality_;
 };
 
 #endif

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -22,7 +22,7 @@ private:
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
   std::auto_ptr<StripClusterizerAlgorithm> algorithm;
-  void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
+  virtual void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
 			     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output) {};
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -22,8 +22,6 @@ private:
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
   std::auto_ptr<StripClusterizerAlgorithm> algorithm;
-  void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
-			     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output) {};
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;
   token_v inputTokens;

--- a/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/DefaultClusterizer_cff.py
@@ -10,8 +10,5 @@ DefaultClusterizer = cms.PSet(
     MaxAdjacentBad = cms.uint32(0),
     QualityLabel = cms.string(""),
     RemoveApvShots     = cms.bool(True),
-    minGoodCharge = cms.double(-2069),
-    doRefineCluster = cms.bool(False),
-    occupancyThreshold = cms.double(0.05),
-    widthThreshold = cms.uint32(4)
+    minGoodCharge = cms.double(-2069)
     )


### PR DESCRIPTION
This just cleans up SiStripClusterizer removing the code that calculates sensor occupancy and flags a cluster as merged if that occupancy is above a threshold.  This approach didn't prove effective in a pileup environment, and instead we implemented the chargePerCM cut in stripCPEfromTrackAngle.  I have left a null refineCluster member function that can be overwritten in a derived class to facilitate studies.
This PR obviates the need to address three of the four parameters cited in this JIRA ticket:
https://its.cern.ch/jira/browse/CMSTRACK-120
since doRefineCluster, occupancyThreshold, and widthThreshold have been removed.
This PR has no effect on production with the default parameters.
