### PR TITLE
fix usage of SeedFromConsecutiveHitsCreator w/in SeedGeneratorFromProtoTracksEDProducer

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h
@@ -41,18 +41,6 @@ public:
       }
     }
 
-  SeedFromConsecutiveHitsCreator(
-      const std::string & propagator = "PropagatorWithMaterial", double seedMomentumForBOFF = -5.0,
-      double aOriginTransverseErrorMultiplier = 1.0, double aMinOneOverPtError = 1.0, const std::string & bname="WithTrackAngle")
-      : thePropagatorLabel(propagator)
-      , theBOFFMomentum(seedMomentumForBOFF)
-      , theOriginTransverseErrorMultiplier(aOriginTransverseErrorMultiplier)
-      , theMinOneOverPtError(aMinOneOverPtError)
-      , TTRHBuilder(bname)
-      , useSimpleMF_(false)
-      , forceKinematicWithRegionDirection_(false)
-  { }
-
   //dtor
   virtual ~SeedFromConsecutiveHitsCreator();
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -43,6 +43,18 @@ void SeedGeneratorFromProtoTracksEDProducer::fillDescriptions(edm::Configuration
   desc.add<bool>("useEventsWithNoVertex", true);
   desc.add<std::string>("TTRHBuilder", "TTRHBuilderWithoutAngle4PixelTriplets");
   desc.add<bool>("usePV", false);
+
+  edm::ParameterSetDescription psd0;
+  psd0.add<std::string>("ComponentName",std::string("SeedFromConsecutiveHitsCreator"));
+  psd0.add<std::string>("propagator",std::string("PropagatorWithMaterial"));
+  psd0.add<double>("SeedMomentumForBOFF",5.0);
+  psd0.add<double>("OriginTransverseErrorMultiplier",1.0);
+  psd0.add<double>("MinOneOverPtError",1.0);
+  psd0.add<std::string>("magneticField",std::string(""));
+  psd0.add<std::string>("TTRHBuilder",std::string("WithTrackAngle"));
+  psd0.add<bool>("forceKinematicWithRegionDirection",false);
+  desc.add<edm::ParameterSetDescription>("SeedCreatorPSet",psd0);
+  
   descriptions.add("SeedGeneratorFromProtoTracksEDProducer", desc);
 }
 
@@ -127,7 +139,9 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
       if (hits.size() > 1) {
         double mom_perp = sqrt(proto.momentum().x()*proto.momentum().x()+proto.momentum().y()*proto.momentum().y());
 	GlobalTrackingRegion region(mom_perp, vtx, 0.2, 0.2);
-	SeedFromConsecutiveHitsCreator seedCreator;
+
+	edm::ParameterSet seedCreatorPSet = theConfig.getParameter<edm::ParameterSet>("SeedCreatorPSet");
+	SeedFromConsecutiveHitsCreator seedCreator(seedCreatorPSet);
 	seedCreator.init(region, es, 0);
 	seedCreator.makeSeed(*result, SeedingHitSet(hits[0], hits[1], hits.size() >2 ? hits[2] : SeedingHitSet::nullPtr() ));
       }


### PR DESCRIPTION
while integrating PR 7781
and after having fixed the muon and electron code [see PR https://github.com/cms-sw/cmssw/pull/8367]
I found there was still an issue w/ the HLT config

it turned out that it was due to the --wrongly-- usage of the default constructor
https://github.com/mtosi/cmssw/blob/CMSSW_7_0_X/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc#L101

this PR is meant to fix this issue
I'm going to do the same PR in 75X as well
