### PR TITLE
Port back from ROOT6 IB for commonality (L1)

### DIFF
--- a/CondFormats/L1TObjects/src/classes_def.xml
+++ b/CondFormats/L1TObjects/src/classes_def.xml
@@ -166,6 +166,8 @@
   <class name="std::map<int, std::vector<L1GtObject> >"/>  
   <class name="std::map<int, std::vector<L1GtObject> >::value_type"/>  
   <class name="L1GtCondition"/>
+  <enum name="L1GtConditionCategory"/>
+  <enum name="L1GtConditionType"/>
   <class name="L1GtMuonTemplate"/>
   <class name="L1GtMuonTemplate::ObjectParameter"/>
   <class name="std::vector<L1GtMuonTemplate::ObjectParameter>"/>
@@ -237,4 +239,6 @@
   <class name="L1CaloGeometry" class_version="L1CaloGeometry_V01">
     <field name="m_gctEtaBinBoundaries" mapping="blob" />
   </class>
+  <enum name="L1GtBoard" />
+  <enum name="L1GtPsbQuad" />
 </lcgdict>

--- a/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
+++ b/DataFormats/L1GlobalMuonTrigger/BuildFile.xml
@@ -1,7 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="FWCore/MessageLogger"/>
 
-<use   name="tbb"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.cc
+++ b/L1Trigger/GlobalTrigger/plugins/CompareToObjectMapRecord.cc
@@ -16,6 +16,7 @@
 #include "CompareToObjectMapRecord.h"
 
 #include <algorithm>
+#include <iostream>
 #include <string>
 #include <vector>
 


### PR DESCRIPTION
This PR ports back simple changes made in CMSSW_7_4_ROOT6_X in the L1 L2 category that are desirable or harmless for CMSSW_7_4_X, in order to increase code commonality. All affected files will be identical in the two releases after this PR is merged. Changes were successfully tested with the short relval matrix.
The changes are:
1)enum declarations needed for ROOT6.
2) removal of an unneeded link dependency
3) Addition of a missing include
