### PR TITLE
Remove leading whitespace from types in classes_*def.xml selection files

### DIFF
--- a/AnalysisDataFormats/TrackInfo/src/classes_def.xml
+++ b/AnalysisDataFormats/TrackInfo/src/classes_def.xml
@@ -5,9 +5,9 @@
    <version ClassVersion="11" checksum="803167075"/>
    <version ClassVersion="10" checksum="2470257581"/>
   </class>
-  <class name="reco::TrackingStateInfo "/>
-  <class name="std::pair<reco::StateType, reco::TrackingStateInfo> "/>
-  <class name="std::map<reco::StateType, reco::TrackingStateInfo> "/>
+  <class name="reco::TrackingStateInfo"/>
+  <class name="std::pair<reco::StateType, reco::TrackingStateInfo>"/>
+  <class name="std::map<reco::StateType, reco::TrackingStateInfo>"/>
   <class name="std::pair< edm::Ref< edm::OwnVector< TrackingRecHit, edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit>  >, reco::TrackingRecHitInfo >"/>
   <class name="std::map< edm::Ref< edm::OwnVector< TrackingRecHit, edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit,edm::refhelper::FindUsingAdvance<edm::OwnVector<TrackingRecHit,edm::ClonePolicy<TrackingRecHit> >,TrackingRecHit>  >, reco::TrackingRecHitInfo >"/>
   <class name="reco::TrackInfo" ClassVersion="10">

--- a/DataFormats/CaloTowers/src/classes_def.xml
+++ b/DataFormats/CaloTowers/src/classes_def.xml
@@ -23,10 +23,10 @@
   <class name="std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > >"/>
   <class name="edm::Wrapper< std::vector<edm::FwdRef<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower, edm::refhelper::FindUsingAdvance<edm::SortedCollection<CaloTower, edm::StrictWeakOrdering<CaloTower> >, CaloTower > > > >"/>
 
-  <class name="edm::reftobase::Holder<reco::Candidate, CaloTowerRef> " />
-  <class name="edm::reftobase::RefHolder<CaloTowerRef> " />
-  <class name="edm::reftobase::VectorHolder<reco::Candidate, CaloTowerRefs> " />
-  <class name="edm::reftobase::RefVectorHolder<CaloTowerRefs> " />
+  <class name="edm::reftobase::Holder<reco::Candidate, CaloTowerRef>" />
+  <class name="edm::reftobase::RefHolder<CaloTowerRef>" />
+  <class name="edm::reftobase::VectorHolder<reco::Candidate, CaloTowerRefs>" />
+  <class name="edm::reftobase::RefVectorHolder<CaloTowerRefs>" />
   <class name="edm::Ptr<CaloTower>"/>
   <class name="edm::PtrVector<CaloTower>"/>
   <class name="std::vector<edm::Ptr<CaloTower> >"/>

--- a/DataFormats/EcalDetId/src/classes_def.xml
+++ b/DataFormats/EcalDetId/src/classes_def.xml
@@ -44,20 +44,20 @@
   <class name="std::set<EEDetId>"/>
   <class name="std::set<EcalTrigTowerDetId>"/>
   <class name="std::set<EcalScDetId>"/>
