### PR TITLE
High FED ID check (74X)

### DIFF
--- a/EventFilter/Utilities/plugins/FRDStreamSource.cc
+++ b/EventFilter/Utilities/plugins/FRDStreamSource.cc
@@ -94,12 +94,18 @@ bool FRDStreamSource::setRunAndEventInfo(edm::EventID& id, edm::TimeValue_t& the
 
 
   while (eventSize > 0) {
+    assert(eventSize>=sizeof(fedt_t));
     eventSize -= sizeof(fedt_t);
     const fedt_t* fedTrailer = (fedt_t*) (event + eventSize);
     const uint32_t fedSize = FED_EVSZ_EXTRACT(fedTrailer->eventsize) << 3; //trailer length counts in 8 bytes
-    eventSize -= (fedSize - sizeof(fedh_t));
+    assert(eventSize>=fedSize - sizeof(fedt_t));
+    eventSize -= (fedSize - sizeof(fedt_t));
     const fedh_t* fedHeader = (fedh_t *) (event + eventSize);
     const uint16_t fedId = FED_SOID_EXTRACT(fedHeader->sourceid);
+    if (fedId>FEDNumbering::MAXFEDID)
+    {
+      throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection") << "Out of range FED ID : " << fedId;
+    }
     if (fedId == FEDNumbering::MINTCDSuTCAFEDID) {
       foundTCDSFED=true;
       evf::evtn::TCDSRecord record((unsigned char *)(event + eventSize ));

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -667,12 +667,18 @@ edm::Timestamp FedRawDataInputSource::fillFEDRawDataCollection(FEDRawDataCollect
   GTPEventID_=0;
   tcds_pointer_ = 0;
   while (eventSize > 0) {
+    assert(eventSize>=sizeof(fedt_t));
     eventSize -= sizeof(fedt_t);
     const fedt_t* fedTrailer = (fedt_t*) (event + eventSize);
     const uint32_t fedSize = FED_EVSZ_EXTRACT(fedTrailer->eventsize) << 3; //trailer length counts in 8 bytes
-    eventSize -= (fedSize - sizeof(fedh_t));
+    assert(eventSize>=fedSize - sizeof(fedt_t));
+    eventSize -= (fedSize - sizeof(fedt_t));
     const fedh_t* fedHeader = (fedh_t *) (event + eventSize);
     const uint16_t fedId = FED_SOID_EXTRACT(fedHeader->sourceid);
+    if(fedId>FEDNumbering::MAXFEDID)
+    {
+      throw cms::Exception("FedRawDataInputSource::fillFEDRawDataCollection") << "Out of range FED ID : " << fedId;
+    }
     if (fedId == FEDNumbering::MINTCDSuTCAFEDID) {
       tcds_pointer_ = (unsigned char *)(event + eventSize );
     }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -449,6 +449,13 @@ namespace evf {
           edm::LogWarning("EvFDaqDirector") << "Unable to obtain a lock for 5 seconds. Checking if run directory and fu.lock file are present -: errno "
                                             << errno <<":"<< strerror(errno) << std::endl;
 
+
+        if (stat(getEoLSFilePathOnFU(ls).c_str(),&buf)==0) {
+          edm::LogWarning("EvFDaqDirector") << "Detected local EoLS for lumisection "<< ls ; 
+          ls++;
+          return noFile;
+        }
+
         if (stat(bu_run_dir_.c_str(), &buf)!=0) return runEnded;
         if (stat((bu_run_dir_+"/fu.lock").c_str(), &buf)!=0) return runEnded;
         lock_attempts=0;

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -634,6 +634,9 @@ namespace evf {
       previousFileSize_ = 0;
     }
 
+    //reached limit
+    if (maxLS>=0 && ls > (unsigned int)maxLS) return false; 
+
     struct stat buf;
     std::stringstream ss;
     unsigned int nextIndex = index;


### PR DESCRIPTION
Changes:
- checking FED id so that write out of vector bounds is caught.
- Added assertions to also catch inconsistencies between event size and individual FED sizes
- fix to exit sequence on CMSSW_STOP file (used for switchover to cloud)
- check whether local EoLS file exists to end the lumisection if unable to acquire a lock for 5 seconds

Same as #9033 for 75X
