### PR TITLE
add castor lowPTjet trigger and reweight threshold via gain v2

### DIFF
--- a/SimCalorimetry/CastorTechTrigProducer/python/castorTTRecord_cfi.py
+++ b/SimCalorimetry/CastorTechTrigProducer/python/castorTTRecord_cfi.py
@@ -1,18 +1,21 @@
 import FWCore.ParameterSet.Config as cms
 
 simCastorTTRecord = cms.EDProducer("CastorTTRecord",
-    CastorDigiCollection 	= cms.InputTag( 'simCastorDigis' ),
-    CastorSignalTS			= cms.uint32(4),
+    CastorDigiCollection    = cms.InputTag( 'simCastorDigis' ),
+    CastorSignalTS          = cms.uint32(4),
     
-    ttpBits           		= cms.vuint32( 60, 61, 62, 63 ), 
-    TriggerBitNames       	= cms.vstring( 'L1Tech_CASTOR_0.v0',
-    									   'L1Tech_CASTOR_TotalEnergy.v0',
-    									   'L1Tech_CASTOR_EM.v0',
-    									   'L1Tech_CASTOR_HaloMuon.v0'
-    									  ),
-    TriggerThresholds		= cms.vdouble(	50, # gap trgger threshold 
-    										135000, # jet energy threshold per sector
-    										1500, 100, # fist EM threshold, second HAD threshold for egamma trigger
-    										50, # muon trigger threshold
-    									 )
+    ttpBits                 = cms.vuint32( 60, 61, 62, 63 ), 
+    TriggerBitNames         = cms.vstring( 'L1Tech_CASTOR_0.v0',
+                                           'L1Tech_CASTOR_TotalEnergy.v0',
+                                           'L1Tech_CASTOR_EM.v0',
+                                           'L1Tech_CASTOR_HaloMuon.v0'
+                                         ),
+    TriggerThresholds       = cms.vdouble( 50, # gap trgger threshold 
+                                           # for old jet trigger version cut on total sector energy
+                                           # 135000,  # jet energy threshold per sector
+                                           48000,     # jet energy threshold on had part of sector energy
+                                           1500, 100, # fist EM threshold, second HAD threshold for egamma trigger
+                                           50,        # muon trigger threshold
+                                           65000,     # low pt jet energy threshold for total sector energy
+                                         )
 )

--- a/SimCalorimetry/CastorTechTrigProducer/src/CastorTTRecord.h
+++ b/SimCalorimetry/CastorTechTrigProducer/src/CastorTTRecord.h
@@ -19,7 +19,7 @@ public:
 
     // get fC from digis and save it to array double energy[16 sectors][14 modules]
     void getEnergy_fC(double energy[16][14], edm::Handle<CastorDigiCollection>& CastorDigiColl,
-    				  edm::Event& e, const edm::EventSetup& c) const;
+    				  edm::Event& e, const edm::EventSetup& c);
 
     // get Trigger decisions | vector needs same SIZE and ORDER as in 'ttpBits_'
     void getTriggerDecisions(std::vector<bool>& decision, double energy[16][14]) const;
@@ -35,6 +35,8 @@ private:
     std::vector<unsigned int> ttpBits_ ;
     std::vector<std::string> TrigNames_ ; 
    	std::vector<double> TrigThresholds_ ;
+
+    double reweighted_gain;
 };
 
 #endif


### PR DESCRIPTION
Dear all,
this update is to implement the newest castor technical triggers how the will be used during VdM run in 2015.
The 4 trigger bits are
60 gap trigger
61 high pt jet trigger
62 low pt jet trigger (new)
63 muon trigger

Because VdM run will be the only data taking with castor and upcoming MC simulation are using CMSSW_7_4_X.

Especiall the new trigger bit 62 has changed significantly compared to the old version. Also the MC samples are already in proccess of being requested.

So it would be very nice to get it into CMSSW_7_4_X.
The same pull request will be done also for CMSSW 7_5_X.

Any help is welcome.

Thanks,
Hauke
