### PR TITLE
Small change to #9016 (Fix of the Linking in PF for forward tracks)

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/importers/ClusterImporterForForwardTracker.cc
+++ b/RecoParticleFlow/PFProducer/plugins/importers/ClusterImporterForForwardTracker.cc
@@ -58,10 +58,10 @@ importToBlock( const edm::Event& e,
 
     //Outside tracker call it HF
     if (type == reco::PFBlockElement::ECAL && 
-	clus->layer()== PFLayer::HF_EM && abs(clus->position().Eta())>3.8)
+	clus->layer()== PFLayer::HF_EM && fabs(clus->position().Eta())>3.8)
             type = reco::PFBlockElement::HFEM;
     if (type == reco::PFBlockElement::HCAL && 
-	clus->layer()== PFLayer::HF_HAD && abs(clus->position().Eta())>3.8)
+	clus->layer()== PFLayer::HF_HAD && fabs(clus->position().Eta())>3.8)
             type = reco::PFBlockElement::HFHAD;
 
 

--- a/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
+++ b/SLHCUpgradeSimulations/Configuration/python/customise_PFlow.py
@@ -5,8 +5,9 @@ def customise_extendedTrackerBarrel( process ) :
         for link in process.particleFlowBlock.linkDefinitions:
             if hasattr(link,'trackerEtaBoundary') : link.trackerEtaBoundary = cms.double(3.0)
         for importer in process.particleFlowBlock.elementImporters :
-            if importer.source.value()=="particleFlowClusterHFEM" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
-            if importer.source.value()=="particleFlowClusterHFHAD" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
+            if importer.source.value()=="particleFlowClusterHFEM" \
+                or importer.source.value()=="particleFlowClusterHFHAD" \
+                or importer.source.value()=="particleFlowClusterHF" : importer.importerName = cms.string("ClusterImporterForForwardTracker")
     return process
 
 def customise_use3DHCalClusters( process ) :


### PR DESCRIPTION
This is effectively #9016, except that it keeps the old collections in the list of things to get customised in case we ever switch back to those.
Either this or #9016 should be merged, not both.  @bachtis will have the final say on which solution he prefers.
