### PR TITLE
Consumes interface for TrackerHitAssociator 

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -23,6 +23,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 //--- for SimHit
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
@@ -61,9 +62,9 @@ class TrackerHitAssociator {
   // in all the wrong places
   TrackerHitAssociator(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
   // Simple constructor
-  TrackerHitAssociator(const edm::Event& e);
+  TrackerHitAssociator(const edm::Event& e); // deprecated
   // Constructor with configurables
-  TrackerHitAssociator(const edm::Event& e, const edm::ParameterSet& conf);
+  TrackerHitAssociator(const edm::Event& e, const edm::ParameterSet& conf); // deprecated
   // Destructor
   virtual ~TrackerHitAssociator(){}
   
@@ -95,6 +96,8 @@ class TrackerHitAssociator {
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
   std::vector<SimHitIdpr> associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const;
   
+  void processEvent(const edm::Event& theEvent);
+
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   simhit_map SimHitMap;
   typedef std::map<simHitCollectionID, std::vector<PSimHit> > simhit_collectionMap;
@@ -103,12 +106,18 @@ class TrackerHitAssociator {
  private:
   typedef std::vector<std::string> vstring;
 
-  void makeMaps(const edm::Event& theEvent, const vstring trackerContainers);
+  void makeMaps(const edm::Event& theEvent);
+
+  void makeMaps(const edm::Event& theEvent, const vstring& trackerContainers); // deprecated
 
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
   
   bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
+  edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripToken_;
+  edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_;
+  std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit> > > cfTokens_;
+  std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simHitTokens_;
   
 };  
 

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -21,7 +21,7 @@ using namespace std;
 using namespace edm;
 
 //
-// Constructor 
+// Constructor (deprecated)
 //
 TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  : 
   doPixel_( true ),
@@ -32,18 +32,19 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  :
   // Take by default all tracker SimHits
   //
   vstring trackerContainers;
-  trackerContainers.push_back("g4SimHitsTrackerHitsTIBLowTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsTIBHighTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsTIDLowTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsTIDHighTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsTOBLowTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsTOBHighTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsTECLowTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsTECHighTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsPixelBarrelLowTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsPixelBarrelHighTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsPixelEndcapLowTof");
-  trackerContainers.push_back("g4SimHitsTrackerHitsPixelEndcapHighTof");
+  trackerContainers.reserve(12);
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTIBLowTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTIBHighTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTIDLowTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTIDHighTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTOBLowTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTOBHighTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTECLowTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsTECHighTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelBarrelLowTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelBarrelHighTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelEndcapLowTof");
+  trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelEndcapHighTof");
 
   makeMaps(e, trackerContainers);
   
@@ -51,25 +52,37 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  :
   if(doPixel_) e.getByLabel("simSiPixelDigis", pixeldigisimlink);
 }
 
+//
+// Constructor with configurables. Supports consumes interface
+//
+
 TrackerHitAssociator::TrackerHitAssociator(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
-  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ) {
+  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
+  assocHitbySimTrack_(conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false) {
 
-  assocHitbySimTrack_ = conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false;
-
-  if(doStrip_) iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
-  if(doPixel_) iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+  if(doStrip_) stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
+  if(doPixel_) pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+  if(!doTrackAssoc_) {
+    vstring trackerContainers(conf.getParameter<vstring>("ROUList"));
+    cfTokens_.reserve(trackerContainers.size());
+    simHitTokens_.reserve(trackerContainers.size());
+    for(auto const& trackerContainer : trackerContainers) {
+      cfTokens_.push_back(iC.consumes<CrossingFrame<PSimHit> >(edm::InputTag("mix", trackerContainer)));
+      simHitTokens_.push_back(iC.consumes<std::vector<PSimHit> >(edm::InputTag("g4SimHits", trackerContainer)));
+    }
+  }
  }
 
 //
-// Constructor with configurables
+// Constructor with configurables (deprecated)
 //
 TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::ParameterSet& conf)  : 
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
-  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ) {
-  assocHitbySimTrack_ = conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false;
+  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
+  assocHitbySimTrack_(conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false) {
   
   //if track association there is no need to access the input collections
   if(!doTrackAssoc_) {
@@ -81,7 +94,71 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::Param
   if(doPixel_) e.getByLabel("simSiPixelDigis", pixeldigisimlink);
 }
 
-void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const vstring trackerContainers) {
+void TrackerHitAssociator::processEvent(const edm::Event& e) {
+  //if track association there is no need to access the input collections
+  if(!doTrackAssoc_) {
+    makeMaps(e);
+  }
+
+  if(doStrip_) e.getByToken(stripToken_, stripdigisimlink);
+  if(doPixel_) e.getByToken(pixelToken_, pixeldigisimlink);
+}
+
+void TrackerHitAssociator::makeMaps(const edm::Event& theEvent) {
+  // Step A: Get Inputs
+  //  The collections are specified via ROUList in the configuration, and can
+  //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof)
+  //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
+
+  for(auto const& cfToken : cfTokens_) {
+    edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
+    int Nhits = 0;
+    if (theEvent.getByToken(cfToken, cf_simhit)) {
+      std::unique_ptr<MixCollection<PSimHit> > thisContainerHits(new MixCollection<PSimHit>(cf_simhit.product()));
+      for (auto const& isim : *thisContainerHits) {
+        DetId theDet(isim.detUnitId());
+        if (assocHitbySimTrack_) {
+          SimHitMap[theDet].push_back(isim);
+        } else {
+          edm::EDConsumerBase::Labels labels;
+          theEvent.labelsForToken(cfToken, labels);
+          std::string trackerContainer(labels.productInstance);
+          unsigned int tofBin = StripDigiSimLink::LowTof;
+          if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+          simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+          SimHitCollMap[theSimHitCollID].push_back(isim);
+        }
+        ++Nhits;
+      }
+      // std::cout << "simHits from crossing frames; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
+    }
+  }
+  for(auto const& simHitToken : simHitTokens_) {
+    edm::Handle<std::vector<PSimHit> > simHits;
+    int Nhits = 0;
+    if(theEvent.getByToken(simHitToken, simHits)) {
+      for (auto const& isim : *simHits) {
+        DetId theDet(isim.detUnitId());
+        if (assocHitbySimTrack_) {
+          SimHitMap[theDet].push_back(isim);
+        } else {
+          edm::EDConsumerBase::Labels labels;
+          theEvent.labelsForToken(simHitToken, labels);
+          std::string trackerContainer(labels.productInstance);
+          unsigned int tofBin = StripDigiSimLink::LowTof;
+          if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+          simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+          SimHitCollMap[theSimHitCollID].push_back(isim);
+        }
+        ++Nhits;
+      }
+      // std::cout << "simHits from prompt collections; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
+    }
+  }
+}
+
+// this instance of makeMaps is deprecated
+void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const vstring& trackerContainers) {
   // Step A: Get Inputs
   //  The collections are specified via ROUList in the configuration, and can
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof) 

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
@@ -221,7 +221,7 @@ class GlobalRecHitsAnalyzer : public DQMEDAnalyzer
     projectHit( const PSimHit& hit,
 		const StripGeomDetUnit* stripDet,
 		const BoundPlane& plane);
-  edm::ParameterSet conf_;
+  TrackerHitAssociator trackerHitAssociator_;
 
   // SiPxl
 

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
@@ -269,7 +269,7 @@ class GlobalRecHitsProducer : public edm::EDProducer
     projectHit( const PSimHit& hit,
 		const StripGeomDetUnit* stripDet,
 		const BoundPlane& plane);
-  edm::ParameterSet conf_;
+  TrackerHitAssociator trackerHitAssociator_;
 
   // SiPxl
 

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -15,7 +15,7 @@ using namespace std;
 
 GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet) :
   fName(""), verbosity(0), frequency(0), label(""), getAllProvenances(false),
-  printProvenanceInfo(false), count(0)
+  printProvenanceInfo(false), trackerHitAssociator_(iPSet, consumesCollector()), count(0)
 {
   consumesMany<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit> > >();
   consumesMany<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit> > >();
@@ -48,8 +48,6 @@ GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet) :
   MuCSCSrc_ = iPSet.getParameter<edm::InputTag>("MuCSCSrc");
   MuRPCSrc_ = iPSet.getParameter<edm::InputTag>("MuRPCSrc");
   MuRPCSimSrc_ = iPSet.getParameter<edm::InputTag>("MuRPCSimSrc");
-
-  conf_ = iPSet;
 
   // fix for consumes
   ECalUncalEBSrc_Token_ = consumes<EBUncalibratedRecHitCollection>(iPSet.getParameter<edm::InputTag>("ECalUncalEBSrc"));
@@ -915,7 +913,8 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent,
     validstrip = false;
   }  
   
