### PR TITLE
Backport of the HCAL negative energy filter code

### DIFF
--- a/CondCore/HcalPlugins/src/plugin.cc
+++ b/CondCore/HcalPlugins/src/plugin.cc
@@ -22,6 +22,9 @@
 #include "CondFormats/DataRecord/interface/HcalInterpolatedPulseCollRcd.h"
 #include "CondFormats/HcalObjects/interface/HcalInterpolatedPulseColl.h"
 
+#include "CondFormats/DataRecord/interface/HBHENegativeEFilterRcd.h"
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"
+
 //
 #include "CondCore/CondDB/interface/Serialization.h"
 
@@ -66,3 +69,4 @@ REGISTER_PLUGIN(HcalOOTPileupCorrectionRcd,OOTPileupCorrectionColl);
 REGISTER_PLUGIN(HcalOOTPileupCompatibilityRcd,OOTPileupCorrectionBuffer);
 REGISTER_PLUGIN(HcalOOTPileupCorrectionMapCollRcd,OOTPileupCorrectionMapColl);
 REGISTER_PLUGIN(HcalInterpolatedPulseCollRcd,HcalInterpolatedPulseColl);
+REGISTER_PLUGIN(HBHENegativeEFilterRcd,HBHENegativeEFilter);

--- a/CondCore/Utilities/src/CondDBFetch.cc
+++ b/CondCore/Utilities/src/CondDBFetch.cc
@@ -133,6 +133,7 @@ namespace cond {
       FETCH_PAYLOAD_CASE( FileBlob )
       FETCH_PAYLOAD_CASE( GBRForest )
       FETCH_PAYLOAD_CASE( GBRForestD )
+      FETCH_PAYLOAD_CASE( HBHENegativeEFilter )
       FETCH_PAYLOAD_CASE( HcalChannelQuality )
       FETCH_PAYLOAD_CASE( HcalCholeskyMatrices )
       FETCH_PAYLOAD_CASE( HcalElectronicsMap )

--- a/CondCore/Utilities/src/CondDBImport.cc
+++ b/CondCore/Utilities/src/CondDBImport.cc
@@ -148,6 +148,7 @@ namespace cond {
       IMPORT_PAYLOAD_CASE( FileBlob )
       IMPORT_PAYLOAD_CASE( GBRForest )
       IMPORT_PAYLOAD_CASE( GBRForestD )
+      IMPORT_PAYLOAD_CASE( HBHENegativeEFilter )
       IMPORT_PAYLOAD_CASE( HcalChannelQuality )
       IMPORT_PAYLOAD_CASE( HcalCholeskyMatrices )
       IMPORT_PAYLOAD_CASE( HcalDcsValues )

--- a/CondCore/Utilities/src/CondFormats.h
+++ b/CondCore/Utilities/src/CondFormats.h
@@ -65,6 +65,7 @@
 #include "CondFormats/HcalObjects/interface/OOTPileupCorrectionBuffer.h"
 #include "CondFormats/HcalObjects/interface/StorableDoubleMap.h"
 #include "CondFormats/HcalObjects/interface/HcalInterpolatedPulseColl.h"
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
 #include "CondFormats/L1TObjects/interface/L1CaloEcalScale.h"

--- a/CondFormats/DataRecord/interface/HBHENegativeEFilterRcd.h
+++ b/CondFormats/DataRecord/interface/HBHENegativeEFilterRcd.h
@@ -1,0 +1,26 @@
+#ifndef CondFormats_HBHENegativeEFilterRcd_h
+#define CondFormats_HBHENegativeEFilterRcd_h
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HBHENegativeEFilterRcd
+// 
+/**\class HBHENegativeEFilterRcd HBHENegativeEFilterRcd.h CondFormats/DataRecord/interface/HBHENegativeEFilterRcd.h
+
+ Description: record for storing HCAL negative energy filter data
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Igor Volobouev
+// Created:     Fri Mar 20 17:05:13 CDT 2015
+//
+
+#include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
+
+class HBHENegativeEFilterRcd : public edm::eventsetup::EventSetupRecordImplementation<HBHENegativeEFilterRcd> {};
+
+#endif // CondFormats_HBHENegativeEFilterRcd_h
+

--- a/CondFormats/DataRecord/src/HBHENegativeEFilterRcd.cc
+++ b/CondFormats/DataRecord/src/HBHENegativeEFilterRcd.cc
@@ -1,0 +1,15 @@
+// -*- C++ -*-
+//
+// Package:     CondFormats/DataRecord
+// Class  :     HBHENegativeEFilterRcd
+// 
+// Implementation:
+//     [Notes on implementation]
+//
+// Author:      Igor Volobouev
+// Created:     Fri Mar 20 17:06:03 CDT 2015
+
+#include "CondFormats/DataRecord/interface/HBHENegativeEFilterRcd.h"
+#include "FWCore/Framework/interface/eventsetuprecord_registration_macro.h"
+
+EVENTSETUP_RECORD_REG(HBHENegativeEFilterRcd);

--- a/CondFormats/HcalObjects/interface/HBHENegativeEFilter.h
+++ b/CondFormats/HcalObjects/interface/HBHENegativeEFilter.h
@@ -1,0 +1,87 @@
+#ifndef CondFormats_HcalObjects_HBHENegativeEFilter_h_
+#define CondFormats_HcalObjects_HBHENegativeEFilter_h_
+
+#include <vector>
+#include <utility>
+#include "FWCore/Utilities/interface/Exception.h"
+
+#include "boost/cstdint.hpp"
+#include "boost/serialization/utility.hpp"
+#include "boost/serialization/access.hpp"
+#include "boost/serialization/split_member.hpp"
+
+#include "DataFormats/HcalDetId/interface/HcalDetId.h"
+#include "CondFormats/HcalObjects/interface/PiecewiseScalingPolynomial.h"
+
+class HBHENegativeEFilter
+{
+public:
+    inline HBHENegativeEFilter() : minCharge_(0.), tFirst_(0), tLast_(0) {}
+
+    // If the vector of cuts is empty, the filter will be disabled
+    HBHENegativeEFilter(const std::vector<PiecewiseScalingPolynomial>& a1vec,
+                        const std::vector<PiecewiseScalingPolynomial>& a2vec,
+                        const std::vector<uint32_t>& iEtaLimits,
+                        const std::vector<std::pair<double,double> >& cut,
+                        double minCharge, unsigned firstTimeSlice,
+                        unsigned lastTimeSlice);
+
+    // Does the sequence of time slices pass the filter?
+    bool checkPassFilter(const HcalDetId& id,
+                         const double* ts, unsigned lenTS) const;
+
+    // Examing various filter data elements
+    inline const PiecewiseScalingPolynomial& getA1(const HcalDetId& id) const
+        {return a1v_.at(getEtaIndex(id));}
+    inline const PiecewiseScalingPolynomial& getA2(const HcalDetId& id) const
+        {return a2v_.at(getEtaIndex(id));}
+    inline const std::vector<uint32_t>& getEtaLimits() const
+        {return iEtaLimits_;}
+    inline const std::vector<std::pair<double,double> >& getCut() const
+        {return cut_;}
+    inline double getMinCharge() const {return minCharge_;}
+    inline unsigned getFirstTimeSlice() const {return tFirst_;}
+    inline unsigned getLastTimeSlice() const {return tLast_;}
+    inline bool isEnabled() const {return !cut_.empty();}
+
+    // Comparison operators
+    bool operator==(const HBHENegativeEFilter& r) const;
+    inline bool operator!=(const HBHENegativeEFilter& r) const
+        {return !(*this == r);}
+
+private:
+    unsigned getEtaIndex(const HcalDetId& id) const;
+    bool validate() const;
+
+    std::vector<PiecewiseScalingPolynomial> a1v_;
+    std::vector<PiecewiseScalingPolynomial> a2v_;
+    std::vector<uint32_t> iEtaLimits_;
+    std::vector<std::pair<double,double> > cut_;
+    double minCharge_;
+    uint32_t tFirst_;
+    uint32_t tLast_;
+
+    friend class boost::serialization::access;
+
+    template<class Archive>
+    inline void save(Archive & ar, const unsigned /* version */) const
+    {
+        if (!validate()) throw cms::Exception(
+            "In HBHENegativeEFilter::save: invalid data");
+        ar & a1v_ & a2v_ & iEtaLimits_ & cut_ & minCharge_ & tFirst_ & tLast_;
+    }
+
+    template<class Archive>
+    inline void load(Archive & ar, const unsigned /* version */)
+    {
+        ar & a1v_ & a2v_ & iEtaLimits_ & cut_ & minCharge_ & tFirst_ & tLast_;
+        if (!validate()) throw cms::Exception(
+            "In HBHENegativeEFilter::load: invalid data");
+    }
+
+    BOOST_SERIALIZATION_SPLIT_MEMBER()
+};
+
+BOOST_CLASS_VERSION(HBHENegativeEFilter, 1)
+
+#endif // CondFormats_HcalObjects_HBHENegativeEFilter_h_

