### PR TITLE
Make 10MB the default stack size for additional threads

### DIFF
--- a/FWCore/Framework/bin/cmsRun.cpp
+++ b/FWCore/Framework/bin/cmsRun.cpp
@@ -54,6 +54,7 @@ static char const* const kHelpOpt = "help";
 static char const* const kHelpCommandOpt = "help,h";
 static char const* const kStrictOpt = "strict";
 
+constexpr unsigned int kDefaultSizeOfStackForThreadsInKB = 10*1024; //10MB
 // -----------------------------------------------
 namespace {
   class EventProcessorWithSentry {
@@ -235,7 +236,7 @@ int main(int argc, char* argv[]) {
       if(vm.count(kNumberOfThreadsOpt)) {
         setNThreadsOnCommandLine=true;
         unsigned int nThreads = vm[kNumberOfThreadsOpt].as<unsigned int>();
-        unsigned int stackSize=0;
+        unsigned int stackSize=kDefaultSizeOfStackForThreadsInKB;
         if(vm.count(kSizeOfStackForThreadOpt)) {
           stackSize=vm[kSizeOfStackForThreadOpt].as<unsigned int>();
         }
@@ -295,8 +296,8 @@ int main(int argc, char* argv[]) {
             auto const& ops = pset->getUntrackedParameterSet("options");
             if(ops.existsAs<unsigned int>("numberOfThreads",false)) {
               unsigned int nThreads = ops.getUntrackedParameter<unsigned int>("numberOfThreads");
-              unsigned int stackSize=0;
-              if(ops.existsAs<unsigned int>("sizeOfStackForThreadsInKB",0)) {
+              unsigned int stackSize=kDefaultSizeOfStackForThreadsInKB;
+              if(ops.existsAs<unsigned int>("sizeOfStackForThreadsInKB",false)) {
                 stackSize = ops.getUntrackedParameter<unsigned int>("sizeOfStackForThreadsInKB");
               }
               const auto nThreadsUsed = setNThreads(nThreads,stackSize,tsiPtr);


### PR DESCRIPTION
Many of our ROOT files require very deep stacks in order to be able to read back certain branches. When read on a non-main thread the default stack size used by TBB is often too small. 10MB appears to be sufficiently large.
