### PR TITLE
Backport of #9600: Fixes for parallel offline and track splitting validations

### DIFF
--- a/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
+++ b/Alignment/OfflineValidation/macros/PlotAlignmentValidation.C
@@ -830,7 +830,7 @@ void PlotAlignmentValidation::plotChi2(const char *inputFile)
   TGaxis::SetMaxDigits(3);
 
   Bool_t errorflag = kTRUE;
-  TFile* fi1 = new TFile(inputFile,"read");
+  TFile* fi1 = TFile::Open(inputFile,"read");
   TDirectoryFile* mta1 = NULL;
   TDirectoryFile* mtb1 = NULL;
   TCanvas* normchi = NULL;

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/alternateValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/alternateValidationTemplates.py
@@ -263,7 +263,7 @@ process.TrackerTrackHitFilter.stripAllInvalidHits = False
 process.TrackerTrackHitFilter.rejectBadStoNHits = True
 process.TrackerTrackHitFilter.StoNcommands = cms.vstring("ALL 18.0")
 process.TrackerTrackHitFilter.rejectLowAngleHits = True
-process.TrackerTrackHitFilter.TrackAngleCut = 0.35 # in rads, starting from the module surface
+process.TrackerTrackHitFilter.TrackAngleCut = 0.1 # in rads, starting from the module surface
 process.TrackerTrackHitFilter.usePixelQualityFlag = True #False
 
 #-- TrackProducer

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -255,7 +255,7 @@ void TkAlExtendedOfflineValidation()
   p.setTreeBaseDir(".oO[OfflineTreeBaseDir]Oo.");
   p.plotDMR(".oO[DMRMethod]Oo.",.oO[DMRMinimum]Oo.,".oO[DMROptions]Oo.");
   p.plotSurfaceShapes(".oO[SurfaceShapes]Oo.");
-  p.plotChi2(".oO[resultPlotFile]Oo._result.root");
+  p.plotChi2("root://eoscms//eos/cms/store/caf/user/$USER/.oO[eosdir]Oo./.oO[resultPlotFile]Oo._result.root");
 }
 """
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/configTemplates.py
@@ -165,9 +165,6 @@ find . -name "*.stdout" -exec gzip -f {} \;
 ######################################################################
 mergeParallelResults="""
 
-#set directory to which TkAlOfflineJobsMerge.C saves the merged file
-# export OUTPUTDIR=.oO[datadir]Oo.
-export OUTPUTDIR=.
 .oO[copyMergeScripts]Oo.
 .oO[haddLoop]Oo.
 

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
@@ -111,9 +111,9 @@ class OfflineValidation(GenericValidationData):
         """
         repMap = self.getRepMap()
 
-        parameters = ",".join(repMap["resultFiles"])
+        parameters = "root://eoscms//eos/cms" + ",root://eoscms//eos/cms".join(repMap["resultFiles"])
 
-        mergedoutputfile = repMap["finalResultFile"]
+        mergedoutputfile = "root://eoscms//eos/cms.oO[finalResultFile]Oo."
         validationsSoFar += ('root -x -b -q -l "TkAlOfflineJobsMerge.C(\\\"'
                              +parameters+'\\\",\\\"'+mergedoutputfile+'\\\")"'
                              +"\n")

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidation.py
@@ -97,10 +97,10 @@ class OfflineValidation(GenericValidationData):
         """
         repMap = self.getRepMap()
         if validationsSoFar == "":
-            validationsSoFar = ('PlotAlignmentValidation p("%(finalOutputFile)s",'
-                                '"%(name)s", %(color)s, %(style)s);\n')%repMap
+            validationsSoFar = ('PlotAlignmentValidation p("root://eoscms//eos/cms%(finalResultFile)s",'
+                                '"%(title)s", %(color)s, %(style)s);\n')%repMap
         else:
