### PR TITLE
New Heavy Ion Tracking Sequence and pT-Dependent Cut for MultiTrackSelector

### DIFF
--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -7,6 +7,9 @@ from RecoHI.HiTracking.HITrackingRegionProducer_cfi import *
 
 from RecoPixelVertexing.PixelTrackFitting.PixelFitterByConformalMappingAndLine_cfi import *
 
+from RecoHI.HiTracking.hiMultiTrackSelector_cfi import *
+from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import *
+
 hiConformalPixelTracks = cms.EDProducer("PixelTrackProducer",
                                         
                                         #passLabel  = cms.string('Pixel triplet low-pt tracks with vertex constraint'),
@@ -22,7 +25,7 @@ hiConformalPixelTracks = cms.EDProducer("PixelTrackProducer",
                                         # Ordered Hits
                                         OrderedHitsFactoryPSet = cms.PSet( 
     ComponentName = cms.string( "StandardHitTripletGenerator" ),
-    SeedingLayers = cms.string( "PixelLayerTriplets" ),
+    SeedingLayers = cms.InputTag( "PixelLayerTriplets" ),
     GeneratorPSet = cms.PSet( 
     PixelTripletHLTGenerator
     )
@@ -49,3 +52,86 @@ hiConformalPixelTracks.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = 5000000
 
 hiConformalPixelTracks.FitterPSet.fixImpactParameter = cms.double(0.0)
 hiConformalPixelTracks.FitterPSet.TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets')
+
+# Selector for quality pixel tracks with tapering high-pT cut
+
+#loose
+hiPixelOnlyStepLooseMTS = hiLooseMTS.clone(
+    name= cms.string('hiPixelOnlyTrkLoose'),
+    chi2n_no1Dmod_par = cms.double(25.0),
+    d0_par2 = cms.vdouble(9999.0, 0.0),              # d0E from tk.d0Error
+    dz_par2 = cms.vdouble(14.0, 0.0), 
+    max_relpterr = cms.double(9999.),
+    min_nhits = cms.uint32(0),
+    applyHIonCuts = cms.bool(True),
+    hIon_pTMaxCut = cms.vdouble(10,5,25,2.5)
+)
+
+hiPixelOnlyStepTightMTS=hiPixelOnlyStepLooseMTS.clone(
+    preFilterName='hiPixelOnlyTrkLoose',
+    chi2n_no1Dmod_par = cms.double(18.0),
+    dz_par2 = cms.vdouble(12.0, 0.0),
+    hIon_pTMaxCut = cms.vdouble(4,2,18,2.5),
+    name= cms.string('hiPixelOnlyTrkTight'),
+    qualityBit = cms.string('tight'),
+    keepAllTracks= cms.bool(True)
+    )
+
+hiPixelOnlyStepHighpurityMTS= hiPixelOnlyStepTightMTS.clone(
+    name= cms.string('hiPixelOnlyTrkHighPurity'),
+    preFilterName='hiPixelOnlyTrkTight',
+    chi2n_no1Dmod_par = cms.double(12.),    
+    dz_par2 = cms.vdouble(10.0, 0.0),
+    hIon_pTMaxCut = cms.vdouble(2.4,1.6,12,2.5),
+    qualityBit = cms.string('highPurity') ## set to '' or comment out if you dont want to set the bit
+    )
+
+hiPixelOnlyStepSelector = hiMultiTrackSelector.clone(
+    src='hiConformalPixelTracks',
+    trackSelectors= cms.VPSet(
+        hiPixelOnlyStepLooseMTS,
+        hiPixelOnlyStepTightMTS,
+        hiPixelOnlyStepHighpurityMTS
+    ) #end of vpset
+    ) #end of clone
+
+
+# selector for tapered full tracks
+
+hiHighPtStepTruncMTS = hiLooseMTS.clone(
+    name= cms.string('hiHighPtTrkTrunc'),
+    chi2n_no1Dmod_par = cms.double(9999.0),
+    d0_par2 = cms.vdouble(9999.0, 0.0),              # d0E from tk.d0Error
+    dz_par2 = cms.vdouble(9999.0, 0.0),
+    max_relpterr = cms.double(9999.),
+    min_nhits = cms.uint32(12),
+    applyHIonCuts = cms.bool(True),
+    hIon_pTMinCut = cms.vdouble(1.0,1.8,0.15,2.5),
+    qualityBit = cms.string('')
+)
+
+hiHighPtStepSelector = hiMultiTrackSelector.clone(
+    src='hiGeneralTracks',
+    trackSelectors= cms.VPSet(
+        hiHighPtStepTruncMTS
+    ) #end of vpset
+    ) #end of clone
+
+
+# make final collection, unmerged for now
+
+hiGeneralAndPixelTracks = trackListMerger.clone(
+    TrackProducers = cms.VInputTag(cms.InputTag('hiConformalPixelTracks'),
+                          cms.InputTag('hiGeneralTracks')
+                     ),
+    hasSelector=cms.vint32(1,1),
+    selectedTrackQuals = cms.VInputTag(
+    cms.InputTag("hiPixelOnlyStepSelector","hiPixelOnlyTrkHighPurity"),
+    cms.InputTag("hiHighPtStepSelector","hiHighPtTrkTrunc")
+#    cms.InputTag('')
+    ),                    
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(False)), 
+                             ),
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False)
+    )

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -104,6 +104,7 @@ hiHighPtStepTruncMTS = hiLooseMTS.clone(
     d0_par2 = cms.vdouble(9999.0, 0.0),              # d0E from tk.d0Error
     dz_par2 = cms.vdouble(9999.0, 0.0),
     max_relpterr = cms.double(9999.),
+    minHitsToBypassChecks = cms.uint32(9999),
     min_nhits = cms.uint32(12),
     applyHIonCuts = cms.bool(True),
     hIon_pTMinCut = cms.vdouble(1.0,1.8,0.15,2.5),

--- a/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
+++ b/RecoHI/HiTracking/python/HILowPtConformalPixelTracks_cfi.py
@@ -2,13 +2,9 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoPixelVertexing.PixelTriplets.PixelTripletHLTGenerator_cfi import *
 from RecoPixelVertexing.PixelLowPtUtilities.ClusterShapeHitFilterESProducer_cfi import *
+from RecoPixelVertexing.PixelTrackFitting.PixelFitterByConformalMappingAndLine_cfi import *
 from RecoHI.HiTracking.HIPixelTrackFilter_cfi import *
 from RecoHI.HiTracking.HITrackingRegionProducer_cfi import *
-
-from RecoPixelVertexing.PixelTrackFitting.PixelFitterByConformalMappingAndLine_cfi import *
-
-from RecoHI.HiTracking.hiMultiTrackSelector_cfi import *
-from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import *
 
 hiConformalPixelTracks = cms.EDProducer("PixelTrackProducer",
                                         
@@ -52,87 +48,3 @@ hiConformalPixelTracks.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = 5000000
 
 hiConformalPixelTracks.FitterPSet.fixImpactParameter = cms.double(0.0)
 hiConformalPixelTracks.FitterPSet.TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelTriplets')
-
-# Selector for quality pixel tracks with tapering high-pT cut
-
-#loose
-hiPixelOnlyStepLooseMTS = hiLooseMTS.clone(
-    name= cms.string('hiPixelOnlyTrkLoose'),
-    chi2n_no1Dmod_par = cms.double(25.0),
-    d0_par2 = cms.vdouble(9999.0, 0.0),              # d0E from tk.d0Error
-    dz_par2 = cms.vdouble(14.0, 0.0), 
-    max_relpterr = cms.double(9999.),
-    min_nhits = cms.uint32(0),
-    applyHIonCuts = cms.bool(True),
-    hIon_pTMaxCut = cms.vdouble(10,5,25,2.5)
-)
-
-hiPixelOnlyStepTightMTS=hiPixelOnlyStepLooseMTS.clone(
-    preFilterName='hiPixelOnlyTrkLoose',
-    chi2n_no1Dmod_par = cms.double(18.0),
-    dz_par2 = cms.vdouble(12.0, 0.0),
-    hIon_pTMaxCut = cms.vdouble(4,2,18,2.5),
-    name= cms.string('hiPixelOnlyTrkTight'),
-    qualityBit = cms.string('tight'),
-    keepAllTracks= cms.bool(True)
-    )
-
-hiPixelOnlyStepHighpurityMTS= hiPixelOnlyStepTightMTS.clone(
-    name= cms.string('hiPixelOnlyTrkHighPurity'),
-    preFilterName='hiPixelOnlyTrkTight',
-    chi2n_no1Dmod_par = cms.double(12.),    
-    dz_par2 = cms.vdouble(10.0, 0.0),
-    hIon_pTMaxCut = cms.vdouble(2.4,1.6,12,2.5),
-    qualityBit = cms.string('highPurity') ## set to '' or comment out if you dont want to set the bit
-    )
-
-hiPixelOnlyStepSelector = hiMultiTrackSelector.clone(
-    src='hiConformalPixelTracks',
-    trackSelectors= cms.VPSet(
-        hiPixelOnlyStepLooseMTS,
-        hiPixelOnlyStepTightMTS,
-        hiPixelOnlyStepHighpurityMTS
-    ) #end of vpset
-    ) #end of clone
-
-
-# selector for tapered full tracks
-
-hiHighPtStepTruncMTS = hiLooseMTS.clone(
-    name= cms.string('hiHighPtTrkTrunc'),
-    chi2n_no1Dmod_par = cms.double(9999.0),
-    d0_par2 = cms.vdouble(9999.0, 0.0),              # d0E from tk.d0Error
-    dz_par2 = cms.vdouble(9999.0, 0.0),
-    max_relpterr = cms.double(9999.),
-    minHitsToBypassChecks = cms.uint32(9999),
-    min_nhits = cms.uint32(12),
-    applyHIonCuts = cms.bool(True),
-    hIon_pTMinCut = cms.vdouble(1.0,1.8,0.15,2.5),
-    qualityBit = cms.string('')
-)
-
-hiHighPtStepSelector = hiMultiTrackSelector.clone(
-    src='hiGeneralTracks',
-    trackSelectors= cms.VPSet(
-        hiHighPtStepTruncMTS
-    ) #end of vpset
-    ) #end of clone
-
-
-# make final collection, unmerged for now
-
-hiGeneralAndPixelTracks = trackListMerger.clone(
-    TrackProducers = cms.VInputTag(cms.InputTag('hiConformalPixelTracks'),
-                          cms.InputTag('hiGeneralTracks')
-                     ),
-    hasSelector=cms.vint32(1,1),
-    selectedTrackQuals = cms.VInputTag(
-    cms.InputTag("hiPixelOnlyStepSelector","hiPixelOnlyTrkHighPurity"),
-    cms.InputTag("hiHighPtStepSelector","hiHighPtTrkTrunc")
-#    cms.InputTag('')
-    ),                    
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(False)), 
-                             ),
-    copyExtras = True,
-    makeReKeyedSeeds = cms.untracked.bool(False)
-    )

