### PR TITLE
Add new ROOT6 checksum to XML spec

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -235,6 +235,7 @@
   </ioread>
 
   <class name="pat::PackedGenParticle" ClassVersion="11">
+    <version ClassVersion="12" checksum="2626711017"/>
     <version ClassVersion="11" checksum="25552245"/>
     <version ClassVersion="10" checksum="389883266"/>
     <field name="p4_" transient="true" />


### PR DESCRIPTION
In order to avoid version clashes that can cause fatal run-time errors, the ROOT6 versions for classes need to be specified in the ROOT5 spec files (with the correct checksums).  This prevents adding a new version in ROOT 5 where the version number conflicts with a ROOT6 version.
One class, pat::PackedGenParticle, has a new class version in ROOT6.  This pull request simply adds it to the ROOT5 spec file.  Neither the ROOT5 version or checksum is changed.
