### PR TITLE
allow compilation by robot in 75X

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -101,7 +101,7 @@ class VersionedSelector : public Selector<T> {
   }
   
 #ifndef __ROOTCLING__
-  using typename Selector<T>::operator();
+  using Selector<T>::operator();
 #endif
   
   const unsigned char* md55Raw() const { return id_md5_; } 


### PR DESCRIPTION
Found during #8493 that robot was not able to compile 75X with:
git cms-addpkg DataFormats/PatCandidates
git cms-addpkg RecoEgamma/ElectronIdentification
scram b vclean && scram build -k -j 24 USER_CXXFLAGS='-fsyntax-only' COMPILER='llvm compile'

@lgray suggested to remove "typename" from a line in VersionedSelector.h.
Compilation worked fine after this change.
