### PR TITLE
Align checksums with ROOT5

### DIFF
--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -17,8 +17,9 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
   <class name="std::vector<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
-  <class name="reco::SuperCluster" ClassVersion="14">
-   <version ClassVersion="14" checksum="705520405"/>
+  <class name="reco::SuperCluster" ClassVersion="15">
+   <version ClassVersion="15" checksum="705520405"/>
+   <version ClassVersion="14" checksum="3716250139"/>
    <version ClassVersion="13" checksum="1878352437"/>
    <version ClassVersion="12" checksum="83023066"/>
    <version ClassVersion="11" checksum="83023066"/>


### PR DESCRIPTION
A new checksum was added for reco::SuperCluster in the ROOT 5 releases (7_4_X) such that the version number conflicts with a ROOT6 version number.
This PR adds the new checksum in ROOT6 and adjusts the version number.
Please merge as soon as convenient.
