### PR TITLE
Copy some memory improvements from 75X to SLHC

### DIFF
--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h
@@ -8,6 +8,9 @@
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
 
+#include "FWCore/Utilities/interface/RunningAverage.h"
+
+
 class TrackingRegion;
 namespace edm { class Event; class EventSetup; }
 #include <vector>
@@ -16,11 +19,12 @@ class HitTripletGenerator : public OrderedHitsGenerator {
 public:
 
   HitTripletGenerator(unsigned int size=500);
+ HitTripletGenerator(HitTripletGenerator const & other) : localRA(other.localRA.mean()){}
 
   virtual ~HitTripletGenerator() { }
 
   virtual const OrderedHitTriplets & run(
-    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es);
+    const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es) final;
 
   // temporary interface, for bckwd compatibility
   virtual void hitTriplets( const TrackingRegion& reg, OrderedHitTriplets & prs,
@@ -29,11 +33,11 @@ public:
   virtual void hitTriplets( const TrackingRegion& reg, OrderedHitTriplets & prs,
       const edm::Event & ev,  const edm::EventSetup& es) = 0;
 
-  virtual void clear();
+  virtual void clear() final;
 
 private:
   OrderedHitTriplets theTriplets;
-
+  edm::RunningAverage localRA;
 };
 
 

--- a/RecoPixelVertexing/PixelTriplets/src/HitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitTripletGenerator.cc
@@ -1,20 +1,20 @@
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
 
-HitTripletGenerator::HitTripletGenerator(unsigned int nSize)
-{
-  theTriplets.reserve(nSize);
-}
+HitTripletGenerator::HitTripletGenerator(unsigned int nSize) : localRA(nSize) {}
 
 const OrderedHitTriplets & HitTripletGenerator::run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
 {
-  theTriplets.clear();
+  assert(theTriplets.size()==0);assert(theTriplets.capacity()==0);
+  theTriplets.reserve(localRA.upper());
   hitTriplets(region, theTriplets, ev, es);
+  localRA.update(theTriplets.size());
+  theTriplets.shrink_to_fit();
   return theTriplets;
 }
 
 void HitTripletGenerator::clear() 
 {
-  theTriplets.clear();
+  theTriplets.clear(); theTriplets.shrink_to_fit();
 }
 

