### PR TITLE
Develop validation post processor

### DIFF
--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -9,6 +9,8 @@ from HLTriggerOffline.Common.HLTValidationHarvest_cff import *
 from FastSimulation.Configuration.Harvesting_cff import *
 
 from Validation.RecoHI.HarvestingHI_cff import *
+from Validation.RecoJets.JetPostProcessor_cff import *
+from Validation.RecoMET.METPostProcessor_cff import *
 
 
 dqmHarvesting = cms.Path(DQMOffline_SecondStep*DQMOffline_Certification)
@@ -31,4 +33,4 @@ genHarvesting = cms.Path(postValidation_gen)
 
 alcaHarvesting = cms.Path()
 
-validationHarvestingMiniAOD = cms.Path()
+validationHarvestingMiniAOD = cms.Path(JetPostProcessor*METPostProcessor)

--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -18,7 +18,7 @@ dqmHarvestingPOG = cms.Path(DQMOffline_SecondStep_PrePOG)
 
 dqmHarvestingPOGMC = cms.Path( DQMOffline_SecondStep_PrePOGMC )
 
-validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen*METPostProcessor)
+validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen)
 
 validationpreprodHarvesting = cms.Path(postValidation_preprod*hltpostvalidation_preprod*postValidation_gen)
 

--- a/Configuration/StandardSequences/python/Harvesting_cff.py
+++ b/Configuration/StandardSequences/python/Harvesting_cff.py
@@ -18,7 +18,7 @@ dqmHarvestingPOG = cms.Path(DQMOffline_SecondStep_PrePOG)
 
 dqmHarvestingPOGMC = cms.Path( DQMOffline_SecondStep_PrePOGMC )
 
-validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen)
+validationHarvesting = cms.Path(postValidation*hltpostvalidation*postValidation_gen*METPostProcessor)
 
 validationpreprodHarvesting = cms.Path(postValidation_preprod*hltpostvalidation_preprod*postValidation_gen)
 

--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -31,7 +31,7 @@ from Validation.RecoParticleFlow.miniAODValidation_cff import *
 prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
-prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence )
+prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence *JetValidationMiniAOD * METValidationMiniAOD)
 
 
 validation = cms.Sequence(cms.SequencePlaceholder("mix")

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -16,6 +16,7 @@ from Validation.RecoTau.DQMMCValidation_cfi import *
 from Validation.RecoEgamma.photonFastSimPostProcessor_cff import *
 from Validation.RecoVertex.PrimaryVertexAnalyzer4PUSlimmed_Client_cfi import *
 from DQMOffline.RecoB.dqmCollector_cff import *
+from Validation.RecoMET.METPostProcessor_cff import *
 
 
 postValidation = cms.Sequence(
@@ -32,6 +33,7 @@ postValidation = cms.Sequence(
     + rpcRecHitPostValidation_step
     + runTauEff + makeBetterPlots
     + bTagCollectorSequenceMCbcl
+    + METPostProcessor
 )
 
 postValidation_preprod = cms.Sequence(
@@ -47,6 +49,7 @@ postValidation_fastsim = cms.Sequence(
     + MuIsoValPostProcessor
     + fastSimPhotonPostProcessor
     + bTagCollectorSequenceMC
+    + METPostProcessor
 )
 
  

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -249,6 +249,7 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
     double log10PtMax  = 3.75;
     int    log10PtBins = 26; 
 
+    //if eta range changed here need change in JetTesterPostProcessor as well
     double etaRange[91] = {-6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2,
 		     -4.0, -3.8, -3.6, -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6,
 		     -2.5, -2.4, -2.3, -2.2, -2.1, -2.0, -1.9, -1.8, -1.7, -1.6,
@@ -295,7 +296,7 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
       mPtCorrOverGen_GenPt_B = ibooker.bookProfile("PtCorrOverGen_GenPt_B", "0<|eta|<1.5", log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
       mPtCorrOverGen_GenPt_E = ibooker.bookProfile("PtCorrOverGen_GenPt_E", "1.5<|eta|<3", log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
       mPtCorrOverGen_GenPt_F = ibooker.bookProfile("PtCorrOverGen_GenPt_F", "3<|eta|<6",   log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
-
+      //if eta range changed here need change in JetTesterPostProcessor as well
       mPtCorrOverGen_GenEta_20_40    = ibooker.bookProfile("PtCorrOverGen_GenEta_20_40",      "20<genPt<40;#eta",    90, etaRange, 0.8, 1.2, " ");
       mPtCorrOverGen_GenEta_40_200    = ibooker.bookProfile("PtCorrOverGen_GenEta_40_200",    "40<genPt<200;#eta",    90, etaRange, 0.8, 1.2, " ");
       mPtCorrOverGen_GenEta_200_600   = ibooker.bookProfile("PtCorrOverGen_GenEta_200_600",   "200<genPt<600;#eta",   90, etaRange, 0.8, 1.2, " ");
@@ -336,6 +337,7 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
     mPtRecoOverGen_GenPhi_B         = ibooker.bookProfile("PtRecoOverGen_GenPhi_B",         "0<|eta|<1.5",     70, -3.5, 3.5, 0, 2, " ");
     mPtRecoOverGen_GenPhi_E         = ibooker.bookProfile("PtRecoOverGen_GenPhi_E",         "1.5<|eta|<3",     70, -3.5, 3.5, 0, 2, " ");
     mPtRecoOverGen_GenPhi_F         = ibooker.bookProfile("PtRecoOverGen_GenPhi_F",         "3<|eta|<6",       70, -3.5, 3.5, 0, 2, " ");
+    //if eta range changed here need change in JetTesterPostProcessor as well
     mPtRecoOverGen_GenEta_20_40    = ibooker.bookProfile("PtRecoOverGen_GenEta_20_40",    "20<genpt<40",    90, etaRange, 0, 2, " ");
     mPtRecoOverGen_GenEta_40_200    = ibooker.bookProfile("PtRecoOverGen_GenEta_40_200",    "40<genpt<200",    90, etaRange, 0, 2, " ");
     mPtRecoOverGen_GenEta_200_600   = ibooker.bookProfile("PtRecoOverGen_GenEta_200_600",   "200<genpt<600",   90, etaRange, 0, 2, " ");

--- a/Validation/RecoJets/plugins/JetTester.cc
+++ b/Validation/RecoJets/plugins/JetTester.cc
@@ -68,6 +68,9 @@ JetTester::JetTester(const edm::ParameterSet& iConfig) :
   mPtCorrOverReco_Eta_200_600         = 0;
   mPtCorrOverReco_Eta_600_1500        = 0;
   mPtCorrOverReco_Eta_1500_3500       = 0;
+  mPtCorrOverReco_Eta_3500_5000       = 0;
+  mPtCorrOverReco_Eta_5000_6500       = 0;
+  mPtCorrOverReco_Eta_3500       = 0;
   mPtCorrOverGen_GenPt_B          = 0;
   mPtCorrOverGen_GenPt_E          = 0;
   mPtCorrOverGen_GenPt_F          = 0;
@@ -76,6 +79,9 @@ JetTester::JetTester(const edm::ParameterSet& iConfig) :
   mPtCorrOverGen_GenEta_200_600   = 0;
   mPtCorrOverGen_GenEta_600_1500  = 0;
   mPtCorrOverGen_GenEta_1500_3500 = 0;
+  mPtCorrOverGen_GenEta_3500_5000 = 0;
+  mPtCorrOverGen_GenEta_5000_6500 = 0;
+  mPtCorrOverGen_GenEta_3500 = 0;
 
   // Generation
   mGenEta      = 0;
@@ -103,6 +109,13 @@ JetTester::JetTester(const edm::ParameterSet& iConfig) :
   mPtRecoOverGen_B_1500_3500 = 0;
   mPtRecoOverGen_E_1500_3500 = 0;
   mPtRecoOverGen_F_1500_3500 = 0;
+  mPtRecoOverGen_B_3500_5000 = 0;
+  mPtRecoOverGen_E_3500_5000 = 0;
+  mPtRecoOverGen_B_5000_6500 = 0;
+  mPtRecoOverGen_E_5000_6500 = 0;
+  mPtRecoOverGen_B_3500 = 0;
+  mPtRecoOverGen_E_3500 = 0;
+  mPtRecoOverGen_F_3500 = 0;
 
   // Generation profiles
   mPtRecoOverGen_GenPt_B          = 0;
@@ -116,6 +129,9 @@ JetTester::JetTester(const edm::ParameterSet& iConfig) :
   mPtRecoOverGen_GenEta_200_600   = 0;
   mPtRecoOverGen_GenEta_600_1500  = 0;
   mPtRecoOverGen_GenEta_1500_3500 = 0;
+  mPtRecoOverGen_GenEta_3500_5000 = 0;
+  mPtRecoOverGen_GenEta_5000_6500 = 0;
+  mPtRecoOverGen_GenEta_3500 = 0;
 
   // Some jet algebra
   mEtaFirst   = 0;
@@ -292,6 +308,9 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
       mPtCorrOverReco_Eta_200_600   = ibooker.bookProfile("PtCorrOverReco_Eta_200_600",   "200<genPt<600",   90, etaRange, 0, 5, " ");
       mPtCorrOverReco_Eta_600_1500  = ibooker.bookProfile("PtCorrOverReco_Eta_600_1500",  "600<genPt<1500",  90, etaRange, 0, 5, " ");
       mPtCorrOverReco_Eta_1500_3500 = ibooker.bookProfile("PtCorrOverReco_Eta_1500_3500", "1500<genPt<3500", 90, etaRange, 0, 5, " ");
+      mPtCorrOverReco_Eta_3500_5000 = ibooker.bookProfile("PtCorrOverReco_Eta_3500_5000", "3500<genPt<5000", 90, etaRange, 0, 5, " ");
+      mPtCorrOverReco_Eta_5000_6500 = ibooker.bookProfile("PtCorrOverReco_Eta_5000_6500", "5000<genPt<6500", 90, etaRange, 0, 5, " ");
+      mPtCorrOverReco_Eta_3500      = ibooker.bookProfile("PtCorrOverReco_Eta_3500",      "genPt>3500",      90, etaRange, 0, 5, " ");
 
       mPtCorrOverGen_GenPt_B = ibooker.bookProfile("PtCorrOverGen_GenPt_B", "0<|eta|<1.5", log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
       mPtCorrOverGen_GenPt_E = ibooker.bookProfile("PtCorrOverGen_GenPt_E", "1.5<|eta|<3", log10PtBins, log10PtMin, log10PtMax, 0.8, 1.2, " ");
@@ -302,6 +321,9 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
       mPtCorrOverGen_GenEta_200_600   = ibooker.bookProfile("PtCorrOverGen_GenEta_200_600",   "200<genPt<600;#eta",   90, etaRange, 0.8, 1.2, " ");
       mPtCorrOverGen_GenEta_600_1500  = ibooker.bookProfile("PtCorrOverGen_GenEta_600_1500",  "600<genPt<1500;#eta",  90, etaRange, 0.8, 1.2, " ");
       mPtCorrOverGen_GenEta_1500_3500 = ibooker.bookProfile("PtCorrOverGen_GenEta_1500_3500", "1500<genPt<3500;#eta", 90, etaRange, 0.8, 1.2, " ");
+      mPtCorrOverGen_GenEta_3500_5000 = ibooker.bookProfile("PtCorrOverGen_GenEta_3500_5000", "3500<genPt<5000;#eta", 90, etaRange, 0.8, 1.2, " ");
+      mPtCorrOverGen_GenEta_5000_6500 = ibooker.bookProfile("PtCorrOverGen_GenEta_5000_6500", "5000<genPt<6500;#eta", 90, etaRange, 0.8, 1.2, " ");
+      mPtCorrOverGen_GenEta_3500      = ibooker.bookProfile("PtCorrOverGen_GenEta_3500",      "genPt>3500;#eta",      90, etaRange, 0.8, 1.2, " ");
     }
 
     mGenEta      = ibooker.book1D("GenEta",      "GenEta",      120,   -6,    6);
@@ -329,6 +351,13 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
     mPtRecoOverGen_B_1500_3500 = ibooker.book1D("PtRecoOverGen_B_1500_3500", "1500<genpt<3500", 90, 0, 2);
     mPtRecoOverGen_E_1500_3500 = ibooker.book1D("PtRecoOverGen_E_1500_3500", "1500<genpt<3500", 90, 0, 2);
     mPtRecoOverGen_F_1500_3500 = ibooker.book1D("PtRecoOverGen_F_1500_3500", "1500<genpt<3500", 90, 0, 2);
+    mPtRecoOverGen_B_3500_5000 = ibooker.book1D("PtRecoOverGen_B_3500_5000", "3500<genpt<5000", 90, 0, 2);
+    mPtRecoOverGen_E_3500_5000 = ibooker.book1D("PtRecoOverGen_E_3500_5000", "3500<genpt<5000", 90, 0, 2);
+    mPtRecoOverGen_B_5000_6500 = ibooker.book1D("PtRecoOverGen_B_5000_6500", "5000<genpt<6500", 90, 0, 2);
+    mPtRecoOverGen_E_5000_6500 = ibooker.book1D("PtRecoOverGen_E_5000_6500", "5000<genpt<6500", 90, 0, 2);
+    mPtRecoOverGen_B_3500      = ibooker.book1D("PtRecoOverGen_B_3500",      "genpt>3500",      90, 0, 2);
+    mPtRecoOverGen_E_3500      = ibooker.book1D("PtRecoOverGen_E_3500",      "genpt>3500",      90, 0, 2);
+    mPtRecoOverGen_F_3500      = ibooker.book1D("PtRecoOverGen_F_3500",      "genpt>3500",      90, 0, 2);
 
     // Generation profiles
     mPtRecoOverGen_GenPt_B          = ibooker.bookProfile("PtRecoOverGen_GenPt_B",          "0<|eta|<1.5",     log10PtBins, log10PtMin, log10PtMax, 0, 2, " ");
@@ -343,6 +372,9 @@ void JetTester::bookHistograms(DQMStore::IBooker & ibooker,
     mPtRecoOverGen_GenEta_200_600   = ibooker.bookProfile("PtRecoOverGen_GenEta_200_600",   "200<genpt<600",   90, etaRange, 0, 2, " ");
     mPtRecoOverGen_GenEta_600_1500  = ibooker.bookProfile("PtRecoOverGen_GenEta_600_1500",  "600<genpt<1500",  90, etaRange, 0, 2, " ");
     mPtRecoOverGen_GenEta_1500_3500 = ibooker.bookProfile("PtRecoOverGen_GenEta_1500_3500", "1500<genpt<3500", 90, etaRange, 0, 2, " ");
+    mPtRecoOverGen_GenEta_3500_5000 = ibooker.bookProfile("PtRecoOverGen_GenEta_3500_5000", "3500<genpt<5000", 90, etaRange, 0, 2, " ");
+    mPtRecoOverGen_GenEta_5000_6500 = ibooker.bookProfile("PtRecoOverGen_GenEta_5000_6500", "5000<genpt<6500", 90, etaRange, 0, 2, " ");
+    mPtRecoOverGen_GenEta_3500      = ibooker.bookProfile("PtRecoOverGen_GenEta_3500",      "genpt>3500",      90, etaRange, 0, 2, " ");
     
     // Some jet algebra
     //------------------------------------------------------------------------
@@ -692,7 +724,7 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
   if(!isMiniAODJet){
     if (nJet >= 2)
       {
-	if (mMjj) mMjj->Fill((p4tmp[0]+p4tmp[1]).mass());
+	if (mMjj){ mMjj->Fill((p4tmp[0]+p4tmp[1]).mass());}
       }
   }else{
     if(index_first_jet>-1){
@@ -787,6 +819,9 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
       else if (ijetPt <  600) mPtCorrOverReco_Eta_200_600  ->Fill(ijetEta, ratio);
       else if (ijetPt < 1500) mPtCorrOverReco_Eta_600_1500 ->Fill(ijetEta, ratio);
       else if (ijetPt < 3500) mPtCorrOverReco_Eta_1500_3500->Fill(ijetEta, ratio);
+      else if (ijetPt < 5000) mPtCorrOverReco_Eta_3500_5000->Fill(ijetEta, ratio);
+      else if (ijetPt < 6500) mPtCorrOverReco_Eta_5000_6500->Fill(ijetEta, ratio);
+      if (ijetPt > 3500) mPtCorrOverReco_Eta_3500->Fill(ijetEta, ratio);
     }
   }
 
@@ -875,6 +910,9 @@ void JetTester::analyze(const edm::Event& mEvent, const edm::EventSetup& mSetup)
               else if (gjet->pt() <  600) mPtCorrOverGen_GenEta_200_600  ->Fill(gjet->eta(), response);
               else if (gjet->pt() < 1500) mPtCorrOverGen_GenEta_600_1500 ->Fill(gjet->eta(), response);
               else if (gjet->pt() < 3500) mPtCorrOverGen_GenEta_1500_3500->Fill(gjet->eta(), response);
+              else if (gjet->pt() < 5000) mPtCorrOverGen_GenEta_3500_5000->Fill(gjet->eta(), response);
+              else if (gjet->pt() < 6500) mPtCorrOverGen_GenEta_5000_6500->Fill(gjet->eta(), response);
+              if (gjet->pt() > 3500) mPtCorrOverGen_GenEta_3500->Fill(gjet->eta(), response);
             }
           }
         }
@@ -910,6 +948,9 @@ void JetTester::fillMatchHists(const double GenEta,
       else if (GenPt <  600)         mPtRecoOverGen_B_200_600  ->Fill(RecoPt / GenPt);
       else if (GenPt < 1500)         mPtRecoOverGen_B_600_1500 ->Fill(RecoPt / GenPt);
       else if (GenPt < 3500)         mPtRecoOverGen_B_1500_3500->Fill(RecoPt / GenPt);
+      else if (GenPt < 5000)         mPtRecoOverGen_B_3500_5000->Fill(RecoPt / GenPt);
+      else if (GenPt < 6500)         mPtRecoOverGen_B_5000_6500->Fill(RecoPt / GenPt);
+      if (GenPt>3500)         mPtRecoOverGen_B_3500->Fill(RecoPt / GenPt);
     }
   else if (fabs(GenEta) < 3.0)
     {
@@ -921,6 +962,9 @@ void JetTester::fillMatchHists(const double GenEta,
       else if (GenPt <  600)         mPtRecoOverGen_E_200_600  ->Fill(RecoPt / GenPt);
       else if (GenPt < 1500)         mPtRecoOverGen_E_600_1500 ->Fill(RecoPt / GenPt);
       else if (GenPt < 3500)         mPtRecoOverGen_E_1500_3500->Fill(RecoPt / GenPt);
+      else if (GenPt < 5000)         mPtRecoOverGen_E_3500_5000->Fill(RecoPt / GenPt);
+      else if (GenPt < 6500)         mPtRecoOverGen_E_5000_6500->Fill(RecoPt / GenPt);
+      if (GenPt>3500)         mPtRecoOverGen_E_3500->Fill(RecoPt / GenPt);
     }
   else if (fabs(GenEta) < 6.0)
     {
@@ -932,11 +976,15 @@ void JetTester::fillMatchHists(const double GenEta,
       else if (GenPt <  600)         mPtRecoOverGen_F_200_600  ->Fill(RecoPt / GenPt);
       else if (GenPt < 1500)         mPtRecoOverGen_F_600_1500 ->Fill(RecoPt / GenPt);
       else if (GenPt < 3500)         mPtRecoOverGen_F_1500_3500->Fill(RecoPt / GenPt);
+      if (GenPt>3500)                mPtRecoOverGen_F_3500->Fill(RecoPt / GenPt);
     }
 
-  if (GenPt > 20 && GenPt < 40) mPtRecoOverGen_GenEta_20_40   ->Fill(GenEta, RecoPt / GenPt);
+  if (GenPt > 20 && GenPt < 40)  mPtRecoOverGen_GenEta_20_40   ->Fill(GenEta, RecoPt / GenPt);
   else if (GenPt <  200)         mPtRecoOverGen_GenEta_40_200  ->Fill(GenEta, RecoPt / GenPt);
   else if (GenPt <  600)         mPtRecoOverGen_GenEta_200_600  ->Fill(GenEta, RecoPt / GenPt);
   else if (GenPt < 1500)         mPtRecoOverGen_GenEta_600_1500 ->Fill(GenEta, RecoPt / GenPt);
   else if (GenPt < 3500)         mPtRecoOverGen_GenEta_1500_3500->Fill(GenEta, RecoPt / GenPt);
+  else if (GenPt < 5000)         mPtRecoOverGen_GenEta_3500_5000->Fill(GenEta, RecoPt / GenPt);
+  else if (GenPt < 6500)         mPtRecoOverGen_GenEta_5000_6500->Fill(GenEta, RecoPt / GenPt);
+  if (GenPt > 3500)              mPtRecoOverGen_GenEta_3500->Fill(GenEta, RecoPt / GenPt);
 }

--- a/Validation/RecoJets/plugins/JetTester.h
+++ b/Validation/RecoJets/plugins/JetTester.h
@@ -97,6 +97,9 @@ class JetTester : public DQMEDAnalyzer {
   MonitorElement* mPtCorrOverReco_Eta_200_600;
   MonitorElement* mPtCorrOverReco_Eta_600_1500;
   MonitorElement* mPtCorrOverReco_Eta_1500_3500;
+  MonitorElement* mPtCorrOverReco_Eta_3500_5000;
+  MonitorElement* mPtCorrOverReco_Eta_5000_6500;
+  MonitorElement* mPtCorrOverReco_Eta_3500;
   MonitorElement* mPtCorrOverGen_GenPt_B;
   MonitorElement* mPtCorrOverGen_GenPt_E;
   MonitorElement* mPtCorrOverGen_GenPt_F;
@@ -105,6 +108,9 @@ class JetTester : public DQMEDAnalyzer {
   MonitorElement* mPtCorrOverGen_GenEta_200_600;
   MonitorElement* mPtCorrOverGen_GenEta_600_1500;
   MonitorElement* mPtCorrOverGen_GenEta_1500_3500;
+  MonitorElement* mPtCorrOverGen_GenEta_3500_5000;
+  MonitorElement* mPtCorrOverGen_GenEta_5000_6500;
+  MonitorElement* mPtCorrOverGen_GenEta_3500;
 
   // Generation
   MonitorElement* mGenEta;
@@ -133,6 +139,14 @@ class JetTester : public DQMEDAnalyzer {
   MonitorElement* mPtRecoOverGen_E_1500_3500;
   MonitorElement* mPtRecoOverGen_F_1500_3500;
 
+  MonitorElement* mPtRecoOverGen_B_3500_5000;
+  MonitorElement* mPtRecoOverGen_E_3500_5000;
+  MonitorElement* mPtRecoOverGen_B_5000_6500;
+  MonitorElement* mPtRecoOverGen_E_5000_6500;
+  MonitorElement* mPtRecoOverGen_B_3500;
+  MonitorElement* mPtRecoOverGen_E_3500;
+  MonitorElement* mPtRecoOverGen_F_3500;
+
   // Generation profiles
   MonitorElement* mPtRecoOverGen_GenPt_B;
   MonitorElement* mPtRecoOverGen_GenPt_E;
@@ -145,6 +159,9 @@ class JetTester : public DQMEDAnalyzer {
   MonitorElement* mPtRecoOverGen_GenEta_200_600;
   MonitorElement* mPtRecoOverGen_GenEta_600_1500;
   MonitorElement* mPtRecoOverGen_GenEta_1500_3500;
+  MonitorElement* mPtRecoOverGen_GenEta_3500_5000;
+  MonitorElement* mPtRecoOverGen_GenEta_5000_6500;
+  MonitorElement* mPtRecoOverGen_GenEta_3500;
 
   // Some jet algebra
   MonitorElement* mEtaFirst;

--- a/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
+++ b/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
@@ -1,0 +1,293 @@
+// -*- C++ -*-
+//
+// Package:    Validation/RecoMET
+// Class:      METTesterPostProcessor
+// 
+// Original Author:  "Matthias Weber"
+//         Created:  Sun Feb 22 14:35:25 CET 2015
+//
+
+#include "Validation/RecoJets/plugins/JetTesterPostProcessor.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+
+// Some switches
+//
+// constructors and destructor
+//
+JetTesterPostProcessor::JetTesterPostProcessor(const edm::ParameterSet& iConfig)
+{
+  inputJetLabelRECO_=iConfig.getParameter<edm::InputTag>("JetTypeRECO");
+  inputJetLabelMiniAOD_=iConfig.getParameter<edm::InputTag>("JetTypeMiniAOD");
+}
+
+
+JetTesterPostProcessor::~JetTesterPostProcessor()
+{ 
+}
+
+
+// ------------ method called right after a run ends ------------
+void 
+JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& iget_)
+{
+  std::vector<std::string> subDirVec;
+  std::string RunDir="JetMET/JetValidation/";
+  iget_.setCurrentFolder(RunDir);
+  jet_dirs=iget_.getSubdirs();
+  bool found_reco_dir=false;
+  bool found_miniaod_dir=false;
+  //loop over jet subdirectories
+  for (int i=0; i<int(jet_dirs.size()); i++) {
+    ibook_.setCurrentFolder(jet_dirs[i]);  
+    if(jet_dirs[i]==(RunDir+inputJetLabelRECO_.label())){
+      found_reco_dir=true;
+    }
+    if(jet_dirs[i]==(RunDir+inputJetLabelMiniAOD_.label())){
+      found_miniaod_dir=true;
+    }
+  }
+  if(found_miniaod_dir && found_reco_dir){
+    std::string rundir_reco=RunDir+inputJetLabelRECO_.label();
+    std::string rundir_miniaod=RunDir+inputJetLabelMiniAOD_.label();
+
+    MonitorElement* mPt_Reco=iget_.get(rundir_reco+"/"+"Pt");
+    MonitorElement* mPhi_Reco=iget_.get(rundir_reco+"/"+"Phi");
+    MonitorElement* mEta_Reco=iget_.get(rundir_reco+"/"+"Eta");
+    MonitorElement* mCorrJetPt_Reco=iget_.get(rundir_reco+"/"+"CorrJetPt");
+    MonitorElement* mCorrJetPhi_Reco=iget_.get(rundir_reco+"/"+"CorrJetPhi");
+    MonitorElement* mCorrJetEta_Reco=iget_.get(rundir_reco+"/"+"CorrJetEta");
+
+    MonitorElement* mPtCorrOverReco_Eta_20_40_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_20_40");
+    MonitorElement* mPtCorrOverReco_Eta_200_600_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_200_600");
+    MonitorElement* mPtCorrOverReco_Eta_1500_3500_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_1500_3500");
+    MonitorElement* mPtCorrOverGen_GenEta_40_200_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverGen_GenEta_40_200");
+    MonitorElement* mPtCorrOverGen_GenEta_600_1500_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverGen_GenEta_600_1500");
+    MonitorElement* mDeltaEta_Reco=iget_.get(rundir_reco+"/"+"DeltaEta");
+    MonitorElement* mDeltaPhi_Reco=iget_.get(rundir_reco+"/"+"DeltaPhi");
+    MonitorElement* mDeltaPt_Reco=iget_.get(rundir_reco+"/"+"DeltaPt");
+    MonitorElement* mMjj_Reco=iget_.get(rundir_reco+"/"+"Mjj");
+    MonitorElement* mNJets40_Reco=iget_.get(rundir_reco+"/"+"NJets");
+    MonitorElement* mchargedHadronMultiplicity_Reco=iget_.get(rundir_reco+"/"+"chargedHadronMultiplicity");
+    MonitorElement* mneutralHadronMultiplicity_Reco=iget_.get(rundir_reco+"/"+"neutralHadronMultiplicity");
+    MonitorElement* mphotonMultiplicity_Reco=iget_.get(rundir_reco+"/"+"photonMultiplicity");
+    MonitorElement* mphotonEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"photonEnergyFraction");
+    MonitorElement* mneutralHadronEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"neutralHadronEnergyFraction");
+    MonitorElement* mchargedHadronEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"chargedHadronEnergyFraction");
+    
+    MonitorElement* mPt_MiniAOD=iget_.get(rundir_miniaod+"/"+"Pt");
+    MonitorElement* mPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"Phi");
+    MonitorElement* mEta_MiniAOD=iget_.get(rundir_miniaod+"/"+"Eta");
+    MonitorElement* mCorrJetPt_MiniAOD=iget_.get(rundir_miniaod+"/"+"CorrJetPt");
+    MonitorElement* mCorrJetPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"CorrJetPhi");
+    MonitorElement* mCorrJetEta_MiniAOD=iget_.get(rundir_miniaod+"/"+"CorrJetEta");
+    MonitorElement* mPtCorrOverReco_Eta_20_40_MiniAOD=iget_.get(rundir_miniaod+"/"+"PtCorrOverReco_Eta_20_40");
+    MonitorElement* mPtCorrOverReco_Eta_200_600_MiniAOD=iget_.get(rundir_miniaod+"/"+"PtCorrOverReco_Eta_200_600");
+    MonitorElement* mPtCorrOverReco_Eta_1500_3500_MiniAOD=iget_.get(rundir_miniaod+"/"+"PtCorrOverReco_Eta_1500_3500");
+    MonitorElement* mPtCorrOverGen_GenEta_40_200_MiniAOD=iget_.get(rundir_miniaod+"/"+"PtCorrOverGen_GenEta_40_200");
+    MonitorElement* mPtCorrOverGen_GenEta_600_1500_MiniAOD=iget_.get(rundir_miniaod+"/"+"PtCorrOverGen_GenEta_600_1500");
+    MonitorElement* mDeltaEta_MiniAOD=iget_.get(rundir_miniaod+"/"+"DeltaEta");
+    MonitorElement* mDeltaPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"DeltaPhi");
+    MonitorElement* mDeltaPt_MiniAOD=iget_.get(rundir_miniaod+"/"+"DeltaPt");
+    MonitorElement* mMjj_MiniAOD=iget_.get(rundir_miniaod+"/"+"Mjj");
+    MonitorElement* mNJets40_MiniAOD=iget_.get(rundir_miniaod+"/"+"NJets");
+    MonitorElement* mchargedHadronMultiplicity_MiniAOD=iget_.get(rundir_miniaod+"/"+"chargedHadronMultiplicity");
+    MonitorElement* mneutralHadronMultiplicity_MiniAOD=iget_.get(rundir_miniaod+"/"+"neutralHadronMultiplicity");
+    MonitorElement* mphotonMultiplicity_MiniAOD=iget_.get(rundir_miniaod+"/"+"photonMultiplicity");
+    MonitorElement* mphotonEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"photonEnergyFraction");
+    MonitorElement* mneutralHadronEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"neutralHadronEnergyFraction");
+    MonitorElement* mchargedHadronEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"chargedHadronEnergyFraction");
+
+    ibook_.setCurrentFolder(RunDir+"MiniAOD_over_RECO");
+    mPt_MiniAOD_over_Reco=ibook_.book1D("Pt_MiniAOD_over_RECO",(TH1F*)mPt_Reco->getRootObject());
+    mPhi_MiniAOD_over_Reco=ibook_.book1D("Phi_MiniAOD_over_RECO",(TH1F*)mPhi_Reco->getRootObject());
+    mEta_MiniAOD_over_Reco=ibook_.book1D("Eta_MiniAOD_over_RECO",(TH1F*)mEta_Reco->getRootObject());
+    mCorrJetPt_MiniAOD_over_Reco=ibook_.book1D("CorrJetPt_MiniAOD_over_RECO",(TH1F*)mCorrJetPt_Reco->getRootObject());
+    mCorrJetPhi_MiniAOD_over_Reco=ibook_.book1D("CorrJetPhi_MiniAOD_over_RECO",(TH1F*)mCorrJetPhi_Reco->getRootObject());
+    mCorrJetEta_MiniAOD_over_Reco=ibook_.book1D("CorrJetEta_MiniAOD_over_RECO",(TH1F*)mCorrJetEta_Reco->getRootObject());
+
+   //if eta range changed here need change in JetTester as well
+   float etarange[91] = {-6.0, -5.8, -5.6, -5.4, -5.2, -5.0, -4.8, -4.6, -4.4, -4.2,
+		     -4.0, -3.8, -3.6, -3.4, -3.2, -3.0, -2.9, -2.8, -2.7, -2.6,
+		     -2.5, -2.4, -2.3, -2.2, -2.1, -2.0, -1.9, -1.8, -1.7, -1.6,
+		     -1.5, -1.4, -1.3, -1.2, -1.1, -1.0, -0.9, -0.8, -0.7, -0.6,
+		     -0.5, -0.4, -0.3, -0.2, -0.1,
+		     0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9,
+		     1.0, 1.1, 1.2, 1.3, 1.4, 1.5, 1.6, 1.7, 1.8, 1.9,
+		     2.0, 2.1, 2.2, 2.3, 2.4, 2.5, 2.6, 2.7, 2.8, 2.9,
+		     3.0, 3.2, 3.4, 3.6, 3.8, 4.0, 4.2, 4.4, 4.6, 4.8,
+		     5.0, 5.2, 5.4, 5.6, 5.8, 6.0};
+
+    mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco=ibook_.book1D("PtCorrOverReco_Eta_20_40_MiniAOD_over_RECO","20<genpt<40",90,etarange);
+    mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco=ibook_.book1D("PtCorrOverReco_Eta_200_600_MiniAOD_over_RECO","200<genpt<600",90,etarange);
+    mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco=ibook_.book1D("PtCorrOverReco_Eta_1500_3500_MiniAOD_over_RECO","1500<genpt<3500",90,etarange);
+    mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco=ibook_.book1D("PtCorrOverGen_GenEta_40_200_MiniAOD_over_RECO","40<genpt<200",90,etarange);
+    mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco=ibook_.book1D("PtCorrOverGen_GenEta_600_1500_MiniAOD_over_RECO","600<genpt<1500",90,etarange);
+    mDeltaPt_MiniAOD_over_Reco=ibook_.book1D("DeltaPt_MiniAOD_over_RECO",(TH1F*)mDeltaPt_Reco->getRootObject());
+    mDeltaPhi_MiniAOD_over_Reco=ibook_.book1D("DeltaPhi_MiniAOD_over_RECO",(TH1F*)mDeltaPhi_Reco->getRootObject());
+    mDeltaEta_MiniAOD_over_Reco=ibook_.book1D("DeltaEta_MiniAOD_over_RECO",(TH1F*)mDeltaEta_Reco->getRootObject());
+    mMjj_MiniAOD_over_Reco=ibook_.book1D("Mjj_MiniAOD_over_RECO",(TH1F*)mMjj_Reco->getRootObject());
+    mNJets40_MiniAOD_over_Reco=ibook_.book1D("NJets_MiniAOD_over_RECO",(TH1F*)mNJets40_Reco->getRootObject());
+    mchargedHadronMultiplicity_MiniAOD_over_Reco=ibook_.book1D("chargedHadronMultiplicity_MiniAOD_over_RECO",(TH1F*)mchargedHadronMultiplicity_Reco->getRootObject());
+    mneutralHadronMultiplicity_MiniAOD_over_Reco=ibook_.book1D("neutralHadronMultiplicity_MiniAOD_over_RECO",(TH1F*)mneutralHadronMultiplicity_Reco->getRootObject());
+    mphotonMultiplicity_MiniAOD_over_Reco=ibook_.book1D("photonMultiplicity_MiniAOD_over_RECO",(TH1F*)mphotonMultiplicity_Reco->getRootObject());
+    mchargedHadronEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("chargedHadronEnergyFraction_MiniAOD_over_RECO",(TH1F*)mchargedHadronEnergyFraction_Reco->getRootObject());
+    mneutralHadronEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("neutralHadronEnergyFraction_MiniAOD_over_RECO",(TH1F*)mneutralHadronEnergyFraction_Reco->getRootObject());
+    mphotonEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("photonEnergyFraction_MiniAOD_over_RECO",(TH1F*)mphotonEnergyFraction_Reco->getRootObject());
+    for(int i=0;i<=(mPt_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPt_Reco->getBinContent(i)!=0){
+	mPt_MiniAOD_over_Reco->setBinContent(i,mPt_MiniAOD->getBinContent(i)/mPt_Reco->getBinContent(i));
+      }else if(mPt_MiniAOD->getBinContent(i)!=0){
+	mPt_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPhi_Reco->getBinContent(i)!=0){
+	mPhi_MiniAOD_over_Reco->setBinContent(i,mPhi_MiniAOD->getBinContent(i)/mPhi_Reco->getBinContent(i));
+      }else if(mPhi_MiniAOD->getBinContent(i)!=0){
+	mPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mEta_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mEta_Reco->getBinContent(i)!=0){
+	mEta_MiniAOD_over_Reco->setBinContent(i,mEta_MiniAOD->getBinContent(i)/mEta_Reco->getBinContent(i));
+      }else if(mEta_MiniAOD->getBinContent(i)!=0){
+	mEta_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mCorrJetPt_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mCorrJetPt_Reco->getBinContent(i)!=0){
+	mCorrJetPt_MiniAOD_over_Reco->setBinContent(i,mCorrJetPt_MiniAOD->getBinContent(i)/mCorrJetPt_Reco->getBinContent(i));
+      }else if(mCorrJetPt_MiniAOD->getBinContent(i)!=0){
+	mCorrJetPt_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mCorrJetPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mCorrJetPhi_Reco->getBinContent(i)!=0){
+	mCorrJetPhi_MiniAOD_over_Reco->setBinContent(i,mCorrJetPhi_MiniAOD->getBinContent(i)/mCorrJetPhi_Reco->getBinContent(i));
+      }else if(mCorrJetPhi_MiniAOD->getBinContent(i)!=0){
+	mCorrJetPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mCorrJetEta_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mCorrJetEta_Reco->getBinContent(i)!=0){
+	mCorrJetEta_MiniAOD_over_Reco->setBinContent(i,mCorrJetEta_MiniAOD->getBinContent(i)/mCorrJetEta_Reco->getBinContent(i));
+      }else if(mCorrJetEta_MiniAOD->getBinContent(i)!=0){
+	mCorrJetEta_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPtCorrOverReco_Eta_20_40_Reco->getBinContent(i)!=0){
+	double value=mPtCorrOverReco_Eta_20_40_MiniAOD->getBinContent(i)/mPtCorrOverReco_Eta_20_40_Reco->getBinContent(i);
+	mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco->setBinContent(i,value);
+      }else if(mPtCorrOverReco_Eta_20_40_MiniAOD->getBinContent(i)!=0){
+	mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    } 
+    for(int i=0;i<=(mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPtCorrOverReco_Eta_200_600_Reco->getBinContent(i)!=0){
+	mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverReco_Eta_200_600_MiniAOD->getBinContent(i)/mPtCorrOverReco_Eta_200_600_Reco->getBinContent(i));
+      }else if(mPtCorrOverReco_Eta_200_600_MiniAOD->getBinContent(i)!=0){
+	mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPtCorrOverReco_Eta_1500_3500_Reco->getBinContent(i)!=0){
+	mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverReco_Eta_1500_3500_MiniAOD->getBinContent(i)/mPtCorrOverReco_Eta_1500_3500_Reco->getBinContent(i));
+      }else if(mPtCorrOverReco_Eta_1500_3500_MiniAOD->getBinContent(i)!=0){
+	mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    } 
+    for(int i=0;i<=(mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPtCorrOverGen_GenEta_40_200_Reco->getBinContent(i)!=0){
+	mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverGen_GenEta_40_200_MiniAOD->getBinContent(i)/mPtCorrOverGen_GenEta_40_200_Reco->getBinContent(i));
+      }else if(mPtCorrOverGen_GenEta_40_200_MiniAOD->getBinContent(i)!=0){
+	mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPtCorrOverGen_GenEta_600_1500_Reco->getBinContent(i)!=0){
+	mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverGen_GenEta_600_1500_MiniAOD->getBinContent(i)/mPtCorrOverGen_GenEta_600_1500_Reco->getBinContent(i));
+      }else if(mPtCorrOverGen_GenEta_600_1500_MiniAOD->getBinContent(i)!=0){
+	mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mDeltaPt_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mDeltaPt_Reco->getBinContent(i)!=0){
+	mDeltaPt_MiniAOD_over_Reco->setBinContent(i,mDeltaPt_MiniAOD->getBinContent(i)/mDeltaPt_Reco->getBinContent(i));
+      }else if(mDeltaPt_MiniAOD->getBinContent(i)!=0){
+	mDeltaPt_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mDeltaPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mDeltaPhi_Reco->getBinContent(i)!=0){
+	mDeltaPhi_MiniAOD_over_Reco->setBinContent(i,mDeltaPhi_MiniAOD->getBinContent(i)/mDeltaPhi_Reco->getBinContent(i));
+      }else if(mDeltaPhi_MiniAOD->getBinContent(i)!=0){
+	mDeltaPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mDeltaEta_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mDeltaEta_Reco->getBinContent(i)!=0){
+	mDeltaEta_MiniAOD_over_Reco->setBinContent(i,mDeltaEta_MiniAOD->getBinContent(i)/mDeltaEta_Reco->getBinContent(i));
+      }else if(mDeltaEta_MiniAOD->getBinContent(i)!=0){
+	mDeltaEta_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mMjj_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMjj_Reco->getBinContent(i)!=0){
+	mMjj_MiniAOD_over_Reco->setBinContent(i,mMjj_MiniAOD->getBinContent(i)/mMjj_Reco->getBinContent(i));
+      }else if(mMjj_MiniAOD->getBinContent(i)!=0){
+	mMjj_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mNJets40_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mNJets40_Reco->getBinContent(i)!=0){
+	mNJets40_MiniAOD_over_Reco->setBinContent(i,mNJets40_MiniAOD->getBinContent(i)/mNJets40_Reco->getBinContent(i));
+      }else if(mNJets40_MiniAOD->getBinContent(i)!=0){
+	mNJets40_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mchargedHadronMultiplicity_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mchargedHadronMultiplicity_Reco->getBinContent(i)!=0){
+	mchargedHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,mchargedHadronMultiplicity_MiniAOD->getBinContent(i)/mchargedHadronMultiplicity_Reco->getBinContent(i));
+      }else if(mchargedHadronMultiplicity_MiniAOD->getBinContent(i)!=0){
+	mchargedHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mneutralHadronMultiplicity_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mneutralHadronMultiplicity_Reco->getBinContent(i)!=0){
+	mneutralHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,mneutralHadronMultiplicity_MiniAOD->getBinContent(i)/mneutralHadronMultiplicity_Reco->getBinContent(i));
+      }else if(mneutralHadronMultiplicity_MiniAOD->getBinContent(i)!=0){
+	mneutralHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mphotonMultiplicity_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mphotonMultiplicity_Reco->getBinContent(i)!=0){
+	mphotonMultiplicity_MiniAOD_over_Reco->setBinContent(i,mphotonMultiplicity_MiniAOD->getBinContent(i)/mphotonMultiplicity_Reco->getBinContent(i));
+      }else if(mphotonMultiplicity_MiniAOD->getBinContent(i)!=0){
+	mphotonMultiplicity_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mchargedHadronEnergyFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mchargedHadronEnergyFraction_Reco->getBinContent(i)!=0){
+	mchargedHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,mchargedHadronEnergyFraction_MiniAOD->getBinContent(i)/mchargedHadronEnergyFraction_Reco->getBinContent(i));
+      }else if(mchargedHadronEnergyFraction_MiniAOD->getBinContent(i)!=0){
+	mchargedHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mneutralHadronEnergyFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mneutralHadronEnergyFraction_Reco->getBinContent(i)!=0){
+	mneutralHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,mneutralHadronEnergyFraction_MiniAOD->getBinContent(i)/mneutralHadronEnergyFraction_Reco->getBinContent(i));
+      }else if(mneutralHadronEnergyFraction_MiniAOD->getBinContent(i)!=0){
+	mneutralHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mphotonEnergyFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mphotonEnergyFraction_Reco->getBinContent(i)!=0){
+	mphotonEnergyFraction_MiniAOD_over_Reco->setBinContent(i,mphotonEnergyFraction_MiniAOD->getBinContent(i)/mphotonEnergyFraction_Reco->getBinContent(i));
+      }else if(mphotonEnergyFraction_MiniAOD->getBinContent(i)!=0){
+	mphotonEnergyFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+  }
+}

