### PR TITLE
Macros need to compile in ROOT6 (DQM)

### DIFF
--- a/Validation/DTRecHits/test/macros.C
+++ b/Validation/DTRecHits/test/macros.C
@@ -73,12 +73,12 @@ TString opt2Dplot = "col";
 // minY, maxY: Y range for plotting and for computing profile if addProfile==true.
 //             Note that the simple profile is very sensitive to the Y range used!
 TH1F* plotAndProfileX (TH2* theh, int rebinX, int rebinY, int rebinProfile, float minY, float maxY, float minX=0, float maxX=0) {
-  TH2* h2=theh->Clone();
+  TH2* h2=(TH2*)theh->Clone();
   
   //  setStyle(h2);
   if (h2==0) {
     cout << "plotAndProfileX: null histo ptr" << endl;
-    return;
+    return 0;
   }
   
   gPad->SetGrid(1,1);
@@ -271,16 +271,17 @@ TF1* drawGFit(TH1 * h1, float nsigmas, float min, float max){
 // If no name is specified, a new name is generated automatically
 TCanvas * newCanvas(TString name="", TString title="",
                      Int_t xdiv=0, Int_t ydiv=0, Int_t form = 1, Int_t w=-1){
-  static int i = 1;
+  static char i = '1';
   if (name == "") {
     name = TString("Canvas ") + i;
     i++;
   }
   if (title == "") title = name;
+  TCanvas * c = 0;
   if (w<0) {
-    TCanvas * c = new TCanvas(name,title, form);
+    c = new TCanvas(name,title, form);
   } else {
-    TCanvas * c = new TCanvas(name,title,form,w);
+    c = new TCanvas(name,title,form,w);
   }
   if (xdiv*ydiv!=0) c->Divide(xdiv,ydiv);
   c->cd(1);
@@ -541,6 +542,7 @@ TStyle * getStyle(TString name="myStyle")
 }
 
 
+void
 setPalette()
 {
   const Int_t NRGBs = 5;
@@ -577,10 +579,10 @@ setPalette()
     Double_t red[NRGBs]   = { 1.00, 1-step, 1-2*step, 1-3*step, 1-4*step };
     Double_t green[NRGBs] = { 1.00, 1-step, 1-2*step, 1-3*step, 1-4*step };
     Double_t blue[NRGBs]  = { 1.00, 1-step, 1-2*step, 1-3*step, 1-4*step };
+    TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
   }
 
 
- TColor::CreateGradientColorTable(NRGBs, stops, red, green, blue, NCont);
  gStyle->SetNumberContours(NCont);
 }
 
@@ -618,7 +620,7 @@ void plotEff(TH1* h1, TH1* h2=0, TH1* h3=0) {
 TH1F* getEffPlot(TH1* hnum, TH1* hden, int rebin=1) {
   hnum->Rebin(rebin);
   hden->Rebin(rebin);
-  TH1F* h = hnum->Clone();
+  TH1F* h = (TH1F*)hnum->Clone();
   h->Sumw2();
   h->Divide(hnum,hden,1.,1.,"B");
   h->SetStats(0);

--- a/Validation/EventGenerator/test/MECompare.C
+++ b/Validation/EventGenerator/test/MECompare.C
@@ -3,7 +3,11 @@
 // ROOT macro for graphical compariosn of Monitor Elements in a user
 // supplied directory between two files with the same histogram content
 
-#include <iostream.h>
+#include <iostream>
+#include <sstream>
+
+std::vector<TString> histoList( TString currentfile, TString theDir );
+void MEComparePlot(TH1 * href_, TH1 * hnew_, TString currentfile, TString referencefile, TString theDir, TString theHisto);
 
 class HistoCompare {
 
@@ -34,9 +38,10 @@ class HistoCompare {
 
 };
 
+void
 HistoCompare::printRes(TString myName, Double_t mypv, TText * myte)
 {
-  std::strstream buf;
+  std::basic_stringstream<char> buf;
   std::string value;
   buf<<"PV="<<mypv<<std::endl;
   buf>>value;
@@ -48,6 +53,7 @@ HistoCompare::printRes(TString myName, Double_t mypv, TText * myte)
 }
 
 
+void
 HistoCompare::PVCompute(TH1 * oldHisto , TH1 * newHisto , TText * te )
 {
 
@@ -64,6 +70,7 @@ HistoCompare::PVCompute(TH1 * oldHisto , TH1 * newHisto , TText * te )
 
 }
 
+void
 HistoCompare::PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te )
 {
 
@@ -80,6 +87,7 @@ HistoCompare::PVCompute(TH2 * oldHisto , TH2 * newHisto , TText * te )
 }
 
 
+void
 HistoCompare::PVCompute(TProfile * oldHisto , TProfile * newHisto , TText * te )
 {
 
@@ -112,8 +120,8 @@ void MECompare( TString currentfile = "new.root",
   std::vector<TString> theList =  histoList(currentfile, theDir);
   
   gROOT ->Reset();
-  char*  rfilename = referencefile ;
-  char*  sfilename = currentfile ;
+  const char*  rfilename = referencefile.Data();
+  const char*  sfilename = currentfile.Data();
   
   delete gROOT->GetListOfFiles()->FindObject(rfilename);
   delete gROOT->GetListOfFiles()->FindObject(sfilename);
@@ -121,7 +129,7 @@ void MECompare( TString currentfile = "new.root",
   TFile * rfile = new TFile(rfilename);
   TFile * sfile = new TFile(sfilename);
   
-  char* baseDir=theDir;
+  const char* baseDir=theDir.Data();
   
   rfile->cd(baseDir);
   gDirectory->ls();
@@ -138,11 +146,9 @@ void MECompare( TString currentfile = "new.root",
 
     TH1* href_;
     rfile->GetObject(theName,href_);
-    href_;
     
     TH1* hnew_;
     sfile->GetObject(theName,hnew_);
-    hnew_;
     
     MEComparePlot(href_, hnew_, currentfile, referencefile, theDir, theList[index]); 
 
@@ -176,10 +182,11 @@ void MEComparePlot(TH1 * href_, TH1 * hnew_, TString currentfile, TString refere
  hnew_->SetMarkerSize(markerSize);
  hnew_->SetMarkerColor(scolor);    
 
+ TCanvas *myPlot = 0;
  if ( href_ && hnew_ ) {
 
  
-   TCanvas *myPlot = new TCanvas("myPlot","Histogram comparison",200,10,700,900);
+   myPlot = new TCanvas("myPlot","Histogram comparison",200,10,700,900);
    TPad *pad1 = new TPad("pad1",
                          "The pad with the function",0.03,0.62,0.50,0.92);
    TPad *pad2 = new TPad("pad2",
@@ -224,7 +231,7 @@ void MEComparePlot(TH1 * href_, TH1 * hnew_, TString currentfile, TString refere
 
  }
  TString plotFile = theHisto+".jpg";
- myPlot->Print(plotFile); 
+ if(myPlot) myPlot->Print(plotFile); 
  
  delete myPV;
  delete myPlot; 
@@ -235,13 +242,13 @@ std::vector<TString> histoList( TString currentfile, TString theDir )
 {
 
  gROOT ->Reset();
- char*  sfilename = currentfile ;
+ const char*  sfilename = currentfile.Data();
 
  delete gROOT->GetListOfFiles()->FindObject(sfilename);
 
  TFile * sfile = new TFile(sfilename);
 
- char* baseDir=theDir;
+ const char* baseDir=theDir.Data();
 
  sfile->cd(baseDir);
 

--- a/Validation/RecoB/test/GridValidation/compare.C
+++ b/Validation/RecoB/test/GridValidation/compare.C
@@ -2,6 +2,7 @@
 #include <string>
 using namespace std;
 
+TGraphErrors * computeGraph(TH1F * effdiscrb, TH1F* effdiscruds);
 
 int colorList[] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}; 
 int markerStyleList[] = {21,21,23,23,22,22,23,23,24,24,24,24,25,25,25,25,26,26,26,26};  
@@ -133,6 +134,7 @@ TGraphErrors *  drawAll()
 
   leg->Draw("same");
 
+  return 0;
 }
 
 

--- a/Validation/RecoB/test/compare.C
+++ b/Validation/RecoB/test/compare.C
@@ -2,6 +2,7 @@
 #include <string>
 using namespace std;
 
+TGraphErrors * computeGraph(TH1F * effdiscrb, TH1F* effdiscruds);
 
 int colorList[] = {1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20}; 
 int markerStyleList[] = {21,21,23,23,22,22,23,23,24,24,24,24,25,25,25,25,26,26,26,26};  
@@ -133,6 +134,7 @@ TGraphErrors *  drawAll()
 
   leg->Draw("same");
 
+  return 0;
 }
 
 

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -1,4 +1,5 @@
 #include <TObjArray.h>
+#include <sstream>
 
 TH1F * DivideHistos
  ( TFile * f,
@@ -22,7 +23,7 @@ TH1F * DivideHistos
  }
 
 void Join
- ( const TObjArray * tokens, TString & common )
+ ( TObjArray * tokens, TString & common )
  {
   tokens->Compress() ;
   if (tokens->GetEntries()==0)
@@ -389,7 +390,7 @@ int electronCompare()
     if (first==std::string::npos) continue ;
     if (line[first]=='#') continue ;
 
-    std::istrstream linestream(line) ;
+    std::basic_istringstream<char> linestream(line) ;
     divide = 0 ; num = denom = "" ;
     linestream >> histo_path >> scaled >> err >> eol >> eoc >> divide >> num >> denom ;
 
@@ -587,4 +588,5 @@ int electronCompare()
   web_page<<"\n</html>"<<std::endl ;
   web_page.close() ;
 
+  return 0;
  }

--- a/Validation/RecoMuon/test/macro/IsoValHistoPublisher.C
+++ b/Validation/RecoMuon/test/macro/IsoValHistoPublisher.C
@@ -1,25 +1,25 @@
 #include <vector>
 #include <algorithm>
 #include "TMath.h"
+#include "PlotHelpers.C"
 
 // Uncomment the following line for some extra debug information
 // #define DEBUG
 
-void IsoValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
+void IsoValHistoPublisher(const char* newFile="NEW_FILE",const char* refFile="REF_FILE") {
   cout << ">> Starting IsoValHistoPublisher(" << newFile << "," << refFile << ")..." << endl;
 
   //====  To be replaced from python ====================
 
-  char* dataType = "DATATYPE";
-  char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
-  char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
+  const char* dataType = "DATATYPE";
+  const char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
+  const char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
   
   
   // ==== Initial settings and loads
   //gROOT->ProcessLine(".x HistoCompare_Tracks.C");
   //gROOT ->Reset();
   gROOT ->SetBatch();
-  gROOT->LoadMacro("macro/PlotHelpers.C");
   gErrorIgnoreLevel = kWarning; // Get rid of the info messages
 
   SetGlobalStyle();

--- a/Validation/RecoMuon/test/macro/PlotHelpers.C
+++ b/Validation/RecoMuon/test/macro/PlotHelpers.C
@@ -15,6 +15,9 @@
 #include "TPaveLabel.h"
 #include <vector>
 
+void NormalizeHistogramsToFirst(TH1* h1, TH1* h2);
+void NormalizeHistogramsTo1(TH1* h1, TH1* h2);
+
 /////
 // Uncomment the following line to get more debuggin output
 // #define DEBUG
@@ -74,7 +77,7 @@ TList* GetListOfDirectories(TDirectory* dir, const char* match = 0) {
   TKey*  key    = 0;
   TKey*  oldkey = 0;
 
-  while ( key = (TKey*)nextkey() ) {
+  while (( key = (TKey*)nextkey() )) {
     TObject *obj = key->ReadObj();
     if ( obj->IsA()->InheritsFrom( "TDirectory" ) ) {
       TString theName = obj->GetName();
@@ -279,7 +282,7 @@ void PlotNHistograms(const TString& pdfFile,
 		     const char* canvasName, const char* canvasTitle,
 		     const TString& refLabel, const TString& newLabel,
 		     unsigned int nhistos, const char** hnames, const char** htitles = 0,
-		     bool* logy = 0, bool* doKolmo = 0, Double_t* norm = 0, bool *resol = false,
+		     bool* logy = 0, bool* doKolmo = 0, Double_t* norm = 0, bool *resol = 0,
 		     Double_t* minx = 0, Double_t* maxx = 0,
 		     Double_t* miny = 0, Double_t* maxy = 0) {
 #ifdef DEBUG
@@ -372,11 +375,11 @@ void PlotNHistograms(const TString& pdfFile,
     hnames_tmp=hnamesi;
     
     sdir->cd(scollname);
-    TIter next(gDirectory->GetListOfKeys());
-    TKey *key;
-    while ((key = (TKey*)next())) { 
+    TIter next2(gDirectory->GetListOfKeys());
+    TKey *key2;
+    while ((key2 = (TKey*)next2())) { 
     
-      TObject *obj = key->ReadObj();
+      TObject *obj = key2->ReadObj();
       TString temp = obj->GetName();
       if ( (temp.Contains("nhits_vs_eta_pfx")) &&
 	   hnamesi.Contains("hits_eta")
@@ -411,23 +414,23 @@ void PlotNHistograms(const TString& pdfFile,
       sh = proj;
     }
 
-    if(TString(sh->GetName()).Contains(" vs "))norm= -999.;
+    if(TString(sh->GetName()).Contains(" vs "))norm[i]= -999.;
 
 
     // Normalize
-    if (norm == -1.)
+    if (norm[i] == -1.)
       NormalizeHistogramsTo1(rh, sh);
-    else if (norm == 0.)
+    else if (norm[i] == 0.)
       NormalizeHistogramsToFirst(rh,sh);
-    else if (norm == -999.){
+    else if (norm[i] == -999.){
       cout << "DEBUG: Normalizing histograms to nothing" << "..." << endl;
     }
     /*    else {
 #ifdef DEBUG
-      cout << "DEBUG: Normalizing histograms to " << norm << "..." << endl;
+      cout << "DEBUG: Normalizing histograms to " << norm[i] << "..." << endl;
 #endif
-      sh->Scale(norm);
-      rh->Scale(norm);
+      sh->Scale(norm[i]);
+      rh->Scale(norm[i]);
       }*/
 
 
@@ -456,7 +459,7 @@ void PlotNHistograms(const TString& pdfFile,
     }
     //Change y axis range
     if (miny) {
-      if (miny < -1E99) {
+      if (miny[i] < -1E99) {
 	rh->GetYaxis()->SetRangeUser(miny[i],maxy[i]);
 	sh->GetYaxis()->SetRangeUser(miny[i],maxy[i]);
       }
@@ -577,7 +580,7 @@ void Plot6Histograms(const TString& pdfFile,
 		     const char* canvasName, const char* canvasTitle,
 		     const TString& refLabel, const TString& newLabel,
 		     const char** hnames, const char** htitles = 0,
-		     bool* logy = 0, bool* doKolmo = 0, Double_t* norm = 0,bool *resol=false,
+		     bool* logy = 0, bool* doKolmo = 0, Double_t* norm = 0,bool *resol=0,
 		     Double_t* minx = 0, Double_t* maxx = 0,
 		     Double_t* miny = 0, Double_t* maxy = 0) {
   
@@ -601,7 +604,7 @@ void Plot5Histograms(const TString& pdfFile,
 		     const char* canvasName, const char* canvasTitle,
 		     const TString& refLabel, const TString& newLabel,
 		     const char** hnames, const char** htitles = 0,
-		     bool* logy = 0, bool* doKolmo = 0, Double_t* norm = 0,bool *resol=false,
+		     bool* logy = 0, bool* doKolmo = 0, Double_t* norm = 0,bool *resol=0,
 		     Double_t* minx = 0, Double_t* maxx = 0,
 		     Double_t* miny = 0, Double_t* maxy = 0) {
   
@@ -644,7 +647,7 @@ void NormalizeHistogramsTo1(TH1* h1, TH1* h2) {
   if (!h1 || !h2) return;
   
   if ( h1->Integral() != 0 && h2->Integral() != 0 ) {
-∂    Double_t scale1 = 1.0/h1->Integral();
+    Double_t scale1 = 1.0/h1->Integral();
     Double_t scale2 = 1.0/h2->Integral();
     h1->Scale(scale1);
     h2->Scale(scale2);

--- a/Validation/RecoMuon/test/macro/RecoMuonValHistoPublisher.C
+++ b/Validation/RecoMuon/test/macro/RecoMuonValHistoPublisher.C
@@ -1,27 +1,27 @@
 #include <vector>
 #include <algorithm>
 #include "TMath.h"
+#include "PlotHelpers.C"
 
 /////
 // Uncomment the following line to get more debuggin output
 // #define DEBUG
 
-void RecoMuonValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
+void RecoMuonValHistoPublisher(const char* newFile="NEW_FILE",const char* refFile="REF_FILE") {
   cout << ">> Starting RecoMuonValHistoPublisher(" << newFile << "," << refFile << ")..." << endl;
 
   //====  To be replaced from python ====================
   
-  char* dataType = "DATATYPE";
-  char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
-  char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
-  char* fastSim = "IS_FSIM";
+  const char* dataType = "DATATYPE";
+  const char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
+  const char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
+  const char* fastSim = "IS_FSIM";
 
 
   // ==== Initial settings and loads
   //gROOT->ProcessLine(".x HistoCompare_Tracks.C");
   //gROOT ->Reset();
   gROOT ->SetBatch();
-  gROOT->LoadMacro("macro/PlotHelpers.C");
   gErrorIgnoreLevel = kWarning; // Get rid of the info messages
 
 
@@ -95,7 +95,8 @@ void RecoMuonValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE"
     TString newDir("NEW_RELEASE/NEWSELECTION/NEW_LABEL/");
     newDir+=myName;
     gSystem->mkdir(newDir,kTRUE);
-    bool *resol = false;
+    bool resolx = false;
+    bool *resol = &resolx;
     bool    logy    [] = {false,   false,  false,      false    };
     bool    doKolmo [] = {true,    true,   true,       true     };
     Double_t minx   [] = {-1E100, -1E100,    -1E100,   5.,    -1E100, -1E100 };

--- a/Validation/RecoMuon/test/macro/RecoValHistoPublisher.C
+++ b/Validation/RecoMuon/test/macro/RecoValHistoPublisher.C
@@ -1,25 +1,25 @@
 #include <vector>
 #include <algorithm>
 #include "TMath.h"
+#include "PlotHelpers.C"
 
 // Uncomment the following line for some extra debug information
 // #define DEBUG
 
-void RecoValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
+void RecoValHistoPublisher(const char* newFile="NEW_FILE",const char* refFile="REF_FILE") {
   cout << ">> Starting RecoValHistoPublisher(" << newFile << "," << refFile << ")..." << endl;
 
   //====  To be replaced from python ====================
   
-  char* dataType = "DATATYPE";
-  char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
-  char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
+  const char* dataType = "DATATYPE";
+  const char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
+  const char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
 
 
   // ==== Initial settings and loads
   //gROOT->ProcessLine(".x HistoCompare_Tracks.C");
   //gROOT ->Reset();
   gROOT ->SetBatch();
-  gROOT->LoadMacro("macro/PlotHelpers.C");
   gErrorIgnoreLevel = kWarning; // Get rid of the info messages
 
   
@@ -117,7 +117,8 @@ void RecoValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
     newDir+=myName;
     gSystem->mkdir(newDir,kTRUE);
     
-    bool *resol = false;
+    bool resolx = false;
+    bool *resol = &resolx;
     bool    logy    [] = {false,   false,  false,      false    };
     bool    doKolmo [] = {true,    true,   true,       true     };
     Double_t minx   [] = {-1E100, -1E100,    5.,   -1E100,    -1E100, -1E100 };

--- a/Validation/RecoMuon/test/macro/SeedValHistoPublisher.C
+++ b/Validation/RecoMuon/test/macro/SeedValHistoPublisher.C
@@ -1,26 +1,26 @@
 #include <vector>
 #include <algorithm>
 #include "TMath.h"
+#include "PlotHelpers.C"
 
 
 //Uncomment the following line to get some more output
 //#define DEBUG 1
 
-void SeedValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
+void SeedValHistoPublisher(const char* newFile="NEW_FILE",const char* refFile="REF_FILE") {
   cout << ">> Starting SeedValHistoPublisher(" << newFile << "," << refFile << ")..." << endl;
 
   //====  To be replaced from python ====================
   
-  char* dataType = "DATATYPE";
-  char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
-  char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
+  const char* dataType = "DATATYPE";
+  const char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
+  const char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
 
 
   // ==== Initial settings and loads
   //gROOT->ProcessLine(".x HistoCompare_Tracks.C");
   //gROOT ->Reset();
   gROOT ->SetBatch();
-  gROOT->LoadMacro("macro/PlotHelpers.C");
   gErrorIgnoreLevel = kWarning; // Get rid of the info messages
 
   

--- a/Validation/RecoMuon/test/macro/TrackValHistoPublisher.C
+++ b/Validation/RecoMuon/test/macro/TrackValHistoPublisher.C
@@ -1,6 +1,8 @@
 #include <vector>
 #include <algorithm>
 #include "TMath.h"
+#include "PlotHelpers.C"
+
 
 //Uncomment the following line to get some more output
 //#define DEBUG 1
@@ -22,7 +24,7 @@ TList* GetListOfBranches(const char* dataType, TFile* file) {
   }
   else {
     cout << "ERROR: Data type " << dataType << " not allowed: only RECO and HLT are considered" << endl;
-    return;
+    return 0;
   }
 
   TDirectory * dir=gDirectory;
@@ -39,23 +41,22 @@ TList* GetListOfBranches(const char* dataType, TFile* file) {
 
 
 
-void TrackValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
+void TrackValHistoPublisher(const char* newFile="NEW_FILE",const char* refFile="REF_FILE") {
 
   cout << ">> Starting TrackValHistoPublisher(" 
        << newFile << "," << refFile << ")..." << endl;
 
   //====  To be replaced from python ====================
   
-  char* dataType = "DATATYPE";
-  char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
-  char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
+  const char* dataType = "DATATYPE";
+  const char* refLabel("REF_LABEL, REF_RELEASE REFSELECTION");
+  const char* newLabel("NEW_LABEL, NEW_RELEASE NEWSELECTION");
 
 
   // ==== Initial settings and loads
   //gROOT->ProcessLine(".x HistoCompare_Tracks.C");
   //gROOT ->Reset();
   gROOT ->SetBatch();
-  gROOT->LoadMacro("macro/PlotHelpers.C");
   gErrorIgnoreLevel = kWarning; // Get rid of the info messages
 
   
@@ -70,7 +71,7 @@ void TrackValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
 
   bool ctf=1;
 
-  bool *resol=0;
+  bool resol = false;
 
   // ==== Some cleaning... is this needed?  
   delete gROOT->GetListOfFiles()->FindObject(refFile);
@@ -223,16 +224,16 @@ void TrackValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
       bool goodAsWell = false;
       if (rcollname.BeginsWith("StandAloneMuons_UpdAtVtx") && 
 	  scollname.BeginsWith("StandAloneMuons_UpdAtVtx")) {
-	if (rcollname.Contains("MuonAssociation")==scollname.Contains("MuonAssociation"));
+	if (rcollname.Contains("MuonAssociation")==scollname.Contains("MuonAssociation")){}
 	goodAsWell = true;
       }
       if (rcollname.BeginsWith("hltL2Muons_UpdAtVtx") && 
 	  scollname.BeginsWith("hltL2Muons_UpdAtVtx")) {
-	if (rcollname.Contains("MuonAssociation")==scollname.Contains("MuonAssociation"));
+	if (rcollname.Contains("MuonAssociation")==scollname.Contains("MuonAssociation")){}
 	goodAsWell = true;
       }
       if (rcollname.BeginsWith("hltL3Tk") && scollname.BeginsWith("hltL3Tk")) {
-	if (rcollname.Contains("MuonAssociation")==scollname.Contains("MuonAssociation"));
+	if (rcollname.Contains("MuonAssociation")==scollname.Contains("MuonAssociation")){}
 	goodAsWell = true;
       }
       //     TString isGood = (goodAsWell? "good": "NOT good");
@@ -241,34 +242,34 @@ void TrackValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
 	
 	if (rcollname.Contains("SET") && !scollname.Contains("SET")) {
 	  while (rcollname.Contains("SET")) {
-	    if (rKey = (TKey*)iter_r())  rcollname = rKey->GetName();
+	    if ((rKey = (TKey*)iter_r()))  rcollname = rKey->GetName();
 	  }
 	}
 	else if (scollname.Contains("SET") && !rcollname.Contains("SET")) {
 	  while (scollname.Contains("SET")) {
-	    if (sKey = (TKey*)iter_s())  scollname = sKey->GetName();
+	    if ((sKey = (TKey*)iter_s()))  scollname = sKey->GetName();
 	  }
 	}
 	
 	if (rcollname.Contains("dyt") && !scollname.Contains("dyt")) {
 	  while (rcollname.Contains("dyt")) {
-	    if (rKey = (TKey*)iter_r())  rcollname = rKey->GetName();
+	    if ((rKey = (TKey*)iter_r()))  rcollname = rKey->GetName();
 	  }
 	}
 	else if (scollname.Contains("dyt") && !rcollname.Contains("dyt")) {
 	  while (scollname.Contains("dyt")) {
-	    if (sKey = (TKey*)iter_s())  scollname = sKey->GetName();
+	    if ((sKey = (TKey*)iter_s()))  scollname = sKey->GetName();
 	  }
 	}
 	
 	if (rcollname.Contains("refitted") && !scollname.Contains("refitted")) {
 	  while (rcollname.Contains("refitted")) {
-	    if (rKey = (TKey*)iter_r())  rcollname = rKey->GetName();
+	    if ((rKey = (TKey*)iter_r()))  rcollname = rKey->GetName();
 	  }
 	}
 	else if (scollname.Contains("refitted") && !rcollname.Contains("refitted")) {
 	  while (scollname.Contains("refitted")) {
-	    if (sKey = (TKey*)iter_s())  scollname = sKey->GetName();
+	    if ((sKey = (TKey*)iter_s()))  scollname = sKey->GetName();
 	  }
 	}
 	
@@ -309,16 +310,16 @@ void TrackValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
     if (ctf) {
       //===== building
       
-     const char* plots1[] = {"effic", "fakerate", "efficPt", "fakeratePt"};
-      const char* plotsl1[] = {"efficiency vs #eta", "fakerate vs #eta", "efficiency vs Pt", "fakerate vs Pt"};
-      bool    logy [] = {false,  false, false,  false  };
+     const char* plots0[] = {"effic", "fakerate", "efficPt", "fakeratePt"};
+      const char* plotsl0[] = {"efficiency vs #eta", "fakerate vs #eta", "efficiency vs Pt", "fakerate vs Pt"};
+      bool    logy0 [] = {false,  false, false,  false  };
       Plot4Histograms(newDir + "/building.pdf",
                       rdir, sdir, 
                       rcollname, scollname,
                       "Seeds", "Efficiency Vs Pt and Vs #eta",
                       refLabel, newLabel,
-                      plots1, plotsl1,
-                      logy, doKolmo, norm,0,minx,maxx,miny,maxy);     
+                      plots0, plotsl0,
+                      logy0, doKolmo, norm,0,minx,maxx,miny,maxy);     
       cout<<"HICE EL HISTO "<<endl;
 
       const char* plots1[] = { "effic_vs_hit", "fakerate_vs_hit","effic_vs_phi","fakerate_vs_phi"};
@@ -401,7 +402,7 @@ void TrackValHistoPublisher(char* newFile="NEW_FILE",char* refFile="REF_FILE") {
 		      "residualdis", "residuals vs Pt",
 		      refLabel, newLabel,
 		      plots5, plotsl5,
-		      logyfalse, doKolmo, norm2,resol);    
+		      logyfalse, doKolmo, norm2,&resol);    
       
       
       

--- a/Validation/RecoParticleFlow/Benchmarks/ElectronRejectionBenchmark/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/ElectronRejectionBenchmark/plot.C
@@ -37,25 +37,25 @@ TString dir = "DQMData/PFTask/Benchmarks/PFTauElecRejection/Gen";
 
 TCanvas c1;
 Styles::FormatPad( &c1, false );
-c1->Divide(4,2);
+c1.Divide(4,2);
 
 Styles styles;
 Style* s1 = styles.s1;
 Style* s2 = styles.s2;
 
 //////
-c1->cd(1);
+c1.cd(1);
 f1.cd(dir);
-TH1F* htau_EoP = (TH1F*) gDirectory.Get("EoverP");
+TH1F* htau_EoP = (TH1F*) gDirectory->Get("EoverP");
 //htau_EoP.Rebin(2);
 Styles::FormatHisto(htau_EoP, s1);
-htau_EoP.Draw();
+htau_EoP->Draw();
 
 f2.cd(dir);
-TH1F* helec_EoP = (TH1F*) gDirectory.Get("EoverP");
+TH1F* helec_EoP = (TH1F*) gDirectory->Get("EoverP");
 //helec_EoP.Rebin(2);
 Styles::FormatHisto(helec_EoP, s2);
-helec_EoP.Draw("same");
+helec_EoP->Draw("same");
 
 c1_1->SetLogy(1);
 if (normHists) {
@@ -68,18 +68,18 @@ fillPerfGraphESUM(eopPerf,htau_EoP,helec_EoP);
 
 
 //////
-c1->cd(2);
+c1.cd(2);
 f1.cd(dir);
-TH1F* htau_HoP = (TH1F*) gDirectory.Get("HoverP");
+TH1F* htau_HoP = (TH1F*) gDirectory->Get("HoverP");
 //htau_HoP.Rebin(2);
 Styles::FormatHisto(htau_HoP, s1);
-htau_HoP.Draw();
+htau_HoP->Draw();
 
 f2.cd(dir);
-TH1F* helec_HoP = (TH1F*) gDirectory.Get("HoverP");
+TH1F* helec_HoP = (TH1F*) gDirectory->Get("HoverP");
 //helec_HoP.Rebin(2);
 Styles::FormatHisto(helec_HoP, s2);
-helec_HoP.Draw("same");
+helec_HoP->Draw("same");
 
 c1_2->SetLogy(1);
 if (normHists) {
@@ -92,18 +92,18 @@ fillPerfGraphHoP(h3x3Perf,htau_HoP,helec_HoP);
 
 /*
 //////
-c1->cd(3);
+c1.cd(3);
 f1.cd(dir);
-TH1F* htau_epreid = (TH1F*) gDirectory.Get("ElecPreID");
+TH1F* htau_epreid = (TH1F*) gDirectory->Get("ElecPreID");
 //htau_epreid.Rebin(2);
 Styles::FormatHisto(htau_epreid, s1);
-htau_epreid.Draw();
+htau_epreid->Draw();
 
 f2.cd(dir);
-TH1F* helec_epreid = (TH1F*) gDirectory.Get("ElecPreID");
+TH1F* helec_epreid = (TH1F*) gDirectory->Get("ElecPreID");
 //helec_epreid.Rebin(2);
 Styles::FormatHisto(helec_epreid, s2);
-helec_epreid.Draw("same");
+helec_epreid->Draw("same");
 
 c1_3->SetLogy(1);
 if (normHists) {
@@ -117,18 +117,18 @@ fillPerfGraphEPreID(epreidPerf,htau_epreid,helec_epreid);
 
 
 //////
-c1->cd(4);
+c1.cd(4);
 f1.cd(dir);
-TH1F* htau_etauD = (TH1F*) gDirectory.Get("TauElecDiscriminant");
+TH1F* htau_etauD = (TH1F*) gDirectory->Get("TauElecDiscriminant");
 //htau_etauD.Rebin(2);
 Styles::FormatHisto(htau_etauD, s1);
-htau_etauD.Draw();
+htau_etauD->Draw();
 
 f2.cd(dir);
-TH1F* helec_etauD = (TH1F*) gDirectory.Get("TauElecDiscriminant");
+TH1F* helec_etauD = (TH1F*) gDirectory->Get("TauElecDiscriminant");
 //helec_etauD.Rebin(2);
 Styles::FormatHisto(helec_etauD, s2);
-helec_etauD.Draw("same");
+helec_etauD->Draw("same");
 
 c1_4->SetLogy(1);
 if (normHists) {
@@ -140,13 +140,13 @@ TGraph* discriminantPerf = new TGraph();
 fillPerfGraphDiscr(discriminantPerf,htau_etauD,helec_etauD);
 
 //////
-c1->cd(5);
+c1,cd(5);
 f1.cd(dir);
-TH2F* htau_hvseop_preid0 = (TH2F*) gDirectory.Get("HoPvsEoP_preid0");
+TH2F* htau_hvseop_preid0 = (TH2F*) gDirectory->Get("HoPvsEoP_preid0");
 //htau_hvseop_preid0.Rebin(2);
-htau_hvseop_preid0.SetLineColor(kBlack);
-htau_hvseop_preid0.SetLineWidth(2);
-htau_hvseop_preid0.Draw("box");
+htau_hvseop_preid0->SetLineColor(kBlack);
+htau_hvseop_preid0->SetLineWidth(2);
+htau_hvseop_preid0->Draw("box");
 
 TLine li1;li1.SetLineWidth(2.);li1.SetLineColor(kBlue);
 li1.DrawLine(0.95,0.05,2.,0.05);
@@ -154,47 +154,47 @@ TLine li2;li2.SetLineWidth(2.);li2.SetLineColor(kBlue);
 li2.DrawLine(0.95,0.,0.95,0.05);
 
 //////
-c1->cd(6);
+c1.cd(6);
 f2.cd(dir);
-TH2F* helec_hvseop_preid0 = (TH2F*) gDirectory.Get("HoPvsEoP_preid0");
-helec_hvseop_preid0.SetLineColor(kBlue);
-helec_hvseop_preid0.SetLineWidth(2);
-helec_hvseop_preid0.Draw("box");
+TH2F* helec_hvseop_preid0 = (TH2F*) gDirectory->Get("HoPvsEoP_preid0");
+helec_hvseop_preid0->SetLineColor(kBlue);
+helec_hvseop_preid0->SetLineWidth(2);
+helec_hvseop_preid0->Draw("box");
 
-TLine li1;li1.SetLineWidth(2.);li1.SetLineColor(kBlue);
+li1.SetLineWidth(2.);li1.SetLineColor(kBlue);
 li1.DrawLine(0.95,0.05,2.,0.05);
-TLine li2;li2.SetLineWidth(2.);li2.SetLineColor(kBlue);
+li2.SetLineWidth(2.);li2.SetLineColor(kBlue);
 li2.DrawLine(0.95,0.,0.95,0.05);
 
 
 //////
-c1->cd(7);
+c1.cd(7);
 f1.cd(dir);
-TH2F* htau_hvseop_preid1 = (TH2F*) gDirectory.Get("HoPvsEoP_preid1");
-htau_hvseop_preid1.SetLineColor(kBlack);
-htau_hvseop_preid1.SetLineWidth(2);
-htau_hvseop_preid1.Draw("box");
+TH2F* htau_hvseop_preid1 = (TH2F*) gDirectory->Get("HoPvsEoP_preid1");
+htau_hvseop_preid1->SetLineColor(kBlack);
+htau_hvseop_preid1->SetLineWidth(2);
+htau_hvseop_preid1->Draw("box");
 
-TLine li1;li1.SetLineWidth(2.);li1.SetLineColor(kRed);
+li1.SetLineWidth(2.);li1.SetLineColor(kRed);
 li1.DrawLine(0.8,0.15,2.,0.15);
-TLine li2;li2.SetLineWidth(2.);li2.SetLineColor(kRed);
+li2.SetLineWidth(2.);li2.SetLineColor(kRed);
 li2.DrawLine(0.8,0.,0.8,0.15);
 
 //////
-c1->cd(8);
+c1.cd(8);
 f2.cd(dir);
-TH2F* helec_hvseop_preid1 = (TH2F*) gDirectory.Get("HoPvsEoP_preid1");
-helec_hvseop_preid1.SetLineColor(kBlue);
-helec_hvseop_preid1.SetLineWidth(2);
-helec_hvseop_preid1.Draw("box");
+TH2F* helec_hvseop_preid1 = (TH2F*) gDirectory->Get("HoPvsEoP_preid1");
+helec_hvseop_preid1->SetLineColor(kBlue);
+helec_hvseop_preid1->SetLineWidth(2);
+helec_hvseop_preid1->Draw("box");
 
-TLine li1;li1.SetLineWidth(2.);li1.SetLineColor(kRed);
+li1.SetLineWidth(2.);li1.SetLineColor(kRed);
 li1.DrawLine(0.8,0.15,2.,0.15);
-TLine li2;li2.SetLineWidth(2.);li2.SetLineColor(kRed);
+li2.SetLineWidth(2.);li2.SetLineColor(kRed);
 li2.DrawLine(0.8,0.,0.8,0.15);
 
 //////
-c1->cd();
+c1.cd();
 gPad->SaveAs(plotName+"1.gif");
 
 
@@ -202,21 +202,21 @@ gPad->SaveAs(plotName+"1.gif");
 
 TCanvas c2;
 Styles::FormatPad( &c2, false );
-c2->Divide(3,2);
+c2.Divide(3,2);
 
 //////
-c2->cd(1);
+c2.cd(1);
 f1.cd(dir);
-TH1F* htau_deltaEta = (TH1F*) gDirectory.Get("pfcand_deltaEta");
+TH1F* htau_deltaEta = (TH1F*) gDirectory->Get("pfcand_deltaEta");
 //htau_deltaEta.Rebin(2);
 Styles::FormatHisto(htau_deltaEta, s1);
-htau_deltaEta.Draw();
+htau_deltaEta->Draw();
 
 f2.cd(dir);
-TH1F* helec_deltaEta = (TH1F*) gDirectory.Get("pfcand_deltaEta");
+TH1F* helec_deltaEta = (TH1F*) gDirectory->Get("pfcand_deltaEta");
 //helec_deltaEta.Rebin(2);
 Styles::FormatHisto(helec_deltaEta, s2);
-helec_deltaEta.Draw("same");
+helec_deltaEta->Draw("same");
 
 gPad->SetLogy(1);
 if (normHists) {
@@ -224,18 +224,18 @@ if (normHists) {
 }
 
 //////
-c2->cd(2);
+c2.cd(2);
 f1.cd(dir);
-TH1F* htau_deltaPhiOverQ = (TH1F*) gDirectory.Get("pfcand_deltaPhiOverQ");
+TH1F* htau_deltaPhiOverQ = (TH1F*) gDirectory->Get("pfcand_deltaPhiOverQ");
 //htau_deltaPhiOverQ.Rebin(2);
 Styles::FormatHisto(htau_deltaPhiOverQ, s1);
-htau_deltaPhiOverQ.Draw();
+htau_deltaPhiOverQ->Draw();
 
 f2.cd(dir);
-TH1F* helec_deltaPhiOverQ = (TH1F*) gDirectory.Get("pfcand_deltaPhiOverQ");
+TH1F* helec_deltaPhiOverQ = (TH1F*) gDirectory->Get("pfcand_deltaPhiOverQ");
 //helec_deltaPhiOverQ.Rebin(2);
 Styles::FormatHisto(helec_deltaPhiOverQ, s2);
-helec_deltaPhiOverQ.Draw("same");
+helec_deltaPhiOverQ->Draw("same");
 
 gPad->SetLogy(1);
 if (normHists) {
@@ -243,18 +243,18 @@ if (normHists) {
 }
 
 //////
-c2->cd(4);
+c2.cd(4);
 f1.cd(dir);
-TH1F* htau_leadTk_pt = (TH1F*) gDirectory.Get("leadTk_pt");
+TH1F* htau_leadTk_pt = (TH1F*) gDirectory->Get("leadTk_pt");
 //htau_leadTk_pt.Rebin(2);
 Styles::FormatHisto(htau_leadTk_pt, s1);
-htau_leadTk_pt.Draw();
+htau_leadTk_pt->Draw();
 
 f2.cd(dir);
-TH1F* helec_leadTk_pt = (TH1F*) gDirectory.Get("leadTk_pt");
+TH1F* helec_leadTk_pt = (TH1F*) gDirectory->Get("leadTk_pt");
 //helec_leadTk_pt.Rebin(2);
 Styles::FormatHisto(helec_leadTk_pt, s2);
-helec_leadTk_pt.Draw("same");
+helec_leadTk_pt->Draw("same");
 
 gPad->SetLogy(1);
 if (normHists) {
@@ -262,18 +262,18 @@ if (normHists) {
 }
 
 //////
-c2->cd(5);
+c2.cd(5);
 f1.cd(dir);
-TH1F* htau_leadTk_eta = (TH1F*) gDirectory.Get("leadTk_eta");
+TH1F* htau_leadTk_eta = (TH1F*) gDirectory->Get("leadTk_eta");
 //htau_leadTk_eta.Rebin(2);
 Styles::FormatHisto(htau_leadTk_eta, s1);
-htau_leadTk_eta.Draw();
+htau_leadTk_eta->Draw();
 
 f2.cd(dir);
-TH1F* helec_leadTk_eta = (TH1F*) gDirectory.Get("leadTk_eta");
+TH1F* helec_leadTk_eta = (TH1F*) gDirectory->Get("leadTk_eta");
 //helec_leadTk_eta.Rebin(2);
 Styles::FormatHisto(helec_leadTk_eta, s2);
-helec_leadTk_eta.Draw("same");
+helec_leadTk_eta->Draw("same");
 
 gPad->SetLogy(1);
 if (normHists) {
@@ -281,18 +281,18 @@ if (normHists) {
 }
 
 //////
-c2->cd(6);
+c2.cd(6);
 f1.cd(dir);
-TH1F* htau_leadTk_phi = (TH1F*) gDirectory.Get("leadTk_phi");
+TH1F* htau_leadTk_phi = (TH1F*) gDirectory->Get("leadTk_phi");
 //htau_leadTk_phi.Rebin(2);
 Styles::FormatHisto(htau_leadTk_phi, s1);
-htau_leadTk_phi.Draw();
+htau_leadTk_phi->Draw();
 
 f2.cd(dir);
-TH1F* helec_leadTk_phi = (TH1F*) gDirectory.Get("leadTk_phi");
+TH1F* helec_leadTk_phi = (TH1F*) gDirectory->Get("leadTk_phi");
 //helec_leadTk_phi.Rebin(2);
 Styles::FormatHisto(helec_leadTk_phi, s2);
-helec_leadTk_phi.Draw("same");
+helec_leadTk_phi->Draw("same");
 
 gPad->SetLogy(1);
 if (normHists) {
@@ -300,18 +300,18 @@ if (normHists) {
 }
 
 //////
-c2->cd(3);
+c2.cd(3);
 f1.cd(dir);
-TH1F* htau_mva = (TH1F*) gDirectory.Get("ElecMVA");
+TH1F* htau_mva = (TH1F*) gDirectory->Get("ElecMVA");
 //htau_mva.Rebin(2);
 Styles::FormatHisto(htau_mva, s1);
-htau_mva.Draw();
+htau_mva->Draw();
 
 f2.cd(dir);
-TH1F* helec_mva = (TH1F*) gDirectory.Get("ElecMVA");
+TH1F* helec_mva = (TH1F*) gDirectory->Get("ElecMVA");
 //helec_mva.Rebin(2);
 Styles::FormatHisto(helec_mva, s2);
-helec_mva.Draw("same");
+helec_mva->Draw("same");
 
 
 // fill performance graphs
@@ -331,9 +331,9 @@ if (normHists) {
 
 TCanvas c3;
 Styles::FormatPad( &c3, false );
-c3->Divide(2,1);
+c3.Divide(2,1);
 
-c3->cd(1);
+c3.cd(1);
 gPad->SetLogy(0);
 gPad->DrawFrame(0.58,0.,1.,0.102);
 //gPad->DrawFrame(0.,0.,1.,1.);
@@ -401,7 +401,7 @@ l.SetTextFont(40);
 
 
 //////
-c3->cd(2);
+c3.cd(2);
 
 TLegend* leg = new TLegend(0.1,0.1,0.89,0.89);
 leg->SetHeader("Electron vs. tau efficiency");
@@ -420,7 +420,7 @@ gPad->Update();
 gPad->Modified();
 
 //////
-c3->cd();
+c3.cd();
 gPad->SaveAs(plotName+"2.gif");
 
 

--- a/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/Fractions.C
+++ b/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/Fractions.C
@@ -34,20 +34,20 @@ gSystem->Load("libValidationRecoParticleFlow.so");
 
 TFile* fast = new TFile(fileFast);
 gStyle->SetOptStat(0);
-TProfile* fastChBrFrac  = ((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRCHEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fastEmBrFrac  = ((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNEEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fastHaBrFrac  = ((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNHEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fastChEnFrac  = ((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERCHEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fastEmEnFrac  = ((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNEEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fastHaEnFrac  = ((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNHEvsPt"))->ProfileX()->Rebin(5);
+TProfile* fastChBrFrac  = dynamic_cast<TProfile*>(((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRCHEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fastEmBrFrac  = dynamic_cast<TProfile*>(((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNEEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fastHaBrFrac  = dynamic_cast<TProfile*>(((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNHEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fastChEnFrac  = dynamic_cast<TProfile*>(((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERCHEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fastEmEnFrac  = dynamic_cast<TProfile*>(((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNEEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fastHaEnFrac  = dynamic_cast<TProfile*>(((TH2F*) fast->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNHEvsPt"))->ProfileX()->Rebin(5));
 
 TFile* full = new TFile(fileFull);
-TProfile* fullChBrFrac  = ((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRCHEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fullEmBrFrac  = ((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNEEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fullHaBrFrac  = ((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNHEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fullChEnFrac  = ((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERCHEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fullEmEnFrac  = ((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNEEvsPt"))->ProfileX()->Rebin(5);
-TProfile* fullHaEnFrac  = ((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNHEvsPt"))->ProfileX()->Rebin(5);
+TProfile* fullChBrFrac  = dynamic_cast<TProfile*>(((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRCHEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fullEmBrFrac  = dynamic_cast<TProfile*>(((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNEEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fullHaBrFrac  = dynamic_cast<TProfile*>(((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/BRNHEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fullChEnFrac  = dynamic_cast<TProfile*>(((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERCHEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fullEmEnFrac  = dynamic_cast<TProfile*>(((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNEEvsPt"))->ProfileX()->Rebin(5));
+TProfile* fullHaEnFrac  = dynamic_cast<TProfile*>(((TH2F*) full->Get("DQMData/PFTask/Benchmarks/ak5PFJets/Gen/ERNHEvsPt"))->ProfileX()->Rebin(5));
 
 TCanvas* c  = new TCanvas();
 c->cd();

--- a/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/JetBenchmarkSpecific/plot.C
@@ -1,11 +1,16 @@
 {
+
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libValidationRecoParticleFlow.so");
 
 //gROOT->LoadMacro("../Tools/NicePlot.C");
 //InitNicePlot();
 
+extern void ResolutionDirection(bool barrel, const char* input, const char* output, const char* title="");
+extern void Compare(unsigned barrel, const char* fastInput, const char* fullInput, const char* output, const char* title, unsigned algo1=0, unsigned algo2=0);
+
 gROOT->ProcessLine(".L makeJetResolutionPlot.C");
+gROOT->ProcessLine(".L ResolutionDirection.C");
 Resolution(1,"JetBenchmark_Fast_3110pre3.root","JetBenchmark_Fast_Barrel.png","Fast simulation - Barrel resolution");
  Resolution(1,"JetBenchmark_Full_3110pre3.root","JetBenchmark_Full_Barrel.png","Full simulation - Barrel resolution");
 Resolution(2,"JetBenchmark_Fast_3110pre3.root","JetBenchmark_Fast_Endcap.png","Fast simulation - Endcap resolution");

--- a/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/compare.C
+++ b/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/compare.C
@@ -98,9 +98,9 @@
   TCanvas c4("c4", "Calo vs Gen");
   Styles::FormatPad( &c4, false );
   gStyle->SetPalette(1);
-  TDirectory* dir = comp.dir1();
+  dir = comp.dir1();
   dir->cd();
-  TH2F *h2 = (TH2F*) dir->Get("RecEt_VS_TrueEt_");
+  h2 = (TH2F*) dir->Get("RecEt_VS_TrueEt_");
   h2->Draw("colz");
   Styles::SavePlot("Calo_vs_Gen", outdir.c_str() );
 
@@ -164,8 +164,8 @@
   Styles::SavePlot("deltaPhi_100_200", outdir.c_str() );
 
   mode = Comparator::GRAPH;
-  Style* style1gr = styles.sgr1;
-  Style* style2gr = styles.sgr2;
+  style1gr = styles.sgr1;
+  style2gr = styles.sgr2;
   comp.SetStyles(style1gr, style2gr, "Particle Flow Met", "Calo Met");
   comp.SetAxis(1, 0.0, 200.);
 

--- a/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot.C
@@ -97,9 +97,9 @@
   TCanvas c4("c4", "Calo vs Gen");
   Styles::FormatPad( &c4, false );
   gStyle->SetPalette(1);
-  TDirectory* dir = comp.dir1();
+  dir = comp.dir1();
   dir->cd();
-  TH2F *h2 = (TH2F*) dir->Get("RecEt_VS_TrueEt_");
+  h2 = (TH2F*) dir->Get("RecEt_VS_TrueEt_");
   h2->Draw("colz");
   Styles::SavePlot("Calo_vs_Gen", outdir.c_str() );
 
@@ -163,8 +163,8 @@
   Styles::SavePlot("deltaPhi_100_200", outdir.c_str() );
 
   mode = Comparator::GRAPH;
-  Style* style1gr = styles.sgr1;
-  Style* style2gr = styles.sgr2;
+  style1gr = styles.sgr1;
+  style2gr = styles.sgr2;
   comp.SetStyles(style1gr, style2gr, "Particle Flow Met", "Calo Met");
   comp.SetAxis(1, 0.0, 200.);
 

--- a/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot_QCD.C
+++ b/Validation/RecoParticleFlow/Benchmarks/METBenchmarkGeneric/plot_QCD.C
@@ -96,9 +96,9 @@
   TCanvas c4("c4", "Calo vs Gen");
   Styles::FormatPad( &c4, false );
   gStyle->SetPalette(1);
-  TDirectory* dir = comp.dir1();
+  dir = comp.dir1();
   dir->cd();
-  TH2F *h2 = (TH2F*) dir->Get("RecEt_VS_TrueEt_");
+  h2 = (TH2F*) dir->Get("RecEt_VS_TrueEt_");
   h2->Draw("colz");
   Styles::SavePlot("Calo_vs_Gen", outdir.c_str() );
 

--- a/Validation/RecoParticleFlow/Benchmarks/PFCandidateBenchmark/plot.C
+++ b/Validation/RecoParticleFlow/Benchmarks/PFCandidateBenchmark/plot.C
@@ -14,48 +14,63 @@
 
   TFile f(file);
   f.cd( dir.c_str() );
+  TPad* tPad = dynamic_cast<TPad*>(gPad);
 
-  pt_.Draw();
-  styles.FormatPad( gPad, true, false, true);
+  TH1* pt_ = 0;
+  gDirectory->GetObject("pt_", pt_);
+  pt_->Draw();
+  styles.FormatPad( tPad, true, false, true);
   styles.FormatHisto( pt_, styles.spred );
 
   TCanvas c2;
-  eta_.Draw();
-  styles.FormatPad( gPad, true, false, false);
+  TH1* eta_ = 0;
+  gDirectory->GetObject("eta_", eta_);
+  eta_->Draw();
+  styles.FormatPad( tPad, true, false, false);
   styles.FormatHisto( eta_, styles.spred );
 
   TCanvas c3;
-  phi_.Draw();
-  styles.FormatPad( gPad, true, false, false);
+  TH1* phi_ = 0;
+  gDirectory->GetObject("phi_", phi_);
+  phi_->Draw();
+  styles.FormatPad( tPad, true, false, false);
   styles.FormatHisto( phi_, styles.spred );
 
   TCanvas c4;
-  charge_.Draw();
-  styles.FormatPad( gPad, true, false, false);
+  TH1* charge_ = 0;
+  gDirectory->GetObject("charge_", charge_);
+  charge_->Draw();
+  styles.FormatPad( tPad, true, false, false);
   styles.FormatHisto( charge_, styles.spred );
 
   TCanvas c5;
-  particleId_.Draw();
-  styles.FormatPad( gPad, true, false, false);
+  TH1* particleId_ = 0;
+  gDirectory->GetObject("particleId_", particleId_);
+  particleId_->Draw();
+  styles.FormatPad( tPad, true, false, false);
   styles.FormatHisto( particleId_, styles.spred );
-  particleId_.GetXaxis()->SetBinLabel(1, "h+-");
-  particleId_.GetXaxis()->SetBinLabel(2, "e");
-  particleId_.GetXaxis()->SetBinLabel(3, "mu");
-  particleId_.GetXaxis()->SetBinLabel(4, "#gamma");
-  particleId_.GetXaxis()->SetBinLabel(5, "h0");
-  particleId_.GetXaxis()->SetBinLabel(6, "HF_h");
-  particleId_.GetXaxis()->SetBinLabel(7, "HF_em");
-  particleId_.GetXaxis()->SetLabelSize(0.06);
-  particleId_.GetXaxis()->SetLabelOffset(0.02);
+  particleId_->GetXaxis()->SetBinLabel(1, "h+-");
+  particleId_->GetXaxis()->SetBinLabel(2, "e");
+  particleId_->GetXaxis()->SetBinLabel(3, "mu");
+  particleId_->GetXaxis()->SetBinLabel(4, "#gamma");
+  particleId_->GetXaxis()->SetBinLabel(5, "h0");
+  particleId_->GetXaxis()->SetBinLabel(6, "HF_h");
+  particleId_->GetXaxis()->SetBinLabel(7, "HF_em");
+  particleId_->GetXaxis()->SetLabelSize(0.06);
+  particleId_->GetXaxis()->SetLabelOffset(0.02);
 
   TCanvas c6;
-  elementsInBlocksSize_.Draw();
-  styles.FormatPad( gPad, true, false, true);
+  TH1* elementsInBlocksSize_ = 0;
+  gDirectory->GetObject("elementsInBlocksSize_", elementsInBlocksSize_);
+  elementsInBlocksSize_->Draw();
+  styles.FormatPad( tPad, true, false, true);
   styles.FormatHisto( elementsInBlocksSize_, styles.spred );
   
   TCanvas c7;
-  delta_et_Over_et_VS_et_.Draw("colz");
-  styles.FormatPad( gPad, false, false, false);
+  TH1* delta_et_Over_et_VS_et_ = 0;
+  gDirectory->GetObject("delta_et_Over_et_VS_et_", delta_et_Over_et_VS_et_);
+  delta_et_Over_et_VS_et_->Draw("colz");
+  styles.FormatPad( tPad, false, false, false);
 //   styles.FormatHisto( delta_pt_, styles.spred );
   
 }

--- a/Validation/RecoParticleFlow/interface/Comparator.h
+++ b/Validation/RecoParticleFlow/interface/Comparator.h
@@ -82,7 +82,8 @@ public:
   TH1* h0() {return h0_;}
   TH1* h1() {return h1_;}
 
-  const TLegend& Legend() {return legend_;}
+  TLegend& Legend() {return legend_;}
+  const TLegend& Legend() const {return legend_;}
   
   // set the styles for further plots
   void SetStyles( Style* s0, 


### PR DESCRIPTION
Do not forward this PR to CMSSW_7_5_ROOT5_X. It is ROOT6 only.
In ROOT6 macros are processed by cling, rather than CINT. Over 500 CMSSW macros do not compile in ROOT6. Since that is too many macros to be fixed centrally, it was decided by David Lange to centrally fix only those 45 macros with compilation errors that have been modified since the switch over to git, since those are the ones most likely to be used. Many of these 45 macros are in the DQM L2 category. This pull request fixes them.
Note 1: While this PR fixes all the compilation errors in these macros, one macro, JetBenchmarkSpecific/plot.C still has link errors that I was not able to easily fix. Still, the fact that now compiles is an improvement.
Note 2:  The declaration of function TLegend() Validation/RecoParticleFlow/interface/Comparator.h needed to be fixed.  The function returned a const reference, but was not declared const.  This caused macros to fail.  I fixed the declaration by marking the function const.  Just in case a non-const function was needed somewhere, I added a correct non-const TLegend() function.
