### PR TITLE
Update HCAL Packing/Unpacking

### DIFF
--- a/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
@@ -582,6 +582,7 @@ void HcalDigiMonitor::analyze(edm::Event const&e, edm::EventSetup const&s)
       dccHeader->getSpigotData(spigot, htr, fed.size()); 
       
       int NTS = htr.getNDD(); //number time slices, in precision channels
+      if (NTS==0) continue; // no DAQ data in this HTR (fully zero-suppressed)
       int dccid=dccHeader->getSourceId();
       
       if(dccid==720 && (spigot==12 || spigot==13)) continue; // calibration HTR

--- a/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
@@ -23,6 +23,9 @@ public:
   /** \brief Constructor from signed ieta, iphi, depth
   */
   HcalTrigTowerDetId(int ieta, int iphi, int depth);
+  /** \brief Constructor from signed ieta, iphi, depth, version
+  */
+  HcalTrigTowerDetId(int ieta, int iphi, int depth, int version);
 
   /** Constructor from a generic cell id */
   HcalTrigTowerDetId(const DetId& id);

--- a/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
+++ b/DataFormats/HcalDetId/interface/HcalTrigTowerDetId.h
@@ -29,6 +29,8 @@ public:
   /** Assignment from a generic cell id */
   HcalTrigTowerDetId& operator=(const DetId& id);
 
+  void setVersion(int version);
+
   /// get the subdetector
   HcalSubdetector subdet() const { return (HcalSubdetector)(subdetId()); }
   /// get the z-side of the tower (1/-1)
@@ -39,8 +41,10 @@ public:
   int ieta() const { return zside()*ietaAbs(); }
   /// get the tower iphi
   int iphi() const { return id_&0x7F; }
-  /// get the depth (zero for LHC, may be nonzero for SuperCMS)
+  /// get the depth (zero for LHC Run 1, may be nonzero for later runs)
   int depth() const { return (id_>>14)&0x7; }
+  /// get the version code for the trigger tower
+  int version() const { return (id_>>17)&0x7; }
 
   static const HcalTrigTowerDetId Undefined;
 

--- a/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
@@ -28,6 +28,10 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(const DetId& gen) {
   id_=gen.rawId();
 }
 
+void HcalTrigTowerDetId::setVersion(int version) {
+  id_|=((version&0x7)<<17);
+}
+
 HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
   if (!gen.null() && (gen.det()!=Hcal || gen.subdetId()!=HcalTriggerTower)) {
     throw cms::Exception("Invalid DetId") << "Cannot assign HcalTrigTowerDetId from " << std::hex << gen.rawId() << std::dec; 
@@ -37,7 +41,7 @@ HcalTrigTowerDetId& HcalTrigTowerDetId::operator=(const DetId& gen) {
 }
 
 std::ostream& operator<<(std::ostream& s,const HcalTrigTowerDetId& id) {
-  s << "(HcalTrigTower " << id.ieta() << ',' << id.iphi();
+  s << "(HcalTrigTower v" << id.version() << ": " << id.ieta() << ',' << id.iphi();
   if (id.depth()>0) s << ',' << id.depth();
   
   return s << ')';

--- a/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
+++ b/DataFormats/HcalDetId/src/HcalTrigTowerDetId.cc
@@ -21,6 +21,13 @@ HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth) : DetId(Hc
     (iphi&0x7F);
 }
 
+HcalTrigTowerDetId::HcalTrigTowerDetId(int ieta, int iphi, int depth, int version) : DetId(Hcal,HcalTriggerTower) {
+  id_|=((depth&0x7)<<14) |
+    ((ieta>0)?(0x2000|(ieta<<7)):((-ieta)<<7)) |
+    (iphi&0x7F);
+  id_|=((version&0x7)<<17);
+}
+ 
 HcalTrigTowerDetId::HcalTrigTowerDetId(const DetId& gen) {
   if (!gen.null() && (gen.det()!=Hcal || gen.subdetId()!=HcalTriggerTower)) {
     throw cms::Exception("Invalid DetId") << "Cannot initialize HcalTrigTowerDetId from " << std::hex << gen.rawId() << std::dec; 

--- a/DataFormats/HcalDigi/interface/HcalDigiCollections.h
+++ b/DataFormats/HcalDigi/interface/HcalDigiCollections.h
@@ -42,8 +42,11 @@ public:
   int size() const { return int(edm::DataFrameContainer::size()); }
   Digi operator[](size_type i) const { return Digi(edm::DataFrameContainer::operator[](i));}
   void addDataFrame(DetId detid, const uint16_t* data) { push_back(detid.rawId(),data); }
+  int samples() const { return int((stride()-Digi::HEADER_WORDS)/Digi::WORDS_PER_SAMPLE); }
+  void sort() { edm::DataFrameContainer::sort(); }
 };
 
 typedef HcalDataFrameContainer<QIE10DataFrame> QIE10DigiCollection;
+
 
 #endif

--- a/DataFormats/HcalDigi/interface/HcalDigiCollections.h
+++ b/DataFormats/HcalDigi/interface/HcalDigiCollections.h
@@ -16,6 +16,7 @@
 #include "DataFormats/HcalDigi/interface/HcalTTPDigi.h"
 
 #include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
 
 typedef edm::SortedCollection<HBHEDataFrame> HBHEDigiCollection;
 typedef edm::SortedCollection<HODataFrame> HODigiCollection;
@@ -47,6 +48,7 @@ public:
 };
 
 typedef HcalDataFrameContainer<QIE10DataFrame> QIE10DigiCollection;
+typedef HcalDataFrameContainer<QIE11DataFrame> QIE11DigiCollection;
 
 
 #endif

--- a/DataFormats/HcalDigi/interface/HcalDigiCollections.h
+++ b/DataFormats/HcalDigi/interface/HcalDigiCollections.h
@@ -37,7 +37,7 @@ template <class Digi>
 class HcalDataFrameContainer : protected edm::DataFrameContainer {
 public:
   HcalDataFrameContainer() { }
-  HcalDataFrameContainer(int nsamples_per_digi) { }
+  HcalDataFrameContainer(int nsamples_per_digi) : edm::DataFrameContainer(nsamples_per_digi*Digi::WORDS_PER_SAMPLE+Digi::HEADER_WORDS) { }
 
   int size() const { return int(edm::DataFrameContainer::size()); }
   Digi operator[](size_type i) const { return Digi(edm::DataFrameContainer::operator[](i));}

--- a/DataFormats/HcalDigi/interface/HcalDigiCollections.h
+++ b/DataFormats/HcalDigi/interface/HcalDigiCollections.h
@@ -15,6 +15,8 @@
 #include "DataFormats/HcalDigi/interface/HOTriggerPrimitiveDigi.h"
 #include "DataFormats/HcalDigi/interface/HcalTTPDigi.h"
 
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+
 typedef edm::SortedCollection<HBHEDataFrame> HBHEDigiCollection;
 typedef edm::SortedCollection<HODataFrame> HODigiCollection;
 typedef edm::SortedCollection<HFDataFrame> HFDigiCollection;
@@ -28,5 +30,20 @@ typedef edm::SortedCollection<CastorDataFrame> CastorDigiCollection;
 typedef edm::SortedCollection<CastorTriggerPrimitiveDigi> CastorTrigPrimDigiCollection;
 typedef edm::SortedCollection<HOTriggerPrimitiveDigi> HOTrigPrimDigiCollection;
 typedef edm::SortedCollection<HcalTTPDigi> HcalTTPDigiCollection;
+
+#include "DataFormats/Common/interface/DataFrameContainer.h"
+
+template <class Digi>
+class HcalDataFrameContainer : protected edm::DataFrameContainer {
+public:
+  HcalDataFrameContainer() { }
+  HcalDataFrameContainer(int nsamples_per_digi) { }
+
+  int size() const { return int(edm::DataFrameContainer::size()); }
+  Digi operator[](size_type i) const { return Digi(edm::DataFrameContainer::operator[](i));}
+  void addDataFrame(DetId detid, const uint16_t* data) { push_back(detid.rawId(),data); }
+};
+
+typedef HcalDataFrameContainer<QIE10DataFrame> QIE10DigiCollection;
 
 #endif

--- a/DataFormats/HcalDigi/interface/QIE10DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE10DataFrame.h
@@ -36,6 +36,8 @@ public:
   DetId detid() const { return DetId(id()); }
   /// total number of samples in the digi
   int samples() const { return (size()-1)/2; }
+  /// get the flavor of the frame
+  int flavor() const { return ((edm::DataFrame::operator[](0)>>12)&0x7); }
   /// was there a link error?
   bool linkError() const { return edm::DataFrame::operator[](0)&0x800; } 
   /// was this a mark-and-pass ZS event?  
@@ -44,7 +46,7 @@ public:
   inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(*this,i*2+1); }
   /// set the sample contents
   void setSample(edm::DataFrame::size_type isample, int adc, int le_tdc, int fe_tdc, int capid, bool soi=false, bool ok=true);
-
+  
 };
 
 std::ostream& operator<<(std::ostream&, const QIE10DataFrame&);

