### PR TITLE
Redo fix for conddb v1

### DIFF
--- a/FWCore/Utilities/src/TypeWithDict.cc
+++ b/FWCore/Utilities/src/TypeWithDict.cc
@@ -147,7 +147,7 @@ namespace edm {
 
     // Handle classes
     TClass* theClass = TClass::GetClass(name.c_str());
-    if (theClass != nullptr) {
+    if (theClass != nullptr && theClass->GetTypeInfo() != nullptr) {
       return TypeWithDict(theClass, property);
     }
 
@@ -210,11 +210,17 @@ namespace edm {
     }
 
     // For a reason not understood, TClass::GetClass sometimes cannot find std::vector<T>::value_type
-    // when T is a nested class.
+    // or std::map<X,T>::value_type when T is a nested class.
+    // This workaround bypasses the problem. The problem really should be debugged.
     if(stripNamespace(name) == "value_type") {
       size_t begin = name.find('<');
       size_t end = name.rfind('>');
       if(begin != std::string::npos && end != std::string::npos && end > ++begin) {
+        size_t amap = name.find("map");
+        if(amap != std::string::npos && amap < begin) {
+           ++end;
+           return TypeWithDict::byName(std::string("std::pair<const ") + name.substr(begin, end - begin), property);
+        }
         return TypeWithDict::byName(name.substr(begin, end - begin), property);
       }
     }
@@ -317,7 +323,9 @@ namespace edm {
     arrayDimensions_(nullptr),
     property_(property) {
     if(ti_ == nullptr) {
-      ti_ = &typeid(TypeWithDict::dummyType);
+      ti_ = &typeid(TypeWithDict::invalidType);
+      class_ = nullptr;
+      property_ = 0L;
     }
   }
 


### PR DESCRIPTION
Pull request #8425, recently merged, included fixes for two problems reading conddb v1 files.
Unfortunately, one of the fixes (the one for maps) was not sufficiently thought through.
That fix broke reading of a different conddb v1 file that was not available to me for testing at the time.
This PR undoes that one fix in #8425, and implements a much better fix.  #8425 should not be reverted, because the other two fixes in it are needed.
This PR has been successfully tested with the short relval matrix.
Please merge this critical PR as soon as convenient.  Since Chris Jones may be travelling, please bypass the L2 signature if not signed in a timely manner.
