### PR TITLE
Refactoring of PoolSource

### DIFF
--- a/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
+++ b/DQM/SiStripMonitorHardware/interface/SiStripSpyEventMatcher.h
@@ -161,7 +161,7 @@ namespace sistrip {
       edm::InputTag reorderedDigisTag_;
       edm::InputTag virginRawDigisTag_;
       uint32_t counterDiffMax_;
-      std::unique_ptr<edm::ProductRegistry> productRegistry_;
+      std::shared_ptr<edm::ProductRegistry> productRegistry_;
       std::unique_ptr<edm::VectorInputSource> const source_;
       std::unique_ptr<edm::ProcessConfiguration> processConfiguration_;
       std::unique_ptr<edm::EventPrincipal> eventPrincipal_;

--- a/DQM/SiStripMonitorHardware/python/SiStripSpyEventMatcher_cfi.py
+++ b/DQM/SiStripMonitorHardware/python/SiStripSpyEventMatcher_cfi.py
@@ -14,10 +14,11 @@ SiStripSpyEventMatcher = cms.EDFilter(
     SpyReorderedDigisTag = cms.InputTag('SiStripSpyDigiConverter','Reordered'),
     SpyVirginRawDigisTag = cms.InputTag('SiStripSpyDigiConverter','VirginRaw'),
     SpySource = cms.SecSource(
-      "PoolSource",
+      "EmbeddedRootSource",
       fileNames = cms.untracked.vstring(
         'SpyFileNameWhichNeedsToBeSet SiStripSpyEventMatcher.SpySource.fileNames'
-        )
+        ),
+        sequential = cms.bool.untracked(True),
       ),
     CounterDiffMaxAllowed = cms.uint32(100)
     )

--- a/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
+++ b/DQM/SiStripMonitorHardware/src/SiStripSpyEventMatcher.cc
@@ -4,8 +4,8 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
+#include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Sources/interface/VectorInputSourceFactory.h"
-#include "FWCore/Framework/interface/InputSourceDescription.h"
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 #include "DataFormats/SiStripDigi/interface/SiStripRawDigi.h"
@@ -65,8 +65,8 @@ namespace sistrip {
     productRegistry_->setFrozen();
 
     eventPrincipal_.reset(new edm::EventPrincipal(source_->productRegistry(),
-                                                  source_->branchIDListHelper(),
-                                                  source_->thinnedAssociationsHelper(),
+                                                  std::make_shared<edm::BranchIDListHelper>(),
+                                                  std::make_shared<edm::ThinnedAssociationsHelper>(),
                                                   *processConfiguration_,
                                                   nullptr));
   }
