### PR TITLE
Drop unneeded explicit dependency in 7_4_X

### DIFF
--- a/AnalysisAlgos/TrackInfoProducer/test/BuildFile.xml
+++ b/AnalysisAlgos/TrackInfoProducer/test/BuildFile.xml
@@ -12,7 +12,6 @@
 <use   name="clhep"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <library   file="TrackInfoAnalyzer.cc" name="TrackInfoAnalyzer">
   <flags   EDM_PLUGIN="1"/>

--- a/CalibTracker/SiPixelErrorEstimation/BuildFile.xml
+++ b/CalibTracker/SiPixelErrorEstimation/BuildFile.xml
@@ -23,7 +23,6 @@
 <use   name="TrackingTools/KalmanUpdators"/>
 <use   name="TrackingTools/MaterialEffects"/>
 <use   name="TrackingTools/Records"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <use   name="rootmath"/>
 <use   name="clhep"/>

--- a/CalibTracker/SiPixelLorentzAngle/BuildFile.xml
+++ b/CalibTracker/SiPixelLorentzAngle/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="SimTracker/TrackerHitAssociation"/>
 <use   name="MagneticField/Records"/>
 <use   name="MagneticField/VolumeBasedEngine"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <use   name="clhep"/>
 <use   name="boost"/>

--- a/CondCore/DBCommon/plugins/BuildFile.xml
+++ b/CondCore/DBCommon/plugins/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Concurrency"/>
 <use   name="CondCore/DBCommon"/>
-<use   name="rootcintex"/>
 <use   name="zlib"/>
 <library   file="SQLiteProxy.cc" name="CondCoreDBCommonSQLiteProxy">
   <flags   EDM_PLUGIN="1"/>

--- a/CondCore/DBCommon/test/BuildFile.xml
+++ b/CondCore/DBCommon/test/BuildFile.xml
@@ -40,6 +40,5 @@
 <bin   file="testCipher.cc" name="testCipher">
 </bin>
 <bin   file="testBlobStreaming.cpp" name="testBlobStreaming">
-  <use   name="rootcintex"/>
   <use   name="zlib"/>
 </bin>

--- a/CondCore/Utilities/BuildFile.xml
+++ b/CondCore/Utilities/BuildFile.xml
@@ -36,7 +36,6 @@
 <use   name="CondFormats/Common"/>
 <use   name="CondFormats/BTauObjects"/>
 <use   name="CondFormats/MFObjects"/>
-<use   name="rootcintex"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CondCore/Utilities/bin/BuildFile.xml
+++ b/CondCore/Utilities/bin/BuildFile.xml
@@ -3,7 +3,6 @@
 <flags CXXFLAGS="-Wno-sign-compare -Wno-unused-variable -ftemplate-depth=600"/>
 
 <bin   file="cmscond_list_iov.cpp" name="cmscond_list_iov">
-  <use   name="rootcintex"/>
 </bin>
 <bin   file="cmscond_duplicate_iov.cpp" name="cmscond_duplicate_iov">
 </bin>
@@ -28,7 +27,6 @@
 <bin   file="cmscond_edit_iov.cpp" name="cmscond_edit_iov">
 </bin>
 <bin   file="cmscond_2XML.cpp" name="cmscond_2XML">
-  <use   name="rootcintex"/>
 </bin>
 <bin   file="cmscond_to_lumiid.cpp" name="cmscond_to_lumiid">
   <use   name="DataFormats/Provenance"/>

--- a/CondCore/Utilities/plugins/BuildFile.xml
+++ b/CondCore/Utilities/plugins/BuildFile.xml
@@ -4,7 +4,6 @@
   <use   name="boost_filesystem"/>
   <use   name="boost_python"/>
   <use   name="boost_regex"/>
-  <use   name="rootcintex"/>
 </library>
 <library   file="EmptyIOVSource.cc" name="CondEmptyIOVSource">
   <use   name="CondCore/CondDB"/>

