### PR TITLE
Added basicjet template for JetCorrectionProducer (heavy ions hlt use…

### DIFF
--- a/JetMETCorrections/Modules/src/SealModule.cc
+++ b/JetMETCorrections/Modules/src/SealModule.cc
@@ -21,6 +21,7 @@
 #include "DataFormats/JetReco/interface/JPTJet.h"
 #include "DataFormats/JetReco/interface/TrackJet.h"
 #include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/JetReco/interface/BasicJet.h"
 #include "CondFormats/JetMETObjects/interface/JetCorrectorParameters.h"
 #include "CondFormats/JetMETObjects/interface/QGLikelihoodObject.h"
 
@@ -44,6 +45,9 @@ DEFINE_FWK_MODULE(TrackJetCorrectionProducer);
 
 typedef JetCorrectionProducer<GenJet> GenJetCorrectionProducer;
 DEFINE_FWK_MODULE(GenJetCorrectionProducer);
+
+typedef JetCorrectionProducer<BasicJet> BasicJetCorrectionProducer;
+DEFINE_FWK_MODULE(BasicJetCorrectionProducer);
 
 DEFINE_FWK_EVENTSETUP_MODULE(JetCorrectionESChain);
 


### PR DESCRIPTION
…), backport to CMSSW_74

A small modification of SealModules.cc so we can have access to *CorrectionProducer for BasicJet object at HLT (our PF jets w/ subtraction are technically basicJets).

This is a back port of the request in CMSSW_75 found here: https://github.com/cms-sw/cmssw/pull/9313
