### PR TITLE
Remove use of Cintex

### DIFF
--- a/CommonTools/Utils/test/testCutParserThreaded.cc
+++ b/CommonTools/Utils/test/testCutParserThreaded.cc
@@ -7,8 +7,6 @@
 #include "TObject.h"
 #include "TVirtualStreamerInfo.h"
 
-#include "Cintex/Cintex.h"
-
 #include <thread>
 #include <atomic>
 #include <iostream>
@@ -40,8 +38,6 @@ int main() {
   std::atomic<int> canStartEval{kNThreads};
   std::atomic<bool> failed{false};
   std::vector<std::thread> threads;
-
-  ROOT::Cintex::Cintex::Enable();
 
   TThread::Initialize();
   //When threading, also have to keep ROOT from logging all TObjects into a list


### PR DESCRIPTION
A recently added unit test does not compile because it references Cintex, which does not exist in ROOT6.  This trivial pull request removes the Cintex references for ROOT6.  Please merge as soon as convenient.
