### PR TITLE
Updates to HCAL relval scripts and standalone configs

### DIFF
--- a/Validation/CaloTowers/test/client_data_cfg.py
+++ b/Validation/CaloTowers/test/client_data_cfg.py
@@ -1,0 +1,141 @@
+import FWCore.ParameterSet.Config as cms
+
+import os
+import sys
+import re
+
+class config: pass
+config.runNumber = int(sys.argv[2])
+print config.runNumber
+
+for arg in sys.argv: 
+   print arg
+
+readFiles = cms.untracked.vstring()
+
+matchRootFile = re.compile("\S*\.root$")
+for argument in sys.argv[3:]:
+   if matchRootFile.search(argument):
+      fileToRead = "file:"+argument
+      readFiles.append(fileToRead)
+
+print "readFiles : \n", readFiles
+
+print config.runNumber
+
+##########
+
+process = cms.Process('HARVESTING')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.EDMtoMEAtRunEnd_cff')
+process.load('Configuration.StandardSequences.Harvesting_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+process.load("DQMServices.Core.DQM_cfg")
+process.load("DQMServices.Components.DQMEnvironment_cfi")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(100)
+)
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.autoCond import autoCond
+#process.GlobalTag.globaltag = autoCond['com10']
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run1_data', '')
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 1
+
+# summary
+process.options = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )
+
+#process.source = cms.Source("PoolSource",
+#    fileNames = readFiles,
+#    processingMode = cms.untracked.string('RunsAndLumis')
+#)
+
+# Input source
+process.source = cms.Source("DQMRootSource",
+    fileNames = readFiles,
+    filterOnRun = cms.untracked.uint32(config.runNumber)                        
+)
+process.options = cms.untracked.PSet(
+    Rethrow = cms.untracked.vstring('ProductNotFound'),
+    fileMode = cms.untracked.string('FULLMERGE')
+)
+
+#process.load('Configuration/StandardSequences/EDMtoMEAtRunEnd_cff')
+##process.EDMtoMEConverter.convertOnEndLumi = False
+#process.dqmSaver.referenceHandling = cms.untracked.string('all')
+## Don't do this: process.dqmSaver.enableMultiThread = cms.untracked.bool(True)
+
+cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
+Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
+process.dqmSaver.workflow = Workflow
+
+#process.dqmSaver.saveByRun         = 1
+#process.dqmSaver.saveAtJobEnd = False
+#process.dqmSaver.forceRunNumber = 208339
+#process.dqmSaver.runIsComplete = True
+#process.dqmSaver.saveByRun = cms.untracked.int32(1)
+#process.dqmSaver.saveAtJobEnd = cms.untracked.bool(True)
+#process.dqmSaver.forceRunNumber = cms.untracked.int32(999999)
+process.DQMStore.collateHistograms = cms.untracked.bool(True)
+process.dqmSaver.convention = 'Offline'
+process.dqmSaver.saveByRun = -1
+process.dqmSaver.saveAtJobEnd = True
+process.dqmSaver.forceRunNumber = config.runNumber
+
+process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+     outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
+     DQMDirName = cms.string("/") # root directory
+)
+
+process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+     outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
+     DQMDirName = cms.string("/") # root directory
+)
+
+process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+     outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
+     DQMDirName = cms.string("/") # root directory
+)
+
+##########
+process.calotowersDQMClient = cms.EDAnalyzer("CaloTowersDQMClient",
+      outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
+#     outputFile = cms.untracked.string(''),
+      DQMDirName = cms.string("/") # root directory
+)
+process.hcalNoiseRatesClient = cms.EDAnalyzer("HcalNoiseRatesClient", 
+     outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
+#     outputFile = cms.untracked.string(''),
+     DQMDirName = cms.string("/") # root directory
+)
+process.hcalRecHitsDQMClient = cms.EDAnalyzer("HcalRecHitsDQMClient", 
+     outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
+#    outputFile = cms.untracked.string(''),
+     DQMDirName = cms.string("/") # root directory
+)
+
+##########
+
+#process.p = cms.Path(process.EDMtoME * process.calotowersClient * process.noiseratesClient * process.hcalrechitsClient * process.dqmSaver)
+#process.p = cms.Path(process.EDMtoME * process.calotowersClient * process.noiseratesClient * process.hcalrechitsClient * process.dqmSaver)
+#process.p = cms.Path(process.EDMtoME * process.dqmSaver)
+#process.p = cms.Path(process.EDMtoME * process.calotowersClient * process.dqmSaver)
+
+process.edmtome_step = cms.Path(process.EDMtoME)
+process.validationHarvesting = cms.Path(process.calotowersClient + process.noiseratesClient + process.hcalrechitsClient + process.calotowersDQMClient + process.hcalNoiseRatesClient + process.hcalRecHitsDQMClient)
+process.dqmsave_step = cms.Path(process.DQMSaver)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.edmtome_step,process.validationHarvesting,process.dqmsave_step)

