### PR TITLE
New Medium muon ID selectors and offline DQM plots (74X)

### DIFF
--- a/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
+++ b/DQMOffline/Muon/interface/MuonKinVsEtaAnalyzer.h
@@ -133,6 +133,14 @@ class MuonKinVsEtaAnalyzer : public DQMEDAnalyzer {
   std::vector<MonitorElement*> chi2LooseTrack;
   std::vector<MonitorElement*> chi2probLooseTrack;
 
+  // Medium muon;
+  std::vector<MonitorElement*> etaMediumTrack;
+  std::vector<MonitorElement*> phiMediumTrack;
+  std::vector<MonitorElement*> pMediumTrack;
+  std::vector<MonitorElement*> ptMediumTrack;
+  std::vector<MonitorElement*> chi2MediumTrack;
+  std::vector<MonitorElement*> chi2probMediumTrack;
+
   // Soft muon;
   std::vector<MonitorElement*> etaSoftTrack;
   std::vector<MonitorElement*> phiSoftTrack;

--- a/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
+++ b/DQMOffline/Muon/src/MuonKinVsEtaAnalyzer.cc
@@ -85,6 +85,7 @@ void MuonKinVsEtaAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     etaStaTrack.push_back(ibooker.book1D("StaMuon_eta_"+EtaName, "#eta_{STA} "+EtaName, etaBin, etaMin, etaMax));
     etaTightTrack.push_back(ibooker.book1D("TightMuon_eta_"+EtaName, "#eta_{Tight} "+EtaName, etaBin, etaMin, etaMax));
     etaLooseTrack.push_back(ibooker.book1D("LooseMuon_eta_"+EtaName, "#eta_{Loose} "+EtaName, etaBin, etaMin, etaMax));
+    etaMediumTrack.push_back(ibooker.book1D("MediumMuon_eta_"+EtaName, "#eta_{Medium} "+EtaName, etaBin, etaMin, etaMax));
     etaSoftTrack.push_back(ibooker.book1D("SoftMuon_eta_"+EtaName, "#eta_{Soft} "+EtaName, etaBin, etaMin, etaMax));
     etaHighPtTrack.push_back(ibooker.book1D("HighPtMuon_eta_"+EtaName, "#eta_{HighPt} "+EtaName, etaBin, etaMin, etaMax));
     
@@ -94,6 +95,7 @@ void MuonKinVsEtaAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     phiStaTrack.push_back(ibooker.book1D("StaMuon_phi_"+EtaName, "#phi_{STA}"+EtaName+" (rad)", phiBin, phiMin, phiMax));
     phiTightTrack.push_back(ibooker.book1D("TightMuon_phi_"+EtaName, "#phi_{Tight}_"+EtaName, phiBin, phiMin, phiMax));
     phiLooseTrack.push_back(ibooker.book1D("LooseMuon_phi_"+EtaName, "#phi_{Loose}_"+EtaName, phiBin, phiMin, phiMax));
+    phiMediumTrack.push_back(ibooker.book1D("MediumMuon_phi_"+EtaName, "#phi_{Medium}_"+EtaName, phiBin, phiMin, phiMax));
     phiSoftTrack.push_back(ibooker.book1D("SoftMuon_phi_"+EtaName, "#phi_{Soft}_"+EtaName, phiBin, phiMin, phiMax));
     phiHighPtTrack.push_back(ibooker.book1D("HighPtMuon_phi_"+EtaName, "#phi_{HighPt}_"+EtaName, phiBin, phiMin, phiMax));
     
@@ -103,6 +105,7 @@ void MuonKinVsEtaAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     pStaTrack.push_back(ibooker.book1D("StaMuon_p"+EtaName, "p_{STA} "+EtaName, pBin, pMin, pMax));
     pTightTrack.push_back(ibooker.book1D("TightMuon_p_"+EtaName, "p_{Tight} "+EtaName, pBin, pMin, pMax));
     pLooseTrack.push_back(ibooker.book1D("LooseMuon_p_"+EtaName, "p_{Loose} "+EtaName, pBin, pMin, pMax));
+    pMediumTrack.push_back(ibooker.book1D("MediumMuon_p_"+EtaName, "p_{Medium} "+EtaName, pBin, pMin, pMax));
     pSoftTrack.push_back(ibooker.book1D("SoftMuon_p_"+EtaName, "p_{Soft} "+EtaName, pBin, pMin, pMax));
     pHighPtTrack.push_back(ibooker.book1D("HighPtMuon_p_"+EtaName, "p_{HighPt} "+EtaName, pBin, pMin, pMax));
 
@@ -112,6 +115,7 @@ void MuonKinVsEtaAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     ptStaTrack.push_back(ibooker.book1D("StaMuon_pt_"+EtaName, "pt_{STA} "+EtaName, ptBin, ptMin, pMax));
     ptTightTrack.push_back(ibooker.book1D("TightMuon_pt_"+EtaName, "pt_{Tight} "+EtaName, ptBin, ptMin, ptMax));
     ptLooseTrack.push_back(ibooker.book1D("LooseMuon_pt_"+EtaName, "pt_{Loose} "+EtaName, ptBin, ptMin, ptMax));
+    ptMediumTrack.push_back(ibooker.book1D("MediumMuon_pt_"+EtaName, "pt_{Medium} "+EtaName, ptBin, ptMin, ptMax));
     ptSoftTrack.push_back(ibooker.book1D("SoftMuon_pt_"+EtaName, "pt_{Soft} "+EtaName, ptBin, ptMin, ptMax));
     ptHighPtTrack.push_back(ibooker.book1D("HighPtMuon_pt_"+EtaName, "pt_{HighPt} "+EtaName, ptBin, ptMin, ptMax));
 
@@ -125,7 +129,9 @@ void MuonKinVsEtaAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
     chi2TightTrack.push_back(ibooker.book1D("TightMuon_chi2_"+EtaName, "#chi^{2}_{Tight} " + EtaName, chiBin, chiMin, chiMax));
     chi2probTightTrack.push_back(ibooker.book1D("TightMuon_chi2prob_"+EtaName, "#chi^{2}_{Tight} prob." + EtaName, chiBin, chiprobMin, chiprobMax));
     chi2LooseTrack.push_back(ibooker.book1D("LooseMuon_chi2_"+EtaName, "#chi^{2}_{Loose} " + EtaName, chiBin, chiMin, chiMax));
+    chi2MediumTrack.push_back(ibooker.book1D("MediumMuon_chi2_"+EtaName, "#chi^{2}_{Medium} " + EtaName, chiBin, chiMin, chiMax));
     chi2probLooseTrack.push_back(ibooker.book1D("LooseMuon_chi2prob_"+EtaName, "#chi^{2}_{Loose} prob." + EtaName, chiBin, chiprobMin, chiprobMax));
+    chi2probMediumTrack.push_back(ibooker.book1D("MediumMuon_chi2prob_"+EtaName, "#chi^{2}_{Medium} prob." + EtaName, chiBin, chiprobMin, chiprobMax));
     chi2SoftTrack.push_back(ibooker.book1D("SoftMuon_chi2_"+EtaName, "#chi^{2}_{Soft} " + EtaName, chiBin, chiMin, chiMax));
     chi2probSoftTrack.push_back(ibooker.book1D("SoftMuon_chi2prob_"+EtaName, "#chi^{2}_{Soft} prob." + EtaName, chiBin, chiprobMin, chiprobMax));
     chi2HighPtTrack.push_back(ibooker.book1D("HighPtMuon_chi2_"+EtaName, "#chi^{2}_{HighPt} " + EtaName, chiBin, chiMin, chiMax));
@@ -276,6 +282,26 @@ void MuonKinVsEtaAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSet
 	  ptLooseTrack[iEtaRegion]->Fill(recoLooseTrack->pt());
 	  chi2LooseTrack[iEtaRegion]->Fill(recoLooseTrack->normalizedChi2());
 	  chi2probLooseTrack[iEtaRegion]->Fill(TMath::Prob(recoLooseTrack->normalizedChi2(),recoLooseTrack->ndof()));
+	}
+      }
+
+      if ( muon::isMediumMuon(recoMu) ) {
+#ifdef DEBUG
+	cout << "[MuonKinVsEtaAnalyzer]: The mu is Medium... Filling the histos" << endl;
+#endif
+	LogTrace(metname)<<"[MuonKinVsEtaAnalyzer] The mu is Medium - filling the histos";
+	reco::TrackRef recoMediumTrack; 
+
+	if ( recoMu.isGlobalMuon()) recoMediumTrack = recoMu.combinedMuon();
+	else recoMediumTrack = recoMu.track();
+
+	if(fabs(recoMediumTrack->eta())>EtaCutMin && fabs(recoMediumTrack->eta())<EtaCutMax){
+	  etaMediumTrack[iEtaRegion]->Fill(recoMediumTrack->eta());
+	  phiMediumTrack[iEtaRegion]->Fill(recoMediumTrack->phi());
+	  pMediumTrack[iEtaRegion]->Fill(recoMediumTrack->p());
+	  ptMediumTrack[iEtaRegion]->Fill(recoMediumTrack->pt());
+	  chi2MediumTrack[iEtaRegion]->Fill(recoMediumTrack->normalizedChi2());
+	  chi2probMediumTrack[iEtaRegion]->Fill(TMath::Prob(recoMediumTrack->normalizedChi2(),recoMediumTrack->ndof()));
 	}
       }
 

