### PR TITLE
Add consumes interface for default constructed TrackerHitAssociator

### DIFF
--- a/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
+++ b/SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h
@@ -57,6 +57,7 @@ class TrackerHitAssociator {
  public:
   struct Config {
     Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC);
+    Config(edm::ConsumesCollector && iC);
     bool doPixel_, doStrip_, doTrackAssoc_, assocHitbySimTrack_;
     edm::EDGetTokenT<edm::DetSetVector<StripDigiSimLink> > stripToken_;
     edm::EDGetTokenT<edm::DetSetVector<PixelDigiSimLink> > pixelToken_;

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -73,7 +73,42 @@ TrackerHitAssociator::TrackerHitAssociator(const edm::ParameterSet& conf, edm::C
  }
 
 //
-// Constructor for Config helper class
+// Constructor for Config helper class, using default parameters
+//
+TrackerHitAssociator::Config::Config(edm::ConsumesCollector && iC) :
+  doPixel_(true),
+  doStrip_(true),
+  doTrackAssoc_(false),
+  assocHitbySimTrack_(false) {
+
+  if(doStrip_) stripToken_ = iC.consumes<edm::DetSetVector<StripDigiSimLink> >(edm::InputTag("simSiStripDigis"));
+  if(doPixel_) pixelToken_ = iC.consumes<edm::DetSetVector<PixelDigiSimLink> >(edm::InputTag("simSiPixelDigis"));
+  if(!doTrackAssoc_) {
+    std::vector<std::string> trackerContainers;
+    trackerContainers.reserve(12);
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTIBLowTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTIBHighTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTIDLowTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTIDHighTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTOBLowTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTOBHighTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTECLowTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsTECHighTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelBarrelLowTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelBarrelHighTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelEndcapLowTof");
+    trackerContainers.emplace_back("g4SimHitsTrackerHitsPixelEndcapHighTof");
+    cfTokens_.reserve(trackerContainers.size());
+    simHitTokens_.reserve(trackerContainers.size());
+    for(auto const& trackerContainer : trackerContainers) {
+      cfTokens_.push_back(iC.consumes<CrossingFrame<PSimHit> >(edm::InputTag("mix", trackerContainer)));
+      simHitTokens_.push_back(iC.consumes<std::vector<PSimHit> >(edm::InputTag("g4SimHits", trackerContainer)));
+    }
+  }
+}
+
+//
+// Constructor for Config helper class, using configured parameters
 //
 TrackerHitAssociator::Config::Config(const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
   doPixel_( conf.getParameter<bool>("associatePixel") ),


### PR DESCRIPTION
This PR just adds a ctor that is not yet used.
The consumes interface has already been implemented for TrackerHitAssociator, but only for the more common use case where the module parameter set is used to construct the TrackerHitAssociator. I inadvertently neglected to implement the consumes interface for the less common case where the TrackerHitAssociator is constructed from hard coded values, rather than configured values. This PR implements the one ctor needed for this case.
