### PR TITLE
Fix of the LInking in PF for forward tracks

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/ClusterImporterForForwardTracker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/ClusterImporterForForwardTracker.cc
@@ -56,12 +56,15 @@ importToBlock( const edm::Event& e,
 	<< "Layer given, " << clus->layer() << " is not a valid PFLayer!";
     }
 
+    
+
     //Outside tracker call it HF
     if (type == reco::PFBlockElement::ECAL && 
-	clus->layer()== PFLayer::HF_EM && abs(clus->position().Eta())>3.8)
+	clus->layer()== PFLayer::HF_EM && fabs(clus->position().Eta())>3.8)
             type = reco::PFBlockElement::HFEM;
+    
     if (type == reco::PFBlockElement::HCAL && 
-	clus->layer()== PFLayer::HF_HAD && abs(clus->position().Eta())>3.8)
+	clus->layer()== PFLayer::HF_HAD && fabs(clus->position().Eta())>3.8)
             type = reco::PFBlockElement::HFHAD;
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -247,14 +247,6 @@ def cust_2023SHCal(process):
         #process.uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
 
-
-        for link in process.particleFlowBlock.linkDefinitions:
-            if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.0)
-        for importer in process.particleFlowBlock.elementImporters :
-            if importer.source.value()=="particleFlowClusterHF" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
-
-
-
     if hasattr(process,'validation_step'):
         process.ecalEndcapClusterTaskExtras.EcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.ecalEndcapRecoSummary.recHitCollection_EE = cms.InputTag("ecalRecHit","EcalRecHitsEK")

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -246,6 +246,15 @@ def cust_2023SHCal(process):
         #process.correctedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         #process.uncleanedOnlyCorrectedMulti5x5SuperClustersWithPreshower.recHitProducer = cms.InputTag("ecalRecHit","EcalRecHitsEK")
 
+
+
+        for link in process.particleFlowBlock.linkDefinitions:
+            if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.0)
+        for importer in process.particleFlowBlock.elementImporters :
+            if importer.source.value()=="particleFlowClusterHF" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
+
+
+
     if hasattr(process,'validation_step'):
         process.ecalEndcapClusterTaskExtras.EcalRecHitCollection = cms.InputTag("ecalRecHit","EcalRecHitsEK")
         process.ecalEndcapRecoSummary.recHitCollection_EE = cms.InputTag("ecalRecHit","EcalRecHitsEK")

--- a/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
@@ -5,8 +5,8 @@ def customise_extendedTrackerBarrel( process ) :
         for link in process.particleFlowBlock.linkDefinitions:
             if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.0)
         for importer in process.particleFlowBlock.elementImporters :
-            if importer.source.value()=="particleFlowClusterHFEM" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
-            if importer.source.value()=="particleFlowClusterHFHAD" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
+            if importer.source.value()=="particleFlowClusterHF" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
+
     return process
 
 def customise_use3DHCalClusters( process ) :


### PR DESCRIPTION
Reactivates linking for tracker -HF  and forward region  (was deactivated since some customizations were not migrated with the migration of the 3D  clustering  in the upgrade + a fix of a small bug 
[switching on the linking of tracks between 3.5-4.0]  No more double counting should be seen module track propagation issues [tricky to extrapolate 0.5 GeV Pt tracks in HF but HF cells large so it works]