@@ -74,13 +74,7 @@ namespace sistrip {
   std::unique_ptr<SpyEventMatcher::Source> SpyEventMatcher::constructSource(const edm::ParameterSet& sourceConfig)
   {
     const edm::VectorInputSourceFactory* sourceFactory = edm::VectorInputSourceFactory::get();
-    edm::InputSourceDescription description(edm::ModuleDescription(),
-                                            *productRegistry_,
-                                            std::make_shared<edm::BranchIDListHelper>(),
-                                            std::make_shared<edm::ThinnedAssociationsHelper>(),
-                                            std::make_shared<edm::ActivityRegistry>(),
-                                            -1, -1, -1,
-                                            edm::PreallocationConfiguration());
+    edm::VectorInputSourceDescription description(productRegistry_, edm::PreallocationConfiguration());
     return sourceFactory->makeVectorInputSource(sourceConfig, description);
   }
 
@@ -88,7 +82,7 @@ namespace sistrip {
   {
     size_t fileNameHash = 0U;
     //add spy events to the map until there are none left
-    source_->loopSequential(*eventPrincipal_,fileNameHash,std::numeric_limits<size_t>::max(),boost::bind(&SpyEventMatcher::addNextEventToMap,this,_1));
+    source_->loopOverEvents(*eventPrincipal_,fileNameHash,std::numeric_limits<size_t>::max(),boost::bind(&SpyEventMatcher::addNextEventToMap,this,_1));
     //debug
     std::ostringstream ss;
     ss << "Events with possible matches (eventID,apvAddress): ";

--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -255,7 +255,7 @@ namespace edm {
     // really needed, we should remove them.
 
     std::shared_ptr<ActivityRegistry>           actReg_;
-    std::shared_ptr<ProductRegistry const>      preg_;
+    std::shared_ptr<ProductRegistry>            preg_;
     std::shared_ptr<BranchIDListHelper>         branchIDListHelper_;
     std::shared_ptr<ThinnedAssociationsHelper>  thinnedAssociationsHelper_;
     ServiceToken                                  serviceToken_;

--- a/FWCore/Framework/interface/InputSource.h
+++ b/FWCore/Framework/interface/InputSource.h
@@ -208,9 +208,6 @@ namespace edm {
     /// Accessor for Process Configuration
     ProcessConfiguration const& processConfiguration() const {return moduleDescription().processConfiguration();}
 
-    /// Accessor for primary input source flag
-    bool primary() const {return primary_;}
-
     /// Accessor for global process identifier
     std::string const& processGUID() const {return processGUID_;}
 
@@ -441,7 +438,6 @@ namespace edm {
     std::unique_ptr<ProcessHistoryRegistry> processHistoryRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
-    bool const primary_;
     std::string processGUID_;
     Timestamp time_;
     mutable bool newRun_;

--- a/FWCore/Framework/interface/InputSourceDescription.h
+++ b/FWCore/Framework/interface/InputSourceDescription.h
@@ -28,7 +28,7 @@ namespace edm {
     }
 
     InputSourceDescription(ModuleDescription const& md,
-                           ProductRegistry& preg,
+                           std::shared_ptr<ProductRegistry> preg,
                            std::shared_ptr<BranchIDListHelper> branchIDListHelper,
                            std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
                            std::shared_ptr<ActivityRegistry> areg,
@@ -37,7 +37,7 @@ namespace edm {
                            int maxSecondsUntilRampdown,
                            PreallocationConfiguration const& allocations) :
       moduleDescription_(md),
-      productRegistry_(&preg),
+      productRegistry_(preg),
       branchIDListHelper_(branchIDListHelper),
       thinnedAssociationsHelper_(thinnedAssociationsHelper),
       actReg_(areg),
@@ -48,7 +48,7 @@ namespace edm {
    }
 
     ModuleDescription moduleDescription_;
-    ProductRegistry* productRegistry_;
+    std::shared_ptr<ProductRegistry> productRegistry_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
     std::shared_ptr<ActivityRegistry> actReg_;

--- a/FWCore/Framework/interface/ScheduleItems.h
+++ b/FWCore/Framework/interface/ScheduleItems.h
@@ -54,7 +54,7 @@ namespace edm {
     clear();
 
     std::shared_ptr<ActivityRegistry> actReg_;
-    std::unique_ptr<SignallingProductRegistry> preg_;
+    std::shared_ptr<SignallingProductRegistry> preg_;
     std::shared_ptr<BranchIDListHelper> branchIDListHelper_;
     std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
     std::unique_ptr<ExceptionToActionTable const> act_table_;

--- a/FWCore/Framework/src/EventProcessor.cc
+++ b/FWCore/Framework/src/EventProcessor.cc
@@ -115,7 +115,7 @@ namespace edm {
   std::unique_ptr<InputSource>
   makeInput(ParameterSet& params,
             CommonParams const& common,
-            ProductRegistry& preg,
+            std::shared_ptr<ProductRegistry> preg,
             std::shared_ptr<BranchIDListHelper> branchIDListHelper,
             std::shared_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper,
             std::shared_ptr<ActivityRegistry> areg,
@@ -513,7 +513,7 @@ namespace edm {
     preallocations_ = PreallocationConfiguration{nThreads,nStreams,nConcurrentLumis,nConcurrentRuns};
 
     // initialize the input source
-    input_ = makeInput(*parameterSet, *common, *items.preg_, items.branchIDListHelper_, items.thinnedAssociationsHelper_, items.actReg_, items.processConfiguration_, preallocations_);
+    input_ = makeInput(*parameterSet, *common, items.preg_, items.branchIDListHelper_, items.thinnedAssociationsHelper_, items.actReg_, items.processConfiguration_, preallocations_);
 
     // intialize the Schedule
     schedule_ = items.initSchedule(*parameterSet,subProcessParameterSet.get(),preallocations_,&processContext_);
@@ -521,7 +521,7 @@ namespace edm {
     // set the data members
     act_table_ = std::move(items.act_table_);
     actReg_ = items.actReg_;
-    preg_.reset(items.preg_.release());
+    preg_ = items.preg_;
     branchIDListHelper_ = items.branchIDListHelper_;
     thinnedAssociationsHelper_ = items.thinnedAssociationsHelper_;
     processConfiguration_ = items.processConfiguration_;

--- a/FWCore/Framework/src/InputSource.cc
+++ b/FWCore/Framework/src/InputSource.cc
@@ -20,7 +20,6 @@
 #include "FWCore/ServiceRegistry/interface/StreamContext.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/do_nothing_deleter.h"
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Utilities/interface/TimeOfDay.h"
 
@@ -43,10 +42,6 @@ namespace edm {
           if(count % 100 - lastDigit == 10) return th;
           return (lastDigit == 1 ? st : (lastDigit == 2 ? nd : rd));
         }
-        template <typename T>
-        std::shared_ptr<T> createSharedPtrToStatic(T* ptr) {
-          return std::shared_ptr<T>(ptr, do_nothing_deleter());
-        }
   }
 
   InputSource::InputSource(ParameterSet const& pset, InputSourceDescription const& desc) :
@@ -60,12 +55,11 @@ namespace edm {
       maxSecondsUntilRampdown_(desc.maxSecondsUntilRampdown_),
       processingMode_(RunsLumisAndEvents),
       moduleDescription_(desc.moduleDescription_),
-      productRegistry_(createSharedPtrToStatic<ProductRegistry>(desc.productRegistry_)),
+      productRegistry_(desc.productRegistry_),
       processHistoryRegistry_(new ProcessHistoryRegistry),
       branchIDListHelper_(desc.branchIDListHelper_),
       thinnedAssociationsHelper_(desc.thinnedAssociationsHelper_),
-      primary_(pset.getParameter<std::string>("@module_label") == std::string("@main_input")),
-      processGUID_(primary_ ? createGlobalIdentifier() : std::string()),
+      processGUID_(createGlobalIdentifier()),
       time_(),
       newRun_(true),
       newLumi_(true),
@@ -84,12 +78,8 @@ namespace edm {
     }
     if (maxSecondsUntilRampdown_ > 0) {
       processingStart_ = std::chrono::steady_clock::now();
-  }
-
-    // Secondary input sources currently do not have a product registry.
-    if(primary_) {
-      assert(desc.productRegistry_ != 0);
     }
+
     std::string const defaultMode("RunsLumisAndEvents");
     std::string const runMode("Runs");
     std::string const runLumiMode("RunsAndLumis");

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -147,7 +147,7 @@ namespace edm {
 
     // set the items
     act_table_ = std::move(items.act_table_);
-    preg_.reset(items.preg_.release());
+    preg_ = items.preg_;
     //CMS-THREADING this only works since Run/Lumis are synchronous so when principalCache asks for
     // the reducedProcessHistoryID from a full ProcessHistoryID that registry will not be in use by
     // another thread. We really need to change how this is done in the PrincipalCache.

--- a/FWCore/ParameterSet/python/Types.py
+++ b/FWCore/ParameterSet/python/Types.py
@@ -1385,17 +1385,17 @@ if __name__ == "__main__":
             f = FileInPath("FWCore/ParameterSet/python/Types.py")
             self.assertEqual(f.configValue(), "'FWCore/ParameterSet/python/Types.py'")
         def testSecSource(self):
-            s1 = SecSource("PoolSource", fileNames = vstring("foo.root"))
-            self.assertEqual(s1.type_(), "PoolSource")
+            s1 = SecSource("EmbeddedRootSource", fileNames = vstring("foo.root"))
+            self.assertEqual(s1.type_(), "EmbeddedRootSource")
             self.assertEqual(s1.configValue(),
-"""PoolSource { """+"""
+"""EmbeddedRootSource { """+"""
     vstring fileNames = {
         'foo.root'
     }
 
 }
 """)
-            s1=SecSource("PoolSource",type=int32(1))
+            s1=SecSource("EmbeddedRootSource",type=int32(1))
             self.assertEqual(s1.type.value(),1)
         def testEventID(self):
             eid = EventID(2, 0, 3)

--- a/FWCore/ParameterSet/test/complete.py
+++ b/FWCore/ParameterSet/test/complete.py
@@ -145,7 +145,7 @@ process.looper = cms.Looper("ALooper",
 )
 
 process.mix = cms.EDProducer("MixingModule",
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
       fileNames = cms.untracked.vstring("file:pileup.root")
     ),
     mixtype = cms.string("fixed"),

--- a/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
+++ b/FWCore/PythonParameterSet/test/makepset_t.cppunit.cc
@@ -78,7 +78,7 @@ void testmakepset::secsourceAux() {
   "    fileName = cms.string('file:CumHits.root')\n"
   ")\n"
   "process.mix = cms.EDFilter('MixingModule',\n"
-  "    input = cms.SecSource('PoolSource',\n"
+  "    input = cms.SecSource('EmbeddedRootSource',\n"
   "        fileNames = cms.untracked.vstring('file:pileup.root')\n"
   "    ),\n"
   "    max_bunch = cms.int32(3),\n"
@@ -100,7 +100,7 @@ void testmakepset::secsourceAux() {
   // Make sure this ParameterSet object has the right contents
   edm::ParameterSet const& mixingModuleParams = ps->getParameterSet("mix");
   edm::ParameterSet const& secondarySourceParams = mixingModuleParams.getParameterSet("input");
-  CPPUNIT_ASSERT(secondarySourceParams.getParameter<std::string>("@module_type") == "PoolSource");
+  CPPUNIT_ASSERT(secondarySourceParams.getParameter<std::string>("@module_type") == "EmbeddedRootSource");
   CPPUNIT_ASSERT(secondarySourceParams.getParameter<std::string>("@module_label") == "input");
   CPPUNIT_ASSERT(secondarySourceParams.getUntrackedParameter<std::vector<std::string> >("fileNames")[0] == "file:pileup.root");
 }

--- a/FWCore/Sources/interface/VectorInputSource.h
+++ b/FWCore/Sources/interface/VectorInputSource.h
@@ -6,7 +6,9 @@ VectorInputSource: Abstract interface for vector input sources.
 ----------------------------------------------------------------------*/
 
 #include "DataFormats/Common/interface/SecondaryEventIDAndFileInfo.h"
-#include "FWCore/Framework/interface/InputSource.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryRegistry.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include <memory>
 #include <string>
@@ -18,34 +20,39 @@ namespace CLHEP {
 
 namespace edm {
   class EventPrincipal;
-  struct InputSourceDescription;
-  class LuminosityBlockID;
+  struct VectorInputSourceDescription;
+  class EventID;
   class ParameterSet;
-  class VectorInputSource : public InputSource {
+  class VectorInputSource {
   public:
-    explicit VectorInputSource(ParameterSet const& pset, InputSourceDescription const& desc);
+    explicit VectorInputSource(ParameterSet const& pset, VectorInputSourceDescription const& desc);
     virtual ~VectorInputSource();
 
     template<typename T>
-    size_t loopRandom(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine*);
-    template<typename T>
-    size_t loopSequential(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator);
-    template<typename T>
-    size_t loopRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, size_t number, T eventOperator, CLHEP::HepRandomEngine*);
-    template<typename T>
-    size_t loopSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, size_t number, T eventOperator);
+    size_t loopOverEvents(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* = nullptr, EventID const* id = nullptr);
+
     template<typename T, typename Iterator>
     size_t loopSpecified(EventPrincipal& cache, size_t& fileNameHash, Iterator const& begin, Iterator const& end, T eventOperator);
 
     void dropUnwantedBranches(std::vector<std::string> const& wantedBranches);
+    //
+    /// Called at beginning of job
+    void doBeginJob();
+
+    /// Called at end of job
+    void doEndJob();
+
+    std::shared_ptr<ProductRegistry const> productRegistry() const {return productRegistry_;}
+    ProductRegistry& productRegistryUpdate() const {return *productRegistry_;}
+    ProcessHistoryRegistry const& processHistoryRegistry() const {return *processHistoryRegistry_;}
+    ProcessHistoryRegistry& processHistoryRegistryForUpdate() {return *processHistoryRegistry_;}
 
   private:
 
     void clearEventPrincipal(EventPrincipal& cache);
-    virtual void readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*) = 0;
-    virtual bool readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, CLHEP::HepRandomEngine*) = 0;
-    virtual bool readOneSequential(EventPrincipal& cache, size_t& fileNameHash) = 0;
-    virtual bool readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id) = 0;
+
+  private:
+    virtual bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) = 0;
     virtual void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& event) = 0;
     void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, EventID const& event) {
       SecondaryEventIDAndFileInfo info(event, fileNameHash);
@@ -53,49 +60,19 @@ namespace edm {
     }
 
     virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) = 0;
+    virtual void beginJob() = 0;
+    virtual void endJob() = 0;
+
+    std::shared_ptr<ProductRegistry> productRegistry_;
+    std::unique_ptr<ProcessHistoryRegistry> processHistoryRegistry_;
   };
 
   template<typename T>
-  size_t VectorInputSource::loopRandom(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* engine) {
+  size_t VectorInputSource::loopOverEvents(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator, CLHEP::HepRandomEngine* engine, EventID const* id) {
     size_t i = 0U;
     for(; i < number; ++i) {
       clearEventPrincipal(cache);
-      readOneRandom(cache, fileNameHash, engine);
-      eventOperator(cache, fileNameHash);
-    }
-    return i;
-  }
-
-  template<typename T>
-  size_t VectorInputSource::loopSequential(EventPrincipal& cache, size_t& fileNameHash, size_t number, T eventOperator) {
-    size_t i = 0U;
-    for(; i < number; ++i) {
-      clearEventPrincipal(cache);
-      bool found = readOneSequential(cache, fileNameHash);
-      if(!found) break;
-      eventOperator(cache, fileNameHash);
-    }
-    return i;
-  }
-
-  template<typename T>
-  size_t VectorInputSource::loopRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, size_t number, T eventOperator, CLHEP::HepRandomEngine* engine) {
-    size_t i = 0U;
-    for(; i < number; ++i) {
-      clearEventPrincipal(cache);
-      bool found = readOneRandomWithID(cache, fileNameHash, id, engine);
-      if(!found) break;
-      eventOperator(cache, fileNameHash);
-    }
-    return i;
-  }
-
-  template<typename T>
-  size_t VectorInputSource::loopSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, size_t number, T eventOperator) {
-    size_t i = 0U;
-    for(; i < number; ++i) {
-      clearEventPrincipal(cache);
-      bool found = readOneSequentialWithID(cache, fileNameHash, id);
+      bool found = readOneEvent(cache, fileNameHash, engine, id);
       if(!found) break;
       eventOperator(cache, fileNameHash);
     }

--- a/FWCore/Sources/interface/VectorInputSourceDescription.h
+++ b/FWCore/Sources/interface/VectorInputSourceDescription.h
@@ -1,0 +1,32 @@
+#ifndef FWCore_Sources_VectorInputSourceDescription_h
+#define FWCore_Sources_VectorInputSourceDescription_h
+
+/*----------------------------------------------------------------------
+
+VectorInputSourceDescription : the stuff that is needed to configure
+a VectorinputSource that does not come in through the ParameterSet  
+----------------------------------------------------------------------*/
+
+#include "FWCore/Framework/src/PreallocationConfiguration.h"
+
+#include <memory>
+
+namespace edm {
+  class PreallocationConfiguration;
+  class ProductRegistry;
+
+  struct VectorInputSourceDescription {
+    VectorInputSourceDescription() :
+      productRegistry_(nullptr) {
+    }
+
+    VectorInputSourceDescription(std::shared_ptr<ProductRegistry> preg, PreallocationConfiguration const& allocations) :
+      productRegistry_(preg), allocations_(&allocations) {
+    }
+
+    std::shared_ptr<ProductRegistry> productRegistry_;
+    PreallocationConfiguration const* allocations_;
+  };
+}
+
+#endif

--- a/FWCore/Sources/interface/VectorInputSourceFactory.h
+++ b/FWCore/Sources/interface/VectorInputSourceFactory.h
@@ -8,10 +8,10 @@
 #include <string>
 
 namespace edm {
-  struct InputSourceDescription;
+  struct VectorInputSourceDescription;
   class ParameterSet;
 
-  typedef VectorInputSource* (ISVecFunc)(ParameterSet const&, InputSourceDescription const&);
+  typedef VectorInputSource* (ISVecFunc)(ParameterSet const&, VectorInputSourceDescription const&);
   typedef edmplugin::PluginFactory<ISVecFunc> VectorInputSourcePluginFactory;
 
   class VectorInputSourceFactory {
@@ -22,7 +22,7 @@ namespace edm {
 
     std::unique_ptr<VectorInputSource>
       makeVectorInputSource(ParameterSet const&,
-                            InputSourceDescription const&) const;
+                            VectorInputSourceDescription const&) const;
 
   private:
     VectorInputSourceFactory();

--- a/FWCore/Sources/src/VectorInputSource.cc
+++ b/FWCore/Sources/src/VectorInputSource.cc
@@ -1,12 +1,17 @@
 /*----------------------------------------------------------------------
 ----------------------------------------------------------------------*/
 #include "FWCore/Sources/interface/VectorInputSource.h"
+#include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 
 namespace edm {
 
-  VectorInputSource::VectorInputSource(ParameterSet const& pset, InputSourceDescription const& desc) :
-    InputSource(pset, desc) {}
+  struct VectorInputSourceDescription;
+
+  VectorInputSource::VectorInputSource(ParameterSet const& pset, VectorInputSourceDescription const& desc) : 
+      productRegistry_(desc.productRegistry_),
+      processHistoryRegistry_(new ProcessHistoryRegistry) {
+  }
 
   VectorInputSource::~VectorInputSource() {}
 
@@ -19,4 +24,15 @@ namespace edm {
   VectorInputSource::clearEventPrincipal(EventPrincipal& cache) {
     cache.clearEventPrincipal();
   }
+
+  void
+  VectorInputSource::doBeginJob() {
+    this->beginJob();
+  }
+
+  void
+  VectorInputSource::doEndJob() {
+    this->endJob();
+  }
+
 }

--- a/FWCore/Sources/src/VectorInputSourceFactory.cc
+++ b/FWCore/Sources/src/VectorInputSourceFactory.cc
@@ -1,4 +1,5 @@
 
+#include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Sources/interface/VectorInputSourceFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
@@ -28,7 +29,7 @@ namespace edm {
 
   std::unique_ptr<VectorInputSource>
   VectorInputSourceFactory::makeVectorInputSource(ParameterSet const& conf,
-					InputSourceDescription const& desc) const {
+					VectorInputSourceDescription const& desc) const {
     std::string modtype = conf.getParameter<std::string>("@module_type");
     FDEBUG(1) << "VectorInputSourceFactory: module_type = " << modtype << std::endl;
     std::unique_ptr<VectorInputSource> wm(VectorInputSourcePluginFactory::get()->create(modtype,conf,desc));

--- a/IOPool/Input/src/EmbeddedRootSource.cc
+++ b/IOPool/Input/src/EmbeddedRootSource.cc
@@ -1,0 +1,68 @@
+/*----------------------------------------------------------------------
+----------------------------------------------------------------------*/
+#include "EmbeddedRootSource.h"
+#include "InputFile.h"
+#include "RootEmbeddedFileSequence.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/Sources/interface/VectorInputSourceDescription.h"
+
+namespace edm {
+
+  class EventID;
+  class EventPrincipal;
+
+  EmbeddedRootSource::EmbeddedRootSource(ParameterSet const& pset, VectorInputSourceDescription const& desc) :
+    VectorInputSource(pset, desc),
+    rootServiceChecker_(),
+    catalog_(pset.getUntrackedParameter<std::vector<std::string> >("fileNames"),
+      pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
+    fileSequence_(new RootEmbeddedFileSequence(pset, *this, catalog_, desc.allocations_->numberOfStreams())) {
+  }
+
+  EmbeddedRootSource::~EmbeddedRootSource() {}
+
+  void
+  EmbeddedRootSource::beginJob() {
+  }
+
+  void
+  EmbeddedRootSource::endJob() {
+    fileSequence_->endJob();
+    InputFile::reportReadBranches();
+  }
+
+  void EmbeddedRootSource::closeFile_() {
+    fileSequence_->closeFile_();
+  }
+
+  bool
+  EmbeddedRootSource::readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine, EventID const* id) {
+    return fileSequence_->readOneEvent(cache, fileNameHash, engine, id);
+  }
+
+  void
+  EmbeddedRootSource::readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id) {
+    fileSequence_->readOneSpecified(cache, fileNameHash, id);
+  }
+
+  void
+  EmbeddedRootSource::dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) {
+    fileSequence_->dropUnwantedBranches_(wantedBranches);
+  }
+
+  void
+  EmbeddedRootSource::fillDescriptions(ConfigurationDescriptions& descriptions) {
+
+    ParameterSetDescription desc;
+
+    std::vector<std::string> defaultStrings;
+    desc.setComment("Reads EDM/Root files for mixing.");
+    desc.addUntracked<std::vector<std::string> >("fileNames")
+        ->setComment("Names of files to be processed.");
+    desc.addUntracked<std::string>("overrideCatalog", std::string());
+    RootEmbeddedFileSequence::fillDescription(desc);
+
+    descriptions.add("source", desc);
+  }
+}

--- a/IOPool/Input/src/EmbeddedRootSource.h
+++ b/IOPool/Input/src/EmbeddedRootSource.h
@@ -1,0 +1,54 @@
+#ifndef IOPool_Input_EmbeddedRootSource_h
+#define IOPool_Input_EmbeddedRootSource_h
+
+/*----------------------------------------------------------------------
+
+EmbeddedRootSource: This is an InputSource
+
+----------------------------------------------------------------------*/
+
+#include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Sources/interface/VectorInputSource.h"
+#include "IOPool/Common/interface/RootServiceChecker.h"
+
+#include <array>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
+namespace edm {
+
+  class ConfigurationDescriptions;
+  class FileCatalogItem;
+  class RootEmbeddedFileSequence;
+  struct VectorInputSourceDescription;
+
+  class EmbeddedRootSource : public VectorInputSource {
+  public:
+    explicit EmbeddedRootSource(ParameterSet const& pset, VectorInputSourceDescription const& desc);
+    virtual ~EmbeddedRootSource();
+    using VectorInputSource::processHistoryRegistryForUpdate;
+    using VectorInputSource::productRegistryUpdate;
+
+    static void fillDescriptions(ConfigurationDescriptions & descriptions);
+
+  private:
+    virtual void closeFile_();
+    virtual void beginJob();
+    virtual void endJob();
+    virtual bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id) override;
+    virtual void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id);
+    virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
+    
+    RootServiceChecker rootServiceChecker_;
+    InputFileCatalog catalog_;
+    std::unique_ptr<RootEmbeddedFileSequence> fileSequence_;
+    
+  }; // class EmbeddedRootSource
+}
+#endif

--- a/IOPool/Input/src/Module.cc
+++ b/IOPool/Input/src/Module.cc
@@ -1,10 +1,9 @@
 #include "FWCore/Framework/interface/InputSourceMacros.h"
 #include "FWCore/Sources/interface/VectorInputSourceMacros.h"
 #include "PoolSource.h"
+#include "EmbeddedRootSource.h"
 
 using edm::PoolSource;
-using edm::PoolRASource;
+using edm::EmbeddedRootSource;
 DEFINE_FWK_INPUT_SOURCE(PoolSource);
-DEFINE_FWK_VECTOR_INPUT_SOURCE(PoolSource);
-DEFINE_FWK_INPUT_SOURCE(PoolRASource);
-DEFINE_FWK_VECTOR_INPUT_SOURCE(PoolRASource);
+DEFINE_FWK_VECTOR_INPUT_SOURCE(EmbeddedRootSource);

--- a/IOPool/Input/src/PoolSource.cc
+++ b/IOPool/Input/src/PoolSource.cc
@@ -2,9 +2,11 @@
 ----------------------------------------------------------------------*/
 #include "PoolSource.h"
 #include "InputFile.h"
-#include "RootInputFileSequence.h"
+#include "RootPrimaryFileSequence.h"
+#include "RootSecondaryFileSequence.h"
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/IndexIntoFile.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
@@ -20,7 +22,6 @@
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/Exception.h"
 #include "FWCore/Utilities/interface/InputType.h"
-#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #include <set>
 
@@ -61,31 +62,26 @@ namespace edm {
   }
 
   PoolSource::PoolSource(ParameterSet const& pset, InputSourceDescription const& desc) :
-    VectorInputSource(pset, desc),
+    InputSource(pset, desc),
     rootServiceChecker_(),
     catalog_(pset.getUntrackedParameter<std::vector<std::string> >("fileNames"),
       pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
     secondaryCatalog_(pset.getUntrackedParameter<std::vector<std::string> >("secondaryFileNames", std::vector<std::string>()),
       pset.getUntrackedParameter<std::string>("overrideCatalog", std::string())),
-    primaryFileSequence_(new RootInputFileSequence(pset, *this, catalog_, desc.allocations_->numberOfStreams(),
-                                                   primary() ? InputType::Primary : InputType::SecondarySource)),
+    primaryFileSequence_(new RootPrimaryFileSequence(pset, *this, catalog_, desc.allocations_->numberOfStreams())),
     secondaryFileSequence_(secondaryCatalog_.empty() ? nullptr :
-                           new RootInputFileSequence(pset, *this, secondaryCatalog_, desc.allocations_->numberOfStreams(),
-                           InputType::SecondaryFile)),
+                           new RootSecondaryFileSequence(pset, *this, secondaryCatalog_, desc.allocations_->numberOfStreams())),
     secondaryRunPrincipal_(),
     secondaryLumiPrincipal_(),
     secondaryEventPrincipals_(),
     branchIDsToReplace_(),
-    resourceSharedWithDelayedReaderPtr_(primary()?
-                                        new SharedResourcesAcquirer{SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()}:
-                                        static_cast<SharedResourcesAcquirer*>(nullptr))
+    resourceSharedWithDelayedReaderPtr_(new SharedResourcesAcquirer{SharedResourcesRegistry::instance()->createAcquirerForSourceDelayedReader()})
   {
     if (secondaryCatalog_.empty() && pset.getUntrackedParameter<bool>("needSecondaryFileNames", false)) {
       throw Exception(errors::Configuration, "PoolSource") << "'secondaryFileNames' must be specified\n";
     }
     if(secondaryFileSequence_) {
       unsigned int nStreams = desc.allocations_->numberOfStreams();
-      assert(primary());
       secondaryEventPrincipals_.reserve(nStreams);
       for(unsigned int index = 0; index < nStreams; ++index) {
         secondaryEventPrincipals_.emplace_back(new EventPrincipal(secondaryFileSequence_->fileProductRegistry(),
@@ -178,11 +174,11 @@ namespace edm {
       if(found) {
         std::shared_ptr<RunAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readRunAuxiliary_();
         checkConsistency(runPrincipal.aux(), *secondaryAuxiliary);
-        secondaryRunPrincipal_.reset(new RunPrincipal(secondaryAuxiliary,
+        secondaryRunPrincipal_ = std::make_shared<RunPrincipal>(secondaryAuxiliary,
                                                       secondaryFileSequence_->fileProductRegistry(),
                                                       processConfiguration(),
                                                       nullptr,
-                                                      runPrincipal.index()));
+                                                      runPrincipal.index());
         secondaryFileSequence_->readRun_(*secondaryRunPrincipal_);
         checkHistoryConsistency(runPrincipal, *secondaryRunPrincipal_);
         runPrincipal.recombine(*secondaryRunPrincipal_, branchIDsToReplace_[InRun]);
@@ -202,11 +198,11 @@ namespace edm {
       if(found) {
         std::shared_ptr<LuminosityBlockAuxiliary> secondaryAuxiliary = secondaryFileSequence_->readLuminosityBlockAuxiliary_();
         checkConsistency(lumiPrincipal.aux(), *secondaryAuxiliary);
-        secondaryLumiPrincipal_.reset(new LuminosityBlockPrincipal(secondaryAuxiliary,
+        secondaryLumiPrincipal_ = std::make_shared<LuminosityBlockPrincipal>(secondaryAuxiliary,
                                                                    secondaryFileSequence_->fileProductRegistry(),
                                                                    processConfiguration(),
                                                                    nullptr,
-                                                                   lumiPrincipal.index()));
+                                                                   lumiPrincipal.index());
         secondaryFileSequence_->readLuminosityBlock_(*secondaryLumiPrincipal_);
         checkHistoryConsistency(lumiPrincipal, *secondaryLumiPrincipal_);
         lumiPrincipal.recombine(*secondaryLumiPrincipal_, branchIDsToReplace_[InLumi]);
@@ -294,42 +290,6 @@ namespace edm {
   }
 
   void
-  PoolSource::readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine) {
-    assert(!secondaryFileSequence_);
-    primaryFileSequence_->readOneRandom(cache, fileNameHash, engine);
-  }
-
-  bool
-  PoolSource::readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& lumiID, CLHEP::HepRandomEngine* engine) {
-    assert(!secondaryFileSequence_);
-    return primaryFileSequence_->readOneRandomWithID(cache, fileNameHash, lumiID, engine);
-  }
-
-  bool
-  PoolSource::readOneSequential(EventPrincipal& cache, size_t& fileNameHash) {
-    assert(!secondaryFileSequence_);
-    return primaryFileSequence_->readOneSequential(cache, fileNameHash);
-  }
-
-  bool
-  PoolSource::readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& lumiID) {
-    assert(!secondaryFileSequence_);
-    return primaryFileSequence_->readOneSequentialWithID(cache, fileNameHash, lumiID);
-  }
-
-  void
-  PoolSource::readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id) {
-    assert(!secondaryFileSequence_);
-    primaryFileSequence_->readOneSpecified(cache, fileNameHash, id);
-  }
-
-  void
-  PoolSource::dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) {
-    assert(!secondaryFileSequence_);
-    primaryFileSequence_->dropUnwantedBranches_(wantedBranches);
-  }
-
-  void
   PoolSource::fillDescriptions(ConfigurationDescriptions & descriptions) {
 
     ParameterSetDescription desc;
@@ -343,8 +303,8 @@ namespace edm {
     desc.addUntracked<bool>("needSecondaryFileNames", false)
         ->setComment("If True, 'secondaryFileNames' must be specified and be non-empty.");
     desc.addUntracked<std::string>("overrideCatalog", std::string());
-    VectorInputSource::fillDescription(desc);
-    RootInputFileSequence::fillDescription(desc);
+    InputSource::fillDescription(desc);
+    RootPrimaryFileSequence::fillDescription(desc);
 
     descriptions.add("source", desc);
   }

--- a/IOPool/Input/src/PoolSource.h
+++ b/IOPool/Input/src/PoolSource.h
@@ -11,7 +11,7 @@ PoolSource: This is an InputSource
 #include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/ProcessingController.h"
-#include "FWCore/Sources/interface/VectorInputSource.h"
+#include "FWCore/Framework/interface/InputSource.h"
 #include "IOPool/Common/interface/RootServiceChecker.h"
 
 #include <array>
@@ -19,24 +19,21 @@ PoolSource: This is an InputSource
 #include <string>
 #include <vector>
 
-namespace CLHEP {
-  class HepRandomEngine;
-}
-
 namespace edm {
 
   class ConfigurationDescriptions;
   class FileCatalogItem;
-  class RootInputFileSequence;
+  class RootPrimaryFileSequence;
+  class RootSecondaryFileSequence;
 
-  class PoolSource : public VectorInputSource {
+  class PoolSource : public InputSource {
   public:
     explicit PoolSource(ParameterSet const& pset, InputSourceDescription const& desc);
     virtual ~PoolSource();
     using InputSource::processHistoryRegistryForUpdate;
     using InputSource::productRegistryUpdate;
 
-    static void fillDescriptions(ConfigurationDescriptions & descriptions);
+    static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
   private:
     virtual void readEvent_(EventPrincipal& eventPrincipal);
@@ -52,25 +49,18 @@ namespace edm {
     virtual void skip(int offset);
     virtual bool goToEvent_(EventID const& eventID);
     virtual void rewind_();
-    virtual void readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*) override;
-    virtual bool readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& lumiID, CLHEP::HepRandomEngine*) override;
-    virtual bool readOneSequential(EventPrincipal& cache, size_t& fileNameHash);
-    virtual bool readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& lumiID);
-    virtual void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id);
-    virtual void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
     virtual void preForkReleaseResources();
     virtual bool randomAccess_() const;
     virtual ProcessingController::ForwardState forwardState_() const;
     virtual ProcessingController::ReverseState reverseState_() const;
 
     SharedResourcesAcquirer* resourceSharedWithDelayedReader_() const override;
-
     
     RootServiceChecker rootServiceChecker_;
     InputFileCatalog catalog_;
     InputFileCatalog secondaryCatalog_;
-    std::unique_ptr<RootInputFileSequence> primaryFileSequence_;
-    std::unique_ptr<RootInputFileSequence> secondaryFileSequence_;
+    std::unique_ptr<RootPrimaryFileSequence> primaryFileSequence_;
+    std::unique_ptr<RootSecondaryFileSequence> secondaryFileSequence_;
     std::shared_ptr<RunPrincipal> secondaryRunPrincipal_;
     std::shared_ptr<LuminosityBlockPrincipal> secondaryLumiPrincipal_;
     std::vector<std::unique_ptr<EventPrincipal>> secondaryEventPrincipals_;
@@ -78,6 +68,5 @@ namespace edm {
     
     std::unique_ptr<SharedResourcesAcquirer> resourceSharedWithDelayedReaderPtr_;
   }; // class PoolSource
-  typedef PoolSource PoolRASource;
 }
 #endif

--- a/IOPool/Input/src/RootEmbeddedFileSequence.cc
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.cc
@@ -1,0 +1,377 @@
+/*----------------------------------------------------------------------
+----------------------------------------------------------------------*/
+#include "EmbeddedRootSource.h"
+#include "InputFile.h"
+#include "RootFile.h"
+#include "RootEmbeddedFileSequence.h"
+#include "RootTree.h"
+
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
+#include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+
+#include "CLHEP/Random/RandFlat.h"
+
+#include <random>
+
+namespace edm {
+  class EventPrincipal;
+
+  RootEmbeddedFileSequence::RootEmbeddedFileSequence(
+                ParameterSet const& pset,
+                EmbeddedRootSource& input,
+                InputFileCatalog const& catalog,
+                unsigned int nStreams) :
+    RootInputFileSequence(pset, catalog),
+    input_(input),
+    orderedProcessHistoryIDs_(),
+    nStreams_(nStreams),
+    sequential_(pset.getUntrackedParameter<bool>("sequential", false)),
+    sameLumiBlock_(pset.getUntrackedParameter<bool>("sameLumiBlock", false)),
+    fptr_(nullptr),
+    eventsRemainingInFile_(0),
+    // The default value provided as the second argument to the getUntrackedParameter function call
+    // is not used when the ParameterSet has been validated and the parameters are not optional
+    // in the description.  This is currently true when PoolSource is the primary input source.
+    // The modules that use PoolSource as a SecSource have not defined their fillDescriptions function
+    // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
+    // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
+    // and should be deleted from the code.
+    initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0U)),
+    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
+    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
+    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
+    productSelectorRules_(pset, "inputCommands", "InputSource"),
+    enablePrefetching_(false) {
+
+    if(noFiles()) {
+      throw Exception(errors::Configuration) << "RootEmbeddedFileSequence no input files specified for secondary input source.\n";
+    }
+    //
+    // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
+    Service<SiteLocalConfig> pSLC;
+    if(pSLC.isAvailable()) {
+      enablePrefetching_ = pSLC->enablePrefetching();
+    }
+
+    // Set the pointer to the function that reads an event.
+    if(sameLumiBlock_) {
+      if(sequential_) {
+        fptr_ = &RootEmbeddedFileSequence::readOneSequentialWithID;
+      } else {
+        fptr_ = &RootEmbeddedFileSequence::readOneRandomWithID;
+      }
+    } else {
+      if(sequential_) {
+        fptr_ = &RootEmbeddedFileSequence::readOneSequential;
+      } else {
+        fptr_ = &RootEmbeddedFileSequence::readOneRandom;
+      }
+    }
+
+    // For the secondary input source we do not stage in.
+    if(sequential_) {
+      // We open the first file
+      if(!atFirstFile()) {
+        setAtFirstFile();
+        initFile(false);
+      }
+      assert(rootFile());
+      rootFile()->setAtEventEntry(IndexIntoFile::invalidEntry);
+      if(!sameLumiBlock_) {
+        skipEntries(initialNumberOfEventsToSkip_);
+      }
+    } else {
+      // We randomly choose the first file to open.
+      // We cannot use the random number service yet.
+      std::ifstream f("/dev/urandom");
+      unsigned int seed;
+      f.read(reinterpret_cast<char*>(&seed), sizeof(seed)); 
+      std::default_random_engine dre(seed);
+      size_t count = numberOfFiles();
+      std::uniform_int_distribution<int> distribution(0, count - 1);
+      while(!rootFile() && count != 0) {
+        --count;
+        int offset = distribution(dre);
+        setAtFileSequenceNumber(offset);
+        initFile(skipBadFiles_);
+      }
+    }
+    if(rootFile()) {
+      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList());
+    }
+  }
+
+  RootEmbeddedFileSequence::~RootEmbeddedFileSequence() {
+  }
+
+  void
+  RootEmbeddedFileSequence::endJob() {
+    closeFile_();
+  }
+
+  void RootEmbeddedFileSequence::closeFile_() {
+    // delete the RootFile object.
+    if(rootFile()) {
+      rootFile().reset();
+    }
+  }
+
+  void RootEmbeddedFileSequence::initFile_(bool skipBadFiles) {
+    initTheFile(skipBadFiles, false, nullptr, "mixingFiles", InputType::SecondarySource);
+  }
+
+  RootEmbeddedFileSequence::RootFileSharedPtr
+  RootEmbeddedFileSequence::makeRootFile(std::shared_ptr<InputFile> filePtr) {
+    size_t currentIndexIntoFile = sequenceNumberOfFile();
+    return std::make_shared<RootFile>(
+          fileName(),
+          ProcessConfiguration(),
+          logicalFileName(),
+          filePtr,
+          nullptr, // eventSkipperByID_
+          false,   // initialNumberOfEventsToSkip_ != 0 (not used)
+          -1,      // remainingEvents() 
+          -1,      // remainingLuminosityBlocks()
+	  nStreams_,
+          0U,      // treeCacheSize_
+          treeMaxVirtualSize_,
+          InputSource::RunsLumisAndEvents,
+          0U,      // setRun_
+          false,   // noEventSort_
+          productSelectorRules_,
+          InputType::SecondarySource,
+          std::make_shared<BranchIDListHelper>(),
+          std::make_shared<ThinnedAssociationsHelper>(),
+          std::vector<BranchID>(), // associationsFromSecondary_
+          nullptr, // duplicateChecker_
+          false,   // dropDescendants_
+          input_.processHistoryRegistryForUpdate(),
+          indexesIntoFiles(),
+          currentIndexIntoFile,
+          orderedProcessHistoryIDs_,
+          bypassVersionCheck_,
+          false,   // labelRawDataLikeMC_
+          false,   // usingGoToEvent_
+          enablePrefetching_);
+  }
+
+  void
+  RootEmbeddedFileSequence::dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) {
+    std::vector<std::string> rules;
+    rules.reserve(wantedBranches.size() + 1);
+    rules.emplace_back("drop *");
+    for(std::string const& branch : wantedBranches) {
+      rules.push_back("keep " + branch + "_*");
+    }
+    ParameterSet pset;
+    pset.addUntrackedParameter("inputCommands", rules);
+    productSelectorRules_ = ProductSelectorRules(pset, "inputCommands", "InputSource");
+  }
+
+  void
+  RootEmbeddedFileSequence::skipEntries(unsigned int offset) {
+    // offset is decremented by the number of events actually skipped.
+    bool completed = rootFile()->skipEntries(offset);
+    while(!completed) {
+      setAtNextFile();
+      if(noMoreFiles()) {
+        setAtFirstFile();
+      }
+      initFile(false);
+      assert(rootFile());
+      rootFile()->setAtEventEntry(IndexIntoFile::invalidEntry);
+      completed = rootFile()->skipEntries(offset);
+    }
+  }
+
+  bool
+  RootEmbeddedFileSequence::readOneSequential(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*) {
+    skipBadFiles_ = false;
+    assert(rootFile());
+    rootFile()->nextEventEntry();
+    bool found = rootFile()->readCurrentEvent(cache);
+    if(!found) {
+      setAtNextFile();
+      if(noMoreFiles()) {
+        setAtFirstFile();
+      }
+      initFile(false);
+      assert(rootFile());
+      rootFile()->setAtEventEntry(IndexIntoFile::invalidEntry);
+      return readOneSequential(cache, fileNameHash, nullptr, nullptr);
+    }
+    fileNameHash = lfnHash();
+    return true;
+  }
+
+  bool
+  RootEmbeddedFileSequence::readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* idp) {
+    assert(idp);
+    EventID const& id = *idp;
+    skipBadFiles_ = false;
+    int offset = initialNumberOfEventsToSkip_;
+    initialNumberOfEventsToSkip_ = 0;
+    if(offset > 0) {
+      assert(rootFile());
+      while(offset > 0) {
+        bool found = readOneSequentialWithID(cache, fileNameHash, nullptr, idp);
+        if(!found) {
+          return false;
+        }
+        --offset;
+      }
+    }
+    assert(rootFile());
+    if(noMoreFiles() ||
+        rootFile()->indexIntoFileIter().run() != id.run() ||
+        rootFile()->indexIntoFileIter().lumi() != id.luminosityBlock()) {
+      bool found = skipToItem(id.run(), id.luminosityBlock(), 0, 0, false);
+      if(!found) {
+        return false;
+      }
+    }
+    assert(rootFile());
+    bool found = rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
+    if(found) {
+      found = rootFile()->readCurrentEvent(cache);
+    }
+    if(!found) {
+      found = skipToItemInNewFile(id.run(), id.luminosityBlock(), 0);
+      if(!found) {
+        return false;
+      }
+      return readOneSequentialWithID(cache, fileNameHash, nullptr, idp);
+    }
+    fileNameHash = lfnHash();
+    return true;
+  }
+
+  void
+  RootEmbeddedFileSequence::readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& idx) {
+    skipBadFiles_ = false;
+    EventID const& id = idx.eventID();
+    bool found = skipToItem(id.run(), id.luminosityBlock(), id.event(), idx.fileNameHash());
+    if(!found) {
+       throw Exception(errors::NotFound) <<
+         "RootEmbeddedFileSequence::readOneSpecified(): Secondary Input files" <<
+         " do not contain specified event:\n" << id << "\n";
+    }
+    assert(rootFile());
+    found = rootFile()->readCurrentEvent(cache);
+    assert(found);
+    fileNameHash = idx.fileNameHash();
+    if(fileNameHash == 0U)  {
+      fileNameHash = lfnHash();
+    }
+  }
+
+  bool
+  RootEmbeddedFileSequence::readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine, EventID const*) {
+    assert(rootFile());
+    assert(engine);
+    skipBadFiles_ = false;
+    unsigned int currentSeqNumber = sequenceNumberOfFile();
+    while(eventsRemainingInFile_ == 0) {
+
+      unsigned int newSeqNumber = CLHEP::RandFlat::shootInt(engine, fileCatalogItems().size());
+      setAtFileSequenceNumber(newSeqNumber);
+      if(newSeqNumber != currentSeqNumber) {
+        initFile(false);
+        currentSeqNumber = newSeqNumber;
+      }
+      eventsRemainingInFile_ = rootFile()->eventTree().entries();
+      if(eventsRemainingInFile_ == 0) {
+        throw Exception(errors::NotFound) <<
+           "RootEmbeddedFileSequence::readOneRandom(): Secondary Input file " << fileName() << " contains no events.\n";
+      }
+      rootFile()->setAtEventEntry(CLHEP::RandFlat::shootInt(engine, eventsRemainingInFile_) - 1);
+    }
+    rootFile()->nextEventEntry();
+
+    bool found = rootFile()->readCurrentEvent(cache);
+    if(!found) {
+      rootFile()->setAtEventEntry(0);
+      bool found = rootFile()->readCurrentEvent(cache);
+      assert(found);
+    }
+    fileNameHash = lfnHash();
+    --eventsRemainingInFile_;
+    return true;
+  }
+
+  bool
+  RootEmbeddedFileSequence::readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine, EventID const* idp) {
+    assert(engine);
+    assert(idp);
+    EventID const& id = *idp;
+    skipBadFiles_ = false;
+    if(noMoreFiles() || !rootFile() ||
+        rootFile()->indexIntoFileIter().run() != id.run() ||
+        rootFile()->indexIntoFileIter().lumi() != id.luminosityBlock()) {
+      bool found = skipToItem(id.run(), id.luminosityBlock(), 0);
+      if(!found) {
+        return false;
+      }
+      int eventsInLumi = 0;
+      assert(rootFile());
+      while(rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock())) ++eventsInLumi;
+      found = skipToItem(id.run(), id.luminosityBlock(), 0);
+      assert(found);
+      int eventInLumi = CLHEP::RandFlat::shootInt(engine, eventsInLumi);
+      for(int i = 0; i < eventInLumi; ++i) {
+        bool found = rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
+        assert(found);
+      }
+    }
+    assert(rootFile());
+    bool found = rootFile()->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
+    if(found) {
+      found = rootFile()->readCurrentEvent(cache);
+    }
+    if(!found) {
+      bool found = rootFile()->setEntryAtItem(id.run(), id.luminosityBlock(), 0);
+      if(!found) {
+        return false;
+      }
+      return readOneRandomWithID(cache, fileNameHash, engine, idp);
+    }
+    fileNameHash = lfnHash();
+    return true;
+  }
+
+  bool
+  RootEmbeddedFileSequence::readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine, EventID const* id) {
+    assert(!sameLumiBlock_ || id != nullptr);
+    assert(sequential_ || engine != nullptr);
+    return (this->*fptr_)(cache, fileNameHash, engine, id);
+  }
+
+  void
+  RootEmbeddedFileSequence::fillDescription(ParameterSetDescription & desc) {
+    desc.addUntracked<bool>("sequential", false)
+        ->setComment("True: loopEvents() reads events sequentially from beginning of first file.\n"
+                     "False: loopEvents() first reads events beginning at random event. New files also chosen randomly");
+    desc.addUntracked<bool>("sameLumiBlock", false)
+        ->setComment("True: loopEvents() reads events only in same lumi as the specified event.\n"
+                     "False: loopEvents() reads events regardless of lumi.");
+    desc.addUntracked<unsigned int>("skipEvents", 0U)
+        ->setComment("Skip the first 'skipEvents' events. Used only if 'sequential' is True and 'sameLumiBlock' is False");
+    desc.addUntracked<bool>("skipBadFiles", false)
+        ->setComment("True:  Ignore any missing or unopenable input file.\n"
+                     "False: Throw exception if missing or unopenable input file.");
+    desc.addUntracked<bool>("bypassVersionCheck", false)
+        ->setComment("True:  Bypass release version check.\n"
+                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
+    desc.addUntracked<int>("treeMaxVirtualSize", -1)
+        ->setComment("Size of ROOT TTree TBasket cache.  Affects performance.");
+
+    ProductSelectorRules::fillDescription(desc, "inputCommands");
+  }
+}

--- a/IOPool/Input/src/RootEmbeddedFileSequence.h
+++ b/IOPool/Input/src/RootEmbeddedFileSequence.h
@@ -1,0 +1,78 @@
+#ifndef IOPool_Input_RootEmbeddedFileSequence_h
+#define IOPool_Input_RootEmbeddedFileSequence_h
+
+/*----------------------------------------------------------------------
+
+RootEmbeddedFileSequence: This is an InputSource
+
+----------------------------------------------------------------------*/
+
+#include "RootInputFileSequence.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ProductSelectorRules.h"
+#include "FWCore/Sources/interface/VectorInputSource.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace CLHEP {
+  class HepRandomEngine;
+}
+
+namespace edm {
+
+  class BranchID;
+  class FileCatalogItem;
+  class InputFileCatalog;
+  class ParameterSetDescription;
+  class EmbeddedRootSource;
+  class RootFile;
+
+  class RootEmbeddedFileSequence : public RootInputFileSequence {
+  public:
+    explicit RootEmbeddedFileSequence(ParameterSet const& pset,
+                                   EmbeddedRootSource& input,
+                                   InputFileCatalog const& catalog,
+                                   unsigned int nStreams);
+    virtual ~RootEmbeddedFileSequence();
+
+    RootEmbeddedFileSequence(RootEmbeddedFileSequence const&) = delete; // Disallow copying and moving
+    RootEmbeddedFileSequence& operator=(RootEmbeddedFileSequence const&) = delete; // Disallow copying and moving
+
+    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
+    virtual void closeFile_() override;
+    void endJob();
+    void skipEntries(unsigned int offset);
+    bool readOneEvent(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
+    bool readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*);
+    bool readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
+    bool readOneSequential(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const*);
+    bool readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*, EventID const* id);
+    void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id);
+
+    void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
+    static void fillDescription(ParameterSetDescription & desc);
+  private:
+    virtual void initFile_(bool skipBadFiles) override;
+    virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
+
+    EmbeddedRootSource& input_;
+
+    std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
+
+    unsigned int nStreams_; 
+    bool sequential_;
+    bool sameLumiBlock_;
+    bool (RootEmbeddedFileSequence::* fptr_)(EventPrincipal&, size_t&, CLHEP::HepRandomEngine*, EventID const*);
+    int eventsRemainingInFile_;
+    int initialNumberOfEventsToSkip_;
+    bool skipBadFiles_;
+    bool bypassVersionCheck_;
+    int const treeMaxVirtualSize_;
+    ProductSelectorRules productSelectorRules_;
+    bool enablePrefetching_;
+  }; // class RootEmbeddedFileSequence
+}
+#endif

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -1,132 +1,38 @@
 /*----------------------------------------------------------------------
 ----------------------------------------------------------------------*/
-#include "DuplicateChecker.h"
-#include "PoolSource.h"
 #include "RootFile.h"
 #include "RootInputFileSequence.h"
-#include "RootTree.h"
 
 #include "DataFormats/Provenance/interface/BranchID.h"
-#include "DataFormats/Provenance/interface/BranchIDListHelper.h"
+#include "DataFormats/Provenance/interface/IndexIntoFile.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
-#include "FWCore/Catalog/interface/SiteLocalConfig.h"
-#include "FWCore/Framework/interface/EventPrincipal.h"
-#include "FWCore/Framework/interface/FileBlock.h"
-#include "FWCore/Framework/interface/LuminosityBlockPrincipal.h"
-#include "FWCore/Framework/interface/RunPrincipal.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "Utilities/StorageFactory/interface/StorageFactory.h"
 
-#include "CLHEP/Random/RandFlat.h"
-#include "InputFile.h"
 #include "TSystem.h"
 
-#include <random>
-
 namespace edm {
+  class BranchIDListHelper;
+  class EventPrincipal;
+  class LuminosityBlockPrincipal;
+  class RunPrincipal;
+
   RootInputFileSequence::RootInputFileSequence(
                 ParameterSet const& pset,
-                PoolSource& input,
-                InputFileCatalog const& catalog,
-                unsigned int nStreams,
-                InputType inputType) :
-    input_(input),
-    inputType_(inputType),
+                InputFileCatalog const& catalog) :
     catalog_(catalog),
-    firstFile_(true),
     lfn_("unknown"),
     lfnHash_(0U),
+    usedFallback_(false),
     findFileForSpecifiedID_(nullptr),
     fileIterBegin_(fileCatalogItems().begin()),
     fileIterEnd_(fileCatalogItems().end()),
     fileIter_(fileIterEnd_),
     fileIterLastOpened_(fileIterEnd_),
     rootFile_(),
-    branchesMustMatch_(BranchDescription::Permissive),
-    indexesIntoFiles_(fileCatalogItems().size()),
-    orderedProcessHistoryIDs_(),
-    nStreams_(nStreams),
-    eventSkipperByID_(inputType == InputType::Primary ? EventSkipperByID::create(pset).release() : 0),
-    eventsRemainingInFile_(0),
-    // The default value provided as the second argument to the getUntrackedParameter function call
-    // is not used when the ParameterSet has been validated and the parameters are not optional
-    // in the description.  This is currently true when PoolSource is the primary input source.
-    // The modules that use PoolSource as a SecSource have not defined their fillDescriptions function
-    // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
-    // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
-    // and should be deleted from the code.
-    initialNumberOfEventsToSkip_(inputType != InputType::SecondaryFile ? pset.getUntrackedParameter<unsigned int>("skipEvents", 0U) : 0U),
-    noEventSort_(inputType == InputType::Primary ? pset.getUntrackedParameter<bool>("noEventSort", true) : false),
-    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
-    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
-    treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize", roottree::defaultCacheSize) : 0U),
-    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
-    setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber", 0U)),
-    productSelectorRules_(pset, "inputCommands", "InputSource"),
-    duplicateChecker_(inputType == InputType::Primary ? new DuplicateChecker(pset) : 0),
-    dropDescendants_(pset.getUntrackedParameter<bool>("dropDescendantsOfDroppedBranches", inputType != InputType::SecondarySource)),
-    labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC", true)),
-    usingGoToEvent_(false),
-    enablePrefetching_(false),
-    usedFallback_(false) {
-
-    // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
-    Service<SiteLocalConfig> pSLC;
-    if(pSLC.isAvailable()) {
-      if(treeCacheSize_ != 0U && pSLC->sourceTTreeCacheSize()) {
-        treeCacheSize_ = *(pSLC->sourceTTreeCacheSize());
-      }
-      enablePrefetching_ = pSLC->enablePrefetching();
-    }
-
-    std::string branchesMustMatch = pset.getUntrackedParameter<std::string>("branchesMustMatch", std::string("permissive"));
-    if(branchesMustMatch == std::string("strict")) branchesMustMatch_ = BranchDescription::Strict;
-
-    StorageFactory *factory = StorageFactory::get();
-
-    if(inputType == InputType::SecondarySource) {
-      // For the secondary input source we do not stage in,
-      // and we randomly choose the first file to open.
-      // We cannot use the random number service yet.
-      std::ifstream f("/dev/urandom");
-      unsigned int seed;
-      f.read(reinterpret_cast<char*>(&seed), sizeof(seed)); 
-      std::default_random_engine dre(seed);
-      size_t count = fileIterEnd_ - fileIterBegin_;
-      std::uniform_int_distribution<int> distribution(0, count - 1);
-      while(!rootFile_ && count != 0) {
-        --count;
-        int offset = distribution(dre);
-        fileIter_ = fileIterBegin_ + offset;
-        initFile(skipBadFiles_);
-      }
-    } else {
-      // Prestage the files
-      for(fileIter_ = fileIterBegin_; fileIter_ != fileIterEnd_; ++fileIter_) {
-        factory->activateTimeout(fileIter_->fileName());
-        factory->stagein(fileIter_->fileName());
-        //NOTE: we do not want to stage in all secondary files since we can be given a list of
-        // thousands of files and prestaging all those files can cause a site to fail.
-        // So, we stage in the first secondary file only.
-        if(inputType_ != InputType::Primary) {
-          break;
-        }
-      }
-      // Open the first file.
-      for(fileIter_ = fileIterBegin_; fileIter_ != fileIterEnd_; ++fileIter_) {
-        initFile(skipBadFiles_);
-        if(rootFile_) break;
-      }
-    }
-    if(rootFile_) {
-      productRegistryUpdate().updateFromInput(rootFile_->productRegistry()->productList());
-      if(inputType == InputType::Primary && initialNumberOfEventsToSkip_ != 0) {
-        skipEvents(initialNumberOfEventsToSkip_);
-      }
-    }
+    indexesIntoFiles_(fileCatalogItems().size()) {
   }
 
   std::vector<FileCatalogItem> const&
@@ -134,262 +40,16 @@ namespace edm {
     return catalog_.fileCatalogItems();
   }
 
-  void
-  RootInputFileSequence::endJob() {
-    closeFile_();
-  }
-
-  std::unique_ptr<FileBlock>
-  RootInputFileSequence::readFile_() {
-    if(firstFile_) {
-      // The first input file has already been opened.
-      firstFile_ = false;
-      if(!rootFile_) {
-        initFile(skipBadFiles_);
-      }
-    } else {
-      if(!nextFile()) {
-        assert(0);
-      }
-    }
-    if(!rootFile_) {
-      return std::unique_ptr<FileBlock>(new FileBlock);
-    }
-    return rootFile_->createFileBlock();
-  }
-
-  void RootInputFileSequence::closeFile_() {
-    // close the currently open file, if any, and delete the RootFile object.
-    if(rootFile_) {
-      if(inputType_ != InputType::SecondarySource) {
-        std::unique_ptr<InputSource::FileCloseSentry>
-        sentry((inputType_ == InputType::Primary) ? new InputSource::FileCloseSentry(input_, lfn_, usedFallback_) : 0);
-        rootFile_->close();
-        if(duplicateChecker_) duplicateChecker_->inputFileClosed();
-      }
-      rootFile_.reset();
-    }
-  }
-
-  void RootInputFileSequence::initFile(bool skipBadFiles) {
-    // We are really going to close the open file.
-
-    // If this is the primary sequence, we are not duplicate checking across files
-    // and we are not using random access to find events, then we can delete the
-    // IndexIntoFile for the file we are closing. If we can't delete all of it,
-    // then we can delete the parts we do not need.
-    if(fileIterLastOpened_ != fileIterEnd_) {
-      size_t currentIndexIntoFile = fileIterLastOpened_ - fileIterBegin_;
-      bool needIndexesForDuplicateChecker = duplicateChecker_ && duplicateChecker_->checkingAllFiles() && !duplicateChecker_->checkDisabled();
-      bool deleteIndexIntoFile = inputType_ == InputType::Primary &&
-                                 !needIndexesForDuplicateChecker &&
-                                 !usingGoToEvent_;
-      if(deleteIndexIntoFile) {
-        indexesIntoFiles_[currentIndexIntoFile].reset();
-      } else {
-        if(indexesIntoFiles_[currentIndexIntoFile]) indexesIntoFiles_[currentIndexIntoFile]->inputFileClosed();
-      }
-      fileIterLastOpened_ = fileIterEnd_;
-    }
-    closeFile_();
-
-    if(fileIter_ == fileIterEnd_) {
-      // No files specified
-      return;
-    }
-
-    // Check if the logical file name was found.
-    if(fileIter_->fileName().empty()) {
-      // LFN not found in catalog.
-      InputFile::reportSkippedFile(fileIter_->fileName(), fileIter_->logicalFileName());
-      if(!skipBadFiles) {
-        throw cms::Exception("LogicalFileNameNotFound", "RootInputFileSequence::initFile()\n")
-          << "Logical file name '" << fileIter_->logicalFileName() << "' was not found in the file catalog.\n"
-          << "If you wanted a local file, you forgot the 'file:' prefix\n"
-          << "before the file name in your configuration file.\n";
-      }
-      LogWarning("") << "Input logical file: " << fileIter_->logicalFileName() << " was not found in the catalog, and will be skipped.\n";
-      return;
-    }
-
-    lfn_ = fileIter_->logicalFileName().empty() ? fileIter_->fileName() : fileIter_->logicalFileName();
-    lfnHash_ = std::hash<std::string>()(lfn_);
-    usedFallback_ = false;
-
-    // Determine whether we have a fallback URL specified; if so, prepare it;
-    // Only valid if it is non-empty and differs from the original filename.
-    std::string fallbackName = fileIter_->fallbackFileName();
-    bool hasFallbackUrl = !fallbackName.empty() && fallbackName != fileIter_->fileName();
-
-    std::shared_ptr<InputFile> filePtr;
-    std::list<std::string> originalInfo;
-    try {
-      std::unique_ptr<InputSource::FileOpenSentry>
-        sentry(inputType_ == InputType::Primary ? new InputSource::FileOpenSentry(input_, lfn_, usedFallback_) : 0);
-      filePtr.reset(new InputFile(gSystem->ExpandPathName(fileIter_->fileName().c_str()), "  Initiating request to open file ", inputType_));
-    }
-    catch (cms::Exception const& e) {
-      if(!skipBadFiles) {
-        if(hasFallbackUrl) {
-          std::ostringstream out;
-          out << e.explainSelf();
-          std::string pfn(gSystem->ExpandPathName(fallbackName.c_str()));
-          InputFile::reportFallbackAttempt(pfn, fileIter_->logicalFileName(), out.str());
-          originalInfo = e.additionalInfo();
-        } else {
-          InputFile::reportSkippedFile(fileIter_->fileName(), fileIter_->logicalFileName());
-          Exception ex(errors::FileOpenError, "", e);
-          ex.addContext("Calling RootInputFileSequence::initFile()");
-          std::ostringstream out;
-          out << "Input file " << fileIter_->fileName() << " could not be opened.";
-          ex.addAdditionalInfo(out.str());
-          throw ex;
-        }
-      }
-    }
-    if(!filePtr && (hasFallbackUrl)) {
-      try {
-        usedFallback_ = true;
-        std::unique_ptr<InputSource::FileOpenSentry>
-          sentry(inputType_ == InputType::Primary ? new InputSource::FileOpenSentry(input_, lfn_, usedFallback_) : 0);
-        std::string fallbackFullName = gSystem->ExpandPathName(fallbackName.c_str());
-        StorageFactory *factory = StorageFactory::get();
-        if (factory) {factory->activateTimeout(fallbackFullName);}
-        filePtr.reset(new InputFile(fallbackFullName.c_str(), "  Fallback request to file ", inputType_));
-      }
-      catch (cms::Exception const& e) {
-        if(!skipBadFiles) {
-          InputFile::reportSkippedFile(fileIter_->fileName(), fileIter_->logicalFileName());
-          Exception ex(errors::FallbackFileOpenError, "", e);
-          ex.addContext("Calling RootInputFileSequence::initFile()");
-          std::ostringstream out;
-          out << "Input file " << fileIter_->fileName() << " could not be opened.\n";
-          out << "Fallback Input file " << fallbackName << " also could not be opened.";
-          if (originalInfo.size()) {
-            out << std::endl << "Original exception info is above; fallback exception info is below.";
-            ex.addAdditionalInfo(out.str());
-            for (auto const & s : originalInfo) {
-              ex.addAdditionalInfo(s);
-            }
-          } else {
-            ex.addAdditionalInfo(out.str());
-          }
-          throw ex;
-        }
-      }
-    }
-    if(filePtr) {
-      std::vector<std::shared_ptr<IndexIntoFile> >::size_type currentIndexIntoFile = fileIter_ - fileIterBegin_;
-      rootFile_ = RootFileSharedPtr(new RootFile(
-          fileIter_->fileName(),
-          processConfiguration(),
-          fileIter_->logicalFileName(),
-          filePtr,
-          eventSkipperByID_,
-          initialNumberOfEventsToSkip_ != 0,
-          remainingEvents(),
-          remainingLuminosityBlocks(),
-	  nStreams_,
-          treeCacheSize_,
-          treeMaxVirtualSize_,
-          input_.processingMode(),
-          setRun_,
-          noEventSort_,
-          productSelectorRules_,
-          inputType_,
-          (inputType_ == InputType::SecondarySource ?  std::make_shared<BranchIDListHelper>() :  input_.branchIDListHelper()),
-          (inputType_ == InputType::SecondarySource ?  std::shared_ptr<ThinnedAssociationsHelper>() : input_.thinnedAssociationsHelper()),
-          associationsFromSecondary_,
-          duplicateChecker_,
-          dropDescendants_,
-          processHistoryRegistryForUpdate(),
-          indexesIntoFiles_,
-          currentIndexIntoFile,
-          orderedProcessHistoryIDs_,
-          bypassVersionCheck_,
-          labelRawDataLikeMC_,
-          usingGoToEvent_,
-          enablePrefetching_));
-
-      assert(rootFile_);
-      fileIterLastOpened_ = fileIter_;
-      indexesIntoFiles_[currentIndexIntoFile] = rootFile_->indexIntoFileSharedPtr();
-      char const* inputType = 0;
-      switch(inputType_) {
-      case InputType::Primary: inputType = "primaryFiles"; break;
-      case InputType::SecondaryFile: inputType = "secondaryFiles"; break;
-      case InputType::SecondarySource: inputType = "mixingFiles"; break;
-      }
-      rootFile_->reportOpened(inputType);
-    } else {
-      InputFile::reportSkippedFile(fileIter_->fileName(), fileIter_->logicalFileName());
-      if(!skipBadFiles) {
-        throw Exception(errors::FileOpenError) <<
-           "RootInputFileSequence::initFile(): Input file " << fileIter_->fileName() << " was not found or could not be opened.\n";
-      }
-      LogWarning("") << "Input file: " << fileIter_->fileName() << " was not found or could not be opened, and will be skipped.\n";
-    }
-  }
-
   std::shared_ptr<ProductRegistry const>
   RootInputFileSequence::fileProductRegistry() const {
-    assert(rootFile_);
-    return rootFile_->productRegistry();
+    assert(rootFile());
+    return rootFile()->productRegistry();
   }
 
   std::shared_ptr<BranchIDListHelper const>
   RootInputFileSequence::fileBranchIDListHelper() const {
-    assert(rootFile_);
-    return rootFile_->branchIDListHelper();
-  }
-
-  bool RootInputFileSequence::nextFile() {
-    if(fileIter_ != fileIterEnd_) ++fileIter_;
-    if(fileIter_ == fileIterEnd_) {
-      if(inputType_ == InputType::Primary) {
-        return false;
-      } else {
-        fileIter_ = fileIterBegin_;
-      }
-    }
-
-    initFile(skipBadFiles_);
-
-    if(inputType_ == InputType::Primary && rootFile_) {
-      // make sure the new product registry is compatible with the main one
-      std::string mergeInfo = productRegistryUpdate().merge(*rootFile_->productRegistry(),
-                                                            fileIter_->fileName(),
-                                                            branchesMustMatch_);
-      if(!mergeInfo.empty()) {
-        throw Exception(errors::MismatchedInputFiles,"RootInputFileSequence::nextFile()") << mergeInfo;
-      }
-    }
-    return true;
-  }
-
-  bool RootInputFileSequence::previousFile() {
-    if(fileIter_ == fileIterBegin_) {
-      if(inputType_ == InputType::Primary) {
-        return false;
-      } else {
-        fileIter_ = fileIterEnd_;
-      }
-    }
-    --fileIter_;
-
-    initFile(false);
-
-    if(inputType_ == InputType::Primary && rootFile_) {
-      // make sure the new product registry is compatible to the main one
-      std::string mergeInfo = productRegistryUpdate().merge(*rootFile_->productRegistry(),
-                                                            fileIter_->fileName(),
-                                                            branchesMustMatch_);
-      if(!mergeInfo.empty()) {
-        throw Exception(errors::MismatchedInputFiles,"RootInputFileSequence::previousEvent()") << mergeInfo;
-      }
-    }
-    if(rootFile_) rootFile_->setToLastEntry();
-    return true;
+    assert(rootFile());
+    return rootFile()->branchIDListHelper();
   }
 
   RootInputFileSequence::~RootInputFileSequence() {
@@ -397,26 +57,26 @@ namespace edm {
 
   std::shared_ptr<RunAuxiliary>
   RootInputFileSequence::readRunAuxiliary_() {
-    assert(rootFile_);
-    return rootFile_->readRunAuxiliary_();
+    assert(rootFile());
+    return rootFile()->readRunAuxiliary_();
   }
 
   std::shared_ptr<LuminosityBlockAuxiliary>
   RootInputFileSequence::readLuminosityBlockAuxiliary_() {
-    assert(rootFile_);
-    return rootFile_->readLuminosityBlockAuxiliary_();
+    assert(rootFile());
+    return rootFile()->readLuminosityBlockAuxiliary_();
   }
 
   void
   RootInputFileSequence::readRun_(RunPrincipal& runPrincipal) {
-    assert(rootFile_);
-    rootFile_->readRun_(runPrincipal);
+    assert(rootFile());
+    rootFile()->readRun_(runPrincipal);
   }
 
   void
   RootInputFileSequence::readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal) {
-    assert(rootFile_);
-    rootFile_->readLuminosityBlock_(lumiPrincipal);
+    assert(rootFile());
+    rootFile()->readLuminosityBlock_(lumiPrincipal);
   }
 
   // readEvent() is responsible for setting up the EventPrincipal.
@@ -434,140 +94,14 @@ namespace edm {
 
   void
   RootInputFileSequence::readEvent(EventPrincipal& eventPrincipal) {
-    assert(rootFile_);
-    rootFile_->readEvent(eventPrincipal);
-  }
-
-  InputSource::ItemType
-  RootInputFileSequence::getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event) {
-    if(fileIter_ == fileIterEnd_) {
-      return InputSource::IsStop;
-    }
-    if(firstFile_) {
-      return InputSource::IsFile;
-    }
-    if(rootFile_) {
-      IndexIntoFile::EntryType entryType = rootFile_->getNextItemType(run, lumi, event);
-      if(entryType == IndexIntoFile::kEvent) {
-        return InputSource::IsEvent;
-      } else if(entryType == IndexIntoFile::kLumi) {
-        return InputSource::IsLumi;
-      } else if(entryType == IndexIntoFile::kRun) {
-        return InputSource::IsRun;
-      }
-      assert(entryType == IndexIntoFile::kEnd);
-    }
-    if(fileIter_ + 1 == fileIterEnd_) {
-      return InputSource::IsStop;
-    }
-    return InputSource::IsFile;
+    assert(rootFile());
+    rootFile()->readEvent(eventPrincipal);
   }
 
   bool
   RootInputFileSequence::containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const {
-    if(!rootFile_) return false;
-    return rootFile_->containsItem(run, lumi, event);
-  }
-
-  // Rewind to before the first event that was read.
-  void
-  RootInputFileSequence::rewind_() {
-    if(fileIter_ != fileIterBegin_) {
-      closeFile_();
-      fileIter_ = fileIterBegin_;
-    }
-    if(!rootFile_) {
-      initFile(false);
-    }
-    rewindFile();
-    firstFile_ = true;
-    if(rootFile_) {
-      if(initialNumberOfEventsToSkip_ != 0) {
-        skipEvents(initialNumberOfEventsToSkip_);
-      }
-    }
-  }
-
-  // Rewind to the beginning of the current file
-  void
-  RootInputFileSequence::rewindFile() {
-    if(rootFile_) rootFile_->rewind();
-  }
-
-  // Advance "offset" events.  Offset can be positive or negative (or zero).
-  bool
-  RootInputFileSequence::skipEvents(int offset) {
-    // We never call skipEvents for secondary input files.  If we did,
-    // we would have to implement synchronization if a new file is opened.
-    // To avoid this, just assert.
-    assert(inputType_ != InputType::SecondaryFile);
-    assert(rootFile_);
-    while(offset != 0) {
-      bool atEnd = rootFile_->skipEvents(offset);
-      if((offset > 0 || atEnd) && !nextFile()) {
-        return false;
-      }
-      if(offset < 0 && !previousFile()) {
-        fileIter_ = fileIterEnd_;
-        return false;
-      }
-    }
-    return true;
-  }
-
-  bool
-  RootInputFileSequence::goToEvent(EventID const& eventID) {
-    usingGoToEvent_ = true;
-    if(rootFile_) {
-      if(rootFile_->goToEvent(eventID)) {
-        return true;
-      }
-      // If only one input file, give up now, to save time.
-      if(rootFile_ && indexesIntoFiles_.size() == 1) {
-        return false;
-      }
-      // Save the current file and position so that we can restore them
-      // if we fail to restore the desired event
-      bool closedOriginalFile = false;
-      std::vector<FileCatalogItem>::const_iterator originalFile = fileIter_;
-      IndexIntoFile::IndexIntoFileItr originalPosition = rootFile_->indexIntoFileIter();
-
-      // Look for item (run/lumi/event) in files previously opened without reopening unnecessary files.
-      typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
-      for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
-        if(*it && (*it)->containsItem(eventID.run(), eventID.luminosityBlock(), eventID.event())) {
-          // We found it. Close the currently open file, and open the correct one.
-          fileIter_ = fileIterBegin_ + (it - indexesIntoFiles_.begin());
-          initFile(false);
-          // Now get the item from the correct file.
-          assert(rootFile_);
-          bool found = rootFile_->goToEvent(eventID);
-          assert(found);
-          return true;
-        }
-      }
-      // Look for item in files not yet opened.
-      for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
-        if(!*it) {
-          fileIter_ = fileIterBegin_ + (it - indexesIntoFiles_.begin());
-          initFile(false);
-          closedOriginalFile = true;
-          if((*it)->containsItem(eventID.run(), eventID.luminosityBlock(), eventID.event())) {
-            assert(rootFile_);
-            if(rootFile_->goToEvent(eventID)) {
-              return true;
-            }
-          }
-        }
-      }
-      if(closedOriginalFile) {
-        fileIter_ = originalFile;
-        initFile(false);
-        assert(rootFile_);
-        rootFile_->setPosition(originalPosition);
-      }
-    }
-    return false;
+    if(!rootFile()) return false;
+    return rootFile()->containsItem(run, lumi, event);
   }
 
   bool
@@ -589,10 +123,10 @@ namespace edm {
     for(auto iter = range.first; iter != range.second; ++iter) {
       // Don't look in files previously opened, because those have already been searched.
       if(!indexesIntoFiles_[iter->second]) {
-        fileIter_ = fileIterBegin_ + iter->second;
-        initFile(false);
-        assert(rootFile_);
-        bool found = rootFile_->setEntryAtItem(run, lumi, event);
+        setAtFileSequenceNumber(iter->second);
+        initFile_(false);
+        assert(rootFile());
+        bool found = rootFile()->setEntryAtItem(run, lumi, event);
         if(found) {
           return true;
         }
@@ -609,10 +143,10 @@ namespace edm {
     for(Iter it = indexesIntoFiles_.begin(), itEnd = indexesIntoFiles_.end(); it != itEnd; ++it) {
       if(!*it) {
         // File not yet opened.
-        fileIter_ = fileIterBegin_ + (it - indexesIntoFiles_.begin());
-        initFile(false);
-        assert(rootFile_);
-        bool found = rootFile_->setEntryAtItem(run, lumi, event);
+        setAtFileSequenceNumber(it - indexesIntoFiles_.begin());
+        initFile_(false);
+        assert(rootFile());
+        bool found = rootFile()->setEntryAtItem(run, lumi, event);
         if(found) {
           return true;
         }
@@ -625,10 +159,10 @@ namespace edm {
   bool
   RootInputFileSequence::skipToItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, size_t fileNameHash, bool currentFileFirst) {
     // Attempt to find item in currently open input file.
-    bool found = currentFileFirst && rootFile_ && rootFile_->setEntryAtItem(run, lumi, event);
+    bool found = currentFileFirst && rootFile() && rootFile()->setEntryAtItem(run, lumi, event);
     if(!found) {
       // If only one input file, give up now, to save time.
-      if(currentFileFirst && rootFile_ && indexesIntoFiles_.size() == 1) {
+      if(currentFileFirst && rootFile() && indexesIntoFiles_.size() == 1) {
         return false;
       }
       // Look for item (run/lumi/event) in files previously opened without reopening unnecessary files.
@@ -637,13 +171,13 @@ namespace edm {
         if(*it && (*it)->containsItem(run, lumi, event)) {
           // We found it. Close the currently open file, and open the correct one.
           std::vector<FileCatalogItem>::const_iterator currentIter = fileIter_;
-          fileIter_ = fileIterBegin_ + (it - indexesIntoFiles_.begin());
+          setAtFileSequenceNumber(it - indexesIntoFiles_.begin());
           if(fileIter_ != currentIter) {
             initFile(false);
           }
           // Now get the item from the correct file.
-          assert(rootFile_);
-          found = rootFile_->setEntryAtItem(run, lumi, event);
+          assert(rootFile());
+          found = rootFile()->setEntryAtItem(run, lumi, event);
           assert(found);
           return true;
         }
@@ -653,323 +187,125 @@ namespace edm {
     return true;
   }
 
-  ProcessHistoryRegistry const&
-  RootInputFileSequence::processHistoryRegistry() const {
-    return input_.processHistoryRegistry();
-  }
-
-  ProcessHistoryRegistry&
-  RootInputFileSequence::processHistoryRegistryForUpdate() {
-    return input_.processHistoryRegistryForUpdate();
-  }
-
-  ProcessConfiguration const&
-  RootInputFileSequence::processConfiguration() const {
-    return input_.processConfiguration();
-  }
-
-  int
-  RootInputFileSequence::remainingEvents() const {
-    return input_.remainingEvents();
-  }
-
-  int
-  RootInputFileSequence::remainingLuminosityBlocks() const {
-    return input_.remainingLuminosityBlocks();
-  }
-
-  ProductRegistry &
-  RootInputFileSequence::productRegistryUpdate() const{
-    return input_.productRegistryUpdate();
-  }
-
-  std::shared_ptr<ProductRegistry const>
-  RootInputFileSequence::productRegistry() const{
-    return input_.productRegistry();
-  }
-
   void
-  RootInputFileSequence::dropUnwantedBranches_(std::vector<std::string> const& wantedBranches) {
-    std::vector<std::string> rules;
-    rules.reserve(wantedBranches.size() + 1);
-    rules.emplace_back("drop *");
-    for(std::string const& branch : wantedBranches) {
-      rules.push_back("keep " + branch + "_*");
-    }
-    ParameterSet pset;
-    pset.addUntrackedParameter("inputCommands", rules);
-    productSelectorRules_ = ProductSelectorRules(pset, "inputCommands", "InputSource");
-  }
+  RootInputFileSequence::initTheFile(bool skipBadFiles,
+                                    bool deleteIndexIntoFile,
+                                    InputSource* input, 
+                                    char const* inputTypeName,
+                                    InputType inputType) {
+    // We are really going to close the open file.
 
-  void
-  RootInputFileSequence::skipEntries(unsigned int offset) {
-    // offset is decremented by the number of events actually skipped.
-    bool completed = rootFile_->skipEntries(offset);
-    while(!completed) {
-      ++fileIter_;
-      if(fileIter_ == fileIterEnd_) {
-        fileIter_ = fileIterBegin_;
+    if(fileIterLastOpened_ != fileIterEnd_) {
+      size_t currentIndexIntoFile = fileIterLastOpened_ - fileIterBegin_;
+      if(deleteIndexIntoFile) {
+        indexesIntoFiles_[currentIndexIntoFile].reset();
+      } else {
+        if(indexesIntoFiles_[currentIndexIntoFile]) indexesIntoFiles_[currentIndexIntoFile]->inputFileClosed();
       }
-      initFile(false);
-      assert(rootFile_);
-      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
-      completed = rootFile_->skipEntries(offset);
+      fileIterLastOpened_ = fileIterEnd_;
     }
-  }
+    closeFile_();
 
-  bool
-  RootInputFileSequence::readOneSequential(EventPrincipal& cache, size_t& fileNameHash) {
-    skipBadFiles_ = false;
-    if(firstFile_) {
-      firstFile_ = false;
-      if(fileIterEnd_ == fileIterBegin_) {
-        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
-      }
-      if(fileIter_ != fileIterBegin_) {
-        fileIter_ = fileIterBegin_;
-        initFile(false);
-      }
-      assert(rootFile_);
-      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
-      skipEntries(initialNumberOfEventsToSkip_);
+    if(noMoreFiles()) {
+      // No files specified
+      return;
     }
-    assert(rootFile_);
-    rootFile_->nextEventEntry();
-    bool found = rootFile_->readCurrentEvent(cache);
-    if(!found) {
-      ++fileIter_;
-      if(fileIter_ == fileIterEnd_) {
-        fileIter_ = fileIterBegin_;
-      }
-      initFile(false);
-      assert(rootFile_);
-      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
-      return readOneSequential(cache, fileNameHash);
-    }
-    fileNameHash = lfnHash_;
-    return true;
-  }
 
-  bool
-  RootInputFileSequence::readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id) {
-    skipBadFiles_ = false;
-    if(firstFile_) {
-      firstFile_ = false;
-      if(fileIterEnd_ == fileIterBegin_) {
-        throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSequential(): no input files specified for secondary input source.\n";
+    // Check if the logical file name was found.
+    if(fileName().empty()) {
+      // LFN not found in catalog.
+      InputFile::reportSkippedFile(fileName(), logicalFileName());
+      if(!skipBadFiles) {
+        throw cms::Exception("LogicalFileNameNotFound", "RootFileSequenceBase::initTheFile()\n")
+          << "Logical file name '" << logicalFileName() << "' was not found in the file catalog.\n"
+          << "If you wanted a local file, you forgot the 'file:' prefix\n"
+          << "before the file name in your configuration file.\n";
       }
-      if(fileIter_ != fileIterBegin_) {
-        fileIter_ = fileIterBegin_;
-        initFile(false);
-      }
-      assert(rootFile_);
-      rootFile_->setAtEventEntry(IndexIntoFile::invalidEntry);
-      int offset = initialNumberOfEventsToSkip_;
-      while(offset > 0) {
-        bool found = readOneSequentialWithID(cache, fileNameHash, id);
-        if(!found) {
-          return false;
+      LogWarning("") << "Input logical file: " << logicalFileName() << " was not found in the catalog, and will be skipped.\n";
+      return;
+    }
+
+    lfn_ = logicalFileName().empty() ? fileName() : logicalFileName();
+    lfnHash_ = std::hash<std::string>()(lfn_);
+    usedFallback_ = false;
+
+    // Determine whether we have a fallback URL specified; if so, prepare it;
+    // Only valid if it is non-empty and differs from the original filename.
+    bool hasFallbackUrl = !fallbackFileName().empty() && fallbackFileName() != fileName();
+
+    std::shared_ptr<InputFile> filePtr;
+    std::list<std::string> originalInfo;
+    try {
+      std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? new InputSource::FileOpenSentry(*input, lfn_, usedFallback_) : nullptr);
+      filePtr = std::make_shared<InputFile>(gSystem->ExpandPathName(fileName().c_str()), "  Initiating request to open file ", inputType);
+    }
+    catch (cms::Exception const& e) {
+      if(!skipBadFiles) {
+        if(hasFallbackUrl) {
+          std::ostringstream out;
+          out << e.explainSelf();
+          std::string pfn(gSystem->ExpandPathName(fallbackFileName().c_str()));
+          InputFile::reportFallbackAttempt(pfn, logicalFileName(), out.str());
+          originalInfo = e.additionalInfo();
+        } else {
+          InputFile::reportSkippedFile(fileName(), logicalFileName());
+          Exception ex(errors::FileOpenError, "", e);
+          ex.addContext("Calling RootFileSequenceBase::initTheFile()");
+          std::ostringstream out;
+          out << "Input file " << fileName() << " could not be opened.";
+          ex.addAdditionalInfo(out.str());
+          throw ex;
         }
-        --offset;
       }
     }
-    assert(rootFile_);
-    if(fileIter_ == fileIterEnd_ ||
-        rootFile_->indexIntoFileIter().run() != id.run() ||
-        rootFile_->indexIntoFileIter().lumi() != id.luminosityBlock()) {
-      bool found = skipToItem(id.run(), id.luminosityBlock(), 0, 0, false);
-      if(!found) {
-        return false;
+    if(!filePtr && (hasFallbackUrl)) {
+      try {
+        usedFallback_ = true;
+        std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? new InputSource::FileOpenSentry(*input, lfn_, usedFallback_) : nullptr);
+        std::string fallbackFullName = gSystem->ExpandPathName(fallbackFileName().c_str());
+        StorageFactory *factory = StorageFactory::get();
+        if (factory) {factory->activateTimeout(fallbackFullName);}
+        filePtr.reset(new InputFile(fallbackFullName.c_str(), "  Fallback request to file ", inputType));
+      }
+      catch (cms::Exception const& e) {
+        if(!skipBadFiles) {
+          InputFile::reportSkippedFile(fileName(), logicalFileName());
+          Exception ex(errors::FallbackFileOpenError, "", e);
+          ex.addContext("Calling RootFileSequenceBase::initTheFile()");
+          std::ostringstream out;
+          out << "Input file " << fileName() << " could not be opened.\n";
+          out << "Fallback Input file " << fallbackFileName() << " also could not be opened.";
+          if (originalInfo.size()) {
+            out << std::endl << "Original exception info is above; fallback exception info is below.";
+            ex.addAdditionalInfo(out.str());
+            for (auto const & s : originalInfo) {
+              ex.addAdditionalInfo(s);
+            }
+          } else {
+            ex.addAdditionalInfo(out.str());
+          }
+          throw ex;
+        }
       }
     }
-    assert(rootFile_);
-    bool found = rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
-    if(found) {
-      found = rootFile_->readCurrentEvent(cache);
-    }
-    if(!found) {
-      found = skipToItemInNewFile(id.run(), id.luminosityBlock(), 0);
-      if(!found) {
-        return false;
-      }
-      return readOneSequentialWithID(cache, fileNameHash, id);
-    }
-    fileNameHash = lfnHash_;
-    return true;
-  }
-
-  void
-  RootInputFileSequence::readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& idx) {
-    firstFile_ = false;
-    if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneSpecified(): no input files specified for secondary input source.\n";
-    }
-    skipBadFiles_ = false;
-    EventID const& id = idx.eventID();
-    bool found = skipToItem(id.run(), id.luminosityBlock(), id.event(), idx.fileNameHash());
-    if(!found) {
-       throw Exception(errors::NotFound) <<
-         "RootInputFileSequence::readOneSpecified(): Secondary Input files" <<
-         " do not contain specified event:\n" << id << "\n";
-    }
-    assert(rootFile_);
-    found = rootFile_->readCurrentEvent(cache);
-    assert(found);
-    fileNameHash = idx.fileNameHash();
-    if(fileNameHash == 0U)  {
-      fileNameHash = lfnHash_;
-    }
-  }
-
-  void
-  RootInputFileSequence::readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine* engine) {
-    firstFile_ = false;
-    if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandom(): no input files specified for secondary input source.\n";
-    }
-    assert(rootFile_);
-    skipBadFiles_ = false;
-    unsigned int currentSeqNumber = fileIter_ - fileIterBegin_;
-    while(eventsRemainingInFile_ == 0) {
-
-      fileIter_ = fileIterBegin_ + CLHEP::RandFlat::shootInt(engine, fileCatalogItems().size());
-      unsigned int newSeqNumber = fileIter_ - fileIterBegin_;
-      if(newSeqNumber != currentSeqNumber) {
-        initFile(false);
-        currentSeqNumber = newSeqNumber;
-      }
-      eventsRemainingInFile_ = rootFile_->eventTree().entries();
-      if(eventsRemainingInFile_ == 0) {
-        throw Exception(errors::NotFound) <<
-           "RootInputFileSequence::readOneRandom(): Secondary Input file " << fileIter_->fileName() << " contains no events.\n";
-      }
-      rootFile_->setAtEventEntry(CLHEP::RandFlat::shootInt(engine, eventsRemainingInFile_) - 1);
-    }
-    rootFile_->nextEventEntry();
-
-    bool found = rootFile_->readCurrentEvent(cache);
-    if(!found) {
-      rootFile_->setAtEventEntry(0);
-      bool found = rootFile_->readCurrentEvent(cache);
-      assert(found);
-    }
-    fileNameHash = lfnHash_;
-    --eventsRemainingInFile_;
-  }
-
-  // bool RootFile::setEntryAtNextEventInLumi(RunNumber_t run, LuminosityBlockNumber_t lumi) {
-
-  bool
-  RootInputFileSequence::readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, CLHEP::HepRandomEngine* engine) {
-    firstFile_ = false;
-    if(fileIterEnd_ == fileIterBegin_) {
-      throw Exception(errors::Configuration) << "RootInputFileSequence::readOneRandomWithID(): no input files specified for secondary input source.\n";
-    }
-    skipBadFiles_ = false;
-    if(fileIter_ == fileIterEnd_ || !rootFile_ ||
-        rootFile_->indexIntoFileIter().run() != id.run() ||
-        rootFile_->indexIntoFileIter().lumi() != id.luminosityBlock()) {
-      bool found = skipToItem(id.run(), id.luminosityBlock(), 0);
-      if(!found) {
-        return false;
-      }
-      int eventsInLumi = 0;
+    if(filePtr) {
+      size_t currentIndexIntoFile = fileIter_ - fileIterBegin_;
+      rootFile_ = makeRootFile(filePtr);
       assert(rootFile_);
-      while(rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock())) ++eventsInLumi;
-      found = skipToItem(id.run(), id.luminosityBlock(), 0);
-      assert(found);
-      int eventInLumi = CLHEP::RandFlat::shootInt(engine, eventsInLumi);
-      for(int i = 0; i < eventInLumi; ++i) {
-        bool found = rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
-        assert(found);
+      fileIterLastOpened_ = fileIter_;
+      setIndexIntoFile(currentIndexIntoFile);
+      rootFile_->reportOpened(inputTypeName);
+    } else {
+      InputFile::reportSkippedFile(fileName(), logicalFileName());
+      if(!skipBadFiles) {
+        throw Exception(errors::FileOpenError) <<
+           "RootFileSequenceBase::initTheFile(): Input file " << fileName() << " was not found or could not be opened.\n";
       }
+      LogWarning("") << "Input file: " << fileName() << " was not found or could not be opened, and will be skipped.\n";
     }
-    assert(rootFile_);
-    bool found = rootFile_->setEntryAtNextEventInLumi(id.run(), id.luminosityBlock());
-    if(found) {
-      found = rootFile_->readCurrentEvent(cache);
-    }
-    if(!found) {
-      bool found = rootFile_->setEntryAtItem(id.run(), id.luminosityBlock(), 0);
-      if(!found) {
-        return false;
-      }
-      return readOneRandomWithID(cache, fileNameHash, id, engine);
-    }
-    fileNameHash = lfnHash_;
-    return true;
   }
-
   void
-  RootInputFileSequence::fillDescription(ParameterSetDescription & desc) {
-    desc.addUntracked<unsigned int>("skipEvents", 0U)
-        ->setComment("Skip the first 'skipEvents' events that otherwise would have been processed.");
-    desc.addUntracked<bool>("noEventSort", true)
-        ->setComment("True:  Process runs, lumis and events in the order they appear in the file (but see notes 1 and 2).\n"
-                     "False: Process runs, lumis and events in each file in numerical order (run#, lumi#, event#) (but see note 3).\n"
-                     "Note 1: Events within the same lumi will always be processed contiguously.\n"
-                     "Note 2: Lumis within the same run will always be processed contiguously.\n"
-                     "Note 3: Any sorting occurs independently in each input file (no sorting across input files).");
-    desc.addUntracked<bool>("skipBadFiles", false)
-        ->setComment("True:  Ignore any missing or unopenable input file.\n"
-                     "False: Throw exception if missing or unopenable input file.");
-    desc.addUntracked<bool>("bypassVersionCheck", false)
-        ->setComment("True:  Bypass release version check.\n"
-                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
-    desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
-        ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
-    desc.addUntracked<int>("treeMaxVirtualSize", -1)
-        ->setComment("Size of ROOT TTree TBasket cache.  Affects performance.");
-    desc.addUntracked<unsigned int>("setRunNumber", 0U)
-        ->setComment("If non-zero, change number of first run to this number. Apply same offset to all runs.  Allowed only for simulation.");
-    desc.addUntracked<bool>("dropDescendantsOfDroppedBranches", true)
-        ->setComment("If True, also drop on input any descendent of any branch dropped on input.");
-    std::string defaultString("permissive");
-    desc.addUntracked<std::string>("branchesMustMatch", defaultString)
-        ->setComment("'strict':     Branches in each input file must match those in the first file.\n"
-                     "'permissive': Branches in each input file may be any subset of those in the first file.");
-    desc.addUntracked<bool>("labelRawDataLikeMC", true)
-        ->setComment("If True: replace module label for raw data to match MC. Also use 'LHC' as process.");
-
-    ProductSelectorRules::fillDescription(desc, "inputCommands");
-    EventSkipperByID::fillDescription(desc);
-    DuplicateChecker::fillDescription(desc);
-  }
-
-  ProcessingController::ForwardState
-  RootInputFileSequence::forwardState() const {
-    if(rootFile_) {
-      if(!rootFile_->wasLastEventJustRead()) {
-        return ProcessingController::kEventsAheadInFile;
-      }
-      std::vector<FileCatalogItem>::const_iterator itr(fileIter_);
-      if(itr != fileIterEnd_) ++itr;
-      if(itr != fileIterEnd_) {
-        return ProcessingController::kNextFileExists;
-      }
-      return ProcessingController::kAtLastEvent;
-    }
-    return ProcessingController::kUnknownForward;
-  }
-
-  ProcessingController::ReverseState
-  RootInputFileSequence::reverseState() const {
-    if(rootFile_) {
-      if(!rootFile_->wasFirstEventJustRead()) {
-        return ProcessingController::kEventsBackwardsInFile;
-      }
-      if(fileIter_ != fileIterBegin_) {
-        return ProcessingController::kPreviousFileExists;
-      }
-      return ProcessingController::kAtFirstEvent;
-    }
-    return ProcessingController::kUnknownReverse;
-  }
-
-  void RootInputFileSequence::initAssociationsFromSecondary(std::set<BranchID> const& associationsFromSecondary) {
-    for(auto const& branchID : associationsFromSecondary) {
-      associationsFromSecondary_.push_back(branchID);
-    }
-    rootFile_->initAssociationsFromSecondary(associationsFromSecondary_);
+  RootInputFileSequence::setIndexIntoFile(size_t index) {
+   indexesIntoFiles_[index] = rootFile()->indexIntoFileSharedPtr();
   }
 }

--- a/IOPool/Input/src/RootInputFileSequence.h
+++ b/IOPool/Input/src/RootInputFileSequence.h
@@ -7,129 +7,93 @@ RootInputFileSequence: This is an InputSource
 
 ----------------------------------------------------------------------*/
 
+#include "InputFile.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/ProductSelectorRules.h"
-#include "FWCore/Framework/interface/ProcessingController.h"
-#include "FWCore/Sources/interface/EventSkipperByID.h"
-#include "FWCore/Sources/interface/VectorInputSource.h"
+#include "FWCore/Catalog/interface/InputFileCatalog.h"
 #include "FWCore/Utilities/interface/InputType.h"
-#include "DataFormats/Provenance/interface/BranchDescription.h"
-#include "DataFormats/Provenance/interface/IndexIntoFile.h"
-#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
 
 #include <memory>
-#include <set>
 #include <string>
 #include <unordered_map>
 #include <vector>
 
-namespace CLHEP {
-  class HepRandomEngine;
-}
-
 namespace edm {
 
-  class BranchID;
-  class DuplicateChecker;
   class FileCatalogItem;
+  class IndexIntoFile;
   class InputFileCatalog;
   class ParameterSetDescription;
-  class PoolSource;
   class RootFile;
 
   class RootInputFileSequence {
   public:
     explicit RootInputFileSequence(ParameterSet const& pset,
-                                   PoolSource& input,
-                                   InputFileCatalog const& catalog,
-                                   unsigned int nStreams,
-                                   InputType inputType);
+                                   InputFileCatalog const& catalog);
     virtual ~RootInputFileSequence();
 
     RootInputFileSequence(RootInputFileSequence const&) = delete; // Disallow copying and moving
     RootInputFileSequence& operator=(RootInputFileSequence const&) = delete; // Disallow copying and moving
 
-    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
+    bool containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
     void readEvent(EventPrincipal& cache);
     std::shared_ptr<LuminosityBlockAuxiliary> readLuminosityBlockAuxiliary_();
     void readLuminosityBlock_(LuminosityBlockPrincipal& lumiPrincipal);
     std::shared_ptr<RunAuxiliary> readRunAuxiliary_();
     void readRun_(RunPrincipal& runPrincipal);
-    std::unique_ptr<FileBlock> readFile_();
-    void closeFile_();
-    void endJob();
-    InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
-    bool containedInCurrentFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event) const;
-    void skipEntries(unsigned int offset);
-    bool skipEvents(int offset);
-    bool goToEvent(EventID const& eventID);
     bool skipToItem(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, size_t fileNameHash = 0U, bool currentFileFirst = true);
-    bool skipToItemInNewFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event);
-    bool skipToItemInNewFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, size_t fileNameHash);
-    void rewind_();
-    void readOneRandom(EventPrincipal& cache, size_t& fileNameHash, CLHEP::HepRandomEngine*);
-    bool readOneRandomWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id, CLHEP::HepRandomEngine*);
-    bool readOneSequential(EventPrincipal& cache, size_t& fileNameHash);
-    bool readOneSequentialWithID(EventPrincipal& cache, size_t& fileNameHash, LuminosityBlockID const& id);
-    void readOneSpecified(EventPrincipal& cache, size_t& fileNameHash, SecondaryEventIDAndFileInfo const& id);
-
-    void dropUnwantedBranches_(std::vector<std::string> const& wantedBranches);
     std::shared_ptr<ProductRegistry const> fileProductRegistry() const;
     std::shared_ptr<BranchIDListHelper const> fileBranchIDListHelper() const;
-    ProcessHistoryRegistry const& processHistoryRegistry() const;
-    ProcessHistoryRegistry& processHistoryRegistryForUpdate();
-    static void fillDescription(ParameterSetDescription & desc);
-    ProcessingController::ForwardState forwardState() const;
-    ProcessingController::ReverseState reverseState() const;
-    void initAssociationsFromSecondary(std::set<BranchID> const&);
-  private:
-    void initFile(bool skipBadFiles);
-    bool nextFile();
-    bool previousFile();
-    void rewindFile();
+  protected:
+    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
+    void initFile(bool skipBadFiles) {initFile_(skipBadFiles);}
+    void initTheFile(bool skipBadFiles, bool deleteIndexIntoFile, InputSource* input, char const* inputTypeName, InputType inputType);
+    bool skipToItemInNewFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event);
+    bool skipToItemInNewFile(RunNumber_t run, LuminosityBlockNumber_t lumi, EventNumber_t event, size_t fileNameHash);
+
+    bool atFirstFile() const {return fileIter_ == fileIterBegin_;}
+    bool atLastFile() const {return fileIter_ + 1 == fileIterEnd_;}
+    bool noMoreFiles() const {return fileIter_ == fileIterEnd_;}
+    bool noFiles() const {return fileIterBegin_ == fileIterEnd_;}
+    size_t sequenceNumberOfFile() const {return fileIter_ - fileIterBegin_;}
+    size_t numberOfFiles() const {return fileIterEnd_ - fileIterBegin_;}
+
+    void setAtFirstFile() {fileIter_ = fileIterBegin_;}
+    void setAtFileSequenceNumber(size_t offset) {fileIter_ = fileIterBegin_ + offset;}
+    void setNoMoreFiles() {fileIter_ = fileIterEnd_;}
+    void setAtNextFile() {++fileIter_;}
+    void setAtPreviousFile() {--fileIter_;}
+
+    std::string const& fileName() const {return fileIter_->fileName();}
+    std::string const& logicalFileName() const {return fileIter_->logicalFileName();}
+    std::string const& fallbackFileName() const {return fileIter_->fallbackFileName();}
+    std::string const& lfn() const {return lfn_;}
     std::vector<FileCatalogItem> const& fileCatalogItems() const;
 
-    std::shared_ptr<ProductRegistry const> productRegistry() const;
-    ProcessConfiguration const& processConfiguration() const;
-    ProductRegistry & productRegistryUpdate() const;
-    int remainingEvents() const;
-    int remainingLuminosityBlocks() const;
+    std::vector<std::shared_ptr<IndexIntoFile> > const& indexesIntoFiles() const {return indexesIntoFiles_;}
+    void setIndexIntoFile(size_t index);
+    size_t lfnHash() const {return lfnHash_;}
+    bool usedFallback() const {return usedFallback_;}
 
-    PoolSource& input_;
-    InputType inputType_;
+    RootFileSharedPtr const& rootFile() const {return rootFile_;}
+    RootFileSharedPtr& rootFile() {return rootFile_;}
+  private:
     InputFileCatalog const& catalog_;
-    bool firstFile_;
     std::string lfn_;
     size_t lfnHash_;
+    bool usedFallback_;
     std::unique_ptr<std::unordered_multimap<size_t, size_t> > findFileForSpecifiedID_;
-    std::vector<FileCatalogItem>::const_iterator fileIterBegin_;
-    std::vector<FileCatalogItem>::const_iterator fileIterEnd_;
+    std::vector<FileCatalogItem>::const_iterator const fileIterBegin_;
+    std::vector<FileCatalogItem>::const_iterator const fileIterEnd_;
     std::vector<FileCatalogItem>::const_iterator fileIter_;
     std::vector<FileCatalogItem>::const_iterator fileIterLastOpened_;
     RootFileSharedPtr rootFile_;
-    BranchDescription::MatchMode branchesMustMatch_;
-
     std::vector<std::shared_ptr<IndexIntoFile> > indexesIntoFiles_;
-    std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
-    std::vector<BranchID> associationsFromSecondary_;
 
-    unsigned int nStreams_; 
-    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
-    int eventsRemainingInFile_;
-    int initialNumberOfEventsToSkip_;
-    bool noEventSort_;
-    bool skipBadFiles_;
-    bool bypassVersionCheck_;
-    unsigned int treeCacheSize_;
-    int const treeMaxVirtualSize_;
-    RunNumber_t setRun_;
-    ProductSelectorRules productSelectorRules_;
-    std::shared_ptr<DuplicateChecker> duplicateChecker_;
-    bool dropDescendants_;
-    bool labelRawDataLikeMC_;
-    bool usingGoToEvent_;
-    bool enablePrefetching_;
-    bool usedFallback_;
+  private:
+    virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) = 0; 
+    virtual void initFile_(bool skipBadFiles) = 0;
+    virtual void closeFile_() = 0;
+
   }; // class RootInputFileSequence
 }
 #endif

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -1,0 +1,407 @@
+/*----------------------------------------------------------------------
+----------------------------------------------------------------------*/
+#include "DuplicateChecker.h"
+#include "InputFile.h"
+#include "PoolSource.h"
+#include "RootFile.h"
+#include "RootPrimaryFileSequence.h"
+#include "RootTree.h"
+
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/Framework/interface/FileBlock.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Utilities/StorageFactory/interface/StorageFactory.h"
+
+namespace edm {
+  RootPrimaryFileSequence::RootPrimaryFileSequence(
+                ParameterSet const& pset,
+                PoolSource& input,
+                InputFileCatalog const& catalog,
+                unsigned int nStreams) :
+    RootInputFileSequence(pset, catalog),
+    input_(input),
+    firstFile_(true),
+    branchesMustMatch_(BranchDescription::Permissive),
+    orderedProcessHistoryIDs_(),
+    nStreams_(nStreams),
+    eventSkipperByID_(EventSkipperByID::create(pset).release()),
+    // The default value provided as the second argument to the getUntrackedParameter function call
+    // is not used when the ParameterSet has been validated and the parameters are not optional
+    // in the description.  This is currently true when PoolSource is the primary input source.
+    // The modules that use PoolSource as a SecSource have not defined their fillDescriptions function
+    // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
+    // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
+    // and should be deleted from the code.
+    initialNumberOfEventsToSkip_(pset.getUntrackedParameter<unsigned int>("skipEvents", 0U)),
+    noEventSort_(pset.getUntrackedParameter<bool>("noEventSort", true)),
+    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
+    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
+    treeCacheSize_(noEventSort_ ? pset.getUntrackedParameter<unsigned int>("cacheSize", roottree::defaultCacheSize) : 0U),
+    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
+    setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber", 0U)),
+    productSelectorRules_(pset, "inputCommands", "InputSource"),
+    duplicateChecker_(new DuplicateChecker(pset)),
+    dropDescendants_(pset.getUntrackedParameter<bool>("dropDescendantsOfDroppedBranches", true)),
+    labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC", true)),
+    usingGoToEvent_(false),
+    enablePrefetching_(false) {
+
+    // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
+    Service<SiteLocalConfig> pSLC;
+    if(pSLC.isAvailable()) {
+      if(treeCacheSize_ != 0U && pSLC->sourceTTreeCacheSize()) {
+        treeCacheSize_ = *(pSLC->sourceTTreeCacheSize());
+      }
+      enablePrefetching_ = pSLC->enablePrefetching();
+    }
+
+    std::string branchesMustMatch = pset.getUntrackedParameter<std::string>("branchesMustMatch", std::string("permissive"));
+    if(branchesMustMatch == std::string("strict")) branchesMustMatch_ = BranchDescription::Strict;
+
+    StorageFactory *factory = StorageFactory::get();
+
+    // Prestage the files
+    for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {
+      factory->activateTimeout(fileName());
+      factory->stagein(fileName());
+    }
+    // Open the first file.
+    for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {
+      initFile(skipBadFiles_);
+      if(rootFile()) break;
+    }
+    if(rootFile()) {
+      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList());
+      if(initialNumberOfEventsToSkip_ != 0) {
+        skipEvents(initialNumberOfEventsToSkip_);
+      }
+    }
+  }
+
+  RootPrimaryFileSequence::~RootPrimaryFileSequence() {
+  }
+
+  void
+  RootPrimaryFileSequence::endJob() {
+    closeFile_();
+  }
+
+  std::unique_ptr<FileBlock>
+  RootPrimaryFileSequence::readFile_() {
+    if(firstFile_) {
+      // The first input file has already been opened.
+      firstFile_ = false;
+      if(!rootFile()) {
+        initFile(skipBadFiles_);
+      }
+    } else {
+      if(!nextFile()) {
+        assert(0);
+      }
+    }
+    if(!rootFile()) {
+      return std::unique_ptr<FileBlock>(new FileBlock);
+    }
+    return rootFile()->createFileBlock();
+  }
+
+  void
+  RootPrimaryFileSequence::closeFile_() {
+    // close the currently open file, if any, and delete the RootFile object.
+    if(rootFile()) {
+      std::unique_ptr<InputSource::FileCloseSentry>
+      sentry(new InputSource::FileCloseSentry(input_, lfn(), usedFallback()));
+      rootFile()->close();
+      if(duplicateChecker_) duplicateChecker_->inputFileClosed();
+      rootFile().reset();
+    }
+  }
+
+  void
+  RootPrimaryFileSequence::initFile_(bool skipBadFiles) {
+    // If we are not duplicate checking across files and we are not using random access to find events,
+    // then we can delete the IndexIntoFile for the file we are closing.
+    // If we can't delete all of it, then we can delete the parts we do not need.
+    bool deleteIndexIntoFile = !usingGoToEvent_ && !(duplicateChecker_ && duplicateChecker_->checkingAllFiles() && !duplicateChecker_->checkDisabled());
+    initTheFile(skipBadFiles, deleteIndexIntoFile, &input_, "primaryFiles", InputType::Primary);
+  }
+
+  RootPrimaryFileSequence::RootFileSharedPtr
+  RootPrimaryFileSequence::makeRootFile(std::shared_ptr<InputFile> filePtr) {
+      size_t currentIndexIntoFile = sequenceNumberOfFile();
+      return std::make_shared<RootFile>(
+          fileName(),
+          input_.processConfiguration(),
+          logicalFileName(),
+          filePtr,
+          eventSkipperByID_,
+          initialNumberOfEventsToSkip_ != 0,
+          remainingEvents(),
+          remainingLuminosityBlocks(),
+	  nStreams_,
+          treeCacheSize_,
+          treeMaxVirtualSize_,
+          input_.processingMode(),
+          setRun_,
+          noEventSort_,
+          productSelectorRules_,
+          InputType::Primary,
+          input_.branchIDListHelper(),
+          input_.thinnedAssociationsHelper(),
+          std::vector<BranchID>(), // associationsFromSecondary_
+          duplicateChecker_,
+          dropDescendants_,
+          input_.processHistoryRegistryForUpdate(),
+          indexesIntoFiles(),
+          currentIndexIntoFile,
+          orderedProcessHistoryIDs_,
+          bypassVersionCheck_,
+          labelRawDataLikeMC_,
+          usingGoToEvent_,
+          enablePrefetching_);
+  }
+
+  bool RootPrimaryFileSequence::nextFile() {
+    if(!noMoreFiles()) setAtNextFile();
+    if(noMoreFiles()) {
+      return false;
+    }
+
+    initFile(skipBadFiles_);
+
+    if(rootFile()) {
+      // make sure the new product registry is compatible with the main one
+      std::string mergeInfo = input_.productRegistryUpdate().merge(*rootFile()->productRegistry(),
+                                                                   fileName(),
+                                                                   branchesMustMatch_);
+      if(!mergeInfo.empty()) {
+        throw Exception(errors::MismatchedInputFiles,"RootPrimaryFileSequence::nextFile()") << mergeInfo;
+      }
+    }
+    return true;
+  }
+
+  bool RootPrimaryFileSequence::previousFile() {
+    if(atFirstFile()) {
+      return false;
+    }
+    setAtPreviousFile();;
+
+    initFile(false);
+
+    if(rootFile()) {
+      // make sure the new product registry is compatible to the main one
+      std::string mergeInfo = input_.productRegistryUpdate().merge(*rootFile()->productRegistry(),
+                                                                   fileName(),
+                                                                   branchesMustMatch_);
+      if(!mergeInfo.empty()) {
+        throw Exception(errors::MismatchedInputFiles,"RootPrimaryFileSequence::previousEvent()") << mergeInfo;
+      }
+    }
+    if(rootFile()) rootFile()->setToLastEntry();
+    return true;
+  }
+
+  InputSource::ItemType
+  RootPrimaryFileSequence::getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event) {
+    if(noMoreFiles()) {
+      return InputSource::IsStop;
+    }
+    if(firstFile_) {
+      return InputSource::IsFile;
+    }
+    if(rootFile()) {
+      IndexIntoFile::EntryType entryType = rootFile()->getNextItemType(run, lumi, event);
+      if(entryType == IndexIntoFile::kEvent) {
+        return InputSource::IsEvent;
+      } else if(entryType == IndexIntoFile::kLumi) {
+        return InputSource::IsLumi;
+      } else if(entryType == IndexIntoFile::kRun) {
+        return InputSource::IsRun;
+      }
+      assert(entryType == IndexIntoFile::kEnd);
+    }
+    if(atLastFile()) {
+      return InputSource::IsStop;
+    }
+    return InputSource::IsFile;
+  }
+
+  // Rewind to before the first event that was read.
+  void
+  RootPrimaryFileSequence::rewind_() {
+    if(!atFirstFile()) {
+      closeFile_();
+      setAtFirstFile();
+    }
+    if(!rootFile()) {
+      initFile(false);
+    }
+    rewindFile();
+    firstFile_ = true;
+    if(rootFile()) {
+      if(initialNumberOfEventsToSkip_ != 0) {
+        skipEvents(initialNumberOfEventsToSkip_);
+      }
+    }
+  }
+
+  // Rewind to the beginning of the current file
+  void
+  RootPrimaryFileSequence::rewindFile() {
+    if(rootFile()) rootFile()->rewind();
+  }
+
+  // Advance "offset" events.  Offset can be positive or negative (or zero).
+  bool
+  RootPrimaryFileSequence::skipEvents(int offset) {
+    assert(rootFile());
+    while(offset != 0) {
+      bool atEnd = rootFile()->skipEvents(offset);
+      if((offset > 0 || atEnd) && !nextFile()) {
+        return false;
+      }
+      if(offset < 0 && !previousFile()) {
+        setNoMoreFiles();
+        return false;
+      }
+    }
+    return true;
+  }
+
+  bool
+  RootPrimaryFileSequence::goToEvent(EventID const& eventID) {
+    usingGoToEvent_ = true;
+    if(rootFile()) {
+      if(rootFile()->goToEvent(eventID)) {
+        return true;
+      }
+      // If only one input file, give up now, to save time.
+      if(rootFile() && indexesIntoFiles().size() == 1) {
+        return false;
+      }
+      // Save the current file and position so that we can restore them
+      // if we fail to restore the desired event
+      bool closedOriginalFile = false;
+      size_t const originalFileSequenceNumber = sequenceNumberOfFile();
+      IndexIntoFile::IndexIntoFileItr originalPosition = rootFile()->indexIntoFileIter();
+
+      // Look for item (run/lumi/event) in files previously opened without reopening unnecessary files.
+      typedef std::vector<std::shared_ptr<IndexIntoFile> >::const_iterator Iter;
+      for(Iter it = indexesIntoFiles().begin(), itEnd = indexesIntoFiles().end(); it != itEnd; ++it) {
+        if(*it && (*it)->containsItem(eventID.run(), eventID.luminosityBlock(), eventID.event())) {
+          // We found it. Close the currently open file, and open the correct one.
+          setAtFileSequenceNumber(it - indexesIntoFiles().begin());
+          initFile(false);
+          // Now get the item from the correct file.
+          assert(rootFile());
+          bool found = rootFile()->goToEvent(eventID);
+          assert(found);
+          return true;
+        }
+      }
+      // Look for item in files not yet opened.
+      for(Iter it = indexesIntoFiles().begin(), itEnd = indexesIntoFiles().end(); it != itEnd; ++it) {
+        if(!*it) {
+          setAtFileSequenceNumber(it - indexesIntoFiles().begin());
+          initFile(false);
+          closedOriginalFile = true;
+          if((*it)->containsItem(eventID.run(), eventID.luminosityBlock(), eventID.event())) {
+            assert(rootFile());
+            if(rootFile()->goToEvent(eventID)) {
+              return true;
+            }
+          }
+        }
+      }
+      if(closedOriginalFile) {
+        setAtFileSequenceNumber(originalFileSequenceNumber);
+        initFile(false);
+        assert(rootFile());
+        rootFile()->setPosition(originalPosition);
+      }
+    }
+    return false;
+  }
+
+  int
+  RootPrimaryFileSequence::remainingEvents() const {
+    return input_.remainingEvents();
+  }
+
+  int
+  RootPrimaryFileSequence::remainingLuminosityBlocks() const {
+    return input_.remainingLuminosityBlocks();
+  }
+
+  void
+  RootPrimaryFileSequence::fillDescription(ParameterSetDescription & desc) {
+    desc.addUntracked<unsigned int>("skipEvents", 0U)
+        ->setComment("Skip the first 'skipEvents' events that otherwise would have been processed.");
+    desc.addUntracked<bool>("noEventSort", true)
+        ->setComment("True:  Process runs, lumis and events in the order they appear in the file (but see notes 1 and 2).\n"
+                     "False: Process runs, lumis and events in each file in numerical order (run#, lumi#, event#) (but see note 3).\n"
+                     "Note 1: Events within the same lumi will always be processed contiguously.\n"
+                     "Note 2: Lumis within the same run will always be processed contiguously.\n"
+                     "Note 3: Any sorting occurs independently in each input file (no sorting across input files).");
+    desc.addUntracked<bool>("skipBadFiles", false)
+        ->setComment("True:  Ignore any missing or unopenable input file.\n"
+                     "False: Throw exception if missing or unopenable input file.");
+    desc.addUntracked<bool>("bypassVersionCheck", false)
+        ->setComment("True:  Bypass release version check.\n"
+                     "False: Throw exception if reading file in a release prior to the release in which the file was written.");
+    desc.addUntracked<unsigned int>("cacheSize", roottree::defaultCacheSize)
+        ->setComment("Size of ROOT TTree prefetch cache.  Affects performance.");
+    desc.addUntracked<int>("treeMaxVirtualSize", -1)
+        ->setComment("Size of ROOT TTree TBasket cache.  Affects performance.");
+    desc.addUntracked<unsigned int>("setRunNumber", 0U)
+        ->setComment("If non-zero, change number of first run to this number. Apply same offset to all runs.  Allowed only for simulation.");
+    desc.addUntracked<bool>("dropDescendantsOfDroppedBranches", true)
+        ->setComment("If True, also drop on input any descendent of any branch dropped on input.");
+    std::string defaultString("permissive");
+    desc.addUntracked<std::string>("branchesMustMatch", defaultString)
+        ->setComment("'strict':     Branches in each input file must match those in the first file.\n"
+                     "'permissive': Branches in each input file may be any subset of those in the first file.");
+    desc.addUntracked<bool>("labelRawDataLikeMC", true)
+        ->setComment("If True: replace module label for raw data to match MC. Also use 'LHC' as process.");
+
+    ProductSelectorRules::fillDescription(desc, "inputCommands");
+    EventSkipperByID::fillDescription(desc);
+    DuplicateChecker::fillDescription(desc);
+  }
+
+  ProcessingController::ForwardState
+  RootPrimaryFileSequence::forwardState() const {
+    if(rootFile()) {
+      if(!rootFile()->wasLastEventJustRead()) {
+        return ProcessingController::kEventsAheadInFile;
+      }
+      if(noMoreFiles() || atLastFile()) { 
+        return ProcessingController::kAtLastEvent;
+      } else {
+        return ProcessingController::kNextFileExists;
+      }
+    }
+    return ProcessingController::kUnknownForward;
+  }
+
+  ProcessingController::ReverseState
+  RootPrimaryFileSequence::reverseState() const {
+    if(rootFile()) {
+      if(!rootFile()->wasFirstEventJustRead()) {
+        return ProcessingController::kEventsBackwardsInFile;
+      }
+      if(!atFirstFile()) {
+        return ProcessingController::kPreviousFileExists;
+      }
+      return ProcessingController::kAtFirstEvent;
+    }
+    return ProcessingController::kUnknownReverse;
+  }
+
+}

--- a/IOPool/Input/src/RootPrimaryFileSequence.h
+++ b/IOPool/Input/src/RootPrimaryFileSequence.h
@@ -1,0 +1,87 @@
+#ifndef IOPool_Input_RootPrimaryFileSequence_h
+#define IOPool_Input_RootPrimaryFileSequence_h
+
+/*----------------------------------------------------------------------
+
+RootPrimaryFileSequence: This is an InputSource
+
+----------------------------------------------------------------------*/
+
+#include "RootInputFileSequence.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/InputSource.h"
+#include "FWCore/Framework/interface/ProductSelectorRules.h"
+#include "FWCore/Framework/interface/ProcessingController.h"
+#include "FWCore/Sources/interface/EventSkipperByID.h"
+#include "DataFormats/Provenance/interface/BranchDescription.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class BranchID;
+  class DuplicateChecker;
+  class FileCatalogItem;
+  class InputFileCatalog;
+  class ParameterSetDescription;
+  class PoolSource;
+  class RootFile;
+
+  class RootPrimaryFileSequence : public RootInputFileSequence{
+  public:
+    explicit RootPrimaryFileSequence(ParameterSet const& pset,
+                                   PoolSource& input,
+                                   InputFileCatalog const& catalog,
+                                   unsigned int nStreams);
+    virtual ~RootPrimaryFileSequence();
+
+    RootPrimaryFileSequence(RootPrimaryFileSequence const&) = delete; // Disallow copying and moving
+    RootPrimaryFileSequence& operator=(RootPrimaryFileSequence const&) = delete; // Disallow copying and moving
+
+    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
+    std::unique_ptr<FileBlock> readFile_();
+    virtual void closeFile_() override;
+    void endJob();
+    InputSource::ItemType getNextItemType(RunNumber_t& run, LuminosityBlockNumber_t& lumi, EventNumber_t& event);
+    bool skipEvents(int offset);
+    bool goToEvent(EventID const& eventID);
+    void rewind_();
+    static void fillDescription(ParameterSetDescription & desc);
+    ProcessingController::ForwardState forwardState() const;
+    ProcessingController::ReverseState reverseState() const;
+  private:
+    virtual void initFile_(bool skipBadFiles) override;
+    virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
+    bool nextFile();
+    bool previousFile();
+    void rewindFile();
+
+    int remainingEvents() const;
+    int remainingLuminosityBlocks() const;
+
+    PoolSource& input_;
+    bool firstFile_;
+    BranchDescription::MatchMode branchesMustMatch_;
+    std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
+
+    unsigned int nStreams_; 
+    std::shared_ptr<EventSkipperByID> eventSkipperByID_;
+    int initialNumberOfEventsToSkip_;
+    bool noEventSort_;
+    bool skipBadFiles_;
+    bool bypassVersionCheck_;
+    unsigned int treeCacheSize_;
+    int const treeMaxVirtualSize_;
+    RunNumber_t setRun_;
+    ProductSelectorRules productSelectorRules_;
+    std::shared_ptr<DuplicateChecker> duplicateChecker_;
+    bool dropDescendants_;
+    bool labelRawDataLikeMC_;
+    bool usingGoToEvent_;
+    bool enablePrefetching_;
+  }; // class RootPrimaryFileSequence
+}
+#endif

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -1,0 +1,136 @@
+/*----------------------------------------------------------------------
+----------------------------------------------------------------------*/
+#include "DuplicateChecker.h"
+#include "PoolSource.h"
+#include "InputFile.h"
+#include "RootFile.h"
+#include "RootSecondaryFileSequence.h"
+#include "RootTree.h"
+
+#include "DataFormats/Provenance/interface/BranchID.h"
+#include "DataFormats/Provenance/interface/ProductRegistry.h"
+#include "FWCore/Catalog/interface/InputFileCatalog.h"
+#include "FWCore/Catalog/interface/SiteLocalConfig.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "Utilities/StorageFactory/interface/StorageFactory.h"
+
+namespace edm {
+  RootSecondaryFileSequence::RootSecondaryFileSequence(
+                ParameterSet const& pset,
+                PoolSource& input,
+                InputFileCatalog const& catalog,
+                unsigned int nStreams) :
+    RootInputFileSequence(pset, catalog),
+    input_(input),
+    firstFile_(true),
+    orderedProcessHistoryIDs_(),
+    nStreams_(nStreams),
+    // The default value provided as the second argument to the getUntrackedParameter function call
+    // is not used when the ParameterSet has been validated and the parameters are not optional
+    // in the description.  This is currently true when PoolSource is the primary input source.
+    // The modules that use PoolSource as a SecSource have not defined their fillDescriptions function
+    // yet, so the ParameterSet does not get validated yet.  As soon as all the modules with a SecSource
+    // have defined descriptions, the defaults in the getUntrackedParameterSet function calls can
+    // and should be deleted from the code.
+    skipBadFiles_(pset.getUntrackedParameter<bool>("skipBadFiles", false)),
+    bypassVersionCheck_(pset.getUntrackedParameter<bool>("bypassVersionCheck", false)),
+    treeMaxVirtualSize_(pset.getUntrackedParameter<int>("treeMaxVirtualSize", -1)),
+    setRun_(pset.getUntrackedParameter<unsigned int>("setRunNumber", 0U)),
+    productSelectorRules_(pset, "inputCommands", "InputSource"),
+    dropDescendants_(pset.getUntrackedParameter<bool>("dropDescendantsOfDroppedBranches", true)),
+    labelRawDataLikeMC_(pset.getUntrackedParameter<bool>("labelRawDataLikeMC", true)),
+    enablePrefetching_(false) {
+
+    // The SiteLocalConfig controls the TTreeCache size and the prefetching settings.
+    Service<SiteLocalConfig> pSLC;
+    if(pSLC.isAvailable()) {
+      enablePrefetching_ = pSLC->enablePrefetching();
+    }
+
+    StorageFactory *factory = StorageFactory::get();
+
+    // Prestage the files
+    //NOTE: we do not want to stage in all secondary files since we can be given a list of
+    // thousands of files and prestaging all those files can cause a site to fail.
+    // So, we stage in the first secondary file only.
+    setAtFirstFile();
+    factory->activateTimeout(fileName());
+    factory->stagein(fileName());
+
+    // Open the first file.
+    for(setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {
+      initFile(skipBadFiles_);
+      if(rootFile()) break;
+    }
+    if(rootFile()) {
+      input_.productRegistryUpdate().updateFromInput(rootFile()->productRegistry()->productList());
+    }
+  }
+
+  RootSecondaryFileSequence::~RootSecondaryFileSequence() {
+  }
+
+  void
+  RootSecondaryFileSequence::endJob() {
+    closeFile_();
+  }
+
+  void
+  RootSecondaryFileSequence::closeFile_() {
+    // close the currently open file, if any, and delete the RootFile object.
+    if(rootFile()) {
+      rootFile()->close();
+      rootFile().reset();
+    }
+  }
+
+  void RootSecondaryFileSequence::initFile_(bool skipBadFiles) {
+    initTheFile(skipBadFiles, false, nullptr, "secondaryFiles", InputType::SecondaryFile);
+  }
+
+  RootSecondaryFileSequence::RootFileSharedPtr
+  RootSecondaryFileSequence::makeRootFile(std::shared_ptr<InputFile> filePtr) {
+    size_t currentIndexIntoFile = sequenceNumberOfFile();
+    return std::make_shared<RootFile>(
+          fileName(),
+          input_.processConfiguration(),
+          logicalFileName(),
+          filePtr,
+          nullptr, // eventSkipperByID_
+          false,   // initialNumberOfEventsToSkip_ != 0
+          -1,      // remainingEvents() 
+          -1,      // remainingLuminosityBlocks()
+	  nStreams_,
+          0U,      // treeCacheSize_
+          treeMaxVirtualSize_,
+          input_.processingMode(),
+          setRun_,
+          false,   // noEventSort_
+          productSelectorRules_,
+          InputType::SecondaryFile,
+          input_.branchIDListHelper(),
+          input_.thinnedAssociationsHelper(),
+          associationsFromSecondary_,
+          nullptr, //duplicateChecker_
+          dropDescendants_,
+          input_.processHistoryRegistryForUpdate(),
+          indexesIntoFiles(),
+          currentIndexIntoFile,
+          orderedProcessHistoryIDs_,
+          bypassVersionCheck_,
+          labelRawDataLikeMC_,
+          false,   // usingGoToEvent_
+          enablePrefetching_);
+  }
+
+  void
+  RootSecondaryFileSequence::initAssociationsFromSecondary(std::set<BranchID> const& associationsFromSecondary) {
+    for(auto const& branchID : associationsFromSecondary) {
+      associationsFromSecondary_.push_back(branchID);
+    }
+    rootFile()->initAssociationsFromSecondary(associationsFromSecondary_);
+  }
+}

--- a/IOPool/Input/src/RootSecondaryFileSequence.h
+++ b/IOPool/Input/src/RootSecondaryFileSequence.h
@@ -1,0 +1,65 @@
+#ifndef IOPool_Input_RootSecondaryFileSequence_h
+#define IOPool_Input_RootSecondaryFileSequence_h
+
+/*----------------------------------------------------------------------
+
+RootSecondaryFileSequence: This is an InputSource
+
+----------------------------------------------------------------------*/
+
+#include "RootInputFileSequence.h"
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/ProductSelectorRules.h"
+#include "DataFormats/Provenance/interface/ProcessHistoryID.h"
+
+#include <memory>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace edm {
+
+  class BranchID;
+  class FileCatalogItem;
+  class InputFileCatalog;
+  class ParameterSetDescription;
+  class PoolSource;
+  class RootFile;
+
+  class RootSecondaryFileSequence : public RootInputFileSequence {
+  public:
+    explicit RootSecondaryFileSequence(ParameterSet const& pset,
+                                   PoolSource& input,
+                                   InputFileCatalog const& catalog,
+                                   unsigned int nStreams);
+    virtual ~RootSecondaryFileSequence();
+
+    RootSecondaryFileSequence(RootSecondaryFileSequence const&) = delete; // Disallow copying and moving
+    RootSecondaryFileSequence& operator=(RootSecondaryFileSequence const&) = delete; // Disallow copying and moving
+
+    typedef std::shared_ptr<RootFile> RootFileSharedPtr;
+    virtual void closeFile_() override;
+    void endJob();
+    static void fillDescription(ParameterSetDescription & desc);
+    void initAssociationsFromSecondary(std::set<BranchID> const&);
+  private:
+    virtual void initFile_(bool skipBadFiles) override;
+    virtual RootFileSharedPtr makeRootFile(std::shared_ptr<InputFile> filePtr) override; 
+
+    PoolSource& input_;
+    bool firstFile_;
+    std::vector<BranchID> associationsFromSecondary_;
+    std::vector<ProcessHistoryID> orderedProcessHistoryIDs_;
+
+    unsigned int nStreams_; 
+    bool skipBadFiles_;
+    bool bypassVersionCheck_;
+    int const treeMaxVirtualSize_;
+    RunNumber_t setRun_;
+    ProductSelectorRules productSelectorRules_;
+    bool dropDescendants_;
+    bool labelRawDataLikeMC_;
+    bool enablePrefetching_;
+  }; // class RootSecondaryFileSequence
+}
+#endif

--- a/IOPool/SecondaryInput/test/SecondaryInLumiInputTest_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondaryInLumiInputTest_cfg.py
@@ -17,8 +17,8 @@ process.source = cms.Source("PoolSource",
 )
 
 process.Thing = cms.EDProducer("SecondaryProducer",
-    lumiSpecified = cms.untracked.bool(True),
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
+         sameLumiBlock = cms.untracked.bool(True),
         fileNames = cms.untracked.vstring('file:SecondaryInputTest2.root')
     )
 )

--- a/IOPool/SecondaryInput/test/SecondaryInputTest_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondaryInputTest_cfg.py
@@ -17,7 +17,7 @@ process.source = cms.Source("PoolSource",
 )
 
 process.Thing = cms.EDProducer("SecondaryProducer",
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         fileNames = cms.untracked.vstring('file:SecondaryInputTest2.root')
     )
 )

--- a/IOPool/SecondaryInput/test/SecondaryProducer.cc
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.cc
@@ -17,7 +17,6 @@
 #include "FWCore/Framework/interface/ConstProductRegistry.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
-#include "FWCore/Framework/interface/InputSourceDescription.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "DataFormats/Provenance/interface/BranchIDListHelper.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
@@ -26,6 +25,7 @@
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Sources/interface/VectorInputSource.h"
+#include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Sources/interface/VectorInputSourceFactory.h"
 #include "FWCore/Utilities/interface/GetPassID.h"
 #include "FWCore/Utilities/interface/ProductKindOfType.h"
@@ -52,9 +52,8 @@ namespace edm {
         secInput_(makeSecInput(pset)),
         processConfiguration_(new ProcessConfiguration(std::string("PROD"), getReleaseVersion(), getPassID())),
         eventPrincipal_(),
-        sequential_(pset.getUntrackedParameter<bool>("sequential", false)),
+        sequential_(pset.getUntrackedParameter<bool>("seq", false)),
         specified_(pset.getUntrackedParameter<bool>("specified", false)),
-        lumiSpecified_(pset.getUntrackedParameter<bool>("lumiSpecified", false)),
         firstEvent_(true),
         firstLoop_(true),
         expectedEventNumber_(sequential_ ? pset.getParameterSet("input").getUntrackedParameter<unsigned int>("skipEvents", 0) + 1 : 1) {
@@ -70,8 +69,8 @@ namespace edm {
 
   void SecondaryProducer::beginJob() {
     eventPrincipal_.reset(new EventPrincipal(secInput_->productRegistry(),
-                                             secInput_->branchIDListHelper(),
-                                             secInput_->thinnedAssociationsHelper(),
+                                             std::make_shared<BranchIDListHelper>(),
+                                             std::make_shared<ThinnedAssociationsHelper>(),
                                              *processConfiguration_,
                                              nullptr));
 
@@ -85,36 +84,25 @@ namespace edm {
     using std::placeholders::_1;
     size_t fileNameHash = 0U;
 
-    if(sequential_) {
-      if(lumiSpecified_) {
-        // Just for simplicity, we use the luminosity block ID from the primary to read the secondary.
-        secInput_->loopSequentialWithID(*eventPrincipal_, fileNameHash, LuminosityBlockID(e.id().run(), e.id().luminosityBlock()), 1, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)));
-      } else {
-        secInput_->loopSequential(*eventPrincipal_, fileNameHash, 1, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)));
-      }
-    } else if(specified_) {
+    if(specified_) {
       // Just for simplicity, we use the event ID from the primary to read the secondary.
       std::vector<SecondaryEventIDAndFileInfo> events(1, SecondaryEventIDAndFileInfo(e.id(), fileNameHash));
       secInput_->loopSpecified(*eventPrincipal_, fileNameHash, events.begin(), events.end(), std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)));
     } else {
-
-      edm::Service<edm::RandomNumberGenerator> rng;
-      if ( ! rng.isAvailable()) {
-        throw cms::Exception("Configuration")
-          << "SecondaryProducer in its random mode requires the RandomNumberGeneratorService\n"
-             "which is not present in the configuration file.  You must add the service\n"
-             "in the configuration file or remove the modules that require it.";
+      CLHEP::HepRandomEngine* engine = nullptr;
+      if (!sequential_) {
+        edm::Service<edm::RandomNumberGenerator> rng;
+        if (!rng.isAvailable()) {
+          throw cms::Exception("Configuration")
+            << "SecondaryProducer requires the RandomNumberGeneratorService,\n"
+               "which is not present in the configuration file.  You must add the service\n"
+               "in the configuration file or remove the modules that require it.";
+        }
+        engine = &rng->getEngine(e.streamID());
       }
-      CLHEP::HepRandomEngine* engine = &rng->getEngine(e.streamID());
-
-      if(lumiSpecified_) {
-        // Just for simplicity, we use the luminosity block ID from the primary to read the secondary.
-        secInput_->loopRandomWithID(*eventPrincipal_, fileNameHash, LuminosityBlockID(e.id().run(), e.id().luminosityBlock()), 1,
-                                    std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)),
-                                    engine);
-      } else {
-        secInput_->loopRandom(*eventPrincipal_, fileNameHash, 1, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)), engine);
-      }
+      // Just for simplicity, we use the event ID from the primary to read the secondary.
+      EventID id = e.id();
+      secInput_->loopOverEvents(*eventPrincipal_, fileNameHash, 1, std::bind(&SecondaryProducer::processOneEvent, this, _1, std::ref(e)), engine, &id);
     }
   }
 
@@ -171,15 +159,9 @@ namespace edm {
   std::shared_ptr<VectorInputSource> SecondaryProducer::makeSecInput(ParameterSet const& ps) {
     ParameterSet const& sec_input = ps.getParameterSet("input");
     PreallocationConfiguration dummy;
-    InputSourceDescription desc(ModuleDescription(),
-                                *productRegistry_,
-				std::make_shared<BranchIDListHelper>(),
-                                std::make_shared<ThinnedAssociationsHelper>(),
-				std::make_shared<ActivityRegistry>(),
-				-1, -1, -1, dummy);
+    VectorInputSourceDescription desc(productRegistry_, dummy);
     std::shared_ptr<VectorInputSource> input_(static_cast<VectorInputSource *>
-      (VectorInputSourceFactory::get()->makeVectorInputSource(sec_input,
-      desc).release()));
+      (VectorInputSourceFactory::get()->makeVectorInputSource(sec_input, desc).release()));
     return input_;
   }
 

--- a/IOPool/SecondaryInput/test/SecondaryProducer.h
+++ b/IOPool/SecondaryInput/test/SecondaryProducer.h
@@ -42,7 +42,7 @@ namespace edm {
 
     std::shared_ptr<VectorInputSource> makeSecInput(ParameterSet const& ps);
 
-    std::unique_ptr<ProductRegistry> productRegistry_;
+    std::shared_ptr<ProductRegistry> productRegistry_;
 
     std::shared_ptr<VectorInputSource> const secInput_;
 
@@ -54,7 +54,7 @@ namespace edm {
 
     bool specified_;
 
-    bool lumiSpecified_;
+    bool sameLumiBlock_;
 
     bool firstEvent_;
 

--- a/IOPool/SecondaryInput/test/SecondarySeqInLumiInputTest_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondarySeqInLumiInputTest_cfg.py
@@ -12,9 +12,10 @@ process.source = cms.Source("PoolSource",
 )
 
 process.Thing = cms.EDProducer("SecondaryProducer",
-    sequential = cms.untracked.bool(True),
-    lumiSpecified = cms.untracked.bool(True),
-    input = cms.SecSource("PoolSource",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
+        sameLumiBlock = cms.untracked.bool(True),
         skipEvents = cms.untracked.uint32(3),
         fileNames = cms.untracked.vstring('file:SecondaryInputTest2.root')
     )

--- a/IOPool/SecondaryInput/test/SecondarySeqInputTest_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondarySeqInputTest_cfg.py
@@ -12,8 +12,9 @@ process.source = cms.Source("PoolSource",
 )
 
 process.Thing = cms.EDProducer("SecondaryProducer",
-    sequential = cms.untracked.bool(True),
-    input = cms.SecSource("PoolSource",
+    seq = cms.untracked.bool(True),
+    input = cms.SecSource("EmbeddedRootSource",
+        sequential = cms.untracked.bool(True),
         skipEvents = cms.untracked.uint32(5),
         fileNames = cms.untracked.vstring('file:SecondaryInputTest2.root')
     )

--- a/IOPool/SecondaryInput/test/SecondarySpecInputTest_cfg.py
+++ b/IOPool/SecondaryInput/test/SecondarySpecInputTest_cfg.py
@@ -13,7 +13,7 @@ process.source = cms.Source("PoolSource",
 
 process.Thing = cms.EDProducer("SecondaryProducer",
     specified = cms.untracked.bool(True),
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         fileNames = cms.untracked.vstring('file:SecondaryInputTest2.root')
     )
 )

--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -174,20 +174,9 @@ namespace edm {
     // that it is the one that knows how many events will be read.
     ids.reserve(pileEventCnt);
     RecordEventID<T> recorder(ids,eventOperator);
-    int read;
-    if (samelumi_) {
-      const edm::LuminosityBlockID lumi(signal.run(), signal.luminosityBlock());
-      if (sequential_)
-        read = input_->loopSequentialWithID(*eventPrincipal_, fileNameHash_, lumi, pileEventCnt, recorder);
-      else
-        read = input_->loopRandomWithID(*eventPrincipal_, fileNameHash_, lumi, pileEventCnt, recorder, randomEngine(streamID));
-    } else {
-      if (sequential_) {
-        read = input_->loopSequential(*eventPrincipal_, fileNameHash_, pileEventCnt, recorder);
-      } else  {
-        read = input_->loopRandom(*eventPrincipal_, fileNameHash_, pileEventCnt, recorder, randomEngine(streamID));
-      }
-    }
+    int read = 0;
+    CLHEP::HepRandomEngine* engine = (sequential_ ? nullptr : randomEngine(streamID));
+    read = input_->loopOverEvents(*eventPrincipal_, fileNameHash_, pileEventCnt, recorder, engine, &signal);
     if (read != pileEventCnt)
       edm::LogWarning("PileUp") << "Could not read enough pileup events: only " << read << " out of " << pileEventCnt << " requested.";
   }

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -3,9 +3,9 @@
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
-#include "FWCore/Framework/interface/InputSourceDescription.h"
 #include "FWCore/Framework/src/SignallingProductRegistry.h"
 #include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
+#include "FWCore/Sources/interface/VectorInputSourceDescription.h"
 #include "FWCore/Sources/interface/VectorInputSourceFactory.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -43,15 +43,8 @@ namespace edm {
     none_(type_ == "none"),
     fileNameHash_(0U),
     productRegistry_(new SignallingProductRegistry),
-    input_(VectorInputSourceFactory::get()->makeVectorInputSource(pset, InputSourceDescription(
-                                                                   ModuleDescription(),
-                                                                   *productRegistry_,
-                                                                   std::make_shared<BranchIDListHelper>(),
-                                                                   std::make_shared<ThinnedAssociationsHelper>(),
-                                                                   std::make_shared<ActivityRegistry>(),
-                                                                   -1, -1, -1,
-                                                                   PreallocationConfiguration()
-                                                                   )).release()),
+    input_(VectorInputSourceFactory::get()->makeVectorInputSource(pset, VectorInputSourceDescription(
+                                                                   productRegistry_, edm::PreallocationConfiguration())).release()),
     processConfiguration_(new ProcessConfiguration(std::string("@MIXING"), getReleaseVersion(), getPassID())),
     eventPrincipal_(),
     lumiPrincipal_(),
@@ -61,8 +54,6 @@ namespace edm {
     vPoissonDistr_OOT_(),
     randomEngines_(),
     playback_(playback),
-    sequential_(pset.getUntrackedParameter<bool>("sequential", false)),
-    samelumi_(pset.getUntrackedParameter<bool>("sameLumiBlock", false)),
     seed_(0) {
 
     // Use the empty parameter set for the parameter set ID of our "@MIXING" process.
@@ -77,8 +68,8 @@ namespace edm {
 
     // A modified HistoryAppender must be used for unscheduled processing.
     eventPrincipal_.reset(new EventPrincipal(input_->productRegistry(),
-                                       input_->branchIDListHelper(),
-                                       input_->thinnedAssociationsHelper(),
+                                       std::make_shared<BranchIDListHelper>(),
+                                       std::make_shared<ThinnedAssociationsHelper>(),
                                        *processConfiguration_,
                                        nullptr));
 

--- a/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R30F12_HCal_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R30F12_HCal_cff.py
@@ -14,7 +14,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
     nbPileupEvents = cms.PSet(
             averageNumber = cms.double(50.0)
         ),

--- a/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R30F12_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R30F12_cff.py
@@ -39,7 +39,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
                    
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
     nbPileupEvents = cms.PSet(
 	    averageNumber = cms.double(2.0)
         ),

--- a/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R34F16_HCal_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R34F16_HCal_cff.py
@@ -14,7 +14,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
     nbPileupEvents = cms.PSet(
             averageNumber = cms.double(5.0)
         ),

--- a/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R34F16_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_Phase1_R34F16_cff.py
@@ -16,7 +16,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
                    
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
     nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(10.0)

--- a/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_stdgeom_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/mixLowLumPU_stdgeom_cff.py
@@ -42,7 +42,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
     nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(19.7)

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_data_cfi.py
@@ -4,7 +4,7 @@ from SimCalorimetry.HcalSimProducers.hcalUnsuppressedDigis_cfi import hcalSimBlo
 
 mixData = cms.EDProducer("DataMixingModule",
                    hcalSimBlock,
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_data_on_sim_cfi.py
@@ -13,7 +13,7 @@ hcalSimBlock.hf2.binOfMaximum = 5
 
 mixData = cms.EDProducer("DataMixingModule",
                    hcalSimBlock,
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_sim_on_sim_cfi.py
@@ -3,7 +3,7 @@ from SimCalorimetry.HcalSimProducers.hcalUnsuppressedDigis_cfi import hcalSimBlo
 
 mixData = cms.EDProducer("DataMixingModule",
           hcalSimBlock,
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/mixOne_simraw_on_sim_cfi.py
@@ -67,7 +67,7 @@ mixData = cms.EDProducer("DataMixingModule",
           ecal_sim_parameter_map,
           ecal_notCont_sim,
           es_electronics_sim,
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         producers = cms.VPSet(cms.convertToVPSet(
                                              ecalDigis = ecalDigis,
                                              ecalPreshowerDigis = ecalPreshowerDigis,

--- a/SimGeneral/DataMixingModule/python/supplementary/mixOne_cfi.py
+++ b/SimGeneral/DataMixingModule/python/supplementary/mixOne_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 # this is the configuration to model pileup adding one zerobias event 
 mix = cms.EDFilter("DataMixingModule",
     # Mixing Module parameters
-    input = cms.SecSource("PoolRASource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/DataMixingModule/python/supplementary/mixOne_sim_cfi.py
+++ b/SimGeneral/DataMixingModule/python/supplementary/mixOne_sim_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 mix = cms.EDFilter("DataMixingModule",
-    input = cms.SecSource("PoolRASource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/DataMixingModule/python/supplementary/mix_cfi.py
+++ b/SimGeneral/DataMixingModule/python/supplementary/mix_cfi.py
@@ -13,7 +13,7 @@ mix = cms.EDFilter("DataMixingModule",
     # Muons:
     DTdigiCollection = cms.InputTag("muonDTDigis"),
     CSCstripdigiCollection = cms.InputTag("muonCSCDigis"),
-    input = cms.SecSource("PoolRASource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(25.0)
         ),

--- a/SimGeneral/MixingModule/python/HiEventMixing_cff.py
+++ b/SimGeneral/MixingModule/python/HiEventMixing_cff.py
@@ -19,7 +19,7 @@ mixGen = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),
@@ -54,7 +54,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(True),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/MixingModule/python/HiMixGEN_cff.py
+++ b/SimGeneral/MixingModule/python/HiMixGEN_cff.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/MixingModule/python/HiMix_cff.py
+++ b/SimGeneral/MixingModule/python/HiMix_cff.py
@@ -24,7 +24,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(True),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/MixingModule/python/StageA156Bx_cfi.py
+++ b/SimGeneral/MixingModule/python/StageA156Bx_cfi.py
@@ -17,7 +17,7 @@ mix = cms.EDProducer("MixingModule",
     mixProdStep2 = cms.bool(False),
     	
     playback = cms.untracked.bool(False),
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(0.1615)

--- a/SimGeneral/MixingModule/python/StageA43Bx_cfi.py
+++ b/SimGeneral/MixingModule/python/StageA43Bx_cfi.py
@@ -17,7 +17,7 @@ mix = cms.EDProducer("MixingModule",
     mixProdStep2 = cms.bool(False),
     
     playback = cms.untracked.bool(False),
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(0.0061)

--- a/SimGeneral/MixingModule/python/mixHighLumPU_4sources_cfi.py
+++ b/SimGeneral/MixingModule/python/mixHighLumPU_4sources_cfi.py
@@ -28,7 +28,7 @@ mix = cms.EDProducer("MixingModule",
 
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(10.)
@@ -42,7 +42,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/68ECAE92-5F99-DD11-ACAB-000423D98E6C.root',
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root')
     ),
-    cosmics = cms.SecSource("PoolSource",
+    cosmics = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.6625e-05)
         ),
@@ -56,7 +56,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/68ECAE92-5F99-DD11-ACAB-000423D98E6C.root',
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root')
      ),
-    beamhalo_minus = cms.SecSource("PoolSource",
+    beamhalo_minus = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(0.00040503)
         ),
@@ -70,7 +70,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/68ECAE92-5F99-DD11-ACAB-000423D98E6C.root',
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root')
      ),
-    beamhalo_plus = cms.SecSource("PoolSource",
+    beamhalo_plus = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(0.00040503)
         ),

--- a/SimGeneral/MixingModule/python/mixHighLumPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mixHighLumPU_cfi.py
@@ -22,7 +22,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(10.0)

--- a/SimGeneral/MixingModule/python/mixInitialLumPU_4sources_cfi.py
+++ b/SimGeneral/MixingModule/python/mixInitialLumPU_4sources_cfi.py
@@ -25,7 +25,7 @@ mix = cms.EDProducer("MixingModule",
 
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(0.5)
@@ -39,7 +39,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/68ECAE92-5F99-DD11-ACAB-000423D98E6C.root',
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root')
     ),
-    cosmics = cms.SecSource("PoolSource",
+    cosmics = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.6625e-05)
         ),
@@ -54,7 +54,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root'
                                           )
     ),
-    beamhalo_minus = cms.SecSource("PoolSource",
+    beamhalo_minus = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(0.00040503)
         ),
@@ -69,7 +69,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root'
                                           )
     ),
-    beamhalo_plus = cms.SecSource("PoolSource",
+    beamhalo_plus = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(0.00040503)
         ),

--- a/SimGeneral/MixingModule/python/mixInitialLumPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mixInitialLumPU_cfi.py
@@ -22,7 +22,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(0.5)

--- a/SimGeneral/MixingModule/python/mixLowLumPU_4sources_cfi.py
+++ b/SimGeneral/MixingModule/python/mixLowLumPU_4sources_cfi.py
@@ -25,7 +25,7 @@ mix = cms.EDProducer("MixingModule",
 
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(2.8)
@@ -39,7 +39,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/68ECAE92-5F99-DD11-ACAB-000423D98E6C.root',
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root')
     ),
-    cosmics = cms.SecSource("PoolSource",
+    cosmics = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.6625e-05)
         ),
@@ -53,7 +53,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/68ECAE92-5F99-DD11-ACAB-000423D98E6C.root',
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root')
     ),
-    beamhalo_minus = cms.SecSource("PoolSource",
+    beamhalo_minus = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(0.00040503)
         ),
@@ -67,7 +67,7 @@ mix = cms.EDProducer("MixingModule",
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/68ECAE92-5F99-DD11-ACAB-000423D98E6C.root',
         '/store/relval/CMSSW_2_1_10/RelValMinBias/GEN-SIM-DIGI-RAW-HLTDEBUG/STARTUP_V7_v2/0000/8802D325-5E99-DD11-B858-000423D98A44.root')
     ),
-    beamhalo_plus = cms.SecSource("PoolSource",
+    beamhalo_plus = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(0.00040503)
         ),

--- a/SimGeneral/MixingModule/python/mixLowLumPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mixLowLumPU_cfi.py
@@ -22,7 +22,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
 	nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0),
             Lumi = cms.double(2.8)

--- a/SimGeneral/MixingModule/python/mix_2012_Startup_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2012_Startup_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59),

--- a/SimGeneral/MixingModule/python/mix_2012_Summer_50ns_PoissonOOTPU_ExtWind_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2012_Summer_50ns_PoissonOOTPU_ExtWind_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59),

--- a/SimGeneral/MixingModule/python/mix_2012_Summer_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2012_Summer_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55,56,57,58,59),

--- a/SimGeneral/MixingModule/python/mix_2012_lumiLevel_15_20_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2012_lumiLevel_15_20_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_2012_peak11_25ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2012_peak11_25ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20),

--- a/SimGeneral/MixingModule/python/mix_2012_peak26_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2012_peak26_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35),

--- a/SimGeneral/MixingModule/python/mix_2015_25ns_HiLum_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_25ns_HiLum_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52),

--- a/SimGeneral/MixingModule/python/mix_2015_25ns_Startup_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_25ns_Startup_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52),

--- a/SimGeneral/MixingModule/python/mix_2015_50ns_Startup_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_2015_50ns_Startup_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52),

--- a/SimGeneral/MixingModule/python/mix_CSA14_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_CSA14_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50),

--- a/SimGeneral/MixingModule/python/mix_E10TeV_L13E31_BX432_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E10TeV_L13E31_BX432_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(75.3), #The Xsec is in mb
             Lumi = cms.double(0.13) # The lumi is in E33 cm-2s-1

--- a/SimGeneral/MixingModule/python/mix_E10TeV_L21E31_BX432_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E10TeV_L21E31_BX432_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(75.3), #The Xsec is in mb
             Lumi = cms.double(0.21) # The lumi is in E33 cm-2s-1

--- a/SimGeneral/MixingModule/python/mix_E14TeV_L10E33_BX2808_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E14TeV_L10E33_BX2808_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0), #The Xsec is in mb
             Lumi = cms.double(10.0) # The lumi is in E33 cm-2s-1

--- a/SimGeneral/MixingModule/python/mix_E14TeV_L28E32_BX2808_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E14TeV_L28E32_BX2808_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(80.0), #The Xsec is in mb
             Lumi = cms.double(2.8) # The lumi is in E33 cm-2s-1

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Ave25_25ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Ave25_25ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Ave25_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Ave25_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Chamonix2012_50ns_PoissonOOT_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Chamonix2012_50ns_PoissonOOT_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Fall2011_Reprocess_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Fall2011_Reprocess_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllEarly_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllEarly_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllEarly_75ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllEarly_75ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllLate_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllLate_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllLate_75ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Flat20_AllLate_75ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_25ns_PoissonOOT_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_25ns_PoissonOOT_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_50ns_PoissonOOT.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_50ns_PoissonOOT.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_75ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_75ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_inTimeOnly_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_FlatDist10_2011EarlyData_inTimeOnly_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_L34E30_BX156_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_L34E30_BX156_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(71.3), # The Xsec is in mb
             Lumi = cms.double(0.034) # The LUmi is in E33 cm-2s-1

--- a/SimGeneral/MixingModule/python/mix_E7TeV_L69E30_BX156_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_L69E30_BX156_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             sigmaInel = cms.double(71.3), # The Xsec is in mb
             Lumi = cms.double(0.069) # The LUmi is in E33 cm-2s-1

--- a/SimGeneral/MixingModule/python/mix_E7TeV_ProbDist_2010Data_BX156_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_ProbDist_2010Data_BX156_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10),

--- a/SimGeneral/MixingModule/python/mix_E7TeV_Summer_2011_50ns_PoissonOOT.py
+++ b/SimGeneral/MixingModule/python/mix_E7TeV_Summer_2011_50ns_PoissonOOT.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E8TeV_FlatDist_2011EarlyData_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E8TeV_FlatDist_2011EarlyData_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E8TeV_ProbDist_2011EarlyData_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E8TeV_ProbDist_2011EarlyData_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24),

--- a/SimGeneral/MixingModule/python/mix_E8TeV_run198588_BX_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E8TeV_run198588_BX_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
              probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45),

--- a/SimGeneral/MixingModule/python/mix_E8TeV_run203002_BX_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E8TeV_run203002_BX_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
              probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45),

--- a/SimGeneral/MixingModule/python/mix_E8TeV_run209148_BX_25ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E8TeV_run209148_BX_25ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
              probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20),

--- a/SimGeneral/MixingModule/python/mix_E8TeV_zmmg_skim_BX_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_E8TeV_zmmg_skim_BX_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
              probFunctionVariable = cms.vint32(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50,51,52,53,54,55),

--- a/SimGeneral/MixingModule/python/mix_FIX_average_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_FIX_average_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/MixingModule/python/mix_Flat_0_50_25ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat_0_50_25ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50),

--- a/SimGeneral/MixingModule/python/mix_Flat_0_50_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat_0_50_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50),

--- a/SimGeneral/MixingModule/python/mix_Flat_10_50_25ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat_10_50_25ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50),

--- a/SimGeneral/MixingModule/python/mix_Flat_10_50_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat_10_50_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50),

--- a/SimGeneral/MixingModule/python/mix_Flat_20_50_50ns_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat_20_50_50ns_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50),

--- a/SimGeneral/MixingModule/python/mix_Flat_20_50_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Flat_20_50_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40,41,42,43,44,45,46,47,48,49,50),

--- a/SimGeneral/MixingModule/python/mix_OOT_Muons_and_minbias_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_OOT_Muons_and_minbias_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('fixed'),
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(40.0)
@@ -35,7 +35,7 @@ mix = cms.EDProducer("MixingModule",
                                                ## need out of time bunch crossings
         fileNames = FileNames
     ),
-    cosmics = cms.SecSource("PoolSource",
+    cosmics = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.)
         ),

--- a/SimGeneral/MixingModule/python/mix_POISSON_average_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_POISSON_average_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         nbPileupEvents = cms.PSet(
             averageNumber = cms.double(1.0)
         ),

--- a/SimGeneral/MixingModule/python/mix_Phys14_50ns_PoissonOOTPU_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_Phys14_50ns_PoissonOOTPU_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26,27,28,29,30,31,32,33,34,35,36,37,38,39,40),

--- a/SimGeneral/MixingModule/python/mix_flat_0_10_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_flat_0_10_cfi.py
@@ -18,7 +18,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('probFunction'),
         nbPileupEvents = cms.PSet(
           probFunctionVariable = cms.vint32(0,1,2,3,4,5,6,7,8,9,10),

--- a/SimGeneral/MixingModule/python/mix_fromDB_cfi.py
+++ b/SimGeneral/MixingModule/python/mix_fromDB_cfi.py
@@ -28,7 +28,7 @@ mix = cms.EDProducer("MixingModule",
     playback = cms.untracked.bool(False),
     useCurrentProcessOnly = cms.bool(False),
 
-    input = cms.SecSource("PoolSource",
+    input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('readDB'),
 	sequential = cms.untracked.bool(False),                          
         fileNames = FileNames 

--- a/SimGeneral/MixingModule/test/read_InputSecSource_PCFcfg.py
+++ b/SimGeneral/MixingModule/test/read_InputSecSource_PCFcfg.py
@@ -23,7 +23,7 @@ process.Analyzer = cms.EDAnalyzer("SecSourceAnalyzer",
      dataStep2 = cms.bool(True),
      collPCF = cms.InputTag("CFWriter"),
 	
-     input = cms.SecSource("PoolSource",
+     input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('fixed'),
         nbPileupEvents = cms.PSet(
         averageNumber = cms.double(1.0)

--- a/SimGeneral/MixingModule/test/read_InputSecSource_cfg.py
+++ b/SimGeneral/MixingModule/test/read_InputSecSource_cfg.py
@@ -20,7 +20,7 @@ process.Analyzer = cms.EDAnalyzer("SecSourceAnalyzer",
      dataStep2 = cms.bool(False),
      collSimTrack = cms.InputTag("g4SimHits"),
 	
-     input = cms.SecSource("PoolSource",
+     input = cms.SecSource("EmbeddedRootSource",
         type = cms.string('fixed'),
         nbPileupEvents = cms.PSet(
         averageNumber = cms.double(1.0)

--- a/Validation/Mixing/test/testsuite1_cfg.py
+++ b/Validation/Mixing/test/testsuite1_cfg.py
@@ -40,7 +40,7 @@ process.mix = cms.EDFilter("MixingModule",
         input = cms.untracked.int32(1)
     ),
     
-    input = cms.SecSource("PoolRASource",
+    input = cms.SecSource("EmbeddedRootSource",
     
 #    fileNames = cms.untracked.vstring('rfio:/castor/cern.ch/cms/store/RelVal/2007/7/11/RelVal-RelVal160pre4SingleEPt35-1184176348/0000/5EF3794C-7530-DC11-833F-000423D6C8EE.root'),
     fileNames = cms.untracked.vstring('rfio:/castor/cern.ch/cms/store/relval/CMSSW_3_0_0_pre6/RelValSingleElectronPt35/GEN-SIM-DIGI-RAW-HLTDEBUG/IDEAL_30X_v1/0005/28116A15-E9DD-DD11-9BA6-001617E30F4C.root'),

--- a/Validation/Mixing/test/testsuite_SmartPointers_cfg.py
+++ b/Validation/Mixing/test/testsuite_SmartPointers_cfg.py
@@ -37,7 +37,7 @@ process.mix = cms.EDProducer("MixingModule",
         input = cms.untracked.int32(1)
     ),
     
-    input = cms.SecSource("PoolRASource",    
+    input = cms.SecSource("EmbeddedRootSource",
     fileNames = cms.untracked.vstring(
    	'/store/relval/CMSSW_3_1_0_pre4/RelValTTbar/GEN-SIM-DIGI-RAW-HLTDEBUG/IDEAL_30X_v1/0003/3AA6EEA4-3B16-DE11-B35F-001617C3B654.root'),
 


### PR DESCRIPTION
PoolSource and the related class RootInputFIleSequence have become cumbersome and difficult to maintain.  In particular, PoolSource is used for both a primary input source and a secondary input source, and contains almost no code that is common to both cases.  It should be two separate classes.
RootInputFileSequence is even worse.  It should be three separate classes.
This PR does the refactoring.  Also, this PR reduces the depth of the inheritance of both sources.
There is no change whatever to the external interface of PoolSource used as a primary source.
The interface for the secondary input source is modified and improved.  In particular, the class used is EmbeddedRootSource, rather than PoolSource.  Also, the function interface is streamlined.
This PR adapts all the users of the secondary input source in CMSSW to the change.
There are only two places outside the framework where the C++ interface to the secondary source is used, but quite a few configuration files that are minimally changed.
Also, to implement a suggestion from Chris Jones, the use of the product registry in constructing the input sources is simplified to uniformly use a std::shared_ptr, for simplicity and consistency.
