### PR TITLE
Add missing include of header boost/shared_ptr.hpp

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -9,6 +9,7 @@
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "boost/cstdint.hpp"
+#include "boost/shared_ptr.hpp"
 #include <set>
 #include <map>
 #include <memory>


### PR DESCRIPTION
Totally technical and trivial.
File  DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h uses boost::shared_ptr but does not include the boost header defining boost::shared_ptr. This header is included indirectly from the framework.  A pending change in the framework will remove this indirect inclusion and cause a compilation error in this header if the missing include is not added.
This PR adds the missing include.
Please bypass the L2 signature if not signed fairly soon, as pending development depends on this trivial PR.
