### PR TITLE
TF1::GetParErrors() const returns const Double_t * in ROOT 6.04.00

### DIFF
--- a/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
+++ b/DQMServices/ClientConfig/plugins/DQMGenericClient.cc
@@ -853,7 +853,7 @@ void DQMGenericClient::limitedFit(MonitorElement * srcME, MonitorElement * meanM
 
 //      histoY->Fit(fitFcn->GetName(),"RME");
       double *par = fitFcn->GetParameters();
-      double *err = fitFcn->GetParErrors();
+      const double *err = fitFcn->GetParErrors();
 
       meanME->setBinContent(i, par[1]);
       meanME->setBinError(i, err[1]);

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitUtils.cc
@@ -1938,7 +1938,7 @@ std::vector<TGraphErrors*> MuScleFitUtils::fitMass (TH2F* histo) {
     if (cont>cont_min) {
       histoY->Fit ("fitFcn", "0", "", 70, 110);
       double *par = fitFcn->GetParameters();
-      double *err = fitFcn->GetParErrors();
+      const double *err = fitFcn->GetParErrors();
 
       Ftop.push_back(par[0]);
       Fwidth.push_back(par[1]);
@@ -2047,7 +2047,7 @@ std::vector<TGraphErrors*> MuScleFitUtils::fitReso (TH2F* histo) {
     if (cont>cont_min) {
       histoY->Fit ("fitFunc", "0", "", -0.2, 0.2);
       double *par = fitFcn->GetParameters();
-      double *err = fitFcn->GetParErrors();
+      const double *err = fitFcn->GetParErrors();
 
       maxs.push_back (par[0]);
       means.push_back (par[1]);


### PR DESCRIPTION
Update in ROOT 6.04.00 changed return type of TF1::GetParErrors() const
to be const.

See ROOT commit: `0539de6de4bb7aba2160da0195296aa0d94209ce`

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
