### PR TITLE
Unique TFormula name

### DIFF
--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromBinnedTFormula.cc
@@ -1,6 +1,12 @@
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromBinnedTFormula.h"
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+
+
 
 const int PerformancePayloadFromBinnedTFormula::InvalidPos=-1;
 
@@ -8,17 +14,22 @@ const int PerformancePayloadFromBinnedTFormula::InvalidPos=-1;
 using namespace std;
 
 void PerformancePayloadFromBinnedTFormula::initialize() {
-  for (unsigned int t=0; t< pls.size(); ++t){
-    std::vector <boost::shared_ptr<TFormula> > temp;
-      for (unsigned int i=0; i< (pls[t].formulas()).size(); ++i){
-	PhysicsTFormulaPayload  tmp = pls[t];
-	boost::shared_ptr<TFormula> tt(new TFormula("rr",tmp.formulas()[i].c_str()));
-	tt->Compile();
-	temp.push_back(tt);
-      }
-      compiledFormulas_.push_back(temp);
-    }
+	boost::uuids::random_generator gen;
+	for (unsigned int t=0; t< pls.size(); ++t){
+		std::vector <boost::shared_ptr<TFormula> > temp;
+		for (unsigned int i=0; i< (pls[t].formulas()).size(); ++i){
+			boost::uuids::uuid uniqueFormulaId = gen();
+			const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
+			PhysicsTFormulaPayload  tmp = pls[t];
+			boost::shared_ptr<TFormula> tt(new TFormula(formulaUniqueName.c_str(),tmp.formulas()[i].c_str()));
+			tt->Compile();
+			temp.push_back(tt);
+		}
+		compiledFormulas_.push_back(temp);
+	}
 }
+
+
 
 const boost::shared_ptr<TFormula>& PerformancePayloadFromBinnedTFormula::getFormula(PerformanceResult::ResultType r ,const BinningPointByMap& p ) const {
   //

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -1,103 +1,102 @@
-#include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
-
-const int PerformancePayloadFromTFormula::InvalidPos=-1;
-
 #include <boost/uuid/uuid.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/lexical_cast.hpp>
 
-#include <iostream>
+#include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 
+const int PerformancePayloadFromTFormula::InvalidPos=-1;
+
+#include <iostream>
 using namespace std;
 
 void PerformancePayloadFromTFormula::initialize() {
 	boost::uuids::random_generator gen;
 
-	for( std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end(); ++formula ) {
-		boost::uuids::uuid uniqueFormulaId = gen();
-		const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
+  for( std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end(); ++formula ) {
+	boost::uuids::uuid uniqueFormulaId = gen();
+	auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
 
-		boost::shared_ptr<TFormula> temp(new TFormula(formulaUniqueName.c_str(),formula->c_str()));
-		temp->Compile();
-		compiledFormulas_.push_back(temp);
-	}
+    boost::shared_ptr<TFormula> temp(new TFormula(formulaUniqueName.c_str(),formula->c_str()));
+    temp->Compile();
+    compiledFormulas_.push_back(temp);
+  }
 }
 
 
 float PerformancePayloadFromTFormula::getResult(PerformanceResult::ResultType r ,const BinningPointByMap& _p) const {
-	BinningPointByMap p = _p;
-	//
-	// which formula to use?
-	//
-	if (! isInPayload(r,p)) return PerformancePayload::InvalidResult;
+  BinningPointByMap p = _p;
+  //
+  // which formula to use?
+  //
+  if (! isInPayload(r,p)) return PerformancePayload::InvalidResult;
 
-	// nice, what to do here???
-	const boost::shared_ptr<TFormula>& formula = compiledFormulas_[resultPos(r)];
-	//
-	// prepare the vector to pass, order counts!!!
-	//
-	std::vector<BinningVariables::BinningVariablesType> t = myBinning();
+  // nice, what to do here???
+  const boost::shared_ptr<TFormula>& formula = compiledFormulas_[resultPos(r)];
+  //
+  // prepare the vector to pass, order counts!!!
+  //
+  std::vector<BinningVariables::BinningVariablesType> t = myBinning();
 
-	// sorry, TFormulas just work up to dimension==4
-	Double_t values[4];
-	int i=0;
-	for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it, ++i){
-		values[i] = p.value(*it);
-	}
-	//
-	// i need a non const version #$%^
-	// Note, in current implementation of TFormula EvalPar should be
-	// thread safe as it does nothing more than call a function
-	// through a function pointer which is stateless. In spite of the
-	// fact that it is not const.
-	return formula->EvalPar(values);
+  // sorry, TFormulas just work up to dimension==4
+  Double_t values[4];
+  int i=0;
+  for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it, ++i){
+    values[i] = p.value(*it);
+  }
+  //
+  // i need a non const version #$%^
+  // Note, in current implementation of TFormula EvalPar should be
+  // thread safe as it does nothing more than call a function
+  // through a function pointer which is stateless. In spite of the
+  // fact that it is not const.
+  return formula->EvalPar(values);
 }
 
 bool PerformancePayloadFromTFormula::isOk(const BinningPointByMap& _p) const {
-	BinningPointByMap p = _p;
-	std::vector<BinningVariables::BinningVariablesType> t = myBinning();
+  BinningPointByMap p = _p;
+  std::vector<BinningVariables::BinningVariablesType> t = myBinning();
 
-	for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
-		if (!   p.isKeyAvailable(*it)) return false;
-		float v = p.value(*it);
-		int pos = limitPos(*it);
-		std::pair<float, float> limits = (pl.limits())[pos];
-		if (v<limits.first || v>limits.second) return false;
-	}
-	return true;
+  for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
+    if (!   p.isKeyAvailable(*it)) return false;
+    float v = p.value(*it);
+    int pos = limitPos(*it);
+    std::pair<float, float> limits = (pl.limits())[pos];
+    if (v<limits.first || v>limits.second) return false;
+  }
+  return true;
 }
 
 bool PerformancePayloadFromTFormula::isInPayload(PerformanceResult::ResultType res,const BinningPointByMap& point) const {
-	// first, let's see if it is available at all
-	if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos) return false;
+  // first, let's see if it is available at all
+  if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos) return false;
 
