### PR TITLE
Implement consumes interface for Adjuster class in MixingModule

### DIFF
--- a/SimGeneral/MixingModule/plugins/Adjuster.h
+++ b/SimGeneral/MixingModule/plugins/Adjuster.h
@@ -2,8 +2,10 @@
 #define SimGeneral_MixingModule_Adjuster_h
 
 #include "DataFormats/Common/interface/Wrapper.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "SimDataFormats/CaloHit/interface/PCaloHitContainer.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
@@ -29,7 +31,7 @@ namespace edm {
   class Adjuster : public AdjusterBase {
 
   public:
-    Adjuster(InputTag const& tag);
+    Adjuster(InputTag const& tag, edm::ConsumesCollector&& iC);
 
     virtual ~Adjuster() {}
 
@@ -38,12 +40,13 @@ namespace edm {
     virtual bool checkSignal(edm::Event const& event) {
       bool got = false;
       edm::Handle<T> result_t;
-      got = event.getByLabel(tag_, result_t);
+      got = event.getByToken(token_, result_t);
       return got;
     }
 
    private:
     InputTag tag_;
+    EDGetTokenT<T> token_;
   };
 
   //==============================================================================
@@ -68,7 +71,7 @@ namespace edm {
   }
 
   template<typename T>
-  Adjuster<T>::Adjuster(InputTag const& tag) : tag_(tag) {
+  Adjuster<T>::Adjuster(InputTag const& tag, ConsumesCollector&& iC) : tag_(tag), token_(iC.consumes<T>(tag)) {
   }
 }
 

--- a/SimGeneral/MixingModule/plugins/MixingModule.cc
+++ b/SimGeneral/MixingModule/plugins/MixingModule.cc
@@ -85,7 +85,7 @@ namespace edm {
             std::string label;
 
             branchesActivate(TypeID(typeid(std::vector<SimTrack>)).friendlyClassName(),std::string(""),tag,label);
-            adjustersObjects_.push_back(new Adjuster<std::vector<SimTrack> >(tag));
+            adjustersObjects_.push_back(new Adjuster<std::vector<SimTrack> >(tag, consumesCollector()));
             bool makeCrossingFrame = pset.getUntrackedParameter<bool>("makeCrossingFrame", false);
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimTrack>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
@@ -106,7 +106,7 @@ namespace edm {
             branchesActivate(TypeID(typeid(edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >)).friendlyClassName(),std::string(""),tag,label);
 	    InputTag mvatag(tag.label(),"MVAVals");
             branchesActivate(TypeID(typeid(edm::ValueMap<float>)).friendlyClassName(),std::string(""),mvatag,label);
-            adjustersObjects_.push_back(new Adjuster<edm::OwnVector<TrackingRecHit> >(tag));
+            adjustersObjects_.push_back(new Adjuster<edm::OwnVector<TrackingRecHit> >(tag, consumesCollector()));
 	    // note: no crossing frame is foreseen to be used for this object type
 	    
 	    LogInfo("MixingModule") <<"Will mix "<<object<<"s with InputTag= "<<tag.encode()<<", label will be "<<label;
@@ -118,7 +118,7 @@ namespace edm {
             std::string label;
 
             branchesActivate(TypeID(typeid(std::vector<SimVertex>)).friendlyClassName(),std::string(""),tag,label);
-            adjustersObjects_.push_back(new Adjuster<std::vector<SimVertex> >(tag));
+            adjustersObjects_.push_back(new Adjuster<std::vector<SimVertex> >(tag, consumesCollector()));
             bool makeCrossingFrame = pset.getUntrackedParameter<bool>("makeCrossingFrame", false);
             if(makeCrossingFrame) {
               workersObjects_.push_back(new MixingWorker<SimVertex>(minBunch_,maxBunch_,bunchSpace_,std::string(""),label,labelCF,maxNbSources_,tag,tagCF));
@@ -156,7 +156,7 @@ namespace edm {
               std::string label;
 
               branchesActivate(TypeID(typeid(std::vector<PCaloHit>)).friendlyClassName(),subdets[ii],tag,label);
-              adjustersObjects_.push_back(new Adjuster<std::vector<PCaloHit> >(tag));
+              adjustersObjects_.push_back(new Adjuster<std::vector<PCaloHit> >(tag, consumesCollector()));
               if(binary_search_all(crossingFrames, tag.instance())) {
                 workersObjects_.push_back(new MixingWorker<PCaloHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF));
                 produces<CrossingFrame<PCaloHit> >(label);
@@ -179,7 +179,7 @@ namespace edm {
               std::string label;
 
               branchesActivate(TypeID(typeid(std::vector<PSimHit>)).friendlyClassName(),subdets[ii],tag,label);
-              adjustersObjects_.push_back(new Adjuster<std::vector<PSimHit> >(tag));
+              adjustersObjects_.push_back(new Adjuster<std::vector<PSimHit> >(tag, consumesCollector()));
               if(binary_search_all(crossingFrames, tag.instance())) {
                 workersObjects_.push_back(new MixingWorker<PSimHit>(minBunch_,maxBunch_,bunchSpace_,subdets[ii],label,labelCF,maxNbSources_,tag,tagCF));
                 produces<CrossingFrame<PSimHit> >(label);


### PR DESCRIPTION
This PR implements the consumes interface for the Adjuster class used internally by MixingModule.
This fixes consumes violations found in several relvals, and is needed for multithreading.
