### PR TITLE
Update ConfigDP to correctly handle DQMIO configuration @ Tier0

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -175,8 +175,18 @@ class ConfigBuilder(object):
         #if not self._options.conditions:
         #        raise Exception("ERROR: No conditions given!\nPlease specify conditions. E.g. via --conditions=IDEAL_30X::All")
 
-	if hasattr(self._options,"datatier") and self._options.datatier and 'DQMIO' in self._options.datatier and 'ENDJOB' in self._options.step:
-		self._options.step=self._options.step.replace(',ENDJOB','')
+	# check that MEtoEDMConverter (running in ENDJOB) and DQMIO don't run in the same job
+	if 'ENDJOB' in self._options.step:
+		if  (hasattr(self._options,"outputDefinition") and \
+		    self._options.outputDefinition != '' and \
+		    any(outdic['dataTier'] == 'DQMIO' for outdic in eval(self._options.outputDefinition))) or \
+		    (hasattr(self._options,"datatier") and \
+		    self._options.datatier and \
+		    'DQMIO' in self._options.datatier):
+			print "removing ENDJOB from steps since not compatible with DQMIO dataTier" 
+			self._options.step=self._options.step.replace(',ENDJOB','')
+
+
 		
         # what steps are provided by this class?
         stepList = [re.sub(r'^prepare_', '', methodName) for methodName in ConfigBuilder.__dict__ if methodName.startswith('prepare_')]

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -159,13 +159,23 @@ def MassReplaceInputTag(aProcess,oldT="rawDataCollector",newT="rawDataRepacker")
 	for s in aProcess.paths_().keys():
 		massSearchReplaceAnyInputTag(getattr(aProcess,s),oldT,newT)
 
+def anyOf(listOfKeys,dict,opt=None):
+	for k in listOfKeys:
+		if k in dict:
+			toReturn=dict[k]
+			dict.pop(k)
+			return toReturn
+	if opt!=None:
+		return opt
+	else:
+		raise Exception("any of "+','.join(listOfKeys)+" are mandatory entries of --output options")
 
 class ConfigBuilder(object):
     """The main building routines """
 
     def __init__(self, options, process = None, with_output = False, with_input = False ):
         """options taken from old cmsDriver and optparse """
-
+	    
         options.outfile_name = options.dirout+options.fileout
 
         self._options = options
@@ -179,7 +189,7 @@ class ConfigBuilder(object):
 	if 'ENDJOB' in self._options.step:
 		if  (hasattr(self._options,"outputDefinition") and \
 		    self._options.outputDefinition != '' and \
-		    any(outdic['dataTier'] == 'DQMIO' for outdic in eval(self._options.outputDefinition))) or \
+		    any(anyOf(['t','tier','dataTier'],outdic) == 'DQMIO' for outdic in eval(self._options.outputDefinition))) or \
 		    (hasattr(self._options,"datatier") and \
 		    self._options.datatier and \
 		    'DQMIO' in self._options.datatier):
@@ -472,18 +482,7 @@ class ConfigBuilder(object):
 	if self._options.outputDefinition:
 		if self._options.datatier:
 			print "--datatier & --eventcontent options ignored"
-			
-		def anyOf(listOfKeys,dict,opt=None):
-			for k in listOfKeys:
-				if k in dict:
-					toReturn=dict[k]
-					dict.pop(k)
-					return toReturn
-			if opt!=None:
-				return opt
-			else:
-				raise Exception("any of "+','.join(listOfKeys)+" are mandatory entries of --output options")
-				
+							
 		#new output convention with a list of dict
 		outList = eval(self._options.outputDefinition)
 		for (id,outDefDict) in enumerate(outList):

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -18,11 +18,11 @@ class RunExpressProcessing:
 
     def __init__(self):
         self.scenario = None
-        self.writeRaw = False
-        self.writeReco = False
-        self.writeFevt = False
-        self.writeAlca = False
-        self.writeDqm = False
+        self.writeRAW = False
+        self.writeRECO = False
+        self.writeFEVT = False
+        self.writeDQM = False
+        self.writeDQMIO = False
         self.noOutput = False
         self.globalTag = None
         self.inputLFN = None
