### PR TITLE
Fix Checksums in DataFormats/PatCandidates

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -16,7 +16,9 @@
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
-  <class name="pat::Electron"  ClassVersion="28">
+  <class name="pat::Electron"  ClassVersion="30">
+   <version ClassVersion="30" checksum="3949366163"/>
+   <version ClassVersion="29" checksum="1784986402"/>
    <version ClassVersion="28" checksum="2518240031"/>
    <version ClassVersion="27" checksum="3863179876"/>
    <field name="superClusterRelinked_" transient="true"/>
@@ -51,7 +53,9 @@
   </ioread>
 
 
-  <class name="pat::Muon"  ClassVersion="16">
+  <class name="pat::Muon"  ClassVersion="18">
+   <version ClassVersion="18" checksum="1163602263"/>
+   <version ClassVersion="17" checksum="1509153359"/>
    <version ClassVersion="16" checksum="2674665735"/>
    <version ClassVersion="15" checksum="1248517999"/>
    <version ClassVersion="14" checksum="132269943"/>


### PR DESCRIPTION
The checksums of pat::Electron and pat::Muon recently changed. The ROOT6 checksums for these classes are now wrong, which causes build errors.
This simple PR copies the new ROOT5 checksums for these classes into the ROOT6 IB, and also adds the correct ROOT6 checksums.
Please merge as soon as convenient.
