### PR TITLE
prevent PAT photon iso variables from overwriting Reco ones

### DIFF
--- a/DataFormats/PatCandidates/interface/Photon.h
+++ b/DataFormats/PatCandidates/interface/Photon.h
@@ -135,16 +135,16 @@ namespace pat {
       float patParticleIso() const { return userIsolation(pat::PfAllParticleIso); }
       /// Returns the isolation calculated with only the charged hadron
       /// PFCandidates
-      float patChargedHadronIso() const { return userIsolation(pat::PfChargedHadronIso); }
+      float chargedHadronIso() const { return reco::Photon::chargedHadronIso(); }
       /// Returns the isolation calculated with only the neutral hadron
       /// PFCandidates
-      float patNeutralHadronIso() const { return userIsolation(pat::PfNeutralHadronIso); }        
+      float neutralHadronIso() const { return reco::Photon::neutralHadronIso(); }
       /// Returns the isolation calculated with only the gamma
       /// PFCandidates
-      float patPhotonIso() const { return userIsolation(pat::PfGammaIso); }
+      float photonIso() const { return reco::Photon::photonIso(); }
       /// Returns the isolation calculated with only the pile-up charged hadron
       /// PFCandidates
-      float patPuChargedHadronIso() const { return userIsolation(pat::PfPUChargedHadronIso); }        
+      float puChargedHadronIso() const { return userIsolation(pat::PfPUChargedHadronIso); }        
 
       /// Returns a user defined isolation value
       float userIso(uint8_t index=0)  const { return userIsolation(IsolationKeys(UserBaseIso + index)); }

--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -101,7 +101,7 @@ class VersionedSelector : public Selector<T> {
   }
   
 #ifndef __ROOTCLING__
-  using typename Selector<T>::operator();
+  using Selector<T>::operator();
 #endif
   
   const unsigned char* md55Raw() const { return id_md5_; } 


### PR DESCRIPTION
This is a different solution, suggested by @monttj and @lgray in #7761, to the issue of pat::Photon variables having the same name as reco::Photon variables. 
Instead of renaming PAT variables (which would introduce an inconsistency between different PAT objects), we force PAT variables to return the corresponding Reco values.
This commit undoes the changes of #7764, which was not approved.
This commit is also backported to 74X in #8494
