### PR TITLE
Fastsim prepare datamixer for fastsim

### DIFF
--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.cc
@@ -4,7 +4,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC) :
-  Input_(conf.getParameter<edm::InputTag>("Input")),
+  InputSignal_(conf.getParameter<edm::InputTag>("InputSignal")),
+  InputPileUp_(conf.getParameter<edm::InputTag>("InputPileUp")),
   GeneralTrackOutput_(conf.getParameter<std::string>("GeneralTrackOutput")),
   HitOutput_(conf.getParameter<std::string>("HitOutput")),
   GeneralTrackExtraOutput_(conf.getParameter<std::string>("GeneralTrackExtraOutput"))
@@ -14,9 +15,9 @@ RecoTrackAccumulator::RecoTrackAccumulator(const edm::ParameterSet& conf, edm::o
   mixMod.produces<TrackingRecHitCollection>(HitOutput_);
   mixMod.produces<reco::TrackExtraCollection>(GeneralTrackExtraOutput_);
 
-  iC.consumes<reco::TrackCollection>(Input_);
-  iC.consumes<TrackingRecHitCollection>(Input_);
-  iC.consumes<reco::TrackExtraCollection>(Input_);
+  iC.consumes<reco::TrackCollection>(InputSignal_);
+  iC.consumes<TrackingRecHitCollection>(InputSignal_);
+  iC.consumes<reco::TrackExtraCollection>(InputSignal_);
 }
   
 RecoTrackAccumulator::~RecoTrackAccumulator() {
@@ -36,12 +37,12 @@ void RecoTrackAccumulator::initializeEvent(edm::Event const& e, edm::EventSetup 
 }
   
 void RecoTrackAccumulator::accumulate(edm::Event const& e, edm::EventSetup const& iSetup) {
-    accumulateEvent( e, iSetup);
+  accumulateEvent( e, iSetup,InputSignal_);
 }
 
 void RecoTrackAccumulator::accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& iSetup, edm::StreamID const&) {
   if (e.bunchCrossing()==0) {
-    accumulateEvent( e, iSetup);
+    accumulateEvent( e, iSetup,InputPileUp_);
   }
 }
 
@@ -54,12 +55,12 @@ void RecoTrackAccumulator::finalizeEvent(edm::Event& e, const edm::EventSetup& i
 }
 
 
