### PR TITLE
Update of MET significance tuning for Phys14 samples

### DIFF
--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -41,10 +41,7 @@ namespace metsig {
      double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met ) const;
 
       private:
-         std::vector<reco::Jet> cleanJets(const edm::View<reco::Jet>& jets, 
-					  const std::vector< edm::Handle<reco::CandidateView> >& leptons);
          bool cleanJet(const reco::Jet& jet, 
-		   //const std::vector<reco::Candidate::LorentzVector>& leptons);
          const std::vector< edm::Handle<reco::CandidateView> >& leptons );
 
          double jetThreshold_;

--- a/RecoMET/METAlgorithms/interface/METSignificance.h
+++ b/RecoMET/METAlgorithms/interface/METSignificance.h
@@ -36,15 +36,16 @@ namespace metsig {
          ~METSignificance();
 
          reco::METCovMatrix getCovariance(const edm::View<reco::Jet>& jets,
-					  const std::vector<reco::Candidate::LorentzVector>& leptons,
+					  const std::vector< edm::Handle<reco::CandidateView> >& leptons,
 					  const edm::View<reco::Candidate>& pfCandidates);
      double getSignificance(const reco::METCovMatrix& cov, const reco::MET& met ) const;
 
       private:
          std::vector<reco::Jet> cleanJets(const edm::View<reco::Jet>& jets, 
-					  const std::vector<reco::Candidate::LorentzVector>& leptons);
+					  const std::vector< edm::Handle<reco::CandidateView> >& leptons);
          bool cleanJet(const reco::Jet& jet, 
-		   const std::vector<reco::Candidate::LorentzVector>& leptons);
+		   //const std::vector<reco::Candidate::LorentzVector>& leptons);
+         const std::vector< edm::Handle<reco::CandidateView> >& leptons );
 
          double jetThreshold_;
          double dR2match_;

--- a/RecoMET/METAlgorithms/src/METSignificance.cc
+++ b/RecoMET/METAlgorithms/src/METSignificance.cc
@@ -61,12 +61,10 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
    // for lepton and jet subtraction
    std::vector<reco::CandidatePtr> footprint;
 
