### PR TITLE
Fix PFCluster and PFEGamma memory

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/interface/Arbor.hh
+++ b/RecoParticleFlow/PFClusterProducer/interface/Arbor.hh
@@ -27,6 +27,8 @@ namespace arbor {
   void MakingCMSCluster();
   
   branchcoll Arbor( std::vector<std::pair<TVector3,float> >, const float CellSize, const float LayerThickness, const float distSeedForMerge, const bool allowSameLayerSeedMerge );
+
+  void ArborFreeMem();
 }
 
 #endif

--- a/RecoParticleFlow/PFClusterProducer/src/Arbor.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/Arbor.cc
@@ -903,4 +903,18 @@ std::vector< std::vector<int> > Arbor(std::vector<std::pair<TVector3,float> > in
 	return Trees;
 
 }
+
+void ArborFreeMem() {
+  HitLinkMap().swap(BackLinksMap);
+  linkcoll().swap(Links);
+  linkcoll().swap(InitLinks);
+  HitLinkMap().swap(alliterBackLinksMap);
+  linkcoll().swap(alliterlinks);
+  linkcoll().swap(links_debug); 
+  linkcoll().swap(IterLinks); 
+  HitLinkMap().swap(IterBackLinks);
+  branchcoll().swap(LengthSortBranchCollection);
+  branchcoll().swap(Trees); 
+}
+
 }

--- a/RecoParticleFlow/PFClusterProducer/src/HGCClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/HGCClusterizer.cc
@@ -434,6 +434,13 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
       output.push_back(cluster);
     }
   }
+
+  //clean up memory
+  std::vector<unsigned>().swap(_usable_tracks);
+  std::unordered_map<unsigned,unsigned>().swap(_rechits_to_clusters);
+  std::vector<KDNode>().swap(_cluster_nodes);
+  std::vector<KDNode>().swap(_hit_nodes);
+  std::vector<KDNode>().swap(_found);
 }
 
 void HGCClusterizer::update(const edm::EventSetup& es) {
@@ -474,7 +481,7 @@ void HGCClusterizer::update(const edm::EventSetup& es) {
 void HGCClusterizer::updateEvent(const edm::Event& ev) {
   _usable_tracks.clear();
   ev.getByToken(_tracksToken,_tracks);
-  const reco::TrackCollection tracks = *_tracks;  
+  const reco::TrackCollection& tracks = *_tracks;  
   _usable_tracks.reserve(tracks.size());
   for( unsigned i = 0; i < tracks.size(); ++i ) {
     const reco::Track& tk = tracks[i];

--- a/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/SimpleArborClusterizer.cc
@@ -90,4 +90,6 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
     }
   }
   edm::LogError("ArborInfo") << "Made " << output.size() << " clusters!";
+  //clean up arbor mem use
+  arbor::ArborFreeMem();
 }

--- a/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
+++ b/RecoParticleFlow/PFProducer/interface/PFEGammaAlgo.h
@@ -115,7 +115,10 @@ class PFEGammaAlgo {
   
   //get electron PFCandidate
   
-  
+  //clean up all of our work areas
+  void cleanUpMemory();
+
+
 private: 
   typedef  std::map< unsigned int, std::vector<unsigned int> >  AssMap;
 

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -558,6 +558,8 @@ PFEGammaProducer::produce(Event& iEvent,
 //   // Write in the event
    iEvent.put(pOutputCandidateCollection);
  
+   pfeg_->cleanUpMemory();
+   
 }
 
 //PFEGammaAlgo: a new method added to set the parameters for electron and photon reconstruction. 

--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -3601,3 +3601,21 @@ bool PFEGammaAlgo::AddElectronCandidate(unsigned int gsf_index,
   }
   return false;
 }
+
+void PFEGammaAlgo::cleanUpMemory() {
+  typedef std::vector<bool> vbool;
+  typedef std::vector< std::pair <unsigned int, unsigned int> > uint_map;
+  typedef std::vector<int> vint;
+  typedef std::vector<unsigned int> vuint;
+  typedef std::vector< reco::PFCandidate > vpfcand;
+  typedef std::vector<reco::PFCandidateEGammaExtra> vpfextra;
+  vbool().swap(lockExtraKf_);
+  vbool().swap(GsfTrackSingleEcal_);
+  uint_map().swap(fifthStepKfTrack_);
+  uint_map().swap(convGsfTrack_);
+  vint().swap(match_ind);
+  vpfcand().swap(permElectronCandidates_);
+  vuint().swap(AddFromElectron_);
+  vpfcand().swap(egCandidate_);
+  vpfextra().swap(egExtra_);
+}


### PR DESCRIPTION
Memory fixes from Lindsey.

Retained memory excluding products before applying this:
![lgray_before](https://cloud.githubusercontent.com/assets/6480160/7767962/aa09d256-006e-11e5-98ff-83027ebd3325.png)

After applying this pull request:
![lgray_after](https://cloud.githubusercontent.com/assets/6480160/7767968/b30e6cf4-006e-11e5-9a30-b4da9fc75450.png)

Note that the yellow line (ElectronSeedProducer) was fixed in #9194, but I didn't have a "before" plot with that fix.  So a big saving of 40-50 Mb from PFClusterProducer.  No visible change in PFEGammaProducer, although that could be washed out from the big allocation in `beginRun`.  That's probably unavoidable from a geom service or something (though I haven't checked) - the way I count the memory, services get lumped in with the first module that calls them.

So current state (this is basically the "after" plot above, but not range limited to match the "before" and the new top 25 rather than the old top 25):
![currentstate_retained](https://cloud.githubusercontent.com/assets/6480160/7768158/56f68742-0070-11e5-8450-f8de287ec75e.png)
Now a lot of the big allocations are in beginRun or beginLumi, which as mentioned above I'm going to assume are unavoidable for now.  Might not be but I'll check those if and when memory becomes a problem again.
Only big thing left that makes the allocations in the events now is `SeedGeneratorFromRegionHitsProducer`.  I'll compare against 75X because I think Vincenzo made a lot of improvements.  Once I get that down I'll run a check of VmSize and RSS and see where we stand in the big picture.

@lgray
