### PR TITLE
Fix for high energy behaviour of ecal pfcluster corrections

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
+++ b/RecoParticleFlow/PFClusterProducer/interface/PFClusterEMEnergyCorrector.h
@@ -25,6 +25,7 @@ class PFClusterEMEnergyCorrector {
  private:    
   bool _applyCrackCorrections;
   bool _applyMVACorrections;
+  double _maxPtForMVAEvaluation;
    
   bool autoDetectBunchSpacing_;
   int bunchSpacingManual_;

--- a/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/CorrectedECALPFClusterProducer.cc
@@ -143,6 +143,7 @@ void CorrectedECALPFClusterProducer::fillDescriptions(edm::ConfigurationDescript
     edm::ParameterSetDescription psd0;
     psd0.add<bool>("applyCrackCorrections",false);
     psd0.add<bool>("applyMVACorrections",false);
+    psd0.add<double>("maxPtForMVAEvaluation",-99.);
     psd0.add<std::string>("algoName","PFClusterEMEnergyCorrector");
     psd0.add<edm::InputTag>("recHitsEBLabel",edm::InputTag("ecalRecHit","EcalRecHitsEB"));
     psd0.add<edm::InputTag>("recHitsEELabel",edm::InputTag("ecalRecHit","EcalRecHitsEE"));

--- a/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
+++ b/RecoParticleFlow/PFClusterProducer/python/particleFlowClusterECAL_cfi.py
@@ -7,6 +7,7 @@ _emEnergyCorrector = cms.PSet(
     algoName = cms.string("PFClusterEMEnergyCorrector"),
     applyCrackCorrections = cms.bool(False),
     applyMVACorrections = cms.bool(True),
+    maxPtForMVAEvaluation = cms.double(90.),
     recHitsEBLabel = cms.InputTag('ecalRecHit', 'EcalRecHitsEB'),
     recHitsEELabel = cms.InputTag('ecalRecHit', 'EcalRecHitsEE'),
     autoDetectBunchSpacing = cms.bool(True),

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -18,6 +18,7 @@ PFClusterEMEnergyCorrector::PFClusterEMEnergyCorrector(const edm::ParameterSet& 
 
    _applyCrackCorrections = conf.getParameter<bool>("applyCrackCorrections");
    _applyMVACorrections = conf.getParameter<bool>("applyMVACorrections");
+   _maxPtForMVAEvaluation = conf.getParameter<double>("maxPtForMVAEvaluation");
   
    
   if (_applyMVACorrections) {
@@ -184,6 +185,13 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
     double e = cluster.energy();
     double pt = cluster.pt(); 
     
+    //limit raw energy value used to evaluate corrections
+    //to avoid bad extrapolation
+    double evale = e;
+    if (_maxPtForMVAEvaluation>0. && pt>_maxPtForMVAEvaluation) {
+      evale *= _maxPtForMVAEvaluation/pt; 
+    }
+    
     double invE = (e == 0.) ? 0. : 1./e; //guard against dividing by 0.
     
     int size = lazyTool.n5x5(cluster);
@@ -246,7 +254,7 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
     }
     
     //fill array for forest evaluation
-    eval[0] = e;
+    eval[0] = evale;
     eval[1] = ietaix;
     eval[2] = iphiiy;
     if (!iseb) {


### PR DESCRIPTION
limit maximum energy (pt) for ecal pf cluster corrections to avoid bad extrapolation beyond region of correction derivation.  At 1TeV this was introducing a ~1% scale shift in the barrel and a ~10% scale shift in the endcap.

Likely issue is limited kinematic coverage of training sample combined with tails in the energy response distribution sufficiently large to create well-populated BDT bins in the region about the kinematic limit of the sample, where all photons are by construction overmeasured (and therefore overcorrected downwards in energy)

@bachtis @lgray @matteosan1

@konush can you incorporate this change into your evaluation scripts and run the validation plots again to make sure this doesn't introduce any strange behaviour in scale/resolution vs eta/pt?  (at least up to the kinematic limit in the present samples...)
