### PR TITLE
Make skeletons generate stream or one types

### DIFF
--- a/FWCore/Skeletons/scripts/mkTemplates/EDAnalyzer/EDAnalyzer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDAnalyzer/EDAnalyzer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -38,7 +38,13 @@
 // class declaration
 //
 
-class __class__ : public edm::EDAnalyzer {
+// If the analyzer does not use TFileService, please remove
+// the template argument to the base class so the class inherits
+// from  edm::one::EDAnalyzer<> and also remove the line from
+// constructor "usesResource("TFileService");"
+// This will improve performance in multithreaded jobs.
+
+class __class__ : public edm::one::EDAnalyzer<edm::one::SharedResources>  {
    public:
       explicit __class__(const edm::ParameterSet&);
       ~__class__();
@@ -50,11 +56,6 @@ class __class__ : public edm::EDAnalyzer {
       virtual void beginJob() override;
       virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
       virtual void endJob() override;
-
-      //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
-      //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
-      //virtual void endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
 
       // ----------member data ---------------------------
 @example_track       edm::InputTag trackTags_; //used to select what tracks to read from configuration file
@@ -78,6 +79,7 @@ __class__::__class__(const edm::ParameterSet& iConfig)
 
 {
    //now do what ever initialization is needed
+   usesResource("TFileService");
 @example_histo   edm::Service<TFileService> fs;
 @example_histo   histo = fs->make<TH1D>("charge" , "Charges" , 200 , -2 , 2 );
 
@@ -138,38 +140,6 @@ void
 __class__::endJob() 
 {
 }
-
-// ------------ method called when starting to processes a run  ------------
-/*
-void 
-__class__::beginRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a run  ------------
-/*
-void 
-__class__::endRun(edm::Run const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when starting to processes a luminosity block  ------------
-/*
-void 
-__class__::beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-/*
-void 
-__class__::endLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&)
-{
-}
-*/
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
 void

--- a/FWCore/Skeletons/scripts/mkTemplates/EDFilter/EDFilter.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDFilter/EDFilter.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 //
 // class declaration
@@ -41,8 +42,10 @@ class __class__ : public edm::stream::EDFilter<> {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
+      virtual void beginStream(edm::StreamID) override;
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      
+      virtual void endStream() override;
+
       //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
@@ -97,6 +100,17 @@ __class__::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    iSetup.get<SetupRecord>().get(pSetup);
 #endif
    return true;
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+__class__::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+__class__::endStream() {
 }
 
 // ------------ method called when starting to processes a run  ------------

--- a/FWCore/Skeletons/scripts/mkTemplates/EDFilter/EDFilter.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDFilter/EDFilter.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -33,7 +33,7 @@
 // class declaration
 //
 
-class __class__ : public edm::EDFilter {
+class __class__ : public edm::stream::EDFilter<> {
    public:
       explicit __class__(const edm::ParameterSet&);
       ~__class__();
@@ -41,9 +41,7 @@ class __class__ : public edm::EDFilter {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
       virtual bool filter(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
       
       //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
@@ -74,7 +72,7 @@ __class__::__class__(const edm::ParameterSet& iConfig)
 __class__::~__class__()
 {
  
-   // do anything here that needs to be done at desctruction time
+   // do anything here that needs to be done at destruction time
    // (e.g. close files, deallocate resources etc.)
 
 }
@@ -99,17 +97,6 @@ __class__::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
    iSetup.get<SetupRecord>().get(pSetup);
 #endif
    return true;
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-__class__::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-__class__::endJob() {
 }
 
 // ------------ method called when starting to processes a run  ------------

--- a/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
@@ -28,6 +28,7 @@
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/StreamID.h"
 
 @example_myparticle #include "DataFormats/MuonReco/interface/Muon.h"
 @example_myparticle #include "DataFormats/EgammaCandidates/interface/PixelMatchGsfElectron.h"
@@ -47,8 +48,10 @@ class __class__ : public edm::stream::EDProducer<> {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
+      virtual void beginStream(edm::StreamID) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      
+      virtual void endStream() override;
+
       //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void beginLuminosityBlock(edm::LuminosityBlock const&, edm::EventSetup const&) override;
@@ -169,6 +172,17 @@ __class__::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 @example_myparticle    
 @example_myparticle    // save the vector
 @example_myparticle    iEvent.put( move(newParticles), "particles" );
+}
+
+// ------------ method called once each stream before processing any runs, lumis or events  ------------
+void
+__class__::beginStream(edm::StreamID)
+{
+}
+
+// ------------ method called once each stream after processing all runs, lumis and events  ------------
+void
+__class__::endStream() {
 }
 
 // ------------ method called when starting to processes a run  ------------

--- a/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
+++ b/FWCore/Skeletons/scripts/mkTemplates/EDProducer/EDProducer.cc
@@ -22,7 +22,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -39,7 +39,7 @@
 // class declaration
 //
 
-class __class__ : public edm::EDProducer {
+class __class__ : public edm::stream::EDProducer<> {
    public:
       explicit __class__(const edm::ParameterSet&);
       ~__class__();
@@ -47,9 +47,7 @@ class __class__ : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override;
       
       //virtual void beginRun(edm::Run const&, edm::EventSetup const&) override;
       //virtual void endRun(edm::Run const&, edm::EventSetup const&) override;
@@ -99,7 +97,7 @@ __class__::__class__(const edm::ParameterSet& iConfig)
 __class__::~__class__()
 {
  
-   // do anything here that needs to be done at desctruction time
+   // do anything here that needs to be done at destruction time
    // (e.g. close files, deallocate resources etc.)
 
 }
@@ -171,17 +169,6 @@ __class__::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 @example_myparticle    
 @example_myparticle    // save the vector
 @example_myparticle    iEvent.put( move(newParticles), "particles" );
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-__class__::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-__class__::endJob() {
 }
 
 // ------------ method called when starting to processes a run  ------------


### PR DESCRIPTION
Modify the skeleton module generator mkedanlzr
to make a "one" type EDAnalyzer declaring a
shared resource of the TFileService. Modify
mkedfltr and mkedprod to generate a "stream"
type EDFilter or EDProducer. Previously these
generated "legacy" type modules.
