### PR TITLE
implement correct track breaking if propagation fails

### DIFF
--- a/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
+++ b/RecoTracker/CkfPattern/src/BaseCkfTrajectoryBuilder.cc
@@ -87,6 +87,13 @@ BaseCkfTrajectoryBuilder::seedMeasurements(const TrajectorySeed& seed,  TempTraj
     }
     else {
       TSOS innerState   = backwardPropagator(seed)->propagate(outerState,hitGeomDet->surface());
+
+      // try to recover if propagation failed
+      if unlikely(!innerState.isValid())
+        innerState =
+          trajectoryStateTransform::transientState(pState, &(hitGeomDet->surface()),
+                                                            forwardPropagator(seed)->magneticField());
+
       if(innerState.isValid()) {
 	TSOS innerUpdated = theUpdator->update(innerState,*recHit);
 	result.emplace(invalidState, innerUpdated, recHit, 0, hitLayer);

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -429,11 +429,9 @@ namespace cms{
          std::pair<TrajectoryStateOnSurface, const GeomDet*> initState;
          bool failed = false;
 
-         do
-         {
+         do {
            // Drop last hit if previous backFitter was not successful
-           if(failed)
-           {
+           if(failed) {
              LogDebug("CkfPattern") << "removing last hit";
              trialTrajectory.pop();
              LogDebug("CkfPattern") << "hits remaining " << trialTrajectory.foundHits();
@@ -441,29 +439,15 @@ namespace cms{
 
            // Get inner state
            const bool doBackFit = (!doSeedingRegionRebuilding) & (!reverseTrajectories);
-
            initState = theInitialState->innerState(trialTrajectory, doBackFit);
 
            // Check if that was successful
-           failed = (! initState.first.isValid() || initState.second == 0);
-         }
-         while(failed && trialTrajectory.foundHits() > 3);
+           failed =  (!initState.first.isValid()) || initState.second == nullptr || edm::isNotFinite(initState.first.globalPosition().x());
+         } while(failed && trialTrajectory.foundHits() > 3);
 
          if(failed) continue;
 
 
-         /* previous code
-	 LogDebug("CkfPattern") << "getting initial state.";
-	 const bool doBackFit = (!doSeedingRegionRebuilding) & (!reverseTrajectories);
-	 std::pair<TrajectoryStateOnSurface, const GeomDet*> && initState = theInitialState->innerState( *it , doBackFit);
-
-	 // temporary protection againt invalid initial states
-	 if ( !initState.first.isValid() || initState.second == nullptr || edm::isNotFinite(initState.first.globalPosition().x())) {
-	   //cout << "invalid innerState, will not make TrackCandidate" << endl;
-	   continue;
-	 }
-	 */
-          
 
 	 PTrajectoryStateOnDet state;
 	 if(useSplitting && (initState.second != recHits.front().det()) && recHits.front().det() ){	 

--- a/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
@@ -100,7 +100,9 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
     if unlikely(!predTsos.isValid()) {
       LogDebug("TrackFitters") << "KFTrajectorySmoother: predicted tsos not valid!";
       LogDebug("TrackFitters") << " retry with last hit removed" << "\n";
-      std::cout << "tsos not valid " << currTsos.globalMomentum().perp() << ' ' 
+      LogDebug("TrackFitters")
+      // std::cout 
+                << "tsos not valid " << currTsos.globalMomentum().perp() << ' ' 
                 << hitSize << ' ' << hitCounter << ' ' << hit->geographicalId() << ' '  
                 << hit->surface()->position().perp() << ' ' << hit->surface()->eta() << ' ' << hit->surface()->phi() << std::endl;
       start++;
@@ -178,13 +180,9 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 	    "pred Tsos pos: " << predTsos.globalPosition() << "\n" <<
 	    "pred Tsos mom: " << predTsos.globalMomentum() << "\n" <<
 	    "TrackingRecHit: " << hit->surface()->toGlobal(hit->localPosition()) << "\n" ;
-	  if( myTraj.foundHits() >= minHits_ ) {
-	    LogDebug("TrackFitters") << " breaking trajectory" << "\n";
-	  } else {        
-	    LogDebug("TrackFitters") << " killing trajectory" << "\n";       
-	    return Trajectory();
-	  }
-	  break;      
+          start++;
+          retry = true;
+          break;
 	}
       
         assert( (hit->geographicalId()!=0U) | (!hit->canImproveWithTrack()) );
@@ -224,13 +222,9 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 	
 	if unlikely(!smooTsos.isValid()) {
 	    LogDebug("TrackFitters") << "KFTrajectorySmoother: smoothed tsos not valid!";
-	    if( myTraj.foundHits() >= minHits_ ) {
-	      LogDebug("TrackFitters") << " breaking trajectory" << "\n";
-	    } else {        
-	      LogDebug("TrackFitters") << " killing trajectory" << "\n";       
-	      return Trajectory();  
-	    }
-	    break;
+            start++;
+            retry = true;
+            break;
 	  }
 	
 	double estimate;

--- a/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
+++ b/TrackingTools/TrackFitters/src/KFTrajectorySmoother.cc
@@ -46,9 +46,6 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 
   const std::vector<TM> & avtm = aTraj.measurements();
   
-  Trajectory ret(aTraj.seed(), usePropagator->propagationDirection());
-  Trajectory & myTraj = ret;
-  myTraj.reserve(avtm.size());
   
   
   
@@ -64,14 +61,28 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 #endif // EDM_ML_DEBUG
   
   
-  TSOS predTsos = avtm.back().forwardPredictedState();
-  predTsos.rescaleError(theErrorRescaling);
-  TSOS currTsos;
   
   TrajectoryStateCombiner combiner;
-  
-  unsigned int hitcounter = avtm.size();
-  for(std::vector<TM>::const_reverse_iterator itm = avtm.rbegin(); itm != (avtm.rend()); ++itm,--hitcounter) {
+  bool retry=false;
+  auto start = avtm.rbegin();
+
+  do {
+    auto hitSize = avtm.rend()-start;
+    if unlikely( hitSize < minHits_ ) {
+      LogDebug("TrackFitters") << " killing trajectory" << "\n";
+      return Trajectory();
+    }
+    Trajectory ret(aTraj.seed(), usePropagator->propagationDirection());
+    Trajectory & myTraj = ret;
+    myTraj.reserve(hitSize);
+    retry=false;
+
+   TSOS predTsos = (*start).forwardPredictedState();
+   predTsos.rescaleError(theErrorRescaling);
+   TSOS currTsos;
+
+    auto hitCounter = hitSize;
+    for(std::vector<TM>::const_reverse_iterator itm = start; itm != (avtm.rend()); ++itm,--hitCounter) {
 
     TransientTrackingRecHit::ConstRecHitPointer hit = itm->recHit();
 
@@ -83,26 +94,25 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
       }
 
 
-
-    if (hitcounter != avtm.size())//no propagation needed for first smoothed (==last fitted) hit 
+    if (itm != start)//no propagation needed for first smoothed (==last fitted) hit 
       predTsos = usePropagator->propagate( currTsos, *(hit->surface()) );
 
     if unlikely(!predTsos.isValid()) {
-	LogDebug("TrackFitters") << "KFTrajectorySmoother: predicted tsos not valid!";
-	if( myTraj.foundHits() >= minHits_ ) {
-	  LogDebug("TrackFitters") << " breaking trajectory" << "\n";
-	} else {        
-	  LogDebug("TrackFitters") << " killing trajectory" << "\n";      
-	  return Trajectory();
-	}
-	break;      
-      }
+      LogDebug("TrackFitters") << "KFTrajectorySmoother: predicted tsos not valid!";
+      LogDebug("TrackFitters") << " retry with last hit removed" << "\n";
+      std::cout << "tsos not valid " << currTsos.globalMomentum().perp() << ' ' 
+                << hitSize << ' ' << hitCounter << ' ' << hit->geographicalId() << ' '  
+                << hit->surface()->position().perp() << ' ' << hit->surface()->eta() << ' ' << hit->surface()->phi() << std::endl;
+      start++;
+      retry = true;        
+      break;
+    }
 
     if(hit->isValid()) {
  
 #ifdef EDM_ML_DEBUG
       LogDebug("TrackFitters")
-	<< "----------------- HIT #" << hitcounter << " (VALID)-----------------------\n"
+	<< "----------------- HIT #" << hitCounter << " (VALID)-----------------------\n"
 	<< "HIT IS AT R   " << hit->globalPosition().perp() << "\n"
 	<< "HIT IS AT Z   " << hit->globalPosition().z() << "\n"
 	<< "HIT IS AT Phi " << hit->globalPosition().phi() << "\n"
@@ -158,8 +168,8 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
       //forward predicted state for first smoothed (last fitted) hit
       //backward predicted state for last smoothed (first fitted) hit
       //combination of forward and backward predictions for other hits
-      if (hitcounter == avtm.size()) combTsos = itm->forwardPredictedState();
-      else if (hitcounter == 1) combTsos = predTsos;
+      if (itm == start) combTsos = itm->forwardPredictedState();
+      else if (hitCounter == 1) combTsos = predTsos;
       else combTsos = combiner(predTsos, itm->forwardPredictedState());
       
       if unlikely(!combTsos.isValid()) {
@@ -208,8 +218,8 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 	  }
 	
 	//smooTsos updates the N-1 hits prediction with the hit
-	if (hitcounter == avtm.size()) smooTsos = itm->updatedState();
-	else if (hitcounter == 1) smooTsos = currTsos;
+	if (itm == start) smooTsos = itm->updatedState();
+	else if (hitCounter == 1) smooTsos = currTsos;
 	else smooTsos = combiner(itm->forwardPredictedState(), currTsos); 
 	
 	if unlikely(!smooTsos.isValid()) {
@@ -224,7 +234,7 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 	  }
 	
 	double estimate;
-	if (hitcounter != avtm.size()) estimate = estimator()->estimate(combTsos, *preciseHit ).second;//correct?
+	if (itm != start) estimate = estimator()->estimate(combTsos, *preciseHit ).second;//correct?
 	else estimate = itm->estimate();
 	
 	LogTrace("TrackFitters")
@@ -258,13 +268,13 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
       }
     } else {
       LogDebug("TrackFitters") 
-	<< "----------------- HIT #" << hitcounter << " (INVALID)-----------------------";      
+	<< "----------------- HIT #" << hitCounter << " (INVALID)-----------------------";      
       
       //no update
       currTsos = predTsos;
       TSOS combTsos;
-      if (hitcounter == avtm.size()) combTsos = itm->forwardPredictedState();
-      else if (hitcounter == 1) combTsos = predTsos;
+      if (itm == start) combTsos = itm->forwardPredictedState();
+      else if (hitCounter == 1) combTsos = predTsos;
       else combTsos = combiner(predTsos, itm->forwardPredictedState());
       
       if unlikely(!combTsos.isValid()) {
@@ -288,7 +298,10 @@ KFTrajectorySmoother::trajectory(const Trajectory& aTraj) const {
 
     }
   } // for loop
+
+   if (!retry) return ret;
+  } while(true);
   
-  return ret; 
+  return Trajectory(); 
   
 }


### PR DESCRIPTION
modifications suggested by Ferenc (@sikler) as very visible at low momentum in minimum bias events

The main issue is that previous code in Smoother was "breaking" the track on the "wrong" side
i.e. returning the far part, not the one closest to the vertex.
The new track-shortening algorithm tries to keep the longest possible track preserving the hits closest to the vertex.

Effect is tiny, still visible for  0.5<|eta|<1.2, where more longer tracks are reconstructed.
Small regression expected,

the other two  modifications have negligible impact in standard condition.
