### PR TITLE
MuonIdProducer code cleaning

### DIFF
--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -123,7 +123,8 @@ muIsoExtractorCalo_(0),muIsoExtractorTrack_(0),muIsoExtractorJet_(0)
      << "Debugging mode with truth matching is turned on!!! Make sure you understand what you are doing!\n"
      << "========================================================================\n";
    if (fillGlobalTrackQuality_){
-     globalTrackQualityInputTag_ = iConfig.getParameter<edm::InputTag>("globalTrackQualityInputTag");
+     const auto& glbQualTag = iConfig.getParameter<edm::InputTag>("globalTrackQualityInputTag");
+     glbQualToken_ = consumes<edm::ValueMap<reco::MuonQuality> >(glbQualTag);
    }
 
    if (fillTrackerKink_) {
@@ -136,7 +137,6 @@ muIsoExtractorCalo_(0),muIsoExtractorTrack_(0),muIsoExtractorJet_(0)
 
    edm::InputTag rpcHitTag("rpcRecHits");
    rpcHitToken_ = consumes<RPCRecHitCollection>(rpcHitTag);
-   glbQualToken_ = consumes<edm::ValueMap<reco::MuonQuality> >(globalTrackQualityInputTag_);
    
 
    //Consumes... UGH
@@ -250,6 +250,7 @@ void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup)
    }
 
    iEvent.getByToken(rpcHitToken_, rpcHitHandle_);
+   if (fillGlobalTrackQuality_) iEvent.getByToken(glbQualToken_, glbQualHandle_);
 
 }
 
@@ -1210,11 +1211,8 @@ double MuonIdProducer::phiOfMuonIneteractionRegion( const reco::Muon& muon ) con
 
 void MuonIdProducer::fillGlbQuality(edm::Event& iEvent, const edm::EventSetup& iSetup, reco::Muon& aMuon)
 {
-  edm::Handle<edm::ValueMap<reco::MuonQuality> > glbQualH;
-  iEvent.getByToken(glbQualToken_, glbQualH);
-
-  if(aMuon.isGlobalMuon() && glbQualH.isValid() && !glbQualH.failedToGet()) {
-    aMuon.setCombinedQuality((*glbQualH)[aMuon.combinedMuon()]);
+  if(aMuon.isGlobalMuon() && glbQualHandle_.isValid() && !glbQualHandle_.failedToGet()) {
+    aMuon.setCombinedQuality((*glbQualHandle_)[aMuon.combinedMuon()]);
   }
 
   LogDebug("MuonIdentification") << "tkChiVal " << aMuon.combinedQuality().trkRelChi2;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -248,6 +248,9 @@ void MuonIdProducer::init(edm::Event& iEvent, const edm::EventSetup& iSetup)
       }
       else throw cms::Exception("FatalError") << "Unknown input collection type: #" << ICTypes::toStr(inputType);
    }
+
+   iEvent.getByToken(rpcHitToken_, rpcHitHandle_);
+
 }
 
 reco::Muon MuonIdProducer::makeMuon(edm::Event& iEvent, const edm::EventSetup& iSetup,
@@ -801,15 +804,12 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
    }
    if ( ! fillMatching_ && ! aMuon.isTrackerMuon() && ! aMuon.isRPCMuon() ) return;
 
-  edm::Handle<RPCRecHitCollection> rpcRecHits;
-  iEvent.getByToken(rpcHitToken_, rpcRecHits);
-
    // fill muon match info
    std::vector<reco::MuonChamberMatch> muonChamberMatches;
    unsigned int nubmerOfMatchesAccordingToTrackAssociator = 0;
    for ( const auto& chamber : info.chambers )
    {
-     if (chamber.id.subdetId() == 3 && rpcRecHits.isValid()  ) continue; // Skip RPC chambers, they are taken care of below)
+     if (chamber.id.subdetId() == 3 && rpcHitHandle_.isValid()  ) continue; // Skip RPC chambers, they are taken care of below)
      reco::MuonChamberMatch matchedChamber;
 
      const auto& lErr = chamber.tState.localError();
@@ -879,7 +879,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
    }
 
    // Fill RPC info
