### PR TITLE
Backport of transient vector fix to CMSSW_7_2_X

### DIFF
--- a/DataFormats/TauReco/src/classes_def_2.xml
+++ b/DataFormats/TauReco/src/classes_def_2.xml
@@ -152,6 +152,44 @@ for(auto const& ref : onfile.selectedIsolationPFGammaCands_) {
 
 
 
+<ioread sourceClass = "reco::PFTau" version="[1-]" 
+ targetClass="reco::PFTau" 
+source = "" 
+target="signalPiZeroCandidates_">
+<![CDATA[
+signalPiZeroCandidates_.clear();
+]]>
+</ioread>
+              
+<ioread sourceClass = "reco::PFTau" version="[1-]" 
+ targetClass="reco::PFTau" 
+source = "" 
+target="isolationPiZeroCandidates_">
+<![CDATA[
+isolationPiZeroCandidates_.clear();
+]]>
+</ioread>
+
+
+<ioread sourceClass = "reco::PFTau" version="[1-]"
+ targetClass="reco::PFTau" 
+source = "" 
+target="signalTauChargedHadronCandidates_">
+<![CDATA[signalTauChargedHadronCandidates_.clear();
+]]>                     
+</ioread>
+                        
+<ioread sourceClass = "reco::PFTau" version="[1-]"
+ targetClass="reco::PFTau" 
+source = "" 
+target="isolationTauChargedHadronCandidates_">
+<![CDATA[
+isolationTauChargedHadronCandidates_.clear();                                              
+]]>
+</ioread>
+
+
+
 
 <!-- <ioread sourceClass="reco::PFTau" version="[-11]" -->
 <!-- source="reco::PFCandidateRefVector selectedIsolationPFCands_;" -->


### PR DESCRIPTION
Backport of 7_4_X bugfix: adding ioread rules clearing transient vectors to DataFormats/TauReco/classes_def_2.xml
