### PR TITLE
migrating to multithreading of RPCPointProducer

### DIFF
--- a/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
@@ -54,13 +54,11 @@ private:
 
 class ObjectMapCSC{
 public:
-  static ObjectMapCSC* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(CSCStationIndex cscstationindex){return mapInstance->rollstoreCSC[cscstationindex];}
+  ObjectMapCSC* GetInstance(const edm::EventSetup& iSetup);
+  std::set<RPCDetId> GetRolls(CSCStationIndex cscstationindex){return rollstoreCSC[cscstationindex];}
 //protected:
   std::map<CSCStationIndex,std::set<RPCDetId> > rollstoreCSC;
   ObjectMapCSC(const edm::EventSetup& iSetup);
-private:
-  static ObjectMapCSC* mapInstance;
-}; 
+};
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
@@ -1,7 +1,7 @@
 #ifndef  CSCSEGTORPC_H
 #define  CSCSEGTORPC_H
 
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
@@ -41,18 +41,18 @@ private:
 
 class ObjectMapCSC{
 public:
-    ObjectMapCSC* GetInstance(const edm::EventSetup& iSetup);
-    std::set<RPCDetId> GetRolls(CSCStationIndex cscstationindex){return rollstoreCSC[cscstationindex];}
+    ObjectMapCSC* getInstance(const edm::EventSetup& iSetup);
+    const std::set<RPCDetId>  getRolls(CSCStationIndex cscstationindex) const {return rollstoreCSC.find(cscstationindex)->second;}
     //protected:
-    std::map<CSCStationIndex,std::set<RPCDetId> > rollstoreCSC;
+    std::map<CSCStationIndex,const std::set<RPCDetId> > rollstoreCSC;
     ObjectMapCSC(const edm::EventSetup& iSetup);
     ObjectMapCSC();
-    void FillObjectMapCSC(const edm::EventSetup& iSetup);
+    void fillObjectMapCSC(const edm::EventSetup& iSetup);
 };
 
 class CSCSegtoRPC {
 public:
-  explicit CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent, bool debug, double eyr, ObjectMapCSC* TheObjectCSC);
+  explicit CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent, bool debug, double eyr,  const ObjectMapCSC *TheObjectCSC);
   ~CSCSegtoRPC();
   RPCRecHitCollection* thePoints(){return _ThePoints;}
    

--- a/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
@@ -6,10 +6,53 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
+class CSCStationIndex{
+public:
+    CSCStationIndex():_region(0),_station(0),_ring(0),_chamber(0){}
+    CSCStationIndex(int region, int station, int ring, int chamber):
+    _region(region),
+    _station(station),
+    _ring(ring),
+    _chamber(chamber){}
+    ~CSCStationIndex(){}
+    int region() const {return _region;}
+    int station() const {return _station;}
+    int ring() const {return _ring;}
+    int chamber() const {return _chamber;}
+    bool operator<(const CSCStationIndex& cscind) const{
+        if(cscind.region()!=this->region())
+            return cscind.region()<this->region();
+        else if(cscind.station()!=this->station())
+            return cscind.station()<this->station();
+        else if(cscind.ring()!=this->ring())
+            return cscind.ring()<this->ring();
+        else if(cscind.chamber()!=this->chamber())
+            return cscind.chamber()<this->chamber();
+        return false;
+    }
+    
+private:
+    int _region;
+    int _station;
+    int _ring;  
+    int _chamber;
+};
+
+
+class ObjectMapCSC{
+public:
+    ObjectMapCSC* GetInstance(const edm::EventSetup& iSetup);
+    std::set<RPCDetId> GetRolls(CSCStationIndex cscstationindex){return rollstoreCSC[cscstationindex];}
+    //protected:
+    std::map<CSCStationIndex,std::set<RPCDetId> > rollstoreCSC;
+    ObjectMapCSC(const edm::EventSetup& iSetup);
+    ObjectMapCSC();
+    void FillObjectMapCSC(const edm::EventSetup& iSetup);
+};
 
 class CSCSegtoRPC {
 public:
-  explicit CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent, bool debug, double eyr);
+  explicit CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent, bool debug, double eyr, ObjectMapCSC* TheObjectCSC);
   ~CSCSegtoRPC();
   RPCRecHitCollection* thePoints(){return _ThePoints;}
    
@@ -20,45 +63,7 @@ private:
   double MaxD;
 };
 
-class CSCStationIndex{
-public:
-  CSCStationIndex():_region(0),_station(0),_ring(0),_chamber(0){}
-  CSCStationIndex(int region, int station, int ring, int chamber):
-    _region(region),
-    _station(station),
-    _ring(ring),
-    _chamber(chamber){}
-  ~CSCStationIndex(){}
-  int region() const {return _region;}
-  int station() const {return _station;}
-  int ring() const {return _ring;}
-  int chamber() const {return _chamber;}
-  bool operator<(const CSCStationIndex& cscind) const{
-    if(cscind.region()!=this->region())
-      return cscind.region()<this->region();
-    else if(cscind.station()!=this->station())
-      return cscind.station()<this->station();
-    else if(cscind.ring()!=this->ring())
-      return cscind.ring()<this->ring();
-    else if(cscind.chamber()!=this->chamber())
-      return cscind.chamber()<this->chamber();
-    return false;
-  }
 
-private:
-  int _region;
-  int _station;
-  int _ring;  
-  int _chamber;
-};
 
-class ObjectMapCSC{
-public:
-  ObjectMapCSC* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(CSCStationIndex cscstationindex){return rollstoreCSC[cscstationindex];}
-//protected:
-  std::map<CSCStationIndex,std::set<RPCDetId> > rollstoreCSC;
-  ObjectMapCSC(const edm::EventSetup& iSetup);
-};
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
@@ -1,15 +1,58 @@
 #ifndef  DTSEGTORPC_H
 #define  DTSEGTORPC_H
 
-
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/Framework/interface/EDAnalyzer.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
 
+class DTStationIndex{
+public:
+    DTStationIndex():_region(0),_wheel(0),_sector(0),_station(0){}
+    DTStationIndex(int region, int wheel, int sector, int station) :
+    _region(region),
+    _wheel(wheel),
+    _sector(sector),
+    _station(station){}
+    ~DTStationIndex(){}
+    int region() const {return _region;}
+    int wheel() const {return _wheel;}
+    int sector() const {return _sector;}
+    int station() const {return _station;}
+    bool operator<(const DTStationIndex& dtind) const{
+        if(dtind.region()!=this->region())
+            return dtind.region()<this->region();
+        else if(dtind.wheel()!=this->wheel())
+            return dtind.wheel()<this->wheel();
+        else if(dtind.sector()!=this->sector())
+            return dtind.sector()<this->sector();
+        else if(dtind.station()!=this->station())
+            return dtind.station()<this->station();
+        return false;
+    }
+    
+private:
+    int _region;
+    int _wheel;
+    int _sector;
+    int _station;
+};
+
+class ObjectMap{
+public:
+    ObjectMap* GetInstance(const edm::EventSetup& iSetup);
+    const std::set<RPCDetId> getRolls(DTStationIndex dtstationindex) const {return rollstoreDT.find(dtstationindex)->second;}
+    //protected:
+    std::map<DTStationIndex,const std::set<RPCDetId> > rollstoreDT;
+    ObjectMap(const edm::EventSetup& iSetup);
+    ObjectMap();
+    void fillObjectMapDT(const edm::EventSetup&);
+};
+
 class DTSegtoRPC {
 public:
-  explicit DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, double eyr);
+  explicit DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, double eyr,const ObjectMap*);
   ~DTSegtoRPC();
   RPCRecHitCollection* thePoints(){return _ThePoints;}
    
@@ -25,45 +68,6 @@ private:
   std::vector<uint32_t> extrapolatedRolls;
 };
 
