### PR TITLE
Migrate from getByLabel to getByToken for SimHitTPAssociationProducer

### DIFF
--- a/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
+++ b/SimGeneral/TrackingAnalysis/interface/SimHitTPAssociationProducer.h
@@ -6,6 +6,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
 #include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
@@ -26,7 +27,7 @@ public:
 private:
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
-  std::vector<edm::InputTag> _simHitSrc;
-  edm::InputTag _trackingParticleSrc;
+  std::vector<edm::EDGetTokenT<edm::PSimHitContainer> > _simHitSrc;
+  edm::EDGetTokenT<TrackingParticleCollection> _trackingParticleSrc;
 };
 #endif


### PR DESCRIPTION
The consumes interface for SimHitTPAssociationProducer was pull requested and merged yesterday.  Since it was decided that the migration to getByToken should be done at the same time, this PR is the corresponding migration from getByLabel to getByToken.
