### PR TITLE
Add Phase1 and Shashlik specific H/E settings for electron reconstruction

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -29,6 +29,7 @@ from SLHCUpgradeSimulations.Configuration.fastsimCustoms import customisePhase2 
 from SLHCUpgradeSimulations.Configuration.customise_mixing import customise_noPixelDataloss as cNoPixDataloss
 from SLHCUpgradeSimulations.Configuration.customise_ecalTime import cust_ecalTime
 from SLHCUpgradeSimulations.Configuration.customise_shashlikTime import cust_shashlikTime
+from SLHCUpgradeSimulations.Configuration.customise_PFlow import customise_phase1ElectronHOverE, customise_shashlikElectronHOverE
 import SLHCUpgradeSimulations.Configuration.aging as aging
 import SLHCUpgradeSimulations.Configuration.jetCustoms as jetCustoms
 
@@ -104,6 +105,7 @@ def cust_2019(process):
     process=customise_HcalPhase1(process)
     process=jetCustoms.customise_jets(process)
 #    process=fixRPCConditions(process)
+    process=customise_phase1ElectronHOverE(process)
     return process
 
 def cust_2019WithGem(process):
@@ -123,6 +125,7 @@ def cust_2023(process):
 
 def cust_2023SHCal(process):
     process=cust_2023Muon(process)
+    process=customise_shashlikElectronHOverE(process)
     if hasattr(process,'L1simulation_step'):
         process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
     if hasattr(process,'digitisation_step'):
@@ -253,6 +256,7 @@ def cust_2023SHCal(process):
 
 def cust_2023SHCalNoExtPix(process):
     process=cust_2023MuonNoExtPix(process)
+    process=customise_shashlikElectronHOverE(process)
     if hasattr(process,'L1simulation_step'):
         process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
     if hasattr(process,'digitisation_step'):

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -29,7 +29,7 @@ from SLHCUpgradeSimulations.Configuration.fastsimCustoms import customisePhase2 
 from SLHCUpgradeSimulations.Configuration.customise_mixing import customise_noPixelDataloss as cNoPixDataloss
 from SLHCUpgradeSimulations.Configuration.customise_ecalTime import cust_ecalTime
 from SLHCUpgradeSimulations.Configuration.customise_shashlikTime import cust_shashlikTime
-from SLHCUpgradeSimulations.Configuration.customise_PFlow import customise_phase1ElectronHOverE, customise_shashlikElectronHOverE
+from SLHCUpgradeSimulations.Configuration.customise_PFlow import customise_phase1ElectronHOverE, customise_shashlikElectronHOverE, customise_HGCalElectronHOverE
 import SLHCUpgradeSimulations.Configuration.aging as aging
 import SLHCUpgradeSimulations.Configuration.jetCustoms as jetCustoms
 
@@ -388,6 +388,7 @@ def cust_2023HGCal_common(process):
     process=customise_ev_BE5DPixel10D(process)
     process=customise_gem2023(process)
     process=customise_rpc(process)
+    process=customise_HGCalElectronHOverE(process)
     process=jetCustoms.customise_jets(process)
     if hasattr(process,'L1simulation_step'):
     	process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)

--- a/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
@@ -56,3 +56,9 @@ def customise_shashlikElectronHOverE( process ) :
         process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEEndcaps = 0.5 
         process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEOuterEndcaps = 1.0
     return process
+
+def customise_HGCalElectronHOverE( process ) :
+    if hasattr( process, "ecalDrivenElectronSeeds" ) :
+        process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodBarrel = 0 # 0 = cone #1 = single tower #2 = towersBehindCluster #3 = clusters (max is 4) 
+        process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEBarrel = 0.15 
+    return process

--- a/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
@@ -39,3 +39,20 @@ def customise_use3DHCalClusters( process ) :
             process.tcMetWithPFclusters.PFClustersHFHAD = cms.InputTag("particleFlowClusterHF")
     return process
 
+def customise_phase1ElectronHOverE( process ) :
+    if hasattr( process, "ecalDrivenElectronSeeds" ) :
+        process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodBarrel = 0 # 0 = cone #1 = single tower #2 = towersBehindCluster #3 = clusters (max is 4) 
+        process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodEndcap = 1 # 0 = cone #1 = single tower #2 = towersBehindCluster #3 = clusters (max is 4)
+        process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEBarrel = 0.15 
+        process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEEndcaps = 0.1 
+        process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEOuterEndcaps = 0.2
+    return process
+
+def customise_shashlikElectronHOverE( process ) :
+    if hasattr( process, "ecalDrivenElectronSeeds" ) :
+        process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodBarrel = 0 # 0 = cone #1 = single tower #2 = towersBehindCluster #3 = clusters (max is 4) 
+        process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodEndcap = 3 # 0 = cone #1 = single tower #2 = towersBehindCluster #3 = clusters (max is 4)
+        process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEBarrel = 0.15 
+        process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEEndcaps = 0.5 
+        process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEOuterEndcaps = 1.0
+    return process


### PR DESCRIPTION
Adds scenario specific H/E parameters for electron reconstruction.  The values are from private correspondence from @hengne.  Tested to make sure the changes are applied correctly by copying cmsDriver commands from the DAS entries for a recent [Shashlik](https://cmsweb.cern.ch/couchdb/reqmgr_config_cache/b71a2d3d091e5a3663ea10d7531f4d79/configFile) and [Phase1](https://cmsweb.cern.ch/couchdb/reqmgr_config_cache/8d486827c8f0a6d9ad5729d56f4fc7b2/configFile) relval sample[1], then using ipython to make sure the parameters are the correct ones for the scenario.

@boudoul, note that I've also added this change to `cust_2023SHCalNoExtPix`.

[1]

```
/RelValQCDForPF_14TeV/CMSSW_6_2_0_SLHC23_patch1-PU_PH2_1K_FB_V6_SHNoTapPU140V2-v4/GEN-SIM-DIGI-RAW
/RelValQCDForPF_14TeV/CMSSW_6_2_0_SLHC21_patch1-PU_PH1_1K_FB_V3_2019GEMPU140aging1k-v1/GEN-SIM-DIGI-RAW
```
