### PR TITLE
Introduced IOV caching in pages

### DIFF
--- a/CondCore/CondDB/src/DbCore.h
+++ b/CondCore/CondDB/src/DbCore.h
@@ -442,6 +442,10 @@ namespace cond {
       m_coralQuery->addToOrderList( orderClause );
     }
 
+    void groupBy( const std::string& expression ){
+      m_coralQuery->groupBy( expression );
+    }
+
     void setForUpdate(){
       m_coralQuery->setForUpdate();
     }

--- a/CondCore/CondDB/src/IOVSchema.cc
+++ b/CondCore/CondDB/src/IOVSchema.cc
@@ -114,7 +114,7 @@ namespace cond {
       buffer.addWhereCondition<NAME>( name );
       updateTable( m_schema, tname, buffer );
     }
-    
+
     IOV::Table::Table( coral::ISchema& schema ):
       m_schema( schema ){
     }
@@ -139,6 +139,7 @@ namespace cond {
     size_t IOV::Table::selectGroups( const std::string& tag, std::vector<cond::Time_t>& groups ){
       Query< SINCE_GROUP > q( m_schema, true );
       q.addCondition<TAG_NAME>( tag );
+      q.groupBy(SINCE_GROUP::group());
       q.addOrderClause<SINCE_GROUP>();
       for( auto row : q ){
 	groups.push_back(std::get<0>(row));
@@ -150,6 +151,7 @@ namespace cond {
       Query< SINCE_GROUP > q( m_schema, true );
       q.addCondition<TAG_NAME>( tag );
       q.addCondition<INSERTION_TIME>( snapshotTime,"<=" );
+      q.groupBy(SINCE_GROUP::group());
       q.addOrderClause<SINCE_GROUP>();
       for( auto row : q ){
 	groups.push_back(std::get<0>(row));

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -82,25 +82,20 @@ namespace cond {
       column( SINCE, cond::Time_t );
       column( PAYLOAD_HASH, std::string, PAYLOAD::PAYLOAD_HASH_SIZE );
       column( INSERTION_TIME, boost::posix_time::ptime );
-      
-      struct MAX_SINCE {					 
-	typedef cond::Time_t type;				   
-	static constexpr size_t size = 0;
-	static std::string tableName(){ return SINCE::tableName(); }	
-	static std::string fullyQualifiedName(){ 
-	  return std::string("MAX(")+SINCE::fullyQualifiedName()+")";
-	} 
-      };
+
       struct SINCE_GROUP {					 
 	typedef cond::Time_t type;				   
 	static constexpr size_t size = 0;
 	static std::string tableName(){ return SINCE::tableName(); }	
 	static std::string fullyQualifiedName(){ 
-	  std::string sgroupSize = boost::lexical_cast<std::string>(cond::time::SINCE_GROUP_SIZE);
-	  return "("+SINCE::fullyQualifiedName()+"/"+sgroupSize+")*"+sgroupSize;	  
+	  return "MIN("+SINCE::fullyQualifiedName()+")";	  
 	} 
+	static std::string group(){
+	  std::string sgroupSize = boost::lexical_cast<std::string>( cond::time::SINCE_GROUP_SIZE);
+	  return "CAST("+SINCE::fullyQualifiedName()+"/"+sgroupSize+" AS INT )*"+sgroupSize;
+	}
       };
-
+ 
       struct SEQUENCE_SIZE {
 	typedef unsigned int type;
 	static constexpr size_t size = 0;


### PR DESCRIPTION
A new caching algorithm for IOVs has been implemented. The IOV groups are defined with a 'GROUP BY' query based on the rounded value of the Since divided by 1000. The MIN value is considered to set the group boundaries. This caching is On with this PR.
