### PR TITLE
Add vtx smearing parameters from run 247324

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -32,7 +32,8 @@ VtxSmeared = {
     'ShiftedCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedShiftedCollision2015_cfi',
     'Shifted5mmCollision2015'  :     'IOMC.EventVertexGenerators.VtxSmearedShifted5mmCollision2015_cfi',
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',
-    'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi'
+    'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi',
+    'ZeroTeslaDNDEtaCollision2015' : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaDNDEtaCollision2015_cfi'
 
 }
 VtxSmearedDefaultKey='NominalCollision2015'

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -33,7 +33,7 @@ VtxSmeared = {
     'Shifted5mmCollision2015'  :     'IOMC.EventVertexGenerators.VtxSmearedShifted5mmCollision2015_cfi',
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',
     'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi',
-    'ZeroTeslaDNDEtaCollision2015' : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaDNDEtaCollision2015_cfi'
+    'ZeroTeslaRun247324Collision'  : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaRun247324Collision_cfi'
 
 }
 VtxSmearedDefaultKey='NominalCollision2015'

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -406,7 +406,7 @@ NominalCollision2015VtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.0),
     Z0 = cms.double(0.0)
 )
-ZeroTeslaDNDEtaCollision2015VtxSmearingParameters = cms.PSet(
+ZeroTeslaRun247324CollisionVtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),
     BetaStar = cms.double(80.0),
     Emittance = cms.double(1.070e-5),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -406,6 +406,17 @@ NominalCollision2015VtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.0),
     Z0 = cms.double(0.0)
 )
+ZeroTeslaDNDEtaCollision2015VtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(80.0),
+    Emittance = cms.double(1.070e-5),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(4.125),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.08621),
+    Y0 = cms.double(0.1657),
+    Z0 = cms.double(-1.688)
+)
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedZeroTeslaDNDEtaCollision2015_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedZeroTeslaDNDEtaCollision2015_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    ZeroTeslaDNDEtaCollision2015VtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedZeroTeslaRun247324Collision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedZeroTeslaRun247324Collision_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
-    ZeroTeslaDNDEtaCollision2015VtxSmearingParameters,
+    ZeroTeslaRun247324CollisionVtxSmearingParameters,
     VtxSmearedCommon
 )


### PR DESCRIPTION
back port of 
https://github.com/cms-sw/cmssw/pull/9645
