### PR TITLE
SimVertexs collection for FastTiming studies

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -851,6 +851,7 @@ class ConfigBuilder(object):
         self.ENDJOBDefaultCFF="Configuration/StandardSequences/EndOfProcess_cff"
         self.ConditionsDefaultCFF = "Configuration/StandardSequences/FrontierConditions_GlobalTag_cff"
         self.CFWRITERDefaultCFF = "Configuration/StandardSequences/CrossingFrameWriter_cff"
+        self.CFSLIMWRTDefaultCFF = "Configuration/StandardSequences/CrossingFrameWriter_cff"
         self.REPACKDefaultCFF="Configuration/StandardSequences/DigiToRaw_Repack_cff"
 
         if "DATAMIX" in self.stepMap.keys():
@@ -872,6 +873,7 @@ class ConfigBuilder(object):
         self.HARVESTINGDefaultSeq=None
         self.ALCAHARVESTDefaultSeq=None
         self.CFWRITERDefaultSeq=None
+        self.CFSLIMWRTDefaultSeq=None
         self.RAW2DIGIDefaultSeq='RawToDigi'
         self.L1RecoDefaultSeq='L1Reco'
         self.L1TrackTriggerDefaultSeq='L1TrackTrigger'
@@ -1371,6 +1373,12 @@ class ConfigBuilder(object):
 	    """ Enrich the schedule with the crossing frame writer step"""
 	    self.loadAndRemember(self.CFWRITERDefaultCFF)
 	    self.scheduleSequence('pcfw','cfwriter_step')
+	    return
+
+    def prepare_CFSLIMWRT(self, sequence = None):
+	    """ Enrich the schedule with the crossing frame slimmed writer step"""
+	    self.loadAndRemember(self.CFSLIMWRTDefaultCFF)
+	    self.scheduleSequence('pcfsw','cfslimwrt_step')
 	    return
 
     def prepare_DATAMIX(self, sequence = None):

--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -202,6 +202,8 @@ def OptionsFromItems(items):
             options.isMC=True
         if 'CFWRITER' in options.trimmedStep:
             options.isMC=True
+        if 'CFSLIMWRT' in options.trimmedStep:
+            options.isMC=True
         if 'DIGI' in options.trimmedStep:
             options.isMC=True
         if (not (options.eventcontent == None)) and 'SIM' in options.eventcontent:

--- a/Configuration/StandardSequences/python/CrossingFrameWriter_cff.py
+++ b/Configuration/StandardSequences/python/CrossingFrameWriter_cff.py
@@ -1,5 +1,8 @@
 import FWCore.ParameterSet.Config as cms
 
 from SimGeneral.MixingModule.cfwriter_cfi import *
+from SimGeneral.MixingModule.psimVertexFilter_cfi import *
 
 pcfw = cms.Sequence(cms.SequencePlaceholder("mix")*cfWriter)
+
+pcfsw = cms.Sequence(cms.SequencePlaceholder("mix")*cfWriter*psimVertexFilter)

--- a/Configuration/StandardSequences/python/CrossingFrameWriter_cff.py
+++ b/Configuration/StandardSequences/python/CrossingFrameWriter_cff.py
@@ -5,4 +5,4 @@ from SimGeneral.MixingModule.psimVertexFilter_cfi import *
 
 pcfw = cms.Sequence(cms.SequencePlaceholder("mix")*cfWriter)
 
-pcfsw = cms.Sequence(cms.SequencePlaceholder("mix")*cfWriter*psimVertexFilter)
+pcfsw = cms.Sequence(cms.SequencePlaceholder("mix")*psimVertexFilter)

