### PR TITLE
Cleanup Geant4 Physics Lists for exotics

### DIFF
--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -255,15 +255,18 @@ void RunManager::initG4(const edm::EventSetup & es)
   // adding GFlash, Russian Roulette for eletrons and gamma, 
   // step limiters on top of any Physics Lists
   phys->RegisterPhysics(new ParametrisedEMPhysics("EMoptions",m_pPhysics));
-  
-  m_kernel->SetPhysics(phys);
-  m_kernel->InitializePhysics();
 
   m_physicsList->ResetStoredInAscii();
   std::string tableDir = m_PhysicsTablesDir;
   if (m_RestorePhysicsTables) {
     m_physicsList->SetPhysicsTableRetrieved(tableDir);
   } 
+  edm::LogInfo("SimG4CoreApplication") 
+    << "RunManager: start initialisation of PhysicsList";
+  
+  m_kernel->SetPhysics(phys);
+  m_kernel->InitializePhysics();
+
   if (m_kernel->RunInitialization()) { m_managerInitialized = true; }
   else { 
     throw SimG4Exception("G4RunManagerKernel initialization failed!"); 
@@ -285,10 +288,12 @@ void RunManager::initG4(const edm::EventSetup & es)
   
   initializeUserActions();
   
-  for (unsigned it=0; it<m_G4Commands.size(); it++) {
-    edm::LogInfo("SimG4CoreApplication") << "RunManager:: Requests UI: "
-                                         << m_G4Commands[it];
-    G4UImanager::GetUIpointer()->ApplyCommand(m_G4Commands[it]);
+  if(0 < m_G4Commands.size()) {
+    G4cout << "RunManager: Requested UI commands: " << G4endl;
+    for (unsigned it=0; it<m_G4Commands.size(); ++it) {
+      G4cout << "    " << m_G4Commands[it] << G4endl;
+      G4UImanager::GetUIpointer()->ApplyCommand(m_G4Commands[it]);
+    }
   }
 
   if("" != m_WriteFile) {

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -134,10 +134,18 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   // adding GFlash, Russian Roulette for eletrons and gamma, 
   // step limiters on top of any Physics Lists
   phys->RegisterPhysics(new ParametrisedEMPhysics("EMoptions",m_pPhysics));
+
+  m_physicsList->ResetStoredInAscii();
+  if (m_RestorePhysicsTables) {
+    m_physicsList->SetPhysicsTableRetrieved(m_PhysicsTablesDir);
+  }
+  edm::LogInfo("SimG4CoreApplication") 
+    << "RunManagerMT: start initialisation of PhysicsList for master";
   
   m_kernel->SetPhysics(phys);
   m_kernel->InitializePhysics();
   m_kernel->SetUpDecayChannels();
+
   // The following line was with the following comment in
   // G4MTRunManager::InitializePhysics() in 10.00.p01; in practice
   // needed to initialize certain singletons during the master thread
@@ -145,12 +153,6 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   //
   //BERTINI, this is needed to create pseudo-particles, to be removed
   G4CascadeInterface::Initialize();
-  //
-
-  m_physicsList->ResetStoredInAscii();
-  if (m_RestorePhysicsTables) {
-    m_physicsList->SetPhysicsTableRetrieved(m_PhysicsTablesDir);
-  }
 
   if (m_kernel->RunInitialization()) { m_managerInitialized = true; }
   else { 
@@ -169,12 +171,13 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   initializeUserActions();
 
-  for (unsigned it=0; it<m_G4Commands.size(); it++) {
-    edm::LogInfo("SimG4CoreApplication") << "RunManagerMT:: Requests UI: "
-                                         << m_G4Commands[it];
-    G4UImanager::GetUIpointer()->ApplyCommand(m_G4Commands[it]);
+  if(0 < m_G4Commands.size()) {
+    G4cout << "RunManagerMT: Requested UI commands: " << G4endl;
+    for (unsigned it=0; it<m_G4Commands.size(); ++it) {
+      G4cout << "    " << m_G4Commands[it] << G4endl;
+      G4UImanager::GetUIpointer()->ApplyCommand(m_G4Commands[it]);
+    }
   }
-
   if("" != m_WriteFile) {
     G4GDMLParser gdml(new G4GDMLReadStructure(), new CMSGDMLWriteStructure());
     gdml.Write(m_WriteFile, m_world->GetWorldVolume(), true);
@@ -187,8 +190,8 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
   // If the Geant4 particle table is needed, decomment the lines below
   //
-  //  G4cout << "Output of G4ParticleTable DumpTable:" << G4endl;
-  //  G4ParticleTable::GetParticleTable()->DumpTable("ALL");
+  //G4ParticleTable::GetParticleTable()->DumpTable("ALL");
+  //
   G4StateManager::GetStateManager()->SetNewState(G4State_GeomClosed);
   m_currentRun = new G4Run(); 
   m_userRunAction->BeginOfRunAction(m_currentRun); 
@@ -196,7 +199,6 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
 
 void RunManagerMT::initializeUserActions() {
   m_runInterface.reset(new SimRunInterface(this, true));
-
   m_userRunAction = new RunAction(m_pRunAction, m_runInterface.get());
   Connect(m_userRunAction);
 }

--- a/SimG4Core/Application/src/RunManagerMTWorker.cc
+++ b/SimG4Core/Application/src/RunManagerMTWorker.cc
@@ -258,6 +258,10 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
 
   // Set the physics list for the worker, share from master
   PhysicsList *physicsList = runManagerMaster.physicsListForWorker();
+
+  edm::LogInfo("SimG4CoreApplication") 
+    << "RunManagerMTWorker: start initialisation of PhysicsList for a thread";
+
   physicsList->InitializeWorker();
   kernel->SetPhysics(physicsList);
   kernel->InitializePhysics();
@@ -271,17 +275,17 @@ void RunManagerMTWorker::initializeThread(const RunManagerMT& runManagerMaster, 
   m_tls->registry.beginOfJobSignal_(&aBeginOfJob);
 
   initializeUserActions();
-
+  /*
   for(const std::string& command: runManagerMaster.G4Commands()) {
     edm::LogInfo("SimG4CoreApplication") << "RunManagerMTWorker:: Requests UI: "
                                          << command;
     G4UImanager::GetUIpointer()->ApplyCommand(command);
   }
+  */
 }
 
 void RunManagerMTWorker::initializeUserActions() {
   m_tls->runInterface.reset(new SimRunInterface(this, false));
-
   m_tls->userRunAction.reset(new RunAction(m_pRunAction, m_tls->runInterface.get()));
   m_tls->userRunAction->SetMaster(false);
   Connect(m_tls->userRunAction.get());

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsList.h
@@ -10,6 +10,7 @@
 #include "G4VPhysicsConstructor.hh"
 
 class G4ProcessHelper;
+class G4Decay;
 
 class CustomPhysicsList : public G4VPhysicsConstructor 
 {
@@ -20,16 +21,13 @@ public:
   virtual void ConstructParticle();
   virtual void ConstructProcess();
 
-protected:
-
-  void addCustomPhysics();
-
 private:
 
-  void setupRHadronPhycis(G4ParticleDefinition* particle);
-  void setupSUSYPhycis(G4ParticleDefinition* particle);
+  static G4ThreadLocal G4Decay* fDecayProcess;
+  static G4ThreadLocal G4ProcessHelper* myHelper;
+  static G4ThreadLocal bool fInitialized;
 
-  G4ProcessHelper *myHelper;
+  bool fHadronicInteraction;
 
   edm::ParameterSet myConfig;
 

--- a/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
+++ b/SimG4Core/CustomPhysics/interface/CustomPhysicsListSS.h
@@ -10,6 +10,7 @@
 #include "G4VPhysicsConstructor.hh"
 
 class G4ProcessHelper;
+class G4Decay;
 
 class CustomPhysicsListSS : public G4VPhysicsConstructor 
 {
@@ -20,16 +21,13 @@ public:
   virtual void ConstructParticle();
   virtual void ConstructProcess();
 
-protected:
-
-  void addCustomPhysics();
-
 private:
 
-  void setupRHadronPhycis(G4ParticleDefinition* particle);
-  void setupSUSYPhycis(G4ParticleDefinition* particle);
+  static G4ThreadLocal G4Decay* fDecayProcess;
+  static G4ThreadLocal G4ProcessHelper* myHelper;
+  static G4ThreadLocal bool fInitialized;
 
-  G4ProcessHelper *myHelper;
+  bool fHadronicInteraction;
 
   edm::ParameterSet myConfig;
 

--- a/SimG4Core/CustomPhysics/python/CustomPhysics_cfi.py
+++ b/SimG4Core/CustomPhysics/python/CustomPhysics_cfi.py
@@ -12,6 +12,7 @@ customPhysicsSetup = cms.PSet(
     amplitude = cms.double(100.0), ##
 
     # R-hadron physics setup
+    rhadronPhysics = cms.bool(True),
     resonant = cms.bool(False),
     gamma = cms.double(0.1),
     reggeModel = cms.bool(False),
@@ -19,4 +20,3 @@ customPhysicsSetup = cms.PSet(
     mixing = cms.double(1.)
 
 )
-

--- a/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
+++ b/SimG4Core/CustomPhysics/python/Exotica_HSCP_SIM_cfi.py
@@ -29,7 +29,7 @@ def customise(process):
 	process.g4SimHits.Physics.type = cms.string('SimG4Core/Physics/CustomPhysics')
 	# add verbosity
 	process.g4SimHits.Physics.Verbosity = cms.untracked.int32(0)
-	process.g4SimHits.G4Commands = cms.vstring('')
+	#process.g4SimHits.G4Commands = cms.vstring("/control/cout/ignoreThreadsExcept 0")
 	# check flavor of exotics and choose exotica Physics List
 	if FLAVOR=="gluino" or FLAVOR=="stop":
           process.customPhysicsSetup.processesDef = PROCESS_FILE
@@ -41,7 +41,7 @@ def customise(process):
         # add custom options
         process.g4SimHits.Physics = cms.PSet(
             process.g4SimHits.Physics, #keep all default value and add others
-            process.customPhysicsSetup,
+            process.customPhysicsSetup
         )	
 
 	return (process)

--- a/SimG4Core/CustomPhysics/src/CustomPhysics.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysics.cc
@@ -23,10 +23,13 @@ CustomPhysics::CustomPhysics(G4LogicalVolumeToDDLogicalPartMap& map,
   G4DataQuestionaire it(photon);
 
   int  ver     = p.getUntrackedParameter<int>("Verbosity",0);
+  bool tracking= p.getParameter<bool>("TrackingCut");
   bool ssPhys  = p.getUntrackedParameter<bool>("ExoticaPhysicsSS",false);
+  double timeLimit = p.getParameter<double>("MaxTrackTime")*ns;
   edm::LogInfo("PhysicsList") << "You are using the simulation engine: "
-			      << "QGSP_FTFP_BERT_EML for regular particles";
-
+			      << "QGSP_FTFP_BERT_EML for regular particles \n"
+			      << "CustomPhysicsList " << ssPhys << " for exotics; "
+                              << " tracking cut " << tracking << "  t(ns)= " << timeLimit/ns;
   // EM Physics
   RegisterPhysics(new CMSEmStandardPhysics(ver));
   //RegisterPhysics(new CMSEmStandardPhysics95msc93("EM standard msc93",ver,""));
@@ -50,7 +53,11 @@ CustomPhysics::CustomPhysics(G4LogicalVolumeToDDLogicalPartMap& map,
   RegisterPhysics(new G4IonPhysics(ver));
 
   // Neutron tracking cut
-  RegisterPhysics(new G4NeutronTrackingCut(ver));
+  if (tracking) {
+    G4NeutronTrackingCut* ncut= new G4NeutronTrackingCut(ver);
+    ncut->SetTimeLimit(timeLimit);
+    RegisterPhysics(ncut);
+  }
 
   // Custom Physics
   if(ssPhys) {

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsList.cc
@@ -2,6 +2,7 @@
 #include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
 #include "SimG4Core/CustomPhysics/interface/DummyChargeFlipProcess.h"
 #include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
+#include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
@@ -12,120 +13,77 @@
 #include "G4hIonisation.hh"
 #include "G4ProcessManager.hh"
 
-#include "G4LeptonConstructor.hh"
-#include "G4MesonConstructor.hh"
-#include "G4BaryonConstructor.hh"
-#include "G4ShortLivedConstructor.hh"
-#include "G4IonConstructor.hh"
-
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.hh"
 #include "SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh"
 
 using namespace CLHEP;
- 
+
+G4ThreadLocal G4Decay* CustomPhysicsList::fDecayProcess = 0;
+G4ThreadLocal G4ProcessHelper* CustomPhysicsList::myHelper = 0;
+G4ThreadLocal bool CustomPhysicsList::fInitialized = false;
 
 CustomPhysicsList::CustomPhysicsList(std::string name, const edm::ParameterSet & p)  
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
+  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
+
   particleDefFilePath = fp.fullPath();
-  edm::LogInfo("CustomPhysics")<<"Path for custom particle definition file: "
-			       <<particleDefFilePath;
-  myHelper = 0;  
+  edm::LogInfo("SimG4CoreCustomPhysics") 
+    << "CustomPhysicsList: Path for custom particle definition file: \n"
+    <<particleDefFilePath;
 }
 
 CustomPhysicsList::~CustomPhysicsList() {
-  delete myHelper;
 }
  
 void CustomPhysicsList::ConstructParticle(){
-  CustomParticleFactory::loadCustomParticles(particleDefFilePath);     
+  G4cout << "===== CustomPhysicsList::ConstructParticle " << this << G4endl;
+  CustomParticleFactory::loadCustomParticles(particleDefFilePath);
 }
  
 void CustomPhysicsList::ConstructProcess() {
-  addCustomPhysics();
-}
- 
-void CustomPhysicsList::addCustomPhysics(){
+  
+  //if(fInitialized) { return; }
+  //fInitialized = true;
 
-  edm::LogInfo("CustomPhysics") << " CustomPhysicsList: adding CustomPhysics processes "
-				<< "for the list of particles: \n";
+  edm::LogInfo("SimG4CoreCustomPhysics") 
+    <<"CustomPhysicsList: adding CustomPhysics processes "
+    << "for the list of particles";
+
+  fDecayProcess = new G4Decay();
+
   aParticleIterator->reset();
 
   while((*aParticleIterator)()) {
     G4ParticleDefinition* particle = aParticleIterator->value();
     if(CustomParticleFactory::isCustomParticle(particle)) {
       CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
-      edm::LogInfo("CustomPhysics") << particle->GetParticleName()
-				    <<"  PDGcode= "<<particle->GetPDGEncoding()
-				    << "  Mass= "
-				    <<particle->GetPDGMass()/GeV  <<" GeV.";
-      if(cp->GetCloud()!=0) {
-	edm::LogInfo("CustomPhysics") << particle->GetParticleName()
-				      <<" CloudMass= "
-				      <<cp->GetCloud()->GetPDGMass()/GeV
-				      <<" GeV; SpectatorMass= "
-				      << cp->GetSpectator()->GetPDGMass()/GeV
-				      <<" GeV.";
-      }
       G4ProcessManager* pmanager = particle->GetProcessManager();
-      if(pmanager) {
+      edm::LogInfo("SimG4CoreCustomPhysics") 
+	<<"CustomPhysicsList: " << particle->GetParticleName()
+	<<"  PDGcode= " << particle->GetPDGEncoding()
+	<< "  Mass= " << particle->GetPDGMass()/GeV  <<" GeV.";
+      if(cp && pmanager) {
 	if(particle->GetPDGCharge() != 0.0) {
 	  pmanager->AddProcess(new G4hMultipleScattering,-1, 1, 1);
 	  pmanager->AddProcess(new G4hIonisation,        -1, 2, 2);
 	}
-	if(cp != 0) {
-	  if(particle->GetParticleType()=="rhadron" || 
-	     particle->GetParticleType()=="mesonino" || 
-	     particle->GetParticleType() == "sbaryon"){
-	    if(!myHelper) myHelper = new G4ProcessHelper(myConfig);
-	    pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper));
-	  }
+	if(fDecayProcess->IsApplicable(*particle)) {
+	  pmanager->AddProcess(new G4Decay, 0, -1, 3);
+	}
+	if(cp->GetCloud() && fHadronicInteraction && 
+	   CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+	  edm::LogInfo("SimG4CoreCustomPhysics") 
+	    <<"CustomPhysicsList: " << particle->GetParticleName()
+	    <<" CloudMass= " <<cp->GetCloud()->GetPDGMass()/GeV
+	    <<" GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass()/GeV<<" GeV.";
+       
+	  if(!myHelper) myHelper = new G4ProcessHelper(myConfig);
+	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper));
 	}
       }
-      else      LogDebug("CustomPhysics") << "   No pmanager";
     }
   }
-}
-
-
-void CustomPhysicsList::setupRHadronPhycis(G4ParticleDefinition* particle)
-{
-  //    LogDebug("CustomPhysics")<<"Configuring rHadron: "
-  //	<<cp->
-
-  CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
-  if(cp->GetCloud()!=0) {
-    LogDebug("CustomPhysics")
-      <<"Cloud mass is "
-      <<cp->GetCloud()->GetPDGMass()/GeV
-      <<" GeV. Spectator mass is "
-      <<static_cast<CustomParticle*>(particle)->GetSpectator()->GetPDGMass()/GeV
-      <<" GeV.";
-  }
-  G4ProcessManager* pmanager = particle->GetProcessManager();
-  if(pmanager){
-    if(!myHelper) myHelper = new G4ProcessHelper(myConfig);
-    if(particle->GetPDGCharge()/eplus != 0){
-      pmanager->AddProcess(new G4hMultipleScattering,-1, 1, 1);
-      pmanager->AddProcess(new G4hIonisation,        -1, 2, 2);
-    }
-    pmanager->AddProcess(new G4Decay, 1, -1, 3);
-    pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper)); //GHEISHA
-  }
-  else      LogDebug("CustomPhysics") << "   No pmanager";
-}
-					       
-void CustomPhysicsList::setupSUSYPhycis(G4ParticleDefinition* particle)
-{
-  G4ProcessManager* pmanager = particle->GetProcessManager();
-  if(pmanager){
-    if(particle->GetPDGCharge()/eplus != 0){
-      pmanager->AddProcess(new G4hMultipleScattering,-1, 1, 1);
-      pmanager->AddProcess(new G4hIonisation,        -1, 2, 2);
-    }
-    pmanager->AddProcess(new G4Decay, 1, -1, 3);
-  }
-  else      LogDebug("CustomPhysics") << "   No pmanager";
 }

--- a/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
+++ b/SimG4Core/CustomPhysics/src/CustomPhysicsListSS.cc
@@ -2,6 +2,7 @@
 #include "SimG4Core/CustomPhysics/interface/CustomParticleFactory.h"
 #include "SimG4Core/CustomPhysics/interface/DummyChargeFlipProcess.h"
 #include "SimG4Core/CustomPhysics/interface/G4ProcessHelper.hh"
+#include "SimG4Core/CustomPhysics/interface/CustomPDGParser.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
@@ -13,30 +14,29 @@
 #include "G4CoulombScattering.hh"
 #include "G4ProcessManager.hh"
 
-#include "G4LeptonConstructor.hh"
-#include "G4MesonConstructor.hh"
-#include "G4BaryonConstructor.hh"
-#include "G4ShortLivedConstructor.hh"
-#include "G4IonConstructor.hh"
-
 #include "SimG4Core/CustomPhysics/interface/FullModelHadronicProcess.hh"
 #include "SimG4Core/CustomPhysics/interface/ToyModelHadronicProcess.hh"
 
 using namespace CLHEP;
+
+G4ThreadLocal G4Decay* CustomPhysicsListSS::fDecayProcess = 0;
+G4ThreadLocal G4ProcessHelper* CustomPhysicsListSS::myHelper = 0;
+G4ThreadLocal bool CustomPhysicsListSS::fInitialized = false;
  
 CustomPhysicsListSS::CustomPhysicsListSS(std::string name, const edm::ParameterSet& p)
   :  G4VPhysicsConstructor(name) 
 {  
   myConfig = p;
   edm::FileInPath fp = p.getParameter<edm::FileInPath>("particlesDef");
+  fHadronicInteraction = p.getParameter<bool>("rhadronPhysics");
   particleDefFilePath = fp.fullPath();
-  edm::LogInfo("CustomPhysics")<<"Path for custom particle definition file: "
-			       <<particleDefFilePath;
+  edm::LogInfo("SimG4CoreCustomPhysics")
+    <<"CustomPhysicsListSS: Path for custom particle definition file: \n" 
+    <<particleDefFilePath;
   myHelper = 0;  
 }
 
 CustomPhysicsListSS::~CustomPhysicsListSS() {
-  delete myHelper;
 }
  
 void CustomPhysicsListSS::ConstructParticle(){
@@ -44,84 +44,45 @@ void CustomPhysicsListSS::ConstructParticle(){
 }
  
 void CustomPhysicsListSS::ConstructProcess() {
-  addCustomPhysics();
-}
- 
-void CustomPhysicsListSS::addCustomPhysics(){
-  edm::LogInfo("CustomPhysics") << " CustomPhysicsListSS: adding CustomPhysics processes";
+
+  if(fInitialized) { return; }
+  fInitialized = true;
+
+  edm::LogInfo("SimG4CoreCustomPhysics") 
+    <<"CustomPhysicsListSS: adding CustomPhysics processes";
+
+  fDecayProcess = new G4Decay();
+
   aParticleIterator->reset();
 
   while((*aParticleIterator)()) {
     G4ParticleDefinition* particle = aParticleIterator->value();
     if(CustomParticleFactory::isCustomParticle(particle)) {
       CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
-      edm::LogInfo("CustomPhysics") << particle->GetParticleName()
-				    <<" PDGcode= "<<particle->GetPDGEncoding()
-				    << " Mass= "
-				    <<particle->GetPDGMass()/GeV  <<" GeV.";
-      if(cp->GetCloud()!=0) {
-	edm::LogInfo("CustomPhysics") <<  particle->GetParticleName()
-				      << " CloudMass= "
-				      <<cp->GetCloud()->GetPDGMass()/GeV
-				      <<" GeV; SpectatorMass= "
-				      <<cp->GetSpectator()->GetPDGMass()/GeV
-				      <<" GeV.";
-      }
       G4ProcessManager* pmanager = particle->GetProcessManager();
-      if(pmanager) {
+      edm::LogInfo("SimG4CoreCustomPhysics") 
+	<<"CustomPhysicsListSS: " << particle->GetParticleName()
+	<<" PDGcode= " << particle->GetPDGEncoding()
+	<< " Mass= " << particle->GetPDGMass()/GeV  <<" GeV.";
+      if(cp && pmanager) {
 	if(particle->GetPDGCharge()/eplus != 0) {
 	  pmanager->AddProcess(new G4CoulombScattering,  -1,-1, 1);
-	  pmanager->AddProcess(new G4hIonisation,        -1, 2, 2);
+	  pmanager->AddProcess(new G4hIonisation,        -1, 1, 2);
 	}
-	if(cp!=0) {
-	  if(particle->GetParticleType()=="rhadron" || 
-	     particle->GetParticleType()=="mesonino" || 
-	     particle->GetParticleType() == "sbaryon"){
-	    if(!myHelper) myHelper = new G4ProcessHelper(myConfig);
-	    pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper));
-	  }
+	if(fDecayProcess->IsApplicable(*particle)) {
+	  pmanager->AddProcess(new G4Decay, 0, -1, 3);
+	}
+	if(cp->GetCloud() && fHadronicInteraction &&
+	   CustomPDGParser::s_isRHadron(particle->GetPDGEncoding())) {
+	  edm::LogInfo("SimG4CoreCustomPhysics") 
+	    <<"CustomPhysicsListSS: " << particle->GetParticleName()
+	    <<" CloudMass= " <<cp->GetCloud()->GetPDGMass()/GeV
+	    <<" GeV; SpectatorMass= " << cp->GetSpectator()->GetPDGMass()/GeV <<" GeV.";
+       
+	  if(!myHelper) myHelper = new G4ProcessHelper(myConfig);
+	  pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper));
 	}
       }
-      else      LogDebug("CustomPhysics") << "   No pmanager";
     }
   }
-}
-
-void CustomPhysicsListSS::setupRHadronPhycis(G4ParticleDefinition* particle)
-{
-  //    LogDebug("CustomPhysics")<<"Configuring rHadron: "
-  //	<<cp->
-
-  CustomParticle* cp = dynamic_cast<CustomParticle*>(particle);
-  if(cp->GetCloud()!=0) {
-    LogDebug("CustomPhysics")
-      <<"Cloud mass is "
-      <<cp->GetCloud()->GetPDGMass()/GeV
-      <<" GeV. Spectator mass is "
-      <<static_cast<CustomParticle*>(particle)->GetSpectator()->GetPDGMass()/GeV
-      <<" GeV.";
-  }
-  G4ProcessManager* pmanager = particle->GetProcessManager();
-  if(pmanager){
-    if(!myHelper) myHelper = new G4ProcessHelper(myConfig);
-    if(particle->GetPDGCharge()/eplus != 0){
-      pmanager->AddProcess(new G4CoulombScattering,  -1,-1, 1);
-      pmanager->AddProcess(new G4hIonisation,        -1, 2, 2);
-    }
-    pmanager->AddDiscreteProcess(new FullModelHadronicProcess(myHelper)); //GHEISHA
-  }
-  else      LogDebug("CustomPhysics") << "   No pmanager";
-}
-					       
-void CustomPhysicsListSS::setupSUSYPhycis(G4ParticleDefinition* particle)
-{
-  G4ProcessManager* pmanager = particle->GetProcessManager();
-  if(pmanager){
-    if(particle->GetPDGCharge()/eplus != 0){
-      pmanager->AddProcess(new G4CoulombScattering,  -1,-1, 1);
-      pmanager->AddProcess(new G4hIonisation,        -1, 2, 2);
-    }
-    pmanager->AddProcess(new G4Decay, 1, -1, 3);
-  }
-  else      LogDebug("CustomPhysics") << "   No pmanager";
 }

--- a/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/G4ProcessHelper.cc
@@ -37,22 +37,20 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
   reggemodel = p.getParameter<bool>("reggeModel");
   mixing = p.getParameter<double>("mixing");
   
-  edm::LogInfo("CustomPhysics")<<"Read in physics parameters:"<<G4endl;
-  edm::LogInfo("CustomPhysics")<<"Resonant = "<< resonant <<G4endl;
-  edm::LogInfo("CustomPhysics")<<"ResonanceEnergy = "<<ek_0/GeV<<" GeV"<<G4endl;
-  edm::LogInfo("CustomPhysics")<<"Gamma = "<<gamma/GeV<<" GeV"<<G4endl;
-  edm::LogInfo("CustomPhysics")<<"Amplitude = "<<amplitude/millibarn<<" millibarn"<<G4endl;
-  edm::LogInfo("CustomPhysics")<<"ReggeSuppression = "<<100*suppressionfactor<<" %"<<G4endl;
-  edm::LogInfo("CustomPhysics")<<"HadronLifeTime = "<<hadronlifetime<<" s"<<G4endl;
-  edm::LogInfo("CustomPhysics")<<"ReggeModel = "<< reggemodel <<G4endl;
-  edm::LogInfo("CustomPhysics")<<"Mixing = "<< mixing*100 <<" %"<<G4endl;
-
+  edm::LogInfo("SimG4CoreCustomPhysics")
+    <<"ProcessHelper: Read in physics parameters:"
+    <<"\n Resonant = "<< resonant 
+    <<"\n ResonanceEnergy = "<<ek_0/GeV<<" GeV"
+    <<"\n Gamma = "<<gamma/GeV<<" GeV"
+    <<"\n Amplitude = "<<amplitude/millibarn<<" millibarn"
+    <<"ReggeSuppression = "<<100*suppressionfactor<<" %"
+    <<"HadronLifeTime = "<<hadronlifetime<<" s"
+    <<"ReggeModel = "<< reggemodel 
+    <<"Mixing = "<< mixing*100 <<" %";
 
   checkfraction = 0;
   n_22 = 0;
   n_23 = 0;
-
-
 
   while(getline(process_stream,line)){
     std::vector<G4String> tokens;
@@ -67,8 +65,9 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
     known_particles[incidentDef]=true;
 
     G4String target = tokens[1];
-    edm::LogInfo("CustomPhysics")<<"Incident: "<<incident
-		    <<" Target: "<<target<<G4endl;
+    edm::LogInfo("SimG4CoreCustomPhysics")
+      <<"ProcessHelper: Incident "<<incident
+      <<"; Target "<<target;
     
     // Making a ReactionProduct
     ReactionProduct prod;
@@ -78,7 +77,6 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
 	{
 	  prod.push_back(particleTable->FindParticle(part)->GetPDGEncoding());
 	} else {
-	  edm::LogInfo("CustomPhysics")<<"Particle: "<<part<<" is unknown."<<G4endl;
 	  G4Exception("G4ProcessHelper", "UnkownParticle", FatalException,
 		      "Initialization: The reaction product list contained an unknown particle");
 	}
@@ -108,13 +106,13 @@ G4ProcessHelper::G4ProcessHelper(const edm::ParameterSet & p){
       {
 	particle->SetPDGLifeTime(hadronlifetime*s);
 	particle->SetPDGStable(false);
-	edm::LogInfo("CustomPhysics")<<"Lifetime of: "<<name<<" set to: "<<particle->GetPDGLifeTime()/s<<" s."<<G4endl;
-	edm::LogInfo("CustomPhysics")<<"Stable: "<<particle->GetPDGStable()<<G4endl;
+	edm::LogInfo("SimG4CoreCustomPhysics")
+	  <<"ProcessHelper: Lifetime of "<<name<<" set to "
+	  <<particle->GetPDGLifeTime()/s<<" s;"
+	  <<" isStable: "<<particle->GetPDGStable();
       }
   }
   theParticleIterator->reset();
-
-
 }
 
 G4bool G4ProcessHelper::ApplicabilityTester(const G4ParticleDefinition& aPart){
@@ -143,12 +141,12 @@ G4double G4ProcessHelper::GetInclusiveCrossSection(const G4DynamicParticle *aPar
     theXsec = 24 * millibarn;
   } else {
     std::vector<G4int> nq=CustomPDGParser::s_containedQuarks(thePDGCode);
-    //    edm::LogInfo("CustomPhysics")<<"Number of quarks: "<<nq.size()<<G4endl;
+    //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Number of quarks: "<<nq.size()<<G4endl;
     for (std::vector<G4int>::iterator it = nq.begin();
 	 it != nq.end();
 	 it++)
       {
-	//	  edm::LogInfo("CustomPhysics")<<"Quarkvector: "<<*it<<G4endl;
+	//	  edm::LogInfo("SimG4CoreCustomPhysics")<<"Quarkvector: "<<*it<<G4endl;
 	if (*it == 1 || *it == 2) theXsec += 12 * millibarn;
 	if (*it == 3) theXsec += 6 * millibarn;
       }
@@ -173,11 +171,7 @@ G4double G4ProcessHelper::GetInclusiveCrossSection(const G4DynamicParticle *aPar
 	if(CustomPDGParser::s_isRBaryon(thePDGCode)) theXsec=3*P*millibarn;
       }
   }
-    
-
-
   //Adding resonance
-
   if(resonant)
     {
       double e_0 = ek_0 + aParticle->GetDefinition()->GetPDGMass(); //Now total energy
@@ -185,8 +179,8 @@ G4double G4ProcessHelper::GetInclusiveCrossSection(const G4DynamicParticle *aPar
       e_0 = sqrt(aParticle->GetDefinition()->GetPDGMass()*aParticle->GetDefinition()->GetPDGMass()
 		 + theProton->GetPDGMass()*theProton->GetPDGMass()
 		 + 2.*e_0*theProton->GetPDGMass());
-      //      edm::LogInfo("CustomPhysics")<<e_0/GeV<<G4endl;
-      //      edm::LogInfo("CustomPhysics")<<ek_0/GeV<<" "<<aParticle->GetDefinition()->GetPDGMass()/GeV<<" "<<theProton->GetPDGMass()/GeV<<G4endl;
+      //      edm::LogInfo("SimG4CoreCustomPhysics")<<e_0/GeV<<G4endl;
+      //      edm::LogInfo("SimG4CoreCustomPhysics")<<ek_0/GeV<<" "<<aParticle->GetDefinition()->GetPDGMass()/GeV<<" "<<theProton->GetPDGMass()/GeV<<G4endl;
       double sqrts=sqrt(aParticle->GetDefinition()->GetPDGMass()*aParticle->GetDefinition()->GetPDGMass()
 			+ theProton->GetPDGMass()*theProton->GetPDGMass() + 2*aParticle->GetTotalEnergy()*theProton->GetPDGMass());
 
@@ -196,11 +190,8 @@ G4double G4ProcessHelper::GetInclusiveCrossSection(const G4DynamicParticle *aPar
       //      if(fabs(aParticle->GetKineticEnergy()/GeV-200)<10)  std::cout<<sqrts/GeV<<" "<<theXsec/millibarn<<std::endl;
     }
 
-
   //  std::cout<<"Xsec/nucleon: "<<theXsec/millibarn<<"millibarn, Total Xsec: "<<theXsec * anElement->GetN()/millibarn<<" millibarn"<<std::endl;
-  //  return theXsec * anElement->GetN();// * 0.523598775598299;
   return theXsec * pow(anElement->GetN(),0.7)*1.25;// * 0.523598775598299;
-
 }
 
 ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4ParticleDefinition*& aTarget){
@@ -283,12 +274,11 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
        prod_it++){
     G4int secondaries = prod_it->size();
     // If the reaction is not possible we will not consider it
-//    if(ReactionIsPossible(*prod_it,aDynamicParticle)){
-      if(ReactionIsPossible(*prod_it,aDynamicParticle)
+    if(ReactionIsPossible(*prod_it,aDynamicParticle)
        && (!reggemodel ||
 	  (baryonise&&ReactionGivesBaryon(*prod_it)) 
 	  ||
-	  (!baryonise&&!ReactionGivesBaryon(*prod_it))
+	   (!baryonise&&!ReactionGivesBaryon(*prod_it))
 	  ||
 	  (CustomPDGParser::s_isSbaryon(theIncidentPDG))
 	  ||
@@ -306,10 +296,10 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
 	G4cerr << "ReactionProduct has unsupported number of secondaries: "<<secondaries<<G4endl;
       }
     } /*else {
-      edm::LogInfo("CustomPhysics")<<"There was an impossible process"<<G4endl;
+      edm::LogInfo("SimG4CoreCustomPhysics")<<"There was an impossible process"<<G4endl;
       }*/
   }
-  //  edm::LogInfo("CustomPhysics")<<"The size of the ReactionProductList is: "<<theReactionProductList.size()<<G4endl;
+  //  edm::LogInfo("SimG4CoreCustomPhysics")<<"The size of the ReactionProductList is: "<<theReactionProductList.size()<<G4endl;
 
   if (theReactionProductList.size()==0) G4Exception("G4ProcessHelper", "NoProcessPossible", FatalException,
 						    "GetFinalState: No process could be selected from the given list.");
@@ -344,19 +334,19 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
       TwotoThreeFlag.push_back(true);
     }
     Probabilities.push_back(CumulatedProbability);
-    //    edm::LogInfo("CustomPhysics")<<"Pushing back cumulated probability: "<<CumulatedProbability<<G4endl;
+    //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Pushing back cumulated probability: "<<CumulatedProbability<<G4endl;
   }
 
   //Renormalising probabilities
-  //  edm::LogInfo("CustomPhysics")<<"Probs: ";
+  //  edm::LogInfo("SimG4CoreCustomPhysics")<<"Probs: ";
   for (std::vector<G4double>::iterator it = Probabilities.begin();
        it != Probabilities.end();
        it++)
     {
       *it /= CumulatedProbability;
-      //      edm::LogInfo("CustomPhysics")<<*it<<" ";
+      //      edm::LogInfo("SimG4CoreCustomPhysics")<<*it<<" ";
     }
-  //  edm::LogInfo("CustomPhysics")<<G4endl;
+  //  edm::LogInfo("SimG4CoreCustomPhysics")<<G4endl;
 
   // Choosing ReactionProduct
 
@@ -369,13 +359,13 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
   while(!selected && tries < 100){
     i=0;
     G4double dice = G4UniformRand();
-    // edm::LogInfo("CustomPhysics")<<"What's the dice?"<<dice<<G4endl;
+    // edm::LogInfo("SimG4CoreCustomPhysics")<<"What's the dice?"<<dice<<G4endl;
     while(dice>Probabilities[i] && i<theReactionProductList.size()){
-      //      edm::LogInfo("CustomPhysics")<<"i: "<<i<<G4endl;
+      //      edm::LogInfo("SimG4CoreCustomPhysics")<<"i: "<<i<<G4endl;
       i++;
     }
 
-    //    edm::LogInfo("CustomPhysics")<<"Chosen i: "<<i<<G4endl;
+    //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Chosen i: "<<i<<G4endl;
 
     if(!TwotoThreeFlag[i]) {
       // 2 -> 2 processes are chosen immediately
@@ -389,20 +379,20 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
     if(selected&&particleTable->FindParticle(theReactionProductList[i][0])->GetPDGCharge()!=aDynamicParticle->GetDefinition()->GetPDGCharge())
       {
 	/*
-	edm::LogInfo("CustomPhysics")<<"Incoming particle "<<aDynamicParticle->GetDefinition()->GetParticleName()
+	edm::LogInfo("SimG4CoreCustomPhysics")<<"Incoming particle "<<aDynamicParticle->GetDefinition()->GetParticleName()
 	      <<" has charge "<<aDynamicParticle->GetDefinition()->GetPDGCharge()<<G4endl;
-	edm::LogInfo("CustomPhysics")<<"Suggested particle "<<particleTable->FindParticle(theReactionProductList[i][0])->GetParticleName()
+	edm::LogInfo("SimG4CoreCustomPhysics")<<"Suggested particle "<<particleTable->FindParticle(theReactionProductList[i][0])->GetParticleName()
 	      <<" has charge "<<particleTable->FindParticle(theReactionProductList[i][0])->GetPDGCharge()<<G4endl;
 	*/
 	if(G4UniformRand()<suppressionfactor) selected = false;
       }
     tries++;
-    //    edm::LogInfo("CustomPhysics")<<"Tries: "<<tries<<G4endl;
+    //    edm::LogInfo("SimG4CoreCustomPhysics")<<"Tries: "<<tries<<G4endl;
   }
   if(tries>=100) G4cerr<<"Could not select process!!!!"<<G4endl;
 
-  //  edm::LogInfo("CustomPhysics")<<"So far so good"<<G4endl;
-  //  edm::LogInfo("CustomPhysics")<<"Sec's: "<<theReactionProductList[i].size()<<G4endl;
+  //  edm::LogInfo("SimG4CoreCustomPhysics")<<"So far so good"<<G4endl;
+  //  edm::LogInfo("SimG4CoreCustomPhysics")<<"Sec's: "<<theReactionProductList[i].size()<<G4endl;
   
   //Updating checkfraction:
   if (theReactionProductList[i].size()==2) {
@@ -412,8 +402,8 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
   }
 
   checkfraction = (1.0*n_22)/(n_22+n_23);
-  //  edm::LogInfo("CustomPhysics")<<"n_22: "<<n_22<<" n_23: "<<n_23<<" Checkfraction: "<<checkfraction<<G4endl;
-  //  edm::LogInfo("CustomPhysics") <<"Biig number: "<<n_22+n_23<<G4endl;
+  //  edm::LogInfo("SimG4CoreCustomPhysics")<<"n_22: "<<n_22<<" n_23: "<<n_23<<" Checkfraction: "<<checkfraction<<G4endl;
+  //  edm::LogInfo("SimG4CoreCustomPhysics") <<"Biig number: "<<n_22+n_23<<G4endl;
   //Return the chosen ReactionProduct
   return theReactionProductList[i];
 }
@@ -421,20 +411,20 @@ ReactionProduct G4ProcessHelper::GetFinalState(const G4Track& aTrack, G4Particle
 G4double G4ProcessHelper::ReactionProductMass(const ReactionProduct& aReaction,const G4DynamicParticle* aDynamicParticle){
   // Incident energy:
   G4double E_incident = aDynamicParticle->GetTotalEnergy();
-  //edm::LogInfo("CustomPhysics")<<"Total energy: "<<E_incident<<" Kinetic: "<<aDynamicParticle->GetKineticEnergy()<<G4endl;
+  //edm::LogInfo("SimG4CoreCustomPhysics")<<"Total energy: "<<E_incident<<" Kinetic: "<<aDynamicParticle->GetKineticEnergy()<<G4endl;
   // sqrt(s)= sqrt(m_1^2 + m_2^2 + 2 E_1 m_2)
   G4double m_1 = aDynamicParticle->GetDefinition()->GetPDGMass();
   G4double m_2 = theTarget->GetPDGMass();
-  //edm::LogInfo("CustomPhysics")<<"M_R: "<<m_1/GeV<<" GeV, M_np: "<<m_2/GeV<<" GeV"<<G4endl;
+  //edm::LogInfo("SimG4CoreCustomPhysics")<<"M_R: "<<m_1/GeV<<" GeV, M_np: "<<m_2/GeV<<" GeV"<<G4endl;
   G4double sqrts = sqrt(m_1*m_1 + m_2*(m_2 + 2 * E_incident));
-  //edm::LogInfo("CustomPhysics")<<"sqrt(s) = "<<sqrts/GeV<<" GeV"<<G4endl;
+  //edm::LogInfo("SimG4CoreCustomPhysics")<<"sqrt(s) = "<<sqrts/GeV<<" GeV"<<G4endl;
   // Sum of rest masses after reaction:
   G4double M_after = 0;
   for (ReactionProduct::const_iterator r_it = aReaction.begin(); r_it !=aReaction.end(); r_it++){
-    //edm::LogInfo("CustomPhysics")<<"Mass contrib: "<<(particleTable->FindParticle(*r_it)->GetPDGMass())/MeV<<" MeV"<<G4endl;
+    //edm::LogInfo("SimG4CoreCustomPhysics")<<"Mass contrib: "<<(particleTable->FindParticle(*r_it)->GetPDGMass())/MeV<<" MeV"<<G4endl;
     M_after += particleTable->FindParticle(*r_it)->GetPDGMass();
   }
-  //edm::LogInfo("CustomPhysics")<<"Intending to return this ReactionProductMass: "<<(sqrts - M_after)/MeV<<" MeV"<<G4endl;
+  //edm::LogInfo("SimG4CoreCustomPhysics")<<"Intending to return this ReactionProductMass: "<<(sqrts - M_after)/MeV<<" MeV"<<G4endl;
   return sqrts - M_after;
 }
 

--- a/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
+++ b/SimG4Core/CustomPhysics/src/HadronicProcessHelper.cc
@@ -46,7 +46,6 @@ HadronicProcessHelper::HadronicProcessHelper(const std::string & fileName){
 	{
 	  prod.push_back(m_particleTable->FindParticle(part)->GetPDGEncoding());
 	} else {
-	  G4cout<<"Particle: "<<part<<" is unknown."<<G4endl;
 	  G4Exception("HadronicProcessHelper", "UnkownParticle", FatalException,
 		      "Initialization: The reaction product list contained an unknown particle");
 	}
@@ -64,14 +63,10 @@ HadronicProcessHelper::HadronicProcessHelper(const std::string & fileName){
 
   processListStream.close();
 
-
   m_checkFraction = 0;
   m_n22 = 0;
   m_n23 = 0;
-
-
 }
-
 
 G4bool HadronicProcessHelper::applicabilityTester(const G4ParticleDefinition& aPart){
   const G4ParticleDefinition* aP = &aPart; 


### PR DESCRIPTION
Several fixes and clean-up CustomPhysics sub-package: 
 1) Fixed Physics Lists for exotics for the MT mode
 2) Fixed option (currently not used) to retrieve tables of cross sections from files
 3) Clean-up PHysicsLists for exotic particles
 4) Clean-up LogInfo printouts in CustomPhysics sub-package 