-  <class name="edm::Wrapper<std::set<EBDetId> > "/>
-  <class name="edm::Wrapper<std::set<EEDetId> > "/>
-  <class name="edm::Wrapper<std::set<EcalTrigTowerDetId> > "/>
-  <class name="edm::Wrapper<std::set<EcalScDetId> > "/>
-  <class name="edm::EDCollection<EBDetId> "/>
-  <class name="edm::EDCollection<EEDetId> "/>
-  <class name="edm::EDCollection<EcalTrigTowerDetId> "/>
-  <class name="edm::EDCollection<EcalScDetId> "/>
-  <class name="edm::EDCollection<EcalElectronicsId> " />
-  <class name="edm::EDCollection<EcalTriggerElectronicsId> " />
-  <class name="edm::Wrapper<edm::EDCollection<EBDetId> > " id="EF1C41A8-6FCA-DDC6-7463-3208C2AEE68F"/>
-  <class name="edm::Wrapper<edm::EDCollection<EEDetId> > " id="182A27B1-7C9F-3114-027F-BF26932C6CD0"/>
-  <class name="edm::Wrapper<edm::EDCollection<EcalTrigTowerDetId> > " id="3177FB3F-B69D-07EC-D5BE-A0AFF6A4D78F"/>
-  <class name="edm::Wrapper<edm::EDCollection<EcalScDetId> > " id="364d0ca9-8daa-4baf-8203-9d86881b51ff"/>
-  <class name="edm::Wrapper<edm::EDCollection<EcalElectronicsId> > " id="1CCDC3B0-D381-60A8-E3B1-B75C4D0F6802"/>
-  <class name="edm::Wrapper<edm::EDCollection<EcalTriggerElectronicsId> > " id="D9FCAC56-29E2-54B9-2F75-EDC0D2E534F0"/>
+  <class name="edm::Wrapper<std::set<EBDetId> >"/>
+  <class name="edm::Wrapper<std::set<EEDetId> >"/>
+  <class name="edm::Wrapper<std::set<EcalTrigTowerDetId> >"/>
+  <class name="edm::Wrapper<std::set<EcalScDetId> >"/>
+  <class name="edm::EDCollection<EBDetId>"/>
+  <class name="edm::EDCollection<EEDetId>"/>
+  <class name="edm::EDCollection<EcalTrigTowerDetId>"/>
+  <class name="edm::EDCollection<EcalScDetId>"/>
+  <class name="edm::EDCollection<EcalElectronicsId>"/>
+  <class name="edm::EDCollection<EcalTriggerElectronicsId>"/>
+  <class name="edm::Wrapper<edm::EDCollection<EBDetId> >" id="EF1C41A8-6FCA-DDC6-7463-3208C2AEE68F"/>
+  <class name="edm::Wrapper<edm::EDCollection<EEDetId> >" id="182A27B1-7C9F-3114-027F-BF26932C6CD0"/>
+  <class name="edm::Wrapper<edm::EDCollection<EcalTrigTowerDetId> >" id="3177FB3F-B69D-07EC-D5BE-A0AFF6A4D78F"/>
+  <class name="edm::Wrapper<edm::EDCollection<EcalScDetId> >" id="364d0ca9-8daa-4baf-8203-9d86881b51ff"/>
+  <class name="edm::Wrapper<edm::EDCollection<EcalElectronicsId> >" id="1CCDC3B0-D381-60A8-E3B1-B75C4D0F6802"/>
+  <class name="edm::Wrapper<edm::EDCollection<EcalTriggerElectronicsId> >" id="D9FCAC56-29E2-54B9-2F75-EDC0D2E534F0"/>
 </lcgdict>

--- a/DataFormats/EcalDigi/src/classes_def.xml
+++ b/DataFormats/EcalDigi/src/classes_def.xml
@@ -95,10 +95,10 @@
    <class name="edm::StrictWeakOrdering<EcalPnDiodeDigi>" /> <!-- Root6 -->
    <class name="edm::SortedCollection<EcalMatacqDigi,edm::StrictWeakOrdering<EcalMatacqDigi> >"/>
    <class name="edm::Wrapper<edm::SortedCollection<ESDataFrame,edm::StrictWeakOrdering<ESDataFrame> > >" splitLevel="0" id="C3D41492-2914-2291-7C22-BBE6D77043F7"/>
