### PR TITLE
Optimize SiStripMonitorTrack to perform less string operations.

### DIFF
--- a/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
+++ b/DQM/SiStripCommon/interface/SiStripFolderOrganizer.h
@@ -76,7 +76,7 @@ class SiStripFolderOrganizer
       void getRingFolderName(std::stringstream& ss, uint32_t rawdetid, const TrackerTopology* tTopo) { getLayerFolderName(ss,rawdetid,tTopo,true); }
       // SubDetector Folder
       void getSubDetFolder(const uint32_t& detid, const TrackerTopology* tTopo, std::string& folder_name);
-      std::pair<std::string, std::string> getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo);
+      std::pair<const std::string, const char *> getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo);
    private:
       SiStripFolderOrganizer(const SiStripFolderOrganizer&); // stop default
       const SiStripFolderOrganizer& operator=(const SiStripFolderOrganizer&); // stop default

--- a/DQM/SiStripCommon/src/SiStripFolderOrganizer.cc
+++ b/DQM/SiStripCommon/src/SiStripFolderOrganizer.cc
@@ -29,6 +29,8 @@
 #define MECHANICAL_FOLDER_NAME "MechanicalView"
 #define SEP "/"
 
+#include <cstring>
+
 SiStripFolderOrganizer::SiStripFolderOrganizer()
 {
   TopFolderName="SiStrip";
@@ -452,46 +454,50 @@ void SiStripFolderOrganizer::getLayerFolderName(std::stringstream& ss, uint32_t 
 //
 // -- Get Subdetector Folder name and the Tag
 //
-std::pair<std::string, std::string> SiStripFolderOrganizer::getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo) {
-  std::pair<std::string, std::string> result;
-  result.first = TopFolderName + SEP MECHANICAL_FOLDER_NAME SEP;
-  std::string subdet_folder;
+std::pair<const std::string, const char *> SiStripFolderOrganizer::getSubDetFolderAndTag(const uint32_t& detid, const TrackerTopology* tTopo) {
+
+  const char *subdet_folder = "";
+  const char *tag = "";
   switch(StripSubdetector::SubDetector(StripSubdetector(detid).subdetId()))
     {
     case StripSubdetector::TIB:
       subdet_folder = "TIB";
-      result.second = subdet_folder;
+      tag = subdet_folder;
       break;
     case StripSubdetector::TOB:
       subdet_folder = "TOB";
-      result.second = subdet_folder;
+      tag = subdet_folder;
       break;
     case StripSubdetector::TID:
       if (tTopo->tidSide(detid) == 2) {
         subdet_folder = "TID/PLUS";
-	result.second = "TID__PLUS";
+        tag = "TID__PLUS";
       } else if (tTopo->tidSide(detid) == 1) {
         subdet_folder = "TID/MINUS";
-	result.second = "TID__MINUS";
+        tag = "TID__MINUS";
       }
       break;
     case StripSubdetector::TEC:
       if (tTopo->tecSide(detid) == 2) {
         subdet_folder = "TEC/PLUS";
-	result.second = "TEC__PLUS";
+        tag = "TEC__PLUS";
       } else if (tTopo->tecSide(detid) == 1) {
         subdet_folder = "TEC/MINUS";
-	result.second = "TEC__MINUS";
+        tag = "TEC__MINUS";
       }
       break;
     default:
       {
-	edm::LogWarning("SiStripCommon") << "WARNING!!! this detid does not belong to tracker" << std::endl;
+        edm::LogWarning("SiStripCommon") << "WARNING!!! this detid does not belong to tracker" << std::endl;
         subdet_folder = "";
       }
     }
-  result.first += subdet_folder;
-  return result; 
+
+  std::string folder;
+  folder.reserve(TopFolderName.size() + strlen(SEP MECHANICAL_FOLDER_NAME SEP) + strlen(subdet_folder) + 1);
+  folder = TopFolderName + SEP MECHANICAL_FOLDER_NAME SEP + subdet_folder;
+
+  return std::pair<const std::string, const char *>(folder, tag);
 }
 
 

--- a/DQM/SiStripCommon/src/SiStripHistoId.cc
+++ b/DQM/SiStripCommon/src/SiStripHistoId.cc
@@ -83,8 +83,6 @@ std::string SiStripHistoId::createHistoLayer(std::string description, std::strin
 
 //std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring, bool flag_thickness){
 std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTopo, bool flag_ring){
-  std::string rest1;
-  
   const int buf_len = 50;
   char temp_str[buf_len];
 
@@ -96,16 +94,16 @@ std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTop
   }else if( subdet.subdetId() == StripSubdetector::TID){
     // ---------------------------  TID  --------------------------- //
     
-    std::string side = "";
+    const char *side = "";
     if (tTopo->tidSide(id) == 1)
       side = "MINUS";
     else if (tTopo->tidSide(id) == 2)
       side = "PLUS";
 
     if (flag_ring)
-      snprintf(temp_str, buf_len, "TID__%s__ring__%i",  side.c_str(), tTopo->tidRing(id) );
+      snprintf(temp_str, buf_len, "TID__%s__ring__%i",  side, tTopo->tidRing(id) );
     else
-      snprintf(temp_str, buf_len, "TID__%s__wheel__%i", side.c_str(), tTopo->tidWheel(id));
+      snprintf(temp_str, buf_len, "TID__%s__wheel__%i", side, tTopo->tidWheel(id));
 
   }else if(subdet.subdetId() == StripSubdetector::TOB){ 
     // ---------------------------  TOB  --------------------------- //
@@ -114,14 +112,14 @@ std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTop
   }else if(subdet.subdetId() == StripSubdetector::TEC){
     // ---------------------------  TEC  --------------------------- //
     
-    std::string side = "";
+    const char *side = "";
     if (tTopo->tecSide(id) == 1)
       side = "MINUS";
     else if (tTopo->tecSide(id) == 2)
       side = "PLUS";
 
     if (flag_ring) 
-      snprintf(temp_str, buf_len, "TEC__%s__ring__%i",  side.c_str(), tTopo->tecRing(id) );
+      snprintf(temp_str, buf_len, "TEC__%s__ring__%i",  side, tTopo->tecRing(id) );
     else {
       /*
       if (flag_thickness) {
@@ -133,7 +131,7 @@ std::string SiStripHistoId::getSubdetid(uint32_t id, const TrackerTopology* tTop
       }
       else
 */
-      snprintf(temp_str, buf_len, "TEC__%s__wheel__%i", side.c_str(), tTopo->tecWheel(id)); 
+      snprintf(temp_str, buf_len, "TEC__%s__wheel__%i", side, tTopo->tecWheel(id)); 
     }
   }else{
     // ---------------------------  ???  --------------------------- //

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -302,7 +302,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
 	createLayerMEs(label, layerDetIds.size() , ibooker );
       }
       // book sub-detector plots
-      std::pair<std::string,std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+      auto sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
       if (SubDetMEsMap.find(sdet_pair.second) == SubDetMEsMap.end()){
 	ibooker.setCurrentFolder(sdet_pair.first);
 

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -416,7 +416,7 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
       }
       
       // book sub-detector plots
-      std::pair<std::string,std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+      auto sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
       if (SubDetMEsMap.find(sdet_pair.second) == SubDetMEsMap.end()){
 	ibooker.setCurrentFolder(sdet_pair.first);
 	createSubDetMEs( ibooker , sdet_pair.second );        

--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -73,13 +73,16 @@ private:
     OffTrack,
     OnTrack
   };
+
+  struct Det2MEs;
+
   //booking
   void book(DQMStore::IBooker &, const TrackerTopology* tTopo);
-  void bookModMEs(DQMStore::IBooker &, const uint32_t& );
-  void bookLayerMEs(DQMStore::IBooker &, const uint32_t&, std::string&);
-  void bookRing(DQMStore::IBooker &, const uint32_t&, std::string&);
+  void bookModMEs(DQMStore::IBooker &, const uint32_t );
+  void bookLayerMEs(DQMStore::IBooker &, const uint32_t, std::string&);
+  void bookRing(DQMStore::IBooker &, const uint32_t, std::string&);
   MonitorElement* handleBookMEs(DQMStore::IBooker &, std::string&, std::string&, std::string&, std::string&);
-  void bookRingMEs(DQMStore::IBooker &, const uint32_t&, std::string&);
+  void bookRingMEs(DQMStore::IBooker &, const uint32_t, std::string&);
   void bookSubDetMEs(DQMStore::IBooker &, std::string& name);
   MonitorElement * bookME1D(DQMStore::IBooker & , const char*, const char*);
   MonitorElement * bookME2D(DQMStore::IBooker & , const char*, const char*);
@@ -99,19 +102,21 @@ private:
 		const SiStripRecHit2D*          hit2D,
 		const SiStripRecHit1D*          hit1D,
 		LocalVector localMomentum);
-  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t& detid, const TrackerTopology* tTopo, enum ClusterFlags flags, LocalVector LV);	
+  bool clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flags, LocalVector LV, const Det2MEs& MEs);	
   template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&);
 
   // fill monitorables 
