### PR TITLE
Hcal noise filters backport

### DIFF
--- a/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
+++ b/CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
@@ -1,0 +1,153 @@
+// -*- C++ -*-
+//
+// Package:    CommonTools/RecoAlgos
+// Class:      BooleanFlagFilter
+// 
+/**\class BooleanFlagFilter BooleanFlagFilter.cc CommonTools/RecoAlgos/plugins/BooleanFlagFilter.cc
+
+ Description: [one line class summary]
+
+ Implementation:
+     [Notes on implementation]
+*/
+//
+// Original Author:  Igor Volobouev
+//         Created:  Fri, 20 Mar 2015 08:05:20 GMT
+//
+//
+
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+//
+// class declaration
+//
+
+class BooleanFlagFilter : public edm::EDFilter {
+   public:
+      explicit BooleanFlagFilter(const edm::ParameterSet&);
+      ~BooleanFlagFilter();
+
+   private:
+      virtual void beginJob() override;
+      virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+      virtual void endJob() override;
+      
+      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
+      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
+
+      // ----------member data ---------------------------
+      edm::EDGetTokenT<bool> inputToken_;
+      bool reverse_;
+};
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+//
+// constructors and destructor
+//
+BooleanFlagFilter::BooleanFlagFilter(const edm::ParameterSet& iConfig)
+{
+   //now do what ever initialization is needed
+   inputToken_ = consumes<bool>(iConfig.getParameter<edm::InputTag>("inputLabel"));
+   reverse_ = iConfig.getParameter<bool>("reverseDecision");
+}
+
+
+BooleanFlagFilter::~BooleanFlagFilter()
+{
+ 
+   // do anything here that needs to be done at desctruction time
+   // (e.g. close files, deallocate resources etc.)
+
+}
+
+
+//
+// member functions
+//
+
+// ------------ method called on each new Event  ------------
+bool
+BooleanFlagFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+   using namespace edm;
+
+   Handle<bool> pIn;
+   iEvent.getByToken(inputToken_, pIn);
+   if (!pIn.isValid())
+   {
+      throw edm::Exception(edm::errors::ProductNotFound) << " could not find requested flag\n";
+      return true;
+   }
+
+   bool result = *pIn;
+   if (reverse_)
+      result = !result;
+
+   return result;
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+BooleanFlagFilter::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+BooleanFlagFilter::endJob() {
+}
+
+// ------------ method called when starting to processes a run  ------------
+/*
+void
+BooleanFlagFilter::beginRun(edm::Run const&, edm::EventSetup const&)
+{ 
+}
+*/
+ 
+// ------------ method called when ending the processing of a run  ------------
+/*
+void
+BooleanFlagFilter::endRun(edm::Run const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when starting to processes a luminosity block  ------------
+/*
+void
+BooleanFlagFilter::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+// ------------ method called when ending the processing of a luminosity block  ------------
+/*
+void
+BooleanFlagFilter::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+*/
+ 
+//define this as a plug-in
+DEFINE_FWK_MODULE(BooleanFlagFilter);

--- a/CommonTools/RecoAlgos/plugins/HBHENoiseFilterResultProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/HBHENoiseFilterResultProducer.cc
@@ -19,6 +19,7 @@
 
 // system include files
 #include <memory>
+#include <map>
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
@@ -26,6 +27,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Utilities/interface/Exception.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -48,23 +50,14 @@ class HBHENoiseFilterResultProducer : public edm::EDProducer {
 
       // parameters
       edm::EDGetTokenT<HcalNoiseSummary> noisetoken_;
-      double minRatio_, maxRatio_;
-      int minHPDHits_, minRBXHits_, minHPDNoOtherHits_;
+      int minHPDHits_;
+      int minHPDNoOtherHits_;
       int minZeros_;
-      double minHighEHitTime_, maxHighEHitTime_;
-      double maxRBXEMF_;
-      int minNumIsolatedNoiseChannels_;
-      double minIsolatedNoiseSumE_, minIsolatedNoiseSumEt_;
-
-      bool useTS4TS5_;
-      bool useRBXRechitR45Loose_;
-      bool useRBXRechitR45Tight_;
 
       bool IgnoreTS4TS5ifJetInLowBVRegion_;
-      edm::InputTag jetlabel_;
-      edm::EDGetTokenT<reco::PFJetCollection> jettoken_;
-      int maxjetindex_;
-      double maxNHF_;
+      std::string defaultDecision_;
+
+      std::map<std::string, bool> decisionMap_;
 };
 
 
