### PR TITLE
Fix issues reported by static analyzer in tracking related code

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/src/TrackCleaner.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/TrackCleaner.cc
@@ -110,7 +110,7 @@ bool TrackCleaner::isCompatible(const DetId & i1,
     if(tTopo->pxbLayer(i1) != tTopo->pxbLayer(i2)) return true;
 
     int dphi = abs(int(tTopo->pxbLadder(i1) - tTopo->pxbLadder(i2)));
-    static int max[3] = {20, 32, 44};
+    constexpr int max[3] = {20, 32, 44};
     if(dphi > max[tTopo->pxbLayer(i1)-1] / 2) dphi = max[tTopo->pxbLayer(i1)-1] - dphi;
 
     int dz   = abs(int(tTopo->pxbModule(i1) - tTopo->pxbModule(i2)));
@@ -124,7 +124,7 @@ bool TrackCleaner::isCompatible(const DetId & i1,
        tTopo->pxfDisk(i1) != tTopo->pxfDisk(i2)) return true;
 
     int dphi = abs(int(tTopo->pxfBlade(i1) - tTopo->pxfBlade(i2)));
-    static int max = 24;
+    constexpr int max = 24;
     if(dphi > max / 2) dphi = max - dphi;
 
     int dr   = abs(int( ((tTopo->pxfModule(i1)-1) * 2 + (tTopo->pxfPanel(i1)-1)) -

--- a/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
+++ b/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.cc
@@ -1,27 +1,38 @@
 #include "RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.h"
-#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
 using namespace std;
 using namespace edm;
 
 
 // constructors and destructor
-TrackAlgoCompareUtil::TrackAlgoCompareUtil(const edm::ParameterSet& iConfig)
+TrackAlgoCompareUtil::TrackAlgoCompareUtil(const edm::ParameterSet& iConfig):
+  trackLabel_algoA(consumes<View<reco::Track>>(iConfig.getParameter<edm::InputTag>("trackLabel_algoA"))),
+  trackLabel_algoB(consumes<View<reco::Track>>(iConfig.getParameter<edm::InputTag>("trackLabel_algoB"))),
+  trackingParticleLabel_fakes(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticleLabel_fakes"))),
+  trackingParticleLabel_effic(consumes<TrackingParticleCollection>(iConfig.getParameter<edm::InputTag>("trackingParticleLabel_effic"))),
+  beamSpotLabel(consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamSpotLabel"))),
+  UseAssociators(iConfig.getParameter< bool >("UseAssociators")),
+  UseVertex(iConfig.getParameter< bool >("UseVertex"))
 {
     //now do what ever other initialization is needed
-    trackLabel_algoA = iConfig.getParameter<edm::InputTag>("trackLabel_algoA");
-    trackLabel_algoB = iConfig.getParameter<edm::InputTag>("trackLabel_algoB");
-    trackingParticleLabel_fakes = iConfig.getParameter<edm::InputTag>("trackingParticleLabel_fakes");
-    trackingParticleLabel_effic = iConfig.getParameter<edm::InputTag>("trackingParticleLabel_effic");
-    vertexLabel_algoA = iConfig.getParameter<edm::InputTag>("vertexLabel_algoA");
-    vertexLabel_algoB = iConfig.getParameter<edm::InputTag>("vertexLabel_algoB");
-    beamSpotLabel = iConfig.getParameter<edm::InputTag>("beamSpotLabel");
-    assocLabel_algoA = iConfig.getUntrackedParameter<std::string>("assocLabel_algoA", "trackAssociatorByHits");
-    assocLabel_algoB = iConfig.getUntrackedParameter<std::string>("assocLabel_algoB", "trackAssociatorByHits");
-    associatormap_algoA = iConfig.getParameter< edm::InputTag >("associatormap_algoA");
-    associatormap_algoB = iConfig.getParameter< edm::InputTag >("associatormap_algoB");
-    UseAssociators = iConfig.getParameter< bool >("UseAssociators");
-    UseVertex = iConfig.getParameter< bool >("UseVertex");
+  if(UseVertex) {
+    vertexLabel_algoA = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexLabel_algoA"));
+    vertexLabel_algoB = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexLabel_algoB"));
+  }
+
+  if(UseAssociators) {
+    assocLabel_algoA = consumes<reco::TrackToTrackingParticleAssociator>(iConfig.getUntrackedParameter<std::string>("assocLabel_algoA", "trackAssociatorByHits"));
+    assocLabel_algoB = consumes<reco::TrackToTrackingParticleAssociator>(iConfig.getUntrackedParameter<std::string>("assocLabel_algoB", "trackAssociatorByHits"));
+  }
+  else {
+    edm::InputTag algoA = iConfig.getParameter< edm::InputTag >("associatormap_algoA");
+    edm::InputTag algoB = iConfig.getParameter< edm::InputTag >("associatormap_algoB");
+
+    associatormap_algoA_recoToSim = consumes<reco::RecoToSimCollection>(algoA);
+    associatormap_algoB_recoToSim = consumes<reco::RecoToSimCollection>(algoB);
+    associatormap_algoA_simToReco = consumes<reco::SimToRecoCollection>(algoA);
+    associatormap_algoB_simToReco = consumes<reco::SimToRecoCollection>(algoB);
+  }
   
     produces<RecoTracktoTPCollection>("AlgoA");
     produces<RecoTracktoTPCollection>("AlgoB");
@@ -34,15 +45,9 @@ TrackAlgoCompareUtil::~TrackAlgoCompareUtil()
 }
 
 
-// ------------ method called once each job just before starting event loop  ------------
-void TrackAlgoCompareUtil::beginJob()
-{
-}
-
-
 // ------------ method called to produce the data  ------------
 void
-TrackAlgoCompareUtil::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+TrackAlgoCompareUtil::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
      // create output collection instance
     std::auto_ptr<RecoTracktoTPCollection> outputAlgoA(new RecoTracktoTPCollection());
@@ -51,27 +56,27 @@ TrackAlgoCompareUtil::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   
     // Get Inputs
     edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
-    iEvent.getByLabel(beamSpotLabel, recoBeamSpotHandle);
+    iEvent.getByToken(beamSpotLabel, recoBeamSpotHandle);
     reco::BeamSpot beamSpot = *recoBeamSpotHandle; 
   
     edm::Handle<View<reco::Track> > trackCollAlgoA;
-    iEvent.getByLabel(trackLabel_algoA, trackCollAlgoA);
+    iEvent.getByToken(trackLabel_algoA, trackCollAlgoA);
   
     edm::Handle< View<reco::Track> > trackCollAlgoB;
-    iEvent.getByLabel(trackLabel_algoB, trackCollAlgoB);
+    iEvent.getByToken(trackLabel_algoB, trackCollAlgoB);
   
     edm::Handle<TrackingParticleCollection> trackingParticleCollFakes;
-    iEvent.getByLabel(trackingParticleLabel_fakes, trackingParticleCollFakes);
+    iEvent.getByToken(trackingParticleLabel_fakes, trackingParticleCollFakes);
   
     edm::Handle<TrackingParticleCollection> trackingParticleCollEffic;
-    iEvent.getByLabel(trackingParticleLabel_effic, trackingParticleCollEffic);
+    iEvent.getByToken(trackingParticleLabel_effic, trackingParticleCollEffic);
   
     edm::Handle<reco::VertexCollection> vertexCollAlgoA;
     edm::Handle<reco::VertexCollection> vertexCollAlgoB;
     if(UseVertex) 
     {
-        iEvent.getByLabel(vertexLabel_algoA, vertexCollAlgoA);
-        iEvent.getByLabel(vertexLabel_algoB, vertexCollAlgoB);
+        iEvent.getByToken(vertexLabel_algoA, vertexCollAlgoA);
+        iEvent.getByToken(vertexLabel_algoB, vertexCollAlgoB);
     }
   
     // call the associator functions:
@@ -84,10 +89,10 @@ TrackAlgoCompareUtil::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     if(UseAssociators)
     {
         edm::Handle<reco::TrackToTrackingParticleAssociator> theAssociator_algoA;
-        iEvent.getByLabel(assocLabel_algoA, theAssociator_algoA);
+        iEvent.getByToken(assocLabel_algoA, theAssociator_algoA);
   
         edm::Handle<reco::TrackToTrackingParticleAssociator> theAssociator_algoB;
-        iEvent.getByLabel(assocLabel_algoB, theAssociator_algoB);
+        iEvent.getByToken(assocLabel_algoB, theAssociator_algoB);
   
         recSimColl_AlgoA = theAssociator_algoA->associateRecoToSim(trackCollAlgoA, trackingParticleCollFakes);
         recSimColl_AlgoB = theAssociator_algoB->associateRecoToSim(trackCollAlgoB, trackingParticleCollFakes);
@@ -98,19 +103,19 @@ TrackAlgoCompareUtil::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     else
     {
         Handle<reco::RecoToSimCollection > recotosimCollectionH_AlgoA;
-        iEvent.getByLabel(associatormap_algoA,recotosimCollectionH_AlgoA);
+        iEvent.getByToken(associatormap_algoA_recoToSim,recotosimCollectionH_AlgoA);
         recSimColl_AlgoA  = *(recotosimCollectionH_AlgoA.product());
         
         Handle<reco::RecoToSimCollection > recotosimCollectionH_AlgoB;
-        iEvent.getByLabel(associatormap_algoB,recotosimCollectionH_AlgoB);
+        iEvent.getByToken(associatormap_algoB_recoToSim,recotosimCollectionH_AlgoB);
         recSimColl_AlgoB  = *(recotosimCollectionH_AlgoB.product());
         
         Handle<reco::SimToRecoCollection > simtorecoCollectionH_AlgoA;
-        iEvent.getByLabel(associatormap_algoA, simtorecoCollectionH_AlgoA);
+        iEvent.getByToken(associatormap_algoA_simToReco, simtorecoCollectionH_AlgoA);
         simRecColl_AlgoA = *(simtorecoCollectionH_AlgoA.product());
 
         Handle<reco::SimToRecoCollection > simtorecoCollectionH_AlgoB;
-        iEvent.getByLabel(associatormap_algoB, simtorecoCollectionH_AlgoB);
+        iEvent.getByToken(associatormap_algoB_simToReco, simtorecoCollectionH_AlgoB);
         simRecColl_AlgoB = *(simtorecoCollectionH_AlgoB.product());
     }
     
@@ -263,14 +268,8 @@ TrackAlgoCompareUtil::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     iEvent.put(outputTP, "TP");
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void TrackAlgoCompareUtil::endJob() 
-{
-}
-
-
 // ------------ Producer Specific Meber Fucntions ----------------------------------------
-void TrackAlgoCompareUtil::SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, TPtoRecoTrack& TPRT)
+void TrackAlgoCompareUtil::SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, TPtoRecoTrack& TPRT) const
 {
     GlobalPoint trackingParticleVertex( tp->vertex().x(), tp->vertex().y(), tp->vertex().z() );
     GlobalVector trackingParticleP3(tp->g4Track_begin()->momentum().x(),
@@ -298,7 +297,7 @@ void TrackAlgoCompareUtil::SetTrackingParticleD0Dz(TrackingParticleRef tp, const
 }
 
 
-void TrackAlgoCompareUtil::SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, RecoTracktoTP& RTTP)
+void TrackAlgoCompareUtil::SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, RecoTracktoTP& RTTP) const
 {
     GlobalPoint trackingParticleVertex( tp->vertex().x(), tp->vertex().y(), tp->vertex().z() );
     GlobalVector trackingParticleP3(tp->g4Track_begin()->momentum().x(),

--- a/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.h
+++ b/RecoTracker/DebugTools/plugins/TrackAlgoCompareUtil.h
@@ -6,7 +6,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -23,6 +23,7 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertex.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingVertexContainer.h"
+#include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 #include "CommonTools/RecoAlgos/interface/RecoTrackSelector.h"
 //#include "CommonTools/RecoAlgos/interface/TrackingParticleSelector.h"
 #include "DataFormats/BeamSpot/interface/BeamSpot.h"
@@ -51,7 +52,7 @@
 
 
 
-class TrackAlgoCompareUtil : public edm::EDProducer 
+class TrackAlgoCompareUtil : public edm::global::EDProducer<>
 {
  public:
    
@@ -60,28 +61,27 @@ class TrackAlgoCompareUtil : public edm::EDProducer
   
  private:
   
-  virtual void beginJob();
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob();
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
   
-  void SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, TPtoRecoTrack& TPRT);
-  void SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, RecoTracktoTP& RTTP);
+  void SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, TPtoRecoTrack& TPRT) const;
+  void SetTrackingParticleD0Dz(TrackingParticleRef tp, const reco::BeamSpot &bs, const MagneticField *bf, RecoTracktoTP& RTTP) const;
       
   // ----------member data ---------------------------
-  edm::InputTag trackLabel_algoA;
-  edm::InputTag trackLabel_algoB;
-  edm::InputTag trackingParticleLabel_fakes;
-  edm::InputTag trackingParticleLabel_effic;
-  edm::InputTag vertexLabel_algoA;
-  edm::InputTag vertexLabel_algoB;
-  edm::InputTag trackingVertexLabel;
-  edm::InputTag beamSpotLabel;
-  edm::InputTag associatormap_algoA;
-  edm::InputTag associatormap_algoB;
-  bool UseAssociators;
-  bool UseVertex;
-  std::string assocLabel_algoA;     
-  std::string assocLabel_algoB;     
+  edm::EDGetTokenT<edm::View<reco::Track>> trackLabel_algoA;
+  edm::EDGetTokenT<edm::View<reco::Track>> trackLabel_algoB;
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleLabel_fakes;
+  edm::EDGetTokenT<TrackingParticleCollection> trackingParticleLabel_effic;
+  edm::EDGetTokenT<reco::VertexCollection> vertexLabel_algoA;
+  edm::EDGetTokenT<reco::VertexCollection> vertexLabel_algoB;
+  edm::EDGetTokenT<reco::BeamSpot> beamSpotLabel;
+  edm::EDGetTokenT<reco::RecoToSimCollection> associatormap_algoA_recoToSim;
+  edm::EDGetTokenT<reco::RecoToSimCollection> associatormap_algoB_recoToSim;
+  edm::EDGetTokenT<reco::SimToRecoCollection> associatormap_algoA_simToReco;
+  edm::EDGetTokenT<reco::SimToRecoCollection> associatormap_algoB_simToReco;
+  edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> assocLabel_algoA;
+  edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> assocLabel_algoB;
+  const bool UseAssociators;
+  const bool UseVertex;
   
 };
 

--- a/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/CosmicTrackSplitter.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -75,7 +75,7 @@
  *     detsToIgnore        = individual list of detids on which hits must be discarded
  */
 namespace reco { namespace modules {
-	class CosmicTrackSplitter : public edm::EDProducer {
+       class CosmicTrackSplitter : public edm::stream::EDProducer<> {
     public:
 		CosmicTrackSplitter(const edm::ParameterSet &iConfig) ;
 		virtual void produce(edm::Event &iEvent, const edm::EventSetup &iSetup) override;

--- a/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/DuplicateTrackMerger.cc
@@ -45,7 +45,7 @@ using namespace reco;
 
        private:
 	 /// MVA discriminator
-	 GBRForest* forest_;
+	 const GBRForest* forest_;
 
 	 /// MVA input variables
 	 float tmva_ddsz_;
@@ -104,7 +104,7 @@ using namespace reco;
 #include "FWCore/Framework/interface/ESHandle.h" 
 #include "TFile.h"
 
-DuplicateTrackMerger::DuplicateTrackMerger(const edm::ParameterSet& iPara) : merger_(iPara)
+DuplicateTrackMerger::DuplicateTrackMerger(const edm::ParameterSet& iPara) : forest_(nullptr), gbrVals_(nullptr), merger_(iPara)
 {
   forestLabel_ = "MVADuplicate";
   useForestFromDB_ = true;
@@ -134,7 +134,6 @@ DuplicateTrackMerger::DuplicateTrackMerger(const edm::ParameterSet& iPara) : mer
   produces<std::vector<TrackCandidate> >("candidates");
   produces<CandidateToDuplicate>("candidateMap");
 
-  forest_ = 0;
   gbrVals_ = new float[9];
   dbFileName_ = "";
   if(iPara.exists("GBRForestLabel"))forestLabel_ = iPara.getParameter<std::string>("GBRForestLabel");
@@ -177,10 +176,10 @@ void DuplicateTrackMerger::produce(edm::Event& iEvent, const edm::EventSetup& iS
     if(useForestFromDB_){
       edm::ESHandle<GBRForest> forestHandle;
       iSetup.get<GBRWrapperRcd>().get(forestLabel_,forestHandle);
-      forest_ = (GBRForest*)forestHandle.product();
+      forest_ = forestHandle.product();
     }else{
       TFile gbrfile(dbFileName_.c_str());
-      forest_ = (GBRForest*)gbrfile.Get(forestLabel_.c_str());
+      forest_ = dynamic_cast<const GBRForest*>(gbrfile.Get(forestLabel_.c_str()));
     }
   }
 

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackerTrackHitFilter.cc
@@ -163,7 +163,7 @@ namespace reco {
 
 
 TrackerTrackHitFilter::Rule::Rule(const std::string &str) {
-    static boost::regex rule("(keep|drop)\\s+([A-Z]+)(\\s+(\\d+))?");
+    static const boost::regex rule("(keep|drop)\\s+([A-Z]+)(\\s+(\\d+))?");
     boost::cmatch match;
     std::string match_1;
     std::string match_2;
@@ -208,9 +208,9 @@ void TrackerTrackHitFilter::parseStoN(const std::string &str) {
   //followed b an arbitrary number of blanks, one or more digits (not necessary, they cannot also be,
   // another set of blank spaces and, again another *eventual* digit
   // static boost::regex rule("\\s+([A-Z]+)(\\s+(\\d+)(\\.)?(\\d+))?(\\s+(\\d+)(\\.)?(\\d+))?");
- static boost::regex rule("([A-Z]+)"
-			  "\\s*(\\d+\\.*\\d*)?"
-			  "\\s*(\\d+\\.*\\d*)?");
+ static const boost::regex rule("([A-Z]+)"
+                                "\\s*(\\d+\\.*\\d*)?"
+                                "\\s*(\\d+\\.*\\d*)?");
 
 
   boost::cmatch match;

--- a/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
+++ b/RecoTracker/MeasurementDet/plugins/TkGluedMeasurementDet.h
@@ -83,7 +83,7 @@ private:
     static bool filter() { return false;}   /// always fast as no estimator available here! 
     size_t size() const { return target_.size();}
 
-    static const MeasurementEstimator  & estimator() { static MeasurementEstimator * dummy=0; return *dummy;}
+    static const MeasurementEstimator  & estimator() { static const MeasurementEstimator * dummy=0; return *dummy;}
 
   private: 
     const GeomDet              * geomDet_;

--- a/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CRackTrajectoryBuilder.h
@@ -238,7 +238,6 @@ class CRackTrajectoryBuilder
  private:
    edm::ESHandle<MagneticField> magfield;
    edm::ESHandle<TrackerGeometry> tracker;
-   edm::ParameterSet conf_;
    
    PropagatorWithMaterial  *thePropagator;
    PropagatorWithMaterial  *thePropagatorOp;
@@ -264,6 +263,7 @@ class CRackTrajectoryBuilder
    TransientTrackingRecHit::RecHitContainer  hits;
    bool seed_plus;
    std::string geometry;
+   std::string theBuilderName;
 //   TransientInitialStateEstimator*  theInitialState;
 };
 

--- a/RecoTracker/SingleTrackPattern/interface/CosmicTrackFinder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CosmicTrackFinder.h
@@ -6,7 +6,7 @@
 // Original Author:  Michele Pioppi-INFN perugia
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -64,7 +64,7 @@ namespace cms
       return t1->chiSquared()< t2->chiSquared();  
     }
   };
-  class CosmicTrackFinder : public edm::EDProducer
+  class CosmicTrackFinder : public edm::stream::EDProducer<>
   {
 
     typedef TrajectoryStateOnSurface     TSOS;

--- a/RecoTracker/SingleTrackPattern/interface/CosmicTrajectoryBuilder.h
+++ b/RecoTracker/SingleTrackPattern/interface/CosmicTrajectoryBuilder.h
@@ -123,7 +123,6 @@ class CosmicTrajectoryBuilder
  private:
    edm::ESHandle<MagneticField> magfield;
    edm::ESHandle<TrackerGeometry> tracker;
-   edm::ParameterSet conf_;
    
    PropagatorWithMaterial  *thePropagator;
    PropagatorWithMaterial  *thePropagatorOp;
@@ -143,6 +142,7 @@ class CosmicTrajectoryBuilder
    TransientTrackingRecHit::RecHitContainer  hits;
    bool seed_plus;
    std::string geometry;
+   std::string theBuilderName;
 };
 
 #endif

--- a/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CRackTrajectoryBuilder.cc
@@ -29,20 +29,21 @@
 using namespace std;
 
 
-CRackTrajectoryBuilder::CRackTrajectoryBuilder(const edm::ParameterSet& conf) : conf_(conf) { 
+CRackTrajectoryBuilder::CRackTrajectoryBuilder(const edm::ParameterSet& conf) {
   //minimum number of hits per tracks
 
-  theMinHits=conf_.getParameter<int>("MinHits");
+  theMinHits=conf.getParameter<int>("MinHits");
   //cut on chi2
-  chi2cut=conf_.getParameter<double>("Chi2Cut");
+  chi2cut=conf.getParameter<double>("Chi2Cut");
   edm::LogInfo("CosmicTrackFinder")<<"Minimum number of hits "<<theMinHits<<" Cut on Chi2= "<<chi2cut;
 
-  debug_info=conf_.getUntrackedParameter<bool>("debug", false);
-  fastPropagation=conf_.getUntrackedParameter<bool>("fastPropagation", false);
-  useMatchedHits=conf_.getUntrackedParameter<bool>("useMatchedHits", true);
+  debug_info=conf.getUntrackedParameter<bool>("debug", false);
+  fastPropagation=conf.getUntrackedParameter<bool>("fastPropagation", false);
+  useMatchedHits=conf.getUntrackedParameter<bool>("useMatchedHits", true);
 
 
-  geometry=conf_.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+  geometry=conf.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+  theBuilderName = conf.getParameter<std::string>("TTRHBuilder");
 
   
 
@@ -55,7 +56,6 @@ CRackTrajectoryBuilder::~CRackTrajectoryBuilder() {
 
 
 void CRackTrajectoryBuilder::init(const edm::EventSetup& es, bool seedplus){
-
 
 //  edm::ParameterSet tise_params = conf_.getParameter<edm::ParameterSet>("TransientInitialStateEstimatorParameters") ;
 // theInitialState          = new TransientInitialStateEstimator( es,tise_params);
@@ -82,8 +82,7 @@ void CRackTrajectoryBuilder::init(const edm::EventSetup& es, bool seedplus){
   
 
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  std::string builderName = conf_.getParameter<std::string>("TTRHBuilder");   
-  es.get<TransientRecHitRecord>().get(builderName,theBuilder);
+  es.get<TransientRecHitRecord>().get(theBuilderName,theBuilder);
   
 
   RHBuilder=   theBuilder.product();

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrackFinder.cc
@@ -29,21 +29,20 @@ namespace cms
 
   CosmicTrackFinder::CosmicTrackFinder(edm::ParameterSet const& conf) : 
     cosmicTrajectoryBuilder_(conf) ,
-    crackTrajectoryBuilder_(conf) ,
-    conf_(conf)
+    crackTrajectoryBuilder_(conf)
   {
-    geometry=conf_.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+    geometry=conf.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
     useHitsSplitting_=conf.getParameter<bool>("useHitsSplitting");
     matchedrecHitsToken_ = consumes<SiStripMatchedRecHit2DCollection>(
-        conf_.getParameter<edm::InputTag>("matchedRecHits"));
+        conf.getParameter<edm::InputTag>("matchedRecHits"));
     rphirecHitsToken_ = consumes<SiStripRecHit2DCollection>(
-        conf_.getParameter<edm::InputTag>("rphirecHits"));
+        conf.getParameter<edm::InputTag>("rphirecHits"));
     stereorecHitsToken_ = consumes<SiStripRecHit2DCollection>(
-        conf_.getParameter<edm::InputTag>("stereorecHits"));
+        conf.getParameter<edm::InputTag>("stereorecHits"));
     pixelRecHitsToken_ = consumes<SiPixelRecHitCollection>(
-        conf_.getParameter<edm::InputTag>("pixelRecHits"));
+        conf.getParameter<edm::InputTag>("pixelRecHits"));
     seedToken_ = consumes<TrajectorySeedCollection>(
-        conf_.getParameter<edm::InputTag>("cosmicSeeds"));
+        conf.getParameter<edm::InputTag>("cosmicSeeds"));
 
     produces<TrackCandidateCollection>();
   }

--- a/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
+++ b/RecoTracker/SingleTrackPattern/src/CosmicTrajectoryBuilder.cc
@@ -18,15 +18,16 @@
 #include "TrackingTools/Records/interface/TransientRecHitRecord.h" 
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateWithArbitraryError.h"
 using namespace std;
-CosmicTrajectoryBuilder::CosmicTrajectoryBuilder(const edm::ParameterSet& conf) : conf_(conf) { 
+CosmicTrajectoryBuilder::CosmicTrajectoryBuilder(const edm::ParameterSet& conf) {
   //minimum number of hits per tracks
 
-  theMinHits=conf_.getParameter<int>("MinHits");
+  theMinHits=conf.getParameter<int>("MinHits");
   //cut on chi2
-  chi2cut=conf_.getParameter<double>("Chi2Cut");
+  chi2cut=conf.getParameter<double>("Chi2Cut");
   edm::LogInfo("CosmicTrackFinder")<<"Minimum number of hits "<<theMinHits<<" Cut on Chi2= "<<chi2cut;
 
-  geometry=conf_.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+  geometry=conf.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+  theBuilderName = conf.getParameter<std::string>("TTRHBuilder");
 }
 
 
@@ -59,8 +60,7 @@ void CosmicTrajectoryBuilder::init(const edm::EventSetup& es, bool seedplus){
   
 
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
-  std::string builderName = conf_.getParameter<std::string>("TTRHBuilder");   
-  es.get<TransientRecHitRecord>().get(builderName,theBuilder);
+  es.get<TransientRecHitRecord>().get(theBuilderName,theBuilder);
   
 
   RHBuilder=   theBuilder.product();

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedGenerator.h
@@ -9,7 +9,7 @@
 //                  to find TrackingSeeds.
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -20,7 +20,7 @@
 #include "RecoTracker/SpecialSeedGenerators/interface/ClusterChecker.h"
 
 
-class CosmicSeedGenerator : public edm::EDProducer
+class CosmicSeedGenerator : public edm::stream::EDProducer<>
 {
  public:
 

--- a/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedGenerator.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/CosmicSeedGenerator.h
@@ -31,7 +31,6 @@ class CosmicSeedGenerator : public edm::stream::EDProducer<>
   virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 
  private:
-  edm::ParameterSet conf_;
   SeedGeneratorForCosmics  cosmic_seed;
   ClusterChecker check;
   // get Inputs

--- a/RecoTracker/SpecialSeedGenerators/interface/SeedGeneratorForCosmics.h
+++ b/RecoTracker/SpecialSeedGenerators/interface/SeedGeneratorForCosmics.h
@@ -41,7 +41,6 @@ class SeedGeneratorForCosmics{
 	      const TrackingRegion& region);
  
  private:
-  edm::ParameterSet conf_;
   int32_t           maxSeeds_;
   GlobalTrackingRegion region;
   CosmicHitPairGenerator* thePairGenerator;

--- a/RecoTracker/SpecialSeedGenerators/src/CosmicSeedGenerator.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/CosmicSeedGenerator.cc
@@ -16,18 +16,18 @@
 
 using namespace std;
 CosmicSeedGenerator::CosmicSeedGenerator(edm::ParameterSet const& conf) : 
-  conf_(conf) ,cosmic_seed(conf),
+  cosmic_seed(conf),
   check(conf,consumesCollector())
 
  {
   edm::LogInfo ("CosmicSeedGenerator")<<"Enter the CosmicSeedGenerator";
   // get Inputs
   matchedrecHitsToken_ = consumes<SiStripMatchedRecHit2DCollection>(
-      conf_.getParameter<edm::InputTag>("matchedRecHits"));
+      conf.getParameter<edm::InputTag>("matchedRecHits"));
   rphirecHitsToken_ = consumes<SiStripRecHit2DCollection>(
-          conf_.getParameter<edm::InputTag>("rphirecHits"));
+          conf.getParameter<edm::InputTag>("rphirecHits"));
   stereorecHitsToken_ = consumes<SiStripRecHit2DCollection>(
-          conf_.getParameter<edm::InputTag>("stereorecHits"));
+          conf.getParameter<edm::InputTag>("stereorecHits"));
 
   produces<TrajectorySeedCollection>();
 }

--- a/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
+++ b/RecoTracker/SpecialSeedGenerators/src/SeedGeneratorForCosmics.cc
@@ -44,27 +44,26 @@ SeedGeneratorForCosmics::init(const SiStripRecHit2DCollection &collstereo,
 }
 
 SeedGeneratorForCosmics::SeedGeneratorForCosmics(edm::ParameterSet const& conf):
-  conf_(conf),
   maxSeeds_(conf.getParameter<int32_t>("maxSeeds"))
 {  
 
-  float ptmin=conf_.getParameter<double>("ptMin");
-  float originradius=conf_.getParameter<double>("originRadius");
-  float halflength=conf_.getParameter<double>("originHalfLength");
-  float originz=conf_.getParameter<double>("originZPosition");
-  seedpt = conf_.getParameter<double>("SeedPt");
+  float ptmin=conf.getParameter<double>("ptMin");
+  float originradius=conf.getParameter<double>("originRadius");
+  float halflength=conf.getParameter<double>("originHalfLength");
+  float originz=conf.getParameter<double>("originZPosition");
+  seedpt = conf.getParameter<double>("SeedPt");
 
-  builderName = conf_.getParameter<std::string>("TTRHBuilder");   
-  geometry=conf_.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
+  builderName = conf.getParameter<std::string>("TTRHBuilder");
+  geometry=conf.getUntrackedParameter<std::string>("GeometricStructure","STANDARD");
   region=GlobalTrackingRegion(ptmin,originradius,
  			      halflength,originz);
-  hitsforseeds=conf_.getUntrackedParameter<std::string>("HitsForSeeds","pairs");
+  hitsforseeds=conf.getUntrackedParameter<std::string>("HitsForSeeds","pairs");
   edm::LogInfo("SeedGeneratorForCosmics")<<" PtMin of track is "<<ptmin<< 
     " The Radius of the cylinder for seeds is "<<originradius <<"cm"  << " The set Seed Momentum" <<  seedpt;
 
   //***top-bottom
-  positiveYOnly=conf_.getParameter<bool>("PositiveYOnly");
-  negativeYOnly=conf_.getParameter<bool>("NegativeYOnly");
+  positiveYOnly=conf.getParameter<bool>("PositiveYOnly");
+  negativeYOnly=conf.getParameter<bool>("NegativeYOnly");
   //***
 
 

--- a/RecoTracker/TkNavigation/plugins/BeamHaloNavigationSchool.cc
+++ b/RecoTracker/TkNavigation/plugins/BeamHaloNavigationSchool.cc
@@ -178,9 +178,9 @@ addInward(const DetLayer * det, const ForwardDetLayer * newF){
   for ( DLC::iterator dli=inwardsLayers.begin();dli!=inwardsLayers.end();dli++)
     {
       if ((**dli).location()==GeomDetEnumerators::barrel)
-        inwardsBarrel.push_back((BarrelDetLayer*)*dli);
+        inwardsBarrel.push_back(static_cast<const BarrelDetLayer*>(*dli));
       else
-        inwardsForward.push_back((ForwardDetLayer*)*dli);
+        inwardsForward.push_back(static_cast<const ForwardDetLayer*>(*dli));
     }
   LogDebug("BeamHaloNavigationSchool")<<"add the new ones";
   //add the other forward layers provided
@@ -219,9 +219,9 @@ addInward(const DetLayer * det, const FDLC& news){
   for ( DLC::iterator dli=inwardsLayers.begin();dli!=inwardsLayers.end();dli++)
     {
       if ((**dli).location()==GeomDetEnumerators::barrel)
-	inwardsBarrel.push_back((BarrelDetLayer*)*dli);	
+	inwardsBarrel.push_back(static_cast<const BarrelDetLayer*>(*dli));
       else
-	inwardsForward.push_back((ForwardDetLayer*)*dli);
+	inwardsForward.push_back(static_cast<const ForwardDetLayer*>(*dli));
     }
   
   LogDebug("BeamHaloNavigationSchool")<<"add the new ones";

--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.h
@@ -8,12 +8,13 @@
 #ifndef DAFTrackProducer_h
 #define DAFTrackProducer_h
 
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/KfTrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/DAFTrackProducerAlgorithm.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajAnnealing.h"
 
-class DAFTrackProducer : public KfTrackProducerBase, public edm::EDProducer {
+class DAFTrackProducer : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
 
   typedef std::vector<Trajectory> TrajectoryCollection;
@@ -21,7 +22,7 @@ public:
   explicit DAFTrackProducer(const edm::ParameterSet& iConfig);
 
   // Implementation of produce method
-  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
 private:
   DAFTrackProducerAlgorithm theAlgo;

--- a/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.cc
+++ b/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.cc
@@ -26,9 +26,9 @@
 //
 // constructors and destructor
 //
-ExtraFromSeeds::ExtraFromSeeds(const edm::ParameterSet& iConfig)
+ExtraFromSeeds::ExtraFromSeeds(const edm::ParameterSet& iConfig):
+  tracks_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks")))
 {
-  tracks_=iConfig.getParameter<edm::InputTag>("tracks");
   produces<ExtremeLight>();
   produces<TrackingRecHitCollection>();
   
@@ -50,12 +50,12 @@ ExtraFromSeeds::~ExtraFromSeeds()
 
 // ------------ method called to produce the data  ------------
 void
-ExtraFromSeeds::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+ExtraFromSeeds::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
 
   // in
   edm::Handle<reco::TrackCollection> tracks;
-  iEvent.getByLabel(tracks_,tracks);
+  iEvent.getByToken(tracks_,tracks);
 
   // out  
   std::auto_ptr<ExtremeLight> exxtralOut(new ExtremeLight());
@@ -83,16 +83,6 @@ ExtraFromSeeds::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   
   iEvent.put(exxtralOut);
   iEvent.put(hitOut);
-}
-// ------------ method called once each job just before starting event loop  ------------
-void 
-ExtraFromSeeds::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-ExtraFromSeeds::endJob() {
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h
+++ b/RecoTracker/TrackProducer/plugins/ExtraFromSeeds.h
@@ -25,7 +25,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -42,7 +42,7 @@
 // class declaration
 //
 
-class ExtraFromSeeds : public edm::EDProducer {
+class ExtraFromSeeds : public edm::global::EDProducer<> {
    public:
       explicit ExtraFromSeeds(const edm::ParameterSet&);
       ~ExtraFromSeeds();
@@ -50,11 +50,9 @@ class ExtraFromSeeds : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
-      
-  edm::InputTag tracks_;
+      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+
+  edm::EDGetTokenT<reco::TrackCollection> tracks_;
   typedef std::vector<unsigned int> ExtremeLight;
 
       // ----------member data ---------------------------

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -10,7 +10,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -36,7 +36,7 @@
 
 
 template<class T>
-class FakeTrackProducer : public edm::EDProducer {
+class FakeTrackProducer : public edm::stream::EDProducer<> {
     public:
       explicit FakeTrackProducer(const edm::ParameterSet & iConfig);
       virtual ~FakeTrackProducer() { }
@@ -44,7 +44,7 @@ class FakeTrackProducer : public edm::EDProducer {
       virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
     private:
       /// Labels for input collections
-      edm::InputTag src_;
+      edm::EDGetTokenT<std::vector<T>> src_;
 
       /// Muon selection
       //StringCutObjectSelector<T> selector_;
@@ -62,7 +62,7 @@ class FakeTrackProducer : public edm::EDProducer {
 
 template<typename T>
 FakeTrackProducer<T>::FakeTrackProducer(const edm::ParameterSet & iConfig) :
-    src_(iConfig.getParameter<edm::InputTag>("src"))
+    src_(consumes<std::vector<T>>(iConfig.getParameter<edm::InputTag>("src")))
     //,selector_(iConfig.existsAs<std::string>("cut") ? iConfig.getParameter<std::string>("cut") : "", true)
 {
     produces<std::vector<reco::Track> >(); 
@@ -81,7 +81,7 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
     Handle<vector<T> > src;
-    iEvent.getByLabel(src_, src);
+    iEvent.getByToken(src_, src);
 
     auto_ptr<vector<reco::Track> > out(new vector<reco::Track>());
     out->reserve(src->size());

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.h
@@ -5,12 +5,13 @@
  *  Refit GSF Tracks. Based on the TrackRefitter.
  */
 
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "TrackingTools/GsfTracking/interface/GsfTrackConstraintAssociation.h"
 
-class GsfTrackRefitter : public GsfTrackProducerBase, public edm::EDProducer {
+class GsfTrackRefitter : public GsfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
 
   /// Constructor

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.h
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.h
@@ -7,10 +7,11 @@
  *  \author cerati
  */
 
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "RecoTracker/TrackProducer/interface/KfTrackProducerBase.h"
 #include "RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h"
 
-class TrackRefitter : public KfTrackProducerBase, public edm::EDProducer {
+class TrackRefitter : public KfTrackProducerBase, public edm::stream::EDProducer<> {
 public:
 
   /// Constructor

--- a/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/DAFTrackProducerAlgorithm.cc
@@ -242,16 +242,12 @@ bool DAFTrackProducerAlgorithm::buildTrack (const Trajectory vtraj,
 					    const reco::BeamSpot& bs,
 					    const reco::TrackRef* BeforeDAFTrack) const
 {
-  //variable declarations
-  reco::Track * theTrack;
-  Trajectory * theTraj; 
-      
   LogDebug("DAFTrackProducerAlgorithm") <<" BUILDER " << std::endl;;
   TrajectoryStateOnSurface innertsos;
   
   if ( vtraj.isValid() ){
 
-    theTraj = new Trajectory( vtraj );
+    std::unique_ptr<Trajectory> theTraj(new Trajectory( vtraj ));
     
     if (vtraj.direction() == alongMomentum) {
     //if (theTraj->direction() == oppositeToMomentum) {
@@ -273,13 +269,13 @@ bool DAFTrackProducerAlgorithm::buildTrack (const Trajectory vtraj,
     //    LogDebug("TrackProducer") <<v<<p<<std::endl;
 
     auto algo = (*BeforeDAFTrack)->algo();
-    theTrack = new reco::Track(vtraj.chiSquared(),
-			       ndof, //in the DAF the ndof is not-integer
-			       pos, mom, tscbl.trackStateAtPCA().charge(), 
-			       tscbl.trackStateAtPCA().curvilinearError(), algo);
+    std::unique_ptr<reco::Track> theTrack(new reco::Track(vtraj.chiSquared(),
+                                                          ndof, //in the DAF the ndof is not-integer
+                                                          pos, mom, tscbl.trackStateAtPCA().charge(),
+                                                          tscbl.trackStateAtPCA().curvilinearError(), algo));
     theTrack->setQualityMask((*BeforeDAFTrack)->qualityMask());
 
-    AlgoProduct aProduct(theTraj,std::make_pair(theTrack,vtraj.direction()));
+    AlgoProduct aProduct(theTraj.release(), std::make_pair(theTrack.release(), vtraj.direction()));
     algoResults.push_back(aProduct);
 
     return true;

--- a/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
+++ b/SimTracker/TrackHistory/plugins/JetVetoedTracksAssociatorAtVertex.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/JetReco/interface/JetTracksAssociation.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -21,27 +21,25 @@
 
 #include "SimTracker/TrackHistory/interface/JetVetoedTracksAssociatorDRVertex.h"
 
-class JetVetoedTracksAssociatorAtVertex : public edm::EDProducer
+class JetVetoedTracksAssociatorAtVertex : public edm::stream::EDProducer<>
 {
 public:
     JetVetoedTracksAssociatorAtVertex(const edm::ParameterSet&);
     virtual ~JetVetoedTracksAssociatorAtVertex();
     virtual void produce(edm::Event&, const edm::EventSetup&) override;
 private:
-    edm::InputTag mJets;
-    edm::InputTag mTracks;
+    edm::EDGetTokenT<edm::View<reco::Jet>> mJets;
+    edm::EDGetTokenT<reco::TrackCollection> mTracks;
     JetVetoedTracksAssociationDRVertex mAssociator;
     TrackClassifier classifier;
 };
 
 JetVetoedTracksAssociatorAtVertex::JetVetoedTracksAssociatorAtVertex(const edm::ParameterSet& fConfig)
-        : mJets (fConfig.getParameter<edm::InputTag> ("jets")),
-        mTracks (fConfig.getParameter<edm::InputTag> ("tracks")),
+        : mJets (consumes<edm::View<reco::Jet>>(fConfig.getParameter<edm::InputTag> ("jets"))),
+        mTracks (consumes<reco::TrackCollection>(fConfig.getParameter<edm::InputTag> ("tracks"))),
         mAssociator (fConfig.getParameter<double> ("coneSize")),
         classifier(fConfig,consumesCollector())
 {
-    consumes<edm::View<reco::Jet>>(mJets);
-    consumes<reco::TrackCollection>(mTracks);
     produces<reco::JetTracksAssociation::Container> ();
 }
 
@@ -53,9 +51,9 @@ void JetVetoedTracksAssociatorAtVertex::produce(edm::Event& fEvent, const edm::E
     classifier.newEvent(fEvent, fSetup);
 
     edm::Handle <edm::View <reco::Jet> > jets_h;
-    fEvent.getByLabel (mJets, jets_h);
+    fEvent.getByToken (mJets, jets_h);
     edm::Handle <reco::TrackCollection> tracks_h;
-    fEvent.getByLabel (mTracks, tracks_h);
+    fEvent.getByToken (mTracks, tracks_h);
 
     std::auto_ptr<reco::JetTracksAssociation::Container> jetTracks (new reco::JetTracksAssociation::Container (reco::JetRefBaseProd(jets_h)));
 

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -474,7 +474,7 @@ void TrackClassifier::vertexInformation()
     GeneratedPrimaryVertex const & genpv = genpvs_.back();
 
     // Get the generated history of the tracks
-    TrackHistory::GenParticleTrail & genParticleTrail = const_cast<TrackHistory::GenParticleTrail &> (tracer_.genParticleTrail());
+    const TrackHistory::GenParticleTrail & genParticleTrail = tracer_.genParticleTrail();
 
     // Vertex counter
     int counter = 0;
@@ -488,7 +488,7 @@ void TrackClassifier::vertexInformation()
 
     // Loop over the generated particles
     for (
-        TrackHistory::GenParticleTrail::reverse_iterator iparticle = genParticleTrail.rbegin();
+        TrackHistory::GenParticleTrail::const_reverse_iterator iparticle = genParticleTrail.rbegin();
         iparticle != genParticleTrail.rend();
         ++iparticle
     )
@@ -515,11 +515,11 @@ void TrackClassifier::vertexInformation()
         }
     }
 
-    TrackHistory::SimParticleTrail & simParticleTrail = const_cast<TrackHistory::SimParticleTrail &> (tracer_.simParticleTrail());
+    const TrackHistory::SimParticleTrail & simParticleTrail = tracer_.simParticleTrail();
 
     // Loop over the generated particles
     for (
-        TrackHistory::SimParticleTrail::reverse_iterator iparticle = simParticleTrail.rbegin();
+        TrackHistory::SimParticleTrail::const_reverse_iterator iparticle = simParticleTrail.rbegin();
         iparticle != simParticleTrail.rend();
         ++iparticle
     )

--- a/SimTracker/TrackHistory/src/VertexClassifier.cc
+++ b/SimTracker/TrackHistory/src/VertexClassifier.cc
@@ -308,7 +308,7 @@ void VertexClassifier::vertexInformation()
     GeneratedPrimaryVertex const & genpv = genpvs_.back();
 
     // Get the generated history of the tracks
-    VertexHistory::GenVertexTrail & genVertexTrail = const_cast<VertexHistory::GenVertexTrail &> (tracer_.genVertexTrail());
+    const VertexHistory::GenVertexTrail & genVertexTrail = tracer_.genVertexTrail();
 
     // Unit transformation from mm to cm
     double const mm = 0.1;
@@ -368,11 +368,11 @@ void VertexClassifier::vertexInformation()
         }
     }
 
-    VertexHistory::SimVertexTrail & simVertexTrail = const_cast<VertexHistory::SimVertexTrail &> (tracer_.simVertexTrail());
+    const VertexHistory::SimVertexTrail & simVertexTrail = tracer_.simVertexTrail();
 
     // Loop over the generated particles
     for (
-        VertexHistory::SimVertexTrail::reverse_iterator ivertex = simVertexTrail.rbegin();
+        VertexHistory::SimVertexTrail::const_reverse_iterator ivertex = simVertexTrail.rbegin();
         ivertex != simVertexTrail.rend();
         ++ivertex
     )

--- a/TrackPropagation/RungeKutta/src/RK4PreciseStep.cc
+++ b/TrackPropagation/RungeKutta/src/RK4PreciseStep.cc
@@ -67,8 +67,5 @@ double RK4PreciseStep::distance( const CartesianState& a, const CartesianState& 
 
 bool RK4PreciseStep::verbose() const
 {
-  // static bool verb = SimpleConfigurable<bool>(false,"RK4PreciseStep:verbose").value();
-
-  static bool verb = true;
-  return verb;
+  return true;
 }

--- a/TrackingTools/DetLayers/src/TkLayerLess.cc
+++ b/TrackingTools/DetLayers/src/TkLayerLess.cc
@@ -7,23 +7,23 @@ bool TkLayerLess::insideOutLess( const DetLayer* a, const DetLayer* b) const
   if (a == b) return false;
 
   const BarrelDetLayer* bla = 
-    dynamic_cast<BarrelDetLayer*>(const_cast<DetLayer*>(a));
+    dynamic_cast<const BarrelDetLayer*>(a);
   const BarrelDetLayer* blb = 
-    dynamic_cast<BarrelDetLayer*>(const_cast<DetLayer*>(b));
+    dynamic_cast<const BarrelDetLayer*>(b);
 
   if      ( bla!=0 && blb!=0) {  // barrel with barrel
     return bla->specificSurface().radius() < blb->specificSurface().radius();
   }
 
   const ForwardDetLayer* flb = 
-    dynamic_cast<ForwardDetLayer*>(const_cast<DetLayer*>(b));
+    dynamic_cast<const ForwardDetLayer*>(b);
 
   if ( bla!=0 && flb!=0) {  // barrel with forward
     return barrelForwardLess( bla, flb);
   }
 
   const ForwardDetLayer* fla = 
-    dynamic_cast<ForwardDetLayer*>(const_cast<DetLayer*>(a));
+    dynamic_cast<const ForwardDetLayer*>(a);
 
   if (fla!=0 && flb!=0) {  //  forward with forward
     return fabs( fla->position().z()) < fabs( flb->position().z());
@@ -48,23 +48,23 @@ bool TkLayerLess::insideOutLessSigned( const DetLayer* a, const DetLayer* b) con
   if (a == b) return false;
 
   const BarrelDetLayer* bla =
-    dynamic_cast<BarrelDetLayer*>(const_cast<DetLayer*>(a));
+    dynamic_cast<const BarrelDetLayer*>(a);
   const BarrelDetLayer* blb =
-    dynamic_cast<BarrelDetLayer*>(const_cast<DetLayer*>(b));
+    dynamic_cast<const BarrelDetLayer*>(b);
 
   if      ( bla!=0 && blb!=0) {  // barrel with barrel
     return bla->specificSurface().radius() < blb->specificSurface().radius();
   }
 
   const ForwardDetLayer* flb =
-    dynamic_cast<ForwardDetLayer*>(const_cast<DetLayer*>(b));
+    dynamic_cast<const ForwardDetLayer*>(b);
 
   if ( bla!=0 && flb!=0) {  // barrel with forward
     return barrelForwardLess( bla, flb);
   }
 
   const ForwardDetLayer* fla =
-    dynamic_cast<ForwardDetLayer*>(const_cast<DetLayer*>(a));
+    dynamic_cast<const ForwardDetLayer*>(a);
 
   if (fla!=0 && flb!=0) {  //  forward with forward
     if (fla->position().z()*flb->position().z() > 0) {// same z-sign

--- a/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixHelix.cc
+++ b/TrackingTools/PatternTools/src/TwoTrackMinimumDistanceHelixHelix.cc
@@ -3,6 +3,7 @@
 #include "MagneticField/Engine/interface/MagneticField.h"
 #include "TrackingTools/TrajectoryParametrization/interface/GlobalTrajectoryParameters.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/isFinite.h"
 
 using namespace std;
 
@@ -156,7 +157,7 @@ bool TwoTrackMinimumDistanceHelixHelix::calculate(
   double pH=0; double pG=0;
   do {
     retval=oneIteration ( pG, pH );
-    if ( std::isinf(pG) || std::isinf(pH) ) retval=true;
+    if ( edm::isNotFinite(pG) || edm::isNotFinite(pH) ) retval=true;
     if ( counter++>themaxiter ) retval=true;
   } while ( (!retval) && ( fabs(pG) > qual || fabs(pH) > qual ));
   if ( fabs ( theg * ( thepG - thepG0 ) ) > themaxjump ) retval=true;

--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -22,11 +22,11 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
 
 
   /// Method called once per event
-  void analyze(const edm::Event&, const edm::EventSetup& );
+  void analyze(const edm::Event&, const edm::EventSetup& ) override;
   /// Method called at the end of the event loop
-  void endRun(edm::Run const&, edm::EventSetup const&);
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   /// Method called to book the DQM histograms
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&);
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
 
 
  protected:

--- a/Validation/RecoTrack/interface/TrackerSeedValidator.h
+++ b/Validation/RecoTrack/interface/TrackerSeedValidator.h
@@ -8,14 +8,14 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "Validation/RecoTrack/interface/MultiTrackValidatorBase.h"
 #include "Validation/RecoTrack/interface/MTVHistoProducerAlgo.h"
 
 #include "TrackingTools/TransientTrackingRecHit/interface/TransientTrackingRecHitBuilder.h"
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
-class TrackerSeedValidator : public edm::EDAnalyzer, protected MultiTrackValidatorBase {
+class TrackerSeedValidator : public DQMEDAnalyzer, protected MultiTrackValidatorBase {
  public:
   /// Constructor
   TrackerSeedValidator(const edm::ParameterSet& pset);
@@ -25,11 +25,11 @@ class TrackerSeedValidator : public edm::EDAnalyzer, protected MultiTrackValidat
 
 
   /// Method called once per event
-  void analyze(const edm::Event&, const edm::EventSetup& );
+  void analyze(const edm::Event&, const edm::EventSetup& ) override;
   /// Method called at the end of the event loop
-  void endRun(edm::Run const&, edm::EventSetup const&);
+  void endRun(edm::Run const&, edm::EventSetup const&) override;
   /// Method called to book the DQM histograms
-  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&);
+  void bookHistograms(DQMStore::IBooker&, edm::Run const&, edm::EventSetup const&) override;
   
  private:
   std::string builderName;

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -999,8 +999,8 @@ void SiStripTrackingRecHitsValid::rechitanalysis_matched(TrajectoryStateOnSurfac
   const StripGeomDetUnit *stripdet = (const StripGeomDetUnit *) (monodet) ; 
 
   const SiStripMatchedRecHit2D *matchedhit = dynamic_cast < const SiStripMatchedRecHit2D * >((*thit).hit());
-  const SiStripRecHit2D *monohit;
-  const SiStripRecHit2D *stereohit;
+  const SiStripRecHit2D *monohit = nullptr;
+  const SiStripRecHit2D *stereohit = nullptr;
 
   if (matchedmonorstereo == "monoHit"){
     auto hm = matchedhit->monoHit();
@@ -1882,8 +1882,8 @@ void SiStripTrackingRecHitsValid::createLayerMEs(DQMStore::IBooker & ibooker,std
   }
   if(layerswitchResolxMFTrackwidthProfileCategory4Rphi) {
     layerMEs.meResolxMFTrackwidthProfileCategory4Rphi = bookMEProfile(ibooker,"TProfResolxMFTrackwidthProfileCategory4Rphi",hidmanager.createHistoLayer("ResolxMF_Track_width_Profile_Category3_Rphi","layer",label,"").c_str() ,"Profile of Resolution in MF vs track width for Category 4");
-    layerMEs.meResolxMFTrackwidthProfileCategory3Rphi->setAxisTitle(("track width for Category 4 in "+ label).c_str(),1);
-    layerMEs.meResolxMFTrackwidthProfileCategory3Rphi->setAxisTitle(("Resolution in MF for Category 4 in "+ label).c_str(),2);
+    layerMEs.meResolxMFTrackwidthProfileCategory4Rphi->setAxisTitle(("track width for Category 4 in "+ label).c_str(),1);
+    layerMEs.meResolxMFTrackwidthProfileCategory4Rphi->setAxisTitle(("Resolution in MF for Category 4 in "+ label).c_str(),2);
   }
   if(layerswitchResolxMFClusterwidthProfileCategory1Rphi) {
     layerMEs.meResolxMFClusterwidthProfileCategory1Rphi = bookMEProfile(ibooker,"TProfResolxMFClusterwidthProfileCategory1Rphi",hidmanager.createHistoLayer("ResolxMF_Cluster_width_Profile_Category1_Rphi","layer",label,"").c_str() ,"Profile of Resolution in MF vs cluster width for Category 1");

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -1117,7 +1117,7 @@ void SiStripTrackingRecHitsValid::rechitanalysis_matched(TrajectoryStateOnSurfac
 
   if(!matched.empty()){
 
-    const StripGeomDetUnit* partnerstripdet =(StripGeomDetUnit*) gluedDet->stereoDet();
+    const StripGeomDetUnit* partnerstripdet = static_cast<const StripGeomDetUnit*>(gluedDet->stereoDet());
     std::pair<LocalPoint,LocalVector> hitPair;
     
     for(vector<PSimHit>::const_iterator m=matched.begin(); m<matched.end(); m++){


### PR DESCRIPTION
This PR fixes some of the issues reported by static analyzer in tracking (related) code.
- Remove const_casts
  - These were "false alarms in practice", like const pointers being casted to non-const before assigning to a const
- Migrated bunch of producers to stream and global, and TrackerSeedValidator to DQMEDAnalyzer
  - Migrated to consumes and getByToken on the same go
- Cleaned non-const statics
- Cleaned unnecessary edm::ParameterSet members in CosmicTrackFinder and CosmicSeedGenerator
  - Not reported by static analyzer, but I couldn't resist removing them while modifying the files for other reasons
- Fixed a typo in SiStripTrackingRecHitsValid that caused the axis labels of incorrect histogram being modified
- Fixed a memory leak in DAFTrackProducerAlgorithm
- Change `std::isinf` -> `edm::isNotFinite` in TwoTrackMinimumDistanceHelixHelix

Tested in CMSSW_7_5_X_2015-02-25-1400 with 740pre7 RelValTTbar. The `std::isinf` -> `edm::isNotFinite` may result small regression in code using TwoTrackMinimumDistanceHelixHelix, otherwise no regression is expected. I didn't see any changes in my tests. Short matrix works.

@rovere @VinInn 
