### PR TITLE
Use getByToken, not getByLabel for GctDigiToRaw

### DIFF
--- a/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.cc
+++ b/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.cc
@@ -38,8 +38,6 @@ using std::vector;
 
 
 GctDigiToRaw::GctDigiToRaw(const edm::ParameterSet& iConfig) :
-  rctInputLabel_(iConfig.getParameter<edm::InputTag>("rctInputLabel")),
-  gctInputLabel_(iConfig.getParameter<edm::InputTag>("gctInputLabel")),
   packRctEm_(iConfig.getUntrackedParameter<bool>("packRctEm", true)),
   packRctCalo_(iConfig.getUntrackedParameter<bool>("packRctCalo", true)),
   fedId_(iConfig.getParameter<int>("gctFedId")),
@@ -51,24 +49,26 @@ GctDigiToRaw::GctDigiToRaw(const edm::ParameterSet& iConfig) :
 
   //register the products
   produces<FEDRawDataCollection>();
-  const std::string gctInputLabelStr = gctInputLabel_.label();
-  consumes<L1GctEmCandCollection>(edm::InputTag(gctInputLabelStr, "isoEm"));
-  consumes<L1GctEmCandCollection>(edm::InputTag(gctInputLabelStr, "nonIsoEm"));
-  consumes<L1GctJetCandCollection>(edm::InputTag(gctInputLabelStr, "cenJets"));
-  consumes<L1GctJetCandCollection>(edm::InputTag(gctInputLabelStr, "forJets"));
-  consumes<L1GctJetCandCollection>(edm::InputTag(gctInputLabelStr, "tauJets"));
-  consumes<L1GctEtTotalCollection>(gctInputLabel_);
-  consumes<L1GctEtHadCollection>(gctInputLabel_);
-  consumes<L1GctEtMissCollection>(gctInputLabel_);
-  consumes<L1GctHFRingEtSumsCollection>(gctInputLabel_);
-  consumes<L1GctHFBitCountsCollection>(gctInputLabel_);
-  consumes<L1GctHtMissCollection>(gctInputLabel_);
-  consumes<L1GctJetCountsCollection>(gctInputLabel_);
+  const edm::InputTag rctInputTag = iConfig.getParameter<edm::InputTag>("rctInputLabel");
+  const edm::InputTag gctInputTag = iConfig.getParameter<edm::InputTag>("gctInputLabel");
+  const std::string gctInputLabelStr = gctInputTag.label();
+  tokenL1GctEmCand_isoEm_ = consumes<L1GctEmCandCollection>(edm::InputTag(gctInputLabelStr, "isoEm"));
+  tokenL1GctEmCand_nonIsoEm_ = consumes<L1GctEmCandCollection>(edm::InputTag(gctInputLabelStr, "nonIsoEm"));
+  tokenGctJetCand_cenJets_ = consumes<L1GctJetCandCollection>(edm::InputTag(gctInputLabelStr, "cenJets"));
+  tokenGctJetCand_forJets_ = consumes<L1GctJetCandCollection>(edm::InputTag(gctInputLabelStr, "forJets"));
+  tokenGctJetCand_tauJets_ = consumes<L1GctJetCandCollection>(edm::InputTag(gctInputLabelStr, "tauJets"));
+  tokenGctEtTotal_ = consumes<L1GctEtTotalCollection>(gctInputTag);
+  tokenGctEtHad_ = consumes<L1GctEtHadCollection>(gctInputTag);
+  tokenGctEtMiss_ = consumes<L1GctEtMissCollection>(gctInputTag);
+  tokenGctHFRingEtSums_ = consumes<L1GctHFRingEtSumsCollection>(gctInputTag);
+  tokenGctHFBitCounts_ = consumes<L1GctHFBitCountsCollection>(gctInputTag);
+  tokenGctHtMiss_ = consumes<L1GctHtMissCollection>(gctInputTag);
+  tokenGctJetCounts_ = consumes<L1GctJetCountsCollection>(gctInputTag);
   if(packRctEm_) {
-    consumes<L1CaloEmCollection>(rctInputLabel_);
+    tokenCaloEm_ = consumes<L1CaloEmCollection>(rctInputTag);
   }
   if(packRctCalo_) {
-    consumes<L1CaloRegionCollection>(rctInputLabel_);
+    tokenCaloRegion_ = consumes<L1CaloRegionCollection>(rctInputTag);
   }
 }
 
@@ -98,42 +98,38 @@ GctDigiToRaw::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   formatTranslator_.setPackingBxId(bx);
   formatTranslator_.setPackingEventId(eventNumber);
  
-  // The GCT and RCT input label strings
-  const std::string gctInputLabelStr = gctInputLabel_.label();
-  const std::string rctInputLabelStr = rctInputLabel_.label();
-  
   // get GCT digis
   edm::Handle<L1GctEmCandCollection> isoEm;
-  iEvent.getByLabel(gctInputLabelStr, "isoEm", isoEm);
+  iEvent.getByToken(tokenL1GctEmCand_isoEm_, isoEm);
   edm::Handle<L1GctEmCandCollection> nonIsoEm;
-  iEvent.getByLabel(gctInputLabelStr, "nonIsoEm", nonIsoEm);
+  iEvent.getByToken(tokenL1GctEmCand_nonIsoEm_, nonIsoEm);
   edm::Handle<L1GctJetCandCollection> cenJets;
