### PR TITLE
Fix bug spoling PV sorting on W' and Z'. Override default ptMax cut

### DIFF
--- a/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
@@ -25,18 +25,29 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
     const reco::Candidate * c= cands[i];
     int absId=abs(c->pdgId());
     if(absId==13 or absId == 11) {
-      sumPt2+=c->pt()*c->pt();
+      float pt =c->pt();
+      float ptErr = (c->bestTrack() != 0)?c->bestTrack()->ptError() :0;
+      if(pt > ptErr) pt-=ptErr; else pt=0;
+      sumPt2+=pt*pt;
       met+=c->p4();
       sumEt+=c->pt();
     } else {
       fjInputs_.push_back(fastjet::PseudoJet(c->px(),c->py(),c->pz(),c->p4().E()));
+      fjInputs_.back().set_user_index(i);
     }
   }
   fastjet::ClusterSequence sequence( fjInputs_, JetDefinition(antikt_algorithm, 0.4));
   auto jets = fastjet::sorted_by_pt(sequence.inclusive_jets(0));
   for (const auto & pj : jets) {
+    float sumPtErr2=0;
+    std::vector<fastjet::PseudoJet> constituents = pj.constituents();
+    for (unsigned j = 0; j < constituents.size(); j++) {
+	const reco::Candidate * c = cands[constituents[j].user_index()];
+        float ptErr = (c->bestTrack() != 0)?c->bestTrack()->ptError() :0;
+	sumPtErr2+=ptErr*ptErr;
+    }
     auto p4 = LorentzVector( pj.px(), pj.py(), pj.pz(), pj.e() ) ;
-    sumPt2+=p4.pt()*p4.pt()*0.8*0.8;
+    if(p4.pt()*p4.pt() > sumPtErr2) sumPt2+=(p4.pt()*p4.pt()-sumPtErr2)*0.8*0.8;
     met+=p4;
     sumEt+=p4.pt();
   }

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -18,6 +18,7 @@ offlinePrimaryVertices=sortedPrimaryVertices.clone(vertices="unsortedOfflinePrim
 offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(vertices=cms.InputTag("unsortedOfflinePrimaryVertices","WithBS"), particles="trackRefsForJetsBeforeSorting")
 trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices")
 trackWithVertexRefSelectorBeforeSorting.ptMax=9e99
+trackWithVertexRefSelectorBeforeSorting.ptErrorCut=9e99
 trackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
 
 

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -18,8 +18,7 @@ offlinePrimaryVertices=sortedPrimaryVertices.clone(vertices="unsortedOfflinePrim
 offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(vertices=cms.InputTag("unsortedOfflinePrimaryVertices","WithBS"), particles="trackRefsForJetsBeforeSorting")
 trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices")
 trackWithVertexRefSelectorBeforeSorting.ptMax=9e99
-trackWithVertexRefSelectorBeforeSorting.ptErrorCut=9e99
-rackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
+trackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
 
 
 vertexreco = cms.Sequence(unsortedOfflinePrimaryVertices*

--- a/RecoVertex/Configuration/python/RecoVertex_cff.py
+++ b/RecoVertex/Configuration/python/RecoVertex_cff.py
@@ -17,7 +17,9 @@ unsortedOfflinePrimaryVertices=offlinePrimaryVertices.clone()
 offlinePrimaryVertices=sortedPrimaryVertices.clone(vertices="unsortedOfflinePrimaryVertices", particles="trackRefsForJetsBeforeSorting")
 offlinePrimaryVerticesWithBS=sortedPrimaryVertices.clone(vertices=cms.InputTag("unsortedOfflinePrimaryVertices","WithBS"), particles="trackRefsForJetsBeforeSorting")
 trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(vertexTag="unsortedOfflinePrimaryVertices")
-trackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
+trackWithVertexRefSelectorBeforeSorting.ptMax=9e99
+trackWithVertexRefSelectorBeforeSorting.ptErrorCut=9e99
+rackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
 
 
 vertexreco = cms.Sequence(unsortedOfflinePrimaryVertices*


### PR DESCRIPTION
tested on 30 W' events, events with PV of 3rd genparticls vs reconstructed PV[0] separated by more than 2mm.

before:

```
************************
*    Row   * recoGenPa *
************************
*        3 * -1.504770 *
*       13 * 1.1502714 *
*       17 * 3.9613052 *
*       20 * 13.721727 *
*       21 * 11.256953 *
*       24 *   9.19751 *
*       25 * -0.218671 *
************************

after:

************************
*    Row   * recoGenPa *
************************
*        3 * -1.504770 *
*       17 * 3.9613052 *
*       21 * 11.256953 *
*       25 * -0.218671 *

```
