### PR TITLE
Add labelsFromToken function to event/lumi/run

### DIFF
--- a/FWCore/Framework/interface/EDConsumerBase.h
+++ b/FWCore/Framework/interface/EDConsumerBase.h
@@ -34,6 +34,7 @@
 #include "DataFormats/Provenance/interface/BranchType.h"
 #include "FWCore/Utilities/interface/ProductHolderIndex.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
+#include "FWCore/Utilities/interface/ProductLabels.h"
 
 
 // forward declarations
@@ -71,11 +72,7 @@ namespace edm {
     void updateLookup(BranchType iBranchType,
                       ProductHolderIndexHelper const&);
     
-    struct Labels {
-      const char*  module;
-      const char*  productInstance;
-      const char*  process;
-    };
+    typedef ProductLabels Labels;
     void labelsForToken(EDGetToken iToken, Labels& oLabels) const;
     
     void modulesDependentUpon(const std::string& iProcessName,

--- a/FWCore/Framework/interface/Event.h
+++ b/FWCore/Framework/interface/Event.h
@@ -216,6 +216,8 @@ namespace edm {
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
+    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
+
     typedef std::vector<std::pair<std::unique_ptr<WrapperBase>, BranchDescription const*> > ProductPtrVec;
 
   private:

--- a/FWCore/Framework/interface/LuminosityBlock.h
+++ b/FWCore/Framework/interface/LuminosityBlock.h
@@ -129,6 +129,8 @@ namespace edm {
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
+    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
+
   private:
     LuminosityBlockPrincipal const&
     luminosityBlockPrincipal() const;

--- a/FWCore/Framework/interface/PrincipalGetAdapter.h
+++ b/FWCore/Framework/interface/PrincipalGetAdapter.h
@@ -104,6 +104,7 @@ edm::Ref<AppleCollection> ref(refApples, index);
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
+#include "FWCore/Utilities/interface/ProductLabels.h"
 
 
 namespace edm {
@@ -201,6 +202,8 @@ namespace edm {
     // Also isolates the PrincipalGetAdapter class
     // from the Principal class.
     EDProductGetter const* prodGetter() const;
+
+    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const;
 
   private:
     // Is this an Event, a LuminosityBlock, or a Run.

--- a/FWCore/Framework/interface/Run.h
+++ b/FWCore/Framework/interface/Run.h
@@ -142,6 +142,8 @@ namespace edm {
 
     ModuleCallingContext const* moduleCallingContext() const { return moduleCallingContext_; }
 
+    void labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const { provRecorder_.labelsForToken(iToken, oLabels); }
+
   private:
     RunPrincipal const&
     runPrincipal() const;

--- a/FWCore/Framework/src/PrincipalGetAdapter.cc
+++ b/FWCore/Framework/src/PrincipalGetAdapter.cc
@@ -96,6 +96,11 @@ namespace edm {
     << "The index of the token was "<<token.index()<<".\n";
   }
   
+  void
+  PrincipalGetAdapter::labelsForToken(EDGetToken const& iToken, ProductLabels& oLabels) const {
+    consumer_->labelsForToken(iToken,oLabels);
+  }
+
   BasicHandle
   PrincipalGetAdapter::makeFailToGetException(KindOfType kindOfType,
                                               TypeID const& productType,

--- a/FWCore/Utilities/interface/ProductLabels.h
+++ b/FWCore/Utilities/interface/ProductLabels.h
@@ -1,0 +1,10 @@
+#ifndef FWCore_Utilities_ProductLabels_h
+#define FWCore_Utilities_ProductLabels_h
+namespace edm {
+    struct ProductLabels {
+      char const*  module;
+      char const*  productInstance;
+      char const*  process;
+    };
+}
+#endif


### PR DESCRIPTION
This pull request adds a new function, labelsForToken() to the Event, LuminosityBlock, and Run.  All the function does is call (indirectly) EDConsumerBase::labelsForToken().
The new functionality is needed for the consumes interface.  In cases where getByToken() will be called from a helper function, there is currently no convenient way to get the module label, product instance name and process name for error messages if the getByToken() fails, or for that matter, for informational messages if it succeeds.
Please expedite testing this pull request, because much further development of the consumes interface depends on it.
