### PR TITLE
FastSim: fix trackref in ConversionTrackCollection

### DIFF
--- a/FastSimulation/Configuration/python/EventContent_cff.py
+++ b/FastSimulation/Configuration/python/EventContent_cff.py
@@ -110,7 +110,8 @@ FastSimRecoTrackerRECO = cms.PSet(
 #AOD content
 FastSimRecoTrackerAOD = cms.PSet(
     outputCommands = cms.untracked.vstring('keep recoTracks_iterativeGSWithMaterialTracks_*_*',
-                                           'keep *_generalTracksBeforeMixing_*_*')
+                                           #'keep *_generalTracksBeforeMixing_*_*'
+                                           )
 )
 
 

--- a/FastSimulation/Configuration/python/Reconstruction_AftMix_cff.py
+++ b/FastSimulation/Configuration/python/Reconstruction_AftMix_cff.py
@@ -109,6 +109,14 @@ _reco.electronGsfTracks.TTRHBuilder = "WithoutRefit"
 # so we feed it with the 'before mixing' track colletion
 _reco.generalConversionTrackProducer.TrackProducer = 'generalTracksBeforeMixing'
 
+# then we need to fix the track references, so that they point to the final track collection, after mixing
+import FastSimulation.Tracking.ConversionTrackRefFix_cfi
+_conversionTrackRefFix = FastSimulation.Tracking.ConversionTrackRefFix_cfi.fixedConversionTracks.clone(
+    src = cms.InputTag("generalConversionTrackProducerTmp"))
+_reco.conversionTrackSequenceNoEcalSeeded.replace(_reco.generalConversionTrackProducer,_reco.generalConversionTrackProducer+_conversionTrackRefFix)
+_reco.generalConversionTrackProducerTmp = _reco.generalConversionTrackProducer
+_reco.generalConversionTrackProducer = _conversionTrackRefFix
+
 # this might be historical: not sure why we do this
 _reco.egammaGlobalReco.replace(_reco.conversionTrackSequence,_reco.conversionTrackSequenceNoEcalSeeded)
 _reco.allConversions.src = 'gsfGeneralConversionTrackMerger'

--- a/FastSimulation/Tracking/BuildFile.xml
+++ b/FastSimulation/Tracking/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="DataFormats/TrackerCommon"/>
 <use   name="DataFormats/TrackingRecHit"/>
 <use   name="DataFormats/TrackerRecHit2D"/>
+<use   name="DataFormats/EgammaTrackReco"/>
 <use   name="Geometry/CommonDetUnit"/>
 <use   name="Geometry/TrackerGeometryBuilder"/>
 <use   name="Geometry/Records"/>

--- a/FastSimulation/Tracking/plugins/ConversionTrackRefFix.cc
+++ b/FastSimulation/Tracking/plugins/ConversionTrackRefFix.cc
@@ -1,0 +1,48 @@
+#include "FastSimulation/Tracking/plugins/ConversionTrackRefFix.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/EgammaTrackReco/interface/ConversionTrack.h"
+
+using namespace std;
+using namespace reco;
+using namespace edm;
+
+ConversionTrackRefFix::ConversionTrackRefFix(const edm::ParameterSet& iConfig)
+{
+  InputTag conversionTracksTag = iConfig.getParameter<InputTag>("src");
+  InputTag newTracksTag = iConfig.getParameter<InputTag>("newTrackCollection");
+  
+  produces<ConversionTrackCollection>();
+
+  conversionTracksToken = consumes<ConversionTrackCollection>(conversionTracksTag);
+  newTracksToken = consumes<TrackCollection>(newTracksTag);
+}
+
+ConversionTrackRefFix::~ConversionTrackRefFix(){}
+
+
+void
+ConversionTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+  Handle<ConversionTrackCollection> conversionTracks;
+  iEvent.getByToken(conversionTracksToken,conversionTracks);
+
+  Handle<TrackCollection> newTracks;
+  iEvent.getByToken(newTracksToken,newTracks);
+
+  auto_ptr<ConversionTrackCollection> output(new ConversionTrackCollection);
+  
+  for(const ConversionTrack &  conversion : *(conversionTracks.product())){
+    size_t trackIndex = conversion.trackRef().key();
+    output->push_back(ConversionTrack(TrackBaseRef(TrackRef(newTracks,trackIndex))));
+    output->back().setTrajRef(conversion.trajRef());
+    output->back().setIsTrackerOnly(conversion.isTrackerOnly());
+    output->back().setIsArbitratedEcalSeeded(conversion.isArbitratedEcalSeeded());
+    output->back().setIsArbitratedMerged(conversion.isArbitratedMerged());
+    output->back().setIsArbitratedMergedEcalGeneral(conversion.isArbitratedMergedEcalGeneral());
+  }
+
+  iEvent.put(output);
+
+}

