### PR TITLE
Trivial changes to become common with 7_4_X

### DIFF
--- a/DQM/DataScouting/src/AlphaTVarProducer.cc
+++ b/DQM/DataScouting/src/AlphaTVarProducer.cc
@@ -74,7 +74,7 @@ AlphaTVarProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 double 
 AlphaTVarProducer::CalcAlphaT(const std::vector<TLorentzVector>& jets){
 	std::vector<double> ETs;
-	TVector3 MHT(CalcMHT(jets), 0.0, 0.0);
+	TVector3 MHT{CalcMHT(jets),0.0,0.0};
 	float HT = CalcHT(jets);
 	//float HT = 0;
 	for(unsigned int i = 0; i < jets.size(); i++){

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -149,7 +149,6 @@
 
   <class name="reco::PFTauTIPAssociation">
     <field name="transientVector_" transient="true"/>
-<!--     <field name="fixed_" transient="true"/> -->
   </class>
   <class name="reco::PFTauTIPAssociationRef"/>
   <class name="reco::PFTauTIPAssociationRefProd"/>
@@ -160,7 +159,6 @@
 
   <class name="reco::PFTauVertexAssociation">
     <field name="transientVector_" transient="true"/>
-<!--     <field name="fixed_" transient="true"/> -->
   </class>
   <class name="reco::PFTauVertexAssociationRef"/>
   <class name="reco::PFTauVertexAssociationRefProd"/>
@@ -171,7 +169,6 @@
 
   <class name="reco::PFTauVertexVAssociation">
     <field name="transientVector_" transient="true"/>
-<!--     <field name="fixed_" transient="true"/> -->
   </class>
   <class name="reco::PFTauVertexVAssociationRef"/>
   <class name="reco::PFTauVertexVAssociationRefProd"/>
@@ -218,7 +215,6 @@
 
  <class name="reco::PFTau3ProngSumAssociation">
     <field name="transientVector_" transient="true"/>
-<!--     <field name="fixed_" transient="true"/> -->
   </class>
   <class name="reco::PFTau3ProngSumAssociationRef"/>
   <class name="reco::PFTau3ProngSumAssociationRefProd"/>

--- a/DataFormats/TrajectoryState/test/BuildFile.xml
+++ b/DataFormats/TrajectoryState/test/BuildFile.xml
@@ -1,5 +1,4 @@
 <use name="DataFormats/TrajectoryState"/>
-<use name="rootmath"/>
 <bin   file="PTraj_t.cpp">
 </bin>
 


### PR DESCRIPTION
There are three more files where the trivial differences between the 7_4_ROOT6_X file and the 7_4_X file can be removed from CMSSW_7_4_ROOT6_X to make the files identical in the two releases. In AlphaTVarProducer.cc, the change is just white space.  In  DataFormats/TauReco/src/classes_def_3.xml, it is the removal of ignored lines in an xml file.  In  DataFormats/TrajectoryState/test/BuildFile.xml, it is the removal of an unnecessary link dependency that was added in 7_4_ROOT6_X
Please merge as soon as convenient.  Test if you must (due to the removal of a link dependency), but please bypass L2 signatures if not signed in a timely manner.
