### PR TITLE
enable CSVv2 in combinedMVA instead of CSV

### DIFF
--- a/RecoBTau/JetTagComputer/python/candidateCombinedMVAComputer_cfi.py
+++ b/RecoBTau/JetTagComputer/python/candidateCombinedMVAComputer_cfi.py
@@ -12,7 +12,7 @@ candidateCombinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('candidateCombinedSecondaryVertexComputer')
+			jetTagComputer = cms.string('candidateCombinedSecondaryVertexV2Computer')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTau/JetTagComputer/python/combinedMVAComputer_cfi.py
+++ b/RecoBTau/JetTagComputer/python/combinedMVAComputer_cfi.py
@@ -12,7 +12,7 @@ combinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('combinedSecondaryVertexComputer')
+			jetTagComputer = cms.string('combinedSecondaryVertexV2Computer')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),


### PR DESCRIPTION
- CSVv2 is outperforming CSV tagger and should be used as input for combinedMVA tagger
- are we allowed to backport this to 74X? it has an impact on the RECO sequence...
