### PR TITLE
Fix -Wpotentially-evaluated-expression warnings

### DIFF
--- a/DataFormats/PatCandidates/src/EventHypothesis.cc
+++ b/DataFormats/PatCandidates/src/EventHypothesis.cc
@@ -1,6 +1,13 @@
 #include "DataFormats/PatCandidates/interface/EventHypothesis.h"
 #include "DataFormats/PatCandidates/interface/EventHypothesisLooper.h"
 
+char *
+pat::EventHypothesis::getDemangledSymbol(const char* mangledSymbol) const {
+    int status;
+    char *demangledSymbol = abi::__cxa_demangle(mangledSymbol, nullptr, nullptr, &status);
+    return (status == 0) ? demangledSymbol : nullptr;
+}
+
 void pat::EventHypothesis::add(const CandRefType &ref, const std::string &role) {
     particles_.push_back(value_type(role,ref));
 }


### PR DESCRIPTION
Clang warns if expression inside `typeid()` or `sizeof()` could create
unwanted side effects.

Two warnings were in this package. Full message:

```
warning: expression with side effects will be evaluated despite being
used as an operand to 'typeid' [-Wpotentially-evaluated-expression]
```

I couldn't find code in CMSSW using `getAs<>()`. They are only tested in
private tests (different package), but it's not executed in CMSSW
testsuite. In addition to that test input file is not present.

The pieces generating message were tested manually in a standalone
testcase.

Tested on GCC (4.9.1) and Clang (pre-3.6).

If it's impossible to demangle symbols at run-time, message will be:

```
You can't convert a 'N3edm3PtrI10Candidate2EE' to a '9Candidate'
Note: you can use 'c++filt -t' command to convert the above in human readable types.
```

This is a light update to old one. Also mention `-t` option, as `c++filt`
does not demangle type symbols by default.

If we can demangle symbols at run-time, message will be:

```
You can't convert a 'Candidate2' to a 'Candidate'
```

Notice that instead of printing `edm::Ptr<Candidate>` it talks about
actual type in `edm::Ptr<>`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
