### PR TITLE
move AdaptorConfig EDM Plugin out of Capabilities

### DIFF
--- a/IOPool/TFileAdaptor/plugins/BuildFile.xml
+++ b/IOPool/TFileAdaptor/plugins/BuildFile.xml
@@ -1,0 +1,1 @@
+<use name="IOPool/TFileAdaptor"/>

--- a/IOPool/TFileAdaptor/plugins/module.cc
+++ b/IOPool/TFileAdaptor/plugins/module.cc
@@ -1,0 +1,6 @@
+#include "IOPool/TFileAdaptor/src/TFileAdaptor.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
+
+typedef TFileAdaptor AdaptorConfig;
+
+DEFINE_FWK_SERVICE(AdaptorConfig);

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -6,7 +6,6 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
 #include "Utilities/StorageFactory/interface/StorageFactory.h"
@@ -272,7 +271,3 @@ TFileAdaptorUI::~TFileAdaptorUI() {}
 void TFileAdaptorUI::stats() const {
   me->stats(std::cout); std::cout << std::endl;
 }
-
-typedef TFileAdaptor AdaptorConfig;
-
-DEFINE_FWK_SERVICE(AdaptorConfig);


### PR DESCRIPTION
This is needed to drop Capabilities Plugins in Root6
