### PR TITLE
Better consumes interface for TrackerHitAssociator

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -52,19 +52,25 @@
 #include <vector>
 
 typedef std::pair<uint32_t, EncodedEventId> SimHitIdpr;
-
 class TrackerHitAssociator {
   
  public:
+  struct Config {
+    Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
+    bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
+    edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripToken_;
+    edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_;
+    std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit> > > cfTokens_;
+    std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simHitTokens_;
+  };
 
-  // Constructor for consumes.. it can be better..eg, this should replace the other constructors 
-  // but there are too many consts 
-  // in all the wrong places
-  TrackerHitAssociator(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
-  // Simple constructor
-  TrackerHitAssociator(const edm::Event& e); // deprecated
-  // Constructor with configurables
-  TrackerHitAssociator(const edm::Event& e, const edm::ParameterSet& conf); // deprecated
+  // The constructor supporting the consumes interface and tokens
+  TrackerHitAssociator(const edm::Event& e, const Config& config);
+
+  TrackerHitAssociator(const edm::ParameterSet& conf, edm::ConsumesCollector&& iC); // deprecated ctor supports consumes but not tokens
+  TrackerHitAssociator(const edm::Event& e); // deprecated simple ctor
+  TrackerHitAssociator(const edm::Event& e, const edm::ParameterSet& conf); // deprecated ctor with config
+
   // Destructor
   virtual ~TrackerHitAssociator(){}
   
@@ -96,9 +102,6 @@ class TrackerHitAssociator {
   std::vector<PSimHit>    associateMultiRecHit(const SiTrackerMultiRecHit * multirechit) const;
   std::vector<SimHitIdpr> associateGSMatchedRecHit(const SiTrackerGSMatchedRecHit2D * gsmrechit) const;
   
-  void processEvent(const edm::Event& theEvent);
-  void clearEvent();
-
   typedef std::map<unsigned int, std::vector<PSimHit> > simhit_map;
   simhit_map SimHitMap;
   typedef std::map<simHitCollectionID, std::vector<PSimHit> > simhit_collectionMap;
@@ -107,21 +110,12 @@ class TrackerHitAssociator {
  private:
   typedef std::vector<std::string> vstring;
 
-  void makeMaps(const edm::Event& theEvent);
-
+  void makeMaps(const edm::Event& theEvent, const Config& config);
   void makeMaps(const edm::Event& theEvent, const vstring& trackerContainers); // deprecated
 
   edm::Handle< edm::DetSetVector<StripDigiSimLink> >  stripdigisimlink;
   edm::Handle< edm::DetSetVector<PixelDigiSimLink> >  pixeldigisimlink;
-  
   bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
-  edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripToken_;
-  edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_;
-  std::vector<edm::EDGetTokenT<CrossingFrame<PSimHit> > > cfTokens_;
-  std::vector<edm::EDGetTokenT<std::vector<PSimHit> > > simHitTokens_;
-  
-};  
-
+};
 
 #endif
-

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -53,10 +53,29 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e)  :
 }
 
 //
-// Constructor with configurables. Supports consumes interface
+// Constructor supporting consumes but not tokens (deprecated) 
 //
-
 TrackerHitAssociator::TrackerHitAssociator(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
+  doPixel_( conf.getParameter<bool>("associatePixel") ),
+  doStrip_( conf.getParameter<bool>("associateStrip") ),
+  doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
+  assocHitbySimTrack_( conf.existsAs<bool>("associateHitbySimTrack") ? conf.getParameter<bool>("associateHitbySimTrack") : false) {
+
+  if(doStrip_) iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
+  if(doPixel_) iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+  if(!doTrackAssoc_) {
+    vstring trackerContainers(conf.getParameter<vstring>("ROUList"));
+    for(auto const& trackerContainer : trackerContainers) {
+      iC.consumes<CrossingFrame<PSimHit> >(edm::InputTag("mix", trackerContainer));
+      iC.consumes<std::vector<PSimHit> >(edm::InputTag("g4SimHits", trackerContainer));
+    }
+  }
+ }
+
+//
+// Constructor for Config helper class
+//
+TrackerHitAssociator::Config::Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
   doTrackAssoc_( conf.getParameter<bool>("associateRecoTracks") ),
@@ -65,7 +84,7 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::ParameterSet& conf, edm::C
   if(doStrip_) stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
   if(doPixel_) pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
   if(!doTrackAssoc_) {
-    vstring trackerContainers(conf.getParameter<vstring>("ROUList"));
+    std::vector<std::string> trackerContainers(conf.getParameter<std::vector<std::string> >("ROUList"));
     cfTokens_.reserve(trackerContainers.size());
     simHitTokens_.reserve(trackerContainers.size());
     for(auto const& trackerContainer : trackerContainers) {
@@ -74,6 +93,23 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::ParameterSet& conf, edm::C
     }
   }
  }
