### PR TITLE
Switch to standard customise via ConfigBuilder for Configuration/DataProcessing

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -2181,8 +2181,10 @@ class ConfigBuilder(object):
 		#this is not supporting the blacklist at this point since I do not understand it
 		self.pythonCfgCode+="#do not add changes to your config after this point (unless you know what you are doing)\n"
 		self.pythonCfgCode+="from FWCore.ParameterSet.Utilities import convertToUnscheduled\n"
-
 		self.pythonCfgCode+="process=convertToUnscheduled(process)\n"
+
+		from FWCore.ParameterSet.Utilities import convertToUnscheduled
+		self.process=convertToUnscheduled(self.process)
 
 		#now add the unscheduled stuff
 		for module in self.importsUnsch:

--- a/Configuration/DataProcessing/python/Impl/cosmics.py
+++ b/Configuration/DataProcessing/python/Impl/cosmics.py
@@ -10,7 +10,6 @@ import os
 import sys
 
 from Configuration.DataProcessing.Reco import Reco
-from Configuration.DataProcessing.RecoTLR import customiseCosmicData
 
 class cosmics(Reco):
     """
@@ -31,9 +30,14 @@ class cosmics(Reco):
         """
         if not 'skims' in args:
             args['skims']= ['@allForPromptCosmics']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
+
         process = Reco.promptReco(self,globalTag, **args)
 
-        customiseCosmicData(process)  
         return process
 
 
@@ -47,9 +51,13 @@ class cosmics(Reco):
 
         if not 'skims' in args:
             args['skims']= ['@allForExpressCosmics']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
         process = Reco.expressProcessing(self,globalTag, **args)
 
-        customiseCosmicData(process)  
         return process
 
     def visualizationProcessing(self, globalTag, **args):
@@ -60,9 +68,12 @@ class cosmics(Reco):
 
         """
 
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicData']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicData')
         process = Reco.visualizationProcessing(self,globalTag, **args)
 
-        customiseCosmicData(process)  
         process.reconstructionCosmics.remove(process.lumiProducer)
 
         return process

--- a/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/cosmicsRun2.py
@@ -10,7 +10,6 @@ import os
 import sys
 
 from Configuration.DataProcessing.Reco import Reco
-from Configuration.DataProcessing.RecoTLR import customiseCosmicDataRun2
 
 class cosmicsRun2(Reco):
     def __init__(self):
@@ -34,9 +33,12 @@ class cosmicsRun2(Reco):
         """
         if not 'skims' in args:
             args['skims']= ['@allForPromptCosmics']
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
         process = Reco.promptReco(self,globalTag, **args)
 
-        customiseCosmicDataRun2(process)  
         return process
 
 
@@ -50,9 +52,12 @@ class cosmicsRun2(Reco):
 
         if not 'skims' in args:
             args['skims']= ['@allForExpressCosmics']
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
         process = Reco.expressProcessing(self,globalTag, **args)
 
-        customiseCosmicDataRun2(process)  
         return process
 
     def visualizationProcessing(self, globalTag, **args):
@@ -63,9 +68,12 @@ class cosmicsRun2(Reco):
 
         """
 
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseCosmicDataRun2')
         process = Reco.visualizationProcessing(self,globalTag, **args)
 
-        customiseCosmicDataRun2(process)  
         process.reconstructionCosmics.remove(process.lumiProducer)
 
         return process

--- a/Configuration/DataProcessing/python/Impl/hcalnzs.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzs.py
@@ -10,7 +10,6 @@ import os
 import sys
 
 from Configuration.DataProcessing.Impl.pp import pp
-from Configuration.DataProcessing.RecoTLR import customisePrompt
 
 class hcalnzs(pp):
     def __init__(self):

--- a/Configuration/DataProcessing/python/Impl/hcalnzsRun2.py
+++ b/Configuration/DataProcessing/python/Impl/hcalnzsRun2.py
@@ -10,7 +10,6 @@ import os
 import sys
 
 from Configuration.DataProcessing.Impl.pp import pp
-from Configuration.DataProcessing.RecoTLR import customisePromptRun2
 
 class hcalnzsRun2(pp):
     def __init__(self):
@@ -32,8 +31,12 @@ class hcalnzsRun2(pp):
         """
         if not 'skims' in args:
             args['skims']=['HcalCalMinBias']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2')
