### PR TITLE
Fix inconsistency in BeamSpot IOV creation in PCL

### DIFF
--- a/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
+++ b/Calibration/TkAlCaRecoProducers/src/AlcaBeamSpotManager.cc
@@ -305,7 +305,8 @@ void AlcaBeamSpotManager::createWeightedPayloads(void){
 	  																															    
       }
       //tmprun = currentBS->second.Run																														    
-      ++countlumi;																																    
+      // increase the counter by one only if the IOV hasn't been closed																														    
+      if (!docreate) ++countlumi;																																    
       
       currentBS = nextBS;
       nextBS	= nextNextBS;


### PR DESCRIPTION
Fix faulty Lumi Section counter restart that caused the max number of LS grouped into an IOV to be 59 rather than 60 as thought. This affects the Prompt Calibration Loop.

Can cause a mismatch for the 2012 replayed runs, but notice of this change has been propagated over the relevant hyper news and experts are aware.
