### PR TITLE
 consistently use momentum at POCA for PFDisplacedVertex momentum computations (same as  #9703  from 74X)

### DIFF
--- a/DataFormats/ParticleFlowReco/src/PFDisplacedVertex.cc
+++ b/DataFormats/ParticleFlowReco/src/PFDisplacedVertex.cc
@@ -146,7 +146,7 @@ PFDisplacedVertex::momentum(M_Hypo massHypo, VertexTrackType T, bool useRefitted
 
 	TrackBaseRef trackRef = originalTrack(refittedTracks()[i]);
 
-	double p2 = trackRef->innerMomentum().Mag2();
+	double p2 = trackRef->momentum().Mag2();
 	P += math::XYZTLorentzVector (trackRef->momentum().x(),
 				      trackRef->momentum().y(),
 				      trackRef->momentum().z(),


### PR DESCRIPTION
other than fixing a technical bug, it also allows to run (particleFlowDisplacedVertexCandidate+particleFlowDisplacedVertex) on AOD.

The difference in results is at numerical roundoff level (checked on ~1K events in ttbar with PU=35).
