### PR TITLE
Fix in two scripts to monitor the SiStrip DB objects

### DIFF
--- a/DQM/SiStripMonitorSummary/scripts/MonitorDB_NewDirStructure_KeepTagLinks_generic.sh
+++ b/DQM/SiStripMonitorSummary/scripts/MonitorDB_NewDirStructure_KeepTagLinks_generic.sh
@@ -609,66 +609,10 @@ EOF
 
 	    getOfflineDQMData.sh $DB $ACCOUNT $TAGSUBDIR $tag
 
-	    for i in {1..4}; do
-		for Plot in `ls *.png | grep TIBLayer$i`; do
-		    mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TIB/Layer$i/Trends;
-		done
-	    done
+	    afstokenchecker.sh "Moving Trend Plots Using the script moveTrendPlots..."
 
-	    for i in {1..6}; do
-		for Plot in `ls *.png | grep TOBLayer$i`; do
-		    mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TOB/Layer$i/Trends;
-		done
-	    done
+            moveTrendPlots.sh $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag
 
-	    for i in {1..3}; do
-		for Plot in `ls *.png | grep TID-Disk$i`; do
-		    mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TID/Side1/Disk$i/Trends;
-		done
-		for Plot in `ls *.png | grep TID+Disk$i`; do
-		    mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TID/Side2/Disk$i/Trends;
-		done
-	    done
-
-	    for i in {1..9}; do
-		for Plot in `ls *.png | grep TEC-Disk$i`; do
-		    mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TEC/Side1/Disk$i/Trends;
-		done
-		for Plot in `ls *.png | grep TEC+Disk$i`; do
-		    mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TEC/Side2/Disk$i/Trends;
-		done
-	    done
-	    
-	    for Plot in `ls *.png | grep TIB`; do
-		mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TIB/Trends;
-	    done
-
-	    for Plot in `ls *.png | grep TOB`; do
-		mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TOB/Trends;
-	    done
-
-	    for Plot in `ls *.png | grep TID-`; do
-		mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TID/Side1/Trends;
-	    done
-
-	    for Plot in `ls *.png | grep TID+`; do
-		mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TID/Side2/Trends;
-	    done
-
-	    for Plot in `ls *.png | grep TEC-`; do
-		mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TEC/Side1/Trends;
-	    done
-
-	    for Plot in `ls *.png | grep TEC+`; do
-		mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/TEC/Side2/Trends;
-	    done
-
-	    for Plot in `ls *.png | grep Tracker`; do
-		mv $Plot $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/plots/Trends;
-	    done
-
-	    mv TrackerSummary.root $STORAGEPATH/$DB/$ACCOUNT/$DBTAGDIR/$TAGSUBDIR/$tag/rootfiles;
-	    rm -f TrackerPlots.root;
 
 	fi
 

--- a/DQM/SiStripMonitorSummary/scripts/getOfflineDQMDataGeneric.sh
+++ b/DQM/SiStripMonitorSummary/scripts/getOfflineDQMDataGeneric.sh
@@ -77,7 +77,7 @@ do
     # This has not any real data
     if [[ $fileName != "${baseName}1.txt" ]] ;
     then
-      if [[ $fileName =~ "^${baseName}"  && $(( `wc -l "$workdir/$fileName" | awk '{print $1}'` - 51 )) > 0 ]] ; # File name must start with this string and must have at least that many lines
+      if [[ $fileName == "${baseName}"*  && $(( `wc -l "$workdir/$fileName" | awk '{print $1}'` - 51 )) > 0 ]] ; # File name must start with this string and must have at least that many lines
       then
         # Extract run number from first row of file
 # AV runNumber of line definition changed to be less dependent on the details of the log file

--- a/DQM/SiStripMonitorSummary/scripts/makeModulePlots.sh
+++ b/DQM/SiStripMonitorSummary/scripts/makeModulePlots.sh
@@ -9,6 +9,6 @@ fi
 if [ $(( $3 & 2 )) -eq 2 ]; then
     pedmon=True
 fi
-cmsRun $CMSSW_BASE/src/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_singlemodule_cfg.py print logDestination=cout outputRootFile=$outputroot moduleList_load=$2 globalTag=$4 connectionString=$5 tagName=$6 recordName=$7 runNumber=$1 PedestalMon=$pedmon NoiseMon=$noisemon gainNorm=$8 
+cmsRun $CMSSW_BASE/src/DQM/SiStripMonitorSummary/test/DBReader_conddbmonitoring_singlemodule_cfg.py logDestination=cout outputRootFile=$outputroot moduleList_load=$2 globalTag=$4 connectionString=$5 tagName=$6 recordName=$7 runNumber=$1 PedestalMon=$pedmon NoiseMon=$noisemon gainNorm=$8 
 
 makeModulePlots $outputroot $2 $3 "/tmp/" $9


### PR DESCRIPTION
If it happens that anyone of the reviewers knows why the way to check if a string starts with a given string I have used so far in DQM/SiStripMonitorSummary/scripts/getOfflineDQMDataGeneric.sh does not work anymore, I would be grateful to know about it. In any case the new version is ok.
