### PR TITLE
Add CaloJet pT to MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -132,6 +132,14 @@ def miniAOD_customizeCommon(process):
     process.load("PhysicsTools.PatAlgos.slimming.pileupJetId_cfi")
     process.patJets.userData.userFloats.src = [ cms.InputTag("pileupJetId:fullDiscriminant"), ]
 
+    ## CaloJets
+    process.caloJetPt = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+         src = process.patJets.jetSource,
+         matched = cms.InputTag("ak4CaloJets"),
+         distMax = cms.double(0.4),
+         value = cms.string('pt') )
+    process.patJets.userData.userFloats.src += [ cms.InputTag("caloJetPt") ]
+
     #VID Electron IDs
     electron_ids = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_CSA14_50ns_V1_cff',
                     'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_CSA14_PU20bx25_V0_cff',

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -133,12 +133,14 @@ def miniAOD_customizeCommon(process):
     process.patJets.userData.userFloats.src = [ cms.InputTag("pileupJetId:fullDiscriminant"), ]
 
     ## CaloJets
-    process.caloJetPt = cms.EDProducer("RecoJetDeltaRValueMapProducer",
+    process.caloJetMap = cms.EDProducer("RecoJetDeltaRValueMapProducer",
          src = process.patJets.jetSource,
          matched = cms.InputTag("ak4CaloJets"),
          distMax = cms.double(0.4),
-         value = cms.string('pt') )
-    process.patJets.userData.userFloats.src += [ cms.InputTag("caloJetPt") ]
+         values = cms.vstring('pt','emEnergyFraction'),
+	 valueLabels = cms.vstring('pt','emEnergyFraction'),
+	 lazyParser = cms.bool(True) )
+    process.patJets.userData.userFloats.src += [ cms.InputTag("caloJetMap:pt"), cms.InputTag("caloJetMap:emEnergyFraction") ]
 
     #VID Electron IDs
     electron_ids = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_CSA14_50ns_V1_cff',


### PR DESCRIPTION
Add CaloJet on pt and emEnergy(=1-hadEnergy) information as userfloat to matched PFJets in MiniAOD for sanity/noise checks.

Adding these two extra float per ak4 jet, gives the following size increase for 1000 events of 1302.0_ProdTTbar_13+ProdTTbar_13+DIGIUP15PROD1+RECOPRODUP15+MINIAODMCUP15:
before change:
patJets_slimmedJets__PAT. 12554 1401.42
after change:
patJets_slimmedJets__PAT. 12981.8 1455.02
