### PR TITLE
Use shrink_to_fit on tracker seed collections

### DIFF
--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromProtoTracksEDProducer.cc
@@ -105,6 +105,7 @@ void SeedGeneratorFromProtoTracksEDProducer::produce(edm::Event& ev, const edm::
     }
   } 
 
+  result->shrink_to_fit();
   ev.put(result);
 }
 

--- a/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/SeedGeneratorFromRegionHitsEDProducer.cc
@@ -92,6 +92,7 @@ void SeedGeneratorFromRegionHitsEDProducer::produce(edm::Event& ev, const edm::E
   if (clustsOrZero){
     if (!theSilentOnClusterCheck)
 	edm::LogError("TooManyClusters") << "Found too many clusters (" << clustsOrZero << "), bailing out.\n";
+    triplets->shrink_to_fit();
     ev.put(triplets);
     return ;
   }
@@ -124,8 +125,12 @@ void SeedGeneratorFromRegionHitsEDProducer::produce(edm::Event& ev, const edm::E
   for (IR ir=regions.begin(), irEnd=regions.end(); ir < irEnd; ++ir) delete (*ir);
 
   // put to event
-  if ( theMerger_!=0)
+  if ( theMerger_!=0) {
+    quadruplets->shrink_to_fit();
     ev.put(quadruplets);
-  else
+  }
+  else {
+    triplets->shrink_to_fit();
     ev.put(triplets);
+  }
 }


### PR DESCRIPTION
Uses shrink_to_fit on the tracker seed collections to try and reduce memory overhead.  Plots attached are for the memory size of the produced collections, which is retained until the OutputModule.  These are using HGCal at 200 pileup.  The first blue line, `pixelPairStepSeeds` is noticeably reduced at this scale.  I tried the same on SeedCombiner (`newCombinedSeeds`, green line) but it has an accurate reserve so makes no difference.
I haven't touched PFRecHitProducer (`particleFlowRecHitHGCEE`, the biggest offender) because I think @lgray has been working on that and has managed to make a significant memory saving.

Memory consumed by just the collections put in the event, before this PR:
![beforeshrink](https://cloud.githubusercontent.com/assets/6480160/7640839/942a1960-fa7d-11e4-8897-1ae1e20c86fb.png)

After:
![aftershrink](https://cloud.githubusercontent.com/assets/6480160/7640842/974f281a-fa7d-11e4-8b8e-02bae283a554.png)

Looking at the VmSize there doesn't seem to be much of a change, but the memory saved is pretty small on this scale.  Every little helps though - or possibly the memory allocator is doing something fancy and not releasing the memory.
![vmsize](https://cloud.githubusercontent.com/assets/6480160/7640844/9a3587d6-fa7d-11e4-9129-fca060b65e42.png)
