### PR TITLE
bug fix to Higgs DQM to PR #9170

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -121,7 +121,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
               "HLT_Mu8_TrkIsoVVL_Ele17_CaloIdL_TrackIdL_IsoVL_v",
               "HLT_Mu17_TrkIsoVVL_Ele12_CaloIdL_TrackIdL_IsoVL_v",
               #prescaled control paths
-              "HLT_Ele17_CaloIdL_TrackIdL_IsoVL_v1",
+              "HLT_Ele17_CaloIdL_TrackIdL_IsoVL_v",
               "HLT_Ele23_Ele12_CaloIdL_TrackIdL_IsoVL_v",
               "HLT_Mu17_TrkIsoVVL_Mu8_TrkIsoVVL_v",
               "HLT_Mu17_TrkIsoVVL_TkMu8_TrkIsoVVL_v",


### PR DESCRIPTION
bug fix to PR #9170: replace the v1 from the single electron 17 path by v only. Was causing the harvesting step to fail for a part of the efficiency plots for this path. Will be back-ported in 74X
