### PR TITLE
Replace getProcessParameterSet function

### DIFF
--- a/DQMServices/Components/src/DQMDcsInfo.cc
+++ b/DQMServices/Components/src/DQMDcsInfo.cc
@@ -37,8 +37,10 @@ void DQMDcsInfo::bookHistograms(DQMStore::IBooker & ibooker,
   // Fetch GlobalTag information and fill the string/ME.
   ibooker.cd();
   ibooker.setCurrentFolder(subsystemname_ +"/CMSSWInfo/");
-  const edm::ParameterSet &globalTagPSet = edm::getProcessParameterSet()
-					   .getParameterSet("PoolDBESSource@GlobalTag");
+
+  const edm::ParameterSet &globalTagPSet =
+    edm::getProcessParameterSetContainingModule(moduleDescription())
+    .getParameterSet("PoolDBESSource@GlobalTag");
 
   ibooker.bookString("globalTag_Step1", globalTagPSet.getParameter<std::string>("globaltag"));
 

--- a/DQMServices/Components/src/DQMDcsInfo.h
+++ b/DQMServices/Components/src/DQMDcsInfo.h
@@ -13,7 +13,6 @@
 #include <FWCore/Framework/interface/Run.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/ParameterSet/interface/Registry.h>
 #include <FWCore/ServiceRegistry/interface/Service.h>
 
 #include <DQMServices/Core/interface/DQMStore.h>

--- a/DQMServices/Components/src/DQMDcsInfoClient.cc
+++ b/DQMServices/Components/src/DQMDcsInfoClient.cc
@@ -35,8 +35,9 @@ DQMDcsInfoClient::beginRun(const edm::Run& r, const edm::EventSetup& c)
   // Fetch GlobalTag information and fill the string/ME.
   dbe_->cd();  
   dbe_->setCurrentFolder(subsystemname_ +"/CMSSWInfo/");
-  const edm::ParameterSet &globalTagPSet = edm::getProcessParameterSet()
-					   .getParameterSet("PoolDBESSource@GlobalTag");
+  const edm::ParameterSet &globalTagPSet =
+    edm::getProcessParameterSetContainingModule(moduleDescription())
+    .getParameterSet("PoolDBESSource@GlobalTag");
 
   dbe_->bookString("globalTag_Harvesting", globalTagPSet.getParameter<std::string>("globaltag"));
 

--- a/DQMServices/Components/src/DQMDcsInfoClient.h
+++ b/DQMServices/Components/src/DQMDcsInfoClient.h
@@ -13,7 +13,6 @@
 #include <FWCore/Framework/interface/Run.h>
 #include <FWCore/Framework/interface/MakerMacros.h>
 #include <FWCore/ParameterSet/interface/ParameterSet.h>
-#include <FWCore/ParameterSet/interface/Registry.h>
 #include <FWCore/ServiceRegistry/interface/Service.h>
 
 #include <DQMServices/Core/interface/DQMStore.h>

--- a/DQMServices/Components/src/DQMEventInfo.cc
+++ b/DQMServices/Components/src/DQMEventInfo.cc
@@ -7,7 +7,6 @@
 #include "DQMEventInfo.h"
 #include "FWCore/Framework/interface/LuminosityBlock.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 #include <TSystem.h>
 
 #include <stdio.h>
@@ -95,7 +94,10 @@ void DQMEventInfo::bookHistograms(DQMStore::IBooker & ibooker,
   ibooker.setCurrentFolder(subfolder);
 
   //Online static histograms
-  const edm::ParameterSet &sourcePSet = edm::getProcessParameterSet().getParameterSet("@main_input");
+  const edm::ParameterSet &sourcePSet =
+    edm::getProcessParameterSetContainingModule(moduleDescription())
+    .getParameterSet("@main_input");
+
   if (sourcePSet.getParameter<std::string>("@module_type") == "EventStreamHttpReader" ){
     std::string evSelection;
     std::vector<std::string> evSelectionList;

--- a/DQMServices/Components/src/DQMProvInfo.cc
+++ b/DQMServices/Components/src/DQMProvInfo.cc
@@ -7,7 +7,6 @@
 
 #include "DQMProvInfo.h"
 #include <TSystem.h>
-#include "DataFormats/Provenance/interface/ProcessHistory.h"
 #include "DataFormats/Scalers/interface/DcsStatus.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GtFdlWord.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
@@ -150,11 +149,11 @@ DQMProvInfo::beginRun(const edm::Run& r, const edm::EventSetup &c ) {
 void DQMProvInfo::analyze(const edm::Event& e, const edm::EventSetup& c){
   if(!gotProcessParameterSet_){
     gotProcessParameterSet_=true;
-    edm::ParameterSet ps;
-    //fetch the real process name
-    nameProcess_ = e.processHistory()[e.processHistory().size()-1].processName();
-    e.getProcessParameterSet(nameProcess_,ps);
-    globalTag_ = ps.getParameterSet("PoolDBESSource@GlobalTag").getParameter<std::string>("globaltag");
+
+    globalTag_ =
+      edm::getProcessParameterSetContainingModule(moduleDescription()).
+      getParameterSet("PoolDBESSource@GlobalTag").
+      getParameter<std::string>("globaltag");
     versGlobaltag_->Fill(globalTag_);
   }
   


### PR DESCRIPTION
Replace the function getProcessParameterSet
in DQMServices. This function is being removed
from the CMSSW Framework because it does not work
properly with SubProcesses and causes issues
with multithreading. The replacement should
yield identical behavior to what was originally
there (except now it works in a SubProcess job).
