### PR TITLE
DQM/L1TMonitor: definite static const int members

### DIFF
--- a/DQM/L1TMonitor/src/L1TdeGCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeGCT.cc
@@ -5,6 +5,7 @@ using namespace dedefs;
 
 const int L1TdeGCT::nGctColl_;
 const int L1TdeGCT::nerr;
+const int L1TdeGCT::nStage1Layer2Coll_;
 
 L1TdeGCT::L1TdeGCT(const edm::ParameterSet& iConfig) {
 


### PR DESCRIPTION
The patch resolves issue with Clang compiler.

N3690 (should be C++11 standard), 9.4.2/3

```
...
The member shall still be defined in a namespace scope if it
is odr-used (3.2) in the program and the namespace scope definition
shall not contain an initializer.
```

9.4.2/4 talks about how `const static` data members are being handled.

Also standard says that no diagnostic is required by compiler.

Same change as in 5790fc114f642b6bd972980b2338a0e624b3e64a

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