--- a/DataFormats/HcalDigi/interface/QIE10DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE10DataFrame.h
@@ -3,16 +3,20 @@
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/Common/interface/DataFrame.h"
+#include <ostream>
 
 /** Precision readout digi from QIE10 including TDC information
 
  */
-class QIE10DataFrame {
+class QIE10DataFrame : protected edm::DataFrame {
 public:
 
-  inline QIE10DataFrame() { }
-  inline QIE10DataFrame(const edm::DataFrameContainer& c, edm::DataFrame::size_type i) : frame_(c,i) { }
-  inline QIE10DataFrame(edm::DataFrame df) : frame_(df) { }
+  static const int WORDS_PER_SAMPLE = 2;
+  static const int HEADER_WORDS = 1;
+
+  QIE10DataFrame() { }
+  QIE10DataFrame(const edm::DataFrameContainer& c, edm::DataFrame::size_type i) : edm::DataFrame(c,i) { }
+  QIE10DataFrame(edm::DataFrame df) : edm::DataFrame(df) { }
 
   class Sample {
   public:
@@ -29,21 +33,21 @@ public:
   };
 
   /// Get the detector id
-  DetId detid() const { return DetId(frame_.id()); }
+  DetId detid() const { return DetId(id()); }
   /// total number of samples in the digi
-  int samples() const { return (frame_.size()-1)/2; }
+  int samples() const { return (size()-1)/2; }
   /// was there a link error?
-  bool linkError() const { return frame_[0]&0x800; } 
+  bool linkError() const { return edm::DataFrame::operator[](0)&0x800; } 
   /// was this a mark-and-pass ZS event?  
-  bool wasMarkAndPass() const {return frame_[0]&0x100; }
+  bool wasMarkAndPass() const {return edm::DataFrame::operator[](0)&0x100; }
   /// get the sample
-  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(frame_,i*2+1); }
+  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(*this,i*2+1); }
   /// set the sample contents
   void setSample(edm::DataFrame::size_type isample, int adc, int le_tdc, int fe_tdc, int capid, bool soi=false, bool ok=true);
 
-private:
-  edm::DataFrame frame_;
 };
+
+std::ostream& operator<<(std::ostream&, const QIE10DataFrame&);
 
 
 #endif // DATAFORMATS_HCALDIGI_QIE10DATAFRAME_H

--- a/DataFormats/HcalDigi/interface/QIE10DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE10DataFrame.h
@@ -1,0 +1,49 @@
+#ifndef DATAFORMATS_HCALDIGI_QIE10DATAFRAME_H
+#define DATAFORMATS_HCALDIGI_QIE10DATAFRAME_H
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/Common/interface/DataFrame.h"
+
+/** Precision readout digi from QIE10 including TDC information
+
+ */
+class QIE10DataFrame {
+public:
+
+  inline QIE10DataFrame() { }
+  inline QIE10DataFrame(const edm::DataFrameContainer& c, edm::DataFrame::size_type i) : frame_(c,i) { }
+  inline QIE10DataFrame(edm::DataFrame df) : frame_(df) { }
+
+  class Sample {
+  public:
+    Sample(const edm::DataFrame& frame, edm::DataFrame::size_type i) : frame_(frame),i_(i) { }
+    int adc() const { return frame_[i_]&0xFF; }
+    int le_tdc() const { return frame_[i_+1]&0x3F; }
+    int te_tdc() const { return (frame_[i_]>>6)&0x1F; }
+    bool ok() const { return frame_[i_]&0x1000; }
+    bool soi() const { return frame_[i_]&0x2000; }
+    int capid() const { return (frame_[i_+1]>>12)&0x3; }
+  private:
+    const edm::DataFrame& frame_;
+    edm::DataFrame::size_type i_;
+  };
+
+  /// Get the detector id
+  DetId detid() const { return DetId(frame_.id()); }
+  /// total number of samples in the digi
+  int samples() const { return (frame_.size()-1)/2; }
+  /// was there a link error?
+  bool linkError() const { return frame_[0]&0x800; } 
+  /// was this a mark-and-pass ZS event?  
+  bool wasMarkAndPass() const {return frame_[0]&0x100; }
+  /// get the sample
+  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(frame_,i*2+1); }
+  /// set the sample contents
+  void setSample(edm::DataFrame::size_type isample, int adc, int le_tdc, int fe_tdc, int capid, bool soi=false, bool ok=true);
+
+private:
+  edm::DataFrame frame_;
+};
+
+
+#endif // DATAFORMATS_HCALDIGI_QIE10DATAFRAME_H

