### PR TITLE
hltConfigFromDB: increase the thread stack size

### DIFF
--- a/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
+++ b/HLTrigger/Configuration/python/Tools/confdbOfflineConverter.py
@@ -113,11 +113,13 @@ class OfflineConverter:
         # setup the java command line and CLASSPATH
         if self.verbose:
             sys.stderr.write("workDir = %s\n" % self.workDir)
-# Use non-blocking random # source /dev/urandom (instead of /dev/random), see:
-# http://blockdump.blogspot.fr/2012/07/connection-problems-inbound-connection.html
-# Also deal with timezone region not found
-# http://stackoverflow.com/questions/9156379/ora-01882-timezone-region-not-found
-        self.javaCmd = ( 'java', '-cp', ':'.join(self.workDir + '/' + jar for jar in self.jars),'-Djava.security.egd=file:///dev/urandom','-Doracle.jdbc.timezoneAsRegion=false','confdb.converter.BrowserConverter' )
+        # use non-blocking random number source /dev/urandom (instead of /dev/random), see:
+        #   http://blockdump.blogspot.fr/2012/07/connection-problems-inbound-connection.html
+        # deal with timezone region not found
+        #   http://stackoverflow.com/questions/9156379/ora-01882-timezone-region-not-found
+        # increase the thread stack size from the default of 1 MB to work around java.lang.StackOverflowError errors, see
+        #   man java
+        self.javaCmd = ( 'java', '-cp', ':'.join(self.workDir + '/' + jar for jar in self.jars), '-Djava.security.egd=file:///dev/urandom', '-Doracle.jdbc.timezoneAsRegion=false', '-Xss32M', 'confdb.converter.BrowserConverter' )
 
 
     def query(self, *args):


### PR DESCRIPTION
increase the java thread stack size from the default (1 MB) to 32 MB, to work around java.lang.StackOverflowError errors
