### PR TITLE
reco step not needed for pu files

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -614,7 +614,7 @@ step1FastUpg2015Defaults =merge([{'-s':'GEN,SIM,RECO,EI,HLT:@relval,VALIDATION',
                            '--datatier':'GEN-SIM-DIGI-RECO,DQMIO',
                            '--relval':'27000,3000'},
                            step1Defaults])
-step1FastPUNewMixing =merge([{'-s':'GEN,SIM,RECO',
+step1FastPUNewMixing =merge([{'-s':'GEN,SIM',
                            '--eventcontent':'FASTPU',
                            '--datatier':'GEN-SIM-RECO'},
                            step1FastUpg2015Defaults])


### PR DESCRIPTION
Track reconstruction is included in the SIM step in FastSim,
(confusing, but for good reasons and to be changed in 75X)
other reconstruction is not required for the pu files.