--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -1,0 +1,56 @@
+#ifndef DATAFORMATS_HCALDIGI_QIE11DATAFRAME_H
+#define DATAFORMATS_HCALDIGI_QIE11DATAFRAME_H
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "DataFormats/Common/interface/DataFrame.h"
+#include <ostream>
+
+/** Precision readout digi from QIE11 including TDC information
+
+ */
+class QIE11DataFrame : protected edm::DataFrame {
+public:
+
+  static const int WORDS_PER_SAMPLE = 1;
+  static const int HEADER_WORDS = 1;
+
+  QIE11DataFrame() { }
+  QIE11DataFrame(const edm::DataFrameContainer& c, edm::DataFrame::size_type i) : edm::DataFrame(c,i) { }
+  QIE11DataFrame(edm::DataFrame df) : edm::DataFrame(df) { }
+
+  class Sample {
+  public:
+    Sample(const edm::DataFrame& frame, edm::DataFrame::size_type i) : frame_(frame),i_(i) { }
+    int adc() const { return frame_[i_]&0xFF; }
+    int tdc() const { return (frame_[i_]>>8)&0x3F; }
+    bool soi() const { return frame_[i_]&0x4000; }
+    int capid() const { return ((((frame_[0]>>8)&0x3)+i_)%3); }
+  private:
+    const edm::DataFrame& frame_;
+    edm::DataFrame::size_type i_;
+  };
+
+  /// Get the detector id
+  DetId detid() const { return DetId(id()); }
+  /// total number of samples in the digi
+  int samples() const { return (size()-1)/2; }
+  /// get the flavor of the frame
+  int flavor() const { return ((edm::DataFrame::operator[](0)>>12)&0x7); }
+  /// was there a link error?
+  bool linkError() const { return edm::DataFrame::operator[](0)&0x800; } 
+  /// was there a capid rotation error?
+  bool capidError() const { return edm::DataFrame::operator[](0)&0x400; } 
+  /// was this a mark-and-pass ZS event?  
+  bool wasMarkAndPass() const {return (flavor()==1); }
+  /// get the sample
+  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(*this,i+1); }
+  void setCapid0(int cap0);
+  /// set the sample contents
+  void setSample(edm::DataFrame::size_type isample, int adc, int tdc, bool soi=false);
+
+};
+
+std::ostream& operator<<(std::ostream&, const QIE11DataFrame&);
+
+
+#endif // DATAFORMATS_HCALDIGI_QIE11DATAFRAME_H

--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -24,7 +24,7 @@ public:
     int adc() const { return frame_[i_]&0xFF; }
     int tdc() const { return (frame_[i_]>>8)&0x3F; }
     bool soi() const { return frame_[i_]&0x4000; }
-    int capid() const { return ((((frame_[0]>>8)&0x3)+i_)%3); }
+    int capid() const { return ((((frame_[0]>>8)&0x3)+i_)%4); }
   private:
     const edm::DataFrame& frame_;
     edm::DataFrame::size_type i_;

--- a/DataFormats/HcalDigi/src/QIE10DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE10DataFrame.cc
@@ -1,0 +1,27 @@
+#include "DataFormats/HcalDigi/interface/QIE10DataFrame.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+
+void QIE10DataFrame::setSample(edm::DataFrame::size_type isample, int adc, int le_tdc, int fe_tdc, int capid, bool soi, bool ok) {
+  if (isample>=size()) return;
+  edm::DataFrame::operator[](isample*2+1)=(adc&0xFF)|(soi?(0x2000):(0))|(ok?(0x1000):(0));
+  edm::DataFrame::operator[](isample*2+2)=(le_tdc&0x3F)|((fe_tdc&0x1F)<<6)|((capid&0x3)<<12)|0x4000;
+}
+
+std::ostream& operator<<(std::ostream& s, const QIE10DataFrame& digi) {
+  if (digi.detid().det()==DetId::Hcal) {
+    s << HcalGenericDetId(digi.detid());
+  } else {
+    s << "DetId(" << digi.detid().rawId() << ")";    
+  }
+  s << " " << digi.samples() << " samples";
+  if (digi.linkError()) s << " LinkError ";
+  if (digi.wasMarkAndPass()) s << " MaP ";
+  s << std::endl;
+  for (int i=0; i<digi.samples(); i++) {
+    s << "  ADC=" << digi[i].adc() << " TDC(LE)=" << digi[i].le_tdc() << " TDC(TE)=" << digi[i].te_tdc() << " CAPID=" << digi[i].capid();
+    if (digi[i].soi()) s << " SOI ";
+    if (!digi[i].ok()) s << " !OK ";
+    s << std::endl;
+  }
+  return s;
+}

--- a/DataFormats/HcalDigi/src/QIE11DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE11DataFrame.cc
@@ -1,0 +1,31 @@
+#include "DataFormats/HcalDigi/interface/QIE11DataFrame.h"
+#include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
+
+void QIE11DataFrame::setCapid0(int cap0) {
+  edm::DataFrame::operator[](0)&=0xFCFF;
+  edm::DataFrame::operator[](0)|=((cap0&0x3)<<8);  
+}
+
+void QIE11DataFrame::setSample(edm::DataFrame::size_type isample, int adc, int tdc, bool soi) {
+  if (isample>=size()) return;
+  edm::DataFrame::operator[](isample+1)=(adc&0xFF)|(soi?(0x4000):(0))|((tdc&0x3F)<<8);
+}
+
+std::ostream& operator<<(std::ostream& s, const QIE11DataFrame& digi) {
+  if (digi.detid().det()==DetId::Hcal) {
+    s << HcalGenericDetId(digi.detid());
+  } else {
+    s << "DetId(" << digi.detid().rawId() << ")";    
+  }
+  s << " " << digi.samples() << " samples";
+  if (digi.linkError()) s << " LinkError ";
+  if (digi.capidError()) s << " CapIdError ";
+  if (digi.wasMarkAndPass()) s << " M&P ";
+  s << std::endl;
+  for (int i=0; i<digi.samples(); i++) {
+    s << "  ADC=" << digi[i].adc() << " TDC=" << digi[i].tdc() << " CAPID=" << digi[i].capid();
+    if (digi[i].soi()) s << " SOI ";
+    s << std::endl;
+  }
+  return s;
+}

--- a/DataFormats/HcalDigi/src/classes.h
+++ b/DataFormats/HcalDigi/src/classes.h
@@ -40,6 +40,7 @@ namespace DataFormats_HcalDigi {
     CastorTrigPrimDigiCollection theCastorTP_;
     HOTrigPrimDigiCollection theHOTP_;
     HcalTTPDigiCollection theTTP_;
+    QIE10DigiCollection theqie10_;
       
     edm::Wrapper<edm::SortedCollection<HBHEDataFrame> > anotherHBHE_;
     edm::Wrapper<edm::SortedCollection<HODataFrame> > anotherHO_;
@@ -66,6 +67,7 @@ namespace DataFormats_HcalDigi {
     edm::Wrapper<HcalTTPDigiCollection> theTTPw_;
     edm::Wrapper<HBHEUpgradeDigiCollection> theUHBHEw_;
     edm::Wrapper<HFUpgradeDigiCollection> theUHFw_;
+    edm::Wrapper<QIE10DigiCollection> theQIE10w_;
   };
 }
 

