### PR TITLE
DataFormats/HGCRecHit: clean dictionary of duplicate selection rules

### DIFF
--- a/DataFormats/HGCRecHit/src/classes_def.xml
+++ b/DataFormats/HGCRecHit/src/classes_def.xml
@@ -20,7 +20,6 @@
   <class name="edm::RefVector<edm::SortedCollection<HGCRecHit,edm::StrictWeakOrdering<HGCRecHit> >,HGCRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<HGCRecHit,edm::StrictWeakOrdering<HGCRecHit> >,HGCRecHit> >"/>
   <class name="edm::RefProd<edm::SortedCollection<HGCRecHit,edm::StrictWeakOrdering<HGCRecHit> > >"/>
 
-  <class name="HGCRecHitCollection"/>
   <class name="edm::Wrapper<HGCRecHitCollection>"/>
  
   <class name="edm::DetSet<HGCRecHit>"/>


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 23 and 17. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "HGCRecHitCollection" while the class is
"edm::SortedCollection<HGCRecHit,edm::StrictWeakOrdering<HGCRecHit> >".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
