### PR TITLE
Refresh the index map of pointers to hits and tracks in Pandora translator

### DIFF
--- a/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.cc
+++ b/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.cc
@@ -160,6 +160,8 @@ PandoraCMSPFCandProducer::~PandoraCMSPFCandProducer()
 // ------------ method called for each event  ------------
 void PandoraCMSPFCandProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
+  recHitMap.clear();
+  recTrackMap.clear();
 
   if(debugHisto) resetVariables();
 
@@ -1541,7 +1543,7 @@ void PandoraCMSPFCandProducer::convertPandoraToCMSSW(const edm::Handle<reco::PFR
         const auto* firsthit = *(firstlayer.second->begin());
         auto iter = recHitMap.find(firsthit->GetParentCaloHitAddress());
         if( iter != recHitMap.end() ) {
-          temp.setLayer(pfrechits[iter->second].layer());
+          temp.setLayer(pfrechits.at(iter->second).layer());
         } else {
           throw cms::Exception("TrackUsedButNotFound")
             << "Hit used in PandoraPFA was not found in the original input hit list!";

--- a/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.cc
+++ b/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.cc
@@ -160,8 +160,6 @@ PandoraCMSPFCandProducer::~PandoraCMSPFCandProducer()
 // ------------ method called for each event  ------------
 void PandoraCMSPFCandProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 {
-  recHitMap.clear();
-  recTrackMap.clear();
 
   if(debugHisto) resetVariables();
 
@@ -185,6 +183,9 @@ void PandoraCMSPFCandProducer::produce(edm::Event& iEvent, const edm::EventSetup
   convertPandoraToCMSSW(tkRefCollection,HGCRecHitHandle,iEvent);
 
    PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=,PandoraApi::Reset(*m_pPandora));
+
+   recHitMap.clear();
+   recTrackMap.clear();
 }
 
 void PandoraCMSPFCandProducer::initPandoraCalibrParameters()
@@ -1674,6 +1675,9 @@ void PandoraCMSPFCandProducer::convertPandoraToCMSSW(const edm::Handle<reco::PFR
 // ------------ method called once each job just before starting event loop  ------------
 void PandoraCMSPFCandProducer::beginJob()
 {   
+  // setup our maps for processing
+  recHitMap.clear();
+  recTrackMap.clear();
 
   const char *pDisplay(::getenv("DISPLAY"));
   if (NULL == pDisplay) {


### PR DESCRIPTION
Fix issue where the index map was not reset each iteration, thus eventually causing a crash either due to bad read or memory usage.

@vandreev11 @pfs @kpedro88 @sethzenz
