### PR TITLE
Tests for enum use in cutParser using ROOT6

### DIFF
--- a/CommonTools/Utils/test/testCutParser.cc
+++ b/CommonTools/Utils/test/testCutParser.cc
@@ -228,7 +228,7 @@ void testCutParser::checkAll() {
   CPPUNIT_ASSERT_THROW((*sel)(o), reco::parser::Exception);                     // it throws wen called
 
   sel.reset();
-  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')",sel, false), cms::Exception);
+  CPPUNIT_ASSERT_THROW(reco::parser::cutParser<reco::Track>("quality('notAnEnum')",sel, false), edm::Exception);
 
   // check hits (for re-implemented virtual functions and exception handling)
   CPPUNIT_ASSERT(hitOk.hasPositionAndError());

--- a/CommonTools/Utils/test/testCutParserThreaded.cc
+++ b/CommonTools/Utils/test/testCutParserThreaded.cc
@@ -7,8 +7,6 @@
 #include "TObject.h"
 #include "TVirtualStreamerInfo.h"
 
-#include "Cintex/Cintex.h"
-
 #include <thread>
 #include <atomic>
 #include <iostream>
@@ -40,8 +38,6 @@ int main() {
   std::atomic<int> canStartEval{kNThreads};
   std::atomic<bool> failed{false};
   std::vector<std::thread> threads;
-
-  ROOT::Cintex::Cintex::Enable();
 
   TThread::Initialize();
   //When threading, also have to keep ROOT from logging all TObjects into a list


### PR DESCRIPTION
The ROOT 6 version of this test has to be different than the ROOT 5 becuase Cintex is gone.
