### PR TITLE
 Remove hardcoded InputTag in PATPhotonProducer (same as #7946 , rebased on smth later)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.cc
@@ -34,8 +34,8 @@ PATPhotonProducer::PATPhotonProducer(const edm::ParameterSet & iConfig) :
 {
   // initialize the configurables
   photonToken_ = consumes<edm::View<reco::Photon> >(iConfig.getParameter<edm::InputTag>("photonSource"));
-  electronToken_ = consumes<reco::GsfElectronCollection>(edm::InputTag("gedGsfElectrons"));
-  hConversionsToken_ = consumes<reco::ConversionCollection>(edm::InputTag("allConversions"));
+  electronToken_ = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electronSource"));
+  hConversionsToken_ = consumes<reco::ConversionCollection>(iConfig.getParameter<edm::InputTag>("conversionSource"));
   beamLineToken_ = consumes<reco::BeamSpot>(iConfig.getParameter<edm::InputTag>("beamLineSrc"));
   embedSuperCluster_ = iConfig.getParameter<bool>("embedSuperCluster");
   embedSeedCluster_ = iConfig.getParameter<bool>( "embedSeedCluster" );
@@ -372,6 +372,7 @@ void PATPhotonProducer::fillDescriptions(edm::ConfigurationDescriptions & descri
   // input source
   iDesc.add<edm::InputTag>("photonSource", edm::InputTag("no default"))->setComment("input collection");
   iDesc.add<edm::InputTag>("electronSource", edm::InputTag("no default"))->setComment("input collection");
+  iDesc.add<edm::InputTag>("conversionSource", edm::InputTag("allConversions"))->setComment("input collection");
 
   iDesc.add<edm::InputTag>("reducedBarrelRecHitCollection", edm::InputTag("reducedEcalRecHitsEB"));
   iDesc.add<edm::InputTag>("reducedEndcapRecHitCollection", edm::InputTag("reducedEcalRecHitsEE"));  

--- a/PhysicsTools/PatAlgos/python/producersLayer1/photonProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/photonProducer_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 patPhotons = cms.EDProducer("PATPhotonProducer",
     # input collection
     photonSource = cms.InputTag("gedPhotons"),
-             
+    electronSource = cms.InputTag("gedGsfElectrons"),                            
     beamLineSrc = cms.InputTag("offlineBeamSpot"),
 
     reducedBarrelRecHitCollection = cms.InputTag("reducedEcalRecHitsEB"),

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -48,6 +48,7 @@ def miniAOD_customizeCommon(process):
     process.patPhotons.embedPreshowerClusters         = False  ## process.patPhotons.embed in AOD externally stored the photon's preshower clusters
     process.patPhotons.embedRecHits         = False  ## process.patPhotons.embed in AOD externally stored the RecHits - can be called from the PATPhotonProducer
     process.patPhotons.photonSource = cms.InputTag("reducedEgamma","reducedGedPhotons")
+    process.patPhotons.electronSource = cms.InputTag("reducedEgamma","reducedGedGsfElectrons")
     process.patPhotons.photonIDSources = cms.PSet(
                 PhotonCutBasedIDLoose = cms.InputTag('reducedEgamma',
                                                       'PhotonCutBasedIDLoose'),


### PR DESCRIPTION
(copy-pasting from #7946)

The hardcoded inputtag were preventing the electronVeto in miniAOD to work properly. Different superClusterRefs for (slimmedPhotons and gedGsfElectrons) were indeed compared returning identically false.
Changed accordingly the configuration to produce miniAOD.
