### PR TITLE
75x Fireworks: port GEM related changes from CMSSW_7_6_X_SLHC

### DIFF
--- a/Fireworks/Core/interface/FWGeometry.h
+++ b/Fireworks/Core/interface/FWGeometry.h
@@ -28,7 +28,7 @@ public:
    static const int kSubdetOffset       = 25;
 
    enum Detector { Tracker = 1, Muon = 2, Ecal = 3, Hcal = 4, Calo = 5 };
-   enum SubDetector { PixelBarrel = 1, PixelEndcap = 2, TIB = 3, TID = 4, TOB = 5, TEC = 6, CSC = 7, DT = 8, RPCBarrel = 9, RPCEndcap = 10 };
+   enum SubDetector { PixelBarrel = 1, PixelEndcap = 2, TIB = 3, TID = 4, TOB = 5, TEC = 6, CSC = 7, DT = 8, RPCBarrel = 9, RPCEndcap = 10, GEM = 11, ME0 = 12};
 
    struct Range {
       double min1;

--- a/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
+++ b/Fireworks/Geometry/interface/FWRecoGeometryESProducer.h
@@ -35,6 +35,7 @@ private:
   void addDTGeometry( void );
   void addRPCGeometry( void );
   void addGEMGeometry( void );
+  void addME0Geometry( void );
   void addPixelBarrelGeometry( void );
   void addPixelForwardGeometry( void );
   void addTIBGeometry( void );

--- a/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
+++ b/Fireworks/Geometry/src/FWRecoGeometryESProducer.cc
@@ -15,6 +15,7 @@
 #include "Geometry/DTGeometry/interface/DTLayer.h"
 #include "Geometry/RPCGeometry/interface/RPCGeometry.h"
 #include "Geometry/GEMGeometry/interface/GEMGeometry.h"
+#include "Geometry/GEMGeometry/interface/ME0Geometry.h"
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 #include "Geometry/TrackerGeometryBuilder/interface/RectangularPixelTopology.h"
@@ -95,18 +96,8 @@ FWRecoGeometryESProducer::produce( const FWRecoGeometryRecord& record )
   addDTGeometry();
   addCSCGeometry();
   addRPCGeometry();
-
-  try 
-  {
-    addGEMGeometry();
-  }
-  catch( cms::Exception& exception )
-  {
-   edm::LogWarning("FWRecoGeometryProducerException")
-     << "Exception caught while building GEM geometry: " << exception.what()
-     << std::endl; 
-  }
-  
+  addGEMGeometry();
+  addME0Geometry();
   addCaloGeometry();
 
   m_fwGeometry->idToName.resize( m_current + 1 );
@@ -260,34 +251,83 @@ FWRecoGeometryESProducer::addGEMGeometry( void )
   // GEM geometry
   //
   DetId detId( DetId::Muon, 4 );
-  const GEMGeometry* gemGeom = (const GEMGeometry*) m_geomRecord->slaveGeometry( detId );
-  for( auto it = gemGeom->etaPartitions().begin(),
-	   end = gemGeom->etaPartitions().end(); 
-       it != end; ++it )
+
+  try 
   {
-    const GEMEtaPartition* roll = (*it);
-    if( roll )
-    {
-      unsigned int rawid = (*it)->geographicalId().rawId();
-      unsigned int current = insert_id( rawid );
-      fillShapeAndPlacement( current, roll );
+    const GEMGeometry* gemGeom = (const GEMGeometry*) m_geomRecord->slaveGeometry( detId );
+  
+    for(auto roll : gemGeom->etaPartitions())
+    { 
+      if( roll )
+      {
+	unsigned int rawid = roll->geographicalId().rawId();
+	unsigned int current = insert_id( rawid );
+	fillShapeAndPlacement( current, roll );
 
-      const StripTopology& topo = roll->specificTopology();
-      m_fwGeometry->idToName[current].topology[0] = topo.nstrips();
-      m_fwGeometry->idToName[current].topology[1] = topo.stripLength();
-      m_fwGeometry->idToName[current].topology[2] = topo.pitch();
+	const StripTopology& topo = roll->specificTopology();
+	m_fwGeometry->idToName[current].topology[0] = topo.nstrips();
+	m_fwGeometry->idToName[current].topology[1] = topo.stripLength();
+	m_fwGeometry->idToName[current].topology[2] = topo.pitch();
 
-      float height = topo.stripLength()/2;
-      LocalPoint  lTop( 0., height, 0.);
-      LocalPoint  lBottom( 0., -height, 0.);
-      m_fwGeometry->idToName[current].topology[3] = roll->localPitch(lTop);
-      m_fwGeometry->idToName[current].topology[4] = roll->localPitch(lBottom);
-      m_fwGeometry->idToName[current].topology[5] = roll->npads();
+	float height = topo.stripLength()/2;
+	LocalPoint  lTop( 0., height, 0.);
+	LocalPoint  lBottom( 0., -height, 0.);
+	m_fwGeometry->idToName[current].topology[3] = roll->localPitch(lTop);
+	m_fwGeometry->idToName[current].topology[4] = roll->localPitch(lBottom);
+	m_fwGeometry->idToName[current].topology[5] = roll->npads();
+      }
+    }
+
+    m_fwGeometry->extraDet.Add(new TNamed("GEM", "GEM muon detector"));
+  }
+  catch( cms::Exception &exception )
+  {
+    edm::LogInfo("FWRecoGeometry") << "failed to produce GEM geometry " << exception.what() << std::endl;
+  }
+}
+
+
+
+void
+FWRecoGeometryESProducer::addME0Geometry( void )
+{
+  //                                                                                                                               
+  // ME0 geometry                                                                                                                  
+  //   
+
+  DetId detId( DetId::Muon, 5 );
+  try 
+  {
+    const ME0Geometry* me0Geom = (const ME0Geometry*) m_geomRecord->slaveGeometry( detId );
+  
+    for(auto roll : me0Geom->etaPartitions())
+    { 
+      if( roll )
+      {
+	unsigned int rawid = roll->geographicalId().rawId();
+	unsigned int current = insert_id( rawid );
+	fillShapeAndPlacement( current, roll );
+	  
+	const StripTopology& topo = roll->specificTopology();
+	m_fwGeometry->idToName[current].topology[0] = topo.nstrips();
+	m_fwGeometry->idToName[current].topology[1] = topo.stripLength();
+	m_fwGeometry->idToName[current].topology[2] = topo.pitch();
+	
+	float height = topo.stripLength()/2;
+	LocalPoint  lTop( 0., height, 0.);
+	LocalPoint  lBottom( 0., -height, 0.);
+	m_fwGeometry->idToName[current].topology[3] = roll->localPitch(lTop);
+	m_fwGeometry->idToName[current].topology[4] = roll->localPitch(lBottom);
+	m_fwGeometry->idToName[current].topology[5] = roll->npads();
+      }
     }
   }
-
-  m_fwGeometry->extraDet.Add(new TNamed("GEM", "GEM muon detector"));
-}
+  catch( cms::Exception &exception )
+  {
+    edm::LogInfo("FWRecoGeometry") << "failed to produce ME0 geometry " << exception.what() << std::endl;
+  }
+}  
+  
 
 
 void

