### PR TITLE
Fix in Track-to-PackedCandidate association

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -234,7 +234,8 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
 
     // Fix track association for sorted candidates
     for(size_t i=0,ntk=mappingTk.size();i<ntk;i++){
-        mappingTk[i]=reverseOrder[mappingTk[i]]; 
+        if(mappingTk[i] >= 0)
+          mappingTk[i]=reverseOrder[mappingTk[i]];
     }
 
     for(size_t i=0,ntk=mappingPuppi.size();i<ntk;i++){


### PR DESCRIPTION
I believe there is a subtle bug in PATPackedCandidateProducer resulting in

```
Exception Message:
Association: index in the map out of upper boundary
```

for some tracks when the Track->PackedCandidate Association is accessed. This PR proposes a fix for it.

As not all PFCandidates have reference to a Track, `mappingTk` contains -1 elements, and accessing `reverseOrder` with `-1` gives junk (fortunately a large number in practice) that is then inserted to `mappingTk`. The edm::Association then throws an exception when such an element is accessed.

Tested in CMSSW_7_5_X_2015-06-06-2300 with wf 11325. I guess there are no visible effects as otherwise this would have been found already (and the associations are also not stored within MiniAOD, right?).

@gpetruc @arizzi 
