### PR TITLE
 Fix pileup jet id bug (resurrect #7827 ; equiv backport of #7834)

### DIFF
--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -29,6 +29,7 @@ PileupJetIdAlgo::PileupJetIdAlgo(const edm::ParameterSet & ps)
 	    tmvaSpectators_      = ps.getParameter<std::vector<std::string> >("tmvaSpectators");
 	    version_             = ps.getParameter<int>("version");
 	  }
+        else version_ = USER;
 	reader_              = 0;
 	edm::ParameterSet jetConfig = ps.getParameter<edm::ParameterSet>("JetIdParams");
 	for(int i0 = 0; i0 < 3; i0++) { 


### PR DESCRIPTION
(valgrind error fix)
There was an uninitialized variable in case "cutbased" was used.

same as  #7834 or earlier closed #7827 