--- a/DPGAnalysis/SiStripTools/bin/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/bin/BuildFile.xml
@@ -1,6 +1,5 @@
 <library   name="DPGAnalysisSiStripToolsMacros" file="*.cc">
 <use   name="DPGAnalysis/SiStripTools"/>
 <use   name="root"/>
-<use   name="rootcintex"/>
 <use   name="rootgraphics"/>
 </library>

--- a/DQM/SiStripHistoricInfoClient/bin/BuildFile.xml
+++ b/DQM/SiStripHistoricInfoClient/bin/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="DQMServices/Diagnostic"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/FWLite"/>
-<use name="rootcintex"/>
 <use name="root"/>
 <use name="boost"/>
 <environment>

--- a/DQM/SiStripMonitorClient/bin/BuildFile.xml
+++ b/DQM/SiStripMonitorClient/bin/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="root"/>
-<use   name="rootcintex"/>
 <use   name="rootgraphics"/>
 <bin   name="check_runcomplete" file="check_runcomplete.cc"></bin>
 <bin   name="listbadmodule" file="listbadmodule.cc"></bin>

--- a/DQM/SiStripMonitorSummary/bin/BuildFile.xml
+++ b/DQM/SiStripMonitorSummary/bin/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="root"/>
-<use   name="rootcintex"/>
 <use   name="rootgraphics"/>
 <bin   name="makePlots" file="makePlots.cc"></bin>
 <bin   name="makeTKTrend" file="makeTKTrend.cc"></bin>

--- a/DQMServices/Core/BuildFile.xml
+++ b/DQMServices/Core/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Version"/>
 <use   name="classlib"/>
-<use   name="rootcintex"/>
 <use   name="roothistmatrix"/>
 <use   name="protobuf"/>
 <export>

--- a/DQMServices/StreamerIO/BuildFile.xml
+++ b/DQMServices/StreamerIO/BuildFile.xml
@@ -14,7 +14,6 @@
 <use   name="Utilities/StorageFactory"/>
 <use   name="HLTrigger/HLTanalyzers"/>
 <use   name="boost"/>
-<use   name="rootcintex"/>
 <use   name="rootcore"/>
 <use   name="zlib"/>
 

--- a/DataFormats/Common/test/BuildFile.xml
+++ b/DataFormats/Common/test/BuildFile.xml
@@ -2,7 +2,6 @@
 <use   name="cppunit"/>
 <use   name="DataFormats/Common"/>
 <bin   name="testDataFormatsCommon" file="testRunner.cpp,testOwnVector.cc,testOneToOneAssociation.cc,testValueMap.cc,testOneToManyAssociation.cc,testAssociationVector.cc,testAssociationNew.cc,testValueMapNew.cc,testSortedCollection.cc,testRangeMap.cc,testIDVectorMap.cc,ref_t.cppunit.cc,DetSetRefVector_t.cppunit.cc,DetSetLazyVector_t.cppunit.cc,reftobase_t.cppunit.cc,reftobasevector_t.cppunit.cc,cloningptr_t.cppunit.cc,ptr_t.cppunit.cc,ptrvector_t.cppunit.cc,containermask_t.cppunit.cc,reftobaseprod_t.cppunit.cc,atomicptrcache_t.cppunit.cc,handle_t.cppunit.cc">
-  <use   name="rootcintex"/>
 </bin>
 <bin   file="DetSetVector_t.cpp">
 </bin>
@@ -11,7 +10,6 @@
 <bin   file="DictionaryTools_t.cpp">
   <use   name="DataFormats/StdDictionaries"/>
   <use   name="DataFormats/WrappedStdDictionaries"/>
-  <use   name="rootcintex"/>
 </bin>
 <bin   file="Wrapper_t.cpp">
 </bin>

