### PR TITLE
Fastsim fix ele track ref

### DIFF
--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -203,7 +203,24 @@ electronGsfTracks.src = 'electronGSGsfTrackCandidates'
 electronGsfTracks.TTRHBuilder = 'WithoutRefit'
 electronGsfTracks.TrajectoryInEvent = True
 
+from RecoParticleFlow.PFTracking.trackerDrivenElectronSeeds_cff import *
+from RecoParticleFlow.PFTracking.mergedElectronSeeds_cfi import *
 
+trackerDrivenElectronSeedsTmp = trackerDrivenElectronSeeds
+trackerDrivenElectronSeedsTmp.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
+trackerDrivenElectronSeeds = cms.EDProducer(
+    "ElectronSeedTrackRefFix",
+    PreGsfLabel = trackerDrivenElectronSeedsTmp.PreGsfLabel,
+    PreIdLabel = trackerDrivenElectronSeedsTmp.PreIdLabel,
+    oldTrackCollection = trackerDrivenElectronSeedsTmp.TkColList[0],
+    newTrackCollection = cms.InputTag("generalTracks"),
+    seedCollection = cms.InputTag("trackerDrivenElectronSeedsTmp",trackerDrivenElectronSeedsTmp.PreGsfLabel.value()),
+    idCollection = cms.InputTag("trackerDrivenElectronSeedsTmp",trackerDrivenElectronSeedsTmp.PreIdLabel.value())
+    )
+print trackerDrivenElectronSeeds.seedCollection
+print trackerDrivenElectronSeeds.idCollection
+
+    
 # PF related electron sequences defined in FastSimulation.ParticleFlow.ParticleFlowFastSim_cff
 from RecoEgamma.ElectronIdentification.electronIdSequence_cff import *
 
