### PR TITLE
New checksum for edm::StreamedProduct class needed for ROOT 6.04.00

### DIFF
--- a/DataFormats/Streamer/src/classes_def.xml
+++ b/DataFormats/Streamer/src/classes_def.xml
@@ -1,6 +1,7 @@
 
 <lcgdict>
- <class name="edm::StreamedProduct" ClassVersion="12">
+ <class name="edm::StreamedProduct" ClassVersion="13">
+  <version ClassVersion="13" checksum="87489871"/>
   <version ClassVersion="12" checksum="855998814"/>
   <version ClassVersion="10" checksum="512531612"/>
   <version ClassVersion="11" checksum="1146084488"/>


### PR DESCRIPTION
Chekcsum changed for `edm::StreamedProduct` class. Modify for ROOT
6.04.00.

@Dr15Jones @wmtan @davidlange6 

This should be the only change in ROOT64_X.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