--- a/DataFormats/Provenance/test/BuildFile.xml
+++ b/DataFormats/Provenance/test/BuildFile.xml
@@ -2,7 +2,6 @@
 <use   name="cppunit"/>
 <use   name="DataFormats/Provenance"/>
 <bin   name="testDataFormatsProvenance"file="testRunner.cpp,eventid_t.cppunit.cc,timestamp_t.cppunit.cc,parametersetid_t.cppunit.cc,indexIntoFile_t.cppunit.cc,indexIntoFile1_t.cppunit.cc,indexIntoFile2_t.cppunit.cc,indexIntoFile3_t.cppunit.cc,indexIntoFile4_t.cppunit.cc,indexIntoFile5_t.cppunit.cc,lumirange_t.cppunit.cc,eventrange_t.cppunit.cc">
-  <use   name="rootcintex"/>
 </bin>
 <bin   file="EntryDescription_t.cpp">
 </bin>

--- a/DataFormats/TrackerCommon/BuildFile.xml
+++ b/DataFormats/TrackerCommon/BuildFile.xml
@@ -3,7 +3,6 @@
 <use name="DataFormats/SiPixelDetId"/>
 <use name="FWCore/MessageLogger"/>
 <use name="FWCore/Utilities"/>
-<use name="rootcintex"/>
 <export>
  <lib   name="1"/>
 </export>

--- a/DataFormats/VertexReco/test/BuildFile.xml
+++ b/DataFormats/VertexReco/test/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
 <use   name="DataFormats/VertexReco"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <bin   name="testDataFormatsVertexReco" file="testVertex.cc,testRunner.cpp">
   <use   name="cppunit"/>

--- a/FWCore/FWLite/BuildFile.xml
+++ b/FWCore/FWLite/BuildFile.xml
@@ -4,7 +4,6 @@
 <use   name="FWCore/RootAutoLibraryLoader"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
-<use   name="rootcintex"/>
 <use   name="rootcore"/>
 <export>
   <lib   name="1"/>

--- a/FWCore/Framework/BuildFile.xml
+++ b/FWCore/Framework/BuildFile.xml
@@ -9,7 +9,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/Version"/>
 <use   name="boost"/>
-<use   name="rootcintex"/>
 <use   name="rootcore"/>
 <flags ADD_SUBDIR="1"/>
 <export>

--- a/FWCore/Framework/test/BuildFile.xml
+++ b/FWCore/Framework/test/BuildFile.xml
@@ -200,7 +200,6 @@
   <use   name="FWCore/RootAutoLibraryLoader"/>
   <use   name="FWCore/Utilities"/>
   <use   name="FWCore/Version"/>
-  <use   name="rootcintex"/>
   <use   name="cppunit"/>
 </bin>
 <bin   name="TestFWCoreFrameworkView" file="View_t.cpp">

--- a/FWCore/RootAutoLibraryLoader/BuildFile.xml
+++ b/FWCore/RootAutoLibraryLoader/BuildFile.xml
@@ -2,7 +2,6 @@
   <lib   name="1"/>
 </export>
 <use   name="FWCore/PluginManager"/>
-<use   name="rootcintex"/>
 <use   name="rootcore"/>
 <use   name="boost_regex"/>
 <use   name="boost"/>

--- a/FWCore/Services/BuildFile.xml
+++ b/FWCore/Services/BuildFile.xml
@@ -10,7 +10,6 @@
 <use   name="FWCore/Concurrency"/>
 <use   name="FWCore/Framework"/>
 <use   name="boost"/>
-<use   name="rootcintex"/>
 <use   name="rootcore"/>
 <use   name="roothistmatrix"/>
 <use   name="xerces-c"/>

--- a/FastSimulation/TrackingRecHitProducer/test/BuildFile.xml
+++ b/FastSimulation/TrackingRecHitProducer/test/BuildFile.xml
@@ -15,7 +15,6 @@
 <use   name="SimTracker/TrackerHitAssociation"/>
 <use   name="SimDataFormats/TrackerDigiSimLink"/>
 <use   name="clhep"/>
