### PR TITLE
fix gtAlgorithmResult method

### DIFF
--- a/CondFormats/L1TObjects/src/L1GtTriggerMenu.cc
+++ b/CondFormats/L1TObjects/src/L1GtTriggerMenu.cc
@@ -758,13 +758,14 @@ void L1GtTriggerMenu::print(std::ostream& myCout, int& printVerbosity) const {
 // get the result for algorithm with name algName
 // use directly the format of decisionWord (no typedef)
 const bool L1GtTriggerMenu::gtAlgorithmResult(const std::string& algName,
-        const std::vector<bool>& decWord) const {
+					      const std::vector<bool>& decWord) const {
 
     bool algResult = false;
 
     CItAlgo itAlgo = m_algorithmMap.find(algName);
     if (itAlgo != m_algorithmMap.end()) {
-        int bitNumber = (itAlgo->second).algoBitNumber();
+        unsigned int bitNumber = (itAlgo->second).algoBitNumber();
+	if((bitNumber+1) > decWord.size()) return false;
         algResult = decWord.at(bitNumber);
         return algResult;
     }


### PR DESCRIPTION
add a check in case the decWord has zero size.
this fixes the crash described in: https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/923.html
not sure this is the correct strategy though
