### PR TITLE
Switching to stream producers for JME Packages

### DIFF
--- a/JetMETCorrections/Modules/interface/JetCorrectionProducer.h
+++ b/JetMETCorrections/Modules/interface/JetCorrectionProducer.h
@@ -9,7 +9,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/Ref.h"
 #include "DataFormats/Common/interface/RefToBase.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -28,7 +28,7 @@ class JetCorrector;
 namespace cms
 {
   template<class T>
-  class JetCorrectionProducer : public edm::EDProducer
+  class JetCorrectionProducer : public edm::stream::EDProducer<>
   {
   public:
     typedef std::vector<T> JetCollection;

--- a/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.h
+++ b/RecoLocalCalo/CaloTowersCreator/src/CaloTowersCreator.h
@@ -1,7 +1,7 @@
 #ifndef RECOLOCALCALO_CALOTOWERSCREATOR_CALOTOWERSCREATOR_H
 #define RECOLOCALCALO_CALOTOWERSCREATOR_CALOTOWERSCREATOR_H 1
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESWatcher.h"
 #include "DataFormats/Common/interface/Handle.h"
@@ -22,7 +22,7 @@
 // rejected hists as well: requested by the MET group
 // for studies of the effect of noise clean up.
 
-class CaloTowersCreator : public edm::EDProducer {
+class CaloTowersCreator : public  edm::stream::EDProducer<> {
 public:
   explicit CaloTowersCreator(const edm::ParameterSet& ps);
   virtual ~CaloTowersCreator() { }

--- a/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
+++ b/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
@@ -20,7 +20,7 @@
 // user include files
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -42,7 +42,7 @@ namespace reco {
   // class declaration
   //
   
-  class HcalNoiseInfoProducer : public edm::EDProducer {
+  class HcalNoiseInfoProducer : public edm::stream::EDProducer<> {
   public:
     explicit HcalNoiseInfoProducer(const edm::ParameterSet&);
     ~HcalNoiseInfoProducer();


### PR DESCRIPTION
As per conversations with TSG, a few JME modules are still not compliant with multithreading. Here are several modules using the legacy producer instead of the stream producers. 
