### PR TITLE
Adding v3 of 25ns, v4 of 50ns and lowPU L1T menus (74X)

### DIFF
--- a/L1Trigger/Configuration/python/customise_overwriteL1Menu.py
+++ b/L1Trigger/Configuration/python/customise_overwriteL1Menu.py
@@ -100,6 +100,17 @@ def L1Menu_Collisions2015_50ns_v3(process):
     return process
 
 
+def L1Menu_Collisions2015_50ns_v4(process):
+    process.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
+    process.l1GtTriggerMenuXml.TriggerMenuLuminosity = 'startup'
+    process.l1GtTriggerMenuXml.DefXmlFile            = 'L1Menu_Collisions2015_50nsGct_v4_L1T_Scales_20141121.xml'
+
+    process.load( 'L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMenuConfig_cff' )
+    process.es_prefer_l1GtParameters = cms.ESPrefer( 'L1GtTriggerMenuXmlProducer', 'l1GtTriggerMenuXml' )
+
+    return process
+
+
 def L1Menu_Collisions2015_lowPU_v1(process):
     process.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
     process.l1GtTriggerMenuXml.TriggerMenuLuminosity = 'startup'
@@ -126,6 +137,17 @@ def L1Menu_Collisions2015_lowPU_v3(process):
     process.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
     process.l1GtTriggerMenuXml.TriggerMenuLuminosity = 'startup'
     process.l1GtTriggerMenuXml.DefXmlFile            = 'L1Menu_Collisions2015_lowPU_v3_L1T_Scales_20141121.xml'
+
+    process.load( 'L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMenuConfig_cff' )
+    process.es_prefer_l1GtParameters = cms.ESPrefer( 'L1GtTriggerMenuXmlProducer', 'l1GtTriggerMenuXml' )
+
+    return process
+
+
+def L1Menu_Collisions2015_lowPU_v4(process):
+    process.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
+    process.l1GtTriggerMenuXml.TriggerMenuLuminosity = 'startup'
+    process.l1GtTriggerMenuXml.DefXmlFile            = 'L1Menu_Collisions2015_lowPU_v4_L1T_Scales_20141121.xml'
 
     process.load( 'L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMenuConfig_cff' )
     process.es_prefer_l1GtParameters = cms.ESPrefer( 'L1GtTriggerMenuXmlProducer', 'l1GtTriggerMenuXml' )

--- a/L1Trigger/Configuration/python/customise_overwriteL1Menu.py
+++ b/L1Trigger/Configuration/python/customise_overwriteL1Menu.py
@@ -45,6 +45,17 @@ def L1Menu_Collisions2015_25ns_v2(process):
     return process
 
 
+def L1Menu_Collisions2015_25ns_v3(process):
+    process.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
+    process.l1GtTriggerMenuXml.TriggerMenuLuminosity = 'startup'
+    process.l1GtTriggerMenuXml.DefXmlFile            = 'L1Menu_Collisions2015_25nsStage1_v3_L1T_Scales_20141121_Imp0_0x1031.xml'
+
+    process.load( 'L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMenuConfig_cff' )
+    process.es_prefer_l1GtParameters = cms.ESPrefer( 'L1GtTriggerMenuXmlProducer', 'l1GtTriggerMenuXml' )
+
+    return process
+
+
 def L1Menu_Collisions2015_50ns_v0(process):
     process.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
     process.l1GtTriggerMenuXml.TriggerMenuLuminosity = 'startup'

