### PR TITLE
Make char arrays fully const in TaggingVariable

### DIFF
--- a/DataFormats/BTauReco/interface/TaggingVariable.h
+++ b/DataFormats/BTauReco/interface/TaggingVariable.h
@@ -133,8 +133,8 @@ namespace reco {
   // import only TaggingVariableName type into reco namespace
   using btau::TaggingVariableName;
 
-  extern const char* TaggingVariableDescription[];
-  extern const char* TaggingVariableTokens[];
+  extern const char* const TaggingVariableDescription[];
+  extern const char* const TaggingVariableTokens[];
 
   TaggingVariableName getTaggingVariableName ( const std::string & name );
 

--- a/DataFormats/BTauReco/src/TaggingVariable.cc
+++ b/DataFormats/BTauReco/src/TaggingVariable.cc
@@ -8,7 +8,7 @@ using namespace std;
 
 namespace reco {
 
-const char* TaggingVariableDescription[] = {
+const char* const TaggingVariableDescription[] = {
   /* [jetEnergy]                                = */ "jet energy",
   /* [jetPt]                                    = */ "jet transverse momentum",
   /* [trackJetPt]                               = */ "track-based jet transverse momentum",
@@ -108,7 +108,7 @@ const char* TaggingVariableDescription[] = {
   /* [lastTaggingVariable]                      = */ ""
 };
 
-const char* TaggingVariableTokens[] = {
+const char* const TaggingVariableTokens[] = {
   /* [jetEnergy]                                = */ "jetEnergy",
   /* [jetPt]                                    = */ "jetPt",
   /* [trackJetPt]                               = */ "trackJetPt",


### PR DESCRIPTION
The globally available arrays of names are now fully const. This
was spotted by the static analyzer.
