### PR TITLE
Cleanup gdml interface and R-hadron custom physics

### DIFF
--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -41,8 +41,6 @@
 
 #include "SimDataFormats/Forward/interface/LHCTransportLinkContainer.h"
 
-#include "HepPDT/defs.h"
-#include "HepPDT/TableBuilder.hh"
 #include "HepPDT/ParticleDataTable.hh"
 #include "SimGeneral/HepPDTRecord/interface/PDTRecord.h"
 
@@ -295,7 +293,7 @@ void RunManager::initG4(const edm::EventSetup & es)
 
   if("" != m_WriteFile) {
     G4GDMLParser gdml(new G4GDMLReadStructure(), new CMSGDMLWriteStructure());
-    gdml.Write(m_WriteFile, world->GetWorldVolume(), false);
+    gdml.Write(m_WriteFile, world->GetWorldVolume(), true);
   }
 
   if("" != m_RegionFile) {
@@ -469,12 +467,6 @@ void RunManager::terminateRun()
     delete m_userRunAction; 
     m_userRunAction = 0;
   }
-  /*
-  if (m_currentRun!=0) { 
-    delete m_currentRun; 
-    m_currentRun = 0; 
-  }
-  */
   if (m_kernel!=0 && !m_runTerminated) {
     delete m_currentEvent;
     m_currentEvent = 0;

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -29,8 +29,6 @@
 
 #include "SimDataFormats/Forward/interface/LHCTransportLinkContainer.h"
 
-#include "HepPDT/defs.h"
-#include "HepPDT/TableBuilder.hh"
 #include "HepPDT/ParticleDataTable.hh"
 
 #include "G4GeometryManager.hh"
@@ -179,7 +177,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   if("" != m_WriteFile) {
     G4GDMLParser gdml(new G4GDMLReadStructure(), new CMSGDMLWriteStructure());
-    gdml.Write(m_WriteFile, m_world->GetWorldVolume(), false);
+    gdml.Write(m_WriteFile, m_world->GetWorldVolume(), true);
   }
 
   if("" != m_RegionFile) {

--- a/SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh
+++ b/SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh
@@ -4,11 +4,11 @@
 #include "G4VDiscreteProcess.hh"
 
 class HadronicProcessHelper;
+class G4FermiPhaseSpaceDecay;
 class HistoHelper;
 class TProfile;
 class TH1D;
 class TH2D;
-
 
 class ToyModelHadronicProcess : public G4VDiscreteProcess
 {
@@ -31,16 +31,11 @@ private:
   
   G4double GetMeanFreePath(const G4Track& aTrack, G4double, G4ForceCondition*);
   
-
-  const G4DynamicParticle* FindRhadron(G4ParticleChange*);
-
   int m_verboseLevel;
   HadronicProcessHelper* m_helper;
+  G4FermiPhaseSpaceDecay* m_decay;
   G4ParticleChange m_particleChange;
   bool m_detachCloud;
-  
-
-
 };
 
 #endif

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -111,6 +111,7 @@ void CustomPhysicsList::setupRHadronPhycis(G4ParticleDefinition* particle)
       pmanager->AddProcess(new G4hMultipleScattering,-1, 1, 1);
       pmanager->AddProcess(new G4hIonisation,        -1, 2, 2);
     }
+    pmanager->AddProcess(new G4Decay, 1, -1, 3);
     pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper)); //GHEISHA
   }
   else      LogDebug("CustomPhysics") << "   No pmanager";

--- a/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/FullModelHadronicProcess.cc
@@ -10,12 +10,13 @@
 
 using namespace CLHEP;
 
-FullModelHadronicProcess::FullModelHadronicProcess(G4ProcessHelper * aHelper, const G4String& processName) :
+FullModelHadronicProcess::FullModelHadronicProcess(G4ProcessHelper * aHelper, 
+						   const G4String& processName) :
   G4VDiscreteProcess(processName), theHelper(aHelper)
 {}
 
-
-FullModelHadronicProcess::~FullModelHadronicProcess(){}
+FullModelHadronicProcess::~FullModelHadronicProcess()
+{}
   
 G4bool FullModelHadronicProcess::IsApplicable(const G4ParticleDefinition& aP)
 {
@@ -29,24 +30,11 @@ G4double FullModelHadronicProcess::GetMicroscopicCrossSection(const G4DynamicPar
   //Get the cross section for this particle/element combination from the ProcessHelper
   G4double InclXsec = theHelper->GetInclusiveCrossSection(aParticle,anElement);
   //  G4cout<<"Returned cross section from helper was: "<<InclXsec/millibarn<<" millibarn"<<G4endl;
-
-  // Need to provide Set-methods for these in time
-  G4double HighestEnergyLimit = 10 * TeV  ;
-  G4double LowestEnergyLimit = 1 * eV;
-
-  G4double ParticleEnergy = aParticle->GetKineticEnergy();
-
-   
-  if (ParticleEnergy > HighestEnergyLimit || ParticleEnergy < LowestEnergyLimit){
-    return 0;
-  } else {
-    //    G4cout << "Microscopic Cross Section: "<<InclXsec / millibarn<<" millibarn"<<G4endl;
-    return InclXsec;
-  }
-
+  return InclXsec;
 }
 
-G4double FullModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4double, G4ForceCondition*)
+G4double FullModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4double, 
+						   G4ForceCondition*)
 {
   G4Material *aMaterial = aTrack.GetMaterial();
   const G4DynamicParticle *aParticle = aTrack.GetDynamicParticle();
@@ -64,80 +52,63 @@ G4double FullModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4doub
 	GetMicroscopicCrossSection( aParticle, (*aMaterial->GetElementVector())[i], aTemp);
       sigma += theAtomicNumDensityVector[i] * xSection;
     }
