### PR TITLE
Fixes to vertex validation

### DIFF
--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -998,20 +998,22 @@ PrimaryVertexAnalyzer4PUSlimmed::getSimPVs(
   }  // End of for summary on discovered simulated primary vertices.
 
   // Now compute the closest distance in z between all simulated vertex
+  // first initialize
+  auto prev_z = simpv.back().z;
+  for(simPrimaryVertex& vsim: simpv) {
+    vsim.closest_vertex_distance_z = std::abs(vsim.z - prev_z);
+    prev_z = vsim.z;
+  }
+  // then calculate
   for (std::vector<simPrimaryVertex>::iterator vsim = simpv.begin();
        vsim != simpv.end(); vsim++) {
     std::vector<simPrimaryVertex>::iterator vsim2 = vsim;
     vsim2++;
     for (; vsim2 != simpv.end(); vsim2++) {
-      double distance_z = fabs(vsim->z - vsim2->z);
-      // Initialize with the next-sibling in the vector: minimization
-      // is performed by the next if.
-      if (vsim->closest_vertex_distance_z < 0) {
-        vsim->closest_vertex_distance_z = distance_z;
-        continue;
-      }
-      if (distance_z < vsim->closest_vertex_distance_z)
-        vsim->closest_vertex_distance_z = distance_z;
+      double distance = std::abs(vsim->z - vsim2->z);
+      // need both to be complete
+      vsim->closest_vertex_distance_z = std::min(vsim->closest_vertex_distance_z, distance);
+      vsim2->closest_vertex_distance_z = std::min(vsim2->closest_vertex_distance_z, distance);
     }
   }
   return simpv;
@@ -1080,20 +1082,21 @@ PrimaryVertexAnalyzer4PUSlimmed::getRecoPVs(
   }  // End of for summary on reconstructed primary vertices.
 
   // Now compute the closest distance in z between all reconstructed vertex
+  // first initialize
+  auto prev_z = recopv.back().z;
+  for(recoPrimaryVertex& vreco: recopv) {
+    vreco.closest_vertex_distance_z = std::abs(vreco.z - prev_z);
+    prev_z = vreco.z;
+  }
   for (std::vector<recoPrimaryVertex>::iterator vreco = recopv.begin();
        vreco != recopv.end(); vreco++) {
     std::vector<recoPrimaryVertex>::iterator vreco2 = vreco;
     vreco2++;
     for (; vreco2 != recopv.end(); vreco2++) {
-      double distance_z = fabs(vreco->z - vreco2->z);
-      // Initialize with the next-sibling in the vector: minimization
-      // is performed by the next if.
-      if (vreco->closest_vertex_distance_z < 0) {
-        vreco->closest_vertex_distance_z = distance_z;
-        continue;
-      }
-      if (distance_z < vreco->closest_vertex_distance_z)
-        vreco->closest_vertex_distance_z = distance_z;
+      double distance = std::abs(vreco->z - vreco2->z);
+      // need both to be complete
+      vreco->closest_vertex_distance_z = std::min(vreco->closest_vertex_distance_z, distance);
+      vreco2->closest_vertex_distance_z = std::min(vreco2->closest_vertex_distance_z, distance);
     }
   }
   return recopv;

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -1102,8 +1102,6 @@ PrimaryVertexAnalyzer4PUSlimmed::getRecoPVs(
 void PrimaryVertexAnalyzer4PUSlimmed::resetSimPVAssociation(
     std::vector<simPrimaryVertex> & simpv) {
   for (auto & v : simpv) {
-    v.num_matched_reco_tracks = 0;
-    v.average_match_quality = 0;
     v.rec_vertices.clear();
   }
 }

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -997,6 +997,10 @@ PrimaryVertexAnalyzer4PUSlimmed::getSimPVs(
     std::cout << "-----------------------------------------------" << std::endl;
   }  // End of for summary on discovered simulated primary vertices.
 
+  // In case of no simulated vertices, break here
+  if(simpv.empty())
+    return simpv;
+
   // Now compute the closest distance in z between all simulated vertex
   // first initialize
   auto prev_z = simpv.back().z;
@@ -1080,6 +1084,10 @@ PrimaryVertexAnalyzer4PUSlimmed::getRecoPVs(
     }
     std::cout << "-----------------------------------------------" << std::endl;
   }  // End of for summary on reconstructed primary vertices.
+
+  // In case of no reco vertices, break here
+  if(recopv.empty())
+    return recopv;
 
   // Now compute the closest distance in z between all reconstructed vertex
   // first initialize

