### PR TITLE
DataFormats/HepMCCandidate: clean dictionary of duplicate selection rules

### DIFF
--- a/DataFormats/HepMCCandidate/src/classes_def.xml
+++ b/DataFormats/HepMCCandidate/src/classes_def.xml
@@ -7,7 +7,6 @@
    <version ClassVersion="10" checksum="2736964676"/>
   </class>
   <class name="std::vector<reco::GenParticle>" />
-  <class name="reco::GenParticleCollection" />
   <class name="edm::Wrapper<std::vector<reco::GenParticle> >" />
   <class name="edm::Association<std::vector<reco::GenParticle> >" />
   <class name="edm::Wrapper<edm::Association<std::vector<reco::GenParticle> > >" />


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 10 and 9. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "reco::GenParticleCollection" while the class
is "vector<reco::GenParticle>".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
