### PR TITLE
Disable Not Working leading edge recovery for saturated ECAL RecHits (7_4_X back-port)

### DIFF
--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
@@ -270,13 +270,7 @@ EcalUncalibRecHitWorkerGlobal::run( const edm::Event & evt,
         }
 
         if ( leadingSample == 4 ) { // saturation on the expected max sample
-               float sratio = 1;
-               if ( detid.subdetId()==EcalBarrel) {
-                       sratio = ebPulseShape_[5] / ebPulseShape_[4];
-               } else {
-                       sratio = eePulseShape_[5] / eePulseShape_[4];
-               }
-	       uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12*sratio, 0, 0, 0);
+	       uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12, 0, 0, 0);
                uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
 	       // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
                uncalibRecHit.setChi2(0);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
@@ -46,9 +46,10 @@ EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::Paramete
 
 	// spike threshold
         ebSpikeThresh_ = ps.getParameter<double>("ebSpikeThreshold");
-        // leading edge parameters
+
         ebPulseShape_ = ps.getParameter<std::vector<double> >("ebPulseShape");
         eePulseShape_ = ps.getParameter<std::vector<double> >("eePulseShape");
+
 	// chi2 parameters
         kPoorRecoFlagEB_ = ps.getParameter<bool>("kPoorRecoFlagEB");
 	kPoorRecoFlagEE_ = ps.getParameter<bool>("kPoorRecoFlagEE");;
@@ -89,7 +90,7 @@ EcalUncalibRecHitWorkerGlobal::EcalUncalibRecHitWorkerGlobal(const edm::Paramete
 
 	// spike threshold
         ebSpikeThresh_ = ps.getParameter<double>("ebSpikeThreshold");
-        // leading edge parameters
+
         ebPulseShape_ = ps.getParameter<std::vector<double> >("ebPulseShape");
         eePulseShape_ = ps.getParameter<std::vector<double> >("eePulseShape");
 	// chi2 parameters
@@ -117,7 +118,6 @@ EcalUncalibRecHitWorkerGlobal::set(const edm::EventSetup& es)
 
         // for the ratio method
 
-        // for the leading edge method
         es.get<EcalTimeCalibConstantsRcd>().get(itime);
         es.get<EcalTimeOffsetConstantRcd>().get(offtime);
 
@@ -270,42 +270,17 @@ EcalUncalibRecHitWorkerGlobal::run( const edm::Event & evt,
         }
 
         if ( leadingSample >= 0 ) { // saturation
-                if ( leadingSample != 4 ) {
-                        // all samples different from the fifth are not reliable for the amplitude estimation
-                        // put by default the energy at the saturation threshold and flag as saturated
-                        float sratio = 1;
-                        if ( detid.subdetId()==EcalBarrel) {
-                                sratio = ebPulseShape_[5] / ebPulseShape_[4];
-                        } else {
-                                sratio = eePulseShape_[5] / eePulseShape_[4];
-                        }
-			uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12*sratio, 0, 0, 0);
-                        uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
+                // all samples different from the fifth are not reliable for the amplitude estimation
+                // put by default the energy at the saturation threshold and flag as saturated
+                // fifth sample also not reliable due to stron non-linearity induced by the slew-rate limit in gain 12
+                float sratio = 1;
+                if ( detid.subdetId()==EcalBarrel) {
+                        sratio = ebPulseShape_[5] / ebPulseShape_[4];
                 } else {
-                        // float clockToNsConstant = 25.;
-                        // reconstruct the rechit
-                        if (detid.subdetId()==EcalEndcap) {
-                                leadingEdgeMethod_endcap_.setPulseShape( eePulseShape_ );
-                                // float mult = (float)eePulseShape_.size() / (float)(*itdg).size();
-                                // bin (or some analogous mapping) will be used instead of the leadingSample
-                                //int bin  = (int)(( (mult * leadingSample + mult/2) * clockToNsConstant + itimeconst ) / clockToNsConstant);
-                                // bin is not uset for the moment
-                                leadingEdgeMethod_endcap_.setLeadingEdgeSample( leadingSample );
-                                uncalibRecHit = leadingEdgeMethod_endcap_.makeRecHit(*itdg, pedVec, gainRatios, 0, 0);
-                                uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kLeadingEdgeRecovered );
-                                leadingEdgeMethod_endcap_.setLeadingEdgeSample( -1 );
-                        } else {
-                                leadingEdgeMethod_barrel_.setPulseShape( ebPulseShape_ );
-                                // float mult = (float)ebPulseShape_.size() / (float)(*itdg).size();
-                                // bin (or some analogous mapping) will be used instead of the leadingSample
-                                //int bin  = (int)(( (mult * leadingSample + mult/2) * clockToNsConstant + itimeconst ) / clockToNsConstant);
-                                // bin is not uset for the moment
-                                leadingEdgeMethod_barrel_.setLeadingEdgeSample( leadingSample );
-                                uncalibRecHit = leadingEdgeMethod_barrel_.makeRecHit(*itdg, pedVec, gainRatios, 0, 0);
-                                uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kLeadingEdgeRecovered );
-                                leadingEdgeMethod_barrel_.setLeadingEdgeSample( -1 );
-                        }
+                        sratio = eePulseShape_[5] / eePulseShape_[4];
                 }
