### PR TITLE
DataFormats/RecoCandidate: clean dictionary of duplicate selection rules

### DIFF
--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -140,7 +140,6 @@
   </class>
   <class name="std::multimap<reco::isodeposit::Direction::Distance,float>"/>
 
-  <class name="reco::IsoDepositMap"/>
   <class name="edm::ValueMap<reco::IsoDeposit>::const_iterator">
     <field name="values_" transient="true"/>
     <field name="i_" transient="true"/>


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 143 and 89. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "reco::IsoDepositMap" while the class is
"edm::ValueMap<reco::IsoDeposit>".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
