### PR TITLE
Packed candidate charge (72X backport)

### DIFF
--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -82,7 +82,7 @@ namespace pat {
       case 11:  return (-1)*(pdgId_>0)+(pdgId_<0); //e
       case 13:  return (-1)*(pdgId_>0)+(pdgId_<0); //mu
       case 15:  return (-1)*(pdgId_>0)+(pdgId_<0); //tau
-      case 24:  return (-1)*(pdgId_>0)+(pdgId_<0); //W
+      case 24:  return (pdgId_>0)-(pdgId_<0); //W
       default:  return 0;  //FIXME: charge is not defined
       }
     }

--- a/DataFormats/PatCandidates/interface/PackedCandidate.h
+++ b/DataFormats/PatCandidates/interface/PackedCandidate.h
@@ -79,10 +79,10 @@ namespace pat {
     virtual int charge() const {
       switch (abs(pdgId_)) {
       case 211: return (pdgId_>0)-(pdgId_<0);
-      case 11:  return (-1)*(pdgId_>0)-(pdgId_<0); //e
-      case 13:  return (-1)*(pdgId_>0)-(pdgId_<0); //mu
-      case 15:  return (-1)*(pdgId_>0)-(pdgId_<0); //tau
-      case 24:  return (-1)*(pdgId_>0)-(pdgId_<0); //W
+      case 11:  return (-1)*(pdgId_>0)+(pdgId_<0); //e
+      case 13:  return (-1)*(pdgId_>0)+(pdgId_<0); //mu
+      case 15:  return (-1)*(pdgId_>0)+(pdgId_<0); //tau
+      case 24:  return (-1)*(pdgId_>0)+(pdgId_<0); //W
       default:  return 0;  //FIXME: charge is not defined
       }
     }


### PR DESCRIPTION
Backport of #8570 to 72X: this bugfix happens at when the miniAOD is analyzed, not when it is produced, so it's something that makes sense to have even in the Phys14 releases.

@arizzi
