### PR TITLE
Improved genTau decay mode finding for tau trigger DQM

### DIFF
--- a/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
+++ b/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
@@ -37,7 +37,7 @@ public:
   
  private:
 
-  bool getGenDecayProducts(const reco::GenParticleRef&, reco::GenParticleRefVector&,
+  void getGenDecayProducts(const reco::GenParticleRef&, reco::GenParticleRefVector&,
 			   int status=1, int pdgId=0);
 
   enum tauDecayModes {kElectron, kMuon, 
@@ -51,6 +51,8 @@ public:
   double ptMinMCMuon_;
   std::vector<int> m_PDG_;
   double etaMax;
+
+  unsigned int nBos_, nTau_, nTauH_, nTauE_, nTauM_, nTauO_; //MB
 
 };
 

--- a/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
+++ b/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
@@ -52,8 +52,6 @@ public:
   std::vector<int> m_PDG_;
   double etaMax;
 
-  unsigned int nBos_, nTau_, nTauH_, nTauE_, nTauM_, nTauO_; //MB
-
 };
 
 #endif

--- a/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
+++ b/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
@@ -37,7 +37,8 @@ public:
   
  private:
 
-  std::vector<reco::GenParticle*> getGenStableDecayProducts(const reco::GenParticle * particle);
+  bool getGenDecayProducts(const reco::GenParticleRef&, reco::GenParticleRefVector&,
+			   int status=1, int pdgId=0);
 
   enum tauDecayModes {kElectron, kMuon, 
 		      kOneProng0pi0, kOneProng1pi0, kOneProng2pi0,

--- a/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
+++ b/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
@@ -28,7 +28,7 @@ HLTTauMCProducer::HLTTauMCProducer(const edm::ParameterSet& mc)
 
 }
 
