### PR TITLE
ClassFiller.cc: do not use obsolete edmplugin::PluginCapabilities

### DIFF
--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -4,8 +4,7 @@
 #include "FWCore/Utilities/interface/DebugMacros.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "FWCore/PluginManager/interface/PluginCapabilities.h"
-
+#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #include "TClass.h"
 
@@ -26,7 +25,10 @@ namespace edm {
 
   void loadCap(std::string const& name) {
     FDEBUG(1) << "Loading dictionary for " << name << "\n";
-    edmplugin::PluginCapabilities::get()->load(dictionaryPlugInPrefix() + name);
+    TypeWithDict typedict = TypeWithDict::byName(name);
+    if (!typedict) {
+      throw cms::Exception("DictionaryMissingClass") << "The dictionary of class '" << name << "' is missing!";
+    }
     TClass* cl = TClass::GetClass(name.c_str());
     loadType(TypeID(*cl->GetTypeInfo()));
   }


### PR DESCRIPTION
Capabilities (SEAL capabilities) files are being removed. Instead of
`edmplugin::PluginCapabilities` use `edm::TypeWithDict` to get
information about types/classes available in dictionaries.

ROOT will take care of loading the dictionary.

Should resolve:

```
===== Test "RunThis_t" ====
argument 0: RunThis_t
argument 1: /bin/bash
argument 2: IOPool/Streamer/test
argument 3: RunSimple_NewStreamer.sh
<..>
Failure cmsRun NewStreamIn_cfg.py: status 65
status = 16640

---> test RunThis_t had ERRORS

```

and

```
===== Test "RunThat_t" ====
<..>

MessageLogger Summary

Severity    # Occurrences   Total Occurrences
--------    -------------   -----------------
24-Jun-2015 03:41:00 CEST  Initiating request to open file file:multiprocess_test.dat
24-Jun-2015 03:41:00 CEST  Successfully opened file file:multiprocess_test.dat
24-Jun-2015 03:41:00 CEST  Closed file file:multiprocess_test.dat
----- Begin Fatal Exception 24-Jun-2015 03:41:00 CEST-----------------------
An exception of category 'PluginNotFound' occurred while
   [0] Constructing the EventProcessor
   [1] Constructing input source of type NewEventStreamFileReader
Exception Message:
Unable to find plugin 'LCGReflex/edm::StreamedProduct' because the category 'Capability' has no known plugins
----- End Fatal Exception -------------------------------------------------
Failure using streamer_multiprocess_cfg.py: status 65
status = 16640

---> test RunThat_t had ERRORS
```

https://cmssdt.cern.ch/SDT/cgi-bin/buildlogs/slc6_amd64_gcc491/CMSSW_7_6_DEVEL_X_2015-06-23-2300/unitTestLogs/IOPool/Streamer

@wmtan @Dr15Jones 

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
