### PR TITLE
Fix hcal dump conditions topo issue

### DIFF
--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -52,6 +52,7 @@ namespace edmtest
     virtual ~ HcalDumpConditions() { }
     virtual void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
+    template<class S, class SRcd> void dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo);
     template<class S, class SRcd> void dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name);
 
   private:
@@ -59,6 +60,27 @@ namespace edmtest
     std::vector<std::string> mDumpRequest;
   };
   
+
+  template<class S, class SRcd>
+  void HcalDumpConditions::dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo)
+  {
+    int myrun = e.id().run();
+    edm::ESHandle<S> p;
+    context.get<SRcd>().get(p);
+    S* myobject = new S(*p.product());
+    if( topo ) myobject->setTopo(topo);
+    
+    std::ostringstream file;
+    file << front << name.c_str() << "_Run" << myrun << ".txt";
+    std::ofstream outStream(file.str().c_str() );
+    std::cout << "HcalDumpConditions: ---- Dumping " << name.c_str() << " ----" << std::endl;
+    HcalDbASCIIIO::dumpObject (outStream, (*myobject) );
+
+    if ( context.get<SRcd>().validityInterval().first() == edm::IOVSyncValue::invalidIOVSyncValue() )
+      std::cout << "error: invalid IOV sync value !" << std::endl;
+
+  }
+
 
   template<class S, class SRcd>
   void HcalDumpConditions::dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name)
