### PR TITLE
ECAL unpacker: consider the ADC hysteresis in the gain switches

### DIFF
--- a/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
@@ -221,23 +221,16 @@ int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalI
   
   // from here on, care about gain switches
   
-  short firstGainWrong=-1;
-  short numGainWrong=0;
-  double higherGain = 1.;
+  short numGain=1;
+  bool gainSwitchError = false;
 
   for (unsigned int i=1; i<nTSamples_; i++ ) {
-
-    if (i>0 && xtalGains_[i-1]>xtalGains_[i]) {
-          higherGain = xtalGains_[i];
-          if (firstGainWrong == -1) { firstGainWrong=i;}
-    }
-
-    if ( xtalGains_[i] == higherGain ) numGainWrong++;
-
+    if (xtalGains_[i-1] >  xtalGains_[i] && numGain<5) gainSwitchError = true;
+    if (xtalGains_[i-1] == xtalGains_[i]) numGain++;
+    else numGain=1;
   }
-  
-  
-  if (numGainWrong > 0 && numGainWrong < 5) {
+
+  if (gainSwitchError) {
     if (! DCCDataUnpacker::silentMode_) {
       edm::LogWarning("IncorrectGain")
         << "A wrong gain transition switch was found for Tower Block in strip " << stripId << " and xtal " << xtalId

--- a/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
+++ b/EventFilter/EcalRawToDigi/src/DCCTowerBlock.cc
@@ -223,16 +223,21 @@ int DCCTowerBlock::unpackXtalData(unsigned int expStripID, unsigned int expXtalI
   
   short firstGainWrong=-1;
   short numGainWrong=0;
-  
+  double higherGain = 1.;
+
   for (unsigned int i=1; i<nTSamples_; i++ ) {
+
     if (i>0 && xtalGains_[i-1]>xtalGains_[i]) {
-          numGainWrong++;
+          higherGain = xtalGains_[i];
           if (firstGainWrong == -1) { firstGainWrong=i;}
     }
+
+    if ( xtalGains_[i] == higherGain ) numGainWrong++;
+
   }
   
   
-  if (numGainWrong > 0) {
+  if (numGainWrong > 0 && numGainWrong < 5) {
     if (! DCCDataUnpacker::silentMode_) {
       edm::LogWarning("IncorrectGain")
         << "A wrong gain transition switch was found for Tower Block in strip " << stripId << " and xtal " << xtalId

--- a/EventFilter/EcalRawToDigi/test/testEcalUnpackerData_cfg.py
+++ b/EventFilter/EcalRawToDigi/test/testEcalUnpackerData_cfg.py
@@ -7,7 +7,7 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(-1) )
 process.source = cms.Source("PoolSource",
  fileNames = 
 #cms.untracked.vstring('file:/tmp/nalmeida/1A1C4478-5866-DE11-A907-001D09F27067.root')
- cms.untracked.vstring('/store/relval/CMSSW_3_8_0/RelValProdTTbar/GEN-SIM-RAW/MC_38Y_V7-v1/0004/306D1971-0C95-DF11-942B-002618943984.root')
+ cms.untracked.vstring('/store/relval/CMSSW_7_4_0/RelValProdTTbar/GEN-SIM-RAW/MCRUN1_74_V4-v1/00000/2C6CC5C9-D0DA-E411-ABF3-0025905B85EE.root')
 
 )
 


### PR DESCRIPTION
In the previous version a gain switch error was triggered as soon as there was a transition from a higher gainID (lower gain) to a lower gain ID (higher gain). 
The ADC, though, has an hysteresis of 5 samples, after which this transition back to a lower gain ID is allowed, after the first gain switch. 

This is considered to happen in a tiny number of events. The effect of this change should be almost invisible in data relvals.

@grasph @argiro @ferriff please also follow this
