### PR TITLE
Commonality with ROOT6 version for CommonTools/Utils

### DIFF
--- a/CommonTools/Utils/src/ExpressionVar.cc
+++ b/CommonTools/Utils/src/ExpressionVar.cc
@@ -1,142 +1,217 @@
 #include "CommonTools/Utils/src/ExpressionVar.h"
+#include "CommonTools/Utils/src/MethodInvoker.h"
+
 #include "FWCore/Utilities/interface/ObjectWithDict.h"
 #include "FWCore/Utilities/interface/FunctionWithDict.h"
 #include "FWCore/Utilities/interface/MemberWithDict.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
+
+#include <cassert>
 #include <map>
-#include <assert.h>
+
 using namespace reco::parser;
 using namespace std;
 
-ExpressionVar::ExpressionVar(const vector<MethodInvoker>& methods, method::TypeCode retType) : 
-  methods_(methods), retType_(retType) { 
-    initObjects_();
-}
-
-ExpressionVar::ExpressionVar(const ExpressionVar &other) :
-  methods_(other.methods_), retType_(other.retType_) { 
-    initObjects_();
-}
-
-ExpressionVar::~ExpressionVar() {
-    for(std::vector<edm::ObjectWithDict>::iterator it = objects_.begin(); it != objects_.end(); ++it) {
-        delStorage(*it);
+void ExpressionVar::initObjects_()
+{
+  objects_.resize(methods_.size());
+  std::vector<edm::ObjectWithDict>::iterator IO = objects_.begin();
+  for (std::vector<MethodInvoker>::const_iterator I = methods_.begin(), E = methods_.end(); I != E; ++IO, ++I) {
+    if (I->isFunction()) {
+      edm::TypeWithDict retType = I->method().finalReturnType();
+      needsDestructor_.push_back(makeStorage(*IO, retType));
     }
-    objects_.clear();
+    else {
+      *IO = edm::ObjectWithDict();
+      needsDestructor_.push_back(false);
+    }
+  }
+}
+
+ExpressionVar::ExpressionVar(const vector<MethodInvoker>& methods,
+                             method::TypeCode retType)
+  : methods_(methods)
+  , retType_(retType)
+{
+  initObjects_();
+}
+
+ExpressionVar::ExpressionVar(const ExpressionVar& rhs)
+  : methods_(rhs.methods_)
+  , retType_(rhs.retType_)
+{
+  initObjects_();
+}
+
+ExpressionVar::~ExpressionVar()
+{
+  for (std::vector<edm::ObjectWithDict>::iterator I = objects_.begin(),
+      E = objects_.end(); I != E; ++I) {
+    delStorage(*I);
+  }
+  objects_.clear();
 }
 
 void
-ExpressionVar::delStorage(edm::ObjectWithDict &obj) {
-    if (obj.address() != 0) {
-        if (obj.typeOf().isPointer() || obj.typeOf().isReference()) {
-            // just delete a void *, as that's what it was
-            void **p = static_cast<void **>(obj.address());
-            delete p;
-        } else {
-            //std::cout << "Calling Destruct on a " << obj.typeOf().qualifiedName() << std::endl;
-            obj.typeOf().deallocate(obj.address());
-        }
-    }
-}
-
-void ExpressionVar::initObjects_() {
-    objects_.resize(methods_.size());
-    std::vector<MethodInvoker>::const_iterator it = methods_.begin(), ed = methods_.end();
-    std::vector<edm::ObjectWithDict>::iterator itobj = objects_.begin();
-    for (; it != ed; ++it, ++itobj) {
-       if(it->isFunction()) {
-          edm::TypeWithDict retType = it->method().finalReturnType();
-          needsDestructor_.push_back(makeStorage(*itobj, retType));
-       } else {
-          *itobj = edm::ObjectWithDict();
-          needsDestructor_.push_back(false);
-       }
-    }
+ExpressionVar::delStorage(edm::ObjectWithDict& obj)
+{
+  if (!obj.address()) {
+    return;
+  }
+  if (obj.typeOf().isPointer() || obj.typeOf().isReference()) {
+    // just delete a void*, as that's what it was
+    void** p = static_cast<void**>(obj.address());
+    delete p;
+  }
+  else {
+    //std::cout << "Calling Destruct on a " <<
+    //  obj.typeOf().qualifiedName() << std::endl;
+    obj.typeOf().deallocate(obj.address());
+  }
 }
 
 bool
-ExpressionVar::makeStorage(edm::ObjectWithDict &obj, const edm::TypeWithDict &retType) {
-    bool ret = false;
-    static const edm::TypeWithDict tVoid(edm::TypeWithDict::byName("void"));
-    if (retType == tVoid) {
-        obj = edm::ObjectWithDict::byType(tVoid);
-    } else if (retType.isPointer() || retType.isReference()) {
-        // in this case, I have to allocate a void *, not an object!
-        obj = edm::ObjectWithDict(retType, new void *);
-    } else {
-        obj = edm::ObjectWithDict(retType, retType.allocate());
-        ret = retType.isClass();
-        //std::cout << "ExpressionVar: reserved memory at "  << obj.address() << " for a " << retType.qualifiedName() << " returned by " << member.name() << std::endl;
-    }
-    return ret;
+ExpressionVar::makeStorage(edm::ObjectWithDict& obj,
+                           const edm::TypeWithDict& retType)
+{
+  static edm::TypeWithDict tVoid(edm::TypeWithDict::byName("void"));
+  bool ret = false;
+  if (retType == tVoid) {
+    obj = edm::ObjectWithDict::byType(tVoid);
+  }
+  else if (retType.isPointer() || retType.isReference()) {
+    // in this case, I have to allocate a void*, not an object!
+    obj = edm::ObjectWithDict(retType, new void*);
+  }
+  else {
+    obj = edm::ObjectWithDict(retType, retType.allocate());
+    ret = retType.isClass();
+    //std::cout << "ExpressionVar: reserved memory at "  << obj.address() <<
+    //  " for a " << retType.qualifiedName() << " returned by " <<
+    //  member.name() << std::endl;
+  }
+  return ret;
 }
 
 bool ExpressionVar::isValidReturnType(method::TypeCode retType)
 {
-   using namespace method;
-   bool ret = false;
-   switch(retType) {
-      case(doubleType) : ret = true; break;
-      case(floatType ) : ret = true; break;
-      case(intType   ) : ret = true; break;
-      case(uIntType  ) : ret = true; break;
-      case(shortType ) : ret = true; break;
-      case(uShortType) : ret = true; break;
-      case(longType  ) : ret = true; break;
-      case(uLongType ) : ret = true; break;
-      case(charType  ) : ret = true; break;
-      case(uCharType ) : ret = true; break;
-      case(boolType  ) : ret = true; break;
-      case(enumType  ) : ret = true; break;
-      case(invalid):
-      default:
-        break;
-   }
-   return ret;
+  using namespace method;
+  bool ret = false;
+  switch (retType) {
+    case (doubleType) :
+      ret = true;
+      break;
+    case (floatType) :
+      ret = true;
+      break;
+    case (intType) :
+      ret = true;
+      break;
+    case (uIntType) :
+      ret = true;
+      break;
+    case (shortType) :
+      ret = true;
+      break;
+    case (uShortType) :
+      ret = true;
+      break;
+    case (longType) :
+      ret = true;
+      break;
+    case (uLongType) :
+      ret = true;
+      break;
+    case (charType) :
+      ret = true;
+      break;
+    case (uCharType) :
+      ret = true;
+      break;
+    case (boolType) :
+      ret = true;
+      break;
+    case (enumType) :
+      ret = true;
+      break;
+    case (invalid):
+    default:
+      break;
+  }
+  return ret;
 }
 
-double ExpressionVar::value(const edm::ObjectWithDict & o) const {
-  edm::ObjectWithDict ro = o;
-  std::vector<MethodInvoker>::const_iterator itm, end = methods_.end();
-  std::vector<edm::ObjectWithDict>::iterator      ito;
-  for(itm = methods_.begin(), ito = objects_.begin(); itm != end; ++itm, ++ito) {
-      ro = itm->invoke(ro, *ito);
+double ExpressionVar::value(const edm::ObjectWithDict& obj) const
+{
+  edm::ObjectWithDict val(obj);
+  std::vector<edm::ObjectWithDict>::iterator IO = objects_.begin();
+  for (std::vector<MethodInvoker>::const_iterator I = methods_.begin(), E = methods_.end(); I != E; ++I, ++IO) {
+    val = I->invoke(val, *IO);
   }
-  double ret = objToDouble(ro, retType_);
-  std::vector<edm::ObjectWithDict>::reverse_iterator rito, rend = objects_.rend();;
-  std::vector<bool>::const_reverse_iterator ritb;
-  for(rito = objects_.rbegin(), ritb = needsDestructor_.rbegin(); rito != rend; ++rito, ++ritb) {
-      if (*ritb) rito->typeOf().destruct(rito->address(), false);
+  double ret = objToDouble(val, retType_);
+  std::vector<bool>::const_reverse_iterator RIB = needsDestructor_.rbegin();
+  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI = objects_.rbegin(), RE = objects_.rend(); RI != RI; ++RIB, ++RI) {
+    if (*RIB) {
+      RI->typeOf().destruct(RI->address(), false);
+    }
   }
   return ret;
 }
 
 double
-ExpressionVar::objToDouble(const edm::ObjectWithDict &obj, method::TypeCode type) {
+ExpressionVar::objToDouble(const edm::ObjectWithDict& obj,
+                           method::TypeCode type)
+{
   using namespace method;
-  void * addr = obj.address();
-  double ret = 0;
-  switch(type) {
-  case(doubleType) : ret = * static_cast<double         *>(addr); break;
-  case(floatType ) : ret = * static_cast<float          *>(addr); break;
-  case(intType   ) : ret = * static_cast<int            *>(addr); break;
-  case(uIntType  ) : ret = * static_cast<unsigned int   *>(addr); break;
-  case(shortType ) : ret = * static_cast<short          *>(addr); break;
-  case(uShortType) : ret = * static_cast<unsigned short *>(addr); break;
-  case(longType  ) : ret = * static_cast<long           *>(addr); break;
-  case(uLongType ) : ret = * static_cast<unsigned long  *>(addr); break;
-  case(charType  ) : ret = * static_cast<char           *>(addr); break;
-  case(uCharType ) : ret = * static_cast<unsigned char  *>(addr); break;
-  case(boolType  ) : ret = * static_cast<bool           *>(addr); break;
-  case(enumType  ) : ret = * static_cast<int            *>(addr); break;
-  default:
-  assert(false);
+  void* addr = obj.address();
+  double ret = 0.0;
+  switch (type) {
+    case doubleType:
+      ret = *static_cast<double*>(addr);
+      break;
+    case floatType:
+      ret = *static_cast<float*>(addr);
+      break;
+    case intType:
+      ret = *static_cast<int*>(addr);
+      break;
+    case uIntType:
+      ret = *static_cast<unsigned int*>(addr);
+      break;
+    case shortType:
+      ret = *static_cast<short*>(addr);
+      break;
+    case uShortType:
+      ret = *static_cast<unsigned short*>(addr);
+      break;
+    case longType:
+      ret = *static_cast<long*>(addr);
+      break;
+    case uLongType:
+      ret = *static_cast<unsigned long*>(addr);
+      break;
+    case charType:
+      ret = *static_cast<char*>(addr);
+      break;
+    case uCharType:
+      ret = *static_cast<unsigned char*>(addr);
+      break;
+    case boolType:
+      ret = *static_cast<bool*>(addr);
+      break;
+    case enumType:
+      ret = *static_cast<int*>(addr);
+      break;
+    default:
+      //FIXME: Error not caught in production build!
+      assert(false && "objToDouble: invalid type!");
+      break;
   };
   return ret;
 }
 
-ExpressionLazyVar::ExpressionLazyVar(const std::vector<LazyInvoker> & methods) :
-    methods_(methods)
+ExpressionLazyVar::ExpressionLazyVar(const std::vector<LazyInvoker>& methods)
+  : methods_(methods)
 {
 }
 
@@ -145,18 +220,20 @@ ExpressionLazyVar::~ExpressionLazyVar()
 }
 
 double
-ExpressionLazyVar::value(const edm::ObjectWithDict & o) const {
-    std::vector<LazyInvoker>::const_iterator it, ed = methods_.end()-1;
-    edm::ObjectWithDict ro = o;
-    for (it = methods_.begin(); it < ed; ++it) {
-        ro = it->invoke(ro, objects_);
-    }
-    double ret = it->invokeLast(ro, objects_);
-    std::vector<edm::ObjectWithDict>::reverse_iterator rit, red = objects_.rend();
-    for (rit = objects_.rbegin(); rit != red; ++rit) {
-        rit->typeOf().destruct(rit->address(), false);
-    }
-    objects_.clear();
-    return ret;
+ExpressionLazyVar::value(const edm::ObjectWithDict& o) const
+{
+  edm::ObjectWithDict val = o;
+  std::vector<LazyInvoker>::const_iterator I = methods_.begin();
+  std::vector<LazyInvoker>::const_iterator E = methods_.end() - 1;
+  for (; I < E; ++I) {
+    val = I->invoke(val, objects_);
+  }
+  double ret = I->invokeLast(val, objects_);
+  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI =
+      objects_.rbegin(), RE = objects_.rend(); RI != RE; ++RI) {
+    RI->typeOf().destruct(RI->address(), false);
+  }
+  objects_.clear();
+  return ret;
 }
 

--- a/CommonTools/Utils/src/ExpressionVar.h
+++ b/CommonTools/Utils/src/ExpressionVar.h
@@ -1,66 +1,74 @@
 #ifndef CommonTools_Utils_ExpressionVar_h
 #define CommonTools_Utils_ExpressionVar_h
+
 /* \class reco::parser::ExpressionVar
  *
  * Variable expression
  *
- * \author original version: Chris Jones, Cornell, 
+ * \author original version: Chris Jones, Cornell,
  *         adapted by Luca Lista, INFN
  *
- * \version $Revision: 1.6 $
- *
  */
+
 #include "CommonTools/Utils/src/ExpressionBase.h"
-#include "CommonTools/Utils/src/TypeCode.h"
 #include "CommonTools/Utils/src/MethodInvoker.h"
+#include "CommonTools/Utils/src/TypeCode.h"
+
 #include <vector>
 
 namespace reco {
-  namespace parser {
-    /// Evaluate an object's method or datamember (or chain of them) to get a number
-    struct ExpressionVar : public ExpressionBase {
-      ExpressionVar(const std::vector<MethodInvoker> & methods, method::TypeCode retType);
+namespace parser {
 
-      ~ExpressionVar() ;
-      ExpressionVar(const ExpressionVar &var) ;
+/// Evaluate an object's method or datamember (or chain of them) to get a number
+class ExpressionVar : public ExpressionBase {
+private: // Private Data Members
+  std::vector<MethodInvoker> methods_;
+  mutable std::vector<edm::ObjectWithDict> objects_;
+  mutable std::vector<bool> needsDestructor_;
+  method::TypeCode retType_;
 
-      virtual double value(const edm::ObjectWithDict & o) const;
+private: // Private Methods
+  void initObjects_();
 
-      static bool isValidReturnType(method::TypeCode);
-      /// performs the needed conversion from void * to double
-      /// this method is used also from the ExpressionLazyVar code
-      static double objToDouble(const edm::ObjectWithDict &obj, method::TypeCode type) ;
+public: // Public Static Methods
+  static bool isValidReturnType(method::TypeCode);
 
-      /// allocate an object to hold the result of a given member (if needed)
-      /// this method is used also from the LazyInvoker code
-      /// returns true if objects returned from this will require a destructor 
-      static bool makeStorage(edm::ObjectWithDict &obj, const edm::TypeWithDict &retType) ;
-      /// delete an objecty, if needed
-      /// this method is used also from the LazyInvoker code
-      static void delStorage(edm::ObjectWithDict &obj);
+  /// performs the needed conversion from void* to double
+  /// this method is used also from the ExpressionLazyVar code
+  static double objToDouble(const edm::ObjectWithDict& obj,
+                            method::TypeCode type);
 
-    private:
-      std::vector<MethodInvoker>  methods_;
-      mutable std::vector<edm::ObjectWithDict> objects_;
-      mutable std::vector<bool>           needsDestructor_;
-      method::TypeCode retType_;
-      void initObjects_();
-    }; 
+  /// allocate an object to hold the result of a given member (if needed)
+  /// this method is used also from the LazyInvoker code
+  /// returns true if objects returned from this will require a destructor
+  static bool makeStorage(edm::ObjectWithDict& obj,
+                          const edm::TypeWithDict& retType);
 
-  /// Same as ExpressionVar but with lazy resolution of object methods
-  /// using the final type of the object, and not the one fixed at compile time
-  struct ExpressionLazyVar : public ExpressionBase {
-      ExpressionLazyVar(const std::vector<LazyInvoker> & methods);
-      ~ExpressionLazyVar() ;
+  /// delete an objecty, if needed
+  /// this method is used also from the LazyInvoker code
+  static void delStorage(edm::ObjectWithDict&);
 
-      virtual double value(const edm::ObjectWithDict & o) const;
+public: // Public Methods
+  ExpressionVar(const std::vector<MethodInvoker>& methods,
+                method::TypeCode retType);
+  ExpressionVar(const ExpressionVar&);
+  ~ExpressionVar();
+  virtual double value(const edm::ObjectWithDict&) const;
+};
 
-    private:
-      std::vector<LazyInvoker> methods_;
-      mutable std::vector<edm::ObjectWithDict> objects_;
-  }; 
+/// Same as ExpressionVar but with lazy resolution of object methods
+/// using the dynamic type of the object, and not the one fixed at compile time
+class ExpressionLazyVar : public ExpressionBase {
+private: // Private Data Members
+  std::vector<LazyInvoker> methods_;
+  mutable std::vector<edm::ObjectWithDict> objects_;
+public:
+  ExpressionLazyVar(const std::vector<LazyInvoker>& methods);
+  ~ExpressionLazyVar();
+  virtual double value(const edm::ObjectWithDict&) const;
+};
 
- }
-}
+} // namespace parser
+} // namespace reco
 
-#endif
+#endif // CommonTools_Utils_ExpressionVar_h

--- a/CommonTools/Utils/src/MethodInvoker.cc
+++ b/CommonTools/Utils/src/MethodInvoker.cc
@@ -17,7 +17,7 @@ MethodInvoker(const edm::FunctionWithDict& method,
   , member_()
   , ints_(ints)
   , isFunction_(true)
-{ 
+{
   setArgs();
   if (isFunction_) {
     retTypeFinal_ = method_.finalReturnType();
@@ -42,7 +42,7 @@ MethodInvoker(const edm::MemberWithDict& member)
   , member_(member)
   , ints_()
   , isFunction_(false)
-{ 
+{
   setArgs();
   //std::cout <<
   //  "Booking " <<
@@ -80,7 +80,7 @@ operator=(const MethodInvoker& rhs)
     isFunction_ = rhs.isFunction_;
     retTypeFinal_ =rhs.retTypeFinal_;
 
-  setArgs();
+    setArgs();
   }
   return *this;
 }
@@ -99,7 +99,7 @@ MethodInvoker::
 methodName() const
 {
   if (isFunction_) {
-     return method_.name();
+    return method_.name();
   }
   return member_.name();
 }
@@ -109,7 +109,7 @@ MethodInvoker::
 returnTypeName() const
 {
   if (isFunction_) {
-     return method_.typeOf().qualifiedName();
+    return method_.typeName();
   }
   return member_.typeOf().qualifiedName();
 }
@@ -127,7 +127,7 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
     //  << " at " << o.address()
     //  << " with " << args_.size() << " arguments"
     //  << std::endl;
-     method_.invoke(o, &ret, args_);
+    method_.invoke(o, &ret, args_);
     // this is correct, it takes pointers and refs into account
     retType = retTypeFinal_; 
   }
@@ -138,23 +138,23 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
     //  << " at " << o.address()
     //  << " with " << args_.size() << " arguments"
     //  << std::endl;
-     ret = member_.get(o);
-     retType = member_.typeOf();
+    ret = member_.get(o);
+    retType = member_.typeOf();
   }
   void* addr = ret.address();
   //std::cout << "Stored result of " <<  methodName() << " (type " <<
   //  returnTypeName() << ") at " << addr << std::endl;
   if (addr == 0) {
     throw edm::Exception(edm::errors::InvalidReference)
-      << "method \"" << methodName() << "\" called with " << args_.size() 
-      << " arguments returned a null pointer ";   
+        << "method \"" << methodName() << "\" called with " << args_.size()
+        << " arguments returned a null pointer ";
   }
   //std::cout << "Return type is " << retType.qualifiedName() << std::endl;
   if (retType.isPointer() || retType.isReference()) {
     // both need void** -> void* conversion
-      if (retType.isPointer()) {
+    if (retType.isPointer()) {
       retType = retType.toType();
-      }
+    }
     else {
       // strip cv & ref flags
       // FIXME: This is only true if the propery passed to the constructor
@@ -162,13 +162,13 @@ invoke(const edm::ObjectWithDict& o, edm::ObjectWithDict& retstore) const
       retType = edm::TypeWithDict(retType, 0L);
     }
     ret = edm::ObjectWithDict(retType, *static_cast<void**>(addr));
-      //std::cout << "Now type is " << retType.qualifiedName() << std::endl;
+    //std::cout << "Now type is " << retType.qualifiedName() << std::endl;
   }
   if (!bool(ret)) {
-     throw edm::Exception(edm::errors::Configuration)
-      << "method \"" << methodName()
-      << "\" returned void invoked on object of type \"" 
-      << o.typeOf().qualifiedName() << "\"\n";
+    throw edm::Exception(edm::errors::Configuration)
+        << "method \"" << methodName()
+        << "\" returned void invoked on object of type \""
+        << o.typeOf().qualifiedName() << "\"\n";
   }
   return ret;
 }
@@ -181,7 +181,7 @@ LazyInvoker(const std::string& name,
 {
 }
 
-LazyInvoker::~LazyInvoker() 
+LazyInvoker::~LazyInvoker()
 {
 }
 
@@ -192,11 +192,11 @@ invoker(const edm::TypeWithDict& type) const
   //std::cout << "LazyInvoker for " << name_ << " called on type " <<
   //  type.qualifiedName() << std::endl;
   SingleInvokerPtr& invoker = invokers_[edm::TypeID(type.typeInfo())];
-    if (!invoker) {
+  if (!invoker) {
     //std::cout << "  Making new invoker for " << name_ << " on type " <<
     //  type.qualifiedName() << std::endl;
-        invoker.reset(new SingleInvoker(type, name_, argsBeforeFixups_));
-    } 
+    invoker.reset(new SingleInvoker(type, name_, argsBeforeFixups_));
+  }
   return *invoker;
 }
 
@@ -205,15 +205,15 @@ LazyInvoker::
 invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
 {
   pair<edm::ObjectWithDict, bool> ret(o, false);
-    do {    
-        edm::TypeWithDict type = ret.first.typeOf();
+  do {
+    edm::TypeWithDict type = ret.first.typeOf();
     if (type.isClass()) {
       type = ret.first.dynamicType();
     }
-        ret = invoker(type).invoke(edm::ObjectWithDict(type, ret.first.address()), v);
+    ret = invoker(type).invoke(edm::ObjectWithDict(type, ret.first.address()), v);
   }
   while (ret.second == false);
-    return ret.first; 
+  return ret.first;
 }
 
 double
@@ -223,38 +223,38 @@ invokeLast(const edm::ObjectWithDict& o,
 {
   pair<edm::ObjectWithDict, bool> ret(o, false);
   const SingleInvoker* i = 0;
-    do {    
-        edm::TypeWithDict type = ret.first.typeOf();
+  do {
+    edm::TypeWithDict type = ret.first.typeOf();
     if (type.isClass()) {
       type = ret.first.dynamicType();
     }
     i = &invoker(type);
-        ret = i->invoke(edm::ObjectWithDict(type, ret.first.address()), v);
+    ret = i->invoke(edm::ObjectWithDict(type, ret.first.address()), v);
   }
   while (ret.second == false);
-    return i->retToDouble(ret.first);
+  return i->retToDouble(ret.first);
 }
 
 SingleInvoker::
 SingleInvoker(const edm::TypeWithDict& type, const std::string& name,
               const std::vector<AnyMethodArgument>& args)
 {
-    TypeStack typeStack(1, type);
-    LazyMethodStack dummy;
-    MethodArgumentStack dummy2;
-    MethodSetter setter(invokers_, dummy, typeStack, dummy2, false);
-    isRefGet_ = !setter.push(name, args, "LazyInvoker dynamic resolution", false);
+  TypeStack typeStack(1, type);
+  LazyMethodStack dummy;
+  MethodArgumentStack dummy2;
+  MethodSetter setter(invokers_, dummy, typeStack, dummy2, false);
+  isRefGet_ = !setter.push(name, args, "LazyInvoker dynamic resolution", false);
   //std::cerr  << "SingleInvoker on type " <<  type.qualifiedName() <<
   //  ", name " << name << (isRefGet_ ? " is just a ref.get " : " is real") <<
   //  std::endl;
   if (invokers_.front().isFunction()) {
-       edm::TypeWithDict retType = invokers_.front().method().finalReturnType();
-       storageNeedsDestructor_ = ExpressionVar::makeStorage(storage_, retType);
+    edm::TypeWithDict retType = invokers_.front().method().finalReturnType();
+    storageNeedsDestructor_ = ExpressionVar::makeStorage(storage_, retType);
   }
   else {
-       storage_ = edm::ObjectWithDict();
-       storageNeedsDestructor_ = false;
-    }
+    storage_ = edm::ObjectWithDict();
+    storageNeedsDestructor_ = false;
+  }
   // typeStack[0] = type of self
   // typeStack[1] = type of ret
   retType_ = reco::typeCode(typeStack[1]);
@@ -263,7 +263,7 @@ SingleInvoker(const edm::TypeWithDict& type, const std::string& name,
 SingleInvoker::
 ~SingleInvoker()
 {
-    ExpressionVar::delStorage(storage_);
+  ExpressionVar::delStorage(storage_);
 }
 
 pair<edm::ObjectWithDict, bool>
@@ -278,32 +278,32 @@ invoke(const edm::ObjectWithDict& o, std::vector<edm::ObjectWithDict>& v) const
   //   std::endl;
   pair<edm::ObjectWithDict, bool>
   ret(invokers_.front().invoke(o, storage_), !isRefGet_);
-    if (storageNeedsDestructor_) {
+  if (storageNeedsDestructor_) {
     //std::cerr << "Storage type: " << storage_.typeOf().qualifiedName() <<
     //  ", I have to call the destructor." << std::endl;
-        v.push_back(storage_);
-    }
-    return ret;
+    v.push_back(storage_);
+  }
+  return ret;
 }
 
 double
 SingleInvoker::
 retToDouble(const edm::ObjectWithDict& o) const
 {
-    if (!ExpressionVar::isValidReturnType(retType_)) {
-        throwFailedConversion(o);
-    }
-    return ExpressionVar::objToDouble(o, retType_);
+  if (!ExpressionVar::isValidReturnType(retType_)) {
+    throwFailedConversion(o);
+  }
+  return ExpressionVar::objToDouble(o, retType_);
 }
 
 void
 SingleInvoker::
 throwFailedConversion(const edm::ObjectWithDict& o) const
 {
-    throw edm::Exception(edm::errors::Configuration)
-        << "member \"" << invokers_.back().methodName()
-        << "\" return type is \"" << invokers_.back().returnTypeName()
-        << "\" retured a \"" << o.typeOf().qualifiedName()
-        << "\" which is not convertible to double.";
+  throw edm::Exception(edm::errors::Configuration)
+      << "member \"" << invokers_.back().methodName()
+      << "\" return type is \"" << invokers_.back().returnTypeName()
+      << "\" retured a \"" << o.typeOf().qualifiedName()
+      << "\" which is not convertible to double.";
 }
 

--- a/CommonTools/Utils/src/MethodInvoker.h
+++ b/CommonTools/Utils/src/MethodInvoker.h
@@ -19,15 +19,15 @@ namespace parser {
 
 class MethodInvoker {
 private: // Private Data Members
-      edm::FunctionWithDict method_;
-      edm::MemberWithDict member_;
-      std::vector<AnyMethodArgument> ints_; // already fixed to the correct type
-      std::vector<void*> args_;
+  edm::FunctionWithDict method_;
+  edm::MemberWithDict member_;
+  std::vector<AnyMethodArgument> ints_; // already fixed to the correct type
+  std::vector<void*> args_;
 
-      bool isFunction_;
+  bool isFunction_;
   edm::TypeWithDict retTypeFinal_;
 private: // Private Function Members
-      void setArgs();
+  void setArgs();
 public: // Public Function Members
   explicit MethodInvoker(const edm::FunctionWithDict& method,
                          const std::vector<AnyMethodArgument>& ints =
@@ -50,19 +50,19 @@ public: // Public Function Members
   edm::ObjectWithDict invoke(const edm::ObjectWithDict& obj,
                              edm::ObjectWithDict& retstore) const;
 };
-        
+
 /// A bigger brother of the MethodInvoker:
 /// - it owns also the object in which to store the result
 /// - it handles by itself the popping out of Refs and Ptrs
 /// in this way, it can map 1-1 to a name and set of args
 struct SingleInvoker : boost::noncopyable {
 private: // Private Data Members
-        method::TypeCode            retType_;
-        std::vector<MethodInvoker>  invokers_;
-        mutable edm::ObjectWithDict      storage_;
-        bool                        storageNeedsDestructor_;
-        /// true if this invoker just pops out a ref and returns (ref.get(), false)
-        bool isRefGet_;
+  method::TypeCode retType_;
+  std::vector<MethodInvoker> invokers_;
+  mutable edm::ObjectWithDict storage_;
+  bool storageNeedsDestructor_;
+  /// true if this invoker just pops out a ref and returns (ref.get(), false)
+  bool isRefGet_;
 public:
   SingleInvoker(const edm::TypeWithDict&, const std::string& name,
                 const std::vector<AnyMethodArgument>& args);
@@ -101,18 +101,18 @@ private: // Private Function Members
 public: // Public Function Members
   explicit LazyInvoker(const std::string& name,
                        const std::vector<AnyMethodArgument>& args);
-      ~LazyInvoker();
+  ~LazyInvoker();
 
   /// invoke method, returns object that points to result
   /// (after stripping '*' and '&')
-      /// the object is still owned by the LazyInvoker
+  /// the object is still owned by the LazyInvoker
   /// the actual edm::ObjectWithDict where the result is
   /// stored will be pushed in vector
-      /// so that, if needed, its destructor can be called
+  /// so that, if needed, its destructor can be called
   edm::ObjectWithDict invoke(const edm::ObjectWithDict& o,
                              std::vector<edm::ObjectWithDict>& v) const;
 
-      /// invoke and coerce result to double
+  /// invoke and coerce result to double
   double invokeLast(const edm::ObjectWithDict& o,
                     std::vector<edm::ObjectWithDict>& v) const;
 };

--- a/CommonTools/Utils/src/MethodSetter.cc
+++ b/CommonTools/Utils/src/MethodSetter.cc
@@ -19,11 +19,11 @@ operator()(const char* begin, const char* end) const
   string name(begin, end);
   string::size_type parenthesis = name.find_first_of('(');
   if ((*begin == '[') || (*begin == '(')) {
-    name.insert(0, "operator..");           // operator..[arg];
-    parenthesis = 10;                       //           ^--- idx = 10
-    name[8] = *begin;                       // operator[.[arg];
+    name.insert(0, "operator..");    // operator..[arg];
+    parenthesis = 10;                //           ^--- idx = 10
+    name[8] = *begin;                // operator[.[arg];
     name[9] = name[name.size() - 1]; // operator[][arg];
-    name[10] = '(';                         // operator[](arg];
+    name[10] = '(';                  // operator[](arg];
     name[name.size() - 1] = ')';     // operator[](arg);
     // we don't actually need the last two, but just for extra care
     //std::cout << "Transformed {" << string(begin,end) << "} into
@@ -34,7 +34,7 @@ operator()(const char* begin, const char* end) const
     name.erase(parenthesis, name.size());
     if (intStack_.size() == 0) {
       throw Exception(begin)
-	<< "expected method argument, but non given.";    
+          << "expected method argument, but non given.";
     }
     for (vector<AnyMethodArgument>::const_iterator i = intStack_.begin();
          i != intStack_.end(); ++i) {
@@ -72,24 +72,22 @@ push(const string& name, const vector<AnyMethodArgument>& args,
     reco::findMethod(type, name, args, fixups, begin, error);
   if (bool(mem.first)) {
     // We found the method.
-     edm::TypeWithDict retType = reco::returnType(mem.first);
+    edm::TypeWithDict retType = reco::returnType(mem.first);
     if (!bool(retType)) {
       // Invalid return type, fatal error, throw.
-        throw Exception(begin)
+      throw Exception(begin)
           << "member \"" << mem.first.name()
           << "\" return type is invalid:\n"
-          << "  member type: \""
-          <<  mem.first.typeOf().qualifiedName() << "\"\n"
           << "  return type: \""
-          << mem.first.returnType().qualifiedName() << "\"\n";
-     }
-     typeStack_.push_back(retType);
-     // check for edm::Ref, edm::RefToBase, edm::Ptr
+          << mem.first.typeName() << "\"\n";
+    }
+    typeStack_.push_back(retType);
+    // check for edm::Ref, edm::RefToBase, edm::Ptr
     if (mem.second) {
       // Without fixups.
       //std::cout << "Mem.second, so book " << mem.first.name() <<
       //  " without fixups." << std::endl;
-        methStack_.push_back(MethodInvoker(mem.first));
+      methStack_.push_back(MethodInvoker(mem.first));
       if (!deep) {
         return false;
       }
@@ -101,71 +99,71 @@ push(const string& name, const vector<AnyMethodArgument>& args,
       // With fixups.
       //std::cout << "Not mem.second, so book " << mem.first.name()
       //  << " with #args = " << fixups.size() << std::endl;
-        methStack_.push_back(MethodInvoker(mem.first, fixups));
-      }
+      methStack_.push_back(MethodInvoker(mem.first, fixups));
+    }
     return true;
   }
   if (error != reco::parser::kNameDoesNotExist) {
     // Fatal error, throw.
     switch (error) {
-           case reco::parser::kIsNotPublic:
-            throw Exception(begin)
-              << "method named \"" << name << "\" for type \"" 
+      case reco::parser::kIsNotPublic:
+        throw Exception(begin)
+            << "method named \"" << name << "\" for type \""
             << type.name() << "\" is not publically accessible.";
-            break;
-           case reco::parser::kIsStatic:
-             throw Exception(begin)
-               << "method named \"" << name << "\" for type \"" 
+        break;
+      case reco::parser::kIsStatic:
+        throw Exception(begin)
+            << "method named \"" << name << "\" for type \""
             << type.name() << "\" is static.";
-             break;
-           case reco::parser::kIsNotConst:
-              throw Exception(begin)
-                << "method named \"" << name << "\" for type \"" 
+        break;
+      case reco::parser::kIsNotConst:
+        throw Exception(begin)
+            << "method named \"" << name << "\" for type \""
             << type.name() << "\" is not const.";
-              break;
-           case reco::parser::kWrongNumberOfArguments:
-               throw Exception(begin)
-                 << "method named \"" << name << "\" for type \"" 
+        break;
+      case reco::parser::kWrongNumberOfArguments:
+        throw Exception(begin)
+            << "method named \"" << name << "\" for type \""
             << type.name() << "\" was passed the wrong number of arguments.";
-               break;
-           case reco::parser::kWrongArgumentType:
-               throw Exception(begin)
-                     << "method named \"" << name << "\" for type \"" 
+        break;
+      case reco::parser::kWrongArgumentType:
+        throw Exception(begin)
+            << "method named \"" << name << "\" for type \""
             << type.name() << "\" was passed the wrong types of arguments.";
-               break;
-           default:  
-            throw Exception(begin)
-             << "method named \"" << name << "\" for type \"" 
+        break;
+      default:
+        throw Exception(begin)
+            << "method named \"" << name << "\" for type \""
             << type.name() << "\" is not usable in this context.";
-        }
-     }
+    }
+  }
   // Not a method, check for a data member.
   error = 0;
   edm::MemberWithDict member(reco::findDataMember(type, name, error));
   if (!bool(member)) {
     // Not a data member either, fatal error, throw.
     switch (error) {
-           case reco::parser::kNameDoesNotExist:
-            throw Exception(begin)
+      case reco::parser::kNameDoesNotExist:
+        throw Exception(begin)
             << "no method or data member named \"" << name
             << "\" found for type \""
             << type.name() << "\"";
-            break;
-           case reco::parser::kIsNotPublic:
-            throw Exception(begin)
-              << "data member named \"" << name << "\" for type \"" 
+        break;
+      case reco::parser::kIsNotPublic:
+        throw Exception(begin)
+            << "data member named \"" << name << "\" for type \""
             << type.name() << "\" is not publically accessible.";
-            break;
-           default:
-           throw Exception(begin)
-             << "data member named \"" << name << "\" for type \"" 
+        break;
+      default:
+        throw Exception(begin)
+            << "data member named \"" << name << "\" for type \""
             << type.name() << "\" is not usable in this context.";
-           break;
-        }
-     }
+        break;
+    }
+  }
   // Ok, it was a data member.
-     typeStack_.push_back(member.typeOf());
-     methStack_.push_back(MethodInvoker(member));
+  typeStack_.push_back(member.typeOf());
+  methStack_.push_back(MethodInvoker(member));
   return true;
 }
-    
+

--- a/CommonTools/Utils/src/MethodSetter.h
+++ b/CommonTools/Utils/src/MethodSetter.h
@@ -46,22 +46,22 @@ public:
   /// If the object is an edm::Ref/Ptr/RefToBase and the method is not
   /// found in the class:
   ///
-      ///  1)  it pushes a no-argument 'get()' method
+  ///  1)  it pushes a no-argument 'get()' method
   ///
   ///  2)  if deep = true, it attempts to resolve and push the method on
   ///      the object to which the edm ref points to.  In that case, the
   ///      MethodStack will contain two more items after this call instead
   ///      of just one.  This behaviour is what you want for non-lazy parsing.
   ///
-      ///  2b) if instead deep = false, it just pushes the 'get' on the stack.
+  ///  2b) if instead deep = false, it just pushes the 'get' on the stack.
   ///      this will allow the LazyInvoker to then re-discover the runtime
   ///      type of the pointee
   ///
-      ///  The method will:
-      ///     - throw exception, if the member can't be resolved
+  ///  The method will:
+  ///     - throw exception, if the member can't be resolved
   ///     - return 'false' if deep = false and it only pushed
   //        a 'get' on the stack
-      ///     - return true otherwise
+  ///     - return true otherwise
   ///
   bool push(const std::string&, const std::vector<AnyMethodArgument>&,
             const char*, bool deep = true) const;

--- a/CommonTools/Utils/src/findDataMember.cc
+++ b/CommonTools/Utils/src/findDataMember.cc
@@ -2,7 +2,7 @@
 //
 // Package:     Utilities
 // Class  :     findDataMember
-// 
+//
 // Implementation:
 //     <Notes on implementation>
 //
@@ -34,33 +34,33 @@ findDataMember(const edm::TypeWithDict& iType,
                int& oError)
 {
   edm::MemberWithDict ret;
-      oError = parser::kNameDoesNotExist;
-      edm::TypeWithDict type = iType;
+  oError = parser::kNameDoesNotExist;
+  edm::TypeWithDict type = iType;
   if (!bool(type)) {
     return ret;
   }
   if (type.isPointer()) {
     type = type.toType();
-         }
+  }
   ret = type.dataMemberByName(iName);
   if (!bool(ret)) {
     // check base classes
-            edm::TypeBases bases(type);
+    edm::TypeBases bases(type);
     for (auto const& B : bases) {
       ret = findDataMember(edm::BaseWithDict(B).typeOf(), iName, oError);
-               //only stop if we found it or some other error happened
+      //only stop if we found it or some other error happened
       if (bool(ret) || (oError != parser::kNameDoesNotExist)) {
-                  break;
-               }
-            }
-         }
+        break;
+      }
+    }
+  }
   if (bool(ret) && !ret.isPublic()) {
     ret = edm::MemberWithDict();
-            oError = parser::kIsNotPublic;
-         }
+    oError = parser::kIsNotPublic;
+  }
   else if (bool(ret)) {
-         oError = parser::kNoError;
-      }
+    oError = parser::kNoError;
+  }
   return ret;
 }
 

--- a/CommonTools/Utils/src/findMethod.cc
+++ b/CommonTools/Utils/src/findMethod.cc
@@ -1,194 +1,268 @@
 #include "CommonTools/Utils/src/findMethod.h"
+
 #include "CommonTools/Utils/src/ErrorCodes.h"
 #include "CommonTools/Utils/interface/Exception.h"
 #include "FWCore/Utilities/interface/BaseWithDict.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/TypeID.h"
 #include "TInterpreter.h"
 #include "TVirtualMutex.h"
+
 #include <cassert>
 
-using namespace std;
-using reco::parser::AnyMethodArgument;
+using AnyMethodArgument=reco::parser::AnyMethodArgument;
 
-//Checks for errors which show we got the correct function be we just can't use it
-static bool fatalErrorCondition(int iError)
+/// Checks for errors which show we got the correct function
+/// but we cannot use it.
+static
+bool
+fatalErrorCondition(const int err)
 {
-   return (reco::parser::kIsNotPublic==iError ||
-      reco::parser::kIsStatic==iError ||
-      reco::parser::kIsFunctionAddedByROOT==iError ||
-      reco::parser::kIsConstructor==iError ||
-      reco::parser::kIsDestructor==iError ||
-      reco::parser::kIsOperator==iError);
-   
+  return (err == reco::parser::kIsNotPublic) ||
+         (err == reco::parser::kIsStatic) ||
+         (err == reco::parser::kIsFunctionAddedByROOT) ||
+         (err == reco::parser::kIsConstructor) ||
+         (err == reco::parser::kIsDestructor) ||
+         (err == reco::parser::kIsOperator);
 }
+
 namespace reco {
-  int checkMethod(const edm::FunctionWithDict & mem, 
-                  const edm::TypeWithDict   & type,
-                  const std::vector<AnyMethodArgument> &args, std::vector<AnyMethodArgument> &fixuppedArgs) {
-    int casts = 0;
-    if (mem.isConstructor()) return -1*parser::kIsConstructor;
-    if (mem.isDestructor()) return -1*parser::kIsDestructor;
-    //if (mem.isOperator()) return -1*parser::kIsOperator;  // no, some operators are allowed, e.g. operator[]
-    if (! mem.isPublic()) return -1*parser::kIsNotPublic;
-    if (mem.isStatic()) return -1*parser::kIsStatic;
-    if ( ! mem.isConst() ) return -1*parser::kIsNotConst;
-    if (mem.name().substr(0, 2) == "__") return -1*parser::kIsFunctionAddedByROOT;
-    if (mem.declaringType().id() != type.id()) {
-        /*std::cerr << "\nMETHOD OVERLOAD " << mem.name() <<
-                       " by "   << type.Name(QUALITIED|SCOPED) <<
-                       " from " << mem.declaringTy[e().Name(QUALIFIED|SCOPED) << std::endl; */
-        return -1*parser::kOverloaded;
-    }
-    size_t minArgs = mem.functionParameterSize(true), maxArgs = mem.functionParameterSize(false);
-    if ((args.size() < minArgs) || (args.size() > maxArgs)) return -1*parser::kWrongNumberOfArguments;
-    /*std::cerr << "\nMETHOD " << mem.name() << " of " << mem.declaringType().name() 
-        << ", min #args = " << minArgs << ", max #args = " << maxArgs 
-        << ", args = " << args.size() << std::endl;*/
-    if (!args.empty()) {
-        std::vector<AnyMethodArgument> tmpFixups;
-        size_t i = 0;
-        for (auto const& param : mem) { 
-            edm::TypeWithDict parameter(param);
-            std::pair<AnyMethodArgument,int> fixup = boost::apply_visitor( reco::parser::AnyMethodArgumentFixup(parameter), args[i] );
-            //std::cerr << "\t ARG " << i << " type is " << parameter.name() << " conversion = " << fixup.second << std::endl; 
-            if (fixup.second >= 0) { 
-                tmpFixups.push_back(fixup.first);
-                casts += fixup.second;
-            } else { 
-                return -1*parser::kWrongArgumentType;
-            }
-            if(++i == args.size()) {
-              break;
-            }
-        }
-        fixuppedArgs.swap(tmpFixups);
-    }
-    /*std::cerr << "\nMETHOD " << mem.name() << " of " << mem.declaringType().name() 
-        << ", min #args = " << minArgs << ", max #args = " << maxArgs 
-        << ", args = " << args.size() << " fixupped args = " << fixuppedArgs.size() << "(" << casts << " implicit casts)" << std::endl; */
-    return casts;
+
+int
+checkMethod(const edm::FunctionWithDict& mem,
+            const edm::TypeWithDict& type,
+            const std::vector<AnyMethodArgument>& args,
+            std::vector<AnyMethodArgument>& fixuppedArgs)
+{
+  int casts = 0;
+  if (mem.isConstructor()) {
+    return -1 * parser::kIsConstructor;
   }
-
-  typedef pair<int,edm::FunctionWithDict> OK;
-  bool nCasts(OK const& a, OK const& b) {
-    return a.first < b.first;
+  if (mem.isDestructor()) {
+    return -1 * parser::kIsDestructor;
   }
+  // Some operators are allowed, e.g. operator[].
+  //if (mem.isOperator()) {
+  //  return -1 * parser::kIsOperator;
+  //}
+  if (!mem.isPublic()) {
+    return -1 * parser::kIsNotPublic;
+  }
+  if (mem.isStatic()) {
+    return -1 * parser::kIsStatic;
+  }
+  if (!mem.isConst()) {
+    return -1 * parser::kIsNotConst;
+  }
+  if (mem.name().substr(0, 2) == "__") {
+    return -1 * parser::kIsFunctionAddedByROOT;
+  }
+  // Functions from a base class are allowed.
+  //if (mem.declaringType() != type) {
+    //std::cerr <<
+    //  "\nMETHOD OVERLOAD " <<
+    //  mem.name() <<
+    //  " by " <<
+    //  type.qualifiedName() <<
+    //  " from " <<
+    //  mem.declaringType().qualifiedName() <<
+    //  std::endl;
+    //return -1 * parser::kOverloaded;
+  //}
 
+  size_t minArgs = mem.functionParameterSize(true);
+  size_t maxArgs = mem.functionParameterSize(false);
+  if ((args.size() < minArgs) || (args.size() > maxArgs)) {
+    return -1 * parser::kWrongNumberOfArguments;
+  }
+  //std::cerr <<
+  //  "\nMETHOD " <<
+  //  mem.name() <<
+  //  " of " <<
+  //  mem.declaringType().name() <<
+  //  ", min #args = " <<
+  //  minArgs <<
+  //  ", max #args = " <<
+  //  maxArgs <<
+  //  ", args = " <<
+  //  args.size() <<
+  //  std::endl;
+  if (!args.empty()) {
+    std::vector<AnyMethodArgument> tmpFixups;
+    size_t i = 0;
+    for (auto const& param : mem) {
+      edm::TypeWithDict parameter(param);
+      std::pair<AnyMethodArgument, int> fixup =
+        boost::apply_visitor(reco::parser::AnyMethodArgumentFixup(parameter),
+                             args[i]);
+      //std::cerr <<
+      //  "\t ARG " <<
+      //  i <<
+      //  " type is " <<
+      //  parameter.name() <<
+      //  " conversion = " <<
+      //  fixup.second <<
+      //  std::endl;
+      if (fixup.second >= 0) {
+        tmpFixups.push_back(fixup.first);
+        casts += fixup.second;
+      }
+      else {
+        return -1 * parser::kWrongArgumentType;
+      }
+      if (++i == args.size()) {
+        break;
+      }
+    }
+    fixuppedArgs.swap(tmpFixups);
+  }
+  //std::cerr <<
+  //  "\nMETHOD " <<
+  //  mem.name() <<
+  //  " of " <<
+  //  mem.declaringType().name() <<
+  //  ", min #args = " <<
+  //  minArgs <<
+  //  ", max #args = " <<
+  //  maxArgs <<
+  //  ", args = " <<
+  //  args.size() <<
+  //  " fixupped args = " <<
+  //  fixuppedArgs.size() <<
+  //  "(" << casts <<
+  //  " implicit casts)" <<
+  //  std::endl;
+  return casts;
+}
 
-  pair<edm::FunctionWithDict, bool> findMethod(const edm::TypeWithDict & t, 
-                                const string & name, 
-                                const std::vector<AnyMethodArgument> &args, 
-                                std::vector<AnyMethodArgument> &fixuppedArgs,
-                                const char* iIterator, 
-                                int& oError) {
-     oError = parser::kNameDoesNotExist;
-    edm::TypeWithDict type = t; 
-    if (! type)  
-      throw parser::Exception(iIterator)
-	<< "No dictionary for class \"" << type.name() << "\".";
-    while(type.isPointer() || type.isTypedef()) type = type.toType();
-    type = edm::TypeWithDict(type, 0L); // strip const, volatile, c++ ref, ..
+typedef std::pair<int, edm::FunctionWithDict> OK;
 
-    pair<edm::FunctionWithDict, bool> mem; mem.second = false;
-    int                               err_fatal = 0;
+bool
+nCasts(const OK& a, const OK& b)
+{
+  return a.first < b.first;
+}
 
-    // suitable members and number of integer->real casts required to get them
-    vector<pair<int,edm::FunctionWithDict> > oks;
+std::pair<edm::FunctionWithDict, bool>
+findMethod(const edm::TypeWithDict& t, /*class=in*/
+           const std::string& name, /*function member name=in*/
+           const std::vector<AnyMethodArgument>& args, /*args=in*/
+           std::vector<AnyMethodArgument>& fixuppedArgs, /*args=out*/
+           const char* iIterator, /*???=out*/
+           int& oError) /*err code=out*/
+{
+  oError = parser::kNameDoesNotExist;
+  edm::TypeWithDict type = t;
+  if (!bool(type)) {
+    throw parser::Exception(iIterator) << "No dictionary for class \"" <<
+          type.name() << "\".";
+  }
+  while(type.isPointer() || type.isTypedef()) {
+    type = type.toType();
+  }
+  type = edm::TypeWithDict(type, 0L); // strip const, volatile, c++ ref, ..
+
+  std::pair<edm::FunctionWithDict, bool> mem;
+  //FIXME: We must initialize mem.first!
+  mem.second = false;
+  // suitable members and number of integer->real casts required to get them
+  std::vector<std::pair<int, edm::FunctionWithDict> > oks;
 
     // first look in base scope
     edm::TypeFunctionMembers functions(type);
-    for(auto const& function : functions) {
-      edm::FunctionWithDict m(function);
-      if(m.name()==name) {
-        int casts = checkMethod(m, type, args, fixuppedArgs);
-        if (casts > -1) {
-            oks.push_back( make_pair(casts,m) );
-        } else {
-           oError = -1*casts;
-           //is this a show stopper error?
-           if(fatalErrorCondition(oError) && err_fatal == 0) {
-              err_fatal = oError;
-           }
+    for (auto const& F : functions) {
+      edm::FunctionWithDict f(F);
+      if (f.name() != name) {
+        continue;
+      }
+      int casts = checkMethod(f, type, args, fixuppedArgs);
+      if (casts > -1) {
+        oks.push_back(std::make_pair(casts, f));
+      } else {
+        oError = -1 * casts;
+        //is this a show stopper error?
+        if (fatalErrorCondition(oError)) {
+          return mem;
         }
       }
     }
-    //std::cout << "At base scope (type " << (type.name()) << ") found " << oks.size() << " methods." << std::endl; 
-
-    if (oks.empty() && err_fatal)
-    {
-       oError = err_fatal;
-       return mem;
-    }
-
-    // found at least one method
-    if (!oks.empty()) {
-        if (oks.size() > 1) {
-            // sort by number of conversions needed
-            sort(oks.begin(), oks.end(), nCasts);
-
-            if (oks[0].first == oks[1].first) { // two methods with same ambiguity
-                throw parser::Exception(iIterator)
-                    << "Can't resolve method \"" << name << "\" for class \"" << type.name() << "\", the two candidates " 
-                    << oks[0].second.name() << " and " << oks[1].second.name() 
-                    << " require the same number of integer->real conversions (" << oks[0].first << ").";        
-            }
-
-            // I should fixup again the args, as both good methods have pushed them on fixuppedArgs
-            fixuppedArgs.clear();
-            checkMethod(oks.front().second, type, args, fixuppedArgs);
-        } 
-        mem.first = oks.front().second;
-    }
-
-    // if nothing was found, look in parent scopes (without checking for cross-scope overloading, as it's not allowed)
-    int baseError=parser::kNameDoesNotExist;
-    if(! mem.first) {
-      R__LOCKGUARD(gCINTMutex);
-      edm::TypeBases bases(type);
-      for(auto const& base : bases) {
-	      if((mem = findMethod(edm::BaseWithDict(base).typeOf(), name, args, fixuppedArgs,iIterator,baseError)).first) break;
-	      if(fatalErrorCondition(baseError)) {
-            oError = baseError;
-            return mem;
-	      }
+  //std::cout << "At base scope (type " << (type.name()) << ") found " <<
+  //  oks.size() << " methods." << std::endl;
+  // found at least one method
+  if (!oks.empty()) {
+    if (oks.size() > 1) {
+      // sort by number of conversions needed
+      sort(oks.begin(), oks.end(), nCasts);
+      if (oks[0].first == oks[1].first) { // two methods with same ambiguity
+        throw parser::Exception(iIterator) << "Can't resolve method \"" <<
+              name << "\" for class \"" << type.name() <<
+              "\", the two candidates " << oks[0].second.name() << " and " <<
+              oks[1].second.name() <<
+              " require the same number of integer->real conversions (" <<
+              oks[0].first << ").";
       }
+      // We must fixup the args again, as both good methods
+      // have pushed them on fixuppedArgs.
+      fixuppedArgs.clear();
+      checkMethod(oks.front().second, type, args, fixuppedArgs);
     }
-
-    // otherwise see if this object is just a Ref or Ptr and we should pop it out
-    if(!mem.first) {
-      // check for edm::Ref or edm::RefToBase or edm::Ptr
-      // std::cout << "Mem.first is null, so looking for templates from type " << type.name() << std::endl;
-      if(type.isTemplateInstance()) {
-         std::string name = type.templateName();
-         if(name.compare("edm::Ref") == 0 ||
-            name.compare("edm::RefToBase") == 0 ||
-            name.compare("edm::Ptr") == 0) {
-          // in this case  i think 'get' should be taken with no arguments!
-          std::vector<AnyMethodArgument> empty, empty2; 
-          int error;
-          mem = findMethod(type, "get", empty, empty2,iIterator,error);
-          if(!mem.first) {
-             throw parser::Exception(iIterator)
-                << "No member \"get\" in reference of type \"" << type.name() << "\".";        
-          }
-          mem.second = true;
-         }
-      }
-    }
-    /*
-    if(!mem.first) {
-      throw edm::Exception(edm::errors::Configuration)
-	<< "member \""" << name << "\"" not found in class \""  << type.name() << "\"";        
-    }
-    */
-    if(mem.first) {
-       oError = parser::kNoError;
-    } else {
-       //use error from base check if we never found function in primary class
-       if(oError == parser::kNameDoesNotExist) {
-          oError = baseError;
-       }
-    }
-    return mem;
+    mem.first = oks.front().second;
   }
+  // if nothing was found, look in parent scopes without
+  // checking for cross-scope overloading, as it is not
+  // allowed
+  int baseError = parser::kNameDoesNotExist;
+  if (!bool(mem.first)) {
+    R__LOCKGUARD(gCINTMutex);
+    edm::TypeBases bases(type);
+    for (auto const& B : bases) {
+      mem = findMethod(edm::BaseWithDict(B).typeOf(), name, args,
+                       fixuppedArgs, iIterator, baseError);
+      if (bool(mem.first)) {
+        break;
+      }
+      if (fatalErrorCondition(baseError)) {
+        oError = baseError;
+        return mem;
+      }
+    }
+  }
+  // otherwise see if this object is just a Ref or Ptr and we should pop it out
+  if (!bool(mem.first)) {
+    // check for edm::Ref or edm::RefToBase or edm::Ptr
+    if (type.isTemplateInstance()) {
+      std::string name = type.templateName();
+      if (!name.compare("edm::Ref") || !name.compare("edm::RefToBase") ||
+          !name.compare("edm::Ptr")) {
+        // in this case  i think 'get' should be taken with no arguments!
+        std::vector<AnyMethodArgument> empty;
+        std::vector<AnyMethodArgument> empty2;
+        int error = 0;
+        mem = findMethod(type, "get", empty, empty2, iIterator, error);
+        if (!bool(mem.first)) {
+          throw parser::Exception(iIterator) <<
+                "No member \"get\" in reference of type \"" <<
+                type.name() << "\".";
+        }
+        mem.second = true;
+      }
+    }
+  }
+  //if (!bool(mem.first)) {
+  //  throw edm::Exception(edm::errors::Configuration) << "member \""" <<
+  //        name << "\"" not found in class \""  << type.name() << "\"";
+  //}
+  if (bool(mem.first)) {
+    oError = parser::kNoError;
+  }
+  else {
+    // use error from base check if we never found function in primary class
+    if (oError == parser::kNameDoesNotExist) {
+      oError = baseError;
+    }
+  }
+  return mem;
 }
+
+} // namespace reco
+

--- a/CommonTools/Utils/src/returnType.cc
+++ b/CommonTools/Utils/src/returnType.cc
@@ -48,10 +48,10 @@ namespace reco {
       Values{name, enumType},
       [](const Values& iLHS, const Values& iRHS) -> bool {
         return std::strcmp(iLHS.first, iRHS.first) < 0;
-    });
+      });
     if (f.first == f.second) {
       return t.isEnum() ? enumType : invalid;
-  }
+    }
     return f.first->second;
   }
 


### PR DESCRIPTION
This pull request is for commonality in the CMSSW code for the package CommonTools/Utils between CMSSW_7_4_ROOT6_X and CMSSW_7_4_X. All the changes in this package in CMSSW_7_4_ROOT6_X that are compatible with ROOT5 are ported back in this PR. The changes may seem extensive, but much of it is white space changes and reformatting.
The CondCore/Utils unit tests and the entire relval matrix pass in 7_4_X with this PR.
