### PR TITLE
Fix errors reported by valgrind

### DIFF
--- a/DQM/SiStripMonitorClient/src/SiStripCertificationInfo.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripCertificationInfo.cc
@@ -30,7 +30,8 @@
 //
 // -- Contructor
 //
-SiStripCertificationInfo::SiStripCertificationInfo(edm::ParameterSet const& pSet) {
+SiStripCertificationInfo::SiStripCertificationInfo(edm::ParameterSet const& pSet) :
+  m_cacheID_(0) {
   // Create MessageSender
   edm::LogInfo( "SiStripCertificationInfo") << "SiStripCertificationInfo::Deleting SiStripCertificationInfo ";
   // get back-end interface

--- a/DQM/SiStripMonitorClient/src/SiStripDaqInfo.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripDaqInfo.cc
@@ -31,7 +31,9 @@
 //
 // -- Contructor
 //
-SiStripDaqInfo::SiStripDaqInfo(edm::ParameterSet const& pSet) {
+SiStripDaqInfo::SiStripDaqInfo(edm::ParameterSet const& pSet) :
+  m_cacheID_(0) {
+
   // Create MessageSender
   edm::LogInfo( "SiStripDaqInfo") << "SiStripDaqInfo::Deleting SiStripDaqInfo ";
 

--- a/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
+++ b/DQM/TrackingMonitorClient/src/TrackingCertificationInfo.cc
@@ -36,6 +36,7 @@ TrackingCertificationInfo::TrackingCertificationInfo(edm::ParameterSet const& pS
   , trackingLSCertificationBooked_(false)
   , nFEDConnected_(0)
   , allPixelFEDConnected_(true)
+  , m_cacheID_(0)
 {
   // Create MessageSender
   edm::LogInfo( "TrackingCertificationInfo") << "TrackingCertificationInfo::Deleting TrackingCertificationInfo ";


### PR DESCRIPTION
Fix errors reported by valgrind related
to uninitialized variables. Really the
same error repeated in 3 places.
