### PR TITLE
fixed mu-nuclear

### DIFF
--- a/SimG4Core/Application/src/ParametrisedEMPhysics.cc
+++ b/SimG4Core/Application/src/ParametrisedEMPhysics.cc
@@ -22,6 +22,8 @@
 #include "G4RegionStore.hh"
 #include "G4Electron.hh"
 #include "G4Positron.hh"
+#include "G4MuonMinus.hh"
+#include "G4MuonPlus.hh"
 #include "G4PionMinus.hh"
 #include "G4PionPlus.hh"
 #include "G4KaonMinus.hh"
@@ -29,13 +31,17 @@
 #include "G4Proton.hh"
 #include "G4AntiProton.hh"
 
+#include "G4MuonNuclearProcess.hh"
+#include "G4MuonVDNuclearModel.hh"
+
 #include "G4EmProcessOptions.hh"
 #include "G4PhysicsListHelper.hh"
 #include "G4SystemOfUnits.hh"
 #include "G4UAtomicDeexcitation.hh"
 #include "G4LossTableManager.hh"
 
-ParametrisedEMPhysics::ParametrisedEMPhysics(std::string name, const edm::ParameterSet & p) 
+ParametrisedEMPhysics::ParametrisedEMPhysics(std::string name, 
+					     const edm::ParameterSet & p) 
   : G4VPhysicsConstructor(name), theParSet(p) 
 {
   theEcalEMShowerModel = 0;
@@ -215,4 +221,13 @@ void ParametrisedEMPhysics::ConstructProcess() {
     G4LossTableManager::Instance()->SetAtomDeexcitation(de);
     de->SetFluo(true);
   }
+  // enable muon nuclear (valid option for Geant4 10.0pX only)
+  bool munuc = theParSet.getParameter<bool>("FlagMuNucl");
+  if(munuc) {
+    G4MuonNuclearProcess* muNucProcess = new G4MuonNuclearProcess();
+    muNucProcess->RegisterMe(new G4MuonVDNuclearModel());
+    ph->RegisterProcess(muNucProcess, G4MuonPlus::MuonPlus());
+    ph->RegisterProcess(muNucProcess, G4MuonMinus::MuonMinus());
+  }
+
 }

--- a/SimG4Core/PhysicsLists/plugins/DummyPhysics.cc
+++ b/SimG4Core/PhysicsLists/plugins/DummyPhysics.cc
@@ -14,7 +14,7 @@ DummyPhysics::DummyPhysics(G4LogicalVolumeToDDLogicalPartMap& map,
   if (emPhys) 
     RegisterPhysics(new DummyEMPhysics("dummyEM"));
   edm::LogInfo("PhysicsList") << "DummyPhysics constructed with EM Physics "
-			      << emPhys << "\n";
+			      << emPhys << " and Decay";
 }
 
 DummyPhysics::~DummyPhysics() {}

--- a/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFCMS_BIC.cc
@@ -25,7 +25,6 @@ FTFCMS_BIC::FTFCMS_BIC(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "FTF_BIC with Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
@@ -37,7 +36,6 @@ FTFCMS_BIC::FTFCMS_BIC(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT.cc
@@ -25,11 +25,12 @@ FTFPCMS_BERT::FTFPCMS_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
+  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT with Flags for EM Physics "
+			      << "FTFP_BERT \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+			      << "   t(ns)= " << timeLimit/ns;
 
   if (emPhys) {
     // EM Physics
@@ -37,7 +38,6 @@ FTFPCMS_BERT::FTFPCMS_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 
@@ -61,7 +61,9 @@ FTFPCMS_BERT::FTFPCMS_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      ncut->SetTimeLimit(timeLimit);
+      RegisterPhysics(ncut);
     }
   }
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML.cc
@@ -25,11 +25,12 @@ FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
+  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EML with Flags for EM Physics "
+			      << "FTFP_BERT_EML: \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+			      << "   t(ns)= " << timeLimit/ns;
 
   if (emPhys) {
     // EM Physics
@@ -37,7 +38,6 @@ FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 
@@ -61,7 +61,9 @@ FTFPCMS_BERT_EML::FTFPCMS_BERT_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      ncut->SetTimeLimit(timeLimit);
+      RegisterPhysics(ncut);
     }
   }
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML95.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EML95.cc
@@ -25,9 +25,8 @@ FTFPCMS_BERT_EML95::FTFPCMS_BERT_EML95(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EML95 with Flags for EM Physics "
+			      << "FTFP_BERT_EML95 \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -37,7 +36,6 @@ FTFPCMS_BERT_EML95::FTFPCMS_BERT_EML95(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_EMV.cc
@@ -25,9 +25,8 @@ FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EMV with Flags for EM Physics "
+			      << "FTFP_BERT_EMV \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -37,7 +36,6 @@ FTFPCMS_BERT_EMV::FTFPCMS_BERT_EMV(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_HP_EML.cc
@@ -25,11 +25,12 @@ FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
+  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EML with Flags for EM Physics "
+			      << "FTFP_BERT_HP_EML \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+			      << "   t(ns)= " << timeLimit/ns;
 
   if (emPhys) {
     // EM Physics
@@ -37,7 +38,6 @@ FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 
@@ -61,7 +61,9 @@ FTFPCMS_BERT_HP_EML::FTFPCMS_BERT_HP_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      ncut->SetTimeLimit(timeLimit);
+      RegisterPhysics(ncut);
     }
   }
 

