### PR TITLE
Fireworks/Core: dictionary cleanup

### DIFF
--- a/Fireworks/Core/src/classes_def.xml
+++ b/Fireworks/Core/src/classes_def.xml
@@ -17,11 +17,8 @@
   <class name="FWGenericParameter<std::string>"/>
   <class name="FWGenericParameter<bool>"/>
   <class name="FWBoolParameterSetter"/>
-  <class name="FWBoolParameter"/>
   <class name="FWStringParameterSetter"/>
-  <class name="FWStringParameter"/>
   <class name="FWLongParameterSetter"/>
-  <class name="FWLongParameter"/>
   <class name="FWEnumParameterSetter"/>
   <class name="FWEnumParameter"/>
   <class name="FWConfiguration::KeyValues"/>


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 24 and 16. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "FWLongParameter" while the class is
"FWGenericParameterWithRange<long>".
Warning: Selection file classes_def.xml, lines 22 and 17. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "FWStringParameter" while the class is
"FWGenericParameter<string>".
Warning: Selection file classes_def.xml, lines 20 and 18. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "FWBoolParameter" while the class is
"FWGenericParameter<bool>".
```

Tested by comparing seal_cap.cc, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