-<use   name="rootcintex"/>
 <use   name="rootgraphics"/>
 <library   file="FamosRecHitAnalysis.cc" name="FamosRecHitAnalysis">
   <use   name="FWCore/Framework"/>

--- a/Fireworks/Core/BuildFile.xml
+++ b/Fireworks/Core/BuildFile.xml
@@ -21,7 +21,6 @@
 <use name="boost_regex"/>
 <use name="boost_system"/>
 <use name="opengl"/>
-<use name="rootcintex"/>
 <use name="rootinteractive"/>
 <use name="rootgraphics"/>
 <use name="sigcpp"/>

--- a/Fireworks/Core/test/BuildFile.xml
+++ b/Fireworks/Core/test/BuildFile.xml
@@ -2,7 +2,6 @@
  <use name="DataFormats/TrackReco"/>
  <use name="Fireworks/Core"/>
  <use name="boost"/>
- <use name="rootcintex"/>
  <use name="rootcore"/>
  <use name="boost_test"/>
 </bin>

--- a/Fireworks/TableWidget/BuildFile.xml
+++ b/Fireworks/TableWidget/BuildFile.xml
@@ -1,4 +1,3 @@
-<use name="rootcintex"/>
 <use name="rootinteractive"/>
 <export>
   <lib name="1"/>

--- a/HLTrigger/Timer/test/BuildFile.xml
+++ b/HLTrigger/Timer/test/BuildFile.xml
@@ -3,7 +3,6 @@
   <use   name="DataFormats/HLTReco"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  <use   name="rootcintex"/>
   <use   name="root"/>
 </bin>
 

--- a/HLTrigger/Tools/bin/BuildFile.xml
+++ b/HLTrigger/Tools/bin/BuildFile.xml
@@ -5,6 +5,5 @@
   <use   name="DataFormats/HLTReco"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  <use   name="rootcintex"/>
   <use   name="rootgraphics"/>
 </bin>

--- a/IOPool/Common/bin/BuildFile.xml
+++ b/IOPool/Common/bin/BuildFile.xml
@@ -1,7 +1,6 @@
 <bin   name="edmProvDump" file="EdmProvDump.cc,">
   <use   name="boost_program_options"/>
   <use   name="rootcore"/>
-  <use   name="rootcintex"/>
   <use   name="DataFormats/Provenance"/>
   <use   name="FWCore/Catalog"/>
   <use   name="FWCore/ParameterSet"/>

--- a/IOPool/Streamer/BuildFile.xml
+++ b/IOPool/Streamer/BuildFile.xml
@@ -12,7 +12,6 @@
 <use   name="FWCore/Version"/>
 <use   name="Utilities/StorageFactory"/>
 <use   name="boost"/>
-<use   name="rootcintex"/>
 <use   name="rootcore"/>
 <use   name="zlib"/>
 <export>

--- a/MuonAnalysis/MomentumScaleCalibration/bin/BuildFile.xml
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="DataFormats/FWLite"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/FWLite"/>
-<use   name="rootcintex"/>
 <use   name="boost"/>
 <use   name="CommonTools/Utils"/>
 <use   name="PhysicsTools/Utilities"/>

--- a/PhysicsTools/CondLiteIO/test/BuildFile.xml
+++ b/PhysicsTools/CondLiteIO/test/BuildFile.xml
@@ -9,7 +9,6 @@
    
    <bin name="testPhysicsToolsCondLiteIO"
       file="recordwriter.cppunit.cpp">
-      <use name="rootcintex"/>
       <use name="rootcore"/>
       <use name="DataFormats/StdDictionaries"/>
       <use name="DataFormats/TestObjects"/>

--- a/PhysicsTools/FWLite/BuildFile.xml
+++ b/PhysicsTools/FWLite/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="boost"/>
 <use   name="rootcore"/>
