### PR TITLE
Added SiPixel class in the utilities for the dropbox.

### DIFF
--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -237,6 +237,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE( SiPixelFedCablingMap )
       FETCH_PAYLOAD_CASE( SiPixelGainCalibrationForHLT )
       FETCH_PAYLOAD_CASE( SiPixelGainCalibrationOffline )
+      FETCH_PAYLOAD_CASE( SiPixelGenErrorDBObject )
       FETCH_PAYLOAD_CASE( SiPixelLorentzAngle )
       FETCH_PAYLOAD_CASE( SiPixelQuality )
       FETCH_PAYLOAD_CASE( SiPixelTemplateDBObject )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -287,6 +287,7 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( SiPixelFedCablingMap )
       IMPORT_PAYLOAD_CASE( SiPixelGainCalibrationForHLT )
       IMPORT_PAYLOAD_CASE( SiPixelGainCalibrationOffline )
+      IMPORT_PAYLOAD_CASE( SiPixelGenErrorDBObject )
       IMPORT_PAYLOAD_CASE( SiPixelLorentzAngle )
       IMPORT_PAYLOAD_CASE( SiPixelQuality )
       IMPORT_PAYLOAD_CASE( SiPixelTemplateDBObject )


### PR DESCRIPTION
This PR adds the possibility for the conddb_import tool to fetch and import the SiPixelGenErrorDBObject class. This is needed for the dropbox to properly handle the payloads of this type.
