### PR TITLE
fixing frontier connection strings in 73x for online dqm (rebased)

### DIFF
--- a/DQM/Integration/python/test/FrontierCondition_GT_autoExpress_cfi.py
+++ b/DQM/Integration/python/test/FrontierCondition_GT_autoExpress_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.connect = "frontier://(proxyurl=http://frontier.cms:3128)(serverurl=http://frontier.cms:8000/FrontierOnProd)(serverurl=http://frontier.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS"
-GlobalTag.pfnPrefix = cms.untracked.string("frontier://(proxyurl=http://frontier.cms:3128)(serverurl=http://frontier.cms:8000/FrontierOnProd)(serverurl=http://frontier.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/")
+GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS"
+GlobalTag.pfnPrefix = cms.untracked.string("frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/")
 GlobalTag.globaltag = "GR_E_V42"
 es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')
 

--- a/DQM/Integration/python/test/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/test/FrontierCondition_GT_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
-GlobalTag.connect = "frontier://(proxyurl=http://frontier.cms:3128)(serverurl=http://frontier.cms:8000/FrontierOnProd)(serverurl=http://frontier.cms:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS"
+GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS"
 GlobalTag.globaltag = "GR_H_V45"
 es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')


### PR DESCRIPTION
fixing frontier connection strings in 73x for online dqm to appease the sys admins. note that this is the same as #8263, just rebased on top of 733.
