### PR TITLE
New HeavyIon ClusterCompatibility object and producer for beam scraping removal

### DIFF
--- a/DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h
+++ b/DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h
@@ -1,0 +1,29 @@
+#ifndef DataFormats_ClusterCompatibility_h
+#define DataFormats_ClusterCompatibility_h
+
+#include <vector>
+
+namespace reco { class ClusterCompatibility {
+public:
+
+  ClusterCompatibility();
+  ClusterCompatibility(float z0, int nHit, float chi);
+  virtual ~ClusterCompatibility();
+
+  float z0() const { return z0_; }
+  int nHit() const { return nHit_; }
+  float chi() const { return chi_; }
+
+protected:
+  
+  float z0_;
+  int nHit_;
+  float chi_;
+
+};
+
+typedef std::vector<reco::ClusterCompatibility> ClusterCompatibilityCollection;
+
+}
+
+#endif

--- a/DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h
+++ b/DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h
@@ -7,23 +7,28 @@ namespace reco { class ClusterCompatibility {
 public:
 
   ClusterCompatibility();
-  ClusterCompatibility(float z0, int nHit, float chi);
   virtual ~ClusterCompatibility();
 
-  float z0() const { return z0_; }
-  int nHit() const { return nHit_; }
-  float chi() const { return chi_; }
+  int nValidPixelHits() const { return nValidPixelHits_; }
+
+  int size() const { return z0_.size(); }
+  float z0(int i) const { return z0_[i]; }
+  int nHit(int i) const { return nHit_[i]; }
+  float chi(int i) const { return chi_[i]; }
+
+  void append(float, int, float);
+  void setNValidPixelHits(int nPxl) { nValidPixelHits_ = nPxl; }
 
 protected:
-  
-  float z0_;
-  int nHit_;
-  float chi_;
+ 
+
+  int nValidPixelHits_;
+ 
+  std::vector<float> z0_;
+  std::vector<int> nHit_;
+  std::vector<float> chi_;
 
 };
 
-typedef std::vector<reco::ClusterCompatibility> ClusterCompatibilityCollection;
-
 }
-
 #endif

--- a/DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h
+++ b/DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h
@@ -9,11 +9,22 @@ public:
   ClusterCompatibility();
   virtual ~ClusterCompatibility();
 
+  /// Number of valid pixel clusters
   int nValidPixelHits() const { return nValidPixelHits_; }
 
+  /// Number of vertex-position hypotheses tested
   int size() const { return z0_.size(); }
+
+  /// Vertex z position for the i-th vertex-position hypothesis
   float z0(int i) const { return z0_[i]; }
+
+  /// Number of compatible non-edge pixel-barrel clusters 
+  /// for the i-th vertex-position hypothesis
   int nHit(int i) const { return nHit_[i]; }
+
+  /// Sum of the difference between the expected and actual 
+  /// width of all compatible non-edge pixel-barrel clusters 
+  /// for the i-th vertex-position hypothesis
   float chi(int i) const { return chi_[i]; }
 
   void append(float, int, float);

--- a/DataFormats/HeavyIonEvent/src/ClusterCompatibility.cc
+++ b/DataFormats/HeavyIonEvent/src/ClusterCompatibility.cc
@@ -1,0 +1,16 @@
+#include "DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h"
+using namespace reco;
+
+ClusterCompatibility::ClusterCompatibility(float z0, int nHit, float chi):
+  z0_(z0),
+  nHit_(nHit),
+  chi_(chi)
+{}
+
+ClusterCompatibility::ClusterCompatibility():
+  z0_(0.),
+  nHit_(0),
+  chi_(0.)
+{}
+
+ClusterCompatibility::~ClusterCompatibility() {}

--- a/DataFormats/HeavyIonEvent/src/ClusterCompatibility.cc
+++ b/DataFormats/HeavyIonEvent/src/ClusterCompatibility.cc
@@ -1,16 +1,18 @@
 #include "DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h"
 using namespace reco;
 
-ClusterCompatibility::ClusterCompatibility(float z0, int nHit, float chi):
-  z0_(z0),
-  nHit_(nHit),
-  chi_(chi)
-{}
-
 ClusterCompatibility::ClusterCompatibility():
-  z0_(0.),
-  nHit_(0),
-  chi_(0.)
+  nValidPixelHits_(0),
+  z0_(),
+  nHit_(),
+  chi_()
 {}
 
 ClusterCompatibility::~ClusterCompatibility() {}
+
+void
+ClusterCompatibility::append(float z0, int nHit, float chi) {
+  z0_.push_back(z0);
+  nHit_.push_back(nHit);
+  chi_.push_back(chi);
+}

