### PR TITLE
Make statics thread-safe in OnlineDb/SiStripConfigDb

### DIFF
--- a/OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h
+++ b/OnlineDB/SiStripConfigDb/interface/SiStripConfigDb.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <list>
 #include <map>
+#include <atomic>
 
 #include "DbClient.h"
 
@@ -452,9 +453,9 @@ class SiStripConfigDb {
   bool openConnection_;
   
   /** Static counter of instances of this class. */
-  static uint32_t cntr_;
+  static std::atomic<uint32_t> cntr_;
 
-  static bool allowCalibUpload_;
+  static std::atomic<bool> allowCalibUpload_;
 
   
 };

--- a/OnlineDB/SiStripConfigDb/interface/SiStripPartition.h
+++ b/OnlineDB/SiStripConfigDb/interface/SiStripPartition.h
@@ -39,7 +39,7 @@ class SiStripPartition {
   
   ~SiStripPartition();
 
-  static std::string defaultPartitionName_;
+  static const std::string defaultPartitionName_;
 
   typedef std::pair<uint32_t,uint32_t> Versions; 
 

--- a/OnlineDB/SiStripConfigDb/src/SiStripConfigDb.cc
+++ b/OnlineDB/SiStripConfigDb/src/SiStripConfigDb.cc
@@ -10,11 +10,11 @@ using namespace sistrip;
 
 // -----------------------------------------------------------------------------
 // 
-uint32_t SiStripConfigDb::cntr_ = 0;
+std::atomic<uint32_t> SiStripConfigDb::cntr_{0};
 
 // -----------------------------------------------------------------------------
 // 
-bool SiStripConfigDb::allowCalibUpload_ = false;
+std::atomic<bool> SiStripConfigDb::allowCalibUpload_{ false };
 
 // -----------------------------------------------------------------------------
 // 
@@ -41,11 +41,11 @@ SiStripConfigDb::SiStripConfigDb( const edm::ParameterSet& pset,
   usingStrips_(true),
   openConnection_(false)
 {
-  cntr_++;
+  auto count = ++cntr_;
   edm::LogVerbatim(mlConfigDb_)
     << "[SiStripConfigDb::" << __func__ << "]"
     << " Constructing database service..."
-    << " (Class instance: " << cntr_ << ")";
+    << " (Class instance: " << count << ")";
   
   // Set DB connection parameters
   dbParams_.reset();
@@ -64,7 +64,7 @@ SiStripConfigDb::~SiStripConfigDb() {
   LogTrace(mlConfigDb_)
     << "[SiStripConfigDb::" << __func__ << "]"
     << " Destructing object...";
-  if ( cntr_ ) { cntr_--; }
+  --cntr_;
 }
 
 // -----------------------------------------------------------------------------

--- a/OnlineDB/SiStripConfigDb/src/SiStripPartition.cc
+++ b/OnlineDB/SiStripConfigDb/src/SiStripPartition.cc
@@ -10,7 +10,7 @@ using namespace sistrip;
 
 // -----------------------------------------------------------------------------
 //
-std::string SiStripPartition::defaultPartitionName_ = "DefaultPartition";
+const std::string SiStripPartition::defaultPartitionName_ = "DefaultPartition";
 
 // -----------------------------------------------------------------------------
 // 


### PR DESCRIPTION
Although the static analyzer should no longer complain about the statics, the Service SiStripConfigDb is still not thread safe.
