### PR TITLE
Bug fix. Fix moduleDescription function

### DIFF
--- a/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
+++ b/FWCore/Framework/interface/stream/EDAnalyzerAdaptorBase.h
@@ -78,6 +78,7 @@ namespace edm {
       template<typename T> void createStreamModules(T iFunc) {
         for(auto& m: m_streamModules) {
           m = iFunc();
+          setModuleDescriptionPtr(m);
         }
       }
       
@@ -158,6 +159,7 @@ namespace edm {
                                          ThinnedAssociationsHelper&) { }
 
       // ---------- member data --------------------------------
+      void setModuleDescriptionPtr(EDAnalyzerBase* m);
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }

--- a/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
+++ b/FWCore/Framework/src/stream/EDAnalyzerAdaptorBase.cc
@@ -233,3 +233,8 @@ EDAnalyzerAdaptorBase::doPostForkReacquireResources(unsigned int iChildIndex, un
     mod->postForkReacquireResources(iChildIndex,iNumberOfChildren);
   }
 }
+
+void
+EDAnalyzerAdaptorBase::setModuleDescriptionPtr(EDAnalyzerBase* m) {
+  m->setModuleDescriptionPtr(&moduleDescription_);
+}

--- a/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
+++ b/FWCore/Framework/test/stubs/TestStreamAnalyzers.cc
@@ -19,10 +19,10 @@ for testing purposes only.
 #include "FWCore/Utilities/interface/GlobalIdentifier.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/Utilities/interface/EDMException.h"
-
-
 
 namespace edmtest {
 namespace stream {
@@ -97,6 +97,10 @@ struct Cache {
     }
     
     void analyze(edm::Event const&, edm::EventSetup const&) override {
+      if(moduleDescription().processName() != edm::Service<edm::service::TriggerNamesService>()->getProcessName()) {
+        throw cms::Exception("LogicError")
+          << "module description not properly initialized in stream analyzer";
+      }
       ++m_count;
       ++(runCache()->value);
        


### PR DESCRIPTION
Fix the moduleDescription function in stream
EDAnalyzers.  Apparently nothing ever called this
because no one reported the problem. If called
it causes a seg fault.  A necessary pointer
was not being initialized that points from
the stream module instance to the adaptor that
manages the stream instances. Also added something
to a unit test that exercises this function.

This bug fix is needed for the new
getProcessParameterSetContainingModule
function to work for stream analyzers,
which is needed to fix a different SubProcess
bug. I noticed this while testing the SubProcess
bug fix.
