### PR TITLE
Add missing std::

### DIFF
--- a/Fireworks/Core/src/FWConfigurationManager.cc
+++ b/Fireworks/Core/src/FWConfigurationManager.cc
@@ -214,7 +214,7 @@ class FWXMLConfigParser : public SimpleSAXParser
       };
 
 public:
-   FWXMLConfigParser(istream &f) 
+   FWXMLConfigParser(std::istream &f) 
    : SimpleSAXParser(f),
      m_state(IN_BEGIN_DOCUMENT),
      m_first(0)


### PR DESCRIPTION
Add missing std:: qualifier.  Also removes an unnecessary difference between 7_4_X and 7_4_ROOT6_X.
