### PR TITLE
DataFormats/HGCDigi: remove HGCEEDetId and HGCHEDetId

### DIFF
--- a/DataFormats/HGCDigi/src/classes_def.xml
+++ b/DataFormats/HGCDigi/src/classes_def.xml
@@ -3,7 +3,7 @@
    <class name="std::vector<HGCSample>"/>
 
    <!-- EE specific -->
-   <class name="HGCEEDetId"/>
+   <!-- HGCEEDetId is provided by DataFormats/ForwardDetId -->
    <class name="HGCDataFrame<HGCEEDetId,HGCSample>"/>
    <class name="std::vector<HGCDataFrame<HGCEEDetId,HGCSample> >"/>
    <class name="edm::SortedCollection<HGCDataFrame<HGCEEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCEEDetId,HGCSample> > >"/>
@@ -12,7 +12,7 @@
    <class name="edm::Wrapper<HGCEEDigiCollection>"/>
 
    <!-- HE specific -->
-   <class name="HGCHEDetId"/>
+   <!-- HGCHEDetId is provided by DataFormats/ForwardDetId -->
    <class name="HGCDataFrame<HGCHEDetId,HGCSample>"/>
    <class name="std::vector<HGCDataFrame<HGCHEDetId,HGCSample> >"/>
    <class name="edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > >"/>


### PR DESCRIPTION
`HGCEEDetId` and `HGCHEDetId` are provided by different dictionary and
ROOT will load those based on rootmap files. These classes are part of
DataFormats/ForwardDetId dictionary.

Fixes 7 failing unit tests.

Fatal exception is throw if both dictionaries are loaded in `cmsRun` process due
to duplication.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