-class DTStationIndex{
-public: 
-  DTStationIndex():_region(0),_wheel(0),_sector(0),_station(0){}
-  DTStationIndex(int region, int wheel, int sector, int station) : 
-    _region(region),
-    _wheel(wheel),
-    _sector(sector),
-    _station(station){}
-  ~DTStationIndex(){}
-  int region() const {return _region;}
-  int wheel() const {return _wheel;}
-  int sector() const {return _sector;}
-  int station() const {return _station;}
-  bool operator<(const DTStationIndex& dtind) const{
-    if(dtind.region()!=this->region())
-      return dtind.region()<this->region();
-    else if(dtind.wheel()!=this->wheel())
-      return dtind.wheel()<this->wheel();
-    else if(dtind.sector()!=this->sector())
-      return dtind.sector()<this->sector();
-    else if(dtind.station()!=this->station())
-      return dtind.station()<this->station();
-    return false;
-  }
 
-private:
-  int _region;
-  int _wheel;
-  int _sector;
-  int _station; 
-};
-
-class ObjectMap{
-public:
-  ObjectMap* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(DTStationIndex dtstationindex){return rollstoreDT[dtstationindex];}
-//protected:
-  std::map<DTStationIndex,std::set<RPCDetId> > rollstoreDT;
-  ObjectMap(const edm::EventSetup& iSetup);
-};
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
@@ -59,13 +59,11 @@ private:
 
 class ObjectMap{
 public:
-  static ObjectMap* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(DTStationIndex dtstationindex){return mapInstance->rollstoreDT[dtstationindex];}
+  ObjectMap* GetInstance(const edm::EventSetup& iSetup);
+  std::set<RPCDetId> GetRolls(DTStationIndex dtstationindex){return rollstoreDT[dtstationindex];}
 //protected:
   std::map<DTStationIndex,std::set<RPCDetId> > rollstoreDT;
   ObjectMap(const edm::EventSetup& iSetup);
-private:
-  static ObjectMap* mapInstance;
-}; 
+};
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
@@ -41,7 +41,7 @@ private:
 
 class ObjectMap{
 public:
-    ObjectMap* GetInstance(const edm::EventSetup& iSetup);
+    ObjectMap* getInstance(const edm::EventSetup& iSetup);
     const std::set<RPCDetId> getRolls(DTStationIndex dtstationindex) const {return rollstoreDT.find(dtstationindex)->second;}
     //protected:
     std::map<DTStationIndex,const std::set<RPCDetId> > rollstoreDT;
@@ -52,7 +52,7 @@ public:
 
 class DTSegtoRPC {
 public:
-  explicit DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, double eyr,const ObjectMap*);
+  explicit DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent, bool debug, double eyr,const ObjectMap*);
   ~DTSegtoRPC();
   RPCRecHitCollection* thePoints(){return _ThePoints;}
    

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -47,6 +47,8 @@ class RPCPointProducer : public edm::stream::EDProducer<> {
     
     ObjectMapCSC* TheCSCObjectsMap_;
     ObjectMap*    TheDTObjectsMap_;
+    ObjectMap2*       TheDTtrackObjectsMap_;
+    ObjectMap2CSC*    TheCSCtrackObjectsMap_;
     edm::ESWatcher<MuonGeometryRecord> MuonGeometryWatcher;
 };
 

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -19,31 +19,28 @@
 // class decleration
 //
 
