### PR TITLE
Remove PoolDBESSource for QGL from cfi file and update Global Tags for RelVals

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_75_V2',
+    'run1_design'       :   '75X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_75_V2',
+    'run1_mc'           :   '75X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_75_V2',
+    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_75_V2',
+    'run1_mc_pa'        :   '75X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_75_V2',
+    'run2_design'       :   '75X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_75_V4',
+    'run2_mc_50ns'      :   '75X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_75_V5',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   'MCHI2_75_V2',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_75_V4A',
+    'run1_data'         :   '75X_dataRun1_v2',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_75_V5A',
-    # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V61A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
-    # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V62A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run2_data'         :   '75X_dataRun2_v2',
+    # GlobalTag for Run1 HLT: it points to the online GT
+    'run1_hlt'          :   '75X_dataRun1_HLT_v1',
+    # GlobalTag for Run2 HLT: it points to the online GT
+    'run2_hlt'          :   '75X_dataRun2_HLT_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019

--- a/RecoJets/JetProducers/python/QGTagger_cfi.py
+++ b/RecoJets/JetProducers/python/QGTagger_cfi.py
@@ -1,22 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-# See https://twiki.cern.ch/twiki/bin/viewauth/CMS/QGDataBaseVersion
-qgDatabaseVersion = 'v1'
-
-from CondCore.DBCommon.CondDBSetup_cfi import *
-QGPoolDBESSource = cms.ESSource("PoolDBESSource",
-      CondDBSetup,
-      toGet = cms.VPSet(),
-      connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000'),
-)
-
-for type in ['AK4PF','AK4PFchs','AK4PF_antib','AK4PFchs_antib']:
-  QGPoolDBESSource.toGet.extend(cms.VPSet(cms.PSet(
-    record = cms.string('QGLikelihoodRcd'),
-    tag    = cms.string('QGLikelihoodObject_'+qgDatabaseVersion+'_'+type),
-    label  = cms.untracked.string('QGL_'+type)
-  )))
-
 QGTagger = cms.EDProducer('QGTagger',
   srcJets		= cms.InputTag('ak4PFJetsCHS'),
   jetsLabel		= cms.string('QGL_AK4PFchs'),


### PR DESCRIPTION
Removing the PoolDBESSource from the QGTagger_cfi file (originally in #9412).
## Changes in Global Tags:
- Run1 ideal simulation:  as DESRUN1_75_V2 ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/DESRUN1_75_V2/75X_mcRun1_design_v1)) with:
  - addition of HCAL geometry parameters for Run1; 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release); 
  - updated ECAL dead channels to be all with status 0, i.e. OK.
- Run1 realistic simulation: as MCRUN1_75_V2 ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/MCRUN1_75_V2/75X_mcRun1_realistic_v1)) with:
  - addition of HCAL geometry parameters for Run1; 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release);  
- Run1 Heavy Ion Simulation: as MCHI1_75_V2  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/MCHI1_75_V2/75X_mcRun1_HeavyIon_v1)) with:
  - addition of HCAL geometry parameters for Run1; 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release);  
- Run1 proton lead Simulation: as MCPA1_75_V2  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/MCPA1_75_V2/75X_mcRun1_pA_v1)) with:
  - addition of HCAL geometry parameters for Run1; 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release);  
- Run2 design Simulation: as DESRUN2_75_V2 ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/DESRUN2_75_V2/75X_mcRun1_design_v1))  with:
  - addition of HCAL geometry parameters for Run2; 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release); 
  - updated L1T menu to the Collision 2015 version for Stage1; 
  - updated ECAL channel status with all channels having status = 0, i.e. OK.
- Run2 startup simulation: as MCRUN2_75_V4  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/MCRUN2_75_V4/75X_mcRun2_startup_v1)) with: 
  - addition of HCAL geometry parameters for Run1 (Run2 is supposed to be identical); 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release); 
  - updated L1T menu to the Collision 2015 version for GCT at 50 ns; 
  - updated L1T GCT Jet seed threshold for 50 ns run;  
  - updated ECAL channel status with values measured in first collisions.
- Run2 asymptotic simulation: as MCRUN2_75_V5  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/MCRUN2_75_V5/75X_mcRun2_asymptotic_v1)) with: 
  - addition of HCAL geometry parameters for Run1 (Run2 is supposed to be identical); 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release); 
  - updated L1T menu to the Collision 2015 version for Stage1 at 25 ns;  
  - updated ECAL channel status with values measured in first collisions.
- Run2 Heavy Ion simulation: as MCHI2_75_V2  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/MCHI2_75_V2/75X_mcRun2_HeavyIon_v1)) with: 
  - addition of HCAL geometry parameters for Run1 (Run2 is supposed to be identical); 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release); 
  - updated L1T menu to the Collision 2015 version for Stage1 at 25 ns; 
  - updated ECAL channel status with values measured in first collisions.
- Run1 Data processing: as GR_R_75_V4  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/GR_R_75_V4/75X_dataRun1_v2)) with: 
  - addition of HCAL geometry parameters with two IOVs for Run1 and Run2 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release) 
  - updated correction for FED test pulse path length in the last IOV for the DT t0 calibration 
  - updated Tracker Geometry Parameters with two IOVs for Run1 and Run2.
- Run1 HLT processing: as GR_H_V61  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/GR_H_V61/75X_dataRun1_HLT_v1)) with 
  - introducing unique tag with Run-1 history and Run-2 conditions for EcalClusterLocalContCorrParametersRcd
  - updated Tracker Geometry Parameters with two IOVs for Run1 and Run2.
- Run2 Data processing: as GR_R_75_V5  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/GR_R_75_V5/75X_dataRun2_v2)) with: 
  - addition of HCAL geometry parameters with two IOVs for Run1 and Run2 
  - addition of QG likelihood payloads with 4 labels (removed the ESPrefer from release) 
  - updated correction for FED test pulse path length in the last IOV for the DT t0 calibration 
  - updated Tracker Geometry Parameters with two IOVs for Run1 and Run2.
- Run2 HLT processing: as GR_H_V62  ([browser](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/GR_H_V62/75X_dataRun2_HLT_v1)) with 
  - introducing unique tag with Run-1 history and Run-2 conditions for EcalClusterLocalContCorrParametersRcd
  - updated Tracker Geometry Parameters with two IOVs for Run1 and Run2.
