### PR TITLE
Default format for new condition databases moved to v2

### DIFF
--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -21,7 +21,7 @@ namespace cond {
 
   // to be removed after the transition to new DB
   typedef enum { UNKNOWN_DB=0, COND_DB, ORA_DB } BackendType;
-  static constexpr BackendType DEFAULT_DB = ORA_DB;
+  static constexpr BackendType DEFAULT_DB = COND_DB;
   // for the validation of migrated data
   typedef enum { ERROR=0, MIGRATED, VALIDATED } MigrationStatus;
   static const std::vector<std::string> validationStatusText = { "Error",

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -70,13 +70,8 @@ namespace cond {
       std::unique_ptr<IGTSchema> gtSchemaHandle( new OraGTSchema( oraSession ) );  		       
       if( !iovSchemaHandle->exists() && !gtSchemaHandle->exists() ){
 	iovSchemaHandle.reset( new IOVSchema( coralSession->nominalSchema() ) );
-	if( iovSchemaHandle->exists() ){
-	  ret = COND_DB;
-	}
+        ret = COND_DB;
       } else {
-	//	edm::LogWarning("CondDB") << "You are using conditions from the old database via: " 
-	//			  << connectionString 
-	//			  << std::endl;
 	ret = ORA_DB;
       }
       oraSession.transaction().commit();

--- a/CondCore/CondDB/test/MyTestData.h
+++ b/CondCore/CondDB/test/MyTestData.h
@@ -50,14 +50,24 @@ public:
   }
 
   bool operator==( const MyTestData& rhs ) const {
-    if( a != rhs.a ) return false;
-    if( b != rhs.b ) return false;
+    if( a != rhs.a ) {
+      return false;
+    }
+    if( b != rhs.b ) {
+      return false;
+    }
     for( size_t i=0;i<2;i++)
       for( size_t j=0;j<2;j++){
-	if(d[i][j]!=rhs.d[i][j]) return false;
-	if(f[i][j]!=rhs.f[i][j]) return false;
+	if(d[i][j]!=rhs.d[i][j]) {
+	  return false;
+	}
+	if(f[i][j]!=rhs.f[i][j]) {
+	  return false;
+	}
       }
-    if( s != rhs.s ) return false;
+    if( s != rhs.s ) {
+      return false;
+    }
     return true;
   }
   bool operator!=( const MyTestData& rhs ) const {
@@ -84,6 +94,8 @@ void MyTestData::serialize(Archive & ar, const unsigned int)
     ar & BOOST_SERIALIZATION_NVP(a);
     ar & BOOST_SERIALIZATION_NVP(b);
     ar & BOOST_SERIALIZATION_NVP(s);
+    ar & BOOST_SERIALIZATION_NVP(d);
+    ar & BOOST_SERIALIZATION_NVP(f);
 }
 
 #endif /* !defined(__GCCXML__) */


### PR DESCRIPTION
With this change, the creation of new instances of condition database will use v2 format. This is meant to change the format of sqlite files for dropBox uploads.
This change should have no consequence on reading or writing on existing databases.
The PR should be included AFTER the switch off of uploads into v1 in the dropBox.
