### PR TITLE
Add consumes interface for getManyByType

### DIFF
--- a/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
+++ b/Validation/GlobalHits/src/GlobalHitsAnalyzer.cc
@@ -16,6 +16,7 @@ GlobalHitsAnalyzer::GlobalHitsAnalyzer(const edm::ParameterSet& iPSet) :
   G4TrkSrc_Token_( consumes<edm::SimTrackContainer>(iPSet.getParameter<edm::InputTag>("G4TrkSrc")) ),
   count(0)
 {
+  consumesMany<edm::HepMCProduct>();
   std::string MsgLoggerCat = "GlobalHitsAnalyzer_GlobalHitsAnalyzer";
 
   // get information from parameter set

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -17,6 +17,9 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet) :
   fName(""), verbosity(0), frequency(0), label(""), getAllProvenances(false),
   printProvenanceInfo(false), count(0)
 {
+  consumesMany<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit> > >();
+  consumesMany<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit> > >();
+  consumesMany<edm::SortedCollection<HORecHit, edm::StrictWeakOrdering<HORecHit> > >();
   std::string MsgLoggerCat = "GlobalRecHitsAnalyzer_GlobalRecHitsAnalyzer";
 
   // get information from parameter set


### PR DESCRIPTION
Add the consumes interface for the getManyByType calls in GlobalHitsAnalyzer amd GlobalRecHitsAnalyzer.  Note: The consumes interface for getManyByType calls does not use tokens.
