### PR TITLE
Add variables to StoppedParticles 75X

### DIFF
--- a/SimG4Core/CustomPhysics/plugins/RHStopDump.cc
+++ b/SimG4Core/CustomPhysics/plugins/RHStopDump.cc
@@ -18,6 +18,15 @@ RHStopDump::RHStopDump(edm::ParameterSet const & parameters)
    fEvent.getByLabel (mProducer, "StoppedParticlesY", ys);
    edm::Handle<std::vector<float> > zs;
    fEvent.getByLabel (mProducer, "StoppedParticlesZ", zs);
+   edm::Handle<std::vector<float> > ts;
+   fEvent.getByLabel (mProducer, "StoppedParticlesTime", ts);
+   edm::Handle<std::vector<int> > ids;
+   fEvent.getByLabel (mProducer, "StoppedParticlesPdgId", ids);
+   edm::Handle<std::vector<float> > masses;
+   fEvent.getByLabel (mProducer, "StoppedParticlesMass", masses);
+   edm::Handle<std::vector<float> > charges;
+   fEvent.getByLabel (mProducer, "StoppedParticlesCharge", charges);
+
    if (names->size() != xs->size() || xs->size() != ys->size() || ys->size() != zs->size()) {
      edm::LogError ("RHStopDump") << "mismatch array sizes name/x/y/z:"
 				  << names->size() << '/' << xs->size() << '/' << ys->size() << '/' << zs->size()
@@ -25,7 +34,8 @@ RHStopDump::RHStopDump(edm::ParameterSet const & parameters)
    }
    else {
      for (size_t i = 0; i < names->size(); ++i) {
-       mStream << (*names)[i] << ' ' << (*xs)[i] << ' ' << (*ys)[i] << ' ' << (*zs)[i] << std::endl;
+       mStream << (*names)[i] << ' ' << (*xs)[i] << ' ' << (*ys)[i] << ' ' << (*zs)[i] << ' ' << (*ts)[i] << std::endl;
+       mStream << (*ids)[i] << ' ' << (*masses)[i] << ' ' << (*charges)[i] << std::endl;
      }
    }
  }

--- a/SimG4Core/CustomPhysics/plugins/RHStopTracer.h
+++ b/SimG4Core/CustomPhysics/plugins/RHStopTracer.h
@@ -28,16 +28,18 @@ class RHStopTracer :  public SimProducer,
   void produce(edm::Event&, const edm::EventSetup&);
  private:
   struct StopPoint {
-    StopPoint (const std::string& fName, double fX, double fY, double fZ, double fT) 
-      : name(fName), x(fX), y(fY), z(fZ), t(fT) 
+    StopPoint (const std::string& fName, double fX, double fY, double fZ, double fT, int fId, double fMass, double fCharge) 
+    : name(fName), x(fX), y(fY), z(fZ), t(fT), id(fId), mass(fMass), charge(fCharge) 
     {}
     std::string name;
     double x;
     double y;
     double z;
     double t;
+    int id;
+    double mass;
+    double charge;
   };
-  bool mDebug;
   bool mStopRegular;
   double mTraceEnergy;
   boost::regex mTraceParticleNameRegex;


### PR DESCRIPTION
Add pdgId, mass, and charge to StoppedParticles, remove an extraneous mDebug parameter, and add the additional variables to RHStopDump.