-HLTTauMCProducer::~HLTTauMCProducer(){ }
+HLTTauMCProducer::~HLTTauMCProducer(){}
 
 void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 {
@@ -47,179 +47,195 @@ void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
   edm::Handle<GenParticleCollection> genParticles;
   iEvent.getByToken(MC_, genParticles);
 
-  GenParticleCollection::const_iterator p = genParticles->begin();
-  
-  for (;p != genParticles->end(); ++p ) {
+  // Look for primary bosons
+  // It is not guaranteed that primary bosons are stored in event history.
+  // Is it really needed when check if taus from the boson is removed? 
+  // Kept for backward compatibility
+  for(GenParticleCollection::const_iterator p = genParticles->begin(); p != genParticles->end(); ++p) {
     //Check the PDG ID
-    bool pdg_ok = true;
+    bool pdg_ok = false;
     for(size_t pi =0;pi<m_PDG_.size();++pi)
       {
-	if(abs((*p).pdgId())== m_PDG_[pi] && abs((*p).status()) == 3 ){
+	//MB if(abs((*p).pdgId())== m_PDG_[pi] && abs((*p).status()) == 3 ){
+	if(abs((*p).pdgId())== m_PDG_[pi] && ( (*p).isHardProcess() || (*p).status() == 3 ) ){
    	  pdg_ok = true;
-	  //	  cout<<" Bsoson particles: "<< (*p).pdgId()<< " " <<(*p).status() << " "<< pdg_ok<<endl;
+	  //cout<<" Bsoson particles: "<< (*p).pdgId()<< " " <<(*p).status() << " "<< pdg_ok<<endl;
+	  break;
    	}
       }
     
     // Check if the boson is one of interest and if there is a valid vertex
-    if(  pdg_ok )
+    if( pdg_ok )
       {
 	product_Mothers->push_back((*p).pdgId());
 
-	std::vector<GenParticle*> decayProducts;
-	
 	TLorentzVector Boson((*p).px(),(*p).py(),(*p).pz(),(*p).energy());	
-	
-	for (GenParticle::const_iterator BosonIt=(*p).begin(); BosonIt != (*p).end(); BosonIt++){
-	  // cout<<" Dparticles: "<< (*BosonIt).pdgId() << " "<< (*BosonIt).status()<<endl;
-	  
-	  if (abs((*BosonIt).pdgId()) == 15 && ((*BosonIt).status()==3)) //if it is a Tau and decayed
-	    {
-	      decayProducts.clear();	  
-	      //	      cout<<" Boson daugther particles: "<< (*BosonIt).pdgId() << " "<< (*BosonIt).status()<< endl;	      
-	      for (GenParticle::const_iterator TauIt = (*BosonIt).begin(); TauIt != (*BosonIt).end(); TauIt++) {
-		//	cout<<" Tau daughter particles: "<< (*TauIt).pdgId() << " "<< (*TauIt).status()<<endl;
-
-		if (abs((*TauIt).pdgId()) == 15 && ((*TauIt).status()==2)) //if it is a Tau and decayed
-		  {		    
-		    decayProducts = getGenStableDecayProducts((reco::GenParticle*) & (*TauIt));	 
-		    //  for (GenParticle::const_iterator TauIt2 = (*TauIt).begin(); TauIt2 != (*TauIt).end(); TauIt2++) {
-		    //		      cout<<" Real Tau particles: "<< (*TauIt2).pdgId() << " "<< (*TauIt2).status()<< " mother: "<< (*TauIt2).mother()->pdgId() << endl;
-		    // }
-		  }
-	      }
-	      
-	      
-	      if ( !decayProducts.empty() )
-		{
-		  
-		  LorentzVector Visible_Taus(0.,0.,0.,0.);
-		  LorentzVector TauDecayProduct(0.,0.,0.,0.);
-		  LorentzVector Neutrino(0.,0.,0.,0.);
-		  
-		  int numElectrons      = 0;
-		  int numMuons          = 0;
-		  int numChargedPions   = 0;
-		  int numNeutralPions   = 0;
-		  int numNeutrinos      = 0;
-		  int numOtherParticles = 0;
-		  
-		  
-		  for (std::vector<GenParticle*>::iterator pit = decayProducts.begin(); pit != decayProducts.end(); pit++)
-		    {
-		      int pdg_id = abs((*pit)->pdgId());
-		      if (pdg_id == 11) numElectrons++;
-		      else if (pdg_id == 13) numMuons++;
-		      else if (pdg_id == 211) numChargedPions++;
-		      else if (pdg_id == 111) numNeutralPions++;
-		      else if (pdg_id == 12 || 
-			       pdg_id == 14 || 
-			       pdg_id == 16) {
-			numNeutrinos++;
-			if (pdg_id == 16) {
-			  Neutrino.SetPxPyPzE((*pit)->px(),(*pit)->py(),(*pit)->pz(),(*pit)->energy());
-			}
-		      }
-		      else if (pdg_id != 22) {
-			numOtherParticles++;
-		      }
-		      
-		      if (pdg_id != 12 &&
-			  pdg_id != 14 && 
-			  pdg_id != 16){
-			TauDecayProduct.SetPxPyPzE((*pit)->px(),(*pit)->py(),(*pit)->pz(),(*pit)->energy());
-			Visible_Taus+=TauDecayProduct;
-		      }	
-		      //		  cout<< "This has to be the same: " << (*pit)->pdgId() << " "<< (*pit)->status()<< " mother: "<< (*pit)->mother()->pdgId() << endl;
-		    }
-		  
-		  int tauDecayMode = kOther;
-		  
-		  if ( numOtherParticles == 0 ){
-		    if ( numElectrons == 1 ){
-		      //--- tau decays into electrons
-		      tauDecayMode = kElectron;
-		    } else if ( numMuons == 1 ){
-		      //--- tau decays into muons
-		      tauDecayMode = kMuon;
-		    } else {
-		      //--- hadronic tau decays
-		      switch ( numChargedPions ){
-		      case 1 : 
-			switch ( numNeutralPions ){
-			case 0 : 
-			  tauDecayMode = kOneProng0pi0;
-			  break;
-			case 1 : 
-			  tauDecayMode = kOneProng1pi0;
-			  break;
-			case 2 : 
-			  tauDecayMode = kOneProng2pi0;
-			  break;
-			}
-			break;
-		      case 3 : 
-			switch ( numNeutralPions ){
-			case 0 : 
-			  tauDecayMode = kThreeProng0pi0;
-			  break;
-			case 1 : 
-			  tauDecayMode = kThreeProng1pi0;
-			  break;
-			}
-			break;
-		      }		    
-		    }
-		  }
-		  
-		  
-		  //		  cout<< "So we have a: " << tauDecayMode <<endl;
-		  
-		  if(tauDecayMode == kElectron)
-		    {		          
-		      if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCElectron_)){
-			product_Electrons->push_back(Visible_Taus);
-			product_Leptons->push_back(Visible_Taus);
-		      }
-		    }
-		  else if (tauDecayMode == kMuon)
-		    {
-		      
-		      if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCMuon_)){
-			product_Muons->push_back(Visible_Taus);
-			product_Leptons->push_back(Visible_Taus);
-		      }
-		    }
-		  else if(tauDecayMode == kOneProng0pi0 || 
-			  tauDecayMode == kOneProng1pi0 || 
-			  tauDecayMode == kOneProng2pi0 ) 
-		    {
-		      if ((abs(Visible_Taus.eta()) < etaMax) && (Visible_Taus.pt() > ptMinMCTau_)){
-			product_OneProng->push_back(Visible_Taus);
-			product_OneAndThreeProng->push_back(Visible_Taus);
-			product_Neutrina->push_back(Neutrino);
-		      }
-		    }
-		  else if (tauDecayMode == kThreeProng0pi0 || 
-			   tauDecayMode == kThreeProng1pi0 )
-		    {
-		      if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCTau_))  {
-			product_ThreeProng->push_back(Visible_Taus);
-			product_OneAndThreeProng->push_back(Visible_Taus);
-			product_Neutrina->push_back(Neutrino);
-		      }								
-		    }
-		  else if (tauDecayMode == kOther)
-		    {
-		      if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCTau_))  {
-			product_Other->push_back(Visible_Taus);
-		      }
-		    }	    				       
-		}
-	    }
-	}			       
-	//  
       }
