### PR TITLE
Bug fix so will compile -O0 -g

### DIFF
--- a/FastSimulation/Tracking/src/TrackingLayer.cc
+++ b/FastSimulation/Tracking/src/TrackingLayer.cc
@@ -1,6 +1,7 @@
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 
-     
+const TrackingLayer::eqfct TrackingLayer::_eqfct;
+
 TrackingLayer::TrackingLayer():
     _subDet(Det::UNKNOWN),
     _side(Side::BARREL),


### PR DESCRIPTION
Fix so that TrackingLayer will compile
with -O0 0g flags.
