### PR TITLE
Fix RecoParticleFlow producers as reported by static analyser

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -180,7 +180,7 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
     double eta = cluster.eta();
     double phi = cluster.phi();    
     
-    double invE = 1./e;
+    double invE = (e == 0.) ? 0. : 1./e; //guard against dividing by 0.
     
     int size = lazyTool.n5x5(cluster);
     

--- a/RecoParticleFlow/PFProducer/src/PFAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFAlgo.cc
@@ -2194,7 +2194,6 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
     //double Caloresolution = neutralHadronEnergyResolution( totalChargedMomentum, hclusterref->positionREP().Eta());
     //Caloresolution *= totalChargedMomentum;
     // that of the charged particles linked to the cluster!
-    double TotalError = sqrt(sumpError2 + Caloresolution*Caloresolution);
 
     /* */
     ////////////////////// TRACKER MUCH LARGER THAN CALO /////////////////////////
@@ -2478,7 +2477,7 @@ void PFAlgo::processBlock( const reco::PFBlockRef& blockref,
     }
 
     // The total uncertainty of the difference Calo-Track
-    TotalError = sqrt(sumpError2 + Caloresolution*Caloresolution);
+    double TotalError = sqrt(sumpError2 + Caloresolution*Caloresolution);
 
     if ( debug_ ) {
       cout<<"\tCompare Calo Energy to total charged momentum "<<endl;


### PR DESCRIPTION
Technical bug fixes already proposed in 73X as part of #7941 
- In `RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc` added a guard against dividing by 0, in case some bug in the future might allow `reco::PFCluster::energy()` to return a 0 value;
- In `RecoParticleFlow/PFProducer/src/PFAlgo.cc`removed not needed calculation within a loop.
