### PR TITLE
Fix the index in the dEdxHitAssociation

### DIFF
--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
@@ -119,7 +119,7 @@ void DeDxHitInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
         } 
      }
 
-     indices.push_back(j);
+     indices.push_back(resultdedxHitColl->size());
      resultdedxHitColl->push_back(hitDeDxInfo);
   }
   ///////////////////////////////////////


### PR DESCRIPTION
Super important bug fix in the dEdxHit association.
The index used was incorrect --> making the map totally useless.
This patch fix the issue and must be used asap  (also for data release).

I am therefore making a PR for both 74X and 75X