@@ -33,7 +33,7 @@ class RunExpressProcessing:
             msg = "No --scenario specified"
             raise RuntimeError, msg
         if self.globalTag == None:
-            msg = "No --global-tag specified"
+            msg = "No --globaltag specified"
             raise RuntimeError, msg
         if self.inputLFN == None:
             msg = "No --lfn specified"
@@ -51,40 +51,40 @@ class RunExpressProcessing:
         print "Using Global Tag: %s" % self.globalTag
 
         dataTiers = []
-        if self.writeRaw:
+        if self.writeRAW:
             dataTiers.append("RAW")
-            print "Configuring to Write out Raw..."
-        if self.writeReco:
+            print "Configuring to Write out RAW"
+        if self.writeRECO:
             dataTiers.append("RECO")
-            print "Configuring to Write out Reco..."
-        if self.writeFevt:
+            print "Configuring to Write out RECO"
+        if self.writeFEVT:
             dataTiers.append("FEVT")
-            print "Configuring to Write out Fevt..."
-        if self.writeAlca:
-            dataTiers.append("ALCARECO")
-            print "Configuring to Write out Alca..."
-        if self.writeDqm:
+            print "Configuring to Write out FEVT"
+        if self.writeDQM:
             dataTiers.append("DQM")
-            print "Configuring to Write out Dqm..."
+            print "Configuring to Write out DQM"
+        if self.writeDQMIO:
+            dataTiers.append("DQMIO")
+            print "Configuring to Write out DQMIO"
+        if self.alcaRecos:
+            dataTiers.append("ALCARECO")
+            print "Configuring to Write out ALCARECO"
 
         try:
             kwds = {}
 
             if self.noOutput:
-                # get config without any output
-                kwds['writeTiers'] = []
+                kwds['outputs'] = []
+            else:
+                outputs = []
+                for dataTier in dataTiers:
+                    outputs.append({ 'dataTier' : dataTier,
+                                     'eventContent' : dataTier,
+                                     'moduleLabel' : "write_%s" % dataTier })
+                kwds['outputs'] = outputs
 
-            elif len(dataTiers) > 0:
-                # get config with specified output
-                kwds['writeTiers'] = dataTiers
-
-            # if none of the above use default output data tiers
-
-
-            if not self.alcaRecos is None:
-                # if skims specified from command line than overwrite the defaults
-                kwds['skims'] = self.alcaRecos
-
+                if self.alcaRecos:
+                    kwds['skims'] = self.alcaRecos
 
             process = scenario.expressProcessing(self.globalTag, **kwds)
 
@@ -111,8 +111,8 @@ class RunExpressProcessing:
 
 
 if __name__ == '__main__':
-    valid = ["scenario=", "raw", "reco", "fevt", "alca", "dqm", "no-output",
-             "global-tag=", "lfn=", 'alcaRecos=']
+    valid = ["scenario=", "raw", "reco", "fevt", "dqm", "dqmio", "no-output",
+             "globaltag=", "lfn=", 'alcarecos=']
     usage = \
 """
 RunExpressProcessing.py <options>
@@ -122,15 +122,18 @@ Where options are:
  --raw (to enable RAW output)
  --reco (to enable RECO output)
  --fevt (to enable FEVT output)
- --alca (to enable ALCARECO output)
  --dqm (to enable DQM output)
+ --dqmio (to enable DQMIO output)
  --no-output (create config with no output, overrides other settings)
- --global-tag=GlobalTag
+ --globaltag=GlobalTag
  --lfn=/store/input/lfn
- --alcaRecos=commasepratedlist
+ --alcarecos=plus_seprated_list
 
-Example:
-python RunExpressProcessing.py --scenario cosmics --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm
+Examples:
+
+python RunExpressProcessing.py --scenario cosmics --globaltag GLOBALTAG::ALL --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlCosmics0T+SiStripCalZeroBias
+
+python RunExpressProcessing.py --scenario pp --globaltag GLOBALTAG::ALL --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
 
 """
     try:
