### PR TITLE
Add missing function implementation

### DIFF
--- a/FWCore/Framework/src/one/EDAnalyzerBase.cc
+++ b/FWCore/Framework/src/one/EDAnalyzerBase.cc
@@ -45,7 +45,12 @@ namespace edm {
     EDAnalyzerBase::~EDAnalyzerBase()
     {
     }
-    
+
+    void
+    EDAnalyzerBase::callWhenNewProductsRegistered(std::function<void(BranchDescription const&)> const& func) {
+      callWhenNewProductsRegistered_ = func;
+    }
+
     bool
     EDAnalyzerBase::doEvent(EventPrincipal& ep, EventSetup const& c,
                             ActivityRegistry* act,


### PR DESCRIPTION
The function callWhenNewProductsRegistered was
declared but never implemented for one/EDAnalyzerBase.
Add the implementation so it can be used although
nothing uses it yet.
