### PR TITLE
Drop a bunch of unneeded dependencies on rootrflx

### DIFF
--- a/Alignment/OfflineValidation/BuildFile.xml
+++ b/Alignment/OfflineValidation/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="TrackingTools/TrackFitters"/>
 <use   name="MagneticField/Engine"/>
-<use   name="rootrflx"/>
+
 <use   name="CLHEP"/>
 <use   name="rootmath"/>
 <export>

--- a/AnalysisDataFormats/EWK/BuildFile.xml
+++ b/AnalysisDataFormats/EWK/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="CommonTools/CandUtils"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="CommonTools/RecoAlgos"/>
-<use   name="rootrflx"/>
+
 <use   name="CLHEP"/>
 <export>
   <lib   name="1"/>

--- a/AnalysisDataFormats/Egamma/BuildFile.xml
+++ b/AnalysisDataFormats/Egamma/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Math"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/AnalysisDataFormats/SUSYBSMObjects/BuildFile.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="DataFormats/CSCRecHit"/>
 <use   name="DataFormats/DTRecHit"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/AnalysisDataFormats/TrackInfo/BuildFile.xml
+++ b/AnalysisDataFormats/TrackInfo/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="SimDataFormats/TrackingAnalysis"/>
 <use   name="TrackingTools/PatternTools"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CalibTracker/SiStripCommon/BuildFile.xml
+++ b/CalibTracker/SiStripCommon/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="CondFormats/DataRecord"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
-<use   name="rootrflx"/>
+
 <use   name="clhep"/>
 <export>
   <lib   name="1"/>

--- a/Calibration/HcalCalibAlgos/BuildFile.xml
+++ b/Calibration/HcalCalibAlgos/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="root"/>
 <use   name="rootgraphics"/>
 <use   name="rootminuit"/>
-<use   name="rootrflx"/>
+
 <use   name="hepmc"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>

--- a/CaloOnlineTools/HcalOnlineDb/BuildFile.xml
+++ b/CaloOnlineTools/HcalOnlineDb/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="boost"/>
 <use   name="oracle"/>
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="xerces-c"/>
 <use   name="zlib"/>
 <use   name="DataFormats/HcalDetId"/>

--- a/CaloOnlineTools/HcalOnlineDb/plugins/BuildFile.xml
+++ b/CaloOnlineTools/HcalOnlineDb/plugins/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="boost"/>
 <use   name="OnlineDB/Oracle"/>
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="xerces-c"/>
 <use   name="zlib"/>
 <use   name="DataFormats/HcalDetId"/>

--- a/CaloOnlineTools/HcalOnlineDb/test/BuildFile.xml
+++ b/CaloOnlineTools/HcalOnlineDb/test/BuildFile.xml
@@ -1,6 +1,6 @@
 <bin   file="xmlTools.cc" name="xmlToolsRun">
   <use   name="DataFormats/Common"/>
-  <use   name="rootrflx"/>
+
   <use   name="DataFormats/HcalDetId"/>
   <use   name="CondTools/Hcal"/>
   <use   name="CalibCalorimetry/HcalTPGAlgos"/>
@@ -10,7 +10,7 @@
 </bin>
 <bin   file="channelQualityTools.cc" name="channelQualityRun">
   <use   name="DataFormats/Common"/>
-  <use   name="rootrflx"/>
+
   <use   name="DataFormats/HcalDetId"/>
   <use   name="CondTools/Hcal"/>
   <use   name="CalibCalorimetry/HcalTPGAlgos"/>

--- a/CommonTools/PileupAlgos/BuildFile.xml
+++ b/CommonTools/PileupAlgos/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="rootcore"/>
 <use   name="fastjet"/>
 <export>

--- a/CommonTools/RecoUtils/BuildFile.xml
+++ b/CommonTools/RecoUtils/BuildFile.xml
@@ -14,7 +14,7 @@
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="RecoVertex/KinematicFit"/>
 <use   name="RecoVertex/KinematicFitPrimitives"/>
-<use   name="rootrflx"/>
+
 <use   name="TrackingTools/TransientTrack"/>
 <use   name="TrackingTools/IPTools"/>
 <use   name="TrackingTools/Records"/>

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <flags   GENREFLEX_ARGS="--"/>
-<use   name="rootrflx"/>
+
 <use   name="CondCore/CondDB"/>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>

--- a/CondCore/DBCommon/plugins/BuildFile.xml
+++ b/CondCore/DBCommon/plugins/BuildFile.xml
@@ -24,6 +24,6 @@
   <flags   EDM_PLUGIN="1"/>
 </library>
 <library   file="BlobStreamingService.cc TBufferBlobStreamingService.cc" name="CondCoreDBCommonTBufferBlobStreamingService">
-  <use   name="rootrflx"/>
+
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/CondCore/DBCommon/test/BuildFile.xml
+++ b/CondCore/DBCommon/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <flags   GENREFLEX_ARGS="--"/>
-<use   name="rootrflx"/>
+
 <use   name="CondCore/DBCommon"/>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>

--- a/CondCore/IOVService/test/BuildFile.xml
+++ b/CondCore/IOVService/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <flags   GENREFLEX_ARGS="--"/>
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="CondCore/DBCommon"/>
 <library   name="testPayloadDict" file="">

--- a/CondCore/ORA/test/BuildFile.xml
+++ b/CondCore/ORA/test/BuildFile.xml
@@ -1,5 +1,5 @@
 <flags   GENREFLEX_ARGS="--"/>
-<use   name="rootrflx"/>
+
 <use   name="CondCore/ORA"/>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>