--- a/CondFormats/HcalObjects/src/HBHENegativeEFilter.cc
+++ b/CondFormats/HcalObjects/src/HBHENegativeEFilter.cc
@@ -1,0 +1,133 @@
+#include <cmath>
+#include <climits>
+
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"
+
+HBHENegativeEFilter::HBHENegativeEFilter(
+    const std::vector<PiecewiseScalingPolynomial>& a1vec,
+    const std::vector<PiecewiseScalingPolynomial>& a2vec,
+    const std::vector<uint32_t>& iEtaLimits,
+    const std::vector<std::pair<double,double> >& cut,
+    const double minCharge,
+    const unsigned firstTimeSlice,
+    const unsigned lastTimeSlice)
+    : a1v_(a1vec),
+      a2v_(a2vec),
+      iEtaLimits_(iEtaLimits),
+      cut_(cut),
+      minCharge_(minCharge),
+      tFirst_(firstTimeSlice),
+      tLast_(lastTimeSlice)
+{
+    if (!validate()) throw cms::Exception(
+        "Invalid HBHENegativeEFilter constructor arguments");
+}
+
+bool HBHENegativeEFilter::validate() const
+{
+    if (cut_.empty())
+        return true;
+
+    const std::size_t nLimits(iEtaLimits_.size());
+    if (nLimits >= static_cast<std::size_t>(UINT_MAX - 1U))
+        return false;
+    for (std::size_t i=1; i<nLimits; ++i)
+        if (!(iEtaLimits_[i-1] < iEtaLimits_[i]))
+            return false;
+
+    if (a1v_.size() != nLimits + 1)
+        return false;
+    if (a2v_.size() != nLimits + 1)
+        return false;
+
+    const std::size_t sz = cut_.size();
+    if (sz >= static_cast<std::size_t>(UINT_MAX - 1U))
+        return false;
+    for (std::size_t i=1; i<sz; ++i)
+        if (!(cut_[i-1U].first < cut_[i].first))
+            return false;
+
+    if (tFirst_ < 2U)
+        return false;
+    if (!(tFirst_ <= tLast_))
+        return false;
+
+    return true;
+}
+
+bool HBHENegativeEFilter::operator==(const HBHENegativeEFilter& r) const
+{
+    if (cut_.empty() && r.cut_.empty())
+        return true;
+    else
+        return a1v_ == r.a1v_ &&
+               a2v_ == r.a2v_ &&
+               iEtaLimits_ == r.iEtaLimits_ &&
+               cut_ == r.cut_ &&
+               minCharge_ == r.minCharge_ &&
+               tFirst_ == r.tFirst_ &&
+               tLast_ == r.tLast_;
+}
+
+unsigned HBHENegativeEFilter::getEtaIndex(const HcalDetId& id) const
+{
+    const unsigned nLimits = iEtaLimits_.size();
+    unsigned which(0U);
+    if (nLimits)
+    {
+        const uint32_t uEta = std::abs(id.ieta());
+        const uint32_t* limits(&iEtaLimits_[0]);
+        for (; which<nLimits; ++which)
+            if (uEta < limits[which])
+                break;
+    }
+    return which;
+}
+
+bool HBHENegativeEFilter::checkPassFilter(const HcalDetId& id,
+                                          const double* ts, const unsigned lenTS) const
+{
+    bool passes = true;
+    const unsigned sz = cut_.size();
+    if (sz)
+    {
+        double chargeInWindow = 0.0;
+        for (unsigned i=tFirst_; i<=tLast_ && i<lenTS; ++i)
+            chargeInWindow += ts[i];
+        if (chargeInWindow >= minCharge_)
+        {
+            // Figure out the cut value for this charge
+            const std::pair<double,double>* cut = &cut_[0];
+            double cutValue = cut[0].second;
+            if (sz > 1U)
+            {
+                // First point larger than charge
+                unsigned largerPoint = 0;
+                for (; cut[largerPoint].first <= chargeInWindow; ++largerPoint) {}
+
+                // Constant extrapolation beyond min and max coords
+                if (largerPoint >= sz)
+                    cutValue = cut[sz - 1U].second;
+                else if (largerPoint)
+                {
+                    const double slope = (cut[largerPoint].second - cut[largerPoint-1U].second)/
+                                         (cut[largerPoint].first - cut[largerPoint-1U].first);
+                    cutValue = cut[largerPoint-1U].second + slope*
+                        (chargeInWindow - cut[largerPoint-1U].first);
+                }
+            }
+
+            // Compare the modified time slices with the cut
+            const unsigned itaIdx = getEtaIndex(id);
+            const PiecewiseScalingPolynomial& a1(a1v_[itaIdx]);
+            const PiecewiseScalingPolynomial& a2(a2v_[itaIdx]);
+
+            for (unsigned i=tFirst_; i<=tLast_ && i<lenTS && passes; ++i)
+            {
+                const double ecorr = ts[i] - a1(ts[i-1U]) - a2(ts[i-2U]);
+                passes = ecorr >= cutValue;
+            }
+        }
+    }
+    return passes;
+}

