### PR TITLE
complete the recoMuon validation workflow for cosmic muons

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1001,6 +1001,7 @@ class ConfigBuilder(object):
             self.RECODefaultCFF="Configuration/StandardSequences/ReconstructionCosmics_cff"
 	    self.SKIMDefaultCFF="Configuration/StandardSequences/SkimsCosmics_cff"
             self.EVTCONTDefaultCFF="Configuration/EventContent/EventContentCosmics_cff"
+            self.VALIDATIONDefaultCFF="Configuration/StandardSequences/ValidationCosmics_cff"
             self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineCosmics_cff"
             if self._options.isMC==True:
                 self.DQMOFFLINEDefaultCFF="DQMOffline/Configuration/DQMOfflineCosmicsMC_cff"

--- a/Configuration/StandardSequences/python/HarvestingCosmics_cff.py
+++ b/Configuration/StandardSequences/python/HarvestingCosmics_cff.py
@@ -9,6 +9,6 @@ from HLTriggerOffline.Common.HLTValidationHarvest_cff import *
 dqmHarvesting = cms.Path(DQMOfflineCosmics_SecondStep*DQMOfflineCosmics_Certification)
 dqmHarvestingPOG = cms.Path(DQMOfflineCosmics_SecondStep_PrePOG)
 
-validationHarvesting = cms.Path(postValidation*hltpostvalidation)
+validationHarvesting = cms.Path(postValidationCosmics)
 
 #alcaHarvesting = cms.Path()

--- a/Configuration/StandardSequences/python/ValidationCosmics_cff.py
+++ b/Configuration/StandardSequences/python/ValidationCosmics_cff.py
@@ -1,0 +1,17 @@
+import FWCore.ParameterSet.Config as cms
+
+
+#RandomNumberGeneratorService = cms.Service("RandomNumberGeneratorService",
+#        mix = cms.PSet(initialSeed = cms.untracked.uint32(12345),
+#                       engineName = cms.untracked.string('HepJamesRandom')
+#        ),
+#        restoreStateLabel = cms.untracked.string("randomEngineStateProducer"),
+#)
+
+from Validation.Configuration.globalValidationCosmics_cff import *
+
+prevalidation = cms.Sequence(globalPrevalidationCosmics)
+
+validation = cms.Sequence(cms.SequencePlaceholder("mix")
+                          *globalValidationCosmics
+                          )

--- a/Validation/Configuration/python/globalValidationCosmics_cff.py
+++ b/Validation/Configuration/python/globalValidationCosmics_cff.py
@@ -1,0 +1,9 @@
+import FWCore.ParameterSet.Config as cms
+
+from SimGeneral.TrackingAnalysis.simHitTPAssociation_cfi import *
+from Validation.RecoMuon.muonValidation_cff import *
+
+# filter/producer "pre-" sequence for globalValidation
+globalPrevalidationCosmics = cms.Sequence(simHitTPAssocProducer)
+
+globalValidationCosmics = cms.Sequence(recoCosmicMuonValidation)

--- a/Validation/Configuration/python/postValidation_cff.py
+++ b/Validation/Configuration/python/postValidation_cff.py
@@ -54,3 +54,7 @@ postValidation_fastsim = cms.Sequence(
 postValidation_gen = cms.Sequence(
     EventGeneratorPostProcessor
 )
+
+postValidationCosmics = cms.Sequence(
+      postProcessorMuonMultiTrack
+)


### PR DESCRIPTION
This PR completes the recoMuon validation workflow for cosmic muons: it uses the previous PR https://github.com/cms-sw/cmssw/pull/8199 (where this further step was foreseen and declared in the description) and obtains validation plots as those linked for https://github.com/cms-sw/cmssw/pull/7044. 

This would run in the runTheMatrix.py -l 1307.0 by adding "VALIDATION" in the string of steps to be run, so step3 would become:
cmsDriver.py  step3 --conditions auto:run2_mc -s RAW2DIGI,L1Reco,RECO,ALCA:MuAlCalIsolatedMu,VALIDATION,DQM -n 10 --eventcontent RECOSIM,DQM --scenario cosmics --datatier GEN-SIM-RECO,DQMIO --customise SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1 --magField 38T_PostLS1

I consider safe to include this as in the moment there is no validation for the MC cosmics processes in the matrix tests. Specific code is needed (TrackingParticle selector for cosmics, parameter definer of cosmics to have the TrackingParticle pars at the point of closest approach to the beam spot, code in associators and track validator) that is already integrated (in both 75X and 74X) from the previous PR. Before the existing code was able to compile but did not run.
So by including it we would check also part of the validation code during the normal release integration cycle.

cheers,
   Giovanni
