### PR TITLE
adding puppi to miniAODs

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -12,12 +12,15 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
+#include "DataFormats/Common/interface/Association.h"
 //Main File
 #include "fastjet/PseudoJet.hh"
 #include "CommonTools/PileupAlgos/plugins/PuppiProducer.h"
@@ -38,6 +41,8 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
 
   produces<edm::ValueMap<float> > ("PuppiWeights");
   produces<edm::ValueMap<LorentzVector> > ("PuppiP4s");
+  produces< edm::ValueMap<reco::CandidatePtr> >(); 
+
   produces<PFOutputCollection>();
 
 
@@ -128,6 +133,7 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   lPupFiller.insert(hPFProduct,lWeights.begin(),lWeights.end());
   lPupFiller.fill();
 
+
   // This is a dummy to access the "translate" method which is a
   // non-static member function even though it doesn't need to be. 
   // Will fix in the future. 
@@ -141,6 +147,9 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   fPuppiCandidates.reset( new PFOutputCollection );
   std::auto_ptr<edm::ValueMap<LorentzVector> > p4PupOut(new edm::ValueMap<LorentzVector>());
   LorentzVectorCollection puppiP4s;
+  std::vector<reco::CandidatePtr> values(hPFProduct->size());
+  //std::vector<int> values(hPFProduct->size());
+  
   for ( auto i0 = hPFProduct->begin(),
 	  i0begin = hPFProduct->begin(),
 	  i0end = hPFProduct->end(); i0 != i0end; ++i0 ) {
@@ -169,10 +178,17 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::ValueMap<LorentzVector>::Filler  p4PupFiller(*p4PupOut);
   p4PupFiller.insert(hPFProduct,puppiP4s.begin(), puppiP4s.end() );
   p4PupFiller.fill();
-
+  
   iEvent.put(lPupOut,"PuppiWeights");
   iEvent.put(p4PupOut,"PuppiP4s");
   iEvent.put(fPuppiCandidates);
+  
+  std::auto_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
+  edm::ValueMap<reco::CandidatePtr>::Filler filler(*pfMap_p);
+  filler.insert(hPFProduct, values.begin(), values.end());
+  filler.fill();
+  iEvent.put(pfMap_p);
+
 }
 
 // ------------------------------------------------------------------------------------------

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -181,8 +181,13 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   
   iEvent.put(lPupOut,"PuppiWeights");
   iEvent.put(p4PupOut,"PuppiP4s");
