### PR TITLE
Fix to allow histogram rebinning to work again for Tracker DQM trend plots in ROOT6

### DIFF
--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -374,7 +374,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
     ibooker.setCurrentFolder(topFolderName_+"/MechanicalView/");
       std::string HistoName = "BPTX rate";
       BPTXrateTrend = ibooker.bookProfile(HistoName,HistoName, LSBin, LSMin, LSMax, 0, 10000.,"");
-      BPTXrateTrend->getTH1()->SetBit(TH1::kCanRebin);
+      BPTXrateTrend->getTH1()->SetCanExtend(TH1::kAllAxes);
       BPTXrateTrend->setAxisTitle("#Lumi section",1);
       BPTXrateTrend->setAxisTitle("Number of BPTX events per LS",2);
     }
@@ -414,7 +414,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
 						       ParametersNclusVsCycleTimeProf2D.getParameter<double>("ymin"),
 						       ParametersNclusVsCycleTimeProf2D.getParameter<double>("ymax"),
 						       0 , 0 );
-      if (NclusVsCycleTimeProf2D->kind() == MonitorElement::DQM_KIND_TPROFILE2D) NclusVsCycleTimeProf2D->getTH1()->SetBit(TH1::kCanRebin);
+      if (NclusVsCycleTimeProf2D->kind() == MonitorElement::DQM_KIND_TPROFILE2D) NclusVsCycleTimeProf2D->getTH1()->SetCanExtend(TH1::kAllAxes);
     }
 
     if (ClusterHisto_){
@@ -1013,7 +1013,7 @@ void SiStripMonitorCluster::createSubDetMEs(std::string label , DQMStore::IBooke
 							 Parameters.getParameter<double>("xmax"),
 							 0 , 0 , "" );
     subdetMEs.SubDetTotClusterProf->setAxisTitle(Parameters.getParameter<std::string>("xaxis"),1);
-    if (subdetMEs.SubDetTotClusterProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotClusterProf->getTH1()->SetBit(TH1::kCanRebin);
+    if (subdetMEs.SubDetTotClusterProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotClusterProf->getTH1()->SetCanExtend(TH1::kAllAxes);
   }
 
   // Total Number of Cluster vs APV cycle - Profile
@@ -1168,7 +1168,7 @@ MonitorElement* SiStripMonitorCluster::bookMETrend(const char* HistoName , DQMSt
 					   0 , 0 , "" );
   if(!me) return me;
   me->setAxisTitle(ParametersTrend.getParameter<std::string>("xaxis"),1);
-  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetBit(TH1::kCanRebin);
+  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetCanExtend(TH1::kAllAxes);
   return me;
 }
 

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -451,7 +451,7 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
 						    "" );
       ShotsVsTimeApvShotsGlobal->setAxisTitle("Time (s)",1);
       ShotsVsTimeApvShotsGlobal->setAxisTitle("# Apv Shots",2);
-      if (ShotsVsTimeApvShotsGlobal->kind() == MonitorElement::DQM_KIND_TPROFILE) ShotsVsTimeApvShotsGlobal->getTH1()->SetBit(TH1::kCanRebin);
+      if (ShotsVsTimeApvShotsGlobal->kind() == MonitorElement::DQM_KIND_TPROFILE) ShotsVsTimeApvShotsGlobal->getTH1()->SetCanExtend(TH1::kAllAxes);
     }
 
     //cumulative number of Strips in APV shots
@@ -886,7 +886,7 @@ MonitorElement* SiStripMonitorDigi::bookMETrend(DQMStore::IBooker & ibooker , co
   if(!me) return me;
 
   me->setAxisTitle("Event Time in Seconds",1);
-  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetBit(TH1::kCanRebin);
+  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetCanExtend(TH1::kAllAxes);
   return me;
 }
 
@@ -1070,7 +1070,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker & ibooker , std::stri
 						    Parameters.getParameter<double>("ymax"),
 						    "" );
     subdetMEs.SubDetTotDigiProf->setAxisTitle("Event Time in Seconds",1);
-    if (subdetMEs.SubDetTotDigiProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotDigiProf->getTH1()->SetBit(TH1::kCanRebin);
+    if (subdetMEs.SubDetTotDigiProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotDigiProf->getTH1()->SetCanExtend(TH1::kAllAxes);
   }
   
   // Number of Digi vs Bx - Profile
@@ -1176,7 +1176,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker & ibooker , std::stri
 						      "" );
     subdetMEs.SubDetNApvShotsProf->setAxisTitle("Time (s)",1);
     subdetMEs.SubDetNApvShotsProf->setAxisTitle("# Apv Shots",2);
