### PR TITLE
Make constexpr methods also const in VecArray

### DIFF
--- a/FWCore/Utilities/interface/VecArray.h
+++ b/FWCore/Utilities/interface/VecArray.h
@@ -66,8 +66,8 @@ namespace edm {
     const_iterator end() const noexcept { return begin()+size_; }
     const_iterator cend() const noexcept { return cbegin()+size_; }
 
-    constexpr bool empty() noexcept { return size_ == 0; }
-    constexpr size_type size() noexcept { return size_; }
+    constexpr bool empty() const noexcept { return size_ == 0; }
+    constexpr size_type size() const noexcept { return size_; }
     static constexpr size_type capacity() noexcept { return N; }
 
     void clear() {


### PR DESCRIPTION
Should fix the compilation failure with clang in #8353.
