### PR TITLE
RecoJets/JetAnalyzers: fix -Werror=maybe-uninitialized

### DIFF
--- a/RecoJets/JetAnalyzers/src/myJetAna.cc
+++ b/RecoJets/JetAnalyzers/src/myJetAna.cc
@@ -1004,7 +1004,7 @@ void myJetAna::analyze( const edm::Event& evt, const edm::EventSetup& es ) {
   // **************************
   // ***  Pass Vertex
   // **************************
-  double VTX;
+  double VTX = 0.;
   int nVTX;
 
   edm::Handle<reco::VertexCollection> vertexCollection;


### PR DESCRIPTION
Resolves:

```
RecoJets/JetAnalyzers/src/myJetAna.cc: In member function 'virtual void myJetAna::analyze(const edm::Event&, const edm::EventSetup&)':
RecoJets/JetAnalyzers/src/myJetAna.cc:1021:17: error: 'VTX' may be used uninitialized in this function [-Werror=maybe-uninitialized]
   if ( (fabs(VTX) < 20.) && (nVTX > 0) ){
                 ^
cc1plus: some warnings being treated as errors
```

Compiling with `USER_CXXFLAGS='-g -fsanitize=undefined -fno-omit-frame-pointer'`

I don't understand why you need this loop:

```
1017   for (reco::VertexCollection::const_iterator vertex=vC.begin(); vertex!=vC.end(); vertex++){
1018     VTX  = vertex->z();
1019   }
```

You could just (untested):

```
if (!vC.empty()) {
  VTX = vC.back().z();
}
```

Or maybe there is a mistake and the code should look like:

```
VTX  += vertex->z();
```

Can someone look into this?
Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
