### PR TITLE
Add missing dictionaries

### DIFF
--- a/Fireworks/Core/src/classes.h
+++ b/Fireworks/Core/src/classes.h
@@ -30,6 +30,8 @@
 #include "Fireworks/Core/interface/FWTSelectorToEventList.h"
 #include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 #include "Fireworks/Core/src/FW3DViewDistanceMeasureTool.h"
+#include "Fireworks/Core/interface/FWPartialConfig.h"
+
 namespace Fireworks_Core {
    struct Fireworks_Core {
       //add 'dummy' Wrapper variable for each class type you put into the Event

--- a/Fireworks/Core/src/classes_def.xml
+++ b/Fireworks/Core/src/classes_def.xml
@@ -36,4 +36,7 @@
   <class name="FWEveDigitSetScalableMarker"/>
   <class name="FWEveDigitSetScalableMarkerGL"/>
   <class name="FW3DViewDistanceMeasureTool"/>
+  <class name="FWPartialConfigGUI"/>
+  <class name="FWPartialConfigLoadGUI"/>
+  <class name="FWPartialConfigSaveGUI"/>
 </lcgdict>


### PR DESCRIPTION
Fis CMSSW_7_4_ROOT5_X linking error in Fireworks/Core by adding missing dictionaries to specification file.  The dictionaries are missing only in CMSSW_7_4_ROOT5_X.
