### PR TITLE
Changed DQM configuration parameters for modified SUSY Single lepton cross-triggers

### DIFF
--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_BTag_SingleLepton_cff.py
@@ -24,7 +24,7 @@ SUSY_HLT_Ele_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                    hltProcess = cms.string('HLT'),
 
                                                    triggerPath = cms.string('HLT_Ele15_IsoVVVL_BTagtop8CSV07_PFHT400'),
-                                                   triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP75_Gsf_v'),
+                                                   triggerPathAuxiliary = cms.string('HLT_Ele35_eta2p1_WP85_Gsf_v'),
                                                    triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
                                                    csvlCut = cms.untracked.double(0.244),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_Control_SingleLepton_cff.py
@@ -24,7 +24,7 @@ SUSY_HLT_Ele_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                       hltProcess = cms.string('HLT'),
 
                                                       triggerPath = cms.string('HLT_Ele15_PFHT300'),
-                                                      triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP75_Gsf_v'),
+                                                      triggerPathAuxiliary = cms.string('HLT_Ele35_eta2p1_WP85_Gsf_v'),
                                                       triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
                                                       csvlCut = cms.untracked.double(0.244),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_MET_SingleLepton_cff.py
@@ -24,7 +24,7 @@ SUSY_HLT_Ele_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                   hltProcess = cms.string('HLT'),
 
                                                   triggerPath = cms.string('HLT_Ele15_IsoVVVL_PFHT400_PFMET70'),
-                                                  triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP75_Gsf_v'),
+                                                  triggerPathAuxiliary = cms.string('HLT_Ele35_eta2p1_WP85_Gsf_v'),
                                                   triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
                                                   csvlCut = cms.untracked.double(0.244),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Ele_HT_SingleLepton_cff.py
@@ -24,7 +24,7 @@ SUSY_HLT_Ele_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                               hltProcess = cms.string('HLT'),
 
                                               triggerPath = cms.string('HLT_Ele15_IsoVVVL_PFHT600'),
-                                              triggerPathAuxiliary = cms.string('HLT_Ele32_eta2p1_WP75_Gsf_v'),
+                                              triggerPathAuxiliary = cms.string('HLT_Ele35_eta2p1_WP85_Gsf_v'),
                                               triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
                                               csvlCut = cms.untracked.double(0.244),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_BTag_SingleLepton_cff.py
@@ -12,7 +12,7 @@ SUSY_HLT_Mu_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                   conversionCollection = cms.InputTag(''),
                                                   beamSpot = cms.InputTag(''),
 
-                                                  leptonFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f3QL3Filtered15QL3trkIsoFiltered0p09','','HLT'),
+                                                  leptonFilter = cms.InputTag('hltL3MuVVVLIsoFIlter','','HLT'),
                                                   hltHt = cms.InputTag('hltPFHT400','','HLT'),
                                                   hltMet = cms.InputTag(''),
                                                   hltJets = cms.InputTag('hltSelector4CentralJetsL1FastJet','','HLT'),
@@ -24,7 +24,7 @@ SUSY_HLT_Mu_HT_BTag_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                   hltProcess = cms.string('HLT'),
 
                                                   triggerPath = cms.string('HLT_Mu15_IsoVVVL_BTagCSV07_PFHT400'),
-                                                  triggerPathAuxiliary = cms.string('HLT_IsoMu24_eta2p1_v'),
+                                                  triggerPathAuxiliary = cms.string('HLT_IsoMu27_v'),
                                                   triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
                                                   csvlCut = cms.untracked.double(0.244),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_Control_SingleLepton_cff.py
@@ -24,7 +24,7 @@ SUSY_HLT_Mu_HT_Control_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                      hltProcess = cms.string('HLT'),
 
                                                      triggerPath = cms.string('HLT_Mu15_PFHT300_v'),
-                                                     triggerPathAuxiliary = cms.string('HLT_IsoMu24_eta2p1_v'),
+                                                     triggerPathAuxiliary = cms.string('HLT_IsoMu27_v'),
                                                      triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
                                                      csvlCut = cms.untracked.double(0.244),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_MET_SingleLepton_cff.py
@@ -12,7 +12,7 @@ SUSY_HLT_Mu_HT_MET_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                                  conversionCollection = cms.InputTag(''),
                                                  beamSpot = cms.InputTag(''),
 
-                                                 leptonFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f3QL3Filtered15QL3trkIsoFiltered0p09','','HLT'),
+                                                 leptonFilter = cms.InputTag('hltL3MuVVVLIsoFIlter','','HLT'),
                                                  hltHt = cms.InputTag('hltPFHT','','HLT'),
                                                  hltMet = cms.InputTag('hltPFMETProducer','','HLT'),
                                                  hltJets = cms.InputTag(''),

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_Mu_HT_SingleLepton_cff.py
@@ -12,7 +12,7 @@ SUSY_HLT_Mu_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              conversionCollection = cms.InputTag(''),
                                              beamSpot = cms.InputTag(''),
 
-                                             leptonFilter = cms.InputTag('hltL3fL1sMu5L1f0L2f3QL3Filtered15QL3trkIsoFiltered0p09','','HLT'),
+                                             leptonFilter = cms.InputTag('hltL3MuVVVLIsoFIlter','','HLT'),
                                              hltHt = cms.InputTag('hltPFHT','','HLT'),
                                              hltMet = cms.InputTag(''),
                                              hltJets = cms.InputTag(''),
@@ -24,7 +24,7 @@ SUSY_HLT_Mu_HT_SingleLepton = cms.EDAnalyzer('SUSY_HLT_SingleLepton',
                                              hltProcess = cms.string('HLT'),
 
                                              triggerPath = cms.string('HLT_Mu15_IsoVVVL_PFHT600_v'),
-                                             triggerPathAuxiliary = cms.string('HLT_IsoMu24_eta2p1_v'),
+                                             triggerPathAuxiliary = cms.string('HLT_IsoMu27_v'),
                                              triggerPathLeptonAuxiliary = cms.string('HLT_PFHT350_PFMET120_NoiseCleaned_v'),
 
                                              csvlCut = cms.untracked.double(0.244),


### PR DESCRIPTION
We are changing the isolation cone to R=0.2 for the SUSY Single lepton cross-triggers
https://its.cern.ch/jira/browse/CMSHLT-311

One module has changed name, so we needed to change the cff file.

Also, the single lepton triggers that we used as a reference have changed thresholds, so we changed those parameters accordingly.

This PR is based on CMSSW_7_5_X and follows the #8476 that was based on CMSSW_7_4_X, as per suggestion of @deguio 
