### PR TITLE
trim hep top tagger combinatorics, drop hepTopTagPFJetsCHS from RECO sequence

### DIFF
--- a/RecoJets/Configuration/python/RecoPFJets_cff.py
+++ b/RecoJets/Configuration/python/RecoPFJets_cff.py
@@ -198,7 +198,7 @@ recoPFJets   =cms.Sequence(#kt4PFJets+kt6PFJets+
                            ca8PFJetsCHSPruned+
                            ca8PFJetsCHSPrunedLinks+
                            cmsTopTagPFJetsCHS+
-                           hepTopTagPFJetsCHS+
+                           #hepTopTagPFJetsCHS+
                            ca15PFJetsCHSMassDropFiltered+
                            ca15PFJetsCHSFiltered
     )

--- a/RecoJets/JetAlgorithms/interface/HEPTopTagger.h
+++ b/RecoJets/JetAlgorithms/interface/HEPTopTagger.h
@@ -275,6 +275,7 @@ void HEPTopTagger::run_tagger()
   for(unsigned rr=0; rr<_top_parts.size(); rr++){
     for(unsigned ll=rr+1; ll<_top_parts.size(); ll++){
       for(unsigned kk=ll+1; kk<_top_parts.size(); kk++){
+	if (_candjets.size() > 32767) continue;//limit combinatorics; FIXME: consider a better solution
 	// define top_constituents candidate before filtering 	      
 	std::vector <PseudoJet> top_constits = _cs->constituents(_top_parts[rr]);
 	_cs->add_constituents(_top_parts[ll],top_constits);


### PR DESCRIPTION
somewhat arbitrary upper limit on the number of candidate jets in the HEPTopTagger.
These conditions appear in running on beam splash events.
The limit is 2^15, we could probably handle ~1M without killing the jobs; but even a few K seems beyond anything realistic.
The size of the candidates grows as N^3 in this algorithm, so it runs away pretty quickly.

After feedback from Jim, I also removed hepTopTagPFJetsCHS from recoPFJets sequence

@rappoccio @jdolen please take a look and maybe suggest something else (on a short time scale)
