### PR TITLE
Backport from 75X (#8522, #8946, #9018)

### DIFF
--- a/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaPlotter.h
@@ -75,6 +75,7 @@ private:
     std::vector<double> _parametersEta;
     std::vector<double> _parametersPhi;
     std::vector<double> _parametersTurnOn;
+    std::vector<double> _parametersTurnOnSumEt;
     std::vector<double> _parametersDxy;
 
     std::map<std::string, MonitorElement *> _elements;

--- a/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
+++ b/HLTriggerOffline/Exotica/interface/HLTExoticaSubAnalysis.h
@@ -147,6 +147,7 @@ private:
     std::vector<double> _parametersEta;
     std::vector<double> _parametersPhi;
     std::vector<double> _parametersTurnOn;
+    std::vector<double> _parametersTurnOnSumEt;
     std::vector<double> _parametersDxy;
 
     /// gen/rec objects cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDiPhoton_cff.py
@@ -4,12 +4,14 @@ DiPhotonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_DoublePho85_v",    # Run2 proposal
         "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon22_AND_HE10_R9Id65_Eta2_Mass15_v",
-        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Eta2_Mass60_v"
+        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Eta2_Mass60_v",
+        "HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon25_AND_HE10_R9Id65_Eta2_Mass15_v" #50ns backup menu
         #"HLT_DoublePhoton70_v"  # Run1 (frozenHLT)
         ),
-    recPhotonLabel  = cms.InputTag("gedPhotons"),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    #recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
-    minCandidates = cms.uint32(2),
+    minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
     parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 250, 300, 400, 500, 600, 700, 800, 900, 1000,
                                     1100, 1200, 1500

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaDisplacedMuEG_cff.py
@@ -13,8 +13,8 @@ DisplacedMuEGPSet = cms.PSet(
         #"HLT_Mu17_Ele8_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v", # Run1
         #"HLT_Mu8_Ele17_CaloIdT_CaloIsoVL_TrkIdVL_TrkIsoVL_v"  # Run1
         ),
-    #recElecLabel  = cms.InputTag("gedGsfElectrons"),
-    recPhotonLabel  = cms.InputTag("gedPhotons"),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    #recPhotonLabel  = cms.InputTag("gedPhotons"),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHT_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHT_cff.py
@@ -4,14 +4,17 @@ HTPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_PFHT650_WideJetMJJ900DEtaJJ1p5_v",
         "HLT_PFHT650_WideJetMJJ950DEtaJJ1p5_v",
-        "HLT_PFHT750_4Jet_v", # Run2
+        #"HLT_PFHT750_4Jet_v", # Run2
+        "HLT_PFHT750_4Jet_Pt50_v",
         "HLT_PFHT650_4Jet_v", # Run2
         "HLT_PFHT550_4Jet_v", # Run2
-        "HLT_PFHT900_v",      # Run2
+        #"HLT_PFHT900_v",      # Run2
+        "HLT_PFHT800_v",
         "HLT_PFHT650_v",
         "HLT_HT900_v",        # Run2
         "HLT_HT300_v",        # Run2
-        "HLT_ECALHT800_v"     # Run2 7e33
+        "HLT_ECALHT800_v",     # Run2 7e33
+        "HLT_Photon90_CaloIdL_PFHT600_v" # 50ns backup menu
         #"HLT_HT750_v"        # Run1 (frozenHLT)
         ),
     recPFMHTLabel  = cms.InputTag("recoExoticaValidationHT"),
@@ -21,12 +24,7 @@ HTPSet = cms.PSet(
     MET_recCut      = cms.string("sumEt > 75"),
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble(0, 50, 100, 150,
-                                   200, 220, 240, 260, 280, 300,
-                                   320, 340, 360, 380, 400,
-                                   420, 440, 460, 480, 500,
-                                   520, 540, 560, 580, 600,
-                                   620, 640, 660, 680, 700,
-                                   750, 800, 850, 900, 950, 1000,
-                                   1100, 1200, 1300, 1400, 1500)
+    parametersTurnOn = cms.vdouble(0, 50, 100, 150, 200, 250, 300, 350, 400,
+                                   500, 600, 700, 800, 900, 1000
+                                   )
 )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtElectron_cff.py
