### PR TITLE
Fix dependencies between DataFormats

### DIFF
--- a/DataFormats/EgammaTrackReco/BuildFile.xml
+++ b/DataFormats/EgammaTrackReco/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/TrackReco"/>
 
 <use   name="clhepheader"/>
 <export>

--- a/DataFormats/METReco/BuildFile.xml
+++ b/DataFormats/METReco/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="DataFormats/Common"/>
 <use   name="DataFormats/RecoCandidate"/>
+<use   name="DataFormats/JetReco"/>
 <use   name="FWCore/Utilities"/>
 <use   name="boost"/>
 <use   name="root"/>

--- a/DataFormats/MuonSeed/BuildFile.xml
+++ b/DataFormats/MuonSeed/BuildFile.xml
@@ -1,6 +1,8 @@
-
 <use   name="clhepheader"/>
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/L1Trigger"/>
+<use   name="DataFormats/TrackReco"/>
+<use   name="DataFormats/TrackingRecHit"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/DataFormats/TrackCandidate/BuildFile.xml
+++ b/DataFormats/TrackCandidate/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/TrackingRecHit"/>
 
 <use   name="clhepheader"/>
 <export>

--- a/DataFormats/TrajectorySeed/BuildFile.xml
+++ b/DataFormats/TrajectorySeed/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/TrackingRecHit"/>
 
 <use   name="clhepheader"/>
 <export>

--- a/FastSimDataFormats/External/BuildFile.xml
+++ b/FastSimDataFormats/External/BuildFile.xml
@@ -1,4 +1,5 @@
 <use   name="DataFormats/Common"/>
+<use   name="DataFormats/GeometrySurface"/>
 
 <export>
   <lib   name="1"/>


### PR DESCRIPTION
According to IB logs ROOT6 run-time is not able to locate some
classes and dictionaries. The patch adds missing dependencies based on
ROOT6 run-time errors and warnings printed while building CMSSW IB.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
