### PR TITLE
Add hepmc to SimDataFormats/PileupSummaryInfo

### DIFF
--- a/SimDataFormats/PileupSummaryInfo/BuildFile.xml
+++ b/SimDataFormats/PileupSummaryInfo/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Math"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
-
+<use   name="hepmc"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
missing at least in root6 - but we should understand why root5 and root6 diverged in this BuildFile..