--- a/CondFormats/Alignment/BuildFile.xml
+++ b/CondFormats/Alignment/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="DataFormats/Math"/>
 <use   name="boost"/>
 <use   name="clhep"/>
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <export>

--- a/CondFormats/BTauObjects/BuildFile.xml
+++ b/CondFormats/BTauObjects/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <export>
   <lib   name="1"/>

--- a/CondFormats/BeamSpotObjects/BuildFile.xml
+++ b/CondFormats/BeamSpotObjects/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <use   name="CLHEP"/>
 <export>
   <lib   name="1"/>

--- a/CondFormats/CSCObjects/BuildFile.xml
+++ b/CondFormats/CSCObjects/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="rootrflx"/>
+
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
 <export>

--- a/CondFormats/Calibration/BuildFile.xml
+++ b/CondFormats/Calibration/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/CastorObjects/BuildFile.xml
+++ b/CondFormats/CastorObjects/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
 <export>

--- a/CondFormats/Common/BuildFile.xml
+++ b/CondFormats/Common/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="boost_serialization"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <use   name="CondCore/ORA"/>
 <export>
   <lib   name="1"/>

--- a/CondFormats/DQMObjects/BuildFile.xml
+++ b/CondFormats/DQMObjects/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/DTObjects/BuildFile.xml
+++ b/CondFormats/DTObjects/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="CondCore/DBCommon"/>
 <use   name="boost_serialization"/>
 <use   name="roothistmatrix"/>
-<use   name="rootrflx"/>
+
 <use   name="root"/>
 <export>
   <lib   name="1"/>

--- a/CondFormats/ESObjects/BuildFile.xml
+++ b/CondFormats/ESObjects/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/EcalCorrections/BuildFile.xml
+++ b/CondFormats/EcalCorrections/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="CondFormats/Serialization"/>
 <use   name="DataFormats/EcalDetId"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <use   name="boost"/>
 <use   name="boost_serialization"/>
 <export>

--- a/CondFormats/EcalObjects/BuildFile.xml
+++ b/CondFormats/EcalObjects/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="boost"/>
 <use   name="boost_serialization"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <use   name="clhep"/>
 <export>
   <lib   name="1"/>

--- a/CondFormats/EgammaObjects/BuildFile.xml
+++ b/CondFormats/EgammaObjects/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="CondFormats/Serialization"/>
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <use   name="roottmva"/>
 <export>
   <lib   name="1"/>

--- a/CondFormats/GeometryObjects/BuildFile.xml
+++ b/CondFormats/GeometryObjects/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="DataFormats/DetId"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/HIObjects/BuildFile.xml
+++ b/CondFormats/HIObjects/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="CondFormats/Serialization"/>
 <use   name="FWCore/Framework"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/HLTObjects/BuildFile.xml
+++ b/CondFormats/HLTObjects/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/HcalObjects/BuildFile.xml
+++ b/CondFormats/HcalObjects/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/JetMETObjects/BuildFile.xml
+++ b/CondFormats/JetMETObjects/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="boost_serialization"/>
 <use   name="root"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <use   name="clhep"/>
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <export>

--- a/CondFormats/L1TObjects/BuildFile.xml
+++ b/CondFormats/L1TObjects/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
 <use   name="DataFormats/L1GlobalCaloTrigger"/>
 <use   name="DataFormats/L1GlobalTrigger"/>

--- a/CondFormats/Luminosity/BuildFile.xml
+++ b/CondFormats/Luminosity/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/MFObjects/BuildFile.xml
+++ b/CondFormats/MFObjects/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CondCore/DBCommon"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/OptAlignObjects/BuildFile.xml
+++ b/CondFormats/OptAlignObjects/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/RPCObjects/BuildFile.xml
+++ b/CondFormats/RPCObjects/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="boost"/>
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/RecoMuonObjects/BuildFile.xml
+++ b/CondFormats/RecoMuonObjects/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="CondFormats/Serialization"/>
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/RunInfo/BuildFile.xml
+++ b/CondFormats/RunInfo/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CoralBase"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/SiPixelObjects/BuildFile.xml
+++ b/CondFormats/SiPixelObjects/BuildFile.xml
@@ -12,7 +12,7 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="boost"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/SiStripObjects/BuildFile.xml
+++ b/CondFormats/SiStripObjects/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="boost_serialization"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondTools/DQM/BuildFile.xml
+++ b/CondTools/DQM/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="RelationalAccess"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondTools/DT/BuildFile.xml
+++ b/CondTools/DT/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="RelationalAccess"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondTools/RunInfo/BuildFile.xml
+++ b/CondTools/RunInfo/BuildFile.xml
@@ -10,7 +10,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="RelationalAccess"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/CondTools/Utilities/test/BuildFile.xml
+++ b/CondTools/Utilities/test/BuildFile.xml
@@ -9,6 +9,6 @@
 <use   name="boost"/>
 <use   name="boost_program_options"/>
 <use   name="CondCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <library   name="testCondToolsUtilities" file="">
 </library>

--- a/DPGAnalysis/SiStripTools/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/BuildFile.xml
@@ -1,6 +1,6 @@
 <flags   GENREFLEX_ARGS="--"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/ServiceRegistry"/>

--- a/DQM/Integration/BuildFile.xml
+++ b/DQM/Integration/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="RelationalAccess"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DQM/SiPixelCommon/BuildFile.xml
+++ b/DQM/SiPixelCommon/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="DQMServices/Core"/>
 <use   name="DataFormats/SiPixelDetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/Alignment/BuildFile.xml
