### PR TITLE
CondFormats/EcalObjects: clean dictionary of duplicate selection rules

### DIFF
--- a/CondFormats/EcalObjects/src/classes_def.xml
+++ b/CondFormats/EcalObjects/src/classes_def.xml
@@ -19,10 +19,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalChannelStatus"/>
-<!-- typedefs for EcalCondTowerObjectContainer -->
-<class name="EcalDCSTowerStatus"/>
 
 <!-- base class -->
 <class name="EcalDAQStatusCode"/>
@@ -34,8 +30,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondTowerObjectContainer -->
-<class name="EcalDAQTowerStatus"/>
 
 <!-- base class -->
 <class name="EcalDQMStatusCode"/>
@@ -54,10 +48,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalDQMChannelStatus"/>
-<!-- typedefs for EcalCondTowerObjectContainer -->
-<class name="EcalDQMTowerStatus"/>
 
 <!-- base class -->
 <class name="EcalMGPAGainRatio"/>
@@ -69,8 +59,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalGainRatios"/>
 
 <!-- base class -->
 <class name="EcalMappingElement"/>
@@ -82,8 +70,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalMappingElectronics"/>
 
 <!-- base class -->
 <class name="EcalPedestal"/>
@@ -95,10 +81,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalPedestals"/>
-
-
 
 <!-- base class -->
 <class name="EcalTPGCrystalStatusCode"/>
@@ -110,8 +92,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalTPGCrystalStatus"/>
 
 <!-- base class -->
 <class name="EcalTPGLinearizationConstant"/>
@@ -123,8 +103,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalTPGLinearizationConst"/>
 
 <!-- base class -->
 <class name="EcalTPGPedestal"/>
@@ -136,8 +114,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalTPGPedestals"/>
 
 <!-- base class -->
 <class name="EcalXtalGroupId"/>
@@ -149,8 +125,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalWeightXtalGroups"/>
 
 <!-- base class is the builtin type float -->
 <!-- templates for EcalCondObjectContainer having the class as template parameter, excluding STL -->
@@ -160,16 +134,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalFloatCondObjectContainer"/>
-<class name="EcalIntercalibConstants"/>
-<class name="EcalIntercalibConstantsMC"/>
-<class name="EcalIntercalibErrors"/>
-<class name="EcalLaserAPDPNRatiosRef"/>
-<class name="EcalLaserAlphas"/>
-<class name="EcalTimeCalibConstants"/>
-<class name="EcalTimeCalibErrors"/>
-
 
 <!-- base class -->
 <class name="EcalLaserAPDPNRatios::EcalLaserAPDPNpair"/>
@@ -186,8 +150,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalLaserAPDPNRatios::EcalLaserAPDPNRatiosMap"/>
 
 <!-- base class -->
 <class name="EcalTimeDependentCorrections::Values"/>
@@ -204,12 +166,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalTimeDependentCorrections::EcalValueMap"/>
-
-<!-- typedefs for EcalTimeDependentCorrections -->
-<class name="EcalLinearCorrections"/>
-
 
 <class name="EcalWeightSet"/>
 
@@ -225,12 +181,6 @@
 <class name="EcalTimeOffsetConstant"/>
 
 <class name="EcalFunParams"/>
-<!-- typedefs -->
-<class name="EcalClusterCrackCorrParameters"/>
-<class name="EcalClusterEnergyCorrectionObjectSpecificParameters"/>
-<class name="EcalClusterEnergyCorrectionParameters"/>
-<class name="EcalClusterEnergyUncertaintyParameters"/>
-<class name="EcalClusterLocalContCorrParameters"/>
 
 <class name="EcalDCUTemperatures"/>
 <class name="EcalPTMTemperatures"/>
@@ -300,8 +250,6 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalPulseShapes"/>
 
 <!-- base class -->
 <class name="EcalPulseCovariance"/>
@@ -313,7 +261,5 @@
    <field name = "eb_" mapping = "blob"/>
    <field name = "ee_" mapping = "blob"/>
 </class>
-<!-- typedefs for EcalCondObjectContainer -->
-<class name="EcalPulseCovariances"/>
 
 </lcgdict>


### PR DESCRIPTION
Thanks to Danilo ROOT 6.04.00 will have user-friendly duplicate
selection rule check.

The amount of warnings are too high to put them into a commit message.

