### PR TITLE
Shifted beam spots for HF non-uniformity study

### DIFF
--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -418,3 +418,25 @@ ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.0),
     Z0 = cms.double(0.0)
 )
+Shifted5mmCollision2015VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(65.0),
+    Emittance = cms.double(5.411e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.3),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.5),
+    Y0 = cms.double(0.0),
+    Z0 = cms.double(0.0)
+)
+Shifted15mmCollision2015VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(65.0),
+    Emittance = cms.double(5.411e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.3),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(1.5),
+    Y0 = cms.double(0.0),
+    Z0 = cms.double(0.0)
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedShifted15mmCollision2015_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedShifted15mmCollision2015_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Shifted15mmCollision2015VtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedShifted5mmCollision2015_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedShifted5mmCollision2015_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Shifted5mmCollision2015VtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
Two extra shifted in transfer direction positions of beam spot are added according to HCAL group requirement. This beam spots will be used to study asymmetry of HF response due to misalignment of HF. 

This is needed for 7_1_X special production reqests.
