### PR TITLE
Fix a race condition in edm::Ref

### DIFF
--- a/DataFormats/Common/interface/RefCore.h
+++ b/DataFormats/Common/interface/RefCore.h
@@ -79,13 +79,13 @@ namespace edm {
 
     void setProductGetter(EDProductGetter const* prodGetter) const;
 
-    WrapperBase const* getProductPtr(std::type_info const& type) const;
+    WrapperBase const* getProductPtr(std::type_info const& type, EDProductGetter const* prodGetter) const;
 
-    WrapperBase const* tryToGetProductPtr(std::type_info const& type) const;
+    WrapperBase const* tryToGetProductPtr(std::type_info const& type, EDProductGetter const* prodGetter) const;
 
-    WrapperBase const* getThinnedProductPtr(std::type_info const& type, unsigned int& thinnedKey) const;
+    WrapperBase const* getThinnedProductPtr(std::type_info const& type, unsigned int& thinnedKey, EDProductGetter const* prodGetter) const;
 
-    bool isThinnedAvailable(unsigned int thinnedKey) const;
+    bool isThinnedAvailable(unsigned int thinnedKey, EDProductGetter const* prodGetter) const;
 
     void productNotFoundException(std::type_info const& type) const;
 

--- a/DataFormats/Common/interface/RefCoreWithIndex.h
+++ b/DataFormats/Common/interface/RefCoreWithIndex.h
@@ -92,8 +92,8 @@ namespace edm {
       toRefCore().setProductGetter(prodGetter);
     }
 
-    WrapperBase const* getProductPtr(std::type_info const& type) const {
-      return toRefCore().getProductPtr(type);
+    WrapperBase const* getProductPtr(std::type_info const& type, EDProductGetter const* prodGetter) const {
+      return toRefCore().getProductPtr(type,prodGetter);
     }
 
     void productNotFoundException(std::type_info const& type) const {

--- a/DataFormats/Common/src/RefCore.cc
+++ b/DataFormats/Common/src/RefCore.cc
@@ -57,7 +57,7 @@ namespace edm {
   }
 
   WrapperBase const*
-  RefCore::getProductPtr(std::type_info const& type) const {
+  RefCore::getProductPtr(std::type_info const& type, EDProductGetter const* prodGetter) const {
     // The following invariant would be nice to establish in all
     // constructors, but we can not be sure that the context in which
     // EDProductGetter::instance() is called will be one where a
@@ -82,7 +82,7 @@ namespace edm {
     if (cachePtrIsInvalid()) {
       throwInvalidRefFromNoCache(TypeID(type),tId);
     }
-    WrapperBase const* product = productGetter()->getIt(tId);
+    WrapperBase const* product = prodGetter->getIt(tId);
     if (product == nullptr) {
       productNotFoundException(type);
     }
@@ -93,7 +93,7 @@ namespace edm {
   }
 
   WrapperBase const*
-  RefCore::tryToGetProductPtr(std::type_info const& type) const {
+  RefCore::tryToGetProductPtr(std::type_info const& type, EDProductGetter const* prodGetter) const {
     ProductID tId = id();
     assert (!isTransient());
     if (!tId.isValid()) {
@@ -103,7 +103,7 @@ namespace edm {
     if (cachePtrIsInvalid()) {
       throwInvalidRefFromNoCache(TypeID(type),tId);
     }
-    WrapperBase const* product = productGetter()->getIt(tId);
+    WrapperBase const* product = prodGetter->getIt(tId);
     if(product != nullptr && !(type == product->dynamicTypeInfo())) {
       wrongTypeException(type, product->dynamicTypeInfo());
     }
@@ -111,10 +111,10 @@ namespace edm {
   }
 
   WrapperBase const*
-  RefCore::getThinnedProductPtr(std::type_info const& type, unsigned int& thinnedKey) const {
+  RefCore::getThinnedProductPtr(std::type_info const& type, unsigned int& thinnedKey, EDProductGetter const* prodGetter) const {
 
     ProductID tId = id();
-    WrapperBase const* product = productGetter()->getThinnedProduct(tId, thinnedKey);
+    WrapperBase const* product = prodGetter->getThinnedProduct(tId, thinnedKey);
 
     if (product == nullptr) {
       productNotFoundException(type);
@@ -126,12 +126,13 @@ namespace edm {
   }
 
   bool
-  RefCore::isThinnedAvailable(unsigned int thinnedKey) const {
+  RefCore::isThinnedAvailable(unsigned int thinnedKey, EDProductGetter const* prodGetter) const {
     ProductID tId = id();
-    if(!tId.isValid() || productGetter() == nullptr) {
-      return false;
+    if(!tId.isValid() || prodGetter == nullptr) {
+      //another thread may have changed it
+      return nullptr != productPtr();
     }
-    WrapperBase const* product = productGetter()->getThinnedProduct(tId, thinnedKey);
+    WrapperBase const* product = prodGetter->getThinnedProduct(tId, thinnedKey);
     return product != nullptr;
   }
 
@@ -166,7 +167,12 @@ namespace edm {
   bool
   RefCore::isAvailable() const {
     ProductID tId = id();
-    return productPtr() != nullptr || (tId.isValid() && productGetter() != nullptr && productGetter()->getIt(tId) != nullptr);
+    //If another thread changes the cache, it will change a non-null productGetter
+    // into a null productGeter but productPtr will be non-null
+    // Therefore reading productGetter() first is the safe order
+    auto prodGetter = productGetter();
+    auto prodPtr = productPtr();
+    return prodPtr != nullptr || (tId.isValid() && prodGetter != nullptr && prodGetter->getIt(tId) != nullptr);
   }
 
   void
@@ -264,8 +270,9 @@ namespace edm {
         setId(productToBeInserted.id());
       }
     }
-    if (productGetter() == 0 && productToBeInserted.productGetter() != 0) {
-      setProductGetter(productToBeInserted.productGetter());
+    auto prodGetter = productToBeInserted.productGetter();
+    if (productGetter() == 0 &&  prodGetter != 0) {
+      setProductGetter(prodGetter);
     }
   }
 }


### PR DESCRIPTION
The code which was used to dereference an edm::Ref had a race condition where one thread could have updated the cache right after another thread checked to see if the cache had been updated. This would lead to productGetter() returning a null value which was then used to attempt a function call. The code now only calls productGetter() once and handles the case where it was changed since the last check.
