### PR TITLE
Stream migration for JME HLT modules

### DIFF
--- a/HLTrigger/JetMET/interface/AnyJetToCaloJetProducer.h
+++ b/HLTrigger/JetMET/interface/AnyJetToCaloJetProducer.h
@@ -7,7 +7,7 @@
 #include "DataFormats/JetReco/interface/CaloJetCollection.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -16,7 +16,7 @@ namespace edm {
    class ConfigurationDescriptions;
 }
 
-class AnyJetToCaloJetProducer: public edm::EDProducer {
+class AnyJetToCaloJetProducer: public edm::stream::EDProducer<> {
 
   public:
 

--- a/HLTrigger/JetMET/interface/HLTCaloJetIDProducer.h
+++ b/HLTrigger/JetMET/interface/HLTCaloJetIDProducer.h
@@ -12,7 +12,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -33,7 +33,7 @@ namespace reco {
 }
 
 // Class declaration
-class HLTCaloJetIDProducer : public edm::EDProducer {
+class HLTCaloJetIDProducer : public edm::stream::EDProducer<> {
   public:
     explicit HLTCaloJetIDProducer(const edm::ParameterSet & iConfig);
     ~HLTCaloJetIDProducer();

--- a/HLTrigger/JetMET/interface/HLTCaloTowerHtMhtProducer.h
+++ b/HLTrigger/JetMET/interface/HLTCaloTowerHtMhtProducer.h
@@ -13,7 +13,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,7 +28,7 @@ namespace edm {
 }
 
 // Class declaration
-class HLTCaloTowerHtMhtProducer : public edm::EDProducer {
+class HLTCaloTowerHtMhtProducer : public edm::stream::EDProducer<> {
   public:
     explicit HLTCaloTowerHtMhtProducer(const edm::ParameterSet & iConfig);
     ~HLTCaloTowerHtMhtProducer();

--- a/HLTrigger/JetMET/interface/HLTHPDFilter.h
+++ b/HLTrigger/JetMET/interface/HLTHPDFilter.h
@@ -9,7 +9,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
@@ -18,7 +18,7 @@ namespace edm {
    class ConfigurationDescriptions;
 }
 
-class HLTHPDFilter : public edm::EDFilter {
+class HLTHPDFilter : public edm::stream::EDFilter<> {
 
    public:
       explicit HLTHPDFilter(const edm::ParameterSet&);

--- a/HLTrigger/JetMET/interface/HLTHcalTowerNoiseCleaner.h
+++ b/HLTrigger/JetMET/interface/HLTHcalTowerNoiseCleaner.h
@@ -6,7 +6,7 @@
  *  \author Alexander Mott (Caltech), Leonard Apanasevich (UIC), John Paul Chou (Brown)
  *
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"   
@@ -20,7 +20,7 @@ namespace edm {
    class ConfigurationDescriptions;
 }
 
-class HLTHcalTowerNoiseCleaner : public edm::EDProducer {
+class HLTHcalTowerNoiseCleaner : public edm::stream::EDProducer<> {
   
  public:
   explicit HLTHcalTowerNoiseCleaner(const edm::ParameterSet&);

--- a/HLTrigger/JetMET/interface/HLTHtMhtProducer.h
+++ b/HLTrigger/JetMET/interface/HLTHtMhtProducer.h
@@ -13,7 +13,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -32,7 +32,7 @@ namespace edm {
 }
 
 // Class declaration
-class HLTHtMhtProducer : public edm::EDProducer {
+class HLTHtMhtProducer : public edm::stream::EDProducer<> {
   public:
     explicit HLTHtMhtProducer(const edm::ParameterSet & iConfig);
     ~HLTHtMhtProducer();

--- a/HLTrigger/JetMET/interface/HLTJetCollForElePlusJets.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollForElePlusJets.h
@@ -19,7 +19,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -38,7 +38,7 @@ namespace edm {
 //
 
 template <typename T>
-class HLTJetCollForElePlusJets: public edm::EDProducer {
+class HLTJetCollForElePlusJets: public edm::stream::EDProducer<> {
   public:
     explicit HLTJetCollForElePlusJets(const edm::ParameterSet&);
     ~HLTJetCollForElePlusJets();

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsForBoostedLeptonPlusJets.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsForBoostedLeptonPlusJets.h
@@ -19,7 +19,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -37,7 +37,7 @@ namespace edm {
 // class declaration
 //
 
-template <typename jetType> class HLTJetCollectionsForBoostedLeptonPlusJets: public edm::EDProducer {
+template <typename jetType> class HLTJetCollectionsForBoostedLeptonPlusJets: public edm::stream::EDProducer<> {
   public:
     explicit HLTJetCollectionsForBoostedLeptonPlusJets(const edm::ParameterSet&);
     ~HLTJetCollectionsForBoostedLeptonPlusJets();

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsForElePlusJets.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsForElePlusJets.h
@@ -19,7 +19,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -39,7 +39,7 @@ namespace edm {
 //
 
 template<typename T>
-class HLTJetCollectionsForElePlusJets: public edm::EDProducer {
+class HLTJetCollectionsForElePlusJets: public edm::stream::EDProducer<> {
   public:
     explicit HLTJetCollectionsForElePlusJets(const edm::ParameterSet&);
     ~HLTJetCollectionsForElePlusJets();

--- a/HLTrigger/JetMET/interface/HLTJetCollectionsForLeptonPlusJets.h
+++ b/HLTrigger/JetMET/interface/HLTJetCollectionsForLeptonPlusJets.h
@@ -19,7 +19,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 
@@ -37,7 +37,7 @@ namespace edm {
 // class declaration
 //
 
-template <typename jetType> class HLTJetCollectionsForLeptonPlusJets: public edm::EDProducer {
+template <typename jetType> class HLTJetCollectionsForLeptonPlusJets: public edm::stream::EDProducer<> {
   public:
     explicit HLTJetCollectionsForLeptonPlusJets(const edm::ParameterSet&);
     ~HLTJetCollectionsForLeptonPlusJets();

--- a/HLTrigger/JetMET/interface/HLTJetL1MatchProducer.h
+++ b/HLTrigger/JetMET/interface/HLTJetL1MatchProducer.h
@@ -2,7 +2,7 @@
 #define HLTJetL1MatchProducer_h
 
 #include <string>
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -17,7 +17,7 @@
 #include "DataFormats/JetReco/interface/BasicJetCollection.h"
 
 template<typename T>
-class HLTJetL1MatchProducer : public edm::EDProducer {
+class HLTJetL1MatchProducer : public edm::stream::EDProducer<> {
  public:
   explicit HLTJetL1MatchProducer(const edm::ParameterSet&);
   ~HLTJetL1MatchProducer();

--- a/HLTrigger/JetMET/interface/HLTJetsCleanedFromLeadingLeptons.h
+++ b/HLTrigger/JetMET/interface/HLTJetsCleanedFromLeadingLeptons.h
@@ -4,7 +4,7 @@
 #include <vector>
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 
@@ -27,7 +27,7 @@
  * HLTJetCollectionsFilter plugin.
  */
 template <typename JetType>
-class HLTJetsCleanedFromLeadingLeptons: public edm::EDProducer
+class HLTJetsCleanedFromLeadingLeptons: public edm::stream::EDProducer<>
 {
 public:
     typedef std::vector<JetType> JetCollection;

--- a/HLTrigger/JetMET/interface/HLTMETCleanerUsingJetID.h
+++ b/HLTrigger/JetMET/interface/HLTMETCleanerUsingJetID.h
@@ -14,7 +14,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -30,7 +30,7 @@ namespace edm {
 }
 
 // Class declaration
-class HLTMETCleanerUsingJetID : public edm::EDProducer {
+class HLTMETCleanerUsingJetID : public edm::stream::EDProducer<> {
   public:
     explicit HLTMETCleanerUsingJetID(const edm::ParameterSet & iConfig);
     ~HLTMETCleanerUsingJetID();

--- a/HLTrigger/JetMET/interface/HLTMhtProducer.h
+++ b/HLTrigger/JetMET/interface/HLTMhtProducer.h
@@ -12,7 +12,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -31,7 +31,7 @@ namespace edm {
 }
 
 // Class declaration
-class HLTMhtProducer : public edm::EDProducer {
+class HLTMhtProducer : public edm::stream::EDProducer<> {
   public:
     explicit HLTMhtProducer(const edm::ParameterSet & iConfig);
     ~HLTMhtProducer();

--- a/HLTrigger/JetMET/interface/HLTPFJetIDProducer.h
+++ b/HLTrigger/JetMET/interface/HLTPFJetIDProducer.h
@@ -11,7 +11,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -25,7 +25,7 @@ namespace edm {
 }
 
 // Class declaration
-class HLTPFJetIDProducer : public edm::EDProducer {
+class HLTPFJetIDProducer : public edm::stream::EDProducer<> {
   public:
     explicit HLTPFJetIDProducer(const edm::ParameterSet & iConfig);
     ~HLTPFJetIDProducer();

--- a/HLTrigger/JetMET/interface/HLTRHemisphere.h
+++ b/HLTrigger/JetMET/interface/HLTRHemisphere.h
@@ -3,7 +3,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
@@ -25,7 +25,7 @@ namespace edm {
 // class declaration
 //
 
-class HLTRHemisphere : public edm::EDFilter {
+class HLTRHemisphere : public edm::stream::EDFilter<> {
 
    public:
 

--- a/HLTrigger/JetMET/interface/HLTTrackMETProducer.h
+++ b/HLTrigger/JetMET/interface/HLTTrackMETProducer.h
@@ -17,7 +17,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -39,7 +39,7 @@ namespace edm {
 }
 
 // Class declaration
-class HLTTrackMETProducer : public edm::EDProducer {
+class HLTTrackMETProducer : public edm::stream::EDProducer<> {
   public:
     explicit HLTTrackMETProducer(const edm::ParameterSet & iConfig);
     ~HLTTrackMETProducer();

--- a/HLTrigger/JetMET/interface/PFJetsMatchedToFilteredCaloJetsProducer.h
+++ b/HLTrigger/JetMET/interface/PFJetsMatchedToFilteredCaloJetsProducer.h
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -19,7 +19,7 @@
 #include <map>
 #include <vector>
 
-class PFJetsMatchedToFilteredCaloJetsProducer: public edm::EDProducer {
+class PFJetsMatchedToFilteredCaloJetsProducer: public edm::stream::EDProducer<> {
  public:
   explicit PFJetsMatchedToFilteredCaloJetsProducer(const edm::ParameterSet&);
   ~PFJetsMatchedToFilteredCaloJetsProducer();


### PR DESCRIPTION
Making the JME HLT modules streamable at request of TSG. After consulting with @fwyzard it seems like the best thing was simply to switch to stream::EDProducer and stream::EDFilter. Tests are checking out. 