-   <class name="edm::Wrapper<edm::SortedCollection<EcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi> > > " splitLevel="0" id="D932A444-CBDD-A27C-4D85-BFED25EFBCF8"/>
-   <class name="edm::Wrapper<edm::SortedCollection<EcalPseudoStripInputDigi,edm::StrictWeakOrdering<EcalPseudoStripInputDigi> > > " splitLevel="0" id=""/>
+   <class name="edm::Wrapper<edm::SortedCollection<EcalTriggerPrimitiveDigi,edm::StrictWeakOrdering<EcalTriggerPrimitiveDigi> > >" splitLevel="0" id="D932A444-CBDD-A27C-4D85-BFED25EFBCF8"/>
+   <class name="edm::Wrapper<edm::SortedCollection<EcalPseudoStripInputDigi,edm::StrictWeakOrdering<EcalPseudoStripInputDigi> > >" splitLevel="0" id=""/>
    <class name="edm::Wrapper<edm::SortedCollection<EBSrFlag,edm::StrictWeakOrdering<EBSrFlag> > >" splitLevel="0" id="C0D3A113-A36C-40F1-A388-28ECE47DCBA5"/>
    <class name="edm::Wrapper<edm::SortedCollection<EESrFlag,edm::StrictWeakOrdering<EESrFlag> > >" splitLevel="0" id="CE18D35E-E4F5-4685-8D9A-213D9ACB0606"/>
-   <class name="edm::Wrapper<edm::SortedCollection<EcalPnDiodeDigi,edm::StrictWeakOrdering<EcalPnDiodeDigi> > > " id="8104DEE4-28BC-284A-8397-7EF8F5DBA1B1"/>
-   <class name="edm::Wrapper<edm::SortedCollection<EcalMatacqDigi,edm::StrictWeakOrdering<EcalMatacqDigi> > > " id="09B54EAE-7A1A-B892-117A-EFE5E32AF982"/>
+   <class name="edm::Wrapper<edm::SortedCollection<EcalPnDiodeDigi,edm::StrictWeakOrdering<EcalPnDiodeDigi> > >" id="8104DEE4-28BC-284A-8397-7EF8F5DBA1B1"/>
+   <class name="edm::Wrapper<edm::SortedCollection<EcalMatacqDigi,edm::StrictWeakOrdering<EcalMatacqDigi> > >" id="09B54EAE-7A1A-B892-117A-EFE5E32AF982"/>
 </lcgdict>

--- a/DataFormats/EgammaCandidates/src/classes_def.xml
+++ b/DataFormats/EgammaCandidates/src/classes_def.xml
@@ -91,7 +91,7 @@
   <class name="edm::Wrapper<edm::RefToBaseVector<reco::Photon> >" />
   <class name="edm::reftobase::BaseVectorHolder<reco::Photon>" />
   <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > > >"/>
-  <class name="edm::ValueMap<edm::Ref<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > > "/>
+  <class name="edm::ValueMap<edm::Ref<std::vector<reco::Photon>,reco::Photon,edm::refhelper::FindUsingAdvance<std::vector<reco::Photon>,reco::Photon> > >"/>
   <!--
   <class name="std::pair<reco::PFCandidateRef,bool>"/>
   <class name="std::vector<std::pair<reco::PFCandidateRef,bool> >"/>

--- a/DataFormats/JetReco/src/classes_def_3.xml
+++ b/DataFormats/JetReco/src/classes_def_3.xml
@@ -102,7 +102,7 @@
   <class name="edm::reftobase::BaseHolder<reco::Jet>" />
   <class name="edm::reftobase::IndirectHolder<reco::Jet>" />
   <class name="edm::reftobase::IndirectVectorHolder<reco::Jet>" />
-  <class name="edm::reftobase::Holder<reco::Candidate,edm::RefToBase<reco::Jet> > "/>
+  <class name="edm::reftobase::Holder<reco::Candidate,edm::RefToBase<reco::Jet> >"/>
   <class name="edm::RefToBaseVector<reco::Jet>"/>
   <class name="edm::Wrapper<edm::RefToBaseVector<reco::Jet> >"/>
   <class name="edm::reftobase::BaseVectorHolder<reco::Jet>"/>

--- a/DataFormats/L1GlobalTrigger/src/classes_def.xml
+++ b/DataFormats/L1GlobalTrigger/src/classes_def.xml
@@ -94,19 +94,19 @@
   </class>
   <class name="edm::Wrapper<L1GtTechnicalTriggerRecord>" splitLevel="0"/>
 
