### PR TITLE
moved ParticleTowerProducer_cff.py to cfi for inclusion in confdb an…

### DIFF
--- a/RecoHI/HiJetAlgos/python/ParticleTowerProducer_cff.py
+++ b/RecoHI/HiJetAlgos/python/ParticleTowerProducer_cff.py
@@ -1,8 +1,0 @@
-import FWCore.ParameterSet.Config as cms
-
-
-particleTowerProducer = cms.EDProducer('ParticleTowerProducer',
-                                       src    = cms.InputTag('particleFlowTmp'),
-                                       useHF = cms.untracked.bool(True)
-                                       )
-

--- a/RecoHI/HiJetAlgos/python/ParticleTowerProducer_cfi.py
+++ b/RecoHI/HiJetAlgos/python/ParticleTowerProducer_cfi.py
@@ -1,0 +1,8 @@
+import FWCore.ParameterSet.Config as cms
+
+
+particleTowerProducer = cms.EDProducer('ParticleTowerProducer',
+                                       src    = cms.InputTag('particleFlowTmp'),
+                                       useHF = cms.untracked.bool(True)
+                                       )
+


### PR DESCRIPTION
Moved RecoHI/HiJetAlgos/python/ParticleTowerProducer_cff.py to cfi for inclusion in confdb and hlt dev.
See HLT Dev. Hypernews for relevant conversation (a search of my username I think is enough to find).

@kkrajczar