-class RPCPointProducer : public edm::EDProducer {
+class RPCPointProducer : public edm::stream::EDProducer<> {
    public:
       explicit RPCPointProducer(const edm::ParameterSet&);
       ~RPCPointProducer();
-      //      edm::InputTag cscSegments;
-      edm::EDGetTokenT<CSCSegmentCollection> cscSegments;
-      edm::EDGetTokenT<DTRecSegment4DCollection> dt4DSegments;
-      //      edm::InputTag dt4DSegments;
-      edm::EDGetTokenT<reco::TrackCollection> tracks;
-      edm::InputTag tracks_;
+
+      const edm::EDGetTokenT<CSCSegmentCollection> cscSegments;
+      const edm::EDGetTokenT<DTRecSegment4DCollection> dt4DSegments;
+      const edm::EDGetTokenT<reco::TrackCollection> tracks;
+      const edm::InputTag tracks_;
    private:
-      virtual void beginJob() ;
-      virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
-      bool incldt;
-      bool inclcsc;
-      bool incltrack; 
-      bool debug;
-      double MinCosAng;
-      double MaxD;
-      double MaxDrb4;
-      double MaxDistanceBetweenSegments;
-      double ExtrapolatedRegion;
-      edm::ParameterSet trackTransformerParam;
-      edm::ParameterSet serviceParameters;
+      void produce(edm::Event&, const edm::EventSetup&) override;
+      const bool debug;
+      const bool incldt;
+      const bool inclcsc;
+      const bool incltrack;
+      const double MinCosAng;
+      const double MaxD;
+      const double MaxDrb4;
+      const double ExtrapolatedRegion;
+      const edm::ParameterSet serviceParameters;
+      const edm::ParameterSet trackTransformerParam;
+
       // ----------member data ---------------------------
 };
 

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -30,7 +30,7 @@ class RPCPointProducer : public edm::stream::EDProducer<> {
       const edm::EDGetTokenT<reco::TrackCollection> tracks;
       const edm::InputTag tracks_;
    private:
-      void beginStream(edm::StreamID) override;
+      void beginRun(edm::Run const&, edm::EventSetup const&) override;
       void produce(edm::Event&, const edm::EventSetup&) override;
       const bool debug;
       const bool incldt;

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -31,6 +31,7 @@ class RPCPointProducer : public edm::stream::EDProducer<> {
       const edm::InputTag tracks_;
    private:
       void beginRun(edm::Run const&, edm::EventSetup const&) override;
+      void endRun(edm::Run const&, edm::EventSetup const&) override;
       void produce(edm::Event&, const edm::EventSetup&) override;
       const bool debug;
       const bool incldt;

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -9,6 +9,7 @@
 #include <DataFormats/CSCRecHit/interface/CSCSegmentCollection.h>
 
 #include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/ESWatcher.h"
 #include <DataFormats/RPCRecHit/interface/RPCRecHit.h>
 #include "DataFormats/MuonDetId/interface/RPCDetId.h"
 #include "RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h"
@@ -29,6 +30,7 @@ class RPCPointProducer : public edm::stream::EDProducer<> {
       const edm::EDGetTokenT<reco::TrackCollection> tracks;
       const edm::InputTag tracks_;
    private:
+      void beginStream(edm::StreamID) override;
       void produce(edm::Event&, const edm::EventSetup&) override;
       const bool debug;
       const bool incldt;
@@ -42,5 +44,8 @@ class RPCPointProducer : public edm::stream::EDProducer<> {
       const edm::ParameterSet trackTransformerParam;
 
       // ----------member data ---------------------------
+    
+    ObjectMapCSC* TheCSCObjectsMap_;
+    edm::ESWatcher<MuonGeometryRecord> MuonGeometryWatcher;
 };
 

--- a/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
+++ b/RecoLocalMuon/RPCRecHit/interface/RPCPointProducer.h
@@ -46,6 +46,7 @@ class RPCPointProducer : public edm::stream::EDProducer<> {
       // ----------member data ---------------------------
     
     ObjectMapCSC* TheCSCObjectsMap_;
+    ObjectMap*    TheDTObjectsMap_;
     edm::ESWatcher<MuonGeometryRecord> MuonGeometryWatcher;
 };
 

--- a/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
@@ -62,7 +62,7 @@ class TracktoRPC {
 public:
 
 
-  explicit TracktoRPC(edm::Handle<reco::TrackCollection> alltracks,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, const edm::ParameterSet& iConfig,edm::InputTag& tracklabel);
+  explicit TracktoRPC(edm::Handle<reco::TrackCollection> alltracks,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel);
 
   ~TracktoRPC();
   RPCRecHitCollection* thePoints(){return _ThePoints;}

--- a/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
@@ -111,13 +111,11 @@ private:
 
 class ObjectMap2{
 public:
-  static ObjectMap2* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(DTStationIndex2 dtstationindex){return mapInstance->rollstoreDT[dtstationindex];}
+  ObjectMap2* GetInstance(const edm::EventSetup& iSetup);
+  std::set<RPCDetId> GetRolls(DTStationIndex2 dtstationindex){return rollstoreDT[dtstationindex];}
 //protected:
   std::map<DTStationIndex2,std::set<RPCDetId> > rollstoreDT;
   ObjectMap2(const edm::EventSetup& iSetup);
-private:
-  static ObjectMap2* mapInstance;
 }; 
 class CSCStationIndex2{
 public:
@@ -153,13 +151,11 @@ private:
 
 class ObjectMap2CSC{
 public:
-  static ObjectMap2CSC* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(CSCStationIndex2 cscstationindex){return mapInstance->rollstoreCSC[cscstationindex];}
+  ObjectMap2CSC* GetInstance(const edm::EventSetup& iSetup);
+  std::set<RPCDetId> GetRolls(CSCStationIndex2 cscstationindex){return rollstoreCSC[cscstationindex];}
 //protected:
   std::map<CSCStationIndex2,std::set<RPCDetId> > rollstoreCSC;
   ObjectMap2CSC(const edm::EventSetup& iSetup);
-private:
-  static ObjectMap2CSC* mapInstance;
 }; 
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
@@ -58,24 +58,7 @@ using reco::MuonCollection;
 using reco::TrackCollection;
 typedef std::vector<Trajectory> Trajectories;
 
-class TracktoRPC {
-public:
 
-
-  explicit TracktoRPC(edm::Handle<reco::TrackCollection> alltracks,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel);
-
-  ~TracktoRPC();
-  RPCRecHitCollection* thePoints(){return _ThePoints;}
-  bool ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::EventSetup& iSetup);
-
-private:
-  RPCRecHitCollection* _ThePoints;
-  edm::OwnVector<RPCRecHit> RPCPointVector;
-  double MaxD;
-
- TrackTransformerBase *theTrackTransformer;
- edm::ESHandle<Propagator> thePropagator;
-};
 
 class DTStationIndex2{
 public: 
@@ -111,12 +94,14 @@ private:
 
 class ObjectMap2{
 public:
-  ObjectMap2* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(DTStationIndex2 dtstationindex){return rollstoreDT[dtstationindex];}
+  ObjectMap2* getInstance(const edm::EventSetup& iSetup);
+  const std::set<RPCDetId> getRolls(DTStationIndex2 dtstationindex) const {return rollstoreDT.find(dtstationindex)->second;}
 //protected:
   std::map<DTStationIndex2,std::set<RPCDetId> > rollstoreDT;
   ObjectMap2(const edm::EventSetup& iSetup);
-}; 
+  ObjectMap2();
+  void fillObjectMapDT(const edm::EventSetup&);
+};
 class CSCStationIndex2{
 public:
   CSCStationIndex2():_region(0),_station(0),_ring(0),_chamber(0){}
@@ -151,11 +136,32 @@ private:
 
 class ObjectMap2CSC{
 public:
-  ObjectMap2CSC* GetInstance(const edm::EventSetup& iSetup);
-  std::set<RPCDetId> GetRolls(CSCStationIndex2 cscstationindex){return rollstoreCSC[cscstationindex];}
+  ObjectMap2CSC* getInstance(const edm::EventSetup& iSetup);
+  const std::set<RPCDetId> getRolls(CSCStationIndex2 cscstationindex) const {return rollstoreCSC.find(cscstationindex)->second;}
 //protected:
   std::map<CSCStationIndex2,std::set<RPCDetId> > rollstoreCSC;
-  ObjectMap2CSC(const edm::EventSetup& iSetup);
-}; 
+    ObjectMap2CSC(const edm::EventSetup& iSetup);
+    ObjectMap2CSC();
+    void fillObjectMapCSC(const edm::EventSetup&);
+};
+
+class TracktoRPC {
+public:
+    
+    
+    explicit TracktoRPC(edm::Handle<reco::TrackCollection> alltracks,const edm::EventSetup& iSetup, const edm::Event& iEvent, const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel,const ObjectMap2* , const ObjectMap2CSC*);
+    
+    ~TracktoRPC();
+    RPCRecHitCollection* thePoints(){return _ThePoints;}
+    bool ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::EventSetup& iSetup);
+    
+private:
+    RPCRecHitCollection* _ThePoints;
+    edm::OwnVector<RPCRecHit> RPCPointVector;
+    double MaxD;
+    
+    TrackTransformerBase *theTrackTransformer;
+    edm::ESHandle<Propagator> thePropagator;
+};
 
 #endif

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -99,7 +99,7 @@ CSCSegtoRPC::CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments, const
   
   MaxD=80.;
 
-  //edm::LogDebug("RPCPointProducer") <<"CSC \t Number of CSC Segments in this event = "<<allCSCSegments->size()<<std::endl;
+   LogDebug("RPCPointProducer") <<"CSC \t Number of CSC Segments in this event = "<<allCSCSegments->size()<<std::endl;
 
   _ThePoints = new RPCRecHitCollection();
 
@@ -306,7 +306,6 @@ CSCSegtoRPC::CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments, const
 	      }
 	    }
 	  }
-    //  delete TheObjectCSC;
 	}
       }
     }

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -159,8 +159,7 @@ CSCSegtoRPC::CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments, const
 	  float dy=segmentDirection.y();
 	  float dz=segmentDirection.z();
 
-	  LogDebug("RPCPointProducer") << "Calling to Object Map class"<<std::endl;
-	  //ObjectMapCSC* TheObjectCSC = new ObjectMapCSC(iSetup);
+
 	  LogDebug("RPCPointProducer") << "Creating the CSCIndex"<<std::endl;
       CSCStationIndex theindex(rpcRegion,rpcStation,rpcRing,rpcSegment);
 	  LogDebug("RPCPointProducer") <<"Getting the Rolls for the given index"<<std::endl;

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -11,14 +11,6 @@
 #include <DataFormats/RPCRecHit/interface/RPCRecHitCollection.h>
 #include <RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h>
 
-ObjectMapCSC* ObjectMapCSC::mapInstance = NULL;
-
-ObjectMapCSC* ObjectMapCSC::GetInstance(const edm::EventSetup& iSetup){
-  if (mapInstance == NULL){
-    mapInstance = new ObjectMapCSC(iSetup);
-  }
-  return mapInstance;
-}
 
 ObjectMapCSC::ObjectMapCSC(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;
@@ -128,12 +120,12 @@ CSCSegtoRPC::CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments, const
 	  float dz=segmentDirection.z();
 
 	  if(debug)  std::cout<<"Calling to Object Map class"<<std::endl;
-	  ObjectMapCSC* TheObjectCSC = ObjectMapCSC::GetInstance(iSetup);
+	  ObjectMapCSC* TheObjectCSC = new ObjectMapCSC(iSetup);
 	  if(debug) std::cout<<"Creating the CSCIndex"<<std::endl;
 	  CSCStationIndex theindex(rpcRegion,rpcStation,rpcRing,rpcSegment);
 	  if(debug) std::cout<<"Getting the Rolls for the given index"<<std::endl;
 	
-	  std::set<RPCDetId> rollsForThisCSC = TheObjectCSC->GetInstance(iSetup)->GetRolls(theindex);
+	  std::set<RPCDetId> rollsForThisCSC = TheObjectCSC->GetRolls(theindex);
 		
 	   
 	  if(debug) std::cout<<"CSC \t \t Getting chamber from Geometry"<<std::endl;
@@ -273,6 +265,7 @@ CSCSegtoRPC::CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments, const
 	      }
 	    }
 	  }
