### PR TITLE
Remove not implemented method in PileupJetIdAlgo

### DIFF
--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -37,11 +37,6 @@ public:
 					       float jec, const reco::Vertex *, const reco::VertexCollection &,
 					       bool calculateMva=false);
 
-	PileupJetIdentifier computeIdVariables(const pat::Jet * jet,
-					       const edm::Ptr<reco::Vertex>,
-					       const std::map<edm::Ptr<reco::Vertex>,edm::PtrVector<pat::PackedCandidate> >&,
-					       bool calculateMva);
-	
 	void set(const PileupJetIdentifier &);
 	PileupJetIdentifier computeMva();
 	const std::string method() const { return tmvaMethod_; }


### PR DESCRIPTION
otherwise this prevents the package to be linked. 
This method is not wanted by default, according to the experts, see HN message: https://hypernews.cern.ch/HyperNews/CMS/get/jet-algorithms/351.html
