### PR TITLE
Adding prescale index and L1 tables with per-type data to 75X

### DIFF
--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -31,10 +31,10 @@
 
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 
-#include "FWCore/Framework/interface/ESHandle.h" //DS         
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h" //DS 
-#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h" //DS 
-#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h" //DS 
+#include "FWCore/Framework/interface/ESHandle.h"          
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"  
+#include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"  
+#include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"  
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
@@ -53,14 +53,22 @@ namespace hltJson {
     HistoJ<unsigned int> *hltErrors; // # of events with error in HLT[i]
     HistoJ<unsigned int> *hltDatasets; // # of events accepted by each dataset 
 
-    std::string baseRunDir;        //Base directory from EvFDaqDirector 
+    unsigned int prescaleIndex; // Prescale index for each lumi section
+
+    std::string baseRunDir; //Base directory from EvFDaqDirector 
     std::string stHltJsd;   //Definition file name for JSON with rates  
 
-    HistoJ<unsigned int> *L1Global;     // Global # of Phyics, Cailibration and Random L1 triggers //DS
-    HistoJ<unsigned int> *L1Accept;     // # of events accepted by L1T[i] //DS 
-    HistoJ<unsigned int> *L1TechAccept; // # of events accepted by L1 Technical Triggers[i] //DS 
+    HistoJ<unsigned int> *L1AlgoAccept;            // # of events accepted by L1T[i]  
+    HistoJ<unsigned int> *L1TechAccept;            // # of events accepted by L1 Technical Triggers[i]  
+    HistoJ<unsigned int> *L1AlgoAcceptPhysics;     // # of Physics events accepted by L1T[i]  
+    HistoJ<unsigned int> *L1TechAcceptPhysics;     // # of Physics events accepted by L1 Technical Triggers[i]  
+    HistoJ<unsigned int> *L1AlgoAcceptCalibration; // # of Calibration events accepted by L1T[i]  
+    HistoJ<unsigned int> *L1TechAcceptCalibration; // # of Calibration events accepted by L1 Technical Triggers[i]  
+    HistoJ<unsigned int> *L1AlgoAcceptRandom;      // # of Random events accepted by L1T[i]  
+    HistoJ<unsigned int> *L1TechAcceptRandom;      // # of Random events accepted by L1 Technical Triggers[i]  
+    HistoJ<unsigned int> *L1Global;                // Global # of Phyics, Cailibration and Random L1 triggers 
     
-    std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            //DS
+    std::string stL1Jsd;                 //Definition file name for JSON with L1 rates            
     std::string streamL1Destination;
     std::string streamHLTDestination;
   };
@@ -122,20 +130,20 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
 
   void writeDefJson(std::string path);
 
-  void writeL1DefJson(std::string path);       //DS
+  void writeL1DefJson(std::string path);       
 
   //Variables from cfg and associated tokens 
   edm::InputTag triggerResults_;                               // Input tag for TriggerResults 
   edm::EDGetTokenT<edm::TriggerResults> triggerResultsToken_;  // Token for TriggerResults
 
-  edm::InputTag level1Results_;                                 // Input tag for L1 GT Readout Record //DS  
+  edm::InputTag level1Results_;                                 // Input tag for L1 GT Readout Record   
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1t_results; // Token for L1 GT Readout Record
 
   //Variables that change at most once per run 
   HLTConfigProvider hltConfig_;         // to get configuration for HLT
-  const L1GtTriggerMenu* m_l1GtMenu;    // L1 trigger menu  //DS 
-  AlgorithmMap algorithmMap;            // L1 algorithm map //DS 
-  AlgorithmMap technicalMap;            // L1 technical triggeral map //DS
+  const L1GtTriggerMenu* m_l1GtMenu;    // L1 trigger menu   
+  AlgorithmMap algorithmMap;            // L1 algorithm map  
+  AlgorithmMap technicalMap;            // L1 technical triggeral map 
 
   const L1GtTriggerMask* m_l1tAlgoMask;
   const L1GtTriggerMask* m_l1tTechMask;
@@ -153,16 +161,17 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
 
   std::string stHltJsd_;                  //Definition file name for JSON with rates
 