-    if (subdetMEs.SubDetNApvShotsProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetNApvShotsProf->getTH1()->SetBit(TH1::kCanRebin);
+    if (subdetMEs.SubDetNApvShotsProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetNApvShotsProf->getTH1()->SetCanExtend(TH1::kAllAxes);
   }
 
 

--- a/DQM/SiStripMonitorHardware/src/HistogramBase.cc
+++ b/DQM/SiStripMonitorHardware/src/HistogramBase.cc
@@ -232,6 +232,6 @@ void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & 
 	      yAxisTitle);
 
   //automatically set the axis range: will accomodate new values keeping the same number of bins.
-  if (aConfig.monitorEle) aConfig.monitorEle->getTProfile()->SetBit(TH1::kCanRebin);
+  if (aConfig.monitorEle) aConfig.monitorEle->getTProfile()->SetCanExtend(TH1::kAllAxes);
 }
  

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -575,7 +575,7 @@ MonitorElement* SiStripMonitorTrack::bookMETrend(DQMStore::IBooker & ibooker , c
 					   ParametersTrend.getParameter<double>("xmin"),
 					   ParametersTrend.getParameter<double>("xmax"),
 					   0 , 0 , "" );
-  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetBit(TH1::kCanRebin);
+  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetCanExtend(TH1::kAllAxes);
 
   if(!me) return me;
   me->setAxisTitle("Lumisection",1);

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -443,7 +443,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
       
       histname = "DistanceOfClosestApproachToBSVsPhi_";
       DistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-      DistanceOfClosestApproachToBSVsPhi->getTH1()->SetBit(TH1::kCanRebin);
+      DistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
       DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi",1);
       DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
       
@@ -504,7 +504,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
       
       histname = "DistanceOfClosestApproachToPVVsPhi_";
       DistanceOfClosestApproachToPVVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-      DistanceOfClosestApproachToPVVsPhi->getTH1()->SetBit(TH1::kCanRebin);
+      DistanceOfClosestApproachToPVVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
       DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track #phi",1);
       DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
       
@@ -538,7 +538,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
 	
 	histname = "TESTDistanceOfClosestApproachToBSVsPhi_";
 	TESTDistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-	TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetBit(TH1::kCanRebin);
+	TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
 	TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi",1);
 	TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
 	
@@ -589,7 +589,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
 	
 	histname = "DistanceOfClosestApproachVsPhi_";
 	DistanceOfClosestApproachVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyMin,DxyMax,"");
-	DistanceOfClosestApproachVsPhi->getTH1()->SetBit(TH1::kCanRebin);
+	DistanceOfClosestApproachVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
 	DistanceOfClosestApproachVsPhi->setAxisTitle("Track #phi",1);
 	DistanceOfClosestApproachVsPhi->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)",2);
       }

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -260,20 +260,20 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
   
      histname = "NumberOfTracksVsLS_"+ CategoryName;
      NumberOfTracksVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax, TKNoMin, (TKNoMax+0.5)*3.-0.5,"");
-     NumberOfTracksVsLS->getTH1()->SetBit(TH1::kCanRebin);
+     NumberOfTracksVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
      NumberOfTracksVsLS->setAxisTitle("#Lumi section",1);
      NumberOfTracksVsLS->setAxisTitle("Number of  Tracks",2);
   
      histname = "NumberOfRecHitsPerTrackVsLS_" + CategoryName;
      NumberOfRecHitsPerTrackVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,0.,40.,"");
-     NumberOfRecHitsPerTrackVsLS->getTH1()->SetBit(TH1::kCanRebin);
+     NumberOfRecHitsPerTrackVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
      NumberOfRecHitsPerTrackVsLS->setAxisTitle("#Lumi section",1);
      NumberOfRecHitsPerTrackVsLS->setAxisTitle("Mean number of RecHits per track",2);
   
      if (doFractionPlot_) {
        histname = "GoodTracksFractionVsLS_"+ CategoryName;
        GoodTracksFractionVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,0,1.1,"");
-       GoodTracksFractionVsLS->getTH1()->SetBit(TH1::kCanRebin);
+       GoodTracksFractionVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
        GoodTracksFractionVsLS->setAxisTitle("#Lumi section",1);
        GoodTracksFractionVsLS->setAxisTitle("Fraction of Good Tracks",2);
      }
@@ -297,7 +297,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
     
        histname = "NumberOfTracksVsGoodPVtx";
        NumberOfTracksVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,TKNoMin, (TKNoMax+0.5)*3.-0.5,"");
-       NumberOfTracksVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
+       NumberOfTracksVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
        NumberOfTracksVsGoodPVtx->setAxisTitle("Number of PV",1);
        NumberOfTracksVsGoodPVtx->setAxisTitle("Mean number of Tracks per Event",2);
     
