### PR TITLE
Add missing dictionary and fix conddb v1

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -19,6 +19,7 @@
   <class pattern="std::vector<ROOT::Math::*>" />
   <class pattern="edm::Wrapper<*>" />
   <class pattern="edm::RefVector<*>" />
+  <class pattern="edm::ValueMap<*>" />
   <class pattern="std::pair<ROOT::Math::PositionVector3D<*>,float>"/>
   <class pattern="std::vector<std::pair<ROOT::Math::PositionVector3D<*>,float> >"/>
 </selection>

--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -147,7 +147,7 @@ namespace edm {
 
     // Handle classes
     TClass* theClass = TClass::GetClass(name.c_str());
-    if (theClass != nullptr && theClass->GetTypeInfo() != nullptr) {
+    if (theClass != nullptr) {
       return TypeWithDict(theClass, property);
     }
 
@@ -317,9 +317,7 @@ namespace edm {
     arrayDimensions_(nullptr),
     property_(property) {
     if(ti_ == nullptr) {
-      ti_ = &typeid(TypeWithDict::invalidType);
-      class_ = nullptr;
-      property_ = 0L;
+      ti_ = &typeid(TypeWithDict::dummyType);
     }
   }
 
@@ -696,6 +694,10 @@ namespace edm {
         value_ptr<std::vector<size_t> > emptyVec;
         newType.arrayDimensions_ = emptyVec;
       } else {
+        std::vector<size_t>& dims = *newType.arrayDimensions_;
+        for(size_t i = 0; i != size; ++i) {
+          dims[i] = dims[i+1];
+        }
         newType.arrayDimensions_->resize(size - 1);
       }
       return newType;


### PR DESCRIPTION
This PR fixes three critical problems specific to the ROOT6 IB.
1) A bug in TypeWithDict.cc in the handling of multidimensional C-style arrays, which breaks reading conddb V1 files
2) Another  bug in TypeWithDict.cc, not specific to maps, nonetheless causes reading maps in conddb V1 files to fail
3) A missing dictionary specification in DataFormats/Math breaks all relvals using PuppiProducer.
The dictionary specification is present in 7_4_X, but somehow is missing in CMSSW_7_4_ROOT6_X.
Please merge this critical PR as soon as convenient, bypassing signatures if not signed in a timely manner.
