### PR TITLE
Fix using GetExpFormula(Option_t *) on TF1 in ROOT 6.04.00

### DIFF
--- a/CondFormats/BTauObjects/interface/BTagEntry.h
+++ b/CondFormats/BTauObjects/interface/BTagEntry.h
@@ -18,6 +18,7 @@
 #include <string>
 #include <TF1.h>
 #include <TH1.h>
+#include <RVersion.h>
 
 #include "CondFormats/Serialization/interface/Serializable.h"
 
@@ -67,7 +68,11 @@ public:
   BTagEntry() {}
   BTagEntry(const std::string &csvLine);
   BTagEntry(const std::string &func, Parameters p);
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
+  BTagEntry(TF1* func, Parameters p);
+#else
   BTagEntry(const TF1* func, Parameters p);
+#endif
   BTagEntry(const TH1* histo, Parameters p);
   ~BTagEntry() {}
   static std::string makeCSVHeader();

--- a/CondFormats/BTauObjects/src/BTagEntry.cc
+++ b/CondFormats/BTauObjects/src/BTagEntry.cc
@@ -108,8 +108,13 @@ BTagEntry::BTagEntry(const std::string &func, BTagEntry::Parameters p):
   }
 }
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
+BTagEntry::BTagEntry(TF1* func, BTagEntry::Parameters p):
+  formula(std::string(func->GetFormula()->GetExpFormula("P").Data())),
+#else
 BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
   formula(std::string(func->GetExpFormula("p").Data())),
+#endif
   params(p)
 {
   if (func->IsZombie()) {

--- a/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
+++ b/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.cc
@@ -114,8 +114,13 @@ throw std::exception();
   }
 }
 
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
+BTagEntry::BTagEntry(TF1* func, BTagEntry::Parameters p):
+  formula(std::string(func->GetFormula()->GetExpFormula("P").Data())),
+#else
 BTagEntry::BTagEntry(const TF1* func, BTagEntry::Parameters p):
   formula(std::string(func->GetExpFormula("p").Data())),
+#endif
   params(p)
 {
   if (func->IsZombie()) {

--- a/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.h
+++ b/RecoBTag/PerformanceDB/test/BTagCalibrationStandalone.h
@@ -18,7 +18,7 @@
 #include <string>
 #include <TF1.h>
 #include <TH1.h>
-
+#include <RVersion.h>
 
 class BTagEntry
 {
@@ -65,7 +65,11 @@ public:
   BTagEntry() {}
   BTagEntry(const std::string &csvLine);
   BTagEntry(const std::string &func, Parameters p);
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
+  BTagEntry(TF1* func, Parameters p);
+#else
   BTagEntry(const TF1* func, Parameters p);
+#endif
   BTagEntry(const TH1* histo, Parameters p);
   ~BTagEntry() {}
   static std::string makeCSVHeader();

--- a/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
+++ b/RecoParticleFlow/PFClusterTools/test/ProducePFCalibrationObject.cc
@@ -20,7 +20,7 @@
 
 
 #include "TF1.h"
-
+#include <RVersion.h>
 
 using namespace std;
 using namespace edm;
@@ -97,7 +97,11 @@ void ProducePFCalibrationObject::beginRun(const edm::Run& run, const edm::EventS
 
       // write them in the containers for the storage
       limitsToWrite.push_back(limits);
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
+      formulasToWrite.push_back(string(function->GetFormula()->GetExpFormula("P").Data()));
+#else
       formulasToWrite.push_back(string(function->GetExpFormula("p").Data()));
+#endif
       resToWrite.push_back(functType[fType]);
 
     }


### PR DESCRIPTION
In ROOT 6.04.00 TF1 does not inherit TFormula interface anymore. Now,
TFormula is a member of TF1. Thus an aditional hop is required for
`GetExpFormula(Option_t *)`. This is not the case for `GetExpFormula()`.

I asked Lorenzo if he could add a const wrapper for `GetExpFormula(Option_t *)`
also. If he agrees, this can be reverted back.

Note that changes are applied if new ROOT is used, thus should have 0 effect
in CMSSW_7_5_X, which is running ROOT 6.02.XX.

New ROOT will be added in DEVEL IBs in a few days.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