-  TrackerHitAssociator associate(iEvent,conf_);
+  TrackerHitAssociator& associate = trackerHitAssociator_;
+  associate.processEvent(iEvent);
   
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);

--- a/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
@@ -12,7 +12,7 @@
 
 GlobalRecHitsProducer::GlobalRecHitsProducer(const edm::ParameterSet& iPSet) :
   fName(""), verbosity(0), frequency(0), label(""), getAllProvenances(false),
-  printProvenanceInfo(false), count(0)
+  printProvenanceInfo(false), trackerHitAssociator_(iPSet, consumesCollector()), count(0)
 {
   std::string MsgLoggerCat = "GlobalRecHitsProducer_GlobalRecHitsProducer";
 
@@ -65,7 +65,6 @@ GlobalRecHitsProducer::GlobalRecHitsProducer(const edm::ParameterSet& iPSet) :
   EBHits_Token_ = consumes<CrossingFrame<PCaloHit> >(edm::InputTag(std::string("mix"), iPSet.getParameter<std::string>("hitsProducer") + std::string("EcalHitsEB")));
   EEHits_Token_ = consumes<CrossingFrame<PCaloHit> >(edm::InputTag(std::string("mix"), iPSet.getParameter<std::string>("hitsProduc\
 er") + std::string("EcalHitsEE")));
-  conf_ = iPSet;
 
   // use value of first digit to determine default output level (inclusive)
   // 0 is none, 1 is basic, 2 is fill output, 3 is gather output
@@ -893,7 +892,8 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
     return;
   }  
 
