### PR TITLE
mt safety updates around RecoLocalCalo RecoMET and JetMETCorrections/Type1MET

### DIFF
--- a/DataFormats/METReco/interface/CommonMETData.h
+++ b/DataFormats/METReco/interface/CommonMETData.h
@@ -11,6 +11,7 @@
 //____________________________________________________________________________||
 struct CommonMETData
 {
+  CommonMETData() :met(0), mex(0), mey(0), mez(0), sumet(0), phi(0) {}
   double met;
   double mex;
   double mey;

--- a/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
@@ -52,6 +52,7 @@ namespace CorrectedMETProducer_namespace
   class CorrectedMETFactoryT
   {
     public:
+     explicit CorrectedMETFactoryT() {}
 
      T operator()(const T&, const CorrMETData&) const
      {

--- a/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
@@ -52,7 +52,6 @@ namespace CorrectedMETProducer_namespace
   class CorrectedMETFactoryT
   {
     public:
-     explicit CorrectedMETFactoryT() {}
 
      T operator()(const T&, const CorrMETData&) const
      {
@@ -96,7 +95,7 @@ class CorrectedMETProducerT : public edm::EDProducer
 	  rawMEt != rawMEtCollection->end(); ++rawMEt ) {
       CorrMETData correction = algorithm_->compMETCorrection(evt, es);
       
-      static const CorrectedMETProducer_namespace::CorrectedMETFactoryT<T> correctedMET_factory;
+      static const CorrectedMETProducer_namespace::CorrectedMETFactoryT<T> correctedMET_factory {};
       T correctedMEt = correctedMET_factory(*rawMEt, correction);
 
       correctedMEtCollection->push_back(correctedMEt);

--- a/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
@@ -95,7 +95,7 @@ class CorrectedMETProducerT : public edm::EDProducer
 	  rawMEt != rawMEtCollection->end(); ++rawMEt ) {
       CorrMETData correction = algorithm_->compMETCorrection(evt, es);
       
-      static CorrectedMETProducer_namespace::CorrectedMETFactoryT<T> correctedMET_factory;
+      static const CorrectedMETProducer_namespace::CorrectedMETFactoryT<T> correctedMET_factory;
       T correctedMEt = correctedMET_factory(*rawMEt, correction);
 
       correctedMEtCollection->push_back(correctedMEt);

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -151,13 +151,13 @@ class PFJetMETcorrInputProducerT : public edm::EDProducer
     for ( int jetIndex = 0; jetIndex < numJets; ++jetIndex ) {
       const T& rawJet = jets->at(jetIndex);
 
-      const static PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType;
+      const static PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType {};
       checkInputType(rawJet);
 
       double emEnergyFraction = rawJet.chargedEmEnergyFraction() + rawJet.neutralEmEnergyFraction();
       if ( skipEM_ && emEnergyFraction > skipEMfractionThreshold_ ) continue;
 
-      const static PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
+      const static PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor {};
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(rawJet);
       if ( skipMuons_ ) {
 	const std::vector<reco::CandidatePtr> & cands = rawJet.daughterPtrVector();

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -151,13 +151,13 @@ class PFJetMETcorrInputProducerT : public edm::EDProducer
     for ( int jetIndex = 0; jetIndex < numJets; ++jetIndex ) {
       const T& rawJet = jets->at(jetIndex);
 
-      static PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType;
+      const static PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType;
       checkInputType(rawJet);
 
       double emEnergyFraction = rawJet.chargedEmEnergyFraction() + rawJet.neutralEmEnergyFraction();
       if ( skipEM_ && emEnergyFraction > skipEMfractionThreshold_ ) continue;
 
-      static PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
+      const static PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(rawJet);
       if ( skipMuons_ ) {
 	const std::vector<reco::CandidatePtr> & cands = rawJet.daughterPtrVector();

--- a/JetMETCorrections/Type1MET/plugins/AddCorrectionsToCaloMET.cc
+++ b/JetMETCorrections/Type1MET/plugins/AddCorrectionsToCaloMET.cc
@@ -2,7 +2,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -17,7 +17,7 @@
 #include <vector>
 
 //____________________________________________________________________________||
-class AddCorrectionsToCaloMET : public edm::EDProducer
+class AddCorrectionsToCaloMET : public edm::stream::EDProducer<>
 {
 
 public:

--- a/JetMETCorrections/Type1MET/plugins/AddCorrectionsToPFMET.cc
+++ b/JetMETCorrections/Type1MET/plugins/AddCorrectionsToPFMET.cc
@@ -2,7 +2,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -17,7 +17,7 @@
 #include <vector>
 
 //____________________________________________________________________________||
-class AddCorrectionsToPFMET : public edm::EDProducer
+class AddCorrectionsToPFMET : public edm::stream::EDProducer<>
 {
 
 public:

--- a/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MuonMETcorrInputProducer.h
@@ -12,7 +12,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,7 +24,7 @@
 
 #include <string>
 
-class MuonMETcorrInputProducer : public edm::EDProducer  
+class MuonMETcorrInputProducer : public edm::stream::EDProducer<>  
 {
  public:
 

--- a/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
@@ -14,7 +14,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -27,7 +27,7 @@
 
 #include <string>
 
-class PFCandMETcorrInputProducer : public edm::EDProducer  
+class PFCandMETcorrInputProducer : public edm::stream::EDProducer<>  
 {
  public:
 

--- a/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/PFchsMETcorrInputProducer.h
@@ -14,7 +14,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -29,7 +29,7 @@
 
 #include <string>
 
-class PFchsMETcorrInputProducer : public edm::EDProducer  
+class PFchsMETcorrInputProducer : public edm::stream::EDProducer<>  
 {
  public:
 

--- a/JetMETCorrections/Type1MET/plugins/ScaleCorrMETData.cc
+++ b/JetMETCorrections/Type1MET/plugins/ScaleCorrMETData.cc
@@ -2,7 +2,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -14,7 +14,7 @@
 #include <iostream>
 
 //____________________________________________________________________________||
-class ScaleCorrMETData : public edm::EDProducer
+class ScaleCorrMETData : public edm::stream::EDProducer<>
 {
 public:
   explicit ScaleCorrMETData(const edm::ParameterSet&);

--- a/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/SysShiftMETcorrInputProducer.h
@@ -12,7 +12,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -25,7 +25,7 @@
 
 #include <string>
 
-class SysShiftMETcorrInputProducer : public edm::EDProducer  
+class SysShiftMETcorrInputProducer : public edm::stream::EDProducer<>  
 {
  public:
 

--- a/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/Type0PFMETcorrInputProducer.h
@@ -12,7 +12,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -26,7 +26,7 @@
 
 #include <string>
 
-class Type0PFMETcorrInputProducer : public edm::EDProducer  
+class Type0PFMETcorrInputProducer : public edm::stream::EDProducer<>  
 {
  public:
 

--- a/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/Type2CorrectionProducer.cc
@@ -2,7 +2,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -18,7 +18,7 @@
 #include <vector>
 
 //____________________________________________________________________________||
-class Type2CorrectionProducer : public edm::EDProducer
+class Type2CorrectionProducer : public edm::stream::EDProducer<>
 {
 public:
   explicit Type2CorrectionProducer(const edm::ParameterSet&);

--- a/PhysicsTools/PatUtils/plugins/modules.cc
+++ b/PhysicsTools/PatUtils/plugins/modules.cc
@@ -6,12 +6,12 @@
 #include "PhysicsTools/UtilAlgos/interface/CachingVariable.h"
 
 namespace configurableAnalysis{
-  char Jet[]="pat::Jet";
-  char Muon[]="pat::Muon";
-  char MET[]="pat::MET";
-  char Electron[]="pat::Electron";
-  char Tau[]="pat::Tau";
-  char Photon[]="pat::Photon";
+  constexpr char Jet[]="pat::Jet";
+  constexpr char Muon[]="pat::Muon";
+  constexpr char MET[]="pat::MET";
+  constexpr char Electron[]="pat::Electron";
+  constexpr char Tau[]="pat::Tau";
+  constexpr char Photon[]="pat::Photon";
 }
 
 #include "DataFormats/PatCandidates/interface/Jet.h"

--- a/RecoLocalCalo/EcalRecAlgos/src/ESRecHitAnalyticAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/ESRecHitAnalyticAlgo.cc
@@ -12,8 +12,8 @@ ESRecHitAnalyticAlgo::~ESRecHitAnalyticAlgo() {
 
 double* ESRecHitAnalyticAlgo::EvalAmplitude(const ESDataFrame& digi, double ped) const {
   
-  double *fitresults = new double[3];
-  double adc[3];  
+  double *fitresults = new double[3] {};
+  double adc[3] {};  
 
   for (int i=0; i<digi.size(); i++) 
     adc[i] = digi.sample(i).adc() - ped;

--- a/RecoLocalCalo/EcalRecAlgos/src/ESRecHitFitAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/ESRecHitFitAlgo.cc
@@ -34,9 +34,9 @@ ESRecHitFitAlgo::~ESRecHitFitAlgo() {
 
 double* ESRecHitFitAlgo::EvalAmplitude(const ESDataFrame& digi, double ped) const {
   
-  double *fitresults = new double[3];
-  double adc[3];  
-  double tx[3];
+  double *fitresults = new double[3] {};
+  double adc[3] {};  
+  double tx[3] {};
   tx[0] = -5.; 
   tx[1] = 20.;
   tx[2] = 45.;
@@ -56,7 +56,7 @@ double* ESRecHitFitAlgo::EvalAmplitude(const ESDataFrame& digi, double ped) cons
   if (r23 < ratioCuts_->getR23Low()) status = 7;
 
   if (int(status) == 0) {
-    double para[10];
+    double para[10] {};
     TGraph *gr = new TGraph(3, tx, adc);
     fit_->SetParameters(50, 10);
     gr->Fit(fit_, "MQ");

--- a/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
+++ b/RecoLocalCalo/EcalRecAlgos/src/ESRecHitSimAlgo.cc
@@ -12,8 +12,8 @@
 EcalRecHit::ESFlags ESRecHitSimAlgo::evalAmplitude(float * results, const ESDataFrame& digi, float ped) const {
   
   float energy = 0;
-  float adc[3];
-  float pw[3];
+  float adc[3] {};
+  float pw[3] {};
   pw[0] = w0_;
   pw[1] = w1_;
   pw[2] = w2_;
@@ -80,7 +80,7 @@ EcalRecHit ESRecHitSimAlgo::reconstruct(const ESDataFrame& digi) const {
   auto const & ang = ang_->getMap().preshower(ind);
   auto const & statusCh = channelStatus_->getMap().preshower(ind);
 
-  float results[3];
+  float results[3] {};
 
   auto status = evalAmplitude(results, digi, ped.getMean());
 
@@ -150,10 +150,10 @@ EcalRecHit ESRecHitSimAlgo::reconstruct(const ESDataFrame& digi) const {
 
 double* ESRecHitSimAlgo::oldEvalAmplitude(const ESDataFrame& digi, const double& ped, const double& w0, const double& w1, const double& w2) const {
   
-  double *results = new double[4];
+  double *results = new double[4] {};
   float energy = 0;
-  double adc[3];
-  float pw[3];
+  double adc[3] {};
+  float pw[3] {};
   pw[0] = w0;
   pw[1] = w1;
   pw[2] = w2;

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHENegativeFlag.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHENegativeFlag.cc
@@ -98,7 +98,7 @@ void HBHENegativeFlagSetter::setPulseShapeFlags(HBHERecHit &hbhe,
       coder.adc2fC(digi,cs);
       const int nRead = cs.size();
 
-      double ts[CaloSamples::MAXSAMPLES];
+      double ts[CaloSamples::MAXSAMPLES] {};
       for (int i=0; i < nRead; i++)
       {
          const int capid = digi[i].capid();

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHETimeProfileStatusBitSetter.cc
@@ -58,7 +58,7 @@ void HBHETimeProfileStatusBitSetter::hbheSetTimeFlagsFromDigi(HBHERecHitCollecti
 {
   
   bool Bits[4]={false, false, false, false};
-  std::vector<HBHEDataFrame> digi = const_cast<std::vector<HBHEDataFrame>&>(udigi);
+  std::vector<HBHEDataFrame> digi(udigi);
   std::sort(digi.begin(), digi.end(), compare_digi_energy()); // sort digis according to energies
   std::vector<double> PulseShape; // store fC values for each time slice
   int DigiSize=0;

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -180,7 +180,7 @@ namespace HcalSimpleRecAlgoImpl {
     // and without OOT pileup corrections. Try to
     // arrange the calculations so that we do not
     // repeat them.
-    double uncorrectedEnergy[CaloSamples::MAXSAMPLES], buf[CaloSamples::MAXSAMPLES];
+    double uncorrectedEnergy[CaloSamples::MAXSAMPLES] {}, buf[CaloSamples::MAXSAMPLES] {};
     double* correctedEnergy = 0;
     double fc_ampl = 0.0, corr_fc_ampl = 0.0;
     bool pulseShapeCorrApplied = false, readjustTiming = false;
@@ -190,8 +190,8 @@ namespace HcalSimpleRecAlgoImpl {
     {
         correctedEnergy = &buf[0];
 
-        double correctionInput[CaloSamples::MAXSAMPLES];
-        double gains[CaloSamples::MAXSAMPLES];
+        double correctionInput[CaloSamples::MAXSAMPLES] {};
+        double gains[CaloSamples::MAXSAMPLES] {};
 
         for (int i=0; i<nRead; ++i)
         {

--- a/RecoMET/METProducers/interface/ElseMETProducer.h
+++ b/RecoMET/METProducers/interface/ElseMETProducer.h
@@ -20,7 +20,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -31,7 +31,7 @@
 //____________________________________________________________________________||
 namespace cms
 {
-  class ElseMETProducer: public edm::EDProducer
+  class ElseMETProducer: public edm::stream::EDProducer<>
     {
     public:
       explicit ElseMETProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/GenMETProducer.h
+++ b/RecoMET/METProducers/interface/GenMETProducer.h
@@ -20,7 +20,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,7 +33,7 @@
 //____________________________________________________________________________||
 namespace cms
 {
-  class GenMETProducer: public edm::EDProducer
+  class GenMETProducer: public edm::stream::EDProducer<>
     {
     public:
       explicit GenMETProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/MinMETProducerT.h
+++ b/RecoMET/METProducers/interface/MinMETProducerT.h
@@ -14,7 +14,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -25,7 +25,7 @@
 #include <vector>
 
 template <typename T>
-class MinMETProducerT : public edm::EDProducer
+class MinMETProducerT : public edm::stream::EDProducer<>
 {
   typedef std::vector<T> METCollection;
 

--- a/RecoMET/METProducers/interface/PFClusterMETProducer.h
+++ b/RecoMET/METProducers/interface/PFClusterMETProducer.h
@@ -5,7 +5,7 @@
 //
 /**\class PFClusterMETProducer
 
- Description: An EDProducer for CaloMET
+ Description: An stream::EDProducer<> for CaloMET
 
  Implementation:
 
@@ -20,7 +20,7 @@
 
 //____________________________________________________________________________||
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -32,7 +32,7 @@
 //____________________________________________________________________________||
 namespace cms
 {
-  class PFClusterMETProducer: public edm::EDProducer
+  class PFClusterMETProducer: public edm::stream::EDProducer<>
     {
     public:
       explicit PFClusterMETProducer(const edm::ParameterSet&);

--- a/RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h
+++ b/RecoMET/METProducers/interface/ParticleFlowForChargedMETProducer.h
@@ -7,7 +7,7 @@
 */  
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -17,7 +17,7 @@
 
 namespace reco
 {
-  class ParticleFlowForChargedMETProducer : public edm::EDProducer {
+  class ParticleFlowForChargedMETProducer : public edm::stream::EDProducer<> {
     
   public:
     explicit ParticleFlowForChargedMETProducer(const edm::ParameterSet&);


### PR DESCRIPTION
this should clear most relevant issues reported by the static analyzer in JetMETCorrections/Type1MET RecoLocalCalo and RecoMET

The original was developed in 740pre8. Tested with a short matrix (regular running) to see no difference.
