### PR TITLE
New Global Tags with fixes and new features for Run1 and Run2

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_75_V0',
+    'run1_design'       :   'DESRUN1_75_V2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_75_V0',
+    'run1_mc'           :   'MCRUN1_75_V2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_75_V0',
+    'run1_mc_hi'        :   'MCHI1_75_V2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_75_V0',
+    'run1_mc_pa'        :   'MCPA1_75_V2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_75_V0',
+    'run2_design'       :   'DESRUN2_75_V2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_75_V0',
+    'run2_mc_50ns'      :   'MCRUN2_75_V4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_75_V1',
+    'run2_mc'           :   'MCRUN2_75_V5',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   'MCHI2_75_V0',
+    'run2_mc_hi'        :   'MCHI2_75_V2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_75_V0A',
+    'run1_data'         :   'GR_R_75_V4A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_75_V1A',
+    'run2_data'         :   'GR_R_75_V5A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V59A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V61A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V60A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V62A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/Configuration/AlCa/python/autoCond_condDBv1.py
+++ b/Configuration/AlCa/python/autoCond_condDBv1.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_75_V0::All',
+    'run1_design'       :   'DESRUN1_75_V2::All',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_75_V0::All',
+    'run1_mc'           :   'MCRUN1_75_V2::All',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_75_V0::All',
+    'run1_mc_hi'        :   'MCHI1_75_V2::All',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_75_V0::All',
+    'run1_mc_pa'        :   'MCPA1_75_V2::All',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_75_V0::All',
+    'run2_design'       :   'DESRUN2_75_V2::All',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_75_V0::All',
+    'run2_mc_50ns'      :   'MCRUN2_75_V4:All',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_75_V1::All',
+    'run2_mc'           :   'MCRUN2_75_V5::All',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   'MCHI2_75_V0::All',
+    'run2_mc_hi'        :   'MCHI2_75_V2::All',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_75_V0A::All',
+    'run1_data'         :   'GR_R_75_V4A::All',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_75_V1A::All',
+    'run2_data'         :   'GR_R_75_V5A::All',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V59A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run1_hlt'          :   'GR_H_V61A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V60A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
+    'run2_hlt'          :   'GR_H_V62A::All,frontier://FrontierProd/CMS_COND_31X_GLOBALTAG,frontier://FrontierProd/',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2::All', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
Several new features included for Run1, Run2 DATA and MC Global Tags. Complete description available at [RelValGT](https://twiki.cern.ch/twiki/bin/viewauth/CMS/RelValGT#CMSSW_7_5_0_pre5).
