### PR TITLE
Online file-locking improvements (75X)

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -85,7 +85,7 @@ namespace evf{
       void removeFile(unsigned int ls, unsigned int index);
       void removeFile(std::string );
 
-      FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize);
+      FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint64_t& lockWaitTime);
       void tryInitializeFuLockFile();
       unsigned int getRunNumber() const { return run_; }
       unsigned int getJumpLS() const { return jumpLS_; }
@@ -136,6 +136,7 @@ namespace evf{
       bool requireTSPSet_;
       std::string selectedTransferMode_;
       std::string hltSourceDirectory_;
+      unsigned int fuLockPollInterval_;
 
       std::string hostname_;
       std::string run_string_;

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -150,6 +150,7 @@ namespace evf{
       void accumulateFileSize(unsigned int lumi, unsigned long fileSize);
       void startedLookingForFile();
       void stoppedLookingForFile(unsigned int lumi);
+      void reportLockWaitAvg(unsigned int ls, double waitTime);
       unsigned int getEventsProcessedForLumi(unsigned int lumi);
       std::string getRunDirName() const { return runDirectory_.stem().string(); }
 
@@ -227,6 +228,7 @@ namespace evf{
       //helpers for source statistics:
       std::map<unsigned int, unsigned long> accuSize_;
       std::vector<double> leadTimes_;
+      std::map<unsigned int, double> avgLockWaitDuringLumi_;
 
       //for output module
       std::map<unsigned int, unsigned int> processedEventsPerLumi_;

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -140,6 +140,7 @@ namespace evf{
       void preStreamEarlyTermination(edm::StreamContext const&, edm::TerminationOrigin);
       void preGlobalEarlyTermination(edm::GlobalContext const&, edm::TerminationOrigin);
       void preSourceEarlyTermination(edm::TerminationOrigin);
+      void setExceptionDetected(unsigned int ls);
 
       //this is still needed for use in special functions like DQM which are in turn framework services
       void setMicroState(MicroStateService::Microstate);

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -150,7 +150,7 @@ namespace evf{
       void accumulateFileSize(unsigned int lumi, unsigned long fileSize);
       void startedLookingForFile();
       void stoppedLookingForFile(unsigned int lumi);
-      void reportLockWaitAvg(unsigned int ls, double waitTime);
+      void reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount);
       unsigned int getEventsProcessedForLumi(unsigned int lumi);
       std::string getRunDirName() const { return runDirectory_.stem().string(); }
 
@@ -228,7 +228,7 @@ namespace evf{
       //helpers for source statistics:
       std::map<unsigned int, unsigned long> accuSize_;
       std::vector<double> leadTimes_;
-      std::map<unsigned int, double> avgLockWaitDuringLumi_;
+      std::map<unsigned int, std::pair<double,unsigned int>> lockStatsDuringLumi_;
 
       //for output module
       std::map<unsigned int, unsigned int> processedEventsPerLumi_;

--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -26,6 +26,7 @@ namespace evf{
       DoubleJ fastThroughputJ_;
       DoubleJ fastAvgLeadTimeJ_;
       IntJ fastFilesProcessedJ_;
+      DoubleJ fastAvgLockWaitJ_;
 
       unsigned int varIndexThrougput_;
 
@@ -52,10 +53,12 @@ namespace evf{
 	fastThroughputJ_ = 0;
 	fastAvgLeadTimeJ_ = 0;
 	fastFilesProcessedJ_ = 0;
+        fastAvgLockWaitJ_ = 0;
         fastMacrostateJ_.setName("Macrostate");
         fastThroughputJ_.setName("Throughput");
         fastAvgLeadTimeJ_.setName("AverageLeadTime");
 	fastFilesProcessedJ_.setName("FilesProcessed");
+	fastAvgLockWaitJ_.setName("AverageLockWaitTime");
 
         fastPathProcessedJ_ = 0;
         fastPathProcessedJ_.setName("Processed");
@@ -68,6 +71,7 @@ namespace evf{
         fm->registerGlobalMonitorable(&fastThroughputJ_,false);
         fm->registerGlobalMonitorable(&fastAvgLeadTimeJ_,false);
         fm->registerGlobalMonitorable(&fastFilesProcessedJ_,false);
+        fm->registerGlobalMonitorable(&fastAvgLockWaitJ_,false);
 
 	for (unsigned int i=0;i<nStreams;i++) {
 	 AtomicMonUInt * p  = new AtomicMonUInt;

--- a/EventFilter/Utilities/interface/FastMonitoringThread.h
+++ b/EventFilter/Utilities/interface/FastMonitoringThread.h
@@ -26,7 +26,8 @@ namespace evf{
       DoubleJ fastThroughputJ_;
       DoubleJ fastAvgLeadTimeJ_;
       IntJ fastFilesProcessedJ_;
-      DoubleJ fastAvgLockWaitJ_;
+      DoubleJ fastLockWaitJ_;
+      IntJ fastLockCountJ_;
 
       unsigned int varIndexThrougput_;
 
@@ -53,12 +54,14 @@ namespace evf{
 	fastThroughputJ_ = 0;
 	fastAvgLeadTimeJ_ = 0;
 	fastFilesProcessedJ_ = 0;
-        fastAvgLockWaitJ_ = 0;
+        fastLockWaitJ_ = 0;
+        fastLockCountJ_ = 0;
         fastMacrostateJ_.setName("Macrostate");
         fastThroughputJ_.setName("Throughput");
         fastAvgLeadTimeJ_.setName("AverageLeadTime");
 	fastFilesProcessedJ_.setName("FilesProcessed");
-	fastAvgLockWaitJ_.setName("AverageLockWaitTime");
+	fastLockWaitJ_.setName("LockWaitUs");
+	fastLockCountJ_.setName("LockCount");
 
         fastPathProcessedJ_ = 0;
         fastPathProcessedJ_.setName("Processed");
@@ -71,7 +74,8 @@ namespace evf{
         fm->registerGlobalMonitorable(&fastThroughputJ_,false);
         fm->registerGlobalMonitorable(&fastAvgLeadTimeJ_,false);
         fm->registerGlobalMonitorable(&fastFilesProcessedJ_,false);
-        fm->registerGlobalMonitorable(&fastAvgLockWaitJ_,false);
+        fm->registerGlobalMonitorable(&fastLockWaitJ_,false);
+        fm->registerGlobalMonitorable(&fastLockCountJ_,false);
 
 	for (unsigned int i=0;i<nStreams;i++) {
 	 AtomicMonUInt * p  = new AtomicMonUInt;

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -545,6 +545,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
     uint32_t crc=0;
     crc = crc32c(crc,(const unsigned char*)event_->payload(),event_->eventSize());
     if ( crc != event_->crc32c() ) {
+      if (fms_) fms_->setExceptionDetected(currentLumiSection_);
       throw cms::Exception("FedRawDataInputSource::getNextEvent") <<
         "Found a wrong crc32c checksum: expected 0x" << std::hex << event_->crc32c() <<
         " but calculated 0x" << crc;
@@ -556,6 +557,7 @@ inline evf::EvFDaqDirector::FileStatus FedRawDataInputSource::getNextEvent()
     adler = adler32(adler,(Bytef*)event_->payload(),event_->eventSize());
 
     if ( adler != event_->adler32() ) {
+      if (fms_) fms_->setExceptionDetected(currentLumiSection_);
       throw cms::Exception("FedRawDataInputSource::getNextEvent") <<
         "Found a wrong Adler32 checksum: expected 0x" << std::hex << event_->adler32() <<
         " but calculated 0x" << adler;

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -921,7 +921,7 @@ void FedRawDataInputSource::readSupervisor()
       if (ls>monLS) {
           monLS=ls;
           if (lockCount)
-            if (fms_) fms_->reportLockWaitAvg(monLS,double(sumLockWaitTimeUs)/(lockCount*1000000));
+            if (fms_) fms_->reportLockWait(monLS,sumLockWaitTimeUs,lockCount);
           lockCount=0;
           sumLockWaitTimeUs=0;
       }

--- a/EventFilter/Utilities/plugins/microstatedef.jsd
+++ b/EventFilter/Utilities/plugins/microstatedef.jsd
@@ -29,8 +29,13 @@
          "operation" : "sum"
       },
       {
-         "name" : "AverageLockWaitTime",
-         "operation" : "avg"
+         "name" : "LockWaitUs",
+         "operation" : "sum"
+      },
+      {
+         "name" : "LockCount",
+         "operation" : "sum"
       }
+
    ]
 }

--- a/EventFilter/Utilities/plugins/microstatedef.jsd
+++ b/EventFilter/Utilities/plugins/microstatedef.jsd
@@ -27,6 +27,10 @@
       {
       	 "name" : "FilesProcessed",
          "operation" : "sum"
+      },
+      {
+         "name" : "AverageLockWaitTime",
+         "operation" : "avg"
       }
    ]
 }

--- a/EventFilter/Utilities/plugins/microstatedeffast.jsd
+++ b/EventFilter/Utilities/plugins/microstatedeffast.jsd
@@ -29,8 +29,13 @@
          "operation" : "sum"
       },
       {
-         "name" : "AverageLockWaitTime",
-         "operation" : "avg"
+         "name" : "LockWaitUs",
+         "operation" : "sum"
+      },
+      {
+         "name" : "LockCount",
+         "operation" : "sum"
       }
+
    ]
 }

--- a/EventFilter/Utilities/plugins/microstatedeffast.jsd
+++ b/EventFilter/Utilities/plugins/microstatedeffast.jsd
@@ -27,6 +27,10 @@
       {
       	 "name" : "FilesProcessed",
          "operation" : "sum"
+      },
+      {
+         "name" : "AverageLockWaitTime",
+         "operation" : "avg"
       }
    ]
 }

--- a/EventFilter/Utilities/python/EvFDaqDirector_cfi.py
+++ b/EventFilter/Utilities/python/EvFDaqDirector_cfi.py
@@ -6,6 +6,7 @@ EvFDaqDirector = cms.Service( "EvFDaqDirector",
     runNumber = cms.untracked.uint32(0),
     outputAdler32Recheck=cms.untracked.bool(False),
     requireTransfersPSet=cms.untracked.bool(False),
-    selectedTransferMode=cms.untracked.string("")
+    selectedTransferMode=cms.untracked.string(""),
+    fuLockPollInterval = cms.untracked.uint32(2000)
     )
 

--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -28,9 +28,9 @@ namespace evf{
         uint32_t recordLumiSection = record->getHeader().getData().header.lumiSection;
 
         if (recordLumiSection != lumiSection) 
-          edm::LogError("AuxiliaryMakers") << "Lumisection mismatch, external : "<<lumiSection << ", record : " << recordLumiSection; 
+          edm::LogWarning("AuxiliaryMakers") << "Lumisection mismatch, external : "<<lumiSection << ", record : " << recordLumiSection; 
         if ((orbitnr >> 18) + 1 != recordLumiSection)
-          edm::LogError("AuxiliaryMakers") << "Lumisection and orbit number mismatch, LS : " << lumiSection << ", LS from orbit: " << ((orbitnr >> 18) + 1) << ", orbit:" << orbitnr;
+          edm::LogWarning("AuxiliaryMakers") << "Lumisection and orbit number mismatch, LS : " << lumiSection << ", LS from orbit: " << ((orbitnr >> 18) + 1) << ", orbit:" << orbitnr;
 
 	return edm::EventAuxiliary(eventId,
 				   processGUID,

--- a/EventFilter/Utilities/src/AuxiliaryMakers.cc
+++ b/EventFilter/Utilities/src/AuxiliaryMakers.cc
@@ -1,6 +1,7 @@
 #include <sys/time.h>
 
 #include "EventFilter/Utilities/interface/AuxiliaryMakers.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 namespace evf{
   namespace evtn{
@@ -23,7 +24,14 @@ namespace evf{
           time = stv.tv_sec;
           time = (time << 32) + stv.tv_usec;
         }
-	int64_t orbitnr = (((uint64_t)record->getHeader().getData().header.orbitHigh) << 16) + record->getHeader().getData().header.orbitLow;
+	uint64_t orbitnr = (((uint64_t)record->getHeader().getData().header.orbitHigh) << 16) + record->getHeader().getData().header.orbitLow;
+        uint32_t recordLumiSection = record->getHeader().getData().header.lumiSection;
+
+        if (recordLumiSection != lumiSection) 
+          edm::LogError("AuxiliaryMakers") << "Lumisection mismatch, external : "<<lumiSection << ", record : " << recordLumiSection; 
+        if ((orbitnr >> 18) + 1 != recordLumiSection)
+          edm::LogError("AuxiliaryMakers") << "Lumisection and orbit number mismatch, LS : " << lumiSection << ", LS from orbit: " << ((orbitnr >> 18) + 1) << ", orbit:" << orbitnr;
+
 	return edm::EventAuxiliary(eventId,
 				   processGUID,
 				   edm::Timestamp(time),

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -491,6 +491,7 @@ namespace evf {
 	// there is a new file to grab or lumisection ended
 	if (bumpedOk) {
 	  // rewind and clear
+          /*
 	  check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
 	  if (check == 0) {
 	    ftruncate(fu_readwritelock_fd_, 0);
@@ -498,6 +499,7 @@ namespace evf {
 	  } else
 	      edm::LogError("EvFDaqDirector") << "seek on fu read/write lock for updating failed with error "
 	                                      << strerror(errno);
+          */
 	  // write new data
 	  check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
 	  if (check == 0) {
@@ -525,8 +527,8 @@ namespace evf {
 			                     << readIndex + 1;
 
 	  } else
-	      edm::LogError("EvFDaqDirector") << "seek on fu read/write lock for updating failed with error "
-	                                      << strerror(errno);
+	      throw cms::Exception("EvFDaqDirector") << "seek on fu read/write lock for updating failed with error "
+	                                             << strerror(errno);
 	}
       } else
 	edm::LogError("EvFDaqDirector") << "seek on fu read/write lock for reading failed with error "

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -514,8 +514,8 @@ namespace evf {
 	if (bumpedOk) {
 	  // write new data
 	  check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
-	  ftruncate(fu_readwritelock_fd_, 0);
 	  if (check == 0) {
+	    ftruncate(fu_readwritelock_fd_, 0);
 	    // write next index in the file, which is the file the next process should take
 	    if (testModeNoBuilderUnit_) {
 	      fprintf(fu_rw_lock_stream, "%u %u %u %u", readLs,

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -787,7 +787,7 @@ namespace evf {
 
   void EvFDaqDirector::lockFULocal() {
     //fcntl(fulocal_rwlock_fd_, F_SETLKW, &fulocal_rw_flk);
-    flock(fulocal_rwlock_fd_,LOCK_EX);
+    flock(fulocal_rwlock_fd_,LOCK_SH);
   }
 
   void EvFDaqDirector::unlockFULocal() {

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -312,6 +312,7 @@ namespace evf{
 		  avgLeadTime_.erase(oldLumi);
 		  filesProcessedDuringLumi_.erase(oldLumi);
 		  accuSize_.erase(oldLumi);
+		  avgLockWaitDuringLumi_.erase(oldLumi);
 		  processedEventsPerLumi_.erase(oldLumi);
 	  }
 	  lastGlobalLumi_= newLumi;
@@ -588,6 +589,13 @@ namespace evf{
 	  }
   }
 
+  void FastMonitoringService::reportLockWaitAvg(unsigned int ls, double waitTime)
+  {
+          std::lock_guard<std::mutex> lock(fmt_.monlock_);
+	  avgLockWaitDuringLumi_[ls]=waitTime;
+
+  }
+
   //for the output module
   unsigned int FastMonitoringService::getEventsProcessedForLumi(unsigned int lumi) {
     std::lock_guard<std::mutex> lock(fmt_.monlock_);
@@ -620,6 +628,12 @@ namespace evf{
       if (iti != filesProcessedDuringLumi_.end())
 	fmt_.m_data.fastFilesProcessedJ_ = iti->second;
       else fmt_.m_data.fastFilesProcessedJ_=0;
+
+      auto itrd = avgLockWaitDuringLumi_.find(ls);
+      if (itrd != avgLockWaitDuringLumi_.end())
+	fmt_.m_data.fastAvgLockWaitJ_ = itrd->second;
+      else fmt_.m_data.fastAvgLockWaitJ_=0.;
+ 
     }
     else return;
 

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -312,7 +312,7 @@ namespace evf{
 		  avgLeadTime_.erase(oldLumi);
 		  filesProcessedDuringLumi_.erase(oldLumi);
 		  accuSize_.erase(oldLumi);
-		  avgLockWaitDuringLumi_.erase(oldLumi);
+		  lockStatsDuringLumi_.erase(oldLumi);
 		  processedEventsPerLumi_.erase(oldLumi);
 	  }
 	  lastGlobalLumi_= newLumi;
@@ -589,10 +589,10 @@ namespace evf{
 	  }
   }
 
-  void FastMonitoringService::reportLockWaitAvg(unsigned int ls, double waitTime)
+  void reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount);
   {
           std::lock_guard<std::mutex> lock(fmt_.monlock_);
-	  avgLockWaitDuringLumi_[ls]=waitTime;
+	  lockStatsDuringLumi_[ls]=std::pair<double,unsigned int>(waitTime,lockCount);
 
   }
 
@@ -629,10 +629,15 @@ namespace evf{
 	fmt_.m_data.fastFilesProcessedJ_ = iti->second;
       else fmt_.m_data.fastFilesProcessedJ_=0;
 
-      auto itrd = avgLockWaitDuringLumi_.find(ls);
-      if (itrd != avgLockWaitDuringLumi_.end())
-	fmt_.m_data.fastAvgLockWaitJ_ = itrd->second;
-      else fmt_.m_data.fastAvgLockWaitJ_=0.;
+      auto itrd = lockStatsDuringLumi_.find(ls);
+      if (itrd != lockStatsDuringLumi_.end()) {
+	fmt_.m_data.fastLockWaitJ_ = itrd->second.first;
+	fmt_.m_data.fastLockCountJ_ = itrd->second.second;
+      }
+      else {
+       fmt_.m_data.fastLockWaitJ_=0.;
+       fmt_.m_data.fastLockCountJ_=0.;
+      }
  
     }
     else return;

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -589,7 +589,7 @@ namespace evf{
 	  }
   }
 
-  void reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount);
+  void FastMonitoringService::reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount)
   {
           std::lock_guard<std::mutex> lock(fmt_.monlock_);
 	  lockStatsDuringLumi_[ls]=std::pair<double,unsigned int>(waitTime,lockCount);

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -246,6 +246,11 @@ namespace evf{
     exception_detected_=true; 
   }
 
+  void FastMonitoringService::setExceptionDetected(unsigned int ls) {
+    if (!ls) exception_detected_=true;
+    else exceptionInLS_.push_back(ls);
+  }
+
   void FastMonitoringService::jobFailure()
   {
     macrostate_ = FastMonitoringThread::sError;


### PR DESCRIPTION
- removed unnecessary file operations on fu.lock file modification
- configurable fu lock poll interval, reduce default value to 2ms, as it is measured to perform better with NFS over 1-Gbit interfaces in old FUs 
- LOCK_EX can be LOCK_SH when taking local lock and acquiring new index(raw) file. It only needs to remain exclusive when writing EoLS file marker in FU.
- writing lock acquire waiting times statistics in fast monitoring service json (for later injection into elastic)
- print warning if there is mismatch between BU (file) and TCDS record lumisection or orbit number
- explicit report of exception from input source to the fast monitoring service so that output can be suppressed (was not being detected with adler32 exception thrown)
