### PR TITLE
Add softdrop normalization parameter

### DIFF
--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -133,7 +133,8 @@ ak8PFJetsCHSTrimmed = ak5PFJetsCHSTrimmed.clone(
 
 ak8PFJetsCHSSoftDrop = ak5PFJetsCHSSoftDrop.clone(
     rParam = 0.8,
-    jetPtMin = 100.0
+    jetPtMin = 100.0,
+    R0 = 100.0
     )
 
 

--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -134,7 +134,7 @@ ak8PFJetsCHSTrimmed = ak5PFJetsCHSTrimmed.clone(
 ak8PFJetsCHSSoftDrop = ak5PFJetsCHSSoftDrop.clone(
     rParam = 0.8,
     jetPtMin = 100.0,
-    R0 = 100.0
+    R0 = 0.8
     )
 
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -75,7 +75,8 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     RcutFactor_(-1.0),
     csRho_EtaMax_(-1.0),
     csRParam_(-1.0),
-    beta_(-1.0)
+    beta_(-1.0),
+    R0_(-1.0)
 {
 
   if ( iConfig.exists("UseOnlyVertexTracks") )
@@ -142,6 +143,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
     csRho_EtaMax_ = -1.0;
     csRParam_ = -1.0;
     beta_ = -1.0;
+    R0_ = -1.0;
     useExplicitGhosts_ = true;
 
     if ( iConfig.exists("useMassDropTagger") ) {
@@ -207,6 +209,7 @@ FastjetJetProducer::FastjetJetProducer(const edm::ParameterSet& iConfig)
       useSoftDrop_ = iConfig.getParameter<bool>("useSoftDrop");
       zCut_ = iConfig.getParameter<double>("zcut");
       beta_ = iConfig.getParameter<double>("beta");
+      R0_ = iConfig.getParameter<double>("R0");
     }
 
   }
@@ -455,7 +458,7 @@ void FastjetJetProducer::runAlgorithm( edm::Event & iEvent, edm::EventSetup cons
     }
 
     if ( useSoftDrop_ ) {
-      fastjet::contrib::SoftDrop * sd = new fastjet::contrib::SoftDrop(beta_, zCut_ );
+      fastjet::contrib::SoftDrop * sd = new fastjet::contrib::SoftDrop(beta_, zCut_, R0_ );
       transformers.push_back( transformer_ptr(sd) );
     }
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.h
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.h
@@ -96,6 +96,7 @@ protected:
   double csRho_EtaMax_;       /// for constituent subtraction : maximum rapidity for ghosts
   double csRParam_;           /// for constituent subtraction : R parameter for KT alg in jet median background estimator
   double beta_;               /// for soft drop : beta (angular exponent)
+  double R0_;                 /// for soft drop : R0 (angular distance normalization - should be set to jet radius in most cases)
 
 
   double subjetPtMin_;        /// for CMSBoostedTauSeedingAlgorithm : subjet pt min

--- a/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak4PFJetsSoftDrop_cfi.py
@@ -8,6 +8,7 @@ ak4PFJetsSoftDrop = ak4PFJets.clone(
     useSoftDrop = cms.bool(True),
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
+    R0   = cms.double(0.4),
     useExplicitGhosts = cms.bool(True),
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")

--- a/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
+++ b/RecoJets/JetProducers/python/ak5PFJetsSoftDrop_cfi.py
@@ -8,6 +8,7 @@ ak5PFJetsSoftDrop = ak5PFJets.clone(
     useSoftDrop = cms.bool(True),
     zcut = cms.double(0.1),
     beta = cms.double(0.0),
+    R0   = cms.double(0.5),
     useExplicitGhosts = cms.bool(True),
     writeCompound = cms.bool(True),
     jetCollInstanceName=cms.string("SubJets")


### PR DESCRIPTION
The soft drop groomer requires three parameters:
https://github.com/cms-externals/fastjet-contrib/blob/master/RecursiveTools/SoftDrop.hh
/// \param beta the value of the beta parameter
/// \param symmetry_cut the value of the cut on the symmetry measure (zcut)
/// \param R0 the angular distance normalisation [1 by default]

By default R0 is set to 1, but ideally it should be set to the jet radius. See equation 1 here:
http://arxiv.org/pdf/1402.2657v2.pdf

The initial CMSSW implementation only included beta and zcut. I've added the R0 parameter and set it to the jet radius for ak8PFJetsCHSSoftDrop, ak4PFJetsSoftDrop, and ak5PFJetsSoftDrop.
