### PR TITLE
StoppedParticles Bug Fix

### DIFF
--- a/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
@@ -12,7 +12,7 @@
 #include "G4Track.hh"
 #include "G4Run.hh"
 #include "G4Event.hh"
-
+#include "G4SystemOfUnits.hh"
 
 RHStopTracer::RHStopTracer(edm::ParameterSet const & p) {
   edm::ParameterSet parameters = p.getParameter<edm::ParameterSet>("RHStopTracer");
@@ -49,9 +49,11 @@ void RHStopTracer::update (const BeginOfTrack * fTrack) {
   const G4Track* track = (*fTrack)();
   if ((track->GetMomentum().mag()> mTraceEnergy) || matched (track->GetDefinition()->GetParticleName())) {
     if (mDebug)
-    std::cout << "RHStopTracer::update-> new track: ID/Name/mass/Parent: " 
+    std::cout << "RHStopTracer::update-> new track: ID/Name/pdgId/mass/charge/Parent: " 
 	      << track->GetTrackID() << '/' << track->GetDefinition()->GetParticleName() << '/' 
-	      << track->GetDefinition()->GetPDGMass() << '/' << track->GetParentID()
+	      << track->GetDefinition()->GetPDGEncoding() << '/'
+	      << track->GetDefinition()->GetPDGMass()/GeV <<" GeV/" << track->GetDefinition()->GetPDGCharge() << '/'
+	      << track->GetParentID()
 	      << std::endl
 	      << " position X/Y/Z: " << track->GetPosition().x() << '/' 
 	      << track->GetPosition().y() << '/' <<  track->GetPosition().z()
@@ -70,9 +72,11 @@ void RHStopTracer::update (const EndOfTrack * fTrack) {
   const G4Track* track = (*fTrack)();
   if ((track->GetMomentum().mag()> mTraceEnergy) || matched (track->GetDefinition()->GetParticleName())) {
     if (mDebug)
-    std::cout << "RHStopTracer::update-> stop track: ID/Name/mass/Parent: " 
+    std::cout << "RHStopTracer::update-> stop track: ID/Name/pdgId/mass/charge/Parent: " 
 	      << track->GetTrackID() << '/' << track->GetDefinition()->GetParticleName() << '/' 
-	      << track->GetDefinition()->GetPDGMass() << '/' << track->GetParentID()
+	      << track->GetDefinition()->GetPDGEncoding() << '/'
+	      << track->GetDefinition()->GetPDGMass()/GeV <<" GeV/" << track->GetDefinition()->GetPDGCharge() << '/'
+	      << track->GetParentID()
 	      << std::endl
 	      << " position X/Y/Z: " << track->GetPosition().x() << '/' 
 	      << track->GetPosition().y() << '/' <<  track->GetPosition().z()

--- a/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopTracer.cc
@@ -8,6 +8,7 @@
 #include "SimG4Core/Application/interface/TrackingAction.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
   
 #include "G4Track.hh"
 #include "G4Run.hh"
@@ -16,7 +17,6 @@
 
 RHStopTracer::RHStopTracer(edm::ParameterSet const & p) {
   edm::ParameterSet parameters = p.getParameter<edm::ParameterSet>("RHStopTracer");
-  mDebug = parameters.getUntrackedParameter<bool>("verbose", false);
   mStopRegular = parameters.getUntrackedParameter<bool>("stopRegularParticles", false);
   mTraceEnergy = 1000 * parameters.getUntrackedParameter<double>("traceEnergy", 1.e20); // GeV->KeV
   mTraceParticleNameRegex = parameters.getParameter<std::string>("traceParticle");
@@ -25,43 +25,35 @@ RHStopTracer::RHStopTracer(edm::ParameterSet const & p) {
   produces< std::vector<float> >("StoppedParticlesY");
   produces< std::vector<float> >("StoppedParticlesZ");
   produces< std::vector<float> >("StoppedParticlesTime");
-
-  if (mDebug) {
-    std::cout << "RHStopTracer::RHStopTracer->" 
-	      << mTraceParticleNameRegex << '/' << mTraceEnergy << std::endl;
-  }
+  
+  LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::RHStopTracer->" 
+				     << mTraceParticleNameRegex << '/' << mTraceEnergy;
 }
 
 RHStopTracer::~RHStopTracer() {
 }
 
 void RHStopTracer::update (const BeginOfRun * fRun) {
-  if (mDebug) 
-    std::cout << "RHStopTracer::update-> begin of the run " << (*fRun)()->GetRunID () << std::endl; 
+  LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> begin of the run " << (*fRun)()->GetRunID();
 }
 
 void RHStopTracer::update (const BeginOfEvent * fEvent) {
-  if (mDebug) 
-    std::cout << "RHStopTracer::update-> begin of the event " << (*fEvent)()->GetEventID () << std::endl; 
+  LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> begin of the event " << (*fEvent)()->GetEventID(); 
 }
 
 void RHStopTracer::update (const BeginOfTrack * fTrack) {
   const G4Track* track = (*fTrack)();
   if ((track->GetMomentum().mag()> mTraceEnergy) || matched (track->GetDefinition()->GetParticleName())) {
-    if (mDebug)
-    std::cout << "RHStopTracer::update-> new track: ID/Name/pdgId/mass/charge/Parent: " 
-	      << track->GetTrackID() << '/' << track->GetDefinition()->GetParticleName() << '/' 
-	      << track->GetDefinition()->GetPDGEncoding() << '/'
-	      << track->GetDefinition()->GetPDGMass()/GeV <<" GeV/" << track->GetDefinition()->GetPDGCharge() << '/'
-	      << track->GetParentID()
-	      << std::endl
-	      << " position X/Y/Z: " << track->GetPosition().x() << '/' 
-	      << track->GetPosition().y() << '/' <<  track->GetPosition().z()
-	      << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
-	      << std::endl
-	      << "    px/py/pz/p=" << track->GetMomentum().x() << '/' 
-	      << track->GetMomentum().y() << '/' << track->GetMomentum().z() << '/'<< track->GetMomentum().mag() 
-	      << std::endl;
+    LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> new track: ID/Name/pdgId/mass/charge/Parent: " 
+				       << track->GetTrackID() << '/' << track->GetDefinition()->GetParticleName() << '/' 
+				       << track->GetDefinition()->GetPDGEncoding() << '/'
+				       << track->GetDefinition()->GetPDGMass()/GeV <<" GeV/" << track->GetDefinition()->GetPDGCharge() << '/'
+				       << track->GetParentID()
+				       << " position X/Y/Z: " << track->GetPosition().x() << '/' 
+				       << track->GetPosition().y() << '/' <<  track->GetPosition().z()
+				       << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
+				       << "    px/py/pz/p=" << track->GetMomentum().x() << '/' 
+				       << track->GetMomentum().y() << '/' << track->GetMomentum().z() << '/'<< track->GetMomentum().mag();
   }
   if (mStopRegular && !matched (track->GetDefinition()->GetParticleName())) { // kill regular particles
     const_cast<G4Track*>(track)->SetTrackStatus(fStopAndKill);
@@ -71,20 +63,16 @@ void RHStopTracer::update (const BeginOfTrack * fTrack) {
 void RHStopTracer::update (const EndOfTrack * fTrack) {
   const G4Track* track = (*fTrack)();
   if ((track->GetMomentum().mag()> mTraceEnergy) || matched (track->GetDefinition()->GetParticleName())) {
-    if (mDebug)
-    std::cout << "RHStopTracer::update-> stop track: ID/Name/pdgId/mass/charge/Parent: " 
-	      << track->GetTrackID() << '/' << track->GetDefinition()->GetParticleName() << '/' 
-	      << track->GetDefinition()->GetPDGEncoding() << '/'
-	      << track->GetDefinition()->GetPDGMass()/GeV <<" GeV/" << track->GetDefinition()->GetPDGCharge() << '/'
-	      << track->GetParentID()
-	      << std::endl
-	      << " position X/Y/Z: " << track->GetPosition().x() << '/' 
-	      << track->GetPosition().y() << '/' <<  track->GetPosition().z()
-	      << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
-	      << std::endl 
-	      << "    px/py/pz/p=" << track->GetMomentum().x() << '/' 
-	      << track->GetMomentum().y() << '/' << track->GetMomentum().z() << '/'<< track->GetMomentum().mag() 
-	      << std::endl;
+    LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::update-> stop track: ID/Name/pdgId/mass/charge/Parent: " 
+				       << track->GetTrackID() << '/' << track->GetDefinition()->GetParticleName() << '/' 
+				       << track->GetDefinition()->GetPDGEncoding() << '/'
+				       << track->GetDefinition()->GetPDGMass()/GeV <<" GeV/" << track->GetDefinition()->GetPDGCharge() << '/'
+				       << track->GetParentID()
+				       << " position X/Y/Z: " << track->GetPosition().x() << '/' 
+				       << track->GetPosition().y() << '/' <<  track->GetPosition().z()
+				       << " R/phi: " << track->GetPosition().perp() << '/' << track->GetPosition().phi()
+				       << "    px/py/pz/p=" << track->GetMomentum().x() << '/' 
+				       << track->GetMomentum().y() << '/' << track->GetMomentum().z() << '/'<< track->GetMomentum().mag();
     if (track->GetMomentum().mag () < 0.001) {
       mStopPoints.push_back (StopPoint (track->GetDefinition()->GetParticleName(),
 					track->GetPosition().x(),
@@ -100,9 +88,8 @@ bool RHStopTracer::matched (const std::string& fName) const {
 }
 
  void RHStopTracer::produce(edm::Event& fEvent, const edm::EventSetup&) {
-  if (mDebug) {
-    std::cout << "RHStopTracer::produce->" << std::endl;
-  }
+   LogDebug("SimG4CoreCustomPhysics") << "RHStopTracer::produce->";
+
    std::auto_ptr<std::vector<std::string> > names (new std::vector<std::string>); 
    std::auto_ptr<std::vector<float> > xs (new std::vector<float>);
    std::auto_ptr<std::vector<float> > ys (new std::vector<float>);

--- a/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
@@ -20,7 +20,7 @@ def customise(process):
 	        type = cms.string('RHStopTracer'),
 		RHStopTracer = cms.PSet(
 		verbose = cms.untracked.bool (False),
-		traceParticle = cms.string ("(~|tau1).*"),
+		traceParticle = cms.string ("((anti_)?~|tau1).*"), #this one regular expression is needed to look for ~HIP*, anti_~HIP*, ~tau1, anti_~tau1, ~g_rho0, ~g_Deltabar0, ~T_uu1++, etc
 		stopRegularParticles = cms.untracked.bool (False)
 		)        
 	    )


### PR DESCRIPTION
The purpose of this PR is to:
- Fix a bug for the StoppedParticles created in the RHStopTracer. Before, the tracks coming from the antiparticles were not looked at, to see if the antiparticles stop in the detector. This is fixed with the one line change in Exotica_HSCP_SIM_cfi.py.
- To better debug this type of problem in the future, more debug statements were added to RHStopTracer.