-	if ( ! isOk(point)) return false;
-	return true;
+  if ( ! isOk(point)) return false;
+  return true;
 }
 
 void PerformancePayloadFromTFormula::printFormula(PerformanceResult::ResultType res) const {
-	//
-	// which formula to use?
-	//
-	if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos)  {
-		cout << "Warning: result not available!" << endl;
-		return;
-	}
+  //
+  // which formula to use?
+  //
+  if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos)  {
+    cout << "Warning: result not available!" << endl;
+    return;
+  }
 
-	// nice, what to do here???
-	const boost::shared_ptr<TFormula>& formula =
-			compiledFormulas_[resultPos(res)];
-	cout << "-- Formula: " << formula->GetExpFormula("p") << endl;
-	// prepare the vector to pass, order counts!!!
-	//
-	std::vector<BinningVariables::BinningVariablesType> t = myBinning();
+  // nice, what to do here???
+  const boost::shared_ptr<TFormula>& formula =
+    compiledFormulas_[resultPos(res)];
+  cout << "-- Formula: " << formula->GetExpFormula("p") << endl;
+  // prepare the vector to pass, order counts!!!
+  //
+  std::vector<BinningVariables::BinningVariablesType> t = myBinning();
 
-	for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
-		int pos = limitPos(*it);
-		std::pair<float, float> limits = (pl.limits())[pos];
-		cout << "      Variable: " << *it << " with limits: " << "from: " << limits.first  << " to: " << limits.second << endl;
-	}
+  for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
+    int pos = limitPos(*it);
+    std::pair<float, float> limits = (pl.limits())[pos];
+    cout << "      Variable: " << *it << " with limits: " << "from: " << limits.first  << " to: " << limits.second << endl;
+  }
 
 }
 

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -2,13 +2,21 @@
 
 const int PerformancePayloadFromTFormula::InvalidPos=-1;
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+
 #include <iostream>
 using namespace std;
 
 void PerformancePayloadFromTFormula::initialize() {
+  boost::uuids::random_generator gen;
+
   for( std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end(); ++formula ) {
-    //FIXME: "rr" should be unique!
-    boost::shared_ptr<TFormula> temp(new TFormula("rr",formula->c_str()));
+    boost::uuids::uuid uniqueFormulaId = gen();
+    const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
+    boost::shared_ptr<TFormula> temp(new TFormula(formulaUniqueName.c_str(),formula->c_str()));
     temp->Compile();
     compiledFormulas_.push_back(temp);
   }

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -1,8 +1,3 @@
-#include <boost/uuid/uuid.hpp>
-#include <boost/uuid/uuid_generators.hpp>
-#include <boost/uuid/uuid_io.hpp>
-#include <boost/lexical_cast.hpp>
-
 #include "CondFormats/PhysicsToolsObjects/interface/PerformancePayloadFromTFormula.h"
 
 const int PerformancePayloadFromTFormula::InvalidPos=-1;
@@ -11,13 +6,9 @@ const int PerformancePayloadFromTFormula::InvalidPos=-1;
 using namespace std;
 
 void PerformancePayloadFromTFormula::initialize() {
-	boost::uuids::random_generator gen;
-
   for( std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end(); ++formula ) {
-	boost::uuids::uuid uniqueFormulaId = gen();
-	auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
-
-    boost::shared_ptr<TFormula> temp(new TFormula(formulaUniqueName.c_str(),formula->c_str()));
+    //FIXME: "rr" should be unique!
+    boost::shared_ptr<TFormula> temp(new TFormula("rr",formula->c_str()));
     temp->Compile();
     compiledFormulas_.push_back(temp);
   }

--- a/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
+++ b/CondFormats/PhysicsToolsObjects/src/PerformancePayloadFromTFormula.cc
@@ -2,92 +2,102 @@
 
 const int PerformancePayloadFromTFormula::InvalidPos=-1;
 
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
+
 #include <iostream>
+
 using namespace std;
 
 void PerformancePayloadFromTFormula::initialize() {
-  for( std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end(); ++formula ) {
-    //FIXME: "rr" should be unique!      
-    boost::shared_ptr<TFormula> temp(new TFormula("rr",formula->c_str()));
-    temp->Compile();
-    compiledFormulas_.push_back(temp);
-  }
+	boost::uuids::random_generator gen;
+
+	for( std::vector<std::string>::const_iterator formula = pl.formulas().begin(); formula != pl.formulas().end(); ++formula ) {
+		boost::uuids::uuid uniqueFormulaId = gen();
+		const auto formulaUniqueName = boost::lexical_cast<std::string>(uniqueFormulaId);
+
+		boost::shared_ptr<TFormula> temp(new TFormula(formulaUniqueName.c_str(),formula->c_str()));
+		temp->Compile();
+		compiledFormulas_.push_back(temp);
+	}
 }
 
 
 float PerformancePayloadFromTFormula::getResult(PerformanceResult::ResultType r ,const BinningPointByMap& _p) const {
-  BinningPointByMap p = _p;
-  //
-  // which formula to use?
-  //
-  if (! isInPayload(r,p)) return PerformancePayload::InvalidResult;
+	BinningPointByMap p = _p;
+	//
+	// which formula to use?
+	//
+	if (! isInPayload(r,p)) return PerformancePayload::InvalidResult;
 
-  // nice, what to do here???
-  const boost::shared_ptr<TFormula>& formula = compiledFormulas_[resultPos(r)];
-  //
-  // prepare the vector to pass, order counts!!!
-  //
-  std::vector<BinningVariables::BinningVariablesType> t = myBinning();
-  
-  // sorry, TFormulas just work up to dimension==4
-  Double_t values[4];
-  int i=0;
-  for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it, ++i){
-    values[i] = p.value(*it);    
-  }
-  //
-  // i need a non const version #$%^
-  // Note, in current implementation of TFormula EvalPar should be
-  // thread safe as it does nothing more than call a function
-  // through a function pointer which is stateless. In spite of the
-  // fact that it is not const.
-  return formula->EvalPar(values);
+	// nice, what to do here???
+	const boost::shared_ptr<TFormula>& formula = compiledFormulas_[resultPos(r)];
+	//
+	// prepare the vector to pass, order counts!!!
+	//
+	std::vector<BinningVariables::BinningVariablesType> t = myBinning();
+
+	// sorry, TFormulas just work up to dimension==4
+	Double_t values[4];
+	int i=0;
+	for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it, ++i){
+		values[i] = p.value(*it);
+	}
+	//
+	// i need a non const version #$%^
+	// Note, in current implementation of TFormula EvalPar should be
+	// thread safe as it does nothing more than call a function
+	// through a function pointer which is stateless. In spite of the
+	// fact that it is not const.
+	return formula->EvalPar(values);
 }
 
 bool PerformancePayloadFromTFormula::isOk(const BinningPointByMap& _p) const {
-  BinningPointByMap p = _p;
-  std::vector<BinningVariables::BinningVariablesType> t = myBinning();
-  
-  for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
-    if (!   p.isKeyAvailable(*it)) return false;
-    float v = p.value(*it);
-    int pos = limitPos(*it);
-    std::pair<float, float> limits = (pl.limits())[pos];
-    if (v<limits.first || v>limits.second) return false;
-  }
-  return true;
+	BinningPointByMap p = _p;
+	std::vector<BinningVariables::BinningVariablesType> t = myBinning();
+
+	for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
+		if (!   p.isKeyAvailable(*it)) return false;
+		float v = p.value(*it);
+		int pos = limitPos(*it);
+		std::pair<float, float> limits = (pl.limits())[pos];
+		if (v<limits.first || v>limits.second) return false;
+	}
+	return true;
 }
 
 bool PerformancePayloadFromTFormula::isInPayload(PerformanceResult::ResultType res,const BinningPointByMap& point) const {
-  // first, let's see if it is available at all
-  if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos) return false;
-  
-  if ( ! isOk(point)) return false;
-  return true;
+	// first, let's see if it is available at all
+	if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos) return false;
+
+	if ( ! isOk(point)) return false;
+	return true;
 }
 
 void PerformancePayloadFromTFormula::printFormula(PerformanceResult::ResultType res) const {
-  //
-  // which formula to use?
-  //
-  if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos)  {
-    cout << "Warning: result not available!" << endl;
-    return;
-  }
-  
-  // nice, what to do here???
-  const boost::shared_ptr<TFormula>& formula = 
-    compiledFormulas_[resultPos(res)];
-  cout << "-- Formula: " << formula->GetExpFormula("p") << endl;
-  // prepare the vector to pass, order counts!!!
-  //
-  std::vector<BinningVariables::BinningVariablesType> t = myBinning();
-  
-  for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
-    int pos = limitPos(*it);
-    std::pair<float, float> limits = (pl.limits())[pos];
-    cout << "      Variable: " << *it << " with limits: " << "from: " << limits.first  << " to: " << limits.second << endl;
-  }
+	//
+	// which formula to use?
+	//
+	if (resultPos(res) == PerformancePayloadFromTFormula::InvalidPos)  {
+		cout << "Warning: result not available!" << endl;
+		return;
+	}
+
+	// nice, what to do here???
+	const boost::shared_ptr<TFormula>& formula =
+			compiledFormulas_[resultPos(res)];
+	cout << "-- Formula: " << formula->GetExpFormula("p") << endl;
+	// prepare the vector to pass, order counts!!!
+	//
+	std::vector<BinningVariables::BinningVariablesType> t = myBinning();
+
+	for (std::vector<BinningVariables::BinningVariablesType>::const_iterator it = t.begin(); it != t.end();++it){
+		int pos = limitPos(*it);
+		std::pair<float, float> limits = (pl.limits())[pos];
+		cout << "      Variable: " << *it << " with limits: " << "from: " << limits.first  << " to: " << limits.second << endl;
+	}
 
 }
 


### PR DESCRIPTION
Many TFormulas were created in a for loop with exactly the same name "rr". 
It was verified that the TFormulas are not overwritten, but this causes ROOT to loose track of all of them.  
@tommasoboccali 
