### PR TITLE
Consumes migration for BCToEFilter

### DIFF
--- a/GeneratorInterface/GenFilters/interface/BCToEFilter.h
+++ b/GeneratorInterface/GenFilters/interface/BCToEFilter.h
@@ -18,9 +18,6 @@
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDFilter.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "GeneratorInterface/GenFilters/interface/BCToEFilterAlgo.h"
@@ -33,7 +30,7 @@ class BCToEFilter : public edm::EDFilter {
   virtual bool filter(edm::Event&, const edm::EventSetup&);
   
  private:
-  BCToEFilterAlgo *BCToEAlgo_;
+  std::unique_ptr<BCToEFilterAlgo> BCToEAlgo_;
   
 };
 #endif

--- a/GeneratorInterface/GenFilters/interface/BCToEFilterAlgo.h
+++ b/GeneratorInterface/GenFilters/interface/BCToEFilterAlgo.h
@@ -15,19 +15,17 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
-
+namespace edm {
+  class ConsumesCollector;
+}
 
 class BCToEFilterAlgo {
  public:
-  BCToEFilterAlgo(const edm::ParameterSet&);
+  BCToEFilterAlgo(const edm::ParameterSet&, edm::ConsumesCollector && iC);
   ~BCToEFilterAlgo();
   
   bool filter(const edm::Event& iEvent);
@@ -47,7 +45,6 @@ class BCToEFilterAlgo {
   float FILTER_ETA_MAX_;
   //filter parameters:
   float eTThreshold_;
-  edm::InputTag genParSource_;
-  
+  edm::EDGetTokenT<reco::GenParticleCollection> genParSource_;
 };
 #endif

--- a/GeneratorInterface/GenFilters/src/BCToEFilter.cc
+++ b/GeneratorInterface/GenFilters/src/BCToEFilter.cc
@@ -1,15 +1,11 @@
 #include "GeneratorInterface/GenFilters/interface/BCToEFilter.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 
-using namespace edm;
-using namespace std;
+BCToEFilter::BCToEFilter(const edm::ParameterSet& iConfig) {
 
+  edm::ParameterSet filterPSet=iConfig.getParameter<edm::ParameterSet>("filterAlgoPSet");
 
-BCToEFilter::BCToEFilter(const edm::ParameterSet& iConfig) { 
-  
-  ParameterSet filterPSet=iConfig.getParameter<edm::ParameterSet>("filterAlgoPSet");
-  
-  BCToEAlgo_=new BCToEFilterAlgo(filterPSet);
-
+  BCToEAlgo_.reset(new BCToEFilterAlgo(filterPSet, consumesCollector()));
 }
 
 BCToEFilter::~BCToEFilter() {
@@ -24,5 +20,3 @@ bool BCToEFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup){
   return result;
 
 }
-
-

--- a/GeneratorInterface/GenFilters/src/BCToEFilterAlgo.cc
+++ b/GeneratorInterface/GenFilters/src/BCToEFilterAlgo.cc
@@ -1,15 +1,15 @@
 #include "GeneratorInterface/GenFilters/interface/BCToEFilterAlgo.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
-using namespace edm;
-using namespace std;
-
-
-BCToEFilterAlgo::BCToEFilterAlgo(const edm::ParameterSet& iConfig) { 
+BCToEFilterAlgo::BCToEFilterAlgo(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC) {
 
   //set constants
   FILTER_ETA_MAX_=2.5;
   eTThreshold_=(float)iConfig.getParameter<double>("eTThreshold");
-  genParSource_=iConfig.getParameter<edm::InputTag>("genParSource");
+  genParSource_=iC.consumes<reco::GenParticleCollection>(iConfig.getParameter<edm::InputTag>("genParSource"));
 
 }
 
@@ -25,8 +25,8 @@ bool BCToEFilterAlgo::filter(const edm::Event& iEvent)  {
 
   
   
-  Handle<reco::GenParticleCollection> genParsHandle;
-  iEvent.getByLabel(genParSource_,genParsHandle);
+  edm::Handle<reco::GenParticleCollection> genParsHandle;
+  iEvent.getByToken(genParSource_,genParsHandle);
   reco::GenParticleCollection genPars=*genParsHandle;
 
   for (uint32_t ig=0;ig<genPars.size();ig++) {


### PR DESCRIPTION
Add consumes call in BCToEFilter. Also change
getByLabel to getByToken, fix a minor memory
leak, and clean up the header includes a bit.
