### PR TITLE
Port back from ROOT6 IB for code commonality (Visualization)

### DIFF
--- a/Fireworks/Core/src/FWTableViewManager.cc
+++ b/Fireworks/Core/src/FWTableViewManager.cc
@@ -290,13 +290,13 @@ FWTableViewManager::tableFormats(const edm::TypeWithDict &key)
          continue;
       if (!m.isConst())
          continue;
-      if (m.returnType().name() == isint)
+      if (m.finalReturnType().name() == isint)
          handle.column(m.name().c_str(), TableEntry::INT);
-      else if (m.returnType().name() == isbool)
+      else if (m.finalReturnType().name() == isbool)
          handle.column(m.name().c_str(), TableEntry::BOOL);
-      else if (m.returnType().name() == isdouble)
+      else if (m.finalReturnType().name() == isdouble)
          handle.column(m.name().c_str(), 5);
-      else if (m.returnType().name() == isfloat)
+      else if (m.finalReturnType().name() == isfloat)
          handle.column(m.name().c_str(), 3);
    }
    edm::TypeDataMembers dataMembers(key);


### PR DESCRIPTION
Port back a change from the ROOT6 IB for code commonality.
finalReturnType() is the correct call here for both ROOT5 and ROOT6 because it strips typedefs from the return type, while returnType() may not strip typedefs.
The file will be identical in the two releases after this PR is merged.
