### PR TITLE
Conddb: move to upper-case table names, ignore non-existing GT table in sqlite

### DIFF
--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -4,6 +4,10 @@ import shutil
 import sys
 import time
 
+# as we need to load the shared lib from here, make sure it's in our path:
+if os.path.join( os.environ['CMSSW_BASE'], 'src') not in sys.path:
+   sys.path.append( os.path.join( os.environ['CMSSW_BASE'], 'src') )
+
 # -------------------------------------------------------------------------------------------------------
 
 payload2xmlCodeTemplate = """
@@ -107,14 +111,20 @@ class CondXmlProcessor(object):
     def __init__(self, condDBIn):
     	self.conddb = condDBIn
     	self._pl2xml_isPrepared = False
-	self._pl2xml_tmpDir = "fakeSubSys4pl/fakePkg4pl"
+
+	if not os.path.exists( os.path.join( os.environ['CMSSW_BASE'], 'src') ):
+	   raise Exception("Looks like you are not running in a CMSSW developer area, $CMSSW_BASE/src/ does not exist")
+
+	self.fakePkgName = "fakeSubSys4pl/fakePkg4pl"
+	self._pl2xml_tmpDir = os.path.join( os.environ['CMSSW_BASE'], 'src', self.fakePkgName )
+
 	self.doCleanup = True
 
     def __del__(self):
 
     	if self.doCleanup: 
- 	   shutil.rmtree( self._pl2xml_tmpDir.split('/')[0] )
-           os.unlink('./pl2xmlComp.so')
+           shutil.rmtree( '/'.join( self._pl2xml_tmpDir.split('/')[:-1] ) )
+           os.unlink( os.path.join( os.environ['CMSSW_BASE'], 'src', './pl2xmlComp.so') )
         return 
 
     def prepPayload2xml(self, session, payload):
@@ -132,8 +142,7 @@ class CondXmlProcessor(object):
         code = payload2xmlCodeTemplate % info
     
         tmpDir = self._pl2xml_tmpDir
-        if ( os.path.exists( tmpDir.split('/')[0] ) or
- 	     os.path.exists( tmpDir ) ) :
+        if ( os.path.exists( tmpDir ) ) :
            msg = '\nERROR: %s already exists, please remove if you did not create that manually !!' % tmpDir
            self.doCleanup = False
 	   raise Exception(msg)
@@ -150,8 +159,10 @@ class CondXmlProcessor(object):
         	 codeFile.write(code)
     	 	 codeFile.close()
     
+	libDir = os.path.join( os.environ["CMSSW_BASE"], 'tmp', os.environ["SCRAM_ARCH"], 'src', self.fakePkgName, 'src', self.fakePkgName.replace('/',''))
+	libName = libDir + '/lib%s.so' % self.fakePkgName.replace('/','') 
     	cmd = "source /afs/cern.ch/cms/cmsset_default.sh;"
-    	cmd += "(cd %s ; scram b 2>&1 >build.log && cp %s/tmp/%s/src/%s/src/%s/lib%s.so ../../pl2xmlComp.so )" % (tmpDir, os.environ["CMSSW_BASE"], os.environ["SCRAM_ARCH"], tmpDir, tmpDir.replace('/',''), tmpDir.replace('/','') ) 
+    	cmd += "(cd %s ; scram b 2>&1 >build.log && cp %s $CMSSW_BASE/src/pl2xmlComp.so )" % (tmpDir, libName)
     	ret = os.system(cmd)
 	if ret != 0 : self.doCleanup = False
 

--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -174,6 +174,6 @@ class CondXmlProcessor(object):
     
         sys.path.append('.')
         import pl2xmlComp
-        resultXML = pl2xmlComp.payload2xml( data, plType )
+        resultXML = pl2xmlComp.payload2xml( str(data), str(plType) )
         print resultXML    
     

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -169,7 +169,7 @@ _Base = sqlalchemy.ext.declarative.declarative_base()
 
 
 class Tag(_Base):
-    __tablename__       = 'tag'
+    __tablename__       = 'TAG'
 
     name                = sqlalchemy.Column(sqlalchemy.String(name_length),           primary_key=True)
     time_type           = sqlalchemy.Column(sqlalchemy.Enum(*tuple(TimeType)),        nullable=False)
@@ -185,19 +185,19 @@ class Tag(_Base):
 
 
 class IOV(_Base):
-    __tablename__       = 'iov'
+    __tablename__       = 'IOV'
 
-    tag_name            = sqlalchemy.Column(sqlalchemy.ForeignKey('tag.name'),        primary_key=True)
+    tag_name            = sqlalchemy.Column(sqlalchemy.ForeignKey('TAG.name'),        primary_key=True)
     since               = sqlalchemy.Column(sqlalchemy.Integer,                       primary_key=True)
     insertion_time      = sqlalchemy.Column(sqlalchemy.TIMESTAMP,                     primary_key=True)
-    payload_hash        = sqlalchemy.Column(sqlalchemy.ForeignKey('payload.hash'),    nullable=False)
+    payload_hash        = sqlalchemy.Column(sqlalchemy.ForeignKey('PAYLOAD.hash'),    nullable=False)
 
     tag                 = sqlalchemy.orm.relationship('Tag')
     payload             = sqlalchemy.orm.relationship('Payload')
 
 
 class Payload(_Base):
-    __tablename__       = 'payload'
+    __tablename__       = 'PAYLOAD'
 
     hash                = sqlalchemy.Column(sqlalchemy.CHAR(hash_length),             primary_key=True)
     object_type         = sqlalchemy.Column(sqlalchemy.String(name_length),           nullable=False)
@@ -208,7 +208,7 @@ class Payload(_Base):
 
 
 class GlobalTag(_Base):
-    __tablename__       = 'global_tag'
+    __tablename__       = 'GLOBAL_TAG'
 
     name                = sqlalchemy.Column(sqlalchemy.String(name_length),           primary_key=True)
     validity            = sqlalchemy.Column(sqlalchemy.Integer,                       nullable=False)
@@ -219,12 +219,12 @@ class GlobalTag(_Base):
 
 
 class GlobalTagMap(_Base):
-    __tablename__       = 'global_tag_map'
+    __tablename__       = 'GLOBAL_TAG_MAP'
 
-    global_tag_name     = sqlalchemy.Column(sqlalchemy.ForeignKey('global_tag.name'), primary_key=True)
+    global_tag_name     = sqlalchemy.Column(sqlalchemy.ForeignKey('GLOBAL_TAG.name'), primary_key=True)
     record              = sqlalchemy.Column(sqlalchemy.String(name_length),           primary_key=True)
     label               = sqlalchemy.Column(sqlalchemy.String(name_length),           primary_key=True)
-    tag_name            = sqlalchemy.Column(sqlalchemy.ForeignKey('tag.name'),        nullable=False)
+    tag_name            = sqlalchemy.Column(sqlalchemy.ForeignKey('TAG.name'),        nullable=False)
 
     global_tag          = sqlalchemy.orm.relationship('GlobalTag')
     tag                 = sqlalchemy.orm.relationship('Tag')

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -67,7 +67,8 @@ def _identify_object(session, objtype, name):
                 raise Exception('There is no tag named %s in the database.' % name)
         elif objtype == 'gt':
             if not _exists(session, conddb.GlobalTag.name, name):
-                raise Exception('There is no global tag named %s in the database.' % name)
+	        # raise Exception('There is no global tag named %s in the database.' % name)
+                logging.info('There is no global tag table in the database.')
         elif objtype == 'payload':
             # In the case of a payload, check and also return the full hash
             return objtype, _get_payload_full_hash(session, name)
@@ -139,10 +140,15 @@ def _confirm_changes(args):
 
 
 def _exists(session, primary_key, value):
-    return session.query(primary_key).\
-        filter(primary_key == value).\
-        count() != 0
+    ret = None
+    try: 
+        ret = session.query(primary_key).\
+    	    filter(primary_key == value).\
+            count() != 0
+    except sqlalchemy.exc.OperationalError:
+        pass
 
+    return ret
 
 def _regexp(connection, field, regexp):
     '''To be used inside filter().
@@ -1312,7 +1318,7 @@ def dump(args):
        		else:
             	   _dump_payload(session, payload, args.loadonly)
 
-    elif args.type == 'gt':
+    elif args.type == 'gt' and _exists(session, conddb.GlobalTag.name, name) != None:
         for payload, in session.query(conddb.IOV.payload_hash).\
             filter(conddb.GlobalTagMap.global_tag_name == name, conddb.IOV.tag_name == conddb.GlobalTagMap.tag_name).\
             distinct():


### PR DESCRIPTION
- move table names to upper case for compatibility with CORAL/Oracle

This PR includes the changes from #9312, so if you agree for both, you can use this and close the other.
For reference, here is the comment from 9312:
- add check to ignore non-existing GT table when reading sqlite files which were created by a C++ tool
