### PR TITLE
Plugin that tags merged clusters per MC truth

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
+++ b/RecoLocalTracker/SiStripClusterizer/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="CalibFormats/SiStripObjects"/>
 <use   name="CalibTracker/Records"/>
 <use   name="EventFilter/SiStripRawToDigi"/>
+<use   name="SimTracker/TrackerHitAssociation"/>
 <export>
   <lib name="1"/>
 </export>

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SealModules.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SealModules.cc
@@ -2,3 +2,5 @@
 
 #include "RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h"
 DEFINE_FWK_MODULE(SiStripClusterizer);
+#include "RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizerTagMCmerged.h"
+DEFINE_FWK_MODULE(SiStripClusterizerTagMCmerged);

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.cc
@@ -23,9 +23,13 @@ produce(edm::Event& event, const edm::EventSetup& es)  {
 //   edm::Handle< edmNew::DetSetVector<SiStripDigi> >  inputNew;  
 
   algorithm->initialize(es);  
+  refiner_iniEvent(event, es);
 
   BOOST_FOREACH( const edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> >& token, inputTokens) {
-    if(      findInput( token, inputOld, event) ) algorithm->clusterize(*inputOld, *output); 
+    if(      findInput( token, inputOld, event) ) {
+      algorithm->clusterize(*inputOld, *output);
+      refineCluster(inputOld, output);
+    } 
 //     else if( findInput( tag, inputNew, event) ) algorithm->clusterize(*inputNew, *output);
     else edm::LogError("Input Not Found") << "[SiStripClusterizer::produce] ";// << tag;
   }

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h
@@ -22,6 +22,13 @@ private:
   template<class T> bool findInput(const edm::EDGetTokenT<T>&, edm::Handle<T>&, const edm::Event&);
   const std::vector<edm::InputTag> inputTags;
   std::auto_ptr<StripClusterizerAlgorithm> algorithm;
+
+  //  Functions to be overridden for studies.  May alter or replace a cluster
+  //  before it is inserted into the event.
+  virtual void refiner_iniEvent(edm::Event&, const edm::EventSetup&) {};
+  virtual void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
+			     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output) {};
+
   typedef edm::EDGetTokenT< edm::DetSetVector<SiStripDigi> > token_t;
   typedef std::vector<token_t> token_v;
   token_v inputTokens;

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizerTagMCmerged.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizerTagMCmerged.cc
@@ -1,0 +1,64 @@
+#include "RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizerTagMCmerged.h"
+#include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
+
+SiStripClusterizerTagMCmerged::
+SiStripClusterizerTagMCmerged(const edm::ParameterSet& conf) 
+  : SiStripClusterizer(conf),
+    confClusterizer_(conf.getParameter<edm::ParameterSet>("Clusterizer")) {
+}
+
+void SiStripClusterizerTagMCmerged::
+refiner_iniEvent(edm::Event& event, const edm::EventSetup& evtSetup) {
+  associator_.reset(new TrackerHitAssociator(event, confClusterizer_));
+}
+
+void SiStripClusterizerTagMCmerged::
+refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
+	      std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output) {
+
+  // Flag MC-truth merged clusters
+
+  for (edmNew::DetSetVector<SiStripCluster>::const_iterator det=output->begin(); det!=output->end(); det++) {
+    uint32_t detId = det->id();
+    int ntk = 0;
+    int NtkAll = 0;
+    for (edmNew::DetSet<SiStripCluster>::iterator clust = det->begin(); clust != det->end(); clust++) {
+	// float dEdx = siStripClusterTools::chargePerCM(ssdid, *clust, locDir);
+      if (associator_ != 0) {
+        std::vector<SimHitIdpr> simtrackid;
+	  bool useAssociateHit = !confClusterizer_.getParameter<bool>("associateRecoTracks");
+	  if (useAssociateHit) {
+	    std::vector<PSimHit> simhit;
+	    associator_->associateCluster(clust, DetId(detId), simtrackid, simhit);
+	    NtkAll = simtrackid.size();
+	    ntk = 0;
+	    if (simtrackid.size() > 1) {
+	      for (auto const& it : simtrackid) {
+		int NintimeHit = 0;
+		for (auto const& ih : simhit) {
+		  // std::cout << "  hit(tk, evt) trk(tk, evt) bunch ("
+		  // 	  << ih.trackId() << ", " << ih.eventId().rawId() << ") ("
+		  // 	  << it.first << ", " << it.second.rawId() << ") "
+		  // 	  << ih.eventId().bunchCrossing()
+		  // 	  << std::endl;
+		  if (ih.trackId() == it.first && ih.eventId() == it.second && ih.eventId().bunchCrossing() == 0) ++NintimeHit;
+		}
+		if (NintimeHit > 0) ++ntk;
+	      }
+	    }
+	  } else {
+	    associator_->associateSimpleRecHitCluster(clust, DetId(detId), simtrackid);
+	    ntk = NtkAll = simtrackid.size();
+	  }
+	  if (ntk > 1) {
+	    clust->setMerged(true);
+	  } else {
+	    clust->setMerged(false);
+	  }
+      }
+      // std::cout << "t_m_w " << " " << NtkAll << " " << clust->isMerged()
+      // 		<< " " << clust->amplitudes().size()
+      // 		<< std::endl;
+    } // traverse clusters
+  }  // traverse sensors
+}