--- a/CondFormats/HcalObjects/src/T_EventSetup_HBHENegativeEFilter.cc
+++ b/CondFormats/HcalObjects/src/T_EventSetup_HBHENegativeEFilter.cc
@@ -1,0 +1,4 @@
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"
+#include "FWCore/Utilities/interface/typelookup.h"
+
+TYPELOOKUP_DATA_REG(HBHENegativeEFilter);

--- a/CondFormats/HcalObjects/src/classes.h
+++ b/CondFormats/HcalObjects/src/classes.h
@@ -102,6 +102,10 @@ namespace CondFormats_HcalObjects {
     std::vector<HcalInterpolatedPulse> myHcalInterpolatedPulseVec;
     HBHEChannelGroups myHBHEChannelGroups;
     HcalInterpolatedPulseColl myHcalInterpolatedPulseColl;
+
+    // HBHE negative energy filter
+    std::vector<PiecewiseScalingPolynomial> myPiecewiseScalingPolynomialVec;
+    HBHENegativeEFilter myHBHENegativeEFilter;
   };
 }
 

--- a/CondFormats/HcalObjects/src/classes_def.xml
+++ b/CondFormats/HcalObjects/src/classes_def.xml
@@ -415,4 +415,6 @@
   <field name="group_" mapping="blob" />
  </class>
  <class name="HcalInterpolatedPulseColl" class_version="1"/>