--- a/RecoHI/HiTracking/python/HIPixelTrackFilter_cfi.py
+++ b/RecoHI/HiTracking/python/HIPixelTrackFilter_cfi.py
@@ -40,6 +40,7 @@ HiProtoTrackFilterBlock = cms.PSet(
 
 HiConformalPixelFilterBlock = cms.PSet(
     ComponentName = cms.string( "HIPixelTrackFilter" ),
+    clusterShapeCacheSrc = cms.InputTag("siPixelClusterShapeCache"),
     ptMin = cms.double( 0.2 ),
     chi2 = cms.double( 80.0 ),
     useClusterShape = cms.bool( False ),

--- a/RecoHI/HiTracking/python/HITrackingRegionProducer_cfi.py
+++ b/RecoHI/HiTracking/python/HITrackingRegionProducer_cfi.py
@@ -17,7 +17,7 @@ HiTrackingRegionWithVertexBlock = cms.PSet(
 
 # global tracking region for low-pt pixel tracks
 HiLowPtTrackingRegionWithVertexBlock = cms.PSet(
-    ptMin         = cms.double(0.2),
+    ptMin         = cms.double(0.25),
     originRadius  = cms.double(0.2),
     nSigmaZ       = cms.double(3.0),
     beamSpot      = cms.InputTag("offlineBeamSpot"),

--- a/RecoHI/HiTracking/python/HiTracking_cff.py
+++ b/RecoHI/HiTracking/python/HiTracking_cff.py
@@ -1,5 +1,5 @@
 
-from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
+from RecoHI.HiTracking.hiMergedConformalPixelTracking_cff import *
 from RecoHI.HiTracking.LowPtTracking_PbPb_cff import *
 from RecoHI.HiTracking.hiLowPtTripletStep_cff import *
 from RecoHI.HiTracking.hiMixedTripletStep_cff import *
@@ -23,11 +23,7 @@ hiTracking = cms.Sequence(
     )
 
 hiTracking_wConformalPixel = cms.Sequence(
-    hiBasicTracking
-    *hiDetachedTripletStep
-    *hiLowPtTripletStep
-    *hiPixelPairStep
-    *hiGeneralTracks
-    *hiConformalPixelTracks    
+    hiTracking
+    *hiMergedConformalPixelTracking 
     )
 

--- a/RecoHI/HiTracking/python/RecoHiTracker_EventContent_cff.py
+++ b/RecoHI/HiTracking/python/RecoHiTracker_EventContent_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 RecoHiTrackerFEVT = cms.PSet(
     outputCommands = cms.untracked.vstring(
 		'keep *_hiGeneralTracks_*_*', 
-                'keep *_hiConformalPixelTracks_*_*',
+                'keep *_hiGeneralAndPixelTracks_*_*',
 		'keep *_hiPixel3PrimTracks_*_*', 
 		'keep *_hiPixel3ProtoTracks_*_*',	
 		'keep *_hiSelectedProtoTracks_*_*',	
@@ -27,7 +27,7 @@ RecoHiTrackerLocalFEVT = cms.PSet(
 RecoHiTrackerRECO = cms.PSet(
     outputCommands = cms.untracked.vstring(
 		'keep *_hiGeneralTracks_*_*', 
-                'keep *_hiConformalPixelTracks_*_*',
+                'keep *_hiGeneralAndPixelTracks_*_*',
 		'keep recoVertexs_hiPixelMedianVertex_*_*',  
 		'keep recoVertexs_hiPixelAdaptiveVertex_*_*',  
 		'keep recoVertexs_hiSelectedVertex_*_*',
@@ -46,7 +46,7 @@ RecoHiTrackerLocalRECO = cms.PSet(
 #AOD content
 RecoHiTrackerAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoTracks_hiGeneralTracks_*_*',
-                                           'keep recoTracks_hiConformalPixelTracks_*_*',
+                                           'keep recoTracks_hiGeneralAndPixelTracks_*_*',
                                            'keep recoVertexs_hiSelectedVertex_*_*'		
     )
 )

--- a/RecoHI/HiTracking/python/hiMergedConformalPixelTracking_cff.py
+++ b/RecoHI/HiTracking/python/hiMergedConformalPixelTracking_cff.py
@@ -1,0 +1,93 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoHI.HiTracking.HILowPtConformalPixelTracks_cfi import *
+from RecoHI.HiTracking.hiMultiTrackSelector_cfi import *
+from RecoTracker.FinalTrackSelectors.trackListMerger_cfi import *
+
+# Selector for quality pixel tracks with tapering high-pT cut
+
+#loose
+hiPixelOnlyStepLooseMTS = hiLooseMTS.clone(
+    name= cms.string('hiPixelOnlyTrkLoose'),
+    chi2n_no1Dmod_par = cms.double(25.0),
+    d0_par2 = cms.vdouble(9999.0, 0.0),              # d0E from tk.d0Error
+    dz_par2 = cms.vdouble(14.0, 0.0), 
+    max_relpterr = cms.double(9999.),
+    min_nhits = cms.uint32(0),
+    applyHIonCuts = cms.bool(True),
+    hIon_pTMaxCut = cms.vdouble(10,5,25,2.5)
+)
+
+hiPixelOnlyStepTightMTS=hiPixelOnlyStepLooseMTS.clone(
+    preFilterName='hiPixelOnlyTrkLoose',
+    chi2n_no1Dmod_par = cms.double(18.0),
+    dz_par2 = cms.vdouble(12.0, 0.0),
+    hIon_pTMaxCut = cms.vdouble(4,2,18,2.5),
+    name= cms.string('hiPixelOnlyTrkTight'),
+    qualityBit = cms.string('tight'),
+    keepAllTracks= cms.bool(True)
+    )
+
+hiPixelOnlyStepHighpurityMTS= hiPixelOnlyStepTightMTS.clone(
+    name= cms.string('hiPixelOnlyTrkHighPurity'),
+    preFilterName='hiPixelOnlyTrkTight',
+    chi2n_no1Dmod_par = cms.double(12.),    
+    dz_par2 = cms.vdouble(10.0, 0.0),
+    hIon_pTMaxCut = cms.vdouble(2.4,1.6,12,2.5),
+    qualityBit = cms.string('highPurity') ## set to '' or comment out if you dont want to set the bit
+    )
+
+hiPixelOnlyStepSelector = hiMultiTrackSelector.clone(
+    src='hiConformalPixelTracks',
+    trackSelectors= cms.VPSet(
+        hiPixelOnlyStepLooseMTS,
+        hiPixelOnlyStepTightMTS,
+        hiPixelOnlyStepHighpurityMTS
+    )
+    )
+
+
+# selector for tapered full tracks
+
+hiHighPtStepTruncMTS = hiLooseMTS.clone(
+    name= cms.string('hiHighPtTrkTrunc'),
+    chi2n_no1Dmod_par = cms.double(9999.0),
+    d0_par2 = cms.vdouble(9999.0, 0.0),              # d0E from tk.d0Error
+    dz_par2 = cms.vdouble(9999.0, 0.0),
+    max_relpterr = cms.double(9999.),
+    minHitsToBypassChecks = cms.uint32(9999),
+    min_nhits = cms.uint32(12),
+    applyHIonCuts = cms.bool(True),
+    hIon_pTMinCut = cms.vdouble(1.0,1.8,0.15,2.5),
+    qualityBit = cms.string('')
+)
+
+hiHighPtStepSelector = hiMultiTrackSelector.clone(
+    src='hiGeneralTracks',
+    trackSelectors= cms.VPSet(
+        hiHighPtStepTruncMTS
+    ) 
+    ) 
+
+
+hiGeneralAndPixelTracks = trackListMerger.clone(
+    TrackProducers = cms.VInputTag(cms.InputTag('hiConformalPixelTracks'),
+                          cms.InputTag('hiGeneralTracks')
+                     ),
+    hasSelector=cms.vint32(1,1),
+    selectedTrackQuals = cms.VInputTag(
+    cms.InputTag("hiPixelOnlyStepSelector","hiPixelOnlyTrkHighPurity"),
+    cms.InputTag("hiHighPtStepSelector","hiHighPtTrkTrunc")
+    ),                    
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1), pQual=cms.bool(False)), 
+                             ),
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False)
+    )
+
+hiMergedConformalPixelTracking = cms.Sequence(
+    hiConformalPixelTracks
+    *hiPixelOnlyStepSelector
+    *hiHighPtStepSelector
+    *hiGeneralAndPixelTracks
+    )

--- a/RecoHI/HiTracking/python/hiMultiTrackSelector_cfi.py
+++ b/RecoHI/HiTracking/python/hiMultiTrackSelector_cfi.py
@@ -29,6 +29,13 @@ hiLooseMTS = cms.PSet(
     max_d0 = cms.double(1000),
     nSigmaZ = cms.double(9999.),
 
+    #  Boolean indicating if HIon related cuts are to be applied
+    applyHIonCuts = cms.bool(False),
+    
+    #  parameters for HIon pT dependent chi2 cut
+    hIon_pTMinCut = cms.vdouble(0.0001,0.000,9999,1.0),
+    hIon_pTMaxCut = cms.vdouble(9998,9999,9999,1.0),
+
    # Cuts on numbers of layers with hits/3D hits/lost hits.
     minNumberLayers = cms.uint32(0),
     minNumber3DLayers = cms.uint32(0),

--- a/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/AnalyticalTrackSelector.cc
@@ -88,6 +88,9 @@ AnalyticalTrackSelector::AnalyticalTrackSelector( const edm::ParameterSet & cfg 
     max_d0_.reserve(1);
     max_z0_.reserve(1);
     nSigmaZ_.reserve(1);
+    applyHIonCuts_.reserve(1);
+    hIon_pTMinCut_.reserve(1);
+    hIon_pTMaxCut_.reserve(1);
     min_layers_.reserve(1);
     min_3Dlayers_.reserve(1);
     max_lostLayers_.reserve(1);
@@ -139,6 +142,10 @@ AnalyticalTrackSelector::AnalyticalTrackSelector( const edm::ParameterSet & cfg 
     max_d0_.push_back(cfg.getParameter<double>("max_d0"));
     max_z0_.push_back(cfg.getParameter<double>("max_z0"));
     nSigmaZ_.push_back(cfg.getParameter<double>("nSigmaZ"));
+
+    // Heavy Ion Specific cuts for low-pT pixel tracking are not implemented
+    applyHIonCuts_.push_back(false);
+
     // Cuts on numbers of layers with hits/3D hits/lost hits.
     min_layers_.push_back(cfg.getParameter<uint32_t>("minNumberLayers") );
     min_3Dlayers_.push_back(cfg.getParameter<uint32_t>("minNumber3DLayers") );

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -108,6 +108,9 @@ MultiTrackSelector::MultiTrackSelector( const edm::ParameterSet & cfg ) :
   max_d0_.reserve(trkSelectors.size());
   max_z0_.reserve(trkSelectors.size());
   nSigmaZ_.reserve(trkSelectors.size());
+  applyHIonCuts_.reserve(trkSelectors.size());
+  hIon_pTMinCut_.reserve(trkSelectors.size());
+  hIon_pTMaxCut_.reserve(trkSelectors.size());
   min_layers_.reserve(trkSelectors.size());
   min_3Dlayers_.reserve(trkSelectors.size());
   max_lostLayers_.reserve(trkSelectors.size());
@@ -149,6 +152,11 @@ MultiTrackSelector::MultiTrackSelector( const edm::ParameterSet & cfg ) :
     max_d0_.push_back(trkSelectors[i].getParameter<double>("max_d0"));
     max_z0_.push_back(trkSelectors[i].getParameter<double>("max_z0"));
     nSigmaZ_.push_back(trkSelectors[i].getParameter<double>("nSigmaZ"));
+    // Boolean indicating if HIon related cuts are to be applied
+    applyHIonCuts_.push_back(trkSelectors[i].getParameter<bool>("applyHIonCuts"));
+    // parameters for HIon pT dependent chi2 cuts
+    hIon_pTMinCut_.push_back(trkSelectors[i].getParameter< std::vector<double> >("hIon_pTMinCut"));
+    hIon_pTMaxCut_.push_back(trkSelectors[i].getParameter< std::vector<double> >("hIon_pTMaxCut"));
     // Cuts on numbers of layers with hits/3D hits/lost hits.
     min_layers_.push_back(trkSelectors[i].getParameter<uint32_t>("minNumberLayers") );
     min_3Dlayers_.push_back(trkSelectors[i].getParameter<uint32_t>("minNumber3DLayers") );
@@ -432,7 +440,22 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
   float lostMidFrac = tk.numberOfLostHits() / (tk.numberOfValidHits() + tk.numberOfLostHits());
   if (lostMidFrac > max_lostHitFraction_[tsNum]) return false;
 
-
+  // HIon pT dependent cuts
+  if( applyHIonCuts_[tsNum] )
+  {
+    // hard cut at absolute min/max pt
+    if( pt < hIon_pTMinCut_[tsNum][0] ) return false;
+    if( pt > hIon_pTMaxCut_[tsNum][0] ) return false;
+    // tapering cuts with chi2n_no1Dmod 
+    double pTMaxCutPos = ( hIon_pTMaxCut_[tsNum][0] - pt ) / ( hIon_pTMaxCut_[tsNum][0] - hIon_pTMaxCut_[tsNum][1] );
+    double pTMinCutPos = ( pt - hIon_pTMinCut_[tsNum][0] ) / ( hIon_pTMinCut_[tsNum][1] - hIon_pTMinCut_[tsNum][0] );
+    if(  pt > hIon_pTMaxCut_[tsNum][1] && 
+         chi2n_no1Dmod > hIon_pTMaxCut_[tsNum][2]*nlayers*pow(pTMaxCutPos,hIon_pTMaxCut_[tsNum][3]) ) 
+      return false;
+    if(  pt < hIon_pTMinCut_[tsNum][1] && 
+         chi2n_no1Dmod > hIon_pTMinCut_[tsNum][2]*nlayers*pow(pTMinCutPos,hIon_pTMinCut_[tsNum][3]) ) 
+      return false;
+  }
 
   //other track parameters
   float d0 = -tk.dxy(vertexBeamSpot.position()), d0E =  tk.d0Error(),

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.h
@@ -108,6 +108,13 @@
             std::vector<double> max_z0_;
             std::vector<double> nSigmaZ_;
 
+            // Boolean indicating if HIon related cuts are to be applied
+            std::vector<bool> applyHIonCuts_;
+
+            // parameters for HIon pT dependent chi2 cuts
+            std::vector<std::vector<double> > hIon_pTMinCut_;
+            std::vector<std::vector<double> > hIon_pTMaxCut_;
+
             /// Cuts on numbers of layers with hits/3D hits/lost hits. 
 	    std::vector<uint32_t> min_layers_;
 	    std::vector<uint32_t> min_3Dlayers_;

--- a/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
+++ b/RecoTracker/FinalTrackSelectors/python/multiTrackSelector_cfi.py
@@ -29,6 +29,13 @@ looseMTS = cms.PSet(
     max_d0 = cms.double(100.),
     max_z0 = cms.double(100.),
     nSigmaZ = cms.double(4.),
+
+    #  Boolean indicating if HIon related cuts are to be applied
+    applyHIonCuts = cms.bool(False),
+    
+    #  parameters for HIon pT dependent chi2 cut
+    hIon_pTMinCut = cms.vdouble(0.0,0.0001,9999,1.0),
+    hIon_pTMaxCut = cms.vdouble(9999,9998,9999,1.0),
     
     # Cuts on numbers of layers with hits/3D hits/lost hits. 
     minNumberLayers = cms.uint32(0),


### PR DESCRIPTION
The purpose of this request is to implement an additional tracking sequence for heavy ion collisions which uses a combination of full (pixel and strip, CKF) tracks and tracks reconstructed from only the pixel detector. This strategy enables the reconstruction of charged particles with reasonable efficiency and low fake rate in high-occupancy PbPb collisions down to pT = 0.3 GeV/c at midrapidity. The current standard heavy ion tracking sequence does not go below pT = 0.5 GeV/c. This additional reach is particularly important for several proposed 2015 analyses. This alternative tracking sequence was first proposed in September at the Tracking POG meeting, see: https://indico.cern.ch/event/334689/contribution/3/material/slides/0.pdf

In order to implement this sequence, a new pT-dependent chi2 cut is needed in the MutliTrackSelector. A configuration switch is implemented and set to false in the default cfi so that this cut does not affect other tracking reconstruction. Currently, this sequence is not added to the default heavy ion reconstruction sequence, as there may not be sufficient time budget to run this during prompt reconstruction. If additional optimization is not possible, the plan is to run this in a re-reco as soon as possible with the 2015 PbPb collision data.

This new feature was proposed earlier last year, but was not added as there was a problem due to some "full tracks" bypassing cuts because they had over 20 valid hits. This was corrected recently, see: https://indico.cern.ch/event/378287/contribution/2/material/slides/0.pdf

Running this additional tracking sequence was tested on the 2011 PbPb data and was found to increase overall reconstruction time with current software by 8 percent, see: https://indico.cern.ch/event/393155/contribution/4/material/slides/0.pdf

Also note that the cut is not implemented in the AnalyticalTrackSelector, which inherits from the MultiTrackSelector. There are many python configurations that configure the AnalyticalTrackSelector directly, so I was hesitant to change the interface. This new cut is hard-coded as false in the AnalyticalTrackSelector so that it is never run and not expected in the configuration.