--- a/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
+++ b/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
@@ -58,6 +58,19 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mCorrJetPhi_Reco=iget_.get(rundir_reco+"/"+"CorrJetPhi");
     MonitorElement* mCorrJetEta_Reco=iget_.get(rundir_reco+"/"+"CorrJetEta");
 
+    map_string_vec.push_back("Pt");
+    map_string_vec.push_back("Phi");
+    map_string_vec.push_back("Eta");
+    map_string_vec.push_back("CorrJetPt");
+    map_string_vec.push_back("CorrJetPhi");
+    map_string_vec.push_back("CorrJetEta");
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"Pt" ,mPt_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"Phi" ,mPhi_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"Eta" ,mEta_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"CorrJetPt"  ,mCorrJetPt_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"CorrJetPhi" ,mCorrJetPhi_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"CorrJetEta" ,mCorrJetEta_Reco));
+
     MonitorElement* mPtCorrOverReco_Eta_20_40_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_20_40");
     MonitorElement* mPtCorrOverReco_Eta_200_600_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_200_600");
     MonitorElement* mPtCorrOverReco_Eta_1500_3500_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_1500_3500");
@@ -75,6 +88,40 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mneutralHadronEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"neutralHadronEnergyFraction");
     MonitorElement* mchargedHadronEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"chargedHadronEnergyFraction");
     
+    map_string_vec.push_back("PtCorrOverReco_Eta_20_40");
+    map_string_vec.push_back("PtCorrOverReco_Eta_200_600");
+    map_string_vec.push_back("PtCorrOverReco_Eta_1500_3500");
+    map_string_vec.push_back("PtCorrOverGen_GenEta_40_200");
+    map_string_vec.push_back("PtCorrOverGen_GenEta_600_1500");
+    map_string_vec.push_back("DeltaEta");
+    map_string_vec.push_back("DeltaPhi");
+    map_string_vec.push_back("DeltaPt");
+    map_string_vec.push_back("Mjj");
+    map_string_vec.push_back("NJets");
+    map_string_vec.push_back("chargedHadronMultiplicity");
+    map_string_vec.push_back("neutralHadronMultiplicity");
+    map_string_vec.push_back("photonMultiplicity");
+    map_string_vec.push_back("chargedHadronEnergyFraction");
+    map_string_vec.push_back("neutralHadronEnergyFraction");
+    map_string_vec.push_back("photonEnergyFraction");
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverReco_Eta_20_40" ,mPtCorrOverReco_Eta_20_40_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverReco_Eta_200_600" ,mPtCorrOverReco_Eta_200_600_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverReco_Eta_1500_3500" ,mPtCorrOverReco_Eta_1500_3500_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverGen_GenEta_40_200" ,mPtCorrOverGen_GenEta_40_200_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverGen_GenEta_600_1500" ,mPtCorrOverGen_GenEta_600_1500_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"DeltaEta" ,mDeltaEta_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"DeltaPhi" ,mDeltaPhi_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"DeltaPt" ,mDeltaPt_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"Mjj" ,mMjj_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"NJets" ,mNJets40_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"chargedHadronMultiplicity" ,mchargedHadronMultiplicity_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"neutralHadronMultiplicity" ,mneutralHadronMultiplicity_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"photonMultiplicity" ,mphotonMultiplicity_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"chargedHadronEnergyFraction" ,mchargedHadronEnergyFraction_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"neutralHadronEnergyFraction" ,mneutralHadronEnergyFraction_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"photonEnergyFraction" ,mphotonEnergyFraction_Reco));
+
     MonitorElement* mPt_MiniAOD=iget_.get(rundir_miniaod+"/"+"Pt");
     MonitorElement* mPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"Phi");
     MonitorElement* mEta_MiniAOD=iget_.get(rundir_miniaod+"/"+"Eta");
@@ -97,6 +144,29 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mphotonEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"photonEnergyFraction");
     MonitorElement* mneutralHadronEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"neutralHadronEnergyFraction");
     MonitorElement* mchargedHadronEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"chargedHadronEnergyFraction");
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Pt" ,mPt_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Phi" ,mPhi_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Eta" ,mEta_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"CorrJetPt"  ,mCorrJetPt_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"CorrJetPhi" ,mCorrJetPhi_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"CorrJetEta" ,mCorrJetEta_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverReco_Eta_20_40" ,mPtCorrOverReco_Eta_20_40_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverReco_Eta_200_600" ,mPtCorrOverReco_Eta_200_600_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverReco_Eta_1500_3500" ,mPtCorrOverReco_Eta_1500_3500_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverGen_GenEta_40_200" ,mPtCorrOverGen_GenEta_40_200_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverGen_GenEta_600_1500" ,mPtCorrOverGen_GenEta_600_1500_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"DeltaEta" ,mDeltaEta_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"DeltaPhi" ,mDeltaPhi_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"DeltaPt" ,mDeltaPt_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Mjj" ,mMjj_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"NJets" ,mNJets40_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"chargedHadronMultiplicity" ,mchargedHadronMultiplicity_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"neutralHadronMultiplicity" ,mneutralHadronMultiplicity_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"photonMultiplicity" ,mphotonMultiplicity_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"chargedHadronEnergyFraction" ,mchargedHadronEnergyFraction_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"neutralHadronEnergyFraction" ,mneutralHadronEnergyFraction_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"photonEnergyFraction" ,mphotonEnergyFraction_MiniAOD));
 
     ibook_.setCurrentFolder(RunDir+"MiniAOD_over_RECO");
     mPt_MiniAOD_over_Reco=ibook_.book1D("Pt_MiniAOD_over_RECO",(TH1F*)mPt_Reco->getRootObject());
@@ -134,159 +204,43 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     mchargedHadronEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("chargedHadronEnergyFraction_MiniAOD_over_RECO",(TH1F*)mchargedHadronEnergyFraction_Reco->getRootObject());
     mneutralHadronEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("neutralHadronEnergyFraction_MiniAOD_over_RECO",(TH1F*)mneutralHadronEnergyFraction_Reco->getRootObject());
     mphotonEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("photonEnergyFraction_MiniAOD_over_RECO",(TH1F*)mphotonEnergyFraction_Reco->getRootObject());