-  <class name="std::vector<L1GtObject> "/>
+  <class name="std::vector<L1GtObject>"/>
   <class name="std::vector<std::vector<L1GtObject> >"/>
 
   <class name="L1GtLogicParser::OperandToken" ClassVersion="10">
    <version ClassVersion="10" checksum="599247693"/>
   </class>
-  <class name="std::vector<L1GtLogicParser::OperandToken> "/>
+  <class name="std::vector<L1GtLogicParser::OperandToken>"/>
 
   <class name="L1GtLogicParser::TokenRPN" ClassVersion="11">
    <version ClassVersion="11" checksum="1759531300"/>
    <version ClassVersion="10" checksum="535147936"/>
   </class>
-  <class name="std::vector<L1GtLogicParser::TokenRPN> "/>
+  <class name="std::vector<L1GtLogicParser::TokenRPN>"/>
 
   <class name="L1GtTriggerMenuLite" ClassVersion="10">
    <version ClassVersion="10" checksum="851367861"/>

--- a/DataFormats/L1Trigger/src/classes_def.xml
+++ b/DataFormats/L1Trigger/src/classes_def.xml
@@ -130,7 +130,7 @@
 
   <class name="edm::reftobase::Holder<reco::Candidate, edm::Ref<std::vector<l1extra::L1EtMissParticle>,l1extra::L1EtMissParticle,edm::refhelper::FindUsingAdvance<std::vector<l1extra::L1EtMissParticle>,l1extra::L1EtMissParticle> > >" />
 
-  <class name="edm::reftobase::Holder<reco::Candidate, edm::RefProd<l1extra::L1EtMissParticle> > "/>
+  <class name="edm::reftobase::Holder<reco::Candidate, edm::RefProd<l1extra::L1EtMissParticle> >"/>
 
   <class name="std::vector<l1extra::L1ParticleMap::L1ObjectType>"/>
 

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -34,13 +34,13 @@
    <version ClassVersion="10" checksum="3022746385"/>
    <version ClassVersion="11" checksum="747083523"/>
   </class>
-  <class name="std::vector<SpecificCaloMETData> "/>
+  <class name="std::vector<SpecificCaloMETData>"/>
 
   <class name="SpecificPFMETData" ClassVersion="11">
    <version ClassVersion="10" checksum="219431109"/>
    <version ClassVersion="11" checksum="1851051058"/>
   </class>
-  <class name="std::vector<SpecificPFMETData> "/>
+  <class name="std::vector<SpecificPFMETData>"/>
   <class name="SpecificGenMETData" ClassVersion="11">
    <version ClassVersion="10" checksum="2173201550"/>
    <version ClassVersion="11" checksum="2260055190"/>

--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -34,9 +34,9 @@
   <class name="reco::PFCandidatePtr"/>
   <class name="std::vector<reco::PFCandidatePtr>"/>
   <class name="edm::Wrapper<edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
-  <class name="edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > "/>
-  <class name="std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > "/>
-  <class name="std::vector<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > "/>
+  <class name="edm::ValueMap<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >"/>
+  <class name="std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > >"/>
+  <class name="std::vector<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
   <class name="edm::Wrapper<edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > > >"/>
   <class name="edm::ValueMap<std::vector<edm::Ref<std::vector<reco::PFCandidate>,reco::PFCandidate,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCandidate>,reco::PFCandidate> > > >"/>
   <class name="edm::Wrapper<edm::ValueMap<edm::Ptr<reco::PFCandidate> > >"/>

--- a/DataFormats/ParticleFlowReco/src/classes_def_2.xml
+++ b/DataFormats/ParticleFlowReco/src/classes_def_2.xml
@@ -191,7 +191,7 @@
 
   <class name="edm::Ref<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack> >"/>
-  <class name="std::vector<edm::Ref<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack> > > "/>
+  <class name="std::vector<edm::Ref<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfPFRecTrack>,reco::GsfPFRecTrack> > >"/>
 
   <class name="edm::Ref<std::vector<reco::PFCluster>,reco::PFCluster,edm::refhelper::FindUsingAdvance<std::vector<reco::PFCluster>,reco::PFCluster> >"/>
 
