### PR TITLE
fix pat::MET variations (uncertainties and correction) reading bug in C++ modules

### DIFF
--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -43,7 +43,10 @@ PATObject<reco::MET>(iOther),
 genMET_(iOther.genMET_),
 caloMET_(iOther.caloMET_),
 pfMET_(iOther.pfMET_),
-uncorInfo_(nullptr)
+uncorInfo_(nullptr),
+uncertaintiesRaw_(iOther.uncertaintiesRaw_),
+uncertaintiesType1_(iOther.uncertaintiesType1_),
+uncertaintiesType1p2_(iOther.uncertaintiesType1p2_)
 {
    auto tmp = iOther.uncorInfo_.load(std::memory_order_acquire);
    if(tmp != nullptr) {
@@ -63,6 +66,9 @@ MET& MET::operator=(MET const& iOther) {
    genMET_ = iOther.genMET_;
    caloMET_ =iOther.caloMET_;
    pfMET_ =iOther.pfMET_;
+   uncertaintiesRaw_ =iOther.uncertaintiesRaw_;
+   uncertaintiesType1_ =iOther.uncertaintiesType1_;
+   uncertaintiesType1p2_ =iOther.uncertaintiesType1p2_;
    auto tmp = iOther.uncorInfo_.load(std::memory_order_acquire);
    if(tmp != nullptr) {
       //Only thread-safe to read iOther.nCorrections_ if iOther.uncorInfo_ != nullptr


### PR DESCRIPTION
Bug fix of the problem reported in 
https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3309.html

Contructor of the pat::MET was not copying the vectors containing the MET uncertainty informations.
