### PR TITLE
Remove declaration of dupicate dictionary for SMatrix

### DIFF
--- a/DataFormats/Math/src/classes.h
+++ b/DataFormats/Math/src/classes.h
@@ -225,9 +225,6 @@ namespace DataFormats_Math {
     ROOT::Math::MatRepStd<double, 10 , 10> smdcw;
     ROOT::Math::MatRepStd<double, 2 , 3> smdcw1;
 
-    //Used by MET Significance matrix
-    ROOT::Math::SMatrix<double,2> smat;
-
     //Used by TauReco
     std::pair<ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag>,float> calotti_ppf;
     std::vector<std::pair<ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<double>,ROOT::Math::DefaultCoordinateSystemTag>,float> > vcalotti_ppf;


### PR DESCRIPTION
The dictionaries for SMatrix<double,2> is already declared in libSMatrix
for ROOT 6 and ROOT gives a warning if it also appears in libDataFormatsMath.