@@ -212,7 +212,7 @@
   <class name="std::vector<pftools::Calibratable>" />
   <class name="std::vector<pftools::CalibratableElement>" />
   <class name="std::vector<pftools::CandidateWrapper>" />
-  <class name="std::vector<pftools::CalibrationResultWrapper> "/>
+  <class name="std::vector<pftools::CalibrationResultWrapper>"/>
   <class name="pftools::CaloWindow"  ClassVersion="10">
    <version ClassVersion="10" checksum="1050281643"/>
   </class>
@@ -266,7 +266,7 @@
 
   <class name="std::vector<reco::PFDisplacedVertex::VertexTrackType>"/>
 
-  <class name="std::vector<std::pair<std::pair<unsigned int,unsigned int>,std::pair<unsigned int,unsigned int> > > "/>
+  <class name="std::vector<std::pair<std::pair<unsigned int,unsigned int>,std::pair<unsigned int,unsigned int> > >"/>
 
   <class name="std::pair<std::pair<unsigned int,unsigned int>,std::pair<unsigned int,unsigned int> >"/>
 

--- a/DataFormats/Provenance/src/classes_def.xml
+++ b/DataFormats/Provenance/src/classes_def.xml
@@ -65,7 +65,7 @@
  <class name="std::vector<std::pair<edm::ProductID, unsigned int> >" />
  <class name="std::vector<edm::EventID>"/>
  <class name="std::vector<std::vector<edm::EventID> >"/>
- <class name="std::vector<std::vector<std::vector<edm::EventID> > > "/>
+ <class name="std::vector<std::vector<std::vector<edm::EventID> > >"/>
  <class name="edm::BranchChildren" ClassVersion="10">
   <version ClassVersion="10" checksum="137742168"/>
  </class>

--- a/DataFormats/RPCDigi/src/classes_def.xml
+++ b/DataFormats/RPCDigi/src/classes_def.xml
@@ -8,7 +8,7 @@
 <class name="MuonDigiCollection<RPCDetId,RPCDigi>"/> 
 <class name="edm::Wrapper<MuonDigiCollection<RPCDetId,RPCDigi>>" splitLevel="0"/> 
 
-<class name="edm::Wrapper<std::map <std::pair<int,int>, int> > "/> 
+<class name="edm::Wrapper<std::map <std::pair<int,int>, int> >"/> 
 <class name="RPCRawDataCounts" ClassVersion="10">
  <version ClassVersion="10" checksum="977138550"/>
 </class>

--- a/DataFormats/SiPixelDigi/src/classes_def.xml
+++ b/DataFormats/SiPixelDigi/src/classes_def.xml
@@ -29,8 +29,8 @@
    <class name="edm::DetSetVector<SiPixelCalibDigi>"/>
    <class name="std::vector<edm::DetSet<SiPixelCalibDigi> >"/>
    <class name="edm::Wrapper<std::vector<edm::DetSet<SiPixelCalibDigi> > >" splitLevel="0"/>
-   <class name="edm::Wrapper<edm::DetSet<SiPixelCalibDigi > > " splitLevel="0"/>
-   <class name="edm::Wrapper<edm::DetSetVector<SiPixelCalibDigi> > " splitLevel="0"/>
+   <class name="edm::Wrapper<edm::DetSet<SiPixelCalibDigi > >" splitLevel="0"/>
+   <class name="edm::Wrapper<edm::DetSetVector<SiPixelCalibDigi> >" splitLevel="0"/>
 
    <class name="edmNew::DetSetVector<SiPixelCalibDigi>"/>
    <class name="edm::Wrapper< edmNew::DetSetVector<SiPixelCalibDigi> >"/>
@@ -44,9 +44,9 @@
    <class name="std::vector<edm::DetSet<SiPixelCalibDigiError> >"/>
    <class name="edm::Wrapper<SiPixelCalibDigiError>" splitLevel="0"/>
    <class name="edm::Wrapper<std::vector<edm::DetSet<SiPixelCalibDigiError> > >" splitLevel="0"/>
