### PR TITLE
Fix build error and align checksums and versions with ROOT5

### DIFF
--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -29,8 +29,9 @@
    <version ClassVersion="10" checksum="1002280074"/>
   </class>
   <class name="edm::Wrapper<reco::PdfInfo>" />
-  <class name="reco::FlavorHistory"  ClassVersion="11">
-   <version ClassVersion="11" checksum="699034420"/>
+  <class name="reco::FlavorHistory"  ClassVersion="12">
+   <version ClassVersion="12" checksum="699034420"/>
+   <version ClassVersion="11" checksum="425358630"/>
    <version ClassVersion="10" checksum="425358630"/>
   </class>
   <class name="std::vector<reco::FlavorHistory>" />

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -18,7 +18,7 @@
   <!-- PAT Objects, and embedded data  -->
   <class name="pat::Electron"  ClassVersion="28">
    <version ClassVersion="28" checksum="2518240031"/>
-   <version ClassVersion="27" checksum="2628480167"/>
+   <version ClassVersion="27" checksum="3863179876"/>
    <field name="superClusterRelinked_" transient="true"/>
    <version ClassVersion="26" checksum="2045819644"/>
    <version ClassVersion="25" checksum="1488101799"/>
@@ -43,7 +43,7 @@
 
   <class name="pat::Muon"  ClassVersion="16">
    <version ClassVersion="16" checksum="2674665735"/>
-   <version ClassVersion="15" checksum="2088272079"/>
+   <version ClassVersion="15" checksum="1248517999"/>
    <version ClassVersion="14" checksum="132269943"/>
    <version ClassVersion="13" checksum="2943499125"/>
    <version ClassVersion="12" checksum="462627330"/>
@@ -142,7 +142,7 @@
 
   <class name="pat::Jet"  ClassVersion="15">
    <version ClassVersion="15" checksum="1826981639"/>
-   <version ClassVersion="14" checksum="766989023"/>
+   <version ClassVersion="14" checksum="1304049301"/>
    <version ClassVersion="13" checksum="130552029"/>
    <field name="caloTowersTemp_" transient="true"/>
    <field name="pfCandidatesTemp_" transient="true"/>
@@ -182,7 +182,7 @@
   </class>
   <class name="pat::PFParticle"  ClassVersion="13">
    <version ClassVersion="13" checksum="223824921"/>
-   <version ClassVersion="12" checksum="2881263841"/>
+   <version ClassVersion="12" checksum="4118931093"/>
    <version ClassVersion="11" checksum="2923110109"/>
    <version ClassVersion="10" checksum="2240381542"/>
   </class>
@@ -240,7 +240,8 @@
     ]]>
   </ioread>
 
-  <class name="pat::PackedGenParticle" ClassVersion="11">
+  <class name="pat::PackedGenParticle" ClassVersion="12">
+    <version ClassVersion="12" checksum="2626711017"/>
     <version ClassVersion="11" checksum="25552245"/>
     <version ClassVersion="10" checksum="389883266"/>
     <field name="p4_" transient="true" />

--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -2,7 +2,7 @@
   
   <class name="reco::PFTau" ClassVersion="18">
    <version ClassVersion="18" checksum="1318776182"/>
-   <version ClassVersion="17" checksum="2612600958"/>
+   <version ClassVersion="17" checksum="1523260402"/>
     <version ClassVersion="16" checksum="2695990650"/>
     <version ClassVersion="15" checksum="4105994460"/>
     <version ClassVersion="14" checksum="3087106015"/>
@@ -250,7 +250,7 @@ isolationTauChargedHadronCandidates_.clear();
 
   <class name="reco::PFTauDecayMode" ClassVersion="13">
    <version ClassVersion="13" checksum="3507751092"/>
-   <version ClassVersion="12" checksum="1678823548"/>
+   <version ClassVersion="12" checksum="2043565930"/>
    <version ClassVersion="11" checksum="3414615810"/>
    <version ClassVersion="10" checksum="2108215737"/>
   </class>
@@ -267,7 +267,7 @@ isolationTauChargedHadronCandidates_.clear();
 
   <class name="reco::RecoTauPiZero" ClassVersion="13">
    <version ClassVersion="13" checksum="3687187514"/>
-   <version ClassVersion="12" checksum="263073298"/>
+   <version ClassVersion="12" checksum="453348937"/>
    <version ClassVersion="11" checksum="2458276705"/>
    <version ClassVersion="10" checksum="465425628"/>
   </class>
@@ -281,7 +281,7 @@ isolationTauChargedHadronCandidates_.clear();
 
   <class name="reco::PFRecoTauChargedHadron" ClassVersion="14">
    <version ClassVersion="14" checksum="3665832588"/>
-   <version ClassVersion="13" checksum="2433815140"/>
+   <version ClassVersion="13" checksum="591384956"/>
    <version ClassVersion="12" checksum="2480143236" />
    <version ClassVersion="11" checksum="858406271" />
    <version ClassVersion="10" checksum="4027987990"/>

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -6,8 +6,9 @@
   <class name="reco::TrackResiduals" ClassVersion="10">
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
-  <class name="reco::TrackBase" ClassVersion="13">
-   <version ClassVersion="13" checksum="3929365050"/>
+  <class name="reco::TrackBase" ClassVersion="14">
+   <version ClassVersion="14" checksum="3929365050"/>
+   <version ClassVersion="13" checksum="1244921154"/>
    <version ClassVersion="12" checksum="2704717983"/>
     <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
     <field name="momentum_" iotype="ROOT::Math::DisplacementVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 


### PR DESCRIPTION
This pull request fixes the build error in DataFormats/PatCandidates, and also aligns versions and checksums with those in ROOT 5 in four packages in which some ROOT 5 class versions or checksums were incorrect or missing.
Please merge this request as soon as convenient.