-  iEvent.put(fPuppiCandidates);
-  
+ // iEvent.put(fPuppiCandidates);
+   edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put( fPuppiCandidates );
+
+   for(unsigned int ic=0, nc = oh->size(); ic < nc; ++ic) {
+	reco::CandidatePtr pkref( oh, ic );
+	values[ic] = pkref;
+   }
   std::auto_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
   edm::ValueMap<reco::CandidatePtr>::Filler filler(*pfMap_p);
   filler.insert(hPFProduct, values.begin(), values.end());

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -39,8 +39,8 @@ PuppiProducer::PuppiProducer(const edm::ParameterSet& iConfig) {
     = consumes<VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexName"));
  
 
-  produces<edm::ValueMap<float> > ("PuppiWeights");
-  produces<edm::ValueMap<LorentzVector> > ("PuppiP4s");
+  produces<edm::ValueMap<float> > ();
+  produces<edm::ValueMap<LorentzVector> > ();
   produces< edm::ValueMap<reco::CandidatePtr> >(); 
 
   produces<PFOutputCollection>();
@@ -179,8 +179,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   p4PupFiller.insert(hPFProduct,puppiP4s.begin(), puppiP4s.end() );
   p4PupFiller.fill();
   
-  iEvent.put(lPupOut,"PuppiWeights");
-  iEvent.put(p4PupOut,"PuppiP4s");
+  iEvent.put(lPupOut);
+  iEvent.put(p4PupOut);
   edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put( fPuppiCandidates );
   for(unsigned int ic=0, nc = oh->size(); ic < nc; ++ic) {
       reco::CandidatePtr pkref( oh, ic );

--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -181,19 +181,18 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   
   iEvent.put(lPupOut,"PuppiWeights");
   iEvent.put(p4PupOut,"PuppiP4s");
- // iEvent.put(fPuppiCandidates);
-   edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put( fPuppiCandidates );
-
-   for(unsigned int ic=0, nc = oh->size(); ic < nc; ++ic) {
-	reco::CandidatePtr pkref( oh, ic );
-	values[ic] = pkref;
-   }
+  edm::OrphanHandle<reco::PFCandidateCollection> oh = iEvent.put( fPuppiCandidates );
+  for(unsigned int ic=0, nc = oh->size(); ic < nc; ++ic) {
+      reco::CandidatePtr pkref( oh, ic );
+      values[ic] = pkref;
+    
+   }  
   std::auto_ptr<edm::ValueMap<reco::CandidatePtr> > pfMap_p(new edm::ValueMap<reco::CandidatePtr>());
   edm::ValueMap<reco::CandidatePtr>::Filler filler(*pfMap_p);
   filler.insert(hPFProduct, values.begin(), values.end());
   filler.fill();
   iEvent.put(pfMap_p);
-
+  
 }
 
 // ------------------------------------------------------------------------------------------

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -345,6 +345,10 @@ namespace pat {
     virtual bool isConvertedPhoton() const { return false; }
     virtual bool isJet() const { return false; }
 
+    // puppiweight
+    void setPuppiWeight(float p);
+    float puppiWeight() const;
+    
   protected:
     uint16_t packedPt_, packedEta_, packedPhi_, packedM_;
     uint16_t packedDxy_, packedDz_, packedDPhi_;
@@ -359,6 +363,7 @@ namespace pat {
     void packBoth() { pack(false); packVtx(false); unpack(); unpackVtx(); } // do it this way, so that we don't loose precision on the angles before computing dxy,dz
     void unpackTrk() const ;
 
+    int8_t packedPuppiweight_;
     /// the four vector                                                 
     mutable PolarLorentzVector p4_;
     mutable LorentzVector p4c_;

--- a/DataFormats/PatCandidates/interface/liblogintpack.h
+++ b/DataFormats/PatCandidates/interface/liblogintpack.h
@@ -11,8 +11,8 @@ namespace logintpack
                 float l =log(fabs(x));
                 float centered = (l-lmin)/(lmax-lmin)*base;
                 int8_t  r=ceil(centered);
-                if(centered >= base-1) return r=base-1;
-                if(centered < 0) return r=0;
+                if(centered >= base-1) r=base-1;
+                if(centered < 0) r=0;
                 if(x<0) r=-r;
                 return r;
         }
@@ -23,8 +23,8 @@ namespace logintpack
 		float l =log(fabs(x));
 		float centered = (l-lmin)/(lmax-lmin)*base;
 		int8_t  r=centered;
-		if(centered >= base-1) return r=base-1;
-		if(centered < 0) return r=0;
+		if(centered >= base-1) r=base-1;
+		if(centered < 0) r=0;
 		if(x<0) r=-r;
 		return r;
 	}

--- a/DataFormats/PatCandidates/interface/liblogintpack.h
+++ b/DataFormats/PatCandidates/interface/liblogintpack.h
@@ -29,6 +29,21 @@ namespace logintpack
 		return r;
 	}
 
+        /// pack a value x distributed in [-1,1], with guarantee that -1 and 1 are preserved exactly in packing and unpacking.
+        /// tries to keep the best precision for x close to the endpoints, sacrifying that in the middle
+	int8_t pack8logClosed(double x,double lmin, double lmax, uint8_t base=128)
+	{
+	        if(base>128) base=128;
+		float l =log(fabs(x));
+		float centered = (l-lmin)/(lmax-lmin)*(base-1);
+		int8_t  r=round(centered);
+		if(centered >= base-1) r=base-1;
+		if(centered < 0) r=0;
+		if(x<0) r=-r;
+		return r;
+	}
+
+
 	double unpack8log(int8_t i,double lmin, double lmax, uint8_t base=128)
 	{
 	        if(base>128) base=128;
@@ -37,5 +52,17 @@ namespace logintpack
 		float val=exp(l);
 		if(i<0) return -val; else return val;
 	}
+
+        /// reverse of pack8logClosed
+	double unpack8logClosed(int8_t i,double lmin, double lmax, uint8_t base=128)
+	{
+	        if(base>128) base=128;
+	        float basef=base-1;
+		float l=lmin+abs(i)/basef*(lmax-lmin);
+                if (abs(i) == base-1) l = lmax;
+		float val=exp(l);
+		if(i<0) return -val; else return val;
+	}
+
 }
 #endif

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -268,6 +268,8 @@ bool pat::PackedCandidate::longLived() const {return false;}
 
 bool pat::PackedCandidate::massConstraint() const {return false;}
 
