### PR TITLE
Refactor RecoTrackSelector and RecoTrackRefSelector

### DIFF
--- a/CommonTools/RecoAlgos/interface/RecoTrackRefSelector.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackRefSelector.h
@@ -4,35 +4,24 @@
  *
  * \author Ian Tomalin, RAL
  *
- *  $Date: 2009/10/13 12:07:49 $
- *  $Revision: 1.1 $
- *
  */
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-#include "CommonTools/RecoAlgos/interface/RecoTrackSelector.h"
+#include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
 
-class RecoTrackRefSelector : public RecoTrackSelector {
-
-  // Would be better for RecoTrackRefSelector and RecoTrackSelector to inherit from common base class,
-  // since this doesn't needed the "selected_" data member from the base class.
-  // To do in future ...
-
+class RecoTrackRefSelector : public RecoTrackSelectorBase {
  public:
+  typedef reco::TrackCollection collection;
   typedef reco::TrackRefVector ref_container;
   typedef ref_container::const_iterator const_ref_iterator;
 
   /// Constructors
   RecoTrackRefSelector() {}
 
-  RecoTrackRefSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) : RecoTrackSelector(cfg, iC) {}
+  RecoTrackRefSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) : RecoTrackSelectorBase(cfg, iC) {}
 
   const_ref_iterator begin() const { return ref_selected_.begin(); }
   const_ref_iterator end() const { return ref_selected_.end(); }
 
