### PR TITLE
Consumes migration

### DIFF
--- a/Alignment/OfflineValidation/BuildFile.xml
+++ b/Alignment/OfflineValidation/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="FWCore/ParameterSet"/>
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
+<use   name="TrackingTools/PatternTools"/>
 <use   name="TrackingTools/TrackFitters"/>
 <use   name="MagneticField/Engine"/>
 

--- a/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
+++ b/Alignment/OfflineValidation/interface/TrackerValidationVariables.h
@@ -4,14 +4,18 @@
 // system include files
 #include <vector>
 
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 class MagneticField;
-class TrackerGeometry;
 class Trajectory;
+
+namespace edm {
+  class ConsumesCollector;
+  class Event;
+  class EventSetup;
+  class ParameterSet;
+}
 
 class TrackerValidationVariables
 { 
@@ -69,20 +73,22 @@ class TrackerValidationVariables
   };
 
   TrackerValidationVariables();
-  TrackerValidationVariables(const edm::EventSetup&, const edm::ParameterSet&);
+  TrackerValidationVariables(const edm::ParameterSet& config,
+                             edm::ConsumesCollector && iC);
   ~TrackerValidationVariables();
 
   void fillHitQuantities(const Trajectory* trajectory, std::vector<AVHitStruct> & v_avhitout);
-  void fillTrackQuantities(const edm::Event&, std::vector<AVTrackStruct> & v_avtrackout);
+  void fillTrackQuantities(const edm::Event&,
+                           const edm::EventSetup&,
+                           std::vector<AVTrackStruct> & v_avtrackout);
 
   // need the following method for MonitorTrackResiduals in DQM/TrackerMonitorTrack
   void fillHitQuantities(const edm::Event&, std::vector<AVHitStruct> & v_avhitout);
 
  private:
 
-  const edm::ParameterSet conf_;
-  edm::ESHandle<TrackerGeometry> tkGeom_;
-  edm::ESHandle<MagneticField> magneticField_;
+  edm::EDGetTokenT<std::vector<Trajectory> > trajCollectionToken_;
+  edm::EDGetTokenT<TrajTrackAssociationCollection> trajTracksToken_;
 };
 
 #endif

--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -37,6 +37,7 @@
 
 // user include files
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -277,6 +278,8 @@ private:
   std::map<int,TrackerOfflineValidation::ModuleHistos> mTecResiduals_;
 
   const edm::EventSetup* lastSetup_;
+
+  TrackerValidationVariables avalidator_;
 };
 
 
@@ -358,7 +361,8 @@ TrackerOfflineValidation::TrackerOfflineValidation(const edm::ParameterSet& iCon
     useOverflowForRMS_(parSet_.getParameter<bool>("useOverflowForRMS")),
     dqmMode_(parSet_.getParameter<bool>("useInDqmMode")),
     moduleDirectory_(parSet_.getParameter<std::string>("moduleDirectoryInOutput")),
-    lastSetup_(nullptr)
+    lastSetup_(nullptr),
+    avalidator_(iConfig, consumesCollector())
 {
 }
 
@@ -969,12 +973,10 @@ TrackerOfflineValidation::analyze(const edm::Event& iEvent, const edm::EventSetu
 {
   if (useOverflowForRMS_)TH1::StatOverflows(kTRUE);
   this->checkBookHists(iSetup); // check whether hists are booked and do so if not yet done
-  
-  TrackerValidationVariables avalidator_(iSetup,parSet_);
-    
+
   std::vector<TrackerValidationVariables::AVTrackStruct> vTrackstruct;
-  avalidator_.fillTrackQuantities(iEvent, vTrackstruct);
-  
+  avalidator_.fillTrackQuantities(iEvent, iSetup, vTrackstruct);
+
   for (std::vector<TrackerValidationVariables::AVTrackStruct>::const_iterator itT = vTrackstruct.begin();	 
        itT != vTrackstruct.end();
        ++itT) {

--- a/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
+++ b/DQM/TrackerMonitorTrack/interface/MonitorTrackResiduals.h
@@ -19,7 +19,7 @@ Monitoring source for track residuals on each detector module
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Run.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
-
+#include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
 
 class MonitorElement;
 class DQMStore;
@@ -54,5 +54,6 @@ class MonitorTrackResiduals : public DQMEDAnalyzer {
   unsigned long long m_cacheID_;
   bool ModOn;
   GenericTriggerEventFlag* genTriggerEventFlag_;
+  TrackerValidationVariables avalidator_;
 };
 #endif

--- a/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
+++ b/DQM/TrackerMonitorTrack/src/MonitorTrackResiduals.cc
@@ -15,7 +15,6 @@
 #include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/SiStripDetId/interface/SiStripDetId.h"
 #include "TrackingTools/TrackFitters/interface/TrajectoryStateCombiner.h"
-#include "Alignment/OfflineValidation/interface/TrackerValidationVariables.h"
 #include "Alignment/TrackerAlignment/interface/TrackerAlignableId.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -24,7 +23,8 @@
 MonitorTrackResiduals::MonitorTrackResiduals(const edm::ParameterSet& iConfig)
    : dqmStore_( edm::Service<DQMStore>().operator->() )
    , conf_(iConfig), m_cacheID_(0)
-   , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig, consumesCollector())) {
+   , genTriggerEventFlag_(new GenericTriggerEventFlag(iConfig, consumesCollector()))
+   , avalidator_(iConfig, consumesCollector()) {
   ModOn = conf_.getParameter<bool>("Mod_On");
 }
 
@@ -157,7 +157,6 @@ void MonitorTrackResiduals::analyze(const edm::Event& iEvent, const edm::EventSe
   iSetup.get<IdealGeometryRecord>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
-  TrackerValidationVariables avalidator_(iSetup,conf_);
   std::vector<TrackerValidationVariables::AVHitStruct> v_hitstruct;
   avalidator_.fillHitQuantities(iEvent,v_hitstruct);
   for (std::vector<TrackerValidationVariables::AVHitStruct>::const_iterator it = v_hitstruct.begin(),


### PR DESCRIPTION
Add consumes calls for the TrackerValidationVariables
helper class used in the modules MonitorTrackResiduals
and TrackerOfflineValidation. This required constructing
it when the module is constructed instead of constructing
a new one every event. Moved getting data from the EventSetup
from the constructor to the event methods. Replace calls
to getByLabel with calls to getByToken.
