### PR TITLE
limit the proofsrv slaves to be only two for these unit tests

### DIFF
--- a/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing2_sel.C
@@ -30,7 +30,7 @@ void proof_thing2_sel()
   }
 
   //Setup the proof server
-  TProof *myProof=TProof::Open( "" );
+  TProof *myProof=TProof::Open( "", "workers=2" );
   
   // This makes sure the TSelector library and dictionary are properly
   // installed in the remote PROOF servers

--- a/FWCore/TFWLiteSelector/test/proof_thing_sel.C
+++ b/FWCore/TFWLiteSelector/test/proof_thing_sel.C
@@ -30,7 +30,7 @@ void proof_thing_sel()
   }
 
   //Setup the proof server
-  TProof *myProof=TProof::Open( "" );
+  TProof *myProof=TProof::Open( "", "workers=2" );
 
   // This makes sure the TSelector library and dictionary are properly
   // installed in the remote PROOF servers


### PR DESCRIPTION
Default limit is 12 and during IB validation  (which now runs on openstack machines) one of the proofserv.exe hanging. This should avoid these stable processes