@@ -76,29 +69,16 @@ HBHENoiseFilterResultProducer::HBHENoiseFilterResultProducer(const edm::Paramete
 {
   //now do what ever initialization is needed
   noisetoken_ = consumes<HcalNoiseSummary>(iConfig.getParameter<edm::InputTag>("noiselabel"));
-  minRatio_ = iConfig.getParameter<double>("minRatio");
-  maxRatio_ = iConfig.getParameter<double>("maxRatio");
   minHPDHits_ = iConfig.getParameter<int>("minHPDHits");
-  minRBXHits_ = iConfig.getParameter<int>("minRBXHits");
   minHPDNoOtherHits_ = iConfig.getParameter<int>("minHPDNoOtherHits");
   minZeros_ = iConfig.getParameter<int>("minZeros");
-  minHighEHitTime_ = iConfig.getParameter<double>("minHighEHitTime");
-  maxHighEHitTime_ = iConfig.getParameter<double>("maxHighEHitTime");
-  maxRBXEMF_ = iConfig.getParameter<double>("maxRBXEMF");
-  minNumIsolatedNoiseChannels_ = iConfig.getParameter<int>("minNumIsolatedNoiseChannels");
-  minIsolatedNoiseSumE_ = iConfig.getParameter<double>("minIsolatedNoiseSumE");
-  minIsolatedNoiseSumEt_ = iConfig.getParameter<double>("minIsolatedNoiseSumEt");
-  useTS4TS5_ = iConfig.getParameter<bool>("useTS4TS5");
-  useRBXRechitR45Loose_ = iConfig.getParameter<bool>("useRBXRechitR45Loose");
-  useRBXRechitR45Tight_ = iConfig.getParameter<bool>("useRBXRechitR45Tight");
-
   IgnoreTS4TS5ifJetInLowBVRegion_ = iConfig.getParameter<bool>("IgnoreTS4TS5ifJetInLowBVRegion");
-  jetlabel_ =  iConfig.getParameter<edm::InputTag>("jetlabel");
-  jettoken_ = mayConsume<reco::PFJetCollection>(jetlabel_);
-  maxjetindex_ = iConfig.getParameter<int>("maxjetindex");
-  maxNHF_ = iConfig.getParameter<double>("maxNHF");
+  defaultDecision_ = iConfig.getParameter<std::string>("defaultDecision");
 
   produces<bool>("HBHENoiseFilterResult");
+  produces<bool>("HBHENoiseFilterResultRun1");
+  produces<bool>("HBHENoiseFilterResultRun2Loose");
+  produces<bool>("HBHENoiseFilterResultRun2Tight");
 }
 
 
@@ -125,63 +105,44 @@ HBHENoiseFilterResultProducer::produce(edm::Event& iEvent, const edm::EventSetup
     throw edm::Exception(edm::errors::ProductNotFound) << " could not find HcalNoiseSummary.\n";
     return;
   }
-  const HcalNoiseSummary summary = *summary_h;
+  const HcalNoiseSummary& summary(*summary_h);
 
-  bool result=true; // stores overall filter result
+  bool goodJetFoundInLowBVRegion = false;
+  if (IgnoreTS4TS5ifJetInLowBVRegion_)
+      goodJetFoundInLowBVRegion = summary.goodJetFoundInLowBVRegion();
 
-  bool goodJetFoundInLowBVRegion=false; // checks whether a jet is in a low BV region, where false noise flagging rate is higher.
+  const bool failCommon = summary.maxHPDHits() >= minHPDHits_ ||
+                          summary.maxHPDNoOtherHits() >= minHPDNoOtherHits_ ||
+                          summary.maxZeros() >= minZeros_;
 
-  if ( IgnoreTS4TS5ifJetInLowBVRegion_==true)
-    {
-      edm::Handle<reco::PFJetCollection> pfjet_h;
-      iEvent.getByToken(jettoken_, pfjet_h);
-      if(pfjet_h.isValid())  // valid jet collection found
-	{
-	  int jetindex=0;
-	  for( reco::PFJetCollection::const_iterator jet = pfjet_h->begin(); jet != pfjet_h->end(); ++jet)
-	    {
-	      if (jetindex>maxjetindex_) break; // only look at first N jets (N specified by user via maxjetindex_)
-	      // Check whether jet is in low-BV region (0<eta<1.4, -1.8<phi<-1.4)
-	      if (jet->eta()>0 && jet->eta()<1.4 &&
-		  jet->phi()>-1.8 && jet->phi()<-1.4)
-		{
-		  // Look for a good jet in low BV region; if found, we will keep event
-		  if  (maxNHF_<0 ||  jet->neutralHadronEnergyFraction()<maxNHF_)
-		    {
-		      goodJetFoundInLowBVRegion=true;
-		      break;
-		    }
-		}
-	      ++jetindex;
-	    }
-	} // if (pfjet_h.isValid())
-      else // no valid jet collection found
-	{
-	  // If no jet collection found, do we want to throw a fatal exception?  Or just proceed normally, not treating the lowBV region as special?
-	  //throw edm::Exception(edm::errors::ProductNotFound) << " could not find PFJetCollection with label "<<jetlabel_<<".\n";
-	}
-    } // if (IgnoreTS4TS5ifJetInLowBVRegion_==true)
+  const bool failRun1 = failCommon || (summary.HasBadRBXTS4TS5() &&
+                                       !goodJetFoundInLowBVRegion);
+  decisionMap_["HBHENoiseFilterResultRun1"] = failRun1;
 
-  if(summary.minE2Over10TS()<minRatio_) result=false;
-  if(summary.maxE2Over10TS()>maxRatio_) result=false;
-  if(summary.maxHPDHits()>=minHPDHits_) result=false;
-  if(summary.maxRBXHits()>=minRBXHits_) result=false;
-  if(summary.maxHPDNoOtherHits()>=minHPDNoOtherHits_) result=false;
-  if(summary.maxZeros()>=minZeros_) result=false;
-  if(summary.min25GeVHitTime()<minHighEHitTime_) result=false;
-  if(summary.max25GeVHitTime()>maxHighEHitTime_) result=false;
-  if(summary.minRBXEMF()<maxRBXEMF_) result=false;
-  if(summary.numIsolatedNoiseChannels()>=minNumIsolatedNoiseChannels_) result=false;
-  if(summary.isolatedNoiseSumE()>=minIsolatedNoiseSumE_) result=false;
-  if(summary.isolatedNoiseSumEt()>=minIsolatedNoiseSumEt_) result=false;
-  if(useTS4TS5_ && summary.HasBadRBXTS4TS5() == true && !goodJetFoundInLowBVRegion) result = false;
-  if(useRBXRechitR45Loose_ && summary.HasBadRBXRechitR45Loose() == true && !goodJetFoundInLowBVRegion) result = false;
-  if(useRBXRechitR45Tight_ && summary.HasBadRBXRechitR45Tight() == true && !goodJetFoundInLowBVRegion) result = false;
+  const bool failRun2Loose = failCommon || (summary.HasBadRBXRechitR45Loose() &&
+                                            !goodJetFoundInLowBVRegion);
+  decisionMap_["HBHENoiseFilterResultRun2Loose"] = failRun2Loose;
 
-  std::auto_ptr<bool> pOut(new bool);
-  *pOut=result;
+  const bool failRun2Tight = failCommon || (summary.HasBadRBXRechitR45Tight() &&
+                                            !goodJetFoundInLowBVRegion);
+  decisionMap_["HBHENoiseFilterResultRun2Tight"] = failRun2Tight;
 
+  // Write out the standard flags
+  std::auto_ptr<bool> pOut;
+  for (std::map<std::string, bool>::const_iterator it = decisionMap_.begin();
+       it != decisionMap_.end(); ++it)
+  {
+      pOut = std::auto_ptr<bool>(new bool(!it->second));
+      iEvent.put(pOut, it->first);
+  }
+
+  // Write out the default flag
+  std::map<std::string, bool>::const_iterator it = decisionMap_.find(defaultDecision_);
+  if (it == decisionMap_.end())
+      throw cms::Exception("Invalid HBHENoiseFilterResultProducer parameter \"defaultDecision\"");
+  pOut = std::auto_ptr<bool>(new bool(!it->second));
   iEvent.put(pOut, "HBHENoiseFilterResult");
+
   return;
 }
 

