### PR TITLE
Tracker Descope Scenarios LHCCNoDefect

### DIFF
--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -31,7 +31,8 @@ upgradeKeys=['2017',
              'Extended2023HGCalMuonPandora',
              'Extended2023HGCalMuonPandoraPU',
              'Extended2023SHCalNoTaperFast',
-             'Extended2023HGCalNoExtPix'
+             'Extended2023HGCalNoExtPix',
+	     'BE5DPixel10DLHCCNoDefect',
          ]
 
 
@@ -62,7 +63,8 @@ upgradeGeoms={ '2017' : 'Extended2017',
                'Extended2023HGCalV4' : 'Extended2023HGCalV4Muon,Extended2023HGCalV4MuonReco',
                'Extended2023HGCalMuonPandora' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
                'Extended2023SHCalNoTaperFast' : 'Extended2023SHCalNoTaper,Extended2023SHCalNoTaperReco',
-               'Extended2023HGCalNoExtPix' : 'Extended2023HGCalNoExtPix'
+               'Extended2023HGCalNoExtPix' : 'Extended2023HGCalNoExtPix',
+               'BE5DPixel10DLHCCNoDefect' : 'ExtendedPhase2TkBE5DPixel10DLHCC'
                }
 upgradeGTs={ '2017' : 'auto:upgrade2017',
              '2019' : 'auto:upgrade2019',
@@ -91,7 +93,8 @@ upgradeGTs={ '2017' : 'auto:upgrade2017',
              'Extended2023HGCalV4' : 'auto:upgradePLS3',
              'Extended2023HGCalMuonPandora' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
              'Extended2023SHCalNoTaperFast' : 'auto:upgradePLS3',
-             'Extended2023HGCalNoExtPix' : 'auto:upgradePLS3'
+             'Extended2023HGCalNoExtPix' : 'auto:upgradePLS3',
+             'BE5DPixel10DLHCCNoDefect' : 'auto:upgradePLS3'
              }
 upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2017',
                  '2019' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2019',
@@ -120,7 +123,8 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'Extended2023HGCalV4' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon',
                  'Extended2023HGCalMuonPandora' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuon',
                  'Extended2023SHCalNoTaperFast' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023SHCalTime',
-                 'Extended2023HGCalNoExtPix' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalPandoraMuonNoExtPix'
+                 'Extended2023HGCalNoExtPix' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalPandoraMuonNoExtPix',
+                 'BE5DPixel10DLHCCNoDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DLHCCNoDefect'
                  }
 
 upgradeFragments=['FourMuPt_1_200_cfi','SingleElectronPt10_cfi',
@@ -199,7 +203,9 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCalMuonPandora':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
                    'Extended2023HGCalMuonPandoraPU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
                    'Extended2023SHCalNoTaperFast' : ['GenSimHLBeamSpotfixFull','DigiFull','RecoFull','HARVESTFull'],
-                   'Extended2023HGCalNoExtPix' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL']
+                   'Extended2023HGCalNoExtPix' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
+                   'BE5DPixel10DLHCCNoDefect':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
+		   
                    }
 
 from  Configuration.PyReleaseValidation.relval_steps import Kby

--- a/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/combinedCustoms.py
@@ -5,6 +5,7 @@ from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE5D import customise a
 from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE5DPixel10D import customise as customiseBE5DPixel10D
 from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE5DPixel10DLHCC import customise as customiseBE5DPixel10DLHCC
 from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE5DPixel10DLHCCCooling import customise as customiseBE5DPixel10DLHCCCooling
+from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE5DPixel10DLHCCNoDefect import customise as customiseBE5DPixel10DLHCCNoDefect
 from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE5DPixel10Ddev import customise as customiseBE5DPixel10Ddev
 
 from SLHCUpgradeSimulations.Configuration.phase2TkCustomsBE import l1EventContent as customise_ev_BE
@@ -59,6 +60,14 @@ def cust_phase2_BE5DPixel10DLHCC(process):
 def cust_phase2_BE5DPixel10DLHCCCooling(process):
     process=customisePostLS1(process)
     process=customiseBE5DPixel10DLHCCCooling(process)
