### PR TITLE
Added Bertini Cascade for FastSimulation of nuclear interactions in tracker

### DIFF
--- a/FastSimulation/MaterialEffects/interface/CMSDummyDeexcitation.h
+++ b/FastSimulation/MaterialEffects/interface/CMSDummyDeexcitation.h
@@ -21,7 +21,7 @@ class CMSDummyDeexcitation : public G4VPreCompoundModel
 { 
 public:
 
-  CMSDummyDeexcitation() {}; 
+  CMSDummyDeexcitation():G4VPreCompoundModel(0, "PRECO") {}; 
 
   virtual ~CMSDummyDeexcitation() {};
 

--- a/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
+++ b/FastSimulation/MaterialEffects/interface/NuclearInteractionFTFSimulator.h
@@ -20,8 +20,6 @@
 #include "G4LorentzVector.hh"
 #include "G4ThreeVector.hh"
 
-#include <vector>
-
 class ParticlePropagator;
 class RandomEngineAndDistribution;
 class G4ParticleDefinition;
@@ -32,13 +30,19 @@ class G4FTFModel;
 class G4ExcitedStringDecay;
 class G4LundStringFragmentation;
 class G4GeneratorPrecompoundInterface;
+class G4CascadeInterface;
+class G4PhysicsLogVector;
+
+static const int numHadrons = 30;
+static const int npoints = 21;
 
 class NuclearInteractionFTFSimulator : public MaterialEffectsSimulator
 {
 public:
 
   /// Constructor
-  NuclearInteractionFTFSimulator(unsigned int distAlgo, double distCut);
+  NuclearInteractionFTFSimulator(unsigned int distAlgo, double distCut, 
+				 double elimit, double eth);
 
   /// Default Destructor
   ~NuclearInteractionFTFSimulator();
@@ -53,15 +57,17 @@ private:
   double distanceToPrimary(const RawParticle& Particle,
 			   const RawParticle& aDaughter) const;
 
-  std::vector<const G4ParticleDefinition*> theG4Hadron;
-  std::vector<double> theNuclIntLength;
-  std::vector<int> theId;
+  static const G4ParticleDefinition* theG4Hadron[numHadrons];
+  static int theId[numHadrons];
+  G4PhysicsLogVector* vect;
 
   G4TheoFSGenerator* theHadronicModel;
   G4FTFModel* theStringModel;
   G4ExcitedStringDecay* theStringDecay; 
   G4LundStringFragmentation* theLund;
   G4GeneratorPrecompoundInterface* theCascade; 
+
+  G4CascadeInterface* theBertiniCascade;
 
   G4Step* dummyStep;
   G4Track* currTrack;
@@ -73,13 +79,14 @@ private:
   G4ThreeVector vectProj;
   G4ThreeVector theBoost;
 
+  double theBertiniLimit;
   double theEnergyLimit;
 
   double theDistCut;
   double distMin;
 
-  int numHadrons;
   int currIdx;
+  size_t index;
   unsigned int theDistAlgo;
 };
 #endif

--- a/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
+++ b/FastSimulation/MaterialEffects/python/MaterialEffects_cfi.py
@@ -15,7 +15,10 @@ MaterialEffectsBlock = cms.PSet(
         Density = cms.double(2.329),
 	# One radiation length in cm
         RadiationLength = cms.double(9.36),
-
+        # upper energy limit for the Bertini cascade 
+        EkinBertiniGeV = cms.double(3.5),
+        # Kinetic energy threshold for secondaries 
+        EkinLimitGeV = cms.double(0.1),
 	# General switches
 	# Enable photon pair conversion 
         PairProduction = cms.bool(True),

--- a/FastSimulation/MaterialEffects/src/MaterialEffects.cc
+++ b/FastSimulation/MaterialEffects/src/MaterialEffects.cc
@@ -203,7 +203,10 @@ MaterialEffects::MaterialEffects(const edm::ParameterSet& matEff)
 
     // Construction
     if ( doG4NuclInteraction ) { 
-      NuclearInteraction = new NuclearInteractionFTFSimulator(distAlgo, distCut); 
+      double elimit = matEff.getParameter<double>("EkinBertiniGeV")*CLHEP::GeV;
+      double eth = matEff.getParameter<double>("EkinLimitGeV")*CLHEP::GeV;
+      NuclearInteraction = 
+	new NuclearInteractionFTFSimulator(distAlgo, distCut, elimit, eth); 
     } else {
       NuclearInteraction = 
 	new NuclearInteractionSimulator(hadronEnergies, hadronTypes, hadronNames, 


### PR DESCRIPTION
Added the Bertini Cascade to fast simulation of hadron-nuclear interaction with kinetic energy below the limit (default value 3.5 GeV). FTF model is used above.

Added tabulated cross section corrections in the energy interval 100 MeV - 1 TeV.

Because but default this  nuclear interaction class is not used no change is expected in comparisons. 
