### PR TITLE
MiniAOD tweaks

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -170,8 +170,6 @@ def miniAOD_customizeCommon(process):
     
     process.patJetsPuppi.userData.userFloats.src = cms.VInputTag(cms.InputTag(""))
     process.patJetsPuppi.jetChargeSource = cms.InputTag("patJetPuppiCharge")
-    process.patJetsPuppi.tagInfoSources = cms.VInputTag(cms.InputTag("pfSecondaryVertexTagInfosPuppi"))
-    process.patJetsPuppi.addTagInfos = cms.bool(True)
 
     process.selectedPatJetsPuppi.cut = cms.string("pt > 20")
 

--- a/PhysicsTools/PatAlgos/python/tools/helpers.py
+++ b/PhysicsTools/PatAlgos/python/tools/helpers.py
@@ -11,7 +11,7 @@ def addESProducers(process,config):
 	module = __import__(config)
 	for name in dir(sys.modules[config]):
 		item = getattr(sys.modules[config],name)
-		if isinstance(item,_Labelable) and not isinstance(item,_ModuleSequenceType) and not name.startswith('_') and not (name == "source" or name == "looper" or name == "subProcess") and not type(item) is cms.PSet:
+		if isinstance(item,cms._Labelable) and not isinstance(item,cms._ModuleSequenceType) and not name.startswith('_') and not (name == "source" or name == "looper" or name == "subProcess") and not type(item) is cms.PSet:
 			if 'ESProducer' in item.type_():
 				setattr(process,name,item)
 

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -392,27 +392,15 @@ class AddJetCollection(ConfigToolBase):
                         requiredTagInfos.append(requiredTagInfo)
             ## load sequences and setups needed for btagging
             ## This loads all available btagger, but the ones we need are added to the process by hand later. Only needed to get the ESProducer. Needs improvement
-            #loadWithPostFix(process,"RecoBTag.Configuration.RecoBTag_cff",postfix)
             if hasattr( process, 'candidateJetProbabilityComputer' ) == False :
-                process.load("RecoBTag.Configuration.RecoBTag_cff")
+                #process.load("RecoBTag.Configuration.RecoBTag_cff") # commented out to prevent loading of IVF modules already run in the standard reconstruction. Instead, loading individual cffs from RecoBTag_cff
+                process.load("RecoBTag.ImpactParameter.impactParameter_cff")
+                process.load("RecoBTag.SecondaryVertex.secondaryVertex_cff")
+                process.load("RecoBTag.SoftLepton.softLepton_cff")
+                process.load("RecoBTau.JetTagComputer.combinedMVA_cff")
             #addESProducers(process,'RecoBTag.Configuration.RecoBTag_cff')
             import RecoBTag.Configuration.RecoBTag_cff as btag
             import RecoJets.JetProducers.caTopTaggers_cff as toptag
-            ## Unload IVF modules already run in the standard reconstruction (to prevent them from re-running in the unscheduled mode)
-            if not runIVF and process._Process__name!='RECO' and hasattr( process, 'bVertexFilter' ): # condition preventing removal of IVF modules in the standard reconstruction or if required by other jet collections
-                if hasattr( process, 'inclusiveCandidateVertexing' ):
-                    for m in getattr( process, 'inclusiveCandidateVertexing' ).moduleNames():
-                        if hasattr( process, m ):
-                            delattr( process, m )
-                    delattr( process, 'inclusiveCandidateVertexing' )
-                if hasattr( process, 'inclusiveVertexing' ):
-                    for m in getattr( process, 'inclusiveVertexing' ).moduleNames():
-                        if hasattr( process, m ):
-                            delattr( process, m )
-                    delattr( process, 'inclusiveVertexing' )
-            ## the following module is never used explicitly but here it is used to distinguish the first from the subsequent calls to switchJetCollection()/addJetCollection()
-            if hasattr( process, 'bVertexFilter' ):
-                delattr( process, 'bVertexFilter' )
 
             ## setup all required btagInfos : we give a dedicated treatment for different
             ## types of tagInfos here. A common treatment is possible but might require a more

--- a/PhysicsTools/PatAlgos/python/tools/jetTools.py
+++ b/PhysicsTools/PatAlgos/python/tools/jetTools.py
@@ -398,8 +398,8 @@ class AddJetCollection(ConfigToolBase):
             #addESProducers(process,'RecoBTag.Configuration.RecoBTag_cff')
             import RecoBTag.Configuration.RecoBTag_cff as btag
             import RecoJets.JetProducers.caTopTaggers_cff as toptag
-            ## Remove IVF modules that were already run by the standard reconstruction to prevent them from re-running in the unscheduled mode
-            if not runIVF and hasattr( process, 'bVertexFilter' ): # 'if' condition preventing jets from removing IVF modules from other jets that want to run them
+            ## Unload IVF modules already run in the standard reconstruction (to prevent them from re-running in the unscheduled mode)
+            if not runIVF and process._Process__name!='RECO' and hasattr( process, 'bVertexFilter' ): # condition preventing removal of IVF modules in the standard reconstruction or if required by other jet collections
                 if hasattr( process, 'inclusiveCandidateVertexing' ):
                     for m in getattr( process, 'inclusiveCandidateVertexing' ).moduleNames():
                         if hasattr( process, m ):


### PR DESCRIPTION
Code changes:
- removed unnecessary lines in the MiniAOD configuration (discussed in #8377)
- implemented in jetTools.py more robust handling of IVF modules which do not have to be re-run in PAT and MiniAOD workflows since they are already run in the standard reconstruction
