### PR TITLE
clean-up fastsim rechits

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
+++ b/DataFormats/TrackerRecHit2D/interface/BaseTrackerRecHit.h
@@ -40,11 +40,11 @@ public:
   virtual ~BaseTrackerRecHit() {}
 
   // no position (as in persistent)
-  BaseTrackerRecHit(DetId id, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id,(unsigned int)(rt)) {}
+ BaseTrackerRecHit(DetId id, trackerHitRTTI::RTTI rt) :  TrackingRecHit(id,(unsigned int)(rt)),qualWord_(0) {}
 
-  BaseTrackerRecHit( const LocalPoint& p, const LocalError&e,
-		     GeomDet const & idet, trackerHitRTTI::RTTI rt) :  
-    TrackingRecHit(idet, (unsigned int)(rt)), pos_(p), err_(e){
+ BaseTrackerRecHit( const LocalPoint& p, const LocalError&e,
+		    GeomDet const & idet, trackerHitRTTI::RTTI rt) :  
+  TrackingRecHit(idet, (unsigned int)(rt)), pos_(p), err_(e), qualWord_(0){
     LocalError lape = static_cast<TrackerGeomDet const *>(det())->localAlignmentError();
     if (lape.valid())
       err_ = LocalError(err_.xx()+lape.xx(),

--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
@@ -7,77 +7,69 @@ class SiTrackerGSRecHit2D;
 
 class SiTrackerGSMatchedRecHit2D : public GSSiTrackerRecHit2DLocalPos{
   
-public:
+ public:
   
-  SiTrackerGSMatchedRecHit2D(): GSSiTrackerRecHit2DLocalPos(),
-			 simhitId_(),
-			 simtrackId_(),
-			 eeId_(),
-                         cluster_(),  
-                         pixelMultiplicityAlpha_(), 
-                         pixelMultiplicityBeta_(),
-                         isMatched_(), 
-                         componentMono_(),
-                         componentStereo_() {}
+ SiTrackerGSMatchedRecHit2D()
+   : GSSiTrackerRecHit2DLocalPos()
+    , simtrackId_(-1)
+    , isMatched_(false)
+    , componentMono_()
+    , componentStereo_(){}
   
   ~SiTrackerGSMatchedRecHit2D() {}
   
- typedef edm::Ref<FastTrackerClusterCollection, FastTrackerCluster > ClusterRef;
- typedef edm::RefProd<FastTrackerClusterCollection> ClusterRefProd;
+  SiTrackerGSMatchedRecHit2D( const LocalPoint & pos, 
+			      const LocalError & err,
+			      const GeomDet & idet,
+			      const uint32_t simtrackId)
+    : GSSiTrackerRecHit2DLocalPos(pos,err,idet)
+    , simtrackId_(simtrackId)
+    , isMatched_(false)
+    , id_(-1)
+    , eeId_(-1)
+    {};
 
+  SiTrackerGSMatchedRecHit2D( const LocalPoint & pos, 
+			      const LocalError & err,
+			      const GeomDet & idet,
+			      const uint32_t simtrackId,
+			      const bool isMatched,
+			      const SiTrackerGSRecHit2D & rMono, 
+			      const SiTrackerGSRecHit2D & rStereo) 
+    : GSSiTrackerRecHit2DLocalPos(pos,err,idet)
+    , simtrackId_(simtrackId)
+    , isMatched_(isMatched)
+    , componentMono_(rMono) 
+    , componentStereo_(rStereo)
+    , id_(-1)
+    , eeId_(-1)
+    {};
 
-  SiTrackerGSMatchedRecHit2D( const LocalPoint&, const LocalError&,
-		       GeomDet const & idet,
-		       const int simhitId,
-		       const int simtrackId,
-		       const uint32_t eeId,
-                       ClusterRef const&  cluster,
-		       const int pixelMultiplicityX,
-		       const int pixelMultiplicityY,
-		       const bool isMatched,
-		       const SiTrackerGSRecHit2D* rMono, 
-		       const SiTrackerGSRecHit2D* rStereo 
-		       );  
-
-  SiTrackerGSMatchedRecHit2D( const LocalPoint&, const LocalError&,
-		       GeomDet const & idet,
-		       const int simhitId,
-		       const int simtrackId,
-		       const uint32_t eeId,
-                       ClusterRef const&  cluster,
-		       const int pixelMultiplicityX,
-		       const int pixelMultiplicityY
-		       );  
 
   virtual SiTrackerGSMatchedRecHit2D * clone() const {SiTrackerGSMatchedRecHit2D * p =  new SiTrackerGSMatchedRecHit2D( * this); p->load(); return p;}
-  
-  const int& simhitId()    const { return simhitId_;}
-  const int& simtrackId()  const { return simtrackId_;}
-  const uint32_t& eeId()   const { return eeId_;}
-  const int& simMultX()    const { return pixelMultiplicityAlpha_;}
-  const int& simMultY()    const { return pixelMultiplicityBeta_;}
-  const bool& isMatched()  const { return isMatched_;}
-  const SiTrackerGSRecHit2D *monoHit() const { return &componentMono_;}
-  const SiTrackerGSRecHit2D *stereoHit() const { return &componentStereo_;}
 
- ClusterRef const& cluster() const { return cluster_;}
-  void setClusterRef(const ClusterRef &ref) { cluster_  = ref; }
- 
+  const uint32_t & id()          const { return id_;}
+  const uint32_t & simtrackId()  const { return simtrackId_;}
+  const uint32_t & eeId()   const { return eeId_;}
+  const bool & isMatched()  const { return isMatched_;}
+  const SiTrackerGSRecHit2D & monoHit() const { return componentMono_;}
+  const SiTrackerGSRecHit2D & stereoHit() const { return componentStereo_;}
+
+  void setId(uint32_t id){id_ = id;}
   void setEeId(uint32_t eeId){eeId_ = eeId;}
 
   virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const;
- 
-private:
-  int const simhitId_;
-  int const simtrackId_;
-  uint32_t eeId_;
-  ClusterRef cluster_;
-  int const pixelMultiplicityAlpha_;
-  int const pixelMultiplicityBeta_;
-  bool isMatched_;
+  
+ private:
+  
+  const uint32_t simtrackId_;
+  const bool isMatched_;
+  
+  const SiTrackerGSRecHit2D componentMono_;
+  const SiTrackerGSRecHit2D componentStereo_;
 
-  SiTrackerGSRecHit2D componentMono_;
-  SiTrackerGSRecHit2D componentStereo_;
+  uint32_t id_;
+  uint32_t eeId_;  
 };
 
 

--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2D.h
@@ -5,61 +5,44 @@
 #include "DataFormats/Common/interface/Ref.h"
 #include "FastSimDataFormats/External/interface/FastTrackerClusterCollection.h" 
 
-// typedef edm::Ref<FastTrackerClusterCollection, FastTrackerCluster > ClusterRef;
-// typedef edm::RefProd<FastTrackerClusterCollection> ClusterRefProd;
-
 class SiTrackerGSRecHit2D : public GSSiTrackerRecHit2DLocalPos{
   
-public:
+ public:
   
- 
   
-  SiTrackerGSRecHit2D(): GSSiTrackerRecHit2DLocalPos(),
-			 simhitId_(),
-			 simtrackId_(),
-			 eeId_(),
-                         cluster_(),  
-			 pixelMultiplicityAlpha_(), 
-                         pixelMultiplicityBeta_() {}
+  
+ SiTrackerGSRecHit2D()
+   : GSSiTrackerRecHit2DLocalPos()
+    , simtrackId_() {}
   
   ~SiTrackerGSRecHit2D() {}
   
- typedef edm::Ref<FastTrackerClusterCollection, FastTrackerCluster > ClusterRef;
- typedef edm::RefProd<FastTrackerClusterCollection> ClusterRefProd;
-
-
-  SiTrackerGSRecHit2D( const LocalPoint&, const LocalError&,
-		       GeomDet const & idet,
-		       const int simhitId,
-		       const int simtrackId,
-		       const uint32_t eeId,
-		       ClusterRef const&  cluster,
-		       const int pixelMultiplicityX,
-		       const int pixelMultiplicityY);     
+  SiTrackerGSRecHit2D( const LocalPoint & pos, 
+		       const LocalError & err,
+		       const GeomDet & idet,
+		       const uint32_t simtrackId)
+    : GSSiTrackerRecHit2DLocalPos(pos,err,idet)
+    , simtrackId_(simtrackId)
+    , id_(-1)
+    , eeId_(-1)
+    {};
   
   virtual SiTrackerGSRecHit2D * clone() const {SiTrackerGSRecHit2D * p = new SiTrackerGSRecHit2D( * this); p->load(); return p;}
   
-  const int& simhitId()    const { return simhitId_;}
-  const int& simtrackId()  const { return simtrackId_;}
+  const uint32_t & id()          const { return id_;}
+  const uint32_t& simtrackId()  const { return simtrackId_;}
   const uint32_t& eeId()   const { return eeId_;}
-  const int& simMultX()    const { return pixelMultiplicityAlpha_;}
-  const int& simMultY()    const { return pixelMultiplicityBeta_;}
-
-  ClusterRef const& cluster() const { return cluster_;}
-  void setClusterRef(const ClusterRef &ref) { cluster_  = ref; }
   
+  void setId(uint32_t id){id_ = id;}
   void setEeId(uint32_t eeId){eeId_ = eeId;}
 
-  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const {return false;}
+  virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const;
   
  private:
   
-  int simhitId_;
-  int simtrackId_;
+  const uint32_t simtrackId_;
+  uint32_t id_;
   uint32_t eeId_;
-  ClusterRef cluster_;
-  int pixelMultiplicityAlpha_;
-  int pixelMultiplicityBeta_;
   
 };
 

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
@@ -1,58 +1,9 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h"
 
-SiTrackerGSMatchedRecHit2D::SiTrackerGSMatchedRecHit2D( const LocalPoint& pos, const LocalError& err,
-					  GeomDet const & idet,
-					  const int simhitId         ,
-					  const int simtrackId       ,
-					  const uint32_t eeId,
-					  ClusterRef const&  cluster ,
-					  const int pixelMultiplicityX = -1,
-					  const int pixelMultiplicityY = -1, 
-					  const bool isMatched = false,
-					  const SiTrackerGSRecHit2D* rMono = 0 , 
-					  const SiTrackerGSRecHit2D* rStereo= 0 ):
-  GSSiTrackerRecHit2DLocalPos(pos,err,idet) ,
-  simhitId_(simhitId) ,
-  simtrackId_(simtrackId) ,
-  eeId_(eeId) ,
-  cluster_(cluster), 
-  pixelMultiplicityAlpha_(pixelMultiplicityX), 
-  pixelMultiplicityBeta_(pixelMultiplicityY), 
-  isMatched_(isMatched), 
-  componentMono_(*rMono), 
-  componentStereo_(*rStereo)
-{}
-
-SiTrackerGSMatchedRecHit2D::SiTrackerGSMatchedRecHit2D( const LocalPoint& pos, const LocalError& err,
-					  GeomDet const & idet,
-					  const int simhitId         ,
-					  const int simtrackId       ,
-					  const uint32_t eeId,
-					  ClusterRef const&  cluster ,
-					  const int pixelMultiplicityX = -1,
-					  const int pixelMultiplicityY = -1):
-  GSSiTrackerRecHit2DLocalPos(pos,err,idet) ,
-  simhitId_(simhitId) ,
-  simtrackId_(simtrackId) ,
-  eeId_(eeId) ,
-  cluster_(cluster),
-  pixelMultiplicityAlpha_(pixelMultiplicityX), 
-  pixelMultiplicityBeta_(pixelMultiplicityY), 
-  isMatched_(0), 
-  componentMono_(), 
-  componentStereo_()
-{}
-
-
-
 bool SiTrackerGSMatchedRecHit2D::sharesInput( const TrackingRecHit* other, 
-					    SharedInputType what) const
- {
-   if (geographicalId() != other->geographicalId()) return false;
-   if(! other->isValid()) return false;
+					      SharedInputType what) const
+{
+  const SiTrackerGSMatchedRecHit2D * otherCasted = dynamic_cast<const SiTrackerGSMatchedRecHit2D*>(other);
+  return bool(otherCasted) && otherCasted->id() == this->id() && otherCasted->eeId() == this->eeId();
+}
 
-   const SiTrackerGSMatchedRecHit2D* otherCast = static_cast<const SiTrackerGSMatchedRecHit2D*>(other);
-
-   return cluster_ == otherCast->cluster();
- }
- 

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerGSRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerGSRecHit2D.cc
@@ -1,19 +1,9 @@
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2D.h"
 
 
-SiTrackerGSRecHit2D::SiTrackerGSRecHit2D( const LocalPoint& pos, const LocalError& err,
-					  GeomDet const & idet,
-					  const int simhitId         ,
-					  const int simtrackId       ,
-					  const uint32_t eeId        ,
-					  ClusterRef const&  cluster ,
-					  const int pixelMultiplicityX = -1,
-					  const int pixelMultiplicityY = -1 
-					   ): 
-  GSSiTrackerRecHit2DLocalPos(pos,err,idet) ,
-  simhitId_(simhitId) ,
-  simtrackId_(simtrackId) ,
-  eeId_(eeId) ,
-  cluster_(cluster), 
-  pixelMultiplicityAlpha_(pixelMultiplicityX), 
-  pixelMultiplicityBeta_(pixelMultiplicityY){}
+bool SiTrackerGSRecHit2D::sharesInput( const TrackingRecHit* other, 
+					      SharedInputType what) const
+{
+  const SiTrackerGSRecHit2D * otherCasted = dynamic_cast<const SiTrackerGSRecHit2D*>(other);
+  return bool(otherCasted) && otherCasted->id() == this->id() && otherCasted->eeId() == this->eeId();
+}

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -5,15 +5,17 @@
    <version ClassVersion="11" checksum="834943006"/>
    <version ClassVersion="10" checksum="2474445311"/>
   </class>
-  <class name="SiTrackerGSRecHit2D" ClassVersion="11">
+  <class name="SiTrackerGSRecHit2D" ClassVersion="12">
+   <version ClassVersion="12" checksum="1369340574"/>
    <version ClassVersion="11" checksum="1613493049"/>
    <version ClassVersion="10" checksum="877294307"/>
   </class>
-  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="13">
-   <version ClassVersion="13" checksum="1553184391"/>
-   <version ClassVersion="12" checksum="2874379530"/>
-   <version ClassVersion="11" checksum="1553184391"/>
-   <version ClassVersion="10" checksum="3741285161"/>
+  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="14">
+    <version ClassVersion="14" checksum="3149196391"/>
+    <version ClassVersion="13" checksum="1553184391"/>
+    <version ClassVersion="12" checksum="2874379530"/>
+    <version ClassVersion="11" checksum="1553184391"/>
+    <version ClassVersion="10" checksum="3741285161"/>
   </class>
 
 

--- a/FastSimulation/Tracking/test/FastTrackAnalyzer.cc
+++ b/FastSimulation/Tracking/test/FastTrackAnalyzer.cc
@@ -538,7 +538,6 @@ void FastTrackAnalyzer::analyze(const edm::Event& event, const edm::EventSetup& 
 	      int currentId = rechit->simtrackId();		      
 	      std::cout << "\t\t\tRecHit # " << ri << "\t SimTrackId = " << currentId << std::endl;
 	      SimTrackIds.push_back(currentId);
-	      std::cout<<"\t\t\t SimHit ID belonging to this RecHit = "<< rechit->simhitId() << std::endl;
 	      DetId detid = rechit->geographicalId();
 	      unsigned int subdet = detid.subdetId();
 

--- a/FastSimulation/TrackingRecHitProducer/interface/GSRecHitMatcher.h
+++ b/FastSimulation/TrackingRecHitProducer/interface/GSRecHitMatcher.h
@@ -16,10 +16,10 @@ class GSRecHitMatcher {
   GSRecHitMatcher() {}
   ~GSRecHitMatcher() {}
 
-  SiTrackerGSMatchedRecHit2D * match( const SiTrackerGSRecHit2D *monoRH,
-				      const SiTrackerGSRecHit2D *stereoRH,
-				      const GluedGeomDet* gluedDet,
-				      LocalVector& trackdirection) const;
+  SiTrackerGSMatchedRecHit2D match( const SiTrackerGSRecHit2D *monoRH,
+				    const SiTrackerGSRecHit2D *stereoRH,
+				    const GluedGeomDet* gluedDet,
+				    LocalVector& trackdirection) const;
   
   
   StripPosition project(const GeomDetUnit *det,
@@ -27,10 +27,10 @@ class GSRecHitMatcher {
 			const StripPosition& strip,
 			const LocalVector& trackdirection) const;
   
-  SiTrackerGSMatchedRecHit2D * projectOnly( const SiTrackerGSRecHit2D *monoRH,
-					    const GeomDet * monoDet,
-					    const GluedGeomDet* gluedDet,
-					    LocalVector& ldir) const;
+  SiTrackerGSMatchedRecHit2D projectOnly( const SiTrackerGSRecHit2D *monoRH,
+					  const GeomDet * monoDet,
+					  const GluedGeomDet* gluedDet,
+					  LocalVector& ldir) const;
   
 };
 

--- a/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.h
+++ b/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.h
@@ -19,7 +19,6 @@
 
 // Data Formats
 #include "SimDataFormats/CrossingFrame/interface/MixCollection.h"
-#include "FastSimDataFormats/External/interface/FastTrackerClusterCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2DCollection.h"
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2DCollection.h"
 #include "DataFormats/GeometryVector/interface/Point3DBase.h"
@@ -66,7 +65,6 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   void smearHits(const edm::PSimHitContainer& input,
   //  void smearHits(edm::Handle<std::vector<PSimHit> >& input,
                  std::map<unsigned, edm::OwnVector<SiTrackerGSRecHit2D> >& theRecHits,
-                 std::map<unsigned, edm::OwnVector<FastTrackerCluster> >& theClusters,
 		 const TrackerTopology *tTopo,
                  RandomEngineAndDistribution const*);
 
@@ -83,9 +81,6 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   void loadMatchedRecHits(std::map<unsigned,edm::OwnVector<SiTrackerGSMatchedRecHit2D> >& theRecHits, 
 		   SiTrackerGSMatchedRecHit2DCollection& theRecHitCollection) const;
 
-  void loadClusters(std::map<unsigned,edm::OwnVector<FastTrackerCluster> >& theClusterMap, 
-                    FastTrackerClusterCollection& theClusterCollection) const;
-  
   private:
   //
   bool gaussianSmearing(const PSimHit& simHit, 
@@ -231,7 +226,6 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   // valid for all the detectors
   double localPositionResolution_z; // cm
   //
-  //  typedef std::map<unsigned int, std::vector<PSimHit>,std::less<unsigned int> > simhit_map;
 
   // Pixel Error Parametrization (barrel)
   SiPixelGaussianSmearingRecHitConverterAlgorithm* thePixelBarrelParametrization;
@@ -240,20 +234,9 @@ class SiTrackerGaussianSmearingRecHitConverter : public edm::stream::EDProducer 
   // Si Strip Error parametrization (generic)
   SiStripGaussianSmearingRecHitConverterAlgorithm* theSiStripErrorParametrization;
 
-  // Temporary RecHit map
-  //  std::map< DetId, edm::OwnVector<SiTrackerGSRecHit2D> > temporaryRecHits;
-
-  // Local correspondence between RecHits and SimHits
-  //  typedef MixCollection<PSimHit>::iterator SimHiterator;
   typedef edm::PSimHitContainer::const_iterator SimHiterator;
   std::vector<SimHiterator> correspondingSimHit;
 
-  typedef SiTrackerGSRecHit2D::ClusterRef ClusterRef;
-  typedef SiTrackerGSRecHit2D::ClusterRefProd ClusterRefProd;
-  // Added for cluster reference
-  ClusterRefProd FastTrackerClusterRefProd;
-
-  
 };
 
 

--- a/FastSimulation/TrackingRecHitProducer/src/GSRecHitMatcher.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/GSRecHitMatcher.cc
@@ -6,10 +6,10 @@
 #include "Geometry/TrackerGeometryBuilder/interface/GluedGeomDet.h"
 #include <cfloat>
 
-SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::match(const SiTrackerGSRecHit2D *monoRH,
-						    const SiTrackerGSRecHit2D *stereoRH,
-						    const GluedGeomDet* gluedDet,
-					            LocalVector& trackdirection) const
+SiTrackerGSMatchedRecHit2D GSRecHitMatcher::match(const SiTrackerGSRecHit2D *monoRH,
+						  const SiTrackerGSRecHit2D *stereoRH,
+						  const GluedGeomDet* gluedDet,
+						  LocalVector& trackdirection) const
 {
 
 
@@ -91,44 +91,24 @@ SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::match(const SiTrackerGSRecHit2D *m
   float yy=invdet2*(sigmap12*c2*c2+sigmap22*c1*c1);
   LocalError error=LocalError(xx,xy,yy);
 
- //  if((gluedDet->surface()).bounds().inside(position,error,3)){
-//     std::cout<<"  ERROR ok "<< std::endl;
-//   }
-//   else {
-//     std::cout<<" ERROR not ok " << std::endl;
-//   }
-  
   //Added by DAO to make sure y positions are zero.
   DetId det(monoRH->geographicalId());
   if(det.subdetId() > 2) {
-    SiTrackerGSRecHit2D *adjustedMonoRH = new SiTrackerGSRecHit2D(LocalPoint(monoRH->localPosition().x(),0,0),
-								  monoRH->localPositionError(),
-								  *monoRH->det(),
-								  monoRH->simhitId(),
-								  monoRH->simtrackId(),
-								  monoRH->eeId(),
-								  monoRH->cluster(),
-								  monoRH->simMultX(),
-								  monoRH->simMultY()
-								  );
+    // why not pass through directly?
+    SiTrackerGSRecHit2D adjustedMonoRH(LocalPoint(monoRH->localPosition().x(),0,0),
+				       monoRH->localPositionError(),
+				       *monoRH->det(),
+				       monoRH->simtrackId());
+    // why not pass through directly?
+    SiTrackerGSRecHit2D adjustedStereoRH(LocalPoint(stereoRH->localPosition().x(),0,0),
+					 stereoRH->localPositionError(),
+					 *stereoRH->det(),
+					 stereoRH->simtrackId());
     
-    SiTrackerGSRecHit2D *adjustedStereoRH = new SiTrackerGSRecHit2D(LocalPoint(stereoRH->localPosition().x(),0,0),
-								    stereoRH->localPositionError(),
-								    *stereoRH->det(),
-								    stereoRH->simhitId(),
-								    stereoRH->simtrackId(),
-								    stereoRH->eeId(),
-								    stereoRH->cluster(),
-								    stereoRH->simMultX(),
-								    stereoRH->simMultY()
-								    );
-    
-    SiTrackerGSMatchedRecHit2D *rV= new SiTrackerGSMatchedRecHit2D(position, error, *gluedDet, monoRH->simhitId(), 
-								   monoRH->simtrackId(), monoRH->eeId(), monoRH->cluster(), 
-								   monoRH->simMultX(), monoRH->simMultY(), 
-								   true, adjustedMonoRH, adjustedStereoRH);
-    delete adjustedMonoRH;
-    delete adjustedStereoRH;
+    // i don't like the 'new'
+    SiTrackerGSMatchedRecHit2D rV(position, error, *gluedDet,
+				  monoRH->simtrackId(), 
+				  true, adjustedMonoRH, adjustedStereoRH);
     return rV;
   }
   
@@ -164,10 +144,10 @@ GSRecHitMatcher::project(const GeomDetUnit *det,
 
 
 
-SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::projectOnly( const SiTrackerGSRecHit2D *monoRH,
-						    const GeomDet * monoDet,
-						    const GluedGeomDet* gluedDet,
-					            LocalVector& ldir) const
+SiTrackerGSMatchedRecHit2D GSRecHitMatcher::projectOnly( const SiTrackerGSRecHit2D *monoRH,
+							 const GeomDet * monoDet,
+							 const GluedGeomDet* gluedDet,
+							 LocalVector& ldir) const
 {
   LocalPoint position(monoRH->localPosition().x(), 0.,0.);
   const BoundPlane& gluedPlane = gluedDet->surface();
@@ -198,39 +178,27 @@ SiTrackerGSMatchedRecHit2D * GSRecHitMatcher::projectOnly( const SiTrackerGSRecH
   //Added by DAO to make sure y positions are zero and correct Mono or stereo Det is filled.
   
   auto otherDet = isMono ? gluedDet->stereoDet() : gluedDet->monoDet();
-  //Good for debugging.
-  //std::cout << "The monoDet = " << monoDet->geographicalId() << ". The gluedMonoDet = " << gluedMonoDet->geographicalId() << ". The gluedStereoDet = " << gluedStereoDet->geographicalId()
-  //    << ". isMono = " << isMono << ". isStereo = " << isStereo <<"." << std::endl;
-
-  SiTrackerGSRecHit2D *adjustedRH = new SiTrackerGSRecHit2D(LocalPoint(monoRH->localPosition().x(),0,0),
-							    monoRH->localPositionError(),
-							    *monoRH->det(),
-							    monoRH->simhitId(),
-							    monoRH->simtrackId(),
-							    monoRH->eeId(),
-							    monoRH->cluster(),
-							    monoRH->simMultX(),
-							    monoRH->simMultY()
-							    );
+  SiTrackerGSRecHit2D adjustedRH(LocalPoint(monoRH->localPosition().x(),0,0),
+				 monoRH->localPositionError(),
+				 *monoRH->det(),
+				 monoRH->simtrackId());
   
   //DAO: Not quite sure what to do about the cluster ref, so I will fill it with the monoRH for now...
-  SiTrackerGSRecHit2D *otherRH = new SiTrackerGSRecHit2D(LocalPoint(-10000,-10000,-10000), LocalError(0,0,0),*otherDet, 0,0,0,monoRH->cluster(),0,0);
+  SiTrackerGSRecHit2D otherRH(LocalPoint(-10000,-10000,-10000), LocalError(0,0,0),*otherDet, -1);//??
   if ((isMono && isStereo)||(!isMono&&!isStereo)) throw cms::Exception("GSRecHitMatcher") << "Something wrong with DetIds.";
   else if (isMono) {
-    SiTrackerGSMatchedRecHit2D *rV= new SiTrackerGSMatchedRecHit2D(projectedHitPos, rotatedError, *gluedDet, 
-								   monoRH->simhitId(),  monoRH->simtrackId(), monoRH->eeId(), monoRH->cluster(),
-								   monoRH->simMultX(), monoRH->simMultY(), false, adjustedRH, otherRH);
-    delete adjustedRH;
-    delete otherRH;
+    // i don't like the new
+    SiTrackerGSMatchedRecHit2D rV(projectedHitPos, rotatedError, *gluedDet, 
+				  monoRH->simtrackId(),
+				  false, adjustedRH, otherRH);
     return rV;
   }
   
   else{
-    SiTrackerGSMatchedRecHit2D *rV=new SiTrackerGSMatchedRecHit2D(projectedHitPos, rotatedError, *gluedDet, 
-								 monoRH->simhitId(),  monoRH->simtrackId(), monoRH->eeId(), monoRH->cluster(),
-								 monoRH->simMultX(), monoRH->simMultY(), false, otherRH, adjustedRH);
-    delete adjustedRH;
-    delete otherRH;
+    // i don't like the new
+    SiTrackerGSMatchedRecHit2D rV(projectedHitPos, rotatedError, *gluedDet, 
+				  monoRH->simtrackId(),
+				  false, otherRH, adjustedRH);
     return rV;
   }
 }


### PR DESCRIPTION
- remove obsolete class members from SiTrackerGS*RecHits
- proper initialisation of BaseTrackerRecHit::qualWord_
- remove memory leak inside GSRecHitMatcher::projectOnly and GSRecHitMatcher::match
- remove obsolete products from SiTrackerGaussianSmearingRecHitConverter

replaces #9643 

Automatically ported from CMSSW_7_5_X #9653 (original by @lveldere).
