### PR TITLE
switch to Pandora recipe with no fragment removal algorithms

### DIFF
--- a/RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms_NoFragRemoval.xml
+++ b/RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms_NoFragRemoval.xml
@@ -1,0 +1,371 @@
+<!-- Pandora settings xml file -->
+
+<pandora>
+    <!-- GLOBAL SETTINGS -->
+    <IsMonitoringEnabled>false</IsMonitoringEnabled>
+    <ShouldDisplayAlgorithmInfo>false</ShouldDisplayAlgorithmInfo>
+    <ShouldCollapseMCParticlesToPfoTarget>true</ShouldCollapseMCParticlesToPfoTarget>
+
+    <!-- PLUGIN SETTINGS -->
+    <HadronicEnergyCorrectionPlugins>CleanClusters ScaleHotHadrons</HadronicEnergyCorrectionPlugins>
+
+    <EmShowerPlugin>
+      LCEmShowerId
+      <RmsCutEnergy>70.0</RmsCutEnergy>
+      <RmsLowECut>70.0</RmsLowECut>
+    </EmShowerPlugin>
+    <PhotonPlugin>LCPhotonId</PhotonPlugin>
+    <ElectronPlugin>
+      LCElectronId
+      <MaxProfileDiscrepancy>0.9</MaxProfileDiscrepancy>
+      <ProfileDiscrepancyForAutoId>0.9</ProfileDiscrepancyForAutoId>
+      <MaxResidualEOverP>0.3</MaxResidualEOverP>
+    </ElectronPlugin>
+    <MuonPlugin>LCMuonId</MuonPlugin>
+
+    <!-- ALGORITHM SETTINGS -->
+
+    <!-- Set calo hit properties, then select tracks and hits to use for clustering -->
+    <algorithm type = "CaloHitPreparationFast">
+        <IsolationSearchSafetyFactor>2.</IsolationSearchSafetyFactor>
+        <IsolationCutDistanceFine>25.</IsolationCutDistanceFine>
+        <IsolationCutDistanceCoarse>200.</IsolationCutDistanceCoarse>
+    </algorithm>
+    <algorithm type = "EventPreparation">
+        <OutputTrackListName>Tracks</OutputTrackListName>
+        <OutputCaloHitListName>CaloHits</OutputCaloHitListName>
+        <OutputMuonCaloHitListName>MuonYokeHits</OutputMuonCaloHitListName>
+        <ReplacementTrackListName>Tracks</ReplacementTrackListName>
+        <ReplacementCaloHitListName>CaloHits</ReplacementCaloHitListName>
+    </algorithm>
+
+    <!-- Clustering parent algorithm runs a daughter clustering algorithm -->
+    <algorithm type = "ClusteringParent">
+        <algorithm type = "ConeClusteringFast" description = "ClusterFormation"/>
+        <algorithm type = "TopologicalAssociationParent" description = "ClusterAssociation">
+            <associationAlgorithms>
+                <algorithm type = "LoopingTracks"/>
+                <algorithm type = "BrokenTracks"/>
+                <algorithm type = "ShowerMipMerging"/>
+                <algorithm type = "ShowerMipMerging2"/>
+                <algorithm type = "BackscatteredTracks"/>
+                <algorithm type = "BackscatteredTracks2"/>
+                <algorithm type = "ShowerMipMerging3"/>
+                <algorithm type = "ShowerMipMerging4"/>
+                <algorithm type = "ProximityBasedMerging">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "ConeBasedMerging">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "MipPhotonSeparation">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "SoftClusterMergingFast">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "IsolatedHitMerging"/>
+            </associationAlgorithms>
+        </algorithm>
+        <ClusterListName>PrimaryClusters</ClusterListName>
+        <ReplaceCurrentClusterList>true</ReplaceCurrentClusterList>
+    </algorithm>
+
+    <!-- Reclustering algorithms run multiple clustering algorithms -->
+    <algorithm type = "SplitTrackAssociations" instance = "SplitTrackAssociations1">
+        <clusteringAlgorithms>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering1">
+                <TanConeAngleFine>0.24</TanConeAngleFine>
+                <TanConeAngleCoarse>0.4</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>2</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>2</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>2.24</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>1.44</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering2">
+                <TanConeAngleFine>0.18</TanConeAngleFine>
+                <TanConeAngleCoarse>0.3</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>1.5</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>1.5</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>1.68</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>1.08</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering3">
+                <TanConeAngleFine>0.15</TanConeAngleFine>
+                <TanConeAngleCoarse>0.25</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>1.25</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>1.25</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>1.4</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>0.9</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering4">
+                <TanConeAngleFine>0.12</TanConeAngleFine>
+                <TanConeAngleCoarse>0.2</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>1</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>1</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>1.12</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>0.72</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering5">
+                <TanConeAngleFine>0.09</TanConeAngleFine>
+                <TanConeAngleCoarse>0.15</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>0.75</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>0.75</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>0.84</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>0.54</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering6">
+                <TanConeAngleFine>0.075</TanConeAngleFine>
+                <TanConeAngleCoarse>0.125</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>0.625</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>0.625</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>0.7</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>0.45</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering7">
+                <TanConeAngleFine>0.06</TanConeAngleFine>
+                <TanConeAngleCoarse>0.1</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>0.5</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>0.5</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>0.56</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>0.36</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering8">
+                <TanConeAngleFine>0.045</TanConeAngleFine>
+                <TanConeAngleCoarse>0.075</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>0.375</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>0.375</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>0.42</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>0.27</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering9">
+                <TanConeAngleFine>0.03</TanConeAngleFine>
+                <TanConeAngleCoarse>0.05</TanConeAngleCoarse>
+                <AdditionalPadWidthsFine>0.25</AdditionalPadWidthsFine>
+                <AdditionalPadWidthsCoarse>0.25</AdditionalPadWidthsCoarse>
+                <SameLayerPadWidthsFine>0.28</SameLayerPadWidthsFine>
+                <SameLayerPadWidthsCoarse>0.18</SameLayerPadWidthsCoarse>
+                <MaxTrackSeedSeparation>100</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering10">
+                <MaxTrackSeedSeparation>250</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>3</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>3</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>2</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering11">
+                <ShouldUseTrackSeed>false</ShouldUseTrackSeed>
+                <MaxTrackSeedSeparation>0</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>0</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>0</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering12">
+                <MaxTrackSeedSeparation>1000</MaxTrackSeedSeparation>
+                <MaxLayersToTrackSeed>6</MaxLayersToTrackSeed>
+                <MaxLayersToTrackLikeHit>3</MaxLayersToTrackLikeHit>
+                <TrackPathWidth>0</TrackPathWidth>
+            </algorithm>
+        </clusteringAlgorithms>
+        <algorithm type = "TopologicalAssociationParent" description = "ClusterAssociation" instance = "reclusterAssociation">
+            <associationAlgorithms>
+                <algorithm type = "LoopingTracks"/>
+                <algorithm type = "BrokenTracks"/>
+                <algorithm type = "ShowerMipMerging"/>
+                <algorithm type = "ShowerMipMerging2"/>
+                <algorithm type = "BackscatteredTracks"/>
+                <algorithm type = "BackscatteredTracks2"/>
+                <algorithm type = "ShowerMipMerging3"/>
+                <algorithm type = "ShowerMipMerging4"/>
+                <algorithm type = "ProximityBasedMerging">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "ConeBasedMerging">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "MipPhotonSeparation">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "SoftClusterMergingFast">
+                    <algorithm type = "TrackClusterAssociationFast"/>
+                </algorithm>
+                <algorithm type = "IsolatedHitMerging"/>
+            </associationAlgorithms>
+        </algorithm>
+        <algorithm type = "TrackClusterAssociationFast" description = "TrackClusterAssociation"></algorithm>
+        <UsingOrderedAlgorithms>true</UsingOrderedAlgorithms>
+        <ShouldUseForcedClustering>true</ShouldUseForcedClustering>
+        <algorithm type = "ForcedClustering" description = "ForcedClustering"/>
+    </algorithm>
+
+    <algorithm type = "SplitMergedClusters" instance = "SplitMergedClusters1">
+        <clusteringAlgorithms>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering1"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering2"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering3"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering4"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering5"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering6"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering7"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering8"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering9"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering10"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering11"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering12"/>
+        </clusteringAlgorithms>
+        <algorithm type = "TopologicalAssociationParent" description = "ClusterAssociation" instance = "reclusterAssociation"></algorithm>
+        <algorithm type = "TrackClusterAssociationFast" description = "TrackClusterAssociation"></algorithm>
+        <UsingOrderedAlgorithms>true</UsingOrderedAlgorithms>
+        <ShouldUseForcedClustering>true</ShouldUseForcedClustering>
+        <algorithm type = "ForcedClustering" description = "ForcedClustering"/>
+    </algorithm>
+
+    <algorithm type = "TrackDrivenMerging">
+        <algorithm type = "TrackClusterAssociationFast" description = "TrackClusterAssociation"></algorithm>
+    </algorithm>
+
+    <algorithm type = "ResolveTrackAssociations">
+        <clusteringAlgorithms>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering1"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering2"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering3"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering4"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering5"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering6"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering7"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering8"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering9"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering10"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering11"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering12"/>
+        </clusteringAlgorithms>
+        <algorithm type = "TopologicalAssociationParent" description = "ClusterAssociation" instance = "reclusterAssociation"></algorithm>
+        <algorithm type = "TrackClusterAssociationFast" description = "TrackClusterAssociation"></algorithm>
+        <UsingOrderedAlgorithms>true</UsingOrderedAlgorithms>
+        <ShouldUseForcedClustering>true</ShouldUseForcedClustering>
+        <algorithm type = "ForcedClustering" description = "ForcedClustering"/>
+    </algorithm>
+
+    <algorithm type = "SplitTrackAssociations" instance = "SplitTrackAssociations1"/>
+    <algorithm type = "SplitMergedClusters" instance = "SplitMergedClusters1"/>
+
+    <algorithm type = "TrackDrivenAssociation">
+        <clusteringAlgorithms>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering1"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering2"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering3"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering4"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering5"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering6"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering7"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering8"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering9"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering10"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering11"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering12"/>
+        </clusteringAlgorithms>
+        <algorithm type = "TopologicalAssociationParent" description = "ClusterAssociation" instance = "reclusterAssociation"></algorithm>
+        <algorithm type = "TrackClusterAssociationFast" description = "TrackClusterAssociation"></algorithm>
+        <UsingOrderedAlgorithms>true</UsingOrderedAlgorithms>
+    </algorithm>
+
+    <algorithm type = "SplitTrackAssociations" instance = "SplitTrackAssociations1"/>
+    <algorithm type = "SplitMergedClusters" instance = "SplitMergedClusters1"/>
+
+    <algorithm type = "ExitingTrack">
+        <clusteringAlgorithms>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering1"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering2"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering3"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering4"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering5"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering6"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering7"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering8"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering9"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering10"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering11"/>
+            <algorithm type = "ConeClusteringFast" instance = "Reclustering12"/>
+        </clusteringAlgorithms>
+        <algorithm type = "TopologicalAssociationParent" description = "ClusterAssociation" instance = "reclusterAssociation"></algorithm>
+        <algorithm type = "TrackClusterAssociationFast" description = "TrackClusterAssociation"></algorithm>
+        <UsingOrderedAlgorithms>true</UsingOrderedAlgorithms>
+        <ShouldUseForcedClustering>true</ShouldUseForcedClustering>
+        <algorithm type = "ForcedClustering" description = "ForcedClustering"/>
+    </algorithm>
+
+    <!-- Photon recovery -->
+    <algorithm type = "PhotonRecovery">
+        <algorithm type = "TrackClusterAssociationFast"/>
+    </algorithm>
+
+    <algorithm type = "MuonPhotonSeparation">
+        <algorithm type = "TrackClusterAssociationFast"/>
+    </algorithm>
+
+    <!-- Prepare particle flow objects -->
+    <algorithm type = "TrackPreparation">
+        <CandidateListNames>Input</CandidateListNames>
+        <MergedCandidateListName>PfoCandidates</MergedCandidateListName>
+        <PfoTrackListName>PfoCreation</PfoTrackListName>
+        <trackClusterAssociationAlgorithms>
+            <algorithm type = "TrackClusterAssociationFast"/>
+            <algorithm type = "LoopingTrackAssociation"/>
+            <algorithm type = "TrackRecovery"/>
+            <algorithm type = "TrackRecoveryHelix"/>
+            <algorithm type = "TrackRecoveryInteractions"/>
+        </trackClusterAssociationAlgorithms>
+    </algorithm>
+
+    <!-- Create particle flow objects -->
+    <algorithm type = "ForceSplitTrackAssociations"/>
+    <algorithm type = "PfoCreation">
+        <OutputPfoListName>PrimaryPfos</OutputPfoListName>
+    </algorithm>
+
+    <algorithm type = "PfoPreparation">
+        <CandidateListNames>PrimaryPfos</CandidateListNames>
+        <MergedCandidateListName>OutputPfos</MergedCandidateListName>
+    </algorithm>
+
+    <!-- Particle flow object modification algorithms -->
+    <algorithm type = "FinalParticleId"/>
+    <algorithm type = "V0PfoCreation"/>
+    <!--algorithm type = "DumpPfosMonitoring"/-->
+    <!--algorithm type = "VisualMonitoring"/-->
+</pandora>