-   std::cout << "Leptons: ";
    // subtract leptons out of sumPt
    for ( std::vector< edm::Handle<reco::CandidateView> >::const_iterator lep_i = leptons.begin();
          lep_i != leptons.end(); ++lep_i ) {
       for( reco::CandidateView::const_iterator lep = (*lep_i)->begin(); lep != (*lep_i)->end(); lep++ ){
-         std::cout << lep->pt() << " ";
          if( lep->pt() > 10 ){
             for( unsigned int n=0; n < lep->numberOfSourceCandidatePtrs(); n++ ){
                if( lep->sourceCandidatePtr(n).isNonnull() and lep->sourceCandidatePtr(n).isAvailable() ){
@@ -76,7 +74,6 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
          }
       }
    }
-   std::cout << std::endl;
    // subtract jets out of sumPt
    for(edm::View<reco::Jet>::const_iterator jet = jets.begin(); jet != jets.end(); ++jet) {
 
@@ -97,25 +94,19 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
          cand != pfCandidates.end(); ++cand){
 
       // check if candidate exists in a lepton or jet
-      //unsigned int iter = cand - pfCandidates.begin();
-      //if (std::find(footprint.begin(), footprint.end(),
-      //         reco::CandidatePtr(&pfCandidates,iter)) != footprint.end()) {
-      //   continue;
-      //}
       bool cleancand = true;
       for(unsigned int i=0; i < footprint.size(); i++){
          if( footprint[i]->p4() == cand->p4() ){
             cleancand = false;
          }
       }
-
+      // if not, add to sumPt
       if( cleancand ){
          sumPt += cand->pt();
       }
 
    }
 
-   std::cout << "Jets: ";
    // add jets to metsig covariance matrix and subtract them from sumPt
    for(edm::View<reco::Jet>::const_iterator jet = jets.begin(); jet != jets.end(); ++jet) {
      
@@ -127,7 +118,6 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
       double feta = std::abs(jeta);
       double c = jet->px()/jet->pt();
       double s = jet->py()/jet->pt();
-     std::cout << jpt << " ";
 
       // jet energy resolutions
       double jeta_res = (std::abs(jeta) < 9.9) ? jeta : 9.89; // JetResolutions defined for |eta|<9.9
@@ -152,26 +142,15 @@ metsig::METSignificance::getCovariance(const edm::View<reco::Jet>& jets,
          cov_xy += (dpt*dpt-dph*dph)*c*s;
          cov_yy += dph*dph*c*c + dpt*dpt*s*s;
 
-         // subtract the pf constituents in each jet out of the sumPt
-         //for(unsigned int i=0; i < jet->numberOfDaughters(); i++){
-         //   sumPt -= jet->daughter(i)->pt();
-         //}
-
       } else {
 
-         // subtract the pf constituents in each jet out of the sumPt
-         for(unsigned int i=0; i < jet->numberOfDaughters(); i++){
-            //sumPt -= jet->daughter(i)->pt();
-         }
          // add the (corrected) jet to the sumPt
          sumPt += jpt;
 
       }
 
    }
-   std::cout << std::endl;
 
-   std::cout << "sumPt: " << sumPt << std::endl;
 
    //protection against unphysical events
    if(sumPt<0) sumPt=0;
@@ -209,8 +188,6 @@ metsig::METSignificance::getSignificance(const reco::METCovMatrix& cov, const re
 bool
 metsig::METSignificance::cleanJet(const reco::Jet& jet, 
       const std::vector< edm::Handle<reco::CandidateView> >& leptons ){
-  
-  if ( jet.pt() < jetThreshold_ ) return false;
 
   for ( std::vector< edm::Handle<reco::CandidateView> >::const_iterator lep_i = leptons.begin();
         lep_i != leptons.end(); ++lep_i ) {
@@ -218,7 +195,7 @@ metsig::METSignificance::cleanJet(const reco::Jet& jet,
         if ( reco::deltaR2(*lep, jet) < dR2match_ ) {
            return false;
         }
-    }
+     }
   }
   return true;
 }

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -14,7 +14,7 @@ METSignificanceParams = cms.PSet(
       jeta = cms.vdouble(0.5, 1.1, 1.7, 2.3),
 
       # tuning parameters
-      jpar = cms.vdouble(1.15061, 1.07776, 1.04204, 1.12509, 1.56414),
-      pjpar = cms.vdouble(0.0, 0.548758)
+      jpar = cms.vdouble(1.42,1.29,1.41,1.40,2.52),
+      pjpar = cms.vdouble(0.0,0.673)
 
       )

--- a/RecoMET/METProducers/python/METSignificanceParams_cfi.py
+++ b/RecoMET/METProducers/python/METSignificanceParams_cfi.py
@@ -14,7 +14,7 @@ METSignificanceParams = cms.PSet(
       jeta = cms.vdouble(0.5, 1.1, 1.7, 2.3),
 
       # tuning parameters
-      jpar = cms.vdouble(1.42,1.29,1.41,1.40,2.52),
-      pjpar = cms.vdouble(0.0,0.673)
+      jpar = cms.vdouble(1.41,1.29,1.41,1.40,2.53),
+      pjpar = cms.vdouble(0.0,0.674)
 
       )

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -53,7 +53,6 @@ namespace cms
     //
     // leptons
     //
-   //std::vector<reco::Candidate::LorentzVector> leptons;
    std::vector< edm::Handle<reco::CandidateView> > leptons;
    for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
          srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
@@ -61,10 +60,7 @@ namespace cms
       edm::Handle<reco::CandidateView> leptons_i;
       event.getByToken(*srcLeptons_i, leptons_i);
       leptons.push_back( leptons_i );
-      for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
-            lepton != leptons_i->end(); ++lepton ) {
-         //leptons.push_back(lepton->p4());
-      }
+
    }
 
    //

