### PR TITLE
Fix ConfigEditor to handle VPSet which have no label

### DIFF
--- a/FWCore/GuiBrowsers/python/ConfigToolBase.py
+++ b/FWCore/GuiBrowsers/python/ConfigToolBase.py
@@ -140,7 +140,7 @@ class ConfigToolBase(object) :
             dumpPython = '#'+self._comment
         dumpPython += "\n"+self._label+"(process "
         for key in self._parameters.keys():
-	  if str(self._parameters[key].value)!=str(self._defaultParameters[key].value):
+	  if repr(self._parameters[key].value)!=repr(self._defaultParameters[key].value):
             dumpPython+= ", "+str(key)+" = "
             if self._parameters[key].type is str:
                 string = "'"+str(self.getvalue(key))+"'"


### PR DESCRIPTION
edmConfigEditor isn't able to display VPSet, since it is looking for their label through the str implementation. Using instead the repr works for any kind of config element.
