### PR TITLE
DQMOffline egamma electrons updates

### DIFF
--- a/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
@@ -310,6 +310,20 @@ void ElectronAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup 
     // select electrons
     if (!selected(gsfIter,vertexTIP)) continue ;
 
+    // invariant mass of 2 selected electrons
+    reco::GsfElectronCollection::const_iterator gsfIter2 ;
+    for
+      ( gsfIter2=gsfIter+1;
+	gsfIter2!=gsfElectrons->end() ;
+	gsfIter2++ )
+      {
+        if (!selected(gsfIter2,vertexTIP)) continue ;
+	float invMass = computeInvMass(*gsfIter,*gsfIter2) ;
+        h1_mee->Fill(invMass) ;
+        if ( ( (gsfIter->charge())*(gsfIter2->charge()) )<0. )
+	  { h1_mee_os->Fill(invMass) ; }
+      }
+    
     // basic quantities
     if (gsfIter->isEB()) h1_vertexPt_barrel->Fill( gsfIter->pt() );
     if (gsfIter->isEE()) h1_vertexPt_endcaps->Fill( gsfIter->pt() );
@@ -438,17 +452,6 @@ void ElectronAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup 
        gsfIter!=gsfElectrons->end() ;
        gsfIter++ )
      {
-      reco::GsfElectronCollection::const_iterator gsfIter2 ;
-      for
-       ( gsfIter2=gsfIter+1;
-         gsfIter2!=gsfElectrons->end() ;
-         gsfIter2++ )
-       {
-        float invMass = computeInvMass(*gsfIter,*gsfIter2) ;
-        if(matchingObjectNum == 1){h1_mee->Fill(invMass) ;}
-        if ((matchingObjectNum == 1) && (((gsfIter->charge())*(gsfIter2->charge()))<0.))
-         { h1_mee_os->Fill(invMass) ; }
-       }
 
       double vertexTIP =
        (gsfIter->vertex().x()-bs.position().x()) * (gsfIter->vertex().x()-bs.position().x()) +

--- a/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronAnalyzer.cc
@@ -498,7 +498,7 @@ float ElectronAnalyzer::computeInvMass
  {
   math::XYZTLorentzVector p12 = e1.p4()+e2.p4() ;
   float mee2 = p12.Dot(p12) ;
-  float invMass = sqrt(mee2) ;
+  float invMass = mee2 > 0. ? sqrt(mee2) : 0;
   return invMass ;
  }
 

--- a/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
+++ b/DQMOffline/EGamma/plugins/ElectronTagProbeAnalyzer.cc
@@ -325,7 +325,7 @@ void ElectronTagProbeAnalyzer::analyze( const edm::Event& iEvent, const edm::Eve
 
       math::XYZTLorentzVector p12 = (*gsfIter).p4()+ pSCprobecandidate;
       float mee2 = p12.Dot(p12);
-      float invMass = sqrt(mee2);
+      float invMass = mee2 > 0. ? sqrt(mee2) : 0.;
 
       if( invMass < massLow_ || invMass > massHigh_ ) continue ;
       
@@ -468,7 +468,7 @@ void ElectronTagProbeAnalyzer::analyze( const edm::Event& iEvent, const edm::Eve
 	  h1_mee->Fill(invMass);
 	  math::XYZTLorentzVector p12bis = (*gsfIter).p4()+ bestGsfElectron.p4() ;
 	  float mee2bis = p12.Dot(p12bis);
-	  float invMassEE = sqrt(mee2bis);
+	  float invMassEE = mee2bis > 0. ? sqrt(mee2bis) : 0.;
 	  if(invMassEE >= massLow_ && invMassEE <= massHigh_){h1_mee_os->Fill(invMassEE);}
 	  std::pair<double,double> p(gsfIter->eta(),bestGsfElectron.eta());
 	  TTCheck.push_back(p);
@@ -491,7 +491,7 @@ float ElectronTagProbeAnalyzer::computeInvMass
  {
   math::XYZTLorentzVector p12 = e1.p4()+e2.p4() ;
   float mee2 = p12.Dot(p12) ;
-  float invMass = sqrt(mee2) ;
+  float invMass = mee2 > 0. ? sqrt(mee2) : 0.;
   return invMass ;
  }
 

--- a/DQMOffline/EGamma/python/electronAnalyzerSequence_cff.py
+++ b/DQMOffline/EGamma/python/electronAnalyzerSequence_cff.py
@@ -3,8 +3,10 @@ import FWCore.ParameterSet.Config as cms
 
 mergedSuperClusters = cms.EDProducer("SuperClusterMerger",
   src = cms.VInputTag( 
-    cms.InputTag("correctedHybridSuperClusters"),
-    cms.InputTag("correctedMulti5x5SuperClustersWithPreshower")
+#    cms.InputTag("correctedHybridSuperClusters"),
+#    cms.InputTag("correctedMulti5x5SuperClustersWithPreshower")
+     cms.InputTag("particleFlowSuperClusterECAL","particleFlowSuperClusterECALBarrel"),
+     cms.InputTag("particleFlowSuperClusterECAL","particleFlowSuperClusterECALEndcapWithPreshower")
   )
 )
 


### PR DESCRIPTION
A few more fixes to DQMOffline/Egamma/Electrons (continuation of PR #9010).
- Avoid NaNs in m_ee plots (check > 0 before taking square root)
- TagAndProbe folder now shows plots (it was empty because of wrong supercluster collection to match with)
- Electron selection was not being applied to m_ee plots, so m_ee plot was the same across folders. 
