### PR TITLE
Fix uninitialized parameter causing relval failures in mixing workflows

### DIFF
--- a/Mixing/Base/interface/PileUp.h
+++ b/Mixing/Base/interface/PileUp.h
@@ -129,9 +129,6 @@ namespace edm {
     // sequential reading
     bool sequential_;
 
-    // force reading pileup events from the same lumisection as the signal event
-    bool samelumi_;
-    
     // read the seed for the histo and probability function cases
     int seed_;
   };

--- a/Mixing/Base/src/PileUp.cc
+++ b/Mixing/Base/src/PileUp.cc
@@ -54,6 +54,7 @@ namespace edm {
     vPoissonDistr_OOT_(),
     randomEngines_(),
     playback_(playback),
+    sequential_(pset.getUntrackedParameter<bool>("sequential", false)),
     seed_(0) {
 
     // Use the empty parameter set for the parameter set ID of our "@MIXING" process.


### PR DESCRIPTION
In PR #9397, I refactored PoolSource, and modified the users of the secondary input source.
Unfortunately, in the base class of the mixing modules, I added a bool parameter that I forgot to initialize, thereby causing relvals using the mixing module with pileup to fail about half the time.
This PR adds the proper initialization of the parameter.  It also removes another parameter that I added that was never used.
This should fix the recently introduced failures in relvals 50208.0, 50202.0, 50200.0,500206.0, 500204.0, 500203.0, 500200.0, 25204.0, 25202.0, 250206.0, and 250200.1.
