### PR TITLE
Bug fix: undo fix of ConversionTracks in case of gen-mixing

### DIFF
--- a/FastSimulation/Configuration/python/MixingModule_Full2Fast.py
+++ b/FastSimulation/Configuration/python/MixingModule_Full2Fast.py
@@ -162,6 +162,7 @@ def prepareGenMixing(process):
 
     # Use generalTracks where DIGI-RECO mixing requires preMixTracks
     process.generalConversionTrackProducer.TrackProducer = cms.string('generalTracks')
+    process.generalConversionTrackProducerTmp.TrackProducer = cms.string('generalTracks')
     process.trackerDrivenElectronSeedsTmp.TkColList = cms.VInputTag(cms.InputTag("generalTracks"))
     process.trackerDrivenElectronSeeds.oldTrackCollection = "generalTracks"
 


### PR DESCRIPTION
undo effects of #9202 in case of gen-mixing
