### PR TITLE
Make ROOT5 checksum known in ROOT6 release

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -25,6 +25,7 @@
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
   <class name="reco::GsfTrack" ClassVersion="15">
+   <version ClassVersion="16" checksum="4129402716"/>
    <version ClassVersion="15" checksum="2494468278"/>
    <version ClassVersion="14" checksum="3085391575"/>
    <version ClassVersion="13" checksum="1287963871"/>


### PR DESCRIPTION
A checksum was updated in CMSSW_7_5_ROOT5_X in PR #9485.
This pull request simply makes the new checkum known to the ROOT6 release.