@@ -147,22 +150,22 @@ python RunExpressProcessing.py --scenario cosmics --global-tag GLOBALTAG::ALL --
         if opt == "--scenario":
             expressinator.scenario = arg
         if opt == "--raw":
-            expressinator.writeRaw = True
+            expressinator.writeRAW = True
         if opt == "--reco":
-            expressinator.writeReco = True
+            expressinator.writeRECO = True
         if opt == "--fevt":
-            expressinator.writeFevt = True
-        if opt == "--alca":
-            expressinator.writeAlca = True
+            expressinator.writeFEVT = True
         if opt == "--dqm":
-            expressinator.writeDqm = True
+            expressinator.writeDQM = True
+        if opt == "--dqmio":
+            expressinator.writeDQMIO = True
         if opt == "--no-output":
             expressinator.noOutput = True
-        if opt == "--global-tag":
+        if opt == "--globaltag":
             expressinator.globalTag = arg
         if opt == "--lfn" :
             expressinator.inputLFN = arg
-        if opt == "--alcaRecos":
+        if opt == "--alcarecos":
             expressinator.alcaRecos = [ x for x in arg.split('+') if len(x) > 0 ]
 
     expressinator()

--- a/Configuration/DataProcessing/test/RunExpressProcessing.py
+++ b/Configuration/DataProcessing/test/RunExpressProcessing.py
@@ -33,7 +33,7 @@ class RunExpressProcessing:
             msg = "No --scenario specified"
             raise RuntimeError, msg
         if self.globalTag == None:
-            msg = "No --globaltag specified"
+            msg = "No --global-tag specified"
             raise RuntimeError, msg
         if self.inputLFN == None:
             msg = "No --lfn specified"
@@ -112,7 +112,7 @@ class RunExpressProcessing:
 
 if __name__ == '__main__':
     valid = ["scenario=", "raw", "reco", "fevt", "dqm", "dqmio", "no-output",
-             "globaltag=", "lfn=", 'alcarecos=']
+             "global-tag=", "lfn=", 'alcarecos=']
     usage = \
 """
 RunExpressProcessing.py <options>
@@ -125,15 +125,15 @@ Where options are:
  --dqm (to enable DQM output)
  --dqmio (to enable DQMIO output)
  --no-output (create config with no output, overrides other settings)
- --globaltag=GlobalTag
+ --global-tag=GlobalTag
  --lfn=/store/input/lfn
  --alcarecos=plus_seprated_list
 
 Examples:
 
-python RunExpressProcessing.py --scenario cosmics --globaltag GLOBALTAG::ALL --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlCosmics0T+SiStripCalZeroBias
+python RunExpressProcessing.py --scenario cosmics --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlCosmics0T+SiStripCalZeroBias
 
-python RunExpressProcessing.py --scenario pp --globaltag GLOBALTAG::ALL --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
+python RunExpressProcessing.py --scenario pp --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio --alcarecos=TkAlMinBias+SiStripCalZeroBias
 
 """
     try:
@@ -161,7 +161,7 @@ python RunExpressProcessing.py --scenario pp --globaltag GLOBALTAG::ALL --lfn /s
             expressinator.writeDQMIO = True
         if opt == "--no-output":
             expressinator.noOutput = True
-        if opt == "--globaltag":
+        if opt == "--global-tag":
             expressinator.globalTag = arg
         if opt == "--lfn" :
             expressinator.inputLFN = arg

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -18,15 +18,14 @@ class RunPromptReco:
 
     def __init__(self):
         self.scenario = None
-        self.writeReco = False
-        self.writeAlca = False
-        self.writeAlcareco = False
-        self.writeAod = False
-	self.writeDqm = False
-	self.writeDqmio = False
+        self.writeRECO = False
+        self.writeAOD = False
+	self.writeDQM = False
+	self.writeDQMIO = False
         self.noOutput = False
         self.globalTag = None
         self.inputLFN = None
