### PR TITLE
Root6 version numbers should be known to Root5

### DIFF
--- a/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
+++ b/AnalysisDataFormats/SUSYBSMObjects/src/classes_def.xml
@@ -23,6 +23,7 @@
    <class name="edm::Wrapper<susybsm::HSCPIsolationCollection>"/>
    <class name="edm::Wrapper<susybsm::HSCPIsolationValueMap>"/>
    <class name="susybsm::HSCPCaloInfo" ClassVersion="11">
+    <version ClassVersion="12" checksum="2407040083"/>
     <version ClassVersion="11" checksum="1170741674"/>
    </class>
    <class name="susybsm::HSCPCaloInfoCollection"/>

--- a/AnalysisDataFormats/TrackInfo/src/classes_def.xml
+++ b/AnalysisDataFormats/TrackInfo/src/classes_def.xml
@@ -2,6 +2,7 @@
   <class name="std::pair<LocalVector,LocalVector>"/>
   <class name="std::pair<LocalPoint,LocalPoint>"/>
   <class name="reco::TrackingRecHitInfo" ClassVersion="10">
+   <version ClassVersion="11" checksum="803167075"/>
    <version ClassVersion="10" checksum="2470257581"/>
   </class>
   <class name="reco::TrackingStateInfo "/>

--- a/CondFormats/SiStripObjects/src/classes_def.xml
+++ b/CondFormats/SiStripObjects/src/classes_def.xml
@@ -96,6 +96,7 @@
   </class>
 
   <class name="Phase2TrackerModule" ClassVersion="10">
+   <version ClassVersion="11" checksum="707066581"/>
     <version ClassVersion="10" checksum="2583259051"/>
   </class>
 

--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -33,6 +33,7 @@
   <class name="edm::Wrapper<reco::JTATagInfoCollection>"/>
 
   <class name="reco::btag::TrackData" ClassVersion="11">
+   <version ClassVersion="12" checksum="889773348"/>
    <version ClassVersion="11" checksum="427805128"/>
    <version ClassVersion="10" checksum="3899080432"/>
   </class>

--- a/DataFormats/BeamSpot/src/classes_def.xml
+++ b/DataFormats/BeamSpot/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
   <class name="reco::BeamSpot" ClassVersion="10">
+   <version ClassVersion="11" checksum="1497064974"/>
    <version ClassVersion="10" checksum="915260007"/>
   </class>
   <class name="edm::Wrapper<reco::BeamSpot>"/>

--- a/DataFormats/CaloRecHit/src/classes_def.xml
+++ b/DataFormats/CaloRecHit/src/classes_def.xml
@@ -6,6 +6,7 @@
    <version ClassVersion="10" checksum="3936140"/>
    <version ClassVersion="11" checksum="2938838489"/>
    <version ClassVersion="12" checksum="4229965835"/>
+   <version ClassVersion="13" checksum="3477374013"/>
   </class>
   <class name="edm::Wrapper<std::vector<std::pair<unsigned long,edm::Ptr<reco::CaloCluster> > > >"/>
   <class name="std::vector<std::pair<unsigned long,edm::Ptr<reco::CaloCluster> > >"/>

--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -49,16 +49,19 @@
   </class>
 
   <class name="reco::LeafRefCandidateT" ClassVersion="11">
+    <version ClassVersion="13" checksum="2417932556"/>
     <version ClassVersion="11" checksum="2417932556"/>
     <version ClassVersion="10" checksum="2404784677"/>
    </class>
 
   <class name="reco::VertexCompositePtrCandidate" ClassVersion="12">
+   <version ClassVersion="13" checksum="3584734005"/>
    <version ClassVersion="12" checksum="3253990857"/>
    <version ClassVersion="11" checksum="2070976353"/>
    <version ClassVersion="10" checksum="955269040"/>
   </class>
   <class name="reco::VertexCompositeCandidate" ClassVersion="12">
+   <version ClassVersion="13" checksum="1561694123"/>
    <version ClassVersion="12" checksum="1204062111"/>
    <version ClassVersion="11" checksum="2801258535"/>
    <version ClassVersion="10" checksum="4177206274"/>
@@ -98,6 +101,7 @@
    <version ClassVersion="10" checksum="547616838"/>
   </class>
   <class name="reco::candidate::const_iterator"  ClassVersion="11">
+   <version ClassVersion="12" checksum="870110996"/>
    <version ClassVersion="11" checksum="1840645481"/>
    <version ClassVersion="10" checksum="473157534"/>
   </class>

