### PR TITLE
Update TrackingParticleFactory::vectorIsInsideVolume(...) function in TrackingTruthAccumulator

### DIFF
--- a/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
+++ b/SimGeneral/TrackingAnalysis/plugins/TrackingTruthAccumulator.cc
@@ -666,7 +666,7 @@ namespace // Unnamed namespace for things only used in this file
 
 	bool ::TrackingParticleFactory::vectorIsInsideVolume( const math::XYZTLorentzVectorD& vector ) const
 	{
-		return ( vector.Pt()<volumeRadius_ && vector.z()<volumeZ_ );
+		return ( vector.Pt()<volumeRadius_ && std::abs( vector.z() )<volumeZ_ );
 	}
 
 	//---------------------------------------------------------------------------------


### PR DESCRIPTION
In the function, the check of vertex z position should be using the absolute value.

I suspect this is an accidental bug. It should not affect anyone who uses official samples, and it should not affect any validation plots because the default in [trackingTruthProducer_cfi.py](https://github.com/cms-sw/cmssw/blob/CMSSW_6_2_SLHCDEV_X/SimGeneral/MixingModule/python/trackingTruthProducer_cfi.py) has

```
    ignoreTracksOutsideVolume = cms.bool(False)
```

When the switch is false, the check of vertex position is not done. It only matters when a person decides to switch it on to get **only** the tracking particles and tracking vertices **inside the tracker**, as specified by the parameters

```
    volumeRadius = cms.double(120.0),
    volumeZ = cms.double(300.0),
```

However, as it is, the cut on vertex z is applied as a single-sided cut, rather than as a double-sided cut. I believe the expected behavior should be the latter, but I guess it's really up to the experts to decide.

This was first discussed on the pull request #9680 . As suggested by @mark-grimes, this is a duplicated pull request, but instead for the CMSSW_6_2_X_SLHC release.