+// puppiweight
+void pat::PackedCandidate::setPuppiWeight(float p) { packedPuppiweight_ = pack8log(p,-2,0);}
 
-
+float pat::PackedCandidate::puppiWeight() const { return unpack8log(packedPuppiweight_,-2,0);}
 

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -269,7 +269,7 @@ bool pat::PackedCandidate::longLived() const {return false;}
 bool pat::PackedCandidate::massConstraint() const {return false;}
 
 // puppiweight
-void pat::PackedCandidate::setPuppiWeight(float p) { packedPuppiweight_ = pack8log(p,-2,0);}
+void pat::PackedCandidate::setPuppiWeight(float p) { packedPuppiweight_ = pack8log((p-0.5)*2,-2,0,64);}
 
-float pat::PackedCandidate::puppiWeight() const { return unpack8log(packedPuppiweight_,-2,0);}
+float pat::PackedCandidate::puppiWeight() const { return unpack8log(packedPuppiweight_,-2,0,64)/2. + 0.5;}
 

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -269,7 +269,7 @@ bool pat::PackedCandidate::longLived() const {return false;}
 bool pat::PackedCandidate::massConstraint() const {return false;}
 
 // puppiweight
-void pat::PackedCandidate::setPuppiWeight(float p) { packedPuppiweight_ = pack8log((p-0.5)*2,-2,0,64);}
+void pat::PackedCandidate::setPuppiWeight(float p) { packedPuppiweight_ = pack8logClosed((p-0.5)*2,-2,0,64);}
 
-float pat::PackedCandidate::puppiWeight() const { return unpack8log(packedPuppiweight_,-2,0,64)/2. + 0.5;}
+float pat::PackedCandidate::puppiWeight() const { return unpack8logClosed(packedPuppiweight_,-2,0,64)/2. + 0.5;}
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -252,8 +252,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="16">
-   <version ClassVersion="17" checksum="1633877368"/>
+  <class name="pat::PackedCandidate" ClassVersion="17">
+    <version ClassVersion="17" checksum="1257500115"/>
     <version ClassVersion="16" checksum="3261782486"/>
     <version ClassVersion="15" checksum="2118306102"/>
     <version ClassVersion="14" checksum="1075333340"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -252,7 +252,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="17">
+  <class name="pat::PackedCandidate" ClassVersion="18">
+    <version ClassVersion="18" checksum="1257500115"/>
     <version ClassVersion="17" checksum="1257500115"/>
     <version ClassVersion="16" checksum="3261782486"/>
     <version ClassVersion="15" checksum="2118306102"/>

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -92,7 +92,7 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   PVOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
   TKOrigs_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("originalTracks"))),
   PuppiWeight_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiWeight"))),