@@ -2,7 +2,8 @@ import FWCore.ParameterSet.Config as cms
 
 HighPtElectronPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_Ele105_CaloIdVT_GsfTrkIdT_v" # Run2 proposal
+        "HLT_Ele105_CaloIdVT_GsfTrkIdT_v", # Run2 proposal
+        "HLT_Ele115_CaloIdVT_GsfTrkIdT_v"  # 50ns backup menu
         ),
     recElecLabel  = cms.InputTag("gedGsfElectrons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaHighPtPhoton_cff.py
@@ -5,15 +5,15 @@ HighPtPhotonPSet = cms.PSet(
         "HLT_Photon175_v",  # Run2 proposal
         "HLT_Photon165_HE10_v",  # Run2 proposal
         "HLT_Photon36_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon31_AND_HE10_R9Id65_Mass10_v",  # Run2 proposal
-        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Mass60_v"  # Run2 proposal
+        "HLT_Photon26_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon16_AND_HE10_R9Id65_Mass60_v",  # Run2 proposal
+        "HLT_Photon90_CaloIdL_PFHT600_v" #50ns backup menu
         #"HLT_Photon135_v"  # Run1 (frozenHLT)
         ),
     recPhotonLabel  = cms.InputTag("gedPhotons"),
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble( 0, 50, 100, 110, 120, 130, 140, 150, 
-                                    160, 170, 180, 190, 200, 
+    parametersTurnOn = cms.vdouble( 0, 50, 100, 150, 200, 
                                     250, 300, 400, 500, 600, 700, 800, 900, 1000,
                                     1100, 1200, 1500
                                    ),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtTrimuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaLowPtTrimuon_cff.py
@@ -1,0 +1,16 @@
+import FWCore.ParameterSet.Config as cms
+
+LowPtTrimuonPSet = cms.PSet(
+    hltPathsToCheck = cms.vstring(
+        "HLT_TrkMu15_DoubleTrkMu5NoFiltersNoVtx_v", #signal
+        "HLT_TrkMu17_DoubleTrkMu8NoFiltersNoVtx_v", #signal
+        "HLT_DiMuon0_Jpsi_Muon",                    # control
+        "HLT_Mu17_TkMu8_DZ",                        # backup
+        "HLT_Mu17_Mu8_DZ"                           # backup
+    ),
+    recMuonLabel  = cms.InputTag("muons"),
+    # -- Analysis specific cuts
+    minCandidates = cms.uint32(3),
+    # -- Analysis specific binnings
+    parametersDxy      = cms.vdouble(50, -2.500, 2.500),
+    )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMETplusTrack_cff.py
@@ -10,22 +10,25 @@ METplusTrackPSet = cms.PSet(
     recPFMETLabel = cms.InputTag("pfMet"),
     #recMETLabel   = cms.InputTag("hltPFMETProducer"),
     genMETLabel   = cms.InputTag("genMetTrue"),
-    recTrackLabel = cms.InputTag("hltIter2Merged"),
+    recMuonLabel  = cms.InputTag("muons"),
+    recElecLabel  = cms.InputTag("gedGsfElectrons"),
+    #recTrackLabel = cms.InputTag("generalTracks"),
     #hltMETLabel   = cms.InputTag("hltMetClean"),                    
     l1METLabel    = cms.InputTag("l1extraParticles","MET"),   
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
     # -- Analysis specific binnings
-    parametersTurnOn = cms.vdouble( 0,  5,  10,  15,  20,  25,  30,  35,  40,  45,  50,
-                                       55,  60,  65,  70,  75,  80,  85,  90,  95, 100,
-                                      105, 110, 115, 120, 125, 130, 135, 140, 145, 150,
-                                      155, 160, 165, 170, 175, 180, 185, 190, 195, 200,
-                                      205, 210, 215, 220, 225, 230, 235, 240, 245, 250,
-                                      255, 260, 265, 270, 275, 280, 285, 290, 295, 300,
-                                      305, 310, 315, 320, 325, 330, 335, 340, 345, 350,
-                                      355, 360, 365, 370, 375, 380, 385, 390, 395, 400,
-                                      405, 410, 415, 420, 425, 430, 435, 440, 445, 450,
-                                      455, 460, 465, 470, 475, 480, 485, 490, 495, 500
+    parametersTurnOn = cms.vdouble(   0,  10,  20,  30,  40,  50,  60,  70,   80,  90,
+                                    100, 110, 120, 130, 140, 150, 160, 170,  180, 190,
+                                    200, 210, 220, 230, 240, 250, 260, 270,  280, 290,
+                                    300, 310, 320, 330, 340, 350, 360, 370,  380, 390,
+                                    400
                                   ),
+    parametersTurnOnSumEt = cms.vdouble(   0,  10,  20,  30,  40,  50,  60,  70,   80,  90,
+                                         100, 110, 120, 130, 140, 150, 160, 170,  180, 190,
+                                         200, 210, 220, 230, 240, 250, 260, 270,  280, 290,
+                                         300, 310, 320, 330, 340, 350, 360, 370,  380, 390,
+                                         400
+                                       ),
 )
 

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaMonojet_cff.py
@@ -2,24 +2,25 @@ import FWCore.ParameterSet.Config as cms
 
 MonojetPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        #"HLT_PFJet260_v", # Run2
-        #"HLT_PFJetCen80_PFMETNoMu100_v",
-        #"HLT_PFJetCen80_PFMHTNoPuNoMu100_v",
-        #"HLT_PFCenJet140_PFMETNoMu100_PFMHTNoMu140_v",
-        #"HLT_PFCenJet140_PFMETNoMu140_PFMHTNoMu140_v",
-        #"HLT_PFCenJet150_PFMETNoMu150_PFMHTNoMu150_v",
-        "HLT_MonoCentralPFJet140_PFMETNoMu100_PFMHTNoMu140_NoiseCleaned_v", 
-        "HLT_MonoCentralPFJet140_PFMETNoMu140_PFMHTNoMu140_NoiseCleaned_v",
-        "HLT_MonoCentralPFJet150_PFMETNoMu150_PFMHTNoMu150_NoiseCleaned_v"
-        #"HLT_CaloJet500_NoID_v",
-        #"HLT_CaloJet500_NoJetID_v",
-        #"HLT_MonoCentralPFJet80_PFMETnoMu105_NHEF0p95_v" # Run1
-        ),
+        "HLT_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v", 
+        "HLT_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v", 
+        #"HLT_MonoCentralPFJet80_PFMETNoMu120_PFMHTNoMu120_NoiseCleaned_v",
+        #"HLT_MonoCentralPFJet80_PFMETNoMu90_PFMHTNoMu90_NoiseCleaned_v",
+        "HLT_CaloMET200_NoiseCleaned_v",
+        "HLT_MonoCentralPFJet80_PFMETNoMu120_NoiseCleaned_PFMHTNoMu120_IDTight_v",
+        "HLT_MonoCentralPFJet80_PFMETNoMu90_NoiseCleaned_PFMHTNoMu90_IDTight_v"
+    ),
 
-    recCaloJetLabel  = cms.InputTag("ak4CaloJets"),
-    recPFJetLabel    = cms.InputTag("ak4PFJets"),
-    recPFMETLabel    = cms.InputTag("recoExoticaValidationMETNoMu"),
-    recPFMHTLabel    = cms.InputTag("recoExoticaValidationMHTNoMu"),
+    recCaloJetLabel    = cms.InputTag("ak4CaloJets"),
+    recPFJetLabel      = cms.InputTag("ak4PFJets"),
+    #GenJetLabel     = cms.InputTag("ak4GenJets"),
+    recPFMETLabel      = cms.InputTag("recoExoticaValidationMETNoMu"),
+    recPFMHTLabel      = cms.InputTag("recoExoticaValidationMHTNoMu"),
+    #PFMETLabel      = cms.InputTag("pfMet"),
+    #PFMHTLabel      = cms.InputTag("recoExoticaValidationHT"),
+
+    #GenMETLabel     = cms.InputTag("genMetTrue"),
+    #GenMETCaloLabel = cms.InputTag("genMetCalo"),
 
     # -- Analysis specific cuts
     minCandidates = cms.uint32(1),
@@ -28,5 +29,6 @@ MonojetPSet = cms.PSet(
                                     160, 170, 180, 190, 200,
                                     220, 240, 260, 280, 300, 
                                     320, 340, 360, 380, 400,
-                                    420, 440, 460, 480, 500),
+                                    420, 440, 460, 480, 500,600,700,800,900,1100,1200,
+                                    1400,1600,1800,2000,2200,2400,2600,2800,3000),
     )

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaPureMET_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 PureMETPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
-        "HLT_PFMET180_NoiseCleaned_v",  # Run2
+        "HLT_PFMET170_NoiseCleaned_v",  # Run2
         "HLT_CaloMET200_NoiseCleaned_v"
         #"HLT_MET120_HBHENoiseCleaned_v" # Run1
         ),

