### PR TITLE
Fix sorting of values in QuickTrackAssociatorHitsByImpl

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -181,6 +181,7 @@ reco::RecoToSimCollection QuickTrackAssociatorByHitsImpl::associateRecoToSimImpl
 			}
 		}
 	}
+	returnValue.post_insert();
 	return returnValue;
 }
 
@@ -238,6 +239,7 @@ reco::SimToRecoCollection QuickTrackAssociatorByHitsImpl::associateSimToRecoImpl
 			}
 		}
 	}
+	returnValue.post_insert();
 	return returnValue;
 
 }
@@ -627,7 +629,6 @@ reco::SimToRecoCollectionSeed QuickTrackAssociatorByHitsImpl::associateSimToReco
 			}
 		}
 	}
-	return returnValue;
 
 	LogTrace("TrackAssociator") << "% of Assoc TPs=" << ((double)returnValue.size())/((double)trackingParticleCollectionHandle->size());
 	returnValue.post_insert();


### PR DESCRIPTION
In case SimToRecoCollection (RecoToSimCollection) has more than 1 track associated to a TrackingParticle (vice versa), in the collection returned by QuickTrackAssociatorHitsByImpl these tracks (TPs) are not sorted by the matching quality. However, edm::Event::put() calls the AssociatorMap::post_insert() (which does the sorting) when a product is inserted to Event. This behaviour can create a subtle difference in cases where the SimToRecoCollection/RecoToSimCollection is read from an Event and where they are produced on the fly.

This PR makes the return values of QuickTrackAssociatorHitsByImpl to be always sorted (the association wrt. TrajectorySeed was already sorted, and that is also the behaviour in other TrackAssociators). I deliberately fixed only the new-style associator, as I intend to clean up the old-style associators in a separate PR.

Tested in 750pre1 with 9k RelValTTbar events. Tiny changes are expected in DQM plots utilizing the track-TP associations such that something from the value of the association is plotted. Couple of examples from MultiTrackValidator for all tracks (black old, red new):
![image](https://cloud.githubusercontent.com/assets/33993/6843443/53628634-d3a3-11e4-9b41-e16165d4ee82.png)
![image](https://cloud.githubusercontent.com/assets/33993/6843463/a437120a-d3a3-11e4-9106-9341abdcd34a.png)

Especially the efficiencies and fake rates reported by MTV should not be affected, but duplicate rate can be, as demonstrated by this plot from HLT tracks
![image](https://cloud.githubusercontent.com/assets/33993/6843618/08e8722e-d3a5-11e4-9171-09a90ab67a4b.png)

@rovere @VinInn 