+
+//
+// Constructor supporting consumes interface
+//
+TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const TrackerHitAssociator::Config& config) :
+  doPixel_(config.doPixel_),
+  doStrip_(config.doStrip_),
+  doTrackAssoc_(config.doTrackAssoc_),
+  assocHitbySimTrack_(config.assocHitbySimTrack_) {
+  //if track association there is no need to access the input collections
+  if(!doTrackAssoc_) {
+    makeMaps(e, config);
+  }
+
+  if(doStrip_) e.getByToken(config.stripToken_, stripdigisimlink);
+  if(doPixel_) e.getByToken(config.pixelToken_, pixeldigisimlink);
+}
 
 //
 // Constructor with configurables (deprecated)
@@ -94,30 +130,13 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::Event& e, const edm::Param
   if(doPixel_) e.getByLabel("simSiPixelDigis", pixeldigisimlink);
 }
 
-void TrackerHitAssociator::processEvent(const edm::Event& e) {
-  //if track association there is no need to access the input collections
-  if(!doTrackAssoc_) {
-    makeMaps(e);
-  }
-
-  if(doStrip_) e.getByToken(stripToken_, stripdigisimlink);
-  if(doPixel_) e.getByToken(pixelToken_, pixeldigisimlink);
-}
-
-void TrackerHitAssociator::clearEvent() {
-  SimHitMap.clear();
-  SimHitCollMap.clear();
-}
-
-void TrackerHitAssociator::makeMaps(const edm::Event& theEvent) {
+void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHitAssociator::Config& config) {
   // Step A: Get Inputs
   //  The collections are specified via ROUList in the configuration, and can
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof)
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
 
-  clearEvent();
-
-  for(auto const& cfToken : cfTokens_) {
+  for(auto const& cfToken : config.cfTokens_) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
     int Nhits = 0;
     if (theEvent.getByToken(cfToken, cf_simhit)) {
@@ -140,7 +159,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent) {
       // std::cout << "simHits from crossing frames; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
     }
   }
