### PR TITLE
SimDataFormats/Vertex: clean unused pattern-based selection rules

### DIFF
--- a/SimDataFormats/Vertex/src/classes_def.xml
+++ b/SimDataFormats/Vertex/src/classes_def.xml
@@ -7,9 +7,9 @@
    <version ClassVersion="11" checksum="801220081"/>
    <version ClassVersion="12" checksum="802888023"/>
   </class>
-  <class pattern="edm::Ref<std::vector<SimVertex>,*>" />
+  <class name="edm::SimVertexRef"/>
   <class name="std::vector<const SimVertex*>"/>
-  <class pattern="edm::RefVector<std::vector<SimVertex>,*>" />
+  <class name="edm::SimVertexRefVector"/>
   <class name="edm::RefProd<std::vector<SimVertex> >" /> 
   <class name="edm::Wrapper<std::vector<SimVertex> >" id="03CAAC2E-3EE1-ACA3-D11B-775772E05B18"/>
 </lcgdict>


### PR DESCRIPTION
The following two types:
- `edm::Ref<std::vector<SimVertex>,*>`
- `edm::RefVector<std::vector<SimVertex>,*>`

are unused by ROOT6, but ROOT5 manages to selected classes with them.

The actual types selected are:
- `edm::SimVertexRef`
- `edm::SimVertexRefVector`

which are already listed in `classes.h` file.

The patch will bring back the missing types to ROOT6 dictionary and
change is ROOT5 compatible.

The difference in ROOT6 dictionary after modification:

```
--- seal_cap.cc.orig    2015-06-08 14:51:16.992555582 +0200
+++ tmp/slc6_amd64_gcc491/src/SimDataFormats/Vertex/src/SimDataFormatsVertex/a/seal_cap.cc      2015-06-08 14:53:26.006608002 +0200
@@ -3,8 +3,12 @@
  "LCGReflex/vector<SimVertex>",
  "LCGReflex/CoreSimVertex",
  "LCGReflex/SimVertex",
+ "LCGReflex/edm::Ref<std::vector<SimVertex>,SimVertex,edm::refhelper::FindUsingAdvance<std::vector<SimVertex>,SimVertex> >",
+ "LCGReflex/edm::Ref<vector<SimVertex>,SimVertex,edm::refhelper::FindUsingAdvance<vector<SimVertex>,SimVertex> >",
  "LCGReflex/std::vector<const SimVertex*>",
  "LCGReflex/vector<const SimVertex*>",
+ "LCGReflex/edm::RefVector<std::vector<SimVertex>,SimVertex,edm::refhelper::FindUsingAdvance<std::vector<SimVertex>,SimVertex> >",
+ "LCGReflex/edm::RefVector<vector<SimVertex>,SimVertex,edm::refhelper::FindUsingAdvance<vector<SimVertex>,SimVertex> >",
  "LCGReflex/edm::RefProd<std::vector<SimVertex> >",
  "LCGReflex/edm::RefProd<vector<SimVertex> >",
  "LCGReflex/edm::Wrapper<std::vector<SimVertex> >",
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
