### PR TITLE
CondFormats/ESObjects: dictionary cleanup

### DIFF
--- a/CondFormats/ESObjects/interface/ESAngleCorrectionFactors.h
+++ b/CondFormats/ESObjects/interface/ESAngleCorrectionFactors.h
@@ -4,6 +4,6 @@
 
 typedef float ESAngleCorrectionFactor;
 typedef ESFloatCondObjectContainer ESAngleCorrectionFactorMap;
-typedef ESIntercalibConstantMap ESAngleCorrectionFactors;
+typedef ESAngleCorrectionFactorMap ESAngleCorrectionFactors;
 
 #endif

--- a/CondFormats/ESObjects/src/classes_def.xml
+++ b/CondFormats/ESObjects/src/classes_def.xml
@@ -23,9 +23,7 @@
 
 <class name="ESGain"/>
 
-<class name="ESIntercalibConstants"/>
-
-<class name="ESAngleCorrectionFactors"/>
+<class name="ESCondObjectContainer<float>"/>
 
 <class name="ESEEIntercalibConstants"/>
 


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate check on
a dictionary generation.

The patch fixes a typo for `ESAngleCorrectionFactors` typedef based on
how `ESIntercalibConstants.h` is structured. The end type does not
change.

Fixes the following warning:

```
Warning: Selection file classes_def.xml, lines 28 and 26. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "ESAngleCorrectionFactors" while the class is
"ESCondObjectContainer".
```

`ESIntercalibConstants` and `ESAngleCorrectionFactors` are both
`ESCondObjectContainer<float>`.

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
