### PR TITLE
CondFormats/Alignment: remove unused selection rules

### DIFF
--- a/CondFormats/Alignment/src/classes_def.xml
+++ b/CondFormats/Alignment/src/classes_def.xml
@@ -2,7 +2,6 @@
  <class name="Alignments" id="2F16F0A9-79D5-4881-CE0B-C271DD84A7F3"/>
  <class name="AlignTransform"/>
  <class name="std::vector<AlignTransform>"/>
- <class name="uint32_t"/>
 
  <class name="AlignmentErrors"/>
  <class name="AlignmentErrorsExtended"/>


### PR DESCRIPTION
The `int32_t` is not selecting anything in ROOT5 and ROOT6.

No changes to types in dictionaries found after removing on ROOT5 and
ROOT6.

Resolves:

```
Warning - unused class rule: uint32_t
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
