### PR TITLE
Multi-threading support

### DIFF
--- a/RecoEcal/EgammaClusterProducers/interface/IslandClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/IslandClusterProducer.h
@@ -5,7 +5,7 @@
 #include <time.h>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -24,7 +24,7 @@
 //
 
 
-class IslandClusterProducer : public edm::EDProducer 
+class IslandClusterProducer : public edm::stream::EDProducer<> 
 {
   public:
 
@@ -32,7 +32,7 @@ class IslandClusterProducer : public edm::EDProducer
 
       ~IslandClusterProducer();
 
-      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
    private:
 

--- a/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
+++ b/RecoHI/HiEgammaAlgos/plugins/HiEgammaSCCorrectionMaker.h
@@ -20,7 +20,7 @@
 #include <memory>
 #include <string>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -37,12 +37,12 @@
 #include "RecoEcal/EgammaCoreTools/interface/EcalClusterTools.h"
 
 
-class HiEgammaSCCorrectionMaker : public edm::EDProducer {
+class HiEgammaSCCorrectionMaker : public edm::stream::EDProducer<> {
 	
    public:
      explicit HiEgammaSCCorrectionMaker(const edm::ParameterSet&);
      ~HiEgammaSCCorrectionMaker();
-     virtual void produce(edm::Event&, const edm::EventSetup&);
+     virtual void produce(edm::Event&, const edm::EventSetup&) override;
 
    private:
 

--- a/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
@@ -47,7 +47,6 @@
 //
 
 class HiSpikeCleaner : public edm::stream::EDProducer<> {
-//class HiSpikeCleaner : public edm::EDProducer {
 public:
   explicit HiSpikeCleaner(const edm::ParameterSet&);
   ~HiSpikeCleaner();

--- a/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSpikeCleaner.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
@@ -46,15 +46,15 @@
 // class declaration
 //
 
-class HiSpikeCleaner : public edm::EDProducer {
+class HiSpikeCleaner : public edm::stream::EDProducer<> {
+//class HiSpikeCleaner : public edm::EDProducer {
 public:
   explicit HiSpikeCleaner(const edm::ParameterSet&);
   ~HiSpikeCleaner();
   
 private:
-  virtual void beginJob() override ;
+
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override ;
   
   // ----------member data ---------------------------
   
@@ -208,17 +208,6 @@ HiSpikeCleaner::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
    // Put collection of corrected SuperClusters into the event
    iEvent.put(corrClusters, outputCollection_);   
    
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-HiSpikeCleaner::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-HiSpikeCleaner::endJob() {
 }
 
 //define this as a plug-in

--- a/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.h
+++ b/RecoHI/HiEgammaAlgos/plugins/HiSuperClusterProducer.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -17,7 +17,7 @@
 //
 
 
-class HiSuperClusterProducer : public edm::EDProducer 
+class HiSuperClusterProducer : public edm::stream::EDProducer<> 
 {
   
   public:
@@ -26,7 +26,7 @@ class HiSuperClusterProducer : public edm::EDProducer
 
       ~HiSuperClusterProducer();
 
-      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void produce(edm::Event&, const edm::EventSetup&) override;
       virtual void endJob();
 
    private:


### PR DESCRIPTION
The purpose of this PR is to migrate four CMSSW "legacy" modules used by the Heavy Ions HLT to multi-threading compliant forms. For reference, the Hypernews thread on HLT Development about this change is https://hypernews.cern.ch/HyperNews/CMS/get/hlt/3872.html.

A backport to 74X will follow shortly. Thanks to @cfmcinn for testing the PR'd changes.

@Martin-Grunewald, @perrotta, @fwyzard, @cfmcinn, @yetkinyilmaz, @richard-cms might want to follow this PR.