-  TrackerHitAssociator associate(iEvent,conf_);
+  TrackerHitAssociator& associate = trackerHitAssociator_;
+  associate.processEvent(iEvent);
 
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);

--- a/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
@@ -85,7 +85,7 @@ class SiPixelTrackingRecHitsValid : public DQMEDAnalyzer
 
  private:
 
-  edm::ParameterSet conf_;
+  TrackerHitAssociator trackerHitAssociator_;
   //TrackLocalAngle *anglefinder_;
   DQMStore* dbe_;
   bool runStandalone;

--- a/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
@@ -421,6 +421,7 @@ class SiStripTrackingRecHitsValid : public DQMEDAnalyzer
   
 
   edm::ParameterSet conf_;
+  TrackerHitAssociator trackerHitAssociator_;
   unsigned long long m_cacheID_;
   edm::ParameterSet Parameters;
 

--- a/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
@@ -109,7 +109,9 @@ void SiPixelTrackingRecHitsValid::beginJob()
   
 }
 
-SiPixelTrackingRecHitsValid::SiPixelTrackingRecHitsValid(const edm::ParameterSet& ps):conf_(ps), dbe_(0), tfile_(0), t_(0)
+SiPixelTrackingRecHitsValid::SiPixelTrackingRecHitsValid(const edm::ParameterSet& ps) :
+  trackerHitAssociator_(ps, consumesCollector()),
+  dbe_(0), tfile_(0), t_(0)
 {
   //Read config file
   MTCCtrack_ = ps.getParameter<bool>("MTCCtrack");
@@ -1092,7 +1094,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
   float mindist = 999999.9;
 
   std::vector<PSimHit> matched;
-  TrackerHitAssociator associate(e,conf_);
+  trackerHitAssociator_.processEvent(e);
 
   edm::ESHandle<TrackerGeometry> pDD;
   es.get<TrackerDigiGeometryRecord> ().get (pDD);
@@ -1267,7 +1269,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 
 		      //Association of the rechit to the simhit
 		      matched.clear();
-		      matched = associate.associateHit(*matchedhit);
+		      matched = trackerHitAssociator_.associateHit(*matchedhit);
 
 		      nsimhit = (int)matched.size();
 

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -43,6 +43,7 @@ class TFile;
 SiStripTrackingRecHitsValid::SiStripTrackingRecHitsValid(const edm::ParameterSet& ps) : 
   dbe_(edm::Service<DQMStore>().operator->()),	
   conf_(ps),
+  trackerHitAssociator_(ps, consumesCollector()),
   m_cacheID_(0)
   // trajectoryInput_( ps.getParameter<edm::InputTag>("trajectoryInput") )
 {
@@ -466,7 +467,8 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event & e, const edm::Event
   DetId detid;
   uint32_t myid;
 
-  TrackerHitAssociator associate(e, conf_);
+  TrackerHitAssociator& associate = trackerHitAssociator_;
+  associate.processEvent(e);
   PSimHit closest;
 
   //Retrieve tracker topology from geometry

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -14,6 +14,7 @@
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 
+#include <memory>
 #include <string>
 
 class DQMStore;
@@ -22,6 +23,7 @@ class MonitorElement;
 class PSimHit;
 class PixelGeomDetUnit;
 class SiPixelRecHit;
+class TrackerHitAssociator;
 class TrackerTopology;
 
 class SiPixelRecHitsValid : public DQMEDAnalyzer {
@@ -113,7 +115,7 @@ class SiPixelRecHitsValid : public DQMEDAnalyzer {
 	MonitorElement* recHitYPullDisk1Plaquettes[7];
 	MonitorElement* recHitYPullDisk2Plaquettes[7];
 
-        edm::ParameterSet conf_;
+        std::unique_ptr<TrackerHitAssociator> trackerHitAssociator_;
         edm::EDGetTokenT<SiPixelRecHitCollection> siPixelRecHitCollectionToken_;
 };
 

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -33,8 +33,8 @@
 #include "Geometry/TrackerNumberingBuilder/interface/GeometricDet.h"
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 
+#include <memory>
 #include <string>
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
@@ -44,6 +44,7 @@
 
 class SiStripDetCabling;
 class SiStripDCSStatus;
+class TrackerHitAssociator;
 
 class SiStripRecHitsValid : public DQMEDAnalyzer {
 
@@ -205,8 +206,8 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   inline void fillME(MonitorElement* ME,float value1,float value2,float value3,float value4){if (ME!=0)ME->Fill(value1,value2,value3,value4);}
 
   edm::ParameterSet conf_;
+  std::unique_ptr<TrackerHitAssociator> trackerHitAssociator_;
   unsigned long long m_cacheID_;
-  edm::ParameterSet Parameters;
   //const StripTopology* topol;
 
   /* static const int MAXHIT = 1000; */
@@ -219,7 +220,6 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   void rechitanalysis(SiStripRecHit2D const rechit,const StripTopology &topol, TrackerHitAssociator& associate);
   void rechitanalysis_matched(SiStripMatchedRecHit2D const rechit, const GluedGeomDet* gluedDet, TrackerHitAssociator& associate);
   
-  //edm::InputTag matchedRecHits_, rphiRecHits_, stereoRecHits_; 
   edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> matchedRecHitsToken_;
   edm::EDGetTokenT<SiStripRecHit2DCollection> rphiRecHitsToken_;
   edm::EDGetTokenT<SiStripRecHit2DCollection> stereoRecHitsToken_;

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -49,7 +49,7 @@
 #include <math.h>
 
 SiPixelRecHitsValid::SiPixelRecHitsValid(const edm::ParameterSet& ps)
-  : conf_(ps)
+  : trackerHitAssociator_(new TrackerHitAssociator(ps, consumesCollector()))
   , siPixelRecHitCollectionToken_( consumes<SiPixelRecHitCollection>( ps.getParameter<edm::InputTag>( "src" ) ) ) {
 
 }
@@ -300,7 +300,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   es.get<TrackerDigiGeometryRecord>().get(geom); 
   const TrackerGeometry& theTracker(*geom);
   
-  TrackerHitAssociator associate( e, conf_ ); 
+  trackerHitAssociator_->processEvent(e);
   
   //iterate over detunits
   for (TrackerGeometry::DetContainer::const_iterator it = geom->dets().begin(); it != geom->dets().end(); it++) 
@@ -324,7 +324,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
       for ( ; pixeliter != pixelrechitRangeIteratorEnd; pixeliter++) 
 	{
 	  matched.clear();
-	  matched = associate.associateHit(*pixeliter);
+	  matched = trackerHitAssociator_->associateHit(*pixeliter);
 	  
 	  if ( !matched.empty() ) 
 	    {

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -47,6 +47,7 @@ namespace helper {
 //Constructor
 SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
   conf_(ps),
+  trackerHitAssociator_(new TrackerHitAssociator(ps, consumesCollector())),
   m_cacheID_(0)
   // matchedRecHits_( ps.getParameter<edm::InputTag>("matchedRecHits") ),
   // rphiRecHits_( ps.getParameter<edm::InputTag>("rphiRecHits") ),
@@ -230,7 +231,8 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   int totrechitstereo =0;
   int totrechitmatched =0;
    
-  TrackerHitAssociator associate(e, conf_);
+  TrackerHitAssociator& associate = *trackerHitAssociator_;
+  associate.processEvent(e);
   
   edm::ESHandle<TrackerGeometry> pDD;
   es.get<TrackerDigiGeometryRecord> ().get (pDD);
@@ -1011,11 +1013,11 @@ void SiStripRecHitsValid::createSubDetMEs(DQMStore::IBooker & ibooker,std::strin
 //------------------------------------------------------------------------------------------
 MonitorElement* SiStripRecHitsValid::bookME1D(DQMStore::IBooker & ibooker, const char* ParameterSetLabel, const char* HistoName, const char* HistoTitle)
 {
-  Parameters =  conf_.getParameter<edm::ParameterSet>(ParameterSetLabel);
+  edm::ParameterSet parameters =  conf_.getParameter<edm::ParameterSet>(ParameterSetLabel);
   return ibooker.book1D(HistoName,HistoTitle,
-			   Parameters.getParameter<int32_t>("Nbinx"),
-			   Parameters.getParameter<double>("xmin"),
-			   Parameters.getParameter<double>("xmax")
+			   parameters.getParameter<int32_t>("Nbinx"),
+			   parameters.getParameter<double>("xmin"),
+			   parameters.getParameter<double>("xmax")
 			   );
 }
 


### PR DESCRIPTION
This pull request implements the consumes interface in class TrackerHitAssociator, which involves adding to one existing constructor and adding two new functions, one public.  Other very minor optimizations were also made to this class.
This pull request also modifies six modules to use the new TrackerHitAssociator interface so that all products read by the TrackerHitAssociator will be read by getByToken, and therefore registered with the consumes interface.  These modules include all five such modules that are known to be used in the relvals.
Note that the current interface to  TrackerHitAssociator was left unchanged because many other modules still use it, although comments were added indicating that it is deprecated.
