### PR TITLE
re-enable the kOutOfTime filtering in PF-rechits 

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -25,7 +25,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                   cleaningThreshold = cms.double(2.0),
                   timingCleaning = cms.bool(True),
                   topologicalCleaning = cms.bool(True),
-                  skipTTRecoveredHits = cms.bool(False)
+                  skipTTRecoveredHits = cms.bool(True)
                   )
              )
            ),
@@ -42,7 +42,7 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                  cleaningThreshold = cms.double(2.0),
                  timingCleaning = cms.bool(True),
                  topologicalCleaning = cms.bool(True),
-                 skipTTRecoveredHits = cms.bool(False)
+                 skipTTRecoveredHits = cms.bool(True)
                  )
             )
           )

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowRecHitECAL_cfi.py
@@ -23,9 +23,9 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                   cms.PSet(
                   name = cms.string("PFRecHitQTestECAL"),
                   cleaningThreshold = cms.double(2.0),
-                  timingCleaning = cms.bool(False),
+                  timingCleaning = cms.bool(True),
                   topologicalCleaning = cms.bool(True),
-                  skipTTRecoveredHits = cms.bool(True)
+                  skipTTRecoveredHits = cms.bool(False)
                   )
              )
            ),
@@ -40,9 +40,9 @@ particleFlowRecHitECAL = cms.EDProducer("PFRecHitProducer",
                  cms.PSet(
                  name = cms.string("PFRecHitQTestECAL"),
                  cleaningThreshold = cms.double(2.0),
-                 timingCleaning = cms.bool(False),
+                 timingCleaning = cms.bool(True),
                  topologicalCleaning = cms.bool(True),
-                 skipTTRecoveredHits = cms.bool(True)
+                 skipTTRecoveredHits = cms.bool(False)
                  )
             )
           )


### PR DESCRIPTION
1) kOutOfTime filtering is needed to complete the ECAL spike rejection together with the topological cuts

2) enable the usage of the ECAL rechits recovered in case of dead trigger towers (new algorithm for the recovery is in place)

@mariadalfonso @bachtis @argiro @cerminar @bendavid please also look at this 