--- a/DataFormats/DTRecHit/src/classes_def.xml
+++ b/DataFormats/DTRecHit/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 <selection>
   <class name="DTRecHit1D" ClassVersion="11">
+   <version ClassVersion="12" checksum="1472176344"/>
    <version ClassVersion="11" checksum="3736924859"/>
    <version ClassVersion="10" checksum="4049488222"/>
   </class>
@@ -43,6 +44,7 @@
    <version ClassVersion="10" checksum="725455680"/>
   </class>
   <class name="DTRecSegment4D" ClassVersion="11">
+   <version ClassVersion="12" checksum="2768723140"/>
    <version ClassVersion="11" checksum="3765797874"/>
    <version ClassVersion="10" checksum="2324947244"/>
   </class>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -55,6 +55,7 @@
    <version ClassVersion="-1" checksum="2819734289"/>
   </class>
   <class name="reco::Photon::EnergyCorrections"  ClassVersion="15">
+   <version ClassVersion="16" checksum="1544393913"/>
    <version ClassVersion="15" checksum="2042715570"/>
   </class>
 
@@ -166,6 +167,7 @@
    <version ClassVersion="10" checksum="190549577"/>
   </class>
   <class name="reco::GsfElectron::Corrections" ClassVersion="11">
+   <version ClassVersion="12" checksum="796270676"/>
    <version ClassVersion="11" checksum="4279379731"/>
   </class>
   <class name="reco::GsfElectron::ChargeInfo" ClassVersion="10">
@@ -218,6 +220,7 @@
     <version ClassVersion="2" checksum="3522539867"/>
   </class>
   <class name="reco::GsfElectron" ClassVersion="18">
+   <version ClassVersion="19" checksum="1682285704"/>
    <version ClassVersion="18" checksum="2072747263"/>
    <version ClassVersion="17" checksum="1861965703"/>
    <version ClassVersion="16" checksum="1022265405"/>

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -18,6 +18,7 @@
   <class name="std::vector<edm::Ref<std::vector<reco::BasicCluster>,reco::BasicCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::BasicCluster>,reco::BasicCluster> > >"/>
 
   <class name="reco::SuperCluster" ClassVersion="14">
+   <version ClassVersion="15" checksum="705520405"/>
    <version ClassVersion="14" checksum="3716250139"/>
    <version ClassVersion="13" checksum="1878352437"/>
    <version ClassVersion="12" checksum="83023066"/>
@@ -35,6 +36,7 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::SuperCluster>,reco::SuperCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::SuperCluster>,reco::SuperCluster> > >"/>
 
   <class name="reco::ClusterShape" ClassVersion="10">
+   <version ClassVersion="11" checksum="3739311734"/>
    <version ClassVersion="10" checksum="2977556974"/>
     <field name="covEtaEta_" iotype="Double32_t"/>
     <field name="covEtaPhi_" iotype="Double32_t"/>
@@ -85,6 +87,7 @@
   <class name="edm::Wrapper<edm::RefVector<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape,edm::refhelper::FindUsingAdvance<std::vector<reco::PreshowerClusterShape>,reco::PreshowerClusterShape> > >" splitLevel="0"/>
 
   <class name="reco::ElectronSeed" ClassVersion="11">
+   <version ClassVersion="12" checksum="536071409"/>
    <version ClassVersion="11" checksum="3831394066"/>
    <version ClassVersion="10" checksum="534580602"/>
   </class>
@@ -102,6 +105,7 @@
 
 
   <class name="reco::PreshowerCluster" ClassVersion="13">
+   <version ClassVersion="14" checksum="3782728123"/>
    <version ClassVersion="13" checksum="2894694325"/>
    <version ClassVersion="12" checksum="1992137647"/>
    <version ClassVersion="11" checksum="469230288"/>

--- a/DataFormats/FEDRawData/src/classes_def.xml
+++ b/DataFormats/FEDRawData/src/classes_def.xml
@@ -9,9 +9,11 @@
   <version ClassVersion="10" checksum="2136542618"/>
  </class>
  <class name="FEDHeader" ClassVersion="10">
+  <version ClassVersion="11" checksum="3644215394"/>
   <version ClassVersion="10" checksum="611523769"/>
  </class>
  <class name="FEDTrailer" ClassVersion="10">
+  <version ClassVersion="11" checksum="2009823250"/>
   <version ClassVersion="10" checksum="120358665"/>
  </class>
  <class name="fedh_struct" ClassVersion="10">

--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -5,6 +5,7 @@
   <class name="std::vector<reco::GsfComponent5D>"/>
 
   <class name="reco::GsfTangent" ClassVersion="10">