-  std::vector<std::string> L1AlgoNames_;  // name of each L1 algorithm trigger      //DS
-  std::vector<int> L1AlgoBitNumber_;      // bit number of each L1 algo trigger     //DS
-  std::vector<std::string> L1TechNames_;  // name of each L1 technical trigger      //DS
-  std::vector<int> L1TechBitNumber_;      // bit number of each L1 tech trigger     //DS
-  std::vector<std::string> L1GlobalType_; // experimentType: Physics, Calibration, Random  //DS
+  std::vector<std::string> L1AlgoNames_;  // name of each L1 algorithm trigger      
+  std::vector<int> L1AlgoBitNumber_;      // bit number of each L1 algo trigger     
+  std::vector<std::string> L1TechNames_;  // name of each L1 technical trigger      
+  std::vector<int> L1TechBitNumber_;      // bit number of each L1 tech trigger     
+  std::vector<std::string> L1GlobalType_; // experimentType: Physics, Calibration, Random  
 
-  std::string stL1Jsd_;                   //Definition file name for JSON with L1 rates           //DS
+  std::string stL1Jsd_;                   //Definition file name for JSON with L1 rates           
 
   //Variables that need to be reset at lumi section boundaries 
-  unsigned int              processed_; // # of events processed 
+  unsigned int              processed_;      // # of events processed 
+  unsigned int              prescaleIndex_;  //Prescale index for each lumi section
 
   std::vector<unsigned int> hltWasRun_; // # of events where HLT[i] was run   
   std::vector<unsigned int> hltL1s_;    // # of events after L1 seed
@@ -173,9 +182,19 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
 
   std::vector<unsigned int> hltDatasets_; // # of events accepted by each dataset 
 
-  std::vector<unsigned int> L1Global_;     // Global # of Physics, Calibration and Random L1 triggers //DS
-  std::vector<unsigned int> L1AlgoAccept_; // # of events accepted by L1T[i]  //DS
-  std::vector<unsigned int> L1TechAccept_; // # of events accepted by L1 Technical Triggers[i]  //DS
+  std::vector<unsigned int> L1AlgoAccept_;            // # of events accepted by L1T[i]  
+  std::vector<unsigned int> L1TechAccept_;            // # of events accepted by L1 Technical Triggers[i]  
+  std::vector<unsigned int> L1AlgoAcceptPhysics_;     // # of Physics events accepted by L1T[i]  
+  std::vector<unsigned int> L1TechAcceptPhysics_;     // # of Physics events accepted by L1 Technical Triggers[i]  
+  std::vector<unsigned int> L1AlgoAcceptCalibration_; // # of Calibration events accepted by L1T[i]  
+  std::vector<unsigned int> L1TechAcceptCalibration_; // # of Calibration events accepted by L1 Technical Triggers[i]  
+  std::vector<unsigned int> L1AlgoAcceptRandom_;      // # of Random events accepted by L1T[i]  
+  std::vector<unsigned int> L1TechAcceptRandom_;      // # of Random events accepted by L1 Technical Triggers[i]  
+  std::vector<unsigned int> L1Global_;                // Global # of Physics, Calibration and Random L1 triggers 
+
+  //Variables for confirming that prescale index did not change
+  unsigned int oldLumi;
+  unsigned int oldPrescaleIndex;
 
  private:
 

--- a/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
+++ b/HLTrigger/JSONMonitoring/interface/TriggerJSONMonitoring.h
@@ -30,6 +30,7 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include "HLTrigger/HLTcore/interface/HLTPrescaleProvider.h"
 
 #include "FWCore/Framework/interface/ESHandle.h"          
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"  
@@ -140,6 +141,7 @@ class TriggerJSONMonitoring : public edm::stream::EDAnalyzer <edm::RunCache<hltJ
   edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1t_results; // Token for L1 GT Readout Record
 
   //Variables that change at most once per run 
