### PR TITLE
DD Core Cleanup

### DIFF
--- a/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
+++ b/Alignment/CocoaApplication/src/CocoaAnalyzer.cc
@@ -138,8 +138,8 @@ void CocoaAnalyzer::ReadXMLFile( const edm::EventSetup& evts )
 	  // get all parts labelled with COCOA using a SpecPar
   DDSpecificsFilter filter;
   filter.setCriteria(val,  // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true  // use merged-specifics or simple-specifics
 		     );

--- a/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
+++ b/CalibMuon/DTCalibration/plugins/DTGeometryParserFromDDD.cc
@@ -19,8 +19,8 @@ DTGeometryParserFromDDD::DTGeometryParserFromDDD(const DDCompactView* cview, con
     // Asking only for the Muon DTs
     DDSpecificsFilter filter;
     filter.setCriteria(val,  // name & value of a variable 
-		       DDSpecificsFilter::matches,
-		       DDSpecificsFilter::AND, 
+		       DDCompOp::matches,
+		       DDLogOp::AND, 
 		       true, // compare strings otherwise doubles
 		       true  // use merged-specifics or simple-specifics
 		       );

--- a/DetectorDescription/Core/interface/DDFilter.h
+++ b/DetectorDescription/Core/interface/DDFilter.h
@@ -1,18 +1,18 @@
 #ifndef DDCore_DDFilter_h
 #define DDCore_DDFilter_h
-/**
- * 28/11/2006  VI clean up of data structure
- *
- *
- */
-#include <vector>
-#include <string>
-#include <iosfwd>
 
-#include "DetectorDescription/Core/interface/DDsvalues.h"
+#include "DetectorDescription/Core/interface/DDValue.h"
+#include <vector>
+#include <iosfwd>
 
 class DDQuery;
 class DDExpandedView;
+
+//! comparison operators to be used with this filter
+enum class DDCompOp { equals, matches, not_equals, not_matches, smaller, bigger, smaller_equals, bigger_equals };
+  
+//! logical operations to obtain one result from two filter comparisons
+enum class DDLogOp { AND, OR };
 
 //! A Filter accepts or rejects a DDExpandedNode based on a user-coded decision rule
 class DDFilter
@@ -25,27 +25,13 @@ public:
   virtual ~DDFilter();
   
   //! true, if the DDExpandedNode fulfills the filter criteria
-  virtual bool accept(const DDExpandedView &) const = 0;
-  
+  virtual bool accept(const DDExpandedView &) const = 0;  
 };
-
-#include "DetectorDescription/Core/interface/DDValue.h"
-#include "DetectorDescription/Core/interface/DDValuePair.h"
-
 
 //! The DDGenericFilter is a runtime-parametrized Filter looking on DDSpecifcs
 class DDSpecificsFilter : public DDFilter
 {
-
   friend std::ostream & operator<<(std::ostream & os, const DDSpecificsFilter & f);
-
-public:
-  //! comparison operators to be used with this filter
-  //! \todo use functors!
-  enum comp_op { equals, matches, not_equals, not_matches, smaller, bigger, smaller_equals, bigger_equals };
-  
-  //! logical operations to obtain one result from two filter comparisons
-  enum log_op { AND, OR };
 
 public:
   DDSpecificsFilter();
@@ -55,15 +41,15 @@ public:
   bool accept(const DDExpandedView &) const; 
 	      
   void setCriteria(const DDValue & nameVal, // name & value of a variable 
-                   comp_op, 
-		   log_op l = AND, 
+                   DDCompOp, 
+		   DDLogOp l = DDLogOp::AND, 
 		   bool asString = true, // compare strings otherwise doubles
 		   bool merged = true // use merged-specifics or simple-specifics
 		   );
 		      
   struct SpecificCriterion {
     SpecificCriterion(const DDValue & nameVal, 
-		      comp_op op,
+		      DDCompOp op,
 		      bool asString,
 		      bool merged)
      : nameVal_(nameVal), 
@@ -73,7 +59,7 @@ public:
      { }
      
      DDValue nameVal_;
-     comp_op comp_;
+     DDCompOp comp_;
      bool asString_;
      bool merged_;
   };
@@ -81,13 +67,9 @@ public:
 protected:  
 
   bool accept_impl(const DDExpandedView &) const;
-    
-  typedef SpecificCriterion  criterion_type;  
-  typedef std::vector<criterion_type> criteria_type;
-  typedef std::vector<log_op> logops_type;
 
-  criteria_type criteria_; 
-  logops_type logOps_;
+  std::vector<SpecificCriterion> criteria_; 
+  std::vector<DDLogOp> logOps_;
 };
 
 std::ostream & operator<<(std::ostream & os, const DDSpecificsFilter & f);

--- a/DetectorDescription/Core/interface/DDFilteredView.h
+++ b/DetectorDescription/Core/interface/DDFilteredView.h
@@ -17,9 +17,7 @@ public:
   
   ~DDFilteredView();
   
-  enum log_op { AND, OR };
-  
-  void addFilter(const DDFilter &, log_op op=AND);
+  void addFilter(const DDFilter &, DDLogOp op = DDLogOp::AND);
   
     //! The logical-part of the current node in the filtered-view
   const DDLogicalPart & logicalPart() const;
@@ -81,18 +79,12 @@ public:
      
 private:
   bool filter();
-  
-private:
+
   DDExpandedView epv_;
   const DDScope * scope_;
-  typedef DDFilter const * criterion_type;
-  typedef std::vector<criterion_type> criteria_type;
-  typedef std::vector<log_op> logops_type;
-  
-  criteria_type criteria_;
-  logops_type logOps_; // logical operation for merging the result of 2 filters
+  std::vector<DDFilter const *> criteria_;
+  std::vector<DDLogOp> logOps_; // logical operation for merging the result of 2 filters
   std::vector<DDGeoHistory> parents_; // filtered-parents
-
 };
 
 #endif

--- a/DetectorDescription/Core/interface/DDQuery.h
+++ b/DetectorDescription/Core/interface/DDQuery.h
@@ -7,15 +7,11 @@
 
 #include <map>
 #include <vector>
-#include <utility>
-
-//class DDCompactView;
 
 //! Base class for querying for nodes in the DDExpandedView
 class DDQuery
 {
 public:
-  enum log_op { AND, OR };
   //! sets up a query
   DDQuery(const DDCompactView &);
   
@@ -23,23 +19,16 @@ public:
   
   virtual const std::vector<DDExpandedNode> & exec();
   
-  virtual void addFilter(const DDFilter &, log_op op=AND);
+  virtual void addFilter(const DDFilter &, DDLogOp op = DDLogOp::AND);
   
   virtual void setScope(const DDScope &);
   
-  //void composeQuery(const DDQuery &);
-  
 protected:
-  //const DDCompactView & cpv_;
   DDExpandedView epv_;  
   const DDScope * scope_;
-  typedef std::pair<bool, DDFilter *> criterion_type;
-  typedef std::vector<criterion_type> criteria_type;
-  typedef std::vector<log_op> logops_type;
   
-  criteria_type criteria_; // one filter and the result on the current node
-  logops_type logOps_; // logical operation for merging the result of 2 filters
-  
+  std::vector<std::pair<bool, DDFilter *> > criteria_; // one filter and the result on the current node
+  std::vector<DDLogOp> logOps_; // logical operation for merging the result of 2 filters
   std::vector<DDExpandedNode> result_; // query result
 };
 

--- a/DetectorDescription/Core/src/DDCheck.cc
+++ b/DetectorDescription/Core/src/DDCheck.cc
@@ -127,7 +127,7 @@ bool DDCheckAll(const DDCompactView & cpv, std::ostream & os)
      lp_names[std::make_pair(lp.name().ns(),lp.name().name())]++;
    }
    
