### PR TITLE
Make ROOT5 more consistent with ROOT6 branch

### DIFF
--- a/DataFormats/TestObjects/src/classes.h
+++ b/DataFormats/TestObjects/src/classes.h
@@ -21,6 +21,9 @@
 #include "DataFormats/Common/interface/RefToBaseProd.h"
 #include "DataFormats/Common/interface/RefToBaseVector.h"
 
+#include "DataFormats/Provenance/interface/EventID.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
+
 namespace DataFormats_TestObjects {
 struct dictionary {
   edm::Wrapper<edmtest::DummyProduct> dummyw12;
@@ -82,5 +85,7 @@ struct dictionary {
   edm::reftobase::VectorHolder<edmtest::Thing, edm::RefVector<std::vector<edmtest::Thing> > > vectorHolderThing;
 
   edm::Wrapper<edmtest::DeleteEarly> wrapperDeleteEarly;
+  edm::Wrapper<edm::EventID> wrapperEventID;
+  edm::Wrapper<edm::ProductID> wrapperProductID;
 };
 }

--- a/DataFormats/TestObjects/src/classes_def.xml
+++ b/DataFormats/TestObjects/src/classes_def.xml
@@ -115,10 +115,10 @@
  <class name="edm::PtrVector<edmtest::Thing>"/>
  <class name="edm::Ref<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
  <class name="edm::RefVector<std::vector<edmtest::Thing>,edmtest::Thing,edm::refhelper::FindUsingAdvance<std::vector<edmtest::Thing>,edmtest::Thing> >"/>
- <class name="edmtest::TrackOfThings"/>
- <class name="std::vector<edmtest::TrackOfThings>" ClassVersion="10">
-  <version ClassVersion="10" checksum="1189167006"/>
+ <class name="edmtest::TrackOfThings" ClassVersion="6">
+  <version ClassVersion="6" checksum="545056495"/>
  </class>
+ <class name="std::vector<edmtest::TrackOfThings>"/>
  <class name="edm::Wrapper<std::vector<edmtest::TrackOfThings> >"/>
  <class name="edm::Wrapper<edmtest::Thing>"/>
  <class name="edm::Wrapper<edmtest::ThingWithMerge>"/>
@@ -145,6 +145,8 @@
  <class name="edm::Wrapper<edmtestprod::X0123456789012345678901234567890123456789012345678901234567890123456789012345678901>"/>
  <class name="edmtest::DeleteEarly" ClassVersion="3">
    <version ClassVersion="3" checksum="1338867524"/>
-</class>   
+ </class>
  <class name="edm::Wrapper<edmtest::DeleteEarly>"/>
+ <class name="edm::Wrapper<edm::EventID>"/>
+ <class name="edm::Wrapper<edm::ProductID>"/>
 </lcgdict>


### PR DESCRIPTION
Note this is needed to make part of the pull
request related to vector<Ptr> auto merge cleanly.
It affects only data formats used in Core
unit tests.
