### PR TITLE
enabling code for timestamp selection after frontier bug fix

### DIFF
--- a/CondCore/CondDB/src/GTSchema.cc
+++ b/CondCore/CondDB/src/GTSchema.cc
@@ -34,14 +34,9 @@ namespace cond {
     bool GLOBAL_TAG::Table::select( const std::string& name, 
 				    cond::Time_t& validity, 
 				    boost::posix_time::ptime& snapshotTime ){
-      // FIXME: FronTier reads from Oracle with a Format not compatible with the parsing in Coral: required is 'YYYY-MM-DD HH24:MI:SSXFF6' 
-      // temporarely disabled to allow to work with FronTier
-      //Query< VALIDITY, SNAPSHOT_TIME > q( session.coralSchema() );
-      //q.addCondition<NAME>( name );
-      //for ( auto row : q ) std::tie( validity, snapshotTime ) = row;
-      Query< VALIDITY > q( m_schema );
+      Query< VALIDITY, SNAPSHOT_TIME > q( m_schema );
       q.addCondition<NAME>( name );
-      for ( auto row : q ) std::tie( validity ) = row;
+      for ( auto row : q ) std::tie( validity, snapshotTime ) = row;
       
       return q.retrievedRows();
     }
@@ -51,14 +46,10 @@ namespace cond {
 				    std::string& description, 
 				    std::string& release, 
 				    boost::posix_time::ptime& snapshotTime ){
-      // FIXME: Frontier reads from Oracle with a Format not compatible with the parsing in Coral: required is 'YYYY-MM-DD HH24:MI:SSXFF6' 
-      // temporarely disabled to allow to work with FronTier
-      //Query< VALIDITY, DESCRIPTION, RELEASE, SNAPSHOT_TIME > q( session.coralSchema() );
-      //q.addCondition<NAME>( name );
-      //for ( auto row : q ) std::tie( validity, description, release, snapshotTime ) = row;
-      Query< VALIDITY, DESCRIPTION, RELEASE > q( m_schema );
+      Query< VALIDITY, DESCRIPTION, RELEASE, SNAPSHOT_TIME > q( m_schema );
       q.addCondition<NAME>( name );
-      for ( auto row : q ) std::tie( validity, description, release ) = row;
+      for ( auto row : q ) std::tie( validity, description, release, snapshotTime ) = row;
+
       return q.retrievedRows();
     }
     

--- a/CondCore/CondDB/test/testConditionDatabase_1.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_1.cpp
@@ -105,6 +105,20 @@ int run( const std::string& connectionString ){
     session.transaction().start();
     readTag( "MyTag", session, snap1 );
     session.transaction().commit();
+    // 
+    session.transaction().start( false );
+    GTEditor gtWriter = session.createGlobalTag("MY_TEST_GT_V0");
+    gtWriter.setDescription( "test GT" );
+    gtWriter.setRelease( "CMSSW_7_5_X" );
+    gtWriter.setSnapshotTime( snap0 );
+    gtWriter.insert( "myrecord", "MyTag" );
+    gtWriter.flush();
+    session.transaction().commit();
+    session.transaction().start();
+    GTProxy gtReader = session.readGlobalTag("MY_TEST_GT_V0");
+    boost::posix_time::ptime snap2 = gtReader.snapshotTime();
+    readTag( "MyTag", session, snap2 );
+    session.transaction().commit();
   } catch (const std::exception& e){
     std::cout << "ERROR: " << e.what() << std::endl;
     return -1;

--- a/CondCore/ESSources/plugins/CondDBESSource.cc
+++ b/CondCore/ESSources/plugins/CondDBESSource.cc
@@ -182,7 +182,12 @@ CondDBESSource::CondDBESSource( const edm::ParameterSet& iConfig ) :
 			  globaltagList,
 			  replacements,
 			  gtMetadata);
-  if(snapshotTime.is_not_a_date_time()) snapshotTime = gtMetadata.snapshotTime;
+  // if no job specific setting has been found, use the GT timestamp
+  if(snapshotTime.is_not_a_date_time()) 
+    snapshotTime = gtMetadata.snapshotTime;
+  // finally, if the snapshot is set to infinity, reset the snapshot to null, to take the full iov set...
+  if(snapshotTime == boost::posix_time::time_from_string(std::string(cond::time::MAX_TIMESTAMP) ) )
+    snapshotTime = boost::posix_time::ptime();
   
   TagCollection::iterator it;
   TagCollection::iterator itBeg = m_tagCollection.begin();

--- a/CondCore/ESSources/test/python/loadall_from_gt_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_gt_cfg.py
@@ -21,7 +21,7 @@ process = cms.Process("TEST")
 #process.add_(cms.Service("PrintEventSetupDataRetrieval", printProviders=cms.untracked.bool(True)))
 
 CondDBSetup = cms.PSet( DBParameters = cms.PSet(
-                                                messageLevel = cms.untracked.int32(1),
+                                                messageLevel = cms.untracked.int32(3),
                                                 )
                         )
 

--- a/CondCore/ESSources/test/python/loadall_from_gt_empty_source_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_gt_empty_source_cfg.py
@@ -58,10 +58,10 @@ process.MessageLogger = cms.Service( "MessageLogger",
                                      detailedInfo = cms.untracked.PSet( threshold = cms.untracked.string( 'INFO' ) ),
                                      )
 
-process.add_( cms.Service( "PrintEventSetupDataRetrieval",
-                           printProviders=cms.untracked.bool( True )
-                           )
-              )
+#process.add_( cms.Service( "PrintEventSetupDataRetrieval",
+#                           printProviders=cms.untracked.bool( True )
+#                           )
+#              )
 
 CondDBSetup = cms.PSet( DBParameters = cms.PSet( authenticationPath = cms.untracked.string( '.' ),
                                                  connectionRetrialPeriod = cms.untracked.int32( 10 ),

--- a/CondCore/ESSources/test/python/loadall_from_prodglobaltag_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_prodglobaltag_cfg.py
@@ -7,7 +7,7 @@ options.register('runNumber',
                  VarParsing.VarParsing.varType.int,
                  "Run number; default gives latest IOV")
 options.register('globalTag',
-                 'START70_V2::All', #default value
+                 'GR_P_V50', #default value
                  VarParsing.VarParsing.multiplicity.singleton,
                  VarParsing.VarParsing.varType.string,
                  "GlobalTag")
@@ -16,10 +16,9 @@ options.parseArguments()
 
 process = cms.Process("TEST")
 
-process.add_(cms.Service("PrintEventSetupDataRetrieval", printProviders=cms.untracked.bool(True)))
+#process.add_(cms.Service("PrintEventSetupDataRetrieval", printProviders=cms.untracked.bool(True)))
 
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
-#process.GlobalTag.globaltag = options.globalTag+'::All'
 process.GlobalTag.globaltag = options.globalTag
 process.GlobalTag.RefreshEachRun=cms.untracked.bool(False)
 process.GlobalTag.DumpStat=cms.untracked.bool(True)


### PR DESCRIPTION
This PR restores the code for the IOV snapshot selection. This functionality was temporarily disabled due to a misbehaviour of the coral Frontier in the handling of TIMESTAMP column. Since the coral patch is now in, we enable the original feature. 