--- a/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_25nsStage1_v3_L1T_Scales_20141121_Imp0_0x1031.xml
+++ b/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_25nsStage1_v3_L1T_Scales_20141121_Imp0_0x1031.xml
@@ -1,0 +1,6437 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<def>
+<header>
+    <MenuInterface>L1Menu_Collisions2015_25nsStage1_v3</MenuInterface>
+    <MenuInterface_CreationDate>2014-07-10</MenuInterface_CreationDate>
+    <MenuInterface_CreationAuthor>Vasile Mihai Ghete, Takashi Matsushita</MenuInterface_CreationAuthor>
+    <MenuInterface_Description>L1 menu for pp data taking 2015, Stage 1 version, integrated MHT/HT, IsoTau</MenuInterface_Description>
+    <Menu_CreationDate>2015-03-19T13:56:07.000000Z</Menu_CreationDate>
+    <Menu_CreationAuthor>Vasile Mihai Ghete, Takashi Matsushita</Menu_CreationAuthor>
+    <Menu_Description>L1 menu for pp data taking 2015</Menu_Description>
+    <AlgImplementation>Imp0</AlgImplementation>
+    <ScaleDbKey>L1T_Scales_20141121</ScaleDbKey>
+</header>
+  <condition_chip_1>
+    <prealgos>
+      <L1_DoubleEG_15_10 algAlias="L1_DoubleEG_15_10">
+        DoubleIsoEG_0x0F_0x0A OR DoubleNoIsoEG_0x0F_0x0A OR ( SingleIsoEG_0x0F AND SingleNoIsoEG_0x0A ) OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x0F )
+        <output_pin nr="6" pin="a" />
+      </L1_DoubleEG_15_10>
+      <L1_DoubleEG_20_10_1LegIso algAlias="L1_DoubleEG_20_10_1LegIso">
+        DoubleIsoEG_0x14_0x0A OR ( SingleIsoEG_0x14 AND SingleNoIsoEG_0x0A ) OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x14 )
+        <output_pin nr="8" pin="a" />
+      </L1_DoubleEG_20_10_1LegIso>
+      <L1_DoubleEG_22_10 algAlias="L1_DoubleEG_22_10">
+        DoubleIsoEG_0x16_0x0A OR DoubleNoIsoEG_0x16_0x0A OR ( SingleIsoEG_0x16 AND SingleNoIsoEG_0x0A ) OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x16 )
+        <output_pin nr="7" pin="a" />
+      </L1_DoubleEG_22_10>
+      <L1_DoubleIsoTau36er algAlias="L1_DoubleIsoTau36er">
+        ( HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17 AND HfRingEtSums_Ind1_0x04_IsoTau_Eta2p17 ) OR ( HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17 AND HfRingEtSums_Ind2_0x04_IsoTau_Eta2p17 ) OR ( HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17 AND HfRingEtSums_Ind3_0x04_IsoTau_Eta2p17 )
+        <output_pin nr="22" pin="a" />
+      </L1_DoubleIsoTau36er>
+      <L1_DoubleIsoTau40er algAlias="L1_DoubleIsoTau40er">
+        ( HfRingEtSums_Ind0_0x05_IsoTau_Eta2p17 AND HfRingEtSums_Ind1_0x05_IsoTau_Eta2p17 ) OR ( HfRingEtSums_Ind0_0x05_IsoTau_Eta2p17 AND HfRingEtSums_Ind2_0x05_IsoTau_Eta2p17 ) OR ( HfRingEtSums_Ind0_0x05_IsoTau_Eta2p17 AND HfRingEtSums_Ind3_0x05_IsoTau_Eta2p17 )
+        <output_pin nr="23" pin="a" />
+      </L1_DoubleIsoTau40er>
+      <L1_DoubleIsoTau44er algAlias="L1_DoubleIsoTau44er">
+        ( HfRingEtSums_Ind0_0x06_IsoTau_Eta2p17 AND HfRingEtSums_Ind1_0x06_IsoTau_Eta2p17 ) OR ( HfRingEtSums_Ind0_0x06_IsoTau_Eta2p17 AND HfRingEtSums_Ind2_0x06_IsoTau_Eta2p17 ) OR ( HfRingEtSums_Ind0_0x06_IsoTau_Eta2p17 AND HfRingEtSums_Ind3_0x06_IsoTau_Eta2p17 )
+        <output_pin nr="25" pin="a" />
+      </L1_DoubleIsoTau44er>
+      <L1_DoubleMu0_Eta1p6_WdEta18 algAlias="L1_DoubleMu0_Eta1p6_WdEta18">
+        DoubleMu_wsc_0x01_Eta1p6_WdEta18
+        <output_pin nr="19" pin="a" />
+      </L1_DoubleMu0_Eta1p6_WdEta18>
+      <L1_DoubleMu0_Eta1p6_WdEta18_OS algAlias="L1_DoubleMu0_Eta1p6_WdEta18_OS">
+        DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS
+        <output_pin nr="28" pin="a" />
+      </L1_DoubleMu0_Eta1p6_WdEta18_OS>
+      <L1_DoubleMu_10_0_WdEta18 algAlias="L1_DoubleMu_10_0_WdEta18">
+        DoubleMu_wsc_0x0D_0x01_WdEta18
+        <output_pin nr="31" pin="a" />
+      </L1_DoubleMu_10_0_WdEta18>
+      <L1_DoubleMu_12_5 algAlias="L1_DoubleMu_12_5">
+        DoubleMu_0x0E_0x09_HighQ
+        <output_pin nr="29" pin="a" />
+      </L1_DoubleMu_12_5>
+      <L1_DoubleS1JetC100 algAlias="L1_DoubleJetC100">
+        DoubleCenJet_0x19
+        <output_pin nr="15" pin="a" />
+      </L1_DoubleS1JetC100>
+      <L1_DoubleS1JetC32_WdPhi7_HTT125 algAlias="L1_DoubleJetC32_WdPhi7_HTT125">
+        DoubleCenJet_wsc_0x08_WdPhi7 AND HTT_0x0FA
+        <output_pin nr="11" pin="a" />
+      </L1_DoubleS1JetC32_WdPhi7_HTT125>
+      <L1_DoubleS1JetC56_ETM60 algAlias="L1_DoubleJetC56_ETM60">
+        DoubleCenJet_0x0E AND ETM_0x078
+        <output_pin nr="18" pin="a" />
+      </L1_DoubleS1JetC56_ETM60>
+      <L1_DoubleS1JetC60_ETM60 algAlias="L1_DoubleJetC60_ETM60">
+        DoubleCenJet_0x0F AND ETM_0x078
+        <output_pin nr="10" pin="a" />
+      </L1_DoubleS1JetC60_ETM60>
+      <L1_ETM60 algAlias="L1_ETM60">
+        ETM_0x078
+        <output_pin nr="14" pin="a" />
+      </L1_ETM60>
+      <L1_ETM60_NotS1Jet52WdPhi2 algAlias="L1_ETM60_NotJet52WdPhi2">
+        ETM_0x078 AND ( NOT Corr_ETM_CenJet_0x78_0x0D_WdPhi2 ) AND ( NOT Corr_ETM_ForJet_0x78_0x0D_WdPhi2 )
+        <output_pin nr="20" pin="a" />
+      </L1_ETM60_NotS1Jet52WdPhi2>
+      <L1_ETM70_NotS1Jet52WdPhi2 algAlias="L1_ETM70_NotJet52WdPhi2">
+        ETM_0x08C AND ( NOT Corr_ETM_CenJet_0x8C_0x0D_WdPhi2 ) AND ( NOT Corr_ETM_ForJet_0x8C_0x0D_WdPhi2 )
+        <output_pin nr="21" pin="a" />
+      </L1_ETM70_NotS1Jet52WdPhi2>
+      <L1_Mu0er_ETM55 algAlias="L1_Mu0er_ETM55">
+        SingleMu_0x01_Eta2p1 AND ETM_0x06E
+        <output_pin nr="9" pin="a" />
+      </L1_Mu0er_ETM55>
+      <L1_Mu16er_IsoTau36er algAlias="L1_Mu16er_IsoTau36er">
+        SingleMu_0x10_Eta2p1 AND ( HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17 OR HfRingEtSums_Ind1_0x04_IsoTau_Eta2p17 OR HfRingEtSums_Ind2_0x04_IsoTau_Eta2p17 OR HfRingEtSums_Ind3_0x04_IsoTau_Eta2p17 )
+        <output_pin nr="1" pin="a" />
+      </L1_Mu16er_IsoTau36er>
+      <L1_QuadMu0 algAlias="L1_QuadMu0">
+        QuadMu_0x01
+        <output_pin nr="26" pin="a" />
+      </L1_QuadMu0>
+      <L1_QuadS1JetC60 algAlias="L1_QuadJetC60">
+        QuadCenJet_0x0F
+        <output_pin nr="16" pin="a" />
+      </L1_QuadS1JetC60>
+      <L1_S1Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1 algAlias="L1_Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1">
+        DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23 AND ( Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1 OR Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1 )
+        <output_pin nr="12" pin="a" />
+      </L1_S1Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1>
+      <L1_S1Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1 algAlias="L1_Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1">
+        ( Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3 OR Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3 ) AND ( Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1 OR Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1 )
+        <output_pin nr="13" pin="a" />
+      </L1_S1Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1>
+      <L1_SingleMu18er algAlias="L1_SingleMu18er">
+        SingleMu_0x11_Eta2p1
+        <output_pin nr="27" pin="a" />
+      </L1_SingleMu18er>
+      <L1_SingleMuBeamHalo algAlias="L1_SingleMuBeamHalo">
+        SingleMu_0x01_BeamHalo
+        <output_pin nr="32" pin="a" />
+      </L1_SingleMuBeamHalo>
+      <L1_SingleS1JetC20_NotBptxOR algAlias="L1_SingleJetC20_NotBptxOR">
+        SingleCenJet_0x05 AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="17" pin="a" />
+      </L1_SingleS1JetC20_NotBptxOR>
+      <L1_TripleEG_14_10_8 algAlias="L1_TripleEG_14_10_8">
+        TripleIsoEG_0x0E_0x0A_0x08 OR TripleNoIsoEG_0x0E_0x0A_0x08 OR ( DoubleIsoEG_0x0E_0x0A AND SingleNoIsoEG_0x08 ) OR ( DoubleNoIsoEG_0x0E_0x0A AND SingleIsoEG_0x08 ) OR ( DoubleIsoEG_0x0E_0x08 AND SingleNoIsoEG_0x0A ) OR ( DoubleNoIsoEG_0x0E_0x08 AND SingleIsoEG_0x0A ) OR ( DoubleIsoEG_0x0A_0x08 AND SingleNoIsoEG_0x0E ) OR ( DoubleNoIsoEG_0x0A_0x08 AND SingleIsoEG_0x0E )
+        <output_pin nr="5" pin="a" />
+      </L1_TripleEG_14_10_8>
+      <L1_TripleMu0 algAlias="L1_TripleMu0">
+        TripleMu_0x01_HighQ
+        <output_pin nr="2" pin="a" />
+      </L1_TripleMu0>
+      <L1_TripleMu_5_5_3 algAlias="L1_TripleMu_5_5_3">
+        TripleMu_0x09_0x09_0x05
+        <output_pin nr="3" pin="a" />
+      </L1_TripleMu_5_5_3>
+      <L1_TripleS1Jet_92_76_64_VBF algAlias="L1_TripleJet_92_76_64_VBF">
+        TripleCenJet_0x17_0x13_0x10 OR ( DoubleCenJet_0x13_0x10 AND SingleForJet_0x17 ) OR ( DoubleCenJet_0x17_0x10 AND SingleForJet_0x13 )
+        <output_pin nr="24" pin="a" />
+      </L1_TripleS1Jet_92_76_64_VBF>
+    </prealgos>
+    <conditions>
+    <Corr_ETM_CenJet_0x78_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:CenJet" type="Type2cor">
+    <Corr_ETM_CenJet_0x78_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x78_0x0D_WdPhi2_ETM>
+    <Corr_ETM_CenJet_0x78_0x0D_WdPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x78_0x0D_WdPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_CenJet_0x78_0x0D_WdPhi2>
+    <Corr_ETM_CenJet_0x8C_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:CenJet" type="Type2cor">
+    <Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_ETM>
+    <Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_CenJet_0x8C_0x0D_WdPhi2>
+    <Corr_ETM_ForJet_0x78_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:ForJet" type="Type2cor">
+    <Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ETM>
+    <Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ForJet condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ForJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_ForJet_0x78_0x0D_WdPhi2>
+    <Corr_ETM_ForJet_0x8C_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:ForJet" type="Type2cor">
+    <Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ETM>
+    <Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ForJet condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ForJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_ForJet_0x8C_0x0D_WdPhi2>
+    <Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1 condition="CondCorrelation" particle="Mu:CenJet" type="Type2cor">
+    <Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_Mu>
+    <Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      003
+    </value>
+    </delta_phi>    </Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1>
+    <Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1 condition="CondCorrelation" particle="Mu:ForJet" type="Type2cor">
+    <Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_Mu>
+    <Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_ForJet condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_ForJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFFE
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      003
+    </value>
+    </delta_phi>    </Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1>
+    <Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3 condition="CondCorrelation" particle="Mu:IsoEG" type="Type2cor">
+    <Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_Mu>
+    <Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_IsoEG condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_IsoEG>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      3F0
+    </value>
+    </delta_phi>    </Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3>
+    <Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3 condition="CondCorrelation" particle="Mu:NoIsoEG" type="Type2cor">
+    <Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_Mu>
+    <Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_NoIsoEG condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_NoIsoEG>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      3F0
+    </value>
+    </delta_phi>    </Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3>
+    <DoubleCenJet_0x0E condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x0E>
+    <DoubleCenJet_0x0F condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x0F>
+    <DoubleCenJet_0x13_0x10 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x13_0x10>
+    <DoubleCenJet_0x17_0x10 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x17_0x10>
+    <DoubleCenJet_0x19 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x19>
+    <DoubleCenJet_wsc_0x08_WdPhi7 condition="calo" particle="jet" type="2_wsc">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        3fff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        0ff
+      </value>
+      </delta_phi>
+    </DoubleCenJet_wsc_0x08_WdPhi7>
+    <DoubleIsoEG_0x0A_0x08 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0A_0x08>
+    <DoubleIsoEG_0x0E_0x08 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0E_0x08>
+    <DoubleIsoEG_0x0E_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0E_0x0A>
+    <DoubleIsoEG_0x0F_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0F_0x0A>
+    <DoubleIsoEG_0x14_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x14_0x0A>
+    <DoubleIsoEG_0x16_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x16_0x0A>
+    <DoubleMu_0x0E_0x09_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        09
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0e<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0E_0x09_HighQ>
+    <DoubleMu_wsc_0x01_Eta1p6_WdEta18 condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFF0000FFFF
+      </value>
+      <value>
+        FFFF0000FFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        000000000007ffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffffffffff
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x01_Eta1p6_WdEta18>
+    <DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFF0000FFFF
+      </value>
+      <value>
+        FFFF0000FFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      2
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        000000000007ffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffffffffff
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS>
+    <DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23 condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        0d
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        ffffffffffffffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffff000000
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23>
+    <DoubleMu_wsc_0x0D_0x01_WdEta18 condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        000000000007ffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffffffffff
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x0D_0x01_WdEta18>
+    <DoubleNoIsoEG_0x0A_0x08 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0A_0x08>
+    <DoubleNoIsoEG_0x0E_0x08 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0E_0x08>
+    <DoubleNoIsoEG_0x0E_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0E_0x0A>
+    <DoubleNoIsoEG_0x0F_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0F_0x0A>
+    <DoubleNoIsoEG_0x16_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x16_0x0A>
+    <ETM_0x06E condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        06e
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x06E>
+    <ETM_0x078 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x078>
+    <ETM_0x08C condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x08C>
+    <HTT_0x0FA condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0fa
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x0FA>
+    <HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="0">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        4
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind0_0x05_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="0">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        5
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind0_0x05_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind0_0x06_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="0">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        6
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind0_0x06_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind1_0x04_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="1">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        4
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind1_0x04_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind1_0x05_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="1">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        5
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind1_0x05_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind1_0x06_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="1">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        6
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind1_0x06_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind2_0x04_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="2">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        4
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind2_0x04_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind2_0x05_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="2">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        5
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind2_0x05_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind2_0x06_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="2">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        6
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind2_0x06_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind3_0x04_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="3">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        4
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind3_0x04_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind3_0x05_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="3">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        5
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind3_0x05_IsoTau_Eta2p17>
+    <HfRingEtSums_Ind3_0x06_IsoTau_Eta2p17 condition="CondHfRingEtSums" particle="HfRingEtSums" type="3">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        6
+      </value>
+      </et_threshold>
+    </HfRingEtSums_Ind3_0x06_IsoTau_Eta2p17>
+    <QuadCenJet_0x0F condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x0F>
+    <QuadMu_0x01 condition="muon" particle="muon" type="4">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </QuadMu_0x01>
+    <SingleCenJet_0x05 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x05>
+    <SingleForJet_0x13 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x13>
+    <SingleForJet_0x17 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x17>
+    <SingleIsoEG_0x08 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x08>
+    <SingleIsoEG_0x0A condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0A>
+    <SingleIsoEG_0x0E condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0E>
+    <SingleIsoEG_0x0F condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0F>
+    <SingleIsoEG_0x14 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x14>
+    <SingleIsoEG_0x16 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x16>
+    <SingleMu_0x01_BeamHalo condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        02
+      </value>
+      </quality>
+    </SingleMu_0x01_BeamHalo>
+    <SingleMu_0x01_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x01_Eta2p1>
+    <SingleMu_0x10_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>10<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x10_Eta2p1>
+    <SingleMu_0x11_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>11<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x11_Eta2p1>
+    <SingleNoIsoEG_0x08 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x08>
+    <SingleNoIsoEG_0x0A condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0A>
+    <SingleNoIsoEG_0x0E condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0E>
+    <SingleNoIsoEG_0x0F condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0F>
+    <SingleNoIsoEG_0x14 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x14>
+    <SingleNoIsoEG_0x16 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x16>
+    <TripleCenJet_0x17_0x13_0x10 condition="calo" particle="jet" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleCenJet_0x17_0x13_0x10>
+    <TripleIsoEG_0x0E_0x0A_0x08 condition="calo" particle="ieg" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleIsoEG_0x0E_0x0A_0x08>
+    <TripleMu_0x01_HighQ condition="muon" particle="muon" type="3">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </TripleMu_0x01_HighQ>
+    <TripleMu_0x09_0x09_0x05 condition="muon" particle="muon" type="3">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </TripleMu_0x09_0x09_0x05>
+    <TripleNoIsoEG_0x0E_0x0A_0x08 condition="calo" particle="eg" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleNoIsoEG_0x0E_0x0A_0x08>
+      <BPTX_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_minus.v0>
+      <BPTX_plus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus.v0>
+    </conditions>
+  </condition_chip_1>
+  <condition_chip_2>
+    <prealgos>
+      <L1_AlwaysTrue algAlias="L1_AlwaysTrue">
+        BPTX_plus_AND_minus.v0 OR ( NOT BPTX_plus_AND_minus.v0 )
+        <output_pin nr="2" pin="a" />
+      </L1_AlwaysTrue>
+      <L1_DoubleEG6_HTT150 algAlias="L1_DoubleEG6_HTT150">
+        ( DoubleIsoEG_0x06 OR DoubleNoIsoEG_0x06 OR ( SingleIsoEG_0x06 AND SingleNoIsoEG_0x06 ) ) AND HTT_0x12C
+        <output_pin nr="93" pin="a" />
+      </L1_DoubleEG6_HTT150>
+      <L1_DoubleMu0 algAlias="L1_DoubleMu0">
+        DoubleMu_0x01_HighQ
+        <output_pin nr="27" pin="a" />
+      </L1_DoubleMu0>
+      <L1_DoubleMu6_EG6 algAlias="L1_DoubleMu6_EG6">
+        DoubleMu_0x0A_HighQ AND ( SingleNoIsoEG_0x06 OR SingleIsoEG_0x06 )
+        <output_pin nr="91" pin="a" />
+      </L1_DoubleMu6_EG6>
+      <L1_DoubleMu7_EG7 algAlias="L1_DoubleMu7_EG7">
+        DoubleMu_0x0B_HighQ AND ( SingleNoIsoEG_0x07 OR SingleIsoEG_0x07 )
+        <output_pin nr="86" pin="a" />
+      </L1_DoubleMu7_EG7>
+      <L1_DoubleMu_10_3p5 algAlias="L1_DoubleMu_10_3p5">
+        DoubleMu_0x0D_0x06_HighQ
+        <output_pin nr="46" pin="a" />
+      </L1_DoubleMu_10_3p5>
+      <L1_DoubleMu_10_Open algAlias="L1_DoubleMu_10_Open">
+        DoubleMu_0x0D_HighQ_0x01
+        <output_pin nr="45" pin="a" />
+      </L1_DoubleMu_10_Open>
+      <L1_DoubleS1JetC112 algAlias="L1_DoubleJetC112">
+        DoubleCenJet_0x1C
+        <output_pin nr="44" pin="a" />
+      </L1_DoubleS1JetC112>
+      <L1_DoubleS1JetC120 algAlias="L1_DoubleJetC120">
+        DoubleCenJet_0x1E
+        <output_pin nr="17" pin="a" />
+      </L1_DoubleS1JetC120>
+      <L1_DoubleS1JetC52 algAlias="L1_DoubleJetC52">
+        DoubleCenJet_0x0D
+        <output_pin nr="41" pin="a" />
+      </L1_DoubleS1JetC52>
+      <L1_DoubleS1JetC84 algAlias="L1_DoubleJetC84">
+        DoubleCenJet_0x15
+        <output_pin nr="42" pin="a" />
+      </L1_DoubleS1JetC84>
+      <L1_DoubleTauJet40er algAlias="L1_DoubleTauJet40er">
+        DoubleTauJet_0x0A_Eta2p17
+        <output_pin nr="12" pin="a" />
+      </L1_DoubleTauJet40er>
+      <L1_EG25er_HTT125 algAlias="L1_EG25er_HTT125">
+        ( SingleNoIsoEG_0x19_Eta2p17 OR SingleIsoEG_0x19_Eta2p17 ) AND HTT_0x0FA
+        <output_pin nr="32" pin="a" />
+      </L1_EG25er_HTT125>
+      <L1_ETM100 algAlias="L1_ETM100">
+        ETM_0x0C8
+        <output_pin nr="70" pin="a" />
+      </L1_ETM100>
+      <L1_ETM30 algAlias="L1_ETM30">
+        ETM_0x03C
+        <output_pin nr="67" pin="a" />
+      </L1_ETM30>
+      <L1_ETM40 algAlias="L1_ETM40">
+        ETM_0x050
+        <output_pin nr="80" pin="a" />
+      </L1_ETM40>
+      <L1_ETM50 algAlias="L1_ETM50">
+        ETM_0x064
+        <output_pin nr="68" pin="a" />
+      </L1_ETM50>
+      <L1_ETM70 algAlias="L1_ETM70">
+        ETM_0x08C
+        <output_pin nr="69" pin="a" />
+      </L1_ETM70>
+      <L1_HTT110_rHTM0p6_rHTM0p0_WdPhi6 algAlias="L1_HTT110_rHTM0p6_rHTM0p0_WdPhi6">
+        HTT_0x0DC AND ( HTM_0x03C_ratio OR HTM_0x000_ratio_WdPhi6 )
+        <output_pin nr="58" pin="a" />
+      </L1_HTT110_rHTM0p6_rHTM0p0_WdPhi6>
+      <L1_HTT125 algAlias="L1_HTT125">
+        HTT_0x0FA
+        <output_pin nr="71" pin="a" />
+      </L1_HTT125>
+      <L1_HTT125_rHTM0p3 algAlias="L1_HTT125_rHTM0p3">
+        HTT_0x0FA AND HTM_0x01E_ratio
+        <output_pin nr="60" pin="a" />
+      </L1_HTT125_rHTM0p3>
+      <L1_HTT150 algAlias="L1_HTT150">
+        HTT_0x12C
+        <output_pin nr="72" pin="a" />
+      </L1_HTT150>
+      <L1_HTT175 algAlias="L1_HTT175">
+        HTT_0x15E
+        <output_pin nr="73" pin="a" />
+      </L1_HTT175>
+      <L1_HTT200 algAlias="L1_HTT200">
+        HTT_0x190
+        <output_pin nr="74" pin="a" />
+      </L1_HTT200>
+      <L1_HTT250 algAlias="L1_HTT250">
+        HTT_0x1F4
+        <output_pin nr="81" pin="a" />
+      </L1_HTT250>
+      <L1_IsoEG20er_TauJet20er_NotWdEta0 algAlias="L1_IsoEG20er_TauJet20er_NotWdEta0">
+        Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0
+        <output_pin nr="13" pin="a" />
+      </L1_IsoEG20er_TauJet20er_NotWdEta0>
+      <L1_Mu10er_ETM50 algAlias="L1_Mu10er_ETM50">
+        SingleMu_0x0D_Eta2p1 AND ETM_0x064
+        <output_pin nr="84" pin="a" />
+      </L1_Mu10er_ETM50>
+      <L1_Mu12_EG10 algAlias="L1_Mu12_EG10">
+        SingleMu_0x0E AND ( SingleNoIsoEG_0x0A OR SingleIsoEG_0x0A )
+        <output_pin nr="10" pin="a" />
+      </L1_Mu12_EG10>
+      <L1_Mu14er_ETM30 algAlias="L1_Mu14er_ETM30">
+        SingleMu_0x0F_Eta2p1 AND ETM_0x03C
+        <output_pin nr="85" pin="a" />
+      </L1_Mu14er_ETM30>
+      <L1_Mu16er_TauJet20er algAlias="L1_Mu16er_TauJet20er">
+        SingleMu_0x10_Eta2p1 AND SingleTauJet_0x05_Eta2p17
+        <output_pin nr="14" pin="a" />
+      </L1_Mu16er_TauJet20er>
+      <L1_Mu20_EG10 algAlias="L1_Mu20_EG10">
+        SingleMu_0x12 AND ( SingleNoIsoEG_0x0A OR SingleIsoEG_0x0A )
+        <output_pin nr="75" pin="a" />
+      </L1_Mu20_EG10>
+      <L1_Mu20_EG8 algAlias="L1_Mu20_EG8">
+        SingleMu_0x12 AND ( SingleNoIsoEG_0x08 OR SingleIsoEG_0x08 )
+        <output_pin nr="82" pin="a" />
+      </L1_Mu20_EG8>
+      <L1_Mu3_S1JetC16_WdEtaPhi2 algAlias="L1_Mu3_JetC16_WdEtaPhi2">
+        Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2
+        <output_pin nr="30" pin="a" />
+      </L1_Mu3_S1JetC16_WdEtaPhi2>
+      <L1_Mu3_S1JetC52_WdEtaPhi2 algAlias="L1_Mu3_JetC52_WdEtaPhi2">
+        Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2
+        <output_pin nr="31" pin="a" />
+      </L1_Mu3_S1JetC52_WdEtaPhi2>
+      <L1_Mu3_S1JetC92_WdEtaPhi2 algAlias="L1_Mu3_JetC92_WdEtaPhi2">
+        Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2
+        <output_pin nr="29" pin="a" />
+      </L1_Mu3_S1JetC92_WdEtaPhi2>
+      <L1_Mu4_EG18 algAlias="L1_Mu4_EG18">
+        SingleMu_0x07 AND ( SingleNoIsoEG_0x12 OR SingleIsoEG_0x12 )
+        <output_pin nr="89" pin="a" />
+      </L1_Mu4_EG18>
+      <L1_Mu5_DoubleEG5 algAlias="L1_Mu5_DoubleEG5">
+        SingleMu_0x09 AND ( DoubleIsoEG_0x05 OR DoubleNoIsoEG_0x05 OR ( SingleIsoEG_0x05 AND SingleNoIsoEG_0x05 ) )
+        <output_pin nr="92" pin="a" />
+      </L1_Mu5_DoubleEG5>
+      <L1_Mu5_EG15 algAlias="L1_Mu5_EG15">
+        SingleMu_0x09 AND ( SingleNoIsoEG_0x0F OR SingleIsoEG_0x0F )
+        <output_pin nr="11" pin="a" />
+      </L1_Mu5_EG15>
+      <L1_Mu5_EG20 algAlias="L1_Mu5_EG20">
+        SingleMu_0x09 AND ( SingleNoIsoEG_0x14 OR SingleIsoEG_0x14 )
+        <output_pin nr="76" pin="a" />
+      </L1_Mu5_EG20>
+      <L1_Mu5_IsoEG18 algAlias="L1_Mu5_IsoEG18">
+        SingleMu_0x09 AND SingleIsoEG_0x12
+        <output_pin nr="77" pin="a" />
+      </L1_Mu5_IsoEG18>
+      <L1_Mu6_DoubleEG10 algAlias="L1_Mu6_DoubleEG10">
+        SingleMu_0x0A AND ( DoubleIsoEG_0x0A OR DoubleNoIsoEG_0x0A OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x0A ) )
+        <output_pin nr="78" pin="a" />
+      </L1_Mu6_DoubleEG10>
+      <L1_Mu6_HTT150 algAlias="L1_Mu6_HTT150">
+        SingleMu_0x0A AND HTT_0x12C
+        <output_pin nr="83" pin="a" />
+      </L1_Mu6_HTT150>
+      <L1_Mu8_HTT125 algAlias="L1_Mu8_HTT125">
+        SingleMu_0x0C AND HTT_0x0FA
+        <output_pin nr="88" pin="a" />
+      </L1_Mu8_HTT125>
+      <L1_QuadS1JetC36_TauJet52 algAlias="L1_QuadJetC36_TauJet52">
+        QuadCenJet_0x09 AND SingleTauJet_0x0D
+        <output_pin nr="94" pin="a" />
+      </L1_QuadS1JetC36_TauJet52>
+      <L1_QuadS1JetC40 algAlias="L1_QuadJetC40">
+        QuadCenJet_0x0A
+        <output_pin nr="47" pin="a" />
+      </L1_QuadS1JetC40>
+      <L1_QuadS1JetC84 algAlias="L1_QuadJetC84">
+        QuadCenJet_0x15
+        <output_pin nr="15" pin="a" />
+      </L1_QuadS1JetC84>
+      <L1_SingleEG10 algAlias="L1_SingleEG10">
+        SingleNoIsoEG_0x0A OR SingleIsoEG_0x0A
+        <output_pin nr="38" pin="a" />
+      </L1_SingleEG10>
+      <L1_SingleEG20 algAlias="L1_SingleEG20">
+        SingleNoIsoEG_0x14 OR SingleIsoEG_0x14
+        <output_pin nr="53" pin="a" />
+      </L1_SingleEG20>
+      <L1_SingleEG25 algAlias="L1_SingleEG25">
+        SingleNoIsoEG_0x19 OR SingleIsoEG_0x19
+        <output_pin nr="49" pin="a" />
+      </L1_SingleEG25>
+      <L1_SingleEG30 algAlias="L1_SingleEG30">
+        SingleNoIsoEG_0x1E OR SingleIsoEG_0x1E
+        <output_pin nr="54" pin="a" />
+      </L1_SingleEG30>
+      <L1_SingleEG35 algAlias="L1_SingleEG35">
+        SingleNoIsoEG_0x23 OR SingleIsoEG_0x23
+        <output_pin nr="55" pin="a" />
+      </L1_SingleEG35>
+      <L1_SingleEG40 algAlias="L1_SingleEG40">
+        SingleNoIsoEG_0x28 OR SingleIsoEG_0x28
+        <output_pin nr="50" pin="a" />
+      </L1_SingleEG40>
+      <L1_SingleEG5 algAlias="L1_SingleEG5">
+        SingleNoIsoEG_0x05 OR SingleIsoEG_0x05
+        <output_pin nr="48" pin="a" />
+      </L1_SingleEG5>
+      <L1_SingleIsoEG18 algAlias="L1_SingleIsoEG18">
+        SingleIsoEG_0x12
+        <output_pin nr="51" pin="a" />
+      </L1_SingleIsoEG18>
+      <L1_SingleIsoEG20er algAlias="L1_SingleIsoEG20er">
+        SingleIsoEG_0x14_Eta2p17
+        <output_pin nr="52" pin="a" />
+      </L1_SingleIsoEG20er>
+      <L1_SingleIsoEG22er algAlias="L1_SingleIsoEG22er">
+        SingleIsoEG_0x16_Eta2p17
+        <output_pin nr="39" pin="a" />
+      </L1_SingleIsoEG22er>
+      <L1_SingleIsoEG25 algAlias="L1_SingleIsoEG25">
+        SingleIsoEG_0x19
+        <output_pin nr="35" pin="a" />
+      </L1_SingleIsoEG25>
+      <L1_SingleIsoEG25er algAlias="L1_SingleIsoEG25er">
+        SingleIsoEG_0x19_Eta2p17
+        <output_pin nr="34" pin="a" />
+      </L1_SingleIsoEG25er>
+      <L1_SingleIsoEG28er algAlias="L1_SingleIsoEG28er">
+        SingleIsoEG_0x1C_Eta2p17
+        <output_pin nr="36" pin="a" />
+      </L1_SingleIsoEG28er>
+      <L1_SingleIsoEG30er algAlias="L1_SingleIsoEG30er">
+        SingleIsoEG_0x1E_Eta2p17
+        <output_pin nr="37" pin="a" />
+      </L1_SingleIsoEG30er>
+      <L1_SingleMu12 algAlias="L1_SingleMu12">
+        SingleMu_0x0E
+        <output_pin nr="62" pin="a" />
+      </L1_SingleMu12>
+      <L1_SingleMu14_Eta2p1 algAlias="L1_SingleMu14er">
+        SingleMu_0x0F_Eta2p1
+        <output_pin nr="43" pin="a" />
+      </L1_SingleMu14_Eta2p1>
+      <L1_SingleMu16 algAlias="L1_SingleMu16">
+        SingleMu_0x10
+        <output_pin nr="57" pin="a" />
+      </L1_SingleMu16>
+      <L1_SingleMu16_Eta2p1 algAlias="L1_SingleMu16er">
+        SingleMu_0x10_Eta2p1
+        <output_pin nr="87" pin="a" />
+      </L1_SingleMu16_Eta2p1>
+      <L1_SingleMu20 algAlias="L1_SingleMu20">
+        SingleMu_0x12
+        <output_pin nr="63" pin="a" />
+      </L1_SingleMu20>
+      <L1_SingleMu20er algAlias="L1_SingleMu20er">
+        SingleMu_0x12_Eta2p1
+        <output_pin nr="61" pin="a" />
+      </L1_SingleMu20er>
+      <L1_SingleMu25 algAlias="L1_SingleMu25">
+        SingleMu_0x13
+        <output_pin nr="65" pin="a" />
+      </L1_SingleMu25>
+      <L1_SingleMu25er algAlias="L1_SingleMu25er">
+        SingleMu_0x13_Eta2p1
+        <output_pin nr="64" pin="a" />
+      </L1_SingleMu25er>
+      <L1_SingleMu30 algAlias="L1_SingleMu30">
+        SingleMu_0x14
+        <output_pin nr="66" pin="a" />
+      </L1_SingleMu30>
+      <L1_SingleMu30er algAlias="L1_SingleMu30er">
+        SingleMu_0x14_Eta2p1
+        <output_pin nr="28" pin="a" />
+      </L1_SingleMu30er>
+      <L1_SingleMu5 algAlias="L1_SingleMu5">
+        SingleMu_0x09
+        <output_pin nr="59" pin="a" />
+      </L1_SingleMu5>
+      <L1_SingleMu6_NotBptxOR algAlias="L1_SingleMu6_NotBptxOR">
+        SingleMu_0x0A AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="90" pin="a" />
+      </L1_SingleMu6_NotBptxOR>
+      <L1_SingleMuOpen algAlias="L1_SingleMuOpen">
+        SingleMu_0x01_Open
+        <output_pin nr="56" pin="a" />
+      </L1_SingleMuOpen>
+      <L1_SingleS1Jet128 algAlias="L1_SingleJet128">
+        SingleCenJet_0x20 OR SingleForJet_0x20
+        <output_pin nr="21" pin="a" />
+      </L1_SingleS1Jet128>
+      <L1_SingleS1Jet176 algAlias="L1_SingleJet176">
+        SingleCenJet_0x2C OR SingleForJet_0x2C
+        <output_pin nr="22" pin="a" />
+      </L1_SingleS1Jet176>
+      <L1_SingleS1Jet200 algAlias="L1_SingleJet200">
+        SingleCenJet_0x32 OR SingleForJet_0x32
+        <output_pin nr="23" pin="a" />
+      </L1_SingleS1Jet200>
+      <L1_SingleS1Jet240 algAlias="L1_SingleJet240">
+        SingleCenJet_0x3C OR SingleForJet_0x3C
+        <output_pin nr="40" pin="a" />
+      </L1_SingleS1Jet240>
+      <L1_SingleS1Jet36 algAlias="L1_SingleJet36">
+        SingleCenJet_0x09 OR SingleForJet_0x09
+        <output_pin nr="24" pin="a" />
+      </L1_SingleS1Jet36>
+      <L1_SingleS1Jet52 algAlias="L1_SingleJet52">
+        SingleCenJet_0x0D OR SingleForJet_0x0D
+        <output_pin nr="18" pin="a" />
+      </L1_SingleS1Jet52>
+      <L1_SingleS1Jet68 algAlias="L1_SingleJet68">
+        SingleCenJet_0x11 OR SingleForJet_0x11
+        <output_pin nr="19" pin="a" />
+      </L1_SingleS1Jet68>
+      <L1_SingleS1Jet92 algAlias="L1_SingleJet92">
+        SingleCenJet_0x17 OR SingleForJet_0x17
+        <output_pin nr="20" pin="a" />
+      </L1_SingleS1Jet92>
+      <L1_SingleS1JetC32_NotBptxOR algAlias="L1_SingleJetC32_NotBptxOR">
+        SingleCenJet_0x08 AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="79" pin="a" />
+      </L1_SingleS1JetC32_NotBptxOR>
+      <L1_ZeroBias algAlias="L1_ZeroBias">
+        BPTX_plus_AND_minus.v0
+        <output_pin nr="1" pin="a" />
+      </L1_ZeroBias>
+    </prealgos>
+    <conditions>
+    <Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0 condition="CondCorrelation" particle="IsoEG:TauJet" type="Type2cor">
+    <Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_IsoEG condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_IsoEG>
+    <Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFE
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      3FF
+    </value>
+    </delta_phi>    </Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0>
+    <Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2 condition="CondCorrelation" particle="Mu:CenJet" type="Type2cor">
+    <Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_Mu>
+    <Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0007
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2>
+    <Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2 condition="CondCorrelation" particle="Mu:CenJet" type="Type2cor">
+    <Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_Mu>
+    <Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0007
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2>
+    <Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2 condition="CondCorrelation" particle="Mu:CenJet" type="Type2cor">
+    <Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2_Mu>
+    <Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0007
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2>
+    <DoubleCenJet_0x0D condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x0D>
+    <DoubleCenJet_0x15 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x15>
+    <DoubleCenJet_0x1C condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1c
+      </value>
+      <value>
+        1c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x1C>
+    <DoubleCenJet_0x1E condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x1E>
+    <DoubleIsoEG_0x05 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x05>
+    <DoubleIsoEG_0x06 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x06>
+    <DoubleIsoEG_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0A>
+    <DoubleMu_0x01_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x01_HighQ>
+    <DoubleMu_0x0A_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0a<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>0a<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0A_HighQ>
+    <DoubleMu_0x0B_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0b
+      </value>
+      <value>
+        0b
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0b<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>0b<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0B_HighQ>
+    <DoubleMu_0x0D_0x06_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        06
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>06<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0D_0x06_HighQ>
+    <DoubleMu_0x0D_HighQ_0x01 condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        fc
+      </value>
+      </quality>
+    </DoubleMu_0x0D_HighQ_0x01>
+    <DoubleNoIsoEG_0x05 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x05>
+    <DoubleNoIsoEG_0x06 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x06>
+    <DoubleNoIsoEG_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0A>
+    <DoubleTauJet_0x0A_Eta2p17 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x0A_Eta2p17>
+    <ETM_0x03C condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        03c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x03C>
+    <ETM_0x050 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        050
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x050>
+    <ETM_0x064 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        064
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x064>
+    <ETM_0x08C condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x08C>
+    <ETM_0x0C8 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0c8
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x0C8>
+    <HTM_0x000_ratio_WdPhi6 condition="esums" particle="htm" type="htm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        000
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        07f
+      </value>
+      </phi>
+    </HTM_0x000_ratio_WdPhi6>
+    <HTM_0x01E_ratio condition="esums" particle="htm" type="htm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        01e
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        03ffff
+      </value>
+      </phi>
+    </HTM_0x01E_ratio>
+    <HTM_0x03C_ratio condition="esums" particle="htm" type="htm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        03c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        03ff
+      </value>
+      </phi>
+    </HTM_0x03C_ratio>
+    <HTT_0x0DC condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0dc
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x0DC>
+    <HTT_0x0FA condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0fa
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x0FA>
+    <HTT_0x12C condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        12c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x12C>
+    <HTT_0x15E condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        15e
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x15E>
+    <HTT_0x190 condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        190
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x190>
+    <HTT_0x1F4 condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        1f4
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x1F4>
+    <QuadCenJet_0x09 condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x09>
+    <QuadCenJet_0x0A condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x0A>
+    <QuadCenJet_0x15 condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x15>
+    <SingleCenJet_0x08 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x08>
+    <SingleCenJet_0x09 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x09>
+    <SingleCenJet_0x0D condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x0D>
+    <SingleCenJet_0x11 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x11>
+    <SingleCenJet_0x17 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x17>
+    <SingleCenJet_0x20 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        20
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x20>
+    <SingleCenJet_0x2C condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        2c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x2C>
+    <SingleCenJet_0x32 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x32>
+    <SingleCenJet_0x3C condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        3c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x3C>
+    <SingleForJet_0x09 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x09>
+    <SingleForJet_0x0D condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x0D>
+    <SingleForJet_0x11 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x11>
+    <SingleForJet_0x17 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x17>
+    <SingleForJet_0x20 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        20
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x20>
+    <SingleForJet_0x2C condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        2c
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x2C>
+    <SingleForJet_0x32 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x32>
+    <SingleForJet_0x3C condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        3c
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x3C>
+    <SingleIsoEG_0x05 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x05>
+    <SingleIsoEG_0x06 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x06>
+    <SingleIsoEG_0x07 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x07>
+    <SingleIsoEG_0x08 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x08>
+    <SingleIsoEG_0x0A condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0A>
+    <SingleIsoEG_0x0F condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0F>
+    <SingleIsoEG_0x12 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x12>
+    <SingleIsoEG_0x14 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x14>
+    <SingleIsoEG_0x14_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x14_Eta2p17>
+    <SingleIsoEG_0x16_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x16_Eta2p17>
+    <SingleIsoEG_0x19 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x19>
+    <SingleIsoEG_0x19_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x19_Eta2p17>
+    <SingleIsoEG_0x1C_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x1C_Eta2p17>
+    <SingleIsoEG_0x1E condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x1E>
+    <SingleIsoEG_0x1E_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x1E_Eta2p17>
+    <SingleIsoEG_0x23 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        23
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x23>
+    <SingleIsoEG_0x28 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        28
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x28>
+    <SingleMu_0x01_Open condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </SingleMu_0x01_Open>
+    <SingleMu_0x07 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>07<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x07>
+    <SingleMu_0x09 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x09>
+    <SingleMu_0x0A condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0a<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0A>
+    <SingleMu_0x0C condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0c
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0c<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0C>
+    <SingleMu_0x0D_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0D_Eta2p1>
+    <SingleMu_0x0E condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0e<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0E>
+    <SingleMu_0x0F_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0f<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0F_Eta2p1>
+    <SingleMu_0x10 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>10<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x10>
+    <SingleMu_0x10_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>10<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x10_Eta2p1>
+    <SingleMu_0x12 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>12<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x12>
+    <SingleMu_0x12_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>12<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x12_Eta2p1>
+    <SingleMu_0x13 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>13<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x13>
+    <SingleMu_0x13_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>13<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x13_Eta2p1>
+    <SingleMu_0x14 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>14<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x14>
+    <SingleMu_0x14_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>14<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x14_Eta2p1>
+    <SingleNoIsoEG_0x05 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x05>
+    <SingleNoIsoEG_0x06 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x06>
+    <SingleNoIsoEG_0x07 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x07>
+    <SingleNoIsoEG_0x08 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x08>
+    <SingleNoIsoEG_0x0A condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0A>
+    <SingleNoIsoEG_0x0F condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0F>
+    <SingleNoIsoEG_0x12 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x12>
+    <SingleNoIsoEG_0x14 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x14>
+    <SingleNoIsoEG_0x19 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x19>
+    <SingleNoIsoEG_0x19_Eta2p17 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x19_Eta2p17>
+    <SingleNoIsoEG_0x1E condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x1E>
+    <SingleNoIsoEG_0x23 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        23
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x23>
+    <SingleNoIsoEG_0x28 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        28
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x28>
+    <SingleTauJet_0x05_Eta2p17 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x05_Eta2p17>
+    <SingleTauJet_0x0D condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x0D>
+      <BPTX_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_minus.v0>
+      <BPTX_plus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus.v0>
+      <BPTX_plus_AND_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus_AND_minus.v0>
+    </conditions>
+  </condition_chip_2>
+<techtriggers>
+  <L1Tech_BPTX_plus_AND_minus.v0>
+    TechTrig
+    <output_pin nr="0" />
+  </L1Tech_BPTX_plus_AND_minus.v0>
+  <L1Tech_BPTX_plus.v0>
+    TechTrig
+    <output_pin nr="1" />
+  </L1Tech_BPTX_plus.v0>
+  <L1Tech_BPTX_minus.v0>
+    TechTrig
+    <output_pin nr="2" />
+  </L1Tech_BPTX_minus.v0>
+  <L1Tech_BPTX_plus_OR_minus.v0>
+    TechTrig
+    <output_pin nr="3" />
+  </L1Tech_BPTX_plus_OR_minus.v0>
+  <L1Tech_BPTX_plus_AND_minus_instance1.v0>
+    TechTrig
+    <output_pin nr="4" />
+  </L1Tech_BPTX_plus_AND_minus_instance1.v0>
+  <L1Tech_BPTX_plus_AND_NOT_minus.v0>
+    TechTrig
+    <output_pin nr="5" />
+  </L1Tech_BPTX_plus_AND_NOT_minus.v0>
+  <L1Tech_BPTX_minus_AND_not_plus.v0>
+    TechTrig
+    <output_pin nr="6" />
+  </L1Tech_BPTX_minus_AND_not_plus.v0>
+  <L1Tech_BPTX_quiet.v0>
+    TechTrig
+    <output_pin nr="7" />
+  </L1Tech_BPTX_quiet.v0>
+  <L1Tech_HCAL_HF_single_channel.v0>
+    TechTrig
+    <output_pin nr="8" />
+  </L1Tech_HCAL_HF_single_channel.v0>
+  <L1Tech_HCAL_HF_coincidence_PM.v2>
+    TechTrig
+    <output_pin nr="9" />
+  </L1Tech_HCAL_HF_coincidence_PM.v2>
+  <L1Tech_HCAL_HF_MMP_or_MPP.v1>
+    TechTrig
+    <output_pin nr="10" />
+  </L1Tech_HCAL_HF_MMP_or_MPP.v1>
+  <L1Tech_HCAL_HO_totalOR.v0>
+    TechTrig
+    <output_pin nr="11" />
+  </L1Tech_HCAL_HO_totalOR.v0>
+  <L1Tech_HCAL_HBHE_totalOR.v0>
+    TechTrig
+    <output_pin nr="12" />
+  </L1Tech_HCAL_HBHE_totalOR.v0>
+  <L1Tech_BPTX_PreBPTX.v0>
+    TechTrig
+    <output_pin nr="16" />
+  </L1Tech_BPTX_PreBPTX.v0>
+  <L1Tech_DT_GlobalOR.v0>
+    TechTrig
+    <output_pin nr="20" />
+  </L1Tech_DT_GlobalOR.v0>
+  <L1Tech_RPC_TTU_barrel_Cosmics.v0>
+    TechTrig
+    <output_pin nr="24" />
+  </L1Tech_RPC_TTU_barrel_Cosmics.v0>
+  <L1Tech_RPC_TTU_pointing_Cosmics.v0>
+    TechTrig
+    <output_pin nr="25" />
+  </L1Tech_RPC_TTU_pointing_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBplus2_Cosmics.v0>
+    TechTrig
+    <output_pin nr="26" />
+  </L1Tech_RPC_TTU_RBplus2_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBplus1_Cosmics.v0>
+    TechTrig
+    <output_pin nr="27" />
+  </L1Tech_RPC_TTU_RBplus1_Cosmics.v0>
+  <L1Tech_RPC_TTU_RB0_Cosmics.v0>
+    TechTrig
+    <output_pin nr="28" />
+  </L1Tech_RPC_TTU_RB0_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBminus1_Cosmics.v0>
+    TechTrig
+    <output_pin nr="29" />
+  </L1Tech_RPC_TTU_RBminus1_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBminus2_Cosmics.v0>
+    TechTrig
+    <output_pin nr="30" />
+  </L1Tech_RPC_TTU_RBminus2_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBst1_collisions.v0>
+    TechTrig
+    <output_pin nr="31" />
+  </L1Tech_RPC_TTU_RBst1_collisions.v0>
+  <L1Tech_BSC_minBias_inner_threshold1.v0>
+    TechTrig
+    <output_pin nr="32" />
+  </L1Tech_BSC_minBias_inner_threshold1.v0>
+  <L1Tech_BSC_minBias_inner_threshold2.v0>
+    TechTrig
+    <output_pin nr="33" />
+  </L1Tech_BSC_minBias_inner_threshold2.v0>
+  <L1Tech_BSC_minBias_OR.v0>
+    TechTrig
+    <output_pin nr="34" />
+  </L1Tech_BSC_minBias_OR.v0>
+  <L1Tech_BSC_HighMultiplicity.v0>
+    TechTrig
+    <output_pin nr="35" />
+  </L1Tech_BSC_HighMultiplicity.v0>
+  <L1Tech_BSC_halo_beam2_inner.v0>
+    TechTrig
+    <output_pin nr="36" />
+  </L1Tech_BSC_halo_beam2_inner.v0>
+  <L1Tech_BSC_halo_beam2_outer.v0>
+    TechTrig
+    <output_pin nr="37" />
+  </L1Tech_BSC_halo_beam2_outer.v0>
+  <L1Tech_BSC_halo_beam1_inner.v0>
+    TechTrig
+    <output_pin nr="38" />
+  </L1Tech_BSC_halo_beam1_inner.v0>
+  <L1Tech_BSC_halo_beam1_outer.v0>
+    TechTrig
+    <output_pin nr="39" />
+  </L1Tech_BSC_halo_beam1_outer.v0>
+  <L1Tech_BSC_minBias_threshold1.v0>
+    TechTrig
+    <output_pin nr="40" />
+  </L1Tech_BSC_minBias_threshold1.v0>
+  <L1Tech_BSC_minBias_threshold2.v0>
+    TechTrig
+    <output_pin nr="41" />
+  </L1Tech_BSC_minBias_threshold2.v0>
+  <L1Tech_BSC_splash_beam1.v0>
+    TechTrig
+    <output_pin nr="42" />
+  </L1Tech_BSC_splash_beam1.v0>
+  <L1Tech_BSC_splash_beam2.v0>
+    TechTrig
+    <output_pin nr="43" />
+  </L1Tech_BSC_splash_beam2.v0>
+  <L1Tech_ZDC_Scint_tight_vertex.v0>
+    TechTrig
+    <output_pin nr="48" />
+  </L1Tech_ZDC_Scint_tight_vertex.v0>
+  <L1Tech_ZDC_Scint_loose_vertex.v0>
+    TechTrig
+    <output_pin nr="49" />
+  </L1Tech_ZDC_Scint_loose_vertex.v0>
+  <L1Tech_ZDC_Scint_plus.v0>
+    TechTrig
+    <output_pin nr="50" />
+  </L1Tech_ZDC_Scint_plus.v0>
+  <L1Tech_ZDC_Scint_minus.v0>
+    TechTrig
+    <output_pin nr="51" />
+  </L1Tech_ZDC_Scint_minus.v0>
+  <L1Tech_TOTEM_Diffractive.v0>
+    TechTrig
+    <output_pin nr="52" />
+  </L1Tech_TOTEM_Diffractive.v0>
+  <L1Tech_TOTEM_MinBias.v0>
+    TechTrig
+    <output_pin nr="53" />
+  </L1Tech_TOTEM_MinBias.v0>
+  <L1Tech_TOTEM_ZeroBias.v0>
+    TechTrig
+    <output_pin nr="54" />
+  </L1Tech_TOTEM_ZeroBias.v0>
+  <L1Tech_TOTEM_LowMultiplicity.v0>
+    TechTrig
+    <output_pin nr="55" />
+  </L1Tech_TOTEM_LowMultiplicity.v0>
+  <L1Tech_FSC_St3Sect45_uppLeft.v0>
+    TechTrig
+    <output_pin nr="56" />
+  </L1Tech_FSC_St3Sect45_uppLeft.v0>
+  <L1Tech_FSC_St3Sect45_uppRight.v0>
+    TechTrig
+    <output_pin nr="57" />
+  </L1Tech_FSC_St3Sect45_uppRight.v0>
+  <L1Tech_FSC_St3Sect45_downRight.v0>
+    TechTrig
+    <output_pin nr="58" />
+  </L1Tech_FSC_St3Sect45_downRight.v0>
+  <L1Tech_FSC_St3Sect45_downLeft.v0>
+    TechTrig
+    <output_pin nr="59" />
+  </L1Tech_FSC_St3Sect45_downLeft.v0>
+  <L1Tech_CASTOR_0.v0>
+    TechTrig
+    <output_pin nr="60" />
+  </L1Tech_CASTOR_0.v0>
+  <L1Tech_CASTOR_TotalEnergy.v0>
+    TechTrig
+    <output_pin nr="61" />
+  </L1Tech_CASTOR_TotalEnergy.v0>
+  <L1Tech_CASTOR_EM.v0>
+    TechTrig
+    <output_pin nr="62" />
+  </L1Tech_CASTOR_EM.v0>
+  <L1Tech_CASTOR_HaloMuon.v0>
+    TechTrig
+    <output_pin nr="63" />
+  </L1Tech_CASTOR_HaloMuon.v0>
+  </techtriggers>
+</def>
+
+<!--MenuImplDescription-->
+<!--L1TmeVersion: 1.0.13-1-->
+<!--TTCablingFkL1TechTrigCabling_2013_Jan_22-->
+<!--ExtCondCablingFkL1ExternalConditionsCabling_2013_Jan_22-->
+<!--AlgoDBLock
+AlgoDBLockEnd-->
+<!--CondDBLock
+BPTX_minus.v0:BPTX_minus.v0
+BPTX_minus_postQuiet.v0:BPTX_minus_postQuiet.v0
+BPTX_plus.v0:BPTX_plus.v0
+BPTX_plus_AND_minus.v0:BPTX_plus_AND_minus.v0
+BPTX_plus_OR_minus.v0:BPTX_plus_OR_minus.v0
+BPTX_plus_postQuiet.v0:BPTX_plus_postQuiet.v0
+BPTXcoincidence:BPTXcoincidence
+BSC_BSC2_minus.v0:BSC_BSC2_minus.v0
+BSC_BSC2_plus.v0:BSC_BSC2_plus.v0
+BSC_HighMultiplicity.v0:BSC_HighMultiplicity.v0
+BSC_halo_beam1_inner.v0:BSC_halo_beam1_inner.v0
+BSC_halo_beam1_outer.v0:BSC_halo_beam1_outer.v0
+BSC_halo_beam2_inner.v0:BSC_halo_beam2_inner.v0
+BSC_halo_beam2_outer.v0:BSC_halo_beam2_outer.v0
+BSC_minBias_OR.v0:BSC_minBias_OR.v0
+BSC_minBias_inner_threshold1.v0:BSC_minBias_inner_threshold1.v0
+BSC_minBias_inner_threshold2.v0:BSC_minBias_inner_threshold2.v0
+BSC_minBias_threshold1.v0:BSC_minBias_threshold1.v0
+BSC_minBias_threshold2.v0:BSC_minBias_threshold2.v0
+BSC_splash_beam1.v0:BSC_splash_beam1.v0
+BSC_splash_beam2.v0:BSC_splash_beam2.v0
+CASTOR_0.v0:CASTOR_0.v0
+CASTOR_EM.v0:CASTOR_EM.v0
+CASTOR_HaloMuon.v0:CASTOR_HaloMuon.v0
+CASTOR_TotalEnergy.v0:CASTOR_TotalEnergy.v0
+Corr_ETM_CenJet_0x78_0x0D_WdPhi2:Corr_ETM_CenJet_0x78_0x0D_WdPhi2
+Corr_ETM_CenJet_0x8C_0x0D_WdPhi2:Corr_ETM_CenJet_0x8C_0x0D_WdPhi2
+Corr_ETM_ForJet_0x78_0x0D_WdPhi2:Corr_ETM_ForJet_0x78_0x0D_WdPhi2
+Corr_ETM_ForJet_0x8C_0x0D_WdPhi2:Corr_ETM_ForJet_0x8C_0x0D_WdPhi2
+Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0:Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0
+Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1:Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1
+Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2:Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2
+Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2:Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2
+Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2:Corr_Mu_CenJet_0x05_0x17_WdEtaPhi2
+Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1:Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1
+Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3:Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3
+Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3:Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3
+DoubleCenJet_0x0D:DoubleCenJet_0x0D
+DoubleCenJet_0x0E:DoubleCenJet_0x0E
+DoubleCenJet_0x0F:DoubleCenJet_0x0F
+DoubleCenJet_0x13_0x10:DoubleCenJet_0x13_0x10
+DoubleCenJet_0x15:DoubleCenJet_0x15
+DoubleCenJet_0x17_0x10:DoubleCenJet_0x17_0x10
+DoubleCenJet_0x19:DoubleCenJet_0x19
+DoubleCenJet_0x1C:DoubleCenJet_0x1C
+DoubleCenJet_0x1E:DoubleCenJet_0x1E
+DoubleCenJet_wsc_0x08_WdPhi7:DoubleCenJet_wsc_0x08_WdPhi7
+DoubleIsoEG_0x05:DoubleIsoEG_0x05
+DoubleIsoEG_0x06:DoubleIsoEG_0x06
+DoubleIsoEG_0x0A:DoubleIsoEG_0x0A
+DoubleIsoEG_0x0A_0x08:DoubleIsoEG_0x0A_0x08
+DoubleIsoEG_0x0E_0x08:DoubleIsoEG_0x0E_0x08
+DoubleIsoEG_0x0E_0x0A:DoubleIsoEG_0x0E_0x0A
+DoubleIsoEG_0x0F_0x0A:DoubleIsoEG_0x0F_0x0A
+DoubleIsoEG_0x14_0x0A:DoubleIsoEG_0x14_0x0A
+DoubleIsoEG_0x16_0x0A:DoubleIsoEG_0x16_0x0A
+DoubleMu_0x01_HighQ:DoubleMu_0x01_HighQ
+DoubleMu_0x0A_HighQ:DoubleMu_0x0A_HighQ
+DoubleMu_0x0B_HighQ:DoubleMu_0x0B_HighQ
+DoubleMu_0x0D_0x06_HighQ:DoubleMu_0x0D_0x06_HighQ
+DoubleMu_0x0D_HighQ_0x01:DoubleMu_0x0D_HighQ_0x01
+DoubleMu_0x0E_0x09_HighQ:DoubleMu_0x0E_0x09_HighQ
+DoubleMu_wsc_0x01_Eta1p6_WdEta18:DoubleMu_wsc_0x01_Eta1p6_WdEta18
+DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS:DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS
+DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23:DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23
+DoubleMu_wsc_0x0D_0x01_WdEta18:DoubleMu_wsc_0x0D_0x01_WdEta18
+DoubleNoIsoEG_0x05:DoubleNoIsoEG_0x05
+DoubleNoIsoEG_0x06:DoubleNoIsoEG_0x06
+DoubleNoIsoEG_0x0A:DoubleNoIsoEG_0x0A
+DoubleNoIsoEG_0x0A_0x08:DoubleNoIsoEG_0x0A_0x08
+DoubleNoIsoEG_0x0E_0x08:DoubleNoIsoEG_0x0E_0x08
+DoubleNoIsoEG_0x0E_0x0A:DoubleNoIsoEG_0x0E_0x0A
+DoubleNoIsoEG_0x0F_0x0A:DoubleNoIsoEG_0x0F_0x0A
+DoubleNoIsoEG_0x16_0x0A:DoubleNoIsoEG_0x16_0x0A
+DoubleTauJet_0x0A_Eta2p17:DoubleTauJet_0x0A_Eta2p17
+Dummy_00:Dummy_00
+Dummy_01:Dummy_01
+Dummy_02:Dummy_02
+Dummy_03:Dummy_03
+Dummy_04:Dummy_04
+Dummy_05:Dummy_05
+Dummy_06:Dummy_06
+Dummy_07:Dummy_07
+Dummy_08:Dummy_08
+Dummy_09:Dummy_09
+Dummy_10:Dummy_10
+Dummy_11:Dummy_11
+Dummy_12:Dummy_12
+Dummy_13:Dummy_13
+Dummy_14:Dummy_14
+Dummy_15:Dummy_15
+Dummy_16:Dummy_16
+Dummy_17:Dummy_17
+Dummy_18:Dummy_18
+Dummy_19:Dummy_19
+Dummy_20:Dummy_20
+Dummy_21:Dummy_21
+Dummy_22:Dummy_22
+Dummy_23:Dummy_23
+Dummy_24:Dummy_24
+Dummy_25:Dummy_25
+Dummy_26:Dummy_26
+Dummy_27:Dummy_27
+Dummy_28:Dummy_28
+Dummy_29:Dummy_29
+Dummy_30:Dummy_30
+Dummy_31:Dummy_31
+Dummy_32:Dummy_32
+Dummy_33:Dummy_33
+Dummy_34:Dummy_34
+Dummy_35:Dummy_35
+Dummy_36:Dummy_36
+Dummy_37:Dummy_37
+Dummy_38:Dummy_38
+Dummy_39:Dummy_39
+Dummy_40:Dummy_40
+Dummy_41:Dummy_41
+Dummy_42:Dummy_42
+Dummy_43:Dummy_43
+Dummy_44:Dummy_44
+Dummy_45:Dummy_45
+Dummy_46:Dummy_46
+Dummy_47:Dummy_47
+Dummy_48:Dummy_48
+Dummy_49:Dummy_49
+Dummy_50:Dummy_50
+Dummy_51:Dummy_51
+Dummy_52:Dummy_52
+Dummy_53:Dummy_53
+Dummy_54:Dummy_54
+Dummy_55:Dummy_55
+Dummy_56:Dummy_56
+Dummy_57:Dummy_57
+Dummy_58:Dummy_58
+Dummy_59:Dummy_59
+Dummy_60:Dummy_60
+Dummy_61:Dummy_61
+Dummy_62:Dummy_62
+Dummy_63:Dummy_63
+ETM_0x03C:ETM_0x03C
+ETM_0x050:ETM_0x050
+ETM_0x064:ETM_0x064
+ETM_0x06E:ETM_0x06E
+ETM_0x078:ETM_0x078
+ETM_0x08C:ETM_0x08C
+ETM_0x0C8:ETM_0x0C8
+FSC_St1Sect45_down.v0:FSC_St1Sect45_down.v0
+FSC_St1Sect45_upp.v0:FSC_St1Sect45_upp.v0
+FSC_St1Sect56_down.v0:FSC_St1Sect56_down.v0
+FSC_St1Sect56_upp.v0:FSC_St1Sect56_upp.v0
+FSC_St2Sect45_down.v0:FSC_St2Sect45_down.v0
+FSC_St2Sect45_upp.v0:FSC_St2Sect45_upp.v0
+FSC_St2Sect56_down.v0:FSC_St2Sect56_down.v0
+FSC_St2Sect56_upp.v0:FSC_St2Sect56_upp.v0
+FSC_St3Sect56_downLeft.v0:FSC_St3Sect56_downLeft.v0
+FSC_St3Sect56_downRight.v0:FSC_St3Sect56_downRight.v0
+FSC_St3Sect56_uppLeft.v0:FSC_St3Sect56_uppLeft.v0
+FSC_St3Sect56_uppRight.v0:FSC_St3Sect56_uppRight.v0
+HCAL_HF_MMP_or_MPP.v0:HCAL_HF_MMP_or_MPP.v0
+HCAL_HF_MMP_or_MPP.v1:HCAL_HF_MMP_or_MPP.v1
+HCAL_HF_MM_or_PP_or_PM.v0:HCAL_HF_MM_or_PP_or_PM.v0
+HCAL_HF_coincidence_PM.v1:HCAL_HF_coincidence_PM.v1
+HCAL_HF_coincidence_PM.v2:HCAL_HF_coincidence_PM.v2
+HCAL_HF_single_channel.v0:HCAL_HF_single_channel.v0
+HCAL_HO_totalOR.v0:HCAL_HO_totalOR.v0
+HTM_0x000_ratio_WdPhi6:HTM_0x000_ratio_WdPhi6
+HTM_0x01E_ratio:HTM_0x01E_ratio
+HTM_0x03C_ratio:HTM_0x03C_ratio
+HTT_0x0DC:HTT_0x0DC
+HTT_0x0FA:HTT_0x0FA
+HTT_0x12C:HTT_0x12C
+HTT_0x15E:HTT_0x15E
+HTT_0x190:HTT_0x190
+HTT_0x1F4:HTT_0x1F4
+HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17:HfRingEtSums_Ind0_0x04_IsoTau_Eta2p17
+HfRingEtSums_Ind0_0x05_IsoTau_Eta2p17:HfRingEtSums_Ind0_0x05_IsoTau_Eta2p17
+HfRingEtSums_Ind0_0x06_IsoTau_Eta2p17:HfRingEtSums_Ind0_0x06_IsoTau_Eta2p17
+HfRingEtSums_Ind1_0x04_IsoTau_Eta2p17:HfRingEtSums_Ind1_0x04_IsoTau_Eta2p17
+HfRingEtSums_Ind1_0x05_IsoTau_Eta2p17:HfRingEtSums_Ind1_0x05_IsoTau_Eta2p17
+HfRingEtSums_Ind1_0x06_IsoTau_Eta2p17:HfRingEtSums_Ind1_0x06_IsoTau_Eta2p17
+HfRingEtSums_Ind2_0x04_IsoTau_Eta2p17:HfRingEtSums_Ind2_0x04_IsoTau_Eta2p17
+HfRingEtSums_Ind2_0x05_IsoTau_Eta2p17:HfRingEtSums_Ind2_0x05_IsoTau_Eta2p17
+HfRingEtSums_Ind2_0x06_IsoTau_Eta2p17:HfRingEtSums_Ind2_0x06_IsoTau_Eta2p17
+HfRingEtSums_Ind3_0x04_IsoTau_Eta2p17:HfRingEtSums_Ind3_0x04_IsoTau_Eta2p17
+HfRingEtSums_Ind3_0x05_IsoTau_Eta2p17:HfRingEtSums_Ind3_0x05_IsoTau_Eta2p17
+HfRingEtSums_Ind3_0x06_IsoTau_Eta2p17:HfRingEtSums_Ind3_0x06_IsoTau_Eta2p17
+QuadCenJet_0x09:QuadCenJet_0x09
+QuadCenJet_0x0A:QuadCenJet_0x0A
+QuadCenJet_0x0F:QuadCenJet_0x0F
+QuadCenJet_0x15:QuadCenJet_0x15
+QuadMu_0x01:QuadMu_0x01
+SingleCenJet_0x05:SingleCenJet_0x05
+SingleCenJet_0x08:SingleCenJet_0x08
+SingleCenJet_0x09:SingleCenJet_0x09
+SingleCenJet_0x0D:SingleCenJet_0x0D
+SingleCenJet_0x11:SingleCenJet_0x11
+SingleCenJet_0x17:SingleCenJet_0x17
+SingleCenJet_0x20:SingleCenJet_0x20
+SingleCenJet_0x2C:SingleCenJet_0x2C
+SingleCenJet_0x32:SingleCenJet_0x32
+SingleCenJet_0x3C:SingleCenJet_0x3C
+SingleForJet_0x09:SingleForJet_0x09
+SingleForJet_0x0D:SingleForJet_0x0D
+SingleForJet_0x11:SingleForJet_0x11
+SingleForJet_0x13:SingleForJet_0x13
+SingleForJet_0x17:SingleForJet_0x17
+SingleForJet_0x20:SingleForJet_0x20
+SingleForJet_0x2C:SingleForJet_0x2C
+SingleForJet_0x32:SingleForJet_0x32
+SingleForJet_0x3C:SingleForJet_0x3C
+SingleIsoEG_0x05:SingleIsoEG_0x05
+SingleIsoEG_0x06:SingleIsoEG_0x06
+SingleIsoEG_0x07:SingleIsoEG_0x07
+SingleIsoEG_0x08:SingleIsoEG_0x08
+SingleIsoEG_0x0A:SingleIsoEG_0x0A
+SingleIsoEG_0x0E:SingleIsoEG_0x0E
+SingleIsoEG_0x0F:SingleIsoEG_0x0F
+SingleIsoEG_0x12:SingleIsoEG_0x12
+SingleIsoEG_0x14:SingleIsoEG_0x14
+SingleIsoEG_0x14_Eta2p17:SingleIsoEG_0x14_Eta2p17
+SingleIsoEG_0x16:SingleIsoEG_0x16
+SingleIsoEG_0x16_Eta2p17:SingleIsoEG_0x16_Eta2p17
+SingleIsoEG_0x19:SingleIsoEG_0x19
+SingleIsoEG_0x19_Eta2p17:SingleIsoEG_0x19_Eta2p17
+SingleIsoEG_0x1C_Eta2p17:SingleIsoEG_0x1C_Eta2p17
+SingleIsoEG_0x1E:SingleIsoEG_0x1E
+SingleIsoEG_0x1E_Eta2p17:SingleIsoEG_0x1E_Eta2p17
+SingleIsoEG_0x23:SingleIsoEG_0x23
+SingleIsoEG_0x28:SingleIsoEG_0x28
+SingleMu_0x01_BeamHalo:SingleMu_0x01_BeamHalo
+SingleMu_0x01_Eta2p1:SingleMu_0x01_Eta2p1
+SingleMu_0x01_Open:SingleMu_0x01_Open
+SingleMu_0x07:SingleMu_0x07
+SingleMu_0x09:SingleMu_0x09
+SingleMu_0x0A:SingleMu_0x0A
+SingleMu_0x0C:SingleMu_0x0C
+SingleMu_0x0D_Eta2p1:SingleMu_0x0D_Eta2p1
+SingleMu_0x0E:SingleMu_0x0E
+SingleMu_0x0F_Eta2p1:SingleMu_0x0F_Eta2p1
+SingleMu_0x10:SingleMu_0x10
+SingleMu_0x10_Eta2p1:SingleMu_0x10_Eta2p1
+SingleMu_0x11_Eta2p1:SingleMu_0x11_Eta2p1
+SingleMu_0x12:SingleMu_0x12
+SingleMu_0x12_Eta2p1:SingleMu_0x12_Eta2p1
+SingleMu_0x13:SingleMu_0x13
+SingleMu_0x13_Eta2p1:SingleMu_0x13_Eta2p1
+SingleMu_0x14:SingleMu_0x14
+SingleMu_0x14_Eta2p1:SingleMu_0x14_Eta2p1
+SingleNoIsoEG_0x05:SingleNoIsoEG_0x05
+SingleNoIsoEG_0x06:SingleNoIsoEG_0x06
+SingleNoIsoEG_0x07:SingleNoIsoEG_0x07
+SingleNoIsoEG_0x08:SingleNoIsoEG_0x08
+SingleNoIsoEG_0x0A:SingleNoIsoEG_0x0A
+SingleNoIsoEG_0x0E:SingleNoIsoEG_0x0E
+SingleNoIsoEG_0x0F:SingleNoIsoEG_0x0F
+SingleNoIsoEG_0x12:SingleNoIsoEG_0x12
+SingleNoIsoEG_0x14:SingleNoIsoEG_0x14
+SingleNoIsoEG_0x16:SingleNoIsoEG_0x16
+SingleNoIsoEG_0x19:SingleNoIsoEG_0x19
+SingleNoIsoEG_0x19_Eta2p17:SingleNoIsoEG_0x19_Eta2p17
+SingleNoIsoEG_0x1E:SingleNoIsoEG_0x1E
+SingleNoIsoEG_0x23:SingleNoIsoEG_0x23
+SingleNoIsoEG_0x28:SingleNoIsoEG_0x28
+SingleTauJet_0x05_Eta2p17:SingleTauJet_0x05_Eta2p17
+SingleTauJet_0x0D:SingleTauJet_0x0D
+TOTEM_1:TOTEM_1
+TOTEM_2:TOTEM_2
+TOTEM_3:TOTEM_3
+TOTEM_Diffractive.v0:TOTEM_Diffractive.v0
+TOTEM_LowMultiplicity.v0:TOTEM_LowMultiplicity.v0
+TOTEM_MinBias.v0:TOTEM_MinBias.v0
+TOTEM_RomanPotsOR:TOTEM_RomanPotsOR
+TOTEM_ZeroBias.v0:TOTEM_ZeroBias.v0
+TripleCenJet_0x17_0x13_0x10:TripleCenJet_0x17_0x13_0x10
+TripleIsoEG_0x0E_0x0A_0x08:TripleIsoEG_0x0E_0x0A_0x08
+TripleMu_0x01_HighQ:TripleMu_0x01_HighQ
+TripleMu_0x09_0x09_0x05:TripleMu_0x09_0x09_0x05
+TripleNoIsoEG_0x0E_0x0A_0x08:TripleNoIsoEG_0x0E_0x0A_0x08
+ZDC_Calo_minus.v0:ZDC_Calo_minus.v0
+ZDC_Calo_plus.v0:ZDC_Calo_plus.v0
+ZDC_Scint_loose_vertex.v0:ZDC_Scint_loose_vertex.v0
+ZDC_Scint_minus.v0:ZDC_Scint_minus.v0
+ZDC_Scint_plus.v0:ZDC_Scint_plus.v0
+ZDC_Scint_tight_vertex.v0:ZDC_Scint_tight_vertex.v0
+ZDC_loose_vertex.v0:ZDC_loose_vertex.v0
+ZDC_minus_over_threshold.v0:ZDC_minus_over_threshold.v0
+ZDC_plus_over_threshold.v0:ZDC_plus_over_threshold.v0
+ZDC_tight_vertex.v0:ZDC_tight_vertex.v0
+CondDBLockEnd-->

