### PR TITLE
Do not apply DT vdrift correction (that accounts for field in phi SLs…

### DIFF
--- a/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
+++ b/RecoLocalMuon/DTRecHit/plugins/DTLinearDriftFromDBAlgo.h
@@ -13,6 +13,7 @@
 
 class DTMtime;
 class DTRecoUncertainties;
+class MagneticField;
 
 class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
  public:
@@ -82,6 +83,10 @@ class DTLinearDriftFromDBAlgo : public DTRecHitBaseAlgo {
 
   //Map of meantimes
   const DTMtime *mTimeMap;
+
+  // MF field
+  const MagneticField* field;
+  int nominalB;
 
   // Map of hit uncertainties
   const DTRecoUncertainties *uncertMap;


### PR DESCRIPTION
… of wheels+-2 of MB1) when B=0
Same as #9314, but for 74X 