-  PuppiCandsMap_(consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
+  PuppiCandsMap_(consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrcMap"))),
   PuppiCands_(consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
   minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
 {

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -225,14 +225,17 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
 
     std::auto_ptr< std::vector<pat::PackedCandidate> > outPtrPSorted( new std::vector<pat::PackedCandidate> );
     std::vector<size_t> order=sort_indexes(*outPtrP);
+    std::vector<size_t> reverseOrder(order.size());
     for(size_t i=0,nc=cands->size();i<nc;i++) {
         outPtrPSorted->push_back((*outPtrP)[order[i]]);
+        reverseOrder[order[i]] = i;
         mappingReverse[order[i]]=i;
+        mappingPuppi[order[i]]=i;
     }
 
     // Fix track association for sorted candidates
     for(size_t i=0,ntk=mappingTk.size();i<ntk;i++){
-        mappingTk[i]=order[mappingTk[i]];
+        mappingTk[i]=reverseOrder[mappingTk[i]]; 
     }
 
     

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -114,9 +114,8 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
     edm::Handle<reco::PFCandidateFwdPtrVector> candsFromPVTight;
     iEvent.getByToken( CandsFromPVTight_, candsFromPVTight );
 
-    bool hasPuppiWeights = false;
     edm::Handle< edm::ValueMap<float> > puppiWeight;
-    if (iEvent.getByToken( PuppiWeight_, puppiWeight )) hasPuppiWeights = true;
+    iEvent.getByToken( PuppiWeight_, puppiWeight );
     
     std::vector<pat::PackedCandidate::PVAssoc> fromPV(cands->size(), pat::PackedCandidate::NoPV);
     for (const reco::PFCandidateFwdPtr &ptr : *candsFromPVLoose) {
@@ -230,7 +229,7 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
           outPtrP->back().setAssociationQuality(pat::PackedCandidate::PVAssociationQuality(pat::PackedCandidate::UsedInFitTight));
         }
 	
-	if (hasPuppiWeights){
+	if (puppiWeight.isValid()){
 	  reco::PFCandidateRef pkref( cands, ic );
 	  outPtrP->back().setPuppiWeight( (*puppiWeight)[pkref]);
 	}

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -91,8 +91,8 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   PVAssoQuality_(consumes<edm::ValueMap<int> >(iConfig.getParameter<edm::InputTag>("vertexAssociator"))),
   PVOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
   TKOrigs_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("originalTracks"))),
-  PuppiWeight_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiWeight"))),
-  PuppiCandsMap_(consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrcMap"))),
+  PuppiWeight_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
+  PuppiCandsMap_(consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
   PuppiCands_(consumes<std::vector< reco::PFCandidate > >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
   minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
 {
@@ -111,11 +111,6 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
     iEvent.getByToken( Cands_, cands );
     std::vector<reco::Candidate>::const_iterator cand;
 
-    edm::Handle<reco::PFCandidateFwdPtrVector> candsFromPVLoose;
-    iEvent.getByToken( CandsFromPVLoose_, candsFromPVLoose );
-    edm::Handle<reco::PFCandidateFwdPtrVector> candsFromPVTight;
-    iEvent.getByToken( CandsFromPVTight_, candsFromPVTight );
-
     edm::Handle< edm::ValueMap<float> > puppiWeight;
     iEvent.getByToken( PuppiWeight_, puppiWeight );
     edm::Handle<edm::ValueMap<reco::CandidatePtr> > puppiCandsMap;
@@ -123,26 +118,6 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
     edm::Handle<std::vector< reco::PFCandidate > > puppiCands;
     iEvent.getByToken( PuppiCands_, puppiCands );
     std::vector<int> mappingPuppi(puppiCands->size());
-
-    std::vector<pat::PackedCandidate::PVAssoc> fromPV(cands->size(), pat::PackedCandidate::NoPV);
-    for (const reco::PFCandidateFwdPtr &ptr : *candsFromPVLoose) {
-        if (ptr.ptr().id() == cands.id()) {
-            fromPV[ptr.ptr().key()]   = pat::PackedCandidate::PVLoose;
-        } else if (ptr.backPtr().id() == cands.id()) {
-            fromPV[ptr.backPtr().key()] = pat::PackedCandidate::PVLoose;
-        } else {
-            throw cms::Exception("Configuration", "The elements from 'inputCollectionFromPVLoose' don't point to 'inputCollection'\n");
-        }
-    }
-    for (const reco::PFCandidateFwdPtr &ptr : *candsFromPVTight) {
-        if (ptr.ptr().id() == cands.id()) {
-            fromPV[ptr.ptr().key()]   = pat::PackedCandidate::PVTight;
-        } else if (ptr.backPtr().id() == cands.id()) {
-            fromPV[ptr.backPtr().key()] = pat::PackedCandidate::PVTight;
-        } else {
-            throw cms::Exception("Configuration", "The elements from 'inputCollectionFromPVTight' don't point to 'inputCollection'\n");
-        }
-    }
 
     edm::Handle<reco::VertexCollection> PVOrigs;
     iEvent.getByToken( PVOrigs_, PVOrigs );

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -70,6 +70,7 @@ namespace pat {
             edm::EDGetTokenT<reco::VertexCollection>         PVOrigs_;
             edm::EDGetTokenT<reco::TrackCollection>          TKOrigs_;
             edm::EDGetTokenT< edm::ValueMap<float> >         PuppiWeight_;
+            edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr> >    PuppiCands_;
 
             double minPtForTrackProperties_;
             // for debugging
@@ -90,6 +91,7 @@ pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::Parameter
   PVOrigs_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("originalVertices"))),
   TKOrigs_(consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("originalTracks"))),
   PuppiWeight_(consumes<edm::ValueMap<float> >(iConfig.getParameter<edm::InputTag>("PuppiWeight"))),
+  PuppiCands_(consumes<edm::ValueMap<reco::CandidatePtr> >(iConfig.getParameter<edm::InputTag>("PuppiSrc"))),
   minPtForTrackProperties_(iConfig.getParameter<double>("minPtForTrackProperties"))
 {
   produces< std::vector<pat::PackedCandidate> > ();
@@ -107,8 +109,6 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
     iEvent.getByToken( Cands_, cands );
     std::vector<reco::Candidate>::const_iterator cand;
 
-<<<<<<< HEAD
-=======
     edm::Handle<reco::PFCandidateFwdPtrVector> candsFromPVLoose;
     iEvent.getByToken( CandsFromPVLoose_, candsFromPVLoose );
     edm::Handle<reco::PFCandidateFwdPtrVector> candsFromPVTight;
@@ -116,7 +116,10 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
 
     edm::Handle< edm::ValueMap<float> > puppiWeight;
     iEvent.getByToken( PuppiWeight_, puppiWeight );
-    
+    edm::Handle<edm::ValueMap<reco::CandidatePtr> > puppiCands;
+    iEvent.getByToken( PuppiCands_, puppiCands );
+    std::vector<int> mappingPuppi(puppiCands->size());
+
     std::vector<pat::PackedCandidate::PVAssoc> fromPV(cands->size(), pat::PackedCandidate::NoPV);
     for (const reco::PFCandidateFwdPtr &ptr : *candsFromPVLoose) {
         if (ptr.ptr().id() == cands.id()) {
@@ -137,7 +140,6 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
         }
     }
 
->>>>>>> 7ee91b6... adding puppi to miniAODs
     edm::Handle<reco::VertexCollection> PVOrigs;
     iEvent.getByToken( PVOrigs_, PVOrigs );
 
@@ -232,11 +234,12 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
 	if (puppiWeight.isValid()){
 	  reco::PFCandidateRef pkref( cands, ic );
 	  outPtrP->back().setPuppiWeight( (*puppiWeight)[pkref]);
+	  mappingPuppi[ic] = ((*puppiCands)[pkref]);
 	}
 	
         mapping[ic] = ic; // trivial at the moment!
         if (cand.trackRef().isNonnull() && cand.trackRef().id() == TKOrigs.id()) {
-          mappingTk[cand.trackRef().key()] = ic;
+	  mappingTk[cand.trackRef().key()] = ic;	    
         }
 
     }
@@ -265,6 +268,7 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
     pc2pfFiller.insert(oh   , order.begin(), order.end());
     // include also the mapping track -> packed PFCand
     pf2pcFiller.insert(TKOrigs, mappingTk.begin(), mappingTk.end());
+    pc2pfFiller.insert(puppiCands, mappingPuppi.begin(), mappingPuppi.end());
 
     pf2pcFiller.fill();
     pc2pfFiller.fill();

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -230,7 +230,6 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
         outPtrPSorted->push_back((*outPtrP)[order[i]]);
         reverseOrder[order[i]] = i;
         mappingReverse[order[i]]=i;
-        mappingPuppi[order[i]]=i;
     }
 
     // Fix track association for sorted candidates
@@ -238,7 +237,10 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
         mappingTk[i]=reverseOrder[mappingTk[i]]; 
     }
 
-    
+    for(size_t i=0,ntk=mappingPuppi.size();i<ntk;i++){
+        mappingPuppi[i]=reverseOrder[mappingPuppi[i]];
+    }
+
     edm::OrphanHandle<pat::PackedCandidateCollection> oh = iEvent.put( outPtrPSorted );
 
     // now build the two maps

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -132,7 +132,43 @@ def miniAOD_customizeCommon(process):
                                makeType1p2corrPFMEt=True,
                                outputModule=None)
 
+    # Adding puppi jets
+    process.load('CommonTools.PileupAlgos.Puppi_cff')
+    process.load('RecoJets.JetProducers.ak4PFJetsPuppi_cfi')
+    #process.puppi.candName = cms.InputTag('packedPFCandidates')
+    #process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 
+    addJetCollection(process, postfix   = "", labelName = 'Puppi', jetSource = cms.InputTag('ak4PFJetsPuppi'),
+                    jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''),
+                    algo= 'AK', rParam = 0.4)
+
+    process.patJetGenJetMatchPuppi.matched =  'slimmedGenJets'
+    process.selectedPatJetsPuppi.cut = cms.string("pt > 20")
+
+    process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
+    process.slimmedJetsPuppi = process.slimmedJets.clone()
+    process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")
+    ## process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("puppi")
+    process.slimmedJetsPuppi.dropDaughters = cms.string("1")
+
+    ## puppi met
+    process.load('RecoMET.METProducers.PFMET_cfi')
+    process.pfMetPuppi = process.pfMet.clone()
+    process.pfMetPuppi.src = cms.InputTag("puppi")
+    process.pfMetPuppi.alias = cms.string('pfMetPuppi')
+
+    from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
+    addMETCollection(process, labelName='patMETPuppi', metSource='pfMetPuppi')
+
+    process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')
+    process.slimmedMETsPuppi = process.slimmedMETs.clone()
+    process.slimmedMETsPuppi.src = cms.InputTag("patMETPuppi")
+    process.slimmedMETsPuppi.rawUncertainties   = cms.InputTag("patPFMet%s")
+    process.slimmedMETsPuppi.type1Uncertainties = cms.InputTag("patPFMetT1%s")
+    process.slimmedMETsPuppi.type1p2Uncertainties = cms.InputTag("patPFMetT1T2%s")
+
+
+    
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars
     process.patJets.userData.userFunctions = cms.vstring(

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -206,20 +206,10 @@ def miniAOD_customizeCommon(process):
 
     process.selectedPatJetsPuppi.cut = cms.string("pt > 20")
 
-    #process.packedPFPuppiCandidates = process.packedPFCandidates.clone()
-    #process.packedPFPuppiCandidates.inputCollection = cms.InputTag("puppi")
-    #process.puppiPtrs = cms.EDProducer("PFCandidateFwdPtrProducer",src = cms.InputTag('puppi'))
-
-
-    process.packedPFCandidates.PuppiSrc = cms.InputTag("puppi")
-    
     process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
     process.slimmedJetsPuppi = process.slimmedJets.clone()
     process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")    
     process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
-    #process.slimmedJetsPuppi.dropDaughters = cms.string("1")
-    #process.slimmedJets.dropDaughters = cms.string("1")
-    process.slimmedJetsAK8.dropDaughters = cms.string("1")
 
     ## puppi met
     process.load('RecoMET.METProducers.PFMET_cfi')

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -132,43 +132,7 @@ def miniAOD_customizeCommon(process):
                                makeType1p2corrPFMEt=True,
                                outputModule=None)
 
-    # Adding puppi jets
-    process.load('CommonTools.PileupAlgos.Puppi_cff')
-    process.load('RecoJets.JetProducers.ak4PFJetsPuppi_cfi')
-    #process.puppi.candName = cms.InputTag('packedPFCandidates')
-    #process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
 
-    addJetCollection(process, postfix   = "", labelName = 'Puppi', jetSource = cms.InputTag('ak4PFJetsPuppi'),
-                    jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''),
-                    algo= 'AK', rParam = 0.4)
-
-    process.patJetGenJetMatchPuppi.matched =  'slimmedGenJets'
-    process.selectedPatJetsPuppi.cut = cms.string("pt > 20")
-
-    process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
-    process.slimmedJetsPuppi = process.slimmedJets.clone()
-    process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")
-    ## process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("puppi")
-    process.slimmedJetsPuppi.dropDaughters = cms.string("1")
-
-    ## puppi met
-    process.load('RecoMET.METProducers.PFMET_cfi')
-    process.pfMetPuppi = process.pfMet.clone()
-    process.pfMetPuppi.src = cms.InputTag("puppi")
-    process.pfMetPuppi.alias = cms.string('pfMetPuppi')
-
-    from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
-    addMETCollection(process, labelName='patMETPuppi', metSource='pfMetPuppi')
-
-    process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')
-    process.slimmedMETsPuppi = process.slimmedMETs.clone()
-    process.slimmedMETsPuppi.src = cms.InputTag("patMETPuppi")
-    process.slimmedMETsPuppi.rawUncertainties   = cms.InputTag("patPFMet%s")
-    process.slimmedMETsPuppi.type1Uncertainties = cms.InputTag("patPFMetT1%s")
-    process.slimmedMETsPuppi.type1p2Uncertainties = cms.InputTag("patPFMetT1T2%s")
-
-
-    
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars
     process.patJets.userData.userFunctions = cms.vstring(
@@ -210,6 +174,70 @@ def miniAOD_customizeCommon(process):
     for idmod in electron_ids:
         setupAllVIDIdsInModule(process,idmod,setupVIDElectronSelection)
 
+    # Adding puppi jets
+    process.load('CommonTools.PileupAlgos.Puppi_cff')
+    process.load('RecoJets.JetProducers.ak4PFJetsPuppi_cfi')
+    #process.puppi.candName = cms.InputTag('packedPFCandidates')
+    #process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
+
+    from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
+    process.ak4PFJetsPuppiTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
+        j2tParametersVX,
+        jets = cms.InputTag("ak4PFJetsPuppi")
+    )
+    process.patJetPuppiCharge = cms.EDProducer("JetChargeProducer",
+        src = cms.InputTag("ak4PFJetsPuppiTracksAssociatorAtVertex"),
+        var = cms.string('Pt'),
+        exp = cms.double(1.0)
+    )
+
+    addJetCollection(process, postfix   = "", labelName = 'Puppi', jetSource = cms.InputTag('ak4PFJetsPuppi'),
+                    jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''),
+                    algo= 'AK', rParam = 0.4,
+                    btagDiscriminators = [
+                    'combinedSecondaryVertexBJetTags'
+                    , 'pfJetBProbabilityBJetTags'
+                    , 'pfJetProbabilityBJetTags'
+                    , 'pfTrackCountingHighPurBJetTags'
+                    , 'pfTrackCountingHighEffBJetTags'
+                    , 'pfSimpleSecondaryVertexHighEffBJetTags'
+                    , 'pfSimpleSecondaryVertexHighPurBJetTags'
+                    , 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
+                    , 'pfCombinedMVABJetTags'
+                    ]
+                    )
+
+    process.patJetGenJetMatchPuppi.matched =  'slimmedGenJets'
+
+    process.patJetsPuppi.userData = process.patJets.userData
+    process.patJetsPuppi.userData.userFloats.src = cms.VInputTag("")
+    process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
+    process.patJetsPuppi.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfosPuppi"))
+    process.patJetsPuppi.addTagInfos = cms.bool(True)
+
+    process.selectedPatJetsPuppi.cut = cms.string("pt > 20")
+
+    process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
+    process.slimmedJetsPuppi = process.slimmedJets.clone()
+    process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")
+    ## process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("puppi")
+    process.slimmedJetsPuppi.dropDaughters = cms.string("1")
+
+    ## puppi met
+    process.load('RecoMET.METProducers.PFMET_cfi')
+    process.pfMetPuppi = process.pfMet.clone()
+    process.pfMetPuppi.src = cms.InputTag("puppi")
+    process.pfMetPuppi.alias = cms.string('pfMetPuppi')
+
+    from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
+    addMETCollection(process, labelName='patMETPuppi', metSource='pfMetPuppi')
+
+    process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')
+    process.slimmedMETsPuppi = process.slimmedMETs.clone()
+    process.slimmedMETsPuppi.src = cms.InputTag("patMETPuppi")
+    process.slimmedMETsPuppi.rawUncertainties   = cms.InputTag("patPFMet%s")
+    process.slimmedMETsPuppi.type1Uncertainties = cms.InputTag("patPFMetT1%s")
+    process.slimmedMETsPuppi.type1p2Uncertainties = cms.InputTag("patPFMetT1T2%s")
 
 
 def miniAOD_customizeMC(process):

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -176,10 +176,11 @@ def miniAOD_customizeCommon(process):
 
     # Adding puppi jets
     process.load('CommonTools.PileupAlgos.Puppi_cff')
