### PR TITLE
fixed a bug (related to dxy;el/mu+other case) and add the 3rd highest pt plots

### DIFF
--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -30,6 +30,10 @@ def efficiency_string(objtype,plot_type,triggerpath):
         xAxis = "p_{T} of Next-to-Leading Generated %s (GeV/c)" % (objtype)
         input_type = "gen%sMaxPt2" % (objtype)
     if plot_type == "TurnOn3":
+        title = "Next-to-next-to-Leading pT Turn-On"
+        xAxis = "p_{T} of Next-to-next-to-Leading Generated %s (GeV/c)" % (objtype)
+        input_type = "gen%sMaxPt3" % (objtype)
+    if plot_type == "TurnOn4":
         title = "SumEt Turn-On"
         xAxis = "SumEt of Leading Generated %s (GeV/c)" % (objtype)
         input_type = "gen%sSumEt" % (objtype)
@@ -63,7 +67,7 @@ def add_reco_strings(strings):
     strings.extend(reco_strings)
 
 
-plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "EffEta", "EffPhi", "EffDxy"]
+plot_types = ["TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4", "EffEta", "EffPhi", "EffDxy"]
 #--- IMPORTANT: Update this collection whenever you introduce a new object
 #               in the code (from EVTColContainer::getTypeString)
 obj_types  = ["Mu","refittedStandAloneMuons","Track","Ele","Photon","PFTau","PFJet","MET","PFMET","PFMHT","GenMET","CaloJet"

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -67,6 +67,7 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker & iBooker,
               } else {
                 bookHist(iBooker, source, objTypeStr, "MaxPt1");
                 bookHist(iBooker, source, objTypeStr, "MaxPt2");
+                bookHist(iBooker, source, objTypeStr, "MaxPt3");
                 bookHist(iBooker, source, objTypeStr, "Eta");
                 bookHist(iBooker, source, objTypeStr, "Phi");
  
@@ -85,6 +86,7 @@ void HLTExoticaPlotter::plotterBookHistos(DQMStore::IBooker & iBooker,
               } else {
                 bookHist(iBooker, source, objTypeStr, "MaxPt1");
                 bookHist(iBooker, source, objTypeStr, "MaxPt2");
+                bookHist(iBooker, source, objTypeStr, "MaxPt3");
                 bookHist(iBooker, source, objTypeStr, "Eta");
                 bookHist(iBooker, source, objTypeStr, "Phi");
 
@@ -120,7 +122,9 @@ void HLTExoticaPlotter::analyze(const bool & isPassTrigger,
     }
 
     int counttotal = 0;
-    const int totalobjectssize2 = 2 * countobjects.size();
+
+    // 3 : pt1, pt2, pt3
+    const int totalobjectssize3 = 3 * countobjects.size();
     // Fill the histos if pass the trigger (just the two with higher pt)
     for (size_t j = 0; j < matches.size(); ++j) {
         // Is this object owned by this trigger? If not we are not interested...
@@ -145,7 +149,8 @@ void HLTExoticaPlotter::analyze(const bool & isPassTrigger,
 	  }
 	}
 
-        if ( dxys.size() ) this->fillHist(isPassTrigger, source, objTypeStr, "Dxy", dxys[j] );
+        if ( dxys.size() && (objType == EVTColContainer::ELEC || objType == EVTColContainer::MUON ) ) 
+           this->fillHist(isPassTrigger, source, objTypeStr, "Dxy", dxys[j] );
 
         if (countobjects[objType] == 0) {
 	  if ( !( TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT") ) || source!="gen" ) {
@@ -163,8 +168,16 @@ void HLTExoticaPlotter::analyze(const bool & isPassTrigger,
 	  ++(countobjects[objType]);
 	  ++counttotal;
         } 
+	else if (countobjects[objType] == 2) {
+	  if( !( TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT") ) ) {
+            this->fillHist(isPassTrigger, source, objTypeStr, "MaxPt3", pt);
+	  }
+	  // Filled the third highest pt ...
+	  ++(countobjects[objType]);
+	  ++counttotal;
+        } 
 	else {
-	  if (counttotal == totalobjectssize2) {
+	  if (counttotal == totalobjectssize3) {
 	    break;
 	  }
         }
@@ -202,7 +215,8 @@ void HLTExoticaPlotter::bookHist(DQMStore::IBooker & iBooker,
       h = new TH1F(name.c_str(), title.c_str(), nBins, min, max);
     }
     else if (variable.find("MaxPt") != std::string::npos) {
-        std::string desc = (variable == "MaxPt1") ? "Leading" : "Next-to-Leading";
+        std::string desc = (variable == "MaxPt1") ? "Leading" : 
+                           (variable == "MaxPt2") ? "Next-to-Leading" : "Next-to-next-to-Leading";
         std::string title = "pT of " + desc + " " + sourceUpper + " " + objType + " "
                             "where event pass the " + _hltPath;
         const size_t nBins = _parametersTurnOn.size() - 1;

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -76,6 +76,10 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,
         _parametersPhi = anpset.getParameter<std::vector<double> >("parametersPhi");
         _pset.insert(true, "parametersPhi", anpset.retrieve("parametersPhi"));
     }
+    if (anpset.exists("parametersDxy")) {
+        _parametersDxy = anpset.getParameter<std::vector<double> >("parametersDxy");
+        _pset.insert(true, "parametersDxy", anpset.retrieve("parametersDxy"));
+    }
 
     // Get names of objects that we may want to get from the event.
     // Notice that genParticles are dealt with separately.
@@ -208,6 +212,7 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(DQMStore::IBooker &iBooker,
             } else {
               bookHist(iBooker, source, objStr, "MaxPt1");
               bookHist(iBooker, source, objStr, "MaxPt2");
+              bookHist(iBooker, source, objStr, "MaxPt3");
               bookHist(iBooker, source, objStr, "Eta");
               bookHist(iBooker, source, objStr, "Phi");
 
@@ -226,6 +231,7 @@ void HLTExoticaSubAnalysis::subAnalysisBookHistos(DQMStore::IBooker &iBooker,
             } else {
               bookHist(iBooker, source, objStr, "MaxPt1");
               bookHist(iBooker, source, objStr, "MaxPt2");
+              bookHist(iBooker, source, objStr, "MaxPt3");
               bookHist(iBooker, source, objStr, "Eta");
               bookHist(iBooker, source, objStr, "Phi");
 
@@ -488,8 +494,9 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
       }
     
       int counttotal = 0;
-      //int totalobjectssize2 = 2 * countobjects->size();
-      int totalobjectssize2 = 2 * countobjects.size();
+
+      // 3 : pt1, pt2, pt3
+      int totalobjectssize3 = 3 * countobjects.size();
 
 
       bool isPassedLeadingCut = true;
@@ -524,9 +531,14 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	  ++(countobjects[objType]);
 	  ++counttotal;
 	} 
+	else if (countobjects[objType] == 2) {
+	  this->fillHist("gen", objTypeStr, "MaxPt3", pt);
+	  ++(countobjects[objType]);
+	  ++counttotal;
+	} 
 	else {
-	  // Already the minimum two objects has been filled, get out...
-	  if (counttotal == totalobjectssize2) {
+	  // Already the minimum three objects has been filled, get out...
+	  if (counttotal == totalobjectssize3) {
 	    size_t max_size = matchesGen.size();
 	    for ( size_t jj = j; jj < max_size; jj++ ) {
 	      matchesGen.erase(matchesGen.end());
@@ -591,8 +603,9 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	}
     
 	int counttotal = 0;
-	//int totalobjectssize2 = 2 * countobjects->size();
-	int totalobjectssize2 = 2 * countobjects.size();
+
+        // 3 : pt1, pt2, pt3
+	int totalobjectssize3 = 3 * countobjects.size();
     
 	/// Debugging.
 	//std::cout << "Our RECO vector has matchesReco.size() = " << matchesReco.size() << std::endl;
@@ -631,9 +644,16 @@ void HLTExoticaSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventS
 	      ++(countobjects[objType]);
 	      ++counttotal;
 	    } 
+	    else if (countobjects[objType] == 2) {
+	      if( ! ( TString(objTypeStr).Contains("MET") || TString(objTypeStr).Contains("MHT") ) ) {
+		this->fillHist("rec", objTypeStr, "MaxPt3", pt);
+	      } 
+	      ++(countobjects[objType]);
+	      ++counttotal;
+	    } 
 	    else {
-	      // Already the minimum two objects has been filled, get out...
-	      if (counttotal == totalobjectssize2) {
+	      // Already the minimum three objects has been filled, get out...
+	      if (counttotal == totalobjectssize3) {
 		size_t max_size = matchesReco.size();
 		for ( size_t jj = j; jj < max_size; jj++ ) {
 		  matchesReco.erase(matchesReco.end());


### PR DESCRIPTION
This is based on the changes #8034.
I have tested this new code in my local area and it works.

There are two independent modifications.
1) bug fix related to dxy plot 
We found that we get an error in specific cases in which trigger path has electron/muon objects and
additionally other objects (e.g. photons).
The problem was caused by
HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc, line:148.
Previously we tried to fill even for non-electron/muon object because the condition (dxys.size() >0) is satisfied.
So now we fill the histograms only if the object is electron/muon.

2) add the 3rd highest Pt plot (the other changes)
This is a request from a trigger developer.