+      delete TheObjectCSC;
 	}
       }
     }

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -11,8 +11,7 @@
 #include <DataFormats/RPCRecHit/interface/RPCRecHitCollection.h>
 #include <RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h>
 
-ObjectMapCSC::ObjectMapCSC(){
-}
+
 
 ObjectMapCSC::ObjectMapCSC(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;

--- a/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
@@ -94,7 +94,7 @@ int distwheel(int wheel1,int wheel2){
   return distance;
 }
 
-DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, const edm::EventSetup& iSetup,const edm::Event& iEvent,bool debug,double eyr, const ObjectMap *TheObjectMap){
+DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, const edm::EventSetup& iSetup,const edm::Event& iEvent,bool debug, double eyr, const ObjectMap *TheObjectMap){
 
   /*
   MinCosAng=iConfig.getUntrackedParameter<double>("MinCosAng",0.95);
@@ -509,7 +509,7 @@ DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, cons
 			    LogDebug("RPCPointProducer") << "MB4 \t \t \t \t roll already extrapolated "<<rpcId<<std::endl;
 			  }
 			  LogDebug("RPCPointProducer") << "MB4 \t \t \t \t Extrapolations done after this point = "<<extrapolatedRolls.size()<<std::endl;
-			  for(uint32_t m=0;m<extrapolatedRolls.size();m++) LogDebug("RPCPointProducer") <<"MB4 \t \t \t \t"<< extrapolatedRolls.at(m)<<std::endl;
+			  if (debug) for(uint32_t m=0;m<extrapolatedRolls.size();m++) LogDebug("RPCPointProducer") <<"MB4 \t \t \t \t"<< extrapolatedRolls.at(m)<<std::endl;
 			}else{
 			  LogDebug("RPCPointProducer") << "MB4 \t \t \t \t No the prediction is outside of this roll"<<std::endl;
 			}

--- a/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
@@ -12,14 +12,7 @@
 #include <RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h>
 #include <ctime>
 
-ObjectMap* ObjectMap::mapInstance = NULL;
 
-ObjectMap* ObjectMap::GetInstance(const edm::EventSetup& iSetup){
-  if (mapInstance == NULL){
-    mapInstance = new ObjectMap(iSetup);
-  }
-  return mapInstance;
-}
 
 ObjectMap::ObjectMap(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;
@@ -180,12 +173,12 @@ DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, cons
 	float dz=segmentDirection.z();
       
 	if(debug)  std::cout<<"Calling to Object Map class"<<std::endl;
-	ObjectMap* TheObject = ObjectMap::GetInstance(iSetup);
+	ObjectMap* TheObject = new ObjectMap(iSetup);
 	if(debug) std::cout<<"Creating the DTIndex"<<std::endl;
 	DTStationIndex theindex(0,dtWheel,dtSector,dtStation);
 	if(debug) std::cout<<"Getting the Rolls for the given index"<<std::endl;
       
-	std::set<RPCDetId> rollsForThisDT = TheObject->GetInstance(iSetup)->GetRolls(theindex);
+	std::set<RPCDetId> rollsForThisDT = TheObject->GetRolls(theindex);
       
 	if(debug) std::cout<<"DT  \t \t Number of rolls for this DT = "<<rollsForThisDT.size()<<std::endl;
       
@@ -274,6 +267,7 @@ DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, cons
 	    if(debug) std::cout<<"DT \t \t \t No, Exrtrapolation too long!, canceled"<<std::endl;
 	  }//D so big
 	}//loop over all the rolls asociated
+    delete TheObject;
       }
     }
   
@@ -371,12 +365,12 @@ DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, cons
 		    }
 		   
 		    if(debug)  std::cout<<"Calling to Object Map class"<<std::endl;
-		    ObjectMap* TheObject = ObjectMap::GetInstance(iSetup);
+		    ObjectMap* TheObject = new ObjectMap(iSetup);
 		    if(debug) std::cout<<"Creating the DTIndex"<<std::endl;
 		    DTStationIndex theindex(0,dtWheel,dtSector,dtStation);
 		    if(debug) std::cout<<"Getting the Rolls for the given index"<<std::endl;
 
-		    std::set<RPCDetId> rollsForThisDT = TheObject->GetInstance(iSetup)->GetRolls(theindex);
+		    std::set<RPCDetId> rollsForThisDT = TheObject->GetRolls(theindex);
 
 		    if(debug) std::cout<<"MB4 \t \t Number of rolls for this DT = "<<rollsForThisDT.size()<<std::endl;
 		    
@@ -494,6 +488,7 @@ DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, cons
 			if(debug) std::cout<<"MB4 \t \t \t No, Exrtrapolation too long!, canceled"<<std::endl;
 		      }
 		    }//loop over all the rollsasociated
+            delete TheObject;
 		  }else{
 		    if(debug) std::cout<<"MB4 \t \t \t \t I found segments in MB4 and MB3 adjacent wheel and/or sector but not compatibles, Diferent Directions"<<std::endl;
 		  }

--- a/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
@@ -12,8 +12,7 @@
 #include <RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h>
 #include <ctime>
 
-ObjectMap::ObjectMap(){
-}
+
 
 ObjectMap::ObjectMap(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -71,7 +71,7 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
       std::auto_ptr<RPCRecHitCollection> TheDTPoints(DTClass.thePoints());     
       iEvent.put(TheDTPoints,"RPCDTExtrapolatedPoints"); 
     }else{
-      if(debug) std::cout<<"RPCHLT Invalid DTSegments collection"<<std::endl;
+      LogDebug("RPCPointProducer") <<  std::cout<<"RPCHLT Invalid DTSegments collection"<<std::endl;
     }
   }
 
@@ -79,14 +79,14 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     edm::Handle<CSCSegmentCollection> allCSCSegments;
     iEvent.getByToken(cscSegments, allCSCSegments);
     
-    if (MuonGeometryWatcher.check(iSetup)) TheCSCObjectsMap_->FillObjectMapCSC(iSetup);
+    if (MuonGeometryWatcher.check(iSetup)) TheCSCObjectsMap_->fillObjectMapCSC(iSetup);
       
     if(allCSCSegments.isValid()){
       CSCSegtoRPC CSCClass(allCSCSegments,iSetup,iEvent,debug,ExtrapolatedRegion, TheCSCObjectsMap_);
       std::auto_ptr<RPCRecHitCollection> TheCSCPoints(CSCClass.thePoints());  
       iEvent.put(TheCSCPoints,"RPCCSCExtrapolatedPoints"); 
     }else{
-      if(debug) std::cout<<"RPCHLT Invalid CSCSegments collection"<<std::endl;
+      LogDebug("RPCPointProducer") << std::cout<<"RPCHLT Invalid CSCSegments collection"<<std::endl;
     }
   }
   if(incltrack){
@@ -97,7 +97,7 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
       std::auto_ptr<RPCRecHitCollection> TheTrackPoints(TrackClass.thePoints());
       iEvent.put(TheTrackPoints,"RPCTrackExtrapolatedPoints");
     }else{
-      std::cout<<"RPCHLT Invalid Tracks collection"<<std::endl;
+      LogDebug("RPCPointProducer") <<"RPCHLT Invalid Tracks collection"<<std::endl;
     }
   }
  

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -81,7 +81,10 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     edm::Handle<CSCSegmentCollection> allCSCSegments;
     iEvent.getByToken(cscSegments, allCSCSegments);
     
-    if (MuonGeometryWatcher.check(iSetup)) TheCSCObjectsMap_->fillObjectMapCSC(iSetup);
+      if (MuonGeometryWatcher.check(iSetup)) {
+          std::cout << "test  geom" << std::endl;
+          TheCSCObjectsMap_->fillObjectMapCSC(iSetup);
+      }
       
     if(allCSCSegments.isValid()){
       CSCSegtoRPC CSCClass(allCSCSegments,iSetup,iEvent, debug, ExtrapolatedRegion, TheCSCObjectsMap_);
@@ -111,11 +114,11 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
  
 }
 
-void  RPCPointProducer::beginStream(edm::StreamID iID){
-    TheDTObjectsMap_  = new ObjectMap();
-    TheCSCObjectsMap_ = new ObjectMapCSC();
-    TheDTtrackObjectsMap_ = new ObjectMap2();
-    TheCSCtrackObjectsMap_ = new ObjectMap2CSC();
+void  RPCPointProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iSetup){
+    TheDTObjectsMap_  = new ObjectMap(iSetup);
+    TheCSCObjectsMap_ = new ObjectMapCSC(iSetup);
+    TheDTtrackObjectsMap_ = new ObjectMap2(iSetup);
+    TheCSCtrackObjectsMap_ = new ObjectMap2CSC(iSetup);
 
     
 }

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -124,5 +124,13 @@ void  RPCPointProducer::beginRun(edm::Run const& iRun, edm::EventSetup const& iS
 }
 
 
+void  RPCPointProducer::endRun(edm::Run const& iRun, edm::EventSetup const& iSetup){
 
+    delete TheDTObjectsMap_;
+    delete TheCSCObjectsMap_;
+    delete TheDTtrackObjectsMap_;
+    delete TheCSCtrackObjectsMap_;
+    
+    
+}
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -95,8 +95,14 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   if(incltrack){
     edm::Handle<reco::TrackCollection> alltracks;
     iEvent.getByToken(tracks,alltracks);
+      
+    if (MuonGeometryWatcher.check(iSetup)) {
+        TheDTtrackObjectsMap_->fillObjectMapDT(iSetup);
+        TheCSCtrackObjectsMap_->fillObjectMapCSC(iSetup);
+    }
+      
     if(!(alltracks->empty())){
-      TracktoRPC TrackClass(alltracks,iSetup,iEvent,debug,trackTransformerParam,tracks_);
+      TracktoRPC TrackClass(alltracks,iSetup,iEvent,trackTransformerParam,tracks_, TheDTtrackObjectsMap_, TheCSCtrackObjectsMap_);
       std::auto_ptr<RPCRecHitCollection> TheTrackPoints(TrackClass.thePoints());
       iEvent.put(TheTrackPoints,"RPCTrackExtrapolatedPoints");
     }else{
@@ -109,6 +115,8 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 void  RPCPointProducer::beginStream(edm::StreamID iID){
     TheDTObjectsMap_  = new ObjectMap();
     TheCSCObjectsMap_ = new ObjectMapCSC();
+    TheDTtrackObjectsMap_ = new ObjectMap2();
+    TheCSCtrackObjectsMap_ = new ObjectMap2CSC();
 
     
 }

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -44,6 +44,8 @@ RPCPointProducer::RPCPointProducer(const edm::ParameterSet& iConfig) :
   produces<RPCRecHitCollection>("RPCDTExtrapolatedPoints");
   produces<RPCRecHitCollection>("RPCCSCExtrapolatedPoints");
   produces<RPCRecHitCollection>("RPCTrackExtrapolatedPoints");
+    
+  //TheCSCObjectsMap_ = new ObjectMapCSC(iSetup);
 }
 
 
@@ -76,8 +78,11 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   if(inclcsc){
     edm::Handle<CSCSegmentCollection> allCSCSegments;
     iEvent.getByToken(cscSegments, allCSCSegments);
+    
+    if (MuonGeometryWatcher.check(iSetup)) TheCSCObjectsMap_->FillObjectMapCSC(iSetup);
+      
     if(allCSCSegments.isValid()){
-      CSCSegtoRPC CSCClass(allCSCSegments,iSetup,iEvent,debug,ExtrapolatedRegion);
+      CSCSegtoRPC CSCClass(allCSCSegments,iSetup,iEvent,debug,ExtrapolatedRegion, TheCSCObjectsMap_);
       std::auto_ptr<RPCRecHitCollection> TheCSCPoints(CSCClass.thePoints());  
       iEvent.put(TheCSCPoints,"RPCCSCExtrapolatedPoints"); 
     }else{
@@ -96,6 +101,12 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     }
   }
  
+}
+
+void  RPCPointProducer::beginStream(edm::StreamID iID){
+    TheCSCObjectsMap_ = new ObjectMapCSC();
+
+    
 }
 
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -66,8 +66,11 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
   if(incldt){
     edm::Handle<DTRecSegment4DCollection> all4DSegments;
     iEvent.getByToken(dt4DSegments, all4DSegments);
+      
+    if (MuonGeometryWatcher.check(iSetup)) TheDTObjectsMap_->fillObjectMapDT(iSetup);
+      
     if(all4DSegments.isValid()){
-      DTSegtoRPC DTClass(all4DSegments,iSetup,iEvent,debug,ExtrapolatedRegion);
+      DTSegtoRPC DTClass(all4DSegments,iSetup,iEvent,debug,ExtrapolatedRegion, TheDTObjectsMap_);
       std::auto_ptr<RPCRecHitCollection> TheDTPoints(DTClass.thePoints());     
       iEvent.put(TheDTPoints,"RPCDTExtrapolatedPoints"); 
     }else{
@@ -104,6 +107,7 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 }
 
 void  RPCPointProducer::beginStream(edm::StreamID iID){
+    TheDTObjectsMap_  = new ObjectMap();
     TheCSCObjectsMap_ = new ObjectMapCSC();
 
     

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -25,27 +25,25 @@
 
 // user include files
 
-RPCPointProducer::RPCPointProducer(const edm::ParameterSet& iConfig)
+RPCPointProducer::RPCPointProducer(const edm::ParameterSet& iConfig) :
+    cscSegments(    consumes<CSCSegmentCollection>(iConfig.getParameter<edm::InputTag>("cscSegments"))),
+    dt4DSegments(   consumes<DTRecSegment4DCollection>(iConfig.getParameter<edm::InputTag>("dt4DSegments"))),
+    tracks(         consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"))),
+    tracks_(        iConfig.getParameter<edm::InputTag>("tracks")),
+    debug(          iConfig.getUntrackedParameter<bool>("debug",false)),
+    incldt(         iConfig.getUntrackedParameter<bool>("incldt",true)),
+    inclcsc(        iConfig.getUntrackedParameter<bool>("inclcsc",true)),
+    incltrack(      iConfig.getUntrackedParameter<bool>("incltrack",true)),
+    MinCosAng(      iConfig.getUntrackedParameter<double>("MinCosAng",0.95)),
+    MaxD(           iConfig.getUntrackedParameter<double>("MaxD",0.95)),
+    MaxDrb4(        iConfig.getUntrackedParameter<double>("MaxDrb4",150.)),
+    ExtrapolatedRegion(iConfig.getUntrackedParameter<double>("ExtrapolatedRegion",0.5)),
+    trackTransformerParam(iConfig.getParameter<edm::ParameterSet>("TrackTransformer"))
 {
-  cscSegments = consumes<CSCSegmentCollection>(iConfig.getParameter<edm::InputTag>("cscSegments"));
-  
-  dt4DSegments = consumes<DTRecSegment4DCollection>(iConfig.getParameter<edm::InputTag>("dt4DSegments"));
-  tracks = consumes<reco::TrackCollection>(iConfig.getParameter<edm::InputTag>("tracks"));
-  tracks_ = iConfig.getParameter<edm::InputTag>("tracks");
-
-  debug=iConfig.getUntrackedParameter<bool>("debug",false);
-  incldt=iConfig.getUntrackedParameter<bool>("incldt",true);
-  inclcsc=iConfig.getUntrackedParameter<bool>("inclcsc",true);
-  incltrack=iConfig.getUntrackedParameter<bool>("incltrack",true);
-  MinCosAng=iConfig.getUntrackedParameter<double>("MinCosAng",0.95);
-  MaxD=iConfig.getUntrackedParameter<double>("MaxD",80.);
-  MaxDrb4=iConfig.getUntrackedParameter<double>("MaxDrb4",150.);
-  ExtrapolatedRegion=iConfig.getUntrackedParameter<double>("ExtrapolatedRegion",0.5);
 
   produces<RPCRecHitCollection>("RPCDTExtrapolatedPoints");
   produces<RPCRecHitCollection>("RPCCSCExtrapolatedPoints");
   produces<RPCRecHitCollection>("RPCTrackExtrapolatedPoints");
-  trackTransformerParam = iConfig.getParameter<edm::ParameterSet>("TrackTransformer");  
 }
 
 
@@ -100,15 +98,6 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
  
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-RPCPointProducer::beginJob()
-{
-}
 
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-RPCPointProducer::endJob() {
-}
 
 

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -45,7 +45,6 @@ RPCPointProducer::RPCPointProducer(const edm::ParameterSet& iConfig) :
   produces<RPCRecHitCollection>("RPCCSCExtrapolatedPoints");
   produces<RPCRecHitCollection>("RPCTrackExtrapolatedPoints");
     
-  //TheCSCObjectsMap_ = new ObjectMapCSC(iSetup);
 }
 
 
@@ -70,7 +69,7 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     if (MuonGeometryWatcher.check(iSetup)) TheDTObjectsMap_->fillObjectMapDT(iSetup);
       
     if(all4DSegments.isValid()){
-      DTSegtoRPC DTClass(all4DSegments,iSetup,iEvent,debug,ExtrapolatedRegion, TheDTObjectsMap_);
+      DTSegtoRPC DTClass(all4DSegments,iSetup,iEvent, debug, ExtrapolatedRegion, TheDTObjectsMap_);
       std::auto_ptr<RPCRecHitCollection> TheDTPoints(DTClass.thePoints());     
       iEvent.put(TheDTPoints,"RPCDTExtrapolatedPoints"); 
     }else{
@@ -85,7 +84,7 @@ void RPCPointProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
     if (MuonGeometryWatcher.check(iSetup)) TheCSCObjectsMap_->fillObjectMapCSC(iSetup);
       
     if(allCSCSegments.isValid()){
-      CSCSegtoRPC CSCClass(allCSCSegments,iSetup,iEvent,debug,ExtrapolatedRegion, TheCSCObjectsMap_);
+      CSCSegtoRPC CSCClass(allCSCSegments,iSetup,iEvent, debug, ExtrapolatedRegion, TheCSCObjectsMap_);
       std::auto_ptr<RPCRecHitCollection> TheCSCPoints(CSCClass.thePoints());  
       iEvent.put(TheCSCPoints,"RPCCSCExtrapolatedPoints"); 
     }else{

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -148,7 +148,7 @@ bool TracktoRPC::ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::E
    } else return false;
 }
 
-TracktoRPC::TracktoRPC(edm::Handle<reco::TrackCollection> alltracks, const edm::EventSetup& iSetup,const edm::Event& iEvent,bool debug,const edm::ParameterSet& iConfig,edm::InputTag& tracklabel){ 
+TracktoRPC::TracktoRPC(edm::Handle<reco::TrackCollection> alltracks, const edm::EventSetup& iSetup,const edm::Event& iEvent,bool debug,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel){
 
  _ThePoints = new RPCRecHitCollection();
 // if(alltracks->empty()) return;

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -16,14 +16,6 @@
 #include <ctime>
 #include <TMath.h>
 
-ObjectMap2* ObjectMap2::mapInstance = NULL;
-
-ObjectMap2* ObjectMap2::GetInstance(const edm::EventSetup& iSetup){
-  if (mapInstance == NULL){
-    mapInstance = new ObjectMap2(iSetup);
-  }
-  return mapInstance;
-}
 
 ObjectMap2::ObjectMap2(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;
@@ -70,14 +62,7 @@ int distwheel2(int wheel1,int wheel2){
   int distance = std::abs(wheel1 - wheel2);
   return distance;
 }
-ObjectMap2CSC* ObjectMap2CSC::mapInstance = NULL;
 
-ObjectMap2CSC* ObjectMap2CSC::GetInstance(const edm::EventSetup& iSetup){
-  if (mapInstance == NULL){
-    mapInstance = new ObjectMap2CSC(iSetup);
-  }
-  return mapInstance;
-}
 
 ObjectMap2CSC::ObjectMap2CSC(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;
@@ -217,9 +202,9 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                 DTChamberId dtid(geomDet->geographicalId().rawId());
                 int dtW=dtid.wheel(), dtS=dtid.sector(), dtT=dtid.station();
                 if(dtS==13) dtS=4; if(dtS==14) dtS=10;
-                ObjectMap2* TheObject = ObjectMap2::GetInstance(iSetup);
+                ObjectMap2* TheObject = new ObjectMap2(iSetup);
                 DTStationIndex2 theindex(0,dtW,dtS,dtT);
-                std::set<RPCDetId> rollsForThisDT = TheObject->GetInstance(iSetup)->GetRolls(theindex);
+                std::set<RPCDetId> rollsForThisDT = TheObject->GetRolls(theindex);
                 for(std::set<RPCDetId>::iterator iteraRoll = rollsForThisDT.begin();iteraRoll != rollsForThisDT.end(); iteraRoll++)
                 {                                 
 	            const RPCRoll* rollasociated = rpcGeo->roll(*iteraRoll);
@@ -239,7 +224,8 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                         if(debug) std::cout << "1\t Barrel RPC roll" << rollasociated->id().rawId() << " "<< servId.name().c_str() <<std::endl;
                       }
                     }
-	      	}                                 
+	      	}
+            delete TheObject;
 	     }
 	  }
        }
@@ -264,13 +250,13 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                 float dx = trajLP.x()-trackLP.x(), dy=trajLP.y()-trackLP.y();//, dz=trajLP.z()-trackLP.z();
                 if( dx>10. && dy>10.) continue;
 
-                ObjectMap2CSC* TheObjectCSC = ObjectMap2CSC::GetInstance(iSetup);
+                ObjectMap2CSC* TheObjectCSC = new ObjectMap2CSC(iSetup);
 	        int En = cscid.endcap(), St = cscid.station(), Ri = cscid.ring();
 	        int rpcSegment = cscid.chamber();
                 if(En==2) En= -1; if(Ri==4) Ri =1; 
 
                 CSCStationIndex2 theindex(En,St,Ri,rpcSegment);
-                std::set<RPCDetId> rollsForThisCSC = TheObjectCSC->GetInstance(iSetup)->GetRolls(theindex);
+                std::set<RPCDetId> rollsForThisCSC = TheObjectCSC->GetRolls(theindex);
                 for (std::set<RPCDetId>::iterator iteraRoll = rollsForThisCSC.begin();iteraRoll != rollsForThisCSC.end(); iteraRoll++)
                 {
 	            const RPCRoll* rollasociated = rpcGeo->roll(*iteraRoll);
@@ -291,6 +277,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                       }
                     }
 	      	}
+                 delete TheObjectCSC;
              }
           }
        } else { if(debug) std::cout << "1\t The hit is not DT/CSC's.   " << std::endl;} 

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -16,6 +16,8 @@
 #include <ctime>
 #include <TMath.h>
 
+ObjectMap2::ObjectMap2(){
+}
 
 ObjectMap2::ObjectMap2(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;
@@ -39,11 +41,44 @@ ObjectMap2::ObjectMap2(const edm::EventSetup& iSetup){
 	  std::set<RPCDetId> myrolls;
 	  if (rollstoreDT.find(ind)!=rollstoreDT.end()) myrolls=rollstoreDT[ind];
 	  myrolls.insert(rpcId);
-	  rollstoreDT[ind]=myrolls;
-	}
+      rollstoreDT.erase(ind);
+      std::pair<DTStationIndex2,const std::set<RPCDetId>> DTroolsWithInd(ind,myrolls);
+      rollstoreDT.insert(DTroolsWithInd);
+      }
       }
     }
   }
+}
+
+void ObjectMap2::fillObjectMapDT(const edm::EventSetup& iSetup){
+    edm::ESHandle<RPCGeometry> rpcGeo;
+    edm::ESHandle<DTGeometry> dtGeo;
+    
+    iSetup.get<MuonGeometryRecord>().get(rpcGeo);
+    iSetup.get<MuonGeometryRecord>().get(dtGeo);
+    
+    for (TrackingGeometry::DetContainer::const_iterator it=rpcGeo->dets().begin();it<rpcGeo->dets().end();it++){
+        if(dynamic_cast< RPCChamber const * >( *it ) != 0 ){
+            auto ch = dynamic_cast<const RPCChamber* >( *it );
+            std::vector< const RPCRoll*> roles = (ch->rolls());
+            for(std::vector<const RPCRoll*>::const_iterator r = roles.begin();r != roles.end(); ++r){
+                RPCDetId rpcId = (*r)->id();
+                int region=rpcId.region();
+                if(region==0){
+                    int wheel=rpcId.ring();
+                    int sector=rpcId.sector();
+                    int station=rpcId.station();
+                    DTStationIndex2 ind(region,wheel,sector,station);
+                    std::set<RPCDetId> myrolls;
+                    if (rollstoreDT.find(ind)!=rollstoreDT.end()) myrolls=rollstoreDT[ind];
+                    myrolls.insert(rpcId);
+                    rollstoreDT.erase(ind);
+                    std::pair<DTStationIndex2,const std::set<RPCDetId>> DTroolsWithInd(ind,myrolls);
+                    rollstoreDT.insert(DTroolsWithInd);
+                }
+            }
+        }
+    }
 }
 
 int distsector2(int sector1,int sector2){
@@ -63,6 +98,8 @@ int distwheel2(int wheel1,int wheel2){
   return distance;
 }
 
+ObjectMap2CSC::ObjectMap2CSC(){
+}
 
 ObjectMap2CSC::ObjectMap2CSC(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;
@@ -93,11 +130,51 @@ ObjectMap2CSC::ObjectMap2CSC(const edm::EventSetup& iSetup){
           std::set<RPCDetId> myrolls;
 	  if (rollstoreCSC.find(ind)!=rollstoreCSC.end()) myrolls=rollstoreCSC[ind];
 	  myrolls.insert(rpcId);
-          rollstoreCSC[ind]=myrolls;
-	}
+        rollstoreCSC.erase(ind);
+        std::pair<CSCStationIndex2,const std::set<RPCDetId>> CSCroolsWithInd(ind,myrolls);
+        rollstoreCSC.insert(CSCroolsWithInd);
+    }
       }
     }
   }
+}
+
+void ObjectMap2CSC::fillObjectMapCSC(const edm::EventSetup& iSetup){
+    edm::ESHandle<RPCGeometry> rpcGeo;
+    edm::ESHandle<CSCGeometry> cscGeo;
+    
+    iSetup.get<MuonGeometryRecord>().get(rpcGeo);
+    iSetup.get<MuonGeometryRecord>().get(cscGeo);
+    
+    for (TrackingGeometry::DetContainer::const_iterator it=rpcGeo->dets().begin();it<rpcGeo->dets().end();it++){
+        if(dynamic_cast< const RPCChamber* >( *it ) != 0 ){
+            const RPCChamber* ch = dynamic_cast< const RPCChamber* >( *it );
+            std::vector< const RPCRoll*> roles = (ch->rolls());
+            for(std::vector<const RPCRoll*>::const_iterator r = roles.begin();r != roles.end(); ++r){
+                RPCDetId rpcId = (*r)->id();
+                int region=rpcId.region();
+                if(region!=0){
+                    int station=rpcId.station();
+                    int ring=rpcId.ring();
+                    int cscring=ring;
+                    int cscstation=station;
+                    RPCGeomServ rpcsrv(rpcId);
+                    int rpcsegment = rpcsrv.segment();
+                    int cscchamber = rpcsegment; //FIX THIS ACCORDING TO RPCGeomServ::segment()Definition
+                    if((station==2||station==3)&&ring==3){//Adding Ring 3 of RPC to the CSC Ring 2
+                        cscring = 2;
+                    }
+                    CSCStationIndex2 ind(region,cscstation,cscring,cscchamber);
+                    std::set<RPCDetId> myrolls;
+                    if (rollstoreCSC.find(ind)!=rollstoreCSC.end()) myrolls=rollstoreCSC[ind];
+                    myrolls.insert(rpcId);
+                    rollstoreCSC.erase(ind);
+                    std::pair<CSCStationIndex2,const std::set<RPCDetId>> CSCroolsWithInd(ind,myrolls);
+                    rollstoreCSC.insert(CSCroolsWithInd);
+                }
+            }
+        }
+    }
 }
 
 bool TracktoRPC::ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::EventSetup& iSetup)
@@ -133,7 +210,7 @@ bool TracktoRPC::ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::E
    } else return false;
 }
 
-TracktoRPC::TracktoRPC(edm::Handle<reco::TrackCollection> alltracks, const edm::EventSetup& iSetup,const edm::Event& iEvent,bool debug,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel){
+TracktoRPC::TracktoRPC(edm::Handle<reco::TrackCollection> alltracks, const edm::EventSetup& iSetup,const edm::Event& iEvent,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel, const ObjectMap2 *TheObjectMap, const ObjectMap2CSC *TheObjectCSCMap){
 
  _ThePoints = new RPCRecHitCollection();
 // if(alltracks->empty()) return;
@@ -158,7 +235,7 @@ double MaxD=999.;
 for (TrackCollection::const_iterator track = alltracks->begin(); track !=alltracks->end(); track++)
 {
  Trajectories trajectories = theTrackTransformer->transform(*track);
- if(debug) std::cout << "Building Trajectory from Track. " << std::endl;
+ LogDebug("RPCPointProducer") <<  "Building Trajectory from Track. " << std::endl;
 
  std::vector<uint32_t> rpcrolls;
  std::vector<uint32_t> rpcrolls2; 
@@ -171,10 +248,10 @@ for (TrackCollection::const_iterator track = alltracks->begin(); track !=alltrac
  if(tInY > tOuY) { float temp=tOuY; tOuY=tInY; tInY=temp; }
  if(tInZ > tOuZ) { float temp=tOuZ; tOuZ=tInZ; tInZ=temp; }
 
- if(debug) std::cout << "in (x,y,z): ("<< tInX <<", "<< tInY <<", "<< tInZ << ")" << std::endl;
- if(debug) std::cout << "out (x,y,z): ("<< tOuX <<", "<< tOuY <<", "<< tOuZ << ")" << std::endl;
+ LogDebug("RPCPointProducer") <<  "in (x,y,z): ("<< tInX <<", "<< tInY <<", "<< tInZ << ")" << std::endl;
+ LogDebug("RPCPointProducer") <<  "out (x,y,z): ("<< tOuX <<", "<< tOuY <<", "<< tOuZ << ")" << std::endl;
 
-if(debug) std::cout << "1. Search expeted RPC roll detid !!" << std::endl;
+LogDebug("RPCPointProducer") <<  "1. Search expeted RPC roll detid !!" << std::endl;
 for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(); hit++)
  {
     if((*hit)->isValid())
@@ -202,9 +279,8 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                 DTChamberId dtid(geomDet->geographicalId().rawId());
                 int dtW=dtid.wheel(), dtS=dtid.sector(), dtT=dtid.station();
                 if(dtS==13) dtS=4; if(dtS==14) dtS=10;
-                ObjectMap2* TheObject = new ObjectMap2(iSetup);
                 DTStationIndex2 theindex(0,dtW,dtS,dtT);
-                std::set<RPCDetId> rollsForThisDT = TheObject->GetRolls(theindex);
+                std::set<RPCDetId> rollsForThisDT = TheObjectMap->getRolls(theindex);
                 for(std::set<RPCDetId>::iterator iteraRoll = rollsForThisDT.begin();iteraRoll != rollsForThisDT.end(); iteraRoll++)
                 {                                 
 	            const RPCRoll* rollasociated = rpcGeo->roll(*iteraRoll);
@@ -221,11 +297,10 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                       {
                         rpcrolls.push_back(rollasociated->id().rawId());
                         RPCGeomServ servId(rollasociated->id().rawId());
-                        if(debug) std::cout << "1\t Barrel RPC roll" << rollasociated->id().rawId() << " "<< servId.name().c_str() <<std::endl;
+                        LogDebug("RPCPointProducer") <<  "1\t Barrel RPC roll" << rollasociated->id().rawId() << " "<< servId.name().c_str() <<std::endl;
                       }
                     }
 	      	}
-            delete TheObject;
 	     }
 	  }
        }
@@ -250,13 +325,12 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                 float dx = trajLP.x()-trackLP.x(), dy=trajLP.y()-trackLP.y();//, dz=trajLP.z()-trackLP.z();
                 if( dx>10. && dy>10.) continue;
 
-                ObjectMap2CSC* TheObjectCSC = new ObjectMap2CSC(iSetup);
 	        int En = cscid.endcap(), St = cscid.station(), Ri = cscid.ring();
 	        int rpcSegment = cscid.chamber();
                 if(En==2) En= -1; if(Ri==4) Ri =1; 
 
                 CSCStationIndex2 theindex(En,St,Ri,rpcSegment);
-                std::set<RPCDetId> rollsForThisCSC = TheObjectCSC->GetRolls(theindex);
+                std::set<RPCDetId> rollsForThisCSC = TheObjectCSCMap->getRolls(theindex);
                 for (std::set<RPCDetId>::iterator iteraRoll = rollsForThisCSC.begin();iteraRoll != rollsForThisCSC.end(); iteraRoll++)
                 {
 	            const RPCRoll* rollasociated = rpcGeo->roll(*iteraRoll);
@@ -273,17 +347,16 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                       {
                         rpcrolls.push_back(rollasociated->id().rawId());
                         RPCGeomServ servId(rollasociated->id().rawId());
-                        if(debug) std::cout << "1\t Forward RPC roll" << rollasociated->id().rawId() << " "<< servId.name().c_str() <<std::endl;
+                        LogDebug("RPCPointProducer") <<  "1\t Forward RPC roll" << rollasociated->id().rawId() << " "<< servId.name().c_str() <<std::endl;
                       }
                     }
 	      	}
-                 delete TheObjectCSC;
              }
           }
-       } else { if(debug) std::cout << "1\t The hit is not DT/CSC's.   " << std::endl;} 
+       } else { LogDebug("RPCPointProducer") <<  "1\t The hit is not DT/CSC's.   " << std::endl;} 
     }
  }
- if(debug) std::cout << "First step OK!!\n2. Search nearest DT/CSC sufrace!!" << std::endl;
+ LogDebug("RPCPointProducer") <<  "First step OK!!\n2. Search nearest DT/CSC sufrace!!" << std::endl;
  std::vector<uint32_t>::iterator rpcroll;
  for( rpcroll=rpcrolls.begin() ; rpcroll < rpcrolls.end(); rpcroll++ )
  {
@@ -320,7 +393,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                {
                    dtcscid=geomDet->geographicalId().rawId();
                    distance = distanceN;
-                   if(debug) std::cout << "2\t DT "<< dtcscid << " Wheel : " << Wh << " station : " << St << " sector : " << Se << std::endl; 
+                   LogDebug("RPCPointProducer") <<  "2\t DT "<< dtcscid << " Wheel : " << Wh << " station : " << St << " sector : " << Se << std::endl; 
                }
             }
             else if (id.det() == DetId::Muon  &&  id.subdetId() == MuonSubdetId::CSC)
@@ -339,7 +412,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                {
                    dtcscid=geomDet->geographicalId().rawId();
                    distance = distanceN;
-                   if(debug) std::cout << "2\t CSC " <<dtcscid <<" region : " << En << " station : " << St << " Ring : " << Ri << " chamber : " << Ch <<std::endl;
+                   LogDebug("RPCPointProducer") <<  "2\t CSC " <<dtcscid <<" region : " << En << " station : " << St << " Ring : " << Ri << " chamber : " << Ch <<std::endl;
                }
             } 
          }
@@ -350,7 +423,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
        rpcNdtcsc[*rpcroll] = dtcscid;
     }
  } 
- if(debug) std::cout << "Second step OK!! \n3. Propagate to RPC from DT/CSC!!" << std::endl;  
+ LogDebug("RPCPointProducer") <<  "Second step OK!! \n3. Propagate to RPC from DT/CSC!!" << std::endl;  
  //std::map<uint32_t, int> rpcput;
  std::vector<uint32_t>::iterator rpcroll2;
  for( rpcroll2=rpcrolls2.begin() ; rpcroll2 < rpcrolls2.end(); rpcroll2++ )
@@ -405,7 +478,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                       RPCRecHit RPCPoint(*rpcroll2,0,LocalPoint(locx,locy,locz));
 
                       RPCGeomServ servId(*rpcroll2);
-                      if(debug) std::cout << "3\t Barrel Expected RPC " << servId.name().c_str() <<
+                      LogDebug("RPCPointProducer") <<  "3\t Barrel Expected RPC " << servId.name().c_str() <<
                         " \tLocalposition X: " << locx << ", Y: "<< locy << " GlobalPosition(x,y,z) (" << rpcGPX <<", "<< rpcGPY <<", " << rpcGPZ << ")"<< std::endl;        
                       RPCPointVector.clear();
                       RPCPointVector.push_back(RPCPoint);
@@ -458,7 +531,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
                    {
                       RPCRecHit RPCPoint(*rpcroll2,0,LocalPoint(locx,locy,locz));
                       RPCGeomServ servId(*rpcroll2);
-                      if(debug) std::cout << "3\t Forward Expected RPC " << servId.name().c_str() <<
+                      LogDebug("RPCPointProducer") <<  "3\t Forward Expected RPC " << servId.name().c_str() <<
                         " \tLocalposition X: " << locx << ", Y: "<< locy << " GlobalPosition(x,y,z) (" << rpcGPX <<", "<< rpcGPY <<", " << rpcGPZ << ")"<< std::endl;
                       RPCPointVector.clear();
                       RPCPointVector.push_back(RPCPoint);
@@ -472,7 +545,7 @@ for(trackingRecHit_iterator hit=track->recHitsBegin(); hit != track->recHitsEnd(
         }
     }
  }
- if(debug) std::cout << "last steps OK!! " << std::endl; 
+ LogDebug("RPCPointProducer") <<  "last steps OK!! " << std::endl; 
 }
 }
 

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -16,8 +16,7 @@
 #include <ctime>
 #include <TMath.h>
 
-ObjectMap2::ObjectMap2(){
-}
+
 
 ObjectMap2::ObjectMap2(const edm::EventSetup& iSetup){
   edm::ESHandle<RPCGeometry> rpcGeo;

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -210,7 +210,7 @@ bool TracktoRPC::ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::E
    } else return false;
 }
 
-TracktoRPC::TracktoRPC(edm::Handle<reco::TrackCollection> alltracks, const edm::EventSetup& iSetup,const edm::Event& iEvent,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel, const ObjectMap2 *TheObjectMap, const ObjectMap2CSC *TheObjectCSCMap){
+TracktoRPC::TracktoRPC(edm::Handle<reco::TrackCollection> alltracks, const edm::EventSetup& iSetup,const edm::Event& iEvents,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel, const ObjectMap2 *TheObjectMap, const ObjectMap2CSC *TheObjectCSCMap){
 
  _ThePoints = new RPCRecHitCollection();
 // if(alltracks->empty()) return;


### PR DESCRIPTION
- migration of the module to a stream producer 
- make const the configuration parameters
- add override to inherited methods

will be backported in 74X  
