### PR TITLE
Use consumes interface for TrackerHitAssociator(RECO)

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/test/ClusterRefinerTagMCmerged.h
+++ b/RecoLocalTracker/SiStripClusterizer/test/ClusterRefinerTagMCmerged.h
@@ -33,8 +33,10 @@ private:
   typedef edm::EDGetTokenT< edmNew::DetSetVector<SiStripCluster> > token_t;
   token_t inputToken;
   edm::ParameterSet confClusterRefiner_;
+  bool useAssociateHit_; 
 
-  std::shared_ptr<TrackerHitAssociator> associator_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+  std::unique_ptr<TrackerHitAssociator> associator_;
 
 };
 

--- a/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugTrackCandidateMaker.h
@@ -26,7 +26,7 @@ namespace cms {
       lastSeed(TrajectorySeedCollection& theSeedColl){return theSeedColl.begin()+1;}
 
     void initDebugger(edm::EventSetup const & es){
-      dbg = new CkfDebugger(es);
+      dbg = new CkfDebugger(es, consumesCollector());
       myTrajectoryBuilder = dynamic_cast<const CkfDebugTrajectoryBuilder*>(theTrajectoryBuilder.get());
       if (myTrajectoryBuilder) myTrajectoryBuilder->setDebugger( dbg);
       else throw cms::Exception("CkfDebugger") << "please use CkfDebugTrajectoryBuilder";

--- a/RecoTracker/DebugTools/interface/CkfDebugger.h
+++ b/RecoTracker/DebugTools/interface/CkfDebugger.h
@@ -42,7 +42,7 @@ typedef TransientTrackingRecHit::ConstRecHitPointer CTTRHp;
 
 class CkfDebugger {
  public:
-  CkfDebugger( edm::EventSetup const & es );
+  CkfDebugger( edm::EventSetup const & es, edm::ConsumesCollector&& iC );
 
   ~CkfDebugger();
   
@@ -101,6 +101,7 @@ class CkfDebugger {
   const GeometricSearchTracker*    theGeomSearchTracker;
   const MeasurementEstimator*  theChi2;
   const Propagator*                theForwardPropagator;
+  TrackerHitAssociator::Config     trackerHitAssociatorConfig_; 
   TrackerHitAssociator*      hitAssociator;
   const MeasurementTracker*        theMeasurementTracker;
   const TransientTrackingRecHitBuilder* theTTRHBuilder;

--- a/RecoTracker/DebugTools/interface/TestHits.h
+++ b/RecoTracker/DebugTools/interface/TestHits.h
@@ -59,8 +59,7 @@ private:
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 
-  const edm::ParameterSet conf_;
-  TrackerHitAssociator * hitAssociator;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   double mineta, maxeta;
 

--- a/RecoTracker/DebugTools/interface/TestSmoothHits.h
+++ b/RecoTracker/DebugTools/interface/TestSmoothHits.h
@@ -60,8 +60,7 @@ private:
 
   std::pair<LocalPoint,LocalVector> projectHit(const PSimHit&, const StripGeomDetUnit*, const BoundPlane&);
 
-  const edm::ParameterSet conf_;
-  TrackerHitAssociator * hitAssociator;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   double mineta, maxeta;
 

--- a/RecoTracker/DebugTools/interface/TestTrackHits.h
+++ b/RecoTracker/DebugTools/interface/TestTrackHits.h
@@ -77,8 +77,7 @@ private:
     throw cms::Exception("CkfDebugger error: rechit of dimension not 1,2,3,4,5");
   }
 
-  const edm::ParameterSet conf_;
-  TrackerHitAssociator * hitAssociator;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   std::string propagatorName;
   std::string builderName;

--- a/RecoTracker/DebugTools/plugins/CkfDebugger.cc
+++ b/RecoTracker/DebugTools/plugins/CkfDebugger.cc
@@ -34,7 +34,7 @@
 
 using namespace std;
 
-CkfDebugger::CkfDebugger( edm::EventSetup const & es ):totSeeds(0)
+CkfDebugger::CkfDebugger( edm::EventSetup const & es, edm::ConsumesCollector&& iC):trackerHitAssociatorConfig_(std::move(iC)), totSeeds(0)
 {
   file = new TFile("out.root","recreate");
   hchi2seedAll = new TH1F("hchi2seedAll","hchi2seedAll",2000,0,200);
@@ -157,7 +157,7 @@ void CkfDebugger::printSimHits( const edm::Event& iEvent)
 {
   edm::LogVerbatim("CkfDebugger") << "\nEVENT #" << iEvent.id();
 
-  hitAssociator = new TrackerHitAssociator(iEvent);//delete deleteHitAssociator() in TrackCandMaker.cc
+  hitAssociator = new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_);//delete deleteHitAssociator() in TrackCandMaker.cc
 
   std::map<unsigned int, std::vector<PSimHit> >& theHitsMap = hitAssociator->SimHitMap;
   idHitsMap.clear();

--- a/RecoTracker/DebugTools/plugins/TestHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestHits.cc
@@ -22,14 +22,14 @@ using namespace std;
 using namespace edm;
 
 TestHits::TestHits(const edm::ParameterSet& iConfig):
-  conf_(iConfig){
-  LogTrace("TestHits") << conf_<< std::endl;
-  propagatorName = conf_.getParameter<std::string>("Propagator");   
-  builderName = conf_.getParameter<std::string>("TTRHBuilder");   
-  srcName = conf_.getParameter<std::string>("src");   
-  fname = conf_.getParameter<std::string>("Fitter");
-  mineta = conf_.getParameter<double>("mineta");
-  maxeta = conf_.getParameter<double>("maxeta");
+  trackerHitAssociatorConfig_(consumesCollector()) {
+  LogTrace("TestHits") << iConfig<< std::endl;
+  propagatorName = iConfig.getParameter<std::string>("Propagator");   
+  builderName = iConfig.getParameter<std::string>("TTRHBuilder");   
+  srcName = iConfig.getParameter<std::string>("src");   
+  fname = iConfig.getParameter<std::string>("Fitter");
+  mineta = iConfig.getParameter<double>("mineta");
+  maxeta = iConfig.getParameter<double>("maxeta");
 }
 
 TestHits::~TestHits(){}
@@ -195,7 +195,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
   LogTrace("TestHits") << "\nnew event";
 
   iEvent.getByLabel(srcName,theTCCollection ); 
-  hitAssociator = new TrackerHitAssociator(iEvent);
+  TrackerHitAssociator hitAssociator(iEvent, trackerHitAssociatorConfig_);
 
   TrajectoryStateCombiner combiner;
 
@@ -245,7 +245,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
       double delta = 99999;
       LocalPoint rhitLPv = rhit->localPosition();
 
-      std::vector<PSimHit> assSimHits = hitAssociator->associateHit(*(rhit->hit()));
+      std::vector<PSimHit> assSimHits = hitAssociator.associateHit(*(rhit->hit()));
       if (assSimHits.size()==0) continue;
       PSimHit shit;
       for(std::vector<PSimHit>::const_iterator m=assSimHits.begin(); m<assSimHits.end(); m++){
@@ -402,7 +402,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
         auto m = dynamic_cast<const SiStripMatchedRecHit2D*>((rhit)->hit())->monoHit();
 	CTTRHp tMonoHit = theBuilder->build(&m);
 	if (tMonoHit==0) continue;
-	vector<PSimHit> assMonoSimHits = hitAssociator->associateHit(*tMonoHit->hit());
+	vector<PSimHit> assMonoSimHits = hitAssociator.associateHit(*tMonoHit->hit());
 	if (assMonoSimHits.size()==0) continue;
 	const PSimHit sMonoHit = *(assSimHits.begin());
 	const Surface * monoSurf = &( tMonoHit->det()->surface() );
@@ -497,7 +497,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 	CTTRHp tStereoHit = 
 	  theBuilder->build(&s);
 	if (tStereoHit==0) continue;
-	vector<PSimHit> assStereoSimHits = hitAssociator->associateHit(*tStereoHit->hit());
+	vector<PSimHit> assStereoSimHits = hitAssociator.associateHit(*tStereoHit->hit());
 	if (assStereoSimHits.size()==0) continue;
 	const PSimHit sStereoHit = *(assSimHits.begin());
 	const Surface * stereoSurf = &( tStereoHit->det()->surface() );
@@ -591,7 +591,6 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
     LogTrace("TestHits") << "traj chi2="  << tchi2 ;
     LogTrace("TestHits") << "track chi2=" << result[0].chiSquared() ;
   }
-  delete hitAssociator;
   LogTrace("TestHits") << "end of event" << std::endl;
 }
 //     TSOS lastState = theTSOS;
@@ -628,7 +627,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 //       double delta = 99999;
 //       LocalPoint rhitLP = rhit->localPosition();
 
-//       std::vector<PSimHit> assSimHits = hitAssociator->associateHit(*(*rhit)->hit());
+//       std::vector<PSimHit> assSimHits = hitAssociator.associateHit(*(*rhit)->hit());
 //       if (assSimHits.size()==0) continue;
 //       PSimHit shit;
 //       for(std::vector<PSimHit>::const_iterator m=assSimHits.begin(); m<assSimHits.end(); m++){
@@ -747,7 +746,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 // 	CTTRHp tMonoHit = 
 // 	  theBuilder->build(dynamic_cast<const SiStripMatchedRecHit2D*>((*rhit)->hit())->monoHit());
 // 	if (tMonoHit==0) continue;
-// 	vector<PSimHit> assMonoSimHits = hitAssociator->associateHit(*tMonoHit->hit());
+// 	vector<PSimHit> assMonoSimHits = hitAssociator.associateHit(*tMonoHit->hit());
 // 	if (assMonoSimHits.size()==0) continue;
 // 	const PSimHit sMonoHit = *(assSimHits.begin());
 // 	const Surface * monoSurf = &( tMonoHit->det()->surface() );
@@ -841,7 +840,7 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 // 	CTTRHp tStereoHit = 
 // 	  theBuilder->build(dynamic_cast<const SiStripMatchedRecHit2D*>((*rhit)->hit())->stereoHit());
 // 	if (tStereoHit==0) continue;
-// 	vector<PSimHit> assStereoSimHits = hitAssociator->associateHit(*tStereoHit->hit());
+// 	vector<PSimHit> assStereoSimHits = hitAssociator.associateHit(*tStereoHit->hit());
 // 	if (assStereoSimHits.size()==0) continue;
 // 	const PSimHit sStereoHit = *(assSimHits.begin());
 // 	const Surface * stereoSurf = &( tStereoHit->det()->surface() );
@@ -932,7 +931,6 @@ void TestHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
 //       }
 //     }
 //   }
-//   delete hitAssociator;
 //   LogTrace("TestHits") << "end of event" << std::endl;
 // }
 

--- a/RecoTracker/DebugTools/plugins/TestOutliers.cc
+++ b/RecoTracker/DebugTools/plugins/TestOutliers.cc
@@ -67,9 +67,9 @@ private:
   edm::InputTag trackTagsOut_; //used to select what tracks to read from configuration file
   edm::InputTag trackTagsOld_; //used to select what tracks to read from configuration file
   edm::InputTag tpTags_; //used to select what tracks to read from configuration file
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> theAssociatorOldToken;
   edm::EDGetTokenT<reco::TrackToTrackingParticleAssociator> theAssociatorOutToken;
-  TrackerHitAssociator* hitAssociator;
   edm::ESHandle<TrackerGeometry> theG;
   std::string out;
   TFile * file;
@@ -122,6 +122,7 @@ TestOutliers::TestOutliers(const edm::ParameterSet& iConfig)
   trackTagsOut_(iConfig.getUntrackedParameter<edm::InputTag>("tracksOut")),
   trackTagsOld_(iConfig.getUntrackedParameter<edm::InputTag>("tracksOld")),
   tpTags_(iConfig.getUntrackedParameter<edm::InputTag>("tp")),
+  trackerHitAssociatorConfig_(consumesCollector()),
   theAssociatorOldToken(consumes<reco::TrackToTrackingParticleAssociator>(iConfig.getUntrackedParameter<edm::InputTag>("TrackAssociatorByHitsOld"))),
   theAssociatorOutToken(consumes<reco::TrackToTrackingParticleAssociator>(iConfig.getUntrackedParameter<edm::InputTag>("TrackAssociatorByHitsOut"))),
   out(iConfig.getParameter<std::string>("out"))
@@ -177,7 +178,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
   edm::Handle<reco::BeamSpot> beamSpot;
   iEvent.getByLabel("offlineBeamSpot",beamSpot); 
 
-  hitAssociator = new TrackerHitAssociator(iEvent);
+  TrackerHitAssociator hitAssociator(iEvent, trackerHitAssociatorConfig_);
 
   edm::Handle<reco::TrackToTrackingParticleAssociator> hAssociatorOld;
   iEvent.getByToken(theAssociatorOldToken, hAssociatorOld);
@@ -546,7 +547,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	      
 	    //LogTrace("TestOutliers") << "vector<SimHitIdpr>";		  
 	    //look if the hit comes from a correct sim track
-	    std::vector<SimHitIdpr> simTrackIds = hitAssociator->associateHitId(**itHit);
+	    std::vector<SimHitIdpr> simTrackIds = hitAssociator.associateHitId(**itHit);
 	    bool goodhit = false;
 	    for(size_t j=0; j<simTrackIds.size(); j++){
 	      for (size_t jj=0; jj<tpids.size(); jj++){
@@ -596,7 +597,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	    //get the vector of sim hit associated and choose the one with the largest energy loss
 	    //double delta = 99999;
 	    //LocalPoint rhitLPv = (*itHit)->localPosition();
-	    //vector<PSimHit> assSimHits = hitAssociator->associateHit(**itHit);
+	    //vector<PSimHit> assSimHits = hitAssociator.associateHit(**itHit);
 	    //if (assSimHits.size()==0) continue;
 	    //PSimHit shit;
 	    //for(std::vector<PSimHit>::const_iterator m=assSimHits.begin(); m<assSimHits.end(); m++){
@@ -610,7 +611,7 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	    unsigned int monoId = 0;
 	    std::vector<double> energyLossM;
 	    std::vector<double> energyLossS;
-	    std::vector<PSimHit> assSimHits = hitAssociator->associateHit(**itHit);
+	    std::vector<PSimHit> assSimHits = hitAssociator.associateHit(**itHit);
 	    if (assSimHits.size()==0) continue;
 	    PSimHit shit;
 	    std::vector<unsigned int> trackIds;
@@ -888,7 +889,6 @@ TestOutliers::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup) {
       }
     }    
   }
-  delete hitAssociator;
 }
 
 

--- a/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestSmoothHits.cc
@@ -21,15 +21,15 @@ using namespace std;
 using namespace edm;
 
 TestSmoothHits::TestSmoothHits(const edm::ParameterSet& iConfig):
-  conf_(iConfig){
-  LogTrace("TestSmoothHits") << conf_<< std::endl;
-  propagatorName = conf_.getParameter<std::string>("Propagator");   
-  builderName = conf_.getParameter<std::string>("TTRHBuilder");   
-  srcName = conf_.getParameter<std::string>("src");   
-  fname = conf_.getParameter<std::string>("Fitter");
-  sname = conf_.getParameter<std::string>("Smoother");
-  mineta = conf_.getParameter<double>("mineta");
-  maxeta = conf_.getParameter<double>("maxeta");
+  trackerHitAssociatorConfig_(consumesCollector()){
+  LogTrace("TestSmoothHits") << iConfig<< std::endl;
+  propagatorName = iConfig.getParameter<std::string>("Propagator");   
+  builderName = iConfig.getParameter<std::string>("TTRHBuilder");   
+  srcName = iConfig.getParameter<std::string>("src");   
+  fname = iConfig.getParameter<std::string>("Fitter");
+  sname = iConfig.getParameter<std::string>("Smoother");
+  mineta = iConfig.getParameter<double>("mineta");
+  maxeta = iConfig.getParameter<double>("maxeta");
 }
 
 TestSmoothHits::~TestSmoothHits(){}
@@ -196,7 +196,7 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
   LogTrace("TestSmoothHits") << "new event" << std::endl;
 
   iEvent.getByLabel(srcName,theTCCollection ); 
-  hitAssociator = new TrackerHitAssociator(iEvent);
+  TrackerHitAssociator hitAssociator(iEvent, trackerHitAssociatorConfig_);
 
   TrajectoryStateCombiner combiner;
 
@@ -251,7 +251,7 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       double delta = 99999;
       LocalPoint rhitLPv = rhit->localPosition();
 
-      std::vector<PSimHit> assSimHits = hitAssociator->associateHit(*(rhit->hit()));
+      std::vector<PSimHit> assSimHits = hitAssociator.associateHit(*(rhit->hit()));
       if (assSimHits.size()==0) continue;
       PSimHit shit;
       for(std::vector<PSimHit>::const_iterator m=assSimHits.begin(); m<assSimHits.end(); m++){
@@ -440,7 +440,7 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 	CTTRHp tMonoHit = 
 	  theBuilder->build(&m);
 	if (tMonoHit==0) continue;
-	vector<PSimHit> assMonoSimHits = hitAssociator->associateHit(*tMonoHit->hit());
+	vector<PSimHit> assMonoSimHits = hitAssociator.associateHit(*tMonoHit->hit());
 	if (assMonoSimHits.size()==0) continue;
 	const PSimHit sMonoHit = *(assSimHits.begin());
 	const Surface * monoSurf = &( tMonoHit->det()->surface() );
@@ -535,7 +535,7 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
 	CTTRHp tStereoHit = 
 	  theBuilder->build(&s);
 	if (tStereoHit==0) continue;
-	vector<PSimHit> assStereoSimHits = hitAssociator->associateHit(*tStereoHit->hit());
+	vector<PSimHit> assStereoSimHits = hitAssociator.associateHit(*tStereoHit->hit());
 	if (assStereoSimHits.size()==0) continue;
 	const PSimHit sStereoHit = *(assSimHits.begin());
 	const Surface * stereoSurf = &( tStereoHit->det()->surface() );
@@ -628,7 +628,6 @@ void TestSmoothHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iS
       //#endif
     }
   }
-  delete hitAssociator;
   LogTrace("TestSmoothHits") << "end of event" << std::endl;
 }
 

--- a/RecoTracker/DebugTools/plugins/TestTrackHits.cc
+++ b/RecoTracker/DebugTools/plugins/TestTrackHits.cc
@@ -16,15 +16,15 @@ using namespace std;
 using namespace edm;
 
 TestTrackHits::TestTrackHits(const edm::ParameterSet& iConfig):
-  conf_(iConfig) {
-  LogTrace("TestTrackHits") << conf_;
-  propagatorName = conf_.getParameter<std::string>("Propagator");   
-  builderName = conf_.getParameter<std::string>("TTRHBuilder");   
-  srcName = conf_.getParameter<std::string>("src");   
-  tpName = conf_.getParameter<std::string>("tpname");   
-  updatorName = conf_.getParameter<std::string>("updator");
-  out = conf_.getParameter<std::string>("out");
-//   ParameterSet cuts = conf_.getParameter<ParameterSet>("RecoTracksCuts"); 
+   trackerHitAssociatorConfig_(consumesCollector()) {
+  LogTrace("TestTrackHits") << iConfig;
+  propagatorName = iConfig.getParameter<std::string>("Propagator");   
+  builderName = iConfig.getParameter<std::string>("TTRHBuilder");   
+  srcName = iConfig.getParameter<std::string>("src");   
+  tpName = iConfig.getParameter<std::string>("tpname");   
+  updatorName = iConfig.getParameter<std::string>("updator");
+  out = iConfig.getParameter<std::string>("out");
+//   ParameterSet cuts = iConfig.getParameter<ParameterSet>("RecoTracksCuts"); 
 //   selectRecoTracks = RecoTrackSelector(cuts.getParameter<double>("ptMin"),
 // 				       cuts.getParameter<double>("minRapidity"),
 // 				       cuts.getParameter<double>("maxRapidity"),
@@ -267,7 +267,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   iEvent.getByLabel("trackAssociatorByHits",trackAssociator);
 
 
-  hitAssociator = new TrackerHitAssociator(iEvent);
+  TrackerHitAssociator hitAssociator(iEvent, trackerHitAssociatorConfig_);
   
   reco::RecoToSimCollection recSimColl=trackAssociator->associateRecoToSim(trackCollectionHandle,
 									   trackingParticleCollectionHandle);
@@ -354,7 +354,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       unsigned int monoId = 0;
       std::vector<double> energyLossM;
       std::vector<double> energyLossS;
-      std::vector<PSimHit> assSimHits = hitAssociator->associateHit(*(rhit)->hit());
+      std::vector<PSimHit> assSimHits = hitAssociator.associateHit(*(rhit)->hit());
       unsigned int  simhitvecsize = assSimHits.size();
       if (simhitvecsize==0) continue;
       PSimHit shit;
@@ -383,7 +383,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       }
       //double delta = 99999;
       //LocalPoint rhitLPv = rhit->localPosition();
-      //vector<PSimHit> assSimHits = hitAssociator->associateHit(*(rhit)->hit());
+      //vector<PSimHit> assSimHits = hitAssociator.associateHit(*(rhit)->hit());
       //unsigned int  simhitvecsize = assSimHits.size();
       //if (simhitvecsize==0) continue;
       //PSimHit shit;
@@ -448,7 +448,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
       //       if (dynamic_cast<const SiStripRecHit2D*>(rhit->hit()))	
       // 	hClsize_vs_Chi2->Fill( chi2increment, ((const SiStripRecHit2D*)(rhit->hit()))->cluster()->amplitudes().size() );
 
-      std::vector<SimHitIdpr> simTrackIds = hitAssociator->associateHitId(*(rhit)->hit());
+      std::vector<SimHitIdpr> simTrackIds = hitAssociator.associateHitId(*(rhit)->hit());
       bool goodhit = false;
       for(size_t j=0; j<simTrackIds.size(); j++){
 	LogTrace("TestTrackHits") << "hit id=" << simTrackIds[j].first;
@@ -729,7 +729,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         auto m = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit->hit())->monoHit();
 	CTTRHp tMonoHit = theBuilder->build(&m);
 	if (tMonoHit==0) continue;
-	vector<PSimHit> assMonoSimHits = hitAssociator->associateHit(*tMonoHit->hit());
+	vector<PSimHit> assMonoSimHits = hitAssociator.associateHit(*tMonoHit->hit());
 	if (assMonoSimHits.size()==0) continue;
 	const PSimHit sMonoHit = *(assMonoSimHits.begin());
 	const Surface * monoSurf = &( tMonoHit->det()->surface() );
@@ -833,7 +833,7 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         auto s = dynamic_cast<const SiStripMatchedRecHit2D*>(rhit->hit())->stereoHit();
 	CTTRHp tStereoHit = theBuilder->build(&s);
 	if (tStereoHit==0) continue;
-	vector<PSimHit> assStereoSimHits = hitAssociator->associateHit(*tStereoHit->hit());
+	vector<PSimHit> assStereoSimHits = hitAssociator.associateHit(*tStereoHit->hit());
 	if (assStereoSimHits.size()==0) continue;
 	const PSimHit sStereoHit = *(assStereoSimHits.begin());
 	const Surface * stereoSurf = &( tStereoHit->det()->surface() );
@@ -938,7 +938,6 @@ void TestTrackHits::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     i++;
   }
   LogTrace("TestTrackHits") << "end of event: processd hits=" << evtHits ;
-  delete hitAssociator;
 }
 
 void TestTrackHits::endJob() {


### PR DESCRIPTION
This PR modifies uses of TrackerHitAssocator to use the consumes interface needed for multithreading. This PR is for packages in the Reco L2 category.