--- a/SimGeneral/MixingModule/plugins/PSimVertexFilter.cc
+++ b/SimGeneral/MixingModule/plugins/PSimVertexFilter.cc
@@ -1,0 +1,52 @@
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/PluginManager/interface/ModuleDef.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/Vertex/interface/SimVertex.h"
+#include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
+
+#include "SimGeneral/MixingModule/plugins/PSimVertexFilter.h"
+
+#include <vector>
+
+
+PSimVertexFilter::PSimVertexFilter(edm::ParameterSet const & config):
+  vtxToken_( consumes<PCrossingFrame<SimVertex> >( config.getParameter<edm::InputTag> ("simVtxTag") ) )
+{
+  //register your products
+  produces<edm::SimVertexContainer >(simVtxFiltered_);
+}
+
+
+PSimVertexFilter::~PSimVertexFilter()
+{}
+
+
+bool 
+PSimVertexFilter::filter(edm::Event& event, const edm::EventSetup& setup)
+{
+  edm::Handle<PCrossingFrame<SimVertex> > genVtxsHandle;
+  event.getByToken(vtxToken_, genVtxsHandle);
+  const PCrossingFrame<SimVertex>* SimVtx = genVtxsHandle.product(); 
+
+  //Create empty output collections
+  std::auto_ptr<edm::SimVertexContainer> simVtxFiltered( new edm::SimVertexContainer );
+  
+
+  //Select interesting objects
+  for(unsigned int iGen=0; iGen<SimVtx->getPileups().size(); ++iGen){
+    if(SimVtx->getPileups().at(iGen)->vertexId() == 0)
+      simVtxFiltered->push_back(SimVertex(SimVtx->getPileups().at(iGen)->position(), SimVtx->getPileups().at(iGen)->position().t(), iGen)); 
+      }
+
+  //Put selected information in the event
+  event.put(simVtxFiltered, simVtxFiltered_);
+  
+  return true;
+}
+
+
+DEFINE_FWK_MODULE(PSimVertexFilter);

--- a/SimGeneral/MixingModule/plugins/PSimVertexFilter.cc
+++ b/SimGeneral/MixingModule/plugins/PSimVertexFilter.cc
@@ -14,10 +14,10 @@
 
 
 PSimVertexFilter::PSimVertexFilter(edm::ParameterSet const & config):
-  vtxToken_( consumes<PCrossingFrame<SimVertex> >( config.getParameter<edm::InputTag> ("simVtxTag") ) )
+    vtxToken_( consumes<CrossingFrame<SimVertex> >( config.getParameter<edm::InputTag> ("simVtxTag") ) )
 {
-  //register your products
-  produces<edm::SimVertexContainer >(simVtxFiltered_);
+    //register your products
+    produces<edm::SimVertexContainer >(simVtxFiltered_);
 }
 
 
@@ -28,24 +28,24 @@ PSimVertexFilter::~PSimVertexFilter()
 bool 
 PSimVertexFilter::filter(edm::Event& event, const edm::EventSetup& setup)
 {
-  edm::Handle<PCrossingFrame<SimVertex> > genVtxsHandle;
-  event.getByToken(vtxToken_, genVtxsHandle);
-  const PCrossingFrame<SimVertex>* SimVtx = genVtxsHandle.product(); 
+    edm::Handle<CrossingFrame<SimVertex> > genVtxsHandle;
+    event.getByToken(vtxToken_, genVtxsHandle);
+    const CrossingFrame<SimVertex>* SimVtx = genVtxsHandle.product(); 
 
-  //Create empty output collections
-  std::auto_ptr<edm::SimVertexContainer> simVtxFiltered( new edm::SimVertexContainer );
+    //Create empty output collections
+    std::auto_ptr<edm::SimVertexContainer> simVtxFiltered( new edm::SimVertexContainer );
   
 
-  //Select interesting objects
-  for(unsigned int iGen=0; iGen<SimVtx->getPileups().size(); ++iGen){
-    if(SimVtx->getPileups().at(iGen)->vertexId() == 0)
-      simVtxFiltered->push_back(SimVertex(SimVtx->getPileups().at(iGen)->position(), SimVtx->getPileups().at(iGen)->position().t(), iGen)); 
-      }
+    //Select interesting objects
+    for(unsigned int iGen=0; iGen<SimVtx->getPileups().size(); ++iGen){
+        if(SimVtx->getPileups().at(iGen)->vertexId() == 0)
+            simVtxFiltered->push_back(SimVertex(SimVtx->getPileups().at(iGen)->position(), SimVtx->getPileups().at(iGen)->position().t(), iGen)); 
+    }
 
-  //Put selected information in the event
-  event.put(simVtxFiltered, simVtxFiltered_);
+    //Put selected information in the event
+    event.put(simVtxFiltered, simVtxFiltered_);
   
-  return true;
+    return true;
 }
 
 

