### PR TITLE
MET bugfix for miniAOD + addition of caloMET in slimmedMET

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -84,10 +84,15 @@ namespace pat {
 	uncorrTAU,    //! uncorrect for TAU only
 	uncorrMAXN
       };
+      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
       float corEx(UncorrectionType ix = uncorrALL) const;
+      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
       float corEy(UncorrectionType ix = uncorrALL) const;
+      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
       float corSumEt(UncorrectionType ix = uncorrALL) const;
+      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
       float uncorrectedPt(UncorrectionType ix = uncorrALL) const;
+      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
       float uncorrectedPhi(UncorrectionType ix = uncorrALL) const;
 
       // ---- methods to know what the pat::MET was constructed from ----

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -67,33 +67,10 @@ namespace pat {
       /// set the associated GenMET
       void setGenMET(const reco::GenMET & gm);
 
-      // ---- methods for MET corrections ----
-      //! uses internal info from mEtCorr
-      //! except for full uncorrection, how do you know which is which?
-      //! you don't, 
-      //! present ordering: 
-      //! 1: jet escale Type1 correction
-      //! 2: muon Type1 (?) correction
-      //! 3: tau Type1 (?) correction
-      unsigned int nCorrections() const;
-      enum UncorrectionType {
-	uncorrNONE = -1, //! do nothing
-	uncorrALL = 0, //! uncorrect to bare bones
-	uncorrJES,     //! uncorrect for JES only
-	uncorrMUON,    //! uncorrect for MUON only
-	uncorrTAU,    //! uncorrect for TAU only
-	uncorrMAXN
-      };
-      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
-      float corEx(UncorrectionType ix = uncorrALL) const;
-      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
-      float corEy(UncorrectionType ix = uncorrALL) const;
-      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
-      float corSumEt(UncorrectionType ix = uncorrALL) const;
-      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
-      float uncorrectedPt(UncorrectionType ix = uncorrALL) const;
-      //MM : the cor/uncor functions are deprecated and return -1 now!! use shifted corrected instead
-      float uncorrectedPhi(UncorrectionType ix = uncorrALL) const;
+      // ---- methods for uncorrected MET ----
+      float uncorrectedPt() const;
+      float uncorrectedPhi() const;
+      float uncorrectedSumEt() const;
 
       // ---- methods to know what the pat::MET was constructed from ----
       /// True if this pat::MET was made from a reco::CaloMET
@@ -161,15 +138,6 @@ namespace pat {
       }
 
       // ---- members for MET corrections ----
-      struct UncorInfo {
-	UncorInfo(): corEx(0), corEy(0), corSumEt(0), pt(0), phi(0) {}
-	float corEx;
-	float corEy;
-	float corSumEt;
-	float pt;
-	float phi;
-      };
-
       enum METUncertainty {
         JetEnUp=0, JetEnDown=1, JetResUp=2, JetResDown=3,
         MuonEnUp=4, MuonEnDown=5, ElectronEnUp=6, ElectronEnDown=7, TauEnUp=8,TauEnDown=9,
@@ -217,20 +185,9 @@ namespace pat {
       // ---- holder for pfMET specific info ---
       std::vector<SpecificPFMETData> pfMET_;
 
-      // uncorrection transients
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-      mutable std::atomic<std::vector<UncorInfo>*> uncorInfo_;
-#else
-      mutable std::vector<UncorInfo>* uncorInfo_;
-#endif
-      mutable unsigned int nCorrections_; //thread-safe protected by uncorInfo_
-      
     protected:
 
       // ---- non-public correction utilities ----
-      void checkUncor_() const;
-      void setPtPhi_(UncorInfo& uci) const;
-
       std::vector<PackedMETUncertainty> uncertaintiesRaw_, uncertaintiesType1_, uncertaintiesType1p2_;
 
   };

--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -144,7 +144,7 @@ namespace pat {
         UnclusteredEnUp=10,UnclusteredEnDown=11, NoShift=12, METUncertaintySize=13
       };
       enum METUncertaintyLevel {
-        Raw=0, Type1=1, Type1p2=2
+        Raw=0, Type1=1, Type1p2=2, Calo=3
       };
       struct Vector2 { 
         double px, py; 
@@ -161,6 +161,15 @@ namespace pat {
       double shiftedSumEt(METUncertainty shift, METUncertaintyLevel level=Type1) const ;
 
       void setShift(double px, double py, double sumEt, METUncertainty shift, METUncertaintyLevel level=Type1) ;
+
+      // specific method to fill and retrieve the caloMET quickly from miniAODs, 
+      //should be used by JetMET experts only for the beginning
+      //of the runII, will be discarded later once we are sure
+      //everything is fine
+      Vector2 caloMETP2() const;
+      double caloMETPt() const;
+      double caloMETPhi() const;
+      double caloMETSumEt() const;
 
       /// this below should be private but Reflex doesn't like it
       class PackedMETUncertainty {
@@ -189,6 +198,8 @@ namespace pat {
 
       // ---- non-public correction utilities ----
       std::vector<PackedMETUncertainty> uncertaintiesRaw_, uncertaintiesType1_, uncertaintiesType1p2_;
+
+      PackedMETUncertainty caloPackedMet_;
 
   };
 

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -45,8 +45,8 @@ caloMET_(iOther.caloMET_),
 pfMET_(iOther.pfMET_),
 uncertaintiesRaw_(iOther.uncertaintiesRaw_),
 uncertaintiesType1_(iOther.uncertaintiesType1_),
-uncertaintiesType1p2_(iOther.uncertaintiesType1p2_) {
-
+uncertaintiesType1p2_(iOther.uncertaintiesType1p2_),
+caloPackedMet_(iOther.caloPackedMet_) {
 }
 
 /// destructor
@@ -62,7 +62,8 @@ MET& MET::operator=(MET const& iOther) {
    uncertaintiesRaw_ = iOther.uncertaintiesRaw_;
    uncertaintiesType1_ = iOther.uncertaintiesType1_;
    uncertaintiesType1p2_ = iOther.uncertaintiesType1p2_;
- 
+   caloPackedMet_ = iOther.caloPackedMet_;
+
    return *this;
 }
 
@@ -114,7 +115,28 @@ double MET::shiftedSumEt(MET::METUncertainty shift, MET::METUncertaintyLevel lev
     return sumEt() + v[shift].dsumEt();
 }
 void MET::setShift(double px, double py, double sumEt, MET::METUncertainty shift, MET::METUncertaintyLevel level) {
+  if(level != Calo ) {
     std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : (level == Type1p2 ? uncertaintiesType1p2_ : uncertaintiesRaw_));
     if (v.empty()) v.resize(METUncertaintySize);
     v[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
+  } else {
+    caloPackedMet_.set(px, py, sumEt);
+  }
+}
+
+MET::Vector2 MET::caloMETP2() const {
+  Vector2 ret{ caloPackedMet_.dpx(), caloPackedMet_.dpy() };
+  return ret;
+}
+
+double MET::caloMETPt() const {
+  return caloMETP2().pt();
+}
+
+double MET::caloMETPhi() const {
+  return caloMETP2().phi();
+}
+
+double MET::caloMETSumEt() const {
+  return caloPackedMet_.dsumEt();
 }

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -90,24 +90,34 @@ void MET::setGenMET(const reco::GenMET & gm) {
 unsigned int MET::nCorrections() const { checkUncor_(); return nCorrections_; }
 
 float MET::corEx(UncorrectionType ix) const {
-  if (ix == uncorrNONE) return 0;
-  checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].corEx;
+  //MM : deprecated, return -1, use shifted functions instead
+  // if (ix == uncorrNONE) return 0;
+  // checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].corEx;
+  return -1;
 }
 float MET::corEy(UncorrectionType ix) const {
-  if (ix == uncorrNONE) return 0;
-  checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].corEy;
+  //MM : deprecated, return -1, use shifted functions instead
+  // if (ix == uncorrNONE) return 0;
+  // checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].corEy;
+  return -1;
 }
 float MET::corSumEt(UncorrectionType ix) const {
-  if (ix == uncorrNONE) return 0;
-  checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].corSumEt;
+  //MM : deprecated, return -1, use shifted functions instead
+  // if (ix == uncorrNONE) return 0;
+  // checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].corSumEt;
+  return -1;
 }
 float MET::uncorrectedPt(UncorrectionType ix) const {
-  if (ix == uncorrNONE) return pt();
-  checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].pt;
+  //MM : deprecated, return -1, use shifted functions instead
+  // if (ix == uncorrNONE) return pt();
+  // checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].pt;
+  return -1;
 }
 float MET::uncorrectedPhi(UncorrectionType ix) const {
-  if (ix == uncorrNONE) return phi();
-  checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].phi;
+  //MM : deprecated, return -1, use shifted functions instead
+  // if (ix == uncorrNONE) return phi();
+  // checkUncor_(); return (*uncorInfo_.load(std::memory_order_acquire))[ix].phi;
+  return -1;
 }
 
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -144,7 +144,8 @@
   <ioread sourceClass = "pat::Jet" version="[1-11]" targetClass="pat::Jet" source="int partonFlavour_" target="jetFlavourInfo_">
     <![CDATA[jetFlavourInfo_ = reco::JetFlavourInfo(0,onfile.partonFlavour_);]]>
   </ioread>
-  <class name="pat::MET"  ClassVersion="13">
+  <class name="pat::MET"  ClassVersion="14">
+   <version ClassVersion="14" checksum="1795935545"/>
    <version ClassVersion="13" checksum="2368359386"/>
    <version ClassVersion="12" checksum="1474251442"/>
    <version ClassVersion="11" checksum="1829185007"/>

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -149,8 +149,6 @@
    <version ClassVersion="12" checksum="1474251442"/>
    <version ClassVersion="11" checksum="1829185007"/>
    <version ClassVersion="10" checksum="1136648776"/>
-    <field name="uncorInfo_" transient="true"/>
-    <field name="nCorrections_" transient="true"/>
   </class>
   <class name="pat::MET::PackedMETUncertainty" ClassVersion="10">
     <version ClassVersion="10" checksum="1984780659"/>

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -46,28 +46,35 @@ pat::PATMETSlimmer::PATMETSlimmer(const edm::ParameterSet & iConfig) :
     maybeReadShifts( iConfig, "rawUncertainties", pat::MET::Raw );
     maybeReadShifts( iConfig, "type1Uncertainties", pat::MET::Type1 );
     maybeReadShifts( iConfig, "type1p2Uncertainties", pat::MET::Type1p2 );
+    maybeReadShifts( iConfig, "caloMET", pat::MET::Calo );
     produces<std::vector<pat::MET> >();
 }
 
 void pat::PATMETSlimmer::maybeReadShifts(const edm::ParameterSet &basePSet, const std::string &name, pat::MET::METUncertaintyLevel level) {
     if (basePSet.existsAs<edm::ParameterSet>(name)) {
         throw cms::Exception("Unsupported", "Reading PSets not supported, for now just use input tag");
-    } else if (basePSet.existsAs<edm::InputTag>(name)) {
+    } else if (basePSet.existsAs<edm::InputTag>(name) ) {
         const edm::InputTag & baseTag = basePSet.getParameter<edm::InputTag>(name);
-        shifts_.push_back(OneMETShift(pat::MET::NoShift,   level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::JetEnUp,   level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::JetResUp,   level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::MuonEnUp,   level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::MuonEnDown, level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::ElectronEnUp,   level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::ElectronEnDown, level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::TauEnUp,   level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::TauEnDown, level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnUp,   level, baseTag, consumesCollector()));
-        shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnDown, level, baseTag, consumesCollector()));
+	if( level!=pat::MET::Calo ) {
+	  shifts_.push_back(OneMETShift(pat::MET::NoShift,   level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::JetEnUp,   level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::JetResUp,   level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::JetResDown, level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::MuonEnUp,   level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::MuonEnDown, level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::ElectronEnUp,   level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::ElectronEnDown, level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::TauEnUp,   level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::TauEnDown, level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnUp,   level, baseTag, consumesCollector()));
+	  shifts_.push_back(OneMETShift(pat::MET::UnclusteredEnDown, level, baseTag, consumesCollector()));
+	}
+	else {
+	  shifts_.push_back(OneMETShift(pat::MET::NoShift,   level, baseTag, consumesCollector()));
+	}
     }
