### PR TITLE
Reduce MultiTrackValidator memory use

### DIFF
--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgo.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgo.h
@@ -54,6 +54,8 @@ class MTVHistoProducerAlgo{
 						   const reco::Track* track,
 						   int numVertices)=0;
 
+  virtual void fill_simTrackBased_histos(int count, int numSimTracks) = 0;
+
   virtual void fill_generic_recoTrack_histos(int count,
 				     	     const reco::Track& track,
 				     	     const math::XYZPoint& bsPosition,

--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -54,6 +54,8 @@ class MTVHistoProducerAlgoForTracker: public MTVHistoProducerAlgo {
 					   const reco::Track* track,
 					   int numVertices);
 
+  void fill_simTrackBased_histos(int count, int numSimTracks);
+
 
   void fill_generic_recoTrack_histos(int count,
 				     const reco::Track& track,

--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -132,6 +132,7 @@ class MTVHistoProducerAlgoForTracker: public MTVHistoProducerAlgo {
   double minChi2, maxChi2; int nintChi2;
   double minDeDx, maxDeDx;  int nintDeDx;
   double minVertcount, maxVertcount;  int nintVertcount;
+  double minTracks, maxTracks; int nintTracks;
 
   //
   double ptRes_rangeMin,ptRes_rangeMax; int ptRes_nbin;

--- a/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
+++ b/Validation/RecoTrack/interface/MTVHistoProducerAlgoForTracker.h
@@ -206,9 +206,6 @@ class MTVHistoProducerAlgoForTracker: public MTVHistoProducerAlgo {
 
   //chi2 and # lost hits vs eta: to be used with doProfileX
   std::vector<MonitorElement*> chi2_vs_eta, nlosthits_vs_eta;
-  std::vector<MonitorElement*> h_chi2meanh, h_losthits_eta;
-  std::vector<MonitorElement*> h_hits_phi;
-  std::vector<MonitorElement*> h_chi2meanhitsh, h_chi2mean_vs_phi;
 
   //resolution of track params: to be used with fitslicesytool
   std::vector<MonitorElement*> dxyres_vs_eta, ptres_vs_eta, dzres_vs_eta, phires_vs_eta, cotThetares_vs_eta;

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -464,7 +464,10 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 	  }
 	//---------- THE PART ABOVE HAS TO BE CLEANED UP. THE PARAMETER DEFINER WAS NOT MEANT TO BE USED IN THIS WAY ----------
 
-	st++;   //This counter counts the number of simulated tracks passing the MTV selection (i.e. tpSelector(tp) )
+        //This counter counts the number of simulated tracks passing the MTV selection (i.e. tpSelector(tp) ), but only for in-time TPs
+        if(tp.eventId().bunchCrossing() == 0) {
+          st++;
+        }
 
 	// in the coming lines, histos are filled using as input
 	// - momentumTP

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -522,7 +522,9 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
       } // End  for (TrackingParticleCollection::size_type i=0; i<tPCeff.size(); i++){
 
-      //if (st!=0) h_tracksSIM[w]->Fill(st);  // TO BE FIXED
+      if(doSimPlots_) {
+        histoProducerAlgo_->fill_simTrackBased_histos(w, st);
+      }
 
 
       // ##############################################

--- a/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidatorGenPs.cc
@@ -280,7 +280,9 @@ void MultiTrackValidatorGenPs::analyze(const edm::Event& event, const edm::Event
       
     } // End  for (GenParticleCollection::size_type i=0; i<tPCeff.size(); i++){
     
-      //if (st!=0) h_tracksSIM[w]->Fill(st);  // TO BE FIXED
+    if(doSimPlots_) {
+      histoProducerAlgo_->fill_simTrackBased_histos(w, st);
+    }
     
     
       // ##############################################

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -218,7 +218,9 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 	double dzSim = vertex.z() - (vertex.x()*momentum.x()+vertex.y()*momentum.y())/sqrt(momentum.perp2())
 	  * momentum.z()/sqrt(momentum.perp2());
 
-	st++;
+        if(tp->eventId().bunchCrossing() == 0) {
+          st++;
+        }
 
 	histoProducerAlgo_->fill_generic_simTrack_histos(w,momentumTP,vertexTP, tp->eventId().bunchCrossing());
 

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -276,6 +276,8 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 
       } // End  for (TrackingParticleCollection::size_type i=0; i<tPCeff.size(); i++){
 
+      histoProducerAlgo_->fill_simTrackBased_histos(w, st);
+
       //
       //fill reconstructed seed histograms
       //

--- a/Validation/RecoTrack/python/HLTpostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/HLTpostProcessorTracker_cfi.py
@@ -66,24 +66,5 @@ postProcessorHLTtracking = cms.EDAnalyzer("DQMGenericClient",
                              "h_thetapulleta '#theta Pull vs #eta' thetapull_vs_eta",
                              "h_thetapullphi '#theta Pull vs #phi' thetapull_vs_phi"
                              ),
-    profile= cms.untracked.vstring(
-                         "chi2mean 'mean #chi^{2} vs #eta' chi2_vs_eta",
-                         "chi2mean_vs_phi 'mean #chi^{2} vs #phi' chi2_vs_phi",
-                         "chi2mean_vs_nhits 'mean #chi^{2} vs n. hits' chi2_vs_nhits",
-                         "hits_eta 'mean #hits vs eta' nhits_vs_eta",
-                         "hits_phi 'mean #hits vs #phi' nhits_vs_phi",
-                         "losthits_eta 'mean #lost hits vs #eta' nlosthits_vs_eta",
-			 "PXBhits_eta 'mean # PXB hits vs #eta' nPXBhits_vs_eta",
-			 "PXFhits_eta 'mean # PXF hits vs #eta' nPXFhits_vs_eta",
-			 "TIBhits_eta 'mean # TIB hits vs #eta' nTIBhits_vs_eta",
-			 "TIDhits_eta 'mean # TID hits vs #eta' nTIDhits_vs_eta",
-			 "TOBhits_eta 'mean # TOB hits vs #eta' nTOBhits_vs_eta",
-			 "TEChits_eta 'mean # TEC hits vs #eta' nTEChits_vs_eta",
-			 "LayersWithMeas_eta 'mean # LayersWithMeas vs #eta' nLayersWithMeas_vs_eta",
-			 "PXLlayersWith2dMeas 'mean # PXLlayersWithMeas vs #eta' nPXLlayersWith2dMeas",
-			 "STRIPlayersWithMeas_eta 'mean # STRIPlayersWithMeas vs #eta' nSTRIPlayersWithMeas_eta",
-			 "STRIPlayersWith1dMeas_eta 'mean # STRIPlayersWith1dMeas vs #eta' nSTRIPlayersWith1dMeas_eta",
-			 "STRIPlayersWith2dMeas_eta 'mean # STRIPlayersWith2dMeas vs #eta' nSTRIPlayersWith2dMeas_eta"
-                         ),
     outputFileName = cms.untracked.string("")
 )

