### PR TITLE
change primaryVertexCut for fast displaced Vertex reconstruction from…

### DIFF
--- a/RecoParticleFlow/PFTracking/python/particleFlowDisplacedVertexCandidate_cfi.py
+++ b/RecoParticleFlow/PFTracking/python/particleFlowDisplacedVertexCandidate_cfi.py
@@ -17,7 +17,7 @@ particleFlowDisplacedVertexCandidate = cms.EDProducer("PFDisplacedVertexCandidat
     dcaCut = cms.double(0.5),
 
     # minimum distance of secondary vertex with respect to the primary
-    primaryVertexCut = cms.double(2.2),
+    primaryVertexCut = cms.double(1.8),
 
     # maximum distance between the DCA Point and the inner hit of the track
     # not used for the moment


### PR DESCRIPTION
… 2.2 to 1.8 cm to observe non-bias beam pipe at RUN II

Dear Experts,

I wold like to thank you a lot for the merging our previous change in the previous pull request:
https://github.com/cms-sw/cmssw/pull/9454

During this week we proceed our study about beam-pipe and we have found that we need also change preliminary/fast algorithm of vertex reconstruction:

https://github.com/cms-sw/cmssw/blob/CMSSW_7_5_X/RecoParticleFlow/PFTracking/python/particleFlowDisplacedVertexCandidate_cfi.py#L20
primaryVertexCut = cms.double(1.8),

before it was 2.2 cm so it slightly effected to our beam-pipe measurement, which is locate around 2.25 cm.
We perform a test for it and you could see it in the attached file. Green curve correspond to reco nuclear interaction with old 2.2 cm cut (preliminary/fast vertex reconstruction) and blue curve to the new 1.8 cm cut. As you could see with blue we could reconstruct slightly more events with lower radius. We plot radius of nuclear interactions only in the region of beam pipe. 

We want make precise measurements of the beam pipe in 2015, that is why we need introduce this change to avoid bias in beam pipe coordinates. 

I would like to ask for request to make this change in CMSSW_7_5_X and after propagate it to CMSSW_7_4_X. This change could be done for RUN II and RUN I at the same time, but we need it only for RUN II. 

Thank you in advance, Anna

![beampipeforrunii_3](https://cloud.githubusercontent.com/assets/5188748/8059307/8f8d6988-0ebf-11e5-92b6-f7a89e3660b4.png)
