### PR TITLE
Add missing references

### DIFF
--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -3,6 +3,10 @@
 #include <climits>
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h"
 
+constexpr float HcalDeterministicFit::invGpar[3];
+constexpr float HcalDeterministicFit::negthre[2];
+constexpr int HcalDeterministicFit::HcalRegion[2];
+
 using namespace std;
 
 HcalDeterministicFit::HcalDeterministicFit() {


### PR DESCRIPTION
The followin symbols:
- `HcalDeterministicFit::HcalRegion`
- `HcalDeterministicFit::negthre`
- `HcalDeterministicFit::invGpar`

are used in `void HcalDeterministicFit::apply<T>` methods.

@davidlange6 this should resolve issues on Clang builds. Possible the last bit.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
