### PR TITLE
DataFormats/TauReco: clean dictionary of duplicate selection rules

### DIFF
--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -109,7 +109,6 @@
   <class name="edm::Association<std::vector<reco::PFTauTransverseImpactParameter> >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauTransverseImpactParameter> > >"/>
 
-  <class name="reco::PFTauTransverseImpactParameterCollection"/>
   <class name="std::vector<reco::PFTauTransverseImpactParameterCollection>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTauTransverseImpactParameterCollection> >"/>
   <class name="edm::Ref<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection> >"/>
@@ -119,7 +118,6 @@
   <class name="edm::Association<std::vector<reco::PFTauTransverseImpactParameterCollection> >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauTransverseImpactParameterCollection> > >"/>
 
-  <class name="reco::PFTauTransverseImpactParameterRef"/>
   <class name="std::vector<reco::PFTauTransverseImpactParameterRef>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTauTransverseImpactParameterRef> >"/>
   <class name="edm::Ref<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef> >"/>
@@ -189,7 +187,6 @@
 
 
 
-  <class name="reco::PFTau3ProngSummaryCollection"/>
   <class name="std::vector<reco::PFTau3ProngSummaryCollection>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTau3ProngSummaryCollection> >"/>
   <class name="edm::Ref<std::vector<reco::PFTau3ProngSummaryCollection>,reco::PFTau3ProngSummaryCollection,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau3ProngSummaryCollection>,reco::PFTau3ProngSummaryCollection> >"/>
@@ -201,7 +198,6 @@
 
 
 
-  <class name="reco::PFTau3ProngSummaryRef"/>
   <class name="std::vector<reco::PFTau3ProngSummaryRef>"/>
   <class name="edm::Wrapper<std::vector<reco::PFTau3ProngSummaryRef> >"/>
   <class name="edm::Ref<std::vector<reco::PFTau3ProngSummaryRef>,reco::PFTau3ProngSummaryRef,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTau3ProngSummaryRef>,reco::PFTau3ProngSummaryRef> >"/>


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def_3.xml, lines 112 and 103. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is
"reco::PFTauTransverseImpactParameterCollection" while the class is
"vector<reco::PFTauTransverseImpactParameter>".

Warning: Selection file classes_def_3.xml, lines 122 and 105. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "reco::PFTauTransverseImpactParameterRef" while
the class is
"edm::Ref<vector<reco::PFTauTransverseImpactParameter>,
reco::PFTauTransverseImpactParameter,
edm::refhelper::FindUsingAdvance<vector<reco::PFTauTransverseImpactParameter>,
reco::PFTauTransverseImpactParameter> >".

Warning: Selection file classes_def_3.xml, lines 192 and 181. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "reco::PFTau3ProngSummaryCollection" while the
class is "vector<reco::PFTau3ProngSummary>".

Warning: Selection file classes_def_3.xml, lines 204 and 183. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "reco::PFTau3ProngSummaryRef" while the class
is "edm::Ref<vector<reco::PFTau3ProngSummary>,reco::PFTau3ProngSummary,
edm::refhelper::FindUsingAdvance<vector<reco::PFTau3ProngSummary>,
reco::PFTau3ProngSummary> >".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
