### PR TITLE
Electron analyzer correction for 7_4_X

### DIFF
--- a/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
@@ -398,8 +398,8 @@ void ElectronAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup 
 
 //    // suppress the endcaps
     h1_matchingObject_Eta->Fill( moIter->eta() );
-//    h1_matchingObject_Pt->Fill( moIter->energy()/cosh(moIter->eta()) );
-//    h1_matchingObject_Phi->Fill( moIter->phi() );
+    h1_matchingObject_Pt->Fill( moIter->energy()/cosh(moIter->eta()) );
+    h1_matchingObject_Phi->Fill( moIter->phi() );
 
     bool okGsfFound = false ;
     double gsfOkRatio = 999999999. ;


### PR DESCRIPTION
Lines https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc#L401-402 are uncommented.
matchingObject_Pt and matchingObject_Phi histos can be computed again.

tests with runTheMatrix.py and number 4.22 5.1 135.4 8.0 140.53 4.53 1306.0 101.0 1000.0 1001.0 1330.0 9.0 1003.0 25.0 25202.0 are OK.

@beaudett
