### PR TITLE
Use shrink_to_fit on the PFRecHit collections

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFRecHitProducer.cc
@@ -81,6 +81,9 @@ void
    outputSizeGuess_.update( out->size() );
    cleanedOutputSizeGuess_.update( cleaned->size() );
 
+   out->shrink_to_fit();
+   cleaned->shrink_to_fit();
+
    iEvent.put(out,"");
    iEvent.put(cleaned,"Cleaned");
    hitmap.clear();


### PR DESCRIPTION
Uses shrink_to_fit in PFRecHitProducer as suggested by @lgray.
Memory size of the produced collections in SLHC25_patch6 (top 25 only):
![before](https://cloud.githubusercontent.com/assets/6480160/7653507/2314a6be-fb0e-11e4-9f9a-3e3f81b66b55.png)
Same again after applying this PR and #9096:
![allmemimprovements](https://cloud.githubusercontent.com/assets/6480160/7653514/29be7080-fb0e-11e4-976a-d8e821292e46.png)

Looking at the VmSize there appears to be an improvement.  This plot is hard to read because the x-axis is approximately time, and they didn't run at the same speed.  Each undulating peak is an event, it rises as control runs through the modules and then drops at the start of the next event.  The red (this PR, #9096 and #9084) is a little faster (wouldn't read anything into that) so the peaks are a little ahead of the blue (SLHC25_patch6).  The important thing is that if you match the corresponding peaks the red is ~100Mb lower.  The vast majority of that is this pull request rather than #9096 or #9084.
![vmsize_allimprovements](https://cloud.githubusercontent.com/assets/6480160/7653568/9d7b19a6-fb0e-11e4-8751-6a614c00e017.png)
