### PR TITLE
Fix unit test

### DIFF
--- a/DataFormats/FWLite/test/BuildFile.xml
+++ b/DataFormats/FWLite/test/BuildFile.xml
@@ -2,7 +2,12 @@
   <use   name="boost"/>
   <use   name="cppunit"/>
 </environment>
+<bin   name="testDataFormatsFWLiteMakeInput" file="TestRunnerDataFormatsFWLite.cpp">
+  <flags   TEST_RUNNER_ARGS=" /bin/bash DataFormats/FWLite/test RefTest.sh"/>
+  <use   name="FWCore/Utilities"/>
+</bin>
 <bin   name="testDataFormatsFWLite" file="test.cppunit.cpp,record.cppunit.cpp,format_type_name.cppunit.cpp">
+  <flags PRE_TEST="testDataFormatsFWLiteMakeInput"/>
   <use   name="DataFormats/FWLite"/>
   <use   name="FWCore/FWLite"/>
   <use   name="DataFormats/TestObjects"/>

--- a/DataFormats/FWLite/test/EmptyFile_cfg.py
+++ b/DataFormats/FWLite/test/EmptyFile_cfg.py
@@ -5,7 +5,7 @@ process = cms.Process("NOCOPY")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:good.root'),
+    fileNames = cms.untracked.vstring('file:goodDataFormatsFWLite.root'),
     # firstRun gives a file with no runs, lumis, or events
     # firstEvent gives a file with no events, but with runs and lumis
     # firstRun = cms.untracked.uint32(100)
@@ -13,7 +13,7 @@ process.source = cms.Source("PoolSource",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('empty.root')
+    fileName = cms.untracked.string('emptyDataFormatsFWLite.root')
 )
 
 process.outp = cms.EndPath(process.out)

--- a/DataFormats/FWLite/test/PartialEventTest_cfg.py
+++ b/DataFormats/FWLite/test/PartialEventTest_cfg.py
@@ -24,7 +24,7 @@ process.filter = cms.EDFilter("TestFilterModule",
 process.OtherThing = cms.EDProducer("OtherThingProducer")
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('partialEvent.root')
+    fileName = cms.untracked.string('partialEventDataFormatsFWLite.root')
 )
 
 process.p = cms.Path( (process.Thing+process.filter)*process.OtherThing)

--- a/DataFormats/FWLite/test/RefTest.sh
+++ b/DataFormats/FWLite/test/RefTest.sh
@@ -3,11 +3,22 @@
 
 function die { echo Failure $1: status $2 ; exit $2 ; }
 
-rm -f ${LOCAL_TEST_DIR}/good.root ${LOCAL_TEST_DIR}/good2.root ${LOCAL_TEST_DIR}/empty.root ${LOCAL_TEST_DIR}/other_only.root ${LOCAL_TEST_DIR}/good_delta5.root
-rm -f good.root good2.root empty.root other_only.root good_delta5.root
+pushd ${LOCAL_TMP_DIR}
 
+rm -f goodDataFormatsFWLite.root good2DataFormatsFWLite.root emptyDataFormatsFWLite.root
+rm -f other_onlyDataFormatsFWLite.root good_delta5DataFormatsFWLite.root
+rm -f partialEventDataFormatsFWLite.root refTestCopyDropDataFormatsFWLite.root
+
+echo RefTest_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/RefTest_cfg.py || die "cmsRun RefTest_cfg.py" $?
+echo RefTest2_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/RefTest2_cfg.py || die "cmsRun RefTest2_cfg.py" $?
+echo EmptyFile_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/EmptyFile_cfg.py || die "cmsRun EmptyFile_cfg.py" $?
+echo PartialEventTest_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/PartialEventTest_cfg.py || die "cmsRun PartialEventTest_cfg.py" $?
+echo RefTestCopyDrop_cfg.py
 cmsRun ${LOCAL_TEST_DIR}/RefTestCopyDrop_cfg.py || die "cmsRun RefTestCopyDrop_cfg.py" $?
+
+popd
+exit 0

--- a/DataFormats/FWLite/test/RefTest2_cfg.py
+++ b/DataFormats/FWLite/test/RefTest2_cfg.py
@@ -19,7 +19,7 @@ process.Thing = cms.EDProducer("ThingProducer",
 process.OtherThing = cms.EDProducer("OtherThingProducer")
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('good_delta5.root')
+    fileName = cms.untracked.string('good_delta5DataFormatsFWLite.root')
 )
 
 process.p = cms.Path(process.Thing*process.OtherThing)

