### PR TITLE
temporary workaround for the truncated hash in the root file (7_4_X)

### DIFF
--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -559,7 +559,8 @@ namespace edm {
       findFileForSpecifiedID_.reset(new std::unordered_multimap<size_t, size_t>);
       auto hasher = std::hash<std::string>();
       for(auto fileIter = fileIterBegin_; fileIter != fileIterEnd_; ++fileIter) {
-        findFileForSpecifiedID_->insert(std::make_pair(hasher(fileIter->logicalFileName()), fileIter - fileIterBegin_));
+	 //        findFileForSpecifiedID_->insert(std::make_pair(hasher(fileIter->logicalFileName()), fileIter - fileIterBegin_));
+         findFileForSpecifiedID_->insert(std::make_pair((hasher(fileIter->logicalFileName()) & 0xffffffff), fileIter - fileIterBegin_));
       }
     }
     // Look up the logical file name in the table


### PR DESCRIPTION
The feature to open only the correct file in playback mode did not work properly, because the 64 bit hash somehow got truncated to 32 bits, so it never matched the hash for any file. This successful workaround, from the user of the feature, Yetkin Yilmaz, is a needed workaround for the problem. It simply limits the hash comparison to the final 32 bits of the hash.
When time permits, the cause of the truncation can be found and fixed, and the workaround removed.
