### PR TITLE
allowing E/g HLT to be seeded by L1 jets

### DIFF
--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
@@ -36,15 +36,14 @@ class HLTEgammaL1MatchFilterRegional : public HLTFilter {
     edm::InputTag l1IsolatedTag_;           // input tag identifying product contains egammas
     edm::InputTag candNonIsolatedTag_;      // input tag identifying product contains egammas
     edm::InputTag l1NonIsolatedTag_;         // input tag identifying product contains egammas
-    edm::InputTag l1CenJetsTag_;
+    edm::InputTag l1CenJetsTag_;//EGamma can now be seeded by L1 Jet seeds (important for high energy) 
     edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candIsolatedToken_;
     edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candNonIsolatedToken_;
 
     edm::InputTag L1SeedFilterTag_;
     edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> L1SeedFilterToken_;
     bool doIsolated_;
-    bool doJets_; //EGamma can now be seeded by L1 Jet seeds (important for high energy) 
-
+   
     int    ncandcut_;        // number of egammas required
     // L1 matching cuts
     double region_eta_size_;

--- a/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
+++ b/HLTrigger/Egamma/interface/HLTEgammaL1MatchFilterRegional.h
@@ -36,12 +36,14 @@ class HLTEgammaL1MatchFilterRegional : public HLTFilter {
     edm::InputTag l1IsolatedTag_;           // input tag identifying product contains egammas
     edm::InputTag candNonIsolatedTag_;      // input tag identifying product contains egammas
     edm::InputTag l1NonIsolatedTag_;         // input tag identifying product contains egammas
+    edm::InputTag l1CenJetsTag_;
     edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candIsolatedToken_;
     edm::EDGetTokenT<reco::RecoEcalCandidateCollection> candNonIsolatedToken_;
 
     edm::InputTag L1SeedFilterTag_;
     edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> L1SeedFilterToken_;
     bool doIsolated_;
+    bool doJets_; //EGamma can now be seeded by L1 Jet seeds (important for high energy) 
 
     int    ncandcut_;        // number of egammas required
     // L1 matching cuts
@@ -53,7 +55,7 @@ class HLTEgammaL1MatchFilterRegional : public HLTFilter {
 
   private:
     bool matchedToL1Cand(const std::vector<l1extra::L1EmParticleRef >& l1Cands,const float scEta,const float scPhi) const;
-
+    bool matchedToL1Cand(const std::vector<l1extra::L1JetParticleRef >& l1Cands,const float scEta,const float scPhi) const;
 };
 
 #endif //HLTEgammaL1MatchFilterRegional_h

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
@@ -13,6 +13,9 @@
 
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/L1TObjects/interface/L1CaloGeometry.h"
@@ -22,6 +25,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+
 
 #define TWOPI 6.283185308
 //
@@ -33,10 +37,11 @@ HLTEgammaL1MatchFilterRegional::HLTEgammaL1MatchFilterRegional(const edm::Parame
    l1IsolatedTag_ = iConfig.getParameter< edm::InputTag > ("l1IsolatedTag");
    candNonIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("candNonIsolatedTag");
    l1NonIsolatedTag_ = iConfig.getParameter< edm::InputTag > ("l1NonIsolatedTag");
-   L1SeedFilterTag_ = iConfig.getParameter< edm::InputTag > ("L1SeedFilterTag");
+   L1SeedFilterTag_ = iConfig.getParameter< edm::InputTag > ("L1SeedFilterTag"); 
+   l1CenJetsTag_ = iConfig.getParameter< edm::InputTag > ("l1CenJetsTag");
    ncandcut_  = iConfig.getParameter<int> ("ncandcut");
    doIsolated_   = iConfig.getParameter<bool>("doIsolated");
-
+   doJets_ = iConfig.getParameter<bool>("doJets");
    region_eta_size_      = iConfig.getParameter<double> ("region_eta_size");
    region_eta_size_ecap_ = iConfig.getParameter<double> ("region_eta_size_ecap");
    region_phi_size_      = iConfig.getParameter<double> ("region_phi_size");
@@ -59,8 +64,10 @@ HLTEgammaL1MatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("candNonIsolatedTag",edm::InputTag("hltRecoNonIsolatedEcalCandidate"));
   desc.add<edm::InputTag>("l1NonIsolatedTag",edm::InputTag("l1extraParticles","NonIsolated"));
   desc.add<edm::InputTag>("L1SeedFilterTag",edm::InputTag("theL1SeedFilter"));
+  desc.add<edm::InputTag>("l1CenJetsTag",edm::InputTag("l1extraParticles","Central"));
   desc.add<int>("ncandcut",1);
   desc.add<bool>("doIsolated",true);
+  desc.add<bool>("doJets",false);
   desc.add<double>("region_eta_size",0.522);
   desc.add<double>("region_eta_size_ecap",1.0);
   desc.add<double>("region_phi_size",1.044);
@@ -84,6 +91,9 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
     filterproduct.addCollectionTag(l1IsolatedTag_);
     if (not doIsolated_)
       filterproduct.addCollectionTag(l1NonIsolatedTag_);
+    if (doJets_){
+      filterproduct.addCollectionTag(l1CenJetsTag_);
+    }
   }
 
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
@@ -110,6 +120,8 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
   std::vector<l1extra::L1EmParticleRef > l1EGNonIso;
   L1SeedOutput->getObjects(TriggerL1NoIsoEG, l1EGNonIso);
 
+  std::vector<l1extra::L1JetParticleRef> l1Jets;
+  L1SeedOutput->getObjects(TriggerL1CenJet, l1Jets);
 
   for (reco::RecoEcalCandidateCollection::const_iterator recoecalcand= recoIsolecalcands->begin(); recoecalcand!=recoIsolecalcands->end(); recoecalcand++) {
 
@@ -128,8 +140,12 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
 	matchedSCNonIso =  matchedToL1Cand(l1EGNonIso,recoecalcand->eta(),recoecalcand->phi());
       }
 
+      bool matchedSCJet=false;
+      if(doJets_){
+	matchedSCJet = matchedToL1Cand(l1Jets,recoecalcand->eta(),recoecalcand->phi());
+      }
 
-      if(matchedSCIso || matchedSCNonIso) {
+      if(matchedSCIso || matchedSCNonIso || matchedSCJet) {
 	n++;
 
 	ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoIsolecalcands, distance(recoIsolecalcands->begin(),recoecalcand) );
@@ -153,7 +169,12 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
       if(fabs(recoecalcand->eta()) < endcap_end_){
 	bool matchedSCNonIso =  matchedToL1Cand(l1EGNonIso,recoecalcand->eta(),recoecalcand->phi());
 	
-	if(matchedSCNonIso) {
+	bool matchedSCJet=false;
+	if(doJets_){
+	  matchedSCJet = matchedToL1Cand(l1Jets,recoecalcand->eta(),recoecalcand->phi());
+	}
+
+	if(matchedSCNonIso || matchedSCJet) {
 	  n++;
 	  ref = edm::Ref<reco::RecoEcalCandidateCollection>(recoNonIsolecalcands, distance(recoNonIsolecalcands->begin(),recoecalcand) );
 	  filterproduct.addObject(TriggerCluster, ref);
@@ -174,6 +195,33 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
 
 bool
 HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1EmParticleRef >& l1Cands,const float scEta,const float scPhi) const
+{
+  for (unsigned int i=0; i<l1Cands.size(); i++) {
+    //ORCA matching method
+    double etaBinLow  = 0.;
+    double etaBinHigh = 0.;	
+    if(fabs(scEta) < barrel_end_){
+      etaBinLow = l1Cands[i]->eta() - region_eta_size_/2.;
+      etaBinHigh = etaBinLow + region_eta_size_;
+    }
+    else{
+      etaBinLow = l1Cands[i]->eta() - region_eta_size_ecap_/2.;
+      etaBinHigh = etaBinLow + region_eta_size_ecap_;
+    }
+
+    float deltaphi=fabs(scPhi -l1Cands[i]->phi());
+    if(deltaphi>TWOPI) deltaphi-=TWOPI;
+    if(deltaphi>TWOPI/2.) deltaphi=TWOPI-deltaphi;
+
+    if(scEta < etaBinHigh && scEta > etaBinLow && deltaphi <region_phi_size_/2. )  {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool
+HLTEgammaL1MatchFilterRegional::matchedToL1Cand(const std::vector<l1extra::L1JetParticleRef >& l1Cands,const float scEta,const float scPhi) const
 {
   for (unsigned int i=0; i<l1Cands.size(); i++) {
     //ORCA matching method

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
@@ -63,7 +63,7 @@ HLTEgammaL1MatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("candNonIsolatedTag",edm::InputTag("hltRecoNonIsolatedEcalCandidate"));
   desc.add<edm::InputTag>("l1NonIsolatedTag",edm::InputTag("l1extraParticles","NonIsolated"));
   desc.add<edm::InputTag>("L1SeedFilterTag",edm::InputTag("theL1SeedFilter"));
-  desc.add<edm::InputTag>("l1CenJetsTag",edm::InputTag("l1extraParticles","Central"));
+  desc.add<edm::InputTag>("l1CenJetsTag",edm::InputTag("hltL1extraParticles","Central"));
   desc.add<int>("ncandcut",1);
   desc.add<bool>("doIsolated",true);
   desc.add<double>("region_eta_size",0.522);

--- a/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
+++ b/HLTrigger/Egamma/src/HLTEgammaL1MatchFilterRegional.cc
@@ -40,8 +40,7 @@ HLTEgammaL1MatchFilterRegional::HLTEgammaL1MatchFilterRegional(const edm::Parame
    L1SeedFilterTag_ = iConfig.getParameter< edm::InputTag > ("L1SeedFilterTag"); 
    l1CenJetsTag_ = iConfig.getParameter< edm::InputTag > ("l1CenJetsTag");
    ncandcut_  = iConfig.getParameter<int> ("ncandcut");
-   doIsolated_   = iConfig.getParameter<bool>("doIsolated");
-   doJets_ = iConfig.getParameter<bool>("doJets");
+   doIsolated_   = iConfig.getParameter<bool>("doIsolated");   
    region_eta_size_      = iConfig.getParameter<double> ("region_eta_size");
    region_eta_size_ecap_ = iConfig.getParameter<double> ("region_eta_size_ecap");
    region_phi_size_      = iConfig.getParameter<double> ("region_phi_size");
@@ -67,7 +66,6 @@ HLTEgammaL1MatchFilterRegional::fillDescriptions(edm::ConfigurationDescriptions&
   desc.add<edm::InputTag>("l1CenJetsTag",edm::InputTag("l1extraParticles","Central"));
   desc.add<int>("ncandcut",1);
   desc.add<bool>("doIsolated",true);
-  desc.add<bool>("doJets",false);
   desc.add<double>("region_eta_size",0.522);
   desc.add<double>("region_eta_size_ecap",1.0);
   desc.add<double>("region_phi_size",1.044);
@@ -91,9 +89,7 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
     filterproduct.addCollectionTag(l1IsolatedTag_);
     if (not doIsolated_)
       filterproduct.addCollectionTag(l1NonIsolatedTag_);
-    if (doJets_){
-      filterproduct.addCollectionTag(l1CenJetsTag_);
-    }
+    filterproduct.addCollectionTag(l1CenJetsTag_);
   }
 
   edm::Ref<reco::RecoEcalCandidateCollection> ref;
@@ -140,10 +136,8 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
 	matchedSCNonIso =  matchedToL1Cand(l1EGNonIso,recoecalcand->eta(),recoecalcand->phi());
       }
 
-      bool matchedSCJet=false;
-      if(doJets_){
-	matchedSCJet = matchedToL1Cand(l1Jets,recoecalcand->eta(),recoecalcand->phi());
-      }
+      bool matchedSCJet = matchedToL1Cand(l1Jets,recoecalcand->eta(),recoecalcand->phi());
+      //  if(matchedSCJet) std::cout <<"matched jet "<<this->moduleDescription().moduleLabel()<<std::endl;
 
       if(matchedSCIso || matchedSCNonIso || matchedSCJet) {
 	n++;
@@ -169,10 +163,8 @@ HLTEgammaL1MatchFilterRegional::hltFilter(edm::Event& iEvent, const edm::EventSe
       if(fabs(recoecalcand->eta()) < endcap_end_){
 	bool matchedSCNonIso =  matchedToL1Cand(l1EGNonIso,recoecalcand->eta(),recoecalcand->phi());
 	
-	bool matchedSCJet=false;
-	if(doJets_){
-	  matchedSCJet = matchedToL1Cand(l1Jets,recoecalcand->eta(),recoecalcand->phi());
-	}
+	bool matchedSCJet = matchedToL1Cand(l1Jets,recoecalcand->eta(),recoecalcand->phi());
+	
 
 	if(matchedSCNonIso || matchedSCJet) {
 	  n++;

--- a/RecoEgamma/EgammaHLTProducers/interface/HLTRecHitInAllL1RegionsProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/HLTRecHitInAllL1RegionsProducer.h
@@ -1,0 +1,321 @@
+#ifndef RecoEgamma_EgammayHLTProducers_HLTRecHitInAllL1RegionsProducer_h_
+#define RecoEgamma_EgammayHLTProducers_HLTRecHitInAllL1RegionsProducer_h_
+
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+// Reco candidates (might not need)
+#include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+
+// Geometry and topology
+#include "Geometry/Records/interface/CaloGeometryRecord.h"
+#include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloCellGeometry.h"
+#include "Geometry/CaloGeometry/interface/CaloGeometry.h"
+
+#include "RecoEcal/EgammaCoreTools/interface/EcalEtaPhiRegion.h"
+// Level 1 Trigger
+#include "DataFormats/L1Trigger/interface/L1EmParticleFwd.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+#include "DataFormats/L1Trigger/interface/L1MuonParticleFwd.h" 
+#include "DataFormats/L1Trigger/interface/L1EmParticle.h"
+#include "DataFormats/L1Trigger/interface/L1JetParticle.h"
+#include "DataFormats/L1Trigger/interface/L1MuonParticle.h"
+
+#include "CondFormats/L1TObjects/interface/L1CaloGeometry.h"
+#include "CondFormats/DataRecord/interface/L1CaloGeometryRecord.h"
+
+#include "DataFormats/EcalRecHit/interface/EcalRecHit.h"
+#include "DataFormats/EcalRecHit/interface/EcalUncalibratedRecHit.h"
+
+
+#include "HLTrigger/HLTcore/interface/defaultModuleLabel.h"
+
+//this is a re-write of HLTRechitInRegionsProducer to be able to handle arbitary L1 collections as inputs
+//in the process, some of the cruft was cleaned up but it mantains almost all the old behaviour
+//think the only difference now is that it wont throw if its not ECALBarrel, ECALEndcap or ECAL PS rec-hit type
+class L1RegionGetterBase {
+public:
+  virtual ~L1RegionGetterBase(){}
+  virtual void getEtaPhiRegions(const edm::Event&,std::vector<EcalEtaPhiRegion>&,const L1CaloGeometry&)const=0;
+};  
+
+template<typename T1> class L1RegionGetter : public L1RegionGetterBase {
+private:
+  double minEt_;
+  double maxEt_;
+  double regionEtaMargin_;
+  double regionPhiMargin_;
+  edm::EDGetTokenT<T1> token_;
+public:
+  L1RegionGetter(const edm::ParameterSet& para,edm::ConsumesCollector & consumesColl):
+    minEt_(para.getParameter<double>("minEt")),
+    maxEt_(para.getParameter<double>("maxEt")),
+    regionEtaMargin_(para.getParameter<double>("regionEtaMargin")),
+    regionPhiMargin_(para.getParameter<double>("regionPhiMargin")),
+    token_(consumesColl.consumes<T1>(para.getParameter<edm::InputTag>("inputColl"))){}
+  
+  void getEtaPhiRegions(const edm::Event&,std::vector<EcalEtaPhiRegion>&,const L1CaloGeometry&)const override;
+};
+
+
+
+template<typename RecHitType>
+class HLTRecHitInAllL1RegionsProducer : public edm::stream::EDProducer<> {
+  
+  using  RecHitCollectionType =edm::SortedCollection<RecHitType>;
+  
+ public:
+
+  HLTRecHitInAllL1RegionsProducer(const edm::ParameterSet& ps);
+  ~HLTRecHitInAllL1RegionsProducer(){}
+
+  void produce(edm::Event&, const edm::EventSetup&) override;
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+ private:
+  L1RegionGetterBase* createL1RegionData(const std::string&,const edm::ParameterSet&,edm::ConsumesCollector &&); //calling function owns this
+  
+  std::vector<std::unique_ptr<L1RegionGetterBase>> l1RegionData_;
+ 
+  std::vector<edm::InputTag> recHitLabels_;
+  std::vector<std::string> productLabels_;
+
+  std::vector<edm::EDGetTokenT<RecHitCollectionType>> recHitTokens_;
+
+  
+};
+
+
+template<typename RecHitType> 
+HLTRecHitInAllL1RegionsProducer<RecHitType>::HLTRecHitInAllL1RegionsProducer(const edm::ParameterSet& para)
+{
+  const std::vector<edm::ParameterSet> l1InputRegions = para.getParameter<std::vector<edm::ParameterSet>>("l1InputRegions");
+  for(auto& pset : l1InputRegions){
+    const std::string type=pset.getParameter<std::string>("type");
+    l1RegionData_.emplace_back(createL1RegionData(type,pset,consumesCollector())); //meh I was going to use a factory but it was going to be overly complex for my needs
+  }
+  recHitLabels_ =para.getParameter<std::vector<edm::InputTag>>("recHitLabels");
+  productLabels_=para.getParameter<std::vector<std::string>>("productLabels");
+
+  for (unsigned int colNr=0; colNr<recHitLabels_.size(); colNr++) { 
+    recHitTokens_.push_back(consumes<RecHitCollectionType>(recHitLabels_[colNr]));
+    produces<RecHitCollectionType> (productLabels_[colNr]);
+  }
+}
+template<typename RecHitType> 
+void HLTRecHitInAllL1RegionsProducer<RecHitType>::fillDescriptions(edm::ConfigurationDescriptions& descriptions)
+{
+  edm::ParameterSetDescription desc;
+  std::vector<std::string> productTags;
+  productTags.push_back("EcalRegionalRecHitsEB");
+  productTags.push_back("EcalRegionalRecHitsEE");
+  desc.add<std::vector<std::string>>("productLabels", productTags);
+  std::vector<edm::InputTag> recHitLabels;
+  recHitLabels.push_back(edm::InputTag("hltEcalRegionalEgammaRecHit:EcalRecHitsEB"));
+  recHitLabels.push_back(edm::InputTag("hltEcalRegionalEgammaRecHit:EcalRecHitsEE"));
+  recHitLabels.push_back(edm::InputTag("hltESRegionalEgammaRecHit:EcalRecHitsES"));
+  desc.add<std::vector<edm::InputTag>>("recHitLabels", recHitLabels);
+  std::vector<edm::ParameterSet> l1InputRegions;
+  edm::ParameterSet emIsoPSet;
+  emIsoPSet.addParameter<std::string>("type","L1EmParticle");
+  emIsoPSet.addParameter<double>("minEt",5);
+  emIsoPSet.addParameter<double>("maxEt",999);
+  emIsoPSet.addParameter<double>("regionEtaMargin",0.14);
+  emIsoPSet.addParameter<double>("regionPhiMargin",0.4);
+  emIsoPSet.addParameter<edm::InputTag>("inputColl",edm::InputTag("hltL1extraParticles:NonIsolated"));
+  l1InputRegions.push_back(emIsoPSet);
+  edm::ParameterSet emNonIsoPSet;
+  emNonIsoPSet.addParameter<std::string>("type","L1EmParticle");
+  emNonIsoPSet.addParameter<double>("minEt",5);
+  emNonIsoPSet.addParameter<double>("maxEt",999);
+  emNonIsoPSet.addParameter<double>("regionEtaMargin",0.14);
+  emNonIsoPSet.addParameter<double>("regionPhiMargin",0.4);
+  emNonIsoPSet.addParameter<edm::InputTag>("inputColl",edm::InputTag("hltL1extraParticles:Isolated"));
+  l1InputRegions.push_back(emNonIsoPSet);
+  
+  edm::ParameterSetDescription l1InputRegionDesc;
+  l1InputRegionDesc.add<std::string>("type");
+  l1InputRegionDesc.add<double>("minEt");
+  l1InputRegionDesc.add<double>("maxEt");
+  l1InputRegionDesc.add<double>("regionEtaMargin");
+  l1InputRegionDesc.add<double>("regionPhiMargin");
+  l1InputRegionDesc.add<edm::InputTag>("inputColl");
+  desc.addVPSet("l1InputRegions",l1InputRegionDesc,l1InputRegions);
+  
+  descriptions.add(defaultModuleLabel<HLTRecHitInAllL1RegionsProducer<RecHitType>>(), desc); 
+}
+
+
+template<typename RecHitType>
+void HLTRecHitInAllL1RegionsProducer<RecHitType>::produce(edm::Event& event, const edm::EventSetup& setup) {
+
+  // get the collection geometry:
+  edm::ESHandle<CaloGeometry> caloGeomHandle;
+  setup.get<CaloGeometryRecord>().get(caloGeomHandle);
+    
+   // Get the CaloGeometry
+  edm::ESHandle<L1CaloGeometry> l1CaloGeom ;
+  setup.get<L1CaloGeometryRecord>().get(l1CaloGeom) ;
+  
+  std::vector<EcalEtaPhiRegion> regions;
+  std::for_each(l1RegionData_.begin(),l1RegionData_.end(),
+		[&event,&regions,l1CaloGeom](const std::unique_ptr<L1RegionGetterBase>& input)
+		{input->getEtaPhiRegions(event,regions,*l1CaloGeom);}
+		);
+    
+  for(size_t recHitColNr=0;recHitColNr<recHitTokens_.size();recHitColNr++){
+    edm::Handle<RecHitCollectionType> recHits;
+    event.getByToken(recHitTokens_[recHitColNr],recHits);
+    
+    if (!(recHits.isValid())) {
+      edm::LogError("ProductNotFound")<< "could not get a handle on the "<<typeid(RecHitCollectionType).name() <<" named "<< recHitLabels_[recHitColNr].encode() << std::endl;
+      continue;
+    }
+
+    std::auto_ptr<RecHitCollectionType> filteredRecHits(new RecHitCollectionType);
+      
+    if(!recHits->empty()){
+      const CaloSubdetectorGeometry* subDetGeom=caloGeomHandle->getSubdetectorGeometry(recHits->front().id());
+      if(!regions.empty()){
+      
+	for(const RecHitType& recHit : *recHits){
+	  const CaloCellGeometry* recHitGeom = subDetGeom->getGeometry(recHit.id());
+	  GlobalPoint position = recHitGeom->getPosition();
+	  for(const auto& region : regions){
+	    if(region.inRegion(position)) {
+	      filteredRecHits->push_back(recHit);
+		break;
+	    }
+	  }
+	}
+      }//end check of empty regions
+    }//end check of empty rec-hits
+    std::cout <<"putting fileter coll in "<<filteredRecHits->size()<<std::endl;
+    event.put(filteredRecHits,productLabels_[recHitColNr]);
+  }//end loop over all rec hit collections
+
+}
+
+
+
+
+
+template<typename RecHitType> 
+L1RegionGetterBase* HLTRecHitInAllL1RegionsProducer<RecHitType>::createL1RegionData(const std::string& type,const edm::ParameterSet& para,edm::ConsumesCollector && consumesCol)
+{
+  if(type=="L1EmParticle"){
+    return new L1RegionGetter<l1extra::L1EmParticleCollection>(para,consumesCol);
+  }else if(type=="L1JetParticle"){
+    return new L1RegionGetter<l1extra::L1JetParticleCollection>(para,consumesCol);
+  }else if(type=="L1MuonParticle"){
+    return new L1RegionGetter<l1extra::L1MuonParticleCollection>(para,consumesCol);
+  }else{
+    //this is a major issue and could lead to rather subtle efficiency losses, so if its incorrectly configured, we're aborting the job!
+    throw cms::Exception("InvalidConfig") << " type "<<type<<" is not recognised, this means the rec-hit you think you are keeping may not be and you should fix this error as it can lead to hard to find efficiency loses"<<std::endl;
+  }
+
+}
+
+
+
+template<typename L1ColType>
+void L1RegionGetter<L1ColType>::getEtaPhiRegions(const edm::Event& event,std::vector<EcalEtaPhiRegion>&regions,const L1CaloGeometry&)const
+{
+  edm::Handle<L1ColType> l1Cands;
+  event.getByToken(token_,l1Cands);
+  
+  for(const auto& l1Cand : *l1Cands){
+    if(l1Cand.et() >= minEt_ && l1Cand.et() < maxEt_){
+      
+      double etaLow = l1Cand.eta() - regionEtaMargin_;
+      double etaHigh = l1Cand.eta() + regionEtaMargin_;
+      double phiLow = l1Cand.phi() - regionPhiMargin_;
+      double phiHigh = l1Cand.phi() + regionPhiMargin_;
+      
+      regions.push_back(EcalEtaPhiRegion(etaLow,etaHigh,phiLow,phiHigh));
+    }
+  }
+}
+
+template<>
+void L1RegionGetter<l1extra::L1JetParticleCollection>::getEtaPhiRegions(const edm::Event& event,std::vector<EcalEtaPhiRegion>&regions,const L1CaloGeometry& l1CaloGeom)const
+{
+  edm::Handle<l1extra::L1JetParticleCollection> l1Cands;
+  event.getByToken(token_,l1Cands);
+  
+  for(const auto& l1Cand : *l1Cands){
+    if(l1Cand.et() >= minEt_ && l1Cand.et() < maxEt_){
+     
+      // Access the GCT hardware object corresponding to the L1Extra EM object.
+      int etaIndex = l1Cand.gctJetCand()->etaIndex();
+      int phiIndex = l1Cand.gctJetCand()->phiIndex();
+      
+      // Use the L1CaloGeometry to find the eta, phi bin boundaries.
+      double etaLow  = l1CaloGeom.etaBinLowEdge(etaIndex);
+      double etaHigh = l1CaloGeom.etaBinHighEdge(etaIndex);
+      double phiLow  = l1CaloGeom.emJetPhiBinLowEdge( phiIndex ) ;
+      double phiHigh = l1CaloGeom.emJetPhiBinHighEdge( phiIndex ) ;
+      
+      etaLow -= regionEtaMargin_;
+      etaHigh += regionEtaMargin_;
+      phiLow -= regionPhiMargin_;
+      phiHigh += regionPhiMargin_;
+
+      
+      regions.push_back(EcalEtaPhiRegion(etaLow,etaHigh,phiLow,phiHigh));
+    }
+  }
+}
+
+template<>
+void L1RegionGetter<l1extra::L1EmParticleCollection>::getEtaPhiRegions(const edm::Event& event,std::vector<EcalEtaPhiRegion>&regions,const L1CaloGeometry& l1CaloGeom)const
+{
+  edm::Handle<l1extra::L1EmParticleCollection> l1Cands;
+  event.getByToken(token_,l1Cands);
+  
+  for(const auto& l1Cand : *l1Cands){
+    if(l1Cand.et() >= minEt_ && l1Cand.et() < maxEt_){
+      
+       // Access the GCT hardware object corresponding to the L1Extra EM object.
+      int etaIndex = l1Cand.gctEmCand()->etaIndex();
+      int phiIndex = l1Cand.gctEmCand()->phiIndex();
+      
+      // Use the L1CaloGeometry to find the eta, phi bin boundaries.
+      double etaLow  = l1CaloGeom.etaBinLowEdge(etaIndex);
+      double etaHigh = l1CaloGeom.etaBinHighEdge(etaIndex);
+      double phiLow  = l1CaloGeom.emJetPhiBinLowEdge( phiIndex ) ;
+      double phiHigh = l1CaloGeom.emJetPhiBinHighEdge( phiIndex ) ;
+      
+      etaLow -= regionEtaMargin_;
+      etaHigh += regionEtaMargin_;
+      phiLow -= regionPhiMargin_;
+      phiHigh += regionPhiMargin_;
+      
+      regions.push_back(EcalEtaPhiRegion(etaLow,etaHigh,phiLow,phiHigh));
+    }
+  }
+}
+
+
+
+
+typedef HLTRecHitInAllL1RegionsProducer<EcalRecHit> HLTEcalRecHitInAllL1RegionsProducer;
+DEFINE_FWK_MODULE(HLTEcalRecHitInAllL1RegionsProducer);
+typedef HLTRecHitInAllL1RegionsProducer<EcalUncalibratedRecHit> HLTEcalUncalibratedRecHitInAllL1RegionsProducer;
+DEFINE_FWK_MODULE(HLTEcalUncalibratedRecHitInAllL1RegionsProducer);
+
+
+#endif
+
+

--- a/RecoEgamma/EgammaHLTProducers/src/HLTRecHitInAllL1RegionsProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/HLTRecHitInAllL1RegionsProducer.cc
@@ -1,0 +1,1 @@
+#include "RecoEgamma/EgammaHLTProducers/interface/HLTRecHitInAllL1RegionsProducer.h"


### PR DESCRIPTION
Dear All,

This pull request has the necessary code to allow the E/g HLT paths to be seeded by L1 Jets. This is discussed in detail [here](https://indico.cern.ch/event/376580/contribution/3/material/slides/1.pdf). I have now confirmed that I can proceed with this so I'm doing so now. 

This requires two changes. First it requires a new class, HLTRecHitInAllL1RegionsProducer which is a re-write of [HLTRechitInRegionsProducer](https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/RecoEgamma/EgammaHLTProducers/interface/HLTRechitInRegionsProducer.h) generalised to accept any combination of L1 seed types. This class is vital the E/g HLT to save time filters the rec-hits used by the PFclusters to be near L1 seeds. This class has been tested on ~30 million events and when configured identically to the old class, it gives identical results.

The second change is to allow the HLTEgammaL1MatchFilterRegional filter to also try to look for L1 jets. If the L1 seed module does not contain a jet seed, nothing will happen.
