### PR TITLE
Bugfix: add LA and BP Records to Millepede alignment result split_MP database

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
@@ -178,10 +178,18 @@ gzip -f millepede.eve
 #list IOVs
 cmscond_list_iov -c sqlite_file:alignments_MP.db -t Alignments
 cmscond_list_iov -c sqlite_file:alignments_MP.db -t Deformations
+cmscond_list_iov -c sqlite_file:alignments_MP.db -t SiStripLorentzAngle_deco
+cmscond_list_iov -c sqlite_file:alignments_MP.db -t SiStripLorentzAngle_peak
+cmscond_list_iov -c sqlite_file:alignments_MP.db -t SiPixelLorentzAngle
+cmscond_list_iov -c sqlite_file:alignments_MP.db -t SiStripBackPlaneCorrection
 
 #split the IOVs
 aligncond_split_iov -s sqlite_file:alignments_MP.db -i Alignments -d sqlite_file:alignments_split_MP.db -t Alignments
 aligncond_split_iov -s sqlite_file:alignments_MP.db -i Deformations -d sqlite_file:alignments_split_MP.db -t Deformations
+aligncond_split_iov -s sqlite_file:alignments_MP.db -i SiStripLorentzAngle_deco -d sqlite_file:alignments_split_MP.db -t SiStripLorentzAngle_deco
+aligncond_split_iov -s sqlite_file:alignments_MP.db -i SiStripLorentzAngle_peak -d sqlite_file:alignments_split_MP.db -t SiStripLorentzAngle_peak
+aligncond_split_iov -s sqlite_file:alignments_MP.db -i SiPixelLorentzAngle -d sqlite_file:alignments_split_MP.db -t SiPixelLorentzAngle
+aligncond_split_iov -s sqlite_file:alignments_MP.db -i SiStripBackPlaneCorrection -d sqlite_file:alignments_split_MP.db -t SiStripBackPlaneCorrection
 
 echo "\nDirectory content after running cmsRun, zipping log file and merging histogram files:"
 ls -lh


### PR DESCRIPTION
Adds the Lorentz-angle and backplane correction records to the special alignments_split_MP.db output database file of the Millepede alignment algorithm. This database file has a special format of one record per IOV and is used internally in the Millepede alignment workflow.
