### PR TITLE
Fix several usages of un-initialized variables in DQM.

### DIFF
--- a/DQM/CastorMonitor/src/CastorBaseMonitor.cc
+++ b/DQM/CastorMonitor/src/CastorBaseMonitor.cc
@@ -14,6 +14,7 @@ CastorBaseMonitor::CastorBaseMonitor() {
   fVerbosity = 0;
   rootFolder_ = "Castor";
   baseFolder_ = "BaseMonitor";
+  showTiming = false;
 }
 
 //======================= Destructor ===============================//

--- a/DQM/L1TMonitor/src/L1TdeCSCTF.cc
+++ b/DQM/L1TMonitor/src/L1TdeCSCTF.cc
@@ -478,7 +478,7 @@ void L1TdeCSCTF::analyze(Event const& e, EventSetup const& es){
     for(int dK=0; dK<15; dK++)
     {
       eDtStub[dJ][dK] = -55;
-      eDtStub[dJ][dK] = -55;
+      dDtStub[dJ][dK] = -55;
       dDtStub[7][dK] = -55;
     }
   }

--- a/DQM/Physics/src/QcdPhotonsDQM.cc
+++ b/DQM/Physics/src/QcdPhotonsDQM.cc
@@ -254,8 +254,6 @@ void QcdPhotonsDQM::bookHistograms(DQMStore::IBooker & ibooker,
 }
 
 void QcdPhotonsDQM::analyze(const Event& iEvent, const EventSetup& iSetup) {
-  num_events_in_run++;
-
   LogTrace(logTraceName) << "Analysis of event # ";
 
   ////////////////////////////////////////////////////////////////////
@@ -530,9 +528,6 @@ void QcdPhotonsDQM::analyze(const Event& iEvent, const EventSetup& iSetup) {
 }
 
 void QcdPhotonsDQM::endRun(const edm::Run& run, const edm::EventSetup& es) {
-  if (num_events_in_run > 0) {
-    h_triggers_passed->getTH1F()->Scale(1.0 / num_events_in_run);
-  }
   h_photon_et_ratio_co_cs->getTH1F()->Divide(h_photon_et_jetco->getTH1F(),
                                              h_photon_et_jetcs->getTH1F());
   h_photon_et_ratio_fo_fs->getTH1F()->Divide(h_photon_et_jetfo->getTH1F(),

--- a/DQM/Physics/src/QcdPhotonsDQM.cc
+++ b/DQM/Physics/src/QcdPhotonsDQM.cc
@@ -104,12 +104,6 @@ QcdPhotonsDQM::QcdPhotonsDQM(const ParameterSet& parameters) {
   h_photon_et_jetcs = 0;
   h_photon_et_jetfo = 0;
   h_photon_et_jetfs = 0;
-  h_photon_et_ratio_co_cs = 0;
-  h_photon_et_ratio_co_fo = 0;
-  h_photon_et_ratio_co_fs = 0;
-  h_photon_et_ratio_cs_fo = 0;
-  h_photon_et_ratio_cs_fs = 0;
-  h_photon_et_ratio_fo_fs = 0;
   h_photon_eta = 0;
   h_triggers_passed = 0;
 
@@ -220,37 +214,6 @@ void QcdPhotonsDQM::bookHistograms(DQMStore::IBooker & ibooker,
   setSumw2(h_photon_et_jetco);
   setSumw2(h_photon_et_jetfs);
   setSumw2(h_photon_et_jetfo);
-
-  // Ratio of the above Photon Et distributions
-  h_photon_et_ratio_co_cs = ibooker.book1D("photon_et_ratio_00_co_cs",
-      "D(|#eta(jet)|<1.45, #eta(jet)*#eta(#gamma)<0) / D(|#eta(jet)|<1.45, "
-      "#eta(jet)*#eta(#gamma)>0);E_{T}(#gamma) (GeV); ratio", num_bins_et, bins_et);
-  h_photon_et_ratio_fo_fs = ibooker.book1D("photon_et_ratio_01_fo_fs",
-      "D(1.55<|#eta(jet)|<2.6, #eta(jet)*#eta(#gamma)<0) / "
-      "D(1.55<|#eta(jet)|<2.6, #eta(jet)*#eta(#gamma)>0);E_{T}(#gamma) (GeV); ratio",
-      num_bins_et, bins_et);
-  h_photon_et_ratio_cs_fs = ibooker.book1D("photon_et_ratio_02_cs_fs",
-      "D(|#eta(jet)|<1.45, #eta(jet)*#eta(#gamma)>0) / D(1.55<|#eta(jet)|<2.6, "
-      "#eta(jet)*#eta(#gamma)>0);E_{T}(#gamma) (GeV); ratio",
-      num_bins_et, bins_et);
-  h_photon_et_ratio_co_fs = ibooker.book1D("photon_et_ratio_03_co_fs",
-      "D(|#eta(jet)|<1.45, #eta(jet)*#eta(#gamma)<0) / D(1.55<|#eta(jet)|<2.6, "
-      "#eta(jet)*#eta(#gamma)>0);E_{T}(#gamma) (GeV); ratio",
-      num_bins_et, bins_et);
-  h_photon_et_ratio_cs_fo = ibooker.book1D("photon_et_ratio_04_cs_fo",
-      "D(|#eta(jet)|<1.45, #eta(jet)*#eta(#gamma)>0) / D(1.55<|#eta(jet)|<2.6, "
-      "#eta(jet)*#eta(#gamma)<0);E_{T}(#gamma) (GeV); ratio",
-      num_bins_et, bins_et);
-  h_photon_et_ratio_co_fo = ibooker.book1D("photon_et_ratio_05_co_fo",
-      "D(|#eta(jet)|<1.45, #eta(jet)*#eta(#gamma)<0) / D(1.55<|#eta(jet)|<2.6, "
-      "#eta(jet)*#eta(#gamma)<0);E_{T}(#gamma) (GeV); ratio",
-      num_bins_et, bins_et);
-  setSumw2(h_photon_et_ratio_co_cs);
-  setSumw2(h_photon_et_ratio_fo_fs);
-  setSumw2(h_photon_et_ratio_cs_fs);
-  setSumw2(h_photon_et_ratio_co_fs);
-  setSumw2(h_photon_et_ratio_cs_fo);
-  setSumw2(h_photon_et_ratio_co_fo);
 }
 
 void QcdPhotonsDQM::analyze(const Event& iEvent, const EventSetup& iSetup) {
@@ -525,21 +488,6 @@ void QcdPhotonsDQM::analyze(const Event& iEvent, const EventSetup& iSetup) {
   }
   // End of Filling histograms
   ////////////////////////////////////////////////////////////////////
-}
-
-void QcdPhotonsDQM::endRun(const edm::Run& run, const edm::EventSetup& es) {
-  h_photon_et_ratio_co_cs->getTH1F()->Divide(h_photon_et_jetco->getTH1F(),
-                                             h_photon_et_jetcs->getTH1F());
-  h_photon_et_ratio_fo_fs->getTH1F()->Divide(h_photon_et_jetfo->getTH1F(),
-                                             h_photon_et_jetfs->getTH1F());
-  h_photon_et_ratio_cs_fs->getTH1F()->Divide(h_photon_et_jetcs->getTH1F(),
-                                             h_photon_et_jetfs->getTH1F());
-  h_photon_et_ratio_co_fs->getTH1F()->Divide(h_photon_et_jetco->getTH1F(),
-                                             h_photon_et_jetfs->getTH1F());
-  h_photon_et_ratio_cs_fo->getTH1F()->Divide(h_photon_et_jetcs->getTH1F(),
-                                             h_photon_et_jetfo->getTH1F());
-  h_photon_et_ratio_co_fo->getTH1F()->Divide(h_photon_et_jetco->getTH1F(),
-                                             h_photon_et_jetfo->getTH1F());
 }
 
 // Local Variables:

--- a/DQM/Physics/src/QcdPhotonsDQM.h
+++ b/DQM/Physics/src/QcdPhotonsDQM.h
@@ -40,9 +40,6 @@ class QcdPhotonsDQM : public DQMEDAnalyzer {
   /// Get the analysis
   void analyze(const edm::Event&, const edm::EventSetup&);
 
-  // Divide histograms
-  void endRun(const edm::Run&, const edm::EventSetup&);
-
  private:
   // ----------member data ---------------------------
 
@@ -93,13 +90,6 @@ class QcdPhotonsDQM : public DQMEDAnalyzer {
   MonitorElement* h_photon_et_jetco;
   MonitorElement* h_photon_et_jetfs;
   MonitorElement* h_photon_et_jetfo;
-
-  MonitorElement* h_photon_et_ratio_co_cs;
-  MonitorElement* h_photon_et_ratio_fo_fs;
-  MonitorElement* h_photon_et_ratio_cs_fs;
-  MonitorElement* h_photon_et_ratio_co_fs;
-  MonitorElement* h_photon_et_ratio_cs_fo;
-  MonitorElement* h_photon_et_ratio_co_fo;
 };
 #endif
 

--- a/DQM/Physics/src/QcdPhotonsDQM.h
+++ b/DQM/Physics/src/QcdPhotonsDQM.h
@@ -69,8 +69,6 @@ class QcdPhotonsDQM : public DQMEDAnalyzer {
   edm::EDGetTokenT<EcalRecHitCollection> theBarrelRecHitToken_;
   edm::EDGetTokenT<EcalRecHitCollection> theEndcapRecHitToken_;
 
-  int num_events_in_run;
-
   // Histograms
   MonitorElement* h_triggers_passed;
   MonitorElement* h_photon_et_beforeCuts;

--- a/DQMOffline/Muon/src/DTSegmentsTask.cc
+++ b/DQMOffline/Muon/src/DTSegmentsTask.cc
@@ -30,8 +30,12 @@ DTSegmentsTask::DTSegmentsTask(const edm::ParameterSet& pset) {
   debug = pset.getUntrackedParameter<bool>("debug",false); 
   parameters = pset;
   
+  // should be init from pset, but it was commented out...
+  // better false than undefined
+  checkNoisyChannels = false;
+
   // the name of the 4D rec hits collection
-  theRecHits4DLabel_ = consumes<DTRecSegment4DCollection>(parameters.getParameter<std::string>("recHits4DLabel")); 
+  theRecHits4DLabel_ = consumes<DTRecSegment4DCollection>(parameters.getParameter<std::string>("recHits4DLabel"));
 }
 
 


### PR DESCRIPTION
In CastorMonitor and DTSegmentsTask the initialization from
ParameterSet was commented out, I don't know why.
I haven't un-un-commented them, just added initial values.

In QcdPhotonsDQM the variable was used to count the number of events,
and scale the histogram at the endJob.
This should be done via dqm harvesting now what we are multithreaded,
and does not make sense in the DQMEDAnalyzer.
If someone cares or needs the rates (instead of actual
values), we will create a DQMEDHarvester.

In L1TdeCSCTF.cc the array was not properly initialized,
because of the single-character error left by the developer.