--- a/DataFormats/FWLite/test/RefTestCopyDrop_cfg.py
+++ b/DataFormats/FWLite/test/RefTestCopyDrop_cfg.py
@@ -5,11 +5,11 @@ process = cms.Process("COPYDROP")
 process.load("FWCore.Framework.test.cmsExceptionsFatal_cff")
 
 process.source = cms.Source("PoolSource",
-    fileNames = cms.untracked.vstring('file:good.root')
+    fileNames = cms.untracked.vstring('file:goodDataFormatsFWLite.root')
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('refTestCopyDrop.root'),
+    fileName = cms.untracked.string('refTestCopyDropDataFormatsFWLite.root'),
     outputCommands = cms.untracked.vstring(
         'keep *',
         'drop *_thinningThingProducerE_*_*',

--- a/DataFormats/FWLite/test/RefTest_cfg.py
+++ b/DataFormats/FWLite/test/RefTest_cfg.py
@@ -218,7 +218,7 @@ process.thinningThingProducerO = cms.EDProducer("ThinningThingProducer",
 )
 
 process.out = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('good.root'),
+    fileName = cms.untracked.string('goodDataFormatsFWLite.root'),
     outputCommands = cms.untracked.vstring(
         'keep *',
         'drop *_thingProducer_*_*',
@@ -234,14 +234,14 @@ process.out = cms.OutputModule("PoolOutputModule",
 )
 
 process.out2 = cms.OutputModule("PoolOutputModule",
-    fileName = cms.untracked.string('good2.root')
+    fileName = cms.untracked.string('good2DataFormatsFWLite.root')
 )
 
 process.out_other = cms.OutputModule("PoolOutputModule",
     outputCommands = cms.untracked.vstring('drop *', 
         'keep edmtestOtherThings_*_*_*', 
         'keep *_TriggerResults_*_*'),
-    fileName = cms.untracked.string('other_only.root')
+    fileName = cms.untracked.string('other_onlyDataFormatsFWLite.root')
 )
 
 process.thinningTestPath = cms.Path(process.thingProducer

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -131,7 +131,7 @@ static void testEvent(fwlite::Event& events) {
 
 void testRefInROOT::testOneGoodFile()
 {
-  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
+   TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    
    testEvent(events);
@@ -151,7 +151,7 @@ void testRefInROOT::testAllLabels()
 
 void testRefInROOT::testEventBase()
 {
-  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
+   TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    edm::InputTag tagFull("OtherThing","testUserTag","TEST");
    edm::InputTag tag("OtherThing","testUserTag");
@@ -270,7 +270,7 @@ void testRefInROOT::failOneBadFile()
 
 void testRefInROOT::testMissingRef()
 {
-  TFile file((tmpdir + "other_onlyDataFormatsFWLite.root").c_str());
+   TFile file((tmpdir + "other_onlyDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    
    for(events.toBegin(); not events.atEnd(); ++events) {
@@ -288,7 +288,7 @@ void testRefInROOT::testMissingRef()
 
 void testRefInROOT::testMissingData()
 {
-  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
+   TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    
    for(events.toBegin(); not events.atEnd(); ++events) {

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -54,26 +54,13 @@ class testRefInROOT: public CppUnit::TestFixture
   CPPUNIT_TEST_SUITE_END();
 public:
   testRefInROOT() { }
-  void setUp()
-  {
-    if(!sWasRun_) {
-      gSystem->Load("libFWCoreFWLite.so");
-      AutoLibraryLoader::enable();
-      
-      char* argv[] = {CHARSTAR("TestRunnerDataFormatsFWLite"),
-		      CHARSTAR("/bin/bash"),
-		      CHARSTAR("DataFormats/FWLite/test"),
-		      CHARSTAR("RefTest.sh")};
-      argv[0] = gArgV;
-      if(0!=ptomaine(sizeof(argv)/sizeof(const char*), argv, environ) ) {
-        std::cerr <<"could not run script needed to make test files\n";
-        ::exit(-1);
-      }
-      sWasRun_ = true;
-    }
+  void setUp() {
+    tmpdir = "tmp/";
+    tmpdir += getenv("SCRAM_ARCH");
+    tmpdir += "/";
   }
-  void tearDown(){}
-  
+  void tearDown(){ }
+
   void testRefFirst();
   void testAllLabels();
   void testOneGoodFile();
@@ -92,6 +79,7 @@ public:
 
  private:
   static bool sWasRun_;
+  std::string tmpdir;
 };
 
 bool testRefInROOT::sWasRun_=false;
@@ -143,7 +131,7 @@ static void testEvent(fwlite::Event& events) {
 
 void testRefInROOT::testOneGoodFile()
 {
-   TFile file("good.root");
+  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    
    testEvent(events);
@@ -151,7 +139,7 @@ void testRefInROOT::testOneGoodFile()
 
 void testRefInROOT::testAllLabels()
 {
-  TFile file("good.root");
+  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
   fwlite::Event events(&file);
 
   for(events.toBegin(); not events.atEnd(); ++events) {
@@ -163,7 +151,7 @@ void testRefInROOT::testAllLabels()
 
 void testRefInROOT::testEventBase()
 {
-   TFile file("good.root");
+  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    edm::InputTag tagFull("OtherThing","testUserTag","TEST");
    edm::InputTag tag("OtherThing","testUserTag");
@@ -213,7 +201,7 @@ void testRefInROOT::testEventBase()
 
 void testRefInROOT::testTo()
 {
-   TFile file("good.root");
+   TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    edm::InputTag tag("Thing");
    edm::EventBase* eventBase = &events;
@@ -247,7 +235,7 @@ void testRefInROOT::testTo()
 
 void testRefInROOT::testRefFirst()
 {
-  TFile file("good.root");
+  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
   fwlite::Event events(&file);
   
   for(events.toBegin(); not events.atEnd(); ++events) {
@@ -282,7 +270,7 @@ void testRefInROOT::failOneBadFile()
 
 void testRefInROOT::testMissingRef()
 {
-   TFile file("other_only.root");
+  TFile file((tmpdir + "other_onlyDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    
    for(events.toBegin(); not events.atEnd(); ++events) {
@@ -300,7 +288,7 @@ void testRefInROOT::testMissingRef()
 
 void testRefInROOT::testMissingData()
 {
-   TFile file("good.root");
+  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
    fwlite::Event events(&file);
    
    for(events.toBegin(); not events.atEnd(); ++events) {
@@ -316,7 +304,7 @@ void testRefInROOT::testMissingData()
 
 void testRefInROOT::testSometimesMissingData()
 {
-  TFile file("partialEvent.root");
+  TFile file((tmpdir + "partialEventDataFormatsFWLite.root").c_str());
   fwlite::Event events(&file);
   
   unsigned int index=0;
@@ -363,14 +351,14 @@ void testRefInROOT::testTwoGoodFiles()
 {
   /*
   std::cout <<"gFile "<<gFile<<std::endl;
-  TFile file("good.root");
+  TFile file((tmpdir + "goodDataFormatsFWLite.root").c_str());
   std::cout <<" file :" << &file<<" gFile: "<<gFile<<std::endl;
   
   TTree* events = dynamic_cast<TTree*>(file.Get(edm::poolNames::eventTreeName()));
   
   testTree(events);
   std::cout <<"working on second file"<<std::endl;
-  TFile file2("good2.root");
+  TFile file2((tmpdir + "good2DataFormatsFWLite.root").c_str());
   std::cout <<" file2 :"<< &file2<<" gFile: "<<gFile<<std::endl;
   events = dynamic_cast<TTree*>(file2.Get(edm::poolNames::eventTreeName()));
   
@@ -383,8 +371,8 @@ void testRefInROOT::testGoodChain()
 {
   /*
   TChain eventChain(edm::poolNames::eventTreeName());
-  eventChain.Add("good.root");
-  eventChain.Add("good2.root");
+  eventChain.Add((tmpdir + "goodDataFormatsFWLite.root").c_str());
+  eventChain.Add((tmpdir + "good2DataFormatsFWLite.root").c_str());
 
   edm::Wrapper<edmtest::OtherThingCollection> *pOthers =0;
   eventChain.SetBranchAddress("edmtestOtherThings_OtherThing_testUserTag_TEST.",&pOthers);
@@ -406,7 +394,7 @@ void testRefInROOT::testGoodChain()
 void testRefInROOT::failChainWithMissingFile()
 {
   TChain eventChain(edm::poolNames::eventTreeName());
-  eventChain.Add("good.root");
+  eventChain.Add((tmpdir + "goodDataFormatsFWLite.root").c_str());
   eventChain.Add("thisFileDoesNotExist.root");
   
   edm::Wrapper<edmtest::OtherThingCollection> *pOthers =0;
@@ -429,7 +417,8 @@ void testRefInROOT::failChainWithMissingFile()
 
 void testRefInROOT::testThinning() {
 
-  std::vector<std::string> files { "good.root", "good.root" };
+  std::vector<std::string> files { (tmpdir + "goodDataFormatsFWLite.root").c_str(),
+                                   (tmpdir + "goodDataFormatsFWLite.root").c_str() };
   fwlite::ChainEvent events(files);
 
   for(events.toBegin(); not events.atEnd(); ++events) {
@@ -567,8 +556,8 @@ void testRefInROOT::testThinning() {
     CPPUNIT_ASSERT_THROW(trackM.refToBaseVector1[8].operator->(), cms::Exception);
   }
 
-  std::vector<std::string> files1 { "refTestCopyDrop.root" };
-  std::vector<std::string> files2 { "good.root" };
+  std::vector<std::string> files1 { (tmpdir + "refTestCopyDropDataFormatsFWLite.root").c_str() };
+  std::vector<std::string> files2 { (tmpdir + "goodDataFormatsFWLite.root").c_str() };
 
   fwlite::MultiChainEvent multiChainEvents(files1, files2);
   for (multiChainEvents.toBegin(); ! multiChainEvents.atEnd(); ++multiChainEvents) {


### PR DESCRIPTION
Fix sporadically failing unit tests in
DataFormats/FWLite. This only affects
unit tests.

Previously, the test forked a process to
make input files and then was supposed to
wait for it to finish, but sometimes it
did not wait for reasons I do not understand.
I simplified this by splitting it into two
tests and used the scram PRE_TEST flag to
sequence them.

The DataFormats/FWLite tests used the same
filenames as the FWCore/FWLite unit tests
in the same directory. I renamed the files
and modified the test to run in the tmp
subdirectory to avoid potential clashes if
the tests were run at the same time.
