### PR TITLE
Port back from ROOT6 IB for commonality (Core)

### DIFF
--- a/DataFormats/FWLite/src/DataGetterHelper.cc
+++ b/DataFormats/FWLite/src/DataGetterHelper.cc
@@ -29,6 +29,7 @@
 
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/FunctionWithDict.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/WrappedClassName.h"
@@ -116,24 +117,19 @@ namespace fwlite {
     {
         GetterOperate op(iGetter);
 
-#if 0
-        // I'm not sure why this is still here. It would fail to
-        // compile for 3 reasons if switched on ...
-
-        //WORK AROUND FOR ROOT!!
-        //Create a new instance so that we can clear any cache the object uses
-        //this slows the code down
-        edm::ObjectWithDict obj = iData.obj_;
-        iData.obj_ = iData.obj_.construct();
-        iData.pObj_ = iData.obj_.address();
-        iData.branch_->SetAddress(&(iData.pObj_));
-        //If a REF to this was requested in the past, we might as well do the work now
-        if(0!=iData.pProd_) {
-            iData.pProd_ = iData.obj_.address();
-        }
-        obj.destruct();
-        //END OF WORK AROUND
-#endif
+        ////WORK AROUND FOR ROOT!!
+        ////Create a new instance so that we can clear any cache the object uses
+        ////this slows the code down
+        //edm::ObjectWithDict obj = iData.obj_;
+        //iData.obj_ = iData.obj_.construct();
+        //iData.pObj_ = iData.obj_.address();
+        //iData.branch_->SetAddress(&(iData.pObj_));
+        ////If a REF to this was requested in the past, we might as well do the work now
+        //if(0!=iData.pProd_) {
+        //    iData.pProd_ = iData.obj_.address();
+        //}
+        //obj.destruct();
+        ////END OF WORK AROUND
 
         TTreeCache* tcache = dynamic_cast<TTreeCache*> (branchMap_->getFile()->GetCacheRead());
 

--- a/DataFormats/FWLite/src/EntryFinder.cc
+++ b/DataFormats/FWLite/src/EntryFinder.cc
@@ -36,7 +36,7 @@ namespace fwlite {
     explicit FWLiteEventFinder(TBranch* auxBranch) : auxBranch_(auxBranch) {}
     virtual ~FWLiteEventFinder() {}
     virtual
-    edm::EventNumber_t getEventNumberOfEntry(long long entry) const override {
+    edm::EventNumber_t getEventNumberOfEntry(edm::IndexIntoFile::EntryNumber_t entry) const override {
       void* saveAddress = auxBranch_->GetAddress();
       edm::EventAuxiliary eventAux;
       edm::EventAuxiliary *pEvAux = &eventAux;

--- a/FWCore/FWLite/test/autoload_with_missing_std.C
+++ b/FWCore/FWLite/test/autoload_with_missing_std.C
@@ -3,7 +3,7 @@
 // edmtest is unknown at this point
 //if( TClass::GetClass("vector<edmtest::Thing>") ) {
 //   cout <<"class already exists!"<<endl;
-//   exit(1);
+//   exit(0);
 //}
 //cout <<"class not present yet"<<endl;
 gSystem->Load("libFWCoreFWLite");

--- a/FWCore/FWLite/test/autoload_with_namespace.C
+++ b/FWCore/FWLite/test/autoload_with_namespace.C
@@ -1,7 +1,7 @@
 {
 if( TClass::GetClass("edmtest::Thing") ) {
    cout <<"class already exists!"<<endl;
-   exit(1);
+   exit(0);
 }
 cout <<"class not present yet"<<endl;
 

--- a/FWCore/FWLite/test/autoload_with_std.C
+++ b/FWCore/FWLite/test/autoload_with_std.C
@@ -3,7 +3,7 @@
 // edmtest is unknown at this point
 //if( TClass::GetClass("std::vector<edmtest::Thing>") ) {
 //   cout <<"class already exists!"<<endl;
-//   exit(1);
+//   exit(0);
 //}
 //cout <<"class not present yet"<<endl;
 gSystem->Load("libFWCoreFWLite");

--- a/IOPool/Output/src/RootOutputTree.h
+++ b/IOPool/Output/src/RootOutputTree.h
@@ -21,7 +21,6 @@ class TFile;
 class TBranch;
 
 namespace edm {
-  class WrapperInterfaceBase;
   class RootOutputTree {
   public:
     RootOutputTree(std::shared_ptr<TFile> filePtr,


### PR DESCRIPTION
This PR ports back simple changes made in CMSSW_7_4_ROOT6_X in the Core L2 category that are desirable or harmless for CMSSW_7_4_X, in order to increase code commonality.  All affected files will be identical in the two releases after this PR is merged.  Changes were successfully tested with the short relval matrix and unit test.
The changes are:
1) An extra include needed for ROOT6.
2) Code featured out by conditional compilation was changed to a comments.
3) A "long long" was replaced by a more descriptive typedef.
4) Macro exit codes used only in unit tests  changed from 1 to 0.  0 is correct. Tests still pass.
5) an unnecessary forward declaration was removed.