--- a/DataFormats/HcalDigi/src/classes.h
+++ b/DataFormats/HcalDigi/src/classes.h
@@ -41,6 +41,7 @@ namespace DataFormats_HcalDigi {
     HOTrigPrimDigiCollection theHOTP_;
     HcalTTPDigiCollection theTTP_;
     QIE10DigiCollection theqie10_;
+    QIE11DigiCollection theqie11_;
       
     edm::Wrapper<edm::SortedCollection<HBHEDataFrame> > anotherHBHE_;
     edm::Wrapper<edm::SortedCollection<HODataFrame> > anotherHO_;
@@ -68,6 +69,7 @@ namespace DataFormats_HcalDigi {
     edm::Wrapper<HBHEUpgradeDigiCollection> theUHBHEw_;
     edm::Wrapper<HFUpgradeDigiCollection> theUHFw_;
     edm::Wrapper<QIE10DigiCollection> theQIE10w_;
+    edm::Wrapper<QIE11DigiCollection> theQIE11w_;
   };
 }
 

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -73,6 +73,7 @@
    <class name="edm::SortedCollection<CastorTriggerPrimitiveDigi,edm::StrictWeakOrdering<CastorTriggerPrimitiveDigi> >"/>
    <class name="edm::SortedCollection<HcalTTPDigi,edm::StrictWeakOrdering<HcalTTPDigi> >"/>
    <class name="edm::SortedCollection<HcalUpgradeDataFrame,edm::StrictWeakOrdering<HcalUpgradeDataFrame> >"/>
+   <class name="HcalDataFrameContainer<QIE10DataFrame>"/>
 
    <class name="edm::Wrapper<edm::SortedCollection<HBHEDataFrame,edm::StrictWeakOrdering<HBHEDataFrame> > >" splitLevel="0" />
    <class name="edm::Wrapper<edm::SortedCollection<HODataFrame,edm::StrictWeakOrdering<HODataFrame> > >" splitLevel="0" />
@@ -86,6 +87,7 @@
    <class name="edm::Wrapper<edm::SortedCollection<CastorTriggerPrimitiveDigi,edm::StrictWeakOrdering<CastorTriggerPrimitiveDigi> > >" splitLevel="0" />
    <class name="edm::Wrapper<edm::SortedCollection<HcalTTPDigi,edm::StrictWeakOrdering<HcalTTPDigi> > >" splitLevel="0" />
    <class name="edm::Wrapper<edm::SortedCollection<HcalUpgradeDataFrame,edm::StrictWeakOrdering<HcalUpgradeDataFrame> > >" splitLevel="0" />
+   <class name="edm::Wrapper<HcalDataFrameContainer<QIE10DataFrame> >" splitLevel="0"/>
    <class name="edm::Wrapper<HcalUnpackerReport>"/>
    <class name="HcalLaserDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="2447500554"/>

--- a/DataFormats/HcalDigi/src/classes_def.xml
+++ b/DataFormats/HcalDigi/src/classes_def.xml
@@ -74,6 +74,7 @@
    <class name="edm::SortedCollection<HcalTTPDigi,edm::StrictWeakOrdering<HcalTTPDigi> >"/>
    <class name="edm::SortedCollection<HcalUpgradeDataFrame,edm::StrictWeakOrdering<HcalUpgradeDataFrame> >"/>
    <class name="HcalDataFrameContainer<QIE10DataFrame>"/>
+   <class name="HcalDataFrameContainer<QIE11DataFrame>"/>
 
    <class name="edm::Wrapper<edm::SortedCollection<HBHEDataFrame,edm::StrictWeakOrdering<HBHEDataFrame> > >" splitLevel="0" />
    <class name="edm::Wrapper<edm::SortedCollection<HODataFrame,edm::StrictWeakOrdering<HODataFrame> > >" splitLevel="0" />
@@ -88,6 +89,7 @@
    <class name="edm::Wrapper<edm::SortedCollection<HcalTTPDigi,edm::StrictWeakOrdering<HcalTTPDigi> > >" splitLevel="0" />
    <class name="edm::Wrapper<edm::SortedCollection<HcalUpgradeDataFrame,edm::StrictWeakOrdering<HcalUpgradeDataFrame> > >" splitLevel="0" />
    <class name="edm::Wrapper<HcalDataFrameContainer<QIE10DataFrame> >" splitLevel="0"/>
+   <class name="edm::Wrapper<HcalDataFrameContainer<QIE11DataFrame> >" splitLevel="0"/>
    <class name="edm::Wrapper<HcalUnpackerReport>"/>
    <class name="HcalLaserDigi" ClassVersion="10">
     <version ClassVersion="10" checksum="2447500554"/>

--- a/DataFormats/HcalDigi/test/HcalDigiDump.cc
+++ b/DataFormats/HcalDigi/test/HcalDigiDump.cc
@@ -33,6 +33,7 @@ HcalDigiDump::HcalDigiDump(edm::ParameterSet const& conf) {
   consumesMany<HcalTTPDigiCollection>();
   consumesMany<HcalUpgradeDigiCollection>();
   consumesMany<QIE10DigiCollection>();
+  consumesMany<QIE11DigiCollection>();
 }
 
 void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
@@ -49,6 +50,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   std::vector<edm::Handle<HcalTTPDigiCollection> > ttp;
   std::vector<edm::Handle<HcalUpgradeDigiCollection> > hup;
   std::vector<edm::Handle<QIE10DigiCollection> > qie10s;
