### PR TITLE
unpack HF uTCA FEDs

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -29,6 +29,10 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   if (fedUnpackList_.empty()) {
     for (int i=FEDNumbering::MINHCALFEDID; i<=FEDNumbering::MAXHCALFEDID; i++)
       fedUnpackList_.push_back(i);
+    // HF uTCA
+    fedUnpackList_.push_back(1118);
+    fedUnpackList_.push_back(1120);
+    fedUnpackList_.push_back(1122);
   } 
   
   unpacker_.setExpectedOrbitMessageTime(expectedOrbitMessageTime_);


### PR DESCRIPTION
Starting today (March 12), the HF front-end data is fed to the three HF uTCA FEDs included in this commit.

CC: @abdoulline
