### PR TITLE
Remove unnecessary ROOT5/ROOT6 diff in SimDataFormats/ValidationFormats

### DIFF
--- a/SimDataFormats/ValidationFormats/BuildFile.xml
+++ b/SimDataFormats/ValidationFormats/BuildFile.xml
@@ -1,7 +1,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/GeometryVector"/>
 <use   name="clhep"/>
-<use   name="geant4"/>
+<use   name="geant4core"/>
 
 <use   name="expat"/>
 <export>


### PR DESCRIPTION
Remove an unnecessary difference between 7_4_X and 7_4_ROOT6_X in this build file. The 7_4_X build file is superior, so 7_4_ROOT6_X will be modified.
Please merge this request as soon as convenient.
