### PR TITLE
DataFormats/HGCDigi: clean dictionary of duplicate selection rules

### DIFF
--- a/DataFormats/HGCDigi/src/classes_def.xml
+++ b/DataFormats/HGCDigi/src/classes_def.xml
@@ -8,7 +8,6 @@
    <class name="std::vector<HGCDataFrame<HGCEEDetId,HGCSample> >"/>
    <class name="edm::SortedCollection<HGCDataFrame<HGCEEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCEEDetId,HGCSample> > >"/>
    <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HGCEEDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HGCEEDetId,HGCSample> > > >" />
-   <class name="HGCEEDigiCollection"/>
    <class name="edm::Wrapper<HGCEEDigiCollection>"/>
 
    <!-- HE specific -->
@@ -17,6 +16,5 @@
    <class name="std::vector<HGCDataFrame<HGCHEDetId,HGCSample> >"/>
    <class name="edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > >"/>
    <class name="edm::Wrapper<edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>,edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > > >" />
-   <class name="HGCHEDigiCollection"/>
    <class name="edm::Wrapper<HGCHEDigiCollection>"/>
 </lcgdict>


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 11 and 9. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "HGCEEDigiCollection" while the class is
"edm::SortedCollection<HGCDataFrame<HGCEEDetId,HGCSample>,
edm::StrictWeakOrdering<HGCDataFrame<HGCEEDetId,HGCSample> > >".

Warning: Selection file classes_def.xml, lines 20 and 18. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "HGCHEDigiCollection" while the class is
"edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>,
edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > >".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
