### PR TITLE
Add informative exception for hash collision

### DIFF
--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -400,7 +400,17 @@ namespace edm {
   ProductHolderBase*
   Principal::getExistingProduct(ProductHolderBase const& productHolder) {
     ProductHolderBase* phb = getExistingProduct(productHolder.branchDescription().branchID());
-    assert(nullptr == phb || BranchKey(productHolder.branchDescription()) == BranchKey(phb->branchDescription()));
+    if(nullptr != phb && BranchKey(productHolder.branchDescription()) != BranchKey(phb->branchDescription())) {
+      BranchDescription const& newProduct = phb->branchDescription();
+      BranchDescription const& existing = productHolder.branchDescription();
+      if(newProduct.branchName() != existing.branchName() && newProduct.branchID() == existing.branchID()) {
+        throw cms::Exception("HashCollision") << "Principal::getExistingProduct\n" <<
+          " Branch " << newProduct.branchName() << " has same branch ID as branch " << existing.branchName() << "\n" <<
+          "Workaround: change process name or product instance name of " << newProduct.branchName() << "\n";
+      } else {
+        assert(nullptr == phb || BranchKey(productHolder.branchDescription()) == BranchKey(phb->branchDescription()));
+      }
+    }
     return phb;
   }
 


### PR DESCRIPTION
Fedor Ratnikov ran a reco job that asserted because two different branches had the same 32 bit hash for a branch ID.  Unfortunately, we cannot easily fix the hash collision issue, but at least we can issue a clear and informative exception when this occurs, instead of a cryptic assert.
