### PR TITLE
Macros need to compile in ROOT6 (Sim) (7_4_X)

### DIFF
--- a/TauAnalysis/MCEmbeddingTools/macros/makeEmbeddingKineReweightLUTs2.C
+++ b/TauAnalysis/MCEmbeddingTools/macros/makeEmbeddingKineReweightLUTs2.C
@@ -75,9 +75,9 @@ struct weightEntryType
   }
   TString name_;
   const TH1* lut_;
-  TAxis* xAxis_;
+  const TAxis* xAxis_;
   Int_t numBinsX_;
-  TAxis* yAxis_;
+  const TAxis* yAxis_;
   Int_t numBinsY_;
   int variableX_;
   int variableY_;

--- a/TauAnalysis/MCEmbeddingTools/macros/makeEmbeddingValidationPlots.C
+++ b/TauAnalysis/MCEmbeddingTools/macros/makeEmbeddingValidationPlots.C
@@ -230,7 +230,7 @@ TGraphAsymmErrors* getEfficiency(const TH1* histogram_numerator, const TH1* hist
     return 0;
   }
   
-  TAxis* xAxis = histogram_numerator->GetXaxis();
+  const TAxis* xAxis = histogram_numerator->GetXaxis();
 
   Int_t nBins = xAxis->GetNbins();
   TArrayF x(nBins);


### PR DESCRIPTION
Do not forward this PR to CMSSW_7_4_ROOT5_X. It is ROOT6 only.
In ROOT6 macros are processed by cling, rather than CINT. Over 500 CMSSW macros do not compile in ROOT6. Since that is too many macros to be fixed centrally, it was decided by David Lange to centrally fix only those 45 macros with compilation errors that have been modified since the switch over to git, since those are the ones most likely to be used. Only two of these 45 macros are in the Sim L2 category. This pull request fixes both of them.
NOTE: These two macros are unusual in the failure to compile with ROOT6 is due to a change in the ROOT API, and not due to CINT/cling differences.