-<use   name="rootcintex"/>
 <use   name="roothistmatrix"/>
 <use   name="CommonTools/Utils"/>
 <use   name="DataFormats/FWLite"/>

--- a/PhysicsTools/FWLite/bin/BuildFile.xml
+++ b/PhysicsTools/FWLite/bin/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="root"/>
 <use   name="boost"/>
-<use   name="rootcintex"/>
 <use   name="FWCore/FWLite"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="DataFormats/Luminosity"/>

--- a/PhysicsTools/MVAComputer/bin/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/bin/BuildFile.xml
@@ -1,13 +1,11 @@
 <bin   name="mvaConvertTMVAWeights" file="mvaConvertTMVAWeights.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  <use   name="rootcintex"/>
   <use   name="rootcore"/>
 </bin>
 <bin   name="mvaExtractPDFs" file="mvaExtractPDFs.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  <use   name="rootcintex"/>
   <use   name="rootcore"/>
   <use   name="roothistmatrix"/>
 </bin>

--- a/PhysicsTools/MVATrainer/bin/BuildFile.xml
+++ b/PhysicsTools/MVATrainer/bin/BuildFile.xml
@@ -3,19 +3,16 @@
   <use   name="FWCore/PluginManager"/>
   <use   name="PhysicsTools/MVAComputer"/>
   <use   name="PhysicsTools/MVATrainer"/>
-  <use   name="rootcintex"/>
   <use   name="rootcore"/>
 </bin>
 <bin   name="mvaTreeComputer" file="mvaTreeComputer.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="FWCore/PluginManager"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  <use   name="rootcintex"/>
   <use   name="rootcore"/>
 </bin>
 <bin   name="mvaExtractor" file="mvaExtractor.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  <use   name="rootcintex"/>
   <use   name="rootcore"/>
 </bin>

--- a/PhysicsTools/PatExamples/bin/BuildFile.xml
+++ b/PhysicsTools/PatExamples/bin/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="root"/>
-<use   name="rootcintex"/>
 <use   name="FWCore/FWLite"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="FWCore/PythonParameterSet"/>

--- a/PhysicsTools/SelectorUtils/bin/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/bin/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="FWCore/FWLite"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PythonParameterSet"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <use   name="boost"/>
 <use   name="boost_python"/>

--- a/RecoBTag/PerformanceDB/bin/BuildFile.xml
+++ b/RecoBTag/PerformanceDB/bin/BuildFile.xml
@@ -9,11 +9,9 @@
 
 <environment>
   <bin   file="TestPerformanceFWLite_ES.cc">
-    <use   name="rootcintex"/>
     <use   name="rootcore"/>
   </bin>
   <bin   file="getbtagPerformance.cc">
-    <use   name="rootcintex"/>
     <use   name="rootcore"/>
   </bin>
 

--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -11,7 +11,6 @@
 <use   name="MagneticField/Engine"/>
 <use   name="SimDataFormats/Vertex"/>
 <use   name="TrackingTools/PatternTools"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <library   file="TrackAnalyzer.cc" name="TrackAnalyzer">
   <flags   EDM_PLUGIN="1"/>

--- a/SimCalorimetry/HcalSimAlgos/test/BuildFile.xml
+++ b/SimCalorimetry/HcalSimAlgos/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  <use name="rootcintex"/>
   <use name="SimCalorimetry/HcalSimAlgos"/>
   <use name="SimDataFormats/CrossingFrame"/>
   <bin file="HcalDigitizerTest.cpp"/>

--- a/TopQuarkAnalysis/Examples/bin/BuildFile.xml
+++ b/TopQuarkAnalysis/Examples/bin/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="AnalysisDataFormats/TopObjects"/>
 <use   name="FWCore/FWLite"/>
 <use   name="FWCore/Framework"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <environment>
   <bin   file="TopHypothesisFWLiteAnalyzer.cc">

