### PR TITLE
automatically drop LHEXMLStringProduct on input from cmsDriver

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -411,7 +411,14 @@ class ConfigBuilder(object):
                self.process.source=cms.Source("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
 	       filesFromDASQuery(self._options.dasquery,self.process.source)
 
-	if self._options.inputCommands:
+	##drop LHEXMLStringProduct on input to save memory if appropriate
+	if 'GEN' in self.stepMap.keys():
+        	if self._options.inputCommands:
+        		self._options.inputCommands+=',drop LHEXMLStringProduct_*_*_*,'
+		else:
+			self._options.inputCommands='keep *, drop LHEXMLStringProduct_*_*_*,'    
+
+	if self.process.source and self._options.inputCommands:
 		if not hasattr(self.process.source,'inputCommands'): self.process.source.inputCommands=cms.untracked.vstring()
 		for command in self._options.inputCommands.split(','):
 			# remove whitespace around the keep/drop statements


### PR DESCRIPTION
Drops on input automatically the LHEXMLStringProduct whenever the GEN step is run with an input file.  (Saves memory which would be used to read the large run product that should only be saved in the initial LHE output step)

Added bonus: ConfigBuilder is now smart enough to simply do nothing in case inputCommands are passed but there is no input file.  (May add flexibility in mcm handling of additional inputCommands in the future)
