### PR TITLE
Reduced pTmin of pixel pairs from 4 to 1 GeV in HI reco

### DIFF
--- a/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
+++ b/RecoHI/HiTracking/python/hiPixelPairStep_cff.py
@@ -46,7 +46,7 @@ hiPixelPairSeedLayers = RecoTracker.TkSeedingLayers.PixelLayerPairs_cfi.PixelLay
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
 hiPixelPairSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff.globalSeedsFromPairsWithVertices.clone()
 hiPixelPairSeeds.RegionFactoryPSet.RegionPSet.VertexCollection=cms.InputTag("hiSelectedVertex")
-hiPixelPairSeeds.RegionFactoryPSet.RegionPSet.ptMin = 4.0
+hiPixelPairSeeds.RegionFactoryPSet.RegionPSet.ptMin = 1.0
 hiPixelPairSeeds.RegionFactoryPSet.RegionPSet.originRadius = 0.005
 hiPixelPairSeeds.RegionFactoryPSet.RegionPSet.nSigmaZ = 4.0
 # sigmaZVertex is only used when usedFixedError is True -Matt


### PR DESCRIPTION
Improves efficiency by 5-10% between 1-4 GeV for the HI reco (pp reco unaffected).
Pixel pairs step timing will be longer, as well as modest increase in PF timing.
Total size of track collection will grow, but fake rate for highPurity tracks (which are what enters analysis) is essentially unchanged.
