### PR TITLE
Adding of HLT2PhotonMET

### DIFF
--- a/HLTrigger/HLTfilters/src/SealModule.cc
+++ b/HLTrigger/HLTfilters/src/SealModule.cc
@@ -106,6 +106,7 @@ typedef HLTDoublet<Electron            ,CaloMET> HLT2ElectronCaloMET;
 typedef HLTDoublet<RecoChargedCandidate,CaloMET> HLT2MuonCaloMET;
 typedef HLTDoublet<Electron            ,    MET> HLT2ElectronMET;
 typedef HLTDoublet<RecoChargedCandidate,    MET> HLT2MuonMET;
+typedef HLTDoublet<RecoEcalCandidate   ,MET> HLT2PhotonMET;
 
 DEFINE_FWK_MODULE(HLTBool);
 DEFINE_FWK_MODULE(HLTFiltCand);
@@ -129,6 +130,7 @@ DEFINE_FWK_MODULE(HLT2ElectronCaloMET);
 DEFINE_FWK_MODULE(HLT2MuonCaloMET);
 DEFINE_FWK_MODULE(HLT2ElectronMET);
 DEFINE_FWK_MODULE(HLT2MuonMET);
+DEFINE_FWK_MODULE(HLT2PhotonMET);
 
 
 DEFINE_FWK_MODULE(HLT1Electron);


### PR DESCRIPTION
Hi,
I'd like to add in CMSSW the HLT2PhotonMET that is missing in HLTrigger/HLTfilters/src/SealModule.cc .
The change is just two lines!
I would need it for the WH -> ev bb trigger, that is waiting for the approval ( https://indico.cern.ch/event/376581/contribution/6/material/slides/0.pdf ).
I need HLT2PhotonMET instead of HLT2ElectronMET because the electrons as saved as photons in the current HLT trigger.
Thanks, Silvio.
cc: @degrutto, @azzurri , @capalmer
