### PR TITLE
ROOT6 checksums needed in ROOT5

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -195,6 +195,7 @@
   </ioread>
 
   <class name="pat::Jet"  ClassVersion="15">
+   <version ClassVersion="16" checksum="4069285947"/>
    <version ClassVersion="15" checksum="727883729"/>
    <version ClassVersion="14" checksum="1304049301"/>
    <version ClassVersion="13" checksum="130552029"/>
@@ -265,6 +266,7 @@
   </class>
 
   <class name="pat::PackedCandidate" ClassVersion="17">
+    <version ClassVersion="18" checksum="4275117305"/>
     <version ClassVersion="17" checksum="1257500115"/>
     <version ClassVersion="16" checksum="3261782486"/>
     <version ClassVersion="15" checksum="2118306102"/>


### PR DESCRIPTION
To help prevent version number clashes, ROOT6 checksums are needed in ROOT5 IBs. This PR adds two new ROOT6 checksums. The checksums used in this release are unchanged, so functionally this PR is a no-op.  Purely technical. Please bypass L2 signature if not signed in a timely manner.
