### PR TITLE
Remove HCAL filters related customization from Reconstruction_Data_cff.py

### DIFF
--- a/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
+++ b/Configuration/StandardSequences/python/Reconstruction_Data_cff.py
@@ -35,9 +35,5 @@ particleFlowRecHitHF.producers[0].qualityTests.append(
         )
     )
 )
-import RecoLocalCalo.HcalRecAlgos.RemoveAddSevLevel as HcalRemoveAddSevLevel
-HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HFDigiTime",11)
-HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHEFlatNoise",12)
-HcalRemoveAddSevLevel.AddFlag(hcalRecAlgos,"HBHESpikeNoise",12)
 
 CSCHaloData.ExpectedBX = cms.int32(3)


### PR DESCRIPTION
Remove HCAL filters related customization from Reconstruction_Data_cff.py. The filters are not ready for 25ns yet.
After discussion with HCAL noise group experts, four lines of configuration are removed.
Full tests using "runTheMatrix.py -s --useInput all" show:
10 10 9 7 6 tests passed, 0 0 0 0 0 failed
