### PR TITLE
Fix checksums and use typedef to fix build errors

### DIFF
--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -1,11 +1,13 @@
 <lcgdict>
-  <class name="std::bitset<reco::TrackBase::algoSize>"/>
+  <class name="reco::TrackBase::AlgoMask"/>
   <class name="reco::HitPattern" ClassVersion="12">
       <version ClassVersion="12" checksum="3922863495"/>
       <version ClassVersion="11" checksum="1621684703"/>
   </class>
 
-  <class name="reco::TrackBase" ClassVersion="13">
+  <class name="reco::TrackBase" ClassVersion="16">
+   <version ClassVersion="16" checksum="3673246687"/>
+   <version ClassVersion="15" checksum="1802760569"/>
    <version ClassVersion="14" checksum="3929365050"/>
    <version ClassVersion="13" checksum="1244921154"/>
     <field name="vertex_" iotype="ROOT::Math::PositionVector3D<ROOT::Math::Cartesian3D<Double32_t>,ROOT::Math::DefaultCoordinateSystemTag>" /> 
@@ -362,7 +364,9 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="13">
+  <class name="reco::Track" ClassVersion="16">
+   <version ClassVersion="16" checksum="697987788"/>
+   <version ClassVersion="15" checksum="3694119510"/>
    <version ClassVersion="14" checksum="4228121071"/>
    <version ClassVersion="13" checksum="36410295"/>
    <version ClassVersion="12" checksum="1190637787"/>


### PR DESCRIPTION
This PR fixes build errors in CMSSW_7_4_ROOT4_X in package DataFormats/TrackReco.
There were two checksum errors, and a bitset class (std::bitsetreco::TrackBase::algoSize) that CINT could not handle. The bitset problem was avoided by using the existing typedef name instead of the class name.
This PR is identical to #9429, which made the same fixes in CMSSW_7_5_ROOT5_X.  At that time, it was not realized that 7_4_ROOT5_X had the same problem.
There will be another PR making the new checksums known in 7_4_X.
