### PR TITLE
Macros need to compile in ROOT6 (Reco)

### DIFF
--- a/RecoParticleFlow/PFClusterTools/test/src/init.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/init.C
@@ -1,8 +1,8 @@
+{
 /*
  * A Root macro to initialise testing of the functionality of the PFClusterTools package
  * 
  */
-{
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	std::cout << "Loaded libraries." << std::endl;
 	using namespace std;

--- a/RecoParticleFlow/PFClusterTools/test/src/testConversion.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/testConversion.C
@@ -7,22 +7,22 @@
 	using namespace pftools;
 	
 	TFile* testConversion = new TFile("TestConversion.root", "recreate");
-	testConversion.mkdir("extraction");
-	testConversion.cd("extraction");
+	testConversion->mkdir("extraction");
+	testConversion->cd("extraction");
 	TTree* tree = new TTree("Extraction", "");
 	Calibratable* c = new Calibratable();
 	tree->Branch("Calibratable", "pftools::Calibratable", &c, 32000, 2);
 	
 	std::cout << "Initialised objects etc.\n";
-	TRandom2 rand;
+	TRandom2 rand2;
 	for (unsigned u(0); u < 1000; ++u) {
 		double eta, phi, energy, ecalFrac, gaussSamp;
 
-		eta = rand.Uniform(0, 1.5);
-		phi = rand.Uniform(0, 3.14);
-		energy = rand.Uniform(2, 20);
-		ecalFrac = rand.Uniform(0, 1.0);
-		gaussSamp = rand.Gaus(1, 0.3);
+		eta = rand2.Uniform(0, 1.5);
+		phi = rand2.Uniform(0, 3.14);
+		energy = rand2.Uniform(2, 20);
+		ecalFrac = rand2.Uniform(0, 1.0);
+		gaussSamp = rand2.Gaus(1, 0.3);
 		//gaussSamp = 1.0;
 
 		c->reset();

--- a/RecoParticleFlow/PFClusterTools/test/src/testWrappers.C
+++ b/RecoParticleFlow/PFClusterTools/test/src/testWrappers.C
@@ -1,8 +1,8 @@
+{
 /*
  * A Root macro to initialise testing of the functionality of the PFClusterTools package
  * 
  */
-{
 	gSystem->Load("libRecoParticleFlowPFClusterTools.so");
 	
 	TFile f("TestWrappers.root", "recreate");

--- a/RecoTracker/TrackProducer/test/analyze_tracks.C
+++ b/RecoTracker/TrackProducer/test/analyze_tracks.C
@@ -7,11 +7,11 @@ TTree * tree = (TTree *) gROOT->FindObject("Events");
 TFile outFile("graphsParTest2.root","recreate");
 float intervals[] = {0,0.5,1.0,1.5,2.0,2.5};
 int bins = 5;
-char * ptinterval  = "4.99<P_{T}<5.01";
-char * etainterval = "|#eta|<2.5";
-char * rs  = "recoTracks_rsWithMaterialTracks__RsWithMaterial";
-char * ctf = "recoTracks_ctfWithMaterialTracks__FinalFits";
-char * sim = "SimTracks_SimG4Object__Test";
+const char * ptinterval  = "4.99<P_{T}<5.01";
+const char * etainterval = "|#eta|<2.5";
+const char * rs  = "recoTracks_rsWithMaterialTracks__RsWithMaterial";
+const char * ctf = "recoTracks_ctfWithMaterialTracks__FinalFits";
+const char * sim = "SimTracks_SimG4Object__Test";
 ////////////////////////////////////////
 vector<float> tot;
 vector<float> ptrmsRS;


### PR DESCRIPTION
In ROOT6 macros are processed by cling, rather than CINT. Over 500 CMSSW macros do not compile in ROOT6. Since that is too many macros to be fixed centrally, it was decided by David Lange to centrally fix only those 45 macros with compilation errors that have been modified since the switch over to git, since those are the ones most likely to be used. A few of these 45 macros are in the Reconstruction L2 category. This pull request partially fixes the compilation errors.  I could not fully fix  RecoParticleFlow/PFClusterTools/test/src/testWrappers.C, because I could not find any place in CMSSW where type "SingleParticleWrapper" was declared. I chose not to fix RecoParticleFlow/PFClusterTools/test/src/clusterCalibrate.C because its only problem is that a constructor that it needs, pftools::PFClusterCalibration(pftools::IO *) has been commented out.  Since it may have been commented out for a good reason, I left this alone.  To fix this macro, simply uncomment the constructor.
