### PR TITLE
Use consumes interface for TrackerHitAssociator(Sim)

### DIFF
--- a/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonAssociatorByHits.h
@@ -14,6 +14,7 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 #include <memory>
 
@@ -26,7 +27,6 @@ class MuonAssociatorByHits {
  public:
   
   MuonAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC);   
-  MuonAssociatorByHits (const edm::ParameterSet& conf);   
   ~MuonAssociatorByHits();
   
   // Originally from TrackAssociatorBase from where this class used to inherit from
@@ -76,6 +76,7 @@ class MuonAssociatorByHits {
  private:
   MuonAssociatorByHitsHelper helper_;
   edm::ParameterSet const conf_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
   std::unique_ptr<muonAssociatorByHitsDiagnostics::InputDumper> diagnostics_;
 };

--- a/SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h
+++ b/SimMuon/MCTruth/interface/MuonToSimAssociatorByHits.h
@@ -6,13 +6,13 @@
 #include "SimMuon/MCTruth/interface/MuonToSimAssociatorBase.h"
 
 #include "SimMuon/MCTruth/interface/MuonAssociatorByHitsHelper.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 class MuonToSimAssociatorByHits : public MuonToSimAssociatorBase {
   
  public:
   
   MuonToSimAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC);   
-  MuonToSimAssociatorByHits (const edm::ParameterSet& conf);   
   ~MuonToSimAssociatorByHits();
 
 
@@ -31,6 +31,7 @@ class MuonToSimAssociatorByHits : public MuonToSimAssociatorBase {
 
   MuonAssociatorByHitsHelper helper_;
   edm::ParameterSet const conf_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
 
 };
 

--- a/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonToTrackingParticleAssociatorEDProducer.cc
@@ -178,6 +178,7 @@ private:
   // ----------member data ---------------------------
   edm::ParameterSet const config_;
   MuonAssociatorByHitsHelper helper_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   TrackerMuonHitExtractor hitExtractor_;
 
   std::unique_ptr<RPCHitAssociator> rpctruth_;
@@ -185,7 +186,6 @@ private:
   std::unique_ptr<CSCHitAssociator> csctruth_;
   std::unique_ptr<TrackerHitAssociator> trackertruth_;
   std::unique_ptr<InputDumper> diagnostics_;
-
 };
 
 //
@@ -203,6 +203,7 @@ private:
 MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDProducer(const edm::ParameterSet& iConfig):
   config_(iConfig),
   helper_(iConfig),
