### PR TITLE
Missing comma after edm::AtomicPtrCache in vector initializer. Adding…

### DIFF
--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -126,7 +126,9 @@ bool support::isSafeClassName(const std::string &cname) {
     "tbb::",
     "class tbb::",
     "edm::AtomicPtrCache",
-    "class edm::AtomicPtrCache"
+    "class edm::AtomicPtrCache",
+    "edm::InputTag",
+    "class edm::InputTag",
     "std::once_flag",
     "struct std::once_flag",
     "boost::<anonymous namespace>::extents",


### PR DESCRIPTION
… edm::InputTag as safe class
