### PR TITLE
PhysicsTools/IsolationAlgos: add missing dependecy on DataFormats/PatCandidates

### DIFF
--- a/PhysicsTools/IsolationAlgos/plugins/BuildFile.xml
+++ b/PhysicsTools/IsolationAlgos/plugins/BuildFile.xml
@@ -3,6 +3,7 @@
 <library   name="PhysicsToolsIsolationAlgos_plugins" file="*.cc">
   <use   name="CommonTools/Utils"/>
   <use   name="DataFormats/Candidate"/>
+  <use   name="DataFormats/PatCandidates"/>
   <use   name="DataFormats/TauReco"/>
   <use   name="DataFormats/TrackReco"/>
   <use   name="PhysicsTools/IsolationAlgos"/>


### PR DESCRIPTION
The plugin is failing to build on CMSSW_7_5_X/AArch64:

```
PhysicsToolsIsolationAlgos_plugins/CITKPFIsolationSumProducer.o: In function 'citk::PFIsolationSumProducer::produce(edm::Event&, edm::EventSetup const&)':
CITKPFIsolationSumProducer.cc:(.text+0x186c): undefined reference to 'pat::PackedCandidate::unpack() const'
PhysicsToolsIsolationAlgos_plugins/CITKPFIsolationSumProducer.o: In function 'pat::PackedCandidate::pt() const':
CITKPFIsolationSumProducer.cc:(.text._ZNK3pat15PackedCandidate2ptEv[_ZNK3pat15PackedCandidate2ptEv]+0x18): undefined reference to 'pat::PackedCandidate::unpack() const'
```

According to LXR `pat::PackedCandidate` is used in 3 files.

http://cmslxr.fnal.gov/ident?v=CMSSW_7_5_X_2015-06-02-2300&_i=PackedCandidate&_remember=1

LXR link should explain everything.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
