### PR TITLE
Port back from ROOT6 IB for commonality (DQM)

### DIFF
--- a/DQM/Physics/src/QcdLowPtDQM.cc
+++ b/DQM/Physics/src/QcdLowPtDQM.cc
@@ -1041,11 +1041,11 @@ void QcdLowPtDQM::fillTracklets(
   }
 
   // fill tracklet based info
-  TAxis *xa = AlphaTracklets->GetXaxis();
-  int ybin = AlphaTracklets->GetYaxis()->FindFixBin(pixels.size());
-  int zbin = AlphaTracklets->GetZaxis()->FindFixBin(trackletV.z());
-  int tbin = AlphaTracklets->GetBin(0, ybin, zbin);
-  for (size_t k = 0; k < tracklets.size(); ++k) {
+  const TAxis *xa = AlphaTracklets->GetXaxis();
+  int ybin  = AlphaTracklets->GetYaxis()->FindFixBin(pixels.size());
+  int zbin  = AlphaTracklets->GetZaxis()->FindFixBin(trackletV.z());
+  int tbin  = AlphaTracklets->GetBin(0,ybin,zbin);
+  for(size_t k=0; k<tracklets.size(); ++k) {
     const Tracklet &tl(tracklets.at(k));
     fill2D(detaphi, tl.deta(), tl.dphi());
     fill1D(deta, tl.deta());

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -599,7 +599,7 @@ DQMStore::print_trace (const std::string &dir, const std::string &name)
   // concurrency problems because the print_trace method is always called behind
   // a lock (see bookTransaction).
   if (!stream_)
-    stream_ = new ofstream("histogramBookingBT.log");
+    stream_ = new std::ofstream("histogramBookingBT.log");
   
   void *array[10];
   size_t size;

--- a/DQMServices/StreamerIO/BuildFile.xml
+++ b/DQMServices/StreamerIO/BuildFile.xml
@@ -5,7 +5,6 @@
 <use   name="FWCore/Framework"/>
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/PluginManager"/>
-<use   name="FWCore/RootAutoLibraryLoader"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="FWCore/Sources"/>
 <use   name="FWCore/Utilities"/>


### PR DESCRIPTION
This PR ports back simple changes made in CMSSW_7_4_ROOT6_X in the DQM L2 category that are desirable or harmless for CMSSW_7_4_X, in order to increase code commonality. All affected files will be identical in the two releases after this PR is merged. Changes were successfully tested with the short relval matrix.
The changes are:
1) Addition of a const qualifier needed in CMSSW_7_4_ROOT6_X
2) Addition of a missing std:: qualifier
3) Removal of an unnecessary include.
