### PR TITLE
testRootStreaming: do not use obsolete edmplugin::PluginCapabilities

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="FWCore/PluginManager"/>
+<use   name="FWCore/Utilities"/>
 <library   name="testCondDBDict" file="">
 </library>
 <bin   file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">

--- a/CondCore/CondDB/test/testRootStreaming.cpp
+++ b/CondCore/CondDB/test/testRootStreaming.cpp
@@ -1,6 +1,7 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
-#include "FWCore/PluginManager/interface/PluginCapabilities.h"
+#include "FWCore/Utilities/interface/TypeWithDict.h"
+#include "FWCore/Utilities/interface/Exception.h"
 #include "MyTestData.h"
 //
 #include <iostream>
@@ -14,9 +15,10 @@ int main (int argc, char** argv)
   int ret = 0;
   edmplugin::PluginManager::Config config;
   edmplugin::PluginManager::configure(edmplugin::standard::config());
-  
-  static std::string const prefix("LCGReflex/");
-  edmplugin::PluginCapabilities::get()->load(prefix + "MyTestData");
+
+  if (!edm::TypeWithDict::byName("MyTestData")) {
+    throw cms::Exception("DictionaryMissingClass") << "The dictionary of class 'MyTestData' is missing!";
+  }
 
   MyTestData d0( 17 );
   d0.print();


### PR DESCRIPTION
Capabilities (SEAL capabilities) files are being removed. Instead of
`edmplugin::PluginCapabilities` use `edm::TypeWithDict` to get
information about types/classes available in dictionaries.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
