### PR TITLE
Fix puppi event content and JEC

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -146,6 +146,7 @@ def miniAOD_customizeCommon(process):
     # Adding puppi jets
     process.load('CommonTools.PileupAlgos.Puppi_cff')
     process.load('RecoJets.JetProducers.ak4PFJetsPuppi_cfi')
+    process.ak4PFJetsPuppi.doAreaFastjet = True # even for standard ak4PFJets this is overwritten in RecoJets/Configuration/python/RecoPFJets_cff
     #process.puppi.candName = cms.InputTag('packedPFCandidates')
     #process.puppi.vertexName = cms.InputTag('offlineSlimmedPrimaryVertices')
     
@@ -161,7 +162,7 @@ def miniAOD_customizeCommon(process):
     )
 
     addJetCollection(process, postfix   = "", labelName = 'Puppi', jetSource = cms.InputTag('ak4PFJetsPuppi'),
-                    jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''),
+                    jetCorrections = ('AK4PFchs', ['L2Relative', 'L3Absolute'], ''),
                     algo= 'AK', rParam = 0.4, btagDiscriminators = map(lambda x: x.value() ,process.patJets.discriminatorSources)
                     )
     

--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -26,6 +26,7 @@ MicroEventContent = cms.PSet(
         'keep *_slimmedTaus*_*_*',
         'keep *_slimmedJets_*_*',
         'keep *_slimmedJetsAK8_*_*',
+        'keep *_slimmedJetsPuppi_*_*',
         'keep *_slimmedMETs*_*_*',
         'keep *_slimmedSecondaryVertices*_*_*',
         'keep *_cmsTopTaggerMap_*_*',


### PR DESCRIPTION
- Keep puppi jets (by mistake they were dropped, because of a conflict between the subjet PR and puppi PR)
- Use AK4PFchs L2+L3 corrections on puppi jets (no L1, since existing L1 corrections for PF or PFchs are not appropriate for puppi)
- Properly compute jet area for puppi jets (allow application of L1 corrections in the future when they will be available for these jets)

@arizzi @jshlee @violatingcp
