### PR TITLE
modify pixel probability cut in final fit to reject hit affected by Dyn-Innefficency

### DIFF
--- a/TrackingTools/TrackFitters/python/RungeKuttaFitters_cff.py
+++ b/TrackingTools/TrackFitters/python/RungeKuttaFitters_cff.py
@@ -23,7 +23,8 @@ KFFittingSmootherWithOutliersRejectionAndRK = RKFittingSmoother.clone(
     ComponentName = cms.string('KFFittingSmootherWithOutliersRejectionAndRK'),
     EstimateCut = cms.double(20.0),
     # ggiurgiu@fnal.gov : Any value lower than -15 turns off this cut.
-    # Recommended default value: -14.0. This will reject only the worst hits with negligible loss in track efficiency.  
-    LogPixelProbabilityCut = cms.double(-14.0),                               
+    # Old Recommended default value: -14.0. This will reject only the worst hits with negligible loss in track efficiency.  
+    # New Recommended default value for Run2: -3.0. This will reject most of the hit affected by Dyn-Innefficency at the cost of a small loss in track efficiency.
+    LogPixelProbabilityCut = cms.double(-3.0),                               
     MinNumberOfHits = cms.int32(3)
 )


### PR DESCRIPTION
the title says all.
please refers to presentation at reco meeting on May 21st
and to the HN thread 
https://hypernews.cern.ch/HyperNews/CMS/get/pixelOfflineSW/1134/1/1.html
Automatically ported from CMSSW_7_5_X #9174 (original by @VinInn).