+  trackerHitAssociatorConfig_(iConfig,consumesCollector()),
   hitExtractor_(iConfig,consumesCollector())
 {
    //register your products
@@ -212,7 +213,6 @@ MuonToTrackingParticleAssociatorEDProducer::MuonToTrackingParticleAssociatorEDPr
    RPCHitAssociator rpctruth(iConfig,consumesCollector());
    DTHitAssociator dttruth(iConfig,consumesCollector());
    CSCHitAssociator cscruth(iConfig,consumesCollector());
-   TrackerHitAssociator trackertruth(iConfig,consumesCollector());
 
   if( iConfig.getUntrackedParameter<bool>("dumpInputCollections") ) {
     diagnostics_.reset( new InputDumper(iConfig, consumesCollector()) );
@@ -253,12 +253,12 @@ MuonToTrackingParticleAssociatorEDProducer::produce(edm::Event& iEvent, const ed
    // the memory.
 
    // Tracker hit association  
-   trackertruth_.reset( new TrackerHitAssociator(iEvent, config_));
+   trackertruth_.reset(new TrackerHitAssociator(iEvent, trackerHitAssociatorConfig_));
    // CSC hit association
-   csctruth_.reset(new CSCHitAssociator(iEvent,iSetup,config_));;
+   csctruth_.reset(new CSCHitAssociator(iEvent,iSetup,config_));
    // DT hit association
    printRtS = false;
-   dttruth_.reset( new DTHitAssociator(iEvent,iSetup,config_,printRtS) );  
+   dttruth_.reset(new DTHitAssociator(iEvent,iSetup,config_,printRtS));
    // RPC hit association
    rpctruth_.reset( new RPCHitAssociator(iEvent,iSetup,config_) );
    

--- a/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonAssociatorByHits.cc
@@ -137,25 +137,15 @@ namespace muonAssociatorByHitsDiagnostics {
 
 MuonAssociatorByHits::MuonAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :  
   helper_(conf),
-  conf_(conf)
+  conf_(conf),
+  trackerHitAssociatorConfig_(conf, std::move(iC))
 {
   //hack for consumes
   RPCHitAssociator rpctruth(conf,std::move(iC));
   DTHitAssociator dttruth(conf,std::move(iC));
   CSCHitAssociator muonTruth(conf,std::move(iC));
-  TrackerHitAssociator trackertruth(conf,std::move(iC));
   if( conf.getUntrackedParameter<bool>("dumpInputCollections") ) {
     diagnostics_.reset( new InputDumper(conf, std::move(iC)) );
-  }
-}
-
-//compatibility constructor - argh
-MuonAssociatorByHits::MuonAssociatorByHits (const edm::ParameterSet& conf) :  
-  helper_(conf),
-  conf_(conf)
-{
-  if( conf.getUntrackedParameter<bool>("dumpInputCollections") ) {
-    diagnostics_.reset( new InputDumper(conf) );
   }
 }
 
@@ -183,7 +173,7 @@ MuonAssociatorByHits::associateRecoToSim( const edm::RefToBaseVector<reco::Track
 
 
   // Tracker hit association  
-  TrackerHitAssociator trackertruth(*e, conf_);
+  TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);
   // CSC hit association
   CSCHitAssociator csctruth(*e,*setup,conf_);
   // DT hit association
@@ -228,7 +218,7 @@ MuonAssociatorByHits::associateSimToReco( const edm::RefToBaseVector<reco::Track
   const TrackerTopology *tTopo=tTopoHand.product();
 
   // Tracker hit association  
-  TrackerHitAssociator trackertruth(*e, conf_);
+  TrackerHitAssociator trackertruth(*e, trackerHitAssociatorConfig_);
   // CSC hit association
   CSCHitAssociator csctruth(*e,*setup,conf_);
   // DT hit association

--- a/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
+++ b/SimMuon/MCTruth/src/MuonToSimAssociatorByHits.cc
@@ -18,7 +18,8 @@ using namespace std;
 
 MuonToSimAssociatorByHits::MuonToSimAssociatorByHits (const edm::ParameterSet& conf, edm::ConsumesCollector && iC) :
   helper_(conf),
-  conf_(conf)
+  conf_(conf),
+  trackerHitAssociatorConfig_(conf,std::move(iC))
 {
   TrackerMuonHitExtractor hitExtractor(conf_,std::move(iC)); 
 
@@ -26,14 +27,8 @@ MuonToSimAssociatorByHits::MuonToSimAssociatorByHits (const edm::ParameterSet& c
   RPCHitAssociator rpctruth(conf,std::move(iC));
   DTHitAssociator dttruth(conf,std::move(iC));
   CSCHitAssociator muonTruth(conf,std::move(iC));
-  TrackerHitAssociator trackertruth(conf,std::move(iC));
 }
 
-//compatibility constructor - argh
-MuonToSimAssociatorByHits::MuonToSimAssociatorByHits (const edm::ParameterSet& conf) :
-  helper_(conf),
-  conf_(conf)
-{}
 
 MuonToSimAssociatorByHits::~MuonToSimAssociatorByHits()
 {
@@ -133,7 +128,7 @@ void MuonToSimAssociatorByHits::associateMuons(MuonToSimCollection & recToSim, S
     
     
     // Tracker hit association  
-    TrackerHitAssociator trackertruth(*event, conf_);
+    TrackerHitAssociator trackertruth(*event, trackerHitAssociatorConfig_);
     // CSC hit association
     CSCHitAssociator csctruth(*event,*setup,conf_);
     // DT hit association

--- a/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsProducer.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/TrackAssociatorByHitsProducer.cc
@@ -59,7 +59,7 @@ private:
   virtual void endJob() override;
   
   // ----------member data ---------------------------
-  edm::ParameterSet conf_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   edm::EDGetTokenT<SimHitTPAssociationList> simHitTpMapToken_;
   TrackAssociatorByHitsImpl::SimToRecoDenomType SimToRecoDenominator;
   const double quality_SimToReco;
@@ -85,19 +85,19 @@ private:
 // constructors and destructor
 //
 TrackAssociatorByHitsProducer::TrackAssociatorByHitsProducer(const edm::ParameterSet& iConfig):
-  conf_(iConfig),
-  simHitTpMapToken_(consumes<SimHitTPAssociationList>(conf_.getParameter<edm::InputTag>("simHitTpMapTag"))),
+  trackerHitAssociatorConfig_(iConfig, consumesCollector()),
+  simHitTpMapToken_(consumes<SimHitTPAssociationList>(iConfig.getParameter<edm::InputTag>("simHitTpMapTag"))),
   SimToRecoDenominator(TrackAssociatorByHitsImpl::denomnone),
-  quality_SimToReco(conf_.getParameter<double>("Quality_SimToReco")),
-  purity_SimToReco(conf_.getParameter<double>("Purity_SimToReco")),
-  cut_RecoToSim(conf_.getParameter<double>("Cut_RecoToSim")),
-  UsePixels(conf_.getParameter<bool>("UsePixels")),
-  UseGrouped(conf_.getParameter<bool>("UseGrouped")),
-  UseSplitting(conf_.getParameter<bool>("UseSplitting")),
-  ThreeHitTracksAreSpecial(conf_.getParameter<bool>("ThreeHitTracksAreSpecial")),
-  AbsoluteNumberOfHits(conf_.getParameter<bool>("AbsoluteNumberOfHits"))
+  quality_SimToReco(iConfig.getParameter<double>("Quality_SimToReco")),
+  purity_SimToReco(iConfig.getParameter<double>("Purity_SimToReco")),
+  cut_RecoToSim(iConfig.getParameter<double>("Cut_RecoToSim")),
+  UsePixels(iConfig.getParameter<bool>("UsePixels")),
+  UseGrouped(iConfig.getParameter<bool>("UseGrouped")),
+  UseSplitting(iConfig.getParameter<bool>("UseSplitting")),
+  ThreeHitTracksAreSpecial(iConfig.getParameter<bool>("ThreeHitTracksAreSpecial")),
+  AbsoluteNumberOfHits(iConfig.getParameter<bool>("AbsoluteNumberOfHits"))
 {
-  std::string tmp = conf_.getParameter<std::string>("SimToRecoDenominator");
+  std::string tmp = iConfig.getParameter<std::string>("SimToRecoDenominator");
   if (tmp=="sim") {
     SimToRecoDenominator = TrackAssociatorByHitsImpl::denomsim;
   } else if (tmp == "reco") {
@@ -110,8 +110,6 @@ TrackAssociatorByHitsProducer::TrackAssociatorByHitsProducer(const edm::Paramete
 
   //register your products  
   produces<reco::TrackToTrackingParticleAssociator>();
-  
-  TrackerHitAssociator temp(conf_, consumesCollector());
 }
 
 
@@ -134,7 +132,7 @@ TrackAssociatorByHitsProducer::produce(edm::StreamID, edm::Event& iEvent, const 
 {
    using namespace edm;
 
-   std::unique_ptr<TrackerHitAssociator> thAssoc( new TrackerHitAssociator(iEvent,conf_));
+   std::unique_ptr<TrackerHitAssociator> thAssoc( new TrackerHitAssociator(iEvent,trackerHitAssociatorConfig_));
 
   edm::ESHandle<TrackerTopology> tTopoHand;
   iSetup.get<TrackerTopologyRcd>().get(tTopoHand);

--- a/SimTracker/TrackHistory/interface/TrackQuality.h
+++ b/SimTracker/TrackHistory/interface/TrackQuality.h
@@ -69,7 +69,7 @@ public:
 
        /param[in] pset with the configuration values
     */
-    TrackQuality(const edm::ParameterSet &);
+    TrackQuality(const edm::ParameterSet &, edm::ConsumesCollector& iC);
 
     //! Pre-process event information (for accessing reconstruction information)
     void newEvent(const edm::Event &, const edm::EventSetup &);
@@ -90,8 +90,8 @@ public:
     }
 
 private:
-    const edm::ParameterSet associatorPSet_;
-    std::auto_ptr<TrackerHitAssociator> associator_;
+    TrackerHitAssociator::Config trackerHitAssociatorConfig_;
+    std::unique_ptr<TrackerHitAssociator> associator_;
 
     std::vector<Layer> layers_;
 };

--- a/SimTracker/TrackHistory/src/TrackClassifier.cc
+++ b/SimTracker/TrackHistory/src/TrackClassifier.cc
@@ -14,7 +14,7 @@ TrackClassifier::TrackClassifier(edm::ParameterSet const & config,
         hepMCLabel_( config.getUntrackedParameter<edm::InputTag>("hepMC") ),
         beamSpotLabel_( config.getUntrackedParameter<edm::InputTag>("beamSpot") ),
         tracer_(config,std::move(collector)),
-        quality_(config)
+        quality_(config, collector)
 {
     collector.consumes<edm::HepMCProduct>(hepMCLabel_);
     collector.consumes<reco::BeamSpot>(beamSpotLabel_);

--- a/SimTracker/TrackHistory/src/TrackQuality.cc
+++ b/SimTracker/TrackHistory/src/TrackQuality.cc
@@ -141,14 +141,14 @@ DetLayer getDetLayer(DetId detId, const TrackerTopology *tTopo)
     return DetLayer(det, layer);
 }
 
-TrackQuality::TrackQuality(const edm::ParameterSet &config) :
-        associatorPSet_(config.getParameter<edm::ParameterSet>("hitAssociator"))
+TrackQuality::TrackQuality(const edm::ParameterSet &config,  edm::ConsumesCollector& iC) :
+        trackerHitAssociatorConfig_(config.getParameter<edm::ParameterSet>("hitAssociator"), std::move(iC))
 {
 }
 
 void TrackQuality::newEvent(const edm::Event &ev, const edm::EventSetup &es)
 {
-    associator_.reset(new TrackerHitAssociator(ev, associatorPSet_));
+    associator_.reset(new TrackerHitAssociator(ev, trackerHitAssociatorConfig_));
 }
 
 void TrackQuality::evaluate(SimParticleTrail const &spt,

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.cc
@@ -95,7 +95,7 @@ using namespace edm;
       DetId detid = ((*it)->geographicalId());
       
       //construct the associator object
-      TrackerHitAssociator  associate(e,conf_);
+      TrackerHitAssociator  associate(e,trackerHitAssociatorConfig_);
       
       if(myid!=999999999){ //if is valid detector
 
@@ -237,7 +237,7 @@ using namespace edm;
 
 
 TestAssociator::TestAssociator(edm::ParameterSet const& conf) : 
-  conf_(conf),
+  trackerHitAssociatorConfig_(conf, consumesCollector()),
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ) {
   cout << " Constructor " << endl;

--- a/SimTracker/TrackerHitAssociation/test/TestAssociator.h
+++ b/SimTracker/TrackerHitAssociation/test/TestAssociator.h
@@ -45,7 +45,7 @@ class TestAssociator : public edm::EDAnalyzer
 
  private:
   
-  edm::ParameterSet conf_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   const StripTopology* topol;
   int numStrips;    // number of strips in the module
   bool doPixel_, doStrip_;

--- a/SimTracker/TrackerHitAssociation/test/myTrackAnalyzer.cc
+++ b/SimTracker/TrackerHitAssociation/test/myTrackAnalyzer.cc
@@ -10,7 +10,7 @@ using namespace edm;
 class TrackerHitAssociator;
 
 myTrackAnalyzer::myTrackAnalyzer(edm::ParameterSet const& conf) : 
-  conf_(conf),
+  trackerHitAssociatorConfig_(conf, consumesCollector()),
   doPixel_( conf.getParameter<bool>("associatePixel") ),
   doStrip_( conf.getParameter<bool>("associateStrip") ),
   trackCollectionTag_(conf.getParameter<edm::InputTag>("trackCollectionTag")) {
@@ -51,7 +51,7 @@ void myTrackAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& se
     if(!doPixel_ && !doStrip_)  throw edm::Exception(errors::Configuration,"Strip and pixel association disabled");
     //NEW
     std::vector<PSimHit> matched;
-    TrackerHitAssociator associate(event, conf_);
+    TrackerHitAssociator associate(event, trackerHitAssociatorConfig_);
     std::vector<unsigned int> SimTrackIds;
 
     const reco::TrackCollection tC = *(trackCollection.product());

--- a/SimTracker/TrackerHitAssociation/test/myTrackAnalyzer.h
+++ b/SimTracker/TrackerHitAssociation/test/myTrackAnalyzer.h
@@ -55,7 +55,7 @@ class myTrackAnalyzer : public edm::EDAnalyzer {
   virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
   
  private:
-  edm::ParameterSet conf_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   bool doPixel_, doStrip_;
   edm::InputTag trackCollectionTag_;
 };


### PR DESCRIPTION
This PR modifies uses of TrackerHitAssocator to use the consumes interface needed for multithreading. This PR is for packages in the Sim L2 category.
