### PR TITLE
Remove unnecessary ROOT5/ROOT6 difference in SimDataFormats/PileupSummar...

### DIFF
--- a/SimDataFormats/PileupSummaryInfo/BuildFile.xml
+++ b/SimDataFormats/PileupSummaryInfo/BuildFile.xml
@@ -1,9 +1,7 @@
 <use   name="DataFormats/Math"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
-<use   name="SimDataFormats/GeneratorProducts"/>
-<use   name="clhep"/>
-
+<use   name="hepmc"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
This PR is part of a campaign to remove unnecessary differences in CMSSW between 7_4_X and 7_4_ROOT6_X. In this particular case, the 7_4_ROOT6_X build file is superior to the 7_4_X build file, in that it avoids unnecessary dependencies. So, in this case, it is 7_4_X/7_5_X that is being updated.