-    for(int i=0;i<=(mPt_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPt_Reco->getBinContent(i)!=0){
-	mPt_MiniAOD_over_Reco->setBinContent(i,mPt_MiniAOD->getBinContent(i)/mPt_Reco->getBinContent(i));
-      }else if(mPt_MiniAOD->getBinContent(i)!=0){
-	mPt_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPhi_Reco->getBinContent(i)!=0){
-	mPhi_MiniAOD_over_Reco->setBinContent(i,mPhi_MiniAOD->getBinContent(i)/mPhi_Reco->getBinContent(i));
-      }else if(mPhi_MiniAOD->getBinContent(i)!=0){
-	mPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mEta_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mEta_Reco->getBinContent(i)!=0){
-	mEta_MiniAOD_over_Reco->setBinContent(i,mEta_MiniAOD->getBinContent(i)/mEta_Reco->getBinContent(i));
-      }else if(mEta_MiniAOD->getBinContent(i)!=0){
-	mEta_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mCorrJetPt_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mCorrJetPt_Reco->getBinContent(i)!=0){
-	mCorrJetPt_MiniAOD_over_Reco->setBinContent(i,mCorrJetPt_MiniAOD->getBinContent(i)/mCorrJetPt_Reco->getBinContent(i));
-      }else if(mCorrJetPt_MiniAOD->getBinContent(i)!=0){
-	mCorrJetPt_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mCorrJetPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mCorrJetPhi_Reco->getBinContent(i)!=0){
-	mCorrJetPhi_MiniAOD_over_Reco->setBinContent(i,mCorrJetPhi_MiniAOD->getBinContent(i)/mCorrJetPhi_Reco->getBinContent(i));
-      }else if(mCorrJetPhi_MiniAOD->getBinContent(i)!=0){
-	mCorrJetPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mCorrJetEta_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mCorrJetEta_Reco->getBinContent(i)!=0){
-	mCorrJetEta_MiniAOD_over_Reco->setBinContent(i,mCorrJetEta_MiniAOD->getBinContent(i)/mCorrJetEta_Reco->getBinContent(i));
-      }else if(mCorrJetEta_MiniAOD->getBinContent(i)!=0){
-	mCorrJetEta_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPtCorrOverReco_Eta_20_40_Reco->getBinContent(i)!=0){
-	double value=mPtCorrOverReco_Eta_20_40_MiniAOD->getBinContent(i)/mPtCorrOverReco_Eta_20_40_Reco->getBinContent(i);
-	mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco->setBinContent(i,value);
-      }else if(mPtCorrOverReco_Eta_20_40_MiniAOD->getBinContent(i)!=0){
-	mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    } 
-    for(int i=0;i<=(mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPtCorrOverReco_Eta_200_600_Reco->getBinContent(i)!=0){
-	mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverReco_Eta_200_600_MiniAOD->getBinContent(i)/mPtCorrOverReco_Eta_200_600_Reco->getBinContent(i));
-      }else if(mPtCorrOverReco_Eta_200_600_MiniAOD->getBinContent(i)!=0){
-	mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPtCorrOverReco_Eta_1500_3500_Reco->getBinContent(i)!=0){
-	mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverReco_Eta_1500_3500_MiniAOD->getBinContent(i)/mPtCorrOverReco_Eta_1500_3500_Reco->getBinContent(i));
-      }else if(mPtCorrOverReco_Eta_1500_3500_MiniAOD->getBinContent(i)!=0){
-	mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    } 
-    for(int i=0;i<=(mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPtCorrOverGen_GenEta_40_200_Reco->getBinContent(i)!=0){
-	mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverGen_GenEta_40_200_MiniAOD->getBinContent(i)/mPtCorrOverGen_GenEta_40_200_Reco->getBinContent(i));
-      }else if(mPtCorrOverGen_GenEta_40_200_MiniAOD->getBinContent(i)!=0){
-	mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPtCorrOverGen_GenEta_600_1500_Reco->getBinContent(i)!=0){
-	mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco->setBinContent(i,mPtCorrOverGen_GenEta_600_1500_MiniAOD->getBinContent(i)/mPtCorrOverGen_GenEta_600_1500_Reco->getBinContent(i));
-      }else if(mPtCorrOverGen_GenEta_600_1500_MiniAOD->getBinContent(i)!=0){
-	mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mDeltaPt_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mDeltaPt_Reco->getBinContent(i)!=0){
-	mDeltaPt_MiniAOD_over_Reco->setBinContent(i,mDeltaPt_MiniAOD->getBinContent(i)/mDeltaPt_Reco->getBinContent(i));
-      }else if(mDeltaPt_MiniAOD->getBinContent(i)!=0){
-	mDeltaPt_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mDeltaPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mDeltaPhi_Reco->getBinContent(i)!=0){
-	mDeltaPhi_MiniAOD_over_Reco->setBinContent(i,mDeltaPhi_MiniAOD->getBinContent(i)/mDeltaPhi_Reco->getBinContent(i));
-      }else if(mDeltaPhi_MiniAOD->getBinContent(i)!=0){
-	mDeltaPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mDeltaEta_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mDeltaEta_Reco->getBinContent(i)!=0){
-	mDeltaEta_MiniAOD_over_Reco->setBinContent(i,mDeltaEta_MiniAOD->getBinContent(i)/mDeltaEta_Reco->getBinContent(i));
-      }else if(mDeltaEta_MiniAOD->getBinContent(i)!=0){
-	mDeltaEta_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mMjj_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMjj_Reco->getBinContent(i)!=0){
-	mMjj_MiniAOD_over_Reco->setBinContent(i,mMjj_MiniAOD->getBinContent(i)/mMjj_Reco->getBinContent(i));
-      }else if(mMjj_MiniAOD->getBinContent(i)!=0){
-	mMjj_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mNJets40_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mNJets40_Reco->getBinContent(i)!=0){
-	mNJets40_MiniAOD_over_Reco->setBinContent(i,mNJets40_MiniAOD->getBinContent(i)/mNJets40_Reco->getBinContent(i));
-      }else if(mNJets40_MiniAOD->getBinContent(i)!=0){
-	mNJets40_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mchargedHadronMultiplicity_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mchargedHadronMultiplicity_Reco->getBinContent(i)!=0){
-	mchargedHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,mchargedHadronMultiplicity_MiniAOD->getBinContent(i)/mchargedHadronMultiplicity_Reco->getBinContent(i));
-      }else if(mchargedHadronMultiplicity_MiniAOD->getBinContent(i)!=0){
-	mchargedHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mneutralHadronMultiplicity_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mneutralHadronMultiplicity_Reco->getBinContent(i)!=0){
-	mneutralHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,mneutralHadronMultiplicity_MiniAOD->getBinContent(i)/mneutralHadronMultiplicity_Reco->getBinContent(i));
-      }else if(mneutralHadronMultiplicity_MiniAOD->getBinContent(i)!=0){
-	mneutralHadronMultiplicity_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mphotonMultiplicity_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mphotonMultiplicity_Reco->getBinContent(i)!=0){
-	mphotonMultiplicity_MiniAOD_over_Reco->setBinContent(i,mphotonMultiplicity_MiniAOD->getBinContent(i)/mphotonMultiplicity_Reco->getBinContent(i));
-      }else if(mphotonMultiplicity_MiniAOD->getBinContent(i)!=0){
-	mphotonMultiplicity_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mchargedHadronEnergyFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mchargedHadronEnergyFraction_Reco->getBinContent(i)!=0){
-	mchargedHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,mchargedHadronEnergyFraction_MiniAOD->getBinContent(i)/mchargedHadronEnergyFraction_Reco->getBinContent(i));
-      }else if(mchargedHadronEnergyFraction_MiniAOD->getBinContent(i)!=0){
-	mchargedHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mneutralHadronEnergyFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mneutralHadronEnergyFraction_Reco->getBinContent(i)!=0){
-	mneutralHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,mneutralHadronEnergyFraction_MiniAOD->getBinContent(i)/mneutralHadronEnergyFraction_Reco->getBinContent(i));
-      }else if(mneutralHadronEnergyFraction_MiniAOD->getBinContent(i)!=0){
-	mneutralHadronEnergyFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mphotonEnergyFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mphotonEnergyFraction_Reco->getBinContent(i)!=0){
-	mphotonEnergyFraction_MiniAOD_over_Reco->setBinContent(i,mphotonEnergyFraction_MiniAOD->getBinContent(i)/mphotonEnergyFraction_Reco->getBinContent(i));
-      }else if(mphotonEnergyFraction_MiniAOD->getBinContent(i)!=0){
-	mphotonEnergyFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Pt" ,mPt_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Phi" ,mPhi_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Eta" ,mEta_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"CorrJetPt"  ,mCorrJetPt_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"CorrJetPhi" ,mCorrJetPhi_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"CorrJetEta" ,mCorrJetEta_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverReco_Eta_20_40" ,mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverReco_Eta_200_600" ,mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverReco_Eta_1500_3500" ,mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverGen_GenEta_40_200" ,mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverGen_GenEta_600_1500" ,mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"DeltaEta" ,mDeltaEta_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"DeltaPhi" ,mDeltaPhi_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"DeltaPt" ,mDeltaPt_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Mjj" ,mMjj_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"NJets" ,mNJets40_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"chargedHadronMultiplicity" ,mchargedHadronMultiplicity_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"neutralHadronMultiplicity" ,mneutralHadronMultiplicity_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"photonMultiplicity" ,mphotonMultiplicity_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"chargedHadronEnergyFraction" ,mchargedHadronEnergyFraction_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"neutralHadronEnergyFraction" ,mneutralHadronEnergyFraction_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"photonEnergyFraction" ,mphotonEnergyFraction_MiniAOD_over_Reco));
+
+    for(unsigned int j=0;j<map_string_vec.size();j++){
+      MonitorElement* monReco=map_of_MEs[rundir_reco+"/"+map_string_vec[j]];if(monReco && monReco->getRootObject()){
+	MonitorElement* monMiniAOD=map_of_MEs[rundir_miniaod+"/"+map_string_vec[j]];if(monMiniAOD && monMiniAOD->getRootObject()){
+	  MonitorElement* monMiniAOD_over_RECO=map_of_MEs[RunDir+"MiniAOD_over_RECO"+"/"+map_string_vec[j]];if(monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()){
+	    for(int i=0;i<=(monMiniAOD_over_RECO->getNbinsX()+1);i++){
+	      if(monReco->getBinContent(i)!=0){
+		monMiniAOD_over_RECO->setBinContent(i,monMiniAOD->getBinContent(i)/monReco->getBinContent(i));
+	      }else if (monMiniAOD->getBinContent(i)!=0){
+		monMiniAOD_over_RECO->setBinContent(i,-0.5);
+	      }
+	    }
+	  }
+	}
       }
     }
   }

--- a/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
+++ b/Validation/RecoJets/plugins/JetTesterPostProcessor.cc
@@ -57,7 +57,7 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mCorrJetPt_Reco=iget_.get(rundir_reco+"/"+"CorrJetPt");
     MonitorElement* mCorrJetPhi_Reco=iget_.get(rundir_reco+"/"+"CorrJetPhi");
     MonitorElement* mCorrJetEta_Reco=iget_.get(rundir_reco+"/"+"CorrJetEta");
-
+    /*
     map_string_vec.push_back("Pt");
     map_string_vec.push_back("Phi");
     map_string_vec.push_back("Eta");
@@ -70,7 +70,7 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"CorrJetPt"  ,mCorrJetPt_Reco));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"CorrJetPhi" ,mCorrJetPhi_Reco));
     map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"CorrJetEta" ,mCorrJetEta_Reco));
-
+    */
     MonitorElement* mPtCorrOverReco_Eta_20_40_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_20_40");
     MonitorElement* mPtCorrOverReco_Eta_200_600_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_200_600");
     MonitorElement* mPtCorrOverReco_Eta_1500_3500_Reco=iget_.get(rundir_reco+"/"+"PtCorrOverReco_Eta_1500_3500");
@@ -87,40 +87,30 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mphotonEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"photonEnergyFraction");
     MonitorElement* mneutralHadronEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"neutralHadronEnergyFraction");
     MonitorElement* mchargedHadronEnergyFraction_Reco=iget_.get(rundir_reco+"/"+"chargedHadronEnergyFraction");
-    
-    map_string_vec.push_back("PtCorrOverReco_Eta_20_40");
-    map_string_vec.push_back("PtCorrOverReco_Eta_200_600");
-    map_string_vec.push_back("PtCorrOverReco_Eta_1500_3500");
-    map_string_vec.push_back("PtCorrOverGen_GenEta_40_200");
-    map_string_vec.push_back("PtCorrOverGen_GenEta_600_1500");
-    map_string_vec.push_back("DeltaEta");
-    map_string_vec.push_back("DeltaPhi");
-    map_string_vec.push_back("DeltaPt");
-    map_string_vec.push_back("Mjj");
-    map_string_vec.push_back("NJets");
-    map_string_vec.push_back("chargedHadronMultiplicity");
-    map_string_vec.push_back("neutralHadronMultiplicity");
-    map_string_vec.push_back("photonMultiplicity");
-    map_string_vec.push_back("chargedHadronEnergyFraction");
-    map_string_vec.push_back("neutralHadronEnergyFraction");
-    map_string_vec.push_back("photonEnergyFraction");
 
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverReco_Eta_20_40" ,mPtCorrOverReco_Eta_20_40_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverReco_Eta_200_600" ,mPtCorrOverReco_Eta_200_600_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverReco_Eta_1500_3500" ,mPtCorrOverReco_Eta_1500_3500_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverGen_GenEta_40_200" ,mPtCorrOverGen_GenEta_40_200_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"PtCorrOverGen_GenEta_600_1500" ,mPtCorrOverGen_GenEta_600_1500_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"DeltaEta" ,mDeltaEta_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"DeltaPhi" ,mDeltaPhi_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"DeltaPt" ,mDeltaPt_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"Mjj" ,mMjj_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"NJets" ,mNJets40_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"chargedHadronMultiplicity" ,mchargedHadronMultiplicity_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"neutralHadronMultiplicity" ,mneutralHadronMultiplicity_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"photonMultiplicity" ,mphotonMultiplicity_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"chargedHadronEnergyFraction" ,mchargedHadronEnergyFraction_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"neutralHadronEnergyFraction" ,mneutralHadronEnergyFraction_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"photonEnergyFraction" ,mphotonEnergyFraction_Reco));
+    std::vector<MonitorElement*>ME_Reco;
+    ME_Reco.push_back(mPt_Reco);
+    ME_Reco.push_back(mPhi_Reco);
+    ME_Reco.push_back(mEta_Reco);
+    ME_Reco.push_back(mCorrJetPt_Reco);
+    ME_Reco.push_back(mCorrJetPhi_Reco);
+    ME_Reco.push_back(mCorrJetEta_Reco);
+    ME_Reco.push_back(mPtCorrOverReco_Eta_20_40_Reco);
+    ME_Reco.push_back(mPtCorrOverReco_Eta_200_600_Reco);
+    ME_Reco.push_back(mPtCorrOverReco_Eta_1500_3500_Reco);
+    ME_Reco.push_back(mPtCorrOverGen_GenEta_40_200_Reco);
+    ME_Reco.push_back(mPtCorrOverGen_GenEta_600_1500_Reco);
+    ME_Reco.push_back(mDeltaEta_Reco);
+    ME_Reco.push_back(mDeltaPhi_Reco);
+    ME_Reco.push_back(mDeltaPt_Reco);
+    ME_Reco.push_back(mMjj_Reco);
+    ME_Reco.push_back(mNJets40_Reco);
+    ME_Reco.push_back(mchargedHadronMultiplicity_Reco);
+    ME_Reco.push_back(mneutralHadronMultiplicity_Reco);
+    ME_Reco.push_back(mphotonMultiplicity_Reco);
+    ME_Reco.push_back(mphotonEnergyFraction_Reco);
+    ME_Reco.push_back(mneutralHadronEnergyFraction_Reco);
+    ME_Reco.push_back(mchargedHadronEnergyFraction_Reco);
 
     MonitorElement* mPt_MiniAOD=iget_.get(rundir_miniaod+"/"+"Pt");
     MonitorElement* mPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"Phi");