--- a/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_50nsGct_v4_L1T_Scales_20141121.xml
+++ b/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_50nsGct_v4_L1T_Scales_20141121.xml
@@ -1,0 +1,9052 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<def>
+<header>
+    <MenuInterface>L1Menu_Collisions2015_50nsGct_v4</MenuInterface>
+    <MenuInterface_CreationDate>2015-06-25</MenuInterface_CreationDate>
+    <MenuInterface_CreationAuthor>V. M. Ghete, T. Matsushita</MenuInterface_CreationAuthor>
+    <MenuInterface_Description>L1 menu for pp data taking 2015, GCT version</MenuInterface_Description>
+    <Menu_CreationDate>2015-06-25</Menu_CreationDate>
+    <Menu_CreationAuthor>V. M. Ghete, T. Matsushita</Menu_CreationAuthor>
+    <Menu_Description>L1 menu for pp data taking 2015</Menu_Description>
+    <AlgImplementation>Imp0</AlgImplementation>
+    <ScaleDbKey>L1T_Scales_20141121</ScaleDbKey>
+</header>
+  <condition_chip_1>
+    <prealgos>
+      <L1_DoubleEG_15_10 algAlias="L1_DoubleEG_15_10">
+        DoubleIsoEG_0x0F_0x0A OR DoubleNoIsoEG_0x0F_0x0A OR ( SingleIsoEG_0x0F AND SingleNoIsoEG_0x0A ) OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x0F )
+        <output_pin nr="6" pin="a" />
+      </L1_DoubleEG_15_10>
+      <L1_DoubleEG_20_10_1LegIso algAlias="L1_DoubleEG_20_10_1LegIso">
+        DoubleIsoEG_0x14_0x0A OR ( SingleIsoEG_0x14 AND SingleNoIsoEG_0x0A ) OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x14 )
+        <output_pin nr="8" pin="a" />
+      </L1_DoubleEG_20_10_1LegIso>
+      <L1_DoubleEG_22_10 algAlias="L1_DoubleEG_22_10">
+        DoubleIsoEG_0x16_0x0A OR DoubleNoIsoEG_0x16_0x0A OR ( SingleIsoEG_0x16 AND SingleNoIsoEG_0x0A ) OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x16 )
+        <output_pin nr="7" pin="a" />
+      </L1_DoubleEG_22_10>
+      <L1_DoubleJetC100 algAlias="L1_DoubleJetC100">
+        DoubleCenJet_0x19 OR DoubleTauJet_0x19 OR ( SingleCenJet_0x19 AND SingleTauJet_0x19 )
+        <output_pin nr="15" pin="a" />
+      </L1_DoubleJetC100>
+      <L1_DoubleJetC32_WdPhi7_HTT125 algAlias="L1_DoubleJetC32_WdPhi7_HTT125">
+        ( DoubleCenJet_wsc_0x08_WdPhi7 OR DoubleTauJet_wsc_0x08_WdPhi7 OR Corr_CenJet_TauJet_0x08_WdPhi7 ) AND HTT_0x0FA
+        <output_pin nr="11" pin="a" />
+      </L1_DoubleJetC32_WdPhi7_HTT125>
+      <L1_DoubleJetC56_ETM60 algAlias="L1_DoubleJetC56_ETM60">
+        ( DoubleCenJet_0x0E OR DoubleTauJet_0x0E OR ( SingleCenJet_0x0E AND SingleTauJet_0x0E ) ) AND ETM_0x078
+        <output_pin nr="18" pin="a" />
+      </L1_DoubleJetC56_ETM60>
+      <L1_DoubleJetC60_ETM60 algAlias="L1_DoubleJetC60_ETM60">
+        ( DoubleCenJet_0x0F OR DoubleTauJet_0x0F OR ( SingleCenJet_0x0F AND SingleTauJet_0x0F ) ) AND ETM_0x078
+        <output_pin nr="10" pin="a" />
+      </L1_DoubleJetC60_ETM60>
+      <L1_DoubleMu0_Eta1p6_WdEta18 algAlias="L1_DoubleMu0_Eta1p6_WdEta18">
+        DoubleMu_wsc_0x01_Eta1p6_WdEta18
+        <output_pin nr="19" pin="a" />
+      </L1_DoubleMu0_Eta1p6_WdEta18>
+      <L1_DoubleMu0_Eta1p6_WdEta18_OS algAlias="L1_DoubleMu0_Eta1p6_WdEta18_OS">
+        DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS
+        <output_pin nr="28" pin="a" />
+      </L1_DoubleMu0_Eta1p6_WdEta18_OS>
+      <L1_DoubleMuOpen algAlias="L1_DoubleMuOpen">
+        DoubleMu_0x01_Open
+        <output_pin nr="1" pin="a" />
+      </L1_DoubleMuOpen>
+      <L1_DoubleMu_10_0_WdEta18 algAlias="L1_DoubleMu_10_0_WdEta18">
+        DoubleMu_wsc_0x0D_0x01_WdEta18
+        <output_pin nr="31" pin="a" />
+      </L1_DoubleMu_10_0_WdEta18>
+      <L1_DoubleMu_12_5 algAlias="L1_DoubleMu_12_5">
+        DoubleMu_0x0E_0x09_HighQ
+        <output_pin nr="29" pin="a" />
+      </L1_DoubleMu_12_5>
+      <L1_ETM60 algAlias="L1_ETM60">
+        ETM_0x078
+        <output_pin nr="14" pin="a" />
+      </L1_ETM60>
+      <L1_ETM60_NotJet52WdPhi2 algAlias="L1_ETM60_NotJet52WdPhi2">
+        ETM_0x078 AND ( NOT Corr_ETM_CenJet_0x78_0x0D_WdPhi2 ) AND ( NOT Corr_ETM_ForJet_0x78_0x0D_WdPhi2 ) AND ( NOT Corr_ETM_TauJet_0x78_0x0D_WdPhi2 )
+        <output_pin nr="20" pin="a" />
+      </L1_ETM60_NotJet52WdPhi2>
+      <L1_ETM70_NotJet52WdPhi2 algAlias="L1_ETM70_NotJet52WdPhi2">
+        ETM_0x08C AND ( NOT Corr_ETM_CenJet_0x8C_0x0D_WdPhi2 ) AND ( NOT Corr_ETM_ForJet_0x8C_0x0D_WdPhi2 ) AND ( NOT Corr_ETM_TauJet_0x8C_0x0D_WdPhi2 )
+        <output_pin nr="21" pin="a" />
+      </L1_ETM70_NotJet52WdPhi2>
+      <L1_ETT130 algAlias="L1_ETT130">
+        ETT_0x104
+        <output_pin nr="22" pin="a" />
+      </L1_ETT130>
+      <L1_Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1 algAlias="L1_Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1">
+        DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23 AND ( Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1 OR Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1 OR Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1 )
+        <output_pin nr="12" pin="a" />
+      </L1_Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1>
+      <L1_Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1 algAlias="L1_Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1">
+        ( Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3 OR Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3 ) AND ( Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1 OR Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1 OR Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1 )
+        <output_pin nr="13" pin="a" />
+      </L1_Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1>
+      <L1_Mu0er_ETM55 algAlias="L1_Mu0er_ETM55">
+        SingleMu_0x01_Eta2p1 AND ETM_0x06E
+        <output_pin nr="9" pin="a" />
+      </L1_Mu0er_ETM55>
+      <L1_QuadJetC60 algAlias="L1_QuadJetC60">
+        QuadCenJet_0x0F OR QuadTauJet_0x0F OR ( TripleCenJet_0x0F AND SingleTauJet_0x0F ) OR ( TripleTauJet_0x0F AND SingleCenJet_0x0F ) OR ( DoubleCenJet_0x0F AND DoubleTauJet_0x0F )
+        <output_pin nr="16" pin="a" />
+      </L1_QuadJetC60>
+      <L1_QuadMu0 algAlias="L1_QuadMu0">
+        QuadMu_0x01
+        <output_pin nr="26" pin="a" />
+      </L1_QuadMu0>
+      <L1_RomanPotsAND algAlias="L1_RomanPotsAND">
+        TOTEM_0
+        <output_pin nr="23" pin="a" />
+      </L1_RomanPotsAND>
+      <L1_SingleJet12_BptxAND algAlias="L1_SingleJet12_BptxAND">
+        ( SingleCenJet_0x03 OR SingleForJet_0x03 OR SingleTauJet_0x03 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="4" pin="a" />
+      </L1_SingleJet12_BptxAND>
+      <L1_SingleJetC20_NotBptxOR algAlias="L1_SingleJetC20_NotBptxOR">
+        ( SingleCenJet_0x05 OR SingleTauJet_0x05 ) AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="17" pin="a" />
+      </L1_SingleJetC20_NotBptxOR>
+      <L1_SingleMu18er algAlias="L1_SingleMu18er">
+        SingleMu_0x11_Eta2p1
+        <output_pin nr="27" pin="a" />
+      </L1_SingleMu18er>
+      <L1_SingleMuBeamHalo algAlias="L1_SingleMuBeamHalo">
+        SingleMu_0x01_BeamHalo
+        <output_pin nr="32" pin="a" />
+      </L1_SingleMuBeamHalo>
+      <L1_TripleEG_14_10_8 algAlias="L1_TripleEG_14_10_8">
+        TripleIsoEG_0x0E_0x0A_0x08 OR TripleNoIsoEG_0x0E_0x0A_0x08 OR ( DoubleIsoEG_0x0E_0x0A AND SingleNoIsoEG_0x08 ) OR ( DoubleNoIsoEG_0x0E_0x0A AND SingleIsoEG_0x08 ) OR ( DoubleIsoEG_0x0E_0x08 AND SingleNoIsoEG_0x0A ) OR ( DoubleNoIsoEG_0x0E_0x08 AND SingleIsoEG_0x0A ) OR ( DoubleIsoEG_0x0A_0x08 AND SingleNoIsoEG_0x0E ) OR ( DoubleNoIsoEG_0x0A_0x08 AND SingleIsoEG_0x0E )
+        <output_pin nr="5" pin="a" />
+      </L1_TripleEG_14_10_8>
+      <L1_TripleJet_92_76_64 algAlias="L1_TripleJet_92_76_64">
+        TripleCenJet_0x17_0x13_0x10 OR TripleTauJet_0x17_0x13_0x10 OR TripleForJet_0x17_0x13_0x10 OR ( DoubleCenJet_0x17_0x13 AND ( SingleTauJet_0x10 OR SingleForJet_0x10 ) ) OR ( DoubleCenJet_0x17_0x10 AND ( SingleTauJet_0x13 OR SingleForJet_0x13 ) ) OR ( DoubleCenJet_0x13_0x10 AND ( SingleTauJet_0x17 OR SingleForJet_0x17 ) ) OR ( DoubleTauJet_0x17_0x13 AND ( SingleCenJet_0x10 OR SingleForJet_0x10 ) ) OR ( DoubleTauJet_0x17_0x10 AND ( SingleCenJet_0x13 OR SingleForJet_0x13 ) ) OR ( DoubleTauJet_0x13_0x10 AND ( SingleCenJet_0x17 OR SingleForJet_0x17 ) ) OR ( DoubleForJet_0x17_0x13 AND ( SingleCenJet_0x10 OR SingleTauJet_0x10 ) ) OR ( DoubleForJet_0x17_0x10 AND ( SingleCenJet_0x13 OR SingleTauJet_0x13 ) ) OR ( DoubleForJet_0x13_0x10 AND ( SingleCenJet_0x17 OR SingleTauJet_0x17 ) ) OR ( SingleCenJet_0x17 AND ( ( SingleTauJet_0x13 AND SingleForJet_0x10 ) OR ( SingleTauJet_0x10 AND SingleForJet_0x13 ) ) ) OR ( SingleCenJet_0x13 AND ( ( SingleTauJet_0x17 AND SingleForJet_0x10 ) OR ( SingleTauJet_0x10 AND SingleForJet_0x17 ) ) ) OR ( SingleCenJet_0x10 AND ( ( SingleTauJet_0x13 AND SingleForJet_0x17 ) OR ( SingleTauJet_0x17 AND SingleForJet_0x13 ) ) )
+        <output_pin nr="24" pin="a" />
+      </L1_TripleJet_92_76_64>
+      <L1_TripleJet_92_76_64_NoFFF algAlias="L1_TripleJet_92_76_64_NoFFF">
+        TripleCenJet_0x17_0x13_0x10 OR TripleTauJet_0x17_0x13_0x10 OR ( DoubleCenJet_0x17_0x13 AND ( SingleTauJet_0x10 OR SingleForJet_0x10 ) ) OR ( DoubleCenJet_0x17_0x10 AND ( SingleTauJet_0x13 OR SingleForJet_0x13 ) ) OR ( DoubleCenJet_0x13_0x10 AND ( SingleTauJet_0x17 OR SingleForJet_0x17 ) ) OR ( DoubleTauJet_0x17_0x13 AND ( SingleCenJet_0x10 OR SingleForJet_0x10 ) ) OR ( DoubleTauJet_0x17_0x10 AND ( SingleCenJet_0x13 OR SingleForJet_0x13 ) ) OR ( DoubleTauJet_0x13_0x10 AND ( SingleCenJet_0x17 OR SingleForJet_0x17 ) ) OR ( DoubleForJet_0x17_0x13 AND ( SingleCenJet_0x10 OR SingleTauJet_0x10 ) ) OR ( DoubleForJet_0x17_0x10 AND ( SingleCenJet_0x13 OR SingleTauJet_0x13 ) ) OR ( DoubleForJet_0x13_0x10 AND ( SingleCenJet_0x17 OR SingleTauJet_0x17 ) ) OR ( SingleCenJet_0x17 AND ( ( SingleTauJet_0x13 AND SingleForJet_0x10 ) OR ( SingleTauJet_0x10 AND SingleForJet_0x13 ) ) ) OR ( SingleCenJet_0x13 AND ( ( SingleTauJet_0x17 AND SingleForJet_0x10 ) OR ( SingleTauJet_0x10 AND SingleForJet_0x17 ) ) ) OR ( SingleCenJet_0x10 AND ( ( SingleTauJet_0x13 AND SingleForJet_0x17 ) OR ( SingleTauJet_0x17 AND SingleForJet_0x13 ) ) )
+        <output_pin nr="25" pin="a" />
+      </L1_TripleJet_92_76_64_NoFFF>
+      <L1_TripleMu0 algAlias="L1_TripleMu0">
+        TripleMu_0x01_HighQ
+        <output_pin nr="2" pin="a" />
+      </L1_TripleMu0>
+      <L1_TripleMu_5_5_3 algAlias="L1_TripleMu_5_5_3">
+        TripleMu_0x09_0x09_0x05
+        <output_pin nr="3" pin="a" />
+      </L1_TripleMu_5_5_3>
+    </prealgos>
+    <conditions>
+    <Corr_CenJet_TauJet_0x08_WdPhi7 condition="CondCorrelation" particle="CenJet:TauJet" type="Type2cor">
+    <Corr_CenJet_TauJet_0x08_WdPhi7_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_CenJet_TauJet_0x08_WdPhi7_CenJet>
+    <Corr_CenJet_TauJet_0x08_WdPhi7_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_CenJet_TauJet_0x08_WdPhi7_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      0FF
+    </value>
+    </delta_phi>    </Corr_CenJet_TauJet_0x08_WdPhi7>
+    <Corr_ETM_CenJet_0x78_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:CenJet" type="Type2cor">
+    <Corr_ETM_CenJet_0x78_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x78_0x0D_WdPhi2_ETM>
+    <Corr_ETM_CenJet_0x78_0x0D_WdPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x78_0x0D_WdPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_CenJet_0x78_0x0D_WdPhi2>
+    <Corr_ETM_CenJet_0x8C_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:CenJet" type="Type2cor">
+    <Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_ETM>
+    <Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_CenJet_0x8C_0x0D_WdPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_CenJet_0x8C_0x0D_WdPhi2>
+    <Corr_ETM_ForJet_0x78_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:ForJet" type="Type2cor">
+    <Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ETM>
+    <Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ForJet condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x78_0x0D_WdPhi2_ForJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_ForJet_0x78_0x0D_WdPhi2>
+    <Corr_ETM_ForJet_0x8C_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:ForJet" type="Type2cor">
+    <Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ETM>
+    <Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ForJet condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_ForJet_0x8C_0x0D_WdPhi2_ForJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_ForJet_0x8C_0x0D_WdPhi2>
+    <Corr_ETM_TauJet_0x78_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:TauJet" type="Type2cor">
+    <Corr_ETM_TauJet_0x78_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_TauJet_0x78_0x0D_WdPhi2_ETM>
+    <Corr_ETM_TauJet_0x78_0x0D_WdPhi2_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_TauJet_0x78_0x0D_WdPhi2_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_TauJet_0x78_0x0D_WdPhi2>
+    <Corr_ETM_TauJet_0x8C_0x0D_WdPhi2 condition="CondCorrelation" particle="ETM:TauJet" type="Type2cor">
+    <Corr_ETM_TauJet_0x8C_0x0D_WdPhi2_ETM condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </Corr_ETM_TauJet_0x8C_0x0D_WdPhi2_ETM>
+    <Corr_ETM_TauJet_0x8C_0x0D_WdPhi2_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_ETM_TauJet_0x8C_0x0D_WdPhi2_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_ETM_TauJet_0x8C_0x0D_WdPhi2>
+    <Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1 condition="CondCorrelation" particle="Mu:CenJet" type="Type2cor">
+    <Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_Mu>
+    <Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      003
+    </value>
+    </delta_phi>    </Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1>
+    <Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1 condition="CondCorrelation" particle="Mu:ForJet" type="Type2cor">
+    <Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_Mu>
+    <Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_ForJet condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1_ForJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFFE
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      003
+    </value>
+    </delta_phi>    </Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1>
+    <Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3 condition="CondCorrelation" particle="Mu:IsoEG" type="Type2cor">
+    <Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_Mu>
+    <Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_IsoEG condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3_IsoEG>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      3F0
+    </value>
+    </delta_phi>    </Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3>
+    <Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3 condition="CondCorrelation" particle="Mu:NoIsoEG" type="Type2cor">
+    <Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_Mu>
+    <Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_NoIsoEG condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3_NoIsoEG>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      3F0
+    </value>
+    </delta_phi>    </Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3>
+    <Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1 condition="CondCorrelation" particle="Mu:TauJet" type="Type2cor">
+    <Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1_Mu>
+    <Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFF
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      003
+    </value>
+    </delta_phi>    </Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1>
+    <DoubleCenJet_0x0E condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x0E>
+    <DoubleCenJet_0x0F condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x0F>
+    <DoubleCenJet_0x13_0x10 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x13_0x10>
+    <DoubleCenJet_0x17_0x10 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x17_0x10>
+    <DoubleCenJet_0x17_0x13 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        13
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x17_0x13>
+    <DoubleCenJet_0x19 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x19>
+    <DoubleCenJet_wsc_0x08_WdPhi7 condition="calo" particle="jet" type="2_wsc">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        3fff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        0ff
+      </value>
+      </delta_phi>
+    </DoubleCenJet_wsc_0x08_WdPhi7>
+    <DoubleForJet_0x13_0x10 condition="calo" particle="fwdjet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleForJet_0x13_0x10>
+    <DoubleForJet_0x17_0x10 condition="calo" particle="fwdjet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleForJet_0x17_0x10>
+    <DoubleForJet_0x17_0x13 condition="calo" particle="fwdjet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        13
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleForJet_0x17_0x13>
+    <DoubleIsoEG_0x0A_0x08 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0A_0x08>
+    <DoubleIsoEG_0x0E_0x08 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0E_0x08>
+    <DoubleIsoEG_0x0E_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0E_0x0A>
+    <DoubleIsoEG_0x0F_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0F_0x0A>
+    <DoubleIsoEG_0x14_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x14_0x0A>
+    <DoubleIsoEG_0x16_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x16_0x0A>
+    <DoubleMu_0x01_Open condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      <value>
+        fc
+      </value>
+      </quality>
+    </DoubleMu_0x01_Open>
+    <DoubleMu_0x0E_0x09_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        09
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0e<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0E_0x09_HighQ>
+    <DoubleMu_wsc_0x01_Eta1p6_WdEta18 condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFF0000FFFF
+      </value>
+      <value>
+        FFFF0000FFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        000000000007ffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffffffffff
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x01_Eta1p6_WdEta18>
+    <DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFF0000FFFF
+      </value>
+      <value>
+        FFFF0000FFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      2
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        000000000007ffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffffffffff
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS>
+    <DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23 condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        0d
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        ffffffffffffffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffff000000
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23>
+    <DoubleMu_wsc_0x0D_0x01_WdEta18 condition="muon" particle="muon" type="2_wsc">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        000000000007ffff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        1ffffffffffffffffff
+      </value>
+      </delta_phi>
+    </DoubleMu_wsc_0x0D_0x01_WdEta18>
+    <DoubleNoIsoEG_0x0A_0x08 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0A_0x08>
+    <DoubleNoIsoEG_0x0E_0x08 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0E_0x08>
+    <DoubleNoIsoEG_0x0E_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0E_0x0A>
+    <DoubleNoIsoEG_0x0F_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0F_0x0A>
+    <DoubleNoIsoEG_0x16_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x16_0x0A>
+    <DoubleTauJet_0x0E condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x0E>
+    <DoubleTauJet_0x0F condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x0F>
+    <DoubleTauJet_0x13_0x10 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x13_0x10>
+    <DoubleTauJet_0x17_0x10 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x17_0x10>
+    <DoubleTauJet_0x17_0x13 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        13
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x17_0x13>
+    <DoubleTauJet_0x19 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x19>
+    <DoubleTauJet_wsc_0x08_WdPhi7 condition="calo" particle="tau" type="2_wsc">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+            <delta_eta max="3fff" min="0000">
+      <value>
+        3fff
+      </value>
+      </delta_eta>
+            <delta_phi max="3ff" min="000">
+      <value>
+        0ff
+      </value>
+      </delta_phi>
+    </DoubleTauJet_wsc_0x08_WdPhi7>
+    <ETM_0x06E condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        06e
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x06E>
+    <ETM_0x078 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x078>
+    <ETM_0x08C condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x08C>
+    <ETT_0x104 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        104
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x104>
+    <HTT_0x0FA condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0fa
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x0FA>
+    <QuadCenJet_0x0F condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x0F>
+    <QuadMu_0x01 condition="muon" particle="muon" type="4">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </QuadMu_0x01>
+    <QuadTauJet_0x0F condition="calo" particle="tau" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadTauJet_0x0F>
+    <SingleCenJet_0x03 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        03
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x03>
+    <SingleCenJet_0x05 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x05>
+    <SingleCenJet_0x0E condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x0E>
+    <SingleCenJet_0x0F condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x0F>
+    <SingleCenJet_0x10 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x10>
+    <SingleCenJet_0x13 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x13>
+    <SingleCenJet_0x17 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x17>
+    <SingleCenJet_0x19 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x19>
+    <SingleForJet_0x03 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        03
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x03>
+    <SingleForJet_0x10 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x10>
+    <SingleForJet_0x13 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x13>
+    <SingleForJet_0x17 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x17>
+    <SingleIsoEG_0x08 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x08>
+    <SingleIsoEG_0x0A condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0A>
+    <SingleIsoEG_0x0E condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0E>
+    <SingleIsoEG_0x0F condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0F>
+    <SingleIsoEG_0x14 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x14>
+    <SingleIsoEG_0x16 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x16>
+    <SingleMu_0x01_BeamHalo condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        02
+      </value>
+      </quality>
+    </SingleMu_0x01_BeamHalo>
+    <SingleMu_0x01_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x01_Eta2p1>
+    <SingleMu_0x11_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>11<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x11_Eta2p1>
+    <SingleNoIsoEG_0x08 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x08>
+    <SingleNoIsoEG_0x0A condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0A>
+    <SingleNoIsoEG_0x0E condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0E>
+    <SingleNoIsoEG_0x0F condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0F>
+    <SingleNoIsoEG_0x14 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x14>
+    <SingleNoIsoEG_0x16 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x16>
+    <SingleTauJet_0x03 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        03
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x03>
+    <SingleTauJet_0x05 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x05>
+    <SingleTauJet_0x0E condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x0E>
+    <SingleTauJet_0x0F condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x0F>
+    <SingleTauJet_0x10 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x10>
+    <SingleTauJet_0x13 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x13>
+    <SingleTauJet_0x17 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x17>
+    <SingleTauJet_0x19 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x19>
+    <TripleCenJet_0x0F condition="calo" particle="jet" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleCenJet_0x0F>
+    <TripleCenJet_0x17_0x13_0x10 condition="calo" particle="jet" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleCenJet_0x17_0x13_0x10>
+    <TripleForJet_0x17_0x13_0x10 condition="calo" particle="fwdjet" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleForJet_0x17_0x13_0x10>
+    <TripleIsoEG_0x0E_0x0A_0x08 condition="calo" particle="ieg" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleIsoEG_0x0E_0x0A_0x08>
+    <TripleMu_0x01_HighQ condition="muon" particle="muon" type="3">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </TripleMu_0x01_HighQ>
+    <TripleMu_0x09_0x09_0x05 condition="muon" particle="muon" type="3">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </TripleMu_0x09_0x09_0x05>
+    <TripleNoIsoEG_0x0E_0x0A_0x08 condition="calo" particle="eg" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleNoIsoEG_0x0E_0x0A_0x08>
+    <TripleTauJet_0x0F condition="calo" particle="tau" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleTauJet_0x0F>
+    <TripleTauJet_0x17_0x13_0x10 condition="calo" particle="tau" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      <value>
+        13
+      </value>
+      <value>
+        10
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleTauJet_0x17_0x13_0x10>
+      <BPTX_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_minus.v0>
+      <BPTX_plus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus.v0>
+      <BPTX_plus_AND_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus_AND_minus.v0>
+      <TOTEM_0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></TOTEM_0>
+    </conditions>
+  </condition_chip_1>
+  <condition_chip_2>
+    <prealgos>
+      <L1_AlwaysTrue algAlias="L1_AlwaysTrue">
+        BPTX_plus_AND_minus.v0 OR ( NOT BPTX_plus_AND_minus.v0 )
+        <output_pin nr="2" pin="a" />
+      </L1_AlwaysTrue>
+      <L1_DoubleEG6_HTT150 algAlias="L1_DoubleEG6_HTT150">
+        ( DoubleIsoEG_0x06 OR DoubleNoIsoEG_0x06 OR ( SingleIsoEG_0x06 AND SingleNoIsoEG_0x06 ) ) AND HTT_0x12C
+        <output_pin nr="93" pin="a" />
+      </L1_DoubleEG6_HTT150>
+      <L1_DoubleJetC112 algAlias="L1_DoubleJetC112">
+        DoubleCenJet_0x1C OR DoubleTauJet_0x1C OR ( SingleCenJet_0x1C AND SingleTauJet_0x1C )
+        <output_pin nr="44" pin="a" />
+      </L1_DoubleJetC112>
+      <L1_DoubleJetC120 algAlias="L1_DoubleJetC120">
+        DoubleCenJet_0x1E OR DoubleTauJet_0x1E_v1 OR ( SingleCenJet_0x1E AND SingleTauJet_0x1E )
+        <output_pin nr="17" pin="a" />
+      </L1_DoubleJetC120>
+      <L1_DoubleJetC52 algAlias="L1_DoubleJetC52">
+        DoubleCenJet_0x0D OR DoubleTauJet_0x0D OR ( SingleCenJet_0x0D AND SingleTauJet_0x0D )
+        <output_pin nr="41" pin="a" />
+      </L1_DoubleJetC52>
+      <L1_DoubleJetC72 algAlias="L1_DoubleJetC72">
+        DoubleCenJet_0x12 OR DoubleTauJet_0x12 OR ( SingleCenJet_0x12 AND SingleTauJet_0x12 )
+        <output_pin nr="16" pin="a" />
+      </L1_DoubleJetC72>
+      <L1_DoubleJetC84 algAlias="L1_DoubleJetC84">
+        DoubleCenJet_0x15 OR DoubleTauJet_0x15 OR ( SingleCenJet_0x15 AND SingleTauJet_0x15 )
+        <output_pin nr="42" pin="a" />
+      </L1_DoubleJetC84>
+      <L1_DoubleMu0 algAlias="L1_DoubleMu0">
+        DoubleMu_0x01_HighQ
+        <output_pin nr="27" pin="a" />
+      </L1_DoubleMu0>
+      <L1_DoubleMu6_EG6 algAlias="L1_DoubleMu6_EG6">
+        DoubleMu_0x0A_HighQ AND ( SingleNoIsoEG_0x06 OR SingleIsoEG_0x06 )
+        <output_pin nr="91" pin="a" />
+      </L1_DoubleMu6_EG6>
+      <L1_DoubleMu7_EG7 algAlias="L1_DoubleMu7_EG7">
+        DoubleMu_0x0B_HighQ AND ( SingleNoIsoEG_0x07 OR SingleIsoEG_0x07 )
+        <output_pin nr="86" pin="a" />
+      </L1_DoubleMu7_EG7>
+      <L1_DoubleMu_10_3p5 algAlias="L1_DoubleMu_10_3p5">
+        DoubleMu_0x0D_0x06_HighQ
+        <output_pin nr="46" pin="a" />
+      </L1_DoubleMu_10_3p5>
+      <L1_DoubleMu_10_Open algAlias="L1_DoubleMu_10_Open">
+        DoubleMu_0x0D_HighQ_0x01
+        <output_pin nr="45" pin="a" />
+      </L1_DoubleMu_10_Open>
+      <L1_DoubleTauJet36er algAlias="L1_DoubleTauJet36er">
+        DoubleTauJet_0x09_Eta2p17
+        <output_pin nr="25" pin="a" />
+      </L1_DoubleTauJet36er>
+      <L1_DoubleTauJet40er algAlias="L1_DoubleTauJet40er">
+        DoubleTauJet_0x0A_Eta2p17
+        <output_pin nr="12" pin="a" />
+      </L1_DoubleTauJet40er>
+      <L1_DoubleTauJet44er algAlias="L1_DoubleTauJet44er">
+        DoubleTauJet_0x0B_Eta2p17
+        <output_pin nr="26" pin="a" />
+      </L1_DoubleTauJet44er>
+      <L1_EG25er_HTT125 algAlias="L1_EG25er_HTT125">
+        ( SingleNoIsoEG_0x19_Eta2p17 OR SingleIsoEG_0x19_Eta2p17 ) AND HTT_0x0FA
+        <output_pin nr="32" pin="a" />
+      </L1_EG25er_HTT125>
+      <L1_ETM100 algAlias="L1_ETM100">
+        ETM_0x0C8
+        <output_pin nr="70" pin="a" />
+      </L1_ETM100>
+      <L1_ETM30 algAlias="L1_ETM30">
+        ETM_0x03C
+        <output_pin nr="67" pin="a" />
+      </L1_ETM30>
+      <L1_ETM40 algAlias="L1_ETM40">
+        ETM_0x050
+        <output_pin nr="80" pin="a" />
+      </L1_ETM40>
+      <L1_ETM50 algAlias="L1_ETM50">
+        ETM_0x064
+        <output_pin nr="68" pin="a" />
+      </L1_ETM50>
+      <L1_ETM70 algAlias="L1_ETM70">
+        ETM_0x08C
+        <output_pin nr="69" pin="a" />
+      </L1_ETM70>
+      <L1_ETT15 algAlias="L1_ETT15">
+        ETT_0x01E
+        <output_pin nr="29" pin="a" />
+      </L1_ETT15>
+      <L1_ETT40 algAlias="L1_ETT40">
+        ETT_0x050
+        <output_pin nr="60" pin="a" />
+      </L1_ETT40>
+      <L1_ETT60 algAlias="L1_ETT60">
+        ETT_0x078
+        <output_pin nr="95" pin="a" />
+      </L1_ETT60>
+      <L1_ETT90 algAlias="L1_ETT90">
+        ETT_0x0B4
+        <output_pin nr="96" pin="a" />
+      </L1_ETT90>
+      <L1_HTT125 algAlias="L1_HTT125">
+        HTT_0x0FA
+        <output_pin nr="71" pin="a" />
+      </L1_HTT125>
+      <L1_HTT150 algAlias="L1_HTT150">
+        HTT_0x12C
+        <output_pin nr="72" pin="a" />
+      </L1_HTT150>
+      <L1_HTT175 algAlias="L1_HTT175">
+        HTT_0x15E
+        <output_pin nr="73" pin="a" />
+      </L1_HTT175>
+      <L1_HTT200 algAlias="L1_HTT200">
+        HTT_0x190
+        <output_pin nr="74" pin="a" />
+      </L1_HTT200>
+      <L1_HTT250 algAlias="L1_HTT250">
+        HTT_0x1F4
+        <output_pin nr="81" pin="a" />
+      </L1_HTT250>
+      <L1_IsoEG20er_TauJet20er_NotWdEta0 algAlias="L1_IsoEG20er_TauJet20er_NotWdEta0">
+        Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0
+        <output_pin nr="13" pin="a" />
+      </L1_IsoEG20er_TauJet20er_NotWdEta0>
+      <L1_Mu10er_ETM50 algAlias="L1_Mu10er_ETM50">
+        SingleMu_0x0D_Eta2p1 AND ETM_0x064
+        <output_pin nr="84" pin="a" />
+      </L1_Mu10er_ETM50>
+      <L1_Mu12_EG10 algAlias="L1_Mu12_EG10">
+        SingleMu_0x0E AND ( SingleNoIsoEG_0x0A OR SingleIsoEG_0x0A )
+        <output_pin nr="10" pin="a" />
+      </L1_Mu12_EG10>
+      <L1_Mu14er_ETM30 algAlias="L1_Mu14er_ETM30">
+        SingleMu_0x0F_Eta2p1 AND ETM_0x03C
+        <output_pin nr="85" pin="a" />
+      </L1_Mu14er_ETM30>
+      <L1_Mu16er_TauJet20er algAlias="L1_Mu16er_TauJet20er">
+        SingleMu_0x10_Eta2p1 AND SingleTauJet_0x05_Eta2p17
+        <output_pin nr="14" pin="a" />
+      </L1_Mu16er_TauJet20er>
+      <L1_Mu16er_TauJet40erORCenJet72er algAlias="L1_Mu16er_TauJet40erORCenJet72er">
+        SingleMu_0x10_Eta2p1 AND ( SingleTauJet_0x0A_Eta2p17 OR SingleCenJet_0x12_Eta2p17 )
+        <output_pin nr="9" pin="a" />
+      </L1_Mu16er_TauJet40erORCenJet72er>
+      <L1_Mu20_EG10 algAlias="L1_Mu20_EG10">
+        SingleMu_0x12 AND ( SingleNoIsoEG_0x0A OR SingleIsoEG_0x0A )
+        <output_pin nr="75" pin="a" />
+      </L1_Mu20_EG10>
+      <L1_Mu20_EG8 algAlias="L1_Mu20_EG8">
+        SingleMu_0x12 AND ( SingleNoIsoEG_0x08 OR SingleIsoEG_0x08 )
+        <output_pin nr="82" pin="a" />
+      </L1_Mu20_EG8>
+      <L1_Mu3_JetC16_WdEtaPhi2 algAlias="L1_Mu3_JetC16_WdEtaPhi2">
+        Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2 OR Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1
+        <output_pin nr="30" pin="a" />
+      </L1_Mu3_JetC16_WdEtaPhi2>
+      <L1_Mu3_JetC52_WdEtaPhi2 algAlias="L1_Mu3_JetC52_WdEtaPhi2">
+        Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2 OR Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1
+        <output_pin nr="31" pin="a" />
+      </L1_Mu3_JetC52_WdEtaPhi2>
+      <L1_Mu4_EG18 algAlias="L1_Mu4_EG18">
+        SingleMu_0x07 AND ( SingleNoIsoEG_0x12 OR SingleIsoEG_0x12 )
+        <output_pin nr="89" pin="a" />
+      </L1_Mu4_EG18>
+      <L1_Mu5_DoubleEG5 algAlias="L1_Mu5_DoubleEG5">
+        SingleMu_0x09 AND ( DoubleIsoEG_0x05 OR DoubleNoIsoEG_0x05 OR ( SingleIsoEG_0x05 AND SingleNoIsoEG_0x05 ) )
+        <output_pin nr="92" pin="a" />
+      </L1_Mu5_DoubleEG5>
+      <L1_Mu5_EG15 algAlias="L1_Mu5_EG15">
+        SingleMu_0x09 AND ( SingleNoIsoEG_0x0F OR SingleIsoEG_0x0F )
+        <output_pin nr="11" pin="a" />
+      </L1_Mu5_EG15>
+      <L1_Mu5_EG20 algAlias="L1_Mu5_EG20">
+        SingleMu_0x09 AND ( SingleNoIsoEG_0x14 OR SingleIsoEG_0x14 )
+        <output_pin nr="76" pin="a" />
+      </L1_Mu5_EG20>
+      <L1_Mu5_IsoEG18 algAlias="L1_Mu5_IsoEG18">
+        SingleMu_0x09 AND SingleIsoEG_0x12
+        <output_pin nr="77" pin="a" />
+      </L1_Mu5_IsoEG18>
+      <L1_Mu6_DoubleEG10 algAlias="L1_Mu6_DoubleEG10">
+        SingleMu_0x0A AND ( DoubleIsoEG_0x0A OR DoubleNoIsoEG_0x0A OR ( SingleIsoEG_0x0A AND SingleNoIsoEG_0x0A ) )
+        <output_pin nr="78" pin="a" />
+      </L1_Mu6_DoubleEG10>
+      <L1_Mu6_HTT150 algAlias="L1_Mu6_HTT150">
+        SingleMu_0x0A AND HTT_0x12C
+        <output_pin nr="83" pin="a" />
+      </L1_Mu6_HTT150>
+      <L1_Mu8_HTT125 algAlias="L1_Mu8_HTT125">
+        SingleMu_0x0C AND HTT_0x0FA
+        <output_pin nr="88" pin="a" />
+      </L1_Mu8_HTT125>
+      <L1_QuadJetC36_TauJet52 algAlias="L1_QuadJetC36_TauJet52">
+        ( QuadCenJet_0x09 OR QuadTauJet_0x09 OR ( TripleCenJet_0x09 AND SingleTauJet_0x09 ) OR ( TripleTauJet_0x09 AND SingleCenJet_0x09 ) OR ( DoubleCenJet_0x09 AND DoubleTauJet_0x09 ) ) AND SingleTauJet_0x0D
+        <output_pin nr="94" pin="a" />
+      </L1_QuadJetC36_TauJet52>
+      <L1_QuadJetC40 algAlias="L1_QuadJetC40">
+        QuadCenJet_0x0A OR QuadTauJet_0x0A OR ( TripleCenJet_0x0A AND SingleTauJet_0x0A ) OR ( TripleTauJet_0x0A AND SingleCenJet_0x0A ) OR ( DoubleCenJet_0x0A AND DoubleTauJet_0x0A )
+        <output_pin nr="47" pin="a" />
+      </L1_QuadJetC40>
+      <L1_QuadJetC84 algAlias="L1_QuadJetC84">
+        QuadCenJet_0x15 OR QuadTauJet_0x15 OR ( TripleCenJet_0x15 AND SingleTauJet_0x15 ) OR ( TripleTauJet_0x15 AND SingleCenJet_0x15 ) OR ( DoubleCenJet_0x15 AND DoubleTauJet_0x15 )
+        <output_pin nr="15" pin="a" />
+      </L1_QuadJetC84>
+      <L1_SingleEG10 algAlias="L1_SingleEG10">
+        SingleNoIsoEG_0x0A OR SingleIsoEG_0x0A
+        <output_pin nr="38" pin="a" />
+      </L1_SingleEG10>
+      <L1_SingleEG15 algAlias="L1_SingleEG15">
+        SingleNoIsoEG_0x0F OR SingleIsoEG_0x0F
+        <output_pin nr="58" pin="a" />
+      </L1_SingleEG15>
+      <L1_SingleEG20 algAlias="L1_SingleEG20">
+        SingleNoIsoEG_0x14 OR SingleIsoEG_0x14
+        <output_pin nr="53" pin="a" />
+      </L1_SingleEG20>
+      <L1_SingleEG25 algAlias="L1_SingleEG25">
+        SingleNoIsoEG_0x19 OR SingleIsoEG_0x19
+        <output_pin nr="49" pin="a" />
+      </L1_SingleEG25>
+      <L1_SingleEG2_BptxAND algAlias="L1_SingleEG2_BptxAND">
+        ( SingleNoIsoEG_0x02 OR SingleIsoEG_0x02 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="3" pin="a" />
+      </L1_SingleEG2_BptxAND>
+      <L1_SingleEG30 algAlias="L1_SingleEG30">
+        SingleNoIsoEG_0x1E OR SingleIsoEG_0x1E
+        <output_pin nr="54" pin="a" />
+      </L1_SingleEG30>
+      <L1_SingleEG35 algAlias="L1_SingleEG35">
+        SingleNoIsoEG_0x23 OR SingleIsoEG_0x23
+        <output_pin nr="55" pin="a" />
+      </L1_SingleEG35>
+      <L1_SingleEG35er algAlias="L1_SingleEG35er">
+        SingleNoIsoEG_0x23_Eta2p17 OR SingleIsoEG_0x23_Eta2p17
+        <output_pin nr="33" pin="a" />
+      </L1_SingleEG35er>
+      <L1_SingleEG40 algAlias="L1_SingleEG40">
+        SingleNoIsoEG_0x28 OR SingleIsoEG_0x28
+        <output_pin nr="50" pin="a" />
+      </L1_SingleEG40>
+      <L1_SingleEG5 algAlias="L1_SingleEG5">
+        SingleNoIsoEG_0x05 OR SingleIsoEG_0x05
+        <output_pin nr="48" pin="a" />
+      </L1_SingleEG5>
+      <L1_SingleIsoEG18 algAlias="L1_SingleIsoEG18">
+        SingleIsoEG_0x12
+        <output_pin nr="51" pin="a" />
+      </L1_SingleIsoEG18>
+      <L1_SingleIsoEG20er algAlias="L1_SingleIsoEG20er">
+        SingleIsoEG_0x14_Eta2p17
+        <output_pin nr="52" pin="a" />
+      </L1_SingleIsoEG20er>
+      <L1_SingleIsoEG22er algAlias="L1_SingleIsoEG22er">
+        SingleIsoEG_0x16_Eta2p17
+        <output_pin nr="39" pin="a" />
+      </L1_SingleIsoEG22er>
+      <L1_SingleIsoEG25 algAlias="L1_SingleIsoEG25">
+        SingleIsoEG_0x19
+        <output_pin nr="35" pin="a" />
+      </L1_SingleIsoEG25>
+      <L1_SingleIsoEG25er algAlias="L1_SingleIsoEG25er">
+        SingleIsoEG_0x19_Eta2p17
+        <output_pin nr="34" pin="a" />
+      </L1_SingleIsoEG25er>
+      <L1_SingleIsoEG28er algAlias="L1_SingleIsoEG28er">
+        SingleIsoEG_0x1C_Eta2p17
+        <output_pin nr="36" pin="a" />
+      </L1_SingleIsoEG28er>
+      <L1_SingleIsoEG30er algAlias="L1_SingleIsoEG30er">
+        SingleIsoEG_0x1E_Eta2p17
+        <output_pin nr="37" pin="a" />
+      </L1_SingleIsoEG30er>
+      <L1_SingleJet128 algAlias="L1_SingleJet128">
+        SingleCenJet_0x20 OR SingleForJet_0x20 OR SingleTauJet_0x20
+        <output_pin nr="21" pin="a" />
+      </L1_SingleJet128>
+      <L1_SingleJet16 algAlias="L1_SingleJet16">
+        SingleCenJet_0x04 OR SingleForJet_0x04 OR SingleTauJet_0x04
+        <output_pin nr="4" pin="a" />
+      </L1_SingleJet16>
+      <L1_SingleJet176 algAlias="L1_SingleJet176">
+        SingleCenJet_0x2C OR SingleForJet_0x2C OR SingleTauJet_0x2C
+        <output_pin nr="22" pin="a" />
+      </L1_SingleJet176>
+      <L1_SingleJet200 algAlias="L1_SingleJet200">
+        SingleCenJet_0x32 OR SingleForJet_0x32 OR SingleTauJet_0x32
+        <output_pin nr="23" pin="a" />
+      </L1_SingleJet200>
+      <L1_SingleJet240 algAlias="L1_SingleJet240">
+        SingleCenJet_0x3C OR SingleForJet_0x3C OR SingleTauJet_0x3C
+        <output_pin nr="40" pin="a" />
+      </L1_SingleJet240>
+      <L1_SingleJet36 algAlias="L1_SingleJet36">
+        SingleCenJet_0x09 OR SingleForJet_0x09 OR SingleTauJet_0x09
+        <output_pin nr="24" pin="a" />
+      </L1_SingleJet36>
+      <L1_SingleJet52 algAlias="L1_SingleJet52">
+        SingleCenJet_0x0D OR SingleForJet_0x0D OR SingleTauJet_0x0D
+        <output_pin nr="18" pin="a" />
+      </L1_SingleJet52>
+      <L1_SingleJet68 algAlias="L1_SingleJet68">
+        SingleCenJet_0x11 OR SingleForJet_0x11 OR SingleTauJet_0x11
+        <output_pin nr="19" pin="a" />
+      </L1_SingleJet68>
+      <L1_SingleJet92 algAlias="L1_SingleJet92">
+        SingleCenJet_0x17 OR SingleForJet_0x17 OR SingleTauJet_0x17
+        <output_pin nr="20" pin="a" />
+      </L1_SingleJet92>
+      <L1_SingleJetC32_NotBptxOR algAlias="L1_SingleJetC32_NotBptxOR">
+        ( SingleCenJet_0x08 OR SingleTauJet_0x08 ) AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="79" pin="a" />
+      </L1_SingleJetC32_NotBptxOR>
+      <L1_SingleMu12 algAlias="L1_SingleMu12">
+        SingleMu_0x0E
+        <output_pin nr="62" pin="a" />
+      </L1_SingleMu12>
+      <L1_SingleMu14_Eta2p1 algAlias="L1_SingleMu14er">
+        SingleMu_0x0F_Eta2p1
+        <output_pin nr="43" pin="a" />
+      </L1_SingleMu14_Eta2p1>
+      <L1_SingleMu16 algAlias="L1_SingleMu16">
+        SingleMu_0x10
+        <output_pin nr="57" pin="a" />
+      </L1_SingleMu16>
+      <L1_SingleMu16_Eta2p1 algAlias="L1_SingleMu16er">
+        SingleMu_0x10_Eta2p1
+        <output_pin nr="87" pin="a" />
+      </L1_SingleMu16_Eta2p1>
+      <L1_SingleMu20 algAlias="L1_SingleMu20">
+        SingleMu_0x12
+        <output_pin nr="63" pin="a" />
+      </L1_SingleMu20>
+      <L1_SingleMu20er algAlias="L1_SingleMu20er">
+        SingleMu_0x12_Eta2p1
+        <output_pin nr="61" pin="a" />
+      </L1_SingleMu20er>
+      <L1_SingleMu25 algAlias="L1_SingleMu25">
+        SingleMu_0x13
+        <output_pin nr="65" pin="a" />
+      </L1_SingleMu25>
+      <L1_SingleMu25er algAlias="L1_SingleMu25er">
+        SingleMu_0x13_Eta2p1
+        <output_pin nr="64" pin="a" />
+      </L1_SingleMu25er>
+      <L1_SingleMu30 algAlias="L1_SingleMu30">
+        SingleMu_0x14
+        <output_pin nr="66" pin="a" />
+      </L1_SingleMu30>
+      <L1_SingleMu30er algAlias="L1_SingleMu30er">
+        SingleMu_0x14_Eta2p1
+        <output_pin nr="28" pin="a" />
+      </L1_SingleMu30er>
+      <L1_SingleMu5 algAlias="L1_SingleMu5">
+        SingleMu_0x09
+        <output_pin nr="59" pin="a" />
+      </L1_SingleMu5>
+      <L1_SingleMuOpen algAlias="L1_SingleMuOpen">
+        SingleMu_0x01_Open
+        <output_pin nr="56" pin="a" />
+      </L1_SingleMuOpen>
+      <L1_SingleMuOpen_NotBptxOR algAlias="L1_SingleMuOpen_NotBptxOR">
+        SingleMu_0x01_Open AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="90" pin="a" />
+      </L1_SingleMuOpen_NotBptxOR>
+      <L1_ZeroBias algAlias="L1_ZeroBias">
+        BPTX_plus_AND_minus.v0
+        <output_pin nr="1" pin="a" />
+      </L1_ZeroBias>
+    </prealgos>
+    <conditions>
+    <Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0 condition="CondCorrelation" particle="IsoEG:TauJet" type="Type2cor">
+    <Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_IsoEG condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_IsoEG>
+    <Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      3FFE
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      3FF
+    </value>
+    </delta_phi>    </Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0>
+    <Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2 condition="CondCorrelation" particle="Mu:CenJet" type="Type2cor">
+    <Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_Mu>
+    <Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0007
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2>
+    <Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2 condition="CondCorrelation" particle="Mu:CenJet" type="Type2cor">
+    <Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_Mu>
+    <Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_CenJet condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2_CenJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0007
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2>
+    <Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1 condition="CondCorrelation" particle="Mu:TauJet" type="Type2cor">
+    <Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1_Mu>
+    <Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0007
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1>
+    <Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1 condition="CondCorrelation" particle="Mu:TauJet" type="Type2cor">
+    <Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1_Mu condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>05<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1_Mu>
+    <Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1_TauJet condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1_TauJet>
+    <delta_eta max="3fff" min="0000">
+    <value>
+      0007
+    </value>
+    </delta_eta>    <delta_phi max="3ff" min="000">
+    <value>
+      007
+    </value>
+    </delta_phi>    </Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1>
+    <DoubleCenJet_0x09 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x09>
+    <DoubleCenJet_0x0A condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x0A>
+    <DoubleCenJet_0x0D condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x0D>
+    <DoubleCenJet_0x12 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x12>
+    <DoubleCenJet_0x15 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x15>
+    <DoubleCenJet_0x1C condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1c
+      </value>
+      <value>
+        1c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x1C>
+    <DoubleCenJet_0x1E condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x1E>
+    <DoubleIsoEG_0x05 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x05>
+    <DoubleIsoEG_0x06 condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x06>
+    <DoubleIsoEG_0x0A condition="calo" particle="ieg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleIsoEG_0x0A>
+    <DoubleMu_0x01_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x01_HighQ>
+    <DoubleMu_0x0A_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0a<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>0a<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0A_HighQ>
+    <DoubleMu_0x0B_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0b
+      </value>
+      <value>
+        0b
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0b<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>0b<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0B_HighQ>
+    <DoubleMu_0x0D_0x06_HighQ condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        06
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>06<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        e0
+      </value>
+      </quality>
+    </DoubleMu_0x0D_0x06_HighQ>
+    <DoubleMu_0x0D_HighQ_0x01 condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        e0
+      </value>
+      <value>
+        fc
+      </value>
+      </quality>
+    </DoubleMu_0x0D_HighQ_0x01>
+    <DoubleNoIsoEG_0x05 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x05>
+    <DoubleNoIsoEG_0x06 condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x06>
+    <DoubleNoIsoEG_0x0A condition="calo" particle="eg" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleNoIsoEG_0x0A>
+    <DoubleTauJet_0x09 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x09>
+    <DoubleTauJet_0x09_Eta2p17 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x09_Eta2p17>
+    <DoubleTauJet_0x0A condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x0A>
+    <DoubleTauJet_0x0A_Eta2p17 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x0A_Eta2p17>
+    <DoubleTauJet_0x0B_Eta2p17 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0b
+      </value>
+      <value>
+        0b
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x0B_Eta2p17>
+    <DoubleTauJet_0x0D condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x0D>
+    <DoubleTauJet_0x12 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x12>
+    <DoubleTauJet_0x15 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x15>
+    <DoubleTauJet_0x1C condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1c
+      </value>
+      <value>
+        1c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x1C>
+    <DoubleTauJet_0x1E_v1 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x1E_v1>
+    <ETM_0x03C condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        03c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x03C>
+    <ETM_0x050 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        050
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x050>
+    <ETM_0x064 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        064
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x064>
+    <ETM_0x08C condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        08c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x08C>
+    <ETM_0x0C8 condition="esums" particle="etm" type="etm">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0c8
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        ffffffffffffffffff
+      </value>
+      </phi>
+    </ETM_0x0C8>
+    <ETT_0x01E condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        01e
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x01E>
+    <ETT_0x050 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        050
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x050>
+    <ETT_0x078 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x078>
+    <ETT_0x0B4 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0b4
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x0B4>
+    <HTT_0x0FA condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0fa
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x0FA>
+    <HTT_0x12C condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        12c
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x12C>
+    <HTT_0x15E condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        15e
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x15E>
+    <HTT_0x190 condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        190
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x190>
+    <HTT_0x1F4 condition="esums" particle="htt" type="htt">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        1f4
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </HTT_0x1F4>
+    <QuadCenJet_0x09 condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x09>
+    <QuadCenJet_0x0A condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x0A>
+    <QuadCenJet_0x15 condition="calo" particle="jet" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadCenJet_0x15>
+    <QuadTauJet_0x09 condition="calo" particle="tau" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadTauJet_0x09>
+    <QuadTauJet_0x0A condition="calo" particle="tau" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadTauJet_0x0A>
+    <QuadTauJet_0x15 condition="calo" particle="tau" type="4">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </QuadTauJet_0x15>
+    <SingleCenJet_0x04 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x04>
+    <SingleCenJet_0x08 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x08>
+    <SingleCenJet_0x09 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x09>
+    <SingleCenJet_0x0A condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x0A>
+    <SingleCenJet_0x0D condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x0D>
+    <SingleCenJet_0x11 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x11>
+    <SingleCenJet_0x12 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x12>
+    <SingleCenJet_0x12_Eta2p17 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x12_Eta2p17>
+    <SingleCenJet_0x15 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x15>
+    <SingleCenJet_0x17 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x17>
+    <SingleCenJet_0x1C condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x1C>
+    <SingleCenJet_0x1E condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x1E>
+    <SingleCenJet_0x20 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        20
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x20>
+    <SingleCenJet_0x2C condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        2c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x2C>
+    <SingleCenJet_0x32 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x32>
+    <SingleCenJet_0x3C condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        3c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x3C>
+    <SingleForJet_0x04 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x04>
+    <SingleForJet_0x09 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x09>
+    <SingleForJet_0x0D condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x0D>
+    <SingleForJet_0x11 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x11>
+    <SingleForJet_0x17 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x17>
+    <SingleForJet_0x20 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        20
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x20>
+    <SingleForJet_0x2C condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        2c
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x2C>
+    <SingleForJet_0x32 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x32>
+    <SingleForJet_0x3C condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        3c
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x3C>
+    <SingleIsoEG_0x02 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        02
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x02>
+    <SingleIsoEG_0x05 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x05>
+    <SingleIsoEG_0x06 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x06>
+    <SingleIsoEG_0x07 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x07>
+    <SingleIsoEG_0x08 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x08>
+    <SingleIsoEG_0x0A condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0A>
+    <SingleIsoEG_0x0F condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x0F>
+    <SingleIsoEG_0x12 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x12>
+    <SingleIsoEG_0x14 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x14>
+    <SingleIsoEG_0x14_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x14_Eta2p17>
+    <SingleIsoEG_0x16_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        16
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x16_Eta2p17>
+    <SingleIsoEG_0x19 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x19>
+    <SingleIsoEG_0x19_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x19_Eta2p17>
+    <SingleIsoEG_0x1C_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x1C_Eta2p17>
+    <SingleIsoEG_0x1E condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x1E>
+    <SingleIsoEG_0x1E_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x1E_Eta2p17>
+    <SingleIsoEG_0x23 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        23
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x23>
+    <SingleIsoEG_0x23_Eta2p17 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        23
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x23_Eta2p17>
+    <SingleIsoEG_0x28 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        28
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x28>
+    <SingleMu_0x01_Open condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </SingleMu_0x01_Open>
+    <SingleMu_0x07 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>07<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x07>
+    <SingleMu_0x09 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>09<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x09>
+    <SingleMu_0x0A condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0a<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0A>
+    <SingleMu_0x0C condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0c
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0c<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0C>
+    <SingleMu_0x0D_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0d<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0D_Eta2p1>
+    <SingleMu_0x0E condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0e
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0e<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0E>
+    <SingleMu_0x0F_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>0f<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x0F_Eta2p1>
+    <SingleMu_0x10 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>10<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x10>
+    <SingleMu_0x10_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        10
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>10<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x10_Eta2p1>
+    <SingleMu_0x12 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>12<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x12>
+    <SingleMu_0x12_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>12<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x12_Eta2p1>
+    <SingleMu_0x13 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>13<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x13>
+    <SingleMu_0x13_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        13
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>13<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x13_Eta2p1>
+    <SingleMu_0x14 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>14<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x14>
+    <SingleMu_0x14_Eta2p1 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>14<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        1FFFFFF01FFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x14_Eta2p1>
+    <SingleNoIsoEG_0x02 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        02
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x02>
+    <SingleNoIsoEG_0x05 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x05>
+    <SingleNoIsoEG_0x06 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x06>
+    <SingleNoIsoEG_0x07 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x07>
+    <SingleNoIsoEG_0x08 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x08>
+    <SingleNoIsoEG_0x0A condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0A>
+    <SingleNoIsoEG_0x0F condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0f
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x0F>
+    <SingleNoIsoEG_0x12 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x12>
+    <SingleNoIsoEG_0x14 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x14>
+    <SingleNoIsoEG_0x19 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x19>
+    <SingleNoIsoEG_0x19_Eta2p17 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        19
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x19_Eta2p17>
+    <SingleNoIsoEG_0x1E condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x1E>
+    <SingleNoIsoEG_0x23 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        23
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x23>
+    <SingleNoIsoEG_0x23_Eta2p17 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        23
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x23_Eta2p17>
+    <SingleNoIsoEG_0x28 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        28
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x28>
+    <SingleTauJet_0x04 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x04>
+    <SingleTauJet_0x05_Eta2p17 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x05_Eta2p17>
+    <SingleTauJet_0x08 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x08>
+    <SingleTauJet_0x09 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x09>
+    <SingleTauJet_0x0A condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x0A>
+    <SingleTauJet_0x0A_Eta2p17 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        3F3F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x0A_Eta2p17>
+    <SingleTauJet_0x0D condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0d
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x0D>
+    <SingleTauJet_0x11 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x11>
+    <SingleTauJet_0x12 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        12
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x12>
+    <SingleTauJet_0x15 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x15>
+    <SingleTauJet_0x17 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        17
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x17>
+    <SingleTauJet_0x1C condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x1C>
+    <SingleTauJet_0x1E condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1e
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x1E>
+    <SingleTauJet_0x20 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        20
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x20>
+    <SingleTauJet_0x2C condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        2c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x2C>
+    <SingleTauJet_0x32 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x32>
+    <SingleTauJet_0x3C condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        3c
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x3C>
+    <TripleCenJet_0x09 condition="calo" particle="jet" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleCenJet_0x09>
+    <TripleCenJet_0x0A condition="calo" particle="jet" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleCenJet_0x0A>
+    <TripleCenJet_0x15 condition="calo" particle="jet" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleCenJet_0x15>
+    <TripleTauJet_0x09 condition="calo" particle="tau" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleTauJet_0x09>
+    <TripleTauJet_0x0A condition="calo" particle="tau" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      <value>
+        0a
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleTauJet_0x0A>
+    <TripleTauJet_0x15 condition="calo" particle="tau" type="3">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      <value>
+        15
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </TripleTauJet_0x15>
+      <BPTX_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_minus.v0>
+      <BPTX_plus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus.v0>
+      <BPTX_plus_AND_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus_AND_minus.v0>
+    </conditions>
+  </condition_chip_2>
+<techtriggers>
+  <L1Tech_BPTX_plus_AND_minus.v0>
+    TechTrig
+    <output_pin nr="0" />
+  </L1Tech_BPTX_plus_AND_minus.v0>
+  <L1Tech_BPTX_plus.v0>
+    TechTrig
+    <output_pin nr="1" />
+  </L1Tech_BPTX_plus.v0>
+  <L1Tech_BPTX_minus.v0>
+    TechTrig
+    <output_pin nr="2" />
+  </L1Tech_BPTX_minus.v0>
+  <L1Tech_BPTX_plus_OR_minus.v0>
+    TechTrig
+    <output_pin nr="3" />
+  </L1Tech_BPTX_plus_OR_minus.v0>
+  <L1Tech_BPTX_plus_AND_minus_instance1.v0>
+    TechTrig
+    <output_pin nr="4" />
+  </L1Tech_BPTX_plus_AND_minus_instance1.v0>
+  <L1Tech_BPTX_plus_AND_NOT_minus.v0>
+    TechTrig
+    <output_pin nr="5" />
+  </L1Tech_BPTX_plus_AND_NOT_minus.v0>
+  <L1Tech_BPTX_minus_AND_not_plus.v0>
+    TechTrig
+    <output_pin nr="6" />
+  </L1Tech_BPTX_minus_AND_not_plus.v0>
+  <L1Tech_BPTX_quiet.v0>
+    TechTrig
+    <output_pin nr="7" />
+  </L1Tech_BPTX_quiet.v0>
+  <L1Tech_HCAL_HF_single_channel.v0>
+    TechTrig
+    <output_pin nr="8" />
+  </L1Tech_HCAL_HF_single_channel.v0>
+  <L1Tech_HCAL_HF_coincidence_PM.v2>
+    TechTrig
+    <output_pin nr="9" />
+  </L1Tech_HCAL_HF_coincidence_PM.v2>
+  <L1Tech_HCAL_HF_MMP_or_MPP.v1>
+    TechTrig
+    <output_pin nr="10" />
+  </L1Tech_HCAL_HF_MMP_or_MPP.v1>
+  <L1Tech_HCAL_HO_totalOR.v0>
+    TechTrig
+    <output_pin nr="11" />
+  </L1Tech_HCAL_HO_totalOR.v0>
+  <L1Tech_HCAL_HBHE_totalOR.v0>
+    TechTrig
+    <output_pin nr="12" />
+  </L1Tech_HCAL_HBHE_totalOR.v0>
+  <L1Tech_BPTX_PreBPTX.v0>
+    TechTrig
+    <output_pin nr="16" />
+  </L1Tech_BPTX_PreBPTX.v0>
+  <L1Tech_DT_GlobalOR.v0>
+    TechTrig
+    <output_pin nr="20" />
+  </L1Tech_DT_GlobalOR.v0>
+  <L1Tech_RPC_TTU_barrel_Cosmics.v0>
+    TechTrig
+    <output_pin nr="24" />
+  </L1Tech_RPC_TTU_barrel_Cosmics.v0>
+  <L1Tech_RPC_TTU_pointing_Cosmics.v0>
+    TechTrig
+    <output_pin nr="25" />
+  </L1Tech_RPC_TTU_pointing_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBplus2_Cosmics.v0>
+    TechTrig
+    <output_pin nr="26" />
+  </L1Tech_RPC_TTU_RBplus2_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBplus1_Cosmics.v0>
+    TechTrig
+    <output_pin nr="27" />
+  </L1Tech_RPC_TTU_RBplus1_Cosmics.v0>
+  <L1Tech__TTU_RB0_Cosmics.v0>
+    TechTrig
+    <output_pin nr="28" />
+  </L1Tech__TTU_RB0_Cosmics.v0>
+  <L1Tech_TOTEM_0>
+    TechTrig
+    <output_pin nr="52" />
+  </L1Tech_TOTEM_0>
+  <L1Tech_TOTEM_1>
+    TechTrig
+    <output_pin nr="53" />
+  </L1Tech_TOTEM_1>
+  <L1Tech_TOTEM_2>
+    TechTrig
+    <output_pin nr="54" />
+  </L1Tech_TOTEM_2>
+  <L1Tech_TOTEM_3>
+    TechTrig
+    <output_pin nr="55" />
+  </L1Tech_TOTEM_3>
+  <L1Tech_CASTOR_Gap.v0>
+    TechTrig
+    <output_pin nr="56" />
+  </L1Tech_CASTOR_Gap.v0>
+  <L1Tech_CASTOR_HighJet.v0>
+    TechTrig
+    <output_pin nr="57" />
+  </L1Tech_CASTOR_HighJet.v0>
+  <L1Tech_CASTOR_MediumJet.v0>
+    TechTrig
+    <output_pin nr="58" />
+  </L1Tech_CASTOR_MediumJet.v0>
+  <L1Tech_CASTOR_HaloMuon.v0>
+    TechTrig
+    <output_pin nr="59" />
+  </L1Tech_CASTOR_HaloMuon.v0>
+  </techtriggers>
+</def>
+
+<!--MenuImplDescriptionL1SA bits enabled in cond_chip.vsd (96-105)-->
+<!--L1TmeVersion: 1.0.13-1-->
+<!--TTCablingFkL1TechTrigCabling_2015_Jun_01-->
+<!--ExtCondCablingFkL1ExternalConditionsCabling_2015_Jun_01-->
+<!--AlgoDBLock
+L1_DoubleMuOpen
+L1_ETT15
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_ETT130
+L1_AlwaysTrue
+L1_DoubleEG6_HTT150
+L1_DoubleEG_15_10
+L1_DoubleEG_20_10_1LegIso
+L1_DoubleEG_22_10
+L1_DoubleJetC100
+L1_DoubleJetC112
+L1_DoubleJetC120
+L1_DoubleJetC32_WdPhi7_HTT125
+L1_DoubleJetC52
+L1_DoubleJetC56_ETM60
+L1_DoubleJetC60_ETM60
+L1_DoubleJetC72
+L1_DoubleJetC84
+L1_DoubleMu0
+L1_DoubleMu0_Eta1p6_WdEta18
+L1_DoubleMu0_Eta1p6_WdEta18_OS
+L1_DoubleMu6_EG6
+L1_DoubleMu7_EG7
+L1_DoubleMuOpen
+L1_DoubleMu_10_0_WdEta18
+L1_DoubleMu_10_3p5
+L1_DoubleMu_10_Open
+L1_DoubleMu_12_5
+L1_DoubleTauJet36er
+L1_DoubleTauJet40er
+L1_DoubleTauJet44er
+L1_EG25er_HTT125
+L1_ETM100
+L1_ETM30
+L1_ETM40
+L1_ETM50
+L1_ETM60
+L1_ETM60_NotJet52WdPhi2
+L1_ETM70
+L1_ETM70_NotJet52WdPhi2
+L1_ETT130
+L1_ETT15
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_HTT125
+L1_HTT150
+L1_HTT175
+L1_HTT200
+L1_HTT250
+L1_IsoEG20er_TauJet20er_NotWdEta0
+L1_Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1
+L1_Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1
+L1_Mu0er_ETM55
+L1_Mu10er_ETM50
+L1_Mu12_EG10
+L1_Mu14er_ETM30
+L1_Mu16er_TauJet20er
+L1_Mu16er_TauJet40erORCenJet72er
+L1_Mu20_EG10
+L1_Mu20_EG8
+L1_Mu3_JetC16_WdEtaPhi2
+L1_Mu3_JetC52_WdEtaPhi2
+L1_Mu4_EG18
+L1_Mu5_DoubleEG5
+L1_Mu5_EG15
+L1_Mu5_EG20
+L1_Mu5_IsoEG18
+L1_Mu6_DoubleEG10
+L1_Mu6_HTT150
+L1_Mu8_HTT125
+L1_QuadJetC36_TauJet52
+L1_QuadJetC40
+L1_QuadJetC60
+L1_QuadJetC84
+L1_QuadMu0
+L1_RomanPotsAND
+L1_SingleEG10
+L1_SingleEG15
+L1_SingleEG20
+L1_SingleEG25
+L1_SingleEG2_BptxAND
+L1_SingleEG30
+L1_SingleEG35
+L1_SingleEG35er
+L1_SingleEG40
+L1_SingleEG5
+L1_SingleIsoEG18
+L1_SingleIsoEG20er
+L1_SingleIsoEG22er
+L1_SingleIsoEG25
+L1_SingleIsoEG25er
+L1_SingleIsoEG28er
+L1_SingleIsoEG30er
+L1_SingleJet128
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet176
+L1_SingleJet200
+L1_SingleJet240
+L1_SingleJet36
+L1_SingleJet52
+L1_SingleJet68
+L1_SingleJet92
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu12
+L1_SingleMu14_Eta2p1
+L1_SingleMu16
+L1_SingleMu16_Eta2p1
+L1_SingleMu18er
+L1_SingleMu20
+L1_SingleMu20er
+L1_SingleMu25
+L1_SingleMu25er
+L1_SingleMu30
+L1_SingleMu30er
+L1_SingleMu5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TripleEG_14_10_8
+L1_TripleJet_92_76_64
+L1_TripleJet_92_76_64_NoFFF
+L1_TripleMu0
+L1_TripleMu_5_5_3
+L1_ZeroBias
+L1_AlwaysTrue
+L1_DoubleEG6_HTT150
+L1_DoubleEG_15_10
+L1_DoubleEG_20_10_1LegIso
+L1_DoubleEG_22_10
+L1_DoubleJetC100
+L1_DoubleJetC112
+L1_DoubleJetC120
+L1_DoubleJetC32_WdPhi7_HTT125
+L1_DoubleJetC52
+L1_DoubleJetC56_ETM60
+L1_DoubleJetC60_ETM60
+L1_DoubleJetC72
+L1_DoubleJetC84
+L1_DoubleMu0
+L1_DoubleMu0_Eta1p6_WdEta18
+L1_DoubleMu0_Eta1p6_WdEta18_OS
+L1_DoubleMu6_EG6
+L1_DoubleMu7_EG7
+L1_DoubleMuOpen
+L1_DoubleMu_10_0_WdEta18
+L1_DoubleMu_10_3p5
+L1_DoubleMu_10_Open
+L1_DoubleMu_12_5
+L1_DoubleTauJet36er
+L1_DoubleTauJet40er
+L1_DoubleTauJet44er
+L1_EG25er_HTT125
+L1_ETM100
+L1_ETM30
+L1_ETM40
+L1_ETM50
+L1_ETM60
+L1_ETM60_NotJet52WdPhi2
+L1_ETM70
+L1_ETM70_NotJet52WdPhi2
+L1_ETT130
+L1_ETT15
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_HTT125
+L1_HTT150
+L1_HTT175
+L1_HTT200
+L1_HTT250
+L1_IsoEG20er_TauJet20er_NotWdEta0
+L1_Jet32_DoubleMu_Open_10_MuMuNotWdPhi23_JetMuWdPhi1
+L1_Jet32_MuOpen_EG10_MuEGNotWdPhi3_JetMuWdPhi1
+L1_Mu0er_ETM55
+L1_Mu10er_ETM50
+L1_Mu12_EG10
+L1_Mu14er_ETM30
+L1_Mu16er_TauJet20er
+L1_Mu16er_TauJet40erORCenJet72er
+L1_Mu20_EG10
+L1_Mu20_EG8
+L1_Mu3_JetC16_WdEtaPhi2
+L1_Mu3_JetC52_WdEtaPhi2
+L1_Mu4_EG18
+L1_Mu5_DoubleEG5
+L1_Mu5_EG15
+L1_Mu5_EG20
+L1_Mu5_IsoEG18
+L1_Mu6_DoubleEG10
+L1_Mu6_HTT150
+L1_Mu8_HTT125
+L1_QuadJetC36_TauJet52
+L1_QuadJetC40
+L1_QuadJetC60
+L1_QuadJetC84
+L1_QuadMu0
+L1_RomanPotsAND
+L1_SingleEG10
+L1_SingleEG15
+L1_SingleEG20
+L1_SingleEG25
+L1_SingleEG2_BptxAND
+L1_SingleEG30
+L1_SingleEG35
+L1_SingleEG35er
+L1_SingleEG40
+L1_SingleEG5
+L1_SingleIsoEG18
+L1_SingleIsoEG20er
+L1_SingleIsoEG22er
+L1_SingleIsoEG25
+L1_SingleIsoEG25er
+L1_SingleIsoEG28er
+L1_SingleIsoEG30er
+L1_SingleJet128
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet176
+L1_SingleJet200
+L1_SingleJet240
+L1_SingleJet36
+L1_SingleJet52
+L1_SingleJet68
+L1_SingleJet92
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu12
+L1_SingleMu14_Eta2p1
+L1_SingleMu16
+L1_SingleMu16_Eta2p1
+L1_SingleMu18er
+L1_SingleMu20
+L1_SingleMu20er
+L1_SingleMu25
+L1_SingleMu25er
+L1_SingleMu30
+L1_SingleMu30er
+L1_SingleMu5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TripleEG_14_10_8
+L1_TripleJet_92_76_64
+L1_TripleJet_92_76_64_NoFFF
+L1_TripleMu0
+L1_TripleMu_5_5_3
+L1_ZeroBias
+AlgoDBLockEnd-->
+<!--CondDBLock
+BPTX_minus.v0:BPTX_minus.v0
+BPTX_minus_postQuiet.v0:BPTX_minus_postQuiet.v0
+BPTX_plus.v0:BPTX_plus.v0
+BPTX_plus_AND_minus.v0:BPTX_plus_AND_minus.v0
+BPTX_plus_OR_minus.v0:BPTX_plus_OR_minus.v0
+BPTX_plus_postQuiet.v0:BPTX_plus_postQuiet.v0
+BPTXcoincidence:BPTXcoincidence
+BSC_BSC2_minus.v0:BSC_BSC2_minus.v0
+BSC_BSC2_plus.v0:BSC_BSC2_plus.v0
+BSC_HighMultiplicity.v0:BSC_HighMultiplicity.v0
+BSC_halo_beam1_inner.v0:BSC_halo_beam1_inner.v0
+BSC_halo_beam1_outer.v0:BSC_halo_beam1_outer.v0
+BSC_halo_beam2_inner.v0:BSC_halo_beam2_inner.v0
+BSC_halo_beam2_outer.v0:BSC_halo_beam2_outer.v0
+BSC_minBias_OR.v0:BSC_minBias_OR.v0
+BSC_minBias_inner_threshold1.v0:BSC_minBias_inner_threshold1.v0
+BSC_minBias_inner_threshold2.v0:BSC_minBias_inner_threshold2.v0
+BSC_minBias_threshold1.v0:BSC_minBias_threshold1.v0
+BSC_minBias_threshold2.v0:BSC_minBias_threshold2.v0
+BSC_splash_beam1.v0:BSC_splash_beam1.v0
+BSC_splash_beam2.v0:BSC_splash_beam2.v0
+CASTOR_0.v0:CASTOR_0.v0
+CASTOR_EM.v0:CASTOR_EM.v0
+CASTOR_HaloMuon.v0:CASTOR_HaloMuon.v0
+CASTOR_TotalEnergy.v0:CASTOR_TotalEnergy.v0
+Corr_CenJet_TauJet_0x08_WdPhi7:Corr_CenJet_TauJet_0x08_WdPhi7
+Corr_ETM_CenJet_0x78_0x0D_WdPhi2:Corr_ETM_CenJet_0x78_0x0D_WdPhi2
+Corr_ETM_CenJet_0x8C_0x0D_WdPhi2:Corr_ETM_CenJet_0x8C_0x0D_WdPhi2
+Corr_ETM_ForJet_0x78_0x0D_WdPhi2:Corr_ETM_ForJet_0x78_0x0D_WdPhi2
+Corr_ETM_ForJet_0x8C_0x0D_WdPhi2:Corr_ETM_ForJet_0x8C_0x0D_WdPhi2
+Corr_ETM_TauJet_0x78_0x0D_WdPhi2:Corr_ETM_TauJet_0x78_0x0D_WdPhi2
+Corr_ETM_TauJet_0x8C_0x0D_WdPhi2:Corr_ETM_TauJet_0x8C_0x0D_WdPhi2
+Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0:Corr_IsoEG_TauJet_0x14_Eta2p17_0x05_Eta2p17_NotWdEta0
+Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1:Corr_Mu_CenJet_0x01_Open_0x08_WdPhi1
+Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2:Corr_Mu_CenJet_0x05_0x04_WdEtaPhi2
+Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2:Corr_Mu_CenJet_0x05_0x0D_WdEtaPhi2
+Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1:Corr_Mu_ForJet_0x01_Open_0x08_WdPhi1
+Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3:Corr_Mu_IsoEG_0x01_Open_0x0A_NotWdPhi3
+Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3:Corr_Mu_NoIsoEG_0x01_Open_0x0A_NotWdPhi3
+Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1:Corr_Mu_TauJet_0x01_Open_0x08_WdPhi1
+Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1:Corr_Mu_TauJet_0x05_0x04_WdEtaPhi2_v1
+Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1:Corr_Mu_TauJet_0x05_0x0D_WdEtaPhi2_v1
+DoubleCenJet_0x09:DoubleCenJet_0x09
+DoubleCenJet_0x0A:DoubleCenJet_0x0A
+DoubleCenJet_0x0D:DoubleCenJet_0x0D
+DoubleCenJet_0x0E:DoubleCenJet_0x0E
+DoubleCenJet_0x0F:DoubleCenJet_0x0F
+DoubleCenJet_0x12:DoubleCenJet_0x12
+DoubleCenJet_0x13_0x10:DoubleCenJet_0x13_0x10
+DoubleCenJet_0x15:DoubleCenJet_0x15
+DoubleCenJet_0x17_0x10:DoubleCenJet_0x17_0x10
+DoubleCenJet_0x17_0x13:DoubleCenJet_0x17_0x13
+DoubleCenJet_0x19:DoubleCenJet_0x19
+DoubleCenJet_0x1C:DoubleCenJet_0x1C
+DoubleCenJet_0x1E:DoubleCenJet_0x1E
+DoubleCenJet_wsc_0x08_WdPhi7:DoubleCenJet_wsc_0x08_WdPhi7
+DoubleForJet_0x13_0x10:DoubleForJet_0x13_0x10
+DoubleForJet_0x17_0x10:DoubleForJet_0x17_0x10
+DoubleForJet_0x17_0x13:DoubleForJet_0x17_0x13
+DoubleIsoEG_0x05:DoubleIsoEG_0x05
+DoubleIsoEG_0x06:DoubleIsoEG_0x06
+DoubleIsoEG_0x0A:DoubleIsoEG_0x0A
+DoubleIsoEG_0x0A_0x08:DoubleIsoEG_0x0A_0x08
+DoubleIsoEG_0x0E_0x08:DoubleIsoEG_0x0E_0x08
+DoubleIsoEG_0x0E_0x0A:DoubleIsoEG_0x0E_0x0A
+DoubleIsoEG_0x0F_0x0A:DoubleIsoEG_0x0F_0x0A
+DoubleIsoEG_0x14_0x0A:DoubleIsoEG_0x14_0x0A
+DoubleIsoEG_0x16_0x0A:DoubleIsoEG_0x16_0x0A
+DoubleMu_0x01_HighQ:DoubleMu_0x01_HighQ
+DoubleMu_0x01_Open:DoubleMu_0x01_Open
+DoubleMu_0x0A_HighQ:DoubleMu_0x0A_HighQ
+DoubleMu_0x0B_HighQ:DoubleMu_0x0B_HighQ
+DoubleMu_0x0D_0x06_HighQ:DoubleMu_0x0D_0x06_HighQ
+DoubleMu_0x0D_HighQ_0x01:DoubleMu_0x0D_HighQ_0x01
+DoubleMu_0x0E_0x09_HighQ:DoubleMu_0x0E_0x09_HighQ
+DoubleMu_wsc_0x01_Eta1p6_WdEta18:DoubleMu_wsc_0x01_Eta1p6_WdEta18
+DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS:DoubleMu_wsc_0x01_Eta1p6_WdEta18_OS
+DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23:DoubleMu_wsc_0x01_Open_0x0D_NotWdPhi23
+DoubleMu_wsc_0x0D_0x01_WdEta18:DoubleMu_wsc_0x0D_0x01_WdEta18
+DoubleNoIsoEG_0x05:DoubleNoIsoEG_0x05
+DoubleNoIsoEG_0x06:DoubleNoIsoEG_0x06
+DoubleNoIsoEG_0x0A:DoubleNoIsoEG_0x0A
+DoubleNoIsoEG_0x0A_0x08:DoubleNoIsoEG_0x0A_0x08
+DoubleNoIsoEG_0x0E_0x08:DoubleNoIsoEG_0x0E_0x08
+DoubleNoIsoEG_0x0E_0x0A:DoubleNoIsoEG_0x0E_0x0A
+DoubleNoIsoEG_0x0F_0x0A:DoubleNoIsoEG_0x0F_0x0A
+DoubleNoIsoEG_0x16_0x0A:DoubleNoIsoEG_0x16_0x0A
+DoubleTauJet_0x09:DoubleTauJet_0x09
+DoubleTauJet_0x09_Eta2p17:DoubleTauJet_0x09_Eta2p17
+DoubleTauJet_0x0A:DoubleTauJet_0x0A
+DoubleTauJet_0x0A_Eta2p17:DoubleTauJet_0x0A_Eta2p17
+DoubleTauJet_0x0B_Eta2p17:DoubleTauJet_0x0B_Eta2p17
+DoubleTauJet_0x0D:DoubleTauJet_0x0D
+DoubleTauJet_0x0E:DoubleTauJet_0x0E
+DoubleTauJet_0x0F:DoubleTauJet_0x0F
+DoubleTauJet_0x12:DoubleTauJet_0x12
+DoubleTauJet_0x13_0x10:DoubleTauJet_0x13_0x10
+DoubleTauJet_0x15:DoubleTauJet_0x15
+DoubleTauJet_0x17_0x10:DoubleTauJet_0x17_0x10
+DoubleTauJet_0x17_0x13:DoubleTauJet_0x17_0x13
+DoubleTauJet_0x19:DoubleTauJet_0x19
+DoubleTauJet_0x1C:DoubleTauJet_0x1C
+DoubleTauJet_0x1E_v1:DoubleTauJet_0x1E_v1
+DoubleTauJet_wsc_0x08_WdPhi7:DoubleTauJet_wsc_0x08_WdPhi7
+Dummy_00:Dummy_00
+Dummy_01:Dummy_01
+Dummy_02:Dummy_02
+Dummy_03:Dummy_03
+Dummy_04:Dummy_04
+Dummy_05:Dummy_05
+Dummy_06:Dummy_06
+Dummy_07:Dummy_07
+Dummy_08:Dummy_08
+Dummy_09:Dummy_09
+Dummy_10:Dummy_10
+Dummy_11:Dummy_11
+Dummy_12:Dummy_12
+Dummy_13:Dummy_13
+Dummy_14:Dummy_14
+Dummy_15:Dummy_15
+Dummy_16:Dummy_16
+Dummy_17:Dummy_17
+Dummy_18:Dummy_18
+Dummy_19:Dummy_19
+Dummy_20:Dummy_20
+Dummy_21:Dummy_21
+Dummy_22:Dummy_22
+Dummy_23:Dummy_23
+Dummy_24:Dummy_24
+Dummy_25:Dummy_25
+Dummy_26:Dummy_26
+Dummy_27:Dummy_27
+Dummy_28:Dummy_28
+Dummy_29:Dummy_29
+Dummy_30:Dummy_30
+Dummy_31:Dummy_31
+Dummy_32:Dummy_32
+Dummy_33:Dummy_33
+Dummy_34:Dummy_34
+Dummy_35:Dummy_35
+Dummy_36:Dummy_36
+Dummy_37:Dummy_37
+Dummy_38:Dummy_38
+Dummy_39:Dummy_39
+Dummy_40:Dummy_40
+Dummy_41:Dummy_41
+Dummy_42:Dummy_42
+Dummy_43:Dummy_43
+Dummy_44:Dummy_44
+Dummy_45:Dummy_45
+Dummy_46:Dummy_46
+Dummy_47:Dummy_47
+Dummy_48:Dummy_48
+Dummy_49:Dummy_49
+Dummy_50:Dummy_50
+Dummy_51:Dummy_51
+Dummy_52:Dummy_52
+Dummy_53:Dummy_53
+Dummy_54:Dummy_54
+Dummy_55:Dummy_55
+Dummy_56:Dummy_56
+Dummy_57:Dummy_57
+Dummy_58:Dummy_58
+Dummy_59:Dummy_59
+Dummy_60:Dummy_60
+Dummy_61:Dummy_61
+Dummy_62:Dummy_62
+Dummy_63:Dummy_63
+ETM_0x03C:ETM_0x03C
+ETM_0x050:ETM_0x050
+ETM_0x064:ETM_0x064
+ETM_0x06E:ETM_0x06E
+ETM_0x078:ETM_0x078
+ETM_0x08C:ETM_0x08C
+ETM_0x0C8:ETM_0x0C8
+ETT_0x01E:ETT_0x01E
+ETT_0x050:ETT_0x050
+ETT_0x078:ETT_0x078
+ETT_0x0B4:ETT_0x0B4
+ETT_0x104:ETT_0x104
+FSC_St1Sect45_down.v0:FSC_St1Sect45_down.v0
+FSC_St1Sect45_upp.v0:FSC_St1Sect45_upp.v0
+FSC_St1Sect56_down.v0:FSC_St1Sect56_down.v0
+FSC_St1Sect56_upp.v0:FSC_St1Sect56_upp.v0
+FSC_St2Sect45_down.v0:FSC_St2Sect45_down.v0
+FSC_St2Sect45_upp.v0:FSC_St2Sect45_upp.v0
+FSC_St2Sect56_down.v0:FSC_St2Sect56_down.v0
+FSC_St2Sect56_upp.v0:FSC_St2Sect56_upp.v0
+FSC_St3Sect56_downLeft.v0:FSC_St3Sect56_downLeft.v0
+FSC_St3Sect56_downRight.v0:FSC_St3Sect56_downRight.v0
+FSC_St3Sect56_uppLeft.v0:FSC_St3Sect56_uppLeft.v0
+FSC_St3Sect56_uppRight.v0:FSC_St3Sect56_uppRight.v0
+HCAL_HF_MMP_or_MPP.v0:HCAL_HF_MMP_or_MPP.v0
+HCAL_HF_MMP_or_MPP.v1:HCAL_HF_MMP_or_MPP.v1
+HCAL_HF_MM_or_PP_or_PM.v0:HCAL_HF_MM_or_PP_or_PM.v0
+HCAL_HF_coincidence_PM.v1:HCAL_HF_coincidence_PM.v1
+HCAL_HF_coincidence_PM.v2:HCAL_HF_coincidence_PM.v2
+HCAL_HF_single_channel.v0:HCAL_HF_single_channel.v0
+HCAL_HO_totalOR.v0:HCAL_HO_totalOR.v0
+HTT_0x0FA:HTT_0x0FA
+HTT_0x12C:HTT_0x12C
+HTT_0x15E:HTT_0x15E
+HTT_0x190:HTT_0x190
+HTT_0x1F4:HTT_0x1F4
+QuadCenJet_0x09:QuadCenJet_0x09
+QuadCenJet_0x0A:QuadCenJet_0x0A
+QuadCenJet_0x0F:QuadCenJet_0x0F
+QuadCenJet_0x15:QuadCenJet_0x15
+QuadMu_0x01:QuadMu_0x01
+QuadTauJet_0x09:QuadTauJet_0x09
+QuadTauJet_0x0A:QuadTauJet_0x0A
+QuadTauJet_0x0F:QuadTauJet_0x0F
+QuadTauJet_0x15:QuadTauJet_0x15
+SingleCenJet_0x03:SingleCenJet_0x03
+SingleCenJet_0x04:SingleCenJet_0x04
+SingleCenJet_0x05:SingleCenJet_0x05
+SingleCenJet_0x08:SingleCenJet_0x08
+SingleCenJet_0x09:SingleCenJet_0x09
+SingleCenJet_0x0A:SingleCenJet_0x0A
+SingleCenJet_0x0D:SingleCenJet_0x0D
+SingleCenJet_0x0E:SingleCenJet_0x0E
+SingleCenJet_0x0F:SingleCenJet_0x0F
+SingleCenJet_0x10:SingleCenJet_0x10
+SingleCenJet_0x11:SingleCenJet_0x11
+SingleCenJet_0x12:SingleCenJet_0x12
+SingleCenJet_0x12_Eta2p17:SingleCenJet_0x12_Eta2p17
+SingleCenJet_0x13:SingleCenJet_0x13
+SingleCenJet_0x15:SingleCenJet_0x15
+SingleCenJet_0x17:SingleCenJet_0x17
+SingleCenJet_0x19:SingleCenJet_0x19
+SingleCenJet_0x1C:SingleCenJet_0x1C
+SingleCenJet_0x1E:SingleCenJet_0x1E
+SingleCenJet_0x20:SingleCenJet_0x20
+SingleCenJet_0x2C:SingleCenJet_0x2C
+SingleCenJet_0x32:SingleCenJet_0x32
+SingleCenJet_0x3C:SingleCenJet_0x3C
+SingleForJet_0x03:SingleForJet_0x03
+SingleForJet_0x04:SingleForJet_0x04
+SingleForJet_0x09:SingleForJet_0x09
+SingleForJet_0x0D:SingleForJet_0x0D
+SingleForJet_0x10:SingleForJet_0x10
+SingleForJet_0x11:SingleForJet_0x11
+SingleForJet_0x13:SingleForJet_0x13
+SingleForJet_0x17:SingleForJet_0x17
+SingleForJet_0x20:SingleForJet_0x20
+SingleForJet_0x2C:SingleForJet_0x2C
+SingleForJet_0x32:SingleForJet_0x32
+SingleForJet_0x3C:SingleForJet_0x3C
+SingleIsoEG_0x02:SingleIsoEG_0x02
+SingleIsoEG_0x05:SingleIsoEG_0x05
+SingleIsoEG_0x06:SingleIsoEG_0x06
+SingleIsoEG_0x07:SingleIsoEG_0x07
+SingleIsoEG_0x08:SingleIsoEG_0x08
+SingleIsoEG_0x0A:SingleIsoEG_0x0A
+SingleIsoEG_0x0E:SingleIsoEG_0x0E
+SingleIsoEG_0x0F:SingleIsoEG_0x0F
+SingleIsoEG_0x12:SingleIsoEG_0x12
+SingleIsoEG_0x14:SingleIsoEG_0x14
+SingleIsoEG_0x14_Eta2p17:SingleIsoEG_0x14_Eta2p17
+SingleIsoEG_0x16:SingleIsoEG_0x16
+SingleIsoEG_0x16_Eta2p17:SingleIsoEG_0x16_Eta2p17
+SingleIsoEG_0x19:SingleIsoEG_0x19
+SingleIsoEG_0x19_Eta2p17:SingleIsoEG_0x19_Eta2p17
+SingleIsoEG_0x1C_Eta2p17:SingleIsoEG_0x1C_Eta2p17
+SingleIsoEG_0x1E:SingleIsoEG_0x1E
+SingleIsoEG_0x1E_Eta2p17:SingleIsoEG_0x1E_Eta2p17
+SingleIsoEG_0x23:SingleIsoEG_0x23
+SingleIsoEG_0x23_Eta2p17:SingleIsoEG_0x23_Eta2p17
+SingleIsoEG_0x28:SingleIsoEG_0x28
+SingleMu_0x01_BeamHalo:SingleMu_0x01_BeamHalo
+SingleMu_0x01_Eta2p1:SingleMu_0x01_Eta2p1
+SingleMu_0x01_Open:SingleMu_0x01_Open
+SingleMu_0x07:SingleMu_0x07
+SingleMu_0x09:SingleMu_0x09
+SingleMu_0x0A:SingleMu_0x0A
+SingleMu_0x0C:SingleMu_0x0C
+SingleMu_0x0D_Eta2p1:SingleMu_0x0D_Eta2p1
+SingleMu_0x0E:SingleMu_0x0E
+SingleMu_0x0F_Eta2p1:SingleMu_0x0F_Eta2p1
+SingleMu_0x10:SingleMu_0x10
+SingleMu_0x10_Eta2p1:SingleMu_0x10_Eta2p1
+SingleMu_0x11_Eta2p1:SingleMu_0x11_Eta2p1
+SingleMu_0x12:SingleMu_0x12
+SingleMu_0x12_Eta2p1:SingleMu_0x12_Eta2p1
+SingleMu_0x13:SingleMu_0x13
+SingleMu_0x13_Eta2p1:SingleMu_0x13_Eta2p1
+SingleMu_0x14:SingleMu_0x14
+SingleMu_0x14_Eta2p1:SingleMu_0x14_Eta2p1
+SingleNoIsoEG_0x02:SingleNoIsoEG_0x02
+SingleNoIsoEG_0x05:SingleNoIsoEG_0x05
+SingleNoIsoEG_0x06:SingleNoIsoEG_0x06
+SingleNoIsoEG_0x07:SingleNoIsoEG_0x07
+SingleNoIsoEG_0x08:SingleNoIsoEG_0x08
+SingleNoIsoEG_0x0A:SingleNoIsoEG_0x0A
+SingleNoIsoEG_0x0E:SingleNoIsoEG_0x0E
+SingleNoIsoEG_0x0F:SingleNoIsoEG_0x0F
+SingleNoIsoEG_0x12:SingleNoIsoEG_0x12
+SingleNoIsoEG_0x14:SingleNoIsoEG_0x14
+SingleNoIsoEG_0x16:SingleNoIsoEG_0x16
+SingleNoIsoEG_0x19:SingleNoIsoEG_0x19
+SingleNoIsoEG_0x19_Eta2p17:SingleNoIsoEG_0x19_Eta2p17
+SingleNoIsoEG_0x1E:SingleNoIsoEG_0x1E
+SingleNoIsoEG_0x23:SingleNoIsoEG_0x23
+SingleNoIsoEG_0x23_Eta2p17:SingleNoIsoEG_0x23_Eta2p17
+SingleNoIsoEG_0x28:SingleNoIsoEG_0x28
+SingleTauJet_0x03:SingleTauJet_0x03
+SingleTauJet_0x04:SingleTauJet_0x04
+SingleTauJet_0x05:SingleTauJet_0x05
+SingleTauJet_0x05_Eta2p17:SingleTauJet_0x05_Eta2p17
+SingleTauJet_0x08:SingleTauJet_0x08
+SingleTauJet_0x09:SingleTauJet_0x09
+SingleTauJet_0x0A:SingleTauJet_0x0A
+SingleTauJet_0x0A_Eta2p17:SingleTauJet_0x0A_Eta2p17
+SingleTauJet_0x0D:SingleTauJet_0x0D
+SingleTauJet_0x0E:SingleTauJet_0x0E
+SingleTauJet_0x0F:SingleTauJet_0x0F
+SingleTauJet_0x10:SingleTauJet_0x10
+SingleTauJet_0x11:SingleTauJet_0x11
+SingleTauJet_0x12:SingleTauJet_0x12
+SingleTauJet_0x13:SingleTauJet_0x13
+SingleTauJet_0x15:SingleTauJet_0x15
+SingleTauJet_0x17:SingleTauJet_0x17
+SingleTauJet_0x19:SingleTauJet_0x19
+SingleTauJet_0x1C:SingleTauJet_0x1C
+SingleTauJet_0x1E:SingleTauJet_0x1E
+SingleTauJet_0x20:SingleTauJet_0x20
+SingleTauJet_0x2C:SingleTauJet_0x2C
+SingleTauJet_0x32:SingleTauJet_0x32
+SingleTauJet_0x3C:SingleTauJet_0x3C
+TOTEM_0:TOTEM_0
+TOTEM_1:TOTEM_1
+TOTEM_2:TOTEM_2
+TOTEM_3:TOTEM_3
+TOTEM_Diffractive.v0:TOTEM_Diffractive.v0
+TOTEM_LowMultiplicity.v0:TOTEM_LowMultiplicity.v0
+TOTEM_MinBias.v0:TOTEM_MinBias.v0
+TOTEM_RomanPotsOR:TOTEM_RomanPotsOR
+TOTEM_ZeroBias.v0:TOTEM_ZeroBias.v0
+TripleCenJet_0x09:TripleCenJet_0x09
+TripleCenJet_0x0A:TripleCenJet_0x0A
+TripleCenJet_0x0F:TripleCenJet_0x0F
+TripleCenJet_0x15:TripleCenJet_0x15
+TripleCenJet_0x17_0x13_0x10:TripleCenJet_0x17_0x13_0x10
+TripleForJet_0x17_0x13_0x10:TripleForJet_0x17_0x13_0x10
+TripleIsoEG_0x0E_0x0A_0x08:TripleIsoEG_0x0E_0x0A_0x08
+TripleMu_0x01_HighQ:TripleMu_0x01_HighQ
+TripleMu_0x09_0x09_0x05:TripleMu_0x09_0x09_0x05
+TripleNoIsoEG_0x0E_0x0A_0x08:TripleNoIsoEG_0x0E_0x0A_0x08
+TripleTauJet_0x09:TripleTauJet_0x09
+TripleTauJet_0x0A:TripleTauJet_0x0A
+TripleTauJet_0x0F:TripleTauJet_0x0F
+TripleTauJet_0x15:TripleTauJet_0x15
+TripleTauJet_0x17_0x13_0x10:TripleTauJet_0x17_0x13_0x10
+ZDC_Calo_minus.v0:ZDC_Calo_minus.v0
+ZDC_Calo_plus.v0:ZDC_Calo_plus.v0
+ZDC_Scint_loose_vertex.v0:ZDC_Scint_loose_vertex.v0
+ZDC_Scint_minus.v0:ZDC_Scint_minus.v0
+ZDC_Scint_plus.v0:ZDC_Scint_plus.v0
+ZDC_Scint_tight_vertex.v0:ZDC_Scint_tight_vertex.v0
+ZDC_loose_vertex.v0:ZDC_loose_vertex.v0
+ZDC_minus_over_threshold.v0:ZDC_minus_over_threshold.v0
+ZDC_plus_over_threshold.v0:ZDC_plus_over_threshold.v0
+ZDC_tight_vertex.v0:ZDC_tight_vertex.v0
+CondDBLockEnd-->

--- a/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_lowPU_v4_L1T_Scales_20141121.xml
+++ b/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_lowPU_v4_L1T_Scales_20141121.xml
@@ -2,10 +2,10 @@
 <def>
 <header>
     <MenuInterface>L1Menu_Collisions2015_lowPU_v4</MenuInterface>
-    <MenuInterface_CreationDate>2015-06-23</MenuInterface_CreationDate>
+    <MenuInterface_CreationDate>2015-06-25</MenuInterface_CreationDate>
     <MenuInterface_CreationAuthor>V. M. Ghete, T. Matsushita</MenuInterface_CreationAuthor>
     <MenuInterface_Description>L1 menu for pp data taking 2015, GCT version</MenuInterface_Description>
-    <Menu_CreationDate>2015-06-23T09:09:43.000000Z</Menu_CreationDate>
+    <Menu_CreationDate>2015-06-25</Menu_CreationDate>
     <Menu_CreationAuthor>V. M. Ghete, T. Matsushita</Menu_CreationAuthor>
     <Menu_Description>L1 menu for pp data taking 2015</Menu_Description>
     <AlgImplementation>Imp0</AlgImplementation>
@@ -271,14 +271,6 @@
         CASTOR_HaloMuon.v0
         <output_pin nr="78" pin="a" />
       </L1_CastorMuon>
-      <L1_DoubleHfBitCountsRing1_P1N1 algAlias="L1_DoubleHfBitCountsRing1_P1N1">
-        ( HfBitCounts_Ind0_0x1 AND HfBitCounts_Ind1_0x1 )
-        <output_pin nr="63" pin="a" />
-      </L1_DoubleHfBitCountsRing1_P1N1>
-      <L1_DoubleHfBitCountsRing2_P1N1 algAlias="L1_DoubleHfBitCountsRing2_P1N1">
-        ( HfBitCounts_Ind2_0x1 AND HfBitCounts_Ind3_0x1 )
-        <output_pin nr="64" pin="a" />
-      </L1_DoubleHfBitCountsRing2_P1N1>
       <L1_DoubleJet20 algAlias="L1_DoubleJet20">
         DoubleCenJet_0x05 OR DoubleForJet_0x05 OR DoubleTauJet_0x05 OR ( SingleCenJet_0x05 AND ( SingleForJet_0x05 OR SingleTauJet_0x05 ) ) OR ( SingleForJet_0x05 AND SingleTauJet_0x05 )
         <output_pin nr="71" pin="a" />
@@ -307,6 +299,10 @@
         ETT_0x0B4
         <output_pin nr="44" pin="a" />
       </L1_ETT90>
+      <L1_MinimumBiasHF1_AND_NoBptxGating algAlias="L1_MinimumBiasHF1_AND_NoBptxGating">
+        ( HfBitCounts_Ind0_0x1 AND HfBitCounts_Ind1_0x1 )
+        <output_pin nr="63" pin="a" />
+      </L1_MinimumBiasHF1_AND_NoBptxGating>
       <L1_MinimumBiasHF1_AND_v1 algAlias="L1_MinimumBiasHF1_AND">
         ( HfBitCounts_Ind0_0x1 AND HfBitCounts_Ind1_0x1 ) AND BPTX_plus_AND_minus.v0
         <output_pin nr="7" pin="a" />
@@ -315,14 +311,26 @@
         ( HfBitCounts_Ind0_0x1 OR HfBitCounts_Ind1_0x1 ) AND BPTX_plus_AND_minus.v0
         <output_pin nr="5" pin="a" />
       </L1_MinimumBiasHF1_OR>
+      <L1_MinimumBiasHF1_OR_NoBptxGating algAlias="L1_MinimumBiasHF1_OR_NoBptxGating">
+        HfBitCounts_Ind0_0x1 OR HfBitCounts_Ind1_0x1
+        <output_pin nr="61" pin="a" />
+      </L1_MinimumBiasHF1_OR_NoBptxGating>
       <L1_MinimumBiasHF2_AND algAlias="L1_MinimumBiasHF2_AND">
         ( HfBitCounts_Ind2_0x1 AND HfBitCounts_Ind3_0x1 ) AND BPTX_plus_AND_minus.v0
         <output_pin nr="8" pin="a" />
       </L1_MinimumBiasHF2_AND>
+      <L1_MinimumBiasHF2_AND_NoBptxGating algAlias="L1_MinimumBiasHF2_AND_NoBptxGating">
+        ( HfBitCounts_Ind2_0x1 AND HfBitCounts_Ind3_0x1 )
+        <output_pin nr="64" pin="a" />
+      </L1_MinimumBiasHF2_AND_NoBptxGating>
       <L1_MinimumBiasHF2_OR algAlias="L1_MinimumBiasHF2_OR">
         ( HfBitCounts_Ind2_0x1 OR HfBitCounts_Ind3_0x1 ) AND BPTX_plus_AND_minus.v0
         <output_pin nr="6" pin="a" />
       </L1_MinimumBiasHF2_OR>
+      <L1_MinimumBiasHF2_OR_NoBptxGating algAlias="L1_MinimumBiasHF2_OR_NoBptxGating">
+        ( HfBitCounts_Ind2_0x1 OR HfBitCounts_Ind3_0x1 )
+        <output_pin nr="62" pin="a" />
+      </L1_MinimumBiasHF2_OR_NoBptxGating>
       <L1_SingleEG20 algAlias="L1_SingleEG20">
         SingleNoIsoEG_0x14 OR SingleIsoEG_0x14
         <output_pin nr="33" pin="a" />
@@ -335,14 +343,6 @@
         SingleNoIsoEG_0x05 OR SingleIsoEG_0x05
         <output_pin nr="32" pin="a" />
       </L1_SingleEG5>
-      <L1_SingleHfBitCountsRing1_1 algAlias="L1_SingleHfBitCountsRing1_1">
-        HfBitCounts_Ind0_0x1 OR HfBitCounts_Ind1_0x1
-        <output_pin nr="61" pin="a" />
-      </L1_SingleHfBitCountsRing1_1>
-      <L1_SingleHfBitCountsRing2_1 algAlias="L1_SingleHfBitCountsRing2_1">
-        ( HfBitCounts_Ind2_0x1 OR HfBitCounts_Ind3_0x1 )
-        <output_pin nr="62" pin="a" />
-      </L1_SingleHfBitCountsRing2_1>
       <L1_SingleJet12_BptxAND algAlias="L1_SingleJet12_BptxAND">
         ( SingleCenJet_0x03 OR SingleForJet_0x03 OR SingleTauJet_0x03 ) AND BPTX_plus_AND_minus.v0
         <output_pin nr="12" pin="a" />
@@ -1608,6 +1608,248 @@
 <!--TTCablingFkL1TechTrigCabling_2015_Jun_01-->
 <!--ExtCondCablingFkL1ExternalConditionsCabling_2015_Jun_01-->
 <!--AlgoDBLock
+L1_AlwaysTrue
+L1_CastorHighJet_v1
+L1_CastorMediumJet_v1
+L1_CastorMuon
+L1_DoubleJet20
+L1_DoubleJet28
+L1_DoubleJet32
+L1_DoubleMuOpen
+L1_ETT130
+L1_ETT15
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_MinimumBiasHF1_AND_v1
+L1_MinimumBiasHF1_OR
+L1_MinimumBiasHF2_AND
+L1_MinimumBiasHF2_OR
+L1_SingleEG20
+L1_SingleEG2_BptxAND
+L1_SingleEG5
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet20
+L1_SingleJet200
+L1_SingleJet36
+L1_SingleJet68
+L1_SingleJet8_BptxAND
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu3p5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TOTEM_0
+L1_TOTEM_1
+L1_TOTEM_3
+L1_ZeroBias
+L1_AlwaysTrue
+L1_CastorHighJet_v1
+L1_CastorMediumJet_v1
+L1_CastorMuon
+L1_DoubleJet20
+L1_DoubleJet28
+L1_DoubleJet32
+L1_DoubleMuOpen
+L1_ETT130
+L1_ETT15
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_MinimumBiasHF1_AND_v1
+L1_MinimumBiasHF1_OR
+L1_MinimumBiasHF2_AND
+L1_MinimumBiasHF2_OR
+L1_SingleEG20
+L1_SingleEG2_BptxAND
+L1_SingleEG5
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet20
+L1_SingleJet200
+L1_SingleJet36
+L1_SingleJet68
+L1_SingleJet8_BptxAND
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu3p5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TOTEM_0
+L1_TOTEM_1
+L1_TOTEM_3
+L1_ZeroBias
+L1_AlwaysTrue
+L1_CastorHighJet_v1
+L1_CastorMediumJet_v1
+L1_CastorMuon
+L1_DoubleHfBitCountsRing1_P1N1
+L1_DoubleHfBitCountsRing2_P1N1
+L1_DoubleJet20
+L1_DoubleJet28
+L1_DoubleJet32
+L1_DoubleMuOpen
+L1_ETT130
+L1_ETT15_BptxAND
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_MinimumBiasHF1_AND_v1
+L1_MinimumBiasHF1_OR
+L1_MinimumBiasHF2_AND
+L1_MinimumBiasHF2_OR
+L1_SingleEG20
+L1_SingleEG2_BptxAND
+L1_SingleEG5
+L1_SingleHfBitCountsRing1_1
+L1_SingleHfBitCountsRing2_1
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet20
+L1_SingleJet200
+L1_SingleJet36
+L1_SingleJet68
+L1_SingleJet8_BptxAND
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu3p5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TOTEM_0
+L1_TOTEM_1
+L1_TOTEM_2
+L1_TOTEM_3
+L1_ZeroBias
+L1_AlwaysTrue
+L1_CastorHighJet_v1
+L1_CastorMediumJet_v1
+L1_CastorMuon
+L1_DoubleHfBitCountsRing1_P1N1
+L1_DoubleHfBitCountsRing2_P1N1
+L1_DoubleJet20
+L1_DoubleJet28
+L1_DoubleJet32
+L1_DoubleMuOpen
+L1_ETT130
+L1_ETT15_BptxAND
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_MinimumBiasHF1_AND_v1
+L1_MinimumBiasHF1_OR
+L1_MinimumBiasHF2_AND
+L1_MinimumBiasHF2_OR
+L1_SingleEG20
+L1_SingleEG2_BptxAND
+L1_SingleEG5
+L1_SingleHfBitCountsRing1_1
+L1_SingleHfBitCountsRing2_1
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet20
+L1_SingleJet200
+L1_SingleJet36
+L1_SingleJet68
+L1_SingleJet8_BptxAND
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu3p5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TOTEM_0
+L1_TOTEM_1
+L1_TOTEM_2
+L1_TOTEM_3
+L1_ZeroBias
+L1_AlwaysTrue
+L1_CastorHighJet_v1
+L1_CastorMediumJet_v1
+L1_CastorMuon
+L1_DoubleJet20
+L1_DoubleJet28
+L1_DoubleJet32
+L1_DoubleMuOpen
+L1_ETT130
+L1_ETT15_BptxAND
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_MinimumBiasHF1_AND_NoBptxGating
+L1_MinimumBiasHF1_AND_v1
+L1_MinimumBiasHF1_OR
+L1_MinimumBiasHF1_OR_NoBptxGating
+L1_MinimumBiasHF2_AND
+L1_MinimumBiasHF2_AND_NoBptxGating
+L1_MinimumBiasHF2_OR
+L1_MinimumBiasHF2_OR_NoBptxGating
+L1_SingleEG20
+L1_SingleEG2_BptxAND
+L1_SingleEG5
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet20
+L1_SingleJet200
+L1_SingleJet36
+L1_SingleJet68
+L1_SingleJet8_BptxAND
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu3p5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TOTEM_0
+L1_TOTEM_1
+L1_TOTEM_2
+L1_TOTEM_3
+L1_ZeroBias
+L1_AlwaysTrue
+L1_CastorHighJet_v1
+L1_CastorMediumJet_v1
+L1_CastorMuon
+L1_DoubleJet20
+L1_DoubleJet28
+L1_DoubleJet32
+L1_DoubleMuOpen
+L1_ETT130
+L1_ETT15_BptxAND
+L1_ETT40
+L1_ETT60
+L1_ETT90
+L1_MinimumBiasHF1_AND_NoBptxGating
+L1_MinimumBiasHF1_AND_v1
+L1_MinimumBiasHF1_OR
+L1_MinimumBiasHF1_OR_NoBptxGating
+L1_MinimumBiasHF2_AND
+L1_MinimumBiasHF2_AND_NoBptxGating
+L1_MinimumBiasHF2_OR
+L1_MinimumBiasHF2_OR_NoBptxGating
+L1_SingleEG20
+L1_SingleEG2_BptxAND
+L1_SingleEG5
+L1_SingleJet12_BptxAND
+L1_SingleJet16
+L1_SingleJet20
+L1_SingleJet200
+L1_SingleJet36
+L1_SingleJet68
+L1_SingleJet8_BptxAND
+L1_SingleJetC20_NotBptxOR
+L1_SingleJetC32_NotBptxOR
+L1_SingleMu3p5
+L1_SingleMuBeamHalo
+L1_SingleMuOpen
+L1_SingleMuOpen_NotBptxOR
+L1_TOTEM_0
+L1_TOTEM_1
+L1_TOTEM_2
+L1_TOTEM_3
+L1_ZeroBias
 AlgoDBLockEnd-->
 <!--CondDBLock
 BPTX_minus.v0:BPTX_minus.v0
@@ -1631,13 +1873,10 @@ BSC_minBias_threshold1.v0:BSC_minBias_threshold1.v0
 BSC_minBias_threshold2.v0:BSC_minBias_threshold2.v0
 BSC_splash_beam1.v0:BSC_splash_beam1.v0
 BSC_splash_beam2.v0:BSC_splash_beam2.v0
-CASTOR_0.v0:CASTOR_0.v0
-CASTOR_EM.v0:CASTOR_EM.v0
 CASTOR_Gap.v0:CASTOR_Gap.v0
 CASTOR_HaloMuon.v0:CASTOR_HaloMuon.v0
 CASTOR_HighJet.v0:CASTOR_HighJet.v0
 CASTOR_MediumJet.v0:CASTOR_MediumJet.v0
-CASTOR_TotalEnergy.v0:CASTOR_TotalEnergy.v0
 DoubleCenJet_0x05:DoubleCenJet_0x05
 DoubleCenJet_0x07:DoubleCenJet_0x07
 DoubleCenJet_0x08:DoubleCenJet_0x08

--- a/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_lowPU_v4_L1T_Scales_20141121.xml
+++ b/L1TriggerConfig/L1GtConfigProducers/data/Luminosity/startup/L1Menu_Collisions2015_lowPU_v4_L1T_Scales_20141121.xml
@@ -1,0 +1,1798 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<def>
+<header>
+    <MenuInterface>L1Menu_Collisions2015_lowPU_v4</MenuInterface>
+    <MenuInterface_CreationDate>2015-06-23</MenuInterface_CreationDate>
+    <MenuInterface_CreationAuthor>V. M. Ghete, T. Matsushita</MenuInterface_CreationAuthor>
+    <MenuInterface_Description>L1 menu for pp data taking 2015, GCT version</MenuInterface_Description>
+    <Menu_CreationDate>2015-06-23T09:09:43.000000Z</Menu_CreationDate>
+    <Menu_CreationAuthor>V. M. Ghete, T. Matsushita</Menu_CreationAuthor>
+    <Menu_Description>L1 menu for pp data taking 2015</Menu_Description>
+    <AlgImplementation>Imp0</AlgImplementation>
+    <ScaleDbKey>L1T_Scales_20141121</ScaleDbKey>
+</header>
+  <condition_chip_1>
+    <prealgos>
+      <L1_DoubleJet32 algAlias="L1_DoubleJet32">
+        DoubleCenJet_0x08 OR DoubleForJet_0x08 OR DoubleTauJet_0x08 OR ( SingleCenJet_0x08 AND ( SingleForJet_0x08 OR SingleTauJet_0x08 ) ) OR ( SingleForJet_0x08 AND SingleTauJet_0x08 )
+        <output_pin nr="1" pin="a" />
+      </L1_DoubleJet32>
+      <L1_DoubleMuOpen algAlias="L1_DoubleMuOpen">
+        DoubleMu_0x01_Open
+        <output_pin nr="2" pin="a" />
+      </L1_DoubleMuOpen>
+      <L1_TOTEM_0 algAlias="L1_TOTEM_0">
+        TOTEM_0
+        <output_pin nr="3" pin="a" />
+      </L1_TOTEM_0>
+      <L1_TOTEM_1 algAlias="L1_TOTEM_1">
+        TOTEM_1
+        <output_pin nr="4" pin="a" />
+      </L1_TOTEM_1>
+      <L1_TOTEM_2 algAlias="L1_TOTEM_2">
+        TOTEM_2
+        <output_pin nr="5" pin="a" />
+      </L1_TOTEM_2>
+    </prealgos>
+    <conditions>
+    <DoubleCenJet_0x08 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x08>
+    <DoubleForJet_0x08 condition="calo" particle="fwdjet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleForJet_0x08>
+    <DoubleMu_0x01_Open condition="muon" particle="muon" type="2_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      <value>
+        fc
+      </value>
+      </quality>
+    </DoubleMu_0x01_Open>
+    <DoubleTauJet_0x08 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x08>
+    <SingleCenJet_0x08 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x08>
+    <SingleForJet_0x08 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x08>
+    <SingleTauJet_0x08 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x08>
+      <TOTEM_0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></TOTEM_0>
+      <TOTEM_1 condition="CondExternal" particle="GtExternal" type="TypeExternal"></TOTEM_1>
+      <TOTEM_2 condition="CondExternal" particle="GtExternal" type="TypeExternal"></TOTEM_2>
+    </conditions>
+  </condition_chip_1>
+  <condition_chip_2>
+    <prealgos>
+      <L1_AlwaysTrue algAlias="L1_AlwaysTrue">
+        BPTX_plus_AND_minus.v0 OR ( NOT BPTX_plus_AND_minus.v0 )
+        <output_pin nr="2" pin="a" />
+      </L1_AlwaysTrue>
+      <L1_CastorHighJet_v1 algAlias="L1_CastorHighJet">
+        CASTOR_HighJet.v0
+        <output_pin nr="77" pin="a" />
+      </L1_CastorHighJet_v1>
+      <L1_CastorMediumJet_v1 algAlias="L1_CastorMediumJet">
+        CASTOR_MediumJet.v0
+        <output_pin nr="76" pin="a" />
+      </L1_CastorMediumJet_v1>
+      <L1_CastorMuon algAlias="L1_CastorMuon">
+        CASTOR_HaloMuon.v0
+        <output_pin nr="78" pin="a" />
+      </L1_CastorMuon>
+      <L1_DoubleHfBitCountsRing1_P1N1 algAlias="L1_DoubleHfBitCountsRing1_P1N1">
+        ( HfBitCounts_Ind0_0x1 AND HfBitCounts_Ind1_0x1 )
+        <output_pin nr="63" pin="a" />
+      </L1_DoubleHfBitCountsRing1_P1N1>
+      <L1_DoubleHfBitCountsRing2_P1N1 algAlias="L1_DoubleHfBitCountsRing2_P1N1">
+        ( HfBitCounts_Ind2_0x1 AND HfBitCounts_Ind3_0x1 )
+        <output_pin nr="64" pin="a" />
+      </L1_DoubleHfBitCountsRing2_P1N1>
+      <L1_DoubleJet20 algAlias="L1_DoubleJet20">
+        DoubleCenJet_0x05 OR DoubleForJet_0x05 OR DoubleTauJet_0x05 OR ( SingleCenJet_0x05 AND ( SingleForJet_0x05 OR SingleTauJet_0x05 ) ) OR ( SingleForJet_0x05 AND SingleTauJet_0x05 )
+        <output_pin nr="71" pin="a" />
+      </L1_DoubleJet20>
+      <L1_DoubleJet28 algAlias="L1_DoubleJet28">
+        DoubleCenJet_0x07 OR DoubleForJet_0x07 OR DoubleTauJet_0x07 OR ( SingleCenJet_0x07 AND ( SingleForJet_0x07 OR SingleTauJet_0x07 ) ) OR ( SingleForJet_0x07 AND SingleTauJet_0x07 )
+        <output_pin nr="22" pin="a" />
+      </L1_DoubleJet28>
+      <L1_ETT130 algAlias="L1_ETT130">
+        ETT_0x104
+        <output_pin nr="45" pin="a" />
+      </L1_ETT130>
+      <L1_ETT15_BptxAND algAlias="L1_ETT15_BptxAND">
+        ETT_0x01E AND BPTX_plus_AND_minus.v0
+        <output_pin nr="41" pin="a" />
+      </L1_ETT15_BptxAND>
+      <L1_ETT40 algAlias="L1_ETT40">
+        ETT_0x050
+        <output_pin nr="42" pin="a" />
+      </L1_ETT40>
+      <L1_ETT60 algAlias="L1_ETT60">
+        ETT_0x078
+        <output_pin nr="43" pin="a" />
+      </L1_ETT60>
+      <L1_ETT90 algAlias="L1_ETT90">
+        ETT_0x0B4
+        <output_pin nr="44" pin="a" />
+      </L1_ETT90>
+      <L1_MinimumBiasHF1_AND_v1 algAlias="L1_MinimumBiasHF1_AND">
+        ( HfBitCounts_Ind0_0x1 AND HfBitCounts_Ind1_0x1 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="7" pin="a" />
+      </L1_MinimumBiasHF1_AND_v1>
+      <L1_MinimumBiasHF1_OR algAlias="L1_MinimumBiasHF1_OR">
+        ( HfBitCounts_Ind0_0x1 OR HfBitCounts_Ind1_0x1 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="5" pin="a" />
+      </L1_MinimumBiasHF1_OR>
+      <L1_MinimumBiasHF2_AND algAlias="L1_MinimumBiasHF2_AND">
+        ( HfBitCounts_Ind2_0x1 AND HfBitCounts_Ind3_0x1 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="8" pin="a" />
+      </L1_MinimumBiasHF2_AND>
+      <L1_MinimumBiasHF2_OR algAlias="L1_MinimumBiasHF2_OR">
+        ( HfBitCounts_Ind2_0x1 OR HfBitCounts_Ind3_0x1 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="6" pin="a" />
+      </L1_MinimumBiasHF2_OR>
+      <L1_SingleEG20 algAlias="L1_SingleEG20">
+        SingleNoIsoEG_0x14 OR SingleIsoEG_0x14
+        <output_pin nr="33" pin="a" />
+      </L1_SingleEG20>
+      <L1_SingleEG2_BptxAND algAlias="L1_SingleEG2_BptxAND">
+        ( SingleNoIsoEG_0x02 OR SingleIsoEG_0x02 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="31" pin="a" />
+      </L1_SingleEG2_BptxAND>
+      <L1_SingleEG5 algAlias="L1_SingleEG5">
+        SingleNoIsoEG_0x05 OR SingleIsoEG_0x05
+        <output_pin nr="32" pin="a" />
+      </L1_SingleEG5>
+      <L1_SingleHfBitCountsRing1_1 algAlias="L1_SingleHfBitCountsRing1_1">
+        HfBitCounts_Ind0_0x1 OR HfBitCounts_Ind1_0x1
+        <output_pin nr="61" pin="a" />
+      </L1_SingleHfBitCountsRing1_1>
+      <L1_SingleHfBitCountsRing2_1 algAlias="L1_SingleHfBitCountsRing2_1">
+        ( HfBitCounts_Ind2_0x1 OR HfBitCounts_Ind3_0x1 )
+        <output_pin nr="62" pin="a" />
+      </L1_SingleHfBitCountsRing2_1>
+      <L1_SingleJet12_BptxAND algAlias="L1_SingleJet12_BptxAND">
+        ( SingleCenJet_0x03 OR SingleForJet_0x03 OR SingleTauJet_0x03 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="12" pin="a" />
+      </L1_SingleJet12_BptxAND>
+      <L1_SingleJet16 algAlias="L1_SingleJet16">
+        SingleCenJet_0x04 OR SingleForJet_0x04 OR SingleTauJet_0x04
+        <output_pin nr="13" pin="a" />
+      </L1_SingleJet16>
+      <L1_SingleJet20 algAlias="L1_SingleJet20">
+        SingleCenJet_0x05 OR SingleForJet_0x05 OR SingleTauJet_0x05
+        <output_pin nr="14" pin="a" />
+      </L1_SingleJet20>
+      <L1_SingleJet200 algAlias="L1_SingleJet200">
+        SingleCenJet_0x32 OR SingleForJet_0x32 OR SingleTauJet_0x32
+        <output_pin nr="17" pin="a" />
+      </L1_SingleJet200>
+      <L1_SingleJet36 algAlias="L1_SingleJet36">
+        SingleCenJet_0x09 OR SingleForJet_0x09 OR SingleTauJet_0x09
+        <output_pin nr="15" pin="a" />
+      </L1_SingleJet36>
+      <L1_SingleJet68 algAlias="L1_SingleJet68">
+        SingleCenJet_0x11 OR SingleForJet_0x11 OR SingleTauJet_0x11
+        <output_pin nr="16" pin="a" />
+      </L1_SingleJet68>
+      <L1_SingleJet8_BptxAND algAlias="L1_SingleJet8_BptxAND">
+        ( SingleCenJet_0x02 OR SingleForJet_0x02 OR SingleTauJet_0x02 ) AND BPTX_plus_AND_minus.v0
+        <output_pin nr="11" pin="a" />
+      </L1_SingleJet8_BptxAND>
+      <L1_SingleJetC20_NotBptxOR algAlias="L1_SingleJetC20_NotBptxOR">
+        ( SingleCenJet_0x05 OR SingleTauJet_0x05 ) AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="18" pin="a" />
+      </L1_SingleJetC20_NotBptxOR>
+      <L1_SingleJetC32_NotBptxOR algAlias="L1_SingleJetC32_NotBptxOR">
+        ( SingleCenJet_0x08 OR SingleTauJet_0x08 ) AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="19" pin="a" />
+      </L1_SingleJetC32_NotBptxOR>
+      <L1_SingleMu3p5 algAlias="L1_SingleMu3p5">
+        SingleMu_0x06
+        <output_pin nr="52" pin="a" />
+      </L1_SingleMu3p5>
+      <L1_SingleMuBeamHalo algAlias="L1_SingleMuBeamHalo">
+        SingleMu_0x01_BeamHalo
+        <output_pin nr="54" pin="a" />
+      </L1_SingleMuBeamHalo>
+      <L1_SingleMuOpen algAlias="L1_SingleMuOpen">
+        SingleMu_0x01_Open
+        <output_pin nr="72" pin="a" />
+      </L1_SingleMuOpen>
+      <L1_SingleMuOpen_NotBptxOR algAlias="L1_SingleMuOpen_NotBptxOR">
+        SingleMu_0x01_Open AND ( NOT ( BPTX_plus.v0 OR BPTX_minus.v0 ) )
+        <output_pin nr="55" pin="a" />
+      </L1_SingleMuOpen_NotBptxOR>
+      <L1_TOTEM_3 algAlias="L1_TOTEM_3">
+        TOTEM_3
+        <output_pin nr="73" pin="a" />
+      </L1_TOTEM_3>
+      <L1_ZeroBias algAlias="L1_ZeroBias">
+        BPTX_plus_AND_minus.v0
+        <output_pin nr="1" pin="a" />
+      </L1_ZeroBias>
+    </prealgos>
+    <conditions>
+    <DoubleCenJet_0x05 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x05>
+    <DoubleCenJet_0x07 condition="calo" particle="jet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleCenJet_0x07>
+    <DoubleForJet_0x05 condition="calo" particle="fwdjet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleForJet_0x05>
+    <DoubleForJet_0x07 condition="calo" particle="fwdjet" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleForJet_0x07>
+    <DoubleTauJet_0x05 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x05>
+    <DoubleTauJet_0x07 condition="calo" particle="tau" type="2_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </DoubleTauJet_0x07>
+    <ETT_0x01E condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        01e
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x01E>
+    <ETT_0x050 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        050
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x050>
+    <ETT_0x078 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        078
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x078>
+    <ETT_0x0B4 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        0b4
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x0B4>
+    <ETT_0x104 condition="esums" particle="ett" type="ett">
+      <et_threshold max="fff" min="000">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <en_overflow mode="bit">
+        0
+      </en_overflow>
+      <value>
+        104
+      </value>
+      </et_threshold>
+            <phi max="ffffffffffffffffff" min="000000000000000000">
+      <value>
+        00
+      </value>
+      </phi>
+    </ETT_0x104>
+    <HfBitCounts_Ind0_0x1 condition="CondHfBitCounts" particle="HfBitCounts" type="0">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1
+      </value>
+      </et_threshold>
+    </HfBitCounts_Ind0_0x1>
+    <HfBitCounts_Ind1_0x1 condition="CondHfBitCounts" particle="HfBitCounts" type="1">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1
+      </value>
+      </et_threshold>
+    </HfBitCounts_Ind1_0x1>
+    <HfBitCounts_Ind2_0x1 condition="CondHfBitCounts" particle="HfBitCounts" type="2">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1
+      </value>
+      </et_threshold>
+    </HfBitCounts_Ind2_0x1>
+    <HfBitCounts_Ind3_0x1 condition="CondHfBitCounts" particle="HfBitCounts" type="3">
+      <et_threshold max="7" min="0">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        1
+      </value>
+      </et_threshold>
+    </HfBitCounts_Ind3_0x1>
+    <SingleCenJet_0x02 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        02
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x02>
+    <SingleCenJet_0x03 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        03
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x03>
+    <SingleCenJet_0x04 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x04>
+    <SingleCenJet_0x05 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x05>
+    <SingleCenJet_0x07 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x07>
+    <SingleCenJet_0x08 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x08>
+    <SingleCenJet_0x09 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x09>
+    <SingleCenJet_0x11 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x11>
+    <SingleCenJet_0x32 condition="calo" particle="jet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleCenJet_0x32>
+    <SingleForJet_0x02 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        02
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x02>
+    <SingleForJet_0x03 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        03
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x03>
+    <SingleForJet_0x04 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x04>
+    <SingleForJet_0x05 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x05>
+    <SingleForJet_0x07 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x07>
+    <SingleForJet_0x09 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x09>
+    <SingleForJet_0x11 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x11>
+    <SingleForJet_0x32 condition="calo" particle="fwdjet" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="0f0f" min="0000">
+      <value>
+        0F0F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleForJet_0x32>
+    <SingleIsoEG_0x02 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        02
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x02>
+    <SingleIsoEG_0x05 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x05>
+    <SingleIsoEG_0x14 condition="calo" particle="ieg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleIsoEG_0x14>
+    <SingleMu_0x01_BeamHalo condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        02
+      </value>
+      </quality>
+    </SingleMu_0x01_BeamHalo>
+    <SingleMu_0x01_Open condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        01
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>01<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        fc
+      </value>
+      </quality>
+    </SingleMu_0x01_Open>
+    <SingleMu_0x06 condition="muon" particle="muon" type="1_s">
+      <pt_h_threshold max="1f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        06
+      </value>
+      </pt_h_threshold>
+      <pt_l_threshold max="1f" min="00">
+      <value>06<en_mip mode="bit">0</en_mip>
+            <en_iso mode="bit">
+        0
+      </en_iso>
+      <request_iso mode="bit">
+        0
+      </request_iso>
+      </value>
+      </pt_l_threshold>
+            <eta max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        FFFFFFFFFFFFFFFF
+      </value>
+      </eta>
+            <phi_h max="8f" min="00">
+      <value>
+        8f
+      </value>
+      </phi_h>
+            <phi_l max="ffffffffffffffff" min="0000000000000000">
+      <value>
+        00
+      </value>
+      </phi_l>
+      <charge_correlation max="7" min="1">
+      1
+      </charge_correlation>
+            <quality max="ff" min="00">
+      <value>
+        f0
+      </value>
+      </quality>
+    </SingleMu_0x06>
+    <SingleNoIsoEG_0x02 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        02
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x02>
+    <SingleNoIsoEG_0x05 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x05>
+    <SingleNoIsoEG_0x14 condition="calo" particle="eg" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        14
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleNoIsoEG_0x14>
+    <SingleTauJet_0x02 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        02
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x02>
+    <SingleTauJet_0x03 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        03
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x03>
+    <SingleTauJet_0x04 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        04
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x04>
+    <SingleTauJet_0x05 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        05
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x05>
+    <SingleTauJet_0x07 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        07
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x07>
+    <SingleTauJet_0x08 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        08
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x08>
+    <SingleTauJet_0x09 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        09
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x09>
+    <SingleTauJet_0x11 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        11
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x11>
+    <SingleTauJet_0x32 condition="calo" particle="tau" type="1_s">
+      <et_threshold max="3f" min="00">
+      <ge_eq mode="bit">
+        1
+      </ge_eq>
+      <value>
+        32
+      </value>
+      </et_threshold>
+      <eta max="7F7F" min="0000">
+      <value>
+        7F7F
+      </value>
+      </eta>
+      <phi max="3ffff" min="00000">
+      <value>
+        3ffff
+      </value>
+      </phi>
+    </SingleTauJet_0x32>
+      <BPTX_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_minus.v0>
+      <BPTX_plus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus.v0>
+      <BPTX_plus_AND_minus.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></BPTX_plus_AND_minus.v0>
+      <CASTOR_HaloMuon.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></CASTOR_HaloMuon.v0>
+      <CASTOR_HighJet.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></CASTOR_HighJet.v0>
+      <CASTOR_MediumJet.v0 condition="CondExternal" particle="GtExternal" type="TypeExternal"></CASTOR_MediumJet.v0>
+      <TOTEM_3 condition="CondExternal" particle="GtExternal" type="TypeExternal"></TOTEM_3>
+    </conditions>
+  </condition_chip_2>
+<techtriggers>
+  <L1Tech_BPTX_plus_AND_minus.v0>
+    TechTrig
+    <output_pin nr="0" />
+  </L1Tech_BPTX_plus_AND_minus.v0>
+  <L1Tech_BPTX_plus.v0>
+    TechTrig
+    <output_pin nr="1" />
+  </L1Tech_BPTX_plus.v0>
+  <L1Tech_BPTX_minus.v0>
+    TechTrig
+    <output_pin nr="2" />
+  </L1Tech_BPTX_minus.v0>
+  <L1Tech_BPTX_plus_OR_minus.v0>
+    TechTrig
+    <output_pin nr="3" />
+  </L1Tech_BPTX_plus_OR_minus.v0>
+  <L1Tech_BPTX_plus_AND_minus_instance1.v0>
+    TechTrig
+    <output_pin nr="4" />
+  </L1Tech_BPTX_plus_AND_minus_instance1.v0>
+  <L1Tech_BPTX_plus_AND_NOT_minus.v0>
+    TechTrig
+    <output_pin nr="5" />
+  </L1Tech_BPTX_plus_AND_NOT_minus.v0>
+  <L1Tech_BPTX_minus_AND_not_plus.v0>
+    TechTrig
+    <output_pin nr="6" />
+  </L1Tech_BPTX_minus_AND_not_plus.v0>
+  <L1Tech_BPTX_quiet.v0>
+    TechTrig
+    <output_pin nr="7" />
+  </L1Tech_BPTX_quiet.v0>
+  <L1Tech_HCAL_HF_single_channel.v0>
+    TechTrig
+    <output_pin nr="8" />
+  </L1Tech_HCAL_HF_single_channel.v0>
+  <L1Tech_HCAL_HF_coincidence_PM.v2>
+    TechTrig
+    <output_pin nr="9" />
+  </L1Tech_HCAL_HF_coincidence_PM.v2>
+  <L1Tech_HCAL_HF_MMP_or_MPP.v1>
+    TechTrig
+    <output_pin nr="10" />
+  </L1Tech_HCAL_HF_MMP_or_MPP.v1>
+  <L1Tech_HCAL_HO_totalOR.v0>
+    TechTrig
+    <output_pin nr="11" />
+  </L1Tech_HCAL_HO_totalOR.v0>
+  <L1Tech_HCAL_HBHE_totalOR.v0>
+    TechTrig
+    <output_pin nr="12" />
+  </L1Tech_HCAL_HBHE_totalOR.v0>
+  <L1Tech_BPTX_PreBPTX.v0>
+    TechTrig
+    <output_pin nr="16" />
+  </L1Tech_BPTX_PreBPTX.v0>
+  <L1Tech_DT_GlobalOR.v0>
+    TechTrig
+    <output_pin nr="20" />
+  </L1Tech_DT_GlobalOR.v0>
+  <L1Tech_RPC_TTU_barrel_Cosmics.v0>
+    TechTrig
+    <output_pin nr="24" />
+  </L1Tech_RPC_TTU_barrel_Cosmics.v0>
+  <L1Tech_RPC_TTU_pointing_Cosmics.v0>
+    TechTrig
+    <output_pin nr="25" />
+  </L1Tech_RPC_TTU_pointing_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBplus2_Cosmics.v0>
+    TechTrig
+    <output_pin nr="26" />
+  </L1Tech_RPC_TTU_RBplus2_Cosmics.v0>
+  <L1Tech_RPC_TTU_RBplus1_Cosmics.v0>
+    TechTrig
+    <output_pin nr="27" />
+  </L1Tech_RPC_TTU_RBplus1_Cosmics.v0>
+  <L1Tech__TTU_RB0_Cosmics.v0>
+    TechTrig
+    <output_pin nr="28" />
+  </L1Tech__TTU_RB0_Cosmics.v0>
+  <L1Tech_TOTEM_0>
+    TechTrig
+    <output_pin nr="52" />
+  </L1Tech_TOTEM_0>
+  <L1Tech_TOTEM_1>
+    TechTrig
+    <output_pin nr="53" />
+  </L1Tech_TOTEM_1>
+  <L1Tech_TOTEM_2>
+    TechTrig
+    <output_pin nr="54" />
+  </L1Tech_TOTEM_2>
+  <L1Tech_TOTEM_3>
+    TechTrig
+    <output_pin nr="55" />
+  </L1Tech_TOTEM_3>
+  <L1Tech_CASTOR_Gap.v0>
+    TechTrig
+    <output_pin nr="56" />
+  </L1Tech_CASTOR_Gap.v0>
+  <L1Tech_CASTOR_HighJet.v0>
+    TechTrig
+    <output_pin nr="57" />
+  </L1Tech_CASTOR_HighJet.v0>
+  <L1Tech_CASTOR_MediumJet.v0>
+    TechTrig
+    <output_pin nr="58" />
+  </L1Tech_CASTOR_MediumJet.v0>
+  <L1Tech_CASTOR_HaloMuon.v0>
+    TechTrig
+    <output_pin nr="59" />
+  </L1Tech_CASTOR_HaloMuon.v0>
+  </techtriggers>
+</def>
+
+<!--MenuImplDescription-->
+<!--L1TmeVersion: 1.0.13-1-->
+<!--TTCablingFkL1TechTrigCabling_2015_Jun_01-->
+<!--ExtCondCablingFkL1ExternalConditionsCabling_2015_Jun_01-->
+<!--AlgoDBLock
+AlgoDBLockEnd-->
+<!--CondDBLock
+BPTX_minus.v0:BPTX_minus.v0
+BPTX_minus_postQuiet.v0:BPTX_minus_postQuiet.v0
+BPTX_plus.v0:BPTX_plus.v0
+BPTX_plus_AND_minus.v0:BPTX_plus_AND_minus.v0
+BPTX_plus_OR_minus.v0:BPTX_plus_OR_minus.v0
+BPTX_plus_postQuiet.v0:BPTX_plus_postQuiet.v0
+BPTXcoincidence:BPTXcoincidence
+BSC_BSC2_minus.v0:BSC_BSC2_minus.v0
+BSC_BSC2_plus.v0:BSC_BSC2_plus.v0
+BSC_HighMultiplicity.v0:BSC_HighMultiplicity.v0
+BSC_halo_beam1_inner.v0:BSC_halo_beam1_inner.v0
+BSC_halo_beam1_outer.v0:BSC_halo_beam1_outer.v0
+BSC_halo_beam2_inner.v0:BSC_halo_beam2_inner.v0
+BSC_halo_beam2_outer.v0:BSC_halo_beam2_outer.v0
+BSC_minBias_OR.v0:BSC_minBias_OR.v0
+BSC_minBias_inner_threshold1.v0:BSC_minBias_inner_threshold1.v0
+BSC_minBias_inner_threshold2.v0:BSC_minBias_inner_threshold2.v0
+BSC_minBias_threshold1.v0:BSC_minBias_threshold1.v0
+BSC_minBias_threshold2.v0:BSC_minBias_threshold2.v0
+BSC_splash_beam1.v0:BSC_splash_beam1.v0
+BSC_splash_beam2.v0:BSC_splash_beam2.v0
+CASTOR_0.v0:CASTOR_0.v0
+CASTOR_EM.v0:CASTOR_EM.v0
+CASTOR_Gap.v0:CASTOR_Gap.v0
+CASTOR_HaloMuon.v0:CASTOR_HaloMuon.v0
+CASTOR_HighJet.v0:CASTOR_HighJet.v0
+CASTOR_MediumJet.v0:CASTOR_MediumJet.v0
+CASTOR_TotalEnergy.v0:CASTOR_TotalEnergy.v0
+DoubleCenJet_0x05:DoubleCenJet_0x05
+DoubleCenJet_0x07:DoubleCenJet_0x07
+DoubleCenJet_0x08:DoubleCenJet_0x08
+DoubleForJet_0x05:DoubleForJet_0x05
+DoubleForJet_0x07:DoubleForJet_0x07
+DoubleForJet_0x08:DoubleForJet_0x08
+DoubleMu_0x01_Open:DoubleMu_0x01_Open
+DoubleTauJet_0x05:DoubleTauJet_0x05
+DoubleTauJet_0x07:DoubleTauJet_0x07
+DoubleTauJet_0x08:DoubleTauJet_0x08
+Dummy_00:Dummy_00
+Dummy_01:Dummy_01
+Dummy_02:Dummy_02
+Dummy_03:Dummy_03
+Dummy_04:Dummy_04
+Dummy_05:Dummy_05
+Dummy_06:Dummy_06
+Dummy_07:Dummy_07
+Dummy_08:Dummy_08
+Dummy_09:Dummy_09
+Dummy_10:Dummy_10
+Dummy_11:Dummy_11
+Dummy_12:Dummy_12
+Dummy_13:Dummy_13
+Dummy_14:Dummy_14
+Dummy_15:Dummy_15
+Dummy_16:Dummy_16
+Dummy_17:Dummy_17
+Dummy_18:Dummy_18
+Dummy_19:Dummy_19
+Dummy_20:Dummy_20
+Dummy_21:Dummy_21
+Dummy_22:Dummy_22
+Dummy_23:Dummy_23
+Dummy_24:Dummy_24
+Dummy_25:Dummy_25
+Dummy_26:Dummy_26
+Dummy_27:Dummy_27
+Dummy_28:Dummy_28
+Dummy_29:Dummy_29
+Dummy_30:Dummy_30
+Dummy_31:Dummy_31
+Dummy_32:Dummy_32
+Dummy_33:Dummy_33
+Dummy_34:Dummy_34
+Dummy_35:Dummy_35
+Dummy_36:Dummy_36
+Dummy_37:Dummy_37
+Dummy_38:Dummy_38
+Dummy_39:Dummy_39
+Dummy_40:Dummy_40
+Dummy_41:Dummy_41
+Dummy_42:Dummy_42
+Dummy_43:Dummy_43
+Dummy_44:Dummy_44
+Dummy_45:Dummy_45
+Dummy_46:Dummy_46
+Dummy_47:Dummy_47
+Dummy_48:Dummy_48
+Dummy_49:Dummy_49
+Dummy_50:Dummy_50
+Dummy_51:Dummy_51
+Dummy_52:Dummy_52
+Dummy_53:Dummy_53
+Dummy_54:Dummy_54
+Dummy_55:Dummy_55
+Dummy_56:Dummy_56
+Dummy_57:Dummy_57
+Dummy_58:Dummy_58
+Dummy_59:Dummy_59
+Dummy_60:Dummy_60
+Dummy_61:Dummy_61
+Dummy_62:Dummy_62
+Dummy_63:Dummy_63
+ETT_0x01E:ETT_0x01E
+ETT_0x050:ETT_0x050
+ETT_0x078:ETT_0x078
+ETT_0x0B4:ETT_0x0B4
+ETT_0x104:ETT_0x104
+FSC_St1Sect45_down.v0:FSC_St1Sect45_down.v0
+FSC_St1Sect45_upp.v0:FSC_St1Sect45_upp.v0
+FSC_St1Sect56_down.v0:FSC_St1Sect56_down.v0
+FSC_St1Sect56_upp.v0:FSC_St1Sect56_upp.v0
+FSC_St2Sect45_down.v0:FSC_St2Sect45_down.v0
+FSC_St2Sect45_upp.v0:FSC_St2Sect45_upp.v0
+FSC_St2Sect56_down.v0:FSC_St2Sect56_down.v0
+FSC_St2Sect56_upp.v0:FSC_St2Sect56_upp.v0
+FSC_St3Sect56_downLeft.v0:FSC_St3Sect56_downLeft.v0
+FSC_St3Sect56_downRight.v0:FSC_St3Sect56_downRight.v0
+FSC_St3Sect56_uppLeft.v0:FSC_St3Sect56_uppLeft.v0
+FSC_St3Sect56_uppRight.v0:FSC_St3Sect56_uppRight.v0
+HCAL_HF_MMP_or_MPP.v0:HCAL_HF_MMP_or_MPP.v0
+HCAL_HF_MMP_or_MPP.v1:HCAL_HF_MMP_or_MPP.v1
+HCAL_HF_MM_or_PP_or_PM.v0:HCAL_HF_MM_or_PP_or_PM.v0
+HCAL_HF_coincidence_PM.v1:HCAL_HF_coincidence_PM.v1
+HCAL_HF_coincidence_PM.v2:HCAL_HF_coincidence_PM.v2
+HCAL_HF_single_channel.v0:HCAL_HF_single_channel.v0
+HCAL_HO_totalOR.v0:HCAL_HO_totalOR.v0
+HfBitCounts_Ind0_0x1:HfBitCounts_Ind0_0x1
+HfBitCounts_Ind1_0x1:HfBitCounts_Ind1_0x1
+HfBitCounts_Ind2_0x1:HfBitCounts_Ind2_0x1
+HfBitCounts_Ind3_0x1:HfBitCounts_Ind3_0x1
+SingleCenJet_0x02:SingleCenJet_0x02
+SingleCenJet_0x03:SingleCenJet_0x03
+SingleCenJet_0x04:SingleCenJet_0x04
+SingleCenJet_0x05:SingleCenJet_0x05
+SingleCenJet_0x07:SingleCenJet_0x07
+SingleCenJet_0x08:SingleCenJet_0x08
+SingleCenJet_0x09:SingleCenJet_0x09
+SingleCenJet_0x11:SingleCenJet_0x11
+SingleCenJet_0x32:SingleCenJet_0x32
+SingleForJet_0x02:SingleForJet_0x02
+SingleForJet_0x03:SingleForJet_0x03
+SingleForJet_0x04:SingleForJet_0x04
+SingleForJet_0x05:SingleForJet_0x05
+SingleForJet_0x07:SingleForJet_0x07
+SingleForJet_0x08:SingleForJet_0x08
+SingleForJet_0x09:SingleForJet_0x09
+SingleForJet_0x11:SingleForJet_0x11
+SingleForJet_0x32:SingleForJet_0x32
+SingleIsoEG_0x02:SingleIsoEG_0x02
+SingleIsoEG_0x05:SingleIsoEG_0x05
+SingleIsoEG_0x14:SingleIsoEG_0x14
+SingleMu_0x01_BeamHalo:SingleMu_0x01_BeamHalo
+SingleMu_0x01_Open:SingleMu_0x01_Open
+SingleMu_0x06:SingleMu_0x06
+SingleNoIsoEG_0x02:SingleNoIsoEG_0x02
+SingleNoIsoEG_0x05:SingleNoIsoEG_0x05
+SingleNoIsoEG_0x14:SingleNoIsoEG_0x14
+SingleTauJet_0x02:SingleTauJet_0x02
+SingleTauJet_0x03:SingleTauJet_0x03
+SingleTauJet_0x04:SingleTauJet_0x04
+SingleTauJet_0x05:SingleTauJet_0x05
+SingleTauJet_0x07:SingleTauJet_0x07
+SingleTauJet_0x08:SingleTauJet_0x08
+SingleTauJet_0x09:SingleTauJet_0x09
+SingleTauJet_0x11:SingleTauJet_0x11
+SingleTauJet_0x32:SingleTauJet_0x32
+TOTEM_0:TOTEM_0
+TOTEM_1:TOTEM_1
+TOTEM_2:TOTEM_2
+TOTEM_3:TOTEM_3
+TOTEM_Diffractive.v0:TOTEM_Diffractive.v0
+TOTEM_LowMultiplicity.v0:TOTEM_LowMultiplicity.v0
+TOTEM_MinBias.v0:TOTEM_MinBias.v0
+TOTEM_RomanPotsOR:TOTEM_RomanPotsOR
+TOTEM_ZeroBias.v0:TOTEM_ZeroBias.v0
+ZDC_Calo_minus.v0:ZDC_Calo_minus.v0
+ZDC_Calo_plus.v0:ZDC_Calo_plus.v0
+ZDC_Scint_loose_vertex.v0:ZDC_Scint_loose_vertex.v0
+ZDC_Scint_minus.v0:ZDC_Scint_minus.v0
+ZDC_Scint_plus.v0:ZDC_Scint_plus.v0
+ZDC_Scint_tight_vertex.v0:ZDC_Scint_tight_vertex.v0
+ZDC_loose_vertex.v0:ZDC_loose_vertex.v0
+ZDC_minus_over_threshold.v0:ZDC_minus_over_threshold.v0
+ZDC_plus_over_threshold.v0:ZDC_plus_over_threshold.v0
+ZDC_tight_vertex.v0:ZDC_tight_vertex.v0
+CondDBLockEnd-->


### PR DESCRIPTION
Adding v3 of 25ns, v4 of 50ns and lowPU L1T menus (74X)

The L1T menus are provided by Takashi MATSUSHITA Takashi.Matsushita@cern.ch
and taken from /afs/cern.ch/user/t/tmatsush/public/L1Menu/
