### PR TITLE
Macros need to compile in ROOT6 (Visualization)

### DIFF
--- a/Fireworks/Geometry/macros/common_foos.C
+++ b/Fireworks/Geometry/macros/common_foos.C
@@ -21,6 +21,7 @@
 
 #include "TPRegexp.h"
 
+typedef TGLClip::EType EClipType;
 
 //==============================================================================
 // Creation, initialization

--- a/Fireworks/Geometry/macros/geom_cms.C
+++ b/Fireworks/Geometry/macros/geom_cms.C
@@ -1,6 +1,8 @@
 // Author: Matevz Tadel
 // Shows full CMS geometry.
 
+#include "common_foos.C"
+
 TEveGeoTopNode *g_cms_all = 0;
 
 void geom_cms()

--- a/Fireworks/Geometry/macros/geom_core_parts.C
+++ b/Fireworks/Geometry/macros/geom_core_parts.C
@@ -2,6 +2,7 @@
 
 // Shows CMS tracker, calo and muon system.
 // Depth can be set for each part independently.
+#include "common_foos.C"
 
 TEveGeoTopNode *g_cms_tracker = 0;
 TEveGeoTopNode *g_cms_calo    = 0;

--- a/Fireworks/Geometry/macros/geom_detail_global.C
+++ b/Fireworks/Geometry/macros/geom_detail_global.C
@@ -1,6 +1,8 @@
 // Author: Matevz Tadel
 // Shows some muon chamber nodes in global coordinate system.
 
+#include "common_foos.C"
+
 void geom_detail_global()
 {
    TEveUtil::LoadMacro("common_foos.C+");

--- a/Fireworks/Geometry/macros/geom_detail_local.C
+++ b/Fireworks/Geometry/macros/geom_detail_local.C
@@ -1,6 +1,8 @@
 // Author: Matevz Tadel
 // Shows one muon chamber in local coordinate system.
 
+#include "common_foos.C"
+
 void geom_detail_local()
 {
    TEveUtil::LoadMacro("common_foos.C+");

--- a/Fireworks/Geometry/macros/geom_plt.C
+++ b/Fireworks/Geometry/macros/geom_plt.C
@@ -1,6 +1,7 @@
 // Shows CMS tracker and PLT
 // Depth can be set for each part independently.
 
+#include "common_foos.C"
 
 void geom_plt()
 {


### PR DESCRIPTION
In ROOT6 macros are processed by cling, rather than CINT. Over 500 CMSSW macros do not compile in ROOT6. Since that is too many macros to be fixed centrally, it was decided by David Lange to centrally fix only those 45 macros with compilation errors that have been modified since the switch over to git, since those are the ones most likely to be used. Only one of these 45 macros is in the Visualization L2 category. This pull request fixes it, plus other macros in the same package with the same problem.