@@ -85,6 +107,7 @@ namespace edmtest
   {
     edm::ESHandle<HcalTopology> topology ;
     context.get<IdealGeometryRecord>().get( topology );
+    const HcalTopology* topo=&(*topology);
 
     using namespace edm::eventsetup;
     std::cout <<"HcalDumpConditions::analyze-> I AM IN RUN NUMBER "<<e.id().run() <<std::endl;
@@ -93,51 +116,51 @@ namespace edmtest
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ElectronicsMap")) != mDumpRequest.end())
       dumpIt(new HcalElectronicsMap, new HcalElectronicsMapRcd, e,context,"ElectronicsMap");
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("QIEData")) != mDumpRequest.end())
-      dumpIt(new HcalQIEData(&(*topology)), new HcalQIEDataRcd, e,context,"QIEData");
+      dumpIt(new HcalQIEData(&(*topology)), new HcalQIEDataRcd, e,context,"QIEData", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("Pedestals")) != mDumpRequest.end())
-      dumpIt(new HcalPedestals(&(*topology)), new HcalPedestalsRcd, e,context,"Pedestals");
+      dumpIt(new HcalPedestals(&(*topology)), new HcalPedestalsRcd, e,context,"Pedestals", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("PedestalWidths")) != mDumpRequest.end())
-      dumpIt(new HcalPedestalWidths(&(*topology)), new HcalPedestalWidthsRcd, e,context,"PedestalWidths");
+      dumpIt(new HcalPedestalWidths(&(*topology)), new HcalPedestalWidthsRcd, e,context,"PedestalWidths", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("Gains")) != mDumpRequest.end())
-      dumpIt(new HcalGains(&(*topology)), new HcalGainsRcd, e,context,"Gains");
+      dumpIt(new HcalGains(&(*topology)), new HcalGainsRcd, e,context,"Gains", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("GainWidths")) != mDumpRequest.end())
-      dumpIt(new HcalGainWidths(&(*topology)), new HcalGainWidthsRcd, e,context,"GainWidths");
+      dumpIt(new HcalGainWidths(&(*topology)), new HcalGainWidthsRcd, e,context,"GainWidths", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ChannelQuality")) != mDumpRequest.end())
-      dumpIt(new HcalChannelQuality(&(*topology)), new HcalChannelQualityRcd, e,context,"ChannelQuality");
+      dumpIt(new HcalChannelQuality(&(*topology)), new HcalChannelQualityRcd, e,context,"ChannelQuality", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("RespCorrs")) != mDumpRequest.end())
-      dumpIt(new HcalRespCorrs(&(*topology)), new HcalRespCorrsRcd, e,context,"RespCorrs");
+      dumpIt(new HcalRespCorrs(&(*topology)), new HcalRespCorrsRcd, e,context,"RespCorrs", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ZSThresholds")) != mDumpRequest.end())
-      dumpIt(new HcalZSThresholds(&(*topology)), new HcalZSThresholdsRcd, e,context,"ZSThresholds");
+      dumpIt(new HcalZSThresholds(&(*topology)), new HcalZSThresholdsRcd, e,context,"ZSThresholds", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("L1TriggerObjects")) != mDumpRequest.end())
-      dumpIt(new HcalL1TriggerObjects(&(*topology)), new HcalL1TriggerObjectsRcd, e,context,"L1TriggerObjects");
+      dumpIt(new HcalL1TriggerObjects(&(*topology)), new HcalL1TriggerObjectsRcd, e,context,"L1TriggerObjects", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("TimeCorrs")) != mDumpRequest.end())
-      dumpIt(new HcalTimeCorrs(&(*topology)), new HcalTimeCorrsRcd, e,context,"TimeCorrs");
+      dumpIt(new HcalTimeCorrs(&(*topology)), new HcalTimeCorrsRcd, e,context,"TimeCorrs", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("LUTCorrs")) != mDumpRequest.end())
-      dumpIt(new HcalLUTCorrs(&(*topology)), new HcalLUTCorrsRcd, e,context,"LUTCorrs");
+      dumpIt(new HcalLUTCorrs(&(*topology)), new HcalLUTCorrsRcd, e,context,"LUTCorrs", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("PFCorrs")) != mDumpRequest.end())
-      dumpIt(new HcalPFCorrs(&(*topology)), new HcalPFCorrsRcd, e,context,"PFCorrs");
+      dumpIt(new HcalPFCorrs(&(*topology)), new HcalPFCorrsRcd, e,context,"PFCorrs", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ValidationCorrs")) != mDumpRequest.end())
-      dumpIt(new HcalValidationCorrs(&(*topology)), new HcalValidationCorrsRcd, e,context,"ValidationCorrs");
+      dumpIt(new HcalValidationCorrs(&(*topology)), new HcalValidationCorrsRcd, e,context,"ValidationCorrs", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("LutMetadata")) != mDumpRequest.end())
-      dumpIt(new HcalLutMetadata(&(*topology)), new HcalLutMetadataRcd, e,context,"LutMetadata");
+      dumpIt(new HcalLutMetadata(&(*topology)), new HcalLutMetadataRcd, e,context,"LutMetadata", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("DcsValues")) != mDumpRequest.end())
       dumpIt(new HcalDcsValues, new HcalDcsRcd, e,context,"DcsValues");
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("DcsMap")) != mDumpRequest.end())
       dumpIt(new HcalDcsMap, new HcalDcsMapRcd, e,context,"DcsMap");
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("CholeskyMatrices")) != mDumpRequest.end())
-      dumpIt(new HcalCholeskyMatrices(&(*topology)), new HcalCholeskyMatricesRcd, e,context,"CholeskyMatrices");
+      dumpIt(new HcalCholeskyMatrices(&(*topology)), new HcalCholeskyMatricesRcd, e,context,"CholeskyMatrices", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("RecoParams")) != mDumpRequest.end())
-      dumpIt(new HcalRecoParams(&(*topology)), new HcalRecoParamsRcd, e,context,"RecoParams");
+      dumpIt(new HcalRecoParams(&(*topology)), new HcalRecoParamsRcd, e,context,"RecoParams", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("TimingParams")) != mDumpRequest.end())
-      dumpIt(new HcalTimingParams(&(*topology)), new HcalTimingParamsRcd, e,context,"TimingParams");
+      dumpIt(new HcalTimingParams(&(*topology)), new HcalTimingParamsRcd, e,context,"TimingParams", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("LongRecoParams")) != mDumpRequest.end())
-      dumpIt(new HcalLongRecoParams(&(*topology)), new HcalLongRecoParamsRcd, e,context,"LongRecoParams");
+      dumpIt(new HcalLongRecoParams(&(*topology)), new HcalLongRecoParamsRcd, e,context,"LongRecoParams", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("ZDCLowGainFractions")) != mDumpRequest.end())
-      dumpIt(new HcalZDCLowGainFractions(&(*topology)), new HcalZDCLowGainFractionsRcd, e,context,"ZDCLowGainFractions");
+      dumpIt(new HcalZDCLowGainFractions(&(*topology)), new HcalZDCLowGainFractionsRcd, e,context,"ZDCLowGainFractions", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("MCParams")) != mDumpRequest.end())
-      dumpIt(new HcalMCParams(&(*topology)), new HcalMCParamsRcd, e,context,"MCParams");
+      dumpIt(new HcalMCParams(&(*topology)), new HcalMCParamsRcd, e,context,"MCParams", topo);
     if (std::find (mDumpRequest.begin(), mDumpRequest.end(), std::string ("FlagHFDigiTimeParams")) != mDumpRequest.end())
