### PR TITLE
Avoid deadlock by taking SharedResource lock first

### DIFF
--- a/FWCore/Framework/src/EDProducer.cc
+++ b/FWCore/Framework/src/EDProducer.cc
@@ -34,9 +34,11 @@ namespace edm {
     Event e(ep, moduleDescription_, mcc);
     e.setConsumer(this);
     {
-      std::lock_guard<std::mutex> guard(mutex_);
+      //Temporary: switch order of locks to avoid a deadlock with unscheduled
+      // proper fix is to releaes resourcesAcquirer when doing a 'getBy*'
+      std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
       {
-        std::lock_guard<SharedResourcesAcquirer> guardAcq(resourceAcquirer_);
+        std::lock_guard<std::mutex> guard(mutex_);
         EventSignalsSentry sentry(act,mcc);
         this->produce(e, c);
       }

--- a/FWCore/Framework/src/one/EDProducerBase.cc
+++ b/FWCore/Framework/src/one/EDProducerBase.cc
@@ -54,9 +54,11 @@ namespace edm {
       Event e(ep, moduleDescription_, mcc);
       e.setConsumer(this);
       {
-        std::lock_guard<std::mutex> guard(mutex_);
+        //Temporary: switch order of locks to avoid a deadlock with unscheduled
+        // proper fix is to releaes resourcesAcquirer when doing a 'getBy*'
+        std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);
         {
-          std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);
+          std::lock_guard<std::mutex> guard(mutex_);
           EventSignalsSentry sentry(act,mcc);
           this->produce(e, c);
         }


### PR DESCRIPTION
Tests running unscheduled workflows found a deadlock do to a legacy
module doing an unscheduled get from another legacy module while another
thread was trying to run the second legacy module. This caused the order
of locks (module lock then legacy lock) to be changed for the second
module which lead to the deadlock.

This change is a temporary workaround in which we take the legacy lock
before the module lock. This work most of the time but still can cause
a deadlock for the case of two 'one' modules both with different shared
resources but one of them calling a legacy module (which tries to take
locks to all resources). A complete fix is forth coming.
