### PR TITLE
Add workflows to reconstruct HGCal using PandoraPFA

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1098,6 +1098,7 @@ from  Configuration.PyReleaseValidation.upgradeWorkflowComponents import *
 # for each geometry define the GT and processing string here
 defaultDataSets={}
 defaultDataSets['Extended2023HGCalMuon']='CMSSW_6_2_0_SLHC20_patch1-DES23_62_V1_refHGCALV5-v'
+defaultDataSets['Extended2023HGCalMuonPandora']=defaultDataSets['Extended2023HGCalMuon'] # Geometry is the same, only reco is different
 defaultDataSets['Extended2023SHCalNoTaper']='CMSSW_6_2_0_SLHC20_patch1-DES23_62_V1_refSHNoTaper-v'
 defaultDataSets['2019WithGEMAging']='CMSSW_6_2_0_SLHC20-DES19_62_V8_UPG2019withGEM-v'
 keys=defaultDataSets.keys()

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -18,7 +18,7 @@ upgradeKeys=['2017',
              'Extended2023Muon',
              'Extended2023HGCalV6Muon',
              'Extended2023SHCalNoTaperNoExtPix',
-             'Extended2023Pixel',            
+             'Extended2023Pixel',
              'Extended2023SHCalNoTaper',
              'Extended2023SHCalNoTaper4Eta',
              'Extended2023HGCal',
@@ -26,9 +26,9 @@ upgradeKeys=['2017',
              'BE5DPixel10DLHCC',
              'Extended2023HGCalV4',
              'Extended2023HGCalMuonPU',
-             'Extended2023SHCalNoTaperPU',	     
+             'Extended2023SHCalNoTaperPU',
              '2019WithGEMAgingPU'
-	     ]
+         ]
 
 
 upgradeGeoms={ '2017' : 'Extended2017',
@@ -137,9 +137,9 @@ upgradeFragments=['FourMuPt_1_200_cfi','SingleElectronPt10_cfi',
                   'SingleMuPt1000Extended_cfi',
                   'TenMuE_0_200_cfi',
                   'SinglePiE50HCAL_cfi',
-		  'QCDForPF_14TeV_cfi',
-		  'DYToLL_M_50_TuneZ2star_14TeV_pythia6_tauola_cff',
-		  'DYtoTauTau_M_50_TuneD6T_14TeV_pythia6_tauola_cff'		  ]
+                  'QCDForPF_14TeV_cfi',
+                  'DYToLL_M_50_TuneZ2star_14TeV_pythia6_tauola_cff',
+                  'DYtoTauTau_M_50_TuneD6T_14TeV_pythia6_tauola_cff'          ]
 
 
 
