### PR TITLE
avoid copies of GenEvent and optimizing random number usage in DIGI step

### DIFF
--- a/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
+++ b/SimCalorimetry/CaloSimAlgos/src/CaloHitResponse.cc
@@ -204,8 +204,7 @@ double CaloHitResponse::analogSignalAmplitude(const DetId & detId, float energy,
   double npe = scl * energy * parameters.simHitToPhotoelectrons(detId);
   // do we need to doPoisson statistics for the photoelectrons?
   if(parameters.doPhotostatistics()) {
-    CLHEP::RandPoissonQ randPoissonQ(*engine, npe);
-    npe = randPoissonQ.fire();
+    npe = CLHEP::RandPoissonQ::shoot(engine,npe);
   }
   if(thePECorrection) npe = thePECorrection->correctPE(detId, npe, engine);
   return npe;

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.cc
@@ -75,9 +75,8 @@ namespace cms
     
     mixMod.produces<PileupVertexContent>().setBranchAlias(alias);
 
-    const edm::InputTag Mtag("generator");
-
-    iC.consumes<edm::HepMCProduct>(Mtag);
+    Mtag_=edm::InputTag("generator");
+    iC.consumes<edm::HepMCProduct>(Mtag_);
   }
   
   PileupVertexAccumulator::~PileupVertexAccumulator(){  
@@ -98,10 +97,6 @@ namespace cms
 
   void
   PileupVertexAccumulator::accumulate(edm::Event const& iEvent, edm::EventSetup const& iSetup) {
-    edm::Handle<edm::HepMCProduct> MCevt;
-    const edm::InputTag Mtag("generator");
-    iEvent.getByLabel(Mtag, MCevt);
-
     // don't do anything for hard-scatter signal events
   }
 
@@ -109,10 +104,9 @@ namespace cms
   PileupVertexAccumulator::accumulate(PileUpEventPrincipal const& iEvent, edm::EventSetup const& iSetup, edm::StreamID const& streamID) {
 
     edm::Handle<edm::HepMCProduct> MCevt;
-    const edm::InputTag Mtag("generator");
-    iEvent.getByLabel(Mtag, MCevt);
+    iEvent.getByLabel(Mtag_, MCevt);
 
-    HepMC::GenEvent * myGenEvent = new HepMC::GenEvent(*(MCevt->GetEvent()));
+    const HepMC::GenEvent *myGenEvent = MCevt->GetEvent();
 
     double pthat = myGenEvent->event_scale();
     float pt_hat = float(pthat);
@@ -129,12 +123,12 @@ namespace cms
     if(viter!=vend){
       // The origin vertex (turn it to cm's from GenEvent mm's)
       HepMC::GenVertex* v = *viter;   
-      float zpos = v->position().z()/10.;
+      float zpos = v->position().z()*0.1;
  
       z_posns_.push_back(zpos);
     }
 
-    delete myGenEvent;
+    //    delete myGenEvent;
 
   }
 

--- a/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
+++ b/SimGeneral/PileupInformation/plugins/PileupVertexAccumulator.h
@@ -20,6 +20,7 @@
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixMod.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "DataFormats/Provenance/interface/EventID.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 namespace edm {
   class ConsumesCollector;
@@ -53,6 +54,8 @@ namespace cms {
   private:
     std::vector<float> pT_Hats_;
     std::vector<float> z_posns_;
+    edm::InputTag Mtag_;
+
   };
 }
 

--- a/SimTracker/Common/src/SiG4UniversalFluctuation.cc
+++ b/SimTracker/Common/src/SiG4UniversalFluctuation.cc
@@ -230,8 +230,7 @@ double SiG4UniversalFluctuation::SampleFluctuations(const double momentum,
         siga=sqrt(a1) ;
         p1 = max(0., CLHEP::RandGaussQ::shoot(engine, a1, siga) + 0.5);
       } else {
-        CLHEP::RandPoissonQ randPoissonQ(*engine, a1);
-        p1 = double(randPoissonQ.fire());
+	p1 = double(CLHEP::RandPoissonQ::shoot(engine,a1));
       }
     
       // excitation type 2
@@ -239,8 +238,7 @@ double SiG4UniversalFluctuation::SampleFluctuations(const double momentum,
         siga=sqrt(a2) ;
         p2 = max(0., CLHEP::RandGaussQ::shoot(engine, a2, siga) + 0.5);
       } else {
-        CLHEP::RandPoissonQ randPoissonQ(*engine, a2);
-        p2 = double(randPoissonQ.fire());
+	p2 = double(CLHEP::RandPoissonQ::shoot(engine,a2));
       }
     
       loss = p1*e1Fluct+p2*e2Fluct;
@@ -259,8 +257,7 @@ double SiG4UniversalFluctuation::SampleFluctuations(const double momentum,
         siga=sqrt(a3) ;
         p3 = max(0., CLHEP::RandGaussQ::shoot(engine, a3, siga) + 0.5);
       } else {
-        CLHEP::RandPoissonQ randPoissonQ(*engine, a3);
-        p3 = double(randPoissonQ.fire());
+	p3 = double(CLHEP::RandPoissonQ::shoot(engine,a3));
       }
       double lossc = 0.;
       if (p3 > 0) {
@@ -302,8 +299,7 @@ double SiG4UniversalFluctuation::SampleFluctuations(const double momentum,
     siga=sqrt(a3);
     p3 = max(0., CLHEP::RandGaussQ::shoot(engine, a3, siga) + 0.5);
   } else {
-    CLHEP::RandPoissonQ randPoissonQ(*engine, a3);
-    p3 = double(randPoissonQ.fire());
+    p3 = double(CLHEP::RandPoissonQ::shoot(engine,a3));
   }
   if (p3 > 0.) {
     double w = (tmax-e0)/tmax;


### PR DESCRIPTION
Roughly 10% improvement in mixing module time

Main change are:
 1) Avoid copying GenEvent when not needed

 2) Avoid creating a random generator using it once. I'm lazy so used the static methods as done elsewhere in the digitizers. One can easily also make the RandPoissonQ object a member data with the same effect. RandPoissonQ does some setup assuming that the mu its given will be used over and over, so there is a CPU penalty for creating it and using it only once.
