### PR TITLE
update FW version to latest HW

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/caloStage1Digis_cfi.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage1Digis_cfi.py
@@ -4,7 +4,7 @@ caloStage1Digis = cms.EDProducer(
     "L1TStage1Layer2Producer",
     CaloRegions = cms.InputTag("rctUpgradeFormatDigis"),
     CaloEmCands = cms.InputTag("rctUpgradeFormatDigis"),
-    FirmwareVersion = cms.uint32(2),  ## 1=HI algo, 2= pp algo
+    FirmwareVersion = cms.uint32(3),  ## 1=HI algo, 3= latest pp algo 
     tauMaxJetIsolationA = cms.double(0.1), ## tau isolation cut
     conditionsLabel = cms.string("")
 )


### PR DESCRIPTION
This increments the firmware version used by stage 1 layer 2 to the latest firmware version for PP.  This brings it in sync with the latest hardware firmware.  Note this change was already made to the simCaloStage1Digis_cfi.py.
