### PR TITLE
RPC efficiency distribution bugfix

### DIFF
--- a/DQM/RPCMonitorClient/src/RPCEfficiencyShiftHisto.cc
+++ b/DQM/RPCMonitorClient/src/RPCEfficiencyShiftHisto.cc
@@ -64,8 +64,7 @@ void RPCEfficiencyShiftHisto::dqmEndJob(DQMStore::IBooker & ibooker, DQMStore::I
    for(int w = -2 ; w<3; w++){
      
        meName.str("");
-       if(w <= 0) meName<<globalFolder_<<"Efficiency_Roll_vs_Sector_Wheel_"<<w;
-       else meName<<globalFolder_<<"Efficiency_Roll_vs_Sector_Wheel_+"<<w;
+       meName<<globalFolder_<<"Efficiency_Roll_vs_Sector_Wheel_"<<w;
 
        myMe = igetter.get(meName.str());
 	 


### PR DESCRIPTION
RPC efficiency ME naming scheme was changed in the 7XY development but this client module (RPCEfficiencyShiftHisto) was not updated.
Wheel +1 and +2 are skipped in the RPC efficiency distribution plot; thus the nEntries of "RPC/RPCEfficiency/EffBarrelRoll" plot was just ~600 which had to be ~1000 (=number of rolls in barrel).
