### PR TITLE
Work around bug in ROOT which affects split classes with iorules

### DIFF
--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -6,7 +6,8 @@
    <field name="p4Polar_" iotype="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<Double32_t> >" />
    <field name="p4Cartesian_" transient="true" />
   </class>
-  <ioread sourceClass = "reco::ParticleState" version="[1-]" targetClass="reco::ParticleState" source="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > p4Polar_" target="p4Cartesian_">
+  <!--The 'int pdgId_' is a workaround for ROOT bug which affects iorules for split classes-->
+  <ioread sourceClass = "reco::ParticleState" version="[1-]" targetClass="reco::ParticleState" source="ROOT::Math::LorentzVector<ROOT::Math::PtEtaPhiM4D<double> > p4Polar_;int pdgId_" target="p4Cartesian_">
    <![CDATA[newObj->setCartesian();]]>
   </ioread>
 


### PR DESCRIPTION
If an iorule is attached to a class rather than a builtin type then
if that class is split in the TFile the iorule will not be run. This
change attached the rule to an additional member which is an int.
