### PR TITLE
Use type instead of auto to avoid problems with ROOT 5

### DIFF
--- a/DataFormats/Common/interface/OneToOneGeneric.h
+++ b/DataFormats/Common/interface/OneToOneGeneric.h
@@ -53,7 +53,7 @@ namespace edm {
 	    "can't insert transient references in uninitialized AssociationMap");
         }
         //another thread might change the value of productGetter()
-        auto getter =ref.key.productGetter();
+        EDProductGetter const* getter =ref.key.productGetter();
         if(getter == nullptr) {
           Exception::throwThis(errors::LogicError,
 	    "can't insert into AssociationMap unless it was initialized with a getter or RefProd(s) or RefToBaseProd(s)");

--- a/DataFormats/Common/interface/OneToValue.h
+++ b/DataFormats/Common/interface/OneToValue.h
@@ -46,7 +46,7 @@ namespace edm {
             "can't insert transient references in uninitialized AssociationMap");
         }
         //another thread might change the value of productGetter()
-        auto getter =ref.key.productGetter();
+        EDProductGetter const* getter =ref.key.productGetter();
         if(getter == nullptr) {
           Exception::throwThis(errors::LogicError,
             "can't insert into AssociationMap unless it was initialized with a getter or RefProd or RefToBaseProd");


### PR DESCRIPTION
ROOT 5 can not parse the use of auto in code. Replaced auto with the actual class type.
