### PR TITLE
Add consumes interface for ObjectViewCleaner

### DIFF
--- a/Validation/RecoTau/plugins/ObjectViewCleaner.cc
+++ b/Validation/RecoTau/plugins/ObjectViewCleaner.cc
@@ -96,6 +96,11 @@ ObjectViewCleaner<T>::ObjectViewCleaner(const edm::ParameterSet& iConfig)
   , nObjectsClean_(0)
 {
   produces<edm::RefToBaseVector<T> >();
+  edm::Handle<edm::View<T> > candidates;
+  consumes<edm::View<T> >(srcCands_);
+  for (auto const& object : srcObjects_) {
+    consumes<edm::View<reco::Candidate> >(object);
+  }
 }
 
 
@@ -125,9 +130,9 @@ void ObjectViewCleaner<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSe
   bool* isClean = new bool[candidates->size()];
   for (unsigned int iObject=0;iObject<candidates->size();iObject++) isClean[iObject] = true;
   
-  for (unsigned int iSrc=0;iSrc<srcObjects_.size();iSrc++) {
+  for (auto const& object : srcObjects_) {
     edm::Handle<edm::View<reco::Candidate> > objects;
-    iEvent.getByLabel(srcObjects_[iSrc],objects);
+    iEvent.getByLabel(object,objects);
     
     for (unsigned int iObject=0;iObject<candidates->size();iObject++) {
       const T& candidate = candidates->at(iObject);

--- a/Validation/RecoTau/plugins/ObjectViewCleaner.cc
+++ b/Validation/RecoTau/plugins/ObjectViewCleaner.cc
@@ -25,6 +25,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
 #include "DataFormats/Common/interface/View.h"
@@ -45,7 +46,6 @@
 #include <vector>
 #include <sstream>
 
-
 ////////////////////////////////////////////////////////////////////////////////
 // class definition
 ////////////////////////////////////////////////////////////////////////////////
@@ -63,8 +63,8 @@ public:
 
 private:  
   // member data
-  edm::InputTag              srcCands_;
-  std::vector<edm::InputTag> srcObjects_;
+  edm::EDGetTokenT<edm::View<T> >                             srcCands_;
+  std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > srcObjects_;
   double                     deltaRMin_;
   
   std::string  moduleLabel_;
@@ -86,8 +86,8 @@ using namespace std;
 //______________________________________________________________________________
 template<typename T>
 ObjectViewCleaner<T>::ObjectViewCleaner(const edm::ParameterSet& iConfig)
-  : srcCands_    (iConfig.getParameter<edm::InputTag>         ("srcObject"))
-  , srcObjects_ (iConfig.getParameter<vector<edm::InputTag> >("srcObjectsToRemove"))
+  : srcCands_   (consumes<edm::View<T> >(iConfig.getParameter<edm::InputTag>         ("srcObject")))
+  , srcObjects_ ()
   , deltaRMin_  (iConfig.getParameter<double>                ("deltaRMin"))
   , moduleLabel_(iConfig.getParameter<string>                ("@module_label"))
   , objKeepCut_(iConfig.existsAs<std::string>("srcObjectSelection") ? iConfig.getParameter<std::string>("srcObjectSelection") : "", true)
@@ -96,10 +96,10 @@ ObjectViewCleaner<T>::ObjectViewCleaner(const edm::ParameterSet& iConfig)
   , nObjectsClean_(0)
 {
   produces<edm::RefToBaseVector<T> >();
-  edm::Handle<edm::View<T> > candidates;
-  consumes<edm::View<T> >(srcCands_);
-  for (auto const& object : srcObjects_) {
-    consumes<edm::View<reco::Candidate> >(object);
+  std::vector<edm::InputTag> srcTags = iConfig.getParameter<vector<edm::InputTag> >("srcObjectsToRemove");
+  srcObjects_.reserve(srcTags.size());
+  for (auto const& tag : srcTags) {
+    srcObjects_.emplace_back(consumes<edm::View<reco::Candidate> >(tag));
   }
 }
 
@@ -125,14 +125,14 @@ void ObjectViewCleaner<T>::produce(edm::Event& iEvent,const edm::EventSetup& iSe
     cleanObjects(new edm::RefToBaseVector<T >());
 
   edm::Handle<edm::View<T> > candidates;
-  iEvent.getByLabel(srcCands_,candidates);
+  iEvent.getByToken(srcCands_,candidates);
   
   bool* isClean = new bool[candidates->size()];
   for (unsigned int iObject=0;iObject<candidates->size();iObject++) isClean[iObject] = true;
   
   for (auto const& object : srcObjects_) {
     edm::Handle<edm::View<reco::Candidate> > objects;
-    iEvent.getByLabel(object,objects);
+    iEvent.getByToken(object,objects);
     
     for (unsigned int iObject=0;iObject<candidates->size();iObject++) {
       const T& candidate = candidates->at(iObject);


### PR DESCRIPTION
Add the consumes interface for ObjectViewCleaner
Also changed one loop to a range for loop for consistency, clarity and maintainability.
