### PR TITLE
Improvements to memory handling of LHE ascii blobs (add lzma compression)

### DIFF
--- a/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
+++ b/GeneratorInterface/LHEInterface/plugins/ExternalLHEAsciiDumper.cc
@@ -74,23 +74,42 @@ ExternalLHEAsciiDumper::endRun(edm::Run const& iRun, edm::EventSetup const&) {
   
   const std::vector<std::string>& lheOutputs = LHEAscii->getStrings();
 
+  unsigned int iout = 0;
+  
   size_t lastdot = lheFileName_.find_last_of(".");
   std::string basename = lheFileName_.substr(0, lastdot);
   std::string extension = lastdot != std::string::npos ?  lheFileName_.substr(lastdot+1, std::string::npos) : "";
 
   for (unsigned int i = 0; i < lheOutputs.size(); ++i){
     std::ofstream outfile;
-    if (i == 0)
+    if (iout == 0)
       outfile.open (lheFileName_.c_str(), std::ofstream::out | std::ofstream::app);
     else {
       std::stringstream fname;
-      fname << basename << "_" << i ;
+      fname << basename << "_" << iout ;
       if (extension != "")
         fname << "." << extension;
       outfile.open (fname.str().c_str(), std::ofstream::out | std::ofstream::app);
     }
     outfile << lheOutputs[i];
     outfile.close();
+    ++iout;
+  }
+  
+  for (unsigned int i = 0; i < LHEAscii->getCompressed().size(); ++i){
+    std::ofstream outfile;
+    if (iout == 0)
+      outfile.open (lheFileName_.c_str(), std::ofstream::out | std::ofstream::app);
+    else {
+      std::stringstream fname;
+      fname << basename << "_" << iout ;
+      if (extension != "")
+        fname << "." << extension;
+      outfile.open (fname.str().c_str(), std::ofstream::out | std::ofstream::app);
+    }
+    LHEAscii->writeCompressedContent(outfile,i);
+    outfile.close();
+    ++iout;
   }
 
 }

--- a/GeneratorInterface/LHEInterface/test/testExternalLHEAsciiDumper_cfg.py
+++ b/GeneratorInterface/LHEInterface/test/testExternalLHEAsciiDumper_cfg.py
@@ -7,7 +7,8 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(-1)
 )
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:lheOutputFile.root')
+    fileNames = cms.untracked.vstring('file:lheOutputFile.root'),
+    processingMode = cms.untracked.string('Runs'),
 )
 
 process.load("GeneratorInterface/LHEInterface/ExternalLHEAsciiDumper_cfi")

--- a/SimDataFormats/GeneratorProducts/BuildFile.xml
+++ b/SimDataFormats/GeneratorProducts/BuildFile.xml
@@ -2,7 +2,7 @@
 <use   name="FWCore/MessageLogger"/>
 <use   name="DataFormats/Common"/>
 <use   name="hepmc"/>
-
+<use   name="xz"/>
 <use   name="roothistmatrix"/>
 <export>
   <lib   name="1"/>

--- a/SimDataFormats/GeneratorProducts/interface/LHEXMLStringProduct.h
+++ b/SimDataFormats/GeneratorProducts/interface/LHEXMLStringProduct.h
@@ -7,14 +7,14 @@
 
 #include <string>
 #include <vector>
+#include <stdint.h>
 
 class LHEXMLStringProduct {
 public:
-  
+    
   // constructors, destructors
   LHEXMLStringProduct();
   LHEXMLStringProduct(const std::string& content);
-  LHEXMLStringProduct(const std::vector<std::string>& content);
   virtual ~LHEXMLStringProduct();
   
   // getters
@@ -22,12 +22,20 @@ public:
     return content_; 
   }
 
+  const std::vector<std::vector<uint8_t> >& getCompressed() const{
+    return compressedContent_; 
+  }
+  
+  void fillCompressedContent(std::istream &input, unsigned int initialSize = 4*1024*1024);
+  void writeCompressedContent(std::ostream &output, unsigned int i) const;
+  
   // merge method. It will be used when merging different jobs populating the same lumi section
   bool mergeProduct(LHEXMLStringProduct const &other);
   
   
 private:
   std::vector<std::string> content_;
+  std::vector<std::vector<uint8_t> > compressedContent_;
 
 };
 

--- a/SimDataFormats/GeneratorProducts/src/LHEXMLStringProduct.cc
+++ b/SimDataFormats/GeneratorProducts/src/LHEXMLStringProduct.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <algorithm> 
+#include <lzma.h>
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
@@ -19,19 +20,122 @@ LHEXMLStringProduct::LHEXMLStringProduct(const string& onelheoutput) :
   content_.push_back(onelheoutput);
 }
 
-LHEXMLStringProduct::LHEXMLStringProduct(const vector<string>& manylheoutput) :
-  content_()
-{
-  content_.insert(content_.end(), manylheoutput.begin(), manylheoutput.end());
-}
 
 LHEXMLStringProduct::~LHEXMLStringProduct()
 {
 }
 
