### PR TITLE
Use consumes interface for TrackerHitAssociator(Geom)

### DIFF
--- a/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
+++ b/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.cc
@@ -66,6 +66,7 @@ using namespace reco;
 
 StdHitNtuplizer::StdHitNtuplizer(edm::ParameterSet const& conf) : 
   conf_(conf), 
+  trackerHitAssociatorConfig_(conf, consumesCollector()),
   src_( conf.getParameter<edm::InputTag>( "src" ) ),
   rphiRecHits_( conf.getParameter<edm::InputTag>("rphiRecHits") ),
   stereoRecHits_( conf.getParameter<edm::InputTag>("stereoRecHits") ),
@@ -141,7 +142,7 @@ void StdHitNtuplizer::analyze(const edm::Event& e, const edm::EventSetup& es)
   e.getByLabel( src_, recHitColl);
 
   // for finding matched simhit
-  TrackerHitAssociator associate( e, conf_ );
+  TrackerHitAssociator associate( e, trackerHitAssociatorConfig_ );
 
 //  std::cout << " Step A: Standard RecHits found " << (recHitColl.product())->dataSize() << std::endl;
   if((recHitColl.product())->dataSize() > 0) {

--- a/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.h
+++ b/SLHCUpgradeSimulations/Geometry/test/StdHitNtuplizer.h
@@ -29,6 +29,7 @@
 
 #include "SimDataFormats/Track/interface/SimTrack.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
+#include "SimTracker/TrackerHitAssociation/interface/TrackerHitAssociator.h"
 
 class TTree;
 class TFile;
@@ -71,6 +72,7 @@ class StdHitNtuplizer : public edm::EDAnalyzer
 
  private:
   edm::ParameterSet conf_;
+  TrackerHitAssociator::Config trackerHitAssociatorConfig_;
   edm::InputTag src_;
   edm::InputTag rphiRecHits_;
   edm::InputTag stereoRecHits_;


### PR DESCRIPTION
This PR modifies uses of TrackerHitAssocator to use the consumes interface needed for multithreading. This PR is for packages in the Geom L2 category.