-
-  return 1.0/sigma;
-  
+  G4double res = DBL_MAX;
+  if(sigma > 0.0) { res = 1./sigma; }
+  return res;
 }
 
 G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
 							  const G4Step&  aStep)
 {
-  //  G4cout<<"*****************    Entering FullModelHadronicProcess::PostStepDoIt       **********************"<<G4endl;
-
+  //  G4cout<<"**** Entering FullModelHadronicProcess::PostStepDoIt       ******"<<G4endl;
   const G4TouchableHandle thisTouchable(aTrack.GetTouchableHandle());
 
   // A little setting up
   aParticleChange.Initialize(aTrack);
-  //  G4DynamicParticle* OrgPart = const_cast<G4DynamicParticle*>(aTrack.GetDynamicParticle());
-  G4DynamicParticle* IncidentRhadron = const_cast<G4DynamicParticle*>(aTrack.GetDynamicParticle());
+  const G4DynamicParticle* IncidentRhadron = aTrack.GetDynamicParticle();
   CustomParticle* CustomIncident = static_cast<CustomParticle*>(IncidentRhadron->GetDefinition());
   const G4ThreeVector aPosition = aTrack.GetPosition();
-  //  std::cout<<"G: "<<aStep.GetStepLength()/cm<<std::endl;
+  //  G4cout<<"G: "<<aStep.GetStepLength()/cm<<G4endl;
   const G4int theIncidentPDG = IncidentRhadron->GetDefinition()->GetPDGEncoding();
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
   std::vector<G4ParticleDefinition*> theParticleDefinitions;
-  //  std::vector<G4DynamicParticle*> *theDynamicParticles;//These are probably redundant, but they can easily be removed :-)
   G4bool IncidentSurvives = false;
   G4bool TargetSurvives = false;
   G4Nucleus targetNucleus(aTrack.GetMaterial());
   G4ParticleDefinition* outgoingRhadron=0;
   G4ParticleDefinition* outgoingCloud=0;
   G4ParticleDefinition* outgoingTarget=0;
-//  double gamma = IncidentRhadron->GetTotalEnergy()/IncidentRhadron->GetDefinition()->GetPDGMass();
-
 
   G4ThreeVector p_0 = IncidentRhadron->GetMomentum();
-
-  //  static int n=0;
-
   G4double e_kin_0 = IncidentRhadron->GetKineticEnergy();
   //  G4cout<<e_kin_0/GeV<<G4endl;
 
   G4DynamicParticle* cloudParticle = new G4DynamicParticle();
   /*
   if(CustomPDGParser::s_isRMeson(theIncidentPDG))
-    std::cout<<"Rmeson"<<std::endl;
+    G4cout<<"Rmeson"<<G4endl;
   if(CustomPDGParser::s_isRBaryon(theIncidentPDG)) 
-    std::cout<<"Rbaryon"<<std::endl;
-  */
-  /*
-  if(CustomPDGParser::s_isRBaryon(theIncidentPDG)) 
-     cloudParticle->SetDefinition(theParticleTable->FindParticle("rhadronbaryoncloud"));
-  if(CustomPDGParser::s_isRMeson(theIncidentPDG) || CustomPDGParser::s_isRGlueball(theIncidentPDG) )
-     cloudParticle->SetDefinition(theParticleTable->FindParticle("rhadronmesoncloud"));
+    G4cout<<"Rbaryon"<<G4endl;
   */
   cloudParticle->SetDefinition(CustomIncident->GetCloud());
 
   if(cloudParticle->GetDefinition() == 0) 
      {
-      std::cout << "FullModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!!" << std::endl;
+      G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!!" << G4endl;
      }
   /*
-  std::cout<<"Incoming particle was "<<IncidentRhadron->GetDefinition()->GetParticleName()<<". Corresponding cloud is "<<cloudParticle->GetDefinition()->GetParticleName()<<std::endl;
+  G4cout<<"Incoming particle was "<<IncidentRhadron->GetDefinition()->GetParticleName()
+  <<". Corresponding cloud is "<<cloudParticle->GetDefinition()->GetParticleName()<<G4endl;
   G4cout<<"Kinetic energy was: "<<IncidentRhadron->GetKineticEnergy()/GeV<<" GeV"<<G4endl;
   */
-  double scale=cloudParticle->GetDefinition()->GetPDGMass()/IncidentRhadron->GetDefinition()->GetPDGMass();
-  //  std::cout<<"Mass ratio: "<<scale<<std::endl;
-  G4LorentzVector cloudMomentum;
-  cloudMomentum.setVectM(IncidentRhadron->GetMomentum()*scale,cloudParticle->GetDefinition()->GetPDGMass());
-  G4LorentzVector gluinoMomentum;
-  //  gluinoMomentum.setVectM(IncidentRhadron->GetMomentum()*(1.-scale),theParticleTable->FindParticle("~g")->GetPDGMass()); 
-  gluinoMomentum.setVectM(IncidentRhadron->GetMomentum()*(1.-scale),CustomIncident->GetSpectator()->GetPDGMass()); 
-  /*
-  G4cout <<"Are these the same?"<<G4endl;
-  G4cout<<gluinoMomentum<<G4endl;
-  G4cout<<(1.-scale) * IncidentRhadron->Get4Momentum()<<G4endl;
-  */
+  double scale=cloudParticle->GetDefinition()->GetPDGMass()
+    /IncidentRhadron->GetDefinition()->GetPDGMass();
+  //  G4cout<<"Mass ratio: "<<scale<<G4endl;
+  G4LorentzVector cloudMomentum(IncidentRhadron->GetMomentum()*scale,
+				cloudParticle->GetDefinition()->GetPDGMass());
+  G4LorentzVector gluinoMomentum(IncidentRhadron->GetMomentum()*(1.-scale),
+				 CustomIncident->GetSpectator()->GetPDGMass()); 
+
   //These two for getting CMS transforms later (histogramming purposes...)
   G4LorentzVector FullRhadron4Momentum = IncidentRhadron->Get4Momentum();
   G4LorentzVector Cloud4Momentum = cloudMomentum;
@@ -147,57 +118,39 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4DynamicParticle* OrgPart = cloudParticle;
 
   /*
-  std::cout<<"Original momentum: "<<IncidentRhadron->Get4Momentum().v().mag()/GeV<<" GeV, corresponding to gamma: "
-  	   <<IncidentRhadron->GetTotalEnergy()/IncidentRhadron->GetDefinition()->GetPDGMass()<<std::endl;
+  G4cout<<"Original momentum: "<<IncidentRhadron->Get4Momentum().v().mag()/GeV
+  <<" GeV, corresponding to gamma: "
+  <<IncidentRhadron->GetTotalEnergy()/IncidentRhadron->GetDefinition()->GetPDGMass()<<G4endl;
   
-  std::cout<<"Cloud momentum: "<<cloudParticle->Get4Momentum().v().mag()/GeV<<" GeV, corresponding to gamma: "
-	   <<cloudParticle->GetTotalEnergy()/cloudParticle->GetDefinition()->GetPDGMass()<<std::endl;
+  G4cout<<"Cloud momentum: "<<cloudParticle->Get4Momentum().v().mag()/GeV
+  <<" GeV, corresponding to gamma: "
+  <<cloudParticle->GetTotalEnergy()/cloudParticle->GetDefinition()->GetPDGMass()<<G4endl;
   */
 
   double E_0 = IncidentRhadron->GetKineticEnergy();
-
-
   G4double ek = OrgPart->GetKineticEnergy();
   G4double amas = OrgPart->GetDefinition()->GetPDGMass();
-  
+  G4ThreeVector dir = (OrgPart->GetMomentum()).unit();
   G4double tkin = targetNucleus.Cinema( ek );
   ek += tkin;
-  OrgPart->SetKineticEnergy( ek );
-  G4double et = ek + amas;
-  G4double p = std::sqrt( std::abs((et-amas)*(et+amas)) );
-  G4double pp = OrgPart->GetMomentum().mag();
-  if( pp > 0.0 )
-    {
-      G4ThreeVector momentum = OrgPart->GetMomentum();
-      OrgPart->SetMomentum( momentum * (p/pp) );
-    }
   
   // calculate black track energies
-  if(ek > 0.) {  tkin = targetNucleus.EvaporationEffects( ek );  ek -= tkin; } // AR_NEWCODE_IMPORT
+  tkin = targetNucleus.EvaporationEffects( ek );  
+  ek -= tkin; 
+
   if(ek+gluinoMomentum.e()-gluinoMomentum.m()<=0.1*MeV||ek<=0.) {
     //Very rare event...
     G4cout<<"Kinetic energy is sick"<<G4endl;
     G4cout<<"Full R-hadron: "<<(ek+gluinoMomentum.e()-gluinoMomentum.m())/MeV<<" MeV" <<G4endl;
     G4cout<<"Quark system: "<<ek/MeV<<" MeV"<<G4endl;
-//    aParticleChange.ProposeTrackStatus( fStopAndKill ); // AR_NEWCODE_IMPORT
     aParticleChange.ProposeTrackStatus( fStopButAlive ); // AR_NEWCODE_IMPORT
     return &aParticleChange;
   }
   OrgPart->SetKineticEnergy( ek );
-  et = ek + amas;
-  p = std::sqrt( std::abs((et-amas)*(et+amas)) );
-  pp = OrgPart->GetMomentum().mag();
-  
-  if( pp > 0.0 )
-    {
-      G4ThreeVector momentum = OrgPart->GetMomentum();
-      OrgPart->SetMomentum( momentum * (p/pp) );
-    }
+  G4double p = std::sqrt(ek*(ek + 2*amas));
+  OrgPart->SetMomentum(dir * p);
 
-
-
-  //Get the final state particles
-  
+  //Get the final state particles  
   G4ParticleDefinition* aTarget; 
   ReactionProduct rp = theHelper->GetFinalState(aTrack,aTarget);
   G4bool force2to2 = false;
@@ -209,70 +162,43 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   //  G4cout<<"Multiplicity of selected final state: "<<rp.size()<<G4endl;
 
   //Getting CMS transforms. Boosting is done at histogram filling
-  G4LorentzVector Target4Momentum;
-  Target4Momentum.set(0.,0.,0.,aTarget->GetPDGMass());
-  //  Target4Momentum.setVectM(0.,targetNucleus.GetN()*GeV);
-  G4LorentzVector psum_full,psum_cloud;
-  psum_full = FullRhadron4Momentum + Target4Momentum;
-  psum_cloud = Cloud4Momentum + Target4Momentum;
+  G4LorentzVector Target4Momentum(0.,0.,0.,aTarget->GetPDGMass());
+
+  G4LorentzVector psum_full = FullRhadron4Momentum + Target4Momentum;
+  G4LorentzVector psum_cloud = Cloud4Momentum + Target4Momentum;
   G4ThreeVector trafo_full_cms = (-1)*psum_full.boostVector();
   G4ThreeVector trafo_cloud_cms = (-1)*psum_cloud.boostVector();
-  /*
-  psum_full.boost(trafo_full_cms);
-  psum_cloud.boost(trafo_cloud_cms);
-  std::cout<<"Checking that the momenta are in deed zero:"<<psum_full.vect()<<std::endl;
-  */
 
   // OK Let's make some particles :-)
   // We're not using them for anything yet, I know, but let's make sure the machinery is there
-
   for(ReactionProduct::iterator it  = rp.begin();
-      it != rp.end();
-      it++)
-    {
-      G4ParticleDefinition* tempDef = theParticleTable->FindParticle(*it);
-      CustomParticle* tempCust = dynamic_cast<CustomParticle*>(tempDef);
-      if (tempDef==aTarget) TargetSurvives = true;
+      it != rp.end(); ++it) {
+    G4ParticleDefinition* tempDef = theParticleTable->FindParticle(*it);
+    CustomParticle* tempCust = dynamic_cast<CustomParticle*>(tempDef);
+    if (tempDef==aTarget) TargetSurvives = true;
 
-      //      if (tempDef->GetParticleType()=="rhadron")
-      if (tempCust!=0)
-	{
-	  outgoingRhadron = tempDef; 
-	  //Setting outgoing cloud definition
-	  /*
-	  if(CustomPDGParser::s_isRBaryon(*it)) 
-	    outgoingCloud=theParticleTable->FindParticle("rhadronbaryoncloud");
-	  if(CustomPDGParser::s_isRMeson(*it) || CustomPDGParser::s_isRGlueball(*it) )
-	    outgoingCloud=theParticleTable->FindParticle("rhadronmesoncloud");
-	  */
-	  outgoingCloud=tempCust->GetCloud();
-	  if(outgoingCloud == 0) 
-	    {
-	      std::cout << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!!" << std::endl;
-	    }
-	  /*
-	  std::cout<<"Outgoing Rhadron is: "<<outgoingRhadron->GetParticleName()<<std::endl;
-	  std::cout<<"Outgoing cloud is: "<<outgoingCloud->GetParticleName()<<std::endl;
-	  */
-	}
-
-      if (tempDef==G4Proton::Proton()||tempDef==G4Neutron::Neutron()) outgoingTarget = tempDef;
-      //      if (tempDef->GetParticleType()!="rhadron"&&rp.size()==2) outgoingTarget = tempDef;
-      if (tempCust==0&&rp.size()==2) outgoingTarget = tempDef;
-      if (tempDef->GetPDGEncoding()==theIncidentPDG) {
-	IncidentSurvives = true;
-      } else {
-	theParticleDefinitions.push_back(tempDef);
-	/*
-	G4DynamicParticle* tempDyn = new G4DynamicParticle();
-	tempDyn->SetDefinition(tempDef);
-	theDynamicParticles->push_back(tempDyn);
-	*/
+    //      if (tempDef->GetParticleType()=="rhadron")
+    if (tempCust!=0) {
+      outgoingRhadron = tempDef; 
+      //Setting outgoing cloud definition
+      outgoingCloud=tempCust->GetCloud();
+      if(outgoingCloud == 0) {
+	G4cout << "FullModelHadronicProcess::PostStepDoIt  Definition of outgoing particle cloud not available!" << G4endl;
       }
+      /*
+	G4cout<<"Outgoing Rhadron is: "<<outgoingRhadron->GetParticleName()<<G4endl;
+	G4cout<<"Outgoing cloud is: "<<outgoingCloud->GetParticleName()<<G4endl;
+      */
     }
 
-  //Not using this, so...
-  //  delete theDynamicParticles;
+    if (tempDef==G4Proton::Proton()||tempDef==G4Neutron::Neutron()) outgoingTarget = tempDef;
+    if (tempCust==0&&rp.size()==2) outgoingTarget = tempDef;
+    if (tempDef->GetPDGEncoding()==theIncidentPDG) {
+      IncidentSurvives = true;
+    } else {
+      theParticleDefinitions.push_back(tempDef);
+    }
+  }
 
   if (outgoingTarget==0) outgoingTarget = theParticleTable->FindParticle(rp[1]);
 
@@ -291,21 +217,18 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   if(IncidentSurvives) NumberOfSecondaries--;
   aParticleChange.SetNumberOfSecondaries(NumberOfSecondaries);
 
-
   // ADAPTED FROM G4LEPionMinusInelastic::ApplyYourself
   // It is bloody ugly, but such is the way of cut 'n' paste
 
-
   // Set up the incident
-  const G4HadProjectile* originalIncident = new G4HadProjectile(*OrgPart);//This is where rotation to z-axis is done (Aarrggh!)
-
+  // This is where rotation to z-axis is done 
+  const G4HadProjectile* originalIncident = new G4HadProjectile(*OrgPart);
 
   //Maybe I need to calculate trafo from R-hadron... Bollocks! Labframe does not move. CMS does.  
   G4HadProjectile* org2 = new G4HadProjectile(*OrgPart);
   G4LorentzRotation trans = org2->GetTrafoToLab();
   delete org2;
   
-  //    if (originalIncident->GetKineticEnergy()<= 0.1*MeV) { //Needs rescaling. The kinetic energy of the quarksystem is the relevant quantity
   
   /*
   G4cout<<"Kinetic energies: "<<G4endl;
@@ -331,7 +254,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   
   G4ReactionProduct targetParticle(aTarget);
   
-  
   G4ReactionProduct currentParticle(const_cast<G4ParticleDefinition *>(originalIncident->GetDefinition() ) );
   currentParticle.SetMomentum( originalIncident->Get4Momentum().vect() );
   currentParticle.SetKineticEnergy( originalIncident->GetKineticEnergy() );
@@ -342,7 +264,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4cout<<"targetParticle: "<<targetParticle.GetMomentum()/GeV<<" GeV"<<G4endl;
   G4cout<<"Fourmomentum from originalIncident: "<<originalIncident->Get4Momentum()<<" vs "<<OrgPart->Get4Momentum()<<G4endl;
   */
-
 
   G4ReactionProduct modifiedOriginal = currentParticle;
   
@@ -357,8 +278,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> vec;  // vec will contain the secondary particles
   G4int vecLen = 0;
   vec.Initialize( 0 );
-
-  
   
   // I hope my understanding of "secondary" is correct here
   // I think that it entails only what is not a surviving incident of target
@@ -376,8 +295,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       }
   }
 
