### PR TITLE
Replace call to getProcessParameterSet

### DIFF
--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -31,6 +31,11 @@ class StreamID;
 class InputFile;
 class InputChunk;
 
+namespace edm {
+  class PathsAndConsumesOfModulesBase;
+  class ProcessContext;
+}
+
 namespace Json{
   class Value;
 }
@@ -48,6 +53,7 @@ namespace evf{
       explicit EvFDaqDirector( const edm::ParameterSet &pset, edm::ActivityRegistry& reg );
       ~EvFDaqDirector();
       void preallocate(edm::service::SystemBounds const& bounds);
+      void preBeginJob(edm::PathsAndConsumesOfModulesBase const&, edm::ProcessContext const&);
       void preBeginRun(edm::GlobalContext const& globalContext);
       void postEndRun(edm::GlobalContext const& globalContext);
       void preGlobalEndLumi(edm::GlobalContext const& globalContext);
@@ -110,7 +116,7 @@ namespace evf{
         fileDeleteLockPtr_=fileDeleteLock;
         filesToDeletePtr_ = filesToDelete;
       }
-      void checkTransferSystemPSet();
+      void checkTransferSystemPSet(edm::ProcessContext const& pc);
       std::string getStreamDestinations(std::string const& stream) const;
 
 

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -2,8 +2,8 @@
 #include "FWCore/ServiceRegistry/interface/Service.h"
 #include "FWCore/ServiceRegistry/interface/SystemBounds.h"
 #include "FWCore/ServiceRegistry/interface/GlobalContext.h"
+#include "FWCore/ServiceRegistry/interface/ProcessContext.h"
 #include "FWCore/Utilities/interface/StreamID.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "EventFilter/Utilities/interface/EvFDaqDirector.h"
@@ -93,6 +93,7 @@ namespace evf {
   {
 
     reg.watchPreallocate(this, &EvFDaqDirector::preallocate);
+    reg.watchPreBeginJob(this, &EvFDaqDirector::preBeginJob);
     reg.watchPreGlobalBeginRun(this, &EvFDaqDirector::preBeginRun);
     reg.watchPostGlobalEndRun(this, &EvFDaqDirector::postEndRun);
     reg.watchPreSourceEvent(this, &EvFDaqDirector::preSourceEvent);
@@ -267,8 +268,11 @@ namespace evf {
     }
     nThreads_=bounds.maxNumberOfStreams();
     nStreams_=bounds.maxNumberOfThreads();
+  }
 
-    checkTransferSystemPSet();
+  void EvFDaqDirector::preBeginJob(edm::PathsAndConsumesOfModulesBase const&,
+                                   edm::ProcessContext const& pc) {
+    checkTransferSystemPSet(pc);
   }
 
   void EvFDaqDirector::preBeginRun(edm::GlobalContext const& globalContext) {
@@ -847,12 +851,15 @@ namespace evf {
   }
 
   //if transferSystem PSet is present in the menu, we require it to be complete and consistent for all specified streams
-  void EvFDaqDirector::checkTransferSystemPSet()
+  void EvFDaqDirector::checkTransferSystemPSet(edm::ProcessContext const& pc)
   {
+    if(transferSystemJson_) return;
+
     transferSystemJson_.reset(new Json::Value);
-    if (edm::getProcessParameterSet().existsAs<edm::ParameterSet>("transferSystem",true))
+    edm::ParameterSet const& topPset = edm::getParameterSet(pc.parameterSetID());
+    if (topPset.existsAs<edm::ParameterSet>("transferSystem",true))
     {
-      const edm::ParameterSet& tsPset(edm::getProcessParameterSet().getParameterSet("transferSystem"));
+      const edm::ParameterSet& tsPset(topPset.getParameterSet("transferSystem"));
 
       Json::Value destinationsVal(Json::arrayValue);
       std::vector<std::string> destinations = tsPset.getParameter<std::vector<std::string>>("destinations");


### PR DESCRIPTION
This is part of a small migration to remove
the function getProcessParameterSet from
CMSSW. It relies on a static global that causes
multithreading issues. And it does not work
correctly with SubProcesses.

I replaced the function with an alternative that
should behave in exactly the same way. Although
I had to move the function call from the preallocate
method to the preBeginJob method.

I do not know how to test this. Can someone test?
If preBeginJob gets called and then it succeeds
in getting the process parameter set, then all should
be OK.
Automatically ported from CMSSW_7_5_X #9697 (original by @wddgit).
