### PR TITLE
ExtVec.h: add long double x2 x4 in ExtVecTraits for AArch64

### DIFF
--- a/DataFormats/Math/interface/ExtVec.h
+++ b/DataFormats/Math/interface/ExtVec.h
@@ -16,6 +16,16 @@ typedef double VECTOR_EXT( 16 ) float64x2_t;
 typedef double VECTOR_EXT( 32 ) float64x4_t;
 typedef double VECTOR_EXT( 64 ) float64x8_t;
 
+// Enable only for AArch64 for now as this would ICE GCC on
+// x86_64.
+// XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65486
+// XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65491
+#if defined(__aarch64__)
+typedef long double VECTOR_EXT( 32 ) float128x2_t;
+typedef long double VECTOR_EXT( 64 ) float128x4_t;
+typedef long double VECTOR_EXT( 128 ) float128x8_t;
+#endif
+
 // template<typename T, int N> using ExtVec =  T __attribute__( ( vector_size( N*sizeof(T) ) ) );
 
 template<typename T, int N>
@@ -43,6 +53,21 @@ struct ExtVecTraits<double, 4> {
   typedef double VECTOR_EXT( 4*sizeof(double) ) type;
 };
 
+// Enable only for AArch64 for now as this would ICE GCC on
+// x86_64.
+// XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65486
+// XXX: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65491
+#if defined(__aarch64__)
+template<>
+struct ExtVecTraits<long double, 2> {
+  typedef long double VECTOR_EXT( 2*sizeof(long double) ) type;
+};
+
+template<>
+struct ExtVecTraits<long double, 4> {
+  typedef long double VECTOR_EXT( 4*sizeof(long double) ) type;
+};
+#endif
 
 template<typename T, int N> using ExtVec =  typename ExtVecTraits<T,N>::type;
 


### PR DESCRIPTION
The patch adds suport for long double vectors. This revealed GCC
bugs on i*86/x86_64/aarch64 (links below). Only done for AArch64,
as this would ICE GCC on x86_64 until fixed.

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65486
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65491

Signed-off-by: David Abdurachmanov davidlt@cern.ch