-  for(auto const& simHitToken : simHitTokens_) {
+  for(auto const& simHitToken : config.simHitTokens_) {
     edm::Handle<std::vector<PSimHit> > simHits;
     int Nhits = 0;
     if(theEvent.getByToken(simHitToken, simHits)) {
@@ -170,8 +189,6 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const vstring& t
   //  The collections are specified via ROUList in the configuration, and can
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof) 
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
-
-  clearEvent();
 
   for(auto const& trackerContainer : trackerContainers) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsAnalyzer.h
@@ -221,7 +221,7 @@ class GlobalRecHitsAnalyzer : public DQMEDAnalyzer
     projectHit( const PSimHit& hit,
 		const StripGeomDetUnit* stripDet,
 		const BoundPlane& plane);
-  TrackerHitAssociator trackerHitAssociator_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   // SiPxl
 

--- a/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
+++ b/Validation/GlobalRecHits/interface/GlobalRecHitsProducer.h
@@ -269,7 +269,7 @@ class GlobalRecHitsProducer : public edm::EDProducer
     projectHit( const PSimHit& hit,
 		const StripGeomDetUnit* stripDet,
 		const BoundPlane& plane);
-  TrackerHitAssociator trackerHitAssociator_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   // SiPxl
 

--- a/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsAnalyzer.cc
@@ -15,7 +15,7 @@ using namespace std;
 
 GlobalRecHitsAnalyzer::GlobalRecHitsAnalyzer(const edm::ParameterSet& iPSet) :
   fName(""), verbosity(0), frequency(0), label(""), getAllProvenances(false),
-  printProvenanceInfo(false), trackerHitAssociator_(iPSet, consumesCollector()), count(0)
+  printProvenanceInfo(false), trackerHitAssociatorConfig_(iPSet, consumesCollector()), count(0)
 {
   consumesMany<edm::SortedCollection<HBHERecHit, edm::StrictWeakOrdering<HBHERecHit> > >();
   consumesMany<edm::SortedCollection<HFRecHit, edm::StrictWeakOrdering<HFRecHit> > >();
@@ -913,15 +913,13 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent,
     validstrip = false;
   }  
   
-  TrackerHitAssociator& associate = trackerHitAssociator_;
-  associate.processEvent(iEvent);
+  TrackerHitAssociator associate(iEvent, trackerHitAssociatorConfig_);
   
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
   if (!pDD.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
-    associate.clearEvent();
     return;
   }
   const TrackerGeometry &tracker(*pDD);
@@ -1139,7 +1137,6 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent,
   if (!geom.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
-    associate.clearEvent();
     return;
   }
 
@@ -1278,7 +1275,6 @@ void GlobalRecHitsAnalyzer::fillTrk(const edm::Event& iEvent,
   if (verbosity > 0)
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
   
-  associate.clearEvent();
   return;
 }
 

--- a/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
+++ b/Validation/GlobalRecHits/src/GlobalRecHitsProducer.cc
@@ -12,7 +12,7 @@
 
 GlobalRecHitsProducer::GlobalRecHitsProducer(const edm::ParameterSet& iPSet) :
   fName(""), verbosity(0), frequency(0), label(""), getAllProvenances(false),
-  printProvenanceInfo(false), trackerHitAssociator_(iPSet, consumesCollector()), count(0)
+  printProvenanceInfo(false), trackerHitAssociatorConfig_(iPSet, consumesCollector()), count(0)
 {
   std::string MsgLoggerCat = "GlobalRecHitsProducer_GlobalRecHitsProducer";
 
@@ -892,15 +892,13 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
     return;
   }  
 
-  TrackerHitAssociator& associate = trackerHitAssociator_;
-  associate.processEvent(iEvent);
+  TrackerHitAssociator associate(iEvent, trackerHitAssociatorConfig_);
 
   edm::ESHandle<TrackerGeometry> pDD;
   iSetup.get<TrackerDigiGeometryRecord>().get(pDD);
   if (!pDD.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
-    associate.clearEvent();
     return;
   }
   const TrackerGeometry &tracker(*pDD);
@@ -1132,7 +1130,6 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
   if (!recHitColl.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find SiPixelRecHitCollection in event!";
-    associate.clearEvent();
     return;
   }  
   
@@ -1142,7 +1139,6 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
   if (!geom.isValid()) {
     edm::LogWarning(MsgLoggerCat)
       << "Unable to find TrackerDigiGeometry in event!";
-    associate.clearEvent();
     return;
   }
   //const TrackerGeometry& theTracker(*geom);
@@ -1287,7 +1283,6 @@ void GlobalRecHitsProducer::fillTrk(edm::Event& iEvent,
   if (verbosity > 0)
     edm::LogInfo(MsgLoggerCat) << eventout << "\n";
 
-  associate.clearEvent();
   return;
 }
 

--- a/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiPixelTrackingRecHitsValid.h
@@ -85,7 +85,7 @@ class SiPixelTrackingRecHitsValid : public DQMEDAnalyzer
 
  private:
 
-  TrackerHitAssociator trackerHitAssociator_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   //TrackLocalAngle *anglefinder_;
   DQMStore* dbe_;
   bool runStandalone;

--- a/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
+++ b/Validation/RecoTrack/interface/SiStripTrackingRecHitsValid.h
@@ -421,7 +421,7 @@ class SiStripTrackingRecHitsValid : public DQMEDAnalyzer
   
 
   edm::ParameterSet conf_;
-  TrackerHitAssociator trackerHitAssociator_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   unsigned long long m_cacheID_;
   edm::ParameterSet Parameters;
 

--- a/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/plugins/SiPixelTrackingRecHitsValid.cc
@@ -110,7 +110,7 @@ void SiPixelTrackingRecHitsValid::beginJob()
 }
 
 SiPixelTrackingRecHitsValid::SiPixelTrackingRecHitsValid(const edm::ParameterSet& ps) :
-  trackerHitAssociator_(ps, consumesCollector()),
+  trackerHitAssociatorConfig_(ps, consumesCollector()),
   dbe_(0), tfile_(0), t_(0)
 {
   //Read config file
@@ -1094,7 +1094,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
   float mindist = 999999.9;
 
   std::vector<PSimHit> matched;
-  trackerHitAssociator_.processEvent(e);
+  TrackerHitAssociator associate(e, trackerHitAssociatorConfig_); 
 
   edm::ESHandle<TrackerGeometry> pDD;
   es.get<TrackerDigiGeometryRecord> ().get (pDD);
@@ -1269,7 +1269,7 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 
 		      //Association of the rechit to the simhit
 		      matched.clear();
-		      matched = trackerHitAssociator_.associateHit(*matchedhit);
+		      matched = associate.associateHit(*matchedhit);
 
 		      nsimhit = (int)matched.size();
 
@@ -1767,5 +1767,5 @@ void SiPixelTrackingRecHitsValid::analyze(const edm::Event& e, const edm::EventS
 	} // tracks > 0.
       
     } //end of MTCCTrack
-    trackerHitAssociator_.clearEvent();
+
 }

