### PR TITLE
Added selection of IOV sequence snapshot

### DIFF
--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -75,6 +75,9 @@ namespace cond {
       // full=true load the full iovSequence 
       void load( const std::string& tag, bool full=false );
       
+      // loads in memory the tag information and the iov groups
+      void load( const std::string& tag, const boost::posix_time::ptime& snapshottime, bool full=false );
+
       // reset the data in memory and execute again the queries for the current tag 
       void reload();
       

--- a/CondCore/CondDB/interface/PayloadProxy.h
+++ b/CondCore/CondDB/interface/PayloadProxy.h
@@ -28,6 +28,8 @@ namespace cond {
       void setUp( Session dbSession );
       
       void loadTag( const std::string& tag );
+
+      void loadTag( const std::string& tag, const boost::posix_time::ptime& snapshotTime );
       
       void reload();
       

--- a/CondCore/CondDB/interface/Session.h
+++ b/CondCore/CondDB/interface/Session.h
@@ -86,10 +86,14 @@ namespace cond {
       void createDatabase();
       
       // read access to the iov sequence. 
-      // by default ( full=false ) the iovs are lazy-loaded in groups when required, with repeatable queries ( for FronTier )
-      // full=true will load the entire sequence in memory. Mainly for test/debugging.
+      // the iovs are lazy-loaded in groups when required, with repeatable queries ( for FronTier )
+      IOVProxy readIov( const std::string& tag, bool full=false );
+
+      // read access to the iov sequence. 
+      // the iovs are lazy-loaded in groups when required, with repeatable queries ( for FronTier )
       IOVProxy readIov( const std::string& tag, 
-			bool full=false );//,const boost::posix_time::ptime& snapshottime )  
+			const boost::posix_time::ptime& snapshottime,
+			bool full=false );  
       
       // 
       bool existsIov( const std::string& tag );

--- a/CondCore/CondDB/interface/Time.h
+++ b/CondCore/CondDB/interface/Time.h
@@ -19,6 +19,8 @@ namespace cond {
     const Time_t MAX_VAL(std::numeric_limits<Time_t>::max());
 
     const Time_t MIN_VAL(0);
+
+    static constexpr const char* const MAX_TIMESTAMP = "9999-12-31 23:59:59.000";
   
     typedef cond::UnpackedTime UnpackedTime;
 

--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -98,6 +98,14 @@ namespace cond {
     std::string execmessage;
   };
 
+  struct GTMetadata_t {
+    Time_t validity;
+    std::string description;
+    std::string release;
+    boost::posix_time::ptime insertionTime;
+    boost::posix_time::ptime snapshotTime;
+  };
+
   class GTEntry_t {
   public: 
     GTEntry_t():

--- a/CondCore/CondDB/interface/Utils.h
+++ b/CondCore/CondDB/interface/Utils.h
@@ -84,7 +84,7 @@ namespace cond {
     inline std::string convertoToOracleConnection(const std::string & input){
 
       // leave the connection string unmodified for sqlite
-      if( input.find("sqlite") == 0 ) return input;
+      if( input.find("sqlite") == 0 || input.find("oracle") == 0) return input;
 
       //static const boost::regex trivial("oracle://(cms_orcon_adg|cms_orcoff_prep)/([_[:alnum:]]+?)");
       static const boost::regex short_frontier("frontier://([[:alnum:]]+?)/([_[:alnum:]]+?)");

--- a/CondCore/CondDB/python/CondDB_cfi.py
+++ b/CondCore/CondDB/python/CondDB_cfi.py
@@ -6,7 +6,8 @@ CondDB = cms.PSet(
         authenticationSystem = cms.untracked.int32(0),
         messageLevel = cms.untracked.int32(0),
     ),
-    connect = cms.string(''), ##db/schema"
+    connect = cms.string(''), 
+    snapshotTime = cms.string(''),
     dbFormat = cms.untracked.int32(0)
 )
 

--- a/CondCore/CondDB/src/IDbSchema.h
+++ b/CondCore/CondDB/src/IDbSchema.h
@@ -54,7 +54,10 @@ namespace cond {
 					    const boost::posix_time::ptime& snapshotTime, 
 					    std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs) = 0;
       virtual size_t selectLatest( const std::string& tag, std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs) = 0;
+      virtual size_t selectSnapshot( const std::string& tag, const boost::posix_time::ptime& snapshotTime,
+                                     std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs) = 0;
       virtual bool getLastIov( const std::string& tag, cond::Time_t& since, cond::Hash& hash ) = 0;
+      virtual bool getSnapshotLastIov( const std::string& tag, const boost::posix_time::ptime& snapshotTime, cond::Time_t& since, cond::Hash& hash ) = 0;
       virtual bool getSize( const std::string& tag, size_t& size ) = 0;
       virtual bool getSnapshotSize( const std::string& tag, const boost::posix_time::ptime& snapshotTime, size_t& size ) = 0;
       virtual void insertOne( const std::string& tag, cond::Time_t since, cond::Hash payloadHash, 

--- a/CondCore/CondDB/src/IOVSchema.h
+++ b/CondCore/CondDB/src/IOVSchema.h
@@ -120,7 +120,11 @@ namespace cond {
 				      const boost::posix_time::ptime& snapshotTime, 
 				      std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs);
 	size_t selectLatest( const std::string& tag, std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs);
+	size_t selectSnapshot( const std::string& tag,
+                               const boost::posix_time::ptime& snapshotTime,
+                               std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs);
 	bool getLastIov( const std::string& tag, cond::Time_t& since, cond::Hash& hash );
+	bool getSnapshotLastIov( const std::string& tag, const boost::posix_time::ptime& snapshotTime, cond::Time_t& since, cond::Hash& hash );
 	bool getSize( const std::string& tag, size_t& size );
         bool getSnapshotSize( const std::string& tag, const boost::posix_time::ptime& snapshotTime, size_t& size );
 	void insertOne( const std::string& tag, cond::Time_t since, cond::Hash payloadHash, const boost::posix_time::ptime& insertTime);

--- a/CondCore/CondDB/src/OraDbSchema.cc
+++ b/CondCore/CondDB/src/OraDbSchema.cc
@@ -210,12 +210,24 @@ namespace cond {
       return ret;      
     }
 
-    bool OraIOVTable::getLastIov( const std::string& tag, cond::Time_t& since, cond::Hash& hash ){
+    size_t OraIOVTable::selectSnapshot( const std::string& tag, const boost::posix_time::ptime&, 
+					std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs){
+      // no (easy) way to do it...                                                                                                                                  
+      return selectLatest( tag, iovs );
+    }
+
+     bool OraIOVTable::getLastIov( const std::string& tag, cond::Time_t& since, cond::Hash& hash ){
       if(!m_cache.load( tag ) || m_cache.iovSequence().size()==0 ) return false;
       cond::IOVElementProxy last = *(--m_cache.iovSequence().end());
       since = last.since();
       hash = last.token();
       return true;
+    }
+
+    bool OraIOVTable::getSnapshotLastIov( const std::string& tag, const boost::posix_time::ptime&, 
+				  cond::Time_t& since, cond::Hash& hash ){
+      // no (easy) way to do it...                                                                                                                                  
+      return getLastIov( tag, since, hash );
     }
 
     bool OraIOVTable::getSize( const std::string& tag, size_t& size ){

--- a/CondCore/CondDB/src/OraDbSchema.h
+++ b/CondCore/CondDB/src/OraDbSchema.h
@@ -100,7 +100,9 @@ namespace cond {
 				    const boost::posix_time::ptime& snapshotTime, 
 				    std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs);
       size_t selectLatest( const std::string& tag, std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs);
+      size_t selectSnapshot( const std::string& tag, const boost::posix_time::ptime& snapshotTime, std::vector<std::tuple<cond::Time_t,cond::Hash> >& iovs);
       bool getLastIov( const std::string& tag, cond::Time_t& since, cond::Hash& hash );
+      bool getSnapshotLastIov( const std::string& tag, const boost::posix_time::ptime& snapshotTime, cond::Time_t& since, cond::Hash& hash );
       bool getSize( const std::string& tag, size_t& size );
       bool getSnapshotSize( const std::string& tag, const boost::posix_time::ptime& snapshotTime, size_t& size );
       void insertOne( const std::string& tag, cond::Time_t since, cond::Hash payloadHash, 

--- a/CondCore/CondDB/src/PayloadProxy.cc
+++ b/CondCore/CondDB/src/PayloadProxy.cc
@@ -22,9 +22,16 @@ namespace cond {
       invalidateCache();
     }
     
+    void BasePayloadProxy::loadTag( const std::string& tag, const boost::posix_time::ptime& snapshotTime ){
+      m_session.transaction().start(true);
+      m_iovProxy = m_session.readIov( tag, snapshotTime );
+      m_session.transaction().commit();
+      invalidateCache();
+    }
+
     void BasePayloadProxy::reload(){
       std::string tag = m_iovProxy.tag();
-      if( !tag.empty() ) loadTag( tag );
+      if( !tag.empty() ) m_iovProxy.reload();
     }
     
     ValidityInterval BasePayloadProxy::setIntervalFor(cond::Time_t time, bool load) {

--- a/CondCore/CondDB/src/Session.cc
+++ b/CondCore/CondDB/src/Session.cc
@@ -85,6 +85,15 @@ namespace cond {
       return proxy;
     }
 
+    IOVProxy  Session::readIov( const std::string& tag,
+                                const boost::posix_time::ptime& snapshottime,
+                                bool full ){
+      m_session->openIovDb();
+      IOVProxy proxy( m_session );
+      proxy.load( tag, snapshottime, full );
+      return proxy;
+    }
+
     bool Session::existsIov( const std::string& tag ){
       m_session->openIovDb();
       return m_session->iovSchema().tagTable().select( tag );

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -9,6 +9,8 @@
 <bin   file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">
   <lib   name="testCondDBDict"/>
 </bin>
+<bin   file="testConditionDatabase_1.cpp" name="testConditionDatabase_1">
+</bin>
 <bin   file="testRootStreaming.cpp" name="testRootStreaming">
   <lib   name="testCondDBDict"/>
 </bin>

--- a/CondCore/CondDB/test/testConditionDatabase_0.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_0.cpp
@@ -126,7 +126,7 @@ int main (int argc, char** argv)
   int ret = 0;
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
-  std::string connectionString0("sqlite_file:cms_conditions.db");
+  std::string connectionString0("sqlite_file:cms_conditions_0.db");
   std::cout <<"## Running with CondDBV2 format..."<<std::endl;
   ret = run( connectionString0 );
   if( ret<0 ) return ret;

--- a/CondCore/CondDB/test/testConditionDatabase_1.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_1.cpp
@@ -121,7 +121,7 @@ int main (int argc, char** argv)
   int ret = 0;
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
-  std::string connectionString0("sqlite_file:cms_conditions.db");
+  std::string connectionString0("sqlite_file:cms_conditions_1.db");
   ret = run( connectionString0 );
   return ret;
 }

--- a/CondCore/CondDB/test/testConditionDatabase_1.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_1.cpp
@@ -1,0 +1,128 @@
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+//
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+//
+#include <fstream>
+#include <iomanip>
+#include <cstdlib>
+#include <iostream>
+
+using namespace cond::persistency;
+
+void readTag( const std::string& tag, Session& session, const boost::posix_time::ptime& snapshotTime ){
+  IOVProxy proxy;
+  if( snapshotTime.is_not_a_date_time() ) proxy = session.readIov( tag );
+  else proxy = session.readIov( tag, snapshotTime );
+  std::cout <<"> iov loaded size="<<proxy.loadedSize()<<std::endl;
+  std::cout <<"> iov sequence size="<<proxy.sequenceSize()<<std::endl;
+  IOVProxy::Iterator iovIt = proxy.find( 107 );
+  if( iovIt == proxy.end() ){
+    std::cout <<">[0] not found!"<<std::endl;
+  } else {
+    cond::Iov_t val = *iovIt;
+    std::cout <<"#[0] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+    boost::shared_ptr<std::string> pay0 = session.fetchPayload<std::string>( val.payloadId );
+    std::cout <<"#[0] payload="<<*pay0<<std::endl;
+  }
+  iovIt = proxy.find( 235 );
+  if( iovIt == proxy.end() ){
+    std::cout <<">[1] not found!"<<std::endl;
+  } else {
+    cond::Iov_t val = *iovIt;
+    std::cout <<"#[1] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+    boost::shared_ptr<std::string> pay0 = session.fetchPayload<std::string>( val.payloadId );
+    std::cout <<"#[1] payload="<<*pay0<<std::endl;
+  }
+}
+
+int run( const std::string& connectionString ){
+  try{
+
+    //*************
+    std::cout <<"> Connecting with db in "<<connectionString<<std::endl;
+    ConnectionPool connPool;
+    connPool.setMessageVerbosity( coral::Debug );
+    Session session = connPool.createSession( connectionString, true, cond::COND_DB );
+    session.transaction().start( false );
+    std::string pay0("Payload #0");
+    std::string pay1("Payload #1");
+    std::string pay2("Payload #2");
+    std::string pay3("Payload #3");
+    std::string pay4("Payload #4");
+    std::string pay5("Payload #5");
+    auto p0 = session.storePayload( pay0 );
+    auto p1 = session.storePayload( pay1 );
+    auto p2 = session.storePayload( pay2 );
+
+    IOVEditor editor;
+    if( !session.existsIov( "MyTag" ) ){
+      editor = session.createIov<std::string>( "MyTag", cond::runnumber ); 
+      editor.setDescription("Test for timestamp selection");
+      editor.insert( 1, p0 );
+      editor.insert( 101, p1 );
+      editor.insert( 201, p2 );
+      std::cout <<"> inserted 3 iovs..."<<std::endl;
+      editor.flush();
+      std::cout <<"> iov changes flushed..."<<std::endl;
+    }
+    session.transaction().commit();
+    boost::posix_time::ptime snap0 = boost::posix_time::microsec_clock::universal_time();
+    std::cout <<"> iov changes committed!..."<<std::endl;
+    ::sleep(2);
+    boost::posix_time::ptime notime;
+    session.transaction().start();
+    readTag( "MyTag", session, notime );
+    session.transaction().commit();
+    session.transaction().start( false );
+    auto p3 = session.storePayload( pay3 );
+    auto p4 = session.storePayload( pay4 );
+    auto p5 = session.storePayload( pay5 );
+    editor = session.editIov( "MyTag" );
+    editor.insert( 101, p3 );
+    editor.insert( 222, p4 );
+    editor.flush();
+    session.transaction().commit();
+    boost::posix_time::ptime snap1 = boost::posix_time::microsec_clock::universal_time();
+    ::sleep(2);
+    session.transaction().start();
+    readTag( "MyTag", session, notime );
+    session.transaction().commit();
+    session.transaction().start( false );
+    editor = session.editIov( "MyTag" );
+    editor.insert( 102, p5 );
+    editor.flush();
+    session.transaction().commit();
+    session.transaction().start();
+    readTag( "MyTag", session, notime );
+    session.transaction().commit();
+    session.transaction().start();
+    readTag( "MyTag", session, snap0 );
+    session.transaction().commit();
+    session.transaction().start();
+    readTag( "MyTag", session, snap1 );
+    session.transaction().commit();
+  } catch (const std::exception& e){
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return -1;
+  } catch (...){
+    std::cout << "UNEXPECTED FAILURE." << std::endl;
+    return -1;
+  }
+  std::cout <<"## Run successfully completed."<<std::endl;
+  return 0;
+}
+
+int main (int argc, char** argv)
+{
+  int ret = 0;
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+  std::string connectionString0("sqlite_file:cms_conditions.db");
+  ret = run( connectionString0 );
+  return ret;
+}
+

--- a/CondCore/ESSources/interface/DataProxy.h
+++ b/CondCore/ESSources/interface/DataProxy.h
@@ -76,7 +76,7 @@ namespace cond {
     DataProxyWrapperBase();
     explicit DataProxyWrapperBase(std::string const & il);
     // late initialize (to allow to load ALL library first)
-    virtual void lateInit(cond::persistency::Session& session, const std::string & tag,
+    virtual void lateInit(cond::persistency::Session& session, const std::string & tag, const boost::posix_time::ptime& snapshotTime,
 			  std::string const & il, std::string const & cs)=0;
 
     void addInfo(std::string const & il, std::string const & cs, std::string const & tag);
@@ -127,11 +127,11 @@ public:
   }
 
   // late initialize (to allow to load ALL library first)
-  virtual void lateInit(cond::persistency::Session& session, const std::string & tag,
+  virtual void lateInit(cond::persistency::Session& session, const std::string & tag, const boost::posix_time::ptime& snapshotTime,
 			std::string const & il, std::string const & cs) {
     m_proxy.reset(new PayProxy(m_source.empty() ?  (const char *)(0) : m_source.c_str() ) );
     m_proxy->setUp( session );
-    m_proxy->loadTag( tag);
+    m_proxy->loadTag( tag, snapshotTime );
     m_edmProxy.reset(new DataProxy(m_proxy));
     addInfo(il, cs, tag);
   }

--- a/CondCore/ESSources/plugins/CondDBESSource.h
+++ b/CondCore/ESSources/plugins/CondDBESSource.h
@@ -94,12 +94,14 @@ class CondDBESSource : public edm::eventsetup::DataProxyProvider,
                                const std::string & prefix,
                                const std::string & postfix,
                                const std::string & roottag,
-                               std::set< cond::GTEntry_t > & tagcoll);
+                               std::set< cond::GTEntry_t > & tagcoll,
+			       cond::GTMetadata_t& gtMetadata);
 
   void fillTagCollectionFromDB( const std::vector<std::string> & connectionStringList,
                                 const std::vector<std::string> & prefixList,
                                 const std::vector<std::string> & postfixList,
                                 const std::vector<std::string> & roottagList,
-                                std::map<std::string,cond::GTEntry_t>& replacement);
+                                std::map<std::string,cond::GTEntry_t>& replacement,
+				cond::GTMetadata_t& gtMetadata);
 };
 #endif

--- a/CondCore/ESSources/python/PoolDBESSource_cfi.py
+++ b/CondCore/ESSources/python/PoolDBESSource_cfi.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-from CondCore.DBCommon.CondDBSetup_cfi import *
+from CondCore.CondDB.CondDB_cfi import *
 
 GlobalTag = cms.ESSource("PoolDBESSource",
     CondDBSetup,
@@ -8,8 +8,8 @@ GlobalTag = cms.ESSource("PoolDBESSource",
     RefreshOpenIOVs  = cms.untracked.bool(False),
     RefreshEachRun   = cms.untracked.bool(False),
     ReconnectEachRun = cms.untracked.bool(False),
-    connect = cms.string('frontier://FrontierProd/CMS_COND_31X_GLOBALTAG'),
-    globaltag = cms.string('UNSPECIFIED::All'),
-    toGet = cms.VPSet( ),   # hook to override or add single payloads
-    BlobStreamerName = cms.untracked.string('TBufferBlobStreamingService')
+    snapshotTime = cms.string(''),
+    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
+    globaltag = cms.string(''),
+    toGet = cms.VPSet( )   # hook to override or add single payloads
 )

--- a/CondCore/ESSources/test/python/loadall_from_gt_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_gt_cfg.py
@@ -7,7 +7,7 @@ options.register('runNumber',
                  VarParsing.VarParsing.varType.int,
                  "Run number; default gives latest IOV")
 options.register('globalTag',
-                 'GR_P_V32', #default value
+                 'GR_P_V50', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "GlobalTag")
@@ -18,25 +18,20 @@ import FWCore.ParameterSet.Config as cms
 
 process = cms.Process("TEST")
 
-process.add_(cms.Service("PrintEventSetupDataRetrieval", printProviders=cms.untracked.bool(True)))
+#process.add_(cms.Service("PrintEventSetupDataRetrieval", printProviders=cms.untracked.bool(True)))
 
-CondDBSetup = cms.PSet( DBParameters = cms.PSet(authenticationPath = cms.untracked.string('.'),
-                                                connectionRetrialPeriod = cms.untracked.int32(10),
-                                                idleConnectionCleanupPeriod = cms.untracked.int32(10),
-                                                messageLevel = cms.untracked.int32(0),
-                                                enablePoolAutomaticCleanUp = cms.untracked.bool(False),
-                                                enableConnectionSharing = cms.untracked.bool(True),
-                                                connectionRetrialTimeOut = cms.untracked.int32(60),
-                                                connectionTimeOut = cms.untracked.int32(0),
-                                                enableReadOnlySessionOnUpdateConnection = cms.untracked.bool(False)
+CondDBSetup = cms.PSet( DBParameters = cms.PSet(
+                                                messageLevel = cms.untracked.int32(1),
                                                 )
                         )
 
 process.GlobalTag = cms.ESSource("PoolDBESSource",
                                  CondDBSetup,
-                                 connect = cms.string('frontier://FrontierProd/CMS_COND_31X_GLOBALTAG'),
+                                 #connect = cms.string('oracle://cms_orcon_adg/CMS_CONDITIONS'),
+                                 connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
                                  #    connect = cms.string('sqlite_fip:CondCore/TagCollection/data/GlobalTag.db'), #For use during release integration
-                                 globaltag = cms.string('UNSPECIFIED::All'),
+                                 globaltag = cms.string(''),
+                                 snapshotTime = cms.string('2012-01-20 23:59:59.000'),
                                  RefreshEachRun=cms.untracked.bool(False),
                                  DumpStat=cms.untracked.bool(False),
                                  pfnPrefix=cms.untracked.string(''),   
@@ -44,7 +39,7 @@ process.GlobalTag = cms.ESSource("PoolDBESSource",
                                  )
 
 
-process.GlobalTag.globaltag = options.globalTag+'::All'
+process.GlobalTag.globaltag = options.globalTag
 process.GlobalTag.DumpStat =  True
 # 'GR09_P_V6::All'
 #'CRAFT09_R_V9::All'

--- a/CondCore/ESSources/test/python/loadall_from_gt_empty_source_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_gt_empty_source_cfg.py
@@ -15,7 +15,7 @@ options.register('messageLevel',
                  VarParsing.VarParsing.varType.int,
                  "Message level; default to 0")
 options.register('globalTag',
-                 'START70_V2::All', #default value
+                 'GR_P_V50', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "GlobalTag")
@@ -97,9 +97,9 @@ elif options.refresh == 4:
 
 process.GlobalTag = cms.ESSource( "PoolDBESSource",
                                   CondDBSetup,
-                                  connect = cms.string( 'frontier://FrontierProd/CMS_COND_31X_GLOBALTAG' ),
+                                  connect = cms.string( 'frontier://FrontierProd/CMS_CONDITIONS' ),
                                   #connect = cms.string('sqlite_fip:CondCore/TagCollection/data/GlobalTag.db'), #For use during release integration
-                                  globaltag = cms.string( 'UNSPECIFIED::All' ),
+                                  globaltag = cms.string( '' ),
                                   RefreshAlways = cms.untracked.bool( refreshAlways ),
                                   RefreshOpenIOVs = cms.untracked.bool( refreshOpenIOVs ),
                                   RefreshEachRun=cms.untracked.bool( refreshEachRun ),


### PR DESCRIPTION
This PR introduce the functionality for selecting the IOV sequence ( Tag ) snapshot. It is enabled by specifying a snapshot validity in the Global Tag ( none for the moment ) or to set a user-defined parameter in the cfg file. The default behaviour is unchanged.