--- a/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
+++ b/Validation/RecoVertex/src/PrimaryVertexAnalyzer4PUSlimmed.cc
@@ -734,25 +734,17 @@ void PrimaryVertexAnalyzer4PUSlimmed::fillResolutionAndPullHistograms(
     PrimaryVertexAnalyzer4PUSlimmed::recoPrimaryVertex& v) {
 
   std::string prefix = "RecoAllAssoc2GenMatched";
-  const simPrimaryVertex *bestMatch = v.sim_vertices_internal[0];
   if(v.sim_vertices_internal.size() > 1) {
-
     prefix += "Merged";
-    // Pick the sim-vertex with largest number of tracks associated to
-    // reco-tracks as the best match
-    auto bestVtx = std::max_element(v.sim_vertices_internal.begin(),
-                                    v.sim_vertices_internal.end(),
-                                    [](const simPrimaryVertex *a, const simPrimaryVertex *b) {
-                                      return a->num_matched_reco_tracks < b->num_matched_reco_tracks;
-                                    });
-    bestMatch = *bestVtx;
   }
 
-
-  const double xres = v.x - bestMatch->x;
-  const double yres = v.y - bestMatch->y;
-  const double zres = v.z - bestMatch->z;
-  const double pt2res = v.ptsq - bestMatch->ptsq;
+  // Use the best match as defined by the vertex truth associator
+  // reco-tracks as the best match
+  const simPrimaryVertex& bestMatch = *(v.sim_vertices_internal[0]);
+  const double xres = v.x - bestMatch.x;
+  const double yres = v.y - bestMatch.y;
+  const double zres = v.z - bestMatch.z;
+  const double pt2res = v.ptsq - bestMatch.ptsq;
 
   const double xresol = xres;
   const double yresol = yres;
@@ -1164,12 +1156,6 @@ void PrimaryVertexAnalyzer4PUSlimmed::matchReco2SimVertices(
         const auto tvPtr = &(*(vertexRefQuality.first));
         vrec->sim_vertices.push_back(tvPtr);
       }
-
-      // TODO: sort the matched sim vertices by eventId to keep old
-      // behaviour for now, to be removed later
-      std::sort(vrec->sim_vertices.begin(), vrec->sim_vertices.end(), [](const TrackingVertex *a, const TrackingVertex *b) {
-          return a->eventId().event() < b->eventId().event();
-        });
 
       for(const TrackingVertex *tv: vrec->sim_vertices) {
         // Set pointers to internal simVertex objects


### PR DESCRIPTION
This PR contains the following fixes to vertex validation:
1. Whenever a sim/reco vertex is matched to multiple reco/sim vertices, use the best match as defined by the associator (currently the one with largest number of shared tracks)
   - Old behaviour was to pick the one with smallest event ID
2. Do not reset `num_matched_reco_tracks` and `average_match_quality` members of `simPrimaryVertex` when switching reco vertex collections, since these two do not depend on sim-reco vertex association
3. Fix calculation of z distance to closest vertex (for both reco and sim vertices)

Tested in CMSSW_7_5_X_2015-06-06-2300, following differences in the histograms are expected (examples from 1000 TTbar+25ns PU events; black is old and red is new):
- Small changes in all `*MatchedMerged_*` histograms (caused by 1.), e.g.
  ![image](https://cloud.githubusercontent.com/assets/33993/8054525/a661a1a4-0e99-11e5-84c2-f21408d665c1.png)
- Smal.l changes in all `*MultiMatchedGen_*` histograms (caused by 1.), e.g.
  ![image](https://cloud.githubusercontent.com/assets/33993/8054659/a82509ee-0e9a-11e5-931a-b9e83f9fe3f0.png)
  and therefore in duplicate rates, e.g.
  ![image](https://cloud.githubusercontent.com/assets/33993/8054717/ec1abe6e-0e9a-11e5-94a6-e4cd59c9cae7.png)
- `*_SharedTrackFractionSimMatched` histograms get filled (caused by 2.), e.g.
  ![image](https://cloud.githubusercontent.com/assets/33993/8054586/25357f1e-0e9a-11e5-911b-8ee390801508.png)
- Values of `*_ClosestDistanceZ` decrease (caused by 3.), e.g.
  ![image](https://cloud.githubusercontent.com/assets/33993/8052946/84e29cca-0e8c-11e5-9409-b962b82b6948.png)

@rovere @VinInn 
