### PR TITLE
Update default vtx smearing for PbPb to 2015 expectation

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -568,7 +568,7 @@ hiAlca = {'--conditions':'auto:run2_mc_HIon', '--customise':'SLHCUpgradeSimulati
 hiAlca2011 = {'--conditions':'auto:run1_mc_hi', '--customise':'SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1_HI'}
 
 hiDefaults2011=merge([hiAlca2011,{'--scenario':'HeavyIons','-n':2,'--beamspot':'RealisticHI2011Collision'}])
-hiDefaults=merge([hiAlca,{'--scenario':'HeavyIons','-n':2,'--beamspot':'RealisticHI2011Collision'}])
+hiDefaults=merge([hiAlca,{'--scenario':'HeavyIons','-n':2,'--beamspot':'NominalHICollision2015'}])
 
 steps['HydjetQ_MinBias_5020GeV']=merge([{'-n':1},hiDefaults,genS('Hydjet_Quenched_MinBias_5020GeV_cfi',U2000by1)])
 steps['HydjetQ_MinBias_5020GeVINPUT']={'INPUT':InputInfo(dataSet='/RelValHydjetQ_MinBias_5020GeV/%s/GEN-SIM'%(baseDataSetRelease[1],),location='STD',split=5)}

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -36,8 +36,8 @@ VtxSmeared = {
     'ShiftedCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedShiftedCollision2015_cfi',
     'Shifted5mmCollision2015'  :     'IOMC.EventVertexGenerators.VtxSmearedShifted5mmCollision2015_cfi',
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',
-    'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi'
-
+    'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi',
+    'NominalHICollision2015':      'IOMC.EventVertexGenerators.VtxSmearedNominalHICollision2015_cfi'
 }
 VtxSmearedDefaultKey='NominalCollision2015'
-VtxSmearedHIDefaultKey='RealisticHI2011Collision'
+VtxSmearedHIDefaultKey='NominalHICollision2015'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedNominalHICollision2015_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedNominalHICollision2015_cfi.py
@@ -1,0 +1,10 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import NominalHICollision2015VtxSmearingParameters,VtxSmearedCommon
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    NominalHICollision2015VtxSmearingParameters,
+    VtxSmearedCommon
+)
+
+
+

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -440,3 +440,17 @@ Shifted15mmCollision2015VtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.0),
     Z0 = cms.double(0.0)
 )
+
+# Estimate for 2015 PbPb collisions, based on feedback from accelerator                                                                                  
+# Beamspot centroid shifted to match pp expectation for 2015                                                                                             
+NominalHICollision2015VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(60.0),
+    Emittance = cms.double(1.70e-07),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(7.06),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.0322),
+    Y0 = cms.double(0.),
+    Z0 = cms.double(0.)
+)


### PR DESCRIPTION
Shifts the centroid of the beam to the origin, exactly as done for 2015 pp.
The beta\* and emittance were also reduced slightly compared to 2011 based on feedback we received from the accelerator community.
The corresponding reco BS is available in GT MCHI2_75_V2, which will be the autocondition used by the relVal once #9300 is merged. 
Worflows that use recycled Hydjet GEN-SIM as input (300-302) will be left with an inconsistent sim and reco beamspot until the next relVal is produced.  We will have to remember to then swtich to use the output of wf 140 as the new input GEN-SIM for these wfs, when it becomes available.
