### PR TITLE
Set StandardSequences to take MF geometry and configuration from the DB

### DIFF
--- a/Configuration/StandardSequences/python/MagneticField_0T_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_0T_cff.py
@@ -1,3 +1,5 @@
+# Load the 0T field map, with the geometry specified in the GT
+
 import FWCore.ParameterSet.Config as cms
-from MagneticField.Engine.autoMagneticFieldProducer_cfi import *
-AutoMagneticFieldESProducer.valueOverride = 0
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
+VolumeBasedMagneticFieldESProducer.valueOverride = 0

--- a/Configuration/StandardSequences/python/MagneticField_20T_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_20T_cff.py
@@ -1,10 +1,5 @@
+# Load the 2T field map, with the geometry and configuration specified in the GT
+
 import FWCore.ParameterSet.Config as cms
-
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#Default is version 85l
-from MagneticField.Engine.volumeBasedMagneticField_1103l_cfi import *
-VolumeBasedMagneticFieldESProducer.version = 'grid_1103l_071212_2t'
-ParametrizedMagneticFieldProducer.parameters.BValue = '2_0T'
-
-
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
+VolumeBasedMagneticFieldESProducer.valueOverride = 9558

--- a/Configuration/StandardSequences/python/MagneticField_30T_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_30T_cff.py
@@ -1,10 +1,5 @@
+# Load the 3 T field map, with the geometry and configuration specified in the GT
+
 import FWCore.ParameterSet.Config as cms
-
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#Default is version 85l
-from MagneticField.Engine.volumeBasedMagneticField_1103l_cfi import *
-VolumeBasedMagneticFieldESProducer.version = 'grid_1103l_071212_3t'
-ParametrizedMagneticFieldProducer.parameters.BValue = '3_0T'
-
-
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
+VolumeBasedMagneticFieldESProducer.valueOverride = 14416

--- a/Configuration/StandardSequences/python/MagneticField_35T_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_35T_cff.py
@@ -1,10 +1,5 @@
+# Load the 3.5 T field map, with the geometry and configuration specified in the GT
+
 import FWCore.ParameterSet.Config as cms
-
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#Default is version 85l
-from MagneticField.Engine.volumeBasedMagneticField_1103l_cfi import *
-VolumeBasedMagneticFieldESProducer.version = 'grid_1103l_071212_3_5t'
-ParametrizedMagneticFieldProducer.parameters.BValue = '3_5T'
-
-
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
+VolumeBasedMagneticFieldESProducer.valueOverride = 16819

--- a/Configuration/StandardSequences/python/MagneticField_38T_PostLS1_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_38T_PostLS1_cff.py
@@ -1,8 +1,6 @@
-import FWCore.ParameterSet.Config as cms
+# Run 2 default field map configuration. This cff is DEPRECATED, please use MagneticField_AutoFromDBCurrent_cff.py
 
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#Default is version 85l
+import FWCore.ParameterSet.Config as cms
 from MagneticField.Engine.volumeBasedMagneticField_120812_largeYE4_cfi import *
 
 # Parabolic parametrized magnetic field used for track building

--- a/Configuration/StandardSequences/python/MagneticField_38T_ToscaMap090322_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_38T_ToscaMap090322_cff.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#version coming from second update of TOSCA simulation after CRAFT08 analysis 
-# enalrged volume also along Z
-
-from MagneticField.Engine.volumeBasedMagneticField_1103l_090322_cfi import *
-

--- a/Configuration/StandardSequences/python/MagneticField_38T_UpdatedMap_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_38T_UpdatedMap_cff.py
@@ -1,8 +1,8 @@
-import FWCore.ParameterSet.Config as cms
+# This cfi is DEPRECATED - to be removed once dependencies are cleared up
 
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#version coming from updated TOSCA simulation after CRAFT08 analysis
-from MagneticField.Engine.volumeBasedMagneticField_1103l_090216_cfi import *
+print 'Using Configuration.StandardSequences.MagneticField_UpdatedMap_cff is DEPRECATED. Please change this to Configuration.StandardSequences.MagneticField_38T_cff'
+
+import FWCore.ParameterSet.Config as cms
+from Configuration.StandardSequences.MagneticField_38T_cff import *
 
 