-  //  if (incidentHasChanged) currentParticle.SetDefinitionAndUpdateE( outgoingRhadron );
-
   if (incidentHasChanged) currentParticle.SetDefinitionAndUpdateE( outgoingCloud );
   if (incidentHasChanged) modifiedOriginal.SetDefinition( outgoingCloud );//Is this correct? It solves the "free energy" checking in ReactionDynamics
   if (targetHasChanged) targetParticle.SetDefinitionAndUpdateE( outgoingTarget );
@@ -388,7 +305,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4cout<<"with momentum: "<<currentParticle.GetMomentum()/GeV<<" GeV"<<G4endl;
   G4cout<<"May be killed?: "<<currentParticle.GetMayBeKilled()<<G4endl;
   */
-  //  G4double e_temp = currentParticle.GetKineticEnergy();
 
   CalculateMomenta( vec, vecLen,
 		    originalIncident, originalTarget, modifiedOriginal,
@@ -422,12 +338,8 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       G4cout<< vec[i]->GetDefinition()->GetParticleName()<<G4endl;
     }
   */
-
-      //    }
-
-  //  G4cout<<"Done!"<<G4endl;
-  //    const G4LorentzRotation& trans(originalIncident->GetTrafoToLab());
-  //    G4cout<<"Check aParticleChange.GetNumberOfSecondaries(): "<<aParticleChange.GetNumberOfSecondaries()<<G4endl;
+  // G4cout<<"Done!"<<G4endl;
+  // const G4LorentzRotation& trans(originalIncident->GetTrafoToLab());
 
   aParticleChange.SetNumberOfSecondaries(vecLen+NumberOfSecondaries);
   G4double e_kin=0;
@@ -458,15 +370,11 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   G4LorentzVector p_g_cms = gluinoMomentum; //gluino in CMS BEFORE collision
   p_g_cms.boost(trafo_full_cms);
 
-  G4LorentzVector p4_new;
-  //    p4_new.setVectM(cloud_p4_full.v()+p_g_cms.v(),outgoingRhadron->GetPDGMass());
-  //    p4_new.boost(-trafo_full_cms);
-    //    p4_new = cloud_p4_new + gluinoMomentum;
-  p4_new.setVectM( cloud_p4_new.v() + gluinoMomentum.v(), outgoingRhadron->GetPDGMass() );
-  //  G4cout<<"P4-diff: "<<(p4_new-cloud_p4_new-gluinoMomentum)/GeV<<", magnitude: "<<(p4_new-cloud_p4_new-gluinoMomentum).m()/MeV<<" MeV" <<G4endl;
+  G4LorentzVector p4_new( cloud_p4_new.v() + gluinoMomentum.v(), outgoingRhadron->GetPDGMass() );
+  //  G4cout<<"P4-diff: "<<(p4_new-cloud_p4_new-gluinoMomentum)/GeV<<", magnitude: "
+  // <<(p4_new-cloud_p4_new-gluinoMomentum).m()/MeV<<" MeV" <<G4endl;
 
-  G4ThreeVector p_new;
-  p_new = p4_new.vect();
+  G4ThreeVector p_new = p4_new.vect();
 
   aParticleChange.ProposeLocalEnergyDeposit((p4_new-cloud_p4_new-gluinoMomentum).m());
 
@@ -491,7 +399,8 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
 	G4cout<<"ALAAAAARM!!! (incident changed from "
 	      <<IncidentRhadron->GetDefinition()->GetParticleName()
 	      <<" to "<<p0->GetDefinition()->GetParticleName()<<")"<<G4endl;
