### PR TITLE
Back port analysis changes from ROOT6 IB

### DIFF
--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuIsolationAnalyzer.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuIsolationAnalyzer.cc
@@ -62,7 +62,7 @@ private:
   template<typename T>
   MuTag muTag(const T & mu) const;
   void Deposits(const pat::IsoDeposit* isodep, double dR_max,  TH1F* hist);
-  void histo(const TH1F* hist, const char* cx, const char* cy) const;
+  void histo(TH1F* hist, const char* cx, const char* cy) const;
 };
 
 template<typename T>
@@ -114,7 +114,7 @@ void ZMuMuIsolationAnalyzer::Deposits(const pat::IsoDeposit* isodep,double dR_ma
   }
 }
 
-void ZMuMuIsolationAnalyzer::histo(const TH1F* hist, const char* cx, const char*cy) const{
+void ZMuMuIsolationAnalyzer::histo(TH1F* hist, const char* cx, const char*cy) const{
   hist->GetXaxis()->SetTitle(cx);
   hist->GetYaxis()->SetTitle(cy);
   hist->GetXaxis()->SetTitleOffset(1);

--- a/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuSaMassHistogram.cc
+++ b/ElectroWeakAnalysis/ZMuMu/plugins/ZMuMuSaMassHistogram.cc
@@ -46,10 +46,10 @@ private:
   double min, max;
   int Nbin;
   TH1F * ZMassSa;
-  void histo(const TH1F* hist, char* cx, char* cy) const;
+  void histo(TH1F* hist, char* cx, char* cy) const;
 };
 
-void ZMuMuSaMassHistogram::histo(const TH1F* hist,char* cx, char*cy) const{
+void ZMuMuSaMassHistogram::histo(TH1F* hist,char* cx, char*cy) const{
   hist->GetXaxis()->SetTitle(cx);
   hist->GetYaxis()->SetTitle(cy);
   hist->GetXaxis()->SetTitleOffset(1);

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
@@ -1131,7 +1131,7 @@ void MuScleFitUtils::minimizeLikelihood()
 {
   // Output file with fit parameters resulting from minimization
   // -----------------------------------------------------------
-  ofstream FitParametersFile;
+  std::ofstream FitParametersFile;
   FitParametersFile.open ("FitParameters.txt", std::ios::app);
   FitParametersFile << "Fitting with resolution, scale, bgr function # "
 		    << ResolFitType << " " << ScaleFitType << " " << BgrFitType

--- a/MuonAnalysis/MomentumScaleCalibration/src/BackgroundFunction.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/src/BackgroundFunction.cc
@@ -7,7 +7,7 @@ void BackgroundFunction::readParameters( TString fileName )
   // std::vector<double> parameterErrors;
 
   // Read the parameters file
-  ifstream parametersFile(fileName.Data());
+  std::ifstream parametersFile(fileName.Data());
   std::string line;
 
   std::string iteration("Iteration ");

--- a/PhysicsTools/ParallelAnalysis/interface/TrackAnalysisAlgorithm.h
+++ b/PhysicsTools/ParallelAnalysis/interface/TrackAnalysisAlgorithm.h
@@ -37,5 +37,4 @@ namespace examples {
 
 }
 
-template<> atomic_TClass_ptr TFWLiteSelector<examples::TrackAnalysisAlgorithm>::fgIsA;
 #endif

--- a/PhysicsTools/Utilities/interface/LumiReweightingStandAlone.h
+++ b/PhysicsTools/Utilities/interface/LumiReweightingStandAlone.h
@@ -17,7 +17,7 @@
   \authors Salvatore Rappoccio, Mike Hildreth
 */
 
-#include "TH1.h"
+#include "TH1F.h"
 #include "TH3.h"
 #include "TFile.h"
 #include "TRandom1.h"
@@ -241,21 +241,21 @@ namespace reweight {
 	  generatedFile_ = new TFile( generatedFileName_.c_str() ) ; //MC distribution
 	  dataFile_      = new TFile( dataFileName_.c_str() );       //Data distribution
 
-	  Data_distr_ = new TH1(  *(static_cast<TH1*>(dataFile_->Get( DataHistName_.c_str() )->Clone() )) );
-	  MC_distr_ = new TH1(  *(static_cast<TH1*>(generatedFile_->Get( GenHistName_.c_str() )->Clone() )) );
+	  Data_distr_ = new TH1F(  *(static_cast<TH1F*>(dataFile_->Get( DataHistName_.c_str() )->Clone() )) );
+	  MC_distr_ = new TH1F(  *(static_cast<TH1F*>(generatedFile_->Get( GenHistName_.c_str() )->Clone() )) );
 
 	  // normalize both histograms first                                                                            
 
 	  Data_distr_->Scale( 1.0/ Data_distr_->Integral() );
 	  MC_distr_->Scale( 1.0/ MC_distr_->Integral() );
 
-	  weights_ = new TH1( *(Data_distr_)) ;
+	  weights_ = new TH1F( *(Data_distr_)) ;
 
 	  // MC * data/MC = data, so the weights are data/MC:
 
 	  weights_->SetName("lumiWeights");
 
-	  TH1* den = new TH1(*(MC_distr_));
+	  TH1F* den = new TH1F(*(MC_distr_));
 
 	  weights_->Divide( den );  // so now the average weight should be 1.0
 
@@ -294,7 +294,7 @@ namespace reweight {
 	Data_distr_ = new TH1F("Data_distr","Data dist",NBins,-0.5, float(NBins)-0.5);
 
 	weights_ = new TH1F("luminumer","luminumer",NBins,-0.5, float(NBins)-0.5);
-	TH1* den = new TH1F("lumidenom","lumidenom",NBins,-0.5, float(NBins)-0.5);
+	TH1F* den = new TH1F("lumidenom","lumidenom",NBins,-0.5, float(NBins)-0.5);
 
 	for(int ibin = 1; ibin<NBins+1; ++ibin ) {
 	  weights_->SetBinContent(ibin, Lumi_distr[ibin-1]);
@@ -1402,11 +1402,11 @@ namespace reweight {
       std::string DataHistName_;
       TFile *generatedFile_;
       TFile *dataFile_;
-      TH1  *weights_;
+      TH1F  *weights_;
 
       //keep copies of normalized distributions:                                                                                  
-      TH1*      MC_distr_;
-      TH1*      Data_distr_;
+      TH1F*      MC_distr_;
+      TH1F*      Data_distr_;
 
       double WeightOOTPU_[25][25];
       double Weight3D_[50][50][50];


### PR DESCRIPTION
This PR removes some differences between CMSSW_7_4_ROOT6_X and CMSSW_7_4_X by back porting changes in analysis packages from 7_4_ROOT6_X that are also OK or beneficial for ROOT5.
The changes have to do with using TH1F pointers instead of TH1 pointers, and also adding missing std:: qualifiers.
