### PR TITLE
 auto pseudo parabolic for data taking or field from DB for B 0T mostly (fix of #9009 )

### DIFF
--- a/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
+++ b/Configuration/StandardSequences/python/MagneticField_AutoFromDBCurrent_cff.py
@@ -18,4 +18,4 @@ AutoParabolicParametrizedMagneticFieldProducer = cms.ESProducer("AutoMagneticFie
    label = cms.untracked.string('ParabolicMf')
 )
 
-
+es_prefer_ParabolicMf = cms.ESPrefer("AutoMagneticFieldESProducer", "AutoParabolicParametrizedMagneticFieldProducer")


### PR DESCRIPTION
This provides a python-based auto-selection of the field to be served in the tracker as parabolicMF.
- proper parabolic for 3.8 T
- uniform 0 for 0 T
- parameterized engine values for intermediate field values