@@ -219,6 +236,7 @@ famosGsfTrackSequence = cms.Sequence(
     newCombinedSeeds+
     particleFlowCluster+
     ecalDrivenElectronSeeds+
+    trackerDrivenElectronSeedsTmp+
     trackerDrivenElectronSeeds+
     electronMergedSeeds+
     electronGSGsfTrackCandidates+

--- a/FastSimulation/Configuration/python/FamosSequences_cff.py
+++ b/FastSimulation/Configuration/python/FamosSequences_cff.py
@@ -206,7 +206,7 @@ electronGsfTracks.TrajectoryInEvent = True
 from RecoParticleFlow.PFTracking.trackerDrivenElectronSeeds_cff import *
 from RecoParticleFlow.PFTracking.mergedElectronSeeds_cfi import *
 
-trackerDrivenElectronSeedsTmp = trackerDrivenElectronSeeds
+trackerDrivenElectronSeedsTmp = trackerDrivenElectronSeeds.clone()
 trackerDrivenElectronSeedsTmp.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
 trackerDrivenElectronSeeds = cms.EDProducer(
     "ElectronSeedTrackRefFix",
@@ -217,9 +217,6 @@ trackerDrivenElectronSeeds = cms.EDProducer(
     seedCollection = cms.InputTag("trackerDrivenElectronSeedsTmp",trackerDrivenElectronSeedsTmp.PreGsfLabel.value()),
     idCollection = cms.InputTag("trackerDrivenElectronSeedsTmp",trackerDrivenElectronSeedsTmp.PreIdLabel.value())
     )
-print trackerDrivenElectronSeeds.seedCollection
-print trackerDrivenElectronSeeds.idCollection
-
     
 # PF related electron sequences defined in FastSimulation.ParticleFlow.ParticleFlowFastSim_cff
 from RecoEgamma.ElectronIdentification.electronIdSequence_cff import *

--- a/FastSimulation/ParticleFlow/python/ParticleFlowFastSimNeutralHadron_cff.py
+++ b/FastSimulation/ParticleFlow/python/ParticleFlowFastSimNeutralHadron_cff.py
@@ -9,8 +9,6 @@ from RecoParticleFlow.PFProducer.particleFlowBlock_cff import *
 from RecoParticleFlow.PFProducer.particleFlow_cff import *
 from RecoParticleFlow.PFProducer.pfElectronTranslator_cff import *
 from RecoParticleFlow.PFProducer.pfPhotonTranslator_cff import *
-from RecoParticleFlow.PFTracking.trackerDrivenElectronSeeds_cff import *
-from RecoParticleFlow.PFTracking.mergedElectronSeeds_cfi import *
 from FastSimulation.ParticleFlow.FSparticleFlow_cfi import *
 from RecoParticleFlow.PFClusterProducer.towerMakerPF_cfi import *
 # The following is replaced by the MVA-based 
@@ -52,10 +50,6 @@ particleFlowRecHitHF.producers[0].qualityTests =cms.VPSet(
 #particleFlow.usePFNuclearInteractions = cms.bool(True)
 #particleFlow.usePFConversions = cms.bool(True)
 #particleFlow.usePFDecays = cms.bool(True)
-
-### With the new mixing scheme, the label of the Trajectory collection for the primary event is different:
-trackerDrivenElectronSeeds.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
-
 
 famosParticleFlowSequence = cms.Sequence(
     caloTowersRec+

--- a/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
+++ b/FastSimulation/ParticleFlow/python/ParticleFlowFastSim_cff.py
@@ -9,8 +9,6 @@ from RecoParticleFlow.PFProducer.particleFlowBlock_cff import *
 from RecoParticleFlow.PFProducer.particleFlow_cff import *
 from RecoParticleFlow.PFProducer.pfElectronTranslator_cff import *
 from RecoParticleFlow.PFProducer.pfPhotonTranslator_cff import *
-from RecoParticleFlow.PFTracking.trackerDrivenElectronSeeds_cff import *
-from RecoParticleFlow.PFTracking.mergedElectronSeeds_cfi import *
 #from FastSimulation.ParticleFlow.FSparticleFlow_cfi import *
 from RecoParticleFlow.PFClusterProducer.towerMakerPF_cfi import *
 # The following is replaced by the MVA-based 
@@ -54,8 +52,6 @@ particleFlowRecHitHF.producers[0].qualityTests =cms.VPSet(
 #particleFlow.usePFDecays = cms.bool(True)
 
 ### With the new mixing scheme, the label of the Trajectory collection for the primary event is different:
-trackerDrivenElectronSeeds.TkColList = cms.VInputTag(cms.InputTag("generalTracksBeforeMixing"))
-
 
 famosParticleFlowSequence = cms.Sequence(
     caloTowersRec+

--- a/FastSimulation/Tracking/BuildFile.xml
+++ b/FastSimulation/Tracking/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
+<use   name="DataFormats/EgammaReco"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.cc
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.cc
@@ -1,0 +1,142 @@
+#include "FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h"
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/ParticleFlowReco/interface/PreId.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeed.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+//
+// class declaration
+//
+
+
+
+
+//
+// constructors and destructor
+//
+
+using namespace std;
+using namespace reco;
+using namespace edm;
+
+ElectronSeedTrackRefFix::ElectronSeedTrackRefFix(const edm::ParameterSet& iConfig)
+{
+  // read parameters
+  preidgsfLabel = iConfig.getParameter<string>("PreGsfLabel");
+  preidLabel= iConfig.getParameter<string>("PreIdLabel");
+  oldTracksTag = iConfig.getParameter<InputTag>("oldTrackCollection");
+  newTracksTag = iConfig.getParameter<InputTag>("newTrackCollection");
+  seedsTag = iConfig.getParameter<InputTag>("seedCollection");
+  idsTag = iConfig.getParameter<InputTag>("idCollection");
+  
+  //register your products
+  produces<reco::ElectronSeedCollection>(preidgsfLabel);
+  produces<reco::PreIdCollection>(preidLabel);
+  produces<ValueMap<reco::PreIdRef> >(preidLabel);
+
+  //create tokens
+  oldTracksToken = consumes<reco::TrackCollection>(oldTracksTag);
+  newTracksToken = consumes<reco::TrackCollection>(newTracksTag);
+  seedsToken = consumes<reco::ElectronSeedCollection>(seedsTag);
+  idsToken = consumes<reco::PreIdCollection >(idsTag);
+  idMapToken = consumes<ValueMap<reco::PreIdRef> >(idsTag) ;
+}
+
+
+ElectronSeedTrackRefFix::~ElectronSeedTrackRefFix()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called to produce the data  ------------
+void
+ElectronSeedTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  using namespace edm;
+
+   Handle<TrackCollection> oldTracks;
+   iEvent.getByToken(oldTracksToken,oldTracks);
+
+   Handle<TrackCollection> newTracks;
+   iEvent.getByToken(newTracksToken,newTracks);
+   
+   Handle<ElectronSeedCollection> iSeeds;
+   iEvent.getByToken(seedsToken,iSeeds);
+   
+   Handle<PreIdCollection > iIds;
+   iEvent.getByToken(idsToken,iIds);
+   
+   Handle<ValueMap<PreIdRef> > iIdMap;
+   iEvent.getByToken(idMapToken,iIdMap);
+
+  auto_ptr<ElectronSeedCollection> oSeeds(new ElectronSeedCollection);
+  auto_ptr<PreIdCollection> oIds(new PreIdCollection);
+  auto_ptr<ValueMap<PreIdRef> > oIdMap(new ValueMap<PreIdRef>);
+
+   ValueMap<PreIdRef>::Filler mapFiller(*oIdMap);
+   
+   for(unsigned int s = 0;s<iSeeds->size();++s){
+     oSeeds->push_back(iSeeds->at(s));
+     TrackRef newTrackRef(newTracks,oSeeds->back().ctfTrack().index());
+     oSeeds->back().setCtfTrack(newTrackRef);
+   }
+
+   for(unsigned int i = 0;i<iIds->size();++i){
+     oIds->push_back(iIds->at(i));
+     TrackRef newTrackRef(newTracks,oIds->back().trackRef().index());
+     oIds->back().setTrack(newTrackRef);
+   }
+
+   iEvent.put(oSeeds,preidgsfLabel);
+   const edm::OrphanHandle<reco::PreIdCollection> preIdProd = iEvent.put(oIds,preidLabel);
+
+   vector<PreIdRef> values;
+   for(unsigned int t = 0;t<newTracks->size();++t){
+     if(t < oldTracks->size()){
+       TrackRef oldTrackRef(oldTracks,t);
+       values.push_back(PreIdRef(preIdProd,(*(iIdMap.product()))[oldTrackRef].index()));
+     }
+     else{
+       values.push_back(PreIdRef());
+     }
+   }
+   mapFiller.insert(newTracks,values.begin(),values.end());
+   mapFiller.fill();
+
+   iEvent.put(oIdMap,preidLabel);
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+ElectronSeedTrackRefFix::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+ElectronSeedTrackRefFix::endJob() {
+}
+ 
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+ElectronSeedTrackRefFix::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
@@ -1,0 +1,46 @@
+// system include files
+#ifndef FastSimulation_Tracking_ElectronSeedTrackRefFix_h
+#define FastSimulation_Tracking_ElectronSeedTrackRefFix_h
+
+
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "DataFormats/ParticleFlowReco/interface/PreIdFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "DataFormats/Common/interface/ValueMap.h"
+
+
+class ElectronSeedTrackRefFix : public edm::EDProducer {
+public:
+  explicit ElectronSeedTrackRefFix(const edm::ParameterSet&);
+  ~ElectronSeedTrackRefFix();
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+private:
+  virtual void beginJob() override;
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void endJob() override;
+    
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<reco::TrackCollection > newTracksToken;
+  edm::EDGetTokenT<reco::TrackCollection > oldTracksToken;
+  edm::EDGetTokenT<reco::ElectronSeedCollection > seedsToken;
+  edm::EDGetTokenT<reco::PreIdCollection > idsToken;
+  edm::EDGetTokenT<edm::ValueMap<reco::PreIdRef>  > idMapToken;
+
+  std::string preidgsfLabel;
+  std::string preidLabel;
+  edm::InputTag oldTracksTag;
+  edm::InputTag newTracksTag;
+  edm::InputTag seedsTag;
+  edm::InputTag idsTag;
+  
+};
+
+#endif

--- a/FastSimulation/Tracking/plugins/SealModule.cc
+++ b/FastSimulation/Tracking/plugins/SealModule.cc
@@ -3,12 +3,14 @@
 #include "FastSimulation/Tracking/plugins/TrackCandidateProducer.h"
 #include "FastSimulation/Tracking/plugins/PixelTracksProducer.h"
 #include "FastSimulation/Tracking/plugins/SimTrackIdProducer.h"
+#include "FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h"
 // reco::Track accumulator:
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "FastSimulation/Tracking/plugins/RecoTrackAccumulator.h"
 
 
 DEFINE_FWK_MODULE(TrajectorySeedProducer);
+DEFINE_FWK_MODULE(ElectronSeedTrackRefFix);
 DEFINE_FWK_MODULE(TrackCandidateProducer);
 DEFINE_FWK_MODULE(PixelTracksProducer);
 DEFINE_FWK_MODULE(SimTrackIdProducer);


### PR DESCRIPTION
This fixes an issue that caused gsfElectrons with tracker-driven seeds not to be considered as electrons by the particle flow, because a broken link between gsfElectron and recoTrack. 

In FastSim, Tracker-driven electron seeds are produced from the track collection before pile-up mixing,
because the algorithm depends on trajectories which are only available before mixing.
Because of this, tracker-driven electrons are linked to the track collection before pile-up mixing.
Particle flow only considers the after-mixing track collection and thus gets confused.

To fix this, A new module, ElectronSeedTrackRefFix, is implemented and inserted in the electron reconstruction sequence. This modules makes a copy of the tracker-driven electron seeds while replacing in each seed,
the reference to the "before mixing" track with a reference to the corresponding "after mixing" track.
