### PR TITLE
CINT cannot handle C++ 11 (e.g. nullptr)

### DIFF
--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -25,7 +25,7 @@ RefCoreWithIndex: The component of edm::Ref containing the product ID and produc
 namespace edm {  
   class RefCoreWithIndex {
   public:
-    RefCoreWithIndex() :  cachePtr_(nullptr),processIndex_(0),productIndex_(0),elementIndex_(edm::key_traits<unsigned int>::value) {}
+    RefCoreWithIndex() :  cachePtr_(0),processIndex_(0),productIndex_(0),elementIndex_(edm::key_traits<unsigned int>::value) {}
 
     RefCoreWithIndex(ProductID const& theId, void const* prodPtr, EDProductGetter const* prodGetter, bool transient, unsigned int elementIndex);
 

--- a/DataFormats/Common/interface/refcore_implementation.h
+++ b/DataFormats/Common/interface/refcore_implementation.h
@@ -93,7 +93,7 @@ namespace edm {
 
 #define PRODUCTPTR_IMPL return refcoreimpl::productPtr(cachePtr_)
 
-#define ISNONNULL_IMPL return isTransient() ? productPtr() != nullptr : id().isValid()
+#define ISNONNULL_IMPL return isTransient() ? productPtr() != 0 : id().isValid()
 
 #define PRODUCTGETTER_IMPL return refcoreimpl::productGetter(cachePtr_)
 


### PR DESCRIPTION
This PR fixes the compilation errors in DataFormats/TrackerRecHit2D in CMSSW_7_5_ROOT5_X.
The problem is simply that rootcint cannot handle the C++11 keyword nullptr.  So, this PR reverts nullptr to 0 for the ROOT5 release only.