--- a/Validation/CaloTowers/test/crab3Config_run_onRelVal_data.py
+++ b/Validation/CaloTowers/test/crab3Config_run_onRelVal_data.py
@@ -1,0 +1,26 @@
+from WMCore.Configuration import Configuration
+config = Configuration()
+
+config.section_("General")
+config.General.requestName = 'JetHT_CMSSW_732_patch1'
+
+config.section_("JobType")
+config.JobType.pluginName = 'Analysis'
+config.JobType.psetName = 'run_onRelVal_KH_cfg.py'
+config.JobType.allowNonProductionCMSSW = False
+
+config.section_("Data")
+config.Data.inputDataset = '/JetHT/CMSSW_7_3_2_patch1-GR_R_73_V0_HcalExtValid_RelVal_jet2012D-v2/RECO'
+config.Data.inputDBS = 'https://cmsweb.cern.ch/dbs/prod/global/DBSReader/'
+config.Data.splitting = 'FileBased'
+config.Data.unitsPerJob = 20
+config.Data.publication = False
+#config.Data.publishDBS = 'https://cmsweb.cern.ch/dbs/prod/phys03/DBSWriter/'
+#config.Data.publishDataName = 'PHYS14_PU20bx25_PHYS14_25_V1-FLAT'
+#Use your own username instead of the "lhx". Keep branch tag in the directory name, e.g., PHYS14_720_Dec23_2014.
+config.Data.outLFN = '/store/user/hatake/DQMIO/'
+
+config.Data.ignoreLocality = False
+
+config.section_("Site")
+config.Site.storageSite = 'T3_US_Baylor'

