### PR TITLE
Fix for FastSim: HltBtagValidation: make the InPutTag for SimVertices configurable.

### DIFF
--- a/HLTriggerOffline/Btag/python/HltBtagValidationFastSim_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidationFastSim_cff.py
@@ -3,6 +3,7 @@ from HLTriggerOffline.Btag.HltBtagValidation_cff import *
 
 #define HltVertexValidationVerticesFastSim for the vertex DQM validation (no hltFastPrimaryVertex)
 HltVertexValidationVerticesFastSim= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
+        SimVertexCollection = cms.InputTag("famosSimHits"),
 	TriggerResults = cms.InputTag('TriggerResults','',"HLT"),
 	HLTPathNames =cms.vstring(
 		'HLT_PFMET120_NoiseCleaned_BTagCSV07_', 

--- a/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
@@ -16,6 +16,7 @@ hltBtagJetsbyRef.jets = cms.InputTag("hltSelector4CentralJetsL1FastJet")
 
 #define HltVertexValidationVertices for the vertex DQM validation
 HltVertexValidationVertices= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
+        SimVertexCollection = cms.InputTag("g4SimHits"),
 	TriggerResults = cms.InputTag('TriggerResults','',"HLT"),
 	HLTPathNames =cms.vstring(
 	'HLT_PFMET120_NoiseCleaned_BTagCSV07_', 

--- a/HLTriggerOffline/Btag/python/hltvertexperformanceanalyzer_cfi.py
+++ b/HLTriggerOffline/Btag/python/hltvertexperformanceanalyzer_cfi.py
@@ -1,5 +1,6 @@
 #define VertexValidationVertices for the vertex DQM validation
 process.VertexValidationVertices= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
+        SimVertexCollection = cms.InputTag("g4SimHits"),
 	TriggerResults = cms.InputTag('TriggerResults',),
 	HLTPathNames = cms.vstring('HLT_PFMHT100_SingleCentralJet60_BTagCSV0p6_v1'),
 	Vertex = cms.VInputTag(cms.InputTag("hltFastPrimaryVertex"), cms.InputTag("hltFastPVPixelVertices"), cms.InputTag("hltVerticesL3"))

--- a/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
@@ -5,7 +5,7 @@ HLTVertexPerformanceAnalyzer::HLTVertexPerformanceAnalyzer(const edm::ParameterS
 	hlTriggerResults_   		= consumes<TriggerResults>(iConfig.getParameter<InputTag> ("TriggerResults"));
 	VertexCollection_           = 	edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "Vertex" ), [this](edm::InputTag const & tag){return mayConsume< reco::VertexCollection>(tag);});
 	hltPathNames_        		= iConfig.getParameter< std::vector<std::string> > ("HLTPathNames");
-	simVertexCollection_ = consumes<std::vector<SimVertex> >(edm::InputTag("g4SimHits"));
+	simVertexCollection_ = consumes<std::vector<SimVertex> >(iConfig.getParameter<edm::InputTag> ("SimVertexCollection"));
 
 	EDConsumerBase::labelsForToken(hlTriggerResults_,label);
 	hlTriggerResults_Label = label.module;


### PR DESCRIPTION
Make the InPutTag for SimVertices configurable.
Implement correct cfg for SimVertices for FastSim and FullSim

Same changes to HLTriggerOffline as in  #8455
