### PR TITLE
Pixel vertex counting alca reco v1

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_Output_cff.py
@@ -1,0 +1,22 @@
+import FWCore.ParameterSet.Config as cms
+
+# AlCaReco for track based calibration using MinBias events
+OutALCARECOLumiPixels_noDrop = cms.PSet(
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOLumiPixels')
+    ),
+    outputCommands = cms.untracked.vstring( 
+        'keep *_siPixelClusters_*_*',
+        'keep *_TriggerResults_*_HLT',
+        'keep L1AcceptBunchCrossings_*_*_*',
+        'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*', # not sure I'll need
+        'keep *_TriggerResults_*_HLT',
+        #'keep DcsStatuss_scalersRawToDigi_*_*', # fairly sure I don't need
+        'keep *_offlinePrimaryVertices_*_*'
+    )
+)
+
+
+import copy
+OutALCARECOLumiPixels=copy.deepcopy(OutALCARECOLumiPixels_noDrop)
+OutALCARECOLumiPixels.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_Output_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_Output_cff.py
@@ -1,9 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
 # AlCaReco for track based calibration using MinBias events
-OutALCARECOLumiPixels_noDrop = cms.PSet(
+OutALCARECOLumiPixelsMinBias_noDrop = cms.PSet(
     SelectEvents = cms.untracked.PSet(
-        SelectEvents = cms.vstring('pathALCARECOLumiPixels')
+        SelectEvents = cms.vstring('pathALCARECOLumiPixelsMinBias')
     ),
     outputCommands = cms.untracked.vstring( 
         'keep *_siPixelClusters_*_*',
@@ -18,5 +18,5 @@ OutALCARECOLumiPixels_noDrop = cms.PSet(
 
 
 import copy
-OutALCARECOLumiPixels=copy.deepcopy(OutALCARECOLumiPixels_noDrop)
-OutALCARECOLumiPixels.outputCommands.insert(0,"drop *")
+OutALCARECOLumiPixelsMinBias=copy.deepcopy(OutALCARECOLumiPixelsMinBias_noDrop)
+OutALCARECOLumiPixelsMinBias.outputCommands.insert(0,"drop *")

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_cff.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+import HLTrigger.HLTfilters.hltHighLevel_cfi
+ALCARECOVertexPixelZeroBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
+    andOr = True, # choose logical OR between Triggerbits
+    eventSetupPathsKey='VertexPixelZeroBias',
+    throw = False # tolerate triggers stated above, but not available
+)
+
+# Sequence #
+seqALCARECOLumiPixelsMinBias = cms.Sequence(ALCARECOVertexPixelZeroBiasHLT)

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -106,3 +106,4 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripPCLHistos_Output_cff import 
 
 # stream for the LumiPixels workflow
 from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixels_Output_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixelsMinBias_Output_cff import *

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -39,8 +39,6 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_cff import *
 ###############################################################
 # LUMI Calibration
 ###############################################################
-# AlCaReco for ALCALUMIPIXELS stream
-from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixels_Output_cff import *
 # AlCaReco for A stream (PD=MinBias)
 from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixelsMinBias_Output_cff import *
 
@@ -126,7 +124,6 @@ pathALCARECOSiPixelLorentzAngle = cms.Path(seqALCARECOSiPixelLorentzAngle)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
 pathALCARECOSiStripCalZeroBias = cms.Path(seqALCARECOSiStripCalZeroBias*ALCARECOSiStripCalZeroBiasDQM)
 
-pathALCARECOLumiPixels = cms.Path(seqALCARECOLumiPixels)
 pathALCARECOLumiPixelsMinBias = cms.Path(seqALCARECOLumiPixelsMinBias)
 
 pathALCARECOEcalCalZElectron = cms.Path(seqALCARECOEcalCalZElectron)
@@ -261,15 +258,6 @@ ALCARECOStreamLumiPixelsMinBias = cms.FilteredStream(
 	paths  = (pathALCARECOLumiPixelsMinBias),
 	content = OutALCARECOLumiPixelsMinBias.outputCommands,
 	selectEvents = OutALCARECOLumiPixelsMinBias.SelectEvents,
-	dataTier = cms.untracked.string('ALCARECO')
-	)
-
-ALCARECOStreamLumiPixels = cms.FilteredStream(
-	responsible = 'Chris Palmer',
-	name = 'LumiPixels',
-	paths  = (pathALCARECOLumiPixels),
-	content = OutALCARECOLumiPixels.outputCommands,
-	selectEvents = OutALCARECOLumiPixels.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -40,7 +40,7 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_cff import *
 # LUMI Calibration
 ###############################################################
 # AlCaReco for A stream (PD=MinBias)
-from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixelsMinBias_Output_cff import *
+from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixelsMinBias_cff import *
 
 ###############################################################
 # ECAL Calibration

--- a/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStreams_cff.py
@@ -37,6 +37,14 @@ from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalMinBias_cff import *
 from Calibration.TkAlCaRecoProducers.ALCARECOSiStripCalZeroBias_cff import *
 
 ###############################################################
+# LUMI Calibration
+###############################################################
+# AlCaReco for ALCALUMIPIXELS stream
+from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixels_Output_cff import *
+# AlCaReco for A stream (PD=MinBias)
+from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixelsMinBias_Output_cff import *
+
+###############################################################
 # ECAL Calibration
 ###############################################################
 # ECAL calibration with isol. electrons
@@ -117,6 +125,9 @@ pathALCARECOTkAlMinBias = cms.Path(seqALCARECOTkAlMinBias*ALCARECOTkAlMinBiasDQM
 pathALCARECOSiPixelLorentzAngle = cms.Path(seqALCARECOSiPixelLorentzAngle)
 pathALCARECOSiStripCalMinBias = cms.Path(seqALCARECOSiStripCalMinBias*ALCARECOSiStripCalMinBiasDQM)
 pathALCARECOSiStripCalZeroBias = cms.Path(seqALCARECOSiStripCalZeroBias*ALCARECOSiStripCalZeroBiasDQM)
+
+pathALCARECOLumiPixels = cms.Path(seqALCARECOLumiPixels)
+pathALCARECOLumiPixelsMinBias = cms.Path(seqALCARECOLumiPixelsMinBias)
 
 pathALCARECOEcalCalZElectron = cms.Path(seqALCARECOEcalCalZElectron)
 pathALCARECOEcalCalWElectron = cms.Path(seqALCARECOEcalCalWElectron)
@@ -241,6 +252,24 @@ ALCARECOStreamSiStripCalZeroBias = cms.FilteredStream(
 	paths  = (pathALCARECOSiStripCalZeroBias),
 	content = OutALCARECOSiStripCalZeroBias.outputCommands,
 	selectEvents = OutALCARECOSiStripCalZeroBias.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+ALCARECOStreamLumiPixelsMinBias = cms.FilteredStream(
+	responsible = 'Chris Palmer',
+	name = 'LumiPixelsMinBias',
+	paths  = (pathALCARECOLumiPixelsMinBias),
+	content = OutALCARECOLumiPixelsMinBias.outputCommands,
+	selectEvents = OutALCARECOLumiPixelsMinBias.SelectEvents,
+	dataTier = cms.untracked.string('ALCARECO')
+	)
+
+ALCARECOStreamLumiPixels = cms.FilteredStream(
+	responsible = 'Chris Palmer',
+	name = 'LumiPixels',
+	paths  = (pathALCARECOLumiPixels),
+	content = OutALCARECOLumiPixels.outputCommands,
+	selectEvents = OutALCARECOLumiPixels.SelectEvents,
 	dataTier = cms.untracked.string('ALCARECO')
 	)
 


### PR DESCRIPTION
The files added/altered introduce a new ALCAReco for zerobias/random triggers.  Pixels clusters and offline reconstructed vertices are saved in the event content for the dual purpose of offline validation of online luminosity and low luminosity luminometer normalization (with vertex counting).
