### PR TITLE
ROOT6 checksums needed in ROOT5

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -17,9 +17,10 @@
 
   <!-- PAT Objects, and embedded data  -->
   <class name="pat::Electron"  ClassVersion="32">
+   <version ClassVersion="33" checksum="459924678"/>
    <version ClassVersion="32" checksum="3508125821"/>
    <version ClassVersion="31" checksum="1881133053"/>
-   <version ClassVersion="30" checksum="3949366163"/>   
+   <version ClassVersion="30" checksum="3949366163"/>
    <version ClassVersion="29" checksum="1784986402"/>
    <version ClassVersion="28" checksum="2518240031"/>
    <version ClassVersion="27" checksum="3863179876"/>


### PR DESCRIPTION
To prevent version clashes, ROOT6 checksums are needed in ROOT5 files to prevent version clashes.
This trivial PR adds the ROOT6 version number and checksum.  It does not affect the checksum used.
Also, on a different line, spurious trailing spaces are removed to make this file more common with the versions in other releases.
Note, this PR has no effect whatsoever in this release.  The sole purpose of the new version number is to prevent a version clash with ROOT6 by deterring someone from adding version 33 with a different checksum.
Please expedite.
