### PR TITLE
Port back from ROOT6 IB for commonality (Sim)

### DIFF
--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -84,10 +84,15 @@
    
    <class name="edm::SortedCollection<ESDataFrame,edm::StrictWeakOrdering<ESDataFrame> >"/>
    <class name="edm::SortedCollection<EcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi> >"/>
+   <class name="edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EcalPseudoStripInputDigi,edm::StrictWeakOrdering<EcalPseudoStripInputDigi> >"/>
+   <class name="edm::StrictWeakOrdering<EcalPseudoStripInputDigi>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EBSrFlag,edm::StrictWeakOrdering<EBSrFlag> >"/>
+   <class name="edm::StrictWeakOrdering<EBSrFlag>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EESrFlag,edm::StrictWeakOrdering<EESrFlag> >"/>
+   <class name="edm::StrictWeakOrdering<EESrFlag>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EcalPnDiodeDigi,edm::StrictWeakOrdering<EcalPnDiodeDigi> >"/>
+   <class name="edm::StrictWeakOrdering<EcalPnDiodeDigi>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EcalMatacqDigi,edm::StrictWeakOrdering<EcalMatacqDigi> >"/>
    <class name="edm::Wrapper<edm::SortedCollection<ESDataFrame,edm::StrictWeakOrdering<ESDataFrame> > >" splitLevel="0" id="C3D41492-2914-2291-7C22-BBE6D77043F7"/>
    <class name="edm::Wrapper<edm::SortedCollection<EcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi> > > " splitLevel="0" id="D932A444-CBDD-A27C-4D85-BFED25EFBCF8"/>

--- a/DataFormats/EcalRawData/src/classes_def.xml
+++ b/DataFormats/EcalRawData/src/classes_def.xml
@@ -7,6 +7,7 @@
    </class>
    <class name="std::vector<EcalDCCHeaderBlock>"/>
    <class name="edm::SortedCollection<EcalDCCHeaderBlock,edm::StrictWeakOrdering<EcalDCCHeaderBlock> >"/>
+   <class name="edm::StrictWeakOrdering<EcalDCCHeaderBlock>" /> <!-- Root6 -->
    <class name="edm::Wrapper<edm::SortedCollection<EcalDCCHeaderBlock,edm::StrictWeakOrdering<EcalDCCHeaderBlock> > >" id="679B9EAA-1B71-051A-FFD7-79D324E1AAC3"/>
    <class name="EcalListOfFEDS" ClassVersion="10">
     <version ClassVersion="10" checksum="1070537451"/>
@@ -25,12 +26,14 @@
    </class>
    <class name="std::vector<ESDCCHeaderBlock>"/>
    <class name="edm::SortedCollection<ESDCCHeaderBlock,edm::StrictWeakOrdering<ESDCCHeaderBlock> >"/>
+   <class name="edm::StrictWeakOrdering<ESDCCHeaderBlock>" /> <!-- Root6 -->
    <class name="edm::Wrapper<edm::SortedCollection<ESDCCHeaderBlock,edm::StrictWeakOrdering<ESDCCHeaderBlock> > >" />
    <class name="ESKCHIPBlock" ClassVersion="10">
     <version ClassVersion="10" checksum="3879602689"/>
    </class>
    <class name="std::vector<ESKCHIPBlock>"/>
    <class name="edm::SortedCollection<ESKCHIPBlock,edm::StrictWeakOrdering<ESKCHIPBlock> >"/>
+   <class name="edm::StrictWeakOrdering<ESKCHIPBlock>" /> <!-- Root6 -->
    <class name="edm::Wrapper<edm::SortedCollection<ESKCHIPBlock,edm::StrictWeakOrdering<ESKCHIPBlock> > >" />
 
 </lcgdict>

--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -6,6 +6,8 @@
   <class name="std::vector<TrackingVertex>::iterator" />
   <class name="std::vector<TrackingVertex>::const_iterator" />
   <class name="edm::Wrapper<std::vector<TrackingVertex> >" />
+  <class name="TrackingVertexRef" />
+  <class name="TrackingVertexRefVector" />
   <class pattern="edm::Ref<std::vector<TrackingVertex>,*>" />
   <class pattern="edm::RefVector<std::vector<TrackingVertex>,*>" />
   <class name="edm::RefProd<std::vector<TrackingVertex> >" />
@@ -19,6 +21,8 @@
   <class pattern="edm::Ref<std::vector<TrackingParticle>,*>" />
   <class pattern="edm::RefVector<std::vector<TrackingParticle>,*>" />
   <class name="edm::RefProd<std::vector<TrackingParticle> >" />
+  <class name="TrackingParticleRef" />
+  <class name="TrackingParticleRefVector" />
 
   <class pattern="edm::Ref< std::vector<HepMC::GenVertex>,*>" />
   <class pattern="edm::RefVector< std::vector<HepMC::GenVertex>,*>" />


### PR DESCRIPTION
This PR ports back simple changes made in CMSSW_7_4_ROOT6_X in the Sim L2 category that are desirable or harmless for CMSSW_7_4_X, in order to increase code commonality. All affected files will be identical in the two releases after this PR is merged. Changes were successfully tested with the short relval matrix.
The changes are additional dictionaries that were needed for ROOT6.