--- a/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
+++ b/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
@@ -11,5 +11,5 @@ HBHENoiseFilterResultProducer = cms.EDProducer(
 )
 
 from Configuration.StandardSequences.Eras import eras
-eras.run2_25ns_specific.toModify(HBHENoiseFilterResultProducer, IgnoreTS4TS5ifJetInLowBVRegion=False)
+eras.run2_common.toModify(HBHENoiseFilterResultProducer, IgnoreTS4TS5ifJetInLowBVRegion=False)
 eras.run2_25ns_specific.toModify(HBHENoiseFilterResultProducer, defaultDecision="HBHENoiseFilterResultRun2Loose")

--- a/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
+++ b/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
@@ -3,23 +3,13 @@ import FWCore.ParameterSet.Config as cms
 HBHENoiseFilterResultProducer = cms.EDProducer(
     'HBHENoiseFilterResultProducer',
     noiselabel = cms.InputTag('hcalnoise'),
-    minRatio = cms.double(-999),
-    maxRatio = cms.double(999),
     minHPDHits = cms.int32(17),
-    minRBXHits = cms.int32(999),
     minHPDNoOtherHits = cms.int32(10),
     minZeros = cms.int32(10),
-    minHighEHitTime = cms.double(-9999.0),
-    maxHighEHitTime = cms.double(9999.0),
-    maxRBXEMF = cms.double(-999.0),
-    minNumIsolatedNoiseChannels = cms.int32(10),
-    minIsolatedNoiseSumE = cms.double(50.0),
-    minIsolatedNoiseSumEt = cms.double(25.0),
-    useTS4TS5 = cms.bool(False),
-    useRBXRechitR45Loose = cms.bool(False),
-    useRBXRechitR45Tight = cms.bool(False),
-    IgnoreTS4TS5ifJetInLowBVRegion=cms.bool(True),
-    jetlabel = cms.InputTag('ak4PFJets'),
-    maxjetindex = cms.int32(0), # maximum jet index that will be checked for 'IgnoreTS4TS5ifJetInLowBVRegion'
-    maxNHF = cms.double(0.9) # maximum allowed jet->neutralHadronEnergyFraction() for a jet in low BV region to be considered 'good' (and thus skip the noise check)
-    )
+    IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(True),
+    defaultDecision = cms.string("HBHENoiseFilterResultRun1")
+)
+
+from Configuration.StandardSequences.Eras import eras
+eras.run2_25ns_specific.toModify(HBHENoiseFilterResultProducer, IgnoreTS4TS5ifJetInLowBVRegion=False)
+eras.run2_25ns_specific.toModify(HBHENoiseFilterResultProducer, defaultDecision="HBHENoiseFilterResultRun2Loose")

