### PR TITLE
FastSim bugfix for gtDigis (7_4_X)

### DIFF
--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -255,6 +255,10 @@ FEVTDEBUGHLTEventContent.outputCommands.extend(FastSimParticleFlowFEVT.outputCom
 # To be used only to create the MinBias sample for "new mixing" (--eventcontent=FASTPU)
 #
 #####################################################################
+
+for _entry in [FEVTDEBUGEventContent,FEVTSIMEventContent,GENRAWEventContent,FEVTDEBUGHLTEventContent,HLTDEBUGEventContent,HLTDebugFEVT,HLTDebugRAW,RAWDEBUGHLTEventContent,RAWRECODEBUGHLTEventContent,RAWRECOSIMHLTEventContent,RAWSIMHLTEventContent,]:
+    _entry.outputCommands.append('drop *_gtDigis_*_*')
+
 FASTPUEventContent = cms.PSet(
     outputCommands = cms.untracked.vstring('drop *', 
                                            'keep *_famosSimHits_*_*',

--- a/FastSimulation/HighLevelTrigger/python/HLTFastReco_cff.py
+++ b/FastSimulation/HighLevelTrigger/python/HLTFastReco_cff.py
@@ -89,11 +89,11 @@ l1extraParticles.hfRingEtSumsSource    = cms.InputTag("simGctDigis")
 l1extraParticles.hfRingBitCountsSource = cms.InputTag("simGctDigis")
 
 # a digi collection not created during packing / unpacking, but required by HLT
-process.gtDigis = cms.EDAlias(
+gtDigis = cms.EDAlias(
     simGtDigis = cms.VPSet(cms.PSet(
-        type = cms.string('L1GlobalTriggerReadoutRecord')
-    ))
-)
+            type = cms.string('L1GlobalTriggerReadoutRecord')
+            ))
+    )
 
 # L1 report
 import L1Trigger.GlobalTriggerAnalyzer.l1GtTrigReport_cfi

--- a/FastSimulation/HighLevelTrigger/python/HLTFastReco_cff.py
+++ b/FastSimulation/HighLevelTrigger/python/HLTFastReco_cff.py
@@ -88,6 +88,12 @@ l1extraParticles.etMissSource  = cms.InputTag("simGctDigis")
 l1extraParticles.hfRingEtSumsSource    = cms.InputTag("simGctDigis")
 l1extraParticles.hfRingBitCountsSource = cms.InputTag("simGctDigis")
 
+# a digi collection not created during packing / unpacking, but required by HLT
+process.gtDigis = cms.EDAlias(
+    simGtDigis = cms.VPSet(cms.PSet(
+        type = cms.string('L1GlobalTriggerReadoutRecord')
+    ))
+)
 
 # L1 report
 import L1Trigger.GlobalTriggerAnalyzer.l1GtTrigReport_cfi

--- a/HLTriggerOffline/Btag/python/HltBtagValidationFastSim_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidationFastSim_cff.py
@@ -3,6 +3,7 @@ from HLTriggerOffline.Btag.HltBtagValidation_cff import *
 
 #define HltVertexValidationVerticesFastSim for the vertex DQM validation (no hltFastPrimaryVertex)
 HltVertexValidationVerticesFastSim= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
+        SimVertexCollection = cms.InputTag("famosSimHits"),
 	TriggerResults = cms.InputTag('TriggerResults','',"HLT"),
 	HLTPathNames =cms.vstring(
 		'HLT_PFMET120_NoiseCleaned_BTagCSV07_', 

--- a/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
+++ b/HLTriggerOffline/Btag/python/HltBtagValidation_cff.py
@@ -16,6 +16,7 @@ hltBtagJetsbyRef.jets = cms.InputTag("hltSelector4CentralJetsL1FastJet")
 
 #define HltVertexValidationVertices for the vertex DQM validation
 HltVertexValidationVertices= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
+        SimVertexCollection = cms.InputTag("g4SimHits"),
 	TriggerResults = cms.InputTag('TriggerResults','',"HLT"),
 	HLTPathNames =cms.vstring(
 	'HLT_PFMET120_NoiseCleaned_BTagCSV07_', 

--- a/HLTriggerOffline/Btag/python/hltvertexperformanceanalyzer_cfi.py
+++ b/HLTriggerOffline/Btag/python/hltvertexperformanceanalyzer_cfi.py
@@ -1,5 +1,6 @@
 #define VertexValidationVertices for the vertex DQM validation
 process.VertexValidationVertices= cms.EDAnalyzer("HLTVertexPerformanceAnalyzer",
+        SimVertexCollection = cms.InputTag("g4SimHits"),
 	TriggerResults = cms.InputTag('TriggerResults',),
 	HLTPathNames = cms.vstring('HLT_PFMHT100_SingleCentralJet60_BTagCSV0p6_v1'),
 	Vertex = cms.VInputTag(cms.InputTag("hltFastPrimaryVertex"), cms.InputTag("hltFastPVPixelVertices"), cms.InputTag("hltVerticesL3"))

--- a/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
+++ b/HLTriggerOffline/Btag/src/HLTVertexPerformanceAnalyzer.cc
@@ -5,7 +5,7 @@ HLTVertexPerformanceAnalyzer::HLTVertexPerformanceAnalyzer(const edm::ParameterS
 	hlTriggerResults_   		= consumes<TriggerResults>(iConfig.getParameter<InputTag> ("TriggerResults"));
 	VertexCollection_           = 	edm::vector_transform(iConfig.getParameter<std::vector<edm::InputTag> >( "Vertex" ), [this](edm::InputTag const & tag){return mayConsume< reco::VertexCollection>(tag);});
 	hltPathNames_        		= iConfig.getParameter< std::vector<std::string> > ("HLTPathNames");
-	simVertexCollection_ = consumes<std::vector<SimVertex> >(edm::InputTag("g4SimHits"));
+	simVertexCollection_ = consumes<std::vector<SimVertex> >(iConfig.getParameter<edm::InputTag> ("SimVertexCollection"));
 
 	EDConsumerBase::labelsForToken(hlTriggerResults_,label);
 	hlTriggerResults_Label = label.module;


### PR DESCRIPTION
make the emulated gtDigis available under the label 'gtDigis' with an EDAlias to 'simGtDigis', required by HLT
