### PR TITLE
Changed function static to be const in ExpressionVar

### DIFF
--- a/CommonTools/Utils/src/ExpressionVar.cc
+++ b/CommonTools/Utils/src/ExpressionVar.cc
@@ -74,7 +74,7 @@ bool
 ExpressionVar::makeStorage(edm::ObjectWithDict& obj,
                            const edm::TypeWithDict& retType)
 {
-  static edm::TypeWithDict tVoid(edm::TypeWithDict::byName("void"));
+  static const edm::TypeWithDict tVoid(edm::TypeWithDict::byName("void"));
   bool ret = false;
   if (retType == tVoid) {
     obj = edm::ObjectWithDict::byType(tVoid);


### PR DESCRIPTION
The static analyzer complained that a function local static in ExpressionVar was not safe. Converting the variable to const stopped the complaint.
