### PR TITLE
Port back from ROOT6 IB for commonality (Reco)

### DIFF
--- a/DataFormats/CaloTowers/src/classes_def.xml
+++ b/DataFormats/CaloTowers/src/classes_def.xml
@@ -13,11 +13,13 @@
   <class name="std::vector<CaloTower>"/>
   <class name="edm::Wrapper<std::vector<CaloTower> >"/>
   <class name="edm::SortedCollection<CaloTower,edm::StrictWeakOrdering<CaloTower> >"/>
+  <class name="edm::StrictWeakOrdering<CaloTower>"/>
   <class name="edm::Ref<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > >"/>  
   <class name="edm::RefVector<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > >"/> 
   <class name="edm::RefProd<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> > >"/> 
   <class name="edm::Wrapper<edm::SortedCollection<CaloTower,edm::StrictWeakOrdering<CaloTower> > >"/> 
   <class name="edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > >"/>
+  <class name="edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower,edm::StrictWeakOrdering<CaloTower> >,CaloTower>" /> <!-- Root6 -->
   <class name="std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > >"/>
   <class name="edm::Wrapper< std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > > >"/>
 

--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -9,14 +9,20 @@
   <class name="edm::Ref<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit> >"/>
   <class name="edm::RefVector<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> >,EcalUncalibratedRecHit> >"/>
   <class name="edm::RefProd<edm::SortedCollection<EcalUncalibratedRecHit,edm::StrictWeakOrdering<EcalUncalibratedRecHit> > >"/>
+  <class name="edm::StrictWeakOrdering<EcalUncalibratedRecHit>"/> <!-- Root6 -->
 
   <class name="EcalRecHit" ClassVersion="12">
    <version ClassVersion="10" checksum="283504841"/>
    <version ClassVersion="11" checksum="3356791847"/>
    <version ClassVersion="12" checksum="3356791847"/>
   </class>
+  <enum name="EcalRecHit::Flags"/>
+  <enum name="EcalRecHit::ESFlags"/>
+  <enum name="EcalSeverityLevel::SeverityLevel"/>
+
   <class name="std::vector<EcalRecHit>"/>
   <class name="edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >"/>
+  <class name="edm::StrictWeakOrdering<EcalRecHit>" /> <!-- Root6 -->
   <class name="edm::Wrapper<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> > >" />
   <class name="edm::Ref<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit> >"/>
   <class name="edm::RefVector<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit> >"/>
@@ -45,5 +51,4 @@
   <class name="edm::Wrapper<edm::RefGetter<EcalRecHit> >"/>
  
   <class name="edm::Ref< edm::LazyGetter<EcalRecHit>, EcalRecHit, edm::FindValue<EcalRecHit> >"/>
-  <enum name="EcalSeverityLevel::SeverityLevel"/> 
 </lcgdict>

--- a/DataFormats/TauReco/BuildFile.xml
+++ b/DataFormats/TauReco/BuildFile.xml
@@ -5,9 +5,7 @@
 <use   name="DataFormats/TrackReco"/>
 <use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/ParticleFlowCandidate"/>
-<use   name="FWCore/Common"/>
 
-<use   name="rootcore"/>
 <flags LCG_DICT_HEADER="classes_hlt.h classes_1.h classes_2.h classes_3.h"/>
 <flags LCG_DICT_XML="classes_def_hlt.xml classes_def_1.xml classes_def_2.xml classes_def_3.xml"/>
 <export>

--- a/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/ProjectedSiStripRecHit2D.h
@@ -76,7 +76,7 @@ private:
   virtual ProjectedSiStripRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner(*this,tsos).release();
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  ConstRecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -41,7 +41,7 @@ public:
 
   
   virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiPixelRecHit>(*this);}
 #endif
 
@@ -60,7 +60,7 @@ private:
   virtual SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner(*this,tsos).release();
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h
@@ -42,7 +42,7 @@ class SiStripMatchedRecHit2D GCC11_FINAL : public BaseTrackerRecHit {
 
 
   virtual SiStripMatchedRecHit2D * clone() const {return new SiStripMatchedRecHit2D( * this);}
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripMatchedRecHit2D>(*this);}
 #endif
 
@@ -66,7 +66,7 @@ private:
   virtual SiStripMatchedRecHit2D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner(*this,tsos).release();
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
@@ -30,7 +30,7 @@ public:
 
 
   virtual SiStripRecHit1D * clone() const GCC11_OVERRIDE {return new SiStripRecHit1D( * this); }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripRecHit1D>(*this);}
 #endif
   
