### PR TITLE
Fix memory leak in PandoraTranslator

### DIFF
--- a/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.cc
+++ b/RecoParticleFlow/PandoraTranslator/plugins/PandoraCMSPFCandProducer.cc
@@ -1161,22 +1161,17 @@ void PandoraCMSPFCandProducer::preparemcParticle(edm::Event& iEvent){ // functio
         
     for(size_t j = 0; j < n; ++ j) {
       const Candidate * d = pa->daughter( j );
-      //if we want to keep it also in GenParticle uncomment here
-      const GenParticle * da = NULL;
-      //We need to check if this daughter has an integer charge
-      bool integercharge = ( ( (int) d->charge() ) - (d->charge()) ) == 0 ? true : false;
-      da = new GenParticle( d->charge(), d->p4() , d->vertex() , d->pdgId() , d->status() , integercharge);    
 
-      double RaVeDa = 10 * std::sqrt(da->vx()*da->vx()+da->vy()*da->vy()+da->vz()*da->vz());
+      double RaVeDa = 10 * std::sqrt(d->vx()*d->vx()+d->vy()*d->vy()+d->vz()*d->vz());
          
       if (i<2) {
          if (RminVtxDaughter[i]>RaVeDa)
             RminVtxDaughter[i] = RaVeDa;
-         if (ZminVtxDaughter[i]>da->vz())
-            ZminVtxDaughter[i] = da->vz();
+         if (ZminVtxDaughter[i]>d->vz())
+            ZminVtxDaughter[i] = d->vz();
       }
   
-      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::SetMCParentDaughterRelationship(*m_pPandora, pa , da));  
+      PANDORA_THROW_RESULT_IF(pandora::STATUS_CODE_SUCCESS, !=, PandoraApi::SetMCParentDaughterRelationship(*m_pPandora, pa , d));
     }
   }
     


### PR DESCRIPTION
This fixes a memory leak of about 0.2 Mb/event in the pandora<->CMSSW translator.  Plots below are for 0 pileup HGCal, since the leak is for each generator particle I don't think it's proportional to pileup (only have gen particles for the signal event).

@lgray says the check for integer charge is unnecessary so the original daughter particle address can used instead of creating a copy.
@lgray, can you check this PR is okay?  As I understand it Pandora needs to be told explicitly about relationships, so the `SetMCParentDaughterRelationship` is still required even though the original particle has a pointer to the daughter, right?

Both plots are the memory retained by each module (top 25 only) after event execution, excluding the products they put in the event.
Before:
![pandorafixbefore](https://cloud.githubusercontent.com/assets/6480160/7630847/ac9e3da0-fa32-11e4-8d64-db5b8c043b9e.png)
And after:
![pandorafixafter](https://cloud.githubusercontent.com/assets/6480160/7630849/ae85fe5a-fa32-11e4-8437-2814b90e6620.png)
