### PR TITLE
Adding a DQM module for dEdxHit info

### DIFF
--- a/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
@@ -30,10 +30,6 @@ Monitoring source for general quantities related to track dEdx.
 #include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
 
 
-
-
-
-class DQMStore;
 class GenericTriggerEventFlag;
 
 class dEdxHitAnalyzer : public DQMEDAnalyzer {
@@ -43,21 +39,13 @@ class dEdxHitAnalyzer : public DQMEDAnalyzer {
   
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
-  virtual void beginJob();
   virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
-  virtual void endJob() ;
-
   double harmonic2(const reco::DeDxHitInfo* dedxHits);
-  
-  //  virtual void beginRun(const edm::Run&, const edm::EventSetup&); 
-  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
-
   void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  void dqmBeginRun(const edm::Run &, const edm::EventSetup &);
   
  private:
   // ----------member data ---------------------------
-  DQMStore * dqmStore_;
   edm::ParameterSet fullconf_;
   edm::ParameterSet conf_;
   
@@ -91,5 +79,23 @@ class dEdxHitAnalyzer : public DQMEDAnalyzer {
   std::string histname;  //for naming the histograms according to algorithm used
   
   GenericTriggerEventFlag* genTriggerEventFlag_;
-  
+
+
+  std::string MEFolderName; 
+
+  int    dEdxNHitBin;
+  double dEdxNHitMin;
+  double dEdxNHitMax;
+
+  int    dEdxStripBin;
+  double dEdxStripMin;
+  double dEdxStripMax;
+
+  int    dEdxPixelBin;
+  double dEdxPixelMin;
+  double dEdxPixelMax;
+
+  int    dEdxHarm2Bin;
+  double dEdxHarm2Min;
+  double dEdxHarm2Max;
 };

--- a/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
@@ -22,12 +22,16 @@ Monitoring source for general quantities related to track dEdx.
 
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
 
-#include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
+#include "DataFormats/Common/interface/ValueMap.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
 
-#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+
+
 
 class DQMStore;
 class GenericTriggerEventFlag;

--- a/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h
@@ -1,0 +1,91 @@
+// -*- C++ -*-
+//
+// 
+/**\class dEdxHitAnalyzer dEdxHitAnalyzer.cc 
+Monitoring source for general quantities related to track dEdx.
+*/
+// Original Author: Loic Quertenmont 2012/07/25 
+
+#include <memory>
+#include <fstream>
+
+#include "FWCore/Utilities/interface/EDGetToken.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDAnalyzer.h"
+
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "DQMServices/Core/interface/MonitorElement.h"
+
+#include "DataFormats/TrackReco/interface/DeDxHitInfo.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+
+#include <DQMServices/Core/interface/DQMEDAnalyzer.h>
+
+class DQMStore;
+class GenericTriggerEventFlag;
+
+class dEdxHitAnalyzer : public DQMEDAnalyzer {
+ public:
+  explicit dEdxHitAnalyzer(const edm::ParameterSet&);
+  ~dEdxHitAnalyzer();
+  
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+  
+  virtual void beginJob();
+  virtual void analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup);
+  virtual void endJob() ;
+
+  double harmonic2(const reco::DeDxHitInfo* dedxHits);
+  
+  //  virtual void beginRun(const edm::Run&, const edm::EventSetup&); 
+  virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+  virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&);
+
+  void bookHistograms(DQMStore::IBooker &, edm::Run const &, edm::EventSetup const &) override;
+  
+ private:
+  // ----------member data ---------------------------
+  DQMStore * dqmStore_;
+  edm::ParameterSet fullconf_;
+  edm::ParameterSet conf_;
+  
+  bool doAllPlots_;
+  bool doDeDxPlots_;
+  
+  struct dEdxMEs 
+  {
+    MonitorElement* ME_StripHitDeDx;
+    MonitorElement* ME_PixelHitDeDx;
+    MonitorElement* ME_NHitDeDx;
+    MonitorElement* ME_Harm2DeDx;
+  
+    dEdxMEs()
+      :ME_StripHitDeDx(NULL)
+      ,ME_PixelHitDeDx(NULL)
+      ,ME_NHitDeDx(NULL)
+      ,ME_Harm2DeDx(NULL)
+    {}
+  };
+  
+  edm::InputTag trackInputTag_;
+  edm::EDGetTokenT<reco::TrackCollection> trackToken_;
+
+  std::vector<std::string> dEdxInputList_;
+  std::vector<edm::EDGetTokenT<reco::DeDxHitInfoAss> > dEdxTokenList_;
+
+  std::string TrackName ;
+  std::vector< std::string  > AlgoNames;
+  std::vector< dEdxMEs > dEdxMEsVector;
+  std::string histname;  //for naming the histograms according to algorithm used
+  
+  GenericTriggerEventFlag* genTriggerEventFlag_;
+  
+};

