### PR TITLE
PreMixing fixes for low-level Ecal Signals

### DIFF
--- a/SimCalorimetry/EcalSimAlgos/src/EcalCoder.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalCoder.cc
@@ -211,11 +211,28 @@ EcalCoder::encode( const EcalSamples& ecalSamples ,
 			       trueRMS[igain]*noiseframe[igain-1][i]      ) ;
 	   signal = asignal;
 	 }
-	 else {
+	 else {  // Any changes made here must be reverse-engineered in EcalSignalGenerator!
 
-	   const double asignal ( // no pedestals for pre-mixing
-				 ecalSamples[i] /( LSB[igain]*icalconst ) );
-	   signal = asignal;
+           if( igain == 1) {
+             const double asignal ( ecalSamples[i]*1000. );  // save low level info                   
+             signal = asignal;
+           }
+           else if( igain == 2) {
+             const double asignal ( ecalSamples[i]/( LSB[1]*icalconst ));
+             signal = asignal;
+           }
+           else if( igain == 3) {   // bet that no pileup hit has an energy over Emax/2             
+             const double asignal ( ecalSamples[i]/( LSB[2]*icalconst ) );
+             signal = asignal;
+           }
+	   else { //not sure we ever get here at gain=0, but hit wil be saturated anyway
+	     const double asignal ( ecalSamples[i]/( LSB[3]*icalconst ) ); // just calculate something
+             signal = asignal;
+	   }
+	   // old version
+	   //const double asignal ( // no pedestals for pre-mixing
+	   //			 ecalSamples[i] /( LSB[igain]*icalconst ) );
+	   //signal = asignal;
 	 }
 
 	 //	 std::cout << " " << ecalSamples[i] << " " << noiseframe[igain-1][i] << std::endl;

--- a/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
+++ b/SimCalorimetry/EcalSimAlgos/src/EcalSignalGenerator.cc
@@ -49,7 +49,16 @@
       int gainId = digi[isample].gainId();
       //int gainId = 1;
 
-      result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
+      if(gainId == 1) {
+        result[isample] = float(digi[isample].adc())/1000./peToA; // special coding                   
+      }
+      else if(gainId > 1) {
+        result[isample] = float(digi[isample].adc())*LSB[gainId-1]*icalconst/peToA;
+      }  // gain = 0                                                                                  
+      else { result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;}
+
+      // old version:
+      //result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
     }
 
     //std::cout << " EcalSignalGenerator:EB noise input " << digi << std::endl;
@@ -111,7 +120,16 @@
       int gainId = digi[isample].gainId();
       //int gainId = 1;
 
-      result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
+      if(gainId == 1) {
+        result[isample] = float(digi[isample].adc())/1000./peToA; // special coding                   
+      }
+      else if(gainId > 1) {
+        result[isample] = float(digi[isample].adc())*LSB[gainId-1]*icalconst/peToA;
+      }  // gain = 0                                                                                  
+      else { result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;}
+
+      // old version
+      //result[isample] = float(digi[isample].adc())*LSB[gainId]*icalconst/peToA;
     }
 
     //std::cout << " EcalSignalGenerator:EE noise input " << digi << std::endl;

--- a/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
+++ b/SimGeneral/MixingModule/python/digi_noNoise_cfi.py
@@ -39,6 +39,7 @@ theDigitizersNoNoise.hcal.doIonFeedback = cms.bool(False)
 theDigitizersNoNoise.hcal.doThermalNoise = cms.bool(False)
 theDigitizersNoNoise.hcal.doTimeSlew = cms.bool(False)
 theDigitizersNoNoise.ecal.doENoise = cms.bool(False)
+theDigitizersNoNoise.ecal.applyConstantTerm = cms.bool(False)
 theDigitizersNoNoise.pixel.AddNoise = cms.bool(True)
 theDigitizersNoNoise.pixel.addNoisyPixels = cms.bool(False)
 theDigitizersNoNoise.pixel.AddPixelInefficiencyFromPython = cms.bool(False) #done in second step


### PR DESCRIPTION
Add special packing/unpacking (internal to Ecal code, not Digi2Raw->Raw2Digi) to preserve low-level Ecal signals for PreMixing only.
