### PR TITLE
Puppi and SoftKiller cloning input candidates when they are of PF type

### DIFF
--- a/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/PuppiProducer.cc
@@ -156,9 +156,8 @@ void PuppiProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
     //for(unsigned int i0 = 0; i0 < lCandidates.size(); i0++) {
     //reco::PFCandidate pCand;
     auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(i0->pdgId());
-    reco::PFCandidate pCand( i0->charge(),
-			     i0->p4(),
-			     id );
+    const reco::PFCandidate *pPF = dynamic_cast<const reco::PFCandidate*>(&(*i0));
+    reco::PFCandidate pCand( pPF ? *pPF : reco::PFCandidate(i0->charge(), i0->p4(), id) );
     LorentzVector pVec = i0->p4();
     int val = i0 - i0begin;
 

--- a/CommonTools/PileupAlgos/plugins/SoftKillerProducer.cc
+++ b/CommonTools/PileupAlgos/plugins/SoftKillerProducer.cc
@@ -134,7 +134,8 @@ SoftKillerProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 	  jend = fjInputs.end(); j != jend; ++j ) {
     const reco::Candidate& cand = pfCandidates->at(j->user_index());
     auto id = dummySinceTranslateIsNotStatic.translatePdgIdToType(cand.pdgId());
-    reco::PFCandidate pCand( cand.charge(), cand.p4(), id );
+    const reco::PFCandidate *pPF = dynamic_cast<const reco::PFCandidate*>(&cand);
+    reco::PFCandidate pCand( pPF ? *pPF : reco::PFCandidate(cand.charge(), cand.p4(), id) );
     auto val = j->user_index();
     auto skmatch = find_if( soft_killed_event.begin(), soft_killed_event.end(), [&val](fastjet::PseudoJet const & i){return i.user_index() == val;} );
     LorentzVector pVec;


### PR DESCRIPTION
Puppi and SoftKiller producers now clone the input candidates if they are of PF type in order to keep things like track Refs, etc. This will enable subjet b tagging for Puppi and SoftKiller jets.

@rappoccio @nhanvtran @violatingcp
