### PR TITLE
fix muon HLT DQM for tk muon (backport in 74X)

### DIFF
--- a/HLTriggerOffline/Muon/python/hltMuonPostProcessors_cff.py
+++ b/HLTriggerOffline/Muon/python/hltMuonPostProcessors_cff.py
@@ -60,7 +60,7 @@ noniso_strings = []
 
 for type in plot_types:
     efficiency_strings.append(efficiency_string("L1", "All", type))
-    for step in ["L2", "L2Iso", "L3", "L3EcalIso", "L3HcalIso", "L3TkIso"]:
+    for step in ["L2", "L2Iso", "L3", "Tk", "L3EcalIso", "L3HcalIso", "L3TkIso"]:
         efficiency_strings.append(efficiency_string(step, "L1", type))
     noniso_strings.append(efficiency_string("L3", "All", type, "Total"))
     iso_strings.append(efficiency_string("L3EcalIso", "All", type, "Total"))

--- a/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonPlotter.cc
@@ -224,7 +224,8 @@ HLTMuonPlotter::analyze(const Event & iEvent, const EventSetup & iSetup)
     
     for (size_t step = 0; step < nSteps; step++) {
       
-      const size_t hltStep = (step >= 2) ? step - 2 : 0;
+      size_t hltStep = (step >= 2) ? step - 2 : 0;
+      if (nSteps == 6) hltStep=hltStep-1; // case of the tracker muon (it has no L2)
       size_t level = 0;
       if ((stepLabels_[step].find("L3TkIso") != string::npos)||(stepLabels_[step].find("TkTkIso") != string::npos)) level = 6;
       else if ((stepLabels_[step].find("L3HcalIso") != string::npos)||(stepLabels_[step].find("TkEcalIso") != string::npos)) level = 5;

--- a/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
+++ b/HLTriggerOffline/Muon/src/HLTMuonValidator.cc
@@ -144,7 +144,6 @@ HLTMuonValidator::stepLabels(const vector<string>& modules) {
                 steps.push_back("TkHcalIso");
         }
         else if (modules[i].find("TkFiltered") != string::npos){
-            steps.push_back("TkL2");
             steps.push_back("Tk");
         }
         else if (modules[i].find("L3") != string::npos)


### PR DESCRIPTION
This PR is the backport of PR #9145 in 74X.
It is a fix in the filter matching which permits to compute per filter efficiencies in the muon HLT validation DQM