--- a/DataFormats/MuonReco/interface/MuonSelectors.h
+++ b/DataFormats/MuonReco/interface/MuonSelectors.h
@@ -83,6 +83,7 @@ namespace muon {
 
    bool isTightMuon(const reco::Muon&, const reco::Vertex&);
    bool isLooseMuon(const reco::Muon&);
+   bool isMediumMuon(const reco::Muon&);
    bool isSoftMuon(const reco::Muon&, const reco::Vertex&);
    bool isHighPtMuon(const reco::Muon&, const reco::Vertex&);
    

--- a/DataFormats/MuonReco/src/MuonSelectors.cc
+++ b/DataFormats/MuonReco/src/MuonSelectors.cc
@@ -764,6 +764,18 @@ bool muon::isLooseMuon(const reco::Muon& muon){
 }
 
 
+bool muon::isMediumMuon(const reco::Muon& muon){
+  if( !( isLooseMuon(muon) && muon.innerTrack()->validFraction() > 0.8 )) return false; 
+
+  bool goodGlb = muon.isGlobalMuon() && 
+    muon.globalTrack()->normalizedChi2() < 3. && 
+    muon.combinedQuality().chi2LocalPosition < 12. && 
+    muon.combinedQuality().trkKink < 20.; 
+
+  return (segmentCompatibility(muon) > (goodGlb ? 0.303 : 0.451)); 
+}
+
+
 bool muon::isSoftMuon(const reco::Muon& muon, const reco::Vertex& vtx){
 
   bool muID = muon::isGoodMuon(muon, TMOneStationTight);

--- a/DataFormats/PatCandidates/interface/Muon.h
+++ b/DataFormats/PatCandidates/interface/Muon.h
@@ -160,6 +160,7 @@ namespace pat {
       /// https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideMuonId
       bool isTightMuon(const reco::Vertex&) const;
       bool isLooseMuon() const;
+      bool isMediumMuon() const;
       bool isSoftMuon(const reco::Vertex&) const;
       bool isHighPtMuon(const reco::Vertex&) const;
 

--- a/DataFormats/PatCandidates/src/Muon.cc
+++ b/DataFormats/PatCandidates/src/Muon.cc
@@ -431,6 +431,11 @@ bool Muon::isLooseMuon() const {
 
 }
 
+bool Muon::isMediumMuon() const {
+  return muon::isMediumMuon(*this);
+
+}
+
 bool Muon::isSoftMuon(const reco::Vertex& vtx) const {
   return muon::isSoftMuon(*this, vtx);
 }


### PR DESCRIPTION
This is to include a new "Medium" muon selector for reco::Muon and pat::Muon. It is a backport to 74X of PR #8876 from 75X. 
The new ID selection was proposed and studied by @gpetruc and @cbotta [1], and is optimized to have efficiency close to Loose muons and fake rate at the same level as Tight muons. 
For monitoring purposes, few plots were included in muon offline DQM.

[1] https://indico.cern.ch/event/357213/contribution/2/material/slides/0.pdf 
