### PR TITLE
trim hep top tagger combinatorics

### DIFF
--- a/RecoJets/JetAlgorithms/interface/HEPTopTagger.h
+++ b/RecoJets/JetAlgorithms/interface/HEPTopTagger.h
@@ -275,6 +275,7 @@ void HEPTopTagger::run_tagger()
   for(unsigned rr=0; rr<_top_parts.size(); rr++){
     for(unsigned ll=rr+1; ll<_top_parts.size(); ll++){
       for(unsigned kk=ll+1; kk<_top_parts.size(); kk++){
+	if (_candjets.size() > 32767) continue;//limit combinatorics; FIXME: consider a better solution
 	// define top_constituents candidate before filtering 	      
 	std::vector <PseudoJet> top_constits = _cs->constituents(_top_parts[rr]);
 	_cs->add_constituents(_top_parts[ll],top_constits);


### PR DESCRIPTION
somewhat arbitrary limit on the number of top tag candidates to 32768; the same as #8330 
This was confirmed by Jim as OK in #8330
Here I'm propagating just the combinatorics trimming; the HEPTopTagger is not running in standard workflows in this release.
