### PR TITLE
Fix of path names in HLT Higgs validation code - 75X

### DIFF
--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -7,7 +7,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH"), 
     histDirectory  = cms.string("HLT/Higgs"),
     
-    # -- The instance name of the reco::GenParticles collection
+    # -- The instance name of the reco::GenParticles collection -
     genParticleLabel = cms.string("genParticles"),
     
     # -- The instance name of the reco::GenJets collection

--- a/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
+++ b/HLTriggerOffline/Higgs/python/hltHiggsValidator_cfi.py
@@ -7,7 +7,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
     analysis       = cms.vstring("HWW", "HZZ", "Hgg", "Htaunu", "H2tau", "VBFHbb_0btag", "VBFHbb_1btag", "VBFHbb_2btag",  "ZnnHbb","DoubleHinTaus","HiggsDalitz","X4b","TTHbbej","AHttH"), 
     histDirectory  = cms.string("HLT/Higgs"),
     
-    # -- The instance name of the reco::GenParticles collection -
+    # -- The instance name of the reco::GenParticles collection 
     genParticleLabel = cms.string("genParticles"),
     
     # -- The instance name of the reco::GenJets collection
@@ -276,7 +276,7 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     ZnnHbb = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_BTagCSV0p7_v",
+            "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_BTagCSV0p72_v",
             "HLT_CaloMHTNoPU90_PFMET90_PFMHT90_IDTight_v"
             "HLT_PFMET120_PFMHT120_IDTight_v",
             "HLT_PFMET110_PFMHT110_IDTight_v",
@@ -293,10 +293,10 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     X4b  = cms.PSet( 
         hltPathsToCheck = cms.vstring(
-            "HLT_DoubleJet90_Double30_TripleCSV0p5_v",
-            "HLT_DoubleJet90_Double30_DoubleCSV0p5_v",
-            "HLT_QuadJet45_TripleCSV0p5_v",
-            "HLT_QuadJet45_DoubleCSV0p5_v",
+            "HLT_DoubleJet90_Double30_TripleBTagCSV0p67_v",
+            "HLT_DoubleJet90_Double30_DoubleBTagCSV0p67_v",
+            "HLT_QuadJet45_TripleBTagCSV0p67_v",
+            "HLT_QuadJet45_DoubleBTagCSV0p67_v",
             ),
         recJetLabel  = cms.string("ak4PFJetsCHS"),
         jetTagLabel  = cms.string("pfCombinedSecondaryVertexBJetTags"),
@@ -321,8 +321,8 @@ hltHiggsValidator = cms.EDAnalyzer("HLTHiggsValidator",
         ),
     AHttH  = cms.PSet(
         hltPathsToCheck = cms.vstring(
-            "HLT_PFHT450_SixJet40_PFBTagCSV_v",
-            "HLT_PFHT400_SixJet30_BTagCSV0p5_2PFBTagCSV_v",
+            "HLT_PFHT450_SixJet40_PFBTagCSV0p72_v",
+            "HLT_PFHT400_SixJet30_BTagCSV0p55_2PFBTagCSV0p72_v",
             "HLT_PFHT450_SixJet40_v",
             "HLT_PFHT400_SixJet30_v",
             ),


### PR DESCRIPTION
This PR fixes the trigger path names in the HLT validation code of Higgs group, accordingly to:
https://its.cern.ch/jira/browse/CMSHLT-405

Automatically ported from CMSSW_7_5_X #9618 (original by @silviodonato).
