### PR TITLE
Fix logic of tev muon track embedding code 

### DIFF
--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -235,7 +235,7 @@ reco::CandidatePtr Muon::sourceCandidatePtr( size_type i ) const {
 void Muon::embedMuonBestTrack(bool force) {
   muonBestTrack_.clear();
   embeddedMuonBestTrack_ = false;
-  bool alreadyEmbedded = force;
+  bool alreadyEmbedded = false;
   if (!force) {
       switch (muonBestTrackType()) {
         case None: alreadyEmbedded = true; break;
@@ -247,7 +247,7 @@ void Muon::embedMuonBestTrack(bool force) {
         case DYT: if (embeddedDytMuon_) alreadyEmbedded = true; break;
       }
   }
-  if (!alreadyEmbedded) {
+  if (force || !alreadyEmbedded) {
       muonBestTrack_.push_back(*reco::Muon::muonBestTrack());
       embeddedMuonBestTrack_ = true;
   }
@@ -256,10 +256,10 @@ void Muon::embedMuonBestTrack(bool force) {
 /// embed the Track selected to be the best measurement of the muon parameters
 void Muon::embedTunePMuonBestTrack(bool force) {
   tunePMuonBestTrack_.clear();
-  bool alreadyEmbedded = force;
+  bool alreadyEmbedded = false;
   embeddedTunePMuonBestTrack_ = false;
   if (!force) {
-      switch (muonBestTrackType()) {
+      switch (tunePMuonBestTrackType()) {
           case None: alreadyEmbedded = true; break;
           case InnerTrack: if (embeddedTrack_) alreadyEmbedded = true; break;
           case OuterTrack: if (embeddedStandAloneMuon_) alreadyEmbedded = true; break;
@@ -272,7 +272,7 @@ void Muon::embedTunePMuonBestTrack(bool force) {
           if (embeddedMuonBestTrack_) alreadyEmbedded = true;
       }
   }
-  if (!alreadyEmbedded) {
+  if (force || !alreadyEmbedded) {
       tunePMuonBestTrack_.push_back(*reco::Muon::tunePMuonBestTrack());
       embeddedTunePMuonBestTrack_ = true;
   }


### PR DESCRIPTION
- fix logic for embedding the `tunePMuonBestTrack` when it's different from the `muonBestTrack` or another already embedded track (bug found in 72X by @Fedespring)
- fix logic when the embedding is called with `bool force = true` to force the embedding even if it's already embedded for beign e.g. the tracker track (it was doing the opposite of what expected!)

None of these should have any impact in 7.4.X in the normal miniAOD production workflow since the code is called with `force = false` and since 7.3.X the TeV muon refits are embedded anyway in the slimmer  (PR #6202), but as is the code is wrong so it's better to fix it in case somebody runs it with a different configuration.
