### PR TITLE
Update ele+HT paths to WPLoose (75X)

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -307,7 +307,9 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     TTHbbej  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
             "HLT_Ele27_WP85_Gsf_v",
-            "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v"
+            "HLT_Ele27_eta2p1_WP85_Gsf_HT200_v",
+            "HLT_Ele27_eta2p1_WPLoose_Gsf_v",
+            "HLT_Ele27_eta2p1_WPLoose_Gsf_HT200_v"
             ),
         recElecLabel   = cms.string("gedGsfElectrons"),
         #recJetLabel  = cms.string("ak4PFJetsCHS"),


### PR DESCRIPTION
Updating the ele+HT paths from WP85 to WPLoose for electron leg of path. See:
https://its.cern.ch/jira/browse/CMSHLT-336
