### PR TITLE
Allow local file system detection to handle bind mounts.

### DIFF
--- a/Utilities/StorageFactory/interface/LocalFileSystem.h
+++ b/Utilities/StorageFactory/interface/LocalFileSystem.h
@@ -23,7 +23,7 @@ private:
   FSInfo *	initFSInfo(void *p);
   int		initFSList(void);
   int		statFSInfo(FSInfo *i);
-  FSInfo *	findMount(const char *path, struct statfs *sfs, struct stat *s);
+  FSInfo *	findMount(const char *path, struct statfs *sfs, struct stat *s, std::vector<std::string> &);
 
   std::vector<FSInfo *> fs_;
   std::vector<std::string> fstypes_;

--- a/Utilities/StorageFactory/src/LocalFileSystem.cc
+++ b/Utilities/StorageFactory/src/LocalFileSystem.cc
@@ -28,11 +28,13 @@ struct LocalFileSystem::FSInfo
   char		*fsname;	//< file system name
   char		*type;		//< file system type
   char		*dir;		//< mount point directory
+  char		*origin = nullptr; //< mount origin
   dev_t		dev;		//< device id
   long		fstype;		//< file system id
   double	freespc;	//< free space in megabytes
   unsigned 	local : 1;	//< flag for local device
   unsigned	checked : 1;	//< flag for valid dev, fstype
+  unsigned	bind : 1;	//< flag for bind mounts
 };
 
 /** Read /proc/filesystems to determine which filesystems are local,
@@ -154,6 +156,8 @@ LocalFileSystem::initFSInfo(void *arg)
   i->dev = m->f_fsid.val[0];
   i->fstype = m->f_type;
   i->freespc = 0;
+  i->bind = 0;
+  i->origin = nullptr;
   if (m->f_bsize > 0)
   {
     i->freespc = m->f_bavail;
@@ -176,17 +180,20 @@ LocalFileSystem::initFSInfo(void *arg)
   size_t fslen = strlen(m->mnt_fsname) + 1;
   size_t dirlen = strlen(m->mnt_dir) + 1;
   size_t typelen = strlen(m->mnt_type) + 1;
-  size_t totlen = infolen + fslen + dirlen + typelen;
+  size_t originlen = strlen(m->mnt_fsname) + 1;
+  size_t totlen = infolen + fslen + dirlen + typelen + originlen;
   FSInfo *i = (FSInfo *) malloc(totlen);
   char *p = (char *) i;
   i->fsname = strncpy(p += infolen, m->mnt_fsname, fslen);
   i->type = strncpy(p += fslen, m->mnt_type, typelen);
   i->dir = strncpy(p += typelen, m->mnt_dir, dirlen);
+  i->origin = strncpy(p += dirlen, m->mnt_fsname, originlen);
   i->dev = -1;
   i->fstype = -1;
   i->freespc = 0;
   i->local = 0;
   i->checked = 0;
+  i->bind = strstr(m->mnt_opts, "bind") != nullptr;
 
   for (size_t j = 0; j < fstypes_.size() && ! i->local; ++j)
     if (fstypes_[j] == i->type)
@@ -313,8 +320,18 @@ LocalFileSystem::statFSInfo(FSInfo *i)
     system is unavailable or some other way dysfunctional, such as
     dead nfs mount or filesystem does not implement statfs().  */
 LocalFileSystem::FSInfo *
-LocalFileSystem::findMount(const char *path, struct statfs *sfs, struct stat *s)
+LocalFileSystem::findMount(const char *path, struct statfs *sfs, struct stat *s, std::vector<std::string> &prev_paths)
 {
+  for (const auto & old_path : prev_paths)
+  {
+    if (!strcmp(old_path.c_str(), path))
+    {
+      edm::LogWarning("LocalFileSystem::findMount()")
+        << "Found a loop in bind mounts; stopping evaluation.";
+      return nullptr;
+    }
+  }
+
   FSInfo *best = 0;
   size_t bestlen = 0;
   size_t len = strlen(path);
@@ -347,6 +364,42 @@ LocalFileSystem::findMount(const char *path, struct statfs *sfs, struct stat *s)
       best = fs_[i];
       bestlen = fslen;
     }
+  }
+  // In the case of a bind mount, try looking again at the source directory.
+  if (best->bind && best->origin)
+  {
+    struct stat s2;
+    struct statfs sfs2;
+    char *fullpath = realpath(best->origin, 0);
+
+    if (! fullpath)
+      fullpath = strdup(best->origin);
+
+    if (lstat(fullpath, &s2) < 0)
+    {
+      int nerr = errno;
+      edm::LogWarning("LocalFileSystem::findMount()")
+        << "Cannot lstat('" << fullpath << "' alias '"
+        << path << "'): " << strerror(nerr) << " (error "
+        << nerr << ")";
+      free(fullpath);
+      return best;
+    }
+
+    if (statfs(fullpath, &sfs2) < 0)
+    {
+      int nerr = errno;
+      edm::LogWarning("LocalFileSystem::findMount()")
+        << "Cannot statfs('" << fullpath << "' alias '"
+        << path << "'): " << strerror(nerr) << " (error "
+        << nerr << ")";
+      free(fullpath);
+      return best;
+    }
+
+    prev_paths.push_back(path);
+    LocalFileSystem::FSInfo *new_best = findMount(fullpath, &sfs2, &s2, prev_paths);
+    return new_best ? new_best : best;
   }
 
   return best;
@@ -393,7 +446,8 @@ LocalFileSystem::isLocalPath(const std::string &path)
     return false;
   }
 
-  FSInfo *m = findMount(fullpath, &sfs, &s);
+  std::vector<std::string> prev_paths;
+  FSInfo *m = findMount(fullpath, &sfs, &s, prev_paths);
   free(fullpath);
 
   return m ? m->local : false;
@@ -474,7 +528,8 @@ LocalFileSystem::findCachePath(const std::vector<std::string> &paths,
       continue;
     }
 
-    FSInfo *m = findMount(fullpath, &sfs, &s);
+    std::vector<std::string> prev_paths;
+    FSInfo *m = findMount(fullpath, &sfs, &s, prev_paths);
 #if 0
     std::cerr /* edm::LogInfo("LocalFileSystem") */
       << "Candidate '" << fullpath << "': "


### PR DESCRIPTION
Bind mounts are like a symlink on steroids - they allow admins to
graft part of the filesystem tree onto a different portion.

They show up as filesystem type "none", which we currently interpret
as a non-local filesystem.

With this patch, if a bind mount is detected, we lookup the source
of the mount and re-run local file system detection on that directory
instead.

Thus, if the bind mount is of a local filesystem, then we correctly
declare it local.  This patch was tested on a T0 VM which hit this
issue.

Recursion is used (so bind-mounts-that-have-bind-mounts are OK);
patch includes cycle detection (although I'm not sure how one can
form a cycle, but I hate infinite recursion).

Sending a PR to 7_3_X per request from Dirk; this should be merged through 7_4_X and 7_5_X also.
