### PR TITLE
Small fix to PR #7823 (Adding the retina fitter)

### DIFF
--- a/L1Trigger/TrackFindingAM/BuildFile.xml
+++ b/L1Trigger/TrackFindingAM/BuildFile.xml
@@ -34,6 +34,7 @@
 <use name="boost"/>
 <use name="root"/>
 <use name="rootrflx"/>
+<use name="rootgpad"/>
 <use name="DataFormats/SiPixelDetId"/>
 <use name="DataFormats/L1TrackTrigger"/>
 <lib name="boost_serialization"/>

--- a/L1Trigger/TrackFindingAM/interface/CMSPatternLayer.h
+++ b/L1Trigger/TrackFindingAM/interface/CMSPatternLayer.h
@@ -96,7 +96,16 @@ class CMSPatternLayer : public PatternLayer{
      \return A string describing the PatternLayer
   **/
   string toStringBinary();
-
+  /**
+     \brief Returns a string representation of the PatternLayer, using binary values and in the correct AM05 order (strip position at the end).
+     \return A string describing the PatternLayer
+  **/
+  string toStringSuperstripBinary();
+  /**
+     \brief Returns a string representation of the PatternLayer, using the encoding needed for a AM05 chip
+     \return A string describing the PatternLayer
+  **/
+  string toAM05Format();
   /**
      \brief Returns the module's Z position
      \return The module's Z position

--- a/L1Trigger/TrackFindingAM/interface/PatternFinder.h
+++ b/L1Trigger/TrackFindingAM/interface/PatternFinder.h
@@ -110,7 +110,11 @@ class PatternFinder{
      \param stop The search will end at this event number
    **/
   void displayEventsSuperstrips(int start, int& stop);
-
+  /**
+    \brief Display the given hits as superstrips if they are part of the sector. Each line will contain the layer ID followed by the 16 bits of the superstrip as an integer.
+    \param hits The list of hits in the event
+  **/
+  void displaySuperstrips(const vector<Hit*> &hits);
   /**
      \brief Use the maximum missing hit threshold instead of the active_threshold
    **/

--- a/L1Trigger/TrackFindingAM/interface/Retina.h
+++ b/L1Trigger/TrackFindingAM/interface/Retina.h
@@ -1,0 +1,83 @@
+#ifndef _RETINA_H_
+#define _RETINA_H_
+
+#include <vector>
+
+#include "Hit.h"
+
+#include "TMath.h"
+#include "TStyle.h"
+#include "TH2D.h"
+#include "TCanvas.h"
+#include "TRandom3.h"
+
+
+using namespace std;
+
+
+struct Hit_t {
+  double x;
+  double y;
+  double z;
+  double rho;
+  short layer;
+  int id;
+};
+
+struct pqPoint_i {
+  int p;
+  int q;
+};
+
+struct pqPoint {
+  double p;
+  double q;
+  double w;
+};
+
+enum FitView { XY, RZ };
+
+class Retina{
+
+ private:
+
+  vector<Hit_t*> hits;
+  unsigned int pbins;
+  unsigned int qbins;
+  double pmin;
+  double pmax;
+  double offset;
+  double qmin;
+  double qmax;
+  double pbinsize;
+  double qbinsize;
+  vector<double> sigma;
+  double minWeight;
+  unsigned int para;
+  FitView view;
+
+  vector <vector <double> > Grid;
+  vector <pqPoint> pqCollection;
+
+  void    makeGrid();
+  double  getResponsePQ(double p, double q);
+  double  getResponseXpXm(double x_plus, double x_minus);
+  pqPoint findMaximumInterpolated(pqPoint_i point_i, double w);
+
+ public:
+  
+  Retina(vector<Hit_t*> hits_, unsigned int pbins_, unsigned int qbins_, 
+	 double pmin_, double pmax_, double qmin_, double qmax_, 
+	 vector<double> sigma_, double minWeight_, unsigned int para_, FitView view_);
+  ~Retina();
+
+  void fillGrid();
+  void dumpGrid(int eventNum=0,int step=1,int imax=0);
+  void findMaxima();
+  void printMaxima();
+  vector <pqPoint> getMaxima();
+  pqPoint getBestPQ();
+
+};
+
+#endif

--- a/L1Trigger/TrackFindingAM/interface/RetinaTrackFitter.h
+++ b/L1Trigger/TrackFindingAM/interface/RetinaTrackFitter.h
@@ -1,0 +1,83 @@
+#ifndef _RETINATRACKFITTER_H_
+#define _RETINATRACKFITTER_H_
+
+#include "TrackFitter.h"
+#include "Retina.h"
+
+#include <set>
+#include <map>
+
+#include <boost/serialization/base_object.hpp>
+#include <boost/serialization/export.hpp>
+
+/**
+   \brief Implementation of a track fitter based on an artificial retina
+**/
+class RetinaTrackFitter:public TrackFitter{
+
+ private:
+
+  unsigned int verboseLevel; 
+  unsigned int event_counter;
+  unsigned int road_id;
+
+  // This contains the retina configuration parameters,
+  // it is filled in initialize():
+  std::map <const char*,double> config[3];
+
+  // This is used to rotate the trigger tower into the first quadrant:
+  const static double rot_angle[8];
+
+  void initialize();
+  void rotateHits(vector<Hit_t*> hits, double angle);
+  void confTrans(vector<Hit_t*> hits);
+
+  friend class boost::serialization::access;
+  
+  template<class Archive> void save(Archive & ar, const unsigned int version) const
+    {
+      ar << boost::serialization::base_object<TrackFitter>(*this);
+      ar << sec_phi;
+    }
+  
+  template<class Archive> void load(Archive & ar, const unsigned int version)
+    {
+      ar >> boost::serialization::base_object<TrackFitter>(*this);
+      ar >> sec_phi;
+    }
+  
+  BOOST_SERIALIZATION_SPLIT_MEMBER()
+
+ public:
+
+  /**
+     \brief Default constructor   
+  **/
+  RetinaTrackFitter();
+
+  /**
+     \brief Constructor   
+     \param nb Layers number
+  **/  
+  RetinaTrackFitter(int nb);
+
+  ~RetinaTrackFitter();
+
+  void mergePatterns();
+  void mergeTracks();
+  void fit();
+  void fit(std::vector<Hit*> hits);
+  TrackFitter* clone();
+
+  void setEventCounter(unsigned int event_counter_){
+    event_counter = event_counter_;
+  };
+  void setRoadID(unsigned int road_id_){
+    road_id = road_id_;
+  };
+  void setVerboseLevel(unsigned int verboseLevel_){
+    verboseLevel = verboseLevel_;
+  }; 
+
+};
+#endif

--- a/L1Trigger/TrackFindingAM/interface/SectorTree.h
+++ b/L1Trigger/TrackFindingAM/interface/SectorTree.h
@@ -12,6 +12,7 @@
 #include "PrincipalTrackFitter.h"
 #include "KarimakiTrackFitter.h"
 #include "HoughFitter.h"
+#include "RetinaTrackFitter.h"
 
 #ifdef IPNL_USE_CUDA
 #include "gpu_struct.h"

--- a/L1Trigger/TrackFindingAM/interface/Track.h
+++ b/L1Trigger/TrackFindingAM/interface/Track.h
@@ -16,6 +16,8 @@ class Track{
   double phi0;
   double eta0;
   double z0;
+  double w_xy;
+  double w_rz;
   vector<int> stub_ids;
 
  public:
@@ -30,8 +32,10 @@ class Track{
      \param p The PHI0 of the track
      \param p_a The Eta0 of the track
      \param p_b The Z0 of the track
+     \param w_xy The weight of the XY-retina maximum
+     \param w_rz The weight of the RZ-retina maximum
   **/
-  Track(double c, double d, double p, double p_a, double p_b);
+  Track(double c, double d, double p, double p_a, double p_b, double Wxy=-1., double Wrz=-1.);
   /**
      \brief Copy Constructor
   **/
@@ -62,6 +66,16 @@ class Track{
      \param z The Z0 of the track
   **/
   void setZ0(double z);
+  /**
+     \brief Set the weight of the XY-retina maximum
+     \param Wxy The weight of the XY-retina maximum
+  **/
+  void setWxy(double Wxy);
+  /**
+     \brief Set the weight of the RZ-retina maximum
+     \param Wrz The weight of the RZ-retina maximum
+  **/
+  void setWrz(double Wrz);
 
   /**
      \brief Add a stub to the list of stubs used to create the track
@@ -104,6 +118,16 @@ class Track{
      \return The Z0 of the track
   **/
   double getZ0();
+  /**
+     \brief Get the weight of the XY-retina maximum
+     \return The weight of the XY-retina maximum
+  **/
+  double getWxy();
+  /**
+     \brief Get the weight of the RZ-retina maximum
+     \return The weight of the RZ-retina maximum
+  **/
+  double getWrz();
 
 };
 #endif

--- a/L1Trigger/TrackFindingAM/plugins/TrackFindingAMProducer.cc
+++ b/L1Trigger/TrackFindingAM/plugins/TrackFindingAMProducer.cc
@@ -69,6 +69,7 @@ class TrackFindingAMProducer : public edm::EDProducer
   std::string                  nBKName;
   int                          nThresh;
   int                          nMissingHits;
+  int                          nDebug;
   SectorTree                   m_st;
   PatternFinder                *m_pf;
   const StackedTrackerGeometry *theStackedTracker;
@@ -96,6 +97,7 @@ TrackFindingAMProducer::TrackFindingAMProducer( const edm::ParameterSet& iConfig
   nBKName            = iConfig.getParameter< std::string >("inputBankFile");
   nThresh            = iConfig.getParameter< int >("threshold");
   nMissingHits       = iConfig.getParameter< int >("nbMissingHits");
+  nDebug             = iConfig.getParameter< int >("debugMode");
 
   std::cout << "Loading pattern bank file : " << std::endl;
   std::cout << nBKName << std::endl;
@@ -255,6 +257,8 @@ void TrackFindingAMProducer::produce( edm::Event& iEvent, const edm::EventSetup&
   /// PAssing the superstrips into the AM chip
 
   std::vector< Sector* > patternsSectors = m_pf->find(m_hits); // AM PR is done here....
+  if(nDebug==1)
+    m_pf->displaySuperstrips(m_hits); // display the supertrips of the event
 
   /// STEP 3
   /// Collect the info and store the track seed stuff

--- a/L1Trigger/TrackFindingAM/plugins/TrackFitRetinaProducer.cc
+++ b/L1Trigger/TrackFindingAM/plugins/TrackFitRetinaProducer.cc
@@ -1,0 +1,692 @@
+/*! \class   TrackFitRetinaProducer
+ *
+ *  \author M Casarsa / L Martini (mostly cut&paste from S.Viret and G.Baulieu's TrackFitHoughProducer) 
+ *  \date   2014, May 20
+ *
+ */
+
+#ifndef TRACK_FITTER_AM_H
+#define TRACK_FITTER_AM_H
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/L1TrackTrigger/interface/TTTypes.h"
+#include "DataFormats/L1TrackTrigger/interface/TTCluster.h"
+#include "DataFormats/L1TrackTrigger/interface/TTStub.h"
+#include "DataFormats/L1TrackTrigger/interface/TTTrack.h"
+#include "DataFormats/Common/interface/DetSetVectorNew.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/MeasurementPoint.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/HepMCCandidate/interface/GenParticle.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+#include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDetUnit.h"
+#include "Geometry/Records/interface/StackedTrackerGeometryRecord.h"
+#include "Geometry/TrackerGeometryBuilder/interface/StackedTrackerGeometry.h"
+
+#include "L1Trigger/TrackFindingAM/interface/CMSPatternLayer.h"
+#include "L1Trigger/TrackFindingAM/interface/PatternFinder.h"
+#include "L1Trigger/TrackFindingAM/interface/SectorTree.h"
+#include "L1Trigger/TrackFindingAM/interface/Hit.h"
+
+#include <boost/archive/text_oarchive.hpp>
+#include <boost/archive/text_iarchive.hpp>
+#include <boost/shared_ptr.hpp>
+#include <memory>
+#include <string>
+#include <map>
+#include <vector>
+#include <iostream>
+#include <fstream>
+#include <math.h>
+
+
+//#ifndef __APPLE__
+//BOOST_CLASS_EXPORT_IMPLEMENT(CMSPatternLayer)
+//#endif
+
+class TrackFitRetinaProducer : public edm::EDProducer
+{
+  public:
+    /// Constructor
+    explicit TrackFitRetinaProducer( const edm::ParameterSet& iConfig );
+
+    /// Destructor;
+    ~TrackFitRetinaProducer();
+
+  private:
+  
+  /// Data members
+  double                       mMagneticField;
+  unsigned int                 nSectors;
+  unsigned int                 nWedges;
+  std::string                  nBKName;
+  int                          nThresh;
+  const StackedTrackerGeometry *theStackedTracker;
+  edm::InputTag                TTStubsInputTag;
+  edm::InputTag                TTPatternsInputTag;
+  std::string                  TTTrackOutputTag;
+  int                          verboseLevel_;
+  bool                         fitPerTriggerTower_;
+  // removeDuplicates_:
+  //            0  --> no duplicate removal
+  //            1  --> use deltaR
+  //            2  --> use common stubs
+  int                          removeDuplicates_;
+
+  unsigned int                 icount;
+
+
+  /// Mandatory methods
+  virtual void beginRun( const edm::Run& run, const edm::EventSetup& iSetup );
+  virtual void endRun( const edm::Run& run, const edm::EventSetup& iSetup );
+  virtual void produce( edm::Event& iEvent, const edm::EventSetup& iSetup );
+
+}; /// Close class
+
+/*! \brief   Implementation of methods
+ */
+
+/// Constructors
+TrackFitRetinaProducer::TrackFitRetinaProducer( const edm::ParameterSet& iConfig )
+{
+  TTStubsInputTag     = iConfig.getParameter< edm::InputTag >( "TTInputStubs" );
+  TTPatternsInputTag  = iConfig.getParameter< edm::InputTag >( "TTInputPatterns" );
+  TTTrackOutputTag    = iConfig.getParameter< std::string >( "TTTrackName" );
+  verboseLevel_       = iConfig.getUntrackedParameter< int >( "verboseLevel", 0 );
+  removeDuplicates_   = iConfig.getUntrackedParameter< int >( "removeDuplicates", 1 );
+  fitPerTriggerTower_ = iConfig.getUntrackedParameter< bool >( "fitPerTriggerTower", false );
+
+  produces< std::vector< TTTrack< Ref_PixelDigi_ > > >( TTTrackOutputTag );
+}
+
+/// Destructor
+TrackFitRetinaProducer::~TrackFitRetinaProducer() {}
+
+/// Begin run
+void TrackFitRetinaProducer::beginRun( const edm::Run& run, const edm::EventSetup& iSetup )
+{
+  /// Initialize the event counter
+  icount = 0;
+  
+  /// Get the geometry references
+  edm::ESHandle< StackedTrackerGeometry > StackedTrackerGeomHandle;
+  iSetup.get< StackedTrackerGeometryRecord >().get( StackedTrackerGeomHandle );
+  theStackedTracker = StackedTrackerGeomHandle.product();
+
+  /// Get magnetic field
+  edm::ESHandle<MagneticField> magneticFieldHandle;
+  iSetup.get<IdealMagneticFieldRecord>().get(magneticFieldHandle);
+  const MagneticField* theMagneticField = magneticFieldHandle.product();
+  double mMagneticFieldStrength = theMagneticField->inTesla(GlobalPoint(0,0,0)).z();
+  mMagneticField = (floor(mMagneticFieldStrength*10.0 + 0.5))/10.0;
+}
+
+/// End run
+void TrackFitRetinaProducer::endRun( const edm::Run& run, const edm::EventSetup& iSetup ) {}
+
+/// Implement the producer
+void TrackFitRetinaProducer::produce( edm::Event& iEvent, const edm::EventSetup& iSetup )
+{
+  
+  icount++;
+
+  // Get GEN particle collection
+  edm::Handle<vector<reco::GenParticle> > genPart;
+  iEvent.getByLabel ("genParticles", genPart);
+
+  /// Prepare output
+  /// The temporary collection is used to store tracks
+  /// before removal of duplicates
+  std::auto_ptr< std::vector< TTTrack< Ref_PixelDigi_ > > > TTTracksForOutput( new std::vector< TTTrack< Ref_PixelDigi_ > > );
+
+  /// Get the Stubs already stored away
+  edm::Handle< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > > > TTStubHandle;
+  edm::Handle< std::vector< TTTrack< Ref_PixelDigi_ > > > TTPatternHandle;
+
+  iEvent.getByLabel( TTStubsInputTag, TTStubHandle );
+  iEvent.getByLabel( TTPatternsInputTag, TTPatternHandle );
+
+  /// STEP 0
+  /// Prepare output
+  TTTracksForOutput->clear();
+
+  int layer  = 0;
+  int ladder = 0;
+  int module = 0;
+
+  /// STEP 1
+  /// Loop over patterns
+
+  //  std::cout << "Start the loop over pattern in order to recover the stubs" << std::endl;
+
+  map<int,vector<Hit*>* > m_hitsPerSector;
+  map<int,set<long>*> m_uniqueHitsPerSector;
+
+  edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >::const_iterator inputIter;
+  edmNew::DetSet< TTStub< Ref_PixelDigi_ > >::const_iterator stubIter;
+
+  std::vector< TTTrack< Ref_PixelDigi_ > >::const_iterator iterTTTrack;
+
+
+  /// Go on only if there are Patterns from PixelDigis
+  if ( TTPatternHandle->size() > 0 )
+  {
+
+    // --- Printout the generated particles:
+    if ( verboseLevel_ > 0 ){
+      cout << "\nEvent = " << icount 
+	   << " ---------------------------------------------------------------------------------" << endl;
+      cout << "  Generated particles:" << endl; 
+      for (std::vector <reco::GenParticle>::const_iterator thepart = genPart->begin(); 
+	                                                   thepart != genPart->end(); 
+	                                                 ++thepart ){
+	
+	// curvature and helix radius:
+	double c = thepart->charge()*0.003*mMagneticField/thepart->pt();
+	double R = thepart->pt()/(0.003*mMagneticField);
+	  
+	// helix center:
+	double x0 = thepart->vx() - thepart->charge()*R*thepart->py()/thepart->pt();
+	double y0 = thepart->vy() + thepart->charge()*R*thepart->px()/thepart->pt();
+	  
+	// transverse and longitudinal impact parameters:
+	double d0 = thepart->charge()*(sqrt(x0*x0+y0*y0)-R);
+	double z0 = thepart->vz() - 2./c*thepart->pz()/thepart->pt()*
+	  asin(0.5*c*sqrt((thepart->vx()*thepart->vx()+thepart->vy()*thepart->vy()-d0*d0)/(1.+c*d0)));
+    
+	cout << "   " << std::distance(genPart->begin(),thepart)
+	     << "  -  pdgId = " << thepart->pdgId()
+	     << "  c = " << c
+	     << "  pt = " << thepart->pt()
+	     << "  d0 = " << d0
+	     << "  phi = " << thepart->phi()
+	     << "  eta = " << thepart->eta()
+	     << "  z0 = " << z0 
+	     << endl;
+
+      } // loop over thepart  
+
+    } // if ( verboseLevel_ > 0 )
+
+
+    if ( verboseLevel_ > 1 )
+      cout << "   Number of roads = " << TTPatternHandle->size() << endl;
+
+
+    /// Loop over Patterns
+    unsigned int tkCnt = 0;
+    unsigned int j     = 0;
+    unsigned int jreal = 0;
+
+    std::map< unsigned int , edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > > stubMap;
+    std::map< unsigned int , edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > > stubMapUsed;
+
+    for ( iterTTTrack = TTPatternHandle->begin();
+	  iterTTTrack != TTPatternHandle->end();
+	  ++iterTTTrack )
+    {
+      edm::Ptr< TTTrack< Ref_PixelDigi_ > > tempTrackPtr( TTPatternHandle, tkCnt++ );
+
+      /// Get everything relevant
+      unsigned int seedSector = tempTrackPtr->getSector();
+      //std::cout << "Pattern in sector " << seedSector << " with " 
+      //		<< seedWedge << " active layers contains " 
+      //		<< nStubs << " stubs" << std::endl;
+
+      std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_  > >, TTStub< Ref_PixelDigi_  > > > trackStubs = tempTrackPtr->getStubRefs();
+
+      //get the hits list of this sector
+      map<int,vector<Hit*>*>::iterator sec_it = m_hitsPerSector.find(seedSector);
+      vector<Hit*> *m_hits;
+      if(sec_it==m_hitsPerSector.end())
+      {
+	m_hits = new vector<Hit*>();
+	m_hitsPerSector[seedSector]=m_hits;
+      }
+      else
+      {
+       m_hits = sec_it->second;
+      }
+
+      //get the hits set of this sector
+      map<int,set<long>*>::iterator set_it = m_uniqueHitsPerSector.find(seedSector);
+      set<long> *m_hitIDs;
+
+      if(set_it==m_uniqueHitsPerSector.end())
+      {
+	m_hitIDs = new set<long>();
+	m_uniqueHitsPerSector[seedSector]=m_hitIDs;
+      }
+      else
+      {
+	m_hitIDs = set_it->second;
+      }
+
+      // Loop over stubs contained in the pattern to recover the info
+
+      vector<Hit*> road_hits;
+
+      for(unsigned int i=0;i<trackStubs.size();i++)
+      {
+	++j;
+
+	edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > tempStubRef = trackStubs.at(i);
+
+	stubMap.insert( std::make_pair( j, tempStubRef ) );
+
+	/// Calculate average coordinates col/row for inner/outer Cluster
+	/// These are already corrected for being at the center of each pixel
+	MeasurementPoint mp0 = tempStubRef->getClusterRef(0)->findAverageLocalCoordinates();
+	GlobalPoint posStub  = theStackedTracker->findGlobalPosition( &(*tempStubRef) );
+	
+	StackedTrackerDetId detIdStub( tempStubRef->getDetId() );
+	//bool isPS = theStackedTracker->isPSModule( detIdStub );
+	
+	const GeomDetUnit* det0 = theStackedTracker->idToDetUnit( detIdStub, 0 );
+	const GeomDetUnit* det1 = theStackedTracker->idToDetUnit( detIdStub, 1 );
+	
+	/// Find pixel pitch and topology related information
+	const PixelGeomDetUnit* pix0 = dynamic_cast< const PixelGeomDetUnit* >( det0 );
+	const PixelGeomDetUnit* pix1 = dynamic_cast< const PixelGeomDetUnit* >( det1 );
+	const PixelTopology* top0    = dynamic_cast< const PixelTopology* >( &(pix0->specificTopology()) );
+	const PixelTopology* top1    = dynamic_cast< const PixelTopology* >( &(pix1->specificTopology()) );
+	
+	/// Find the z-segment
+	int cols0   = top0->ncolumns();
+	int cols1   = top1->ncolumns();
+	int ratio   = cols0/cols1; /// This assumes the ratio is integer!
+	int segment = floor( mp0.y() / ratio );
+	
+	// Here we rearrange the number in order to be compatible with the AM emulator
+	if ( detIdStub.isBarrel() )
+	{
+	  layer  = detIdStub.iLayer()+4;
+	  ladder = detIdStub.iPhi()-1;
+	  module = detIdStub.iZ()-1;
+	}
+	else if ( detIdStub.isEndcap() )
+	{
+	  layer  = 10+detIdStub.iZ()+abs((int)(detIdStub.iSide())-2)*7;
+	  ladder = detIdStub.iRing()-1;
+	  module = detIdStub.iPhi()-1;
+	}
+
+	//cout << layer << " / " << ladder << " / " << module << " / " << std::endl;
+
+	int strip  =  mp0.x();
+	int tp     = -1;
+	float eta  = 0;
+	float phi0 = 0;
+	float spt  = 0;
+	float x    = posStub.x();
+	float y    = posStub.y();
+	float z    = posStub.z();
+	float x0   = 0.;
+	float y0   = 0.;
+	float z0   = 0.;
+	float ip   = sqrt(x0*x0+y0*y0);
+	
+	//Check if the stub is already in the list
+	long hit_id = (long)layer*10000000000+(long)ladder*100000000
+	  +module*100000+segment*10000+strip;
+
+	pair<set<long>::iterator,bool> result = m_hitIDs->insert(hit_id);
+
+	if(result.second==true) //this is a new stub -> add it to the list
+	{
+	  ++jreal;
+	  stubMapUsed.insert( std::make_pair( jreal, tempStubRef ) );
+
+	  if (jreal>=16384)
+	  {
+	    cout << "Problem!!!" << endl;
+	    continue;
+	  }
+
+	  Hit* h = new Hit(layer,ladder, module, segment, strip, 
+			   jreal, tp, spt, ip, eta, phi0, x, y, z, x0, y0, z0);
+	  m_hits->push_back(h);
+
+	}
+
+	if ( !fitPerTriggerTower_ ){
+
+	  // Find the stub index:
+	  unsigned int stub_index = 0;
+	  for(std::map< unsigned int , 
+		edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, 
+		TTStub< Ref_PixelDigi_ > > >::iterator istub  = stubMapUsed.begin();
+	                                               istub != stubMapUsed.end(); 
+                                                     ++istub ){
+
+	    if ( istub->second == tempStubRef )
+	      stub_index =  istub->first;
+
+	  }
+
+	  if ( stub_index > 0 ){
+	    Hit* h1 = new Hit(layer,ladder, module, segment, strip, 
+			      stub_index, tp, spt, ip, eta, phi0, x, y, z, x0, y0, z0);
+	    road_hits.push_back(h1);
+	  }
+
+	}
+
+      } /// End of loop over track stubs
+
+
+      // =====================================================================================================
+      //  Fit the road stubs:
+      // =====================================================================================================
+
+      if ( fitPerTriggerTower_ ) continue;
+
+      if ( verboseLevel_ > 1 )
+	cout << "   road/number of stubs = " << j << " / " << road_hits.size() << endl;
+
+      std::vector<Track*> tracks; 
+      std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > > tempVec;
+      RetinaTrackFitter* fitter = new RetinaTrackFitter(5);
+
+      fitter->setSectorID(seedSector);
+      fitter->setEventCounter(icount);
+      fitter->setRoadID(j);
+      fitter->setVerboseLevel(0);
+     
+      fitter->fit(road_hits);
+      tracks.clear();
+      tracks = fitter->getTracks();
+      fitter->clean();
+
+      // Store the tracks (no duplicate cleaning yet)
+      for(unsigned int tt=0;tt<tracks.size();tt++){	
+
+	double pt_fit = 0.003*mMagneticField/ tracks[tt]->getCurve();
+
+	if ( verboseLevel_ > 1 ){
+	  cout << "   Fitted track:  "
+	       << tt << "  -  c = " << tracks[tt]->getCurve()
+	       << "  pt = " << pt_fit
+	       << "  d0 = " << tracks[tt]->getD0()
+	       << "  phi = " << tracks[tt]->getPhi0()
+	       << "  eta = " << tracks[tt]->getEta0()
+	       << "  z0 = " << tracks[tt]->getZ0() 
+	       << "  -   weights = " << tracks[tt]->getWxy() << " " <<  tracks[tt]->getWrz() 
+	       << endl;
+	}
+	    
+	tempVec.clear();
+
+	vector<int> stubs = tracks[tt]->getStubs();
+	for(unsigned int sti=0;sti<stubs.size();sti++){
+	  //cout<<stubs[sti]<<endl;
+	  tempVec.push_back( stubMapUsed[ stubs[sti] ] );
+	}
+
+	double pz = pt_fit/(tan(2.*atan(exp(-tracks[tt]->getEta0()))));
+
+	TTTrack< Ref_PixelDigi_ > tempTrack( tempVec );
+	GlobalPoint POCA(0.,0.,tracks[tt]->getZ0());
+	GlobalVector mom(pt_fit*cos(tracks[tt]->getPhi0()),
+			 pt_fit*sin(tracks[tt]->getPhi0()),
+			 pz);
+
+	//	std::cout << tracks[tt]->getZ0() << " / " << POCA.z() << std::endl;
+
+
+	// kludge: We save the maximum weights in the chi2 variable
+	tempTrack.setChi2(tracks[tt]->getWxy(), 5);
+	tempTrack.setChi2(tracks[tt]->getWrz(), 4);
+
+	tempTrack.setRInv(tracks[tt]->getCurve(), 5);
+
+	tempTrack.setSector( seedSector );
+	tempTrack.setWedge( -1 );
+	tempTrack.setMomentum( mom , 5);
+	tempTrack.setPOCA( POCA , 5);
+	//	std::cout << tracks[tt]->getZ0() << " / " << POCA.z() << " / " << tempTrack.getPOCA().z() << std::endl;
+	TTTracksForOutput->push_back( tempTrack );
+	    
+	delete tracks[tt];
+      }
+    
+      // --- Clean-up memory:
+      delete(fitter);
+
+      // Clean-up the road stub vector:
+      for(std::vector<Hit*>::iterator ihit=road_hits.begin(); ihit!=road_hits.end(); ++ihit)
+	delete *ihit;
+
+    } // End of loop over patterns
+
+
+    //free the map of sets
+    for(map<int,set<long>*>::iterator set_it=m_uniqueHitsPerSector.begin();set_it!=m_uniqueHitsPerSector.end();set_it++)
+      delete set_it->second;//delete the set*
+
+
+    // =====================================================================================================
+    //  Fit the all trigger tower stubs:
+    // =====================================================================================================
+
+    if ( fitPerTriggerTower_ ) {
+
+      RetinaTrackFitter* fitter = new RetinaTrackFitter(5);
+      vector<Track*> tracks; 
+      std::vector< edm::Ref< edmNew::DetSetVector< TTStub< Ref_PixelDigi_ > >, TTStub< Ref_PixelDigi_ > > > tempVec;
+
+      // Loop over the different sectors
+      for(map<int,vector<Hit*>*>::iterator sec_it=m_hitsPerSector.begin();sec_it!=m_hitsPerSector.end();sec_it++)
+	{
+	  //cout<<"Sector "<<sec_it->first<<endl;
+	  fitter->setSectorID(sec_it->first);
+	  fitter->setEventCounter(icount);
+	  fitter->setVerboseLevel(0);
+
+	  // Do the fit
+	  fitter->fit(*(sec_it->second));
+	  tracks.clear();
+	  tracks = fitter->getTracks();
+	  fitter->clean();
+
+
+	  // Store the tracks (no duplicate cleaning yet)
+	  for(unsigned int tt=0;tt<tracks.size();tt++)
+	    {	
+
+	      tempVec.clear();
+
+	      double pt_fit = 0.003*mMagneticField/ tracks[tt]->getCurve();
+
+	      if ( verboseLevel_ > 1 ){
+		cout << "   Fitted track:  "
+		     << tt << "  -  c = " << tracks[tt]->getCurve()
+		     << "  pt = " << pt_fit
+		     << "  d0 = " << tracks[tt]->getD0()
+		     << "  phi = " << tracks[tt]->getPhi0()
+		     << "  eta = " << tracks[tt]->getEta0()
+		     << "  z0 = " << tracks[tt]->getZ0() 
+		     << "  -   weights = " << tracks[tt]->getWxy() << " " <<  tracks[tt]->getWrz() 
+		     << endl;
+	      }
+
+	      vector<int> stubs = tracks[tt]->getStubs();
+	      for(unsigned int sti=0;sti<stubs.size();sti++){
+		//cout<<stubs[sti]<<endl;
+		tempVec.push_back( stubMapUsed[ stubs[sti] ] );
+	      }
+
+	      double pz = pt_fit/(tan(2.*atan(exp(-tracks[tt]->getEta0()))));
+	      
+	      TTTrack< Ref_PixelDigi_ > tempTrack( tempVec );
+	      GlobalPoint POCA(0.,0.,tracks[tt]->getZ0());
+	      GlobalVector mom(pt_fit*cos(tracks[tt]->getPhi0()),
+			       pt_fit*sin(tracks[tt]->getPhi0()),
+			       pz);
+
+	      //	std::cout << tracks[tt]->getZ0() << " / " << POCA.z() << std::endl;
+
+
+	      // kludge: We save the maximum weights in the chi2 variable
+	      tempTrack.setChi2(tracks[tt]->getWxy(), 5);
+	      tempTrack.setChi2(tracks[tt]->getWrz(), 4);
+
+	      tempTrack.setRInv(tracks[tt]->getCurve(), 5);
+
+	      tempTrack.setSector( sec_it->first );
+	      tempTrack.setWedge( -1 );
+	      tempTrack.setMomentum( mom , 5);
+	      tempTrack.setPOCA( POCA , 5);
+	      //	std::cout << tracks[tt]->getZ0() << " / " << POCA.z() << " / " << tempTrack.getPOCA().z() << std::endl;
+	      TTTracksForOutput->push_back( tempTrack );
+	    
+	      delete tracks[tt];
+	    }
+
+	}
+    
+      delete(fitter);
+    
+    } // if ( fitPerTriggerTower_ )
+
+
+    // =====================================================================================================
+    //  Remove duplicate tracks:
+    // =====================================================================================================
+    if ( TTTracksForOutput->size()>1 && removeDuplicates_>0 ){
+
+      
+      for ( std::vector< TTTrack< Ref_PixelDigi_ > >::iterator itrk  = TTTracksForOutput->begin();
+	                                                       itrk != TTTracksForOutput->end(); 
+	                                                     ++itrk ){
+
+	for ( std::vector< TTTrack< Ref_PixelDigi_ > >::iterator jtrk  = itrk+1;
+	                                                         jtrk != TTTracksForOutput->end(); 
+	                                                              ){ 
+
+	  // Method I: identify duplicates cutting on deltaR
+	  if ( removeDuplicates_ == 1 ) {
+
+	    double delta_phi =  itrk->getMomentum(5).phi() - jtrk->getMomentum(5).phi();
+	    if (fabs(delta_phi) > 3.14159265358979312)
+	      delta_phi = 6.28318530717958623 - fabs(delta_phi);
+	    double delta_eta =  itrk->getMomentum(5).eta() - jtrk->getMomentum(5).eta();
+
+	    double delta_R = sqrt(delta_phi*delta_phi+delta_eta*delta_eta); 
+
+	    if ( delta_R < 0.05 ){ 
+
+	      double weight_itrk = itrk->getChi2(5) + itrk->getChi2(4);
+	      double weight_jtrk = jtrk->getChi2(5) + jtrk->getChi2(4);
+
+	      // Remove the duplicate with smaller weight:
+	      if ( weight_itrk < weight_jtrk ){
+		itrk = TTTracksForOutput->erase(itrk);
+		--itrk;
+		break;
+	      } 
+	      else { 
+		jtrk = TTTracksForOutput->erase(jtrk);
+		continue;
+	      }
+
+	    }
+
+	  }
+	  // Method II: identify duplicates checking whether the two tracks 
+	  //            have more than one stub in common:
+	  else if ( removeDuplicates_ == 2 ){ 
+
+	    if ( itrk->isTheSameAs(*jtrk) ) {
+
+	      double weight_itrk = itrk->getChi2(5) + itrk->getChi2(4);
+	      double weight_jtrk = jtrk->getChi2(5) + jtrk->getChi2(4);
+
+	      // Remove the duplicate with smaller weight:
+	      if ( weight_itrk < weight_jtrk ){
+		itrk = TTTracksForOutput->erase(itrk);
+		--itrk;
+		break;
+	      } 
+	      else { 
+		jtrk = TTTracksForOutput->erase(jtrk);
+		continue;
+	      }
+
+	    }
+
+	  }
+
+	  ++jtrk;
+
+	} // loop over jtrk
+
+      } // loop over itrk
+
+    } // if ( TTTracksForOutput->size()>1 && removeDuplicates_>0 )
+
+  
+    
+    // =====================================================================================================
+    //  Printout the fitted tracks:
+    // =====================================================================================================
+    if ( TTTracksForOutput->size()>0 && verboseLevel_>0 ){
+      
+      if ( removeDuplicates_==0 )
+	cout << "  Fitted tracks (no duplicate removal):" << endl;
+      else
+	cout << "  Fitted tracks (after duplicate removal):" << endl;
+      
+      for ( std::vector< TTTrack< Ref_PixelDigi_ > >::iterator itrk  = TTTracksForOutput->begin();
+	                                                             itrk != TTTracksForOutput->end(); 
+                                                                   ++itrk ){
+	cout << "   "
+	     << std::distance(TTTracksForOutput->begin(),itrk)
+	     << "  -  c = " << itrk->getRInv(5)
+	     << "  pt = " << itrk->getMomentum(5).perp()
+	  //<< "  d0 = 0 " 
+	     << "  phi = " << itrk->getMomentum(5).phi()
+	     << "  eta = " << itrk->getMomentum(5).eta()
+	     << "  z0 = "  << itrk->getPOCA(5).z() 
+	     << endl;
+
+      }
+    
+    } // if  ( TTTracksForOutput->size()>0 && verboseLevel_>0 )
+
+
+    // Clean up the stubs map:
+    for(map<int,vector<Hit*>*>::iterator sec_it  = m_hitsPerSector.begin();
+	                                 sec_it != m_hitsPerSector.end();
+	                               ++sec_it ){
+
+      for(unsigned int i=0;i<sec_it->second->size();i++)
+	delete sec_it->second->at(i);//delete the Hit object
+      
+      delete sec_it->second;//delete the vector*
+
+    }
+
+
+  } // if  ( TTPatternHandle->size() > 0 )
+
+
+  /// Put in the event content
+  iEvent.put( TTTracksForOutput, TTTrackOutputTag);
+
+}
+
+// DEFINE THIS AS A PLUG-IN
+DEFINE_FWK_MODULE(TrackFitRetinaProducer);
+
+#endif
+

--- a/L1Trigger/TrackFindingAM/python/L1AMTrack_cfi.py
+++ b/L1Trigger/TrackFindingAM/python/L1AMTrack_cfi.py
@@ -9,12 +9,26 @@ TTPatternsFromStub = cms.EDProducer("TrackFindingAMProducer",
    nbMissingHits      = cms.int32(-1)
 )
 
-# Hough-based trackfit default sequence
-TTTracksFromPattern = cms.EDProducer("TrackFitHoughProducer",
-   TTInputStubs       = cms.InputTag("TTStubsFromPixelDigis", "StubAccepted"),
-   TTInputPatterns    = cms.InputTag("MergePROutput", "AML1Patterns"),
-   TTTrackName        = cms.string("AML1Tracks"),
-)
+## Trackfit default sequence
+
+doRetinaFit = False
+
+TTTracksFromPattern = ( cms.EDProducer("TrackFitRetinaProducer",
+                                       TTInputStubs       = cms.InputTag("TTStubsFromPixelDigis", "StubAccepted"),
+                                       TTInputPatterns    = cms.InputTag("MergePROutput", "AML1Patterns"),
+                                       TTTrackName        = cms.string("AML1Tracks"),
+                                       verboseLevel       = cms.untracked.int32(1),
+                                       fitPerTriggerTower = cms.untracked.bool(False),
+                                       removeDuplicates   = cms.untracked.int32(1)
+                                       )
+                        if doRetinaFit else
+                        cms.EDProducer("TrackFitHoughProducer",
+                                       TTInputStubs       = cms.InputTag("TTStubsFromPixelDigis", "StubAccepted"),
+                                       TTInputPatterns    = cms.InputTag("MergePROutput", "AML1Patterns"),
+                                       TTTrackName        = cms.string("AML1Tracks"),
+                                       )
+                        )
+
 
 # AM output merging sequence
 MergePROutput = cms.EDProducer("AMOutputMerger",

--- a/L1Trigger/TrackFindingAM/src/Retina.cc
+++ b/L1Trigger/TrackFindingAM/src/Retina.cc
@@ -1,0 +1,249 @@
+#include "../interface/Retina.h"
+
+Retina::Retina(vector<Hit_t*> hits_, unsigned int pbins_, unsigned int qbins_, 
+	       double pmin_, double pmax_, double qmin_, double qmax_, 
+	       vector<double> sigma_, double minWeight_, unsigned int para_, FitView view_) :
+  hits(hits_),
+  pbins(pbins_),
+  qbins(qbins_),
+  pmin(pmin_),
+  pmax(pmax_),
+  offset(0.),
+  qmin(qmin_+offset),
+  qmax(qmax_+offset),
+  sigma(sigma_),
+  minWeight(minWeight_),
+  para(para_),
+  view(view_)
+{
+
+  pbinsize = (pmax-pmin)/(double)pbins;
+  qbinsize = (qmax-qmin)/(double)qbins;
+
+  makeGrid();
+}
+
+Retina::~Retina() {
+}
+
+
+void Retina::makeGrid() {
+  Grid.resize(pbins);
+  for (unsigned int i = 0; i < pbins; i++) {
+    Grid[i].resize(qbins);
+  }
+}
+
+void Retina::fillGrid() {
+  for (unsigned int i = 0; i < pbins; i++) {
+    for (unsigned int j = 0; j < qbins; j++) {
+      double p_value = pmin + pbinsize * (i + 0.5);
+      double q_value = qmin + qbinsize * (j + 0.5);
+      if (para == 0) Grid[i][j] = getResponsePQ(p_value, q_value);
+      if (para == 1) Grid[i][j] = getResponseXpXm(p_value, q_value);
+      //cout << i << " " << j << " p = " << p_value << " q = " << q_value << " w = " << Grid[i][j] << endl;    
+    }
+  }
+}
+
+double Retina::getResponsePQ(double p, double q) {
+
+  double Rij = 0.;
+  unsigned int hits_tot = hits.size();
+
+  for (unsigned int kr = 0; kr < hits_tot; kr++) {
+
+    double x  = ( view == XY ? hits[kr]->x : hits[kr]->z   );
+    double y  = ( view == XY ? hits[kr]->y : hits[kr]->rho );
+
+    double Sijkr = (p*x-y+q)/p;
+
+    double term = exp(-0.5*Sijkr*Sijkr/(sigma[0]*sigma[0]));
+
+    Rij += term;
+
+  }
+  if (Rij < 1e-6) return 1e-6;
+  else return Rij;
+
+}
+
+
+double Retina::getResponseXpXm(double x_plus, double x_minus) {
+
+  double Rij = 0.;
+  unsigned int hits_tot = hits.size();
+
+  // *** This is always assuming barrel hits, it has to be checked 
+  double y0 = 23.0;
+  double y1 = 108.0;
+  if ( view == XY ){
+    y0 = 0.5/y0;
+    y1 = 0.5/y1;
+  }
+  // ***
+
+  // Get p and q from x_plus and x_minus
+  const double x0 = x_plus - x_minus;
+  const double x1 = x_plus + x_minus;
+  const double p = (y1 - y0) / (x1 - x0);
+  const double q = y0 - p*x0;
+
+  for (unsigned int kr = 0; kr < hits_tot; kr++) {
+    
+    double x = ( view == XY ? hits[kr]->x : hits[kr]->z   );
+    double y = ( view == XY ? hits[kr]->y : hits[kr]->rho );
+
+    double sigma_local = sigma[0];
+
+    if ( view == RZ && fabs(y) > 60. )
+      sigma_local = sigma[3];
+
+    double Sijkr = (p*x-y+q)/p;  // from  x - (y-q)/p
+    //double Sijkr = fabs(y-p*x-q)/sqrt(1.+p*p);
+
+    double term = exp(-0.5*Sijkr*Sijkr/(sigma_local*sigma_local));
+
+    Rij += term;
+  }
+  if (Rij < 1e-6) return 1e-6;
+  else return Rij;
+  
+}
+
+
+void Retina::dumpGrid(int eventNum, int step, int imax) {
+
+  TH2D *pq_h = new TH2D("pq_h", "x_{+}-x_{-} grid;x_{+};x_{-}", pbins, pmin, pmax, qbins, qmin, qmax);
+  for (unsigned int i = 0; i < pbins; i++) {
+    for (unsigned int j = 0; j < qbins; j++) {
+      pq_h->SetBinContent(i+1, j+1, Grid[i][j]);
+    }
+  }
+  gStyle->SetPalette(53);
+  gStyle->SetPaintTextFormat("5.2f");
+  TCanvas *c = new TCanvas("c", "c", 650, 600);
+  c->SetRightMargin(0.1346749);
+  pq_h->SetStats(false);
+  pq_h->SetMaximum(7.);
+  pq_h->SetMinimum(0.);
+  string draw_s("COLZTEXT");
+  if (qbins > 30 || pbins > 30) draw_s = "COLZ";
+  pq_h->Draw(draw_s.c_str());
+  string fit_view = "XY";
+  if (view == RZ) fit_view = "RZ";
+  c->SaveAs(Form("PQgrid_%d_%s_%d-%d.png",eventNum,fit_view.c_str(),step,imax));
+  //c->SaveAs(Form("PQgrid_%d_%s_%d-%d.root",eventNum,fit_view.c_str(),step,imax));
+
+  delete pq_h;
+  delete c;
+}
+
+
+
+void Retina::findMaxima() {
+
+  for (unsigned int i = 1; i < pbins-1; i++) {
+    for (unsigned int j = 1; j < qbins-1; j++) {
+      if (    Grid[i][j] > Grid[i-1][j]
+	   && Grid[i][j] > Grid[i+1][j]
+	   && Grid[i][j] > Grid[i][j-1]
+	   && Grid[i][j] > Grid[i][j+1]
+
+	   && Grid[i][j] > Grid[i+1][j+1]
+	   && Grid[i][j] > Grid[i+1][j-1]
+	   && Grid[i][j] > Grid[i-1][j-1]
+	   && Grid[i][j] > Grid[i-1][j+1]
+	   ) {
+	if (Grid[i][j] < minWeight) continue; // cleaning
+	pqPoint_i point_i;
+	point_i.p = i;
+	point_i.q = j;
+	//cout << "not interpolated " << Grid[i][j] << endl;
+	pqPoint point_interpolated = findMaximumInterpolated(point_i, Grid[i][j]);
+	pqCollection.push_back(point_interpolated);
+      }
+    }
+  }
+
+}
+
+
+pqPoint Retina::findMaximumInterpolated(pqPoint_i point_i, double w) {
+  int p_i = point_i.p;
+  int q_i = point_i.q;
+
+  double p_mean = 0.;
+  double q_mean = 0.;
+
+  p_mean = (pmin + pbinsize * (p_i - 0.5)) * Grid[p_i-1][q_i] +
+           (pmin + pbinsize * (p_i + 0.5)) * Grid[p_i][q_i] +
+           (pmin + pbinsize * (p_i + 1.5)) * Grid[p_i+1][q_i];
+
+  p_mean += (pmin + pbinsize * (p_i - 0.5)) * Grid[p_i-1][q_i-1] +
+  	    (pmin + pbinsize * (p_i + 0.5)) * Grid[p_i][q_i-1] +
+            (pmin + pbinsize * (p_i + 1.5)) * Grid[p_i+1][q_i-1];
+
+  p_mean += (pmin + pbinsize * (p_i - 0.5)) * Grid[p_i-1][q_i+1] +
+            (pmin + pbinsize * (p_i + 0.5)) * Grid[p_i][q_i+1] +
+  	    (pmin + pbinsize * (p_i + 1.5)) * Grid[p_i+1][q_i+1];
+
+  p_mean /= (Grid[p_i-1][q_i] + Grid[p_i][q_i] + Grid[p_i+1][q_i] +
+  	     Grid[p_i-1][q_i-1] + Grid[p_i][q_i-1] + Grid[p_i+1][q_i-1] +
+  	     Grid[p_i-1][q_i+1] + Grid[p_i][q_i+1] + Grid[p_i+1][q_i+1]);
+
+
+  q_mean =  (qmin + qbinsize * (q_i - 0.5)) * Grid[p_i][q_i-1] +
+  	    (qmin + qbinsize * (q_i + 0.5)) * Grid[p_i][q_i] +
+  	    (qmin + qbinsize * (q_i + 1.5)) * Grid[p_i][q_i+1];
+
+  q_mean += (qmin + qbinsize * (q_i - 0.5)) * Grid[p_i-1][q_i-1] +
+  	    (qmin + qbinsize * (q_i + 0.5)) * Grid[p_i-1][q_i] +
+  	    (qmin + qbinsize * (q_i + 1.5)) * Grid[p_i-1][q_i+1];
+
+  q_mean += (qmin + qbinsize * (q_i - 0.5)) * Grid[p_i+1][q_i-1] +
+  	    (qmin + qbinsize * (q_i + 0.5)) * Grid[p_i+1][q_i] +
+  	    (qmin + qbinsize * (q_i + 1.5)) * Grid[p_i+1][q_i+1];
+
+  q_mean /= (Grid[p_i][q_i-1] + Grid[p_i][q_i] + Grid[p_i][q_i+1] +
+	     Grid[p_i-1][q_i-1] + Grid[p_i-1][q_i] + Grid[p_i-1][q_i+1] +
+	     Grid[p_i+1][q_i-1] + Grid[p_i+1][q_i] + Grid[p_i+1][q_i+1]);
+
+  pqPoint point_o;
+  point_o.p = p_mean;
+  point_o.q = q_mean;
+  point_o.w = w;
+  //	cout << "interpolated " << Grid[p_mean][j] << endl;
+  return point_o;
+}
+
+void Retina::printMaxima() {
+  unsigned int size = pqCollection.size();
+  if ( view == XY )
+    cout << "MAXIMA p , q , w (XY view):" << endl;
+  else if ( view == RZ )
+    cout << "MAXIMA p , q , w (RZ view):" << endl;
+  for (unsigned int i = 0; i < size; i++) {
+    cout << pqCollection[i].p << " , " << pqCollection[i].q << " , " << pqCollection[i].w << endl;
+  }
+}
+
+vector <pqPoint> Retina::getMaxima() {
+  return pqCollection;
+}
+
+pqPoint Retina::getBestPQ() {
+  unsigned int size = pqCollection.size();
+  double max = 0.;
+  pqPoint bestPQ;
+  bestPQ.w = -1.;
+  for (unsigned int i = 0; i < size; i++) {
+    if (pqCollection[i].w > max) {
+      max = pqCollection[i].w;
+      bestPQ = pqCollection[i];
+    }
+  }
+  //	cout << " bestPQp " << bestPQ.p << "   bestPQq = " << bestPQ.q << " best w" << bestPQ.w << endl;
+  return bestPQ;
+}
+

--- a/L1Trigger/TrackFindingAM/src/RetinaTrackFitter.cc
+++ b/L1Trigger/TrackFindingAM/src/RetinaTrackFitter.cc
@@ -1,0 +1,754 @@
+#include "../interface/RetinaTrackFitter.h"
+
+const double RetinaTrackFitter::rot_angle[8] = {  0.39269908169872414,   //  pi/8
+						  -0.39269908169872414,   // -pi/8
+						  -1.17809724509617242,   // -3/8 pi
+						  -1.96349540849362070,   // -5/8 pi
+						  -2.74889357189106898,   // -7/8 pi
+						  -3.53429173528851726,   // -9/8 pi
+						  -4.31968989868596509,   // -11/8 pi
+						  -5.10508806208341426 }; // -13/8 pi
+
+RetinaTrackFitter::RetinaTrackFitter():TrackFitter(0)
+{
+  verboseLevel  = 0;
+  event_counter = 0;
+  road_id       = 0;
+
+  initialize();
+}
+
+RetinaTrackFitter::RetinaTrackFitter(int nb):TrackFitter(nb)
+{
+  verboseLevel  = 0;
+  event_counter = 0;
+  road_id       = 0;
+
+  initialize();
+}
+
+RetinaTrackFitter::~RetinaTrackFitter(){
+}
+
+
+void RetinaTrackFitter::fit(vector<Hit*> hits_){
+  if ( hits_.size()>1024 ){
+    cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter << "/" 
+	 << road_id << ": too many stubs for fitting, fit aborted!" << endl;
+    return;
+  }
+
+  if ( hits_.size()<(unsigned int) nb_layers ){
+    cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter << "/" 
+	 << road_id << ": only " << hits_.size() << " stubs found, fit aborted!" << endl;
+    return;
+  }
+
+
+  // --- Constants used in X+-X- transformation:
+  double y0 =  0.0217391304347826081; // 0.5/23.
+  double y1 =  0.0046296296296296294; // 0.5/108.
+
+
+  // --- Determine in which phi sector and eta range the trigger tower is:
+  const int phi_sector = sector_id % 8;
+  const int eta_range  = sector_id / 8;
+
+  int trigTow_type = 0;
+  if ( eta_range==1 || eta_range==4 )
+    trigTow_type = 1;
+  else if ( eta_range==0 || eta_range==5 )
+    trigTow_type = 2;
+
+
+  // --- Fill the stubs vector:
+  vector <Hit_t*> hits;
+  vector <Hit_t*> hits_RZ;
+
+  for(unsigned int ihit=0; ihit<hits_.size(); ihit++){
+  
+    Hit_t* hit = new Hit_t();
+    hit->x     = hits_[ihit]->getX();
+    hit->y     = hits_[ihit]->getY();
+    // NB: We flip the z sign for the trigger towers with negative eta in
+    //     order to use the same retina setup as for eta > 0 
+    hit->z     = ( eta_range > 2 ? hits_[ihit]->getZ() : -hits_[ihit]->getZ() );
+    hit->rho   = sqrt( hits_[ihit]->getX()*hits_[ihit]->getX() +
+		       hits_[ihit]->getY()*hits_[ihit]->getY() );
+    hit->layer = (short) hits_[ihit]->getLayer();
+    hit->id    = hits_[ihit]->getID();
+    
+    hits.push_back(hit);
+
+    if (verboseLevel==2 )
+      cout << ihit << "  -  " 
+    	   << " x = " << hits_[ihit]->getX() << "   "
+    	   << " y = " << hits_[ihit]->getY() << "   "
+    	   << " z = " << hits_[ihit]->getZ() << " ---> " 
+    	   << " R = " << sqrt(hits_[ihit]->getX()*hits_[ihit]->getX()+
+    			      hits_[ihit]->getY()*hits_[ihit]->getY())
+    	   << "  -  id = " <<  hits_[ihit]->getID()
+    	   << endl;
+
+  }
+
+
+
+  // ===========================================================================
+  //  XY fit
+  // ===========================================================================
+
+  // --- Phi sector rotation:
+  rotateHits(hits, rot_angle[phi_sector]);
+
+  // --- Conformal transformation: 
+  confTrans(hits);
+
+  //
+  // --- First step ------------------------------------------------------------
+  //
+
+  // --- Setup the retina:
+  double pbins_step1 = config[trigTow_type]["xy_pbins_step1"];
+  double qbins_step1 = config[trigTow_type]["xy_qbins_step1"];
+  double pmin_step1  = config[trigTow_type]["xy_pmin_step1"];
+  double pmax_step1  = config[trigTow_type]["xy_pmax_step1"];
+  double qmin_step1  = config[trigTow_type]["xy_qmin_step1"];
+  double qmax_step1  = config[trigTow_type]["xy_qmax_step1"];
+  
+  double minWeight_step1 = config[trigTow_type]["xy_threshold_step1"];
+
+  double pstep_step1 = (pmax_step1-pmin_step1)/pbins_step1;
+  double qstep_step1 = (qmax_step1-qmin_step1)/qbins_step1;
+
+  vector <double> sigma_step1(8,sqrt(pstep_step1*pstep_step1+qstep_step1*qstep_step1));
+  if ( config[trigTow_type]["xy_sigma1_step1"] != 0. ) 
+    sigma_step1[0] = config[trigTow_type]["xy_sigma1_step1"];
+  if ( config[trigTow_type]["xy_sigma2_step1"] != 0. ) 
+    sigma_step1[1] = config[trigTow_type]["xy_sigma2_step1"];
+  if ( config[trigTow_type]["xy_sigma3_step1"] != 0. ) 
+    sigma_step1[2] = config[trigTow_type]["xy_sigma3_step1"];
+  if ( config[trigTow_type]["xy_sigma4_step1"] != 0. ) 
+    sigma_step1[3] = config[trigTow_type]["xy_sigma4_step1"];
+  if ( config[trigTow_type]["xy_sigma5_step1"] != 0. ) 
+    sigma_step1[4] = config[trigTow_type]["xy_sigma5_step1"];
+  if ( config[trigTow_type]["xy_sigma6_step1"] != 0. ) 
+    sigma_step1[5] = config[trigTow_type]["xy_sigma6_step1"];
+  if ( config[trigTow_type]["xy_sigma7_step1"] != 0. ) 
+    sigma_step1[6] = config[trigTow_type]["xy_sigma7_step1"];
+  if ( config[trigTow_type]["xy_sigma8_step1"] != 0. ) 
+    sigma_step1[7] = config[trigTow_type]["xy_sigma8_step1"];
+
+
+  Retina retinaXY_step1(hits, pbins_step1+2, qbins_step1+2, 
+			pmin_step1-pstep_step1, pmax_step1+pstep_step1, 
+			qmin_step1-qstep_step1, qmax_step1+qstep_step1, 
+			sigma_step1, minWeight_step1, 1, XY);
+
+
+  // --- Fill the retina and find maxima:
+  retinaXY_step1.fillGrid();
+  retinaXY_step1.findMaxima();
+  if ( verboseLevel==1 )
+    retinaXY_step1.dumpGrid(event_counter,1,0);
+  if ( verboseLevel==2 )
+    retinaXY_step1.printMaxima();
+
+
+  // --- Get first step maxima:
+  vector <pqPoint> maximaXY_step1 = retinaXY_step1.getMaxima();
+
+  if ( maximaXY_step1.size()==0 && verboseLevel>0 ){
+    cout << "*** WARNING in RetinaTrackFitter::fit() at event/road = " << event_counter << "/" 
+	 << road_id << ": no maximum found in XY fit-step 1." << endl;
+    retinaXY_step1.dumpGrid(event_counter,1,0);
+  }
+
+  if ( maximaXY_step1.size() > 10 ){
+    cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter 
+	 << "/" << road_id << ": " << maximaXY_step1.size() 
+	 << " maxima found in XY fit-step 1, fit aborted!" << endl;
+    if ( verboseLevel>0 ) 
+      retinaXY_step1.dumpGrid(event_counter,1,0);
+    return;
+  }
+
+
+  //
+  // --- Second step -----------------------------------------------------------
+  //
+
+  double pbins_step2 = config[trigTow_type]["xy_pbins_step2"];
+  double qbins_step2 = config[trigTow_type]["xy_qbins_step2"];
+
+  // --- Zoom around first step maxima:
+  for (unsigned int imax=0; imax<maximaXY_step1.size(); ++imax){
+
+    // --- Retina setup:
+    double pmin_step2 = maximaXY_step1[imax].p - config[trigTow_type]["xy_zoom_step2"]*pstep_step1;
+    double pmax_step2 = maximaXY_step1[imax].p + config[trigTow_type]["xy_zoom_step2"]*pstep_step1;
+    double qmin_step2 = maximaXY_step1[imax].q - config[trigTow_type]["xy_zoom_step2"]*qstep_step1;
+    double qmax_step2 = maximaXY_step1[imax].q + config[trigTow_type]["xy_zoom_step2"]*qstep_step1;
+   
+    double pstep_step2 = (pmax_step2-pmin_step2)/pbins_step2;
+    double qstep_step2 = (qmax_step2-qmin_step2)/qbins_step2;
+    
+    double minWeight_step2 = config[trigTow_type]["xy_threshold_step2"];
+
+    vector <double> sigma_step2(8,sqrt(pstep_step2*pstep_step2+qstep_step2*qstep_step2));
+    if ( config[trigTow_type]["xy_sigma1_step2"] != 0. ) 
+      sigma_step2[0] = config[trigTow_type]["xy_sigma1_step2"];
+    if ( config[trigTow_type]["xy_sigma2_step2"] != 0. ) 
+      sigma_step2[1] = config[trigTow_type]["xy_sigma2_step2"];
+    if ( config[trigTow_type]["xy_sigma3_step2"] != 0. ) 
+      sigma_step2[2] = config[trigTow_type]["xy_sigma3_step2"];
+    if ( config[trigTow_type]["xy_sigma4_step2"] != 0. ) 
+      sigma_step2[3] = config[trigTow_type]["xy_sigma4_step2"];
+    if ( config[trigTow_type]["xy_sigma5_step2"] != 0. ) 
+      sigma_step2[4] = config[trigTow_type]["xy_sigma5_step2"];
+    if ( config[trigTow_type]["xy_sigma6_step2"] != 0. ) 
+      sigma_step2[5] = config[trigTow_type]["xy_sigma6_step2"];
+    if ( config[trigTow_type]["xy_sigma7_step2"] != 0. ) 
+      sigma_step2[6] = config[trigTow_type]["xy_sigma7_step2"];
+    if ( config[trigTow_type]["xy_sigma8_step2"] != 0. ) 
+      sigma_step2[7] = config[trigTow_type]["xy_sigma8_step2"];
+
+
+    Retina retinaXY_step2(hits, pbins_step2+2, qbins_step2+2, 
+			  pmin_step2-pstep_step2, pmax_step2+pstep_step2, 
+			  qmin_step2-qstep_step2, qmax_step2+qstep_step2, 
+			  sigma_step2, minWeight_step2, 1, XY);
+
+
+    // --- Fill the retina and find maxima:
+    retinaXY_step2.fillGrid();
+    retinaXY_step2.findMaxima();
+    if ( verboseLevel==1 )
+      retinaXY_step2.dumpGrid(event_counter,2,imax);
+    if ( verboseLevel==2 )
+      retinaXY_step2.printMaxima();
+
+
+    // --- Get second step maxima:
+    vector <pqPoint> maximaXY_step2 = retinaXY_step2.getMaxima();
+
+    if ( maximaXY_step2.size()==0 && verboseLevel>0 ){
+      cout << "*** WARNING in RetinaTrackFitter::fit() at event/road = " << event_counter << "/" 
+	   << road_id << ": no maximum found in XY fit-step 2 (step-1 XY maximum #" << imax << ")." 
+	   << endl;
+      retinaXY_step2.dumpGrid(event_counter,2,imax);
+    }
+
+    if ( maximaXY_step2.size() > 10 ){
+      cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter 
+	   << "/" << road_id << ": " << maximaXY_step2.size() 
+	   << " maxima found in XY fit-step 2 (step-1 XY maximum #" << imax << "), fit aborted!" 
+	   << endl;
+      if ( verboseLevel>0 ) 
+	retinaXY_step2.dumpGrid(event_counter,2,imax);
+      continue;
+    }
+
+
+    // --- Loop over XY second step maxima:
+    for (unsigned int itrk=0; itrk<maximaXY_step2.size(); ++itrk){
+
+      // --- Invert the X+-X- transformation:
+      double p = 0.5*(y1 - y0)/maximaXY_step2[itrk].q;
+      double q = y0 - p*(maximaXY_step2[itrk].p-maximaXY_step2[itrk].q);
+
+
+      // --- Associate stubs to this maximum:
+      hits_RZ.clear();
+      unsigned int n_stubsPS = 0;
+      for (unsigned int ihit=0; ihit<hits.size(); ++ihit){
+      
+	double dist   = (p*hits[ihit]->x-hits[ihit]->y+q)/p;
+	//double dist   = fabs(hits[ihit]->y-p*hits[ihit]->x-q)/sqrt(1.+p*p);
+	double weight = exp(-0.5*dist*dist/(sigma_step2[0]*sigma_step2[0]));
+
+	if ( weight > 0.5 ){
+	  hits_RZ.push_back(hits[ihit]);
+	  if ( hits[ihit]->rho > 60. )
+	    n_stubsPS++;
+	}
+	else
+	  if ( verboseLevel>0 )
+	    cout << "*** WARNING in RetinaTrackFitter::fit() at event/road = " << event_counter 
+		 << "/" << road_id << ": stub " << hits[ihit]->id << " with weight = " << weight 
+		 << " has not been associated to the XY step-2 maximum #" << imax << "." << endl;
+      }
+      if ( hits_RZ.size() < 3 ){
+	if ( verboseLevel>0 )
+	  cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter 
+	       << "/" << road_id << ": only " <<  hits_RZ.size() 
+	       << " stubs associated to the XY step-2 maximum #" << imax << ", fit aborted!" << endl;
+	continue;
+      }
+
+      // --- Rotate back the original phi sector:
+      q = q/(cos(rot_angle[phi_sector])+p*sin(rot_angle[phi_sector]));
+      p = (p*cos(rot_angle[phi_sector])-sin(rot_angle[phi_sector]))/
+        (cos(rot_angle[phi_sector])+p*sin(rot_angle[phi_sector]));
+
+
+      // --- Invert the conformal transformation and get the track parameters:
+      double a = -0.5*p/q;
+      double b =  0.5/q;
+    
+      double c   = 1./sqrt(a*a+b*b);
+      double phi = atan(p);
+      //if ( phi<0. )
+      //	phi += TMath::TwoPi();
+
+      // =========================================================================
+      //  RZ fit
+      // =========================================================================
+
+      y0 = 0.5/y0;
+      y1 = 0.5/y1;
+
+      double eta = -9999.;
+      double z0  = -9999.;
+    
+
+      //
+      // --- First step ----------------------------------------------------------
+      //
+
+      pbins_step1 = config[trigTow_type]["rz_pbins_step1"];
+      qbins_step1 = config[trigTow_type]["rz_qbins_step1"];
+      pmin_step1  = config[trigTow_type]["rz_pmin_step1"];
+      pmax_step1  = config[trigTow_type]["rz_pmax_step1"];
+      qmin_step1  = config[trigTow_type]["rz_qmin_step1"];
+      qmax_step1  = config[trigTow_type]["rz_qmax_step1"];
+
+      minWeight_step1 = config[trigTow_type]["rz_threshold_step1"];
+
+      pstep_step1 = (pmax_step1-pmin_step1)/pbins_step1;
+      qstep_step1 = (qmax_step1-qmin_step1)/qbins_step1;
+
+      for (unsigned int ilayer=0; ilayer<8; ++ilayer)
+	sigma_step1[ilayer] = sqrt(pstep_step1*pstep_step1+qstep_step1*qstep_step1);
+
+      if ( config[trigTow_type]["rz_sigma1_step1"] != 0. ) 
+	sigma_step1[0] = config[trigTow_type]["rz_sigma1_step1"];
+      if ( config[trigTow_type]["rz_sigma2_step1"] != 0. ) 
+	sigma_step1[1] = config[trigTow_type]["rz_sigma2_step1"];
+      if ( config[trigTow_type]["rz_sigma3_step1"] != 0. ) 
+	sigma_step1[2] = config[trigTow_type]["rz_sigma3_step1"];
+      if ( config[trigTow_type]["rz_sigma4_step1"] != 0. ) 
+	sigma_step1[3] = config[trigTow_type]["rz_sigma4_step1"];
+      if ( config[trigTow_type]["rz_sigma5_step1"] != 0. ) 
+	sigma_step1[4] = config[trigTow_type]["rz_sigma5_step1"];
+      if ( config[trigTow_type]["rz_sigma6_step1"] != 0. ) 
+	sigma_step1[5] = config[trigTow_type]["rz_sigma6_step1"];
+      if ( config[trigTow_type]["rz_sigma7_step1"] != 0. ) 
+	sigma_step1[6] = config[trigTow_type]["rz_sigma7_step1"];
+      if ( config[trigTow_type]["rz_sigma8_step1"] != 0. ) 
+	sigma_step1[7] = config[trigTow_type]["rz_sigma8_step1"];
+
+      
+      Retina retinaRZ_step1(hits_RZ, pbins_step1+2, qbins_step1+2, 
+			    pmin_step1-pstep_step1, pmax_step1+pstep_step1, 
+			    qmin_step1-qstep_step1, qmax_step1+qstep_step1, 
+			    sigma_step1, minWeight_step1, 1, RZ);
+
+
+      retinaRZ_step1.fillGrid();
+      retinaRZ_step1.findMaxima();
+      if ( verboseLevel==1 )
+	retinaRZ_step1.dumpGrid(event_counter,1,imax);
+      if ( verboseLevel==2 )
+	retinaRZ_step1.printMaxima();
+
+
+      // --- Get first step maximum:
+      vector <pqPoint> maximaRZ_step1 = retinaRZ_step1.getMaxima();
+
+      if ( maximaRZ_step1.size()==0 && verboseLevel>0 ){
+	cout << "*** WARNING in RetinaTrackFitter::fit() at event/road = " << event_counter 
+	     << "/" << road_id << ": no maximum found in RZ fit-step 1 (step-1 maximum #" 
+	     << imax << ")." << endl;
+	retinaXY_step2.dumpGrid(event_counter,2,imax);
+      }
+
+      if ( maximaRZ_step1.size() > 10 ){
+	cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter 
+	     << "/" << road_id << ": " << maximaRZ_step1.size() 
+	     << " maxima found in RZ fit-step 1 (step-1 maximum #" << imax << "), fit aborted!" 
+	     << endl;
+	if ( verboseLevel>0 ) 
+	  retinaRZ_step1.dumpGrid(event_counter,1,imax);
+	continue;
+      }
+
+      
+      //
+      // --- Second step ---------------------------------------------------------
+      //
+
+      pbins_step2 = config[trigTow_type]["rz_pbins_step2"];
+      qbins_step2 = config[trigTow_type]["rz_qbins_step2"];
+
+      // Zoom around first step maxima
+      for (unsigned int imax_RZ=0; imax_RZ<maximaRZ_step1.size(); ++imax_RZ){
+
+	double pmin_step2 = maximaRZ_step1[imax_RZ].p - config[trigTow_type]["rz_zoom_step2"]*pstep_step1;
+	double pmax_step2 = maximaRZ_step1[imax_RZ].p + config[trigTow_type]["rz_zoom_step2"]*pstep_step1;
+	double qmin_step2 = maximaRZ_step1[imax_RZ].q - config[trigTow_type]["rz_zoom_step2"]*qstep_step1;
+	double qmax_step2 = maximaRZ_step1[imax_RZ].q + config[trigTow_type]["rz_zoom_step2"]*qstep_step1;
+   
+	double pstep_step2 = (pmax_step2-pmin_step2)/pbins_step2;
+	double qstep_step2 = (qmax_step2-qmin_step2)/qbins_step2;
+    
+	double minWeight_step2 = config[trigTow_type]["rz_threshold_step2"];
+	// If less than 3 PS stubs are available, adjust the maximum-finder threshold:
+	if (  n_stubsPS < 3 )
+	  minWeight_step2 *= 0.66;
+
+	vector <double> sigma_step2(8,sqrt(pstep_step2*pstep_step2+qstep_step2*qstep_step2));
+	for (unsigned int ilayer=3; ilayer<6; ++ilayer)
+	  sigma_step2[ilayer] = 8.*sqrt(pstep_step2*pstep_step2+qstep_step2*qstep_step2);
+
+	if ( config[trigTow_type]["rz_sigma1_step2"] != 0. ) 
+	  sigma_step2[0] = config[trigTow_type]["rz_sigma1_step2"];
+	if ( config[trigTow_type]["rz_sigma2_step2"] != 0. ) 
+	  sigma_step2[1] = config[trigTow_type]["rz_sigma2_step2"];
+	if ( config[trigTow_type]["rz_sigma3_step2"] != 0. ) 
+	  sigma_step2[2] = config[trigTow_type]["rz_sigma3_step2"];
+	if ( config[trigTow_type]["rz_sigma4_step2"] != 0. ) 
+	  sigma_step2[3] = config[trigTow_type]["rz_sigma4_step2"];
+	if ( config[trigTow_type]["rz_sigma5_step2"] != 0. ) 
+	  sigma_step2[4] = config[trigTow_type]["rz_sigma5_step2"];
+	if ( config[trigTow_type]["rz_sigma6_step2"] != 0. ) 
+	  sigma_step2[5] = config[trigTow_type]["rz_sigma6_step2"];
+	if ( config[trigTow_type]["rz_sigma7_step2"] != 0. ) 
+	  sigma_step2[6] = config[trigTow_type]["rz_sigma7_step2"];
+	if ( config[trigTow_type]["rz_sigma8_step2"] != 0. ) 
+	  sigma_step2[7] = config[trigTow_type]["rz_sigma8_step2"];
+
+
+	Retina retinaRZ_step2(hits_RZ, pbins_step2+2, qbins_step2+2, 
+			      pmin_step2-pstep_step2, pmax_step2+pstep_step2, 
+			      qmin_step2-qstep_step2, qmax_step2+qstep_step2, 
+			      sigma_step2, minWeight_step2, 1, RZ);
+
+
+	retinaRZ_step2.fillGrid();
+	retinaRZ_step2.findMaxima();
+	if ( verboseLevel==1 )
+	  retinaRZ_step2.dumpGrid(event_counter,2,imax*100+imax_RZ);
+	if ( verboseLevel==2 )
+	  retinaRZ_step2.printMaxima();
+
+	pqPoint bestpqRZ_step2 = retinaRZ_step2.getBestPQ();
+
+	// --- If no RZ maximum is found, skip the road:
+	if ( bestpqRZ_step2.w == -1. ) {
+	  if ( verboseLevel>0 )
+	    cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter 
+		 << "/" << road_id << ": no maximum found in RZ fit-step 2 (step-1 XY maximum #" 
+		 << imax << ", step-1 RZ maximum #" << imax_RZ << "), fit aborted!" << endl;
+	  continue;
+	}
+
+	if ( retinaRZ_step2.getMaxima().size() > 10 ){
+	  cout << "*** ERROR in RetinaTrackFitter::fit() at event/road = " << event_counter 
+	       << "/" << road_id << ": " << retinaRZ_step2.getMaxima().size()
+	       << " maxima found in RZ fit-step 2 (step-1 maximum #" << imax 
+	       << ", step-1 RZ maximum #" << imax_RZ << "), fit aborted!" << endl;
+	  if ( verboseLevel>0 ) 
+	    retinaRZ_step2.dumpGrid(event_counter,2,imax*100+imax_RZ);
+	  continue;
+	}
+
+
+	// --- Invert the X+-X- transformation:
+	double p = 0.5*(y1 - y0)/bestpqRZ_step2.q;
+	double q = y0 - p*(bestpqRZ_step2.p-bestpqRZ_step2.q);
+
+
+	// --- Get the track parameters:
+	double theta = atan(p);
+	if ( theta < 0. ){
+	  if ( verboseLevel>0 ) 
+	    cout << "*** WARNING in RetinaTrackFitter::fit() at event/road = " << event_counter 
+		 << "/" << road_id << ": theta corrected from " << theta << " to " << theta+TMath::Pi() 
+		 << endl;
+	  theta += TMath::Pi();
+	}
+	eta = -log(tan(0.5*theta));
+	z0  = -q/p;
+
+
+	// --- Invert eta and z0 signs if we are fitting a negative-eta tower:
+	if ( eta_range < 3 ){
+	  eta = -eta;
+	  z0  = -z0;
+	}
+
+
+	// --- Save the track:
+	Track* trk = new Track(c, 0., phi, eta, z0, maximaXY_step2[itrk].w, bestpqRZ_step2.w);
+	for(unsigned int ihit=0; ihit<hits_RZ.size(); ihit++)
+	  trk->addStubIndex(hits_RZ[ihit]->id);
+
+	tracks.push_back(trk);
+	
+
+      } // imax_RZ loop
+
+ 
+    } // itrk loop
+ 
+ 
+  } // imax loop
+
+
+  // --- Clean-up pointers:
+  for(vector<Hit_t*>::iterator it=hits.begin(); it!=hits.end(); ++it)
+    delete *it;
+
+  
+}
+
+void RetinaTrackFitter::fit(){
+
+  vector<Hit*> activatedHits;
+
+  //////// Get the list of unique stubs from all the patterns ///////////
+  set<int> ids;
+  int total=0;
+  
+  for(unsigned int i=0;i<patterns.size();i++){
+    vector<Hit*> allHits = patterns[i]->getHits();
+    total+=allHits.size();
+    for(unsigned int j=0;j<allHits.size();j++){
+      pair<set<int>::iterator,bool> result = ids.insert(allHits[j]->getID());
+      if(result.second==true)
+	activatedHits.push_back(allHits[j]);
+    }
+  }
+
+  fit(activatedHits);
+ 
+}
+
+
+void RetinaTrackFitter::mergePatterns(){
+  //cout<<"Merging of patterns not implemented"<<endl;
+}
+
+
+void RetinaTrackFitter::mergeTracks(){
+}
+
+
+TrackFitter* RetinaTrackFitter::clone(){
+  RetinaTrackFitter* fit = new RetinaTrackFitter(nb_layers);
+  fit->setPhiRotation(sec_phi);
+  fit->setSectorID(sector_id);
+  return fit;
+}
+
+void RetinaTrackFitter::rotateHits(vector<Hit_t*> hits, double angle){
+  
+  for (unsigned int ihit=0; ihit<hits.size(); ihit++) {
+    double x = hits[ihit]->x*cos(angle) - hits[ihit]->y*sin(angle);
+    double y = hits[ihit]->x*sin(angle) + hits[ihit]->y*cos(angle);
+    hits[ihit]->x = x;
+    hits[ihit]->y = y;
+  }
+
+}
+
+void RetinaTrackFitter::confTrans(vector<Hit_t*> hits){
+  
+  for (unsigned int ihit=0; ihit<hits.size(); ihit++) {
+    double R2 = hits[ihit]->x*hits[ihit]->x + hits[ihit]->y*hits[ihit]->y;
+    hits[ihit]->x /= R2;
+    hits[ihit]->y /= R2;
+  }
+
+}
+
+void RetinaTrackFitter::initialize(){
+
+  // Enter all the retina parameters
+  // (we refer to the detector geometry in
+  //  http://sviret.web.cern.ch/sviret/Images/CMS/Upgrade/Eta6_Phi8.jpg)
+
+  // --- Central trigger tower:
+  config[0]["xy_pbins_step1"]     = 40.;
+  config[0]["xy_qbins_step1"]     = 40.;
+  config[0]["xy_pmin_step1"]      = -0.05;
+  config[0]["xy_pmax_step1"]      =  0.05;
+  config[0]["xy_qmin_step1"]      = -0.05;
+  config[0]["xy_qmax_step1"]      =  0.05;
+  config[0]["xy_threshold_step1"] =  4.5;
+  config[0]["xy_sigma1_step1"]    =  0.;
+  config[0]["xy_sigma2_step1"]    =  0.;
+  config[0]["xy_sigma3_step1"]    =  0.;
+  config[0]["xy_sigma4_step1"]    =  0.;
+  config[0]["xy_sigma5_step1"]    =  0.;
+  config[0]["xy_sigma6_step1"]    =  0.;
+  config[0]["xy_sigma7_step1"]    =  0.;
+  config[0]["xy_sigma8_step1"]    =  0.;
+  config[0]["xy_pbins_step2"]     = 100.;
+  config[0]["xy_qbins_step2"]     = 100.;
+  config[0]["xy_zoom_step2"]      = 1.;
+  config[0]["xy_threshold_step2"] =  4.5;
+  config[0]["xy_sigma1_step2"]    =  0.;
+  config[0]["xy_sigma2_step2"]    =  0.;
+  config[0]["xy_sigma3_step2"]    =  0.;
+  config[0]["xy_sigma4_step2"]    =  0.;
+  config[0]["xy_sigma5_step2"]    =  0.;
+  config[0]["xy_sigma6_step2"]    =  0.;
+  config[0]["xy_sigma7_step2"]    =  0.;
+  config[0]["xy_sigma8_step2"]    =  0.;
+
+  config[0]["rz_pbins_step1"]     = 20.;
+  config[0]["rz_qbins_step1"]     = 20.;
+  config[0]["rz_pmin_step1"]      = -20.;
+  config[0]["rz_pmax_step1"]      =  60.;
+  config[0]["rz_qmin_step1"]      = -60.;
+  config[0]["rz_qmax_step1"]      =  60.;
+  config[0]["rz_threshold_step1"] =  4.5;
+  config[0]["rz_sigma1_step1"]    =  0.;
+  config[0]["rz_sigma2_step1"]    =  0.;
+  config[0]["rz_sigma3_step1"]    =  0.;
+  config[0]["rz_sigma4_step1"]    =  0.;
+  config[0]["rz_sigma5_step1"]    =  0.;
+  config[0]["rz_sigma6_step1"]    =  0.;
+  config[0]["rz_sigma7_step1"]    =  0.;
+  config[0]["rz_sigma8_step1"]    =  0.;
+  config[0]["rz_pbins_step2"]     = 80.;
+  config[0]["rz_qbins_step2"]     = 80.;
+  config[0]["rz_zoom_step2"]      = 1.5;
+  config[0]["rz_threshold_step2"] =  4.;
+  config[0]["rz_sigma1_step2"]    =  0.;
+  config[0]["rz_sigma2_step2"]    =  0.;
+  config[0]["rz_sigma3_step2"]    =  0.;
+  config[0]["rz_sigma4_step2"]    =  0.;
+  config[0]["rz_sigma5_step2"]    =  0.;
+  config[0]["rz_sigma6_step2"]    =  0.;
+  config[0]["rz_sigma7_step2"]    =  0.;
+  config[0]["rz_sigma8_step2"]    =  0.;
+
+  // --- Hybrid trigger tower:
+  config[1]["xy_pbins_step1"]     = 40.;
+  config[1]["xy_qbins_step1"]     = 40.;
+  config[1]["xy_pmin_step1"]      = -0.05;
+  config[1]["xy_pmax_step1"]      =  0.05;
+  config[1]["xy_qmin_step1"]      = -0.05;
+  config[1]["xy_qmax_step1"]      =  0.05;
+  config[1]["xy_threshold_step1"] =  4.;
+  config[1]["xy_sigma1_step1"]    =  0.;
+  config[1]["xy_sigma2_step1"]    =  0.;
+  config[1]["xy_sigma3_step1"]    =  0.;
+  config[1]["xy_sigma4_step1"]    =  0.;
+  config[1]["xy_sigma5_step1"]    =  0.;
+  config[1]["xy_sigma6_step1"]    =  0.;
+  config[1]["xy_sigma7_step1"]    =  0.;
+  config[1]["xy_sigma8_step1"]    =  0.;
+  config[1]["xy_pbins_step2"]     = 100.;
+  config[1]["xy_qbins_step2"]     = 100.;
+  config[1]["xy_zoom_step2"]      = 1.;
+  config[1]["xy_threshold_step2"] =  4.;
+  config[1]["xy_sigma1_step2"]    =  0.;
+  config[1]["xy_sigma2_step2"]    =  0.;
+  config[1]["xy_sigma3_step2"]    =  0.;
+  config[1]["xy_sigma4_step2"]    =  0.;
+  config[1]["xy_sigma5_step2"]    =  0.;
+  config[1]["xy_sigma6_step2"]    =  0.;
+  config[1]["xy_sigma7_step2"]    =  0.;
+  config[1]["xy_sigma8_step2"]    =  0.;
+
+  config[1]["rz_pbins_step1"]     = 20.;
+  config[1]["rz_qbins_step1"]     = 20.;
+  config[1]["rz_pmin_step1"]      = 40.;
+  config[1]["rz_pmax_step1"]      = 140.;
+  config[1]["rz_qmin_step1"]      = 0.;
+  config[1]["rz_qmax_step1"]      = 120.;
+  config[1]["rz_threshold_step1"] =  4.;
+  config[1]["rz_sigma1_step1"]    =  0.;
+  config[1]["rz_sigma2_step1"]    =  0.;
+  config[1]["rz_sigma3_step1"]    =  0.;
+  config[1]["rz_sigma4_step1"]    =  0.;
+  config[1]["rz_sigma5_step1"]    =  0.;
+  config[1]["rz_sigma6_step1"]    =  0.;
+  config[1]["rz_sigma7_step1"]    =  0.;
+  config[1]["rz_sigma8_step1"]    =  0.;
+  config[1]["rz_pbins_step2"]     = 80.;
+  config[1]["rz_qbins_step2"]     = 80.;
+  config[1]["rz_zoom_step2"]      = 1.5;
+  config[1]["rz_threshold_step2"] =  3.;
+  config[1]["rz_sigma1_step2"]    =  0.;
+  config[1]["rz_sigma2_step2"]    =  0.;
+  config[1]["rz_sigma3_step2"]    =  0.;
+  config[1]["rz_sigma4_step2"]    =  0.;
+  config[1]["rz_sigma5_step2"]    =  0.;
+  config[1]["rz_sigma6_step2"]    =  0.;
+  config[1]["rz_sigma7_step2"]    =  0.;
+  config[1]["rz_sigma8_step2"]    =  0.;
+
+  // --- Forward trigger tower:
+  config[2]["xy_pbins_step1"]     = 40.;
+  config[2]["xy_qbins_step1"]     = 40.;
+  config[2]["xy_pmin_step1"]      = -0.05;
+  config[2]["xy_pmax_step1"]      =  0.05;
+  config[2]["xy_qmin_step1"]      = -0.05;
+  config[2]["xy_qmax_step1"]      =  0.05;
+  config[2]["xy_threshold_step1"] =  4.;
+  config[2]["xy_sigma1_step1"]    =  0.;
+  config[2]["xy_sigma2_step1"]    =  0.;
+  config[2]["xy_sigma3_step1"]    =  0.;
+  config[2]["xy_sigma4_step1"]    =  0.;
+  config[2]["xy_sigma5_step1"]    =  0.;
+  config[2]["xy_sigma6_step1"]    =  0.;
+  config[2]["xy_sigma7_step1"]    =  0.;
+  config[2]["xy_sigma8_step1"]    =  0.;
+  config[2]["xy_pbins_step2"]     = 100.;
+  config[2]["xy_qbins_step2"]     = 100.;
+  config[2]["xy_zoom_step2"]      = 1.;
+  config[2]["xy_threshold_step2"] =  4.;
+  config[2]["xy_sigma1_step2"]    =  0.;
+  config[2]["xy_sigma2_step2"]    =  0.;
+  config[2]["xy_sigma3_step2"]    =  0.;
+  config[2]["xy_sigma4_step2"]    =  0.;
+  config[2]["xy_sigma5_step2"]    =  0.;
+  config[2]["xy_sigma6_step2"]    =  0.;
+  config[2]["xy_sigma7_step2"]    =  0.;
+  config[2]["xy_sigma8_step2"]    =  0.;
+
+  config[2]["rz_pbins_step1"]     = 20.;
+  config[2]["rz_qbins_step1"]     = 20.;
+  config[2]["rz_pmin_step1"]      = 140.;
+  config[2]["rz_pmax_step1"]      = 240.;
+  config[2]["rz_qmin_step1"]      = 80.;
+  config[2]["rz_qmax_step1"]      = 180.;
+  config[2]["rz_threshold_step1"] =  4.;
+  config[2]["rz_sigma1_step1"]    =  1.5;
+  config[2]["rz_sigma2_step1"]    =  1.5;
+  config[2]["rz_sigma3_step1"]    =  1.5;
+  config[2]["rz_sigma4_step1"]    =  1.5;
+  config[2]["rz_sigma5_step1"]    =  1.5;
+  config[2]["rz_sigma6_step1"]    =  1.5;
+  config[2]["rz_sigma7_step1"]    =  1.5;
+  config[2]["rz_sigma8_step1"]    =  1.5;
+  config[2]["rz_pbins_step2"]     = 80.;
+  config[2]["rz_qbins_step2"]     = 80.;
+  config[2]["rz_zoom_step2"]      = 1.5;
+  config[2]["rz_threshold_step2"] = 3.;
+  config[2]["rz_sigma1_step2"]    = 0.;
+  config[2]["rz_sigma2_step2"]    = 0.;
+  config[2]["rz_sigma3_step2"]    = 0.;
+  config[2]["rz_sigma4_step2"]    = 0.;
+  config[2]["rz_sigma5_step2"]    = 0.;
+  config[2]["rz_sigma6_step2"]    = 0.;
+  config[2]["rz_sigma7_step2"]    = 0.;
+  config[2]["rz_sigma8_step2"]    = 0.;
+
+
+}

--- a/L1Trigger/TrackFindingAM/src/Track.cc
+++ b/L1Trigger/TrackFindingAM/src/Track.cc
@@ -1,19 +1,23 @@
 #include "../interface/Track.h"
 
 Track::Track(){
-  curve = 0;
-  d0    = 0;
-  phi0  = 0;
-  eta0  = 0;
-  z0    = 0;
+  curve = 0.;
+  d0    = 0.;
+  phi0  = 0.;
+  eta0  = 0.;
+  z0    = 0.;
+  w_xy  = 0.;
+  w_rz  = 0.;
 }
 
-Track::Track(double c, double d, double p, double p_a, double p_b){
+Track::Track(double c, double d, double p, double p_a, double p_b, double Wxy, double Wrz){
   curve = c;
   d0    = d;
   phi0  = p;
   eta0  = p_a;
   z0    = p_b;
+  w_xy  = Wxy;
+  w_rz  = Wrz;
 }
 
 Track::Track(const Track& ref){
@@ -22,6 +26,8 @@ Track::Track(const Track& ref){
   phi0  = ref.phi0;
   eta0  = ref.eta0;
   z0    = ref.z0;
+  w_xy  = ref.w_xy;
+  w_rz  = ref.w_rz;
   for(unsigned int i=0;i<ref.stub_ids.size();i++){
     stub_ids.push_back(ref.stub_ids[i]);
   }
@@ -45,6 +51,14 @@ void Track::setEta0(double p_a){
 
 void Track::setZ0(double p_b){
   z0=p_b;
+}
+
+void Track::setWxy(double Wxy){
+  w_xy=Wxy;
+}
+
+void Track::setWrz(double Wrz){
+  w_rz=Wrz;
 }
 
 void Track::addStubIndex(int s){
@@ -79,4 +93,12 @@ double Track::getEta0(){
 
 double Track::getZ0(){
   return z0;
+}
+
+double Track::getWxy(){
+  return w_xy;
+}
+
+double Track::getWrz(){
+  return w_rz;
 }

--- a/L1Trigger/TrackFindingAM/test/AMPR_test.py
+++ b/L1Trigger/TrackFindingAM/test/AMPR_test.py
@@ -64,6 +64,7 @@ process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:upgradePLS3', '')
 process.TTPatternsFromStub.inputBankFile = cms.string('/afs/cern.ch/work/s/sviret/testarea/PatternBanks/BE_5D/Eta7_Phi8/ss32_cov40/612_SLHC6_MUBANK_lowmidhig_sec35_ss32_cov40.pbk')
 process.TTPatternsFromStub.threshold     = cms.int32(5)
 process.TTPatternsFromStub.nbMissingHits = cms.int32(-1)
+process.TTPatternsFromStub.debugMode = cms.int32(0)
 
 # The name of the stub container over which the association is done, please note that the filtered cluster container is
 # not associated due to the lack of simPixelDigis in official samples


### PR DESCRIPTION
This fixes a potential memory leak in #7823 if the `RetinaTrackFitter::fit` function returns early.  There's a comment on #7823 explaining where this can happen.  I have no idea how likely the condition is to be met, but safer not to introduce any potential for a memory leak.

Changing the `hits` vector to an `edm::OwnVector` would have been a more "CMSSW friendly" solution, but that would have required changing the class interface since the vector is passed around.

@sviret, let me know if you're happy with this solution. You should be able to see just my changes at https://github.com/cms-sw/cmssw/commit/7463d3051813ad19d742ccd04f77c7c4c2e5c0e3.

(EDIT - that link for the commit with my changes isn't working for some reason. No idea why.)