+  HLTPrescaleProvider hltPrescaleProvider_; // To get at HLTConfigProvider
   HLTConfigProvider hltConfig_;         // to get configuration for HLT
   const L1GtTriggerMenu* m_l1GtMenu;    // L1 trigger menu   
   AlgorithmMap algorithmMap;            // L1 algorithm map  

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -21,15 +21,11 @@
 
 TriggerJSONMonitoring::TriggerJSONMonitoring(const edm::ParameterSet& ps)
 {
-  if (ps.exists("triggerResults")) triggerResults_ = ps.getParameter<edm::InputTag> ("triggerResults");
-  else                             triggerResults_ = edm::InputTag("TriggerResults","","HLT");
-
+  triggerResults_      = ps.getParameter<edm::InputTag> ("triggerResults");
   triggerResultsToken_ = consumes<edm::TriggerResults>(triggerResults_);
 
-  if (ps.exists("L1Results")) level1Results_ = ps.getParameter<edm::InputTag>("L1Results");   
-  else                        level1Results_ = edm::InputTag("hltGtDigis");                  
-
-  m_l1t_results        = consumes<L1GlobalTriggerReadoutRecord>(level1Results_);             
+  level1Results_ = ps.getParameter<edm::InputTag>("L1Results");   
+  m_l1t_results  = consumes<L1GlobalTriggerReadoutRecord>(level1Results_);             
                                                      
 }
 

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -26,10 +26,10 @@ TriggerJSONMonitoring::TriggerJSONMonitoring(const edm::ParameterSet& ps)
 
   triggerResultsToken_ = consumes<edm::TriggerResults>(triggerResults_);
 
-  if (ps.exists("L1Results")) level1Results_ = ps.getParameter<edm::InputTag>("L1Results");  //DS 
-  else                        level1Results_ = edm::InputTag("hltGtDigis");                  //DS
+  if (ps.exists("L1Results")) level1Results_ = ps.getParameter<edm::InputTag>("L1Results");   
+  else                        level1Results_ = edm::InputTag("hltGtDigis");                  
 
-  m_l1t_results        = consumes<L1GlobalTriggerReadoutRecord>(level1Results_);             //DS
+  m_l1t_results        = consumes<L1GlobalTriggerReadoutRecord>(level1Results_);             
                                                      
 }
 
@@ -41,7 +41,7 @@ void
 TriggerJSONMonitoring::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
   edm::ParameterSetDescription desc;
   desc.add<edm::InputTag>("triggerResults",edm::InputTag("TriggerResults","","HLT"));
-  desc.add<edm::InputTag>("L1Results",edm::InputTag("hltGtDigis"));              //DS  
+  desc.add<edm::InputTag>("L1Results",edm::InputTag("hltGtDigis"));                
   descriptions.add("triggerJSONMonitoring", desc);
 }
 
@@ -71,7 +71,12 @@ TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   const std::vector<bool> & algoword = L1TResults.decisionWord();  
   if (algoword.size() == L1AlgoAccept_.size()){
     for (unsigned int i = 0; i < algoword.size(); i++){
-      if (algoword[i]) L1AlgoAccept_[i]++;
+      if (algoword[i]){
+	L1AlgoAccept_[i]++;
+	if (ex == 1) L1AlgoAcceptPhysics_[i]++;
+	if (ex == 2) L1AlgoAcceptCalibration_[i]++;
+	if (ex == 3) L1AlgoAcceptRandom_[i]++;
+      }
     }
   }
   else {
@@ -81,7 +86,12 @@ TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& 
   const std::vector<bool> & techword = L1TResults.technicalTriggerWord();
   if (techword.size() == L1TechAccept_.size()){
     for (unsigned int i = 0; i < techword.size(); i++){
-      if (techword[i]) L1TechAccept_[i]++;
+      if (techword[i]){
+	L1TechAccept_[i]++;
+	if (ex == 1) L1TechAcceptPhysics_[i]++;
+	if (ex == 2) L1TechAcceptCalibration_[i]++;
+	if (ex == 3) L1TechAcceptRandom_[i]++;
+      }
     }
   }
   else{
@@ -124,6 +134,18 @@ TriggerJSONMonitoring::analyze(const edm::Event& iEvent, const edm::EventSetup& 
     }
     if (acceptedByDS[ds]) hltDatasets_[ds]++;
   }
+
+  //Prescale index
+  prescaleIndex_ = hltConfig_.prescaleSet(iEvent, iSetup);
+
+  //Check that the prescale index hasn't changed inside a lumi section
+  unsigned int newLumi = (unsigned int) iEvent.eventAuxiliary().luminosityBlock();
+  if (oldLumi == newLumi and prescaleIndex_ != oldPrescaleIndex){
+    LogWarning("TriggerJSONMonitoring")<<"Prescale index has changed from "<<oldPrescaleIndex<<" to "<<prescaleIndex_<<" inside lumi section "<<newLumi;
+  }
+  oldLumi = newLumi;
+  oldPrescaleIndex = prescaleIndex_;
+
 }//End analyze function     
 
 void
