### PR TITLE
DataFormats/Candidate: remove duplicate selection rule

### DIFF
--- a/DataFormats/Candidate/src/classes_def.xml
+++ b/DataFormats/Candidate/src/classes_def.xml
@@ -122,7 +122,6 @@
   <class name="edm::reftobase::RefHolder<reco::CandidateRef>"/>
   <class name="edm::reftobase::RefHolder<reco::CandidatePtr>"/>
 
-  <class name="edm::RefToBase<reco::Candidate>" />
   <class name="std::vector<edm::RefToBase<reco::Candidate> >" />
   <class name="std::vector<edm::Ptr<reco::Candidate> >" />
   <class name="std::vector<edm::PtrVector<reco::Candidate> >" />


### PR DESCRIPTION
The following warning is produced by ROOT 6.04.00+:

```
Warning: Selection file classes_def.xml, lines 159 and 115. Attempt to
select with a named selection rule an already selected class. The name
used in the selection is "reco::CandidateBaseRef" while the class is
"edm::RefToBase<reco::Candidate>".
```

Note that lines are wrong. Actual lines are 169 and 125 (offset by 10).

```
125   <class name="edm::RefToBase<reco::Candidate>" />
..
169   <class name="reco::CandidateBaseRef" />
```

Looking at CMSSW code:

```
DataFormats/Candidate/interface/CandidateFwd.h:
typedef edm::RefToBase<Candidate> CandidateBaseRef;
```

The patch removes duplicate selection rule.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