-   if ( rpcRecHits.isValid() )
+   if ( rpcHitHandle_.isValid() )
    {
      for ( const auto& chamber : info.chambers )
      {
@@ -908,7 +908,7 @@ void MuonIdProducer::fillMuonId(edm::Event& iEvent, const edm::EventSetup& iSetu
 
        matchedChamber.id = chamber.id;
 
-       for ( const auto& rpcRecHit : *rpcRecHits )
+       for ( const auto& rpcRecHit : *rpcHitHandle_ )
        {
          reco::MuonRPCHitMatch rpcHitMatch;
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.cc
@@ -9,21 +9,9 @@
 //
 
 
-// system include files
-#include <memory>
-
 // user include files
-#include "FWCore/Framework/interface/Frameworkfwd.h"
-//#include "FWCore/Framework/interface/EDProducer.h"
+#include "RecoMuon/MuonIdentification/plugins/MuonIdProducer.h"
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-
-#include "DataFormats/Common/interface/Handle.h"
-#include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/MuonReco/interface/MuonCocktails.h"
 #include "DataFormats/MuonReco/interface/MuonTime.h"
 #include "DataFormats/MuonReco/interface/MuonTimeExtra.h"
@@ -31,15 +19,8 @@
 #include "DataFormats/RecoCandidate/interface/IsoDeposit.h"
 #include "DataFormats/RecoCandidate/interface/IsoDepositFwd.h"
 
-#include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
-
-#include <boost/regex.hpp>
-#include "RecoMuon/MuonIdentification/plugins/MuonIdProducer.h"
-
 #include "PhysicsTools/IsolationAlgos/interface/IsoDepositExtractorFactory.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
-
-#include <algorithm>
 
 #include "DataFormats/MuonDetId/interface/MuonSubdetId.h"
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
@@ -47,7 +28,6 @@
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 
 #include "RecoMuon/MuonIdentification/interface/MuonMesh.h"
-
 
 #include "RecoMuon/MuonIdentification/interface/MuonKinkFinder.h"
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -199,7 +199,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    edm::EDGetTokenT<RPCRecHitCollection> rpcHitToken_;
    edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > glbQualToken_;
 
-
+   edm::Handle<RPCRecHitCollection> rpcHitHandle_;
    
    MuonCaloCompatibility muonCaloCompatibility_;
    reco::isodeposit::IsoDepositExtractor* muIsoExtractorCalo_;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -132,6 +132,9 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
        else if ( s == "outer tracks" ) return OUTER_TRACKS;
        else if ( s == "links" ) return LINKS;
        else if ( s == "muons" ) return MUONS;
+       else if ( s == "tev firstHit" ) return TEV_FIRSTHIT;
+       else if ( s == "tev picky"    ) return TEV_PICKY   ;
+       else if ( s == "tev dyt"      ) return TEV_DYT     ;
 
        throw cms::Exception("FatalError") << "Unknown input collection type: " << s;
      }
@@ -142,7 +145,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
          case OUTER_TRACKS: return "outer tracks";
          case LINKS       : return "links"       ;
          case MUONS       : return "muons"       ;
-         case TEV_FIRSTHIT: return "tev firsthit";
+         case TEV_FIRSTHIT: return "tev firstHit";
          case TEV_PICKY   : return "tev picky"   ;
          case TEV_DYT     : return "tev dyt"     ;
          default: throw cms::Exception("FatalError") << "Unknown input collection type";

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -200,6 +200,7 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    edm::EDGetTokenT<edm::ValueMap<reco::MuonQuality> > glbQualToken_;
 
    edm::Handle<RPCRecHitCollection> rpcHitHandle_;
+   edm::Handle<edm::ValueMap<reco::MuonQuality> > glbQualHandle_;
    
    MuonCaloCompatibility muonCaloCompatibility_;
    reco::isodeposit::IsoDepositExtractor* muIsoExtractorCalo_;

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -117,9 +117,41 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
      
    TrackDetectorAssociator trackAssociator_;
    TrackAssociatorParameters parameters_;
-   
+
+   struct ICTypes
+   {
+     enum ICTypeKey {
+       INNER_TRACKS, OUTER_TRACKS,
+       LINKS, MUONS,
+       TEV_FIRSTHIT, TEV_PICKY, TEV_DYT,
+       NONE
+     };
+
+     static ICTypeKey toKey(const std::string& s) {
+       if      ( s == "inner tracks" ) return INNER_TRACKS;
+       else if ( s == "outer tracks" ) return OUTER_TRACKS;
+       else if ( s == "links" ) return LINKS;
+       else if ( s == "muons" ) return MUONS;
+
+       throw cms::Exception("FatalError") << "Unknown input collection type: " << s;
+     }
+
+     static std::string toStr(const ICTypeKey k) {
+       switch ( k ) {
+         case INNER_TRACKS: return "inner tracks";
+         case OUTER_TRACKS: return "outer tracks";
+         case LINKS       : return "links"       ;
+         case MUONS       : return "muons"       ;
+         case TEV_FIRSTHIT: return "tev firsthit";
+         case TEV_PICKY   : return "tev picky"   ;
+         case TEV_DYT     : return "tev dyt"     ;
+         default: throw cms::Exception("FatalError") << "Unknown input collection type";
+       }
+       return "";
+     }
+   };
    std::vector<edm::InputTag> inputCollectionLabels_;
-   std::vector<std::string>   inputCollectionTypes_;
+   std::vector<ICTypes::ICTypeKey> inputCollectionTypes_;
 
    MuonTimingFiller* theTimingFiller_;
 

--- a/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
+++ b/RecoMuon/MuonIdentification/plugins/MuonIdProducer.h
@@ -114,6 +114,10 @@ class MuonIdProducer : public edm::stream::EDProducer<> {
    double phiOfMuonIneteractionRegion( const reco::Muon& muon ) const;
 
    bool checkLinks(const reco::MuonTrackLinks*) const ;
+   inline bool approxEqual(const double a, const double b, const double tol=1E-3) const
+   {
+     return std::abs(a-b) < tol;
+   }
      
    TrackDetectorAssociator trackAssociator_;
    TrackAssociatorParameters parameters_;


### PR DESCRIPTION
This is cleanup of MuonIdProducer in C++ code level (and simplification with C++0x syntax).
This is purely technical code change, basicaly no change in logic. 

Thus output must be bitwise identical. - no difference with very small statistics for muons using the runEdmFileComparison.py tool.
Small improvement of CPU timing is observed TTbarLepton Pileup RelVal sample (1.314 -> 1.251 sec/evt).
