### PR TITLE
Fix ROOT6 -> ROOT5 forward port

### DIFF
--- a/CommonTools/Utils/test/testExpressionEvaluator.cc
+++ b/CommonTools/Utils/test/testExpressionEvaluator.cc
@@ -9,6 +9,7 @@
 #include "DataFormats/Candidate/interface/LeafCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
+#include "Cintex/Cintex.h"
 
 
 class testExpressionEvaluator : public CppUnit::TestFixture {
@@ -17,7 +18,7 @@ class testExpressionEvaluator : public CppUnit::TestFixture {
   CPPUNIT_TEST_SUITE_END();
 
 public:
-  testExpressionEvaluator() {} // for crappy pats
+  testExpressionEvaluator() {ROOT::Cintex::Cintex::Enable();} // for crappy pats
   ~testExpressionEvaluator(){}
   void checkAll(); 
 

--- a/CondFormats/BTauObjects/src/BTagCalibration.cc
+++ b/CondFormats/BTauObjects/src/BTagCalibration.cc
@@ -60,7 +60,7 @@ void BTagCalibration::readCSV(std::istream &s)
   }
 }
 
-void BTagCalibration::makeCSV(ostream &s) const
+void BTagCalibration::makeCSV(std::ostream &s) const
 { 
   s << tagger_ << ";" << BTagEntry::makeCSVHeader();
   for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i 

--- a/CondFormats/BTauObjects/src/BTagEntry.cc
+++ b/CondFormats/BTauObjects/src/BTagEntry.cc
@@ -124,7 +124,7 @@ BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
 // e.g. "x<0 ? 1 : x<1 ? 2 : x<2 ? 3 : 4"
 std::string th1ToFormulaLin(const TH1* hist) {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
   std::stringstream buff;
   buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
   for (int i=1; i<nbins+1; ++i) {
@@ -187,7 +187,7 @@ BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
   params(p)
 {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
 
   // overwrite bounds with histo values
   if (params.operatingPoint == BTagEntry::OP_RESHAPING) {

--- a/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
+++ b/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
@@ -131,7 +131,7 @@ throw std::exception();
 // e.g. "x<0 ? 1 : x<1 ? 2 : x<2 ? 3 : 4"
 std::string th1ToFormulaLin(const TH1* hist) {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
   std::stringstream buff;
   buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
   for (int i=1; i<nbins+1; ++i) {
@@ -194,7 +194,7 @@ BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
   params(p)
 {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
 
   // overwrite bounds with histo values
   if (params.operatingPoint == BTagEntry::OP_RESHAPING) {
@@ -328,7 +328,7 @@ void BTagCalibration::readCSV(std::istream &s)
   }
 }
 
-void BTagCalibration::makeCSV(ostream &s) const
+void BTagCalibration::makeCSV(std::ostream &s) const
 { 
   s << tagger_ << ";" << BTagEntry::makeCSVHeader();
   for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i 


### PR DESCRIPTION
Should fix the mess done with #8480 and #8481  and align ROOT6 and ROOT5 builds even more.