@@ -174,7 +174,7 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'BE5DPixel10DLHCC':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCalV6Muon':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023SHCalNoTaperNoExtPix':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
-                   'Extended2023Pixel':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],          
+                   'Extended2023Pixel':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023SHCalNoTaper':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023SHCalNoTaper4Eta':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCal':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
@@ -249,9 +249,9 @@ howMuches={'FourMuPt_1_200_cfi':Kby(10,100),
            'MinBias_TuneZ2star_14TeV_pythia6_cff':Kby(9,100),
            'WM_14TeV_cfi':Kby(9,100),
            'ZMM_14TeV_cfi':Kby(18,100),
-	   'QCDForPF_14TeV_cfi':Kby(9,50),
-	   'DYToLL_M_50_TuneZ2star_14TeV_pythia6_tauola_cff':Kby(9,100),
-	   'DYtoTauTau_M_50_TuneD6T_14TeV_pythia6_tauola_cff':Kby(9,100)
+            'QCDForPF_14TeV_cfi':Kby(9,50),
+            'DYToLL_M_50_TuneZ2star_14TeV_pythia6_tauola_cff':Kby(9,100),
+            'DYtoTauTau_M_50_TuneD6T_14TeV_pythia6_tauola_cff':Kby(9,100)
            }
 
 upgradeDatasetFromFragment={'FourMuPt_1_200_cfi': 'FourMuPt1_200',
@@ -316,9 +316,9 @@ upgradeDatasetFromFragment={'FourMuPt_1_200_cfi': 'FourMuPt1_200',
                             'MinBias_TuneZ2star_14TeV_pythia6_cff' : 'MinBias_TuneZ2star_14TeV',
                             'WM_14TeV_cfi' : 'WM_14TeV',
                             'ZMM_14TeV_cfi' : 'ZMM_14TeV',
-			    'QCDForPF_14TeV_cfi' : 'QCDForPF_14TeV',
-			    'DYToLL_M_50_TuneZ2star_14TeV_pythia6_tauola_cff' : 'DYToLL_M_50_TuneZ2star_14TeV',
-			    'DYtoTauTau_M_50_TuneD6T_14TeV_pythia6_tauola_cff' : 'DYtoTauTau_M_50_TuneD6T_14TeV'
+                            'QCDForPF_14TeV_cfi' : 'QCDForPF_14TeV',
+                            'DYToLL_M_50_TuneZ2star_14TeV_pythia6_tauola_cff' : 'DYToLL_M_50_TuneZ2star_14TeV',
+                            'DYtoTauTau_M_50_TuneD6T_14TeV_pythia6_tauola_cff' : 'DYtoTauTau_M_50_TuneD6T_14TeV'
                             }
 
 

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -27,7 +27,9 @@ upgradeKeys=['2017',
              'Extended2023HGCalV4',
              'Extended2023HGCalMuonPU',
              'Extended2023SHCalNoTaperPU',
-             '2019WithGEMAgingPU'
+             '2019WithGEMAgingPU',
+             'Extended2023HGCalMuonPandora',
+             'Extended2023HGCalMuonPandoraPU'
          ]
 
 
@@ -55,7 +57,8 @@ upgradeGeoms={ '2017' : 'Extended2017',
                'Extended2023SHCalNoTaper4Eta' : 'Extended2023SHCalNoTaper4Eta,Extended2023SHCalNoTaper4EtaReco',
                'Extended2023HGCal' : 'Extended2023HGCal,Extended2023HGCalReco',
                'Extended2023HGCalMuon4Eta' : 'Extended2023HGCalMuon4Eta,Extended2023HGCalMuon4EtaReco',
-               'Extended2023HGCalV4' : 'Extended2023HGCalV4Muon,Extended2023HGCalV4MuonReco'
+               'Extended2023HGCalV4' : 'Extended2023HGCalV4Muon,Extended2023HGCalV4MuonReco',
+               'Extended2023HGCalMuonPandora' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco'
                }
 upgradeGTs={ '2017' : 'auto:upgrade2017',
              '2019' : 'auto:upgrade2019',
@@ -81,7 +84,8 @@ upgradeGTs={ '2017' : 'auto:upgrade2017',
              'Extended2023SHCalNoTaper4Eta' : 'auto:upgradePLS3',
              'Extended2023HGCal' : 'auto:upgradePLS3',
              'Extended2023HGCalMuon4Eta' : 'auto:upgradePLS3',
-             'Extended2023HGCalV4' : 'auto:upgradePLS3'
+             'Extended2023HGCalV4' : 'auto:upgradePLS3',
+             'Extended2023HGCalMuonPandora' : 'PH2_1K_FB_V6::All' #EB aged at 1000fb-1
              }
 upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2017',
                  '2019' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2019',
@@ -107,7 +111,8 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'Extended2023SHCalNoTaper4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023SHCal',
                  'Extended2023HGCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCal',
                  'Extended2023HGCalMuon4Eta' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon',
-                 'Extended2023HGCalV4' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon'
+                 'Extended2023HGCalV4' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon',
+                 'Extended2023HGCalMuonPandora' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuon'
                  }
 
 upgradeFragments=['FourMuPt_1_200_cfi','SingleElectronPt10_cfi',
@@ -182,7 +187,9 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCalV4' : ['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCalMuonPU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
                    'Extended2023SHCalNoTaperPU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPU','HARVESTFullPU'],
-                   '2019WithGEMAgingPU':['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU']
+                   '2019WithGEMAgingPU':['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU'],
+                   'Extended2023HGCalMuonPandora':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
+                   'Extended2023HGCalMuonPandoraPU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL']
                    }
 
 from  Configuration.PyReleaseValidation.relval_steps import Kby


### PR DESCRIPTION
Creates two new workflows to use HGCal v5 but using PandoraPFA in the reconstruction.  Workflows are exactly the same as the normal Extended2023HGCalMuon except that this customisation function is used:

```
RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuon
```

Numbers are 156xx for 0 pileup; and 158xx for 140 pileup.
Also fixed some whitespace.

@boudoul, I'd be interested if you have a better way of implementing this.  I just replicated the Extended2023HGCalMuon workflows and changed the customisation function.  There is obviously a lot of duplication so perhaps you have a better solution?
Also, I wasn't sure if some of the older workflows could be replaced, so played it safe and added new ones.

@vandreev11, @pfs, @lgray, @sethzenz, @kpedro88