--- a/DataFormats/HeavyIonEvent/src/classes.h
+++ b/DataFormats/HeavyIonEvent/src/classes.h
@@ -24,9 +24,6 @@ namespace DataFormats_HeavyIonEvent {
      reco::ClusterCompatibility clus_compat;
      edm::Wrapper<reco::ClusterCompatibility> w_clus_compat;
 
-     reco::ClusterCompatibilityCollection clus_compat_col;
-     edm::Wrapper<reco::ClusterCompatibilityCollection> w_clus_compat_col;
-
      reco::VoronoiBackground vor;
      edm::Wrapper<reco::VoronoiBackground> wvor;
 

--- a/DataFormats/HeavyIonEvent/src/classes.h
+++ b/DataFormats/HeavyIonEvent/src/classes.h
@@ -1,4 +1,5 @@
 #include "DataFormats/HeavyIonEvent/interface/Centrality.h"
+#include "DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h"
 #include "DataFormats/HeavyIonEvent/interface/EvtPlane.h"
 #include "DataFormats/HeavyIonEvent/interface/HeavyIon.h"
 #include "DataFormats/HeavyIonEvent/interface/VoronoiBackground.h"
@@ -19,6 +20,12 @@ namespace DataFormats_HeavyIonEvent {
 
      reco::EvtPlaneCollection evcol;
      edm::Wrapper<reco::EvtPlaneCollection> wevcol;
+
+     reco::ClusterCompatibility clus_compat;
+     edm::Wrapper<reco::ClusterCompatibility> w_clus_compat;
+
+     reco::ClusterCompatibilityCollection clus_compat_col;
+     edm::Wrapper<reco::ClusterCompatibilityCollection> w_clus_compat_col;
 
      reco::VoronoiBackground vor;
      edm::Wrapper<reco::VoronoiBackground> wvor;

--- a/DataFormats/HeavyIonEvent/src/classes_def.xml
+++ b/DataFormats/HeavyIonEvent/src/classes_def.xml
@@ -23,7 +23,4 @@
 <class name="edm::Wrapper<std::vector<reco::VoronoiBackground> >" />
 <class name="reco::ClusterCompatibility" />
 <class name="edm::Wrapper<reco::ClusterCompatibility>"/>
-<class name="edm::ValueMap<reco::ClusterCompatibility>" />
-<class name="std::vector<reco::ClusterCompatibility>" />
-<class name="edm::Wrapper<std::vector<reco::ClusterCompatibility> >" />
 </lcgdict>

--- a/DataFormats/HeavyIonEvent/src/classes_def.xml
+++ b/DataFormats/HeavyIonEvent/src/classes_def.xml
@@ -21,4 +21,9 @@
 <class name="edm::Wrapper<edm::ValueMap<reco::VoronoiBackground> >" />
 <class name="std::vector<reco::VoronoiBackground>" />
 <class name="edm::Wrapper<std::vector<reco::VoronoiBackground> >" />
+<class name="reco::ClusterCompatibility" />
+<class name="edm::Wrapper<reco::ClusterCompatibility>"/>
+<class name="edm::ValueMap<reco::ClusterCompatibility>" />
+<class name="std::vector<reco::ClusterCompatibility>" />
+<class name="edm::Wrapper<std::vector<reco::ClusterCompatibility> >" />
 </lcgdict>

--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -53,6 +53,7 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               * hiEgammaSequence
                                               * hiParticleFlowReco
                                               * hiCentrality
+                                              * hiClusterCompatibility
                                               * hiEvtPlane
                                               * hcalnoise
                                               )

--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -22,6 +22,7 @@ from RecoHI.Configuration.Reconstruction_hiPF_cff import *
 
 # Heavy Ion Event Characterization
 from RecoHI.HiCentralityAlgos.HiCentrality_cfi import *
+from RecoHI.HiCentralityAlgos.HiClusterCompatibility_cfi import *
 from RecoHI.HiEvtPlaneAlgos.HiEvtPlane_cfi import *
 
 # HCAL noise producer
@@ -38,6 +39,7 @@ globalRecoPbPb = cms.Sequence(hiTracking
                               * hiEgammaSequence
                               * hiParticleFlowReco
                               * hiCentrality
+                              * hiClusterCompatibility
                               * hiEvtPlane
                               * hcalnoise
                               )

--- a/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
@@ -131,34 +131,9 @@ ClusterCompatibilityProducer::produce(edm::Event& iEvent, const edm::EventSetup&
       vhits.push_back(vh);
     }
  
-    // get CompatibleHits for each z-position
-    // estimate best z-position from cluster lengths
-    double zest = 0.0;
-    reco::ClusterCompatibility chits;
-    int nhits = 0, nhits_max = 0;
-    double chi = 0.0, chi_max = 1e+9;
-    for(double z0 = minZ_; z0 <= maxZ_; z0 += zStep_) {
-      chits = getContainedHits(vhits, z0);
-      creco->push_back(chits); 
-      nhits = chits.nHit();
-      chi = chits.chi();
-      if(nhits == 0)
-        continue;
-      if(nhits > nhits_max) {
-        chi_max = 1e+9;
-        nhits_max = nhits;
-      }
-      if(nhits >= nhits_max && chi < chi_max) {
-        chi_max = chi;
-        zest = z0;
-      }
-    }
-
-    // make sure to also store best z-position +/- 10 cm
-    // if this is out of range
-    double zminus = zest - 10., zplus = zest + 10.;
-    if( zminus < minZ_ ) creco->push_back(getContainedHits(vhits, zminus));
-    if( zplus > maxZ_ ) creco->push_back(getContainedHits(vhits, zplus));
+    // produce ClusterCompatibility object for each z-position
+    for(double z0 = minZ_; z0 <= maxZ_; z0 += zStep_) 
+      creco->push_back(getContainedHits(vhits, z0));
 
   }
   iEvent.put(creco);

