### PR TITLE
Add Tracker Parameters to Tests and Writers

### DIFF
--- a/CondTools/Geometry/test/calogeometrywriter.py
+++ b/CondTools/Geometry/test/calogeometrywriter.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CaloGeometryWriter")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load('Configuration/StandardSequences/GeometryExtended_cff')
-process.load('Geometry/CaloEventSetup/CaloGeometryDBWriter_cfi')
+process.load('CondCore.DBCommon.CondDBCommon_cfi')
+process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Geometry.CaloEventSetup.CaloGeometryDBWriter_cfi')
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
                             timetype = cms.string('runnumber'),
@@ -33,4 +33,3 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.p1 = cms.Path(process.CaloGeometryWriter)
-

--- a/CondTools/Geometry/test/cscgeometrywriter.py
+++ b/CondTools/Geometry/test/cscgeometrywriter.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("CSCGeometryWriter")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load('Configuration/StandardSequences/GeometryExtended_cff')
-
+process.load('CondCore.DBCommon.CondDBCommon_cfi')
+process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -11,7 +11,6 @@ process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),
                             interval = cms.uint64(1)
                             )
-
 
 process.CSCGeometryWriter = cms.EDAnalyzer("CSCRecoIdealDBLoader")
 
@@ -29,4 +28,3 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.p1 = cms.Path(process.CSCGeometryWriter)
-

--- a/CondTools/Geometry/test/dtgeometrywriter.py
+++ b/CondTools/Geometry/test/dtgeometrywriter.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("DTGeometryWriter")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load('Configuration/StandardSequences/GeometryExtended_cff')
-
+process.load('CondCore.DBCommon.CondDBCommon_cfi')
+process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -11,7 +11,6 @@ process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),
                             interval = cms.uint64(1)
                             )
-
 
 process.DTGeometryWriter = cms.EDAnalyzer("DTRecoIdealDBLoader")
 
@@ -29,4 +28,3 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.p1 = cms.Path(process.DTGeometryWriter)
-

--- a/CondTools/Geometry/test/geometrytest_db.py
+++ b/CondTools/Geometry/test/geometrytest_db.py
@@ -1,10 +1,11 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.AlCa.autoCond import autoCond
 
 process = cms.Process("GeometryWriter")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load('Configuration/StandardSequences/GeometryDB_cff')
-
+process.load('CondCore.DBCommon.CondDBCommon_cfi')
+process.load('Configuration.StandardSequences.GeometryDB_cff')
 process.load('Configuration/StandardSequences/FrontierConditions_GlobalTag_cff')
+process.GlobalTag.globaltag = autoCond['run1_mc']
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -26,11 +27,9 @@ process.GeometryTester = cms.EDAnalyzer("GeometryTester",
                                         RPCTest = cms.untracked.bool(True),
                                         geomLabel = cms.untracked.string("Extended")
                                         )
- 
- 
+
 process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
 process.p1 = cms.Path(process.GeometryTester)
-

--- a/CondTools/Geometry/test/geometrytest_local.py
+++ b/CondTools/Geometry/test/geometrytest_local.py
@@ -1,4 +1,5 @@
 import FWCore.ParameterSet.Config as cms
+from Configuration.AlCa.autoCond import autoCond
 
 process = cms.Process("GeometryTest")
 
@@ -9,10 +10,9 @@ process.source = cms.Source("EmptyIOVSource",
                             interval = cms.uint64(1)
                             )
 
-process.load("Configuration/StandardSequences/FrontierConditions_GlobalTag_cff")
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.GlobalTag.globaltag = autoCond['run1_mc']
 
