### PR TITLE
Calling TFormula::SetName leads to thread safety issues

### DIFF
--- a/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
+++ b/RecoTauTag/RecoTau/plugins/RecoTauDiscriminantCutMultiplexer.cc
@@ -114,7 +114,7 @@ namespace
     return std::unique_ptr<const TGraph>{ new TGraph(*graphPayload.product()) };
   }  
 
-  std::unique_ptr<TFormula> loadTFormulaFromDB(const edm::EventSetup& es, const std::string& formulaName, const int& verbosity_ = 0)
+  std::unique_ptr<TFormula> loadTFormulaFromDB(const edm::EventSetup& es, const std::string& formulaName, const TString& newName, const int& verbosity_ = 0)
   {
     if(verbosity_){
       std::cout << "<loadTFormulaFromDB>:" << std::endl;
@@ -124,7 +124,7 @@ namespace
     es.get<PhysicsTFormulaPayloadRcd>().get(formulaName, formulaPayload);
 
     if ( formulaPayload->formulas().size() == 1 && formulaPayload->limits().size() == 1 ) {
-      return std::unique_ptr<TFormula> {new TFormula("mvaNormalizationFormula", formulaPayload->formulas().at(0).data()) };
+      return std::unique_ptr<TFormula> {new TFormula(newName, formulaPayload->formulas().at(0).data()) };
     } else {
       throw cms::Exception("RecoTauDiscriminantCutMultiplexer::loadTFormulaFromDB") 
 	<< "Failed to load TFormula = " << formulaName << " from Database !!\n";
@@ -203,8 +203,7 @@ void RecoTauDiscriminantCutMultiplexer::beginEvent(const edm::Event& evt, const 
 	inputFile = openInputFile(inputFileName_);
 	mvaOutput_normalization_ = loadObjectFromFile<TFormula>(*inputFile, mvaOutputNormalizationName_);
       } else {
-	auto temp = loadTFormulaFromDB(es, mvaOutputNormalizationName_, verbosity_);
-	temp->SetName(Form("%s_mvaOutput_normalization", moduleLabel_.data()));
+	auto temp = loadTFormulaFromDB(es, mvaOutputNormalizationName_, Form("%s_mvaOutput_normalization", moduleLabel_.data()), verbosity_);
 	mvaOutput_normalization_.reset(temp.release());
       }
     }


### PR DESCRIPTION
When a TFormula is created, it may be added to a global list of formulas.
If that happens, then calling TFormula::SetName at the same time another
thread is looping through the list of formulas can lead to a crash.
Setting the name correctly in the constructor avoids the problem.
This problem was found by helgrind.
