### PR TITLE
Use shrink_to_fit on TrackProducer collections

### DIFF
--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -124,6 +124,12 @@ namespace edm {
     OwnVector<T, P>& operator=(OwnVector<T, P>&&) noexcept;
 #endif
 
+    void shrink_to_fit() {
+#ifndef CMS_NOCXX11
+      data_.shrink_to_fit();
+#endif
+    }
+
 
     void reserve(size_t);
     template <typename D> void push_back(D*& d);

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -164,11 +164,14 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
   LogTrace("TrackingRegressionTest") << "=================================================";
   
   
+  selTracks->shrink_to_fit();
+  selTrackExtras->shrink_to_fit();
   rTracks_ = evt.put( selTracks );
   evt.put( selTrackExtras );
   evt.put( selHits );
 
   if(trajectoryInEvent_) {
+    selTrajectories->shrink_to_fit();
     edm::OrphanHandle<std::vector<Trajectory> > rTrajs = evt.put(selTrajectories);
 
     // Now Create traj<->tracks association map

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -166,6 +166,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
   
   selTracks->shrink_to_fit();
   selTrackExtras->shrink_to_fit();
+  selHits->shrink_to_fit();
   rTracks_ = evt.put( selTracks );
   evt.put( selTrackExtras );
   evt.put( selHits );


### PR DESCRIPTION
Uses shrink_to_fit to reduce the memory used by the produced collections in TrackProducer, basically backported from 74X.  This also adds shrink_to_fit to the edm::OwnVector interface, also backported from 74X.
Note that since this includes a change to the edm::OwnVector header a checkdeps will pull in 417 packages.

Even though each individual TrackProducer doesn't have comparatively large collections, because there are so many of them if you sum up by producer type it's actually one of the largest.  This plot is 200 pileup before applying this pull request (but with some of the other PRs in the queue):
![productsizebyclass](https://cloud.githubusercontent.com/assets/6480160/7692759/a682dde6-fdbf-11e4-98b1-4313b279b6f2.png)

I've been doing a few tests and it doesn't seem to make a huge amount of difference.  I didn't do the checkdeps, but I don't see why that would have made a difference.  Anyway, the shrink_to_fit is only going to improve things - peak memory use is not a problem for TrackProducer.