+   <version ClassVersion="11" checksum="1153524498"/>
    <version ClassVersion="10" checksum="3902664602"/>
      <field name="position_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
      <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" />
@@ -24,6 +25,7 @@
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
   <class name="reco::GsfTrack" ClassVersion="13">
+   <version ClassVersion="14" checksum="3085391575"/>
    <version ClassVersion="13" checksum="1287963871"/>
    <version ClassVersion="12" checksum="1456169080"/>
    <version ClassVersion="11" checksum="1456169080"/>

--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -26,6 +26,7 @@
   </class>
   <class name="edm::Wrapper<reco::PdfInfo>" />
   <class name="reco::FlavorHistory"  ClassVersion="11">
+   <version ClassVersion="12" checksum="699034420"/>
    <version ClassVersion="11" checksum="425358630"/>
    <version ClassVersion="10" checksum="425358630"/>
   </class>
@@ -34,6 +35,7 @@
   <class name="edm::ValueMap<reco::FlavorHistory >" />
   <class name="edm::Wrapper<edm::ValueMap<reco::FlavorHistory > >" />
   <class name="reco::FlavorHistoryEvent"  ClassVersion="10">
+   <version ClassVersion="11" checksum="1284576356"/>
    <version ClassVersion="10" checksum="3632760022"/>
   </class>
   <class name="std::vector<reco::FlavorHistoryEvent>" />

--- a/DataFormats/L1GlobalCaloTrigger/src/classes_def.xml
+++ b/DataFormats/L1GlobalCaloTrigger/src/classes_def.xml
@@ -6,15 +6,19 @@
    <version ClassVersion="10" checksum="3816719986"/>
   </class>
   <class name="L1GctInternJetData" ClassVersion="10">
+   <version ClassVersion="11" checksum="2229153073"/>
    <version ClassVersion="10" checksum="3106448375"/>
   </class>
   <class name="L1GctInternEtSum" ClassVersion="10">
+   <version ClassVersion="11" checksum="405572632"/>
    <version ClassVersion="10" checksum="1283596122"/>
   </class>
   <class name="L1GctInternHtMiss" ClassVersion="10">
+   <version ClassVersion="11" checksum="1282537724"/>
    <version ClassVersion="10" checksum="2668056860"/>
   </class>
   <class name="L1GctInternHFData" ClassVersion="10">
+   <version ClassVersion="11" checksum="1304507668"/>
    <version ClassVersion="10" checksum="1000233428"/>
   </class>
   <class name="L1GctFibreWord" ClassVersion="10">

--- a/DataFormats/L1GlobalTrigger/src/classes_def.xml
+++ b/DataFormats/L1GlobalTrigger/src/classes_def.xml
@@ -103,6 +103,7 @@
   <class name="std::vector<L1GtLogicParser::OperandToken> "/>
 
   <class name="L1GtLogicParser::TokenRPN" ClassVersion="10">
+   <version ClassVersion="11" checksum="1759531300"/>
    <version ClassVersion="10" checksum="535147936"/>
   </class>
   <class name="std::vector<L1GtLogicParser::TokenRPN> "/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -24,6 +24,7 @@
   <class name="edm::Wrapper<l1t::EGammaBxCollection>"/>
 
   <class name="l1t::EtSum" ClassVersion="12">
+   <version ClassVersion="13" checksum="914893879"/>
    <version ClassVersion="12" checksum="2853072620"/>
    <version ClassVersion="11" checksum="2043464580"/>
    <version ClassVersion="10" checksum="3389025278"/>
@@ -48,6 +49,7 @@
   <class name="edm::Wrapper<l1t::MuonBxCollection>"/>
 
   <class name="l1t::CaloSpare" ClassVersion="12">
+   <version ClassVersion="13" checksum="50826133"/>
    <version ClassVersion="12" checksum="3118488206"/>
    <version ClassVersion="11" checksum="2308880166"/>
    <version ClassVersion="10" checksum="3477497140"/>
@@ -56,11 +58,13 @@
   <class name="edm::Wrapper<l1t::CaloSpareBxCollection>"/>
 
   <class name="l1extra::L1EmParticle" ClassVersion="12">
+   <version ClassVersion="13" checksum="3236372598"/>
    <version ClassVersion="12" checksum="3931086678"/>
    <version ClassVersion="11" checksum="711885342"/>
    <version ClassVersion="10" checksum="2019457791"/>
   </class>
   <class name="l1extra::L1JetParticle" ClassVersion="12">
