### PR TITLE
Macros need to compile in ROOT6 (Analysis)

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/Plot_mass.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/Plot_mass.C
@@ -40,7 +40,7 @@ public:
 int getXbins(const TH1 * h, const double & xMin, const double & xMax)
 {
   // To get the correct integral for rescaling determine the borders
-  TAxis * xAxis = h->GetXaxis();
+  const TAxis * xAxis = h->GetXaxis();
   double xAxisMin = xAxis->GetXmin();
   // The bins have all the same width, therefore we can use this
   double binWidth = xAxis->GetBinWidth(1);

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlap.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlap.C
@@ -6,6 +6,7 @@
 //------------------------------------------//
 
 #include <iostream>
+#include <vector>
 #include "Gtypes.h"
 #include "TROOT.h"
 #include "TStyle.h"
@@ -69,10 +70,11 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  }  
  
 
- TString LegLabels[nOfFiles];    
+ std::vector<TString> LegLabels;
+ LegLabels.reserve(nOfFiles);    
  for(Int_t j=0; j < nOfFiles; j++) {       
    TObjString* legend = (TObjString*)LabelList->At(j);    
-   LegLabels[j] = legend->String();    
+   LegLabels.push_back(legend->String());
    std::cout<<"LegLabels["<<j<<"]"<<LegLabels[j]<<std::endl;  
  }
 
