### PR TITLE
Use consumes interface for TrackerHitAssociator(ALCA)

### DIFF
--- a/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
+++ b/CalibTracker/SiPixelErrorEstimation/interface/SiPixelErrorEstimation.h
@@ -380,6 +380,7 @@ class SiPixelErrorEstimation : public edm::EDAnalyzer
 
   TTree * ttree_track_hits_strip_;
   
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 };
 
 #endif

--- a/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
+++ b/CalibTracker/SiPixelErrorEstimation/src/SiPixelErrorEstimation.cc
@@ -34,7 +34,8 @@ using namespace std;
 using namespace edm;
 
 SiPixelErrorEstimation::SiPixelErrorEstimation(const edm::ParameterSet& ps):tfile_(0), ttree_all_hits_(0), 
-									    ttree_track_hits_(0), ttree_track_hits_strip_(0) 
+									    ttree_track_hits_(0), ttree_track_hits_strip_(0),
+									    trackerHitAssociatorConfig_(consumesCollector())
 {
   //Read config file
   outputFile_ = ps.getUntrackedParameter<string>( "outputFile", "SiPixelErrorEstimation_Ntuple.root" );
@@ -391,7 +392,7 @@ SiPixelErrorEstimation::analyze(const edm::Event& e, const edm::EventSetup& es)
   float mindist = 999999.9;
 
   std::vector<PSimHit> matched;
-  TrackerHitAssociator associate(e);
+  TrackerHitAssociator associate(e, trackerHitAssociatorConfig_);
 
   edm::ESHandle<TrackerGeometry> pDD;
   es.get<TrackerDigiGeometryRecord> ().get (pDD);

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.cc
@@ -38,7 +38,7 @@ using namespace reco;
 using namespace analyzer;
 
 SiPixelLorentzAngle::SiPixelLorentzAngle(edm::ParameterSet const& conf) : 
-  conf_(conf), filename_(conf.getParameter<std::string>("fileName")), filenameFit_(conf.getParameter<std::string>("fileNameFit")), ptmin_(conf.getParameter<double>("ptMin")), simData_(conf.getParameter<bool>("simData")),	normChi2Max_(conf.getParameter<double>("normChi2Max")), clustSizeYMin_(conf.getParameter<int>("clustSizeYMin")), residualMax_(conf.getParameter<double>("residualMax")), clustChargeMax_(conf.getParameter<double>("clustChargeMax")),hist_depth_(conf.getParameter<int>("binsDepth")), hist_drift_(conf.getParameter<int>("binsDrift"))
+  filename_(conf.getParameter<std::string>("fileName")), filenameFit_(conf.getParameter<std::string>("fileNameFit")), ptmin_(conf.getParameter<double>("ptMin")), simData_(conf.getParameter<bool>("simData")),	normChi2Max_(conf.getParameter<double>("normChi2Max")), clustSizeYMin_(conf.getParameter<int>("clustSizeYMin")), residualMax_(conf.getParameter<double>("residualMax")), clustChargeMax_(conf.getParameter<double>("clustChargeMax")),hist_depth_(conf.getParameter<int>("binsDepth")), hist_drift_(conf.getParameter<int>("binsDrift")), trackerHitAssociatorConfig_(consumesCollector())
 {
   //   	anglefinder_=new  TrackLocalAngle(conf);
   hist_x_ = 50;
@@ -168,8 +168,8 @@ void SiPixelLorentzAngle::analyze(const edm::Event& e, const edm::EventSetup& es
   es.get<TrackerDigiGeometryRecord>().get(estracker);
   tracker=&(* estracker);
 
-  TrackerHitAssociator* associate;
-  if(simData_) associate = new TrackerHitAssociator(e); else associate = 0; 
+  std::unique_ptr<TrackerHitAssociator> associate;
+  if (simData_) associate.reset(new TrackerHitAssociator(e, trackerHitAssociatorConfig_));
   // restet values
   module_=-1;
   layer_=-1;

--- a/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
+++ b/CalibTracker/SiPixelLorentzAngle/src/SiPixelLorentzAngle.h
@@ -144,7 +144,6 @@ class SiPixelLorentzAngle : public edm::EDAnalyzer
   Rechit rechitF_;
   
   // parameters from config file
-  edm::ParameterSet conf_;
   std::string filename_;
   std::string filenameFit_;
   double ptmin_;
@@ -155,7 +154,10 @@ class SiPixelLorentzAngle : public edm::EDAnalyzer
   double clustChargeMax_;
   int hist_depth_;
   int hist_drift_;
-  
+
+  // for the TrackerHitAssociator
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+
   // histogram etc
   int hist_x_;
   int hist_y_;

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.cc
@@ -34,7 +34,8 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
-IsolatedTracksCone::IsolatedTracksCone(const edm::ParameterSet& iConfig) {
+IsolatedTracksCone::IsolatedTracksCone(const edm::ParameterSet& iConfig) :
+   trackerHitAssociatorConfig_(consumesCollector()) {
 
   //now do what ever initialization is needed
   doMC            = iConfig.getUntrackedParameter<bool>  ("DoMC", false); 
@@ -289,8 +290,8 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent,
   ////////////////////////////
   // Primary loop over tracks
   ////////////////////////////
-  TrackerHitAssociator* associate=0;
-  if (doMC) associate = new TrackerHitAssociator(iEvent);
+  std::unique_ptr<TrackerHitAssociator> associate;
+  if (doMC) associate.reset(new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
   
 
   nTRK      = 0;
@@ -916,8 +917,6 @@ void IsolatedTracksCone::analyze(const edm::Event& iEvent,
   ntp->Fill();
   nEVT++;
   
-  
-  delete associate;
 }
   
 

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.h
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksCone.h
@@ -58,6 +58,9 @@
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
 
+// tracker hit associator
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+
 // ecal / hcal
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -120,6 +123,8 @@ private:
   int    myverbose_;
   bool   useJetTrigger_;
   double drLeadJetVeto_, ptMinLeadJet_;
+
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   edm::EDGetTokenT<l1extra::L1JetParticleCollection> tok_L1extTauJet_;
   edm::EDGetTokenT<l1extra::L1JetParticleCollection> tok_L1extCenJet_;

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.cc
@@ -14,7 +14,8 @@
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgo.h"
 #include "RecoLocalCalo/EcalRecAlgos/interface/EcalSeverityLevelAlgoRcd.h"
 
-IsolatedTracksHcalScale::IsolatedTracksHcalScale(const edm::ParameterSet& iConfig) {
+IsolatedTracksHcalScale::IsolatedTracksHcalScale(const edm::ParameterSet& iConfig) :
+   trackerHitAssociatorConfig_(consumesCollector()) {
 
   //now do what ever initialization is needed
   doMC                                = iConfig.getUntrackedParameter<bool>("DoMC", false); 
@@ -155,7 +156,7 @@ void IsolatedTracksHcalScale::analyze(const edm::Event& iEvent, const edm::Event
   edm::Handle<edm::PCaloHitContainer> pcalohh;
 
   //associates tracker rechits/simhits to a track
-  TrackerHitAssociator* associate=0;
+  std::unique_ptr<TrackerHitAssociator> associate;
  
   if (doMC) {
     iEvent.getByToken(tok_simTk_,SimTk);
@@ -163,7 +164,7 @@ void IsolatedTracksHcalScale::analyze(const edm::Event& iEvent, const edm::Event
     iEvent.getByToken(tok_caloEB_, pcaloeb);
     iEvent.getByToken(tok_caloEE_, pcaloee);
     iEvent.getByToken(tok_caloHH_, pcalohh);
-    associate = new TrackerHitAssociator(iEvent);
+    associate.reset(new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
   }
  
   unsigned int nTracks=0;
@@ -326,8 +327,6 @@ void IsolatedTracksHcalScale::analyze(const edm::Event& iEvent, const edm::Event
     }
   }
 
-  //  delete associate;
-  if (associate) delete associate;
   tree->Fill();
 }
 

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.h
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksHcalScale.h
@@ -76,6 +76,10 @@
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
+
+// tracker hit associator
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+
 // ecal / hcal
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -131,6 +135,8 @@ private:
   spr::trackSelectionParameters selectionParameters;
   double      a_mipR, a_coneR, a_charIsoR, a_neutIsoR;
   double      tMinE_, tMaxE_;
+
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   edm::EDGetTokenT<reco::TrackCollection>   tok_genTrack_;
   edm::EDGetTokenT<reco::VertexCollection>  tok_recVtx_;

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.cc
@@ -32,7 +32,8 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
 
-IsolatedTracksNxN::IsolatedTracksNxN(const edm::ParameterSet& iConfig) {
+IsolatedTracksNxN::IsolatedTracksNxN(const edm::ParameterSet& iConfig) :
+   trackerHitAssociatorConfig_(consumesCollector()) {
 
   //now do what ever initialization is needed
   doMC                   = iConfig.getUntrackedParameter<bool>  ("DoMC", false); 
@@ -455,8 +456,8 @@ void IsolatedTracksNxN::analyze(const edm::Event& iEvent, const edm::EventSetup&
   if (doMC) iEvent.getByToken(tok_caloHH_, pcalohh);
   
   //associates tracker rechits/simhits to a track
-  TrackerHitAssociator* associate=0;
-  if (doMC) associate = new TrackerHitAssociator(iEvent);
+  std::unique_ptr<TrackerHitAssociator> associate;
+  if (doMC) associate.reset(new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
 
   //===================================================================================
   

--- a/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.h
+++ b/Calibration/IsolatedParticles/plugins/IsolatedTracksNxN.h
@@ -70,6 +70,10 @@
 #include "TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h"
 #include "TrackingTools/TrackAssociator/interface/TrackDetectorAssociator.h"
 #include "SimTracker/Records/interface/TrackAssociatorRecord.h"
+
+// tracker hit associator
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
+
 // ecal / hcal
 #include "Geometry/CaloGeometry/interface/CaloGeometry.h"
 #include "Geometry/CaloGeometry/interface/CaloSubdetectorGeometry.h"
@@ -149,6 +153,8 @@ private:
   int    debugTrks_;
   bool   printTrkHitPattern_;
   int    myverbose_;
+
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   edm::EDGetTokenT<l1extra::L1JetParticleCollection>  tok_L1extTauJet_;
   edm::EDGetTokenT<l1extra::L1JetParticleCollection>  tok_L1extCenJet_;


### PR DESCRIPTION
This PR modifies uses of TrackerHitAssocator to use the consumes interface needed for multithreading.  This PR is for packages in the ALCA L2 category.