--- a/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
+++ b/RecoParticleFlow/PandoraTranslator/python/runPandora_cfi.py
@@ -10,7 +10,8 @@ pandorapfanew = cms.EDProducer('PandoraCMSPFCandProducer',
     genParticles= cms.InputTag("genParticles"),
     # use slow algorithms until fast algoritms are available in the CMSSW external pandora library
 #    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms_slow.xml'),
-    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms.xml'),
+#    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms.xml'),
+    inputconfigfile = cms.FileInPath('RecoParticleFlow/PandoraTranslator/data/PandoraSettingsBasic_cms_NoFragRemoval.xml'),
 
     energyCorrMethod = cms.string('ABSCORR'),
 #   absorber thickness correction


### PR DESCRIPTION
This commit adds a modified Pandora recipe with no fragment removal algorithms, and sets it as the default recipe in the python configuration. This increases the speed of Pandora in high-pileup environments with little effect on the jet resolution, see attached slides:

![hgcal pandora jer nofragremoval 2](https://cloud.githubusercontent.com/assets/4672808/7302537/9f698eb6-e9af-11e4-97c5-481176613616.png)
![hgcal pandora jer nofragremoval 3](https://cloud.githubusercontent.com/assets/4672808/7302406/d1b3afe2-e9ae-11e4-891d-603b0fb6f7ad.png)

attn: @lgray, @vandreev11, @pfs, @boudoul
