### PR TITLE
Port back from ROOT6 IB for code commonality (Core again)

### DIFF
--- a/DataFormats/Common/doc/Common_containers.doc
+++ b/DataFormats/Common/doc/Common_containers.doc
@@ -44,8 +44,8 @@ Commonly used persistent containers.
 </pre>
 \endhtmlonly
   The attribute <tt>transientMap_</tt> has to be declared transient in the
-  Reflex dictionary. Other used persistent 
-  types have to be declared in the Reflex dictionary, depending case by case:
+  dictionary. Other used persistent 
+  types have to be declared in the dictionary, depending case by case:
 \htmlonly
 <pre>
 &lt;lcgdict&gt;

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -1,4 +1,5 @@
 <lcgdict>
+ <enum name="edm::BranchType"/>
  <class name="edm::ViewTypeChecker" ClassVersion="2">
   <version ClassVersion="2" checksum="2398868528"/>
  </class>

--- a/FWCore/MessageLogger/interface/ELseverityLevel.h
+++ b/FWCore/MessageLogger/interface/ELseverityLevel.h
@@ -53,6 +53,7 @@ namespace edm {
 class ELseverityLevel;
 
 
+#ifndef __ROOTCLING__
 // ----------------------------------------------------------------------
 // Synonym for type of ELseverityLevel-generating function:
 // ----------------------------------------------------------------------
@@ -90,6 +91,7 @@ struct ELslProxy  {
   const ELstring  getVarName()  const;
 
 };  // ELslProxy<ELslGen>
+#endif
 
 // ----------------------------------------------------------------------
 
@@ -155,6 +157,7 @@ private:
 };  // ELseverityLevel
 
 
+#ifndef __ROOTCLING__
 // ----------------------------------------------------------------------
 // Declare the globally available severity objects,
 // one generator function and one proxy per non-default ELsev_:
@@ -183,6 +186,16 @@ extern ELslProxy< ELsevereGen          > const  ELsevere;
 
 extern ELslGen  ELhighestSeverityGen;
 extern ELslProxy< ELhighestSeverityGen > const  ELhighestSeverity;
+#else
+ELseverityLevel const  ELzeroSeverity;
+ELseverityLevel const  ELdebug;
+ELseverityLevel const  ELinfo;
+ELseverityLevel const  ELwarning;
+ELseverityLevel const  ELerror;
+ELseverityLevel const  ELunspecified;
+ELseverityLevel const  ELsevere;
+ELseverityLevel const  ELhighestSeverity;
+#endif
 
 
 // ----------------------------------------------------------------------