-  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, uint32_t detid, const LocalVector LV);
-  void fillMEs(SiStripClusterInfo*,uint32_t detid, const TrackerTopology* tTopo, float,enum ClusterFlags,  const LocalVector LV);
+  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, const uint32_t detid, const LocalVector LV);
+  void fillMEs(SiStripClusterInfo*,const uint32_t detid, float,enum ClusterFlags,  const LocalVector LV, const Det2MEs& MEs);
+
   inline void fillME(MonitorElement* ME,float value1){if (ME!=0)ME->Fill(value1);}
   inline void fillME(MonitorElement* ME,float value1,float value2){if (ME!=0)ME->Fill(value1,value2);}
   inline void fillME(MonitorElement* ME,float value1,float value2,float value3){if (ME!=0)ME->Fill(value1,value2,value3);}
   inline void fillME(MonitorElement* ME,float value1,float value2,float value3,float value4){if (ME!=0)ME->Fill(value1,value2,value3,value4);}
 
+  Det2MEs findMEs(const TrackerTopology* tTopo, const uint32_t detid);
+
   // ----------member data ---------------------------
-  
 private:
   edm::ParameterSet conf_;
   std::string histname; 
@@ -182,6 +187,12 @@ private:
   std::map<std::string, LayerMEs>     LayerMEsMap;
   std::map<std::string, RingMEs>      RingMEsMap;
   std::map<std::string, SubDetMEs>    SubDetMEsMap;  