+        self.alcaRecos = None
 
     def __call__(self):
         if self.scenario == None:
@@ -51,32 +50,40 @@ class RunPromptReco:
         print "Using Global Tag: %s" % self.globalTag
 
         dataTiers = []
-        if self.writeReco:
+        if self.writeRECO:
             dataTiers.append("RECO")
-            print "Configuring to Write out Reco..."
-        if self.writeAlcareco:
-            dataTiers.append("ALCARECO")
-            print "Configuring to Write out Alca..."
-        if self.writeAod:
+            print "Configuring to Write out RECO"
+        if self.writeAOD:
             dataTiers.append("AOD")
-            print "Configuring to Write out AOD..."
-	if self.writeDqm:
+            print "Configuring to Write out AOD"
+	if self.writeDQM:
             dataTiers.append("DQM")
-            print "Configuring to Write out Dqm..."
-	if self.writeDqmio:
+            print "Configuring to Write out DQM"
+	if self.writeDQMIO:
             dataTiers.append("DQMIO")
-            print "Configuring to Write out Dqmio..."
+            print "Configuring to Write out DQMIO"
+        if self.alcaRecos:
+            dataTiers.append("ALCARECO")
+            print "Configuring to Write out ALCARECO"
 
         try:
+            kwds = {}
+
             if self.noOutput:
-                # get config without any output
-                process = scenario.promptReco(globalTag = self.globalTag, writeTiers = [])
-            elif len(dataTiers) > 0:
-                # get config with specified output
-                process = scenario.promptReco(globalTag = self.globalTag, writeTiers = dataTiers)
+                kwds['outputs'] = []
             else:
-                # use default output data tiers
-                process = scenario.promptReco(globalTag = self.globalTag)
+                outputs = []
+                for dataTier in dataTiers:
+                    outputs.append({ 'dataTier' : dataTier,
+                                     'eventContent' : dataTier,
+                                     'moduleLabel' : "write_%s" % dataTier })
+                kwds['outputs'] = outputs
+
+                if self.alcaRecos:
+                    kwds['skims'] = self.alcaRecos
+
+            process = scenario.promptReco(self.globalTag, **kwds)
+
         except NotImplementedError, ex:
             print "This scenario does not support Prompt Reco:\n"
             return
@@ -100,8 +107,8 @@ class RunPromptReco:
 
 
 if __name__ == '__main__':
-    valid = ["scenario=", "reco", "alcareco", "aod", "dqm", "dqmio",
-             "no-output", "global-tag=", "lfn="]
+    valid = ["scenario=", "reco", "aod", "dqm", "dqmio", "no-output",
+             "globaltag=", "lfn=", "alcarecos=" ]
     usage = \
 """
 RunPromptReco.py <options>
@@ -109,17 +116,19 @@ RunPromptReco.py <options>
 Where options are:
  --scenario=ScenarioName
  --reco (to enable RECO output)
- --alcareco (to enable ALCARECO output)
  --aod (to enable AOD output)
  --dqm (to enable DQM output)
  --dqmio (to enable DQMIO output)
  --no-output (create config with no output, overrides other settings)
- --global-tag=GlobalTag
+ --globaltag=GlobalTag
  --lfn=/store/input/lfn
-
+ --alcarecos=plus_seprated_list
 
 Example:
-python RunPromptReco.py --scenario=cosmics --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever
+
+python RunPromptReco.py --scenario=cosmics --reco --aod --dqmio --globaltag GLOBALTAG::ALL --lfn=/store/whatever --alcarecos=TkAlCosmics0T+MuAlGlobalCosmics
+
+python RunPromptReco.py --scenario=pp --reco --aod --dqmio --globaltag GLOBALTAG::ALL --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias
 
 """
     try:
@@ -137,8 +146,6 @@ python RunPromptReco.py --scenario=cosmics --reco --aod --alcareco --dqm --globa
             recoinator.scenario = arg
         if opt == "--reco":
             recoinator.writeReco = True
