### PR TITLE
Fixing import script for DTRecoConditions

### DIFF
--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -65,6 +65,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE( DTLVStatus )
       FETCH_PAYLOAD_CASE( DTMtime )
       FETCH_PAYLOAD_CASE( DTReadOutMapping )
+      FETCH_PAYLOAD_CASE( DTRecoConditions )	
       FETCH_PAYLOAD_CASE( DTRecoUncertainties )
       FETCH_PAYLOAD_CASE( DTStatusFlag )
       FETCH_PAYLOAD_CASE( DTT0 )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -80,6 +80,7 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( DTLVStatus )
       IMPORT_PAYLOAD_CASE( DTMtime )
       IMPORT_PAYLOAD_CASE( DTReadOutMapping )
+      IMPORT_PAYLOAD_CASE( DTRecoConditions )
       IMPORT_PAYLOAD_CASE( DTRecoUncertainties )
       IMPORT_PAYLOAD_CASE( DTStatusFlag )
       IMPORT_PAYLOAD_CASE( DTT0 )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -37,6 +37,7 @@
 #include "CondFormats/DTObjects/interface/DTT0.h"
 #include "CondFormats/DTObjects/interface/DTTPGParameters.h"
 #include "CondFormats/DTObjects/interface/DTTtrig.h"
+#include "CondFormats/DTObjects/interface/DTRecoConditions.h"
 #include "CondFormats/DTObjects/interface/DTRecoUncertainties.h"
 #include "CondFormats/ESObjects/interface/ESEEIntercalibConstants.h"
 #include "CondFormats/ESObjects/interface/ESGain.h"


### PR DESCRIPTION
This PR adds the possibility for the `conddb_import` tool to fetch and import the `DTRecoConditions` class. This is needed for the dropbox to properly handle the payloads of this type.
