### PR TITLE
clone methods return unique_ptr

### DIFF
--- a/DataFormats/Common/interface/View.h
+++ b/DataFormats/Common/interface/View.h
@@ -22,6 +22,7 @@ Description: Provide access to the collected elements contained by any WrapperBa
 #include "boost/iterator/indirect_iterator.hpp"
 
 #include <vector>
+#include <memory>
 
 namespace edm {
 
@@ -37,13 +38,17 @@ namespace edm {
   class ViewBase {
   public:
     virtual ~ViewBase();
-    ViewBase* clone() const;
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    std::unique_ptr<ViewBase> clone() const;
+#endif
 
   protected:
     ViewBase();
     ViewBase(ViewBase const&);
     ViewBase& operator=(ViewBase const&);
-    virtual ViewBase* doClone() const = 0;
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    virtual std::unique_ptr<ViewBase> doClone() const = 0;
+#endif
     void swap(ViewBase&) {} // Nothing to swap
   };
 
@@ -135,7 +140,9 @@ namespace edm {
   private:
     seq_t items_;
     std::vector<Ptr<value_type> > vPtrs_;
-    ViewBase* doClone() const;
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
+    std::unique_ptr<ViewBase> doClone() const override;
+#endif
   };
 
   // Associated free functions (same as for std::vector)
@@ -329,12 +336,14 @@ namespace edm {
       output.items_[i] = first;
   }
 
+#if !defined(__CINT__) && !defined(__MAKECINT__) && !defined(__REFLEX__)
   template<typename T>
-  ViewBase*
+  std::unique_ptr<ViewBase>
   View<T>::doClone() const {
-    return new View(*this);
+    return std::unique_ptr<ViewBase>{new View(*this)};
   }
-
+#endif
+  
   template<typename T>
   inline
   View<T>&

--- a/DataFormats/Common/src/View.cc
+++ b/DataFormats/Common/src/View.cc
@@ -9,10 +9,10 @@ namespace edm
 
   ViewBase::~ViewBase() { }
 
-  ViewBase*
+  std::unique_ptr<ViewBase>
   ViewBase::clone() const
   {
-    ViewBase* p = doClone();
+    auto p = doClone();
     assert(typeid(*p)==typeid(*this) && "doClone() incorrectly overriden");
     return p;
   }

--- a/FWCore/Framework/test/View_t.cpp
+++ b/FWCore/Framework/test/View_t.cpp
@@ -122,9 +122,9 @@ void testView::cloning()
   View v1;
   edm::View<int>::fill_from_range(vals, vals+sz, v1);
   
-  edm::ViewBase* base = v1.clone();
+  auto base = v1.clone();
   CPPUNIT_ASSERT(base);
-  edm::View<int>* view = dynamic_cast<edm::View<int>*>(base);
+  edm::View<int>* view = dynamic_cast<edm::View<int>*>(base.get());
   CPPUNIT_ASSERT(view);
   if(view) {
     CPPUNIT_ASSERT(*view == v1);


### PR DESCRIPTION
The static analyzer was complaining that the const clone methods were return bare pointers. Changed to using std::unique_ptr<> instead.
