### PR TITLE
Remove some more printouts from RECO step

### DIFF
--- a/CalibFormats/SiStripObjects/src/SiStripQuality.cc
+++ b/CalibFormats/SiStripObjects/src/SiStripQuality.cc
@@ -198,7 +198,7 @@ void SiStripQuality::add(const RunInfo *runInfo)
     // This must not happen
     if( !check.empty() ) {
       // throw cms::Exception("LogicError")
-      edm::LogWarning("SiStripQuality") 
+      edm::LogInfo("SiStripQuality") 
         << "The cabling should always include the active feds in runInfo and possibly have some more"
         << "there are instead " << check.size() << " feds only active in runInfo";
       // The "false" means that we are only printing the output, but not setting the strips as bad.

--- a/CommonTools/Statistics/src/GammaSeries.cc
+++ b/CommonTools/Statistics/src/GammaSeries.cc
@@ -13,6 +13,9 @@ float GammaSeries( float a, float x )
   if( x == 0. )
     return 0.;
 
+  if( a == 0. ) // this happens at the end, but save all the iterations
+    return 0.;
+
   // coefficient c_n of x^n is Gamma(a)/Gamma(a+1+n), which leads to the
   // recurrence relation c_n = c_(n-1) / (a+n-1) with c_0 = 1/a
   double term = 1/a;

--- a/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
+++ b/DQM/SiPixelMonitorRawData/src/SiPixelRawDataErrorSource.cc
@@ -108,7 +108,6 @@ void SiPixelRawDataErrorSource::analyze(const edm::Event& iEvent, const edm::Eve
     edm::Handle<FEDRawDataCollection> rawDataHandle;
     iEvent.getByToken(inputSourceToken_, rawDataHandle);
     if(!rawDataHandle.isValid()){
-      std::cout << "inputsource is empty" << std::endl;
       edm::LogInfo("SiPixelRawDataErrorSource") << "inputsource is empty";
     }
     else{

--- a/PhysicsTools/TagAndProbe/plugins/ObjectViewCleaner.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ObjectViewCleaner.cc
@@ -38,7 +38,7 @@
 #include "DataFormats/EgammaCandidates/interface/Electron.h"
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
@@ -162,10 +162,9 @@ void ObjectViewCleaner<T>::endJob()
   stringstream ss;
   ss<<"nObjectsTot="<<nObjectsTot_<<" nObjectsClean="<<nObjectsClean_
     <<" fObjectsClean="<<100.*(nObjectsClean_/(double)nObjectsTot_)<<"%\n";
-  cout<<"++++++++++++++++++++++++++++++++++++++++++++++++++"
-      <<"\n"<<moduleLabel_<<"(ObjectViewCleaner) SUMMARY:\n"<<ss.str()
-      <<"++++++++++++++++++++++++++++++++++++++++++++++++++"
-      <<endl;
+  edm::LogInfo("ObjectViewCleaner")<<"++++++++++++++++++++++++++++++++++++++++++++++++++"
+	      <<"\n"<<moduleLabel_<<"(ObjectViewCleaner) SUMMARY:\n"<<ss.str()
+	      <<"++++++++++++++++++++++++++++++++++++++++++++++++++";
 }
 
 

--- a/RecoVertex/BeamSpotProducer/src/BSFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BSFitter.cc
@@ -570,10 +570,7 @@ reco::BeamSpot BSFitter::Fit_d0phi() {
 	//returns 0 if OK
 	auto status = h1z->Fit(&fgaus,"QLM0","",h1z->GetMean() -2.*h1z->GetRMS(),h1z->GetMean() +2.*h1z->GetRMS());
 
-	//std::cout << "fitted "<< std::endl;
-
-	//std::cout << "got function" << std::endl;
-	if (status){	
+	if (status!=0 && status!=4000){	//4000 is the status if no new minimum is found by improve
 	  edm::LogError("NoBeamSpotFit")<<"gaussian fit failed. no BS d0 fit";		
 	  return reco::BeamSpot();
 	}

--- a/RecoVertex/BeamSpotProducer/src/PVFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/PVFitter.cc
@@ -203,7 +203,7 @@ void PVFitter::setTree(TTree* tree){
 bool PVFitter::runBXFitter() {
 
   using namespace ROOT::Minuit2;
-
+  std::cout << bxMap_.size() << std::endl;
   edm::LogInfo("PVFitter") << " Number of bunch crossings: " << bxMap_.size() << std::endl;
 
   bool fit_ok = true;

--- a/RecoVertex/BeamSpotProducer/src/PVFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/PVFitter.cc
@@ -203,7 +203,6 @@ void PVFitter::setTree(TTree* tree){
 bool PVFitter::runBXFitter() {
 
   using namespace ROOT::Minuit2;
-  std::cout << bxMap_.size() << std::endl;
   edm::LogInfo("PVFitter") << " Number of bunch crossings: " << bxMap_.size() << std::endl;
 
   bool fit_ok = true;

--- a/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/muonCustoms.py
@@ -102,9 +102,9 @@ def csc_PathVsModule_SanityCheck(process):
         ('digi2raw_step', 'cscpacker'),
         ('digi2raw_step', 'csctfpacker'),
         ('reconstruction', 'csc2DRecHits'),
-        ('dqmoffline_step', 'muonAnalyzer'),
+        ('dqmoffline_step', 'muonAnalyzer')
         #('dqmHarvesting', ''),
-        ('validation_step', 'relvalMuonBits')
+#        ('validation_step', 'relvalMuonBits')
     ]
     # verify:
     for path_name, module_name in paths_modules:

--- a/Validation/RecoTau/plugins/ObjectViewCleaner.cc
+++ b/Validation/RecoTau/plugins/ObjectViewCleaner.cc
@@ -40,6 +40,7 @@
 #include "DataFormats/TrackReco/interface/Track.h"
 
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include <memory>
 #include <vector>
@@ -161,10 +162,9 @@ void ObjectViewCleaner<T>::endJob()
   stringstream ss;
   ss<<"nObjectsTot="<<nObjectsTot_<<" nObjectsClean="<<nObjectsClean_
     <<" fObjectsClean="<<100.*(nObjectsClean_/(double)nObjectsTot_)<<"%\n";
-  cout<<"++++++++++++++++++++++++++++++++++++++++++++++++++"
-      <<"\n"<<moduleLabel_<<"(ObjectViewCleaner) SUMMARY:\n"<<ss.str()
-      <<"++++++++++++++++++++++++++++++++++++++++++++++++++"
-      <<endl;
+  edm::LogInfo("ObjectViewCleaner")<<"++++++++++++++++++++++++++++++++++++++++++++++++++"
+	      <<"\n"<<moduleLabel_<<"(ObjectViewCleaner) SUMMARY:\n"<<ss.str()
+	      <<"++++++++++++++++++++++++++++++++++++++++++++++++++";
 }
 
 


### PR DESCRIPTION
Some notes:

-- I'm not sure why CMS has two copies of ObjectViewCleaner.  They seem identical, presumably the one in Validation/RecoTau should be removed
-- The beam spot fitter change reflects that if "improve" is called and does not find a new minimum, it returns status=4 (which is then turned into status=4000 by the time the exit of TH1F::Fit is called