+   <version ClassVersion="13" checksum="2428218521"/>
    <version ClassVersion="12" checksum="4036782287"/>
    <version ClassVersion="11" checksum="979511831"/>
    <version ClassVersion="10" checksum="2992828146"/>
@@ -71,11 +75,13 @@
    <version ClassVersion="10" checksum="404862417"/>
   </class>
   <class name="l1extra::L1EtMissParticle" ClassVersion="12">
+   <version ClassVersion="13" checksum="2570765761"/>
    <version ClassVersion="12" checksum="3702781837"/>
    <version ClassVersion="11" checksum="2391271061"/>
    <version ClassVersion="10" checksum="256436604"/>
   </class>
   <class name="l1extra::L1ParticleMap" ClassVersion="10">
+   <version ClassVersion="11" checksum="3029280877"/>
    <field name="indexCombosState_" transient="true"/>
    <version ClassVersion="10" checksum="72905536"/>
   </class>

--- a/DataFormats/MuonReco/src/classes_def.xml
+++ b/DataFormats/MuonReco/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
   <class name="reco::Muon" ClassVersion="16">
+   <version ClassVersion="17" checksum="2296096670"/>
    <version ClassVersion="16" checksum="1808419014"/>
    <version ClassVersion="15" checksum="4145317518"/>
    <version ClassVersion="11" checksum="199341143"/>

--- a/DataFormats/MuonSeed/src/classes_def.xml
+++ b/DataFormats/MuonSeed/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
       <class name="L2MuonTrajectorySeed"  ClassVersion="10">
+       <version ClassVersion="11" checksum="541533207"/>
        <version ClassVersion="10" checksum="2502730614"/>
       </class>
       <class name="edm::RefToBase<L2MuonTrajectorySeed>"/>
@@ -24,6 +25,7 @@
       <class name="edm::helpers::KeyVal<edm::Ref<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> >,edm::RefVector<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed,edm::refhelper::FindUsingAdvance<std::vector<L2MuonTrajectorySeed>,L2MuonTrajectorySeed> > >"/>
 
       <class name="L3MuonTrajectorySeed"  ClassVersion="10">
+       <version ClassVersion="11" checksum="981061883"/>
        <version ClassVersion="10" checksum="2200485484"/>
       </class>
       <class name="edm::RefToBase<L3MuonTrajectorySeed>"/>

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -1,6 +1,7 @@
 <lcgdict>
 
    <class name="reco::PFCandidate" ClassVersion="16">
+    <version ClassVersion="17" checksum="3126170233"/>
     <version ClassVersion="16" checksum="3060382005"/>
     <version ClassVersion="15" checksum="1136968957"/>
     <version ClassVersion="10" checksum="536762407"/>
@@ -45,6 +46,7 @@
   <class name="edm::reftobase::RefVectorHolder<reco::PFCandidateRefVector >"/>
 
   <class name="reco::IsolatedPFCandidate"  ClassVersion="12">
+   <version ClassVersion="13" checksum="1855164250"/>
    <version ClassVersion="12" checksum="2650360086"/>
    <version ClassVersion="11" checksum="696008414"/>
    <version ClassVersion="10" checksum="1426765407"/>
@@ -57,6 +59,7 @@
   <class name="reco::IsolatedPFCandidatePtr"/>
 
   <class name="reco::PileUpPFCandidate"  ClassVersion="12">
+   <version ClassVersion="13" checksum="1734488695"/>
    <version ClassVersion="12" checksum="2377890195"/>
    <version ClassVersion="11" checksum="1422984859"/>
    <version ClassVersion="10" checksum="1986419188"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_1.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_1.xml
@@ -45,6 +45,7 @@
   <class name="reco::ConvBremSeed" ClassVersion="11">
    <version ClassVersion="10" checksum="2980747190"/>
    <version ClassVersion="11" checksum="637662266"/>
+   <version ClassVersion="12" checksum="2604169839"/>
   </class>
   <class name="std::vector<reco::ConvBremSeed>"/>
   <class name="edm::Ref<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed,edm::refhelper::FindUsingAdvance<std::vector<reco::ConvBremSeed>,reco::ConvBremSeed> >"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -2,6 +2,7 @@
 <selection>
 
   <class name="reco::PFCluster" ClassVersion="15">
+   <version ClassVersion="16" checksum="1786894710"/>
    <version ClassVersion="15" checksum="1837961152"/>
    <version ClassVersion="14" checksum="3610074122"/>
    <version ClassVersion="13" checksum="1305770681"/>
