### PR TITLE
ROOT6 checksums must be known to ROOT5

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -17,6 +17,7 @@
 
   <!-- PAT Objects, and embedded data  -->
   <class name="pat::Electron"  ClassVersion="29">
+   <version ClassVersion="30" checksum="3949366163"/>
    <version ClassVersion="29" checksum="1784986402"/>
    <version ClassVersion="28" checksum="2518240031"/>
    <version ClassVersion="27" checksum="3863179876"/>
@@ -51,6 +52,7 @@
 
 
   <class name="pat::Muon"  ClassVersion="17">
+   <version ClassVersion="18" checksum="1163602263"/>
    <version ClassVersion="17" checksum="1509153359"/>
    <version ClassVersion="16" checksum="2674665735"/>
    <version ClassVersion="15" checksum="1248517999"/>


### PR DESCRIPTION
To prevent inconsistent version numbers, ROOT6 version numbers and checksums must be known in the ROOT5 release under development. This PR adds the new ROOT6 version numbers for two classes to the releases using ROOT5.
This is a purely technical PR.
