### PR TITLE
move TrackTSelectorAnalyzer EDM Plugin out of Capabilities

### DIFF
--- a/PhysicsTools/ParallelAnalysis/plugins/BuildFile.xml
+++ b/PhysicsTools/ParallelAnalysis/plugins/BuildFile.xml
@@ -1,0 +1,1 @@
+<use name="PhysicsTools/ParallelAnalysis"/>

--- a/PhysicsTools/ParallelAnalysis/plugins/SealModule.cc
+++ b/PhysicsTools/ParallelAnalysis/plugins/SealModule.cc
@@ -1,4 +1,3 @@
-#include "FWCore/PluginManager/interface/ModuleDef.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "PhysicsTools/ParallelAnalysis/interface/TSelectorAnalyzer.h"
 #include "PhysicsTools/ParallelAnalysis/interface/TrackAnalysisAlgorithm.h"


### PR DESCRIPTION
This is needed to drop Capabilities Plugins in Root6
