### PR TITLE
Make ElectronTagger thread safe

### DIFF
--- a/RecoBTag/SoftLepton/interface/ElectronTagger.h
+++ b/RecoBTag/SoftLepton/interface/ElectronTagger.h
@@ -5,7 +5,8 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
 #include "RecoBTag/SoftLepton/interface/MvaSoftElectronEstimator.h"
-#include "TRandom3.h"
+#include <random>
+#include <mutex>
 
 /** \class ElectronTagger
  *
@@ -19,29 +20,22 @@ public:
 
   /// explicit ctor 
  ElectronTagger(const edm::ParameterSet & );
- ~ElectronTagger(); 
-  virtual float discriminator(const TagInfoHelper & tagInfo) const;
+  virtual float discriminator(const TagInfoHelper & tagInfo) const override;
 //  std::vector<string> vecstr;
 //  string path_mvaWeightFileEleID;
 private:
   btag::LeptonSelector m_selector;
-  TRandom3* random;
   edm::FileInPath WeightFile;
-  MvaSoftEleEstimator* mvaID;
+  mutable std::mutex m_mutex;
+  std::unique_ptr<MvaSoftEleEstimator> mvaID;
 };
 
 ElectronTagger::ElectronTagger(const edm::ParameterSet & configuration):
     m_selector(configuration)
   {
 	uses("seTagInfos");
-        random=new TRandom3();
 	WeightFile=configuration.getParameter<edm::FileInPath>("weightFile");
-	mvaID=new MvaSoftEleEstimator(WeightFile.fullPath());
+	mvaID.reset(new MvaSoftEleEstimator(WeightFile.fullPath()));
   }
 
-
-ElectronTagger::~ElectronTagger() {
-        delete random;
-	delete mvaID;
-  }
 #endif

--- a/RecoBTag/SoftLepton/interface/ElectronTagger.h
+++ b/RecoBTag/SoftLepton/interface/ElectronTagger.h
@@ -5,7 +5,6 @@
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
 #include "RecoBTag/SoftLepton/interface/MvaSoftElectronEstimator.h"
-#include <random>
 #include <mutex>
 
 /** \class ElectronTagger

--- a/RecoBTag/SoftLepton/src/ElectronTagger.cc
+++ b/RecoBTag/SoftLepton/src/ElectronTagger.cc
@@ -11,13 +11,19 @@ float ElectronTagger::discriminator(const TagInfoHelper & tagInfo) const {
   // default value, used if there are no leptons associated to this jet
   float bestTag = - std::numeric_limits<float>::infinity();
   const reco::CandSoftLeptonTagInfo & info = tagInfo.get<reco::CandSoftLeptonTagInfo>();
+
+  std::default_random_engine random;
+  std::uniform_real_distribution<float> dist(0.f,1.f);
+
+  //MvaSofEleEstimator is not thread safe
+  std::lock_guard<std::mutex> lock(m_mutex);
   // if there are multiple leptons, look for the highest tag result
   for (unsigned int i = 0; i < info.leptons(); i++) {
     const reco::SoftLeptonProperties & properties = info.properties(i);
     if (m_selector(properties)) {
 	int theSeed=1+round(10000.0*std::abs(properties.deltaR));
-	random->SetSeed(theSeed);
-	float rndm = random->Uniform(0,1);
+	random.seed(theSeed);
+	float rndm = dist(random);
 	//for negative tagger, flip 50% of the negative signs to positive value
 	float sip3d = (m_selector.isNegative() && rndm<0.5) ? -properties.sip3d : properties.sip3d;
 	float tag = mvaID->mvaValue( properties.sip2d, sip3d, properties.ptRel, properties.deltaR, properties.ratio,properties.elec_mva);

--- a/RecoBTag/SoftLepton/src/ElectronTagger.cc
+++ b/RecoBTag/SoftLepton/src/ElectronTagger.cc
@@ -1,4 +1,5 @@
 #include <limits>
+#include <random>
 
 #include "DataFormats/BTauReco/interface/SoftLeptonTagInfo.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
@@ -12,7 +13,7 @@ float ElectronTagger::discriminator(const TagInfoHelper & tagInfo) const {
   float bestTag = - std::numeric_limits<float>::infinity();
   const reco::CandSoftLeptonTagInfo & info = tagInfo.get<reco::CandSoftLeptonTagInfo>();
 
-  std::default_random_engine random;
+  std::mt19937_64 random;
   std::uniform_real_distribution<float> dist(0.f,1.f);
 
   //MvaSofEleEstimator is not thread safe


### PR DESCRIPTION
Since the ElectronTagger can be obtained via the EventSetup, the
const methods of the class must be thread safe. This required replacing
TRandom3 with C++11 random facility (since TRandom3 uses a global seed)
and using an std::mutex to protect MvaSoftEleEstimator since the
way it interacts with TMVA::Reader is thread-unsafe.
