### PR TITLE
Temporary fix to clear TrackerHitAssociator maps each event

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -97,6 +97,7 @@ class TrackerHitAssociator {
   std::vector<SimHitIdpr> associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const;
   
   void processEvent(const edm::Event& theEvent);
+  void clearEvent();
 
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   simhit_map SimHitMap;

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -104,14 +104,18 @@ void TrackerHitAssociator::processEvent(const edm::Event& e) {
   if(doPixel_) e.getByToken(pixelToken_, pixeldigisimlink);
 }
 
+void TrackerHitAssociator::clearEvent() {
+  SimHitMap.clear();
+  SimHitCollMap.clear();
+}
+
 void TrackerHitAssociator::makeMaps(const edm::Event& theEvent) {
   // Step A: Get Inputs
   //  The collections are specified via ROUList in the configuration, and can
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof)
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
 
-  SimHitMap.clear();  // Start fresh after previous event.
-  SimHitCollMap.clear();
+  clearEvent();
 
   for(auto const& cfToken : cfTokens_) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
@@ -167,8 +171,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const vstring& t
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof) 
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
 
-  SimHitMap.clear();  // Start fresh after previous event.
-  SimHitCollMap.clear();
+  clearEvent();
 
   for(auto const& trackerContainer : trackerContainers) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -921,6 +921,7 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent,
   if (!pDD.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
+    associate.clearEvent();
     return;
   }
   const TrackerGeometry &tracker(*pDD);
@@ -1138,6 +1139,7 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent,
   if (!geom.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
+    associate.clearEvent();
     return;
   }
 
@@ -1276,6 +1278,7 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent,
   if (verbosity > 0)
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
   
+  associate.clearEvent();
   return;
 }
 

--- a/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
@@ -900,6 +900,7 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
   if (!pDD.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
+    associate.clearEvent();
     return;
   }
   const TrackerGeometry &tracker(*pDD);
@@ -1131,6 +1132,7 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
   if (!recHitColl.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find SiPixelRecHitCollection in event!";
+    associate.clearEvent();
     return;
   }  
   
@@ -1140,6 +1142,7 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
   if (!geom.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
+    associate.clearEvent();
     return;
   }
   //const TrackerGeometry& theTracker(*geom);
@@ -1284,6 +1287,7 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
   if (verbosity > 0)
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
 
+  associate.clearEvent();
   return;
 }
 

--- a/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
@@ -1767,5 +1767,5 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	} // tracks > 0.
       
     } //end of MTCCTrack
-
+    trackerHitAssociator_.clearEvent();
 }

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -948,6 +948,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event & e, const edm::Event
   }
   //cout<<"DebugLine303"<<endl;
 
+  associate.clearEvent();
 }
 
 

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -384,6 +384,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 	    }
 	} // <-----end rechit loop 
     } // <------ end detunit loop
+  trackerHitAssociator_->clearEvent();
 }
 
 void SiPixelRecHitsValid::fillBarrel(const SiPixelRecHit& recHit, const PSimHit& simHit, 

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -410,6 +410,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   fillME(totalMEs.meNumTotStereo,totrechitstereo);
   fillME(totalMEs.meNumTotMatched,totrechitmatched);
  
+  associate.clearEvent();
 }
 
   


### PR DESCRIPTION
The change to TrackerHitAssociator to support the consumes interface was done in a suboptimal way that, among other things, did not release the PSimHit maps until the beginning of the next event, causing memory issues.  This PR is a simple temporary  fix to clear the maps at the proper time.
This fix was requested by David Lange.
Since my tests of this PR are still in progress, it would be prudent to test this PR before merging.
NOTE: The consumes interface for TrackerHitAssociator will later be re-implemented in a more robust and less error-prone way very soon.