+++ b/DataFormats/Alignment/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/BTauReco/BuildFile.xml
+++ b/DataFormats/BTauReco/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="boost"/>
 <use   name="clhep"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/BeamSpot/BuildFile.xml
+++ b/DataFormats/BeamSpot/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="rootcore"/>
-<use   name="rootrflx"/>
+
 <use   name="clhep"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/CLHEP/BuildFile.xml
+++ b/DataFormats/CLHEP/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="clhep"/>
-<use   name="rootrflx"/>
+
 <use   name="rootmath"/>
 <use   name="DataFormats/Math"/>
 <export>

--- a/DataFormats/CSCDigi/BuildFile.xml
+++ b/DataFormats/CSCDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/CSCRecHit/BuildFile.xml
+++ b/DataFormats/CSCRecHit/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/TrackingRecHit"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/CaloRecHit/BuildFile.xml
+++ b/DataFormats/CaloRecHit/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/DetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/CaloTowers/BuildFile.xml
+++ b/DataFormats/CaloTowers/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="DataFormats/Math"/>
 <use   name="FWCore/Utilities"/>
 <use   name="DataFormats/Candidate"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/CastorReco/BuildFile.xml
+++ b/DataFormats/CastorReco/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Candidate"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/DTDigi/BuildFile.xml
+++ b/DataFormats/DTDigi/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/FEDRawData"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/DTRecHit/BuildFile.xml
+++ b/DataFormats/DTRecHit/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/EcalDetId/BuildFile.xml
+++ b/DataFormats/EcalDetId/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/EcalDigi/BuildFile.xml
+++ b/DataFormats/EcalDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/EcalDetId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/EcalRawData/BuildFile.xml
+++ b/DataFormats/EcalRawData/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/EcalRecHit/BuildFile.xml
+++ b/DataFormats/EcalRecHit/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/CaloRecHit"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/EcalDetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/EgammaCandidates/BuildFile.xml
+++ b/DataFormats/EgammaCandidates/BuildFile.xml
@@ -12,7 +12,7 @@
 <use   name="DataFormats/GeometryCommonDetAlgo"/>
 # <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/EgammaReco/BuildFile.xml
+++ b/DataFormats/EgammaReco/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="clhepheader"/>
 <use   name="DataFormats/CaloRecHit"/>
 <use   name="DataFormats/TrackingRecHit"/>

--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/FEDRawData/BuildFile.xml
+++ b/DataFormats/FEDRawData/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/Utilities"/>
 <use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/FP420Cluster/BuildFile.xml
+++ b/DataFormats/FP420Cluster/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/FP420Digi/BuildFile.xml
+++ b/DataFormats/FP420Digi/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/GEMDigi/BuildFile.xml
+++ b/DataFormats/GEMDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/GEMRecHit/BuildFile.xml
+++ b/DataFormats/GEMRecHit/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/TrackingRecHit"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/GeometryCommonDetAlgo/BuildFile.xml
+++ b/DataFormats/GeometryCommonDetAlgo/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="DataFormats/GeometryVector"/>
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/GeometrySurface/BuildFile.xml
+++ b/DataFormats/GeometrySurface/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/GeometryVector"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/GeometryVector/BuildFile.xml
+++ b/DataFormats/GeometryVector/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/Math"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/GsfTrackReco/BuildFile.xml
+++ b/DataFormats/GsfTrackReco/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/HLTReco/BuildFile.xml
+++ b/DataFormats/HLTReco/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="DataFormats/CLHEP"/>
 <use   name="DataFormats/Candidate"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/HcalCalibObjects/BuildFile.xml
+++ b/DataFormats/HcalCalibObjects/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/HcalDetId/BuildFile.xml
+++ b/DataFormats/HcalDetId/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/HcalDigi/BuildFile.xml
+++ b/DataFormats/HcalDigi/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/HcalIsolatedTrack/BuildFile.xml
+++ b/DataFormats/HcalIsolatedTrack/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="DataFormats/RecoCandidate"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/HcalRecHit/BuildFile.xml
+++ b/DataFormats/HcalRecHit/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/CaloRecHit"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/HcalDetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/HeavyIonEvent/BuildFile.xml
+++ b/DataFormats/HeavyIonEvent/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/Common"/>
 <use   name="CondFormats/HIObjects"/>
 <use   name="CondFormats/DataRecord"/>

--- a/DataFormats/Histograms/BuildFile.xml
+++ b/DataFormats/Histograms/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <use   name="roothistmatrix"/>
 <use   name="DataFormats/Common"/>
 <export>

--- a/DataFormats/JetReco/BuildFile.xml
+++ b/DataFormats/JetReco/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="DataFormats/ParticleFlowReco"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <flags LCG_DICT_HEADER="classes_1.h classes_2.h classes_3.h classes_4.h"/>
 <flags LCG_DICT_XML="classes_def_1.xml classes_def_2.xml classes_def_3.xml classes_def_4.xml"/>
 <export>

--- a/DataFormats/L1CSCTrackFinder/BuildFile.xml
+++ b/DataFormats/L1CSCTrackFinder/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
 <use   name="DataFormats/MuonDetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1CaloTrigger/BuildFile.xml
