### PR TITLE
Change missing consumes from Info to Error

### DIFF
--- a/FWCore/Framework/src/Principal.cc
+++ b/FWCore/Framework/src/Principal.cc
@@ -110,7 +110,7 @@ namespace edm {
 
   namespace {
     void failedToRegisterConsumesMany(edm::TypeID const& iType) {
-      LogInfo("GetManyWithoutRegistration")<<"::getManyByType called for "<<iType<<" without a corresponding consumesMany being called for this module. \n";
+      LogError("GetManyWithoutRegistration")<<"::getManyByType called for "<<iType<<" without a corresponding consumesMany being called for this module. \n";
     }
     
     void failedToRegisterConsumes(KindOfType kindOfType,
@@ -118,7 +118,7 @@ namespace edm {
                                   std::string const& moduleLabel,
                                   std::string const& productInstanceName,
                                   std::string const& processName) {
-      LogInfo("GetByLabelWithoutRegistration")<<"::getByLabel without corresponding call to consumes or mayConsumes for this module.\n"
+      LogError("GetByLabelWithoutRegistration")<<"::getByLabel without corresponding call to consumes or mayConsumes for this module.\n"
       << (kindOfType == PRODUCT_TYPE ? "  type: " : " type: edm::View<")<<productType
       << (kindOfType == PRODUCT_TYPE ? "\n  module label: " : ">\n  module label: ")<<moduleLabel
       <<"\n  product instance name: '"<<productInstanceName


### PR DESCRIPTION
Changed the logger message for a missing consumes from being LogInfo to LogError.
The next step for the future will be to change this to an exception.
Automatically ported from CMSSW_7_5_X #9700 (original by @Dr15Jones).