--- a/DataFormats/METReco/interface/HcalNoiseSummary.h
+++ b/DataFormats/METReco/interface/HcalNoiseSummary.h
@@ -138,6 +138,7 @@ class HcalNoiseSummary
   bool HasBadRBXTS4TS5(void) const;
   bool HasBadRBXRechitR45Loose(void) const;
   bool HasBadRBXRechitR45Tight(void) const;
+  bool goodJetFoundInLowBVRegion(void) const;
 
   double GetCalibChargeHF(void) const;
   int    GetCalibCountHF(void)  const;
@@ -197,6 +198,7 @@ class HcalNoiseSummary
   bool hasBadRBXTS4TS5_;
   bool hasBadRBXRechitR45Loose_;
   bool hasBadRBXRechitR45Tight_;
+  bool goodJetFoundInLowBVRegion_;
 
   int calibCountTS45_;
   int calibCountgt15TS45_;
@@ -216,7 +218,6 @@ class HcalNoiseSummary
   edm::RefVector<CaloTowerCollection> loosenoisetwrs_;
   edm::RefVector<CaloTowerCollection> tightnoisetwrs_;
   edm::RefVector<CaloTowerCollection> hlnoisetwrs_;
-
 };
 
 #endif

--- a/DataFormats/METReco/src/HcalNoiseHPD.cc
+++ b/DataFormats/METReco/src/HcalNoiseHPD.cc
@@ -110,28 +110,28 @@ const edm::RefVector<HBHERecHitCollection> HcalNoiseHPD::recHits(void) const
   return rechits_;
 }
   
