### PR TITLE
Set UnbinnedLikelihoodFit::getParameterErrors() return as const double *

### DIFF
--- a/RecoTracker/DeDx/interface/UnbinnedLikelihoodFit.h
+++ b/RecoTracker/DeDx/interface/UnbinnedLikelihoodFit.h
@@ -47,7 +47,7 @@ class UnbinnedLikelihoodFit : public TObject
     double getParameterValue(uint32_t i) { return function_ ? function_->GetParameter(i) : 0; }
     double getParameterError(uint32_t i) { return function_ ? function_->GetParError(i)  : 0; }
     double* getParameterValues() { return function_ ? function_->GetParameters() : NULL; }
-    double* getParameterErrors() { return function_ ? function_->GetParErrors()  : NULL; }
+    const double* getParameterErrors() { return function_ ? function_->GetParErrors()  : NULL; }
   
   private:
     // input data


### PR DESCRIPTION
Update in ROOT 6.04.00 changed return type of `TF1::GetParErrors()
const` to be const.

See ROOT commit: 0539de6de4bb7aba2160da0195296aa0d94209ce

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
