### PR TITLE
Remove mutable from RefCore users

### DIFF
--- a/DataFormats/Common/interface/Ref.h
+++ b/DataFormats/Common/interface/Ref.h
@@ -292,7 +292,7 @@ namespace edm {
     // or derived from it.
     void checkTypeAtCompileTime(C const*) {}
 
-    mutable RefCore product_;
+    RefCore product_;
     key_type index_;
   };
 
@@ -448,7 +448,7 @@ namespace edm {
     // or derived from it.
     void checkTypeAtCompileTime(product_type const*) {}
 
-    mutable RefCoreWithIndex product_;
+    RefCoreWithIndex product_;
   };
 }
 

--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -43,10 +43,18 @@ namespace edm {
     /**If productPtr is not 0 then productGetter will be 0 since only one is available at a time */
     void const* productPtr() const {PRODUCTPTR_IMPL;}
 
+    /**This function is 'const' even though it changes an internal value becuase it is meant to be
+     used as a way to store in a thread-safe way a cache of a value. This allows classes which use
+     the RefCore to not have to declare it 'mutable'
+     */
     void setProductPtr(void const* prodPtr) const { 
       setCacheIsProductPtr(prodPtr);
     }
 
+    /**This function is 'const' even though it changes an internal value becuase it is meant to be
+     used as a way to store in a thread-safe way a cache of a value. This allows classes which use
+     the RefCore to not have to declare it 'mutable'
+     */
     bool tryToSetProductPtrForFirstTime(void const* prodPtr) const {
       return refcoreimpl::tryToSetCacheItemForFirstTime(cachePtr_, prodPtr);
     }

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -45,10 +45,18 @@ namespace edm {
     /**If productPtr is not 0 then productGetter will be 0 since only one is available at a time */
     void const* productPtr() const {PRODUCTPTR_IMPL;}
 
-    void setProductPtr(void const* prodPtr) const { 
+    /**This function is 'const' even though it changes an internal value becuase it is meant to be
+     used as a way to store in a thread-safe way a cache of a value. This allows classes which use
+     the RefCore to not have to declare it 'mutable'
+     */
+    void setProductPtr(void const* prodPtr) const {
       setCacheIsProductPtr(prodPtr);
     }
 
+    /**This function is 'const' even though it changes an internal value becuase it is meant to be
+     used as a way to store in a thread-safe way a cache of a value. This allows classes which use
+     the RefCore to not have to declare it 'mutable'
+     */
     bool tryToSetProductPtrForFirstTime(void const* prodPtr) const {
       return refcoreimpl::tryToSetCacheItemForFirstTime(cachePtr_, prodPtr);
     }

--- a/DataFormats/Common/interface/RefToBaseProd.h
+++ b/DataFormats/Common/interface/RefToBaseProd.h
@@ -97,9 +97,8 @@ namespace edm {
     View<T> const* viewPtr() const {
       return reinterpret_cast<const View<T>*>(product_.productPtr());
     }
-    //needs to be mutable so we can modify the 'productPtr' it holds
-    // so that 'productPtr' can hold our View
-    mutable RefCore product_;
+
+    RefCore product_;
   };
 
   template<typename T>


### PR DESCRIPTION
Code which used RefCore were declaring it mutable even though it was not necessary. These were removed.
This avoids the complaint from the static analyzer.
