### PR TITLE
Fix compilation error in EventSetup::tryToGet

### DIFF
--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -70,7 +70,7 @@ class EventSetup
         BOOST_STATIC_ASSERT((boost::is_base_and_derived<edm::eventsetup::EventSetupRecord, T>::value));
         const T* value = nullptr;
         eventSetupTryToGetImplementation(*this, value);
-        return *value;
+        return value;
       }
 
       /** can directly access data if data_default_record_trait<> is defined for this data type **/

--- a/FWCore/Framework/test/eventsetup_t.cppunit.cc
+++ b/FWCore/Framework/test/eventsetup_t.cppunit.cc
@@ -48,6 +48,7 @@ CPPUNIT_TEST_SUITE(testEventsetup);
 
 CPPUNIT_TEST(constructTest);
 CPPUNIT_TEST(getTest);
+CPPUNIT_TEST(tryToGetTest);
 CPPUNIT_TEST_EXCEPTION(getExcTest,edm::eventsetup::NoRecordException<DummyRecord>);
 CPPUNIT_TEST(recordProviderTest);
 CPPUNIT_TEST(provenanceTest);
@@ -74,6 +75,7 @@ public:
 
   void constructTest();
   void getTest();
+  void tryToGetTest();
   void getExcTest();
   void recordProviderTest();
   void recordValidityTest();
@@ -122,6 +124,21 @@ void testEventsetup::getTest()
    const DummyRecord& gottenRecord = eventSetup.get<DummyRecord>();
    CPPUNIT_ASSERT(non_null(&gottenRecord));
    CPPUNIT_ASSERT(&dummyRecord == &gottenRecord);
+}
+
+void testEventsetup::tryToGetTest()
+{
+  eventsetup::EventSetupProvider provider;
+  EventSetup const& eventSetup = provider.eventSetupForInstance(IOVSyncValue::invalidIOVSyncValue());
+  CPPUNIT_ASSERT(non_null(&eventSetup));
+  //eventSetup.get<DummyRecord>();
+  //CPPUNIT_ASSERT_THROW(eventSetup.get<DummyRecord>(), edm::eventsetup::NoRecordException<DummyRecord>);
+  
+  DummyRecord dummyRecord;
+  provider.addRecordToEventSetup(dummyRecord);
+  const DummyRecord* gottenRecord = eventSetup.tryToGet<DummyRecord>();
+  CPPUNIT_ASSERT(non_null(gottenRecord));
+  CPPUNIT_ASSERT(&dummyRecord == gottenRecord);
 }
 
 void testEventsetup::getExcTest()


### PR DESCRIPTION
A typo in EventSetup::tryToGet kept the templated function from compiling. Added a unit test to make sure the problem does not reoccur.
