### PR TITLE
TrackingTools/TrajectoryState: clean up selection rules

### DIFF
--- a/TrackingTools/TrajectoryState/src/classes_def.xml
+++ b/TrackingTools/TrajectoryState/src/classes_def.xml
@@ -1,21 +1,8 @@
 <lcgdict>
-  <!-- not needed
-  <class name="TrackParamConstraint"/>
-  -->
-
   <!-- persistent="false" qualifier for non-wrappers is deprecated. Will be removed when no longer needed.-->
   <class name="std::vector<TrackParamConstraint>" persistent="false"/>
   <class name="edm::Wrapper<std::vector<TrackParamConstraint> >" persistent="false"/>
-
-  <!-- not needed
-  <class name="edm::RefProd<std::vector<TrackParamConstraint> >"/>
-  -->
-
   <class name="edm::AssociationMap<edm::OneToOne<reco::TrackCollection,std::vector<TrackParamConstraint>, unsigned int> >" >
     <field name="transientMap_" transient="true" />
   </class>
-
-  <!-- not needed
-  <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<TrackParamConstraint> > >"/>
-  -->
 </lcgdict>

--- a/TrackingTools/TrajectoryState/src/classes_def.xml
+++ b/TrackingTools/TrajectoryState/src/classes_def.xml
@@ -18,6 +18,4 @@
   <!-- not needed
   <class name="edm::helpers::KeyVal<edm::RefProd<std::vector<reco::Track> >,edm::RefProd<std::vector<TrackParamConstraint> > >"/>
   -->
-
-  <class name="edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::TrackCollection,std::vector<TrackParamConstraint> > >"  persistent="false" />
 </lcgdict>


### PR DESCRIPTION
Remove old and commented out selection rules. In addition to that resolve ROOT 6.04.00 warning:

```
Warning - unused class rule: edm::Wrapper<edm::AssociationMap<edm::OneToOne<reco::TrackCollection,std::vector<TrackParamConstraint> > >
```

The dictionary is not changed for ROOT5 and ROOT6.

Review.
