### PR TITLE
Update TrackingParticleFactory::vectorIsInsideVolume(...) function for SLHC version

### DIFF
--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -666,7 +666,7 @@ namespace // Unnamed namespace for things only used in this file
 
 	bool ::TrackingParticleFactory::vectorIsInsideVolume( const math::XYZTLorentzVectorD& vector ) const
 	{
-		return ( vector.Pt()<volumeRadius_ && vector.z()<volumeZ_ );
+		return ( vector.Pt()<volumeRadius_ && std::abs( vector.z() )<volumeZ_ );
 	}
 
 	//---------------------------------------------------------------------------------


### PR DESCRIPTION
The check of vertex z position should be using the absolute value
