### PR TITLE
Fixing PromptCalibProdSiStripGains to work in 74X

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -45,17 +45,15 @@ ALCARECOCalibrationTracks = AlignmentTrackSelector.clone(
 # FIXME: the beam-spot should be kept in the AlCaReco (if not already there) and dropped from here
 from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 
-from RecoTracker.TrackProducer.TrackRefitter_cfi import *
-ALCARECOCalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("ALCARECOCalibrationTracks"))
-
-from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import *
-
+from RecoTracker.TrackProducer.TrackRefitters_cff import * 
+ALCARECOCalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("ALCARECOCalibrationTracks"),
+                                                     NavigationSchool = cms.string("")
+                                                     )
 
 # refit and BS can be dropped if done together with RECO.
 # track filter can be moved in acalreco if no otehr users
 ALCARECOTrackFilterRefit = cms.Sequence(ALCARECOCalibrationTracks +
                                         offlineBeamSpot +
-                                        MeasurementTrackerEvent +
                                         ALCARECOCalibrationTracksRefit )
 
 

--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOPromptCalibProdSiStripGains_cff.py
@@ -45,7 +45,10 @@ ALCARECOCalibrationTracks = AlignmentTrackSelector.clone(
 # FIXME: the beam-spot should be kept in the AlCaReco (if not already there) and dropped from here
 from RecoVertex.BeamSpotProducer.BeamSpot_cff import *
 
-from RecoTracker.TrackProducer.TrackRefitters_cff import * 
+from RecoTracker.IterativeTracking.InitialStep_cff import *
+from RecoTracker.Configuration.RecoTrackerP5_cff import *
+from RecoTracker.TrackProducer.TrackRefitter_cfi import *
+
 ALCARECOCalibrationTracksRefit = TrackRefitter.clone(src = cms.InputTag("ALCARECOCalibrationTracks"),
                                                      NavigationSchool = cms.string("")
                                                      )


### PR DESCRIPTION
Fix in the `ALCARECOPromptCalibProdSiStripGains_cff.py` configuration for running SiStrip Gain calibration at PCL. First detected [here](https://hypernews.cern.ch/HyperNews/CMS/get/calibrations/1707.html), followed-up [here](https://hypernews.cern.ch/HyperNews/CMS/get/tracker-performance/1772/1/1.html). Backport of #9103 
