### PR TITLE
Add or remove blank lines to make consistent with 7_4_X

### DIFF
--- a/AnalysisAlgos/TrackInfoProducer/test/BuildFile.xml
+++ b/AnalysisAlgos/TrackInfoProducer/test/BuildFile.xml
@@ -12,7 +12,6 @@
 <use   name="clhep"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/ParameterSet"/>
-
 <use   name="root"/>
 <library   file="TrackInfoAnalyzer.cc" name="TrackInfoAnalyzer">
   <flags   EDM_PLUGIN="1"/>

--- a/CaloOnlineTools/HcalOnlineDb/test/BuildFile.xml
+++ b/CaloOnlineTools/HcalOnlineDb/test/BuildFile.xml
@@ -1,5 +1,6 @@
 <bin   file="xmlTools.cc" name="xmlToolsRun">
   <use   name="DataFormats/Common"/>
+
   <use   name="DataFormats/HcalDetId"/>
   <use   name="CondTools/Hcal"/>
   <use   name="CalibCalorimetry/HcalTPGAlgos"/>
@@ -9,6 +10,7 @@
 </bin>
 <bin   file="channelQualityTools.cc" name="channelQualityRun">
   <use   name="DataFormats/Common"/>
+
   <use   name="DataFormats/HcalDetId"/>
   <use   name="CondTools/Hcal"/>
   <use   name="CalibCalorimetry/HcalTPGAlgos"/>

--- a/CommonTools/PileupAlgos/BuildFile.xml
+++ b/CommonTools/PileupAlgos/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="DataFormats/ParticleFlowCandidate"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="root"/>
+
 <use   name="rootcore"/>
 <use   name="fastjet"/>
 <export>

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -1,4 +1,5 @@
 <flags   GENREFLEX_ARGS="--"/>
+
 <use   name="CondCore/CondDB"/>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>

--- a/CondCore/CondDB/test/testFrontier.cpp
+++ b/CondCore/CondDB/test/testFrontier.cpp
@@ -30,7 +30,6 @@ int main (int argc, char** argv)
 
   std::string connectionString("frontier://FrontierProd/CMS_COND_31X_RUN_INFO");
   std::cout <<"# Connecting with db in "<<connectionString<<std::endl;
