### PR TITLE
change primaryVertexCut for displaced Vertex reconstruction from 2.5 …

### DIFF
--- a/RecoParticleFlow/PFTracking/python/particleFlowDisplacedVertex_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/particleFlowDisplacedVertex_cfi.py
@@ -18,7 +18,7 @@ particleFlowDisplacedVertex = cms.EDProducer("PFDisplacedVertexProducer",
 
     # minimal radius below which we do not reconstruct interactions
     # typically the position of the first Pixel layer or beam pipe
-    primaryVertexCut = cms.double(2.5),
+    primaryVertexCut = cms.double(1.8),
 
     # radius below which we don't wamt to reconstruct displaced
     # vertices


### PR DESCRIPTION
Dear CMSSW experts,

I would like to request to change primaryVertexCut for displaced Vertex reconstruction from 2.5
to 1.8 cm to observe beam pipe at RUN II in Displaced Vertex collection, because it was changed since RUN I and now for RUN II beam pipe at 2.25 cm. We need this change to perform measurements of beam pipe position in detector. 
We have simulated beam pipe with mc_run2 configuration and with new 1.8 cm cut and could reconstruct it in MC (picture is attached).

Best regards, Anna

![beampipeforrunii](https://cloud.githubusercontent.com/assets/5188748/7986959/00547122-0adb-11e5-84ea-24608f8ed6de.png)
