### PR TITLE
Backport changes from ROOT6 IB for code commonality (Sim again)

### DIFF
--- a/SimDataFormats/CaloHit/src/CastorShowerEvent.cc
+++ b/SimDataFormats/CaloHit/src/CastorShowerEvent.cc
@@ -1,8 +1,6 @@
 #include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
 #include <iostream>
 
-ClassImp(CastorShowerEvent)
-
 CastorShowerEvent::CastorShowerEvent() {
    // Clear();
    // std::cout << "\n    *** CastorShowerEvent object created ***    " << std::endl;

--- a/SimDataFormats/CaloHit/src/CastorShowerLibraryInfo.cc
+++ b/SimDataFormats/CaloHit/src/CastorShowerLibraryInfo.cc
@@ -1,8 +1,6 @@
 #include "SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h"
 #include <iostream>
 
-ClassImp(CastorShowerLibraryInfo)
-
 CastorShowerLibraryInfo::CastorShowerLibraryInfo() {
    // Clear();
    // std::cout << "\n    *** CastorShowerLibraryInfo object created ***    " << std::endl;

--- a/SimDataFormats/CaloHit/src/classes.h
+++ b/SimDataFormats/CaloHit/src/classes.h
@@ -1,3 +1,5 @@
+#include "SimDataFormats/CaloHit/interface/CastorShowerEvent.h"
+#include "SimDataFormats/CaloHit/interface/CastorShowerLibraryInfo.h"
 #include "SimDataFormats/CaloHit/interface/HFShowerLibraryEventInfo.h"
 #include "SimDataFormats/CaloHit/interface/HFShowerPhoton.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHit.h"


### PR DESCRIPTION
Port back changes from the ROOT6 IB in the Sim L2 category that are harmless or beneficial for the ROOT5 IB, for code commonality. After this PR is merged, all three affected files will be identical in the two releases.
