### PR TITLE
Remove unnecessary ROOT5/ROOT6 diffs in SimDataFormats/GeneratorInterfac...

### DIFF
--- a/SimDataFormats/GeneratorProducts/src/classes.h
+++ b/SimDataFormats/GeneratorProducts/src/classes.h
@@ -3,21 +3,6 @@
 #include <map>
 #include <set>
 
-// BEGIN WORKAROUND for HepMC
-#include "HepMC/WeightContainer.h"
-#include "HepMC/SimpleVector.h"
-#include "HepMC/IteratorRange.h"
-#include <iostream>
-#include <iterator>
-//#include <vector>
-//#include <set>
-#include <algorithm>
-#include <cstddef>
-#define protected public
-#include "HepMC/GenVertex.h"
-#undef protected
-// END WORKAROUND for HepMC
-
 #include "DataFormats/Common/interface/Wrapper.h"
 #include "DataFormats/Common/interface/RefVector.h"
 
@@ -31,8 +16,7 @@
 #include "SimDataFormats/GeneratorProducts/interface/GenFilterInfo.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 #include "SimDataFormats/GeneratorProducts/interface/GenLumiInfoProduct.h"
-
-#include "HepMC/GenRanges.h"
+#include <HepMC/GenRanges.h>
 
 namespace SimDataFormats_GeneratorProducts {
 	struct dictionary {

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -17,7 +17,6 @@
      <version ClassVersion="10" checksum="920043842"/>
     </class>
 	<class name="HepMC::WeightContainer" ClassVersion="14">
-  <version ClassVersion="14" checksum="481001444"/>
   <version ClassVersion="10" checksum="2163093401"/>
   <version ClassVersion="11" checksum="376377869"/>
   <version ClassVersion="12" checksum="2537869863"/>


### PR DESCRIPTION
Remove unnecessary differences between 7_4_X and 7_4_ROOT6_X in this package, as a workaround used earlier for ROOT6 is no longer needed.  Also, in an XML spec file, there was a duplicate line that this PR removes.
Please merge as soon as convenient.
