### PR TITLE
Update to ALCARECO MuonAlignment producers

### DIFF
--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlCalIsolatedMu_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlCalIsolatedMu_Output_cff.py
@@ -7,6 +7,7 @@ OutALCARECOMuAlCalIsolatedMu_noDrop = cms.PSet(
     ),
     outputCommands = cms.untracked.vstring(
         'keep *_ALCARECOMuAlCalIsolatedMu_*_*', 
+        'keep *_generalTracks_*_*',
         'keep *_muonCSCDigis_*_*', 
         'keep *_muonDTDigis_*_*', 
         'keep *_muonRPCDigis_*_*', 
@@ -19,6 +20,8 @@ OutALCARECOMuAlCalIsolatedMu_noDrop = cms.PSet(
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
+        'keep *_offlineBeamSpot_*_*',
+        'keep *_offlinePrimaryVertices_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*')
 )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlCalIsolatedMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlCalIsolatedMu_cff.py
@@ -29,7 +29,7 @@ ALCARECOMuAlCalIsolatedMu = Alignment.CommonAlignmentProducer.AlignmentMuonSelec
 # DT calibration needs as many muons with DIGIs as possible, which in cosmic ray runs means standAloneMuons
 #    nHitMinGB = 1, # muon collections now merge globalMuons, standAlone, and trackerMuons: this stream has always assumed globalMuons
     ptMin=cms.double(0.),
-    pMin=cms.double(25.)
+    pMin=cms.double(25.),
     etaMin = -2.6,
     etaMax = 2.6,
     )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlCalIsolatedMu_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlCalIsolatedMu_cff.py
@@ -8,6 +8,20 @@ ALCARECOMuAlCalIsolatedMuHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLeve
     throw = False # tolerate triggers not available
     )
 
+# DCS partitions
+# "EBp","EBm","EEp","EEm","HBHEa","HBHEb","HBHEc","HF","HO","RPC" 
+# "DT0","DTp","DTm","CSCp","CSCm","CASTOR","TIBTID","TOB","TECp","TECm"
+# "BPIX","FPIX","ESp","ESm"
+
+import DPGAnalysis.Skims.skim_detstatus_cfi
+ALCARECOMuAlCalIsolatedDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clone(
+    DetectorType = cms.vstring('DT0','DTp','DTm','CSCp','CSCm'),
+    ApplyFilter  = cms.bool(True),
+    AndOr        = cms.bool(False),
+    DebugOn      = cms.untracked.bool(False)
+)
+
+
 import Alignment.CommonAlignmentProducer.AlignmentMuonSelector_cfi
 ALCARECOMuAlCalIsolatedMu = Alignment.CommonAlignmentProducer.AlignmentMuonSelector_cfi.AlignmentMuonSelector.clone(
     src = cms.InputTag("muons"),
@@ -15,7 +29,9 @@ ALCARECOMuAlCalIsolatedMu = Alignment.CommonAlignmentProducer.AlignmentMuonSelec
 # DT calibration needs as many muons with DIGIs as possible, which in cosmic ray runs means standAloneMuons
 #    nHitMinGB = 1, # muon collections now merge globalMuons, standAlone, and trackerMuons: this stream has always assumed globalMuons
     ptMin=cms.double(0.),
-    pMin=cms.double(10.)
+    pMin=cms.double(25.)
+    etaMin = -2.6,
+    etaMax = 2.6,
     )
 
-seqALCARECOMuAlCalIsolatedMu = cms.Sequence(ALCARECOMuAlCalIsolatedMuHLT + ALCARECOMuAlCalIsolatedMu)
+seqALCARECOMuAlCalIsolatedMu = cms.Sequence(ALCARECOMuAlCalIsolatedMuHLT + ALCARECOMuAlCalIsolatedDCSFilter + ALCARECOMuAlCalIsolatedMu)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_Output_cff.py
@@ -9,6 +9,9 @@ OutALCARECOMuAlGlobalCosmics_noDrop = cms.PSet(
     ),
     outputCommands = cms.untracked.vstring(
 	'keep *_ALCARECOMuAlGlobalCosmics_*_*',
+        'keep *_ALCARECOMuAlCosmicsCTF_*_*',
+        'keep *_ALCARECOMuAlCosmicsCosmicTF_*_*',
+        'keep *_ALCARECOMuAlCosmicsRegional_*_*',
         'keep *_muonCSCDigis_*_*',
 	'keep *_muonDTDigis_*_*',
 	'keep *_muonRPCDigis_*_*',

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlGlobalCosmics_cff.py
@@ -15,7 +15,7 @@ ALCARECOMuAlGlobalCosmicsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLeve
 # "BPIX","FPIX","ESp","ESm"
 import DPGAnalysis.Skims.skim_detstatus_cfi
 ALCARECOMuAlGlobalCosmicsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clone(
-    DetectorType = cms.vstring('DT0','DTp','DTm'),
+    DetectorType = cms.vstring('DT0','DTp','DTm',"CSCp","CSCm"),
     ApplyFilter  = cms.bool(True),
     AndOr        = cms.bool(False),
     DebugOn      = cms.untracked.bool(False)
@@ -32,4 +32,48 @@ ALCARECOMuAlGlobalCosmics = Alignment.CommonAlignmentProducer.AlignmentMuonSelec
     etaMax =  100.0
     )
 
+
+
+#________________________________Track selection____________________________________
+# AlCaReco for track based alignment using Cosmic muons reconstructed by Combinatorial Track Finder
+
+import Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi
+ALCARECOMuAlCosmicsCTF = Alignment.CommonAlignmentProducer.AlignmentTrackSelector_cfi.AlignmentTrackSelector.clone(
+    src = 'ctfWithMaterialTracksP5',
+    filter = True,
+    applyBasicCuts = True,
+    ptMin = 0., ##10
+    ptMax = 99999.,
+    pMin = 4., ##10
+    pMax = 99999.,
+    etaMin = -99., 
+    etaMax = 99., 
+
+    nHitMin = 7,
+    nHitMin2D = 2,
+    chi2nMax = 999999.,
+
+    applyMultiplicityFilter = False,
+    applyNHighestPt = True, ## select only highest pT track
+    nHighestPt = 1
+    )
+
+# AlCaReco for track based alignment using Cosmic muons reconstructed by Cosmic Track Finder
+# (same cuts)
+ALCARECOMuAlCosmicsCosmicTF = ALCARECOMuAlCosmicsCTF.clone(
+    src = 'cosmictrackfinderP5' ## different for CTF
+    )
+
+# AlCaReco for track based alignment using Cosmic muons reconstructed by Regional Cosmic Tracking
+# (same cuts)
+ALCARECOMuAlCosmicsRegional = ALCARECOMuAlCosmicsCTF.clone(
+    src = 'regionalCosmicTracks'
+    )
+
+#________________________________Sequences____________________________________  
+
 seqALCARECOMuAlGlobalCosmics = cms.Sequence(ALCARECOMuAlGlobalCosmicsHLT + ALCARECOMuAlGlobalCosmicsDCSFilter + ALCARECOMuAlGlobalCosmics)
+
+seqALCARECOMuAlCosmicsCTF = cms.Sequence(ALCARECOMuAlCosmicsCTF)
+seqALCARECOMuAlCosmicsCosmicTF = cms.Sequence(ALCARECOMuAlCosmicsCosmicTF)
+seqALCARECOMuAlCosmicsRegional = cms.Sequence(ALCARECOMuAlCosmicsRegional)

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlOverlaps_Output_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlOverlaps_Output_cff.py
@@ -5,11 +5,24 @@ OutALCARECOMuAlOverlaps_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
         SelectEvents = cms.vstring('pathALCARECOMuAlOverlaps')
     ),
