### PR TITLE
Rename AutoLibraryLoader (FWLite), which is misnamed

### DIFF
--- a/Alignment/OfflineValidation/macros/runExtendedOfflineValidationPlots.C
+++ b/Alignment/OfflineValidation/macros/runExtendedOfflineValidationPlots.C
@@ -3,7 +3,7 @@ void runExtendedOfflineValidationPlots()
 {
   // load framework lite just to find the CMSSW libs...
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   //compile the makro
   gROOT->ProcessLine(".L PlotAlignmentValidation.C++");
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -245,7 +245,7 @@ void TkAlExtendedOfflineValidation()
 {
   // load framework lite just to find the CMSSW libs...
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   //compile the makro
   gROOT->ProcessLine(".L .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C++");
   // gROOT->ProcessLine(".L ./PlotAlignmentValidation.C++");

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -219,7 +219,7 @@ int TkAlOfflineJobsMerge(TString pars, TString outFile)
 {
 // load framework lite just to find the CMSSW libs...
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 //compile the macro
 gROOT->ProcessLine(".L merge_TrackerOfflineValidation.C++");
 

--- a/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C
+++ b/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C
@@ -26,7 +26,7 @@ you can get by these lines (add them to your rootlogon.C):
 if (gSystem->Getenv("CMSSW_RELEASE_BASE") != '\0') {
   printf("\nLoading CMSSW FWLite...\n");
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }
 
 */

--- a/Alignment/SurveyAnalysis/macros/rootlogon.C
+++ b/Alignment/SurveyAnalysis/macros/rootlogon.C
@@ -9,7 +9,7 @@
   gSystem->Load("libDataFormatsSiPixelDetId.so");
   gSystem->Load("libDataFormatsSiStripDetId.so");
   gSystem->Load("libFWCoreFWLite.so");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   gStyle->SetCanvasBorderMode(0);
   gStyle->SetPadBorderMode(0);

--- a/CalibMuon/RPCCalibration/test/cmsbrowse
+++ b/CalibMuon/RPCCalibration/test/cmsbrowse
@@ -10,7 +10,7 @@ fi
 cat <<EOF >| /tmp/cmsbrowse_tmp.C
 {
       gSystem->Load("$CMSSW_RELEASE_BASE/lib/$SCRAM_ARCH/libFWCoreFWLite.so");
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
       hfile = new TFile("${file}","READONLY");
       new TBrowser("CMS Browser",hfile);
 }

--- a/Calibration/EcalAlCaRecoProducers/test/nPU_mc.py
+++ b/Calibration/EcalAlCaRecoProducers/test/nPU_mc.py
@@ -7,7 +7,7 @@ from PhysicsTools.PythonAnalysis import *
 
 #print_options.set_float_precision(4)
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 
 #import EcalDetId
 #from DataFormats.EcalDetId import *

--- a/Calibration/EcalAlCaRecoProducers/test/reRecoValidation.py
+++ b/Calibration/EcalAlCaRecoProducers/test/reRecoValidation.py
@@ -7,7 +7,7 @@ from PhysicsTools.PythonAnalysis import *
 
 #print_options.set_float_precision(4)
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 
 #import EcalDetId
 #from DataFormats.EcalDetId import *

--- a/Calibration/EcalAlCaRecoProducers/test/recHitsValidation.py
+++ b/Calibration/EcalAlCaRecoProducers/test/recHitsValidation.py
@@ -7,7 +7,7 @@ from PhysicsTools.PythonAnalysis import *
 
 #print_options.set_float_precision(4)
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 
 #import EcalDetId
 #from DataFormats.EcalDetId import *

--- a/CommonTools/CandAlgos/test/rootlogon.C
+++ b/CommonTools/CandAlgos/test/rootlogon.C
@@ -1,4 +1,4 @@
 {
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }

--- a/CommonTools/ParticleFlow/test/Macros/isolation.C
+++ b/CommonTools/ParticleFlow/test/Macros/isolation.C
@@ -2,7 +2,7 @@
 
 
 gSystem->Load("libFWCoreFWLite.so");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 TFile f("testPFPAT.root");
 
 TTree* Events = 0;

--- a/CommonTools/ParticleFlow/test/Macros/plotVertex.py
+++ b/CommonTools/ParticleFlow/test/Macros/plotVertex.py
@@ -6,7 +6,7 @@ gROOT.Macro( os.path.expanduser( '~/rootlogon.C' ) )
 
 def loadFWLite():
     gSystem.Load("libFWCoreFWLite")
-    gROOT.ProcessLine('AutoLibraryLoader::enable();')
+    gROOT.ProcessLine('FWLiteEnabler::enable();')
     gSystem.Load("libFWCoreFWLite")
 
 

--- a/CommonTools/ParticleFlow/test/Macros/ptJets.C
+++ b/CommonTools/ParticleFlow/test/Macros/ptJets.C
@@ -2,7 +2,7 @@
 
 
   gSystem->Load("libFWCoreFWLite.so");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   TFile f("patTuple_PF2PAT.root");
   
   TTree *Events = 0;

--- a/CommonTools/ParticleFlow/test/Macros/ptMus.C
+++ b/CommonTools/ParticleFlow/test/Macros/ptMus.C
@@ -2,7 +2,7 @@
 
 
   gSystem->Load("libFWCoreFWLite.so");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   TFile f("patTuple_PF2PAT.root");
 
   TTree* Events = 0;

--- a/CommonTools/ParticleFlow/test/Macros/rootlogon.C
+++ b/CommonTools/ParticleFlow/test/Macros/rootlogon.C
@@ -9,7 +9,7 @@ void rootlogon() {
 
 void loadFWLite() {
   gSystem->Load("libFWCoreFWLite.so");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }
 
 TTree* getEventsrootlogon() {

--- a/CommonTools/ParticleFlow/test/Macros/testMuonTopProjection.C
+++ b/CommonTools/ParticleFlow/test/Macros/testMuonTopProjection.C
@@ -1,7 +1,7 @@
 {
 
   gSystem->Load("libFWCoreFWLite.so");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   TFile fDisabled("tpDisabled.root");
   TTree *tDisabled = (TTree*) fDisabled.Get("Events");

--- a/CommonTools/RecoAlgos/test/rootlogon.C
+++ b/CommonTools/RecoAlgos/test/rootlogon.C
@@ -1,4 +1,4 @@
 {
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }

--- a/CondFormats/JetMETObjects/test/TestCorrections.C
+++ b/CondFormats/JetMETObjects/test/TestCorrections.C
@@ -2,7 +2,7 @@ void TestCorrections(double rawPt, double rawEta, double rawPhi, double rawE, do
 {
   gROOT->ProcessLine("#include <vector>");
   gSystem->Load("libFWCoreFWLite.so");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   ////////////// Construct the JetCorrectorParameters objects ///////////////////////
   string L1Tag    = "../data/Jec11V0_L1Offset_AK5JPT.txt"; 
   string L1JPTTag = "../data/Jec11V0_L1JPTOffset_AK5JPT.txt"; 

--- a/CondTools/Utilities/test/rootlogon.C
+++ b/CondTools/Utilities/test/rootlogon.C
@@ -3,5 +3,5 @@
     gSystem->Load("libtestCondToolsUtilities");
     gSystem->Load("libCondFormatsEcalObjects");
     gSystem->Load("libCondFormatsCalibration");
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
 }  

--- a/Configuration/EventContent/test/rootlogon.C
+++ b/Configuration/EventContent/test/rootlogon.C
@@ -1,4 +1,4 @@
 {
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }

--- a/DQM/SiStripHistoricInfoClient/bin/SiStripHDQMInspector.cc
+++ b/DQM/SiStripHistoricInfoClient/bin/SiStripHDQMInspector.cc
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include <TROOT.h>
 #include <TFile.h>
 #include <TSystem.h>
@@ -160,7 +160,7 @@ void SiStripHDQMInspector( const string & dbName, const string & tagName, const 
 int main (int argc, char* argv[])
 {
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   if (argc != 6 && argc != 7) {
     std::cerr << "Usage: " << argv[0] << " [Database] [TagName] [Password] [WhiteListFile] [NRuns] " << std::endl;

--- a/DQM/SiStripHistoricInfoClient/bin/TrackingHDQMInspector.cc
+++ b/DQM/SiStripHistoricInfoClient/bin/TrackingHDQMInspector.cc
@@ -4,7 +4,7 @@
 #include "DQMServices/Diagnostic/interface/DQMHistoryCreateTrend.h"
 #include <string>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include <TROOT.h>
 #include <TFile.h>
 #include <TSystem.h>
@@ -209,7 +209,7 @@ void TrackingHDQMInspector( const string & dbName, const string & tagName, const
 int main (int argc, char* argv[])
 {
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   if (argc != 6 && argc != 7) {
     std::cerr << "Usage: " << argv[0] << " [Database] [TagName] [Password] [WhiteListFile] [NRuns] " << std::endl;

--- a/DQM/SiStripHistoricInfoClient/bin/WebTrackingHDQMInspector.cc
+++ b/DQM/SiStripHistoricInfoClient/bin/WebTrackingHDQMInspector.cc
@@ -10,7 +10,7 @@
 #include <sstream>
 #include <fstream>
 #include <iostream>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include <TROOT.h>
 #include <TFile.h>
 #include <TSystem.h>
@@ -240,7 +240,7 @@ int main (int argc, char* argv[])
 {
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   if (argc < 9) {
     std::cerr << argv[0] << " [Database] [TagName] [Password] [WhiteListFile] [SelectedTrends] [FirstRun] [LastRun] [CondList]" << std::endl;

--- a/DQM/SiStripHistoricInfoClient/test/TrendsWithIOVIterator/rootlogon.C
+++ b/DQM/SiStripHistoricInfoClient/test/TrendsWithIOVIterator/rootlogon.C
@@ -14,5 +14,5 @@ gSystem->Load("libFWCoreFWLite");
 gSystem->Load("libtestSiStripHistoricDQM"); 
 gSystem->Load("libCondFormatsSiStripObjects"); 
 
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 }

--- a/DQMOffline/CalibCalo/test/compare.py
+++ b/DQMOffline/CalibCalo/test/compare.py
@@ -129,7 +129,7 @@ except ImportError:
         runcmd2(environment,"./compare.py",tuple(sys.argv[1:-1]))#works only if compare.py is located in the pwd
 else:    
     gSystem.Load("libFWCoreFWLite.so")
-    AutoLibraryLoader.enable()
+    FWLiteEnabler::enable()
     outfile=TFile(root_out,"recreate")
     histo=[]
     canvas=[]

--- a/DQMServices/Diagnostic/test/dummyTest/SiPixelPlottingExample.C
+++ b/DQMServices/Diagnostic/test/dummyTest/SiPixelPlottingExample.C
@@ -13,7 +13,7 @@
   int const NRuns = 2;
 
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
 
 

--- a/DQMServices/Diagnostic/test/dummyTest/test_Inspector.cc
+++ b/DQMServices/Diagnostic/test/dummyTest/test_Inspector.cc
@@ -12,7 +12,7 @@
 
 gSystem->Load("libFWCoreFWLite");  
 
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
    
 gROOT->Reset();
 

--- a/DQMServices/Diagnostic/test/genericTest/test_Inspector.cc
+++ b/DQMServices/Diagnostic/test/genericTest/test_Inspector.cc
@@ -12,7 +12,7 @@
 
 gSystem->Load("libFWCoreFWLite");  
 
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
    
 gROOT->Reset();
 

--- a/DataFormats/FWLite/python/__init__.py
+++ b/DataFormats/FWLite/python/__init__.py
@@ -8,7 +8,7 @@ from FWCore.ParameterSet.VarParsing import VarParsing
 
 
 ROOT.gSystem.Load("libFWCoreFWLite")
-ROOT.AutoLibraryLoader.enable()
+ROOT.FWLiteEnabler.enable()
 
 # Whether warn() should print anythingg
 quietWarn = False

--- a/DataFormats/FWLite/test/chainevent_looping_cint.C
+++ b/DataFormats/FWLite/test/chainevent_looping_cint.C
@@ -7,7 +7,7 @@ class loadFWLite {
    public:
       loadFWLite() {
          gSystem->Load("libFWCoreFWLite");
-         AutoLibraryLoader::enable();
+         FWLiteEnabler::enable();
       }
 };
 

--- a/DataFormats/FWLite/test/event_looping_cint.C
+++ b/DataFormats/FWLite/test/event_looping_cint.C
@@ -7,7 +7,7 @@ class loadFWLite {
    public:
       loadFWLite() {
          gSystem->Load("libFWCoreFWLite");
-         AutoLibraryLoader::enable();
+         FWLiteEnabler::enable();
       }
 };
 

--- a/DataFormats/FWLite/test/productid_cint.C
+++ b/DataFormats/FWLite/test/productid_cint.C
@@ -7,7 +7,7 @@ class loadFWLite {
    public:
       loadFWLite() {
          gSystem->Load("libFWCoreFWLite");
-         AutoLibraryLoader::enable();
+         FWLiteEnabler::enable();
       }
 };
 

--- a/DataFormats/FWLite/test/runlumi_looping_cint.C
+++ b/DataFormats/FWLite/test/runlumi_looping_cint.C
@@ -7,7 +7,7 @@ class loadFWLite {
    public:
       loadFWLite() {
          gSystem->Load("libFWCoreFWLite");
-         AutoLibraryLoader::enable();
+         FWLiteEnabler::enable();
       }
 };
 

--- a/DataFormats/FWLite/test/test.cppunit.cpp
+++ b/DataFormats/FWLite/test/test.cppunit.cpp
@@ -8,7 +8,7 @@ Test program for edm::Ref use in ROOT.
 #include <string>
 #include <vector>
 #include <cppunit/extensions/HelperMacros.h>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "TFile.h"
 #include "TSystem.h"
 #include "DataFormats/TestObjects/interface/OtherThingCollection.h"
@@ -56,7 +56,7 @@ public:
   testRefInROOT() { }
   void setUp() {
     if(!sWasRun_) {
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
       sWasRun_ = true;
     }
     tmpdir = "tmp/";

--- a/DataFormats/FWLite/test/triggerResultsByName_cint.C
+++ b/DataFormats/FWLite/test/triggerResultsByName_cint.C
@@ -3,7 +3,7 @@ class loadFWLite {
   public:
     loadFWLite() {
       gSystem->Load("libFWCoreFWLite");
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
     }
 };
 

--- a/DataFormats/FWLite/test/triggerResultsByName_multi_cint.C
+++ b/DataFormats/FWLite/test/triggerResultsByName_multi_cint.C
@@ -3,7 +3,7 @@ class loadFWLite {
   public:
     loadFWLite() {
       gSystem->Load("libFWCoreFWLite");
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
     }
 };
 

--- a/DataFormats/FWLite/test/triggernames_cint.C
+++ b/DataFormats/FWLite/test/triggernames_cint.C
@@ -3,7 +3,7 @@ class loadFWLite {
   public:
     loadFWLite() {
       gSystem->Load("libFWCoreFWLite");
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
     }
 };
 

--- a/DataFormats/FWLite/test/triggernames_multi_cint.C
+++ b/DataFormats/FWLite/test/triggernames_multi_cint.C
@@ -3,7 +3,7 @@ class loadFWLite {
   public:
     loadFWLite() {
       gSystem->Load("libFWCoreFWLite");
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
     }
 };
 

--- a/DataFormats/FWLite/test/vector_int_cint.C
+++ b/DataFormats/FWLite/test/vector_int_cint.C
@@ -11,7 +11,7 @@ class loadFWLite {
    public:
       loadFWLite() {
          gSystem->Load("libFWCoreFWLite");
-         AutoLibraryLoader::enable();
+         FWLiteEnabler::enable();
       }
 };
 

--- a/DataFormats/ParticleFlowReco/test/init.C
+++ b/DataFormats/ParticleFlowReco/test/init.C
@@ -3,6 +3,6 @@
 // library, which contains the ROOT interface
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libDataFormatsParticleFlowReco.so");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 }

--- a/ElectroWeakAnalysis/ZMuMu/bin/zChi2Fit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zChi2Fit.cpp
@@ -15,7 +15,7 @@
 #include "PhysicsTools/Utilities/interface/rootPlot.h"
 #include "PhysicsTools/Utilities/interface/Expression.h"
 #include "PhysicsTools/Utilities/interface/HistoPdf.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TH1.h"

--- a/ElectroWeakAnalysis/ZMuMu/bin/zFitToyMc.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zFitToyMc.cpp
@@ -14,7 +14,7 @@
 #include "PhysicsTools/Utilities/interface/rootPlot.h"
 #include "PhysicsTools/Utilities/interface/Expression.h"
 #include "PhysicsTools/Utilities/interface/HistoPdf.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TH1.h"

--- a/ElectroWeakAnalysis/ZMuMu/bin/zUMLChi2Fit.cpp
+++ b/ElectroWeakAnalysis/ZMuMu/bin/zUMLChi2Fit.cpp
@@ -14,7 +14,7 @@
 #include "PhysicsTools/Utilities/interface/rootPlot.h"
 #include "PhysicsTools/Utilities/interface/Expression.h"
 #include "PhysicsTools/Utilities/interface/HistoPdf.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "PhysicsTools/Utilities/interface/Likelihood.h"
@@ -109,7 +109,7 @@ int main(int ac, char *av[]) {
       rebinMuMu1HLTConst(rebinMuMu1HLT), rebinMuMu2HLTConst(rebinMuMu2HLT), 
       rebinMuTkConst(rebinMuTk), rebinMuSaConst(rebinMuSa);
 
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
     TFile file("zMuSa-UML.root");
     fwlite::Event ev(&file);
     

--- a/ElectroWeakAnalysis/ZMuMu/test/rootlogon.C
+++ b/ElectroWeakAnalysis/ZMuMu/test/rootlogon.C
@@ -9,6 +9,6 @@
   gSystem->AddIncludePath("$CMSSW_BASE/src");
   gROOT->ProcessLine(".L setTDRStyle.C");
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   setTDRStyle();
 }

--- a/ElectroWeakAnalysis/ZMuMu/test/stackPlot10pb/rootlogon.C
+++ b/ElectroWeakAnalysis/ZMuMu/test/stackPlot10pb/rootlogon.C
@@ -9,6 +9,6 @@
   gSystem->AddIncludePath("$CMSSW_BASE/src");
   gROOT->ProcessLine(".L setTDRStyle.C");
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   setTDRStyle();
 }

--- a/ElectroWeakAnalysis/ZMuMu/test/stackPlots/rootlogon.C
+++ b/ElectroWeakAnalysis/ZMuMu/test/stackPlots/rootlogon.C
@@ -9,6 +9,6 @@
   gSystem->AddIncludePath("$CMSSW_BASE/src");
   gROOT->ProcessLine(".L setTDRStyle.C");
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   setTDRStyle();
 }

--- a/FWCore/FWLite/bin/storageSize.cc
+++ b/FWCore/FWLite/bin/storageSize.cc
@@ -17,7 +17,7 @@
 #include "TBufferFile.h"
 
 // user include files
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 
@@ -66,7 +66,7 @@ int main(int argc, char* argv[]) try
    
    std::string className(vm[kClassNameOpt].as<std::string>());
    
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
 
    TClass* cls = TClass::GetClass(className.c_str());
    if(0==cls) {

--- a/FWCore/FWLite/bin/storageSizeForBranch.cc
+++ b/FWCore/FWLite/bin/storageSizeForBranch.cc
@@ -20,7 +20,7 @@
 #include "TTree.h"
 
 // user include files
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 
@@ -108,7 +108,7 @@ int main(int argc, char* argv[]) try
    }
    
    
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
 
    TClass* cls = TClass::GetClass(branch->GetClassName());
    if(0==cls) {

--- a/FWCore/FWLite/doc/FWLite.doc
+++ b/FWCore/FWLite/doc/FWLite.doc
@@ -8,24 +8,21 @@
 </center>
 
 \section desc Description
-Automatic loading of shared libraries within Root prompt. This utility 
-can be enabled before opening any root file interactively. All libraries 
-containing the dictionaries of the data types stored on the opened file 
-will be automatically loaded using a plugin mechanism.
+This utility can be enabled before opening any root file interactively.
+fwlite will be enabled.
 
 \subsection interface Public interface
-- AutoLibraryLoader: automatic library loader.
 
 \subsection modules Modules
 None.
 
 \subsection tests Unit tests and examples
-- rootlogon.C: enable automatic library loading. 
+- rootlogon.C: enable fwlite
   The usage from Root prompt is the following:
 \htmlonly
 <pre>
   gSystem->Load("libFWCoreFWLite")
-  AutoLibraryLoader::enable()
+  FWLiteEnabler::enable()
 </pre>
 \endhtmlonly
 
@@ -33,5 +30,5 @@ None.
 To be reviewed.
 
 <hr>
-Last updated: @DATE@ L. Lista
+Last updated: @DATE@ W. Tanenbaum
 */

--- a/FWCore/FWLite/interface/FWLiteEnabler.h
+++ b/FWCore/FWLite/interface/FWLiteEnabler.h
@@ -1,0 +1,25 @@
+#ifndef FWCore_FWLite_FWLiteEnabler_h
+#define FWCore_FWLite_FWLiteEnabler_h
+/**\class FWLiteEnabler
+ *
+ * helper class to enable fwlite.
+ * Using a free function enable() directly does not work in macros.
+ *
+ */
+class DummyClassToStopCompilerWarning;
+
+class FWLiteEnabler {
+  friend class DummyClassToStopCompilerWarning;
+public:
+  FWLiteEnabler(const FWLiteEnabler&) = delete; // stop default
+  FWLiteEnabler const& operator=(FWLiteEnabler const&) = delete; // stop default
+  /// enable automatic library loading  
+  static void enable();
+
+private:
+  static bool enabled_;
+  FWLiteEnabler();
+};
+
+
+#endif

--- a/FWCore/FWLite/src/AutoLibraryLoader.cc
+++ b/FWCore/FWLite/src/AutoLibraryLoader.cc
@@ -11,18 +11,11 @@
 //
 
 // system include files
-#include <iostream>
-#include "TROOT.h"
-#include "TInterpreter.h"
-#include "TApplication.h"
 
+#include <iostream>
 // user include files
 #include "FWCore/FWLite/interface/AutoLibraryLoader.h"
-#include "FWCore/FWLite/src/BareRootProductGetter.h"
-#include "FWCore/PluginManager/interface/PluginManager.h"
-#include "FWCore/PluginManager/interface/standard.h"
-
-#include "FWCore/FWLite/interface/setRefStreamer.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 //
 // constants, enums and typedefs
 //
@@ -31,13 +24,11 @@
 // static data member definitions
 //
 
-bool AutoLibraryLoader::enabled_(false);
 
 //
 // constructors and destructor
 //
-AutoLibraryLoader::AutoLibraryLoader()
-{
+AutoLibraryLoader::AutoLibraryLoader() {
 }
 
 
@@ -46,64 +37,17 @@ AutoLibraryLoader::AutoLibraryLoader()
 //
 
 void
-AutoLibraryLoader::enable()
-{
-   if (enabled_) { return; }
-   enabled_ = true;
-
-   edmplugin::PluginManager::configure(edmplugin::standard::config());
-   static BareRootProductGetter s_getter;
-   //this function must be called
-   // so that the TClass we need will be available
-   fwlite::setRefStreamer(&s_getter);
-   
-   //Make it easy to load our headers
-   TInterpreter* intrp= gROOT->GetInterpreter();
-   const char* env = getenv("CMSSW_FWLITE_INCLUDE_PATH");
-   if( 0 != env) {
-     //this is a comma separated list
-     const char* start = env;
-     const char* end;
-     do{
-       //find end
-       for(end=start; *end!=0 and *end != ':';++end);
-       std::string dir(start, end);
-       intrp->AddIncludePath(dir.c_str());
-       start = end+1;
-     }while(*end != 0);
-   }
-   
-   bool foundCMSIncludes = false;
-   env = getenv("CMSSW_BASE");
-   if( 0 != env) {
-     foundCMSIncludes = true;
-     std::string dir(env);
-     dir += "/src";
-     intrp->AddIncludePath(dir.c_str());
-   }
-
-   env = getenv("CMSSW_RELEASE_BASE");
-   if( 0 != env) {
-     foundCMSIncludes = true;
-     std::string dir(env);
-     dir += "/src";
-     intrp->AddIncludePath(dir.c_str());
-   }
-   if( not foundCMSIncludes) {
-     std::cerr <<"Could not find the environment variables \n"
-     <<"  CMSSW_BASE or\n"
-     <<"  CMSSW_RELEASE_BASE\n"
-     <<" therefore attempting to '#include' any CMS headers will not work"<<std::endl;
-   }
-   if (0 != gApplication) {
-     gApplication->InitializeGraphics();
-   }
+AutoLibraryLoader::enable() {
+  std::cerr << "WARNING: AutoLibraryloader::enable() and AutoLibraryLoader.h are deprecated.\n" <<
+  "Use FWLiteEnabler::enable() and FWLiteEnabler.h instead"  << std::endl;
+  FWLiteEnabler::enable();
 }
 
 void
 AutoLibraryLoader::loadAll()
 {
-  // std::cout <<"LoadAllDictionaries"<<std::endl;
-  enable();
+  std::cerr << "WARNING: AutoLibraryloader::loadAll() and AutoLibraryLoader.h are deprecated.\n" <<
+  "Use FWLiteEnabler::enable() and FWLiteEnabler.h instead"  << std::endl;
+  FWLiteEnabler::enable();
 }
 

--- a/FWCore/FWLite/src/FWLiteEnabler.cc
+++ b/FWCore/FWLite/src/FWLiteEnabler.cc
@@ -1,0 +1,102 @@
+// -*- C++ -*-
+//
+// Package:     LibraryLoader
+// Class  :     FWLiteEnabler
+//
+// Implementation:
+//     <Notes on implementation>
+//
+//
+
+// system include files
+#include <iostream>
+#include "TROOT.h"
+#include "TInterpreter.h"
+#include "TApplication.h"
+
+// user include files
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
+#include "FWCore/FWLite/src/BareRootProductGetter.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+
+#include "FWCore/FWLite/interface/setRefStreamer.h"
+
+//
+// constants, enums and typedefs
+//
+
+//
+// static data member definitions
+//
+
+  bool FWLiteEnabler::enabled_(false);
+
+
+//
+// constructors and destructor
+//
+// Note: this ctor will never be invoked.
+// All data and functions are static
+  FWLiteEnabler::FWLiteEnabler() {
+  }
+
+
+//
+// member functions
+//
+
+  void
+  FWLiteEnabler::enable() {
+   if (enabled_) { return; }
+   enabled_ = true;
+
+   edmplugin::PluginManager::configure(edmplugin::standard::config());
+   static BareRootProductGetter s_getter;
+   //this function must be called
+   // so that the TClass we need will be available
+   fwlite::setRefStreamer(&s_getter);
+
+   //Make it easy to load our headers
+   TInterpreter* intrp= gROOT->GetInterpreter();
+   char const* env = getenv("CMSSW_FWLITE_INCLUDE_PATH");
+   if(0 != env) {
+     //this is a comma separated list
+     char const* start = env;
+     char const* end;
+     do {
+       //find end
+       for(end=start; *end!=0 and *end != ':';++end);
+       std::string dir(start, end);
+       intrp->AddIncludePath(dir.c_str());
+       start = end+1;
+     } while(*end != 0);
+   }
+
+   bool foundCMSIncludes = false;
+   env = getenv("CMSSW_BASE");
+   if(0 != env) {
+     foundCMSIncludes = true;
+     std::string dir(env);
+     dir += "/src";
+     intrp->AddIncludePath(dir.c_str());
+   }
+
+   env = getenv("CMSSW_RELEASE_BASE");
+   if(0 != env) {
+     foundCMSIncludes = true;
+     std::string dir(env);
+     dir += "/src";
+     intrp->AddIncludePath(dir.c_str());
+   }
+   if(not foundCMSIncludes) {
+     std::cerr <<"Could not find the environment variables \n"
+     <<"  CMSSW_BASE or\n"
+     <<"  CMSSW_RELEASE_BASE\n"
+     <<" therefore attempting to '#include' any CMS headers will not work"<<std::endl;
+   }
+   if (0 != gApplication) {
+     gApplication->InitializeGraphics();
+   }
+  }
+

--- a/FWCore/FWLite/src/classes.h
+++ b/FWCore/FWLite/src/classes.h
@@ -1,2 +1,3 @@
 #include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "FWCore/FWLite/src/branchToClass.h"

--- a/FWCore/FWLite/src/classes_def.xml
+++ b/FWCore/FWLite/src/classes_def.xml
@@ -2,4 +2,7 @@
  <class name="AutoLibraryLoader" ClassVersion="10">
    <version ClassVersion="10" checksum="981711899"/>
  </class>
+ <class name="FWLiteEnabler" ClassVersion="10">
+   <version ClassVersion="10" checksum="60237984"/>
+ </class>
 </lcgdict>

--- a/FWCore/FWLite/test/autoload_with_missing_std.C
+++ b/FWCore/FWLite/test/autoload_with_missing_std.C
@@ -7,7 +7,7 @@
 //}
 //cout <<"class not present yet"<<endl;
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 if( !TClass::GetClass("vector<edmtest::Thing>") ) {
    exit(1);
 }

--- a/FWCore/FWLite/test/autoload_with_namespace.C
+++ b/FWCore/FWLite/test/autoload_with_namespace.C
@@ -6,7 +6,7 @@ if( TClass::GetClass("edmtest::Thing") ) {
 cout <<"class not present yet"<<endl;
 
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 if( !TClass::GetClass("edmtest::Thing") ) {
    cout <<"class still missing"<<endl;
    exit(1);

--- a/FWCore/FWLite/test/autoload_with_std.C
+++ b/FWCore/FWLite/test/autoload_with_std.C
@@ -7,7 +7,7 @@
 //}
 //cout <<"class not present yet"<<endl;
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 if( !TClass::GetClass("std::vector<edmtest::Thing>") ) {
    cout <<"class still missing"<<endl;
    exit(1);

--- a/FWCore/FWLite/test/ref_t.cppunit.cpp
+++ b/FWCore/FWLite/test/ref_t.cppunit.cpp
@@ -20,7 +20,7 @@ the following sequence of commands.
   cmsenv
   root.exe
   gSystem->Load("libFWCoreFWLite.so");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   TFile f("good.root");
 
 Then this one will draw just a simple variable:
@@ -53,7 +53,7 @@ using ROOT's "Draw" interface.
 #include <string>
 #include <vector>
 #include <cppunit/extensions/HelperMacros.h>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "TFile.h"
 #include "TTree.h"
 #include "TBranch.h"
@@ -93,7 +93,7 @@ public:
   {
     if(!sWasRun_) {
       gSystem->Load("libFWCoreFWLite.so");
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
       
       char* argv[] = {CHARSTAR("testFWCoreFWLite"),
 		      CHARSTAR("/bin/bash"),

--- a/FWCore/FWLite/test/rootlogon.C
+++ b/FWCore/FWLite/test/rootlogon.C
@@ -1,2 +1,2 @@
 gSystem->Load("libFWCoreFWLite")
-AutoLibraryLoader::enable()
+FWLiteEnabler::enable()

--- a/FWCore/ROOTTests/test/read_threaded_t.cc
+++ b/FWCore/ROOTTests/test/read_threaded_t.cc
@@ -10,7 +10,7 @@
 #include "TObjString.h"
 #include "TH1F.h"
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include <memory>
 #include <cassert>
@@ -97,7 +97,7 @@ int main(int argc, char** argv) {
 
 
  
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   //Tell Root we want to be multi-threaded
   TThread::Initialize();

--- a/FWCore/TFWLiteSelector/doc/proofNotes.txt
+++ b/FWCore/TFWLiteSelector/doc/proofNotes.txt
@@ -95,7 +95,7 @@ Now you will want to do something useful, like run a TSelector.
 This turned out to be quite tricky. Here is an example.
 We made a ThingsTSelector, which we put into libFWCoreTFWLiteSelectorTest.
 To ensure that our TSelector was auto-loaded we loaded libFWCoreFWLite
-and then enabled the AutoLibraryLoader.
+and then enabled fwlite.
 NOTE WELL: libFWCoreTFWLiteSelectorTest.so must be in the LD_LIBRARY_PATH
 for all the proofd's you are running.
 
@@ -111,7 +111,7 @@ everything load properly on the remote proof host(s).
     // This makes the TSelectors in the library available to the
     // remote proof session
     gSystem->Load("libFWCoreFWLite");
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
     gSystem->Load("libFWCoreTFWLiteSelectorTest");
   }
 
@@ -123,11 +123,8 @@ Now make proof_local.C
 
     // You need this to allow ROOT to be able to use a ThingsTSelector
     gSystem->Load("libFWCoreFWLite");
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
 
-    // Have to load library manually since Proof does not use the 
-    // mechanism used by TFile to find class dictionaries and therefore
-    // the AutoLibraryLoader cannot help
     gSystem->Load("libFWCoreTFWLiteSelectorTest");
 
     // This makes sure the TSelector library and dictionary are properly

--- a/FWCore/TFWLiteSelector/test/proof_remote.C
+++ b/FWCore/TFWLiteSelector/test/proof_remote.C
@@ -1,6 +1,6 @@
 {
   //This make the TSelectors in the library available to the remote proof session
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   gSystem->Load("libFWCoreTFWLiteSelectorTest");
 }

--- a/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
@@ -9,13 +9,13 @@ class loadFWLite {
    public:
       loadFWLite() {
          gSystem->Load("libFWCoreFWLite");
-         AutoLibraryLoader::enable();
+         FWLiteEnabler::enable();
       }
 };
 
 static loadFWLite lfw;
 #else
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #endif
 
 void proof_thing2_sel()
@@ -41,10 +41,7 @@ void proof_thing2_sel()
 
   // So inline it...
   myProof->Exec("gSystem->Load(\"libFWCoreFWLite\"); "
-               "AutoLibraryLoader::enable(); "
-  // Have to load library manually since Proof does not use the 
-  // mechanism used by TFile to find class dictionaries and therefore
-  // the AutoLibraryLoader can not help
+               "FWLiteEnabler::enable(); "
                "gSystem->Load(\"libFWCoreTFWLiteSelectorTest\");");
   
   //This creates the 'data set' which defines what files we need to process

--- a/FWCore/TFWLiteSelector/test/proof_thing_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing_sel.C
@@ -9,13 +9,13 @@ class loadFWLite {
    public:
       loadFWLite() {
          gSystem->Load("libFWCoreFWLite");
-         AutoLibraryLoader::enable();
+         FWLiteEnabler::enable();
       }
 };
 
 static loadFWLite lfw;
 #else
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #endif
 
 void proof_thing_sel()
@@ -41,10 +41,7 @@ void proof_thing_sel()
 
   // So inline it...
   myProof->Exec("gSystem->Load(\"libFWCoreFWLite\"); "
-               "AutoLibraryLoader::enable(); "
-  // Have to load library manually since Proof does not use the 
-  // mechanism used by TFile to find class dictionaries and therefore
-  // the AutoLibraryLoader can not help
+               "FWLiteEnabler::enable(); "
                "gSystem->Load(\"libFWCoreTFWLiteSelectorTest\");");
 
   // This creates the 'data set' which defines what files we need to process

--- a/FWCore/TFWLiteSelector/test/thing2_sel.C
+++ b/FWCore/TFWLiteSelector/test/thing2_sel.C
@@ -1,10 +1,7 @@
 {
   //Need this to allow ROOT to be able to use a ThingsTSelector
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
-  //Have to load library manually since Proof does not use the 
-  // mechanism used by TFile to find class dictionaries and therefore
-  // the AutoLibraryLoader can not help
+  FWLiteEnabler::enable();
   gSystem->Load("libFWCoreTFWLiteSelectorTest");
   
   TSelector* sel = new tfwliteselectortest::ThingsTSelector2();

--- a/FWCore/TFWLiteSelector/test/thing_sel.C
+++ b/FWCore/TFWLiteSelector/test/thing_sel.C
@@ -1,10 +1,7 @@
 {
   //Need this to allow ROOT to be able to use a ThingsTSelector
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
-  //Have to load library manually since Proof does not use the 
-  // mechanism used by TFile to find class dictionaries and therefore
-  // the AutoLibraryLoader can not help
+  FWLiteEnabler::enable();
   gSystem->Load("libFWCoreTFWLiteSelectorTest");
 
   TSelector* sel = new tfwliteselectortest::ThingsTSelector();

--- a/FWCore/Utilities/scripts/edmAddClassVersion
+++ b/FWCore/Utilities/scripts/edmAddClassVersion
@@ -227,7 +227,7 @@ if __name__ == '__main__':
     if options.library is None:
         if 0 != ROOT.gSystem.Load("libFWCoreFWLite"):
             raise RuntimeError("failed to load libFWCoreFWLite")
-        ROOT.AutoLibraryLoader.enable()
+        ROOT.fwlite.enable()
     else:
         if 0 != ROOT.gSystem.Load(options.library):
             raise RuntimeError("failed to load library '"+options.library+"'")

--- a/FastSimulation/MaterialEffects/test/init.C
+++ b/FastSimulation/MaterialEffects/test/init.C
@@ -4,6 +4,6 @@
 // library, which contains the ROOT interface
 gSystem->Load("libFWCoreFWLite.so");
 gSystem->Load("libFastSimulationMaterialEffects.so");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 }

--- a/FastSimulation/PileUpProducer/test/test_pileup.C
+++ b/FastSimulation/PileUpProducer/test/test_pileup.C
@@ -4,7 +4,7 @@
 Don't forget these commands, if they are not in your rootlogon.C:
 
    gSystem->Load("libFWCoreFWLite.so"); 
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
    gSystem->Load("libDataFormatsFWLite.so");
 
 */

--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -60,7 +60,7 @@
 
 #include "Fireworks/Core/interface/fwLog.h"
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #if defined(R__LINUX)
 #include "TGX11.h" // !!!! AMT has to be at the end to pass build
@@ -288,7 +288,7 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
 
    //Delay creating guiManager and enabling autoloading until here so that if we have a 'help' request we don't
    // open any graphics or build dictionaries
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
 
    TEveManager::Create(kFALSE, eveMode ? "FIV" : "FI");
 

--- a/Fireworks/Core/src/FWItemAccessorFactory.cc
+++ b/Fireworks/Core/src/FWItemAccessorFactory.cc
@@ -126,8 +126,8 @@ FWItemAccessorFactory::accessorFor(const TClass* iClass) const
    // NOTE: This is done only a few times, not really performance critical.
    // If you want this to be fast, the loop can be moved in the 
    // constructor. Notice that this will require constructing FWEventItemsManager 
-   // after the plugin manager (i.e. invoking AutoLibraryLoader::enable()) is configured
-   // (i.e. invoking AutoLibraryLoader::enable()) in CmsShowMain.
+   // after the plugin manager (i.e. invoking FWLiteEnabler::enable()) is configured
+   // (i.e. invoking FWLiteEnabler::enable()) in CmsShowMain.
    std::string accessorName;
    if (hasAccessor(iClass, accessorName))
    {

--- a/GeneratorInterface/Pythia6Interface/test/H190ZZ4muAnalysisExample.C
+++ b/GeneratorInterface/Pythia6Interface/test/H190ZZ4muAnalysisExample.C
@@ -10,7 +10,7 @@
 // since it already in the rootlogon.C
 //
 //   gSystem->Load("libFWCoreFWLite") ;
-//   AutoLibraryLoader::enable() ;
+//   FWLiteEnabler::enable() ;
    
    TFile* f = new TFile("PythiaH190ZZ4mu_cfi_py_GEN.root") ;
    

--- a/GeneratorInterface/Pythia6Interface/test/rootlogon.C
+++ b/GeneratorInterface/Pythia6Interface/test/rootlogon.C
@@ -1,4 +1,4 @@
 {
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }

--- a/HLTrigger/Timer/test/analyzeTiming.cpp
+++ b/HLTrigger/Timer/test/analyzeTiming.cpp
@@ -14,7 +14,7 @@
 // needed for event-id info
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
 //
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include "HLTrigger/Timer/test/AnalyzeTiming.h"
 
@@ -36,7 +36,7 @@ int main(int argc, char ** argv)
 {
   // load libraries
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // default arguments
   string filename = "hlt.root";

--- a/HLTrigger/Tools/bin/hltTimingSummary.cpp
+++ b/HLTrigger/Tools/bin/hltTimingSummary.cpp
@@ -20,7 +20,7 @@
 
 #include "DataFormats/HLTReco/interface/HLTPerformanceInfo.h"
 #include "DataFormats/Provenance/interface/EventAuxiliary.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "DataFormats/Common/interface/Wrapper.h"
 
 //--- Created by:  
@@ -630,7 +630,7 @@ int main(int argc, char ** argv) {
     
   //-- Load libraries ---//
   gSystem->Load("libFWCoreFWLite") ;
-  AutoLibraryLoader::enable () ;
+  FWLiteEnabler::enable () ;
 
   //--- Default arguments ---//
   std::string filename = "hlt.root" ;

--- a/HeavyIonsAnalysis/Configuration/macros/rootlogon.C
+++ b/HeavyIonsAnalysis/Configuration/macros/rootlogon.C
@@ -2,7 +2,7 @@
 {
   gSystem->Load( "libFWCoreFWLite" );
   gSystem->Load("libDataFormatsFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
  
   //open dummy file for automatic loading of necessary libraries
   new TFile("./hiCommonSkimAOD.root");

--- a/IOMC/EventVertexGenerators/test/vtx_check.C
+++ b/IOMC/EventVertexGenerators/test/vtx_check.C
@@ -2,7 +2,7 @@
 {
 
    gSystem->Load("libFWCoreFWLite") ;
-   AutoLibraryLoader::enable() ;
+   FWLiteEnabler::enable() ;
    
    TFile* f = new TFile("pgun.root") ;
    

--- a/JetMETCorrections/MinBias/test/rootlogon.C.old
+++ b/JetMETCorrections/MinBias/test/rootlogon.C.old
@@ -1,4 +1,4 @@
 {
   gSystem->Load("./libPhysicsToolsFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }

--- a/L1Trigger/GlobalMuonTrigger/test/checkgmt.C
+++ b/L1Trigger/GlobalMuonTrigger/test/checkgmt.C
@@ -4,7 +4,7 @@ using namespace std;
    gROOT->Reset();
 
    gSystem->Load("libPhysicsToolsFWLite") ;
-   AutoLibraryLoader::enable() ;
+   FWLiteEnabler::enable() ;
    
    TFile* f = new TFile("runGMT.root") ;
    

--- a/MuonAnalysis/MomentumScaleCalibration/bin/MuScleFitTreeProvenance.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/MuScleFitTreeProvenance.cc
@@ -8,7 +8,7 @@
 #include <TFile.h>
 #include <TSystem.h>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
 #include "MuonAnalysis/MomentumScaleCalibration/interface/MuScleFitProvenance.h"
 

--- a/MuonAnalysis/MomentumScaleCalibration/bin/TreeDump.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/TreeDump.cc
@@ -7,7 +7,7 @@
 #include <sstream>
 #include <fstream>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "MuonAnalysis/MomentumScaleCalibration/interface/RootTreeHandler.h"
 
 /**
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // open input file (can be located on castor)
   TFile* inFile = TFile::Open(fileName.c_str());

--- a/MuonAnalysis/MomentumScaleCalibration/bin/TreeFromDump.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/TreeFromDump.cc
@@ -11,7 +11,7 @@
 #include <TFile.h>
 #include <TSystem.h>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "MuonAnalysis/MomentumScaleCalibration/interface/RootTreeHandler.h"
 
 /**
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   // MuonPairVector pairVector;
   std::vector<MuonPair> pairVector;

--- a/MuonAnalysis/MomentumScaleCalibration/bin/ZntupleToTreeConverter.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/ZntupleToTreeConverter.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/Common/interface/Handle.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
@@ -53,14 +53,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part:
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   // book a set of histograms
   fwlite::TFileService fs = fwlite::TFileService("analyzeBasics.root");

--- a/PerfTools/EdmEvent/bin/edmEventSize.cpp
+++ b/PerfTools/EdmEvent/bin/edmEventSize.cpp
@@ -14,7 +14,7 @@
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TError.h>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 static const char * const kHelpOpt = "help";
 static const char * const kHelpCommandOpt = "help,h";
@@ -88,7 +88,7 @@ int main( int argc, char * argv[] ) {
 
   if( vm.count( kAutoLoadOpt ) != 0 ) {
     gSystem->Load( "libFWCoreFWLite" );
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
   }
   else 
     gErrorIgnoreLevel = kError; 

--- a/PerfTools/EdmEvent/src/EdmEventSize.cc
+++ b/PerfTools/EdmEvent/src/EdmEventSize.cc
@@ -21,7 +21,6 @@
 #include "TH1.h"
 #include "TCanvas.h"
 #include "Riostream.h"
-// #include "FWCore/FWLite/src/AutoLibraryLoader.h"
 
 #include "TBufferFile.h"
 

--- a/PerfTools/EdmEvent/test/branchSizes.cpp
+++ b/PerfTools/EdmEvent/test/branchSizes.cpp
@@ -19,7 +19,7 @@
 #include <TBranch.h>
 #include <TH1.h>
 #include <TCanvas.h>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include <utility>
 
 #include "TBufferFile.h"
@@ -187,7 +187,7 @@ int main( int argc, char * argv[] ) {
   
   if( vm.count( kAutoLoadOpt ) != 0 ) {
     gSystem->Load( "libFWCoreFWLite" );
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
   }
 
   string fileName = vm[kDataFileOpt].as<string>();

--- a/PhysicsTools/FWLite/bin/FWLiteHistograms.cc
+++ b/PhysicsTools/FWLite/bin/FWLiteHistograms.cc
@@ -12,7 +12,7 @@
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
@@ -29,14 +29,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // initialize command line parser
   optutl::CommandLineParser parser ("Analyze FWLite Histograms");

--- a/PhysicsTools/FWLite/bin/FWLiteLumiAccess.cc
+++ b/PhysicsTools/FWLite/bin/FWLiteLumiAccess.cc
@@ -4,7 +4,7 @@
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/FWLite/interface/Handle.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include "DataFormats/FWLite/interface/Run.h"
 #include "DataFormats/FWLite/interface/LuminosityBlock.h"
@@ -15,7 +15,7 @@
 int main(int argc, char ** argv){
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // initialize command line parser
   optutl::CommandLineParser parser ("Analyze FWLite Histograms");

--- a/PhysicsTools/FWLite/bin/FWLiteWithPythonConfig.cc
+++ b/PhysicsTools/FWLite/bin/FWLiteWithPythonConfig.cc
@@ -5,7 +5,7 @@
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include "DataFormats/FWLite/interface/InputSource.h"
 #include "DataFormats/FWLite/interface/OutputFiles.h"
@@ -26,14 +26,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // parse arguments
   if ( argc < 2 ) {

--- a/PhysicsTools/FWLite/bin/FWLiteWithSelectorUtils.cc
+++ b/PhysicsTools/FWLite/bin/FWLiteWithSelectorUtils.cc
@@ -5,7 +5,7 @@
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include "DataFormats/FWLite/interface/InputSource.h"
 #include "DataFormats/FWLite/interface/OutputFiles.h"
@@ -27,14 +27,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   if ( argc < 2 ) {
     std::cout << "Usage : " << argv[0] << " [parameters.py]" << std::endl;

--- a/PhysicsTools/FWLite/src/EventContainer.cc
+++ b/PhysicsTools/FWLite/src/EventContainer.cc
@@ -4,7 +4,7 @@
 #include <iomanip>
 #include <cassert>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/EventContainer.h"
 #include "PhysicsTools/FWLite/interface/dout.h"
 #include "DataFormats/FWLite/interface/MultiChainEvent.h"
@@ -38,7 +38,7 @@ EventContainer::EventContainer (optutl::CommandLineParser &parser,
    // Call the autoloader if not already called.
    if (! sm_autoloaderCalled)
    {
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
       sm_autoloaderCalled = true;      
    }
 

--- a/PhysicsTools/FWLite/test/testScanner.cc
+++ b/PhysicsTools/FWLite/test/testScanner.cc
@@ -1,7 +1,7 @@
 /// This is only to make sure that our FWLite tools also compile with gcc
 /// that usually spots errors in a much more readable way
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/Scanner.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/Track.h"
@@ -16,7 +16,7 @@ int main (int argc, char* argv[])
 {
     if (argc != 2) { std::cerr << "usage: " << argv[0] << " cmssw_reco_file.root" << std::endl; return 2; }
 
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
     gROOT->SetStyle ("Plain");
     gStyle->SetPalette(1);
     gStyle->SetHistMinimumZero(1);

--- a/PhysicsTools/HepMCCandAlgos/test/HZZ4muAnalysisExample.C
+++ b/PhysicsTools/HepMCCandAlgos/test/HZZ4muAnalysisExample.C
@@ -10,7 +10,7 @@
 // since it already in the rootlogon.C
 //
 //   gSystem->Load("libFWCoreFWLite") ;
-//   AutoLibraryLoader::enable() ;
+//   FWLiteEnabler::enable() ;
    
    TFile* f = new TFile("../../../Configuration/Examples/data/pythiaH190ZZ4mu.root") ;
    

--- a/PhysicsTools/HepMCCandAlgos/test/rootlogon.C
+++ b/PhysicsTools/HepMCCandAlgos/test/rootlogon.C
@@ -1,4 +1,4 @@
 {
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }

--- a/PhysicsTools/Heppy/python/loadlibs.py
+++ b/PhysicsTools/Heppy/python/loadlibs.py
@@ -4,7 +4,7 @@ def load_libs():
     print 'loading FWLite.'
     #load the libaries needed
     gSystem.Load("libFWCoreFWLite")
-    gROOT.ProcessLine('AutoLibraryLoader::enable();')
+    gROOT.ProcessLine('FWLiteEnabler::enable();')
     gSystem.Load("libFWCoreFWLite")
         
     #now the RootTools stuff

--- a/PhysicsTools/ParallelAnalysis/test/trackExample.C
+++ b/PhysicsTools/ParallelAnalysis/test/trackExample.C
@@ -1,7 +1,7 @@
 {
 /// enable automatic data formats librarly loading
    gSystem->Load("libFWCoreFWLite");
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
 /// set up events chain
    TChain events("Events");
    events.Add("aod.root");

--- a/PhysicsTools/PatAlgos/test/fwlite/rootlogon.C
+++ b/PhysicsTools/PatAlgos/test/fwlite/rootlogon.C
@@ -1,6 +1,6 @@
 {
   gSystem->Load("libFWCoreFWLite.so"); 
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   gSystem->Load("libDataFormatsFWLite.so");
   gROOT->ProcessLine("namespace edm {typedef edm::Wrapper<vector<float> > Wrapper<vector<float,allocator<float> > >; }");
   gROOT->ProcessLine("namespace edm {typedef edm::Wrapper<vector<double> > Wrapper<vector<double,allocator<double> > >; }");

--- a/PhysicsTools/PatExamples/bin/JPsiFWLiteAnalyzer.cc
+++ b/PhysicsTools/PatExamples/bin/JPsiFWLiteAnalyzer.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/CompositeCandidate.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 using namespace std;
 
@@ -22,14 +22,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
     
   // open input file (can be located on castor)
   TFile* inFile = TFile::Open( "file:jpsi.root" );

--- a/PhysicsTools/PatExamples/bin/PatAnalysisTasksExercise.cc
+++ b/PhysicsTools/PatExamples/bin/PatAnalysisTasksExercise.cc
@@ -10,7 +10,7 @@ int main(int argc, char* argv[])
 {
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // only allow one argument for this simple example which should be the
   // the python cfg file

--- a/PhysicsTools/PatExamples/bin/PatBasicFWLiteAnalyzer.cc
+++ b/PhysicsTools/PatExamples/bin/PatBasicFWLiteAnalyzer.cc
@@ -12,7 +12,7 @@
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include "DataFormats/FWLite/interface/InputSource.h"
 #include "DataFormats/FWLite/interface/OutputFiles.h"
@@ -28,14 +28,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // only allow one argument for this simple example which should be the
   // the python cfg file

--- a/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetAnalyzer.cc
+++ b/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetAnalyzer.cc
@@ -14,7 +14,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
 #include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
 
@@ -24,14 +24,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part:
   //
-  //  * enable the AutoLibraryLoader
+  //  * enable FWLite
   //  * book the histograms of interest
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // only allow one argument for this simple example which should be the
   // the python cfg file

--- a/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetAnalyzer_Selector.cc
+++ b/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetAnalyzer_Selector.cc
@@ -22,7 +22,7 @@ This example creates a histogram of Jet Pt, using Jets with Pt above 30 and ETA 
 #include "PhysicsTools/SelectorUtils/interface/JetIDSelectionFunctor.h"
 #include "PhysicsTools/SelectorUtils/interface/PFJetIDSelectionFunctor.h"
 #include "PhysicsTools/SelectorUtils/interface/RunLumiSelector.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
 #include "DataFormats/FWLite/interface/ChainEvent.h"
 #include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
@@ -244,7 +244,7 @@ int main (int argc, char* argv[])
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
 
   cout << "Getting parameters" << endl;

--- a/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetUnitTest.cc
+++ b/PhysicsTools/PatExamples/bin/PatBasicFWLiteJetUnitTest.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
 #include "TStopwatch.h"
 
@@ -23,7 +23,7 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part:
   //
-  //  * enable the AutoLibraryLoader
+  //  * enable FWLite
   //  * book the histograms of interest
   //  * open the input file
   // ----------------------------------------------------------------------
@@ -32,7 +32,7 @@ int main(int argc, char* argv[])
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
  
   // book a set of histograms
   fwlite::TFileService fs = fwlite::TFileService(argv[2]);

--- a/PhysicsTools/PatExamples/bin/PatCleaningExercise.cc
+++ b/PhysicsTools/PatExamples/bin/PatCleaningExercise.cc
@@ -10,7 +10,7 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
 #include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
 
@@ -24,14 +24,14 @@ int main(int argc, char *argv[]){
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // only allow one argument for this simple example which should be the
   // the python cfg file

--- a/PhysicsTools/PatExamples/bin/PatMcMatchFWLiteAnalyzer.cc
+++ b/PhysicsTools/PatExamples/bin/PatMcMatchFWLiteAnalyzer.cc
@@ -13,7 +13,7 @@
 #include "DataFormats/FWLite/interface/Handle.h"
 #include "DataFormats/PatCandidates/interface/Muon.h" // Include the examined data formats
 #include "DataFormats/PatCandidates/interface/Jet.h"  // Include the examined data formats
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 
 int main(int argc, char* argv[]) 
@@ -21,14 +21,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   // book a set of histograms
   TH2F* muonPt_  = new TH2F( "muonPt", "Muon Pt", 60, 0., 300., 60, 0., 300. ); // 2-D histo for muon Pt

--- a/PhysicsTools/PatExamples/bin/PatMuonEDMAnalyzer.cc
+++ b/PhysicsTools/PatExamples/bin/PatMuonEDMAnalyzer.cc
@@ -12,7 +12,7 @@
 
 #include "DataFormats/FWLite/interface/Event.h"
 #include "DataFormats/Common/interface/Handle.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 #include "DataFormats/MuonReco/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
@@ -24,14 +24,14 @@ int main(int argc, char* argv[])
   // ----------------------------------------------------------------------
   // First Part: 
   //
-  //  * enable the AutoLibraryLoader 
+  //  * enable FWLite 
   //  * book the histograms of interest 
   //  * open the input file
   // ----------------------------------------------------------------------
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // initialize command line parser
   optutl::CommandLineParser parser ("Analyze FWLite Histograms");

--- a/PhysicsTools/PatExamples/bin/PatMuonFWLiteAnalyzer.cc
+++ b/PhysicsTools/PatExamples/bin/PatMuonFWLiteAnalyzer.cc
@@ -8,7 +8,7 @@ int main(int argc, char* argv[])
 {
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // only allow one argument for this simple example which should be the
   // the python cfg file

--- a/PhysicsTools/PatExamples/test/TestCorrections_FWLiteMacro.C
+++ b/PhysicsTools/PatExamples/test/TestCorrections_FWLiteMacro.C
@@ -5,7 +5,7 @@
     /*
       {
       gSystem->Load("libFWCoreFWLite.so");
-      AutoLibraryLoader::enable();
+      FWLiteEnabler::enable();
       gSystem->Load("libDataFormatsFWLite.so");
       gSystem->Load("libDataFormatsPatCandidates.so");
       gSystem->Load("libRooFit") ;
@@ -34,7 +34,7 @@
   // these includes are needed to make the  "gSystem" commands below work
 #include "TSystem.h"
 #include "TROOT.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #endif
 
 

--- a/PhysicsTools/PythonAnalysis/examples/MCTruth.py
+++ b/PhysicsTools/PythonAnalysis/examples/MCTruth.py
@@ -2,7 +2,7 @@ from PhysicsTools.PythonAnalysis import *
 from ROOT import *
 # prepare the FWLite autoloading mechanism
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 
 # load the file with the generator output
 theFile = TFile("generatorOutput.root")

--- a/PhysicsTools/PythonAnalysis/examples/MCTruth2.py
+++ b/PhysicsTools/PythonAnalysis/examples/MCTruth2.py
@@ -3,7 +3,7 @@ from ROOT import *
 
 # prepare the FWLite autoloading mechanism
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 
 # access the event tree
 events = EventTree("generatorOutput.root")

--- a/PhysicsTools/PythonAnalysis/examples/interactiveExample.py
+++ b/PhysicsTools/PythonAnalysis/examples/interactiveExample.py
@@ -5,7 +5,7 @@ from ROOT import *
 
 # prepare the FWLite autoloading mechanism
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 
 # enable support for files > 2 GB
 gSystem.Load("libIOPoolTFileAdaptor")

--- a/PhysicsTools/PythonAnalysis/examples/start.py
+++ b/PhysicsTools/PythonAnalysis/examples/start.py
@@ -4,5 +4,5 @@ from ROOT import *
 from PhysicsTools.PythonAnalysis import *
 
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 

--- a/PhysicsTools/PythonAnalysis/examples/trackerHits.py
+++ b/PhysicsTools/PythonAnalysis/examples/trackerHits.py
@@ -3,7 +3,7 @@ from PhysicsTools.PythonAnalysis import *
 from ROOT import *
 
 gSystem.Load("libFWCoreFWLite.so")
-AutoLibraryLoader.enable()
+FWLiteEnabler::enable()
 
 # opening file
 events = EventTree("simevent.root")

--- a/PhysicsTools/RecoAlgos/test/rootlogon.C
+++ b/PhysicsTools/RecoAlgos/test/rootlogon.C
@@ -1,4 +1,4 @@
 {
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 }

--- a/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
+++ b/PhysicsTools/SelectorUtils/bin/calculateIdMD5.cc
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <TSystem.h>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -16,7 +16,7 @@ int main ( int argc, char ** argv )
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   if ( argc < 3 ) {
     std::cout << "Usage : " << argv[0] 

--- a/PhysicsTools/SelectorUtils/bin/testSelection_wplusjets.C
+++ b/PhysicsTools/SelectorUtils/bin/testSelection_wplusjets.C
@@ -3,7 +3,7 @@
 #include "DataFormats/FWLite/interface/ChainEvent.h"
 #include "DataFormats/FWLite/interface/MultiChainEvent.h"
 #include "PhysicsTools/SelectorUtils/interface/WPlusJetsEventSelector.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
 #include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
@@ -31,7 +31,7 @@ int main ( int argc, char ** argv )
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   if ( argc < 2 ) {
     std::cout << "Usage : " << argv[0] << " [parameters.py]" << std::endl;

--- a/PhysicsTools/UtilAlgos/bin/FWLiteWithBasicAnalyzer.cc
+++ b/PhysicsTools/UtilAlgos/bin/FWLiteWithBasicAnalyzer.cc
@@ -8,7 +8,7 @@ int main(int argc, char* argv[])
 {
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 
   // only allow one argument for this simple example which should be the
   // the python cfg file

--- a/PhysicsTools/UtilAlgos/interface/FWLiteAnalyzerWrapper.h
+++ b/PhysicsTools/UtilAlgos/interface/FWLiteAnalyzerWrapper.h
@@ -12,7 +12,7 @@
 #include "DataFormats/FWLite/interface/ChainEvent.h"
 #include "DataFormats/FWLite/interface/InputSource.h"
 #include "DataFormats/FWLite/interface/OutputFiles.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "FWCore/ParameterSet/interface/ProcessDesc.h"
 #include "PhysicsTools/FWLite/interface/TFileService.h"
 #include "FWCore/PythonParameterSet/interface/PythonProcessDesc.h"
@@ -44,7 +44,7 @@
    {
      // load framework libraries
      gSystem->Load( "libFWCoreFWLite" );
-     AutoLibraryLoader::enable();
+     FWLiteEnabler::enable();
      
      // only allow one argument for this simple example which should be the
      // the python cfg file

--- a/RecoBTag/PerformanceDB/bin/TestPerformanceFWLite_ES.cc
+++ b/RecoBTag/PerformanceDB/bin/TestPerformanceFWLite_ES.cc
@@ -3,7 +3,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 
 #include "PhysicsTools/CondLiteIO/interface/RecordWriter.h"
@@ -15,7 +15,7 @@
 
 int main(int argc, char ** argv)
 {
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   std::cout << "Test!!!" << std::endl << std::endl;
   TFile f("performance_ssvm.root","READ");

--- a/RecoBTag/PerformanceDB/bin/getbtagPerformance.cc
+++ b/RecoBTag/PerformanceDB/bin/getbtagPerformance.cc
@@ -3,7 +3,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 
 
 #include "PhysicsTools/CondLiteIO/interface/RecordWriter.h"
@@ -20,7 +20,7 @@ using optutl::CommandLineParser;
 int main(int argc, char ** argv)
 {
   // load fwlite libraries
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   // command line options
   optutl::CommandLineParser parser ("get performance");
   

--- a/RecoEcal/EgammaCoreTools/test/runTestEcalClusterToolsFWLite.C
+++ b/RecoEcal/EgammaCoreTools/test/runTestEcalClusterToolsFWLite.C
@@ -1,6 +1,6 @@
 {
 gSystem->Load("libFWCoreFWLite.so"); 
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 gSystem->Load("libDataFormatsFWLite.so");
 gSystem->Load("libGeometryCaloTopology.so");
 gSystem->Load("libRecoEcalEgammaCoreTools.so");

--- a/RecoJets/Configuration/doc/WorkBook/analyzeJets_head.C
+++ b/RecoJets/Configuration/doc/WorkBook/analyzeJets_head.C
@@ -1,7 +1,7 @@
 {
 
   gSystem->Load("libFWCoreFWLite.so"); 
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 //  TFile* file = TFile::Open("dcap://cmsdca.fnal.gov:24136/pnfs/fnal.gov/usr/cms/WAX/11/store/RelVal/2006/11/3/RelVal120pre4ZPrimeDijets700/D61917D6-2E6C-DB11-BBBA-0030487074C3.root");
   TFile* file = TFile::Open("SinglePiE50HCAL_cfi_GEN_SIM_DIGI_L1_DIGI2RAW_RAW2DIGI_RECO.root");
 

--- a/RecoJets/JetProducers/test/analyzeJets_head.C
+++ b/RecoJets/JetProducers/test/analyzeJets_head.C
@@ -1,7 +1,7 @@
 {
 
   gSystem->Load("libFWCoreFWLite.so"); 
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   TFile file("evtgen_jets.root");
 
 }

--- a/RecoJets/JetProducers/test/analyzeJets_headChain.C
+++ b/RecoJets/JetProducers/test/analyzeJets_headChain.C
@@ -1,7 +1,7 @@
 {
 
   gSystem->Load("libFWCoreFWLite.so"); 
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   TChain chain("Events");
   chain.Add("evtgen_jets.root");
   chain.Add("evtgen_jets2.root");

--- a/RecoMuon/MuonIdentification/test/rootlogon.C
+++ b/RecoMuon/MuonIdentification/test/rootlogon.C
@@ -2,7 +2,7 @@
    gROOT->SetStyle("Plain");
    cout << "loading..." <<endl;
    gSystem->Load("libFWCoreFWLite");
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
    gSystem->Load("libRooFit.so");
    using namespace RooFit;
 }

--- a/RecoParticleFlow/PFClusterProducer/test/init.C
+++ b/RecoParticleFlow/PFClusterProducer/test/init.C
@@ -1,6 +1,6 @@
 {
 
 gSystem->Load("libFWCoreFWLite.so");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 }

--- a/RecoTracker/FinalTrackSelectors/test/analyze_head.C
+++ b/RecoTracker/FinalTrackSelectors/test/analyze_head.C
@@ -1,7 +1,7 @@
 {
 
   gSystem->Load("libFWCoreFWLite.so"); 
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
 //  TFile file("merger.root");
   TFile file("tau.root");
 

--- a/RecoTracker/TrackProducer/test/analyze_HZZ_head.C
+++ b/RecoTracker/TrackProducer/test/analyze_HZZ_head.C
@@ -1,7 +1,7 @@
 {
 
   gSystem->Load("libFWCoreFWLite.so"); 
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   TFile file("../../../higgs.root");
 
 }

--- a/RecoTracker/TrackProducer/test/analyze_head.C
+++ b/RecoTracker/TrackProducer/test/analyze_head.C
@@ -1,7 +1,7 @@
 {
 
   gSystem->Load("libFWCoreFWLite.so"); 
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   TFile file("recoTracks.root");
 
 }

--- a/RecoTracker/TrackProducer/test/analyze_reftracks.C
+++ b/RecoTracker/TrackProducer/test/analyze_reftracks.C
@@ -1,6 +1,6 @@
 {
 gSystem->Load("libFWCoreFWLite.so");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 TFile file("RefittedTracks.root");
 /////////SET THESE VALUES///////////////
 float intervals[] = {0,0.8,1.4,2.0,2.5};

--- a/RecoTracker/TrackProducer/test/analyze_tracks.C
+++ b/RecoTracker/TrackProducer/test/analyze_tracks.C
@@ -1,6 +1,6 @@
 {
 gSystem->Load("libFWCoreFWLite.so");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 /////////SET THESE VALUES///////////////
 TFile file("TracksParTest2.root");
 TTree * tree = (TTree *) gROOT->FindObject("Events");

--- a/SUSYBSMAnalysis/HSCP/python/LaunchOnCondor.py
+++ b/SUSYBSMAnalysis/HSCP/python/LaunchOnCondor.py
@@ -124,7 +124,7 @@ def CreateTheShellFile(argv):
                 shell_file.write('   gSystem->SetMakeSharedLib(makeshared);\n')
                 shell_file.write('   gSystem->SetIncludePath("-I$ROOFITSYS/include");\n')
 	        shell_file.write('   gSystem->Load("libFWCoreFWLite");\n')
-	        shell_file.write('   AutoLibraryLoader::enable();\n')
+	        shell_file.write('   FWLiteEnabler::enable();\n')
 	        shell_file.write('   gSystem->Load("libDataFormatsFWLite.so");\n')
 	        shell_file.write('   gSystem->Load("libAnalysisDataFormatsSUSYBSMObjects.so");\n')
 	        shell_file.write('   gSystem->Load("libDataFormatsVertexReco.so");\n')

--- a/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/Analysis_Step234.sh
+++ b/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/Analysis_Step234.sh
@@ -4,7 +4,7 @@ root -l -b << EOF
   TString dummy = makeshared.ReplaceAll("-Wshadow ", "");
   gSystem->SetMakeSharedLib(makeshared);
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   gSystem->Load("libDataFormatsFWLite.so");
   gSystem->Load("libAnalysisDataFormatsSUSYBSMObjects.so");
   gSystem->Load("libDataFormatsVertexReco.so");

--- a/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/DumpInfo.sh
+++ b/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/DumpInfo.sh
@@ -4,7 +4,7 @@ root -l -b << EOF
   TString dummy = makeshared.ReplaceAll("-Wshadow ", "");
   gSystem->SetMakeSharedLib(makeshared);
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   gSystem->Load("libDataFormatsFWLite.so");
   gSystem->Load("libAnalysisDataFormatsSUSYBSMObjects.so");
   gSystem->Load("libDataFormatsVertexReco.so");

--- a/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/LaunchOnCondor.py
+++ b/SUSYBSMAnalysis/HSCP/test/ICHEP_Analysis/LaunchOnCondor.py
@@ -117,7 +117,7 @@ def CreateTheShellFile(argv):
 	        shell_file.write('   gSystem->SetMakeSharedLib(makeshared);\n')
                 shell_file.write('   gSystem->SetIncludePath("-I$ROOFITSYS/include");\n')
 	        shell_file.write('   gSystem->Load("libFWCoreFWLite");\n')
-	        shell_file.write('   AutoLibraryLoader::enable();\n')
+	        shell_file.write('   FWLiteEnabler::enable();\n')
 	        shell_file.write('   gSystem->Load("libDataFormatsFWLite.so");\n')
 	        shell_file.write('   gSystem->Load("libAnalysisDataFormatsSUSYBSMObjects.so");\n')
 	        shell_file.write('   gSystem->Load("libDataFormatsVertexReco.so");\n')

--- a/SUSYBSMAnalysis/HSCP/test/UsefulScripts/GetLuminosity/GetLuminosity.sh
+++ b/SUSYBSMAnalysis/HSCP/test/UsefulScripts/GetLuminosity/GetLuminosity.sh
@@ -4,7 +4,7 @@ root -l -b << EOF
   TString dummy = makeshared.ReplaceAll("-W ", "");
   gSystem->SetMakeSharedLib(makeshared);
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();;
   gSystem->Load("libDataFormatsFWLite.so");
   gSystem->Load("libDataFormatsCommon.so");
   .x GetLuminosity.C+

--- a/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/LaunchOnCondor.py
+++ b/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/LaunchOnCondor.py
@@ -117,7 +117,7 @@ def CreateTheShellFile(argv):
 	        shell_file.write('   gSystem->SetMakeSharedLib(makeshared);\n')
                 shell_file.write('   gSystem->SetIncludePath("-I$ROOFITSYS/include");\n')
 	        shell_file.write('   gSystem->Load("libFWCoreFWLite");\n')
-	        shell_file.write('   AutoLibraryLoader::enable();\n')
+	        shell_file.write('   FWLiteEnabler::enable();;\n')
 	        shell_file.write('   gSystem->Load("libDataFormatsFWLite.so");\n')
 	        shell_file.write('   gSystem->Load("libAnalysisDataFormatsSUSYBSMObjects.so");\n')
 	        shell_file.write('   gSystem->Load("libDataFormatsVertexReco.so");\n')

--- a/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/MakePlot.sh
+++ b/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/MakePlot.sh
@@ -5,7 +5,7 @@ root -l -b << EOF
   TString dummy = makeshared.ReplaceAll("-Wshadow ", "");
   gSystem->SetMakeSharedLib(makeshared);
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();;
   gSystem->Load("libDataFormatsFWLite.so");
   gSystem->Load("libDataFormatsHepMCCandidate.so");
   gSystem->Load("libDataFormatsCommon.so");

--- a/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/StabilityCheck.sh
+++ b/SUSYBSMAnalysis/HSCP/test/UsefulScripts/StabilityCheck/StabilityCheck.sh
@@ -5,7 +5,7 @@ root -l -b << EOF
   TString dummy = makeshared.ReplaceAll("-Wshadow ", "");
   gSystem->SetMakeSharedLib(makeshared);
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();;
   gSystem->Load("libDataFormatsFWLite.so");
   gSystem->Load("libDataFormatsHepMCCandidate.so");
   gSystem->Load("libDataFormatsCommon.so");

--- a/SUSYBSMAnalysis/HSCP/test/UsefulScripts/TriggerStudy/TriggerStudy.sh
+++ b/SUSYBSMAnalysis/HSCP/test/UsefulScripts/TriggerStudy/TriggerStudy.sh
@@ -6,7 +6,7 @@ root -l -b << EOF
   TString dummy = makeshared.ReplaceAll("-Wshadow ", "");
   gSystem->SetMakeSharedLib(makeshared);
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();;
   gSystem->Load("libDataFormatsFWLite.so");
   gSystem->Load("libDataFormatsHepMCCandidate.so");
   gSystem->Load("libDataFormatsCommon.so");

--- a/SimG4CMS/HcalTestBeam/test/rootlogon.C
+++ b/SimG4CMS/HcalTestBeam/test/rootlogon.C
@@ -1,7 +1,7 @@
 {
 cout << "Loading FWLite..." << endl;
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 cout << "Redefining colors..." << endl;
 

--- a/TopQuarkAnalysis/Examples/bin/TopElecFWLiteAnalyzer.cc
+++ b/TopQuarkAnalysis/Examples/bin/TopElecFWLiteAnalyzer.cc
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 
 #include "TopQuarkAnalysis/Examples/bin/NiceStyle.cc"
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   // set nice style for histograms
   setNiceStyle();

--- a/TopQuarkAnalysis/Examples/bin/TopHypothesisFWLiteAnalyzer.cc
+++ b/TopQuarkAnalysis/Examples/bin/TopHypothesisFWLiteAnalyzer.cc
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "AnalysisDataFormats/TopObjects/interface/TtSemiLeptonicEvent.h"
 
 #include "TopQuarkAnalysis/Examples/bin/NiceStyle.cc"
@@ -31,7 +31,7 @@ int main(int argc, char* argv[])
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   // set nice style for histograms
   setNiceStyle();

--- a/TopQuarkAnalysis/Examples/bin/TopJetFWLiteAnalyzer.cc
+++ b/TopQuarkAnalysis/Examples/bin/TopJetFWLiteAnalyzer.cc
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 
 #include "TopQuarkAnalysis/Examples/bin/NiceStyle.cc"
@@ -28,7 +28,7 @@ int main(int argc, char* argv[])
 
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   // set nice style for histograms
   setNiceStyle();

--- a/TopQuarkAnalysis/Examples/bin/TopMuonFWLiteAnalyzer.cc
+++ b/TopQuarkAnalysis/Examples/bin/TopMuonFWLiteAnalyzer.cc
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <iostream>
 
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "DataFormats/PatCandidates/interface/Electron.h"
 
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
   
   // load framework libraries
   gSystem->Load( "libFWCoreFWLite" );
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   // set nice style for histograms
   setNiceStyle();

--- a/TopQuarkAnalysis/TopEventSelection/bin/TtSemiLRSignalSel_PurityLoop.cpp
+++ b/TopQuarkAnalysis/TopEventSelection/bin/TtSemiLRSignalSel_PurityLoop.cpp
@@ -14,7 +14,7 @@
 #include <TStyle.h>
 #include <TKey.h>
 #include <vector>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "AnalysisDataFormats/TopObjects/interface/TtSemiEvtSolution.h"
 #include "TopQuarkAnalysis/TopTools/interface/LRHelpFunctions.h"
 
@@ -81,7 +81,7 @@ std::vector<int> obsNrs;
 
 int main() { 
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   
   // define all histograms & fit functions

--- a/TopQuarkAnalysis/TopEventSelection/bin/TtSemiLRSignalSel_SoverSplusBLoop.cpp
+++ b/TopQuarkAnalysis/TopEventSelection/bin/TtSemiLRSignalSel_SoverSplusBLoop.cpp
@@ -14,7 +14,7 @@
 #include <TStyle.h>
 #include <TKey.h>
 #include <vector>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "AnalysisDataFormats/TopObjects/interface/TtSemiEvtSolution.h"
 #include "TopQuarkAnalysis/TopTools/interface/LRHelpFunctions.h"
 
@@ -139,7 +139,7 @@ bool MuonIso = true;
 
 int main() { 
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   
   // define all histograms & fit functions

--- a/TopQuarkAnalysis/TopJetCombination/bin/TtSemiLRJetComb_PurityLoop.cpp
+++ b/TopQuarkAnalysis/TopJetCombination/bin/TtSemiLRJetComb_PurityLoop.cpp
@@ -14,7 +14,7 @@
 #include <TStyle.h>
 #include <TKey.h>
 #include <vector>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "AnalysisDataFormats/TopObjects/interface/TtSemiEvtSolution.h"
 #include "TopQuarkAnalysis/TopTools/interface/LRHelpFunctions.h"
 
@@ -61,7 +61,7 @@ std::vector<int> obsNrs;
 
 int main() { 
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   
   // define all histograms & fit functions

--- a/TopQuarkAnalysis/TopJetCombination/bin/TtSemiLRJetComb_SoverSplusBLoop.cpp
+++ b/TopQuarkAnalysis/TopJetCombination/bin/TtSemiLRJetComb_SoverSplusBLoop.cpp
@@ -14,7 +14,7 @@
 #include <TStyle.h>
 #include <TKey.h>
 #include <vector>
-#include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "AnalysisDataFormats/TopObjects/interface/TtSemiEvtSolution.h"
 #include "TopQuarkAnalysis/TopTools/interface/LRHelpFunctions.h"
 
@@ -72,7 +72,7 @@ std::vector<const char*> obsFits;
 
 int main() { 
   gSystem->Load("libFWCoreFWLite");
-  AutoLibraryLoader::enable();
+  FWLiteEnabler::enable();
   
   
   // define all histograms & fit functions

--- a/TrackingTools/TrackAssociator/test/rootlogon.C
+++ b/TrackingTools/TrackAssociator/test/rootlogon.C
@@ -2,7 +2,7 @@
    gROOT->SetStyle("Plain");
    cout << "loading..." <<endl;
    gSystem->Load("libFWCoreFWLite");
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
    gSystem->Load("libRooFit.so");
    using namespace RooFit;
 }

--- a/Validation/CaloTowers/test/macros/rootlogon.C
+++ b/Validation/CaloTowers/test/macros/rootlogon.C
@@ -7,5 +7,5 @@ void rootlogon()
     setColors();
     
     gSystem->Load("libFWCoreFWLite.so");
-    AutoLibraryLoader::enable();
+    FWLiteEnabler::enable();
 }

--- a/Validation/EcalHits/test/rootlogon.C
+++ b/Validation/EcalHits/test/rootlogon.C
@@ -1,7 +1,7 @@
 {
 cout << "Loading FWLite..." << endl;
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 gSystem->Load("libSimDataFormatsEcalValidation.so");
 gSystem->Load("libSimDataFormatsTrack.so");
 gSystem->Load("libSimDataFormatsVertex.so");

--- a/Validation/GlobalDigis/test/rootlogon.C
+++ b/Validation/GlobalDigis/test/rootlogon.C
@@ -1,7 +1,7 @@
 {
 cout << "Loading FWLite..." << endl;    // load CMSSW libraries
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 cout << "Setting Style to Plain..." << endl;
 gROOT->SetStyle("Plain");        // Switches off the ROOT default style

--- a/Validation/GlobalHits/test/rootlogon.C
+++ b/Validation/GlobalHits/test/rootlogon.C
@@ -1,7 +1,7 @@
 {
 cout << "Loading FWLite..." << endl;    // load CMSSW libraries
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 cout << "Setting Style to Plain..." << endl;
 gROOT->SetStyle("Plain");        // Switches off the ROOT default style

--- a/Validation/GlobalRecHits/test/rootlogon.C
+++ b/Validation/GlobalRecHits/test/rootlogon.C
@@ -1,7 +1,7 @@
 {
 cout << "Loading FWLite..." << endl;    // load CMSSW libraries
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 cout << "Setting Style to Plain..." << endl;
 gROOT->SetStyle("Plain");        // Switches off the ROOT default style

--- a/Validation/HcalHits/test/rootlogon.C
+++ b/Validation/HcalHits/test/rootlogon.C
@@ -3,7 +3,7 @@
 cout << "FWlite ..." << endl;
 
 gSystem->Load("libFWCoreFWLite.so");
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
 
 cout << "Redefining colors ..." << endl;
 

--- a/Validation/MuonIdentification/test/rootlogon.C
+++ b/Validation/MuonIdentification/test/rootlogon.C
@@ -2,7 +2,7 @@
    gROOT->SetStyle("Plain");
    cout << "loading..." <<endl;
    gSystem->Load("libFWCoreFWLite");
-   AutoLibraryLoader::enable();
+   FWLiteEnabler::enable();
    gSystem->Load("libRooFit.so");
    using namespace RooFit;
 }

--- a/Validation/RecoVertex/test/pv111.C
+++ b/Validation/RecoVertex/test/pv111.C
@@ -1,6 +1,6 @@
 gSystem->Load("libFWCoreFWLite");
 
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 // reco file with vertices
 TFile f("pv_reco.root");

--- a/Validation/Tools/scripts/edmOneToOneComparison.py
+++ b/Validation/Tools/scripts/edmOneToOneComparison.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
     random.seed( os.getpid() )
     GenObject.loadConfigFile (options.config)
     ROOT.gSystem.Load("libFWCoreFWLite.so")
-    ROOT.AutoLibraryLoader.enable()
+    ROOT.FWLiteEnabler::enable()
     # Let's parse any args
     doubleColonRE = re.compile (r'(.+):(.+):(.+)')
     if options.alias:

--- a/Validation/Tools/scripts/simpleEdmComparison.py
+++ b/Validation/Tools/scripts/simpleEdmComparison.py
@@ -127,7 +127,7 @@ if __name__ == "__main__":
 
     ROOT.gSystem.Load("libFWCoreFWLite.so")
     ROOT.gSystem.Load("libDataFormatsFWLite.so")
-    ROOT.AutoLibraryLoader.enable()
+    ROOT.FWLiteEnabler::enable()
 
     chain1 = Events ([options.file1], forceEvent=True)
     chain2 = Events ([options.file2], forceEvent=True)

--- a/Validation/Tools/scripts/useReflexToDescribeForGenObject.py
+++ b/Validation/Tools/scripts/useReflexToDescribeForGenObject.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
     ROOT.gSystem.Load("libFWCoreFWLite")
     ROOT.gSystem.Load("libDataFormatsFWLite")
     ROOT.gSystem.Load("libReflexDict")
-    ROOT.AutoLibraryLoader.enable()
+    ROOT.FWLiteEnabler::enable()
     mylist, etaPhiFound = getObjectList (objectName, goName, options.verbose,
                                          options.privateMemberData)
     if not len (mylist):

--- a/Validation/TrackerHits/test/rootlogon.C
+++ b/Validation/TrackerHits/test/rootlogon.C
@@ -1,6 +1,6 @@
 {
 cout << "Loading FWLite..." << endl;
 gSystem->Load("libFWCoreFWLite");
-AutoLibraryLoader::enable();
+FWLiteEnabler::enable();
 
 } 


### PR DESCRIPTION
The class AutoLibraryLoader, in FWLite, is badly misnamed, because, with the use of rootmap files, this class no longer loads any libraries. A new class, FWLiteEnabler, replaces AutoLibraryLoader.
The AutoLibraryLoader class is kept for now just in case any private user code is using it.
FWLiteEnabler::enable() replaces AutoLibraryLoader::enable().
Any remaining use of AutoLibraryLoader::enable() will work for now, but a warning message will be given.