-	G4cout<<"Energy loss: "<<(e_kin_0-p0->GetKineticEnergy())/GeV<<" GeV (should be positive)"<<G4endl;
+	G4cout<<"Energy loss: "<<(e_kin_0-p0->GetKineticEnergy())/GeV
+	      <<" GeV (should be positive)"<<G4endl;
 	//Turns out problem is only in 2 -> 3 (Won't fix 2 -> 2 energy deposition)
 	if(rp.size()!=3) G4cout<<"DOUBLE ALAAAAARM!!!"<<G4endl;
       } /*else {
@@ -500,12 +409,10 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       if(std::abs(p0->GetKineticEnergy()-e_kin_0)>100*GeV) {
 	G4cout<<"Diff. too big"<<G4endl;
       }
-
       aParticleChange.ProposeTrackStatus( fStopAndKill );
     }
   else
     {
-
       G4double p = p_new.mag();
       if( p > DBL_MIN )
 	aParticleChange.ProposeMomentumDirection( p_new.x()/p, p_new.y()/p, p_new.z()/p );
@@ -514,22 +421,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       
       G4double aE = sqrt(p*p+(outgoingRhadron->GetPDGMass()*outgoingRhadron->GetPDGMass()) );
       e_kin = aE - outgoingRhadron->GetPDGMass();
-      /* AR_NEWCODE_IMPORT 
-      if(e_kin>e_kin_0) {
-	G4cout<<"ALAAAAARM!!!"<<G4endl;
-	G4cout<<"Energy loss: "<<(e_kin_0-e_kin)/GeV<<" GeV (should be positive)"<<G4endl;
-	if(rp.size()!=3) G4cout<<"DOUBLE ALAAAAARM!!!"<<G4endl;
-      }
-      if(std::abs(e_kin-e_kin_0)>100*GeV) {
-	G4cout<<"Diff. too big"<<G4endl;
-      }
-
-      if (std::fabs(aE)<.1*eV) aE=.1*eV;
-      aParticleChange.ProposeEnergy( aE- outgoingRhadron->GetPDGMass() ); //I do not know if this is correct...
-      if(std::abs(e_kin-e_kin_0)>100*GeV) {
-	G4cout<<"Diff. too big"<<G4endl;
-      }
-          */
     }
   
   //    return G4VDiscreteProcess::PostStepDoIt( aTrack, aStep);