-        if opt == "--alcareco":
-            recoinator.writeAlcareco = True
         if opt == "--aod":
             recoinator.writeAod = True
         if opt == "--dqm":
@@ -147,10 +154,11 @@ python RunPromptReco.py --scenario=cosmics --reco --aod --alcareco --dqm --globa
             recoinator.writeDqmio = True
         if opt == "--no-output":
             recoinator.noOutput = True
-        if opt == "--global-tag":
+        if opt == "--globaltag":
             recoinator.globalTag = arg
         if opt == "--lfn" :
             recoinator.inputLFN = arg
-        
+        if opt == "--alcarecos":
+            recoinator.alcaRecos = [ x for x in arg.split('+') if len(x) > 0 ]
 
     recoinator()

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -32,7 +32,7 @@ class RunPromptReco:
             msg = "No --scenario specified"
             raise RuntimeError, msg
         if self.globalTag == None:
-            msg = "No --globaltag specified"
+            msg = "No --global-tag specified"
             raise RuntimeError, msg
         if self.inputLFN == None:
             msg = "No --lfn specified"
@@ -108,7 +108,7 @@ class RunPromptReco:
 
 if __name__ == '__main__':
     valid = ["scenario=", "reco", "aod", "dqm", "dqmio", "no-output",
-             "globaltag=", "lfn=", "alcarecos=" ]
+             "global-tag=", "lfn=", "alcarecos=" ]
     usage = \
 """
 RunPromptReco.py <options>
@@ -120,15 +120,15 @@ Where options are:
  --dqm (to enable DQM output)
  --dqmio (to enable DQMIO output)
  --no-output (create config with no output, overrides other settings)
- --globaltag=GlobalTag
+ --global-tag=GlobalTag
  --lfn=/store/input/lfn
  --alcarecos=plus_seprated_list
 
 Example:
 
-python RunPromptReco.py --scenario=cosmics --reco --aod --dqmio --globaltag GLOBALTAG::ALL --lfn=/store/whatever --alcarecos=TkAlCosmics0T+MuAlGlobalCosmics
+python RunPromptReco.py --scenario=cosmics --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlCosmics0T+MuAlGlobalCosmics
 
-python RunPromptReco.py --scenario=pp --reco --aod --dqmio --globaltag GLOBALTAG::ALL --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias
+python RunPromptReco.py --scenario=pp --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias
 
 """
     try:
@@ -154,7 +154,7 @@ python RunPromptReco.py --scenario=pp --reco --aod --dqmio --globaltag GLOBALTAG
             recoinator.writeDqmio = True
         if opt == "--no-output":
             recoinator.noOutput = True
-        if opt == "--globaltag":
+        if opt == "--global-tag":
             recoinator.globalTag = arg
         if opt == "--lfn" :
             recoinator.inputLFN = arg

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -11,67 +11,34 @@ function die { echo $1: status $2 ;  exit $2; }
 function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?; }
 
 
