### PR TITLE
Complete the consumes interface for package L1Trigger/DTTrackFinder 

### DIFF
--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
@@ -68,7 +68,7 @@ class L1MuDTTrackFinder {
     virtual ~L1MuDTTrackFinder();
 
     /// build the structure of the barrel MTTF
-    void setup();
+    void setup(edm::ConsumesCollector&& iC);
 
     /// run the barrel MTTF
     void run(const edm::Event& e, const edm::EventSetup& c);

--- a/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
+++ b/L1Trigger/DTTrackFinder/interface/L1MuDTTrackFinder.h
@@ -35,9 +35,11 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/ParameterSet/interface/ParameterSet.h>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+class L1MuDTChambPhContainer;
 class L1MuDTTFConfig;
 class L1MuDTSecProcMap;
 class L1MuDTSecProcId;
@@ -120,6 +122,7 @@ class L1MuDTTrackFinder {
     std::vector<L1MuDTEtaProcessor*> m_epvec;        ///< Eta Processors
     std::vector<L1MuDTWedgeSorter*>  m_wsvec;        ///< Wedge Sorters
     L1MuDTMuonSorter*                m_ms;           ///< DT Muon Sorter
+    edm::EDGetTokenT<L1MuDTChambPhContainer> m_DTDigiToken;
 
     static L1MuDTTFConfig*           m_config;       ///< Track Finder configuration
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
@@ -60,8 +60,9 @@ using namespace std;
 // Constructors --
 //----------------
 
-L1MuDTEtaProcessor::L1MuDTEtaProcessor(const L1MuDTTrackFinder& tf, int id) :
+L1MuDTEtaProcessor::L1MuDTEtaProcessor(const L1MuDTTrackFinder& tf, int id, edm::ConsumesCollector&& iC) :
       m_tf(tf), m_epid(id), m_foundPattern(0), m_tseta(15) {
+  iC.consumes<L1MuDTChambThContainer>(L1MuDTTFConfig::getDTDigiInputTag());
 
   m_tseta.reserve(15);
   

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.cc
@@ -61,8 +61,8 @@ using namespace std;
 //----------------
 
 L1MuDTEtaProcessor::L1MuDTEtaProcessor(const L1MuDTTrackFinder& tf, int id, edm::ConsumesCollector&& iC) :
-      m_tf(tf), m_epid(id), m_foundPattern(0), m_tseta(15) {
-  iC.consumes<L1MuDTChambThContainer>(L1MuDTTFConfig::getDTDigiInputTag());
+      m_tf(tf), m_epid(id), m_foundPattern(0), m_tseta(15),
+      m_DTDigiToken(iC.consumes<L1MuDTChambThContainer>(L1MuDTTFConfig::getDTDigiInputTag())) {
 
   m_tseta.reserve(15);
   
@@ -218,7 +218,7 @@ void L1MuDTEtaProcessor::receiveData(int bx, const edm::Event& e, const edm::Eve
   c.get< L1MuDTTFMasksRcd >().get( msks );
 
   edm::Handle<L1MuDTChambThContainer> dttrig;
-  e.getByLabel(L1MuDTTFConfig::getDTDigiInputTag(),dttrig);
+  e.getByToken(m_DTDigiToken,dttrig);
 
   // const int bx_offset = dttrig->correctBX();
   int bx_offset=0;

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
@@ -38,7 +38,9 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "L1Trigger/DTTrackFinder/src/L1MuDTAddressArray.h"
+class L1MuDTChambThContainer;
 class L1MuDTTrackSegEta;
 class L1MuDTTrackFinder;
 class L1MuDTTrack;
@@ -118,6 +120,7 @@ class L1MuDTEtaProcessor {
     L1MuDTTrack*                              m_TrackCand[12];    
     L1MuDTTrack*                              m_TracKCand[12];    
     std::vector<const L1MuDTTrackSegEta*>     m_tseta;
+    edm::EDGetTokenT<L1MuDTChambThContainer>  m_DTDigiToken;
     
     edm::ESHandle< L1MuDTEtaPatternLut >  theEtaPatternLUT;  // ETF look-up table
     edm::ESHandle< L1MuDTQualPatternLut > theQualPatternLUT; // EMU look-up tables

--- a/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTEtaProcessor.h
@@ -33,10 +33,11 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-#include <DataFormats/Common/interface/Handle.h>
-#include <FWCore/Framework/interface/Event.h>
-#include <FWCore/Framework/interface/ESHandle.h>
-#include <FWCore/Framework/interface/EventSetup.h>
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "L1Trigger/DTTrackFinder/src/L1MuDTAddressArray.h"
 class L1MuDTTrackSegEta;
 class L1MuDTTrackFinder;
@@ -54,7 +55,7 @@ class L1MuDTEtaProcessor {
   public:
 
     /// constructor
-    L1MuDTEtaProcessor(const L1MuDTTrackFinder&, int id );
+    L1MuDTEtaProcessor(const L1MuDTTrackFinder&, int id, edm::ConsumesCollector&& iC);
 
     /// destructor
     virtual ~L1MuDTEtaProcessor();

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorProcessor.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorProcessor.cc
@@ -51,9 +51,10 @@ using namespace std;
 //----------------
 
 L1MuDTSectorProcessor::L1MuDTSectorProcessor(const L1MuDTTrackFinder& tf,
-                                             const L1MuDTSecProcId& id) :
+                                             const L1MuDTSecProcId& id,
+                                             edm::ConsumesCollector&& iC) :
       m_tf(tf), m_spid(id), 
-      m_SectorReceiver(new L1MuDTSectorReceiver(*this)),
+      m_SectorReceiver(new L1MuDTSectorReceiver(*this, std::move(iC))),
       m_DataBuffer(new L1MuDTDataBuffer(*this)),
       m_EU(new L1MuDTExtrapolationUnit(*this)),
       m_TA(new L1MuDTTrackAssembler(*this)), 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorProcessor.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorProcessor.h
@@ -36,7 +36,8 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
 class L1MuDTSectorReceiver;
 class L1MuDTDataBuffer;
 class L1MuDTExtrapolationUnit;
@@ -54,7 +55,7 @@ class L1MuDTSectorProcessor {
   public:
 
     /// constructor
-    L1MuDTSectorProcessor(const L1MuDTTrackFinder&, const L1MuDTSecProcId& );
+    L1MuDTSectorProcessor(const L1MuDTTrackFinder&, const L1MuDTSecProcId&, edm::ConsumesCollector&&);
 
     /// destructor
     virtual ~L1MuDTSectorProcessor();

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.cc
@@ -53,11 +53,9 @@ using namespace std;
 // Constructors --
 //----------------
 L1MuDTSectorReceiver::L1MuDTSectorReceiver(L1MuDTSectorProcessor& sp, edm::ConsumesCollector && iC) : 
-        m_sp(sp) {
-   iC.consumes<L1MuDTChambPhContainer>(L1MuDTTFConfig::getDTDigiInputTag());
-   if ((L1MuDTTFConfig::getCSCTrSInputTag()).label() != "none" ) {
-     iC.consumes<CSCTriggerContainer<csctf::TrackStub> >(L1MuDTTFConfig::getCSCTrSInputTag());
-   }
+        m_sp(sp),
+        m_DTDigiToken(iC.consumes<L1MuDTChambPhContainer>(L1MuDTTFConfig::getDTDigiInputTag())),
+        m_CSCTrSToken(iC.mayConsume<CSCTriggerContainer<csctf::TrackStub> >(L1MuDTTFConfig::getCSCTrSInputTag())) {
 }
 
 
@@ -108,7 +106,7 @@ void L1MuDTSectorReceiver::reset() {
 void L1MuDTSectorReceiver::receiveDTBXData(int bx, const edm::Event& e, const edm::EventSetup& c) {
 
   edm::Handle<L1MuDTChambPhContainer> dttrig;
-  e.getByLabel(L1MuDTTFConfig::getDTDigiInputTag(),dttrig);
+  e.getByToken(m_DTDigiToken,dttrig);
 
   L1MuDTChambPhDigi const* ts=0;
 
@@ -228,7 +226,7 @@ void L1MuDTSectorReceiver::receiveCSCData(int bx, const edm::Event& e, const edm
   if ( bx < -6 || bx > 6 ) return;
 
   edm::Handle<CSCTriggerContainer<csctf::TrackStub> > csctrig;
-  e.getByLabel(L1MuDTTFConfig::getCSCTrSInputTag(),csctrig);
+  e.getByToken(m_CSCTrSToken,csctrig);
 
   const int bxCSC = 6;
   

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.cc
@@ -52,9 +52,12 @@ using namespace std;
 //----------------
 // Constructors --
 //----------------
-L1MuDTSectorReceiver::L1MuDTSectorReceiver(L1MuDTSectorProcessor& sp) : 
+L1MuDTSectorReceiver::L1MuDTSectorReceiver(L1MuDTSectorProcessor& sp, edm::ConsumesCollector && iC) : 
         m_sp(sp) {
-
+   iC.consumes<L1MuDTChambPhContainer>(L1MuDTTFConfig::getDTDigiInputTag());
+   if ((L1MuDTTFConfig::getCSCTrSInputTag()).label() != "none" ) {
+     iC.consumes<CSCTriggerContainer<csctf::TrackStub> >(L1MuDTTFConfig::getCSCTrSInputTag());
+   }
 }
 
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.h
@@ -36,9 +36,15 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+class L1MuDTChambPhContainer;
 class L1MuDTSectorProcessor;
 class L1MuDTTFParameters;
 class L1MuDTTFMasks;
+template<typename T> class CSCTriggerContainer;
+namespace csctf {
+  class TrackStub;
+}
 
 //              ---------------------
 //              -- Class Interface --
@@ -77,6 +83,8 @@ class L1MuDTSectorReceiver {
   private:
 
     L1MuDTSectorProcessor& m_sp;
+    edm::EDGetTokenT<L1MuDTChambPhContainer> m_DTDigiToken;
+    edm::EDGetTokenT<CSCTriggerContainer<csctf::TrackStub> > m_CSCTrSToken;
 
     edm::ESHandle< L1MuDTTFParameters > pars;
     edm::ESHandle< L1MuDTTFMasks >      msks;

--- a/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.h
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTSectorReceiver.h
@@ -32,9 +32,10 @@
 // Collaborating Class Declarations --
 //------------------------------------
 
-#include <DataFormats/Common/interface/Handle.h>
-#include <FWCore/Framework/interface/ESHandle.h>
-#include <FWCore/Framework/interface/Event.h>
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/Event.h"
 class L1MuDTSectorProcessor;
 class L1MuDTTFParameters;
 class L1MuDTTFMasks;
@@ -48,7 +49,7 @@ class L1MuDTSectorReceiver {
   public:
 
     /// constructor
-    L1MuDTSectorReceiver(L1MuDTSectorProcessor& );
+    L1MuDTSectorReceiver(L1MuDTSectorProcessor&, edm::ConsumesCollector&& iC);
 
     /// destructor
     virtual ~L1MuDTSectorReceiver();

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTFSetup.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTFSetup.cc
@@ -44,7 +44,7 @@ using namespace std;
 
 L1MuDTTFSetup::L1MuDTTFSetup(const edm::ParameterSet & ps, edm::ConsumesCollector && iC) : m_tf(new L1MuDTTrackFinder(ps,std::move(iC))) {
   // setup  the barrel Muon Trigger Track Finder
-  m_tf->setup(); 
+  m_tf->setup(std::move(iC)); 
 
 }
 

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -110,7 +110,7 @@ L1MuDTTrackFinder::~L1MuDTTrackFinder() {
 //
 // setup MTTF configuration
 //
-void L1MuDTTrackFinder::setup() {
+void L1MuDTTrackFinder::setup( edm::ConsumesCollector&& iC) {
 
   // build the barrel Muon Trigger Track Finder
 
@@ -123,7 +123,7 @@ void L1MuDTTrackFinder::setup() {
     if ( wh == 0 ) continue;
     for ( int sc = 0; sc < 12; sc++ ) {
       L1MuDTSecProcId tmpspid(wh,sc);
-      L1MuDTSectorProcessor* sp = new L1MuDTSectorProcessor(*this,tmpspid);
+      L1MuDTSectorProcessor* sp = new L1MuDTSectorProcessor(*this,tmpspid,std::move(iC));
       if ( L1MuDTTFConfig::Debug(2) ) cout << "creating " << tmpspid << endl;
       m_spmap->insert(tmpspid,sp);
     }
@@ -131,7 +131,7 @@ void L1MuDTTrackFinder::setup() {
  
   // create new eta processors and wedge sorters
   for ( int sc = 0; sc < 12; sc++ ) {
-    L1MuDTEtaProcessor* ep = new L1MuDTEtaProcessor(*this,sc);
+    L1MuDTEtaProcessor* ep = new L1MuDTEtaProcessor(*this,sc,std::move(iC));
     if ( L1MuDTTFConfig::Debug(2) ) cout << "creating Eta Processor " << sc << endl;
     m_epvec.push_back(ep);
     L1MuDTWedgeSorter* ws = new L1MuDTWedgeSorter(*this,sc);

--- a/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
+++ b/L1Trigger/DTTrackFinder/src/L1MuDTTrackFinder.cc
@@ -69,7 +69,7 @@ L1MuDTTrackFinder::L1MuDTTrackFinder(const edm::ParameterSet & ps,edm::ConsumesC
   _cache.reserve(4*17);
   _cache0.reserve(144*17);
 
-  iC.consumes<L1MuDTChambPhContainer>(L1MuDTTFConfig::getDTDigiInputTag());
+  m_DTDigiToken = iC.consumes<L1MuDTChambPhContainer>(L1MuDTTFConfig::getDTDigiInputTag());
 }
 
 
@@ -154,7 +154,7 @@ void L1MuDTTrackFinder::run(const edm::Event& e, const edm::EventSetup& c) {
   // run the barrel Muon Trigger Track Finder
 
   edm::Handle<L1MuDTChambPhContainer> dttrig;
-  e.getByLabel(L1MuDTTFConfig::getDTDigiInputTag(),dttrig);
+  e.getByToken(m_DTDigiToken,dttrig);
   if ( dttrig->getContainer()->size() == 0 ) return;
 
   if ( L1MuDTTFConfig::Debug(2) ) cout << endl;


### PR DESCRIPTION
The consumes interface  in package  L1Trigger/DTTrackFinder was previously only implemented for one of the four getByLabel calls in the package.  This pull request implements the consumes interface for the remaining getByLabel calls.
