### PR TITLE
Make ROOT5 checksums known in ROOT6

### DIFF
--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -1,5 +1,5 @@
 <lcgdict>
-  <class name="std::bitset<reco::TrackBase::algoSize>"/>
+  <class name="reco::TrackBase::AlgoMask"/>
   <class name="reco::HitPattern" ClassVersion="12">
       <version ClassVersion="12" checksum="3922863495"/>
       <version ClassVersion="11" checksum="1621684703"/>
@@ -8,6 +8,7 @@
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
   <class name="reco::TrackBase" ClassVersion="15">
+   <version ClassVersion="16" checksum="3673246687"/>
    <version ClassVersion="15" checksum="1802760569"/>
    <version ClassVersion="14" checksum="3929365050"/>
    <version ClassVersion="13" checksum="1244921154"/>
@@ -354,6 +355,7 @@
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
   <class name="reco::Track" ClassVersion="15">
+   <version ClassVersion="16" checksum="697987788"/>
    <version ClassVersion="15" checksum="3694119510"/>
    <version ClassVersion="14" checksum="4228121071"/>
    <version ClassVersion="13" checksum="36410295"/>


### PR DESCRIPTION
PR #9429 fixed build errors in CMSSW_7_5_ROOT5_X by updating checksums.
This PR simply makes the ROOT5 checksums known in the ROOT6 release (7_5_X).
It also replaces a class name with its typedef to be consistent with CMSSW_7_5_ROOT5_X.
