### PR TITLE
73X add pT hat and eventID info to pileup summary

### DIFF
--- a/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
+++ b/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
@@ -266,8 +266,10 @@ void PileUpProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
   
   std::vector<float> trueInteractionList;
   trueInteractionList.push_back(truePUevts);
+
+  std::vector<edm::EventID> eventInfoList;
   
-  PileupMixing_ = std::auto_ptr< PileupMixingContent >(new PileupMixingContent(bunchCrossingList,numInteractionList,trueInteractionList,450)); // it shouldn't matter what the assumed bunchspacing is if there is no OOT PU. Add argument for compatibility.
+  PileupMixing_ = std::auto_ptr< PileupMixingContent >(new PileupMixingContent(bunchCrossingList,numInteractionList,trueInteractionList,eventInfoList,450)); // it shouldn't matter what the assumed bunchspacing is if there is no OOT PU. Add argument for compatibility.
   iEvent.put(PileupMixing_);
 
   // Get N events from random files

--- a/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
+++ b/FastSimulation/PileUpProducer/plugins/PileUpProducer.cc
@@ -29,8 +29,9 @@
 PileUpProducer::PileUpProducer(edm::ParameterSet const & p) : hprob(0), currentValuesWereSet(false)
 {    
 
-  // This producer produces an object PileupMixingContent, needed by PileupSummaryInfo
+  // This producer produces an object PileupMixingContent and PileupVertexContent, needed by PileupSummaryInfo
   produces<PileupMixingContent>();
+  produces<PileupVertexContent>();
   // This producer produces a HepMCProduct, with all pileup vertices/particles
   produces<edm::HepMCProduct>("PileUpEvents");
   
@@ -256,7 +257,11 @@ void PileUpProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
 
   // Save this information in the PileupMixingContent object
   // IMPORTANT: the bunch crossing number is always 0 because FastSim has no out-of-time PU
+
+
+
   std::auto_ptr< PileupMixingContent > PileupMixing_;
+  std::auto_ptr< PileupVertexContent > PileupVertexing_;
 
   std::vector<int> bunchCrossingList;
   bunchCrossingList.push_back(0);
@@ -268,9 +273,24 @@ void PileUpProducer::produce(edm::Event & iEvent, const edm::EventSetup & es)
   trueInteractionList.push_back(truePUevts);
 
   std::vector<edm::EventID> eventInfoList;
+
+  std::vector<float> pThatList;
+  std::vector<float> zposList;
+  // generate fake EventID list to prevent crash in PileupInfo
+  for(uint32_t index=0; index!=uint(PUevts); ++index) {
+    edm::EventID Fake(index,index,index);
+    eventInfoList.push_back(Fake);
+    pThatList.push_back(0.);
+    zposList.push_back(0.);
+  }
   
   PileupMixing_ = std::auto_ptr< PileupMixingContent >(new PileupMixingContent(bunchCrossingList,numInteractionList,trueInteractionList,eventInfoList,450)); // it shouldn't matter what the assumed bunchspacing is if there is no OOT PU. Add argument for compatibility.
   iEvent.put(PileupMixing_);
+
+  PileupVertexing_ = std::auto_ptr< PileupVertexContent >(new PileupVertexContent(pThatList, zposList));
+
+  iEvent.put(PileupVertexing_);
+
 
   // Get N events from random files
   for ( int ievt=0; ievt<PUevts; ++ievt ) { 

--- a/FastSimulation/PileUpProducer/plugins/PileUpProducer.h
+++ b/FastSimulation/PileUpProducer/plugins/PileUpProducer.h
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h"
 
 #include <vector>
 #include <string>

--- a/SimDataFormats/PileupSummaryInfo/BuildFile.xml
+++ b/SimDataFormats/PileupSummaryInfo/BuildFile.xml
@@ -1,5 +1,8 @@
+<use   name="DataFormats/Math"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/Provenance"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
+<use   name="clhep"/>
 <use   name="rootrflx"/>
 <export>
   <lib   name="1"/>

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h
@@ -19,6 +19,7 @@ Usage: purely descriptive
 #include <vector>
 #include <string>
 #include <iostream>
+#include "DataFormats/Provenance/interface/EventID.h"
 
 class PileupMixingContent {
 
@@ -29,7 +30,10 @@ class PileupMixingContent {
   PileupMixingContent( std::vector<int>& bunchCrossing,
 		       std::vector<int>& n_interactions, 
 		       std::vector<float>& True_interactions,
-		       int bunchSpacing): bunchSpacing_(bunchSpacing)
+		       std::vector<edm::EventID>& eventInfos,
+		       int bunchSpacing): 
+  eventInfos_(eventInfos),
+  bunchSpacing_(bunchSpacing)
  {
 
     bunchCrossing_.reserve(bunchCrossing.size());
@@ -63,12 +67,14 @@ class PileupMixingContent {
     bunchCrossing_.clear();
     n_interactions_.clear();
     n_TrueInteractions_.clear();
+    eventInfos_.clear();
   };
 
   const std::vector<int>& getMix_Ninteractions() const { return n_interactions_; }
   const std::vector<float>& getMix_TrueInteractions() const { return n_TrueInteractions_; }
   const std::vector<int>& getMix_bunchCrossing() const { return bunchCrossing_; }
   const int & getMix_bunchSpacing() const { return bunchSpacing_; }
+  const std::vector<edm::EventID> getMix_eventInfo() const {return eventInfos_;}
 
  private:
 
@@ -78,6 +84,7 @@ class PileupMixingContent {
   std::vector<int> bunchCrossing_;
   std::vector<int> n_interactions_;
   std::vector<float> n_TrueInteractions_;
+  std::vector<edm::EventID> eventInfos_;
   int bunchSpacing_;
 
 };

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
@@ -26,7 +26,7 @@ class PileupSummaryInfo {
  public:
 
   PileupSummaryInfo(){};
-
+ 
   PileupSummaryInfo( const int num_PU_vertices,
 		     std::vector<float>& zpositions,
 		     std::vector<float>& sumpT_lowpT,
@@ -49,6 +49,7 @@ class PileupSummaryInfo {
 		     std::vector<float>& sumpT_highpT,
 		     std::vector<int>& ntrks_lowpT,
 		     std::vector<int>& ntrks_highpT,
+		     std::vector<edm::EventID>& eventInfo,
 		     int bunchCrossing,
 		     float TrueNumInteractions,
 		     int bunchSpacing);

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h
@@ -42,7 +42,6 @@ class PileupSummaryInfo {
 		     std::vector<int>& ntrks_highpT,
 		     int bunchCrossing);
 
-
   PileupSummaryInfo( const int num_PU_vertices,
 		     std::vector<float>& zpositions,
 		     std::vector<float>& sumpT_lowpT,
@@ -50,6 +49,7 @@ class PileupSummaryInfo {
 		     std::vector<int>& ntrks_lowpT,
 		     std::vector<int>& ntrks_highpT,
 		     std::vector<edm::EventID>& eventInfo,
+		     std::vector<float>& pT_hats,
 		     int bunchCrossing,
 		     float TrueNumInteractions,
 		     int bunchSpacing);
@@ -69,6 +69,7 @@ class PileupSummaryInfo {
   const std::vector<int>& getPU_ntrks_highpT() const { return ntrks_highpT_; }
   const std::vector<float>& getPU_instLumi() const { return instLumi_; }
   const std::vector<edm::EventID>& getPU_EventID() const { return eventInfo_; }
+  const std::vector<float>& getPU_pT_hats() const { return pT_hats_; }
   const int getBunchCrossing() const { return bunchCrossing_;}
   const int getBunchSpacing() const { return bunchSpacing_;}
   const float getTrueNumInteractions() const { return TrueNumInteractions_;}
@@ -83,6 +84,8 @@ class PileupSummaryInfo {
   std::vector<float> sumpT_highpT_;
   std::vector<int> ntrks_lowpT_;
   std::vector<int> ntrks_highpT_;
+  std::vector<edm::EventID> eventInfo_;
+  std::vector<float> pT_hats_;
   int bunchCrossing_;
   int bunchSpacing_;
   float TrueNumInteractions_;
@@ -91,7 +94,7 @@ class PileupSummaryInfo {
   // for DataMixer pileup, we only have raw information:
 
   std::vector<float> instLumi_;
-  std::vector<edm::EventID> eventInfo_;
+
 
 };
 

--- a/SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h
+++ b/SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h
@@ -1,0 +1,59 @@
+#ifndef PileupVertexContent_h
+#define PileupVertexContent_h
+// -*- C++ -*-
+//
+// Package:     PileupVertexContent
+// Class  :     PileupVertexContent
+// 
+/**\class PileupVertexContent PileupVertexContent.h SimDataFormats/PileupVertexContent/interface/PileupVertexContent.h
+
+Description: contains information related to the details of the pileup simulation for a given event, filled by Special "Digitizer" that has access to each pileup event
+Usage: purely descriptive
+*/
+//
+// Original Author:  Mike Hildreth, Notre Dame
+//         Created:  April 18, 2011
+//
+//
+
+#include <vector>
+#include <string>
+#include <iostream>
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "DataFormats/Math/interface/LorentzVector.h"
+
+class PileupVertexContent {
+
+ public:
+
+  PileupVertexContent(){};
+
+  PileupVertexContent( std::vector<float>& pT_hat,
+		       std::vector<float>& z_Vtx ):
+  pT_hats_(pT_hat),
+  z_Vtxs_(z_Vtx)
+ { };
+
+
+
+
+  ~PileupVertexContent(){
+    pT_hats_.clear();
+    z_Vtxs_.clear();
+  };
+
+  const std::vector<float>& getMix_pT_hats() const { return pT_hats_; }
+  const std::vector<float>& getMix_z_Vtxs() const { return z_Vtxs_; }
+
+ private:
+
+  // for "standard" pileup: we have MC Truth information for these
+
+
+  std::vector<float> pT_hats_;
+  std::vector<float> z_Vtxs_;
+
+};
+
+#endif

--- a/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
+++ b/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
@@ -12,7 +12,6 @@
 
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 
-
 PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
                      std::vector<float>& zpositions, 
                      std::vector<float>& sumpT_lowpT,
@@ -80,32 +79,23 @@ PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
                      std::vector<float>& sumpT_highpT,
                      std::vector<int>&   ntrks_lowpT,
 		     std::vector<int>&   ntrks_highpT,
+		     std::vector<edm::EventID>& eventInfo,
 		     int bunchCrossing,
 		     float TrueNumInteractions,
-		     int bunchSpacing)
+ 	             int bunchSpacing):
+  zpositions_(zpositions),
+  sumpT_lowpT_(sumpT_lowpT),
+  sumpT_highpT_(sumpT_highpT),
+  ntrks_lowpT_(ntrks_lowpT),
+  ntrks_highpT_(ntrks_highpT),
+  eventInfo_(eventInfo)
 {
 
   num_PU_vertices_ =  num_PU_vertices;
-  zpositions_.clear();
-  sumpT_lowpT_.clear();
-  sumpT_highpT_.clear();
-  ntrks_lowpT_.clear();
-  ntrks_highpT_.clear();
   instLumi_.clear();
-  eventInfo_.clear();
   bunchCrossing_ = bunchCrossing;
   TrueNumInteractions_ = TrueNumInteractions;
   bunchSpacing_ = bunchSpacing;
-
-  int NLoop = zpositions.size();
-
-  for( int ivtx = 0; ivtx<NLoop ; ++ivtx) {
-    zpositions_.push_back(zpositions[ivtx]); 
-    sumpT_lowpT_.push_back(sumpT_lowpT[ivtx]);
-    sumpT_highpT_.push_back(sumpT_highpT[ivtx]);
-    ntrks_lowpT_.push_back(ntrks_lowpT[ivtx]);
-    ntrks_highpT_.push_back(ntrks_highpT[ivtx]);
-  }
 
 }
 

--- a/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
+++ b/SimDataFormats/PileupSummaryInfo/src/PileupSummaryInfo.cc
@@ -80,6 +80,7 @@ PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
                      std::vector<int>&   ntrks_lowpT,
 		     std::vector<int>&   ntrks_highpT,
 		     std::vector<edm::EventID>& eventInfo,
+                     std::vector<float>& pThats, 
 		     int bunchCrossing,
 		     float TrueNumInteractions,
  	             int bunchSpacing):
@@ -88,7 +89,8 @@ PileupSummaryInfo::PileupSummaryInfo( const int num_PU_vertices,
   sumpT_highpT_(sumpT_highpT),
   ntrks_lowpT_(ntrks_lowpT),
   ntrks_highpT_(ntrks_highpT),
-  eventInfo_(eventInfo)
+  eventInfo_(eventInfo),
+  pT_hats_(pThats)
 {
 
   num_PU_vertices_ =  num_PU_vertices;

--- a/SimDataFormats/PileupSummaryInfo/src/classes.h
+++ b/SimDataFormats/PileupSummaryInfo/src/classes.h
@@ -1,5 +1,6 @@
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 #include <vector>
 
@@ -13,6 +14,10 @@ namespace SimDataFormats_PileupSummaryInfo {
     std::vector<PileupMixingContent> dummy5;
     edm::Wrapper<PileupMixingContent> dummy6;
     edm::Wrapper<std::vector<PileupMixingContent> > dummy7;
+    PileupVertexContent dummy8;
+    std::vector<PileupVertexContent> dummy9;
+    edm::Wrapper<PileupVertexContent> dummy10;
+    edm::Wrapper<std::vector<PileupVertexContent> > dummy11;
   };
 }
 

--- a/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
+++ b/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
@@ -1,5 +1,6 @@
 <lcgdict>
-  <class name="PileupSummaryInfo" ClassVersion="11">
+  <class name="PileupSummaryInfo" ClassVersion="12">
+   <version ClassVersion="12" checksum="231481749"/>
    <version ClassVersion="11" checksum="1526417022"/>
   </class>
   <class name="std::vector<PileupSummaryInfo>"/>  
@@ -12,4 +13,10 @@
   <class name="std::vector<PileupMixingContent>"/>  
   <class name="edm::Wrapper<PileupMixingContent>"/>
   <class name="edm::Wrapper<std::vector<PileupMixingContent> >"/>
+  <class name="PileupVertexContent" ClassVersion="-1">
+   <version ClassVersion="-1" checksum="3263569137"/>
+  </class>
+  <class name="std::vector<PileupVertexContent>"/>  
+  <class name="edm::Wrapper<PileupVertexContent>"/>
+  <class name="edm::Wrapper<std::vector<PileupVertexContent> >"/>
 </lcgdict>

--- a/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
+++ b/SimDataFormats/PileupSummaryInfo/src/classes_def.xml
@@ -5,8 +5,9 @@
   <class name="std::vector<PileupSummaryInfo>"/>  
   <class name="edm::Wrapper<PileupSummaryInfo>"/>
   <class name="edm::Wrapper<std::vector<PileupSummaryInfo> >"/>
-  <class name="PileupMixingContent" ClassVersion="11">
+  <class name="PileupMixingContent" ClassVersion="12">
    <version ClassVersion="11" checksum="468037571"/>
+   <version ClassVersion="12" checksum="624720677"/>
   </class>
   <class name="std::vector<PileupMixingContent>"/>  
   <class name="edm::Wrapper<PileupMixingContent>"/>

--- a/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
+++ b/SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h
@@ -21,7 +21,7 @@
 // system include files
 #include <vector>
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
-
+#include "DataFormats/Provenance/interface/EventID.h"
 
 
 // user include files
@@ -79,7 +79,9 @@ class DigiAccumulatorMixMod {
 
     virtual void StorePileupInformation( std::vector<int> &numInteractionList,
 					 std::vector<int> &bunchCrossingList,
-					 std::vector<float> &TrueInteractionList, int bunchSpace){ }
+					 std::vector<float> &TrueInteractionList, 
+					 std::vector<edm::EventID> &eventList,
+					 int bunchSpace){ }
 
     virtual PileupMixingContent* getEventPileupInfo() { 
       std::cout << " You must override the virtual functions in DigiAccumulatorMixMod in\n" << "order to access PileupInformation.  Returning empty object." << std::endl;

--- a/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
+++ b/SimGeneral/MixingModule/interface/PileUpEventPrincipal.h
@@ -38,8 +38,6 @@ public:
   template<typename T>
   bool
   getByLabel(edm::InputTag const& tag, edm::Handle<T>& result) const {
-    typedef typename T::value_type ItemType;
-    typedef typename T::iterator iterator;
     edm::BasicHandle bh = principal_.getByLabel(edm::PRODUCT_TYPE, edm::TypeID(typeid(T)), tag, nullptr, mcc_);
     convert_handle(std::move(bh), result);
     return result.isValid();

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -361,6 +361,7 @@ namespace edm {
     //}
 
     int KeepTrackOfPileup = 0;
+    std::vector<edm::EventID> eventInfoList;
 
     for (int bunchIdx = minBunch_; bunchIdx <= maxBunch_; ++bunchIdx) {
       for (size_t setBcrIdx=0; setBcrIdx<workers_.size(); ++setBcrIdx) {
@@ -399,6 +400,10 @@ namespace edm {
                                                             _2, vertexOffset, std::ref(setup), e.streamID()), NumPU_Events, e.streamID()
             );
           playbackInfo_->setStartEventId(recordEventID, readSrcIdx, bunchIdx, KeepTrackOfPileup);
+	  const std::vector<edm::EventID>& playEventID =
+            playbackInfo_->getStartEventId(readSrcIdx, bunchIdx);
+	  for ( unsigned int pu=0; pu<playEventID.size(); pu++ ) { eventInfoList.push_back(playEventID[pu]); }
+
           KeepTrackOfPileup+=NumPU_Events;
         } else {
 	  const std::vector<edm::EventID>& playEventID =
@@ -412,6 +417,7 @@ namespace edm {
             std::bind(&MixingModule::pileAllWorkers, std::ref(*this), _1, mcc, bunchIdx,
                         _2, vertexOffset, std::ref(setup), e.streamID())
             );
+	  for ( unsigned int pu=0; pu<playEventID.size(); pu++ ) eventInfoList.push_back(playEventID[pu]);
         }
       }
       for(Accumulators::const_iterator accItr = digiAccumulators_.begin(), accEnd = digiAccumulators_.end(); accItr != accEnd; ++accItr) {
@@ -444,6 +450,7 @@ namespace edm {
       (*accItr)->StorePileupInformation( bunchCrossingList,
 					 numInteractionList,
 					 TrueInteractionList,
+					 eventInfoList,
 					 bunchSpace_);
     }
 
@@ -451,6 +458,7 @@ namespace edm {
     PileupMixing_ = std::auto_ptr<PileupMixingContent>(new PileupMixingContent(bunchCrossingList,
                                                                                numInteractionList,
                                                                                TrueInteractionList,
+									       eventInfoList,
 									       bunchSpace_));
 
     e.put(PileupMixing_);

--- a/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_MixPreMix_cfi.py
@@ -6,6 +6,7 @@ from SimGeneral.MixingModule.pixelDigitizer_cfi import *
 from SimGeneral.MixingModule.stripDigitizer_cfi import *
 #from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 #from SimGeneral.MixingModule.hcalDigitizer_cfi import *
+from SimGeneral.MixingModule.pileupVtxDigitizer_cfi import *
 from SimGeneral.MixingModule.castorDigitizer_cfi import *
 from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
 
@@ -18,6 +19,9 @@ theDigitizersMixPreMix = cms.PSet(
   ),
   castor  = cms.PSet(
     castorDigitizer
+  ),
+  puVtx = cms.PSet(
+    pileupVtxDigitizer
   )
 )
 
@@ -30,6 +34,9 @@ theDigitizersMixPreMixValid = cms.PSet(
   ),
   castor  = cms.PSet(
     castorDigitizer
+  ),
+  puVtx = cms.PSet(
+    pileupVtxDigitizer
   ),
   mergedtruth = cms.PSet(
     trackingParticles

--- a/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
@@ -7,6 +7,7 @@ from SimGeneral.MixingModule.stripDigitizer_cfi import *
 from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 from SimGeneral.MixingModule.hcalDigitizer_cfi import *
 from SimGeneral.MixingModule.castorDigitizer_cfi import *
+from SimGeneral.MixingModule.pileupVtxDigitizer_cfi import *
 from SimGeneral.MixingModule.trackingTruthProducer_cfi import *
 
 theDigitizersNoNoise = cms.PSet(
@@ -24,6 +25,9 @@ theDigitizersNoNoise = cms.PSet(
   ),
   castor  = cms.PSet(
     castorDigitizer
+  ),
+  puVtx = cms.PSet(
+    pileupVtxDigitizer
   )
 )
 

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -7,6 +7,7 @@ from SimGeneral.MixingModule.stripDigitizer_cfi import *
 from SimGeneral.MixingModule.ecalDigitizer_cfi import *
 from SimGeneral.MixingModule.hcalDigitizer_cfi import *
 from SimGeneral.MixingModule.castorDigitizer_cfi import *
+from SimGeneral.MixingModule.pileupVtxDigitizer_cfi import *
 from SimGeneral.MixingModule.trackingTruthProducerSelection_cfi import *
 
 theDigitizers = cms.PSet(
@@ -22,8 +23,11 @@ theDigitizers = cms.PSet(
   hcal = cms.PSet(
     hcalDigitizer
   ),
-  castor  = cms.PSet(
+  castor = cms.PSet(
     castorDigitizer
+  ),
+  puVtx = cms.PSet(
+    pileupVtxDigitizer
   )
 )
 

--- a/SimGeneral/MixingModule/python/digitizers_cfi.py
+++ b/SimGeneral/MixingModule/python/digitizers_cfi.py
@@ -47,6 +47,9 @@ theDigitizersValid = cms.PSet(
   castor  = cms.PSet(
     castorDigitizer
   ),
+  puVtx = cms.PSet(
+    pileupVtxDigitizer
+  ),
   mergedtruth = cms.PSet(
     trackingParticles
   )

--- a/SimGeneral/MixingModule/python/pileupVtxDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/pileupVtxDigitizer_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+pileupVtxDigitizer = cms.PSet(
+    accumulatorType = cms.string("PileupVertexAccumulator"),
+    hitsProducer = cms.string('generator'),
+    makeDigiSimLinks = cms.untracked.bool(False))
+

--- a/SimGeneral/PileupInformation/interface/PileupInformation.h
+++ b/SimGeneral/PileupInformation/interface/PileupInformation.h
@@ -21,6 +21,7 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupMixingContent.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h"
 
 #include "SimGeneral/TrackingAnalysis/interface/EncodedTruthId.h"
 
@@ -57,6 +58,7 @@ private:
     edm::EDGetTokenT<TrackingParticleCollection>     trackingTruthT_;
     edm::EDGetTokenT<TrackingVertexCollection>     trackingTruthV_;
     edm::EDGetTokenT<PileupMixingContent>            PileupInfoLabel_;
+    edm::EDGetTokenT<PileupVertexContent>            PileupVtxLabel_;
 
     bool LookAtTrackingTruth_ ;
 

--- a/SimGeneral/PileupInformation/interface/PileupInformation.h
+++ b/SimGeneral/PileupInformation/interface/PileupInformation.h
@@ -54,10 +54,14 @@ private:
     double                   volumeZ_;
     double                   pTcut_1_;
     double                   pTcut_2_;
+    bool isPreMixed_;
+
 
     edm::EDGetTokenT<TrackingParticleCollection>     trackingTruthT_;
     edm::EDGetTokenT<TrackingVertexCollection>     trackingTruthV_;
     edm::EDGetTokenT<PileupMixingContent>            PileupInfoLabel_;
+    edm::EDGetTokenT<int> bunchSpacingToken_;
+    edm::EDGetTokenT<std::vector<PileupSummaryInfo> > pileupSummaryToken_;
     edm::EDGetTokenT<PileupVertexContent>            PileupVtxLabel_;
 
     bool LookAtTrackingTruth_ ;

--- a/SimGeneral/PileupInformation/plugins/BuildFile.xml
+++ b/SimGeneral/PileupInformation/plugins/BuildFile.xml
@@ -10,6 +10,7 @@
 <use   name="SimDataFormats/TrackingHit"/>
 <use   name="SimDataFormats/Vertex"/>
 <use   name="SimTracker/Common"/>
+<use   name="SimGeneral/MixingModule"/>
 <use   name="clhep"/>
 <library   file="*.cc" name="SimGeneralPileupInformationPlugins">
   <flags   EDM_PLUGIN="1"/>

--- a/SimGeneral/PileupInformation/plugins/PileupInformation.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupInformation.cc
@@ -23,28 +23,38 @@ PileupInformation::PileupInformation(const edm::ParameterSet & config)
 
     pTcut_1_                = 0.1;
     pTcut_2_                = 0.5; // defaults                                                       
-    distanceCut_            = config.getParameter<double>("vertexDistanceCut");
-    volumeRadius_           = config.getParameter<double>("volumeRadius");
-    volumeZ_                = config.getParameter<double>("volumeZ");
-    pTcut_1_                = config.getParameter<double>("pTcut_1");
-    pTcut_2_                = config.getParameter<double>("pTcut_2");
 
-    PileupInfoLabel_        = consumes<PileupMixingContent>(config.getParameter<edm::InputTag>("PileupMixingLabel"));
-    PileupVtxLabel_         = consumes<PileupVertexContent>(config.getParameter<edm::InputTag>("PileupMixingLabel"));
+    isPreMixed_             = config.getParameter<bool>("isPreMixed");
 
-    LookAtTrackingTruth_    = config.getUntrackedParameter<bool>("doTrackTruth");
+    if ( !isPreMixed_ ) {
+      distanceCut_            = config.getParameter<double>("vertexDistanceCut");
+      volumeRadius_           = config.getParameter<double>("volumeRadius");
+      volumeZ_                = config.getParameter<double>("volumeZ");
+      pTcut_1_                = config.getParameter<double>("pTcut_1");
+      pTcut_2_                = config.getParameter<double>("pTcut_2");
+      
+      PileupInfoLabel_        = consumes<PileupMixingContent>(config.getParameter<edm::InputTag>("PileupMixingLabel"));
+      
+      PileupVtxLabel_         = consumes<PileupVertexContent>(config.getParameter<edm::InputTag>("PileupMixingLabel"));
 
-    trackingTruthT_          = mayConsume<TrackingParticleCollection>(config.getParameter<edm::InputTag>("TrackingParticlesLabel"));
-    trackingTruthV_          = mayConsume<TrackingVertexCollection>(config.getParameter<edm::InputTag>("TrackingParticlesLabel"));
-
-    MessageCategory_        = "PileupInformation";
-
-    edm::LogInfo (MessageCategory_) << "Setting up PileupInformation";
-    edm::LogInfo (MessageCategory_) << "Vertex distance cut set to " << distanceCut_  << " mm";
-    edm::LogInfo (MessageCategory_) << "Volume radius set to "       << volumeRadius_ << " mm";
-    edm::LogInfo (MessageCategory_) << "Volume Z      set to "       << volumeZ_      << " mm";
-    edm::LogInfo (MessageCategory_) << "Lower pT Threshold set to "       << pTcut_1_      << " GeV";
-    edm::LogInfo (MessageCategory_) << "Upper pT Threshold set to "       << pTcut_2_      << " GeV";
+      LookAtTrackingTruth_    = config.getUntrackedParameter<bool>("doTrackTruth");
+      
+      trackingTruthT_          = mayConsume<TrackingParticleCollection>(config.getParameter<edm::InputTag>("TrackingParticlesLabel"));
+      trackingTruthV_          = mayConsume<TrackingVertexCollection>(config.getParameter<edm::InputTag>("TrackingParticlesLabel"));
+      
+      MessageCategory_        = "PileupInformation";
+      
+      edm::LogInfo (MessageCategory_) << "Setting up PileupInformation";
+      edm::LogInfo (MessageCategory_) << "Vertex distance cut set to " << distanceCut_  << " mm";
+      edm::LogInfo (MessageCategory_) << "Volume radius set to "       << volumeRadius_ << " mm";
+      edm::LogInfo (MessageCategory_) << "Volume Z      set to "       << volumeZ_      << " mm";
+      edm::LogInfo (MessageCategory_) << "Lower pT Threshold set to "       << pTcut_1_      << " GeV";
+      edm::LogInfo (MessageCategory_) << "Upper pT Threshold set to "       << pTcut_2_      << " GeV";
+    }
+    else{
+      pileupSummaryToken_=consumes<std::vector<PileupSummaryInfo> >(config.getParameter<edm::InputTag>("PileupSummaryInfoInputTag"));
+      bunchSpacingToken_=consumes<int>(config.getParameter<edm::InputTag>("BunchSpacingInputTag"));
+    }  
 
 
     produces< std::vector<PileupSummaryInfo> >();

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -1,0 +1,159 @@
+// -*- C++ -*-
+//
+// Package:    PileupVertexAccumulator
+// Class:      PileupVertexAccumulator
+// 
+/**\class PileupVertexAccumulator PileupVertexAccumulator.cc SimTracker/PileupVertexAccumulator/src/PileupVertexAccumulator.cc
+
+ Description: <one line class summary>
+
+ Implementation:
+     <Notes on implementation>
+*/
+//
+// Original Author: Mike Hildreth - Notre Dame
+//         Created:  Wed Jan 21 05:14:48 CET 2015
+//
+//
+
+
+// system include files
+#include <memory>
+#include <set>
+
+// user include files
+#include "PileupVertexAccumulator.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/one/EDProducer.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/GenRunInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupVertexContent.h"
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "SimGeneral/MixingModule/interface/PileUpEventPrincipal.h"
+
+#include "FWCore/Utilities/interface/StreamID.h"
+#include "FWCore/Utilities/interface/Exception.h"
+
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+//using namespace std;
+
+
+namespace cms
+{
+  PileupVertexAccumulator::PileupVertexAccumulator(const edm::ParameterSet& iConfig, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC)
+  {
+    edm::LogInfo ("PixelDigitizer ") <<"Enter the Pixel Digitizer";
+    
+    const std::string alias ("PileupVertexAccum"); 
+    
+    mixMod.produces<PileupVertexContent>().setBranchAlias(alias);
+
+    const edm::InputTag Mtag("generator");
+
+    iC.consumes<edm::HepMCProduct>(Mtag);
+  }
+  
+  PileupVertexAccumulator::~PileupVertexAccumulator(){  
+  }
+
+
+  //
+  // member functions
+  //
+  
+  void
+  PileupVertexAccumulator::initializeEvent(edm::Event const& e, edm::EventSetup const& iSetup) {
+    // Make sure that the first crossing processed starts indexing the minbias events from zero.
+
+    pT_Hats_.clear();
+    z_posns_.clear();
+  }
+
+  void
+  PileupVertexAccumulator::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
+    edm::Handle<edm::HepMCProduct> MCevt;
+    const edm::InputTag Mtag("generator");
+    iEvent.getByLabel(Mtag, MCevt);
+
+
+
+    // don't do anything for hard-scatter signal events
+  }
+
+  void
+  PileupVertexAccumulator::accumulate(PileUpEventPrincipal const& iEvent, edm::EventSetup const& iSetup, edm::StreamID const& streamID) {
+
+    edm::Handle<edm::HepMCProduct> MCevt;
+    const edm::InputTag Mtag("generator");
+    iEvent.getByLabel(Mtag, MCevt);
+
+    HepMC::GenEvent * myGenEvent = new HepMC::GenEvent(*(MCevt->GetEvent()));
+
+    double pthat = myGenEvent->event_scale();
+    float pt_hat = float(pthat);
+
+    std::cout << " vertex pt_hat " << pt_hat << std::endl;
+    
+    pT_Hats_.push_back(pt_hat);
+
+    HepMC::GenEvent::vertex_const_iterator viter;
+    HepMC::GenEvent::vertex_const_iterator vbegin = myGenEvent->vertices_begin();
+    HepMC::GenEvent::vertex_const_iterator vend = myGenEvent->vertices_end();
+
+    // for production point, pick first vertex
+    viter=vbegin; 
+
+    if(viter!=vend){
+      // The origin vertex (turn it to cm's from GenEvent mm's)
+      HepMC::GenVertex* v = *viter;   
+      float zpos = v->position().z()/10.;
+ 
+      z_posns_.push_back(zpos);
+
+      std::cout << " vertex z pos " << zpos << std::endl;
+    }
+
+    delete myGenEvent;
+
+  }
+
+  // ------------ method called to produce write the data  ------------
+  void
+  PileupVertexAccumulator::finalizeEvent(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+
+    std::auto_ptr<PileupVertexContent> PUVtxC(new PileupVertexContent(pT_Hats_, z_posns_));
+
+    // write output to event
+    iEvent.put(PUVtxC);
+  }
+
+
+}// end namespace cms::
+

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -119,8 +119,6 @@ namespace cms
     double pthat = myGenEvent->event_scale();
     float pt_hat = float(pthat);
 
-    std::cout << " vertex pt_hat " << pt_hat << std::endl;
-    
     pT_Hats_.push_back(pt_hat);
 
     HepMC::GenEvent::vertex_const_iterator viter;
@@ -136,8 +134,6 @@ namespace cms
       float zpos = v->position().z()/10.;
  
       z_posns_.push_back(zpos);
-
-      std::cout << " vertex z pos " << zpos << std::endl;
     }
 
     delete myGenEvent;

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
@@ -1,0 +1,60 @@
+#ifndef PileupVertexAccumulator_h
+#define PileupVertexAccumulator_h
+
+/** \class PileupVertexAccumulator
+ *
+ * PileupVertexAccumulator saves some pileup vertex information which is passed to
+ * PileupSummaryInformation
+ *
+ * \author Mike Hildreth
+ *
+ * \version   Jan 22 2015  
+
+ *
+ ************************************************************/
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/Provenance/interface/EventID.h"
+
+namespace edm {
+  class ConsumesCollector;
+  namespace one {
+    class EDProducerBase;
+  }
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+  template<typename T> class Handle;
+  class StreamID;
+}
+
+class PileUpEventPrincipal;
+
+namespace cms {
+  class PileupVertexAccumulator : public DigiAccumulatorMixMod {
+  public:
+
+    explicit PileupVertexAccumulator(const edm::ParameterSet& conf, edm::one::EDProducerBase& mixMod, edm::ConsumesCollector& iC);
+
+    virtual ~PileupVertexAccumulator();
+
+    virtual void initializeEvent(edm::Event const& e, edm::EventSetup const& c) override;
+    virtual void accumulate(edm::Event const& e, edm::EventSetup const& c) override;
+    virtual void accumulate(PileUpEventPrincipal const& e, edm::EventSetup const& c, edm::StreamID const&) override;
+    virtual void finalizeEvent(edm::Event& e, edm::EventSetup const& c) override;
+
+    virtual void beginJob() {}
+
+  private:
+    std::vector<float> pT_Hats_;
+    std::vector<float> z_posns_;
+  };
+}
+
+
+#endif

--- a/SimGeneral/PileupInformation/plugins/SealModule.cc
+++ b/SimGeneral/PileupInformation/plugins/SealModule.cc
@@ -1,0 +1,7 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
+#include "PileupVertexAccumulator.h"
+
+using cms::PileupVertexAccumulator;
+DEFINE_DIGI_ACCUMULATOR(PileupVertexAccumulator);
+

--- a/SimGeneral/PileupInformation/python/AddPileupSummaryPreMixed_cfi.py
+++ b/SimGeneral/PileupInformation/python/AddPileupSummaryPreMixed_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+#pileupSummary = cms.EDProducer("PileupInformation",
+addPileupInfo = cms.EDProducer("PileupInformation",
+                               isPreMixed = cms.bool(True),
+                               PileupSummaryInfoInputTag=cms.InputTag('mixData'),
+                               BunchSpacingInputTag=cms.InputTag('mixData','bunchSpacing')
+)

--- a/SimGeneral/PileupInformation/python/AddPileupSummary_cfi.py
+++ b/SimGeneral/PileupInformation/python/AddPileupSummary_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 #pileupSummary = cms.EDProducer("PileupInformation",
 addPileupInfo = cms.EDProducer("PileupInformation",
-
+    isPreMixed = cms.bool(False),
     TrackingParticlesLabel = cms.InputTag('mergedtruth'),
     PileupMixingLabel = cms.InputTag('mix'),
     simHitLabel = cms.string('g4SimHits'),

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizer.h
@@ -20,6 +20,7 @@
 
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/Provenance/interface/EventID.h"
 
 namespace edm {
   class ConsumesCollector;
@@ -61,8 +62,9 @@ namespace cms {
 
     virtual void StorePileupInformation( std::vector<int> &numInteractionList,
 					 std::vector<int> &bunchCrossingList,
-					 std::vector<float> &TrueInteractionList, int bunchSpacing){
-      PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList, bunchSpacing);
+					 std::vector<float> &TrueInteractionList, 
+					 std::vector<edm::EventID> &eventInfoList, int bunchSpacing){
+      PileupInfo_ = new PileupMixingContent(numInteractionList, bunchCrossingList, TrueInteractionList, eventInfoList, bunchSpacing);
     }
 
     virtual PileupMixingContent* getEventPileupInfo() { return PileupInfo_; }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -545,7 +545,6 @@ void SiPixelDigitizerAlgorithm::calculateInstlumiFactor(PileupMixingContent* puI
   //Instlumi scalefactor calculating for dynamic inefficiency
   
   if (puInfo) {
-    
     const std::vector<int> bunchCrossing = puInfo->getMix_bunchCrossing();
     const std::vector<float> TrueInteractionList = puInfo->getMix_TrueInteractions();      
     const int bunchSpacing = puInfo->getMix_bunchSpacing();


### PR DESCRIPTION
Backport of similar changes from 74X, requested by TSG.
