### PR TITLE
Bugfix in L1 GCT ET sums hardware emulator

### DIFF
--- a/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EtSumAlgorithmImpHW.cc
+++ b/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EtSumAlgorithmImpHW.cc
@@ -255,13 +255,16 @@ l1t::Stage1Layer2EtSumAlgorithmImpHW::doSumAndMET(const std::vector<SimpleRegion
 }
 
 // converts phase from 3Q16 to 0-71
+// Expects abs(phase) <= 205887 (pi*2^16)
 int
 l1t::Stage1Layer2EtSumAlgorithmImpHW::cordicToMETPhi(int phase)
 {
+  assert(abs(phase)<=205887);
   for(size_t i=0; i<cordicPhiValues.size()-1; ++i)
     if ( phase >= cordicPhiValues[i] && phase < cordicPhiValues[i+1] )
       return i;
-  return -1;
+  // if phase == +205887 (+pi), return zero
+  return 0;
 }
 
 int l1t::Stage1Layer2EtSumAlgorithmImpHW::DiJetPhi(const std::vector<l1t::Jet> * jets)  const {


### PR DESCRIPTION
Algorithm bug triggered an assertion.
Fix has been discussed with @mulhearn
This should also get applied to 7_5_X.  I'm not sure the most proper way to do this, two pull requests?

First observed in Run 245684, Event 1063307554, LumiSection 476.
To reproduce, need to change the region sums source in `L1Trigger/L1TCalorimeter/test/SimL1Emulator_Stage1.py` to the hardware values rather than reproducing from RAW.  This is due to the particular run setup for that run.

``` python
from L1Trigger.L1TCalorimeter.simRctUpgradeFormatDigis_cfi import *
simRctUpgradeFormatDigis.regionTag = cms.InputTag("gctDigis")
simRctUpgradeFormatDigis.emTag = cms.InputTag("gctDigis")
```

The event can be found at `/afs/cern.ch/user/z/zhangj/public/Splashes_Run245684_1_2_IKY.root`
The output was

```
/home/l1tlocal/CMSSW_7_4_2/src/L1Trigger/L1TCalorimeter/src/firmware/Stage1Layer2EtSumAlgorithmImpHW.cc:245:
std::tuple<int, int, int> l1t::Stage1Layer2EtSumAlgorithmImpHW::doSumAndMET(const std::vector<l1t::Stage1Layer2EtSumAlgorithmImpHW::SimpleRegion>&, l1t::Stage1Layer2EtSumAlgorithmImpHW::ETSumType): 
Assertion `metPhi >=0 && metPhi < 18' failed.
```