+	        uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12*sratio, 0, 0, 0);
+                uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
 		// do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
                 uncalibRecHit.setChi2(0);
         } else {

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.cc
@@ -269,20 +269,39 @@ EcalUncalibRecHitWorkerGlobal::run( const edm::Event & evt,
                 leadingSample = ((EcalDataFrame)(*itdg)).lastUnsaturatedSample();
         }
 
-        if ( leadingSample >= 0 ) { // saturation
-                // all samples different from the fifth are not reliable for the amplitude estimation
-                // put by default the energy at the saturation threshold and flag as saturated
-                // fifth sample also not reliable due to stron non-linearity induced by the slew-rate limit in gain 12
-                float sratio = 1;
-                if ( detid.subdetId()==EcalBarrel) {
-                        sratio = ebPulseShape_[5] / ebPulseShape_[4];
-                } else {
-                        sratio = eePulseShape_[5] / eePulseShape_[4];
-                }
-	        uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12*sratio, 0, 0, 0);
-                uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
-		// do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
-                uncalibRecHit.setChi2(0);
+        if ( leadingSample == 4 ) { // saturation on the expected max sample
+               float sratio = 1;
+               if ( detid.subdetId()==EcalBarrel) {
+                       sratio = ebPulseShape_[5] / ebPulseShape_[4];
+               } else {
+                       sratio = eePulseShape_[5] / eePulseShape_[4];
+               }
+	       uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12*sratio, 0, 0, 0);
+               uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
+	       // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
+               uncalibRecHit.setChi2(0);
+        } else if ( leadingSample >= 0 ) { // saturation on other samples: cannot extrapolate from the fourth one
+               double pedestal = 0.;
+               double gainratio = 1.;
+               int gainId = ((EcalDataFrame)(*itdg)).sample(5).gainId();
+
+               if (gainId==0 || gainId==3) {
+                 pedestal = aped->mean_x1;
+                 gainratio = aGain->gain6Over1()*aGain->gain12Over6();
+               }
+               else if (gainId==1) {
+                 pedestal = aped->mean_x12;
+                 gainratio = 1.;
+               }
+               else if (gainId==2) {
+                 pedestal = aped->mean_x6;
+                 gainratio = aGain->gain12Over6();
+               }
+               double amplitude = ((double)(((EcalDataFrame)(*itdg)).sample(5).adc()) - pedestal) * gainratio;
+               uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), amplitude, 0, 0, 0);
+               uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
+               // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
+               uncalibRecHit.setChi2(0);
         } else {
                 // weights method
                 EcalTBWeights::EcalTDCId tdcid(1);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerGlobal.h
@@ -13,7 +13,6 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecWeightsAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecChi2Algo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h"
-#include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitLeadingEdgeAlgo.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeOffsetConstant.h"
@@ -102,13 +101,10 @@ class EcalUncalibRecHitWorkerGlobal : public EcalUncalibRecHitWorkerBaseClass {
 
                 edm::ESHandle<EcalTimeBiasCorrections> timeCorrBias_;
 
-                // leading edge method
                 edm::ESHandle<EcalTimeCalibConstants> itime;
 		edm::ESHandle<EcalTimeOffsetConstant> offtime;
                 std::vector<double> ebPulseShape_;
                 std::vector<double> eePulseShape_;
-                EcalUncalibRecHitLeadingEdgeAlgo<EBDataFrame> leadingEdgeMethod_barrel_;
-                EcalUncalibRecHitLeadingEdgeAlgo<EEDataFrame> leadingEdgeMethod_endcap_;
 
                 // chi2 method
 		bool kPoorRecoFlagEB_;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -322,13 +322,7 @@ EcalUncalibRecHitWorkerMultiFit::run( const edm::Event & evt,
         int leadingSample = ((EcalDataFrame)(*itdg)).lastUnsaturatedSample();
 
         if ( leadingSample == 4 ) { // saturation on the expected max sample
-               float sratio = 1;
-               if ( detid.subdetId()==EcalBarrel) {
-                       sratio = ebPulseShape_[5] / ebPulseShape_[4];
-               } else {
-                       sratio = eePulseShape_[5] / eePulseShape_[4];
-               }
-	       uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12*sratio, 0, 0, 0);
+	       uncalibRecHit = EcalUncalibratedRecHit( (*itdg).id(), 4095*12, 0, 0, 0);
                uncalibRecHit.setFlagBit( EcalUncalibratedRecHit::kSaturated );
 	       // do not propagate the default chi2 = -1 value to the calib rechit (mapped to 64), set it to 0 when saturation
                uncalibRecHit.setChi2(0);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -14,7 +14,6 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitTimeWeightsAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRecChi2Algo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitRatioMethodAlgo.h"
-#include "RecoLocalCalo/EcalRecAlgos/interface/EcalUncalibRecHitLeadingEdgeAlgo.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/EcalObjects/interface/EcalTimeCalibConstants.h"
@@ -131,13 +130,10 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
 
                 edm::ESHandle<EcalTimeBiasCorrections> timeCorrBias_;
 
-                // leading edge method
                 edm::ESHandle<EcalTimeCalibConstants> itime;
 		edm::ESHandle<EcalTimeOffsetConstant> offtime;
                 std::vector<double> ebPulseShape_;
                 std::vector<double> eePulseShape_;
-                EcalUncalibRecHitLeadingEdgeAlgo<EBDataFrame> leadingEdgeMethod_barrel_;
-                EcalUncalibRecHitLeadingEdgeAlgo<EEDataFrame> leadingEdgeMethod_endcap_;
 
 
                 // chi2 thresholds for flags settings

--- a/RecoLocalCalo/EcalRecProducers/test/testMultipleEcalRecoLocal_cfg.py
+++ b/RecoLocalCalo/EcalRecProducers/test/testMultipleEcalRecoLocal_cfg.py
@@ -8,11 +8,11 @@ process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
 process.load('Configuration.Geometry.GeometrySimDB_cff')
 process.load('Configuration.StandardSequences.MagneticField_38T_PostLS1_cff')
 process.load('Configuration.StandardSequences.EndOfProcess_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.load('Configuration.StandardSequences.RawToDigi_cff')
 process.load('Configuration.StandardSequences.Reconstruction_cff')
 
-process.GlobalTag.globaltag = 'POSTLS172_V1::All'
+process.GlobalTag.globaltag = 'GR_R_74_V10A'
 process.GlobalTag.toGet = cms.VPSet(
     cms.PSet(record = cms.string("GeometryFileRcd"),
              tag = cms.string("XMLFILE_Geometry_2015_72YV2_Extended2015ZeroMaterial_mc"),
@@ -39,13 +39,13 @@ process.ecalGlobalUncalibRecHit = RecoLocalCalo.EcalRecProducers.ecalGlobalUncal
 # get uncalib rechits from multifit method / time from ratio
 import RecoLocalCalo.EcalRecProducers.ecalMultiFitUncalibRecHit_cfi
 process.ecalMultiFitUncalibRecHit =  RecoLocalCalo.EcalRecProducers.ecalMultiFitUncalibRecHit_cfi.ecalMultiFitUncalibRecHit.clone()
-process.ecalMultiFitUncalibRecHit.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4)
-process.ecalMultiFitUncalibRecHit.useLumiInfoRunHeader = False
+process.ecalMultiFitUncalibRecHit.algoPSet.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4)
+process.ecalMultiFitUncalibRecHit.algoPSet.useLumiInfoRunHeader = cms.bool( False )
 # get uncalib rechits from multifit method / time from weights
 process.ecalMultiFit2UncalibRecHit =  RecoLocalCalo.EcalRecProducers.ecalMultiFitUncalibRecHit_cfi.ecalMultiFitUncalibRecHit.clone()
-process.ecalMultiFit2UncalibRecHit.timealgo = cms.string("WeightsMethod")
-process.ecalMultiFit2UncalibRecHit.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4)
-process.ecalMultiFit2UncalibRecHit.useLumiInfoRunHeader = False
+process.ecalMultiFit2UncalibRecHit.algoPSet.timealgo = cms.string("WeightsMethod")
+process.ecalMultiFit2UncalibRecHit.algoPSet.activeBXs = cms.vint32(-5,-4,-3,-2,-1,0,1,2,3,4)
+process.ecalMultiFit2UncalibRecHit.algoPSet.useLumiInfoRunHeader = cms.bool ( False )
 
 # get the recovered digis
 if isMC:
@@ -79,19 +79,10 @@ process.ecalRecHitMultiFit2.EBrechitCollection = 'EcalRecHitsMultiFit2EB'
 process.ecalRecHitMultiFit2.EErechitCollection = 'EcalRecHitsMultiFit2EE'
 
 process.maxEvents = cms.untracked.PSet(  input = cms.untracked.int32(1000) )
-path = '/store/group/dpg_ecal/comm_ecal/localreco/cmssw_720p4/photongun_pu25_ave40/'
+path = '/store/data/Run2012D/DoubleElectron/RAW-RECO/ZElectron-22Jan2013-v1/10000/'
 process.source = cms.Source("PoolSource",
                             duplicateCheckMode = cms.untracked.string("noDuplicateCheck"),
-                            fileNames = cms.untracked.vstring(path+'photongun_pu25_ave40_lsfext2_990.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_991.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_992.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_993.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_994.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_995.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_996.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_997.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_998.root',
-                                                              path+'photongun_pu25_ave40_lsfext2_999.root'
+                            fileNames = cms.untracked.vstring(path+'0008202C-E78F-E211-AADB-0026189437FD.root'
                                                               ))
 
 


### PR DESCRIPTION
- Back-porting this change also in the 7_4_X branch. 
- The full comments are in the PR #8717.

@argiro @cerminar @pierinim @ferriff @crovelli @paramatti please also follow this.
