### PR TITLE
undo damage done with percolating Detector Description outside geometry building implementation in TrackerGeometry

### DIFF
--- a/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
+++ b/Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h
@@ -2,7 +2,6 @@
 #define Geometry_TrackerGeometryBuilder_TrackerGeometry_H
 
 #include "Geometry/CommonDetUnit/interface/TrackingGeometry.h"
-#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/CommonDetUnit/interface/GeomDetEnumerators.h"
 #include "Geometry/CommonDetUnit/interface/TrackerGeomDet.h"
 
@@ -98,8 +97,6 @@ private:
 
   GeomDetEnumerators::SubDetector theSubDetTypeMap[6];
   unsigned int theNumberOfLayers[6];
-
-  static const  GeomDetEnumerators::SubDetector geometricDetToGeomDet(GeometricDet::GDEnumType gdenum);
 
 };
 

--- a/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
+++ b/Geometry/TrackerGeometryBuilder/src/TrackerGeometry.cc
@@ -14,6 +14,32 @@
 #include <iostream>
 #include <map>
 
+
+#include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
+
+namespace {
+GeomDetEnumerators::SubDetector
+geometricDetToGeomDet(GeometricDet::GDEnumType gdenum) {
+  // provide a map between the GeometricDet enumerators and the GeomDet enumerators of the possible tracker subdetectors
+  if(gdenum == GeometricDet::GDEnumType::PixelBarrel ) return GeomDetEnumerators::SubDetector::PixelBarrel;
+  if(gdenum == GeometricDet::GDEnumType::PixelEndCap) return GeomDetEnumerators::SubDetector::PixelEndcap;
+  if(gdenum == GeometricDet::GDEnumType::TIB) return GeomDetEnumerators::SubDetector::TIB;
+  if(gdenum == GeometricDet::GDEnumType::TID) return GeomDetEnumerators::SubDetector::TID;
+  if(gdenum == GeometricDet::GDEnumType::TOB) return GeomDetEnumerators::SubDetector::TOB;
+  if(gdenum == GeometricDet::GDEnumType::TEC) return GeomDetEnumerators::SubDetector::TEC;
+  if(gdenum == GeometricDet::GDEnumType::PixelPhase1Barrel) return GeomDetEnumerators::SubDetector::P1PXB;
+  if(gdenum == GeometricDet::GDEnumType::PixelPhase1EndCap) return GeomDetEnumerators::SubDetector::P1PXEC;
+  if(gdenum == GeometricDet::GDEnumType::PixelPhase2EndCap) return GeomDetEnumerators::SubDetector::P2PXEC;
+  if(gdenum == GeometricDet::GDEnumType::OTPhase2Barrel) return GeomDetEnumerators::SubDetector::P2OTB;
+  if(gdenum == GeometricDet::GDEnumType::OTPhase2EndCap) return GeomDetEnumerators::SubDetector::P2OTEC;
+  return GeomDetEnumerators::SubDetector::invalidDet;
+}
+                                      
+   
+
+}
+
+
 TrackerGeometry::TrackerGeometry(GeometricDet const* gd) :  theTrackerDet(gd)
 {
   for(unsigned int i=0;i<6;++i) {
@@ -227,21 +253,4 @@ const TrackerGeometry::DetIdContainer&
 TrackerGeometry::detIds()   const 
 {
   return theDetIds;
-}
-
-const GeomDetEnumerators::SubDetector 
-TrackerGeometry::geometricDetToGeomDet(GeometricDet::GDEnumType gdenum) {
-  // provide a map between the GeometricDet enumerators and the GeomDet enumerators of the possible tracker subdetectors
-  if(gdenum == GeometricDet::GDEnumType::PixelBarrel ) return GeomDetEnumerators::SubDetector::PixelBarrel;
-  if(gdenum == GeometricDet::GDEnumType::PixelEndCap) return GeomDetEnumerators::SubDetector::PixelEndcap;
-  if(gdenum == GeometricDet::GDEnumType::TIB) return GeomDetEnumerators::SubDetector::TIB;
-  if(gdenum == GeometricDet::GDEnumType::TID) return GeomDetEnumerators::SubDetector::TID;
-  if(gdenum == GeometricDet::GDEnumType::TOB) return GeomDetEnumerators::SubDetector::TOB;
-  if(gdenum == GeometricDet::GDEnumType::TEC) return GeomDetEnumerators::SubDetector::TEC;
-  if(gdenum == GeometricDet::GDEnumType::PixelPhase1Barrel) return GeomDetEnumerators::SubDetector::P1PXB;
-  if(gdenum == GeometricDet::GDEnumType::PixelPhase1EndCap) return GeomDetEnumerators::SubDetector::P1PXEC;
-  if(gdenum == GeometricDet::GDEnumType::PixelPhase2EndCap) return GeomDetEnumerators::SubDetector::P2PXEC;
-  if(gdenum == GeometricDet::GDEnumType::OTPhase2Barrel) return GeomDetEnumerators::SubDetector::P2OTB;
-  if(gdenum == GeometricDet::GDEnumType::OTPhase2EndCap) return GeomDetEnumerators::SubDetector::P2OTEC;
-  return GeomDetEnumerators::SubDetector::invalidDet;
 }

--- a/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/src/PixelFitterByHelixProjections.cc
@@ -62,7 +62,7 @@ namespace {
     return (std::abs(dr) > 1.e-3f) ? dz/dr : 0;
   }
 
-  inline float func_phi(float xC, float yC, int charge) {
+  inline float phi(float xC, float yC, int charge) {
     return  (charge>0) ? std::atan2(xC,-yC) :  std::atan2(-xC,yC);
   }
 
@@ -153,7 +153,7 @@ reco::Track* PixelFitterByHelixProjections::run(
     valPt = (invPt > 1.e-4f) ? 1.f/invPt : 1.e4f;
     CircleFromThreePoints::Vector2D center = circle.center();
     valTip = iCharge * (center.mag()-1.f/curvature);
-    valPhi = func_phi(center.x(), center.y(), iCharge);
+    valPhi = phi(center.x(), center.y(), iCharge);
   } 
   else {
     valPt = 1.e4f; 


### PR DESCRIPTION
remove GeometricDet include from the interface of TrackerGeometry
Detector Description SHALL NOT percolate to computational code.
It SHALL be used only in the implementation of the geometry builders

@venturia here is the fix
