### PR TITLE
Fixing Magnetic field for track refit in HIP

### DIFF
--- a/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
+++ b/Alignment/HIPAlignmentAlgorithm/python/common_cff_py.txt
@@ -1,7 +1,7 @@
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
 # loading magnetic field and geometry
-process.load("Configuration.StandardSequences.MagneticField_cff")
+process.load("Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff")
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
 
 # loading the alignment producer


### PR DESCRIPTION
Fix magnetic field used in track refitting in HIP jobs. Now shall automatically account for the correct magnetic field, by accessing to the magnet current from DB. 
