### PR TITLE
HCAL Cosmics reco configuration update

### DIFF
--- a/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
+++ b/RecoLocalCalo/Configuration/python/RecoLocalCalo_Cosmics_cff.py
@@ -22,16 +22,17 @@ from RecoLocalCalo.Configuration.hcalLocalReco_cff import *
 # sequence CaloLocalReco and CaloGlobalReco
 #
 calolocalreco = cms.Sequence(ecalLocalRecoSequence+hcalLocalRecoSequence)
-hbheprereco.firstSample = 1
-hbheprereco.samplesToAdd = 8
+hbheprereco.puCorrMethod = 0 
+hbheprereco.firstSample = 0
+hbheprereco.samplesToAdd = 10
 hbheprereco.correctForTimeslew = False
 hbheprereco.correctForPhaseContainment = False
-horeco.firstSample = 1
-horeco.samplesToAdd = 8
+horeco.firstSample = 0
+horeco.samplesToAdd = 10
 horeco.correctForTimeslew = False
 horeco.correctForPhaseContainment = False
-hfreco.firstSample = 1
-hfreco.samplesToAdd = 4
+hfreco.firstSample = 0
+hfreco.samplesToAdd = 10 ### min(10,size) in the algo
 hfreco.correctForTimeslew = False
 hfreco.correctForPhaseContainment = False
 #--- special temporary DB-usage unsetting 


### PR DESCRIPTION
This is to replace the default Method 2 (which may not work for out-of-time signals)  with "classical" Method 0, for which the range of TS used is maximally expanded. 
For CRAFT and Splashes data in particular, and for Cosmics data in general.
