### PR TITLE
MiniAOD met fixes

### DIFF
--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -93,36 +93,81 @@ float MET::uncorrectedSumEt() const {
 
 
 MET::Vector2 MET::shiftedP2(MET::METUncertainty shift, MET::METUncertaintyLevel level)  const {
+    if (level != Type1 && level != Type1p2 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw, Type1 and Type1p2\n");
     const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : (level == Type1p2 ? uncertaintiesType1p2_ : uncertaintiesRaw_));
     if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type");
+    if (v.size() == 1) {
+        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)");
+        return Vector2{ (px() + v.front().dpx()), (py() + v.front().dpy()) };
+    }
     Vector2 ret{ (px() + v[shift].dpx()), (py() + v[shift].dpy()) };
     return ret;
 }
 MET::Vector MET::shiftedP3(MET::METUncertainty shift, MET::METUncertaintyLevel level)  const {
+    if (level != Type1 && level != Type1p2 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw, Type1 and Type1p2\n");
     const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : (level == Type1p2 ? uncertaintiesType1p2_ : uncertaintiesRaw_));
     if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type");
+    if (v.size() == 1) {
+        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)");
+        return Vector(px() + v.front().dpx(), py() + v.front().dpy(), 0);
+    }
     return Vector(px() + v[shift].dpx(), py() + v[shift].dpy(), 0);
 }
 MET::LorentzVector MET::shiftedP4(METUncertainty shift, MET::METUncertaintyLevel level)  const {
+    if (level != Type1 && level != Type1p2 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw, Type1 and Type1p2\n");
     const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : (level == Type1p2 ? uncertaintiesType1p2_ : uncertaintiesRaw_));
     if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type");
+    if (v.size() == 1) {
+        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)");
+        double x = px() + v.front().dpx(), y = py() + v.front().dpy();
+        return LorentzVector(x, y, 0, std::hypot(x,y));
+    }
     double x = px() + v[shift].dpx(), y = py() + v[shift].dpy();
     return LorentzVector(x, y, 0, std::hypot(x,y));
 }
 double MET::shiftedSumEt(MET::METUncertainty shift, MET::METUncertaintyLevel level) const {
+    if (level != Type1 && level != Type1p2 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw, Type1 and Type1p2\n");
     const std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : (level == Type1p2 ? uncertaintiesType1p2_ : uncertaintiesRaw_));
     if (v.empty()) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type");
+    if (v.size() == 1) {
+        if (shift != MET::METUncertainty::NoShift) throw cms::Exception("Unsupported", "MET uncertainties not available for the specified correction type (only central value available)");
+        return sumEt() + v.front().dsumEt();
+    }
     return sumEt() + v[shift].dsumEt();
 }