@@ -139,7 +161,7 @@ TriggerJSONMonitoring::resetRun(bool changed){
     for (unsigned int i = 0; i < L1AlgoNames_.size(); i++) {
       L1AlgoNames_.at(i) = "";
     }
-    //Get L1 algorithm trigger names - //DS     
+    //Get L1 algorithm trigger names -      
     for (CItAlgo itAlgo = algorithmMap.begin(); itAlgo != algorithmMap.end(); itAlgo++) {
       int bitNumber = (itAlgo->second).algoBitNumber();
       L1AlgoNames_.at(bitNumber) = itAlgo->first;
@@ -149,16 +171,16 @@ TriggerJSONMonitoring::resetRun(bool changed){
     for (unsigned int i = 0; i < L1TechNames_.size(); i++) {
       L1TechNames_.at(i) = "";
     }
-    //Get L1 technical trigger names - //DS          
+    //Get L1 technical trigger names -           
     for (CItAlgo itAlgo = technicalMap.begin(); itAlgo != technicalMap.end(); itAlgo++) {
       int bitNumber = (itAlgo->second).algoBitNumber();
       L1TechNames_.at(bitNumber) = itAlgo->first;
     }
 
-    L1GlobalType_.clear();  //DS 
-    L1Global_.clear();     //DS
+    L1GlobalType_.clear();   
+    L1Global_.clear();     
     
-    //Set the experimentType - //DS         
+    //Set the experimentType -          
     L1GlobalType_.push_back( "Physics" );
     L1GlobalType_.push_back( "Calibration" );
     L1GlobalType_.push_back( "Random" );
@@ -166,9 +188,9 @@ TriggerJSONMonitoring::resetRun(bool changed){
 
   const unsigned int n  = hltNames_.size();
   const unsigned int d  = datasetNames_.size();
-  const unsigned int la = L1AlgoNames_.size();      //DS 
-  const unsigned int lt = L1TechNames_.size();  //DS   
-  const unsigned int lg = L1GlobalType_.size(); //DS     
+  const unsigned int la = L1AlgoNames_.size();       
+  const unsigned int lt = L1TechNames_.size();     
+  const unsigned int lg = L1GlobalType_.size();      
 
   if (changed) {
     //Resize per-path counters   
@@ -178,9 +200,18 @@ TriggerJSONMonitoring::resetRun(bool changed){
     hltAccept_.resize(n);
     hltReject_.resize(n);
     hltErrors_.resize(n);
+
     L1AlgoAccept_.resize(la);         
+    L1AlgoAcceptPhysics_.resize(la);         
+    L1AlgoAcceptCalibration_.resize(la);         
+    L1AlgoAcceptRandom_.resize(la);         
+
     L1TechAccept_.resize(lt);          
-    L1Global_.resize(lg);           //DS      
+    L1TechAcceptPhysics_.resize(lt);          
+    L1TechAcceptCalibration_.resize(lt);          
+    L1TechAcceptRandom_.resize(lt);          
+
+    L1Global_.resize(lg);                 
     //Resize per-dataset counter    
     hltDatasets_.resize(d);
     //Resize htlIndex     
@@ -233,18 +264,27 @@ TriggerJSONMonitoring::resetLumi(){
   for (unsigned int i = 0; i < hltDatasets_.size(); i++) {
     hltDatasets_[i] = 0;
   }
-  //Reset L1 per-algo counters - //DS    
+  //Reset L1 per-algo counters -     
   for (unsigned int i = 0; i < L1AlgoAccept_.size(); i++) {
-    L1AlgoAccept_[i] = 0;
+    L1AlgoAccept_[i]            = 0;
+    L1AlgoAcceptPhysics_[i]     = 0;
+    L1AlgoAcceptCalibration_[i] = 0;
+    L1AlgoAcceptRandom_[i]      = 0;
   }
-  //Reset L1 per-tech counters - //DS   
+  //Reset L1 per-tech counters -    
   for (unsigned int i = 0; i < L1TechAccept_.size(); i++) {
-    L1TechAccept_[i] = 0;
+    L1TechAccept_[i]            = 0;
+    L1TechAcceptPhysics_[i]     = 0;
+    L1TechAcceptCalibration_[i] = 0;
+    L1TechAcceptRandom_[i]      = 0;
   }
-  //Reset L1 global counters - //DS     
+  //Reset L1 global counters -      
   for (unsigned int i = 0; i < L1GlobalType_.size(); i++) {
     L1Global_[i] = 0;
   }
+
+  //Luminosity and prescale index
+  prescaleIndex_ = 0;
 
 }//End resetLumi function  
 
@@ -258,11 +298,11 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
   std::string monPath = baseRunDir_ + "/";
 
   //Get/update the L1 trigger menu from the EventSetup
-  edm::ESHandle<L1GtTriggerMenu> l1GtMenu;           //DS
-  iSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);    //DS
-  m_l1GtMenu = l1GtMenu.product();                   //DS
-  algorithmMap = m_l1GtMenu->gtAlgorithmMap();       //DS
-  technicalMap = m_l1GtMenu->gtTechnicalTriggerMap();//DS
+  edm::ESHandle<L1GtTriggerMenu> l1GtMenu;           
+  iSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);    
+  m_l1GtMenu = l1GtMenu.product();                   
+  algorithmMap = m_l1GtMenu->gtAlgorithmMap();       
+  technicalMap = m_l1GtMenu->gtTechnicalTriggerMap();
 
   //Get masks (for now, only use them to find the number of triggers)
   edm::ESHandle<L1GtTriggerMask> l1GtAlgoMask;           
@@ -297,7 +337,7 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
 
     writeDefJson(baseRunDir_ + "/" + stHltJsd_);
     
-    //Create definition file for L1 Rates - //DS 
+    //Create definition file for L1 Rates -  
     std::stringstream ssL1Jsd;
     ssL1Jsd << "run" << std::setfill('0') << std::setw(6) << nRun << "_ls0000";
     ssL1Jsd << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsd";
@@ -364,6 +404,10 @@ TriggerJSONMonitoring::beginRun(edm::Run const& iRun, edm::EventSetup const& iSe
     outL1Ini.close();
   }
 
+  //Initialize variables for verification of prescaleIndex
+  oldLumi          = 0;
+  oldPrescaleIndex = 0;
+
 }//End beginRun function        
 
 void TriggerJSONMonitoring::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup& iSetup){ resetLumi(); }
@@ -386,9 +430,23 @@ TriggerJSONMonitoring::globalBeginLuminosityBlockSummary(const edm::LuminosityBl
 
   iSummary->hltDatasets = new HistoJ<unsigned int>(1, MAXPATHS);
 
-  iSummary->L1Accept     = new HistoJ<unsigned int>(1, MAXPATHS); //DS                           
-  iSummary->L1TechAccept = new HistoJ<unsigned int>(1, MAXPATHS); //DS 
-  iSummary->L1Global     = new HistoJ<unsigned int>(1, MAXPATHS); //DS 
+  iSummary->prescaleIndex = 100;
+
+  iSummary->L1AlgoAccept            = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1TechAccept            = new HistoJ<unsigned int>(1, MAXPATHS);  
+  iSummary->L1AlgoAcceptPhysics     = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1TechAcceptPhysics     = new HistoJ<unsigned int>(1, MAXPATHS);  
+  iSummary->L1AlgoAcceptCalibration = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1TechAcceptCalibration = new HistoJ<unsigned int>(1, MAXPATHS);  
+  iSummary->L1AlgoAcceptRandom      = new HistoJ<unsigned int>(1, MAXPATHS);                            
+  iSummary->L1TechAcceptRandom      = new HistoJ<unsigned int>(1, MAXPATHS);  
+  iSummary->L1Global                = new HistoJ<unsigned int>(1, MAXPATHS);  
+
+  iSummary->baseRunDir           = "";
+  iSummary->stHltJsd             = "";
+  iSummary->stL1Jsd              = "";
+  iSummary->streamL1Destination  = "";
+  iSummary->streamHLTDestination = "";
 
   return iSummary;
 }//End globalBeginLuminosityBlockSummary function  
@@ -411,21 +469,30 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
     for (unsigned int ui = 0; ui < hltDatasets_.size(); ui++){
       iSummary->hltDatasets->update(hltDatasets_.at(ui));
     }
+    iSummary->prescaleIndex = prescaleIndex_;
+
     iSummary->stHltJsd   = stHltJsd_;
     iSummary->baseRunDir = baseRunDir_;
     
-    for (unsigned int ui = 0; ui < L1AlgoAccept_.size(); ui++){  //DS  
-      iSummary->L1Accept->update(L1AlgoAccept_.at(ui));
+    for (unsigned int ui = 0; ui < L1AlgoAccept_.size(); ui++){    
+      iSummary->L1AlgoAccept           ->update(L1AlgoAccept_.at(ui));
+      iSummary->L1AlgoAcceptPhysics    ->update(L1AlgoAcceptPhysics_.at(ui));
+      iSummary->L1AlgoAcceptCalibration->update(L1AlgoAcceptCalibration_.at(ui));
+      iSummary->L1AlgoAcceptRandom     ->update(L1AlgoAcceptRandom_.at(ui));
     }
-    for (unsigned int ui = 0; ui < L1TechAccept_.size(); ui++){  //DS 
-      iSummary->L1TechAccept->update(L1TechAccept_.at(ui));
+    for (unsigned int ui = 0; ui < L1TechAccept_.size(); ui++){   
+      iSummary->L1TechAccept           ->update(L1TechAccept_.at(ui));
+      iSummary->L1TechAcceptPhysics    ->update(L1TechAcceptPhysics_.at(ui));
+      iSummary->L1TechAcceptCalibration->update(L1TechAcceptCalibration_.at(ui));
+      iSummary->L1TechAcceptRandom     ->update(L1TechAcceptRandom_.at(ui));
     }
-    for (unsigned int ui = 0; ui < L1GlobalType_.size(); ui++){  //DS  
+    for (unsigned int ui = 0; ui < L1GlobalType_.size(); ui++){    
       iSummary->L1Global    ->update(L1Global_.at(ui));
     }
-    iSummary->stL1Jsd = stL1Jsd_;    //DS  
+    iSummary->stL1Jsd = stL1Jsd_;      
+
     iSummary->streamHLTDestination = runCache()->streamHLTDestination;
-    iSummary->streamL1Destination = runCache()->streamL1Destination;
+    iSummary->streamL1Destination  = runCache()->streamL1Destination;
   }
 
   else{
@@ -442,13 +509,19 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
     for (unsigned int ui = 0; ui < hltDatasets_.size(); ui++){
       iSummary->hltDatasets->value().at(ui) += hltDatasets_.at(ui);
     }
-    for (unsigned int ui = 0; ui < L1AlgoAccept_.size(); ui++){  //DS                           
-      iSummary->L1Accept->value().at(ui) += L1AlgoAccept_.at(ui);
+    for (unsigned int ui = 0; ui < L1AlgoAccept_.size(); ui++){                             
+      iSummary->L1AlgoAccept->value().at(ui)            += L1AlgoAccept_.at(ui);
+      iSummary->L1AlgoAcceptPhysics->value().at(ui)     += L1AlgoAcceptPhysics_.at(ui);
+      iSummary->L1AlgoAcceptCalibration->value().at(ui) += L1AlgoAcceptCalibration_.at(ui);
+      iSummary->L1AlgoAcceptRandom->value().at(ui)      += L1AlgoAcceptRandom_.at(ui);
     }
-    for (unsigned int ui = 0; ui < L1TechAccept_.size(); ui++){  //DS                              
-      iSummary->L1TechAccept->value().at(ui) += L1TechAccept_.at(ui);
+    for (unsigned int ui = 0; ui < L1TechAccept_.size(); ui++){                                
+      iSummary->L1TechAccept->value().at(ui)            += L1TechAccept_.at(ui);
+      iSummary->L1TechAcceptPhysics->value().at(ui)     += L1TechAcceptPhysics_.at(ui);
+      iSummary->L1TechAcceptCalibration->value().at(ui) += L1TechAcceptCalibration_.at(ui);
+      iSummary->L1TechAcceptRandom->value().at(ui)      += L1TechAcceptRandom_.at(ui);
     }
-    for (unsigned int ui = 0; ui < L1Global_.size(); ui++){  //DS                             
+    for (unsigned int ui = 0; ui < L1Global_.size(); ui++){                               
       iSummary->L1Global->value().at(ui) += L1Global_.at(ui);
     }
 
@@ -492,6 +565,8 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
 
     hltJsnData[DataPoint::DATA].append(iSummary->hltDatasets->toJsonValue());
 
+    hltJsnData[DataPoint::DATA].append(iSummary->prescaleIndex);
+
     std::string && result = writer.write(hltJsnData);
 
     std::stringstream ssHltJsnData;
@@ -508,9 +583,15 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     l1JsnData[DataPoint::DEFINITION] = iSummary->stL1Jsd;
 
     l1JsnData[DataPoint::DATA].append(iSummary->processed->toJsonValue());
-    l1JsnData[DataPoint::DATA].append(iSummary->L1Accept ->toJsonValue());
-    l1JsnData[DataPoint::DATA].append(iSummary->L1TechAccept ->toJsonValue()); //DS       
-    l1JsnData[DataPoint::DATA].append(iSummary->L1Global ->toJsonValue());     //DS 
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAccept           ->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1TechAccept           ->toJsonValue());        
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAcceptPhysics    ->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1TechAcceptPhysics    ->toJsonValue());        
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAcceptCalibration->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1TechAcceptCalibration->toJsonValue());        
+    l1JsnData[DataPoint::DATA].append(iSummary->L1AlgoAcceptRandom     ->toJsonValue());
+    l1JsnData[DataPoint::DATA].append(iSummary->L1TechAcceptRandom     ->toJsonValue());        
+    l1JsnData[DataPoint::DATA].append(iSummary->L1Global               ->toJsonValue());      
     result = writer.write(l1JsnData);
 
     std::stringstream ssL1JsnData;
@@ -616,9 +697,15 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
 
   delete iSummary->hltDatasets;
 
-  delete iSummary->L1Accept;     //DS    
-  delete iSummary->L1TechAccept; //DS             
-  delete iSummary->L1Global;     //DS                  
+  delete iSummary->L1AlgoAccept;         
+  delete iSummary->L1TechAccept;              
+  delete iSummary->L1AlgoAcceptPhysics;         
+  delete iSummary->L1TechAcceptPhysics;              
+  delete iSummary->L1AlgoAcceptCalibration;         
+  delete iSummary->L1TechAcceptCalibration;              
+  delete iSummary->L1AlgoAcceptRandom;         
+  delete iSummary->L1TechAcceptRandom;              
+  delete iSummary->L1Global;                       
 
   //Note: Do not delete the iSummary pointer. The framework does something with it later on    
   //      and deleting it results in a segmentation fault.  
@@ -670,7 +757,12 @@ TriggerJSONMonitoring::writeDefJson(std::string path){
   outfile << "      {" ;
   outfile << " \"name\" : \"Dataset-Accepted\"," ;
   outfile << " \"type\" : \"integer\"," ;
-  outfile << " \"operation\" : \"histo\"}" << std::endl;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"Prescale-Index\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"sample\"}" << std::endl;
 
   outfile << "   ]" << std::endl;
   outfile << "}" << std::endl;
@@ -680,7 +772,7 @@ TriggerJSONMonitoring::writeDefJson(std::string path){
 
 
 void
-TriggerJSONMonitoring::writeL1DefJson(std::string path){  //DS            
+TriggerJSONMonitoring::writeL1DefJson(std::string path){              
 
   std::ofstream outfile( path );
   outfile << "{" << std::endl;
@@ -691,12 +783,42 @@ TriggerJSONMonitoring::writeL1DefJson(std::string path){  //DS
   outfile << " \"operation\" : \"histo\"}," << std::endl;
 
   outfile << "      {" ;
-  outfile << " \"name\" : \"L1-Accepted\"," ;
+  outfile << " \"name\" : \"L1-AlgoAccepted\"," ;
   outfile << " \"type\" : \"integer\"," ;
   outfile << " \"operation\" : \"histo\"}," << std::endl;
 
   outfile << "      {" ;
   outfile << " \"name\" : \"L1-TechAccepted\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-AlgoAccepted-Physics\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-TechAccepted-Physics\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-AlgoAccepted-Calibration\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-TechAccepted-Calibration\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-AlgoAccepted-Random\"," ;
+  outfile << " \"type\" : \"integer\"," ;
+  outfile << " \"operation\" : \"histo\"}," << std::endl;
+
+  outfile << "      {" ;
+  outfile << " \"name\" : \"L1-TechAccepted-Random\"," ;
   outfile << " \"type\" : \"integer\"," ;
   outfile << " \"operation\" : \"histo\"}," << std::endl;
 


### PR DESCRIPTION
Forward porting #9301 to CMSSW_7_5_X. This adds the prescale index and L1 trigger tables split by event type.
