### PR TITLE
Secondary input source improvements/fixes

### DIFF
--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -58,7 +58,7 @@ namespace edm {
     // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
     // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
     // and should be deleted from the code.
-    initialNumberOfEventsToSkip_(inputType == InputType::Primary ? pset.getUntrackedParameter<unsigned int>("skipEvents", 0U) : 0U),
+    initialNumberOfEventsToSkip_(inputType != InputType::SecondaryFile ? pset.getUntrackedParameter<unsigned int>("skipEvents", 0U) : 0U),
     noEventSort_(inputType == InputType::Primary ? pset.getUntrackedParameter<bool>("noEventSort", true) : false),
     skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
     bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
@@ -91,8 +91,9 @@ namespace edm {
       // For the secondary input source we do not stage in,
       // and we randomly choose the first file to open.
       // We cannot use the random number service yet.
-      unsigned int seed =  getpid();
-      seed = (seed << 16) + seed;
+      std::ifstream f("/dev/urandom");
+      unsigned int seed;
+      f.read(reinterpret_cast<char*>(&seed), sizeof(seed)); 
       std::default_random_engine dre(seed);
       size_t count = fileIterEnd_ - fileIterBegin_;
       std::uniform_int_distribution<int> distribution(0, count - 1);
@@ -122,7 +123,7 @@ namespace edm {
     }
     if(rootFile_) {
       productRegistryUpdate().updateFromInput(rootFile_->productRegistry()->productList());
-      if(initialNumberOfEventsToSkip_ != 0) {
+      if(inputType == InputType::Primary && initialNumberOfEventsToSkip_ != 0) {
         skipEvents(initialNumberOfEventsToSkip_);
       }
     }
@@ -700,17 +701,39 @@ namespace edm {
     productSelectorRules_ = ProductSelectorRules(pset, "inputCommands", "InputSource");
   }
 
+  void
+  RootInputFileSequence::skipEntries(unsigned int offset) {
+    while(offset > 0) {
+      while(offset > 0 && rootFile_->nextEventEntry()) {
+        --offset;
+      }
+      if(offset > 0) {
+        ++fileIter_;
+        if(fileIter_ == fileIterEnd_) {
+          fileIter_ = fileIterBegin_;
+        }
+        initFile(false);
+        assert(rootFile_);
+        rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
+      }
+    }
+  }
+
   bool
   RootInputFileSequence::readOneSequential(EventPrincipal& cache, size_t& fileNameHash) {
     skipBadFiles_ = false;
-    if(fileIter_ == fileIterEnd_ || !rootFile_) {
+    if(firstFile_) {
+      firstFile_ = false;
       if(fileIterEnd_ == fileIterBegin_) {
         throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
       }
-      fileIter_ = fileIterBegin_;
-      initFile(false);
+      if(fileIter_ != fileIterBegin_) {
+        fileIter_ = fileIterBegin_;
+        initFile(false);
+      }
       assert(rootFile_);
       rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
+      skipEntries(initialNumberOfEventsToSkip_);
     }
     assert(rootFile_);
     rootFile_->nextEventEntry();
@@ -718,7 +741,7 @@ namespace edm {
     if(!found) {
       ++fileIter_;
       if(fileIter_ == fileIterEnd_) {
-        return false;
+        fileIter_ = fileIterBegin_;
       }
       initFile(false);
       assert(rootFile_);
@@ -731,11 +754,29 @@ namespace edm {
 
   bool
   RootInputFileSequence::readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id) {
-    if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequentialWithID(): no input files specified for secondary input source.\n";
-    }
     skipBadFiles_ = false;
-    if(fileIter_ == fileIterEnd_ || !rootFile_ ||
+    if(firstFile_) {
+      firstFile_ = false;
+      if(fileIterEnd_ == fileIterBegin_) {
+        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
+      }
+      if(fileIter_ != fileIterBegin_) {
+        fileIter_ = fileIterBegin_;
+        initFile(false);
+      }
+      assert(rootFile_);
+      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
+      int offset = initialNumberOfEventsToSkip_;
+      while(offset > 0) {
+        bool found = readOneSequentialWithID(cache, fileNameHash, id);
+        if(!found) {
+          return false;
+        }
+        --offset;
+      }
+    }
+    assert(rootFile_);
+    if(fileIter_ == fileIterEnd_ ||
         rootFile_->indexIntoFileIter().run() != id.run() ||
         rootFile_->indexIntoFileIter().lumi() != id.luminosityBlock()) {
       bool found = skipToItem(id.run(), id.luminosityBlock(), 0, 0, false);
@@ -761,6 +802,7 @@ namespace edm {
 
   void
   RootInputFileSequence::readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& idx) {
+    firstFile_ = false;
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSpecified(): no input files specified for secondary input source.\n";
     }
@@ -779,10 +821,12 @@ namespace edm {
     if(fileNameHash == 0U)  {
       fileNameHash = lfnHash_;
     }
+    std::cerr << "Sequential event: " << cache.id() << std::endl;
   }
 
   void
   RootInputFileSequence::readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine) {
+    firstFile_ = false;
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandom(): no input files specified for secondary input source.\n";
     }
@@ -820,6 +864,7 @@ namespace edm {
 
   bool
   RootInputFileSequence::readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, CLHEP::HepRandomEngine* engine) {
+    firstFile_ = false;
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandomWithID(): no input files specified for secondary input source.\n";
     }

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -60,6 +60,7 @@ namespace edm {
     void endJob();
     InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     bool containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
+    void skipEntries(unsigned int offset);
     bool skipEvents(int offset);
     bool goToEvent(EventID const& eventID);
     bool skipToItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, size_t fileNameHash = 0U, bool currentFileFirst = true);

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -57,7 +57,7 @@ namespace edm {
         lumiSpecified_(pset.getUntrackedParameter<bool>("lumiSpecified", false)),
         firstEvent_(true),
         firstLoop_(true),
-        expectedEventNumber_(1) {
+        expectedEventNumber_(sequential_ ? pset.getParameterSet("input").getUntrackedParameter<unsigned int>("skipEvents", 0) + 1 : 1) {
     processConfiguration_->setParameterSetID(ParameterSet::emptyParameterSetID());
     processConfiguration_->setProcessConfigurationID();
  

--- a/IOPool/SecondaryInput/test/SecondarySeqInLumiInputTest_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondarySeqInLumiInputTest_cfg.py
@@ -15,6 +15,7 @@ process.Thing = cms.EDProducer("SecondaryProducer",
     sequential = cms.untracked.bool(True),
     lumiSpecified = cms.untracked.bool(True),
     input = cms.SecSource("PoolSource",
+        skipEvents = cms.untracked.uint32(3),
         fileNames = cms.untracked.vstring('file:SecondaryInputTest2.root')
     )
 )

--- a/IOPool/SecondaryInput/test/SecondarySeqInputTest_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondarySeqInputTest_cfg.py
@@ -14,6 +14,7 @@ process.source = cms.Source("PoolSource",
 process.Thing = cms.EDProducer("SecondaryProducer",
     sequential = cms.untracked.bool(True),
     input = cms.SecSource("PoolSource",
+        skipEvents = cms.untracked.uint32(5),
         fileNames = cms.untracked.vstring('file:SecondaryInputTest2.root')
     )
 )


### PR DESCRIPTION
This PR makes several improvements/fixes to the secondary input source.
1) In "sequential" mode (referred to as "deterministic" mode by WMAgent), the skipEvents parameter is currently  ignored silently.  This PR implements the initial skipping of events if this parameter is non-zero.
2) In sequential mode, the secondary source currently will not return any more events after the last event in the last file specified.  This PR implements looping back to the beginning of the first file.
3) The secondary input source opens a random input file in its ctor.  The random number seed uses getpid() to determine the seed.  Brian Bockelman pointed out that getpid() is deterministic at some sites.  This PR replaces the use of getpid() with /dev/urandom to determine the seed.  Note that linux and OSX both support /dev/urandom.
4) When the randomization of the first input file was implemented, a bug was introduced in sequential mode such that the sequence of events began with the randomly chosen file, rather than the first file.
This bug is fixed by the same change that implements 1).
Note that 1), and possibly 2), are needed by any reasonable deterministic scheme to avoid duplication of premixed pileup.
5) The secondary input source unit tests are enhanced to test that the skipEvents parameter is working correctly.
