### PR TITLE
Fixed uninitialized values used by HcalNoiseAlgo

### DIFF
--- a/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
@@ -5,6 +5,9 @@ CommonHcalNoiseRBXData::CommonHcalNoiseRBXData(const reco::HcalNoiseRBX& rbx, do
    std::vector<std::pair<double, double> > &TS4TS5UpperCut,
    std::vector<std::pair<double, double> > &TS4TS5LowerCut,
    double minRBXRechitR45E)
+  :r45Count_(0)
+  ,r45Fraction_(0)
+  ,r45EnergyFraction_(0)
 {
   // energy
   energy_ = rbx.recHitEnergy(minRecHitE); 


### PR DESCRIPTION
The class CommonHcalNoiseRBXData used by HcalNoiseAlgo contained
three member data which were only conditionally set. The problem
was found by valgrind.
