### PR TITLE
Updated defaut PAT jet b-taggers

### DIFF
--- a/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
+++ b/PhysicsTools/PatAlgos/python/patInputFiles_cff.py
@@ -1,93 +1,93 @@
 import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 
-# /RelValTTbar_13/CMSSW_7_4_0_pre5-PU25ns_MCRUN2_73_V7-v1/MINIAODSIM
-filesRelValProdTTbarPileUpMINIAODSIM = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
+# /RelValTTbar_13/CMSSW_7_4_0_pre8-PU25ns_MCRUN2_74_V7-v1/MINIAODSIM
+filesRelValTTbarPileUpMINIAODSIM = cms.untracked.vstring(
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre8'
                         #, relVal        = 'RelValTTbar_13'
-                        #, globalTag     = 'PU25ns_MCRUN2_73_V7'
+                        #, globalTag     = 'PU25ns_MCRUN2_74_V7'
                         #, dataTier      = 'MINIAODSIM'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_4_0_pre5/RelValTTbar_13/MINIAODSIM/PU25ns_MCRUN2_73_V7-v1/00000/B626832E-D6A0-E411-B0D9-0025905938A8.root'
+        '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/MINIAODSIM/PU25ns_MCRUN2_74_V7-v1/00000/122AA6C7-6BBD-E411-80C1-002590593902.root'
     )
 
-# /RelValProdTTbar_13/CMSSW_7_4_0_pre5-MCRUN2_73_V7-v1/AODSIM
+# /RelValProdTTbar_13/CMSSW_7_4_0_pre8-MCRUN2_74_V7-v1/AODSIM
 filesRelValProdTTbarAODSIM = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre8'
                         #, relVal        = 'RelValProdTTbar_13'
-                        #, globalTag     = 'MCRUN2_73_V7'
+                        #, globalTag     = 'MCRUN2_74_V7'
                         #, dataTier      = 'AODSIM'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_4_0_pre5/RelValProdTTbar_13/AODSIM/MCRUN2_73_V7-v1/00000/621B749D-F19D-E411-896C-003048FFCBA4.root'
+        '/store/relval/CMSSW_7_4_0_pre8/RelValProdTTbar_13/AODSIM/MCRUN2_74_V7-v1/00000/44E1E4BA-50BD-E411-A57A-002618943949.root'
     )
 
-# /RelValProdTTbar_13/CMSSW_7_4_0_pre5-MCRUN2_73_V7-v1/GEN-SIM-RECO
+# /RelValProdTTbar_13/CMSSW_7_4_0_pre8-MCRUN2_74_V7-v1/GEN-SIM-RECO
 filesRelValProdTTbarGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre8'
                         #, relVal        = 'RelValProdTTbar_13'
-                        #, globalTag     = 'MCRUN2_73_V7'
+                        #, globalTag     = 'MCRUN2_74_V7'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_4_0_pre5/RelValProdTTbar_13/GEN-SIM-RECO/MCRUN2_73_V7-v1/00000/4EBA2C0B-EB9D-E411-810A-002618FDA248.root'
+        '/store/relval/CMSSW_7_4_0_pre8/RelValProdTTbar_13/GEN-SIM-RECO/MCRUN2_74_V7-v1/00000/32B61181-4FBD-E411-A930-0026189438F6.root'
     )
 
-# /RelValTTbar/CMSSW_7_4_0_pre5-PU_MCRUN1_73_V2_FastSim-v1/GEN-SIM-DIGI-RECO
-filesRelValTTbarPileUpFastSimGENSIMDIGIRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
-                        #, relVal        = 'RelValTTbar'
-                        #, globalTag     = 'PU_MCRUN1_73_V2_FastSim'
+# /RelValTTbar_13/CMSSW_7_4_0_pre8-MCRUN2_74_V7_FastSim-v1/GEN-SIM-DIGI-RECO
+filesRelValTTbarFastSimGENSIMDIGIRECO = cms.untracked.vstring(
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre8'
+                        #, relVal        = 'RelValTTbar_13'
+                        #, globalTag     = 'MCRUN2_74_V7_FastSim'
                         #, dataTier      = 'GEN-SIM-DIGI-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_4_0_pre5/RelValTTbar/GEN-SIM-DIGI-RECO/PU_MCRUN1_73_V2_FastSim-v1/00000/00024C55-D39D-E411-969A-0025905A60C6.root'
+        '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-DIGI-RECO/MCRUN2_74_V7_FastSim-v1/00000/008BD645-1EBD-E411-B3D0-003048FFD740.root'
     )
 
-# /RelValTTbar_13/CMSSW_7_4_0_pre5-PU25ns_MCRUN2_73_V7-v1/GEN-SIM-RECO
+# /RelValTTbar_13/CMSSW_7_4_0_pre8-PU25ns_MCRUN2_74_V7-v1/GEN-SIM-RECO
 filesRelValTTbarPileUpGENSIMRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre8'
                         #, relVal        = 'RelValTTbar_13'
-                        #, globalTag     = 'PU25ns_MCRUN2_73_V7'
+                        #, globalTag     = 'PU25ns_MCRUN2_74_V7'
                         #, dataTier      = 'GEN-SIM-RECO'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_4_0_pre5/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_73_V7-v1/00000/0A054268-C9A0-E411-8CE6-0025905A6134.root'
+        '/store/relval/CMSSW_7_4_0_pre8/RelValTTbar_13/GEN-SIM-RECO/PU25ns_MCRUN2_74_V7-v1/00000/10D198BE-64BD-E411-A4E4-00248C55CC40.root'
     )
 