+ <class name="std::vector<PiecewiseScalingPolynomial>"/>
+ <class name="HBHENegativeEFilter" class_version="1"/>
 </lcgdict>   

--- a/CondFormats/HcalObjects/src/headers.h
+++ b/CondFormats/HcalObjects/src/headers.h
@@ -11,3 +11,4 @@
 #include "CondFormats/HcalObjects/interface/HcalInterpolatedPulse.h"
 #include "CondFormats/HcalObjects/interface/HcalInterpolatedPulseColl.h"
 #include "CondFormats/HcalObjects/interface/HBHEChannelGroups.h"
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"

--- a/CondTools/Hcal/plugins/HBHENegativeEFilterDBModules.cc
+++ b/CondTools/Hcal/plugins/HBHENegativeEFilterDBModules.cc
@@ -1,0 +1,13 @@
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"
+#include "CondFormats/DataRecord/interface/HBHENegativeEFilterRcd.h"
+
+#include "CondTools/Hcal/interface/BoostIODBWriter.h"
+#include "CondTools/Hcal/interface/BoostIODBReader.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef BoostIODBWriter<HBHENegativeEFilter> HBHENegativeEFilterDBWriter;
+typedef BoostIODBReader<HBHENegativeEFilter,HBHENegativeEFilterRcd> HBHENegativeEFilterDBReader;
+
+DEFINE_FWK_MODULE(HBHENegativeEFilterDBWriter);
+DEFINE_FWK_MODULE(HBHENegativeEFilterDBReader);

