### PR TITLE
Fix and update of pede param plotting macros

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/macros/GFUtils/GFHistManager.C
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/GFUtils/GFHistManager.C
@@ -33,8 +33,8 @@
 
 ClassImp(GFHistManager)
 
-const Int_t GFHistManager::kDefaultPadsPerCanX = 4;
-const Int_t GFHistManager::kDefaultPadsPerCanY = 3;
+const Int_t GFHistManager::kDefaultPadsPerCanX = 1;
+const Int_t GFHistManager::kDefaultPadsPerCanY = 1;
 const Int_t GFHistManager::kDefaultDepth = 0;
 TString GFHistManager::fgLegendEntryOption = "l";
 
@@ -50,6 +50,7 @@ GFHistManager::GFHistManager()
   fLegendY2 = 0.99;
   fLegendX2 = 0.99;
   fStatsX1 = 0.72, fStatsX2 = 0.995, fStatsY1 = .8, fStatsY2 = .995;
+  fCanvasName = "canvas";
   fCanvasWidth = 600;
   fCanvasHeight = 600;
 }
@@ -68,6 +69,7 @@ GFHistManager::GFHistManager(TH1* hist)
   fLegendY2 = 0.99;
   fLegendX2 = 0.99;
   fStatsX1 = 0.72, fStatsX2 = 0.995, fStatsY1 = .8, fStatsY2 = .995;
+  fCanvasName = "canvas";
   fCanvasWidth = 600;
   fCanvasHeight = 600;
 }
@@ -86,6 +88,7 @@ GFHistManager::GFHistManager(TCollection* hists)
   fLegendY2 = 0.99;
   fLegendX2 = 0.99;
   fStatsX1 = 0.72, fStatsX2 = 0.995, fStatsY1 = .8, fStatsY2 = .995;
+  fCanvasName = "canvas";
   fCanvasWidth = 600;
   fCanvasHeight = 600;
 }
@@ -306,6 +309,8 @@ void GFHistManager::DrawReally(Int_t layer)
 	histNo++;
       }
     } // loop over pads
+    const TString name = can->GetTitle();
+    can->SaveAs(name+".pdf");
   } // loop over canvases
 }
 
@@ -528,6 +533,8 @@ TLegendEntry* GFHistManager::AddHist(TH1* hist, Int_t layer, const char* legendT
 #if ROOT_VERSION_CODE < ROOT_VERSION(5,6,0)
     if (TString(gStyle->GetName()) == "Plain") legend->SetBorderSize(1);
 #endif
+    legend->SetTextFont(42);
+    legend->SetFillColor(kWhite);
     legends->AddAtAndExpand(legend, layerHistArrays->IndexOf(newHist));
     return legend->AddEntry(hist, legendTitle, legOpt ? legOpt : fgLegendEntryOption.Data());
   }
@@ -577,6 +584,7 @@ TLegendEntry* GFHistManager::AddHistSame(TH1* hist, Int_t layer, Int_t histNum,
 	if (TString(gStyle->GetName()) == "Plain") legend->SetBorderSize(1);
 #endif
 	legends->AddAtAndExpand(legend, histNum);
+	legend->SetFillColor(kWhite);
       }
       result = legend->AddEntry(hist,legendTitle, legOpt ? legOpt : fgLegendEntryOption.Data());
     }
@@ -678,6 +686,7 @@ TLegend* GFHistManager::AddLegend(Int_t layer, Int_t histoNum,
 #if ROOT_VERSION_CODE < ROOT_VERSION(5,6,0)
     if (TString(gStyle->GetName()) == "Plain") legend->SetBorderSize(1);
 #endif
+    legend->SetFillColor(kWhite);
     legendsOfLayer->AddAtAndExpand(legend, histoNum);
   }
 
@@ -845,7 +854,7 @@ void GFHistManager::MakeCanvases(Int_t layer)
     fCanArrays->AddAtAndExpand(new TObjArray, layer);
   }
 
-  TString canName("canvas");
+  TString canName(fCanvasName);
   (canName += layer) += "_";
 
   for(Long_t i = 0; i < nCanvases; i++){
@@ -1377,6 +1386,7 @@ void GFHistManager::MakeDifferentStyle(GFHistArray* hists)
     }
     hists->At(i)->SetLineColor(color);
     hists->At(i)->SetMarkerColor(color);
