### PR TITLE
fix for the iov sequence iterators as delivered by the caching in pages

### DIFF
--- a/CondCore/CondDB/interface/IOVProxy.h
+++ b/CondCore/CondDB/interface/IOVProxy.h
@@ -34,7 +34,7 @@ namespace cond {
 	//
 	Iterator();
 	Iterator( IOVContainer::const_iterator current, IOVContainer::const_iterator end, 
-		  cond::TimeType timeType, cond::Time_t endOfValidity );
+		  cond::TimeType timeType, cond::Time_t lastTill, cond::Time_t endOfValidity );
 	Iterator( const Iterator& rhs );
 	
 	//
@@ -55,6 +55,7 @@ namespace cond {
 	IOVContainer::const_iterator m_current;
 	IOVContainer::const_iterator m_end;
 	cond::TimeType m_timeType;
+	cond::Time_t m_lastTill;
 	cond::Time_t m_endOfValidity;
       };
       

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -11,6 +11,8 @@
 </bin>
 <bin   file="testConditionDatabase_1.cpp" name="testConditionDatabase_1">
 </bin>
+<bin   file="testConditionDatabase_2.cpp" name="testConditionDatabase_2">
+</bin>
 <bin   file="testRootStreaming.cpp" name="testRootStreaming">
   <lib   name="testCondDBDict"/>
 </bin>

--- a/CondCore/CondDB/test/testConditionDatabase_2.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_2.cpp
@@ -63,6 +63,14 @@ int run( const std::string& connectionString ){
       editor.flush();
       std::cout <<"> iov changes flushed..."<<std::endl;
     }
+    if( !session.existsIov( "MyTag2" ) ){
+      editor = session.createIov<std::string>( "MyTag2", cond::runnumber );
+      editor.setDescription("Test for timestamp selection");
+      editor.insert( 100, p0 );
+      std::cout <<"> inserted 1 iovs..."<<std::endl;
+      editor.flush();
+      std::cout <<"> iov changes flushed..."<<std::endl;
+    }
     session.transaction().commit();
     std::cout <<"> iov changes committed!..."<<std::endl;
     ::sleep(2);
