### PR TITLE
FWCore/Integration: remove unused variables (Clang errors)

### DIFF
--- a/FWCore/Integration/test/AssociationMapAnalyzer.cc
+++ b/FWCore/Integration/test/AssociationMapAnalyzer.cc
@@ -73,11 +73,9 @@ namespace edmtest {
 
     edm::Handle<std::vector<int> > inputCollection1;
     event.getByToken(inputToken1_, inputCollection1);
-    std::vector<int> const& vint1 = *inputCollection1;
 
     edm::Handle<std::vector<int> > inputCollection2;
     event.getByToken(inputToken2_, inputCollection2);
-    std::vector<int> const& vint2 = *inputCollection2;
 
     // Readout some entries from some AssociationMaps and check that
     // we readout the same content as was was put in. We know the values

--- a/FWCore/Integration/test/AssociationMapProducer.cc
+++ b/FWCore/Integration/test/AssociationMapProducer.cc
@@ -73,11 +73,9 @@ namespace edmtest {
 
     edm::Handle<std::vector<int> > inputCollection1;
     event.getByToken(inputToken1_, inputCollection1);
-    std::vector<int> const& vint1 = *inputCollection1;
 
     edm::Handle<std::vector<int> > inputCollection2;
     event.getByToken(inputToken2_, inputCollection2);
-    std::vector<int> const& vint2 = *inputCollection2;
 
     // insert some entries into some AssociationMaps, in another
     // module we will readout the contents and check that we readout


### PR DESCRIPTION
```
CMSSW_7_5_CLANG_X_2015-04-26-2300/src/FWCore/Integration/test/AssociationMapProducer.cc:76:29: error: unused variable 'vint1' [-Werror,-Wunused-variable]
CMSSW_7_5_CLANG_X_2015-04-26-2300/src/FWCore/Integration/test/AssociationMapProducer.cc:80:29: error: unused variable 'vint2' [-Werror,-Wunused-variable]
CMSSW_7_5_CLANG_X_2015-04-26-2300/src/FWCore/Integration/test/AssociationMapAnalyzer.cc:76:29: error: unused variable 'vint1' [-Werror,-Wunused-variable]
CMSSW_7_5_CLANG_X_2015-04-26-2300/src/FWCore/Integration/test/AssociationMapAnalyzer.cc:80:29: error: unused variable 'vint2' [-Werror,-Wunused-variable]
```

Reported by Clang.
Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