@@ -210,9 +223,11 @@ extern bool  operator>= ( ELseverityLevel const & e1
 
 // ----------------------------------------------------------------------
 
+#ifndef __ROOTCLING__
 #define ELSEVERITYLEVEL_ICC
   #include "FWCore/MessageLogger/interface/ELseverityLevel.icc"
 #undef  ELSEVERITYLEVEL_ICC
+#endif
 
 
 // ----------------------------------------------------------------------

--- a/FWCore/Modules/src/EventContentAnalyzer.cc
+++ b/FWCore/Modules/src/EventContentAnalyzer.cc
@@ -177,7 +177,7 @@ namespace edm {
        try {
           size_t temp; //used to hold the memory for the return value
           FunctionWithDict sizeFunc = iObject.typeOf().functionMemberByName("size");
-          assert(sizeFunc.returnType() == typeid(size_t));
+          assert(sizeFunc.finalReturnType() == typeid(size_t));
           sizeObj = ObjectWithDict(TypeWithDict(typeid(size_t)), &temp);
           sizeFunc.invoke(iObject, &sizeObj);
           //std::cout << "size of type '" << sizeObj.name() << "' " << sizeObj.typeName() << std::endl;
@@ -192,7 +192,7 @@ namespace edm {
           LogAbsolute("EventContent") << iIndent << iName << kNameValueSep << "[size=" << size << "]";//"\n";
           ObjectWithDict contained;
           std::string indexIndent = iIndent + iIndentDelta;
-          TypeWithDict atReturnType(atMember.returnType());
+          TypeWithDict atReturnType(atMember.finalReturnType());
           //std::cout << "return type " << atReturnType.name() << " size of " << atReturnType.SizeOf()
           // << " pointer? " << atReturnType.isPointer() << " ref? " << atReturnType.isReference() << std::endl;
 

--- a/FWCore/PluginManager/BuildFile.xml
+++ b/FWCore/PluginManager/BuildFile.xml
@@ -1,6 +1,5 @@
 <use   name="boost"/>
 <use   name="tbb"/>
-<use   name="rootcint"/>
 <use   name="boost_filesystem"/>
 <use   name="FWCore/Utilities"/>
 <export>

--- a/FWCore/Utilities/interface/TypeDemangler.h
+++ b/FWCore/Utilities/interface/TypeDemangler.h
@@ -6,5 +6,7 @@
 namespace edm {
   std::string
   typeDemangle(char const* mangledName);
+  void
+  replaceString(std::string& demangledName, std::string const& from, std::string const& to);
 }
 #endif

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -84,6 +84,16 @@ namespace {
 }
 
 namespace edm {
+  void
+  replaceString(std::string& demangledName, std::string const& from, std::string const& to) {
+    // from must not be a substring of to.
+    std::string::size_type length = from.size(); 
+    std::string::size_type pos = 0;
+    while((pos = demangledName.find(from, pos)) != std::string::npos) {
+       demangledName.replace(pos, length, to); 
+    }
+  }
+
   std::string
   typeDemangle(char const* mangledName) {
     int status = 0;
@@ -97,10 +107,12 @@ namespace edm {
     } 
     std::string demangledName(demangled);
     free(demangled);
-    // We must use the same conventions used by REFLEX.
+    // We must use the same conventions previously used by REFLEX.
     // The order of these is important.
     // No space after comma
-    reformatter(demangledName, "(.*), (.*)", "$1,$2");
+    replaceString(demangledName, ", ", ",");
+    // No space before opening square bracket
+    replaceString(demangledName, " [", "[");
     // Strip default allocator
     std::string const allocator(",std::allocator<");
     removeParameter(demangledName, allocator);
@@ -112,7 +124,7 @@ namespace edm {
     // Put const qualifier before identifier.
     constBeforeIdentifier(demangledName);
     // No two consecutive '>' 
-    reformatter(demangledName, "(.*)>>(.*)", "$1> >$2");
+    replaceString(demangledName, ">>", "> >");
     // No u or l qualifiers for integers.
     reformatter(demangledName, "(.*[<,][0-9]+)[ul]l*([,>].*)", "$1$2");
     return demangledName;

--- a/IOPool/Common/bin/BuildFile.xml
+++ b/IOPool/Common/bin/BuildFile.xml
@@ -8,6 +8,7 @@
   <use   name="FWCore/Services"/>
   <use   name="FWCore/Utilities"/>
   <use   name="DataFormats/StdDictionaries"/>
+  <use   name="DataFormats/WrappedStdDictionaries"/>
 </bin>
 <bin   name="edmFileUtil" file="EdmFileUtil.cpp,CollUtil.cc">
   <use   name="boost"/>

--- a/IOPool/Common/interface/CustomStreamer.h
+++ b/IOPool/Common/interface/CustomStreamer.h
@@ -39,7 +39,7 @@ namespace edm {
   template <typename T>
   void
   SetCustomStreamer() {
-    TClass *cl = TClass::GetClass(TypeID(typeid(T)).className().c_str());
+    TClass *cl = TClass::GetClass(typeid(T));
     if (cl->GetStreamer() == 0) {
       cl->AdoptStreamer(new CustomStreamer<T>());
     }
@@ -48,7 +48,7 @@ namespace edm {
   template <typename T>
   void
   SetCustomStreamer(T const&) {
-    TClass *cl = TClass::GetClass(TypeID(typeid(T)).className().c_str());
+    TClass *cl = TClass::GetClass(typeid(T));
     if (cl->GetStreamer() == 0) {
       cl->AdoptStreamer(new CustomStreamer<T>());
     }


### PR DESCRIPTION
Port back more changes from 7_4_ROOT6_X in the Core L2 category that are beneficial or harmless for 7_4_X for code commonality.  Six of the nine affected files will become identical between the two releases, while the other three,  DataFormats/Provenance/src/classes_def.xml, FWCore/Modules/src/EventContentAnalyzer.cc, and FWCore/Utilities/src/TypeDemangler.cc, will still have some ROOT5/ROOT6 differences, but fewer than now.
Due to the current problems with frontier, I was unable to run the usual short relval matrix, but the unit tests for the affected packages all pass.