+++ b/DataFormats/L1CaloTrigger/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/DetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1DTTrackFinder/BuildFile.xml
+++ b/DataFormats/L1DTTrackFinder/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1GlobalCaloTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalCaloTrigger/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1CaloTrigger"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <use   name="tbb"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/L1GlobalTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalTrigger/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1TCalorimeter/BuildFile.xml
+++ b/DataFormats/L1TCalorimeter/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1Trigger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1TGlobal/BuildFile.xml
+++ b/DataFormats/L1TGlobal/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1Trigger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1Trigger/BuildFile.xml
+++ b/DataFormats/L1Trigger/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/LTCDigi/BuildFile.xml
+++ b/DataFormats/LTCDigi/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/Luminosity/BuildFile.xml
+++ b/DataFormats/Luminosity/BuildFile.xml
@@ -1,4 +1,4 @@
-<use name="rootrflx"/>
+
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/PatCandidates"/>

--- a/DataFormats/METReco/BuildFile.xml
+++ b/DataFormats/METReco/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/Math/BuildFile.xml
+++ b/DataFormats/Math/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="rootmath"/>
 <use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/MuonDetId/BuildFile.xml
+++ b/DataFormats/MuonDetId/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/DetId"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/MuonReco/BuildFile.xml
+++ b/DataFormats/MuonReco/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="DataFormats/DTRecHit"/>
 <use   name="DataFormats/CSCRecHit"/>
 <use   name="DataFormats/VertexReco"/>
-<use   name="rootrflx"/>
+
 <use   name="rootmath"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/MuonSeed/BuildFile.xml
+++ b/DataFormats/MuonSeed/BuildFile.xml
@@ -1,4 +1,4 @@
-<use   name="rootrflx"/>
+
 <use   name="clhepheader"/>
 <use   name="DataFormats/Common"/>
 <export>

--- a/DataFormats/ParticleFlowCandidate/BuildFile.xml
+++ b/DataFormats/ParticleFlowCandidate/BuildFile.xml
@@ -9,7 +9,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="rootcore"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/ParticleFlowReco/BuildFile.xml
+++ b/DataFormats/ParticleFlowReco/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <flags LCG_DICT_HEADER="classes_1.h classes_2.h"/>
 <flags LCG_DICT_XML="classes_def_1.xml classes_def_2.xml"/>
 <export>

--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -16,7 +16,7 @@
 <use   name="DataFormats/L1Trigger"/>
 <use   name="DataFormats/HLTReco"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <flags LCG_DICT_HEADER="classes_objects.h classes_trigger.h classes_user.h classes_other.h"/>
 <flags LCG_DICT_XML="classes_def_objects.xml classes_def_trigger.xml classes_def_user.xml classes_def_other.xml"/>
 <export>

--- a/DataFormats/Phase2TrackerDigi/BuildFile.xml
+++ b/DataFormats/Phase2TrackerDigi/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/RPCDigi/BuildFile.xml
+++ b/DataFormats/RPCDigi/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="CondFormats/RPCObjects"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/RPCRecHit/BuildFile.xml
+++ b/DataFormats/RPCRecHit/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="DataFormats/TrackingRecHit"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/RecoCandidate/BuildFile.xml
+++ b/DataFormats/RecoCandidate/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="clhep"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/Scalers/BuildFile.xml
+++ b/DataFormats/Scalers/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiPixelCluster/BuildFile.xml
+++ b/DataFormats/SiPixelCluster/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiPixelDetId/BuildFile.xml
+++ b/DataFormats/SiPixelDetId/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/DetId"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiPixelDigi/BuildFile.xml
+++ b/DataFormats/SiPixelDigi/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/SiPixelDetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiPixelRawData/BuildFile.xml
+++ b/DataFormats/SiPixelRawData/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiStripCluster/BuildFile.xml
+++ b/DataFormats/SiStripCluster/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiStripCommon/BuildFile.xml
+++ b/DataFormats/SiStripCommon/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiStripDetId/BuildFile.xml
+++ b/DataFormats/SiStripDetId/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/DetId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/SiStripDigi/BuildFile.xml
+++ b/DataFormats/SiStripDigi/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/StdDictionaries/BuildFile.xml
+++ b/DataFormats/StdDictionaries/BuildFile.xml
@@ -1,4 +1,5 @@
-<use   name="rootrflx"/>
+<use name="rootrflx"/>
+
 <flags LCG_DICT_HEADER="classes_map.h classes_others.h classes_pair.h classes_vector.h"/>
 <flags LCG_DICT_XML="classes_def_map.xml classes_def_others.xml classes_def_pair.xml classes_def_vector.xml"/>
 <export>

--- a/DataFormats/TauReco/BuildFile.xml
+++ b/DataFormats/TauReco/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="FWCore/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="rootcore"/>
 <flags LCG_DICT_HEADER="classes_hlt.h classes_1.h classes_2.h classes_3.h"/>
 <flags LCG_DICT_XML="classes_def_hlt.xml classes_def_1.xml classes_def_2.xml classes_def_3.xml"/>

--- a/DataFormats/TrackCandidate/BuildFile.xml
+++ b/DataFormats/TrackCandidate/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/TrackReco/BuildFile.xml
+++ b/DataFormats/TrackReco/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="FWCore/Utilities"/>
 <use   name="clhepheader"/>
-<use   name="rootrflx"/>
+
 <use   name="rootmath"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/TrackerRecHit2D/BuildFile.xml
+++ b/DataFormats/TrackerRecHit2D/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/TrackingRecHit/BuildFile.xml
+++ b/DataFormats/TrackingRecHit/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="clhep"/>
 <use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/TrackingSeed/BuildFile.xml
+++ b/DataFormats/TrackingSeed/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/TrajectorySeed/BuildFile.xml
+++ b/DataFormats/TrajectorySeed/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>

