### PR TITLE
fix rechitinregions

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTRechitInRegionsProducer.cc
@@ -159,8 +159,10 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 	    
 	    std::vector<EcalEtaPhiRegion>::const_iterator region;
 	    for (region=regions.begin(); region!=regions.end(); region++) {
-	      if (region->inRegion(position))
+	      if (region->inRegion(position)) {
 		uhits->push_back(*it);
+		break;
+	      }
 	    }
 	  }
 	}
@@ -202,8 +204,10 @@ void HLTRechitInRegionsProducer<T1>::produce(edm::Event& evt, const edm::EventSe
 	    
 	    std::vector<EcalEtaPhiRegion>::const_iterator region;
 	    for (region=regions.begin(); region!=regions.end(); region++) {
-	      if (region->inRegion(position))
+	      if (region->inRegion(position)) {
 		hits->push_back(*it);
+		break;
+	      }
 	    }
 	  }
 	}


### PR DESCRIPTION
The filter produces a collection of hits within L1 seeded regions. With the old implementation if a hit was belonging to more than 1 region it was added multiple times in the collection. Given the size of the L1 regions the overlap is mainly reduced to their boundaries so the artificial increase of energy is observed in the PFClusters used to compute Ecal Isolation rather than in SuperClusters (checked to be ~the same).

Compared online and offline Sum(PFClusters_Et) around HLT candidates (in dr<0.3). The fraction of events in Zee  with (E_online-E_offline)/E_offline > 15% is:
with bug 8%;
with bug-fix ~1%.

The bug is affecting just HLT reconstruction, the filter is not used anywhere else.
