### PR TITLE
Backport of #9532: More All-In-One tool improvements

### DIFF
--- a/Alignment/OfflineValidation/macros/trackSplitPlot.C
+++ b/Alignment/OfflineValidation/macros/trackSplitPlot.C
@@ -556,23 +556,15 @@ void saveplot(TCanvas *c1,TString saveas)
     if (saveas == "")
         return;
     TString saveas2 = saveas,
-            saveas3 = saveas,
-            saveas4;
+            saveas3 = saveas;
     saveas2.ReplaceAll(".pngepsroot","");
     saveas3.Remove(saveas3.Length()-11);
     if (saveas2 == saveas3)
     {
-        stringstream s1,s2,s3;
-        s1 << saveas2 << ".png";
-        s2 << saveas2 << ".eps";
-        s3 << saveas2 << ".root";
-        saveas2 = s1.str();
-        saveas3 = s2.str();
-        saveas4 = s3.str();
-        c1->SaveAs(saveas2);
-        c1->SaveAs(saveas3);
-        c1->SaveAs(saveas4);
-        return;
+        c1->SaveAs(saveas.ReplaceAll(".pngepsroot",".png"));
+        c1->SaveAs(saveas.ReplaceAll(".png",".eps"));
+        c1->SaveAs(saveas.ReplaceAll(".eps",".root"));
+        c1->SaveAs(saveas.ReplaceAll(".root",".pdf"));
     }
     else
     {

--- a/Alignment/OfflineValidation/macros/trackSplitPlot.C
+++ b/Alignment/OfflineValidation/macros/trackSplitPlot.C
@@ -34,7 +34,7 @@ TCanvas *trackSplitPlot(Int_t nFiles,TString *files,TString *names,TString xvar,
     if (nFiles < 1) nFiles = 1;
 
     const Int_t n = nFiles;
-    
+
     setTDRStyle();
     gStyle->SetOptStat(0);        //for histograms, the mean and rms are included in the legend if nFiles >= 2
                                   //if nFiles == 1, there is no legend, so they're in the statbox
@@ -212,7 +212,7 @@ TCanvas *trackSplitPlot(Int_t nFiles,TString *files,TString *names,TString xvar,
         }
         if (relative && pull)
             tree->SetBranchAddress(sigmaorgvariable,&sigmaorg);
-   
+
         Int_t notincluded = 0;                              //this counts the number that aren't in the right run range.
                                                             //it's subtracted from lengths[i] in order to normalize the histograms
 
@@ -273,14 +273,14 @@ TCanvas *trackSplitPlot(Int_t nFiles,TString *files,TString *names,TString xvar,
                 }
             }
 
-            if (lengths[i] < 10 ? true : 
+            if (lengths[i] < 10 ? true :
                 (((j+1)/(int)(pow(10,(int)(log10(lengths[i]))-1)))*(int)(pow(10,(int)(log10(lengths[i]))-1)) == j + 1 || j + 1 == lengths[i]))
             //print when j+1 is a multiple of 10^x, where 10^x has 1 less digit than lengths[i]
             // and when it's finished
             //For example, if lengths[i] = 123456, it will print this when j+1 = 10000, 20000, ..., 120000, 123456
             //So it will print between 10 and 100 times: 10 when lengths[i] = 10^x and 100 when lengths[i] = 10^x - 1
             {
-                cout << j + 1 << "/" << lengths[i] << ": "; 
+                cout << j + 1 << "/" << lengths[i] << ": ";
                 if (type == Profile || type == ScatterPlot || type == Resolution)
                     cout << x << ", " << y << endl;
                 if (type == OrgHistogram)
@@ -466,7 +466,7 @@ TCanvas *trackSplitPlot(Int_t nFiles,TString *files,TString *names,TString xvar,
             return 0;
         }
 
-        
+
         c1->Update();
         Double_t x1min  = .98*gPad->GetUxmin() + .02*gPad->GetUxmax();
         Double_t x2max  = .02*gPad->GetUxmin() + .98*gPad->GetUxmax();
@@ -482,7 +482,7 @@ TCanvas *trackSplitPlot(Int_t nFiles,TString *files,TString *names,TString xvar,
         }
         Double_t newy2max = placeLegend(legend,width,height,x1min,y1min,x2max,y2max);
         maxp->GetYaxis()->SetRangeUser(gPad->GetUymin(),(newy2max-.02*gPad->GetUymin())/.98);
-                
+
         legend->SetFillStyle(0);
         legend->Draw();
     }
@@ -704,7 +704,7 @@ void misalignmentDependence(TCanvas *c1old,
     {
         yaxislabel = axislabel(yvar,'y',relative,resolution,pull);
         for (Int_t i = 0; i < nFiles; i++)
-        { 
+        {
             if (!used[i]) continue;
             if (!resolution)
             {
@@ -865,7 +865,7 @@ void misalignmentDependence(TCanvas *c1old,
             stufftodelete->Add(g);
             delete[] xvalues;        //A TGraph2DErrors has its own copy of xvalues and yvalues, so it's ok to delete these copies.
             delete[] yvalues;
-            
+
             TString xaxislabel = "#epsilon_{";
             xaxislabel.Append(misalignment);
             xaxislabel.Append("}cos(#delta)");
@@ -1127,7 +1127,7 @@ Bool_t misalignmentDependence(TCanvas *c1old,
             functionname = "#Deltad_{xy}/#delta(#Deltad_{xy})=-Asin(2#phi_{org}+B)";
             //functionname = "#Deltad_{xy}/#delta(#Deltad_{xy})=-Asin(2#phi_{org}+B)+C";
         }
-        
+
         if (xvar == "theta" && yvar == "dz" && !resolution && !pull)
         {
             f = new TF1("line","-[0]*(x-[1])");
@@ -1280,7 +1280,7 @@ Bool_t misalignmentDependence(TCanvas *c1old,
                                f,parameter,parametername,functionname,relative,resolution,pull,saveas);
     delete f;
     return true;
-    
+
 }
 
 
@@ -1426,7 +1426,7 @@ void makePlots(Int_t nFiles,TString *files,TString *names,TString misalignment,D
                 for (Int_t i = 0; i < nPlots; i++)
                 {
                     stringstream ss;
-                    ss << directory << slashstring << plotnames[i] << "." << pullstring 
+                    ss << directory << slashstring << plotnames[i] << "." << pullstring
                        << xvarstring << yvarstring << relativestring << ".pngepsroot";
                     s.push_back(ss.str());
                     if (misalignment != "")
@@ -1745,17 +1745,33 @@ TString axislabel(TString variable, Char_t axis, Bool_t relative, Bool_t resolut
         s << "#Delta";
     s << fancyname(variable);
     if (relative && axis == 'y')
-        s << " / " << fancyname(variable);
+    {
+        s << " / ";
+        if (!pull)
+            s << "(";
+        s << fancyname(variable);
+    }
     Bool_t nHits = (variable[0] == 'n' && variable[1] == 'H' && variable[2] == 'i'
                                        && variable[3] == 't' && variable[4] == 's');
     if (relative || (axis == 'x' && variable != "runNumber" && !nHits))
         s << "_{org}";
-    if (pull && axis == 'y')
+    if (axis == 'y')
     {
-        s << " / #delta(#Delta" << fancyname(variable);
-        if (relative)
-            s << " / " << fancyname(variable) << "_{org}";
-        s << ")";
+        if (pull)
+        {
+            s << " / #delta(#Delta" << fancyname(variable);
+            if (relative)
+                s << " / " << fancyname(variable) << "_{org}";
+            s << ")";
+        }
+        else
+        {
+            if (!relative)
+                s << " / ";
+            s << "#sqrt{2}";
+            if (relative)
+                s << ")";
+        }
     }
     if (resolution && axis == 'y')
         s << ")";
@@ -2276,7 +2292,7 @@ void setTDRStyle() {
   gStyle->SetEndErrorSize(2);
   //gStyle->SetErrorMarker(20);
   gStyle->SetErrorX(0.);
-  
+
   gStyle->SetMarkerStyle(7);
 
   //For the fit/function:
@@ -2364,7 +2380,7 @@ void setTDRStyle() {
   gStyle->SetOptLogz(0);
 
   // Postscript options:
-  
+
   gStyle->SetPaperSize(20.,20.);
   // gStyle->SetLineScalePS(Float_t scale = 3);
   // gStyle->SetLineStyleString(Int_t i, const char* text);

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/betterConfigParser.py
@@ -1,31 +1,28 @@
 import ConfigParser
 import os
 import copy
+import collections
 from TkAlExceptions import AllInOneError
 
 
-class AdaptedDict(dict):
+class AdaptedDict(collections.OrderedDict):
     """
     Dictionary which handles updates of values for already existing keys
     in a modified way.
-    Instead of replacing the old value, the new value is appended to the
-    value string separated by `self.getSep()`.
+    adapteddict[key] returns a list of all values associated with key
     This dictionary is used in the class `BetterConfigParser` instead of the
     default `dict_type` of the `ConfigParser` class.
     """
 
-    def getSep(self):
-        """
-        This method returns the separator used to separate the values for 
-        duplicate options in a config.
-        """
-        return " |/| "
+    def __init__(self, *args, **kwargs):
+        self.validationslist = []
+        collections.OrderedDict.__init__(self, *args, **kwargs)
 
-    def __setitem__(self, key, value, dict_setitem=dict.__setitem__):
+    def __setitem__(self, key, value, dict_setitem=collections.OrderedDict.__setitem__):
         """
         od.__setitem__(i, y) <==> od[i]=y
         Updating an existing key appends the new value to the old value
-        separated by `self.getSep()` instead of replacing it.
+        instead of replacing it.
 
         Arguments:
         - `key`: key part of the key-value pair
@@ -33,23 +30,26 @@ class AdaptedDict(dict):
         - `dict_item`: method which is used for finally setting the item
         """
 
-        if "__name__" in self and self["__name__"]=="validation" \
-                and key in self and value!=self[key][0]:
-            the_value = [self[key][0]+self.getSep()+value[0]]
+        if key != "__name__" and "__name__" in self and self["__name__"]=="validation":
+            self.validationslist.append((key, value))
         else:
-            the_value = value
-        dict_setitem(self, key, the_value)
+            dict_setitem(self, key, value)
 
+    def __getitem__(self, key):
+        if key != "__name__" and "__name__" in self and self["__name__"]=="validation":
+            return [validation[1] for validation in self.validationslist if validation[0] == key]
+        else:
+            return collections.OrderedDict.__getitem__(self, key)
+
+    def items(self):
+        if "__name__" in self and self["__name__"]=="validation":
+            return self.validationslist
+        else:
+            return collections.OrderedDict.items(self)
 
 class BetterConfigParser(ConfigParser.ConfigParser):
     def __init__(self):
         ConfigParser.ConfigParser.__init__(self,dict_type=AdaptedDict)
-        dummyDict = AdaptedDict()
-        self._sep = dummyDict.getSep()
-        del dummyDict
-
-    def getSep(self):
-        return self._sep
 
     def optionxform(self, optionstr):
         return optionstr
@@ -172,3 +172,27 @@ class BetterConfigParser(ConfigParser.ConfigParser):
                        %(option, section))
                 raise AllInOneError(msg)
 
+    def items(self, section, raw=False, vars=None):
+        if section == "validation":
+            if raw or vars:
+                raise NotImplementedError("'raw' and 'vars' do not work for betterConfigParser.items()!")
+            items = self._sections["validation"].items()
+            itemscopy = items[:]
+            for item in items:
+                if not isinstance(item[1], (str, unicode)):
+                    itemscopy.remove(item)
+            return itemscopy
+        else:
+            return ConfigParser.ConfigParser.items(self, section, raw, vars)
+
+    def write(self, fp):
+        """Write an .ini-format representation of the configuration state."""
+        for section in self._sections:
+            fp.write("[%s]\n" % section)
+            for (key, value) in self._sections[section].items():
+                if key == "__name__" or not isinstance(value, (str, unicode)):
+                    continue
+                if (value is not None) or (self._optcre == self.OPTCRE):
+                    key = " = ".join((key, str(value).replace('\n', '\n\t')))
+                fp.write("%s\n" % (key))
+            fp.write("\n")

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -184,6 +184,7 @@ ls -al .oO[mergeParallelFilePrefixes]Oo. > .oO[datadir]Oo./log_rootfilelist.txt
 compareAlignmentsExecution="""
 #merge for .oO[validationId]Oo. if it does not exist or is not up-to-date
 echo -e "\n\nComparing validations"
+cmsMkdir /store/caf/user/$USER/.oO[eosdir]Oo./
 cp .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/scripts/compareFileAges.C .
 root -x -q -b -l "compareFileAges.C(\\\"root://eoscms.cern.ch//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./.oO[validationId]Oo._result.root\\\", \\\".oO[compareStringsPlain]Oo.\\\")"
 comparisonNeeded=${?}

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -189,10 +189,16 @@ class Dataset:
                             msg += "\nCheck your config file to make sure that it worked properly."
                             print msg
 
-                            self.__firstUsedRun = -1
-                            self.__lastUsedRun = -1
+                            runlist = self.__getRunList()
                             if firstRun or lastRun:
+                                self.__firstusedrun = -1
+                                self.__lastusedrun = -1
                                 jsoncontents = re.sub("\d+:(\d+|max)-\d+:(\d+|max)", self.getForceRunRangeFunction(firstRun, lastRun), jsoncontents)
+                                self.__firstusedrun = max(self.__firstusedrun, int(self.__findInJson(runlist[0],"run_number")))
+                                self.__lastusedrun = min(self.__lastusedrun, int(self.__findInJson(runlist[-1],"run_number")))
+                            else:
+                                self.__firstusedrun = int(self.__findInJson(runlist[0],"run_number"))
+                                self.__lastusedrun = int(self.__findInJson(runlist[-1],"run_number"))
                             lumiSecExtend = jsoncontents
                             splitLumiList = [[""]]
 
@@ -202,11 +208,13 @@ class Dataset:
                 lumiSecStr = [ "lumiSecs.extend( [\n'" + lumis + "'\n] )" \
                                for lumis in lumiSecStr ]
                 lumiSecExtend = "\n".join( lumiSecStr )
-                self.__firstusedrun = splitLumiList[0][0].split(":")[0]
-                self.__lastusedrun = splitLumiList[-1][-1].split(":")[0]
+                runlist = self.__getRunList()
+                self.__firstusedrun = max(int(splitLumiList[0][0].split(":")[0]), int(self.__findInJson(runlist[0],"run_number")))
+                self.__lastusedrun = min(int(splitLumiList[-1][-1].split(":")[0]), int(self.__findInJson(runlist[-1],"run_number")))
         else:
-            self.__firstusedrun = self.__findInJson(self.__getRunList()[0],"run_number")
-            self.__lastusedrun = self.__findInJson(self.__getRunList()[-1],"run_number")
+            runlist = self.__getRunList()
+            self.__firstusedrun = int(self.__findInJson(self.__getRunList()[0],"run_number"))
+            self.__lastusedrun = int(self.__findInJson(self.__getRunList()[-1],"run_number"))
 
         if crab:
             files = ""
@@ -277,7 +285,6 @@ class Dataset:
     def forcerunrange(self, firstRun, lastRun, s):
         """s must be in the format run1:lum1-run2:lum2"""
         s = s.group()
-        print s
         run1 = s.split("-")[0].split(":")[0]
         lum1 = s.split("-")[0].split(":")[1]
         run2 = s.split("-")[1].split(":")[0]
@@ -290,10 +297,10 @@ class Dataset:
         if int(run2) > lastRun:
             run2 = lastRun
             lum2 = "max"
-        if int(run1) < self.__firstUsedRun:
-            self.__firstUsedRun = int(run1)
-        if int(run2) > self.__lastUsedRun:
-            self.__lastUsedRun = int(run2)
+        if int(run1) < self.__firstusedrun or self.__firstusedrun < 0:
+            self.__firstusedrun = int(run1)
+        if int(run2) > self.__lastusedrun:
+            self.__lastusedrun = int(run2)
         return "%s:%s-%s:%s" % (run1, lum1, run2, lum2)
 
     def getForceRunRangeFunction(self, firstRun, lastRun):
@@ -452,9 +459,12 @@ class Dataset:
                     "Try limiting the run range using firstRun, lastRun, begin, end, or JSON,\n"
                     "or increasing the tolerance (in dataset.py) from %s.") % (self.__name, firstrunB, lastrunB, tolerance)
         except TypeError:
-            if "unknown" in firstrunB:
-                return firstrunB
-            else:
+            try:
+                if "unknown" in firstrunB:
+                    return firstrunB
+                else:
+                    return lastrunB
+            except TypeError:
                 return lastrunB
 
     def __getFileInfoList( self, dasLimit, parent = False ):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -321,8 +321,20 @@ class Dataset:
         except KeyError:
             error = None
         if error or self.__findInJson(jsondict,"status") != 'ok' or "data" not in jsondict:
-            msg = ("The DAS query returned a error.  Here is the output\n" + str(jsondict) +
-                   "\nIt's possible that this was a server error.  If so, it may work if you try again later")
+            jsonstr = str(jsondict)
+            if len(jsonstr) > 10000:
+                jsonfile = "das_query_output_%i.txt"
+                i = 0
+                while os.path.lexists(jsonfile % i):
+                    i += 1
+                jsonfile = jsonfile % i
+                theFile = open( jsonfile, "w" )
+                theFile.write( jsonstr )
+                theFile.close()
+                msg = "The DAS query returned an error.  The output is very long, and has been stored in:\n" + jsonfile
+            else:
+                msg = "The DAS query returned a error.  Here is the output\n" + jsonstr
+            msg += "\nIt's possible that this was a server error.  If so, it may work if you try again later"
             raise AllInOneError(msg)
         return self.__findInJson(jsondict,"data")
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/genericValidation.py
@@ -59,13 +59,12 @@ class GenericValidation:
             self.scramarch = os.environ["SCRAM_ARCH"]
             self.cmsswreleasebase = os.environ["CMSSW_RELEASE_BASE"]
         else:
-            self.scramarch = None
-            self.cmsswreleasebase = None
             command = ("cd '" + self.cmssw + "' && eval `scramv1 ru -sh 2> /dev/null`"
-                       ' && echo "$SCRAM_ARCH\n$CMSSW_RELEASE_BASE"')
+                       ' && echo "$CMSSW_BASE\n$SCRAM_ARCH\n$CMSSW_RELEASE_BASE"')
             commandoutput = getCommandOutput2(command).split('\n')
-            self.scramarch = commandoutput[0]
-            self.cmsswreleasebase = commandoutput[1]
+            self.cmssw = commandoutput[0]
+            self.scramarch = commandoutput[1]
+            self.cmsswreleasebase = commandoutput[2]
 
         self.AutoAlternates = True
         if config.has_option("alternateTemplates","AutoAlternates"):

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -91,11 +91,12 @@ class PreexistingOfflineValidation(PreexistingValidation):
         returned, else the validation is appended to the list
         """
         repMap = self.getRepMap()
+        repMap["file"] = self.getCompareStrings("OfflineValidation", plain = True)
         if validationsSoFar == "":
-            validationsSoFar = ('PlotAlignmentValidation p("root://eoscms//eos/cms%(finalResultFile)s",'
+            validationsSoFar = ('PlotAlignmentValidation p("%(file)s",'
                                 '"%(title)s", %(color)s, %(style)s);\n')%repMap
         else:
-            validationsSoFar += ('  p.loadFileList("root://eoscms//eos/cms%(finalResultFile)s", "%(title)s",'
+            validationsSoFar += ('  p.loadFileList("%(file)s", "%(title)s",'
                                  '%(color)s, %(style)s);\n')%repMap
         return validationsSoFar
 
@@ -112,7 +113,7 @@ class PreexistingTrackSplittingValidation(PreexistingValidation):
         repMap = self.getRepMap()
         comparestring = self.getCompareStrings("TrackSplittingValidation")
         if validationsSoFar != "":
-            validationsSoFar += ','
+            validationsSoFar += ',"\n              "'
         validationsSoFar += comparestring
         return validationsSoFar
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -1,0 +1,132 @@
+import os
+from genericValidation import GenericValidation, GenericValidationData
+from offlineValidation import OfflineValidation
+from trackSplittingValidation import TrackSplittingValidation
+from monteCarloValidation import MonteCarloValidation
+from zMuMuValidation import ZMuMuValidation
+from geometryComparison import GeometryComparison
+from TkAlExceptions import AllInOneError
+
+class PreexistingValidation(GenericValidation):
+    """
+    Object representing a validation that has already been run,
+    but should be included in plots.
+    """
+    def __init__(self, valName, config, valType,
+                 addDefaults = {}, addMandatories=[]):
+        self.name = valName
+        self.general = config.getGeneral()
+        self.config = config
+        self.filesToCompare = {}
+
+        defaults = {"title": self.name, "color": 1, "style": 1}
+        defaults.update(addDefaults)
+        mandatories = ["file"]
+        mandatories += addMandatories
+
+        theUpdate = config.getResultingSection("preexisting"+valType+":"+self.name,
+                                               defaultDict = defaults,
+                                               demandPars = mandatories)
+        self.general.update(theUpdate)
+
+        self.title = self.general["title"]
+        if "|" in self.title or "," in self.title or '"' in self.title:
+            msg = "The characters '|', '\"', and ',' cannot be used in the alignment title!"
+            raise AllInOneError(msg)
+
+        self.filesToCompare[GenericValidationData.defaultReferenceName] = \
+            self.general["file"]
+
+        knownOpts = defaults.keys()+mandatories
+        ignoreOpts = []
+        config.checkInput("preexisting"+valType+":"+self.name,
+                          knownSimpleOptions = knownOpts,
+                          ignoreOptions = ignoreOpts)
+
+    def getRepMap(self):
+        result = self.general
+        return result
+
+    def getCompareStrings( self, requestId = None, plain = False ):
+        result = {}
+        repMap = self.getRepMap()
+        for validationId in self.filesToCompare:
+            repMap["file"] = self.filesToCompare[ validationId ]
+            if repMap["file"].startswith( "/castor/" ):
+                repMap["file"] = "rfio:%(file)s"%repMap
+            elif repMap["file"].startswith( "/store/" ):
+                repMap["file"] = "root://eoscms.cern.ch//eos/cms%(file)s"%repMap
+            if plain:
+                result[validationId]=repMap["file"]
+            else:
+                result[validationId]= "%(file)s=%(title)s|%(color)s|%(style)s"%repMap
+        if requestId == None:
+            return result
+        else:
+            if not "." in requestId:
+                requestId += ".%s"%GenericValidation.defaultReferenceName
+            if not requestId.split(".")[-1] in result:
+                msg = ("could not find %s in reference Objects!"
+                       %requestId.split(".")[-1])
+                raise AllInOneError(msg)
+            return result[ requestId.split(".")[-1] ]
+
+    def createFiles(self, *args, **kwargs):
+        raise AllInOneError("Shouldn't be here...")
+    def createConfiguration(self, *args, **kwargs):
+        raise AllInOneError("Shouldn't be here...")
+    def createScript(self, *args, **kwargs):
+        raise AllInOneError("Shouldn't be here...")
+    def createCrabCfg(self, *args, **kwargs):
+        raise AllInOneError("Shouldn't be here...")
+
+class PreexistingOfflineValidation(PreexistingValidation):
+    def __init__(self, valName, config,
+                 addDefaults = {}, addMandatories=[]):
+        PreexistingValidation.__init__(self, valName, config, "offline",
+                                       addDefaults, addMandatories)
+    def appendToExtendedValidation( self, validationsSoFar = "" ):
+        """
+        if no argument or "" is passed a string with an instantiation is
+        returned, else the validation is appended to the list
+        """
+        repMap = self.getRepMap()
+        if validationsSoFar == "":
+            validationsSoFar = ('PlotAlignmentValidation p("root://eoscms//eos/cms%(finalResultFile)s",'
+                                '"%(title)s", %(color)s, %(style)s);\n')%repMap
+        else:
+            validationsSoFar += ('  p.loadFileList("root://eoscms//eos/cms%(finalResultFile)s", "%(title)s",'
+                                 '%(color)s, %(style)s);\n')%repMap
+        return validationsSoFar
+
+class PreexistingTrackSplittingValidation(PreexistingValidation):
+    def __init__(self, valName, config,
+                 addDefaults = {}, addMandatories=[]):
+        PreexistingValidation.__init__(self, valName, config, "split",
+                                       addDefaults, addMandatories)
+    def appendToExtendedValidation( self, validationsSoFar = "" ):
+        """
+        if no argument or "" is passed a string with an instantiation is
+        returned, else the validation is appended to the list
+        """
+        repMap = self.getRepMap()
+        comparestring = self.getCompareStrings("TrackSplittingValidation")
+        if validationsSoFar != "":
+            validationsSoFar += ','
+        validationsSoFar += comparestring
+        return validationsSoFar
+
+class PreexistingMonteCarloValidation(PreexistingValidation):
+    def __init__(self, valName, config,
+                 addDefaults = {}, addMandatories=[]):
+        PreexistingValidation.__init__(self, valName, config, "mcValidate",
+                                       addDefaults, addMandatories)
+
+class PreexistingZMuMuValidation(PreexistingValidation):
+    def __init__(self, *args, **kwargs):
+        raise AllInOneError("Preexisting Z->mumu validation not implemented")
+        #more complicated, it has multiple output files
+
+class PreexistingGeometryComparison(PreexistingValidation):
+    def __init__(self, *args, **kwargs):
+        raise AllInOneError("Preexisting geometry comparison not implemented")

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -83,8 +83,16 @@ class PreexistingValidation(GenericValidation):
 class PreexistingOfflineValidation(PreexistingValidation):
     def __init__(self, valName, config,
                  addDefaults = {}, addMandatories=[]):
+        defaults = {
+            "DMRMethod":"median,rmsNorm",
+            "DMRMinimum":"30",
+            "DMROptions":"",
+            "OfflineTreeBaseDir":"TrackHitFilter",
+            "SurfaceShapes":"none"
+            }
+        defaults.update(addDefaults)
         PreexistingValidation.__init__(self, valName, config, "offline",
-                                       addDefaults, addMandatories)
+                                       defaults, addMandatories)
     def appendToExtendedValidation( self, validationsSoFar = "" ):
         """
         if no argument or "" is passed a string with an instantiation is

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/preexistingValidation.py
@@ -19,9 +19,9 @@ class PreexistingValidation(GenericValidation):
         self.config = config
         self.filesToCompare = {}
 
-        defaults = {"title": self.name, "color": 1, "style": 1}
+        defaults = {"title": self.name}
         defaults.update(addDefaults)
-        mandatories = ["file"]
+        mandatories = ["file", "color", "style"]
         mandatories += addMandatories
 
         theUpdate = config.getResultingSection("preexisting"+valType+":"+self.name,

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
@@ -54,7 +54,7 @@ class TrackSplittingValidation(GenericValidationData):
         repMap = self.getRepMap()
         comparestring = self.getCompareStrings("TrackSplittingValidation")
         if validationsSoFar != "":
-            validationsSoFar += ','
+            validationsSoFar += ',"\n              "'
         validationsSoFar += comparestring
         return validationsSoFar
 

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -276,7 +276,10 @@ def createMergeScript( path, validations ):
             "DownloadData":"",
             "CompareAlignments":"",
             "RunExtendedOfflineValidation":"",
-            "RunTrackSplitPlot":""
+            "RunTrackSplitPlot":"",
+            "CMSSW_BASE": os.environ["CMSSW_BASE"],
+            "SCRAM_ARCH": os.environ["SCRAM_ARCH"],
+            "CMSSW_RELEASE_BASE": os.environ["CMSSW_RELEASE_BASE"],
             })
 
     comparisonLists = {} # directory of lists containing the validations that are comparable

--- a/Alignment/OfflineValidation/scripts/validateAlignments.py
+++ b/Alignment/OfflineValidation/scripts/validateAlignments.py
@@ -523,7 +523,7 @@ To merge the outcome of all validation procedures run TkAlMerge.sh in your valid
 
     validations = []
     for validation in config.items("validation"):
-        alignmentList = validation[1].split(config.getSep())
+        alignmentList = [validation[1]]
         validationsToAdd = [(validation[0],alignment) \
                                 for alignment in alignmentList]
         validations.extend(validationsToAdd)


### PR DESCRIPTION
The primary addition here is "preexisting" validations, which make it possible to configure the All In One tool to include validations that were already run into plots, without running them again.

This is independent of running validations on 74X data.  I separated that in #9551 because its purpose is different.

This is orthogonal to #9536 and #9551, they should merge together without a problem.
