### PR TITLE
MINIAOD: reducing packedMETunceratinty to float16 on top of 8159

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -4,6 +4,7 @@
 #ifndef DataFormats_PatCandidates_MET_h
 #define DataFormats_PatCandidates_MET_h
 
+
 /**
   \class    pat::MET MET.h "DataFormats/PatCandidates/interface/MET.h"
   \brief    Analysis-level MET class
@@ -176,14 +177,19 @@ namespace pat {
         // defined as C++ class so that I can change the packing without having to touch the code elsewhere
         // the compiler should anyway inline everything whenever possible
         public:
-            PackedMETUncertainty() : dpx_(0), dpy_(0), dsumEt_(0) {}
-            PackedMETUncertainty(float dpx, float dpy, float dsumEt) : dpx_(dpx), dpy_(dpy), dsumEt_(dsumEt) {}
-            double dpx() const { return dpx_; }
-            double dpy() const { return dpy_; }
-            double dsumEt() const { return dsumEt_; }
-            void set(float dpx, float dpy, float dsumEt) { dpx_ = dpx; dpy_ = dpy; dsumEt_ = dsumEt; }
+            PackedMETUncertainty() : dpx_(0), dpy_(0), dsumEt_(0) {pack(); unpack();}
+            PackedMETUncertainty(float dpx, float dpy, float dsumEt) : dpx_(dpx), dpy_(dpy), dsumEt_(dsumEt) {pack();unpack();}
+            double dpx() const { if(!unpacked_) unpack(); return dpx_; }
+            double dpy() const { if(!unpacked_) unpack(); return dpy_; }
+            double dsumEt() const { if(!unpacked_) unpack(); return dsumEt_; }
+            void set(float dpx, float dpy, float dsumEt) { dpx_ = dpx; dpy_ = dpy; dsumEt_ = dsumEt; pack(); unpack();}
+            void  unpack() const ;
+            void  pack();
+
         protected:
-            float dpx_, dpy_, dsumEt_;
+            mutable float dpx_, dpy_, dsumEt_;
+            mutable bool unpacked_;
+            uint16_t packedDpx_,packedDpy_,packedDSumEt_;
       };
     private:
 

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -140,3 +140,19 @@ double MET::caloMETPhi() const {
 double MET::caloMETSumEt() const {
   return caloPackedMet_.dsumEt();
 }
+
+#include "DataFormats/PatCandidates/interface/libminifloat.h"
+
+void MET::PackedMETUncertainty::pack() {
+  packedDpx_  =  MiniFloatConverter::float32to16(dpx_);
+  packedDpy_  =  MiniFloatConverter::float32to16(dpy_);
+  packedDSumEt_  =  MiniFloatConverter::float32to16(dsumEt_);
+}
+void  MET::PackedMETUncertainty::unpack() const {
+  unpacked_=true;
+  dpx_=MiniFloatConverter::float16to32(packedDpx_);
+  dpy_=MiniFloatConverter::float16to32(packedDpy_);
+  dsumEt_=MiniFloatConverter::float16to32(packedDSumEt_);
+
+}
+

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -214,9 +214,20 @@
    <version ClassVersion="11" checksum="1829185007"/>
    <version ClassVersion="10" checksum="1136648776"/>
   </class>
-  <class name="pat::MET::PackedMETUncertainty" ClassVersion="10">
+  <class name="pat::MET::PackedMETUncertainty" ClassVersion="11">
+    <version ClassVersion="11" checksum="3523936012"/>
     <version ClassVersion="10" checksum="1984780659"/>
+    <field name="dpx_" transient="true" />
+    <field name="dpy_" transient="true" />
+    <field name="dsumEt_" transient="true" />
+    <field name="unpacked_" transient="true" />
+
   </class>
+  <ioread sourceClass="pat::PackedMETUncertainty"  version="[1-]" targetClass="pat::PackedMETUncertainty" source="" target="unpacked_">
+        <![CDATA[unpacked_ = false;
+            ]]>
+  </ioread>
+
   <class name="std::vector<pat::MET::PackedMETUncertainty>" />
   <class name="pat::MHT"  ClassVersion="12">
    <version ClassVersion="12" checksum="965016657"/>


### PR DESCRIPTION
This uses float16 in pat::MET::PackedMETUnceratinty and saves about 100bytes per MET per Event.

With PUPPI PR #8122 the total saving is 200bytes/Event

This PR is on top of #8159  @gpetruc
