### PR TITLE
Back out ROOT6 only changes

### DIFF
--- a/DPGAnalysis/SiStripTools/bin/MultiplicityPlotMacros.cc
+++ b/DPGAnalysis/SiStripTools/bin/MultiplicityPlotMacros.cc
@@ -103,7 +103,7 @@ TH1D* AverageRunMultiplicity(TFile& ff, const char* module, const bool excludeLa
   CommonAnalyzer camult(&ff,"",module);
 
   TH1D* clusmult = new TH1D("clusmult","Average Multiplicity vs run",10,0.,10.);
-  clusmult->SetCanExtend(TH1::kXaxis);
+  clusmult->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = camult.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/DPGAnalysis/SiStripTools/bin/OOTMultiplicityPlotMacros.h
+++ b/DPGAnalysis/SiStripTools/bin/OOTMultiplicityPlotMacros.h
@@ -35,13 +35,13 @@ class OOTSummary {
   TH1F* hngoodbx;
   OOTSummary() {
     hootfrac = new TH1F("ootfrac","OOT fraction vs fill/run",10,0.,10.);
-    hootfrac->SetCanExtend(TH1::kXaxis);
+    hootfrac->SetBit(TH1::kCanRebin);
 
     hootfracsum = new TH1F("ootfracsum","OOT summed fraction vs fill/run",10,0.,10.);
-    hootfracsum->SetCanExtend(TH1::kXaxis);
+    hootfracsum->SetBit(TH1::kCanRebin);
   
     hngoodbx = new TH1F("ngoodbx","Number of good BX pairs vs fill/run",10,0.,10.);
-    hngoodbx->SetCanExtend(TH1::kXaxis);
+    hngoodbx->SetBit(TH1::kCanRebin);
     
   }
   ~OOTSummary() {

--- a/DPGAnalysis/SiStripTools/bin/SiStripQualityHistoryPlots.cc
+++ b/DPGAnalysis/SiStripTools/bin/SiStripQualityHistoryPlots.cc
@@ -20,7 +20,7 @@ TH1D* AverageRunBadChannels(TFile& ff, const char* module, const char* histo, co
   CommonAnalyzer camult(&ff,"",module);
 
   TH1D* badchannels = new TH1D("badchannels","Average Number of Bad Channels vs run",10,0.,10.);
-  badchannels->SetCanExtend(TH1::kXaxis);
+  badchannels->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = camult.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/DPGAnalysis/SiStripTools/bin/StatisticsPlots.cc
+++ b/DPGAnalysis/SiStripTools/bin/StatisticsPlots.cc
@@ -144,7 +144,7 @@ TH1D* SummaryHisto(TFile& ff, const char* module) {
   CommonAnalyzer castat(&ff,"",module);
   
   TH1D* nevents = new TH1D("nevents","Number of events vs run",10,0.,10.);
-  nevents->SetCanExtend(TH1::kXaxis);
+  nevents->SetBit(TH1::kCanRebin);
   
   std::vector<unsigned int> runs = castat.getRunList();
   std::sort(runs.begin(),runs.end());
@@ -277,7 +277,7 @@ void StatisticsPlots(const char* fullname, const char* module, const char* label
   // Summary histograms
 
   TH1D* nevents = new TH1D("nevents","Number of events vs run",10,0.,10.);
-  nevents->SetCanExtend(TH1::kXaxis);
+  nevents->SetBit(TH1::kCanRebin);
 
 
   std::vector<unsigned int> runs = castat.getRunList();

--- a/DPGAnalysis/SiStripTools/interface/DigiBXCorrHistogramMaker.h
+++ b/DPGAnalysis/SiStripTools/interface/DigiBXCorrHistogramMaker.h
@@ -283,7 +283,7 @@ void DigiBXCorrHistogramMaker<T>::book(const char* dirname, const std::map<int,s
       sprintf(title,"%s %s multiplicity vs BX mod(70) and Orbit",slab.c_str(),m_hitname.c_str());
       m_ndigivscycletime[i] =  m_rhm.makeTProfile2D(name,title,70,-0.5,69.5,90,0.,90*262144);
       //      m_ndigivscycletime[i]->GetXaxis()->SetTitle("Event 1 BX mod(70)"); m_ndigivscycletime[i]->GetYaxis()->SetTitle("time [Orb#]");
-      //      m_ndigivscycletime[i]->SetCanExtend(TH1::kYaxis);
+      //      m_ndigivscycletime[i]->SetBit(TH1::kCanRebin);
     }
 
     // vs BX number
@@ -326,7 +326,7 @@ void DigiBXCorrHistogramMaker<T>::beginRun(const unsigned int nrun) {
     if(m_runHisto) {
       if(m_ndigivscycletime[i]) {
 	(*m_ndigivscycletime[i])->GetXaxis()->SetTitle("Event 1 BX mod(70)"); (*m_ndigivscycletime[i])->GetYaxis()->SetTitle("time [Orb#]");
-	(*m_ndigivscycletime[i])->SetCanExtend(TH1::kAllAxes);
+	(*m_ndigivscycletime[i])->SetBit(TH1::kCanRebin);
       }
     }
   }

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseMonitor.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseMonitor.cc
@@ -185,7 +185,7 @@ APVCyclePhaseMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
        sprintf(hname,"phasevsorbit_%s",phase->first.c_str());
        edm::LogInfo("TProfileBeingBooked") << "TProfile " << hname << " being booked" ;
        _hphasevsorbit[phase->first] = subrun.make<TProfile>(hname,hname,m_LSfrac*m_maxLS,0,m_maxLS*262144);
-       _hphasevsorbit[phase->first]->SetCanExtend(TH1::kXaxis);
+       _hphasevsorbit[phase->first]->SetBit(TH1::kCanRebin);
        _hphasevsorbit[phase->first]->GetXaxis()->SetTitle("time [orbit#]"); _hphasevsorbit[phase->first]->GetYaxis()->SetTitle("Phase");
 
      }
@@ -242,7 +242,7 @@ APVCyclePhaseMonitor::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   }
   for(std::map<std::string,TProfile**>::const_iterator prof=_hselectedphasevsorbit.begin();prof!=_hselectedphasevsorbit.end();++prof) {
     if(*(prof->second)) {
-      (*(prof->second))->SetCanExtend(TH1::kXaxis);
+      (*(prof->second))->SetBit(TH1::kCanRebin);
       (*(prof->second))->GetXaxis()->SetTitle("time [orbit#]");
       (*(prof->second))->GetYaxis()->SetTitle("Phase");
     }
@@ -259,7 +259,7 @@ APVCyclePhaseMonitor::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   }
   for(std::map<std::string,TProfile**>::const_iterator prof=_hselectedphasevectorvsorbit.begin();prof!=_hselectedphasevectorvsorbit.end();++prof) {
     if(*(prof->second)) {
-      (*(prof->second))->SetCanExtend(TH1::kXaxis);
+      (*(prof->second))->SetBit(TH1::kCanRebin);
       (*(prof->second))->GetXaxis()->SetTitle("time [orbit#]");
       (*(prof->second))->GetYaxis()->SetTitle("Phase");
     }

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseProducerFromL1TS.cc
@@ -222,32 +222,32 @@ APVCyclePhaseProducerFromL1TS::beginRun(const edm::Run& iRun, const edm::EventSe
 
     if(_hlresync && *_hlresync) {
       (*_hlresync)->GetXaxis()->SetTitle("Orbit");     (*_hlresync)->GetYaxis()->SetTitle("Events");
-      (*_hlresync)->SetCanExtend(TH1::kXaxis);
+      (*_hlresync)->SetBit(TH1::kCanRebin);
     }
 
     if(_hlOC0 && *_hlOC0) {
       (*_hlOC0)->GetXaxis()->SetTitle("Orbit");     (*_hlOC0)->GetYaxis()->SetTitle("Events");
-      (*_hlOC0)->SetCanExtend(TH1::kXaxis);
+      (*_hlOC0)->SetBit(TH1::kCanRebin);
     }
 
     if(_hlTE && *_hlTE) {
       (*_hlTE)->GetXaxis()->SetTitle("Orbit");     (*_hlTE)->GetYaxis()->SetTitle("Events");
-      (*_hlTE)->SetCanExtend(TH1::kXaxis);
+      (*_hlTE)->SetBit(TH1::kCanRebin);
     }
 
     if(_hlstart && *_hlstart) {
       (*_hlstart)->GetXaxis()->SetTitle("Orbit");     (*_hlstart)->GetYaxis()->SetTitle("Events");
-      (*_hlstart)->SetCanExtend(TH1::kXaxis);
+      (*_hlstart)->SetBit(TH1::kCanRebin);
     }
 
     if(_hlEC0 && *_hlEC0) {
       (*_hlEC0)->GetXaxis()->SetTitle("Orbit");     (*_hlEC0)->GetYaxis()->SetTitle("Events");
-      (*_hlEC0)->SetCanExtend(TH1::kXaxis);
+      (*_hlEC0)->SetBit(TH1::kCanRebin);
     }
 
     if(_hlHR && *_hlHR) {
       (*_hlHR)->GetXaxis()->SetTitle("Orbit");     (*_hlHR)->GetYaxis()->SetTitle("Events");
-      (*_hlHR)->SetCanExtend(TH1::kXaxis);
+      (*_hlHR)->SetBit(TH1::kCanRebin);
     }
 
     if(_hdlec0lresync && *_hdlec0lresync) {

--- a/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
@@ -405,7 +405,7 @@ APVShotsAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup&)
 
   if(_nShotsVsTimerun && *_nShotsVsTimerun) {
     (*_nShotsVsTimerun)->GetXaxis()->SetTitle("Orbit");  (*_nShotsVsTimerun)->GetYaxis()->SetTitle("Number of Shots");
-    (*_nShotsVsTimerun)->SetCanExtend(TH1::kXaxis);
+    (*_nShotsVsTimerun)->SetBit(TH1::kCanRebin);
   }
 
   if(_whichAPVrun && *_whichAPVrun) {

--- a/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
+++ b/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
@@ -111,7 +111,7 @@ DuplicateRecHits::DuplicateRecHits(const edm::ParameterSet& iConfig):
 
   m_nduplicate = tfserv->make<TH1F>("nduplicate","Number of duplicated clusters per track",10,-0.5,9.5);
   m_nduplmod = tfserv->make<TH1F>("nduplmod","Number of duplicated clusters per module",10,-0.5,9.5);
-  m_nduplmod->SetCanExtend(TH1::kXaxis);
+  m_nduplmod->SetBit(TH1::kCanRebin);
 }
 
 

--- a/DPGAnalysis/SiStripTools/plugins/EventTimeDistribution.cc
+++ b/DPGAnalysis/SiStripTools/plugins/EventTimeDistribution.cc
@@ -235,7 +235,7 @@ EventTimeDistribution::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   if(*_bxincycle) {  (*_bxincycle)->GetXaxis()->SetTitle("Event BX mod(70)"); }
 
   if(*_orbit) {
-    (*_orbit)->SetCanExtend(TH1::kXaxis);
+    (*_orbit)->SetBit(TH1::kCanRebin);
     (*_orbit)->GetXaxis()->SetTitle("time [Orb#]");
   }
 
@@ -252,7 +252,7 @@ EventTimeDistribution::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   }
 
   if(_orbitvsbxincycle && *_orbitvsbxincycle) {
-    (*_orbitvsbxincycle)->SetCanExtend(TH1::kYaxis);
+    (*_orbitvsbxincycle)->SetBit(TH1::kCanRebin);
     (*_orbitvsbxincycle)->GetXaxis()->SetTitle("Event BX mod(70)"); (*_orbitvsbxincycle)->GetYaxis()->SetTitle("time [Orb#]");
   }
 

--- a/DPGAnalysis/SiStripTools/plugins/FEDBadModuleFilter.cc
+++ b/DPGAnalysis/SiStripTools/plugins/FEDBadModuleFilter.cc
@@ -175,7 +175,7 @@ FEDBadModuleFilter::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup
 
     m_rhm.beginRun(iRun);
     if(*m_nbadvsorbrun) {
-      (*m_nbadvsorbrun)->SetCanExtend(TH1::kXaxis);
+      (*m_nbadvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_nbadvsorbrun)->GetXaxis()->SetTitle("time [Orb#]");
       (*m_nbadvsorbrun)->GetYaxis()->SetTitle("Bad Channels");
     }

--- a/DPGAnalysis/SiStripTools/plugins/SiPixelQualityHistory.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SiPixelQualityHistory.cc
@@ -199,7 +199,7 @@ SiPixelQualityHistory::beginRun(const edm::Run& iRun, const edm::EventSetup& iSe
 
     if(m_badmodrun.find(name)!=m_badmodrun.end()) {
       if(m_badmodrun[name] && *m_badmodrun[name]) {
-	(*m_badmodrun[name])->SetCanExtend(TH1::kXaxis);
+	(*m_badmodrun[name])->SetBit(TH1::kCanRebin);
 	(*m_badmodrun[name])->GetXaxis()->SetTitle("time [Orb#]"); (*m_badmodrun[name])->GetYaxis()->SetTitle("bad components");
       }
     }

--- a/DPGAnalysis/SiStripTools/plugins/SiStripQualityHistory.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SiStripQualityHistory.cc
@@ -207,7 +207,7 @@ SiStripQualityHistory::beginRun(const edm::Run& iRun, const edm::EventSetup& iSe
 
     if(m_badmodrun.find(name)!=m_badmodrun.end()) {
       if(m_badmodrun[name] && *m_badmodrun[name]) {
-	(*m_badmodrun[name])->SetCanExtend(TH1::kXaxis);
+	(*m_badmodrun[name])->SetBit(TH1::kCanRebin);
 	(*m_badmodrun[name])->GetXaxis()->SetTitle("time [Orb#]"); (*m_badmodrun[name])->GetYaxis()->SetTitle("bad components");
       }
     }

--- a/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
@@ -364,7 +364,7 @@ TrackCount::beginRun(const edm::Run& iRun, const edm::EventSetup&)
 
   if(m_runHisto) {
     (*m_ntrkvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");    (*m_ntrkvsorbrun)->GetYaxis()->SetTitle("Ntracks");
-    (*m_ntrkvsorbrun)->SetCanExtend(TH1::kXaxis);
+    (*m_ntrkvsorbrun)->SetBit(TH1::kCanRebin);
   }
 }
 

--- a/DPGAnalysis/SiStripTools/src/DigiInvestigatorHistogramMaker.cc
+++ b/DPGAnalysis/SiStripTools/src/DigiInvestigatorHistogramMaker.cc
@@ -149,7 +149,7 @@ void DigiInvestigatorHistogramMaker::beginRun(const edm::Run& iRun) {
     if(_runHisto) {
       if(*_nmultvsorbrun[i]) {
 	(*_nmultvsorbrun[i])->GetXaxis()->SetTitle("time [orbit#]");    (*_nmultvsorbrun[i])->GetYaxis()->SetTitle("Hits");
-	(*_nmultvsorbrun[i])->SetCanExtend(TH1::kXaxis);
+	(*_nmultvsorbrun[i])->SetBit(TH1::kCanRebin);
       }
       if(*_nmultvsbxrun[i]) {
 	(*_nmultvsbxrun[i])->GetXaxis()->SetTitle("BX#");  (*_nmultvsbxrun[i])->GetYaxis()->SetTitle("Mean Number of Hits"); 

--- a/Validation/RecoVertex/bin/BSvsPVPlots.cc
+++ b/Validation/RecoVertex/bin/BSvsPVPlots.cc
@@ -168,17 +168,17 @@ void BSvsPVPlots(const char* fullname,const char* module, const char* label, con
 
   // Summary histograms
   TH1D* deltaxsum = new TH1D("deltaxsum","(PV-BS) Fitted X position vs run",10,0.,10.);
-  deltaxsum->SetCanExtend(TH1::kAllAxes);
+  deltaxsum->SetBit(TH1::kCanRebin);
   TH1D* deltaysum = new TH1D("deltaysum","(PV-BS) Fitted Y position vs run",10,0.,10.);
-  deltaysum->SetCanExtend(TH1::kAllAxes);
+  deltaysum->SetBit(TH1::kCanRebin);
 
   TH1D* deltaxmeansum = new TH1D("deltaxmeansum","(PV-BS) Mean X position vs run",10,0.,10.);
-  deltaxmeansum->SetCanExtend(TH1::kAllAxes);
+  deltaxmeansum->SetBit(TH1::kCanRebin);
   TH1D* deltaymeansum = new TH1D("deltaymeansum","(PV-BS) Mean Y position vs run",10,0.,10.);
-  deltaymeansum->SetCanExtend(TH1::kAllAxes);
+  deltaymeansum->SetBit(TH1::kCanRebin);
 
   TH1D* deltazmeansum = new TH1D("deltazmeansum","(PV-BS) Mean Z position vs run",10,0.,10.);
-  deltazmeansum->SetCanExtend(TH1::kAllAxes);
+  deltazmeansum->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = castat.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/Validation/RecoVertex/bin/PrimaryVertexPlots.cc
+++ b/Validation/RecoVertex/bin/PrimaryVertexPlots.cc
@@ -346,21 +346,21 @@ void PrimaryVertexPlots(const char* fullname,const char* module, const char* pos
   // Summary histograms
   /*
   TH1D* vtxxsum = new TH1D("vtxxsum","(BS-PV) Fitted X position vs run",10,0.,10.);
-  vtxxsum->SetCanExtend(TH1::kAllAxes);
+  vtxxsum->SetBit(TH1::kCanRebin);
   TH1D* vtxysum = new TH1D("vtxysum","(BS-PV) Fitted Y position vs run",10,0.,10.);
-  vtxysum->SetCanExtend(TH1::kAllAxes);
+  vtxysum->SetBit(TH1::kCanRebin);
   TH1D* vtxzsum = new TH1D("vtxzsum","(BS-PV) Fitted Y position vs run",10,0.,10.);
-  vtxzsum->SetCanExtend(TH1::kAllAxes);
+  vtxzsum->SetBit(TH1::kCanRebin);
   */
 
   TH1D* vtxxmeansum = new TH1D("vtxxmeansum","PV mean X position vs run",10,0.,10.);
-  vtxxmeansum->SetCanExtend(TH1::kAllAxes);
+  vtxxmeansum->SetBit(TH1::kCanRebin);
   TH1D* vtxymeansum = new TH1D("vtxymeansum","PV mean Y position vs run",10,0.,10.);
-  vtxymeansum->SetCanExtend(TH1::kAllAxes);
+  vtxymeansum->SetBit(TH1::kCanRebin);
   TH1D* vtxzmeansum = new TH1D("vtxzmeansum","PV mean Z position vs run",10,0.,10.);
-  vtxzmeansum->SetCanExtend(TH1::kAllAxes);
+  vtxzmeansum->SetBit(TH1::kCanRebin);
   TH1D* vtxzsigmasum = new TH1D("vtxzsigmasum","PV sigma Z position vs run",10,0.,10.);
-  vtxzsigmasum->SetCanExtend(TH1::kAllAxes);
+  vtxzsigmasum->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = castat.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/Validation/RecoVertex/bin/multibsvspvplots.cc
+++ b/Validation/RecoVertex/bin/multibsvspvplots.cc
@@ -37,17 +37,17 @@ void multibsvspvplots(const char* module, const char* label, const char* postfix
 
   // Summary histograms
   TH1D* deltaxsum = new TH1D("deltaxsum","(PV-BS) Fitted X position vs run",10,0.,10.);
-  deltaxsum->SetCanExtend(TH1::kAllAxes);
+  deltaxsum->SetBit(TH1::kCanRebin);
   TH1D* deltaysum = new TH1D("deltaysum","(PV-BS) Fitted Y position vs run",10,0.,10.);
-  deltaysum->SetCanExtend(TH1::kAllAxes);
+  deltaysum->SetBit(TH1::kCanRebin);
 
   TH1D* deltaxmeansum = new TH1D("deltaxmeansum","(PV-BS) Mean X position vs run",10,0.,10.);
-  deltaxmeansum->SetCanExtend(TH1::kAllAxes);
+  deltaxmeansum->SetBit(TH1::kCanRebin);
   TH1D* deltaymeansum = new TH1D("deltaymeansum","(PV-BS) Mean Y position vs run",10,0.,10.);
-  deltaymeansum->SetCanExtend(TH1::kAllAxes);
+  deltaymeansum->SetBit(TH1::kCanRebin);
 
   TH1D* deltazmeansum = new TH1D("deltazmeansum","(PV-BS) Mean Z position vs run",10,0.,10.);
-  deltazmeansum->SetCanExtend(TH1::kAllAxes);
+  deltazmeansum->SetBit(TH1::kCanRebin);
 
   TF1* fdoubleg = new TF1("doubleg","[1]*exp(-0.5*((x-[0])/[2])**2)+[3]*exp(-0.5*((x-[0])/[4])**2)+[5]*exp(sqrt((x-[0])**2)*[6])",-.2,.2);
   fdoubleg->SetLineColor(kRed);

--- a/Validation/RecoVertex/src/BSvsPVHistogramMaker.cc
+++ b/Validation/RecoVertex/src/BSvsPVHistogramMaker.cc
@@ -164,11 +164,11 @@ void BSvsPVHistogramMaker::beginRun(const unsigned int nrun) {
 
     if(_runHistoProfile) {
       (*_hdeltaxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hdeltaxvsorbrun)->GetYaxis()->SetTitle("#Delta(X) [cm]");
-      (*_hdeltaxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*_hdeltaxvsorbrun)->SetBit(TH1::kCanRebin);
       (*_hdeltayvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hdeltayvsorbrun)->GetYaxis()->SetTitle("#Delta(Y) [cm]");
-      (*_hdeltayvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*_hdeltayvsorbrun)->SetBit(TH1::kCanRebin);
       (*_hdeltazvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hdeltazvsorbrun)->GetYaxis()->SetTitle("#Delta(Z) [cm]");
-      (*_hdeltazvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*_hdeltazvsorbrun)->SetBit(TH1::kCanRebin);
     }
     if(_runHistoBXProfile) {
       (*_hdeltaxvsbxrun)->GetXaxis()->SetTitle("BX");   (*_hdeltaxvsbxrun)->GetYaxis()->SetTitle("#Delta(X) [cm]");

--- a/Validation/RecoVertex/src/BeamSpotHistogramMaker.cc
+++ b/Validation/RecoVertex/src/BeamSpotHistogramMaker.cc
@@ -98,17 +98,17 @@ void BeamSpotHistogramMaker::beginRun(const unsigned int nrun) {
   (*_hbssigmazrun)->GetXaxis()->SetTitle("sigmaZ [cm]");   (*_hbssigmazrun)->GetYaxis()->SetTitle("Events");
 
   (*_hbsxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbsxvsorbrun)->GetYaxis()->SetTitle("X [cm]");
-  (*_hbsxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbsxvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbsyvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbsyvsorbrun)->GetYaxis()->SetTitle("Y [cm]");
-  (*_hbsyvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbsyvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbszvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbszvsorbrun)->GetYaxis()->SetTitle("Z [cm]");
-  (*_hbszvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbszvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbssigmaxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbssigmaxvsorbrun)->GetYaxis()->SetTitle("sigmaX [cm]");
-  (*_hbssigmaxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbssigmaxvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbssigmayvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbssigmayvsorbrun)->GetYaxis()->SetTitle("sigmaY [cm]");
-  (*_hbssigmayvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbssigmayvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbssigmazvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbssigmazvsorbrun)->GetYaxis()->SetTitle("sigmaZ [cm]");
-  (*_hbssigmazvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbssigmazvsorbrun)->SetBit(TH1::kCanRebin);
 
 
 }

--- a/Validation/RecoVertex/src/VertexHistogramMaker.cc
+++ b/Validation/RecoVertex/src/VertexHistogramMaker.cc
@@ -217,13 +217,13 @@ void VertexHistogramMaker::beginRun(const edm::Run& iRun) {
 
     if(m_runHistoProfile) {
       (*m_hvtxxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hvtxxvsorbrun)->GetYaxis()->SetTitle("X [cm]");
-      (*m_hvtxxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hvtxxvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hvtxyvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hvtxyvsorbrun)->GetYaxis()->SetTitle("Y [cm]");
-      (*m_hvtxyvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hvtxyvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hvtxzvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hvtxzvsorbrun)->GetYaxis()->SetTitle("Z [cm]");
-      (*m_hvtxzvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hvtxzvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hnvtxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hnvtxvsorbrun)->GetYaxis()->SetTitle("Nvertices");
-      (*m_hnvtxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hnvtxvsorbrun)->SetBit(TH1::kCanRebin);
     }
 
     if(m_runHistoBXProfile) {
@@ -243,9 +243,9 @@ void VertexHistogramMaker::beginRun(const edm::Run& iRun) {
 
     if(m_runHisto2D) {
       (*m_hnvtxvsbxvsorbrun)->GetXaxis()->SetTitle("BX#"); (*m_hnvtxvsbxvsorbrun)->GetYaxis()->SetTitle("time [orbit#]");
-      (*m_hnvtxvsbxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hnvtxvsbxvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hnvtxvsorbrun2D)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hnvtxvsorbrun2D)->GetYaxis()->SetTitle("Nvertices");
-      (*m_hnvtxvsorbrun2D)->SetCanExtend(TH1::kAllAxes);
+      (*m_hnvtxvsorbrun2D)->SetBit(TH1::kCanRebin);
     }
   }
 }


### PR DESCRIPTION
This PR backs out ROOT6 only changes that were automatically merged from CMSSW_7_4_X, but not yet in an IB. 
If this PR makes it into the next IB, it will prevent build errors from happening in the first place.
If not, it will fix the build errors after the fact.
Please expedite.