--- a/DataFormats/TrajectoryState/BuildFile.xml
+++ b/DataFormats/TrajectoryState/BuildFile.xml
@@ -1,5 +1,6 @@
-<use   name="rootrflx"/>
 <use   name="boost_header"/>
+<use   name="DataFormats/Math"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/V0Candidate/BuildFile.xml
+++ b/DataFormats/V0Candidate/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/VertexReco"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/VZero/BuildFile.xml
+++ b/DataFormats/VZero/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/VertexReco"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/VertexReco/BuildFile.xml
+++ b/DataFormats/VertexReco/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="FWCore/Utilities"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/ElectroWeakAnalysis/Utilities/BuildFile.xml
+++ b/ElectroWeakAnalysis/Utilities/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="DataFormats/PatCandidates"/>
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="CommonTools/CandUtils"/>
-<use   name="rootrflx"/>
+
 <use   name="RecoMuon/Records"/>
 <use   name="CondFormats/RecoMuonObjects"/>
 <use   name="MuonAnalysis/MomentumScaleCalibration"/>

--- a/EventFilter/ESDigiToRaw/BuildFile.xml
+++ b/EventFilter/ESDigiToRaw/BuildFile.xml
@@ -5,4 +5,4 @@
 <use   name="EventFilter/FEDInterface"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="rootrflx"/>
+

--- a/EventFilter/ESRawToDigi/BuildFile.xml
+++ b/EventFilter/ESRawToDigi/BuildFile.xml
@@ -6,6 +6,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="EventFilter/EcalRawToDigi"/>
-<use   name="rootrflx"/>
+
 <use   name="rootcore"/>
 <flags   EDM_PLUGIN="1"/>

--- a/EventFilter/EcalDigiToRaw/BuildFile.xml
+++ b/EventFilter/EcalDigiToRaw/BuildFile.xml
@@ -6,6 +6,6 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="Geometry/EcalMapping"/>
-<use   name="rootrflx"/>
+
 <flags   EDM_PLUGIN="1"/>
 

--- a/EventFilter/EcalRawToDigi/BuildFile.xml
+++ b/EventFilter/EcalRawToDigi/BuildFile.xml
@@ -17,7 +17,7 @@
 <use   name="RecoLocalCalo/EcalRecAlgos"/>
 <use   name="RecoLocalCalo/EcalRecProducers"/>
 <use   name="Utilities/StorageFactory"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/EventFilter/RPCRawToDigi/BuildFile.xml
+++ b/EventFilter/RPCRawToDigi/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/RPCObjects"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <use   name="boost"/>
 <use   name="root"/>
 <export>

--- a/FWCore/Skeletons/scripts/mkTemplates/DataPkg/BuildFile.xml
+++ b/FWCore/Skeletons/scripts/mkTemplates/DataPkg/BuildFile.xml
@@ -1,5 +1,5 @@
 <use name="DataFormats/Common"/>
-<use name="rootrflx"/>
+
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
+++ b/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name=DataFormats/Common>
-<use name=rootrflx>
+
 <export>
   <lib name=__subsys__xxxEventHypothesis>
   <use name=DataFormats/Common>
-  <use name=rootrflx>
+
 </export>

--- a/FWCore/Utilities/BuildFile.xml
+++ b/FWCore/Utilities/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="boost_regex"/>
 <use   name="rootcintex"/>
 <use   name="rootcore"/>
-<use   name="rootrflx"/>
+
 <use   name="tbb"/>
 <use   name="libuuid"/>
 <export>

--- a/FastSimDataFormats/External/BuildFile.xml
+++ b/FastSimDataFormats/External/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/FastSimDataFormats/NuclearInteractions/BuildFile.xml
+++ b/FastSimDataFormats/NuclearInteractions/BuildFile.xml
@@ -1,4 +1,4 @@
-<use   name="rootrflx"/>
+
 <use   name="rootcore"/>
 <use   name="DataFormats/Common"/>
 <use   name="SimDataFormats/Vertex"/>

--- a/FastSimDataFormats/PileUpEvents/BuildFile.xml
+++ b/FastSimDataFormats/PileUpEvents/BuildFile.xml
@@ -1,4 +1,5 @@
-<use   name="rootrflx"/>
+<use name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/Fireworks/Muons/plugins/BuildFile.xml
+++ b/Fireworks/Muons/plugins/BuildFile.xml
@@ -15,7 +15,7 @@
  <use name="Fireworks/Core"/>
  <use name="Fireworks/Muons"/>
  <use name="rootinteractive"/>
- <use name="rootrflx"/>
+
  <lib name="Eve"/>
  <lib name="Geom"/>
  <lib name="RGL"/>

--- a/Fireworks/Tracks/plugins/BuildFile.xml
+++ b/Fireworks/Tracks/plugins/BuildFile.xml
@@ -14,7 +14,7 @@
  <use name="Fireworks/Tracks"/>
  <use name="rootinteractive"/>
  <use name="rootphysics"/>
- <use name="rootrflx"/>
+
  <lib name="Eve"/>
  <lib name="Geom"/>
  <lib name="RGL"/>

--- a/GeneratorInterface/Hydjet2Interface/BuildFile.xml
+++ b/GeneratorInterface/Hydjet2Interface/BuildFile.xml
@@ -19,7 +19,7 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="root"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <use   name="rootcore"/>
 <export> 
   <lib   name="1"/>

--- a/HiggsAnalysis/HiggsToGammaGamma/BuildFile.xml
+++ b/HiggsAnalysis/HiggsToGammaGamma/BuildFile.xml
@@ -15,6 +15,6 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="clhep"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <flags   EDM_PLUGIN="1"/>
 

