### PR TITLE
fix ECAL cluster input for PFCaloJets

### DIFF
--- a/RecoJets/JetProducers/python/hltParticleFlowForJets_cfi.py
+++ b/RecoJets/JetProducers/python/hltParticleFlowForJets_cfi.py
@@ -11,7 +11,7 @@ hltParticleFlowBlock = cms.EDProducer("PFBlockProducer",
     verbose = cms.untracked.bool(False),
     elementImporters = cms.VPSet(
         cms.PSet(
-            source = cms.InputTag("particleFlowClusterECALUncorrected"), #we use uncorrected
+            source = cms.InputTag("particleFlowClusterECAL"),
             importerName = cms.string('GenericClusterImporter')
         ),
         cms.PSet(


### PR DESCRIPTION
PFCaloJets are documented here:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/JMARPFCaloJetAndPFClusterJets
They are not run in default RECO.
This fix switches from uncorrected to corrected ECAL clusters as input.
PFAlgo does not run with uncorrected ECAL clusters and is inconsistent with PF hadron calibration.
