### PR TITLE
Change VtxSmearing for pPb to fix a failing IB test

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -553,7 +553,7 @@ steps['QCD_Pt_170_230']=genS('QCD_Pt_170_230_8TeV_TuneCUETP8M1_cfi',Kby(25,100))
 
 
 ## pPb tests
-step1PPbDefaults={'--beamspot':'Realistic8TeVCollisionPPbBoost'}
+step1PPbDefaults={'--beamspot':'Realistic5TeVPPbBoost'}
 steps['AMPT_PPb_5020GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaults,genS('AMPT_PPb_5020GeV_MinimumBias_cfi',Kby(9,100))])
 # GF to be uncommented when GEN-SIM becomes available
 # steps['AMPT_PPb_5020GeV_MinimumBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValAMPT_PPb_5020GeV_MinimumBias/%s/GEN-SIM'%(baseDataSetRelease[4],),location='STD')}

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -553,7 +553,7 @@ steps['QCD_Pt_170_230']=genS('QCD_Pt_170_230_8TeV_TuneCUETP8M1_cfi',Kby(25,100))
 
 
 ## pPb tests
-step1PPbDefaults={'--beamspot':'Realistic5TeVPPbBoost'}
+step1PPbDefaults={'--beamspot':'Realistic8TeVCollision'}
 steps['AMPT_PPb_5020GeV_MinimumBias']=merge([{'-n':10},step1PPbDefaults,genS('AMPT_PPb_5020GeV_MinimumBias_cfi',Kby(9,100))])
 # GF to be uncommented when GEN-SIM becomes available
 # steps['AMPT_PPb_5020GeV_MinimumBiasINPUT']={'INPUT':InputInfo(dataSet='/RelValAMPT_PPb_5020GeV_MinimumBias/%s/GEN-SIM'%(baseDataSetRelease[4],),location='STD')}


### PR DESCRIPTION
Workflow 280.0 is failing in the IB tests both in 74X and in 75X with the error "KeyError: 'Realistic8TeVCollisionPPbBoost'". Indeed, Realistic8TeVCollisionPPbBoost is no longer defined in https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/Configuration/StandardSequences/python/VtxSmeared.py. After discussing the issue with @yetkinyilmaz we understand that the vtx smearing should be changed to Realistic5TeVPPbBoost; which is the purpose of this PR.

The proposed change was tested to fix workflow 280.0.

@BetterWang, @yetkinyilmaz, @mandrenguyen 