--- a/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackHitsDetailView.cc
@@ -427,6 +427,11 @@ FWTrackHitsDetailView::addModules( const reco::Track& track,
 	    case MuonSubdetId::RPC:
 	       name = "RPC";
 	       break;
+	    case MuonSubdetId::GEM:
+	       name = "GEM";
+	       break;
+	    case MuonSubdetId::ME0:
+	       name = "ME0";
 	    default:
 	       break;
 	    }

--- a/Fireworks/Tracks/plugins/FWTrackResidualDetailView.h
+++ b/Fireworks/Tracks/plugins/FWTrackResidualDetailView.h
@@ -23,6 +23,7 @@
 //      |mu = 0      DT  = 1            layer                             hit type = 0-3
 //      |mu = 0      CSC = 2            layer                             hit type = 0-3
 //      |mu = 0      RPC = 3            layer                             hit type = 0-3
+//      |mu = 0      GEM = 3            layer                             hit type = 0-3
 //
 //      hit type, see DataFormats/TrackingRecHit/interface/TrackingRecHit.h
 //      valid    = valid hit                                     = 0

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -44,6 +44,8 @@
 #include "DataFormats/MuonDetId/interface/DTChamberId.h"
 #include "DataFormats/MuonDetId/interface/CSCDetId.h"
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
+#include "DataFormats/MuonDetId/interface/GEMDetId.h"
+#include "DataFormats/MuonDetId/interface/ME0DetId.h"
 
 #include "DataFormats/EcalDetId/interface/EcalSubdetector.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"

--- a/Fireworks/Tracks/src/TrackUtils.cc
+++ b/Fireworks/Tracks/src/TrackUtils.cc
@@ -786,6 +786,26 @@ info(const DetId& id) {
 	       }
 	    }
 	    break;
+            case MuonSubdetId::GEM:
+	    {
+	       GEMDetId detId(id.rawId());
+	       oss << "GEM chamber (region, station, ring, chamber, layer): "
+		   << detId.region() << ", "
+		   << detId.station() << ", "
+		   << detId.ring() << ", "
+		   << detId.chamber() << ", "
+		   << detId.layer();
+	    }
+	    break;
+            case MuonSubdetId::ME0:
+	    {
+	       ME0DetId detId(id.rawId());
+	       oss << "ME0 chamber (region, chamber, layer): "
+		   << detId.region() << ", "
+		   << detId.chamber() << ", "
+		   << detId.layer();
+	    }
+	    break;
 	 }
 	 break;
     


### PR DESCRIPTION
This are changes in packages:
Fireworks/Core (3D and projected geometry)
Fireworks/Tracks/ (tooltips in detail views)
Fireworks/Geometry (reco geometry producer added ME0)

Changes in Fireworks/Muons are skipped because required data formats are not ported yet.
