### PR TITLE
the canonical type of std::atomic<T*> in template <T> edm::AtomicPtrC…

### DIFF
--- a/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
+++ b/Utilities/StaticAnalyzers/scripts/data-class-funcs.py
@@ -173,7 +173,6 @@ for dataclassfunc in sorted(dataclassfuncs):
 				exact= r"^" + re.escape(flaggedclass) + r"$"
 				exactmatch=re.match(exact,dataclass)
 				if exactmatch:
-				if re.match(flaggedclass,dataclass):
 					print "Flagged event setup data class '"+dataclass+"' is accessed in call stack '",
 					path = nx.shortest_path(G,tfunc,dataclassfunc)
 					for p in path:

--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -671,7 +671,7 @@ void ClassChecker::checkASTDecl(const clang::CXXRecordDecl *RD, clang::ento::Ana
                     WalkAST walker(this,BR, mgr.getAnalysisDeclContext(RD), (*(RD->ctor_begin()))->getMostRecentDecl() ) ;
                     std::string buf;
                     llvm::raw_string_ostream os(buf);
-                    os << "Mutable member '" <<t.getAsString()<<" "<<*D << "' in data class '"<<support::getQualifiedName(*RD)<<"', might be thread-unsafe when accessing via a const handle.";
+                    os << "Mutable member '" <<t.getCanonicalType().getAsString()<<" "<<*D << "' in data class '"<<support::getQualifiedName(*RD)<<"', might be thread-unsafe when accessing via a const handle.";
                     BR.EmitBasicReport(D, this, "Mutable member in data class",
                         "Data Class Const Correctness", os.str(), DLoc);
                     std::string pname = support::getQualifiedName(*(RD));

--- a/Utilities/StaticAnalyzers/src/CmsSupport.cpp
+++ b/Utilities/StaticAnalyzers/src/CmsSupport.cpp
@@ -112,8 +112,9 @@ std::string support::getQualifiedName(const clang::NamedDecl &d) {
 bool support::isSafeClassName(const std::string &cname) {
 
   static const std::vector<std::string> names = {
-    "std::atomic",
-    "struct std::atomic",
+    "atomic<",
+    "std::atomic<",
+    "struct std::atomic<",
     "std::__atomic_",
     "std::mutex",
     "std::recursive_mutex",

--- a/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/MutableMemberChecker.cpp
@@ -29,7 +29,7 @@ void MutableMemberChecker::checkASTDecl(const clang::FieldDecl *D,
 	    if ( ! support::isDataClass( D->getParent()->getQualifiedNameAsString() ) ) return;
 	    std::string buf;
 	    llvm::raw_string_ostream os(buf);
-	    os << "Mutable member'" <<t.getAsString()<<" "<<*D << "' in class '"<<D->getParent()->getQualifiedNameAsString()<<"', might be thread-unsafe when accessing via a const handle.";
+	    os << "Mutable member'" <<t.getCanonicalType().getAsString()<<" "<<*D << "' in class '"<<D->getParent()->getQualifiedNameAsString()<<"', might be thread-unsafe when accessing via a const handle.";
 	    BR.EmitBasicReport(D, this, "mutable member",
 	    					"ThreadSafety", os.str(), DLoc);
 	    return;


### PR DESCRIPTION
…ache is atomic<parameter-type-0-0 *>
Automatically ported from CMSSW_7_5_X #9726 (original by @gartung).
