### PR TITLE
bug fixes in CSC (ME11) trigger primitives for re-emulation; fix ME11 selective readout

### DIFF
--- a/DataFormats/L1CSCTrackFinder/interface/CSCTFConstants.h
+++ b/DataFormats/L1CSCTrackFinder/interface/CSCTFConstants.h
@@ -13,9 +13,9 @@
 class CSCTFConstants
 {
  public:
-  enum WG_and_Strip { MAX_NUM_WIRES = 119, MAX_NUM_STRIPS = 80,
+  enum WG_and_Strip { MAX_NUM_WIRES = 119, MAX_NUM_STRIPS = 80, MAX_NUM_STRIPS_7CFEBS = 112,
 			     NUM_DI_STRIPS = 40+1, // Add 1 to allow for staggering of strips
-			     NUM_HALF_STRIPS = 160+1};
+		             NUM_HALF_STRIPS = 160+1, NUM_HALF_STRIPS_7CFEBS = 224+1};
 
   enum Layer_Info { NUM_LAYERS = 6, KEY_LAYER = 4 }; // shouldn't key layer be 3?
 

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -299,7 +299,7 @@ void CSCDigiToRaw::add(const CSCCLCTDigiCollection & clctDigis)
       //CLCTs are packed by chamber not by A/B parts in ME11
       //me11a appears only in simulation with SLHC algorithm settings
       //without the shift, it's impossible to distinguish A and B parts
-      if (me11a){
+      if (me11a && formatVersion_ == 2013){
 	std::vector<CSCCLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
 	for (std::vector<CSCCLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
 	  if (iC->getCFEB() >= 0 && iC->getCFEB() < 3){//sanity check, mostly
@@ -326,7 +326,7 @@ void CSCDigiToRaw::add(const CSCCorrelatedLCTDigiCollection & corrLCTDigis)
       //LCTs are packed by chamber not by A/B parts in ME11
       //me11a appears only in simulation with SLHC algorithm settings
       //without the shift, it's impossible to distinguish A and B parts
-      if (me11a){
+      if (me11a && formatVersion_ == 2013){
 	std::vector<CSCCorrelatedLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
         for (std::vector<CSCCorrelatedLCTDigi>::iterator iC = shiftedDigis.begin(); iC != shiftedDigis.end(); ++iC) {
           if (iC->getStrip() >= 0 && iC->getStrip() < 96){//sanity check, mostly

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -295,7 +295,21 @@ void CSCDigiToRaw::add(const CSCCLCTDigiCollection & clctDigis)
       CSCDetId cscDetId=(*j).first;
       CSCEventData & cscData = findEventData(cscDetId);
 
-      cscData.add(std::vector<CSCCLCTDigi>((*j).second.first, (*j).second.second));
+      bool me11a = cscDetId.station() == 1 && cscDetId.ring() == 4;
+      //CLCTs are packed by chamber not by A/B parts in ME11
+      if (me11a){
+	std::vector<CSCCLCTDigi> shiftedDigis((*j).second.first, (*j).second.second);
+	for (auto iC : shiftedDigis) {
+	  if (iC.getCFEB() >= 0 && iC.getCFEB() < 3){//sanity check, mostly
+	    iC = CSCCLCTDigi(iC.isValid(), iC.getQuality(), iC.getPattern(), iC.getStripType(),
+			     iC.getBend(), iC.getStrip(), iC.getCFEB()+4, iC.getBX(), 
+			     iC.getTrknmb(), iC.getFullBX());
+	  }
+	}
+	cscData.add(shiftedDigis);
+      } else {
+	cscData.add(std::vector<CSCCLCTDigi>((*j).second.first, (*j).second.second));
+      }
     }
 }
 

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -82,7 +82,7 @@ bool accept(const CSCDetId & cscId, const LCTCollection & lcts,
 // need to specialize for pretriggers, since they don't have a getBX()
 template<>
 bool accept(const CSCDetId & cscId, const CSCCLCTPreTriggerCollection & lcts,
-            int bxMin, int bxMax, bool me1abCheck = false)
+            int bxMin, int bxMax, bool me1abCheck)
 {
   if (bxMin == -999) return true;
   int nominalBX = 6;

--- a/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
+++ b/EventFilter/CSCRawToDigi/src/CSCDigiToRaw.cc
@@ -40,7 +40,7 @@ CSCDetId chamberID(const CSCDetId & cscDetId)
 
 template<typename LCTCollection>
 bool accept(const CSCDetId & cscId, const LCTCollection & lcts,
-            int bxMin, int bxMax)
+            int bxMin, int bxMax, bool me1abCheck = false)
 {
   if (bxMin == -999) return true;
   int nominalBX = 6;
@@ -57,13 +57,32 @@ bool accept(const CSCDetId & cscId, const LCTCollection & lcts,
           break;
         }
     }
+
+  bool me1 = cscId.station() == 1 && cscId.ring() == 1;
+  //this is another "creative" recovery of smart ME1A-ME1B TMB logic cases: 
+  //wire selective readout requires at least one (A)LCT in the full chamber
+  if (me1 && result == false && me1abCheck){
+    CSCDetId me1aId = CSCDetId(chamberId.endcap(), chamberId.station(), 4, chamberId.chamber(), 0);
+    lctRange = lcts.get(me1aId);
+    for (typename LCTCollection::const_iterator lctItr = lctRange.first;
+	 lctItr != lctRange.second; ++lctItr)
+      {
+	int bx = lctItr->getBX() - nominalBX;
+	if (bx >= bxMin && bx <= bxMax)
+	  {
+	    result = true;
+	    break;
+	  }
+      }
+  }
+
   return result;
 }
 
 // need to specialize for pretriggers, since they don't have a getBX()
 template<>
 bool accept(const CSCDetId & cscId, const CSCCLCTPreTriggerCollection & lcts,
-            int bxMin, int bxMax)
+            int bxMin, int bxMax, bool me1abCheck = false)
 {
   if (bxMin == -999) return true;
   int nominalBX = 6;
@@ -80,6 +99,21 @@ bool accept(const CSCDetId & cscId, const CSCCLCTPreTriggerCollection & lcts,
           break;
         }
     }
+  bool me1a = cscId.station() == 1 && cscId.ring() == 4;
+  if (me1a && result == false && me1abCheck) {
+    //check pretriggers in me1a as well; relevant for TMB emulator writing to separate detIds
+    lctRange = lcts.get(cscId);
+    for (CSCCLCTPreTriggerCollection::const_iterator lctItr = lctRange.first;
+	 lctItr != lctRange.second; ++lctItr)
+      {
+	int bx = *lctItr - nominalBX;
+	if (bx >= bxMin && bx <= bxMax)
+	  {
+	    result = true;
+	    break;
+	  }
+      }    
+  }
   return result;
 }
 
@@ -146,9 +180,10 @@ void CSCDigiToRaw::add(const CSCStripDigiCollection& stripDigis,
       CSCDetId cscDetId=(*j).first;
       // only digitize if there are pre-triggers
       
+      bool me1abCheck = formatVersion_ == 2013;
       /* !!! Testing. Uncomment for production */
      if (!usePreTriggers_ || packEverything_ ||
-	(usePreTriggers_ && cscd2r::accept(cscDetId, preTriggers, preTriggerWindowMin_, preTriggerWindowMax_)) )
+	(usePreTriggers_ && cscd2r::accept(cscDetId, preTriggers, preTriggerWindowMin_, preTriggerWindowMax_, me1abCheck)) )
         {
           bool me1a = (cscDetId.station()==1) && (cscDetId.ring()==4);
           bool zplus = (cscDetId.endcap() == 1);
@@ -209,7 +244,8 @@ void CSCDigiToRaw::add(const CSCWireDigiCollection& wireDigis,
   for (CSCWireDigiCollection::DigiRangeIterator j=wireDigis.begin(); j!=wireDigis.end(); ++j)
     {
       CSCDetId cscDetId=(*j).first;
-      if (packEverything_ || cscd2r::accept(cscDetId, alctDigis, alctWindowMin_, alctWindowMax_))
+      bool me1abCheck = formatVersion_ == 2013;
+      if (packEverything_ || cscd2r::accept(cscDetId, alctDigis, alctWindowMin_, alctWindowMax_, me1abCheck))
         {
           CSCEventData & cscData = findEventData(cscDetId);
           std::vector<CSCWireDigi>::const_iterator digiItr = (*j).second.first;
@@ -231,7 +267,8 @@ void CSCDigiToRaw::add(const CSCComparatorDigiCollection & comparatorDigis,
     {
       CSCDetId cscDetId=(*j).first;
       CSCEventData & cscData = findEventData(cscDetId);
-      if (packEverything_ || cscd2r::accept(cscDetId, clctDigis, clctWindowMin_, clctWindowMax_))
+      bool me1abCheck = formatVersion_ == 2013;
+      if (packEverything_ || cscd2r::accept(cscDetId, clctDigis, clctWindowMin_, clctWindowMax_, me1abCheck))
         {
           bool me1a = (cscDetId.station()==1) && (cscDetId.ring()==4);
 	  

--- a/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
+++ b/L1Trigger/CSCCommonTrigger/interface/CSCConstants.h
@@ -12,9 +12,9 @@
 class CSCConstants
 {
  public:
-  enum WG_and_Strip { MAX_NUM_WIRES = 119, MAX_NUM_STRIPS = 80,
+  enum WG_and_Strip { MAX_NUM_WIRES = 119, MAX_NUM_STRIPS = 80, MAX_NUM_STRIPS_7CFEBS = 112,
 			     NUM_DI_STRIPS = 40+1, // Add 1 to allow for staggering of strips
-			     NUM_HALF_STRIPS = 160+1};
+		             NUM_HALF_STRIPS = 160+1, NUM_HALF_STRIPS_7CFEBS = 224+1};
 
   enum Layer_Info { NUM_LAYERS = 6, KEY_CLCT_LAYER = 3, KEY_CLCT_LAYER_PRE_TMB07 = 4, KEY_ALCT_LAYER = 3 };
 

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -454,7 +454,7 @@ void CSCCathodeLCTProcessor::checkConfigParameters() {
   static const unsigned int max_nplanes_hit_pretrig = 1 << 3;
   static const unsigned int max_nplanes_hit_pattern = 1 << 3;
   static const unsigned int max_pid_thresh_pretrig  = 1 << 4;
-  static const unsigned int max_min_separation = CSCConstants::NUM_HALF_STRIPS;
+  static const unsigned int max_min_separation = CSCConstants::NUM_HALF_STRIPS_7CFEBS;
   static const unsigned int max_tmb_l1a_window_size = 1 << 4;
 
   // Checks.
@@ -574,7 +574,8 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
       // to them.
       // For SLHC ME1/1 is set to have 4 CFEBs in ME1/b and 3 CFEBs in ME1/a
       if (isME11) {
-	if (!smartME1aME1b && !disableME1a && theRing == 1 ) numStrips = 80;
+	if (!smartME1aME1b && !disableME1a && theRing == 1 && !gangedME1a) numStrips = 112;
+	if (!smartME1aME1b && !disableME1a && theRing == 1 && gangedME1a) numStrips = 80;
 	if (!smartME1aME1b &&  disableME1a && theRing == 1 ) numStrips = 64;
 	if ( smartME1aME1b && !disableME1a && theRing == 1 ) numStrips = 64;
 	if ( smartME1aME1b && !disableME1a && theRing == 4 ) {
@@ -583,14 +584,14 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
 	}
       }
 
-      if (numStrips > CSCConstants::MAX_NUM_STRIPS) {
+      if (numStrips > CSCConstants::MAX_NUM_STRIPS_7CFEBS) {
 	if (infoV >= 0) edm::LogError("L1CSCTPEmulatorSetupError")
 	  << "+++ Number of strips, " << numStrips
 	  << " found in ME" << ((theEndcap == 1) ? "+" : "-")
 	  << theStation << "/" << theRing << "/" << theChamber
 	  << " (sector " << theSector << " subsector " << theSubsector
 	  << " trig id. " << theTrigChamber << ")"
-	  << " exceeds max expected, " << CSCConstants::MAX_NUM_STRIPS
+	  << " exceeds max expected, " << CSCConstants::MAX_NUM_STRIPS_7CFEBS
 	  << " +++\n" 
 	  << "+++ CSC geometry looks garbled; no emulation possible +++\n";
 	numStrips = -1;
@@ -642,9 +643,9 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
   if (!noDigis) {
     // Get halfstrip (and possibly distrip) times from comparator digis.
     std::vector<int>
-      halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS];
+      halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
     std::vector<int>
-      distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS];
+      distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
     if (isTMB07) { // TMB07 (latest) version: halfstrips only.
       readComparatorDigis(halfstrip);
     }
@@ -660,7 +661,7 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
     // to the number of planes required to pre-trigger.)
     unsigned int layersHit = 0;
     for (int i_layer = 0; i_layer < CSCConstants::NUM_LAYERS; i_layer++) {
-      for (int i_hstrip = 0; i_hstrip < CSCConstants::NUM_HALF_STRIPS;
+      for (int i_hstrip = 0; i_hstrip < CSCConstants::NUM_HALF_STRIPS_7CFEBS;
 	   i_hstrip++) {
 	if (!halfstrip[i_layer][i_hstrip].empty()) {layersHit++; break;}
       }
@@ -677,8 +678,8 @@ CSCCathodeLCTProcessor::run(const CSCComparatorDigiCollection* compdc) {
 }
 
 void CSCCathodeLCTProcessor::run(
-  const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-  const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+  const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+  const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   // This version of the run() function can either be called in a standalone
   // test, being passed the halfstrip and distrip times, or called by the 
   // run() function above.  It uses the findLCTs() method to find vectors
@@ -833,7 +834,7 @@ void CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc,
 }
 
 void CSCCathodeLCTProcessor::readComparatorDigis(
-        std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+        std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   // Single-argument version for TMB07 (halfstrip-only) firmware.
   // Takes the comparator & time info and stuffs it into halfstrip vector.
   // Multiple hits on the same strip are allowed.
@@ -931,17 +932,17 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
 }
 
 void CSCCathodeLCTProcessor::readComparatorDigis(
-  std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-  std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+  std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+  std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   // Two-argument version for pre-TMB07 (halfstrip and distrips) firmware.
   // Takes the comparator & time info and stuffs it into halfstrip and (and
   // possibly distrip) vector.
 
-  int time[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS];
-  int comp[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS];
-  int digiNum[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS];
+  int time[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS_7CFEBS];
+  int comp[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS_7CFEBS];
+  int digiNum[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_STRIPS_7CFEBS];
   for (int i = 0; i < CSCConstants::NUM_LAYERS; i++){
-    for (int j = 0; j < CSCConstants::MAX_NUM_STRIPS; j++) {
+    for (int j = 0; j < CSCConstants::MAX_NUM_STRIPS_7CFEBS; j++) {
       time[i][j]    = -999;
       comp[i][j]    =    0;
       digiNum[i][j] = -999;
@@ -1023,7 +1024,7 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
   for (int i = 0; i < CSCConstants::NUM_LAYERS; i++) {
     // Use the comparator info to setup the halfstrips and distrips.  -BT
     // This loop is only for halfstrips.
-    for (int j = 0; j < CSCConstants::MAX_NUM_STRIPS; j++) {
+    for (int j = 0; j < CSCConstants::MAX_NUM_STRIPS_7CFEBS; j++) {
       if (time[i][j] >= 0) {
 	int i_halfstrip = 2*j + comp[i][j] + stagger[i];
 	// 2*j    : convert strip to 1/2 strip
@@ -1076,9 +1077,9 @@ void CSCCathodeLCTProcessor::readComparatorDigis(
   }
 }
 
-void CSCCathodeLCTProcessor::distripStagger(int stag_triad[CSCConstants::MAX_NUM_STRIPS],
-				   int stag_time[CSCConstants::MAX_NUM_STRIPS],
-				   int stag_digi[CSCConstants::MAX_NUM_STRIPS],
+void CSCCathodeLCTProcessor::distripStagger(int stag_triad[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
+				   int stag_time[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
+				   int stag_digi[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
 				   int i_strip, bool debug) {
   // Author: Jason Mumford (mumford@physics.ucla.edu)
   // This routine takes care of the stagger situation where there is a hit
@@ -1159,7 +1160,7 @@ void CSCCathodeLCTProcessor::distripStagger(int stag_triad[CSCConstants::MAX_NUM
 // class were discarded.
 // --------------------------------------------------------------------------
 // Idealized version for MC studies.
-std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS], int stripType)
+std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS], int stripType)
 {
   int j;
   int best_strip = 0;
@@ -1170,7 +1171,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
   const unsigned int ptrn_thrsh[2] = {nplanes_hit_pattern, nplanes_hit_pattern};
   int highest_quality = 0;
 
-  int keystrip_data[CSCConstants::NUM_HALF_STRIPS][7];
+  int keystrip_data[CSCConstants::NUM_HALF_STRIPS_7CFEBS][7];
   int final_lcts[max_lct_num];
 
   std::vector <CSCCLCTDigi> lctList;
@@ -1259,14 +1260,14 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
 
 
 // Idealized version for MC studies.
-bool CSCCathodeLCTProcessor::preTrigger(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+bool CSCCathodeLCTProcessor::preTrigger(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 					const int stripType, const int nStrips,
 					int& first_bx)
 {
   static const int hs_thresh = nplanes_hit_pretrig;
   static const int ds_thresh = nplanes_hit_pretrig;
 
-  unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS];
+  unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
   int i_layer, i_strip, this_layer, this_strip;
   int hits, layers_hit;
   bool hit_layer[CSCConstants::NUM_LAYERS];
@@ -1321,8 +1322,8 @@ bool CSCCathodeLCTProcessor::preTrigger(const std::vector<int> strip[CSCConstant
 
 
 // Idealized version for MC studies.
-void CSCCathodeLCTProcessor::getKeyStripData(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-        int keystrip_data[CSCConstants::NUM_HALF_STRIPS][7],
+void CSCCathodeLCTProcessor::getKeyStripData(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+        int keystrip_data[CSCConstants::NUM_HALF_STRIPS_7CFEBS][7],
         int nStrips, int first_bx, int& best_strip, int stripType) {
   int lct_pattern[NUM_PATTERN_STRIPS];
   int key_strip, this_layer, this_strip;
@@ -1455,8 +1456,8 @@ bool CSCCathodeLCTProcessor::hitIsGood(int hitTime, int BX) {
 // --------------------------------------------------------------------------
 // Pre-2007 version.
 std::vector <CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
- const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
- const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+ const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+ const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   std::vector <CSCCLCTDigi> lctList;
   int _bx[2] = {999, 999};
   int first_bx = 999;
@@ -1475,8 +1476,8 @@ std::vector <CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
   int d_keyStrip[MAX_CFEBS];       // one key per CFEB
   unsigned int d_nhits[MAX_CFEBS]; // number of hits in envelope for each key
   int keystrip_data[2][7];    // 2 possible LCTs per CSC x 7 LCT quantities
-  unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]; // simulate digital one-shot
-  unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]; // simulate digital one-shot
+  unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]; // simulate digital one-shot
+  unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]; // simulate digital one-shot
   bool pre_trig[2] = {false, false};
 
   // All half-strip and di-strip pattern envelopes are evaluated
@@ -1579,8 +1580,8 @@ std::vector <CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(
 
 // Pre-2007 version.
 bool CSCCathodeLCTProcessor::preTrigger(
-   const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+   const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 					const int stripType, const int nStrips,
 					const int start_bx, int& first_bx) {
   if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
@@ -1615,7 +1616,7 @@ bool CSCCathodeLCTProcessor::preTrigger(
 
 // Pre-2007 version.
 bool CSCCathodeLCTProcessor::preTrigLookUp(
-	   const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+	   const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 	   const int stripType, const int nStrips,
 	   const unsigned int bx_time) {
   static const int hs_thresh = nplanes_hit_pretrig;
@@ -1674,7 +1675,7 @@ bool CSCCathodeLCTProcessor::preTrigLookUp(
 
 // Pre-2007 version.
 void CSCCathodeLCTProcessor::latchLCTs(
-	   const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+	   const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 	   int keyStrip[MAX_CFEBS], unsigned int n_hits[MAX_CFEBS],
 	   const int stripType, const int nStrips, const int bx_time) {
 
@@ -1910,8 +1911,8 @@ void CSCCathodeLCTProcessor::priorityEncode(
 
 // Pre-2007 version.
 void CSCCathodeLCTProcessor::getKeyStripData(
-		const unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-		const unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+		const unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+		const unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		int keystrip_data[2][7], const int first_bx) {
 
   int lct_pattern[NUM_PATTERN_STRIPS];
@@ -2063,7 +2064,7 @@ void CSCCathodeLCTProcessor::getPattern(unsigned int pattern_num,
 // Monte Carlo studies in March 2008 (CMSSW_2_0_0).
 // --------------------------------------------------------------------------
 // TMB-07 version.
-std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   std::vector<CSCCLCTDigi> lctList;
 
   // Max. number of half-strips for this chamber.
@@ -2075,7 +2076,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
   enum {max_lcts = 2};
   // 2 possible LCTs per CSC x 7 LCT quantities
   int keystrip_data[max_lcts][7] = {{0}};
-  unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS];
+  unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
   pulseExtension(halfstrip, maxHalfStrips, pulse);
@@ -2121,7 +2122,7 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
       start_bx = first_bx + 1;
 
       // Quality for sorting.
-      int quality[CSCConstants::NUM_HALF_STRIPS];
+      int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
       int best_halfstrip[max_lcts], best_quality[max_lcts];
       for (int ilct = 0; ilct < max_lcts; ilct++) {
 	best_halfstrip[ilct] = -1;
@@ -2255,9 +2256,9 @@ std::vector<CSCCLCTDigi> CSCCathodeLCTProcessor::findLCTs(const std::vector<int>
 
 // Common to all versions.
 void CSCCathodeLCTProcessor::pulseExtension(
- const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+ const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
  const int nStrips,
- unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+ unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
 
   static const unsigned int bits_in_pulse = 8*sizeof(pulse[0][0]);
 
@@ -2303,7 +2304,7 @@ void CSCCathodeLCTProcessor::pulseExtension(
 
 // TMB-07 version.
 bool CSCCathodeLCTProcessor::preTrigger(
-  const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+  const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 					const int start_bx, int& first_bx) {
   if (infoV > 1) LogTrace("CSCCathodeLCTProcessor")
     << "....................PreTrigger...........................";
@@ -2356,7 +2357,7 @@ bool CSCCathodeLCTProcessor::preTrigger(
 
 // TMB-07 version.
 bool CSCCathodeLCTProcessor::ptnFinding(
-	   const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+	   const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 	   const int nStrips, const unsigned int bx_time)
 {
   if (bx_time >= fifo_tbins) return false;
@@ -2479,7 +2480,7 @@ bool CSCCathodeLCTProcessor::ptnFinding(
 // TMB-07 version.
 void CSCCathodeLCTProcessor::markBusyKeys(const int best_hstrip,
 					  const int best_patid,
-                                int quality[CSCConstants::NUM_HALF_STRIPS]) {
+                                int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   int nspan = min_separation;
   int pspan = min_separation;
 
@@ -2488,7 +2489,7 @@ void CSCCathodeLCTProcessor::markBusyKeys(const int best_hstrip,
   //  nspan = pspan = pattern2007[best_patid][NUM_PATTERN_HALFSTRIPS+1]-1;
 
   for (int hstrip = best_hstrip-nspan; hstrip <= best_hstrip+pspan; hstrip++) {
-    if (hstrip >= 0 && hstrip < CSCConstants::NUM_HALF_STRIPS) {
+    if (hstrip >= 0 && hstrip < CSCConstants::NUM_HALF_STRIPS_7CFEBS) {
       quality[hstrip] = 0;
     }
   }
@@ -2501,7 +2502,7 @@ void CSCCathodeLCTProcessor::markBusyKeys(const int best_hstrip,
 // --------------------------------------------------------------------------
 // SLHC version.
 std::vector<CSCCLCTDigi>
-CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS])
+CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS])
 {
   std::vector<CSCCLCTDigi> lctList;
 
@@ -2513,14 +2514,14 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
   enum { max_lcts = 2 };
 
   // keeps dead-time zones around key halfstrips of triggered CLCTs
-  bool busyMap[CSCConstants::NUM_HALF_STRIPS][MAX_CLCT_BINS];
-  for (int i = 0; i < CSCConstants::NUM_HALF_STRIPS; i++)
+  bool busyMap[CSCConstants::NUM_HALF_STRIPS_7CFEBS][MAX_CLCT_BINS];
+  for (int i = 0; i < CSCConstants::NUM_HALF_STRIPS_7CFEBS; i++)
     for (int j = 0; j < MAX_CLCT_BINS; j++)
       busyMap[i][j] = false;
 
   std::vector<CSCCLCTDigi> lctListBX;
 
-  unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS];
+  unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   // Fire half-strip one-shots for hit_persist bx's (4 bx's by default).
   pulseExtension(halfstrip, maxHalfStrips, pulse);
@@ -2572,7 +2573,7 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
       int keystrip_data[max_lcts][7] = {{0}};
 
       // Quality for sorting.
-      int quality[CSCConstants::NUM_HALF_STRIPS];
+      int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
       int best_halfstrip[max_lcts], best_quality[max_lcts];
       for (int ilct = 0; ilct < max_lcts; ilct++)
       {
@@ -2580,7 +2581,7 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
         best_quality[ilct] = 0;
       }
 
-      bool pretrig_zone[CSCConstants::NUM_HALF_STRIPS];
+      bool pretrig_zone[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
       // Calculate quality from pattern id and number of hits, and
       // simultaneously select best-quality LCT.
@@ -2588,9 +2589,9 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
       {
         // first, mark half-strip zones around pretriggers
         // that happened at the current first_bx
-        for (int hstrip = 0; hstrip < CSCConstants::NUM_HALF_STRIPS; hstrip++)
+        for (int hstrip = 0; hstrip < CSCConstants::NUM_HALF_STRIPS_7CFEBS; hstrip++)
           pretrig_zone[hstrip] = 0;
-        for (int hstrip = 0; hstrip < CSCConstants::NUM_HALF_STRIPS; hstrip++)
+        for (int hstrip = 0; hstrip < CSCConstants::NUM_HALF_STRIPS_7CFEBS; hstrip++)
         {
           if (ispretrig[hstrip])
           {
@@ -2598,8 +2599,8 @@ CSCCathodeLCTProcessor::findLCTsSLHC(const std::vector<int> halfstrip[CSCConstan
             int max_hs = hstrip + pretrig_trig_zone;
             if (min_hs < 0)
               min_hs = 0;
-            if (max_hs > CSCConstants::NUM_HALF_STRIPS - 1)
-              max_hs = CSCConstants::NUM_HALF_STRIPS - 1;
+            if (max_hs > CSCConstants::NUM_HALF_STRIPS_7CFEBS - 1)
+              max_hs = CSCConstants::NUM_HALF_STRIPS_7CFEBS - 1;
             for (int hs = min_hs; hs <= max_hs; hs++)
               pretrig_zone[hs] = 1;
             if (infoV > 1)
@@ -2795,7 +2796,7 @@ void CSCCathodeLCTProcessor::dumpConfigParams() const {
 }
 
 // Reasonably nice dump of digis on half-strips and di-strips.
-void CSCCathodeLCTProcessor::dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS], const int stripType, const int nStrips) const
+void CSCCathodeLCTProcessor::dumpDigis(const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS], const int stripType, const int nStrips) const
 {
   LogDebug("CSCCathodeLCTProcessor")
     << "ME" << ((theEndcap == 1) ? "+" : "-")
@@ -3071,7 +3072,7 @@ void CSCCathodeLCTProcessor::testPatterns() {
   //there are 16 strips in our uber-pattern, each of which can be on or off.
   // 2^16 = 65536
   for (int possibleHits = 0; possibleHits < 65536; possibleHits++) {
-    std::vector<int> stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS];
+    std::vector<int> stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS];
     //assign one bit to each strip in an array. I'll start centered around strip 10.
     stripsHit[0][ 9].push_back(( possibleHits &     1 ) != 0);     // 2^0
     stripsHit[0][10].push_back(( possibleHits &     2 ) != 0);     // 2^1
@@ -3162,7 +3163,7 @@ void CSCCathodeLCTProcessor::testPatterns() {
 }
 
 int CSCCathodeLCTProcessor::findNumLayersHit(std::vector<int> 
-          stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+          stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   int number = 0;
   for (int layer = 0; layer < CSCConstants::NUM_LAYERS; layer++) {
     if ((!stripsHit[layer][ 9].empty()) || 
@@ -3171,3 +3172,5 @@ int CSCCathodeLCTProcessor::findNumLayersHit(std::vector<int>
   }
   return number;
 }
+
+//  LocalWords:  CMSSW pretrig

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -812,7 +812,7 @@ void CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc,
 				  digiIt->getTimeBinWord());
       digiV[id.layer()-1].push_back(digi_corr);
     }
-    else if (smartME1aME1b){
+    else if (smartME1aME1b && (me1bProc || me1aProc)){
       //stay within bounds; in data all comps are in ME11B DetId
 
       if (me1aProc && me1b && origStrip > 64){//this is data

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.cc
@@ -804,7 +804,8 @@ void CSCCathodeLCTProcessor::getDigis(const CSCComparatorDigiCollection* compdc,
   for (CSCComparatorDigiCollection::const_iterator digiIt = rcompd.first;
        digiIt != rcompd.second; ++digiIt) {
     unsigned int origStrip = digiIt->getStrip();
-    if (me1a && origStrip <= 16 && !disableME1a && !smartME1aME1b) {
+    unsigned int maxStripsME1a = gangedME1a ? 16 : 48;
+    if (me1a && origStrip <= maxStripsME1a && !disableME1a && !smartME1aME1b) {
       // Move ME1/A comparators from CFEB=0 to CFEB=4 if this has not
       // been done already.
       CSCComparatorDigi digi_corr(origStrip+64,

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCCathodeLCTProcessor.h
@@ -58,8 +58,8 @@ class CSCCathodeLCTProcessor
 
   /** Called in test mode and by the run(compdc) function; does the actual LCT
       finding. */
-  void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-	   const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+  void run(const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+	   const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
  
   /** Access routines to comparator digis. */
   bool getDigis(const CSCComparatorDigiCollection* compdc);
@@ -82,9 +82,9 @@ class CSCCathodeLCTProcessor
 
   std::vector<int> preTriggerBXs() const {return thePreTriggerBXs;}
 
-  static void distripStagger(int stag_triad[CSCConstants::MAX_NUM_STRIPS],
-			     int stag_time[CSCConstants::MAX_NUM_STRIPS],
-			     int stag_digi[CSCConstants::MAX_NUM_STRIPS],
+  static void distripStagger(int stag_triad[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
+			     int stag_time[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
+			     int stag_digi[CSCConstants::MAX_NUM_STRIPS_7CFEBS],
 			     int i_distrip, bool debug = false);
 
   /** Set ring number
@@ -191,24 +191,24 @@ class CSCCathodeLCTProcessor
   static const int cfeb_strips[2];
 
   //---------------- Methods common to all firmware versions ------------------
-  void readComparatorDigis(std::vector<int>halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-			   std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
-  void readComparatorDigis(std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+  void readComparatorDigis(std::vector<int>halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+			   std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
+  void readComparatorDigis(std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
   void pulseExtension(
- const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+ const std::vector<int> time[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
  const int nStrips,
- unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+ unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   //------------- Functions for idealized version for MC studies --------------
   std::vector<CSCCLCTDigi> findLCTs(
-     const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+     const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
      int stripType);
   bool preTrigger(
-     const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+     const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
      const int stripType, const int nStrips, int& first_bx);
   void getKeyStripData(
-     const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-     int keystrip_data[CSCConstants::NUM_HALF_STRIPS][7],
+     const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+     int keystrip_data[CSCConstants::NUM_HALF_STRIPS_7CFEBS][7],
      int nStrips, int first_bx, int& best_strip, int stripType);
   void getPattern(int pattern_num, int strip_value[NUM_PATTERN_STRIPS],
 		  int bx_time, int &quality, int &bend);
@@ -216,17 +216,17 @@ class CSCCathodeLCTProcessor
 
   //-------------------- Functions for pre-2007 firmware ----------------------
   std::vector<CSCCLCTDigi> findLCTs(
-  const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-  const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+  const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+  const std::vector<int> distrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
   bool preTrigger(
-      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+   unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
       const int stripType, const int nStrips,
       const int start_bx, int& first_bx);
-  bool preTrigLookUp(const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+  bool preTrigLookUp(const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		     const int stripType, const int nStrips,
 		     const unsigned int bx_time);
-  void latchLCTs(const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+  void latchLCTs(const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		 int keyStrip[MAX_CFEBS], unsigned int nhits[MAX_CFEBS],
 		 const int stripType, const int nStrips, const int bx_time);
   void priorityEncode(const int h_keyStrip[MAX_CFEBS],
@@ -234,8 +234,8 @@ class CSCCathodeLCTProcessor
 		      const int d_keyStrip[MAX_CFEBS],
 		      const unsigned int d_nhits[MAX_CFEBS],
 		      int keystrip_data[2][7]);
-  void getKeyStripData(const unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-		       const unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+  void getKeyStripData(const unsigned int h_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+		       const unsigned int d_pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
 		       int keystrip_data[2][7], const int first_bx);
   void getPattern(unsigned int pattern_num,
 		  const int strip_value[NUM_PATTERN_STRIPS],
@@ -243,26 +243,26 @@ class CSCCathodeLCTProcessor
 
   //--------------- Functions for 2007 version of the firmware ----------------
   std::vector<CSCCLCTDigi> findLCTs(
- const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+ const std::vector<int> halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
   bool preTrigger(
-      const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+      const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
       const int start_bx, int& first_bx);
   bool ptnFinding(
-      const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+      const unsigned int pulse[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
       const int nStrips, const unsigned int bx_time);
   void markBusyKeys(const int best_hstrip, const int best_patid,
-		    int quality[CSCConstants::NUM_HALF_STRIPS]);
+		    int quality[CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
-  unsigned int best_pid[CSCConstants::NUM_HALF_STRIPS];
-  unsigned int nhits[CSCConstants::NUM_HALF_STRIPS];
-  int first_bx_corrected[CSCConstants::NUM_HALF_STRIPS];
+  unsigned int best_pid[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
+  unsigned int nhits[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
+  int first_bx_corrected[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   //--------------- Functions for SLHC studies ----------------
 
   std::vector<CSCCLCTDigi> findLCTsSLHC(
-    const std::vector<int>  halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+    const std::vector<int>  halfstrip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
-  bool ispretrig[CSCConstants::NUM_HALF_STRIPS];
+  bool ispretrig[CSCConstants::NUM_HALF_STRIPS_7CFEBS];
 
   //--------------------------- Auxiliary methods -----------------------------
   /** Dump CLCT configuration parameters. */
@@ -270,7 +270,7 @@ class CSCCathodeLCTProcessor
 
   /** Dump digis on half-strips and di-strips. */
   void dumpDigis(
-      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
+      const std::vector<int> strip[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
       const int stripType, const int nStrips) const;
 
   //--------------------------- Methods for tests -----------------------------
@@ -278,7 +278,7 @@ class CSCCathodeLCTProcessor
   void testLCTs();
   void printPatterns();
   void testPatterns();
-  int findNumLayersHit(std::vector<int> stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+  int findNumLayersHit(std::vector<int> stripsHit[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 };
 
 #endif

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.cc
@@ -267,8 +267,8 @@ void CSCMotherboard::checkConfigParameters() {
 
 void CSCMotherboard::run(
  const std::vector<int> w_times[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES],
- const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
- const std::vector<int> ds_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]) {
+ const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+ const std::vector<int> ds_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]) {
   // Debug version.  -JM
   clear();
   alct->run(w_times);            // run anode LCT

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCMotherboard.h
@@ -54,8 +54,8 @@ class CSCMotherboard
 
   /** Test version of run function. */
   void run(const std::vector<int> w_time[CSCConstants::NUM_LAYERS][CSCConstants::MAX_NUM_WIRES],
-	   const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS],
-	   const std::vector<int> ds_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS]);
+	   const std::vector<int> hs_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS],
+	   const std::vector<int> ds_times[CSCConstants::NUM_LAYERS][CSCConstants::NUM_HALF_STRIPS_7CFEBS]);
 
   /** Run function for normal usage.  Runs cathode and anode LCT processors,
       takes results and correlates into CorrelatedLCT. */

--- a/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
+++ b/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc
@@ -310,9 +310,9 @@ void CSCTriggerPrimitivesBuilder::build(const CSCBadChambers* badChambers,
               // Cathode LCTs pretriggers
               if (!preTriggerBXs1a.empty()) {
                 LogTrace("L1CSCTrigger")
-                  << "Put " << preTriggerBXs.size() << " CLCT pretrigger"
-                  << ((preTriggerBXs.size() > 1) ? "s " : " ") << "in collection\n";
-                oc_pretrig.put(std::make_pair(preTriggerBXs.begin(),preTriggerBXs.end()), detid);
+                  << "Put " << preTriggerBXs1a.size() << " CLCT pretrigger"
+                  << ((preTriggerBXs1a.size() > 1) ? "s " : " ") << "in collection\n";
+                oc_pretrig.put(std::make_pair(preTriggerBXs1a.begin(),preTriggerBXs1a.end()), detid1a);
               }
             } // upgraded TMB
 

--- a/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc
+++ b/L1Trigger/CSCTriggerPrimitives/test/CSCTriggerPrimitivesReader.cc
@@ -133,9 +133,9 @@ CSCTriggerPrimitivesReader::CSCTriggerPrimitivesReader(const edm::ParameterSet& 
   wireDigi_token_   = consumes<CSCWireDigiCollection>(wireDigiProducer_);
   compDigi_token_   = consumes<CSCComparatorDigiCollection>(compDigiProducer_);
 
-  alcts_d_token_    = consumes<CSCALCTDigiCollection>(edm::InputTag(lctProducerData_));
-  clcts_d_token_    = consumes<CSCCLCTDigiCollection>(edm::InputTag(lctProducerData_));
-  lcts_tmb_d_token_ = consumes<CSCCorrelatedLCTDigiCollection>(edm::InputTag(lctProducerData_));
+  alcts_d_token_    = consumes<CSCALCTDigiCollection>(edm::InputTag(lctProducerData_, "MuonCSCALCTDigi"));
+  clcts_d_token_    = consumes<CSCCLCTDigiCollection>(edm::InputTag(lctProducerData_, "MuonCSCCLCTDigi"));
+  lcts_tmb_d_token_ = consumes<CSCCorrelatedLCTDigiCollection>(edm::InputTag(lctProducerData_, "MuonCSCCorrelatedLCTDigi"));
 
   alcts_e_token_    = consumes<CSCALCTDigiCollection>(edm::InputTag(lctProducerEmul_));
   clcts_e_token_    = consumes<CSCCLCTDigiCollection>(edm::InputTag(lctProducerEmul_));


### PR DESCRIPTION
This is supposed to address issues with running CSC (ME11 part) emulator on run2 data (currently broken for ME11a) and for re-emulation applications of run2 MC (currently possible from sim digis, but appears to be less convenient than done from RAW).
Additionally, the selective readout for run2 MC was fixed (currently the CSC selective readout emulation is disabled in run2 MC; everything is saved.)
- extend CLCT processor to cover 7 CFEBs (that's how OTMB works now), this is for current data
- pick up correct ranges for smartME11ab case for the (MC only at this point) SLHC algorithm
- updated CLCT processor to also correctly read comparators on MC inputs if configured with unganged ME1a for "current" TMB algorithm (that's what we have in current OTMB firmware now)
- fix CSCTriggerPrimitivesReader (minor, input names got mixed up after getByLabel -> getByToken conversion done last year)
- added a shift of 4 CFEBs or 128 halfstrips for packed CLCTs and LCTs coming from ME1a (see notes below), they show up in SLHC-OTMB MC algorithm only. [this is the only change that affects output of Run2 MC "standard" workflows; note though that the unpacked LCTs and CLCTs are not really used, other than in the limited set of DQM and non-standard validation; if fixes in 74X are no longer possible, we can take this out and live with the ambiguous packing]
- fixed ME1A pretrigger filling in MC by the CSCTriggerPrimitivesBuilder
- made the packer aware of pretriggers and ALCTs showing up in ME1A detid with the SLHC-OTMB algorithm (this should make it possible to correctly emulate selective readout during packing; disabled for run2 MC)

An equivalent of this PR will be made for 74X and 75X.
This is an initial submission to review with corresponding experts.

Changes show up only Run2 MC "standard" DQM plots like this (me1/1a occupancies are present); there are no changes in regular reco or HLT objects.
![wf1320_hostripsandwiresandclct](https://cloud.githubusercontent.com/assets/4676718/6990601/505c9aea-da35-11e4-8213-a8e46c787af5.png)
