### PR TITLE
No longer need AutoLibraryLoader for edmCheckClassVersion

### DIFF
--- a/FWCore/Utilities/scripts/edmCheckClassVersion
+++ b/FWCore/Utilities/scripts/edmCheckClassVersion
@@ -166,9 +166,6 @@ import ROOT
 ROOT.gROOT.SetBatch(True)
 ROOT.gROOT.ProcessLine(".autodict")
 if options.library is None:
-    if 0 != ROOT.gSystem.Load("libFWCoreFWLite"):
-        raise RuntimeError("failed to load libFWCoreFWLite")
-    ROOT.AutoLibraryLoader.enable()
     if options.checkdict :
         print "Dictionary checks require a specific library"
 else:


### PR DESCRIPTION
With ROOT 6 we no longer use the AutoLibraryLoader to load dictionaries. We now allow ROOT to do the loading itself.
