### PR TITLE
Macros need to compile in ROOT6 (ALCA)

### DIFF
--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
@@ -60,13 +60,13 @@ PlotAlignmentValidation::PlotAlignmentValidation(const char *inputFile,std::stri
 //------------------------------------------------------------------------------
 PlotAlignmentValidation::~PlotAlignmentValidation()
 {
-  delete sourcelist;
 
   for(std::vector<TkOfflineVariables*>::iterator it = sourceList.begin();
       it != sourceList.end(); ++it){
     delete (*it);
   }
 
+  delete sourcelist;
 }
 
 //------------------------------------------------------------------------------
@@ -214,7 +214,7 @@ void PlotAlignmentValidation::plotOutlierModules(const char *outputFileName, std
   
   gStyle->SetOptStat(111111);
   gStyle->SetStatY(0.9);
-  //TList treelist=getTreeList();
+  //TList* treelist=getTreeList();
   
   TCanvas *c1 = new TCanvas("canv", "canv", 800, 500);
   //setCanvasStyle( *c1 );
@@ -312,13 +312,13 @@ void PlotAlignmentValidation::plotOutlierModules(const char *outputFileName, std
 }
 
 //------------------------------------------------------------------------------
-TList PlotAlignmentValidation::getTreeList()
+TList* PlotAlignmentValidation::getTreeList()
 {
-  TList treeList = new TList();
+  TList *treeList = new TList();
   TFile *first_source = (TFile*)sourcelist->First();
   std::cout<<first_source->GetName()<<std::endl;
   TDirectoryFile *d=(TDirectoryFile*)first_source->Get( treeBaseDir.c_str() ); 
-  treeList.Add( (TTree*)(*d).Get("TkOffVal") );
+  treeList->Add( (TTree*)(*d).Get("TkOffVal") );
   
   if( moreThanOneSource ==true ){
     TFile *nextsource = (TFile*)sourcelist->After( first_source );
@@ -326,7 +326,7 @@ TList PlotAlignmentValidation::getTreeList()
       std::cout<<nextsource->GetName()<<std::endl;
       d=(TDirectoryFile*)nextsource->Get("TrackerOfflineValidation"); 
       
-      treeList.Add((TTree*)(*d).Get("TkOffVal"));
+      treeList->Add((TTree*)(*d).Get("TkOffVal"));
       
       nextsource = (TFile*)sourcelist->After( nextsource );
     }

--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
@@ -72,6 +72,7 @@ TkOfflineVariables::TkOfflineVariables(std::string fileName, std::string baseDir
 class PlotAlignmentValidation {
 public:
   //PlotAlignmentValidation(TString *tmp);
+  PlotAlignmentValidation() {}
   PlotAlignmentValidation(const char *inputFile,std::string fileName="", int lineColor=1, int lineStyle=1);
   ~PlotAlignmentValidation();
   void loadFileList(const char *inputFile, std::string fileName="", int lineColor=2, int lineStyle=1);
@@ -89,7 +90,7 @@ public:
   THStack* addHists(const char *selection, const TString &residType = "xPrime", TLegend **myLegend = 0, bool printModuleIds = false);//add hists fulfilling 'selection' on TTree; residType: xPrime,yPrime,xPrimeNorm,yPrimeNorm,x,y,xNorm; if (printModuleIds): cout DetIds
   
 private : 
-  TList getTreeList();
+  TList* getTreeList();
   std::string treeBaseDir;
 
   bool useFit_;

--- a/Alignment/OfflineValidation/macros/trackSplitPlot.C
+++ b/Alignment/OfflineValidation/macros/trackSplitPlot.C
@@ -9,6 +9,7 @@ Table Of Contents
 6. TDR Style
 ***********************************/
 
+#include <vector>
 #include "trackSplitPlot.h"
 
 //===================
@@ -119,7 +120,7 @@ TCanvas *trackSplitPlot(Int_t nFiles,TString *files,TString *names,TString xvar,
     if (type == Profile || type == ScatterPlot || type == Histogram || type == Resolution)
         axislimits(nFiles,files,yvar,'y',relative,pull,ymin,ymax);
 
-    TString meansrmss[n];
+    std::vector<TString> meansrmss(n);
     Bool_t  used[n];        //a file is not "used" if it's MC data and the x variable is run number, or if the filename is blank
 
     for (Int_t i = 0; i < n; i++)

--- a/CalibTracker/SiStripChannelGain/test/7TeVData/PlotMacro.C
+++ b/CalibTracker/SiStripChannelGain/test/7TeVData/PlotMacro.C
@@ -17,7 +17,7 @@
 
 
 #include<vector>
-#include<tdrstyle.C>
+#include "tdrstyle.C"
 
 void PlotMacro_Core(string input, string moduleName, string output);
 TF1*  getLandau(TH1* InputHisto, double* FitResults, double LowRange=50, double HighRange=5400);

--- a/Calibration/IsolatedParticles/test/CalibTree.C
+++ b/Calibration/IsolatedParticles/test/CalibTree.C
@@ -90,9 +90,9 @@ public :
   virtual void     Show(Long64_t entry = -1);
   bool             goodTrack();
   void BookHisto(std::string fname);
+  TFile          *fout;
 
 private:
-  TFile          *fout;
   TProfile       *hprof_ndets;
 
 };


### PR DESCRIPTION
In ROOT6 macros are processed by cling, rather than CINT. Over 500 CMSSW macros do not compile in ROOT6. Since that is too many macros to be fixed centrally, it was decided by David Lange to centrally fix only those 45 macros with compilation errors that have been modified since the switch over to git, since those are the ones most likely to be used. Only four of these 45 macros are in the ALCA L2 category. This pull request fixes them.
