### PR TITLE
Fix handler order

### DIFF
--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -120,6 +120,7 @@ namespace {
           (el_message.find("matrix not positive definite") != std::string::npos) ||
           (el_message.find("not a TStreamerInfo object") != std::string::npos) ||
           (el_message.find("Problems declaring payload") != std::string::npos) ||
+          (el_message.find("Announced number of args different from the real number of argument passed") != std::string::npos) || // Always printed if gDebug>0 - regardless of whether warning message is real.
           (el_location.find("Fit") != std::string::npos) ||
           (el_location.find("TDecompChol::Solve") != std::string::npos) ||
           (el_location.find("THistPainter::PaintInit") != std::string::npos) ||

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -182,6 +182,7 @@
 
     if (!native("file"))      addType(mgr, "^file:");
     if (!native("http"))      addType(mgr, "^http:");
+    if (!native("http"))      addType(mgr, "^http[s]?:");
     if (!native("ftp"))       addType(mgr, "^ftp:");
     /* always */              addType(mgr, "^web:");
     /* always */              addType(mgr, "^gsiftp:");

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -176,6 +176,10 @@
     // set our own root plugins
     TPluginManager* mgr = gROOT->GetPluginManager();
 
+    // Make sure ROOT parses system directories first.
+    mgr->LoadHandlersFromPluginDirs("TFile");
+    mgr->LoadHandlersFromPluginDirs("TSystem");
+
     if (!native("file"))      addType(mgr, "^file:");
     if (!native("http"))      addType(mgr, "^http:");
     if (!native("ftp"))       addType(mgr, "^ftp:");
@@ -189,9 +193,8 @@
     if (!native("storm"))     addType(mgr, "^storm:");
     if (!native("storm-lcg")) addType(mgr, "^storm-lcg:");
     if (!native("lstore"))    addType(mgr, "^lstore:");
-    // This is ready to go from a code point-of-view.
-    // Waiting on the validation "OK" from Computing.
     if (!native("root"))      addType(mgr, "^root:", 1); // See comments in addType
+    if (!native("root"))      addType(mgr, "^[x]?root:", 1); // See comments in addType
   }
 
   void


### PR DESCRIPTION
Apparently, when a file open error occurs in a built-in TFile plugin, we get a SIGABRT with the dreaded "terminate called after throwing an instance of...".  (To reproduce, simply try to open a file named "dcap://dcache-cms-dcap.desy.de//pnfs/desy.de/cms/tier2/store/foo/bar" without this PR).

I wasn't able to figure that one out, however.  I did figure out the regression in the ROOT6 branch that caused TFileAdaptor to not be used for dCap; fixed in this PR.
