### PR TITLE
enable generic CPE to run without GenErrors

### DIFF
--- a/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
+++ b/RecoLocalTracker/SiPixelRecHits/interface/PixelCPEGenericESProducer.h
@@ -18,6 +18,7 @@ class  PixelCPEGenericESProducer: public edm::ESProducer{
   edm::ESInputTag magname_;
   bool useLAWidthFromDB_;
   bool useLAAlignmentOffsets_;
+  bool UseErrorsFromTemplates_;
 };
 
 

--- a/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
+++ b/RecoLocalTracker/SiPixelRecHits/plugins/PixelCPEGenericESProducer.cc
@@ -39,7 +39,8 @@ PixelCPEGenericESProducer::PixelCPEGenericESProducer(const edm::ParameterSet & p
   pset_ = p;
   setWhatProduced(this,myname);
 
-  //std::cout<<" ESProducer "<<myname<<" "<<useLAWidthFromDB_<<" "<<useLAAlignmentOffsets_<<std::endl; //dk
+  //std::cout<<" ESProducer "<<myname<<" "<<useLAWidthFromDB_<<" "<<useLAAlignmentOffsets_<<" "
+  //	   <<UseErrorsFromTemplates_<<std::endl; //dk
 
 }
 
@@ -81,6 +82,8 @@ PixelCPEGenericESProducer::produce(const TkPixelCPERecord & iRecord){
   if(UseErrorsFromTemplates_) {  // do only when generrors are needed
     iRecord.getRecord<SiPixelGenErrorDBObjectRcd>().get(genErrorDBObject); 
     genErrorDBObjectProduct = genErrorDBObject.product();
+    //} else {
+    //std::cout<<" pass an empty GenError pointer"<<std::endl;
   }
   cpe_  = boost::shared_ptr<PixelClusterParameterEstimator>
     (new PixelCPEGeneric(pset_,magfield.product(),*pDD.product(),

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEBase.cc
@@ -68,7 +68,7 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const & conf,
 
   //-- Template Calibration Object from DB
 #ifdef NEW_CPEERROR
-  if(theFlag_!=0) templateDBobject_ = templateDBobject;
+  if(theFlag_!=0) templateDBobject_ = templateDBobject; // flag to check if it is generic or templates
 #else
   templateDBobject_ = templateDBobject;
 #endif
@@ -78,6 +78,7 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const & conf,
 
   // Read templates and/or generic errors from DB
   LoadTemplatesFromDB_ = conf.getParameter<bool>("LoadTemplatesFromDB"); 
+  //cout<<" use generros/templaets "<<LoadTemplatesFromDB_<<endl;
 
   //--- Algorithm's verbosity
   theVerboseLevel = 
@@ -107,7 +108,6 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const & conf,
   //useLAAlignmentOffsets_ = conf.existsAs<bool>("useLAAlignmentOffsets")?
   //conf.getParameter<bool>("useLAAlignmentOffsets"):false;
 
-
   // Used only for testing
   lAOffset_ = conf.existsAs<double>("lAOffset")?  // fixed LA value 
               conf.getParameter<double>("lAOffset"):0.0;
@@ -130,7 +130,8 @@ PixelCPEBase::PixelCPEBase(edm::ParameterSet const & conf,
 			   <<lAOffset_<<" "<<lAWidthBPix_<<" "<<lAWidthFPix_<<endl; //dk
   
   fillDetParams();
-  
+
+  //cout<<" LA "<<lAOffset_<<" "<<lAWidthBPix_<<" "<<lAWidthFPix_<<endl; //dk
 }
 
 //-----------------------------------------------------------------------------
@@ -186,6 +187,7 @@ void PixelCPEBase::fillDetParams()
 
     if(theFlag_==0) { // for generic
 #ifdef NEW_CPEERROR
+      if(LoadTemplatesFromDB_ ) // do only if genError requested 
 	p.detTemplateId = genErrorDBObject_->getGenErrorID(p.theDet->geographicalId().rawId());
 #else   
       if(useNewSimplerErrors) 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -74,32 +74,9 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
   DoCosmics_                 = conf.getParameter<bool>("DoCosmics");
   //LoadTemplatesFromDB_       = conf.getParameter<bool>("LoadTemplatesFromDB");
 
-  bool isUpgrade=false;
-  if ( conf.exists("Upgrade") && conf.getParameter<bool>("Upgrade")) {
-    isUpgrade=true;
-    xerr_barrel_ln_= {0.00114,0.00104,0.00214};
-    xerr_barrel_ln_def_=0.00425;
-    yerr_barrel_ln_= {0.00299,0.00203,0.0023,0.00237,0.00233,0.00243,0.00232,0.00259,0.00176};
-    yerr_barrel_ln_def_=0.00245;
-    xerr_endcap_= {0.00151,0.000813,0.00221};
-    xerr_endcap_def_=0.00218;
-    yerr_endcap_= {0.00261,0.00107,0.00264};
-    yerr_endcap_def_=0.00357;
-    
-    if ( conf.exists("SmallPitch") && conf.getParameter<bool>("SmallPitch")) {
-      xerr_barrel_l1_= {0.00104, 0.000691, 0.00122};
-      xerr_barrel_l1_def_=0.00321;
-      yerr_barrel_l1_= {0.00199,0.00136,0.0015,0.00153,0.00152,0.00171,0.00154,0.00157,0.00154};
-      yerr_barrel_l1_def_=0.00164;
-    }
-    else{
-      xerr_barrel_l1_= {0.00114,0.00104,0.00214};
-      xerr_barrel_l1_def_=0.00425;
-      yerr_barrel_l1_= {0.00299,0.00203,0.0023,0.00237,0.00233,0.00243,0.00232,0.00259,0.00176};
-      yerr_barrel_l1_def_=0.00245;
-    }
-  }
-  isUpgrade_=isUpgrade;
+  // no clear what upgrade means, is it phase1, phase2? Probably delete.
+  isUpgrade_= false;
+  if ( conf.exists("Upgrade") && conf.getParameter<bool>("Upgrade")) isUpgrade_=true;
 
   // Select the position error source 
   // For upgrde and cosmics force the use simple errors 
@@ -151,8 +128,49 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
 
 #endif // NEW_CPEERROR
 
+  }  else {
+    if(MYDEBUG) cout<<" Use simple parametrised errors "<<endl;
   } // if ( UseErrorsFromTemplates_ )
   
+
+  // Rechit errors in case other, more correct, errors are not vailable
+  // This are constants. Maybe there is a more efficienct way to store them.
+  if(!isUpgrade_) {  // normal case
+    xerr_barrel_l1_= {0.00115, 0.00120, 0.00088};
+    xerr_barrel_l1_def_=0.01030;
+    yerr_barrel_l1_= {0.00375,0.00230,0.00250,0.00250,0.00230,0.00230,0.00210,0.00210,0.00240};
+    yerr_barrel_l1_def_=0.00210;
+    xerr_barrel_ln_= {0.00115, 0.00120, 0.00088};
+    xerr_barrel_ln_def_=0.01030;
+    yerr_barrel_ln_= {0.00375,0.00230,0.00250,0.00250,0.00230,0.00230,0.00210,0.00210,0.00240};
+    yerr_barrel_ln_def_=0.00210;
+    xerr_endcap_= {0.0020, 0.0020};
+    xerr_endcap_def_=0.0020;
+    yerr_endcap_= {0.00210};
+    yerr_endcap_def_=0.00075;
+  } else { // isUpgrade=true, funny case
+    xerr_barrel_ln_= {0.00114,0.00104,0.00214};
+    xerr_barrel_ln_def_=0.00425;
+    yerr_barrel_ln_= {0.00299,0.00203,0.0023,0.00237,0.00233,0.00243,0.00232,0.00259,0.00176};
+    yerr_barrel_ln_def_=0.00245;
+    xerr_endcap_= {0.00151,0.000813,0.00221};
+    xerr_endcap_def_=0.00218;
+    yerr_endcap_= {0.00261,0.00107,0.00264};
+    yerr_endcap_def_=0.00357;
+    
+    if ( conf.exists("SmallPitch") && conf.getParameter<bool>("SmallPitch")) {
+      xerr_barrel_l1_= {0.00104, 0.000691, 0.00122};
+      xerr_barrel_l1_def_=0.00321;
+      yerr_barrel_l1_= {0.00199,0.00136,0.0015,0.00153,0.00152,0.00171,0.00154,0.00157,0.00154};
+      yerr_barrel_l1_def_=0.00164;
+    } else {
+      xerr_barrel_l1_= {0.00114,0.00104,0.00214};
+      xerr_barrel_l1_def_=0.00425;
+      yerr_barrel_l1_= {0.00299,0.00203,0.0023,0.00237,0.00233,0.00243,0.00232,0.00259,0.00176};
+      yerr_barrel_l1_def_=0.00245;
+    }
+  } // if isUpgrade
+
   if(MYDEBUG) {
     cout << "From PixelCPEGeneric::PixelCPEGeneric(...)" << endl;
     cout << "(int)UseErrorsFromTemplates_ = " << (int)UseErrorsFromTemplates_    << endl;
@@ -162,21 +180,6 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
     cout << "(int)LoadTemplatesFromDB_    = " << (int)LoadTemplatesFromDB_       << endl;
   }
 
-
-  // Default case for rechit errors in case other, more correct, errors are not vailable
-  // This are constants. Maybe there is a more efficienct way to store them.
-  xerr_barrel_l1_= {0.00115, 0.00120, 0.00088};
-  xerr_barrel_l1_def_=0.01030;
-  yerr_barrel_l1_= {0.00375,0.00230,0.00250,0.00250,0.00230,0.00230,0.00210,0.00210,0.00240};
-  yerr_barrel_l1_def_=0.00210;
-  xerr_barrel_ln_= {0.00115, 0.00120, 0.00088};
-  xerr_barrel_ln_def_=0.01030;
-  yerr_barrel_ln_= {0.00375,0.00230,0.00250,0.00250,0.00230,0.00230,0.00210,0.00210,0.00240};
-  yerr_barrel_ln_def_=0.00210;
-  xerr_endcap_= {0.0020, 0.0020};
-  xerr_endcap_def_=0.0020;
-  yerr_endcap_= {0.00210};
-  yerr_endcap_def_=0.00075;
 
 }
 

--- a/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
+++ b/RecoLocalTracker/SiPixelRecHits/src/PixelCPEGeneric.cc
@@ -84,7 +84,6 @@ PixelCPEGeneric::PixelCPEGeneric(edm::ParameterSet const & conf,
 
   if ( !UseErrorsFromTemplates_ && ( TruncatePixelCharge_       || 
 				     IrradiationBiasCorrection_ || 
-				     DoCosmics_                 ||
 				     LoadTemplatesFromDB_ ) )  {
     throw cms::Exception("PixelCPEGeneric::PixelCPEGeneric: ") 
       << "\nERROR: UseErrorsFromTemplates_ is set to False in PixelCPEGeneric_cfi.py. "
@@ -666,13 +665,11 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
 	<<sizex<<" "<<sizey<<endl;
   }
 
-  //if likely(UseErrorsFromTemplates_ && (qBin_!= 0) ) {
   if likely(UseErrorsFromTemplates_ ) {
       //
       // Use template errors 
       //cout << "Track angles are known. We can use either errors from templates or the error parameterization from DB." << endl;
       
-
       if ( !edgex ) { // Only use this for non-edge clusters
 	if ( sizex == 1 ) {
 	  if ( !bigInX ) {xerr = theClusterParam.sx1;} 
@@ -695,7 +692,7 @@ PixelCPEGeneric::localError(DetParam const & theDetParam,  ClusterParam & theClu
   } else  { // simple errors
 
     // This are the simple errors, hardcoded in the code 
-    cout << "Track angles are not known and we are processing cosmics." << endl; 
+    //cout << "Track angles are not known " << endl; 
     //cout << "Default angle estimation which assumes track from PV (0,0,0) does not work." << endl;
       
     if ( theDetParam.thePart == GeomDetEnumerators::PixelBarrel || theDetParam.thePart == GeomDetEnumerators::P1PXB )  {


### PR DESCRIPTION
To be able to test CPE generic even when GenErrors are not present.
This feature is especially for MC for phase1 pixels. It has no effect for the data reconstruction.
