### PR TITLE
add conddb subcommand to list ALL tags in condDBv2

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -596,6 +596,18 @@ def _since_filter(time_type):
     return lambda since: since
 
 
+def listTags_(args):
+    connection = connect(args)
+    session = connection.session()
+
+    output_table(args,
+        session.query(conddb.Tag.name, conddb.Tag.time_type, conddb.Tag.object_type, conddb.Tag.synchronization, conddb.Tag.end_of_validity, conddb.Tag.insertion_time, conddb.Tag.description ).\
+            order_by(conddb.Tag.insertion_time, conddb.Tag.name).\
+            all(),
+        ['Name', 'TimeType', 'ObjectType', 'Synchronisation', 'EndOfValidity', 'Insertion_time', 'Description'],
+    )
+
+
 def listGTs_(args):
     connection = connect(args)
     session = connection.session()
@@ -1308,6 +1320,9 @@ def main():
     parser_list.add_argument('--snapshot', '-T', default=None, help="Snapshot time. If provided, the output will represent the state of the IOVs inserted into database up to the given time. The format of the string must be one of the following: '2013-01-20', '2013-01-20 10:11:12' or '2013-01-20 10:11:12.123123'.")
     parser_list.add_argument('--limit', '-L', type=int, default=500, help='Limit on the number of IOVs returned. The returned results are the latest N IOVs. Only applies when listing tags.')
     parser_list.set_defaults(func=list_)
+
+    parser_listTags = parser_subparsers.add_parser('listTags', description='Lists all the Tags available in the DB.')
+    parser_listTags.set_defaults(func=listTags_)
 
     parser_listGTs = parser_subparsers.add_parser('listGTs', description='Lists the GTs available in the DB.')
     parser_listGTs.set_defaults(func=listGTs_)


### PR DESCRIPTION
add subcommand to conddb tool to list ALL tags in condDBv2 (>7200 at present!)