--- a/CondTools/Hcal/test/HBHENegativeEFilterDBReader_cfg.py
+++ b/CondTools/Hcal/test/HBHENegativeEFilterDBReader_cfg.py
@@ -1,0 +1,29 @@
+database = "sqlite_file:HBHENegativeEFilter_V00_data.db"
+tag = "HBHENegativeEFilter_V00_data"
+outputfile = "dbread.bbin"
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('HBHENegativeEFilterDBRead')
+
+process.source = cms.Source('EmptySource') 
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 
+
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = database
+# process.CondDB.dbFormat = cms.untracked.int32(1)
+
+process.PoolDBESSource = cms.ESSource("PoolDBESSource",
+    process.CondDB,
+    toGet = cms.VPSet(cms.PSet(
+        record = cms.string("HBHENegativeEFilterRcd"),
+        tag = cms.string(tag)
+    ))
+)
+
+process.dumper = cms.EDAnalyzer(
+    'HBHENegativeEFilterDBReader',
+    outputFile = cms.string(outputfile)
+)
+
+process.p = cms.Path(process.dumper)

--- a/CondTools/Hcal/test/HBHENegativeEFilterDBWriter_cfg.py
+++ b/CondTools/Hcal/test/HBHENegativeEFilterDBWriter_cfg.py
@@ -1,0 +1,51 @@
+database = "sqlite_file:HBHENegativeEFilter_V00_data.db"
+tag = "HBHENegativeEFilter_V00_data"
+inputfile = "HBHENegativeEFilter_V00_data.bbin"
+
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('HBHENegativeEFilterDBWrite') 
+
+process.source = cms.Source('EmptyIOVSource',
+    lastValue = cms.uint64(1),
+    timetype = cms.string('runnumber'),
+    firstValue = cms.uint64(1),
+    interval = cms.uint64(1)
+) 
+process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(1)) 
+
+process.load("CondCore.CondDB.CondDB_cfi")
+process.CondDB.connect = database
+# process.CondDB.dbFormat = cms.untracked.int32(1)
+
+# Data is tagged in the database by the "tag" parameter specified in the
+# PoolDBOutputService configuration. We then check if the tag already exists.
+#
+# -- If the tag does not exist, a new interval of validity (IOV) for this tag
+#    is created, valid till "end of time".
+#
+# -- If the tag already exists: the IOV of the previous data is stopped at
+#    "current time" and we register new data valid from now on (currentTime
+#    is the time of the current event!). 
+#
+# The "record" parameter should be the same in the PoolDBOutputService
+# configuration and in the module which writes the object. It is basically
+# used in order to just associate the record with the tag.
+#
+process.PoolDBOutputService = cms.Service(
+    "PoolDBOutputService",
+    process.CondDB,
+    timetype = cms.untracked.string('runnumber'),
+    toPut = cms.VPSet(cms.PSet(
+        record = cms.string("HBHENegativeEFilterRcd"),
+        tag = cms.string(tag)
+    ))
+)
+
+process.filereader = cms.EDAnalyzer(
+    'HBHENegativeEFilterDBWriter',
+    inputFile = cms.string(inputfile),
+    record = cms.string("HBHENegativeEFilterRcd")
+)
+
+process.p = cms.Path(process.filereader)

--- a/RecoLocalCalo/HcalRecAlgos/interface/HBHENegativeFlag.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HBHENegativeFlag.h
@@ -1,53 +1,27 @@
-//---------------------------------------------------------------------------
 #ifndef HBHENegativeFlag_H
 #define HBHENegativeFlag_H
+
 //---------------------------------------------------------------------------
 // Negative filter algorithms for HBHE noise flagging
-// 
-// Original Author: Yi Chen (Caltech), (1)3364 (Aug. 21, 2014)
 //---------------------------------------------------------------------------
-#include <string>
-#include <vector>
-#include <map>
-#include "boost/shared_ptr.hpp"
-//---------------------------------------------------------------------------
+
 #include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
