### PR TITLE
CondFormats/SiStripObjects: clean dictionary of duplicate selection rules

### DIFF
--- a/CondFormats/SiStripObjects/src/classes_def.xml
+++ b/CondFormats/SiStripObjects/src/classes_def.xml
@@ -10,7 +10,6 @@
   <class name="FedChannelConnection"/>
   <class name="std::vector<FedChannelConnection>"/>
   <class name="std::vector< std::vector<FedChannelConnection> >"/>
-  <class name="SiStripFedCabling::Conns"/>
 
   <class name="SiStripPedestals" class_version="0">
     <field name="indexes" mapping="blob"/>
@@ -34,7 +33,6 @@
   <class name="std::vector<SiStripThreshold::Data>"/>
   <class name="SiStripThreshold::DetRegistry"/>
   <class name="std::vector<SiStripThreshold::DetRegistry>"/>
-  <class name="SiStripThreshold::Container"/>
   <class name="std::vector<SiStripThreshold::Container>"/>
 
   <class name="SiStripApvGain" class_version="0">


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

```
Warning: Selection file classes_def.xml, lines 13 and 11. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "SiStripFedCabling::Conns" while the class is
"vector<FedChannelConnection>".

Warning: Selection file classes_def.xml, lines 37 and 34. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "SiStripThreshold::Container" while the class
is "vector<SiStripThreshold::Data>".
```

Tested by comparing `seal_cap.cc`, which does not change after this
patchset.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