--- a/JetMETCorrections/JetParton/BuildFile.xml
+++ b/JetMETCorrections/JetParton/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/RecoCandidate"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/JetMETCorrections/TauJet/BuildFile.xml
+++ b/JetMETCorrections/TauJet/BuildFile.xml
@@ -12,7 +12,7 @@
 <use   name="RecoTauTag/TauTagTools"/>
 <use   name="TrackingTools/TrackAssociator"/>
 <use   name="RecoTauTag/RecoTau"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/JetMETCorrections/TauJet/plugins/BuildFile.xml
+++ b/JetMETCorrections/TauJet/plugins/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="DataFormats/JetReco"/>
 <use   name="JetMETCorrections/Objects"/>
-<use   name="rootrflx"/>
+
 <use   name="RecoTauTag/RecoTau"/>
 <library   file="TauJetCorrectorExample.cc" name="TauJetCorrectorExample">
   <flags   EDM_PLUGIN="1"/>

--- a/L1Trigger/DTBti/BuildFile.xml
+++ b/L1Trigger/DTBti/BuildFile.xml
@@ -9,7 +9,7 @@
 <use   name="L1Trigger/DTUtilities"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/DTSectorCollector/BuildFile.xml
+++ b/L1Trigger/DTSectorCollector/BuildFile.xml
@@ -9,7 +9,7 @@
 <use   name="L1Trigger/DTTriggerServerPhi"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/DTTraco/BuildFile.xml
+++ b/L1Trigger/DTTraco/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="L1Trigger/DTTriggerServerTheta"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/DTTrigger/BuildFile.xml
+++ b/L1Trigger/DTTrigger/BuildFile.xml
@@ -15,5 +15,5 @@
 <use   name="Utilities/General"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <flags   EDM_PLUGIN="1"/>

--- a/L1Trigger/DTTriggerServerPhi/BuildFile.xml
+++ b/L1Trigger/DTTriggerServerPhi/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="L1Trigger/DTTraco"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/DTTriggerServerTheta/BuildFile.xml
+++ b/L1Trigger/DTTriggerServerTheta/BuildFile.xml
@@ -6,7 +6,7 @@
 <use   name="L1TriggerConfig/DTTPGConfig"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/DTUtilities/BuildFile.xml
+++ b/L1Trigger/DTUtilities/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="CondFormats/DTObjects"/>
 <use   name="CLHEP"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/L1TriggerConfig/DTTPGConfig/BuildFile.xml
+++ b/L1TriggerConfig/DTTPGConfig/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="CondFormats/DTObjects"/>
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondCore/DBOutputService"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/L1TriggerConfig/DTTPGConfigProducers/BuildFile.xml
+++ b/L1TriggerConfig/DTTPGConfigProducers/BuildFile.xml
@@ -14,6 +14,6 @@
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="RelationalAccess"/>
-<use   name="rootrflx"/>
+
 <use   name="L1TriggerConfig/DTTPGConfig"/>
 <flags   EDM_PLUGIN="1"/>

--- a/MuonAnalysis/MomentumScaleCalibration/BuildFile.xml
+++ b/MuonAnalysis/MomentumScaleCalibration/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="heppdt"/>
 <use   name="clhep"/>
 <use   name="rootminuit"/>
-<use   name="rootrflx"/>
+
 <use   name="roothistmatrix"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/Utilities"/>

--- a/PhysicsTools/Heppy/BuildFile.xml
+++ b/PhysicsTools/Heppy/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="root"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
-<use name="rootrflx"/>
+
 <use name="rootpy"/>
 <use name="clhepheader"/>
 <use name="DataFormats/Candidate"/>

--- a/PhysicsTools/HeppyCore/BuildFile.xml
+++ b/PhysicsTools/HeppyCore/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="root"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
-<use name="rootrflx"/>
+
 <use name="rootpy"/>
 <export>
 <lib name="1"/>

--- a/PhysicsTools/JetMCUtils/BuildFile.xml
+++ b/PhysicsTools/JetMCUtils/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/PhysicsTools/ParallelAnalysis/BuildFile.xml
+++ b/PhysicsTools/ParallelAnalysis/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="FWCore/TFWLiteSelector"/>
 <use   name="clhep"/>
 <use   name="rootgpad"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/PhysicsTools/SelectorUtils/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/BuildFile.xml
@@ -13,7 +13,7 @@
 <use name="FWCore/FWLite"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
-<use name="rootrflx"/>
+
 <use name="rootcore"/>
 <use name="root"/>
 <use name="openssl"/>

--- a/PhysicsTools/Utilities/BuildFile.xml
+++ b/PhysicsTools/Utilities/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/Provenance"/>
 <use   name="FWCore/Utilities"/>
 <use   name="SimDataFormats/PileupSummaryInfo"/>
-<use   name="rootrflx"/>
+
 <use   name="roofit"/>
 <use   name="rootcore"/>
 <use   name="root"/>

--- a/RecoBTag/ImpactParameter/test/BuildFile.xml
+++ b/RecoBTag/ImpactParameter/test/BuildFile.xml
@@ -1,4 +1,4 @@
-<use   name="rootrflx"/>
+
 <use   name="clhep"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>

