### PR TITLE
Fixing AlCaRecoTriggerBits reading/writing for condDBv2 

### DIFF
--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdRead_cfg.py
@@ -28,8 +28,9 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(250000) )
 
 # Input for AlCaRecoTriggerBitsRcd,
 # either via GloblalTag (use of _cfi instead of _cff sufficient and faster):
+from Configuration.AlCa.autoCond import autoCond
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
-process.GlobalTag.globaltag = "GR09_P_V8_34X::All"#"DESIGN_3X_V13::All" #choose your tag
+process.GlobalTag.globaltag = autoCond['run2_data'] #choose your tag
 
 # ...or specify database and tag:  
 #import CondCore.DBCommon.CondDBSetup_cfi

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
@@ -69,7 +69,7 @@ process.dbInput = cms.ESSource(
     "PoolDBESSource",
     CondCore.DBCommon.CondDBSetup_cfi.CondDBSetup,
 #    connect = cms.string('sqlite_file:AlCaRecoTriggerBits.db'),
-    connect = cms.string('frontier://FrontierProd/CMS_COND_31X_HLT'),
+    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('AlCaRecoTriggerBitsRcd'),
 #        tag = cms.string('TestTag') # choose tag to update

--- a/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
+++ b/CondTools/HLT/test/AlCaRecoTriggerBitsRcdUpdate_cfg.py
@@ -73,7 +73,7 @@ process.dbInput = cms.ESSource(
     toGet = cms.VPSet(cms.PSet(
         record = cms.string('AlCaRecoTriggerBitsRcd'),
 #        tag = cms.string('TestTag') # choose tag to update
-        tag = cms.string('AlCaRecoHLTpaths_Christmas09_offline')
+        tag = cms.string('AlCaRecoHLTpaths8e29_1e31_v7_hlt')
         )
                       )
     )


### PR DESCRIPTION
Title says it all. No need here to change `Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi`, since it's already pointing to condDBv2 by default.
