### PR TITLE
removing pixel saturation for heb

### DIFF
--- a/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
@@ -64,7 +64,7 @@ hgchebackDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer")
                                                    shaperN       = cms.double(1.),
                                                    shaperTau     = cms.double(0.),
                                                    caliceSpecific = cms.PSet( nPEperMIP = cms.double(11.0),
-                                                                              #1156 pixels => saturation ~300MIP
+                                                                              #1156 pixels => saturation ~600MIP
                                                                               nTotalPE  = cms.double(11560),
                                                                               xTalk     = cms.double(0.25),
                                                                               sdPixels  = cms.double(3.0) )

--- a/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/hgcalDigitizer_cfi.py
@@ -64,7 +64,8 @@ hgchebackDigitizer = cms.PSet( accumulatorType   = cms.string("HGCDigiProducer")
                                                    shaperN       = cms.double(1.),
                                                    shaperTau     = cms.double(0.),
                                                    caliceSpecific = cms.PSet( nPEperMIP = cms.double(11.0),
-                                                                              nTotalPE  = cms.double(1156),
+                                                                              #1156 pixels => saturation ~300MIP
+                                                                              nTotalPE  = cms.double(11560),
                                                                               xTalk     = cms.double(0.25),
                                                                               sdPixels  = cms.double(3.0) )
                                                    )


### PR DESCRIPTION
Relaxing constraint on max. number of pixels in BH which implied a saturation after digitisation.
The previous constraint was bound to the CALICE test beam benchmark.

@vandreev11 As just agreed.
@lgray