--- a/RecoEgamma/ElectronIdentification/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="MagneticField/Engine"/>
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="PhysicsTools/SelectorUtils"/>
-<use name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoHI/HiCentralityAlgos/BuildFile.xml
+++ b/RecoHI/HiCentralityAlgos/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoHI/HiEvtPlaneAlgos/BuildFile.xml
+++ b/RecoHI/HiEvtPlaneAlgos/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoHI/HiMuonAlgos/BuildFile.xml
+++ b/RecoHI/HiMuonAlgos/BuildFile.xml
@@ -23,7 +23,7 @@
 <use   name="RecoVertex/KalmanVertexFit"/>
 <use   name="RecoVertex/VertexPrimitives"/>
 <use   name="DataFormats/L1GlobalMuonTrigger"/>
-<use   name="rootrflx"/>
+
 <use   name="clhep"/>
 <export>
   <lib   name="1"/>

--- a/RecoHI/HiMuonAlgos/plugins/BuildFile.xml
+++ b/RecoHI/HiMuonAlgos/plugins/BuildFile.xml
@@ -1,5 +1,5 @@
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>

--- a/RecoJets/FFTJetAlgorithms/BuildFile.xml
+++ b/RecoJets/FFTJetAlgorithms/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/Common"/>
-<use   name="rootrflx"/>
+
 <use   name="fftjet"/>
 <use   name="fftw3"/>
 <export>

--- a/RecoParticleFlow/PFClusterTools/BuildFile.xml
+++ b/RecoParticleFlow/PFClusterTools/BuildFile.xml
@@ -4,7 +4,7 @@
 <use   name="DataFormats/EcalDetId"/>
 <use   name="boost"/>
 <use   name="rootphysics"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoRomanPot/RecoFP420/BuildFile.xml
+++ b/RecoRomanPot/RecoFP420/BuildFile.xml
@@ -15,7 +15,7 @@
 <use   name="hepmc"/>
 <use   name="gsl"/>
 <use   name="rootmath"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoTauTag/ImpactParameter/BuildFile.xml
+++ b/RecoTauTag/ImpactParameter/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/BTauReco"/>
 <use   name="DataFormats/VertexReco"/>
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/Math"/>
 <use   name="boost"/>
 <use   name="root"/>

--- a/RecoTauTag/ImpactParameter/plugins/BuildFile.xml
+++ b/RecoTauTag/ImpactParameter/plugins/BuildFile.xml
@@ -5,7 +5,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/BTauReco"/>
 <use   name="DataFormats/VertexReco"/>
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/Math"/>
 <use   name="boost"/>
 <use   name="root"/>

--- a/RecoTracker/MeasurementDet/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/BuildFile.xml
@@ -23,4 +23,4 @@
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>
 <use   name="RecoTracker/TkDetLayers"/>
-<use   name="rootrflx"/>
+

--- a/RecoTracker/NuclearSeedGenerator/BuildFile.xml
+++ b/RecoTracker/NuclearSeedGenerator/BuildFile.xml
@@ -22,7 +22,7 @@
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoTracker/TkSeedGenerator/BuildFile.xml
+++ b/RecoTracker/TkSeedGenerator/BuildFile.xml
@@ -18,7 +18,7 @@
 <use   name="TrackingTools/MaterialEffects"/>
 <use   name="TrackingTools/Records"/>
 <use   name="CommonTools/Utils"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/plugins/BuildFile.xml
@@ -8,7 +8,7 @@
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <use   name="root"/>
 <use   name="rootminuit"/>
 <use   name="RecoVertex/BeamSpotProducer"/>

--- a/RecoVertex/BeamSpotProducer/test/BuildFile.xml
+++ b/RecoVertex/BeamSpotProducer/test/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="CondFormats/DataRecord"/>
 <use   name="CondCore/DBOutputService"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <use   name="root"/>
 <use   name="rootminuit"/>
 <use   name="RecoVertex/BeamSpotProducer"/>

--- a/SimDataFormats/CaloHit/BuildFile.xml
+++ b/SimDataFormats/CaloHit/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="SimDataFormats/EncodedEventId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/CaloTest/BuildFile.xml
+++ b/SimDataFormats/CaloTest/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="SimDataFormats/CaloHit"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/CrossingFrame/BuildFile.xml
+++ b/SimDataFormats/CrossingFrame/BuildFile.xml
@@ -9,7 +9,7 @@
 <use   name="SimDataFormats/TrackingHit"/>
 <use   name="SimDataFormats/Vertex"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/DigiSimLinks/BuildFile.xml
+++ b/SimDataFormats/DigiSimLinks/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="SimDataFormats/EncodedEventId"/>
 <use   name="DataFormats/MuonDetId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/EcalTestBeam/BuildFile.xml
+++ b/SimDataFormats/EcalTestBeam/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/CaloTowers"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/EncodedEventId/BuildFile.xml
+++ b/SimDataFormats/EncodedEventId/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
 <use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/Forward/BuildFile.xml
+++ b/SimDataFormats/Forward/BuildFile.xml
@@ -3,4 +3,4 @@
 </export>
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+

--- a/SimDataFormats/GeneratorProducts/BuildFile.xml
+++ b/SimDataFormats/GeneratorProducts/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/Common"/>
 <use   name="hepmc"/>
-<use   name="rootrflx"/>
+
 <use   name="roothistmatrix"/>
 <export>
   <lib   name="1"/>

--- a/SimDataFormats/HcalTestBeam/BuildFile.xml
+++ b/SimDataFormats/HcalTestBeam/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/MessageLogger"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/HiGenData/BuildFile.xml
+++ b/SimDataFormats/HiGenData/BuildFile.xml
@@ -1,4 +1,4 @@
-<use   name="rootrflx"/>
+
 <use   name="DataFormats/HepMCCandidate"/>
 <export>
   <lib   name="1"/>

