### PR TITLE
bugfix for ConversionTools

### DIFF
--- a/RecoEgamma/EgammaTools/interface/ConversionTools.h
+++ b/RecoEgamma/EgammaTools/interface/ConversionTools.h
@@ -68,11 +68,11 @@ class ConversionTools
                                                   const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, float dRMax = 0.1, float dEtaMax = 999., float dPhiMax = 999., float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=1);
 
     static bool                        hasMatchedPromptElectron(const reco::SuperClusterRef &sc, const edm::Handle<reco::GsfElectronCollection> &eleCol,
-                                                  const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
+                                                  const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch=true, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
 
 
     static reco::GsfElectronRef        matchedPromptElectron(const reco::SuperClusterRef &sc, const edm::Handle<reco::GsfElectronCollection> &eleCol,
-                                                  const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
+                                                  const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch=true, float lxyMin=2.0, float probMin=1e-6, unsigned int nHitsBeforeVtxMax=0);
 
 };
 #endif

--- a/RecoEgamma/EgammaTools/src/ConversionTools.cc
+++ b/RecoEgamma/EgammaTools/src/ConversionTools.cc
@@ -294,7 +294,7 @@ reco::ConversionRef ConversionTools::matchedConversion(const reco::SuperCluster 
 
 //--------------------------------------------------------------------------------------------------
 bool ConversionTools::hasMatchedPromptElectron(const reco::SuperClusterRef &sc, const edm::Handle<reco::GsfElectronCollection> &eleCol,
-                   const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
+                   const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
 {
 
   //check if a given SuperCluster matches to at least one GsfElectron having zero expected inner hits
@@ -310,7 +310,7 @@ bool ConversionTools::hasMatchedPromptElectron(const reco::SuperClusterRef &sc, 
     if (it->gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS) > 0) continue;
 
     //check if electron is matching to a conversion
-    if (hasMatchedConversion(*it,convCol,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
+    if (hasMatchedConversion(*it,convCol,beamspot,allowCkfMatch,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
    
    
     return true;
@@ -324,7 +324,7 @@ bool ConversionTools::hasMatchedPromptElectron(const reco::SuperClusterRef &sc, 
 
 //--------------------------------------------------------------------------------------------------
 reco::GsfElectronRef ConversionTools::matchedPromptElectron(const reco::SuperClusterRef &sc, const edm::Handle<reco::GsfElectronCollection> &eleCol,
-                   const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
+                   const edm::Handle<reco::ConversionCollection> &convCol, const math::XYZPoint &beamspot, bool allowCkfMatch, float lxyMin, float probMin, unsigned int nHitsBeforeVtxMax)
 {
 
   //check if a given SuperCluster matches to at least one GsfElectron having zero expected inner hits
@@ -342,7 +342,7 @@ reco::GsfElectronRef ConversionTools::matchedPromptElectron(const reco::SuperClu
     if (it->gsfTrack()->hitPattern().numberOfHits(reco::HitPattern::MISSING_INNER_HITS) > 0) continue;
 
     //check if electron is matching to a conversion
-    if (hasMatchedConversion(*it,convCol,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
+    if (hasMatchedConversion(*it,convCol,beamspot,allowCkfMatch,lxyMin,probMin,nHitsBeforeVtxMax)) continue;
    
    
     match = GsfElectronRef(eleCol,it-eleCol->begin());


### PR DESCRIPTION
Same as 7917 but for 74X. Bug fix in ConversionTools; one function call was missing a parameter.

On line 313 the call:
hasMatchedConversion(*it,convCol,beamspot,lxyMin,probMin,nHitsBeforeVtxMax)
When *it is a reco::GsfElectron (L305), the called function is 
defined in line 51-52 of the header.
The function prototype for this version, expects the 4th argument to be 
"bool allowCkfMatch" but in the function call this parameter is missing 
(or, rather, the value of lxyMin is passed in this spot). 
Since "float" can be cast to "bool" and "unsigned int" can be cast to "float", 
it will compile but the behavior will not be what is expected.

After the fix we expect to see slightly more photons not passing the electron veto i.e. passElectronVeto()==0
(in gamma+Jet sample I see the percentage going from 7.7% to 8.0%).
