### PR TITLE
Fixed checksum upload validation when compressing LHE files

### DIFF
--- a/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
+++ b/GeneratorInterface/LHEInterface/scripts/cmsLHEtoEOSManager.py
@@ -205,12 +205,6 @@ if __name__ == '__main__':
                 print "Important! Input file "+f+" is already zipped: please make sure you verified its integrity with xmllint before zipping it. You can do it with:\n"
                 print "xmllint file.lhe\n"
                 print "Otherwise it is best to pass the unzipped file to this script and let it check its integrity and compress the file with the --compress option\n"
-                exeCheckSum = subprocess.Popen(["/afs/cern.ch/cms/caf/bin/cms_adler32",f], stdout=subprocess.PIPE) 
-                getCheckSum = subprocess.Popen(["awk", "{print $1}"], stdin=exeCheckSum.stdout, stdout=subprocess.PIPE)
-                exeCheckSum.stdout.close()
-                output,err = getCheckSum.communicate()
-              #  print 'orig file checksum = ' + output + '\n'
-                theCheckSumList.append(output)
             # Check the local file existence
             if not os.path.exists(f):
                 raise Exception('Input file '+f+' does not exists')
@@ -218,12 +212,6 @@ if __name__ == '__main__':
                 theCheckIntegrityCommand = 'xmllint -noout '+f
                 exeCheckIntegrity = subprocess.Popen(["/bin/sh","-c", theCheckIntegrityCommand])
                 intCode = exeCheckIntegrity.wait()
-                exeCheckSum = subprocess.Popen(["/afs/cern.ch/cms/caf/bin/cms_adler32",f], stdout=subprocess.PIPE) 
-                getCheckSum = subprocess.Popen(["awk", "{print $1}"], stdin=exeCheckSum.stdout, stdout=subprocess.PIPE)
-                exeCheckSum.stdout.close()
-                output,err = getCheckSum.communicate()
-              #  print 'orig file checksum = ' + output + '\n'
-                theCheckSumList.append(output)
                 if(intCode is not 0):
                     raise Exception('Input file '+f+ ' is corrupted')
             if reallyDoIt and options.compress:
@@ -233,15 +221,15 @@ if __name__ == '__main__':
               theCompressionCommand = 'xz '+f
               exeCompression = subprocess.Popen(["/bin/sh","-c",theCompressionCommand])
               exeCompression.communicate()
-              exeCheckSum = subprocess.Popen(["/afs/cern.ch/cms/caf/bin/cms_adler32",f+".xz"], stdout=subprocess.PIPE) 
-              getCheckSum = subprocess.Popen(["awk", "{print $1}"], stdin=exeCheckSum.stdout, stdout=subprocess.PIPE)
-              exeCheckSum.stdout.close()
-              output,err = getCheckSum.communicate()
-             #  print 'orig file checksum = ' + output + '\n'
-              theCheckSumList.append(output)
               theCompressedFilesList.append(f+'.xz')
         if reallyDoIt and options.compress:
           theList = theCompressedFilesList
+        for f in theList:
+            exeCheckSum = subprocess.Popen(["/afs/cern.ch/cms/caf/bin/cms_adler32",f], stdout=subprocess.PIPE) 
+            getCheckSum = subprocess.Popen(["awk", "{print $1}"], stdin=exeCheckSum.stdout, stdout=subprocess.PIPE)
+            exeCheckSum.stdout.close()
+            output,err = getCheckSum.communicate()
+            theCheckSumList.append(output)
 
     newArt = 0
     uploadPath = ''


### PR DESCRIPTION
Script only gets the checksum of the files being added to EOS.
When compressing LHE files with the previous behavior, the script added a checksum for both the original `.lhe` file and the compressed `.lhe.xz`. Therefore, it would not compare the correct checksum to the file in EOS and and always produce a warning if the compression option was used.

Previously it checked:
eos/file1.lhe.xz <-> local/file1.lhe
eos/file2.lhe.xz <-> local/file1.lhe.xz
eos/file3.lhe.xz <-> local/file2.lhe
eos/file4.lhe.xz <-> local/file2.lhe.xz
etc.

Now it checks
eos/file1.lhe.xz <-> local/file1.lhe.xz
eos/file2.lhe.xz <-> local/file2.lhe.xz
eos/file3.lhe.xz <-> local/file3.lhe.xz
eos/file4.lhe.xz <-> local/file4.lhe.xz
etc.
