### PR TITLE
adding a flag for isolated noise filter

### DIFF
--- a/CommonTools/RecoAlgos/plugins/HBHENoiseFilterResultProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/HBHENoiseFilterResultProducer.cc
@@ -57,6 +57,11 @@ class HBHENoiseFilterResultProducer : public edm::EDProducer {
       bool IgnoreTS4TS5ifJetInLowBVRegion_;
       std::string defaultDecision_;
 
+      int minNumIsolatedNoiseChannels_;
+      double minIsolatedNoiseSumE_;
+      double minIsolatedNoiseSumEt_;
+
+      // other members
       std::map<std::string, bool> decisionMap_;
 };
 
@@ -75,10 +80,16 @@ HBHENoiseFilterResultProducer::HBHENoiseFilterResultProducer(const edm::Paramete
   IgnoreTS4TS5ifJetInLowBVRegion_ = iConfig.getParameter<bool>("IgnoreTS4TS5ifJetInLowBVRegion");
   defaultDecision_ = iConfig.getParameter<std::string>("defaultDecision");
 
+  // parameters related to isolation filter
+  minNumIsolatedNoiseChannels_ = iConfig.getParameter<int>("minNumIsolatedNoiseChannels");
+  minIsolatedNoiseSumE_ = iConfig.getParameter<double>("minIsolatedNoiseSumE");
+  minIsolatedNoiseSumEt_ = iConfig.getParameter<double>("minIsolatedNoiseSumEt");
+
   produces<bool>("HBHENoiseFilterResult");
   produces<bool>("HBHENoiseFilterResultRun1");
   produces<bool>("HBHENoiseFilterResultRun2Loose");
   produces<bool>("HBHENoiseFilterResultRun2Tight");
+  produces<bool>("HBHEIsoNoiseFilterResult");
 }
 
 
@@ -143,6 +154,13 @@ HBHENoiseFilterResultProducer::produce(edm::Event& iEvent, const edm::EventSetup
   pOut = std::auto_ptr<bool>(new bool(!it->second));
   iEvent.put(pOut, "HBHENoiseFilterResult");
 
+  // Check isolation requirements
+  const bool failIsolation = summary.numIsolatedNoiseChannels() >= minNumIsolatedNoiseChannels_ ||
+                             summary.isolatedNoiseSumE() >= minIsolatedNoiseSumE_ ||
+                             summary.isolatedNoiseSumEt() >= minIsolatedNoiseSumEt_;
+  pOut = std::auto_ptr<bool>(new bool(!failIsolation));
+  iEvent.put(pOut, "HBHEIsoNoiseFilterResult");
+  
   return;
 }
 

--- a/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
+++ b/CommonTools/RecoAlgos/python/HBHENoiseFilterResultProducer_cfi.py
@@ -7,7 +7,10 @@ HBHENoiseFilterResultProducer = cms.EDProducer(
     minHPDNoOtherHits = cms.int32(10),
     minZeros = cms.int32(10),
     IgnoreTS4TS5ifJetInLowBVRegion = cms.bool(True),
-    defaultDecision = cms.string("HBHENoiseFilterResultRun1")
+    defaultDecision = cms.string("HBHENoiseFilterResultRun1"),
+    minNumIsolatedNoiseChannels = cms.int32(10),
+    minIsolatedNoiseSumE = cms.double(50.0),
+    minIsolatedNoiseSumEt = cms.double(25.0)
 )
 
 from Configuration.StandardSequences.Eras import eras


### PR DESCRIPTION
Add a flag for the isolated noise filter to the event as requested by the HCAL Noise Workgroup.