--- a/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
+++ b/Validation/RecoTrack/src/SiStripTrackingRecHitsValid.cc
@@ -43,7 +43,7 @@ class TFile;
 SiStripTrackingRecHitsValid::SiStripTrackingRecHitsValid(const edm::ParameterSet& ps) : 
   dbe_(edm::Service<DQMStore>().operator->()),	
   conf_(ps),
-  trackerHitAssociator_(ps, consumesCollector()),
+  trackerHitAssociatorConfig_(ps, consumesCollector()),
   m_cacheID_(0)
   // trajectoryInput_( ps.getParameter<edm::InputTag>("trajectoryInput") )
 {
@@ -467,8 +467,7 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event & e, const edm::Event
   DetId detid;
   uint32_t myid;
 
-  TrackerHitAssociator& associate = trackerHitAssociator_;
-  associate.processEvent(e);
+  TrackerHitAssociator associate(e, trackerHitAssociatorConfig_);
   PSimHit closest;
 
   //Retrieve tracker topology from geometry
@@ -948,7 +947,6 @@ void SiStripTrackingRecHitsValid::analyze(const edm::Event & e, const edm::Event
   }
   //cout<<"DebugLine303"<<endl;
 
-  associate.clearEvent();
 }
 
 

--- a/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiPixelRecHitsValid.h
@@ -13,8 +13,8 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
-#include <memory>
 #include <string>
 
 class DQMStore;
@@ -23,7 +23,6 @@ class MonitorElement;
 class PSimHit;
 class PixelGeomDetUnit;
 class SiPixelRecHit;
