### PR TITLE
create a directory with FastSim examples

### DIFF
--- a/FastSimulation/Examples/test/README.md
+++ b/FastSimulation/Examples/test/README.md
@@ -1,0 +1,1 @@
+# FastSim examples


### PR DESCRIPTION
To help managing release-specific FastSim documentation we introduce a new directory FastSimulation/Examples

Purpose is to maintain a set of cff and cmsDriver commands in this directory 
This pr is ~empty,

As soon as we have the directory in the release we'll start filling it.
