### PR TITLE
Avoid calls to mallopt() if ASan is active

### DIFF
--- a/FWCore/Utilities/src/MallocOpts.cc
+++ b/FWCore/Utilities/src/MallocOpts.cc
@@ -162,6 +162,7 @@ namespace edm
     error_message_.clear();
     changed_ = false;
 
+#ifndef __SANITIZE_ADDRESS__
 #ifdef M_MMAP_MAX
     if(mallopt(M_MMAP_MAX,values_.mmap_max_)<0)
       error_message_ += "Could not set M_MMAP_MAX\n"; 
@@ -177,6 +178,7 @@ namespace edm
 #ifdef M_MMAP_THRESHOLD
     if(mallopt(M_MMAP_THRESHOLD,values_.mmap_thr_)<0)
       error_message_ += "ERROR: Could not set M_MMAP_THRESHOLD\n";
+#endif
 #endif
   }
 


### PR DESCRIPTION
`mallopt()` calls are not valid on ASan builds, avoid them.

Without this I keep getting `ERROR:` from CMSSW and exact same string fragment is used in ASan reports. This cleans the noise created by not working `mallopt()` calls on ASan builds.

Makes grepping easier.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