--- a/SimGeneral/MixingModule/plugins/PSimVertexFilter.h
+++ b/SimGeneral/MixingModule/plugins/PSimVertexFilter.h
@@ -1,0 +1,34 @@
+#ifndef _PSimVertexFilter_H
+#define _PSimVertexFilter_H
+
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "SimDataFormats/CrossingFrame/interface/CrossingFrame.h"
+#include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
+#include "SimDataFormats/Vertex/interface/SimVertex.h"
+
+
+//
+// class decleration
+//
+
+class PSimVertexFilter : public edm::EDFilter{
+ public:
+  explicit PSimVertexFilter(const edm::ParameterSet&);
+  ~PSimVertexFilter();
+
+  virtual bool filter(edm::Event& event, const edm::EventSetup& setup);
+
+ private:
+  const edm::EDGetTokenT<PCrossingFrame<SimVertex> > vtxToken_;
+  const std::string simVtxFiltered_;
+};
+
+#endif

--- a/SimGeneral/MixingModule/plugins/PSimVertexFilter.h
+++ b/SimGeneral/MixingModule/plugins/PSimVertexFilter.h
@@ -20,15 +20,15 @@
 //
 
 class PSimVertexFilter : public edm::EDFilter{
- public:
-  explicit PSimVertexFilter(const edm::ParameterSet&);
-  ~PSimVertexFilter();
+public:
+    explicit PSimVertexFilter(const edm::ParameterSet&);
+    ~PSimVertexFilter();
 
-  virtual bool filter(edm::Event& event, const edm::EventSetup& setup);
+    virtual bool filter(edm::Event& event, const edm::EventSetup& setup);
 
- private:
-  const edm::EDGetTokenT<PCrossingFrame<SimVertex> > vtxToken_;
-  const std::string simVtxFiltered_;
+private:
+    const edm::EDGetTokenT<CrossingFrame<SimVertex> > vtxToken_;
+    const std::string simVtxFiltered_;
 };
 
 #endif

--- a/SimGeneral/MixingModule/python/psimVertexFilter_cfi.py
+++ b/SimGeneral/MixingModule/python/psimVertexFilter_cfi.py
@@ -1,0 +1,6 @@
+import FWCore.ParameterSet.Config as cms
+
+psimVertexFilter = cms.EDFilter("PSimVertexFilter",
+                                simVtxTag = cms.InputTag("cfWriter", "g4SimHits", "DIGI2RAW")
+                                )
+

--- a/SimGeneral/MixingModule/python/psimVertexFilter_cfi.py
+++ b/SimGeneral/MixingModule/python/psimVertexFilter_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
 psimVertexFilter = cms.EDFilter("PSimVertexFilter",
-                                simVtxTag = cms.InputTag("cfWriter", "g4SimHits", "DIGI2RAW")
+                                simVtxTag = cms.InputTag("mix", "g4SimHits", "DIGI2RAW")
                                 )
 


### PR DESCRIPTION
Adding SimVertex collection for interaction vertices only (PU+Signal), the collection are produced as a slimmer version of the CrossingFrame transient collection. This PR addresses the memory issues of the default CFWriter module collections.

@amartelli  
