### PR TITLE
update L1TRCTParameters for FGCut,HOECut, and EIC Isolation

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/caloStage1RCTLuts_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/caloStage1RCTLuts_cff.py
@@ -14,14 +14,14 @@ RCTConfigProducers.jetMETLSB = 0.5 # Determines what scale the UCT sees for regi
 #RCTConfigProducers.eMinForFGCut = 999.
 #RCTConfigProducers.eMaxForFGCut = -999.
 RCTConfigProducers.eMinForFGCut = 6
-RCTConfigProducers.eMaxForFGCut = 999.
+RCTConfigProducers.eMaxForFGCut = 63.
 RCTConfigProducers.hOeCut = 0.05
 #RCTConfigProducers.eMinForHoECut = 999.
 #RCTConfigProducers.eMaxForHoECut = -999.
 ## RCTConfigProducers.eMinForHoECut = 1
 ## RCTConfigProducers.eMaxForHoECut = 30
 RCTConfigProducers.eMinForHoECut = 5
-RCTConfigProducers.eMaxForHoECut = 100
+RCTConfigProducers.eMaxForHoECut = 63
 
 #RCTConfigProducers.hMinForHoECut = 999.
 ## RCTConfigProducers.hMinForHoECut = 1.0
@@ -31,7 +31,7 @@ RCTConfigProducers.hMinForHoECut = 5.0
 #RCTConfigProducers.hActivityCut = 0.5
 RCTConfigProducers.hActivityCut = 4.0
 RCTConfigProducers.eActivityCut = 4.0
-RCTConfigProducers.eicIsolationThreshold = 100
+RCTConfigProducers.eicIsolationThreshold = 7
 
 l1CaloScales.L1CaloEmEtScaleLSB = 0.5 # must be the same as egammaLSB
 


### PR DESCRIPTION
The standard sequences take these parameters from the GT, so this should have no direct effect.  However, we would like to keep our local parameter files in sync with GT in case of non-standard use.
