### PR TITLE
New Electron Validation Histos

### DIFF
--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -60,9 +60,9 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   }/**/
 
   // profiles from 2D histos
-  profileX(iBooker, iGetter, "EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}");
-  profileX(iBooker, iGetter, "EoEtrueVsrecOfflineVertices_barrel","E/Etrue vs number of primary vertices , barrel","N_{primary vertices}","E/E_{true}");
-  profileX(iBooker, iGetter, "EoEtrueVsrecOfflineVertices_endcaps","E/Etrue vs number of primary vertices , endcaps","N_{primary vertices}","E/E_{true}");
+  profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}");
+  profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices_barrel","E/Etrue vs number of primary vertices , barrel","N_{primary vertices}","E/E_{true}");
+  profileX(iBooker, iGetter, "scl_EoEtrueVsrecOfflineVertices_endcaps","E/Etrue vs number of primary vertices , endcaps","N_{primary vertices}","E/E_{true}");
 
   profileX(iBooker, iGetter, "PoPtrueVsEta","mean ele momentum / gen momentum vs eta","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPtrueVsPhi","mean ele momentum / gen momentum vs phi","#phi (rad)","<P/P_{gen}>");

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalPostValidator.cc
@@ -60,6 +60,10 @@ void ElectronMcSignalPostValidator::finalize( DQMStore::IBooker & iBooker, DQMSt
   }/**/
 
   // profiles from 2D histos
+  profileX(iBooker, iGetter, "EoEtrueVsrecOfflineVertices","E/Etrue vs number of primary vertices","N_{primary vertices}","E/E_{true}");
+  profileX(iBooker, iGetter, "EoEtrueVsrecOfflineVertices_barrel","E/Etrue vs number of primary vertices , barrel","N_{primary vertices}","E/E_{true}");
+  profileX(iBooker, iGetter, "EoEtrueVsrecOfflineVertices_endcaps","E/Etrue vs number of primary vertices , endcaps","N_{primary vertices}","E/E_{true}");
+
   profileX(iBooker, iGetter, "PoPtrueVsEta","mean ele momentum / gen momentum vs eta","#eta","<P/P_{gen}>");
   profileX(iBooker, iGetter, "PoPtrueVsPhi","mean ele momentum / gen momentum vs phi","#phi (rad)","<P/P_{gen}>");
   profileX(iBooker, iGetter, "EoEtruePfVsEg","mean pflow sc energy / true energy vs e/g sc energy","E/E_{gen} (e/g)","<E/E_{gen}> (pflow)") ;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -173,9 +173,6 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_recTrackNum = 0 ;
   h1_recSeedNum = 0 ;
   h1_recOfflineVertices = 0 ;
-  h2_EoEtrueVsrecOfflineVertices = 0 ; // new 2015.15.05
-  h2_EoEtrueVsrecOfflineVertices_barrel = 0 ; // new 2015.15.05
-  h2_EoEtrueVsrecOfflineVertices_endcaps = 0 ; // new 2015.15.05
 
   h1_mc_Eta = 0 ;
   h1_mc_AbsEta = 0 ;
@@ -279,6 +276,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_EoEtrue_barrel_new_phigap = 0 ;
   h1_scl_EoEtrue_ebeegap_new = 0 ;
   h1_scl_EoEtrue_endcaps_new_deegap = 0 ;
+  h2_scl_EoEtrueVsrecOfflineVertices = 0 ; // new 2015.15.05
+  h2_scl_EoEtrueVsrecOfflineVertices_barrel = 0 ; // new 2015.15.05
+  h2_scl_EoEtrueVsrecOfflineVertices_endcaps = 0 ; // new 2015.15.05
   h1_scl_EoEtrue_endcaps_new_ringgap = 0 ;
   h1_scl_Et = 0 ;
   h2_scl_EtVsEta = 0 ;
@@ -307,6 +307,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_E5x5 = 0 ;
   h1_scl_E5x5_barrel = 0 ;
   h1_scl_E5x5_endcaps = 0 ;
+  h1_scl_Etot = 0 ; // new 2015.18.05
+  h1_scl_Etot_barrel = 0 ; // new 2015.18.05
+  h1_scl_Etot_endcaps = 0 ; // new 2015.18.05
 
   h1_ele_ambiguousTracks = 0 ;
   h2_ele_ambiguousTracksVsEta = 0 ;
@@ -547,9 +550,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_recTrackNum = bookH1(iBooker, "recTrackNum","# rec gsf tracks",41, -0.5,40.5,"N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum","# rec electron seeds",101, -0.5,100.5,"N_{seed}");
   h1_recOfflineVertices = bookH1(iBooker, "recOfflineVertices","# rec Offline Primary Vertices",61, -0.5,60.5,"N_{Vertices}"); 
-  h2_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
-  h2_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
-  h2_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_scl_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_scl_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
 
   // mc
   setBookPrefix("h_mc") ;
@@ -722,6 +725,10 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_E5x5_barrel = bookH1withSumw2(iBooker, "E5x5_barrel","ele supercluster energy in 5x5 barrel",p_nbin,0.,p_max,"E5x5 (GeV)","Events","ELE_LOGY E1 P");
   h1_scl_E5x5_endcaps = bookH1withSumw2(iBooker, "E5x5_endcaps","ele supercluster energy in 5x5 endcaps",p_nbin,0.,p_max,"E5x5 (GeV)","Events","ELE_LOGY E1 P");
   h2_scl_EoEtruePfVsEg = bookH2(iBooker, "EoEtruePfVsEg","ele supercluster energy / gen energy pflow vs eg",75,-0.1,1.4, 75, -0.1, 1.4,"E/E_{gen} (e/g)","E/E_{gen} (pflow)") ;
