### PR TITLE
FastSim PF electrons: fix gen-mixing after pr #8231

### DIFF
--- a/FastSimulation/Configuration/python/MixingModule_Full2Fast.py
+++ b/FastSimulation/Configuration/python/MixingModule_Full2Fast.py
@@ -125,7 +125,9 @@ def prepareGenMixing(process):
 
     # Use generalTracks where DIGI-RECO mixing requires preMixTracks
     process.generalConversionTrackProducer.TrackProducer = cms.string('generalTracks')
-    process.trackerDrivenElectronSeeds.TkColList = cms.VInputTag(cms.InputTag("generalTracks"))
+    # it's not nice but gen-mixing will be depricated anyhow
+    process.trackerDrivenElectronSeedsTmp.TkColList = cms.VInputTag(cms.InputTag("generalTracks"))
+    process.trackerDrivenElectronSeeds.oldTrackCollection = cms.InputTag('generalTracks')
 
     # PileUp info must be read from PileUpProducer, rather than from MixingModule
     process.addPileupInfo.PileupMixingLabel = cms.InputTag("famosPileUp")


### PR DESCRIPTION
fix after #8231 for genmixing

@davidlange6 sorry, this is late, but urgent, we really need it in the next 74 release.

Track collections used to fix the the tracker-driven electron seeds are adapted to the gen-mix case.
The fix becomes a zero operation in case of gen-mixing, as it should.
Better would be to remove the fix completely, but this was implemented faster, and we'll depricate gen-mixing soon.