--- a/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
+++ b/HLTriggerOffline/Exotica/python/analyses/hltExoticaSingleMuon_cff.py
@@ -3,7 +3,10 @@ import FWCore.ParameterSet.Config as cms
 SingleMuonPSet = cms.PSet(
     hltPathsToCheck = cms.vstring(
         "HLT_Mu45_e2p1_v", # Run 2 
-        "HLT_Mu50_v" # Run 2
+        "HLT_Mu50_v", # Run 2
+        #50ns backup menu
+        "HLT_Mu55_v",
+        "HLT_Mu50_eta2p1_v"
         ),
     recMuonLabel  = cms.InputTag("muons"),
     # -- Analysis specific cuts

--- a/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaPostProcessors_cff.py
@@ -98,6 +98,10 @@ for type in plot_types:
 add_reco_strings(efficiency_strings)
 
 #--- IMPORTANT: Here you have to add the analyses one by one.
+hltExoticaPostLowPtTrimuon = hltExoticaPostProcessor.clone()
+hltExoticaPostLowPtTrimuon.subDirs = ['HLT/Exotica/LowPtTrimuon']
+hltExoticaPostLowPtTrimuon.efficiencyProfile = efficiency_strings
+
 hltExoticaPostHighPtDimuon = hltExoticaPostProcessor.clone()
 hltExoticaPostHighPtDimuon.subDirs = ['HLT/Exotica/HighPtDimuon']
 hltExoticaPostHighPtDimuon.efficiencyProfile = efficiency_strings
@@ -191,6 +195,8 @@ hltExoticaHTDisplacedJets.subDirs = ['HLT/Exotica/HTDisplacedJets']
 hltExoticaHTDisplacedJets.efficiencyProfile = efficiency_strings
 
 hltExoticaPostProcessors = cms.Sequence(
+    # Tri-lepton paths
+    hltExoticaPostLowPtTrimuon +
     # Di-lepton paths
     hltExoticaPostHighPtDimuon +
     hltExoticaPostHighPtDielectron +

--- a/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
+++ b/HLTriggerOffline/Exotica/python/hltExoticaValidator_cfi.py
@@ -14,6 +14,7 @@
 import FWCore.ParameterSet.Config as cms
 
 # Validation categories (sub-analyses)
+from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtTrimuon_cff      import LowPtTrimuonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtDimuon_cff      import HighPtDimuonPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHighPtDielectron_cff  import HighPtDielectronPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaLowPtDimuon_cff       import LowPtDimuonPSet
@@ -32,7 +33,7 @@ from HLTriggerOffline.Exotica.analyses.hltExoticaPureMET_cff           import Pu
 from HLTriggerOffline.Exotica.analyses.hltExoticaMETplusTrack_cff      import METplusTrackPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaMonojet_cff           import MonojetPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaMonojetBackup_cff     import MonojetBackupPSet
-from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedDimuonDijet_cff import DisplacedDimuonDijetPSet
+#from HLTriggerOffline.Exotica.analyses.hltExoticaDisplacedDimuonDijet_cff import DisplacedDimuonDijetPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaEleMu_cff             import EleMuPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaHTDisplacedJets_cff   import HTDisplacedJetsPSet
 from HLTriggerOffline.Exotica.analyses.hltExoticaPhotonMET_cff         import PhotonMETPSet
@@ -48,6 +49,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     # appears in Run summary/Exotica/ANALYSIS_NAME
 
     analysis       = cms.vstring(
+        "LowPtTrimuon",
         "HighPtDimuon",
         "HighPtDielectron",
         "LowPtDimuon",
@@ -67,7 +69,7 @@ hltExoticaValidator = cms.EDAnalyzer(
         "METplusTrack",
         "Monojet",
         "MonojetBackup",
-        "DisplacedDimuonDijet",
+        #"DisplacedDimuonDijet",
         "EleMu",
         "PhotonMET",
         "HTDisplacedJets"
@@ -88,6 +90,17 @@ hltExoticaValidator = cms.EDAnalyzer(
                                    62, 64, 66, 68, 70, 72, 74, 76, 78, 80,
                                    82, 84, 86, 88, 90, 92, 94, 96, 98, 100,
                                    ),
+
+    # TurnOn for SumEt
+    parametersTurnOnSumEt = cms.vdouble(    0,  100,  200,  300,  400,  500,  600,  700,  800,  900,
+                                         1000, 1100, 1200, 1300, 1400, 1500, 1600, 1700, 1800, 1900,  
+                                         2000, 2100, 2200, 2300, 2400, 2500, 2600, 2700, 2800, 2900,  
+                                         3000, 3100, 3200, 3300, 3400, 3500, 3600, 3700, 3800, 3900,  
+                                         4000, 4100, 4200, 4300, 4400, 4500, 4600, 4700, 4800, 4900,  
+                                         5000, 5100, 5200, 5300, 5400, 5500, 5600, 5700, 5800, 5900,  
+                                         6000, 6100, 6200, 6300, 6400, 6500, 6600, 6700, 6800, 6900,  
+                                         7000
+                                       ),
 
     # -- (NBins, minVal, maxValue) for the Eta and Phi efficiency plots
     parametersEta      = cms.vdouble(48, -2.400, 2.400),
@@ -184,6 +197,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     # for any object you want.
     #    * Var_genCut, Var_recCut (cms.string): where Var=Mu, Ele, Photon, Jet, PFTau, MET (see above)
 
+    LowPtTrimuon     = LowPtTrimuonPSet,
     HighPtDimuon     = HighPtDimuonPSet,
     HighPtDielectron = HighPtDielectronPSet,
     LowPtDimuon      = LowPtDimuonPSet,
@@ -203,7 +217,7 @@ hltExoticaValidator = cms.EDAnalyzer(
     Monojet          = MonojetPSet,
     MonojetBackup    = MonojetBackupPSet,
     HT               = HTPSet,
-    DisplacedDimuonDijet = DisplacedDimuonDijetPSet,
+    #DisplacedDimuonDijet = DisplacedDimuonDijetPSet,
     EleMu            = EleMuPSet,
     PhotonMET        = PhotonMETPSet,
     HTDisplacedJets  = HTDisplacedJetsPSet 

--- a/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaPlotter.cc
@@ -27,6 +27,7 @@ HLTExoticaPlotter::HLTExoticaPlotter(const edm::ParameterSet & pset,
     _parametersEta(pset.getParameter<std::vector<double> >("parametersEta")),
     _parametersPhi(pset.getParameter<std::vector<double> >("parametersPhi")),
     _parametersTurnOn(pset.getParameter<std::vector<double> >("parametersTurnOn")),
+    _parametersTurnOnSumEt(pset.getParameter<std::vector<double> >("parametersTurnOnSumEt")),
     _parametersDxy(pset.getParameter<std::vector<double> >("parametersDxy"))
 {
     LogDebug("ExoticaValidation") << "In HLTExoticaPlotter::constructor()";
@@ -199,10 +200,10 @@ void HLTExoticaPlotter::bookHist(DQMStore::IBooker & iBooker,
 
     if (variable.find("SumEt") != std::string::npos) {
         std::string title = "Sum ET of " + sourceUpper + " " + objType;
-        const size_t nBins = _parametersTurnOn.size() - 1;
+        const size_t nBins = _parametersTurnOnSumEt.size() - 1;
         float * edges = new float[nBins + 1];
         for (size_t i = 0; i < nBins + 1; i++) {
-            edges[i] = _parametersTurnOn[i];
+            edges[i] = _parametersTurnOnSumEt[i];
         }
         h = new TH1F(name.c_str(), title.c_str(), nBins, edges);
         delete[] edges;

--- a/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
+++ b/HLTriggerOffline/Exotica/src/HLTExoticaSubAnalysis.cc
@@ -38,6 +38,7 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,
     _parametersEta(pset.getParameter<std::vector<double> >("parametersEta")),
     _parametersPhi(pset.getParameter<std::vector<double> >("parametersPhi")),
     _parametersTurnOn(pset.getParameter<std::vector<double> >("parametersTurnOn")),
+    _parametersTurnOnSumEt(pset.getParameter<std::vector<double> >("parametersTurnOnSumEt")),
     _parametersDxy(pset.getParameter<std::vector<double> >("parametersDxy")),
     _recMuonSelector(0),
     _recMuonTrkSelector(0),
@@ -79,6 +80,10 @@ HLTExoticaSubAnalysis::HLTExoticaSubAnalysis(const edm::ParameterSet & pset,
     if (anpset.exists("parametersDxy")) {
         _parametersDxy = anpset.getParameter<std::vector<double> >("parametersDxy");
         _pset.insert(true, "parametersDxy", anpset.retrieve("parametersDxy"));
+    }
+    if (anpset.exists("parametersTurnOnSumEt")) {
+        _parametersTurnOnSumEt = anpset.getParameter<std::vector<double> >("parametersTurnOnSumEt");
+        _pset.insert(true, "parametersTurnOnSumEt", anpset.retrieve("parametersTurnOnSumEt"));
     }
 
     // Get names of objects that we may want to get from the event.
@@ -1034,10 +1039,10 @@ void HLTExoticaSubAnalysis::bookHist(DQMStore::IBooker & iBooker,
     
     if (variable.find("SumEt") != std::string::npos) {
       std::string title = "Sum ET of " + sourceUpper + " " + objType;
-      const size_t nBins = _parametersTurnOn.size() - 1;
+      const size_t nBins = _parametersTurnOnSumEt.size() - 1;
       float * edges = new float[nBins + 1];
       for (size_t i = 0; i < nBins + 1; i++) {
-	edges[i] = _parametersTurnOn[i];
+	edges[i] = _parametersTurnOnSumEt[i];
       }
       h = new TH1F(name.c_str(), title.c_str(), nBins, edges);
       delete[] edges;


### PR DESCRIPTION
(From #8522)
Modified METplusTrack conf, MonoJet conf. Added LowPtTrimuon conf. Introduced turnOnSumEt to set bins separately from turnOn of Pt.

(From #8946)
Update path names and binnings.

(From #9018)
Modified paths. Fixed a bug in MonoJet conf. Remove DisplacedDimuonDijet. recPhotons label in DisplacedMuEG and DiPhoton is replaced to recElectrons label.
Added paths : HT: HLT_PFHT750_4Jet_Pt50_v HLT_PFHT800_v HLT_Photon90_CaloIdL_PFHT600_v
HighPtElectron: HLT_Ele115_CaloIdVT_GsfTrkIdT_v
DiPhoton: HLT_Photon42_R9Id85_OR_CaloId24b40e_Iso50T80L_Photon25_AND_HE10_R9Id65_Eta2_Mass15_v
HighPtPhoton: HLT_Photon90_CaloIdL_PFHT600_v
SingleMuon: HLT_Mu55_v HLT_Mu50_eta2p1_v
