### PR TITLE
Remove unnecessary link dependency

### DIFF
--- a/PhysicsTools/PatExamples/bin/BuildFile.xml
+++ b/PhysicsTools/PatExamples/bin/BuildFile.xml
@@ -1,6 +1,4 @@
 <use   name="root"/>
-<use   name="boost"/>
-
 <use   name="FWCore/FWLite"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="FWCore/PythonParameterSet"/>


### PR DESCRIPTION
Totally trivial. Remove an unnecessary link dependency. This makes the BuildFile identical with that in CMSSW_7_4_X.
Please bypass L2 signature, because this is totally technical, and merge as soon as convenient.