+
     outputCommands = cms.untracked.vstring(
         'keep *_ALCARECOMuAlOverlaps_*_*',
+        'keep *_generalTracks_*_*',
+        'keep *_muonCSCDigis_*_*',
+        'keep *_muonDTDigis_*_*',
+        'keep *_muonRPCDigis_*_*',
+        'keep *_dt1DRecHits_*_*',
+        'keep *_dt2DSegments_*_*',
+        'keep *_dt4DSegments_*_*',
+        'keep *_csc2DRecHits_*_*',
+        'keep *_cscSegments_*_*',
+        'keep *_rpcRecHits_*_*',
         'keep L1AcceptBunchCrossings_*_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_*',
+        'keep *_offlineBeamSpot_*_*',
+        'keep *_offlinePrimaryVertices_*_*',
         'keep DcsStatuss_scalersRawToDigi_*_*')
 )
 

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlOverlaps_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlOverlaps_cff.py
@@ -31,7 +31,7 @@ ALCARECOMuAlOverlaps = cms.EDFilter("AlignmentCSCOverlapSelectorModule",
 
 import Alignment.CommonAlignmentProducer.AlignmentMuonSelector_cfi
 ALCARECOMuAlOverlapsMuonSelector = Alignment.CommonAlignmentProducer.AlignmentMuonSelector_cfi.AlignmentMuonSelector.clone(
-    ptMin = 3.
+    ptMin = 3.,
     etaMin = -2.6,
     etaMax = 2.6,
     )

--- a/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlOverlaps_cff.py
+++ b/Alignment/CommonAlignmentProducer/python/ALCARECOMuAlOverlaps_cff.py
@@ -12,6 +12,8 @@ ALCARECOMuAlOverlapsHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clo
 # "EBp","EBm","EEp","EEm","HBHEa","HBHEb","HBHEc","HF","HO","RPC"
 # "DT0","DTp","DTm","CSCp","CSCm","CASTOR","TIBTID","TOB","TECp","TECm"
 # "BPIX","FPIX","ESp","ESm"
+
+
 import DPGAnalysis.Skims.skim_detstatus_cfi
 ALCARECOMuAlOverlapsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.clone(
     DetectorType = cms.vstring('CSCp','CSCm'),
@@ -23,13 +25,15 @@ ALCARECOMuAlOverlapsDCSFilter = DPGAnalysis.Skims.skim_detstatus_cfi.dcsstatus.c
 ALCARECOMuAlOverlaps = cms.EDFilter("AlignmentCSCOverlapSelectorModule",
     filter = cms.bool(True),
     src = cms.InputTag("ALCARECOMuAlOverlapsMuonSelector","StandAlone"),
-    minHitsPerChamber = cms.uint32(4),
+    minHitsPerChamber = cms.uint32(1),
     station = cms.int32(0) ## all stations: the algorithm can handle multiple stations now
 )
 
 import Alignment.CommonAlignmentProducer.AlignmentMuonSelector_cfi
 ALCARECOMuAlOverlapsMuonSelector = Alignment.CommonAlignmentProducer.AlignmentMuonSelector_cfi.AlignmentMuonSelector.clone(
     ptMin = 3.
+    etaMin = -2.6,
+    etaMax = 2.6,
     )
 
 seqALCARECOMuAlOverlaps = cms.Sequence(ALCARECOMuAlOverlapsHLT+ALCARECOMuAlOverlapsDCSFilter+ALCARECOMuAlOverlapsMuonSelector*ALCARECOMuAlOverlaps)


### PR DESCRIPTION
This includes several changes to the ALCARECO Producers used by during MuonAlignment (changed thresholds, added several new collections to the output files, changed some of the detector status flags and fixed a bug that existed in the Overlaps stream during Run-1).