--- a/DQM/TrackingMonitor/python/dEdxAnalyzer_cff.py
+++ b/DQM/TrackingMonitor/python/dEdxAnalyzer_cff.py
@@ -23,6 +23,12 @@ dedxDQMHarm2SO.UsePixel = cms.bool(False)
 dedxDQMHarm2PO = dedxDQMHarm2SP.clone()
 dedxDQMHarm2PO.UseStrip = cms.bool(False)
 
+
+from RecoTracker.DeDx.dedxEstimators_cff import dedxHitInfo
+dedxDQMHitInfo = dedxHitInfo.clone()
+dedxDQMHitInfo.tracks                     = cms.InputTag("generalTracks")
+dedxDQMHitInfo.trajectoryTrackAssociation = cms.InputTag("generalTracks")
+
 #dEdxMonitor = cms.Sequence(
 #    RefitterForDedxDQMDeDx * dedxDQMHarm2SP * dedxDQMHarm2SO * dedxDQMHarm2PO
 #    * dEdxAnalyzer

--- a/DQM/TrackingMonitor/python/dEdxAnalyzer_cff.py
+++ b/DQM/TrackingMonitor/python/dEdxAnalyzer_cff.py
@@ -23,12 +23,6 @@ dedxDQMHarm2SO.UsePixel = cms.bool(False)
 dedxDQMHarm2PO = dedxDQMHarm2SP.clone()
 dedxDQMHarm2PO.UseStrip = cms.bool(False)
 
-
-from RecoTracker.DeDx.dedxEstimators_cff import dedxHitInfo
-dedxDQMHitInfo = dedxHitInfo.clone()
-dedxDQMHitInfo.tracks                     = cms.InputTag("generalTracks")
-dedxDQMHitInfo.trajectoryTrackAssociation = cms.InputTag("generalTracks")
-
 #dEdxMonitor = cms.Sequence(
 #    RefitterForDedxDQMDeDx * dedxDQMHarm2SP * dedxDQMHarm2SO * dedxDQMHarm2PO
 #    * dEdxAnalyzer

--- a/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
+++ b/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
@@ -42,3 +42,37 @@ dEdxAnalyzer = cms.EDAnalyzer("dEdxAnalyzer",
        dEdxHIPmassMax      = cms.double(5.05),
     )                          
 )
+
+
+dEdxHitAnalyzer = cms.EDAnalyzer("dEdxHitAnalyzer",
+    dEdxParameters = cms.PSet(
+       doAllPlots          = cms.bool(False),
+       doDeDxPlots         = cms.bool(True),
+       FolderName          = cms.string('Tracking/dEdxHits'),
+       OutputMEsInRootFile = cms.bool(False),
+       OutputFileName      = cms.string('MonitorTrack.root'),
+       
+       #input collections
+#       TracksForDeDx       = cms.string('RefitterForDedxDQMDeDx'),
+       TracksForDeDx       = cms.string('generalTracks'),
+       deDxHitProducers       = cms.vstring('dedxDQMHitInfo'),
+
+       #histograms definition
+       dEdxNHitBin         = cms.int32(30),
+       dEdxNHitMin         = cms.double(0),
+       dEdxNHitMax         = cms.double(30.),
+
+       dEdxStripBin        = cms.int32(100),
+       dEdxStripMin        = cms.double(0),
+       dEdxStripMax        = cms.double(1000.),
+
+       dEdxPixelBin        = cms.int32(100),
+       dEdxPixelMin        = cms.double(0),
+       dEdxPixelMax        = cms.double(200000.),
+
+       dEdxHarm2Bin             = cms.int32(50),
+       dEdxHarm2Min             = cms.double(0),
+       dEdxHarm2Max             = cms.double(10.),
+
+    )                          
+)

