### PR TITLE
Btag DQM: move from binomial error to ClopperPearson error for Efficiency

### DIFF
--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -99,8 +99,8 @@ public:
 protected:
 
   void fillVariable ( const int & flavour , const T & var , const T & w) const;
-  double ClopperPearsonUnc(TH1F* a, TH1F* b, int bin);
-  void ComputeEfficiency(TH1F* a, TH1F* b, int bin);
+  double ClopperPearsonUnc(TH1F* num, TH1F* den, int bin);
+  void ComputeEfficiency(TH1F* num, TH1F* den, int bin);
   
   //
   // the data members
@@ -510,56 +510,28 @@ void FlavourHistograms<T>::epsPlot(const std::string& name)
    tc.Print((name + theBaseNameTitle + ".eps").c_str());
 }
 
-/*
-// needed for efficiency computations -> this / b
-// (void : alternative would be not to overwrite the histos but to return a cloned HistoDescription)
 template <class T>
-void FlavourHistograms<T>::divide ( const FlavourHistograms<T> & bHD ) const {
-  // divide histos using binomial errors
-  //
-  // ATTENTION: It's the responsability of the user to make sure that the HistoDescriptions
-  //            involved in this operation have been constructed with the statistics option switched on!!
-  //
-  if(theHisto_all) theHisto_all  ->getTH1F()-> Divide ( theHisto_all->getTH1F()  , bHD.histo_all () , 1.0 , 1.0 , "b" ) ;    
-    if (mcPlots_) {
-      if (mcPlots_>2 ) {
-	theHisto_d    ->getTH1F()-> Divide ( theHisto_d ->getTH1F()   , bHD.histo_d   () , 1.0 , 1.0 , "b" ) ;    
-	theHisto_u    ->getTH1F()-> Divide ( theHisto_u ->getTH1F()   , bHD.histo_u   () , 1.0 , 1.0 , "b" ) ;
-	theHisto_s    ->getTH1F()-> Divide ( theHisto_s ->getTH1F()   , bHD.histo_s   () , 1.0 , 1.0 , "b" ) ;
-	theHisto_g    ->getTH1F()-> Divide ( theHisto_g  ->getTH1F()  , bHD.histo_g   () , 1.0 , 1.0 , "b" ) ;
-	theHisto_dus  ->getTH1F()-> Divide ( theHisto_dus->getTH1F()  , bHD.histo_dus () , 1.0 , 1.0 , "b" ) ;
-      }
-      theHisto_c    ->getTH1F()-> Divide ( theHisto_c ->getTH1F()   , bHD.histo_c   () , 1.0 , 1.0 , "b" ) ;
-      theHisto_b    ->getTH1F()-> Divide ( theHisto_b ->getTH1F()   , bHD.histo_b   () , 1.0 , 1.0 , "b" ) ;
-      theHisto_ni   ->getTH1F()-> Divide ( theHisto_ni->getTH1F()   , bHD.histo_ni  () , 1.0 , 1.0 , "b" ) ;
-      theHisto_dusg ->getTH1F()-> Divide ( theHisto_dusg->getTH1F() , bHD.histo_dusg() , 1.0 , 1.0 , "b" ) ;
-      theHisto_pu   ->getTH1F()-> Divide ( theHisto_pu->getTH1F() , bHD.histo_pu() , 1.0 , 1.0 , "b" ) ;
-    }
-}
-*/  
-template <class T>
-double FlavourHistograms<T>::ClopperPearsonUnc(TH1F* a, TH1F* b, int bin){
-  double effVal = a->GetBinContent(bin)/b->GetBinContent(bin);
-  double errLo = TEfficiency::ClopperPearson((int)b->GetBinContent(bin), 
-					     (int)a->GetBinContent(bin),
+double FlavourHistograms<T>::ClopperPearsonUnc(TH1F* num, TH1F* den, int bin){
+  double effVal = num->GetBinContent(bin)/den->GetBinContent(bin);
+  double errLo = TEfficiency::ClopperPearson((int)den->GetBinContent(bin), 
+					     (int)num->GetBinContent(bin),
 					     0.683,false);
-  double errUp = TEfficiency::ClopperPearson((int)b->GetBinContent(bin), 
-					     (int)a->GetBinContent(bin),
+  double errUp = TEfficiency::ClopperPearson((int)den->GetBinContent(bin), 
+					     (int)num->GetBinContent(bin),
 					     0.683,true);
   return (effVal - errLo > errUp - effVal) ? effVal - errLo : errUp - effVal; 
 }
 
 template <class T>
-void FlavourHistograms<T>::ComputeEfficiency(TH1F* a, TH1F* b, int bin){
+void FlavourHistograms<T>::ComputeEfficiency(TH1F* num, TH1F* den, int bin){
   double effVal = 1.;
   double errVal = 0.;
-  if (b->GetBinContent(bin)>0) {
-    effVal = a->GetBinContent(bin)/b->GetBinContent(bin); 
+  if (den->GetBinContent(bin)>0) {
+    effVal = num->GetBinContent(bin)/den->GetBinContent(bin); 
     errVal = ClopperPearsonUnc(a, b, bin);
   }
-  a->SetBinContent(bin, effVal);
-  //a->SetBinEntries(bin, 1);
-  a->SetBinError(bin, errVal);
+  num->SetBinContent(bin, effVal);
+  num->SetBinError(bin, errVal);
 }
 
 template <class T>

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -13,6 +13,7 @@
 #include "TROOT.h"
 #include "TSystem.h"
 #include "TStyle.h"
+#include "TEfficiency.h"
 
 #include "DQMOffline/RecoB/interface/Tools.h"
 #include "DQMOffline/RecoB/interface/HistoProviderDQM.h"
@@ -58,7 +59,8 @@ public:
 
   // needed for efficiency computations -> this / b
   // (void : alternative would be not to overwrite the histos but to return a cloned HistoDescription)
-  void divide ( const FlavourHistograms<T> & bHD ) const ;
+  //void divide ( const FlavourHistograms<T> & bHD ) const ;
+  void divide ( const FlavourHistograms<T> & bHD ) ;
 
   inline void SetMaximum(const double& max) { theMax = max;}
   inline void SetMinimum(const double& min) { theMin = min;}
@@ -97,6 +99,8 @@ public:
 protected:
 
   void fillVariable ( const int & flavour , const T & var , const T & w) const;
+  double ClopperPearsonUnc(TH1F* a, TH1F* b, int bin);
+  void ComputeEfficiency(TH1F* a, TH1F* b, int bin);
   
   //
   // the data members
@@ -506,7 +510,7 @@ void FlavourHistograms<T>::epsPlot(const std::string& name)
    tc.Print((name + theBaseNameTitle + ".eps").c_str());
 }
 
-
+/*
 // needed for efficiency computations -> this / b
 // (void : alternative would be not to overwrite the histos but to return a cloned HistoDescription)
 template <class T>
@@ -532,7 +536,52 @@ void FlavourHistograms<T>::divide ( const FlavourHistograms<T> & bHD ) const {
       theHisto_pu   ->getTH1F()-> Divide ( theHisto_pu->getTH1F() , bHD.histo_pu() , 1.0 , 1.0 , "b" ) ;
     }
 }
-  
+*/  
+template <class T>
+double FlavourHistograms<T>::ClopperPearsonUnc(TH1F* a, TH1F* b, int bin){
+  double effVal = a->GetBinContent(bin)/b->GetBinContent(bin);
+  double errLo = TEfficiency::ClopperPearson((int)b->GetBinContent(bin), 
+					     (int)a->GetBinContent(bin),
+					     0.683,false);
+  double errUp = TEfficiency::ClopperPearson((int)b->GetBinContent(bin), 
+					     (int)a->GetBinContent(bin),
+					     0.683,true);
+  return (effVal - errLo > errUp - effVal) ? effVal - errLo : errUp - effVal; 
+}
+
+template <class T>
+void FlavourHistograms<T>::ComputeEfficiency(TH1F* a, TH1F* b, int bin){
+  double effVal = 1.;
+  double errVal = 0.;
+  if (b->GetBinContent(bin)>0) {
+    effVal = a->GetBinContent(bin)/b->GetBinContent(bin); 
+    errVal = ClopperPearsonUnc(a, b, bin);
+  }
+  a->SetBinContent(bin, effVal);
+  //a->SetBinEntries(bin, 1);
+  a->SetBinError(bin, errVal);
+}
+
+template <class T>
+void FlavourHistograms<T>::divide ( const FlavourHistograms<T> & bHD ) {
+  for(int bin = 0; bin < theNBins+2; bin++){
+    if(theHisto_all) ComputeEfficiency(theHisto_all  ->getTH1F(), bHD.histo_all(), bin);
+    if (mcPlots_) {
+      if (mcPlots_>2 ) {
+	ComputeEfficiency(theHisto_d    ->getTH1F(), bHD.histo_d   (), bin) ;    
+	ComputeEfficiency(theHisto_u    ->getTH1F(), bHD.histo_u   (), bin) ;
+	ComputeEfficiency(theHisto_s    ->getTH1F(), bHD.histo_s   (), bin) ;
+	ComputeEfficiency(theHisto_g    ->getTH1F(), bHD.histo_g   (), bin) ;
+	ComputeEfficiency(theHisto_dus  ->getTH1F(), bHD.histo_dus (), bin) ;
+      }
+      ComputeEfficiency(theHisto_c    ->getTH1F(), bHD.histo_c   (), bin) ;
+      ComputeEfficiency(theHisto_b    ->getTH1F(), bHD.histo_b   (), bin) ;
+      ComputeEfficiency(theHisto_ni   ->getTH1F(), bHD.histo_ni  (), bin) ;
+      ComputeEfficiency(theHisto_dusg ->getTH1F(), bHD.histo_dusg(), bin) ;
+      ComputeEfficiency(theHisto_pu   ->getTH1F(), bHD.histo_pu  (), bin) ;
+    }
+  }
+}
 
 template <class T>
 void FlavourHistograms<T>::fillVariable ( const int & flavour , const T & var , const T & w) const {

--- a/DQMOffline/RecoB/interface/FlavourHistorgrams.h
+++ b/DQMOffline/RecoB/interface/FlavourHistorgrams.h
@@ -57,10 +57,8 @@ public:
 
   void epsPlot(const std::string& name);
 
-  // needed for efficiency computations -> this / b
-  // (void : alternative would be not to overwrite the histos but to return a cloned HistoDescription)
-  //void divide ( const FlavourHistograms<T> & bHD ) const ;
   void divide ( const FlavourHistograms<T> & bHD ) ;
+  void setEfficiencyFlag();
 
   inline void SetMaximum(const double& max) { theMax = max;}
   inline void SetMinimum(const double& min) { theMin = min;}
@@ -528,7 +526,7 @@ void FlavourHistograms<T>::ComputeEfficiency(TH1F* num, TH1F* den, int bin){
   double errVal = 0.;
   if (den->GetBinContent(bin)>0) {
     effVal = num->GetBinContent(bin)/den->GetBinContent(bin); 
-    errVal = ClopperPearsonUnc(a, b, bin);
+    errVal = ClopperPearsonUnc(num, den, bin);
   }
   num->SetBinContent(bin, effVal);
   num->SetBinError(bin, errVal);
@@ -553,6 +551,26 @@ void FlavourHistograms<T>::divide ( const FlavourHistograms<T> & bHD ) {
       ComputeEfficiency(theHisto_pu   ->getTH1F(), bHD.histo_pu  (), bin) ;
     }
   }
+}
+
+template <class T>
+void FlavourHistograms<T>::setEfficiencyFlag(){
+  if(theHisto_all) theHisto_all  ->setEfficiencyFlag();
+  if (mcPlots_) {
+    if (mcPlots_>2 ) {
+      theHisto_d    ->setEfficiencyFlag();
+      theHisto_u    ->setEfficiencyFlag();
+      theHisto_s    ->setEfficiencyFlag();
+      theHisto_g    ->setEfficiencyFlag();
+      theHisto_dus  ->setEfficiencyFlag();
+    }
+    theHisto_c    ->setEfficiencyFlag();
+    theHisto_b    ->setEfficiencyFlag();
+    theHisto_ni   ->setEfficiencyFlag();
+    theHisto_dusg ->setEfficiencyFlag();
+    theHisto_pu   ->setEfficiencyFlag();
+  }
+
 }
 
 template <class T>

--- a/DQMOffline/RecoB/src/EffPurFromHistos.cc
+++ b/DQMOffline/RecoB/src/EffPurFromHistos.cc
@@ -150,6 +150,7 @@ EffPurFromHistos::EffPurFromHistos (const FlavourHistograms<double> * dDiscrimin
 
   // divide to get efficiency vs. discriminator cut from absolute numbers
   discrCutEfficScan->divide ( *discrNoCutEffic );  // does: histos including discriminator cut / flat histo
+  discrCutEfficScan->setEfficiencyFlag();
 }
 
 
@@ -478,10 +479,15 @@ void EffPurFromHistos::compute (DQMStore::IBooker & ibook)
   HistoProviderDQM prov("Btag",label_,ibook);
   if(mcPlots_>2){
     EffFlavVsBEff_d    = (prov.book1D ( hB + "D"    + hE , hB + "D"    + hE , nBinOutput , startOutput , endOutput ));
+    EffFlavVsBEff_d->setEfficiencyFlag();
     EffFlavVsBEff_u    = (prov.book1D ( hB + "U"    + hE , hB + "U"    + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsBEff_u->setEfficiencyFlag();
     EffFlavVsBEff_s    = (prov.book1D ( hB + "S"    + hE , hB + "S"    + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsBEff_s->setEfficiencyFlag();
     EffFlavVsBEff_g    = (prov.book1D ( hB + "G"    + hE , hB + "G"    + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsBEff_g->setEfficiencyFlag();
     EffFlavVsBEff_dus  = (prov.book1D ( hB + "DUS"  + hE , hB + "DUS"  + hE , nBinOutput , startOutput , endOutput )) ;
+    EffFlavVsBEff_dus->setEfficiencyFlag();
   }
   else {
     EffFlavVsBEff_d = 0;
@@ -491,10 +497,15 @@ void EffPurFromHistos::compute (DQMStore::IBooker & ibook)
     EffFlavVsBEff_dus = 0;
   }
   EffFlavVsBEff_c    = (prov.book1D ( hB + "C"    + hE , hB + "C"    + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsBEff_c->setEfficiencyFlag();
   EffFlavVsBEff_b    = (prov.book1D ( hB + "B"    + hE , hB + "B"    + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsBEff_b->setEfficiencyFlag();
   EffFlavVsBEff_ni   = (prov.book1D ( hB + "NI"   + hE , hB + "NI"   + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsBEff_ni->setEfficiencyFlag();
   EffFlavVsBEff_dusg = (prov.book1D ( hB + "DUSG" + hE , hB + "DUSG" + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsBEff_dusg->setEfficiencyFlag();
   EffFlavVsBEff_pu   = (prov.book1D ( hB + "PU"   + hE , hB + "PU"   + hE , nBinOutput , startOutput , endOutput )) ;
+  EffFlavVsBEff_pu->setEfficiencyFlag();
 
   if(mcPlots_>2){
     EffFlavVsBEff_d->getTH1F()->SetXTitle ( "b-jet efficiency" );


### PR DESCRIPTION
- Change the way to assign error on Efficiency: binomial -> ClopperPearson as should give better error estimation for low efficiency cases.
- Take the opportunity to add missing Efficiency Flag for efficiency plots.