@@ -44,7 +44,7 @@ private:
   virtual SiStripRecHit1D * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner(*this,tsos).release();
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -30,7 +30,7 @@ public:
   void setClusterRef(ClusterRef const & ref)  {setClusterStripRef(ref);}
 
   virtual SiStripRecHit2D * clone() const GCC11_OVERRIDE {return new SiStripRecHit2D( * this); }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripRecHit2D>(*this);}
 #endif
   
@@ -43,7 +43,7 @@ private:
   virtual SiStripRecHit2D* clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner(*this,tsos).release();
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner.makeShared(*this,tsos);
   }

--- a/DataFormats/TrackerRecHit2D/interface/TkCloner.h
+++ b/DataFormats/TrackerRecHit2D/interface/TkCloner.h
@@ -18,7 +18,7 @@ public:
     return hit.clone(*this, tsos);
   }
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
   TrackingRecHit::ConstRecHitPointer makeShared(TrackingRecHit::ConstRecHitPointer const & hit, TrajectoryStateOnSurface const& tsos) const {
     return hit->canImproveWithTrack() ?  hit->cloneSH(*this, tsos) : hit;
     // return  hit->cloneSH(*this, tsos);
@@ -31,7 +31,7 @@ public:
   virtual std::unique_ptr<SiStripMatchedRecHit2D> operator()(SiStripMatchedRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual std::unique_ptr<ProjectedSiStripRecHit2D> operator()(ProjectedSiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual TrackingRecHit::ConstRecHitPointer makeShared(SiPixelRecHit const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit2D const & hit, TrajectoryStateOnSurface const& tsos) const=0;
   virtual TrackingRecHit::ConstRecHitPointer makeShared(SiStripRecHit1D const & hit, TrajectoryStateOnSurface const& tsos) const=0;

--- a/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
@@ -17,7 +17,7 @@ public:
   virtual ~InvalidTrackingRecHit() {}
 
   virtual InvalidTrackingRecHit * clone() const GCC11_OVERRIDE {return new InvalidTrackingRecHit(*this);}
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return RecHitPointer(clone());}
 #endif
 

--- a/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/TrackingRecHit.h
@@ -12,9 +12,6 @@
 
 
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
-#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
-#define NO_DICT
-#endif
 
 #include<vector>
 #include<memory>
@@ -26,7 +23,7 @@ class KfComponentsHolder;
 class TrackingRecHit {
 public:
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
    using      RecHitPointer = std::shared_ptr<TrackingRecHit const>;  // requires to much editing
    using ConstRecHitPointer = std::shared_ptr<TrackingRecHit const>;   
 #else
@@ -75,7 +72,7 @@ public:
 
   
   virtual TrackingRecHit * clone() const = 0;
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual RecHitPointer cloneSH() const { return RecHitPointer(clone());}
   // clone and add the geom (ready for refit)
   RecHitPointer cloneForFit(const GeomDet & idet) const {
@@ -105,7 +102,7 @@ public:
   virtual std::vector<TrackingRecHit*> recHits() = 0;
   virtual void recHitsV(std::vector<TrackingRecHit*> & );
 
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual ConstRecHitContainer transientHits() const {
     ConstRecHitContainer result;
     std::vector<const TrackingRecHit*> hits;
@@ -174,7 +171,7 @@ private:
     assert("clone"==nullptr);
     return clone(); // default
   }
-#ifdef NO_DICT
+#ifndef __GCCXML__
   virtual  RecHitPointer cloneSH(TkCloner const&, TrajectoryStateOnSurface const&) const {
     assert("cloneSH"==nullptr);
     return cloneSH(); // default


### PR DESCRIPTION
This PR ports back simple changes made in CMSSW_7_4_ROOT6_X in the Reco L2 category that are desirable or harmless for CMSSW_7_4_X, in order to increase code commonality. All affected files will be identical in the two releases after this PR is merged. Changes were successfully tested with the short relval matrix.
The changes are:
1) Extra class dictionaries and enum declarations needed in XML spec files for ROOT6.
2) Removal of unneeded link dependencies.
3) Replacement of the use of NO_DICT preprocessor variable with **GCCXML** preprocessor variable, which is used throughout much of CMSSW.
