### PR TITLE
Remove blank line for code commonality

### DIFF
--- a/DQM/SiStripMonitorClient/bin/BuildFile.xml
+++ b/DQM/SiStripMonitorClient/bin/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="root"/>
-
 <use   name="rootgraphics"/>
 <bin   name="check_runcomplete" file="check_runcomplete.cc"></bin>
 <bin   name="listbadmodule" file="listbadmodule.cc"></bin>


### PR DESCRIPTION
Totally trivial.  For code commonality. Removing a blank line from this BuildFile makes it identical with the one in CMSSW_7_5_ROOT6_X.
Please bypass L2 signatures for this totally trivial PR.
