### PR TITLE
Fix compilation error in CommonTools/Utils

### DIFF
--- a/CommonTools/Utils/test/testExpressionEvaluator.cc
+++ b/CommonTools/Utils/test/testExpressionEvaluator.cc
@@ -9,7 +9,6 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
-#include "Cintex/Cintex.h"
 
 
 class testExpressionEvaluator : public CppUnit::TestFixture {
@@ -18,7 +17,7 @@ class testExpressionEvaluator : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  testExpressionEvaluator() {ROOT::Cintex::Cintex::Enable();} // for crappy pats
+  testExpressionEvaluator() {} // for crappy pats
   ~testExpressionEvaluator(){}
   void checkAll(); 
 


### PR DESCRIPTION
This PR fixes the 7_5_X build error in CommonTools/Utils.  It should _not_ be forward ported into CMSSW_7_5_ROOT5_X.

The compilation errors in CondFormats/BTauObjects and RecoBTag/PerformanceDB were fixed in a separate PR.
