### PR TITLE
Made file access in SimHitPrinter thread safe

### DIFF
--- a/SimG4CMS/Muon/interface/SimHitPrinter.h
+++ b/SimG4CMS/Muon/interface/SimHitPrinter.h
@@ -18,6 +18,7 @@
 #include "DataFormats/GeometryVector/interface/LocalPoint.h"
 
 #include<fstream>
+#include <atomic>
 
 class SimHitPrinter {
 public:
@@ -34,7 +35,7 @@ public:
   void printLocal(LocalPoint,LocalPoint) const;
   void printGlobal(GlobalPoint) const;
 private:
-  static std::ofstream * theFile;
+  static std::atomic<std::ofstream*> theFile;
 };
 
 #endif


### PR DESCRIPTION
Since multiple instances of SimHitPrinter all share the same output
file via a static and those instances can be running on different
threads the file has to be protected by a mutex. In addition,
the creation of the file itself is done in a thread safe way.