+  }// End of search for the bosons
+
+  // Look for taus
+  GenParticleRefVector allTaus;
+  unsigned index = 0;
+  for(GenParticleCollection::const_iterator p = genParticles->begin(); p != genParticles->end(); ++p, ++index) {
+    
+    const GenParticle& genP = *p;
+    //accept only isPromptDecayed() particles
+    if( !genP.isPromptDecayed() ) continue;
+    //check if it is tau, i.e. if |pdgId|=15
+    if( std::abs( genP.pdgId() ) == 15 ) {
+      GenParticleRef genRef(genParticles, index);
+      //check if it is the last tau in decay/radiation chain
+      GenParticleRefVector daugTaus;
+      if( !getGenDecayProducts(genRef, daugTaus, 0, 15) )
+	allTaus.push_back(genRef);
+    }
+  } 
+
+  // Find stable tau decay products and build visible taus
+  for(GenParticleRefVector::const_iterator t = allTaus.begin(); t != allTaus.end(); ++t) {
+    //look for all stable (status=1) decay products
+    GenParticleRefVector decayProducts;
+    getGenDecayProducts(*t,decayProducts,1);
+
+    //build visible taus and recognize decay mode
+    if( !decayProducts.empty() ) {
+      
+      LorentzVector Visible_Taus(0.,0.,0.,0.);
+      LorentzVector TauDecayProduct(0.,0.,0.,0.);
+      LorentzVector Neutrino(0.,0.,0.,0.);
+      
+      int numElectrons      = 0;
+      int numMuons          = 0;
+      int numChargedPions   = 0;
+      int numNeutralPions   = 0;
+      int numPhotons        = 0;
+      int numNeutrinos      = 0;
+      int numOtherParticles = 0;
+      
+      for(GenParticleRefVector::const_iterator pit = decayProducts.begin(); pit != decayProducts.end(); ++pit) {
+	int pdg_id = abs((*pit)->pdgId());
+	if (pdg_id == 11) numElectrons++;
+	else if (pdg_id == 13) numMuons++;
+	else if (pdg_id == 211 || pdg_id == 321 ) numChargedPions++; //Count both pi+ and K+
+	else if (pdg_id == 111 || pdg_id == 130 || pdg_id == 310) numNeutralPions++; //Count both pi0 and K0_L/S
+	else if (pdg_id == 12 || 
+		 pdg_id == 14 || 
+		 pdg_id == 16) {
+	  numNeutrinos++;
+	  if (pdg_id == 16) {
+	    Neutrino.SetPxPyPzE((*pit)->px(),(*pit)->py(),(*pit)->pz(),(*pit)->energy());
+	  }
+	}
+	else if (pdg_id == 22) numPhotons++;
+	else {
+	  numOtherParticles++;
+	}
+	
+	if (pdg_id != 12 &&
+	    pdg_id != 14 && 
+	    pdg_id != 16){
+	  TauDecayProduct.SetPxPyPzE((*pit)->px(),(*pit)->py(),(*pit)->pz(),(*pit)->energy());
+	  Visible_Taus+=TauDecayProduct;
+	}
+	//		  cout<< "This has to be the same: " << (*pit)->pdgId() << " "<< (*pit)->status()<< " mother: "<< (*pit)->mother()->pdgId() << endl;
+      }
+      
+      int tauDecayMode = kOther;
+      
+      if ( numOtherParticles == 0 ){
+	if ( numElectrons == 1 ){
+	  //--- tau decays into electrons
+	  tauDecayMode = kElectron;
+	} else if ( numMuons == 1 ){
+	  //--- tau decays into muons
+	  tauDecayMode = kMuon;
+	} else {
+	  //--- hadronic tau decays
+	  switch ( numChargedPions ){
+	  case 1 :
+	    if( numNeutralPions !=0 ){
+	      tauDecayMode = kOther;
+	      break;
+	    }
+	    switch ( numPhotons ){
+	    case 0:
+	      tauDecayMode = kOneProng0pi0;
+              break;
+	    case 2:
+	      tauDecayMode = kOneProng1pi0;
+              break;
+	    case 4:
+	      tauDecayMode = kOneProng2pi0;
+              break;
+	    default:
+	      tauDecayMode = kOther;
+	      break;
+	    }
+	    break;
+	  case 3 : 
+	    if( numNeutralPions !=0 ){
+	      tauDecayMode = kOther;
+	      break;
+	    }
+	    switch ( numPhotons ){
+	    case 0 : 
+	      tauDecayMode = kThreeProng0pi0;
+	      break;
+	    case 2 : 
+	      tauDecayMode = kThreeProng1pi0;
+	      break;
+	    default:
+	      tauDecayMode = kOther;
+	      break;
+	    }
+	    break;
+	  }
+	}
+      }
+      
+      //		  cout<< "So we have a: " << tauDecayMode <<endl;
+      if(tauDecayMode == kElectron)
+	{
+	  if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCElectron_)){
+	    product_Electrons->push_back(Visible_Taus);
+	    product_Leptons->push_back(Visible_Taus);
+	  }
+	}
+      else if (tauDecayMode == kMuon)
+	{
+	  if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCMuon_)){
+	    product_Muons->push_back(Visible_Taus);
+	    product_Leptons->push_back(Visible_Taus);
+	  }
+	}
+      else if(tauDecayMode == kOneProng0pi0 || 
+	      tauDecayMode == kOneProng1pi0 || 
+	      tauDecayMode == kOneProng2pi0 ) 
+	{
+	  if ((abs(Visible_Taus.eta()) < etaMax) && (Visible_Taus.pt() > ptMinMCTau_)){
+	    product_OneProng->push_back(Visible_Taus);
+	    product_OneAndThreeProng->push_back(Visible_Taus);
+	    product_Neutrina->push_back(Neutrino);
+	  }
+	}
+      else if (tauDecayMode == kThreeProng0pi0 || 
+	       tauDecayMode == kThreeProng1pi0 )
+	{
+	  if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCTau_))  {
+	    product_ThreeProng->push_back(Visible_Taus);
+	    product_OneAndThreeProng->push_back(Visible_Taus);
+	    product_Neutrina->push_back(Neutrino);
+	  }
+	}
+      else if (tauDecayMode == kOther)
+	{
+	  if((abs(Visible_Taus.eta())<etaMax)&&(Visible_Taus.pt()>ptMinMCTau_))  {
+	    product_Other->push_back(Visible_Taus);
+	  }
+	}
+    }
   }
