### PR TITLE
Remove duplicate function productHistoryRegistryUpdate()

### DIFF
--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -868,7 +868,7 @@ DQMRootSource::setupFile(unsigned int iIndex)
     std::string* pPassID = &passID;
     processHistoryTree->SetBranchAddress(kProcessConfigurationPassID,&pPassID);
 
-    edm::ProcessHistoryRegistry& phr = processHistoryRegistryUpdate();
+    edm::ProcessHistoryRegistry& phr = processHistoryRegistryForUpdate();
     std::vector<edm::ProcessConfiguration> configs;
     configs.reserve(5);
     m_historyIDs.clear();

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -171,9 +171,6 @@ namespace edm {
     /// Const accessor for process history registry.
     ProcessHistoryRegistry const& processHistoryRegistry() const {return *processHistoryRegistry_;}
 
-    /// Non-const accessor for process history registry.
-    ProcessHistoryRegistry& processHistoryRegistryForUpdate() {return *processHistoryRegistry_;}
-
     /// Accessor for branchIDListHelper
     std::shared_ptr<BranchIDListHelper> branchIDListHelper() const {return branchIDListHelper_;}
 
@@ -349,7 +346,7 @@ namespace edm {
     void setTimestamp(Timestamp const& theTime) {time_ = theTime;}
 
     ProductRegistry& productRegistryUpdate() const {return *productRegistry_;}
-    ProcessHistoryRegistry& processHistoryRegistryUpdate() const {return *processHistoryRegistry_;}
+    ProcessHistoryRegistry& processHistoryRegistryForUpdate() const {return *processHistoryRegistry_;}
     ItemType state() const{return state_;}
     void setRunAuxiliary(RunAuxiliary* rp) {
       runAuxiliary_.reset(rp);

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -33,7 +33,7 @@ namespace edm {
   public:
     explicit PoolSource(ParameterSet const& pset, InputSourceDescription const& desc);
     virtual ~PoolSource();
-    using InputSource::processHistoryRegistryUpdate;
+    using InputSource::processHistoryRegistryForUpdate;
     using InputSource::productRegistryUpdate;
 
     static void fillDescriptions(ConfigurationDescriptions & descriptions);

--- a/IOPool/Streamer/src/StreamerInputSource.cc
+++ b/IOPool/Streamer/src/StreamerInputSource.cc
@@ -244,7 +244,7 @@ namespace edm {
         throw cms::Exception("StreamTranslation","Event deserialization error")
           << "got a null event from input stream\n";
     }
-    processHistoryRegistryUpdate().registerProcessHistory(sendEvent_->processHistory());
+    processHistoryRegistryForUpdate().registerProcessHistory(sendEvent_->processHistory());
 
     FDEBUG(5) << "Got event: " << sendEvent_->aux().id() << " " << sendEvent_->products().size() << std::endl;
     if(runAuxiliary().get() == nullptr || runAuxiliary()->run() != sendEvent_->aux().run()) {


### PR DESCRIPTION
I noticed that class InputSource had two different member functions that were identical except for the function name.  There is no good reason for this, and it may be confusing.  So, I removed productHistoryRegistryUpdate(), which was called in fewer places than productHistoryRegistryForUpdate(), and replaced its usage.  The function need not be public.
This PR is fairly trivial.
If the DQM L2 does not respond in a timely manner, I suggest that the DQM signature be bypassed, as there are no functional changes to DQM.
