### PR TITLE
Removed use of ZombieKillerService

### DIFF
--- a/FWCore/Concurrency/python/dropNonMTSafe.py
+++ b/FWCore/Concurrency/python/dropNonMTSafe.py
@@ -11,9 +11,5 @@ def dropNonMTSafe(process):
   process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(4),
                                        sizeOfStackForThreadsInKB = cms.untracked.uint32(10*1024),
                                        numberOfStreams = cms.untracked.uint32(0))
-  if not hasattr(process,"ZombieKillerService"):
-    process.add_(cms.Service("ZombieKillerService",
-                             secondsBetweenChecks = cms.untracked.uint32(120),
-                             numberOfAllowedFailedChecksInARow = cms.untracked.uint32(4)))
 
   return process


### PR DESCRIPTION
The ZombieKillerService has been killing jobs which knowingly have times with long waits (e.g. requesting files from xrootd). Also, all our tests put a cutoff of 1 hour on jobs anyway.
