### PR TITLE
Fix Checksum error in build of DataFormats/PatCandidates (7_5_ROOT5_X) (again)

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -269,7 +269,8 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="17">
+  <class name="pat::PackedCandidate" ClassVersion="19">
+    <version ClassVersion="19" checksum="359155190"/>
     <version ClassVersion="18" checksum="4275117305"/>
     <version ClassVersion="17" checksum="1257500115"/>
     <version ClassVersion="16" checksum="3261782486"/>


### PR DESCRIPTION
This trival pull request fixes a checksum error causing a build error in DataFormats/PatCandidates that is specific to CMSSW_7_5_ROOT5_X.
Since this is trivial, techincal. and obvious, please merge quickly.
