### PR TITLE
Fix an uninitialized value in JetDeltaRValueMapProducer

### DIFF
--- a/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
@@ -42,7 +42,8 @@ public:
       value_( params.existsAs<std::string>("value") ? params.getParameter<std::string>("value") : "" ),
       values_( params.existsAs<std::vector<std::string> >("values") ? params.getParameter<std::vector<std::string> >("values") : std::vector<std::string>() ),
       valueLabels_( params.existsAs<std::vector<std::string> >("valueLabels") ? params.getParameter<std::vector<std::string> >("valueLabels") : std::vector<std::string>() ),
-      lazyParser_( params.existsAs<bool>("lazyParser") ? params.getParameter<bool>("lazyParser") : false )
+      lazyParser_( params.existsAs<bool>("lazyParser") ? params.getParameter<bool>("lazyParser") : false ),
+      multiValue_(false)
   {
     if( value_!="" )
     {


### PR DESCRIPTION
A member data was only set conditionally. This problem was found
by valgrind when running over the Tier0 job which intermittently has
memory problems.