+//  h1_scl_Etot = bookH1(iBooker, "Etot","Total basicclusters energy",50,0.2,1.2,"E_{tot}");
+  h1_scl_Etot = bookH1withSumw2(iBooker, "Etot","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_Etot_barrel = bookH1withSumw2(iBooker, "Etot","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_Etot_endcaps = bookH1withSumw2(iBooker, "Etot","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
 
   // matched electron, gsf tracks
   setBookPrefix("h_ele") ;
@@ -1300,9 +1307,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_vertexPtVsPhi->Fill(  bestGsfElectron.phi(),bestGsfElectron.pt() );
     h1_ele_vertexEta->Fill( bestGsfElectron.eta() );
     
-    h2_EoEtrueVsrecOfflineVertices->Fill( (*vertexCollectionHandle).size(), bestGsfElectron.ecalEnergy()/mcIter->p() );
-    if (bestGsfElectron.isEB())  h2_EoEtrueVsrecOfflineVertices_barrel->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
-    if (bestGsfElectron.isEE())  h2_EoEtrueVsrecOfflineVertices_endcaps->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    h2_scl_EoEtrueVsrecOfflineVertices->Fill( (*vertexCollectionHandle).size(), bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEB())  h2_scl_EoEtrueVsrecOfflineVertices_barrel->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEE())  h2_scl_EoEtrueVsrecOfflineVertices_endcaps->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
     
     // generated distributions for matched electrons
     h1_mc_Pt_matched->Fill( mcIter->pt() );
@@ -1406,6 +1413,16 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     if (!bestGsfElectron.parentSuperCluster().isNull()) pfEnergy = bestGsfElectron.parentSuperCluster()->energy();
     h2_scl_EoEtruePfVsEg->Fill(bestGsfElectron.ecalEnergy()/mcIter->p(),pfEnergy/mcIter->p());
 
+    float Etot = 0.; 
+    CaloCluster_iterator it = bestGsfElectron.superCluster()->clustersBegin();
+    CaloCluster_iterator itend = bestGsfElectron.superCluster()->clustersEnd();
+    for(; it !=itend;++it) {
+        Etot += (*it)->energy();
+    }
+    h1_scl_Etot->Fill( Etot/mcIter->p() );
+    if (bestGsfElectron.isEB()) h1_scl_Etot_barrel->Fill( Etot/mcIter->p() );
+    if (bestGsfElectron.isEE()) h1_scl_Etot_endcaps->Fill( Etot/mcIter->p() );
+    
     // track related distributions
     h1_ele_ambiguousTracks->Fill( bestGsfElectron.ambiguousGsfTracksSize() );
     h2_ele_ambiguousTracksVsEta->Fill( bestGsfElectron.eta(), bestGsfElectron.ambiguousGsfTracksSize() );

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -727,8 +727,8 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h2_scl_EoEtruePfVsEg = bookH2(iBooker, "EoEtruePfVsEg","ele supercluster energy / gen energy pflow vs eg",75,-0.1,1.4, 75, -0.1, 1.4,"E/E_{gen} (e/g)","E/E_{gen} (pflow)") ;
 //  h1_scl_Etot = bookH1(iBooker, "Etot","Total basicclusters energy",50,0.2,1.2,"E_{tot}");
   h1_scl_Etot = bookH1withSumw2(iBooker, "Etot","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
-  h1_scl_Etot_barrel = bookH1withSumw2(iBooker, "Etot","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
-  h1_scl_Etot_endcaps = bookH1withSumw2(iBooker, "Etot","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_Etot_barrel = bookH1withSumw2(iBooker, "Etot_barrel","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_Etot_endcaps = bookH1withSumw2(iBooker, "Etot_endcaps","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
 
   // matched electron, gsf tracks
   setBookPrefix("h_ele") ;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -276,9 +276,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_EoEtrue_barrel_new_phigap = 0 ;
   h1_scl_EoEtrue_ebeegap_new = 0 ;
   h1_scl_EoEtrue_endcaps_new_deegap = 0 ;
-  h2_EoEtrueVsrecOfflineVertices = 0 ; // new 2015.15.05
-  h2_EoEtrueVsrecOfflineVertices_barrel = 0 ; // new 2015.15.05
-  h2_EoEtrueVsrecOfflineVertices_endcaps = 0 ; // new 2015.15.05
+  h2_scl_EoEtrueVsrecOfflineVertices = 0 ; // new 2015.15.05
+  h2_scl_EoEtrueVsrecOfflineVertices_barrel = 0 ; // new 2015.15.05
+  h2_scl_EoEtrueVsrecOfflineVertices_endcaps = 0 ; // new 2015.15.05
   h1_scl_EoEtrue_endcaps_new_ringgap = 0 ;
   h1_scl_Et = 0 ;
   h2_scl_EtVsEta = 0 ;
@@ -307,9 +307,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_E5x5 = 0 ;
   h1_scl_E5x5_barrel = 0 ;
   h1_scl_E5x5_endcaps = 0 ;
-  h1_scl_Etot = 0 ; // new 2015.18.05
-  h1_scl_Etot_barrel = 0 ; // new 2015.18.05
-  h1_scl_Etot_endcaps = 0 ; // new 2015.18.05
+  h1_scl_bcl_EtotoEtrue = 0 ; // new 2015.18.05
+  h1_scl_bcl_EtotoEtrue_barrel = 0 ; // new 2015.18.05
+  h1_scl_bcl_EtotoEtrue_endcaps = 0 ; // new 2015.18.05
 
   h1_ele_ambiguousTracks = 0 ;
   h2_ele_ambiguousTracksVsEta = 0 ;
@@ -550,9 +550,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_recTrackNum = bookH1(iBooker, "recTrackNum","# rec gsf tracks",41, -0.5,40.5,"N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum","# rec electron seeds",101, -0.5,100.5,"N_{seed}");
   h1_recOfflineVertices = bookH1(iBooker, "recOfflineVertices","# rec Offline Primary Vertices",61, -0.5,60.5,"N_{Vertices}"); 
-  h2_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
-  h2_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
-  h2_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "scl_EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_scl_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "scl_EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_scl_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "scl_EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
 
   // mc
   setBookPrefix("h_mc") ;
@@ -725,10 +725,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_E5x5_barrel = bookH1withSumw2(iBooker, "E5x5_barrel","ele supercluster energy in 5x5 barrel",p_nbin,0.,p_max,"E5x5 (GeV)","Events","ELE_LOGY E1 P");
   h1_scl_E5x5_endcaps = bookH1withSumw2(iBooker, "E5x5_endcaps","ele supercluster energy in 5x5 endcaps",p_nbin,0.,p_max,"E5x5 (GeV)","Events","ELE_LOGY E1 P");
   h2_scl_EoEtruePfVsEg = bookH2(iBooker, "EoEtruePfVsEg","ele supercluster energy / gen energy pflow vs eg",75,-0.1,1.4, 75, -0.1, 1.4,"E/E_{gen} (e/g)","E/E_{gen} (pflow)") ;
-//  h1_scl_Etot = bookH1(iBooker, "Etot","Total basicclusters energy",50,0.2,1.2,"E_{tot}");
-  h1_scl_Etot = bookH1withSumw2(iBooker, "Etot","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
-  h1_scl_Etot_barrel = bookH1withSumw2(iBooker, "Etot_barrel","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
-  h1_scl_Etot_endcaps = bookH1withSumw2(iBooker, "Etot_endcaps","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_bcl_EtotoEtrue = bookH1withSumw2(iBooker, "bcl_EtotoEtrue","Total basicclusters energy",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_bcl_EtotoEtrue_barrel = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_barrel","Total basicclusters energy , barrel",50,0.2,1.2,"E/E_{gen}");
+  h1_scl_bcl_EtotoEtrue_endcaps = bookH1withSumw2(iBooker, "bcl_EtotoEtrue_endcaps","Total basicclusters energy , endcaps",50,0.2,1.2,"E/E_{gen}");
 
   // matched electron, gsf tracks
   setBookPrefix("h_ele") ;
@@ -1307,9 +1306,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_vertexPtVsPhi->Fill(  bestGsfElectron.phi(),bestGsfElectron.pt() );
     h1_ele_vertexEta->Fill( bestGsfElectron.eta() );
     
-    h2_EoEtrueVsrecOfflineVertices->Fill( (*vertexCollectionHandle).size(), bestGsfElectron.ecalEnergy()/mcIter->p() );
-    if (bestGsfElectron.isEB())  h2_EoEtrueVsrecOfflineVertices_barrel->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
-    if (bestGsfElectron.isEE())  h2_EoEtrueVsrecOfflineVertices_endcaps->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    h2_scl_EoEtrueVsrecOfflineVertices->Fill( (*vertexCollectionHandle).size(), bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEB())  h2_scl_EoEtrueVsrecOfflineVertices_barrel->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEE())  h2_scl_EoEtrueVsrecOfflineVertices_endcaps->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
     
     // generated distributions for matched electrons
     h1_mc_Pt_matched->Fill( mcIter->pt() );
@@ -1419,9 +1418,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     for(; it !=itend;++it) {
         Etot += (*it)->energy();
     }
-    h1_scl_Etot->Fill( Etot/mcIter->p() );
-    if (bestGsfElectron.isEB()) h1_scl_Etot_barrel->Fill( Etot/mcIter->p() );
-    if (bestGsfElectron.isEE()) h1_scl_Etot_endcaps->Fill( Etot/mcIter->p() );
+    h1_scl_bcl_EtotoEtrue->Fill( Etot/mcIter->p() );
+    if (bestGsfElectron.isEB()) h1_scl_bcl_EtotoEtrue_barrel->Fill( Etot/mcIter->p() );
+    if (bestGsfElectron.isEE()) h1_scl_bcl_EtotoEtrue_endcaps->Fill( Etot/mcIter->p() );
     
     // track related distributions
     h1_ele_ambiguousTracks->Fill( bestGsfElectron.ambiguousGsfTracksSize() );

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -276,9 +276,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_EoEtrue_barrel_new_phigap = 0 ;
   h1_scl_EoEtrue_ebeegap_new = 0 ;
   h1_scl_EoEtrue_endcaps_new_deegap = 0 ;
-  h2_scl_EoEtrueVsrecOfflineVertices = 0 ; // new 2015.15.05
-  h2_scl_EoEtrueVsrecOfflineVertices_barrel = 0 ; // new 2015.15.05
-  h2_scl_EoEtrueVsrecOfflineVertices_endcaps = 0 ; // new 2015.15.05
+  h2_EoEtrueVsrecOfflineVertices = 0 ; // new 2015.15.05
+  h2_EoEtrueVsrecOfflineVertices_barrel = 0 ; // new 2015.15.05
+  h2_EoEtrueVsrecOfflineVertices_endcaps = 0 ; // new 2015.15.05
   h1_scl_EoEtrue_endcaps_new_ringgap = 0 ;
   h1_scl_Et = 0 ;
   h2_scl_EtVsEta = 0 ;
@@ -550,9 +550,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_recTrackNum = bookH1(iBooker, "recTrackNum","# rec gsf tracks",41, -0.5,40.5,"N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum","# rec electron seeds",101, -0.5,100.5,"N_{seed}");
   h1_recOfflineVertices = bookH1(iBooker, "recOfflineVertices","# rec Offline Primary Vertices",61, -0.5,60.5,"N_{Vertices}"); 
-  h2_scl_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
-  h2_scl_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
-  h2_scl_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
 
   // mc
   setBookPrefix("h_mc") ;
@@ -1307,9 +1307,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_vertexPtVsPhi->Fill(  bestGsfElectron.phi(),bestGsfElectron.pt() );
     h1_ele_vertexEta->Fill( bestGsfElectron.eta() );
     
-    h2_scl_EoEtrueVsrecOfflineVertices->Fill( (*vertexCollectionHandle).size(), bestGsfElectron.ecalEnergy()/mcIter->p() );
-    if (bestGsfElectron.isEB())  h2_scl_EoEtrueVsrecOfflineVertices_barrel->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
-    if (bestGsfElectron.isEE())  h2_scl_EoEtrueVsrecOfflineVertices_endcaps->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    h2_EoEtrueVsrecOfflineVertices->Fill( (*vertexCollectionHandle).size(), bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEB())  h2_EoEtrueVsrecOfflineVertices_barrel->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEE())  h2_EoEtrueVsrecOfflineVertices_endcaps->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
     
     // generated distributions for matched electrons
     h1_mc_Pt_matched->Fill( mcIter->pt() );

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.cc
@@ -172,7 +172,10 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_recCoreNum = 0 ;
   h1_recTrackNum = 0 ;
   h1_recSeedNum = 0 ;
-  h1_recOfflineVertices = 0 ;  // new 2015.04.02
+  h1_recOfflineVertices = 0 ;
+  h2_EoEtrueVsrecOfflineVertices = 0 ; // new 2015.15.05
+  h2_EoEtrueVsrecOfflineVertices_barrel = 0 ; // new 2015.15.05
+  h2_EoEtrueVsrecOfflineVertices_endcaps = 0 ; // new 2015.15.05
 
   h1_mc_Eta = 0 ;
   h1_mc_AbsEta = 0 ;
@@ -292,9 +295,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_scl_SigIEtaIEta = 0 ;
   h1_scl_SigIEtaIEta_barrel = 0 ;
   h1_scl_SigIEtaIEta_endcaps = 0 ;
-  h1_scl_full5x5_sigmaIetaIeta = 0 ; // new 2014.01.12
-  h1_scl_full5x5_sigmaIetaIeta_barrel = 0 ; // new 2014.01.12
-  h1_scl_full5x5_sigmaIetaIeta_endcaps = 0 ; // new 2014.01.12
+  h1_scl_full5x5_sigmaIetaIeta = 0 ;
+  h1_scl_full5x5_sigmaIetaIeta_barrel = 0 ;
+  h1_scl_full5x5_sigmaIetaIeta_endcaps = 0 ;
   h1_scl_E1x5 = 0 ;
   h1_scl_E1x5_barrel = 0 ;
   h1_scl_E1x5_endcaps = 0 ;
@@ -470,9 +473,9 @@ ElectronMcSignalValidator::ElectronMcSignalValidator( const edm::ParameterSet & 
   h1_ele_fbrem = 0 ;
   p1_ele_fbremVsEta_mode = 0 ;
   p1_ele_fbremVsEta_mean = 0 ;
-  h1_ele_superclusterfbrem = 0 ; // new 2014.02.12
-  h1_ele_superclusterfbrem_barrel = 0 ; // new 2014.02.12
-  h1_ele_superclusterfbrem_endcaps = 0 ; // new 2014.02.12
+  h1_ele_superclusterfbrem = 0 ;
+  h1_ele_superclusterfbrem_barrel = 0 ;
+  h1_ele_superclusterfbrem_endcaps = 0 ;
   h2_ele_PinVsPoutGolden_mode = 0 ;
   h2_ele_PinVsPoutShowering_mode = 0 ;
   h2_ele_PinVsPoutGolden_mean = 0 ;
@@ -543,7 +546,10 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_recCoreNum = bookH1(iBooker, "recCoreNum","# rec electron cores",21, -0.5,20.5,"N_{core}");
   h1_recTrackNum = bookH1(iBooker, "recTrackNum","# rec gsf tracks",41, -0.5,40.5,"N_{track}");
   h1_recSeedNum = bookH1(iBooker, "recSeedNum","# rec electron seeds",101, -0.5,100.5,"N_{seed}");
-  h1_recOfflineVertices = bookH1(iBooker, "recOfflineVertices","# rec Offline Primary Vertices",61, -0.5,60.5,"N_{Vertices}");  // new 2015.04.02
+  h1_recOfflineVertices = bookH1(iBooker, "recOfflineVertices","# rec Offline Primary Vertices",61, -0.5,60.5,"N_{Vertices}"); 
+  h2_EoEtrueVsrecOfflineVertices = bookH2(iBooker, "EoEtrueVsrecOfflineVertices", "E/Etrue vs number of primary vertices", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_EoEtrueVsrecOfflineVertices_barrel = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_barrel", "E/Etrue vs number of primary , barrel", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
+  h2_EoEtrueVsrecOfflineVertices_endcaps = bookH2(iBooker, "EoEtrueVsrecOfflineVertices_endcaps", "E/Etrue vs number of primary , endcaps", 10, 0., 50., 50, 0., 2.5, "N_{primary vertices}", "E/E_{true}");
 
   // mc
   setBookPrefix("h_mc") ;
@@ -703,11 +709,9 @@ void ElectronMcSignalValidator::bookHistograms( DQMStore::IBooker & iBooker, edm
   h1_scl_SigIEtaIEta = bookH1withSumw2(iBooker, "sigietaieta","ele supercluster sigma ieta ieta",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_SigIEtaIEta_barrel = bookH1withSumw2(iBooker, "sigietaieta_barrel","ele supercluster sigma ieta ieta, barrel",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_SigIEtaIEta_endcaps = bookH1withSumw2(iBooker, "sigietaieta_endcaps","ele supercluster sigma ieta ieta, endcaps",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
-// new 2014.01.12
   h1_scl_full5x5_sigmaIetaIeta = bookH1withSumw2(iBooker, "full5x5_sigietaieta","ele supercluster full5x5 sigma ieta ieta",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_full5x5_sigmaIetaIeta_barrel = bookH1withSumw2(iBooker, "full5x5_sigietaieta_barrel","ele supercluster full5x5 sigma ieta ieta, barrel",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
   h1_scl_full5x5_sigmaIetaIeta_endcaps = bookH1withSumw2(iBooker, "full5x5_sigietaieta_endcaps","ele supercluster full5x5 sigma ieta ieta, endcaps",100,0.,0.05,"#sigma_{i#eta i#eta}","Events","ELE_LOGY E1 P");
-// new 2014.01.12
   h1_scl_E1x5 = bookH1withSumw2(iBooker, "E1x5","ele supercluster energy in 1x5",p_nbin,0., p_max,"E1x5 (GeV)","Events","ELE_LOGY E1 P");
   h1_scl_E1x5_barrel = bookH1withSumw2(iBooker, "E1x5_barrel","ele supercluster energy in 1x5 barrel",p_nbin,0., p_max,"E1x5 (GeV)","Events","ELE_LOGY E1 P");
   h1_scl_E1x5_endcaps = bookH1withSumw2(iBooker, "E1x5_endcaps","ele supercluster energy in 1x5 endcaps",p_nbin,0., p_max,"E1x5 (GeV)","Events","ELE_LOGY E1 P");
@@ -1020,7 +1024,6 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
   edm::Handle<edm::ValueMap<double> > isoFromDepsHcal04Handle;
   iEvent.getByToken( isoFromDepsHcal04Tag_, isoFromDepsHcal04Handle);
 
-  /* new 2015.03.02 */
   edm::Handle<reco::VertexCollection> vertexCollectionHandle;
   iEvent.getByToken(offlineVerticesCollection_, vertexCollectionHandle);
   if(!vertexCollectionHandle.isValid()) 
@@ -1029,7 +1032,6 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
   {
       edm::LogInfo("ElectronMcSignalValidator::analyze") << "vertexCollectionHandle OK" ;
   }
-  /* end new */
   
   edm::LogInfo("ElectronMcSignalValidator::analyze")
     <<"Treating event "<<iEvent.id()
@@ -1038,7 +1040,7 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
   h1_recCoreNum->Fill((*gsfElectronCores).size());
   h1_recTrackNum->Fill((*gsfElectronTracks).size());
   h1_recSeedNum->Fill((*gsfElectronSeeds).size());
-  h1_recOfflineVertices->Fill((*vertexCollectionHandle).size()); // new 2015.04.02
+  h1_recOfflineVertices->Fill((*vertexCollectionHandle).size());
 
 
   //===============================================
@@ -1297,6 +1299,11 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h2_ele_vertexPtVsEta->Fill(  bestGsfElectron.eta(),bestGsfElectron.pt() );
     h2_ele_vertexPtVsPhi->Fill(  bestGsfElectron.phi(),bestGsfElectron.pt() );
     h1_ele_vertexEta->Fill( bestGsfElectron.eta() );
+    
+    h2_EoEtrueVsrecOfflineVertices->Fill( (*vertexCollectionHandle).size(), bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEB())  h2_EoEtrueVsrecOfflineVertices_barrel->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    if (bestGsfElectron.isEE())  h2_EoEtrueVsrecOfflineVertices_endcaps->Fill( (*vertexCollectionHandle).size(),bestGsfElectron.ecalEnergy()/mcIter->p() );
+    
     // generated distributions for matched electrons
     h1_mc_Pt_matched->Fill( mcIter->pt() );
     h1_mc_Phi_matched->Fill( mcIter->phi() );
@@ -1383,11 +1390,9 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
     h1_scl_SigIEtaIEta->Fill(bestGsfElectron.scSigmaIEtaIEta());
     if (bestGsfElectron.isEB()) h1_scl_SigIEtaIEta_barrel->Fill(bestGsfElectron.scSigmaIEtaIEta());
     if (bestGsfElectron.isEE()) h1_scl_SigIEtaIEta_endcaps->Fill(bestGsfElectron.scSigmaIEtaIEta());
-// new 2014.01.12
     h1_scl_full5x5_sigmaIetaIeta->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
     if (bestGsfElectron.isEB()) h1_scl_full5x5_sigmaIetaIeta_barrel->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
     if (bestGsfElectron.isEE()) h1_scl_full5x5_sigmaIetaIeta_endcaps->Fill(bestGsfElectron.full5x5_sigmaIetaIeta());
-// new 2014.01.12
     h1_scl_E1x5->Fill(bestGsfElectron.scE1x5());
     if (bestGsfElectron.isEB()) h1_scl_E1x5_barrel->Fill(bestGsfElectron.scE1x5());
     if (bestGsfElectron.isEE()) h1_scl_E1x5_endcaps->Fill(bestGsfElectron.scE1x5());
@@ -1596,7 +1601,6 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
       h1_ele_fbrem_endcaps->Fill(fbrem_mode_endcaps);
      }
 
-// new 2014/02/12
     double superclusterfbrem_mode =  bestGsfElectron.superClusterFbrem();
     h1_ele_superclusterfbrem->Fill(superclusterfbrem_mode);
 
@@ -1611,7 +1615,6 @@ void ElectronMcSignalValidator::analyze( const edm::Event & iEvent, const edm::E
       double superclusterfbrem_mode_endcaps = bestGsfElectron.superClusterFbrem();
       h1_ele_superclusterfbrem_endcaps->Fill(superclusterfbrem_mode_endcaps);
      }
-// new 2014/02/12
 
     p1_ele_fbremVsEta_mode->Fill(bestGsfElectron.eta(),fbrem_mode);
 

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -36,7 +36,7 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     edm::EDGetTokenT<reco::GsfElectronCoreCollection> electronCoreCollection_;
     edm::EDGetTokenT<reco::GsfTrackCollection> electronTrackCollection_;
     edm::EDGetTokenT<reco::ElectronSeedCollection> electronSeedCollection_;
-    edm::EDGetTokenT<reco::VertexCollection> offlineVerticesCollection_;    // new 03/02/2015 
+    edm::EDGetTokenT<reco::VertexCollection> offlineVerticesCollection_; 
     edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_ ;
     bool readAOD_;
 
@@ -96,7 +96,10 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_recCoreNum;
     MonitorElement *h1_recTrackNum;
     MonitorElement *h1_recSeedNum;
-    MonitorElement *h1_recOfflineVertices; // new 2015.04.02
+    MonitorElement *h1_recOfflineVertices; 
+    MonitorElement *h2_EoEtrueVsrecOfflineVertices; // new 2015.15.05
+    MonitorElement *h2_EoEtrueVsrecOfflineVertices_barrel; // new 2015.15.05
+    MonitorElement *h2_EoEtrueVsrecOfflineVertices_endcaps; // new 2015.15.05
 
     MonitorElement *h1_mc_Eta;
     MonitorElement *h1_mc_AbsEta;
@@ -224,9 +227,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_scl_SigIEtaIEta;
     MonitorElement *h1_scl_SigIEtaIEta_barrel;
     MonitorElement *h1_scl_SigIEtaIEta_endcaps;
-    MonitorElement *h1_scl_full5x5_sigmaIetaIeta; // new 2014.01.12
-    MonitorElement *h1_scl_full5x5_sigmaIetaIeta_barrel; // new 2014.01.12
-    MonitorElement *h1_scl_full5x5_sigmaIetaIeta_endcaps; // new 2014.01.12
+    MonitorElement *h1_scl_full5x5_sigmaIetaIeta; 
+    MonitorElement *h1_scl_full5x5_sigmaIetaIeta_barrel; 
+    MonitorElement *h1_scl_full5x5_sigmaIetaIeta_endcaps; 
     MonitorElement *h1_scl_E1x5;
     MonitorElement *h1_scl_E1x5_barrel;
     MonitorElement *h1_scl_E1x5_endcaps;
@@ -403,9 +406,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_ele_fbrem;
     MonitorElement *h1_ele_fbrem_barrel;
     MonitorElement *h1_ele_fbrem_endcaps;
-    MonitorElement *h1_ele_superclusterfbrem; // new 2014.02.12
-    MonitorElement *h1_ele_superclusterfbrem_barrel; // new 2014.02.12
-    MonitorElement *h1_ele_superclusterfbrem_endcaps; // new 2014.02.12
+    MonitorElement *h1_ele_superclusterfbrem; 
+    MonitorElement *h1_ele_superclusterfbrem_barrel; 
+    MonitorElement *h1_ele_superclusterfbrem_endcaps; 
 
     MonitorElement *p1_ele_fbremVsEta_mode;
     MonitorElement *p1_ele_fbremVsEta_mean;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -97,9 +97,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_recTrackNum;
     MonitorElement *h1_recSeedNum;
     MonitorElement *h1_recOfflineVertices; 
-    MonitorElement *h2_EoEtrueVsrecOfflineVertices; // new 2015.15.05
-    MonitorElement *h2_EoEtrueVsrecOfflineVertices_barrel; // new 2015.15.05
-    MonitorElement *h2_EoEtrueVsrecOfflineVertices_endcaps; // new 2015.15.05
+    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices; // new 2015.15.05
+    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_barrel; // new 2015.15.05
+    MonitorElement *h2_scl_EoEtrueVsrecOfflineVertices_endcaps; // new 2015.15.05
 
     MonitorElement *h1_mc_Eta;
     MonitorElement *h1_mc_AbsEta;
@@ -239,6 +239,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_scl_E5x5;
     MonitorElement *h1_scl_E5x5_barrel;
     MonitorElement *h1_scl_E5x5_endcaps;
+    MonitorElement *h1_scl_Etot; // new 2015.18.05
+    MonitorElement *h1_scl_Etot_barrel; // new 2015.18.05
+    MonitorElement *h1_scl_Etot_endcaps; // new 2015.18.05
 
     MonitorElement *h1_ele_ambiguousTracks;
     MonitorElement *h2_ele_ambiguousTracksVsEta;

--- a/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
+++ b/Validation/RecoEgamma/plugins/ElectronMcSignalValidator.h
@@ -239,9 +239,9 @@ class ElectronMcSignalValidator : public ElectronDqmAnalyzerBase
     MonitorElement *h1_scl_E5x5;
     MonitorElement *h1_scl_E5x5_barrel;
     MonitorElement *h1_scl_E5x5_endcaps;
-    MonitorElement *h1_scl_Etot; // new 2015.18.05
-    MonitorElement *h1_scl_Etot_barrel; // new 2015.18.05
-    MonitorElement *h1_scl_Etot_endcaps; // new 2015.18.05
+    MonitorElement *h1_scl_bcl_EtotoEtrue; // new 2015.18.05
+    MonitorElement *h1_scl_bcl_EtotoEtrue_barrel; // new 2015.18.05
+    MonitorElement *h1_scl_bcl_EtotoEtrue_endcaps; // new 2015.18.05
 
     MonitorElement *h1_ele_ambiguousTracks;
     MonitorElement *h2_ele_ambiguousTracksVsEta;

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -48,9 +48,9 @@ ElectronMcSignalValidator/h_scl_EoEtrue_barrel_new_phigap   1 1 1 0
 ElectronMcSignalValidator/h_scl_EoEtrue_ebeegap_new         1 1 1 0
 ElectronMcSignalValidator/h_scl_EoEtrue_endcaps_new         1 1 0 0
 ElectronMcSignalValidator/h_scl_EoEtrue_endcaps_new_deegap  1 1 1 0
-ElectronMcSignalValidator/h_EoEtrueVsrecOfflineVertices_pfx 1 1 0 0
-ElectronMcSignalValidator/h_EoEtrueVsrecOfflineVertices_barrel_pfx 1 1 0 0
-ElectronMcSignalValidator/h_EoEtrueVsrecOfflineVertices_endcaps_pfx 1 1 1 0
+ElectronMcSignalValidator/h_scl_EoEtrueVsrecOfflineVertices_pfx 1 1 0 0
+ElectronMcSignalValidator/h_scl_EoEtrueVsrecOfflineVertices_barrel_pfx 1 1 0 0
+ElectronMcSignalValidator/h_scl_EoEtrueVsrecOfflineVertices_endcaps_pfx 1 1 1 0
 ElectronMcSignalValidator/h_ele_EtaMnEtaTrue                1 1 0 0
 ElectronMcSignalValidator/h_ele_EtaMnEtaTrue_barrel         1 1 0 0
 ElectronMcSignalValidator/h_ele_EtaMnEtaTrue_endcaps        1 1 1 0
@@ -129,6 +129,9 @@ ElectronMcSignalValidator/h_scl_E2x5max_endcaps             1 1 1 0
 ElectronMcSignalValidator/h_scl_E5x5                        1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_barrel                 1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_endcaps                1 1 1 0
+ElectronMcSignalValidator/h_scl_Etot                        1 1 0 0
+ElectronMcSignalValidator/h_scl_Etot_barrel                 1 1 0 0
+ElectronMcSignalValidator/h_scl_Etot_endcaps               1 1 1 0
 ElectronMcSignalValidator/h_ele_HoEVsEta_pfx                0 1 1 1
 
 Electron track variables

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -34,7 +34,7 @@ Comparison with MC truth (residuals)
 ElectronMcSignalValidator/h_ele_ChargeMnChargeTrue          1 1 1 0
 ElectronMcSignalValidator/h_ele_PoPtrue                     1 1 0 0
 ElectronMcSignalValidator/h_ele_PoPtrue_barrel              1 1 0 0
-ElectronMcSignalValidator/h_ele_PoPtrue_endcaps             1	1 1 0
+ElectronMcSignalValidator/h_ele_PoPtrue_endcaps             1 1 1 0
 ElectronMcSignalValidator/h_ele_PoPtrue_golden_barrel       1 1 0 0
 ElectronMcSignalValidator/h_ele_PoPtrue_golden_endcaps      1 1 1 0
 ElectronMcSignalValidator/h_ele_PoPtrue_showering_barrel    1 1 0 0
@@ -129,9 +129,9 @@ ElectronMcSignalValidator/h_scl_E2x5max_endcaps             1 1 1 0
 ElectronMcSignalValidator/h_scl_E5x5                        1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_barrel                 1 1 0 0
 ElectronMcSignalValidator/h_scl_E5x5_endcaps                1 1 1 0
-ElectronMcSignalValidator/h_scl_Etot                        1 1 0 0
-ElectronMcSignalValidator/h_scl_Etot_barrel                 1 1 0 0
-ElectronMcSignalValidator/h_scl_Etot_endcaps               1 1 1 0
+ElectronMcSignalValidator/h_scl_bcl_EtotoEtrue              1 1 0 0
+ElectronMcSignalValidator/h_scl_bcl_EtotoEtrue_barrel       1 1 0 0
+ElectronMcSignalValidator/h_scl_bcl_EtotoEtrue_endcaps      1 1 1 0
 ElectronMcSignalValidator/h_ele_HoEVsEta_pfx                0 1 1 1
 
 Electron track variables

--- a/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
+++ b/Validation/RecoEgamma/test/ElectronMcSignalHistos.txt
@@ -22,7 +22,7 @@ ElectronMcSignalValidator/h_ele_Et                          1 1 1 0
 ElectronMcSignalValidator/h_ele_outerP_mode                 1 1 1 0
 ElectronMcSignalValidator/h_ele_outerPt_mode                1 1 1 0
 ElectronMcSignalValidator/h_ele_vertexPtVsEta_pfx           0 1 1 0
-ElectronMcSignalValidator/h_ele_ecalEnergyError		    1 1 0 0
+ElectronMcSignalValidator/h_ele_ecalEnergyError		        1 1 0 0
 ElectronMcSignalValidator/h_ele_ecalEnergyError_barrel      1 1 0 0
 ElectronMcSignalValidator/h_ele_ecalEnergyError_endcaps     1 1 1 0
 ElectronMcSignalValidator/h_ele_combinedP4Error             1 1 0 0
@@ -48,6 +48,9 @@ ElectronMcSignalValidator/h_scl_EoEtrue_barrel_new_phigap   1 1 1 0
 ElectronMcSignalValidator/h_scl_EoEtrue_ebeegap_new         1 1 1 0
 ElectronMcSignalValidator/h_scl_EoEtrue_endcaps_new         1 1 0 0
 ElectronMcSignalValidator/h_scl_EoEtrue_endcaps_new_deegap  1 1 1 0
+ElectronMcSignalValidator/h_EoEtrueVsrecOfflineVertices_pfx 1 1 0 0
+ElectronMcSignalValidator/h_EoEtrueVsrecOfflineVertices_barrel_pfx 1 1 0 0
+ElectronMcSignalValidator/h_EoEtrueVsrecOfflineVertices_endcaps_pfx 1 1 1 0
 ElectronMcSignalValidator/h_ele_EtaMnEtaTrue                1 1 0 0
 ElectronMcSignalValidator/h_ele_EtaMnEtaTrue_barrel         1 1 0 0
 ElectronMcSignalValidator/h_ele_EtaMnEtaTrue_endcaps        1 1 1 0

--- a/Validation/RecoEgamma/test/electronCompare.C
+++ b/Validation/RecoEgamma/test/electronCompare.C
@@ -1,5 +1,7 @@
-#include <TObjArray.h>
 #include <sstream>
+#include <TObjArray.h>
+
+using namespace std;
 
 TH1F * DivideHistos
  ( TFile * f,
@@ -22,10 +24,11 @@ TH1F * DivideHistos
   return h_res ;
  }
 
+// ( const TObjArray * tokens, TString & common ) // const with ROOT5
 void Join
  ( TObjArray * tokens, TString & common )
  {
-  tokens->Compress() ;
+  tokens->Compress() ; // if const is used with TObjArray, must be commented with ROOT6
   if (tokens->GetEntries()==0)
    { common = "" ; return ; }
   else
@@ -107,10 +110,12 @@ int electronCompare()
 
 //-----
 // AC
-//  std::cout << "red_file : C : " << CMP_RED_FILE << std::endl;
-//  std::cout << "blue_file : C : " << CMP_BLUE_FILE << std::endl;
+  std::cout << "red_file : C : " << CMP_RED_FILE << std::endl;
+  std::cout << "blue_file : C : " << CMP_BLUE_FILE << std::endl;
   std::cout << "red_release : C : " << CMP_RED_RELEASE << std::endl;
   std::cout << "blue_release : C : " << CMP_BLUE_RELEASE << std::endl;
+  std::cout << "CMP_RED_NAME : " << CMP_RED_NAME << std::endl;
+  std::cout << "CMP_BLUE_NAME : " << CMP_BLUE_NAME << std::endl;
 //-----
   
 // style:
@@ -159,6 +164,7 @@ int electronCompare()
 
   TString internal_path("DQMData/Run 1/EgammaV/Run summary/") ;
   TString old_internal_path("DQMData/EgammaV/") ;
+//  TString new_internal_path("DQMData/Run 1/EgammaV/Run summary/") ;
 
   TString file_ref_dir ;
   TFile * file_ref = 0 ;
@@ -250,8 +256,8 @@ int electronCompare()
      <<", and the "<<CMP_BLUE_NAME<<" histograms are in blue." ;*/
     web_page
      <<"<p>In all plots below"
-     <<", the "<<CMP_RED_RELEASE<<" histograms are in red"
-     <<", and the "<<CMP_BLUE_RELEASE<<" histograms are in blue." ;
+     <<", the <b><font color='red'>"<<CMP_RED_RELEASE<<"</font></b> histograms are in red"
+     <<", and the <b><font color='blue'>"<<CMP_BLUE_RELEASE<<"</font></b> histograms are in blue." ;
 /*	std::cout <<"<p>In all plots below "
      <<", the "<<CMP_RED_RELEASE<<" histograms are in red"
      <<", and the "<<CMP_BLUE_RELEASE<<" histograms are in blue." << std::endl ;*/
@@ -277,6 +283,8 @@ int electronCompare()
 
   // canvas_name std::string => TString
   TString canvas_name, histo_name, histo_full_path, gif_name, gif_path ;
+  TString Pt1000_path_extension ; Pt1000_path_extension = "ElectronMcSignalValidator/" ; // needed for comparison between new >= 740pre8 and old < 740pre8 for Pt1000
+  TString histo_full_path_Pt1000 ;
   TString short_histo_name ;
   TString first_short_histo_name, first_histo_name ;
   TString dl_short_histo_name, dl_histo_name ;
@@ -390,6 +398,8 @@ int electronCompare()
     if (first==std::string::npos) continue ;
     if (line[first]=='#') continue ;
 
+//    std::istrstream linestream(line) ;
+//    istringstream linestream(line) ;
     std::basic_istringstream<char> linestream(line) ;
     divide = 0 ; num = denom = "" ;
     linestream >> histo_path >> scaled >> err >> eol >> eoc >> divide >> num >> denom ;
@@ -416,28 +426,39 @@ int electronCompare()
     // search histo_ref
     if ( file_ref != 0 )
      {
-//      std::cout << "\n histo_full_path : " << histo_full_path << std::endl ;
-//      std::cout << "file_ref_dir : " << file_ref_dir << std::endl ;
       if (file_ref_dir.IsNull())
        { histo_full_path = histo_name ; /*std::cout << "file_ref_dir.IsNull()" << std::endl ;*/ }
       else
        { histo_full_path = file_ref_dir ; histo_full_path += histo_path.c_str() ; /*std::cout << "file_ref_dir.NotNull()" << std::endl ;*/ }
-      //std::cout << "histo_full_path : " << histo_full_path << std::endl ;
-      //histo_ref2 = (TH1 *)file_ref->Get(histo_full_path) ;
+   // WARNING
+   // the line below have to be unmasked if the reference release is prior to 740pre8 and for Pt1000
+   // before 740pre8 : DQMData/Run 1/EgammaV/Run summary/ ElectronMcSignalValidator/ histo name (same as Pt35, Pt10, ....)
+   // after 740pre8  : DQMData/Run 1/EgammaV/Run summary/ ElectronMcSignalValidatorPt1000/ histo name
+      histo_full_path_Pt1000 = file_ref_dir ; histo_full_path_Pt1000 += Pt1000_path_extension; histo_full_path_Pt1000 += histo_name ; // for Pt1000 
+   // END WARNING
+//      std::cout << "histo_full_path ref : " << histo_full_path << std::endl ;
+
       histo_ref = (TH1 *)file_ref->Get(histo_full_path) ;
-//      std::cout << "histo_ref Name : " << histo_ref->GetName() << std::endl ; // A.C. to be removed
-//      std::cout<<histo_ref->GetName()<<" has "<<histo_ref->GetName()->GetEffectiveEntries()<<" entries"
       if (histo_ref!=0)
        {
         // renaming those histograms avoid very strange bugs because they
         // have the same names as the ones loaded from the new file
         histo_ref->SetName(TString(histo_ref->GetName())+"_ref") ;
 //        std::cout << "histo_ref Name : " << histo_ref->GetName() << " - histo_new Name : " << histo_name << std::endl ; // A.C. to be removed
-  }
-      else
-       {
-        web_page<<"No <b>"<<histo_path<<"</b> for "<<CMP_BLUE_NAME<<".<br>" ;
-//        std::cout<<"No "<<histo_path<<" for "<<CMP_BLUE_NAME<<std::endl ;
+      }
+      else // no histo
+      {
+            histo_ref = (TH1 *)file_ref->Get(histo_full_path_Pt1000) ;
+            if (histo_ref!=0)
+            {
+                // renaming those histograms avoid very strange bugs because they
+                // have the same names as the ones loaded from the new file
+                histo_ref->SetName(TString(histo_ref->GetName())+"_ref") ;
+            }
+            else 
+            {
+                web_page<<"No <b>"<<histo_path<<"</b> for "<<CMP_BLUE_NAME<<".<br>" ;
+            }
        }
      }
 
@@ -445,6 +466,8 @@ int electronCompare()
     histo_full_path = file_new_dir ; histo_full_path += histo_path.c_str() ;
     histo_new = (TH1 *)file_new->Get(histo_full_path) ;
 //    std::cout << "histo_new Name : " << histo_new->GetName() << std::endl ; // A.C. to be removed
+//    std::cout << "histo_full_path new : " << histo_full_path << std::endl ;
+//    std::cout << "histo_path.cstr new : " << histo_path.c_str() << std::endl ;
 
     // special treatments
     if ((scaled==1)&&(histo_new!=0)&&(histo_ref!=0)&&(histo_ref->GetEntries()!=0))
@@ -582,11 +605,13 @@ int electronCompare()
        } while (cat.empty()) ;
      }
    }
+  std::cout << "on ferme le fichier" << std::endl;
   histo_file2.close() ;
   web_page<<"</td></tr></table>\n" ;
 
   web_page<<"\n</html>"<<std::endl ;
+  std::cout << "on ferme la page" << std::endl;
   web_page.close() ;
-
-  return 0;
+  std::cout << "page fermee" << std::endl;
+return 0;
  }


### PR DESCRIPTION
New histos have been added for electron validation : E/Etrue as a function of the number of primary vertices (barrel+endcaps, barrel, endcaps) and total energy of basicclusters (barrel+endcaps, barrel, endcaps).

tests have been made on : 
4.22_RunCosmics2011A+RunCosmics2011A+RECOCOSD+ALCACOSD+SKIMCOSD+HARVESTDC 1 1 1 1 1 tests passed, 0 0 0 0 0 failed

5.1_TTbar+TTbarFS+HARVESTFS 
1 1 tests passed, 0 0 failed

135.4_ZEE_13+ZEEFS_13+HARVESTUP15FS+MINIAODMCUP15FS 
1 1 1 tests passed, 0 0 0 failed

8.0_BeamHalo+BeamHalo+DIGICOS+RECOCOS+ALCABH+HARVESTCOS 
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

140.53_RunHI2011+RunHI2011+RECOHID11+HARVESTDHI 
1 1 1 tests passed, 0 0 0 failed

4.53_RunPhoton2012B+RunPhoton2012B+HLTD+RECODreHLT+HARVESTDreHLT+MINIAODDreHLT 
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

1306.0_SingleMuPt1_UP15+SingleMuPt1_UP15+DIGIUP15+RECOUP15+HARVESTUP15+MINIAODMCUP15 
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

101.0_SingleElectronE120EHCAL+SingleElectronE120EHCAL 
1 tests passed, 0 failed

1000.0_RunMinBias2011A+RunMinBias2011A+TIER0+SKIMD+HARVESTDfst2+ALCASPLIT 
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

1001.0_RunMinBias2011A+RunMinBias2011A+TIER0EXP+ALCAEXP+ALCAHARVD 
1 1 1 1 tests passed, 0 0 0 0 failed

1330.0_ZMM_13+ZMM_13+DIGIUP15+RECOUP15+HARVESTUP15+MINIAODMCUP15 
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

9.0_Higgs200ChargedTaus+Higgs200ChargedTaus+DIGI+RECO+HARVEST 
1 1 1 1 tests passed, 0 0 0 0 failed

1003.0_RunMinBias2012A+RunMinBias2012A+RECODDQM+HARVESTDDQM 
1 1 1 tests passed, 0 0 0 failed

25.0_TTbar+TTbar+DIGI+RECO+HARVEST+ALCATT 
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

25202.0_TTbar_13+TTbar_13+DIGIUP15_PU25+RECOUP15_PU25+HARVESTUP15_PU25+MINIAODMCUP15 
1 1 1 1 1 tests passed, 0 0 0 0 0 failed

No others changes

@beaudett 
