### PR TITLE
reserve more memory for sistrips to keep on-demand clusters from reallocation

### DIFF
--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -215,7 +215,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
     
     if(onDemand) assert(output->onDemand());
 
-    output->reserve(15000,6*10000);
+    output->reserve(15000,12*10000);
 
 
 

--- a/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/MultiTrackSelector.cc
@@ -518,7 +518,7 @@ void MultiTrackSelector::run( edm::Event& evt, const edm::EventSetup& es ) const
 
     LogDebug("SelectVertex") << " select vertex with z position " << it->z() << " " 
 			     << it->chi2() << " " << it->ndof() << " " << TMath::Prob(it->chi2(), static_cast<int32_t>(it->ndof()));
-    Vertex vtx = *it;
+    const Vertex& vtx = *it;
     bool pass = vertexCut_[tsNum]( vtx );
     if( pass ) { 
       points.push_back(it->position()); 


### PR DESCRIPTION
@fwyzard @Martin-Grunewald @VinInn @rovere 

In recent IBs we started getting segfaults in step2 in high-PU workflow (25202, ttbar PU35@25ns).
With debugging, the  event (it was event 28 at least in CMSSW_7_5_X_2015-05-16-1100) had a segfault right after the number of clusters grew above 60K.
It looks like recent HLT tables have more reasons to run iterative tracking, probably making the on-demand facility going to essentially full unpacking level.
This situation is much less likely to happen in real HLT with all the prescales in place, but still it could happen.

I doubled the reserve, which is roughly the edge of the cluster multiplicity with full unpacking  scaled to PU50.
 If I trust interactive root, one empty cluster is 32 bytes  ==> +1.9MB increase] due to the reserve, which is fairly small.

I suppose this is needed in 74X as well.