-template<class T> void RecoTrackAccumulator::accumulateEvent(const T& e, edm::EventSetup const& iSetup) {
+template<class T> void RecoTrackAccumulator::accumulateEvent(const T& e, edm::EventSetup const& iSetup,const edm::InputTag & label) {
 
   edm::Handle<reco::TrackCollection> tracks;
   edm::Handle<TrackingRecHitCollection> hits;
   edm::Handle<reco::TrackExtraCollection> trackExtras;
-  if(!(e.getByLabel(Input_, tracks) and e.getByLabel(Input_, hits) and e.getByLabel(Input_, trackExtras))){
+  if(!(e.getByLabel(label, tracks) and e.getByLabel(label, hits) and e.getByLabel(label, trackExtras))){
     edm::LogError ("Failed to find track, hit or trackExtra collections");
     exit(1);
   }

--- a/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
+++ b/FastSimulation/Tracking/plugins/RecoTrackAccumulator.h
@@ -46,7 +46,7 @@ class RecoTrackAccumulator : public DigiAccumulatorMixMod
   virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c);
   
  private:
-  template<class T> void accumulateEvent(const T& e, edm::EventSetup const& c);
+  template<class T> void accumulateEvent(const T& e, edm::EventSetup const& c,const edm::InputTag & label);
 
   std::auto_ptr<reco::TrackCollection> NewTrackList_;
   std::auto_ptr<reco::TrackExtraCollection> NewTrackExtraList_;
@@ -55,7 +55,8 @@ class RecoTrackAccumulator : public DigiAccumulatorMixMod
   reco::TrackExtraRefProd rTrackExtras;
   TrackingRecHitRefProd rHits;
 
-  edm::InputTag Input_;
+  edm::InputTag InputSignal_;
+  edm::InputTag InputPileUp_;
 
   std::string GeneralTrackOutput_;
   std::string HitOutput_;

--- a/FastSimulation/Tracking/python/recoTrackAccumulator_cfi.py
+++ b/FastSimulation/Tracking/python/recoTrackAccumulator_cfi.py
@@ -7,7 +7,8 @@
 import FWCore.ParameterSet.Config as cms
 
 recoTrackAccumulator = cms.PSet(
-    Input = cms.InputTag("generalTracksBeforeMixing"),
+    InputSignal = cms.InputTag("generalTracksBeforeMixing"),
+    InputPileUp = cms.InputTag("generalTracksBeforeMixing"),
 
     GeneralTrackOutput = cms.string("generalTracks"),
     GeneralTrackExtraOutput = cms.string("generalTracks"),

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -172,18 +172,16 @@ namespace edm
 
     MuonWorker_ = new DataMixingMuonWorker(ps, consumesCollector());
 
-    // Si-Strips
-
-    useSiStripRawDigi_ = ps.exists("SiStripRawDigiSource")?
-      ps.getParameter<std::string>("SiStripRawDigiSource")=="PILEUP" ||
-      ps.getParameter<std::string>("SiStripRawDigiSource")=="SIGNAL" : false;
-
-    SiStripDigiCollectionDM_  = ps.getParameter<std::string>("SiStripDigiCollectionDM");
-
-
 
     if(MergeTrackerDigis_) {
 
+      // Si-Strips
+
+      useSiStripRawDigi_ = ps.exists("SiStripRawDigiSource")?
+	ps.getParameter<std::string>("SiStripRawDigiSource")=="PILEUP" ||
+	ps.getParameter<std::string>("SiStripRawDigiSource")=="SIGNAL" : false;
+      
+      SiStripDigiCollectionDM_  = ps.getParameter<std::string>("SiStripDigiCollectionDM");
 
       if(useSiStripRawDigi_) {
 	

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.cc
@@ -25,7 +25,10 @@
 //
 #include "SimDataFormats/CrossingFrame/interface/CrossingFramePlaybackInfoNew.h"
 #include "DataMixingModule.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
 
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 
 using namespace std;
 
@@ -43,6 +46,7 @@ namespace edm
     ZDCPileInputTag_(ps.getParameter<edm::InputTag>("ZDCPileInputTag")),
 							    label_(ps.getParameter<std::string>("Label"))
   {  
+
     // prepare for data access in DataMixingEcalDigiWorkerProd
     tok_eb_ = consumes<EBDigitizerTraits::DigiCollection>(EBPileInputTag_);
     tok_ee_ = consumes<EEDigitizerTraits::DigiCollection>(EEPileInputTag_);
@@ -62,7 +66,7 @@ namespace edm
 
     // Check to see if we are working in Full or Fast Simulation
 
-    DoFastSim_ = (ps.getParameter<std::string>("IsThisFastSim")).compare("YES") == 0;
+    MergeTrackerDigis_ = (ps.getParameter<std::string>("TrackerMergeType")).compare("Digis") == 0;
     MergeEMDigis_ = (ps.getParameter<std::string>("EcalMergeType")).compare("Digis") == 0;
     MergeHcalDigis_ = (ps.getParameter<std::string>("HcalMergeType")).compare("Digis") == 0;
     if(MergeHcalDigis_) MergeHcalDigisProd_ = (ps.getParameter<std::string>("HcalDigiMerge")=="FullProd");
@@ -73,65 +77,7 @@ namespace edm
 
     // Put Fast Sim Sequences here for Simplification: Fewer options!
 
-    if(DoFastSim_) {
-
-    // declare the products to produce
-
-      //Ecal:
-
-      EBRecHitCollectionDM_        = ps.getParameter<std::string>("EBRecHitCollectionDM");
-      EERecHitCollectionDM_        = ps.getParameter<std::string>("EERecHitCollectionDM");
-      ESRecHitCollectionDM_        = ps.getParameter<std::string>("ESRecHitCollectionDM");
-
-      produces< EBRecHitCollection >(EBRecHitCollectionDM_);
-      produces< EERecHitCollection >(EERecHitCollectionDM_);
-      produces< ESRecHitCollection >(ESRecHitCollectionDM_);
-
-      EMWorker_ = new DataMixingEMWorker(ps, consumesCollector() );
-
-      //Hcal:
-
-      HBHERecHitCollectionDM_ = ps.getParameter<std::string>("HBHERecHitCollectionDM");
-      HORecHitCollectionDM_   = ps.getParameter<std::string>("HORecHitCollectionDM");
-      HFRecHitCollectionDM_   = ps.getParameter<std::string>("HFRecHitCollectionDM");
-      ZDCRecHitCollectionDM_  = ps.getParameter<std::string>("ZDCRecHitCollectionDM");
-
-      produces< HBHERecHitCollection >(HBHERecHitCollectionDM_);
-      produces< HORecHitCollection >(HORecHitCollectionDM_);
-      produces< HFRecHitCollection >(HFRecHitCollectionDM_);
-      produces< ZDCRecHitCollection >(ZDCRecHitCollectionDM_);
-
-      HcalWorker_ = new DataMixingHcalWorker(ps, consumesCollector());
-
-      //Muons:
-
-      DTDigiCollectionDM_  = ps.getParameter<std::string>("DTDigiCollectionDM");
-      RPCDigiCollectionDM_ = ps.getParameter<std::string>("RPCDigiCollectionDM");
-      CSCStripDigiCollectionDM_ = ps.getParameter<std::string>("CSCStripDigiCollectionDM");
-      CSCWireDigiCollectionDM_  = ps.getParameter<std::string>("CSCWireDigiCollectionDM");
-      CSCComparatorDigiCollectionDM_  = ps.getParameter<std::string>("CSCComparatorDigiCollectionDM");
-
-      produces< DTDigiCollection >();
-      produces< RPCDigiCollection >();
-      produces< CSCStripDigiCollection >(CSCStripDigiCollectionDM_);
-      produces< CSCWireDigiCollection >(CSCWireDigiCollectionDM_);
-      produces< CSCComparatorDigiCollection >(CSCComparatorDigiCollectionDM_);
-
-      MuonWorker_ = new DataMixingMuonWorker(ps, consumesCollector());
-
-      //Tracks:
-
-      GeneralTrackCollectionDM_  = ps.getParameter<std::string>("GeneralTrackDigiCollectionDM");
-      produces< reco::TrackCollection >(GeneralTrackCollectionDM_);
-      GeneralTrackWorker_ = new DataMixingGeneralTrackWorker(ps, consumesCollector());
-
-    }
-    else{  // Full Simulation options
-
-      //cout<<"FastSim False!!!"<<endl;
-
-    // declare the products to produce
-    // Start with EM
+    
     if(MergeEMDigis_) {
 
       // cout<<"EM Digis TRUE!!!"<<endl;
@@ -234,37 +180,47 @@ namespace edm
 
     SiStripDigiCollectionDM_  = ps.getParameter<std::string>("SiStripDigiCollectionDM");
 
-    if(useSiStripRawDigi_) {
 
-      produces< edm::DetSetVector<SiStripRawDigi> > (SiStripDigiCollectionDM_);
-      SiStripRawWorker_ = new DataMixingSiStripRawWorker(ps, consumesCollector());
 
-    } else {
+    if(MergeTrackerDigis_) {
 
-      produces< edm::DetSetVector<SiStripDigi> > (SiStripDigiCollectionDM_);
 
+      if(useSiStripRawDigi_) {
+	
+	produces< edm::DetSetVector<SiStripRawDigi> > (SiStripDigiCollectionDM_);
+	SiStripRawWorker_ = new DataMixingSiStripRawWorker(ps, consumesCollector());
+	
+      } else {
+	
+	produces< edm::DetSetVector<SiStripDigi> > (SiStripDigiCollectionDM_);
+	
+	if( addMCDigiNoise_ ) {
+	  SiStripMCDigiWorker_ = new DataMixingSiStripMCDigiWorker(ps, consumesCollector());
+	}
+	else {
+	  SiStripWorker_ = new DataMixingSiStripWorker(ps, consumesCollector());
+	}
+      }
+      
+      // Pixels
+      
+      PixelDigiCollectionDM_  = ps.getParameter<std::string>("PixelDigiCollectionDM");
+      
+      produces< edm::DetSetVector<PixelDigi> > (PixelDigiCollectionDM_);
+      
       if( addMCDigiNoise_ ) {
-	SiStripMCDigiWorker_ = new DataMixingSiStripMCDigiWorker(ps, consumesCollector());
+	SiPixelMCDigiWorker_ = new DataMixingSiPixelMCDigiWorker(ps, consumesCollector());
       }
       else {
-	SiStripWorker_ = new DataMixingSiStripWorker(ps, consumesCollector());
+	SiPixelWorker_ = new DataMixingSiPixelWorker(ps, consumesCollector());
       }
+
+    } 
+    else{
+      //Tracks:
+      edm::ConsumesCollector iC(consumesCollector());
+      GeneralTrackWorker_ = DigiAccumulatorMixModFactory::get()->makeDigiAccumulator(ps.getParameterSet("tracker"), *this, iC).release();
     }
-
-    // Pixels
-
-    PixelDigiCollectionDM_  = ps.getParameter<std::string>("PixelDigiCollectionDM");
-
-    produces< edm::DetSetVector<PixelDigi> > (PixelDigiCollectionDM_);
-
-    if( addMCDigiNoise_ ) {
-      SiPixelMCDigiWorker_ = new DataMixingSiPixelMCDigiWorker(ps, consumesCollector());
-    }
-    else {
-      SiPixelWorker_ = new DataMixingSiPixelWorker(ps, consumesCollector());
-    }
-
-    } // end of Fast/Full switch
 
     // Pileup Information: if doing pre-mixing, we have to save the pileup information from the Secondary stream
 
@@ -320,14 +276,20 @@ namespace edm
   void DataMixingModule::initializeEvent(const edm::Event &e, const edm::EventSetup& ES) { 
 
     if( addMCDigiNoise_ ) {
-      SiStripMCDigiWorker_->initializeEvent( e, ES );
-      SiPixelMCDigiWorker_->initializeEvent( e, ES );
+      if(MergeTrackerDigis_){
+	SiStripMCDigiWorker_->initializeEvent( e, ES );
+	SiPixelMCDigiWorker_->initializeEvent( e, ES );
+      }
+      else{
+	GeneralTrackWorker_->initializeEvent(e,ES);
+      }
       EcalDigiWorkerProd_->initializeEvent( e, ES );
     }
     if( addMCDigiNoise_ && MergeHcalDigisProd_) {
       HcalDigiWorkerProd_->initializeEvent( e, ES );
     }
   }
+  
 
   void DataMixingModule::beginRun(edm::Run const& run, const edm::EventSetup& ES) { 
     BMixingModule::beginRun( run, ES);
@@ -357,15 +319,16 @@ namespace edm
       else { delete HcalDigiWorker_; }}
     else {delete HcalWorker_;}
     if(MuonWorker_) delete MuonWorker_;
-    if(DoFastSim_){
-      delete GeneralTrackWorker_;
-    }else{
+    if(MergeTrackerDigis_){
       if(useSiStripRawDigi_)
 	delete SiStripRawWorker_;
       else if(addMCDigiNoise_ ) delete SiStripMCDigiWorker_;
       else delete SiStripWorker_;
       if(addMCDigiNoise_ ) delete SiPixelMCDigiWorker_;
       else delete SiPixelWorker_;
+    }
+    else{
+      delete GeneralTrackWorker_;
     }
     if(MergePileup_) { delete PUWorker_;}
   }
@@ -396,18 +359,19 @@ namespace edm
     // Muon
     MuonWorker_->addMuonSignals(e);
 
-    if(DoFastSim_){
-       GeneralTrackWorker_->addGeneralTrackSignals(e);
+    if(MergeTrackerDigis_){
+      // SiStrips
+      if(useSiStripRawDigi_) SiStripRawWorker_->addSiStripSignals(e);
+      else if(addMCDigiNoise_ ) SiStripMCDigiWorker_->addSiStripSignals(e);
+      else SiStripWorker_->addSiStripSignals(e);
+      
+      // SiPixels
+      if(addMCDigiNoise_ ) SiPixelMCDigiWorker_->addSiPixelSignals(e);
+      else SiPixelWorker_->addSiPixelSignals(e);
     }else{
-    // SiStrips
-    if(useSiStripRawDigi_) SiStripRawWorker_->addSiStripSignals(e);
-    else if(addMCDigiNoise_ ) SiStripMCDigiWorker_->addSiStripSignals(e);
-    else SiStripWorker_->addSiStripSignals(e);
-
-    // SiPixels
-    if(addMCDigiNoise_ ) SiPixelMCDigiWorker_->addSiPixelSignals(e);
-    else SiPixelWorker_->addSiPixelSignals(e);
-    }    
+      //GeneralTrackWorker_->addGeneralTrackSignal(e);
+      GeneralTrackWorker_->accumulate(e,ES);
+    }
     AddedPileup_ = false;
 
   } // end of addSignals
@@ -423,7 +387,6 @@ namespace edm
     ModuleContextSentry moduleContextSentry(&moduleCallingContext, parentContext);
 
     LogDebug("DataMixingModule") <<"\n===============> adding pileups from event  "<<ep.id()<<" for bunchcrossing "<<bcr;
-
 
     // Note:  setupPileUpEvent may modify the run and lumi numbers of the EventPrincipal to match that of the primary event.
     setupPileUpEvent(ES);
@@ -462,10 +425,7 @@ namespace edm
     // Muon
     MuonWorker_->addMuonPileups(bcr, &ep, eventNr, &moduleCallingContext);
 
-    if(DoFastSim_){
-      GeneralTrackWorker_->addGeneralTrackPileups(bcr, &ep, eventNr, &moduleCallingContext);
-    }else{
-      
+    if(MergeTrackerDigis_){      
       // SiStrips
       if(useSiStripRawDigi_) SiStripRawWorker_->addSiStripPileups(bcr, &ep, eventNr, &moduleCallingContext);
       else if(addMCDigiNoise_ ) SiStripMCDigiWorker_->addSiStripPileups(bcr, &ep, eventNr, &moduleCallingContext);
@@ -475,9 +435,12 @@ namespace edm
       //whoops this should be for the MC worker ????? SiPixelWorker_->setPileupInfo(ps,bunchSpacing);
       if(addMCDigiNoise_ ) SiPixelMCDigiWorker_->addSiPixelPileups(bcr, &ep, eventNr, &moduleCallingContext);
       else SiPixelWorker_->addSiPixelPileups(bcr, &ep, eventNr, &moduleCallingContext);
+    }else{
+      PileUpEventPrincipal pep(ep,&moduleCallingContext,bcr);
+      GeneralTrackWorker_->accumulate(pep, ES,ep.streamID());
     }
-
-
+    
+    
   }
 
 
@@ -510,14 +473,21 @@ namespace edm
           NumPU_Events = 1;
         }  
 
+	if(!MergeTrackerDigis_)
+	  GeneralTrackWorker_->initializeBunchCrossing(e, ES, bunchCrossing);
+
         source->readPileUp(
                 e.id(),
                 recordEventID,
                 std::bind(&DataMixingModule::pileWorker, std::ref(*this),
-                            _1, bunchCrossing, _2, std::cref(ES), mcc),
+			  _1, bunchCrossing, _2, std::cref(ES), mcc),
 		NumPU_Events,
                 e.streamID()
-                );
+			   );
+
+	if(!MergeTrackerDigis_)
+	  GeneralTrackWorker_->finalizeBunchCrossing(e, ES, bunchCrossing);
+	
       }
     }
 
@@ -559,9 +529,7 @@ namespace edm
     // Muon
     MuonWorker_->putMuon(e);
 
-    if(DoFastSim_){
-       GeneralTrackWorker_->putGeneralTrack(e);
-    }else{
+    if(MergeTrackerDigis_){
        // SiStrips
       if(useSiStripRawDigi_) SiStripRawWorker_->putSiStrip(e);
       else if(addMCDigiNoise_ ) SiStripMCDigiWorker_->putSiStrip(e, ES);
@@ -570,6 +538,8 @@ namespace edm
        // SiPixels
       if(addMCDigiNoise_ ) SiPixelMCDigiWorker_->putSiPixel(e, ES, ps, bunchSpacing); 
       else SiPixelWorker_->putSiPixel(e);
+    }else{
+      GeneralTrackWorker_->finalizeEvent(e,ES);
     }
 
 

--- a/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingModule.h
@@ -35,13 +35,13 @@
 #include "SimGeneral/DataMixingModule/plugins/DataMixingSiStripRawWorker.h"
 #include "SimGeneral/DataMixingModule/plugins/DataMixingSiPixelWorker.h"
 #include "SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.h"
-#include "SimGeneral/DataMixingModule/plugins/DataMixingGeneralTrackWorker.h"
 #include "SimGeneral/DataMixingModule/plugins/DataMixingPileupCopy.h"
 
 #include <map>
 #include <vector>
 #include <string>
 
+class DigiAccumulatorMixMod;
 
 namespace edm {
 
@@ -117,11 +117,8 @@ namespace edm {
       // SiPixels
       std::string PixelDigiCollectionDM_  ; // secondary name to be given to new SiPixel digis
 
-      // Tracks
-      std::string GeneralTrackCollectionDM_;
-      // FastSimulation or not?
-
-      bool DoFastSim_;
+      // merge tracker digis or tracks?
+      bool MergeTrackerDigis_;
 
       // Submodules to handle the individual detectors
 
@@ -180,7 +177,7 @@ namespace edm {
 
       // Tracks
 
-      DataMixingGeneralTrackWorker *GeneralTrackWorker_;
+      DigiAccumulatorMixMod * GeneralTrackWorker_;
 
       virtual void getSubdetectorNames();  
 

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
@@ -24,7 +24,7 @@ mixData = cms.EDProducer("DataMixingModule",
     #                   
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
-    IsThisFastSim = cms.string('NO'),  # kludge for fast simulation flag...
+    TrackerMergeType = cms.string('Digis'),  # kludge for fast simulation flag...
     # Use digis?               
     EcalMergeType = cms.string('Digis'),  # set to "Digis" to merge digis
     HcalMergeType = cms.string('Digis'),

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
@@ -32,7 +32,6 @@ mixData = cms.EDProducer("DataMixingModule",
     #
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
-    IsThisFastSim = cms.string('NO'),  # kludge for fast simulation flag...
     # Use digis? 
     TrackerMergeType = cms.string("Digis"),
     EcalMergeType = cms.string('Digis'),  # set to "Digis" to merge digis

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
@@ -33,7 +33,8 @@ mixData = cms.EDProducer("DataMixingModule",
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
     IsThisFastSim = cms.string('NO'),  # kludge for fast simulation flag...
-    # Use digis?               
+    # Use digis? 
+    TrackerMergeType = cms.string("Digis"),
     EcalMergeType = cms.string('Digis'),  # set to "Digis" to merge digis
     HcalMergeType = cms.string('Digis'),
     HcalDigiMerge = cms.string('FullProd'),

--- a/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
@@ -22,7 +22,6 @@ mixData = cms.EDProducer("DataMixingModule",
     #
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
-    IsThisFastSim = cms.string('NO'),  # kludge for fast simulation flag...
     # Merge Pileup Info?
     MergePileupInfo = cms.bool(True),                         
     # Use digis?

--- a/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
@@ -25,10 +25,11 @@ mixData = cms.EDProducer("DataMixingModule",
     IsThisFastSim = cms.string('NO'),  # kludge for fast simulation flag...
     # Merge Pileup Info?
     MergePileupInfo = cms.bool(True),                         
-    # Use digis?               
+    # Use digis?
+    TrackerMergeType = cms.string("Digis"),
     EcalMergeType = cms.string('Digis'),  # set to "Digis" to merge digis
     HcalMergeType = cms.string('Digis'),
-    HcalDigiMerge = cms.string('NotProd'), #use sim hits for signal
+    HcalDigiMerge = cms.string('NotProd'), #use sim hits for signal                         
     #
     # Input Specifications:
     #

--- a/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
@@ -96,7 +96,7 @@ mixData = cms.EDProducer("DataMixingModule",
     #
     mixProdStep1 = cms.bool(False),
     mixProdStep2 = cms.bool(False),
-    IsThisFastSim = cms.string('NO'),  # kludge for fast simulation flag...
+    TrackerMergeType = cms.string('Digis'),  # kludge for fast simulation flag...
     # Merge Pileup Info?
     MergePileupInfo = cms.bool(True),                         
     # Use digis?               


### PR DESCRIPTION
prepare DataMixingModule to mix tracks, required for PU mixing in FastSim.
The old and incomplete DataMixingGeneralTrackWorker is replaced with the RecoTrackAccumulator,
already in use to mix tracks for FastSim inside the MixingModule.

This change is required in 74X.
