### PR TITLE
Fixing import script for HBHENegativeEFilter

### DIFF
--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -134,6 +134,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE( FileBlob )
       FETCH_PAYLOAD_CASE( GBRForest )
       FETCH_PAYLOAD_CASE( GBRForestD )
+      FETCH_PAYLOAD_CASE( HBHENegativeEFilter )
       FETCH_PAYLOAD_CASE( HcalChannelQuality )
       FETCH_PAYLOAD_CASE( HcalCholeskyMatrices )
       FETCH_PAYLOAD_CASE( HcalElectronicsMap )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -149,6 +149,7 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( FileBlob )
       IMPORT_PAYLOAD_CASE( GBRForest )
       IMPORT_PAYLOAD_CASE( GBRForestD )
+      IMPORT_PAYLOAD_CASE( HBHENegativeEFilter )	
       IMPORT_PAYLOAD_CASE( HcalChannelQuality )
       IMPORT_PAYLOAD_CASE( HcalCholeskyMatrices )
       IMPORT_PAYLOAD_CASE( HcalDcsValues )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -66,6 +66,7 @@
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h"
 #include "CondFormats/HcalObjects/interface/StorableDoubleMap.h"
 #include "CondFormats/HcalObjects/interface/HcalInterpolatedPulseColl.h"
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
 #include "CondFormats/L1TObjects/interface/L1CaloEcalScale.h"


### PR DESCRIPTION
This PR adds the possibility for the `conddb_import` tool to fetch and import the class `HBHENegativeEFilter`. This is needed for the dropbox to properly handle the payloads of this type.