-
   try{
     //*************
     ConnectionPool connPool;

--- a/CondCore/DBCommon/plugins/BuildFile.xml
+++ b/CondCore/DBCommon/plugins/BuildFile.xml
@@ -23,6 +23,6 @@
   <flags   EDM_PLUGIN="1"/>
 </library>
 <library   file="BlobStreamingService.cc TBufferBlobStreamingService.cc" name="CondCoreDBCommonTBufferBlobStreamingService">
-  
+
   <flags   EDM_PLUGIN="1"/>
 </library>

--- a/CondCore/RegressionTest/test/BuildFile.xml
+++ b/CondCore/RegressionTest/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <flags   GENREFLEX_ARGS="--"/>
-
 <use   name="CondCore/RegressionTest"/>
 <use   name="CondCore/Utilities"/>
 <use   name="DataFormats/StdDictionaries"/>

--- a/CondFormats/CSCObjects/BuildFile.xml
+++ b/CondFormats/CSCObjects/BuildFile.xml
@@ -2,6 +2,7 @@
 <use   name="DataFormats/MuonDetId"/>
 <use   name="FWCore/MessageLogger"/>
 <use   name="FWCore/ParameterSet"/>
+
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
 <export>

--- a/CondFormats/CastorObjects/BuildFile.xml
+++ b/CondFormats/CastorObjects/BuildFile.xml
@@ -2,9 +2,9 @@
 <use   name="DataFormats/DetId"/>
 <use   name="DataFormats/HcalDetId"/>
 <use   name="FWCore/Utilities"/>
+
 <use   name="CondFormats/Serialization"/>
 <use   name="boost_serialization"/>
-
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/EgammaObjects/BuildFile.xml
+++ b/CondFormats/EgammaObjects/BuildFile.xml
@@ -3,8 +3,8 @@
 <use   name="CondFormats/Serialization"/>
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <use   name="boost_serialization"/>
-<use   name="roottmva"/>
 
+<use   name="roottmva"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/MFObjects/BuildFile.xml
+++ b/CondFormats/MFObjects/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/Utilities"/>
 <use   name="CondCore/DBCommon"/>
 <use   name="boost_serialization"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DPGAnalysis/SiStripTools/bin/BuildFile.xml
+++ b/DPGAnalysis/SiStripTools/bin/BuildFile.xml
@@ -1,6 +1,5 @@
 <library   name="DPGAnalysisSiStripToolsMacros" file="*.cc">
 <use   name="DPGAnalysis/SiStripTools"/>
 <use   name="root"/>
-
 <use   name="rootgraphics"/>
 </library>

--- a/DQM/Integration/BuildFile.xml
+++ b/DQM/Integration/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="RelationalAccess"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DQM/SiStripHistoricInfoClient/bin/BuildFile.xml
+++ b/DQM/SiStripHistoricInfoClient/bin/BuildFile.xml
@@ -2,7 +2,6 @@
 <use name="DQMServices/Diagnostic"/>
 <use name="FWCore/Framework"/>
 <use name="FWCore/FWLite"/>
-
 <use name="root"/>
 <use name="boost"/>
 <environment>

--- a/DQM/SiStripMonitorSummary/bin/BuildFile.xml
+++ b/DQM/SiStripMonitorSummary/bin/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="root"/>
-
 <use   name="rootgraphics"/>
 <bin   name="makePlots" file="makePlots.cc"></bin>
 <bin   name="makeTKTrend" file="makeTKTrend.cc"></bin>

--- a/DataFormats/JetReco/BuildFile.xml
+++ b/DataFormats/JetReco/BuildFile.xml
@@ -6,6 +6,7 @@
 <use   name="DataFormats/ParticleFlowReco"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="FWCore/Utilities"/>
+
 <flags LCG_DICT_HEADER="classes_1.h classes_2.h classes_3.h classes_4.h"/>
 <flags LCG_DICT_XML="classes_def_1.xml classes_def_2.xml classes_def_3.xml classes_def_4.xml"/>
 <export>

--- a/DataFormats/L1TCalorimeter/BuildFile.xml
+++ b/DataFormats/L1TCalorimeter/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1Trigger"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/L1TGlobal/BuildFile.xml
+++ b/DataFormats/L1TGlobal/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="DataFormats/Candidate"/>
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/L1Trigger"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/Luminosity/BuildFile.xml
+++ b/DataFormats/Luminosity/BuildFile.xml
@@ -1,3 +1,4 @@
+
 <use name="DataFormats/Common"/>
 <use name="FWCore/Utilities"/>
 <use name="DataFormats/PatCandidates"/>

--- a/DataFormats/Phase2TrackerDigi/BuildFile.xml
+++ b/DataFormats/Phase2TrackerDigi/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/VertexReco/test/BuildFile.xml
+++ b/DataFormats/VertexReco/test/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>
 <use   name="DataFormats/VertexReco"/>
-
 <use   name="root"/>
 <bin   name="testDataFormatsVertexReco" file="testVertex.cc,testRunner.cpp">
   <use   name="cppunit"/>

--- a/FWCore/Skeletons/scripts/mkTemplates/DataPkg/BuildFile.xml
+++ b/FWCore/Skeletons/scripts/mkTemplates/DataPkg/BuildFile.xml
@@ -1,4 +1,5 @@
 <use name="DataFormats/Common"/>
+
 <export>
   <lib name="1"/>
 </export>

--- a/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
+++ b/FWCore/Skeletons/scripts/mkTemplates/EventHypothesis/BuildFile.xml
@@ -1,5 +1,7 @@
 <use name=DataFormats/Common>
+
 <export>
   <lib name=__subsys__xxxEventHypothesis>
   <use name=DataFormats/Common>
+
 </export>

--- a/FastSimulation/TrackingRecHitProducer/test/BuildFile.xml
+++ b/FastSimulation/TrackingRecHitProducer/test/BuildFile.xml
@@ -15,7 +15,6 @@
 <use   name="SimTracker/TrackerHitAssociation"/>
 <use   name="SimDataFormats/TrackerDigiSimLink"/>
 <use   name="clhep"/>
-
 <use   name="rootgraphics"/>
 <library   file="FamosRecHitAnalysis.cc" name="FamosRecHitAnalysis">
   <use   name="FWCore/Framework"/>

--- a/Fireworks/Core/test/BuildFile.xml
+++ b/Fireworks/Core/test/BuildFile.xml
@@ -2,7 +2,6 @@
  <use name="DataFormats/TrackReco"/>
  <use name="Fireworks/Core"/>
  <use name="boost"/>
- 
  <use name="rootcore"/>
  <use name="boost_test"/>
 </bin>

--- a/Fireworks/Muons/plugins/BuildFile.xml
+++ b/Fireworks/Muons/plugins/BuildFile.xml
@@ -15,6 +15,7 @@
  <use name="Fireworks/Core"/>
  <use name="Fireworks/Muons"/>
  <use name="rootinteractive"/>
+
  <lib name="Eve"/>
  <lib name="Geom"/>
  <lib name="RGL"/>

--- a/Fireworks/Tracks/plugins/BuildFile.xml
+++ b/Fireworks/Tracks/plugins/BuildFile.xml
@@ -14,6 +14,7 @@
  <use name="Fireworks/Tracks"/>
  <use name="rootinteractive"/>
  <use name="rootphysics"/>
+
  <lib name="Eve"/>
  <lib name="Geom"/>
  <lib name="RGL"/>

--- a/GeneratorInterface/Hydjet2Interface/BuildFile.xml
+++ b/GeneratorInterface/Hydjet2Interface/BuildFile.xml
@@ -19,6 +19,7 @@
 <use   name="CommonTools/UtilAlgos"/>
 <use   name="root"/>
 <use   name="rootmath"/>
+
 <use   name="rootcore"/>
 <export> 
   <lib   name="1"/>

--- a/HLTrigger/Timer/test/BuildFile.xml
+++ b/HLTrigger/Timer/test/BuildFile.xml
@@ -3,7 +3,6 @@
   <use   name="DataFormats/HLTReco"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  
   <use   name="root"/>
 </bin>
 

--- a/HLTrigger/Tools/bin/BuildFile.xml
+++ b/HLTrigger/Tools/bin/BuildFile.xml
@@ -5,6 +5,5 @@
   <use   name="DataFormats/HLTReco"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  
   <use   name="rootgraphics"/>
 </bin>

--- a/MuonAnalysis/MomentumScaleCalibration/bin/BuildFile.xml
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="DataFormats/FWLite"/>
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/FWLite"/>
-
 <use   name="boost"/>
 <use   name="CommonTools/Utils"/>
 <use   name="PhysicsTools/Utilities"/>

--- a/PhysicsTools/CondLiteIO/test/BuildFile.xml
+++ b/PhysicsTools/CondLiteIO/test/BuildFile.xml
@@ -9,7 +9,6 @@
    
    <bin name="testPhysicsToolsCondLiteIO"
       file="recordwriter.cppunit.cpp">
-      
       <use name="rootcore"/>
       <use name="DataFormats/StdDictionaries"/>
       <use name="DataFormats/TestObjects"/>

--- a/PhysicsTools/FWLite/bin/BuildFile.xml
+++ b/PhysicsTools/FWLite/bin/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="root"/>
 <use   name="boost"/>
-
 <use   name="FWCore/FWLite"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="DataFormats/Luminosity"/>

--- a/PhysicsTools/Heppy/BuildFile.xml
+++ b/PhysicsTools/Heppy/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="root"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
+
 <use name="rootpy"/>
 <use name="clhepheader"/>
 <use name="DataFormats/Candidate"/>

--- a/PhysicsTools/HeppyCore/BuildFile.xml
+++ b/PhysicsTools/HeppyCore/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="root"/>
 <use name="rootcore"/>
 <use name="rootinteractive"/>
+
 <use name="rootpy"/>
 <export>
 <lib name="1"/>

--- a/PhysicsTools/MVAComputer/bin/BuildFile.xml
+++ b/PhysicsTools/MVAComputer/bin/BuildFile.xml
@@ -1,13 +1,11 @@
 <bin   name="mvaConvertTMVAWeights" file="mvaConvertTMVAWeights.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  
   <use   name="rootcore"/>
 </bin>
 <bin   name="mvaExtractPDFs" file="mvaExtractPDFs.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  
   <use   name="rootcore"/>
   <use   name="roothistmatrix"/>
 </bin>

--- a/PhysicsTools/MVATrainer/bin/BuildFile.xml
+++ b/PhysicsTools/MVATrainer/bin/BuildFile.xml
@@ -3,19 +3,16 @@
   <use   name="FWCore/PluginManager"/>
   <use   name="PhysicsTools/MVAComputer"/>
   <use   name="PhysicsTools/MVATrainer"/>
-  
   <use   name="rootcore"/>
 </bin>
 <bin   name="mvaTreeComputer" file="mvaTreeComputer.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="FWCore/PluginManager"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  
   <use   name="rootcore"/>
 </bin>
 <bin   name="mvaExtractor" file="mvaExtractor.cpp">
   <use   name="FWCore/Utilities"/>
   <use   name="PhysicsTools/MVAComputer"/>
-  
   <use   name="rootcore"/>
 </bin>

--- a/PhysicsTools/SelectorUtils/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/BuildFile.xml
@@ -13,6 +13,7 @@
 <use name="FWCore/FWLite"/>
 <use name="FWCore/ParameterSet"/>
 <use name="FWCore/Utilities"/>
+
 <use name="rootcore"/>
 <use name="root"/>
 <use name="openssl"/>

--- a/PhysicsTools/SelectorUtils/bin/BuildFile.xml
+++ b/PhysicsTools/SelectorUtils/bin/BuildFile.xml
@@ -3,7 +3,6 @@
 <use   name="FWCore/FWLite"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PythonParameterSet"/>
-
 <use   name="root"/>
 <use   name="boost"/>
 <use   name="boost_python"/>

--- a/RecoBTag/PerformanceDB/bin/BuildFile.xml
+++ b/RecoBTag/PerformanceDB/bin/BuildFile.xml
@@ -9,11 +9,9 @@
 
 <environment>
   <bin   file="TestPerformanceFWLite_ES.cc">
-    
     <use   name="rootcore"/>
   </bin>
   <bin   file="getbtagPerformance.cc">
-    
     <use   name="rootcore"/>
   </bin>
 

--- a/RecoEgamma/ElectronIdentification/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/BuildFile.xml
@@ -7,6 +7,7 @@
 <use   name="MagneticField/Engine"/>
 <use   name="RecoEgamma/EgammaTools"/>
 <use   name="PhysicsTools/SelectorUtils"/>
+
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoTauTag/ImpactParameter/plugins/BuildFile.xml
+++ b/RecoTauTag/ImpactParameter/plugins/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/BTauReco"/>
 <use   name="DataFormats/VertexReco"/>
+
 <use   name="DataFormats/Math"/>
 <use   name="boost"/>
 <use   name="root"/>

--- a/RecoTracker/MeasurementDet/BuildFile.xml
+++ b/RecoTracker/MeasurementDet/BuildFile.xml
@@ -23,3 +23,4 @@
 <use   name="TrackingTools/TrajectoryState"/>
 <use   name="TrackingTools/TransientTrackingRecHit"/>
 <use   name="RecoTracker/TkDetLayers"/>
+

--- a/RecoTracker/TrackProducer/test/BuildFile.xml
+++ b/RecoTracker/TrackProducer/test/BuildFile.xml
@@ -11,7 +11,6 @@
 <use   name="MagneticField/Engine"/>
 <use   name="SimDataFormats/Vertex"/>
 <use   name="TrackingTools/PatternTools"/>
-
 <use   name="root"/>
 <library   file="TrackAnalyzer.cc" name="TrackAnalyzer">
   <flags   EDM_PLUGIN="1"/>

--- a/SimCalorimetry/HcalSimAlgos/test/BuildFile.xml
+++ b/SimCalorimetry/HcalSimAlgos/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <environment>
-  
   <use name="SimCalorimetry/HcalSimAlgos"/>
   <use name="SimDataFormats/CrossingFrame"/>
   <bin file="HcalDigitizerTest.cpp"/>

--- a/SimDataFormats/JetMatching/BuildFile.xml
+++ b/SimDataFormats/JetMatching/BuildFile.xml
@@ -1,6 +1,7 @@
 <use name="DataFormats/Common"/>
 <use name="DataFormats/HepMCCandidate"/>
 <use name="DataFormats/JetReco"/>
+
 <export>
   <lib name="1"/>
 </export>

--- a/TopQuarkAnalysis/Examples/bin/BuildFile.xml
+++ b/TopQuarkAnalysis/Examples/bin/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="AnalysisDataFormats/TopObjects"/>
 <use   name="FWCore/FWLite"/>
 <use   name="FWCore/Framework"/>
-
 <use   name="root"/>
 <environment>
   <bin   file="TopHypothesisFWLiteAnalyzer.cc">

--- a/TopQuarkAnalysis/TopEventSelection/bin/BuildFile.xml
+++ b/TopQuarkAnalysis/TopEventSelection/bin/BuildFile.xml
@@ -3,7 +3,6 @@
   <use   name="TopQuarkAnalysis/TopTools"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  
   <use   name="root"/>
   <bin   file="TtSemiLRSignalSel_SoverSplusBLoop.cpp">
   </bin>

--- a/TopQuarkAnalysis/TopJetCombination/bin/BuildFile.xml
+++ b/TopQuarkAnalysis/TopJetCombination/bin/BuildFile.xml
@@ -3,7 +3,6 @@
   <use   name="TopQuarkAnalysis/TopTools"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  
   <use   name="root"/>
   <bin   file="TtSemiLRJetComb_SoverSplusBLoop.cpp">
   </bin>

--- a/Validation/RecoMuon/plugins/BuildFile.xml
+++ b/Validation/RecoMuon/plugins/BuildFile.xml
@@ -21,7 +21,6 @@
 <use   name="SimTracker/Common"/>
 <use   name="SimTracker/Records"/>
 <use   name="RecoLocalTracker/ClusterParameterEstimator"/>
-
 <use   name="root"/>
 <use   name="SimTracker/TrackAssociation"/>
 <use   name="SimTracker/TrackerHitAssociation"/>

--- a/Validation/RecoMuon/test/BuildFile.xml
+++ b/Validation/RecoMuon/test/BuildFile.xml
@@ -4,7 +4,6 @@
   <use   name="boost_program_options"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  
   <use   name="rootgraphics"/>
   <use   name="root"/>
 </bin>
@@ -13,7 +12,6 @@
   <use   name="boost"/>
   <use   name="FWCore/FWLite"/>
   <use   name="FWCore/Framework"/>
-  
   <use   name="rootgraphics"/>
   <use   name="root"/>
 </bin>


### PR DESCRIPTION
I found 51 files, all but one of them build files, where the file in CMSSW_7_4_ROOT6_X differs from CMSSW_7_4_X only because of the addition or removal of blank lines.  This trivial pull request modifies the CMSSW_7_4_ROOT6_X files to be identical with those in CMSSW_7_4_X by adding or removing blank lines.  This may prevent some merge conflicts or merge errors in the future, and avoids spurious differences when comparing releases.
Please merge this totally trivial pull request as soon as convenient.
Test it if you must, but please bypass L2 signatures.
