### PR TITLE
Remove HWW DQM modules 

### DIFF
--- a/DQM/Physics/BuildFile.xml
+++ b/DQM/Physics/BuildFile.xml
@@ -20,5 +20,4 @@
 <use   name="CondFormats/EcalObjects"/>
 <use   name="RecoJets/JetProducers"/>
 <use   name="RecoJets/JetAlgorithms"/>
-<use   name="DQM/PhysicsHWW"/>
 <flags   EDM_PLUGIN="1"/> 

--- a/DQM/Physics/python/DQMPhysics_cff.py
+++ b/DQM/Physics/python/DQMPhysics_cff.py
@@ -14,7 +14,7 @@ from DQM.Physics.susyDQM_cfi import *
 from DQM.Physics.HiggsDQM_cfi import *
 from DQM.Physics.ExoticaDQM_cfi import *
 from DQM.Physics.B2GDQM_cfi import *
-from DQM.PhysicsHWW.hwwDQM_cfi import *
+#from DQM.PhysicsHWW.hwwDQM_cfi import *
 from DQM.Physics.CentralityDQM_cfi import *
 from DQM.Physics.topJetCorrectionHelper_cfi import *
 
@@ -34,7 +34,7 @@ dqmPhysics = cms.Sequence( bphysicsOniaDQM
                            *HiggsDQM
                            *ExoticaDQM
                            *B2GDQM
-                           *hwwDQM
+#                           *hwwDQM
                            )
 
 bphysicsOniaDQMHI = bphysicsOniaDQM.clone(vertex=cms.InputTag("hiSelectedVertex"))
@@ -43,4 +43,4 @@ dqmPhysicsHI = cms.Sequence(bphysicsOniaDQMHI+CentralityDQM)
 from DQM.Physics.qcdPhotonsCosmicDQM_cff import *
 dqmPhysicsCosmics = cms.Sequence(dqmPhysics)
 dqmPhysicsCosmics.replace(qcdPhotonsDQM, qcdPhotonsCosmicDQM)
-dqmPhysicsCosmics.replace(hwwDQM, hwwCosmicDQM)
+#dqmPhysicsCosmics.replace(hwwDQM, hwwCosmicDQM)

--- a/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineCosmics_cff.py
@@ -52,6 +52,6 @@ DQMOfflineCosmics = cms.Sequence( DQMOfflineCosmicsPreDPG *
 
 DQMOfflineCosmicsPhysics = cms.Sequence( dqmPhysicsCosmics )
 
-DQMOfflineCosmicsNoHWW = cms.Sequence(DQMOfflineCosmics)
-DQMOfflineCosmicsNoHWW.remove(hwwCosmicDQM)
+#DQMOfflineCosmicsNoHWW = cms.Sequence(DQMOfflineCosmics)
+#DQMOfflineCosmicsNoHWW.remove(hwwCosmicDQM)
 

--- a/DQMOffline/Configuration/python/DQMOffline_cff.py
+++ b/DQMOffline/Configuration/python/DQMOffline_cff.py
@@ -123,5 +123,6 @@ DQMOfflineBTag = cms.Sequence( bTagPlotsDATA )
                                                                  
 DQMOfflineMiniAOD = cms.Sequence( miniAODDQMSequence )
 
-DQMOfflineNoHWW = cms.Sequence(DQMOffline)
-DQMOfflineNoHWW.remove(hwwAnalyzer)
+#nothing has hww for now
+#DQMOfflineNoHWW = cms.Sequence(DQMOffline)
+#DQMOfflineNoHWW.remove(hwwAnalyzer)


### PR DESCRIPTION
We've discovered that there are a bunch of classes that code copied from elsewhere in CMSSW into DQM/PhysicsHWW. As those classes have now gotten out of sync, and that the libs get randomly chosen or not depending on how the linker feels at any given time, this PR is to remove any use of the classes for now.  Any duplicated code should be removed or renamed (hopefully removed) in order to restore the use of this package.