+    process.patCandidates += process.puppi
     process.load('RecoJets.JetProducers.ak4PFJetsPuppi_cfi')
     #process.puppi.candName = cms.InputTag('packedPFCandidates')
     #process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
-
+    
     from RecoJets.JetAssociationProducers.j2tParametersVX_cfi import j2tParametersVX
     process.ak4PFJetsPuppiTracksAssociatorAtVertex = cms.EDProducer("JetTracksAssociatorAtVertex",
         j2tParametersVX,
@@ -196,21 +197,29 @@ def miniAOD_customizeCommon(process):
                     algo= 'AK', rParam = 0.4, btagDiscriminators = map(lambda x: x.value() ,process.patJets.discriminatorSources)
                     )
     
-    process.patJetGenJetMatchPuppi.matched =  'slimmedGenJets'
-
-    process.patJetsPuppi.userData = process.patJets.userData
-    process.patJetsPuppi.userData.userFloats.src = cms.VInputTag("")
+    process.patJetGenJetMatchPuppi.matched = 'slimmedGenJets'
+    
+    process.patJetsPuppi.userData.userFloats.src = cms.VInputTag(cms.InputTag(""))
     process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
     process.patJetsPuppi.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfosPuppi"))
     process.patJetsPuppi.addTagInfos = cms.bool(True)
 
     process.selectedPatJetsPuppi.cut = cms.string("pt > 20")
 