--- a/Configuration/StandardSequences/python/MagneticField_38T_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_38T_cff.py
@@ -1,12 +1,5 @@
+# Load the 3.8 T field map, with the geometry and configuration specified in the GT
+
 import FWCore.ParameterSet.Config as cms
-
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#Default is version 85l
-from MagneticField.Engine.volumeBasedMagneticField_090322_2pi_scaled_cfi import *
-
-# Parabolic parametrized magnetic field used for track building
-from MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi import ParametrizedMagneticFieldProducer as ParabolicParametrizedMagneticFieldProducer
-ParabolicParametrizedMagneticFieldProducer.label = "ParabolicMf"
-
-
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
+VolumeBasedMagneticFieldESProducer.valueOverride = 18268

--- a/Configuration/StandardSequences/python/MagneticField_38T_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_38T_cff.py
@@ -3,3 +3,10 @@
 import FWCore.ParameterSet.Config as cms
 from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
 VolumeBasedMagneticFieldESProducer.valueOverride = 18268
+
+
+# Parabolic parametrized magnetic field used for track building.
+# NOTE that as of now  this does not scale with the current from the DB.
+from MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi import ParametrizedMagneticFieldProducer as ParabolicParametrizedMagneticFieldProducer
+ParabolicParametrizedMagneticFieldProducer.label = "ParabolicMf"
+

--- a/Configuration/StandardSequences/python/MagneticField_38T_polyFit2D_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_38T_polyFit2D_cff.py
@@ -1,7 +1,6 @@
-import FWCore.ParameterSet.Config as cms
+#Configuration for teh RUN 1 field map + detailed (2D) parametrization of tracker region.
 
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
+import FWCore.ParameterSet.Config as cms
 from MagneticField.Engine.volumeBasedMagneticField_090322_2pi_scaled_cfi import *
 
 

--- a/Configuration/StandardSequences/python/MagneticField_40T_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_40T_cff.py
@@ -1,10 +1,5 @@
+# Load the 4 T field map, with the geometry and configuration specified in the GT
+
 import FWCore.ParameterSet.Config as cms
-
-# This cfi contains everything needed to use the VolumeBased magnetic
-# field engine.
-#Default is version 85l
-from MagneticField.Engine.volumeBasedMagneticField_1103l_cfi import *
-VolumeBasedMagneticFieldESProducer.version = 'grid_1103l_071212_4t'
-ParametrizedMagneticFieldProducer.parameters.BValue = '4_0T'
-
-
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
+VolumeBasedMagneticFieldESProducer.valueOverride = 19262

--- a/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
@@ -1,10 +1,11 @@
+# Load the field map corresponding to the current stored in the runInfo,
+# with the geometry and configuration specified in the GT
+
 import FWCore.ParameterSet.Config as cms
+from MagneticField.Engine.volumeBasedMagneticFieldFromDB_cfi import *
 
-#this will load the auto magnetic field producer reading the current from the DB
-# and loading the best map available for that current as specified in the file 
-from MagneticField.Engine.autoMagneticFieldProducer_cfi import *
-
-# Parabolic parametrized magnetic field used for track building
+# Parabolic parametrized magnetic field used for track building.
+# NOTE that as of now  this does not scale with the current from the DB.
 from MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi import ParametrizedMagneticFieldProducer as ParabolicParametrizedMagneticFieldProducer
 ParabolicParametrizedMagneticFieldProducer.label = "ParabolicMf"
 

--- a/Configuration/StandardSequences/python/MagneticField_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_cff.py
@@ -1,6 +1,5 @@
+# Load the default 3.8 T field map with the geometry and configuration specified in the GT.
+# Note that this does NOT depend on the actual solenoid current:
+# MagneticField_AutoFromDBCurrent_cff should be used if a current-dependent map is needed.
 import FWCore.ParameterSet.Config as cms
-
-#
-# Master configuration for the magnetic field
-# old mapping with 4T
 from Configuration.StandardSequences.MagneticField_38T_cff import *


### PR DESCRIPTION
This update sets the StandardSequences for MF to take MF configuration and geometry from the DB (ie linked to the GT). No code change (everything was ready in #5785, but it took ages to get new payloads in the DB). 
No change in results. Regression-tested for all nominal maps.
