### PR TITLE
added new option to XtoFFbarFilter

### DIFF
--- a/GeneratorInterface/GenFilters/interface/XtoFFbarFilter.h
+++ b/GeneratorInterface/GenFilters/interface/XtoFFbarFilter.h
@@ -55,6 +55,7 @@ private:
   std::vector<int> idDaughterF_;
   std::vector<int> idMotherY_;
   std::vector<int> idDaughterG_;
+  bool idYequalsX_;
   bool requireY_;
 
   edm::Handle<reco::GenParticleCollection> genParticles_;
@@ -65,7 +66,7 @@ private:
   double xSumR_;
   double xSumCtau_;
   unsigned int totalEvents_;
-  unsigned int rejectedEvents_;
+  unsigned int keptEvents_;
 };
 
 #endif

--- a/GeneratorInterface/GenFilters/python/XtoFFbarFilter_cfi.py
+++ b/GeneratorInterface/GenFilters/python/XtoFFbarFilter_cfi.py
@@ -3,19 +3,25 @@ import FWCore.ParameterSet.Config as cms
 XtoFFbarFilter = cms.EDFilter("XtoFFbarFilter",
     src = cms.InputTag("genParticles"),
 
-    # Require event to contain X -> f fbar decay, where X and f are specified below.
-    # Optionally also require it to contain a Y -> g g-bar decay.
+    # Require event to contain decay of X -> f f'-bar + anything.
+    # Optionally also require it to contain decay Y -> g g'-bar + anything.
+    # N.B. Particles f and f' must both appear in idDaughterF list, but need not be identical to each other.
+    # N.B. Particles g and g' must both appear in idDaughterG list, but need not be identical to each other.
 
     # Allowed PDG ID codes of mother X particle
     idMotherX = cms.vint32(6000111, 6000112, 6000113),
-    # Allowed PDG ID of daughter f-fbar pair (don't specify anti-particle code)
+    # Allowed PDG ID of daughter f or f'
     idDaughterF = cms.vint32(1,2,3,4,5,6,11,13,15), 
 
-    # If the following vectors are empty, it will not be required that a Y --> g g-bar
-    # decay is present.
+    # If the following vectors are empty, it will not be required that decay Y --> g g'-bar + anything
+    # is present.
                               
     # Allowed PDG ID codes of mother Y particle
     idMotherY = cms.vint32(6000111, 6000112, 6000113),
-    # Allowed PDG ID of daughter g-gbar pair (don't specify anti-particle code)
-    idDaughterG = cms.vint32(1,2,3,4,5,6,11,13,15)
+    # Allowed PDG ID of daughter g or g'
+    idDaughterG = cms.vint32(1,2,3,4,5,6,11,13,15),
+
+    # If this is set true, then parameter idMotherY is ignored, and instead set equal to idMotherX.
+    # Furthermore, events are vetoed if they contain more than one species from the list idMotherX. 
+    idYequalsX = cms.bool(False)
 )


### PR DESCRIPTION
1) Added a new cfg parameter "idYequalsX" to XtoFFbarFilter, allowing one to require that the event should contain two long-lived particles of the same particle species.

2) Improved the comments & tidied the code slightly.
