### PR TITLE
Fix typo spotted by Giulio possibly causing memory leak

### DIFF
--- a/CommonTools/Utils/src/ExpressionVar.cc
+++ b/CommonTools/Utils/src/ExpressionVar.cc
@@ -150,7 +150,7 @@ double ExpressionVar::value(const edm::ObjectWithDict& obj) const
   }
   double ret = objToDouble(val, retType_);
   std::vector<bool>::const_reverse_iterator RIB = needsDestructor_.rbegin();
-  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI = objects_.rbegin(), RE = objects_.rend(); RI != RI; ++RIB, ++RI) {
+  for (std::vector<edm::ObjectWithDict>::reverse_iterator RI = objects_.rbegin(), RE = objects_.rend(); RI != RE; ++RIB, ++RI) {
     if (*RIB) {
       RI->typeOf().destruct(RI->address(), false);
     }


### PR DESCRIPTION
Fix obvious typo spotted by Giulio Eulisse. Thank you, Giulio! This typo has been in the code for ROOT6 back as far as 7_0_ROOT6_X, but was only recently introduced into the code for ROOT5 only very recently. The effect of this but is that a loop possibly invoking destructors terminates immediately, thereby possibly causing a memory leak.
I tested this fix with the unit test for the package and the entire short relval matrix, and all the tests pass.
As this is a bug fix, it should be expedited.
This fix will be identical in 7_4_X, 7_4_ROOT6_X, 7_5_X, and 7_5_ROOT5_X.
