### PR TITLE
avoid relocation of SiStripCluster DetSetVector in case of onDemand

### DIFF
--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -23,6 +23,8 @@ namespace edm { namespace refhelper { template<typename T> struct FindForNewDetS
 namespace edmNew {
   typedef uint32_t det_id_type;
 
+  struct CapacityExaustedException {};
+
   namespace dslv {
     template< typename T> class LazyGetter;
   }
@@ -60,6 +62,9 @@ namespace edmNew {
     void errorFilling();
     void errorIdExists(det_id_type iid);
     void throw_range(det_id_type iid);
+    inline void throwCapacityExausted() { throw CapacityExaustedException();}
+
+
    }
 
   /** an optitimized container that linearized a "map of vector".
@@ -149,12 +154,24 @@ namespace edmNew {
 	saveEmpty=true; // avoid mess in destructor
       }
 
+      void checkCapacityExausted() const {
+        if (v.onDemand()   && v.m_data.size()==v.m_data.capacity()) dstvdetails::throwCapacityExausted();
+      }
+
+      void checkCapacityExausted(size_type s) const {
+        if (v.onDemand()   && v.m_data.size()+s>v.m_data.capacity()) dstvdetails::throwCapacityExausted();
+      }
+
+
       void reserve(size_type s) {
+        if (item.offset+s <= v.m_data.capacity()) return;
+        if (v.onDemand()) dstvdetails::throwCapacityExausted();	
 	v.m_data.reserve(item.offset+s);
       }
       
       
       void resize(size_type s) {
+        checkCapacityExausted(s);
 	v.m_data.resize(item.offset+s);
 	item.size=s;
       }
@@ -170,11 +187,13 @@ namespace edmNew {
       DataIter end() { return v.m_data.end();}
 
       void push_back(data_type const & d) {
+        checkCapacityExausted();
 	v.m_data.push_back(d);
 	item.size++;
       }
 #ifndef CMS_NOCXX11
       void push_back(data_type && d) {
+        checkCapacityExausted();
         v.m_data.push_back(std::move(d));
         item.size++;
       }

--- a/DataFormats/Common/interface/DetSetVectorNew.h
+++ b/DataFormats/Common/interface/DetSetVectorNew.h
@@ -11,6 +11,7 @@
 #include <boost/iterator/counting_iterator.hpp>
 #include <boost/any.hpp>
 #include <memory>
+#include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/GCC11Compatibility.h"
 
 
@@ -23,7 +24,7 @@ namespace edm { namespace refhelper { template<typename T> struct FindForNewDetS
 namespace edmNew {
   typedef uint32_t det_id_type;
 
-  struct CapacityExaustedException {};
+  struct CapacityExaustedException : public cms::Exception {  CapacityExaustedException(): cms::Exception("Capacity exausted in DetSetVectorNew"){} };
 
   namespace dslv {
     template< typename T> class LazyGetter;

--- a/DataFormats/Common/test/DetSetNew_t.cpp
+++ b/DataFormats/Common/test/DetSetNew_t.cpp
@@ -263,11 +263,13 @@ namespace {
     Getter(TestDetSet * itest):ntot(0), test(*itest){}
 
     void fill(FF& ff) override {
-      int n=ff.id()-20;
-      CPPUNIT_ASSERT(n>0);
-      ff.resize(n);
-      std::copy(test.sv.begin(),test.sv.begin()+n,ff.begin());
-      ntot+=n;
+      try {
+         int n=ff.id()-20;
+        CPPUNIT_ASSERT(n>0);
+        ff.resize(n);
+        std::copy(test.sv.begin(),test.sv.begin()+n,ff.begin());
+        ntot+=n;
+      } catch (edmNew::CapacityExaustedException) {}
     }
 
     unsigned int ntot;
@@ -427,6 +429,7 @@ void TestDetSet::onDemand() {
       CPPUNIT_ASSERT(!detsets.isValid(21));
       CPPUNIT_ASSERT(!detsets.isValid(22));
       //      DST df = *detsets.find(21);
+      detsets.reserve(5,100);
       DST df = *detsets.find(21,true);
       CPPUNIT_ASSERT(df.id()==21);
       CPPUNIT_ASSERT(df.size()==1);

--- a/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/StripClusterizerAlgorithm.h
@@ -23,6 +23,7 @@ class StripClusterizerAlgorithm {
   virtual ~StripClusterizerAlgorithm() {}
   virtual void initialize(const edm::EventSetup&);
 
+
   //Offline DetSet interface
   typedef edmNew::DetSetVector<SiStripCluster> output_t;
   void clusterize(const    edm::DetSetVector<SiStripDigi> &, output_t &);
@@ -40,7 +41,8 @@ class StripClusterizerAlgorithm {
   virtual void addFed(sistrip::FEDZSChannelUnpacker & unpacker, uint16_t ipair, output_t::FastFiller & out) {}
   virtual void stripByStripAdd(uint16_t strip, uint8_t adc, output_t::FastFiller & out) {}
   virtual void stripByStripEnd(output_t::FastFiller & out) {}
-
+  
+  virtual void cleanState(){}
 
   struct InvalidChargeException : public cms::Exception { public: InvalidChargeException(const SiStripDigi&); };
 

--- a/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
+++ b/RecoLocalTracker/SiStripClusterizer/interface/ThreeThresholdAlgorithm.h
@@ -39,6 +39,7 @@ class ThreeThresholdAlgorithm final : public StripClusterizerAlgorithm {
 
   void stripByStripEnd(output_t::FastFiller & out) override { endCandidate(out);}
 
+  void cleanState() override {clearCandidate();}
 
 
  private:

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -215,8 +215,7 @@ class SiStripClusterizerFromRaw final : public edm::stream::EDProducer<>  {
     
     if(onDemand) assert(output->onDemand());
 
-    output->reserve(15000,6*10000);
-
+    output->reserve(15000,12*10000);
 
 
     if (!onDemand) {
@@ -287,7 +286,7 @@ void SiStripClusterizerFromRaw::run(const FEDRawDataCollection& rawColl,
 }
 
 void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::FastFiller & record) {
-
+try {
   incReady();
 
   auto idet= record.id();
@@ -444,7 +443,9 @@ void ClusterFiller::fill(StripClusterizerAlgorithm::output_t::FastFiller & recor
   if(!record.empty()) incNoZ();
 
   // COUT << "filled " << record.size() << std::endl;
-  
+} catch (edmNew::CapacityExaustedException) {
+  edm::LogError(sistrip::mlRawToCluster_) << "too many Sistrip Clusters to fit space allocated for OnDemand";
+}  
 
 }
 

--- a/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
+++ b/RecoLocalTracker/SiStripClusterizer/plugins/ClustersFromRawProducer.cc
@@ -345,7 +345,9 @@ try {
 	    unpacker++;
             }
 	  */
-	} catch (const cms::Exception& e) {
+	} catch (edmNew::CapacityExaustedException) {
+          throw;
+        } catch (const cms::Exception& e) {
 	  if (edm::isDebugEnabled()) {
 	    std::ostringstream ss;
 	    ss << "Unordered clusters for channel " << fedCh << " on FED " << fedId << ": " << e.what();
@@ -368,7 +370,9 @@ try {
 	    unpacker++;
 	    }
 	  */
-	} catch (const cms::Exception& e) {
+	} catch (edmNew::CapacityExaustedException) {
+           throw;
+        }catch (const cms::Exception& e) {
 	  if (edm::isDebugEnabled()) {
 	    std::ostringstream ss;
 	    ss << "Unordered clusters for channel " << fedCh << " on FED " << fedId << ": " << e.what();
@@ -445,6 +449,7 @@ try {
   // COUT << "filled " << record.size() << std::endl;
 } catch (edmNew::CapacityExaustedException) {
   edm::LogError(sistrip::mlRawToCluster_) << "too many Sistrip Clusters to fit space allocated for OnDemand";
+  clusterizer.cleanState();
 }  
 
 }


### PR DESCRIPTION
this is a "stop-gap" solution to avoid HTL to crash in case of of relocation of the SiStrip DetSetVector.
It will now not add any more Cluster and issue an Error.

Tested with a very small reserve

should supersede #9241
