### PR TITLE
Fixes for compilation errors in CondFormats and RecoBTag

### DIFF
--- a/CondFormats/BTauObjects/src/BTagCalibration.cc
+++ b/CondFormats/BTauObjects/src/BTagCalibration.cc
@@ -60,7 +60,7 @@ void BTagCalibration::readCSV(std::istream &s)
   }
 }
 
-void BTagCalibration::makeCSV(ostream &s) const
+void BTagCalibration::makeCSV(std::ostream &s) const
 { 
   s << tagger_ << ";" << BTagEntry::makeCSVHeader();
   for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i 

--- a/CondFormats/BTauObjects/src/BTagEntry.cc
+++ b/CondFormats/BTauObjects/src/BTagEntry.cc
@@ -124,7 +124,7 @@ BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
 // e.g. "x<0 ? 1 : x<1 ? 2 : x<2 ? 3 : 4"
 std::string th1ToFormulaLin(const TH1* hist) {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
   std::stringstream buff;
   buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
   for (int i=1; i<nbins+1; ++i) {
@@ -187,7 +187,7 @@ BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
   params(p)
 {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
 
   // overwrite bounds with histo values
   if (params.operatingPoint == BTagEntry::OP_RESHAPING) {

--- a/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
+++ b/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
@@ -131,7 +131,7 @@ throw std::exception();
 // e.g. "x<0 ? 1 : x<1 ? 2 : x<2 ? 3 : 4"
 std::string th1ToFormulaLin(const TH1* hist) {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
   std::stringstream buff;
   buff << "x<" << axis->GetBinLowEdge(1) << " ? 0. : ";  // default value
   for (int i=1; i<nbins+1; ++i) {
@@ -194,7 +194,7 @@ BTagEntry::BTagEntry(const TH1* hist, BTagEntry::Parameters p):
   params(p)
 {
   int nbins = hist->GetNbinsX();
-  TAxis * axis = hist->GetXaxis();
+  TAxis const* axis = hist->GetXaxis();
 
   // overwrite bounds with histo values
   if (params.operatingPoint == BTagEntry::OP_RESHAPING) {
@@ -328,7 +328,7 @@ void BTagCalibration::readCSV(std::istream &s)
   }
 }
 
-void BTagCalibration::makeCSV(ostream &s) const
+void BTagCalibration::makeCSV(std::ostream &s) const
 { 
   s << tagger_ << ";" << BTagEntry::makeCSVHeader();
   for (std::map<std::string, std::vector<BTagEntry> >::const_iterator i 


### PR DESCRIPTION
This trivial pull request fixes the compilation errors in CondFormats/BTauObjects and RecoBTag/PerformanceDB.  The same changes are already in 7_5_X.
Please merge as soon as convenient, bypassing L2 signatures if not signed promptly.
Note: The preexisting build error in Fireworks/Core is unaffected by this PR.
