### PR TITLE
Clean unsused selection rules (ROOT 6.04.00)

### DIFF
--- a/AnalysisDataFormats/Egamma/src/classes_def.xml
+++ b/AnalysisDataFormats/Egamma/src/classes_def.xml
@@ -11,7 +11,6 @@
    <class name="edm::AssociationMap<edm::OneToOne<std::vector<reco::GsfElectron>, std::vector<reco::ElectronID>, unsigned int > >">
      <field name="transientMap_" transient="true" />
    </class>
-   <class pattern="edm::KeyVal<*>" />
    <class pattern="edm::Wrapper<edm::AssociationMap<*>" />
    <class pattern="edm::Ref<edm::AssociationMap<*>" />
    <class pattern="edm::RefProd<edm::AssociationMap<*>" />

--- a/DataFormats/EgammaReco/src/classes_def.xml
+++ b/DataFormats/EgammaReco/src/classes_def.xml
@@ -128,7 +128,6 @@
   </class>
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::SuperCluster> >, edm::RefProd<std::vector<reco::HFEMClusterShape> > >"/>
 
-  <class pattern="edm::KeyVal<*>" />
   <class pattern="edm::Wrapper<edm::AssociationMap<*>" />
   <class pattern="edm::Ref<edm::AssociationMap<*>" />
   <class pattern="edm::RefProd<edm::AssociationMap<*>" />

--- a/DataFormats/RecoCandidate/src/classes_def.xml
+++ b/DataFormats/RecoCandidate/src/classes_def.xml
@@ -89,11 +89,7 @@
   <class name="edm::ValueMap<reco::IsoDeposit>" />
   <class name="edm::ValueMap<reco::FitQuality>" />
   <class pattern="edm::Wrapper<edm::ValueMap<*>" />
-  <class pattern="edm::KeyVal<*>" />
   <class pattern="edm::Wrapper<edm::AssociationMap<*>" />
-  <class pattern="edm::Ref<edm::AssociationMap<*>" />
-  <class pattern="edm::RefProd<edm::AssociationMap<*>" />
-  <class pattern="edm::RefVector<edm::AssociationMap<*>" />
  
   <class name="edm::reftobase::Holder<reco::Candidate, reco::RecoChargedCandidateRef>" />
   <class name="edm::reftobase::RefHolder<reco::RecoChargedCandidateRef>" />

--- a/DataFormats/TrackCandidate/src/classes_def.xml
+++ b/DataFormats/TrackCandidate/src/classes_def.xml
@@ -11,7 +11,6 @@
   <class name="edm::AssociationMap<edm::OneToOne<std::vector<TrackCandidate>, std::vector<TrajectorySeed>, unsigned int > >" >
     <field name="transientMap_" transient="true" />
   </class>
-  <class pattern="edm::KeyVal<*>" />
   <class pattern="edm::Wrapper<edm::AssociationMap<*>" />
   <class pattern="edm::Ref<edm::AssociationMap<*>" />
   <class pattern="edm::RefProd<edm::AssociationMap<*>" />

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -374,11 +374,7 @@
   <class name="edm::Ptr<reco::Track>" />
   <class name="std::vector<edm::Ptr<reco::Track> >" />
 
-  <class pattern="edm::KeyVal<*>" />
   <class pattern="edm::Wrapper<edm::AssociationMap<*>" />
-  <class pattern="edm::Ref<edm::AssociationMap<*>" />
-  <class pattern="edm::RefProd<edm::AssociationMap<*>" />
-  <class pattern="edm::RefVector<edm::AssociationMap<*>" />
 
   <class name="edm::helpers::Key<edm::RefProd <std::vector <reco::Track> > >" />
 

--- a/TrackingTools/PatternTools/src/classes_def.xml
+++ b/TrackingTools/PatternTools/src/classes_def.xml
@@ -25,8 +25,6 @@
     <field name="transientMap_" transient="true"/>
   </class>
 
-  <class pattern="edm::KeyVal<*>"/>
-
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<std::vector<Trajectory>,std::vector<reco::Track>,unsigned short> > >" persistent="false" />
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::TrackCollection,std::vector<MomentumConstraint>,unsigned int> > >" />
   <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::TrackCollection,std::vector<VertexConstraint>,unsigned int> > >"/>


### PR DESCRIPTION
`edm::KeyVal` never existed, it was `edm::helpers::KeyVal`. As these
never were selected -- remove. Enabling them in 6 packages with a
corrected name would create duplicate types in dictionaries.

The following types:
- `edm::RefVector<edm::AssociationMap*`
- `edm::RefProd<edm::AssociationMap*`
- `edm::Ref<edm::AssociationMap*`

do not exist in `DataFormats/RecoCandidate` and `DataFormats/TrackReco`
dictionary translation units. Similar rules exist in
`DataFormats/TrackCandidate`, but in this package `genreflex` does select
them.

Due to regression in ROOT6 `genreflex` these warnings are temporarely
non fatal. CMS makes `genreflex` to fail on any warning by default. This
is already fixed in ROOT6 master branch.

Would be happy if a second pair of eyes would double check.

@wmtan 

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
