### PR TITLE
Fix ROOT6 -> ROOT5 auto merge

### DIFF
--- a/DataFormats/Common/interface/RefVector.h
+++ b/DataFormats/Common/interface/RefVector.h
@@ -157,7 +157,7 @@ namespace edm {
                   FillViewHelperVector& helpers) const;
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(12)
   private:
 
     contents_type refVector_;

--- a/DataFormats/Common/interface/RefVectorBase.h
+++ b/DataFormats/Common/interface/RefVectorBase.h
@@ -124,7 +124,7 @@ namespace edm {
 #endif
 
     //Needed for ROOT storage
-    CMS_CLASS_VERSION(10)
+    CMS_CLASS_VERSION(12)
 
   private:
 

--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -269,7 +269,9 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="17">
+  <class name="pat::PackedCandidate" ClassVersion="19">
+    <version ClassVersion="20" checksum="2078702780"/>
+    <version ClassVersion="19" checksum="359155190"/>
     <version ClassVersion="18" checksum="4275117305"/>
     <version ClassVersion="17" checksum="1257500115"/>
     <version ClassVersion="16" checksum="3261782486"/>


### PR DESCRIPTION
Fix auto merge problems of PR 8559 for the merge
from 7_5_X to 7_5_ROOT5_X. These problems were
expected  and are related to necessary differences
in data format checksums and versions.

I recommend these be immediately merged as the current
ROOT5 build is broken and this is code we knew
in advance would not merge.
