### PR TITLE
take RCT parameters from GT

### DIFF
--- a/L1Trigger/L1TCalorimeter/python/L1TCaloStage1_PPFromRaw_cff.py
+++ b/L1Trigger/L1TCalorimeter/python/L1TCaloStage1_PPFromRaw_cff.py
@@ -5,8 +5,8 @@ from L1Trigger.L1TCalorimeter.caloStage1Params_cfi import *
 # HCAL TP hack
 from L1Trigger.L1TCalorimeter.L1TRerunHCALTP_FromRaw_cff import *
 
-### CCLA include latest RCT calibrations from UCT
-from L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff import *
+#now taken from GT:
+#from L1Trigger.L1TCalorimeter.caloStage1RCTLuts_cff import *
 
 from Configuration.StandardSequences.RawToDigi_Data_cff import ecalDigis
 


### PR DESCRIPTION
I just noticed that
L1Trigger/L1TCalorimeter/python/L1TCaloStage1_PPFromRaw_cff.py
uses L1RCTParameters from local config file instead of the GT.  

This is only called from
cmssw/Configuration/StandardSequences/python/SimL1EmulatorRepack_GCTGT_cff.py
but seems to be a place where L1RCTParameters are being set by config instead of GT.  

I think this should be fixed (though at the moment they are being kept in sync so no change should be noticed).

@Martin-Grunewald is there some subtlety regarding L1Repack that make this necessary?
