### PR TITLE
Fixing reversed distance in accessing subjet collections

### DIFF
--- a/DataFormats/PatCandidates/src/Jet.cc
+++ b/DataFormats/PatCandidates/src/Jet.cc
@@ -596,7 +596,7 @@ pat::JetPtrCollection const & Jet::subjets( unsigned int index) const {
 pat::JetPtrCollection const & Jet::subjets( std::string label ) const { 
   auto found = find( subjetLabels_.begin(), subjetLabels_.end(), label );
   if ( found != subjetLabels_.end() ){
-    auto index = std::distance( found , subjetLabels_.begin() );
+    auto index = std::distance( subjetLabels_.begin(), found );
     return subjetCollections_[index]; 
   }
   else {


### PR DESCRIPTION
The order of the iterators in "std::distance" was reversed, giving negative numbers (and hence nonsense when dereferencing the index). 
