### PR TITLE
No longer read a value before it is initialized in CastorMonitorModule

### DIFF
--- a/DQM/CastorMonitor/src/CastorMonitorModule.cc
+++ b/DQM/CastorMonitor/src/CastorMonitorModule.cc
@@ -1,4 +1,4 @@
-#include <DQM/CastorMonitor/interface/CastorMonitorModule.h>
+#include "DQM/CastorMonitor/interface/CastorMonitorModule.h"
 #include "DataFormats/FEDRawData/interface/FEDNumbering.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -19,7 +19,8 @@
 
 //==================================================================//
 //======================= Constructor ==============================//
-CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet& ps)
+CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet& ps):
+  fVerbosity{ps.getUntrackedParameter<int>("debug", 0)}
 {
   if(fVerbosity>0) std::cout<<"CastorMonitorModule Constructor(start)"<<std::endl;
 
@@ -28,7 +29,6 @@ CastorMonitorModule::CastorMonitorModule(const edm::ParameterSet& ps)
   inputLabelDigi_ 	= ps.getParameter<edm::InputTag>("digiLabel");
   inputLabelRecHitCASTOR_  = ps.getParameter<edm::InputTag>("CastorRecHitLabel");
   NBunchesOrbit		= ps.getUntrackedParameter<int>("nBunchesOrbit",3563);
-  fVerbosity		= ps.getUntrackedParameter<int>("debug", 0);
   showTiming_ 		= ps.getUntrackedParameter<bool>("showTiming",false);
 //inputLabelCastorTowers_  = ps.getParameter<edm::InputTag>("CastorTowerLabel"); 
 //dump2database_   	= ps.getUntrackedParameter<bool>("dump2database",false);


### PR DESCRIPTION
The member variable fVerbosity was being read before it was ever set
and therefore we were getting random cout printouts in the job.
