### PR TITLE
cout replaced by LogVerbatim

### DIFF
--- a/DataFormats/CSCDigi/src/CSCALCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCALCTDigi.cc
@@ -7,7 +7,7 @@
  */
 
 #include <DataFormats/CSCDigi/interface/CSCALCTDigi.h>
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iomanip>
 #include <iostream>
 
@@ -83,17 +83,18 @@ bool CSCALCTDigi::operator != (const CSCALCTDigi& rhs) const {
 /// Debug
 void CSCALCTDigi::print() const {
   if (isValid()) {
-    std::cout << "CSC ALCT #"         << setw(1) << getTrknmb()
+    edm::LogVerbatim("CSCDigi") 
+              << "CSC ALCT #"         << setw(1) << getTrknmb()
 	      << ": Valid = "         << setw(1) << isValid()
 	      << " Quality = "        << setw(2) << getQuality()
 	      << " Accel. = "         << setw(1) << getAccelerator()
 	      << " PatternB = "       << setw(1) << getCollisionB()
 	      << " Key wire group = " << setw(3) << getKeyWG()
 	      << " BX = "             << setw(2) << getBX()
-              << " Full BX= "         << std::setw(1) << getFullBX() << std::endl;
+	      << " Full BX= "         << std::setw(1) << getFullBX();
   }
   else {
-    std::cout << "Not a valid Anode LCT." << std::endl;
+    edm::LogVerbatim("CSCDigi") << "Not a valid Anode LCT.";
   }
 }
 

--- a/DataFormats/CSCDigi/src/CSCCFEBStatusDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCFEBStatusDigi.cc
@@ -4,7 +4,7 @@
  * \author N.Terentiev, CMU
  */
 #include <DataFormats/CSCDigi/interface/CSCCFEBStatusDigi.h>
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include <stdint.h>
 
@@ -95,44 +95,52 @@ std::vector<int> CSCCFEBStatusDigi::getTRIG_TIME() const {
 
             /// Debug
 void CSCCFEBStatusDigi::print() const {
-    std::cout << "CSC CFEB # : " << getCFEBNmb() <<"\n";
-    std::cout << " SCAFullCond: ";
-    if(getSCAFullCond().size()!=0){
-    for (size_t i = 0; i<4; ++i ){
-        std::cout <<" " <<(getSCAFullCond())[i]; }
-	}
-    else {
-    std::cout << " " <<"BWORD is not valied";
-    }	
-    std::cout << "\n";
-    std::cout << " CRC: ";
-    for (size_t i = 0; i<getCRC().size(); ++i ){
-        std::cout <<" " <<(getCRC())[i]; }
-    std::cout<<"\n";
-    std::cout << " TS_FLAG: ";
-    for (size_t i = 0; i<getTS_FLAG().size(); ++i ){
-        std::cout <<" " <<(getTS_FLAG())[i]; }
-    std::cout<<"\n";
-    std::cout << " SCA_FULL: ";
-    for (size_t i = 0; i<getSCA_FULL().size(); ++i ){
-        std::cout <<" " <<(getSCA_FULL())[i]; }
-    std::cout<<"\n";
-    std::cout << " LCT_PHASE: ";
-    for (size_t i = 0; i<getLCT_PHASE().size(); ++i ){
-        std::cout <<" " <<(getLCT_PHASE())[i]; }
-    std::cout<<"\n";
-    std::cout << " L1A_PHASE: ";
-    for (size_t i = 0; i<getL1A_PHASE().size(); ++i ){
-        std::cout <<" " <<(getL1A_PHASE())[i]; }
-    std::cout<<"\n";
-    std::cout << " SCA_BLK: ";
-    for (size_t i = 0; i<getSCA_BLK().size(); ++i ){
-        std::cout <<" " <<(getSCA_BLK())[i]; }
-    std::cout<<"\n";
-    std::cout << " TRIG_TIME: ";
-    for (size_t i = 0; i<getTRIG_TIME().size(); ++i ){
-        std::cout <<" " <<(getTRIG_TIME())[i]; }
-    std::cout<<"\n";
+  edm::LogVerbatim("CSCDigi") << "CSC CFEB # : " << getCFEBNmb();
+  
+  std::ostringstream ost;
+  ost << " SCAFullCond: ";
+  if(getSCAFullCond().size()!=0){
+    for (size_t i = 0; i<4; ++i ){ ost << " " <<(getSCAFullCond())[i]; }
+  }
+  else {
+    ost << " " <<"BWORD is not valid";
+  }	
+  edm::LogVerbatim("CSCDigi") << ost.str();
+
+  ost.clear();
+  ost << " CRC: ";
+  for (size_t i = 0; i<getCRC().size(); ++i ){ ost << " " <<(getCRC())[i]; }
+  edm::LogVerbatim("CSCDigi") << ost.str();
+
+  ost.clear();
+  ost << " TS_FLAG: ";
+  for (size_t i = 0; i<getTS_FLAG().size(); ++i ){ ost << " " <<(getTS_FLAG())[i]; }
+  edm::LogVerbatim("CSCDigi") << ost.str();
+
+  ost.clear();
+  ost << " SCA_FULL: ";
+  for (size_t i = 0; i<getSCA_FULL().size(); ++i ){ ost << " " <<(getSCA_FULL())[i]; }
+  edm::LogVerbatim("CSCDigi") << ost.str();
+
+  ost.clear();
+  ost << " LCT_PHASE: ";
+  for (size_t i = 0; i<getLCT_PHASE().size(); ++i ){ ost << " " <<(getLCT_PHASE())[i]; }
+  edm::LogVerbatim("CSCDigi") << ost.str();
+
+  ost.clear();
+  ost << " L1A_PHASE: ";
+  for (size_t i = 0; i<getL1A_PHASE().size(); ++i ){ ost << " " <<(getL1A_PHASE())[i]; }
+  edm::LogVerbatim("CSCDigi") << ost.str();
+
+  ost.clear();
+  ost << " SCA_BLK: ";
+  for (size_t i = 0; i<getSCA_BLK().size(); ++i ){ ost << " " <<(getSCA_BLK())[i]; }
+  edm::LogVerbatim("CSCDigi") << ost.str();
+
+  ost.clear();
+  ost << " TRIG_TIME: ";
+  for (size_t i = 0; i<getTRIG_TIME().size(); ++i ){ ost << " " <<(getTRIG_TIME())[i]; }
+  edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
 std::ostream & operator<<(std::ostream & o, const CSCCFEBStatusDigi& digi) {

--- a/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCLCTDigi.cc
@@ -7,7 +7,7 @@
  */
 
 #include <DataFormats/CSCDigi/interface/CSCCLCTDigi.h>
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iomanip>
 #include <iostream>
 
@@ -120,7 +120,8 @@ void CSCCLCTDigi::print() const {
     char stripType = (getStripType() == 0) ? 'D' : 'H';
     char bend      = (getBend()      == 0) ? 'L' : 'R';
 
-    std::cout << " CSC CLCT #"    << std::setw(1) << getTrknmb()
+    edm::LogVerbatim("CSCDigi")
+              << " CSC CLCT #"    << std::setw(1) << getTrknmb()
 	      << ": Valid = "     << std::setw(1) << isValid()
 	      << " Key Strip = "  << std::setw(3) << getKeyStrip()
 	      << " Strip = "      << std::setw(2) << getStrip()
@@ -130,10 +131,10 @@ void CSCCLCTDigi::print() const {
 	      << " Strip type = " << std::setw(1) << stripType
 	      << " CFEB ID = "    << std::setw(1) << getCFEB()
 	      << " BX = "         << std::setw(1) << getBX() 
-              << " Full BX= "     << std::setw(1) << getFullBX() << std::endl;
+              << " Full BX= "     << std::setw(1) << getFullBX();
   }
   else {
-    std::cout << "Not a valid Cathode LCT." << std::endl;
+    edm::LogVerbatim("CSCDigi") << "Not a valid Cathode LCT.";
   }
 }
 

--- a/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCComparatorDigi.cc
@@ -4,6 +4,7 @@
  * \author M.Schmitt, Northwestern
  */
 #include <DataFormats/CSCDigi/interface/CSCComparatorDigi.h>
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include <algorithm>
 #include <iterator>
@@ -92,14 +93,13 @@ void CSCComparatorDigi::setComparator(int comparator) {
 
 void
 CSCComparatorDigi::print() const {
-  std::cout << "CSCComparatorDigi strip: " << getStrip() 
-       << " comparator: " << getComparator() 
-	    << " first time bin: "<< getTimeBin()
-       << " time bins on: ";
+  std::ostringstream ost;
+  ost << "CSCComparatorDigi | strip " << getStrip()
+      << " | comparator " << getComparator() 
+      << " | first time bin "  << getTimeBin() << " | time bins on ";
   std::vector<int> tbins=getTimeBinsOn();
-  std::copy( tbins.begin(), tbins.end(), 
-     std::ostream_iterator<int>( std::cout, " "));
-  std::cout << std::endl; 
+  for(unsigned int i=0; i<tbins.size();i++) {ost << tbins[i] << " ";}
+  edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
 //@@ Doesn't print all time bins

--- a/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCCorrelatedLCTDigi.cc
@@ -7,6 +7,7 @@
  */
 
 #include "DataFormats/CSCDigi/interface/CSCCorrelatedLCTDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
 /// Constructors
@@ -65,7 +66,8 @@ bool CSCCorrelatedLCTDigi::operator==(const CSCCorrelatedLCTDigi &rhs) const {
 /// Debug
 void CSCCorrelatedLCTDigi::print() const {
   if (isValid()) {
-    std::cout << "CSC LCT #"        << getTrknmb() 
+    edm::LogVerbatim("CSCDigi")
+              << "CSC LCT #"        << getTrknmb() 
 	      << ": Valid = "       << isValid()
 	      << " Quality = "      << getQuality()
 	      << " Key Wire = "     << getKeyWG()
@@ -73,10 +75,10 @@ void CSCCorrelatedLCTDigi::print() const {
               << " Pattern = "      << getPattern()
 	      << " Bend = "         << ( (getBend() == 0) ? 'L' : 'R' )
 	      << " BX = "           << getBX() 
-	      << " MPC Link = "     << getMPCLink() << std::endl;
+	      << " MPC Link = "     << getMPCLink();
   }
   else {
-    std::cout << "Not a valid correlated LCT." << std::endl;
+    edm::LogVerbatim("CSCDigi") << "Not a valid correlated LCT.";
   }
 }
 

--- a/DataFormats/CSCDigi/src/CSCDCCFormatStatusDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCDCCFormatStatusDigi.cc
@@ -18,7 +18,7 @@
  */
 
 #include "DataFormats/CSCDigi/interface/CSCDCCFormatStatusDigi.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include <iomanip>
 
@@ -53,23 +53,51 @@ void CSCDCCFormatStatusDigi::setDCCExaminerInfo(const ExaminerMaskType fDCC_MASK
             /// Debug
 void CSCDCCFormatStatusDigi::print() const {
 
-   std::cout << "CSCDCCFormatStatusDigi: DCC=" << std::dec << getDCCId() 
+  // Keep original code in case I messed up the formatting in some subtle way when switching to MessageLogger
+  //
+  //   std::cout << "CSCDCCFormatStatusDigi: DCC=" << std::dec << getDCCId() 
+  //	<< " DCCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getDCCMask()
+  //	<< " CSCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCMask()
+  //	<< " DCCErrors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUSummaryErrors() 
+  //	<< std::dec << "\n";
+  //   std::set<DDUIdType> ddu_list = getListOfDDUs();
+  //   for (std::set<DDUIdType>::iterator itr=ddu_list.begin(); itr != ddu_list.end(); ++itr) {
+  //   	std::cout << "DDU_" << std::dec << ((*itr)&0xFF) 
+  //	<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUErrors(*itr) << "\n"; 
+  //   }
+  //   std::set<CSCIdType> csc_list = getListOfCSCs();
+  //   for (std::set<CSCIdType>::iterator itr=csc_list.begin(); itr != csc_list.end(); ++itr) {
+  //	
+  //        std::cout << "CSC_" << std::dec << (((*itr)>>4)&0xFF) << "_" << ((*itr)&0xF) 
+  //		<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCErrors(*itr) 
+  //		<< " Payload=0x" << std::setw(8) << std::setfill('0') << getCSCPayload(*itr) 
+  //		<< " Status=0x" << std::setw(8) << std::setfill('0') << getCSCStatus(*itr) << "\n";
+  //   }
+
+  edm::LogVerbatim("CSCDigi") << "CSCDCCFormatStatusDigi: DCC=" << std::dec << getDCCId() 
 	<< " DCCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getDCCMask()
 	<< " CSCMask=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCMask()
 	<< " DCCErrors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUSummaryErrors() 
-	<< std::dec << "\n";
+        << std::dec;
+
+   std::ostringstream ost;
+
    std::set<DDUIdType> ddu_list = getListOfDDUs();
    for (std::set<DDUIdType>::iterator itr=ddu_list.begin(); itr != ddu_list.end(); ++itr) {
-   	std::cout << "DDU_" << std::dec << ((*itr)&0xFF) 
-	<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUErrors(*itr) << "\n"; 
+   	ost  << "DDU_" << std::dec << ((*itr)&0xFF) 
+	     << " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getDDUErrors(*itr);
+	edm::LogVerbatim("CSCDigi") << ost.str();
+	ost.clear();
    }
+
    std::set<CSCIdType> csc_list = getListOfCSCs();
    for (std::set<CSCIdType>::iterator itr=csc_list.begin(); itr != csc_list.end(); ++itr) {
-	
-        std::cout << "CSC_" << std::dec << (((*itr)>>4)&0xFF) << "_" << ((*itr)&0xF) 
+        ost << "CSC_" << std::dec << (((*itr)>>4)&0xFF) << "_" << ((*itr)&0xF) 
 		<< " Errors=0x" << std::hex << std::setw(8) << std::setfill('0') << getCSCErrors(*itr) 
 		<< " Payload=0x" << std::setw(8) << std::setfill('0') << getCSCPayload(*itr) 
-		<< " Status=0x" << std::setw(8) << std::setfill('0') << getCSCStatus(*itr) << "\n";
+	    << " Status=0x" << std::setw(8) << std::setfill('0') << getCSCStatus(*itr);
+	edm::LogVerbatim("CSCDigi") << ost.str();
+	ost.clear();
    }
 
 }

--- a/DataFormats/CSCDigi/src/CSCDCCStatusDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCDCCStatusDigi.cc
@@ -5,6 +5,7 @@
  *
  */
 #include "DataFormats/CSCDigi/interface/CSCDCCStatusDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <ostream>
 #include <cstring>
 #include <iostream>
@@ -26,9 +27,9 @@ const uint16_t CSCDCCStatusDigi::getDCCTTS() const {
 }
 
 void CSCDCCStatusDigi::print() const {
-     std::cout << " Header: " << std::hex << *header_ <<
-     " Trailer: " << std::hex << *trailer_ << " ErrorFlag: " <<  errorFlag_ <<
-     " TTS: " << getDCCTTS() << std::dec << std::endl;
+  edm::LogVerbatim("CSCDigi") << " Header: " << std::hex << *header_ <<
+    " Trailer: " << std::hex << *trailer_ << " ErrorFlag: " <<  errorFlag_ <<
+    " TTS: " << getDCCTTS() << std::dec;
 }
 
 std::ostream & operator<<(std::ostream & o, const CSCDCCStatusDigi& digi) {

--- a/DataFormats/CSCDigi/src/CSCDDUStatusDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCDDUStatusDigi.cc
@@ -5,6 +5,7 @@
  *
  */
 #include "DataFormats/CSCDigi/interface/CSCDDUStatusDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <ostream>
 #include <cstring>
 #include <iostream>
@@ -24,8 +25,8 @@ const uint16_t CSCDDUStatusDigi::getDDUTTS() const {
 }
 
 void CSCDDUStatusDigi::print() const {
-     std::cout << " Header: " << std::hex << *header_ <<
-     " Trailer: " << std::hex << *trailer_ << " TTS: " << getDDUTTS() << std::dec << std::endl;
+  edm::LogVerbatim("CSCDigi") << " Header: " << std::hex << *header_ <<
+    " Trailer: " << std::hex << *trailer_ << " TTS: " << getDDUTTS() << std::dec;
 }
 
 std::ostream & operator<<(std::ostream & o, const CSCDDUStatusDigi& digi) {

--- a/DataFormats/CSCDigi/src/CSCRPCDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCRPCDigi.cc
@@ -8,6 +8,7 @@
 
 
 #include "DataFormats/CSCDigi/interface/CSCRPCDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 
 /// Constructors
@@ -29,10 +30,8 @@ CSCRPCDigi::CSCRPCDigi (){
 
 /// Debug
 void CSCRPCDigi::print() const {
-  std::cout << "RPC = " << getRpc()
-	    << "  Pad = " << getPad()
-	    << "  Tbin = " << getTbin() 
-	    << "  BXN = " << getBXN() << std::endl;
+  edm::LogVerbatim("CSCDigi") << "CSCRPCDigi | rpc " << getRpc() << " | pad " << getPad()
+	    << " | tbin " << getTbin() << " | bxn  " << getBXN();
 }
 
 std::ostream & operator<<(std::ostream & o, const CSCRPCDigi& digi) {

--- a/DataFormats/CSCDigi/src/CSCStripDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCStripDigi.cc
@@ -4,6 +4,7 @@
  * \author M.Schmitt, Northwestern
  */
 #include "DataFormats/CSCDigi/interface/CSCStripDigi.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include <cstdint>
 
@@ -35,22 +36,16 @@ void CSCStripDigi::setADCCounts(const std::vector<int>&vADCCounts) {
 // Debug
 void
 CSCStripDigi::print() const {
-  std::cout << "CSC Strip: " << getStrip() << "  ADC Counts: ";
-  for (int i=0; i<(int)getADCCounts().size(); i++) {std::cout << getADCCounts()[i] << " ";}
-  std::cout << "\n";
-  std::cout << "            " << "  ADCOverflow: ";
-  for (int i=0; i<(int)getADCOverflow().size(); i++) {std::cout << getADCOverflow()[i] << " ";}
-  std::cout << "\n";
-  std::cout << "            " << "  OverflappedSample: ";
-  for (int i=0; i<(int)getOverlappedSample().size(); i++) {
-  //if(getOverlappedSample()[i]!=1)
-  std::cout << getOverlappedSample()[i] << " ";}
-  std::cout << "\n";
-  std::cout << "            " << "  L1APhases: ";
-  for(int i=0; i<(int)getL1APhase().size(); i++){
-     std::cout << getL1APhase()[i] << " ";
-  }
-  std::cout << "\n";
+  std::ostringstream ost;
+  ost << "CSCStripDigi | strip " << getStrip() << " | ADCCounts ";
+  for (int i=0; i<(int)getADCCounts().size(); i++) {ost << getADCCounts()[i] << " ";}
+  ost << " | Overflow ";
+  for (int i=0; i<(int)getADCOverflow().size(); i++) {ost << getADCOverflow()[i] << " ";}
+  ost << " | Overlapped ";
+  for (int i=0; i<(int)getOverlappedSample().size(); i++) {ost << getOverlappedSample()[i] << " ";}
+  ost << " | L1APhase ";
+  for(int i=0; i<(int)getL1APhase().size(); i++){ost << getL1APhase()[i] << " ";}
+  edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
 std::ostream & operator<<(std::ostream & o, const CSCStripDigi& digi) {

--- a/DataFormats/CSCDigi/src/CSCWireDigi.cc
+++ b/DataFormats/CSCDigi/src/CSCWireDigi.cc
@@ -5,7 +5,7 @@
  */
 
 #include "DataFormats/CSCDigi/interface/CSCWireDigi.h"
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iostream>
 #include <stdint.h>
 
@@ -60,15 +60,14 @@ std::vector<int> CSCWireDigi::getTimeBinsOn() const {
   /// Debug
 
 void CSCWireDigi::print() const {
-  std::cout << " CSC Wire " << getWireGroup() << " | "
-            << " CSC Wire BX # " << getWireGroupBX() << " | " 
-            << " CSC BX + Wire " << std::hex << getBXandWireGroup() << " | " << std::dec
-            << " CSC Wire First Time Bin On " << getTimeBin()  
-            << std::endl;
-  std::cout << " CSC Time Bins On ";
+  std::ostringstream ost;
+  ost << "CSCWireDigi | wg " << getWireGroup() << " | "
+      << " BX # " << getWireGroupBX() << " | "
+      << " BX + Wire " << std::hex << getBXandWireGroup() << " | " << std::dec
+      << " First Time Bin On " << getTimeBin() << " | Time Bins On ";
   std::vector<int> tbins=getTimeBinsOn();
-  for(unsigned int i=0; i<tbins.size();i++) std::cout<<tbins[i]<<" ";
-  std::cout<<std::endl; 
+  for(unsigned int i=0; i<tbins.size();i++) {ost << tbins[i] << " ";}
+  edm::LogVerbatim("CSCDigi") << ost.str();
 }
 
 std::ostream & operator<<(std::ostream & o, const CSCWireDigi& digi) {


### PR DESCRIPTION
Converted all occurrences of cout in DataFormats/CSCDigi/ to MessageLogger. There were 11 .cc files containing 'cout' in print() functions, They have all been converted to LogVerbatim. I've only tested some of them but that's fine because they're never used in production anyway - they're used for expert debugging only. The standard  "runTheMatrix.py -s --useInput all" tests run fine, unsurprisingly, in 7_5_X. I was assured by Chris Jones that making this change should not affect the Digi structure, or break compatibility in any way :)