-  void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) final {
+  void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) {
     init(event, es);
     ref_selected_.clear();
     for (unsigned int i = 0; i < c->size(); i++) {

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelector.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelector.h
@@ -4,20 +4,10 @@
  *
  * \author Giuseppe Cerati, INFN
  *
- *  $Date: 2013/06/05 14:49:09 $
- *  $Revision: 1.3.12.2 $
- *
  */
-#include "FWCore/Framework/interface/ConsumesCollector.h"
-#include "DataFormats/TrackReco/interface/Track.h"
-#include "DataFormats/TrackReco/interface/TrackFwd.h"
-#include "DataFormats/BeamSpot/interface/BeamSpot.h"
-#include "DataFormats/VertexReco/interface/Vertex.h"
-#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
 
-#include "FWCore/Utilities/interface/InputTag.h"
-
-class RecoTrackSelector {
+class RecoTrackSelector: public RecoTrackSelectorBase {
  public:
   typedef reco::TrackCollection collection;
   typedef std::vector<const reco::Track *> container;
@@ -26,43 +16,12 @@ class RecoTrackSelector {
   /// Constructors
   RecoTrackSelector() {}
   RecoTrackSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) :
-    RecoTrackSelector( cfg, iC ) {}
-  RecoTrackSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector & iC ) :
-    ptMin_(cfg.getParameter<double>("ptMin")),
-    minRapidity_(cfg.getParameter<double>("minRapidity")),
-    maxRapidity_(cfg.getParameter<double>("maxRapidity")),
-    tip_(cfg.getParameter<double>("tip")),
-    lip_(cfg.getParameter<double>("lip")),
-    minHit_(cfg.getParameter<int>("minHit")),
-    minPixelHit_(cfg.getParameter<int>("minPixelHit")),
-    minLayer_(cfg.getParameter<int>("minLayer")),
-    min3DLayer_(cfg.getParameter<int>("min3DLayer")),
-    maxChi2_(cfg.getParameter<double>("maxChi2")),
-    bsSrcToken_(iC.consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>("beamSpot"))),
-    usePV_(cfg.getParameter<bool>("usePV")) {
-      if (usePV_) vertexToken_ = iC.consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertexTag"));
-      std::vector<std::string> quality = cfg.getParameter<std::vector<std::string> >("quality");
-      for (unsigned int j=0;j<quality.size();j++) quality_.push_back(reco::TrackBase::qualityByName(quality[j]));
-      std::vector<std::string> algorithm = cfg.getParameter<std::vector<std::string> >("algorithm");
-      for (unsigned int j=0;j<algorithm.size();j++) algorithm_.push_back(reco::TrackBase::algoByName(algorithm[j]));
-    }
+    RecoTrackSelectorBase( cfg, iC ) {}
 
   const_iterator begin() const { return selected_.begin(); }
   const_iterator end() const { return selected_.end(); }
 
-
-  void init(const edm::Event & event, const edm::EventSetup&es) {
-     edm::Handle<reco::BeamSpot> beamSpot;
-     event.getByToken(bsSrcToken_,beamSpot);
-     vertex_ = beamSpot->position();
-     if (!usePV_) return;
-     edm::Handle<reco::VertexCollection> hVtx;
-     event.getByToken(vertexToken_, hVtx);
-     if (hVtx->empty()) return;
-     vertex_ = (*hVtx)[0].position();
-  }
-
-  virtual void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) {
+  void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) {
     init(event,es);
     selected_.clear();
     for( reco::TrackCollection::const_iterator trk = c->begin();
@@ -72,60 +31,10 @@ class RecoTrackSelector {
       }
   }
 
-  bool operator()( const reco::Track & t) const {
-    bool quality_ok = true;
-    if (quality_.size()!=0) {
-      quality_ok = false;
-      for (unsigned int i = 0; i<quality_.size();++i) {
-	if (t.quality(quality_[i])){
-	  quality_ok = true;
-	  break;
-	}
-      }
-    }
-    
-    bool algo_ok = true;
-    if (algorithm_.size()!=0) {
-      if (std::find(algorithm_.begin(),algorithm_.end(),t.algo())==algorithm_.end()) algo_ok = false;
-    }
-    return
-      (
-       (algo_ok & quality_ok) &&
-       t.hitPattern().numberOfValidHits() >= minHit_ &&
-       t.hitPattern().numberOfValidPixelHits() >= minPixelHit_ &&
-       t.hitPattern().trackerLayersWithMeasurement() >= minLayer_ &&
-       t.hitPattern().pixelLayersWithMeasurement() +
-       t.hitPattern().numberOfValidStripLayersWithMonoAndStereo() >= min3DLayer_ &&
-       fabs(t.pt()) >= ptMin_ &&
-       t.eta() >= minRapidity_ && t.eta() <= maxRapidity_ &&
-       fabs(t.dxy(vertex_)) <= tip_ &&
-       fabs(t.dsz(vertex_)) <= lip_  &&
-       t.normalizedChi2()<=maxChi2_
-      );
-
-  }
-
   size_t size() const { return selected_.size(); }
 
- protected:
-  double ptMin_;
-  double minRapidity_;
-  double maxRapidity_;
-  double tip_;
-  double lip_;
-  int    minHit_;
-  int    minPixelHit_;
-  int    minLayer_;
-  int    min3DLayer_;
-  double maxChi2_;
-  std::vector<reco::TrackBase::TrackQuality> quality_;
-  std::vector<reco::TrackBase::TrackAlgorithm> algorithm_;
-  edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;
-  bool usePV_;
-  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
-  reco::Track::Point vertex_;
+ private:
   container selected_;
-  edm::EventID previousEvent;
 };
 
 #endif

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -1,0 +1,104 @@
+#ifndef CommonTools_RecoAlgos_RecoTrackSelectorBase_h
+#define CommonTools_RecoAlgos_RecoTrackSelectorBase_h
+
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+
+
+class RecoTrackSelectorBase {
+public:
+  RecoTrackSelectorBase() {}
+  RecoTrackSelectorBase(const edm::ParameterSet & cfg, edm::ConsumesCollector & iC):
+    ptMin_(cfg.getParameter<double>("ptMin")),
+    minRapidity_(cfg.getParameter<double>("minRapidity")),
+    maxRapidity_(cfg.getParameter<double>("maxRapidity")),
+    tip_(cfg.getParameter<double>("tip")),
+    lip_(cfg.getParameter<double>("lip")),
+    maxChi2_(cfg.getParameter<double>("maxChi2")),
+    minHit_(cfg.getParameter<int>("minHit")),
+    minPixelHit_(cfg.getParameter<int>("minPixelHit")),
+    minLayer_(cfg.getParameter<int>("minLayer")),
+    min3DLayer_(cfg.getParameter<int>("min3DLayer")),
+    usePV_(cfg.getParameter<bool>("usePV")),
+    bsSrcToken_(iC.consumes<reco::BeamSpot>(cfg.getParameter<edm::InputTag>("beamSpot"))) {
+      if (usePV_)
+        vertexToken_ = iC.consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vertexTag"));
+      for(const std::string& quality: cfg.getParameter<std::vector<std::string> >("quality"))
+        quality_.push_back(reco::TrackBase::qualityByName(quality));
+      for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("algorithm"))
+        algorithm_.push_back(reco::TrackBase::algoByName(algorithm));
+    }
+
+  void init(const edm::Event& event, const edm::EventSetup& es) {
+     edm::Handle<reco::BeamSpot> beamSpot;
+     event.getByToken(bsSrcToken_,beamSpot);
+     vertex_ = beamSpot->position();
+     if (!usePV_) return;
+     edm::Handle<reco::VertexCollection> hVtx;
+     event.getByToken(vertexToken_, hVtx);
+     if (hVtx->empty()) return;
+     vertex_ = (*hVtx)[0].position();
+  }
+
+  bool operator()( const reco::Track & t) const {
+    bool quality_ok = true;
+    if (quality_.size()!=0) {
+      quality_ok = false;
+      for (unsigned int i = 0; i<quality_.size();++i) {
+	if (t.quality(quality_[i])){
+	  quality_ok = true;
+	  break;
+	}
+      }
+    }
+
+    bool algo_ok = true;
+    if (algorithm_.size()!=0) {
+      if (std::find(algorithm_.begin(),algorithm_.end(),t.algo())==algorithm_.end()) algo_ok = false;
+    }
+    return
+      (
+       (algo_ok & quality_ok) &&
+       t.hitPattern().numberOfValidHits() >= minHit_ &&
+       t.hitPattern().numberOfValidPixelHits() >= minPixelHit_ &&
+       t.hitPattern().trackerLayersWithMeasurement() >= minLayer_ &&
+       t.hitPattern().pixelLayersWithMeasurement() +
+       t.hitPattern().numberOfValidStripLayersWithMonoAndStereo() >= min3DLayer_ &&
+       fabs(t.pt()) >= ptMin_ &&
+       t.eta() >= minRapidity_ && t.eta() <= maxRapidity_ &&
+       fabs(t.dxy(vertex_)) <= tip_ &&
+       fabs(t.dsz(vertex_)) <= lip_  &&
+       t.normalizedChi2()<=maxChi2_
+      );
+  }
+
+
+private:
+  double ptMin_;
+  double minRapidity_;
+  double maxRapidity_;
+  double tip_;
+  double lip_;
+  double maxChi2_;
+  int    minHit_;
+  int    minPixelHit_;
+  int    minLayer_;
+  int    min3DLayer_;
+  bool usePV_;
+
+  edm::EDGetTokenT<reco::BeamSpot> bsSrcToken_;
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken_;
+
+  std::vector<reco::TrackBase::TrackQuality> quality_;
+  std::vector<reco::TrackBase::TrackAlgorithm> algorithm_;
+
+  reco::Track::Point vertex_;
+};
+
+#endif

