### PR TITLE
Remove unnecessary link dependency and blank line (Code commonality)

### DIFF
--- a/DQM/SiStripMonitorClient/bin/BuildFile.xml
+++ b/DQM/SiStripMonitorClient/bin/BuildFile.xml
@@ -1,5 +1,4 @@
 <use   name="root"/>
-
 <use   name="rootgraphics"/>
 <bin   name="check_runcomplete" file="check_runcomplete.cc"></bin>
 <bin   name="listbadmodule" file="listbadmodule.cc"></bin>

--- a/PhysicsTools/PatExamples/bin/BuildFile.xml
+++ b/PhysicsTools/PatExamples/bin/BuildFile.xml
@@ -1,6 +1,4 @@
 <use   name="root"/>
-<use   name="boost"/>
-
 <use   name="FWCore/FWLite"/>
 <use   name="DataFormats/FWLite"/>
 <use   name="FWCore/PythonParameterSet"/>


### PR DESCRIPTION
This trivial PR removes an unnecessary link dependency and an unnecessary blank line.
These changes are already in CMSSW_7_4_ROOT5_X, so this will also make these two build files identical across 7_4 and 7_5 releases, as well as removing the burden of an unneeded link dependency.
Historical note:  These changes were already in 7_4_X when it was on ROOT5.  I had queued these two changes for 7_4_ROOT6_X five days ago, but they did not get merged in time for the conversion of 7_4_X to ROOT6, which restored the spurious link dependency in 7_4_X.  This PR cleans this all up.
As this is totally technical, please bypass L2 signatures if not signed in a timely manner.
