### PR TITLE
Disable private unit tests in LumiProducer

### DIFF
--- a/RecoLuminosity/LumiProducer/test/BuildFile.xml
+++ b/RecoLuminosity/LumiProducer/test/BuildFile.xml
@@ -8,6 +8,7 @@
 </bin>
 
 <bin file="testWrite2LumiDB.cpp" name="testWrite2LumiDB">
+  <flags NO_TESTRUN="1"/>
   <use name="FWCore/PluginManager"/>
   <use name="RecoLuminosity/LumiProducer"/>
 </bin>
@@ -32,8 +33,10 @@
 </bin>
 
 <bin file="testBoostRegex.cpp" name="testBoostRegex">
+  <flags NO_TESTRUN="1"/>
   <use name="boost"/>
 </bin>
+
 <bin file="validation/populateDummy2LumiDB.cpp" name="populateDummy2LumiDB">
   <flags NO_TESTRUN="1"/>
   <use name="FWCore/PluginManager"/>


### PR DESCRIPTION
Took some unit tests in LumiProducer which were intended for only private tests and disabled them in test/BuildFile.xml.