+
+  struct Det2MEs {
+      struct LayerMEs *iLayer;
+      struct RingMEs *iRing;
+      struct SubDetMEs *iSubdet;
+  };
   
   edm::ESHandle<TrackerGeometry> tkgeom_;
   edm::ESHandle<SiStripDetCabling> SiStripDetCabling_;

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -204,7 +204,7 @@ void SiStripMonitorTrack::book(DQMStore::IBooker & ibooker , const TrackerTopolo
 }
 
 //--------------------------------------------------------------------------------
-void SiStripMonitorTrack::bookModMEs(DQMStore::IBooker & ibooker , const uint32_t & id)//Histograms at MODULE level
+void SiStripMonitorTrack::bookModMEs(DQMStore::IBooker & ibooker , const uint32_t id)//Histograms at MODULE level
 {
   std::string name = "det";
   SiStripHistoId hidmanager;
@@ -271,7 +271,7 @@ MonitorElement* SiStripMonitorTrack::handleBookMEs(DQMStore::IBooker & ibooker ,
 // -- Book Layer Level Histograms and Trend plots
 //
 //------------------------------------------------------------------------
-void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint32_t& mod_id, std::string& layer_id)
+void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint32_t mod_id, std::string& layer_id)
 {
   std::string name = "layer";
   std::string view = "layerView";
@@ -359,7 +359,7 @@ void SiStripMonitorTrack::bookLayerMEs(DQMStore::IBooker & ibooker , const uint3
 
 }
 
-void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker & ibooker , const uint32_t& mod_id, std::string& ring_id)
+void SiStripMonitorTrack::bookRingMEs(DQMStore::IBooker & ibooker , const uint32_t mod_id, std::string& ring_id)
 {
 
   std::string name = "ring";
@@ -875,7 +875,8 @@ template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, Local
       const SiStripCluster* SiStripCluster_ = &*(tkrecHit->cluster());
       SiStripClusterInfo SiStripClusterInfo_(*SiStripCluster_,es,detid);
 
-      if ( clusterInfos(&SiStripClusterInfo_,detid, tTopo, OnTrack, LV ) )
+      const Det2MEs MEs = findMEs(tTopo, detid);
+      if (clusterInfos(&SiStripClusterInfo_,detid, OnTrack, LV, MEs))
       {
         vPSiStripCluster.insert(SiStripCluster_);
       }
@@ -903,13 +904,13 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
   }
   else
   {
-
     //Loop on Dets
     for (edmNew::DetSetVector<SiStripCluster>::const_iterator DSViter=siStripClusterHandle->begin();
          DSViter!=siStripClusterHandle->end();
          DSViter++)
     {
       uint32_t detid=DSViter->id();
+      const Det2MEs MEs = findMEs(tTopo, detid);
 
       LogDebug("SiStripMonitorTrack") << "on detid "<< detid << " N Cluster= " << DSViter->size();
 
@@ -921,7 +922,7 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
         if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end())
         {
           SiStripClusterInfo SiStripClusterInfo_(*ClusIter,es,detid);
-          clusterInfos(&SiStripClusterInfo_,detid,tTopo,OffTrack,LV);
+          clusterInfos(&SiStripClusterInfo_,detid,OffTrack,LV,MEs);
         }
       }
     }
