### PR TITLE
Index bug in miniAOD substructure jets

### DIFF
--- a/PhysicsTools/PatUtils/plugins/JetSubstructurePacker.cc
+++ b/PhysicsTools/PatUtils/plugins/JetSubstructurePacker.cc
@@ -66,8 +66,9 @@ JetSubstructurePacker::produce(edm::Event& iEvent, const edm::EventSetup&)
 	    reco::CandidatePtr candPtr =  jjet.daughterPtr( ida);
 	    nextSubjets.push_back( edm::Ptr<pat::Jet> ( candPtr ) );
 	  }
+	  break;
 	}
-	break;
+	
       }
 
       outputs->back().addSubjets( nextSubjets, algoLabels_[index] );


### PR DESCRIPTION
There is a critical type-o where "break" and "}" were accidentally switched. This means that the only subjets that are stored are those for the FIRST jet that is in the loop instead of all of them. 
