### PR TITLE
FastSim: fix unreadable schedule

### DIFF
--- a/FastSimulation/Configuration/python/Reconstruction_AftMix_cff.py
+++ b/FastSimulation/Configuration/python/Reconstruction_AftMix_cff.py
@@ -20,6 +20,7 @@ _mod2del = []
 # offlineBeamSpot is reconstructed before mixing
 ########################################## 
 _mod2del.append(_reco.offlineBeamSpot)
+_reco.globalreco.remove(_reco.offlineBeamSpot) # temporary removing this by hand, cause the usual removal (see end of this file) doesn't seem work
 
 ###########################################
 # no castor / zdc in FastSim


### PR DESCRIPTION
offlineBeampot is removed from globalreco sequence,
since it is part of the before-mixing reconstruction sequence
