### PR TITLE
Modified paths. Fixed a bug in MonoJet conf. Remove DisplacedDimuonDi…

### DIFF
--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
@@ -4,12 +4,14 @@ DiPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoublePho85_v",    # Run2 proposal
         "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon22_AND_HE10_R9Id65_Eta2_Mass15_v",
-        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Eta2_Mass60_v"
+        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Eta2_Mass60_v",
+        "HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon25_AND_HE10_R9Id65_Eta2_Mass15_v" #50ns backup menu
         #"HLT_DoublePhoton70_v"  # Run1 (frozenHLT)
         ),
-    recPhotonLabel  = cms.InputTag("gedPhotons"),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    #recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
-    minCandidates = cms.uint32(2),
+    minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
                                     1100, 1200, 1500

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
@@ -13,8 +13,8 @@ DisplacedMuEGPSet = cms.PSet(
         #"HLT_Mu17_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v", # Run1
         #"HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v"  # Run1
         ),
-    #recElecLabel  = cms.InputTag("gedGsfElectrons"),
-    recPhotonLabel  = cms.InputTag("gedPhotons"),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    #recPhotonLabel  = cms.InputTag("gedPhotons"),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHT_cff.py
@@ -4,14 +4,17 @@ HTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v",
         "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v",
-        "HLT_PFHT750_4Jet_v", # Run2
+        #"HLT_PFHT750_4Jet_v", # Run2
+        "HLT_PFHT750_4Jet_Pt50_v",
         "HLT_PFHT650_4Jet_v", # Run2
         "HLT_PFHT550_4Jet_v", # Run2
-        "HLT_PFHT900_v",      # Run2
+        #"HLT_PFHT900_v",      # Run2
+        "HLT_PFHT800_v",
         "HLT_PFHT650_v",
         "HLT_HT900_v",        # Run2
         "HLT_HT300_v",        # Run2
-        "HLT_ECALHT800_v"     # Run2 7e33
+        "HLT_ECALHT800_v",     # Run2 7e33
+        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
         #"HLT_HT750_v"        # Run1 (frozenHLT)
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Ele105_CaloIdVT_GsfTrkIdT_v" # Run2 proposal
+        "HLT_Ele105_CaloIdVT_GsfTrkIdT_v", # Run2 proposal
+        "HLT_Ele115_CaloIdVT_GsfTrkIdT_v"  # 50ns backup menu
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
@@ -5,7 +5,8 @@ HighPtPhotonPSet = cms.PSet(
         "HLT_Photon175_v",  # Run2 proposal
         "HLT_Photon165_HE10_v",  # Run2 proposal
         "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon31_AND_HE10_R9Id65_Mass10_v",  # Run2 proposal
-        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Mass60_v"  # Run2 proposal
+        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Mass60_v",  # Run2 proposal
+        "HLT_Photon90_CaloIdL_PFHT600_v" #50ns backup menu
         #"HLT_Photon135_v"  # Run1 (frozenHLT)
         ),
     recPhotonLabel  = cms.InputTag("gedPhotons"),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
@@ -11,11 +11,11 @@ MonojetPSet = cms.PSet(
         "HLT_MonoCentralPFJet80_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v"
     ),
 
-    CaloJetLabel    = cms.InputTag("ak4CaloJets"),
-    PFJetLabel      = cms.InputTag("ak4PFJets"),
+    recCaloJetLabel    = cms.InputTag("ak4CaloJets"),
+    recPFJetLabel      = cms.InputTag("ak4PFJets"),
     #GenJetLabel     = cms.InputTag("ak4GenJets"),
-    PFMETLabel      = cms.InputTag("recoExoticaValidationMETNoMu"),
-    PFMHTLabel      = cms.InputTag("recoExoticaValidationMHTNoMu"),
+    recPFMETLabel      = cms.InputTag("recoExoticaValidationMETNoMu"),
+    recPFMHTLabel      = cms.InputTag("recoExoticaValidationMHTNoMu"),
     #PFMETLabel      = cms.InputTag("pfMet"),
     #PFMHTLabel      = cms.InputTag("recoExoticaValidationHT"),
 

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
@@ -3,7 +3,10 @@ import FWCore.ParameterSet.Config as cms
 SingleMuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Mu45_e2p1_v", # Run 2 
-        "HLT_Mu50_v" # Run 2
+        "HLT_Mu50_v", # Run 2
+        #50ns backup menu
+        "HLT_Mu55_v",
+        "HLT_Mu50_eta2p1_v"
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -33,7 +33,7 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaPureMET_cff           import Pu
 from HLTriggerOffline.Exotica.analyses.hltExoticaMETplusTrack_cff      import METplusTrackPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaMonojet_cff           import MonojetPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaMonojetBackup_cff     import MonojetBackupPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedDimuonDijet_cff import DisplacedDimuonDijetPSet
+#from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedDimuonDijet_cff import DisplacedDimuonDijetPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaEleMu_cff             import EleMuPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHTDisplacedJets_cff   import HTDisplacedJetsPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaPhotonMET_cff         import PhotonMETPSet
@@ -69,7 +69,7 @@ hltExoticaValidator = cms.EDAnalyzer(
         "METplusTrack",
         "Monojet",
         "MonojetBackup",
-        "DisplacedDimuonDijet",
+        #"DisplacedDimuonDijet",
         "EleMu",
         "PhotonMET",
         "HTDisplacedJets"
@@ -217,7 +217,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     Monojet          = MonojetPSet,
     MonojetBackup    = MonojetBackupPSet,
     HT               = HTPSet,
-    DisplacedDimuonDijet = DisplacedDimuonDijetPSet,
+    #DisplacedDimuonDijet = DisplacedDimuonDijetPSet,
     EleMu            = EleMuPSet,
     PhotonMET        = PhotonMETPSet,
     HTDisplacedJets  = HTDisplacedJetsPSet 


### PR DESCRIPTION
…jet. recPhotons label in DisplacedMuEG and DiPhoton is replaced to recElectrons label.

Added paths :
HT:
HLT_PFHT750_4Jet_Pt50_v
HLT_PFHT800_v
HLT_Photon90_CaloIdL_PFHT600_v

HighPtElectron:
HLT_Ele115_CaloIdVT_GsfTrkIdT_v

DiPhoton:
HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon25_AND_HE10_R9Id65_Eta2_Mass15_v

HighPtPhoton:
HLT_Photon90_CaloIdL_PFHT600_v

SingleMuon:
HLT_Mu55_v
HLT_Mu50_eta2p1_v
