### PR TITLE
Trim FastjetJetProducer memory

### DIFF
--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -317,6 +317,12 @@ void FastjetJetProducer::produceTrackJets( edm::Event & iEvent, const edm::Event
     LogDebug("FastjetTrackJetProducer") << "Put " << jets->size() << " jets in the event.\n";
     iEvent.put(jets);
 
+    // Clear the work vectors so that memory is free for other modules.
+    // Use the trick of swapping with an empty vector so that the memory
+    // is actually given back rather than silently kept.
+    decltype(fjInputs_)().swap(fjInputs_);
+    decltype(fjJets_)().swap(fjJets_);
+    decltype(inputs_)().swap(inputs_);  
 }
 
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -194,6 +194,11 @@ void FastjetJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & i
   
   }
 
+  // fjClusterSeq_ retains quite a lot of memory - about 1 to 7Mb at 200 pileup
+  // depending on the exact configuration; and there are 24 FastjetJetProducers in the
+  // sequence so this adds up to about 60 Mb. It's allocated every time runAlgorithm
+  // is called, so safe to delete here.
+  fjClusterSeq_.reset();
 }
 
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -402,6 +402,13 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   output( iEvent, iSetup );
   LogDebug("VirtualJetProducer") << "Wrote jets\n";
   
+  // Clear the work vectors so that memory is free for other modules.
+  // Use the trick of swapping with an empty vector so that the memory
+  // is actually given back rather than silently kept.
+  decltype(fjInputs_)().swap(fjInputs_);
+  decltype(fjJets_)().swap(fjJets_);
+  decltype(inputs_)().swap(inputs_);  
+
   return;
 }
 


### PR DESCRIPTION
FastjetJetProducer keeps a chunk of memory between events unnecessarily.  With the 24 instances in the standard sequence this amounts to more than 70 Mb at 200 pileup.
Here is the retained memory, excluding produced collection sizes, summed over all instances of the class at 200 pileup:
![fastjet_before](https://cloud.githubusercontent.com/assets/6480160/7749331/9f302cae-ffc4-11e4-8707-1f0e68eaaf3c.png)

Here is the same thing after applying this pull request:
![fastjet_after](https://cloud.githubusercontent.com/assets/6480160/7749346/bc0104c0-ffc4-11e4-8e70-d5af24658b99.png)

Swapping out the work vectors with empty vectors saves about 10 Mb of that 70.  The remainder is from deleting the `fjClusterSeq_` object in between events (it's created new each event anyway).

@lgray 