+    #process.packedPFPuppiCandidates = process.packedPFCandidates.clone()
+    #process.packedPFPuppiCandidates.inputCollection = cms.InputTag("puppi")
+    #process.puppiPtrs = cms.EDProducer("PFCandidateFwdPtrProducer",src = cms.InputTag('puppi'))
+
+
+    process.packedPFCandidates.PuppiSrc = cms.InputTag("puppi")
+    
     process.load('PhysicsTools.PatAlgos.slimming.slimmedJets_cfi')
     process.slimmedJetsPuppi = process.slimmedJets.clone()
-    process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")
-    ## process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("puppi")
-    process.slimmedJetsPuppi.dropDaughters = cms.string("1")
+    process.slimmedJetsPuppi.src = cms.InputTag("selectedPatJetsPuppi")    
+    process.slimmedJetsPuppi.packedPFCandidates = cms.InputTag("packedPFCandidates")
+    #process.slimmedJetsPuppi.dropDaughters = cms.string("1")
+    #process.slimmedJets.dropDaughters = cms.string("1")
+    process.slimmedJetsAK8.dropDaughters = cms.string("1")
 
     ## puppi met
     process.load('RecoMET.METProducers.PFMET_cfi')

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -193,20 +193,9 @@ def miniAOD_customizeCommon(process):
 
     addJetCollection(process, postfix   = "", labelName = 'Puppi', jetSource = cms.InputTag('ak4PFJetsPuppi'),
                     jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''),
