### PR TITLE
Avoid segfault in edmProvDump -d when parentage ID is out of bounds

### DIFF
--- a/IOPool/Common/bin/EdmProvDump.cc
+++ b/IOPool/Common/bin/EdmProvDump.cc
@@ -816,7 +816,7 @@ ProvenanceDumper::work_() {
             storedProvBranch->GetEntry(i);
             for(auto const& item : info) {
               edm::BranchID bid(item.branchID_);
-              perProductParentage[bid].insert(orderedParentageIDs[item.parentageIDIndex_]);
+              perProductParentage[bid].insert(orderedParentageIDs.at(item.parentageIDIndex_));
             }
           }
         } else {


### PR DESCRIPTION
edmProvDump -d currently will segfault if the input file has a parentage ID that is out of bounds.
This totally trivial PR simply changes the std:;vector square bracket operator to the at() function so that an out of bounds exception will be thrown instead of a segfault.
