### PR TITLE
Fed vector hf upgrade fix

### DIFF
--- a/DQM/L1TMonitor/interface/L1TdeRCT.h
+++ b/DQM/L1TMonitor/interface/L1TdeRCT.h
@@ -249,7 +249,7 @@ private:
 
 
   //begin fed vector information
-  static const int crateFED[90];
+  static const int crateFED[108];
   MonitorElement *fedVectorMonitorRUN_;
   MonitorElement *fedVectorMonitorLS_;
   ///////////////////////////////

--- a/DQM/L1TMonitor/src/L1TdeRCT.cc
+++ b/DQM/L1TMonitor/src/L1TdeRCT.cc
@@ -73,25 +73,25 @@ const float CHNLMIN = -0.5;
 const float CHNLMAX = 395.5;
 
 
-const int L1TdeRCT::crateFED[90]=
-    {613, 614, 603, 702, 1118,
-     611, 612, 602, 700, 1118,
-     627, 610, 601,716,  1122,
-     625, 626, 609, 714, 1122,
-     623, 624, 608, 712, 1122,
-     621, 622, 607, 710, 1120,
-     619, 620, 606, 708, 1120,
-     617, 618, 605, 706, 1120,
-     615, 616, 604, 704, 1118,
-     631, 632, 648, 703, 1118,
-     629, 630, 647, 701, 1118,
-     645, 628, 646, 717, 1122,
-     643, 644, 654, 715, 1122,
-     641, 642, 653, 713, 1122,
-     639, 640, 652, 711, 1120,
-     637, 638, 651, 709, 1120,
-     635, 636, 650, 707, 1120,
-     633, 634, 649, 705, 1118
+const int L1TdeRCT::crateFED[108]=
+    {613, 614, 603, 702,  718,1118,
+     611, 612, 602, 700, 718, 1118,
+     627, 610, 601,716,  722, 1122,
+     625, 626, 609, 714, 722, 1122,
+     623, 624, 608, 712, 722, 1122,
+     621, 622, 607, 710, 720, 1120,
+     619, 620, 606, 708, 720, 1120,
+     617, 618, 605, 706, 720, 1120,
+     615, 616, 604, 704, 718, 1118,
+     631, 632, 648, 703, 719, 1118,
+     629, 630, 647, 701, 719, 1118,
+     645, 628, 646, 717, 723, 1122,
+     643, 644, 654, 715, 723, 1122,
+     641, 642, 653, 713, 723, 1122,
+     639, 640, 652, 711, 721, 1120,
+     637, 638, 651, 709, 721, 1120,
+     635, 636, 650, 707, 721, 1120,
+     633, 634, 649, 705, 719, 1118
 };
 
 
@@ -1801,10 +1801,10 @@ void L1TdeRCT::bookHistograms(DQMStore::IBooker &ibooker, const edm::Run& run , 
 
 
   ibooker.setCurrentFolder(histFolder_+"/DBData");
-  fedVectorMonitorRUN_ = ibooker.book2D("rctFedVectorMonitorRUN", "FED Vector Monitor Per Run",90,0,90,2,0,2);
-  fedVectorMonitorLS_ = ibooker.book2D("rctFedVectorMonitorLS", "FED Vector Monitor Per LS",90,0,90,2,0,2);
+  fedVectorMonitorRUN_ = ibooker.book2D("rctFedVectorMonitorRUN", "FED Vector Monitor Per Run",108,0,108,2,0,2);
+  fedVectorMonitorLS_ = ibooker.book2D("rctFedVectorMonitorLS", "FED Vector Monitor Per LS",108,0,108,2,0,2);
 
-  for(unsigned int i=0;i<90;++i) {
+  for(unsigned int i=0;i<108;++i) {
     char fed[10];
     sprintf(fed,"%d",crateFED[i]);
     fedVectorMonitorRUN_->getTH2F()->GetXaxis()->SetBinLabel(i+1,fed);
@@ -1919,7 +1919,7 @@ void L1TdeRCT::readFEDVector(MonitorElement* histogram,const edm::EventSetup& es
       caloFeds.push_back(fedNum);
   }
   
-  for(unsigned int i=0;i<90;++i) {
+  for(unsigned int i=0;i<108;++i) {
     std::vector<int>::iterator fv = std::find(caloFeds.begin(),caloFeds.end(),crateFED[i]);
     if(fv!=caloFeds.end()) {
       histogram->setBinContent(i+1,2,1);

--- a/L1Trigger/RegionalCaloTrigger/interface/L1RCTProducer.h
+++ b/L1Trigger/RegionalCaloTrigger/interface/L1RCTProducer.h
@@ -88,12 +88,12 @@ class L1RCTProducer : public edm::EDProducer
     eeFed,
     hbheFed,
     hfFed,
-    c_max = hfFed
+    hfFedUp,
+    c_max = hfFedUp
   };
 
+  static const int crateFED[18][6];
 
-
-  static const int crateFED[18][5];
   static const int minBarrel = 1;
   static const int maxBarrel = 17;
   static const int minEndcap = 17;

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
@@ -13,27 +13,25 @@ using std::vector;
 
 using std::cout;
 using std::endl;
-const int L1RCTProducer::crateFED[18][5]=
-      {{613, 614, 603, 702, 1118},
-    {611, 612, 602, 700, 1118},
-    {627, 610, 601, 716, 1122},
-    {625, 626, 609, 714, 1122},
-    {623, 624, 608, 712, 1122},
-    {621, 622, 607, 710, 1120},
-    {619, 620, 606, 708, 1120},
-    {617, 618, 605, 706, 1120},
-    {615, 616, 604, 704, 1118},
-    {631, 632, 648, 703, 1118},
-    {629, 630, 647, 701, 1118},
-    {645, 628, 646, 717, 1122},
-    {643, 644, 654, 715, 1122},
-    {641, 642, 653, 713, 1122},
-    {639, 640, 652, 711, 1120},
-    {637, 638, 651, 709, 1120},
-    {635, 636, 650, 707, 1120},
-    {633, 634, 649, 705, 1118}};
-
-
+const int L1RCTProducer::crateFED[18][6]=
+    {{613, 614, 603, 702, 718, 1118},
+    {611, 612, 602, 700, 718, 1118},
+    {627, 610, 601, 716, 722, 1122},
+    {625, 626, 609, 714, 722, 1122},
+    {623, 624, 608, 712, 722, 1122},
+    {621, 622, 607, 710, 720, 1120},
+    {619, 620, 606, 708, 720, 1120},
+    {617, 618, 605, 706, 720, 1120},
+    {615, 616, 604, 704, 718, 1118},
+    {631, 632, 648, 703, 719, 1118},
+    {629, 630, 647, 701, 719, 1118},
+    {645, 628, 646, 717, 723, 1122},
+    {643, 644, 654, 715, 723, 1122},
+    {641, 642, 653, 713, 723, 1122},
+    {639, 640, 652, 711, 721, 1120},
+    {637, 638, 651, 709, 721, 1120},
+    {635, 636, 650, 707, 721, 1120},
+    {633, 634, 649, 705, 719, 1118}};
 
 L1RCTProducer::L1RCTProducer(const edm::ParameterSet& conf) : 
   rctLookupTables(new L1RCTLookupTables),
@@ -203,6 +201,7 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 	caloFeds.push_back(fedNum);
     }
 
+  // Try to 
   for(int  cr = 0; cr < 18; ++cr)
     {
       
@@ -210,12 +209,13 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 	{
 	  bool fedFound = false;
 	  
-	  
 	  //Try to find the FED
-	  std::vector<int>::iterator fv = std::find(caloFeds.begin(),caloFeds.end(),crateFED[cr][cs]);
+	  std::vector<int>::iterator fv= std::find(caloFeds.begin(),caloFeds.end(),crateFED[cr][cs]);
 	  if(fv!=caloFeds.end())
 	    fedFound = true;
-	  
+	 
+
+ 
 	  if(!fedFound) {
 	    int eta_min=0;
 	    int eta_max=0;
@@ -261,6 +261,17 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 	      phi_even[1] = true;
 	      ecal = false;
 	      break;
+
+          case hfFedUp:
+            eta_min = minHF;
+            eta_max = maxHF;
+
+            phi_even[0] = true;
+            phi_even[1] = true;
+            ecal = false;
+            break;
+
+
 	    default:
 	      break;
 	      

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
@@ -207,7 +207,6 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
   
     }
 
-  // Try to 
   for(int  cr = 0; cr < 18; ++cr)
     {
       

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
@@ -192,6 +192,8 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 //   std::cout << " FED vector" << std::endl;
 //   printFedVector(Feds);
 
+  bool useUpgradedHF=false;
+
   std::vector<int> caloFeds;  // pare down the feds to the interesting ones
   // is this unneccesary?
   // Mike B : This will decrease the find speed so better do it
@@ -200,6 +202,9 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
       int fedNum = *cf;
       if((fedNum > 600 && fedNum <724) || fedNum==1118 || fedNum == 1120 || fedNum == 1122) 
 	caloFeds.push_back(fedNum);
+
+      if(fedNum==1118 || fedNum == 1120 || fedNum == 1122) useUpgradedHF=true;
+  
     }
 
   // Try to 
@@ -255,6 +260,8 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 	      break;
 	      
 	    case hfFed:	
+            if(useUpgradedHF) break;
+
 	      eta_min = minHF;
 	      eta_max = maxHF;
 	      
@@ -264,6 +271,8 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 	      break;
 
           case hfFedUp:
+            if(!useUpgradedHF) break;
+
             eta_min = minHF;
             eta_max = maxHF;
 

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
@@ -260,7 +260,7 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 	      break;
 	      
 	    case hfFed:	
-            if(useUpgradedHF) break;
+	      if(useUpgradedHF) break;
 
 	      eta_min = minHF;
 	      eta_max = maxHF;
@@ -270,16 +270,16 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 	      ecal = false;
 	      break;
 
-          case hfFedUp:
-            if(!useUpgradedHF) break;
+	    case hfFedUp:
+	      if(!useUpgradedHF) break;
 
-            eta_min = minHF;
-            eta_max = maxHF;
+	      eta_min = minHF;
+	      eta_max = maxHF;
 
-            phi_even[0] = true;
-            phi_even[1] = true;
-            ecal = false;
-            break;
+	      phi_even[0] = true;
+	      phi_even[1] = true;
+	      ecal = false;
+	      break;
 
 
 	    default:

--- a/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
+++ b/L1Trigger/RegionalCaloTrigger/plugins/L1RCTProducer.cc
@@ -183,7 +183,8 @@ void L1RCTProducer::updateFedVector(const edm::EventSetup& eventSetup, bool getF
 
 //   // adding fed mask into channel mask
   
-  const std::vector<int> Feds = getFromOmds ? getFedVectorFromOmds(eventSetup) : getFedVectorFromRunInfo(eventSetup); // so can create/initialize/assign const quantity in one line accounting for if statement
+  const std::vector<int> Feds = getFromOmds ? getFedVectorFromOmds(eventSetup) : getFedVectorFromRunInfo(eventSetup); 
+  // so can create/initialize/assign const quantity in one line accounting for if statement
   // wikipedia says this is exactly what it's for: http://en.wikipedia.org/wiki/%3F:#C.2B.2B
 
 //   std::cout << "Contents of ";


### PR DESCRIPTION
Updates the RCT producer (&DQM for RCT) for backwards compatibility for changes in HF (it should work both on data and in MC). 
