### PR TITLE
Add missing GCC11_OVERRIDE / override

### DIFF
--- a/DataFormats/Common/interface/IndirectVectorHolder.h
+++ b/DataFormats/Common/interface/IndirectVectorHolder.h
@@ -91,10 +91,10 @@ namespace edm {
 	typename RefVectorHolderBase::const_iterator i;
       };
 
-      const_iterator begin() const {
+      const_iterator begin() const GCC11_OVERRIDE {
 	return const_iterator( new const_iterator_imp_specific( helper_->begin() ) );
       }
-      const_iterator end() const {
+      const_iterator end() const GCC11_OVERRIDE {
 	return const_iterator( new const_iterator_imp_specific( helper_->end() ) );
       }
     };

--- a/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiPixelRecHit.h
@@ -40,9 +40,9 @@ public:
   virtual bool isPixel() const GCC11_OVERRIDE { return true;}
 
   
-  virtual SiPixelRecHit * clone() const {return new SiPixelRecHit( * this); }
+  virtual SiPixelRecHit * clone() const GCC11_OVERRIDE {return new SiPixelRecHit( * this); }
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const { return std::make_shared<SiPixelRecHit>(*this);}
+  virtual RecHitPointer cloneSH() const GCC11_OVERRIDE { return std::make_shared<SiPixelRecHit>(*this);}
 #endif
 
   
@@ -50,18 +50,18 @@ public:
 
   void setClusterRef(ClusterRef const & ref)  {setClusterPixelRef(ref);}
 
-  virtual int dimension() const {return 2;}
-  virtual void getKfComponents( KfComponentsHolder & holder ) const { getKfComponents2D(holder); }
+  virtual int dimension() const GCC11_OVERRIDE {return 2;}
+  virtual void getKfComponents( KfComponentsHolder & holder ) const GCC11_OVERRIDE { getKfComponents2D(holder); }
   
   
-  virtual bool canImproveWithTrack() const {return true;}
+  virtual bool canImproveWithTrack() const GCC11_OVERRIDE {return true;}
 private:
   // double dispatch
-  virtual SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+  virtual SiPixelRecHit * clone(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner(*this,tsos).release();
   }
 #ifndef __GCCXML__
-  virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const {
+  virtual  RecHitPointer cloneSH(TkCloner const& cloner, TrajectoryStateOnSurface const& tsos) const GCC11_OVERRIDE {
     return cloner.makeShared(*this,tsos);
   }
 #endif  

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit1D.h
@@ -31,7 +31,7 @@ public:
 
   virtual SiStripRecHit1D * clone() const GCC11_OVERRIDE {return new SiStripRecHit1D( * this); }
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripRecHit1D>(*this);}
+  virtual RecHitPointer cloneSH() const GCC11_OVERRIDE { return std::make_shared<SiStripRecHit1D>(*this);}
 #endif
   
 

--- a/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiStripRecHit2D.h
@@ -31,7 +31,7 @@ public:
 
   virtual SiStripRecHit2D * clone() const GCC11_OVERRIDE {return new SiStripRecHit2D( * this); }
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const { return std::make_shared<SiStripRecHit2D>(*this);}
+  virtual RecHitPointer cloneSH() const GCC11_OVERRIDE { return std::make_shared<SiStripRecHit2D>(*this);}
 #endif
   
   virtual int dimension() const GCC11_OVERRIDE {return 2;}

--- a/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
+++ b/DataFormats/TrackingRecHit/interface/InvalidTrackingRecHit.h
@@ -18,27 +18,27 @@ public:
 
   virtual InvalidTrackingRecHit * clone() const GCC11_OVERRIDE {return new InvalidTrackingRecHit(*this);}
 #ifndef __GCCXML__
-  virtual RecHitPointer cloneSH() const { return RecHitPointer(clone());}
+  virtual RecHitPointer cloneSH() const GCC11_OVERRIDE { return RecHitPointer(clone());}
 #endif
 
   
-  virtual AlgebraicVector parameters() const;
+  virtual AlgebraicVector parameters() const GCC11_OVERRIDE;
 
-  virtual AlgebraicSymMatrix parametersError() const;
+  virtual AlgebraicSymMatrix parametersError() const GCC11_OVERRIDE;
 
-  virtual AlgebraicMatrix projectionMatrix() const;
+  virtual AlgebraicMatrix projectionMatrix() const GCC11_OVERRIDE;
 
-  virtual int dimension() const { return 0;}
+  virtual int dimension() const GCC11_OVERRIDE { return 0;}
 
-  virtual LocalPoint localPosition() const;
+  virtual LocalPoint localPosition() const GCC11_OVERRIDE;
 
-  virtual LocalError localPositionError() const;
+  virtual LocalError localPositionError() const GCC11_OVERRIDE;
 
-  virtual std::vector<const TrackingRecHit*> recHits() const;
+  virtual std::vector<const TrackingRecHit*> recHits() const GCC11_OVERRIDE;
 
-  virtual std::vector<TrackingRecHit*> recHits();
+  virtual std::vector<TrackingRecHit*> recHits() GCC11_OVERRIDE;
 
-  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const;
+  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const GCC11_OVERRIDE;
 
 private:
 

--- a/TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h
+++ b/TrackingTools/TrajectoryState/interface/BasicSingleTrajectoryState.h
@@ -15,7 +15,7 @@ public:
   template<typename... Args>
     BasicSingleTrajectoryState(Args && ...args) : BasicTrajectoryState(std::forward<Args>(args)...){/* assert(weight()>0);*/}
 
-  pointer clone() const {
+  pointer clone() const GCC11_OVERRIDE {
     return build<BasicSingleTrajectoryState>(*this);
   }
 #else


### PR DESCRIPTION
Clang pre-3.7 throws a warning for any missing `override` if `override`
is used at least once in a class thus enforsing to be consistent.

Resolves dozens of warnings in ROOT 6.04.00.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
