### PR TITLE
Remove cerr left in inadvertently

### DIFF
--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -821,7 +821,6 @@ namespace edm {
     if(fileNameHash == 0U)  {
       fileNameHash = lfnHash_;
     }
-    std::cerr << "Sequential event: " << cache.id() << std::endl;
   }
 
   void


### PR DESCRIPTION
In a recent improvement, PR #9091, I inadvertently left in a std::cerr statement I used to debug it.
This trivial PR simply removes the statement, which was causing IB logs to fill up.
