### PR TITLE
2400 MB changed to 3000

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -98,7 +98,7 @@ class MatrixInjector(object):
             "unmergedLFNBase" : "/store/unmerged",
             "mergedLFNBase" : "/store/relval",
             "dashboardActivity" : "relval",
-            "Memory" : 2400,
+            "Memory" : 3000,
             "SizePerEvent" : 1234,
             "TimePerEvent" : 20
             }


### PR DESCRIPTION
This change is needed for relval submission (affects only workflow injection)
See : https://hypernews.cern.ch/HyperNews/CMS/get/comp-ops/2304/2/1/1/1/1.html
Synchronized with any other 7X releases (like for example PR#9335)  
Whenever the next release will be built, this should be included for relval submission 