--- a/CommonTools/RecoAlgos/python/recoTrackRefSelector_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackRefSelector_cfi.py
@@ -1,22 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+from CommonTools.RecoAlgos.recoTrackSelectorPSet_cfi import recoTrackSelectorPSet as _recoTrackSelectorPSet
+
 recoTrackRefSelector = cms.EDFilter("RecoTrackRefSelector",
-    src = cms.InputTag("generalTracks"),
-    maxChi2 = cms.double(10000.0),
-    tip = cms.double(120.0),
-    minRapidity = cms.double(-5.0),
-    lip = cms.double(300.0),
-    ptMin = cms.double(0.1),
-    maxRapidity = cms.double(5.0),
-    quality = cms.vstring('loose'),
-    algorithm = cms.vstring(),
-    minLayer = cms.int32(3),
-    min3DLayer = cms.int32(0),
-    minHit = cms.int32(0),
-    minPixelHit = cms.int32(0),
-    beamSpot = cms.InputTag("offlineBeamSpot"),
-    usePV = cms.bool(False),
-    vertexTag = cms.InputTag('offlinePrimaryVertices')
+    _recoTrackSelectorPSet
 )
 
 

--- a/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
@@ -1,0 +1,20 @@
+import FWCore.ParameterSet.Config as cms
+
+recoTrackSelectorPSet = cms.PSet(
+    src = cms.InputTag("generalTracks"),
+    maxChi2 = cms.double(10000.0),
+    tip = cms.double(120.0),
+    minRapidity = cms.double(-5.0),
+    lip = cms.double(300.0),
+    ptMin = cms.double(0.1),
+    maxRapidity = cms.double(5.0),
+    quality = cms.vstring('loose'),
+    algorithm = cms.vstring(),
+    minLayer = cms.int32(3),
+    min3DLayer = cms.int32(0),
+    minHit = cms.int32(0),
+    minPixelHit = cms.int32(0),
+    beamSpot = cms.InputTag("offlineBeamSpot"),
+    usePV = cms.bool(False),
+    vertexTag = cms.InputTag('offlinePrimaryVertices')
+)