@@ -145,28 +135,29 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mneutralHadronEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"neutralHadronEnergyFraction");
     MonitorElement* mchargedHadronEnergyFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"chargedHadronEnergyFraction");
 
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Pt" ,mPt_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Phi" ,mPhi_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Eta" ,mEta_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"CorrJetPt"  ,mCorrJetPt_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"CorrJetPhi" ,mCorrJetPhi_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"CorrJetEta" ,mCorrJetEta_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverReco_Eta_20_40" ,mPtCorrOverReco_Eta_20_40_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverReco_Eta_200_600" ,mPtCorrOverReco_Eta_200_600_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverReco_Eta_1500_3500" ,mPtCorrOverReco_Eta_1500_3500_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverGen_GenEta_40_200" ,mPtCorrOverGen_GenEta_40_200_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"PtCorrOverGen_GenEta_600_1500" ,mPtCorrOverGen_GenEta_600_1500_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"DeltaEta" ,mDeltaEta_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"DeltaPhi" ,mDeltaPhi_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"DeltaPt" ,mDeltaPt_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"Mjj" ,mMjj_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"NJets" ,mNJets40_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"chargedHadronMultiplicity" ,mchargedHadronMultiplicity_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"neutralHadronMultiplicity" ,mneutralHadronMultiplicity_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"photonMultiplicity" ,mphotonMultiplicity_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"chargedHadronEnergyFraction" ,mchargedHadronEnergyFraction_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"neutralHadronEnergyFraction" ,mneutralHadronEnergyFraction_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"photonEnergyFraction" ,mphotonEnergyFraction_MiniAOD));
+    std::vector<MonitorElement*>ME_MiniAOD;
+    ME_MiniAOD.push_back(mPt_MiniAOD);
+    ME_MiniAOD.push_back(mPhi_MiniAOD);
+    ME_MiniAOD.push_back(mEta_MiniAOD);
+    ME_MiniAOD.push_back(mCorrJetPt_MiniAOD);
+    ME_MiniAOD.push_back(mCorrJetPhi_MiniAOD);
+    ME_MiniAOD.push_back(mCorrJetEta_MiniAOD);
+    ME_MiniAOD.push_back(mPtCorrOverReco_Eta_20_40_MiniAOD);
+    ME_MiniAOD.push_back(mPtCorrOverReco_Eta_200_600_MiniAOD);
+    ME_MiniAOD.push_back(mPtCorrOverReco_Eta_1500_3500_MiniAOD);
+    ME_MiniAOD.push_back(mPtCorrOverGen_GenEta_40_200_MiniAOD);
+    ME_MiniAOD.push_back(mPtCorrOverGen_GenEta_600_1500_MiniAOD);
+    ME_MiniAOD.push_back(mDeltaEta_MiniAOD);
+    ME_MiniAOD.push_back(mDeltaPhi_MiniAOD);
+    ME_MiniAOD.push_back(mDeltaPt_MiniAOD);
+    ME_MiniAOD.push_back(mMjj_MiniAOD);
+    ME_MiniAOD.push_back(mNJets40_MiniAOD);
+    ME_MiniAOD.push_back(mchargedHadronMultiplicity_MiniAOD);
+    ME_MiniAOD.push_back(mneutralHadronMultiplicity_MiniAOD);
+    ME_MiniAOD.push_back(mphotonMultiplicity_MiniAOD);
+    ME_MiniAOD.push_back(mphotonEnergyFraction_MiniAOD);
+    ME_MiniAOD.push_back(mneutralHadronEnergyFraction_MiniAOD);
+    ME_MiniAOD.push_back(mchargedHadronEnergyFraction_MiniAOD);
 
     ibook_.setCurrentFolder(RunDir+"MiniAOD_over_RECO");
     mPt_MiniAOD_over_Reco=ibook_.book1D("Pt_MiniAOD_over_RECO",(TH1F*)mPt_Reco->getRootObject());