--- a/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/FTFPCMS_BERT_XS_EML.cc
@@ -26,11 +26,12 @@ FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
+  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "FTFP_BERT_EML with Flags for EM Physics "
+			      << "FTFP_BERT_XS_EML \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+			      << "   t(ns)= " << timeLimit/ns;
 
   if (emPhys) {
     // EM Physics
@@ -38,7 +39,6 @@ FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 
@@ -64,7 +64,9 @@ FTFPCMS_BERT_XS_EML::FTFPCMS_BERT_XS_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      ncut->SetTimeLimit(timeLimit);
+      RegisterPhysics(ncut);
     }
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
+++ b/SimG4Core/PhysicsLists/plugins/QBBCCMS.cc
@@ -25,9 +25,8 @@ QBBCCMS::QBBCCMS(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QBBC with Flags for EM Physics "
+			      << "QBBC \n Flags for EM Physics "
 			      << emPhys << " and for Hadronic Physics "
 			      << hadPhys 
 			      << " and tracking cut " << tracking;
@@ -38,7 +37,6 @@ QBBCCMS::QBBCCMS(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT.cc
@@ -25,9 +25,8 @@ QGSPCMS_BERT::QGSPCMS_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT with Flags for EM Physics "
+			      << "QGSP_BERT \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -37,7 +36,6 @@ QGSPCMS_BERT::QGSPCMS_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML.cc
@@ -25,7 +25,6 @@ QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
 			      << "QGSP_BERT_EML with Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
@@ -37,7 +36,6 @@ QGSPCMS_BERT_EML::QGSPCMS_BERT_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML95.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EML95.cc
@@ -25,9 +25,8 @@ QGSPCMS_BERT_EML95::QGSPCMS_BERT_EML95(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT_EML95 with Flags for EM Physics "
+			      << "QGSP_BERT_EML95 \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -37,7 +36,6 @@ QGSPCMS_BERT_EML95::QGSPCMS_BERT_EML95(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMLSYNC.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMLSYNC.cc
@@ -25,9 +25,8 @@ QGSPCMS_BERT_EMLSYNC::QGSPCMS_BERT_EMLSYNC(G4LogicalVolumeToDDLogicalPartMap& ma
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT_EMLSYNC with Flags for EM Physics "
+			      << "QGSP_BERT_EMLSYNC \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -39,7 +38,6 @@ QGSPCMS_BERT_EMLSYNC::QGSPCMS_BERT_EMLSYNC(G4LogicalVolumeToDDLogicalPartMap& ma
     G4EmExtraPhysics* extra = new G4EmExtraPhysics(ver);
     G4String yes = "ON";
     extra->Synch(yes);
-    if(munucl) { extra->MuonNuclear(yes); }
     RegisterPhysics(extra);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_EMV.cc
@@ -25,9 +25,8 @@ QGSPCMS_BERT_EMV::QGSPCMS_BERT_EMV(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT_EMV with Flags for EM Physics "
+			      << "QGSP_BERT_EMV \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -37,7 +36,6 @@ QGSPCMS_BERT_EMV::QGSPCMS_BERT_EMV(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_BERT_HP_EML.cc
@@ -25,9 +25,8 @@ QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_BERT_HP_EML with Flags for EM Physics "
+			      << "QGSP_BERT_HP_EML \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -37,7 +36,6 @@ QGSPCMS_BERT_HP_EML::QGSPCMS_BERT_HP_EML(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT.cc
@@ -25,11 +25,12 @@ QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
+  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT with Flags for EM Physics "
+			      << "QGSP_FTFP_BERT \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+			      << "   t(ns)= " << timeLimit/ns;
 
   if (emPhys) {
     // EM Physics
@@ -37,7 +38,6 @@ QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 
@@ -61,7 +61,9 @@ QGSPCMS_FTFP_BERT::QGSPCMS_FTFP_BERT(G4LogicalVolumeToDDLogicalPartMap& map,
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      ncut->SetTimeLimit(timeLimit);
+      RegisterPhysics(ncut);
     }
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML.cc
@@ -26,10 +26,9 @@ QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(G4LogicalVolumeToDDLogicalPartMap& 
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EML with Flags for EM Physics "
+			      << "QGSP_FTFP_BERT_EML \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking
 			      << "   t(ns)= " << timeLimit/ns;
@@ -40,7 +39,6 @@ QGSPCMS_FTFP_BERT_EML::QGSPCMS_FTFP_BERT_EML(G4LogicalVolumeToDDLogicalPartMap& 
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML95.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML95.cc
@@ -25,9 +25,8 @@ QGSPCMS_FTFP_BERT_EML95::QGSPCMS_FTFP_BERT_EML95(G4LogicalVolumeToDDLogicalPartM
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EML95 with Flags for EM Physics "
+			      << "QGSP_FTFP_BERT_EML95 \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -37,7 +36,6 @@ QGSPCMS_FTFP_BERT_EML95::QGSPCMS_FTFP_BERT_EML95(G4LogicalVolumeToDDLogicalPartM
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML95msc93.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML95msc93.cc
@@ -26,9 +26,8 @@ QGSPCMS_FTFP_BERT_EML95msc93::QGSPCMS_FTFP_BERT_EML95msc93(G4LogicalVolumeToDDLo
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EML95msc93 with Flags for EM Physics "
+			      << "QGSP_FTFP_BERT_EML95msc93 \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
 			      << hadPhys << " and tracking cut " << tracking;
 
@@ -38,7 +37,6 @@ QGSPCMS_FTFP_BERT_EML95msc93::QGSPCMS_FTFP_BERT_EML95msc93(G4LogicalVolumeToDDLo
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 

--- a/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML_New.cc
+++ b/SimG4Core/PhysicsLists/plugins/QGSPCMS_FTFP_BERT_EML_New.cc
@@ -28,11 +28,12 @@ QGSPCMS_FTFP_BERT_EML_New::QGSPCMS_FTFP_BERT_EML_New(G4LogicalVolumeToDDLogicalP
   bool emPhys  = p.getUntrackedParameter<bool>("EMPhysics",true);
   bool hadPhys = p.getUntrackedParameter<bool>("HadPhysics",true);
   bool tracking= p.getParameter<bool>("TrackingCut");
-  bool munucl  = p.getParameter<bool>("FlagMuNucl");
+  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EML_New with Flags for EM Physics "
+			      << "QGSP_FTFP_BERT_EML_New \n Flags for EM Physics "
 			      << emPhys << ", for Hadronic Physics "
-			      << hadPhys << " and tracking cut " << tracking;
+			      << hadPhys << " and tracking cut " << tracking
+			      << "   t(ns)= " << timeLimit/ns;
 
   if (emPhys) {
     // EM Physics
@@ -41,7 +42,6 @@ QGSPCMS_FTFP_BERT_EML_New::QGSPCMS_FTFP_BERT_EML_New(G4LogicalVolumeToDDLogicalP
 
     // Synchroton Radiation & GN Physics
     G4EmExtraPhysics* gn = new G4EmExtraPhysics(ver);
-    if(munucl) { G4String yes = "on"; gn->MuonNuclear(yes); }
     RegisterPhysics(gn);
   }
 
@@ -65,7 +65,9 @@ QGSPCMS_FTFP_BERT_EML_New::QGSPCMS_FTFP_BERT_EML_New(G4LogicalVolumeToDDLogicalP
 
     // Neutron tracking cut
     if (tracking) {
-      RegisterPhysics( new G4NeutronTrackingCut(ver));
+      G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+      ncut->SetTimeLimit(timeLimit);
+      RegisterPhysics(ncut);
     }
   }
 

--- a/SimG4Core/PhysicsLists/plugins/module.cc
+++ b/SimG4Core/PhysicsLists/plugins/module.cc
@@ -1,6 +1,5 @@
 #include "SimG4Core/Physics/interface/PhysicsListFactory.h"
 
-#include "CMSModel.hh"
 #include "DummyPhysics.hh"
 #include "FTFCMS_BIC.hh"
 #include "FTFPCMS_BERT.hh"
@@ -22,7 +21,6 @@
 #include "QGSPCMS_FTFP_BERT_EML_New.hh"
 #include "QGSPCMS_FTFP_BERT_EML95msc93.hh"
 
-DEFINE_PHYSICSLIST(CMSModel);
 DEFINE_PHYSICSLIST(DummyPhysics);
 typedef FTFCMS_BIC FTF_BIC;
 DEFINE_PHYSICSLIST(FTF_BIC);


### PR DESCRIPTION
In MT mode there is a problem that muon nuclear interaction cannot be enabled as it was possible in sequential mode. This is due to a problem in Genat4 10.0. In this PR an alternative method enabling muon-nuclear is implemented. Additionally some clean-up of tracking cut in several Physics Lists are done (this is also optional feature). Printouts from PhysicsLists are also improved.

This PR should not affect mainstream SIM but is useful for neutron background studies. 
