### PR TITLE
Consumes migration for AlignmentTrackSelectorModule

### DIFF
--- a/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentGlobalTrackSelector.h
@@ -1,10 +1,13 @@
-
 #ifndef Alignment_CommonAlignmentAlgorithm_AlignmentGlobalTrackSelector_h
 #define Alignment_CommonAlignmentAlgorithm_AlignmentGlobalTrackSelector_h
 
+#include "DataFormats/JetReco/interface/CaloJetCollection.h"
+#include "DataFormats/MuonReco/interface/MuonFwd.h"
+
 //Framework
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 //STL
 #include <vector>
 
@@ -19,7 +22,7 @@ class AlignmentGlobalTrackSelector
   typedef std::vector<const reco::Track*> Tracks; 
 
   /// constructor
-  AlignmentGlobalTrackSelector(const edm::ParameterSet & cfg);
+  AlignmentGlobalTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
 
   /// destructor
   ~AlignmentGlobalTrackSelector();
@@ -47,18 +50,18 @@ class AlignmentGlobalTrackSelector
   bool theJetCountFilterSwitch;
 
   //global Muon Filter
-  edm::InputTag theMuonSource;
+  edm::EDGetTokenT<reco::MuonCollection> theMuonToken;
   double theMaxTrackDeltaR;
   int theMinGlobalMuonCount;
 
   //isolation Cut
-  edm::InputTag theJetIsoSource;
+  edm::EDGetTokenT<reco::CaloJetCollection> theJetIsoToken;
   double theMaxJetPt;
   double theMinJetDeltaR;
   int theMinIsolatedCount;
 
   //jet count Filter
-  edm::InputTag theJetCountSource;
+  edm::EDGetTokenT<reco::CaloJetCollection> theJetCountToken;
   double theMinJetPt;
   int theMaxJetCount;
 

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h
@@ -1,8 +1,13 @@
 #ifndef Alignment_CommonAlignmentAlgorithm_AlignmentTrackSelector_h
 #define Alignment_CommonAlignmentAlgorithm_AlignmentTrackSelector_h
 
+#include "DataFormats/Alignment/interface/AliClusterValueMapFwd.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include <vector>
 
 namespace edm {
@@ -23,7 +28,7 @@ class AlignmentTrackSelector
   typedef std::vector<const reco::Track*> Tracks; 
 
   /// constructor
-  AlignmentTrackSelector(const edm::ParameterSet & cfg);
+  AlignmentTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
 
   /// destructor
   ~AlignmentTrackSelector();
@@ -70,8 +75,8 @@ class AlignmentTrackSelector
   const double nHitMin_,nHitMax_,chi2nMax_, d0Min_,d0Max_,dzMin_,dzMax_;
   const int theCharge_;
   const double minHitChargeStrip_, minHitIsolation_;
-  const edm::InputTag rphirecHitsTag_;
-  const edm::InputTag matchedrecHitsTag_;
+  edm::EDGetTokenT<SiStripRecHit2DCollection> rphirecHitsToken_;
+  edm::EDGetTokenT<SiStripMatchedRecHit2DCollection> matchedrecHitsToken_;
   const bool countStereoHitAs2D_; // count hits on stereo components of GluedDet for nHitMin2D_?
   const unsigned int nHitMin2D_;
   const int minHitsinTIB_, minHitsinTOB_, minHitsinTID_, minHitsinTEC_;
@@ -87,6 +92,7 @@ class AlignmentTrackSelector
   std::vector<double> RorZofLastHitMax_;
 
   const edm::InputTag clusterValueMapTag_;  // ValueMap containing association cluster - flag
+  edm::EDGetTokenT<AliClusterValueMap> clusterValueMapToken_;  // ValueMap containing association cluster - flag
   const int minPrescaledHits_;
   const bool applyPrescaledHitsFilter_;
 
@@ -95,7 +101,6 @@ class AlignmentTrackSelector
   std::vector<reco::TrackBase::TrackAlgorithm> trkSteps_;
   bool applyTrkQualityCheck_;
   bool applyIterStepCheck_;
-
 };
 
 #endif