--- a/FastSimulation/Tracking/plugins/ConversionTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ConversionTrackRefFix.h
@@ -1,0 +1,24 @@
+#ifndef FastSimulation_Tracking_ConversionTrackRefFix_h
+#define FastSimulation_Tracking_ConversionTrackRefFix_h
+
+#include <memory>
+
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/EgammaTrackReco/interface/ConversionTrackFwd.h"
+
+class ConversionTrackRefFix : public edm::stream::EDProducer<>
+{
+ public:
+  explicit ConversionTrackRefFix(const edm::ParameterSet&);
+  ~ConversionTrackRefFix();
+  
+ private:
+  
+  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  edm::EDGetTokenT<reco::ConversionTrackCollection > conversionTracksToken;
+  edm::EDGetTokenT<reco::TrackCollection > newTracksToken;
+};
+
+#endif

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.cc
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.cc
@@ -1,6 +1,5 @@
 #include "FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -119,17 +118,6 @@ ElectronSeedTrackRefFix::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    iEvent.put(oIdMap,preidLabel);
 }
 
-// ------------ method called once each job just before starting event loop  ------------
-void 
-ElectronSeedTrackRefFix::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-ElectronSeedTrackRefFix::endJob() {
-}
- 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void
 ElectronSeedTrackRefFix::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
@@ -15,7 +15,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 
-class ElectronSeedTrackRefFix : public edm::stream::EDProducer {
+class ElectronSeedTrackRefFix : public edm::stream::EDProducer<> {
 public:
   explicit ElectronSeedTrackRefFix(const edm::ParameterSet&);
   ~ElectronSeedTrackRefFix();

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
@@ -23,9 +23,7 @@ public:
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
 private:
-  virtual void beginJob() override;
   virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override;
     
   // ----------member data ---------------------------
   edm::EDGetTokenT<reco::TrackCollection > newTracksToken;

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
@@ -11,7 +11,7 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/EgammaReco/interface/ElectronSeedFwd.h"
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
 

--- a/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
+++ b/FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h
@@ -15,7 +15,7 @@
 #include "DataFormats/Common/interface/ValueMap.h"
 
 
-class ElectronSeedTrackRefFix : public edm::EDProducer {
+class ElectronSeedTrackRefFix : public edm::stream::EDProducer {
 public:
   explicit ElectronSeedTrackRefFix(const edm::ParameterSet&);
   ~ElectronSeedTrackRefFix();

--- a/FastSimulation/Tracking/plugins/SealModule.cc
+++ b/FastSimulation/Tracking/plugins/SealModule.cc
@@ -4,6 +4,7 @@
 #include "FastSimulation/Tracking/plugins/PixelTracksProducer.h"
 #include "FastSimulation/Tracking/plugins/SimTrackIdProducer.h"
 #include "FastSimulation/Tracking/plugins/ElectronSeedTrackRefFix.h"
+#include "FastSimulation/Tracking/plugins/ConversionTrackRefFix.h"
 // reco::Track accumulator:
 #include "SimGeneral/MixingModule/interface/DigiAccumulatorMixModFactory.h"
 #include "FastSimulation/Tracking/plugins/RecoTrackAccumulator.h"
@@ -14,4 +15,5 @@ DEFINE_FWK_MODULE(ElectronSeedTrackRefFix);
 DEFINE_FWK_MODULE(TrackCandidateProducer);
 DEFINE_FWK_MODULE(PixelTracksProducer);
 DEFINE_FWK_MODULE(SimTrackIdProducer);
+DEFINE_FWK_MODULE(ConversionTrackRefFix);
 DEFINE_DIGI_ACCUMULATOR(RecoTrackAccumulator);

--- a/FastSimulation/Tracking/python/ConversionTrackRefFix_cfi.py
+++ b/FastSimulation/Tracking/python/ConversionTrackRefFix_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+fixedConversionTracks = cms.EDProducer(
+    "ConversionTrackRefFix",
+    src = cms.InputTag("generalConversionTrackProducer"),
+    newTrackCollection = cms.InputTag("generalTracks")
+    )


### PR DESCRIPTION
- the original ConversionTrackCollection is copied. In the copy, reference to tracks in the before-mixing track collection are replaced with references to the after-mixing track collection
- the before-mixing track collection is dropped from AODSIM, which is justified by the above
- should be considered for backporting to 74X as it reduces the AODSIM event content