@@ -36,6 +37,7 @@
 
 
   <class name="reco::PFRecHit" ClassVersion="16">
+   <version ClassVersion="17" checksum="2606786437"/>
    <version ClassVersion="10" checksum="1807687081"/>
    <version ClassVersion="11" checksum="3727193351"/>
    <version ClassVersion="12" checksum="207373238"/>
@@ -74,6 +76,7 @@
 -->  
 
   <class name="reco::PFTrajectoryPoint" ClassVersion="11">
+   <version ClassVersion="12" checksum="2337677018"/>
    <version ClassVersion="11" checksum="2337677018"/>
 <!-- Removed by Patrick: avoid many useless PFTrack copies (memory+CPU) and costless for RECO/AOD
     <field name="posrep_" transient="true"/>
@@ -84,6 +87,7 @@
 
   <class name="edm::RefVector<std::vector<reco::PFBlock>,reco::PFBlock,edm::refhelper::FindUsingAdvance<std::vector<reco::PFBlock>,reco::PFBlock> >"/>
   <class name="reco::PFRecTrack" ClassVersion="11">
+   <version ClassVersion="12" checksum="2850643502"/>
    <version ClassVersion="11" checksum="2924298092"/>
    <version ClassVersion="10" checksum="2979491836"/>
     <!-- <field name="doPropagation_" transient="true"/> -->
@@ -93,6 +97,7 @@
   <class name="edm::Wrapper<std::vector<reco::PFRecTrack> >"/>
 
   <class name="reco::GsfPFRecTrack" ClassVersion="11">
+   <version ClassVersion="12" checksum="2203231294"/>
    <version ClassVersion="11" checksum="2592328732"/>
    <version ClassVersion="10" checksum="3411096264"/>
     <!-- <field name="doPropagation_" transient="true"/> -->
@@ -102,6 +107,7 @@
   <class name="edm::Wrapper<std::vector<reco::GsfPFRecTrack> >"/>
 
   <class name="reco::PFBrem" ClassVersion="11">
+   <version ClassVersion="12" checksum="3001582852"/>
    <version ClassVersion="11" checksum="1785919010"/>
    <version ClassVersion="10" checksum="3922569476"/>
   </class>
@@ -116,6 +122,7 @@
   <class name="edm::Wrapper<std::vector<reco::PFSimParticle> >"/>
 
   <class name="reco::PFBlockElement" ClassVersion="11">
+   <version ClassVersion="12" checksum="3101496393"/>
    <version ClassVersion="11" checksum="3944635097"/>
     <!-- <field name="multilinkslinks_" transient="true"/> -->
    <field name="nullTrack_" transient="true"/>
@@ -131,6 +138,7 @@
   <class name="edm::Wrapper<edm::OwnVector<reco::PFBlockElement, edm::ClonePolicy<reco::PFBlockElement> > >" />
 
   <class name="reco::PFBlockElementTrack" ClassVersion="12">
+   <version ClassVersion="13" checksum="1449646331"/>
    <version ClassVersion="12" checksum="417575083"/>
    <version ClassVersion="10" checksum="2342660248"/>
    <version ClassVersion="11" checksum="1450496342"/>
@@ -140,6 +148,7 @@
   </class>
 
   <class name="reco::PFBlockElementGsfTrack" ClassVersion="11">
+   <version ClassVersion="12" checksum="1521047275"/>
    <version ClassVersion="11" checksum="1367777435"/>
    <version ClassVersion="10" checksum="549349370"/>
 <!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)
@@ -149,6 +158,7 @@
   </class>
 
   <class name="reco::PFBlockElementBrem" ClassVersion="11">
+   <version ClassVersion="12" checksum="112730380"/>
    <version ClassVersion="11" checksum="2362699420"/>
    <version ClassVersion="10" checksum="2231967579"/>
 <!-- removed by Florian. It useful to have this Ref (especially for a reprocessing)
@@ -159,6 +169,7 @@
 
 
   <class name="reco::PFBlockElementCluster" ClassVersion="12">
+   <version ClassVersion="13" checksum="775826696"/>
    <version ClassVersion="12" checksum="1263691576"/>
    <version ClassVersion="10" checksum="2503385411"/>
    <version ClassVersion="11" checksum="2936163017"/>
@@ -185,6 +196,7 @@
   <class name="edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> >"/>
 
   <class name="pftools::CalibrationResultWrapper" ClassVersion="10">
+   <version ClassVersion="11" checksum="3535169833"/>
    <version ClassVersion="10" checksum="1290295437"/>
   </class>
   <class name="pftools::Calibratable"  ClassVersion="10">
