### PR TITLE
Bug fix. Add function to get top level PSet

### DIFF
--- a/FWCore/Framework/test/stubs/HistoryAnalyzer.cc
+++ b/FWCore/Framework/test/stubs/HistoryAnalyzer.cc
@@ -86,6 +86,17 @@ namespace edmtest {
       edm::ParameterSet proc_pset;
       event.getProcessParameterSet(event.processHistory().rbegin()->processName(),proc_pset);
 
+      {
+        // test the function getProcessParameterSetContainingModule this is a
+        // convenient spot to test because this module is run in both a
+        // a single process and in a subprocess.
+        edm::ParameterSet proc_pset2 = edm::getProcessParameterSetContainingModule(moduleDescription());
+        assert(proc_pset2.id() == proc_pset.id());
+        vstring paths1 = proc_pset.getParameter<vstring>("@paths");
+        vstring paths2 = proc_pset2.getParameter<vstring>("@paths");
+        assert(paths1 == paths2);
+      }
+
       edm::pset::Registry* reg = edm::pset::Registry::instance();
 
       if (!expectedPaths_.empty()) {

--- a/FWCore/Integration/test/EventHistory_SubProcess_cfg.py
+++ b/FWCore/Integration/test/EventHistory_SubProcess_cfg.py
@@ -260,3 +260,13 @@ process6.p2 = cms.Path(process6.historytest*process6.analyzerOnPath)
 process6.ep61 = cms.EndPath(process6.out)
 process6.ep62 = cms.EndPath(process6.producerOnEndPath*process6.filterOnEndPath*process6.out*process6.historytest)
 process6.ep63 = cms.EndPath(process6.analyzerOnEndPath*process6.out2*process6.out)
+
+process7 = cms.Process("SEVENTH")
+
+process6.subProcess = cms.SubProcess(process7)
+
+process7.dummyproducerxxx = cms.EDProducer("IntProducer",
+    ivalue = cms.int32(2)
+)
+
+process7.p1 = cms.Path(process7.dummyproducerxxx)

--- a/FWCore/ParameterSet/interface/ParameterSet.h
+++ b/FWCore/ParameterSet/interface/ParameterSet.h
@@ -30,6 +30,7 @@ namespace cms {
 }
 
 namespace edm {
+  class ModuleDescription;
   typedef std::vector<ParameterSet> VParameterSet;
 
   class ParameterSet {
@@ -334,6 +335,9 @@ namespace edm {
   // Free function to retrieve a parameter set, given the parameter set ID.
   ParameterSet const&
   getParameterSet(ParameterSetID const& id);
+
+  ParameterSet const&
+  getProcessParameterSetContainingModule(ModuleDescription const& moduleDescription);
 
   // specializations
   // ----------------------------------------------------------------------

--- a/FWCore/ParameterSet/src/ParameterSet.cc
+++ b/FWCore/ParameterSet/src/ParameterSet.cc
@@ -16,6 +16,8 @@
 #include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
+
 #include <algorithm>
 #include <iostream>
 #include <sstream>
@@ -951,12 +953,17 @@ namespace edm {
   // Free function to return a parameterSet given its ID.
   ParameterSet const&
   getParameterSet(ParameterSetID const& id) {
-    ParameterSet const* result = 0;
-    if(0 == (result = pset::Registry::instance()->getMapped(id))) {
-      throw Exception(errors::Configuration, "MissingParameterSet:")
+    ParameterSet const* result = nullptr;
+    if(nullptr == (result = pset::Registry::instance()->getMapped(id))) {
+      throw Exception(errors::LogicError, "MissingParameterSet:")
         << "Parameter Set ID '" << id << "' not found.";
     }
     return *result;
+  }
+
+  ParameterSet const&
+  getProcessParameterSetContainingModule(ModuleDescription const& moduleDescription) {
+    return getParameterSet(moduleDescription.mainParameterSetID());
   }
 
   void ParameterSet::deprecatedInputTagWarning(std::string const& name,


### PR DESCRIPTION
Add a new function that allows one to get a
top level ParameterSet by passing in a
ModuleDescription which is available in
all modules.

This is the Core part of the changes needed to
fix modules that were using the old
getProcessParameterSet function. This depends
on a single global static ParameterSetID.
It fails when used in SubProcesses would return
the ParameterSet for the wrong process/SubProcess.
The bug only affects jobs with SubProcesses.
This global was also problematic for multithreading
(had to be protected with a mutex).

More changes will follow this to convert
all uses of the old function to an alternative
and then eventually to delete it. Merging this
PR quickly will make it easier to test the others
quickly.
