### PR TITLE
reduce creation of string objects and use char* instead of string

### DIFF
--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -99,7 +99,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
   //  The collections are specified via ROUList in the configuration, and can
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof)
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
-  const char* highTag = "HighTof";
+  const char* const highTag = "HighTof";
   for(auto const& cfToken : config.cfTokens_) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
     int Nhits = 0;
@@ -112,9 +112,8 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
         } else {
           edm::EDConsumerBase::Labels labels;
           theEvent.labelsForToken(cfToken, labels);
-          std::string trackerContainer(labels.productInstance);
-          unsigned int tofBin = StripDigiSimLink::LowTof;
-          if (trackerContainer.find(highTag) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+          unsigned int tofBin = StripDigiSimLink::LowTof; 
+	  if(std::strstr(labels.productInstance, highTag) != NULL) tofBin = StripDigiSimLink::HighTof;
           simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
           SimHitCollMap[theSimHitCollID].push_back(isim);
         }
@@ -134,9 +133,8 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
         } else {
           edm::EDConsumerBase::Labels labels;
           theEvent.labelsForToken(simHitToken, labels);
-          std::string trackerContainer(labels.productInstance);
-          unsigned int tofBin = StripDigiSimLink::LowTof;
-          if (trackerContainer.find(highTag) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+          unsigned int tofBin = StripDigiSimLink::LowTof; 
+	  if(std::strstr(labels.productInstance, highTag) != NULL) tofBin = StripDigiSimLink::HighTof;
           simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
           SimHitCollMap[theSimHitCollID].push_back(isim);
         }

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -113,7 +113,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
           edm::EDConsumerBase::Labels labels;
           theEvent.labelsForToken(cfToken, labels);
           unsigned int tofBin = StripDigiSimLink::LowTof; 
-	  if(std::strstr(labels.productInstance, highTag) != NULL) tofBin = StripDigiSimLink::HighTof;
+          if(std::strstr(labels.productInstance, highTag) != NULL) tofBin = StripDigiSimLink::HighTof;
           simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
           SimHitCollMap[theSimHitCollID].push_back(isim);
         }
@@ -134,7 +134,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
           edm::EDConsumerBase::Labels labels;
           theEvent.labelsForToken(simHitToken, labels);
           unsigned int tofBin = StripDigiSimLink::LowTof; 
-	  if(std::strstr(labels.productInstance, highTag) != NULL) tofBin = StripDigiSimLink::HighTof;
+          if(std::strstr(labels.productInstance, highTag) != NULL) tofBin = StripDigiSimLink::HighTof;
           simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
           SimHitCollMap[theSimHitCollID].push_back(isim);
         }

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -102,51 +102,84 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
   const char* const highTag = "HighTof";
   unsigned int tofBin; 
   edm::EDConsumerBase::Labels labels;