-   for( auto mit : lp_names ) {
+   for( const auto& mit : lp_names ) {
      if (mit.second >1) {
        os << "interesting: " << mit.first.first << ":" << mit.first.second
           << " counted " << mit.second << " times!" << std::endl;

--- a/DetectorDescription/Core/src/DDCheckMaterials.cc
+++ b/DetectorDescription/Core/src/DDCheckMaterials.cc
@@ -90,7 +90,7 @@ bool DDCheckMaterials(std::ostream & os, std::vector<std::pair<std::string,DDNam
    
    DDBase<DDName,DDI::Material*>::StoreT::value_type& mr = DDBase<DDName,DDI::Material*>::StoreT::instance();
 
-   for( auto i : mr ) {
+   for( const auto& i : mr ) {
 	std::pair<std::string,DDName> error("","");
 	DDMaterial tmat(i.first); 
 

--- a/DetectorDescription/Core/src/DDConstant.cc
+++ b/DetectorDescription/Core/src/DDConstant.cc
@@ -1,10 +1,7 @@
 #include "DetectorDescription/Core/interface/DDConstant.h"
-
-// Evaluator 
 #include "DetectorDescription/ExprAlgo/interface/ExprEvalSingleton.h"
 
 DDConstant::DDConstant() : DDBase<DDName,double*>() { }
-
 
 DDConstant::DDConstant(const DDName & name) : DDBase<DDName,double*>() 
 {
@@ -15,7 +12,6 @@ DDConstant::DDConstant(const DDName & name,double* vals)
 {
   prep_ = StoreT::instance().create(name,vals);
 }  
-
 
 std::ostream & operator<<(std::ostream & os, const DDConstant & cons)
 {
@@ -30,31 +26,21 @@ std::ostream & operator<<(std::ostream & os, const DDConstant & cons)
   return os;
 }
 
-
-void DDConstant::createConstantsFromEvaluator()
+void
+DDConstant::createConstantsFromEvaluator( void )
 {
-  ClhepEvaluator & ev = ExprEvalSingleton::instance();
-  ClhepEvaluator * eval = dynamic_cast<ClhepEvaluator*>(&ev);
-  if (eval){
-    const std::vector<std::string> & vars = eval->variables();
-    const std::vector<std::string> & vals = eval->values();
-    if (vars.size() != vals.size()) {
-      throw cms::Exception("DDException") << "DDConstants::createConstansFromEvaluator(): different size of variable names & values!";
-    }
-    size_t i(0), s(vars.size());
-    for (; i<s; ++i) {
-      const std::string & sr = vars[i];
-      typedef std::string::size_type ST;
-      ST i1 = sr.find("___");
-      DDName name(std::string(sr,i1+3,sr.size()-1),std::string(sr,0,i1));       
-      double* dv = new double;
-      *dv = eval->eval(sr.c_str());
-      DDConstant cst(name,dv);//(ddname); 
-    }  
+  auto& eval = ExprEvalSingleton::instance();
+  const auto& vars = eval.variables();
+  const auto& vals = eval.values();
+  if( vars.size() != vals.size()) {
+    throw cms::Exception( "DDException" )
+      << "DDConstants::createConstansFromEvaluator(): different size of variable names & values!";
   }
-  else {
-    throw cms::Exception("DDException") << "DDConstants::createConstansFromEvaluator(): expression-evaluator is not a ClhepEvaluator-implementation!";
+  for( const auto& it : vars ) {
+    auto found = it.find( "___" );
+    DDName name( std::string( it, found + 3, it.size() - 1 ), std::string( it, 0, found ));       
+    double* dv = new double;
+    *dv = eval.eval( it.c_str());
+    DDConstant cst( name, dv );
   }
 }
-
-

--- a/DetectorDescription/Core/src/DDCurrentNamespace.cc
+++ b/DetectorDescription/Core/src/DDCurrentNamespace.cc
@@ -1,8 +1,5 @@
 #include "DetectorDescription/Core/interface/DDCurrentNamespace.h"
 
-//std::string DDCurrentNamespace::ns_ = "GLOBAL";
-
-
 std::string & 
 DDCurrentNamespace::ns() 
 {

--- a/DetectorDescription/Core/src/DDDivision.cc
+++ b/DetectorDescription/Core/src/DDDivision.cc
@@ -4,21 +4,6 @@
 #include "DetectorDescription/Base/interface/DDdebug.h"
 
 using DDI::Division;
-
-// void DD_NDC(const DDName & n) {
-//  std::vector<DDName> & ns = DIVNAMES::instance()[n.name()];
-//  typedef std::vector<DDName>::iterator IT;
-//  bool alreadyIn(false);
-//  for(IT p = ns.begin(); p != ns.end() ; ++p) {
-//    if ( p->ns() == n.ns()) {
-//      alreadyIn = true;
-//      break;
-//    } 
-//  }
-//  if (!alreadyIn) {
-//    ns.push_back(n);
-//  }  
-// }
   
 std::ostream & 
 operator<<(std::ostream & os, const DDDivision & div)
@@ -45,7 +30,6 @@ DDDivision::DDDivision() : DDBase<DDName, DDI::Division*>()
 DDDivision::DDDivision( const DDName & name) : DDBase<DDName,DDI::Division*>()
 {
   prep_ = StoreT::instance().create(name);
-  //  DD_NDC(name);
 }
 
 DDDivision::DDDivision( const DDName & name,
@@ -57,7 +41,6 @@ DDDivision::DDDivision( const DDName & name,
 {
   DCOUT('C', "create Division name=" << name << " parent=" << parent.name() << " axis=" << DDAxesNames::name(axis) << " nReplicas=" << nReplicas << " width=" << width << " offset=" << offset);
   prep_ = StoreT::instance().create(name, new Division(parent, axis, nReplicas, width, offset)); 
-  //  DD_NDC(name);
 } 
 
 DDDivision::DDDivision( const DDName & name,
@@ -68,7 +51,6 @@ DDDivision::DDDivision( const DDName & name,
 {
   DCOUT('C', "create Division name=" << name << " parent=" << parent.name() << " axis=" << DDAxesNames::name(axis) << " nReplicas=" << nReplicas << " offset=" << offset);
   prep_ = StoreT::instance().create(name, new Division(parent, axis, nReplicas, offset)); 
-  //  DD_NDC(name);
 }
 
 DDDivision::DDDivision( const DDName & name,
@@ -79,7 +61,6 @@ DDDivision::DDDivision( const DDName & name,
 {
   DCOUT('C', "create Division name=" << name << " parent=" << parent.name() << " axis=" << DDAxesNames::name(axis) << " width=" << width << " offset=" << offset);
   prep_ = StoreT::instance().create(name, new Division(parent, axis, width, offset)); 
-  //  DD_NDC(name);
 }
 
 DDAxes DDDivision::axis() const

--- a/DetectorDescription/Core/src/DDExpandedNode.cc
+++ b/DetectorDescription/Core/src/DDExpandedNode.cc
@@ -1,5 +1,6 @@
 #include "DetectorDescription/Core/interface/DDExpandedNode.h"
 #include "DetectorDescription/Core/interface/DDPosData.h"
+#include <ostream>
 
 DDExpandedNode::DDExpandedNode(const DDLogicalPart & lp, 
                                const DDPosData * pd, 
@@ -9,17 +10,13 @@ DDExpandedNode::DDExpandedNode(const DDLogicalPart & lp,
  : logp_(lp), posd_(pd), trans_(t), rot_(r), siblingno_(siblingno)
 { }
 
-
 DDExpandedNode::~DDExpandedNode()
 { }   
-   
 
 bool DDExpandedNode::operator==(const DDExpandedNode & n) const {
   return ( (logp_==n.logp_) && 
-	   (posd_->copyno_ == n.posd_->copyno_) ); 
-  
+	   (posd_->copyno_ == n.posd_->copyno_) );  
 }	 		  		 
-
      
 int DDExpandedNode::copyno() const 
 {
@@ -27,23 +24,17 @@ int DDExpandedNode::copyno() const
   return posd_->copyno_; 
 }
 
-#include <ostream>
-
 std::ostream & operator<<(std::ostream & os, const DDExpandedNode & n)
 {
   os << n.logicalPart().name() 
      << '[' << n.copyno() << ']';
-     //<< ',' << n.siblingno()  << ']';
   return os;
 }
 
-
 std::ostream & operator<<(std::ostream & os, const DDGeoHistory & h)
 {
-   DDGeoHistory::const_iterator it = h.begin();
-   for (; it != h.end(); ++it) {
-     os << '/' << *it;
+   for( const auto& it : h ) {
+     os << '/' << it;
    }
    return os;
 }
-

--- a/DetectorDescription/Core/src/DDExpandedView.cc
+++ b/DetectorDescription/Core/src/DDExpandedView.cc
@@ -177,15 +177,6 @@ bool DDExpandedView::parent()
   return result;  
 }
 
-/*
-bool DDExpandedView::hasChildren() const
-{
-  bool result = false;
-   
-  return result;
-}
-*/
-
 // same implementation as in GraphWalker !
 /** 
    Tree transversal:
@@ -210,14 +201,11 @@ bool DDExpandedView::next()
     res=true;
   else {
    while(parent()) {
-     //DCOUT('C', "pa=" << logicalPart() );
      if(nextSibling()) {
-       //DCOUT('C', "ns=" << logicalPart() );
        res=true;
        break;
      }  
    }
-   //DCOUT('C', current().first << " "<< current().second );
   }
   return res;
 }
@@ -231,21 +219,19 @@ bool DDExpandedView::nextB()
 }
 
 
-void dump(const DDGeoHistory & h)
+void dump(const DDGeoHistory & history)
 {
-   DDGeoHistory::const_iterator it = h.begin();
    edm::LogInfo("DDExpandedView")  << "--GeoHistory-Dump--[" << std::endl;
    int i=0;
-   for (; it != h.end(); ++it) {
-     edm::LogInfo("DDExpandedView")  << " " << i << it->logicalPart() << std::endl;
+   for( const auto& it : history ) {
+     edm::LogInfo("DDExpandedView")  << " " << i << it.logicalPart() << std::endl;
      ++i;	  
    }
    edm::LogInfo("DDExpandedView")  << "]---------" << std::endl;
 }
 
 /** 
-   User specific data can be attac
-hed to single nodes or a selection of
+   User specific data can be attached to single nodes or a selection of
    nodes in the expanded view through the DDSpecifics interface.
       
    The resulting std::vector is of size 0 if no specific data was attached.
@@ -262,19 +248,17 @@ std::vector< const DDsvalues_type *>  DDExpandedView::specifics() const
 void
 DDExpandedView::specificsV(std::vector<const DDsvalues_type * > & result) const
 {
-  unsigned int i(0);
-  const std::vector<std::pair<const DDPartSelection*, const DDsvalues_type*> > & specs = logicalPart().attachedSpecifics();
+  const auto & specs = logicalPart().attachedSpecifics();
   if( specs.size())
   {
     result.reserve(specs.size());
-    for (; i<specs.size(); ++i) {
-      const std::pair<const DDPartSelection*, const DDsvalues_type*>& sp = specs[i];
+    for( const auto& it : specs ) {
       // a part selection
-      const DDPartSelection & psel = *(sp.first);
+      const DDPartSelection & psel = *(it.first);
       const DDGeoHistory & hist = geoHistory();
       
       if (DDCompareEqual(hist, psel)()) 
-	result.push_back( sp.second );
+	result.push_back( it.second );
     }
   }  
 }
@@ -287,16 +271,13 @@ DDsvalues_type DDExpandedView::mergedSpecifics() const {
 
 void DDExpandedView::mergedSpecificsV(DDsvalues_type & merged) const
 {
-
   merged.clear();
-  const std::vector<std::pair<const DDPartSelection*, const DDsvalues_type*> > & specs = logicalPart().attachedSpecifics();
+  const auto& specs = logicalPart().attachedSpecifics();
   if (specs.empty()) return;
   const DDGeoHistory & hist = geoHistory();
-  for (size_t i=0; i<specs.size(); ++i) {
-    const std::pair<const DDPartSelection*, const DDsvalues_type*>& sp = specs[i];
-    const DDPartSelection & psel = *(sp.first);
-    if (DDCompareEqual(hist, psel)())
-      merge(merged,*sp.second);
+  for( const auto& it : specs ) {
+    if (DDCompareEqual(hist, *it.first)())
+      merge(merged,*it.second);
   }
 }
 
@@ -367,21 +348,17 @@ bool DDExpandedView::goToHistory(const DDGeoHistory & pos)
 {
   bool result = true;
   int tempD = depth_;
-  //DCOUT('G', " goto- target= " << pos );
   DDGeoHistory tempScope = scope_;
   reset();
   DDGeoHistory::size_type s = pos.size();
   for( DDGeoHistory::size_type j=1; j<s; ++j) {
     if (! firstChild()) {
       result = false;
-      //edm::LogError("DDExpandedView") << " ERROR!  , wrong usage of DDExpandedView::goTo! " << std::endl;
-      //exit(1);
       break;
     }  
     int i=0;
     for (; i<pos[j].siblingno(); ++i) {
       if (! nextSibling()) {
-        //edm::LogError("DDExpandedView") << " ERROR!  , wrong usage of DDExpandedView::goTo! " << std::endl;        
 	result = false;
       }	
     }
@@ -395,8 +372,7 @@ bool DDExpandedView::goToHistory(const DDGeoHistory & pos)
     scope_ = tempScope;
     depth_ = tempD;
   }
-  
-  //DCOUT('G', " goto-result = " << history_ );
+
   return result;
 }
 
@@ -419,15 +395,12 @@ bool DDExpandedView::descend(const DDGeoHistory & sc)
   const DDExpandedNode & curNode = history_.back();
   
   if (sc.size()) {
-    //DCOUT('x', "curN=" << curNode.logicalPart() << " scope[0]=" << sc[cur].logicalPart() );
     if (curNode==sc[cur]) {
       bool res(false);
       while(cur+1 < mxx && firstChild()) {
         ++cur;
-        //DCOUT('x', "fc-curN=" << history_.back().logicalPart() << " scope[x]=" << sc[cur].logicalPart() );
         if (!(history_.back()==sc[cur])) {
 	  while(nextSibling()) {
-	    //DCOUT('x', "ns-curN=" << history_.back().logicalPart() << " scope[x]=" << sc[cur].logicalPart() );
 	    if (history_.back()==sc[cur]) {
 	      res=true;
 	      break;
@@ -461,7 +434,6 @@ bool DDExpandedView::goTo(int const * newpos, size_t sz)
   bool result(false);
   
   // save the current position
-  //nav_type savedPos = navPos(); 
   DDGeoHistory savedPos = history_;
    
   // reset to root node 
@@ -487,7 +459,6 @@ bool DDExpandedView::goTo(int const * newpos, size_t sz)
   }
   return result;
 }
-
 
 DDExpandedView::nav_type DDExpandedView::navPos() const
 {

--- a/DetectorDescription/Core/src/DDFilter.cc
+++ b/DetectorDescription/Core/src/DDFilter.cc
@@ -1,16 +1,12 @@
 #include "DetectorDescription/Core/interface/DDFilter.h"
 #include "DetectorDescription/Core/interface/DDExpandedView.h"
-
-// Message logger.
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 DDFilter::DDFilter() 
 { }
 
-
 DDFilter::~DDFilter()
 { }
-
 
 // =======================================================================
 // =======================================================================
@@ -27,25 +23,24 @@ DDFilter::~DDFilter()
  **/
 
 namespace {
-
-
+  
 // SpecificsFilterString-comparison (sfs)
   inline bool sfs_compare(const DDSpecificsFilter::SpecificCriterion & crit,
 			  const DDsvalues_type & sv) {
     DDsvalues_type::const_iterator it = find(sv,crit.nameVal_.id());
     if (it == sv.end()) return false;
     switch (crit.comp_) {
-    case DDSpecificsFilter::equals: case DDSpecificsFilter::matches:
+    case DDCompOp::equals: case DDCompOp::matches:
       return ( crit.nameVal_.strings() == it->second.strings() );
-    case DDSpecificsFilter::not_equals: case DDSpecificsFilter::not_matches:
+    case DDCompOp::not_equals: case DDCompOp::not_matches:
       return ( crit.nameVal_.strings() != it->second.strings() );
-    case DDSpecificsFilter::smaller_equals:
+    case DDCompOp::smaller_equals:
       return ( it->second.strings() <= crit.nameVal_.strings() );
-    case DDSpecificsFilter::smaller:
+    case DDCompOp::smaller:
       return ( it->second.strings() < crit.nameVal_.strings() );
-    case DDSpecificsFilter::bigger_equals:
+    case DDCompOp::bigger_equals:
       return ( it->second.strings() >= crit.nameVal_.strings() );
-    case DDSpecificsFilter::bigger:	 
+    case DDCompOp::bigger:	 
       return ( it->second.strings() > crit.nameVal_.strings() );
     default:
       return false;
@@ -60,17 +55,17 @@ namespace {
     if (it == sv.end()) return false;
     if (it->second.isEvaluated() ) {
       switch (crit.comp_) {
-      case DDSpecificsFilter::equals: case DDSpecificsFilter::matches:
+      case DDCompOp::equals: case DDCompOp::matches:
 	return (crit.nameVal_.doubles() == it->second.doubles() );
-      case DDSpecificsFilter::not_equals: case DDSpecificsFilter::not_matches:
+      case DDCompOp::not_equals: case DDCompOp::not_matches:
 	return (crit.nameVal_.doubles() != it->second.doubles() );
-      case DDSpecificsFilter::smaller_equals:
+      case DDCompOp::smaller_equals:
 	return ( it->second.doubles() <= crit.nameVal_.doubles() );
-      case DDSpecificsFilter::smaller:
+      case DDCompOp::smaller:
 	return ( it->second.doubles() < crit.nameVal_.doubles() );
-      case DDSpecificsFilter::bigger_equals:
+      case DDCompOp::bigger_equals:
 	return ( it->second.doubles() >= crit.nameVal_.doubles() );
-      case DDSpecificsFilter::bigger:	 
+      case DDCompOp::bigger:	 
 	return ( it->second.doubles() > crit.nameVal_.doubles() );
       default:
 	return false;
@@ -88,26 +83,18 @@ namespace {
     // The meaning of this is defined for each operator below.
     bool result = false; 
     
-    std::vector<const DDsvalues_type *>::const_iterator spit = specs.begin();
-    
     // go through all specifics
-    //   edm::LogInfo("DDFilter") << "Checking all specifics." << std::endl;
-    for (;  spit != specs.end(); ++spit) {
-      DDsvalues_type::const_iterator it = (**spit).begin();
-      
+    for( const auto& spit : specs ) {
       // go through all DDValues of the current specific.     
-      for (;  it != (**spit).end(); ++it) {
+      for( const auto& it : *spit ) {
 	
 	size_t ci = 0; // criteria values index
 	size_t si = 0; // specs values index
 	// compare all the crit values to all the specs values when the name matches.
 	
 	while ( !result && ci < crit.nameVal_.strings().size()) {
-	  if (it->second.id() == crit.nameVal_.id()) {	
-	    //	   edm::LogInfo("DDFilter") << "  Actually checking " << it->second.name() << std::endl;     
-	    while ( !result && si < it->second.strings().size()) {
-	      //	       edm::LogInfo("DDFilter") << "**** is " << crit.nameVal_.strings()[ci] << " = " << it->second.strings()[si] << " ?" << std::endl;
-	      
+	  if (it.second.id() == crit.nameVal_.id()) {	
+	    while ( !result && si < it.second.strings().size()) {
 	      switch (crit.comp_) {
 		// equals means at least one value in crit matches one value
 		// in specs.
@@ -117,52 +104,48 @@ namespace {
 		// 
 		// Maybe we should have an 'in' or 'contains' operator and equals would meaning
 		// would be changed to mean ALL equal.
-	      case DDSpecificsFilter::equals: 
-	      case DDSpecificsFilter::matches:
-	      case DDSpecificsFilter::not_equals: 
-	      case DDSpecificsFilter::not_matches: 
-		result = ( crit.nameVal_.strings()[ci] == it->second.strings()[si] );
+	      case DDCompOp::equals: 
+	      case DDCompOp::matches:
+	      case DDCompOp::not_equals: 
+	      case DDCompOp::not_matches: 
+		result = ( crit.nameVal_.strings()[ci] == it.second.strings()[si] );
 		break;
 		
 		// less than or equals means that ALL values in specs
 		// are less than or equals ALL values in crit.  therefore
 		// if even ONE is bigger, then this is false.
-	      case DDSpecificsFilter::smaller_equals:
-		result = ( it->second.strings()[si] > crit.nameVal_.strings()[ci] );
+	      case DDCompOp::smaller_equals:
+		result = ( it.second.strings()[si] > crit.nameVal_.strings()[ci] );
 		break;
 		
 		// less than means that all are strictly less than, therefore
 		// if one is greater than or equal, then this is false
-	      case DDSpecificsFilter::smaller:
-		result = ( it->second.strings()[si] >= crit.nameVal_.strings()[ci] );
+	      case DDCompOp::smaller:
+		result = ( it.second.strings()[si] >= crit.nameVal_.strings()[ci] );
 		break;
 		
 		// greater or equal to means that all values in specs are
 		// greater than or equals to all values in crit.  therefore
 		// if even ONE is less than, then this is false
-	      case DDSpecificsFilter::bigger_equals:
-		result = ( it->second.strings()[si] < crit.nameVal_.strings()[ci] );
+	      case DDCompOp::bigger_equals:
+		result = ( it.second.strings()[si] < crit.nameVal_.strings()[ci] );
 		break;
 		
 		// greater means that all values in specs are greater than
 		// all values in crit.  therefore if even one is less than or
 		// equal to crit, then this is false;
-	      case DDSpecificsFilter::bigger:	 
-		result = ( it->second.strings() <= crit.nameVal_.strings() );
+	      case DDCompOp::bigger:	 
+		result = ( it.second.strings() <= crit.nameVal_.strings() );
 	      }
-	      //edm::LogInfo("DDFilter") << "       si = " << si << "  result = " << result ;
 	      si ++;
 	    }
-	    //edm::LogInfo("DDFilter") << "  ci = " << ci << std::endl;
 	    
-	    if ( crit.comp_ == DDSpecificsFilter::not_equals 
-		 || crit.comp_ == DDSpecificsFilter::not_matches
-		 || crit.comp_ == DDSpecificsFilter::smaller_equals 
-		 || crit.comp_ == DDSpecificsFilter::smaller
-		 || crit.comp_ == DDSpecificsFilter::bigger)
+	    if ( crit.comp_ == DDCompOp::not_equals 
+		 || crit.comp_ == DDCompOp::not_matches
+		 || crit.comp_ == DDCompOp::smaller_equals 
+		 || crit.comp_ == DDCompOp::smaller
+		 || crit.comp_ == DDCompOp::bigger)
 	      result = !result;
-	    
-	    //edm::LogInfo("DDFilter") << "           it = " << it->second.name() << " final result = " << result << std::endl;
 	  }
 	  ++ci;
 	}
@@ -178,18 +161,11 @@ namespace {
     // The meaning of this is defined for each operator below.
     bool result = false; 
     
-    //   edm::LogInfo("DDFilter") << "specs.size()=" << specs.size() << std::endl;
-    //   edm::LogInfo("DDFilter") << "crit.nameVal_.doubles().size()=" << crit.nameVal_.doubles().size() << std::endl;
-    std::vector<const DDsvalues_type *>::const_iterator spit = specs.begin();
-    
     // go through all specifics
-    for (;  spit != specs.end(); ++spit) {
-      
-      DDsvalues_type::const_iterator it = (**spit).begin();
-      
+    for( const auto& spit : specs ) {
       // go through all DDValues of the current specific.     
-      for (;  it != (**spit).end(); ++it) {
-	if ( !it->second.isEvaluated() ) {
+      for( const auto& it : *spit ) {
+	if ( !it.second.isEvaluated() ) {
 	  edm::LogWarning("DD:Filter") << "(nm) Attempt to access a DDValue as doubles but DDValue is NOT Evaluated!" 
 				       << crit.nameVal_.name();
 	  continue; // go on to next one, do not attempt to acess doubles()
@@ -198,12 +174,9 @@ namespace {
 	size_t si = 0; // specs values index
 	// compare all the crit values to all the specs values when the name matches.
 	
-	while ( !result && ci < crit.nameVal_.doubles().size()) {
-	  
-	  if (it->second.id() == crit.nameVal_.id()) {	     
-	    //	   edm::LogInfo("DDFilter") << "  Actually checking " << it->second.name() << std::endl;     
-	    while ( !result && si < it->second.doubles().size()) {
-	      //	     edm::LogInfo("DDFilter") << "**** is " << crit.nameVal_.doubles()[ci] << " = " << it->second.doubles()[ci] << " ?" << std::endl;
+	while ( !result && ci < crit.nameVal_.doubles().size()) {	  
+	  if (it.second.id() == crit.nameVal_.id()) {
+	    while ( !result && si < it.second.doubles().size()) {
 	      switch (crit.comp_) {
 		
 		// equals means at least one value in crit matches one value
@@ -211,70 +184,57 @@ namespace {
 		//
 		// not equals means that no values in crit match no values in specs
 		//  (see below the ! (not))
-	      case DDSpecificsFilter::equals: 
-	      case DDSpecificsFilter::matches:
-	      case DDSpecificsFilter::not_equals: 
-	      case DDSpecificsFilter::not_matches: 
-		result = ( crit.nameVal_.doubles()[ci] == it->second.doubles()[si] );
+	      case DDCompOp::equals: 
+	      case DDCompOp::matches:
+	      case DDCompOp::not_equals: 
+	      case DDCompOp::not_matches: 
+		result = ( crit.nameVal_.doubles()[ci] == it.second.doubles()[si] );
 		break;
 		
 		// less than or equals means that ALL values in specs
 		// are less than or equals ALL values in crit.  therefore
 		// if even ONE is bigger, then this is false.
-	      case DDSpecificsFilter::smaller_equals:
-		result = ( it->second.doubles()[si] > crit.nameVal_.doubles()[ci] );
+	      case DDCompOp::smaller_equals:
+		result = ( it.second.doubles()[si] > crit.nameVal_.doubles()[ci] );
 		break;
 		
 		// less than means that all are strictly less than, therefore
 		// if one is greater than or equal, then this is false
-	      case DDSpecificsFilter::smaller:
-		result = ( it->second.doubles()[si] >= crit.nameVal_.doubles()[ci] );
+	      case DDCompOp::smaller:
+		result = ( it.second.doubles()[si] >= crit.nameVal_.doubles()[ci] );
 		break;
 		
 		// greater or equal to means that all values in specs are
 		// greater than or equals to all values in crit.  therefore
 		// if even ONE is less than, then this is false
-	      case DDSpecificsFilter::bigger_equals:
-		result = ( it->second.doubles()[si] < crit.nameVal_.doubles()[ci] );
+	      case DDCompOp::bigger_equals:
+		result = ( it.second.doubles()[si] < crit.nameVal_.doubles()[ci] );
 		break;
 		
 		// greater means that all values in specs are greater than
 		// all values in crit.  therefore if even one is less than or
 		// equal to crit, then this is false;
-	      case DDSpecificsFilter::bigger:	 
-		result = ( it->second.doubles() <= crit.nameVal_.doubles() );
+	      case DDCompOp::bigger:	 
+		result = ( it.second.doubles() <= crit.nameVal_.doubles() );
 	      }
-	      //	     edm::LogInfo("DDFilter") << "       si = " << si << "  result = " << result ;
 	      si ++;
-	      
 	    }
-	    //	   edm::LogInfo("DDFilter") << "  ci = " << ci << std::endl;
-	    
-	    if ( crit.comp_ == DDSpecificsFilter::not_equals 
-		 || crit.comp_ == DDSpecificsFilter::not_matches
-		 || crit.comp_ == DDSpecificsFilter::smaller_equals 
-		 || crit.comp_ == DDSpecificsFilter::smaller
-		 || crit.comp_ == DDSpecificsFilter::bigger)
+	    if ( crit.comp_ == DDCompOp::not_equals 
+		 || crit.comp_ == DDCompOp::not_matches
+		 || crit.comp_ == DDCompOp::smaller_equals 
+		 || crit.comp_ == DDCompOp::smaller
+		 || crit.comp_ == DDCompOp::bigger)
 	      result = !result;
-	    
-	    //	   edm::LogInfo("DDFilter") << "           it = " << it->second.name() << " final result = " << result << std::endl;
-	    
 	  }
-	  
 	  ++ci;
 	}
       }
-    }
-    
+    }    
     return result;
-  }		 
-  
-  
-
+  }
 }
 
 // ================================================================================================
-
 DDSpecificsFilter::DDSpecificsFilter() 
   : DDFilter()
 { }
@@ -283,8 +243,8 @@ DDSpecificsFilter::~DDSpecificsFilter() {}
 
 
 void DDSpecificsFilter::setCriteria(const DDValue & nameVal, // name & value of a variable 
-                   comp_op op, 
-		   log_op l, 
+                   DDCompOp op, 
+		   DDLogOp l, 
 		   bool asStrin, // compare std::strings otherwise doubles
 		   bool merged // use merged-specifics or simple-specifics
 		   )
@@ -298,21 +258,17 @@ bool DDSpecificsFilter::accept(const DDExpandedView & node) const
   return accept_impl(node);
 } 
 
-
 bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
 {
   bool result = true;
-  criteria_type::const_iterator it = criteria_.begin();
-  criteria_type::const_iterator crEnd = criteria_.end();
-  logops_type::const_iterator logOpIt = logOps_.begin();
-  //logops_type::iterator logOpEnd = logOps_.end();
+  auto logOpIt = logOps_.begin();
   const DDLogicalPart & logp = node.logicalPart();
   DDsvalues_type  sv;
   std::vector<const DDsvalues_type *> specs;
-  for (; it != crEnd; ++it, ++logOpIt) {
+  for( auto it = begin(criteria_); it != end(criteria_); ++it, ++logOpIt ) {
     // avoid useless evaluations
-    if ( (   result &&(*logOpIt)==OR ) ||
-	 ( (!result)&&(*logOpIt)==AND) ) continue; 
+    if ( (   result &&(*logOpIt)==DDLogOp::OR ) ||
+	 ( (!result)&&(*logOpIt)==DDLogOp::AND) ) continue; 
 
     bool locres=false;
     if (logp.hasDDValue(it->nameVal_)) { 
@@ -340,7 +296,7 @@ bool DDSpecificsFilter::accept_impl(const DDExpandedView & node) const
 	}  
       }
     }
-    if (*logOpIt==AND) {
+    if (*logOpIt==DDLogOp::AND) {
       result &= locres;
     }
     else {

--- a/DetectorDescription/Core/src/DDFilteredView.cc
+++ b/DetectorDescription/Core/src/DDFilteredView.cc
@@ -1,7 +1,5 @@
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
 #include "DetectorDescription/Core/interface/DDCompactView.h"
-
-// Message logger.
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 DDFilteredView::DDFilteredView(const DDCompactView & cpv)
@@ -10,42 +8,34 @@ DDFilteredView::DDFilteredView(const DDCompactView & cpv)
    parents_.push_back(epv_.geoHistory());
 }
 
-
 DDFilteredView::~DDFilteredView()
 { }
-
 
 const DDLogicalPart & DDFilteredView::logicalPart() const
 {
   return epv_.logicalPart();
 }
 
-
-void DDFilteredView::addFilter(const DDFilter & f, log_op op)
+void DDFilteredView::addFilter(const DDFilter & f, DDLogOp op)
 {
   criteria_.push_back(&f); 
   logOps_.push_back(op);
-  //DCOUT('F',"DDQuery::addFilter(): log-op=" << op );
 }
-
-  
+ 
 const DDTranslation & DDFilteredView::translation() const
 {
    return epv_.translation();
 }
-
 	 
 const DDRotationMatrix & DDFilteredView::rotation() const		           
 {
    return epv_.rotation();
 }
-
    
 const DDGeoHistory &  DDFilteredView::geoHistory() const
 {
    return epv_.geoHistory();
 }
-
 
 std::vector<const DDsvalues_type * > DDFilteredView::specifics() const
 {
@@ -65,22 +55,20 @@ void  DDFilteredView::mergedSpecificsV(DDsvalues_type & merged) const
 
 DDsvalues_type DDFilteredView::mergedSpecifics() const
 {
-   DDsvalues_type merged;epv_.mergedSpecificsV(merged);
+  DDsvalues_type merged;
+  epv_.mergedSpecificsV(merged);
   return merged;
 }
-
 
 int DDFilteredView::copyno() const
 {
   return epv_.copyno();
 }
 
-
 const DDGeoHistory & DDFilteredView::scope() const
 {
   return epv_.scope();
 }
-
 
 bool DDFilteredView::setScope(const DDGeoHistory & hist)
 {
@@ -92,7 +80,6 @@ bool DDFilteredView::setScope(const DDGeoHistory & hist)
   return result;
 }  
 
-
 void DDFilteredView::clearScope()
 {
    epv_.clearScope();
@@ -100,27 +87,19 @@ void DDFilteredView::clearScope()
    parents_.push_back(epv_.geoHistory());
 }
 
-
 bool DDFilteredView::next()
 {
    bool result = false;
    int i=0;
-   //epv_.scope_.clear();
-   //DCOUT('F', "DDFilteredView::next(): scope of ExpandedView = " << epv_.scope_ );
    while(epv_.next()) {
-     //DCOUT('F', " node " << i << " " << epv_.logicalPart().ddname() );
      ++i;
-     //DCOUT('F', "DDFilteredView::next() at " << epv_.geoHistory().back() );
      if ( filter() ) {
        result = true;
-       //DCOUT('F', "DDFilteredView::next(): filter()==true at " << epv_.geoHistory() );
        break;
      }
    }
-   //DCOUT('F', "DDFilteredView::next(): just iterated over " << i << " nodes."); 
    return result;
 }
-
 
 /**
  Algorithm:
@@ -162,7 +141,6 @@ bool DDFilteredView::firstChild()
    return result;
 }
 
-
 /**
   Algorithm:
   
@@ -176,8 +154,6 @@ bool DDFilteredView::nextSibling()
   //      B is the firstChild matching the filter in the subtrees of A's siblings
   bool result = false;
   DDGeoHistory savedPos = epv_.geoHistory();
-  
-  //DDGeoHistory::size_type level = parents_.back().size();
   
   bool flag = true;
   //bool shuffleParent = false;
@@ -210,7 +186,6 @@ bool DDFilteredView::nextSibling()
   return result;
 }
 
-
 bool DDFilteredView::parent()
 {
    bool result = false;
@@ -235,34 +210,27 @@ bool DDFilteredView::parent()
    return result;
 }
 
-
 void DDFilteredView::reset()
 {
-  //while (epv_.parent())
-  //  ;
   epv_.reset();
   parents_.clear();
   parents_.push_back(epv_.geoHistory());          
 }
 
-
 bool DDFilteredView::filter()
 {
   bool result = true;
-  //DCOUT('Q', "Filter: " << epv_.history_);
-  criteria_type::const_iterator it = criteria_.begin();
-  logops_type::const_iterator logOpIt = logOps_.begin();
+  auto logOpIt = logOps_.begin();
   // loop over all user-supplied criteria (==filters)
-  for (; it != criteria_.end(); ++it, ++logOpIt) {
+  for( auto it = begin(criteria_); it != end(criteria_); ++it, ++logOpIt) {
     // avoid useless evaluations
-    if ( (   result &&(*logOpIt)==OR ) ||
-	 ( (!result)&&(*logOpIt)==AND) ) continue; 
+    if(( result && ( *logOpIt ) == DDLogOp::OR ) ||
+       (( !result ) && ( *logOpIt ) == DDLogOp::AND )) continue; 
     
     bool locres = (*it)->accept(epv_);
-    // need correction DCOUT('F', " Filter(" << criteria_.end()-it << ") accepted: " << epv_.geoHistory().back());
     
     // now do the logical-operations on the results encountered so far:
-    if (*logOpIt==AND) { // AND
+    if (*logOpIt == DDLogOp::AND) { // AND
       result &= locres; 
     }
     else { // OR
@@ -272,18 +240,15 @@ bool DDFilteredView::filter()
   return result;
 }
 
-
 DDFilteredView::nav_type DDFilteredView::navPos() const
 {
   return epv_.navPos();
 }
 
-
 DDFilteredView::nav_type DDFilteredView::copyNumbers() const
 {
   return epv_.copyNumbers();
 }
-
 
 bool DDFilteredView::goTo(const DDFilteredView::nav_type & /*n*/)
 {
@@ -292,7 +257,6 @@ bool DDFilteredView::goTo(const DDFilteredView::nav_type & /*n*/)
  bool result(false);
  return result;
 }
-
 
 void DDFilteredView::print() {
   edm::LogInfo("DDFliteredView") << "FilteredView Status" << std::endl
@@ -303,7 +267,6 @@ void DDFilteredView::print() {
     edm::LogInfo("DDFliteredView") << "  " << parents_[i] << std::endl;
     
 }
-
 
 const std::vector<DDGeoHistory> & DDFilteredView::history() const
 {

--- a/DetectorDescription/Core/src/DDLogicalPart.cc
+++ b/DetectorDescription/Core/src/DDLogicalPart.cc
@@ -8,10 +8,9 @@
 void
 DD_NC( const DDName & n )
 {
-  std::vector<DDName> & ns = LPNAMES::instance()[n.name()];
-  typedef std::vector<DDName>::iterator IT;
+  auto & ns = LPNAMES::instance()[n.name()];
   bool alreadyIn( false );
-  for( IT p = ns.begin(); p != ns.end(); ++p )
+  for( const auto& p : ns )
   {
     if( p->ns() == n.ns())
     {

--- a/DetectorDescription/Core/src/DDLogicalPart.cc
+++ b/DetectorDescription/Core/src/DDLogicalPart.cc
@@ -12,7 +12,7 @@ DD_NC( const DDName & n )
   bool alreadyIn( false );
   for( const auto& p : ns )
   {
-    if( p->ns() == n.ns())
+    if( p.ns() == n.ns())
     {
       alreadyIn = true;
       break;

--- a/DetectorDescription/RegressionTest/test/tutorial.cc
+++ b/DetectorDescription/RegressionTest/test/tutorial.cc
@@ -401,40 +401,32 @@ void tutorial()
   // test the filter
   //bool doIt=true;
 
-
-
-  std::map<std::string,DDSpecificsFilter::comp_op> cop;
-  cop["=="] = DDSpecificsFilter::equals;
-  cop["!="] = DDSpecificsFilter::not_equals;
-  cop["<"]  = DDSpecificsFilter::smaller;
-  cop[">"]  = DDSpecificsFilter::bigger;
-  cop[">="]  = DDSpecificsFilter::bigger_equals;
-  cop["<="]  = DDSpecificsFilter::smaller_equals;
-  std::map<std::string,DDSpecificsFilter::log_op> lop;
-  lop["AND"] = DDSpecificsFilter::AND;
-  lop["OR"] = DDSpecificsFilter::OR;
-  std::map<std::string,DDQuery::log_op> qop;
-  qop["AND"] = DDQuery::AND;
-  qop["OR"] = DDQuery::OR;
-  std::map<DDQuery::log_op,DDFilteredView::log_op> mmlog;
-  mmlog[DDQuery::AND] = DDFilteredView::AND;
-  mmlog[DDQuery::OR] = DDFilteredView::OR;
+  std::map<std::string,DDCompOp> cop;
+  cop["=="] = DDCompOp::equals;
+  cop["!="] = DDCompOp::not_equals;
+  cop["<"]  = DDCompOp::smaller;
+  cop[">"]  = DDCompOp::bigger;
+  cop[">="]  = DDCompOp::bigger_equals;
+  cop["<="]  = DDCompOp::smaller_equals;
+  std::map<std::string,DDLogOp> lop;
+  lop["AND"] = DDLogOp::AND;
+  lop["OR"] = DDLogOp::OR;
   bool moreFilters = true;
   bool moreQueries = true;
   bool moreFilterCriteria = true;
   std::string flog, ls, p, cs, v, q;
   while(moreQueries) {
-    std::vector<std::pair<DDQuery::log_op,DDSpecificsFilter*> > vecF;
+    std::vector<std::pair<DDLogOp,DDSpecificsFilter*> > vecF;
     while(moreFilters) { 
       DDSpecificsFilter * f = new DDSpecificsFilter();
       std::string flog;
       std::string asString;
       bool asStringBool = false;
-      std::cout << "filter log_op = ";
+      std::cout << "filter LogOp = ";
       std::cin >> flog;
       if(flog=="end") 
 	break;
-      vecF.push_back(std::make_pair(qop[flog],f));
+      vecF.push_back(std::make_pair(lop[flog],f));
       while (moreFilterCriteria) {
 	std::cout << " logic   = ";
 	std::cin >> ls;
@@ -467,7 +459,7 @@ void tutorial()
    
     DDScope scope;
     DDQuery query(ccv);
-    std::vector<std::pair<DDQuery::log_op,DDSpecificsFilter*> >::size_type loop=0;
+    std::vector<std::pair<DDLogOp,DDSpecificsFilter*> >::size_type loop=0;
     for(; loop < vecF.size(); ++loop) {
       DDFilter * filter = vecF[loop].second;  
       const DDFilter & fi = *filter;
@@ -573,8 +565,8 @@ void tutorial()
     DDFilteredView fv(compactview);
 
     if (ans=="y") {
-      for (std::vector<std::pair<DDQuery::log_op,DDSpecificsFilter*> >::size_type j=0; j<vecF.size(); ++j) {
-	fv.addFilter(*(vecF[j].second), mmlog[vecF[j].first]);
+      for (std::vector<std::pair<DDLogOp,DDSpecificsFilter*> >::size_type j=0; j<vecF.size(); ++j) {
+	fv.addFilter(*(vecF[j].second), DDLogOp::AND);
       }
     
       //bool looop = true;

--- a/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
+++ b/Geometry/CSCGeometryBuilder/src/CSCGeometryParsFromDD.cc
@@ -34,8 +34,8 @@ bool CSCGeometryParsFromDD::build( const DDCompactView* cview
 
   DDSpecificsFilter filter;
   filter.setCriteria(muval, // name & value of a variable 
-		     DDSpecificsFilter::equals,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::equals,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
+++ b/Geometry/CaloEventSetup/interface/CaloGeometryLoader.icc
@@ -42,16 +42,16 @@ CaloGeometryLoader<T>::CaloGeometryLoader()
    m_filter.setCriteria( DDValue( "SensitiveDetector",
 				  "EcalSensitiveDetector",
 				  0                        ),
-			 DDSpecificsFilter::equals,
-			 DDSpecificsFilter::AND,
+			 DDCompOp::equals,
+			 DDLogOp::AND,
 			 true,
 			 true                               ) ;
 
    m_filter.setCriteria( DDValue( "ReadOutName",
 				  T::hitString(),
 				  0                  ),
-			 DDSpecificsFilter::equals,
-			 DDSpecificsFilter::AND,
+			 DDCompOp::equals,
+			 DDLogOp::AND,
 			 true,
 			 true                       ) ;
 }

--- a/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryBuilderFromDDD.cc
@@ -47,8 +47,8 @@ void DTGeometryBuilderFromDDD::build(boost::shared_ptr<DTGeometry> theGeometry,
   // Asking only for the Muon DTs
   DDSpecificsFilter filter;
   filter.setCriteria(val,  // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true  // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
+++ b/Geometry/DTGeometryBuilder/src/DTGeometryParsFromDD.cc
@@ -48,8 +48,8 @@ void DTGeometryParsFromDD::build(const DDCompactView* cview,
   // Asking only for the Muon DTs
   DDSpecificsFilter filter;
   filter.setCriteria(val,  // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true  // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/plugins/EcalTBHodoscopeGeometryLoaderFromDDD.cc
@@ -10,7 +10,6 @@
 #include "DetectorDescription/Core/interface/DDTransform.h"
 #include "DetectorDescription/Core/interface/DDExpandedView.h"
 #include "DetectorDescription/Core/interface/DDName.h"
-//#include "DetectorDescription/Core/interface/DDInit.h"
 
 typedef CaloCellGeometry::CCGFloat CCGFloat ;
 
@@ -137,16 +136,16 @@ DDFilter* EcalTBHodoscopeGeometryLoaderFromDDD::getDDFilter()
    filter->setCriteria( DDValue( "SensitiveDetector",
 				 "EcalTBH4BeamDetector",
 				 0 ),
-			DDSpecificsFilter::equals,
-			DDSpecificsFilter::AND,
+			DDCompOp::equals,
+			DDLogOp::AND,
 			true,
 			true ) ;
 
    filter->setCriteria( DDValue( "ReadOutName",
 				 "EcalTBH4BeamHits",
 				 0 ),
-			DDSpecificsFilter::equals,
-			DDSpecificsFilter::AND,
+			DDCompOp::equals,
+			DDLogOp::AND,
 			true,
 			true ) ;
    return filter;

--- a/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
+++ b/Geometry/EcalTestBeam/test/ee/CaloGeometryLoaderTest.icc
@@ -26,7 +26,7 @@ CaloGeometryLoaderTest<T>::CaloGeometryLoaderTest()
 				  "EndcapSC",
 //				  "EESCEnv1",
 				  0                  ),
-			 DDSpecificsFilter::equals    ) ;
+			 DDCompOp::equals    ) ;
 }
 
 template <class T>

--- a/Geometry/EcalTestBeam/test/ee/EcalEndcapGeometryLoaderFromDDD.cc
+++ b/Geometry/EcalTestBeam/test/ee/EcalEndcapGeometryLoaderFromDDD.cc
@@ -8,7 +8,6 @@
 template class CaloGeometryLoaderTest< EcalEndcapGeometry > ;
 
 #include "DetectorDescription/Core/interface/DDFilteredView.h"
-//#include "DetectorDescription/Core/interface/DDInit.h"
 
 
 #include <iostream>

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryBuilderFromDDD.cc
@@ -41,8 +41,8 @@ GEMGeometry* GEMGeometryBuilderFromDDD::build(const DDCompactView* cview, const 
   // Asking only for the MuonGEM's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/GEMGeometryParsFromDD.cc
@@ -38,8 +38,8 @@ GEMGeometryParsFromDD::build(const DDCompactView* cview,
   // Asking only for the MuonGEM's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
+++ b/Geometry/GEMGeometryBuilder/src/ME0GeometryBuilderFromDDD.cc
@@ -34,15 +34,15 @@ ME0GeometryBuilderFromDDD::~ME0GeometryBuilderFromDDD()
 
 ME0Geometry* ME0GeometryBuilderFromDDD::build(const DDCompactView* cview, const MuonDDDConstants& muonConstants)
 {
-  std::string attribute = "ReadOutName"; // could come from .orcarc
-  std::string value     = "MuonME0Hits";    // could come from .orcarc
+  std::string attribute = "ReadOutName";
+  std::string value     = "MuonME0Hits";
   DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonME0's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/HcalCommonData/src/HcalNumberingFromDDD.cc
+++ b/Geometry/HcalCommonData/src/HcalNumberingFromDDD.cc
@@ -615,7 +615,7 @@ void HcalNumberingFromDDD::initialize(std::string & name,
 
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,name,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   bool ok = fv.firstChild();

--- a/Geometry/HcalTowerAlgo/src/HcalParametersFromDD.cc
+++ b/Geometry/HcalTowerAlgo/src/HcalParametersFromDD.cc
@@ -78,8 +78,9 @@ HcalParametersFromDD::build( const DDCompactView* cpv,
   DDValue val( attribute, value, 0.0 );
   
   DDSpecificsFilter filter;
-  filter.setCriteria( val, DDSpecificsFilter::not_equals,
-		      DDSpecificsFilter::AND, true, // compare strings 
+  filter.setCriteria( val,
+		      DDCompOp::not_equals,
+		      DDLogOp::AND, true, // compare strings 
 		      true  // use merged-specifics or simple-specifics
 		     );
   DDFilteredView fv( *cpv );

--- a/Geometry/MuonNumbering/src/MuonDDDConstants.cc
+++ b/Geometry/MuonNumbering/src/MuonDDDConstants.cc
@@ -20,8 +20,8 @@ MuonDDDConstants::MuonDDDConstants( const DDCompactView& cpv ) {
   
   DDSpecificsFilter filter;
   filter.setCriteria(val,
-		     DDSpecificsFilter::not_equals,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::not_equals,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true  // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryBuilderFromDDD.cc
@@ -40,8 +40,8 @@ RPCGeometry* RPCGeometryBuilderFromDDD::build(const DDCompactView* cview, const 
   // Asking only for the MuonRPC's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
+++ b/Geometry/RPCGeometryBuilder/src/RPCGeometryParsFromDD.cc
@@ -32,15 +32,15 @@ void
 RPCGeometryParsFromDD::build(const DDCompactView* cview, 
       const MuonDDDConstants& muonConstants, RecoIdealGeometry& rgeo )
 {
-  std::string attribute = "ReadOutName"; // could come from .orcarc
-  std::string value     = "MuonRPCHits";    // could come from .orcarc
+  std::string attribute = "ReadOutName";
+  std::string value     = "MuonRPCHits";
   DDValue val(attribute, value, 0.0);
 
   // Asking only for the MuonRPC's
   DDSpecificsFilter filter;
   filter.setCriteria(val, // name & value of a variable 
-		     DDSpecificsFilter::matches,
-		     DDSpecificsFilter::AND, 
+		     DDCompOp::matches,
+		     DDLogOp::AND, 
 		     true, // compare strings otherwise doubles
 		     true // use merged-specifics or simple-specifics
 		     );

--- a/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
+++ b/Geometry/TrackerNumberingBuilder/plugins/DDDCmsTrackerContruction.cc
@@ -18,7 +18,7 @@ DDDCmsTrackerContruction::construct( const DDCompactView* cpv, std::vector<int> 
   std::string value = "any";
   DDSpecificsFilter filter;
   DDValue ddv( attribute, value, 0 );
-  filter.setCriteria( ddv, DDSpecificsFilter::not_equals );
+  filter.setCriteria( ddv, DDCompOp::not_equals );
   
   DDFilteredView fv( *cpv ); 
   fv.addFilter( filter );

--- a/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
+++ b/GeometryReaders/XMLIdealGeometryESSource/test/TestSpecParAnalyzer.cc
@@ -103,8 +103,8 @@ TestSpecParAnalyzer::analyze( const edm::Event& iEvent, const edm::EventSetup& i
      DDValue fval(specName_, specStrValue_, 0.0);
      DDSpecificsFilter filter;
      filter.setCriteria(fval, // name & value of a variable 
-			DDSpecificsFilter::equals,
-			DDSpecificsFilter::AND, 
+			DDCompOp::equals,
+			DDLogOp::AND, 
 			true, // compare strings otherwise doubles
 			true // use merged-specifics or simple-specifics
 			);

--- a/SLHCUpgradeSimulations/Geometry/src/PrintGeomMatInfo.cc
+++ b/SLHCUpgradeSimulations/Geometry/src/PrintGeomMatInfo.cc
@@ -113,7 +113,7 @@ void PrintGeomMatInfo::update(const BeginOfJob * job)
 	    std::string sd        = names[i];
 	    DDSpecificsFilter filter;
 	    DDValue           ddv(attribute,sd,0);
-	    filter.setCriteria(ddv,DDSpecificsFilter::equals);
+	    filter.setCriteria(ddv,DDCompOp::equals);
 	    DDFilteredView fv(*pDD);
 	    std::cout << "PrintGeomMatInfo:: Get Filtered view for " 
 		      << attribute << " = " << sd << std::endl;

--- a/SimG4CMS/Calo/src/CaloTrkProcessing.cc
+++ b/SimG4CMS/Calo/src/CaloTrkProcessing.cc
@@ -45,7 +45,7 @@ CaloTrkProcessing::CaloTrkProcessing(G4String name,
   G4String attribute = "ReadOutName"; 
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,name,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/Calo/src/ECalSD.cc
+++ b/SimG4CMS/Calo/src/ECalSD.cc
@@ -76,7 +76,7 @@ ECalSD::ECalSD(G4String name, const DDCompactView & cpv,
   std::string attribute = "ReadOutName";
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,name,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();
@@ -278,7 +278,7 @@ void ECalSD::initMap(G4String sd, const DDCompactView & cpv) {
   G4String attribute = "ReadOutName";
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,sd,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/Calo/src/HCalSD.cc
+++ b/SimG4CMS/Calo/src/HCalSD.cc
@@ -132,7 +132,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     value     = "HF";
     DDSpecificsFilter filter0;
     DDValue           ddv0(attribute, value, 0);
-    filter0.setCriteria(ddv0, DDSpecificsFilter::equals);
+    filter0.setCriteria(ddv0, DDCompOp::equals);
     DDFilteredView fv0(cpv);
     fv0.addFilter(filter0);
     hfNames = getNames(fv0);
@@ -162,7 +162,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     value     = "HFFibre";
     DDSpecificsFilter filter1;
     DDValue           ddv1(attribute,value,0);
-    filter1.setCriteria(ddv1, DDSpecificsFilter::equals);
+    filter1.setCriteria(ddv1, DDCompOp::equals);
     DDFilteredView fv1(cpv);
     fv1.addFilter(filter1);
     fibreNames = getNames(fv1);
@@ -186,7 +186,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     value     = "HFPMT";
     DDSpecificsFilter filter3;
     DDValue           ddv3(attribute,value,0);
-    filter3.setCriteria(ddv3,DDSpecificsFilter::equals);
+    filter3.setCriteria(ddv3,DDCompOp::equals);
     DDFilteredView fv3(cpv);
     fv3.addFilter(filter3);
     std::vector<G4String> pmtNames = getNames(fv3);
@@ -211,7 +211,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     value     = "HFFibreBundleStraight";
     DDSpecificsFilter filter4;
     DDValue           ddv4(attribute,value,0);
-    filter4.setCriteria(ddv4,DDSpecificsFilter::equals);
+    filter4.setCriteria(ddv4,DDCompOp::equals);
     DDFilteredView fv4(cpv);
     fv4.addFilter(filter4);
     std::vector<G4String> fibreNames = getNames(fv4);
@@ -235,7 +235,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     value     = "HFFibreBundleConical";
     DDSpecificsFilter filter5;
     DDValue           ddv5(attribute,value,0);
-    filter5.setCriteria(ddv5,DDSpecificsFilter::equals);
+    filter5.setCriteria(ddv5,DDCompOp::equals);
     DDFilteredView fv5(cpv);
     fv5.addFilter(filter5);
     fibreNames = getNames(fv5);
@@ -261,7 +261,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
     value     = name;
     DDSpecificsFilter filter6;
     DDValue           ddv6(attribute,value,0);
-    filter6.setCriteria(ddv6,DDSpecificsFilter::equals);
+    filter6.setCriteria(ddv6,DDCompOp::equals);
     DDFilteredView fv6(cpv);
     fv6.addFilter(filter6);
     if (fv6.firstChild()) {
@@ -284,7 +284,7 @@ HCalSD::HCalSD(G4String name, const DDCompactView & cpv,
   attribute = "ReadOutName";
   DDSpecificsFilter filter2;
   DDValue           ddv2(attribute,name,0);
-  filter2.setCriteria(ddv2,DDSpecificsFilter::equals);
+  filter2.setCriteria(ddv2,DDCompOp::equals);
   DDFilteredView fv2(cpv);
   fv2.addFilter(filter2);
   bool dodet = fv2.firstChild();

--- a/SimG4CMS/Calo/src/HFFibre.cc
+++ b/SimG4CMS/Calo/src/HFFibre.cc
@@ -29,7 +29,7 @@ HFFibre::HFFibre(std::string & name, const DDCompactView & cpv,
   std::string value     = "HF";
   DDSpecificsFilter filter1;
   DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDSpecificsFilter::equals);
+  filter1.setCriteria(ddv1,DDCompOp::equals);
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   bool dodet = fv1.firstChild();
@@ -79,7 +79,7 @@ HFFibre::HFFibre(std::string & name, const DDCompactView & cpv,
   value     = name;
   DDSpecificsFilter filter2;
   DDValue           ddv2(attribute,value,0);
-  filter2.setCriteria(ddv2,DDSpecificsFilter::equals);
+  filter2.setCriteria(ddv2,DDCompOp::equals);
   DDFilteredView fv2(cpv);
   fv2.addFilter(filter2);
   dodet     = fv2.firstChild();

--- a/SimG4CMS/Calo/src/HFShower.cc
+++ b/SimG4CMS/Calo/src/HFShower.cc
@@ -39,7 +39,7 @@ HFShower::HFShower(std::string & name, const DDCompactView & cpv,
   G4String value     = name;
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,value,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   bool dodet = fv.firstChild();

--- a/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
+++ b/SimG4CMS/Calo/src/HFShowerFibreBundle.cc
@@ -37,7 +37,7 @@ HFShowerFibreBundle::HFShowerFibreBundle(std::string & name,
   G4String value     = name;
   DDSpecificsFilter filter0;
   DDValue           ddv0(attribute,value,0);
-  filter0.setCriteria(ddv0,DDSpecificsFilter::equals);
+  filter0.setCriteria(ddv0,DDCompOp::equals);
   DDFilteredView fv0(cpv);
   fv0.addFilter(filter0);
   if (fv0.firstChild()) {
@@ -62,7 +62,7 @@ HFShowerFibreBundle::HFShowerFibreBundle(std::string & name,
   value     = "HFPMT";
   DDSpecificsFilter filter1;
   DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDSpecificsFilter::equals);
+  filter1.setCriteria(ddv1,DDCompOp::equals);
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   if (fv1.firstChild()) {

--- a/SimG4CMS/Calo/src/HFShowerLibrary.cc
+++ b/SimG4CMS/Calo/src/HFShowerLibrary.cc
@@ -114,7 +114,7 @@ HFShowerLibrary::HFShowerLibrary(std::string & name, const DDCompactView & cpv,
   G4String value     = name;
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,value,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   bool dodet = fv.firstChild();

--- a/SimG4CMS/Calo/src/HFShowerPMT.cc
+++ b/SimG4CMS/Calo/src/HFShowerPMT.cc
@@ -29,7 +29,7 @@ HFShowerPMT::HFShowerPMT(std::string & name, const DDCompactView & cpv,
   G4String value     = name;
   DDSpecificsFilter filter0;
   DDValue           ddv0(attribute,value,0);
-  filter0.setCriteria(ddv0,DDSpecificsFilter::equals);
+  filter0.setCriteria(ddv0,DDCompOp::equals);
   DDFilteredView fv0(cpv);
   fv0.addFilter(filter0);
   if (fv0.firstChild()) {
@@ -54,7 +54,7 @@ HFShowerPMT::HFShowerPMT(std::string & name, const DDCompactView & cpv,
   value     = "HFPMT";
   DDSpecificsFilter filter1;
   DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDSpecificsFilter::equals);
+  filter1.setCriteria(ddv1,DDCompOp::equals);
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   if (fv1.firstChild()) {

--- a/SimG4CMS/Calo/src/HFShowerParam.cc
+++ b/SimG4CMS/Calo/src/HFShowerParam.cc
@@ -84,7 +84,7 @@ HFShowerParam::HFShowerParam(std::string & name, const DDCompactView & cpv,
   G4String value     = name;
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,value,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   bool dodet = fv.firstChild();

--- a/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
+++ b/SimG4CMS/CherenkovAnalysis/src/DreamSD.cc
@@ -196,7 +196,7 @@ void DreamSD::initMap(G4String sd, const DDCompactView & cpv) {
   G4String attribute = "ReadOutName";
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,sd,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB02SD.cc
@@ -122,7 +122,7 @@ void HcalTB02SD::initMap(G4String sd, const DDCompactView & cpv) {
   G4String attribute = "ReadOutName";
   DDSpecificsFilter filter;
   DDValue           ddv(attribute,sd,0);
-  filter.setCriteria(ddv,DDSpecificsFilter::equals);
+  filter.setCriteria(ddv,DDCompOp::equals);
   DDFilteredView fv(cpv);
   fv.addFilter(filter);
   fv.firstChild();

--- a/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
+++ b/SimG4CMS/HcalTestBeam/src/HcalTB06BeamSD.cc
@@ -52,7 +52,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(G4String name, const DDCompactView & cpv,
   value     = "WireChamber";
   DDSpecificsFilter filter1;
   DDValue           ddv1(attribute,value,0);
-  filter1.setCriteria(ddv1,DDSpecificsFilter::equals);
+  filter1.setCriteria(ddv1,DDCompOp::equals);
   DDFilteredView fv1(cpv);
   fv1.addFilter(filter1);
   wcNames = getNames(fv1);
@@ -67,7 +67,7 @@ HcalTB06BeamSD::HcalTB06BeamSD(G4String name, const DDCompactView & cpv,
   attribute = "ReadOutName";
   DDSpecificsFilter filter2;
   DDValue           ddv2(attribute,name,0);
-  filter2.setCriteria(ddv2,DDSpecificsFilter::equals);
+  filter2.setCriteria(ddv2,DDCompOp::equals);
   DDFilteredView fv2(cpv);
   fv2.addFilter(filter2);
   bool dodet = fv2.firstChild();

--- a/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
+++ b/SimG4Core/PrintGeomInfo/src/PrintGeomInfoAction.cc
@@ -83,7 +83,7 @@ void PrintGeomInfoAction::update(const BeginOfJob * job) {
       std::string sd        = names[i];
       DDSpecificsFilter filter;
       DDValue           ddv(attribute,sd,0);
-      filter.setCriteria(ddv,DDSpecificsFilter::equals);
+      filter.setCriteria(ddv,DDCompOp::equals);
       DDFilteredView fv(*pDD);
       std::cout << "PrintGeomInfoAction:: Get Filtered view for " 
 		<< attribute << " = " << sd << std::endl;

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListGroups.cc
@@ -423,7 +423,7 @@ ListGroups::analyze(const edm::Event& evt, const edm::EventSetup& setup) {
   DDFilteredView fv(*hDdd);
 
   DDSpecificsFilter filter;
-  filter.setCriteria(DDValue("TrackingMaterialGroup", ""), DDSpecificsFilter::not_equals);
+  filter.setCriteria(DDValue("TrackingMaterialGroup", ""), DDCompOp::not_equals);
   fv.addFilter(filter);
 
   while (fv.next()) {

--- a/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/ListIds.cc
@@ -92,7 +92,7 @@ ListIds::analyze(const edm::Event& evt, const edm::EventSetup& setup){
   std::string attribute = "TkDDDStructure";
   CmsTrackerStringToEnum theCmsTrackerStringToEnum;
   DDSpecificsFilter filter;
-  filter.setCriteria(DDValue(attribute, "any", 0), DDSpecificsFilter::not_equals);
+  filter.setCriteria(DDValue(attribute, "any", 0), DDCompOp::not_equals);
   DDFilteredView fv(*hDdd); 
   fv.addFilter(filter);
   if (theCmsTrackerStringToEnum.type(dddGetString(attribute, fv)) != GeometricDet::Tracker) {

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
@@ -32,7 +32,7 @@ MaterialAccountingGroup::MaterialAccountingGroup( const std::string & name, cons
   // retrieve the elements from DDD
   DDFilteredView fv( geometry );
   DDSpecificsFilter filter;
-  filter.setCriteria(DDValue("TrackingMaterialGroup", name), DDSpecificsFilter::equals);
+  filter.setCriteria(DDValue("TrackingMaterialGroup", name), DDCompOp::equals);
   fv.addFilter(filter);
   while (fv.next()) {
     // DD3Vector and DDTranslation are the same type as math::XYZVector

--- a/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
+++ b/Validation/Geometry/src/MaterialBudgetHcalHistos.cc
@@ -39,7 +39,7 @@ void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView & cpv) {
     std::string value     = "HcalHits";
     DDSpecificsFilter filter1;
     DDValue           ddv1(attribute,value,0);
-    filter1.setCriteria(ddv1,DDSpecificsFilter::equals);
+    filter1.setCriteria(ddv1,DDCompOp::equals);
     DDFilteredView fv1(cpv);
     fv1.addFilter(filter1);
     sensitives = getNames(fv1);
@@ -55,7 +55,7 @@ void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView & cpv) {
     value     = "HF";
     DDSpecificsFilter filter2;
     DDValue           ddv2(attribute,value,0);
-    filter2.setCriteria(ddv2,DDSpecificsFilter::equals);
+    filter2.setCriteria(ddv2,DDCompOp::equals);
     DDFilteredView fv2(cpv);
     fv2.addFilter(filter2);
     hfNames = getNames(fv2);
@@ -80,7 +80,7 @@ void MaterialBudgetHcalHistos::fillBeginJob(const DDCompactView & cpv) {
       value     = ecalRO[k];
       DDSpecificsFilter filter3;
       DDValue           ddv3(attribute,value,0);
-      filter3.setCriteria(ddv3,DDSpecificsFilter::equals);
+      filter3.setCriteria(ddv3,DDCompOp::equals);
       DDFilteredView fv3(cpv);
       fv3.addFilter(filter3);
       std::vector<std::string> senstmp = getNames(fv3);


### PR DESCRIPTION
- Use auto for simplicity
- Use range-based for loops
- Remove commented out code
- Use enum class for operations
- Clean up unneeded typedefs