@@ -221,6 +233,7 @@
   <class name="std::pair<unsigned int,pftools::CaloRing>" />  
   
   <class name="pftools::ParticleFiltrationDecision" ClassVersion="10">
+   <version ClassVersion="11" checksum="1016852148"/>
    <version ClassVersion="10" checksum="2525480962"/>
   </class>
   <class name="std::vector<pftools::ParticleFiltrationDecision>"/>
@@ -242,6 +255,7 @@
   <class name="edm::Ref< std::vector<reco::PFDisplacedVertexCandidate>, reco::PFDisplacedVertexCandidate, edm::refhelper::FindUsingAdvance<std::vector<reco::PFDisplacedVertexCandidate>,reco::PFDisplacedVertexCandidate> >"/>
 
   <class name="reco::PFDisplacedVertex" ClassVersion="11">
+   <version ClassVersion="12" checksum="2818127737"/>
    <version ClassVersion="11" checksum="4172417049"/>
    <version ClassVersion="10" checksum="4202892065"/>
   </class>
@@ -267,6 +281,7 @@
   <class name="edm::Ref<std::vector<reco::PreId>,reco::PreId,edm::refhelper::FindUsingAdvance<std::vector<reco::PreId>,reco::PreId> >" />
 
   <class name="reco::PFBlockElementSuperCluster" ClassVersion="12">
+   <version ClassVersion="13" checksum="3749373244"/>
    <version ClassVersion="12" checksum="1656578540"/>
    <version ClassVersion="10" checksum="456156271"/>
    <version ClassVersion="11" checksum="3584097231"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -17,6 +17,7 @@
 
   <!-- PAT Objects, and embedded data  -->
   <class name="pat::Electron"  ClassVersion="27">
+   <version ClassVersion="28" checksum="2518240031"/>
    <version ClassVersion="27" checksum="3863179876"/>
    <field name="superClusterRelinked_" transient="true"/>
    <version ClassVersion="26" checksum="2045819644"/>
@@ -39,6 +40,7 @@
   </ioread>
 
   <class name="pat::Muon"  ClassVersion="15">
+   <version ClassVersion="16" checksum="2674665735"/>
    <version ClassVersion="15" checksum="1248517999"/>
    <version ClassVersion="14" checksum="132269943"/>
    <version ClassVersion="13" checksum="2943499125"/>
@@ -133,6 +135,7 @@
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="14">
+   <version ClassVersion="15" checksum="1826981639"/>
    <version ClassVersion="14" checksum="1304049301"/>
    <version ClassVersion="13" checksum="130552029"/>
    <field name="caloTowersTemp_" transient="true"/>
@@ -172,6 +175,7 @@
    <version ClassVersion="10" checksum="417284221"/>
   </class>
   <class name="pat::PFParticle"  ClassVersion="12">
+   <version ClassVersion="13" checksum="223824921"/>
    <version ClassVersion="12" checksum="4118931093"/>
    <version ClassVersion="11" checksum="2923110109"/>
    <version ClassVersion="10" checksum="2240381542"/>
@@ -191,6 +195,7 @@
   </class>
 
   <class name="pat::PackedCandidate" ClassVersion="16">
+   <version ClassVersion="17" checksum="1633877368"/>
     <version ClassVersion="16" checksum="3261782486"/>
     <version ClassVersion="15" checksum="2118306102"/>
     <version ClassVersion="14" checksum="1075333340"/>

--- a/DataFormats/PatCandidates/src/classes_def_other.xml
+++ b/DataFormats/PatCandidates/src/classes_def_other.xml
@@ -49,6 +49,7 @@
   <class name="edm::Wrapper<edm::ValueMap<pat::LookupTableRecord> >" />
 
   <class name="pat::CandKinResolution"  ClassVersion="12">
+   <version ClassVersion="13" checksum="1576481716"/>
    <field name="covmatrix_" transient="true"/>
    <field name="hasMatrix_" transient="true"/>
    <version ClassVersion="12" checksum="811710989"/>

--- a/DataFormats/PatCandidates/src/classes_def_trigger.xml
+++ b/DataFormats/PatCandidates/src/classes_def_trigger.xml
@@ -73,6 +73,7 @@
   <class name="std::vector&lt;pat::L1Seed&gt;::const_iterator" />
 
   <class name="pat::TriggerCondition"  ClassVersion="10">
