### PR TITLE
Make callWhenNewProductsRegistered public

### DIFF
--- a/FWCore/Framework/interface/ProducerBase.h
+++ b/FWCore/Framework/interface/ProducerBase.h
@@ -47,7 +47,6 @@ namespace edm {
     using ProductRegistryHelper::produces;
     using ProductRegistryHelper::typeLabelList;
 
-  protected:
     void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
        callWhenNewProductsRegistered_ = func;
     }

--- a/FWCore/Framework/interface/one/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/one/EDAnalyzerBase.h
@@ -63,8 +63,6 @@ namespace edm {
       // Warning: the returned moduleDescription will be invalid during construction
       ModuleDescription const& moduleDescription() const { return moduleDescription_; }
 
-    protected:
-      
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 
     private:

--- a/FWCore/Framework/interface/stream/EDAnalyzer.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzer.h
@@ -57,8 +57,7 @@ namespace edm {
       // ---------- static member functions --------------------
       
       // ---------- member functions ---------------------------
-      
-    protected:
+
       using EDAnalyzerBase::callWhenNewProductsRegistered;
       
     private:

--- a/FWCore/Framework/interface/stream/EDAnalyzerBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerBase.h
@@ -52,7 +52,6 @@ namespace edm {
       ModuleDescription const& moduleDescription() const {
         return *moduleDescriptionPtr_;
       }
-    protected:
 
       void callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func);
 


### PR DESCRIPTION
This is needed for the consumes migration of
L1GtUtils. It will make testing the other more
significant parts of that migration easier if
this is integrated quickly. This change is
trivial.