--- a/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
+++ b/DQM/TrackingMonitor/python/dEdxAnalyzer_cfi.py
@@ -53,9 +53,8 @@ dEdxHitAnalyzer = cms.EDAnalyzer("dEdxHitAnalyzer",
        OutputFileName      = cms.string('MonitorTrack.root'),
        
        #input collections
-#       TracksForDeDx       = cms.string('RefitterForDedxDQMDeDx'),
        TracksForDeDx       = cms.string('generalTracks'),
-       deDxHitProducers       = cms.vstring('dedxDQMHitInfo'),
+       deDxHitProducers       = cms.vstring('dedxHitInfo'),
 
        #histograms definition
        dEdxNHitBin         = cms.int32(30),

--- a/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
@@ -20,8 +20,7 @@
 #include "TMath.h"
 
 dEdxHitAnalyzer::dEdxHitAnalyzer(const edm::ParameterSet& iConfig) 
-  : dqmStore_( edm::Service<DQMStore>().operator->() )
-  , fullconf_( iConfig )
+  : fullconf_( iConfig )
   , conf_    (fullconf_.getParameter<edm::ParameterSet>("dEdxParameters") )
   , doAllPlots_  ( conf_.getParameter<bool>("doAllPlots") )
   , doDeDxPlots_ ( conf_.getParameter<bool>("doDeDxPlots") )    
@@ -35,6 +34,25 @@ dEdxHitAnalyzer::dEdxHitAnalyzer(const edm::ParameterSet& iConfig)
   for (auto const& tag : dEdxInputList_) {
     dEdxTokenList_.push_back(consumes<reco::DeDxHitInfoAss>(edm::InputTag(tag) ) );
   }
+
+  // parameters from the configuration
+  MEFolderName   = conf_.getParameter<std::string>("FolderName"); 
+
+  dEdxNHitBin     = conf_.getParameter<int>(   "dEdxNHitBin");
+  dEdxNHitMin     = conf_.getParameter<double>("dEdxNHitMin");
+  dEdxNHitMax     = conf_.getParameter<double>("dEdxNHitMax");
+
+  dEdxStripBin    = conf_.getParameter<int>(   "dEdxStripBin");
+  dEdxStripMin    = conf_.getParameter<double>("dEdxStripMin");
+  dEdxStripMax    = conf_.getParameter<double>("dEdxStripMax");
+
+  dEdxPixelBin    = conf_.getParameter<int>(   "dEdxPixelBin");
+  dEdxPixelMin    = conf_.getParameter<double>("dEdxPixelMin");
+  dEdxPixelMax    = conf_.getParameter<double>("dEdxPixelMax");
+
+  dEdxHarm2Bin    = conf_.getParameter<int>(   "dEdxHarm2Bin");
+  dEdxHarm2Min    = conf_.getParameter<double>("dEdxHarm2Min");
+  dEdxHarm2Max    = conf_.getParameter<double>("dEdxHarm2Max");
 }
 
 dEdxHitAnalyzer::~dEdxHitAnalyzer() 