@@ -929,7 +930,38 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
 }
 
 //------------------------------------------------------------------------
-bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t& detid, const TrackerTopology* tTopo, enum ClusterFlags flag, const LocalVector LV)
+SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology* tTopo, const uint32_t detid) {
+  SiStripHistoId hidmanager1;
+
+  std::string layer_id = hidmanager1.getSubdetid(detid, tTopo, false);
+  std::string ring_id  = hidmanager1.getSubdetid(detid, tTopo, true);
+  std::string sdet_tag = folderOrganizer_.getSubDetFolderAndTag(detid, tTopo).second;
+
+  Det2MEs me;
+  me.iLayer = nullptr;
+  me.iRing = nullptr;
+  me.iSubdet = nullptr;
+
+  std::map<std::string, LayerMEs>::iterator iLayer  = LayerMEsMap.find(layer_id);
+  if (iLayer != LayerMEsMap.end()) {
+    me.iLayer = &(iLayer->second);
+  }
+
+  std::map<std::string, RingMEs>::iterator iRing  = RingMEsMap.find(ring_id);
+  if (iRing != RingMEsMap.end()) {
+    me.iRing = &(iRing->second);
+  }
+
+  std::map<std::string, SubDetMEs>::iterator iSubdet  = SubDetMEsMap.find(sdet_tag);
+  if (iSubdet != SubDetMEsMap.end()) {
+    me.iSubdet = &(iSubdet->second);
+  }
+
+  return me;
+}
+
+//------------------------------------------------------------------------
+bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, const LocalVector LV, const Det2MEs& MEs)
 {
 
   if (cluster==NULL) return false;
@@ -941,11 +973,9 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
        cluster->width() > widthUpperLimit_) ) return false;
   // start of the analysis
 
