### PR TITLE
Port back from ROOT6 IB for commonality (DB/ALCA)

### DIFF
--- a/CondFormats/Common/interface/IOVSequence.h
+++ b/CondFormats/Common/interface/IOVSequence.h
@@ -27,7 +27,7 @@ namespace cond {
     typedef ora::QueryableVector<Item> Container;
     typedef Container::iterator iterator;
     typedef Container::const_iterator const_iterator;
-    typedef enum { Unknown=-1, Obsolete, Tag, TagInGT, ChildTag, ChildTagInGT } ScopeType;
+    enum ScopeType { Unknown=-1, Obsolete, Tag, TagInGT, ChildTag, ChildTagInGT };
 
     IOVSequence();
 

--- a/CondFormats/Common/src/classes_def.xml
+++ b/CondFormats/Common/src/classes_def.xml
@@ -14,6 +14,9 @@
   <field name="m_scope" persistency="loose_on_reading" />
  </class>
 
+ <typedef name="ora::QueryableVector<cond::IOVElement>::store_base_type" />
+ <typedef name="ora::PVector<cond::IOVElement>::value_type" />
+ <enum name="cond::IOVSequence::ScopeType" />
 
  <class name="cond::IOVProvenance"/>
  <class name="cond::IOVDescription"/>

--- a/CondFormats/DTObjects/BuildFile.xml
+++ b/CondFormats/DTObjects/BuildFile.xml
@@ -7,7 +7,6 @@
 <use   name="boost_serialization"/>
 <use   name="roothistmatrix"/>
 
-<use   name="root"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/CondFormats/EcalObjects/src/classes_def.xml
+++ b/CondFormats/EcalObjects/src/classes_def.xml
@@ -2,6 +2,8 @@
 
 <!-- base class -->
 <class name="EcalChannelStatusCode"/>
+<enum name="EcalChannelStatusCode::Code"/>
+<enum name="EcalChannelStatusCode::Bits"/>
 <!-- templates for EcalCondObjectContainer having the class as template parameter -->
 <class name="std::vector<EcalChannelStatusCode>"/>
 <class name="EcalContainer<EEDetId,EcalChannelStatusCode>"/>

--- a/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
+++ b/CondFormats/PhysicsToolsObjects/src/MVAComputer.cc
@@ -9,7 +9,7 @@
 //     the discriminator computer calibration object. POOL doesn't support
 //     polymorph pointers, so this is implemented using multiple containers
 //     for each possible sub-class and an index array from which the
-//     array of pointers can be reconstructed. 
+//     array of pointers can be reconstructed.
 //
 // Author:      Christophe Saout
 // Created:     Sat Apr 24 15:18 CEST 2007
@@ -22,8 +22,6 @@
 #include <cstddef>
 
 #include <atomic>
-
-#include <Reflex/Reflex.h>
 
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/TypeID.h"
@@ -182,10 +180,10 @@ std::vector<VarProcessor*> MVAComputer::getProcessors() const
 	return processors;
 }
 
-void MVAComputer::addProcessor(const VarProcessor *proc)
+void MVAComputer::addProcessor(const VarProcessor* proc)
 {
-	cacheId = getNextMVAComputerCacheId();
-        processors.push_back(proc->clone().release());
+  cacheId = getNextMVAComputerCacheId();
+  processors.push_back(proc->clone().release());
 }
 
 static MVAComputerContainer::CacheId getNextMVAComputerContainerCacheId()


### PR DESCRIPTION
This PR ports back simple changes made in CMSSW_7_4_ROOT6_X in the DB and ALCA L2 categories that are desirable or harmless for CMSSW_7_4_X, in order to increase code commonality. All affected files will be identical in the two releases after this PR is merged. Changes were successfully tested with the short relval matrix.
The changes are:
1) removal of unnecessary typedef keyword
2) addition of enum specifications in XML spec files (needed for ROOT6)
3) addition of typedef specifications in XML files (needed for ROOT6)
4) removal of unneeded link dependency
5) removal of unneeded header include
6) modifications to white space (mostly incidental)
