### PR TITLE
Resolve null-dereference and enable Linux containers

### DIFF
--- a/Utilities/StorageFactory/src/LocalFileSystem.cc
+++ b/Utilities/StorageFactory/src/LocalFileSystem.cc
@@ -366,7 +366,7 @@ LocalFileSystem::findMount(const char *path, struct statfs *sfs, struct stat *s,
     }
   }
   // In the case of a bind mount, try looking again at the source directory.
-  if (best->bind && best->origin)
+  if (best && best->bind && best->origin)
   {
     struct stat s2;
     struct statfs sfs2;

--- a/Utilities/StorageFactory/src/LocalFileSystem.cc
+++ b/Utilities/StorageFactory/src/LocalFileSystem.cc
@@ -230,13 +230,14 @@ LocalFileSystem::initFSList(void)
 
   free(mtab);
 #else
+  const char * const _PATH_MOUNTED_LINUX = "/proc/self/mounts";
   struct mntent *m;
-  FILE *mtab = setmntent(_PATH_MOUNTED, "r");
+  FILE *mtab = setmntent(_PATH_MOUNTED_LINUX, "r");
   if (! mtab)
   {
     int nerr = errno;
     edm::LogWarning("LocalFileSystem::initFSList()")
-      << "Cannot read '" << _PATH_MOUNTED << "': "
+      << "Cannot read '" << _PATH_MOUNTED_LINUX << "': "
       << strerror(nerr) << " (error " << nerr << ")";
     return -1;
   }


### PR DESCRIPTION
Notice: commit messages contains more information.

CMSSW fails on at least one site where Linux containers are used (probably instead of virtual machines). You cannot trust `/etc/mtab` content, go directly for `/proc/self/mounts`.

Same issue happens if CMSSW is compiled with ASan, in this case `realpath` was not doing a correct job for "`.`". Could be a bug in ASan interceptor. 