--- a/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
+++ b/Alignment/CommonAlignmentProducer/interface/AlignmentTwoBodyDecayTrackSelector.h
@@ -3,8 +3,9 @@
 #define Alignment_CommonAlignmentAlgorithm_AlignmentTwoBodyDecayTrackSelector_h
 
 //Framework
-#include "FWCore/Utilities/interface/InputTag.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 //STL
 #include <vector>
 // forward declaration:
@@ -18,7 +19,7 @@ class AlignmentTwoBodyDecayTrackSelector
   typedef std::vector<const reco::Track*> Tracks; 
 
   /// constructor
-  AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet & cfg);
+  AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
 
   /// destructor
   ~AlignmentTwoBodyDecayTrackSelector();
@@ -57,7 +58,7 @@ class AlignmentTwoBodyDecayTrackSelector
   int theCharge;
   bool theUnsignedSwitch;
   //missing ET Filter
-  edm::InputTag theMissingETSource;
+  edm::EDGetTokenT<reco::CaloMETCollection> theMissingETToken;
   //acoplanarity Filter
   double theAcoplanarDistance;
   //helpers

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
@@ -23,9 +23,9 @@ struct TrackConfigSelector {
   typedef reco::TrackCollection collection;
 
  TrackConfigSelector( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    theBaseSelector(cfg),
-    theGlobalSelector(cfg.getParameter<edm::ParameterSet>("GlobalSelector")),
-    theTwoBodyDecaySelector(cfg.getParameter<edm::ParameterSet>("TwoBodyDecaySelector"))
+   theBaseSelector(cfg, iC),
+   theGlobalSelector(cfg.getParameter<edm::ParameterSet>("GlobalSelector"), iC),
+   theTwoBodyDecaySelector(cfg.getParameter<edm::ParameterSet>("TwoBodyDecaySelector"), iC)
   {
     //TODO Wrap the BaseSelector into its own PSet
     theBaseSwitch = theBaseSelector.useThisFilter();

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTrackSelector.cc
@@ -14,8 +14,6 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2D.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerMultiRecHit.h"
 #include "DataFormats/SiStripCluster/interface/SiStripCluster.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h"
 #include "DataFormats/Alignment/interface/AlignmentClusterFlag.h"
 #include "DataFormats/Alignment/interface/AliClusterValueMap.h"
 
@@ -32,7 +30,7 @@ const int kFPIX = PixelSubdetector::PixelEndcap;
 
 // constructor ----------------------------------------------------------------
 
-AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet & cfg) :
+AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC) :
   applyBasicCuts_( cfg.getParameter<bool>( "applyBasicCuts" ) ),
   applyNHighestPt_( cfg.getParameter<bool>( "applyNHighestPt" ) ),
   applyMultiplicityFilter_( cfg.getParameter<bool>( "applyMultiplicityFilter" ) ),
@@ -61,8 +59,6 @@ AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet & cfg) :
   theCharge_( cfg.getParameter<int>( "theCharge" ) ),
   minHitChargeStrip_( cfg.getParameter<double>( "minHitChargeStrip" ) ),
   minHitIsolation_( cfg.getParameter<double>( "minHitIsolation" ) ),
-  rphirecHitsTag_( cfg.getParameter<edm::InputTag>("rphirecHits") ),
-  matchedrecHitsTag_( cfg.getParameter<edm::InputTag>("matchedrecHits") ),
   countStereoHitAs2D_( cfg.getParameter<bool>( "countStereoHitAs2D" ) ),
   nHitMin2D_( cfg.getParameter<unsigned int>( "nHitMin2D" ) ),
   // Ugly to use the same getParameter n times, but this allows const cut variables...