-#process.GlobalTag.DumpStat=cms.untracked.bool(True)
-#process.GlobalTag.DBParameters.messageLevel = 3
 process.GlobalTag.toGet = cms.VPSet(
     cms.PSet(record = cms.string("PCastorRcd"),
              tag = cms.string("CASTORRECO_Geometry_TagXX"),
@@ -42,16 +42,6 @@ process.GlobalTag.toGet = cms.VPSet(
              tag = cms.string("EBRECO_Geometry_TagXX"),
              connect = cms.untracked.string("sqlite_file:myfile.db")
              ),
-#    cms.PSet(record = cms.string("GeometryFileRcd"),
-#             tag = cms.string("XMLFILE_Geometry_IdealGFlash_TagXX"),
-#             connect = cms.untracked.string("sqlite_file:myfile.db"),
-#             label = cms.untracked.string("IdealGFlash")
-#             ),
-#    cms.PSet(record = cms.string("GeometryFileRcd"),
-#             tag = cms.string("XMLFILE_Geometry_Ideal_TagXX"),
-#             connect = cms.untracked.string("sqlite_file:myfile.db"),
-#             label = cms.untracked.string("Ideal")
-#             ),
     cms.PSet(record = cms.string("RPCRecoGeometryRcd"),
              tag = cms.string("RPCRECO_Geometry_TagXX"),
              connect = cms.untracked.string("sqlite_file:myfile.db")
@@ -64,11 +54,6 @@ process.GlobalTag.toGet = cms.VPSet(
              tag = cms.string("EPRECO_Geometry_TagXX"),
              connect = cms.untracked.string("sqlite_file:myfile.db")
              ),
-#    cms.PSet(record = cms.string("GeometryFileRcd"),
-#             tag = cms.string("XMLFILE_Geometry_ExtendedGFlash_TagXX"),
-#             connect = cms.untracked.string("sqlite_file:myfile.db"),
-#             label = cms.untracked.string("ExtendedGFlash")
-#             ),
     cms.PSet(record = cms.string("GeometryFileRcd"),
              tag = cms.string("XMLFILE_Geometry_Extended_TagXX"),
              connect = cms.untracked.string("sqlite_file:myfile.db"),
@@ -81,6 +66,10 @@ process.GlobalTag.toGet = cms.VPSet(
              ),
     cms.PSet(record = cms.string("IdealGeometryRecord"),
              tag = cms.string("TKRECO_Geometry_TagXX"),
+             connect = cms.untracked.string("sqlite_file:myfile.db")
+             ),
+    cms.PSet(record = cms.string('PTrackerParametersRcd'),
+             tag = cms.string('TKParameters_Geometry_TagXX'),
              connect = cms.untracked.string("sqlite_file:myfile.db")
              ),
     cms.PSet(record = cms.string("PHcalRcd"),
@@ -114,14 +103,7 @@ process.GlobalTag.toGet = cms.VPSet(
 #                                      )
 
 process.MessageLogger = cms.Service("MessageLogger")
-#014
-#015 process.WhatsItESProducer = cms.ESProducer("WhatsItESProducer")
-#016
-#017 process.DoodadESSource = cms.ESSource("DoodadESSource")
-#018
 process.demo = cms.EDAnalyzer("PrintEventSetupContent")
-#020
-#021 process.p = cms.Path(process.demo)
 
 process.GeometryTester = cms.EDAnalyzer("GeometryTester",
                                         XMLTest = cms.untracked.bool(True),

--- a/CondTools/Geometry/test/geometrywriter.py
+++ b/CondTools/Geometry/test/geometrywriter.py
@@ -23,6 +23,7 @@ process.TrackerGeometricDetExtraESModule = cms.ESProducer( "TrackerGeometricDetE
 
 process.TrackerGeometryWriter = cms.EDAnalyzer("PGeometricDetBuilder")
 process.TrackerGeometryExtraWriter = cms.EDAnalyzer("PGeometricDetExtraBuilder")
+process.TrackerParametersWriter = cms.EDAnalyzer("PTrackerParametersDBBuilder")
 
 process.CaloGeometryWriter = cms.EDAnalyzer("PCaloGeometryBuilder")
 
@@ -40,6 +41,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),tag = cms.string('XMLFILE_Geometry_Extended_TagXX')),
                                                             cms.PSet(record = cms.string('IdealGeometryRecord'),tag = cms.string('TKRECO_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PGeometricDetExtraRcd'),tag = cms.string('TKExtra_Geometry_TagXX')),
+                                                            cms.PSet(record = cms.string('PTrackerParametersRcd'),tag = cms.string('TKParameters_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PEcalBarrelRcd'),   tag = cms.string('EBRECO_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PEcalEndcapRcd'),   tag = cms.string('EERECO_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PEcalPreshowerRcd'),tag = cms.string('EPRECO_Geometry_TagXX')),
@@ -58,5 +60,5 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerGeometryExtraWriter+process.CaloGeometryWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter)
+process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerGeometryExtraWriter+process.TrackerParametersWriter+process.CaloGeometryWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter)
 

--- a/CondTools/Geometry/test/geometryxmlwriter.py
+++ b/CondTools/Geometry/test/geometryxmlwriter.py
@@ -1,7 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("GeometryXMLWriter")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
 process.load('Configuration.Geometry.GeometryExtended_cff')
 
 process.source = cms.Source("EmptyIOVSource",
@@ -13,7 +12,7 @@ process.source = cms.Source("EmptyIOVSource",
 
 process.BigXMLWriter = cms.EDAnalyzer("OutputDDToDDL",
                               rotNumSeed = cms.int32(0),
-                              fileName = cms.untracked.string("fred.xml")
+                              fileName = cms.untracked.string("geTagXX.xml")
                               )
 
 
@@ -22,4 +21,3 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.p1 = cms.Path(process.BigXMLWriter)
-

--- a/CondTools/Geometry/test/rpcgeometrywriter.py
+++ b/CondTools/Geometry/test/rpcgeometrywriter.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("RPCGeometryWriter")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load('Configuration/StandardSequences/GeometryExtended_cff')
-
+process.load('CondCore.DBCommon.CondDBCommon_cfi')
+process.load('Configuration.StandardSequences.GeometryExtended_cff')
+process.load('Geometry.MuonNumbering.muonNumberingInitialization_cfi')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -11,7 +11,6 @@ process.source = cms.Source("EmptyIOVSource",
                             firstValue = cms.uint64(1),
                             interval = cms.uint64(1)
                             )
-
 
 process.RPCGeometryWriter = cms.EDAnalyzer("RPCRecoIdealDBLoader")
 
@@ -29,4 +28,3 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.p1 = cms.Path(process.RPCGeometryWriter)
-

--- a/CondTools/Geometry/test/trackergeometrywriter.py
+++ b/CondTools/Geometry/test/trackergeometrywriter.py
@@ -1,12 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TrackerGeometryWriter")
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
-process.load("Configuration.Geometry.GeometryExtended_cff")
+process.load('CondCore.DBCommon.CondDBCommon_cfi')
+process.load('Configuration.Geometry.GeometryExtended_cff')
 
-index = process.XMLIdealGeometryESSource.geomXMLFiles.index('Geometry/TrackerCommonData/data/pixfwdMaterials.xml')
-process.XMLIdealGeometryESSource.geomXMLFiles.insert(index, 'Geometry/TrackerCommonData/data/trackerParameters.xml')
-    
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
                             timetype = cms.string('runnumber'),
@@ -27,9 +24,9 @@ process.CondDBCommon.timetype = cms.untracked.string('runnumber')
 process.CondDBCommon.connect = cms.string('sqlite_file:myfile.db')
 process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           process.CondDBCommon,
-                                          toPut = cms.VPSet(cms.PSet(record = cms.string('IdealGeometryRecord'),tag = cms.string('TKRECO_Geometry_Test02')),
-                                                            cms.PSet(record = cms.string('PGeometricDetExtraRcd'),tag = cms.string('TKExtra_Geometry_Test02')),
-                                                            cms.PSet(record = cms.string('PTrackerParametersRcd'),tag = cms.string('TK_Parameters_Test02'))
+                                          toPut = cms.VPSet(cms.PSet(record = cms.string('IdealGeometryRecord'),tag = cms.string('TKRECO_Geometry_Test01')),
+                                                            cms.PSet(record = cms.string('PGeometricDetExtraRcd'),tag = cms.string('TKExtra_Geometry_Test01')),
+                                                            cms.PSet(record = cms.string('PTrackerParametersRcd'),tag = cms.string('TKParameters_Geometry_Test01'))
                                                             )
                                           )
 
@@ -38,4 +35,3 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.p1 = cms.Path(process.TrackerGeometryWriter*process.TrackerGeometryExtraWriter*process.TrackerParametersWriter)
-

--- a/CondTools/Geometry/test/writehelpers/geometrywriter.py
+++ b/CondTools/Geometry/test/writehelpers/geometrywriter.py
@@ -32,6 +32,7 @@ process.TrackerGeometricDetExtraESModule = cms.ESProducer( "TrackerGeometricDetE
 
 process.TrackerGeometryWriter = cms.EDAnalyzer("PGeometricDetBuilder")
 process.TrackerGeometryExtraWriter = cms.EDAnalyzer("PGeometricDetExtraBuilder")
+process.TrackerParametersWriter = cms.EDAnalyzer("PTrackerParametersDBBuilder")
 
 process.CaloGeometryWriter = cms.EDAnalyzer("PCaloGeometryBuilder")
 
@@ -49,6 +50,7 @@ process.PoolDBOutputService = cms.Service("PoolDBOutputService",
                                           toPut = cms.VPSet(cms.PSet(record = cms.string('GeometryFileRcd'),tag = cms.string('XMLFILE_Geometry_TagXX_Extended2015_mc')),
                                                             cms.PSet(record = cms.string('IdealGeometryRecord'),tag = cms.string('TKRECO_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PGeometricDetExtraRcd'),tag = cms.string('TKExtra_Geometry_TagXX')),
+                                                            cms.PSet(record = cms.string('PTrackerParametersRcd'),tag = cms.string('TKParameters_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PEcalBarrelRcd'),   tag = cms.string('EBRECO_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PEcalEndcapRcd'),   tag = cms.string('EERECO_Geometry_TagXX')),
                                                             cms.PSet(record = cms.string('PEcalPreshowerRcd'),tag = cms.string('EPRECO_Geometry_TagXX')),
@@ -67,4 +69,4 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1)
     )
 
-process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerGeometryExtraWriter+process.CaloGeometryWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter)
+process.p1 = cms.Path(process.XMLGeometryWriter+process.TrackerGeometryWriter+process.TrackerGeometryExtraWriter+process.TrackerParametersWriter+process.CaloGeometryWriter+process.CSCGeometryWriter+process.DTGeometryWriter+process.RPCGeometryWriter)

--- a/CondTools/Geometry/test/writehelpers/splitDatabase.sh
+++ b/CondTools/Geometry/test/writehelpers/splitDatabase.sh
@@ -4,6 +4,7 @@ cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:GeometryFileExtended2
 cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:GeometryFileIdeal2015.db -D CondFormatsGeometryObjects  -t XMLFILE_Geometry_TagXX_Ideal2015_mc -l sqlite_file:localpopconlog.db
 cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:TKRECO_Geometry.db -D CondFormatsGeometryObjects  -t TKRECO_Geometry_TagXX -l sqlite_file:localpopconlog.db
 cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:TKExtra_Geometry.db -D CondFormatsGeometryObjects  -t TKExtra_Geometry_TagXX -l sqlite_file:localpopconlog.db
+cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:TKParameters_Geometry.db -D CondFormatsGeometryObjects  -t TKParameters_Geometry_TagXX -l sqlite_file:localpopconlog.db
 cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:EBRECO_Geometry.db -D CondFormatsGeometryObjects  -t EBRECO_Geometry_TagXX -l sqlite_file:localpopconlog.db
 cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:EERECO_Geometry.db -D CondFormatsGeometryObjects  -t EERECO_Geometry_TagXX -l sqlite_file:localpopconlog.db
 cmscond_export_iov -s sqlite_file:myfile.db -d sqlite_file:EPRECO_Geometry.db -D CondFormatsGeometryObjects  -t EPRECO_Geometry_TagXX -l sqlite_file:localpopconlog.db

--- a/CondTools/Geometry/test/xmlgeometrywriter.py
+++ b/CondTools/Geometry/test/xmlgeometrywriter.py
@@ -1,9 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("XMLGeometryWriter")
-# empty input service, fire 10 events
-#    include "FWCore/MessageLogger/data/MessageLogger.cfi"
-process.load("CondCore.DBCommon.CondDBCommon_cfi")
+process.load('CondCore.DBCommon.CondDBCommon_cfi')
 
 process.source = cms.Source("EmptyIOVSource",
                             lastValue = cms.uint64(1),
@@ -30,4 +28,3 @@ process.maxEvents = cms.untracked.PSet(
     )
 
 process.p1 = cms.Path(process.XMLGeometryWriter)
-


### PR DESCRIPTION
- Add new Tracker parameter record to the tests and writers.
- Add missing Muon Numbering producer.
- Use Auto conditions.
- Cleanup configurations.
