### PR TITLE
Fix use-after-free in DynamicTruncation::preliminaryFit

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -387,7 +387,7 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
     }
   }
   if (!prelFitMeas.empty()) prelFitMeas.pop_back();
-  for (ConstRecHitContainer::const_iterator imrh = prelFitMeas.end(); imrh != prelFitMeas.begin(); imrh-- ) {
+  for (auto imrh = prelFitMeas.rbegin(); imrh != prelFitMeas.rend(); ++imrh) {
     DetId id = (*imrh)->geographicalId(); 
     TrajectoryStateOnSurface tmp = propagatorPF->propagate(prelFitState, theG->idToDet(id)->surface());
     if (tmp.isValid()) prelFitState = tmp; 


### PR DESCRIPTION
On the first iteration we used end() of STL container. end() returns
a pointer after the last element in container. In this case, we were
starting iteration from the last **removed** `TrackingRecHit`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
