### PR TITLE
Switching to GenJetsNoNu in MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
-    src = cms.InputTag("ak4GenJets"),
+    src = cms.InputTag("ak4GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
     cut = cms.string("pt > 8"),
     clearDaughters = cms.bool(False), #False means rekeying
@@ -10,7 +10,7 @@ slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
 
 
 slimmedGenJetsAK8 = cms.EDProducer("PATGenJetSlimmer",
-    src = cms.InputTag("ak8GenJets"),
+    src = cms.InputTag("ak8GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
     cut = cms.string("pt > 150"),
     clearDaughters = cms.bool(False), #False means rekeying


### PR DESCRIPTION
Spitting https://github.com/cms-sw/cmssw/pull/8241 into two PRs: one for RECO (https://github.com/cms-sw/cmssw/pull/8359) and this PR for miniAOD