-float HcalNoiseHPD::recHitEnergy(float threshold) const
+float HcalNoiseHPD::recHitEnergy(const float threshold) const
 {
-  float total=0.0;
+  double total=0.0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
-    float energy=(*it)->energy();
+    const float energy=(*it)->eraw();
     if(energy>=threshold) total+=energy;
   }
   return total;
 }
 
-float HcalNoiseHPD::recHitEnergyFailR45(float threshold) const
+float HcalNoiseHPD::recHitEnergyFailR45(const float threshold) const
 {
-  float total=0.0;
+  double total=0.0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
-    float energy=(*it)->energy();
+    const float energy=(*it)->eraw();
     if((*it)->flagField(HcalCaloFlagLabels::HBHETS4TS5Noise))
        if(energy>=threshold) total+=energy;
   }
   return total;
 }
 
-float HcalNoiseHPD::minRecHitTime(float threshold) const
+float HcalNoiseHPD::minRecHitTime(const float threshold) const
 {
   float mintime=9999999;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
@@ -142,7 +142,7 @@ float HcalNoiseHPD::minRecHitTime(float threshold) const
   return mintime;
 }
   
-float HcalNoiseHPD::maxRecHitTime(float threshold) const
+float HcalNoiseHPD::maxRecHitTime(const float threshold) const
 {
   float maxtime=-9999999;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it) {
@@ -153,20 +153,20 @@ float HcalNoiseHPD::maxRecHitTime(float threshold) const
   return maxtime;
 }
 
-int HcalNoiseHPD::numRecHits(float threshold) const
+int HcalNoiseHPD::numRecHits(const float threshold) const
 {
   int count=0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it)
-    if((*it)->energy()>=threshold) ++count;
+    if((*it)->eraw()>=threshold) ++count;
   return count;
 }
 
-int HcalNoiseHPD::numRecHitsFailR45(float threshold) const
+int HcalNoiseHPD::numRecHitsFailR45(const float threshold) const
 {
   int count=0;
   for(edm::RefVector<HBHERecHitCollection>::const_iterator it=rechits_.begin(); it!=rechits_.end(); ++it)
     if((*it)->flagField(HcalCaloFlagLabels::HBHETS4TS5Noise))
-      if((*it)->energy()>=threshold) ++count;
+      if((*it)->eraw()>=threshold) ++count;
   return count;
 }
 

--- a/DataFormats/METReco/src/HcalNoiseSummary.cc
+++ b/DataFormats/METReco/src/HcalNoiseSummary.cc
@@ -339,6 +339,11 @@ bool HcalNoiseSummary::HasBadRBXRechitR45Tight(void) const
    return hasBadRBXRechitR45Tight_;
 }
 
