### PR TITLE
SimDataFormats/TrackingAnalysis: unused selection rules cleanup

### DIFF
--- a/SimDataFormats/TrackingAnalysis/src/classes_def.xml
+++ b/SimDataFormats/TrackingAnalysis/src/classes_def.xml
@@ -8,8 +8,6 @@
   <class name="edm::Wrapper<std::vector<TrackingVertex> >" />
   <class name="TrackingVertexRef" />
   <class name="TrackingVertexRefVector" />
-  <class pattern="edm::Ref<std::vector<TrackingVertex>,*>" />
-  <class pattern="edm::RefVector<std::vector<TrackingVertex>,*>" />
   <class name="edm::RefProd<std::vector<TrackingVertex> >" />
 
   <class name="TrackingParticle" ClassVersion="11">
@@ -18,15 +16,10 @@
   </class>
   <class name="std::vector<TrackingParticle>" />
   <class name="edm::Wrapper<std::vector<TrackingParticle> >" />
-  <class pattern="edm::Ref<std::vector<TrackingParticle>,*>" />
-  <class pattern="edm::RefVector<std::vector<TrackingParticle>,*>" />
   <class name="edm::RefProd<std::vector<TrackingParticle> >" />
   <class name="TrackingParticleRef" />
   <class name="TrackingParticleRefVector" />
-
-  <class pattern="edm::Ref< std::vector<HepMC::GenVertex>,*>" />
-  <class pattern="edm::RefVector< std::vector<HepMC::GenVertex>,*>" />
-
+  <class name="edm::Wrapper<TrackingParticleRefVector>"/>
  
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track> >" />
   <class name="edm::helpers::KeyVal<edm::RefToBaseProd<reco::Track>,edm::RefProd<std::vector<TrackingParticle> > >" />
@@ -38,7 +31,4 @@
 
   <class name="std::vector<std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double> >" />
   <class name="std::pair<edm::Ref<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >,double>" />
-
-  <class pattern="edm::Wrapper<edm::RefVector<std::vector<TrackingParticle>,*> >" />
-
 </lcgdict>


### PR DESCRIPTION
There are no `HepMC::GenVertex` type in dictionary, thus the following
two rules matches nothing:
- `edm::RefVector< std::vector<HepMC::GenVertex>,*>`
- `edm::Ref< std::vector<HepMC::GenVertex>,*>`

The following two patterns:
- `edm::Ref<std::vector<TrackingParticle>,*>`
- `edm::RefVector<std::vector<TrackingParticle>,*>`

have exact types already specified in other selection rules:
- `TrackingParticleRef`
- `TrackingParticleRefVector`

The following two patterns:
- `edm::Ref<std::vector<TrackingVertex>,*>`
- `edm::RefVector<std::vector<TrackingVertex>,*>`

have exact types already specified in other selection rules:
- `TrackingVertexRef`
- `TrackingVertexRefVector`

The following rule:

```
edm::Wrapper<edm::RefVector<std::vector<TrackingParticle>,*> >
```

as matching a class in ROOT5, but not in ROOT6. The pattern rule was
changed to specific class selection rule:

```
edm::Wrapper<edm::RefVector<std::vector<TrackingParticle>,
TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<
TrackingParticle>,TrackingParticle> > >
```

to get it selected in ROOT5 and ROOT6.

Simply put, no changes on ROOT5 dictionary, but ROOT6 gained a lost
type. Capabilities file difference on ROOT6 after modification:

```
--- seal_cap.cc.orig    2015-06-08 13:57:15.647872453 +0200
+++ tmp/slc6_amd64_gcc491/src/SimDataFormats/TrackingAnalysis/src/SimDataFormatsTrackingAnalysis/a/seal_cap.cc  2015-06-08 13:57:51.402169047 +0200
@@ -25,6 +25,8 @@
  "LCGReflex/edm::Ref<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> >",
  "LCGReflex/edm::RefVector<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> >",
  "LCGReflex/edm::RefVector<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> >",
+ "LCGReflex/edm::Wrapper<edm::RefVector<std::vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<std::vector<TrackingParticle>,TrackingParticle> > >",
+ "LCGReflex/edm::Wrapper<edm::RefVector<vector<TrackingParticle>,TrackingParticle,edm::refhelper::FindUsingAdvance<vector<TrackingParticle>,TrackingParticle> > >",
  "LCGReflex/edm::helpers::KeyVal<edm::RefProd<std::vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track> >",
  "LCGReflex/edm::helpers::KeyVal<edm::RefProd<vector<TrackingParticle> >,edm::RefToBaseProd<reco::Track> >",
  "LCGReflex/edm::helpers::KeyVal<edm::RefToBaseProd<reco::Track>,edm::RefProd<std::vector<TrackingParticle> > >",
```

Two lines added, but both are the same type. Due to ROOT5 compatibility ROOT6 adds `std::vector` and `vector` (no `std` namespace).
Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