@@ -92,6 +88,14 @@ AlignmentTrackSelector::AlignmentTrackSelector(const edm::ParameterSet & cfg) :
   minPrescaledHits_( cfg.getParameter<int>("minPrescaledHits")),
   applyPrescaledHitsFilter_(clusterValueMapTag_.encode().size() && minPrescaledHits_ > 0)
 {
+  if(applyIsolation_) {
+    rphirecHitsToken_ = iC.consumes<SiStripRecHit2DCollection>(cfg.getParameter<edm::InputTag>("rphirecHits"));
+    matchedrecHitsToken_ = iC.consumes<SiStripMatchedRecHit2DCollection>(cfg.getParameter<edm::InputTag>("matchedrecHits"));
+  }
+
+  if(applyPrescaledHitsFilter_) {
+    clusterValueMapToken_ = iC.consumes<AliClusterValueMap>(clusterValueMapTag_);
+  }
 
   //convert track quality from string to enum
   std::vector<std::string> trkQualityStrings(cfg.getParameter<std::vector<std::string> >("trackQualities"));
@@ -621,8 +625,8 @@ bool AlignmentTrackSelector::isIsolated(const TrackingRecHit* therechit, const e
   edm::Handle<SiStripRecHit2DCollection> rphirecHits;
   edm::Handle<SiStripMatchedRecHit2DCollection> matchedrecHits;
   // es.get<TrackerDigiGeometryRecord>().get(tracker);
-  evt.getByLabel( rphirecHitsTag_, rphirecHits );
-  evt.getByLabel( matchedrecHitsTag_, matchedrecHits ); 
+  evt.getByToken( rphirecHitsToken_, rphirecHits );
+  evt.getByToken( matchedrecHitsToken_, matchedrecHits );
 
   SiStripRecHit2DCollection::DataContainer::const_iterator istripSt; 
   SiStripMatchedRecHit2DCollection::DataContainer::const_iterator istripStm; 
@@ -685,7 +689,7 @@ AlignmentTrackSelector::checkPrescaledHits(const Tracks& tracks, const edm::Even
 
   //take Cluster-Flag Assomap
   edm::Handle<AliClusterValueMap> fMap;
-  evt.getByLabel( clusterValueMapTag_, fMap);
+  evt.getByToken( clusterValueMapToken_, fMap);
   const AliClusterValueMap &flagMap=*fMap;
 
   //for each track loop on hits and count the number of taken hits

--- a/Alignment/CommonAlignmentProducer/src/AlignmentTwoBoyDecayTrackSelector.cc
+++ b/Alignment/CommonAlignmentProducer/src/AlignmentTwoBoyDecayTrackSelector.cc
@@ -3,6 +3,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/EDMException.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 //DataFormats
 #include <DataFormats/TrackReco/interface/Track.h>
@@ -20,8 +21,7 @@ using namespace std;
 using namespace edm; 
 // constructor ----------------------------------------------------------------
 
-AlignmentTwoBodyDecayTrackSelector::AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet & cfg) :
-  theMissingETSource("met")
+AlignmentTwoBodyDecayTrackSelector::AlignmentTwoBodyDecayTrackSelector(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC)
 {
  LogDebug("Alignment")   << "> applying two body decay Trackfilter ...";
   theMassrangeSwitch = cfg.getParameter<bool>( "applyMassrangeFilter" );
@@ -53,7 +53,8 @@ AlignmentTwoBodyDecayTrackSelector::AlignmentTwoBodyDecayTrackSelector(const edm
   }
   theMissingETSwitch = cfg.getParameter<bool>( "applyMissingETFilter" );
   if(theMissingETSwitch){
-    theMissingETSource = cfg.getParameter<InputTag>( "missingETSource" );
+    edm::InputTag theMissingETSource = cfg.getParameter<InputTag>( "missingETSource" );
+    theMissingETToken = iC.consumes<reco::CaloMETCollection>(theMissingETSource);
     LogDebug("Alignment") << ">  missing Et Source: "<< theMissingETSource;
   }
   theAcoplanarityFilterSwitch = cfg.getParameter<bool>( "applyAcoplanarityFilter" );
@@ -198,7 +199,7 @@ AlignmentTwoBodyDecayTrackSelector::checkMETMass(const Tracks& cands,const edm::
   TLorentzVector mother;
 
   Handle<reco::CaloMETCollection> missingET;
-  iEvent.getByLabel(theMissingETSource ,missingET);
+  iEvent.getByToken(theMissingETToken ,missingET);
   if (!missingET.isValid()) {
     LogError("Alignment")<< "@SUB=AlignmentTwoBodyDecayTrackSelector::checkMETMass"
 			 << ">  could not optain missingET Collection!";


### PR DESCRIPTION
Add consumes calls for module AlignmentTrackSelectorModule.
Also convert getByLabel calls to getByToken. These calls
were a couple levels deep in 3 helper classes.
