### PR TITLE
Nibble per lumisection from TCDS FED and transferPSet update (74X)

### DIFF
--- a/EventFilter/FEDInterface/interface/FED1024.h
+++ b/EventFilter/FEDInterface/interface/FED1024.h
@@ -62,7 +62,7 @@ namespace evf{
 	  uint32_t activePartitions1;
 	  uint32_t nibble;
 	  uint32_t lumiSection;
-	  uint16_t reserved3;
+	  uint16_t nibblesPerLumiSection;
 	  uint16_t reserved4;
 	  uint16_t reserved5;
 	  uint16_t inputs;

--- a/EventFilter/Utilities/plugins/testGlobalNumbers.cc
+++ b/EventFilter/Utilities/plugins/testGlobalNumbers.cc
@@ -133,8 +133,8 @@ namespace test{
 	std::cout << "lumiSection;	   "
 		  << dec << (unsigned int)record.getHeader().getData().header.lumiSection;
 	std::cout << "\n";	 
-	std::cout << "reserved3;	   "
-		  << hex <<(unsigned int)record.getHeader().getData().header.reserved3;	
+	std::cout << "nibblesPerLumiSection"
+		  << hex <<(unsigned int)record.getHeader().getData().header.nibblesPerLumiSection;
 	std::cout << "\n"; 
 	std::cout << "reserved4;	   "
 		  << hex <<(unsigned int)record.getHeader().getData().header. reserved4;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -881,17 +881,14 @@ namespace evf {
     std::string streamRequestName;
     if (transferSystemJson_->isMember(stream.c_str()))
       streamRequestName = stream;
-    else { 
-      if (transferSystemJson_->isMember("default"))
-        streamRequestName = "default";
+    else {
+      std::stringstream msg;
+      msg << "Transfer system mode definitions missing for -: " << stream;
+      if (requireTSPSet_)
+        throw cms::Exception("EvFDaqDirector") << msg.str();
       else {
-        std::stringstream msg;
-        msg << "Transfer system mode definitions missing for -: " << stream;
-        if (requireTSPSet_)
-          throw cms::Exception("EvFDaqDirector") << msg.str();
-        else 
-          edm::LogWarning("EvFDaqDirector") << msg.str() << " (permissive mode)";
-          return std::string();
+        edm::LogWarning("EvFDaqDirector") << msg.str() << " (permissive mode)";
+        return std::string();
       }
     }
     //return empty if strict check parameter is not on


### PR DESCRIPTION
- Updated TCDS record to read new nibbles per LS entry
- removing "default" stream in transfer PSet as it is agreed to nto have default for this

(equivalent of 73X #8153)
