### PR TITLE
new DQM GUI tested in parallel

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -57,7 +57,7 @@ class MatrixInjector(object):
             self.wmagent = 'cmsweb.cern.ch'
 
         if not self.dqmgui:
-            self.dqmgui="https://cmsweb.cern.ch/dqm/relval"
+            self.dqmgui="https://cmsweb.cern.ch/dqm/relval;https://cmsweb-testbed.cern.ch/dqm/relval"
         #couch stuff
         self.couch = 'https://'+self.wmagent+'/couchdb'
 # self.couchDB = 'reqmgr_config_cache'


### PR DESCRIPTION
As requested by DQM-gui team, MatrixInjector is configured  to send DQM output to two guis (standard + testbed) This will stay ~ 1 month for the transition before putting in production the new DQM GUI.
This PR is affecting  workflow submission only.
@franzoni, I followed your instructions , you may want to check as well- Thanks.
