### PR TITLE
Fixed btagging sequence definition

### DIFF
--- a/RecoBTag/Configuration/python/RecoBTag_cff.py
+++ b/RecoBTag/Configuration/python/RecoBTag_cff.py
@@ -90,4 +90,7 @@ pfCTagging = cms.Sequence(
     pfCombinedSecondaryVertexSoftLeptonCtagLJetTags
 )
 
-btagging = legacyBTagging + pfBTagging #* pfCTagging
+btagging = cms.Sequence(
+    legacyBTagging +
+    pfBTagging #* pfCTagging
+)


### PR DESCRIPTION
The `btagging` sequence is now explicitly defined as a `cms.Sequence(...)`. It turns out that if it is not, `process.load("RecoBTag.Configuration.RecoBTag_cff")` does not load and add it to the `process`.