@@ -43,57 +61,19 @@ dEdxHitAnalyzer::~dEdxHitAnalyzer()
   if (genTriggerEventFlag_)      delete genTriggerEventFlag_;
 }
 
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-dEdxHitAnalyzer::endJob() 
-{
-    bool outputMEsInRootFile   = conf_.getParameter<bool>("OutputMEsInRootFile");
-    std::string outputFileName = conf_.getParameter<std::string>("OutputFileName");
-    if(outputMEsInRootFile)
-    {
-      dqmStore_->showDirStructure();
-      dqmStore_->save(outputFileName);
-    }
-}
-
-/*
 // -- BeginRun
 //---------------------------------------------------------------------------------//
-void dEdxHitAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
+void dEdxHitAnalyzer::dqmBeginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
 {
- 
   // Initialize the GenericTriggerEventFlag
   if ( genTriggerEventFlag_->on() ) genTriggerEventFlag_->initRun( iRun, iSetup );
 }
-*/
+
 
 void dEdxHitAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
 				  edm::Run const & iRun,
 				  edm::EventSetup const & iSetup ) 
 {
-
-  // Initialize the GenericTriggerEventFlag
-  if ( genTriggerEventFlag_->on() ) genTriggerEventFlag_->initRun( iRun, iSetup );
-  
-
-    // parameters from the configuration
-    std::string MEFolderName   = conf_.getParameter<std::string>("FolderName"); 
-
-    int    dEdxNHitBin     = conf_.getParameter<int>(   "dEdxNHitBin");
-    double dEdxNHitMin     = conf_.getParameter<double>("dEdxNHitMin");
-    double dEdxNHitMax     = conf_.getParameter<double>("dEdxNHitMax");
-
-    int    dEdxStripBin    = conf_.getParameter<int>(   "dEdxStripBin");
-    double dEdxStripMin    = conf_.getParameter<double>("dEdxStripMin");
-    double dEdxStripMax    = conf_.getParameter<double>("dEdxStripMax");
-
-    int    dEdxPixelBin    = conf_.getParameter<int>(   "dEdxPixelBin");
-    double dEdxPixelMin    = conf_.getParameter<double>("dEdxPixelMin");
-    double dEdxPixelMax    = conf_.getParameter<double>("dEdxPixelMax");
-
-    int    dEdxHarm2Bin    = conf_.getParameter<int>(   "dEdxHarm2Bin");
-    double dEdxHarm2Min    = conf_.getParameter<double>("dEdxHarm2Min");
-    double dEdxHarm2Max    = conf_.getParameter<double>("dEdxHarm2Max");
 
     ibooker.setCurrentFolder(MEFolderName);
 
@@ -127,11 +107,6 @@ void dEdxHitAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
        }
     }
 }