--- a/TopQuarkAnalysis/TopEventSelection/bin/BuildFile.xml
+++ b/TopQuarkAnalysis/TopEventSelection/bin/BuildFile.xml
@@ -3,7 +3,6 @@
   <use   name="TopQuarkAnalysis/TopTools"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  <use   name="rootcintex"/>
   <use   name="root"/>
   <bin   file="TtSemiLRSignalSel_SoverSplusBLoop.cpp">
   </bin>

--- a/TopQuarkAnalysis/TopJetCombination/bin/BuildFile.xml
+++ b/TopQuarkAnalysis/TopJetCombination/bin/BuildFile.xml
@@ -3,7 +3,6 @@
   <use   name="TopQuarkAnalysis/TopTools"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  <use   name="rootcintex"/>
   <use   name="root"/>
   <bin   file="TtSemiLRJetComb_SoverSplusBLoop.cpp">
   </bin>

--- a/Validation/RecoMuon/plugins/BuildFile.xml
+++ b/Validation/RecoMuon/plugins/BuildFile.xml
@@ -21,7 +21,6 @@
 <use   name="SimTracker/Common"/>
 <use   name="SimTracker/Records"/>
 <use   name="RecoLocalTracker/ClusterParameterEstimator"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <use   name="SimTracker/TrackAssociation"/>
 <use   name="SimTracker/TrackerHitAssociation"/>

--- a/Validation/RecoMuon/test/BuildFile.xml
+++ b/Validation/RecoMuon/test/BuildFile.xml
@@ -4,7 +4,6 @@
   <use   name="boost_program_options"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  <use   name="rootcintex"/>
   <use   name="rootgraphics"/>
   <use   name="root"/>
 </bin>
@@ -13,7 +12,6 @@
   <use   name="boost"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  <use   name="rootcintex"/>
   <use   name="rootgraphics"/>
   <use   name="root"/>
 </bin>

--- a/Validation/RecoTrack/plugins/BuildFile.xml
+++ b/Validation/RecoTrack/plugins/BuildFile.xml
@@ -19,7 +19,6 @@
 <use   name="SimDataFormats/EncodedEventId"/>
 <use   name="SimTracker/Records"/>
 <use   name="RecoLocalTracker/ClusterParameterEstimator"/>
-<use   name="rootcintex"/>
 <use   name="root"/>
 <use   name="SimTracker/TrackAssociation"/>
 <use   name="SimTracker/TrackerHitAssociation"/>

--- a/Validation/RecoVertex/BuildFile.xml
+++ b/Validation/RecoVertex/BuildFile.xml
@@ -27,7 +27,6 @@
 <use   name="MagneticField/Engine"/>
 <use   name="SimDataFormats/Vertex"/>
 <use   name="SimDataFormats/TrackingAnalysis"/>
-<use   name="rootcintex"/>
 <use   name="SimTracker/TrackAssociation"/>
 <use   name="SimTracker/TrackerHitAssociation"/>
 <use   name="SimTracker/TrackHistory"/>

--- a/Validation/RecoVertex/bin/BuildFile.xml
+++ b/Validation/RecoVertex/bin/BuildFile.xml
@@ -1,6 +1,5 @@
 <library   name="ValidationRecoVertexMacros" file="*.cc">
 <use   name="DPGAnalysis/SiStripTools"/>
 <use   name="root"/>
-<use   name="rootcintex"/>
 <use   name="rootgraphics"/>
 </library>


### PR DESCRIPTION
FWCore/Utilities depends on rootcintex, so  everything else does. This allows to reduce the differences with BuildFiles in ROOT6 branch to a minimum.
Note: Due to minor differences between 7_4_X and 7_5_X, this PR will currently not automatically merge in 7_5_X.  So, this request is for 7_4_X only. #8246 is the equivalent for 7_5_X.
