### PR TITLE
DataFormats/Math: remove unused selection rules

### DIFF
--- a/DataFormats/Math/src/classes_def.xml
+++ b/DataFormats/Math/src/classes_def.xml
@@ -5,7 +5,6 @@
   <class pattern="ROOT::Math::PxPyPzE4D<*>" />
   <class pattern="ROOT::Math::Cartesian3D<*>" />
   <class pattern="ROOT::Math::CylindricalEta3D<*>" />
-  <class pattern="ROOT::Math::Polar3D<*>" />
   <class pattern="ROOT::Math::LorentzVector<*>" />
   <class pattern="ROOT::Math::DisplacementVector3D<*>" />
   <class pattern="ROOT::Math::PositionVector3D<*>" />


### PR DESCRIPTION
`ROOT::Math::Polar3D<*>` is not available in the translation unit, thus
there is nothing to select into dictionary.

Tested on ROOT5 and ROOT6. Removing does not modify the types in
dictionary.

Resolves:

```
Warning - unused class rule: ROOT::Math::Polar3D<*>
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
