### PR TITLE
Update of muon regional iterative tracking in HI reco

### DIFF
--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -63,7 +63,7 @@ hiRegitMuDetachedTripletStepTrackCandidates        =  RecoTracker.IterativeTrack
 
 # fitting: feed new-names
 hiRegitMuDetachedTripletStepTracks                 = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTracks.clone(
-    AlgorithmName = cms.string('iter6'),
+    AlgorithmName = cms.string('undefAlgorithm'),
     src                 = 'hiRegitMuDetachedTripletStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -56,7 +56,7 @@ hiRegitMuInitialStepTrackCandidates        =  RecoTracker.IterativeTracking.Init
 
 # fitting: feed new-names
 hiRegitMuInitialStepTracks                 = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTracks.clone(
-    AlgorithmName = cms.string('iter3'),
+    AlgorithmName = cms.string('undefAlgorithm'),
     src                 = 'hiRegitMuInitialStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
@@ -74,7 +74,7 @@ hiRegitMuLowPtTripletStepTrackCandidates        =  RecoTracker.IterativeTracking
 
 # fitting: feed new-names
 hiRegitMuLowPtTripletStepTracks                 = RecoTracker.IterativeTracking.LowPtTripletStep_cff.lowPtTripletStepTracks.clone(
-    AlgorithmName = cms.string('iter4'),
+    AlgorithmName = cms.string('undefAlgorithm'),
     src                 = 'hiRegitMuLowPtTripletStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -93,7 +93,7 @@ hiRegitMuMixedTripletStepTrackCandidates        =  RecoTracker.IterativeTracking
 
 # fitting: feed new-names
 hiRegitMuMixedTripletStepTracks                 = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTracks.clone(
-    AlgorithmName = cms.string('iter7'),
+    AlgorithmName = cms.string('undefAlgorithm'),
     src                 = 'hiRegitMuMixedTripletStepTrackCandidates',
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -69,7 +69,7 @@ hiRegitMuPixelLessStepTrackCandidates        =  RecoTracker.IterativeTracking.Pi
 
 # fitting: feed new-names
 hiRegitMuPixelLessStepTracks                 = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTracks.clone(
-    AlgorithmName = cms.string('iter8'),
+    AlgorithmName = cms.string('undefAlgorithm'),
     src                 = 'hiRegitMuPixelLessStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -20,10 +20,10 @@ from RecoTracker.IterativeTracking.PixelPairStep_cff import *
 
 # NEW CLUSTERS (remove previously used clusters)
 hiRegitMuPixelPairStepClusters = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepClusters.clone(
-    oldClusterRemovalInfo = cms.InputTag("hiRegitMuLowPtTripletStepClusters"),
-    trajectories = cms.InputTag("hiRegitMuLowPtTripletStepTracks"),
-    overrideTrkQuals = cms.InputTag('hiRegitMuLowPtTripletStepSelector','hiRegitMuLowPtTripletStep'),
-    TrackQuality          = cms.string('tight')
+    trajectories          = cms.InputTag("hiRegitMuInitialStepTracks"),
+		overrideTrkQuals      = cms.InputTag('hiRegitMuInitialStepSelector','hiRegitMuInitialStep'),
+		oldClusterRemovalInfo = cms.InputTag(""),
+		TrackQuality          = cms.string('tight')
 )
 
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -74,7 +74,7 @@ hiRegitMuPixelPairStepTrackCandidates        =  RecoTracker.IterativeTracking.Pi
 
 # fitting: feed new-names
 hiRegitMuPixelPairStepTracks                 = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTracks.clone(
-    AlgorithmName = cms.string('iter5'),
+    AlgorithmName = cms.string('undefAlgorithm'),
     src                 = 'hiRegitMuPixelPairStepTrackCandidates',
     clustersToSkip       = cms.InputTag('hiRegitMuPixelPairStepClusters'),
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
@@ -90,7 +90,7 @@ hiRegitMuTobTecStepTrackCandidates        =  RecoTracker.IterativeTracking.TobTe
 
 # fitting: feed new-names
 hiRegitMuTobTecStepTracks                 = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepTracks.clone(
-    AlgorithmName = cms.string('iter9'),
+    AlgorithmName = cms.string('undefAlgorithm'),
     src                 = 'hiRegitMuTobTecStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
+++ b/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
@@ -1,44 +1,32 @@
 import FWCore.ParameterSet.Config as cms
 
 from RecoHI.HiMuonAlgos.HiRegitMuonInitialStep_cff import *
-from RecoHI.HiMuonAlgos.HiRegitMuonLowPtTripletStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonPixelPairStep_cff import *
-from RecoHI.HiMuonAlgos.HiRegitMuonDetachedTripletStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonMixedTripletStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonPixelLessStep_cff import *
-from RecoHI.HiMuonAlgos.HiRegitMuonTobTecStep_cff import *
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiGeneralAndRegitMuTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiRegitMuInitialStepTracks'),
-                      cms.InputTag('hiRegitMuLowPtTripletStepTracks'),
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
-                      cms.InputTag('hiRegitMuDetachedTripletStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
-                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
-                      cms.InputTag('hiRegitMuTobTecStepTracks')
+                      cms.InputTag('hiRegitMuPixelLessStepTracks')
                       ),
     selectedTrackQuals = cms.VInputTag(cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
-                                       cms.InputTag("hiRegitMuLowPtTripletStepSelector","hiRegitMuLowPtTripletStepLoose"),
                                        cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
-                                       cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep"),
                                        cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
-                                       cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
-                                       cms.InputTag("hiRegitMuTobTecStepSelector","hiRegitMuTobTecStep")
+                                       cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep")
                                        ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1),
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6), pQual=cms.bool(True))),
+    hasSelector=cms.vint32(1,1,1,1),
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3), pQual=cms.bool(True))),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
 
 hiRegitMuTracking = cms.Sequence(hiRegitMuonInitialStep
-                                 *hiRegitMuonDetachedTripletStep
-                                 *hiRegitMuonLowPtTripletStep
                                  *hiRegitMuonPixelPairStep
                                  *hiRegitMuonMixedTripletStep
                                  *hiRegitMuonPixelLessStep
-                                 *hiRegitMuonTobTecStep
                                  )
 
 # Standalone muons

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -26,28 +26,22 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
                       cms.InputTag('hiLowPtTripletStepTracks'),
                       cms.InputTag('hiPixelPairGlobalPrimTracks'),
                       cms.InputTag('hiRegitMuInitialStepTracks'),
-                      cms.InputTag('hiRegitMuLowPtTripletStepTracks'),
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
-                      cms.InputTag('hiRegitMuDetachedTripletStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
-                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
-                      cms.InputTag('hiRegitMuTobTecStepTracks')
+                      cms.InputTag('hiRegitMuPixelLessStepTracks')
                      ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1,1,1),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
     cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
     cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
     cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
-    cms.InputTag("hiRegitMuLowPtTripletStepSelector","hiRegitMuLowPtTripletStepLoose"),
     cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
-    cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep"),
     cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
-    cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
-    cms.InputTag("hiRegitMuTobTecStepSelector","hiRegitMuTobTecStep")
+    cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep")
     ),                    
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8,9,10), pQual=cms.bool(True)),  # should this be False?
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7), pQual=cms.bool(True)),  # should this be False?
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)


### PR DESCRIPTION
The muon regional iterative (regit) tracking in heavy-ion reconstruction is updated with the following changes:
- removing the LowPt, Detached and TobTec iterations. These iterations don't change the muon reconstruction efficiency, so removing them saves a bit of time in reconstruction.
- fixing the algorithm name assigned to tracks found by muon regit, with an existing name. The tracks are assigned the flag "undefAlgorithm", this can be changed if someone has a strong opinion about it.

Documentation of the effect of these changes on the reconstruction performance and resources needed is under finalization and made available very soon. As stated above, the HI muon reconstruction is basically unchanged, only a little bit faster.
