### PR TITLE
update conddb tool to improve handling/showing of time-types/time-stamps

### DIFF
--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -615,7 +615,7 @@ def _since_filter(time_type):
         return lambda since: '%s (%s)' % (_convertTimeType(since), since)
 
     if time_type == conddb.TimeType.lumi:
-        return lambda since: '%s Lumi %5s' % (_high(since), _low(since))
+        return lambda since: '%s Lumi %5s (%s)' % (_high(since), _low(since), since)
 
     return lambda since: since
 
@@ -672,8 +672,6 @@ def list_(args):
             time_type = session.query(conddb.Tag.time_type).\
                 filter(conddb.Tag.name == name).\
                 scalar()
-
-	    logging.info("time type : %s" % time_type)
 
             output_table(args,
                 session.query(conddb.IOV.since, conddb.IOV.insertion_time, conddb.IOV.payload_hash, conddb.Payload.object_type).\

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -615,7 +615,7 @@ def _since_filter(time_type):
         return lambda since: '%s (%s)' % (_convertTimeType(since), since)
 
     if time_type == conddb.TimeType.lumi:
-        return lambda since: '%s Lumi %5s (%s)' % (_high(since), _low(since), since)
+        return lambda since: '%s : %5s (%s)' % (_high(since), _low(since), since)
 
     return lambda since: since
 
@@ -672,6 +672,12 @@ def list_(args):
             time_type = session.query(conddb.Tag.time_type).\
                 filter(conddb.Tag.name == name).\
                 scalar()
+	
+	    sinceLabel = 'Since: Run '
+	    if time_type == conddb.TimeType.time:
+	        sinceLabel = 'Since: UTC          (timestamp)'
+	    if time_type == conddb.TimeType.lumi:
+	        sinceLabel = '  Run  : Lumi  (rawSince)'
 
             output_table(args,
                 session.query(conddb.IOV.since, conddb.IOV.insertion_time, conddb.IOV.payload_hash, conddb.Payload.object_type).\
@@ -685,7 +691,7 @@ def list_(args):
                     from_self().\
                     order_by(conddb.IOV.since, conddb.IOV.insertion_time).\
                     all(),
-                ['Since (UTC)', 'Insertion Time', 'Payload', 'Object Type'],
+                [sinceLabel, 'Insertion Time', 'Payload', 'Object Type'],
                 filters = [_since_filter(time_type), None, None, None],
             )
 

--- a/CondCore/Utilities/scripts/conddb
+++ b/CondCore/Utilities/scripts/conddb
@@ -591,9 +591,9 @@ def _low(n):
 
 def _convertTimeType(since):
     try:
-        return str(datetime.datetime.fromtimestamp(_high(since)).replace(microsecond = _low(since)))
+        return str(datetime.datetime.utcfromtimestamp(_high(since)).replace(microsecond = _low(since)))
     except ValueError:
-        return str(datetime.datetime.fromtimestamp(_high(since)).replace(microsecond = _low(since)/1000))
+        return str(datetime.datetime.utcfromtimestamp(_high(since)).replace(microsecond = _low(since)/1000))
 
 
 def _since_filter(time_type):
@@ -612,7 +612,7 @@ def _since_filter(time_type):
     '''
 
     if time_type == conddb.TimeType.time:
-        return _convertTimeType
+        return lambda since: '%s (%s)' % (_convertTimeType(since), since)
 
     if time_type == conddb.TimeType.lumi:
         return lambda since: '%s Lumi %5s' % (_high(since), _low(since))
@@ -673,6 +673,8 @@ def list_(args):
                 filter(conddb.Tag.name == name).\
                 scalar()
 
+	    logging.info("time type : %s" % time_type)
+
             output_table(args,
                 session.query(conddb.IOV.since, conddb.IOV.insertion_time, conddb.IOV.payload_hash, conddb.Payload.object_type).\
                     join(conddb.IOV.payload).\
@@ -685,7 +687,7 @@ def list_(args):
                     from_self().\
                     order_by(conddb.IOV.since, conddb.IOV.insertion_time).\
                     all(),
-                ['Since', 'Insertion Time', 'Payload', 'Object Type'],
+                ['Since (UTC)', 'Insertion Time', 'Payload', 'Object Type'],
                 filters = [_since_filter(time_type), None, None, None],
             )
 


### PR DESCRIPTION
Convert time stamps to UTC when printing, also add "raw" timestamp to output to ease comparisons.
Insertion time still shown in local time.
"De-mangle" run-lumi based timestamps, show run and lumi separate plus "raw" timestamp.
Update table-header info accordingly.