--- a/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
@@ -5,7 +5,7 @@
 // Original Author (of Derivative Producer):  Eric Appelt
 //         Created:  Mon Apr 27, 2015
 
-#include <tuple>
+#include <iostream>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/EDProducer.h"
@@ -168,6 +168,7 @@ ClusterCompatibilityProducer::produce(edm::Event& iEvent, const edm::EventSetup&
 
 reco::ClusterCompatibility ClusterCompatibilityProducer::getContainedHits(const std::vector<VertexHit> &hits, double z0) const
 {
+
   // Calculate number of hits contained in v-shaped window in cluster y-width vs. z-position.
   int n = 0;
   double chi = 0.;

--- a/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/ClusterCompatibilityProducer.cc
@@ -1,0 +1,199 @@
+//
+// Derived from HLTrigger/special/src/HLTPixelClusterShapeFilter.cc
+// at version 7_5_0_pre3
+//
+// Original Author (of Derivative Producer):  Eric Appelt
+//         Created:  Mon Apr 27, 2015
+
+#include <tuple>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/Common/interface/Handle.h"
+#include "DataFormats/GeometryVector/interface/LocalPoint.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiPixelRecHitCollection.h"
+#include "DataFormats/HeavyIonEvent/interface/ClusterCompatibility.h"
+
+#include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetUnit.h"
+#include "Geometry/CommonTopologies/interface/PixelTopology.h"
+#include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/CommonDetUnit/interface/GeomDet.h"
+
+
+//
+// class declaration
+//
+
+class ClusterCompatibilityProducer : public edm::EDProducer {
+
+  public:
+    explicit ClusterCompatibilityProducer(const edm::ParameterSet&);
+    ~ClusterCompatibilityProducer();
+
+  private:
+    virtual void beginJob() override ;
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    virtual void endJob() override ;
+
+    edm::EDGetTokenT<SiPixelRecHitCollection> inputToken_;
+    edm::InputTag       inputTag_;      // input tag identifying product containing pixel clusters
+    double              minZ_;          // beginning z-vertex position
+    double              maxZ_;          // end z-vertex position
+    double              zStep_;         // size of steps in z-vertex test
+
+    struct VertexHit
+    {
+      float z;
+      float r;
+      float w;
+    };
+
+    reco::ClusterCompatibility getContainedHits(const std::vector<VertexHit> &hits, double z0) const;
+
+};
+
+ClusterCompatibilityProducer::ClusterCompatibilityProducer(const edm::ParameterSet& config):
+  inputTag_     (config.getParameter<edm::InputTag>("inputTag")),
+  minZ_         (config.getParameter<double>("minZ")),
+  maxZ_         (config.getParameter<double>("maxZ")),
+  zStep_        (config.getParameter<double>("zStep"))
+{
+  inputToken_ = consumes<SiPixelRecHitCollection>(inputTag_);
+  LogDebug("") << "Using the " << inputTag_ << " input collection";
+  produces<reco::ClusterCompatibilityCollection>();
+}
+
+ClusterCompatibilityProducer::~ClusterCompatibilityProducer() {}
+
+void
+ClusterCompatibilityProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  std::auto_ptr<reco::ClusterCompatibilityCollection> creco(new reco::ClusterCompatibilityCollection());
+
+  // get hold of products from Event
+  edm::Handle<SiPixelRecHitCollection> hRecHits;
+  iEvent.getByToken(inputToken_, hRecHits);
+
+  // get tracker geometry
+  if (hRecHits.isValid()) {
+    edm::ESHandle<TrackerGeometry> trackerHandle;
+    iSetup.get<TrackerDigiGeometryRecord>().get(trackerHandle);
+    const TrackerGeometry *tgeo = trackerHandle.product();
+    const SiPixelRecHitCollection *hits = hRecHits.product();
+
+    // loop over pixel rechits
+    int nPxlHits=0;
+    std::vector<VertexHit> vhits;
+    for(SiPixelRecHitCollection::DataContainer::const_iterator hit = hits->data().begin(),
+          end = hits->data().end(); hit != end; ++hit) {
+      if (!hit->isValid())
+        continue;
+      ++nPxlHits;
+      DetId id(hit->geographicalId());
+      if(id.subdetId() != int(PixelSubdetector::PixelBarrel))
+        continue;
+      const PixelGeomDetUnit *pgdu = static_cast<const PixelGeomDetUnit*>(tgeo->idToDet(id));
+      if (1) {
+        const PixelTopology *pixTopo = &(pgdu->specificTopology());
+        std::vector<SiPixelCluster::Pixel> pixels(hit->cluster()->pixels());
+        bool pixelOnEdge = false;
+        for(std::vector<SiPixelCluster::Pixel>::const_iterator pixel = pixels.begin();
+            pixel != pixels.end(); ++pixel) {
+          int pixelX = pixel->x;
+          int pixelY = pixel->y;
+          if(pixTopo->isItEdgePixelInX(pixelX) || pixTopo->isItEdgePixelInY(pixelY)) {
+            pixelOnEdge = true;
+            break;
+          }
+        }
+        if (pixelOnEdge)
+          continue;
+      }
+
+      LocalPoint lpos = LocalPoint(hit->localPosition().x(),
+                                   hit->localPosition().y(),
+                                   hit->localPosition().z());
+      GlobalPoint gpos = pgdu->toGlobal(lpos);
+      VertexHit vh;
+      vh.z = gpos.z();
+      vh.r = gpos.perp();
+      vh.w = hit->cluster()->sizeY();
+      vhits.push_back(vh);
+    }
+ 
+    // get CompatibleHits for each z-position
+    // estimate best z-position from cluster lengths
+    double zest = 0.0;
+    reco::ClusterCompatibility chits;
+    int nhits = 0, nhits_max = 0;
+    double chi = 0.0, chi_max = 1e+9;
+    for(double z0 = minZ_; z0 <= maxZ_; z0 += zStep_) {
+      chits = getContainedHits(vhits, z0);
+      creco->push_back(chits); 
+      nhits = chits.nHit();
+      chi = chits.chi();
+      if(nhits == 0)
+        continue;
+      if(nhits > nhits_max) {
+        chi_max = 1e+9;
+        nhits_max = nhits;
+      }
+      if(nhits >= nhits_max && chi < chi_max) {
+        chi_max = chi;
+        zest = z0;
+      }
+    }
+
+    // make sure to also store best z-position +/- 10 cm
+    // if this is out of range
+    double zminus = zest - 10., zplus = zest + 10.;
+    if( zminus < minZ_ ) creco->push_back(getContainedHits(vhits, zminus));
+    if( zplus > maxZ_ ) creco->push_back(getContainedHits(vhits, zplus));
+
+  }
+  iEvent.put(creco);
+
+}
+
+
+reco::ClusterCompatibility ClusterCompatibilityProducer::getContainedHits(const std::vector<VertexHit> &hits, double z0) const
+{
+  // Calculate number of hits contained in v-shaped window in cluster y-width vs. z-position.
+  int n = 0;
+  double chi = 0.;
+
+  for(std::vector<VertexHit>::const_iterator hit = hits.begin(); hit!= hits.end(); hit++) {
+    double p = 2 * fabs(hit->z - z0)/hit->r + 0.5; // FIXME <- this comment from the HLT filter, need
+    if(fabs(p - hit->w) <= 1.) {                   //          to understand what it means
+      chi += fabs(p - hit->w);
+      n++;
+    }
+  }
+  return reco::ClusterCompatibility(z0, n, chi);
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void 
+ClusterCompatibilityProducer::beginJob()
+{
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+ClusterCompatibilityProducer::endJob()
+{
+}
+
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(ClusterCompatibilityProducer);

--- a/RecoHI/HiCentralityAlgos/python/ClusterCompatibility_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/ClusterCompatibility_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+hiClusterCompatibility = cms.EDProducer("ClusterCompatibilityProducer",
+   inputTag      = cms.InputTag( "hltSiPixelRecHits" ),
+   saveTags = cms.bool( False ),
+   minZ          = cms.double(-20.0),
+   maxZ          = cms.double(20.05),
+   zStep         = cms.double(0.2)
+)

--- a/RecoHI/HiCentralityAlgos/python/ClusterCompatibility_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/ClusterCompatibility_cfi.py
@@ -1,9 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-hiClusterCompatibility = cms.EDProducer("ClusterCompatibilityProducer",
-   inputTag      = cms.InputTag( "siPixelRecHits" ),
-   saveTags = cms.bool( False ),
-   minZ          = cms.double(-20.0),
-   maxZ          = cms.double(20.05),
-   zStep         = cms.double(0.2)
-)

--- a/RecoHI/HiCentralityAlgos/python/ClusterCompatibility_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/ClusterCompatibility_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 hiClusterCompatibility = cms.EDProducer("ClusterCompatibilityProducer",
-   inputTag      = cms.InputTag( "hltSiPixelRecHits" ),
+   inputTag      = cms.InputTag( "siPixelRecHits" ),
    saveTags = cms.bool( False ),
    minZ          = cms.double(-20.0),
    maxZ          = cms.double(20.05),

--- a/RecoHI/HiCentralityAlgos/python/HiClusterCompatibility_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/HiClusterCompatibility_cfi.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+hiClusterCompatibility = cms.EDProducer("ClusterCompatibilityProducer",
+   inputTag      = cms.InputTag( "siPixelRecHits" ),
+   saveTags = cms.bool( False ),
+   minZ          = cms.double(-40.0),
+   maxZ          = cms.double(40.05),
+   zStep         = cms.double(0.2)
+)

--- a/RecoHI/HiCentralityAlgos/python/HiClusterCompatibility_cfi.py
+++ b/RecoHI/HiCentralityAlgos/python/HiClusterCompatibility_cfi.py
@@ -2,7 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 hiClusterCompatibility = cms.EDProducer("ClusterCompatibilityProducer",
    inputTag      = cms.InputTag( "siPixelRecHits" ),
-   saveTags = cms.bool( False ),
    minZ          = cms.double(-40.0),
    maxZ          = cms.double(40.05),
    zStep         = cms.double(0.2)

--- a/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
+++ b/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
@@ -1,16 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 RecoHiCentralityFEVT = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*')
-    outputCommands = cms.untracked.vstring('keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
+    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
 
 RecoHiCentralityRECO = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*')
-    outputCommands = cms.untracked.vstring('keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
+    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
 
 RecoHiCentralityAOD = cms.PSet(
-    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*')
-    outputCommands = cms.untracked.vstring('keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
+    outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*',
+                                           'keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )

--- a/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
+++ b/RecoHI/HiCentralityAlgos/python/RecoHiCentrality_EventContent_cff.py
@@ -2,12 +2,15 @@ import FWCore.ParameterSet.Config as cms
 
 RecoHiCentralityFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*')
+    outputCommands = cms.untracked.vstring('keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
 
 RecoHiCentralityRECO = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*')
+    outputCommands = cms.untracked.vstring('keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )
 
 RecoHiCentralityAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoCentrality*_hiCentrality_*_*')
+    outputCommands = cms.untracked.vstring('keep recoClusterCompatibility*_hiClusterCompatibility_*_*')
     )


### PR DESCRIPTION
This request is to create a new "ClusterCompatibility" DataFormat and associated producer for use in the HeavyIon reconstruction scenario.

This DataFormat is required in order to facilitate a change in analysis strategy for heavy ion data in 2015, where RECO may be replaced with AOD. In previous years, RECO event content has been stored which includes pixel clusters. The pixel cluster information was used to run the HLTPixelClusterShapeFilter to remove beam scraping events from analysis samples. The ClusterCompatibility object provides a small (2.5 kB compressed) summary of the cluster-vertex compatibility information given a hypothesis of a collision vertex at several positions along the z-axis. 

From the information stored in the ClusterCompatibility object, it is possible to implement a filter with identical behavior to the HLTPixelClusterShapeFilter that does not need access to the collection of pixel clusters, which is not present in AOD. Such a filter has been implemented and tested, but is not part of this pull request. 

In addition to allowing the removal of beam scraping events from analysis samples, the ClusterCompatibility object could be used to identify PbPb collision events with multiple collision vertices. This is not currently possible using tracks, as the specialized heavy ion tracking is performed relative to a specific single vertex position.