+    process=customise_HcalPhase2(process)
+    process=customise_ev_BE5DPixel10D(process)
+    process=jetCustoms.customise_jets(process)
+    return process
+
+def cust_phase2_BE5DPixel10DLHCCNoDefect(process):
+    process=customisePostLS1(process)
+    process=customiseBE5DPixel10DLHCCNoDefect(process)
     process=customise_HcalPhase2(process)
     process=customise_ev_BE5DPixel10D(process)
     process=jetCustoms.customise_jets(process)

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10DLHCCNoDefect.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10DLHCCNoDefect.py
@@ -1,0 +1,331 @@
+import FWCore.ParameterSet.Config as cms
+import SLHCUpgradeSimulations.Configuration.customise_PFlow as customise_PFlow
+
+#GEN-SIM so far...
+def customise(process):
+    if hasattr(process,'DigiToRaw'):
+        process=customise_DigiToRaw(process)
+    if hasattr(process,'RawToDigi'):
+        process=customise_RawToDigi(process)
+    n=0
+    if hasattr(process,'reconstruction') or hasattr(process,'dqmoffline_step'):
+        if hasattr(process,'mix'):
+            if hasattr(process.mix,'input'):
+                n=process.mix.input.nbPileupEvents.averageNumber.value()
+        else:
+            print 'phase1TkCustoms requires a --pileup option to cmsDriver to run the reconstruction/dqm'
+            print 'Please provide one!'
+            sys.exit(1)
+    if hasattr(process,'reconstruction'):
+        process=customise_Reco(process,float(n))
+    if hasattr(process,'digitisation_step'):
+        process=customise_Digi(process)
+    if hasattr(process,'dqmoffline_step'):
+        process=customise_DQM(process,n)
+    if hasattr(process,'dqmHarvesting'):
+        process=customise_harvesting(process)
+    if hasattr(process,'validation_step'):
+        process=customise_Validation(process,float(n))
+    process=customise_condOverRides(process)
+    
+    return process
+
+def customise_Digi(process):
+    process.mix.digitizers.pixel.MissCalibrate = False
+    process.mix.digitizers.pixel.LorentzAngle_DB = False
+    process.mix.digitizers.pixel.killModules = False
+    process.mix.digitizers.pixel.useDB = False
+    process.mix.digitizers.pixel.DeadModules_DB = False
+    process.mix.digitizers.pixel.NumPixelBarrel = cms.int32(10)
+    process.mix.digitizers.pixel.NumPixelEndcap = cms.int32(14)
+    process.mix.digitizers.pixel.ThresholdInElectrons_FPix = cms.double(2000.0)
+    process.mix.digitizers.pixel.ThresholdInElectrons_BPix = cms.double(2000.0)
+    process.mix.digitizers.pixel.ThresholdInElectrons_BPix_L1 = cms.double(2000.0)
+    process.mix.digitizers.pixel.thePixelColEfficiency_BPix4 = cms.double(0.999)
+    process.mix.digitizers.pixel.thePixelEfficiency_BPix4 = cms.double(0.999)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_BPix4 = cms.double(0.999)
+    process.mix.digitizers.pixel.thePixelColEfficiency_FPix3 = cms.double(0.999)
+    process.mix.digitizers.pixel.thePixelEfficiency_FPix3 = cms.double(0.999)
+    process.mix.digitizers.pixel.thePixelChipEfficiency_FPix3 = cms.double(0.999)
+    process.mix.digitizers.pixel.AddPixelInefficiencyFromPython = cms.bool(False)
+    process.mix.digitizers.strip.ROUList = cms.vstring("g4SimHitsTrackerHitsPixelBarrelLowTof",
+                         'g4SimHitsTrackerHitsPixelEndcapLowTof')
+    # Check if mergedtruth is in the sequence first, could be taken out depending on cmsDriver options
+    if hasattr(process.mix.digitizers,"mergedtruth") :    
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBLowTof"))
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIBHighTof"))
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBLowTof"))
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTOBHighTof"))
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECLowTof"))
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTECHighTof"))
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDLowTof"))
+        process.mix.digitizers.mergedtruth.simHitCollections.tracker.remove( cms.InputTag("g4SimHits","TrackerHitsTIDHighTof"))
+    
+    return process
+
+
+def customise_DigiToRaw(process):
+    process.digi2raw_step.remove(process.siPixelRawData)
+    process.digi2raw_step.remove(process.rpcpacker)
+    return process
+
+def customise_RawToDigi(process):
+    process.raw2digi_step.remove(process.siPixelDigis)
+    return process
+
+def customise_Reco(process,pileup):
+
+
+
+    #use with latest pixel geometry
+    process.ClusterShapeHitFilterESProducer.PixelShapeFile = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par')
+    # Need this line to stop error about missing siPixelDigis.
+    process.MeasurementTracker.inactivePixelDetectorLabels = cms.VInputTag()
+
+    # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
+    process.pixellayertriplets.layerList = cms.vstring('BPix1+BPix2+BPix3', 'BPix2+BPix3+BPix4',
+						       'BPix2+BPix3+FPix1_pos', 'BPix2+BPix3+FPix1_neg',
+						       'BPix1+BPix2+FPix1_pos', 'BPix1+BPix2+FPix1_neg',
+						       'BPix2+FPix1_pos+FPix2_pos', 'BPix2+FPix1_neg+FPix2_neg',
+						       'BPix1+FPix1_pos+FPix2_pos', 'BPix1+FPix1_neg+FPix2_neg',
+						       'BPix1+FPix2_pos+FPix3_pos', 'BPix1+FPix2_neg+FPix3_neg',
+						       'FPix1_pos+FPix2_pos+FPix3_pos', 'FPix1_neg+FPix2_neg+FPix3_neg',
+						       'FPix2_pos+FPix3_pos+FPix4_pos', 'FPix2_neg+FPix3_neg+FPix4_neg',
+						       'FPix3_pos+FPix4_pos+FPix5_pos', 'FPix3_neg+FPix4_neg+FPix5_neg',
+						       'FPix4_pos+FPix5_pos+FPix6_pos', 'FPix4_neg+FPix5_neg+FPix6_neg',
+						       'FPix5_pos+FPix6_pos+FPix7_pos', 'FPix5_neg+FPix6_neg+FPix7_neg',
+						       'FPix6_pos+FPix7_pos+FPix8_pos', 'FPix6_neg+FPix7_neg+FPix8_neg',
+						       'FPix6_pos+FPix7_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix9_neg')
+
+    # New tracking.  This is really ugly because it redefines globalreco and reconstruction.
+    # It can be removed if change one line in Configuration/StandardSequences/python/Reconstruction_cff.py
+    # from RecoTracker_cff.py to RecoTrackerPhase1PU140_cff.py
+
+    # remove all the tracking first
+    itIndex=process.globalreco.index(process.trackingGlobalReco)
+    grIndex=process.reconstruction.index(process.globalreco)
+
+    process.reconstruction.remove(process.globalreco)
+    process.globalreco.remove(process.iterTracking)
+    process.globalreco.remove(process.electronSeedsSeq)
+    process.reconstruction_fromRECO.remove(process.trackingGlobalReco)
+    del process.iterTracking
+    del process.ckftracks
+    del process.ckftracks_woBH
+    del process.ckftracks_wodEdX
+    del process.ckftracks_plus_pixelless
+    del process.trackingGlobalReco
+    del process.electronSeedsSeq
+    del process.InitialStep
+    del process.LowPtTripletStep
+    del process.PixelPairStep
+    del process.DetachedTripletStep
+    del process.MixedTripletStep
+    del process.PixelLessStep
+    del process.TobTecStep
+    del process.earlyGeneralTracks
+    del process.ConvStep
+    del process.earlyMuons
+    del process.muonSeededStepCore
+    del process.muonSeededStepExtra 
+    del process.muonSeededStep
+    del process.muonSeededStepDebug
+    
+    # add the correct tracking back in
+    process.load("RecoTracker.Configuration.RecoTrackerPhase2BEPixel10D_cff")
+
+    process.globalreco.insert(itIndex,process.trackingGlobalReco)
+    process.reconstruction.insert(grIndex,process.globalreco)
+    #Note process.reconstruction_fromRECO is broken
+    
+    # End of new tracking configuration which can be removed if new Reconstruction is used.
+
+
+    process.reconstruction.remove(process.castorreco)
+    process.reconstruction.remove(process.CastorTowerReco)
+    process.reconstruction.remove(process.ak7BasicJets)
+    process.reconstruction.remove(process.ak7CastorJetID)
+
+    #the quadruplet merger configuration     
+    process.load("RecoPixelVertexing.PixelTriplets.quadrupletseedmerging_cff")
+    process.pixelseedmergerlayers.BPix.TTRHBuilder = cms.string("PixelTTRHBuilderWithoutAngle" )
+    process.pixelseedmergerlayers.BPix.HitProducer = cms.string("siPixelRecHits" )
+    process.pixelseedmergerlayers.FPix.TTRHBuilder = cms.string("PixelTTRHBuilderWithoutAngle" )
+    process.pixelseedmergerlayers.FPix.HitProducer = cms.string("siPixelRecHits" )    
+    process.pixelseedmergerlayers.layerList = cms.vstring('BPix1+BPix2+BPix3+BPix4',
+						       'BPix1+BPix2+BPix3+FPix1_pos','BPix1+BPix2+BPix3+FPix1_neg',
+						       'BPix1+BPix2+FPix1_pos+FPix2_pos', 'BPix1+BPix2+FPix1_neg+FPix2_neg',
+						       'BPix1+FPix1_pos+FPix2_pos+FPix3_pos', 'BPix1+FPix1_neg+FPix2_neg+FPix3_neg',
+						       'FPix1_pos+FPix2_pos+FPix3_pos+FPix4_pos', 'FPix1_neg+FPix2_neg+FPix3_neg+FPix4_neg',
+						       'FPix2_pos+FPix3_pos+FPix4_pos+FPix5_pos', 'FPix2_neg+FPix3_neg+FPix4_neg+FPix5_neg',
+						       'FPix3_pos+FPix4_pos+FPix5_pos+FPix6_pos', 'FPix3_neg+FPix4_neg+FPix5_neg+FPix6_pos',
+						       'FPix4_pos+FPix5_pos+FPix6_pos+FPix7_pos', 'FPix4_neg+FPix5_neg+FPix6_neg+FPix7_neg',
+						       'FPix5_pos+FPix6_pos+FPix7_pos+FPix8_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix8_neg',
+						       'FPix5_pos+FPix6_pos+FPix7_pos+FPix9_pos', 'FPix5_neg+FPix6_neg+FPix7_neg+FPix9_neg',
+						       'FPix6_pos+FPix7_pos+FPix8_pos+FPix9_pos', 'FPix6_neg+FPix7_neg+FPix8_neg+FPix9_neg')
+    
+    
+    # Need these until pixel templates are used
+    process.load("SLHCUpgradeSimulations.Geometry.recoFromSimDigis_cff")
+    # PixelCPEGeneric #
+    process.PixelCPEGenericESProducer.Upgrade = cms.bool(True)
+    process.PixelCPEGenericESProducer.UseErrorsFromTemplates = cms.bool(False)
+    process.PixelCPEGenericESProducer.LoadTemplatesFromDB = cms.bool(False)
+    process.PixelCPEGenericESProducer.TruncatePixelCharge = cms.bool(False)
+    process.PixelCPEGenericESProducer.IrradiationBiasCorrection = False
+    process.PixelCPEGenericESProducer.DoCosmics = False
+    # CPE for other steps
+    process.siPixelRecHits.CPE = cms.string('PixelCPEGeneric')
+    # Turn of template use in tracking (iterative steps handled inside their configs)
+    process.mergedDuplicateTracks.TTRHBuilder = 'WithTrackAngle'
+    process.ctfWithMaterialTracks.TTRHBuilder = 'WithTrackAngle'
+    process.muonSeededSeedsInOut.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+    process.muonSeededTracksInOut.TTRHBuilder=cms.string('WithTrackAngle')
+    process.muons1stStep.TrackerKinkFinderParameters.TrackerRecHitBuilder=cms.string('WithTrackAngle')
+    process.regionalCosmicTracks.TTRHBuilder=cms.string('WithTrackAngle')
+    process.cosmicsVetoTracksRaw.TTRHBuilder=cms.string('WithTrackAngle')
+    # End of pixel template needed section
+    
+    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.layerList  = cms.vstring('BPix9+BPix8')  # Optimize later
+    process.regionalCosmicTrackerSeeds.OrderedHitsFactoryPSet.LayerPSet.BPix = cms.PSet(
+        HitProducer = cms.string('siPixelRecHits'),
+        hitErrorRZ = cms.double(0.006),
+        useErrorsFromParam = cms.bool(True),
+        TTRHBuilder = cms.string('TTRHBuilderWithoutAngle4PixelPairs'),
+        skipClusters = cms.InputTag("pixelPairStepClusters"),
+        hitErrorRPhi = cms.double(0.0027)
+    )
+    # Make pixelTracks use quadruplets
+    process.pixelTracks.SeedMergerPSet = cms.PSet(
+        layerListName = cms.string('PixelSeedMergerQuadruplets'),
+        addRemainingTriplets = cms.bool(False),
+        mergeTriplets = cms.bool(True),
+        ttrhBuilderLabel = cms.string('PixelTTRHBuilderWithoutAngle')
+        )
+    process.pixelTracks.OrderedHitsFactoryPSet.GeneratorPSet.maxElement = cms.uint32(0)
+    process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
+    process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
+    process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
+
+    # Particle flow needs to know that the eta range has increased, for
+    # when linking tracks to HF clusters
+    process=customise_PFlow.customise_extendedTrackerBarrel( process )
+
+    return process
+
+def customise_condOverRides(process):
+    process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_BarrelEndcap5DPixel10DLHCCNoDefect_cff')
+    process.trackerNumberingSLHCGeometry.layerNumberPXB = cms.uint32(20)
+    process.trackerTopologyConstants.pxb_layerStartBit = cms.uint32(20)
+    process.trackerTopologyConstants.pxb_ladderStartBit = cms.uint32(12)
+    process.trackerTopologyConstants.pxb_moduleStartBit = cms.uint32(2)
+    process.trackerTopologyConstants.pxb_layerMask = cms.uint32(15)
+    process.trackerTopologyConstants.pxb_ladderMask = cms.uint32(255)
+    process.trackerTopologyConstants.pxb_moduleMask = cms.uint32(1023)
+    process.trackerTopologyConstants.pxf_diskStartBit = cms.uint32(18)
+    process.trackerTopologyConstants.pxf_bladeStartBit = cms.uint32(12)
+    process.trackerTopologyConstants.pxf_panelStartBit = cms.uint32(10)
+    process.trackerTopologyConstants.pxf_moduleMask = cms.uint32(255)
+    return process
+
+
+def l1EventContent(process):
+    #extend the event content
+
+    alist=['RAWSIM','FEVTDEBUG','FEVTDEBUGHLT','GENRAW','RAWSIMHLT','FEVT']
+    for a in alist:
+        b=a+'output'
+        if hasattr(process,b):
+
+            getattr(process,b).outputCommands.append('keep *_TTClustersFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTStubsFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTTracksFromPixelDigis_*_*')
+
+            getattr(process,b).outputCommands.append('keep *_TTClusterAssociatorFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTStubAssociatorFromPixelDigis_*_*')
+            getattr(process,b).outputCommands.append('keep *_TTTrackAssociatorFromPixelDigis_*_*')
+
+            getattr(process,b).outputCommands.append('drop PixelDigiSimLinkedmDetSetVector_mix_*_*')
+            getattr(process,b).outputCommands.append('drop PixelDigiedmDetSetVector_mix_*_*')
+
+            getattr(process,b).outputCommands.append('keep *_simSiPixelDigis_*_*')
+
+    return process
+
+def customise_DQM(process,pileup):
+    # We cut down the number of iterative tracking steps
+#    process.dqmoffline_step.remove(process.TrackMonStep3)
+#    process.dqmoffline_step.remove(process.TrackMonStep4)
+#    process.dqmoffline_step.remove(process.TrackMonStep5)
+#    process.dqmoffline_step.remove(process.TrackMonStep6)
+    			    #The following two steps were removed
+                            #process.PixelLessStep*
+                            #process.TobTecStep*
+#    process.dqmoffline_step.remove(process.muonAnalyzer)
+    process.dqmoffline_step.remove(process.jetMETAnalyzer)
+#    process.dqmoffline_step.remove(process.TrackMonStep9)
+#    process.dqmoffline_step.remove(process.TrackMonStep10)
+#    process.dqmoffline_step.remove(process.PixelTrackingRecHitsValid)
+
+    #put isUpgrade flag==true
+    process.SiPixelRawDataErrorSource.isUpgrade = cms.untracked.bool(True)
+    process.SiPixelDigiSource.isUpgrade = cms.untracked.bool(True)
+    process.SiPixelClusterSource.isUpgrade = cms.untracked.bool(True)
+    process.SiPixelRecHitSource.isUpgrade = cms.untracked.bool(True)
+    process.SiPixelTrackResidualSource.isUpgrade = cms.untracked.bool(True)
+    process.SiPixelHitEfficiencySource.isUpgrade = cms.untracked.bool(True)
+    
+    from DQM.TrackingMonitor.customizeTrackingMonitorSeedNumber import customise_trackMon_IterativeTracking_PHASE1PU140
+    process=customise_trackMon_IterativeTracking_PHASE1PU140(process)
+    process.dqmoffline_step.remove(process.Phase1Pu70TrackMonStep2)
+    process.dqmoffline_step.remove(process.Phase1Pu70TrackMonStep4)
+    if hasattr(process,"globalrechitsanalyze") : # Validation takes this out if pileup is more than 30
+       process.globalrechitsanalyze.ROUList = cms.vstring(
+          'g4SimHitsTrackerHitsPixelBarrelLowTof', 
+          'g4SimHitsTrackerHitsPixelBarrelHighTof', 
+          'g4SimHitsTrackerHitsPixelEndcapLowTof', 
+          'g4SimHitsTrackerHitsPixelEndcapHighTof')
+    return process
+
+def customise_Validation(process,pileup):
+    process.validation_step.remove(process.PixelTrackingRecHitsValid)
+    process.validation_step.remove(process.stripRecHitsValid)
+    process.validation_step.remove(process.trackerHitsValid)
+    process.validation_step.remove(process.StripTrackingRecHitsValid)
+    # We don't run the HLT
+    process.validation_step.remove(process.HLTSusyExoVal)
+    process.validation_step.remove(process.hltHiggsValidator)
+    process.validation_step.remove(process.relvalMuonBits)
+    if pileup>30:
+        process.trackValidator.label=cms.VInputTag(cms.InputTag("cutsRecoTracksHp"))
+        process.tracksValidationSelectors = cms.Sequence(process.cutsRecoTracksHp)
+        process.globalValidation.remove(process.recoMuonValidation)
+        process.validation.remove(process.recoMuonValidation)
+        process.validation_preprod.remove(process.recoMuonValidation)
+        process.validation_step.remove(process.recoMuonValidation)
+        process.validation.remove(process.globalrechitsanalyze)
+        process.validation_prod.remove(process.globalrechitsanalyze)
+        process.validation_step.remove(process.globalrechitsanalyze)
+        process.validation.remove(process.stripRecHitsValid)
+        process.validation_step.remove(process.stripRecHitsValid)
+        process.validation_step.remove(process.StripTrackingRecHitsValid)
+        process.globalValidation.remove(process.vertexValidation)
+        process.validation.remove(process.vertexValidation)
+        process.validation_step.remove(process.vertexValidation)
+        process.mix.input.nbPileupEvents.averageNumber = cms.double(0.0)
+        process.mix.minBunch = cms.int32(0)
+        process.mix.maxBunch = cms.int32(0)
+
+    if hasattr(process,'simHitTPAssocProducer'):    
+        process.simHitTPAssocProducer.simHitSrc=cms.VInputTag(cms.InputTag("g4SimHits","TrackerHitsPixelBarrelLowTof"),
+                                                              cms.InputTag("g4SimHits","TrackerHitsPixelEndcapLowTof"))
+
+    return process
+
+def customise_harvesting(process):
+    process.dqmHarvesting.remove(process.jetMETDQMOfflineClient)
+    process.dqmHarvesting.remove(process.dataCertificationJetMET)
+    process.dqmHarvesting.remove(process.sipixelEDAClient)
+    process.dqmHarvesting.remove(process.sipixelCertification)
+    return (process)
+

