### PR TITLE
Sort the output of ClusterTPAssociationProducer

### DIFF
--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -86,8 +86,8 @@ namespace
 } // end of the unnamed namespace
 
 QuickTrackAssociatorByHitsImpl::QuickTrackAssociatorByHitsImpl(edm::EDProductGetter const& productGetter,
-                                                               std::shared_ptr<const TrackerHitAssociator> hitAssoc,
-                                                               std::shared_ptr<const ClusterTPAssociationList> clusterToTPMap,
+                                                               std::unique_ptr<const TrackerHitAssociator> hitAssoc,
+                                                               const ClusterTPAssociationList *clusterToTPMap,
 
                                                                bool absoluteNumberOfHits,
                                                                double qualitySimToReco,
@@ -97,7 +97,7 @@ QuickTrackAssociatorByHitsImpl::QuickTrackAssociatorByHitsImpl(edm::EDProductGet
                                                                SimToRecoDenomType simToRecoDenominator):
   productGetter_(&productGetter),
   hitAssociator_(std::move(hitAssoc)),
-  clusterToTPMap_(std::move(clusterToTPMap)),
+  clusterToTPMap_(clusterToTPMap),
   qualitySimToReco_(qualitySimToReco),
   puritySimToReco_(puritySimToReco),
   cutRecoToSim_(cutRecoToSim),
@@ -304,7 +304,7 @@ template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<
 	{
 
 		std::pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( *it, TrackingParticleRef() ); //TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
-		auto range=std::equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
+		auto range=std::equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, ClusterTPAssociationProducer::clusterTPAssociationListGreater );
 		if( range.first != range.second )
 		{
 			for( auto ip=range.first; ip != range.second; ++ip )
@@ -497,7 +497,7 @@ template<typename iter> int QuickTrackAssociatorByHitsImpl::getDoubleCount( cons
 		for( std::vector<OmniClusterRef>::const_iterator it=oClusters.begin(); it != oClusters.end(); ++it )
 		{
 			std::pair<OmniClusterRef,TrackingParticleRef> clusterTPpairWithDummyTP( *it, TrackingParticleRef() ); //TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
-			auto range=std::equal_range( clusterToTPList.begin(), clusterToTPList.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
+			auto range=std::equal_range( clusterToTPList.begin(), clusterToTPList.end(), clusterTPpairWithDummyTP, ClusterTPAssociationProducer::clusterTPAssociationListGreater );
 			if( range.first != range.second )
 			{
 				for( auto ip=range.first; ip != range.second; ++ip )

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.cc
@@ -304,7 +304,7 @@ template<typename T_TPCollection,typename iter> std::vector< std::pair<edm::Ref<
 	{
 
 		std::pair < OmniClusterRef, TrackingParticleRef > clusterTPpairWithDummyTP( *it, TrackingParticleRef() ); //TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
-		auto range=std::equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, ClusterTPAssociationProducer::clusterTPAssociationListGreater );
+		auto range=std::equal_range( clusterToTPMap.begin(), clusterToTPMap.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
 		if( range.first != range.second )
 		{
 			for( auto ip=range.first; ip != range.second; ++ip )
@@ -497,7 +497,7 @@ template<typename iter> int QuickTrackAssociatorByHitsImpl::getDoubleCount( cons
 		for( std::vector<OmniClusterRef>::const_iterator it=oClusters.begin(); it != oClusters.end(); ++it )
 		{
 			std::pair<OmniClusterRef,TrackingParticleRef> clusterTPpairWithDummyTP( *it, TrackingParticleRef() ); //TP is dummy: for clusterTPAssociationListGreater sorting only the cluster is needed
-			auto range=std::equal_range( clusterToTPList.begin(), clusterToTPList.end(), clusterTPpairWithDummyTP, ClusterTPAssociationProducer::clusterTPAssociationListGreater );
+			auto range=std::equal_range( clusterToTPList.begin(), clusterToTPList.end(), clusterTPpairWithDummyTP, clusterTPAssociationListGreater );
 			if( range.first != range.second )
 			{
 				for( auto ip=range.first; ip != range.second; ++ip )

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -5,7 +5,7 @@
 
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
-#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h"
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationList.h"
 
 // Forward declarations
 class TrackerHitAssociator;
@@ -64,7 +64,6 @@ namespace edm {
 class QuickTrackAssociatorByHitsImpl : public reco::TrackToTrackingParticleAssociatorBaseImpl
 {
 public:
-  typedef ClusterTPAssociationProducer::ClusterTPAssociationList ClusterTPAssociationList;
   enum SimToRecoDenomType {denomnone,denomsim,denomreco};
 
   QuickTrackAssociatorByHitsImpl(edm::EDProductGetter const& productGetter,

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsImpl.h
@@ -5,6 +5,8 @@
 
 #include "SimDataFormats/Associations/interface/TrackToTrackingParticleAssociator.h"
 
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h"
+
 // Forward declarations
 class TrackerHitAssociator;
 
@@ -59,18 +61,15 @@ namespace edm {
  * Functionality to associate using pre calculated cluster to TrackingParticle maps added by Subir Sarker sometime in 2013.
  * Overhauled to remove mutables to make it thread safe by Mark Grimes 01/May/2014.
  */
-
-  inline bool clusterTPAssociationListGreater(std::pair<OmniClusterRef, TrackingParticleRef> i,std::pair<OmniClusterRef, TrackingParticleRef> j) { return (i.first.rawIndex()>j.first.rawIndex()); }
-
 class QuickTrackAssociatorByHitsImpl : public reco::TrackToTrackingParticleAssociatorBaseImpl
 {
 public:
-  typedef std::vector<std::pair<OmniClusterRef, TrackingParticleRef> > ClusterTPAssociationList;
+  typedef ClusterTPAssociationProducer::ClusterTPAssociationList ClusterTPAssociationList;
   enum SimToRecoDenomType {denomnone,denomsim,denomreco};
 
   QuickTrackAssociatorByHitsImpl(edm::EDProductGetter const& productGetter,
-                                 std::shared_ptr<const TrackerHitAssociator> hitAssoc,
-                                 std::shared_ptr<const ClusterTPAssociationList> clusterToTPMap,
+                                 std::unique_ptr<const TrackerHitAssociator> hitAssoc,
+                                 const ClusterTPAssociationList *clusterToTPMap,
                                  bool absoluteNumberOfHits,
                                  double qualitySimToReco,
                                  double puritySimToReco,
@@ -190,8 +189,8 @@ public:
   //void prepareEitherHitAssociatorOrClusterToTPMap( const edm::Event* pEvent, std::unique_ptr<ClusterTPAssociationList>& pClusterToTPMap, std::unique_ptr<TrackerHitAssociator>& pHitAssociator ) const;
 
   edm::EDProductGetter const* productGetter_;
-  std::shared_ptr<const TrackerHitAssociator> hitAssociator_;
-  std::shared_ptr<const ClusterTPAssociationList> clusterToTPMap_;
+  std::unique_ptr<const TrackerHitAssociator> hitAssociator_;
+  const ClusterTPAssociationList *clusterToTPMap_;
   
   double qualitySimToReco_;
   double puritySimToReco_;

--- a/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
+++ b/SimTracker/TrackAssociatorProducers/plugins/QuickTrackAssociatorByHitsProducer.cc
@@ -40,9 +40,6 @@
 namespace {
 }
 
-
-using ClusterTPAssociationList = QuickTrackAssociatorByHitsImpl::ClusterTPAssociationList;
-
 class QuickTrackAssociatorByHitsProducer : public edm::global::EDProducer<> {
    public:
       explicit QuickTrackAssociatorByHitsProducer(const edm::ParameterSet&);

--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationList.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationList.h
@@ -1,0 +1,17 @@
+#ifndef SimTracker_TrackerHitAssociation_ClusterTPAssociationList_h
+#define SimTracker_TrackerHitAssociation_ClusterTPAssociationList_h
+
+#include "DataFormats/TrackerRecHit2D/interface/OmniClusterRef.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticle.h"
+#include "SimDataFormats/TrackingAnalysis/interface/TrackingParticleFwd.h"
+
+#include <vector>
+#include <utility>
+
+typedef std::vector<std::pair<OmniClusterRef, TrackingParticleRef> > ClusterTPAssociationList;
+
+inline bool clusterTPAssociationListGreater(std::pair<OmniClusterRef, TrackingParticleRef> i,std::pair<OmniClusterRef, TrackingParticleRef> j) {
+  return i.first.rawIndex() > j.first.rawIndex();
+}
+
+#endif

--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h
@@ -25,16 +25,10 @@ class ClusterTPAssociationProducer : public edm::stream::EDProducer<>
 {
 public:
   //typedef std::pair<uint32_t, EncodedEventId> SimTrackIdentifier;
-  typedef std::vector<std::pair<OmniClusterRef, TrackingParticleRef> > ClusterTPAssociationList;
   typedef std::vector<OmniClusterRef> OmniClusterCollection;
 
   explicit ClusterTPAssociationProducer(const edm::ParameterSet&);
   ~ClusterTPAssociationProducer();
-
-
-  static bool clusterTPAssociationListGreater(std::pair<OmniClusterRef, TrackingParticleRef> i,std::pair<OmniClusterRef, TrackingParticleRef> j) {
-    return i.first.rawIndex() > j.first.rawIndex();
-  }
 
 private:
   virtual void beginJob() {}

--- a/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h
+++ b/SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h
@@ -31,6 +31,11 @@ public:
   explicit ClusterTPAssociationProducer(const edm::ParameterSet&);
   ~ClusterTPAssociationProducer();
 
+
+  static bool clusterTPAssociationListGreater(std::pair<OmniClusterRef, TrackingParticleRef> i,std::pair<OmniClusterRef, TrackingParticleRef> j) {
+    return i.first.rawIndex() > j.first.rawIndex();
+  }
+
 private:
   virtual void beginJob() {}
   virtual void produce(edm::Event&, const edm::EventSetup&);

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -19,6 +19,7 @@
 
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationProducer.h"
+#include "SimTracker/TrackerHitAssociation/interface/ClusterTPAssociationList.h"
 
 ClusterTPAssociationProducer::ClusterTPAssociationProducer(const edm::ParameterSet & cfg) 
   : _verbose(cfg.getParameter<bool>("verbose")),

--- a/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
+++ b/SimTracker/TrackerHitAssociation/plugins/ClusterTPAssociationProducer.cc
@@ -42,7 +42,7 @@ ClusterTPAssociationProducer::~ClusterTPAssociationProducer() {
 }
 		
 void ClusterTPAssociationProducer::produce(edm::Event& iEvent, const edm::EventSetup& es) {
-  std::auto_ptr<ClusterTPAssociationList> clusterTPList(new ClusterTPAssociationList);
+  auto clusterTPList = std::make_unique<ClusterTPAssociationList>();
  
   // Pixel DigiSimLink
   edm::Handle<edm::DetSetVector<PixelDigiSimLink> > sipixelSimLinks;
@@ -152,7 +152,8 @@ void ClusterTPAssociationProducer::produce(edm::Event& iEvent, const edm::EventS
     }
   }
 
-  iEvent.put(clusterTPList);
+  std::sort(clusterTPList->begin(), clusterTPList->end(), clusterTPAssociationListGreater);
+  iEvent.put(std::move(clusterTPList));
 }
 
 template <typename T>


### PR DESCRIPTION
While preparing #9223, I noticed that the ClusterTPAssociationList is copied in QuickTrackAssociatorByHitsImplProducer (to sort it), and the inserted to Event as part of reco::TrackToTrackingParticleAssociator. IgProf shows that in RelVal TTbar+35BX@25ns sample this takes O(4-5 MB) of memory in a RAW2DIGI,RECO,VALIDATION,DQM workflow.

In this PR I try to avoid the copy by sorting ClusterTPAssociationList in ClusterTPAssociationProducer before the product is put in Event.

On the same go, I turned the shared_ptr<TrackerHitAssociator> to unique_ptr as the TrackerHitAssociator is not shared with other objects, and moved to C++14 make_unique.

Tested in CMSSW_7_5_X_2015-05-13-2300 and CMSSW_7_5_X_2015-05-21-2300, no changes expected in results.

@rovere @VinInn 
