### PR TITLE
Path renaming in HLT DQM (JIRA-333)

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -276,12 +276,12 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     ZnnHbb = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_BTagCSV0p7_v",
-            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDLoose_v"
-            "HLT_PFMET120_PFMHT120_IDLoose_v",
-            "HLT_PFMET110_PFMHT110_IDLoose_v",
-            "HLT_PFMET100_PFMHT100_IDLoose_v",
-            "HLT_PFMET90_PFMHT90_IDLoose_v",
+            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_BTagCSV0p7_v",
+            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_v"
+            "HLT_PFMET120_PFMHT120_IDTight_v",
+            "HLT_PFMET110_PFMHT110_IDTight_v",
+            "HLT_PFMET100_PFMHT100_IDTight_v",
+            "HLT_PFMET90_PFMHT90_IDTight_v",
             ),
         Jet_recCut   = cms.string("pt > 10 && abs(eta) < 2.6"),
         recJetLabel  = cms.string("ak4PFJetsCHS"),


### PR DESCRIPTION
This PR fixes the path names changed with https://its.cern.ch/jira/browse/CMSHLT-333 (IDLoose -> IDTight)