--- a/RecoMET/METProducers/src/METSignificanceProducer.cc
+++ b/RecoMET/METProducers/src/METSignificanceProducer.cc
@@ -53,15 +53,17 @@ namespace cms
     //
     // leptons
     //
-   std::vector<reco::Candidate::LorentzVector> leptons;
+   //std::vector<reco::Candidate::LorentzVector> leptons;
+   std::vector< edm::Handle<reco::CandidateView> > leptons;
    for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
          srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
 
-     edm::Handle<reco::CandidateView> leptons_i;
+      edm::Handle<reco::CandidateView> leptons_i;
       event.getByToken(*srcLeptons_i, leptons_i);
+      leptons.push_back( leptons_i );
       for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
             lepton != leptons_i->end(); ++lepton ) {
-         leptons.push_back(lepton->p4());
+         //leptons.push_back(lepton->p4());
       }
    }
 
@@ -87,7 +89,7 @@ namespace cms
 
    event.put( covPtr, "METCovariance" );
    event.put( significance, "METSignificance" );
- 
+
   }
 
 //____________________________________________________________________________||

--- a/RecoMET/METProducers/src/PFMETProducer.cc
+++ b/RecoMET/METProducers/src/PFMETProducer.cc
@@ -70,15 +70,18 @@ namespace cms
   reco::METCovMatrix PFMETProducer::getMETCovMatrix(const edm::Event& event, const edm::View<reco::Candidate>& candInput) const {
 
 	// leptons
-	std::vector<reco::Candidate::LorentzVector> leptons;
+	std::vector< edm::Handle<reco::CandidateView> > leptons;
 	for ( std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > >::const_iterator srcLeptons_i = lepTokens_.begin();
 	      srcLeptons_i != lepTokens_.end(); ++srcLeptons_i ) {
 	  edm::Handle<reco::CandidateView> leptons_i;
 	  event.getByToken(*srcLeptons_i, leptons_i);
+     leptons.push_back( leptons_i );
+     /*
 	  for ( reco::CandidateView::const_iterator lepton = leptons_i->begin();
 		lepton != leptons_i->end(); ++lepton ) {
-	    leptons.push_back(lepton->p4());
+	    leptons.push_back(*lepton);
 	  }
+     */
 	}
 
 	// jets

--- a/RecoMET/METProducers/test/recoMET_METSignificance_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_METSignificance_cfg.py
@@ -16,7 +16,8 @@ process.source = cms.Source(
     "PoolSource",
     fileNames = cms.untracked.vstring(
        ### MINIAODSIM
-       '/store/relval/CMSSW_7_3_0_pre1/RelValTTbar_13/MINIAODSIM/PU25ns_PRE_LS172_V15-v1/00000//A652D13A-335F-E411-90BA-02163E008D01.root'
+        '/store/relval/CMSSW_7_3_0/RelValZMM_13/MINIAODSIM/MCRUN2_73_V7-v1/00000/127CA68E-8981-E411-A524-002590593872.root',
+        '/store/relval/CMSSW_7_3_0/RelValZMM_13/MINIAODSIM/MCRUN2_73_V7-v1/00000/56FE228D-8981-E411-9AD8-0025905A6126.root'
        )
     )
 
@@ -34,7 +35,7 @@ process.out = cms.OutputModule(
 ##____________________________________________________________________________||
 process.options   = cms.untracked.PSet(wantSummary = cms.untracked.bool(True))
 process.MessageLogger.cerr.FwkReport.reportEvery = 50
-process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(-1))
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(100))
 
 ##____________________________________________________________________________||
 process.p = cms.Path(


### PR DESCRIPTION
late update for the MET significance tuning.
Input parameters are computed on Phys14 samples, and the sumpt is now corrected from jet constituents and leptons.

Package involved : 
RecoMET/METAlgorithms
RecoMET/METProducers

PR is transparent for reco sequence and tests, as the MET significance is not computed per default.
The PFMETProducer is modified just to take into account the proper change of lepton format in the METSignificance algorithm. 
