### PR TITLE
Remove unnecessary and dangerous mutable qualifiers

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h
@@ -509,11 +509,11 @@ private:
     /// flag for call of getL1GtRunCache in beginRun
     bool m_beginRunCache;
 
-    /// cached input tags from provenance - they are updated once per run only
+    /// cached input tags from provenance
 
-    mutable edm::InputTag m_provL1GtRecordInputTag;
-    mutable edm::InputTag m_provL1GtReadoutRecordInputTag;
-    mutable edm::InputTag m_provL1GtTriggerMenuLiteInputTag;
+    edm::InputTag m_provL1GtRecordInputTag;
+    edm::InputTag m_provL1GtReadoutRecordInputTag;
+    edm::InputTag m_provL1GtTriggerMenuLiteInputTag;
     
     /// run cache ID 
     edm::RunID m_runIDCache;


### PR DESCRIPTION
This pull request removes the unnecessary and dangerous mutable qualifier from three InputTag data members of class L1GtUtils.
The qualifiers are unnecessary because these data members are not, in fact, modified, as everything builds fine when these qualifiers are removed.
These mutable qualifiers are dangerous for thread safety.  They are also incompatible with the consumes interface, as the InputTags of consumed data members must be known at construction time.
