### PR TITLE
Don't declare undefined functions

### DIFF
--- a/CondFormats/JetMETObjects/interface/METCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/METCorrectorParameters.h
@@ -79,10 +79,10 @@ class METCorrectorParameters
     const Record& record(unsigned fBin)                          const {return mRecords[fBin]; }
     const Definitions& definitions()                             const {return mDefinitions;   }
     unsigned size()                                              const {return mRecords.size();}
-    unsigned size(unsigned fVar)                                 const;
-    int binIndex(const std::vector<float>& fX)                   const;
-    int neighbourBin(unsigned fIndex, unsigned fVar, bool fNext) const;
-    std::vector<float> binCenters(unsigned fVar)                 const;
+    //unsigned size(unsigned fVar)                                 const;
+    //int binIndex(const std::vector<float>& fX)                   const;
+    //int neighbourBin(unsigned fIndex, unsigned fVar, bool fNext) const;
+    //std::vector<float> binCenters(unsigned fVar)                 const;
     void printScreen()                                           const;
     void printFile(const std::string& fFileName)                 const;
     bool isValid() const { return valid_; }


### PR DESCRIPTION
The class METCorrectorParameters has several member functions whose definitions are commented out, while the declarations are still present.  This is OK in C++, but this is not OK for ROOT5, because the generated dictionary contains calls to the undefined functions, and so fails to link.
This PR simply comments out the declarations of the functions whose definitions are commented out.
Please expedite merging this, as this will fix (virtually?) all the link errors in CMSSW_7_5_ROOT5_X.