-      dumpIt(new HcalFlagHFDigiTimeParams(&(*topology)), new HcalFlagHFDigiTimeParamsRcd, e,context,"FlagHFDigiTimeParams");
+      dumpIt(new HcalFlagHFDigiTimeParams(&(*topology)), new HcalFlagHFDigiTimeParamsRcd, e,context,"FlagHFDigiTimeParams", topo);
 
     
   }

--- a/CondTools/Hcal/plugins/HcalDumpConditions.cc
+++ b/CondTools/Hcal/plugins/HcalDumpConditions.cc
@@ -54,6 +54,7 @@ namespace edmtest
 
     template<class S, class SRcd> void dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo);
     template<class S, class SRcd> void dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name);
+    template<class S> void writeToFile(S* myS, const edm::Event& e, std::string name);
 
   private:
     std::string front;
@@ -64,18 +65,13 @@ namespace edmtest
   template<class S, class SRcd>
   void HcalDumpConditions::dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name, const HcalTopology * topo)
   {
-    int myrun = e.id().run();
     edm::ESHandle<S> p;
     context.get<SRcd>().get(p);
     S* myobject = new S(*p.product());
     if( topo ) myobject->setTopo(topo);
     
-    std::ostringstream file;
-    file << front << name.c_str() << "_Run" << myrun << ".txt";
-    std::ofstream outStream(file.str().c_str() );
-    std::cout << "HcalDumpConditions: ---- Dumping " << name.c_str() << " ----" << std::endl;
-    HcalDbASCIIIO::dumpObject (outStream, (*myobject) );
-
+    writeToFile(myobject, e, name);
+    
     if ( context.get<SRcd>().validityInterval().first() == edm::IOVSyncValue::invalidIOVSyncValue() )
       std::cout << "error: invalid IOV sync value !" << std::endl;
 
@@ -85,22 +81,25 @@ namespace edmtest
   template<class S, class SRcd>
   void HcalDumpConditions::dumpIt(S* myS, SRcd* mySRcd, const edm::Event& e, const edm::EventSetup& context, std::string name)
   {
-    int myrun = e.id().run();
     edm::ESHandle<S> p;
     context.get<SRcd>().get(p);
     S* myobject = new S(*p.product());
-    
-    std::ostringstream file;
-    file << front << name.c_str() << "_Run" << myrun << ".txt";
-    std::ofstream outStream(file.str().c_str() );
-    std::cout << "HcalDumpConditions: ---- Dumping " << name.c_str() << " ----" << std::endl;
-    HcalDbASCIIIO::dumpObject (outStream, (*myobject) );
 
+    writeToFile(myobject, e, name);
+    
     if ( context.get<SRcd>().validityInterval().first() == edm::IOVSyncValue::invalidIOVSyncValue() )
       std::cout << "error: invalid IOV sync value !" << std::endl;
 
   }
 
+  template<class S> void HcalDumpConditions::writeToFile(S* myS, const edm::Event& e, std::string name){
+    int myrun = e.id().run();
+    std::ostringstream file;
+    file << front << name.c_str() << "_Run" << myrun << ".txt";
+    std::ofstream outStream(file.str().c_str() );
+    std::cout << "HcalDumpConditions: ---- Dumping " << name.c_str() << " ----" << std::endl;
+    HcalDbASCIIIO::dumpObject (outStream, (*myS) );
+  }
 
   void
    HcalDumpConditions::analyze(const edm::Event& e, const edm::EventSetup& context)


### PR DESCRIPTION
Fix the "topology pointer not set" issue in a dump condition tool that is useful to look at the condition DB.
