### PR TITLE
Force use of OscarMTProducer when running multi-threaded

### DIFF
--- a/FWCore/Concurrency/python/dropNonMTSafe.py
+++ b/FWCore/Concurrency/python/dropNonMTSafe.py
@@ -11,5 +11,8 @@ def dropNonMTSafe(process):
   process.options = cms.untracked.PSet(numberOfThreads = cms.untracked.uint32(4),
                                        sizeOfStackForThreadsInKB = cms.untracked.uint32(10*1024),
                                        numberOfStreams = cms.untracked.uint32(0))
+  if ( x for x in process.producers.itervalues() if x.type_() == "OscarProducer" ) :
+    from SimG4Core.Application.customiseMultithreadedSim import customiseMultithreadedSim
+    customiseMultithreadedSim(process)
 
   return process


### PR DESCRIPTION
Until we switch to using OscarMTProducer for all simulations we need to have the IBs which run multi-threaded use OscarMTProducer. The multi-threaded IBs all call dropNonMTSafe to turn on threading so this hack will do the trick for now.
