### PR TITLE
FWCore/Services: do not optimize 'edmtest::FpeTester::analyze'

### DIFF
--- a/FWCore/Services/test/FpeTester.cc
+++ b/FWCore/Services/test/FpeTester.cc
@@ -53,6 +53,7 @@ namespace edmtest {
   FpeTester::~FpeTester() {
   }
 
+  [[clang::optnone]]
   void
   FpeTester::analyze(edm::Event const&, edm::EventSetup const&) {
     if (testname_ == "division") {


### PR DESCRIPTION
Resolves unit test (`fpe_test_2.sh`) failure in CLANG IB.

```
Completed cmsRun with DIVIDEBYZERO exception enabled
cmsRun status:  0
Test FAILED, status neither 136 nor 11
status = 256
```

`do_division` call is optimized out from `edmtest::FpeTester::analyze`.
It's caused by division by zero, which is undefined behavior thus
compiler is free to do what it wants, e.g., optimize it out.

Disable any optimizations on the function.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
