### PR TITLE
Added GT tables in V2 created databases. Improved error handling in seri...

### DIFF
--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -198,7 +198,14 @@ namespace cond {
     template <typename T> inline cond::Hash Session::storePayload( const T& payload, const boost::posix_time::ptime& creationTime ){
       
       std::string payloadObjectType = cond::demangledName(typeid(payload));
-      return storePayloadData( payloadObjectType, serialize( payload, isOraSession() ), creationTime ); 
+      cond::Hash ret; 
+      try{
+	ret = storePayloadData( payloadObjectType, serialize( payload, isOraSession() ), creationTime ); 
+      } catch ( const cond::persistency::Exception& e ){
+	std::string em(e.what());
+	throwException( "Payload of type "+payloadObjectType+" could not be stored. "+em,"Session::storePayload"); 	
+      }
+      return ret;
     }
     
     template <typename T> inline boost::shared_ptr<T> Session::fetchPayload( const cond::Hash& payloadHash ){
@@ -206,9 +213,16 @@ namespace cond {
       cond::Binary streamerInfoData;
       std::string payloadType;
       if(! fetchPayloadData( payloadHash, payloadType, payloadData, streamerInfoData ) ) 
-	throwException( "Payload with id="+payloadHash+" has not been found in the database.",
+	throwException( "Payload with id "+payloadHash+" has not been found in the database.",
 			"Session::fetchPayload" );
-      return deserialize<T>(  payloadType, payloadData, streamerInfoData, isOraSession() );
+      boost::shared_ptr<T> ret;
+      try{ 
+	ret = deserialize<T>(  payloadType, payloadData, streamerInfoData, isOraSession() );
+      } catch ( const cond::persistency::Exception& e ){
+	std::string em(e.what());
+	throwException( "Payload of type "+payloadType+" with id "+payloadHash+" could not be loaded. "+em,"Session::fetchPayload"); 
+      }
+      return ret;
     }
 
     class TransactionScope {

--- a/CondCore/CondDB/src/GTSchema.cc
+++ b/CondCore/CondDB/src/GTSchema.cc
@@ -13,6 +13,16 @@ namespace cond {
       return existsTable( m_schema, tname );
     }
 
+    void GLOBAL_TAG::Table::create(){
+      if( exists() ){
+	throwException( "GLOBAL_TAG table already exists in this schema.",
+			"GLOBAL_TAG::Table::create");
+      }
+      TableDescription< NAME, VALIDITY, DESCRIPTION, RELEASE, SNAPSHOT_TIME, INSERTION_TIME > descr( tname );
+      descr.setPrimaryKey<NAME>();
+      createTable( m_schema, descr.get() );
+    }
+
     bool GLOBAL_TAG::Table::select( const std::string& name ){
       Query< NAME > q( m_schema );
       q.addCondition<NAME>( name );
@@ -82,6 +92,16 @@ namespace cond {
     bool GLOBAL_TAG_MAP::Table::exists(){
       return existsTable( m_schema, tname );
     }
+
+    void GLOBAL_TAG_MAP::Table::create(){
+      if( exists() ){
+	throwException( "GLOBAL_TAG_MAP table already exists in this schema.",
+			"GLOBAL_TAG_MAP::Table::create");
+      }
+      TableDescription< GLOBAL_TAG_NAME, RECORD, LABEL, TAG_NAME > descr( tname );
+      descr.setPrimaryKey< GLOBAL_TAG_NAME, RECORD, LABEL >();
+      createTable( m_schema, descr.get() );
+    }
     
     bool GLOBAL_TAG_MAP::Table::select( const std::string& gtName, 
 					std::vector<std::tuple<std::string,std::string,std::string> >& tags ){
@@ -119,6 +139,11 @@ namespace cond {
       if( !m_gtTable.exists() ) return false;
       if( !m_gtMapTable.exists() ) return false;
       return true;
+    }
+
+    void GTSchema::create(){
+      m_gtTable.create();
+      m_gtMapTable.create();
     }
 
     GLOBAL_TAG::Table& GTSchema::gtTable(){

--- a/CondCore/CondDB/src/GTSchema.h
+++ b/CondCore/CondDB/src/GTSchema.h
@@ -24,6 +24,7 @@ namespace cond {
 	explicit Table( coral::ISchema& schema );
 	virtual ~Table(){}
 	bool exists();
+	void create();
 	bool select( const std::string& name);
 	bool select( const std::string& name, cond::Time_t& validity, boost::posix_time::ptime& snapshotTime );
 	bool select( const std::string& name, cond::Time_t& validity, std::string& description, 
@@ -53,6 +54,7 @@ namespace cond {
 	explicit Table( coral::ISchema& schema );
 	virtual ~Table(){}
 	bool exists();
+	void create();
 	bool select( const std::string& gtName, std::vector<std::tuple<std::string,std::string,std::string> >& tags );
 	bool select( const std::string& gtName, const std::string& preFix, const std::string& postFix,
 		     std::vector<std::tuple<std::string,std::string,std::string> >& tags );
@@ -67,6 +69,7 @@ namespace cond {
       explicit GTSchema( coral::ISchema& schema );
       virtual ~GTSchema(){}
       bool exists();
+      void create();
       GLOBAL_TAG::Table& gtTable();
       GLOBAL_TAG_MAP::Table& gtMapTable();
     private:

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -104,6 +104,7 @@ namespace cond {
     public:
       virtual ~IGTTable(){}
       virtual bool exists() = 0;
+      virtual void create() = 0;
       virtual bool select( const std::string& name ) = 0;
       virtual bool select( const std::string& name, cond::Time_t& validity, boost::posix_time::ptime& snapshotTime ) = 0;
       virtual bool select( const std::string& name, cond::Time_t& validity, std::string& description, 
@@ -118,6 +119,7 @@ namespace cond {
     public:
       virtual ~IGTMapTable(){}
       virtual bool exists() = 0;
+      virtual void create() = 0;
       virtual bool select( const std::string& gtName, std::vector<std::tuple<std::string,std::string,std::string> >& tags ) = 0;
       virtual bool select( const std::string& gtName, const std::string& preFix, const std::string& postFix, 
 			   std::vector<std::tuple<std::string,std::string,std::string> >& tags ) = 0;
@@ -128,6 +130,7 @@ namespace cond {
     public: 
       virtual ~IGTSchema(){}
       virtual bool exists() = 0;
+      virtual void create() = 0;
       virtual IGTTable& gtTable() = 0;
       virtual IGTMapTable& gtMapTable() = 0;
     };

--- a/CondCore/CondDB/src/OraDbSchema.cc
+++ b/CondCore/CondDB/src/OraDbSchema.cc
@@ -371,6 +371,12 @@ namespace cond {
       m_gtTable( session ),
       m_gtMapTable( session ){
     }
+
+
+    void OraGTSchema::create(){
+      throwException("GT Schema can't be create in ORA implementation.",
+                     "OraGTSchema::create");
+    }
       
     bool OraGTSchema::exists(){
       cond::TagCollectionRetriever gtRetriever( m_session, "", "" );

--- a/CondCore/CondDB/src/OraDbSchema.h
+++ b/CondCore/CondDB/src/OraDbSchema.h
@@ -135,6 +135,7 @@ namespace cond {
     public:
       explicit OraGTTable( DbSession& session ); 
       virtual ~OraGTTable(){}
+      void create(){}
       bool exists(){
 	return true;
       }
@@ -154,6 +155,7 @@ namespace cond {
     public:
       explicit OraGTMapTable( DbSession& session );
       virtual ~OraGTMapTable(){}
+      void create(){}
       bool exists(){
 	return true;
       }
@@ -169,6 +171,7 @@ namespace cond {
     public: 
       OraGTSchema( DbSession& session );
       virtual ~OraGTSchema(){}
+      void create();
       bool exists();
       IGTTable& gtTable();
       IGTMapTable& gtMapTable();

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -75,7 +75,7 @@ namespace cond {
     
     //
     void Session::createDatabase(){
-      m_session->openIovDb( SessionImpl::CREATE );
+      m_session->openDb();
     }
 
     IOVProxy Session::readIov( const std::string& tag, bool full ){
@@ -98,7 +98,7 @@ namespace cond {
 
     IOVEditor Session::createIov( const std::string& payloadType, const std::string& tag, cond::TimeType timeType, 
 				  cond::SynchronizationType synchronizationType ){
-      m_session->openIovDb( SessionImpl::CREATE );
+      m_session->openDb();
       if( m_session->iovSchema().tagTable().select( tag ) ) 
 	throwException( "The specified tag \""+tag+"\" already exist in the database.","Session::createIov");
       IOVEditor editor( m_session, tag, timeType, payloadType, synchronizationType );
@@ -110,7 +110,7 @@ namespace cond {
 				  cond::TimeType timeType,
 				  cond::SynchronizationType synchronizationType,
 				  const boost::posix_time::ptime& creationTime ){
-      m_session->openIovDb( SessionImpl::CREATE );
+      m_session->openDb();
       if( m_session->iovSchema().tagTable().select( tag ) ) 
 	throwException( "The specified tag \""+tag+"\" already exist in the database.","Session::createIov");
       IOVEditor editor( m_session, tag, timeType, payloadType, synchronizationType, creationTime );
@@ -119,7 +119,7 @@ namespace cond {
 
     IOVEditor Session::createIovForPayload( const Hash& payloadHash, const std::string& tag, cond::TimeType timeType,
 					    cond::SynchronizationType synchronizationType ){
-      m_session->openIovDb( SessionImpl::CREATE );
+      m_session->openDb();
       if( m_session->iovSchema().tagTable().select( tag ) ) 
 	throwException( "The specified tag \""+tag+"\" already exist in the database.","Session::createIovForPayload");
       std::string payloadType("");
@@ -178,7 +178,7 @@ namespace cond {
     cond::Hash Session::storePayloadData( const std::string& payloadObjectType, 
 					  const std::pair<Binary,Binary>& payloadAndStreamerInfoData,
 					  const boost::posix_time::ptime& creationTime ){
-      m_session->openIovDb( SessionImpl::CREATE );
+      m_session->openDb();
       return m_session->iovSchema().payloadTable().insertIfNew( payloadObjectType, payloadAndStreamerInfoData.first, 
 								payloadAndStreamerInfoData.second, creationTime );
     }

--- a/CondCore/CondDB/src/SessionImpl.cc
+++ b/CondCore/CondDB/src/SessionImpl.cc
@@ -176,14 +176,39 @@ namespace cond {
       }
     }
 
-    void SessionImpl::openGTDb(){
+    void SessionImpl::openGTDb( SessionImpl::FailureOnOpeningPolicy policy ){
       if(!transaction.get()) throwException( "The transaction is not active.","SessionImpl::open" );
       if( !transaction->gtDbOpen ){
 	transaction->gtDbExists = gtSchemaHandle->exists();
 	transaction->gtDbOpen = true;
       }
       if( !transaction->gtDbExists ){
-	throwException( "GT Database does not exist.","SessionImpl::openGTDb");
+        if( policy==CREATE ){
+          gtSchemaHandle->create();
+          transaction->gtDbExists = true;
+        } else {
+          if( policy==THROW) throwException( "GT Database does not exist.","SessionImpl::openGTDb");
+	}
+      }
+    }
+
+    void SessionImpl::openDb(){
+      if(!transaction.get()) throwException( "The transaction is not active.","SessionImpl::openIovDb" );
+      if( !transaction->iovDbOpen ){
+        transaction->iovDbExists = iovSchemaHandle->exists();
+        transaction->iovDbOpen = true;
+      }
+      if( !transaction->gtDbOpen ){
+        transaction->gtDbExists = gtSchemaHandle->exists();
+        transaction->gtDbOpen = true;
+      }
+      if( !transaction->iovDbExists ){
+	iovSchemaHandle->create();
+	transaction->iovDbExists = true;
+	if( !transaction->gtDbExists ){
+	  gtSchemaHandle->create();
+	  transaction->gtDbExists = true;
+	}
       }
     }
     

--- a/CondCore/CondDB/src/SessionImpl.h
+++ b/CondCore/CondDB/src/SessionImpl.h
@@ -59,7 +59,8 @@ namespace cond {
       bool isTransactionActive( bool deep=true ) const;
 
       void openIovDb( FailureOnOpeningPolicy policy = THROW );
-      void openGTDb();
+      void openGTDb( FailureOnOpeningPolicy policy = THROW );
+      void openDb();
       IIOVSchema& iovSchema();
       IGTSchema& gtSchema();
       // only for the bridging...

--- a/CondCore/Utilities/bin/BuildFile.xml
+++ b/CondCore/Utilities/bin/BuildFile.xml
@@ -63,3 +63,6 @@
 <bin   file="conddb_copy_iov.cpp" name="conddb_copy_iov">
   <use   name="CondCore/CondDB"/>
 </bin>
+<bin   file="conddb_test.cpp" name="conddb_test">
+  <use   name="CondCore/CondDB"/>
+</bin>

--- a/CondCore/Utilities/bin/conddb_test.cpp
+++ b/CondCore/Utilities/bin/conddb_test.cpp
@@ -1,0 +1,65 @@
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+
+#include "CondCore/Utilities/interface/Utilities.h"
+#include "CondCore/Utilities/interface/CondDBImport.h"
+#include <iostream>
+
+#include <sstream>
+
+namespace cond {
+
+  class TestIovUtilities : public cond::Utilities {
+    public:
+      TestIovUtilities();
+      ~TestIovUtilities();
+      int execute();
+  };
+}
+
+cond::TestIovUtilities::TestIovUtilities():Utilities("conddb_copy_iov"){
+  addConnectOption("connect","c","target connection string (required)");
+  addAuthenticationOptions();
+  addOption<bool>("read","r","de-serialize the specified payload");
+  addOption<std::string>("hash","x","hash of the payload");
+}
+
+cond::TestIovUtilities::~TestIovUtilities(){
+}
+
+int cond::TestIovUtilities::execute(){
+
+  bool debug = hasDebug();
+  std::string connect = getOptionValue<std::string>("connect");
+
+  std::string hash("");
+  bool read = hasOptionValue( "read" );
+  if( read ){
+    hash = getOptionValue<std::string>("hash");
+  }
+
+  persistency::ConnectionPool connPool;
+  if( hasOptionValue("authPath") ){
+    connPool.setAuthenticationPath( getOptionValue<std::string>( "authPath") ); 
+  }
+  connPool.configure();
+
+  std::cout <<"# Connecting to source database on "<<connect<<std::endl;
+  persistency::Session session = connPool.createSession( connect );
+
+  session.transaction().start( true );
+  try{
+    persistency::fetch( hash, session ); 
+    std::cout <<"De-serialization of payload "<<hash<<" performed correctly."<<std::endl;
+  } catch ( const persistency::Exception& e ){
+    std::cout <<"De-serialization of payload "<<hash<<" failed: "<<e.what()<<std::endl; 
+  }
+  session.transaction().commit();
+  return 0;
+}
+
+int main( int argc, char** argv ){
+
+  cond::TestIovUtilities utilities;
+  return utilities.run(argc,argv);
+}
+


### PR DESCRIPTION
In this PR:
- sqlite database files in v2 format will contain also the ( empty ) GT tables. Required for the command line tools to work properly
- the exceptions in the serialization/de-serialization are re-thrown with the additional information required for the error tracing ( payload type, payload hash, ... )
