### PR TITLE
Fix compilation error with EDM_ML_DEBUG

### DIFF
--- a/PhysicsTools/UtilAlgos/interface/CachingVariable.h
+++ b/PhysicsTools/UtilAlgos/interface/CachingVariable.h
@@ -394,7 +394,7 @@ class ExpressionVariable : public CachingVariable {
     edm::Handle<edm::View<Object> > oH;
     iEvent.getByToken(src_,oH);
     if (index_>=oH->size()){
-      LogDebug(method())<<"fail to get object at index: "<<index_<<" in collection: "<<src_;
+      LogDebug(method())<<"fail to get object at index: "<<index_<<" in collection: "<<srcTag_;
       return std::make_pair(false,0);
     }
 


### PR DESCRIPTION
ExpressionVariable was failing to compile with
the command "scram b USER_CXXFLAGS="-DEDM_ML_DEBUG"
because EDGetTokens cannot be printed with
operator<< which was happening in a LogDebug
print statement.
