### PR TITLE
auto pseudo parabolic for data taking or field from DB for B 0T mostly

### DIFF
--- a/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
@@ -5,7 +5,17 @@ import FWCore.ParameterSet.Config as cms
 from MagneticField.Engine.autoMagneticFieldProducer_cfi import *
 
 # Parabolic parametrized magnetic field used for track building
-from MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi import ParametrizedMagneticFieldProducer as ParabolicParametrizedMagneticFieldProducer
-ParabolicParametrizedMagneticFieldProducer.label = "ParabolicMf"
+from MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi import ParametrizedMagneticFieldProducer as ParabolicParametrizedMagneticFieldProducer38T
+ParabolicParametrizedMagneticFieldProducer38T.label = "ParabolicMf38T"
+
+AutoParabolicParametrizedMagneticFieldProducer = cms.ESProducer("AutoMagneticFieldESProducer",
+    # if positive, set B value (in kGauss), overriding the current reading from DB
+    valueOverride = cms.int32(-1),
+    nominalCurrents = cms.untracked.vint32(-1, 0,9558,14416,16819,18268,19262),
+    mapLabels = cms.untracked.vstring("ParabolicMf38T",
+                                      "slave_0", "slave_20", "slave_30", "slave_35", 
+                                      "ParabolicMf38T", "slave_40" ),
+   label = cms.untracked.string('ParabolicMf')
+)
 
 

--- a/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
@@ -5,8 +5,8 @@ import FWCore.ParameterSet.Config as cms
 from MagneticField.Engine.autoMagneticFieldProducer_cfi import *
 
 # Parabolic parametrized magnetic field used for track building
-from MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi import ParametrizedMagneticFieldProducer as ParabolicParametrizedMagneticFieldProducer38T
-ParabolicParametrizedMagneticFieldProducer38T.label = "ParabolicMf38T"
+import MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi
+ParabolicParametrizedMagneticFieldProducer38T = MagneticField.ParametrizedEngine.ParabolicParametrizedField_cfi.ParametrizedMagneticFieldProducer.clone( label = "ParabolicMf38T" )
 
 AutoParabolicParametrizedMagneticFieldProducer = cms.ESProducer("AutoMagneticFieldESProducer",
     # if positive, set B value (in kGauss), overriding the current reading from DB

--- a/MagneticField/ParametrizedEngine/src/OAEParametrizedMagneticField.h
+++ b/MagneticField/ParametrizedEngine/src/OAEParametrizedMagneticField.h
@@ -32,6 +32,8 @@ class OAEParametrizedMagneticField : public MagneticField {
   /// Destructor
   virtual ~OAEParametrizedMagneticField();
   
+  virtual MagneticField* clone() const { return new OAEParametrizedMagneticField(*this);}
+
   GlobalVector inTesla (const GlobalPoint& gp) const;
 
   GlobalVector inTeslaUnchecked (const GlobalPoint& gp) const;

--- a/MagneticField/ParametrizedEngine/src/ParabolicParametrizedMagneticField.h
+++ b/MagneticField/ParametrizedEngine/src/ParabolicParametrizedMagneticField.h
@@ -25,6 +25,8 @@ class ParabolicParametrizedMagneticField : public MagneticField {
   /// Destructor
   virtual ~ParabolicParametrizedMagneticField();
   
+  virtual MagneticField* clone() const { return new ParabolicParametrizedMagneticField(*this);}
+
   GlobalVector inTesla (const GlobalPoint& gp) const;
 
   GlobalVector inTeslaUnchecked (const GlobalPoint& gp) const;

--- a/MagneticField/UniformEngine/src/UniformMagneticField.h
+++ b/MagneticField/UniformEngine/src/UniformMagneticField.h
@@ -19,6 +19,8 @@ class UniformMagneticField : public MagneticField {
 
   virtual ~UniformMagneticField() {}
 
+  virtual MagneticField* clone() const { return new UniformMagneticField(*this);}
+
   GlobalVector inTesla (const GlobalPoint& gp) const;
 
   GlobalVector inTeslaUnchecked (const GlobalPoint& gp) const;


### PR DESCRIPTION
This provides a python-based auto-selection of the field to be served in the tracker as parabolicMF.
- proper parabolic for 3.8 T
- uniform 0 for 0 T
- parameterized engine values for intermediate field values