`seal_cap.cc` was checked after re-compilation and none of types were
removed from the dictionary.

Full list of warnings:

```
Warning: Selection file classes_def.xml, lines 164 and 159. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalFloatCondObjectContainer" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 99 and 94. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalPedestals" while the class is "EcalCondObjectContainer<EcalPedestal>".
Warning: Selection file classes_def.xml, lines 153 and 148. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalWeightXtalGroups" while the class is "EcalCondObjectContainer<EcalXtalGroupId>".
Warning: Selection file classes_def.xml, lines 73 and 68. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalGainRatios" while the class is "EcalCondObjectContainer<EcalMGPAGainRatio>".
Warning: Selection file classes_def.xml, lines 165 and 164. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalIntercalibConstants" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 166 and 165. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalIntercalibConstantsMC" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 167 and 166. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalIntercalibErrors" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 304 and 299. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalPulseShapes" while the class is "EcalCondObjectContainer<EcalPulseShape>".
Warning: Selection file classes_def.xml, lines 317 and 312. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalPulseCovariances" while the class is "EcalCondObjectContainer<EcalPulseCovariance>".
Warning: Selection file classes_def.xml, lines 170 and 167. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalTimeCalibConstants" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 171 and 170. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalTimeCalibErrors" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 23 and 11. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalChannelStatus" while the class is "EcalCondObjectContainer<EcalChannelStatusCode>".
Warning: Selection file classes_def.xml, lines 60 and 53. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalDQMTowerStatus" while the class is "EcalCondTowerObjectContainer<EcalDQMStatusCode>".
Warning: Selection file classes_def.xml, lines 58 and 46. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalDQMChannelStatus" while the class is "EcalCondObjectContainer<EcalDQMStatusCode>".
Warning: Selection file classes_def.xml, lines 25 and 18. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalDCSTowerStatus" while the class is "EcalCondTowerObjectContainer<EcalChannelStatusCode>".
Warning: Selection file classes_def.xml, lines 38 and 33. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalDAQTowerStatus" while the class is "EcalCondTowerObjectContainer<EcalDAQStatusCode>".
Warning: Selection file classes_def.xml, lines 169 and 171. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalLaserAlphas" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 208 and 203. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalTimeDependentCorrections::EcalValueMap" while the class is "EcalCondObjectContainer<EcalTimeDependentCorrections::Values>".
Warning: Selection file classes_def.xml, lines 190 and 185. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalLaserAPDPNRatios::EcalLaserAPDPNRatiosMap" while the class is "EcalCondObjectContainer<EcalLaserAPDPNRatios::EcalLaserAPDPNpair>".
Warning: Selection file classes_def.xml, lines 211 and 195. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalLinearCorrections" while the class is "EcalTimeDependentCorrections".
Warning: Selection file classes_def.xml, lines 168 and 169. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalLaserAPDPNRatiosRef" while the class is "EcalCondObjectContainer<float>".
Warning: Selection file classes_def.xml, lines 127 and 122. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalTPGLinearizationConst" while the class is "EcalCondObjectContainer<EcalTPGLinearizationConstant>".
Warning: Selection file classes_def.xml, lines 140 and 135. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalTPGPedestals" while the class is "EcalCondObjectContainer<EcalTPGPedestal>".
Warning: Selection file classes_def.xml, lines 86 and 81. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalMappingElectronics" while the class is "EcalCondObjectContainer<EcalMappingElement>".
Warning: Selection file classes_def.xml, lines 233 and 227. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalClusterLocalContCorrParameters" while the class is "EcalFunParams".
Warning: Selection file classes_def.xml, lines 229 and 233. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalClusterCrackCorrParameters" while the class is "EcalFunParams".
Warning: Selection file classes_def.xml, lines 231 and 229. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalClusterEnergyCorrectionParameters" while the class is "EcalFunParams".
Warning: Selection file classes_def.xml, lines 232 and 231. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalClusterEnergyUncertaintyParameters" while the class is "EcalFunParams".
Warning: Selection file classes_def.xml, lines 230 and 232. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalClusterEnergyCorrectionObjectSpecificParameters" while the class is "EcalFunParams".
Warning: Selection file classes_def.xml, lines 114 and 109. Attempt to select with a named selection rule an already selected class. The name used in the selection is "EcalTPGCrystalStatus" while the class is "EcalCondObjectContainer<EcalTPGCrystalStatusCode>".
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
