### PR TITLE
transferSystem PSet support and other DAQ updates (73X)

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -257,7 +257,7 @@ DQMFileSaver::saveForOnline(int run, const std::string &suffix, const std::strin
 
 
 boost::property_tree::ptree
-DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, evf::FastMonitoringService *fms)
+DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, const std::string transferDestinationStr, evf::FastMonitoringService *fms)
 {
   namespace bpt = boost::property_tree;
   namespace bfs = boost::filesystem;
@@ -296,7 +296,7 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, e
   fileSize.put("", dataFileStat.st_size); // Size in bytes of the data file
   inputFiles.put("", ""); // We do not care about input files!
   fileAdler32.put("", -1); // placeholder to match output json definition
-  transferDestination.put("", transferDestination_); // Data file the information refers to
+  transferDestination.put("", transferDestinationStr); // SM Transfer destination field
 
   data.push_back(std::make_pair("", processedEvents));
   data.push_back(std::make_pair("", acceptedEvents));
@@ -397,7 +397,7 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
   rename(openHistoFilePathName.c_str(), histoFilePathName.c_str());
 
   // Write the json file in the open directory.
-  bpt::ptree pt = fillJson(run, lumi, histoFilePathName, fms_);
+  bpt::ptree pt = fillJson(run, lumi, histoFilePathName, transferDestination_, fms_);
   write_json(openJsonFilePathName, pt);
   rename(openJsonFilePathName.c_str(), jsonFilePathName.c_str());
 }
@@ -631,6 +631,11 @@ DQMFileSaver::beginJob()
   
   // Determine if we are running multithreading asking to the DQMStore. Not to be moved in the ctor
   enableMultiThread_ = dbe_->enableMultiThread_;
+
+  if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
+  {
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
+  } 
 }
 
 std::shared_ptr<saverDetails::NoCache>