@@ -312,7 +312,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
     
        histname = "NumberOfTracksVsBXlumi_"+ CategoryName;
        NumberOfTracksVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax, TKNoMin, TKNoMax,"");
-       NumberOfTracksVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
+       NumberOfTracksVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
        NumberOfTracksVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
        NumberOfTracksVsBXlumi->setAxisTitle("Mean number of Tracks",2);
     

--- a/DQM/TrackingMonitor/src/VertexMonitor.cc
+++ b/DQM/TrackingMonitor/src/VertexMonitor.cc
@@ -233,37 +233,37 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "NumberOfPVtxVsBXlumi_" + label_;
       NumberOfPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,60.,"");
-      NumberOfPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
+      NumberOfPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
       NumberOfPVtxVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       NumberOfPVtxVsBXlumi->setAxisTitle("Mean number of PV",2);
 
       histname = "NumberOfGoodPVtxVsBXlumi_" + label_;
       NumberOfGoodPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,60.,"");
-      NumberOfGoodPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
+      NumberOfGoodPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
       NumberOfGoodPVtxVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       NumberOfGoodPVtxVsBXlumi->setAxisTitle("Mean number of PV",2);
 
       histname = "FractionOfGoodPVtxVsBXlumi_" + label_;
       FractionOfGoodPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,1.5,"");
-      FractionOfGoodPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
+      FractionOfGoodPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
       FractionOfGoodPVtxVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       FractionOfGoodPVtxVsBXlumi->setAxisTitle("Mean number of PV",2);
 
       histname = "NumberOfBADndofPVtxVsBXlumi_" + label_;
       NumberOfBADndofPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,60.,"");
-      NumberOfBADndofPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
+      NumberOfBADndofPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
       NumberOfBADndofPVtxVsBXlumi->setAxisTitle("BADndof #PV",1);
       NumberOfBADndofPVtxVsBXlumi->setAxisTitle("Number of Events",2);
     
       histname = "GoodPVtxSumPtVsBXlumi_" + label_;
       GoodPVtxSumPtVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,500.,"");
-      GoodPVtxSumPtVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxSumPtVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxSumPtVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxSumPtVsBXlumi->setAxisTitle("Mean pv #Sum p_{T}^{2} [GeV^{2}/c]^{2}",2);
       
       histname = "GoodPVtxNumberOfTracksVsBXlumi_" + label_;
       GoodPVtxNumberOfTracksVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,100.,"");
-      GoodPVtxNumberOfTracksVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxNumberOfTracksVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxNumberOfTracksVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxNumberOfTracksVsBXlumi->setAxisTitle("Mean pv number of tracks",2);
 
@@ -276,25 +276,25 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "Chi2oNDFVsBXlumi_" + label_;
       Chi2oNDFVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2NDFMin,Chi2NDFMax,"");
-      Chi2oNDFVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
+      Chi2oNDFVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
       Chi2oNDFVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       Chi2oNDFVsBXlumi -> setAxisTitle("Mean #chi^{2}/ndof",2);
 
       histname = "Chi2ProbVsBXlumi_" + label_;
       Chi2ProbVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2ProbMin,Chi2ProbMax,"");
-      Chi2ProbVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
+      Chi2ProbVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
       Chi2ProbVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       Chi2ProbVsBXlumi -> setAxisTitle("Mean #chi^{2}/prob",2);
 
       histname = "GoodPVtxChi2oNDFVsBXlumi_" + label_;
       GoodPVtxChi2oNDFVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2NDFMin,Chi2NDFMax,"");
-      GoodPVtxChi2oNDFVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxChi2oNDFVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxChi2oNDFVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxChi2oNDFVsBXlumi -> setAxisTitle("Mean PV #chi^{2}/ndof",2);
 
       histname = "GoodPVtxChi2ProbVsBXlumi_" + label_;
       GoodPVtxChi2ProbVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2ProbMin,Chi2ProbMax,"");
-      GoodPVtxChi2ProbVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxChi2ProbVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxChi2ProbVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxChi2ProbVsBXlumi -> setAxisTitle("Mean PV #chi^{2}/prob",2);
     }
@@ -305,37 +305,37 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "NumberOfPVtxVsGoodPVtx_" + label_;
       NumberOfPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      NumberOfPVtxVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
+      NumberOfPVtxVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
       NumberOfPVtxVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       NumberOfPVtxVsGoodPVtx->setAxisTitle("Mean number of PV",2);
 
       histname = "FractionOfGoodPVtxVsGoodPVtx_" + label_;
       FractionOfGoodPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      FractionOfGoodPVtxVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
+      FractionOfGoodPVtxVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
       FractionOfGoodPVtxVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       FractionOfGoodPVtxVsGoodPVtx->setAxisTitle("Mean fraction of Good PV",2);
 
       histname = "FractionOfGoodPVtxVsPVtx_" + label_;
       FractionOfGoodPVtxVsPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      FractionOfGoodPVtxVsPVtx->getTH1()->SetBit(TH1::kCanRebin);
+      FractionOfGoodPVtxVsPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
       FractionOfGoodPVtxVsPVtx->setAxisTitle("Number of Good PV",1);
       FractionOfGoodPVtxVsPVtx->setAxisTitle("Mean number of Good PV",2);
 
       histname = "NumberOfBADndofPVtxVsGoodPVtx_" + label_;
       NumberOfBADndofPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      NumberOfBADndofPVtxVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
+      NumberOfBADndofPVtxVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
       NumberOfBADndofPVtxVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       NumberOfBADndofPVtxVsGoodPVtx->setAxisTitle("Mean Number of BAD PV",2);
     
       histname = "GoodPVtxSumPtVsGoodPVtx_" + label_;
       GoodPVtxSumPtVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,500.,"");
-      GoodPVtxSumPtVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxSumPtVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxSumPtVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       GoodPVtxSumPtVsGoodPVtx->setAxisTitle("Mean pv #Sum p_{T}^{2} [GeV^{2}/c]^{2}",2);
       
       histname = "GoodPVtxNumberOfTracksVsGoodPVtx_" + label_;
       GoodPVtxNumberOfTracksVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,100.,"");
-      GoodPVtxNumberOfTracksVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxNumberOfTracksVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxNumberOfTracksVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       GoodPVtxNumberOfTracksVsGoodPVtx->setAxisTitle("Mean pv number of tracks",2);
       
@@ -348,13 +348,13 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "GoodPVtxChi2oNDFVsGoodPVtx_" + label_;
       GoodPVtxChi2oNDFVsGoodPVtx  = ibooker.bookProfile(histname,histname,GoodPVtxBin, GoodPVtxMin,GoodPVtxMax,Chi2NDFMin,Chi2NDFMax,"");
-      GoodPVtxChi2oNDFVsGoodPVtx -> getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxChi2oNDFVsGoodPVtx -> getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxChi2oNDFVsGoodPVtx -> setAxisTitle("Number of Good PV",1);
       GoodPVtxChi2oNDFVsGoodPVtx -> setAxisTitle("Mean PV #chi^{2}/ndof",2);
 
       histname = "GoodPVtxChi2ProbVsGoodPVtx_" + label_;
       GoodPVtxChi2ProbVsGoodPVtx  = ibooker.bookProfile(histname,histname,GoodPVtxBin, GoodPVtxMin,GoodPVtxMax,Chi2ProbMin,Chi2ProbMax,"");
-      GoodPVtxChi2ProbVsGoodPVtx -> getTH1()->SetBit(TH1::kCanRebin);
+      GoodPVtxChi2ProbVsGoodPVtx -> getTH1()->SetCanExtend(TH1::kAllAxes);
       GoodPVtxChi2ProbVsGoodPVtx -> setAxisTitle("Number of Good PV",1);
       GoodPVtxChi2ProbVsGoodPVtx -> setAxisTitle("Mean PV #chi^{2}/prob",2);
 

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -72,7 +72,7 @@ namespace {
   }
   //NOTE: the merge logic comes from DataFormats/Histograms/interface/MEtoEDMFormat.h
   void mergeTogether(TH1* iOriginal,TH1* iToAdd) {
-    if(iOriginal->TestBit(TH1::kCanRebin)==true && iToAdd->TestBit(TH1::kCanRebin) ==true) {
+    if(iOriginal->CanExtendAllAxes() && iToAdd->CanExtendAllAxes()) {
       TList list;
       list.Add(iToAdd);
       if( -1 == iOriginal->Merge(&list)) {


### PR DESCRIPTION
In ROOT6 the TH1 kCanRebin option doesn't work anymore. This affects the behavior of the current tracker DQM trend plots. They are no longer correctly updated to accommodate an expanded histogram axis to show trends vs lumi section for longer runs for example, since the histograms can no longer be rebinned. This fix updates the use of the SetBit(kCanRebin) option to SetCanExtend(TH1::kAllAxes) as recommended for ROOT6 in the Tracker DQM code and is needed quite urgently to restore the correct behavior for the trend plots. Also, the code for DQMRootSource (DQMServices/FwkIO/plugins/DQMRootSource.cc) is updated for the merging of rebinnable histograms during harvesting to be compatible with the new ROOT6 behavior (the old TestBit(TH1::kCanRebin) is replaced with the new CanExtendAllAxes()).
