### PR TITLE
Skip all entries (per file) at once, not one at a time.

### DIFF
--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -138,6 +138,7 @@ namespace edm {
       indexIntoFileIter_ = indexIntoFileEnd_;
     }
 
+    bool skipEntries(unsigned int& offset) {return eventTree_.skipEntries(offset);}
     bool skipEvents(int& offset);
     bool goToEvent(EventID const& eventID);
     bool nextEventEntry() {return eventTree_.next();}

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -703,19 +703,17 @@ namespace edm {
 
   void
   RootInputFileSequence::skipEntries(unsigned int offset) {
-    while(offset > 0) {
-      while(offset > 0 && rootFile_->nextEventEntry()) {
-        --offset;
+    // offset is decremented by the number of events actually skipped.
+    bool completed = rootFile_->skipEntries(offset);
+    while(!completed) {
+      ++fileIter_;
+      if(fileIter_ == fileIterEnd_) {
+        fileIter_ = fileIterBegin_;
       }
-      if(offset > 0) {
-        ++fileIter_;
-        if(fileIter_ == fileIterEnd_) {
-          fileIter_ = fileIterBegin_;
-        }
-        initFile(false);
-        assert(rootFile_);
-        rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
-      }
+      initFile(false);
+      assert(rootFile_);
+      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
+      completed = rootFile_->skipEntries(offset);
     }
   }
 

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -368,6 +368,22 @@ namespace edm {
     }
   }
 
+  bool
+  RootTree::skipEntries(unsigned int& offset) {
+    entryNumber_ += offset;
+    bool retval = (entryNumber_ < entries_);
+    if(retval) {
+      offset = 0;
+    } else {
+      // Not enough entries in the file to skip.
+      // The +1 is needed because entryNumber_ is -1 at the initialization of the tree, not 0.
+      long long overshoot = entryNumber_ + 1 - entries_;
+      entryNumber_ = entries_;
+      offset = overshoot;
+    }
+    return retval;
+  }
+
   void
   RootTree::startTraining() {
     if (cacheSize_ == 0) {

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -90,6 +90,7 @@ namespace edm {
     bool current(EntryNumber entry) const {return entry < entries_ && entry >= 0;}
     void rewind() {entryNumber_ = 0;}
     void close();
+    bool skipEntries(unsigned int& offset);
     EntryNumber const& entryNumber() const {return entryNumber_;}
     EntryNumber const& entryNumberForIndex(unsigned int index) const;
     EntryNumber const& entries() const {return entries_;}


### PR DESCRIPTION
This is a performance improvements to the implementation of the skipEvents parameter in sequential (AKA deterministic) mode for the secondary input source.  The prior implementation skipped one event at a time.  The improved implementation skips all events to be skipped, per file, all at once.
