### PR TITLE
Fixed uninitialized value in L1TGMT

### DIFF
--- a/DQM/L1TMonitor/interface/L1TGMT.h
+++ b/DQM/L1TMonitor/interface/L1TGMT.h
@@ -52,12 +52,12 @@ virtual ~L1TGMT();
 
 protected:
 // Analyze
-  void analyze(const edm::Event& e, const edm::EventSetup& c);
+  void analyze(const edm::Event& e, const edm::EventSetup& c) override;
 
 // BeginJob
 
-  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&);
+  virtual void dqmBeginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventSetup&) override;
   virtual void bookHistograms(DQMStore::IBooker &ibooker, edm::Run const&, edm::EventSetup const&) override ;
 
 private:
@@ -103,14 +103,10 @@ private:
   
   MonitorElement* subs_dbx[4];  
 
-  int nev_; // Number of events processed
-  std::string outputFile_; //file name for ROOT ouput
-  bool verbose_;
-  bool monitorDaemon_;
+  const bool verbose_;
   std::ofstream logFile_;
-  edm::EDGetTokenT<L1MuGMTReadoutCollection> gmtSource_ ;
+  const edm::EDGetTokenT<L1MuGMTReadoutCollection> gmtSource_ ;
   
-  int evnum_old_; // event number of previous event
   int bxnum_old_; // bx of previous event
   int obnum_old_; // orbit of previous event
   int trsrc_old_; // code of trigger source ( bits: 0 DT, 1 bRPC, 2 CSC, 3 fRPC )

--- a/DQM/L1TMonitor/src/L1TGMT.cc
+++ b/DQM/L1TMonitor/src/L1TGMT.cc
@@ -21,23 +21,13 @@ using namespace edm;
 const double L1TGMT::piconv_ = 180. / acos(-1.);
 
 L1TGMT::L1TGMT(const ParameterSet& ps)
+  :   verbose_(ps.getUntrackedParameter<bool>("verbose", false))   // verbosity switch
+  , gmtSource_(consumes<L1MuGMTReadoutCollection>(ps.getParameter< InputTag >("gmtSource")))
+  , bxnum_old_(0)
+  , obnum_old_(0)
+  , trsrc_old_(0)
  {
-   gmtSource_ = consumes<L1MuGMTReadoutCollection>(ps.getParameter< InputTag >("gmtSource"));
-
-  // verbosity switch
-  verbose_ = ps.getUntrackedParameter<bool>("verbose", false);
-
   if(verbose_) cout << "L1TGMT: constructor...." << endl;
-
-  outputFile_ = ps.getUntrackedParameter<string>("outputFile", "");
-  if ( outputFile_.size() != 0 ) {
-    cout << "L1T Monitoring histograms will be saved to " << outputFile_.c_str() << endl;
-  }
-
-  bool disable = ps.getUntrackedParameter<bool>("disableROOToutput", false);
-  if(disable){
-    outputFile_="";
-  }
 }
 
 L1TGMT::~L1TGMT()
@@ -58,7 +48,6 @@ void L1TGMT::beginLuminosityBlock(const edm::LuminosityBlock&, const edm::EventS
 void L1TGMT::analyze(const Event& e, const EventSetup& c)
 {
   
-  nev_++; 
   if(verbose_) cout << "L1TGMT: analyze...." << endl;
 
 
@@ -120,7 +109,6 @@ void L1TGMT::analyze(const Event& e, const EventSetup& c)
     
     // get the absolute bx number of the L1A
     int Bx = RRItr->getBxNr();
-    int Ev = RRItr->getEvNr();
     
     bx_number->Fill(double(Bx));
  
@@ -231,7 +219,6 @@ void L1TGMT::analyze(const Event& e, const EventSetup& c)
     }
     
     // save quantities for the next event
-    evnum_old_ = Ev;
     bxnum_old_ = Bx;
     obnum_old_ = e.orbitNumber();
     trsrc_old_ = 0;


### PR DESCRIPTION
There were three member values which were not set. The problem was
found by valgrind.
Also removed unnecessary member variables and made some const.
