### PR TITLE
Cosmic GEN configuration with tighter pointing cuts

### DIFF
--- a/Configuration/Generator/python/UndergroundCosmicSPLooseMu_cfi.py
+++ b/Configuration/Generator/python/UndergroundCosmicSPLooseMu_cfi.py
@@ -1,0 +1,45 @@
+import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.GenFilters.CosmicGenFilterHelix_cff import * 
+
+generator = cms.EDProducer("CosMuoGenProducer",
+    ZCentrOfTarget = cms.double(0.0),
+    MinP = cms.double(10.0),
+    MinP_CMS = cms.double(-1.0), ##negative means MinP_CMS = MinP. Only change this if you know what you are doing!
+    MaxP = cms.double(3000.0),
+    MinTheta = cms.double(0.0),
+    MaxTheta = cms.double(84.),
+    MinPhi = cms.double(0.0),
+    MaxPhi = cms.double(360.0),
+    MinT0 = cms.double(-12.5),
+    MaxT0 = cms.double(12.5),
+    PlugVx = cms.double(0.0),
+    PlugVz = cms.double(-14000.0),                
+    MinEnu = cms.double(10.),                
+    MaxEnu = cms.double(10000.),                
+    NuProdAlt = cms.double(7.5e6),                       
+    AcptAllMu = cms.bool(False), 
+    ElossScaleFactor = cms.double(1.0),
+    RadiusOfTarget = cms.double(8000.0),
+    ZDistOfTarget = cms.double(15000.0),
+    TrackerOnly = cms.bool(False),
+    TIFOnly_constant = cms.bool(False),
+    TIFOnly_linear = cms.bool(False),
+    MTCCHalf = cms.bool(False),
+    Verbosity = cms.bool(False),
+    RhoAir = cms.double(0.001214),
+    RhoWall = cms.double(2.5),
+    RhoRock = cms.double(2.5),
+    RhoClay = cms.double(2.3),
+    RhoPlug = cms.double(2.5),
+    ClayWidth = cms.double(50000.),
+                           
+    MultiMuon = cms.bool(False),
+    # MultiMuon = cms.bool(True),
+    MultiMuonFileName = cms.string("CORSIKAmultiMuon.root"),
+    MultiMuonFileFirstEvent = cms.int32(1),
+    MultiMuonNmin = cms.int32(2),              
+)
+
+
+#Filter
+ProductionFilterSequence = cms.Sequence(generator*cosmicInPixelLoose)

--- a/GeneratorInterface/GenFilters/python/CosmicGenFilterHelix_cff.py
+++ b/GeneratorInterface/GenFilters/python/CosmicGenFilterHelix_cff.py
@@ -3,3 +3,10 @@ import FWCore.ParameterSet.Config as cms
 from GeneratorInterface.GenFilters.CosmicGenFilterHelix_cfi import *
 from TrackPropagation.SteppingHelixPropagator.SteppingHelixPropagatorAlong_cfi import *
 
+cosmicInPixelLoose = cosmicInTracker.clone()
+
+cosmicInPixelLoose.radius = cms.double(20.0) ## i.e. twice 
+cosmicInPixelLoose.minZ = cms.double(-100.0) ## the RECO SP
+cosmicInPixelLoose.maxZ = cms.double(100.0)  ## skim cuts
+
+


### PR DESCRIPTION
This PR includes a GEN configuration to prodce cosmic muons and filter them with tighter pointing requirement w.r.t. what done with runTheMatrix.py -l 1307.
That configuration is tuned to generate "super-pointing" muons that are needed to compare the muon pT assignment performance in DATA and MC. It skims more muons at GEN-SIM level, thus is more efficient to produce events similar to the ones we want to study. 
After discussing with @franzoni , it was agreed to include this configuration in RelVal workflows and ask for a RelVal based pre-production to perform a validation round before requestiong for a larger Cosmic production.
Just the GEN fragment and the filter are included in this PR, eventual extension of the matrix should be taken care of by PdmV. 
