### PR TITLE
Simplified commands to copy geometry comparison plots into subfolders, changed units in rotation plots

### DIFF
--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparison.py
@@ -120,37 +120,6 @@ class GeometryComparison(GenericValidation):
                      ".oO[name]Oo..Comparison_common"+name+".root\",\""
                      "./\")'\n")
                 if  self.copyImages:
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("rfmkdir -p .oO[datadir]Oo./.oO[name]Oo."
-                        #~ ".Comparison_common"+name+"_Images\n")
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("find . -maxdepth 1 -name \"*PXB*\" "
-                        #~ "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        #~ "/.oO[name]Oo..Comparison_common"+name+"_Images/\" \n")
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("find . -maxdepth 1 -name \"*PXF*\" "
-                        #~ "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        #~ "/.oO[name]Oo..Comparison_common"+name+"_Images/\" \n")
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("find . -maxdepth 1 -name \"*TIB*\" "
-                        #~ "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        #~ "/.oO[name]Oo..Comparison_common"+name+"_Images/\" \n")
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("find . -maxdepth 1 -name \"*TID*\" "
-                        #~ "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        #~ "/.oO[name]Oo..Comparison_common"+name+"_Images/\" \n")
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("find . -maxdepth 1 -name \"*TEC*\" "
-                        #~ "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        #~ "/.oO[name]Oo..Comparison_common"+name+"_Images/\" \n")
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("find . -maxdepth 1 -name \"*TOB*\" "
-                        #~ "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        #~ "/.oO[name]Oo..Comparison_common"+name+"_Images/\" \n")
-                   #~ repMap["runComparisonScripts"] += \
-                       #~ ("find . -maxdepth 1 -name \"*tracker*\" "
-                        #~ "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        #~ "/.oO[name]Oo..Comparison_common"+name+"_Images/\" \n")
                    repMap["runComparisonScripts"] += \
                        ("rfmkdir -p .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images\n")
@@ -163,162 +132,37 @@ class GeometryComparison(GenericValidation):
                    repMap["runComparisonScripts"] += \
                        ("rfmkdir -p .oO[datadir]Oo./.oO[name]Oo."
                         ".Comparison_common"+name+"_Images/CrossTalk\n")
+                        
+                   ### At the moment translations are immages with suffix _1 and _2, rotations _3 and _4, and cross talk _5 and _6
+                   ### The numeration depends on the order of the MakePlots(x, y) commands in comparisonScript.C
+                   ### If comparisonScript.C is changed, check if the following lines need to be changed as well
                    repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*phi_vs_dr*\" "
+                       ("find . -maxdepth 1 -name \"*_1*\" "
                         "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
                         "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
                    repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*phi_vs_dx*\" "
+                       ("find . -maxdepth 1 -name \"*_2*\" "
                         "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
                         "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
+                   
                    repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*phi_vs_dy*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*phi_vs_dz*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*phi_vs_rdphi*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*r_vs_dr*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*r_vs_dx*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*r_vs_dy*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*r_vs_dz*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*r_vs_rdphi*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*z_vs_dr*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*z_vs_dx*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*z_vs_dy*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*z_vs_dz*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*z_vs_rdphi*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Translations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*alpha_vs_dalpha*\" "
+                       ("find . -maxdepth 1 -name \"*_3*\" "
                         "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
                         "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
                    repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*alpha_vs_dbeta*\" "
+                       ("find . -maxdepth 1 -name \"*_4*\" "
                         "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
                         "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
+                   
                    repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*alpha_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*beta_vs_dalpha*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*beta_vs_dbeta*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*beta_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*gamma_vs_dalpha*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*gamma_vs_dbeta*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*gamma_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/Rotations/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dr_vs_dalpha*\" "
+                       ("find . -maxdepth 1 -name \"*_5*\" "
                         "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
                         "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
                    repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dr_vs_dbeta*\" "
+                       ("find . -maxdepth 1 -name \"*_6*\" "
                         "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
                         "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dr_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dx_vs_dalpha*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dx_vs_dbeta*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dx_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dy_vs_dalpha*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dy_vs_dbeta*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dy_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dz_vs_dalpha*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dz_vs_dbeta*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*dz_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*rdphi_vs_dalpha*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*rdphi_vs_dbeta*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
-                   repMap["runComparisonScripts"] += \
-                       ("find . -maxdepth 1 -name \"*rdphi_vs_dgamma*\" "
-                        "-print | xargs -I {} bash -c \"rfcp {} .oO[datadir]Oo."
-                        "/.oO[name]Oo..Comparison_common"+name+"_Images/CrossTalk/\" \n")
+                   
                    repMap["runComparisonScripts"] += \
                        ("find . -maxdepth 1 -name "
                         "\"TkMap_SurfDeform*.pdf\" -print | xargs -I {} bash -c"

--- a/Alignment/OfflineValidation/scripts/comparisonScript.C
+++ b/Alignment/OfflineValidation/scripts/comparisonScript.C
@@ -45,7 +45,7 @@ void comparisonScript (TString inFile,//="mp1510_vs_mp1509.Comparison_commonTrac
     x.push_back("z");                                           	trans->SetBranchUnits("z",     "cm");      //trans->SetBranchMax("z", 100); trans->SetBranchMin("z", -100);
     y.push_back("dr");		trans->SetBranchSF("dr", 	10000);     trans->SetBranchUnits("dr",    "#mum");
     y.push_back("dz");		trans->SetBranchSF("dz", 	10000);     trans->SetBranchUnits("dz",    "#mum");
-    y.push_back("rdphi");	trans->SetBranchSF("rdphi",10000);     trans->SetBranchUnits("rdphi", "#mum rad");
+    y.push_back("rdphi");	trans->SetBranchSF("rdphi",10000);      trans->SetBranchUnits("rdphi", "#mum rad");
     y.push_back("dx");		trans->SetBranchSF("dx", 	10000);     trans->SetBranchUnits("dx",    "#mum");    //trans->SetBranchMax("dx", 10); trans->SetBranchMin("dx", -10);
     y.push_back("dy");		trans->SetBranchSF("dy", 	10000);     trans->SetBranchUnits("dy",    "#mum");    //trans->SetBranchMax("dy", 10); trans->SetBranchMin("dy", -10);
     trans->MakePlots(x, y); // default output is pdf, but png gives a nicer result, so we use it as well
@@ -62,12 +62,12 @@ void comparisonScript (TString inFile,//="mp1510_vs_mp1509.Comparison_commonTrac
     // -> every combination possible will be performed
     // /!\ always give units (otherwise, unexpected bug from root...)
     vector<TString> a,b;
-    a.push_back("alpha");       rot->SetBranchUnits("alpha",    "rad");  
-    a.push_back("beta");        rot->SetBranchUnits("beta",   "rad");
-    a.push_back("gamma");       rot->SetBranchUnits("gamma",   "rad");
-    b.push_back("dalpha");      rot->SetBranchUnits("dalpha",    "rad");      
-    b.push_back("dbeta");       rot->SetBranchUnits("dbeta",    "rad");     
-    b.push_back("dgamma");      rot->SetBranchUnits("dgamma",    "rad");    
+    a.push_back("alpha");       									rot->SetBranchUnits("alpha",    "rad");  
+    a.push_back("beta");        									rot->SetBranchUnits("beta",   "rad");
+    a.push_back("gamma");       									rot->SetBranchUnits("gamma",   "rad");
+    b.push_back("dalpha");	rot->SetBranchSF("dalpha", 	1000);      rot->SetBranchUnits("dalpha",    "mrad");      
+    b.push_back("dbeta");   rot->SetBranchSF("dbeta", 	1000);    	rot->SetBranchUnits("dbeta",    "mrad");     
+    b.push_back("dgamma");  rot->SetBranchSF("dgamma", 	1000);    	rot->SetBranchUnits("dgamma",    "mrad");    
     rot->MakePlots(a, b); // default output is pdf, but png gives a nicer result, so we use it as well
     // remark: what takes the more time is the creation of the output files,
     //         not the looping on the tree (because the code is perfect, of course :p)
@@ -81,14 +81,14 @@ void comparisonScript (TString inFile,//="mp1510_vs_mp1509.Comparison_commonTrac
     // -> every combination possible will be performed
     // /!\ always give units (otherwise, unexpected bug from root...)
     vector<TString> dx,dy;
-    dx.push_back("dr");		cross->SetBranchSF("dr", 	10000);     cross->SetBranchUnits("dr",    "#mum");
-    dx.push_back("dz");		cross->SetBranchSF("dz", 	10000);     cross->SetBranchUnits("dz",    "#mum");
-    dx.push_back("rdphi");	cross->SetBranchSF("rdphi",10000);     cross->SetBranchUnits("rdphi", "#mum rad");
-    dx.push_back("dx");		cross->SetBranchSF("dx", 	10000);     cross->SetBranchUnits("dx",    "#mum");  
-    dx.push_back("dy");		cross->SetBranchSF("dy", 	10000);     cross->SetBranchUnits("dy",    "#mum"); 
-    dy.push_back("dalpha");      cross->SetBranchUnits("dalpha",    "rad");      
-    dy.push_back("dbeta");       cross->SetBranchUnits("dbeta",    "rad");     
-    dy.push_back("dgamma");      cross->SetBranchUnits("dgamma",    "rad");    
+    dx.push_back("dalpha"); cross->SetBranchSF("dalpha", 1000);     cross->SetBranchUnits("dalpha", "mrad");      
+    dx.push_back("dbeta");  cross->SetBranchSF("dbeta", 1000);     	cross->SetBranchUnits("dbeta",  "mrad");     
+    dx.push_back("dgamma"); cross->SetBranchSF("dgamma", 1000);     cross->SetBranchUnits("dgamma", "mrad"); 
+    dy.push_back("dr");		cross->SetBranchSF("dr", 	10000);     cross->SetBranchUnits("dr",    "#mum");
+    dy.push_back("dz");		cross->SetBranchSF("dz", 	10000);     cross->SetBranchUnits("dz",    "#mum");
+    dy.push_back("rdphi");	cross->SetBranchSF("rdphi",10000);      cross->SetBranchUnits("rdphi", "#mum rad");
+    dy.push_back("dx");		cross->SetBranchSF("dx", 	10000);     cross->SetBranchUnits("dx",    "#mum");  
+    dy.push_back("dy");		cross->SetBranchSF("dy", 	10000);     cross->SetBranchUnits("dy",    "#mum");     
     cross->MakePlots(dx,dy); // default output is pdf, but png gives a nicer result, so we use it as well
     // remark: what takes the more time is the creation of the output files,
     //         not the looping on the tree (because the code is perfect, of course :p)


### PR DESCRIPTION
- simplified the commands to copy geometry comparison plots into subfolders
- erased some lines which were commented out
- copy commands for global plots were forgotten in PR 9200, global plots are now included in the simpler structure
- changed the unit for differences in rotation angles from rad to mrad to avoid small numbers
