### PR TITLE
edmPluginHelp: differentiate thread-safe from legacy output modules

### DIFF
--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFiller.h
@@ -31,9 +31,11 @@ method of the templated argument.  This allows the ParameterSetDescriptionFiller
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/OutputModule.h"
 #include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/one/EDProducer.h"
 #include "FWCore/Framework/interface/one/EDFilter.h"
+#include "FWCore/Framework/interface/one/OutputModule.h"
 #include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/stream/EDFilter.h"
@@ -64,12 +66,16 @@ namespace edm {
         return kExtendedBaseForEDProducer;
       if (std::is_base_of<edm::EDFilter, T>::value)
         return kExtendedBaseForEDFilter;
+      if (std::is_base_of<edm::OutputModule, T>::value)
+        return kExtendedBaseForOutputModule;
       if (std::is_base_of<edm::one::EDAnalyzerBase, T>::value)
         return kExtendedBaseForOneEDAnalyzer;
       if (std::is_base_of<edm::one::EDProducerBase, T>::value)
         return kExtendedBaseForOneEDProducer;
       if (std::is_base_of<edm::one::EDFilterBase, T>::value)
         return kExtendedBaseForOneEDFilter;
+      if (std::is_base_of<edm::one::OutputModuleBase, T>::value)
+        return kExtendedBaseForOneOutputModule;
       if (std::is_base_of<edm::stream::EDAnalyzerBase, T>::value)
         return kExtendedBaseForStreamEDAnalyzer;
       if (std::is_base_of<edm::stream::EDProducerBase, T>::value)

--- a/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
+++ b/FWCore/ParameterSet/interface/ParameterSetDescriptionFillerBase.h
@@ -54,9 +54,11 @@ protected:
      static const std::string kExtendedBaseForEDAnalyzer;
      static const std::string kExtendedBaseForEDProducer;
      static const std::string kExtendedBaseForEDFilter;
+     static const std::string kExtendedBaseForOutputModule;
      static const std::string kExtendedBaseForOneEDAnalyzer;
      static const std::string kExtendedBaseForOneEDProducer;
      static const std::string kExtendedBaseForOneEDFilter;
+     static const std::string kExtendedBaseForOneOutputModule;
      static const std::string kExtendedBaseForStreamEDAnalyzer;
      static const std::string kExtendedBaseForStreamEDProducer;
      static const std::string kExtendedBaseForStreamEDFilter;

--- a/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
+++ b/FWCore/ParameterSet/src/ParameterSetDescriptionFillerBase.cc
@@ -26,9 +26,11 @@ const std::string edm::ParameterSetDescriptionFillerBase::kBaseForESProducer("ES
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDAnalyzer("EDAnalyzer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDProducer("EDProducer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForEDFilter("EDFilter");
+const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForOutputModule("OutputModule");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForOneEDAnalyzer("one::EDAnalyzer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForOneEDProducer("one::EDProducer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForOneEDFilter("one::EDFilter");
+const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForOneOutputModule("one::OutputModule");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForStreamEDAnalyzer("stream::EDAnalyzer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForStreamEDProducer("stream::EDProducer");
 const std::string edm::ParameterSetDescriptionFillerBase::kExtendedBaseForStreamEDFilter("stream::EDFilter");


### PR DESCRIPTION
Extend `ParameterSetDescriptionFiller` to handle one vs. legacy OutputModules.
