### PR TITLE
MINIAOD BUGFIX: pvREF not set for some electrons

### DIFF
--- a/CommonTools/RecoAlgos/interface/PrimaryVertexAssignment.h
+++ b/CommonTools/RecoAlgos/interface/PrimaryVertexAssignment.h
@@ -35,32 +35,30 @@ class PrimaryVertexAssignment {
 
   std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex(const reco::VertexCollection& vertices, 
                const reco::TrackRef& trackRef,
-//               const reco::Track & track,
+               const reco::Track * track,
                const edm::View<reco::Candidate> & jets,
               const TransientTrackBuilder & builder) const;
 
-/*  std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex(const reco::VertexCollection& vertices, 
-               const reco::TrackRef & track,
-               const edm::View<reco::Candidate> & jets,
-              const TransientTrackBuilder & builder) const {
-      return chargedHadronVertex(vertices,track,*track,jets,builder);
-  }
   std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex(const reco::VertexCollection& vertices,
-               const reco::Candidate & baseCand,
+               const reco::TrackRef& trackRef,
                const edm::View<reco::Candidate> & jets,
-              const TransientTrackBuilder & builder) const {
-    if(baseCand.bestTrack()!=0)  
-      return chargedHadronVertex(vertices,edm::Ref<reco::TrackCollection>(),*(baseCand.bestTrack()),jets,builder);
-  }
-*/
+              const TransientTrackBuilder & builder) const
+ {
+	return chargedHadronVertex(vertices,trackRef,&(*trackRef),jets,builder);
+ }
 
   std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex( const reco::VertexCollection& vertices,
                                    const reco::PFCandidate& pfcand,
                                    const edm::View<reco::Candidate>& jets,
                                    const TransientTrackBuilder& builder) const {
-      if(pfcand.trackRef().isNull())
-         return std::pair<int,PrimaryVertexAssignment::Quality>(-1,PrimaryVertexAssignment::Unassigned);
-      return chargedHadronVertex(vertices,pfcand.trackRef(),jets,builder);
+	  if(pfcand.gsfTrackRef().isNull())
+	  {
+		  if(pfcand.trackRef().isNull())
+			  return std::pair<int,PrimaryVertexAssignment::Quality>(-1,PrimaryVertexAssignment::Unassigned);
+		  else 
+			  return chargedHadronVertex(vertices,pfcand.trackRef(),jets,builder);
+	  }
+	  return chargedHadronVertex(vertices,reco::TrackRef(),&(*pfcand.gsfTrackRef()),jets,builder);
   }
   std::pair<int,PrimaryVertexAssignment::Quality> chargedHadronVertex( const reco::VertexCollection& vertices,
                                    const reco::RecoChargedRefCandidate& chcand,

--- a/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
@@ -9,7 +9,8 @@
 
 std::pair<int,PrimaryVertexAssignment::Quality>
 PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vertices,
-                                   const reco::TrackRef& track,
+                                   const reco::TrackRef& trackRef,
+                                   const reco::Track* track,
                                    const edm::View<reco::Candidate>& jets,
                                    const TransientTrackBuilder& builder) const {
 
@@ -19,7 +20,7 @@ PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vert
   typedef reco::Vertex::trackRef_iterator IT;
   float bestweight=0;
   for( auto const & vtx : vertices) {
-      float w = vtx.trackWeight(track);
+      float w = vtx.trackWeight(trackRef);
       if (w > bestweight){
           bestweight=w;
           iVertex=index;
@@ -100,7 +101,7 @@ PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vert
   // all other tracks could be non-B secondaries and we just attach them with closest Z
   if(vtxIdMinDz>=0)
      return std::pair<int,PrimaryVertexAssignment::Quality>(vtxIdMinDz,PrimaryVertexAssignment::OtherDz);
-
+   std::cout << "UNASSIGNED! " <<  vtxIdMinDz << std::endl;
   //If for some reason even the dz failed (when?) we consider the track not assigned
   return std::pair<int,PrimaryVertexAssignment::Quality>(-1,PrimaryVertexAssignment::Unassigned);
 }

--- a/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexAssignment.cc
@@ -101,7 +101,6 @@ PrimaryVertexAssignment::chargedHadronVertex( const reco::VertexCollection& vert
   // all other tracks could be non-B secondaries and we just attach them with closest Z
   if(vtxIdMinDz>=0)
      return std::pair<int,PrimaryVertexAssignment::Quality>(vtxIdMinDz,PrimaryVertexAssignment::OtherDz);
-   std::cout << "UNASSIGNED! " <<  vtxIdMinDz << std::endl;
   //If for some reason even the dz failed (when?) we consider the track not assigned
   return std::pair<int,PrimaryVertexAssignment::Quality>(-1,PrimaryVertexAssignment::Unassigned);
 }

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -160,11 +160,10 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
             if(dz<dist) {pvi=ii;dist=dz; }
           }
           PV = reco::VertexRef(PVs, pvi);
-          PVpos = PV->position();
           math::XYZPoint vtx = cand.vertex();
           pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
           const reco::VertexRef & PVOrig = associatedPV[reco::CandidatePtr(cands,ic)];
-          PV = reco::VertexRef(PVs, PVOrig.key()); // WARNING: assume the PV slimmer is keeping same order
+          if(PVOrig.isNonNull()) PV = reco::VertexRef(PVs, PVOrig.key()); // WARNING: assume the PV slimmer is keeping same order
           int quality=associationQuality[reco::CandidatePtr(cands,ic)];
 //          if ((size_t)pvi!=PVOrig.key()) std::cout << "not closest in Z" << pvi << " " << PVOrig.key() << " " << cand.pt() << " " << quality << std::endl;
           //          TrajectoryStateOnSurface tsos = extrapolator.extrapolate(trajectoryStateTransform::initialFreeState(*ctrack,&*magneticField), RecoVertex::convertPos(PV->position()));

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -163,7 +163,7 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
           math::XYZPoint vtx = cand.vertex();
           pat::PackedCandidate::LostInnerHits lostHits = pat::PackedCandidate::noLostInnerHits;
           const reco::VertexRef & PVOrig = associatedPV[reco::CandidatePtr(cands,ic)];
-          if(PVOrig.isNonNull()) PV = reco::VertexRef(PVs, PVOrig.key()); // WARNING: assume the PV slimmer is keeping same order
+          if(PVOrig.isNonnull()) PV = reco::VertexRef(PVs, PVOrig.key()); // WARNING: assume the PV slimmer is keeping same order
           int quality=associationQuality[reco::CandidatePtr(cands,ic)];
 //          if ((size_t)pvi!=PVOrig.key()) std::cout << "not closest in Z" << pvi << " " << PVOrig.key() << " " << cand.pt() << " " << quality << std::endl;
           //          TrajectoryStateOnSurface tsos = extrapolator.extrapolate(trajectoryStateTransform::initialFreeState(*ctrack,&*magneticField), RecoVertex::convertPos(PV->position()));


### PR DESCRIPTION
Electron pfCandidates with gsfTracks but without a generalTrack are not associated to PVs in MINIAOD.
The fix tests both gsfTracks and regular tracks for all PFCandidates (preferring the gsfTrack when both available)

@gpetruc 