+    hists->At(i)->SetMarkerSize(0.02);
     hists->At(i)->SetLineStyle(style);
   }
 }
@@ -1597,4 +1607,9 @@ void GFHistManager::ColourFuncs(GFHistArray *hists) const
       func->SetLineStyle(h->GetLineStyle());
     }
   } 
+}
+
+//________________________________________________________
+void GFHistManager::SetCanvasName(const TString& name) {
+  fCanvasName = name;
 }

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/GFUtils/GFHistManager.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/GFUtils/GFHistManager.h
@@ -65,6 +65,7 @@ public:
   virtual void SetNumHistsXY(UInt_t numX, UInt_t numY, Int_t layer);
   virtual void SetLogY(Bool_t yesNo = kTRUE);
   virtual void SetLogY(Int_t layer, Bool_t yesNo = kTRUE);
+  void SetCanvasName(const TString& name);
   virtual void SetCanvasWidth(Int_t w) {fCanvasWidth = w;}
   virtual void SetCanvasHeight(Int_t h) {fCanvasHeight = h;}
   virtual void SetHistsOption(Option_t* option);
@@ -150,6 +151,7 @@ private:
   Double_t     fStatsX2;       // ...of first statsbox in case
   Double_t     fStatsY1;       // ... many have to be drawn
   Double_t     fStatsY2;       // ... (subsequent boxes are shifted)
+  TString      fCanvasName;
   Int_t        fCanvasWidth;   // pixel width
   Int_t        fCanvasHeight;  //       height of canvases (maybe relativly manipulated...) 
   static TString fgLegendEntryOption; // option used for legend entry style

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePede.C
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePede.C
@@ -2010,3 +2010,8 @@ void PlotMillePede::CopyAddBinning(TString &name, const TH1 *h) const
 
   name += ')';
 }
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+void PlotMillePede::SetOutName(const TString& name) {
+  fHistManager->SetCanvasName(name);
+}

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePede.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePede.h
@@ -230,6 +230,8 @@ class PlotMillePede : public MillePedeTrees
   TString AlignableObjIdString(Int_t objId) const;
 
   void CopyAddBinning(TString &name, const TH1 *hist) const;// extend 'name' taking binning from hist
+  void SetOutName(const TString& name);
+
  private: 
   Int_t PrepareAdd(bool addPlots);
 

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePedeIOV.C
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePedeIOV.C
@@ -23,7 +23,7 @@
 
 PlotMillePedeIOV::PlotMillePedeIOV(const char *fileName, Int_t maxIov,
 				   Int_t hieraLevel)