-  for(auto const& cfToken : config.cfTokens_) {
-    edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
-    int Nhits = 0;
-    if (theEvent.getByToken(cfToken, cf_simhit)) {
-      std::unique_ptr<MixCollection<PSimHit> > thisContainerHits(new MixCollection<PSimHit>(cf_simhit.product())); 
-      theEvent.labelsForToken(cfToken, labels);
-      if(std::strstr(labels.productInstance, highTag) != NULL) {
-        tofBin = StripDigiSimLink::HighTof;
-      } else {
-        tofBin = StripDigiSimLink::LowTof; 
-      }    
-      for (auto const& isim : *thisContainerHits) {
-        DetId theDet(isim.detUnitId());
-        if (assocHitbySimTrack_) {
-          SimHitMap[theDet].push_back(isim);
+  if (assocHitbySimTrack_) {
+    for(auto const& cfToken : config.cfTokens_) {
+      edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
+      //int Nhits = 0;
+      if (theEvent.getByToken(cfToken, cf_simhit)) {
+        std::unique_ptr<MixCollection<PSimHit> > thisContainerHits(new MixCollection<PSimHit>(cf_simhit.product())); 
+        theEvent.labelsForToken(cfToken, labels);
+        if(std::strstr(labels.productInstance, highTag) != NULL) {
+          tofBin = StripDigiSimLink::HighTof;
         } else {
-          simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
-          SimHitCollMap[theSimHitCollID].push_back(isim);
+          tofBin = StripDigiSimLink::LowTof; 
+        }    
+        for (auto const& isim : *thisContainerHits) {
+          DetId theDet(isim.detUnitId());
+          SimHitMap[theDet].push_back(isim);
+        //  ++Nhits;
         }
-        ++Nhits;
-      }
       // std::cout << "simHits from crossing frames; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
+      }
     }
-  }
-  for(auto const& simHitToken : config.simHitTokens_) {
-    edm::Handle<std::vector<PSimHit> > simHits;
-    int Nhits = 0;
-    if(theEvent.getByToken(simHitToken, simHits)) {
-      theEvent.labelsForToken(simHitToken, labels);
-      if(std::strstr(labels.productInstance, highTag) != NULL) {
-        tofBin = StripDigiSimLink::HighTof;
-      } else {
-        tofBin = StripDigiSimLink::LowTof; 
-      }
-      for (auto const& isim : *simHits) {
-        DetId theDet(isim.detUnitId());
-        if (assocHitbySimTrack_) {
-          SimHitMap[theDet].push_back(isim);
+    for(auto const& simHitToken : config.simHitTokens_) {
+      edm::Handle<std::vector<PSimHit> > simHits;
+      //int Nhits = 0;
+      if(theEvent.getByToken(simHitToken, simHits)) {
+        theEvent.labelsForToken(simHitToken, labels);
+        if(std::strstr(labels.productInstance, highTag) != NULL) {
+          tofBin = StripDigiSimLink::HighTof;
         } else {
-          simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
-          SimHitCollMap[theSimHitCollID].push_back(isim);
+          tofBin = StripDigiSimLink::LowTof; 
         }
-        ++Nhits;
-      }
+        for (auto const& isim : *simHits) {
+          DetId theDet(isim.detUnitId());
+          SimHitMap[theDet].push_back(isim);
+        //++Nhits;
+        }
       // std::cout << "simHits from prompt collections; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
+      }
+    }
+  } else {
+    simHitCollectionID theSimHitCollID;
+    for(auto const& cfToken : config.cfTokens_) {
+      edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
+      //int Nhits = 0;
+      if (theEvent.getByToken(cfToken, cf_simhit)) {
+        std::unique_ptr<MixCollection<PSimHit> > thisContainerHits(new MixCollection<PSimHit>(cf_simhit.product())); 
+        theEvent.labelsForToken(cfToken, labels);
+        if(std::strstr(labels.productInstance, highTag) != NULL) {
+          tofBin = StripDigiSimLink::HighTof;
+        } else {
+          tofBin = StripDigiSimLink::LowTof; 
+        }    
+        for (auto const& isim : *thisContainerHits) {
+          DetId theDet(isim.detUnitId());
+          theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+          SimHitCollMap[theSimHitCollID].push_back(isim);
+        //++Nhits;
+        }
+      // std::cout << "simHits from crossing frames; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
+      }
+    }
+    for(auto const& simHitToken : config.simHitTokens_) {
+      edm::Handle<std::vector<PSimHit> > simHits;
+      //int Nhits = 0;
+      if(theEvent.getByToken(simHitToken, simHits)) {
+        theEvent.labelsForToken(simHitToken, labels);
+        if(std::strstr(labels.productInstance, highTag) != NULL) {
+          tofBin = StripDigiSimLink::HighTof;
+        } else {
+          tofBin = StripDigiSimLink::LowTof; 
+        }
+        for (auto const& isim : *simHits) {
+          DetId theDet(isim.detUnitId());
+          theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
+          SimHitCollMap[theSimHitCollID].push_back(isim);
+        //++Nhits;
+        }
+      // std::cout << "simHits from prompt collections; map size = " << SimHitCollMap.size() << ", Hit count = " << Nhits << std::endl;
+      }
     }
   }
 }

--- a/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
+++ b/SimTracker/TrackerHitAssociation/src/TrackerHitAssociator.cc
@@ -99,7 +99,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
   //  The collections are specified via ROUList in the configuration, and can
   //  be either crossing frames (e.g., mix/g4SimHitsTrackerHitsTIBLowTof)
   //  or just PSimHits (e.g., g4SimHits/TrackerHitsTIBLowTof)
-
+  const char* highTag = "HighTof";
   for(auto const& cfToken : config.cfTokens_) {
     edm::Handle<CrossingFrame<PSimHit> > cf_simhit;
     int Nhits = 0;
@@ -114,7 +114,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
           theEvent.labelsForToken(cfToken, labels);
           std::string trackerContainer(labels.productInstance);
           unsigned int tofBin = StripDigiSimLink::LowTof;
-          if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+          if (trackerContainer.find(highTag) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
           simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
           SimHitCollMap[theSimHitCollID].push_back(isim);
         }
@@ -136,7 +136,7 @@ void TrackerHitAssociator::makeMaps(const edm::Event& theEvent, const TrackerHit
           theEvent.labelsForToken(simHitToken, labels);
           std::string trackerContainer(labels.productInstance);
           unsigned int tofBin = StripDigiSimLink::LowTof;
-          if (trackerContainer.find(std::string("HighTof")) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
+          if (trackerContainer.find(highTag) != std::string::npos) tofBin = StripDigiSimLink::HighTof;
           simHitCollectionID theSimHitCollID = std::make_pair(theDet.subdetId(), tofBin);
           SimHitCollMap[theSimHitCollID].push_back(isim);
         }


### PR DESCRIPTION
PR of a work intended to optimize gradually the perfrormance of tracker validation code.
Outputs are supposed to be unchanged.
Any comments and suggestions are welcome -more optimizations will follow in the near future 
Automatically ported from CMSSW_7_5_X #9678 (original by @ngrenz).
