### PR TITLE
update checksum to fix build error in DataFormats/GsfTrackReco

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -24,7 +24,9 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="13">
+  <class name="reco::GsfTrack" ClassVersion="16">
+   <version ClassVersion="16" checksum="4129402716"/>
+   <version ClassVersion="15" checksum="2494468278"/>
    <version ClassVersion="14" checksum="3085391575"/>
    <version ClassVersion="13" checksum="1287963871"/>
    <version ClassVersion="12" checksum="1456169080"/>


### PR DESCRIPTION
DataFormats/GsfTrackReco does not build in CMSSW_7_5_ROOT5_X due to an incorrect checksum.
This PR adds the correct checksum and updates the class version number to fix the build error.
There will be another PR in 7_5_X to (#9486) make this new ROOT5 checksum known in the ROOT6 release.