-  iEvent.getByLabel(gctInputLabelStr, "cenJets", cenJets);
+  iEvent.getByToken(tokenGctJetCand_cenJets_, cenJets);
   edm::Handle<L1GctJetCandCollection> forJets;
-  iEvent.getByLabel(gctInputLabelStr, "forJets", forJets);
+  iEvent.getByToken(tokenGctJetCand_forJets_, forJets);
   edm::Handle<L1GctJetCandCollection> tauJets;
-  iEvent.getByLabel(gctInputLabelStr, "tauJets", tauJets);
+  iEvent.getByToken(tokenGctJetCand_tauJets_, tauJets);
   edm::Handle<L1GctEtTotalCollection> etTotal;
-  iEvent.getByLabel(gctInputLabelStr, "", etTotal);
+  iEvent.getByToken(tokenGctEtTotal_,  etTotal);
   edm::Handle<L1GctEtHadCollection> etHad;
-  iEvent.getByLabel(gctInputLabelStr, "", etHad);
+  iEvent.getByToken(tokenGctEtHad_,  etHad);
   edm::Handle<L1GctEtMissCollection> etMiss;
-  iEvent.getByLabel(gctInputLabelStr, "", etMiss);
+  iEvent.getByToken(tokenGctEtMiss_,  etMiss);
   edm::Handle<L1GctHFRingEtSumsCollection> hfRingSums;
-  iEvent.getByLabel(gctInputLabelStr, "", hfRingSums);
+  iEvent.getByToken(tokenGctHFRingEtSums_,  hfRingSums);
   edm::Handle<L1GctHFBitCountsCollection> hfBitCounts;
-  iEvent.getByLabel(gctInputLabelStr, "", hfBitCounts);
+  iEvent.getByToken(tokenGctHFBitCounts_,  hfBitCounts);
   edm::Handle<L1GctHtMissCollection> htMiss;
-  iEvent.getByLabel(gctInputLabelStr, "", htMiss);
+  iEvent.getByToken(tokenGctHtMiss_,  htMiss);
   edm::Handle<L1GctJetCountsCollection> jetCounts;
-  iEvent.getByLabel(gctInputLabelStr, "", jetCounts);
+  iEvent.getByToken(tokenGctJetCounts_, jetCounts);
 
   // get RCT EM Cand digi
   bool packRctEmThisEvent = packRctEm_;
   edm::Handle<L1CaloEmCollection> rctEm;
   if(packRctEmThisEvent)
   {
-    iEvent.getByLabel(rctInputLabelStr, rctEm);
+    iEvent.getByToken(tokenCaloEm_, rctEm);
     if(rctEm.failedToGet())
     {
       packRctEmThisEvent = false;
@@ -146,7 +142,7 @@ GctDigiToRaw::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle<L1CaloRegionCollection> rctCalo;
   if(packRctCaloThisEvent)
   {
-    iEvent.getByLabel(rctInputLabelStr, rctCalo);
+    iEvent.getByToken(tokenCaloRegion_, rctCalo);
     if(rctCalo.failedToGet())
     {
       packRctCaloThisEvent = false;

--- a/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.h
+++ b/EventFilter/GctRawToDigi/plugins/GctDigiToRaw.h
@@ -28,7 +28,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawData.h"
 
@@ -52,9 +52,21 @@ class GctDigiToRaw : public edm::EDProducer {
 
  private:  // members
 
-  // input tags
-  edm::InputTag rctInputLabel_;
-  edm::InputTag gctInputLabel_;
+  // input tokens
+  edm::EDGetTokenT<L1GctEmCandCollection> tokenL1GctEmCand_isoEm_;
+  edm::EDGetTokenT<L1GctEmCandCollection> tokenL1GctEmCand_nonIsoEm_;
+  edm::EDGetTokenT<L1GctJetCandCollection> tokenGctJetCand_cenJets_;
+  edm::EDGetTokenT<L1GctJetCandCollection> tokenGctJetCand_forJets_;
+  edm::EDGetTokenT<L1GctJetCandCollection> tokenGctJetCand_tauJets_;
+  edm::EDGetTokenT<L1GctEtTotalCollection> tokenGctEtTotal_;
+  edm::EDGetTokenT<L1GctEtHadCollection> tokenGctEtHad_;
+  edm::EDGetTokenT<L1GctEtMissCollection> tokenGctEtMiss_;
+  edm::EDGetTokenT<L1GctHFRingEtSumsCollection> tokenGctHFRingEtSums_;
+  edm::EDGetTokenT<L1GctHFBitCountsCollection> tokenGctHFBitCounts_;
+  edm::EDGetTokenT<L1GctHtMissCollection> tokenGctHtMiss_;
+  edm::EDGetTokenT<L1GctJetCountsCollection> tokenGctJetCounts_;
+  edm::EDGetTokenT<L1CaloEmCollection> tokenCaloEm_;
+  edm::EDGetTokenT<L1CaloRegionCollection> tokenCaloRegion_;
 
   // pack flags
   bool packRctEm_;


### PR DESCRIPTION
The consumes interface for GctDigiToRaw was done recently. This pull request completes the migration by replacing getByLabel with getByToken.
