### PR TITLE
use isPromptFinalState() instead of genParticle status for egamma HLT relval

### DIFF
--- a/HLTriggerOffline/Egamma/python/EgammaValidationAutoConf_cff.py
+++ b/HLTriggerOffline/Egamma/python/EgammaValidationAutoConf_cff.py
@@ -29,10 +29,9 @@ samples.num   = [1,
 # produce generated paricles in acceptance               #
 ##########################################################
 
-genp = cms.EDFilter("PdgIdAndStatusCandViewSelector",
-    status = cms.vint32(3),
+genp = cms.EDFilter("CandViewSelector",
     src = cms.InputTag("genParticles"),
-    pdgId = cms.vint32(11)  # replaced in loop
+    cut = cms.string("isPromptFinalState() & abs(pdgId) = 11")  # replaced in loop
 )
 
 fiducial = cms.EDFilter("EtaPtMinCandViewSelector",
@@ -55,7 +54,7 @@ for samplenum in range(len(samples.names)):
     # clone genparticles and select correct type
     genpartname = "genpart"+samples.names[samplenum]
     globals()[genpartname] = genp.clone()
-    setattr(globals()[genpartname],"pdgId",cms.vint32(samples.pdgid[samplenum]) ) # set pdgId
+    setattr(globals()[genpartname],"cut",cms.string("isPromptFinalState() & abs(pdgId) = "+str(samples.pdgid[samplenum])) ) # set pdgId
     egammaSelectors *= globals()[genpartname]                            # add to sequence
 
     # clone generator fiducial region


### PR DESCRIPTION
Use isPromptFinalState() introduced in PR #7812 instead of genParticle status for egamma HLT relval to get plots for pythia8 samples.