--- a/PhysicsTools/RecoAlgos/python/recoTrackSelector_cfi.py
+++ b/PhysicsTools/RecoAlgos/python/recoTrackSelector_cfi.py
@@ -1,22 +1,9 @@
 import FWCore.ParameterSet.Config as cms
 
+from CommonTools.RecoAlgos.recoTrackSelectorPSet_cfi import recoTrackSelectorPSet as _recoTrackSelectorPSet
+
 recoTrackSelector = cms.EDProducer("RecoTrackSelector",
-    src = cms.InputTag("generalTracks"),
-    maxChi2 = cms.double(10000.0),
-    tip = cms.double(120.0),
-    minRapidity = cms.double(-5.0),
-    lip = cms.double(300.0),
-    ptMin = cms.double(0.1),
-    maxRapidity = cms.double(5.0),
-    quality = cms.vstring('loose'),
-    algorithm = cms.vstring(),
-    minLayer = cms.int32(3),
-    min3DLayer = cms.int32(0),
-    minHit = cms.int32(0),
-    minPixelHit = cms.int32(0),
-    beamSpot = cms.InputTag("offlineBeamSpot"),
-    usePV = cms.bool(False),
-    vertexTag = cms.InputTag('offlinePrimaryVertices'),
+    _recoTrackSelectorPSet,
     copyExtras = cms.untracked.bool(True), ## copies also extras and rechits on RECO
     copyTrajectories = cms.untracked.bool(False) # don't set this to true on AOD!
 )


### PR DESCRIPTION
This PR refactors the commonalities of RecoTrackSelector and RecoTrackRefSelector to a new base class (RecoTrackSelectorBase; as suggested by a comment in RecoTrackRefSelector). I'm planning to add a third variant (reading tracks through View), and without the refactoring the code would become even more messy. I also took the opportunity to do a similar refactoring of the configuration parameters. I took this separate from the other developments in the hope of smoother integration for purely technical changes.

Tested in CMSSW_7_5_X_2015-06-14-2300, no changes expected in results.

@rovere @VinInn 
Automatically ported from CMSSW_7_5_X #9658 (original by @makortel).
