### PR TITLE
avoid dereferencing of null pointer

### DIFF
--- a/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
+++ b/SimMuon/RPCDigitizer/src/RPCSimSetUp.cc
@@ -105,7 +105,8 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
 
   uint32_t detId, current_detId, this_detId;
   RPCDetId rpcId, current_rpcId, this_rpcId;
-  const RPCRoll * current_roll,* this_roll;
+  const RPCRoll * current_roll = nullptr;
+  const RPCRoll * this_roll = nullptr;
   unsigned int current_nStrips;
 
   LogDebug ("RPCSimSetup")<<"RPCSimSetUp::setRPCSetUp :: ClusterSizeItem :: begin"<<std::endl;
@@ -222,7 +223,7 @@ void RPCSimSetUp::setRPCSetUp(const std::vector<RPCStripNoises::NoiseItem>& vnoi
   }
 
   sslognoiseitem <<"Start Position ::            current_detId = "<<current_detId<<" aka "<<current_rpcId;
-  sslognoiseitem <<" is a valid roll with pointer "<<current_roll<<" and has "<<current_roll->nstrips()<<" strips"<<std::endl;
+  sslognoiseitem <<" is a valid roll with pointer "<<current_roll<<" and has "<<((!current_roll)?(current_roll->nstrips()):(0))<<" strips"<<std::endl;
   sslognoiseitem <<" ------------------------------------------------------------------------------------------------------------------------------------- "<<std::endl;
   for(std::vector<RPCStripNoises::NoiseItem>::const_iterator it = vnoise.begin(); it != vnoise.end(); ++it) {
 


### PR DESCRIPTION
Setting current_roll and this_roll to nullptr at beginning explicitly.
Avoiding dereferencing of null pointer current_roll->nstrips() 