-            validationsSoFar += ('p.loadFileList("%(finalOutputFile)s", "%(name)s",'
+            validationsSoFar += ('  p.loadFileList("root://eoscms//eos/cms%(finalResultFile)s", "%(title)s",'
                                  '%(color)s, %(style)s);\n')%repMap
         return validationsSoFar
 
@@ -111,9 +111,9 @@ class OfflineValidation(GenericValidationData):
         """
         repMap = self.getRepMap()
 
-        parameters = ",".join(repMap["outputFiles"])
+        parameters = ",".join(repMap["resultFiles"])
 
-        mergedoutputfile = repMap["finalOutputFile"]
+        mergedoutputfile = repMap["finalResultFile"]
         validationsSoFar += ('root -x -b -q -l "TkAlOfflineJobsMerge.C(\\\"'
                              +parameters+'\\\",\\\"'+mergedoutputfile+'\\\")"'
                              +"\n")

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/offlineValidationTemplates.py
@@ -190,38 +190,14 @@ process.offlineBeamSpot*process.HighPuritySelector*process.TrackRefitter1*proces
 
 ######################################################################
 ######################################################################
-mergeOfflineParallelResults="""
-
-# Merging works also if there is only one file to merge
-# if merged file already exists it will be moved to a backup file (~)
-
-# run TkAlOfflineJobsMerge.C
-echo -e "\n\nMerging results from offline parallel jobs with TkAlOfflineJobsMerge.C"
-#set directory to which TkAlOfflineJobsMerge.C saves the merged file
-# export OUTPUTDIR=.oO[datadir]Oo.
-export OUTPUTDIR=.
-cp .oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C .
-.oO[haddLoop]Oo.
-
-# create log file
-# ls -al .oO[datadir]Oo./AlignmentValidation*.root > .oO[datadir]Oo./log_rootfilelist.txt
-ls -al AlignmentValidation*.root > .oO[datadir]Oo./log_rootfilelist.txt
-
-# Remove parallel job files
-.oO[rmUnmerged]Oo.
-"""
-
-
-######################################################################
-######################################################################
 mergeOfflineParJobsTemplate="""
+#include ".oO[CMSSW_BASE]Oo./src/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C"
+
 int TkAlOfflineJobsMerge(TString pars, TString outFile)
 {
 // load framework lite just to find the CMSSW libs...
 gSystem->Load("libFWCoreFWLite");
 AutoLibraryLoader::enable();
-//compile the macro
-gROOT->ProcessLine(".L merge_TrackerOfflineValidation.C++");
 
 return hadd(pars, outFile);
 }

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
@@ -65,8 +65,8 @@ class TrackSplittingValidation(GenericValidationData):
         """
         repMap = self.getRepMap()
 
-        parameters = " ".join(os.path.join("root://eoscms//eos/cms",file) for file in repMap["resultFiles"])
+        parameters = " ".join(os.path.join("root://eoscms//eos/cms", file.lstrip("/")) for file in repMap["resultFiles"])
 
-        mergedoutputfile = os.path.join("root://eoscms//eos/cms",repMap["finalResultFile"])
+        mergedoutputfile = os.path.join("root://eoscms//eos/cms", repMap["finalResultFile"].lstrip("/"))
         validationsSoFar += "hadd %s %s\n" % (mergedoutputfile, parameters)
         return validationsSoFar

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidation.py
@@ -65,8 +65,8 @@ class TrackSplittingValidation(GenericValidationData):
         """
         repMap = self.getRepMap()
 
-        parameters = " ".join(repMap["outputFiles"])
+        parameters = " ".join(os.path.join("root://eoscms//eos/cms",file) for file in repMap["resultFiles"])
 
-        mergedoutputfile = repMap["finalOutputFile"]
+        mergedoutputfile = os.path.join("root://eoscms//eos/cms",repMap["finalResultFile"])
         validationsSoFar += "hadd %s %s\n" % (mergedoutputfile, parameters)
         return validationsSoFar

--- a/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
+++ b/Alignment/OfflineValidation/python/TkAlAllInOneTool/trackSplittingValidationTemplates.py
@@ -141,7 +141,9 @@ process.TrackRefitter2 = process.TrackRefitter1.clone(
 
 ### Now adding the construction of global Muons
 # what Chang did...
-process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
+#   In 74X it no longer works if ReconstructionCosmics is imported
+#   Results in 73X are identical with or without it so it seems safe to remove
+#process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
 
 process.cosmicValidation = cms.EDAnalyzer("CosmicSplitterValidation",
 	ifSplitMuons = cms.bool(False),

--- a/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C
+++ b/Alignment/OfflineValidation/scripts/merge_TrackerOfflineValidation.C
@@ -72,7 +72,7 @@ int hadd(const char *filesSeparatedByCommaOrEmpty = "", const char * outputFile 
     Int_t nEvt = 0;
     //get file name
     std::cout<<"Type in general file name (ending is added automatically)."<<std::endl;
-    std::cout<<"i.e. Validation_CRUZET_data as name, code adds 1,2,3 + .root"<<std::endl;
+    std::cout<<"i.e. Validation_CRUZET_data_ as name, code adds 1,2,3 + .root"<<std::endl;
     std::cin>>inputFileName;
     
     std::cout << "Type number of files to merge." << std::endl;
@@ -117,10 +117,9 @@ int hadd(const char *filesSeparatedByCommaOrEmpty = "", const char * outputFile 
   TString outputFileString;
 
   if (strlen(outputFile)!=0) 
-    outputFileString = TString("$OUTPUTDIR/")+ TString(outputFile);
+    outputFileString = TString(outputFile);
   else
-    outputFileString = "$OUTPUTDIR/merge_output.root";
-  
+    outputFileString = "merge_output.root";
   TFile *Target = TFile::Open( outputFileString, "RECREATE" );
   MergeRootfile( Target, FileList);
   std::cout << "Finished merging of histograms." << std::endl;
@@ -175,9 +174,9 @@ int hadd(const char *filesSeparatedByCommaOrEmpty = "", const char * outputFile 
 /////////////////////////////////////////////////////////////////////////
 void MergeRootfile( TDirectory *target, TList *sourcelist) {
 
- 
-  TString path( (char*)strstr( target->GetPath(), ":" ) );
-  path.Remove( 0, 2 );
+  cout << target->GetPath() << endl;
+  TString path( (char*)strstr( target->GetPath(), ".root:" ) );
+  path.Remove( 0, 7 );
   //  TString tmp;
   TFile *first_source = (TFile*)sourcelist->First();
   first_source->cd( path );


### PR DESCRIPTION
Fixes to get the track splitting validation and parallel jobs for the offline validation working in 74X and up

(includes one commit rebased from #9550 to avoid a merge conflict)