@@ -645,7 +650,6 @@ DQMFileSaver::globalBeginRun(const edm::Run &r, const edm::EventSetup &) const
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {
     evf::EvFDaqDirector * daqDirector = (evf::EvFDaqDirector *) (edm::Service<evf::EvFDaqDirector>().operator->());
-    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
     const std::string initFileName = daqDirector->getInitFilePath(stream_label_);
     std::ofstream file(initFileName);
     file.close();

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -285,7 +285,7 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, e
   std::string dataFileName = bfs::path(dataFilePathName).filename().string();
   // The availability test of the FastMonitoringService was done in the ctor.
   bpt::ptree data;
-  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32;
+  bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination;
 
   processedEvents.put("", fms ? (fms->getEventsProcessedForLumi(lumi)) : -1); // Processed events
   acceptedEvents.put("", fms ? (fms->getEventsProcessedForLumi(lumi)) : -1); // Accepted events, same as processed for our purposes
@@ -296,6 +296,7 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, e
   fileSize.put("", dataFileStat.st_size); // Size in bytes of the data file
   inputFiles.put("", ""); // We do not care about input files!
   fileAdler32.put("", -1); // placeholder to match output json definition
+  transferDestination.put("", transferDestination_); // Data file the information refers to
 
   data.push_back(std::make_pair("", processedEvents));
   data.push_back(std::make_pair("", acceptedEvents));
@@ -305,6 +306,7 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, e
   data.push_back(std::make_pair("", fileSize));
   data.push_back(std::make_pair("", inputFiles));
   data.push_back(std::make_pair("", fileAdler32));
+  data.push_back(std::make_pair("", transferDestination));
 
   pt.add_child("data", data);
 
@@ -643,7 +645,7 @@ DQMFileSaver::globalBeginRun(const edm::Run &r, const edm::EventSetup &) const
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {
     evf::EvFDaqDirector * daqDirector = (evf::EvFDaqDirector *) (edm::Service<evf::EvFDaqDirector>().operator->());
-    daqDirector->writeTransferSystemJsonMaybe(stream_label_);
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestination(stream_label_);
     const std::string initFileName = daqDirector->getInitFilePath(stream_label_);
     std::ofstream file(initFileName);
     file.close();

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -645,7 +645,7 @@ DQMFileSaver::globalBeginRun(const edm::Run &r, const edm::EventSetup &) const
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {
     evf::EvFDaqDirector * daqDirector = (evf::EvFDaqDirector *) (edm::Service<evf::EvFDaqDirector>().operator->());
-    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestination(stream_label_);
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
     const std::string initFileName = daqDirector->getInitFilePath(stream_label_);
     std::ofstream file(initFileName);
     file.close();

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -643,6 +643,7 @@ DQMFileSaver::globalBeginRun(const edm::Run &r, const edm::EventSetup &) const
   if ((convention_ == FilterUnit) && (!fakeFilterUnitMode_))
   {
     evf::EvFDaqDirector * daqDirector = (evf::EvFDaqDirector *) (edm::Service<evf::EvFDaqDirector>().operator->());
+    daqDirector->writeTransferSystemJsonMaybe(stream_label_);
     const std::string initFileName = daqDirector->getInitFilePath(stream_label_);
     std::ofstream file(initFileName);
     file.close();

--- a/DQMServices/Components/src/DQMFileSaver.h
+++ b/DQMServices/Components/src/DQMFileSaver.h
@@ -21,7 +21,7 @@ public:
   // used by the JsonWritingTimedPoolOutputModule,
   // fms will be nullptr in such case
   static boost::property_tree::ptree fillJson(
-      int run, int lumi, const std::string &dataFilePathName,
+      int run, int lumi, const std::string &dataFilePathName, const std::string transferDestinationStr,
       evf::FastMonitoringService *fms);
 
   

--- a/DQMServices/Components/src/DQMFileSaver.h
+++ b/DQMServices/Components/src/DQMFileSaver.h
@@ -94,6 +94,7 @@ private:
 
   static const std::string streamPrefix_;
   static const std::string streamSuffix_;
+  std::string transferDestination_;
 };
 
 #endif // DQMSERVICES_COMPONEntS_DQMFILESAVER_H

--- a/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
+++ b/DQMServices/StreamerIO/plugins/JsonWritingTimeoutPoolOutputModule.cc
@@ -38,8 +38,9 @@ JsonWritingTimeoutPoolOutputModule::physicalAndLogicalNameForNewFile() {
 
 void JsonWritingTimeoutPoolOutputModule::doExtrasAfterCloseFile() {
   std::string json_tmp_ = currentJsonName_ + ".open";
+  std::string transferDest = "";
   auto pt =
-      DQMFileSaver::fillJson(runNumber_, sequence_, currentFileName_, nullptr);
+      DQMFileSaver::fillJson(runNumber_, sequence_, currentFileName_, transferDest, nullptr);
   write_json(json_tmp_, pt);
   rename(json_tmp_.c_str(), currentJsonName_.c_str());
 }

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -31,6 +31,10 @@ class StreamID;
 class InputFile;
 class InputChunk;
 
+namespace Json{
+  class Value;
+}
+
 namespace evf{
 
   class FastMonitoringService;
@@ -65,6 +69,7 @@ namespace evf{
       std::string getMergedDatChecksumFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getOpenInitFilePath(std::string const& stream) const;
       std::string getInitFilePath(std::string const& stream) const;
+      std::string getTransferFilePath(std::string const& stream) const;
       std::string getOpenProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getMergedProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
@@ -106,7 +111,8 @@ namespace evf{
         fileDeleteLockPtr_=fileDeleteLock;
         filesToDeletePtr_ = filesToDelete;
       }
-      void writeTransferSystemJsonMaybe();
+      void checkTransferSystemPSet();
+      void writeTransferSystemJsonMaybe(std::string const& stream) const;
 
 
     private:
@@ -184,6 +190,8 @@ namespace evf{
       bool readEolsDefinition_ = true;
       unsigned int eolsNFilesIndex_ = 1;
       std::string stopFilePath_;
+
+      std::shared_ptr<Json::Value> transferSystemJson_;
   };
 }
 

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -72,6 +72,7 @@ namespace evf{
       std::string getMergedRootHistogramFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getEoLSFilePathOnBU(const unsigned int ls) const;
       std::string getEoLSFilePathOnFU(const unsigned int ls) const;
+      std::string getBoLSFilePathOnFU(const unsigned int ls) const;
       std::string getEoRFilePath() const;
       std::string getEoRFilePathOnFU() const;
       std::string getRunOpenDirPath() const {return run_dir_ +"/open";}

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -125,6 +125,7 @@ namespace evf{
       bool directorBu_;
       unsigned int run_;
       bool outputAdler32Recheck_;
+      std::string hltSourceDirectory_;
 
       std::string hostname_;
       std::string run_string_;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -63,6 +63,7 @@ namespace evf{
       std::string getOutputJsonFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getMergedDatFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getMergedDatChecksumFilePath(const unsigned int ls, std::string const& stream) const;
+      std::string getOpenInitFilePath(std::string const& stream) const;
       std::string getInitFilePath(std::string const& stream) const;
       std::string getOpenProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -112,7 +112,8 @@ namespace evf{
         filesToDeletePtr_ = filesToDelete;
       }
       void checkTransferSystemPSet();
-      void writeTransferSystemJsonMaybe(std::string const& stream) const;
+      std::string getStreamDestination(std::string const& stream) const;
+      //void writeTransferSystemJsonMaybe(std::string const& stream) const;
 
 
     private:
@@ -191,6 +192,7 @@ namespace evf{
       unsigned int eolsNFilesIndex_ = 1;
       std::string stopFilePath_;
 
+      std::string selectedTransferMode_;
       std::shared_ptr<Json::Value> transferSystemJson_;
   };
 }

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -69,7 +69,6 @@ namespace evf{
       std::string getMergedDatChecksumFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getOpenInitFilePath(std::string const& stream) const;
       std::string getInitFilePath(std::string const& stream) const;
-      std::string getTransferFilePath(std::string const& stream) const;
       std::string getOpenProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;
       std::string getMergedProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -112,8 +112,7 @@ namespace evf{
         filesToDeletePtr_ = filesToDelete;
       }
       void checkTransferSystemPSet();
-      std::string getStreamDestination(std::string const& stream) const;
-      //void writeTransferSystemJsonMaybe(std::string const& stream) const;
+      std::string getStreamDestinations(std::string const& stream) const;
 
 
     private:
@@ -136,6 +135,7 @@ namespace evf{
       unsigned int run_;
       bool outputAdler32Recheck_;
       bool requireTSPSet_;
+      std::string selectedTransferMode_;
       std::string hltSourceDirectory_;
 
       std::string hostname_;
@@ -192,7 +192,6 @@ namespace evf{
       unsigned int eolsNFilesIndex_ = 1;
       std::string stopFilePath_;
 
-      std::string selectedTransferMode_;
       std::shared_ptr<Json::Value> transferSystemJson_;
   };
 }

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -106,6 +106,7 @@ namespace evf{
         fileDeleteLockPtr_=fileDeleteLock;
         filesToDeletePtr_ = filesToDelete;
       }
+      void writeTransferSystemJsonMaybe();
 
 
     private:
@@ -127,6 +128,7 @@ namespace evf{
       bool directorBu_;
       unsigned int run_;
       bool outputAdler32Recheck_;
+      bool requireTSPSet_;
       std::string hltSourceDirectory_;
 
       std::string hostname_;

--- a/EventFilter/Utilities/interface/FFFNamingSchema.h
+++ b/EventFilter/Utilities/interface/FFFNamingSchema.h
@@ -23,6 +23,13 @@ namespace fffnaming {
     return ss.str();
   }
 
+  inline std::string bolsFileName(const unsigned int run, const unsigned int ls) {
+    std::stringstream ss;
+    runLumiPrefixFill(ss,run,ls);
+    ss << "_BoLS.jsn";
+    return ss.str();
+  }
+
   inline std::string eorFileName(const unsigned int run) {
     std::stringstream ss;
     ss << "run" << std::setfill('0') << std::setw(6) << run << "_ls0000" << "_EoR.jsn";

--- a/EventFilter/Utilities/interface/FFFNamingSchema.h
+++ b/EventFilter/Utilities/interface/FFFNamingSchema.h
@@ -59,14 +59,6 @@ namespace fffnaming {
     return ss.str();
   }
 
-  inline std::string transferFileName(const unsigned int run, const unsigned int ls, std::string const& stream) {
-    std::stringstream ss;
-    runLumiPrefixFill(ss,run,ls);
-    ss  << "_transfer" << stream << ".jsn";
-    return ss.str();
-  }
-
-
   inline std::string initFileNameWithInstance(const unsigned int run, const unsigned int ls, std::string const& stream, std::string const& instance) {
     std::stringstream ss;
     runLumiPrefixFill(ss,run,ls);

--- a/EventFilter/Utilities/interface/FFFNamingSchema.h
+++ b/EventFilter/Utilities/interface/FFFNamingSchema.h
@@ -59,6 +59,14 @@ namespace fffnaming {
     return ss.str();
   }
 
+  inline std::string transferFileName(const unsigned int run, const unsigned int ls, std::string const& stream) {
+    std::stringstream ss;
+    runLumiPrefixFill(ss,run,ls);
+    ss  << "_transfer" << stream << ".jsn";
+    return ss.str();
+  }
+
+
   inline std::string initFileNameWithInstance(const unsigned int run, const unsigned int ls, std::string const& stream, std::string const& instance) {
     std::stringstream ss;
     runLumiPrefixFill(ss,run,ls);

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -59,6 +59,7 @@ private:
   virtual void rewind_() override;
 
   void maybeOpenNewLumiSection(const uint32_t lumiSection);
+  void createBoLSFile(const uint32_t lumiSection,bool checkIfExists);
   evf::EvFDaqDirector::FileStatus nextEvent();
   evf::EvFDaqDirector::FileStatus getNextEvent();
   edm::Timestamp fillFEDRawDataCollection(FEDRawDataCollection&);

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -44,15 +44,18 @@ RawEventFileWriterForBU::RawEventFileWriterForBU(edm::ParameterSet const& ps):
   eolJsonDef_.addLegendItem("NEvents","integer",DataPointDefinition::SUM);
   eolJsonDef_.addLegendItem("NFiles","integer",DataPointDefinition::SUM);
   eolJsonDef_.addLegendItem("TotalEvents","integer",DataPointDefinition::SUM);
+  eolJsonDef_.addLegendItem("NLostEvents","integer",DataPointDefinition::SUM);
 
   perLumiEventCount_.setName("NEvents");
   perLumiFileCount_.setName("NFiles");
   perLumiTotalEventCount_.setName("TotalEvents");
+  perLumiLostEventCount_.setName("NLostEvents");
 
   lumiMon_ = new FastMonitor(&eolJsonDef_,false);
   lumiMon_->registerGlobalMonitorable(&perLumiEventCount_,false,nullptr);
   lumiMon_->registerGlobalMonitorable(&perLumiFileCount_,false,nullptr);
   lumiMon_->registerGlobalMonitorable(&perLumiTotalEventCount_,false,nullptr);
+  lumiMon_->registerGlobalMonitorable(&perLumiLostEventCount_,false,nullptr);
   lumiMon_->commit(nullptr);
 
 
@@ -61,15 +64,18 @@ RawEventFileWriterForBU::RawEventFileWriterForBU(edm::ParameterSet const& ps):
   eorJsonDef_.addLegendItem("NEvents","integer",DataPointDefinition::SUM);
   eorJsonDef_.addLegendItem("NFiles","integer",DataPointDefinition::SUM);
   eorJsonDef_.addLegendItem("NLumis","integer",DataPointDefinition::SUM);
+  eorJsonDef_.addLegendItem("LastLumi","integer",DataPointDefinition::SUM);
 
   perRunEventCount_.setName("NEvents");
   perRunFileCount_.setName("NFiles");
   perRunLumiCount_.setName("NLumis");
+  perRunLastLumi_.setName("LastLumi");
  
   runMon_ = new FastMonitor(&eorJsonDef_,false);
   runMon_->registerGlobalMonitorable(&perRunEventCount_,false,nullptr);
   runMon_->registerGlobalMonitorable(&perRunFileCount_,false,nullptr);
   runMon_->registerGlobalMonitorable(&perRunLumiCount_,false,nullptr);
+  runMon_->registerGlobalMonitorable(&perRunLastLumi_,false,nullptr);
   runMon_->commit(nullptr);
 
   instance = this;
@@ -266,6 +272,7 @@ void RawEventFileWriterForBU::endOfLS(int ls)
   perRunEventCount_.value() += perLumiEventCount_.value();
   perRunFileCount_.value() += perLumiFileCount_.value();
   perRunLumiCount_.value() += 1;
+  perRunLastLumi_.value() = ls;
 
   perLumiEventCount_ = 0;
   perLumiFileCount_ = 0;

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -85,5 +85,8 @@ class RawEventFileWriterForBU
 
   static RawEventFileWriterForBU* instance;
 
+  unsigned int lumiOpen_ = 0;
+  unsigned int lumiClosed_ = 0;
+
 };
 #endif

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -56,10 +56,12 @@ class RawEventFileWriterForBU
   IntJ perRunEventCount_;
   IntJ perRunFileCount_;
   IntJ perRunLumiCount_;
+  IntJ perRunLastLumi_;
 
   IntJ perLumiEventCount_;
   IntJ perLumiFileCount_;
   IntJ perLumiTotalEventCount_;
+  IntJ perLumiLostEventCount_;
 
   IntJ perFileEventCount_;
 

--- a/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventOutputModuleForBU.h
@@ -9,6 +9,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
+#include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
 #include "IOPool/Streamer/interface/FRDEventMessage.h"
@@ -97,8 +98,10 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventPrincipal const& e, ed
   // determine the expected size of the FRDEvent IN BYTES !!!!!
   int headerSize = frdVersion_<3 ? (4+1024)*sizeof(uint32) : 7*sizeof(uint32);
   int expectedSize = headerSize;
+  int nFeds = frdVersion_<3? 1024 : FEDNumbering::lastFEDId()+1;
 
-  for (int idx = 0; idx < 1024; ++idx) {
+
+  for (int idx = 0; idx < nFeds; ++idx) {
     FEDRawData singleFED = fedBuffers->FEDData(idx);
     expectedSize += singleFED.size();
   }
@@ -128,7 +131,7 @@ void RawEventOutputModuleForBU<Consumer>::write(edm::EventPrincipal const& e, ed
     *bufPtr++ = 0;
   }
   uint32 *payloadPtr=bufPtr;
-  for (int idx = 0; idx < 1024; ++idx) {
+  for (int idx = 0; idx < nFeds; ++idx) {
     FEDRawData singleFED = fedBuffers->FEDData(idx);
     if (singleFED.size() > 0) {
       memcpy(bufPtr, singleFED.data(), singleFED.size());

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -41,7 +41,8 @@ namespace evf {
     virtual void stop() const;
     virtual void doOutputHeader(InitMsgBuilder const& init_message) const;
     virtual void doOutputEvent(EventMsgBuilder const& msg) const;
-    //    virtual void beginRun(edm::RunPrincipal const&);
+    //virtual void beginRun(edm::RunPrincipal const&, edm::ModuleCallingContext const*);
+    virtual void beginJob();
     virtual void beginLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
     virtual void endLuminosityBlock(edm::LuminosityBlockPrincipal const&, edm::ModuleCallingContext const*);
 
@@ -147,9 +148,6 @@ namespace evf {
     jsonMonitor_->registerGlobalMonitorable(&transferDestination_,false);
     jsonMonitor_->commit(nullptr);
 
-    //get stream transfer destination
-    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
-
   }
   
   template<typename Consumer>
@@ -221,6 +219,14 @@ namespace evf {
     Consumer::fillDescription(desc);
     descriptions.add("streamerOutput", desc);
   }
+
+  template<typename Consumer>
+  void RecoEventOutputModuleForFU<Consumer>::beginJob()
+  {
+    //get stream transfer destination
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
+  }
+
 
   template<typename Consumer>
   void RecoEventOutputModuleForFU<Consumer>::beginLuminosityBlock(edm::LuminosityBlockPrincipal const &ls, edm::ModuleCallingContext const*)

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -146,6 +146,10 @@ namespace evf {
     jsonMonitor_->registerGlobalMonitorable(&fileAdler32_,false);
     jsonMonitor_->registerGlobalMonitorable(&transferDestination_,false);
     jsonMonitor_->commit(nullptr);
+
+    //get stream transfer destination
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations(stream_label_);
+
   }
   
   template<typename Consumer>
@@ -174,7 +178,6 @@ namespace evf {
   void
   RecoEventOutputModuleForFU<Consumer>::doOutputHeader(InitMsgBuilder const& init_message) const
   {
-    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestination(stream_label_);
     c_->doOutputHeader(init_message);
 
     const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(stream_label_);

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -58,6 +58,7 @@ namespace evf {
     IntJ filesize_; 
     StringJ inputFiles_;
     IntJ fileAdler32_; 
+    StringJ transferDestination_; 
     boost::shared_ptr<FastMonitor> jsonMonitor_;
     evf::FastMonitoringService *fms_;
     DataPointDefinition outJsonDef_;
@@ -80,6 +81,7 @@ namespace evf {
     filesize_(0),
     inputFiles_(),
     fileAdler32_(1),
+    transferDestination_(),
     outBuf_(new unsigned char[1024*1024])
   {
     std::string baseRunDir = edm::Service<evf::EvFDaqDirector>()->baseRunDir();
@@ -103,6 +105,7 @@ namespace evf {
     filesize_.setName("Filesize");
     inputFiles_.setName("InputFiles");
     fileAdler32_.setName("FileAdler32");
+    transferDestination_.setName("TransferDestination");
 
     outJsonDef_.setDefaultGroup("data");
     outJsonDef_.addLegendItem("Processed","integer",DataPointDefinition::SUM);
@@ -113,6 +116,7 @@ namespace evf {
     outJsonDef_.addLegendItem("Filesize","integer",DataPointDefinition::SUM);
     outJsonDef_.addLegendItem("InputFiles","string",DataPointDefinition::CAT);
     outJsonDef_.addLegendItem("FileAdler32","integer",DataPointDefinition::ADLER32);
+    outJsonDef_.addLegendItem("TransferDestination","string",DataPointDefinition::SAME);
     std::stringstream tmpss,ss;
     tmpss << baseRunDir << "/open/" << "output_" << getpid() << ".jsd";
     ss << baseRunDir << "/" << "output_" << getpid() << ".jsd";
@@ -140,6 +144,7 @@ namespace evf {
     jsonMonitor_->registerGlobalMonitorable(&filesize_,false);
     jsonMonitor_->registerGlobalMonitorable(&inputFiles_,false);
     jsonMonitor_->registerGlobalMonitorable(&fileAdler32_,false);
+    jsonMonitor_->registerGlobalMonitorable(&transferDestination_,false);
     jsonMonitor_->commit(nullptr);
   }
   
@@ -155,6 +160,7 @@ namespace evf {
 	                                       << openInitFileName;
     c_->setInitMessageFile(openInitFileName);
     c_->start();
+    
   }
   
   template<typename Consumer>
@@ -168,7 +174,7 @@ namespace evf {
   void
   RecoEventOutputModuleForFU<Consumer>::doOutputHeader(InitMsgBuilder const& init_message) const
   {
-    edm::Service<evf::EvFDaqDirector>()->writeTransferSystemJsonMaybe(stream_label_);
+    transferDestination_ = edm::Service<evf::EvFDaqDirector>()->getStreamDestination(stream_label_);
     c_->doOutputHeader(init_message);
 
     const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(stream_label_);

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -168,6 +168,7 @@ namespace evf {
   void
   RecoEventOutputModuleForFU<Consumer>::doOutputHeader(InitMsgBuilder const& init_message) const
   {
+    edm::Service<evf::EvFDaqDirector>()->writeTransferSystemJsonMaybe(stream_label_);
     c_->doOutputHeader(init_message);
 
     const std::string openIniFileName = edm::Service<evf::EvFDaqDirector>()->getOpenInitFilePath(stream_label_);

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.cc
@@ -19,6 +19,7 @@ namespace evf {
     //Write the Init Message to init file and close it
     if ( stream_writer_preamble_.get() ) {
       stream_writer_preamble_->write(init_message);
+      preamble_adler32_ = stream_writer_preamble_->adler32();
       stream_writer_preamble_.reset();
     }
   }
@@ -40,6 +41,7 @@ namespace evf {
 
   void RecoEventWriterForFU::setInitMessageFile(std::string const& init){
     stream_writer_preamble_.reset(new StreamerOutputFile(init));
+    preamble_adler32_ = 1;
   }
 
   void RecoEventWriterForFU::setOutputFile(std::string const& events){

--- a/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventWriterForFU.h
@@ -42,12 +42,14 @@ namespace evf
     void start(){}
     void stop(){}
 
+    uint32 get_adler32_ini() const { return preamble_adler32_;}
     uint32 get_adler32() const { return stream_writer_events_->adler32();}
 
   private:
 
     boost::shared_ptr<StreamerOutputFile> stream_writer_preamble_;
     boost::shared_ptr<StreamerOutputFile> stream_writer_events_;
+    uint32 preamble_adler32_=1;
 
   };
 }

--- a/EventFilter/Utilities/plugins/output.jsd
+++ b/EventFilter/Utilities/plugins/output.jsd
@@ -39,6 +39,12 @@
          "name" : "FileAdler32",
          "operation" : "sum",
          "type" : "integer"
+      },
+      {
+         "name" : "TransferDestination",
+         "operation" : "same",
+         "type" : "string"
       }
+
    ]
 }

--- a/EventFilter/Utilities/python/EvFDaqDirector_cfi.py
+++ b/EventFilter/Utilities/python/EvFDaqDirector_cfi.py
@@ -5,6 +5,7 @@ EvFDaqDirector = cms.Service( "EvFDaqDirector",
     baseDir = cms.untracked.string(""),
     runNumber = cms.untracked.uint32(0),
     outputAdler32Recheck=cms.untracked.bool(False),
-    requireTransfersPSet=cms.untracked.bool(False)
+    requireTransfersPSet=cms.untracked.bool(False),
+    selectedTransferMode=cms.untracked.string("")
     )
 

--- a/EventFilter/Utilities/python/EvFDaqDirector_cfi.py
+++ b/EventFilter/Utilities/python/EvFDaqDirector_cfi.py
@@ -4,6 +4,7 @@ EvFDaqDirector = cms.Service( "EvFDaqDirector",
     buBaseDir = cms.untracked.string(""),
     baseDir = cms.untracked.string(""),
     runNumber = cms.untracked.uint32(0),
-    outputAdler32Recheck=cms.untracked.bool(False)
+    outputAdler32Recheck=cms.untracked.bool(False),
+    requireTransfersPSet=cms.untracked.bool(False)
     )
 

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -189,8 +189,12 @@ namespace evf {
 	    retval = mkdir(tmphltdir.c_str(),S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
 
             boost::filesystem::copy_file(hltSourceDirectory_+"/HltConfig.py",tmphltdir+"/HltConfig.py");
-            boost::filesystem::copy_file(hltSourceDirectory_+"/CMSSW_VERSION",tmphltdir+"/CMSSW_VERSION");
-            boost::filesystem::copy_file(hltSourceDirectory_+"/SCRAM_ARCH",tmphltdir+"/SCRAM_ARCH");
+            try {
+              boost::filesystem::copy_file(hltSourceDirectory_+"/CMSSW_VERSION",tmphltdir+"/CMSSW_VERSION");
+              boost::filesystem::copy_file(hltSourceDirectory_+"/SCRAM_ARCH",tmphltdir+"/SCRAM_ARCH");
+            } catch (...) {}
+
+            boost::filesystem::copy_file(hltSourceDirectory_+"/fffParameters.jsn",tmphltdir+"/fffParameters.jsn");
 
             boost::filesystem::rename(tmphltdir,hltdir);
 	  }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -349,6 +349,10 @@ namespace evf {
     return run_dir_ + "/" + fffnaming::streamerDataChecksumFileNameWithInstance(run_,ls,stream,hostname_);
   }
 
+  std::string EvFDaqDirector::getOpenInitFilePath(std::string const& stream) const {
+    return run_dir_ + "/open/" + fffnaming::initFileNameWithPid(run_,0,stream);
+  }
+
   std::string EvFDaqDirector::getInitFilePath(std::string const& stream) const {
     return run_dir_ + "/" + fffnaming::initFileNameWithPid(run_,0,stream);
   }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -385,6 +385,10 @@ namespace evf {
     return run_dir_ + "/" + fffnaming::eolsFileName(run_,ls);
   }
 
+  std::string EvFDaqDirector::getBoLSFilePathOnFU(const unsigned int ls) const {
+    return run_dir_ + "/" + fffnaming::bolsFileName(run_,ls);
+  }
+
   std::string EvFDaqDirector::getEoRFilePath() const {
     return bu_run_dir_ + "/" + fffnaming::eorFileName(run_);
   }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -366,12 +366,6 @@ namespace evf {
     return run_dir_ + "/" + fffnaming::initFileNameWithPid(run_,0,stream);
   }
 
-  std::string EvFDaqDirector::getTransferFilePath(std::string const& stream) const {
-    assert(stream.size() && stream.substr(0,6)=="stream");
-    std::string streamUpper = "Stream"+stream.substr(6,std::string::npos);
-    return run_dir_ + "/" + fffnaming::transferFileName(run_,0,streamUpper);
-  }
-
   std::string EvFDaqDirector::getOpenProtocolBufferHistogramFilePath(const unsigned int ls, std::string const& stream) const {
     return run_dir_ + "/open/" + fffnaming::protocolBufferHistogramFileNameWithPid(run_,ls,stream);
   }

--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -88,6 +88,10 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
   static std::shared_ptr<hltJson::runVars> globalBeginRun(edm::Run const&, edm::EventSetup const&, void const*){
     std::shared_ptr<hltJson::runVars> rv(new hltJson::runVars);
     rv->wroteFiles = false;
+    if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
+      edm::Service<evf::EvFDaqDirector>()->writeTransferSystemJsonMaybe("streamHLTRates");
+      edm::Service<evf::EvFDaqDirector>()->writeTransferSystemJsonMaybe("streamL1Rates");
+    }
     return rv;
   }
   

--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -61,11 +61,15 @@ namespace hltJson {
     HistoJ<unsigned int> *L1TechAccept; // # of events accepted by L1 Technical Triggers[i] //DS 
     
     std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            //DS
+    std::string streamL1Destination;
+    std::string streamHLTDestination;
   };
   //End lumi struct
   //Struct for storing variable written once per run
   struct runVars{
     mutable std::atomic<bool> wroteFiles;
+    mutable std::string streamL1Destination;
+    mutable std::string streamHLTDestination;
   };
 }//End hltJson namespace   
 
@@ -87,11 +91,11 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
 
   static std::shared_ptr<hltJson::runVars> globalBeginRun(edm::Run const&, edm::EventSetup const&, void const*){
     std::shared_ptr<hltJson::runVars> rv(new hltJson::runVars);
-    rv->wroteFiles = false;
     if (edm::Service<evf::EvFDaqDirector>().isAvailable()) {
-      edm::Service<evf::EvFDaqDirector>()->writeTransferSystemJsonMaybe("streamHLTRates");
-      edm::Service<evf::EvFDaqDirector>()->writeTransferSystemJsonMaybe("streamL1Rates");
+      rv->streamHLTDestination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamHLTRates");
+      rv->streamL1Destination = edm::Service<evf::EvFDaqDirector>()->getStreamDestinations("streamL1Rates");
     }
+    rv->wroteFiles = false;
     return rv;
   }
   

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -555,7 +555,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     hltDaqJsn[DataPoint::DATA].append((unsigned int)hltJsnFilesize_.value());
     hltDaqJsn[DataPoint::DATA].append(hltJsnInputFiles_.value());
     hltDaqJsn[DataPoint::DATA].append((unsigned int)hltJsnFileAdler32_.value());
-    hltDaqJsn[DataPoint::DATA].append(iSummary_->streamHLTDestination);
+    hltDaqJsn[DataPoint::DATA].append(iSummary->streamHLTDestination);
 
     result = writer.write(hltDaqJsn);
 
@@ -591,7 +591,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     l1DaqJsn[DataPoint::DATA].append((unsigned int)l1JsnFilesize_.value());
     l1DaqJsn[DataPoint::DATA].append(l1JsnInputFiles_.value());
     l1DaqJsn[DataPoint::DATA].append((unsigned int)l1JsnFileAdler32_.value());
-    l1DaqJsn[DataPoint::DATA].append(iSummary_->streamL1Destination);
+    l1DaqJsn[DataPoint::DATA].append(iSummary->streamL1Destination);
 
     result = writer.write(l1DaqJsn);
 

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -291,7 +291,7 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
     
     //Create definition file for HLT Rates                 
     std::stringstream ssHltJsd;
-    ssHltJsd << "run" << nRun << "_ls0000";
+    ssHltJsd << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000";
     ssHltJsd << "_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
     stHltJsd_ = ssHltJsd.str();
 
@@ -299,7 +299,7 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
     
     //Create definition file for L1 Rates - //DS 
     std::stringstream ssL1Jsd;
-    ssL1Jsd << "run" << nRun << "_ls0000";
+    ssL1Jsd << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000";
     ssL1Jsd << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
     stL1Jsd_ = ssL1Jsd.str();
 
@@ -326,7 +326,7 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
     std::string && result = writer.write(hltIni);
   
     std::stringstream ssHltIni;
-    ssHltIni << "run" << nRun << "_ls0000_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".ini";
+    ssHltIni << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".ini";
     
     std::ofstream outHltIni( monPath + ssHltIni.str() );
     outHltIni<<result;
@@ -357,7 +357,7 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
     result = writer.write(l1Ini);
   
     std::stringstream ssL1Ini;
-    ssL1Ini << "run" << nRun << "_ls0000_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".ini";
+    ssL1Ini << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".ini";
     
     std::ofstream outL1Ini( monPath + ssL1Ini.str() );
     outL1Ini<<result;
@@ -424,6 +424,8 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
       iSummary->L1Global    ->update(L1Global_.at(ui));
     }
     iSummary->stL1Jsd = stL1Jsd_;    //DS  
+    iSummary->streamHLTDestination = runCache()->streamHLTDestination;
+    iSummary->streamL1Destination = runCache()->streamL1Destination;
   }
 
   else{
@@ -493,7 +495,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     std::string && result = writer.write(hltJsnData);
 
     std::stringstream ssHltJsnData;
-    ssHltJsnData <<  "run" << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssHltJsnData <<  "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
     ssHltJsnData << "_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsndata";
 
     std::ofstream outHltJsnData( monPath + ssHltJsnData.str() );
@@ -512,7 +514,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     result = writer.write(l1JsnData);
 
     std::stringstream ssL1JsnData;
-    ssL1JsnData << "run" << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssL1JsnData << "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
     ssL1JsnData << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsndata";
 
     std::ofstream outL1JsnData( monPath + "/" + ssL1JsnData.str() );
@@ -553,11 +555,12 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     hltDaqJsn[DataPoint::DATA].append((unsigned int)hltJsnFilesize_.value());
     hltDaqJsn[DataPoint::DATA].append(hltJsnInputFiles_.value());
     hltDaqJsn[DataPoint::DATA].append((unsigned int)hltJsnFileAdler32_.value());
+    hltDaqJsn[DataPoint::DATA].append(iSummary_->streamHLTDestination);
 
     result = writer.write(hltDaqJsn);
 
     std::stringstream ssHltDaqJsn;
-    ssHltDaqJsn <<  "run" << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssHltDaqJsn <<  "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
     ssHltDaqJsn << "_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
 
     std::ofstream outHltDaqJsn( monPath + ssHltDaqJsn.str() );
@@ -588,11 +591,12 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     l1DaqJsn[DataPoint::DATA].append((unsigned int)l1JsnFilesize_.value());
     l1DaqJsn[DataPoint::DATA].append(l1JsnInputFiles_.value());
     l1DaqJsn[DataPoint::DATA].append((unsigned int)l1JsnFileAdler32_.value());
+    l1DaqJsn[DataPoint::DATA].append(iSummary_->streamL1Destination);
 
     result = writer.write(l1DaqJsn);
 
     std::stringstream ssL1DaqJsn;
-    ssL1DaqJsn <<  "run" << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
+    ssL1DaqJsn <<  "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
     ssL1DaqJsn << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsn";
 
     std::ofstream outL1DaqJsn( monPath + ssL1DaqJsn.str() );


### PR DESCRIPTION
changes:
- beginning of lumisection files written locally by FUs to indicate opening new LS from the input source to other DAQ components (introduced to create backpressure in case of delay in LS processing)
- Each Ini file checksum is verified after writing to disk and before renaming into location where it is taken by hltd
- transfer system PSet and selected destination support. Selected destination is passed as VarArgs parameter. A parameter is added to control whether exception is thrown when PSet is incomplete or parameter missing. New output json field is added to output module as well as JSON and DQMHistograms modules
- fixed min. number of run digits in filenames used by TriggerJSONMonitoring (only relevant for test run numbers smaller than 100000).
- Fake BU and Raw writer improvements:
  - FED 1024 is handled in Raw writer
  - closing last LS written when interrupted from shell
  - updated schema of EoLS and Eor jsd/json
  - ability to copy menu directory when starting a run by script
  - fffParameters.jsn file handling