-                    algo= 'AK', rParam = 0.4,
-                    btagDiscriminators = [
-                    'combinedSecondaryVertexBJetTags'
-                    , 'pfJetBProbabilityBJetTags'
-                    , 'pfJetProbabilityBJetTags'
-                    , 'pfTrackCountingHighPurBJetTags'
-                    , 'pfTrackCountingHighEffBJetTags'
-                    , 'pfSimpleSecondaryVertexHighEffBJetTags'
-                    , 'pfSimpleSecondaryVertexHighPurBJetTags'
-                    , 'pfCombinedInclusiveSecondaryVertexV2BJetTags'
-                    , 'pfCombinedMVABJetTags'
-                    ]
+                    algo= 'AK', rParam = 0.4, btagDiscriminators = map(lambda x: x.value() ,process.patJets.discriminatorSources)
                     )
-
+    
     process.patJetGenJetMatchPuppi.matched =  'slimmedGenJets'
 
     process.patJetsPuppi.userData = process.patJets.userData

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -176,7 +176,6 @@ def miniAOD_customizeCommon(process):
 
     # Adding puppi jets
     process.load('CommonTools.PileupAlgos.Puppi_cff')
-    process.patCandidates += process.puppi
     process.load('RecoJets.JetProducers.ak4PFJetsPuppi_cfi')
     #process.puppi.candName = cms.InputTag('packedPFCandidates')
     #process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -6,5 +6,8 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     originalVertices = cms.InputTag("offlinePrimaryVertices"),
     originalTracks = cms.InputTag("generalTracks"),
     vertexAssociator = cms.InputTag("primaryVertexAssociation","original"),
