### PR TITLE
Change fast timing workflows to stop using crossing frames

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1180,16 +1180,6 @@ for k in upgradeKeys:
                                       }
     if cust!=None : upgradeStepDict['DigiFull'][k]['--customise']=cust
     
-    upgradeStepDict['DigiFullFastTimer'][k] = {'-s':'DIGI:pdigi_valid,CFWRITER,L1,DIGI2RAW',
-                                      '--conditions':gt,
-                                      '--datatier':'GEN-SIM-DIGI-RAW',
-                                      '-n':'10',
-                                      '--magField' : '38T_PostLS1',
-                                      '--eventcontent':'FEVTDEBUGHLT',
-                                      '--geometry' : geom
-                                      }
-    if cust!=None : upgradeStepDict['DigiFullFastTimer'][k]['--customise']=cust
-    
     upgradeStepDict['DigiFullTrigger'][k] = {'-s':'DIGI:pdigi_valid,L1,L1TrackTrigger,DIGI2RAW',
                                       '--conditions':gt,
                                       '--datatier':'GEN-SIM-DIGI-RAW',
@@ -1222,18 +1212,6 @@ for k in upgradeKeys:
                                       '--geometry' : geom
                                       }
     if cust!=None : upgradeStepDict['RecoFull'][k]['--customise']=cust
-
- 
-    upgradeStepDict['RecoFullFastTimer'][k] = {'-s':'RAW2DIGI,L1Reco,RECO,VALIDATION,DQM',
-                                      '--conditions':gt,
-                                      '--datatier':'GEN-SIM-RECO,DQMIO',
-                                      '-n':'10',
-                                      '--eventcontent':'RECOSIM,DQM',
-                                      '--magField' : '38T_PostLS1',
-                                      '--geometry' : geom
-				      #'--customise_commands=process.ecalDetailedTimeRecHit.correctForVertexZPosition=False':''
-                                      }
-    if cust!=None : upgradeStepDict['RecoFullFastTimer'][k]['--customise']=cust
 
  
     if k2 in PUDataSets:

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -166,7 +166,7 @@ upgradeFragments=['FourMuPt_1_200_cfi','SingleElectronPt10_cfi',
 # step5 is digi+l1tracktrigger
 # step6 is fastsim
 # step7 is fastsim harvesting
-upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','GenSimHLBeamSpotfixFull','DigiFull','DigiFullFastTimer','RecoFull','RecoFullFastTimer','RecoFullHGCAL','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','HARVESTFullPU','DigiFullTrigger']
+upgradeSteps=['GenSimFull','GenSimHLBeamSpotFull','GenSimHLBeamSpotfixFull','DigiFull','RecoFull','RecoFullHGCAL','HARVESTFull','DigiTrkTrigFull','FastSim','HARVESTFast','DigiFullPU','RecoFullPU','RecoFullPUHGCAL','HARVESTFullPU','DigiFullTrigger']
 
 upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    '2019':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
@@ -198,7 +198,7 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    '2019WithGEMAgingPU':['GenSimFull','DigiFullPU','RecoFullPU','HARVESTFullPU'],
                    'Extended2023HGCalMuonPandora':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
                    'Extended2023HGCalMuonPandoraPU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
-                   'Extended2023SHCalNoTaperFast' : ['GenSimHLBeamSpotfixFull','DigiFullFastTimer','RecoFullFastTimer','HARVESTFull'],
+                   'Extended2023SHCalNoTaperFast' : ['GenSimHLBeamSpotfixFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCalNoExtPix' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL']
                    }
 

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -626,6 +626,11 @@ def cust_2023SHCalTime(process):
         process.mix.digitizers.mergedtruth.createInitialVertexCollection = True
     if hasattr(process,'reconstruction_step'):
         process.ecalDetailedTimeRecHit.correctForVertexZPosition=False
+    # This next part limits the pileup to be in time only, as
+    # requested by the fast timing group
+    if hasattr(process,'mix'):
+        process.mix.minBunch = 0
+        process.mix.maxBunch = 0
     return process
 
 def cust_2023Pixel(process):

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -615,18 +615,17 @@ def cust_2023HGCalV6Muon(process):
 def cust_2023SHCalTime(process):
     process=cust_2023SHCal(process)
     process=cust_shashlikTime(process)
-    process=cust_ecalTime(process)    
+    process=cust_ecalTime(process)
     if hasattr(process,'RECOSIMEventContent'):
-        process.RECOSIMEventContent.outputCommands.append('keep *_cfWriter_g4SimHits_*')
+        process.RECOSIMEventContent.outputCommands.append('keep *_mix_InitialVertices_*')
     if hasattr(process,'FEVTDEBUGEventContent'):
-     	process.FEVTDEBUGEventContent.outputCommands.append('keep *_cfWriter_g4SimHits_*')
+        process.FEVTDEBUGEventContent.outputCommands.append('keep *_mix_InitialVertices_*')
     if hasattr(process,'FEVTDEBUGHLTEventContent'):
-     	process.FEVTDEBUGHLTEventContent.outputCommands.append('keep *_cfWriter_g4SimHits_*')
+        process.FEVTDEBUGHLTEventContent.outputCommands.append('keep *_mix_InitialVertices_*')
     if hasattr(process,'digitisation_step'):
-    	process.mix.mixObjects.mixVertices.makeCrossingFrame=cms.untracked.bool(True)
-	process.mix.mixObjects.mixTracks.makeCrossingFrame=cms.untracked.bool(True)
+        process.mix.digitizers.mergedtruth.createInitialVertexCollection = True
     if hasattr(process,'reconstruction_step'):
-	process.ecalDetailedTimeRecHit.correctForVertexZPosition=False
+        process.ecalDetailedTimeRecHit.correctForVertexZPosition=False
     return process
 
 def cust_2023Pixel(process):


### PR DESCRIPTION
Changes the fast timing workflows to output a TrackingVertex collection (introduced with #8975) with all initial vertices, instead of using a collection of SimVertex CrossingFrames.  Since the CrossingFrames are no longer required, the `DigiFullFastTimer` step has been removed and it now uses the normal `DigiFull` step.
The new collection adds ~31kb per event to the file size at 140 pileup, so the reco step has been changed to `RecoFull` and `RecoFullFastTimer` removed as well.  The only difference between the two was smaller event content in `RecoFullFastTimer`, and file size is no longer an issue.
As a reminder, the workflow numbers are 160xx.

@simonepigazzini
@boudoul, note this changes some of the workflows you introduced.
