### PR TITLE
DataFormats/PatCandidates: add missing class

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -98,6 +98,9 @@
    <version ClassVersion="10" checksum="2244564938"/>
   </class>
   <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
+   <class name="edm::AtomicPtrCache<std::vector<CaloTowerPtr> >">
+     <field name="m_data" transient="true"/>
+  </class>
    <class name="edm::AtomicPtrCache<reco::TrackRefVector>">
      <field name="m_data" transient="true"/>
   </class>


### PR DESCRIPTION
While building CMSSW the following warning is generated by ROOT6
run-time:

```
TClass::Init:0: RuntimeWarning: no dictionary for class
edm::AtomicPtrCache<vector<edm::Ptr<CaloTower> > > is available
```

Add missing class `edm::AtomicPtrCache<vector<edm::Ptr<CaloTower> > >`

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
