### PR TITLE
Fix switch to ak8GenJetsNoNu in miniaod

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
@@ -10,7 +10,7 @@ slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
 
 
 slimmedGenJetsAK8 = cms.EDProducer("PATGenJetSlimmer",
-    src = cms.InputTag("ak8GenJets"),
+    src = cms.InputTag("ak8GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
     cut = cms.string("pt > 150"),
     clearDaughters = cms.bool(False), #False means rekeying


### PR DESCRIPTION
In the previous PR #8241 where MiniAOD GenJets were switched to NoNu, AK8GenJetsNoNu were forgotten.