+    PuppiWeight = cms.InputTag("puppi","PuppiWeights"),
+    PuppiSrc = cms.InputTag("puppi"),
+    PuppiSrcMap = cms.InputTag("puppi"),
     minPtForTrackProperties = cms.double(0.95)
 )

--- a/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/packedPFCandidates_cfi.py
@@ -6,8 +6,6 @@ packedPFCandidates = cms.EDProducer("PATPackedCandidateProducer",
     originalVertices = cms.InputTag("offlinePrimaryVertices"),
     originalTracks = cms.InputTag("generalTracks"),
     vertexAssociator = cms.InputTag("primaryVertexAssociation","original"),
-    PuppiWeight = cms.InputTag("puppi","PuppiWeights"),
     PuppiSrc = cms.InputTag("puppi"),
-    PuppiSrcMap = cms.InputTag("puppi"),
     minPtForTrackProperties = cms.double(0.95)
 )


### PR DESCRIPTION
added puppi jet collection and puppi met into miniAODs

added jet charge, btagging, secondary vertex info and daughter links for puppi jets

added puppi weights as packed 8 bit into packcandidates

removed labels in puppi producer since only three different types of objects are produced

fixed the packing for liblogintpack, negative values were being lost

updated PackedCandidate ClassVersion to 17

added new iputs to PATPackedCandidateProducer, (PuppiWeight, PuppiCandsMap and PuppiCands) to save puppi weights into packcandidates and ValueMap for puppi to be able to map back to the puppi candidates from puppi jets to packcandidates
