### PR TITLE
Update efficiency plots, PU range and added HggControlPath directory

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsPostProcessors_cff.py
@@ -119,28 +119,30 @@ for type in plot_types:
 
 
 #add the summary plots
+efficiency_summary_strings = []
 for an in _config.analysis:
-    efficiency_strings.append("EffSummaryPaths_"+an+"_gen ' Efficiency of paths used in "+an+" ; trigger path ' SummaryPaths_"+an+"_gen_passingHLT SummaryPaths_"+an+"_gen")
+    efficiency_summary_strings.append("EffSummaryPaths_"+an+"_gen ' Efficiency of paths used in "+an+" ; trigger path ' SummaryPaths_"+an+"_gen_passingHLT SummaryPaths_"+an+"_gen")
     for trig in triggers:
-        efficiency_strings.append("Eff_trueVtxDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs nb of interactions ; nb events passing each path ' trueVtxDist_"+an+"_gen_"+trig+" trueVtxDist_"+an+"_gen")
+        efficiency_summary_strings.append("Eff_trueVtxDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs nb of interactions ; nb events passing each path ' trueVtxDist_"+an+"_gen_"+trig+" trueVtxDist_"+an+"_gen")
 
+efficiency_strings.extend(efficiency_summary_strings)
 efficiency_strings.extend(get_reco_strings(efficiency_strings))
-
-
 
 hltHiggsPostHWW = hltHiggsPostProcessor.clone()
 hltHiggsPostHWW.subDirs = ['HLT/Higgs/HWW']
 hltHiggsPostHWW.efficiencyProfile = efficiency_strings
 
-
 hltHiggsPostHZZ = hltHiggsPostProcessor.clone()
 hltHiggsPostHZZ.subDirs = ['HLT/Higgs/HZZ']
 hltHiggsPostHZZ.efficiencyProfile = efficiency_strings
 
-
 hltHiggsPostHgg = hltHiggsPostProcessor.clone()
 hltHiggsPostHgg.subDirs = ['HLT/Higgs/Hgg']
 hltHiggsPostHgg.efficiencyProfile = efficiency_strings
+
+hltHiggsPostHggControlPaths = hltHiggsPostProcessor.clone()
+hltHiggsPostHggControlPaths.subDirs = ['HLT/Higgs/HggControlPaths']
+hltHiggsPostHggControlPaths.efficiencyProfile = efficiency_strings
 
 hltHiggsPostDoubleHinTaus = hltHiggsPostProcessor.clone()
 hltHiggsPostDoubleHinTaus.subDirs = ['HLT/Higgs/DoubleHinTaus']
@@ -154,19 +156,19 @@ hltHiggsPostH2tau = hltHiggsPostProcessor.clone()
 hltHiggsPostH2tau.subDirs = ['HLT/Higgs/H2tau']
 hltHiggsPostH2tau.efficiencyProfile = efficiency_strings
 
-
 hltHiggsPostHtaunu = hltHiggsPostProcessor.clone()
 hltHiggsPostHtaunu.subDirs = ['HLT/Higgs/Htaunu']
 hltHiggsPostHtaunu.efficiencyProfile = efficiency_strings
 
 
-efficiency_strings_TTHbbej = list(efficiency_strings)
+efficiency_strings_TTHbbej = []
 #add the summary plots
 for an in _config.analysis:
     for trig in triggers:
         efficiency_strings_TTHbbej.append("Eff_HtDist_"+an+"_gen_"+trig+" ' Efficiency of "+trig+" vs sum pT of jets ; sum pT of jets ' HtDist_"+an+"_gen_"+trig+" HtDist_"+an+"_gen")
 
 efficiency_strings_TTHbbej.extend(get_reco_strings(efficiency_strings_TTHbbej))
+efficiency_strings_TTHbbej.extend(efficiency_strings)
 
 hltHiggsPostTTHbbej = hltHiggsPostProcessor.clone()
 hltHiggsPostTTHbbej.subDirs = ['HLT/Higgs/TTHbbej']
@@ -195,6 +197,7 @@ for type in plot_types:
             efficiency_strings.append(efficiency_string(obj,type,trig))
 
 efficiency_strings = get_reco_strings(efficiency_strings)
+efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 
 hltHiggsPostVBFHbb_2btag = hltHiggsPostProcessor.clone()
 hltHiggsPostVBFHbb_2btag.subDirs = ['HLT/Higgs/VBFHbb_2btag']
@@ -202,7 +205,6 @@ hltHiggsPostVBFHbb_2btag.efficiencyProfile = efficiency_strings
 
 #Specific plots for VBFHbb_1btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
-NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
 plot_types = []
 NminOneCuts = (_config.__getattribute__("VBFHbb_1btag")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
@@ -211,6 +213,15 @@ if NminOneCuts:
             if( NminOneCutNames[iCut] == "EffmaxCSV" ):
                 plot_types.pop()
             plot_types.append(NminOneCutNames[iCut])
+                       
+efficiency_strings = []
+for type in plot_types:
+    for obj in ["Jet"]:
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
+
+efficiency_strings = get_reco_strings(efficiency_strings)
+efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
     
 hltHiggsPostVBFHbb_1btag = hltHiggsPostProcessor.clone()
 hltHiggsPostVBFHbb_1btag.subDirs = ['HLT/Higgs/VBFHbb_1btag']
@@ -218,18 +229,27 @@ hltHiggsPostVBFHbb_1btag.efficiencyProfile = efficiency_strings
 
 #Specific plots for VBFHbb_0btag  
 #dEtaqq, mqq, dPhibb, CVS1, maxCSV_jets, maxCSV_E, MET, pt1, pt2, pt3, pt4
-NminOneCutNames = ("EffdEtaqq", "Effmqq", "EffdPhibb", "EffCSV1", "EffCSV2", "EffCSV3",  "EffmaxCSV", "", "", "TurnOn1", "TurnOn2", "TurnOn3", "TurnOn4")
 plot_types = []
 NminOneCuts = (_config.__getattribute__("VBFHbb_0btag")).__getattribute__("NminOneCuts")
 if NminOneCuts: 
     for iCut in range(0,len(NminOneCuts)):
         if( NminOneCuts[iCut] and NminOneCutNames[iCut] ):
+            if( NminOneCutNames[iCut] == "EffmaxCSV" ):
+                plot_types.pop()
             plot_types.append(NminOneCutNames[iCut])
+
+efficiency_strings = []
+for type in plot_types:
+    for obj in ["Jet"]:
+        for trig in triggers:
+            efficiency_strings.append(efficiency_string(obj,type,trig))
+
+efficiency_strings = get_reco_strings(efficiency_strings)
+efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 
 hltHiggsPostVBFHbb_0btag = hltHiggsPostProcessor.clone()
 hltHiggsPostVBFHbb_0btag.subDirs = ['HLT/Higgs/VBFHbb_0btag']
 hltHiggsPostVBFHbb_0btag.efficiencyProfile = efficiency_strings
-
 
 
 #Specific plots for ZnnHbb
@@ -259,6 +279,7 @@ for type in plot_types:
 
 efficiency_strings2 = get_reco_strings(efficiency_strings2)
 efficiency_strings += efficiency_strings2
+efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
     
 hltHiggsPostZnnHbb = hltHiggsPostProcessor.clone()
 hltHiggsPostZnnHbb.subDirs = ['HLT/Higgs/ZnnHbb']
@@ -280,6 +301,7 @@ for type in plot_types:
             efficiency_strings.append(efficiency_string(obj,type,trig))
         
 efficiency_strings = get_reco_strings(efficiency_strings)
+efficiency_strings.extend(get_reco_strings(efficiency_summary_strings))
 
 hltHiggsPostX4b = hltHiggsPostProcessor.clone()
 hltHiggsPostX4b.subDirs = ['HLT/Higgs/X4b']
@@ -291,6 +313,7 @@ hltHiggsPostProcessors = cms.Sequence(
         hltHiggsPostHWW+
         hltHiggsPostHZZ+
         hltHiggsPostHgg+
+        hltHiggsPostHggControlPaths+
         hltHiggsPostHtaunu+
         hltHiggsPostH2tau+
         hltHiggsPostTTHbbej+

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         
     hltProcessName = cms.string("HLT"),
-    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH"), 
+    analysis       = cms.vstring("HWW", "HZZ", "Hgg", "HggControlPaths", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH"), 
     histDirectory  = cms.string("HLT/Higgs"),
     
     # -- The instance name of the reco::GenParticles collection
@@ -31,7 +31,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     # -- (NBins, minVal, maxValue) for the Eta,Phi and nInterations efficiency plots
     parametersEta      = cms.vdouble(48, -2.400, 2.400),
     parametersPhi      = cms.vdouble(50, -3.142, 3.142),
-    parametersPu       = cms.vdouble(10, 0, 20),
+    parametersPu       = cms.vdouble(10, 0, 50),
     parametersHt       = cms.untracked.vdouble(100, 0, 1000),
 
     # TO BE DEPRECATED --------------------------------------------
@@ -150,13 +150,20 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     Hgg = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_Diphoton30_18_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_PixelSeed_Mass70_v",
             "HLT_Diphoton44_28_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P1_R9Id50b80e_v",
             "HLT_Diphoton30_18_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_Mass95_v",
             "HLT_Diphoton28_14_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_Mass50_Eta_1p5_v",
             "HLT_Diphoton30_18_R9Id85_AND_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_Solid_Mass30_v",
             "HLT_Diphoton30_18_R9Id85_AND_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_PV_v",
             "HLT_Diphoton30_18_R9Id85_AND_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_DoublePV_v"
+        ),
+        recPhotonLabel  = cms.string("photons"),
+        # -- Analysis specific cuts
+        minCandidates = cms.uint32(2), 
+        ),
+    HggControlPaths = cms.PSet( 
+        hltPathsToCheck = cms.vstring(
+            "HLT_Diphoton30_18_R9Id85_OR_Iso50T80LCaloId24b40e_AND_HE10P0_R9Id50b80e_PixelSeed_Mass70_v"
         ),
         recPhotonLabel  = cms.string("photons"),
         # -- Analysis specific cuts

--- a/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
+++ b/HLTriggerOffline/Higgs/src/HLTHiggsSubAnalysis.cc
@@ -341,7 +341,7 @@ void HLTHiggsSubAnalysis::bookHistograms(DQMStore::IBooker &ibooker)
         double minHt   = paramsHt[1];
         double maxHt   = paramsHt[2];
 
-        _elements[nameVtxPlot] = ibooker.book1D(nameVtxPlot.c_str(), titlePu.c_str(), nBinsPu, minPu, maxPu);
+        if( (! _useNminOneCuts) || sources[i] == "rec" ) _elements[nameVtxPlot] = ibooker.book1D(nameVtxPlot.c_str(), titlePu.c_str(), nBinsPu, minPu, maxPu);
         if( _bookHtPlots ) _elements[nameHtPlot] = ibooker.book1D(nameHtPlot.c_str(), titleHt.c_str(), nBinsHt, minHt, maxHt);
         for (size_t j = 0 ; j < _hltPathsToCheck.size() ; j++){
                 //declare the efficiency vs interaction plots
@@ -352,7 +352,7 @@ void HLTHiggsSubAnalysis::bookHistograms(DQMStore::IBooker &ibooker)
                         shortpath = path.substr(0, path.rfind("_v"));
                 }
             std::string titlePassingPu = "nb of interations in the event passing path " + shortpath;
-            _elements[nameVtxPlot+"_"+shortpath] = ibooker.book1D(nameVtxPlot+"_"+shortpath, titlePassingPu.c_str(), nBinsPu, minPu, maxPu);
+            if( (! _useNminOneCuts) || sources[i] == "rec" ) _elements[nameVtxPlot+"_"+shortpath] = ibooker.book1D(nameVtxPlot+"_"+shortpath, titlePassingPu.c_str(), nBinsPu, minPu, maxPu);
 
             std::string titlePassingHt = "sum of jet pT in the event passing path " + shortpath;
             if( _bookHtPlots ) _elements[nameHtPlot+"_"+shortpath] = ibooker.book1D(nameHtPlot+"_"+shortpath, titlePassingHt.c_str(), nBinsHt, minHt, maxHt);
@@ -678,7 +678,7 @@ void HLTHiggsSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventSet
 
         //fill the efficiency vs nb of interactions
         std::string nameVtxPlot = "trueVtxDist_"+_analysisname+"_"+u2str[it->first];
-        _elements[nameVtxPlot]->Fill(nbMCvtx);
+        if( (! _useNminOneCuts) || it->first == RECO ) _elements[nameVtxPlot]->Fill(nbMCvtx);
 
         //fill the efficiency vs sum pT of jets
         std::string nameHtPlot = "HtDist_"+_analysisname+"_"+u2str[it->first];
@@ -710,7 +710,7 @@ void HLTHiggsSubAnalysis::analyze(const edm::Event & iEvent, const edm::EventSet
             _elements[SummaryName]->Fill(refOfThePath);
             if (ispassTrigger) {
                 _elements[SummaryName+"_passingHLT"]->Fill(refOfThePath,1);
-                _elements[nameVtxPlot+"_"+fillShortPath.c_str()]->Fill(nbMCvtx);
+                if( (! _useNminOneCuts) || it->first == RECO ) _elements[nameVtxPlot+"_"+fillShortPath.c_str()]->Fill(nbMCvtx);
                 if( _bookHtPlots ) _elements[nameHtPlot+"_"+fillShortPath.c_str()]->Fill(Htmap[it->first]);
             }
             else {


### PR DESCRIPTION
Maintainance of the HLTValidation Higgs code, updating the PU range and correcting some inconsistenties. In more detail:

hltHiggsValidator_cfi.py:
- PU binning: 10 bins between [0,50]
- Added a hltHiggsPostHggControlPaths directory

hltHiggsPostProcessors_cff.py:
- Added EffSummary and Vtx plots for b directories
- Corrected the TTHbbej rec EffSummary in ROOT6
- Removed empty gen trueVx histograms and gen eff for NminOne plots.

The total number of histograms is slightly decreasing. Comparison done with DQMStoreStats module:

| subsystem/folder | histograms | bins | Empty bins | Empty/Total | bins per histogram | MB | kB per histogram |
| --- | --- | --- | --- | --- | --- | --- | --- |
| Higgs after | 1295 | 47836 | 43239 | 0.904 | 36.9 | 0.182 | 0.144 |
| Higgs before | 1301 | 47692 | 43136 | 0.904 | 36.7 | 0.182 | 0.143 |