-#include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
-#include "CondFormats/HcalObjects/interface/AbsOOTPileupCorrection.h"
-//---------------------------------------------------------------------------
-class HBHENegativeFlagSetter;
-//---------------------------------------------------------------------------
+#include "CondFormats/HcalObjects/interface/HBHENegativeEFilter.h"
+
 class HBHENegativeFlagSetter
 {
-   public:
-      HBHENegativeFlagSetter();
-      HBHENegativeFlagSetter(double minimumChargeThreshold,
-            double tS4TS5ChargeThreshold,
-            int first, int last,
-            std::vector<double> threshold,
-            std::vector<double> cut);
-      ~HBHENegativeFlagSetter();
-      void setPulseShapeFlags(HBHERecHit& hbhe, const HBHEDataFrame &digi,
-            const HcalCoder &coder, const HcalCalibrations &calib);
-      void setHBHEPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr);
-      void setBXInfo(const BunchXParameter *info, unsigned length);
-   private:
-      double mMinimumChargeThreshold;
-      double mTS4TS5ChargeThreshold;
-      boost::shared_ptr<AbsOOTPileupCorrection> hbhePileupCorr_;
-      int mFirst;
-      int mLast;
-      const BunchXParameter *mBunchCrossingInfo;
-      unsigned mLengthBunchCrossingInfo;
-      std::vector<std::pair<double, double> > mCut;
-   private:
-      bool checkPassFilter(double charge, double discriminant, std::vector<std::pair<double, double> > &cuts,
-         int side);
-};
-//---------------------------------------------------------------------------
-#endif
+public:
+    inline HBHENegativeFlagSetter() : filter_(0) {}
 
+    inline void configFilter(const HBHENegativeEFilter* f) {filter_ = f;}
+
+    void setPulseShapeFlags(HBHERecHit& hbhe, const HBHEDataFrame &digi,
+                            const HcalCoder &coder, const HcalCalibrations &calib);
+private:
+    const HBHENegativeEFilter* filter_;
+};
+
+#endif

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHENegativeFlag.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHENegativeFlag.cc
@@ -1,98 +1,14 @@
-//---------------------------------------------------------------------------
-#include <string>
-#include <vector>
-#include <iostream>
-#include <algorithm>
-#include <fstream>
-#include <cmath>
-
-//---------------------------------------------------------------------------
 #include "RecoLocalCalo/HcalRecAlgos/interface/HBHENegativeFlag.h"
+#include "CalibFormats/CaloObjects/interface/CaloSamples.h"
 #include "DataFormats/METReco/interface/HcalCaloFlagLabels.h"
 