-# /SingleMu/CMSSW_7_4_0_pre5-GR_R_73_V0A_RelVal_mu2012D-v1/MINIAOD
+# /SingleMu/CMSSW_7_4_0_pre8-GR_R_74_V8A_RelVal_mu2012D-v1/MINIAOD
 filesRelValSingleMuMINIAOD = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre8'
                         #, relVal        = 'SingleMu'
-                        #, globalTag     = 'GR_R_73_V0A_RelVal_mu2012D'
+                        #, globalTag     = 'GR_R_74_V8A_RelVal_mu2012D'
                         #, dataTier      = 'MINIAOD'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_4_0_pre5/SingleMu/MINIAOD/GR_R_73_V0A_RelVal_mu2012D-v1/00000/0855341F-5C9E-E411-9A51-0025905A60CA.root'
+        '/store/relval/CMSSW_7_4_0_pre8/SingleMu/MINIAOD/GR_R_74_V8A_RelVal_mu2012D-v1/00000/2494813A-ECBD-E411-ADDB-0025905A48FC.root'
     )
 
-# /SingleMu/CMSSW_7_4_0_pre5-GR_R_73_V0A_RelVal_mu2012D-v1/RECO
+# /SingleMu/CMSSW_7_4_0_pre8-GR_R_74_V8A_RelVal_mu2012D-v1/RECO
 filesSingleMuRECO = cms.untracked.vstring(
-    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre5'
+    #pickRelValInputFiles( cmsswVersion  = 'CMSSW_7_4_0_pre8'
                         #, relVal        = 'SingleMu'
                         #, dataTier      = 'RECO'
-                        #, globalTag     = 'GR_R_73_V0A_RelVal_mu2012D'
+                        #, globalTag     = 'GR_R_74_V8A_RelVal_mu2012D'
                         #, maxVersions   = 1
                         #, numberOfFiles = 1
                         #, useDAS        = True
                         #)
-        '/store/relval/CMSSW_7_4_0_pre5/SingleMu/RECO/GR_R_73_V0A_RelVal_mu2012D-v1/00000/00005DA8-EE9D-E411-A0B2-002618FDA277.root'
+        '/store/relval/CMSSW_7_4_0_pre8/SingleMu/RECO/GR_R_74_V8A_RelVal_mu2012D-v1/00000/001F3051-89BD-E411-9DAA-0025905822B6.root'
     )

--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -43,8 +43,9 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("pfTrackCountingHighEffBJetTags"),
         cms.InputTag("pfSimpleSecondaryVertexHighEffBJetTags"),
         cms.InputTag("pfSimpleSecondaryVertexHighPurBJetTags"),
+        cms.InputTag("pfCombinedSecondaryVertexV2BJetTags"),
         cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-#        cms.InputTag("pfCombinedSecondaryVertexSoftLeptonBJetTags"),
+        cms.InputTag("pfCombinedSecondaryVertexSoftLeptonBJetTags"),
         cms.InputTag("pfCombinedMVABJetTags")
     ),
     # clone tag infos ATTENTION: these take lots of space!

--- a/PhysicsTools/PatAlgos/test/patTuple_fastsim_cfg.py
+++ b/PhysicsTools/PatAlgos/test/patTuple_fastsim_cfg.py
@@ -14,8 +14,8 @@ process.load("PhysicsTools.PatAlgos.selectionLayer1.selectedPatCandidates_cff")
 #
 #   process.GlobalTag.globaltag =  ...    ##  (according to https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions)
 #                                         ##
-from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpFastSimGENSIMDIGIRECO
-process.source.fileNames = filesRelValTTbarPileUpFastSimGENSIMDIGIRECO
+from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarFastSimGENSIMDIGIRECO
+process.source.fileNames = filesRelValTTbarFastSimGENSIMDIGIRECO
 #                                         ##
 process.maxEvents.input = 100
 #                                         ##

--- a/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
+++ b/RecoBTag/SecondaryVertex/src/CombinedSVComputer.cc
@@ -219,7 +219,7 @@ CombinedSVComputer::operator () (const CandIPTagInfo &ipInfo,
 		numberofvertextracks = numberofvertextracks + (svInfo.secondaryVertex(i)).numberOfSourceCandidatePtrs();
 
 		const reco::VertexCompositePtrCandidate &vertex = svInfo.secondaryVertex(i);
-		const std::vector<CandidatePtr> tracks = vertex.daughterPtrVector();
+		const std::vector<CandidatePtr> & tracks = vertex.daughterPtrVector();
 		for(std::vector<CandidatePtr>::const_iterator track = tracks.begin(); track != tracks.end(); ++track) {
 			vertexKinematics.add(*(*track)->bestTrack(), 1.0);
 			vars.insert(btau::trackEtaRel, reco::btau::etaRel(jetDir,(*track)->momentum()), true);

--- a/TopQuarkAnalysis/Configuration/test/patRefSel_muJets_cfg.py
+++ b/TopQuarkAnalysis/Configuration/test/patRefSel_muJets_cfg.py
@@ -190,8 +190,8 @@ else:
 if len( inputFiles ) == 0:
   if runOnMiniAOD:
     if runOnMC:
-      from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValProdTTbarPileUpMINIAODSIM
-      inputFiles = filesRelValProdTTbarPileUpMINIAODSIM
+      from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValTTbarPileUpMINIAODSIM
+      inputFiles = filesRelValTTbarPileUpMINIAODSIM
     else:
       from PhysicsTools.PatAlgos.patInputFiles_cff import filesRelValSingleMuMINIAOD
       inputFiles = filesRelValSingleMuMINIAOD


### PR DESCRIPTION
Now that CMSSW_7_4_0_pre8 RelVals are available, the list of default PAT jet b-taggers has been updated. This PR completes the changes introduced in #7542, #7678, and #7732.
