### PR TITLE
Remove unnecessary ROOT5/ROOT6 diffs in CondCore/IOVService

### DIFF
--- a/CondCore/IOVService/test/classes.h
+++ b/CondCore/IOVService/test/classes.h
@@ -1,1 +1,1 @@
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"

--- a/CondCore/IOVService/test/testIOVCopy.cc
+++ b/CondCore/IOVService/test/testIOVCopy.cc
@@ -6,7 +6,7 @@
 #include "CondCore/DBCommon/interface/DbTransaction.h"
 #include "CondCore/DBCommon/interface/Exception.h"
 #include "CondCore/IOVService/interface/IOVEditor.h"
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"
 #include <iostream>
 
 int main(){

--- a/CondCore/IOVService/test/testIOVDelete.cc
+++ b/CondCore/IOVService/test/testIOVDelete.cc
@@ -6,7 +6,7 @@
 #include "CondCore/DBCommon/interface/DbTransaction.h"
 #include "CondCore/DBCommon/interface/Exception.h"
 #include "CondCore/IOVService/interface/IOVEditor.h"
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"
 #include <iostream>
 int main(){
   edmplugin::PluginManager::Config config;

--- a/CondCore/IOVService/test/testqueryPContainer.cc
+++ b/CondCore/IOVService/test/testqueryPContainer.cc
@@ -5,7 +5,7 @@
 #include "CondCore/DBCommon/interface/Exception.h"
 #include "CondCore/DBCommon/interface/DbTransaction.h"
 #include "CondCore/IOVService/interface/IOVEditor.h"
-#include "testPayloadObj.h"
+#include "CondCore/IOVService/test/testPayloadObj.h"
 #include <iostream>
 int main(){
   edmplugin::PluginManager::Config config;


### PR DESCRIPTION
Some changes made to CondCore/IOVService in CMSSW_7_4_ROOT6_X should have also been made in CMSSW_7_4_X for code compatibility.  This PR makes these changes in 7_4_X.
The changes are trivial, namely using the correct relative path to an included local header.
