### PR TITLE
Fix the ECAL summary initialization problem

### DIFF
--- a/DQM/EcalMonitorClient/interface/DQWorkerClient.h
+++ b/DQM/EcalMonitorClient/interface/DQWorkerClient.h
@@ -33,7 +33,7 @@ namespace ecaldqm
     bool retrieveSource(DQMStore::IGetter&, ProcessType);
 
     bool runsOn(ProcessType _type) const { return _type == kJob || hasLumiPlots_; }
-    void resetMEs();
+    virtual void resetMEs();
     virtual void producePlots(ProcessType) = 0;
 
     void setStatusManager(StatusManager const& _manager) { statusManager_ = &_manager; }

--- a/DQM/EcalMonitorClient/interface/SummaryClient.h
+++ b/DQM/EcalMonitorClient/interface/SummaryClient.h
@@ -10,6 +10,7 @@ namespace ecaldqm {
     SummaryClient();
     ~SummaryClient() {}
 
+    void resetMEs() override;
     void producePlots(ProcessType) override;
 
   private:

--- a/DQM/EcalMonitorClient/src/SummaryClient.cc
+++ b/DQM/EcalMonitorClient/src/SummaryClient.cc
@@ -33,20 +33,38 @@ namespace ecaldqm
   }
 
   void
-  SummaryClient::producePlots(ProcessType _pType)
+  SummaryClient::resetMEs()
   {
+    DQWorkerClient::resetMEs();
+
     MESet& meReportSummaryContents(MEs_.at("ReportSummaryContents"));
     MESet& meReportSummary(MEs_.at("ReportSummary"));
+    MESet& meReportSummaryMap(MEs_.at("ReportSummaryMap"));
 
-    // TODO GIVE IMPLEMENTATIONT TO PER-LUMI REPORT
+    for(unsigned iDCC(0); iDCC < nDCC; ++iDCC){
+      int dccid(iDCC + 1);
+      meReportSummaryContents.fill(dccid, -1.);
+    }
+
+    meReportSummary.fill(-1.);
+
+    meReportSummaryMap.reset(-1.);
+  }
+
+  void
+  SummaryClient::producePlots(ProcessType _pType)
+  {
+    if(_pType == kLumi && !onlineMode_) return;
+    // TODO: Implement offline per-lumi summary
+
+    MESet& meReportSummaryContents(MEs_.at("ReportSummaryContents"));
+    MESet& meReportSummary(MEs_.at("ReportSummary"));
 
     for(unsigned iDCC(0); iDCC < nDCC; ++iDCC){
       int dccid(iDCC + 1);
       meReportSummaryContents.fill(dccid, 1.);
     }
     meReportSummary.fill(1.);
-
-    if(_pType == kLumi) return;
 
     MESet const& sIntegrityByLumi(sources_.at("IntegrityByLumi"));
     MESet const& sDesyncByLumi(sources_.at("DesyncByLumi"));
@@ -90,7 +108,7 @@ namespace ecaldqm
 
       int integrity(iItr->getBinContent());
 
-      if(integrity == kUnknown){
+      if(integrity == kUnknown || integrity == kMUnknown){
         qItr->setBinContent(integrity);
         continue;
       }


### PR DESCRIPTION
Modify the ECAL DQM code to fix the summary initialization problem, which caused the summary map to show 100% in when ECAL is actually out.

The original PR #8057 was closed by mistake. Sorry for that.
