### PR TITLE
extend Shashlik H/E cut not only for seeding, also in GsfElectronProduce...

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
@@ -57,8 +57,10 @@ def customise_shashlikElectronHOverE( process ) :
         process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEOuterEndcaps = 1.0
     if hasattr(process,'ecalDrivenGsfElectrons'):
         process.ecalDrivenGsfElectrons.hOverEMethodEndcap = cms.int32(3)
+        process.ecalDrivenGsfElectrons.maxHOverEEndcaps = cms.double(99999.)
     if hasattr(process,'gsfElectrons'):
         process.gsfElectrons.hOverEMethodEndcap = cms.int32(3)
+        process.gsfElectrons.maxHOverEEndcaps = cms.double(99999.)
     return process
 
 def customise_HGCalElectronHOverE( process ) :


### PR DESCRIPTION
...r and GsfElectronEcalDrivenProducer

This to fix the issue noticed in the SLHC25 RelVal.

The H/E cuts only relaxed in the seeding, but should also extend the same cut in GsfElectronProducer and GsfElectronEcalDrivenProducer.
