### PR TITLE
Made use of edm::RefCore thread-safe

### DIFF
--- a/DataFormats/Common/interface/FwdPtr.h
+++ b/DataFormats/Common/interface/FwdPtr.h
@@ -104,7 +104,9 @@ namespace edm {
 
     /// Accessor for product getter.
     EDProductGetter const* productGetter() const {
-      if (ptr_.productGetter()) return ptr_.productGetter();
+      //another thread might cause productGetter() to change its value
+      EDProductGetter const* getter = ptr_.productGetter();
+      if (getter) return getter;
       else return backPtr_.productGetter();
     }
 

--- a/DataFormats/Common/interface/FwdRef.h
+++ b/DataFormats/Common/interface/FwdRef.h
@@ -177,7 +177,9 @@ namespace edm {
 
     /// Accessor for product getter.
     EDProductGetter const* productGetter() const {
-      if ( ref_.productGetter() ) return ref_.productGetter();
+      //another thread might cause productGetter() to change its value
+      EDProductGetter const* getter = ref_.productGetter();
+      if ( getter ) return getter;
       else return backRef_.productGetter();
     }
 

--- a/DataFormats/Common/interface/Holder.h
+++ b/DataFormats/Common/interface/Holder.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/CMS_CLASS_VERSION.h"
 #include "DataFormats/Common/interface/BaseHolder.h"
 #include "DataFormats/Common/interface/RefHolder.h"
+#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <memory>
 
 namespace edm {
@@ -21,28 +22,28 @@ namespace edm {
       Holder& operator= (Holder const& rhs);
       void swap(Holder& other);
       virtual ~Holder();
-      virtual BaseHolder<T>* clone() const;
+      virtual BaseHolder<T>* clone() const GCC11_OVERRIDE;
 
-      virtual T const* getPtr() const;
-      virtual ProductID id() const;
-      virtual size_t key() const;
-      virtual bool isEqualTo(BaseHolder<T> const& rhs) const;
+      virtual T const* getPtr() const GCC11_OVERRIDE;
+      virtual ProductID id() const GCC11_OVERRIDE;
+      virtual size_t key() const GCC11_OVERRIDE;
+      virtual bool isEqualTo(BaseHolder<T> const& rhs) const GCC11_OVERRIDE;
       REF const& getRef() const;
 
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
-					  std::string& msg) const;
+					  std::string& msg) const GCC11_OVERRIDE;
 
-      virtual std::auto_ptr<RefHolderBase> holder() const {
+      virtual std::auto_ptr<RefHolderBase> holder() const GCC11_OVERRIDE {
 	return std::auto_ptr<RefHolderBase>( new RefHolder<REF>( ref_ ) );
       }
-      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const;
-      virtual EDProductGetter const* productGetter() const;
+      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const GCC11_OVERRIDE;
+      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const { return ref_.isAvailable(); }
+      virtual bool isAvailable() const GCC11_OVERRIDE { return ref_.isAvailable(); }
 
-      virtual bool isTransient() const { return ref_.isTransient(); }
+      virtual bool isTransient() const GCC11_OVERRIDE { return ref_.isTransient(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)

--- a/DataFormats/Common/interface/IndirectHolder.h
+++ b/DataFormats/Common/interface/IndirectHolder.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/BaseHolder.h"
 #include "DataFormats/Common/interface/RefHolderBase.h"
 #include "DataFormats/Provenance/interface/ProductID.h"
+#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 #include <memory>
 
@@ -37,23 +38,23 @@ namespace edm {
       void swap(IndirectHolder& other);
       virtual ~IndirectHolder();
       
-      virtual BaseHolder<T>* clone() const;
-      virtual T const* getPtr() const;
-      virtual ProductID id() const;
-      virtual size_t key() const;
-      virtual bool isEqualTo(BaseHolder<T> const& rhs) const;
+      virtual BaseHolder<T>* clone() const GCC11_OVERRIDE;
+      virtual T const* getPtr() const GCC11_OVERRIDE;
+      virtual ProductID id() const GCC11_OVERRIDE;
+      virtual size_t key() const GCC11_OVERRIDE;
+      virtual bool isEqualTo(BaseHolder<T> const& rhs) const GCC11_OVERRIDE;
 
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
-					  std::string& msg) const;
-      virtual std::auto_ptr<RefHolderBase> holder() const;
-      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const;
-      virtual EDProductGetter const* productGetter() const;
+					  std::string& msg) const GCC11_OVERRIDE;
+      virtual std::auto_ptr<RefHolderBase> holder() const GCC11_OVERRIDE;
+      virtual std::auto_ptr<BaseVectorHolder<T> > makeVectorHolder() const GCC11_OVERRIDE;
+      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const { return helper_->isAvailable(); }
+      virtual bool isAvailable() const GCC11_OVERRIDE { return helper_->isAvailable(); }
 
-      virtual bool isTransient() const { return helper_->isTransient(); }
+      virtual bool isTransient() const GCC11_OVERRIDE { return helper_->isTransient(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)

--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -4,6 +4,7 @@
 #include "DataFormats/Common/interface/BaseVectorHolder.h"
 #include "DataFormats/Common/interface/RefVectorHolderBase.h"
 #include "DataFormats/Common/interface/IndirectHolder.h"
+#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <memory>
 
 namespace edm {
@@ -25,18 +26,18 @@ namespace edm {
       virtual ~IndirectVectorHolder();
       IndirectVectorHolder& operator= (IndirectVectorHolder const& rhs);
       void swap(IndirectVectorHolder& other);
-      virtual BaseVectorHolder<T>* clone() const;
-      virtual BaseVectorHolder<T>* cloneEmpty() const;
-      virtual ProductID id() const;
-      virtual EDProductGetter const* productGetter() const;
-      virtual bool empty() const;
-      virtual size_type size() const;
-      virtual void clear();
-      virtual base_ref_type const at(size_type idx) const;
-      virtual std::auto_ptr<reftobase::RefVectorHolderBase> vectorHolder() const {
+      virtual BaseVectorHolder<T>* clone() const GCC11_OVERRIDE;
+      virtual BaseVectorHolder<T>* cloneEmpty() const GCC11_OVERRIDE;
+      virtual ProductID id() const GCC11_OVERRIDE;
+      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
+      virtual bool empty() const GCC11_OVERRIDE;
+      virtual size_type size() const GCC11_OVERRIDE;
+      virtual void clear() GCC11_OVERRIDE;
+      virtual base_ref_type const at(size_type idx) const GCC11_OVERRIDE;
+      virtual std::auto_ptr<reftobase::RefVectorHolderBase> vectorHolder() const GCC11_OVERRIDE {
 	return std::auto_ptr<reftobase::RefVectorHolderBase>( helper_->clone() );
       }
-      virtual void push_back( const BaseHolder<T> * r ) {
+      virtual void push_back( const BaseHolder<T> * r ) GCC11_OVERRIDE {
 	typedef IndirectHolder<T> holder_type;
 	const holder_type * h = dynamic_cast<const holder_type *>( r );
 	if( h == 0 )
@@ -47,7 +48,7 @@ namespace edm {
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const { return helper_->isAvailable(); }
+      virtual bool isAvailable() const GCC11_OVERRIDE { return helper_->isAvailable(); }
 
       //Used by ROOT storage
       CMS_CLASS_VERSION(10)

--- a/DataFormats/Common/interface/OneToMany.h
+++ b/DataFormats/Common/interface/OneToMany.h
@@ -48,11 +48,13 @@ namespace edm {
           Exception::throwThis(errors::InvalidReference,
 	    "can't insert transient references in uninitialized AssociationMap");
         }
-        if(ref.key.productGetter() == nullptr) {
+        //another thread might cause productGetter() to change values
+        EDProductGetter const* getter = ref.key.productGetter();
+        if(getter == nullptr) {
           Exception::throwThis(errors::LogicError,
 	    "can't insert into AssociationMap unless it was initialized with a getter or RefProd(s) or RefToBaseProd(s)");
         }
-        ref.key = KeyRefProd(k.id(), ref.key.productGetter());
+        ref.key = KeyRefProd(k.id(), getter);
         ref.val = ValRefProd(v.id(), ref.val.productGetter());
       }
       helpers::checkRef(ref.key, k); helpers::checkRef(ref.val, v);

--- a/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
+++ b/DataFormats/Common/interface/OneToManyWithQualityGeneric.h
@@ -61,11 +61,13 @@ namespace edm {
           Exception::throwThis(errors::InvalidReference,
 	    "can't insert transient references in uninitialized AssociationMap");
         }
-        if(ref.key.productGetter() == nullptr) {
+        //another thread might cause productGetter() to return a different value
+        EDProductGetter const* getter = ref.key.productGetter();
+        if(getter == nullptr) {
           Exception::throwThis(errors::LogicError,
 	    "can't insert into AssociationMap unless it was initialized with a getter or RefProd(s) or RefToBaseProd(s)");
         }
-        ref.key = KeyRefProd(k.id(), ref.key.productGetter());
+        ref.key = KeyRefProd(k.id(), getter);
         ref.val = ValRefProd(vref.id(), ref.val.productGetter());
       }
       helpers::checkRef(ref.key, k); helpers::checkRef(ref.val, vref);

--- a/DataFormats/Common/interface/OneToOneGeneric.h
+++ b/DataFormats/Common/interface/OneToOneGeneric.h
@@ -52,11 +52,13 @@ namespace edm {
           Exception::throwThis(errors::InvalidReference,
 	    "can't insert transient references in uninitialized AssociationMap");
         }
-        if(ref.key.productGetter() == nullptr) {
+        //another thread might change the value of productGetter()
+        auto getter =ref.key.productGetter();
+        if(getter == nullptr) {
           Exception::throwThis(errors::LogicError,
 	    "can't insert into AssociationMap unless it was initialized with a getter or RefProd(s) or RefToBaseProd(s)");
         }
-        ref.key = KeyRefProd(k.id(), ref.key.productGetter());
+        ref.key = KeyRefProd(k.id(), getter);
         ref.val = ValRefProd(v.id(), ref.val.productGetter());
       }
       helpers::checkRef(ref.key, k); helpers::checkRef(ref.val, v);

--- a/DataFormats/Common/interface/OneToValue.h
+++ b/DataFormats/Common/interface/OneToValue.h
@@ -45,11 +45,13 @@ namespace edm {
           Exception::throwThis(errors::InvalidReference,
             "can't insert transient references in uninitialized AssociationMap");
         }
-        if(ref.key.productGetter() == nullptr) {
+        //another thread might change the value of productGetter()
+        auto getter =ref.key.productGetter();
+        if(getter == nullptr) {
           Exception::throwThis(errors::LogicError,
             "can't insert into AssociationMap unless it was initialized with a getter or RefProd or RefToBaseProd");
         }
-        ref.key = KeyRefProd(k.id(), ref.key.productGetter());
+        ref.key = KeyRefProd(k.id(), getter);
       }
       helpers::checkRef(ref.key, k);
       index_type ik = index_type(k.key());

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -128,6 +128,11 @@ namespace edm {
           iOther.productGetter(),
           iOther.isTransient()),
     key_(iOther.key()) {
+      //make sure a race condition didn't happen where between the call to hasProductCache() and
+      // productGetter() the object was gotten
+      if(iOther.hasProductCache() and not hasProductCache()) {
+        core_.setProductPtr(static_cast<T const*>(iOther.get()) );
+      }
     }
 
     template<typename U>
@@ -180,7 +185,7 @@ namespace edm {
 
     key_type key() const {return key_;}
 
-    bool hasProductCache() const { return 0 != core_.productPtr(); }
+    bool hasProductCache() const { return nullptr != core_.productPtr(); }
 
     RefCore const& refCore() const {return core_;}
     // ---------- member functions ---------------------------
@@ -196,11 +201,12 @@ namespace edm {
     T const* getItem_(C const* product, key_type iKey);
 
     void getData_(bool throwIfNotFound = true) const {
-      if(!hasProductCache() && productGetter() != nullptr) {
-        WrapperBase const* prod = productGetter()->getIt(core_.id());
+      auto getter = productGetter();
+      if(getter != nullptr) {
+        WrapperBase const* prod = getter->getIt(core_.id());
         unsigned int iKey = key_;
         if(prod == nullptr) {
-          prod = productGetter()->getThinnedProduct(core_.id(), iKey);
+          prod = getter->getThinnedProduct(core_.id(), iKey);
           if(prod == nullptr) {
             if(throwIfNotFound) {
               core_.productNotFoundException(typeid(T));

--- a/DataFormats/Common/interface/Ptr.h
+++ b/DataFormats/Common/interface/Ptr.h
@@ -201,7 +201,7 @@ namespace edm {
     T const* getItem_(C const* product, key_type iKey);
 
     void getData_(bool throwIfNotFound = true) const {
-      auto getter = productGetter();
+      EDProductGetter const* getter = productGetter();
       if(getter != nullptr) {
         WrapperBase const* prod = getter->getIt(core_.id());
         unsigned int iKey = key_;

--- a/DataFormats/Common/interface/PtrVectorBase.h
+++ b/DataFormats/Common/interface/PtrVectorBase.h
@@ -36,8 +36,15 @@ namespace edm {
     typedef key_type size_type;
 
     explicit PtrVectorBase(ProductID const& productID, void const* prodPtr = 0,
-                           EDProductGetter const* prodGetter = 0) :
-      core_(productID, prodPtr, prodGetter, false), indicies_() {}
+                           EDProductGetter const* prodGetter = 0)
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    :
+      core_(productID, prodPtr, prodGetter, false), indicies_(), cachedItems_(nullptr) {}
+#else
+    ;
+#endif
+    
+    PtrVectorBase( const PtrVectorBase&);
 
     virtual ~PtrVectorBase();
 
@@ -58,7 +65,7 @@ namespace edm {
     /// Accessor for product getter.
     EDProductGetter const* productGetter() const {return core_.productGetter();}
 
-    bool hasCache() const { return !cachedItems_.empty(); }
+    bool hasCache() const { return cachedItems_; }
 
     /// True if the data is in memory or is available in the Event
     /// No type checking is done.
@@ -74,14 +81,20 @@ namespace edm {
     size_type capacity() const {return indicies_.capacity();}
 
     /// Clear the PtrVector
-    void clear() { core_ = RefCore(); indicies_.clear(); cachedItems_.clear(); }
-
+    void clear()
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    { core_ = RefCore(); indicies_.clear(); if(cachedItems_) { delete cachedItems_.load(); cachedItems_.store(nullptr); } }
+#else
+    ;
+#endif
+  
     bool operator==(PtrVectorBase const& iRHS) const;
     // ---------- static member functions --------------------
 
     // ---------- member functions ---------------------------
     /// Reserve space for RefVector
-    void reserve(size_type n) {indicies_.reserve(n); cachedItems_.reserve(n);}
+    void reserve(size_type n) {indicies_.reserve(n);
+      if(cachedItems_) {(*cachedItems_).reserve(n);} }
 
     void setProductGetter(EDProductGetter* iGetter) const { core_.setProductGetter(iGetter); }
 
@@ -101,24 +114,28 @@ namespace edm {
 
     std::vector<void const*>::const_iterator void_begin() const {
       getProduct_();
-      checkCachedItems();
-      return cachedItems_.begin();
+      if(not checkCachedItems()) {
+        return emptyCache().begin();
+      }
+      return (*cachedItems_).begin();
     }
     std::vector<void const*>::const_iterator void_end() const {
       getProduct_();
-      checkCachedItems();
-      return cachedItems_.end();
+      if(not checkCachedItems()) {
+        return emptyCache().end();
+      }
+      return (*cachedItems_).end();
     }
 
     template<typename TPtr>
     TPtr makePtr(unsigned long iIndex) const {
       if (isTransient()) {
-        return TPtr(reinterpret_cast<typename TPtr::value_type const*>(cachedItems_[iIndex]),
+        return TPtr(reinterpret_cast<typename TPtr::value_type const*>((*cachedItems_)[iIndex]),
                   indicies_[iIndex]);
       }
-      if (hasCache() && (cachedItems_[iIndex] != nullptr || productGetter() == nullptr)) {
+      if (hasCache() && ((*cachedItems_)[iIndex] != nullptr || productGetter() == nullptr)) {
         return TPtr(this->id(),
-                  reinterpret_cast<typename TPtr::value_type const*>(cachedItems_[iIndex]),
+                  reinterpret_cast<typename TPtr::value_type const*>((*cachedItems_)[iIndex]),
                   indicies_[iIndex]);
       }
       return TPtr(this->id(), indicies_[iIndex], productGetter());
@@ -128,14 +145,14 @@ namespace edm {
     TPtr makePtr(std::vector<void const*>::const_iterator const iIt) const {
       if (isTransient()) {
         return TPtr(reinterpret_cast<typename TPtr::value_type const*>(*iIt),
-                  indicies_[iIt - cachedItems_.begin()]);
+                  indicies_[iIt - (*cachedItems_).begin()]);
       }
       if (hasCache() && (*iIt != nullptr || productGetter() == nullptr)) {
         return TPtr(this->id(),
                   reinterpret_cast<typename TPtr::value_type const*>(*iIt),
-                  indicies_[iIt - cachedItems_.begin()]);
+                  indicies_[iIt - (*cachedItems_).begin()]);
       }
-      return TPtr(this->id(), indicies_[iIt - cachedItems_.begin()], productGetter());
+      return TPtr(this->id(), indicies_[iIt - (*cachedItems_).begin()], productGetter());
     }
 
   private:
@@ -145,13 +162,24 @@ namespace edm {
       assert(false);
       return *reinterpret_cast<const std::type_info*>(0);
     }
+    
+    //returns false if the cache is not yet set
+    bool checkCachedItems() const;
+    
+    PtrVectorBase& operator=(const PtrVectorBase&);
 
-    void checkCachedItems() const;
-
+    //Used when we need an iterator but cache is not yet set
+    static const std::vector<void const*>& emptyCache();
+    
     // ---------- member data --------------------------------
     RefCore core_;
     std::vector<key_type> indicies_;
-    mutable std::vector<void const*> cachedItems_; //! transient
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    mutable std::atomic<std::vector<void const*>*> cachedItems_; //! transient
+#else
+    mutable td::vector<void const*>* cachedItems_;               //!transient
+#endif
+
   };
 }
 

--- a/DataFormats/Common/interface/PtrVectorBase.h
+++ b/DataFormats/Common/interface/PtrVectorBase.h
@@ -177,7 +177,7 @@ namespace edm {
 #if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
     mutable std::atomic<std::vector<void const*>*> cachedItems_; //! transient
 #else
-    mutable td::vector<void const*>* cachedItems_;               //!transient
+    mutable std::vector<void const*>* cachedItems_;               //!transient
 #endif
 
   };

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -86,17 +86,21 @@ namespace edm {
     void setId(ProductID const& iId);
     void setTransient() {SETTRANSIENT_IMPL;}
     void setCacheIsProductPtr() const {SETCACHEISPRODUCTPTR_IMPL;}
-    void unsetCacheIsProductPtr() const {UNSETCACHEISPRODUCTPTR_IMPL;}
+    void setCacheIsProductGetter() const {SETCACHEISPRODUCTGETTER_IMPL;}
     bool cacheIsProductPtr() const {CACHEISPRODUCTPTR_IMPL;}
+    bool cachePtrIsInvalid() const { return 0 == (reinterpret_cast<std::uintptr_t>(cachePtr_) & refcoreimpl::kCacheIsProductPtrMask); }
 
-    
+
+    //The low bit of the address is used to determine  if the cachePtr_
+    // is storing the productPtr or the EDProductGetter. The bit is set if
+    // the address refers to the EDProductGetter.
     mutable void const* cachePtr_;               // transient
-    //The following are what is stored in a ProductID
-    // the high two bits of processIndex are used to store info on
-    // if this is transient and if the cachePtr_ is storing the productPtr
+    //The following is what is stored in a ProductID
+    // the high bit of processIndex is used to store info on
+    // if this is transient.
     //If the type or order of the member data is changes you MUST also update
     // the custom streamer in RefCoreStreamer.cc and RefCoreWithIndex
-    mutable ProcessIndex processIndex_;
+    ProcessIndex processIndex_;
     ProductIndex productIndex_;
 
   };

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -142,6 +142,7 @@ namespace edm {
     return lhs.isTransient() ? (rhs.isTransient() ? lhs.productPtr() < rhs.productPtr() : false) : (rhs.isTransient() ? true : lhs.id() < rhs.id());
   }
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   inline 
   void
   RefCore::swap(RefCore & other) {
@@ -153,6 +154,7 @@ namespace edm {
   inline void swap(edm::RefCore & lhs, edm::RefCore & rhs) {
     lhs.swap(rhs);
   }
+#endif
 }
 
 #endif

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -13,6 +13,9 @@ RefCore: The component of edm::Ref containing the product ID and product getter.
 
 #include <algorithm>
 #include <typeinfo>
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+#include <atomic>
+#endif
 
 namespace edm {
   class RefCoreWithIndex;
@@ -26,16 +29,28 @@ namespace edm {
 
     RefCore(ProductID const& theId, void const* prodPtr, EDProductGetter const* prodGetter, bool transient);
 
+    RefCore( RefCore const&);
+    
+    RefCore& operator=(RefCore const&);
+
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    RefCore( RefCore&& ) = default;
+    RefCore& operator=(RefCore&&) = default;
+#endif
+    
     ProductID id() const {ID_IMPL;}
 
     /**If productPtr is not 0 then productGetter will be 0 since only one is available at a time */
     void const* productPtr() const {PRODUCTPTR_IMPL;}
 
     void setProductPtr(void const* prodPtr) const { 
-      cachePtr_=prodPtr;
-      setCacheIsProductPtr();
+      setCacheIsProductPtr(prodPtr);
     }
 
+    bool tryToSetProductPtrForFirstTime(void const* prodPtr) const {
+      return refcoreimpl::tryToSetCacheItemForFirstTime(cachePtr_, prodPtr);
+    }
+    
     // Checks for null
     bool isNull() const {return !isNonnull(); }
 
@@ -85,16 +100,20 @@ namespace edm {
     cachePtr_(iCache), processIndex_(iProcessIndex), productIndex_(iProductIndex) {}
     void setId(ProductID const& iId);
     void setTransient() {SETTRANSIENT_IMPL;}
-    void setCacheIsProductPtr() const {SETCACHEISPRODUCTPTR_IMPL;}
-    void setCacheIsProductGetter() const {SETCACHEISPRODUCTGETTER_IMPL;}
-    bool cacheIsProductPtr() const {CACHEISPRODUCTPTR_IMPL;}
-    bool cachePtrIsInvalid() const { return 0 == (reinterpret_cast<std::uintptr_t>(cachePtr_) & refcoreimpl::kCacheIsProductPtrMask); }
-
+    void setCacheIsProductPtr(const void* iItem) const {SETCACHEISPRODUCTPTR_IMPL(iItem);}
+    void setCacheIsProductGetter(EDProductGetter const * iGetter) const {SETCACHEISPRODUCTGETTER_IMPL(iGetter);}
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    bool cachePtrIsInvalid() const { return 0 == (reinterpret_cast<std::uintptr_t>(cachePtr_.load()) & refcoreimpl::kCacheIsProductPtrMask); }
+#endif
 
     //The low bit of the address is used to determine  if the cachePtr_
     // is storing the productPtr or the EDProductGetter. The bit is set if
     // the address refers to the EDProductGetter.
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    mutable std::atomic<void const*> cachePtr_; // transient
+#else
     mutable void const* cachePtr_;               // transient
+#endif
     //The following is what is stored in a ProductID
     // the high bit of processIndex is used to store info on
     // if this is transient.
@@ -128,7 +147,7 @@ namespace edm {
   RefCore::swap(RefCore & other) {
     std::swap(processIndex_, other.processIndex_);
     std::swap(productIndex_, other.productIndex_);
-    std::swap(cachePtr_, other.cachePtr_);
+    other.cachePtr_.store(cachePtr_.exchange(other.cachePtr_.load()));
   }
 
   inline void swap(edm::RefCore & lhs, edm::RefCore & rhs) {

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -143,6 +143,7 @@ namespace edm {
 
   };
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   inline 
   void
   RefCoreWithIndex::swap(RefCoreWithIndex & other) {
@@ -151,6 +152,7 @@ namespace edm {
     other.cachePtr_.store(cachePtr_.exchange(other.cachePtr_.load()));
     std::swap(elementIndex_,other.elementIndex_);
   }
+#endif
 
   inline void swap(edm::RefCoreWithIndex & lhs, edm::RefCoreWithIndex & rhs) {
     lhs.swap(rhs);

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -21,7 +21,7 @@ RefCoreWithIndex: The component of edm::Ref containing the product ID and produc
 namespace edm {  
   class RefCoreWithIndex {
   public:
-    RefCoreWithIndex() :  cachePtr_(0),processIndex_(0),productIndex_(0),elementIndex_(edm::key_traits<unsigned int>::value) {}
+    RefCoreWithIndex() :  cachePtr_(nullptr),processIndex_(0),productIndex_(0),elementIndex_(edm::key_traits<unsigned int>::value) {}
 
     RefCoreWithIndex(ProductID const& theId, void const* prodPtr, EDProductGetter const* prodGetter, bool transient, unsigned int elementIndex);
 
@@ -105,17 +105,21 @@ namespace edm {
     }
     void setTransient() {SETTRANSIENT_IMPL;}
     void setCacheIsProductPtr() const {SETCACHEISPRODUCTPTR_IMPL;}
-    void unsetCacheIsProductPtr() const {UNSETCACHEISPRODUCTPTR_IMPL;}
+    void setCacheIsProductGetter() const {SETCACHEISPRODUCTGETTER_IMPL;}
     bool cacheIsProductPtr() const {CACHEISPRODUCTPTR_IMPL;}
 
     //NOTE: the order MUST remain the same as a RefCore
     // since we play tricks to allow a pointer to a RefCoreWithIndex
     // to be the same as a pointer to a RefCore
+
+    //The low bit of the address is used to determine  if the cachePtr_
+    // is storing the productPtr or the EDProductGetter. The bit is set if
+    // the address refers to the EDProductGetter.
     mutable void const* cachePtr_;               // transient
-    //The following are what is stored in a ProductID
-    // the high two bits of processIndex are used to store info on
-    // if this is transient and if the cachePtr_ is storing the productPtr
-    mutable ProcessIndex processIndex_;
+    //The following is what is stored in a ProductID
+    // the high bit of processIndex is used to store info on
+    // if this is transient.
+    ProcessIndex processIndex_;
     ProductIndex productIndex_;
     unsigned int elementIndex_;
 

--- a/DataFormats/Common/interface/RefHolder_.h
+++ b/DataFormats/Common/interface/RefHolder_.h
@@ -6,6 +6,7 @@
 #include "DataFormats/Provenance/interface/ProductID.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
+#include "FWCore/Utilities/interface/GCC11Compatibility.h"
 #include <memory>
 
 namespace edm {
@@ -22,28 +23,28 @@ namespace edm {
       explicit RefHolder(REF const& ref);
       void swap(RefHolder& other);
       virtual ~RefHolder();
-      virtual RefHolderBase* clone() const;
+      virtual RefHolderBase* clone() const GCC11_OVERRIDE;
 
-      virtual ProductID id() const;
-      virtual size_t key() const;
-      virtual bool isEqualTo(RefHolderBase const& rhs) const;
+      virtual ProductID id() const GCC11_OVERRIDE;
+      virtual size_t key() const GCC11_OVERRIDE;
+      virtual bool isEqualTo(RefHolderBase const& rhs) const GCC11_OVERRIDE;
       virtual bool fillRefIfMyTypeMatches(RefHolderBase& fillme,
-					  std::string& msg) const;
+					  std::string& msg) const GCC11_OVERRIDE;
       REF const& getRef() const;
       void setRef(REF const& r);
-      virtual std::auto_ptr<RefVectorHolderBase> makeVectorHolder() const;
-      virtual EDProductGetter const* productGetter() const;
+      virtual std::auto_ptr<RefVectorHolderBase> makeVectorHolder() const GCC11_OVERRIDE;
+      virtual EDProductGetter const* productGetter() const GCC11_OVERRIDE;
 
       /// Checks if product collection is in memory or available
       /// in the Event. No type checking is done.
-      virtual bool isAvailable() const { return ref_.isAvailable(); }
+      virtual bool isAvailable() const GCC11_OVERRIDE { return ref_.isAvailable(); }
 
-      virtual bool isTransient() const { return ref_.isTransient(); }
+      virtual bool isTransient() const GCC11_OVERRIDE { return ref_.isTransient(); }
 
       //Needed for ROOT storage
       CMS_CLASS_VERSION(10)
     private:
-      virtual void const* pointerToType(TypeWithDict const& iToType) const;
+      virtual void const* pointerToType(TypeWithDict const& iToType) const GCC11_OVERRIDE;
       REF ref_;
     };
 

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -133,6 +133,7 @@ namespace edm {
     return * operator->();
   }
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   /// Member dereference operator
   template<typename T>
   inline
@@ -160,6 +161,7 @@ namespace edm {
     }
     return viewPtr();
   }
+#endif
 
   template<typename T>
   inline

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -137,7 +137,9 @@ namespace edm {
   template<typename T>
   inline
   View<T> const* RefToBaseProd<T>::operator->() const {
-    if(product_.productPtr() == 0) {
+    //Another thread might change the value returned so just get it once
+    auto getter = product_.productGetter();
+    if(getter != nullptr) {
       if(product_.isNull()) {
         Exception::throwThis(errors::InvalidReference,
           "attempting get view from a null RefToBaseProd.\n");
@@ -145,13 +147,16 @@ namespace edm {
       ProductID tId = product_.id();
       std::vector<void const*> pointers;
       FillViewHelperVector helpers;
-      WrapperBase const* prod = product_.productGetter()->getIt(tId);
+      WrapperBase const* prod = getter->getIt(tId);
       if(prod == nullptr) {
         Exception::throwThis(errors::InvalidReference,
                              "attempting to get view from an unavailable RefToBaseProd.");
       }
       prod->fillView(tId, pointers, helpers);
-      product_.setProductPtr((new View<T>(pointers, helpers,product_.productGetter())));
+      std::unique_ptr<View<T>> tmp{ new View<T>(pointers, helpers, getter) };
+      if( product_.tryToSetProductPtrForFirstTime(tmp.get())) {
+        tmp.release();
+      }
     }
     return viewPtr();
   }

--- a/DataFormats/Common/interface/RefToPtr.h
+++ b/DataFormats/Common/interface/RefToPtr.h
@@ -23,8 +23,12 @@ namespace edm {
     }
     if (ref.isTransient()) {
       return Ptr<T>(ref.get(), ref.key());
-    } else if (not ref.hasProductCache()) {
-      return Ptr<T>(ref.id(), ref.key(), ref.productGetter());
+    } else {
+      //Another thread could change this value so get only once
+      EDProductGetter const* getter = ref.productGetter();
+      if (getter) {
+        return Ptr<T>(ref.id(), ref.key(), getter);
+      }
     }
     return Ptr<T>(ref.id(), ref.get(), ref.key());
   }

--- a/DataFormats/Common/interface/refcore_implementation.h
+++ b/DataFormats/Common/interface/refcore_implementation.h
@@ -21,6 +21,8 @@
 //
 
 // system include files
+#include <limits>
+#include <cstdint>
 
 // user include files
 
@@ -28,28 +30,38 @@
 namespace edm {
   namespace refcoreimpl {
     const unsigned short kTransientBit = 0x8000;
-    const unsigned short kCacheIsProductPtrBit = 0x4000;
-    const unsigned short kCacheIsProductPtrMask = 0xBFFF;
+    const std::uintptr_t kCacheIsProductPtrBit = 0x1;
+    const std::uintptr_t kCacheIsProductPtrMask = std::numeric_limits<std::uintptr_t>::max() ^ kCacheIsProductPtrBit;
     const unsigned short kProcessIndexMask = 0x3FFF;
+    
+    inline void setCacheIsProductGetter( void const * & ptr) {
+      std::uintptr_t tmp = reinterpret_cast<std::uintptr_t>(ptr); tmp |=refcoreimpl::kCacheIsProductPtrBit; ptr = reinterpret_cast<void const*>(tmp);
+    }
+
+    inline void unsetCacheIsProductGetter( void const * & ptr) {
+      std::uintptr_t tmp = reinterpret_cast<std::uintptr_t>(ptr); tmp &=refcoreimpl::kCacheIsProductPtrMask; ptr = reinterpret_cast<void const*>(tmp);
+    }
+
   }
+  
 }
 
 #define ID_IMPL return ProductID(processIndex_ & refcoreimpl::kProcessIndexMask,productIndex_)
 
-#define PRODUCTPTR_IMPL return cacheIsProductPtr()?cachePtr_:static_cast<void const*>(0)
+#define PRODUCTPTR_IMPL return cacheIsProductPtr()?cachePtr_:static_cast<void const*>(nullptr)
 
-#define ISNONNULL_IMPL return isTransient() ? productPtr() != 0 : id().isValid()
+#define ISNONNULL_IMPL return isTransient() ? productPtr() != nullptr : id().isValid()
 
-#define PRODUCTGETTER_IMPL return (!cacheIsProductPtr())? static_cast<EDProductGetter const*>(cachePtr_):static_cast<EDProductGetter const*>(0)
+#define PRODUCTGETTER_IMPL return (!cacheIsProductPtr())? reinterpret_cast<EDProductGetter const*>(reinterpret_cast<std::uintptr_t>(cachePtr_)&refcoreimpl::kCacheIsProductPtrMask):static_cast<EDProductGetter const*>(nullptr)
 
 #define ISTRANSIENT_IMPL return 0!=(processIndex_ & refcoreimpl::kTransientBit)
 
 #define SETTRANSIENT_IMPL processIndex_ |=refcoreimpl::kTransientBit
 
-#define SETCACHEISPRODUCTPTR_IMPL processIndex_ |=refcoreimpl::kCacheIsProductPtrBit
+#define SETCACHEISPRODUCTPTR_IMPL refcoreimpl::unsetCacheIsProductGetter(cachePtr_)
 
-#define UNSETCACHEISPRODUCTPTR_IMPL processIndex_ &=refcoreimpl::kCacheIsProductPtrMask
+#define SETCACHEISPRODUCTGETTER_IMPL refcoreimpl::setCacheIsProductGetter(cachePtr_)
 
-#define CACHEISPRODUCTPTR_IMPL return 0 != (processIndex_ & refcoreimpl::kCacheIsProductPtrBit)
+#define CACHEISPRODUCTPTR_IMPL return 0 == (reinterpret_cast<std::uintptr_t>(cachePtr_) & refcoreimpl::kCacheIsProductPtrBit)
 
 #endif

--- a/DataFormats/Common/src/PtrVectorBase.cc
+++ b/DataFormats/Common/src/PtrVectorBase.cc
@@ -31,10 +31,22 @@ namespace edm {
 //
 // constructor and destructor
 //
-  PtrVectorBase::PtrVectorBase() {
+  PtrVectorBase::PtrVectorBase(): cachedItems_(nullptr) {
   }
 
   PtrVectorBase::~PtrVectorBase() {
+    delete cachedItems_.load();
+  }
+
+  PtrVectorBase::PtrVectorBase( const PtrVectorBase& iOther):
+  core_(iOther.core_),
+  indicies_(iOther.indicies_),
+  cachedItems_(nullptr)
+  {
+    auto cache = iOther.cachedItems_.load();
+    if(cache) {
+      cachedItems_.store( new std::vector<void const*>(*cache));
+    }
   }
 
 //
@@ -50,20 +62,26 @@ namespace edm {
   PtrVectorBase::swap(PtrVectorBase& other) {
     core_.swap(other.core_);
     indicies_.swap(other.indicies_);
-    cachedItems_.swap(other.cachedItems_);
+    other.cachedItems_.store(cachedItems_.exchange(other.cachedItems_.load()));
   }
 
   void
   PtrVectorBase::push_back_base(RefCore const& core, key_type iKey, void const* iData) {
     core_.pushBackItem(core, false);
     //Did we already push a 'non-cached' Ptr into the container or is this a 'non-cached' Ptr?
-    if(indicies_.size() == cachedItems_.size()) {
+    if(not cachedItems_ and indicies_.empty()) {
+      cachedItems_.store( new std::vector<void const*>());
+      (*cachedItems_).reserve(indicies_.capacity());
+    }
+    auto tmpCachedItems = cachedItems_.load();
+    if(tmpCachedItems and (indicies_.size() == (*tmpCachedItems).size())) {
       if(iData) {
-        cachedItems_.push_back(iData);
+        tmpCachedItems->push_back(iData);
       } else if(key_traits<key_type>::value == iKey) {
-        cachedItems_.push_back(0);
+        tmpCachedItems->push_back(nullptr);
       } else {
-        cachedItems_.clear();
+        delete tmpCachedItems;
+        cachedItems_.store(nullptr);
       }
     }
     indicies_.push_back(iKey);
@@ -80,7 +98,8 @@ namespace edm {
       }
       getProduct_();
     }
-    for(auto ptr : cachedItems_) {
+    auto tmpCachedItems = cachedItems_.load();
+    for(auto ptr : *tmpCachedItems) {
       if(ptr == nullptr) {
         return false;
       }
@@ -99,40 +118,61 @@ namespace edm {
     if(indicies_.size() == 0) {
       return;
     }
-    if(0 == productGetter()) {
+    //NOTE: Another thread could be getting the data
+    auto tmpProductGetter = productGetter();
+    if(nullptr == tmpProductGetter) {
       throw Exception(errors::LogicError) << "Tried to get data for a PtrVector which has no EDProductGetter\n";
     }
-    WrapperBase const* product = productGetter()->getIt(id());
+    WrapperBase const* product = tmpProductGetter->getIt(id());
+
+    auto tmpCachedItems = std::make_unique<std::vector<void const*>>();
 
     if(product != nullptr) {
-      product->fillPtrVector(typeInfo(), indicies_, cachedItems_);
+      product->fillPtrVector(typeInfo(), indicies_, *tmpCachedItems);
+      
+      std::vector<void const*>* expected = nullptr;
+      if(cachedItems_.compare_exchange_strong(expected, tmpCachedItems.get())) {
+        //we were the first thread to change the value
+        tmpCachedItems.release();
+      }
+
       return;
     }
-
-    cachedItems_.resize(indicies_.size(), nullptr);
+    
+    tmpCachedItems->resize(indicies_.size(), nullptr);
 
     std::vector<unsigned int> thinnedKeys;
     thinnedKeys.assign(indicies_.begin(), indicies_.end());
     std::vector<WrapperBase const*> wrappers(indicies_.size(), nullptr);
-    productGetter()->getThinnedProducts(id(), wrappers, thinnedKeys);
+    tmpProductGetter->getThinnedProducts(id(), wrappers, thinnedKeys);
     unsigned int nWrappers = wrappers.size();
     assert(wrappers.size() == indicies_.size());
-    assert(wrappers.size() == cachedItems_.size());
+    assert(wrappers.size() == tmpCachedItems->size());
     for(unsigned k = 0; k < nWrappers; ++k) {
       if (wrappers[k] != nullptr) {
-        wrappers[k]->setPtr(typeInfo(), thinnedKeys[k], cachedItems_[k]);
+        wrappers[k]->setPtr(typeInfo(), thinnedKeys[k], (*tmpCachedItems)[k]);
+      }
+    }
+    {
+      std::vector<void const*>* expected = nullptr;
+      if(cachedItems_.compare_exchange_strong(expected, tmpCachedItems.get())) {
+        //we were the first thread to change the value
+        tmpCachedItems.release();
       }
     }
   }
 
-  void
+  bool
   PtrVectorBase::checkCachedItems() const {
-    for(auto item : cachedItems_) {
+    auto tmp = cachedItems_.load();
+    if(not tmp) { return false;}
+    for(auto item : *tmp) {
       if(item == nullptr) {
         throw Exception(errors::InvalidReference) << "Asked for data from a PtrVector which refers to a non-existent product with ProductID "
                                                   << id() << "\n";
       }
     }
+    return true;
   }
 
   bool
@@ -151,4 +191,11 @@ namespace edm {
 //
 // static member functions
 //
+
+  static const std::vector<void const*> s_emptyCache{};
+  
+  const std::vector<void const*>& PtrVectorBase::emptyCache() {
+    return s_emptyCache;
+  }
+  
 }

--- a/DataFormats/Common/src/RefCore.cc
+++ b/DataFormats/Common/src/RefCore.cc
@@ -32,7 +32,7 @@ void throwInvalidRefFromNoCache(const edm::TypeID& id, edm::ProductID const& pro
 namespace edm {
 
   RefCore::RefCore(ProductID const& theId, void const* prodPtr, EDProductGetter const* prodGetter, bool transient) :
-      cachePtr_(prodPtr?prodPtr:prodGetter),
+      cachePtr_(prodPtr),
       processIndex_(theId.processIndex()),
       productIndex_(theId.productIndex())
       {
@@ -40,9 +40,21 @@ namespace edm {
           setTransient();
         }
         if(prodPtr==nullptr && prodGetter!=nullptr) {
-          setCacheIsProductGetter();
+          setCacheIsProductGetter(prodGetter);
         }
       }
+  
+  RefCore::RefCore( RefCore const& iOther) :
+      cachePtr_(iOther.cachePtr_.load()),
+      processIndex_(iOther.processIndex_),
+      productIndex_(iOther.productIndex_) {}
+  
+  RefCore& RefCore::operator=( RefCore const& iOther) {
+    cachePtr_ = iOther.cachePtr_.load();
+    processIndex_ = iOther.processIndex_;
+    productIndex_ = iOther.productIndex_;
+    return *this;
+  }
 
   WrapperBase const*
   RefCore::getProductPtr(std::type_info const& type) const {
@@ -159,8 +171,7 @@ namespace edm {
 
   void
   RefCore::setProductGetter(EDProductGetter const* prodGetter) const {
-    cachePtr_ = prodGetter;
-    setCacheIsProductGetter();
+    setCacheIsProductGetter(prodGetter);
   }
   
   void 
@@ -211,10 +222,13 @@ namespace edm {
     //Since productPtr and productGetter actually share the same pointer internally,
     // we want to be sure that if the productPtr is set we use that one and only if
     // it isn't set do we set the productGetter if available
-    if (productPtr() == 0 && productToBeInserted.productPtr() != 0) {
+    if (productPtr() == nullptr && productToBeInserted.productPtr() != nullptr) {
       setProductPtr(productToBeInserted.productPtr());
-    } else if (productPtr() == 0 && productGetter() == 0 && productToBeInserted.productGetter() != 0) {
-      setProductGetter(productToBeInserted.productGetter());
+    } else {
+      auto getter = productToBeInserted.productGetter();
+      if (cachePtrIsInvalid() && getter != nullptr) {
+        setProductGetter(getter);
+      }
     }
   }
 

--- a/DataFormats/Common/src/RefCore.cc
+++ b/DataFormats/Common/src/RefCore.cc
@@ -39,8 +39,8 @@ namespace edm {
         if(transient) {
           setTransient();
         }
-        if(prodPtr!=0 || prodGetter==0) {
-          setCacheIsProductPtr();
+        if(prodPtr==nullptr && prodGetter!=nullptr) {
+          setCacheIsProductGetter();
         }
       }
 
@@ -67,7 +67,7 @@ namespace edm {
     }
 
     //if (productPtr() == 0 && productGetter() == 0) {
-    if (cachePtr_ == 0) {
+    if (cachePtrIsInvalid()) {
       throwInvalidRefFromNoCache(TypeID(type),tId);
     }
     WrapperBase const* product = productGetter()->getIt(tId);
@@ -88,7 +88,7 @@ namespace edm {
       throwInvalidRefFromNullOrInvalidRef(TypeID(type));
     }
 
-    if (cachePtr_ == 0) {
+    if (cachePtrIsInvalid()) {
       throwInvalidRefFromNoCache(TypeID(type),tId);
     }
     WrapperBase const* product = productGetter()->getIt(tId);
@@ -160,7 +160,7 @@ namespace edm {
   void
   RefCore::setProductGetter(EDProductGetter const* prodGetter) const {
     cachePtr_ = prodGetter;
-    unsetCacheIsProductPtr();
+    setCacheIsProductGetter();
   }
   
   void 

--- a/DataFormats/Common/src/RefCoreWithIndex.cc
+++ b/DataFormats/Common/src/RefCoreWithIndex.cc
@@ -9,7 +9,7 @@
 namespace edm {
 
   RefCoreWithIndex::RefCoreWithIndex(ProductID const& theId, void const* prodPtr, EDProductGetter const* prodGetter, bool transient, unsigned int iIndex) :
-      cachePtr_(prodPtr?prodPtr:prodGetter),
+      cachePtr_(prodPtr),
       processIndex_(theId.processIndex()),
       productIndex_(theId.productIndex()),
       elementIndex_(iIndex)
@@ -18,14 +18,29 @@ namespace edm {
           setTransient();
         }
         if(prodPtr==nullptr && prodGetter!=nullptr) {
-          setCacheIsProductGetter();
+          setCacheIsProductGetter(prodGetter);
         }
       }
 
   RefCoreWithIndex::RefCoreWithIndex(RefCore const& iCore, unsigned int iIndex):
-  cachePtr_(iCore.cachePtr_),
+  cachePtr_(iCore.cachePtr_.load()),
   processIndex_(iCore.processIndex_),
   productIndex_(iCore.productIndex_),
   elementIndex_(iIndex){}
   
+  RefCoreWithIndex::RefCoreWithIndex( RefCoreWithIndex const& iOther) :
+    cachePtr_(iOther.cachePtr_.load()),
+    processIndex_(iOther.processIndex_),
+    productIndex_(iOther.productIndex_),
+    elementIndex_(iOther.elementIndex_){}
+  
+  RefCoreWithIndex& RefCoreWithIndex::operator=( RefCoreWithIndex const& iOther) {
+    cachePtr_ = iOther.cachePtr_.load();
+    processIndex_ = iOther.processIndex_;
+    productIndex_ = iOther.productIndex_;
+    elementIndex_ = iOther.elementIndex_;
+    return *this;
+  }
+
 }
+

--- a/DataFormats/Common/src/RefCoreWithIndex.cc
+++ b/DataFormats/Common/src/RefCoreWithIndex.cc
@@ -17,8 +17,8 @@ namespace edm {
         if(transient) {
           setTransient();
         }
-        if(prodPtr!=0 || prodGetter==0) {
-          setCacheIsProductPtr();
+        if(prodPtr==nullptr && prodGetter!=nullptr) {
+          setCacheIsProductGetter();
         }
       }
 

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -13,18 +13,6 @@
   <version ClassVersion="11" checksum="3425324092"/>
    <field name="cachePtr_" transient = "true"/>
  </class>
- <!-- The std::*atomic* dictionaries are only needed to work around a temporary bug in ROOT-->
- <class name="std::atomic<const void*>"/>
- <class name="std::__atomic_base<const void*>">
-  <field name="_M_p" transient = "true"/>
- </class>
- <class name="const void*"/>
- <class name="std::atomic<std::vector<const void*>*>"/>
- <class name="std::__atomic_base<std::vector<const void*>*>">
-   <field name="_M_p" transient = "true"/>
- </class>
- <class name="std::vector<const void*>*"/>
- <!-- end fix -->
  <ioread sourceClass = "edm::RefCore" version="[1-]" targetClass="edm::RefCore" source="" target="cachePtr_">
    <![CDATA[
      edm::EDProductGetter const* getter;

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -13,10 +13,23 @@
   <version ClassVersion="11" checksum="3425324092"/>
    <field name="cachePtr_" transient = "true"/>
  </class>
+ <!-- The std::*atomic* dictionaries are only needed to work around a temporary bug in ROOT-->
+ <class name="std::atomic<const void*>"/>
+ <class name="std::__atomic_base<const void*>">
+  <field name="_M_p" transient = "true"/>
+ </class>
+ <class name="const void*"/>
+ <class name="std::atomic<std::vector<const void*>*>"/>
+ <class name="std::__atomic_base<std::vector<const void*>*>">
+   <field name="_M_p" transient = "true"/>
+ </class>
+ <class name="std::vector<const void*>*"/>
+ <!-- end fix -->
  <ioread sourceClass = "edm::RefCore" version="[1-]" targetClass="edm::RefCore" source="" target="cachePtr_">
    <![CDATA[
-     edm::EDProductGetter::assignEDProductGetter(reinterpret_cast<edm::EDProductGetter const*&>(cachePtr_));
-     edm::refcoreimpl::setCacheIsProductGetter(cachePtr_);
+     edm::EDProductGetter const* getter;
+     edm::EDProductGetter::assignEDProductGetter(getter);
+     edm::refcoreimpl::setCacheIsProductGetter(cachePtr_, getter);
       ]]>
  </ioread>
   <class name="edm::RefCoreWithIndex" ClassVersion="11">
@@ -25,8 +38,9 @@
   </class>
   <ioread sourceClass = "edm::RefCoreWithIndex" version="[1-]" targetClass="edm::RefCoreWithIndex" source="" target="cachePtr_">
     <![CDATA[
-      edm::EDProductGetter::assignEDProductGetter(reinterpret_cast<edm::EDProductGetter const*&>(cachePtr_));
-      edm::refcoreimpl::setCacheIsProductGetter(cachePtr_);
+      edm::EDProductGetter const* getter;
+      edm::EDProductGetter::assignEDProductGetter(getter);
+      edm::refcoreimpl::setCacheIsProductGetter(cachePtr_, getter);
     ]]>
   </ioread>
  <class name="edm::ThinnedAssociation" ClassVersion="10">
@@ -85,7 +99,7 @@
  </class>
   <!-- -->
   <ioread sourceClass = "edm::PtrVectorBase" version="[1-]" targetClass="edm::PtrVectorBase" source = "" target="cachedItems_">
-    <![CDATA[cachedItems_.clear();
+    <![CDATA[delete cachedItems_.load(); cachedItems_=nullptr;
     ]]>
   </ioread>
    <!-- -->

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -87,7 +87,7 @@
  </class>
   <!-- -->
   <ioread sourceClass = "edm::PtrVectorBase" version="[1-]" targetClass="edm::PtrVectorBase" source = "" target="cachedItems_">
-    <![CDATA[delete cachedItems_.load(); cachedItems_=nullptr;
+    <![CDATA[delete &(*cachedItems_); cachedItems_=nullptr;
     ]]>
   </ioread>
    <!-- -->

--- a/DataFormats/Common/src/classes_def.xml
+++ b/DataFormats/Common/src/classes_def.xml
@@ -16,6 +16,7 @@
  <ioread sourceClass = "edm::RefCore" version="[1-]" targetClass="edm::RefCore" source="" target="cachePtr_">
    <![CDATA[
      edm::EDProductGetter::assignEDProductGetter(reinterpret_cast<edm::EDProductGetter const*&>(cachePtr_));
+     edm::refcoreimpl::setCacheIsProductGetter(cachePtr_);
       ]]>
  </ioread>
   <class name="edm::RefCoreWithIndex" ClassVersion="11">
@@ -25,6 +26,7 @@
   <ioread sourceClass = "edm::RefCoreWithIndex" version="[1-]" targetClass="edm::RefCoreWithIndex" source="" target="cachePtr_">
     <![CDATA[
       edm::EDProductGetter::assignEDProductGetter(reinterpret_cast<edm::EDProductGetter const*&>(cachePtr_));
+      edm::refcoreimpl::setCacheIsProductGetter(cachePtr_);
     ]]>
   </ioread>
  <class name="edm::ThinnedAssociation" ClassVersion="10">

--- a/DataFormats/TrackReco/interface/TrackExtraBase.h
+++ b/DataFormats/TrackReco/interface/TrackExtraBase.h
@@ -52,12 +52,15 @@ public:
 
     /// get a ref to i-th recHit
     TrackingRecHitRef recHitRef(unsigned int i) const {
-      if(m_hitCollection.productPtr()) {
+      //Another thread might change the RefCore at the same time.
+      // By using a copy we will be safe.
+      edm::RefCore hitCollection( m_hitCollection);
+      if(hitCollection.productPtr()) {
         TrackingRecHitRef::finder_type finder;
-        TrackingRecHitRef::value_type const* item = finder(*(static_cast<TrackingRecHitRef::product_type const*>(m_hitCollection.productPtr())), m_firstHit+i);
-        return TrackingRecHitRef(m_hitCollection.id(), item, m_firstHit+i);
+        TrackingRecHitRef::value_type const* item = finder(*(static_cast<TrackingRecHitRef::product_type const*>(hitCollection.productPtr())), m_firstHit+i);
+        return TrackingRecHitRef(hitCollection.id(), item, m_firstHit+i);
       }
-      return TrackingRecHitRef(m_hitCollection,m_firstHit+i);
+      return TrackingRecHitRef(hitCollection,m_firstHit+i);
     }
 
     /// get i-th recHit


### PR DESCRIPTION
The internal caching done by an edm::RefCore is now thread safe. All uses of edm::RefCore were also changed to be thread-safe.
