### PR TITLE
Removed unnecessary const cast from FileBlob

### DIFF
--- a/CondFormats/Common/src/FileBlob.cc
+++ b/CondFormats/Common/src/FileBlob.cc
@@ -65,9 +65,9 @@ void FileBlob::write(std::ostream & os) const {
       edm::LogError("FileBlob")<< "uncompressing error " << zerr
                                    << " original size was " << isize
                                    << " new size is " << destLen;
-    os.write((const char *)(&*out.begin()),out.size());
+    os.write(reinterpret_cast<const char *>(&*out.begin()),out.size());
   }else{
-    os.write((char *)&*blob.begin(),blob.size());
+    os.write(reinterpret_cast<const char *>(&*blob.begin()),blob.size());
   }
 }
 


### PR DESCRIPTION
The static analyzer was complaining about a const cast done in a
const function. There was no reason to do a const cast so it was
removed.
