### PR TITLE
fix propagator in SeedFromConsecutiveHitsCreator config file

### DIFF
--- a/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
@@ -1,5 +1,5 @@
-Bimport FWCore.ParameterSet.Config as cms
-0;95;c
+import FWCore.ParameterSet.Config as cms
+
 SeedFromConsecutiveHitsCreator = cms.PSet(
   ComponentName = cms.string('SeedFromConsecutiveHitsCreator'),
 #  propagator = cms.string('PropagatorWithMaterial'),

--- a/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
+++ b/RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py
@@ -1,9 +1,9 @@
-import FWCore.ParameterSet.Config as cms
-
+Bimport FWCore.ParameterSet.Config as cms
+0;95;c
 SeedFromConsecutiveHitsCreator = cms.PSet(
   ComponentName = cms.string('SeedFromConsecutiveHitsCreator'),
-  propagator = cms.string('PropagatorWithMaterial'),
-#  propagator = cms.string('PropagatorWithMaterialParabolicMf'),
+#  propagator = cms.string('PropagatorWithMaterial'),
+  propagator = cms.string('PropagatorWithMaterialParabolicMf'),
   SeedMomentumForBOFF = cms.double(5.0),
   OriginTransverseErrorMultiplier = cms.double(1.0),
   MinOneOverPtError = cms.double(1.0),


### PR DESCRIPTION
RecoTracker/TkSeedGenerator/python/SeedFromConsecutiveHitsCreator_cfi.py 
had a not coherent default setting (propagator <----> SimpleMagneticField)

@VinInn @rovere : why RecoTracker/TkSeedGenerator/plugins/SeedFromConsecutiveHitsCreator.h/cc in 75x is not in synch w/ 74x ?
