### PR TITLE
Backport changes from ROOT6 IB for code commonality (reco again)

### DIFF
--- a/DataFormats/BTauReco/src/classes_def.xml
+++ b/DataFormats/BTauReco/src/classes_def.xml
@@ -152,19 +152,15 @@
 
   <!-- Dictionary for the association in SVTagInfoProxy-->
   <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::Vertex> > > >" persistent="false"/>
-  <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::Vertex> > >" persistent="false"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::Vertex> > >"/>
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::SecondaryVertexTagInfo>, std::vector<reco::Vertex>, unsigned int > > >" persistent="false"/>
-  <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
-  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::SecondaryVertexTagInfo>, std::vector<reco::Vertex>, unsigned int > >" persistent="false">
+  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::SecondaryVertexTagInfo>, std::vector<reco::Vertex>, unsigned int > >">
     <field name="transientMap_" transient="true" />
   </class>
   <class name="edm::Wrapper<edm::helpers::KeyVal<edm::RefProd<std::vector<reco::CandSecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::VertexCompositePtrCandidate> > > >" persistent="false"/>
-  <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::CandSecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::VertexCompositePtrCandidate> > >" persistent="false"/>
+  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::CandSecondaryVertexTagInfo> >, edm::RefProd<std::vector<reco::VertexCompositePtrCandidate> > >"/>
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToMany<std::vector<reco::CandSecondaryVertexTagInfo>, std::vector<reco::VertexCompositePtrCandidate>, unsigned int > > >" persistent="false"/>
-  <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
-  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::CandSecondaryVertexTagInfo>, std::vector<reco::VertexCompositePtrCandidate>, unsigned int > >" persistent="false">
+  <class name="edm::AssociationMap<edm::OneToMany<std::vector<reco::CandSecondaryVertexTagInfo>, std::vector<reco::VertexCompositePtrCandidate>, unsigned int > >">
     <field name="transientMap_" transient="true" />
   </class>
 

--- a/DataFormats/Math/src/classes.h
+++ b/DataFormats/Math/src/classes.h
@@ -1,7 +1,6 @@
 #define G__DICTIONARY
-
-
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
+
 #ifdef CMS_NOCXX11
 #define SMATRIX_USE_COMPUTATION
 #else

--- a/DataFormats/TrajectoryState/BuildFile.xml
+++ b/DataFormats/TrajectoryState/BuildFile.xml
@@ -1,6 +1,7 @@
-<use   name="boost_header"/>
-<use   name="DataFormats/Math"/>
 
+<use   name="DataFormats/Math"/>
+<use   name="boost_header"/>
+<use   name="rootcore"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
+++ b/TrackingTools/AnalyticalJacobians/src/JacobianCurvilinearToLocal.cc
@@ -34,7 +34,7 @@ JacobianCurvilinearToLocal::
 JacobianCurvilinearToLocal(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
 			   const GlobalTrajectoryParameters& globalParameters,
-			   const MagneticField&) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
  
   // GlobalPoint  x =  globalParameters.position();
   // GlobalVector h  = magField.inInverseGeV(x);

--- a/TrackingTools/AnalyticalJacobians/src/JacobianLocalToCurvilinear.cc
+++ b/TrackingTools/AnalyticalJacobians/src/JacobianLocalToCurvilinear.cc
@@ -30,7 +30,7 @@ JacobianLocalToCurvilinear::
 JacobianLocalToCurvilinear(const Surface& surface, 
 			   const LocalTrajectoryParameters& localParameters,
 			   const GlobalTrajectoryParameters& globalParameters,
-			   const MagneticField&) : theJacobian(ROOT::Math::SMatrixNoInit()) {
+			   const MagneticField& magField) : theJacobian(ROOT::Math::SMatrixNoInit()) {
 
   // GlobalPoint  x =  globalParameters.position();
   // GlobalVector h  = magField.inInverseGeV(x);

--- a/TrackingTools/PatternTools/src/classes_def.xml
+++ b/TrackingTools/PatternTools/src/classes_def.xml
@@ -1,20 +1,17 @@
 <lcgdict>
   <class name="Trajectory"/>
-  <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
   <class name="std::vector<Trajectory>" />
   <class name="edm::Wrapper<std::vector<Trajectory> >" persistent="false"/>
   <class name="edm::RefProd<std::vector<Trajectory> >"/>
   <class name="edm::Ref<std::vector<Trajectory>, Trajectory, edm::refhelper::FindUsingAdvance<std::vector<Trajectory>, Trajectory> >"/>
 
   <class name="MomentumConstraint"/>
-  <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
-  <class name="std::vector<MomentumConstraint>" persistent="false"/>
+  <class name="std::vector<MomentumConstraint>"/>
   <class name="edm::Wrapper<std::vector<MomentumConstraint> >" persistent="false"/>
   <class name="edm::RefProd<std::vector<MomentumConstraint> >"/>
 
   <class name="VertexConstraint"/>
-  <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
-  <class name="std::vector<VertexConstraint>" persistent="false"/>
+  <class name="std::vector<VertexConstraint>"/>
   <class name="edm::Wrapper<std::vector<VertexConstraint> >" persistent="false"/>
   <class name="edm::RefProd<std::vector<VertexConstraint> >"/>
 
@@ -63,4 +60,6 @@
   <class name="std::vector<TrajAnnealing>" persistent="false"/>
   <class name="edm::Wrapper<std::vector<TrajAnnealing> >" persistent="false"/>
 
+  <!-- This next spec should not really be here, but it is a workaround for a ROOT6 problem (Danilo Piparo).-->
+  <class name="GlobalErrorBase<double,ErrorMatrixTag>" />
 </lcgdict>


### PR DESCRIPTION
Port back minor changes from the ROOT6 IB in the Reco L2 category that are harmless or beneficial for the ROOT5 IB, for code commonality. After this PR is merged, three of the six affected files will be identical in the two releases, while the other three will still have some differences between the ROOT5 and ROOT6 IB's, but fewer such differences.  These changes were tested with the short relval matrix and all tests passed.
The changes are:
1) DataFormats/BTauReco/src/classes_def.xml (remove deprecated obsolete attributes and the comments referring to them)
2) DataFormats/Math/src/classes.h (modify white space)
3) DataFormats/TrajectoryState/BuildFile.xml (modify white space and add link dependency)
4) TrackingTools/AnalyticalJacobians/src/\* (trivial. add names for arguments)
5) TrackingTools/PatternTools/src/classes_def.xml (remove deprecated obsolete attributes and the comments referring them, and add one dictionary) 