--- a/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizerTagMCmerged.h
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizerTagMCmerged.h
@@ -1,0 +1,31 @@
+#ifndef RecoLocalTracker_SiStripClusterizerTagMCmerged_h
+#define RecoLocalTracker_SiStripClusterizerTagMCmerged_h
+
+#include "RecoLocalTracker/SiStripClusterizer/plugins/SiStripClusterizer.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+
+//
+// Use MC truth to identify merged clusters, i.e., those associated with more than one
+// (in-time) SimTrack.
+//
+// Author:  Bill Ford (wtford)  3 March 2015
+//
+
+class SiStripClusterizerTagMCmerged : public SiStripClusterizer {
+
+public:
+
+  explicit SiStripClusterizerTagMCmerged(const edm::ParameterSet& conf);
+
+private:
+
+  edm::ParameterSet confClusterizer_;
+  virtual void refiner_iniEvent(edm::Event&, const edm::EventSetup&);
+  virtual void refineCluster(const edm::Handle< edm::DetSetVector<SiStripDigi> >& input,
+			     std::auto_ptr< edmNew::DetSetVector<SiStripCluster> >& output);
+
+  std::shared_ptr<TrackerHitAssociator> associator_;
+
+};
+
+#endif

--- a/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_tagMCmerged_cfi.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/SiStripClusterizer_tagMCmerged_cfi.py
@@ -1,0 +1,24 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoLocalTracker.SiStripClusterizer.DefaultClusterizer_cff import *
+
+siStripClusters = cms.EDProducer("SiStripClusterizerTagMCmerged",
+                               Clusterizer = DefaultClusterizer,
+                               DigiProducersList = cms.VInputTag(
+    cms.InputTag('siStripDigis','ZeroSuppressed'),
+    cms.InputTag('siStripZeroSuppression','VirginRaw'),
+    cms.InputTag('siStripZeroSuppression','ProcessedRaw'),
+    cms.InputTag('siStripZeroSuppression','ScopeMode')),
+                               )
+#  For TrackerHitAssociator
+siStripClusters.Clusterizer.ROUList = cms.vstring('g4SimHitsTrackerHitsTIBLowTof',
+                      'g4SimHitsTrackerHitsTIBHighTof',
+                      'g4SimHitsTrackerHitsTIDLowTof',
+                      'g4SimHitsTrackerHitsTIDHighTof',
+                      'g4SimHitsTrackerHitsTOBLowTof',
+                      'g4SimHitsTrackerHitsTOBHighTof',
+                      'g4SimHitsTrackerHitsTECLowTof',
+                      'g4SimHitsTrackerHitsTECHighTof')
+siStripClusters.Clusterizer.associateRecoTracks = cms.bool(True)  # True to save some time if no PU
+siStripClusters.Clusterizer.associatePixel = cms.bool(False)
+siStripClusters.Clusterizer.associateStrip = cms.bool(True)

--- a/RecoLocalTracker/SiStripClusterizer/python/tagMCmergedCustomize_cff.py
+++ b/RecoLocalTracker/SiStripClusterizer/python/tagMCmergedCustomize_cff.py
@@ -1,0 +1,24 @@
+#
+# With this customization the SiStripClusterizerTagMCmerged module will be substituted
+# for the standard clusterizer.  If a cluster is matched to more than one simTrack
+# its "merged" bit will be set, so that SiStripCluster::isMerged() will return true.
+#
+# If pileup is present, add the following line so that only in-time simTracks will
+# be counted, and make sure that process.mix is on the path. 
+# process.siStripClusters.Clusterizer.associateRecoTracks = cms.bool(False)
+#
+
+import FWCore.ParameterSet.Config as cms
+
+def tagMCmerged(process):
+
+  stripClusIndex = process.striptrackerlocalreco.index(process.siStripClusters)                                                                   
+  process.striptrackerlocalreco.remove(process.siStripClusters)
+  del process.siStripClusters
+  process.load('RecoLocalTracker.SiStripClusterizer.SiStripClusterizer_tagMCmerged_cfi')
+  process.striptrackerlocalreco.insert(stripClusIndex,process.siStripClusters)
+
+# Override the chargePerCM cut in stripCPE and use cluster::isMerged() instead.
+  process.StripCPEfromTrackAngleESProducer.parameters.maxChgOneMIP = cms.double(-6000.)                                                                   
+
+  return(process)


### PR DESCRIPTION
Modify SiStripClusterizer to include two null members that can be overridden in a derived class.  The derived class can alter the clusters before they are inserted into the event.  Implement here one such class for MC studies.  It sets the cluster's isMerged() state according to whether it is associated with more than one (in-time) SimTrack.
Production is unaffected.  The new plugin can be added to the workflow via the customization config provided here.
