### PR TITLE
Check for 'branchListIndexes' branch before adding to TTreeCache

### DIFF
--- a/IOPool/Input/src/RootTree.cc
+++ b/IOPool/Input/src/RootTree.cc
@@ -405,7 +405,10 @@ namespace edm {
     rawTreeCache_->StopLearningPhase();
     treeCache_->StartLearningPhase();
     treeCache_->SetEntryRange(switchOverEntry_, tree_->GetEntries());
-    treeCache_->AddBranch(poolNames::branchListIndexesBranchName().c_str(), kTRUE);
+    // Make sure that 'branchListIndexes' branch exist in input file
+    if (filePtr_->Get(poolNames::branchListIndexesBranchName().c_str()) != nullptr) {
+      treeCache_->AddBranch(poolNames::branchListIndexesBranchName().c_str(), kTRUE);
+    }
     treeCache_->AddBranch(BranchTypeToAuxiliaryBranchName(branchType_).c_str(), kTRUE);
     trainedSet_.clear();
     triggerSet_.clear();


### PR DESCRIPTION
The following is causing a crash on 4.6 workflow with ROOT 6.04.00.

Particular input file example:

```
/store/data/Run2010A/MinimumBias/RAW-RECO/v6/000/138/923/142C82F8-4285-DF11-B26D-00E081791865.root
```

This input file does not contain 'branchListIndexes' branch.

For more details, look at ROOT-7015 and ROOT commit:
5fc68e7a161370008aa97cac9c5cdda6ad326ea5

```
..this avoids the situation where the user could ask for a
branch to be added to a TTree's cache and have the
call silently have no effect.
```

ROOT 6.04.00 will trigger error exception if input file does not
have required branch.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
