### PR TITLE
Trim FastjetJetProducer memory (forward port #9203 to 74X)

### DIFF
--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -244,6 +244,11 @@ void FastjetJetProducer::produce( edm::Event & iEvent, const edm::EventSetup & i
   
   }
 
+  // fjClusterSeq_ retains quite a lot of memory - about 1 to 7Mb at 200 pileup
+  // depending on the exact configuration; and there are 24 FastjetJetProducers in the
+  // sequence so this adds up to about 60 Mb. It's allocated every time runAlgorithm
+  // is called, so safe to delete here.
+  fjClusterSeq_.reset();
 }
 
 

--- a/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/FastjetJetProducer.cc
@@ -368,6 +368,12 @@ void FastjetJetProducer::produceTrackJets( edm::Event & iEvent, const edm::Event
     LogDebug("FastjetTrackJetProducer") << "Put " << jets->size() << " jets in the event.\n";
     iEvent.put(jets);
 
+    // Clear the work vectors so that memory is free for other modules.
+    // Use the trick of swapping with an empty vector so that the memory
+    // is actually given back rather than silently kept.
+    decltype(fjInputs_)().swap(fjInputs_);
+    decltype(fjJets_)().swap(fjJets_);
+    decltype(inputs_)().swap(inputs_);  
 }
 
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -418,6 +418,13 @@ void VirtualJetProducer::produce(edm::Event& iEvent,const edm::EventSetup& iSetu
   output( iEvent, iSetup );
   LogDebug("VirtualJetProducer") << "Wrote jets\n";
   
+  // Clear the work vectors so that memory is free for other modules.
+  // Use the trick of swapping with an empty vector so that the memory
+  // is actually given back rather than silently kept.
+  decltype(fjInputs_)().swap(fjInputs_);
+  decltype(fjJets_)().swap(fjJets_);
+  decltype(inputs_)().swap(inputs_);  
+
   return;
 }
 

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.cc
@@ -61,7 +61,7 @@ namespace reco {
 }                                                                                        
 
 //______________________________________________________________________________
-const char *VirtualJetProducer::JetType::names[] = {
+const char *const VirtualJetProducer::JetType::names[] = {
   "BasicJet","GenJet","CaloJet","PFJet","TrackJet","PFClusterJet"
 };
 
@@ -70,7 +70,7 @@ const char *VirtualJetProducer::JetType::names[] = {
 VirtualJetProducer::JetType::Type
 VirtualJetProducer::JetType::byName(const string &name)
 {
-  const char **pos = std::find(names, names + LastJetType, name);
+  const char *const *pos = std::find(names, names + LastJetType, name);
   if (pos == names + LastJetType) {
     std::string errorMessage="Requested jetType not supported: "+name+"\n";
     throw cms::Exception("Configuration",errorMessage);

--- a/RecoJets/JetProducers/plugins/VirtualJetProducer.h
+++ b/RecoJets/JetProducers/plugins/VirtualJetProducer.h
@@ -44,7 +44,7 @@ protected:
       PFClusterJet,
       LastJetType  // no real type, technical
     };
-    static const char *names[];
+    static const char *const names[];
     static Type byName(const std::string &name);
   };
     


### PR DESCRIPTION
This forward ports some memory improvements in FastjetJetProducer from 6_2_X_SLHC; there are some plots on #9203 with the memory saving.  The 75X port is #9206, I was also advised to port to 74X.
This bit below is just the description copied from the 75X PR:

This forward ports some memory improvements found in 6_2_X_SLHC. At 200 pileup it saved ~70Mb memory, there are plots on #9203. Presumably at lower pileup the savings aren't as good.

Note that this is from empirically checking where the memory was being used - there could be other subclasses of `VirtualJetProducer` that would benefit from a similar fix. I didn't want to touch the `fjClusterSeq_` object in the base class because I didn't know how the other subclasses use it - for `FastjetJetProducer` I can see that it's recreated anew with every event.

At 200 pileup 1/7th of the memory saving was from swapping out the work vectors, and 6/7th was from freeing the `fjClusterSeq_` object.