+  std::vector<edm::Handle<QIE11DigiCollection> > qie11s;
 
   try {
     e.getManyByType(hbhe);
@@ -211,6 +213,18 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<QIE10DigiCollection> >::iterator i;
     for (i=qie10s.begin(); i!=qie10s.end(); i++) {
       const QIE10DigiCollection& c=*(*i);
+      
+      for (int j=0; j < c.size(); j++)
+	cout << c[j] << std::endl;
+    }
+  } catch (...) {
+  }
+
+  try {
+    e.getManyByType(qie11s);
+    std::vector<edm::Handle<QIE11DigiCollection> >::iterator i;
+    for (i=qie11s.begin(); i!=qie11s.end(); i++) {
+      const QIE11DigiCollection& c=*(*i);
       
       for (int j=0; j < c.size(); j++)
 	cout << c[j] << std::endl;

--- a/DataFormats/HcalDigi/test/HcalDigiDump.cc
+++ b/DataFormats/HcalDigi/test/HcalDigiDump.cc
@@ -57,6 +57,8 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<HBHEDigiCollection> >::iterator i;
     for (i=hbhe.begin(); i!=hbhe.end(); i++) {
       const HBHEDigiCollection& c=*(*i);
+
+      cout << "HB/HE Digis: " << i->provenance()->branchName() << endl;
       
       for (HBHEDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
@@ -70,6 +72,8 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<HFDigiCollection> >::iterator i;
     for (i=hf.begin(); i!=hf.end(); i++) {
       const HFDigiCollection& c=*(*i);
+
+      cout << "HF Digis: " << i->provenance()->branchName() << endl;
       
       for (HFDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
@@ -83,7 +87,9 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<HODigiCollection> >::iterator i;
     for (i=ho.begin(); i!=ho.end(); i++) {
       const HODigiCollection& c=*(*i);
-      
+
+      cout << "HO Digis: " << i->provenance()->branchName() << endl;
+            
       for (HODigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
 
@@ -97,7 +103,9 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<HcalTrigPrimDigiCollection> >::iterator i;
     for (i=htp.begin(); i!=htp.end(); i++) {
       const HcalTrigPrimDigiCollection& c=*(*i);
-      
+
+      cout << "HcalTrigPrim Digis: " << i->provenance()->branchName() << endl;
+            
       for (HcalTrigPrimDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
 
@@ -111,7 +119,9 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<HOTrigPrimDigiCollection> >::iterator i;
     for (i=hotp.begin(); i!=hotp.end(); i++) {
       const HOTrigPrimDigiCollection& c=*(*i);
-      
+
+      cout << "HO TP Digis: " << i->provenance()->branchName() << endl;
+            
       for (HOTrigPrimDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
 
@@ -125,7 +135,9 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<HcalCalibDigiCollection> >::iterator i;
     for (i=hc.begin(); i!=hc.end(); i++) {
       const HcalCalibDigiCollection& c=*(*i);
-      
+
+      cout << "Calibration Digis: " << i->provenance()->branchName() << endl;
+            
       for (HcalCalibDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
     }
@@ -137,7 +149,9 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<ZDCDigiCollection> >::iterator i;
     for (i=zdc.begin(); i!=zdc.end(); i++) {
       const ZDCDigiCollection& c=*(*i);
-      
+
+      cout << "ZDC Digis: " << i->provenance()->branchName() << endl;
+            
       for (ZDCDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
     }
@@ -149,7 +163,9 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
     std::vector<edm::Handle<CastorDigiCollection> >::iterator i;
     for (i=castor.begin(); i!=castor.end(); i++) {
       const CastorDigiCollection& c=*(*i);
-      
+
+      cout << "Castor Digis: " << i->provenance()->branchName() << endl;
+            
       for (CastorDigiCollection::const_iterator j=c.begin(); j!=c.end(); j++)
 	cout << *j << std::endl;
     }

--- a/DataFormats/HcalDigi/test/HcalDigiDump.cc
+++ b/DataFormats/HcalDigi/test/HcalDigiDump.cc
@@ -32,6 +32,7 @@ HcalDigiDump::HcalDigiDump(edm::ParameterSet const& conf) {
   consumesMany<HcalHistogramDigiCollection>();
   consumesMany<HcalTTPDigiCollection>();
   consumesMany<HcalUpgradeDigiCollection>();
+  consumesMany<QIE10DigiCollection>();
 }
 
 void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
@@ -47,6 +48,7 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   std::vector<edm::Handle<HcalHistogramDigiCollection> > hh;  
   std::vector<edm::Handle<HcalTTPDigiCollection> > ttp;
   std::vector<edm::Handle<HcalUpgradeDigiCollection> > hup;
+  std::vector<edm::Handle<QIE10DigiCollection> > qie10s;
 
   try {
     e.getManyByType(hbhe);
@@ -204,6 +206,17 @@ void HcalDigiDump::analyze(edm::Event const& e, edm::EventSetup const& c) {
   } catch (...) {
   }
 
+  try {
+    e.getManyByType(qie10s);
+    std::vector<edm::Handle<QIE10DigiCollection> >::iterator i;
+    for (i=qie10s.begin(); i!=qie10s.end(); i++) {
+      const QIE10DigiCollection& c=*(*i);
+      
+      for (int j=0; j < c.size(); j++)
+	cout << c[j] << std::endl;
+    }
+  } catch (...) {
+  }
 
   cout << endl;    
 }

--- a/EventFilter/HcalRawToDigi/interface/HcalHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalHTRData.h
@@ -100,7 +100,8 @@ class HcalHTRData {
 	    do_capid=false);
   /** \brief pack header and trailer (call _after_ pack)*/
   void packHeaderTrailer(int L1Anumber, int bcn, int submodule, int
-			 orbitn, int pipeline, int ndd, int nps, int firmwareRev=0);
+			 orbitn, int pipeline, int ndd, int nps, int firmwareRev=0,
+			 int firmwareFlav=0);
 
   /** \brief pack trailer with Mark and Pass bits */
   void packUnsuppressed(const bool* mp);

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -53,6 +53,7 @@ class HcalUHTRData {
     uint8_t le_tdc() const;
     uint8_t te_tdc() const;
     bool soi() const;
+    bool ok() const;
 
     uint16_t operator*() const { return *m_ptr; }
 

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -53,6 +53,7 @@ class HcalUHTRData {
     uint8_t le_tdc() const;
     uint8_t te_tdc() const;
     bool soi() const;
+    uint8_t capid() const;
     bool ok() const;
 
     uint16_t operator*() const { return *m_ptr; }
@@ -62,10 +63,12 @@ class HcalUHTRData {
 
     bool operator==(const const_iterator& i) { return m_ptr==i.m_ptr; }
     bool operator!=(const const_iterator& i) { return m_ptr!=i.m_ptr; }
+    const uint16_t* raw() const { return m_ptr; }
 
   private:
     void determineMode();
     const uint16_t* m_ptr, *m_limit;
+    const uint16_t* m_header_ptr, *m_0th_data_ptr;
     int m_microstep;
     int m_stepclass;
     int m_flavor;

--- a/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUHTRData.h
@@ -50,8 +50,8 @@ class HcalUHTRData {
     uint16_t value() const { return *m_ptr; }
 
     uint8_t adc() const;
-    uint8_t re_tdc() const;
-    uint8_t fe_tdc() const;
+    uint8_t le_tdc() const;
+    uint8_t te_tdc() const;
     bool soi() const;
 
     uint16_t operator*() const { return *m_ptr; }

--- a/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
+++ b/EventFilter/HcalRawToDigi/interface/HcalUnpacker.h
@@ -14,6 +14,7 @@
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 #include "CondFormats/HcalObjects/interface/HcalElectronicsMap.h"
 #include "DataFormats/HcalDigi/interface/HcalTTPDigi.h"
+#include "DataFormats/HcalDigi/interface/HcalDigiCollections.h"
 #include <set>
 
 class HcalUnpacker {
@@ -29,6 +30,7 @@ public:
     std::vector<HcalTriggerPrimitiveDigi>* tpCont;
     std::vector<HOTriggerPrimitiveDigi>* tphoCont;
     std::vector<HcalTTPDigi>* ttp;
+    QIE10DigiCollection* qie10;
   };
 
   /// for normal data

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -53,6 +53,7 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
     produces<ZDCDigiCollection>();
   if (unpackTTP_)
     produces<HcalTTPDigiCollection>();
+  produces<QIE10DigiCollection>();
 
   memset(&stats_,0,sizeof(stats_));
 
@@ -172,6 +173,10 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   std::auto_ptr<HODigiCollection> ho_prod(new HODigiCollection());
   std::auto_ptr<HcalTrigPrimDigiCollection> htp_prod(new HcalTrigPrimDigiCollection());  
   std::auto_ptr<HOTrigPrimDigiCollection> hotp_prod(new HOTrigPrimDigiCollection());  
+  if (colls.qie10 == 0) {
+    colls.qie10 = new QIE10DigiCollection(); 
+  }
+  std::auto_ptr<QIE10DigiCollection> qie10_prod(colls.qie10);
 
   hbhe_prod->swap_contents(hbhe);
   hf_prod->swap_contents(hf);
@@ -198,12 +203,14 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   hf_prod->sort();
   htp_prod->sort();
   hotp_prod->sort();
+  qie10_prod->sort();
 
   e.put(hbhe_prod);
   e.put(ho_prod);
   e.put(hf_prod);
   e.put(htp_prod);
   e.put(hotp_prod);
+  e.put(qie10_prod);
 
   /// calib
   if (unpackCalib_) {

--- a/EventFilter/HcalRawToDigi/src/HcalDCCHeader.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalDCCHeader.cc
@@ -51,6 +51,8 @@ void HcalDCCHeader::clear() {
 void HcalDCCHeader::setHeader(int sourceid, int bcn, int l1aN, int orbN) {
   commondataformat0=0x8|((sourceid&0xFFF)<<8)|((bcn&0xFFF)<<20);
   commondataformat1=0x50000000u|(l1aN&0xFFFFFF);
+  commondataformat2=((orbN&0xFFFFFFF)<<4);
+  commondataformat3=((orbN>>28)&0xF);
 }
 
 void HcalDCCHeader::copySpigotData(unsigned int spigot_id, const HcalHTRData& data, bool valid, unsigned char LRB_error_word) {

--- a/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalHTRData.cc
@@ -235,7 +235,7 @@ void HcalHTRData::pack(unsigned char* daq_lengths, unsigned short* daq_samples,
   unsigned short* ptr=m_ownData+headerLen;
   if (tp_samples!=0 && tp_lengths!=0) {
     for (ichan=0; ichan<24; ichan++) {
-      unsigned short chanid=((ichan%3)+((ichan/3)<<2))<<11;
+      unsigned short chanid=((ichan%4)+(((ichan/4)+1)<<2))<<11;
       for (isample=0; isample<tp_lengths[ichan] && isample<MAXIMUM_SAMPLES_PER_CHANNEL; isample++) {
 	ptr[tp_words_total]=chanid|(tp_samples[ichan*MAXIMUM_SAMPLES_PER_CHANNEL+isample]&0x3FF);
 	tp_words_total++;
@@ -280,7 +280,7 @@ void HcalHTRData::pack(unsigned char* daq_lengths, unsigned short* daq_samples,
 
 }
 
-void HcalHTRData::packHeaderTrailer(int L1Anumber, int bcn, int submodule, int orbitn, int pipeline, int ndd, int nps, int firmwareRev) {
+void HcalHTRData::packHeaderTrailer(int L1Anumber, int bcn, int submodule, int orbitn, int pipeline, int ndd, int nps, int firmwareRev, int firmwareFlav) {
   m_ownData[0]=L1Anumber&0xFF;
   m_ownData[1]=(L1Anumber&0xFFFF00)>>8;
   if (m_formatVersion==-1) {
@@ -297,7 +297,7 @@ void HcalHTRData::packHeaderTrailer(int L1Anumber, int bcn, int submodule, int o
     m_ownData[4]=((m_formatVersion&0xF)<<12)|(bcn&0xFFF);
     m_ownData[5]|=((nps&0x1F)<<3)|0x1;
     m_ownData[6]=((firmwareRev&0x70000)>>3)|(firmwareRev&0x1FFF);
-    m_ownData[7]=pipeline&0xFF;
+    m_ownData[7]=(pipeline&0xFF)|((firmwareFlav&0x3F)<<8);
     m_ownData[m_rawLength-4]&=0x7FF;
     m_ownData[m_rawLength-4]|=(ndd&0x1F)<<11;
   }

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -38,9 +38,9 @@ static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const Hca
   HcalTrigPrimDigiCollection::const_iterator i=pt->find(tid);
   if (i!=pt->end()) {
     int presamples=i->presamples();
-    int samples=i->size();
+    size=i->size();
 
-    for (int j=0; j<samples; j++) {
+    for (int j=0; j<size; j++) {
        buffer[j]=(*i)[j].raw();
        if (j==presamples) buffer[j]|=0x0200;
     }

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -180,7 +180,8 @@ void HcalPacker::pack(int fedid, int dccnumber,
 					pipeline,
 					samples,
 					presamples,
-					firmwareRev);
+					firmwareRev,
+					1);  // need non-zero falvor
       if (haveUnsuppressed) {
 	spigots[spigot].packUnsuppressed(channelIsMP);
       }

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -18,7 +18,7 @@ HcalPacker::Collections::Collections() {
 template <class Coll, class DetIdClass> 
 int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presamples,bool& isUS, bool& isMP) {
   isUS=false; isMP=false;
-  if (pt==0) return 0;
+  if (pt==0) { return 0; }
   int size=0;
   typename Coll::const_iterator i=pt->find(DetIdClass(did));
   if (i!=pt->end()) {
@@ -26,14 +26,15 @@ int process(const Coll* pt, const DetId& did, unsigned short* buffer, int& presa
     isMP=i->zsMarkAndPass();
     presamples=i->presamples();
     size=i->size();
-    for (int j=0; j<size; j++) 
+    for (int j=0; j<size; j++) {
       buffer[j]=(*i)[j].raw();
+    }
   }
   return size;
 }
 
 static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const HcalTrigTowerDetId& tid, unsigned short* buffer) {
-  if (pt==0) return 0;
+  if (pt==0) { return 0; }
   int size=0;
   HcalTrigPrimDigiCollection::const_iterator i=pt->find(tid);
   if (i!=pt->end()) {
@@ -42,7 +43,7 @@ static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const Hca
 
     for (int j=0; j<size; j++) {
        buffer[j]=(*i)[j].raw();
-       if (j==presamples) buffer[j]|=0x0200;
+       if (j==presamples) { buffer[j]|=0x0200; }
     }
   }
   return size;
@@ -50,7 +51,7 @@ static unsigned char processTrig(const HcalTrigPrimDigiCollection* pt, const Hca
 
 int HcalPacker::findSamples(const DetId& did, const Collections& inputs,
 			    unsigned short* buffer, int &presamples, bool& isUS, bool& isMP) {
-  if (!(did.det()==DetId::Hcal || (did.det()== DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId)) ) return 0;
+  if (!(did.det()==DetId::Hcal || (did.det()== DetId::Calo && did.subdetId()==HcalZDCDetId::SubdetectorId)) ) { return 0; }
   int size=0;
   HcalGenericDetId genId(did);
   
@@ -96,7 +97,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
     int npresent=0;
     int presamples=-1, samples=-1;
     bool haveUnsuppressed=false;
-    for (int fiber=1; fiber<=8; fiber++) 
+    for (int fiber=1; fiber<=8; fiber++) {
       for (int fiberchan=0; fiberchan<3; fiberchan++) {
 	int linear=(fiber-1)*3+fiberchan;
 	HcalQIESample chanSample(0,0,fiber,fiberchan,false,false);
@@ -108,7 +109,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
 	// does this partial id exist?
 	HcalElectronicsId fullEid;
 	HcalGenericDetId genId;
-	if (!emap.lookup(partialEid,fullEid,genId)) continue;
+	if (!emap.lookup(partialEid,fullEid,genId)) { continue; }
 
 
 	// next, see if there is a digi with this id
@@ -120,7 +121,7 @@ void HcalPacker::pack(int fedid, int dccnumber,
 	channelIsMP[linear]=isMP;
 
 	if (mysamples>0) {
-	  if (samples<0) samples=mysamples;
+	  if (samples<0) { samples=mysamples; }
 	  else if (samples!=mysamples) {
 	    edm::LogError("HCAL") << "Mismatch of samples in a single HTR (unsupported) " << mysamples << " != " << samples;
 	    continue;
@@ -132,13 +133,15 @@ void HcalPacker::pack(int fedid, int dccnumber,
 	    edm::LogError("HCAL") << "Mismatch of presamples in a single HTR (unsupported) " << mypresamples << " != " << presamples;
 	    continue;	    
 	  }
-	  for (int ii=0; ii<samples; ii++)
+	  for (int ii=0; ii<samples; ii++) {
 	    database[ii]=(database[ii]&0x7FF)|chanid;
+      }
 	  preclen[linear]=(unsigned char)(samples);
 	  npresent++;
 	}	
       }
-    for (int slb=1; slb<=6; slb++) 
+    }
+    for (int slb=1; slb<=6; slb++) {
       for (int slbchan=0; slbchan<=3; slbchan++) {
 	int linear=(slb-1)*4+slbchan;
 	HcalTriggerPrimitiveSample idCvt(0,0,slb,slbchan);
@@ -165,11 +168,13 @@ void HcalPacker::pack(int fedid, int dccnumber,
         npresent++;
       }
 	  
-	  for (unsigned char q=0; q<triglen[linear]; q++)
+	  for (unsigned char q=0; q<triglen[linear]; q++) {
 	    trigbase[q]=(trigbase[q]&0x7FF)|chanid;
+      }
 
 	}
       }
+    }
     /// pack into HcalHTRData
     if (npresent>0) {
       spigots[spigot].pack(&(preclen[0]),&(precdata[0]),
@@ -219,8 +224,9 @@ void HcalPacker::pack(int fedid, int dccnumber,
 
   // pack the HTR data into the FEDRawData block using HcalDCCHeader
   for (int spigot=0; spigot<15; spigot++) {
-    if (spigots[spigot].getRawLength()>0)
+    if (spigots[spigot].getRawLength()>0) {
       dcc->copySpigotData(spigot,spigots[spigot],true,0);
+    }
   }
   // trailer
   FEDTrailer fedTrailer(output.data()+(output.size()-8));

--- a/EventFilter/HcalRawToDigi/src/HcalPacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalPacker.cc
@@ -156,11 +156,18 @@ void HcalPacker::pack(int fedid, int dccnumber,
           
 	// finally, what about a trigger channel?
 	if (!tid.null()) {
+      if (presamples < 0) {
+        exampleEId = fullEid;
+      }
 	  unsigned short* trigbase=&(trigdata[linear*HcalHTRData::MAXIMUM_SAMPLES_PER_CHANNEL]);
 	  triglen[linear]=processTrig(inputs.tpCont,tid,trigbase);
+      if (triglen[linear]) {
+        npresent++;
+      }
 	  
 	  for (unsigned char q=0; q<triglen[linear]; q++)
 	    trigbase[q]=(trigbase[q]&0x7FF)|chanid;
+
 	}
       }
     /// pack into HcalHTRData
@@ -173,6 +180,14 @@ void HcalPacker::pack(int fedid, int dccnumber,
       int submodule=exampleEId.htrTopBottom()&0x1;
       submodule|=(exampleEId.htrSlot()&0x1F)<<1;
       submodule|=(exampleEId.readoutVMECrateId()&0x1f)<<6;
+      // Samples and Presamples can't be negative, or the HeaderTrailer will
+      // generate a large large number using them (unsigned int roll over)
+      if (samples < 0) {
+        samples = 0;
+      }
+      if (presamples < 0) {
+        presamples = 0;
+      }
       spigots[spigot].packHeaderTrailer(nl1a,
 					bcn,
 					submodule,

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -33,7 +33,7 @@ uint8_t HcalUHTRData::const_iterator::adc() const {
   else return (*m_ptr)&0xFF;
 }
 
-uint8_t HcalUHTRData::const_iterator::re_tdc() const {
+uint8_t HcalUHTRData::const_iterator::le_tdc() const {
   if (m_flavor==0x5) return 0x80;
   else if (m_flavor == 2) return (m_ptr[1]&0x3F);
   else return (((*m_ptr)&0x3F00)>>8);
@@ -45,7 +45,7 @@ bool HcalUHTRData::const_iterator::soi() const {
   else return (((*m_ptr)&0x4000));
 }
 
-uint8_t HcalUHTRData::const_iterator::fe_tdc() const {
+uint8_t HcalUHTRData::const_iterator::te_tdc() const {
   if (m_flavor==2) return(m_ptr[1]>>6)&0x1F;
   else return 0x80;
 }

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -50,6 +50,11 @@ uint8_t HcalUHTRData::const_iterator::te_tdc() const {
   else return 0x80;
 }
 
+bool HcalUHTRData::const_iterator::ok() const {
+  if (m_flavor == 2) { return (m_ptr[0]>>12)&0x1; }
+  else if (m_flavor == 4) { return (m_ptr[0]>>13)&0x1; }
+  else return { false; }
+}
 
 HcalUHTRData::const_iterator HcalUHTRData::begin() const {
   return HcalUHTRData::const_iterator(m_raw16+HEADER_LENGTH_16BIT,m_raw16+(m_rawLength64-1)*sizeof(uint64_t)/sizeof(uint16_t));

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -19,7 +19,11 @@ HcalUHTRData::const_iterator& HcalUHTRData::const_iterator::operator++() {
     else { m_ptr+=2; }
   }
 
-  if (isHeader()) determineMode();
+  if (isHeader()) {
+    determineMode();
+    m_header_ptr = m_ptr;
+    m_0th_data_ptr = m_header_ptr + 1;
+  }
   return *this;
 }
 
@@ -53,10 +57,21 @@ uint8_t HcalUHTRData::const_iterator::te_tdc() const {
   else return 0x80;
 }
 
+uint8_t HcalUHTRData::const_iterator::capid() const {
+  if (m_flavor==2) return(m_ptr[1]>>12)&0x3;
+  else if (m_flavor == 1 || m_flavor == 0) {
+    // For flavor 0,1 we only get the first capid in the header, and so we need
+    // to count the number of data rows and figure out which cap we want,
+    // knowing that they go 0->1->2->3->0
+    return 0;
+  }
+  else { return 0; }
+}
+
 bool HcalUHTRData::const_iterator::ok() const {
   if (m_flavor == 2) { return (m_ptr[0]>>12)&0x1; }
   else if (m_flavor == 4) { return (m_ptr[0]>>13)&0x1; }
-  else return { false; }
+  else { return false; }
 }
 
 HcalUHTRData::const_iterator HcalUHTRData::begin() const {

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -14,7 +14,10 @@ HcalUHTRData::const_iterator& HcalUHTRData::const_iterator::operator++() {
     if (m_microstep==0) { m_ptr++; m_microstep++; }
     else { m_microstep--; }
   } 
-  else if (m_stepclass==2) m_ptr+=2;
+  else if (m_stepclass==2) {
+    if (isHeader()) { m_ptr++; }
+    else { m_ptr+=2; }
+  }
 
   if (isHeader()) determineMode();
   return *this;

--- a/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUHTRData.cc
@@ -25,7 +25,7 @@ void HcalUHTRData::const_iterator::determineMode() {
   m_flavor=flavor();
   m_stepclass=0;
   if (m_flavor==5) { m_stepclass=1; m_microstep=0; }
-  else if ((m_flavor&0x6)==0x2) { m_stepclass=2; }
+  else if (m_flavor == 2) { m_stepclass=2; }
 }
 
 uint8_t HcalUHTRData::const_iterator::adc() const {
@@ -35,19 +35,19 @@ uint8_t HcalUHTRData::const_iterator::adc() const {
 
 uint8_t HcalUHTRData::const_iterator::re_tdc() const {
   if (m_flavor==0x5) return 0x80;
-  else if ((m_flavor&0x6)==0x2) return (m_ptr[1]&0x3F);
+  else if (m_flavor == 2) return (m_ptr[1]&0x3F);
   else return (((*m_ptr)&0x3F00)>>8);
 }
 
 bool HcalUHTRData::const_iterator::soi() const {
   if (m_flavor==0x5) return false;
-  else if ((m_flavor&0x6)==0x2) return (m_ptr[0]&0x2000);
+  else if (m_flavor == 2) return (m_ptr[0]&0x2000);
   else return (((*m_ptr)&0x4000));
 }
 
 uint8_t HcalUHTRData::const_iterator::fe_tdc() const {
-  if (m_flavor==0x5 || (m_flavor&0x6)==0x0) return 0x80;
-  else return ((m_ptr[1]>>6)&0xF);
+  if (m_flavor==2) return(m_ptr[1]>>6)&0x1F;
+  else return 0x80;
 }
 
 

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -668,7 +668,7 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	       ++i);
 	}
       } else if (i.flavor()==0x4) { // TP digis
-	int ilink=((i.channelid()>>4)&0x7);
+	int ilink=((i.channelid()>>4)&0xF);
 	int itower=(i.channelid()&0xF);
 	HcalElectronicsId eid(crate,slot,ilink,itower,true);
 	DetId did=emap.lookupTrigger(eid);

--- a/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
+++ b/EventFilter/HcalRawToDigi/src/HcalUnpacker.cc
@@ -590,7 +590,33 @@ void HcalUnpacker::unpackUTCA(const FEDRawData& raw, const HcalElectronicsMap& e
 	++i;
 	continue;
       }
-      if (i.flavor()==0x5) { // Old-style digis
+      if (i.flavor() == 2) {
+	int ifiber=((i.channelid()>>2)&0x1F);
+	int ichan=(i.channelid()&0x3);
+	HcalElectronicsId eid(crate,slot,ifiber,ichan, false);
+	DetId did=emap.lookup(eid);
+
+	// Count from current position to next header, or equal to end
+	const uint16_t* head_pos = i.raw();
+	int ns = 0;
+	for (++i; i != iend && !i.isHeader(); ++i) {
+	  ns++; 
+	}
+
+	// Check QEI10 container exists
+	if (colls.qie10 == 0) {
+	  colls.qie10 = new QIE10DigiCollection(ns);
+	}
+	else if (colls.qie10->samples() != ns) {
+	  // This is horrible
+	  edm::LogError("Invalid Data") << "Collection has " << colls.qie10->samples() << " samples per digi, raw data has " << ns << "!";
+	  return;
+	}
+
+	// Insert data
+	colls.qie10->addDataFrame(did, head_pos);
+      }
+      else if (i.flavor()==0x5) { // Old-style digis
 	int ifiber=((i.channelid()>>2)&0x1F);
 	int ichan=(i.channelid()&0x3);
 	HcalElectronicsId eid(crate,slot,ifiber,ichan, false);
@@ -688,6 +714,7 @@ HcalUnpacker::Collections::Collections() {
   zdcCont=0;
   calibCont=0;
   ttp=0;
+  qie10=0;
 }
 
 void HcalUnpacker::unpack(const FEDRawData& raw, const HcalElectronicsMap& emap, std::vector<HcalHistogramDigi>& histoDigis) {

--- a/L1Trigger/RegionalCaloTrigger/src/L1RCT.cc
+++ b/L1Trigger/RegionalCaloTrigger/src/L1RCT.cc
@@ -164,6 +164,9 @@ void L1RCT::digiInput(const EcalTrigPrimDigiCollection& ecalCollection,
   //if (nHcalDigi != 4176){ std::cout << "L1RCT: Warning: There are " << nHcalDigi << "hcal digis instead of 4176!" << std::endl;}
   // incl HF 4032 + 144 = 4176
   for (int i = 0; i < nHcalDigi; i++){
+    if (hcalCollection[i].id().version() != 0) {
+      continue;
+    }
     short ieta = (short) hcalCollection[i].id().ieta(); 
     unsigned short absIeta = (unsigned short) abs(ieta);
     unsigned short cal_iphi = (unsigned short) hcalCollection[i].id().iphi();


### PR DESCRIPTION
Several related HCAL uHTR Packing/Unpacking changes are included in this request:
- Add support for data from QIE10s
- Add skeletal support for QIE11s
- Fix an old Packing bug where Trigger Primitives were not packed properly
- Add a version number to HcalTrigTowerDetId in preparation for upcoming Trigger Primitive changes

CC: @jmmans, @abdoulline
