### PR TITLE
Fix Checksum error in build of DataFormats/PatCandidates (7_5_ROOT5_X)

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -16,7 +16,10 @@
   <class name="pat::Lepton<reco::BaseTau>" />
 
   <!-- PAT Objects, and embedded data  -->
-  <class name="pat::Electron"  ClassVersion="29">
+  <class name="pat::Electron"  ClassVersion="32">
+   <version ClassVersion="33" checksum="459924678"/>
+   <version ClassVersion="32" checksum="3508125821"/>
+   <version ClassVersion="31" checksum="1881133053"/>
    <version ClassVersion="30" checksum="3949366163"/>
    <version ClassVersion="29" checksum="1784986402"/>
    <version ClassVersion="28" checksum="2518240031"/>


### PR DESCRIPTION
Fix checksum causing build error in DataFormats/PatCandidates, and bring checksums up to date.
Since this is a fix for a checksum error that causes the package to not build, please expedite this.
If it fixes the build error, that should be enough.
