### PR TITLE
Update Phase1 tracking configuration based on 62X_SLHC

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/QuadrupletSeedMerger.cc
@@ -672,7 +672,7 @@ bool SeedMergerPixelLayer::isValidName( const std::string& name ) {
   }
 
   else if( std::string::npos != name.find( "FPix" ) ) {
-    if( layer > 0 && layer < 4 ) {
+    if( layer > 0 && layer < 10 ) {
       if( std::string::npos != name.find( "pos", 6 ) || std::string::npos != name.find( "neg", 6 ) ) return true;
     }
 

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_DetachedQuadStep_cff.py
@@ -67,6 +67,7 @@ detachedQuadStepSeeds.SeedComparitorPSet = cms.PSet(
     )
 detachedQuadStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+detachedQuadStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_DetachedQuadStep_cff.py
@@ -134,7 +134,7 @@ detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     AlgorithmName = cms.string('mixedTripletStep'), 
     src = 'detachedQuadStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_ElectronSeeds_cff.py
@@ -53,6 +53,7 @@ tripletElectronSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.g
 tripletElectronSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag('tripletElectronSeedLayers')
 tripletElectronSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 tripletElectronSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(0)
+tripletElectronSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
 tripletElectronClusterMask = seedClusterRemover.clone(

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_HighPtTripletStep_cff.py
@@ -47,6 +47,7 @@ highPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
     )
     )
 highPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'highPtTripletStepSeedLayers'
+highPtTripletStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_HighPtTripletStep_cff.py
@@ -104,7 +104,7 @@ highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProdu
     # In the future, a new enum or alias may be added to support iteration name aliases.
     AlgorithmName = cms.string('lowPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
@@ -55,8 +55,9 @@ initialStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProd
 import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 initialStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('initialStepTrajectoryFilter')),
+    minNrOfHitsForRebuild = 1,
     alwaysUseInvalidHits = True,
-    maxCand = 6,
+    maxCand = 7,
     estimator = cms.string('initialStepChi2Est'),
     maxDPhiForLooperReconstruction = cms.double(2.0),
     maxPtForLooperReconstruction = cms.double(0.7) 
@@ -94,36 +95,36 @@ initialStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.mul
             minNumberLayers = 3,
             maxNumberLostLayers = 3,
             minNumber3DLayers = 3,
-            d0_par1 = ( 0.7, 4.0 ),
-            dz_par1 = ( 0.8, 4.0 ),
-            d0_par2 = ( 0.4, 4.0 ),
-            dz_par2 = ( 0.6, 4.0 )
+            d0_par1 = ( 0.8, 4.0 ),
+            dz_par1 = ( 0.9, 4.0 ),
+            d0_par2 = ( 0.5, 4.0 ),
+            dz_par2 = ( 0.7, 4.0 )
             ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'initialStepTight',
             preFilterName = 'initialStepLoose',
-            chi2n_par = 1.0,
+            chi2n_par = 1.2,
             res_par = ( 0.003, 0.002 ),
+            minNumberLayers = 3,
+            maxNumberLostLayers = 2,
+            minNumber3DLayers = 3,
+            d0_par1 = ( 0.7, 4.0 ),
+            dz_par1 = ( 0.8, 4.0 ),
+            d0_par2 = ( 0.4, 4.0 ),
+            dz_par2 = ( 0.6, 4.0 )
+            ),
+        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+            name = 'initialStep',
+            preFilterName = 'initialStepTight',
+            chi2n_par = 0.9,
+            res_par = ( 0.003, 0.001 ),
             minNumberLayers = 3,
             maxNumberLostLayers = 2,
             minNumber3DLayers = 3,
             d0_par1 = ( 0.6, 4.0 ),
             dz_par1 = ( 0.7, 4.0 ),
             d0_par2 = ( 0.35, 4.0 ),
-            dz_par2 = ( 0.5, 4.0 )
-            ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
-            name = 'initialStep',
-            preFilterName = 'initialStepTight',
-            chi2n_par = 0.7,
-            res_par = ( 0.003, 0.001 ),
-            minNumberLayers = 3,
-            maxNumberLostLayers = 2,
-            minNumber3DLayers = 3,
-            d0_par1 = ( 0.5, 4.0 ),
-            dz_par1 = ( 0.7, 4.0 ),
-            d0_par2 = ( 0.25, 4.0 ),
-            dz_par2 = ( 0.4, 4.0 )
+            dz_par2 = ( 0.45, 4.0 )
             ),
         ) #end of vpset
     ) #end of clone

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
@@ -31,6 +31,7 @@ initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globa
     )
 )
 initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
+initialStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
@@ -81,7 +81,7 @@ initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.cl
     src = 'initialStepTrackCandidates',
     AlgorithmName = cms.string('initialStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
 )
 
 # Final selection

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_InitialStep_cff.py
@@ -97,34 +97,34 @@ initialStepSelector = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.mul
             minNumber3DLayers = 3,
             d0_par1 = ( 0.8, 4.0 ),
             dz_par1 = ( 0.9, 4.0 ),
-            d0_par2 = ( 0.5, 4.0 ),
-            dz_par2 = ( 0.7, 4.0 )
+            d0_par2 = ( 0.6, 4.0 ),
+            dz_par2 = ( 0.8, 4.0 )
             ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'initialStepTight',
             preFilterName = 'initialStepLoose',
-            chi2n_par = 1.2,
+            chi2n_par = 1.4,
             res_par = ( 0.003, 0.002 ),
             minNumberLayers = 3,
             maxNumberLostLayers = 2,
             minNumber3DLayers = 3,
             d0_par1 = ( 0.7, 4.0 ),
             dz_par1 = ( 0.8, 4.0 ),
-            d0_par2 = ( 0.4, 4.0 ),
-            dz_par2 = ( 0.6, 4.0 )
+            d0_par2 = ( 0.5, 4.0 ),
+            dz_par2 = ( 0.7, 4.0 )
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'initialStep',
             preFilterName = 'initialStepTight',
-            chi2n_par = 0.9,
+            chi2n_par = 1.0,
             res_par = ( 0.003, 0.001 ),
             minNumberLayers = 3,
             maxNumberLostLayers = 2,
             minNumber3DLayers = 3,
             d0_par1 = ( 0.6, 4.0 ),
             dz_par1 = ( 0.7, 4.0 ),
