### PR TITLE
Transient vector bugfix

### DIFF
--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -156,6 +156,8 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
 
 
 
+
+
 <ioread sourceClass = "reco::PFTau" version="[1-]" 
  targetClass="reco::PFTau" 
 source = "" 

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -155,6 +155,44 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
 
 
 
+
+<ioread sourceClass = "reco::PFTau" version="[1-]" 
+ targetClass="reco::PFTau" 
+source = "" 
+target="signalPiZeroCandidates_">
+<![CDATA[
+signalPiZeroCandidates_.clear();
+]]>
+</ioread>
+              
+<ioread sourceClass = "reco::PFTau" version="[1-]" 
+ targetClass="reco::PFTau" 
+source = "" 
+target="isolationPiZeroCandidates_">
+<![CDATA[
+isolationPiZeroCandidates_.clear();
+]]>
+</ioread>
+
+<ioread sourceClass = "reco::PFTau" version="[1-]"
+ targetClass="reco::PFTau" 
+source = "" 
+target="signalTauChargedHadronCandidates_">
+<![CDATA[signalTauChargedHadronCandidates_.clear();
+]]>                                    
+</ioread>
+                                      
+<ioread sourceClass = "reco::PFTau" version="[1-]"
+ targetClass="reco::PFTau" 
+source = "" 
+target="isolationTauChargedHadronCandidates_">                                          
+<![CDATA[
+isolationTauChargedHadronCandidates_.clear();                                              
+]]>                                                
+</ioread>
+
+
+
 <!-- <ioread sourceClass="reco::PFTau" version="[-11]" -->
 <!-- source="reco::PFCandidateRefVector selectedIsolationPFCands_;" -->
 <!--  targetClass="reco::PFTau" -->

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -174,6 +174,7 @@ isolationPiZeroCandidates_.clear();
 ]]>
 </ioread>
 
+
 <ioread sourceClass = "reco::PFTau" version="[1-]"
  targetClass="reco::PFTau" 
 source = "" 


### PR DESCRIPTION
Bugfix: Added ioread rules to clear transient vectors in DataFormats/TauReco/src/classes_def_2.xml

Hypernews: https://hypernews.cern.ch/HyperNews/CMS/get/physTools/3315/1/1.html