+bool HcalNoiseSummary::goodJetFoundInLowBVRegion(void) const
+{
+   return goodJetFoundInLowBVRegion_;
+}
+
 int HcalNoiseSummary::GetCalibCountTS45(void) const
 {
   return calibCountTS45_;

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -127,11 +127,12 @@
   <class name="reco::HcalNoiseRBXCollection"/>
   <class name="edm::Wrapper<reco::HcalNoiseRBXCollection>"/>
 
-  <class name="HcalNoiseSummary" ClassVersion="14">
+  <class name="HcalNoiseSummary" ClassVersion="15">
    <version ClassVersion="11" checksum="664452001"/>
    <version ClassVersion="12" checksum="4280559065"/>
    <version ClassVersion="13" checksum="382065414"/>
    <version ClassVersion="14" checksum="651605939"/>
+   <version ClassVersion="15" checksum="2415916091"/>
   </class>
   <class name="edm::Wrapper<HcalNoiseSummary>"/>
 

--- a/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
+++ b/RecoMET/METProducers/interface/HcalNoiseInfoProducer.h
@@ -35,6 +35,7 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/JetReco/interface/PFJetCollection.h"
 
 namespace reco {
 
@@ -66,6 +67,7 @@ namespace reco {
     void filldigis(edm::Event&, const edm::EventSetup&, HcalNoiseRBXArray&, HcalNoiseSummary&);
     void fillcalotwrs(edm::Event&, const edm::EventSetup&, HcalNoiseRBXArray&, HcalNoiseSummary&) const;
     void filltracks(edm::Event&, const edm::EventSetup&, HcalNoiseSummary&) const;
+    void filljetinfo(edm::Event&, const edm::EventSetup&, HcalNoiseSummary&) const;
 
     // other helper functions
     void fillOtherSummaryVariables(HcalNoiseSummary& summary, const CommonHcalNoiseRBXData& data) const;
@@ -87,17 +89,21 @@ namespace reco {
     int maxCaloTowerIEta_;      // maximum caloTower ieta
     double maxTrackEta_;        // maximum eta of the track
     double minTrackPt_;         // minimum track Pt
+    double maxNHF_;
+    int maxjetindex_;
     
     std::string digiCollName_;         // name of the digi collection
     std::string recHitCollName_;       // name of the rechit collection
     std::string caloTowerCollName_;    // name of the caloTower collection
     std::string trackCollName_;        // name of the track collection
+    std::string jetCollName_;          // name of the jet collection
 
     edm::EDGetTokenT<HBHEDigiCollection> hbhedigi_token_;
     edm::EDGetTokenT<HcalCalibDigiCollection> hcalcalibdigi_token_;
     edm::EDGetTokenT<HBHERecHitCollection> hbherechit_token_;
     edm::EDGetTokenT<CaloTowerCollection> calotower_token_;
     edm::EDGetTokenT<reco::TrackCollection> track_token_;
+    edm::EDGetTokenT<reco::PFJetCollection> jet_token_;
 
     double TotalCalibCharge;    // placeholder to calculate total charge in calibration channels
 

--- a/RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi.py
+++ b/RecoMET/METProducers/python/hcalnoiseinfoproducer_cfi.py
@@ -107,12 +107,15 @@ hcalnoise = cms.EDProducer(
     maxCaloTowerIEta = cms.int32(20),
     maxTrackEta = cms.double(2.0),
     minTrackPt = cms.double(1.0),
+    maxNHF = cms.double(0.9),
+    maxjetindex = cms.int32(0),
 
     # collection names
     digiCollName = cms.string('hcalDigis'),
     recHitCollName = cms.string('hbhereco'),
     caloTowerCollName = cms.string('towerMaker'),
     trackCollName = cms.string('generalTracks'),
+    jetCollName = cms.string('ak4PFJets'),
 
     # severity level
     HcalAcceptSeverityLevel = cms.uint32(9),

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -49,6 +49,8 @@ def customisePostLS1(process):
     # 25ns specific customisation
     if hasattr(process,'digitisation_step'):
         process = customise_Digi_25ns(process)
+    if hasattr(process,'dqmoffline_step'):
+        process = customise_DQM_25ns(process)
 
     return process
 
@@ -99,6 +101,16 @@ def customise_DQM(process):
     #process.dqmoffline_step.remove(process.jetMETAnalyzer)
     # Turn off flag of gangedME11a
     process.l1tCsctf.gangedME11a = cms.untracked.bool(False)
+    # Turn off "low bias voltage" region in HCAL noise filters
+    if hasattr(process,'HBHENoiseFilterResultProducer'):
+        process.HBHENoiseFilterResultProducer.IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(False)
+    return process
+
+
+def customise_DQM_25ns(process):
+    # Switch the default decision of the HCAL noise filter
+    if hasattr(process,'HBHENoiseFilterResultProducer'):
+        process.HBHENoiseFilterResultProducer.defaultDecision = cms.string("HBHENoiseFilterResultRun2Loose")
     return process
 
 


### PR DESCRIPTION
Backporting PR #8685

Compared to PR #8685, there is a minor difference in the config files -- the "HBHENoiseFilterResultRun2Loose" flag is made default only for 25 ns Run 2 rather than for the whole Run 2. For 50 ns Run 2 we still use "HBHENoiseFilterResultRun1".
