### PR TITLE
Add 2015 pileup scenarios

### DIFF
--- a/Configuration/StandardSequences/python/Mixing.py
+++ b/Configuration/StandardSequences/python/Mixing.py
@@ -104,6 +104,9 @@ addMixingScenario("E8TeV_2012_ZmumugSkim",{'file': 'SimGeneral.MixingModule.mix_
 addMixingScenario("CSA14_50ns_PoissonOOT",{'file': 'SimGeneral.MixingModule.mix_CSA14_50ns_PoissonOOTPU_cfi'})
 addMixingScenario("CSA14_inTimeOnly",{'file': 'SimGeneral.MixingModule.mix_CSA14_inTimeOnly_cfi'})
 addMixingScenario("Phys14_50ns_PoissonOOT",{'file': 'SimGeneral.MixingModule.mix_Phys14_50ns_PoissonOOTPU_cfi'})
+addMixingScenario("2015_25ns_HiLum_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25ns_HiLum_PoissonOOTPU_cfi'})
+addMixingScenario("2015_25ns_Startup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_25ns_Startup_PoissonOOTPU_cfi'})
+addMixingScenario("2015_50ns_Startup_PoissonOOTPU",{'file': 'SimGeneral.MixingModule.mix_2015_50ns_Startup_PoissonOOTPU_cfi'})
 addMixingScenario("ProdStep2",{'file': 'SimGeneral.MixingModule.mixProdStep2_cfi'})
 addMixingScenario("fromDB",{'file': 'SimGeneral.MixingModule.mix_fromDB_cfi'})
 

--- a/SimGeneral/MixingModule/python/mix_2015_25ns_HiLum_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_25ns_HiLum_PoissonOOTPU_cfi.py
@@ -1,0 +1,85 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("PoolSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42),
+          probValue = cms.vdouble(
+                     7.85E-07,
+                     3.72E-06,
+                     9.80E-06,
+                     1.57E-05,
+                     4.71E-05,
+                     9.43E-05,
+                     5.97E-04,
+                     4.95E-03,
+                     1.62E-02,
+                     2.84E-02,
+                     4.13E-02,
+                     6.02E-02,
+                     7.98E-02,
+                     9.70E-02,
+                     1.06E-01,
+                     1.00E-01,
+                     8.46E-02,
+                     6.99E-02,
+                     5.89E-02,
+                     5.04E-02,
+                     4.29E-02,
+                     3.58E-02,
+                     2.93E-02,
+                     2.34E-02,
+                     1.83E-02,
+                     1.41E-02,
+                     1.07E-02,
+                     7.98E-03,
+                     5.81E-03,
+                     4.15E-03,
+                     2.89E-03,
+                     1.97E-03,
+                     1.31E-03,
+                     8.50E-04,
+                     5.38E-04,
+                     3.32E-04,
+                     1.99E-04,
+                     1.17E-04,
+                     6.66E-05,
+                     3.69E-05,
+                     1.99E-05,
+                     1.26E-06,
+                     4.71E-07),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+	sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+

--- a/SimGeneral/MixingModule/python/mix_2015_25ns_Startup_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_25ns_Startup_PoissonOOTPU_cfi.py
@@ -1,0 +1,79 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(25), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("PoolSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36),
+          probValue = cms.vdouble(
+                      1.57E-06,
+                      4.62E-06,
+                      1.26E-05,
+                      4.71E-05,
+                      1.41E-04,
+                      6.29E-04,
+                      7.16E-03,
+                      2.40E-02,
+                      4.12E-02,
+                      6.50E-02,
+                      9.36E-02,
+                      1.18E-01,
+                      1.27E-01,
+                      1.11E-01,
+                      8.88E-02,
+                      7.19E-02,
+                      5.95E-02,
+                      4.89E-02,
+                      3.90E-02,
+                      3.01E-02,
+                      2.26E-02,
+                      1.65E-02,
+                      1.18E-02,
+                      8.21E-03,
+                      5.53E-03,
+                      3.61E-03,
+                      2.28E-03,
+                      1.39E-03,
+                      8.17E-04,
+                      4.63E-04,
+                      2.53E-04,
+                      1.33E-04,
+                      6.75E-05,
+                      3.29E-05,
+                      1.57E-05,
+                      7.85E-06,
+                      3.14E-06),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+	sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+

--- a/SimGeneral/MixingModule/python/mix_2015_50ns_Startup_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_50ns_Startup_PoissonOOTPU_cfi.py
@@ -1,0 +1,95 @@
+import FWCore.ParameterSet.Config as cms
+
+# configuration to model pileup for initial physics phase
+from SimGeneral.MixingModule.mixObjects_cfi import theMixObjects
+from SimGeneral.MixingModule.mixPoolSource_cfi import *
+from SimGeneral.MixingModule.digitizers_cfi import *
+
+mix = cms.EDProducer("MixingModule",
+    digitizers = cms.PSet(theDigitizers),
+    LabelPlayback = cms.string(''),
+    maxBunch = cms.int32(3),
+    minBunch = cms.int32(-12), ## in terms of 25 nsec
+
+    bunchspace = cms.int32(50), ##ns
+    mixProdStep1 = cms.bool(False),
+    mixProdStep2 = cms.bool(False),
+
+    playback = cms.untracked.bool(False),
+    useCurrentProcessOnly = cms.bool(False),
+
+    input = cms.SecSource("PoolSource",
+        type = cms.string('probFunction'),
+        nbPileupEvents = cms.PSet(
+          probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52),
+          probValue = cms.vdouble(
+                                    4.71E-09,
+                                    2.86E-06,
+                                    4.85E-06,
+                                    1.53E-05,
+                                    3.14E-05,
+                                    6.28E-05,
+                                    1.26E-04,
+                                    3.93E-04,
+                                    1.42E-03,
+                                    6.13E-03,
+                                    1.40E-02,
+                                    2.18E-02,
+                                    2.94E-02,
+                                    4.00E-02,
+                                    5.31E-02,
+                                    6.53E-02,
+                                    7.64E-02,
+                                    8.42E-02,
+                                    8.43E-02,
+                                    7.68E-02,
+                                    6.64E-02,
+                                    5.69E-02,
+                                    4.94E-02,
+                                    4.35E-02,
+                                    3.84E-02,
+                                    3.37E-02,
+                                    2.92E-02,
+                                    2.49E-02,
+                                    2.10E-02,
+                                    1.74E-02,
+                                    1.43E-02,
+                                    1.16E-02,
+                                    9.33E-03,
+                                    7.41E-03,
+                                    5.81E-03,
+                                    4.49E-03,
+                                    3.43E-03,
+                                    2.58E-03,
+                                    1.91E-03,
+                                    1.39E-03,
+                                    1.00E-03,
+                                    7.09E-04,
+                                    4.93E-04,
+                                    3.38E-04,
+                                    2.28E-04,
+                                    1.51E-04,
+                                    9.83E-05,
+                                    6.29E-05,
+                                    3.96E-05,
+                                    2.45E-05,
+                                    1.49E-05,
+                                    4.71E-06,
+                                    2.36E-06),
+          histoFileName = cms.untracked.string('histProbFunction.root'),
+        ),
+	sequential = cms.untracked.bool(False),
+        manage_OOT = cms.untracked.bool(True),  ## manage out-of-time pileup
+        ## setting this to True means that the out-of-time pileup
+        ## will have a different distribution than in-time, given
+        ## by what is described on the next line:
+        OOT_type = cms.untracked.string('Poisson'),  ## generate OOT with a Poisson matching the number chosen for in-time
+        #OOT_type = cms.untracked.string('fixed'),  ## generate OOT with a fixed distribution
+        #intFixed_OOT = cms.untracked.int32(2),
+        fileNames = FileNames
+    ),
+    mixObjects = cms.PSet(theMixObjects)
+)
+
+
+


### PR DESCRIPTION
Add three 2015 pileup scenarios based on 2012 luminosity distributions.  50ns is identical to 2012.  25ns "startup" is 2012 scaled by 2/3.  25ns "HiLum" is 50ns scaled by 4/5. 