-INPUT=${LOCAL_TEST_DIR}/RunExpressProcessing.py
+runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-runTest "${INPUT} --scenario cosmics --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
-runTest "${INPUT} --scenario pp --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
-runTest "${INPUT} --scenario cosmicsRun2 --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
-runTest "${INPUT} --scenario ppRun2 --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
-runTest "${INPUT} --scenario HeavyIons --global-tag GLOBALTAG::ALL --lfn /store/whatever --fevt --alca --dqm"
-
-
-INPUT=${LOCAL_TEST_DIR}/RunRepack.py
-
-runTest "${INPUT} --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons")
+for scenario in "${arr[@]}"
+do
+     runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
+     runTest "${LOCAL_TEST_DIR}/RunVisualizationProcessing.py --scenario $scenario --lfn /store/whatever --global-tag GLOBALTAG --fevt"
+     runTest "${LOCAL_TEST_DIR}/RunAlcaHarvesting.py --scenario $scenario --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
+done
 
 
-INPUT=${LOCAL_TEST_DIR}/RunPromptReco.py
-
-runTest "${INPUT} --scenario=cosmics --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-runTest "${INPUT} --scenario=pp --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-runTest "${INPUT} --scenario=cosmicsRun2 --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-runTest "${INPUT} --scenario=ppRun2 --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-runTest "${INPUT} --scenario=HeavyIons --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-runTest "${INPUT} --scenario=AlCaLumiPixels --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-#runTest "${INPUT} --scenario=AlCaP0 --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-#runTest "${INPUT} --scenario=AlCaPhiSymEcal --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-runTest "${INPUT} --scenario=AlCaTestEnable --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-runTest "${INPUT} --scenario=hcalnzs --reco --aod --alcareco --dqm --global-tag GLOBALTAG::ALL --lfn=/store/whatever"
-
-INPUT=${LOCAL_TEST_DIR}/RunAlcaSkimming.py
-
-runTest "${INPUT} --scenario pp --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBias,PromptCalibProd"
-runTest "${INPUT} --scenario cosmics --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripPCLHistos"
-runTest "${INPUT} --scenario ppRun2 --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBias,PromptCalibProd"
-runTest "${INPUT} --scenario cosmicsRun2 --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripPCLHistos"
-runTest "${INPUT} --scenario HeavyIons --lfn=/store/whatever --global-tag GLOBALTAG::ALL --skims SiStripCalZeroBias,SiStripCalMinBias,TkAlMinBiasHI,PromptCalibProd"
-runTest "${INPUT} --scenario AlCaLumiPixels --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims LumiPixels"
-#runTest "${INPUT} --scenario AlCaP0 --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims EcalCalPi0Calib"
-#runTest "${INPUT} --scenario AlCaPhiSymEcal --lfn /store/whatever --global-tag GLOBALTAG::ALL --skims EcalCalPhiSym"
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs")
+for scenario in "${arr[@]}"
+do
+     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+done
 
 
-INPUT=${LOCAL_TEST_DIR}/RunAlcaHarvesting.py
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels")
+for scenario in "${arr[@]}"
+do
+     runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
+     runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
+done
 
-runTest "${INPUT} --scenario pp --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
-runTest "${INPUT} --scenario cosmics --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=SiStripQuality"
-runTest "${INPUT} --scenario ppRun2 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
-runTest "${INPUT} --scenario cosmicsRun2 --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=SiStripQuality"
-runTest "${INPUT} --scenario HeavyIons --lfn /store/whatever --dataset /A/B/C --global-tag GLOBALTAG::ALL --workflows=BeamSpotByRun,BeamSpotByLumi,SiStripQuality"
 
-INPUT=${LOCAL_TEST_DIR}/RunDQMHarvesting.py
 
-runTest "${INPUT} --scenario pp --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
-runTest "${INPUT} --scenario cosmics --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
-runTest "${INPUT} --scenario ppRun2 --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
-runTest "${INPUT} --scenario cosmicsRun2 --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
-runTest "${INPUT} --scenario AlCaLumiPixels --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
-#runTest "${INPUT} --scenario AlCaP0 --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
-#runTest "${INPUT} --scenario AlCaPhiSymEcal --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG::ALL"
 
-INPUT=${LOCAL_TEST_DIR}/RunVisualizationProcessing.py
 
-runTest "${INPUT} --scenario pp --lfn /store/whatever --global-tag GLOBALTAG::ALL --fevt"
-runTest "${INPUT} --scenario cosmics --lfn /store/whatever --global-tag GLOBALTAG::ALL --fevt"
-runTest "${INPUT} --scenario ppRun2 --lfn /store/whatever --global-tag GLOBALTAG::ALL --fevt"
-runTest "${INPUT} --scenario cosmicsRun2 --lfn /store/whatever --global-tag GLOBALTAG::ALL --fevt"
-runTest "${INPUT} --scenario HeavyIons --lfn /store/whatever --global-tag GLOBALTAG::ALL --fevt"
+
+


### PR DESCRIPTION
Update express and prompt test scripts to use exactly the parameters set by Tier0. 
Protect ConfigBuilder from running MEtoEDMConverter together with DQMIO.
