### PR TITLE
Macros need to compile in ROOT6 (CommonTools)

### DIFF
--- a/CommonTools/ParticleFlow/test/Macros/isolation.C
+++ b/CommonTools/ParticleFlow/test/Macros/isolation.C
@@ -5,22 +5,28 @@ gSystem->Load("libFWCoreFWLite.so");
 AutoLibraryLoader::enable();
 TFile f("testPFPAT.root");
 
-Events.Draw("recoIsolatedPFCandidates_pfPionsIsolation__PFPAT.obj.isolation_>>h2");
+TTree* Events = 0;
+gDirectory->GetObject("Events", Events);
 
-Events.Draw("recoIsolatedPFCandidates_pfLeptonsPtGt5Isolation__PFPAT.obj.isolation_>>h1","","same");
+Events->Draw("recoIsolatedPFCandidates_pfPionsIsolation__PFPAT.obj.isolation_>>h2");
+Events->Draw("recoIsolatedPFCandidates_pfLeptonsPtGt5Isolation__PFPAT.obj.isolation_>>h1","","same");
 
-h1.SetLineColor(4);
-h1.SetLineWidth(3);
-h1.SetFillStyle(3005);
-h1.SetFillColor(4);
+TH1* h1 = 0;
+gDirectory->GetObject("h1", h1);
+h1->SetLineColor(4);
+h1->SetLineWidth(3);
+h1->SetFillStyle(3005);
+h1->SetFillColor(4);
 
-h2.SetTitle("H to ZZ to 4 mu. Isolation cone 0.2; p_{T} fraction");
-h2.SetStats(0);
-h2.SetLineWidth(3);
+TH1* h2 = 0;
+gDirectory->GetObject("h2", h2);
+h2->SetTitle("H to ZZ to 4 mu. Isolation cone 0.2; p_{T} fraction");
+h2->SetStats(0);
+h2->SetLineWidth(3);
 
 TLegend leg(0.35, 0.6, 0.89,0.89);
-leg.AddEntry(&h1, "Muon PFCandidates","lf");
-leg.AddEntry(&h2, "Pion PFCandidates","lf");
+leg.AddEntry(h1, "Muon PFCandidates","lf");
+leg.AddEntry(h2, "Pion PFCandidates","lf");
 leg.Draw();
 
 gPad->SetLogy();

--- a/CommonTools/ParticleFlow/test/Macros/ptJets.C
+++ b/CommonTools/ParticleFlow/test/Macros/ptJets.C
@@ -5,17 +5,23 @@
   AutoLibraryLoader::enable();
   TFile f("patTuple_PF2PAT.root");
   
-  Events.Draw("patJets_selectedPatJets__PAT.obj.pt()>>h1");
-  Events.Draw("patJets_selectedPatJetsPFlow__PAT.obj.pt()>>h2","","same");
+  TTree *Events = 0;
+  gDirectory->GetObject("Events", Events);
+  Events->Draw("patJets_selectedPatJets__PAT.obj.pt()>>h1");
+  Events->Draw("patJets_selectedPatJetsPFlow__PAT.obj.pt()>>h2","","same");
  
-  h1.SetStats( false );
-  h1.Draw();
+  TH1* h1 = 0;
+  gDirectory->GetObject("h1", h1);
+  h1->SetStats( false );
+  h1->Draw();
 
-  h2.SetLineColor(4);
-  h2.Draw("same");
+  TH1* h2 = 0;
+  gDirectory->GetObject("h2", h2);
+  h2->SetLineColor(4);
+  h2->Draw("same");
 
   TLegend leg(0.6,0.6,0.8,0.8);
-  leg.AddEntry( &h1, "std PAT");
-  leg.AddEntry( &h2, "PF2PAT+PAT");
+  leg.AddEntry( h1, "std PAT");
+  leg.AddEntry( h2, "PF2PAT+PAT");
   leg.Draw();
 }

--- a/CommonTools/ParticleFlow/test/Macros/ptMus.C
+++ b/CommonTools/ParticleFlow/test/Macros/ptMus.C
@@ -4,18 +4,25 @@
   gSystem->Load("libFWCoreFWLite.so");
   AutoLibraryLoader::enable();
   TFile f("patTuple_PF2PAT.root");
-  
-  Events.Draw("patMuons_selectedPatMuons__PAT.obj.pt()>>h1");
-  Events.Draw("patMuons_selectedPatMuonsPFlow__PAT.obj.pt()>>h2","","same");
- 
-  h1.SetStats( false );
-  h1.Draw();
 
