### PR TITLE
Update calibration code to properly use TrackerTopology after PR 7966

### DIFF
--- a/CalibTracker/Records/interface/SiStripDependentRecords.h
+++ b/CalibTracker/Records/interface/SiStripDependentRecords.h
@@ -17,7 +17,7 @@ class SiStripDetCablingRcd : public edm::eventsetup::DependentRecordImplementati
   boost::mpl::vector<SiStripFedCablingRcd,TrackerTopologyRcd,IdealGeometryRecord> > {};
 
 class SiStripRegionCablingRcd : public edm::eventsetup::DependentRecordImplementation<SiStripRegionCablingRcd,
-  boost::mpl::vector<SiStripDetCablingRcd,TrackerDigiGeometryRecord,IdealGeometryRecord> > {};
+  boost::mpl::vector<SiStripDetCablingRcd,TrackerDigiGeometryRecord,TrackerTopologyRcd> > {};
 
 // class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainRcd, boost::mpl::vector<SiStripApvGainRcd> > {};
 class SiStripGainRcd : public edm::eventsetup::DependentRecordImplementation<SiStripGainRcd, boost::mpl::vector<SiStripApvGainRcd, SiStripApvGain2Rcd, SiStripApvGain3Rcd> > {};

--- a/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
+++ b/CalibTracker/SiStripESProducers/plugins/geom/SiStripRegionConnectivity.cc
@@ -6,6 +6,7 @@
 #include "CalibTracker/Records/interface/SiStripDetCablingRcd.h"
 #include "CalibFormats/SiStripObjects/interface/SiStripDetCabling.h"
 #include "DataFormats/SiStripCommon/interface/SiStripConstants.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 using namespace sistrip;
 
@@ -30,7 +31,7 @@ std::auto_ptr<SiStripRegionCabling> SiStripRegionConnectivity::produceRegionCabl
   iRecord.getRecord<TrackerDigiGeometryRecord>().get( tkgeom );
   
   edm::ESHandle<TrackerTopology> tTopoHandle;
-  iRecord.getRecord<IdealGeometryRecord>().get(tTopoHandle);
+  iRecord.getRecord<TrackerTopologyRcd>().get(tTopoHandle);
   const TrackerTopology* const tTopo = tTopoHandle.product();
 
   //here build an object of type SiStripRegionCabling using the information from class SiStripDetCabling **PLUS** the geometry.


### PR DESCRIPTION
Fix a crash due to the recent changes in Tracker paramenters read from DB and TrackerTopology, introduced by PR #7966 , that were not propagated in this calibration code.
