### PR TITLE
Fix crash in ElectronSeedProducer

### DIFF
--- a/RecoEgamma/EgammaIsolationAlgos/src/EgammaTowerIsolation.cc
+++ b/RecoEgamma/EgammaIsolationAlgos/src/EgammaTowerIsolation.cc
@@ -43,7 +43,7 @@ EgammaTowerIsolation::EgammaTowerIsolation (float extRadiusI,
     delete newAlgo;
     newAlgo = new EgammaTowerIsolationNew<1>(&extRadius,&intRadius,*towers);
     oldTowers=towers;
-    id15 = (*towers)[15].id();
+    id15 = towers->size()>15 ? (*towers)[15].id() : 0;
   }
 }
 


### PR DESCRIPTION
This fixes the crash in SLHC26 Phase1 2017 workflows reported here:

https://hypernews.cern.ch/HyperNews/CMS/get/relval/3696.html

Tested on 1 of the input sets specified in the tarballs discussed in that email.  Logs from 12 of the 14 tarballs have the same error, the other 2 appear to complete successfully.
There are still the various warnings about missing input as pointed out here:

https://hypernews.cern.ch/HyperNews/CMS/get/upgrade-tp-studies/189.html

but the full sample now runs.  Those errors are being investigated by experts, they will be fixed in another pull request as required.

@boudoul