@@ -205,33 +196,33 @@ JetTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     mneutralHadronEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("neutralHadronEnergyFraction_MiniAOD_over_RECO",(TH1F*)mneutralHadronEnergyFraction_Reco->getRootObject());
     mphotonEnergyFraction_MiniAOD_over_Reco=ibook_.book1D("photonEnergyFraction_MiniAOD_over_RECO",(TH1F*)mphotonEnergyFraction_Reco->getRootObject());
 
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Pt" ,mPt_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Phi" ,mPhi_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Eta" ,mEta_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"CorrJetPt"  ,mCorrJetPt_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"CorrJetPhi" ,mCorrJetPhi_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"CorrJetEta" ,mCorrJetEta_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverReco_Eta_20_40" ,mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverReco_Eta_200_600" ,mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverReco_Eta_1500_3500" ,mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverGen_GenEta_40_200" ,mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"PtCorrOverGen_GenEta_600_1500" ,mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"DeltaEta" ,mDeltaEta_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"DeltaPhi" ,mDeltaPhi_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"DeltaPt" ,mDeltaPt_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"Mjj" ,mMjj_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"NJets" ,mNJets40_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"chargedHadronMultiplicity" ,mchargedHadronMultiplicity_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"neutralHadronMultiplicity" ,mneutralHadronMultiplicity_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"photonMultiplicity" ,mphotonMultiplicity_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"chargedHadronEnergyFraction" ,mchargedHadronEnergyFraction_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"neutralHadronEnergyFraction" ,mneutralHadronEnergyFraction_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"photonEnergyFraction" ,mphotonEnergyFraction_MiniAOD_over_Reco));
-
-    for(unsigned int j=0;j<map_string_vec.size();j++){
-      MonitorElement* monReco=map_of_MEs[rundir_reco+"/"+map_string_vec[j]];if(monReco && monReco->getRootObject()){
-	MonitorElement* monMiniAOD=map_of_MEs[rundir_miniaod+"/"+map_string_vec[j]];if(monMiniAOD && monMiniAOD->getRootObject()){
-	  MonitorElement* monMiniAOD_over_RECO=map_of_MEs[RunDir+"MiniAOD_over_RECO"+"/"+map_string_vec[j]];if(monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()){
+    std::vector<MonitorElement*>ME_MiniAOD_over_Reco;
+    ME_MiniAOD_over_Reco.push_back(mPt_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPhi_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mEta_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mCorrJetPt_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mCorrJetPhi_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mCorrJetEta_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mDeltaEta_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mDeltaPhi_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mDeltaPt_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMjj_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mNJets40_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mchargedHadronMultiplicity_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mneutralHadronMultiplicity_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mphotonMultiplicity_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mphotonEnergyFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mneutralHadronEnergyFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mchargedHadronEnergyFraction_MiniAOD_over_Reco);
+    for(unsigned int j=0;j<ME_MiniAOD_over_Reco.size();j++){
+      MonitorElement* monReco=ME_Reco[j];if(monReco && monReco->getRootObject()){
+	MonitorElement* monMiniAOD=ME_MiniAOD[j];if(monMiniAOD && monMiniAOD->getRootObject()){
+	  MonitorElement* monMiniAOD_over_RECO=ME_MiniAOD_over_Reco[j];if(monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()){
 	    for(int i=0;i<=(monMiniAOD_over_RECO->getNbinsX()+1);i++){
 	      if(monReco->getBinContent(i)!=0){
 		monMiniAOD_over_RECO->setBinContent(i,monMiniAOD->getBinContent(i)/monReco->getBinContent(i));

--- a/Validation/RecoJets/plugins/JetTesterPostProcessor.h
+++ b/Validation/RecoJets/plugins/JetTesterPostProcessor.h
@@ -1,0 +1,67 @@
+#ifndef JETTESTERPOSTPROCESSOR_H
+#define JETTESTERPOSTPROCESSOR_H
+
+// author: Matthias Weber, Feb 2015
+
+// system include files
+#include <memory>
+#include <stdio.h>
+#include <math.h>
+#include <sstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+//
+// class decleration
+//
+
+class JetTesterPostProcessor : public DQMEDHarvester {
+   public:
+      explicit JetTesterPostProcessor(const edm::ParameterSet&);
+      ~JetTesterPostProcessor();
+
+   private:
+      virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) ;
+
+      edm::InputTag inputJetLabelRECO_;
+      edm::InputTag inputJetLabelMiniAOD_;
+
+      std::vector<std::string> jet_dirs;
+
+
+      MonitorElement* mPt_MiniAOD_over_Reco;
+      MonitorElement* mPhi_MiniAOD_over_Reco;
+      MonitorElement* mEta_MiniAOD_over_Reco;
+      MonitorElement* mCorrJetPt_MiniAOD_over_Reco;
+      MonitorElement* mCorrJetPhi_MiniAOD_over_Reco;
+      MonitorElement* mCorrJetEta_MiniAOD_over_Reco;
+      MonitorElement* mPtCorrOverReco_Eta_20_40_MiniAOD_over_Reco;
+      MonitorElement* mPtCorrOverReco_Eta_200_600_MiniAOD_over_Reco;
+      MonitorElement* mPtCorrOverReco_Eta_1500_3500_MiniAOD_over_Reco;
+      MonitorElement* mPtCorrOverGen_GenEta_40_200_MiniAOD_over_Reco;
+      MonitorElement* mPtCorrOverGen_GenEta_600_1500_MiniAOD_over_Reco;
+      MonitorElement* mDeltaEta_MiniAOD_over_Reco;
+      MonitorElement* mDeltaPhi_MiniAOD_over_Reco;
+      MonitorElement* mDeltaPt_MiniAOD_over_Reco;
+      MonitorElement* mMjj_MiniAOD_over_Reco;
+      MonitorElement* mNJets40_MiniAOD_over_Reco;
+      MonitorElement* mchargedHadronMultiplicity_MiniAOD_over_Reco;
+      MonitorElement* mneutralHadronMultiplicity_MiniAOD_over_Reco;
+      MonitorElement* mphotonMultiplicity_MiniAOD_over_Reco;
+      MonitorElement* mphotonEnergyFraction_MiniAOD_over_Reco;
+      MonitorElement* mneutralHadronEnergyFraction_MiniAOD_over_Reco;
+      MonitorElement* mchargedHadronEnergyFraction_MiniAOD_over_Reco;
+
+};
+
+#endif

--- a/Validation/RecoJets/plugins/JetTesterPostProcessor.h
+++ b/Validation/RecoJets/plugins/JetTesterPostProcessor.h
@@ -37,10 +37,6 @@ class JetTesterPostProcessor : public DQMEDHarvester {
       edm::InputTag inputJetLabelMiniAOD_;
 
       std::vector<std::string> jet_dirs;
-      std::vector<std::string> map_string_vec;
-      std::map< std::string, MonitorElement*> map_of_MEs;
-
-
       MonitorElement* mPt_MiniAOD_over_Reco;
       MonitorElement* mPhi_MiniAOD_over_Reco;
       MonitorElement* mEta_MiniAOD_over_Reco;

--- a/Validation/RecoJets/plugins/JetTesterPostProcessor.h
+++ b/Validation/RecoJets/plugins/JetTesterPostProcessor.h
@@ -37,6 +37,8 @@ class JetTesterPostProcessor : public DQMEDHarvester {
       edm::InputTag inputJetLabelMiniAOD_;
 
       std::vector<std::string> jet_dirs;
+      std::vector<std::string> map_string_vec;
+      std::map< std::string, MonitorElement*> map_of_MEs;
 
 
       MonitorElement* mPt_MiniAOD_over_Reco;

--- a/Validation/RecoJets/plugins/SealModule.cc
+++ b/Validation/RecoJets/plugins/SealModule.cc
@@ -2,7 +2,9 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "JetTester.h"
+#include "JetTesterPostProcessor.h"
 #include "JetTester_HeavyIons.h"
 
 DEFINE_FWK_MODULE( JetTester );
+DEFINE_FWK_MODULE( JetTesterPostProcessor );
 DEFINE_FWK_MODULE( JetTester_HeavyIons );

--- a/Validation/RecoJets/python/JetPostProcessor_cff.py
+++ b/Validation/RecoJets/python/JetPostProcessor_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoJets.JetPostProcessor_cfi import *
+JetPostProcessor = cms.Sequence(JetPostprocessing)

--- a/Validation/RecoJets/python/JetPostProcessor_cfi.py
+++ b/Validation/RecoJets/python/JetPostProcessor_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+################# Postprocessing #########################
+JetPostprocessing = cms.EDAnalyzer('JetTesterPostProcessor',
+                    JetTypeRECO = cms.InputTag("ak4PFJetsCHS"),
+                    JetTypeMiniAOD = cms.InputTag("slimmedJets")
+                   )  

--- a/Validation/RecoJets/test/sequence_validation_cfg.py
+++ b/Validation/RecoJets/test/sequence_validation_cfg.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("JETVALIDATION")
 
-#process.load("Configuration.StandardSequences.GeometryDB_cff")
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 #process.load("Configuration.StandardSequences.Reconstruction_cff")
 #process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
@@ -14,7 +14,7 @@ process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 #process.GlobalTag.globaltag = 'START42_V17::All'
 ##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
 ## for 6_2_0 QCD
-process.GlobalTag.globaltag = 'PRE_LS172_V16::All'
+process.GlobalTag.globaltag = 'GR_R_74_V0A::All'
 
 #process.load("Configuration.StandardSequences.Services_cff")
 #process.load("Configuration.StandardSequences.Simulation_cff")
@@ -48,6 +48,7 @@ readFiles.extend( [
 
 # Validation module
 process.load("Validation.RecoJets.JetValidation_cff")
+process.load("Validation.RecoJets.JetPostProcessor_cff")
 #process.load("Validation.RecoHI.JetValidationHeavyIons_cff")
 
 process.maxEvents = cms.untracked.PSet(
@@ -70,6 +71,7 @@ process.p1 = cms.Path(
                       process.JetValidation
                       #for MiniAOD
                       #process.JetValidationMiniAOD
+                      *process.JetPostProcessor
                       *process.dqmSaver
 )
 

--- a/Validation/RecoJets/test/sequence_validation_cfg.py
+++ b/Validation/RecoJets/test/sequence_validation_cfg.py
@@ -14,7 +14,7 @@ process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 #process.GlobalTag.globaltag = 'START42_V17::All'
 ##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
 ## for 6_2_0 QCD
-process.GlobalTag.globaltag = 'GR_R_74_V0A::All'
+process.GlobalTag.globaltag = 'MCRUN2_74_V7::All'
 
 #process.load("Configuration.StandardSequences.Services_cff")
 #process.load("Configuration.StandardSequences.Simulation_cff")
@@ -30,17 +30,13 @@ secFiles = cms.untracked.vstring()
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
        #for RECO
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/22A79853-D85E-E411-BAA9-02163E00C055.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/28923A16-C95E-E411-871C-02163E00FFCE.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/307F76E6-E05E-E411-90AF-02163E00B036.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/4E03E1A5-CE5E-E411-AE0F-02163E008BE3.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/689DCC5B-D35E-E411-A720-02163E00D13A.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/CC3F6060-DA5E-E411-BA7C-02163E0105B8.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/D470466A-C55E-E411-A382-02163E00EB5D.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/E2A34427-E75E-E411-ABBA-02163E008DD3.root',
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/FCE96BE5-F15E-E411-BD38-02163E00D13A.root' 
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/48E3FDFE-3DBD-E411-9B99-0025905A613C.root',
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/706A960F-54BD-E411-8561-00261894384F.root',
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/E4EF6410-54BD-E411-8838-002590593920.root',
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/FA18AB00-3EBD-E411-AAE8-0025905A608A.root'
        #for MINIAODtests 
-       #'/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/MINIAODSIM/PU50ns_PRE_LS172_V16-v1/00000/9886ACB4-F45E-E411-9E5D-02163E00F01E.root' 
+       #'/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/MINIAODSIM/MCRUN2_74_V7-v1/00000/C265418B-58BD-E411-8167-0025905A6056.root',
+       #'/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/MINIAODSIM/MCRUN2_74_V7-v1/00000/C4BE1C8C-58BD-E411-9D78-0025905A60EE.root' 
        #test HI sequence for jets
        #'/store/relval/CMSSW_7_3_0_pre1/RelValQCD_Pt_80_120_13_HI/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/5C15CC80-0B5A-E411-AF4B-02163E00ECD2.root',
        #'/store/relval/CMSSW_7_3_0_pre1/RelValQCD_Pt_80_120_13_HI/GEN-SIM-RECO/PRE_LS172_V15-v1/00000/FC51FED6-B559-E411-9131-02163E006D72.root' 

--- a/Validation/RecoMET/plugins/METTester.cc
+++ b/Validation/RecoMET/plugins/METTester.cc
@@ -91,9 +91,6 @@ METTester::METTester(const edm::ParameterSet& iConfig)
   mChargedHadEtFraction=0;
   mMuonEtFraction=0; 
   mInvisibleEtFraction=0;
-  
-  //MET variables
-  
   //PFMET variables
   mMETDifference_GenMETTrue_MET0to20=0;
   mMETDifference_GenMETTrue_MET20to40=0;
@@ -104,9 +101,7 @@ METTester::METTester(const edm::ParameterSet& iConfig)
   mMETDifference_GenMETTrue_MET150to200=0;
   mMETDifference_GenMETTrue_MET200to300=0;
   mMETDifference_GenMETTrue_MET300to400=0;
-  mMETDifference_GenMETTrue_MET400to500=0;
-  mMETDifference_GenMETTrue_METResolution=0;
-  
+  mMETDifference_GenMETTrue_MET400to500=0; 
  
 } 
 void METTester::bookHistograms(DQMStore::IBooker & ibooker,
@@ -141,10 +136,6 @@ void METTester::bookHistograms(DQMStore::IBooker & ibooker,
       mMETDifference_GenMETTrue_MET200to300 = ibooker.book1D("METResolution_GenMETTrue_MET200to300", "METResolution_GenMETTrue_MET200to300", 500,-500,500); 
       mMETDifference_GenMETTrue_MET300to400 = ibooker.book1D("METResolution_GenMETTrue_MET300to400", "METResolution_GenMETTrue_MET300to400", 500,-500,500); 
       mMETDifference_GenMETTrue_MET400to500 = ibooker.book1D("METResolution_GenMETTrue_MET400to500", "METResolution_GenMETTrue_MET400to500", 500,-500,500); 
-      //this will be filled at the end of the job using info from above hists
-      int nBins = 10;
-      float bins[] = {0.,20.,40.,60.,80.,100.,150.,200.,300.,400.,500.};
-      mMETDifference_GenMETTrue_METResolution     = ibooker.book1D("METResolution_GenMETTrue_InMETBins","METResolution_GenMETTrue_InMETBins",nBins, bins); 
     }
     if ( isCaloMET) { 
       mCaloMaxEtInEmTowers             = ibooker.book1D("CaloMaxEtInEmTowers","CaloMaxEtInEmTowers",300,0,1500);   //5GeV
@@ -381,37 +372,8 @@ void METTester::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       mPFHFEMEtFraction->Fill(patmet->Type7EtFraction());//HFEMEt  
     }
   }  
-  //This is so dirty I could cry. It should be called only ONCE in endJob. But the MonitorElements don't exist then any more.
-  FillMETRes();
 }
 
-//void METTester::endRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
-void METTester::FillMETRes()
-{
-  if(!isGenMET){
-    mMETDifference_GenMETTrue_METResolution->setBinContent(1, mMETDifference_GenMETTrue_MET0to20->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(2, mMETDifference_GenMETTrue_MET20to40->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(3, mMETDifference_GenMETTrue_MET40to60->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(4, mMETDifference_GenMETTrue_MET60to80->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(5, mMETDifference_GenMETTrue_MET80to100->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(6, mMETDifference_GenMETTrue_MET100to150->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(7, mMETDifference_GenMETTrue_MET150to200->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(8, mMETDifference_GenMETTrue_MET200to300->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(9, mMETDifference_GenMETTrue_MET300to400->getMean());
-    mMETDifference_GenMETTrue_METResolution->setBinContent(10, mMETDifference_GenMETTrue_MET400to500->getMean());
-    
-    //the error computation should be done in a postProcessor in the harvesting step otherwise the histograms will be just summed
-    mMETDifference_GenMETTrue_METResolution->setBinError(1, mMETDifference_GenMETTrue_MET0to20->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(2, mMETDifference_GenMETTrue_MET20to40->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(3, mMETDifference_GenMETTrue_MET40to60->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(4, mMETDifference_GenMETTrue_MET60to80->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(5, mMETDifference_GenMETTrue_MET80to100->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(6, mMETDifference_GenMETTrue_MET100to150->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(7, mMETDifference_GenMETTrue_MET150to200->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(8, mMETDifference_GenMETTrue_MET200to300->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(9, mMETDifference_GenMETTrue_MET300to400->getRMS());
-    mMETDifference_GenMETTrue_METResolution->setBinError(10, mMETDifference_GenMETTrue_MET400to500->getRMS());
-  }
-}
+
 
 

--- a/Validation/RecoMET/plugins/METTester.h
+++ b/Validation/RecoMET/plugins/METTester.h
@@ -153,8 +153,6 @@ public:
   MonitorElement* mMETDifference_GenMETTrue_MET200to300;
   MonitorElement* mMETDifference_GenMETTrue_MET300to400;
   MonitorElement* mMETDifference_GenMETTrue_MET400to500;
-  MonitorElement* mMETDifference_GenMETTrue_METResolution;
-
   
 
   bool isCaloMET;

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -1,0 +1,245 @@
+// -*- C++ -*-
+//
+// Package:    Validation/RecoMET
+// Class:      METTesterPostProcessor
+// 
+// Original Author:  "Matthias Weber"
+//         Created:  Sun Feb 22 14:35:25 CET 2015
+//
+
+#include "Validation/RecoMET/plugins/METTesterPostProcessor.h"
+#include "FWCore/Framework/interface/LuminosityBlock.h"
+#include "FWCore/Framework/interface/Run.h"
+
+// Some switches
+//
+// constructors and destructor
+//
+METTesterPostProcessor::METTesterPostProcessor(const edm::ParameterSet& iConfig)
+{
+  inputMETLabelRECO_=iConfig.getParameter<edm::InputTag>("METTypeRECO");
+  inputMETLabelMiniAOD_=iConfig.getParameter<edm::InputTag>("METTypeMiniAOD");
+}
+
+
+METTesterPostProcessor::~METTesterPostProcessor()
+{ 
+}
+
+
+// ------------ method called right after a run ends ------------
+void 
+METTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& iget_)
+{
+  std::vector<std::string> subDirVec;
+  std::string RunDir="JetMET/METValidation/";
+  iget_.setCurrentFolder(RunDir);
+  met_dirs=iget_.getSubdirs();
+  //bin definition for resolution plot
+  int nBins = 10;
+  float bins[] = {0.,20.,40.,60.,80.,100.,150.,200.,300.,400.,500.};
+  bool found_reco_dir=false;
+  bool found_miniaod_dir=false;
+  //loop over met subdirectories
+  for (int i=0; i<int(met_dirs.size()); i++) {
+    ibook_.setCurrentFolder(met_dirs[i]);  
+    mMETDifference_GenMETTrue_METResolution = ibook_.book1D("METResolution_GenMETTrue_InMETBins","METResolution_GenMETTrue_InMETBins",nBins, bins); 
+    FillMETRes(met_dirs[i],iget_);
+    if(met_dirs[i]==(RunDir+inputMETLabelRECO_.label())){
+      found_reco_dir=true;
+    }
+    if(met_dirs[i]==(RunDir+inputMETLabelMiniAOD_.label())){
+      found_miniaod_dir=true;
+    }
+  }
+  if(found_miniaod_dir && found_reco_dir){
+    std::string rundir_reco=RunDir+inputMETLabelRECO_.label();
+    std::string rundir_miniaod=RunDir+inputMETLabelMiniAOD_.label();
+    MonitorElement* mMET_Reco=iget_.get(rundir_reco+"/"+"MET");
+    MonitorElement* mMETPhi_Reco=iget_.get(rundir_reco+"/"+"METPhi");
+    MonitorElement* mSumET_Reco=iget_.get(rundir_reco+"/"+"SumET");
+    MonitorElement* mMETDifference_GenMETTrue_Reco=iget_.get(rundir_reco+"/"+"METDifference_GenMETTrue");
+    MonitorElement* mMETDeltaPhi_GenMETTrue_Reco=iget_.get(rundir_reco+"/"+"METDeltaPhi_GenMETTrue"); 
+    MonitorElement* mPFPhotonEtFraction_Reco=iget_.get(rundir_reco+"/"+"photonEtFraction"); 
+    MonitorElement* mPFNeutralHadronEtFraction_Reco=iget_.get(rundir_reco+"/"+"neutralHadronEtFraction"); 
+    MonitorElement* mPFChargedHadronEtFraction_Reco=iget_.get(rundir_reco+"/"+"chargedHadronEtFraction"); 
+    MonitorElement* mPFHFHadronEtFraction_Reco=iget_.get(rundir_reco+"/"+"HFHadronEtFraction"); 
+    MonitorElement* mPFHFEMEtFraction_Reco=iget_.get(rundir_reco+"/"+"HFEMEtFraction"); 
+    MonitorElement* mMETDifference_GenMETTrue_MET20to40_Reco=iget_.get(rundir_reco+"/"+"METResolution_GenMETTrue_MET20to40");
+    MonitorElement* mMETDifference_GenMETTrue_MET100to150_Reco=iget_.get(rundir_reco+"/"+"METResolution_GenMETTrue_MET100to150");
+    MonitorElement* mMETDifference_GenMETTrue_MET300to400_Reco=iget_.get(rundir_reco+"/"+"METResolution_GenMETTrue_MET300to400");
+
+    MonitorElement* mMET_MiniAOD=iget_.get(rundir_miniaod+"/"+"MET");
+    MonitorElement* mMETPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"METPhi");
+    MonitorElement* mSumET_MiniAOD=iget_.get(rundir_miniaod+"/"+"SumET");
+    MonitorElement* mMETDifference_GenMETTrue_MiniAOD=iget_.get(rundir_miniaod+"/"+"METDifference_GenMETTrue");
+    MonitorElement* mMETDeltaPhi_GenMETTrue_MiniAOD=iget_.get(rundir_miniaod+"/"+"METDeltaPhi_GenMETTrue"); 
+    MonitorElement* mPFPhotonEtFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"photonEtFraction"); 
+    MonitorElement* mPFNeutralHadronEtFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"neutralHadronEtFraction"); 
+    MonitorElement* mPFChargedHadronEtFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"chargedHadronEtFraction"); 
+    MonitorElement* mPFHFHadronEtFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"HFHadronEtFraction"); 
+    MonitorElement* mPFHFEMEtFraction_MiniAOD=iget_.get(rundir_miniaod+"/"+"HFEMEtFraction"); 
+    MonitorElement* mMETDifference_GenMETTrue_MET20to40_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET20to40");
+    MonitorElement* mMETDifference_GenMETTrue_MET100to150_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET100to150");
+    MonitorElement* mMETDifference_GenMETTrue_MET300to400_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET300to400");
+
+    ibook_.setCurrentFolder(RunDir+"MiniAOD_over_RECO");
+    mMET_MiniAOD_over_Reco=ibook_.book1D("MET_MiniAOD_over_RECO",(TH1F*)mMET_Reco->getRootObject());
+    mMETPhi_MiniAOD_over_Reco=ibook_.book1D("METPhi_MiniAOD_over_RECO",(TH1F*)mMETPhi_Reco->getRootObject());
+    mSumET_MiniAOD_over_Reco=ibook_.book1D("SumET_MiniAOD_over_RECO",(TH1F*)mSumET_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MiniAOD_over_Reco=ibook_.book1D("METDifference_GenMETTrue_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_Reco->getRootObject());
+    mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco=ibook_.book1D("METDeltaPhi_GenMETTrue_MiniAOD_over_RECO",(TH1F*)mMETDeltaPhi_GenMETTrue_Reco->getRootObject());
+    mPFPhotonEtFraction_MiniAOD_over_Reco=ibook_.book1D("photonEtFraction_MiniAOD_over_RECO",(TH1F*)mPFPhotonEtFraction_Reco->getRootObject());
+    mPFNeutralHadronEtFraction_MiniAOD_over_Reco=ibook_.book1D("neutralHadronEtFraction_MiniAOD_over_RECO",(TH1F*)mPFNeutralHadronEtFraction_Reco->getRootObject());
+    mPFChargedHadronEtFraction_MiniAOD_over_Reco=ibook_.book1D("chargedHadronEtFraction_MiniAOD_over_RECO",(TH1F*)mPFChargedHadronEtFraction_Reco->getRootObject());
+    mPFHFHadronEtFraction_MiniAOD_over_Reco=ibook_.book1D("HFHadronEtFraction_MiniAOD_over_RECO",(TH1F*)mPFHFHadronEtFraction_Reco->getRootObject());
+    mPFHFEMEtFraction_MiniAOD_over_Reco=ibook_.book1D("HFEMEtEtFraction_MiniAOD_over_RECO",(TH1F*)mPFHFEMEtFraction_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET20to40_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET20to40_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET100to150_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET100to150_Reco->getRootObject());
+    mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET300to400_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET300to400_Reco->getRootObject());
+    for(int i=0;i<=(mMET_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMET_Reco->getBinContent(i)!=0){
+	mMET_MiniAOD_over_Reco->setBinContent(i,mMET_MiniAOD->getBinContent(i)/mMET_Reco->getBinContent(i));
+      }else if(mMET_MiniAOD->getBinContent(i)!=0){
+	mMET_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mMETPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMETPhi_Reco->getBinContent(i)!=0){
+	mMETPhi_MiniAOD_over_Reco->setBinContent(i,mMETPhi_MiniAOD->getBinContent(i)/mMETPhi_Reco->getBinContent(i));
+      }else if(mMETPhi_MiniAOD->getBinContent(i)!=0){
+	mMETPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mSumET_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mSumET_Reco->getBinContent(i)!=0){
+	mSumET_MiniAOD_over_Reco->setBinContent(i,mSumET_MiniAOD->getBinContent(i)/mSumET_Reco->getBinContent(i));
+      }else if(mSumET_MiniAOD->getBinContent(i)!=0){
+	mSumET_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mMETDifference_GenMETTrue_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMETDifference_GenMETTrue_Reco->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_Reco->getBinContent(i));
+      }else if(mMETDifference_GenMETTrue_MiniAOD->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMETDeltaPhi_GenMETTrue_Reco->getBinContent(i)!=0){
+	mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,mMETDeltaPhi_GenMETTrue_MiniAOD->getBinContent(i)/mMETDeltaPhi_GenMETTrue_Reco->getBinContent(i));
+      }else if(mMETDeltaPhi_GenMETTrue_MiniAOD->getBinContent(i)!=0){
+	mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPFPhotonEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPFPhotonEtFraction_Reco->getBinContent(i)!=0){
+	mPFPhotonEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFPhotonEtFraction_MiniAOD->getBinContent(i)/mPFPhotonEtFraction_Reco->getBinContent(i));
+      }else if(mPFPhotonEtFraction_MiniAOD->getBinContent(i)!=0){
+	mPFPhotonEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPFNeutralHadronEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPFNeutralHadronEtFraction_Reco->getBinContent(i)!=0){
+	mPFNeutralHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFNeutralHadronEtFraction_MiniAOD->getBinContent(i)/mPFNeutralHadronEtFraction_Reco->getBinContent(i));
+      }else if(mPFNeutralHadronEtFraction_MiniAOD->getBinContent(i)!=0){
+	mPFNeutralHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPFChargedHadronEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPFChargedHadronEtFraction_Reco->getBinContent(i)!=0){
+	mPFChargedHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFChargedHadronEtFraction_MiniAOD->getBinContent(i)/mPFChargedHadronEtFraction_Reco->getBinContent(i));
+      }else if(mPFChargedHadronEtFraction_MiniAOD->getBinContent(i)!=0){
+	mPFChargedHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPFHFHadronEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPFHFHadronEtFraction_Reco->getBinContent(i)!=0){
+	mPFHFHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFHFHadronEtFraction_MiniAOD->getBinContent(i)/mPFHFHadronEtFraction_Reco->getBinContent(i));
+      }else if(mPFHFHadronEtFraction_MiniAOD->getBinContent(i)!=0){
+	mPFHFHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mPFHFEMEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mPFHFEMEtFraction_Reco->getBinContent(i)!=0){
+	mPFHFEMEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFHFEMEtFraction_MiniAOD->getBinContent(i)/mPFHFEMEtFraction_Reco->getBinContent(i));
+      }else if(mPFHFEMEtFraction_MiniAOD->getBinContent(i)!=0){
+	mPFHFEMEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMETDifference_GenMETTrue_MET20to40_Reco->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MET20to40_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_MET20to40_Reco->getBinContent(i));
+      }else if(mMETDifference_GenMETTrue_MET20to40_MiniAOD->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMETDifference_GenMETTrue_MET100to150_Reco->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MET100to150_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_MET100to150_Reco->getBinContent(i));
+      }else if(mMETDifference_GenMETTrue_MET100to150_MiniAOD->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+    for(int i=0;i<=(mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco->getNbinsX()+1);i++){
+      if(mMETDifference_GenMETTrue_MET300to400_Reco->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MET300to400_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_MET300to400_Reco->getBinContent(i));
+      }else if(mMETDifference_GenMETTrue_MET300to400_MiniAOD->getBinContent(i)!=0){
+	mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco->setBinContent(i,-0.5);
+      }
+    }
+  }
+}
+
+
+void METTesterPostProcessor::FillMETRes(std::string metdir, DQMStore::IGetter & iget)
+{
+
+  mMETDifference_GenMETTrue_MET0to20=0;
+  mMETDifference_GenMETTrue_MET20to40=0;
+  mMETDifference_GenMETTrue_MET40to60=0;
+  mMETDifference_GenMETTrue_MET60to80=0;
+  mMETDifference_GenMETTrue_MET80to100=0;
+  mMETDifference_GenMETTrue_MET100to150=0;
+  mMETDifference_GenMETTrue_MET150to200=0;
+  mMETDifference_GenMETTrue_MET200to300=0;
+  mMETDifference_GenMETTrue_MET300to400=0;
+  mMETDifference_GenMETTrue_MET400to500=0;
+ 
+
+  mMETDifference_GenMETTrue_MET0to20 = iget.get(metdir+"/METResolution_GenMETTrue_MET0to20");
+  mMETDifference_GenMETTrue_MET20to40 = iget.get(metdir+"/METResolution_GenMETTrue_MET20to40");
+  mMETDifference_GenMETTrue_MET40to60 = iget.get(metdir+"/METResolution_GenMETTrue_MET40to60");
+  mMETDifference_GenMETTrue_MET60to80 = iget.get(metdir+"/METResolution_GenMETTrue_MET60to80");
+  mMETDifference_GenMETTrue_MET80to100 = iget.get(metdir+"/METResolution_GenMETTrue_MET80to100");
+  mMETDifference_GenMETTrue_MET100to150 = iget.get(metdir+"/METResolution_GenMETTrue_MET100to150");
+  mMETDifference_GenMETTrue_MET150to200 = iget.get(metdir+"/METResolution_GenMETTrue_MET150to200");
+  mMETDifference_GenMETTrue_MET200to300 = iget.get(metdir+"/METResolution_GenMETTrue_MET200to300");
+  mMETDifference_GenMETTrue_MET300to400 = iget.get(metdir+"/METResolution_GenMETTrue_MET300to400");
+  mMETDifference_GenMETTrue_MET400to500 = iget.get(metdir+"/METResolution_GenMETTrue_MET400to500"); 
+  if(mMETDifference_GenMETTrue_MET0to20 && mMETDifference_GenMETTrue_MET0to20->getRootObject()){//check one object, if existing, then the remaining ME's exist too
+    //for genmet none of these ME's are filled
+    mMETDifference_GenMETTrue_METResolution->setBinContent(1, mMETDifference_GenMETTrue_MET0to20->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(2, mMETDifference_GenMETTrue_MET20to40->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(3, mMETDifference_GenMETTrue_MET40to60->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(4, mMETDifference_GenMETTrue_MET60to80->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(5, mMETDifference_GenMETTrue_MET80to100->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(6, mMETDifference_GenMETTrue_MET100to150->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(7, mMETDifference_GenMETTrue_MET150to200->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(8, mMETDifference_GenMETTrue_MET200to300->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(9, mMETDifference_GenMETTrue_MET300to400->getMean());
+    mMETDifference_GenMETTrue_METResolution->setBinContent(10, mMETDifference_GenMETTrue_MET400to500->getMean());
+    
+    //the error computation should be done in a postProcessor in the harvesting step otherwise the histograms will be just summed
+    mMETDifference_GenMETTrue_METResolution->setBinError(1, mMETDifference_GenMETTrue_MET0to20->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(2, mMETDifference_GenMETTrue_MET20to40->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(3, mMETDifference_GenMETTrue_MET40to60->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(4, mMETDifference_GenMETTrue_MET60to80->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(5, mMETDifference_GenMETTrue_MET80to100->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(6, mMETDifference_GenMETTrue_MET100to150->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(7, mMETDifference_GenMETTrue_MET150to200->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(8, mMETDifference_GenMETTrue_MET200to300->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(9, mMETDifference_GenMETTrue_MET300to400->getRMS());
+    mMETDifference_GenMETTrue_METResolution->setBinError(10, mMETDifference_GenMETTrue_MET400to500->getRMS());
+  }
+}

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -69,32 +69,21 @@ METTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mMETDifference_GenMETTrue_MET100to150_Reco=iget_.get(rundir_reco+"/"+"METResolution_GenMETTrue_MET100to150");
     MonitorElement* mMETDifference_GenMETTrue_MET300to400_Reco=iget_.get(rundir_reco+"/"+"METResolution_GenMETTrue_MET300to400");
 
-    map_string_vec.push_back("MET");
-    map_string_vec.push_back("METPhi");
-    map_string_vec.push_back("SumET");
-    map_string_vec.push_back("METDifference_GenMETTrue");
-    map_string_vec.push_back("METDeltaPhi_GenMETTrue");
-    map_string_vec.push_back("photonEtFraction");
-    map_string_vec.push_back("neutralHadronEtFraction");
-    map_string_vec.push_back("chargedHadronEtFraction");
-    map_string_vec.push_back("HFHadronEtFraction");
-    map_string_vec.push_back("HFEMEtFraction");
-    map_string_vec.push_back("METResolution_GenMETTrue_MET20to40");
-    map_string_vec.push_back("METResolution_GenMETTrue_MET100to150");
-    map_string_vec.push_back("METResolution_GenMETTrue_MET300to400");
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"MET" ,mMET_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METPhi" ,mMETPhi_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"SumET" ,mSumET_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METDifference_GenMETTrue"  ,mMETDifference_GenMETTrue_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METDeltaPhi_GenMETTrue" ,mMETDeltaPhi_GenMETTrue_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"photonEtFraction" ,mPFPhotonEtFraction_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"chargedHadronEtFraction" ,mPFChargedHadronEtFraction_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"neutralHadronEtFraction" ,mPFNeutralHadronEtFraction_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"HFHadronEtFraction" ,mPFHFHadronEtFraction_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"HFEMEtFraction" ,mPFHFEMEtFraction_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METResolution_GenMETTrue_MET20to40" ,mMETDifference_GenMETTrue_MET20to40_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METResolution_GenMETTrue_MET100to150" ,mMETDifference_GenMETTrue_MET100to150_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METResolution_GenMETTrue_MET300to400" ,mMETDifference_GenMETTrue_MET300to400_Reco));
+    std::vector<MonitorElement*>ME_Reco;
+    ME_Reco.push_back(mMET_Reco);
+    ME_Reco.push_back(mMETPhi_Reco);
+    ME_Reco.push_back(mSumET_Reco);
+    ME_Reco.push_back(mMETDifference_GenMETTrue_Reco);
+    ME_Reco.push_back(mMETDeltaPhi_GenMETTrue_Reco);
+    ME_Reco.push_back(mPFPhotonEtFraction_Reco);
+    ME_Reco.push_back(mPFNeutralHadronEtFraction_Reco);
+    ME_Reco.push_back(mPFChargedHadronEtFraction_Reco);
+    ME_Reco.push_back(mPFHFHadronEtFraction_Reco);
+    ME_Reco.push_back(mPFHFEMEtFraction_Reco);
+    ME_Reco.push_back(mMETDifference_GenMETTrue_MET20to40_Reco);
+    ME_Reco.push_back(mMETDifference_GenMETTrue_MET100to150_Reco);
+    ME_Reco.push_back(mMETDifference_GenMETTrue_MET300to400_Reco);
+
 
     MonitorElement* mMET_MiniAOD=iget_.get(rundir_miniaod+"/"+"MET");
     MonitorElement* mMETPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"METPhi");
@@ -110,19 +99,20 @@ METTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mMETDifference_GenMETTrue_MET100to150_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET100to150");
     MonitorElement* mMETDifference_GenMETTrue_MET300to400_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET300to400");
 
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"MET" ,mMET_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METPhi" ,mMETPhi_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"SumET" ,mSumET_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METDifference_GenMETTrue"  ,mMETDifference_GenMETTrue_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METDeltaPhi_GenMETTrue" ,mMETDeltaPhi_GenMETTrue_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"photonEtFraction" ,mPFPhotonEtFraction_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"chargedHadronEtFraction" ,mPFChargedHadronEtFraction_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"neutralHadronEtFraction" ,mPFNeutralHadronEtFraction_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"HFHadronEtFraction" ,mPFHFHadronEtFraction_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"HFEMEtFraction" ,mPFHFEMEtFraction_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET20to40" ,mMETDifference_GenMETTrue_MET20to40_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET100to150" ,mMETDifference_GenMETTrue_MET100to150_MiniAOD));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET300to400" ,mMETDifference_GenMETTrue_MET300to400_MiniAOD));
+    std::vector<MonitorElement*>ME_MiniAOD;
+    ME_MiniAOD.push_back(mMET_MiniAOD);
+    ME_MiniAOD.push_back(mMETPhi_MiniAOD);
+    ME_MiniAOD.push_back(mSumET_MiniAOD);
+    ME_MiniAOD.push_back(mMETDifference_GenMETTrue_MiniAOD);
+    ME_MiniAOD.push_back(mMETDeltaPhi_GenMETTrue_MiniAOD);
+    ME_MiniAOD.push_back(mPFPhotonEtFraction_MiniAOD);
+    ME_MiniAOD.push_back(mPFNeutralHadronEtFraction_MiniAOD);
+    ME_MiniAOD.push_back(mPFChargedHadronEtFraction_MiniAOD);
+    ME_MiniAOD.push_back(mPFHFHadronEtFraction_MiniAOD);
+    ME_MiniAOD.push_back(mPFHFEMEtFraction_MiniAOD);
+    ME_MiniAOD.push_back(mMETDifference_GenMETTrue_MET20to40_MiniAOD);
+    ME_MiniAOD.push_back(mMETDifference_GenMETTrue_MET100to150_MiniAOD);
+    ME_MiniAOD.push_back(mMETDifference_GenMETTrue_MET300to400_MiniAOD);
 
     ibook_.setCurrentFolder(RunDir+"MiniAOD_over_RECO");
     mMET_MiniAOD_over_Reco=ibook_.book1D("MET_MiniAOD_over_RECO",(TH1F*)mMET_Reco->getRootObject());
@@ -139,24 +129,25 @@ METTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET100to150_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET100to150_Reco->getRootObject());
     mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET300to400_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET300to400_Reco->getRootObject());
 
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"MET" ,mMET_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METPhi" ,mMETPhi_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"SumET" ,mSumET_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METDifference_GenMETTrue"  ,mMETDifference_GenMETTrue_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METDeltaPhi_GenMETTrue" ,mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"photonEtFraction" ,mPFPhotonEtFraction_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"chargedHadronEtFraction" ,mPFChargedHadronEtFraction_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"neutralHadronEtFraction" ,mPFNeutralHadronEtFraction_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"HFHadronEtFraction" ,mPFHFHadronEtFraction_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"HFEMEtFraction" ,mPFHFEMEtFraction_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METResolution_GenMETTrue_MET20to40" ,mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METResolution_GenMETTrue_MET100to150" ,mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco));
-    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METResolution_GenMETTrue_MET300to400" ,mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco));
+    std::vector<MonitorElement*>ME_MiniAOD_over_Reco;
+    ME_MiniAOD_over_Reco.push_back(mMET_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETPhi_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mSumET_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPFPhotonEtFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPFNeutralHadronEtFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPFChargedHadronEtFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPFHFHadronEtFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mPFHFEMEtFraction_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco);
+    ME_MiniAOD_over_Reco.push_back(mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco);
 
-    for(unsigned int j=0;j<map_string_vec.size();j++){
-      MonitorElement* monReco=map_of_MEs[rundir_reco+"/"+map_string_vec[j]];if(monReco && monReco->getRootObject()){
-	MonitorElement* monMiniAOD=map_of_MEs[rundir_miniaod+"/"+map_string_vec[j]];if(monMiniAOD && monMiniAOD->getRootObject()){
-	  MonitorElement* monMiniAOD_over_RECO=map_of_MEs[RunDir+"MiniAOD_over_RECO"+"/"+map_string_vec[j]];if(monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()){
+    for(unsigned int j=0;j<ME_MiniAOD_over_Reco.size();j++){
+      MonitorElement* monReco=ME_Reco[j];if(monReco && monReco->getRootObject()){
+	MonitorElement* monMiniAOD=ME_MiniAOD[j];if(monMiniAOD && monMiniAOD->getRootObject()){
+	  MonitorElement* monMiniAOD_over_RECO=ME_MiniAOD_over_Reco[j];if(monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()){
 	    for(int i=0;i<=(monMiniAOD_over_RECO->getNbinsX()+1);i++){
 	      if(monReco->getBinContent(i)!=0){
 		monMiniAOD_over_RECO->setBinContent(i,monMiniAOD->getBinContent(i)/monReco->getBinContent(i));

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.cc
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.cc
@@ -69,6 +69,33 @@ METTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mMETDifference_GenMETTrue_MET100to150_Reco=iget_.get(rundir_reco+"/"+"METResolution_GenMETTrue_MET100to150");
     MonitorElement* mMETDifference_GenMETTrue_MET300to400_Reco=iget_.get(rundir_reco+"/"+"METResolution_GenMETTrue_MET300to400");
 
+    map_string_vec.push_back("MET");
+    map_string_vec.push_back("METPhi");
+    map_string_vec.push_back("SumET");
+    map_string_vec.push_back("METDifference_GenMETTrue");
+    map_string_vec.push_back("METDeltaPhi_GenMETTrue");
+    map_string_vec.push_back("photonEtFraction");
+    map_string_vec.push_back("neutralHadronEtFraction");
+    map_string_vec.push_back("chargedHadronEtFraction");
+    map_string_vec.push_back("HFHadronEtFraction");
+    map_string_vec.push_back("HFEMEtFraction");
+    map_string_vec.push_back("METResolution_GenMETTrue_MET20to40");
+    map_string_vec.push_back("METResolution_GenMETTrue_MET100to150");
+    map_string_vec.push_back("METResolution_GenMETTrue_MET300to400");
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"MET" ,mMET_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METPhi" ,mMETPhi_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"SumET" ,mSumET_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METDifference_GenMETTrue"  ,mMETDifference_GenMETTrue_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METDeltaPhi_GenMETTrue" ,mMETDeltaPhi_GenMETTrue_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"photonEtFraction" ,mPFPhotonEtFraction_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"chargedHadronEtFraction" ,mPFChargedHadronEtFraction_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"neutralHadronEtFraction" ,mPFNeutralHadronEtFraction_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"HFHadronEtFraction" ,mPFHFHadronEtFraction_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"HFEMEtFraction" ,mPFHFEMEtFraction_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METResolution_GenMETTrue_MET20to40" ,mMETDifference_GenMETTrue_MET20to40_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METResolution_GenMETTrue_MET100to150" ,mMETDifference_GenMETTrue_MET100to150_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_reco+"/"+"METResolution_GenMETTrue_MET300to400" ,mMETDifference_GenMETTrue_MET300to400_Reco));
+
     MonitorElement* mMET_MiniAOD=iget_.get(rundir_miniaod+"/"+"MET");
     MonitorElement* mMETPhi_MiniAOD=iget_.get(rundir_miniaod+"/"+"METPhi");
     MonitorElement* mSumET_MiniAOD=iget_.get(rundir_miniaod+"/"+"SumET");
@@ -82,6 +109,20 @@ METTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     MonitorElement* mMETDifference_GenMETTrue_MET20to40_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET20to40");
     MonitorElement* mMETDifference_GenMETTrue_MET100to150_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET100to150");
     MonitorElement* mMETDifference_GenMETTrue_MET300to400_MiniAOD=iget_.get(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET300to400");
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"MET" ,mMET_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METPhi" ,mMETPhi_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"SumET" ,mSumET_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METDifference_GenMETTrue"  ,mMETDifference_GenMETTrue_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METDeltaPhi_GenMETTrue" ,mMETDeltaPhi_GenMETTrue_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"photonEtFraction" ,mPFPhotonEtFraction_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"chargedHadronEtFraction" ,mPFChargedHadronEtFraction_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"neutralHadronEtFraction" ,mPFNeutralHadronEtFraction_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"HFHadronEtFraction" ,mPFHFHadronEtFraction_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"HFEMEtFraction" ,mPFHFEMEtFraction_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET20to40" ,mMETDifference_GenMETTrue_MET20to40_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET100to150" ,mMETDifference_GenMETTrue_MET100to150_MiniAOD));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(rundir_miniaod+"/"+"METResolution_GenMETTrue_MET300to400" ,mMETDifference_GenMETTrue_MET300to400_MiniAOD));
 
     ibook_.setCurrentFolder(RunDir+"MiniAOD_over_RECO");
     mMET_MiniAOD_over_Reco=ibook_.book1D("MET_MiniAOD_over_RECO",(TH1F*)mMET_Reco->getRootObject());
@@ -97,95 +138,34 @@ METTesterPostProcessor::dqmEndJob(DQMStore::IBooker& ibook_, DQMStore::IGetter& 
     mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET20to40_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET20to40_Reco->getRootObject());
     mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET100to150_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET100to150_Reco->getRootObject());
     mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco=ibook_.book1D("METResolution_GenMETTrue_MET300to400_MiniAOD_over_RECO",(TH1F*)mMETDifference_GenMETTrue_MET300to400_Reco->getRootObject());
-    for(int i=0;i<=(mMET_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMET_Reco->getBinContent(i)!=0){
-	mMET_MiniAOD_over_Reco->setBinContent(i,mMET_MiniAOD->getBinContent(i)/mMET_Reco->getBinContent(i));
-      }else if(mMET_MiniAOD->getBinContent(i)!=0){
-	mMET_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mMETPhi_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMETPhi_Reco->getBinContent(i)!=0){
-	mMETPhi_MiniAOD_over_Reco->setBinContent(i,mMETPhi_MiniAOD->getBinContent(i)/mMETPhi_Reco->getBinContent(i));
-      }else if(mMETPhi_MiniAOD->getBinContent(i)!=0){
-	mMETPhi_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mSumET_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mSumET_Reco->getBinContent(i)!=0){
-	mSumET_MiniAOD_over_Reco->setBinContent(i,mSumET_MiniAOD->getBinContent(i)/mSumET_Reco->getBinContent(i));
-      }else if(mSumET_MiniAOD->getBinContent(i)!=0){
-	mSumET_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mMETDifference_GenMETTrue_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMETDifference_GenMETTrue_Reco->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_Reco->getBinContent(i));
-      }else if(mMETDifference_GenMETTrue_MiniAOD->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMETDeltaPhi_GenMETTrue_Reco->getBinContent(i)!=0){
-	mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,mMETDeltaPhi_GenMETTrue_MiniAOD->getBinContent(i)/mMETDeltaPhi_GenMETTrue_Reco->getBinContent(i));
-      }else if(mMETDeltaPhi_GenMETTrue_MiniAOD->getBinContent(i)!=0){
-	mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPFPhotonEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPFPhotonEtFraction_Reco->getBinContent(i)!=0){
-	mPFPhotonEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFPhotonEtFraction_MiniAOD->getBinContent(i)/mPFPhotonEtFraction_Reco->getBinContent(i));
-      }else if(mPFPhotonEtFraction_MiniAOD->getBinContent(i)!=0){
-	mPFPhotonEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPFNeutralHadronEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPFNeutralHadronEtFraction_Reco->getBinContent(i)!=0){
-	mPFNeutralHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFNeutralHadronEtFraction_MiniAOD->getBinContent(i)/mPFNeutralHadronEtFraction_Reco->getBinContent(i));
-      }else if(mPFNeutralHadronEtFraction_MiniAOD->getBinContent(i)!=0){
-	mPFNeutralHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPFChargedHadronEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPFChargedHadronEtFraction_Reco->getBinContent(i)!=0){
-	mPFChargedHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFChargedHadronEtFraction_MiniAOD->getBinContent(i)/mPFChargedHadronEtFraction_Reco->getBinContent(i));
-      }else if(mPFChargedHadronEtFraction_MiniAOD->getBinContent(i)!=0){
-	mPFChargedHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPFHFHadronEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPFHFHadronEtFraction_Reco->getBinContent(i)!=0){
-	mPFHFHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFHFHadronEtFraction_MiniAOD->getBinContent(i)/mPFHFHadronEtFraction_Reco->getBinContent(i));
-      }else if(mPFHFHadronEtFraction_MiniAOD->getBinContent(i)!=0){
-	mPFHFHadronEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mPFHFEMEtFraction_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mPFHFEMEtFraction_Reco->getBinContent(i)!=0){
-	mPFHFEMEtFraction_MiniAOD_over_Reco->setBinContent(i,mPFHFEMEtFraction_MiniAOD->getBinContent(i)/mPFHFEMEtFraction_Reco->getBinContent(i));
-      }else if(mPFHFEMEtFraction_MiniAOD->getBinContent(i)!=0){
-	mPFHFEMEtFraction_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMETDifference_GenMETTrue_MET20to40_Reco->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MET20to40_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_MET20to40_Reco->getBinContent(i));
-      }else if(mMETDifference_GenMETTrue_MET20to40_MiniAOD->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMETDifference_GenMETTrue_MET100to150_Reco->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MET100to150_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_MET100to150_Reco->getBinContent(i));
-      }else if(mMETDifference_GenMETTrue_MET100to150_MiniAOD->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco->setBinContent(i,-0.5);
-      }
-    }
-    for(int i=0;i<=(mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco->getNbinsX()+1);i++){
-      if(mMETDifference_GenMETTrue_MET300to400_Reco->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco->setBinContent(i,mMETDifference_GenMETTrue_MET300to400_MiniAOD->getBinContent(i)/mMETDifference_GenMETTrue_MET300to400_Reco->getBinContent(i));
-      }else if(mMETDifference_GenMETTrue_MET300to400_MiniAOD->getBinContent(i)!=0){
-	mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco->setBinContent(i,-0.5);
+
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"MET" ,mMET_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METPhi" ,mMETPhi_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"SumET" ,mSumET_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METDifference_GenMETTrue"  ,mMETDifference_GenMETTrue_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METDeltaPhi_GenMETTrue" ,mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"photonEtFraction" ,mPFPhotonEtFraction_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"chargedHadronEtFraction" ,mPFChargedHadronEtFraction_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"neutralHadronEtFraction" ,mPFNeutralHadronEtFraction_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"HFHadronEtFraction" ,mPFHFHadronEtFraction_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"HFEMEtFraction" ,mPFHFEMEtFraction_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METResolution_GenMETTrue_MET20to40" ,mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METResolution_GenMETTrue_MET100to150" ,mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco));
+    map_of_MEs.insert(std::pair<std::string,MonitorElement*>(RunDir+"MiniAOD_over_RECO"+"/"+"METResolution_GenMETTrue_MET300to400" ,mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco));
+
+    for(unsigned int j=0;j<map_string_vec.size();j++){
+      MonitorElement* monReco=map_of_MEs[rundir_reco+"/"+map_string_vec[j]];if(monReco && monReco->getRootObject()){
+	MonitorElement* monMiniAOD=map_of_MEs[rundir_miniaod+"/"+map_string_vec[j]];if(monMiniAOD && monMiniAOD->getRootObject()){
+	  MonitorElement* monMiniAOD_over_RECO=map_of_MEs[RunDir+"MiniAOD_over_RECO"+"/"+map_string_vec[j]];if(monMiniAOD_over_RECO && monMiniAOD_over_RECO->getRootObject()){
+	    for(int i=0;i<=(monMiniAOD_over_RECO->getNbinsX()+1);i++){
+	      if(monReco->getBinContent(i)!=0){
+		monMiniAOD_over_RECO->setBinContent(i,monMiniAOD->getBinContent(i)/monReco->getBinContent(i));
+	      }else if (monMiniAOD->getBinContent(i)!=0){
+		monMiniAOD_over_RECO->setBinContent(i,-0.5);
+	      }
+	    }
+	  }
+	}
       }
     }
   }

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.h
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.h
@@ -1,0 +1,69 @@
+#ifndef METTESTERPOSTPROCESSOR_H
+#define METTESTERPOSTPROCESSOR_H
+
+// author: Matthias Weber, Feb 2015
+
+// system include files
+#include <memory>
+#include <stdio.h>
+#include <math.h>
+#include <sstream>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "CommonTools/UtilAlgos/interface/TFileService.h"
+#include "DQMServices/Core/interface/DQMEDHarvester.h"
+//
+// class decleration
+//
+
+class METTesterPostProcessor : public DQMEDHarvester {
+   public:
+      explicit METTesterPostProcessor(const edm::ParameterSet&);
+      ~METTesterPostProcessor();
+
+   private:
+      virtual void dqmEndJob(DQMStore::IBooker &, DQMStore::IGetter &) ;
+
+      edm::InputTag inputMETLabelRECO_;
+      edm::InputTag inputMETLabelMiniAOD_;
+
+      std::vector<std::string> met_dirs;
+      void FillMETRes(std::string metdir,DQMStore::IGetter &);
+      MonitorElement* mMETDifference_GenMETTrue_MET0to20;
+      MonitorElement* mMETDifference_GenMETTrue_MET20to40;
+      MonitorElement* mMETDifference_GenMETTrue_MET40to60;
+      MonitorElement* mMETDifference_GenMETTrue_MET60to80;
+      MonitorElement* mMETDifference_GenMETTrue_MET80to100;
+      MonitorElement* mMETDifference_GenMETTrue_MET100to150;
+      MonitorElement* mMETDifference_GenMETTrue_MET150to200;
+      MonitorElement* mMETDifference_GenMETTrue_MET200to300;
+      MonitorElement* mMETDifference_GenMETTrue_MET300to400;
+      MonitorElement* mMETDifference_GenMETTrue_MET400to500;
+      MonitorElement* mMETDifference_GenMETTrue_METResolution; 
+
+      MonitorElement* mMET_MiniAOD_over_Reco;
+      MonitorElement* mMETPhi_MiniAOD_over_Reco;
+      MonitorElement* mSumET_MiniAOD_over_Reco;
+      MonitorElement* mPFPhotonEtFraction_MiniAOD_over_Reco;
+      MonitorElement* mPFNeutralHadronEtFraction_MiniAOD_over_Reco;
+      MonitorElement* mPFChargedHadronEtFraction_MiniAOD_over_Reco;
+      MonitorElement* mPFHFHadronEtFraction_MiniAOD_over_Reco;
+      MonitorElement* mPFHFEMEtFraction_MiniAOD_over_Reco;
+      MonitorElement* mMETDifference_GenMETTrue_MiniAOD_over_Reco;
+      MonitorElement* mMETDeltaPhi_GenMETTrue_MiniAOD_over_Reco;
+      MonitorElement* mMETDifference_GenMETTrue_MET20to40_MiniAOD_over_Reco;
+      MonitorElement* mMETDifference_GenMETTrue_MET100to150_MiniAOD_over_Reco;
+      MonitorElement* mMETDifference_GenMETTrue_MET300to400_MiniAOD_over_Reco;
+
+};
+
+#endif

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.h
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.h
@@ -37,6 +37,10 @@ class METTesterPostProcessor : public DQMEDHarvester {
       edm::InputTag inputMETLabelMiniAOD_;
 
       std::vector<std::string> met_dirs;
+      std::vector<std::string> map_string_vec;
+      std::map< std::string, MonitorElement*> map_of_MEs;
+
+
       void FillMETRes(std::string metdir,DQMStore::IGetter &);
       MonitorElement* mMETDifference_GenMETTrue_MET0to20;
       MonitorElement* mMETDifference_GenMETTrue_MET20to40;

--- a/Validation/RecoMET/plugins/METTesterPostProcessor.h
+++ b/Validation/RecoMET/plugins/METTesterPostProcessor.h
@@ -37,9 +37,6 @@ class METTesterPostProcessor : public DQMEDHarvester {
       edm::InputTag inputMETLabelMiniAOD_;
 
       std::vector<std::string> met_dirs;
-      std::vector<std::string> map_string_vec;
-      std::map< std::string, MonitorElement*> map_of_MEs;
-
 
       void FillMETRes(std::string metdir,DQMStore::IGetter &);
       MonitorElement* mMETDifference_GenMETTrue_MET0to20;

--- a/Validation/RecoMET/plugins/SealModule.cc
+++ b/Validation/RecoMET/plugins/SealModule.cc
@@ -1,7 +1,9 @@
 #include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "METTester.h"
+#include "METTesterPostProcessor.h"
 
 DEFINE_FWK_MODULE (METTester) ;
+DEFINE_FWK_MODULE (METTesterPostProcessor) ;
 
 

--- a/Validation/RecoMET/python/METPostProcessor_cff.py
+++ b/Validation/RecoMET/python/METPostProcessor_cff.py
@@ -1,0 +1,4 @@
+import FWCore.ParameterSet.Config as cms
+
+from Validation.RecoMET.METPostProcessor_cfi import *
+METPostProcessor = cms.Sequence(METPostprocessing)

--- a/Validation/RecoMET/python/METPostProcessor_cfi.py
+++ b/Validation/RecoMET/python/METPostProcessor_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+################# Postprocessing #########################
+METPostprocessing = cms.EDAnalyzer('METTesterPostProcessor',
+                    METTypeRECO = cms.InputTag("pfMetT1"),
+                    METTypeMiniAOD = cms.InputTag("slimmedMETs")
+                   )  

--- a/Validation/RecoMET/test/sequence_validation_cfg.py
+++ b/Validation/RecoMET/test/sequence_validation_cfg.py
@@ -3,9 +3,8 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("METVALIDATION")
 
-process.load("Configuration.StandardSequences.GeometryDB_cff")
-#process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
-#process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
+from Configuration.StandardSequences.GeometryRecoDB_cff import *
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
 process.load("Configuration/StandardSequences/MagneticField_cff")
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
@@ -13,7 +12,7 @@ process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 #process.GlobalTag.globaltag = 'START42_V17::All'
 ##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
 ## for 6_2_0 QCD
-process.GlobalTag.globaltag = 'PRE_LS172_V16::All'
+process.GlobalTag.globaltag = 'GR_R_74_V0A::All'
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
@@ -23,6 +22,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 #
 
 process.load("Validation.RecoMET.METRelValForDQM_cff")
+process.load("Validation.RecoMET.METPostProcessor_cff")
 
 
 readFiles = cms.untracked.vstring()
@@ -49,14 +49,15 @@ process.dqmSaver.referenceHandling = cms.untracked.string('all')
 cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/JetMET/'+str(cmssw_version)+'/METValidation'
 process.dqmSaver.workflow = Workflow
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
 
 process.p = cms.Path(#for RECO
                      process.metPreValidSeq*
-                     process.METValidation
+                     process.METValidation*
                      #for MiniAOD
-                     #process.METValidationMiniAOD
+                     #process.METValidationMiniAOD*
+                     process.METPostProcessor
                      *process.dqmSaver
 )
 

--- a/Validation/RecoMET/test/sequence_validation_cfg.py
+++ b/Validation/RecoMET/test/sequence_validation_cfg.py
@@ -12,7 +12,7 @@ process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
 #process.GlobalTag.globaltag = 'START42_V17::All'
 ##process.GlobalTag.globaltag = 'MC_38Y_V14::All'
 ## for 6_2_0 QCD
-process.GlobalTag.globaltag = 'GR_R_74_V0A::All'
+process.GlobalTag.globaltag = 'MCRUN2_74_V7::All'
 
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.FwkReport.reportEvery = 1000
@@ -30,17 +30,13 @@ secFiles = cms.untracked.vstring()
 process.source = cms.Source ("PoolSource",fileNames = readFiles, secondaryFileNames = secFiles)
 readFiles.extend( [
        #for RECO
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/22A79853-D85E-E411-BAA9-02163E00C055.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/28923A16-C95E-E411-871C-02163E00FFCE.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/307F76E6-E05E-E411-90AF-02163E00B036.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/4E03E1A5-CE5E-E411-AE0F-02163E008BE3.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/689DCC5B-D35E-E411-A720-02163E00D13A.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/CC3F6060-DA5E-E411-BA7C-02163E0105B8.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/D470466A-C55E-E411-A382-02163E00EB5D.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/E2A34427-E75E-E411-ABBA-02163E008DD3.root',
-        '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V16-v1/00000/FCE96BE5-F15E-E411-BD38-02163E00D13A.root'
-        #for MINIAODtests 
-        #'/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/MINIAODSIM/PU50ns_PRE_LS172_V16-v1/00000/9886ACB4-F45E-E411-9E5D-02163E00F01E.root' 
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/48E3FDFE-3DBD-E411-9B99-0025905A613C.root',
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/706A960F-54BD-E411-8561-00261894384F.root',
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/E4EF6410-54BD-E411-8838-002590593920.root',
+       '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/FA18AB00-3EBD-E411-AAE8-0025905A608A.root'
+       #for MINIAODtests 
+       #'/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/MINIAODSIM/MCRUN2_74_V7-v1/00000/C265418B-58BD-E411-8167-0025905A6056.root',
+       #'/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/MINIAODSIM/MCRUN2_74_V7-v1/00000/C4BE1C8C-58BD-E411-9D78-0025905A60EE.root' 
 ] );
 
 process.load('Configuration/StandardSequences/EDMtoMEAtJobEnd_cff')
@@ -49,7 +45,7 @@ process.dqmSaver.referenceHandling = cms.untracked.string('all')
 cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
 Workflow = '/JetMET/'+str(cmssw_version)+'/METValidation'
 process.dqmSaver.workflow = Workflow
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(1001) )
 
 
 process.p = cms.Path(#for RECO


### PR DESCRIPTION
Add Validation PostProcessor modules for MET and JET in order to compare RECO and MINIAOD validation output histograms. Add Jet and MET MiniAOD validation sequences into global MiniAOD validation sequence, add PostProcessor sequence for comparing MiniAOD and RECO.

Add METPostProcessor into default Validation Harvesting sequence. Calculation of GenMET vs RECOMET overview histogram now performed correctly at the end of each run.
