### PR TITLE
Backport changes from ROOT6 IB for code commonality (Analysis)

### DIFF
--- a/DataFormats/PatCandidates/interface/UserData.h
+++ b/DataFormats/PatCandidates/interface/UserData.h
@@ -57,7 +57,6 @@ namespace pat {
   protected:
     /// Get out the data (can't template non virtual functions)
     virtual const void * data_  () const = 0;
-    static std::string demangleName(const char* iMangledName);
 
   private:
     static void checkDictionaries(const std::type_info &type) ;
@@ -97,7 +96,9 @@ std::auto_ptr<pat::UserData> pat::UserData::make(const T &value, bool transientO
 
 template<typename T> 
 const std::string & pat::UserHolder<T>::typeName_() {
-    static const std::string name(demangleName(typeid(T).name()));
+    static int status = 0;
+    static const char * demangled = abi::__cxa_demangle(typeid(T).name(),  0, 0, &status);
+    static const std::string name(status == 0 ? demangled : "[UNKNOWN]");
     return name;
 }
 

--- a/DataFormats/PatCandidates/src/UserData.cc
+++ b/DataFormats/PatCandidates/src/UserData.cc
@@ -24,11 +24,3 @@ void pat::UserData::checkDictionaries(const std::type_info &type) {
             << "   you need to specify them in classes_def.xml.\n";
     } // check for dictionary
 }
-
-std::string pat::UserData::demangleName(const char* iMangledName) {
-   int status = 0;
-   char * demangled = abi::__cxa_demangle(iMangledName,  0, 0, &status);
-   const std::string name(status == 0 ? demangled : "[UNKNOWN]");
-   if((status ==0) and (nullptr != demangled)) { free(demangled);}
-   return name;
-}

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -100,7 +100,9 @@ class VersionedSelector : public Selector<T> {
     return this->operator()(ref, ret);
   }
   
-  using Selector<T>::operator();
+#ifndef __ROOTCLING__
+  using typename Selector<T>::operator();
+#endif
   
   const unsigned char* md55Raw() const { return id_md5_; } 
   bool operator==(const VersionedSelector& other) const {


### PR DESCRIPTION
Back port some more changes from the ROOT6 IB in the Analysis L2 category for code compatibility.
These changes are harmless or beneficial for ROOT5. Two of the three affected files will be identical in the two releases after this PR is merged, while UserData.cc will retain one minor difference,
