### PR TITLE
Remove unnecessary output from PFBlockAlgo

### DIFF
--- a/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
+++ b/RecoParticleFlow/PFProducer/src/PFBlockAlgo.cc
@@ -135,7 +135,7 @@ PFBlockAlgo::findBlocks() {
     }
     */    
   }
-  std::cout << "(new) Found " << blocks_->size() << " PFBlocks!" << std::endl;
+  edm::LogInfo("PFBlockAlgo") << "Found " << blocks_->size() << " PFBlocks!" << std::endl;
 }
 
 // start from first element in elements_


### PR DESCRIPTION
PFBlockAlgo reports to std::cout every event how many blocks are found.  This changes it to use a `edm::LogInfo` message instead.
