### PR TITLE
Swap with empty vectors to free up memory in ElectronSeedProducer

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/ElectronSeedGenerator.cc
@@ -277,6 +277,10 @@ void  ElectronSeedGenerator::run
     seedsFromThisCluster(sclRefs[i],hoe1s[i],hoe2s[i],out,tTopo);
   }
 
+  // Clear recHits_ from the final loop
+  decltype(recHits_) temp;
+  recHits_.swap(temp); // Make sure the memory for the pointers is cleared as well
+  
   LogDebug ("run") << ": For event "<<e.id();
   LogDebug ("run") <<"Nr of superclusters after filter: "<<sclRefs.size()
    <<", no. of ElectronSeeds found  = " << out.size();

--- a/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/PixelHitMatcher.cc
@@ -238,8 +238,10 @@ PixelHitMatcher::compatibleSeeds
      } // end loop on first seed hit
    } // end loop on seeds
 
-  mapTsos_.clear() ;
-  mapTsos2_.clear() ;
+  decltype(mapTsos_) temp1; // Using ".clear()" wasn't freeing the memory, which is quite a lot at high pileup
+  mapTsos_.swap(temp1);
+  decltype(mapTsos2_) temp2;
+  mapTsos2_.swap(temp2);
 
   return result ;
  }


### PR DESCRIPTION
Using `clear` on temporary vectors wasn't freeing up the memory.  Changed to a swap with an empty vector instead.

At 200 pileup this frees up about 40 Mb.  Retained memory before (including the product, although that is a tiny fraction of it for this):
![electronseedretained_before](https://cloud.githubusercontent.com/assets/6480160/7739736/32e22fc2-ff5e-11e4-92ea-07658c8a56e6.png)

And after applying this pull request:
![electronseedretained_after](https://cloud.githubusercontent.com/assets/6480160/7739739/3de15f74-ff5e-11e4-911b-1c75359e2a61.png)
