### PR TITLE
Preparing alternative e-map handling in unpacker for 73X

### DIFF
--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.cc
@@ -24,6 +24,13 @@ HcalRawToDigi::HcalRawToDigi(edm::ParameterSet const& conf):
   unpackerMode_(conf.getUntrackedParameter<int>("UnpackerMode",0)),
   expectedOrbitMessageTime_(conf.getUntrackedParameter<int>("ExpectedOrbitMessageTime",-1))
 {
+  if(conf.exists("ElectronicsMap")) {
+    electronicsMapLabel_ = conf.getParameter<std::string>("ElectronicsMap");
+  }
+  else {
+    electronicsMapLabel_ = "";  
+  }
+  
   tok_data_ = consumes<FEDRawDataCollection>(conf.getParameter<edm::InputTag>("InputLabel"));
 
   if (fedUnpackList_.empty()) {
@@ -73,7 +80,9 @@ void HcalRawToDigi::produce(edm::Event& e, const edm::EventSetup& es)
   // get the mapping
   edm::ESHandle<HcalDbService> pSetup;
   es.get<HcalDbRecord>().get( pSetup );
-  const HcalElectronicsMap* readoutMap=pSetup->getHcalMapping();
+  edm::ESHandle<HcalElectronicsMap> item;
+  es.get<HcalElectronicsMapRcd>().get(electronicsMapLabel_, item);
+  const HcalElectronicsMap* readoutMap = item.product();
   
   // Step B: Create empty output  : three vectors for three classes...
   std::vector<HBHEDataFrame> hbhe;

--- a/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
+++ b/EventFilter/HcalRawToDigi/plugins/HcalRawToDigi.h
@@ -41,6 +41,7 @@ private:
   bool unpackCalib_, unpackZDC_, unpackTTP_;
   bool silent_,complainEmptyData_;
   int unpackerMode_,expectedOrbitMessageTime_;
+  std::string electronicsMapLabel_;
 
   struct Statistics {
     int max_hbhe, ave_hbhe;


### PR DESCRIPTION
This is to allow for (an instance of) unpacker to use alternative emap (with appropriate label) with customized string
ElectronicsMap = cms.string("")
NB: default " " means regular GT tag.

Similar to what's submitted to 75X/74X -  
https://github.com/cms-sw/cmssw/pull/8600
https://github.com/cms-sw/cmssw/pull/8610