+   <version ClassVersion="11" checksum="296420442"/>
    <version ClassVersion="10" checksum="4134787846"/>
   </class>
   <class name="std::vector&lt;pat::TriggerCondition&gt;" />

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -32,6 +32,7 @@
   </class>
 
   <class name="reco::FitQuality"  ClassVersion="10">
+   <version ClassVersion="11" checksum="2062631270"/>
    <version ClassVersion="10" checksum="1584619238"/>
   </class>
   <class name="std::vector<reco::FitQuality>" />

--- a/DataFormats/SiStripCommon/src/classes_def.xml
+++ b/DataFormats/SiStripCommon/src/classes_def.xml
@@ -1,22 +1,27 @@
 <lcgdict>
 
   <class name="SiStripFecKey" ClassVersion="11">
+   <version ClassVersion="12" checksum="2586598758"/>
    <version ClassVersion="11" checksum="2386840938"/>
    <version ClassVersion="10" checksum="1449235727"/>
   </class>
   <class name="SiStripFedKey" ClassVersion="11">
+   <version ClassVersion="12" checksum="1254242092"/>
    <version ClassVersion="11" checksum="4225883312"/>
    <version ClassVersion="10" checksum="2750106675"/>
   </class>
   <class name="SiStripDetKey" ClassVersion="11">
+   <version ClassVersion="12" checksum="3517099146"/>
    <version ClassVersion="11" checksum="127556950"/>
    <version ClassVersion="10" checksum="3857728603"/>
   </class>
   <class name="SiStripNullKey" ClassVersion="11">
+   <version ClassVersion="12" checksum="4093621542"/>
    <version ClassVersion="11" checksum="1699414770"/>
    <version ClassVersion="10" checksum="3635527151"/>
   </class>
   <class name="SiStripKey" ClassVersion="10">
+   <version ClassVersion="11" checksum="1776974681"/>
    <version ClassVersion="10" checksum="3677735205"/>
   </class>
 
@@ -24,6 +29,7 @@
   <class name="edm::Wrapper<sistrip::ApvReadoutMode>"/>
   <class name="edm::Wrapper<sistrip::FedReadoutMode>"/>
   <class name="SiStripEventSummary" ClassVersion="10">
+   <version ClassVersion="11" checksum="2603270775"/>
    <version ClassVersion="10" checksum="1592002308"/>
   </class>
   <class name="edm::Wrapper<SiStripEventSummary>"/>

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -1,6 +1,7 @@
 <lcgdict>
   
   <class name="reco::PFTau" ClassVersion="17">
+   <version ClassVersion="18" checksum="1318776182"/>
    <version ClassVersion="17" checksum="1523260402"/>
     <version ClassVersion="16" checksum="2695990650"/>
     <version ClassVersion="15" checksum="4105994460"/>
@@ -207,6 +208,7 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
 
 
   <class name="reco::PFTauDecayMode" ClassVersion="12">
+   <version ClassVersion="13" checksum="3507751092"/>
    <version ClassVersion="12" checksum="2043565930"/>
    <version ClassVersion="11" checksum="3414615810"/>
    <version ClassVersion="10" checksum="2108215737"/>
@@ -223,6 +225,7 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTau> > >"/>
 
   <class name="reco::RecoTauPiZero" ClassVersion="12">
+   <version ClassVersion="13" checksum="3687187514"/>
    <version ClassVersion="12" checksum="453348937"/>
    <version ClassVersion="11" checksum="2458276705"/>
    <version ClassVersion="10" checksum="465425628"/>
@@ -236,6 +239,7 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
   <class name="edm::reftobase::Holder<reco::CompositePtrCandidate, edm::Ref<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero,edm::refhelper::FindUsingAdvance<std::vector<reco::RecoTauPiZero>,reco::RecoTauPiZero> > >" />
 
   <class name="reco::PFRecoTauChargedHadron" ClassVersion="13">
+   <version ClassVersion="14" checksum="3665832588"/>
    <version ClassVersion="13" checksum="591384956"/>
    <version ClassVersion="12" checksum="2480143236" />
    <version ClassVersion="11" checksum="858406271" />

--- a/DataFormats/TrackCandidate/src/classes_def.xml
+++ b/DataFormats/TrackCandidate/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
   <class name="TrackCandidate" ClassVersion="11">
+   <version ClassVersion="12" checksum="2330668139"/>
    <version ClassVersion="11" checksum="3750078709"/>
    <version ClassVersion="10" checksum="1620910795"/>
   </class>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -5,6 +5,7 @@
   </class>
 
   <class name="reco::TrackBase" ClassVersion="13">
