### PR TITLE
Fixing eventSetupPathsKey for ALCARECOLumiPixelsMinBias 

### DIFF
--- a/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_cff.py
+++ b/Calibration/TkAlCaRecoProducers/python/ALCARECOLumiPixelsMinBias_cff.py
@@ -3,8 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import HLTrigger.HLTfilters.hltHighLevel_cfi
 ALCARECOVertexPixelZeroBiasHLT = HLTrigger.HLTfilters.hltHighLevel_cfi.hltHighLevel.clone(
     andOr = True, # choose logical OR between Triggerbits
-    eventSetupPathsKey='TkAlMinBias',
-    #eventSetupPathsKey='VertexPixelZeroBias',
+    eventSetupPathsKey='VertexPixelZeroBias',
     throw = False # tolerate triggers stated above, but not available
 )
 


### PR DESCRIPTION
one-liner to get the ALCARECOLumiPixelsMinBias to work with correct trigger bits.