-   <class name="edm::Wrapper<edm::DetSet<SiPixelCalibDigiError> > " splitLevel="0"/>
-   <class name="edm::Wrapper<edm::DetSetVector<SiPixelCalibDigiError> > " splitLevel="0"/>
+   <class name="edm::Wrapper<edm::DetSet<SiPixelCalibDigiError> >" splitLevel="0"/>
+   <class name="edm::Wrapper<edm::DetSetVector<SiPixelCalibDigiError> >" splitLevel="0"/>
 
-   <class name="edmNew::DetSetVector<SiPixelCalibDigiError> "/>
-   <class name="edm::Wrapper<edmNew::DetSetVector<SiPixelCalibDigiError> > "/>
+   <class name="edmNew::DetSetVector<SiPixelCalibDigiError>"/>
+   <class name="edm::Wrapper<edmNew::DetSetVector<SiPixelCalibDigiError> >"/>
 </lcgdict>

--- a/DataFormats/TauReco/src/classes_def_3.xml
+++ b/DataFormats/TauReco/src/classes_def_3.xml
@@ -105,7 +105,7 @@
   <class name="edm::Ref<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> >"/>
   <class name="edm::RefProd<std::vector<reco::PFTauTransverseImpactParameter> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> >"/>
-  <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameter, edm::Ref<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> > > " />
+  <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameter, edm::Ref<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameter>,reco::PFTauTransverseImpactParameter> > >" />
   <class name="edm::Association<std::vector<reco::PFTauTransverseImpactParameter> >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauTransverseImpactParameter> > >"/>
 
@@ -115,7 +115,7 @@
   <class name="edm::Ref<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection> >"/>
   <class name="edm::RefProd<std::vector<reco::PFTauTransverseImpactParameterCollection> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection> >"/>
-  <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameterCollection, edm::Ref<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection> > > " />
+  <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameterCollection, edm::Ref<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterCollection>,reco::PFTauTransverseImpactParameterCollection> > >" />
   <class name="edm::Association<std::vector<reco::PFTauTransverseImpactParameterCollection> >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauTransverseImpactParameterCollection> > >"/>
 
@@ -125,7 +125,7 @@
   <class name="edm::Ref<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef> >"/>
   <class name="edm::RefProd<std::vector<reco::PFTauTransverseImpactParameterRef> >"/>
   <class name="edm::RefVector<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef> >"/>
-  <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameterRef, edm::Ref<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef> > > " />
+  <class name="edm::reftobase::Holder<reco::PFTauTransverseImpactParameterRef, edm::Ref<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef,edm::refhelper::FindUsingAdvance<std::vector<reco::PFTauTransverseImpactParameterRef>,reco::PFTauTransverseImpactParameterRef> > >" />
   <class name="edm::Association<std::vector<reco::PFTauTransverseImpactParameterRef> >"/>
   <class name="edm::Wrapper<edm::Association<std::vector<reco::PFTauTransverseImpactParameterRef> > >"/>
 

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -463,14 +463,14 @@
 
 
      <class name="std::pair<reco::Track,reco::Track>"/>
-     <class name="edm::Wrapper<std::pair<reco::Track,reco::Track> > "/>
+     <class name="edm::Wrapper<std::pair<reco::Track,reco::Track> >"/>
      <class name="std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> >" />
      <class name="edm::Wrapper<std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> > >" />
      <class name="std::vector<std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> > >"/>
      <class name="edm::Wrapper<std::vector<std::pair<TrackCandidate,std::pair<reco::Track,reco::Track> > > >"/>
 
      <class name="std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > >"/>
-     <class name="edm::Wrapper<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > > "/>
+     <class name="edm::Wrapper<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > >"/>
      <class name="std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > >" />
      <class name="edm::Wrapper<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > > >" />
      <class name="std::vector<std::pair<TrackCandidate,std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> > > > >"/>

