### PR TITLE
bug fix for ouput ASCII file when writeTxt_ is set false

### DIFF
--- a/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/BeamFitter.cc
@@ -625,7 +625,7 @@ void BeamFitter::dumpTxtFile(std::string & fileName, bool append){
 
   std::string tmpname = outputTxt_;
   char index[15];
-  if (appendRunTxt_ && !ffilename_changed ) {
+  if (appendRunTxt_ && writeTxt_ && !ffilename_changed ) {
       sprintf(index,"%s%i","_Run", frun );
       tmpname.insert(outputTxt_.length()-4,index);
       fileName = tmpname;


### PR DESCRIPTION
minor bug fix for output  .txt files for the case when writeTxt_ is set to false otherwise it changes the name of the dip output file.  