--- a/SimDataFormats/JetMatching/BuildFile.xml
+++ b/SimDataFormats/JetMatching/BuildFile.xml
@@ -1,7 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/JetReco"/>
-<use name="rootrflx"/>
+
 <export>
   <lib name="1"/>
 </export>

--- a/SimDataFormats/PileupSummaryInfo/BuildFile.xml
+++ b/SimDataFormats/PileupSummaryInfo/BuildFile.xml
@@ -3,7 +3,7 @@
 <use   name="DataFormats/Provenance"/>
 <use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="clhep"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/RPCDigiSimLink/BuildFile.xml
+++ b/SimDataFormats/RPCDigiSimLink/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="SimDataFormats/EncodedEventId"/>
 <use   name="SimDataFormats/TrackingHit"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/RandomEngine/BuildFile.xml
+++ b/SimDataFormats/RandomEngine/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/Track/BuildFile.xml
+++ b/SimDataFormats/Track/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Math"/>
 <use   name="SimDataFormats/EncodedEventId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/TrackerDigiSimLink/BuildFile.xml
+++ b/SimDataFormats/TrackerDigiSimLink/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="SimDataFormats/EncodedEventId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/TrackingAnalysis/BuildFile.xml
+++ b/SimDataFormats/TrackingAnalysis/BuildFile.xml
@@ -7,7 +7,7 @@
 <use   name="SimDataFormats/Track"/>
 <use   name="SimDataFormats/TrackingHit"/>
 <use   name="SimDataFormats/Vertex"/>
-<use   name="rootrflx"/>
+
 <use   name="clhepheader"/>
 <export>
   <lib   name="1"/>

--- a/SimDataFormats/TrackingHit/BuildFile.xml
+++ b/SimDataFormats/TrackingHit/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="SimDataFormats/EncodedEventId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimDataFormats/ValidationFormats/BuildFile.xml
+++ b/SimDataFormats/ValidationFormats/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="DataFormats/GeometryVector"/>
 <use   name="clhep"/>
 <use   name="geant4core"/>
-<use   name="rootrflx"/>
+
 <use   name="expat"/>
 <export>
   <lib   name="1"/>

--- a/SimDataFormats/Vertex/BuildFile.xml
+++ b/SimDataFormats/Vertex/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Math"/>
 <use   name="SimDataFormats/EncodedEventId"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimG4CMS/Calo/BuildFile.xml
+++ b/SimG4CMS/Calo/BuildFile.xml
@@ -21,7 +21,7 @@
 <use   name="geant4core"/>
 <use   name="hepmc"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="rootmath"/>
 <export>
   <lib   name="1"/>

--- a/SimG4Core/Application/BuildFile.xml
+++ b/SimG4Core/Application/BuildFile.xml
@@ -24,7 +24,7 @@
 <use   name="geant4core"/>
 <use   name="hepmc"/>
 <use   name="heppdt"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimMuon/GEMDigitizer/BuildFile.xml
+++ b/SimMuon/GEMDigitizer/BuildFile.xml
@@ -23,7 +23,7 @@
 <use   name="PhysicsTools/UtilAlgos"/>
 <use   name="RelationalAccess"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="SimDataFormats/CrossingFrame"/>
 <use   name="SimGeneral/HepPDTRecord"/>
 <use   name="Utilities/General"/>

--- a/SimMuon/MCTruth/BuildFile.xml
+++ b/SimMuon/MCTruth/BuildFile.xml
@@ -27,7 +27,7 @@
 <use   name="boost"/>
 <use   name="clhep"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/SimMuon/RPCDigitizer/BuildFile.xml
+++ b/SimMuon/RPCDigitizer/BuildFile.xml
@@ -23,7 +23,7 @@
 <use   name="PhysicsTools/UtilAlgos"/>
 <use   name="RelationalAccess"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <use   name="SimDataFormats/CrossingFrame"/>
 <use   name="SimDataFormats/RPCDigiSimLink"/>
 <use   name="SimDataFormats/TrackerDigiSimLink"/>

--- a/SimTracker/TrackAssociation/BuildFile.xml
+++ b/SimTracker/TrackAssociation/BuildFile.xml
@@ -21,7 +21,7 @@
 <use   name="clhep"/>
 <use   name="boost"/>
 <use   name="root"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib    name="1"/>
 </export>

--- a/TBDataFormats/EcalTBObjects/BuildFile.xml
+++ b/TBDataFormats/EcalTBObjects/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/EcalDetId"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/TBDataFormats/HcalTBObjects/BuildFile.xml
+++ b/TBDataFormats/HcalTBObjects/BuildFile.xml
@@ -1,6 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="boost"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/TrackingTools/PatternTools/BuildFile.xml
+++ b/TrackingTools/PatternTools/BuildFile.xml
@@ -11,7 +11,7 @@
 <use   name="TrackingTools/GeomPropagators"/>
 <use   name="TrackingTools/TrajectoryParametrization"/>
 <use   name="TrackingTools/TrajectoryState"/>
-<use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -9,7 +9,7 @@
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <use   name="TrackingTools/TrajectoryParametrization"/>
 <use   name="MagneticField/Engine"/>
-<use   name="rootrflx"/>
+
 <use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>

--- a/Validation/RecoParticleFlow/BuildFile.xml
+++ b/Validation/RecoParticleFlow/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="rootgpad"/>
 <use   name="rootcore"/>
 <use   name="rootrflx"/>
+
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
DataFormats/Math and DataFormats/DetId depend on rootrflx, so basically everything else does. This allows to reduce the differences with BuildFiles in ROOT6 branch to a minimum.