-  std::pair<std::string,std::string> sdet_pair = folderOrganizer_.getSubDetFolderAndTag(detid,tTopo);
-  std::map<std::string, SubDetMEs>::iterator iSubdet  = SubDetMEsMap.find(sdet_pair.second);
-  if(iSubdet != SubDetMEsMap.end()){
-    if (flag == OnTrack) iSubdet->second.totNClustersOnTrack++;
-    else if (flag == OffTrack) iSubdet->second.totNClustersOffTrack++;
+  if (MEs.iSubdet != nullptr) {
+    if (flag == OnTrack) MEs.iSubdet->totNClustersOnTrack++;
+    else if (flag == OffTrack) MEs.iSubdet->totNClustersOffTrack++;
   }
 
   float cosRZ = -2;
@@ -957,8 +987,7 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
   std::string name;
 
   // Filling SubDet/Layer Plots (on Track + off Track)
-  fillMEs(cluster,detid,tTopo,cosRZ,flag,LV);
-
+  fillMEs(cluster,detid,cosRZ,flag,LV,MEs);
 
   //******** TkHistoMaps
   if (TkHistoMap_On_) {
@@ -990,7 +1019,7 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
 }
 #include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 //--------------------------------------------------------------------------------
-void SiStripMonitorTrack::fillModMEs(SiStripClusterInfo* cluster,std::string name,float cos,uint32_t detid, const LocalVector LV)
+void SiStripMonitorTrack::fillModMEs(SiStripClusterInfo* cluster,std::string name,float cos,const uint32_t detid, const LocalVector LV)
 {
   std::map<std::string, ModMEs>::iterator iModME  = ModMEsMap.find(name);
   if(iModME!=ModMEsMap.end()){
@@ -1036,15 +1065,10 @@ void SiStripMonitorTrack::fillModMEs(SiStripClusterInfo* cluster,std::string nam
   }
 }
 
-//------------------------------------------------------------------------
-void SiStripMonitorTrack::fillMEs(SiStripClusterInfo* cluster,uint32_t detid, const TrackerTopology* tTopo, float cos, enum ClusterFlags flag,  const LocalVector LV)
-{
-  std::pair<std::string,int32_t> SubDetAndLayer = folderOrganizer_.GetSubDetAndLayer(detid,tTopo,false);
-  SiStripHistoId hidmanager1;
-  std::string layer_id = hidmanager1.getSubdetid(detid,tTopo,false);
-  std::string ring_id  = hidmanager1.getSubdetid(detid, tTopo, true);
 
-  std::pair<std::string,std::string> sdet_pair = folderOrganizer_.getSubDetFolderAndTag(detid,tTopo);
+//------------------------------------------------------------------------
+void SiStripMonitorTrack::fillMEs(SiStripClusterInfo* cluster, const uint32_t detid, float cos, enum ClusterFlags flag,  const LocalVector LV, const Det2MEs& MEs)
+{
   float    StoN     = cluster->signalOverNoise();
   float    noise    = cluster->noiseRescaledByGain();
   uint16_t charge   = cluster->charge();
@@ -1061,57 +1085,55 @@ void SiStripMonitorTrack::fillMEs(SiStripClusterInfo* cluster,uint32_t detid, co
   float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, *cluster, locDir);
   
   // layerMEs
-  std::map<std::string, LayerMEs>::iterator iLayer  = LayerMEsMap.find(layer_id);
-  if (iLayer != LayerMEsMap.end()) {
+  if (MEs.iLayer != nullptr) {
     if(flag==OnTrack){
-      if(noise > 0.0) fillME(iLayer->second.ClusterStoNCorrOnTrack, StoN*cos);
+      if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrOnTrack, StoN*cos);
       if(noise == 0.0) LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << cluster->noiseRescaledByGain() << std::endl;
-      fillME(iLayer->second.ClusterChargeCorrOnTrack, charge*cos);
-      fillME(iLayer->second.ClusterChargeOnTrack, charge);
-      fillME(iLayer->second.ClusterNoiseOnTrack, noise);
-      fillME(iLayer->second.ClusterWidthOnTrack, width);
-      fillME(iLayer->second.ClusterPosOnTrack, position);
-      fillME(iLayer->second.ClusterChargePerCMfromTrack, dQdx_fromTrack);
-      fillME(iLayer->second.ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
+      fillME(MEs.iLayer->ClusterChargeCorrOnTrack, charge*cos);
+      fillME(MEs.iLayer->ClusterChargeOnTrack, charge);
+      fillME(MEs.iLayer->ClusterNoiseOnTrack, noise);
+      fillME(MEs.iLayer->ClusterWidthOnTrack, width);
+      fillME(MEs.iLayer->ClusterPosOnTrack, position);
+      fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
+      fillME(MEs.iLayer->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
     } else {
-      fillME(iLayer->second.ClusterChargeOffTrack, charge);
-      fillME(iLayer->second.ClusterNoiseOffTrack, noise);
-      fillME(iLayer->second.ClusterWidthOffTrack, width);
-      fillME(iLayer->second.ClusterPosOffTrack, position);
-      fillME(iLayer->second.ClusterChargePerCMfromOriginOffTrack, dQdx_fromOrigin);
+      fillME(MEs.iLayer->ClusterChargeOffTrack, charge);
+      fillME(MEs.iLayer->ClusterNoiseOffTrack, noise);
+      fillME(MEs.iLayer->ClusterWidthOffTrack, width);
+      fillME(MEs.iLayer->ClusterPosOffTrack, position);
+      fillME(MEs.iLayer->ClusterChargePerCMfromOriginOffTrack, dQdx_fromOrigin);
     }
   }
+
   // ringMEs
-  std::map<std::string, RingMEs>::iterator iRing  = RingMEsMap.find(ring_id);
-  if (iRing != RingMEsMap.end()) {
+  if (MEs.iRing != nullptr) {
     if(flag==OnTrack){
-      if(noise > 0.0) fillME(iRing->second.ClusterStoNCorrOnTrack, StoN*cos);
+      if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrOnTrack, StoN*cos);
       if(noise == 0.0) LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << cluster->noiseRescaledByGain() << std::endl;
-      fillME(iRing->second.ClusterChargeCorrOnTrack, charge*cos);
-      fillME(iRing->second.ClusterChargeOnTrack, charge);
-      fillME(iRing->second.ClusterNoiseOnTrack, noise);
-      fillME(iRing->second.ClusterWidthOnTrack, width);
-      fillME(iRing->second.ClusterChargePerCMfromTrack, dQdx_fromTrack);
-      fillME(iRing->second.ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
+      fillME(MEs.iRing->ClusterChargeCorrOnTrack, charge*cos);
+      fillME(MEs.iRing->ClusterChargeOnTrack, charge);
+      fillME(MEs.iRing->ClusterNoiseOnTrack, noise);
+      fillME(MEs.iRing->ClusterWidthOnTrack, width);
+      fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
+      fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
     } else {
-      fillME(iRing->second.ClusterChargeOffTrack, charge);
-      fillME(iRing->second.ClusterNoiseOffTrack, noise);
-      fillME(iRing->second.ClusterWidthOffTrack, width);
-      fillME(iRing->second.ClusterChargePerCMfromOriginOffTrack, dQdx_fromOrigin);
+      fillME(MEs.iRing->ClusterChargeOffTrack, charge);
+      fillME(MEs.iRing->ClusterNoiseOffTrack, noise);
+      fillME(MEs.iRing->ClusterWidthOffTrack, width);
+      fillME(MEs.iRing->ClusterChargePerCMfromOriginOffTrack, dQdx_fromOrigin);
     }
   }
   // subdetMEs
-  std::map<std::string, SubDetMEs>::iterator iSubdet  = SubDetMEsMap.find(sdet_pair.second);
-  if(iSubdet != SubDetMEsMap.end() ){
+  if(MEs.iSubdet != nullptr){
     if(flag==OnTrack){
-      fillME(iSubdet->second.ClusterChargeOnTrack,charge);
-      if(noise > 0.0) fillME(iSubdet->second.ClusterStoNCorrOnTrack,StoN*cos);
-      fillME(iSubdet->second.ClusterChargePerCMfromTrack,dQdx_fromTrack);
-      fillME(iSubdet->second.ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
+      fillME(MEs.iSubdet->ClusterChargeOnTrack,charge);
+      if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrOnTrack,StoN*cos);
+      fillME(MEs.iSubdet->ClusterChargePerCMfromTrack,dQdx_fromTrack);
+      fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
     } else {
-      fillME(iSubdet->second.ClusterChargeOffTrack,charge);
-      if(noise > 0.0) fillME(iSubdet->second.ClusterStoNOffTrack,StoN);
-      fillME(iSubdet->second.ClusterChargePerCMfromOriginOffTrack,dQdx_fromOrigin);
+      fillME(MEs.iSubdet->ClusterChargeOffTrack,charge);
+      if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNOffTrack,StoN);
+      fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOffTrack,dQdx_fromOrigin);
     }
   }
 }

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -684,7 +684,7 @@ void SiStripRecHitsValid::createMEs(DQMStore::IBooker & ibooker,const edm::Event
       createLayerMEs(ibooker,label);
     }
     // book sub-detector plots 
-    std::pair<std::string,std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+    auto sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
     // std::cout << "sdet_pair " << sdet_pair.first << " " << sdet_pair.second << std::endl;
     if (SubDetMEsMap.find(det_layer_pair.first) == SubDetMEsMap.end()){
       ibooker.setCurrentFolder(sdet_pair.first);


### PR DESCRIPTION
Optimize SiStripMonitorTrack to perform less string operations.

https://hypernews.cern.ch/HyperNews/CMS/get/swDevelopment/3171.html

before: http://micius.web.cern.ch/micius/cgi-bin/igprof-navigator/sistrip_original/76
after: http://micius.web.cern.ch/micius/cgi-bin/igprof-navigator/sistrip_modified/80

Please review and test.
