### PR TITLE
Fix use-after-free bug in typeCode

### DIFF
--- a/CommonTools/Utils/src/returnType.cc
+++ b/CommonTools/Utils/src/returnType.cc
@@ -43,9 +43,9 @@ namespace reco {
 
   TypeCode typeCode(const edm::TypeWithDict& t) {
     typedef std::pair<const char* const, method::TypeCode> Values;
-    const char* name = t.name().c_str();
+    std::string name = t.name();
     auto f = std::equal_range(retTypeVec.begin(), retTypeVec.end(),
-      Values{name, enumType},
+      Values{name.c_str(), enumType},
       [](const Values& iLHS, const Values& iRHS) -> bool {
         return std::strcmp(iLHS.first, iRHS.first) < 0;
       });


### PR DESCRIPTION
`edm::TypeWithDict::name()` returns a `std::string`. The code was
taking a pointer to temporary string. Thus causing CutParser to
fail depending on random values in memory.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
