### PR TITLE
Fix creating a pat::MET from a reco::MET pointing to a pat::MET

### DIFF
--- a/DataFormats/PatCandidates/src/MET.cc
+++ b/DataFormats/PatCandidates/src/MET.cc
@@ -18,6 +18,8 @@ MET::MET(const reco::MET & aMET) : PATObject<reco::MET>(aMET) {
     if (calo != 0) caloMET_.push_back(calo->getSpecific());
     const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(&aMET);
     if (pf != 0) pfMET_.push_back(pf->getSpecific());
+    const pat::MET * pm = dynamic_cast<const pat::MET *>(&aMET);
+    if (pm != 0) this->operator=(*pm);
 }
 
 
@@ -27,6 +29,8 @@ MET::MET(const edm::RefToBase<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETR
     if (calo != 0) caloMET_.push_back(calo->getSpecific());
     const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
     if (pf != 0) pfMET_.push_back(pf->getSpecific());
+    const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
+    if (pm != 0) this->operator=(*pm);
 }
 
 /// constructor from ref to reco::MET
@@ -35,6 +39,8 @@ MET::MET(const edm::Ptr<reco::MET> & aMETRef) : PATObject<reco::MET>(aMETRef) {
     if (calo != 0) caloMET_.push_back(calo->getSpecific());
     const reco::PFMET * pf = dynamic_cast<const reco::PFMET *>(aMETRef.get());
     if (pf != 0) pfMET_.push_back(pf->getSpecific());
+    const pat::MET * pm = dynamic_cast<const pat::MET *>(aMETRef.get());
+    if (pm != 0) this->operator=(*pm);
 }
 
 /// copy constructor


### PR DESCRIPTION
Before, if a `pat::MET` was created from a base class c++ or edm pointer, all the data members not in the base class `reco::MET` were not copied. 
And apparently PyFWLite can decide to call the constructor with `reco::MET` argument even when it should know that the object it has in hand is a `pat::MET`, so this fix is important if somebody tries to copy a `pat::MET`object by value in PyFWLite (e.g. to modify it later)

Let me know if I should make the PR also to `CMSSW_7_5_X` or to `CMSSW_7_4_ROOT6_X`
(this versy same branch merges also in `CMSSW_7_5_X`)

@cbernet @arizzi 