-#include "FWCore/Utilities/interface/Exception.h"
-#include "FWCore/MessageLogger/interface/MessageLogger.h"
-
-#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
-#include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
-#include "DataFormats/HcalRecHit/interface/HBHERecHit.h"
-
-#include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
-#include "CalibFormats/HcalObjects/interface/HcalCoderDb.h"
-#include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
-
-#include "CondFormats/DataRecord/interface/HcalOOTPileupCorrectionRcd.h"
-#include "CondFormats/HcalObjects/interface/OOTPileupCorrectionColl.h"
-#include "CondFormats/HcalObjects/interface/OOTPileupCorrData.h"
-
-#include "Geometry/CaloTopology/interface/HcalTopology.h"
-#include "Geometry/Records/interface/IdealGeometryRecord.h"
-//---------------------------------------------------------------------------
-HBHENegativeFlagSetter::HBHENegativeFlagSetter()
+void HBHENegativeFlagSetter::setPulseShapeFlags(
+    HBHERecHit &hbhe, 
+    const HBHEDataFrame &digi,
+    const HcalCoder &coder, 
+    const HcalCalibrations &calib)
 {
-   //
-   // Argumentless constructor; should not be used
-   // 
-   // If arguments not properly specified for the constructor, I don't think
-   // we'd trust the flagging algorithm.
-   // Set the minimum charge threshold large enough so that nothing will be flagged.
-   // 
-
-   mMinimumChargeThreshold = 99999999;
-   mTS4TS5ChargeThreshold = 99999999;
-   mFirst = 4;
-   mLast = 6;
-   mBunchCrossingInfo = NULL;
-   mLengthBunchCrossingInfo = 0;
-}
-//---------------------------------------------------------------------------
-HBHENegativeFlagSetter::HBHENegativeFlagSetter(double minimumChargeThreshold,
-   double tS4TS5ChargeThreshold, int first, int last,
-   std::vector<double> threshold, std::vector<double> cut)
-{
-   //
-   // The constructor that should be used
-   //
-   // Copies various thresholds and limits and parameters to the class for future use.
-   //
-
-   mMinimumChargeThreshold = minimumChargeThreshold;
-   mTS4TS5ChargeThreshold = tS4TS5ChargeThreshold;
-   mFirst = first;
-   mLast = last;
-
-   if (mFirst < 2 || mLast < mFirst)
-       throw cms::Exception("Invalid mFirst, mLast specification");
-
-   mBunchCrossingInfo = NULL;
-   mLengthBunchCrossingInfo = 0;
-
-   for(int i = 0; i < (int)std::min(threshold.size(), cut.size()); i++)
-      mCut.push_back(std::pair<double, double>(threshold[i], cut[i]));
-   std::sort(mCut.begin(), mCut.end());
-}
-//---------------------------------------------------------------------------
-HBHENegativeFlagSetter::~HBHENegativeFlagSetter()
-{
-   // Dummy destructor - there's nothing to destruct by hand here
-}
-//---------------------------------------------------------------------------
-void HBHENegativeFlagSetter::setPulseShapeFlags(HBHERecHit &hbhe, 
-   const HBHEDataFrame &digi,
-   const HcalCoder &coder, 
-   const HcalCalibrations &calib)
-{
-   //
-   // Decide if a digi/pulse is good or bad using negative energy discriminants
-   //
-   // SetPulseShapeFlags determines the total charge in the digi.
-   // If the charge is above the minimum threshold, the code then
-   // runs the flag-setting algorithms to determine whether the
-   // flags should be set.
-   //
-
-   const OOTPileupCorrData* corrObj = dynamic_cast<OOTPileupCorrData*>(hbhePileupCorr_.get());
-   if (corrObj)
+   if (filter_)
    {
       CaloSamples cs;
       coder.adc2fC(digi,cs);
@@ -105,89 +21,8 @@ void HBHENegativeFlagSetter::setPulseShapeFlags(HBHERecHit &hbhe,
          ts[i] = cs[i] - calib.pedestal(capid);
       }
 
-      double ChargeInWindow = 0.0;
-      for(int i = mFirst; i <= mLast && i < CaloSamples::MAXSAMPLES; i++)
-         ChargeInWindow += ts[i];
-      if(ChargeInWindow < mMinimumChargeThreshold)
-         return;
-
-      const OOTPileupCorrDataFcn& fcn = corrObj->getCorrectionByID(hbhe.id());
-      const PiecewiseScalingPolynomial& a1 = fcn.getA1();
-      const PiecewiseScalingPolynomial& a2 = fcn.getA2();
-
-      bool passes = true;
-      for (int i = mFirst; i <= mLast && passes; i++)
-      {
-          const double ecorr = ts[i] - a1(ts[i-1]) - a2(ts[i-2]);
-          passes = checkPassFilter(ChargeInWindow, ecorr, mCut, -1);
-      }
+      const bool passes = filter_->checkPassFilter(hbhe.id(), &ts[0], nRead);
       if (!passes)
           hbhe.setFlagField(1, HcalCaloFlagLabels::HBHENegativeNoise);
    }
 }
-//---------------------------------------------------------------------------
-void HBHENegativeFlagSetter::setHBHEPileupCorrection(boost::shared_ptr<AbsOOTPileupCorrection> corr)
-{
-    hbhePileupCorr_ = corr;
-}
-//---------------------------------------------------------------------------
-void HBHENegativeFlagSetter::setBXInfo(const BunchXParameter *info, unsigned length)
-{
-   mBunchCrossingInfo = info;
-   mLengthBunchCrossingInfo = length;
-}
-//---------------------------------------------------------------------------
-bool HBHENegativeFlagSetter::checkPassFilter(double charge,
-					       double discriminant,
-					       std::vector<std::pair<double, double> > &cuts, 
-					       int side)
-{
-   //
-   // Checks whether Discriminant value passes Cuts for the specified Charge.  True if pulse is good.
-   //
-   // The "Cuts" pairs are assumed to be sorted in terms of size from small to large,
-   //    where each "pair" = (Charge, Discriminant)
-   // "Side" is either positive or negative, which determines whether to discard the pulse if discriminant
-   //    is greater or smaller than the cut value
-   //
-
-   if(cuts.size() == 0)   // safety check that there are some cuts defined
-      return true;
-
-   if(charge <= cuts[0].first)   // too small to cut on
-      return true;
-
-   int indexLargerThanCharge = -1;   // find the range it is falling in
-   for(int i = 1; i < (int)cuts.size(); i++)
-   {
-      if(cuts[i].first > charge)
-      {
-         indexLargerThanCharge = i;
-         break;
-      }
-   }
-
-   double limit = 1000000;
-
-   if(indexLargerThanCharge == -1)   // if charge is greater than the last entry, assume flat line
-      limit = cuts[cuts.size()-1].second;
-   else   // otherwise, do a linear interpolation to find the cut position
-   {
-      double C1 = cuts[indexLargerThanCharge].first;
-      double C2 = cuts[indexLargerThanCharge-1].first;
-      double L1 = cuts[indexLargerThanCharge].second;
-      double L2 = cuts[indexLargerThanCharge-1].second;
-
-      limit = (charge - C1) / (C2 - C1) * (L2 - L1) + L1;
-   }
-
-   if(side > 0 && discriminant > limit)
-      return false;
-   if(side < 0 && discriminant < limit)
-      return false;
-
-   return true;
-}
-//---------------------------------------------------------------------------
-
-

