### PR TITLE
MultiChainEvent: don't throw in getByProductID

### DIFF
--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -367,9 +367,6 @@ edm::WrapperBase const* MultiChainEvent::getByProductID(edm::ProductID const&iID
   if (edp == nullptr) {
     (const_cast<MultiChainEvent*>(this))->toSec(event1_->id());
     edp = event2_->getByProductID(iID);
-    if (edp == nullptr) {
-      throw cms::Exception("ProductNotFound") << "Cannot find product " << iID;
-    }
   }
   return edp;
 }


### PR DESCRIPTION
The behaviour before this fix causes an exception to be thrown
when using ref.isAvailable() if the product is missing in both
the primary and the secondary file.

This bugfix is already present in 7_3_X and later, see
https://github.com/cms-sw/cmssw/commit/87d13c05c6dc6f4acf17a55a9af7293725e11040#diff-a7cf5650266eb5357959bebb6fd57f82