-
-void dEdxHitAnalyzer::beginJob()
-{
-}
-
 
 double dEdxHitAnalyzer::harmonic2(const reco::DeDxHitInfo* dedxHits){
      if(!dedxHits)return -1;
@@ -199,16 +174,6 @@ void dEdxHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 
  
 
-void 
-dEdxHitAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void 
-dEdxHitAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void

--- a/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/dEdxHitAnalyzer.cc
@@ -1,0 +1,223 @@
+/*
+ *  See header file for a description of this class.
+ *
+ *  \author Loic Quertenmont 
+ */
+#include "DQM/TrackingMonitor/interface/dEdxHitAnalyzer.h"
+
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrack.h"
+#include "MagneticField/Engine/interface/MagneticField.h"
+
+#include "CommonTools/TriggerUtils/interface/GenericTriggerEventFlag.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "DQMServices/Core/interface/DQMStore.h"
+
+#include <string>
+#include "TMath.h"
+
+dEdxHitAnalyzer::dEdxHitAnalyzer(const edm::ParameterSet& iConfig) 
+  : dqmStore_( edm::Service<DQMStore>().operator->() )
+  , fullconf_( iConfig )
+  , conf_    (fullconf_.getParameter<edm::ParameterSet>("dEdxParameters") )
+  , doAllPlots_  ( conf_.getParameter<bool>("doAllPlots") )
+  , doDeDxPlots_ ( conf_.getParameter<bool>("doDeDxPlots") )    
+  , genTriggerEventFlag_( new GenericTriggerEventFlag(conf_,consumesCollector()) )
+{
+
+  trackInputTag_ = edm::InputTag(conf_.getParameter<std::string>("TracksForDeDx") );
+  trackToken_ = consumes<reco::TrackCollection>(trackInputTag_);
+
+  dEdxInputList_ = conf_.getParameter<std::vector<std::string> >("deDxHitProducers");
+  for (auto const& tag : dEdxInputList_) {
+    dEdxTokenList_.push_back(consumes<reco::DeDxHitInfoAss>(edm::InputTag(tag) ) );
+  }
+}
+
+dEdxHitAnalyzer::~dEdxHitAnalyzer() 
+{ 
+
+  if (genTriggerEventFlag_)      delete genTriggerEventFlag_;
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void 
+dEdxHitAnalyzer::endJob() 
+{
+    bool outputMEsInRootFile   = conf_.getParameter<bool>("OutputMEsInRootFile");
+    std::string outputFileName = conf_.getParameter<std::string>("OutputFileName");
+    if(outputMEsInRootFile)
+    {
+      dqmStore_->showDirStructure();
+      dqmStore_->save(outputFileName);
+    }
+}
+
+/*
+// -- BeginRun
+//---------------------------------------------------------------------------------//
+void dEdxHitAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup)
+{
+ 
+  // Initialize the GenericTriggerEventFlag
+  if ( genTriggerEventFlag_->on() ) genTriggerEventFlag_->initRun( iRun, iSetup );
+}
+*/
+
+void dEdxHitAnalyzer::bookHistograms(DQMStore::IBooker & ibooker,
+				  edm::Run const & iRun,
+				  edm::EventSetup const & iSetup ) 
+{
+
+  // Initialize the GenericTriggerEventFlag
+  if ( genTriggerEventFlag_->on() ) genTriggerEventFlag_->initRun( iRun, iSetup );
+  
+
+    // parameters from the configuration
+    std::string MEFolderName   = conf_.getParameter<std::string>("FolderName"); 
+
+    int    dEdxNHitBin     = conf_.getParameter<int>(   "dEdxNHitBin");
+    double dEdxNHitMin     = conf_.getParameter<double>("dEdxNHitMin");
+    double dEdxNHitMax     = conf_.getParameter<double>("dEdxNHitMax");
+
+    int    dEdxStripBin    = conf_.getParameter<int>(   "dEdxStripBin");
+    double dEdxStripMin    = conf_.getParameter<double>("dEdxStripMin");
+    double dEdxStripMax    = conf_.getParameter<double>("dEdxStripMax");
+
+    int    dEdxPixelBin    = conf_.getParameter<int>(   "dEdxPixelBin");
+    double dEdxPixelMin    = conf_.getParameter<double>("dEdxPixelMin");
+    double dEdxPixelMax    = conf_.getParameter<double>("dEdxPixelMax");
+
+    int    dEdxHarm2Bin    = conf_.getParameter<int>(   "dEdxHarm2Bin");
+    double dEdxHarm2Min    = conf_.getParameter<double>("dEdxHarm2Min");
+    double dEdxHarm2Max    = conf_.getParameter<double>("dEdxHarm2Max");
+
+    ibooker.setCurrentFolder(MEFolderName);
+
+    // book the Hit Property histograms
+    // ---------------------------------------------------------------------------------//
+
+    if ( doDeDxPlots_ || doAllPlots_ ){
+      for(unsigned int i=0;i<dEdxInputList_.size();i++){
+         ibooker.setCurrentFolder(MEFolderName+"/"+ dEdxInputList_[i]);
+         dEdxMEsVector.push_back(dEdxMEs() );
+
+         histname = "Strip_dEdxPerCluster_"; 
+         dEdxMEsVector[i].ME_StripHitDeDx = ibooker.book1D(histname, histname, dEdxStripBin, dEdxStripMin, dEdxStripMax);
+         dEdxMEsVector[i].ME_StripHitDeDx->setAxisTitle("dEdx of on-track strip cluster (ADC)");
+         dEdxMEsVector[i].ME_StripHitDeDx->setAxisTitle("Number of Strip clusters", 2);
+
+         histname = "Pixel_dEdxPerCluster_"; 
+         dEdxMEsVector[i].ME_PixelHitDeDx = ibooker.book1D(histname, histname, dEdxPixelBin, dEdxPixelMin, dEdxPixelMax);
+         dEdxMEsVector[i].ME_PixelHitDeDx->setAxisTitle("dEdx of on-track pixel cluster (ADC)");
+         dEdxMEsVector[i].ME_PixelHitDeDx->setAxisTitle("Number of Pixel clusters", 2);
+
+         histname =  "NumberOfdEdxHitsPerTrack_";
+         dEdxMEsVector[i].ME_NHitDeDx = ibooker.book1D(histname, histname, dEdxNHitBin, dEdxNHitMin, dEdxNHitMax);
+         dEdxMEsVector[i].ME_NHitDeDx->setAxisTitle("Number of dEdxHits per Track");
+         dEdxMEsVector[i].ME_NHitDeDx->setAxisTitle("Number of Tracks", 2);
+
+         histname =  "Harm2_dEdxPerTrack_"; 
+         dEdxMEsVector[i].ME_Harm2DeDx = ibooker.book1D(histname, histname,dEdxHarm2Bin, dEdxHarm2Min, dEdxHarm2Max);
+         dEdxMEsVector[i].ME_Harm2DeDx->setAxisTitle("Harmonic2 dEdx estimator for each Track");
+         dEdxMEsVector[i].ME_Harm2DeDx->setAxisTitle("Number of Tracks", 2);
+       }
+    }
+}
+
+void dEdxHitAnalyzer::beginJob()
+{
+}
+
+
+double dEdxHitAnalyzer::harmonic2(const reco::DeDxHitInfo* dedxHits){
+     if(!dedxHits)return -1;
+     std::vector<double> vect;
+     for(unsigned int h=0;h<dedxHits->size();h++){
+        DetId detid(dedxHits->detId(h));  
+        double Norm = (detid.subdetId()<3)?3.61e-06:3.61e-06*265;
+        double ChargeOverPathlength = Norm*dedxHits->charge(h)/dedxHits->pathlength(h);
+        vect.push_back(ChargeOverPathlength); //save charge
+     }
+
+     int size = vect.size();
+     if(size<=0)return -1;
+     double result=0;
+     double expo = -2;
+     for(int i = 0; i< size; i ++){
+        result+=pow(vect[i],expo); 
+     }
+     return pow(result/size,1./expo);
+}
+
+
+// -- Analyse
+// ---------------------------------------------------------------------------------//
+void dEdxHitAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+
+  // Filter out events if Trigger Filtering is requested
+  if (genTriggerEventFlag_->on()&& ! genTriggerEventFlag_->accept( iEvent, iSetup) ) return;
+
+
+   if ( doDeDxPlots_ || doAllPlots_ ){
+      edm::Handle<reco::TrackCollection> trackCollectionHandle;
+      iEvent.getByToken(trackToken_, trackCollectionHandle );
+      if(!trackCollectionHandle.isValid())return;
+
+      for(unsigned int i=0;i<dEdxInputList_.size();i++){
+         edm::Handle<reco::DeDxHitInfoAss> dEdxObjectHandle;
+	 iEvent.getByToken(dEdxTokenList_[i], dEdxObjectHandle );
+         if(!dEdxObjectHandle.isValid())continue;
+              
+         for(unsigned int t=0; t<trackCollectionHandle->size(); t++){
+            reco::TrackRef track = reco::TrackRef( trackCollectionHandle, t );
+
+            if(track->quality(reco::TrackBase::highPurity) ) {
+               const reco::DeDxHitInfo* dedxHits = NULL;
+               if(!track.isNull()) {
+                  reco::DeDxHitInfoRef dedxHitsRef = (*dEdxObjectHandle)[track];
+                  if(!dedxHitsRef.isNull())dedxHits = &(*dedxHitsRef);
+               }
+               if(!dedxHits)continue;
+
+               for(unsigned int h=0;h<dedxHits->size();h++){
+                  DetId detid(dedxHits->detId(h));
+                  if(detid.subdetId()>=3)dEdxMEsVector[i].ME_StripHitDeDx   ->Fill(dedxHits->charge(h));
+                  if(detid.subdetId()<3 )dEdxMEsVector[i].ME_PixelHitDeDx   ->Fill(dedxHits->charge(h));
+               }
+               dEdxMEsVector[i].ME_NHitDeDx->Fill(dedxHits->size());
+               dEdxMEsVector[i].ME_Harm2DeDx->Fill(harmonic2(dedxHits));
+            }
+         }
+      }
+   }
+}
+
+ 
+
+void 
+dEdxHitAnalyzer::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method called when ending the processing of a luminosity block  ------------
+void 
+dEdxHitAnalyzer::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
+{
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+dEdxHitAnalyzer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  //The following says we do not know what parameters are allowed so do no validation
+  // Please change this to state exactly what you do use, even if it is no parameters
+  edm::ParameterSetDescription desc;
+  desc.setUnknown();
+  descriptions.addDefault(desc);
+}
+
+DEFINE_FWK_MODULE(dEdxHitAnalyzer);

--- a/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
+++ b/DQM/TrackingMonitorSource/python/TrackingSourceConfig_Tier0_cff.py
@@ -125,7 +125,7 @@ trackingDQMgoodOfflinePrimaryVertices.filter = cms.bool(False)
 # Sequence
 TrackingDQMSourceTier0 = cms.Sequence()
 # dEdx monitoring
-TrackingDQMSourceTier0 += dedxHarmonicSequence * dEdxMonCommon    
+TrackingDQMSourceTier0 += dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon   
 #    # temporary patch in order to have BXlumi
 #    * lumiProducer
 # track collections
@@ -147,7 +147,7 @@ TrackingDQMSourceTier0 += dqmInfoTracking
 
 TrackingDQMSourceTier0Common = cms.Sequence()
 # dEdx monitoring
-TrackingDQMSourceTier0Common += (dedxHarmonicSequence * dEdxMonCommon)    
+TrackingDQMSourceTier0Common += (dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon)    
 ## monitor track collections
 for tracks in selectedTracks :
     if tracks != 'generalTracks':
@@ -166,7 +166,7 @@ TrackingDQMSourceTier0Common += dqmInfoTracking
 
 TrackingDQMSourceTier0MinBias = cms.Sequence()
 # dEdx monitoring
-TrackingDQMSourceTier0MinBias += dedxHarmonicSequence * dEdxMonCommon    
+TrackingDQMSourceTier0MinBias += dedxHarmonicSequence * dEdxMonCommon * dEdxHitMonCommon    
 #    * lumiProducer
 #    * trackingDQMgoodOfflinePrimaryVertices
 # monitor track collections

--- a/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
+++ b/DQM/TrackingMonitorSource/python/dEdxAnalyzer_cff.py
@@ -6,6 +6,8 @@ import DQM.TrackingMonitor.dEdxAnalyzer_cfi
 # Clone for all PDs but MinBias ####
 dEdxMonCommon = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
 
+dEdxHitMonCommon = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
+
 # Clone for MinBias ####
 dEdxMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
 dEdxMonMB.dEdxParameters.andOr         = cms.bool( False )
@@ -15,6 +17,14 @@ dEdxMonMB.dEdxParameters.hltDBKey      = cms.string("Tracker_MB")
 dEdxMonMB.dEdxParameters.errorReplyHlt = cms.bool( False )
 dEdxMonMB.dEdxParameters.andOrHlt      = cms.bool(True) 
 
+dEdxHitMonMB = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
+dEdxHitMonMB.dEdxParameters.andOr         = cms.bool( False )
+dEdxHitMonMB.dEdxParameters.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+dEdxHitMonMB.dEdxParameters.hltPaths      = cms.vstring("HLT_ZeroBias_*")
+dEdxHitMonMB.dEdxParameters.hltDBKey      = cms.string("Tracker_MB")
+dEdxHitMonMB.dEdxParameters.errorReplyHlt = cms.bool( False )
+dEdxHitMonMB.dEdxParameters.andOrHlt      = cms.bool(True) 
+
 # Clone for SingleMu ####
 dEdxMonMU = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxAnalyzer.clone()
 dEdxMonMU.dEdxParameters.andOr         = cms.bool( False )
@@ -23,4 +33,9 @@ dEdxMonMU.dEdxParameters.hltPaths      = cms.vstring("HLT_SingleMu40_Eta2p1_*")
 dEdxMonMU.dEdxParameters.errorReplyHlt = cms.bool( False )
 dEdxMonMU.dEdxParameters.andOrHlt      = cms.bool(True) 
 
-
+dEdxHitMonMU = DQM.TrackingMonitor.dEdxAnalyzer_cfi.dEdxHitAnalyzer.clone()
+dEdxHitMonMU.dEdxParameters.andOr         = cms.bool( False )
+dEdxHitMonMU.dEdxParameters.hltInputTag   = cms.InputTag( "TriggerResults::HLT" )
+dEdxHitMonMU.dEdxParameters.hltPaths      = cms.vstring("HLT_SingleMu40_Eta2p1_*")
+dEdxHitMonMU.dEdxParameters.errorReplyHlt = cms.bool( False )
+dEdxHitMonMU.dEdxParameters.andOrHlt      = cms.bool(True) 

--- a/DQM/TrackingMonitorSource/python/dedxHarmonic2monitor_cfi.py
+++ b/DQM/TrackingMonitorSource/python/dedxHarmonic2monitor_cfi.py
@@ -15,11 +15,16 @@ dedxDQMHarm2SO.UsePixel = cms.bool(False)
 dedxDQMHarm2PO = dedxDQMHarm2SP.clone()
 dedxDQMHarm2PO.UseStrip = cms.bool(False)
 
+from RecoTracker.DeDx.dedxEstimators_cff import dedxHitInfo
+dedxDQMHitInfo = dedxHitInfo.clone()
+dedxDQMHitInfo.tracks                     = cms.InputTag("generalTracks")
+dedxDQMHitInfo.trajectoryTrackAssociation = cms.InputTag("generalTracks")
 
 dedxHarmonicSequence = cms.Sequence()
 dedxHarmonicSequence+=dedxDQMHarm2SP
 dedxHarmonicSequence+=dedxDQMHarm2SO
 dedxHarmonicSequence+=dedxDQMHarm2PO
+dedxHarmonicSequence+=dedxDQMHitInfo
 
 #dEdxMonitor = cms.Sequence(
 #    RefitterForDedxDQMDeDx * dedxDQMHarm2SP * dedxDQMHarm2SO * dedxDQMHarm2PO

--- a/DQM/TrackingMonitorSource/python/dedxHarmonic2monitor_cfi.py
+++ b/DQM/TrackingMonitorSource/python/dedxHarmonic2monitor_cfi.py
@@ -15,16 +15,10 @@ dedxDQMHarm2SO.UsePixel = cms.bool(False)
 dedxDQMHarm2PO = dedxDQMHarm2SP.clone()
 dedxDQMHarm2PO.UseStrip = cms.bool(False)
 
-from RecoTracker.DeDx.dedxEstimators_cff import dedxHitInfo
-dedxDQMHitInfo = dedxHitInfo.clone()
-dedxDQMHitInfo.tracks                     = cms.InputTag("generalTracks")
-dedxDQMHitInfo.trajectoryTrackAssociation = cms.InputTag("generalTracks")
-
 dedxHarmonicSequence = cms.Sequence()
 dedxHarmonicSequence+=dedxDQMHarm2SP
 dedxHarmonicSequence+=dedxDQMHarm2SO
 dedxHarmonicSequence+=dedxDQMHarm2PO
-dedxHarmonicSequence+=dedxDQMHitInfo
 
 #dEdxMonitor = cms.Sequence(
 #    RefitterForDedxDQMDeDx * dedxDQMHarm2SP * dedxDQMHarm2SO * dedxDQMHarm2PO

--- a/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
+++ b/RecoTracker/DeDx/plugins/DeDxHitInfoProducer.cc
@@ -85,6 +85,7 @@ void DeDxHitInfoProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
 
      //track selection
      if(track.pt()<minTrackPt ||  std::abs(track.eta())>maxTrackEta ||track.numberOfValidHits()<minTrackHits){
+        cit++;
         indices.push_back(-1);
         continue;
      }


### PR DESCRIPTION
This PR add a DQM module to monitor dEdxHit info.
And also fix a small bug in the dEdxHitInfo producer in standard RECO.
Hope this can be included in the release that will be used for both MC and Data reconstruction
Backport of this changes for 74X are also there
