### PR TITLE
Fix memory leak in SimpleDAFHitCollector

### DIFF
--- a/RecoTracker/SiTrackerMRHTools/interface/GroupedDAFHitCollector.h
+++ b/RecoTracker/SiTrackerMRHTools/interface/GroupedDAFHitCollector.h
@@ -34,7 +34,7 @@ public:
 	virtual ~GroupedDAFHitCollector(){}
 
 	virtual std::vector<TrajectoryMeasurement> recHits(const Trajectory&, 
-							   const MeasurementTrackerEvent *theMT) const;
+							   const MeasurementTrackerEvent *theMT) const override;
 
 	const SiTrackerMultiRecHitUpdator* getUpdator() const {return theUpdator;}
 	const MeasurementEstimator* getEstimator() const {return theEstimator;}

--- a/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
+++ b/RecoTracker/SiTrackerMRHTools/src/SimpleDAFHitCollector.cc
@@ -54,7 +54,9 @@ vector<TrajectoryMeasurement> SimpleDAFHitCollector::recHits(const Trajectory& t
       DetId id = itrajmeas->recHit()->geographicalId();
       MeasurementDetWithData measDet = theMTE->idToDet(id);
       tracking::TempMeasurements tmps;
+      
       std::vector<const TrackingRecHit*> hits;
+      std::vector<std::unique_ptr<const TrackingRecHit>> hitsOwner;
 
       TrajectoryStateOnSurface smoothtsos = itrajmeas->updatedState();
       //the error is scaled in order to take more "compatible" hits
@@ -88,9 +90,9 @@ vector<TrajectoryMeasurement> SimpleDAFHitCollector::recHits(const Trajectory& t
             TransientTrackingRecHit::RecHitPointer transient = 
 						   theUpdator->getBuilder()->build(tmps.hits[i]->hit());
             TrackingRecHit::ConstRecHitPointer preciseHit = theHitCloner.makeShared(transient,combtsos);
-	    TrackingRecHit * righthit = rightdimension(*preciseHit);	
-            hits.push_back(righthit);
-
+	    auto righthit = rightdimension(*preciseHit);
+            hitsOwner.push_back(std::move(righthit));
+            hits.push_back(hitsOwner.back().get());
           }
 
         }


### PR DESCRIPTION
While tracing down a false postive thread-safety problem 'identified' by the static analyzer [const function returning a non-const pointer] I discovered a memory leak.

The newly created hit returned from `SimpleDAFHitCollector::rightdimension()` were stored in a `std::vector` of const pointers. That vector was passed to `SiTrackerMultiRecHitUpdator` which passes each individual entry to `TransientTrackingRecHitBuilder::build()` which then clones the hit. The original hit was never deleted.

Both the false positive and the memory leak were fixed by using `std::unique_ptr<>`
