### PR TITLE
cmsDriver: error message when --filein is missing

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -151,7 +151,11 @@ def OptionsFromItems(items):
 
     if options.filein=="" and not (first_step in ("ALL","GEN","LHE","SIM_CHAIN")):
         options.dirin="file:"+options.dirin.replace('file:','')
-        options.filein=trimmedEvtType+"_"+prec_step[first_step]+"."+filesuffix
+        if first_step in prec_step:
+            options.filein=trimmedEvtType+"_"+prec_step[first_step]+"."+filesuffix
+        else:
+            print "ERROR: the given steps require an input file, please specify it using the option --filein"
+            sys.exit(1)
 
 
     # Prepare the canonical file name for output / config file etc


### PR DESCRIPTION
When running cmsDirver with "-s VALIDATION" and without specifying an input file with the option --filein cmsDriver prints  a non-informative python error message.

With this pr included, cmsDriver provides a proper error message 
when cmsDriver is provided with a set of steps that require an input file,
but for which cmsDriver has not default input file, such as "-s VALIDATION"