--- a/Validation/CaloTowers/test/macros/RelValHarvest.py
+++ b/Validation/CaloTowers/test/macros/RelValHarvest.py
@@ -10,41 +10,29 @@ parser.add_option("-p", "--printDataSets", action="store_true", dest="printDS", 
 (options, args) = parser.parse_args()
 
 # This is a dictionary of flags to pull out the datasets of interest mapped to the desired name from the hcal script
-dsFlags = {'RelValTTbar_':'TTbar', 'RelValQCD_Pt_80_120_':'QCD', 'RelValQCD_Pt_3000_3500_':'HighPtQCD', 'RelValMinBias_':'MinBias'}
-# Dataset to select (simply so we only get one of each sample above)
-sds = "GEN-SIM-RECO"
+dsFlags = {'RelValTTbar_13__':'TTbar', 'RelValQCD_Pt_80_120_13__':'QCD', 'RelValQCD_Pt_3000_3500_13__':'HighPtQCD', 'RelValMinBias_13TeV_pythia8__':'MinBias'}
 # filename prefix 
 fnPrefix = "DQM_V0001_R000000001"
 # blank curl command 
-curl = "/usr/bin/curl -O -L --capath %(CERT_DIR)s --key %(USER_PROXY)s --cert %(USER_PROXY)s https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/%(relvalDIR)s/%(fname)s"
+curl = "/usr/bin/curl -O -L --capath %(CERT_DIR)s --key %(USER_PROXY)s --cert %(USER_PROXY)s https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/%(relvalDIR)s"
 # output file name blank
 ofnBlank = "HcalRecHitValidationRelVal_%(sample)s_%(label)s_%(info)s.root"
 # default release file for MC stub
-dfTextFile = "%s_%s.txt"
+#dfTextFile = "%s_%s.txt"
+dfTextFile = "%s"
 
 # ensure all required parameters are included
-if len(args) < 2:
-    print "Usage: ./RelValHarvest.py fullReleaseName [RelValDataSetList.txt] [Dataset]"
-    print "fullReleaseName : CMSSW_5_2_0_pre3"
-    print "RelValDataSetList.txt : text file from relval announcement"
-    print "Dataset : usually DQMIO, but if that is not avaliable then GEN-SIM-RECO"
+if len(args) < 1:
+    print "Usage: ./RelValHarvest.py fullReleaseName"
+    print "fullReleaseName : CMSSW_7_4_0_pre8"
     exit(0)
 
 # gather input parameter
 label     = args[0]
-fileinPost = "standard"
-dataset = "DQMIO"
-if len(args) > 1:
-    fileinPost = args[1]
-    if len(args) > 2:
-        dataset = args[2]
 
-filein = dfTextFile%(label, fileinPost)
-print "Taking filenames form file %s"%filein
-
-# retrieve the list of datasets
-if not os.path.isfile(filein):
-    os.system("wget http://cms-project-relval.web.cern.ch/cms-project-relval/relval_stats/%s"%filein)
+# gather necessary proxy info for curl
+X509_CERT_DIR = os.getenv('X509_CERT_DIR', "/etc/grid-security/certificates")
+X509_USER_PROXY = os.getenv('X509_USER_PROXY')
 
 # modify label to shortened format (remove CMSSW and '_')
 slabel = label.replace('CMSSW','').replace("_","")
@@ -53,51 +41,62 @@ slabel = label.replace('CMSSW','').replace("_","")
 clabel = label.split("_")
 relvalDIR = "%s_%s_%s_x"%(clabel[0], clabel[1], clabel[2])
 
-# initialize voms proxy for transfer
-if not options.printDS:
-    os.system('voms-proxy-init -voms cms')
+print "Taking filenames form file %s"%relvalDIR
 
-# gather necessary proxy info for curl
-X509_CERT_DIR = os.getenv('X509_CERT_DIR', "/etc/grid-security/certificates")
-X509_USER_PROXY = os.getenv('X509_USER_PROXY')
+# retrieve the list of datasets
+if not os.path.isfile(relvalDIR):
+    #os.system("wget http://cms-project-relval.web.cern.ch/cms-project-relval/relval_stats/%s"%filein)
+    curlCommand = curl%{"CERT_DIR":X509_CERT_DIR, "USER_PROXY":X509_USER_PROXY, "relvalDIR":relvalDIR}
+    print curlCommand
+    os.system(curlCommand)        
+
+# initialize voms proxy for transfer
+#if not options.printDS:
+#    os.system('voms-proxy-init -voms cms')
 
 # open raw inpout file 
-fin = open(filein, "r")
+fin = open(relvalDIR, "r")
 
 # loop over file and pull out lines of interest
 for line in fin:
     # limit to one entry per dataset
-    if sds in line:
+    if label in line:
         # select datasets of interest
         for str in dsFlags.keys():
             if str in line:
                 # extract dataset path
-                path = line.split('|')[1].strip()
+                path = line.split('\'')[1].strip()
+
                 #print "Getting DQM output from dataset: %s"%path
                 print path
                 if options.printDS:
                     continue
+
                 # construct file name
-                fname = fnPrefix + path.replace("/","__").replace(sds, "%s.root"%dataset)
-                # copy file with curl
-                curlCommand = curl%{"CERT_DIR":X509_CERT_DIR,"USER_PROXY":X509_USER_PROXY, "relvalDIR":relvalDIR,"fname":fname}
-                print curlCommand
-                os.system(curlCommand)
-                # rename file for use with hcal scripts
-                # DQM_V0001_R000000001__RelValTTbar_13__CMSSW_7_2_0_pre7-PU50ns_PRE_LS172_V12-v1__DQMIO.root
-                # get dataset info from file name 
+                fname = path.split("/")[-1]
+
+                # create file name for use with hcal scripts
                 info = fname.split("__")[2].replace(label, "").strip("-")
                 ofn = ofnBlank%{"sample":dsFlags[str],"label":slabel,"info":info}
-                mvCommand = "mv %(fn)s %(ofn)s"%{"fn":fname,"ofn":ofn}
-                print mvCommand
-                os.system(mvCommand)
-                print ""
+                
+                #Check if file exists already
+                if not os.path.isfile(ofn):
+                    # copy file with curl
+                    curlCommand = curl%{"CERT_DIR":X509_CERT_DIR,"USER_PROXY":X509_USER_PROXY, "relvalDIR":relvalDIR} + "/" + fname
+                    print curlCommand
+                    os.system(curlCommand)
+
+                    # Rename file for use with HCAL scripts
+                    mvCommand = "mv %(fn)s %(ofn)s"%{"fn":fname,"ofn":ofn}
+                    print mvCommand
+                    os.system(mvCommand)
+                    print ""
 
 if options.printDS:
     exit()
 
 # Copy the single pion scan part from Salavat's directory
-spFileName = "pi50scan%s_ECALHCAL_CaloTowers.root"%slabel
+spFileName = "pi50scan%s_fullGeom_ECALHCAL_CaloTowers.root"%slabel
 cpCommand = "cp /afs/cern.ch/user/a/abdullin/public/pi50_scan/%s ."%spFileName
 if not os.path.isfile(spFileName):
     print cpCommand

--- a/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
+++ b/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
@@ -1,0 +1,152 @@
+import os
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process("hcalval")
+process.load("Configuration.StandardSequences.Reconstruction_cff")
+process.load("Configuration.StandardSequences.Geometry_cff")
+
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+from Configuration.AlCa.autoCond import autoCond
+process.GlobalTag.globaltag = autoCond['startup']
+
+process.load("FWCore.MessageLogger.MessageLogger_cfi")
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
+
+#process.load("DQMServices.Core.DQM_cfg")
+#process.DQM.collectorHost = ''
+
+process.load("DQMServices.Core.DQMStore_cfi")
+process.load("DQMServices.Components.MEtoEDMConverter_cfi")
+
+#process.load("DQMOffline.Configuration.DQMOffline_cff")
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring(
+        '/store/data/Run2012D/JetHT/RECO/22Jan2013-v1/10004/1ACCAD9D-E496-E211-AA96-90E6BA19A25A.root',
+        '/store/data/Run2012D/JetHT/RECO/22Jan2013-v1/10005/92C62727-2897-E211-8FDA-20CF3027A62F.root',
+        '/store/data/Run2012D/JetHT/RECO/22Jan2013-v1/10015/DE3B5E5B-DE96-E211-BF85-002590747D92.root',
+        '/store/data/Run2012D/JetHT/RECO/22Jan2013-v1/10015/F2E70090-DD96-E211-AA17-E0CB4EA0A8FE.root',
+        '/store/data/Run2012D/JetHT/RECO/22Jan2013-v1/10015/FC59BBF3-DE96-E211-B868-E0CB4E1A11A1.root'
+      ),
+    inputCommands = cms.untracked.vstring('keep *', 'drop *_MEtoEDMConverter_*_*')
+)
+
+#process.FEVT = cms.OutputModule("PoolOutputModule",
+#     outputCommands = cms.untracked.vstring('drop *', 'keep *_MEtoEDMConverter_*_*'),
+#     fileName = cms.untracked.string("HcalValHarvestingEDM.root")
+#)
+
+process.hcalTowerAnalyzer = cms.EDAnalyzer("CaloTowersValidation",
+    outputFile               = cms.untracked.string('CaloTowersValidationRelVal.root'),
+    CaloTowerCollectionLabel = cms.untracked.InputTag('towerMaker'),
+
+    hcalselector             = cms.untracked.string('all'),
+    mc                       = cms.untracked.string('no'),
+    useAllHistos             = cms.untracked.bool(False)                         
+)
+
+process.noiseRates = cms.EDAnalyzer('NoiseRates',
+    outputFile   = cms.untracked.string('NoiseRatesRelVal.root'),
+    rbxCollName  = cms.untracked.InputTag('hcalnoise'),
+
+    minRBXEnergy = cms.untracked.double(20.0),
+    minHitEnergy = cms.untracked.double(1.5),
+    useAllHistos = cms.untracked.bool(False)                         
+)
+
+process.hcalRecoAnalyzer = cms.EDAnalyzer("HcalRecHitsValidation",
+    outputFile                = cms.untracked.string('HcalRecHitValidationRelVal.root'),
+    HBHERecHitCollectionLabel = cms.untracked.InputTag("hbhereco"),
+    HFRecHitCollectionLabel   = cms.untracked.InputTag("hfreco"),
+    HORecHitCollectionLabel   = cms.untracked.InputTag("horeco"),
+
+    eventype                  = cms.untracked.string('multi'),
+    ecalselector              = cms.untracked.string('yes'),
+    hcalselector              = cms.untracked.string('all'),
+    mc                        = cms.untracked.string('no'),
+    useAllHistos              = cms.untracked.bool(False)                                                                                                          
+)
+
+process.load('Configuration/StandardSequences/EDMtoMEAtRunEnd_cff')
+process.dqmSaver.referenceHandling = cms.untracked.string('all')
+
+cmssw_version = os.environ.get('CMSSW_VERSION','CMSSW_X_Y_Z')
+Workflow = '/HcalValidation/'+'Harvesting/'+str(cmssw_version)
+process.dqmSaver.workflow = Workflow
+#process.dqmSaver.saveByRun         = 1
+#process.dqmSaver.saveAtJobEnd = False
+
+process.calotowersClient = cms.EDAnalyzer("CaloTowersClient", 
+     outputFile = cms.untracked.string('CaloTowersHarvestingME.root'),
+     DQMDirName = cms.string("/") # root directory
+)
+
+process.noiseratesClient = cms.EDAnalyzer("NoiseRatesClient", 
+     outputFile = cms.untracked.string('NoiseRatesHarvestingME.root'),
+     DQMDirName = cms.string("/") # root directory
+)
+
+process.hcalrechitsClient = cms.EDAnalyzer("HcalRecHitsClient", 
+     outputFile = cms.untracked.string('HcalRecHitsHarvestingME.root'),
+     DQMDirName = cms.string("/") # root directory
+)
+
+##########
+process.calotowersAnalyzer = cms.EDAnalyzer("CaloTowersAnalyzer",
+     outputFile               = cms.untracked.string(''),
+     CaloTowerCollectionLabel = cms.untracked.InputTag('towerMaker'),
+     hcalselector             = cms.untracked.string('all'),
+     useAllHistos             = cms.untracked.bool(False)
+)
+ 
+process.hcalRecHitsAnalyzer = cms.EDAnalyzer("HcalRecHitsAnalyzer",
+#    outputFile                = cms.untracked.string('HcalRecHitValidationRelVal.root'),
+    outputFile                = cms.untracked.string(''),
+
+    HBHERecHitCollectionLabel = cms.untracked.InputTag("hbhereco"),
+    HFRecHitCollectionLabel   = cms.untracked.InputTag("hfreco"),
+    HORecHitCollectionLabel   = cms.untracked.InputTag("horeco"),
+
+    eventype                  = cms.untracked.string('multi'),
+    ecalselector              = cms.untracked.string('yes'),
+    hcalselector              = cms.untracked.string('all'),
+    useAllHistos              = cms.untracked.bool(False)                                 
+)
+
+process.hcalNoiseRates = cms.EDAnalyzer('HcalNoiseRates',
+#    outputFile   = cms.untracked.string('NoiseRatesRelVal.root'),
+    outputFile   = cms.untracked.string(''),
+    rbxCollName  = cms.untracked.InputTag('hcalnoise'),
+    minRBXEnergy = cms.untracked.double(20.0),
+    minHitEnergy = cms.untracked.double(1.5),
+    useAllHistos = cms.untracked.bool(False)
+)
+
+##########
+
+process.p2 = cms.Path( process.hcalTowerAnalyzer * process.noiseRates * process.hcalRecoAnalyzer * 
+                       process.calotowersAnalyzer * process.hcalRecHitsAnalyzer * process.hcalNoiseRates)
+#                       * process.calotowersClient * process.noiseratesClient * process.hcalrechitsClient * process.dqmSaver)
+
+#
+# DQMIO
+#
+#process.DQMStore.enableMultiThread = cms.untracked.bool(False)
+process.load('Configuration.EventContent.EventContent_cff')
+process.DQMoutput = cms.OutputModule("DQMRootOutputModule",
+    splitLevel = cms.untracked.int32(0),
+    outputCommands = process.DQMEventContent.outputCommands,
+    fileName = cms.untracked.string('file:DQMIO.root'),
+    dataset = cms.untracked.PSet(
+        filterName = cms.untracked.string(''),
+        dataTier = cms.untracked.string('DQMIO')
+    )
+)
+
+#process.output = cms.EndPath(process.FEVT * process.DQMoutput)
+process.output = cms.EndPath(process.DQMoutput)
+process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True) )

--- a/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
+++ b/Validation/CaloTowers/test/run_onRelVal_data_cfg.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("hcalval")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
-process.load("Configuration.StandardSequences.Geometry_cff")
+process.load("Configuration.StandardSequences.GeometryRecoDB_cff")
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 from Configuration.AlCa.autoCond import autoCond
@@ -16,7 +16,7 @@ process.MessageLogger.cerr.FwkReport.reportEvery = 100
 #process.DQM.collectorHost = ''
 
 process.load("DQMServices.Core.DQMStore_cfi")
-process.load("DQMServices.Components.MEtoEDMConverter_cfi")
+#process.load("DQMServices.Components.MEtoEDMConverter_cfi")
 
 #process.load("DQMOffline.Configuration.DQMOffline_cff")
 


### PR DESCRIPTION
Changes in  Validation/CaloTowers/test
- RelValHarvest.py updated to circumvent poorly named relval dataset status files
- new configs for rerunning DQM file feneration on data added

Is it still possible to include this change in a 7_4_X release as well as well?