+
         process = pp.promptReco(self,globalTag,**args)
         
-        #add the former top level patches here
-        customisePromptRun2(process)
         return process

--- a/Configuration/DataProcessing/python/Impl/pp.py
+++ b/Configuration/DataProcessing/python/Impl/pp.py
@@ -11,7 +11,6 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
-from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
 class pp(Reco):
     """
@@ -32,11 +31,14 @@ class pp(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePrompt']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePrompt')
+
         process = Reco.promptReco(self,globalTag, **args)
 
-        #add the former top level patches here
-        customisePrompt(process)
-        
         return process
 
 
@@ -49,10 +51,14 @@ class pp(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForExpress']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
+
         process = Reco.expressProcessing(self,globalTag, **args)
         
-        customiseExpress(process)
-                
         return process
 
     def visualizationProcessing(self, globalTag, **args):
@@ -62,10 +68,14 @@ class pp(Reco):
         Proton collision data taking visualization processing
 
         """
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpress']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpress')
+
         process = Reco.visualizationProcessing(self,globalTag, **args)
         
-        customiseExpress(process)
-                
         return process
 
     def alcaHarvesting(self, globalTag, datasetName, **args):

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -11,7 +11,6 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
-from Configuration.DataProcessing.RecoTLR import customisePromptRun2,customiseExpressRun2
 
 class ppRun2(Reco):
     def __init__(self):