+    
 }
 
 pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_, pat::MET::METUncertaintyLevel level_, const edm::InputTag & baseTag, edm::ConsumesCollector && cc) :

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -74,13 +74,14 @@ pat::PATMETSlimmer::OneMETShift::OneMETShift(pat::MET::METUncertainty shift_, pa
     shift(shift_), level(level_)
 {
     std::string baseTagStr = baseTag.encode();
+    bool isSmeared=baseTagStr.find("Smeared")!=(size_t)-1; //temporary 74X fix for handling the JER uncertainties
     char buff[1024];
     switch (shift) {
-        case pat::MET::NoShift  : snprintf(buff, 1023, baseTagStr.c_str(), "OriginalReserved");   break;
+        case pat::MET::NoShift  : snprintf(buff, 1023, baseTagStr.c_str(), "");   break;
         case pat::MET::JetEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetEnUp");   break;
         case pat::MET::JetEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetEnDown"); break;
-        case pat::MET::JetResUp  : snprintf(buff, 1023, baseTagStr.c_str(), "JetResUp");   break;
-        case pat::MET::JetResDown: snprintf(buff, 1023, baseTagStr.c_str(), "JetResDown"); break;
+        case pat::MET::JetResUp  : snprintf(buff, 1023, baseTagStr.c_str(), isSmeared?"JetResUp":"");   break;
+        case pat::MET::JetResDown: snprintf(buff, 1023, baseTagStr.c_str(), isSmeared?"JetResDown":""); break;
         case pat::MET::MuonEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnUp");   break;
         case pat::MET::MuonEnDown: snprintf(buff, 1023, baseTagStr.c_str(), "MuonEnDown"); break;
         case pat::MET::ElectronEnUp  : snprintf(buff, 1023, baseTagStr.c_str(), "ElectronEnUp");   break;

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -125,11 +125,13 @@ def miniAOD_customizeCommon(process):
     process.patJetsAK4PFForMetUnc.getJetMCFlavour = False
     runType1PFMEtUncertainties(process,
                                addToPatDefaultSequence=False,
+                               jetCollectionUnskimmed="patJetsAK4PFForMetUnc",
                                jetCollection="selectedPatJetsAK4PFForMetUnc",
                                electronCollection="selectedPatElectrons",
                                muonCollection="selectedPatMuons",
                                tauCollection="selectedPatTaus",
                                makeType1p2corrPFMEt=True,
+                               doSmearJets=False,
                                outputModule=None)
 
 

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -134,6 +134,12 @@ def miniAOD_customizeCommon(process):
                                doSmearJets=False,
                                outputModule=None)
 
+    from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
+    addMETCollection(process,
+                     labelName = "patCaloMet",
+                     metSource = "caloMet"
+                     )
+  
 
     #keep this after all addJetCollections otherwise it will attempt computing them also for stuf with no taginfos
     #Some useful BTAG vars

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -137,7 +137,7 @@ def miniAOD_customizeCommon(process):
     from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
     addMETCollection(process,
                      labelName = "patCaloMet",
-                     metSource = "caloMet"
+                     metSource = "caloMetM"
                      )
   
 

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedMETs_cfi.py
@@ -5,5 +5,8 @@ slimmedMETs = cms.EDProducer("PATMETSlimmer",
    rawUncertainties   = cms.InputTag("patPFMet%s"),
    type1Uncertainties = cms.InputTag("patPFMetT1%s"),
    type1p2Uncertainties = cms.InputTag("patPFMetT1T2%s"),
+
+   #caloMET, will be used for the beginning of ata takin by the JetMET people
+   caloMET = cms.InputTag("patCaloMet"),
 )
 

--- a/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
+++ b/PhysicsTools/PatUtils/interface/PATJetCorrExtractor.h
@@ -69,6 +69,14 @@ class PATJetCorrExtractor
 
     try {
       corrJetP4 = jet.correctedP4(jetCorrLabel);
+      if(rawJetP4_specified != nullptr) {
+	//MM: compensate for potential removal of constituents (as muons)
+	//similar effect in JetMETCorrection/Type1MET/interface/JetCorrExtractor.h
+	reco::Candidate::LorentzVector rawJetP4 = jet.correctedP4("Uncorrected");
+	double corrFactor = corrJetP4.pt()/rawJetP4.pt();
+	corrJetP4 = (*rawJetP4_specified);
+	corrJetP4 *= corrFactor;
+      }
     } catch( cms::Exception e ) {
       throw cms::Exception("InvalidRequest")
 	<< "The JEC level " << jetCorrLabel << " does not exist !!\n"

--- a/PhysicsTools/PatUtils/python/tools/objectsUncertaintyTools.py
+++ b/PhysicsTools/PatUtils/python/tools/objectsUncertaintyTools.py
@@ -175,9 +175,9 @@ def addShiftedJetCollections(process, jetCollection, lastJetCollection,
     # Creating two sets for shifted jets corrections, depending of the use needed :
     #
 
-    variations=["Up","Down"]
+    variations = { "Up":1., "Down":-1.  }
 
-    for var in variations:
+    for var in variations.keys():
         # in case of "raw" (uncorrected) MET,
         # add residual jet energy corrections in quadrature to jet energy uncertainties:
         # cf. https://twiki.cern.ch/twiki/bin/view/CMS/MissingETUncertaintyPrescription
@@ -190,7 +190,7 @@ def addShiftedJetCollections(process, jetCollection, lastJetCollection,
                                          addResidualJES = cms.bool(True),
                                          jetCorrLabelUpToL3 = cms.InputTag(jetCorrLabelUpToL3.value()),
                                          jetCorrLabelUpToL3Res = cms.InputTag(jetCorrLabelUpToL3Res.value()),
-                                         shiftBy = cms.double(+1.*varyByNsigmas)
+                                         shiftBy = cms.double(variations[var]*varyByNsigmas)
                                          )
 
         jetCollectionEnShiftForRawMEt = \

--- a/PhysicsTools/PatUtils/python/tools/runType1PFMEtUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runType1PFMEtUncertainties.py
@@ -267,7 +267,6 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
         #fix the default jets for the type1 computation to those used to compute the uncertainties
         #in order to be consistent with what is done in the correction and uncertainty step
         #particularly true for miniAODs
-        print "MMM input tag::: ",isValidInputTag(jetCollectionUnskimmed),"  ",jetCollectionUnskimmed
         if isValidInputTag(jetCollectionUnskimmed):
             getattr(process,"patPFJetMETtype1p2Corr").src = jetCollectionUnskimmed
             getattr(process,"patPFJetMETtype2Corr").src = jetCollectionUnskimmed

--- a/PhysicsTools/PatUtils/python/tools/runType1PFMEtUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/runType1PFMEtUncertainties.py
@@ -37,11 +37,14 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
                           "Input PFCandidate collection", Type=cms.InputTag)
         self.addParameter(self._defaultParameters, 'doApplyUnclEnergyCalibration', False,
                           "Flag to enable/disable usage of 'unclustered energy' calibration", Type=bool)
+        self.addParameter(self._defaultParameters, 'jetCollectionUnskimmed', None,
+                          "Unskimmed jets for type1 and type2 computations", Type=cms.InputTag, acceptNoneValue=True)
         self._parameters = copy.deepcopy(self._defaultParameters)
         self._comment = ""
 
     def _addCorrPFMEt(self, process, metUncertaintySequence,
-                      shiftedParticleCollections, pfCandCollection, doApplyUnclEnergyCalibration,
+                      shiftedParticleCollections, pfCandCollection,jetCollectionUnskimmed,
+                      doApplyUnclEnergyCalibration,
                       collectionsToKeep,
                       doSmearJets,
                       makeType1corrPFMEt,
@@ -58,7 +61,7 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
         if not hasattr(process, 'producePatPFMETCorrectionsUnc'):
             process.load("PhysicsTools.PatUtils.patPFMETCorrections_cff")
 
-
+       
         #
         #protections against inconsistent met correction scheme :
         #
@@ -261,6 +264,14 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
         collectionsToKeep.extend( singleParticleShiftedMETs );
 
 
+        #fix the default jets for the type1 computation to those used to compute the uncertainties
+        #in order to be consistent with what is done in the correction and uncertainty step
+        #particularly true for miniAODs
+        print "MMM input tag::: ",isValidInputTag(jetCollectionUnskimmed),"  ",jetCollectionUnskimmed
+        if isValidInputTag(jetCollectionUnskimmed):
+            getattr(process,"patPFJetMETtype1p2Corr").src = jetCollectionUnskimmed
+            getattr(process,"patPFJetMETtype2Corr").src = jetCollectionUnskimmed
+
 
 
     def _prepareShiftedUnclusteredEnergy(self, process, metUncertaintySequence, varyByNsigmas, postfix):
@@ -362,6 +373,7 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
                  muonCollection               = None,
                  tauCollection                = None,
                  jetCollection                = None,
+                 jetCollectionUnskimmed       = None,
                  dRjetCleaning                = None,
                  jetCorrLabel                 = None,
                  doSmearJets                  = None,
@@ -390,6 +402,7 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
             muonCollection = muonCollection,
             tauCollection = tauCollection,
             jetCollection = jetCollection,
+           # jetCollectionUnskimmed = jetCollectionUnskimmed,
             jetCorrLabel = jetCorrLabel,
             doSmearJets = doSmearJets,
             jetSmearFileName = jetSmearFileName,
@@ -422,6 +435,8 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
         pfCandCollection = self._initializeInputTag(pfCandCollection, 'pfCandCollection')
         if doApplyUnclEnergyCalibration is None:
             doApplyUnclEnergyCalibration = self._defaultParameters['doApplyUnclEnergyCalibration'].value
+       
+        jetCollectionUnskimmed  = self._initializeInputTag(jetCollectionUnskimmed, 'jetCollectionUnskimmed')
 
         self.setParameter('dRjetCleaning', dRjetCleaning)
         self.setParameter('makeType1corrPFMEt', makeType1corrPFMEt)
@@ -431,6 +446,12 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
         self.setParameter('sysShiftCorrParameter', sysShiftCorrParameter)
         self.setParameter('pfCandCollection', pfCandCollection)
         self.setParameter('doApplyUnclEnergyCalibration', doApplyUnclEnergyCalibration)
+        self.setParameter('jetCollectionUnskimmed', jetCollectionUnskimmed)
+
+        #specific postfix for miniAODs
+        #temporary fix for 74X on the handling of JER uncertainties
+        if doSmearJets:
+            postfix="Smeared"
 
         self.apply(process)
 
@@ -440,6 +461,7 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
         muonCollection = self._parameters['muonCollection'].value
         tauCollection = self._parameters['tauCollection'].value
         jetCollection = self._parameters['jetCollection'].value
+        jetCollectionUnskimmed = self._parameters['jetCollectionUnskimmed'].value
         jetCorrLabel = self._parameters['jetCorrLabel'].value
         dRjetCleaning =  self._parameters['dRjetCleaning'].value
         doSmearJets = self._parameters['doSmearJets'].value
@@ -519,7 +541,8 @@ class RunType1PFMEtUncertainties(JetMEtUncertaintyTools):
         #--------------------------------------------------------------------------------------------
 
         self._addCorrPFMEt(process, metUncertaintySequence,
-                           shiftedParticleCollections, pfCandCollection, doApplyUnclEnergyCalibration,
+                           shiftedParticleCollections, pfCandCollection, jetCollectionUnskimmed,
+                           doApplyUnclEnergyCalibration,
                            collectionsToKeep,
                            doSmearJets,
                            makeType1corrPFMEt,


### PR DESCRIPTION
This PR fixes the most important bugs observed in miniAODs during the Phys14 exercise.
(NB. the full fix is only complete with #8027 integrated)

Following changes are implemented :
- pat::MET cor and uncorrected functions are deprecated and now retrieve -1, shift function have to be used instead
- MET smearing is disabled per default from the miniAOD production config file.
- protections in the PATMETSlimmer producer have been added to not crash if jet resolution uncertainties are missing (because they are computed and are relevant only when smearing is applied in the current implementation)
- fix of the jet energy scale uncertainty Up/Down variations which were identical
- fix of the unclustered energy scale variation not properly computed due to skimmed jet collection used to compute the type1 and 2 MET correction (unclustered energy scale variation is linked to the type2 MET correction)
- fix a bug during the type1 computation in PAT, due to muon cleaning not properly taken into account
- add basic caloMET information int he slimmedMET class, can be then accessible in one round for experts who wants to have a look at the caloMET

Changes expected during the validation : 
- smearing has been removed from the MET, MET pt resolution will improve compared to the old code implementation
- fix of the muon cleaning for the type1 MET brings back a perfect agreement between the RECO and PAT level. small variations expected in events containing muons. 
