### PR TITLE
double url for DQM gui upload of harvesting (75x)

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixInjector.py
+++ b/Configuration/PyReleaseValidation/python/MatrixInjector.py
@@ -62,7 +62,7 @@ class MatrixInjector(object):
                 self.DbsUrl = "https://"+self.wmagent+"/dbs/int/global/DBSReader"
 
         if not self.dqmgui:
-            self.dqmgui="https://cmsweb.cern.ch/dqm/relval"
+            self.dqmgui="https://cmsweb.cern.ch/dqm/relval;https://cmsweb-testbed.cern.ch/dqm/relval"
         #couch stuff
         self.couch = 'https://'+self.wmagent+'/couchdb'
 #        self.couchDB = 'reqmgr_config_cache'


### PR DESCRIPTION
- double url for DQM gui upload of harvesting; to test new gui in parallel to prod
- only affects submission of production relval wokflows; no impact on performance @vanbesien @rovere
  Automatically ported from CMSSW_7_5_X #9735 (original by @franzoni).
