### PR TITLE
Fixing the Expected Digi Size Issue for HF

### DIFF
--- a/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
+++ b/DQM/HcalMonitorTasks/src/HcalDigiMonitor.cc
@@ -578,6 +578,20 @@ void HcalDigiMonitor::analyze(edm::Event const&e, edm::EventSetup const&s)
 	if (debug_>0)
 		std::cout << "### Processing FED: " << i << std::endl;
 
+	//	For uTCA spigos are useless => by default we have digisize = 4
+	//	As of 20.05.2015
+	//	HF = 2
+	if ((i>=1118 && i<=1122) ||
+			(i>=718 && i<=723))
+	{
+		mindigisizeHF_ = 4;
+		maxdigisizeHF_ = 4;
+		DigiExpectedSize->Fill(2, 4);
+		continue;
+	}
+
+	//	VME readout contains Number of Time Samples per Digi
+	//	uTCA doesn't!
     HcalHTRData htr;  
     for (int spigot=0; spigot<HcalDCCHeader::SPIGOT_COUNT; spigot++) {    
       if (!dccHeader->getSpigotPresent(spigot)) continue;
@@ -1125,7 +1139,7 @@ int HcalDigiMonitor::process_Digi(DIGI& digi, DigiHists& h, int& firstcap)
 	      maxtime=ff;
 	    }
 	}
-      
+    
       if (maxtime>=2 && maxtime<=5 && maxenergy>20 && maxenergy<100)  // only look between time slices 2-5; anything else should be nonsense
 	{
 	  for (int ff=0;ff<digisize;++ff){


### PR DESCRIPTION
Due to the switch to the uTCA readout, the notion of spigot goes away.
Therefore there is no expected digi size saved in the RAW Data.
Have to manually put a check on HF for that purpose.

Will rebase on top of 74 and submit for 74 next
