### PR TITLE
Fastsim: cleanup tracker rechits & remove memory leak GSRecHitMatcher

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -40,11 +40,11 @@ public:
   virtual ~BaseTrackerRecHit() {}
 
   // no position (as in persistent)
-  BaseTrackerRecHit(DetId id, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id,(unsigned int)(rt)) {}
+ BaseTrackerRecHit(DetId id, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id,(unsigned int)(rt)),qualWord_(0) {}
 
-  BaseTrackerRecHit( const LocalPoint& p, const LocalError&e,
-		     GeomDet const & idet, trackerHitRTTI::RTTI rt) :  
-    TrackingRecHit(idet, (unsigned int)(rt)), pos_(p), err_(e){
+ BaseTrackerRecHit( const LocalPoint& p, const LocalError&e,
+		    GeomDet const & idet, trackerHitRTTI::RTTI rt) :  
+  TrackingRecHit(idet, (unsigned int)(rt)), pos_(p), err_(e), qualWord_(0){
     LocalError lape = static_cast<TrackerGeomDet const *>(det())->localAlignmentError();
     if (lape.valid())
       err_ = LocalError(err_.xx()+lape.xx(),

--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
@@ -7,77 +7,69 @@ class SiTrackerGSRecHit2D;
 
 class SiTrackerGSMatchedRecHit2D : public GSSiTrackerRecHit2DLocalPos{
   
-public:
+ public:
   
-  SiTrackerGSMatchedRecHit2D(): GSSiTrackerRecHit2DLocalPos(),
-			 simhitId_(),
-			 simtrackId_(),
-			 eeId_(),
-                         cluster_(),  
-                         pixelMultiplicityAlpha_(), 
-                         pixelMultiplicityBeta_(),
-                         isMatched_(), 
-                         componentMono_(),
-                         componentStereo_() {}
+ SiTrackerGSMatchedRecHit2D()
+   : GSSiTrackerRecHit2DLocalPos()
+    , simtrackId_(-1)
+    , isMatched_(false)
+    , componentMono_()
+    , componentStereo_(){}
   
   ~SiTrackerGSMatchedRecHit2D() {}
   
- typedef edm::Ref<FastTrackerClusterCollection, FastTrackerCluster > ClusterRef;
- typedef edm::RefProd<FastTrackerClusterCollection> ClusterRefProd;
+  SiTrackerGSMatchedRecHit2D( const LocalPoint & pos, 
+			      const LocalError & err,
+			      const GeomDet & idet,
+			      const uint32_t simtrackId)
+    : GSSiTrackerRecHit2DLocalPos(pos,err,idet)
+    , simtrackId_(simtrackId)
+    , isMatched_(false)
+    , id_(-1)
+    , eeId_(-1)
+    {};
 
+  SiTrackerGSMatchedRecHit2D( const LocalPoint & pos, 
+			      const LocalError & err,
+			      const GeomDet & idet,
+			      const uint32_t simtrackId,
+			      const bool isMatched,
+			      const SiTrackerGSRecHit2D & rMono, 
+			      const SiTrackerGSRecHit2D & rStereo) 
+    : GSSiTrackerRecHit2DLocalPos(pos,err,idet)
+    , simtrackId_(simtrackId)
+    , isMatched_(isMatched)
+    , componentMono_(rMono) 
+    , componentStereo_(rStereo)
+    , id_(-1)
+    , eeId_(-1)
+    {};
 
-  SiTrackerGSMatchedRecHit2D( const LocalPoint&, const LocalError&,
-		       GeomDet const & idet,
-		       const int simhitId,
-		       const int simtrackId,
-		       const uint32_t eeId,
-                       ClusterRef const&  cluster,
-		       const int pixelMultiplicityX,
-		       const int pixelMultiplicityY,
-		       const bool isMatched,
-		       const SiTrackerGSRecHit2D* rMono, 
-		       const SiTrackerGSRecHit2D* rStereo 
-		       );  
-
-  SiTrackerGSMatchedRecHit2D( const LocalPoint&, const LocalError&,
-		       GeomDet const & idet,
-		       const int simhitId,
-		       const int simtrackId,
-		       const uint32_t eeId,
-                       ClusterRef const&  cluster,
-		       const int pixelMultiplicityX,
-		       const int pixelMultiplicityY
-		       );  
 
   virtual SiTrackerGSMatchedRecHit2D * clone() const {SiTrackerGSMatchedRecHit2D * p =  new SiTrackerGSMatchedRecHit2D( * this); p->load(); return p;}
-  
-  const int& simhitId()    const { return simhitId_;}
-  const int& simtrackId()  const { return simtrackId_;}
-  const uint32_t& eeId()   const { return eeId_;}
-  const int& simMultX()    const { return pixelMultiplicityAlpha_;}
-  const int& simMultY()    const { return pixelMultiplicityBeta_;}
-  const bool& isMatched()  const { return isMatched_;}
-  const SiTrackerGSRecHit2D *monoHit() const { return &componentMono_;}
-  const SiTrackerGSRecHit2D *stereoHit() const { return &componentStereo_;}
 
- ClusterRef const& cluster() const { return cluster_;}
-  void setClusterRef(const ClusterRef &ref) { cluster_  = ref; }
- 
+  const uint32_t & id()          const { return id_;}
+  const uint32_t & simtrackId()  const { return simtrackId_;}
+  const uint32_t & eeId()   const { return eeId_;}
+  const bool & isMatched()  const { return isMatched_;}
+  const SiTrackerGSRecHit2D & monoHit() const { return componentMono_;}
+  const SiTrackerGSRecHit2D & stereoHit() const { return componentStereo_;}
+
+  void setId(uint32_t id){id_ = id;}
   void setEeId(uint32_t eeId){eeId_ = eeId;}
 
   virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const;
- 
-private:
-  int const simhitId_;
-  int const simtrackId_;
-  uint32_t eeId_;
-  ClusterRef cluster_;
-  int const pixelMultiplicityAlpha_;
-  int const pixelMultiplicityBeta_;
-  bool isMatched_;
+  
+ private:
+  
+  const uint32_t simtrackId_;
+  const bool isMatched_;
+  
+  const SiTrackerGSRecHit2D componentMono_;
+  const SiTrackerGSRecHit2D componentStereo_;
 
-  SiTrackerGSRecHit2D componentMono_;
-  SiTrackerGSRecHit2D componentStereo_;
+  uint32_t id_;
+  uint32_t eeId_;  
 };
 
 

--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2D.h
@@ -5,61 +5,44 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "FastSimDataFormats/External/interface/FastTrackerClusterCollection.h" 
 
-// typedef edm::Ref<FastTrackerClusterCollection, FastTrackerCluster > ClusterRef;
-// typedef edm::RefProd<FastTrackerClusterCollection> ClusterRefProd;
-
 class SiTrackerGSRecHit2D : public GSSiTrackerRecHit2DLocalPos{
   
-public:
+ public:
   
- 
   
-  SiTrackerGSRecHit2D(): GSSiTrackerRecHit2DLocalPos(),
-			 simhitId_(),
-			 simtrackId_(),
-			 eeId_(),
-                         cluster_(),  
-			 pixelMultiplicityAlpha_(), 
-                         pixelMultiplicityBeta_() {}
+  
+ SiTrackerGSRecHit2D()
+   : GSSiTrackerRecHit2DLocalPos()
+    , simtrackId_() {}
   
   ~SiTrackerGSRecHit2D() {}
   
- typedef edm::Ref<FastTrackerClusterCollection, FastTrackerCluster > ClusterRef;
- typedef edm::RefProd<FastTrackerClusterCollection> ClusterRefProd;
-
-
-  SiTrackerGSRecHit2D( const LocalPoint&, const LocalError&,
-		       GeomDet const & idet,
-		       const int simhitId,
-		       const int simtrackId,
-		       const uint32_t eeId,
-		       ClusterRef const&  cluster,
-		       const int pixelMultiplicityX,
-		       const int pixelMultiplicityY);     
+  SiTrackerGSRecHit2D( const LocalPoint & pos, 
+		       const LocalError & err,
+		       const GeomDet & idet,
+		       const uint32_t simtrackId)
+    : GSSiTrackerRecHit2DLocalPos(pos,err,idet)
+    , simtrackId_(simtrackId)
+    , id_(-1)
+    , eeId_(-1)
+    {};
   
   virtual SiTrackerGSRecHit2D * clone() const {SiTrackerGSRecHit2D * p = new SiTrackerGSRecHit2D( * this); p->load(); return p;}
   
-  const int& simhitId()    const { return simhitId_;}
-  const int& simtrackId()  const { return simtrackId_;}
+  const uint32_t & id()          const { return id_;}
+  const uint32_t& simtrackId()  const { return simtrackId_;}
   const uint32_t& eeId()   const { return eeId_;}
-  const int& simMultX()    const { return pixelMultiplicityAlpha_;}
-  const int& simMultY()    const { return pixelMultiplicityBeta_;}
-
-  ClusterRef const& cluster() const { return cluster_;}
-  void setClusterRef(const ClusterRef &ref) { cluster_  = ref; }
   
+  void setId(uint32_t id){id_ = id;}
   void setEeId(uint32_t eeId){eeId_ = eeId;}
 
-  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const {return false;}
+  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const;
   
  private:
   
-  int simhitId_;
-  int simtrackId_;
+  const uint32_t simtrackId_;
+  uint32_t id_;
   uint32_t eeId_;
-  ClusterRef cluster_;
-  int pixelMultiplicityAlpha_;
-  int pixelMultiplicityBeta_;
   
 };
 

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
@@ -1,58 +1,9 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h"
 
-SiTrackerGSMatchedRecHit2D::SiTrackerGSMatchedRecHit2D( const LocalPoint& pos, const LocalError& err,
-					  GeomDet const & idet,
-					  const int simhitId         ,
-					  const int simtrackId       ,
-					  const uint32_t eeId,
-					  ClusterRef const&  cluster ,
-					  const int pixelMultiplicityX = -1,
-					  const int pixelMultiplicityY = -1, 
-					  const bool isMatched = false,
-					  const SiTrackerGSRecHit2D* rMono = 0 , 
-					  const SiTrackerGSRecHit2D* rStereo= 0 ):
-  GSSiTrackerRecHit2DLocalPos(pos,err,idet) ,
-  simhitId_(simhitId) ,
-  simtrackId_(simtrackId) ,
-  eeId_(eeId) ,
-  cluster_(cluster), 
-  pixelMultiplicityAlpha_(pixelMultiplicityX), 
-  pixelMultiplicityBeta_(pixelMultiplicityY), 
-  isMatched_(isMatched), 
-  componentMono_(*rMono), 
-  componentStereo_(*rStereo)
-{}
-
-SiTrackerGSMatchedRecHit2D::SiTrackerGSMatchedRecHit2D( const LocalPoint& pos, const LocalError& err,
-					  GeomDet const & idet,
-					  const int simhitId         ,
-					  const int simtrackId       ,
-					  const uint32_t eeId,
-					  ClusterRef const&  cluster ,
-					  const int pixelMultiplicityX = -1,
-					  const int pixelMultiplicityY = -1):
-  GSSiTrackerRecHit2DLocalPos(pos,err,idet) ,
-  simhitId_(simhitId) ,
-  simtrackId_(simtrackId) ,
-  eeId_(eeId) ,
-  cluster_(cluster),
-  pixelMultiplicityAlpha_(pixelMultiplicityX), 
-  pixelMultiplicityBeta_(pixelMultiplicityY), 
-  isMatched_(0), 
-  componentMono_(), 
-  componentStereo_()
-{}
-
-
-
 bool SiTrackerGSMatchedRecHit2D::sharesInput( const TrackingRecHit* other, 
-					    SharedInputType what) const
- {
-   if (geographicalId() != other->geographicalId()) return false;
-   if(! other->isValid()) return false;
+					      SharedInputType what) const
+{
+  const SiTrackerGSMatchedRecHit2D * otherCasted = dynamic_cast<const SiTrackerGSMatchedRecHit2D*>(other);
+  return bool(otherCasted) && otherCasted->id() == this->id() && otherCasted->eeId() == this->eeId();
+}
 
-   const SiTrackerGSMatchedRecHit2D* otherCast = static_cast<const SiTrackerGSMatchedRecHit2D*>(other);
-
-   return cluster_ == otherCast->cluster();
- }
- 

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerGSRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerGSRecHit2D.cc
@@ -1,19 +1,9 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2D.h"
 
 
-SiTrackerGSRecHit2D::SiTrackerGSRecHit2D( const LocalPoint& pos, const LocalError& err,
-					  GeomDet const & idet,
-					  const int simhitId         ,
-					  const int simtrackId       ,
-					  const uint32_t eeId        ,
-					  ClusterRef const&  cluster ,
-					  const int pixelMultiplicityX = -1,
-					  const int pixelMultiplicityY = -1 
-					   ): 
-  GSSiTrackerRecHit2DLocalPos(pos,err,idet) ,
-  simhitId_(simhitId) ,
-  simtrackId_(simtrackId) ,
-  eeId_(eeId) ,
-  cluster_(cluster), 
-  pixelMultiplicityAlpha_(pixelMultiplicityX), 
-  pixelMultiplicityBeta_(pixelMultiplicityY){}
+bool SiTrackerGSRecHit2D::sharesInput( const TrackingRecHit* other, 
+					      SharedInputType what) const
+{
+  const SiTrackerGSRecHit2D * otherCasted = dynamic_cast<const SiTrackerGSRecHit2D*>(other);
+  return bool(otherCasted) && otherCasted->id() == this->id() && otherCasted->eeId() == this->eeId();
+}

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -5,15 +5,17 @@
    <version ClassVersion="11" checksum="834943006"/>
    <version ClassVersion="10" checksum="2474445311"/>
   </class>
-  <class name="SiTrackerGSRecHit2D" ClassVersion="11">
+  <class name="SiTrackerGSRecHit2D" ClassVersion="12">
+   <version ClassVersion="12" checksum="1369340574"/>
    <version ClassVersion="11" checksum="1613493049"/>
    <version ClassVersion="10" checksum="877294307"/>
   </class>
-  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="13">
-   <version ClassVersion="13" checksum="1553184391"/>
-   <version ClassVersion="12" checksum="2874379530"/>
-   <version ClassVersion="11" checksum="1553184391"/>
-   <version ClassVersion="10" checksum="3741285161"/>
+  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="14">
+    <version ClassVersion="14" checksum="3149196391"/>
+    <version ClassVersion="13" checksum="1553184391"/>
+    <version ClassVersion="12" checksum="2874379530"/>
+    <version ClassVersion="11" checksum="1553184391"/>
+    <version ClassVersion="10" checksum="3741285161"/>
   </class>
 
 

--- a/FastSimulation/EgammaElectronAlgos/python/electronGSGsfTrackCandidates_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/electronGSGsfTrackCandidates_cff.py
@@ -3,8 +3,7 @@ import FWCore.ParameterSet.Config as cms
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 # GsfTrackCandidateMaker
 electronGSGsfTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-electronGSGsfTrackCandidates.SeedProducer = cms.InputTag("electronMergedSeeds")
-electronGSGsfTrackCandidates.SeedCleaning = True
+electronGSGsfTrackCandidates.src = cms.InputTag("electronMergedSeeds")
 electronGSGsfTrackCandidates.MinNumberOfCrossedLayers = 5
 #electronGSGsfTrackCandidates.SplitHits = False
 electronGSGsfTrackCandidates.OverlapCleaning = True

--- a/FastSimulation/EgammaElectronAlgos/python/hltElectronGsfTracks_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/hltElectronGsfTracks_cff.py
@@ -6,13 +6,13 @@ import TrackingTools.GsfTracking.GsfElectronFit_cfi
 # from  FastSimulation.Configuration.StandardSequences_cff import famosGsfTrackSequence
 
 hltEgammaCkfTrackCandidatesForGSF = electronGSGsfTrackCandidates.clone()
-hltEgammaCkfTrackCandidatesForGSF.SeedProducer = "hltEgammaElectronPixelSeeds"
+hltEgammaCkfTrackCandidatesForGSF.src = "hltEgammaElectronPixelSeeds"
 hltEgammaGsfTracks = TrackingTools.GsfTracking.GsfElectronFit_cfi.GsfGlobalElectronTest.clone()
 hltEgammaGsfTracks.src = 'hltEgammaCkfTrackCandidatesForGSF'
 hltEgammaGsfTracks.TTRHBuilder = 'WithoutRefit'
 hltEgammaGsfTracks.TrajectoryInEvent = True
 
 hltEgammaCkfTrackCandidatesForGSFUnseeded = electronGSGsfTrackCandidates.clone()
-hltEgammaCkfTrackCandidatesForGSFUnseeded.SeedProducer = "hltEgammaElectronPixelSeedsUnseeded"
+hltEgammaCkfTrackCandidatesForGSFUnseeded.src = "hltEgammaElectronPixelSeedsUnseeded"
 hltEgammaGsfTracksUnseeded = hltEgammaGsfTracks.clone()
 hltEgammaGsfTracksUnseeded.src =  'hltEgammaCkfTrackCandidatesForGSFUnseeded'

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatch3HitElectronSequencesForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatch3HitElectronSequencesForHLT_cff.py
@@ -17,9 +17,7 @@ from FastSimulation.Tracking.GlobalPixelTracking_cff import *
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkf3HitL1SeededTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkf3HitL1SeededTrackCandidates.SeedProducer = cms.InputTag("hltL1SeededStartUpElectronPixelSeeds")
-hltCkf3HitL1SeededTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkf3HitL1SeededTrackCandidates.SeedCleaning = True
+hltCkf3HitL1SeededTrackCandidates.src = cms.InputTag("hltL1SeededStartUpElectronPixelSeeds")
 hltCkf3HitL1SeededTrackCandidates.SplitHits = False
 
 # CTF track fit with material
@@ -45,9 +43,7 @@ HLTPixelMatch3HitElectronL1SeededTrackingSequence = cms.Sequence(hltCkf3HitL1See
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkf3HitL1IsoTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkf3HitL1IsoTrackCandidates.SeedProducer = cms.InputTag("hltL1IsoStartUpElectronPixelSeeds")
-hltCkf3HitL1IsoTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkf3HitL1IsoTrackCandidates.SeedCleaning = True
+hltCkf3HitL1IsoTrackCandidates.src = cms.InputTag("hltL1IsoStartUpElectronPixelSeeds")
 hltCkf3HitL1IsoTrackCandidates.SplitHits = False
 
 # CTF track fit with material
@@ -74,9 +70,7 @@ HLTPixelMatch3HitElectronL1IsoTrackingSequence = cms.Sequence(hltCkf3HitL1IsoTra
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkf3HitL1NonIsoTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkf3HitL1NonIsoTrackCandidates.SeedProducer = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
-hltCkf3HitL1NonIsoTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkf3HitL1NonIsoTrackCandidates.SeedCleaning = True
+hltCkf3HitL1NonIsoTrackCandidates.src = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
 hltCkf3HitL1NonIsoTrackCandidates.SplitHits = False
 
 # CTF track fit with material
@@ -103,9 +97,7 @@ HLTPixelMatch3HitElectronL1IsoTrackingSequence = cms.Sequence(hltCkf3HitL1NonIso
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkf3HitActivityTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkf3HitActivityTrackCandidates.SeedProducer = cms.InputTag("hltActivityStartUpElectronPixelSeeds")
-hltCkf3HitActivityTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkf3HitActivityTrackCandidates.SeedCleaning = True
+hltCkf3HitActivityTrackCandidates.src = cms.InputTag("hltActivityStartUpElectronPixelSeeds")
 hltCkf3HitActivityTrackCandidates.SplitHits = False
 
 # CTF track fit with material

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronActivitySequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronActivitySequenceForHLT_cff.py
@@ -20,7 +20,7 @@ hltCkfActivityTrackCandidates.SplitHits = False
 
 hltActivityCkfTrackCandidatesForGSF = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
 hltActivityCkfTrackCandidatesForGSF.src = cms.InputTag("hltActivityStartUpElectronPixelSeeds")
-
+hltActivityCkfTrackCandidatesForGSF.SplitHits = True
 
 
 # CTF track fit with material

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronActivitySequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronActivitySequenceForHLT_cff.py
@@ -15,16 +15,11 @@ from FastSimulation.Tracking.GlobalPixelTracking_cff import *
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkfActivityTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkfActivityTrackCandidates.SeedProducer = cms.InputTag("hltActivityStartUpElectronPixelSeeds")
-hltCkfActivityTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkfActivityTrackCandidates.SeedCleaning = True
+hltCkfActivityTrackCandidates.src = cms.InputTag("hltActivityStartUpElectronPixelSeeds")
 hltCkfActivityTrackCandidates.SplitHits = False
 
 hltActivityCkfTrackCandidatesForGSF = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltActivityCkfTrackCandidatesForGSF.SeedProducer = cms.InputTag("hltActivityStartUpElectronPixelSeeds")
-hltActivityCkfTrackCandidatesForGSF.MaxNumberOfCrossedLayers = 999
-hltActivityCkfTrackCandidatesForGSF.SeedCleaning = True
-hltActivityCkfTrackCandidatesForGSF.SplitHits = True
+hltActivityCkfTrackCandidatesForGSF.src = cms.InputTag("hltActivityStartUpElectronPixelSeeds")
 
 
 

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1IsoLargeWindowSequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1IsoLargeWindowSequenceForHLT_cff.py
@@ -40,10 +40,8 @@ from FastSimulation.Tracking.GlobalPixelTracking_cff import *
 # Track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 hltCkfL1IsoLargeWindowTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkfL1IsoLargeWindowTrackCandidates.SeedProducer = cms.InputTag("hltL1IsoLargeWindowElectronPixelSeeds")
+hltCkfL1IsoLargeWindowTrackCandidates.src = cms.InputTag("hltL1IsoLargeWindowElectronPixelSeeds")
 hltCkfL1IsoLargeWindowTrackCandidates.TrackProducers = cms.VInputTag(cms.InputTag("hltCtfL1IsoWithMaterialTracks"))
-hltCkfL1IsoLargeWindowTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkfL1IsoLargeWindowTrackCandidates.SeedCleaning = True
 hltCkfL1IsoLargeWindowTrackCandidates.SplitHits = False
 
 

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1IsoSequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1IsoSequenceForHLT_cff.py
@@ -33,18 +33,14 @@ from FastSimulation.Tracking.GlobalPixelTracking_cff import *
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkfL1IsoTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-#hltCkfL1IsoTrackCandidates.SeedProducer = cms.InputTag("hltL1IsoElectronPixelSeeds")
-hltCkfL1IsoTrackCandidates.SeedProducer = cms.InputTag("hltL1IsoStartUpElectronPixelSeeds")
-hltCkfL1IsoTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkfL1IsoTrackCandidates.SeedCleaning = True
+#hltCkfL1IsoTrackCandidates.src = cms.InputTag("hltL1IsoElectronPixelSeeds")
+hltCkfL1IsoTrackCandidates.src = cms.InputTag("hltL1IsoStartUpElectronPixelSeeds")
 hltCkfL1IsoTrackCandidates.SplitHits = False
 
 # Not needed any longer 
 #hltCkfL1IsoStartUpTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-#hltCkfL1IsoStartUpTrackCandidates.SeedProducer = cms.InputTag("hltL1IsoStartUpElectronPixelSeeds")
+#hltCkfL1IsoStartUpTrackCandidates.src = cms.InputTag("hltL1IsoStartUpElectronPixelSeeds")
 #hltCkfL1IsoStartUpTrackCandidates.TrackProducers = []
-#hltCkfL1IsoStartUpTrackCandidates.MaxNumberOfCrossedLayers = 999
-#hltCkfL1IsoStartUpTrackCandidates.SeedCleaning = True
 #hltCkfL1IsoStartUpTrackCandidates.SplitHits = False
 
 # CTF track fit with material

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1NonIsoLargeWindowSequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1NonIsoLargeWindowSequenceForHLT_cff.py
@@ -38,10 +38,8 @@ from FastSimulation.Tracking.GlobalPixelTracking_cff import *
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkfL1NonIsoLargeWindowTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkfL1NonIsoLargeWindowTrackCandidates.SeedProducer = cms.InputTag("hltL1NonIsoLargeWindowElectronPixelSeeds")
+hltCkfL1NonIsoLargeWindowTrackCandidates.src = cms.InputTag("hltL1NonIsoLargeWindowElectronPixelSeeds")
 hltCkfL1NonIsoLargeWindowTrackCandidates.TrackProducers = cms.VInputTag(cms.InputTag("hltCtfL1NonIsoWithMaterialTracks"))
-hltCkfL1NonIsoLargeWindowTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkfL1NonIsoLargeWindowTrackCandidates.SeedCleaning = True
 hltCkfL1NonIsoLargeWindowTrackCandidates.SplitHits = False
 
 

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1NonIsoSequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1NonIsoSequenceForHLT_cff.py
@@ -38,19 +38,15 @@ import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 
 hltCkfL1NonIsoTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-#hltCkfL1NonIsoTrackCandidates.SeedProducer = cms.InputTag("hltL1NonIsoElectronPixelSeeds")
-hltCkfL1NonIsoTrackCandidates.SeedProducer = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
+#hltCkfL1NonIsoTrackCandidates.src = cms.InputTag("hltL1NonIsoElectronPixelSeeds")
+hltCkfL1NonIsoTrackCandidates.src = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
 #hltCkfL1NonIsoTrackCandidates.TrackProducers = []
-hltCkfL1NonIsoTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkfL1NonIsoTrackCandidates.SeedCleaning = True
 hltCkfL1NonIsoTrackCandidates.SplitHits = False
 
 #not needed 
 #hltCkfL1NonIsoStartUpTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-#hltCkfL1NonIsoStartUpTrackCandidates.SeedProducer = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
+#hltCkfL1NonIsoStartUpTrackCandidates.src = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
 #hltCkfL1NonIsoStartUpTrackCandidates.TrackProducers = []
-#hltCkfL1NonIsoStartUpTrackCandidates.MaxNumberOfCrossedLayers = 999
-#hltCkfL1NonIsoStartUpTrackCandidates.SeedCleaning = True
 #hltCkfL1NonIsoStartUpTrackCandidates.SplitHits = False
 
 # CTF track fit with material

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1SeededLargeWindowSequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1SeededLargeWindowSequenceForHLT_cff.py
@@ -38,10 +38,8 @@ from FastSimulation.Tracking.GlobalPixelTracking_cff import *
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltCkfL1SeededLargeWindowTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltCkfL1SeededLargeWindowTrackCandidates.SeedProducer = cms.InputTag("hltL1SeededLargeWindowElectronPixelSeeds")
+hltCkfL1SeededLargeWindowTrackCandidates.src = cms.InputTag("hltL1SeededLargeWindowElectronPixelSeeds")
 hltCkfL1SeededLargeWindowTrackCandidates.TrackProducers = cms.VInputTag(cms.InputTag("hltCtfL1SeededWithMaterialTracks"))
-hltCkfL1SeededLargeWindowTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkfL1SeededLargeWindowTrackCandidates.SeedCleaning = True
 hltCkfL1SeededLargeWindowTrackCandidates.SplitHits = False
 
 

--- a/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1SeededSequenceForHLT_cff.py
+++ b/FastSimulation/EgammaElectronAlgos/python/pixelMatchElectronL1SeededSequenceForHLT_cff.py
@@ -38,26 +38,20 @@ import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 
 hltCkfL1SeededTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-#hltCkfL1SeededTrackCandidates.SeedProducer = cms.InputTag("hltL1SeededElectronPixelSeeds")
-hltCkfL1SeededTrackCandidates.SeedProducer = cms.InputTag("hltL1SeededStartUpElectronPixelSeeds")
+#hltCkfL1SeededTrackCandidates.src = cms.InputTag("hltL1SeededElectronPixelSeeds")
+hltCkfL1SeededTrackCandidates.src = cms.InputTag("hltL1SeededStartUpElectronPixelSeeds")
 #hltCkfL1SeededTrackCandidates.TrackProducers = []
-hltCkfL1SeededTrackCandidates.MaxNumberOfCrossedLayers = 999
-hltCkfL1SeededTrackCandidates.SeedCleaning = True
 hltCkfL1SeededTrackCandidates.SplitHits = False
 
 hltL1SeededCkfTrackCandidatesForGSF = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltL1SeededCkfTrackCandidatesForGSF.SeedProducer = cms.InputTag("hltL1SeededStartUpElectronPixelSeeds")
+hltL1SeededCkfTrackCandidatesForGSF.src = cms.InputTag("hltL1SeededStartUpElectronPixelSeeds")
 #hltL1SeededCkfTrackCandidatesForGSF.TrackProducers = []
-hltL1SeededCkfTrackCandidatesForGSF.MaxNumberOfCrossedLayers = 999
-hltL1SeededCkfTrackCandidatesForGSF.SeedCleaning = True
 hltL1SeededCkfTrackCandidatesForGSF.SplitHits = True
 
 #not needed 
 #hltCkfL1NonIsoStartUpTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-#hltCkfL1NonIsoStartUpTrackCandidates.SeedProducer = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
+#hltCkfL1NonIsoStartUpTrackCandidates.src = cms.InputTag("hltL1NonIsoStartUpElectronPixelSeeds")
 #hltCkfL1NonIsoStartUpTrackCandidates.TrackProducers = []
-#hltCkfL1NonIsoStartUpTrackCandidates.MaxNumberOfCrossedLayers = 999
-#hltCkfL1NonIsoStartUpTrackCandidates.SeedCleaning = True
 #hltCkfL1NonIsoStartUpTrackCandidates.SplitHits = False
 
 # CTF track fit with material

--- a/FastSimulation/HighLevelTrigger/python/HLTFastRecoForMuon_cff.py
+++ b/FastSimulation/HighLevelTrigger/python/HLTFastRecoForMuon_cff.py
@@ -44,13 +44,13 @@ hltL3NoFiltersTrajSeedIOHit = TSG.l3seeds("IOHitCascade")
 ## Make one TrackCand for each seeder
 from FastSimulation.Muons.TrackCandidateFromL2_cfi import *
 hltL3TrackCandidateFromL2OIState = FastSimulation.Muons.TrackCandidateFromL2_cfi.hltL3TrackCandidateFromL2.clone()
-hltL3TrackCandidateFromL2OIState.SeedProducer = "hltL3TrajSeedOIState"
+hltL3TrackCandidateFromL2OIState.src = "hltL3TrajSeedOIState"
 hltL3TrackCandidateFromL2OIHit = FastSimulation.Muons.TrackCandidateFromL2_cfi.hltL3TrackCandidateFromL2.clone()
-hltL3TrackCandidateFromL2OIHit.SeedProducer = "hltL3TrajSeedOIHit"    
+hltL3TrackCandidateFromL2OIHit.src = "hltL3TrajSeedOIHit"    
 hltL3TrackCandidateFromL2IOHit = FastSimulation.Muons.TrackCandidateFromL2_cfi.hltL3TrackCandidateFromL2.clone()
-hltL3TrackCandidateFromL2IOHit.SeedProducer = "hltL3TrajSeedIOHit"
+hltL3TrackCandidateFromL2IOHit.src = "hltL3TrajSeedIOHit"
 hltL3TrackCandidateFromL2NoVtx = FastSimulation.Muons.TrackCandidateFromL2_cfi.hltL3TrackCandidateFromL2.clone()
-hltL3TrackCandidateFromL2NoVtx.SeedProducer = "hltL3TrajectorySeedNoVtx"
+hltL3TrackCandidateFromL2NoVtx.src = "hltL3TrajectorySeedNoVtx"
 
 
 # (Not-so) Regional Tracking - needed because the TrackCandidateProducer needs the seeds
@@ -64,23 +64,19 @@ hltCkfTrackCandidatesJpsiTk = cms.Sequence(globalPixelTracking)
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltMuCkfTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltMuCkfTrackCandidates.SeedProducer = cms.InputTag("hltMuTrackSeeds")
-hltMuCkfTrackCandidates.SeedCleaning = True
+hltMuCkfTrackCandidates.src = cms.InputTag("hltMuTrackSeeds")
 hltMuCkfTrackCandidates.SplitHits = False
 
 hltMuTrackJpsiCkfTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltMuTrackJpsiCkfTrackCandidates.SeedProducer = cms.InputTag("hltMuTrackJpsiTrackSeeds")
-hltMuTrackJpsiCkfTrackCandidates.SeedCleaning = True
+hltMuTrackJpsiCkfTrackCandidates.src = cms.InputTag("hltMuTrackJpsiTrackSeeds")
 hltMuTrackJpsiCkfTrackCandidates.SplitHits = False
 
 hltMuTrackJpsiEffCkfTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltMuTrackJpsiEffCkfTrackCandidates.SeedProducer = cms.InputTag("hltMuTrackJpsiTrackSeeds")
-hltMuTrackJpsiEffCkfTrackCandidates.SeedCleaning = True
+hltMuTrackJpsiEffCkfTrackCandidates.src = cms.InputTag("hltMuTrackJpsiTrackSeeds")
 hltMuTrackJpsiEffCkfTrackCandidates.SplitHits = False
 
 hltMuTrackCkfTrackCandidatesOnia = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltMuTrackCkfTrackCandidatesOnia.SeedProducer = cms.InputTag("hltMuTrackTrackSeedsOnia")
-hltMuTrackCkfTrackCandidatesOnia.SeedCleaning = True
+hltMuTrackCkfTrackCandidatesOnia.src = cms.InputTag("hltMuTrackTrackSeedsOnia")
 hltMuTrackCkfTrackCandidatesOnia.SplitHits = False
 
 # CTF track fit with material

--- a/FastSimulation/HighLevelTrigger/python/HLTFastRecoForTau_cff.py
+++ b/FastSimulation/HighLevelTrigger/python/HLTFastRecoForTau_cff.py
@@ -45,8 +45,7 @@ hltPixelTracksReg.RegionFactoryPSet.RegionPSet = cms.PSet(
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 
 hltTau3MuCkfTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-hltTau3MuCkfTrackCandidates.SeedProducer = cms.InputTag("hltTau3MuPixelSeedsFromPixelTracks")
-hltTau3MuCkfTrackCandidates.SeedCleaning = True
+hltTau3MuCkfTrackCandidates.src = cms.InputTag("hltTau3MuPixelSeedsFromPixelTracks")
 hltTau3MuCkfTrackCandidates.SplitHits = False
 
 

--- a/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
@@ -37,8 +37,6 @@ FastTSGFromIOHit::~FastTSGFromIOHit()
 
 void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon, const TrackingRegion& region, std::vector<TrajectorySeed> & result) {
   
-  std::cout << "hey, i'm here!" << std::endl;
-
   // Retrieve the Monte Carlo truth (SimTracks)
   edm::Handle<edm::SimTrackContainer> theSimTracks;
   getEvent()->getByLabel(theSimTrackCollectionLabel,theSimTracks);
@@ -60,7 +58,6 @@ void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon, const TrackingRegi
   if ( muRef->pt() < thePtCut 
        || muRef->innerMomentum().Rho() < thePtCut 
        || muRef->innerMomentum().R() < 2.5 ){
-    std::cout << "returning..." << std::endl;
   }return;
   
   // Copy the collection of seeds (ahem, this is time consuming!)
@@ -102,7 +99,6 @@ void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon, const TrackingRegi
   unsigned int is=0;
   unsigned int isMax=tkSeeds.size();
   for (;is!=isMax;++is){
-    std::cout << "!!! " << tkSeeds[is].nHits() << std::endl;
     result.push_back( L3MuonTrajectorySeed(tkSeeds[is], muRef));
   } // End of tk seed loop
   

--- a/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
+++ b/FastSimulation/Muons/plugins/FastTSGFromIOHit.cc
@@ -37,6 +37,8 @@ FastTSGFromIOHit::~FastTSGFromIOHit()
 
 void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon, const TrackingRegion& region, std::vector<TrajectorySeed> & result) {
   
+  std::cout << "hey, i'm here!" << std::endl;
+
   // Retrieve the Monte Carlo truth (SimTracks)
   edm::Handle<edm::SimTrackContainer> theSimTracks;
   getEvent()->getByLabel(theSimTrackCollectionLabel,theSimTracks);
@@ -57,7 +59,9 @@ void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon, const TrackingRegi
   // Cut on muons with low momenta
   if ( muRef->pt() < thePtCut 
        || muRef->innerMomentum().Rho() < thePtCut 
-       || muRef->innerMomentum().R() < 2.5 ) return;
+       || muRef->innerMomentum().R() < 2.5 ){
+    std::cout << "returning..." << std::endl;
+  }return;
   
   // Copy the collection of seeds (ahem, this is time consuming!)
   std::vector<TrajectorySeed> tkSeeds;
@@ -98,6 +102,7 @@ void FastTSGFromIOHit::trackerSeeds(const TrackCand& staMuon, const TrackingRegi
   unsigned int is=0;
   unsigned int isMax=tkSeeds.size();
   for (;is!=isMax;++is){
+    std::cout << "!!! " << tkSeeds[is].nHits() << std::endl;
     result.push_back( L3MuonTrajectorySeed(tkSeeds[is], muRef));
   } // End of tk seed loop
   

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -122,7 +122,6 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     TrajectorySeedHitCandidate recHitCandidate;
     unsigned numberOfCrossedLayers = 0;      
     for ( ; recHitIter != recHitEnd; ++recHitIter) {
-	  
       recHitCandidate = TrajectorySeedHitCandidate(&(*recHitIter),trackerGeometry.product(),trackerTopology.product());
       if ( recHitCandidates.size() == 0 || !recHitCandidate.isOnTheSameLayer(recHitCandidates.back()) ) {
 	++numberOfCrossedLayers;
@@ -146,15 +145,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	const SiTrackerGSRecHit2D* mHit = recHitCandidates[index].matchedHit()->monoHit();
-	const SiTrackerGSRecHit2D* sHit = recHitCandidates[index].matchedHit()->stereoHit();
-	if( mHit->simhitId() < sHit->simhitId() ) {
-	  trackRecHits.push_back(mHit->clone());
-	  trackRecHits.push_back(sHit->clone());
-	} else {
-	  trackRecHits.push_back(sHit->clone());
-	  trackRecHits.push_back(mHit->clone());
-	}
+	trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
+	trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
       }
       else {
 	trackRecHits.push_back(recHitCandidates[index].hit()->clone());

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -40,12 +40,6 @@
 //Propagator withMaterial
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 
-
-//
-
-//for debug only 
-//#define FAMOS_DEBUG
-
 TrackCandidateProducer::TrackCandidateProducer(const edm::ParameterSet& conf)
 {  
   // products

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
@@ -52,10 +52,8 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
 
   bool rejectOverlaps;
   bool splitHits;
-  bool seedCleaning;
  
   edm::InputTag simTracks_;
-  double estimatorCut_;
 
   // tokens & labels
   edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken;

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
@@ -45,8 +45,6 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   
  private:
 
-  void addSplitHits(const TrajectorySeedHitCandidate&, std::vector<TrajectorySeedHitCandidate>&); 
-  
   unsigned int minNumberOfCrossedLayers;
   unsigned int maxNumberOfCrossedLayers;
 

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
@@ -39,23 +39,13 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   
   explicit TrackCandidateProducer(const edm::ParameterSet& conf);
   
-  virtual ~TrackCandidateProducer();
-  
-  virtual void beginRun(edm::Run const& run, const edm::EventSetup & es) override;
+  virtual ~TrackCandidateProducer(){;}
   
   virtual void produce(edm::Event& e, const edm::EventSetup& es) override;
   
  private:
 
   void addSplitHits(const TrajectorySeedHitCandidate&, std::vector<TrajectorySeedHitCandidate>&); 
-  const TrackerGeometry*  theGeometry;
-  const MagneticField*  theMagField;
-  PropagatorWithMaterial* thePropagator;
-
-
-  edm::InputTag seedProducer;
-  edm::InputTag hitProducer;
-  std::vector<edm::InputTag> trackProducers;
   
   unsigned int minNumberOfCrossedLayers;
   unsigned int maxNumberOfCrossedLayers;
@@ -67,11 +57,13 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   edm::InputTag simTracks_;
   double estimatorCut_;
 
-  // tokens
+  // tokens & labels
   edm::EDGetTokenT<edm::View<TrajectorySeed> > seedToken;
   edm::EDGetTokenT<SiTrackerGSMatchedRecHit2DCollection> recHitToken;
   edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
   edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
+  std::string propagatorLabel;
+  
 };
 
 #endif

--- a/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
@@ -30,7 +30,7 @@ detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.tr
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 detachedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    SeedProducer = cms.InputTag("detachedTripletStepSeeds"),
+    src = cms.InputTag("detachedTripletStepSeeds"),
     MinNumberOfCrossedLayers = 3
     )
 

--- a/FastSimulation/Tracking/python/GlobalMixedTracking_cff.py
+++ b/FastSimulation/Tracking/python/GlobalMixedTracking_cff.py
@@ -11,7 +11,7 @@ globalMixedWithMaterialTracks = RecoTracker.TrackProducer.CTFFinalFitWithMateria
 
 # The sequence
 ctfTracking = cms.Sequence(globalMixedSeeds*globalMixedTrackCandidates*globalMixedWithMaterialTracks*ctfWithMaterialTracks)
-globalMixedTrackCandidates.SeedProducer = cms.InputTag("globalMixedSeeds")
+globalMixedTrackCandidates.src = cms.InputTag("globalMixedSeeds")
 globalMixedTrackCandidates.TrackProducers = ['globalPixelWithMaterialTracks']
 globalMixedWithMaterialTracks.src = 'globalMixedTrackCandidates'
 globalMixedWithMaterialTracks.TTRHBuilder = 'WithoutRefit'

--- a/FastSimulation/Tracking/python/GlobalPixelTracking_cff.py
+++ b/FastSimulation/Tracking/python/GlobalPixelTracking_cff.py
@@ -11,7 +11,7 @@ import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cfi
 
 ###################
 globalPixelTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-globalPixelTrackCandidates.SeedProducer = cms.InputTag("globalPixelSeeds")
+globalPixelTrackCandidates.src = cms.InputTag("globalPixelSeeds")
 
 globalPixelWithMaterialTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cfi.ctfWithMaterialTracks.clone()
 globalPixelWithMaterialTracks.src = 'globalPixelTrackCandidates'
@@ -29,7 +29,7 @@ globalPixelStepIds = cms.EDProducer("SimTrackIdProducer",
 
 
 globalPixelTrackCandidatesForElectrons = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-globalPixelTrackCandidatesForElectrons.SeedProducer = cms.InputTag("globalPixelSeedsForElectrons")
+globalPixelTrackCandidatesForElectrons.src = cms.InputTag("globalPixelSeedsForElectrons")
 #globalPixelTrackCandidatesForElectrons.TrackProducers = cms.vstring(['globalPixelWithMaterialTracks'])
     
 globalPixelWithMaterialTracksForElectrons = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cfi.ctfWithMaterialTracks.clone()
@@ -42,7 +42,7 @@ globalPixelWithMaterialTracksForElectrons.TrajectoryInEvent = cms.bool(True)
 ####################
 
 globalPixelTrackCandidatesForPhotons = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone()
-globalPixelTrackCandidatesForPhotons.SeedProducer = cms.InputTag("globalPixelSeedsForPhotons")
+globalPixelTrackCandidatesForPhotons.src = cms.InputTag("globalPixelSeedsForPhotons")
 #globalPixelTrackCandidatesForPhotons.TrackProducers = cms.vstring(['globalPixelWithMaterialTracks'])
 
 globalPixelWithMaterialTracksForPhotons = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cfi.ctfWithMaterialTracks.clone()

--- a/FastSimulation/Tracking/python/InitialStep_cff.py
+++ b/FastSimulation/Tracking/python/InitialStep_cff.py
@@ -21,7 +21,7 @@ initialStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectory
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 initialStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    SeedProducer = cms.InputTag("initialStepSeeds"),
+    src = cms.InputTag("initialStepSeeds"),
     MinNumberOfCrossedLayers = 3
     )
 

--- a/FastSimulation/Tracking/python/LowPtTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/LowPtTripletStep_cff.py
@@ -33,7 +33,7 @@ lowPtTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.traje
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 lowPtTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    SeedProducer = cms.InputTag("lowPtTripletStepSeeds"),
+    src = cms.InputTag("lowPtTripletStepSeeds"),
     MinNumberOfCrossedLayers = 3
 )
 

--- a/FastSimulation/Tracking/python/MixedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/MixedTripletStep_cff.py
@@ -57,7 +57,7 @@ mixedTripletStepSeeds = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixed
 #track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 mixedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    SeedProducer = cms.InputTag("mixedTripletStepSeeds"),
+    src = cms.InputTag("mixedTripletStepSeeds"),
     MinNumberOfCrossedLayers = 3
 )
 

--- a/FastSimulation/Tracking/python/PixelLessStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelLessStep_cff.py
@@ -36,7 +36,7 @@ pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajecto
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 pixelLessStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    SeedProducer = cms.InputTag("pixelLessStepSeeds"),
+    src = cms.InputTag("pixelLessStepSeeds"),
     MinNumberOfCrossedLayers = 6 # ?
 )
 

--- a/FastSimulation/Tracking/python/PixelLessTracking_cff.py
+++ b/FastSimulation/Tracking/python/PixelLessTracking_cff.py
@@ -10,7 +10,7 @@ import RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cfi
 pixelLessWithMaterialTracks = RecoTracker.TrackProducer.CTFFinalFitWithMaterial_cfi.ctfWithMaterialTracks.clone()
 # The sequence
 pixelLessTracking = cms.Sequence(pixelLessSeeds*pixelLessTrackCandidates*pixelLessWithMaterialTracks)
-pixelLessTrackCandidates.SeedProducer = cms.InputTag("pixelLessSeeds")
+pixelLessTrackCandidates.src = cms.InputTag("pixelLessSeeds")
 pixelLessWithMaterialTracks.src = 'pixelLessTrackCandidates'
 pixelLessWithMaterialTracks.TTRHBuilder = 'WithoutRefit'
 pixelLessWithMaterialTracks.Fitter = 'KFFittingSmootherWithOutlierRejection'

--- a/FastSimulation/Tracking/python/PixelPairStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelPairStep_cff.py
@@ -33,7 +33,7 @@ pixelPairStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajecto
 # track candidate 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 pixelPairStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    SeedProducer = cms.InputTag("pixelPairStepSeeds"),
+    src = cms.InputTag("pixelPairStepSeeds"),
     MinNumberOfCrossedLayers = 2 # ?
 )
 

--- a/FastSimulation/Tracking/python/TobTecStep_cff.py
+++ b/FastSimulation/Tracking/python/TobTecStep_cff.py
@@ -61,7 +61,7 @@ tobTecStepSeeds = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeeds.c
 # track candidate
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 tobTecStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    SeedProducer = cms.InputTag("tobTecStepSeeds"),
+    src = cms.InputTag("tobTecStepSeeds"),
     MinNumberOfCrossedLayers = 3
 )
 

--- a/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
@@ -5,8 +5,7 @@ trackCandidateProducer = cms.EDProducer(
     recHits = cms.InputTag("siTrackerGaussianSmearingRecHits","TrackerGSMatchedRecHits"),
     # The smallest number of crossed layers to make a candidate
     MinNumberOfCrossedLayers = cms.uint32(5),
-    # The number of crossed layers needed before stopping tracking
-    MaxNumberOfCrossedLayers = cms.uint32(999),
+
     src = cms.InputTag("globalPixelSeeds"),
 
     # Reject overlapping hits? (GroupedTracking from 170pre2 onwards)

--- a/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
@@ -1,12 +1,13 @@
 import FWCore.ParameterSet.Config as cms
 
-trackCandidateProducer = cms.EDProducer("TrackCandidateProducer",
-    HitProducer = cms.InputTag("siTrackerGaussianSmearingRecHits","TrackerGSMatchedRecHits"),
+trackCandidateProducer = cms.EDProducer(
+    "TrackCandidateProducer",
+    recHits = cms.InputTag("siTrackerGaussianSmearingRecHits","TrackerGSMatchedRecHits"),
     # The smallest number of crossed layers to make a candidate
     MinNumberOfCrossedLayers = cms.uint32(5),
     # The number of crossed layers needed before stopping tracking
     MaxNumberOfCrossedLayers = cms.uint32(999),
-    SeedProducer = cms.InputTag("globalPixelSeeds"),
+    src = cms.InputTag("globalPixelSeeds"),
 
     # Reject overlapping hits? (GroupedTracking from 170pre2 onwards)
     OverlapCleaning = cms.bool(False),
@@ -15,8 +16,10 @@ trackCandidateProducer = cms.EDProducer("TrackCandidateProducer",
 
     # Split matched hits? 
     SplitHits = cms.bool(True),
-    SimTracks = cms.InputTag(''),
-    EstimatorCut = cms.double(0)
+    simTracks = cms.InputTag('famosSimHits'),
+    EstimatorCut = cms.double(0),
+
+    propagator = cms.string('PropagatorWithMaterial')
 )
 
 

--- a/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
@@ -11,14 +11,11 @@ trackCandidateProducer = cms.EDProducer(
 
     # Reject overlapping hits? (GroupedTracking from 170pre2 onwards)
     OverlapCleaning = cms.bool(False),
-    # Reject copies of tracks from several seeds - take the first seed in that case
-    SeedCleaning = cms.bool(True),
 
     # Split matched hits? 
     SplitHits = cms.bool(True),
     simTracks = cms.InputTag('famosSimHits'),
-    EstimatorCut = cms.double(0),
-
+    
     propagator = cms.string('PropagatorWithMaterial')
 )
 

--- a/FastSimulation/Tracking/test/FastTrackAnalyzer.cc
+++ b/FastSimulation/Tracking/test/FastTrackAnalyzer.cc
@@ -538,7 +538,6 @@ void FastTrackAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& 
 	      int currentId = rechit->simtrackId();		      
 	      std::cout << "\t\t\tRecHit # " << ri << "\t SimTrackId = " << currentId << std::endl;
 	      SimTrackIds.push_back(currentId);
-	      std::cout<<"\t\t\t SimHit ID belonging to this RecHit = "<< rechit->simhitId() << std::endl;
 	      DetId detid = rechit->geographicalId();
 	      unsigned int subdet = detid.subdetId();
 

--- a/FastSimulation/TrackingRecHitProducer/interface/GSRecHitMatcher.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/GSRecHitMatcher.h
@@ -16,10 +16,10 @@ class GSRecHitMatcher {
   GSRecHitMatcher() {}
   ~GSRecHitMatcher() {}
 
-  SiTrackerGSMatchedRecHit2D * match( const SiTrackerGSRecHit2D *monoRH,
-				      const SiTrackerGSRecHit2D *stereoRH,
-				      const GluedGeomDet* gluedDet,
-				      LocalVector& trackdirection) const;
+  SiTrackerGSMatchedRecHit2D match( const SiTrackerGSRecHit2D *monoRH,
+				    const SiTrackerGSRecHit2D *stereoRH,
+				    const GluedGeomDet* gluedDet,
+				    LocalVector& trackdirection) const;
   
   
   StripPosition project(const GeomDetUnit *det,
@@ -27,10 +27,10 @@ class GSRecHitMatcher {
 			const StripPosition& strip,
 			const LocalVector& trackdirection) const;
   
-  SiTrackerGSMatchedRecHit2D * projectOnly( const SiTrackerGSRecHit2D *monoRH,
-					    const GeomDet * monoDet,
-					    const GluedGeomDet* gluedDet,
-					    LocalVector& ldir) const;
+  SiTrackerGSMatchedRecHit2D projectOnly( const SiTrackerGSRecHit2D *monoRH,
+					  const GeomDet * monoDet,
+					  const GluedGeomDet* gluedDet,
+					  LocalVector& ldir) const;
   
 };
 

--- a/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.h
+++ b/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.h
@@ -19,7 +19,6 @@
 
 // Data Formats
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
-#include "FastSimDataFormats/External/interface/FastTrackerClusterCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2DCollection.h"
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
@@ -66,7 +65,6 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   void smearHits(const edm::PSimHitContainer& input,
   //  void smearHits(edm::Handle<std::vector<PSimHit> >& input,
                  std::map<unsigned, edm::OwnVector<SiTrackerGSRecHit2D> >& theRecHits,
-                 std::map<unsigned, edm::OwnVector<FastTrackerCluster> >& theClusters,
 		 const TrackerTopology *tTopo,
                  RandomEngineAndDistribution const*);
 
@@ -83,9 +81,6 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   void loadMatchedRecHits(std::map<unsigned,edm::OwnVector<SiTrackerGSMatchedRecHit2D> >& theRecHits, 
 		   SiTrackerGSMatchedRecHit2DCollection& theRecHitCollection) const;
 
-  void loadClusters(std::map<unsigned,edm::OwnVector<FastTrackerCluster> >& theClusterMap, 
-                    FastTrackerClusterCollection& theClusterCollection) const;
-  
   private:
   //
   bool gaussianSmearing(const PSimHit& simHit, 
@@ -231,7 +226,6 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   // valid for all the detectors
   double localPositionResolution_z; // cm
   //
-  //  typedef std::map<unsigned int, std::vector<PSimHit>,std::less<unsigned int> > simhit_map;
 
   // Pixel Error Parametrization (barrel)
   SiPixelGaussianSmearingRecHitConverterAlgorithm* thePixelBarrelParametrization;
@@ -240,20 +234,9 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   // Si Strip Error parametrization (generic)
   SiStripGaussianSmearingRecHitConverterAlgorithm* theSiStripErrorParametrization;
 
-  // Temporary RecHit map
-  //  std::map< DetId, edm::OwnVector<SiTrackerGSRecHit2D> > temporaryRecHits;
-
-  // Local correspondence between RecHits and SimHits
-  //  typedef MixCollection<PSimHit>::iterator SimHiterator;
   typedef edm::PSimHitContainer::const_iterator SimHiterator;
   std::vector<SimHiterator> correspondingSimHit;
 
-  typedef SiTrackerGSRecHit2D::ClusterRef ClusterRef;
-  typedef SiTrackerGSRecHit2D::ClusterRefProd ClusterRefProd;
-  // Added for cluster reference
-  ClusterRefProd FastTrackerClusterRefProd;
-
-  
 };
 
 

--- a/FastSimulation/TrackingRecHitProducer/src/GSRecHitMatcher.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/GSRecHitMatcher.cc
@@ -6,10 +6,10 @@
 #include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
 #include <cfloat>
 
-SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::match(const SiTrackerGSRecHit2D *monoRH,
-						    const SiTrackerGSRecHit2D *stereoRH,
-						    const GluedGeomDet* gluedDet,
-					            LocalVector& trackdirection) const
+SiTrackerGSMatchedRecHit2D GSRecHitMatcher::match(const SiTrackerGSRecHit2D *monoRH,
+						  const SiTrackerGSRecHit2D *stereoRH,
+						  const GluedGeomDet* gluedDet,
+						  LocalVector& trackdirection) const
 {
 
 
@@ -91,44 +91,24 @@ SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::match(const SiTrackerGSRecHit2D *m
   float yy=invdet2*(sigmap12*c2*c2+sigmap22*c1*c1);
   LocalError error=LocalError(xx,xy,yy);
 
- //  if((gluedDet->surface()).bounds().inside(position,error,3)){
-//     std::cout<<"  ERROR ok "<< std::endl;
-//   }
-//   else {
-//     std::cout<<" ERROR not ok " << std::endl;
-//   }
-  
   //Added by DAO to make sure y positions are zero.
   DetId det(monoRH->geographicalId());
   if(det.subdetId() > 2) {
-    SiTrackerGSRecHit2D *adjustedMonoRH = new SiTrackerGSRecHit2D(LocalPoint(monoRH->localPosition().x(),0,0),
-								  monoRH->localPositionError(),
-								  *monoRH->det(),
-								  monoRH->simhitId(),
-								  monoRH->simtrackId(),
-								  monoRH->eeId(),
-								  monoRH->cluster(),
-								  monoRH->simMultX(),
-								  monoRH->simMultY()
-								  );
+    // why not pass through directly?
+    SiTrackerGSRecHit2D adjustedMonoRH(LocalPoint(monoRH->localPosition().x(),0,0),
+				       monoRH->localPositionError(),
+				       *monoRH->det(),
+				       monoRH->simtrackId());
+    // why not pass through directly?
+    SiTrackerGSRecHit2D adjustedStereoRH(LocalPoint(stereoRH->localPosition().x(),0,0),
+					 stereoRH->localPositionError(),
+					 *stereoRH->det(),
+					 stereoRH->simtrackId());
     
-    SiTrackerGSRecHit2D *adjustedStereoRH = new SiTrackerGSRecHit2D(LocalPoint(stereoRH->localPosition().x(),0,0),
-								    stereoRH->localPositionError(),
-								    *stereoRH->det(),
-								    stereoRH->simhitId(),
-								    stereoRH->simtrackId(),
-								    stereoRH->eeId(),
-								    stereoRH->cluster(),
-								    stereoRH->simMultX(),
-								    stereoRH->simMultY()
-								    );
-    
-    SiTrackerGSMatchedRecHit2D *rV= new SiTrackerGSMatchedRecHit2D(position, error, *gluedDet, monoRH->simhitId(), 
-								   monoRH->simtrackId(), monoRH->eeId(), monoRH->cluster(), 
-								   monoRH->simMultX(), monoRH->simMultY(), 
-								   true, adjustedMonoRH, adjustedStereoRH);
-    delete adjustedMonoRH;
-    delete adjustedStereoRH;
+    // i don't like the 'new'
+    SiTrackerGSMatchedRecHit2D rV(position, error, *gluedDet,
+				  monoRH->simtrackId(), 
+				  true, adjustedMonoRH, adjustedStereoRH);
     return rV;
   }
   
@@ -164,10 +144,10 @@ GSRecHitMatcher::project(const GeomDetUnit *det,
 
 
 
-SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::projectOnly( const SiTrackerGSRecHit2D *monoRH,
-						    const GeomDet * monoDet,
-						    const GluedGeomDet* gluedDet,
-					            LocalVector& ldir) const
+SiTrackerGSMatchedRecHit2D GSRecHitMatcher::projectOnly( const SiTrackerGSRecHit2D *monoRH,
+							 const GeomDet * monoDet,
+							 const GluedGeomDet* gluedDet,
+							 LocalVector& ldir) const
 {
   LocalPoint position(monoRH->localPosition().x(), 0.,0.);
   const BoundPlane& gluedPlane = gluedDet->surface();
@@ -198,39 +178,27 @@ SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::projectOnly( const SiTrackerGSRecH
   //Added by DAO to make sure y positions are zero and correct Mono or stereo Det is filled.
   
   auto otherDet = isMono ? gluedDet->stereoDet() : gluedDet->monoDet();
-  //Good for debugging.
-  //std::cout << "The monoDet = " << monoDet->geographicalId() << ". The gluedMonoDet = " << gluedMonoDet->geographicalId() << ". The gluedStereoDet = " << gluedStereoDet->geographicalId()
-  //    << ". isMono = " << isMono << ". isStereo = " << isStereo <<"." << std::endl;
-
-  SiTrackerGSRecHit2D *adjustedRH = new SiTrackerGSRecHit2D(LocalPoint(monoRH->localPosition().x(),0,0),
-							    monoRH->localPositionError(),
-							    *monoRH->det(),
-							    monoRH->simhitId(),
-							    monoRH->simtrackId(),
-							    monoRH->eeId(),
-							    monoRH->cluster(),
-							    monoRH->simMultX(),
-							    monoRH->simMultY()
-							    );
+  SiTrackerGSRecHit2D adjustedRH(LocalPoint(monoRH->localPosition().x(),0,0),
+				 monoRH->localPositionError(),
+				 *monoRH->det(),
+				 monoRH->simtrackId());
   
   //DAO: Not quite sure what to do about the cluster ref, so I will fill it with the monoRH for now...
-  SiTrackerGSRecHit2D *otherRH = new SiTrackerGSRecHit2D(LocalPoint(-10000,-10000,-10000), LocalError(0,0,0),*otherDet, 0,0,0,monoRH->cluster(),0,0);
+  SiTrackerGSRecHit2D otherRH(LocalPoint(-10000,-10000,-10000), LocalError(0,0,0),*otherDet, -1);//??
   if ((isMono && isStereo)||(!isMono&&!isStereo)) throw cms::Exception("GSRecHitMatcher") << "Something wrong with DetIds.";
   else if (isMono) {
-    SiTrackerGSMatchedRecHit2D *rV= new SiTrackerGSMatchedRecHit2D(projectedHitPos, rotatedError, *gluedDet, 
-								   monoRH->simhitId(),  monoRH->simtrackId(), monoRH->eeId(), monoRH->cluster(),
-								   monoRH->simMultX(), monoRH->simMultY(), false, adjustedRH, otherRH);
-    delete adjustedRH;
-    delete otherRH;
+    // i don't like the new
+    SiTrackerGSMatchedRecHit2D rV(projectedHitPos, rotatedError, *gluedDet, 
+				  monoRH->simtrackId(),
+				  false, adjustedRH, otherRH);
     return rV;
   }
   
   else{
-    SiTrackerGSMatchedRecHit2D *rV=new SiTrackerGSMatchedRecHit2D(projectedHitPos, rotatedError, *gluedDet, 
-								 monoRH->simhitId(),  monoRH->simtrackId(), monoRH->eeId(), monoRH->cluster(),
-								 monoRH->simMultX(), monoRH->simMultY(), false, otherRH, adjustedRH);
-    delete adjustedRH;
-    delete otherRH;
+    // i don't like the new
+    SiTrackerGSMatchedRecHit2D rV(projectedHitPos, rotatedError, *gluedDet, 
+				  monoRH->simtrackId(),
+				  false, otherRH, adjustedRH);
     return rV;
   }
 }


### PR DESCRIPTION
- remove obsolete data members
- get rid of a memory leak inside GSRecHitMatcher, helper function of SiTrackerGaussianSmearingRecHitConverter

to be rebased after #9595 gets merged 
