### PR TITLE
Fix classes.h file

### DIFF
--- a/PhysicsTools/Heppy/src/classes.h
+++ b/PhysicsTools/Heppy/src/classes.h
@@ -17,27 +17,6 @@
 //#include "EgammaAnalysis/ElectronTools/interface/ElectronEnergyCalibrator.h"
 #include <vector>
 namespace {
-  namespace {
-    heppy::BTagSF  bTagSF_; 
-    heppy::RochCor rc_;
-    heppy::RochCor2012 rc2012_;
-    heppy::FSRWeightAlgo walgo_;
-    heppy::TriggerBitChecker checker;
-    heppy::CMGMuonCleanerBySegmentsAlgo cmgMuonCleanerBySegmentsAlgo;
-    heppy::EGammaMvaEleEstimatorFWLite egMVA;
-    heppy::Hemisphere hemisphere(std::vector<float> px, 
-				 std::vector<float> py, 
-				 std::vector<float> pz, 
-				 std::vector<float> E, int hemi_seed, 
-				 int hemi_association);
-    heppy::Hemisphere hemisphere_;
-    heppy::Davismt2 mt2;
-    heppy::mt2w_bisect::mt2w mt2wlept;
-    heppy::AlphaT alphaT;
-    heppy::ReclusterJets reclusterJets(std::vector<float> px, std::vector<float> py, std::vector<float> pz, std::vector<float> E, double ktpower, double rparam);
-    //  heppy::SimpleElectron fuffaElectron;
-    //  ElectronEnergyCalibrator fuffaElectronCalibrator;
-    //  heppy::ElectronEPcombinator fuffaElectronCombinator;
-
-  }
+  struct heppy_dictionary {
+  };
 }


### PR DESCRIPTION
Bug fix:  This PR fixes three problems with PhysicsTools/Heppy/src/classes.h.
This needs to be fixed to clear up build warnings in  CMSSW_7_4_ROOT6, but since the fix is not ROOT6 specific, our policy is to put it in 7_4_X.
1) There are functions explicitly declared in this header, which makes no sense and causes build warnings in CMSSW_7_4_ROOT6_X.
2) This header uses the long discarded and inferior doubly nested anonymous namespace, rather than a uniquely named  struct inside an anonymous namespace.
This could be fatal in ROOT6 (and perhaps even in ROOT 5) if there are duplicate names.
3) This header declares classes that are not template instances.  Unlike the two issues above, this is probably harmless, but it is unnecessary.  In fact, none of the declared classes are template instances.

This is a purely technical fix, and should bypass the L2 signature if not signed in a reasonable time.
Of course, it should still have the usual testing.
