### PR TITLE
Add missing include to fix build problem

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -8,6 +8,7 @@
 
 
 #include <iostream>
+#include <unordered_set>
 
 template<typename P>
 class MCTruthHelper {


### PR DESCRIPTION
This trivial PR adds a missing #include to fix a compilation error in CMSSW_7_4_ROOT5_X.
