### PR TITLE
Reimplement SimpleJetCorrector::correctionBin for ROOT 6.04.00

### DIFF
--- a/CondFormats/JetMETObjects/interface/SimpleJetCorrector.h
+++ b/CondFormats/JetMETObjects/interface/SimpleJetCorrector.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include <TFormula.h>
+#include <RVersion.h>
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 
 class JetCorrectorParameters;
@@ -29,7 +30,11 @@ class SimpleJetCorrector
   //-------- Member functions -----------
   SimpleJetCorrector(const SimpleJetCorrector&);
   SimpleJetCorrector& operator= (const SimpleJetCorrector&);
+#if ROOT_VERSION_CODE >= ROOT_VERSION(6,03,00)
+  float    invert(const Double_t *args, const Double_t *params) const;
+#else
   float    invert(const std::vector<float>& fX, TFormula&) const;
+#endif
   float    correctionBin(unsigned fBin,const std::vector<float>& fY) const;
   unsigned findInvertVar();
   void     setFuncParameters();


### PR DESCRIPTION
ROOT6 (master, pre-6.04.00) has a new implemention for TFormula. For
thread-safety we are making copies of TFormula, because we need to
modify it by changing the parameters. Copies are no more needed for
ROOT 6.04.00 and instead

```
Double_t EvalPar(const Double_t *, const Double_t *) const
```

can be used to evalute TFormula without modification.

Without this change CMSSW spends most of it's cpu time in TFormula ctor
and memory consumption (due to string allocations) goes up by 2-2.5X.

ROOT6 commit, which made `EvalPar` thread-safe:
bcfb68afac1db25d824d35557493d0f3c941b332

Tested with CMSSW_7_5_DEVEL_X_2015-05-26-2300 (incl. ROOT6 
master branch), resource usage compared with 4.63 workflow step3 (RECO). 
All within expected behavior.

Without this pull request CMSSW + ROOT 6.04.00 most likely would force
build machine to go offline (due to memory usage).

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
