### PR TITLE
Fix Checksums in DataFormats/GsfTrackReco

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -24,7 +24,9 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="13">
+  <class name="reco::GsfTrack" ClassVersion="16">
+   <version ClassVersion="16" checksum="4129402716"/>
+   <version ClassVersion="15" checksum="2494468278"/>
    <version ClassVersion="14" checksum="3085391575"/>
    <version ClassVersion="13" checksum="1287963871"/>
    <version ClassVersion="12" checksum="1456169080"/>


### PR DESCRIPTION
This PR corrects a checksum in DataFormats/GsfTrackReco to fix a build error in this package.
There is also a PR (#9607) in CMSSW_7_4_X to make the new checksum known there.
Please expedite the merge.
