### PR TITLE
DataFormats/DetId: clean dictionary of duplicate selection rules

### DIFF
--- a/DataFormats/DetId/src/classes_def.xml
+++ b/DataFormats/DetId/src/classes_def.xml
@@ -4,7 +4,6 @@
   </class>
   <class name="std::vector<DetId>"/>
   <class name="edm::EDCollection<DetId>"/>
-  <class name="DetIdCollection"/>
   <class name="edm::Wrapper<edm::EDCollection<DetId> >"/>
   <class name="std::vector<std::pair<DetId,float> >"/>  
   <class name="std::pair<DetId,float>"/>               


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 7 and 6. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "DetIdCollection" while the class is
"edm::EDCollection<DetId>".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
