### PR TITLE
Turn off calo muons in HI reco sequence

### DIFF
--- a/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
@@ -33,8 +33,8 @@ globalMuons.TrackerCollectionLabel = hiTracks
 # replace with heavy ion jet label
 muons.JetExtractorPSet.JetCollectionLabel = cms.InputTag("iterativeConePu5CaloJets")
 
-# turn off calo muons for timing considerations?
-#muons.fillCaloCompatibility = cms.bool(False)
+# turn off calo muons for timing considerations
+muons.minPCaloMuon = cms.double( 1.0E9 )
 
 # HI muon sequence (passed to RecoHI.Configuration.Reconstruction_HI_cff)
 


### PR DESCRIPTION
Removing calo muons saves about 1/3 of the time of the total muon sequence in central PbPb events, as discussed with @echapon 

The following code had been commented out:
-# turn off calo muons for timing considerations?
-#muons.fillCaloCompatibility = cms.bool(False)

but activating this didn't change the timing at all, so minPCaloMuon was set to a very large number instead, as done at the HLT.

@trocino @battibass, can you confirm that this is the preferred way to do this?
