### PR TITLE
BeamSpot Fitter: added parameters to the migrad functor to supersede EDM defaults

### DIFF
--- a/RecoVertex/BeamSpotProducer/src/PVFitter.cc
+++ b/RecoVertex/BeamSpotProducer/src/PVFitter.cc
@@ -235,17 +235,17 @@ bool PVFitter::runBXFitter() {
     // fit parameters: positions, widths, x-y correlations, tilts in xz and yz
     //
     MnUserParameters upar;
-    upar.Add("x", 0., 0.02, -10., 10.);       // 0
-    upar.Add("y", 0., 0.02, -10., 10.);       // 1
-    upar.Add("z", 0., 0.20, -30., 30.);       // 2
-    upar.Add("ex", 0.015, 0.01, 0., 10.);     // 3
-    upar.Add("corrxy", 0., 0.02, -1., 1.);    // 4
-    upar.Add("ey", 0.015, 0.01, 0., 10.);     // 5
-    upar.Add("dxdz", 0., 0.0002, -0.1, 0.1);  // 6
-    upar.Add("dydz", 0., 0.0002, -0.1, 0.1);  // 7
-    upar.Add("ez", 1., 0.1, 0., 30.);         // 8
-    upar.Add("scale", errorScale_, errorScale_/10.,
-             errorScale_/2., errorScale_*2.); // 9
+    upar.Add("x"     , 0.   , 0.02  , -10., 10.);  // 0
+    upar.Add("y"     , 0.   , 0.02  , -10., 10.);  // 1
+    upar.Add("z"     , 0.   , 0.20  , -30., 30.);  // 2
+    upar.Add("ex"    , 0.015, 0.01  , 0.  , 10.);  // 3
+    upar.Add("corrxy", 0.   , 0.02  , -1. , 1. );  // 4
+    upar.Add("ey"    , 0.015, 0.01  , 0.  , 10.);  // 5
+    upar.Add("dxdz"  , 0.   , 0.0002, -0.1, 0.1);  // 6
+    upar.Add("dydz"  , 0.   , 0.0002, -0.1, 0.1);  // 7
+    upar.Add("ez"    , 1.   , 0.1   , 0.  , 30.);  // 8
+    upar.Add("scale", errorScale_   , errorScale_/10.,
+                      errorScale_/2., errorScale_*2.);      // 9
     MnMigrad migrad(*fcn, upar);
 
     //
@@ -255,7 +255,7 @@ bool PVFitter::runBXFitter() {
     upar.Fix(6);
     upar.Fix(7);
     upar.Fix(9);
-    FunctionMinimum ierr = migrad();
+    FunctionMinimum ierr = migrad(0,1.);
     if ( !ierr.IsValid() ) {
         edm::LogInfo("PVFitter") << "3D beam spot fit failed in 1st iteration" << std::endl;
 	fit_ok = false;
@@ -270,7 +270,7 @@ bool PVFitter::runBXFitter() {
 		   upar.Value(1)+sigmaCut_*upar.Value(5),
 		   upar.Value(2)-sigmaCut_*upar.Value(8),
 		   upar.Value(2)+sigmaCut_*upar.Value(8));
-    ierr = migrad();
+    ierr = migrad(0,1.);
     if ( !ierr.IsValid() ) {
       edm::LogInfo("PVFitter") << "3D beam spot fit failed in 2nd iteration" << std::endl;
       fit_ok = false;
@@ -282,7 +282,7 @@ bool PVFitter::runBXFitter() {
     upar.Release(4);
     upar.Release(6);
     upar.Release(7);
-    ierr = migrad();
+    ierr = migrad(0,1.);
     if ( !ierr.IsValid() ) {
         edm::LogInfo("PVFitter") << "3D beam spot fit failed in 3rd iteration" << std::endl;
 	fit_ok = false;
@@ -408,7 +408,7 @@ bool PVFitter::runFitter() {
       migrad.Fix(6);
       migrad.Fix(7);
       migrad.Fix(9);
-      FunctionMinimum ierr = migrad();
+      FunctionMinimum ierr = migrad(0,1.);
       if ( !ierr.IsValid() ) {
           edm::LogWarning("PVFitter") << "3D beam spot fit failed in 1st iteration" << std::endl;
           return false;
@@ -428,7 +428,7 @@ bool PVFitter::runFitter() {
                      results[1]+sigmaCut_*results[5],
                      results[2]-sigmaCut_*results[8],
                      results[2]+sigmaCut_*results[8]);
-      ierr = migrad();
+      ierr = migrad(0,1.);
       if ( !ierr.IsValid() ) {
           edm::LogWarning("PVFitter") << "3D beam spot fit failed in 2nd iteration" << std::endl;
           return false;
@@ -439,7 +439,7 @@ bool PVFitter::runFitter() {
       migrad.Release(4);
       migrad.Release(6);
       migrad.Release(7);
-      ierr = migrad();
+      ierr = migrad(0,1.);
       if ( !ierr.IsValid() ) {
           edm::LogWarning("PVFitter") << "3D beam spot fit failed in 3rd iteration" << std::endl;
           return false;
@@ -584,4 +584,3 @@ PVFitter::pvQuality (const BeamSpotFitPVData& pv) const
   double ey = pv.posError[1];
   return ex*ex*ey*ey*(1-pv.posCorr[0]*pv.posCorr[0]);
 }
-


### PR DESCRIPTION
moving 75X PR fwd https://github.com/cms-sw/cmssw/pull/9852
