### PR TITLE
Fix compiler warning for QIEXXDataFrames

### DIFF
--- a/DataFormats/HcalDigi/interface/QIE10DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE10DataFrame.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/Common/interface/DataFrame.h"
+#include "DataFormats/Common/interface/DataFrameContainer.h"
 #include <ostream>
 
 /** Precision readout digi from QIE10 including TDC information
@@ -13,6 +14,7 @@ public:
 
   static const int WORDS_PER_SAMPLE = 2;
   static const int HEADER_WORDS = 1;
+  static const int FLAG_WORDS = 1;
 
   QIE10DataFrame() { }
   QIE10DataFrame(const edm::DataFrameContainer& c, edm::DataFrame::size_type i) : edm::DataFrame(c,i) { }
@@ -21,12 +23,20 @@ public:
   class Sample {
   public:
     Sample(const edm::DataFrame& frame, edm::DataFrame::size_type i) : frame_(frame),i_(i) { }
-    int adc() const { return frame_[i_]&0xFF; }
-    int le_tdc() const { return frame_[i_+1]&0x3F; }
-    int te_tdc() const { return (frame_[i_]>>6)&0x1F; }
-    bool ok() const { return frame_[i_]&0x1000; }
-    bool soi() const { return frame_[i_]&0x2000; }
-    int capid() const { return (frame_[i_+1]>>12)&0x3; }
+    static const int MASK_ADC = 0xFF;
+    static const int MASK_LE_TDC = 0x3F;
+    static const int MASK_TE_TDC = 0x1F;
+    static const int OFFSET_TE_TDC = 6;
+    static const int MASK_SOI = 0x2000;
+    static const int MASK_OK = 0x1000;
+    static const int MASK_CAPID = 0x3;
+    static const int OFFSET_CAPID = 12;
+    int adc() const { return frame_[i_]&MASK_ADC; }
+    int le_tdc() const { return frame_[i_+1]&MASK_LE_TDC; }
+    int te_tdc() const { return (frame_[i_+1]>>OFFSET_TE_TDC)&MASK_TE_TDC; }
+    bool ok() const { return frame_[i_]&MASK_OK; }
+    bool soi() const { return frame_[i_]&MASK_SOI; }
+    int capid() const { return (frame_[i_+1]>>OFFSET_CAPID)&MASK_CAPID; }
   private:
     const edm::DataFrame& frame_;
     edm::DataFrame::size_type i_;
@@ -35,17 +45,25 @@ public:
   /// Get the detector id
   DetId detid() const { return DetId(id()); }
   /// total number of samples in the digi
-  int samples() const { return (size()-1)/2; }
+  int samples() const { return (size()-HEADER_WORDS-FLAG_WORDS)/WORDS_PER_SAMPLE; }
   /// get the flavor of the frame
-  int flavor() const { return ((edm::DataFrame::operator[](0)>>12)&0x7); }
+  static const int OFFSET_FLAVOR = 12;
+  static const int MASK_FLAVOR = 0x7;
+  int flavor() const { return ((edm::DataFrame::operator[](0)>>OFFSET_FLAVOR)&MASK_FLAVOR); }
   /// was there a link error?
-  bool linkError() const { return edm::DataFrame::operator[](0)&0x800; } 
-  /// was this a mark-and-pass ZS event?  
-  bool wasMarkAndPass() const {return edm::DataFrame::operator[](0)&0x100; }
+  static const int MASK_LINKERROR = 0x800;
+  bool linkError() const { return edm::DataFrame::operator[](0)&MASK_LINKERROR; }
+  /// was this a mark-and-pass ZS event?
+  static const int MASK_MARKPASS = 0x100;
+  bool wasMarkAndPass() const {return edm::DataFrame::operator[](0)&MASK_MARKPASS; }
   /// get the sample
-  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(*this,i*2+1); }
+  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(*this,i*WORDS_PER_SAMPLE+HEADER_WORDS); }
   /// set the sample contents
   void setSample(edm::DataFrame::size_type isample, int adc, int le_tdc, int fe_tdc, int capid, bool soi=false, bool ok=true);
+  /// get the flag word
+  uint16_t flags() const { return edm::DataFrame::operator[](size()-1); }
+  /// set the flag word
+  void setFlags(uint16_t v);
   
 };
 

--- a/DataFormats/HcalDigi/interface/QIE11DataFrame.h
+++ b/DataFormats/HcalDigi/interface/QIE11DataFrame.h
@@ -3,6 +3,7 @@
 
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "DataFormats/Common/interface/DataFrame.h"
+#include "DataFormats/Common/interface/DataFrameContainer.h"
 #include <ostream>
 
 /** Precision readout digi from QIE11 including TDC information
@@ -13,6 +14,7 @@ public:
 
   static const int WORDS_PER_SAMPLE = 1;
   static const int HEADER_WORDS = 1;
+  static const int FLAG_WORDS = 1;
 
   QIE11DataFrame() { }
   QIE11DataFrame(const edm::DataFrameContainer& c, edm::DataFrame::size_type i) : edm::DataFrame(c,i) { }
@@ -21,10 +23,16 @@ public:
   class Sample {
   public:
     Sample(const edm::DataFrame& frame, edm::DataFrame::size_type i) : frame_(frame),i_(i) { }
-    int adc() const { return frame_[i_]&0xFF; }
-    int tdc() const { return (frame_[i_]>>8)&0x3F; }
-    bool soi() const { return frame_[i_]&0x4000; }
-    int capid() const { return ((((frame_[0]>>8)&0x3)+i_)%4); }
+    static const int MASK_ADC = 0xFF;
+    static const int MASK_TDC = 0x3F;
+    static const int OFFSET_TDC = 8; // 8 bits
+    static const int MASK_SOI = 0x4000;
+    static const int MASK_CAPID = 0x3;
+    static const int OFFSET_CAPID = 8;
+    int adc() const { return frame_[i_]&MASK_ADC; }
+    int tdc() const { return (frame_[i_]>>8)&MASK_TDC; }
+    bool soi() const { return frame_[i_]&MASK_SOI; }
+    int capid() const { return ((((frame_[0]>>OFFSET_CAPID)&MASK_CAPID)+i_)&MASK_CAPID); }
   private:
     const edm::DataFrame& frame_;
     edm::DataFrame::size_type i_;
@@ -33,20 +41,28 @@ public:
   /// Get the detector id
   DetId detid() const { return DetId(id()); }
   /// total number of samples in the digi
-  int samples() const { return (size()-1)/2; }
+  int samples() const { return (size()-HEADER_WORDS-FLAG_WORDS)/WORDS_PER_SAMPLE; }
   /// get the flavor of the frame
-  int flavor() const { return ((edm::DataFrame::operator[](0)>>12)&0x7); }
+  static const int OFFSET_FLAVOR = 12;
+  static const int MASK_FLAVOR = 0x7;
+  int flavor() const { return ((edm::DataFrame::operator[](0)>>OFFSET_FLAVOR)&MASK_FLAVOR); }
   /// was there a link error?
-  bool linkError() const { return edm::DataFrame::operator[](0)&0x800; } 
+  static const int MASK_LINKERROR = 0x800;
+  bool linkError() const { return edm::DataFrame::operator[](0)&MASK_LINKERROR; } 
   /// was there a capid rotation error?
-  bool capidError() const { return edm::DataFrame::operator[](0)&0x400; } 
-  /// was this a mark-and-pass ZS event?  
+  static const int MASK_CAPIDERROR = 0x400;
+  bool capidError() const { return edm::DataFrame::operator[](0)&MASK_CAPIDERROR; } 
+  /// was this a mark-and-pass ZS event?
   bool wasMarkAndPass() const {return (flavor()==1); }
   /// get the sample
-  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(*this,i+1); }
+  inline Sample operator[](edm::DataFrame::size_type i) const { return Sample(*this,i+HEADER_WORDS); }
   void setCapid0(int cap0);
   /// set the sample contents
   void setSample(edm::DataFrame::size_type isample, int adc, int tdc, bool soi=false);
+  /// get the flag word
+  uint16_t flags() const { return edm::DataFrame::operator[](size()-1); }
+  /// set the flag word
+  void setFlags(uint16_t v);
 
 };
 

--- a/DataFormats/HcalDigi/src/QIE10DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE10DataFrame.cc
@@ -3,9 +3,14 @@
 
 void QIE10DataFrame::setSample(edm::DataFrame::size_type isample, int adc, int le_tdc, int fe_tdc, int capid, bool soi, bool ok) {
   if (isample>=size()) return;
-  edm::DataFrame::operator[](isample*2+1)=(adc&0xFF)|(soi?(0x2000):(0))|(ok?(0x1000):(0));
-  edm::DataFrame::operator[](isample*2+2)=(le_tdc&0x3F)|((fe_tdc&0x1F)<<6)|((capid&0x3)<<12)|0x4000;
+  edm::DataFrame::operator[](isample*WORDS_PER_SAMPLE+HEADER_WORDS)=(adc&Sample::MASK_ADC)|(soi?(Sample::MASK_SOI):(0))|(ok?(Sample::MASK_OK):(0));
+  edm::DataFrame::operator[](isample*WORDS_PER_SAMPLE+HEADER_WORDS+1)=(le_tdc&Sample::MASK_LE_TDC)|((fe_tdc&Sample::MASK_TE_TDC)<<Sample::OFFSET_TE_TDC)|((capid&Sample::MASK_CAPID)<<Sample::OFFSET_CAPID)|0x4000; // 0x4000 marks this as second word of a pair
 }
+
+void QIE10DataFrame::setFlags(uint16_t v) {
+  edm::DataFrame::operator[](size()-1)=v;
+}
+
 
 std::ostream& operator<<(std::ostream& s, const QIE10DataFrame& digi) {
   if (digi.detid().det()==DetId::Hcal) {

--- a/DataFormats/HcalDigi/src/QIE11DataFrame.cc
+++ b/DataFormats/HcalDigi/src/QIE11DataFrame.cc
@@ -2,13 +2,17 @@
 #include "DataFormats/HcalDetId/interface/HcalGenericDetId.h"
 
 void QIE11DataFrame::setCapid0(int cap0) {
-  edm::DataFrame::operator[](0)&=0xFCFF;
-  edm::DataFrame::operator[](0)|=((cap0&0x3)<<8);  
+  edm::DataFrame::operator[](0)&=0xFCFF; // inversion of the capid0 mask
+  edm::DataFrame::operator[](0)|=((cap0&Sample::MASK_CAPID)<<Sample::OFFSET_CAPID);  
+}
+
+void QIE11DataFrame::setFlags(uint16_t v) {
+  edm::DataFrame::operator[](size()-1)=v;
 }
 
 void QIE11DataFrame::setSample(edm::DataFrame::size_type isample, int adc, int tdc, bool soi) {
   if (isample>=size()) return;
-  edm::DataFrame::operator[](isample+1)=(adc&0xFF)|(soi?(0x4000):(0))|((tdc&0x3F)<<8);
+  edm::DataFrame::operator[](isample+1)=(adc&Sample::MASK_ADC)|(soi?(Sample::MASK_SOI):(0))|((tdc&Sample::MASK_TDC)<<Sample::OFFSET_TDC);
 }
 
 std::ostream& operator<<(std::ostream& s, const QIE11DataFrame& digi) {


### PR DESCRIPTION
This fixes the compiler warnings introduced in #7950 (see https://github.com/cms-sw/cmssw/pull/8103#issuecomment-78237524).

Additionally we have done the following:
- Replace "magic numbers" with constants (see https://github.com/cms-sw/cmssw/pull/7950#discussion_r25869739)
- Add "flag" word which will inevitably be required operationally