+
   iEvent.put(product_Leptons,"LeptonicTauLeptons");
   iEvent.put(product_Electrons,"LeptonicTauElectrons");
   iEvent.put(product_Muons,"LeptonicTauMuons");
@@ -230,32 +246,27 @@ void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
   iEvent.put(product_Neutrina,"Neutrina"); 
   iEvent.put(product_Mothers,"Mothers"); 
   
-  						       
 }
+
 // Helper Function
 
-std::vector<reco::GenParticle*> HLTTauMCProducer::getGenStableDecayProducts(const reco::GenParticle* particle)
-{
-  std::vector<GenParticle*> decayProducts;
-  decayProducts.clear();
-
-  //  std::cout << " Are we ever here?: "<< (*particle).numberOfDaughters() << std::endl;
-  for ( GenParticle::const_iterator daughter_particle = (*particle).begin();daughter_particle != (*particle).end(); ++daughter_particle ){   
-
-    int pdg_id = abs((*daughter_particle).pdgId());
-
-//    // check if particle is stable
-    if ( pdg_id == 11 || pdg_id == 12 || pdg_id == 13 || pdg_id == 14 || pdg_id == 16 ||  pdg_id == 111 || pdg_id == 211 ){
-      // stable particle, identified by pdg code
-      decayProducts.push_back((reco::GenParticle*) &(* daughter_particle));
-    } 
-    else {
-//      // unstable particle, identified by non-zero decay vertex
-      std::vector<GenParticle*> addDecayProducts = getGenStableDecayProducts((reco::GenParticle*) &(*daughter_particle));
-      for ( std::vector<GenParticle*>::const_iterator adddaughter_particle = addDecayProducts.begin(); adddaughter_particle != addDecayProducts.end(); ++adddaughter_particle ){
-	decayProducts.push_back((*adddaughter_particle));
-      }
+bool HLTTauMCProducer::getGenDecayProducts(const GenParticleRef& mother, GenParticleRefVector& products,
+					   int status, int pdgId ) {
+  bool found = false;
+  
+  const GenParticleRefVector& daughterRefs = mother->daughterRefVector();
+  
+  for(GenParticleRefVector::const_iterator d = daughterRefs.begin(); d != daughterRefs.end(); ++d) {
+    
+    if( (status==0 || (*d)->status() == status) && 
+	(pdgId==0 || std::abs((*d)->pdgId()) == pdgId) ) {
+      
+      products.push_back(*d);
+      found = true;
     }
+    else 
+      found = getGenDecayProducts(*d, products, status, pdgId);
   }
-  return decayProducts;
-}
+  
+  return found;
+} 

--- a/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
+++ b/HLTriggerOffline/Tau/src/HLTTauMCProducer.cc
@@ -56,7 +56,6 @@ void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
     bool pdg_ok = false;
     for(size_t pi =0;pi<m_PDG_.size();++pi)
       {
-	//MB if(abs((*p).pdgId())== m_PDG_[pi] && abs((*p).status()) == 3 ){
 	if(abs((*p).pdgId())== m_PDG_[pi] && ( (*p).isHardProcess() || (*p).status() == 3 ) ){
    	  pdg_ok = true;
 	  //cout<<" Bsoson particles: "<< (*p).pdgId()<< " " <<(*p).status() << " "<< pdg_ok<<endl;
@@ -86,7 +85,8 @@ void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
       GenParticleRef genRef(genParticles, index);
       //check if it is the last tau in decay/radiation chain
       GenParticleRefVector daugTaus;
-      if( !getGenDecayProducts(genRef, daugTaus, 0, 15) )
+      getGenDecayProducts(genRef, daugTaus, 0, 15);      
+      if( daugTaus.size()==0 )
 	allTaus.push_back(genRef);
     }
   } 
@@ -250,10 +250,9 @@ void HLTTauMCProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
 
 // Helper Function
 
-bool HLTTauMCProducer::getGenDecayProducts(const GenParticleRef& mother, GenParticleRefVector& products,
+void HLTTauMCProducer::getGenDecayProducts(const GenParticleRef& mother, GenParticleRefVector& products,
 					   int status, int pdgId ) {
-  bool found = false;
-  
+
   const GenParticleRefVector& daughterRefs = mother->daughterRefVector();
   
   for(GenParticleRefVector::const_iterator d = daughterRefs.begin(); d != daughterRefs.end(); ++d) {
@@ -262,11 +261,9 @@ bool HLTTauMCProducer::getGenDecayProducts(const GenParticleRef& mother, GenPart
 	(pdgId==0 || std::abs((*d)->pdgId()) == pdgId) ) {
       
       products.push_back(*d);
-      found = true;
     }
     else 
-      found = getGenDecayProducts(*d, products, status, pdgId);
+      getGenDecayProducts(*d, products, status, pdgId);
   }
   
-  return found;
 } 


### PR DESCRIPTION
This request is to integrate an improved tau decay product finding for tau trigger DQM using new status flags introduced to genParticle dataformat. The imporved code works correctly with Pythia6 and Pythia8 samples, which was not the case with the old code.