+   <version ClassVersion="14" checksum="3929365050"/>
    <version ClassVersion="13" checksum="1244921154"/>
     <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
@@ -345,6 +346,7 @@
 
 
   <class name="reco::TrackExtra" ClassVersion="12">
+   <version ClassVersion="13" checksum="2526033150"/>
    <version ClassVersion="12" checksum="106004853"/>
    <version ClassVersion="11" checksum="2586227274"/>
    <version ClassVersion="10" checksum="1613098482"/>
@@ -360,6 +362,7 @@
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
   <class name="reco::Track" ClassVersion="13">
+   <version ClassVersion="14" checksum="4228121071"/>
    <version ClassVersion="13" checksum="36410295"/>
    <version ClassVersion="12" checksum="1190637787"/>
    <version ClassVersion="11" checksum="1190637787"/>
@@ -487,6 +490,7 @@
 
 
    <class name="reco::DeDxHitInfo" ClassVersion="2">
+    <version ClassVersion="3" checksum="2577777556"/>
     <version ClassVersion="2" checksum="3000986250"/>
    </class>
    <class name="reco::DeDxHitInfoCollection"/>

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -10,6 +10,7 @@
    <version ClassVersion="10" checksum="877294307"/>
   </class>
   <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="11">
+   <version ClassVersion="12" checksum="2874379530"/>
    <version ClassVersion="11" checksum="1553184391"/>
    <version ClassVersion="10" checksum="3741285161"/>
   </class>

--- a/DataFormats/TrajectorySeed/src/classes_def.xml
+++ b/DataFormats/TrajectorySeed/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
   <class name="TrajectorySeed" ClassVersion="10">
+   <version ClassVersion="11" checksum="1603723857"/>
    <version ClassVersion="10" checksum="611162820"/>
   </class>
   <class name="edm::RefToBase<TrajectorySeed>"/>

--- a/FastSimDataFormats/External/src/classes_def.xml
+++ b/FastSimDataFormats/External/src/classes_def.xml
@@ -8,6 +8,7 @@
  <class name="edm::Wrapper<std::vector<FastL1BitInfo> >"/>
 
  <class name="FastTrackerCluster" ClassVersion="10">
+  <version ClassVersion="11" checksum="325524572"/>
   <version ClassVersion="10" checksum="2829380995"/>
  </class>
  <class name="std::vector<FastTrackerCluster*>"/>

--- a/FastSimDataFormats/NuclearInteractions/src/classes_def.xml
+++ b/FastSimDataFormats/NuclearInteractions/src/classes_def.xml
@@ -13,6 +13,7 @@
   <class name="std::vector<NUEvent::NUInteraction>"/>
 
   <class name="FSimVertexType" ClassVersion="10">
+   <version ClassVersion="11" checksum="3374332624"/>
    <version ClassVersion="10" checksum="1253390925"/>
   </class>
   <class name="std::vector<FSimVertexType>"/>
@@ -20,6 +21,7 @@
   <class name="edm::Ref< std::vector<FSimVertexType>, FSimVertexType, edm::refhelper::FindUsingAdvance< std::vector<FSimVertexType>, FSimVertexType> >"/>
 
   <class name="FSimDisplacedVertex" ClassVersion="10">
+   <version ClassVersion="11" checksum="2164432722"/>
    <version ClassVersion="10" checksum="251560649"/>
   </class>
   <class name="std::vector<FSimDisplacedVertex>"/>

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -2,6 +2,7 @@
 	<!-- HepMC externals -->
 
 	<class name="HepMC::GenEvent" ClassVersion="10">
+  <version ClassVersion="11" checksum="2967452289"/>
   <version ClassVersion="10" checksum="2993730389"/>
  </class>
 	<class name="HepMC::GenVertex" ClassVersion="10">
@@ -20,6 +21,7 @@
   <version ClassVersion="11" checksum="376377869"/>
   <version ClassVersion="12" checksum="2537869863"/>
   <version ClassVersion="13" checksum="1293886956"/>
+  <version ClassVersion="14" checksum="481001444"/>
  </class>
 	<class name="HepMC::FourVector" ClassVersion="10">
   <version ClassVersion="10" checksum="3279825169"/>


### PR DESCRIPTION
Root6 class version numbers should be known to ROOT5. This prevents serious problems.
This PR is totally technical, as all it does is add version numbers for ROOT6 into the ROOT5 IB.  It changes absolutely nothing in ROOT5.  No version numbers or checksums or code is modified.
I suggest that L2's be given a reasonable time to sign or comment, and if they do not, the L2 signature(s) should be bypassed.
