### PR TITLE
Tests for enum use in cutParser

### DIFF
--- a/CommonTools/Utils/test/BuildFile.xml
+++ b/CommonTools/Utils/test/BuildFile.xml
@@ -9,3 +9,7 @@
   <use   name="CommonTools/Utils"/>
   <use   name="cppunit"/>
 </bin>
+<bin name="testCommonToolsUtilThreaded" file="testCutParserThreaded.cc">
+  <use   name="DataFormats/TrackReco"/>
+  <use   name="CommonTools/Utils"/>
+</bin>

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -229,7 +229,7 @@ void testCutParser::checkAll() {
   CPPUNIT_ASSERT_THROW((*sel)(o), reco::parser::Exception);                     // it throws wen called
 
   sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')",sel, false), edm::Exception);
+  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')",sel, false), cms::Exception);
 
   // check hits (for re-implemented virtual functions and exception handling)
   CPPUNIT_ASSERT(hitOk.hasPositionAndError());

--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -108,7 +108,7 @@ void testCutParser::checkAll() {
                  1.5, 2.5, 3.5, 4.5, 5.5 };
   reco::TrackBase::CovarianceMatrix cov(e, e + 15);
   trk = reco::Track(chi2, ndof, v, p, -1, cov);
-
+  trk.setQuality(reco::Track::highPurity);
 
   GlobalPoint gp(0,0,0);
   BoundPlane* plane = new BoundPlane( gp, Surface::RotationType());
@@ -180,6 +180,15 @@ void testCutParser::checkAll() {
   check( "test_bit(4, 2)", true  );
   check( "test_bit(4, 3)", false );
 
+  // check quality
+  check("quality('highPurity')", true );
+  check("quality('loose')", false );
+  check("quality('tight')", false );
+  check("quality('confirmed')", false );
+  check("quality('goodIterative')", true);
+  check("quality('looseSetWithPV')", false);
+  check("quality('highPuritySetWithPV')", false);
+
   // check handling of errors 
   //   first those who are the same in lazy and non lazy parsing
   for (int lazy = 0; lazy <= 1; ++lazy) {
@@ -219,6 +228,8 @@ void testCutParser::checkAll() {
   CPPUNIT_ASSERT(reco::parser::cutParser<reco::Track>("pt.pt < 1",sel, true));  // same for this
   CPPUNIT_ASSERT_THROW((*sel)(o), reco::parser::Exception);                     // it throws wen called
 
+  sel.reset();
+  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')",sel, false), edm::Exception);
 
   // check hits (for re-implemented virtual functions and exception handling)
   CPPUNIT_ASSERT(hitOk.hasPositionAndError());

--- a/CommonTools/Utils/test/testCutParserThreaded.cc
+++ b/CommonTools/Utils/test/testCutParserThreaded.cc
@@ -1,0 +1,94 @@
+#include "CommonTools/Utils/interface/cutParser.h"
+#include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "TThread.h"
+#include "TObject.h"
+#include "TVirtualStreamerInfo.h"
+
+#include <thread>
+#include <atomic>
+#include <iostream>
+#include <string>
+
+namespace {
+  class Decrementer {
+  public:
+    Decrementer(std::atomic<int>& iValue): value_(iValue), dec_(true) {}
+    ~Decrementer() {
+      if(dec_) { --value_;}
+    }
+
+    void decrement() {
+      --value_;
+      dec_=false;
+    }
+
+  private:
+    std::atomic<int>& value_;
+    bool dec_;
+  };
+}
+
+int main() {
+
+  constexpr int kNThreads = 30;
+  std::atomic<int> canStart{kNThreads};
+  std::atomic<int> canStartEval{kNThreads};
+  std::atomic<bool> failed{false};
+  std::vector<std::thread> threads;
+
+  TThread::Initialize();
+  //When threading, also have to keep ROOT from logging all TObjects into a list
+  TObject::SetObjectStat(false);
+  
+  //Have to avoid having Streamers modify themselves after they have been used
+  TVirtualStreamerInfo::Optimize(false);
+
+
+  for(int i=0; i<kNThreads; ++i) {
+    threads.emplace_back([i,&canStart,&canStartEval,&failed]() {
+        try {
+          static thread_local TThread guard;
+          reco::Track trk(20., 20., reco::Track::Point(), reco::Track::Vector(1.,1.,1.), +1, reco::Track::CovarianceMatrix{});
+          trk.setQuality(reco::Track::highPurity);
+          std::string const cut( " pt >= 1 & quality('highPurity') ");
+          //std::cout <<cut<<std::endl;
+          bool const lazy = true;
+          
+          --canStart;
+          while( canStart > 0 ) {}
+
+          //need to make sure canStartEval is decremented even if we have an exception
+          Decrementer decCanStartEval(canStartEval);
+
+          StringCutObjectSelector<reco::Track> select(cut, lazy);
+
+          decCanStartEval.decrement();
+
+          while( canStartEval > 0 ) {}
+          if( not select(trk) ) {
+            std::cout <<"selection failed"<<std::endl;
+            failed = true;
+          }
+        } catch(cms::Exception const& exception) {
+          std::cout <<exception.what()<<std::endl;
+          failed = true;
+        }
+      });
+  }
+  canStart = true;
+  
+  for(auto& thread: threads) {
+    thread.join();
+  }
+  
+  if(failed) {
+    std::cout <<"FAILED"<<std::endl;
+    return 1;
+  }
+
+  std::cout <<"OK"<<std::endl;
+  return 0;
+}

--- a/CommonTools/Utils/test/testCutParserThreaded.cc
+++ b/CommonTools/Utils/test/testCutParserThreaded.cc
@@ -7,6 +7,8 @@
 #include "TObject.h"
 #include "TVirtualStreamerInfo.h"
 
+#include "Cintex/Cintex.h"
+
 #include <thread>
 #include <atomic>
 #include <iostream>
@@ -38,6 +40,8 @@ int main() {
   std::atomic<int> canStartEval{kNThreads};
   std::atomic<bool> failed{false};
   std::vector<std::thread> threads;
+
+  ROOT::Cintex::Cintex::Enable();
 
   TThread::Initialize();
   //When threading, also have to keep ROOT from logging all TObjects into a list


### PR DESCRIPTION
If I run with multiple threads in the ROOT6  we get an intermittent failure from the cutParser. This problem was traced back to TEnum not being thread safe. The test added by this pull request replicates the circumstances of the failure. This test will be useful for monitoring the thread safety of the cutParser for both ROOT 5 and 6.