-  : fHistManager(new GFHistManager)
+  : fHistManager(new GFHistManager), fTitle("")
 {
   if (maxIov <= 0) { // find maximum IOV in file if not specified
     maxIov = 0;
@@ -153,6 +153,9 @@ void PlotMillePedeIOV::DrawPedeParam(Option_t *option, unsigned int nNonRigidPar
       const TString errPar(Form("#sigma(%s)", i0->NamePede(iMulti).Data()));
       h->SetTitle(errPar + " IOVs" += i0->TitleAdd() += ";IOV;"
 		  + errPar + i0->UnitPede(iMulti));
+    } else if (fTitle != "" ) {
+      h->SetTitle(i0->NamePede(iMulti) + " IOVs" + i0->TitleAdd() + ", " + fTitle + ";IOV;"
+		  + i0->NamePede(iMulti) += i0->UnitPede(iMulti));
     } else {     // 'usual' title for drawing parameter values
       h->SetTitle((i0->NamePede(iMulti) += " IOVs") += i0->TitleAdd() += ";IOV;"
 		  + i0->NamePede(iMulti) += i0->UnitPede(iMulti));
@@ -162,6 +165,9 @@ void PlotMillePedeIOV::DrawPedeParam(Option_t *option, unsigned int nNonRigidPar
     // Create legend refering to graphs and add to manager:  
     Double_t x1, x2, y1, y2; fHistManager->GetLegendX1Y1X2Y2(x1, y1, x2, y2);
     TLegend *legend = new TLegend(x1, y1, x2, y2);
+    legend->SetFillColor(kWhite);
+    legend->SetTextFont(42);
+    legend->SetBorderSize(1);
     fHistManager->AddLegend(legend, layer, iMulti);
     Int_t nGr = 0;
     while (TGraph* graph = static_cast<TGraph*>(iter.Next())){

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePedeIOV.h
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/PlotMillePedeIOV.h
@@ -56,8 +56,8 @@ class PlotMillePedeIOV
 
   void DrawPedeParam(Option_t *option = "", unsigned int nNonRigidParam = 0);// "add", any of "x","y","z","id" to add position or DetId in legend, "err" error (not value), "val" skip error bar even if valid 
 
-  //  void SetTitle(const char *title) {fTitle = title;}
-  //  const TString& GetTitle() const { return fTitle;}
+  void SetTitle(const char *title) {fTitle = title;}
+  const TString& GetTitle() const { return fTitle;}
   GFHistManager* GetHistManager() { return fHistManager;}
   PlotMillePede* GetPlotMillePede(unsigned int i) { return (i < fIovs.size() ? fIovs[i] : 0);}
 
@@ -75,7 +75,6 @@ class PlotMillePedeIOV
   void AddAdditionalSel(const TString &xyzrPhiNhit, Float_t min, Float_t max); // min <= x,y,z,r,phi,Nhit < max
   void ClearAdditionalSel();
 
- private:
   struct ParId {
     //parameter identified by id (=DetId), objId (=hieraLevel), parameter
   public:
@@ -87,9 +86,10 @@ class PlotMillePedeIOV
   };
   // end struct ParId
 
+ private:
   GFHistManager *fHistManager;
   std::vector<PlotMillePede*> fIovs;
-
+  TString fTitle;
 };
 
 #endif

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/createPedeParamIOVPlots.C
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/createPedeParamIOVPlots.C
@@ -1,0 +1,53 @@
+// Plot IOV-dependent parameters
+//
+//
+// Execute as (in an interactive ROOT session):
+//
+//  > .L createPedeParamIOVPlots.C
+//  > compile()
+//  > .L createPedeParamIOVPlots.C
+
+
+#include "TString.h"
+#include "TROOT.h"
+
+#include "GFUtils/GFHistManager.h"
+#include "PlotMillePedeIOV.h"
+
+
+void compile() {
+  gROOT->ProcessLine(".L allMillePede.C");
+  gROOT->ProcessLine("allMillePede()");
+  gROOT->ProcessLine(".L setGStyle.C");
+  gROOT->ProcessLine("setGStyle()");
+}
+
+void createPedeParamIOVPlots(const TString& treeFile1, const TString& title1, const TString& treeFile2="", const TString& title2="") {
+  const int subDetIds[6]       = { 1,      2,      3,     4,     5,     6     };
+  const TString subDetNames[6] = { "BPIX", "FPIX", "TIB", "TID", "TOB", "TEC" };
+  const TString coords[6]      = { "x",    "xz",   "z",   "z",   "z",   "z"   }; // printed in legend
+
+  const bool has2 = treeFile2.Length()>0;
+
+  TString outNamePrefix1(title1);
+  outNamePrefix1.ReplaceAll(" ","_");
+  TString outNamePrefix2(title2);
+  outNamePrefix2.ReplaceAll(" ","_");
+
+  PlotMillePedeIOV iov(treeFile1,-1,1); // large-scale hierarchy level
+  iov.SetTitle(title1);
+  for(int i = 0; i < 6; ++i) {
+    iov.SetSubDetId(subDetIds[i]);
+    iov.GetHistManager()->SetCanvasName(outNamePrefix1+"_PedeParamIOV_"+subDetNames[i]+"_");
+    iov.DrawPedeParam(coords[i]);
+  }
+  if( has2 ) {
+    PlotMillePedeIOV iov2(treeFile2,-1,1); // large-scale hierarchy level
+    iov2.SetTitle(title2);
+    for(int i = 0; i < 6; ++i) {
+      iov2.SetSubDetId(subDetIds[i]);
+      iov2.GetHistManager()->SetCanvasName(outNamePrefix2+"_PedeParamIOV_"+subDetNames[i]+"_");
+      iov2.DrawPedeParam(coords[i]);
+    }
+  }
+}

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/createPedeParamPlots.C
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/createPedeParamPlots.C
@@ -1,0 +1,88 @@
+// Plot distributions of module-level parameters
+//
+// Execute as (in an interactive ROOT session):
+//
+//  > .L createPedeParamPlots.C
+//  > compile()
+//  > createPedeParamPlots("<path-to-treeFile_merge.root","<label>")
+//
+//
+//
+// NB: Currently, the treeFile-writing assumes the 5th  column in millepede.res
+//     to be the parameter uncertainties (as it is the case when running pede in
+//     inversion mode) and puts those values in the tree. If pede is not run in
+//     inversion mode, the 5th column might be sth else and thus the plotted errors
+//     do not make sense. --> Ignore all plots other than <name>_0_<det>.pdf in that
+//     case!
+
+#include "TString.h"
+#include "TROOT.h"
+
+#include "GFUtils/GFHistManager.h"
+#include "PlotMillePede.h"
+
+
+void compile() {
+  gROOT->ProcessLine(".L allMillePede.C");
+  gROOT->ProcessLine("allMillePede()");
+  gROOT->ProcessLine(".L setGStyle.C");
+  gROOT->ProcessLine("setGStyle()");
+}
+
+void createPedeParamPlots(const TString& treeFile1, const TString& title1, const TString& treeFile2="", const TString& title2="") {
+
+  const int subDetIds[6]       = { 1,      2,      3,     4,     5,     6     };
+  const TString subDetNames[6] = { "BPIX", "FPIX", "TIB", "TID", "TOB", "TEC" };
+  const TString coords[6]      = { "x",    "xz",   "z",   "z",   "z",   "z"   }; // printed in legend
+
+  const bool has2 = treeFile2.Length()>0;
+
+  TString outNamePrefix1(title1);
+  outNamePrefix1.ReplaceAll(" ","_");
+  TString outNamePrefix2(title2);
+  outNamePrefix2.ReplaceAll(" ","_");
+  
+   PlotMillePede* p1 = new PlotMillePede(treeFile1);
+   if( !has2 ) p1->SetTitle(title1);
+   p1->SetBowsParameters(true);
+   p1->SetHieraLevel(0);		// lowest level
+
+   PlotMillePede* p2 = NULL;
+   if( has2 ) {
+     p2 = new PlotMillePede(treeFile2);
+     p2->SetTitle(title2);
+     p2->SetBowsParameters(true);
+     p2->SetHieraLevel(0);		// lowest level
+   }
+
+   for(int i = 0; i < 6; ++i) {
+     p1->SetSubDetId(subDetIds[i]);
+     p1->SetOutName(outNamePrefix1+"_PedeParam_"+subDetNames[i]+"_");
+     p1->DrawPedeParam();
+
+     if( has2 ) {
+       p2->SetSubDetId(subDetIds[i]);
+       p2->SetOutName(outNamePrefix2+"_PedeParam_"+subDetNames[i]+"_");
+       p2->DrawPedeParam();
+     }
+
+     if( has2 ) {
+       p1->SetOutName(outNamePrefix1+"-"+outNamePrefix2+"_PedeParam_"+subDetNames[i]+"_");
+       p1->GetHistManager()->Overlay(p1->GetHistManager(),0,0,title1);
+       p1->GetHistManager()->Overlay(p2->GetHistManager(),0,0,p2->GetTitle());
+       p1->GetHistManager()->Draw();
+       p1->GetHistManager()->SameWithStats(true);
+       p1->GetHistManager()->Draw();
+     }
+   }
+
+   // do the first plots again to have the correct title
+   if( has2 ) {
+     p1->SetTitle(title1);
+     for(int i = 0; i < 6; ++i) {
+       p1->SetSubDetId(subDetIds[i]);
+       p1->SetOutName(outNamePrefix1+"_PedeParam_"+subDetNames[i]+"_");
+       p1->DrawPedeParam();
+     }
+   }
+}

--- a/Alignment/MillePedeAlignmentAlgorithm/macros/setGStyle.C
+++ b/Alignment/MillePedeAlignmentAlgorithm/macros/setGStyle.C
@@ -1,0 +1,101 @@
+#include "TStyle.h"
+
+void setGStyle() {
+  // Zero horizontal error bars
+  gStyle->SetErrorX(0);
+  
+  //  For the canvas
+  gStyle->SetCanvasBorderMode(0);
+  gStyle->SetCanvasColor(kWhite);
+  gStyle->SetCanvasDefH(800); //Height of canvas
+  gStyle->SetCanvasDefW(800); //Width of canvas
+  gStyle->SetCanvasDefX(0);   //Position on screen
+  gStyle->SetCanvasDefY(0);
+  
+  //  For the frame
+  gStyle->SetFrameBorderMode(0);
+  gStyle->SetFrameBorderSize(1);
+  gStyle->SetFrameFillColor(kBlack);
+  gStyle->SetFrameFillStyle(0);
+  gStyle->SetFrameLineColor(kBlack);
+  gStyle->SetFrameLineStyle(0);
+  gStyle->SetFrameLineWidth(1);
+  
+  //  For the Pad
+  gStyle->SetPadBorderMode(0);
+  gStyle->SetPadColor(kWhite);
+  gStyle->SetPadGridX(false);
+  gStyle->SetPadGridY(false);
+  gStyle->SetGridColor(0);
+  gStyle->SetGridStyle(3);
+  gStyle->SetGridWidth(1);
+  
+  //  Margins
+  gStyle->SetPadTopMargin(0.08);
+  gStyle->SetPadBottomMargin(0.15);
+  gStyle->SetPadLeftMargin(0.19);
+  gStyle->SetPadRightMargin(0.04);
+  
+  //  For the histo:
+  gStyle->SetHistLineColor(kBlack);
+  gStyle->SetHistLineStyle(0);
+  gStyle->SetHistLineWidth(2);
+  gStyle->SetMarkerSize(1.4);
+  gStyle->SetEndErrorSize(4);
+  
+  gStyle->SetOptStat("MR");
+  gStyle->SetStatColor(kWhite);
+  gStyle->SetStatFont(42);
+  gStyle->SetStatFontSize(0.03);
+  gStyle->SetStatTextColor(1);
+  gStyle->SetStatFormat("6.4g");
+  gStyle->SetStatBorderSize(1);
+  gStyle->SetStatX(0.94);              
+  gStyle->SetStatY(0.90);              
+  gStyle->SetStatH(0.10);
+  gStyle->SetStatW(0.22);
+  
+  //  For the Global title:
+  gStyle->SetOptTitle(1);
+  gStyle->SetTitleFont(42,"");
+  gStyle->SetTitleColor(1);
+  gStyle->SetTitleTextColor(1);
+  gStyle->SetTitleFillColor(0);
+  gStyle->SetTitleFontSize(0.1);
+  gStyle->SetTitleAlign(13);
+  gStyle->SetTitleX(0.00);
+  gStyle->SetTitleH(0.05);
+  gStyle->SetTitleBorderSize(0);
+  gStyle->SetTitleX(0.23);
+  
+  //  For the axis
+  gStyle->SetAxisColor(1,"XYZ");
+  gStyle->SetTickLength(0.03,"XYZ");
+  gStyle->SetNdivisions(510,"XYZ");
+  gStyle->SetPadTickX(1);
+  gStyle->SetPadTickY(1);
+  gStyle->SetStripDecimals(kFALSE);
+  
+  //  For the axis labels and titles
+  gStyle->SetTitleColor(1,"XYZ");
+  gStyle->SetLabelColor(1,"XYZ");
+  // For the axis labels:
+  gStyle->SetLabelFont(42,"XYZ");
+  gStyle->SetLabelOffset(0.007,"XYZ");
+  gStyle->SetLabelSize(0.045,"XYZ");
+  // For the axis titles:
+  gStyle->SetTitleFont(42,"XYZ");
+  gStyle->SetTitleSize(0.06,"XYZ");
+  gStyle->SetTitleXOffset(1.0);
+  gStyle->SetTitleYOffset(1.5);
+  
+  //  For the legend
+  gStyle->SetLegendBorderSize(0);
+  
+  //  For the statistics box
+  gStyle->SetStatFontSize(0.04);
+  gStyle->SetStatX(0.92);              
+  gStyle->SetStatY(0.86);              
+  gStyle->SetStatH(0.2);
+  gStyle->SetStatW(0.3);
+}


### PR DESCRIPTION
- Fix compilation in ROOT6
- Modify default output: one canvas per plot, stored as pdf
- Modify default style
- Add some steering scripts for easy plotting

Automatically ported from CMSSW_7_5_X #9711 (original by @mschrode).
