### PR TITLE
Timing improvement for PFEGammaAlgo in HI

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFEGammaAlgo.cc
@@ -1356,16 +1356,19 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
  // look through our KF tracks in this block and match 
  void PFEGammaAlgo::
  removeOrLinkECALClustersToKFTracks() {
+   typedef std::multimap<double, unsigned> MatchedMap;
+   typedef const reco::PFBlockElementGsfTrack* GsfTrackElementPtr;
    if( !_splayedblock[reco::PFBlockElement::ECAL].size() ||
        !_splayedblock[reco::PFBlockElement::TRACK].size()   ) return;
-   std::multimap<double, unsigned> matchedGSFs, matchedECALs;
+   MatchedMap matchedGSFs, matchedECALs;
+   std::unordered_map<GsfTrackElementPtr,MatchedMap> gsf_ecal_cache;
    for( auto& kftrack : _splayedblock[reco::PFBlockElement::TRACK] ) {
      matchedGSFs.clear();
      _currentblock->associatedElements(kftrack.first->index(), _currentlinks,
 				       matchedGSFs,
 				       reco::PFBlockElement::GSF,
 				       reco::PFBlock::LINKTEST_ALL);
-     if( !matchedGSFs.size() ) { // only run this is we aren't associated to GSF
+     if( !matchedGSFs.size() ) { // only run this if we aren't associated to GSF
        LesserByDistance closestTrackToECAL(_currentblock,_currentlinks,
 					   &kftrack);      
        auto ecalbegin = _splayedblock[reco::PFBlockElement::ECAL].begin();
@@ -1395,13 +1398,19 @@ initializeProtoCands(std::list<PFEGammaAlgo::ProtoEGObject>& egobjs) {
 	   if(elemasgsf->trackType(reco::PFBlockElement::T_FROM_GAMMACONV)) {
 	     continue; // keep clusters that have a found conversion GSF near
 	   }
-	   matchedECALs.clear();
-	   _currentblock->associatedElements(elemasgsf->index(), _currentlinks,
-					     matchedECALs,
-					     reco::PFBlockElement::ECAL,
-					     reco::PFBlock::LINKTEST_ALL);
-	   if( matchedECALs.size() ) {
-	     if( matchedECALs.begin()->second == closestECAL.first->index() ) {
+	   // make sure cache exists
+	   if( !gsf_ecal_cache.count(elemasgsf) ) {
+	     matchedECALs.clear();
+	     _currentblock->associatedElements(elemasgsf->index(), _currentlinks,
+					       matchedECALs,
+					       reco::PFBlockElement::ECAL,
+					       reco::PFBlock::LINKTEST_ALL);
+	     gsf_ecal_cache.emplace(elemasgsf,matchedECALs);
+	     MatchedMap().swap(matchedECALs);
+	   } 
+	   const MatchedMap& ecal_matches = gsf_ecal_cache[elemasgsf];	   
+	   if( ecal_matches.size() ) {
+	     if( ecal_matches.begin()->second == closestECAL.first->index() ) {
 	       gsflinked = true;
 	       break;
 	     }


### PR DESCRIPTION
Use tactical cache in PFEgammaAlgo to avoid time blow up in HI events.

No changes expected/observed in local tests.
No real timing change in pp. Nice factor of 3 speed up in HI events.

Igprof (using VoronoiBackgroundProducer for normalization, these were done on different systems and different numbers of events):
before:
27.8     479.80  VoronoiBackgroundProducer::produce(edm::Event&, edm::EventSetup const&) [27]
7.2     123.77  PFEGammaProducer::produce(edm::Event&, edm::EventSetup const&) [43]

after:
32.9     823.18  VoronoiBackgroundProducer::produce(edm::Event&, edm::EventSetup const&) [27]
2.8      68.93  PFEGammaProducer::produce(edm::Event&, edm::EventSetup const&) [65]
