### PR TITLE
Update the Run2_HI era to use the latest trigger menu XML file

### DIFF
--- a/L1TriggerConfig/L1GtConfigProducers/python/l1GtTriggerMenuXml_cfi.py
+++ b/L1TriggerConfig/L1GtConfigProducers/python/l1GtTriggerMenuXml_cfi.py
@@ -20,11 +20,10 @@ l1GtTriggerMenuXml = cms.ESProducer("L1GtTriggerMenuXmlProducer",
 from Configuration.StandardSequences.Eras import eras
 # Change the trigger menu depending on whether this is 25ns, 50ns or HI running
 eras.run2_25ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030.xml' )
+eras.run2_HI_specific.toModify( l1GtTriggerMenuXml,   DefXmlFile = 'L1Menu_CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1.xml' )
 
-## The following two menus haven't been implemented yet, so until then use
+## The following menu hasn't been implemented yet, so until then use
 ## the same menu as for 25ns.
 #eras.run2_50ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_50ns_v0_L1T_Scales_20141121_Imp0_0x1031.xml' )
-#eras.run2_HI_specific.toModify( l1GtTriggerMenuXml,   DefXmlFile = 'L1Menu_CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1.xml' )
-## FIXME - take out these lines and uncomment the ones above once the menus are implemented.
+## FIXME - take out this lines and uncomment the one above once the menus are implemented.
 eras.run2_50ns_specific.toModify( l1GtTriggerMenuXml, DefXmlFile = 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030.xml' )
-eras.run2_HI_specific.toModify( l1GtTriggerMenuXml,   DefXmlFile = 'L1Menu_Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030.xml' )


### PR DESCRIPTION
Updates the Run2_HI era to match a change put in with #7915, specifically [this one](https://github.com/cms-sw/cmssw/pull/7915/files#diff-80e4fb12cec8d8b1d195b3251bfda038R100).
