### PR TITLE
default snapshot time for gt set to infinity

### DIFF
--- a/CondCore/Utilities/bin/conddb_migrate_gt.cpp
+++ b/CondCore/Utilities/bin/conddb_migrate_gt.cpp
@@ -192,7 +192,7 @@ int cond::MigrateGTUtilities::execute(){
     newGT = session.createGlobalTag( gtag );
     newGT.setDescription( "GT "+gtag+" migrated from account "+sourceConnect );
     newGT.setRelease( release );
-    newGT.setSnapshotTime( boost::posix_time::microsec_clock::universal_time() );
+    newGT.setSnapshotTime( boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP) ) );
   }
   std::cout <<"Processing "<<gtlist.size()<<" tags."<<std::endl;
   size_t nerr = 0;


### PR DESCRIPTION
In the migration tool, the default snapshot time for the destination GT (v2)  is changed from the current time to infinity. 