--- a/DataFormats/VertexReco/src/classes_def.xml
+++ b/DataFormats/VertexReco/src/classes_def.xml
@@ -19,22 +19,22 @@
 
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Vertex> >,edm::RefProd<std::vector<reco::Track> > >" />  
   <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,float> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,float> > > > " />		
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,float> > > >" />
   <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,float,unsigned int> >" />
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,float,unsigned int> > >" />
   <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,int> > > > " />		
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,std::vector<std::pair<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,int> > > >" />
   <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,int,unsigned int> >" />						
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Vertex>,std::vector<reco::Track>,int,unsigned int> > >" />
 
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<reco::Vertex> > >" />  
   <class name="edm::helpers::KeyVal<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > >" />
-  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > > > " />
+  <class name="std::map<unsigned int,edm::helpers::KeyVal<edm::Ref<std::vector<reco::Track>,reco::Track,edm::refhelper::FindUsingAdvance<std::vector<reco::Track>,reco::Track> >,std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> > > >" />
   <class name="edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Track>,std::vector<reco::Vertex>,int,unsigned int> >" />
 <!--      <class name="edm::Wrapper<edm::AssociationMap<edm::OneToManyWithQuality<std::vector<reco::Track>,std::vector<reco::Vertex>,int,unsigned int> > >" /> -->
 
 
- <class name="edm::Association<std::vector<reco::Vertex> > "/>
+ <class name="edm::Association<std::vector<reco::Vertex> >"/>
  <class name="edm::Wrapper<edm::Association<std::vector<reco::Vertex> > >"/>
   <class name="std::vector<std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int> >" />
   <class name="std::pair<edm::Ref<std::vector<reco::Vertex>,reco::Vertex,edm::refhelper::FindUsingAdvance<std::vector<reco::Vertex>,reco::Vertex> >,int>" />

--- a/FastSimDataFormats/NuclearInteractions/src/classes_def.xml
+++ b/FastSimDataFormats/NuclearInteractions/src/classes_def.xml
@@ -17,7 +17,7 @@
    <version ClassVersion="10" checksum="1253390925"/>
   </class>
   <class name="std::vector<FSimVertexType>"/>
-  <class name="edm::Wrapper< std::vector<FSimVertexType> > "/>  
+  <class name="edm::Wrapper< std::vector<FSimVertexType> >"/>  
   <class name="edm::Ref< std::vector<FSimVertexType>, FSimVertexType, edm::refhelper::FindUsingAdvance< std::vector<FSimVertexType>, FSimVertexType> >"/>
 
   <class name="FSimDisplacedVertex" ClassVersion="11">
@@ -25,7 +25,7 @@
    <version ClassVersion="10" checksum="251560649"/>
   </class>
   <class name="std::vector<FSimDisplacedVertex>"/>
-  <class name="edm::Wrapper< std::vector<FSimDisplacedVertex> > "/>  
+  <class name="edm::Wrapper< std::vector<FSimDisplacedVertex> >"/>  
   <class name="edm::Ref< std::vector<FSimDisplacedVertex>, FSimDisplacedVertex, edm::refhelper::FindUsingAdvance< std::vector<FSimDisplacedVertex>, FSimDisplacedVertex> >"/>
 
 </lcgdict>

--- a/SimDataFormats/CaloHit/src/classes_def.xml
+++ b/SimDataFormats/CaloHit/src/classes_def.xml
@@ -3,7 +3,7 @@
    <version ClassVersion="10" checksum="682759659"/>
   </class>
   <class name="std::vector<PCaloHit>"/>
-  <class name="std::vector<const PCaloHit*> "/>
+  <class name="std::vector<const PCaloHit*>"/>
   <class name="edm::Wrapper<std::vector<PCaloHit>>" splitLevel="0"/>
   <class name="HFShowerPhoton" ClassVersion="10">
    <version ClassVersion="10" checksum="3736969110"/>


### PR DESCRIPTION
Trailing or leading whitespace could create problems for ROOT6
genreflex.

E.g., `AnalysisDataFormats/TrackInfo`

```
Warning - unused class rule: reco::TrackingStateInfo
```

ROOT6 couldn't get a match because of leading whitespace.

ROOT5 compatibility was restored at ROOT6 commit:
`c7f7ef9160b833c799f398154ef16c5fd1c34313`

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
