### PR TITLE
Root6 version numbers should be known to Root5. (Core)

### DIFF
--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -5,6 +5,7 @@
   <version ClassVersion="3" checksum="1936948526"/>
  </class>
  <class name="edm::EDProductGetter" ClassVersion="10">
+  <version ClassVersion="11" checksum="2247759761"/>
   <version ClassVersion="10" checksum="2702412727"/>
  </class>
  <class name="edm::RefCore" ClassVersion="11">
@@ -88,6 +89,7 @@
 
 
 <class name="edm::DataFrame" ClassVersion="10">
+ <version ClassVersion="11" checksum="3066866109"/>
  <version ClassVersion="10" checksum="1632285442"/>
 </class>
 <class name="edm::DataFrameContainer" ClassVersion="10">

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -32,6 +32,7 @@
   <version ClassVersion="10" checksum="959162848"/>
  </class>
  <class name="edm::EventAuxiliary" ClassVersion="10">
+  <version ClassVersion="11" checksum="3721392547"/>
   <version ClassVersion="10" checksum="580036702"/>
  </class>
  <class name="edm::History" ClassVersion="10">
@@ -79,6 +80,7 @@
  </class>
  <class name="std::vector<edm::StoredProductProvenance>"/>
  <class name="edm::BranchDescription" ClassVersion="12">
+  <version ClassVersion="13" checksum="1036656842"/>
   <version ClassVersion="12" checksum="1833963582"/>
   <version ClassVersion="11" checksum="1571703000"/>
   <field name="transient_" transient="true"/>

--- a/DataFormats/Streamer/src/classes_def.xml
+++ b/DataFormats/Streamer/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
  <class name="edm::StreamedProduct" ClassVersion="11">
+  <version ClassVersion="12" checksum="855998814"/>
   <version ClassVersion="10" checksum="512531612"/>
   <version ClassVersion="11" checksum="1146084488"/>
  </class>

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -10,6 +10,7 @@
   <version ClassVersion="10" checksum="380152127"/>
  </class>
  <class name="edmtest::EnumProduct" ClassVersion="10">
+  <version ClassVersion="11" checksum="3817882977"/>
   <version ClassVersion="10" checksum="3025325436"/>
  </class>
  <enum name="edmtest::TheEnumProduct"/>

--- a/FWCore/Common/src/classes_def.xml
+++ b/FWCore/Common/src/classes_def.xml
@@ -12,6 +12,7 @@
    <version ClassVersion="10" checksum="2872088986"/>
   </class>
   <class name="edm::TriggerResultsByName" ClassVersion="10">
+   <version ClassVersion="11" checksum="3334716878"/>
    <version ClassVersion="10" checksum="1282053882"/>
   </class>
 </lcgdict>


### PR DESCRIPTION
Root6 class version numbers should be known to ROOT5.  This prevents serious problems.
This PR is for the affected classes in the Core software category