--- a/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
+++ b/RecoTracker/CkfPattern/src/CkfTrackCandidateMakerBase.cc
@@ -277,7 +277,7 @@ namespace cms{
       unsmoothedResult.erase(std::remove_if(unsmoothedResult.begin(),unsmoothedResult.end(),
 					    std::not1(std::mem_fun_ref(&Trajectory::isValid))),
 			     unsmoothedResult.end());
-      
+      unsmoothedResult.shrink_to_fit();
       // If requested, reverse the trajectories creating a new 1-hit seed on the last measurement of the track
       if (reverseTrajectories) {
         vector<Trajectory> reversed; 

--- a/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLeg.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/PhotonConversionTrajectorySeedProducerFromSingleLeg.cc
@@ -80,6 +80,7 @@ void PhotonConversionTrajectorySeedProducerFromSingleLeg::produce(edm::Event& ev
 
   
   //edm::LogInfo("debugTrajSeedFromSingleLeg") << " TrajectorySeedCollection size " << result->size();
+  result->shrink_to_fit();
   ev.put(result, _newSeedCandidates);  
 
   //FIXME 

--- a/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
@@ -11,6 +11,7 @@
 #include "RecoTracker/TkTrackingRegions/interface/OrderedHitsGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
 #include "RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h"
+#include "FWCore/Utilities/interface/RunningAverage.h"
 
 class TrackingRegion;
 namespace edm { class Event; class EventSetup; }
@@ -19,6 +20,7 @@ class HitPairGenerator : public OrderedHitsGenerator {
 public:
 
   explicit HitPairGenerator(unsigned int size=7500);
+  HitPairGenerator(HitPairGenerator const & other) : localRA(other.localRA.mean()){}
 
   virtual ~HitPairGenerator() { }
 
@@ -41,17 +43,11 @@ public:
 
   virtual HitPairGenerator* clone() const = 0;
 
-  virtual void clear() {
-     // back to initial allocation if too large
-     if (thePairs.capacity()> 4*m_capacity) {
-       OrderedHitPairs tmp; tmp.reserve(m_capacity); tmp.swap(thePairs);
-     } 
-     thePairs.clear(); 
-  } 
+  virtual void clear() final;
 
 private:
   OrderedHitPairs thePairs;
-  unsigned int m_capacity;
+  edm::RunningAverage localRA;
 
 };
 

--- a/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
+++ b/RecoTracker/TkHitPairs/interface/RecHitsSortedInPhi.h
@@ -141,6 +141,7 @@ public:
   std::size_t size() const { return indeces.size()/2;}
   bool empty() const { return indeces.empty();}
   void clear() { indeces.clear();}
+  void shrink_to_fit() { indeces.shrink_to_fit();}
 
   void add (int il, int ol) { indeces.push_back(il);indeces.push_back(ol);}
 

--- a/RecoTracker/TkHitPairs/src/HitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGenerator.cc
@@ -1,14 +1,21 @@
 #include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
 
-HitPairGenerator::HitPairGenerator(unsigned int nSize) : m_capacity(nSize)
-{
-  thePairs.reserve(nSize);
-}
+HitPairGenerator::HitPairGenerator(unsigned int nSize) : localRA(nSize) {}
 
 const OrderedHitPairs & HitPairGenerator::run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
 {
-  thePairs.clear();
+  assert(thePairs.size()==0); assert(thePairs.capacity()==0);
+  thePairs.reserve(localRA.upper());
   hitPairs(region, thePairs, ev, es);
+  thePairs.shrink_to_fit();
   return thePairs;
 }
+
+
+void HitPairGenerator::clear() 
+{
+  localRA.update(thePairs.size());
+  thePairs.clear(); thePairs.shrink_to_fit();
+}
+

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -168,6 +168,7 @@ HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& regio
     delete checkRZ;
   }
   LogDebug("HitPairGeneratorFromLayerPair")<<" total number of pairs provided back: "<<result.size();
+  result.shrink_to_fit();
   return result;
 }
 

--- a/RecoVertex/V0Producer/src/V0Producer.cc
+++ b/RecoVertex/V0Producer/src/V0Producer.cc
@@ -74,8 +74,8 @@ void V0Producer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
 	      std::back_inserter(*lambdaCandidates) );
 
    // Write the collections to the Event
-   iEvent.put( kShortCandidates, std::string("Kshort") );
-   iEvent.put( lambdaCandidates, std::string("Lambda") );
+   kShortCandidates->shrink_to_fit(); iEvent.put( kShortCandidates, std::string("Kshort") );
+   lambdaCandidates->shrink_to_fit(); iEvent.put( lambdaCandidates, std::string("Lambda") );
 
 }
 


### PR DESCRIPTION
Found the problem in `SeedGeneratorFromRegionHitsEDProducer` and realised Vincenzo had fixed in 75X, just using `vector.clear(); vector.shrink_to_fit();` - I'd been greping for things of the form `vector.swap(temp)`.  So I went through and copied the majority of the occurrences of `shrink_to_fit` in 75X to SLHC.  There's also a few uses of `edm::RunningAverage` to estimate a reserve size.

Retained memory, excluding products before:
![mem75x_before](https://cloud.githubusercontent.com/assets/6480160/7782802/fa3f64a8-0121-11e5-97f4-31f4586ba94e.png)
After applying this pull request:
![mem75x_after](https://cloud.githubusercontent.com/assets/6480160/7782803/fbe75af4-0121-11e5-95ae-3383322e9384.png)

So there's a saving of ~85 Mb just in `SeedGeneratorFromRegionHitsEDProducer`.  Probably quite a few savings in smaller modules too, which could add up to quite a bit.

Think I'm going to call it a day now - all the big memory allocations are before the first event, so probably services, database reads etcetera.  The only exception is PoolOutputModule which I'm reluctant to get into.  I'll start running some full RSS and VmSize tests and post here later.

@lgray