--- a/SLHCUpgradeSimulations/Geometry/python/fakeConditions_BarrelEndcap5DPixel10DLHCCNoDefect_cff.py
+++ b/SLHCUpgradeSimulations/Geometry/python/fakeConditions_BarrelEndcap5DPixel10DLHCCNoDefect_cff.py
@@ -1,0 +1,47 @@
+import FWCore.ParameterSet.Config as cms
+
+siPixelFakeGainOfflineESSource = cms.ESSource("SiPixelFakeGainOfflineESSource",
+        file = 
+cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Pixel10D_LHCC/EmptyPixelSkimmedGeometry.txt')
+        )
+es_prefer_fake_gain = cms.ESPrefer("SiPixelFakeGainOfflineESSource","siPixelFakeGainOfflineESSource")
+
+siPixelFakeLorentzAngleESSource = cms.ESSource("SiPixelFakeLorentzAngleESSource",
+        file = 
+cms.FileInPath('SLHCUpgradeSimulations/Geometry/data/PhaseII/Pixel10D_LHCC/PixelSkimmedGeometry.txt')
+        )
+es_prefer_fake_lorentz = cms.ESPrefer("SiPixelFakeLorentzAngleESSource","siPixelFakeLorentzAngleESSource")
+
+
+from RecoVertex.BeamSpotProducer.BeamSpotFakeParameters_cfi import *
+BeamSpotFakeConditions.X0 = cms.double(0.0)
+BeamSpotFakeConditions.Y0 = cms.double(0.0)
+BeamSpotFakeConditions.Z0 = cms.double(0.0)
+BeamSpotFakeConditions.dxdz = cms.double(0.0)
+BeamSpotFakeConditions.dydz = cms.double(0.0)
+BeamSpotFakeConditions.sigmaZ = cms.double(5.3)
+BeamSpotFakeConditions.widthX = cms.double(0.015)
+BeamSpotFakeConditions.widthY = cms.double(0.015)
+BeamSpotFakeConditions.emittanceX = cms.double(0.)
+BeamSpotFakeConditions.emittanceY = cms.double(0.)
+BeamSpotFakeConditions.betaStar = cms.double(0.)
+BeamSpotFakeConditions.errorX0 = cms.double(0.00208)
+BeamSpotFakeConditions.errorY0 = cms.double(0.00208)
+BeamSpotFakeConditions.errorZ0 = cms.double(0.00508)
+BeamSpotFakeConditions.errordxdz = cms.double(0.0)
+BeamSpotFakeConditions.errordydz = cms.double(0.0)
+BeamSpotFakeConditions.errorSigmaZ = cms.double(0.060)
+BeamSpotFakeConditions.errorWidth = cms.double(0.0013)
+
+es_prefer_beamspot = cms.ESPrefer("BeamSpotFakeConditions","")
+
+from SimGeneral.TrackingAnalysis.trackingParticles_cfi import *
+mergedtruth.volumeRadius = cms.double(100.0)
+mergedtruth.volumeZ = cms.double(900.0)
+mergedtruth.discardOutVolume = cms.bool(True)
+
+
+#from Geometry.TrackerNumberingBuilder.pixelSLHCGeometryConstants_cfi import *
+from Geometry.TrackerGeometryBuilder.idealForDigiTrackerSLHCGeometry_cff import *
+
+


### PR DESCRIPTION
This PR is adding the reference scenario for the Tracker Descope Document : the usual layer 4 has been removed but no defects have been added ; This is to have a good reference to compare for producing the results for the scope document.
Since relvals will be produced, I have added the scenario is runthematrix too - It can be run with the following number : 164XX