+void LHEXMLStringProduct::fillCompressedContent(std::istream &input, unsigned int initialSize) {
+  //create blob with desired size
+  compressedContent_.emplace_back(initialSize);
+  std::vector<uint8_t> &output = compressedContent_.back();
+    
+  //read buffer
+  constexpr unsigned int bufsize = 4096;
+  char inbuf[bufsize];
+  
+  //initialize lzma
+  uint32_t preset = 9;
+  lzma_stream strm = LZMA_STREAM_INIT;
+  lzma_ret ret = lzma_easy_encoder(&strm, preset, LZMA_CHECK_CRC64);
+  
+  lzma_action action = LZMA_RUN;
+  
+  strm.next_in = reinterpret_cast<uint8_t*>(&inbuf[0]);
+  strm.avail_in = 0;
+  strm.next_out = output.data();
+  strm.avail_out = output.size();
+  
+  unsigned int compressedSize = 0;
+    
+  while (ret==LZMA_OK) {
+    //read input to buffer if necessary
+    if (strm.avail_in == 0 && !input.eof()) {
+      input.read(inbuf, bufsize);
+      strm.next_in = reinterpret_cast<uint8_t*>(&inbuf[0]);
+      strm.avail_in = input.gcount();
+      if (input.eof()) {
+        //signal to lzma that there is no more input
+        action = LZMA_FINISH;
+      }
+    }
+
+    //actual compression
+    ret = lzma_code(&strm, action);
+    
+    //update compressed size
+    compressedSize = output.size() - strm.avail_out;
+    
+    //if output blob is full and compression is still going, allocate more memory
+    if (strm.avail_out == 0 && ret==LZMA_OK) {
+      unsigned int oldsize = output.size();
+      output.resize(2*oldsize);
+      strm.next_out = &output[oldsize];
+      strm.avail_out = output.size() - oldsize;
+    }
+    
+  }
+  
+  lzma_end(&strm);
+  
+  if (ret!=LZMA_STREAM_END) {
+    throw cms::Exception("CompressionError")
+      << "There was a failure in LZMA compression in LHEXMLStringProduct.";
+  }
+  
+  //trim output blob
+  output.resize(compressedSize);
+  
+}
+
+void LHEXMLStringProduct::writeCompressedContent(std::ostream &output, unsigned int i) const {
+  
+  //initialize lzma
+  lzma_stream strm = LZMA_STREAM_INIT;
+  lzma_ret ret = lzma_stream_decoder(&strm, UINT64_MAX, LZMA_CONCATENATED);
+  //all output available from the start, so start "close out" immediately
+  lzma_action action = LZMA_FINISH;
+  
+  //write buffer
+  constexpr unsigned int bufsize = 4096;
+  char outbuf[bufsize];
+  
+  const std::vector<uint8_t> &input = compressedContent_[i];
+  
+  strm.next_in = input.data();
+  strm.avail_in = input.size();
+  strm.next_out = reinterpret_cast<uint8_t*>(&outbuf[0]);
+  strm.avail_out = bufsize;
+  
+  while (ret==LZMA_OK) {
+    
+    ret = lzma_code(&strm, action);
+    
+    //write to stream
+    output.write(outbuf,bufsize-strm.avail_out);
+    
+    //output buffer full, recycle
+    if (strm.avail_out==0 && ret==LZMA_OK) {
+      strm.next_out = reinterpret_cast<uint8_t*>(&outbuf[0]);
+      strm.avail_out = bufsize;
+    }
+  }
+    
+  lzma_end(&strm);
+  
+  if (ret!=LZMA_STREAM_END) {
+    throw cms::Exception("DecompressionError")
+      << "There was a failure in LZMA decompression in LHEXMLStringProduct.";
+  }
+  
+}
+
+
+
 bool LHEXMLStringProduct::mergeProduct(LHEXMLStringProduct const &other)
 {
-  content_.insert(content_.end(), other.getStrings().begin(), other.getStrings().end());  
+  content_.insert(content_.end(), other.getStrings().begin(), other.getStrings().end());
+  compressedContent_.insert(compressedContent_.end(), other.getCompressed().begin(), other.getCompressed().end());
   return true;
 }
 

--- a/SimDataFormats/GeneratorProducts/src/classes_def.xml
+++ b/SimDataFormats/GeneratorProducts/src/classes_def.xml
@@ -178,8 +178,9 @@
 	<class name="LHERunInfoProduct::Header" ClassVersion="10">
   <version ClassVersion="10" checksum="1310911082"/>
  </class>
- <class name="LHEXMLStringProduct" ClassVersion="10">
+ <class name="LHEXMLStringProduct" ClassVersion="11">
   <version ClassVersion="10" checksum="4158740350"/>
+  <version ClassVersion="11" checksum="3778311764"/>
  </class> 
  <class name="edm::Wrapper&lt;LHEXMLStringProduct&gt;"/>
 	<class name="std::vector&lt;LHERunInfoProduct::Header&gt;"/>


### PR DESCRIPTION
Solves in a minimal way (ie without changing the basic workflow) the large memory usage issue discussed in
https://hypernews.cern.ch/HyperNews/CMS/get/edmFramework/3458/1/1/1/1/1/1/1/1/1/2/1/1/1/1/1/1/1/1/1/3/1/1/1.html

Basically the uncompressed ascii blobs from the lhe's were loaded into memory all at once and killing both LHE merge and GEN-SIM jobs in production.  (The straw that broke the camel's back being the increase in the number of alternate pdf weights used for LO madgraph in Run 2 production)