@@ -537,7 +428,7 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
     {
       G4DynamicParticle *p1 = new G4DynamicParticle;
       p1->SetDefinition( targetParticle.GetDefinition() );
-      //      G4cout<<"Target secondary: "<<targetParticle.GetDefinition()->GetParticleName()<<G4endl;
+      //G4cout<<"Target secondary: "<<targetParticle.GetDefinition()->GetParticleName()<<G4endl;
       G4ThreeVector momentum = targetParticle.GetMomentum();
       momentum = momentum.rotate(cache,what);
       p1->SetMomentum( momentum );
@@ -554,8 +445,6 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
     G4cout<<"#sec's: "<<aParticleChange.GetNumberOfSecondaries()<<G4endl;
   */
   
-  
-  
   for(int i=0; i<vecLen; ++i )
     {
       pa = new G4DynamicParticle();
@@ -569,118 +458,54 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
       Trackn->SetTouchableHandle(thisTouchable);
       aParticleChange.AddSecondary(Trackn);
 
-      // debug 
-
-//       G4cerr << "FullModelHadronicProcess: New secondary " << i 
-//              << " ID " << Trackn->GetTrackID() 
-//              << " PDG " << Trackn->GetDefinition()->GetParticleName() 
-//              << " position " << Trackn->GetPosition() 
-//              << " volume " << Trackn->GetTouchable() 
-//              << " handle " << Trackn->GetTouchableHandle() << G4endl;
-
       delete vec[i];
     } 
 
   // Histogram filling  
   const G4DynamicParticle* theRhadron = FindRhadron(&aParticleChange);
   
+  if (theRhadron!=NULL||IncidentSurvives) {      
+    double E_new;
+    if(IncidentSurvives) {
+      E_new = e_kin;
+    } else {
+      E_new = theRhadron->GetKineticEnergy();
+      if(CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
+	 !=CustomPDGParser::s_isRMeson(theIncidentPDG)
+	 ||
+	 CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
+	 !=CustomPDGParser::s_isMesonino(theIncidentPDG)
+	 ) {
+	G4cout<<"Rm: "<<CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
+	      <<" vs: "<<CustomPDGParser::s_isRMeson(theIncidentPDG)<<G4endl;
+	G4cout<<"Sm: "<<CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
+	      <<" vs: "<<CustomPDGParser::s_isMesonino(theIncidentPDG)<<G4endl;
 
-  if (theRhadron!=NULL||IncidentSurvives)
-    {
-      
-      double E_new;
-      if(IncidentSurvives)
-	{
-	  //	  E_new = currentParticle.GetKineticEnergy();
-	  E_new = e_kin;
-	} else {
-	  E_new = theRhadron->GetKineticEnergy();
-	  if(CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
-	     !=CustomPDGParser::s_isRMeson(theIncidentPDG)
-	     ||
-	     CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
-	     !=CustomPDGParser::s_isMesonino(theIncidentPDG)
-	     ) {
-
-	    G4cout<<"Rm: "<<CustomPDGParser::s_isRMeson(theRhadron->GetDefinition()->GetPDGEncoding())
-		     <<" vs: "<<CustomPDGParser::s_isRMeson(theIncidentPDG)<<G4endl;
-	    G4cout<<"Sm: "<<CustomPDGParser::s_isMesonino(theRhadron->GetDefinition()->GetPDGEncoding())
-		     <<" vs: "<<CustomPDGParser::s_isMesonino(theIncidentPDG)<<G4endl;
-
-	  }
-	}
-      
-      //Calculating relevant scattering angles.
-      G4LorentzVector p4_old_full = FullRhadron4Momentum; //R-hadron in CMS BEFORE collision
-      p4_old_full.boost(trafo_full_cms);
-      G4LorentzVector p4_old_cloud = FullRhadron4Momentum; //R-hadron in cloud CMS BEFORE collision
-      p4_old_cloud.boost(trafo_cloud_cms);
-      G4LorentzVector p4_full = p4_new; //R-hadron in CMS AFTER collision
-      //      G4cout<<p4_full.v()/GeV<<G4endl;
-      p4_full=p4_full.boost(trafo_full_cms);
-      //      G4cout<<p4_full.m()<<" / "<<(cloud_p4_new+gluinoMomentum).boost(trafo_full_cms).m()<<G4endl;
-      G4LorentzVector p4_cloud = p4_new; //R-hadron in cloud CMS AFTER collision
-      p4_cloud.boost(trafo_cloud_cms);
-
-      
-      /*
-      G4double dtheta_fullcms = p4_full.vect().angle(p4_old_full.vect());
-      G4double dtheta_cloudcms = p4_cloud.vect().angle(p4_old_cloud.vect());
-      G4double dtheta_lab = p_new.angle(p_0);//acos(p_0*p_new/(p_0.mag()*p_new.mag())); 
-
-      G4double cloud_dtheta_fullcms = cloud_p4_full.vect().angle(cloud_p4_old_full.vect());
-      G4double cloud_dtheta_cloudcms = cloud_p4_cloud.vect().angle(p4_old_cloud.vect());
-      G4double cloud_dtheta_lab = cloud_p4_new.vect().angle(p_0);
-      //Writing out momenta for manual check of boosts:
-      G4cout<<"******************************************"<<G4endl;
-
-      G4cout<<"R-hadron, before: "<<G4endl;
-      G4cout<<"Lab: "<<FullRhadron4Momentum.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"CMS: "<<p4_old_full.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"after: "<<G4endl;
-      G4cout<<"Lab: "<<p4_new.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"CMS: "<<p4_full.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"cos(theta*): "<<cos(dtheta_fullcms)<<G4endl;
-      G4cout<<"Gluino: "<<G4endl;
-      G4cout<<"Lab: "<<gluinoMomentum.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"CMS: "<<p_g_cms.v().mag()/GeV<<" GeV"<<G4endl;
-
-      G4cout<<"Cloud, before: "<<G4endl;
-      G4cout<<"Lab: "<<Cloud4Momentum.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"CMS: "<<cloud_p4_old_full.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"after: "<<G4endl;
-      G4cout<<"CMS: "<<cloud_p4_full.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"cloud cos(theta*): "<<cos(cloud_dtheta_fullcms)<<G4endl;
-      G4cout<<"Longitudinal: "<<cos(cloud_dtheta_fullcms)*cloud_p4_full.v().mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"~Combined longitudinal: "<<(cos(cloud_dtheta_fullcms)*cloud_p4_full.v().mag()+p4_old_full.v().mag())/GeV<<" GeV"<<G4endl;
-      if ((cos(cloud_dtheta_fullcms)*cloud_p4_full.v().mag()+p4_old_full.v().mag())<0.) G4cout<<"ALAAARM"<<G4endl;
-      G4cout<<"Psum cos(theta*): "<<cos((p_g_cms.v()+cloud_p4_full.v()).angle(p4_old_full.v()))<<G4endl;
-      G4cout<<"True R-hadron (CMS): "<<(p_g_cms.v()+cloud_p4_full.v()).mag()/GeV<<" GeV"<<G4endl;
-      G4cout<<"******************************************"<<G4endl;
-      G4cout<<"Fucking manual fucking calculation:"<<G4endl;
-      G4cout<<"Momenta:"<<G4endl;
-      G4cout<<"Cloud, lab: "<<cloud_p4_new.v()/GeV<<" + gluino: "<<gluinoMomentum.v()/GeV
-	    <<" = "<<(cloud_p4_new.v()+gluinoMomentum.v())/GeV
-	    <<". Boost to CMS: "<<(cloud_p4_new+gluinoMomentum).boost(trafo_full_cms).v()/GeV<<G4endl;
-      G4cout<<"Cloud, CMS: "<<cloud_p4_full.v()/GeV<<" + gluino: "<<p_g_cms.v()/GeV
-	    <<" = "<<(cloud_p4_full.v()+p_g_cms.v())/GeV
-	    <<". Boost to Lab: "<<(cloud_p4_full+p_g_cms).boost(-trafo_full_cms).v()/GeV<<G4endl;
-      G4cout<<"Ref: "<<p4_new.v()/GeV<<" / "<<p4_full.v()/GeV<<G4endl;
-      G4cout<<"******************************************"<<G4endl;
-      */
-
-
-      //      std::cout<<"Lab, fullcms, cloudcms: "<<dtheta_lab<<", "<<dtheta_fullcms<<", "<<dtheta_cloudcms<<std::endl;
-      G4double AbsDeltaE = E_0-E_new;
-      //      G4cout <<"Energy loss: "<<AbsDeltaE/GeV<<G4endl;
-      if (AbsDeltaE > 10*GeV) {
-	G4cout<<"Energy loss larger than 10 GeV..."<<G4endl;
-	G4cout<<"E_0: "<<E_0/GeV<<" GeV"<<G4endl;
-	G4cout<<"E_new: "<<E_new/GeV<<" GeV"<<G4endl;
-	G4cout<<"Gamma: "<<IncidentRhadron->GetTotalEnergy()/IncidentRhadron->GetDefinition()->GetPDGMass()<<G4endl;
-	G4cout<<"x: "<<aPosition.x()/cm<<" cm"<<G4endl;
       }
-     } 
+    }
+      
+    //Calculating relevant scattering angles.
+    G4LorentzVector p4_old_full = FullRhadron4Momentum; //R-hadron in CMS BEFORE collision
+    p4_old_full.boost(trafo_full_cms);
+    G4LorentzVector p4_old_cloud = FullRhadron4Momentum; //R-hadron in cloud CMS BEFORE collision
+    p4_old_cloud.boost(trafo_cloud_cms);
+    G4LorentzVector p4_full = p4_new; //R-hadron in CMS AFTER collision
+    //      G4cout<<p4_full.v()/GeV<<G4endl;
+    p4_full=p4_full.boost(trafo_full_cms);
+    // G4cout<<p4_full.m()<<" / "<<(cloud_p4_new+gluinoMomentum).boost(trafo_full_cms).m()<<G4endl;
+    G4LorentzVector p4_cloud = p4_new; //R-hadron in cloud CMS AFTER collision
+    p4_cloud.boost(trafo_cloud_cms);
+
+    G4double AbsDeltaE = E_0-E_new;
+    //      G4cout <<"Energy loss: "<<AbsDeltaE/GeV<<G4endl;
+    if (AbsDeltaE > 10*GeV) {
+      G4cout<<"Energy loss larger than 10 GeV..."<<G4endl;
+      G4cout<<"E_0: "<<E_0/GeV<<" GeV"<<G4endl;
+      G4cout<<"E_new: "<<E_new/GeV<<" GeV"<<G4endl;
+      G4cout<<"Gamma: "<<IncidentRhadron->GetTotalEnergy()/IncidentRhadron->GetDefinition()->GetPDGMass()<<G4endl;
+      G4cout<<"x: "<<aPosition.x()/cm<<" cm"<<G4endl;
+    }
+  } 
   delete originalIncident;
   delete originalTarget;
   //  aParticleChange.DumpInfo();
@@ -689,37 +514,27 @@ G4VParticleChange* FullModelHadronicProcess::PostStepDoIt(const G4Track& aTrack,
   //clear interaction length      
   ClearNumberOfInteractionLengthLeft();
 
-  
-  return &aParticleChange;
-  
+  return &aParticleChange;  
 }
 
 
 void FullModelHadronicProcess::CalculateMomenta(
-					       G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
-					       G4int &vecLen,
-					       const G4HadProjectile *originalIncident,   // the original incident particle
-					       const G4DynamicParticle *originalTarget,
-					       G4ReactionProduct &modifiedOriginal,   // Fermi motion and evap. effects included
-					       G4Nucleus &targetNucleus,
-					       G4ReactionProduct &currentParticle,
-					       G4ReactionProduct &targetParticle,
-					       G4bool &incidentHasChanged,
-					       G4bool &targetHasChanged,
-					       G4bool quasiElastic )
+     G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec,
+     G4int &vecLen,
+     const G4HadProjectile *originalIncident,   // the original incident particle
+     const G4DynamicParticle *originalTarget,
+     G4ReactionProduct &modifiedOriginal,   // Fermi motion and evap. effects included
+     G4Nucleus &targetNucleus,
+     G4ReactionProduct &currentParticle,
+     G4ReactionProduct &targetParticle,
+     G4bool &incidentHasChanged,
+     G4bool &targetHasChanged,
+     G4bool quasiElastic )
 {
   FullModelReactionDynamics theReactionDynamics;
 
   cache = 0;
   what = originalIncident->Get4Momentum().vect();
-
-  //Commented out like in casqmesmin.F where CALL STPAIR is commented out
-  /*
-  theReactionDynamics.ProduceStrangeParticlePairs( vec, vecLen,
-						   modifiedOriginal, originalTarget,
-						   currentParticle, targetParticle,
-						   incidentHasChanged, targetHasChanged );
-  */
 
   if( quasiElastic )
     {
@@ -737,8 +552,6 @@ void FullModelHadronicProcess::CalculateMomenta(
   G4bool leadFlag = MarkLeadingStrangeParticle( currentParticle,
 						targetParticle,
 						leadingStrangeParticle );
-
-
 
   //
   // Note: the number of secondaries can be reduced in GenerateXandPt and TwoCluster
@@ -828,32 +641,22 @@ void FullModelHadronicProcess::CalculateMomenta(
   //   proton/neutron black track particles [was enp(1) in fortran code]
   // DTABlackTrackEnergy is the kinetic energy available for
   //   deuteron/triton/alpha particles      [was enp(3) in fortran code]
-  //const G4double pnCutOff = 0.1;
-  //const G4double dtaCutOff = 0.1;
-  //if( (targetNucleus.GetN() >= 1.5)
-  //    && !(incidentHasChanged || targetHasChanged)
-  //    && (targetNucleus.GetPNBlackTrackEnergy()/MeV <= pnCutOff)
-  //    && (targetNucleus.GetDTABlackTrackEnergy()/MeV <= dtaCutOff) )
-  //{
   // the atomic weight of the target nucleus is >= 1.5            AND
   //   neither the incident nor the target particles have changed  AND
   //     there is no kinetic energy available for either proton/neutron
   //     or for deuteron/triton/alpha black track particles
   // For diffraction scattering on heavy nuclei use elastic routines instead
-  //G4cerr << "*** Error in G4InelasticInteraction::CalculateMomenta" << G4endl;
-  //G4cerr << "*** the elastic scattering would be better here ***" <<G4endl;
-  //}
+
   theReactionDynamics.TwoBody( vec, vecLen,
 			       modifiedOriginal, originalTarget,
 			       currentParticle, targetParticle,
 			       targetNucleus, targetHasChanged );
 }
 
-
 G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(
-							    const G4ReactionProduct &currentParticle,
-							    const G4ReactionProduct &targetParticle,
-							    G4ReactionProduct &leadParticle )
+       const G4ReactionProduct &currentParticle,
+       const G4ReactionProduct &targetParticle,
+       G4ReactionProduct &leadParticle )
 {
   // the following was in GenerateXandPt and TwoCluster
   // add a parameter to the GenerateXandPt function telling it about the strange particle
@@ -878,7 +681,8 @@ G4bool FullModelHadronicProcess::MarkLeadingStrangeParticle(
   return lead;
 }
 
-void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec, G4int &vecLen)
+void FullModelHadronicProcess::Rotate(G4FastVector<G4ReactionProduct,MYGHADLISTSIZE> &vec, 
+				      G4int &vecLen)
 {
   G4double rotation = 2.*pi*G4UniformRand();
   cache = rotation;

--- a/SimG4Core/CustomPhysics/src/ToyModelHadronicProcess.cc
+++ b/SimG4Core/CustomPhysics/src/ToyModelHadronicProcess.cc
@@ -2,7 +2,7 @@
 #include "G4ProcessManager.hh"
 #include "G4ParticleTable.hh"
 #include "G4Track.hh"
-#include "Randomize.hh"
+#include "G4FermiPhaseSpaceDecay.hh"
 //Our includes
 #include "SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh"
 #include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
@@ -10,51 +10,38 @@
 #include "SimG4Core/CustomPhysics/interface/HadronicProcessHelper.hh"
 #include "SimG4Core/CustomPhysics/interface/Decay3Body.h"
 
+#include <vector>
+
 using namespace CLHEP;
 
-ToyModelHadronicProcess::ToyModelHadronicProcess(HadronicProcessHelper * aHelper, const G4String& processName) :
+ToyModelHadronicProcess::ToyModelHadronicProcess(HadronicProcessHelper * aHelper, 
+						 const G4String& processName) :
   G4VDiscreteProcess(processName), m_verboseLevel(0),  m_helper(aHelper),  m_detachCloud(true)
 {
-  // Instantiating helper class
-  //m_helper = HadronicProcessHelper::instance();
-  //m_verboseLevel=0;
-  //m_detachCloud=true;
-
+  m_decay = new G4FermiPhaseSpaceDecay();
 }
-
-  
+ 
 G4bool ToyModelHadronicProcess::IsApplicable(const G4ParticleDefinition& aP)
 {
   return m_helper->applicabilityTester(aP);
 }
 
 G4double ToyModelHadronicProcess::GetMicroscopicCrossSection(const G4DynamicParticle *particle,
-							    const G4Element *element,
-							    G4double /*temperature*/)
+							     const G4Element *element,
+							     G4double /*temperature*/)
 {
   //Get the cross section for this particle/element combination from the ProcessHelper
   G4double inclusiveCrossSection = m_helper->inclusiveCrossSection(particle,element);
-
-  // Need to provide Set-methods for these in time
-  G4double highestEnergyLimit = 10 * TeV  ;
-  G4double lowestEnergyLimit = 1 * eV;
-  G4double particleEnergy = particle->GetKineticEnergy();
    
-  if (particleEnergy > highestEnergyLimit || particleEnergy < lowestEnergyLimit){
-    if(m_verboseLevel >= 1) std::cout << "ToyModelHadronicProcess: Energy out of bounds [" << 
-			      lowestEnergyLimit / MeV << "MeV , " << 
-			      highestEnergyLimit / MeV << "MeV ] while it is " << particleEnergy/MeV  << 
-			      std::endl;
-    return 0;
-  } else {
-    if(m_verboseLevel >= 3) std::cout << "ToyModelHadronicProcess: Return cross section " << inclusiveCrossSection << std::endl;
-    return inclusiveCrossSection;
+  if(m_verboseLevel >= 3) {
+    G4cout << "ToyModelHadronicProcess: Return cross section " << inclusiveCrossSection 
+	   << G4endl;
   }
-
+  return inclusiveCrossSection;
 }
 
-
-G4double ToyModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4double, G4ForceCondition*)
+G4double ToyModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4double, 
+						  G4ForceCondition*)
 {
   G4Material *aMaterial = aTrack.GetMaterial();
   const G4DynamicParticle *aParticle = aTrack.GetDynamicParticle();
@@ -72,93 +59,85 @@ G4double ToyModelHadronicProcess::GetMeanFreePath(const G4Track& aTrack, G4doubl
 	GetMicroscopicCrossSection( aParticle, (*aMaterial->GetElementVector())[i], aTemp);
       sigma += theAtomicNumDensityVector[i] * xSection;
     }
-
-  return 1.0/sigma;
-  
+  G4double x = DBL_MAX;
+  if(sigma > 0.0) { x = 1./sigma; }
+  return x;  
 }
 
-
 G4VParticleChange* ToyModelHadronicProcess::PostStepDoIt(const G4Track& track,
-							const G4Step& /*  step*/)
+							 const G4Step& /*  step*/)
 {
-
   const G4TouchableHandle thisTouchable(track.GetTouchableHandle());
   
   // A little setting up
   G4ParticleTable* theParticleTable = G4ParticleTable::GetParticleTable();
   m_particleChange.Initialize(track);
-  //  G4DynamicParticle* incidentRHadron = const_cast<G4DynamicParticle*>(track.GetDynamicParticle()); //This will contain RHadron Def + RHad momentum
-  const G4DynamicParticle* incidentRHadron = track.GetDynamicParticle(); //This will contain RHadron Def + RHad momentum
-//  double E_0 = incidentRHadron->GetKineticEnergy();
-//  const G4int theIncidentPDG = incidentRHadron->GetDefinition()->GetPDGEncoding();
+
+  //This will contain RHadron Def + RHad momentum
+  const G4DynamicParticle* incidentRHadron = track.GetDynamicParticle(); 
   const G4ThreeVector aPosition = track.GetPosition();
 
-//  double gamma = incidentRHadron->GetTotalEnergy()/incidentRHadron->GetDefinition()->GetPDGMass();
-
   CustomParticle* CustomIncident = dynamic_cast<CustomParticle*>(incidentRHadron->GetDefinition());
-  G4DynamicParticle* cloudParticle =  new G4DynamicParticle(); //This will contain Cloud Def + scaled momentum
-           
-  //  G4int rHadronPdg = incidentRHadron->GetDefinition()->GetPDGEncoding();
 
+  //This will contain Cloud Def + scaled momentum
+  G4DynamicParticle* cloudParticle =  new G4DynamicParticle(); 
+           
   //set cloud definition
-  if(CustomIncident==0)
-    {
-      std::cout << "ToyModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!!" << std::endl;
-    } else {
-      cloudParticle->SetDefinition(CustomIncident->GetCloud());
-    }
+  if(CustomIncident==0) {
+    G4cout << "ToyModelHadronicProcess::PostStepDoIt  Definition of particle cloud not available!" 
+	   << G4endl;
+  } else {
+    cloudParticle->SetDefinition(CustomIncident->GetCloud());
+  }
      
   //compute scaled momentum  
-  double scale=cloudParticle->GetDefinition()->GetPDGMass()/incidentRHadron->GetDefinition()->GetPDGMass();
-  G4LorentzVector cloudMomentum;
-  cloudMomentum.setVectM(incidentRHadron->GetMomentum()*scale,cloudParticle->GetDefinition()->GetPDGMass());
-  G4LorentzVector gluinoMomentum;
-  gluinoMomentum.setVectM(incidentRHadron->GetMomentum()*(1.-scale),CustomIncident->GetSpectator()->GetPDGMass());
+  double scale = cloudParticle->GetDefinition()->GetPDGMass()
+    /incidentRHadron->GetDefinition()->GetPDGMass();
+  G4LorentzVector cloudMomentum(incidentRHadron->GetMomentum()*scale,
+				cloudParticle->GetDefinition()->GetPDGMass());
+  G4LorentzVector gluinoMomentum(incidentRHadron->GetMomentum()*(1.-scale),
+				 CustomIncident->GetSpectator()->GetPDGMass());
   
   cloudParticle->Set4Momentum(cloudMomentum);         	
   
   const G4DynamicParticle *incidentParticle;
-  if(! m_detachCloud) incidentParticle = incidentRHadron; 
-  else incidentParticle= cloudParticle;
+  if(! m_detachCloud) { incidentParticle = incidentRHadron; } 
+  else                { incidentParticle = cloudParticle; }
   
   if(m_verboseLevel >= 3)
     { 
-      std::cout << "ToyModelHadronicProcess::PostStepDoIt    After scaling " << std::endl;
-      std::cout << "      RHadron "<<incidentRHadron->GetDefinition()->GetParticleName()<<"         pdgmass= " << incidentRHadron->GetDefinition()->GetPDGMass() / GeV
-		<< " P= " << incidentRHadron->Get4Momentum() / GeV<<" mass= "<< incidentRHadron->Get4Momentum().m() / GeV <<std::endl;
-      std::cout << "      Cloud   "<<cloudParticle->GetDefinition()->GetParticleName()<<"         pdgmass= " << cloudParticle->GetDefinition()->GetPDGMass() / GeV
-		<< " P= " << cloudParticle->Get4Momentum() / GeV<<" mass= "<< cloudParticle->Get4Momentum().m() / GeV <<std::endl;
-      std::cout << "      Incident          pdgmass= " << incidentParticle->GetDefinition()->GetPDGMass() / GeV
-		<< " P= " << incidentParticle->Get4Momentum() / GeV<<" mass= "<< incidentParticle->Get4Momentum().m() / GeV <<std::endl;
+      G4cout << "ToyModelHadronicProcess::PostStepDoIt    After scaling " << G4endl;
+      G4cout << "      RHadron "<<incidentRHadron->GetDefinition()->GetParticleName()
+	     <<"         pdgmass= " << incidentRHadron->GetDefinition()->GetPDGMass() / GeV
+	     << " P= " << incidentRHadron->Get4Momentum() / GeV<<" mass= "
+	     << incidentRHadron->Get4Momentum().m() / GeV <<G4endl;
+      G4cout << "      Cloud   "<<cloudParticle->GetDefinition()->GetParticleName()
+	     <<"         pdgmass= " << cloudParticle->GetDefinition()->GetPDGMass() / GeV
+	     << " P= " << cloudParticle->Get4Momentum() / GeV<<" mass= "
+	     << cloudParticle->Get4Momentum().m() / GeV <<G4endl;
+      G4cout << "      Incident          pdgmass= " 
+	     << incidentParticle->GetDefinition()->GetPDGMass() / GeV
+	     << " P= " << incidentParticle->Get4Momentum() / GeV<<" mass= "
+	     << incidentParticle->Get4Momentum().m() / GeV <<G4endl;
     }
  
   const G4ThreeVector position = track.GetPosition();
-  const G4int incidentParticlePDG = incidentRHadron->GetDefinition()->GetPDGEncoding();
   std::vector<G4ParticleDefinition*> newParticles;        // this will contain clouds
   std::vector<G4ParticleDefinition*> newParticlesRHadron; // this will contain r-hadron
 
-  G4bool incidentSurvives = false;
-  
   //Get the final state particles and target
   G4ParticleDefinition* targetParticle; 
-  HadronicProcessHelper::ReactionProduct reactionProduct = m_helper->finalState(incidentRHadron,track.GetMaterial(),targetParticle);
+  HadronicProcessHelper::ReactionProduct reactionProduct = 
+    m_helper->finalState(incidentRHadron,track.GetMaterial(),targetParticle);
 
-  // Fill a list of the new particles to create 
-  //(i.e. reaction products without the incident if it survives)
-   
+  // Fill a list of the new particles to create including the incident if it survives
   for(HadronicProcessHelper::ReactionProduct::iterator it  = reactionProduct.begin();
       it != reactionProduct.end() ;  
-      it++)
+      ++it)
     {
       G4ParticleDefinition * productDefinition =theParticleTable->FindParticle(*it);
-
-      if (productDefinition->GetPDGEncoding()==incidentParticlePDG)
-        incidentSurvives = true;
-
       newParticlesRHadron.push_back(productDefinition);
-      
-      CustomParticle* cProd = 0;
-      cProd = dynamic_cast<CustomParticle*>(productDefinition);
+      CustomParticle* cProd = dynamic_cast<CustomParticle*>(productDefinition);
 
       if( cProd!=0 && m_detachCloud)
 	productDefinition=cProd->GetCloud();
@@ -168,199 +147,92 @@ G4VParticleChange* ToyModelHadronicProcess::PostStepDoIt(const G4Track& track,
   
   int numberOfSecondaries = reactionProduct.size();
   
-  if(m_verboseLevel >= 2) std::cout << "ToyModelHadronicProcess::PostStepDoIt  N secondaries: " 
-				    << numberOfSecondaries << std::endl;
-  
+  if(m_verboseLevel >= 2) {
+    G4cout << "ToyModelHadronicProcess::PostStepDoIt  N secondaries: " 
+	   << numberOfSecondaries << G4endl;
+  }
 
-  //************ My toy model ********************
-  // 2 -> 2 goes to CM, chooses a random direction and fires the particles off back to back
-  // 2 -> 3 Effectively two two-body decays
+  // Getting 4-momenta
+  G4LorentzVector sum4Momentum = incidentParticle->Get4Momentum();
+  G4LorentzVector target4Momentum(0,0,0,targetParticle->GetPDGMass());
+  sum4Momentum += target4Momentum;
+  G4ThreeVector   cmBoost = sum4Momentum.boostVector();
+  G4double M = sum4Momentum.m();
 
-  // Getting fourmomenta
-  const G4LorentzVector incident4Momentum = incidentParticle->Get4Momentum();
-  const G4LorentzVector target4Momentum(0,0,0,targetParticle->GetPDGMass());
-  const G4LorentzVector sum4Momentum = incident4Momentum + target4Momentum;
-  const G4ThreeVector   cmBoost = sum4Momentum.boostVector();//The boost from CM to lab
-  const G4LorentzVector cm4Momentum = sum4Momentum.rest4Vector();
-
-  if(m_verboseLevel >= 2) std::cout << "ToyModelHadronicProcess::PostStepDoIt  Kinematics in GeV: " << std::endl 
-				    << "     Boost   = " << cmBoost / GeV<< std::endl
-				    << "     4P CM   = " << cm4Momentum / GeV << std::endl
-				    << "     4P Inc  = " << incident4Momentum / GeV << std::endl
-				    << "     4P Targ = " << target4Momentum  / GeV<< std::endl;
-
-  //Choosing random direction
-  const G4double phi_p = 2*pi*G4UniformRand()-pi ;
-  const G4double theta_p = pi*G4UniformRand() ;
-  const G4ThreeVector randomDirection(sin(theta_p)*cos(phi_p),
-				      sin(theta_p)*sin(phi_p),
-				      cos(theta_p));
-  
-
+  if(m_verboseLevel >= 2) {
+    G4cout << "ToyModelHadronicProcess::PostStepDoIt  Kinematics in GeV: " << G4endl 
+	   << "     Boost   = " << cmBoost / GeV<< G4endl
+	   << "     4P Lab  = " << sum4Momentum / GeV << G4endl
+	   << "     Ecm  = " << M / GeV << G4endl;
+  }
   std::vector<G4double> m;
-  std::vector<G4LorentzVector> fourMomenta;
-  
+
   //Fill the masses
-  for(int ip=0;ip<numberOfSecondaries;ip++)     
+  for(int ip=0; ip<numberOfSecondaries; ++ip)     
     {
       m.push_back(newParticles[ip]->GetPDGMass());
     }
 
+  std::vector<G4LorentzVector*>* fourMomenta = m_decay->Decay(M, m);
 
-  if (numberOfSecondaries==2){
-    // 2 -> 2
-    
-    //Get the CM energy
-    G4double energy = cm4Momentum.e();
-    G4ThreeVector p[2];
-
-    //Size of momenta in CM
-    
-
-    // Energy conservation: 
-    G4double cmMomentum = 1/(2*energy)*sqrt(energy*energy*energy*energy + m[0]*m[0]*m[0]*m[0] + m[1]*m[1]*m[1]*m[1]
-					    - 2*(m[0]*m[0] + m[1]*m[1])*energy*energy -2*m[0]*m[0]*m[1]*m[1]);
-    p[0] = cmMomentum * randomDirection;
-    p[1] = -p[0];
-
-    if(m_verboseLevel >= 2) std::cout << "ToyModelHadronicProcess::PostStepDoIt  2->2: " << std::endl 
-				      << "     Pcm(GeV)   = " << cmMomentum / GeV << std::endl;
-
-    for(int ip=0;ip<2;ip++)     
-      {
-	//Compute energy
-	G4double e = sqrt(p[ip].mag2() + m[ip]*m[ip]);
-	//Set 4-vectory
-	fourMomenta.push_back(G4LorentzVector(p[ip],e));
-	//Boost back to lab
-	fourMomenta[ip].boost(cmBoost);      
-
-	if(m_verboseLevel >= 2) std::cout  << "     particle " << ip <<" Plab(GeV)  = " << fourMomenta[ip] /GeV << std::endl;
-      }
-
-  } else if (numberOfSecondaries==3) {
-
-    // 2 -> 3
-    //Size of momenta in CM
-    for (std::vector<G4double>::iterator it=m.begin();it!=m.end();it++) 
-      fourMomenta.push_back(G4LorentzVector(0,0,0,*it));      
-
-    Decay3Body KinCalc;
-    KinCalc.doDecay(cm4Momentum, fourMomenta[0], fourMomenta[1], fourMomenta[2] );
-    
-    //Rotating the plane to a random orientation, and boosting home
-    CLHEP::HepRotation rotation(randomDirection,G4UniformRand()*2*pi);
-    for (std::vector<G4LorentzVector>::iterator it = fourMomenta.begin();
-	 it!=fourMomenta.end();
-	 it++)
-      {
-	*it *= rotation;
-	(*it).boost(cmBoost);
-      }
-    if(m_verboseLevel >= 3) G4cout<<"Momentum-check: "<<incident4Momentum /GeV<<" GeV vs "
-				  << (fourMomenta[0]+fourMomenta[1]+fourMomenta[2])/GeV<<G4endl;
-
-  }
-    
-    
-  //Now we have the fourMomenta of all the products (coming from 2->2 or 2->3)
-  if(incidentSurvives){
-    //if incident particle survives the number of secondaries is n-1
-    m_particleChange.SetNumberOfSecondaries(numberOfSecondaries-1);
-    if(m_verboseLevel >= 3) std::cout  << "Incident survives: set num secondaries to " << numberOfSecondaries-1 << std::endl;
-
-  } else {
-    //incident particle has to be killed and number of secondaries is n
+  if(fourMomenta) {
+ 
+    //incident particle has to be killed 
     m_particleChange.SetNumberOfSecondaries(numberOfSecondaries);
     m_particleChange.ProposeTrackStatus(fStopAndKill);
-    if(m_verboseLevel >= 3) std::cout  << "Incident does not survive: stopAndKill + set num secondaries to " << numberOfSecondaries << std::endl;
-  }  
-  //  double e_kin;
+    if(m_verboseLevel >= 3) {
+      G4cout  << "Incident does not survive: stopAndKill + set num secondaries to " 
+	      << numberOfSecondaries << G4endl;
+    }  
 
-  for (int ip=0; ip <numberOfSecondaries;ip++)
-    {
-      if (newParticlesRHadron[ip]==incidentRHadron->GetDefinition()) // does incident paricle survive?
-	{
-	  //	incidentSurvives = true; //yes! Modify its dynamic properties
-	  if(m_detachCloud) 
-	    {
-	      if(m_verboseLevel >= 3)
-		std::cout  << "ToyModelHadronicProcess::PostStepDoIt   Add gluino momentum " <<
-		  fourMomenta[ip]/GeV <<"(m="<< fourMomenta[ip].m()/ GeV<<") + " <<gluinoMomentum/GeV<<std::endl; ;
-	      G4LorentzVector p4_new = gluinoMomentum+fourMomenta[ip];
-	      G4ThreeVector momentum = p4_new.vect();
-	      double rhMass=newParticlesRHadron[ip]->GetPDGMass() ;
-	      //	      e_kin = sqrt(momentum.mag()*momentum.mag()+rhMass*rhMass)-rhMass;
-	      //	      fourMomenta[ip]=G4LorentzVector(momentum,sqrt(momentum.mag2()+rhMass*rhMass));
-	      fourMomenta[ip].setVectM(momentum,rhMass);
+    for (int ip=0; ip <numberOfSecondaries; ++ip) {
+      // transform to Lab
+      (*fourMomenta)[ip]->boost(cmBoost);
 
-//	      double virt=(p4_new-fourMomenta[ip]).m()/MeV;
-
-	      if(m_verboseLevel >= 3)
-		std::cout <<  " = " << fourMomenta[ip]/GeV <<"(m="<< fourMomenta[ip].m() / GeV<<") vs. "<<rhMass/GeV 
-			  << std::endl;     	
-	    }
-	  m_particleChange.ProposeMomentumDirection(fourMomenta[ip].vect()/fourMomenta[ip].vect().mag()); 
-	  m_particleChange.ProposeEnergy(fourMomenta[ip].e()-fourMomenta[ip].mag());      
-	  if(m_verboseLevel >= 3) std::cout  << "ToyModelHadronicProcess::PostStepDoIt   Propose momentum " << fourMomenta[ip]/GeV << std::endl;
-	} else { //this particle is not the incident one
-	  //Create new dynamic particle
-	  G4DynamicParticle* productDynParticle = new G4DynamicParticle();
-	  //Set the pDef to the dynParte
-	  productDynParticle->SetDefinition(newParticlesRHadron[ip]);
-	  //Set the 4-vector to dynPart
-	  if(newParticlesRHadron[ip]!=newParticles[ip] && m_detachCloud )  // check if it is a cloud, second check is useless
-	    {
-	      G4LorentzVector p4_new;
-	      p4_new.setVectM(gluinoMomentum.vect()+fourMomenta[ip].vect(),productDynParticle->GetDefinition()->GetPDGMass());
-	      //	      productDynParticle->SetMomentum(fourMomenta[ip].vect()+gluinoMomentum.vect());  
-	      productDynParticle->Set4Momentum(p4_new);  
-
-//	      double virt=(gluinoMomentum+fourMomenta[ip]-p4_new).m()/MeV;
-
-	      if(m_verboseLevel >= 3)
-		std::cout  << "ToyModelHadronicProcess::PostStepDoIt   Add gluino momentum " <<
-		  fourMomenta[ip]/GeV 
-			   <<"(m="<< fourMomenta[ip].m()/ GeV<<") + " 
-			   <<gluinoMomentum/GeV 
-			   <<" = " << productDynParticle->Get4Momentum()/GeV
-			   <<" => "<<productDynParticle->Get4Momentum().m()/GeV
-			   <<" vs. "<<productDynParticle->GetDefinition()->GetPDGMass()/GeV
-			   << std::endl;     	
-	    }
-	  else
-	    {
-	      productDynParticle->Set4Momentum(fourMomenta[ip]);       	
-	    }
-	  //Create a G4Track
-	  G4Track* productTrack = new G4Track(productDynParticle,
-					      track.GetGlobalTime(),
-					      position);
-      productTrack->SetTouchableHandle(thisTouchable);
-	  //Append to the result
-	  if(m_verboseLevel >= 3) std::cout  << "ToyModelHadronicProcess::PostStepDoIt   Add secondary with 4-Momentum " << productDynParticle->Get4Momentum()/GeV << std::endl;
-	  m_particleChange.AddSecondary(productTrack);
+      // added cloud to R-hadron
+      if (newParticlesRHadron[ip]==incidentRHadron->GetDefinition()) {
+	if(m_detachCloud) {
+	  if(m_verboseLevel >= 3) {
+	    G4cout  << "ToyModelHadronicProcess::PostStepDoIt   Add gluino momentum " 
+		    << *((*fourMomenta)[ip])/GeV <<"(m="<< (*fourMomenta)[ip]->m()/ GeV
+		    <<") + " <<gluinoMomentum/GeV<<G4endl; 
+	  }
+	  G4LorentzVector p4_new = gluinoMomentum + *((*fourMomenta)[ip]);
+	  G4ThreeVector momentum = p4_new.vect();
+	  double rhMass = newParticlesRHadron[ip]->GetPDGMass();
+	  (*fourMomenta)[ip]->setVectM(momentum,rhMass);
+	  if(m_verboseLevel >= 3) {
+	    G4cout <<  " = " << *((*fourMomenta)[ip])/GeV <<"(m="<< (*fourMomenta)[ip]->m() / GeV
+		   <<") vs. "<<rhMass/GeV 
+		   << G4endl;     	
+	  }
 	}
-    } 
+      }
+      //Create new dynamic particle
+      G4DynamicParticle* productDynParticle = new G4DynamicParticle();
+      //Set the pDef to the dynParte
+      productDynParticle->SetDefinition(newParticlesRHadron[ip]);
+      //Set the 4-vector to dynPart
+      productDynParticle->Set4Momentum(*((*fourMomenta)[ip]));  
 
+      if(m_verboseLevel >= 3) {
+	G4cout  << "ToyModelHadronicProcess::PostStepDoIt: " << *((*fourMomenta)[ip])/GeV 
+		<< "(m="<< (*fourMomenta)[ip]->m()/ GeV<<") " 
+		<< newParticlesRHadron[ip]->GetParticleName()
+		<< G4endl;     	
+      }
+      //Create a G4Track
+      G4Track* productTrack = new G4Track(productDynParticle,
+					  track.GetGlobalTime(),
+					  position);
+      productTrack->SetTouchableHandle(thisTouchable);
+      m_particleChange.AddSecondary(productTrack);
+      delete (*fourMomenta)[ip];
+    }
+    delete fourMomenta;
+  } 
   //clear interaction length      
   ClearNumberOfInteractionLengthLeft();
-  //return the result
   return &m_particleChange;
-  
 }
 
-const G4DynamicParticle* ToyModelHadronicProcess::FindRhadron(G4ParticleChange* aParticleChange)
-{
-  G4int nsec = aParticleChange->GetNumberOfSecondaries();
-  if (nsec==0) return 0;
-  int i = 0;
-  G4bool found = false;
-  while (i!=nsec && !found){
-    if (dynamic_cast<CustomParticle*>(aParticleChange->GetSecondary(i)->GetDynamicParticle()->GetDefinition())!=0) found = true;
-    i++;
-  }
-  i--;
-  if(found) return aParticleChange->GetSecondary(i)->GetDynamicParticle();
-  return 0;
-}


### PR DESCRIPTION
Includes only clean-up and should not affect mainstream simulation.

1) modified options to dump CMS geometry to gdml file (request from Geant4 team).
2) Allow R-hadrons to decay
3) Clean-up old code for R-hadron hadronic interactions (should not change its physics).
