### PR TITLE
Backport secondary input source improvements from 7_5_X

### DIFF
--- a/IOPool/Input/src/RootFile.h
+++ b/IOPool/Input/src/RootFile.h
@@ -138,6 +138,7 @@ namespace edm {
       indexIntoFileIter_ = indexIntoFileEnd_;
     }
 
+    bool skipEntries(unsigned int& offset) {return eventTree_.skipEntries(offset);}
     bool skipEvents(int& offset);
     bool goToEvent(EventID const& eventID);
     bool nextEventEntry() {return eventTree_.next();}

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -24,6 +24,8 @@
 #include "InputFile.h"
 #include "TSystem.h"
 
+#include <random>
+
 namespace edm {
   RootInputFileSequence::RootInputFileSequence(
                 ParameterSet const& pset,
@@ -56,7 +58,7 @@ namespace edm {
     // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
     // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
     // and should be deleted from the code.
-    initialNumberOfEventsToSkip_(inputType == InputType::Primary ? pset.getUntrackedParameter<unsigned int>("skipEvents", 0U) : 0U),
+    initialNumberOfEventsToSkip_(inputType != InputType::SecondaryFile ? pset.getUntrackedParameter<unsigned int>("skipEvents", 0U) : 0U),
     noEventSort_(inputType == InputType::Primary ? pset.getUntrackedParameter<bool>("noEventSort", true) : false),
     skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
     bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
@@ -80,28 +82,48 @@ namespace edm {
       enablePrefetching_ = pSLC->enablePrefetching();
     }
 
-    StorageFactory *factory = StorageFactory::get();
-    for(fileIter_ = fileIterBegin_; fileIter_ != fileIterEnd_; ++fileIter_) {
-      factory->activateTimeout(fileIter_->fileName());
-      factory->stagein(fileIter_->fileName());
-      //NOTE: we do not want to stage in all secondary files since we can be given a list of
-      // thousands of files and prestaging all those files can cause a site to fail.
-      // So, we stage in the first secondary file only.
-      if(inputType_ != InputType::Primary) {
-        break;
-      }
-    }
-
     std::string branchesMustMatch = pset.getUntrackedParameter<std::string>("branchesMustMatch", std::string("permissive"));
     if(branchesMustMatch == std::string("strict")) branchesMustMatch_ = BranchDescription::Strict;
 
-    for(fileIter_ = fileIterBegin_; fileIter_ != fileIterEnd_; ++fileIter_) {
-      initFile(skipBadFiles_);
-      if(rootFile_) break;
+    StorageFactory *factory = StorageFactory::get();
+
+    if(inputType == InputType::SecondarySource) {
+      // For the secondary input source we do not stage in,
+      // and we randomly choose the first file to open.
+      // We cannot use the random number service yet.
+      std::ifstream f("/dev/urandom");
+      unsigned int seed;
+      f.read(reinterpret_cast<char*>(&seed), sizeof(seed)); 
+      std::default_random_engine dre(seed);
+      size_t count = fileIterEnd_ - fileIterBegin_;
+      std::uniform_int_distribution<int> distribution(0, count - 1);
+      while(!rootFile_ && count != 0) {
+        --count;
+        int offset = distribution(dre);
+        fileIter_ = fileIterBegin_ + offset;
+        initFile(skipBadFiles_);
+      }
+    } else {
+      // Prestage the files
+      for(fileIter_ = fileIterBegin_; fileIter_ != fileIterEnd_; ++fileIter_) {
+        factory->activateTimeout(fileIter_->fileName());
+        factory->stagein(fileIter_->fileName());
+        //NOTE: we do not want to stage in all secondary files since we can be given a list of
+        // thousands of files and prestaging all those files can cause a site to fail.
+        // So, we stage in the first secondary file only.
+        if(inputType_ != InputType::Primary) {
+          break;
+        }
+      }
+      // Open the first file.
+      for(fileIter_ = fileIterBegin_; fileIter_ != fileIterEnd_; ++fileIter_) {
+        initFile(skipBadFiles_);
+        if(rootFile_) break;
+      }
     }
     if(rootFile_) {
       productRegistryUpdate().updateFromInput(rootFile_->productRegistry()->productList());
-      if(initialNumberOfEventsToSkip_ != 0) {
+      if(inputType == InputType::Primary && initialNumberOfEventsToSkip_ != 0) {
         skipEvents(initialNumberOfEventsToSkip_);
       }
     }
@@ -679,17 +701,37 @@ namespace edm {
     productSelectorRules_ = ProductSelectorRules(pset, "inputCommands", "InputSource");
   }
 
-  bool
-  RootInputFileSequence::readOneSequential(EventPrincipal& cache, size_t& fileNameHash) {
-    skipBadFiles_ = false;
-    if(fileIter_ == fileIterEnd_ || !rootFile_) {
-      if(fileIterEnd_ == fileIterBegin_) {
-        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
+  void
+  RootInputFileSequence::skipEntries(unsigned int offset) {
+    // offset is decremented by the number of events actually skipped.
+    bool completed = rootFile_->skipEntries(offset);
+    while(!completed) {
+      ++fileIter_;
+      if(fileIter_ == fileIterEnd_) {
+        fileIter_ = fileIterBegin_;
       }
-      fileIter_ = fileIterBegin_;
       initFile(false);
       assert(rootFile_);
       rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
+      completed = rootFile_->skipEntries(offset);
+    }
+  }
+
+  bool
+  RootInputFileSequence::readOneSequential(EventPrincipal& cache, size_t& fileNameHash) {
+    skipBadFiles_ = false;
+    if(firstFile_) {
+      firstFile_ = false;
+      if(fileIterEnd_ == fileIterBegin_) {
+        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
+      }
+      if(fileIter_ != fileIterBegin_) {
+        fileIter_ = fileIterBegin_;
+        initFile(false);
+      }
+      assert(rootFile_);
+      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
+      skipEntries(initialNumberOfEventsToSkip_);
     }
     assert(rootFile_);
     rootFile_->nextEventEntry();
@@ -697,7 +739,7 @@ namespace edm {
     if(!found) {
       ++fileIter_;
       if(fileIter_ == fileIterEnd_) {
-        return false;
+        fileIter_ = fileIterBegin_;
       }
       initFile(false);
       assert(rootFile_);
@@ -710,11 +752,29 @@ namespace edm {
 
   bool
   RootInputFileSequence::readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id) {
-    if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequentialWithID(): no input files specified for secondary input source.\n";
-    }
     skipBadFiles_ = false;
-    if(fileIter_ == fileIterEnd_ || !rootFile_ ||
+    if(firstFile_) {
+      firstFile_ = false;
+      if(fileIterEnd_ == fileIterBegin_) {
+        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
+      }
+      if(fileIter_ != fileIterBegin_) {
+        fileIter_ = fileIterBegin_;
+        initFile(false);
+      }
+      assert(rootFile_);
+      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
+      int offset = initialNumberOfEventsToSkip_;
+      while(offset > 0) {
+        bool found = readOneSequentialWithID(cache, fileNameHash, id);
+        if(!found) {
+          return false;
+        }
+        --offset;
+      }
+    }
+    assert(rootFile_);
+    if(fileIter_ == fileIterEnd_ ||
         rootFile_->indexIntoFileIter().run() != id.run() ||
         rootFile_->indexIntoFileIter().lumi() != id.luminosityBlock()) {
       bool found = skipToItem(id.run(), id.luminosityBlock(), 0, 0, false);
@@ -740,6 +800,7 @@ namespace edm {
 
   void
   RootInputFileSequence::readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& idx) {
+    firstFile_ = false;
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSpecified(): no input files specified for secondary input source.\n";
     }
@@ -762,6 +823,7 @@ namespace edm {
 
   void
   RootInputFileSequence::readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine) {
+    firstFile_ = false;
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandom(): no input files specified for secondary input source.\n";
     }
@@ -799,6 +861,7 @@ namespace edm {
 
   bool
   RootInputFileSequence::readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, CLHEP::HepRandomEngine* engine) {
+    firstFile_ = false;
     if(fileIterEnd_ == fileIterBegin_) {
       throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandomWithID(): no input files specified for secondary input source.\n";
     }

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -60,6 +60,7 @@ namespace edm {
     void endJob();
     InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
     bool containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
+    void skipEntries(unsigned int offset);
     bool skipEvents(int offset);
     bool goToEvent(EventID const& eventID);
     bool skipToItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, size_t fileNameHash = 0U, bool currentFileFirst = true);

--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -368,6 +368,22 @@ namespace edm {
     }
   }
 
+  bool
+  RootTree::skipEntries(unsigned int& offset) {
+    entryNumber_ += offset;
+    bool retval = (entryNumber_ < entries_);
+    if(retval) {
+      offset = 0;
+    } else {
+      // Not enough entries in the file to skip.
+      // The +1 is needed because entryNumber_ is -1 at the initialization of the tree, not 0.
+      long long overshoot = entryNumber_ + 1 - entries_;
+      entryNumber_ = entries_;
+      offset = overshoot;
+    }
+    return retval;
+  }
+
   void
   RootTree::startTraining() {
     if (cacheSize_ == 0) {

--- a/IOPool/Input/src/RootTree.h
+++ b/IOPool/Input/src/RootTree.h
@@ -90,6 +90,7 @@ namespace edm {
     bool current(EntryNumber entry) const {return entry < entries_ && entry >= 0;}
     void rewind() {entryNumber_ = 0;}
     void close();
+    bool skipEntries(unsigned int& offset);
     EntryNumber const& entryNumber() const {return entryNumber_;}
     EntryNumber const& entryNumberForIndex(unsigned int index) const;
     EntryNumber const& entries() const {return entries_;}


### PR DESCRIPTION
Improvements to the secondary input source, back ported from 7_5_X, as requested at Core Software meeting:
1) skipEvents parameter now supported in sequential mode (AKA deterministic mode)
2) sequential mode now loops  back to first file after the last file
3) First file opened is randomized.
Items 1) and 2) are needed to support the avoidance of duplication in the use of premixed pileup.
This is a back port of PR's #9091, #9155, and #9163 combined, not including the unit test enhancement, which is not being back ported.
