### PR TITLE
Fix unit test

### DIFF
--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -55,6 +55,10 @@ class testRefInROOT: public CppUnit::TestFixture
 public:
   testRefInROOT() { }
   void setUp() {
+    if(!sWasRun_) {
+      AutoLibraryLoader::enable();
+      sWasRun_ = true;
+    }
     tmpdir = "tmp/";
     tmpdir += getenv("SCRAM_ARCH");
     tmpdir += "/";


### PR DESCRIPTION
This only affects the DataFormats/FWLite unit
test. Only the ROOT 5 branch unit test is broken,
but I'm adding it to the ROOT 5 and ROOT 6 branches
for consistency.

The dictionary loading in AutoLibraryLoader::enable()
is required in ROOT 5 and not needed in ROOT 6 (that
part actually does nothing in ROOT 6 so AutoLibraryLoader
should probably be renamed). The enable() function
does other things, but those are not needed in this
test. The Ref's are function anyway because of the
GetterOperate mechanism in FWLite that is provided
when using the Event and related classes (but would
not be in bare ROOT mode). This unit test is really a
fully compiled executable and not a macro so the
header finding parts of enable() are not needed either.
