### PR TITLE
bsunanda:Run2 hcx12 Correct double definitions

### DIFF
--- a/DataFormats/ForwardDetId/interface/HGCHEDetId.h
+++ b/DataFormats/ForwardDetId/interface/HGCHEDetId.h
@@ -1,4 +1,3 @@
-
 #ifndef DataFormats_ForwardDetId_HGCHEDetId_H
 #define DataFormats_ForwardDetId_HGCHEDetId_H 1
 

--- a/DataFormats/ForwardDetId/src/classes.h
+++ b/DataFormats/ForwardDetId/src/classes.h
@@ -4,3 +4,19 @@
 #include "DataFormats/ForwardDetId/interface/HGCalDetId.h"
 #include "DataFormats/ForwardDetId/interface/FastTimeDetId.h"
 
+namespace DataFormats_ForwardDetId {
+  struct dictionary {
+
+    //EE specific
+    HGCEEDetId anHGCEEDetId;
+
+    //HE specific
+    HGCHEDetId anHGCHEDetId;
+
+    //HGCal specific
+    HGCalDetId anHGCalDetId;
+
+    //FastTimer specific
+    FastTimeDetId anFastTimeDetId;
+  };
+}

--- a/DataFormats/HGCDigi/src/classes.h
+++ b/DataFormats/HGCDigi/src/classes.h
@@ -7,7 +7,6 @@ namespace DataFormats_HGCDigi {
     std::vector<HGCSample> vHGCsample;
 
     //EE specific
-    HGCEEDetId anHGCEEDetId;
     HGCDataFrame<HGCEEDetId,HGCSample> anHGCEEDataFrame;
     std::vector<HGCDataFrame<HGCEEDetId,HGCSample> > vHGCEEDataFrames;
     edm::SortedCollection< HGCDataFrame<HGCEEDetId,HGCSample> > scHGCEEDataFrames;
@@ -16,7 +15,6 @@ namespace DataFormats_HGCDigi {
     edm::Wrapper<HGCEEDigiCollection> wdcHGCEE;
 
     //HE specific
-    HGCHEDetId anHGCHEDetId;
     HGCDataFrame<HGCHEDetId,HGCSample> anHGCHEDataFrame;
     std::vector<HGCDataFrame<HGCHEDetId,HGCSample> > vHGCHEDataFrames;
     edm::SortedCollection< HGCDataFrame<HGCHEDetId,HGCSample> > scHGCHEDataFrames;

--- a/DataFormats/HGCDigi/src/classes_def.xml
+++ b/DataFormats/HGCDigi/src/classes_def.xml
@@ -3,7 +3,6 @@
    <class name="std::vector<HGCSample>"/>
 
    <!-- EE specific -->
-   <!-- HGCEEDetId is provided by DataFormats/ForwardDetId -->
    <class name="HGCDataFrame<HGCEEDetId,HGCSample>"/>
    <class name="std::vector<HGCDataFrame<HGCEEDetId,HGCSample> >"/>
    <class name="edm::SortedCollection<HGCDataFrame<HGCEEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCEEDetId,HGCSample> > >"/>
@@ -11,7 +10,6 @@
    <class name="edm::Wrapper<HGCEEDigiCollection>"/>
 
    <!-- HE specific -->
-   <!-- HGCHEDetId is provided by DataFormats/ForwardDetId -->
    <class name="HGCDataFrame<HGCHEDetId,HGCSample>"/>
    <class name="std::vector<HGCDataFrame<HGCHEDetId,HGCSample> >"/>
    <class name="edm::SortedCollection<HGCDataFrame<HGCHEDetId,HGCSample>, edm::StrictWeakOrdering<HGCDataFrame<HGCHEDetId,HGCSample> > >"/>


### PR DESCRIPTION
Remove double definitions of some of the DetId's in the Digi definitions
Automatically ported from CMSSW_7_5_X #9461 (original by @bsunanda).
