### PR TITLE
Remove duplicate classes

### DIFF
--- a/DataFormats/StdDictionaries/src/classes_def_pair.xml
+++ b/DataFormats/StdDictionaries/src/classes_def_pair.xml
@@ -1,5 +1,4 @@
 <lcgdict>
- <class name="std::pair<const int,int>"/>
  <class name="std::pair<const int,std::pair<double,double> >"/>
  <class name="std::pair<const int,std::pair<unsigned int,unsigned int> >"/>
  <class name="std::pair<const int,std::pair<unsigned long,unsigned long> >"/>
@@ -8,7 +7,6 @@
  <class name="std::pair<const short,short>"/>
  <class name="std::pair<const short,unsigned int>"/>
  <class name="std::pair<const std::basic_string<char>,bool>"/>
- <class name="std::pair<const std::basic_string<char>,int>"/>
  <class name="std::pair<const std::basic_string<char>,std::basic_string<char> >"/>
  <class name="std::pair<const std::basic_string<char>,std::map<std::basic_string<char>,std::basic_string<char> > >"/>
  <class name="std::pair<const std::basic_string<char>,std::pair<unsigned int,unsigned int> >"/>
@@ -34,11 +32,7 @@
  <class name="std::pair<const unsigned short,float>"/>
  <class name="std::pair<const unsigned short,std::vector<unsigned short> >"/>
  <class name="std::pair<const unsigned short,unsigned short>"/>
- <class name="std::pair<double,double>"/>
  <class name="std::pair<double,std::vector<double> >"/>
- <class name="std::pair<float,float>"/>
- <class name="std::pair<int,double>"/>
- <class name="std::pair<int,int>"/>
  <class name="std::pair<int,std::pair<double,double> >"/>
  <class name="std::pair<int,std::pair<unsigned int,unsigned int> >"/>
  <class name="std::pair<int,std::pair<unsigned long,unsigned long> >"/>
@@ -47,9 +41,6 @@
  <class name="std::pair<short,std::vector<short> >"/>
  <class name="std::pair<short,unsigned int>"/>
  <class name="std::pair<std::basic_string<char>,bool>"/>
- <class name="std::pair<std::basic_string<char>,double>"/>
- <class name="std::pair<std::basic_string<char>,float>"/>
- <class name="std::pair<std::basic_string<char>,int>"/>
  <class name="std::pair<std::basic_string<char>,std::basic_string<char> >"/>
  <class name="std::pair<std::basic_string<char>,std::map<std::basic_string<char>,std::basic_string<char> > >"/>
  <class name="std::pair<std::basic_string<char>,std::pair<unsigned int,unsigned int> >"/>


### PR DESCRIPTION
Resolve the following run-time warnings/errors on ROOT 6.04.00:

```
Warning in <TInterpreter::ReadRootmapFile>: class pair<const int,int> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<const std::string,int> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<const string,int> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<double,double> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<float,float> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<int,double> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<int,int> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<std::string,int> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<string,double> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<string,float> found in libCore.so is already in libDataFormatsStdDictionaries.so
Warning in <TInterpreter::ReadRootmapFile>: class pair<string,int> found in libCore.so is already in libDataFormatsStdDictionaries.so
```

There types are already defined in `libCore.so`. ROOT 6 built with
configure/Makfile does not generate `libCore.rootmap`, but it does
once built with CMake.

This is for `CMSSW_7_5_ROOT64_X`.