-  h2.SetLineColor(4);
-  h2.Draw("same");
+  TTree* Events = 0;
+  gDirectory->GetObject("Events", Events);
+  
+  Events->Draw("patMuons_selectedPatMuons__PAT.obj.pt()>>h1");
+  Events->Draw("patMuons_selectedPatMuonsPFlow__PAT.obj.pt()>>h2","","same");
+ 
+  TH1* h1 = 0;
+  gDirectory->GetObject("h1", h1);
+  h1->SetStats( false );
+  h1->Draw();
+
+  TH1* h2 = 0;
+  gDirectory->GetObject("h2", h2);
+  h2->SetLineColor(4);
+  h2->Draw("same");
 
   TLegend leg(0.6,0.6,0.8,0.8);
-  leg.AddEntry( &h1, "std PAT");
-  leg.AddEntry( &h2, "PF2PAT+PAT");
+  leg.AddEntry( h1, "std PAT");
+  leg.AddEntry( h2, "PF2PAT+PAT");
   leg.Draw();
 }

--- a/CommonTools/ParticleFlow/test/Macros/rootlogon.C
+++ b/CommonTools/ParticleFlow/test/Macros/rootlogon.C
@@ -12,6 +12,12 @@ void loadFWLite() {
   AutoLibraryLoader::enable();
 }
 
+TTree* getEventsrootlogon() {
+  TTree* events = 0;
+  gDirectory->GetObject("Events", events);
+  return events;
+}
+
 void initAOD(const char* process) {
 
   string verticesAod = "recoVertexs_offlinePrimaryVertices__"; 
@@ -26,6 +32,7 @@ void initAOD(const char* process) {
   string pfJetsAod = "recoPFJets_iterativeCone5PFJets__";  
   pfJetsAod += process;
 
+  TTree* Events = getEventsrootlogon();
   Events->SetAlias("verticesAod", verticesAod.c_str()); 
   Events->SetAlias("pfCandidatesAod",  pfCandidatesAod.c_str());
   Events->SetAlias("ic5GenJetsAod",  ic5GenJetsAod.c_str());
@@ -52,6 +59,7 @@ void initPF2PAT(const char* process) {
   string decaysFromZs = "recoGenParticles_decaysFromZs__";
   decaysFromZs += process;
 
+  TTree* Events = getEventsrootlogon();
   Events->SetAlias("met", met.c_str() );
   Events->SetAlias("pileUp", pu.c_str() );
   Events->SetAlias("jetsAll", jetsin.c_str() );
@@ -76,6 +84,7 @@ void initPAT(const char* process) {
   
   string patCaloJets = "patJets_selectedPatJets__"; patCaloJets += process;
 
+  TTree* Events = getEventsrootlogon();
   Events->SetAlias("patTaus", taus.c_str() );
   Events->SetAlias("patJets", jets.c_str() );
   Events->SetAlias("patCaloJets", patCaloJets.c_str() );

--- a/CommonTools/ParticleFlow/test/Macros/testMuonTopProjection.C
+++ b/CommonTools/ParticleFlow/test/Macros/testMuonTopProjection.C
@@ -9,17 +9,21 @@
   TTree *tEnabled = (TTree*) fEnabled.Get("Events");
   
   
-  tDisabled.Draw("patJets_selectedPatJetsPFlow__PAT.obj.pt()>>h1");
-  tEnabled.Draw("patJets_selectedPatJetsPFlow__PAT.obj.pt()>>h2","","same");
+  if(tDisabled != 0) tDisabled->Draw("patJets_selectedPatJetsPFlow__PAT.obj.pt()>>h1");
+  if(tEnabled != 0) tEnabled->Draw("patJets_selectedPatJetsPFlow__PAT.obj.pt()>>h2","","same");
  
-  h1.SetStats( false );
-  h1.Draw();
+  TH1* h1 = 0;
+  gDirectory->GetObject("h1", h1);
+  h1->SetStats( false );
+  h1->Draw();
 
-  h2.SetLineColor(4);
-  h2.Draw("same");
+  TH1* h2 = 0;
+  gDirectory->GetObject("h2", h2);
+  h2->SetLineColor(4);
+  h2->Draw("same");
 
   TLegend leg(0.6,0.6,0.8,0.8);
-  leg.AddEntry( &h1, "Muon TP disabled");
-  leg.AddEntry( &h2, "Muon TP enabled");
+  leg.AddEntry( h1, "Muon TP disabled");
+  leg.AddEntry( h2, "Muon TP enabled");
   leg.Draw();
 }


### PR DESCRIPTION
In ROOT6 macros are processed by cling, rather than CINT. Over 500 CMSSW macros do not compile in ROOT6. Since that is too many macros to be fixed centrally, it was decided by David Lange to centrally fix only those 45 macros with compilation errors that have been modified since the switch over to git, since those are the ones most likely to be used. Five of these 45 macros are in CommonTools (both Reco and Analysis L2 categories).  This pull request fixes them.
