### PR TITLE
Offline validation for 74X collisions and cosmics

### DIFF
--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.h
@@ -88,6 +88,25 @@ public:
   
   THStack* addHists(const char *selection, const TString &residType = "xPrime", TLegend **myLegend = 0, bool printModuleIds = false);//add hists fulfilling 'selection' on TTree; residType: xPrime,yPrime,xPrimeNorm,yPrimeNorm,x,y,xNorm; if (printModuleIds): cout DetIds
   
+  // These are helpers for DMR plotting
+
+  struct DMRPlotInfo {
+    std::string variable;
+    int nbins;
+    double min, max;
+    int minHits;
+    bool plotPlain, plotSplits, plotLayers;
+    int subDetId, nLayers;
+    THStack* hstack;
+    TLegend* legend;
+    TkOfflineVariables* vars;
+    float maxY;
+    TH1F* h;
+    TH1F* h1;
+    TH1F* h2;
+    bool firsthisto;
+  };
+
 private : 
   TList* getTreeList();
   std::string treeBaseDir;
@@ -115,25 +134,6 @@ private :
   bool moreThanOneSource;
   std::string fileNames[10];
   int fileCounter;	
-
-  // These are helpers for DMR plotting
-
-  struct DMRPlotInfo {
-    std::string variable;
-    int nbins;
-    double min, max;
-    int minHits;
-    bool plotPlain, plotSplits, plotLayers;
-    int subDetId, nLayers;
-    THStack* hstack;
-    TLegend* legend;
-    TkOfflineVariables* vars;
-    float maxY;
-    TH1F* h;
-    TH1F* h1;
-    TH1F* h2;
-    bool firsthisto;
-  };
 
   std::string getSelectionForDMRPlot(int minHits, int subDetId, int direction = 0, int layer = 0);
   std::string getVariableForDMRPlot(const std::string& histoname, const std::string& variable,

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/alternateValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/alternateValidationTemplates.py
@@ -125,7 +125,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
  ##
  ## GlobalTag Conditions (if needed)
  ##
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
 #process.GlobalTag.connect="frontier://FrontierProd/CMS_COND_21X_GLOBALTAG"
 # process.GlobalTag.connect="frontier://FrontierProd/CMS_COND_31X_GLOBALTAG"
@@ -291,7 +291,7 @@ process.AlignmentTrackSelector.maxMultiplicity = 1
 
 ## GlobalTag Conditions (if needed)
 ##
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
 
 
@@ -446,7 +446,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
  ##
  ## GlobalTag Conditions (if needed)
  ##
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
 # process.GlobalTag.connect="frontier://FrontierProd/CMS_COND_31X_GLOBALTAG"
 
@@ -1034,7 +1034,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
  ##
  ## GlobalTag Conditions (if needed)
  ##
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 # process.GlobalTag.connect = "frontier://FrontierProd/CMS_COND_31X_GLOBALTAG"
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -241,13 +241,14 @@ done
 ######################################################################
 ######################################################################
 extendedValidationTemplate="""
+#include ".oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C"
 void TkAlExtendedOfflineValidation()
 {
   // load framework lite just to find the CMSSW libs...
   gSystem->Load("libFWCoreFWLite");
   AutoLibraryLoader::enable();
   //compile the makro
-  gROOT->ProcessLine(".L .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C++");
+  //gROOT->ProcessLine(".L .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C++");
   // gROOT->ProcessLine(".L ./PlotAlignmentValidation.C++");
 
   .oO[extendedInstantiation]Oo.

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/dataset.py
@@ -653,7 +653,7 @@ class Dataset:
         if self.__predefined:
             snippet = ("process.load(\"Alignment.OfflineValidation.%s_cff\")\n"
                        "process.maxEvents = cms.untracked.PSet(\n"
-                       "    input = cms.untracked.int32(.oO[nEvents]Oo.)\n"
+                       "    input = cms.untracked.int32(.oO[nEvents]Oo. / .oO[parallelJobs]Oo.)\n"
                        ")\n"
                        "process.source.skipEvents=cms.untracked.uint32(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[parallelJobs]Oo.)"
                        %(self.__name))
@@ -664,7 +664,7 @@ class Dataset:
             return snippet
         theMap = { "process": "process.",
                    "tab": " " * len( "process." ),
-                   "nEvents": ".oO[nEvents]Oo.",
+                   "nEvents": ".oO[nEvents]Oo. / .oO[parallelJobs]Oo.",
                    "skipEventsString": "process.source.skipEvents=cms.untracked.uint32(.oO[nIndex]Oo.*.oO[nEvents]Oo./.oO[parallelJobs]Oo.)\n",
                    "importCms": "",
                    "header": ""

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparisonTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/geometryComparisonTemplates.py
@@ -6,7 +6,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("ValidationIntoNTuples")
 
 # global tag
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo." 
 
 process.load("Configuration.Geometry.GeometryDB_cff")
@@ -48,7 +48,7 @@ import FWCore.ParameterSet.Config as cms
 process = cms.Process("validation")
 
 # global tag
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo." 
 process.load("Configuration.Geometry.GeometryDB_cff")
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -146,7 +146,7 @@ process.load("RecoVertex.BeamSpotProducer.BeamSpot_cff")
  ##
  ## GlobalTag Conditions (if needed)
  ##
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
 
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
@@ -20,7 +20,7 @@ process.load('Configuration.StandardSequences.Services_cff')
 process.load("Configuration.Geometry.GeometryDB_cff")
 
 # including global tag
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 # setting global tag
 #process.GlobalTag.connect = "frontier://FrontierProd/CMS_COND_21X_GLOBALTAG"
 # process.GlobalTag.connect="frontier://FrontierProd/CMS_COND_31X_GLOBALTAG"

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/zMuMuValidationTemplates.py
@@ -27,7 +27,7 @@ process.load("Configuration.Geometry.GeometryDB_cff")
 
 
 ########### DATABASE conditions ############################
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
+process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff")
 process.GlobalTag.globaltag = ".oO[GlobalTag]Oo."
 
 .oO[condLoad]Oo.


### PR DESCRIPTION
CondDBv2 and ROOT6 compilation.  Also in 75X as #9552, without the CondDBv2 part because as I understand it CondDBv2 is the default in 75X.

I explicitly checked that this, #9536, and #9550 are all orthogonal to each other.