-            d0_par2 = ( 0.35, 4.0 ),
-            dz_par2 = ( 0.45, 4.0 )
+            d0_par2 = ( 0.45, 4.0 ),
+            dz_par2 = ( 0.55, 4.0 )
             ),
         ) #end of vpset
     ) #end of clone

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
@@ -10,6 +10,7 @@ lowPtQuadStepClusters = trackClusterRemover.clone(
     trajectories                             = cms.InputTag("highPtTripletStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("highPtTripletStepClusters"),
     overrideTrkQuals                         = cms.InputTag('highPtTripletStepSelector','highPtTripletStep'),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
@@ -115,7 +115,7 @@ lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
     # In the future, a new enum or alias may be added to support iteration name aliases.
     AlgorithmName = cms.string('pixelPairStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtQuadStep_cff.py
@@ -57,6 +57,7 @@ import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cf
 lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
 lowPtQuadStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 lowPtQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+lowPtQuadStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtTripletStep_cff.py
@@ -7,6 +7,7 @@ lowPtTripletStepClusters = trackClusterRemover.clone(
     trajectories                             = cms.InputTag("lowPtQuadStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("lowPtQuadStepClusters"),
     overrideTrkQuals                         = cms.InputTag('lowPtQuadStepSelector','lowPtQuadStep'),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtTripletStep_cff.py
@@ -47,6 +47,7 @@ import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cf
 lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
 lowPtTripletStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+lowPtTripletStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_LowPtTripletStep_cff.py
@@ -102,7 +102,7 @@ lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     src = 'lowPtTripletStepTrackCandidates',
     AlgorithmName = cms.string('lowPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_PixelPairStep_cff.py
@@ -52,6 +52,7 @@ pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(
     )
 pixelPairStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement =  cms.uint32(0)
+pixelPairStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU140_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU140_PixelPairStep_cff.py
@@ -106,7 +106,7 @@ pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
     AlgorithmName = cms.string('pixelPairStep'),
     src = 'pixelPairStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 # Final selection

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_DetachedQuadStep_cff.py
@@ -68,6 +68,7 @@ detachedQuadStepSeeds.SeedComparitorPSet = cms.PSet(
     )
 detachedQuadStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 detachedQuadStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+detachedQuadStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_DetachedQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_DetachedQuadStep_cff.py
@@ -135,7 +135,7 @@ detachedQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     AlgorithmName = cms.string('mixedTripletStep'),
     src = 'detachedQuadStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_ElectronSeeds_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_ElectronSeeds_cff.py
@@ -53,6 +53,7 @@ tripletElectronSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.g
 tripletElectronSeeds.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag('tripletElectronSeedLayers')
 tripletElectronSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 tripletElectronSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(0)
+tripletElectronSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 from RecoLocalTracker.SubCollectionProducers.SeedClusterRemover_cfi import seedClusterRemover
 tripletElectronClusterMask = seedClusterRemover.clone(

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_HighPtTripletStep_cff.py
@@ -47,6 +47,7 @@ highPtTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
     )
     )
 highPtTripletStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'highPtTripletStepSeedLayers'
+highPtTripletStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_HighPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_HighPtTripletStep_cff.py
@@ -104,7 +104,7 @@ highPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProdu
     # In the future, a new enum or alias may be added to support iteration name aliases.
     AlgorithmName = cms.string('lowPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_InitialStep_cff.py
@@ -31,6 +31,7 @@ initialStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globa
     )
 )
 initialStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'initialStepSeedLayers'
+initialStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_InitialStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_InitialStep_cff.py
@@ -80,7 +80,7 @@ initialStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.cl
     src = 'initialStepTrackCandidates',
     AlgorithmName = cms.string('initialStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
 )
 
 # Final selection

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
@@ -7,6 +7,7 @@ lowPtQuadStepClusters = trackClusterRemover.clone(
     trajectories                             = cms.InputTag("highPtTripletStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("highPtTripletStepClusters"),
     overrideTrkQuals                         = cms.InputTag('highPtTripletStepSelector','highPtTripletStep'),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
@@ -112,7 +112,7 @@ lowPtQuadStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
     # In the future, a new enum or alias may be added to support iteration name aliases.
     AlgorithmName = cms.string('pixelPairStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtQuadStep_cff.py
@@ -48,6 +48,7 @@ lowPtQuadStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.glo
     )
 )
 lowPtQuadStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'lowPtQuadStepSeedLayers'
+lowPtQuadStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
 import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtTripletStep_cff.py
@@ -7,6 +7,7 @@ lowPtTripletStepClusters = trackClusterRemover.clone(
     trajectories                             = cms.InputTag("lowPtQuadStepTracks"),
     pixelClusters                            = cms.InputTag("siPixelClusters"),
     stripClusters                            = cms.InputTag("siStripClusters"),
+    oldClusterRemovalInfo                    = cms.InputTag("lowPtQuadStepClusters"),
     overrideTrkQuals                         = cms.InputTag('lowPtQuadStepSelector','lowPtQuadStep'),
     TrackQuality                             = cms.string('highPurity'),
     minNumberOfLayersWithMeasBeforeFiltering = cms.int32(0),

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtTripletStep_cff.py
@@ -106,7 +106,7 @@ lowPtTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     src = 'lowPtTripletStepTrackCandidates',
     AlgorithmName = cms.string('lowPtTripletStep'),
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 from TrackingTools.TrajectoryCleaning.TrajectoryCleanerBySharedHits_cfi import trajectoryCleanerBySharedHits

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_LowPtTripletStep_cff.py
@@ -51,6 +51,7 @@ import RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cf
 lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.SeedComparitorPSet = RecoPixelVertexing.PixelLowPtUtilities.LowPtClusterShapeSeedComparitor_cfi.LowPtClusterShapeSeedComparitor
 lowPtTripletStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 lowPtTripletStepSeeds.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+lowPtTripletStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
@@ -66,6 +66,7 @@ mixedTripletStepSeedsA.SeedComparitorPSet = cms.PSet(
     )
 mixedTripletStepSeedsA.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 mixedTripletStepSeedsA.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+mixedTripletStepSeedsA.SeedCreatorPSet.SimpleMagneticField = ''
 
 # SEEDING LAYERS
 mixedTripletStepSeedLayersB = cms.EDProducer("SeedingLayersEDProducer",
@@ -100,6 +101,7 @@ mixedTripletStepSeedsB.SeedComparitorPSet = cms.PSet(
     )
 mixedTripletStepSeedsB.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 mixedTripletStepSeedsB.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+mixedTripletStepSeedsB.SeedCreatorPSet.SimpleMagneticField = ''
 
 import RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi
 mixedTripletStepSeeds = RecoTracker.TkSeedGenerator.GlobalCombinedSeeds_cfi.globalCombinedSeeds.clone()

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
@@ -177,7 +177,7 @@ mixedTripletStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProduc
     AlgorithmName = cms.string('mixedTripletStep'),
     src = 'mixedTripletStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
 )
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_MixedTripletStep_cff.py
@@ -36,7 +36,7 @@ mixedTripletStepSeedLayersA = cms.EDProducer("SeedingLayersEDProducer",
     TEC = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         useRingSlector = cms.bool(True),
-        TTRHBuilder = cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069),
+        TTRHBuilder = cms.string('WithTrackAngle'), minGoodCharge = cms.double(-1.0),
         minRing = cms.int32(1),
         maxRing = cms.int32(2),
         skipClusters = cms.InputTag('mixedTripletStepClusters')

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_PixelPairStep_cff.py
@@ -52,6 +52,7 @@ pixelPairStepSeeds.SeedComparitorPSet = cms.PSet(
     )
 pixelPairStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 pixelPairStepSeeds.OrderedHitsFactoryPSet.maxElement =  cms.uint32(0)
+pixelPairStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_PixelPairStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_PixelPairStep_cff.py
@@ -106,7 +106,7 @@ pixelPairStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.
     AlgorithmName = cms.string('pixelPairStep'),
     src = 'pixelPairStepTrackCandidates',
     Fitter = cms.string('FlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 # Final selection

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_TobTecStep_cff.py
@@ -73,6 +73,7 @@ tobTecStepSeeds.SeedComparitorPSet = cms.PSet(
     )
 tobTecStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool(False)
 tobTecStepSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(0)
+tobTecStepSeeds.SeedCreatorPSet.SimpleMagneticField = ''
 
 # QUALITY CUTS DURING TRACK BUILDING (for inwardss and outwards track building steps)
 import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_TobTecStep_cff.py
@@ -42,14 +42,14 @@ tobTecStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
     TOB = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         skipClusters = cms.InputTag('tobTecStepSeedClusters'),
-        TTRHBuilder = cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+        TTRHBuilder = cms.string('WithTrackAngle'), minGoodCharge = cms.double(-1.0)
     ),
     TEC = cms.PSet(
         matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
         skipClusters = cms.InputTag('tobTecStepSeedClusters'),
         #    untracked bool useSimpleRphiHitsCleaner = false
         useRingSlector = cms.bool(True),
-        TTRHBuilder = cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069),
+        TTRHBuilder = cms.string('WithTrackAngle'), minGoodCharge = cms.double(-1.0),
         minRing = cms.int32(5),
         maxRing = cms.int32(5)
     )

--- a/RecoTracker/IterativeTracking/python/Phase1PU70_TobTecStep_cff.py
+++ b/RecoTracker/IterativeTracking/python/Phase1PU70_TobTecStep_cff.py
@@ -187,7 +187,7 @@ tobTecStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clo
     AlgorithmName = cms.string('tobTecStep'),
     #Fitter = 'tobTecStepFitterSmoother',
     Fitter = cms.string('tobTecFlexibleKFFittingSmoother'),
-    TTRHBuilder=cms.string('WithTrackAngle'), minGoodCharge = cms.double(2069)
+    TTRHBuilder=cms.string('WithTrackAngle')
     )
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi


### PR DESCRIPTION
This PR is a partial forward-port PRs #2954 and #3050 (the parts related to Phase1) from 62X_SLHC. In addition, the Phase1 tracking configuration is modified as follows to match the configuration in 62X_SLHC
- Use default magnetic field for Phase1 seeding (instead of the 75X-default `ParabolicMf`)
- Remove minGoodCharge parameter from TrackProducer modules
  - TrackProducer does not make any use of this parameter, looks like it has been added erroneously
- Disable cluster charge cut in seeding layers

Conflicts with #7789 (easily resolvable though).

Should have no effect on standard run1/run2 workflows. 

@rovere @VinInn @boudoul @venturia 
