### PR TITLE
Thread-safe conversion for HLT modules in CommonTools/RecoAlgos, backport of #9081

### DIFF
--- a/CommonTools/RecoAlgos/interface/TrackSelector.h
+++ b/CommonTools/RecoAlgos/interface/TrackSelector.h
@@ -14,6 +14,8 @@
  * $Id: TrackSelector.h,v 1.1 2009/03/04 13:11:28 llista Exp $
  *
  */
+
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
@@ -130,7 +132,7 @@ namespace helper {
 
 
   //----------------------------------------------------------------------
-  class TrackSelectorBase : public edm::EDFilter {
+  class TrackSelectorBase : public edm::stream::EDFilter<> {
   public:
     TrackSelectorBase( const edm::ParameterSet & cfg ) {
       std::string alias( cfg.getParameter<std::string>( "@module_label" ) );
@@ -145,7 +147,7 @@ namespace helper {
 
 
   template<>
-  struct StoreManagerTrait<reco::TrackCollection> {
+  struct StoreManagerTrait< reco::TrackCollection, edm::stream::EDFilter<> > {
     typedef TrackCollectionStoreManager type;
     typedef TrackSelectorBase base;
   };

--- a/CommonTools/RecoAlgos/plugins/LargestEtCaloJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/LargestEtCaloJetSelector.cc
@@ -6,12 +6,12 @@
  *
  */
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "CommonTools/UtilAlgos/interface/SortCollectionSelector.h"
 #include "DataFormats/JetReco/interface/CaloJet.h"
 #include "CommonTools/Utils/interface/EtComparator.h"
 
-typedef ObjectSelector<
+typedef ObjectSelectorStream<
           SortCollectionSelector<
             reco::CaloJetCollection, 
               GreaterByEt<reco::CaloJet> 

--- a/CommonTools/RecoAlgos/plugins/LargestEtPFJetSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/LargestEtPFJetSelector.cc
@@ -6,12 +6,12 @@
  *
  */
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "CommonTools/UtilAlgos/interface/SortCollectionSelector.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
 #include "CommonTools/Utils/interface/EtComparator.h"
 
-typedef ObjectSelector<
+typedef ObjectSelectorStream<
           SortCollectionSelector<
             reco::PFJetCollection, 
               GreaterByEt<reco::PFJet> 


### PR DESCRIPTION
HLT modules LargestEtCaloJetSelector, LargestEtPFJetSelector, and RecoTrackRefSelector in CommonTools/RecoAlgos migrated to be thread safe. This PR is a backport of #9081, which was merged and has been in 75X since CMSSW_7_5_X_2015-05-25-1100. It was created in response to a request from Andrea Bocci: https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1353.html

This change should have no effect on monitored quantities.