@@ -76,21 +84,7 @@ int run( const std::string& connectionString ){
     proxy.find( 101 );
     for( const auto i : proxy ){
       std::cout <<"# iov since "<<i.since<<" - till "<<i.till<<std::endl; 
-    }    
-    session.transaction().commit();
-    session.transaction().start( false );
-    if( !session.existsIov( "MyTag2" ) ){
-      editor = session.createIov<std::string>( "MyTag2", cond::runnumber ); 
-      editor.setDescription("Test for timestamp selection");
-      editor.insert( 100, p0 );
-      std::cout <<"> inserted 1 iovs..."<<std::endl;
-      editor.flush();
-      std::cout <<"> iov changes flushed..."<<std::endl;
     }
-    session.transaction().commit();
-    std::cout <<"> iov changes committed!..."<<std::endl;
-    ::sleep(2);
-    session.transaction().start();
     proxy = session.readIov( "MyTag2" );
     readIov( proxy, 1, false );
     readIov( proxy, 100, true );

--- a/CondCore/CondDB/test/testConditionDatabase_2.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_2.cpp
@@ -1,0 +1,119 @@
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+//
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+//
+#include <fstream>
+#include <iomanip>
+#include <cstdlib>
+#include <iostream>
+
+using namespace cond::persistency;
+
+
+int readIov( IOVProxy& proxy, cond::Time_t targetTime, bool expectedOk ){
+  IOVProxy::Iterator iovIt = proxy.find( targetTime );
+  if( expectedOk ){
+    if( iovIt == proxy.end() ){
+      std::cout <<"#ERROR: no valid iov found for time "<<targetTime<<std::endl;
+      return -1;
+    } else {
+      std::cout <<"#OK: found iov with since "<<(*iovIt).since<<" - till "<<(*iovIt).till<<" for time "<<targetTime<<std::endl;
+    }
+  } else {
+    if( iovIt == proxy.end() ){
+      std::cout <<"#OK: no valid iov found for time "<<targetTime<<std::endl;
+    } else {
+      std::cout <<"#ERROR: found iov="<<(*iovIt).since<<" for time "<<targetTime<<std::endl;
+      return -1;
+    }
+  }
+  return 0;    
+}
+
+int run( const std::string& connectionString ){
+  try{
+
+    //*************
+    std::cout <<"> Connecting with db in "<<connectionString<<std::endl;
+    ConnectionPool connPool;
+    connPool.setMessageVerbosity( coral::Debug );
+    Session session = connPool.createSession( connectionString, true, cond::COND_DB );
+    session.transaction().start( false );
+    std::string pay0("Payload #0");
+    std::string pay1("Payload #1");
+    auto p0 = session.storePayload( pay0);
+    auto p1 = session.storePayload( pay1);
+
+    IOVEditor editor;
+    if( !session.existsIov( "MyTag" ) ){
+      editor = session.createIov<std::string>( "MyTag", cond::runnumber ); 
+      editor.setDescription("Test for timestamp selection");
+      editor.insert( 100, p0 );
+      editor.insert( 200, p1 );
+      editor.insert( 1001, p0 );
+      editor.insert( 1500, p1 );
+      editor.insert( 2100, p0 );
+      editor.insert( 2500, p1 );
+      editor.insert( 10000, p0 );
+      std::cout <<"> inserted 7 iovs..."<<std::endl;
+      editor.flush();
+      std::cout <<"> iov changes flushed..."<<std::endl;
+    }
+    session.transaction().commit();
+    std::cout <<"> iov changes committed!..."<<std::endl;
+    ::sleep(2);
+    session.transaction().start();
+    IOVProxy proxy = session.readIov( "MyTag" );
+    readIov( proxy, 1, false );
+    readIov( proxy, 100, true );
+    readIov( proxy, 1499, true );
+    readIov( proxy, 1500, true );
+    readIov( proxy, 20000, true );
+    proxy.find( 101 );
+    for( const auto i : proxy ){
+      std::cout <<"# iov since "<<i.since<<" - till "<<i.till<<std::endl; 
+    }    
+    session.transaction().commit();
+    session.transaction().start( false );
+    if( !session.existsIov( "MyTag2" ) ){
+      editor = session.createIov<std::string>( "MyTag2", cond::runnumber ); 
+      editor.setDescription("Test for timestamp selection");
+      editor.insert( 100, p0 );
+      std::cout <<"> inserted 1 iovs..."<<std::endl;
+      editor.flush();
+      std::cout <<"> iov changes flushed..."<<std::endl;
+    }
+    session.transaction().commit();
+    std::cout <<"> iov changes committed!..."<<std::endl;
+    ::sleep(2);
+    session.transaction().start();
+    proxy = session.readIov( "MyTag2" );
+    readIov( proxy, 1, false );
+    readIov( proxy, 100, true );
+    session.transaction().commit();
+
+  } catch (const std::exception& e){
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return -1;
+  } catch (...){
+    std::cout << "UNEXPECTED FAILURE." << std::endl;
+    return -1;
+  }
+  std::cout <<"## Run successfully completed."<<std::endl;
+  return 0;
+}
+
+int main (int argc, char** argv)
+{
+  int ret = 0;
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+  std::string connectionString0("sqlite_file:cms_conditions_2.db");
+  ret = run( connectionString0 );
+  return ret;
+}
+

--- a/CondCore/CondDB/test/testConditionDatabase_2.cpp
+++ b/CondCore/CondDB/test/testConditionDatabase_2.cpp
@@ -63,6 +63,14 @@ int run( const std::string& connectionString ){
       editor.flush();
       std::cout <<"> iov changes flushed..."<<std::endl;
     }
+    if( !session.existsIov( "MyTag2" ) ){
+      editor = session.createIov<std::string>( "MyTag2", cond::runnumber );
+      editor.setDescription("Test for timestamp selection");
+      editor.insert( 100, p0 );
+      std::cout <<"> inserted 1 iovs..."<<std::endl;
+      editor.flush();
+      std::cout <<"> iov changes flushed..."<<std::endl;
+    }
     session.transaction().commit();
     std::cout <<"> iov changes committed!..."<<std::endl;
     ::sleep(2);
@@ -77,20 +85,6 @@ int run( const std::string& connectionString ){
     for( const auto i : proxy ){
       std::cout <<"# iov since "<<i.since<<" - till "<<i.till<<std::endl; 
     }    
-    session.transaction().commit();
-    session.transaction().start( false );
-    if( !session.existsIov( "MyTag2" ) ){
-      editor = session.createIov<std::string>( "MyTag2", cond::runnumber ); 
-      editor.setDescription("Test for timestamp selection");
-      editor.insert( 100, p0 );
-      std::cout <<"> inserted 1 iovs..."<<std::endl;
-      editor.flush();
-      std::cout <<"> iov changes flushed..."<<std::endl;
-    }
-    session.transaction().commit();
-    std::cout <<"> iov changes committed!..."<<std::endl;
-    ::sleep(2);
-    session.transaction().start();
     proxy = session.readIov( "MyTag2" );
     readIov( proxy, 1, false );
     readIov( proxy, 100, true );


### PR DESCRIPTION
This PR contains a fix for the iterator of the iov sequence. The till value is set to the upper bound of the cache when the iteration reaches the end of the page.
