### PR TITLE
Remove unnecessary ROOT5/ROOT6 diff in TrackingTools/TrajectoryState

### DIFF
--- a/TrackingTools/TrajectoryState/BuildFile.xml
+++ b/TrackingTools/TrajectoryState/BuildFile.xml
@@ -6,11 +6,11 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/TrajectoryState"/>
 <use   name="DataFormats/BeamSpot"/>
-<use   name="MagneticField/Engine"/>
 <use   name="TrackingTools/AnalyticalJacobians"/>
 <use   name="TrackingTools/TrajectoryParametrization"/>
+<use   name="MagneticField/Engine"/>
 
-<use   name="vdt"/>
+<use   name="vdt_headers"/>
 <export>
   <lib   name="1"/>
 </export>


### PR DESCRIPTION
Remove an unnecessary difference between 7_4_X and 7_4_ROOT6_X in this build file.  The 7_4_X build file is superior, so 7_4_ROOT6_X will be modified.
Please merge this request as soon as convenient.
