### PR TITLE
Backport IOPool/Streamer changes for ROOT6 that are OK for ROOT5

### DIFF
--- a/IOPool/Streamer/BuildFile.xml
+++ b/IOPool/Streamer/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
-<use   name="FWCore/RootAutoLibraryLoader"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="FWCore/Sources"/>
 <use   name="FWCore/Utilities"/>

--- a/IOPool/Streamer/src/StreamSerializer.cc
+++ b/IOPool/Streamer/src/StreamSerializer.cc
@@ -25,7 +25,8 @@
 #include "zlib.h"
 #include <algorithm>
 #include <cstdlib>
-#include <list>
+#include <iostream>
+#include <vector>
 
 namespace edm {
 

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -3,7 +3,6 @@
 
 #include "IOPool/Streamer/interface/InitMsgBuilder.h"
 #include "IOPool/Streamer/interface/EventMsgBuilder.h"
-#include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/EventSelector.h"
 #include "FWCore/ParameterSet/interface/Registry.h"
@@ -15,9 +14,12 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
+#include <iostream>
+#include <memory>
 #include <string>
 #include <sys/time.h>
 #include <unistd.h>
+#include <vector>
 #include "zlib.h"
 
 namespace {
@@ -93,8 +95,6 @@ namespace edm {
     int got_host = gethostname(host_name_, 255);
     if(got_host != 0) strncpy(host_name_, "noHostNameFoundOrTooLong", sizeof(host_name_));
     //loadExtraClasses();
-    // do the line below instead of loadExtraClasses() to avoid Root errors
-    RootAutoLibraryLoader::enable();
 
     // 25-Jan-2008, KAB - pull out the trigger selection request
     // which we need for the INIT message


### PR DESCRIPTION
This PR removes some unnecessary differences between CMSSW_7_4_X and CMSSW_7_4_ROOT6_X in IOPool/Streamer by backporting changes for ROOT6 that are OK and even beneficial for ROOT5.
In this case, they are 1) the removal of an unnecessary use of and dependency on RootAutoLibraryLoader, 2) the inclusion of missing headers, and the removal of an unnecessary include.
Tests showed that RootAutoLibraryLoader::enable() is not needed here.
