### PR TITLE
Remove two remaining unnecessary direct dependencies on rootrflx

### DIFF
--- a/DataFormats/TrackingRecHit/BuildFile.xml
+++ b/DataFormats/TrackingRecHit/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="FWCore/Utilities"/>
 <use   name="clhep"/>
-<use   name="rootrflx"/>
 
 <export>
   <lib   name="1"/>

--- a/SimDataFormats/Associations/BuildFile.xml
+++ b/SimDataFormats/Associations/BuildFile.xml
@@ -1,6 +1,5 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/RecoCandidate"/>
-<use name="rootrflx"/>
 <use name="clhep"/>
 <export>
   <lib name="1"/>


### PR DESCRIPTION
Since virtually everything has an indirect dependency on rootrflx through DataFormats/Math or DataFormats/DetId, Giulio recently removed explicit link dependencies on rootrflx from many BuildFiles so as to remove BuildFile differences between CMSSW_7_4_X and CMSSW_7_4_ROOT6_X.  I discovered two additional BuildFiles in which this explcit dependency can be removed.  
