### PR TITLE
DataFormats/EcalRecHit: clean dictionary of duplicate selection rules

### DIFF
--- a/DataFormats/EcalRecHit/src/classes_def.xml
+++ b/DataFormats/EcalRecHit/src/classes_def.xml
@@ -28,7 +28,6 @@
   <class name="edm::RefVector<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit,edm::refhelper::FindUsingAdvance<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >,EcalRecHit> >"/>
   <class name="edm::RefProd<edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> > >"/>
 
-  <class name="EcalRecHitCollection"/>
   <class name="edm::Wrapper<EcalRecHitCollection>"/>
  
   <class name="edm::DetSet<EcalRecHit>"/>


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 31 and 24. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "EcalRecHitCollection" while the class is
"edm::SortedCollection<EcalRecHit,edm::StrictWeakOrdering<EcalRecHit> >".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
