### PR TITLE
Topic pandora track cleaning

### DIFF
--- a/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.cc
+++ b/RecoBTag/SoftLepton/plugins/SoftPFMuonTagInfoProducer.cc
@@ -148,10 +148,13 @@ bool SoftPFMuonTagInfoProducer::isTightMuon(const reco::Muon* muon) {
 
 bool SoftPFMuonTagInfoProducer::isMuonClean(edm::Event& iEvent,const reco::PFCandidate* PFcandidate){
 	const reco::Muon* muon=PFcandidate->muonRef().get();
- 	if(muonId>=0 && !isLooseMuon(muon)) return false;
-      	if(muonId>=1 && !isSoftMuon (muon)) return false;
-      	if(muonId>=2 && !isTightMuon(muon)) return false;
-	return true;
+	if( muon != nullptr && PFcandidate->muonRef().isNonnull() ) {
+	  if(muonId>=0 && !isLooseMuon(muon)) return false;
+	  if(muonId>=1 && !isSoftMuon (muon)) return false;
+	  if(muonId>=2 && !isTightMuon(muon)) return false;
+	  return true;
+	}
+	return false;
 }
 
 

--- a/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.h
+++ b/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.h
@@ -393,4 +393,7 @@ private:
   short _debugLevel;
   double speedoflight;
 
+  double _deltaPtOverPtForPfo;
+  double _deltaPtOverPtForClusterlessPfo;
+
 };

--- a/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
+++ b/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
@@ -23,6 +23,6 @@ pandorapfanew = cms.EDProducer('PandoraCMSPFCandProducer',
     useOverburdenCorrection = cms.bool(False), #disabled until the overburden values make sense
     pf_electron_output_col=cms.string('electrons'),
     outputFile = cms.string('pandoraoutput.root'),
-    MaxDeltaPtOverPtForPfo = cms.double(100),
-    MaxDeltaPtOverPtForClusterlessPfo = cms.double(50),
+    MaxDeltaPtOverPtForPfo = cms.double(1.00),
+    MaxDeltaPtOverPtForClusterlessPfo = cms.double(0.50),
 )

--- a/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
+++ b/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
@@ -22,5 +22,7 @@ pandorapfanew = cms.EDProducer('PandoraCMSPFCandProducer',
     overburdenDepthFile = cms.FileInPath('RecoParticleFlow/PFClusterProducer/data/HGCMaterialOverburden.root'),
     useOverburdenCorrection = cms.bool(False), #disabled until the overburden values make sense
     pf_electron_output_col=cms.string('electrons'),
-    outputFile = cms.string('pandoraoutput.root')
+    outputFile = cms.string('pandoraoutput.root'),
+    MaxDeltaPtOverPtForPfo = cms.double(100),
+    MaxDeltaPtOverPtForClusterlessPfo = cms.double(50),
 )


### PR DESCRIPTION
@kpedro88 submitting this PR for @lgray. Cuts on delta_pt/pt were added for the Pandora PF objects to reject misreconstructed tracks. These cuts had the desired effect of removing jets/charged hadrons with unphysically high energies.

Before:
![pfjetenergy_before_deltapt_cut](https://cloud.githubusercontent.com/assets/4672808/6456695/a1092bd2-c12d-11e4-873f-a5b498def7a8.png)

After:
![pfjetenergy_after_deltapt_cut](https://cloud.githubusercontent.com/assets/4672808/6456697/a8c9a6b2-c12d-11e4-9500-ad77533825d4.png)

Please include this PR in the release with the other HGCal Pandora PRs. This is important for physics performance.

Attn: @vandreev11 @pfs @sethzenz
