### PR TITLE
Add low lumi HI jet and photon triggers HLT DQM entries (backport from 75X)

### DIFF
--- a/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_HLT_Client_cff.py
@@ -12,6 +12,8 @@ from DQMOffline.Trigger.HLTTauPostProcessor_cfi import *
 from DQMOffline.Trigger.DQMOffline_HLT_Cert_cff import *
 from DQMOffline.Trigger.HLTInclusiveVBFClient_cfi import *
 from DQMOffline.Trigger.FSQHLTOfflineClient_cfi import  *
+from DQMOffline.Trigger.HILowLumiHLTOfflineClient_cfi import  *
+
 
 hltOfflineDQMClient = cms.Sequence(
 #    hltGeneralSeqClient *
@@ -19,6 +21,7 @@ hltOfflineDQMClient = cms.Sequence(
     hltMuonPostVal *
     jetMETHLTOfflineClient *
     fsqClient *
+    HiJetClient *
     #tagAndProbeEfficiencyPostProcessor *
     HLTTauPostSeq *
     dqmOfflineHLTCert *

--- a/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
+++ b/DQMOffline/Trigger/python/DQMOffline_Trigger_cff.py
@@ -49,6 +49,7 @@ from DQMOffline.Trigger.JetMETHLTOfflineAnalyzer_cff import *
 
 
 from DQMOffline.Trigger.FSQHLTOfflineSource_cfi import *
+from DQMOffline.Trigger.HILowLumiHLTOfflineSource_cfi import *
 
 # TnP
 #from DQMOffline.Trigger.TnPEfficiency_cff import *
@@ -79,6 +80,7 @@ offlineHLTSource = cms.Sequence(
     #jetMETHLTOfflineSource *
     jetMETHLTOfflineAnalyzer *
     fsqHLTOfflineSourceSequence *
+    HILowLumiHLTOfflineSourceSequence *
     #TnPEfficiency *
     hltInclusiveVBFSource *
     trackingMonitorHLT *

--- a/DQMOffline/Trigger/python/HILowLumiHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/HILowLumiHLTOfflineClient_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 HiJetClient = cms.EDAnalyzer("DQMGenericClient",
-    subDirs        = cms.untracked.vstring("HLT/HI/HLT_SingleJet*", "HLT/HI/HLT_HISinglePhoton*"),
+    subDirs        = cms.untracked.vstring("HLT/HI/HLT_AK4Calo*", "HLT/HI/HLT_AK4PF*", "HLT/HI/HLT_HISinglePhoton*"),
     verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
     outputFileName = cms.untracked.string(''),
     commands       = cms.vstring(),

--- a/DQMOffline/Trigger/python/HILowLumiHLTOfflineClient_cfi.py
+++ b/DQMOffline/Trigger/python/HILowLumiHLTOfflineClient_cfi.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+HiJetClient = cms.EDAnalyzer("DQMGenericClient",
+    subDirs        = cms.untracked.vstring("HLT/HI/HLT_SingleJet*", "HLT/HI/HLT_HISinglePhoton*"),
+    verbose        = cms.untracked.uint32(0), # Set to 2 for all messages
+    outputFileName = cms.untracked.string(''),
+    commands       = cms.vstring(),
+    resolution     = cms.vstring(),
+    efficiency     = cms.vstring(
+        #"effVsRecoPtAve 'Trigger efficiency vs reco ptAve; average p_{T}^{reco}' recoPFJetsTopology_ptAve_nominator recoPFJetsTopology_ptAve_denominator"
+    ),
+)

--- a/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
@@ -1,5 +1,4 @@
 import FWCore.ParameterSet.Config as cms
-import math
 
 def getHILowLumiTriggers():
     ret=cms.VPSet()

--- a/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
+++ b/DQMOffline/Trigger/python/HILowLumiHLTOfflineSource_cfi.py
@@ -1,0 +1,151 @@
+import FWCore.ParameterSet.Config as cms
+import math
+
+def getHILowLumiTriggers():
+    ret=cms.VPSet()
+    partialPathName = "HLT_AK4CaloJet30_v"
+    hltHICaloJet30 =  cms.PSet(
+        triggerSelection = cms.string(partialPathName+"*"),
+        handlerType = cms.string("FromHLT"),
+        partialPathName = cms.string(partialPathName),
+        partialFilterName  = cms.string("hltSingleAK4CaloJet"),
+        dqmhistolabel  = cms.string("hltHICaloJet30"),
+        mainDQMDirname = cms.untracked.string(dirname),
+        singleObjectsPreselection = cms.string("1==1"),
+        singleObjectDrawables =  cms.VPSet(
+            cms.PSet (name = cms.string("pt"), expression = cms.string("pt"), bins = cms.int32(58), min = cms.double(10), max = cms.double(300)),
+            cms.PSet (name = cms.string("eta"), expression = cms.string("eta"), bins = cms.int32(100), min = cms.double(-5), max = cms.double(5)),
+            cms.PSet (name = cms.string("phi"), expression = cms.string("phi"), bins = cms.int32(100), min = cms.double(-3.15), max = cms.double(3.15))
+        ),
+        combinedObjectSelection =  cms.string("1==1"),
+        combinedObjectSortCriteria = cms.string("at(0).pt"),
+        combinedObjectDimension = cms.int32(1),
+        combinedObjectDrawables =  cms.VPSet()
+    )
+    ret.append(hltHICaloJet30)
+
+    hltHICaloJet40 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet40_v"),
+                                  triggerSelection = cms.string("HLT_AK4CaloJet40_v*"),
+                                  dqmhistolabel = cms.string("hltHICaloJet40")
+                                  )
+    ret.append(hltHICaloJet40)
+
+    hltHICaloJet50 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet50_v"),
+                                  triggerSelection = cms.string("HLT_AK4CaloJet50_v*"),
+                                  dqmhistolabel = cms.string("hltHICaloJet50")
+    )
+    ret.append(hltHICaloJet50)
+
+    hltHICaloJet80 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet80_v"),
+                                  triggerSelection = cms.string("HLT_AK4CaloJet80_v*"),
+                                  dqmhistolabel = cms.string("hltHICaloJet80")
+    )
+    ret.append(hltHICaloJet80)
+
+    hltHICaloJet100 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4CaloJet100_v"),
+                                  triggerSelection = cms.string("HLT_AK4CaloJet100_v*"),
+                                  dqmhistolabel = cms.string("hltHICaloJet100")
+    )
+    ret.append(hltHICaloJet100)
+
+
+    hltHIPFJet30 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_AK4PFJet30_v"),
+                                  triggerSelection = cms.string("HLT_AK4PFJet30_v*"),
+                                  dqmhistolabel = cms.string("hltHIPFJet30"),
+                                  partialFilterName  = cms.string("hltSingleAK4PFJet")
+                                  )
+    ret.append(hltHIPFJet30)
+
+    hltHIPFJet50 = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet50_v"),
+                                  triggerSelection = cms.string("HLT_AK4PFJet50_v*"),
+                                  dqmhistolabel = cms.string("hltHIPFJet50")
+    )
+    ret.append(hltHIPFJet50)
+
+    hltHIPFJet80 = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet80_v"),
+                                  triggerSelection = cms.string("HLT_AK4PFJet80_v*"),
+                                  dqmhistolabel = cms.string("hltHIPFJet80")
+    )
+    ret.append(hltHIPFJet80)
+
+    hltHIPFJet100 = hltHIPFJet30.clone(partialPathName = cms.string("HLT_AK4PFJet100_v"),
+                                  triggerSelection = cms.string("HLT_AK4PFJet100_v*"),
+                                  dqmhistolabel = cms.string("hltHIPFJet100")
+    )
+    ret.append(hltHIPFJet100)
+
+    hltHISinglePhoton10 = hltHICaloJet30.clone(partialPathName = cms.string("HLT_HISinglePhoton10_v"),
+                                               triggerSelection = cms.string("HLT_HISinglePhoton10_v*"),
+                                               dqmhistolabel = cms.string("hltHISinglePhoton10"),
+                                               partialFilterName  = cms.string("hltHIPhoton")
+    )
+    ret.append(hltHISinglePhoton10)
+
+    hltHISinglePhoton15 = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton15_v"),
+                                                    triggerSelection = cms.string("HLT_HISinglePhoton15_v*"),
+                                                    dqmhistolabel = cms.string("hltHISinglePhoton15")
+    )
+    ret.append(hltHISinglePhoton15)
+
+
+    hltHISinglePhoton20 = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton20_v"),
+                                                    triggerSelection = cms.string("HLT_HISinglePhoton20_v*"),
+                                                    dqmhistolabel = cms.string("hltHISinglePhoton20")
+    )
+    ret.append(hltHISinglePhoton20)
+
+    hltHISinglePhoton40 = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton40_v"),
+                                                    triggerSelection = cms.string("HLT_HISinglePhoton40_v*"),
+                                                    dqmhistolabel = cms.string("hltHISinglePhoton40")
+    )
+    ret.append(hltHISinglePhoton40)
+
+    hltHISinglePhoton60 = hltHISinglePhoton10.clone(partialPathName = cms.string("HLT_HISinglePhoton60_v"),
+                                                    triggerSelection = cms.string("HLT_HISinglePhoton60_v*"),
+                                                    dqmhistolabel = cms.string("hltHISinglePhoton60")
+    )
+    ret.append(hltHISinglePhoton60)
+
+    return ret
+
+def getHILowLumi():
+    ret = cms.VPSet()
+    ret.extend(getHILowLumiTriggers())
+    return ret
+
+dirname = "HLT/HI/"
+
+processName = "HLT"
+
+HILowLumiHLTOfflineSource = cms.EDAnalyzer("FSQDiJetAve",
+    triggerConfiguration =  cms.PSet(
+      hltResults = cms.InputTag('TriggerResults','',processName),
+      l1tResults = cms.InputTag(''),
+      #l1tResults = cms.InputTag('gtDigis'),
+      daqPartitions = cms.uint32(1),
+      l1tIgnoreMask = cms.bool( False ),
+      l1techIgnorePrescales = cms.bool( False ),
+      throw  = cms.bool( False )
+    ),
+
+#                                           hltProcessName = cms.string("HLT"),
+    # HLT paths passing any one of these regular expressions will be included    
+
+#    hltPathsToCheck = cms.vstring(
+#      "HLT_HISinglePhoton10_v1",
+#    ),
+
+#    requiredTriggers = cms.untracked.vstring(
+#      "HLT_HISinglePhoton10_v1",
+#    ),
+
+                                           
+    triggerSummaryLabel = cms.InputTag("hltTriggerSummaryAOD","", processName),
+    triggerResultsLabel = cms.InputTag("TriggerResults","", processName),
+    useGenWeight = cms.bool(False),
+    #useGenWeight = cms.bool(True),
+    todo = cms.VPSet(getHILowLumi())
+)
+
+#from JetMETCorrections.Configuration.CorrectedJetProducers_cff import *
+HILowLumiHLTOfflineSourceSequence = cms.Sequence(HILowLumiHLTOfflineSource)


### PR DESCRIPTION
These are HLT DQM modules meant to be used for the low-lumi PU=0.4 runs. Based in 741patch1. See pr into 75X here: https://github.com/cms-sw/cmssw/pull/9086

@richard-cms, @kkrajczar