--- a/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
+++ b/Validation/RecoTrack/python/MTVHistoProducerAlgoForTrackerBlock_cfi.py
@@ -88,6 +88,10 @@ MTVHistoProducerAlgoForTrackerBlock = cms.PSet(
     minVertcount = cms.double(-0.5),
     maxVertcount = cms.double(160.5),
     nintVertcount = cms.int32(161),
+
+    minTracks = cms.double(0),
+    maxTracks = cms.double(2000),
+    nintTracks = cms.int32(100),
     #
     #parameters for resolution plots
     ptRes_rangeMin = cms.double(-0.1),

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -99,25 +99,6 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
                              "h_thetapulleta '#theta Pull vs #eta' thetapull_vs_eta",
                              "h_thetapullphi '#theta Pull vs #phi' thetapull_vs_phi"
                              ),
-    profile= cms.untracked.vstring(
-                         "chi2mean 'mean #chi^{2} vs #eta' chi2_vs_eta",
-                         "chi2mean_vs_phi 'mean #chi^{2} vs #phi' chi2_vs_phi",
-                         "chi2mean_vs_nhits 'mean #chi^{2} vs n. hits' chi2_vs_nhits",
-                         "hits_eta 'mean #hits vs eta' nhits_vs_eta",
-                         "hits_phi 'mean #hits vs #phi' nhits_vs_phi",
-                         "losthits_eta 'mean #lost hits vs #eta' nlosthits_vs_eta",
-			 "PXBhits_eta 'mean # PXB hits vs #eta' nPXBhits_vs_eta",
-			 "PXFhits_eta 'mean # PXF hits vs #eta' nPXFhits_vs_eta",
-			 "TIBhits_eta 'mean # TIB hits vs #eta' nTIBhits_vs_eta",
-			 "TIDhits_eta 'mean # TID hits vs #eta' nTIDhits_vs_eta",
-			 "TOBhits_eta 'mean # TOB hits vs #eta' nTOBhits_vs_eta",
-			 "TEChits_eta 'mean # TEC hits vs #eta' nTEChits_vs_eta",
-			 "LayersWithMeas_eta 'mean # LayersWithMeas vs #eta' nLayersWithMeas_vs_eta",
-			 "PXLlayersWith2dMeas 'mean # PXLlayersWithMeas vs #eta' nPXLlayersWith2dMeas",
-			 "STRIPlayersWithMeas_eta 'mean # STRIPlayersWithMeas vs #eta' nSTRIPlayersWithMeas_eta",
-			 "STRIPlayersWith1dMeas_eta 'mean # STRIPlayersWith1dMeas vs #eta' nSTRIPlayersWith1dMeas_eta",
-			 "STRIPlayersWith2dMeas_eta 'mean # STRIPlayersWith2dMeas vs #eta' nSTRIPlayersWith2dMeas_eta"
-                         ),
     outputFileName = cms.untracked.string("")
 )
 

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -174,11 +174,15 @@ MTVHistoProducerAlgoForTracker::~MTVHistoProducerAlgoForTracker(){
 }
 
 void MTVHistoProducerAlgoForTracker::bookSimHistos(DQMStore::IBooker& ibook){
-  h_ptSIM.push_back( ibook.book1D("ptSIM", "generated p_{t}", 5500, 0, 110 ) );
-  h_etaSIM.push_back( ibook.book1D("etaSIM", "generated pseudorapidity", 500, -2.5, 2.5 ) );
+  h_ptSIM.push_back( ibook.book1D("ptSIM", "generated p_{t}", nintPt, minPt, maxPt) );
+  h_etaSIM.push_back( ibook.book1D("etaSIM", "generated pseudorapidity", nintEta, minEta, maxEta) );
   h_tracksSIM.push_back( ibook.book1D("tracksSIM","number of simulated tracks",200,-0.5,99.5) );
-  h_vertposSIM.push_back( ibook.book1D("vertposSIM","Transverse position of sim vertices",100,0.,120.) );
+  h_vertposSIM.push_back( ibook.book1D("vertposSIM","Transverse position of sim vertices", nintVertpos, minVertpos, maxVertpos) );
   h_bunchxSIM.push_back( ibook.book1D("bunchxSIM", "bunch crossing", 22, -5, 5 ) );
+
+  if(useLogPt) {
+    BinLogX(h_ptSIM.back()->getTH1F());
+  }
 }
 
 void MTVHistoProducerAlgoForTracker::bookSimTrackHistos(DQMStore::IBooker& ibook){

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -176,9 +176,9 @@ MTVHistoProducerAlgoForTracker::~MTVHistoProducerAlgoForTracker(){
 void MTVHistoProducerAlgoForTracker::bookSimHistos(DQMStore::IBooker& ibook){
   h_ptSIM.push_back( ibook.book1D("ptSIM", "generated p_{t}", nintPt, minPt, maxPt) );
   h_etaSIM.push_back( ibook.book1D("etaSIM", "generated pseudorapidity", nintEta, minEta, maxEta) );
-  h_tracksSIM.push_back( ibook.book1D("tracksSIM","number of simulated tracks",200,-0.5,99.5) );
+  h_tracksSIM.push_back( ibook.book1D("tracksSIM","number of simulated tracks",100,-0.5,99.5) );
   h_vertposSIM.push_back( ibook.book1D("vertposSIM","Transverse position of sim vertices", nintVertpos, minVertpos, maxVertpos) );
-  h_bunchxSIM.push_back( ibook.book1D("bunchxSIM", "bunch crossing", 22, -5, 5 ) );
+  h_bunchxSIM.push_back( ibook.book1D("bunchxSIM", "bunch crossing", 21, -15.5, 5.5 ) );
 
   if(useLogPt) {
     BinLogX(h_ptSIM.back()->getTH1F());
@@ -241,8 +241,8 @@ void MTVHistoProducerAlgoForTracker::bookSimTrackHistos(DQMStore::IBooker& ibook
 }
 
 void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
-  h_tracks.push_back( ibook.book1D("tracks","number of reconstructed tracks",401,-0.5,400.5) );
-  h_fakes.push_back( ibook.book1D("fakes","number of fake reco tracks",101,-0.5,100.5) );
+  h_tracks.push_back( ibook.book1D("tracks","number of reconstructed tracks", 100, 0, 2000) );
+  h_fakes.push_back( ibook.book1D("fakes","number of fake reco tracks", 100, 0, 2000) );
   h_charge.push_back( ibook.book1D("charge","charge",3,-1.5,1.5) );
 
   h_hits.push_back( ibook.book1D("hits", "number of hits per track", nintHit,minHit,maxHit ) );

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -87,6 +87,11 @@ MTVHistoProducerAlgoForTracker::MTVHistoProducerAlgoForTracker(const edm::Parame
   maxVertcount  = pset.getParameter<double>("maxVertcount");
   nintVertcount = pset.getParameter<int>("nintVertcount");
 
+  //parameters for number of tracks plots
+  minTracks  = pset.getParameter<double>("minTracks");
+  maxTracks  = pset.getParameter<double>("maxTracks");
+  nintTracks = pset.getParameter<int>("nintTracks");
+
   //parameters for resolution plots
   ptRes_rangeMin = pset.getParameter<double>("ptRes_rangeMin");
   ptRes_rangeMax = pset.getParameter<double>("ptRes_rangeMax");
@@ -176,7 +181,7 @@ MTVHistoProducerAlgoForTracker::~MTVHistoProducerAlgoForTracker(){
 void MTVHistoProducerAlgoForTracker::bookSimHistos(DQMStore::IBooker& ibook){
   h_ptSIM.push_back( ibook.book1D("ptSIM", "generated p_{t}", nintPt, minPt, maxPt) );
   h_etaSIM.push_back( ibook.book1D("etaSIM", "generated pseudorapidity", nintEta, minEta, maxEta) );
-  h_tracksSIM.push_back( ibook.book1D("tracksSIM","number of simulated tracks",100,-0.5,99.5) );
+  h_tracksSIM.push_back( ibook.book1D("tracksSIM","number of simulated tracks", nintTracks, minTracks, maxTracks) );
   h_vertposSIM.push_back( ibook.book1D("vertposSIM","Transverse position of sim vertices", nintVertpos, minVertpos, maxVertpos) );
   h_bunchxSIM.push_back( ibook.book1D("bunchxSIM", "bunch crossing", 21, -15.5, 5.5 ) );
 
@@ -241,8 +246,8 @@ void MTVHistoProducerAlgoForTracker::bookSimTrackHistos(DQMStore::IBooker& ibook
 }
 
 void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
-  h_tracks.push_back( ibook.book1D("tracks","number of reconstructed tracks", 100, 0, 2000) );
-  h_fakes.push_back( ibook.book1D("fakes","number of fake reco tracks", 100, 0, 2000) );
+  h_tracks.push_back( ibook.book1D("tracks","number of reconstructed tracks", nintTracks, minTracks, maxTracks) );
+  h_fakes.push_back( ibook.book1D("fakes","number of fake reco tracks", nintTracks, minTracks, maxTracks) );
   h_charge.push_back( ibook.book1D("charge","charge",3,-1.5,1.5) );
 
   h_hits.push_back( ibook.book1D("hits", "number of hits per track", nintHit,minHit,maxHit ) );
@@ -359,7 +364,7 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
   chi2_vs_nhits.push_back( ibook.bookProfile("chi2mean_vs_nhits","mean #chi^{2} vs nhits",nintHit,minHit,maxHit, 100,0,10, " ") );
 
   etares_vs_eta.push_back( ibook.book2D("etares_vs_eta","etaresidue vs eta",nintEta,minEta,maxEta,200,-0.1,0.1) );
-  nrec_vs_nsim.push_back( ibook.book2D("nrec_vs_nsim","nrec vs nsim",401,-0.5,400.5,401,-0.5,400.5) );
+  nrec_vs_nsim.push_back( ibook.book2D("nrec_vs_nsim","nrec vs nsim", nintTracks,minTracks,maxTracks, nintTracks,minTracks,maxTracks) );
 
   chi2_vs_eta.push_back( ibook.bookProfile("chi2mean","mean #chi^{2} vs #eta",nintEta,minEta,maxEta, 200, 0, 20, " " ));
   chi2_vs_phi.push_back( ibook.bookProfile("chi2mean_vs_phi","mean #chi^{2} vs #phi",nintPhi,minPhi,maxPhi, 200, 0, 20, " " ) );

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -355,36 +355,37 @@ void MTVHistoProducerAlgoForTracker::bookRecoHistos(DQMStore::IBooker& ibook){
   h_assocSharedHit.push_back(ibook.book1D("assocSharedHit","number of shared hits",41,-0.5,40.5));
   // ----------------------
 
-  chi2_vs_nhits.push_back( ibook.book2D("chi2_vs_nhits","#chi^{2} vs nhits",25,0,25,100,0,10) );
+  // use the standard error of the mean as the errors in the profile
+  chi2_vs_nhits.push_back( ibook.bookProfile("chi2mean_vs_nhits","mean #chi^{2} vs nhits",nintHit,minHit,maxHit, 100,0,10, " ") );
 
   etares_vs_eta.push_back( ibook.book2D("etares_vs_eta","etaresidue vs eta",nintEta,minEta,maxEta,200,-0.1,0.1) );
   nrec_vs_nsim.push_back( ibook.book2D("nrec_vs_nsim","nrec vs nsim",401,-0.5,400.5,401,-0.5,400.5) );
 
-  chi2_vs_eta.push_back( ibook.book2D("chi2_vs_eta","chi2_vs_eta",nintEta,minEta,maxEta, 200, 0, 20 ));
-  chi2_vs_phi.push_back( ibook.book2D("chi2_vs_phi","#chi^{2} vs #phi",nintPhi,minPhi,maxPhi, 200, 0, 20 ) );
+  chi2_vs_eta.push_back( ibook.bookProfile("chi2mean","mean #chi^{2} vs #eta",nintEta,minEta,maxEta, 200, 0, 20, " " ));
+  chi2_vs_phi.push_back( ibook.bookProfile("chi2mean_vs_phi","mean #chi^{2} vs #phi",nintPhi,minPhi,maxPhi, 200, 0, 20, " " ) );
 
-  nhits_vs_eta.push_back( ibook.book2D("nhits_vs_eta","nhits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nPXBhits_vs_eta.push_back( ibook.book2D("nPXBhits_vs_eta","# PXB its vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nPXFhits_vs_eta.push_back( ibook.book2D("nPXFhits_vs_eta","# PXF hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nTIBhits_vs_eta.push_back( ibook.book2D("nTIBhits_vs_eta","# TIB hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nTIDhits_vs_eta.push_back( ibook.book2D("nTIDhits_vs_eta","# TID hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nTOBhits_vs_eta.push_back( ibook.book2D("nTOBhits_vs_eta","# TOB hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nTEChits_vs_eta.push_back( ibook.book2D("nTEChits_vs_eta","# TEC hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
+  nhits_vs_eta.push_back( ibook.bookProfile("hits_eta","mean hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nPXBhits_vs_eta.push_back( ibook.bookProfile("PXBhits_vs_eta","mean # PXB its vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nPXFhits_vs_eta.push_back( ibook.bookProfile("PXFhits_vs_eta","mean # PXF hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nTIBhits_vs_eta.push_back( ibook.bookProfile("TIBhits_vs_eta","mean # TIB hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nTIDhits_vs_eta.push_back( ibook.bookProfile("TIDhits_vs_eta","mean # TID hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nTOBhits_vs_eta.push_back( ibook.bookProfile("TOBhits_vs_eta","mean # TOB hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nTEChits_vs_eta.push_back( ibook.bookProfile("TEChits_vs_eta","mean # TEC hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
 
-  nLayersWithMeas_vs_eta.push_back( ibook.book2D("nLayersWithMeas_vs_eta","# Layers with measurement vs eta",
-						nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nPXLlayersWithMeas_vs_eta.push_back( ibook.book2D("nPXLlayersWithMeas_vs_eta","# PXL Layers with measurement vs eta",
-						   nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nSTRIPlayersWithMeas_vs_eta.push_back( ibook.book2D("nSTRIPlayersWithMeas_vs_eta","# STRIP Layers with measurement vs eta",
-						      nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nSTRIPlayersWith1dMeas_vs_eta.push_back( ibook.book2D("nSTRIPlayersWith1dMeas_vs_eta","# STRIP Layers with 1D measurement vs eta",
-							nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
-  nSTRIPlayersWith2dMeas_vs_eta.push_back( ibook.book2D("nSTRIPlayersWith2dMeas_vs_eta","# STRIP Layers with 2D measurement vs eta",
-						       nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
+  nLayersWithMeas_vs_eta.push_back( ibook.bookProfile("LayersWithMeas_eta","mean # Layers with measurement vs eta",
+                                                      nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nPXLlayersWithMeas_vs_eta.push_back( ibook.bookProfile("PXLlayersWithMeas_vs_eta","mean # PXL Layers with measurement vs eta",
+                                                         nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nSTRIPlayersWithMeas_vs_eta.push_back( ibook.bookProfile("STRIPlayersWithMeas_vs_eta","mean # STRIP Layers with measurement vs eta",
+                                                           nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nSTRIPlayersWith1dMeas_vs_eta.push_back( ibook.bookProfile("STRIPlayersWith1dMeas_vs_eta","mean # STRIP Layers with 1D measurement vs eta",
+                                                             nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
+  nSTRIPlayersWith2dMeas_vs_eta.push_back( ibook.bookProfile("STRIPlayersWith2dMeas_vs_eta","mean # STRIP Layers with 2D measurement vs eta",
+                                                             nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
 
-  nhits_vs_phi.push_back( ibook.book2D("nhits_vs_phi","#hits vs #phi",nintPhi,minPhi,maxPhi,nintHit,minHit,maxHit) );
+  nhits_vs_phi.push_back( ibook.bookProfile("hits_phi","mean # hits vs #phi",nintPhi,minPhi,maxPhi,nintHit,minHit,maxHit, " ") );
 
-  nlosthits_vs_eta.push_back( ibook.book2D("nlosthits_vs_eta","nlosthits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit) );
+  nlosthits_vs_eta.push_back( ibook.bookProfile("losthits_vs_eta","mean # lost hits vs eta",nintEta,minEta,maxEta,nintHit,minHit,maxHit, " ") );
 
   //resolution of track parameters
   //                       dPt/Pt    cotTheta        Phi            TIP            LIP

--- a/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
+++ b/Validation/RecoTrack/src/MTVHistoProducerAlgoForTracker.cc
@@ -559,6 +559,10 @@ void MTVHistoProducerAlgoForTracker::fill_recoAssociated_simTrack_histos(int cou
 
 }
 
+void MTVHistoProducerAlgoForTracker::fill_simTrackBased_histos(int count, int numSimTracks){
+  h_tracksSIM[count]->Fill(numSimTracks);
+}
+
 // dE/dx
 void MTVHistoProducerAlgoForTracker::fill_dedx_recoTrack_histos(int count, const edm::RefToBase<reco::Track>& trackref, const std::vector< const edm::ValueMap<reco::DeDxData> *>& v_dEdx) {
   for (unsigned int i=0; i<v_dEdx.size(); i++) {


### PR DESCRIPTION
This PR reduces the amount of memory in the histograms booked by MultiTrackValidator from ~60 MB to ~36 MB (checked with IgProf in a TTbar+25ns PU job, MEM_LIVE after 100 events). 
1. Change all 2D histograms that were used as an input for making a profile in harvesting step to TProfile (mean chi2 vs. eta, phi, nhits; mean number of hits vs. eta, phi; more specific mean numbers of hits or layers vs. eta).
2. Rebinned various 1D histograms (number of tracks; TrackingParticle pT, eta, vertex transverse position, bunch crossing)

In addition, the histogram of TrackingParticles/event is again filled (only in-time BX is considered).

Tested in CMSSW_7_5_X_2015-06-06-2300, following changes are expected (black old, red new):
- Tiny numerical differences in the previously-2D-now-TProfile histograms, e.g. mean chi2 vs. eta
  ![image](https://cloud.githubusercontent.com/assets/33993/8057379/2839a138-0eb1-11e5-9ad3-58b99cfe6ffd.png)
- Chi2 vs. nhits is shifted by -0.5 hits (the binning is now the same as in other nhits histograms)
  ![image](https://cloud.githubusercontent.com/assets/33993/8057263/f517d21c-0eaf-11e5-833d-66fa7adbe729.png)
- All "number of tracks" histograms have different binning, e.g.
  ![image](https://cloud.githubusercontent.com/assets/33993/8057287/328a6934-0eb0-11e5-8c2b-b28fb3532482.png)
- The histogram under `.../simulation` folder have different binning, e.g.
  ![image](https://cloud.githubusercontent.com/assets/33993/8057300/4fb83a04-0eb0-11e5-9e07-520be9e828bc.png)

@rovere @VinInn 