@@ -108,7 +110,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoMassVsPhiPlus[j] = (TH1D*)fin->Get("MassVsPhiPlus/allHistos/meanHisto")){
+   if (( histoMassVsPhiPlus[j] = (TH1D*)fin->Get("MassVsPhiPlus/allHistos/meanHisto"))){
      histoMassVsPhiPlus[j]->SetLineStyle(linestylelist[j]);
      histoMassVsPhiPlus[j]->SetMarkerColor(colorlist[j]);
      histoMassVsPhiPlus[j]->SetLineColor(colorlist[j]);
@@ -146,7 +148,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoMassVsEtaPlus[j] = (TH1D*)fin->Get("MassVsEtaPlus/allHistos/meanHisto")){
+   if (( histoMassVsEtaPlus[j] = (TH1D*)fin->Get("MassVsEtaPlus/allHistos/meanHisto"))){
      histoMassVsEtaPlus[j]->SetLineStyle(linestylelist[j]);
      histoMassVsEtaPlus[j]->SetMarkerColor(colorlist[j]);
      histoMassVsEtaPlus[j]->SetLineColor(colorlist[j]);
@@ -184,7 +186,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoMassVsEtaPlusMinusDiff[j] = (TH1D*)fin->Get("MassVsEtaPlusMinusDiff/allHistos/meanHisto")){
+   if (( histoMassVsEtaPlusMinusDiff[j] = (TH1D*)fin->Get("MassVsEtaPlusMinusDiff/allHistos/meanHisto"))){
      histoMassVsEtaPlusMinusDiff[j]->SetLineStyle(linestylelist[j]);
      histoMassVsEtaPlusMinusDiff[j]->SetMarkerColor(colorlist[j]);
      histoMassVsEtaPlusMinusDiff[j]->SetLineColor(colorlist[j]);
@@ -221,7 +223,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoMassVsPhiMinus[j] = (TH1D*)fin->Get("MassVsPhiMinus/allHistos/meanHisto")){
+   if (( histoMassVsPhiMinus[j] = (TH1D*)fin->Get("MassVsPhiMinus/allHistos/meanHisto"))){
      histoMassVsPhiMinus[j]->SetLineStyle(linestylelist[j]);
      histoMassVsPhiMinus[j]->SetMarkerColor(colorlist[j]);
      histoMassVsPhiMinus[j]->SetLineColor(colorlist[j]);
@@ -259,7 +261,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoMassVsEtaMinus[j] = (TH1D*)fin->Get("MassVsEtaMinus/allHistos/meanHisto")){
+   if (( histoMassVsEtaMinus[j] = (TH1D*)fin->Get("MassVsEtaMinus/allHistos/meanHisto"))){
      histoMassVsEtaMinus[j]->SetLineStyle(linestylelist[j]);
      histoMassVsEtaMinus[j]->SetMarkerColor(colorlist[j]);
      histoMassVsEtaMinus[j]->SetLineColor(colorlist[j]);
@@ -303,7 +305,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoMassVsEtaPhiPlus[j] = (TH2D*)fin->Get("MassVsEtaPhiPlus/allHistos/meanHisto")){
+   if (( histoMassVsEtaPhiPlus[j] = (TH2D*)fin->Get("MassVsEtaPhiPlus/allHistos/meanHisto"))){
      if ( j == 0 ) {
        histoMassVsEtaPhiPlus[j]->SetTitle(LegLabels[j]);
        histoMassVsEtaPhiPlus[j]->GetXaxis()->SetTitle("positive muon #phi (rad)");
@@ -339,7 +341,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
 //  for(Int_t j=0; j < nOfFiles; j++) {     
    
 //    TFile *fin = (TFile*)FileList->At(j);    
-//    if ( histoMassVsEtaPhiMinus[j] = (TH2D*)fin->Get("MassVsEtaPhiMinus/allHistos/meanHisto")){
+//    if (( histoMassVsEtaPhiMinus[j] = (TH2D*)fin->Get("MassVsEtaPhiMinus/allHistos/meanHisto"))){
 //      if ( j == 0 ) {
 //        histoMassVsEtaPhiMinus[j]->GetXaxis()->SetTitle("negative muon #phi (rad)");
 //        histoMassVsEtaPhiMinus[j]->GetYaxis()->SetTitle("negative muon #eta");
@@ -380,7 +382,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
 //  for(Int_t j=0; j < nOfFiles; j++) {     
    
 //    TFile *fin = (TFile*)FileList->At(j);    
-//    if ( histoSigmaVsPhiPlus[j] = (TH1D*)fin->Get("MassVsPhiPlus/allHistos/sigmaHisto")){
+//    if (( histoSigmaVsPhiPlus[j] = (TH1D*)fin->Get("MassVsPhiPlus/allHistos/sigmaHisto"))){
 //      histoSigmaVsPhiPlus[j]->SetLineStyle(linestylelist_resol[j]);
 //      histoSigmaVsPhiPlus[j]->SetMarkerColor(colorlist_resol[j]);
 //      histoSigmaVsPhiPlus[j]->SetLineColor(colorlist_resol[j]);
@@ -419,7 +421,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoSigmaVsEtaPlus[j] = (TH1D*)fin->Get("MassVsEtaPlus/allHistos/sigmaHisto")){
+   if (( histoSigmaVsEtaPlus[j] = (TH1D*)fin->Get("MassVsEtaPlus/allHistos/sigmaHisto"))){
      histoSigmaVsEtaPlus[j]->SetLineStyle(linestylelist_resol[j]);
      histoSigmaVsEtaPlus[j]->SetMarkerColor(colorlist_resol[j]);
      histoSigmaVsEtaPlus[j]->SetLineColor(colorlist_resol[j]);
@@ -457,7 +459,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
 //  for(Int_t j=0; j < nOfFiles; j++) {     
    
 //    TFile *fin = (TFile*)FileList->At(j);    
-//    if ( histoSigmaVsEtaPlusMinusDiff[j] = (TH1D*)fin->Get("MassVsEtaPlusMinusDiff/allHistos/sigmaHisto")){
+//    if (( histoSigmaVsEtaPlusMinusDiff[j] = (TH1D*)fin->Get("MassVsEtaPlusMinusDiff/allHistos/sigmaHisto"))){
 //      histoSigmaVsEtaPlusMinusDiff[j]->SetLineStyle(linestylelist_resol[j]);
 //      histoSigmaVsEtaPlusMinusDiff[j]->SetMarkerColor(colorlist_resol[j]);
 //      histoSigmaVsEtaPlusMinusDiff[j]->SetLineColor(colorlist_resol[j]);
@@ -496,7 +498,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
 //  for(Int_t j=0; j < nOfFiles; j++) {     
    
 //    TFile *fin = (TFile*)FileList->At(j);    
-//    if ( histoSigmaVsPt[j] = (TH1D*)fin->Get("MassVsPt/allHistos/sigmaHisto")){
+//    if (( histoSigmaVsPt[j] = (TH1D*)fin->Get("MassVsPt/allHistos/sigmaHisto"))){
 //      histoSigmaVsPt[j]->SetLineStyle(linestylelist_resol[j]);
 //      histoSigmaVsPt[j]->SetMarkerColor(colorlist_resol[j]);
 //      histoSigmaVsPt[j]->SetLineColor(colorlist_resol[j]);
@@ -536,7 +538,7 @@ void MultiHistoOverlap(TString namesandlabels, Int_t nOfFiles, const TString& ou
  for(Int_t j=0; j < nOfFiles; j++) {     
    
    TFile *fin = (TFile*)FileList->At(j);    
-   if ( histoLineShape[j] = (RooPlot*)fin->Get("hRecBestResAllEvents_Mass_frame")){
+   if (( histoLineShape[j] = (RooPlot*)fin->Get("hRecBestResAllEvents_Mass_frame"))){
      std::cout<<"Writing fit histogrem file n. "<<j<<std::endl;
      histoLineShape[j]->Write();
      cFit->cd(j+1);

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlap_Upsilon.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlap_Upsilon.C
@@ -10,6 +10,7 @@
  #include "TH2.h"
  #include "TPad.h"
 
+ extern void setTDRStyle();
         
  using namespace ROOT::Math;
  
@@ -68,8 +69,7 @@
  histo1->Draw();
  leg->AddEntry(histo1,"this validation","L");  
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
- f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
+ TF1 * f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
  f1->SetParameter(2, 1.);
@@ -86,8 +86,7 @@
  histo2->Draw("same");
  leg->AddEntry(histo2,"reference","L");   
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
- f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
+ TF1 * f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
  f2->SetParameter(2, 1.);
@@ -119,7 +118,6 @@
  histo1->GetXaxis()->SetRangeUser(-3.14,3.14);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -137,7 +135,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
@@ -169,7 +166,6 @@
  histo1->GetXaxis()->SetRangeUser(-2.6,2.6);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("linear1", "[0]+[1]*x", -2.6, 2.6);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -186,7 +182,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("linear2", "[0]+[1]*x", -2.6, 2.6);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
@@ -217,7 +212,6 @@
  histo1->GetXaxis()->SetRangeUser(-2.6,2.6);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("linear1", "[0]+[1]*x", -2.6, 2.6);
  f1->SetParameter(0, 0.);
  f1->SetParameter(1, 0.);
@@ -234,7 +228,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("linear2", "[0]+[1]*x", -2.6, 2.6);
  f2->SetParameter(0, 0.);
  f2->SetParameter(1, 0.);
@@ -265,7 +258,6 @@
  histo1->GetXaxis()->SetRangeUser(-3.2,3.2);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("linear1", "[0]+[1]*x", -3.2, 3.2);
  f1->SetParameter(0, 0.);
  f1->SetParameter(1, 0.);
@@ -282,7 +274,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("linear1", "[0]+[1]*x", -3.2, 3.2);
  f2->SetParameter(0, 0.);
  f2->SetParameter(1, 0.);
@@ -314,7 +305,6 @@
  histo1->GetXaxis()->SetRangeUser(-1.1,1.1);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0; 
  f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -1.1, 1.1);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -332,7 +322,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0; 
  f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -1.1, 1.1);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
@@ -364,7 +353,6 @@
  histo1->GetXaxis()->SetRangeUser(-3.14,3.14);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0; 
  f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -382,7 +370,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0; 
  f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlap_Z.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/MultiHistoOverlap_Z.C
@@ -9,6 +9,7 @@
  #include "TFile.h"
  #include "TH2.h"
  #include "TPad.h"
+ //#include "MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/tdrstyle.C"
 
  using namespace ROOT::Math;
  
@@ -33,7 +34,7 @@
  bool switchONfit= false;
  bool switchONfitEta= false;
   
- gROOT->LoadMacro("tdrstyle.C"); 
+ gROOT->LoadMacro("MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/tdrstyle.C"); 
  setTDRStyle();
 
  TCanvas* c0 = new TCanvas("c0", "c0",50, 20, 800,600);
@@ -67,8 +68,7 @@
  histo1->Draw();
  leg->AddEntry(histo1,"this validation","L");  
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
- f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
+ TF1 * f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
  f1->SetParameter(2, 1.);
@@ -85,8 +85,7 @@
  histo2->Draw("same");
  leg->AddEntry(histo2,"reference","L");   
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
- f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
+ TF1 * f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
  f2->SetParameter(2, 1.);
@@ -118,7 +117,6 @@
  histo1->GetXaxis()->SetRangeUser(-3.14,3.14);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -136,7 +134,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
@@ -168,7 +165,6 @@
  histo1->GetXaxis()->SetRangeUser(-2.6,2.6);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("linear1", "[0]+[1]*x", -2.6, 2.6);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -185,7 +181,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("linear2", "[0]+[1]*x", -2.6, 2.6);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
@@ -216,7 +211,6 @@
  histo1->GetXaxis()->SetRangeUser(-2.6,2.6);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("linear1", "[0]+[1]*x", -2.6, 2.6);
  f1->SetParameter(0, 0.);
  f1->SetParameter(1, 0.);
@@ -233,7 +227,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("linear2", "[0]+[1]*x", -2.6, 2.6);
  f2->SetParameter(0, 0.);
  f2->SetParameter(1, 0.);
@@ -264,7 +257,6 @@
  histo1->GetXaxis()->SetRangeUser(-3.2,3.2);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0;
  f1 = new TF1("linear1", "[0]+[1]*x", -3.2, 3.2);
  f1->SetParameter(0, 0.);
  f1->SetParameter(1, 0.);
@@ -281,7 +273,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0;
  f2 = new TF1("linear1", "[0]+[1]*x", -3.2, 3.2);
  f2->SetParameter(0, 0.);
  f2->SetParameter(1, 0.);
@@ -313,7 +304,6 @@
  histo1->GetXaxis()->SetRangeUser(-1.1,1.1);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0; 
  f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -1.1, 1.1);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -331,7 +321,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0; 
  f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -1.1, 1.1);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);
@@ -363,7 +352,6 @@
  histo1->GetXaxis()->SetRangeUser(-3.14,3.14);
  histo1->Draw();
  //--- fit ----------------------------------------------
- TF1 * f1 = 0; 
  f1 = new TF1("cosinusoidal1", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f1->SetParameter(0, 90.5);
  f1->SetParameter(1, 1.);
@@ -381,7 +369,6 @@
  histo2->SetMarkerColor(2);
  histo2->Draw("same");
  //--- fit ----------------------------------------------
- TF1 * f2 = 0; 
  f2 = new TF1("cosinusoidal2", "[0]+[1]*cos(x+[2])", -3.14, 3.14);
  f2->SetParameter(0, 90.5);
  f2->SetParameter(1, 1.);

--- a/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/tdrstyle.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/Macros/RooFit/tdrstyle.C
@@ -1,6 +1,7 @@
 #include "TStyle.h"
 
 // tdrGrid: Turns the grid lines on (true) or off (false)
+extern  TStyle* tdrStyle;
 
 void tdrGrid(bool gridOn) {
   tdrStyle->SetPadGridX(gridOn);

--- a/MuonAnalysis/MomentumScaleCalibration/test/StatisticalErrors/MakePlot.C
+++ b/MuonAnalysis/MomentumScaleCalibration/test/StatisticalErrors/MakePlot.C
@@ -6,6 +6,8 @@
 #include <vector>
 #include <string>
 
+void makePlot(std::vector<double> vec, double& meanP, double& rmsP, double& sigmaP, std::string parNum);
+void skimValues(std::vector<double>& vec, double mean, double rms);
 
 void MakePlot() {
   ifstream file("Values.txt");

--- a/PhysicsTools/TagAndProbe/test/utilities/ThreeCategorySimZFitter.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/ThreeCategorySimZFitter.C
@@ -36,9 +36,12 @@
 #include <TH2F.h>
 #include <TTree.h>
 #include <TGraph.h>
-
+#include "tdrstyle.C"
 
 using namespace RooFit;
+
+void makeSignalPdf();
+void makeBkgPdf();
 
 // The signal & background Pdf 
 RooRealVar *rooMass_;
@@ -146,12 +149,12 @@ void ThreeCategorySimZFitter()
 
   // Define background yield variables: they are not related to each other  
   float numBkgHighPurity=11.8;
-  if(selection=="WP80") numBkgHighPurity=3.0; 
+  if(!strcmp(selection,"WP80")) numBkgHighPurity=3.0; 
   RooRealVar nBkgTT("nBkgTT","nBkgTT", numBkgHighPurity);
   RooRealVar nBkgTF_BB("nBkgTF_BB","nBkgTF_BB", 58.0,     0.0, 500.);
   RooRealVar nBkgTF_End("nBkgTF_End","nBkgTF_End", 110.2, 0.0, 500.);
-   if(FIX_NUIS_PARS) nBkgTF_BB->setConstant(true);
-   if(FIX_NUIS_PARS) nBkgTF_End->setConstant(true);
+   if(FIX_NUIS_PARS) nBkgTF_BB.setConstant(true);
+   if(FIX_NUIS_PARS) nBkgTF_End.setConstant(true);
 
   ////////////////////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////////////////////
@@ -159,7 +162,7 @@ void ThreeCategorySimZFitter()
   // They are linked together by the total cross section:  e.g. 
   //          Nbb = sigma*L*Abb*effB
 
-  char* formula;
+  const char* formula = 0;
   RooArgList* args;
   formula="lumi*xsec*(acc_BB*eff_B*eff_B + acc_EB*eff_B*eff_E + acc_EE*eff_E*eff_E)+nBkgTT";
   args = new RooArgList(lumi,xsec,acc_BB,acc_EB,acc_EE,eff_B,eff_E,nBkgTT);
@@ -301,7 +304,7 @@ void ThreeCategorySimZFitter()
 //   c->SaveAs( cname + TString(".C"));
 
 
-  TString cname = Form("Zmass_TF_BB%dnb", (int)(1000*intLumi) );
+  cname = Form("Zmass_TF_BB%dnb", (int)(1000*intLumi) );
   c = new TCanvas(cname,cname,500,500);
   RooPlot* frame2 = Mass.frame(60., 120., 12);
   data_TF_BB->plotOn(frame2,RooFit::DataError(errorType));
@@ -314,31 +317,31 @@ void ThreeCategorySimZFitter()
   frame2->SetMinimum(0);
   frame2->Draw("e0");
   frame2->GetYaxis()->SetNdivisions(505);
-  TPaveText *plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
+  plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
    plotlabel->SetTextColor(kBlack);
    plotlabel->SetFillColor(kWhite);
    plotlabel->SetBorderSize(0);
    plotlabel->SetTextAlign(12);
    plotlabel->SetTextSize(0.03);
    plotlabel->AddText("CMS Preliminary 2010");
-  TPaveText *plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
+  plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
    plotlabel2->SetTextColor(kBlack);
    plotlabel2->SetFillColor(kWhite);
    plotlabel2->SetBorderSize(0);
    plotlabel2->SetTextAlign(12);
    plotlabel2->SetTextSize(0.03);
    plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  TPaveText *plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
+  plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
    plotlabel3->SetTextColor(kBlack);
    plotlabel3->SetFillColor(kWhite);
    plotlabel3->SetBorderSize(0);
    plotlabel3->SetTextAlign(12);
    plotlabel3->SetTextSize(0.03);
-  char temp[100];
-  sprintf(temp, "%.1f", intLumi);
+  char temp2[100];
+  sprintf(temp2, "%.1f", intLumi);
   plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-  temp + string(" pb^{ -1}")).c_str());
-  TPaveText *plotlabel4 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
+  temp2 + string(" pb^{ -1}")).c_str());
+  plotlabel4 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
    plotlabel4->SetTextColor(kBlack);
    plotlabel4->SetFillColor(kWhite);
    plotlabel4->SetBorderSize(0);
@@ -346,32 +349,32 @@ void ThreeCategorySimZFitter()
    plotlabel4->SetTextSize(0.03);
    nsig = nSigTF_BB.getVal();
    nsigerr = nSigTF_BB.getPropagatedError(*fitResult) ;
-   sprintf(temp, "Signal = %.2f #pm %.2f", nsig, nsigerr);
-   plotlabel4->AddText(temp);
-  TPaveText *plotlabel5 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
+   sprintf(temp2, "Signal = %.2f #pm %.2f", nsig, nsigerr);
+   plotlabel4->AddText(temp2);
+  plotlabel5 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
    plotlabel5->SetTextColor(kBlack);
    plotlabel5->SetFillColor(kWhite);
    plotlabel5->SetBorderSize(0);
    plotlabel5->SetTextAlign(12);
    plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", nBkgTF_BB.getVal(), nBkgTF_BB.getError());
-   plotlabel5->AddText(temp);
-  TPaveText *plotlabel6 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
+   sprintf(temp2, "Bkg = %.2f #pm %.2f", nBkgTF_BB.getVal(), nBkgTF_BB.getError());
+   plotlabel5->AddText(temp2);
+  plotlabel6 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
    plotlabel6->SetTextColor(kBlack);
    plotlabel6->SetFillColor(kWhite);
    plotlabel6->SetBorderSize(0);
    plotlabel6->SetTextAlign(12);
    plotlabel6->SetTextSize(0.03);
-   sprintf(temp, "#epsilon_{EB} = %.3f #pm %.3f", eff_B.getVal(), eff_B.getError() );
-   plotlabel6->AddText(temp);
-  TPaveText *plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
+   sprintf(temp2, "#epsilon_{EB} = %.3f #pm %.3f", eff_B.getVal(), eff_B.getError() );
+   plotlabel6->AddText(temp2);
+   plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
    plotlabel7->SetTextColor(kBlack);
    plotlabel7->SetFillColor(kWhite);
    plotlabel7->SetBorderSize(0);
    plotlabel7->SetTextAlign(12);
    plotlabel7->SetTextSize(0.03);
-   sprintf(temp, "#epsilon_{EE} = %.3f #pm %.3f", eff_E.getVal(), eff_E.getError() );
-   plotlabel7->AddText(temp);
+   sprintf(temp2, "#epsilon_{EE} = %.3f #pm %.3f", eff_E.getVal(), eff_E.getError() );
+   plotlabel7->AddText(temp2);
 
   plotlabel->Draw();
   plotlabel2->Draw();
@@ -390,7 +393,7 @@ void ThreeCategorySimZFitter()
 
 // $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
 
-  TString cname = Form("Zmass_TF_EndCaps%dnb", (int)(1000*intLumi) );
+  cname = Form("Zmass_TF_EndCaps%dnb", (int)(1000*intLumi) );
   c = new TCanvas(cname,cname,500,500);
   RooPlot* frame3 = Mass.frame(60., 120., 12);
   data_TF_End->plotOn(frame3,RooFit::DataError(errorType));
@@ -403,31 +406,31 @@ void ThreeCategorySimZFitter()
   frame3->SetMinimum(0);
   frame3->Draw("e0");
   frame3->GetYaxis()->SetNdivisions(505);
-  TPaveText *plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
+  plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
    plotlabel->SetTextColor(kBlack);
    plotlabel->SetFillColor(kWhite);
    plotlabel->SetBorderSize(0);
    plotlabel->SetTextAlign(12);
    plotlabel->SetTextSize(0.03);
    plotlabel->AddText("CMS Preliminary 2010");
-  TPaveText *plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
+  plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
    plotlabel2->SetTextColor(kBlack);
    plotlabel2->SetFillColor(kWhite);
    plotlabel2->SetBorderSize(0);
    plotlabel2->SetTextAlign(12);
    plotlabel2->SetTextSize(0.03);
    plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  TPaveText *plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
+  plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
    plotlabel3->SetTextColor(kBlack);
    plotlabel3->SetFillColor(kWhite);
    plotlabel3->SetBorderSize(0);
    plotlabel3->SetTextAlign(12);
    plotlabel3->SetTextSize(0.03);
-  char temp[100];
-  sprintf(temp, "%.1f", intLumi);
+  char temp3[100];
+  sprintf(temp3, "%.1f", intLumi);
   plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-  temp + string(" pb^{ -1}")).c_str());
-  TPaveText *plotlabel4 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
+  temp3 + string(" pb^{ -1}")).c_str());
+  plotlabel4 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
    plotlabel4->SetTextColor(kBlack);
    plotlabel4->SetFillColor(kWhite);
    plotlabel4->SetBorderSize(0);
@@ -435,32 +438,32 @@ void ThreeCategorySimZFitter()
    plotlabel4->SetTextSize(0.03);
    nsig = nSigTF_End.getVal();
    nsigerr = nSigTF_End.getPropagatedError(*fitResult) ;
-   sprintf(temp, "Signal = %.2f #pm %.2f", nsig, nsigerr);
-   plotlabel4->AddText(temp);
-  TPaveText *plotlabel5 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
+   sprintf(temp3, "Signal = %.2f #pm %.2f", nsig, nsigerr);
+   plotlabel4->AddText(temp3);
+  plotlabel5 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
    plotlabel5->SetTextColor(kBlack);
    plotlabel5->SetFillColor(kWhite);
    plotlabel5->SetBorderSize(0);
    plotlabel5->SetTextAlign(12);
    plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", nBkgTF_End.getVal(), nBkgTF_End.getError());
-   plotlabel5->AddText(temp);
-  TPaveText *plotlabel6 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
+   sprintf(temp3, "Bkg = %.2f #pm %.2f", nBkgTF_End.getVal(), nBkgTF_End.getError());
+   plotlabel5->AddText(temp3);
+  plotlabel6 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
    plotlabel6->SetTextColor(kBlack);
    plotlabel6->SetFillColor(kWhite);
    plotlabel6->SetBorderSize(0);
    plotlabel6->SetTextAlign(12);
    plotlabel6->SetTextSize(0.03);
-   sprintf(temp, "#epsilon_{EB} = %.3f #pm %.3f", eff_B.getVal(), eff_B.getError() );
-   plotlabel6->AddText(temp);
-  TPaveText *plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
+   sprintf(temp3, "#epsilon_{EB} = %.3f #pm %.3f", eff_B.getVal(), eff_B.getError() );
+   plotlabel6->AddText(temp3);
+  plotlabel7 = new TPaveText(0.6,0.72,0.8,0.77,"NDC");
    plotlabel7->SetTextColor(kBlack);
    plotlabel7->SetFillColor(kWhite);
    plotlabel7->SetBorderSize(0);
    plotlabel7->SetTextAlign(12);
    plotlabel7->SetTextSize(0.03);
-   sprintf(temp, "#epsilon_{EE} = %.3f #pm %.3f", eff_E.getVal(), eff_E.getError() );
-   plotlabel7->AddText(temp);
+   sprintf(temp3, "#epsilon_{EE} = %.3f #pm %.3f", eff_E.getVal(), eff_E.getError() );
+   plotlabel7->AddText(temp3);
 
   plotlabel->Draw();
   plotlabel2->Draw();

--- a/PhysicsTools/TagAndProbe/test/utilities/TwoCategorySimZFitter.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/TwoCategorySimZFitter.C
@@ -36,9 +36,12 @@
 #include <TH2F.h>
 #include <TTree.h>
 #include <TGraph.h>
-
+#include "tdrstyle.C"
 
 using namespace RooFit;
+
+void makeSignalPdf();
+void makeBkgPdf();
 
 // The signal & background Pdf 
 RooRealVar *rooMass_;
@@ -133,14 +136,14 @@ void TwoCategorySimZFitter()
 
   // Define background yield variables: they are not related to each other  
   float numBkgHighPurity=11.8;
-  if(selection=="WP80") numBkgHighPurity=3.0; 
+  if(!strcmp(selection,"WP80")) numBkgHighPurity=3.0; 
   RooRealVar nBkgTT("nBkgTT","nBkgTT", numBkgHighPurity);
   RooRealVar nBkgTF("nBkgTF","nBkgTF", 58.0,     0.0, 500.);
-  if(selection=="WP80") {
-     nBkgTF->setVal(0.0);
-     nBkgTF->setConstant(true);
+  if(!strcmp(selection,"WP80")) {
+     nBkgTF.setVal(0.0);
+     nBkgTF.setConstant(true);
   }
-   if(FIX_NUIS_PARS) nBkgTF->setConstant(true);
+   if(FIX_NUIS_PARS) nBkgTF.setConstant(true);
 
   ////////////////////////////////////////////////////////////////////////////
   ////////////////////////////////////////////////////////////////////////////
@@ -148,7 +151,7 @@ void TwoCategorySimZFitter()
   // They are linked together by the total cross section:  e.g. 
   //          Nbb = sigma*L*Abb*effB
 
-  char* formula;
+  const char* formula = 0;
   RooArgList* args;
   formula="lumi*xsec*acc*eff*eff+nBkgTT";
   args = new RooArgList(lumi,xsec,acc,eff,nBkgTT);
@@ -268,7 +271,7 @@ void TwoCategorySimZFitter()
 //   c->SaveAs( cname + TString(".C"));
 
 
-  TString cname = Form("Zmass_TF%dnb", (int)(1000*intLumi) );
+  cname = Form("Zmass_TF%dnb", (int)(1000*intLumi) );
   c = new TCanvas(cname,cname,500,500);
   RooPlot* frame2 = Mass.frame(60., 120., 12);
   data_TF->plotOn(frame2,RooFit::DataError(errorType));
@@ -281,31 +284,31 @@ void TwoCategorySimZFitter()
   frame2->SetMinimum(0);
   frame2->Draw("e0");
   frame2->GetYaxis()->SetNdivisions(505);
-  TPaveText *plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
+  plotlabel = new TPaveText(0.23,0.87,0.43,0.92,"NDC");
    plotlabel->SetTextColor(kBlack);
    plotlabel->SetFillColor(kWhite);
    plotlabel->SetBorderSize(0);
    plotlabel->SetTextAlign(12);
    plotlabel->SetTextSize(0.03);
    plotlabel->AddText("CMS Preliminary 2010");
-  TPaveText *plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
+  plotlabel2 = new TPaveText(0.23,0.82,0.43,0.87,"NDC");
    plotlabel2->SetTextColor(kBlack);
    plotlabel2->SetFillColor(kWhite);
    plotlabel2->SetBorderSize(0);
    plotlabel2->SetTextAlign(12);
    plotlabel2->SetTextSize(0.03);
    plotlabel2->AddText("#sqrt{s} = 7 TeV");
-  TPaveText *plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
+  plotlabel3 = new TPaveText(0.23,0.75,0.43,0.80,"NDC");
    plotlabel3->SetTextColor(kBlack);
    plotlabel3->SetFillColor(kWhite);
    plotlabel3->SetBorderSize(0);
    plotlabel3->SetTextAlign(12);
    plotlabel3->SetTextSize(0.03);
-  char temp[100];
-  sprintf(temp, "%.1f", intLumi);
+  char temp2[100];
+  sprintf(temp2, "%.1f", intLumi);
   plotlabel3->AddText((string("#int#font[12]{L}dt = ") + 
-  temp + string(" pb^{ -1}")).c_str());
-  TPaveText *plotlabel4 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
+  temp2 + string(" pb^{ -1}")).c_str());
+  plotlabel4 = new TPaveText(0.6,0.87,0.8,0.92,"NDC");
    plotlabel4->SetTextColor(kBlack);
    plotlabel4->SetFillColor(kWhite);
    plotlabel4->SetBorderSize(0);
@@ -313,24 +316,24 @@ void TwoCategorySimZFitter()
    plotlabel4->SetTextSize(0.03);
    nsig = nSigTF.getVal();
    nsigerr = nSigTF.getPropagatedError(*fitResult) ; 
-   sprintf(temp, "Signal = %.2f #pm %.2f", nsig, nsigerr);
-   plotlabel4->AddText(temp);
-  TPaveText *plotlabel5 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
+   sprintf(temp2, "Signal = %.2f #pm %.2f", nsig, nsigerr);
+   plotlabel4->AddText(temp2);
+  plotlabel5 = new TPaveText(0.6,0.82,0.8,0.87,"NDC");
    plotlabel5->SetTextColor(kBlack);
    plotlabel5->SetFillColor(kWhite);
    plotlabel5->SetBorderSize(0);
    plotlabel5->SetTextAlign(12);
    plotlabel5->SetTextSize(0.03);
-   sprintf(temp, "Bkg = %.2f #pm %.2f", nBkgTF.getVal(), nBkgTF.getError());
-   plotlabel5->AddText(temp);
-  TPaveText *plotlabel6 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
+   sprintf(temp2, "Bkg = %.2f #pm %.2f", nBkgTF.getVal(), nBkgTF.getError());
+   plotlabel5->AddText(temp2);
+  TPaveText* plotlabel6 = new TPaveText(0.6,0.77,0.8,0.82,"NDC");
    plotlabel6->SetTextColor(kBlack);
    plotlabel6->SetFillColor(kWhite);
    plotlabel6->SetBorderSize(0);
    plotlabel6->SetTextAlign(12);
    plotlabel6->SetTextSize(0.03);
-   sprintf(temp, "#epsilon = %.3f #pm %.3f", eff.getVal(), eff.getError() );
-   plotlabel6->AddText(temp);
+   sprintf(temp2, "#epsilon = %.3f #pm %.3f", eff.getVal(), eff.getError() );
+   plotlabel6->AddText(temp2);
   plotlabel->Draw();
   plotlabel2->Draw();
   plotlabel3->Draw();

--- a/PhysicsTools/TagAndProbe/test/utilities/tdrstyle.C
+++ b/PhysicsTools/TagAndProbe/test/utilities/tdrstyle.C
@@ -1,5 +1,6 @@
 #include "TStyle.h"
 
+TStyle* tdrStyle;
 // tdrGrid: Turns the grid lines on (true) or off (false)
 
 void tdrGrid(bool gridOn) {


### PR DESCRIPTION
In ROOT6 macros are processed by cling, rather than CINT. Over 500 CMSSW macros do not compile in ROOT6. Since that is too many macros to be fixed centrally, it was decided by David Lange to centrally fix only those 45 macros with compilation errors that have been modified since the switch over to git, since those are the ones most likely to be used. Several of these 45 macros are in the Analysis L2 category. This pull request fixes them.
Note:  While this PR fixes all the compilation errors in these macros, one macro, MultiHistoOverlap_Upsilon.C still has a link error that I was not able to easily fix.  Still, the fact that now compiles is an improvement.
