### PR TITLE
Add missing include to fix build problem

### DIFF
--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -8,6 +8,7 @@
 
 
 #include <iostream>
+#include <unordered_set>
 
 template<typename P>
 class MCTruthHelper {


### PR DESCRIPTION
This trivial PR adds a missing include to fix a build error in CMSSW_7_4_ROOT5_X.
Since the header is also missing in 7_4_X, and for code commonality, this fix should go into 7_4_X as well, since it is just an accident that there is no build error due to this in 7_4_X.
