### PR TITLE
Preparing alternative e-map handling in unpacker for 74X

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -26,6 +26,7 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   unpackerMode_(conf.getUntrackedParameter<int>("UnpackerMode",0)),
   expectedOrbitMessageTime_(conf.getUntrackedParameter<int>("ExpectedOrbitMessageTime",-1))
 {
+  electronicsMapLabel_ = conf.getParameter<std::string>("ElectronicsMap");
   tok_data_ = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("InputLabel"));
 
   if (fedUnpackList_.empty()) {
@@ -77,6 +78,7 @@ void HcalRawToDigi::fillDescriptions(edm::ConfigurationDescriptions& description
   desc.addUntracked<int>("UnpackerMode",0);
   desc.addUntracked<int>("ExpectedOrbitMessageTime",-1);
   desc.add<edm::InputTag>("InputLabel",edm::InputTag("rawDataCollector"));
+  desc.add<std::string>("ElectronicsMap","");
   descriptions.add("hcalRawToDigi",desc);
 }
 
@@ -90,7 +92,9 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   // get the mapping
   edm::ESHandle<HcalDbService> pSetup;
   es.get<HcalDbRecord>().get( pSetup );
-  const HcalElectronicsMap* readoutMap=pSetup->getHcalMapping();
+  edm::ESHandle<HcalElectronicsMap> item;
+  es.get<HcalElectronicsMapRcd>().get(electronicsMapLabel_, item);
+  const HcalElectronicsMap* readoutMap = item.product();
   
   // Step B: Create empty output  : three vectors for three classes...
   std::vector<HBHEDataFrame> hbhe;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
@@ -42,6 +42,7 @@ private:
   const bool unpackCalib_, unpackZDC_, unpackTTP_;
   const bool silent_, complainEmptyData_;
   const int unpackerMode_, expectedOrbitMessageTime_;
+  std::string electronicsMapLabel_;
 
   struct Statistics {
     int max_hbhe, ave_hbhe;


### PR DESCRIPTION
This is to allow for (an instance of) unpacker to use alternative emap (with appropriate label) with customized string 
ElectronicsMap = cms.string("") 
NB: default " " means regular GT tag.

Identical to what's submitted to 75X -  https://github.com/cms-sw/cmssw/pull/8600
