### PR TITLE
TrackerHitAssociator clear maps each new event

### DIFF
--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -167,6 +167,9 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const vstring& t
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof) 
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
 
+  SimHitMap.clear();  // Start fresh after previous event.
+  SimHitCollMap.clear();
+
   for(auto const& trackerContainer : trackerContainers) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
     edm::InputTag tag_cf("mix", trackerContainer);

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -110,6 +110,9 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent) {
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof)
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
 
+  SimHitMap.clear();  // Start fresh after previous event.
+  SimHitCollMap.clear();
+
   for(auto const& cfToken : cfTokens_) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
     int Nhits = 0;


### PR DESCRIPTION
Just implement the minimal fix suggested by Dmitrijus to prevent the memory leak from the TrackerHitAssociator in CMSSW_7_5_0_pre2.  I'll need to invest some effort to understand the consumes changes made by David Lange and Bill Tanenbaum, before attempting any more ambitious cure.  I also haven't tested anything beyond compilation.  So I leave to reviewers to decide whether to go with this PR as a quick fix or look for something better.
