### PR TITLE
fix tau charged fraction access and JEC L1 corrections in the mva met code

### DIFF
--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -315,20 +315,20 @@ double PFMETProducerMVA::chargedEnFrac(const reco::Candidate *iCand,
   const reco::PFTau *lPFTau = 0; 
   lPFTau = dynamic_cast<const reco::PFTau*>(iCand);
   if(lPFTau != nullptr) { 
-    for (UInt_t i0 = 0; i0 < lPFTau->signalPFCands().size(); i0++) { 
-      lPtTot += (lPFTau->signalPFCands())[i0]->pt(); 
-      if((lPFTau->signalPFCands())[i0]->charge() == 0) continue;
-      lPtCharged += (lPFTau->signalPFCands())[i0]->pt(); 
+    for (UInt_t i0 = 0; i0 < lPFTau->signalCands().size(); i0++) { 
+      lPtTot += (lPFTau->signalCands())[i0]->pt(); 
+      if((lPFTau->signalCands())[i0]->charge() == 0) continue;
+      lPtCharged += (lPFTau->signalCands())[i0]->pt(); 
     }
   } 
   else { 
     const pat::Tau *lPatPFTau = nullptr; 
     lPatPFTau = dynamic_cast<const pat::Tau*>(iCand);
     if(lPatPFTau != nullptr) { 
-      for (UInt_t i0 = 0; i0 < lPatPFTau->signalPFCands().size(); i0++) { 
-	lPtTot += (lPatPFTau->signalPFCands())[i0]->pt(); 
-	if((lPatPFTau->signalPFCands())[i0]->charge() == 0) continue;
-	lPtCharged += (lPatPFTau->signalPFCands())[i0]->pt(); 
+      for (UInt_t i0 = 0; i0 < lPatPFTau->signalCands().size(); i0++) { 
+	lPtTot += (lPatPFTau->signalCands())[i0]->pt(); 
+	if((lPatPFTau->signalCands())[i0]->charge() == 0) continue;
+	lPtCharged += (lPatPFTau->signalCands())[i0]->pt(); 
       }
     }
   }

--- a/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
+++ b/RecoMET/METPUSubtraction/plugins/PFMETProducerMVA.cc
@@ -315,10 +315,10 @@ double PFMETProducerMVA::chargedEnFrac(const reco::Candidate *iCand,
   const reco::PFTau *lPFTau = 0; 
   lPFTau = dynamic_cast<const reco::PFTau*>(iCand);
   if(lPFTau != nullptr) { 
-    for (UInt_t i0 = 0; i0 < lPFTau->signalCands().size(); i0++) { 
-      lPtTot += (lPFTau->signalCands())[i0]->pt(); 
-      if((lPFTau->signalCands())[i0]->charge() == 0) continue;
-      lPtCharged += (lPFTau->signalCands())[i0]->pt(); 
+    for (UInt_t i0 = 0; i0 < lPFTau->signalPFCands().size(); i0++) { 
+      lPtTot += (lPFTau->signalPFCands())[i0]->pt(); 
+      if((lPFTau->signalPFCands())[i0]->charge() == 0) continue;
+      lPtCharged += (lPFTau->signalPFCands())[i0]->pt(); 
     }
   } 
   else { 

--- a/RecoMET/METPUSubtraction/test/mvaMETOnMiniAOD_cfg.py
+++ b/RecoMET/METPUSubtraction/test/mvaMETOnMiniAOD_cfg.py
@@ -58,6 +58,7 @@ process.MINIAODSIMoutput = cms.OutputModule("PoolOutputModule",
 
 process.load("RecoJets.JetProducers.ak4PFJets_cfi")
 process.ak4PFJets.src = cms.InputTag("packedPFCandidates")
+process.ak4PFJets.doAreaFastjet = cms.bool(True)
 
 from JetMETCorrections.Configuration.DefaultJEC_cff import ak4PFJetsL1FastL2L3
 


### PR DESCRIPTION
Fix the access to the candidate forming a pat::Tau, which was giving unphysical tau charged fraction.
Force also the L1 jet computation in the mvaMET, to be sure the user is not dependent of any change in the ak4PFJet producer options.

Packaged touched : RecoMET/METPUSubtraction

N.B : PR does not affect any standard sequence and is fully transparent for the tests. It just allows the analyzers to not need any extra merge-topic.
