### PR TITLE
Fix use-after-free bug in typeCode

### DIFF
--- a/CommonTools/Utils/src/returnType.cc
+++ b/CommonTools/Utils/src/returnType.cc
@@ -43,9 +43,9 @@ namespace reco {
 
   TypeCode typeCode(const edm::TypeWithDict& t) {
     typedef std::pair<const char* const, method::TypeCode> Values;
-    const char* name = t.name().c_str();
+    std::string name = t.name();
     auto f = std::equal_range(retTypeVec.begin(), retTypeVec.end(),
-      Values{name, enumType},
+      Values{name.c_str(), enumType},
       [](const Values& iLHS, const Values& iRHS) -> bool {
         return std::strcmp(iLHS.first, iRHS.first) < 0;
       });


### PR DESCRIPTION
`edm::TypeWithDict::name()` returns a `std::string`. The code was
taking a pointer to temporary string. Thus causing CutParser to
fail depending on random values in memory.

GDB output below. Memory pattern was set to 0x04, thus the `name` is just a sequence of 0x04.

```
Breakpoint 3, reco::parser::ExpressionVarSetter::push (this=0x12fda930,
    begin=0x12fd7b58 "strip < 400000 && pixel < 40000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + 0.1*strip)",
    end=0x12fd7b5d " < 400000 && pixel < 40000 && (strip < 50000 + 10*pixel) && (pixel < 5000 + 0.1*strip)")
    at /build/davidlt/debug/CMSSW_7_5_0_pre4/src/CommonTools/Utils/src/ExpressionVarSetter.cc:17
17        edm::TypeWithDict type = typeStack_.back();
(gdb) n
18        method::TypeCode retType = reco::typeCode(type);
(gdb) p type
$25 = {ti_ = 0x7ffff6546b20 <typeinfo for int>, class_ = 0x0, enum_ = 0x0, dataType_ = 0x3a0fd10, arrayDimensions_ = {myP = 0x0}, property_ = 0}
(gdb) s
reco::typeCode (t=...) at /build/davidlt/debug/CMSSW_7_5_0_pre4/src/CommonTools/Utils/src/returnType.cc:46
46          const char* name = t.name().c_str();
(gdb) n
51            });
(gdb) p name
$26 = 0x12fda128 '\004' <repeats 16 times>, "\061"
```

```
----- Begin Fatal Exception 25-May-2015 10:35:59 CEST-----------------------
An exception of category 'Configuration' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing module: class=SeedGeneratorFromRegionHitsEDProducer label='initialStepSeedsPreSplitting'
Exception Message:
Cut parser error:member "strip" has an invalid return type: "int" (char 0)
----- End Fatal Exception -------------------------------------------------
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
