### PR TITLE
Fixed warnings from clang

### DIFF
--- a/DataFormats/Common/interface/Trie.h
+++ b/DataFormats/Common/interface/Trie.h
@@ -282,7 +282,6 @@ namespace edm{
   /// visit each node of the trie
   template<typename V, typename T>
   void walkTrie(V & v,  TrieNode<T> const  & n, std::string const & label="") {
-    typedef TrieNode<T> const node_base;
     typedef TrieNodeIter<T> node_iterator;
     node_iterator e;
     for (node_iterator p(&n); p!=e; ++p) {
@@ -296,7 +295,6 @@ namespace edm{
   /// visits only leaf nodes 
   template<typename V, typename T>
   bool iterateTrieLeaves(V & v,  TrieNode<T> const  & n, std::string const & label="") {
-    typedef TrieNode<T> const node_base;
     typedef TrieNodeIter<T> node_iterator;
     node_iterator e;
     node_iterator p(&n);

--- a/DataFormats/Common/interface/fillPtrVector.h
+++ b/DataFormats/Common/interface/fillPtrVector.h
@@ -43,7 +43,6 @@ namespace edm {
       typedef COLLECTION                            product_type;
       typedef typename GetProduct<product_type>::element_type     element_type;
       typedef typename product_type::const_iterator iter;
-      typedef typename product_type::size_type      size_type;
 
       oPtr.reserve(iIndicies.size());
       if(iToType == typeid(element_type)) {

--- a/DataFormats/Common/interface/setPtr.h
+++ b/DataFormats/Common/interface/setPtr.h
@@ -41,7 +41,6 @@ namespace edm {
       typedef COLLECTION                            product_type;
       typedef typename GetProduct<product_type>::element_type     element_type;
       typedef typename product_type::const_iterator iter;
-      typedef typename product_type::size_type      size_type;
 
       if(iToType == typeid(element_type)) {
         iter it = coll.begin();

--- a/DataFormats/Common/test/DetSetVector_t.cpp
+++ b/DataFormats/Common/test/DetSetVector_t.cpp
@@ -19,6 +19,11 @@ using namespace edm;
 //------------------------------------------------------
 // This is a sample VALUE class, almost the simplest possible.
 //------------------------------------------------------
+namespace {
+  bool is_null(const void* iPtr) {
+    return iPtr == nullptr ;
+  }
+}
 
 struct Empty { };
 
@@ -176,7 +181,7 @@ namespace {
     virtual void
     getThinnedProducts(ProductID const& pid,
                        std::vector<WrapperBase const*>& wrappers,
-                       std::vector<unsigned int>& keys) const { }
+                       std::vector<unsigned int>& keys) const override { }
 
     virtual unsigned int
     transitionIndex_() const override {return 0U;}
@@ -344,7 +349,7 @@ void work() {
     try {
       coll_type::reference r = c[edm::det_id_type(100)];
       assert("Failed to throw required exception" == 0);
-      assert(&r == 0); // to silence warning of unused r
+      assert(is_null(&r)); // to silence warning of unused r
     }
     catch (edm::Exception const& x) {
       // Test we have the right exception category
@@ -361,7 +366,7 @@ void work() {
       coll_type::const_reference r
         = static_cast<coll_type const&>(c)[edm::det_id_type(100)];
       assert("Failed to throw required exception" == 0);
-      assert(&r == 0); // to silence warning of unused r
+      assert(is_null(&r)); // to silence warning of unused r
     }
     catch (edm::Exception const& x) {
       // Test we have the right exception category

--- a/DataFormats/Common/test/SimpleEDProductGetter.h
+++ b/DataFormats/Common/test/SimpleEDProductGetter.h
@@ -42,7 +42,7 @@ public:
   virtual void
   getThinnedProducts(edm::ProductID const& pid,
                      std::vector<edm::WrapperBase const*>& wrappers,
-                     std::vector<unsigned int>& keys) const { }
+                     std::vector<unsigned int>& keys) const override { }
 
 
 private:

--- a/DataFormats/Common/test/ptr_t.cppunit.cc
+++ b/DataFormats/Common/test/ptr_t.cppunit.cc
@@ -297,7 +297,7 @@ namespace {
       virtual void
       getThinnedProducts(ProductID const& pid,
                          std::vector<WrapperBase const*>& wrappers,
-                         std::vector<unsigned int>& keys) const { }
+                         std::vector<unsigned int>& keys) const override { }
 
       virtual unsigned int transitionIndex_() const override {
         return 0U;

--- a/DataFormats/Common/test/ptrvector_t.cppunit.cc
+++ b/DataFormats/Common/test/ptrvector_t.cppunit.cc
@@ -49,7 +49,7 @@ namespace testPtr {
     virtual void
     getThinnedProducts(edm::ProductID const& pid,
                        std::vector<edm::WrapperBase const*>& wrappers,
-                       std::vector<unsigned int>& keys) const { }
+                       std::vector<unsigned int>& keys) const override { }
 
 
     virtual unsigned int transitionIndex_() const override {

--- a/DataFormats/Common/test/ref_t.cppunit.cc
+++ b/DataFormats/Common/test/ref_t.cppunit.cc
@@ -169,7 +169,7 @@ namespace {
       virtual void
       getThinnedProducts(ProductID const& pid,
                          std::vector<WrapperBase const*>& wrappers,
-                         std::vector<unsigned int>& keys) const { }
+                         std::vector<unsigned int>& keys) const override { }
 
       virtual unsigned int transitionIndex_() const override {
         return 0U;

--- a/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
+++ b/DataFormats/Common/test/reftobaseprod_t.cppunit.cc
@@ -184,7 +184,7 @@ namespace {
       virtual void
       getThinnedProducts(ProductID const& pid,
                          std::vector<WrapperBase const*>& wrappers,
-                         std::vector<unsigned int>& keys) const { }
+                         std::vector<unsigned int>& keys) const override { }
 
       virtual unsigned int transitionIndex_() const override {
          return 0U;

--- a/FWCore/Framework/src/EventSetupProvider.cc
+++ b/FWCore/Framework/src/EventSetupProvider.cc
@@ -96,7 +96,7 @@ EventSetupProvider::insert(const EventSetupRecordKey& iKey, std::auto_ptr<EventS
 void 
 EventSetupProvider::add(boost::shared_ptr<DataProxyProvider> iProvider)
 {
-   assert(&(*iProvider) != 0);
+   assert(iProvider.get() != 0);
    dataProviders_->push_back(iProvider);
 }
 
@@ -114,7 +114,7 @@ EventSetupProvider::replaceExisting(boost::shared_ptr<DataProxyProvider> dataPro
 void 
 EventSetupProvider::add(boost::shared_ptr<EventSetupRecordIntervalFinder> iFinder)
 {
-   assert(&(*iFinder) != 0);
+   assert(iFinder.get() != 0);
    finders_->push_back(iFinder);
 }
 

--- a/FWCore/Framework/src/ModuleHolder.h
+++ b/FWCore/Framework/src/ModuleHolder.h
@@ -78,7 +78,7 @@ namespace edm {
       }
       
       std::unique_ptr<OutputModuleCommunicator>
-      createOutputModuleCommunicator() {
+      createOutputModuleCommunicator() override {
         return std::move(OutputModuleCommunicatorT<T>::createIfNeeded(m_mod.get()));
       }
     private:

--- a/FWCore/Framework/test/Event_t.cpp
+++ b/FWCore/Framework/test/Event_t.cpp
@@ -521,7 +521,6 @@ void testEvent::getByLabel() {
   typedef edmtest::IntProduct product_t;
   typedef std::unique_ptr<product_t> ap_t;
   typedef Handle<product_t> handle_t;
-  typedef std::vector<handle_t> handle_vec;
 
   ap_t one(new product_t(1));
   ap_t two(new product_t(2));
@@ -607,7 +606,6 @@ void testEvent::getByToken() {
   typedef edmtest::IntProduct product_t;
   typedef std::unique_ptr<product_t> ap_t;
   typedef Handle<product_t> handle_t;
-  typedef std::vector<handle_t> handle_vec;
   
   ap_t one(new product_t(1));
   ap_t two(new product_t(2));
@@ -733,7 +731,6 @@ void testEvent::deleteProduct() {
   
   typedef edmtest::IntProduct product_t;
   typedef std::unique_ptr<product_t> ap_t;
-  typedef Handle<product_t> handle_t;
   
   ap_t one(new product_t(1));
   addProduct(std::move(one),   "int1_tag", "int1");

--- a/FWCore/Framework/test/esproducer_t.cppunit.cc
+++ b/FWCore/Framework/test/esproducer_t.cppunit.cc
@@ -160,7 +160,7 @@ void testEsproducer::getFromTest()
       const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
    }
@@ -182,7 +182,7 @@ void testEsproducer::getfromShareTest()
       const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
    }
@@ -205,17 +205,17 @@ void testEsproducer::labelTest()
       const edm::EventSetup& eventSetup = provider.eventSetupForInstance(edm::IOVSyncValue(time));
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get("foo",pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
       
       eventSetup.get<DummyRecord>().get("fi",pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
       
       eventSetup.get<DummyRecord>().get("fum",pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(iTime == pDummy->value_);
    }
@@ -275,7 +275,7 @@ void testEsproducer::decoratorTest()
       CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_pre);
       CPPUNIT_ASSERT(iTime - 1 == TestDecorator::s_post);
       eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<"pre "<<TestDecorator::s_pre << " post " << TestDecorator::s_post << std::endl;
       CPPUNIT_ASSERT(iTime == TestDecorator::s_pre);
       CPPUNIT_ASSERT(iTime == TestDecorator::s_post);
@@ -328,7 +328,7 @@ void testEsproducer::dependsOnTest()
       edm::ESHandle<DummyData> pDummy;
       
       eventSetup.get<DepRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       CPPUNIT_ASSERT(3*iTime == pDummy->value_);
    }
 }
@@ -354,7 +354,7 @@ void testEsproducer::forceCacheClearTest()
    {
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(1 == pDummy->value_);
    }
@@ -362,7 +362,7 @@ void testEsproducer::forceCacheClearTest()
    {
       edm::ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       std::cout <<pDummy->value_ << std::endl;
       CPPUNIT_ASSERT(2 == pDummy->value_);
    }

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -36,6 +36,11 @@
 #include "FWCore/Framework/test/DummyEventSetupRecordRetriever.h"
 
 using namespace edm;
+namespace {
+  bool non_null(const void* iPtr) {
+    return iPtr != 0;
+  }
+}
 
 class testEventsetup: public CppUnit::TestFixture
 {
@@ -100,7 +105,7 @@ void testEventsetup::constructTest()
    const Timestamp time(1);
    const IOVSyncValue timestamp(time);
    EventSetup const& eventSetup = provider.eventSetupForInstance(timestamp);
-   CPPUNIT_ASSERT(&eventSetup != 0);
+   CPPUNIT_ASSERT(non_null(&eventSetup));
    CPPUNIT_ASSERT(eventSetup.iovSyncValue() == timestamp);
 }
 
@@ -108,14 +113,14 @@ void testEventsetup::getTest()
 {
    eventsetup::EventSetupProvider provider;
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-   CPPUNIT_ASSERT(&eventSetup != 0);
+   CPPUNIT_ASSERT(non_null(&eventSetup));
    //eventSetup.get<DummyRecord>();
    //CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
    
    DummyRecord dummyRecord;
    provider.addRecordToEventSetup(dummyRecord);
    const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-   CPPUNIT_ASSERT(0 != &gottenRecord);
+   CPPUNIT_ASSERT(non_null(&gottenRecord));
    CPPUNIT_ASSERT(&dummyRecord == &gottenRecord);
 }
 
@@ -123,7 +128,7 @@ void testEventsetup::getExcTest()
 {
    eventsetup::EventSetupProvider provider;
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
-   CPPUNIT_ASSERT(&eventSetup != 0);
+   CPPUNIT_ASSERT(non_null(&eventSetup));
    eventSetup.get<DummyRecord>();
    //CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
 }
@@ -152,7 +157,7 @@ void testEventsetup::recordProviderTest()
    //       this is a 'hack' to have the 'get' succeed
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
    const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-   CPPUNIT_ASSERT(0 != &gottenRecord);
+   CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
 
 
@@ -262,7 +267,7 @@ void testEventsetup::proxyProviderTest()
    
    EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
    const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
-   CPPUNIT_ASSERT(0 != &gottenRecord);
+   CPPUNIT_ASSERT(non_null(&gottenRecord));
 }
 
 void testEventsetup::producerConflictTest()

--- a/FWCore/Framework/test/fullchain_t.cppunit.cc
+++ b/FWCore/Framework/test/fullchain_t.cppunit.cc
@@ -57,10 +57,10 @@ void testfullChain::getfromDataproxyproviderTest()
       EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue(time));
       ESHandle<DummyData> pDummy;
       eventSetup.get<DummyRecord>().get(pDummy);
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
       
       eventSetup.getData(pDummy);
    
-      CPPUNIT_ASSERT(0 != &(*pDummy));
+      CPPUNIT_ASSERT(0 != pDummy.product());
    }
 }

--- a/FWCore/Framework/test/stubs/TestGlobalFilters.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalFilters.cc
@@ -526,7 +526,7 @@ struct UnsafeCache {
     }
 
 
-    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const {
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
       ++m_count;
       gblp = true;
     }

--- a/FWCore/Framework/test/stubs/TestGlobalProducers.cc
+++ b/FWCore/Framework/test/stubs/TestGlobalProducers.cc
@@ -507,7 +507,7 @@ struct UnsafeCache {
       }
     }
 
-    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const {
+    void globalBeginLuminosityBlockProduce(edm::LuminosityBlock&, edm::EventSetup const&) const override {
       ++m_count;
       gblp = true;
     }

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -96,7 +96,7 @@ struct Cache {
       m_count = 0;
     }
     
-    void analyze(edm::Event const&, edm::EventSetup const&) {
+    void analyze(edm::Event const&, edm::EventSetup const&) override {
       ++m_count;
       ++(runCache()->value);
        

--- a/FWCore/Framework/test/stubs/ToyModules.cc
+++ b/FWCore/Framework/test/stubs/ToyModules.cc
@@ -339,7 +339,6 @@ namespace edmtest {
     typedef PROD                     product_type;
     //FIXME
     typedef typename product_type::FastFiller detset;
-    typedef typename detset::value_type       value_type;
     typedef typename detset::id_type       id_type;
 
     std::unique_ptr<product_type> p(new product_type());


### PR DESCRIPTION
The clang compiler was complaining about several standard items:
-unused typedefs in functions
-missing override in a class where override is specified for other functions
-checking if a reference actually points to nullptr