-class TrackerHitAssociator;
 class TrackerTopology;
 
 class SiPixelRecHitsValid : public DQMEDAnalyzer {
@@ -115,7 +114,7 @@ class SiPixelRecHitsValid : public DQMEDAnalyzer {
 	MonitorElement* recHitYPullDisk1Plaquettes[7];
 	MonitorElement* recHitYPullDisk2Plaquettes[7];
 
-        std::unique_ptr<TrackerHitAssociator> trackerHitAssociator_;
+        TrackerHitAssociator::Config trackerHitAssociatorConfig_;
         edm::EDGetTokenT<SiPixelRecHitCollection> siPixelRecHitCollectionToken_;
 };
 

--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -34,17 +34,16 @@
 #include "Geometry/TrackerGeometryBuilder/interface/PixelGeomDetType.h"
 #include "Geometry/TrackerGeometryBuilder/interface/StripGeomDetType.h"
 
-#include <memory>
 #include <string>
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 //For RecHit
 #include "DataFormats/TrackerRecHit2D/interface/SiStripRecHit2DCollection.h" 
 #include "DataFormats/TrackerRecHit2D/interface/SiStripMatchedRecHit2DCollection.h" 
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 class SiStripDetCabling;
 class SiStripDCSStatus;
-class TrackerHitAssociator;
 
 class SiStripRecHitsValid : public DQMEDAnalyzer {
 
@@ -206,7 +205,7 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
   inline void fillME(MonitorElement* ME,float value1,float value2,float value3,float value4){if (ME!=0)ME->Fill(value1,value2,value3,value4);}
 
   edm::ParameterSet conf_;
-  std::unique_ptr<TrackerHitAssociator> trackerHitAssociator_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   unsigned long long m_cacheID_;
   //const StripTopology* topol;
 

--- a/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiPixelRecHitsValid.cc
@@ -44,12 +44,10 @@
 #include "SimDataFormats/TrackingHit/interface/PSimHit.h"
 #include "SimDataFormats/TrackingHit/interface/PSimHitContainer.h"
 
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
-
 #include <math.h>
 
 SiPixelRecHitsValid::SiPixelRecHitsValid(const edm::ParameterSet& ps)
-  : trackerHitAssociator_(new TrackerHitAssociator(ps, consumesCollector()))
+  : trackerHitAssociatorConfig_(ps, consumesCollector())
   , siPixelRecHitCollectionToken_( consumes<SiPixelRecHitCollection>( ps.getParameter<edm::InputTag>( "src" ) ) ) {
 
 }
@@ -300,7 +298,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   es.get<TrackerDigiGeometryRecord>().get(geom); 
   const TrackerGeometry& theTracker(*geom);
   
-  trackerHitAssociator_->processEvent(e);
+  TrackerHitAssociator associate(e, trackerHitAssociatorConfig_);
   
   //iterate over detunits
   for (TrackerGeometry::DetContainer::const_iterator it = geom->dets().begin(); it != geom->dets().end(); it++) 
@@ -324,7 +322,7 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
       for ( ; pixeliter != pixelrechitRangeIteratorEnd; pixeliter++) 
 	{
 	  matched.clear();
-	  matched = trackerHitAssociator_->associateHit(*pixeliter);
+	  matched = associate.associateHit(*pixeliter);
 	  
 	  if ( !matched.empty() ) 
 	    {
@@ -384,7 +382,6 @@ void SiPixelRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
 	    }
 	} // <-----end rechit loop 
     } // <------ end detunit loop
-  trackerHitAssociator_->clearEvent();
 }
 
 void SiPixelRecHitsValid::fillBarrel(const SiPixelRecHit& recHit, const PSimHit& simHit, 

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -1,5 +1,4 @@
 #include "Validation/TrackerRecHits/interface/SiStripRecHitsValid.h"
-#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h" 
 
 //needed for the geometry: 
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
@@ -47,7 +46,7 @@ namespace helper {
 //Constructor
 SiStripRecHitsValid::SiStripRecHitsValid(const ParameterSet& ps) :
   conf_(ps),
-  trackerHitAssociator_(new TrackerHitAssociator(ps, consumesCollector())),
+  trackerHitAssociatorConfig_(ps, consumesCollector()),
   m_cacheID_(0)
   // matchedRecHits_( ps.getParameter<edm::InputTag>("matchedRecHits") ),
   // rphiRecHits_( ps.getParameter<edm::InputTag>("rphiRecHits") ),
@@ -231,8 +230,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   int totrechitstereo =0;
   int totrechitmatched =0;
    
-  TrackerHitAssociator& associate = *trackerHitAssociator_;
-  associate.processEvent(e);
+  TrackerHitAssociator associate(e, trackerHitAssociatorConfig_);
   
   edm::ESHandle<TrackerGeometry> pDD;
   es.get<TrackerDigiGeometryRecord> ().get (pDD);
@@ -410,7 +408,6 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   fillME(totalMEs.meNumTotStereo,totrechitstereo);
   fillME(totalMEs.meNumTotMatched,totrechitmatched);
  
-  associate.clearEvent();
 }
 
   


### PR DESCRIPTION
This PR replaces the previous consumes interface for TrackerHitAssociator (implemented in #8647) with a much better interface.  Prior to #8647, each TrackerHitAssociator instance was created and destroyed on a per event per module basis, which guaranteed that each auxiliary structure (e.g. map of PSimHits) were deleted as soon as it was no longer needed.  PR #8647 unfortunately extended the lifetime of each TrackerHitAssociator instance to be the entire job, so that each map needed to be manually deleted.  This is an error prone interface.
This new interface restores the lifetime of each TrackerHitAssociator instance to be per module per event, which automatically guarantees that the memory problems will not occur.  The consumes interface is implemented by using a helper class TrackerHitAssociator::Config.  Instances of this helper class do last the entire job, but this helper class does not contain any per event data, so there are no memory issues.
Although this PR needs to be tested, it should be expedited, as use of the consumes interface for other TrackerHitAssociator users (there are many) depends on this PR, and development will be hindered if this is not merged in a timely manner.  I would strongly suggest that L2 signatures be bypassed if not signed in a timely manner, unless, of course, an L2 has issues with this PR.
