### PR TITLE
Optimize multi-threaded image saving

### DIFF
--- a/Fireworks/Core/interface/FWTEveViewer.h
+++ b/Fireworks/Core/interface/FWTEveViewer.h
@@ -21,7 +21,9 @@
 // system include files
 
 #include <thread>
-
+#include <future>
+#include <mutex>
+#include <condition_variable>
 
 // user include files
 
@@ -52,16 +54,28 @@ public:
 
    FWTGLViewer* SpawnFWTGLViewer();
 
-   std::thread  CaptureAndSaveImage(const TString& file, int height=-1);
+   std::future<int> CaptureAndSaveImage(const TString& file, int height=-1);
 
 private:
    FWTEveViewer(const FWTEveViewer&); // stop default
 
    const FWTEveViewer& operator=(const FWTEveViewer&); // stop default
 
+   void spawn_image_thread();
+
    // ---------- member data --------------------------------
 
    FWTGLViewer *m_fwGlViewer;
+
+   std::vector<unsigned char> m_imgBuffer;
+
+   TString                 m_name;
+   int                     m_ww, m_hh;
+   bool                    m_thr_exit = false;
+   std::thread            *m_thr = 0;
+   std::promise<int>       m_prom;
+   std::mutex              m_moo;
+   std::condition_variable m_cnd;
 };
 
 

--- a/Fireworks/Core/interface/FWTGLViewer.h
+++ b/Fireworks/Core/interface/FWTGLViewer.h
@@ -59,6 +59,8 @@ private:
 
    // ---------- member data --------------------------------
 
+   TGLFBO *m_fbo;
+   int     m_fbo_w, m_fbo_h;
 };
 
 

--- a/Fireworks/Core/src/FWGUIManager.cc
+++ b/Fireworks/Core/src/FWGUIManager.cc
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <sstream>
 #include <thread>
+#include <future>
 
 #include "TGButton.h"
 #include "TGLabel.h"
@@ -916,7 +917,8 @@ FWGUIManager::exportAllViews(const std::string& format, int height)
       }
    }
 
-   std::vector<std::thread> workers;
+   std::vector<std::future<int>> futures;
+   
    const edm::EventBase *event = getCurrentEvent();
    for (name_map_i i = vls.begin(); i != vls.end(); ++i)
    {
@@ -937,7 +939,7 @@ FWGUIManager::exportAllViews(const std::string& format, int height)
          if (GLEW_EXT_framebuffer_object)
          {
             // Multi-threaded save
-            workers.push_back((*j)->CaptureAndSaveImage(file, height));
+            futures.push_back((*j)->CaptureAndSaveImage(file, height));
          }
          else
          {
@@ -950,9 +952,9 @@ FWGUIManager::exportAllViews(const std::string& format, int height)
       }
    }
 
-   for (auto &w : workers)
+   for (auto &f : futures)
    {
-      w.join();
+      f.get();
    }
 }
 

--- a/Fireworks/Core/src/FWTEveViewer.cc
+++ b/Fireworks/Core/src/FWTEveViewer.cc
@@ -49,7 +49,18 @@ FWTEveViewer::FWTEveViewer(const char* n, const char* t) :
 // }
 
 FWTEveViewer::~FWTEveViewer()
-{}
+{
+   m_thr->detach();
+
+   {
+      std::unique_lock<std::mutex> lk(m_moo);
+
+      m_thr_exit = true;
+      m_cnd.notify_one();
+   }
+
+   delete m_thr;
+}
 
 //
 // assignment operators
@@ -63,9 +74,41 @@ FWTEveViewer::~FWTEveViewer()
 //   return *this;
 // }
 
+//==============================================================================
+
 //
 // member functions
 //
+
+void FWTEveViewer::spawn_image_thread()
+{
+   m_thr = new std::thread([=]() {
+         while (true)
+         {
+            {
+               std::unique_lock<std::mutex> lk(m_moo);
+               m_cnd.wait(lk);
+
+               if (m_thr_exit)
+               {
+                  return;
+               }
+            }
+            if (m_name.EndsWith(".jpg"))
+            {
+               SaveJpg(m_name, &m_imgBuffer[0], m_ww, m_hh);
+            }
+            else
+            {
+               SavePng(m_name, &m_imgBuffer[0], m_ww, m_hh);
+            }
+
+            m_prom.set_value(0);
+         }
+      });
+}
+
+//------------------------------------------------------------------------------
 
 FWTGLViewer* FWTEveViewer::SpawnFWTGLViewer()
 {
@@ -84,7 +127,8 @@ FWTGLViewer* FWTEveViewer::SpawnFWTGLViewer()
    return m_fwGlViewer;
 }
 
-std::thread FWTEveViewer::CaptureAndSaveImage(const TString& file, int height)
+std::future<int>
+FWTEveViewer::CaptureAndSaveImage(const TString& file, int height)
 {
    static const TString eh("FWTEveViewer::CaptureAndSaveImage");
 
@@ -97,7 +141,9 @@ std::thread FWTEveViewer::CaptureAndSaveImage(const TString& file, int height)
    if (fbo == 0)
    {
       ::Error(eh, "Returned FBO is 0.");
-      return std::thread();
+      m_prom = std::promise<int>();
+      m_prom.set_value(-1);
+      return m_prom.get_future();
    }
 
    int ww, hh;
@@ -114,27 +160,27 @@ std::thread FWTEveViewer::CaptureAndSaveImage(const TString& file, int height)
 
    fbo->SetAsReadBuffer();
 
-   UChar_t* xx = new UChar_t[3 * ww * hh];
-   glPixelStorei(GL_PACK_ALIGNMENT, 1);
-   glReadPixels(0, 0, ww, hh, GL_RGB, GL_UNSIGNED_BYTE, xx);
-
-   delete fbo;
-
-   std::thread thr([=]()
+   size_t bufsize = 3 * ww * hh;
+   if (bufsize != m_imgBuffer.size())
    {
-      if (file.EndsWith(".jpg"))
-      {
-         SaveJpg(file, xx, ww, hh);
-      }
-      else
-      {
-         SavePng(file, xx, ww, hh);
-      }
+      m_imgBuffer.resize(bufsize);
+   }
 
-      delete [] xx;
-   });
+   glPixelStorei(GL_PACK_ALIGNMENT, 1);
+   glReadPixels(0, 0, ww, hh, GL_RGB, GL_UNSIGNED_BYTE, &m_imgBuffer[0]);
 
-   return thr;
+   {
+      std::unique_lock<std::mutex> lk(m_moo);
+
+      m_prom = std::promise<int>();
+      m_name = file;
+      m_ww   = ww;
+      m_hh   = hh;
+
+      m_cnd.notify_one();
+   }
+
+   return m_prom.get_future();
 }
 
 //


### PR DESCRIPTION
Reuse as many resources as possible for online image capture:
- keep one image saving thread per eve view;
- reuse FBO objects (as long as they keep the same size);
- reuse intermediate buffers for image creation.
  All this shaves off about 10% of execution time when saving 5 extremely large images.
