### PR TITLE
SiStrip summary report back to old shape

### DIFF
--- a/DQM/SiStripMonitorClient/src/SiStripQualityChecker.cc
+++ b/DQM/SiStripMonitorClient/src/SiStripQualityChecker.cc
@@ -232,6 +232,8 @@ void SiStripQualityChecker::fillSubDetStatus(DQMStore* dqm_store,
     std::string dname = (*ic);
     if (dname.find("BadModuleList") != std::string::npos) continue;
     std::vector<MonitorElement*> meVec;
+    if (dname.find("ring") !=std::string::npos) continue;
+    
     ybin++;
     dqm_store->cd((*ic));
     meVec = dqm_store->getContents((*ic));


### PR DESCRIPTION
This is a bug fix to restore the shape of SiStrip report histos to normal (i.e 3 bins in TID+/- and 9 in TEC)
