### PR TITLE
Made static EcalSrFlag::srfNames fully const

### DIFF
--- a/DataFormats/EcalDigi/interface/EcalSrFlag.h
+++ b/DataFormats/EcalDigi/interface/EcalSrFlag.h
@@ -78,7 +78,7 @@ protected:
 private:
   /** Human readable flag value names
    */
-  static const char* srfNames[];
+  static const char* const srfNames[];
 };
   
 #endif //ECALSRFLAG not defined

--- a/DataFormats/EcalDigi/src/EcalSrFlag.cc
+++ b/DataFormats/EcalDigi/src/EcalSrFlag.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/EcalDigi/interface/EcalSrFlag.h"
 
-const char* EcalSrFlag::srfNames[] = {
+const char* const EcalSrFlag::srfNames[] = {
   "Suppress",           //SRF_SUPPRESS
   "Zs1",                //SRF_ZS1
   "Zs2",                //SRF_ZS2


### PR DESCRIPTION
Although it never changed, the static pointer EcalSrFlag::srfNames
was non-const. This lead to complaints from the static analyzer.
Automatically ported from CMSSW_7_5_X #9722 (original by @Dr15Jones).