--- a/RecoLocalCalo/HcalRecAlgos/src/HBHETimingShapedFlag.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HBHETimingShapedFlag.cc
@@ -14,6 +14,10 @@ HBHETimingShapedFlagSetter::HBHETimingShapedFlagSetter()
 {
 }
 
+HBHETimingShapedFlagSetter::~HBHETimingShapedFlagSetter()
+{
+}
+
 HBHETimingShapedFlagSetter::HBHETimingShapedFlagSetter(const std::vector<double>& v_userEnvelope)
 {
   makeTfilterEnvelope(v_userEnvelope);

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
@@ -31,7 +31,9 @@ hbheprereco = cms.EDProducer(
     setTimingShapedCutsFlags  = cms.bool(True),
     setTimingTrustFlags       = cms.bool(False), # timing flags currently only implemented for HF
     setPulseShapeFlags        = cms.bool(True),
-    setNegativeFlags          = cms.bool(True), # only in HBHE
+
+    # Disable negative energy filter pending db support
+    setNegativeFlags          = cms.bool(False),
 
     flagParameters= cms.PSet(nominalPedestal=cms.double(3.0),  #fC
                              hitEnergyMinimum=cms.double(1.0), #GeV
@@ -76,13 +78,6 @@ hbheprereco = cms.EDProducer(
                                     TS4TS5LowerCut = cms.vdouble(-1, -0.7, -0.5, -0.4, -0.3, 0.1),
                                     UseDualFit = cms.bool(True),
                                     TriangleIgnoreSlow = cms.bool(False)),
-
-    negativeParameters = cms.PSet(MinimumChargeThreshold = cms.double(20),
-                                  TS4TS5ChargeThreshold = cms.double(70),
-                                  First = cms.int32(4),
-                                  Last = cms.int32(6),
-                                  Threshold = cms.vdouble(100, 120, 160, 200, 300, 500, 1.0e4),
-                                  Cut = cms.vdouble(-50, -100, -100, -100, -100, -100, -1.0e6)),
 
     # shaped cut parameters are triples of (energy, low time threshold, high time threshold) values.
     # The low and high thresholds must straddle zero (i.e., low<0, high>0); use win_offset to shift.

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
@@ -54,7 +54,6 @@ class HcalTopology;
 
     private:      
       typedef void (HcalSimpleRecAlgo::*SetCorrectionFcn)(boost::shared_ptr<AbsOOTPileupCorrection>);
-      typedef void (HBHENegativeFlagSetter::*SetCorrectionFcnForNegative)(boost::shared_ptr<AbsOOTPileupCorrection>);
 
       HcalSimpleRecAlgo reco_;
       HcalADCSaturationFlag* saturationFlagSetter_;
@@ -106,7 +105,6 @@ class HcalTopology;
       std::string mcOOTCorrectionName_;
       std::string mcOOTCorrectionCategory_;
       SetCorrectionFcn setPileupCorrection_;
-      SetCorrectionFcnForNegative setPileupCorrectionForNegative_;
 
       HcalRecoParams* paramTS;  // firstSample & sampleToAdd from DB  
       std::unique_ptr<HcalFlagHFDigiTimeParams> HFDigiTimeParams; // HF DigiTime parameters


### PR DESCRIPTION
Backporting PR #8447, #8923, and #9105

The implementation of the negative energy filter was confirmed to be correct by the HCAL Noise WG using a configuration from a private database.

The filter is still not enabled, pending the GT (requested).