+
 void MET::setShift(double px, double py, double sumEt, MET::METUncertainty shift, MET::METUncertaintyLevel level) {
-  if(level != Calo ) {
+  if( level != Calo ) {
+    if (level != Type1 && level != Type1p2 && level != Raw) throw cms::Exception("Unsupported", "MET uncertainties only supported for Raw, Type1 and Type1p2\n");
     std::vector<PackedMETUncertainty> &v = (level == Type1 ? uncertaintiesType1_ : (level == Type1p2 ? uncertaintiesType1p2_ : uncertaintiesRaw_));
-    if (v.empty()) v.resize(METUncertaintySize);
-    v[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
+    if (shift == MET::METUncertainty::NoShift) {
+        if (v.empty()) { // fresh MET: make size 1, add this
+            v.resize(1);
+            v.back().set(px - this->px(), py - this->py(), sumEt - this->sumEt());
+        } else if (v.size() == 1) {  // only unshifted, and I'm updating it
+            v.back().set(px - this->px(), py - this->py(), sumEt - this->sumEt());
+        } else if (v.size() != MET::METUncertainty::METUncertaintySize) { 
+            // already initialized with something I don't understand
+            throw cms::Exception("Unsupported", "setShift called after the set of uncertainties is not of a supported size (not 0, 1, or METUncertaintySize)\n");
+        } else {
+            // full set of uncertainties, and I'm updating the no-shift one
+            v[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
+        }
+    } else {
+        if (v.empty()) { // fresh MET. make room for all
+            v.resize(METUncertaintySize);
+        } else if (v.size() == 1) { // I had set only the unshifted, so I extend it copying over the existing one
+            v.resize(METUncertaintySize, v.back()); 
+        } else if (v.size() != MET::METUncertainty::METUncertaintySize) { // already initialized with something I don't understand
+            throw cms::Exception("Unsupported", "setShift called after the set of uncertainties is not of a supported size (not 0, 1, or METUncertaintySize)\n");
+        }
+        v[shift].set(px - this->px(), py - this->py(), sumEt - this->sumEt());
+    }
   } else {
     caloPackedMet_.set(px, py, sumEt);
   }
 }
+
 
 MET::Vector2 MET::caloMETP2() const {
   Vector2 ret{ caloPackedMet_.dpx(), caloPackedMet_.dpy() };

--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -85,7 +85,7 @@ float MET::uncorrectedPt() const {
   return shiftedPt(MET::METUncertainty::NoShift, MET::METUncertaintyLevel::Raw);
 }
 float MET::uncorrectedPhi() const {
-   return shiftedPt(MET::METUncertainty::NoShift, MET::METUncertaintyLevel::Raw);
+   return shiftedPhi(MET::METUncertainty::NoShift, MET::METUncertaintyLevel::Raw);
 }
 float MET::uncorrectedSumEt() const {
   return shiftedSumEt(MET::METUncertainty::NoShift, MET::METUncertaintyLevel::Raw);

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -224,9 +224,8 @@
     <field name="unpacked_" transient="true" />
 
   </class>
-  <ioread sourceClass="pat::PackedMETUncertainty"  version="[1-]" targetClass="pat::PackedMETUncertainty" source="" target="unpacked_">
-        <![CDATA[unpacked_ = false;
-            ]]>
+  <ioread sourceClass="pat::MET::PackedMETUncertainty"  version="[1-]" targetClass="pat::MET::PackedMETUncertainty" source="" target="unpacked_">
+        <![CDATA[unpacked_ = false; ]]>
   </ioread>
 
   <class name="std::vector<pat::MET::PackedMETUncertainty>" />

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -227,6 +227,7 @@
   <ioread sourceClass="pat::MET::PackedMETUncertainty"  version="[1-]" targetClass="pat::MET::PackedMETUncertainty" source="" target="unpacked_">
         <![CDATA[unpacked_ = false; ]]>
   </ioread>
+  <class name="pat::MET::Vector2"  transient="true" />
 
   <class name="std::vector<pat::MET::PackedMETUncertainty>" />
   <class name="pat::MHT"  ClassVersion="12">

--- a/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMETSlimmer.cc
@@ -55,7 +55,8 @@ void pat::PATMETSlimmer::maybeReadShifts(const edm::ParameterSet &basePSet, cons
         throw cms::Exception("Unsupported", "Reading PSets not supported, for now just use input tag");
     } else if (basePSet.existsAs<edm::InputTag>(name) ) {
         const edm::InputTag & baseTag = basePSet.getParameter<edm::InputTag>(name);
-	if( level!=pat::MET::Calo ) {
+        const std::string &encoded = baseTag.encode();
+	if( encoded.find("%s") != std::string::npos ) {
 	  shifts_.push_back(OneMETShift(pat::MET::NoShift,   level, baseTag, consumesCollector()));
 	  shifts_.push_back(OneMETShift(pat::MET::JetEnUp,   level, baseTag, consumesCollector()));
 	  shifts_.push_back(OneMETShift(pat::MET::JetEnDown, level, baseTag, consumesCollector()));

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -80,7 +80,7 @@ def miniAOD_customizeCommon(process):
     #
     # apply type I/type I + II PFMEt corrections to pat::MET object
     # and estimate systematic uncertainties on MET
-    # FIXME: this and the typeI MET should become AK4 once we have the proper JEC?
+    # FIXME: are we 100% sure this should still be PF and not PFchs? 
     from PhysicsTools.PatUtils.tools.runType1PFMEtUncertainties import runType1PFMEtUncertainties
     addJetCollection(process, postfix   = "ForMetUnc", labelName = 'AK4PF', jetSource = cms.InputTag('ak4PFJets'), jetCorrections = ('AK4PF', ['L1FastJet', 'L2Relative', 'L3Absolute'], ''))
     process.patJetsAK4PFForMetUnc.getJetMCFlavour = False
@@ -184,16 +184,27 @@ def miniAOD_customizeCommon(process):
     process.pfMetPuppi = process.pfMet.clone()
     process.pfMetPuppi.src = cms.InputTag("puppi")
     process.pfMetPuppi.alias = cms.string('pfMetPuppi')
+    ## type1 correction, from puppi jets
+    process.corrPfMetType1Puppi = process.corrPfMetType1.clone(
+        src = 'ak4PFJetsPuppi',
+        jetCorrLabel = 'ak4PFCHSL2L3Corrector',
+    )
+    del process.corrPfMetType1Puppi.offsetCorrLabel # no L1 for PUPPI jets
+    process.pfMetT1Puppi = process.pfMetT1.clone(
+        src = 'pfMetPuppi',
+        srcCorrections = [ cms.InputTag("corrPfMetType1Puppi","type1") ]
+    )
 
     from PhysicsTools.PatAlgos.tools.metTools import addMETCollection
-    addMETCollection(process, labelName='patMETPuppi', metSource='pfMetPuppi')
+    addMETCollection(process, labelName='patMETPuppi',   metSource='pfMetT1Puppi') # T1
+    addMETCollection(process, labelName='patPFMetPuppi', metSource='pfMetPuppi')   # RAW
 
     process.load('PhysicsTools.PatAlgos.slimming.slimmedMETs_cfi')
     process.slimmedMETsPuppi = process.slimmedMETs.clone()
     process.slimmedMETsPuppi.src = cms.InputTag("patMETPuppi")
-    process.slimmedMETsPuppi.rawUncertainties   = cms.InputTag("patPFMet%s")
-    process.slimmedMETsPuppi.type1Uncertainties = cms.InputTag("patPFMetT1%s")
-    process.slimmedMETsPuppi.type1p2Uncertainties = cms.InputTag("patPFMetT1T2%s")
+    process.slimmedMETsPuppi.rawUncertainties   = cms.InputTag("patPFMetPuppi") # only central value
+    process.slimmedMETsPuppi.type1Uncertainties = cms.InputTag("patPFMetT1")    # only central value for now
+    del process.slimmedMETsPuppi.type1p2Uncertainties # not available
 
 
 def miniAOD_customizeMC(process):

--- a/PhysicsTools/PatUtils/python/tools/jmeUncertaintyTools.py
+++ b/PhysicsTools/PatUtils/python/tools/jmeUncertaintyTools.py
@@ -89,6 +89,8 @@ class JetMEtUncertaintyTools(ConfigToolBase):
             finalCut = cms.string('')
         )
         numOverlapCollections = 0
+        radius = 0.5
+        if "ak4" in jetCollection.moduleLabel.lower(): radius=0.4
         for collection in [
             [ 'electrons', electronCollection ],
             [ 'photons',   photonCollection   ],
@@ -99,7 +101,7 @@ class JetMEtUncertaintyTools(ConfigToolBase):
                     src                 = collection[1],
                     algorithm           = cms.string("byDeltaR"),
                     preselection        = cms.string(""),
-                    deltaR              = cms.double(0.5),
+                    deltaR              = cms.double(radius),
                     checkRecoComponents = cms.bool(False),
                     pairCut             = cms.string(""),
                     requireNoOverlaps   = cms.bool(True),

--- a/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
@@ -26,13 +26,11 @@ def propagateMEtUncertainties(process, particleCollection, particleType,
     sequence += moduleMETcorrShiftDown
     
     # propagate effects of up/down shifts to MET
-    moduleMETshiftUp = metProducer.clone(
-        #hardcoded disabling of type2 correction not needed here
-        applyType2Corrections = cms.bool(False),
-        src = cms.InputTag(metProducer.label()),
-        srcType1Corrections = cms.VInputTag(
-            cms.InputTag(moduleMETcorrShiftUpName)
-        )
+    moduleMETshiftUp = cms.EDProducer("CorrectedPATMETProducer",
+            applyType1Corrections = cms.bool(True),
+            applyType2Corrections = cms.bool(False),
+            src = cms.InputTag(metProducer.label()),
+            srcType1Corrections = cms.VInputTag(cms.InputTag(moduleMETcorrShiftUpName))
     )
     metProducerLabel = metProducer.label()
     if postfix != "":

--- a/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
@@ -27,6 +27,8 @@ def propagateMEtUncertainties(process, particleCollection, particleType,
     
     # propagate effects of up/down shifts to MET
     moduleMETshiftUp = metProducer.clone(
+        #hardcoded disabling of type2 correction not needed here
+        applyType2Corrections = cms.bool(False),
         src = cms.InputTag(metProducer.label()),
         srcType1Corrections = cms.VInputTag(
             cms.InputTag(moduleMETcorrShiftUpName)
@@ -39,6 +41,7 @@ def propagateMEtUncertainties(process, particleCollection, particleType,
         else:
             raise StandardError("Tried to remove postfix %s from label %s, but it wasn't there" % (postfix, metProducerLabel))
     moduleMETshiftUpName = "%s%s%sUp" % (metProducerLabel, particleType, shiftType)
+    print "==========> ",metProducerLabel,"  ", moduleMETshiftUpName
     moduleMETshiftUpName += postfix
     setattr(process, moduleMETshiftUpName, moduleMETshiftUp)
     sequence += moduleMETshiftUp

--- a/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
+++ b/PhysicsTools/PatUtils/python/tools/propagateMEtUncertainties.py
@@ -41,7 +41,6 @@ def propagateMEtUncertainties(process, particleCollection, particleType,
         else:
             raise StandardError("Tried to remove postfix %s from label %s, but it wasn't there" % (postfix, metProducerLabel))
     moduleMETshiftUpName = "%s%s%sUp" % (metProducerLabel, particleType, shiftType)
-    print "==========> ",metProducerLabel,"  ", moduleMETshiftUpName
     moduleMETshiftUpName += postfix
     setattr(process, moduleMETshiftUpName, moduleMETshiftUp)
     sequence += moduleMETshiftUp


### PR DESCRIPTION
On top of #8391 
- fix some issues when reading pat::MET 
- allow writing alternate METs without uncertainties 
- make puppi met be a type1 met but save also the raw met (i.e. just like for the pf met)
- fix also uncertainties for the raw met

@mmarionncern  @arizzi @mariadalfonso @jshlee
