### PR TITLE
complete consumes interface for /HLTRechitInRegionsProducer

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/interface/HLTRechitInRegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTRechitInRegionsProducer.h
@@ -10,6 +10,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 // Reco candidates
 #include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
@@ -49,11 +50,11 @@ class HLTRechitInRegionsProducer : public edm::stream::EDProducer<> {
   void getEtaPhiRegions(std::vector<EcalEtaPhiRegion> *, T1Collection, const L1CaloGeometry&, bool);
     
   const bool useUncalib_;
-  const edm::InputTag l1TagIsolated_;
-  const edm::InputTag l1TagNonIsolated_;
 
   const bool doIsolated_;
 
+  const edm::EDGetTokenT<T1Collection> l1TokenIsolated_;
+  const edm::EDGetTokenT<T1Collection> l1TokenNonIsolated_;
   const double l1LowerThr_;
   const double l1UpperThr_;
   const double l1LowerThrIgnoreIsolation_;

--- a/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
@@ -44,9 +44,9 @@
 template<typename T1>
 HLTRechitInRegionsProducer<T1>::HLTRechitInRegionsProducer(const edm::ParameterSet& ps):
   useUncalib_      (ps.getParameter<bool>("useUncalib")),
-  l1TagIsolated_   (ps.getParameter< edm::InputTag > ("l1TagIsolated")),
-  l1TagNonIsolated_(ps.getParameter< edm::InputTag > ("l1TagNonIsolated")),
   doIsolated_      (ps.getParameter<bool>("doIsolated")),
+  l1TokenIsolated_ (doIsolated_ ? consumes<T1Collection>(ps.getParameter<edm::InputTag>("l1TagIsolated")) : edm::EDGetTokenT<T1Collection>()),
+  l1TokenNonIsolated_(consumes<T1Collection>(ps.getParameter<edm::InputTag>("l1TagNonIsolated"))),
   l1LowerThr_      (ps.getParameter<double> ("l1LowerThr")),
   l1UpperThr_      (ps.getParameter<double> ("l1UpperThr")),
   l1LowerThrIgnoreIsolation_(ps.getParameter<double> ("l1LowerThrIgnoreIsolation")),
@@ -108,12 +108,13 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
     
   //Get the L1 EM Particle Collection
   edm::Handle< T1Collection > emIsolColl ;
-  if(doIsolated_) 
-    evt.getByLabel(l1TagIsolated_, emIsolColl);
+  if(doIsolated_) {
+    evt.getByToken(l1TokenIsolated_, emIsolColl);
+  }
 
   //Get the L1 EM Particle Collection
   edm::Handle< T1Collection > emNonIsolColl ;
-  evt.getByLabel(l1TagNonIsolated_, emNonIsolColl);
+  evt.getByToken(l1TokenNonIsolated_, emNonIsolColl);
   
   // Get the CaloGeometry
   edm::ESHandle<L1CaloGeometry> l1CaloGeom ;


### PR DESCRIPTION
The consumes interface was previously implemented for HLTRechitInRegionsProducer, but two consumed products were omitted from the implementation.  This pull request implements the consumes interface for those two products.
