### PR TITLE
DataFormats/CaloTowers: add missing class

### DIFF
--- a/DataFormats/CaloTowers/src/classes.h
+++ b/DataFormats/CaloTowers/src/classes.h
@@ -11,6 +11,7 @@
 #include "DataFormats/Common/interface/PtrVector.h"
 #include "DataFormats/Common/interface/FwdRef.h"
 #include "DataFormats/Common/interface/FwdPtr.h"
+#include "DataFormats/Common/interface/AtomicPtrCache.h"
 
 
 namespace DataFormats_CaloTowers {
@@ -40,5 +41,6 @@ namespace DataFormats_CaloTowers {
     std::vector<edm::Ptr<CaloTower> > vp1;
 
     std::vector<CaloTowerDetId> vctdi;
+    edm::AtomicPtrCache<std::vector<CaloTowerPtr> > easvrp;
   };
 }

--- a/DataFormats/CaloTowers/src/classes_def.xml
+++ b/DataFormats/CaloTowers/src/classes_def.xml
@@ -34,4 +34,9 @@
   <class name="std::vector<edm::FwdPtr<CaloTower> >"/>
 
   <class name="std::vector<CaloTowerDetId>"/>
+
+  <!--NOTE: the declaration of AtomicPtrCache are a temporary work around until ROOT 6 where they will not be needed -->
+  <class name="edm::AtomicPtrCache<std::vector<CaloTowerPtr> >">
+    <field name="m_data" transient="true"/>
+  </class>
 </lcgdict>

--- a/DataFormats/PatCandidates/BuildFile.xml
+++ b/DataFormats/PatCandidates/BuildFile.xml
@@ -15,6 +15,7 @@
 <use   name="CondFormats/L1TObjects"/>
 <use   name="DataFormats/L1Trigger"/>
 <use   name="DataFormats/HLTReco"/>
+<use   name="DataFormats/CaloTowers"/>
 <use   name="boost"/>
 
 <flags LCG_DICT_HEADER="classes_objects.h classes_trigger.h classes_user.h classes_other.h"/>


### PR DESCRIPTION
While building CMSSW the following warning is generated by ROOT6
run-time:

```
TClass::Init:0: RuntimeWarning: no dictionary for class
edm::AtomicPtrCache<vector<edm::Ptr<CaloTower> > > is available
```

Add missing class `edm::AtomicPtrCache<vector<edm::Ptr<CaloTower> > >`

The only user of this is `DataFormats/PatCandidates`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
