### PR TITLE
Remove PoolDBESSource from cfi file

### DIFF
--- a/RecoJets/JetProducers/python/QGTagger_cfi.py
+++ b/RecoJets/JetProducers/python/QGTagger_cfi.py
@@ -1,22 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# See https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
-qgDatabaseVersion = 'v1'
-
-from CondCore.DBCommon.CondDBSetup_cfi import *
-QGPoolDBESSource = cms.ESSource("PoolDBESSource",
-      CondDBSetup,
-      toGet = cms.VPSet(),
-      connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),
-)
-
-for type in ['AK4PF','AK4PFchs','AK4PF_antib','AK4PFchs_antib']:
-  QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
-    record = cms.string('QGLikelihoodRcd'),
-    tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
-    label  = cms.untracked.string('QGL_'+type)
-  )))
-
 QGTagger = cms.EDProducer('QGTagger',
   srcJets		= cms.InputTag('ak4PFJetsCHS'),
   jetsLabel		= cms.string('QGL_AK4PFchs'),


### PR DESCRIPTION
Removing the PoolDBESSource from the QGTagger_cfi file, will move this to GT
