### PR TITLE
Consumes migration for CosmicGenFilterHelix

### DIFF
--- a/GeneratorInterface/GenFilters/interface/CosmicGenFilterHelix.h
+++ b/GeneratorInterface/GenFilters/interface/CosmicGenFilterHelix.h
@@ -20,13 +20,15 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Event.h"
 
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 
 #include "DataFormats/GeometrySurface/interface/Plane.h"
 #include "DataFormats/GeometrySurface/interface/Cylinder.h"
 #include "DataFormats/GeometryVector/interface/GlobalPoint.h"
 #include "DataFormats/GeometryVector/interface/GlobalVector.h"
+
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
 #include <TObjArray.h>
 
@@ -56,7 +58,7 @@ class CosmicGenFilterHelix : public edm::EDFilter {
   const Propagator* getPropagator(const edm::EventSetup &setup) const;
 // ----------member data ---------------------------
 
-  const edm::InputTag     theSrc;
+  edm::EDGetTokenT<edm::HepMCProduct> theSrcToken;
   const std::vector<int>  theIds; /// requested Ids
   const std::vector<int>  theCharges; /// charges, parallel to theIds
   const std::string thePropagatorName; // tag to get propagator from ESetup

--- a/GeneratorInterface/GenFilters/src/CosmicGenFilterHelix.cc
+++ b/GeneratorInterface/GenFilters/src/CosmicGenFilterHelix.cc
@@ -10,8 +10,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "FWCore/Utilities/interface/InputTag.h"
 
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
@@ -41,14 +40,15 @@
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 CosmicGenFilterHelix::CosmicGenFilterHelix(const edm::ParameterSet& cfg) 
-  : theSrc(cfg.getParameter<edm::InputTag>("src")),
-    theIds(cfg.getParameter<std::vector<int> >("pdgIds")),
+  : theIds(cfg.getParameter<std::vector<int> >("pdgIds")),
     theCharges(cfg.getParameter<std::vector<int> >("charges")),
     thePropagatorName(cfg.getParameter<std::string>("propagator")),
     theMinP2(cfg.getParameter<double>("minP")*cfg.getParameter<double>("minP")),
     theMinPt2(cfg.getParameter<double>("minPt")*cfg.getParameter<double>("minPt")),
     theDoMonitor(cfg.getUntrackedParameter<bool>("doMonitor"))
 {
+  theSrcToken = consumes<edm::HepMCProduct>(cfg.getParameter<edm::InputTag>("src"));
+
   if (theIds.size() != theCharges.size()) {
     throw cms::Exception("BadConfig") << "CosmicGenFilterHelix: "
 				      << "'pdgIds' and 'charges' need same length.";
@@ -82,7 +82,7 @@ CosmicGenFilterHelix::~CosmicGenFilterHelix()
 bool CosmicGenFilterHelix::filter(edm::Event &iEvent, const edm::EventSetup &iSetup)
 {
   edm::Handle<edm::HepMCProduct> hepMCEvt;
-  iEvent.getByLabel(theSrc, hepMCEvt);
+  iEvent.getByToken(theSrcToken, hepMCEvt);
   const HepMC::GenEvent *mCEvt = hepMCEvt->GetEvent();
   const MagneticField *bField = this->getMagneticField(iSetup); // should be fast (?)
   const Propagator *propagator = this->getPropagator(iSetup);


### PR DESCRIPTION
Add consumes function calls for the module
CosmicGenFilterHelix. Convert getByLabel call
to getByToken.
