### PR TITLE
Separate tp emulator parameters for HF.

### DIFF
--- a/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
+++ b/SimCalorimetry/HcalTrigPrimAlgos/interface/HcalTriggerPrimitiveAlgo.h
@@ -22,7 +22,8 @@ public:
   HcalTriggerPrimitiveAlgo(bool pf, const std::vector<double>& w, 
                            int latency,
                            uint32_t FG_threshold, uint32_t ZS_threshold,
-                           int numberOfSamples, int numberOfPresamples,
+                           int numberOfSamples,   int numberOfPresamples,
+                           int numberOfSamplesHF, int numberOfPresamplesHF,
                            uint32_t minSignalThreshold=0, uint32_t PMT_NoiseThreshold=0);
   ~HcalTriggerPrimitiveAlgo();
 
@@ -63,6 +64,8 @@ public:
   int ZS_threshold_I_;
   int numberOfSamples_;
   int numberOfPresamples_;
+  int numberOfSamplesHF_;
+  int numberOfPresamplesHF_;
   uint32_t minSignalThreshold_;
   uint32_t PMT_NoiseThreshold_; 
 

--- a/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
+++ b/SimCalorimetry/HcalTrigPrimAlgos/src/HcalTriggerPrimitiveAlgo.cc
@@ -15,12 +15,15 @@ using namespace std;
 HcalTriggerPrimitiveAlgo::HcalTriggerPrimitiveAlgo( bool pf, const std::vector<double>& w, int latency,
                                                     uint32_t FG_threshold, uint32_t ZS_threshold,
                                                     int numberOfSamples, int numberOfPresamples,
+                                                    int numberOfSamplesHF, int numberOfPresamplesHF,
                                                     uint32_t minSignalThreshold, uint32_t PMT_NoiseThreshold)
                                                    : incoder_(0), outcoder_(0),
                                                    theThreshold(0), peakfind_(pf), weights_(w), latency_(latency),
                                                    FG_threshold_(FG_threshold), ZS_threshold_(ZS_threshold),
                                                    numberOfSamples_(numberOfSamples),
                                                    numberOfPresamples_(numberOfPresamples),
+                                                   numberOfSamplesHF_(numberOfSamplesHF),
+                                                   numberOfPresamplesHF_(numberOfPresamplesHF),
                                                    minSignalThreshold_(minSignalThreshold),
                                                    PMT_NoiseThreshold_(PMT_NoiseThreshold),
                                                    peak_finder_algorithm_(2)
@@ -29,6 +32,8 @@ HcalTriggerPrimitiveAlgo::HcalTriggerPrimitiveAlgo( bool pf, const std::vector<d
    if (!peakfind_){
       numberOfSamples_ = 1; 
       numberOfPresamples_ = 0;
+      numberOfSamplesHF_ = 1; 
+      numberOfPresamplesHF_ = 0;
    }
    // Switch to integer for comparisons - remove compiler warning
    ZS_threshold_I_ = ZS_threshold_;
@@ -262,10 +267,10 @@ void HcalTriggerPrimitiveAlgo::analyzeHF(IntegerCaloSamples & samples, HcalTrigg
 
    // Align digis and TP
    int dgPresamples=samples.presamples(); 
-   int tpPresamples=numberOfPresamples_;
+   int tpPresamples=numberOfPresamplesHF_;
    int shift = dgPresamples - tpPresamples;
    int dgSamples=samples.size();
-   int tpSamples=numberOfSamples_;
+   int tpSamples=numberOfSamplesHF_;
    if(shift<0 || shift+tpSamples>dgSamples){
 	edm::LogInfo("HcalTriggerPrimitiveAlgo::analyzeHF") << 
 	    "TP presample or size from the configuration file is out of the accessible range. Using digi values from data instead...";

--- a/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
+++ b/SimCalorimetry/HcalTrigPrimProducers/python/hcaltpdigi_cfi.py
@@ -8,6 +8,8 @@ simHcalTriggerPrimitiveDigis = cms.EDProducer("HcalTrigPrimDigiProducer",
     ZS_threshold = cms.uint32(1),  ## threshold for setting fine grain bit
     numberOfSamples = cms.int32(4),
     numberOfPresamples = cms.int32(2),
+    numberOfSamplesHF = cms.int32(4),
+    numberOfPresamplesHF = cms.int32(2),
     MinSignalThreshold = cms.uint32(0), # For HF PMT veto
     PMTNoiseThreshold = cms.uint32(0),  # For HF PMT veto
 #

--- a/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
+++ b/SimCalorimetry/HcalTrigPrimProducers/src/HcalTrigPrimDigiProducer.cc
@@ -28,11 +28,13 @@ HcalTrigPrimDigiProducer::HcalTrigPrimDigiProducer(const edm::ParameterSet& ps)
 	  ps.getParameter<std::vector<double> >("weights"),
 	  ps.getParameter<int>("latency"),
 	  ps.getParameter<uint32_t>("FG_threshold"),
-      ps.getParameter<uint32_t>("ZS_threshold"),
+          ps.getParameter<uint32_t>("ZS_threshold"),
 	  ps.getParameter<int>("numberOfSamples"),
 	  ps.getParameter<int>("numberOfPresamples"),
-      ps.getParameter<uint32_t>("MinSignalThreshold"),
-      ps.getParameter<uint32_t>("PMTNoiseThreshold")
+	  ps.getParameter<int>("numberOfSamplesHF"),
+	  ps.getParameter<int>("numberOfPresamplesHF"),
+	  ps.getParameter<uint32_t>("MinSignalThreshold"),
+	  ps.getParameter<uint32_t>("PMTNoiseThreshold")
    ),
   inputLabel_(ps.getParameter<std::vector<edm::InputTag> >("inputLabel")),
   inputTagFEDRaw_(ps.getParameter<edm::InputTag> ("InputTagFEDRaw")),


### PR DESCRIPTION
A small modification to the Hcal TP emulator to pass the “presamples" and “samples” separately for HF. 
This will allow emulating TPs with different values of these parameters for HBHE and HF (which is the case now).
The default values in the configuration file stay the same. 