@@ -35,11 +34,14 @@ class ppRun2(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2')
+
         process = Reco.promptReco(self,globalTag, **args)
 
-        #add the former top level patches here
-        customisePromptRun2(process)
-        
         return process
 
 
@@ -52,10 +54,14 @@ class ppRun2(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForExpress']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
+
         process = Reco.expressProcessing(self,globalTag, **args)
         
-        customiseExpressRun2(process)
-                
         return process
 
     def visualizationProcessing(self, globalTag, **args):
@@ -65,10 +71,13 @@ class ppRun2(Reco):
         Proton collision data taking visualization processing
 
         """
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2')
+
         process = Reco.visualizationProcessing(self,globalTag, **args)
         
-        customiseExpressRun2(process)
-                
         return process
 
     def alcaHarvesting(self, globalTag, datasetName, **args):

--- a/Configuration/DataProcessing/python/Impl/ppRun2B0T.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2B0T.py
@@ -11,7 +11,6 @@ import sys
 
 from Configuration.DataProcessing.Reco import Reco
 import FWCore.ParameterSet.Config as cms
-from Configuration.DataProcessing.RecoTLR import customisePromptRun2B0T,customiseExpressRun2B0T
 
 class ppRun2B0T(Reco):
     def __init__(self):
@@ -35,11 +34,14 @@ class ppRun2B0T(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2B0T']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2B0T')
+
         process = Reco.promptReco(self,globalTag, **args)
 
-        #add the former top level patches here
-        customisePromptRun2B0T(process)
-        
         return process
 
 
@@ -52,10 +54,14 @@ class ppRun2B0T(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForExpress']
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T')
+
+
         process = Reco.expressProcessing(self,globalTag, **args)
         
-        customiseExpressRun2B0T(process)
-                
         return process
 
     def visualizationProcessing(self, globalTag, **args):
@@ -65,10 +71,13 @@ class ppRun2B0T(Reco):
         Proton collision data taking visualization processing
 
         """
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2B0T')
+
         process = Reco.visualizationProcessing(self,globalTag, **args)
         
-        customiseExpressRun2B0T(process)
-                
         return process
 
     def alcaHarvesting(self, globalTag, datasetName, **args):

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -49,6 +49,9 @@ class Reco(Scenario):
                     options.runUnscheduled=True
                     
 
+        if 'customs' in args:
+            options.customisation_file=args['customs']
+
         options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+step+miniAODStep+',DQM'+dqmStep+',ENDJOB'
 
 
@@ -94,6 +97,10 @@ class Reco(Scenario):
         if 'inputSource' in args:
             options.filetype = args['inputSource']
         process = cms.Process('RECO')
+
+        if 'customs' in args:
+            options.customisation_file=args['customs']
+
         cb = ConfigBuilder(options, process = process, with_output = True, with_input = True)
 
         cb.prepare()
@@ -135,6 +142,10 @@ class Reco(Scenario):
         print "Using %s source"%options.filetype            
 
         process = cms.Process('RECO')
+
+        if 'customs' in args:
+            options.customisation_file=args['customs']
+
         cb = ConfigBuilder(options, process = process, with_output = True, with_input = True)
 
         cb.prepare()
@@ -179,6 +190,9 @@ class Reco(Scenario):
             options.conditions += ','+args['globalTagConnect']
 
         options.triggerResultsProcess = 'RECO'
+
+        if 'customs' in args:
+            options.customisation_file=args['customs']
         
         process = cms.Process('ALCA')
         cb = ConfigBuilder(options, process = process)
@@ -215,6 +229,10 @@ class Reco(Scenario):
  
         process = cms.Process("HARVESTING")
         process.source = dqmIOSource(args)
+
+        if 'customs' in args:
+            options.customisation_file=args['customs']
+
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()
 
@@ -247,6 +265,10 @@ class Reco(Scenario):
  
         process = cms.Process("ALCAHARVEST")
         process.source = cms.Source("PoolSource")
+
+        if 'customs' in args:
+            options.customisation_file=args['customs']
+
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()
 
@@ -274,6 +296,10 @@ class Reco(Scenario):
         options.conditions = gtNameAndConnect(globalTag, args)
         process = cms.Process("SKIM")
         process.source = cms.Source("PoolSource")
+
+        if 'customs' in args:
+            options.customisation_file=args['customs']
+
         configBuilder = ConfigBuilder(options, process = process)
         configBuilder.prepare()
 

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -82,8 +82,8 @@ def customiseExpressRun2(process):
     return process
 
 def customiseExpressRun2B0T(process):
-    process=customiseExpressRun2(process)
     process=customiseForRunI(process)
+    process=customiseExpressRun2(process)
     return process
 
 ##############################################################################
@@ -91,7 +91,12 @@ def customisePrompt(process):
     process= customisePPData(process)
 
     #add the lumi producer in the prompt reco only configuration
+    if not hasattr(process,'lumiProducer'):
+        #unscheduled..
+        from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+        process.lumiProducer=lumiProducer
     process.reconstruction_step+=process.lumiProducer
+
     return process
 
 ##############################################################################
@@ -101,8 +106,8 @@ def customisePromptRun2(process):
     return process
 
 def customisePromptRun2B0T(process):
-    process=customisePromptRun2(process)
     process=customiseForRunI(process)
+    process=customisePromptRun2(process)
     return process
 
 
@@ -129,7 +134,12 @@ def customisePromptHI(process):
     process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
 
      #add the lumi producer in the prompt reco only configuration
+    if not hasattr(process,'lumiProducer'):
+        #unscheduled..
+        from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+        process.lumiProducer=lumiProducer
     process.reconstruction_step+=process.lumiProducer
+        
 
     return process
 

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,8 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-#"ppRun2B0T")
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "HeavyIons")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "


### PR DESCRIPTION
Changed the Reco.py in DataProcessing to use the standard customise functionality in ConfigBuilder for better support of unscheduled mode. Contents of fully dumped Tier0 configs are the same (and there are fewer differences between relval and Tier0 now)

Fixed bug in ConfigBuilder to apply unscheduled mode to both the dumped cfg and the process itself (the latter was missing before)
