### PR TITLE
Switch to optimised PandoraPFA

### DIFF
--- a/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
+++ b/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
@@ -9,8 +9,8 @@ pandorapfanew = cms.EDProducer('PandoraCMSPFCandProducer',
     tPRecoTrackAsssociation= cms.InputTag("trackingParticleRecoTrackAsssociation"),
     genParticles= cms.InputTag("genParticles"),
     # use slow algorithms until fast algoritms are available in the CMSSW external pandora library
-    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms_slow.xml'),
-#    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms.xml'),
+#    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms_slow.xml'),
+    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms.xml'),
 
     energyCorrMethod = cms.string('ABSCORR'),
 #   absorber thickness correction


### PR DESCRIPTION
Should cut down event time from ~hour per event to ~13 minutes (apparently) when using PanoraPFA for HGCal reconstruction.
