### PR TITLE
Remove function getCentralityBinsFromDB

### DIFF
--- a/DataFormats/HeavyIonEvent/interface/Centrality.h
+++ b/DataFormats/HeavyIonEvent/interface/Centrality.h
@@ -83,12 +83,5 @@ protected:
 
 }
 
-#include "DataFormats/HeavyIonEvent/interface/CentralityBins.h"
-#include "FWCore/Framework/interface/EventSetup.h"
-const CentralityBins* getCentralityBinsFromDB(const edm::EventSetup& iSetup);
-
-
-
 #endif 
-
 

--- a/DataFormats/HeavyIonEvent/src/Centrality.cc
+++ b/DataFormats/HeavyIonEvent/src/Centrality.cc
@@ -2,7 +2,6 @@
 //
 
 #include "DataFormats/HeavyIonEvent/interface/Centrality.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 
 #include <iostream>
 using namespace std;
@@ -40,49 +39,4 @@ nPixelTracks_(0)
 Centrality::~Centrality()
 {
 }
-
-#include "CondFormats/HIObjects/interface/CentralityTable.h"
-#include "CondFormats/DataRecord/interface/HeavyIonRcd.h"
-#include "FWCore/Framework/interface/ESHandle.h"
-
-const CentralityBins* getCentralityBinsFromDB(const edm::EventSetup& iSetup){
-
-  string centralityLabel = "";
-  string centralityMC = "";
-  
-  const edm::ParameterSet &thepset = edm::getProcessParameterSet();
-  if(thepset.exists("HeavyIonGlobalParameters")){
-    edm::ParameterSet hiPset = thepset.getParameter<edm::ParameterSet>("HeavyIonGlobalParameters");
-    centralityLabel = hiPset.getParameter<string>("centralityVariable");
-    if(hiPset.exists("nonDefaultGlauberModel")){
-      centralityMC = hiPset.getParameter<string>("nonDefaultGlauberModel");
-      centralityLabel += centralityMC;
-    }
-  }
-  
-  edm::ESHandle<CentralityTable> inputDB_;
-  iSetup.get<HeavyIonRcd>().get(centralityLabel,inputDB_);
-  int nbinsMax = inputDB_->m_table.size();
-  //cout<<"nbinsMax "<<nbinsMax<<endl;
-   CentralityBins* CB = new CentralityBins("ctemp","",nbinsMax);
-   for(int j=0; j<nbinsMax; j++){
-
-      const CentralityTable::CBin* thisBin;
-      thisBin = &(inputDB_->m_table[j]);
-      CB->table_[j].bin_edge = thisBin->bin_edge;
-      CB->table_[j].n_part_mean = thisBin->n_part.mean;
-      CB->table_[j].n_part_var  = thisBin->n_part.var;
-      CB->table_[j].n_coll_mean = thisBin->n_coll.mean;
-      CB->table_[j].n_coll_var  = thisBin->n_coll.var;
-      CB->table_[j].n_hard_mean = thisBin->n_hard.mean;
-      CB->table_[j].n_hard_var  = thisBin->n_hard.var;
-      CB->table_[j].b_mean = thisBin->b.mean;
-      CB->table_[j].b_var = thisBin->b.var;
-
-   }
-
-   return CB;
-}
-
-
 

--- a/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
+++ b/RecoHI/HiCentralityAlgos/plugins/CentralityBinProducer.cc
@@ -26,6 +26,7 @@
 #include "FWCore/Framework/interface/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/RecoHI/HiJetAlgos/interface/ParametrizedSubtractor.h
+++ b/RecoHI/HiJetAlgos/interface/ParametrizedSubtractor.h
@@ -9,6 +9,8 @@
 
 #include "TF1.h"
 
+class CentralityBins;
+
 class ParametrizedSubtractor : public PileUpSubtractor {
  public:
   ParametrizedSubtractor(const edm::ParameterSet& iConfig, edm::ConsumesCollector && iC);

--- a/RecoHI/HiJetAlgos/src/ParametrizedSubtractor.cc
+++ b/RecoHI/HiJetAlgos/src/ParametrizedSubtractor.cc
@@ -7,6 +7,9 @@
 #include "Geometry/Records/interface/CaloGeometryRecord.h"
 
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "TFile.h"
+
 #include <string>
 #include <iostream>
 using namespace std;
@@ -49,6 +52,9 @@ ParametrizedSubtractor::ParametrizedSubtractor(const edm::ParameterSet& iConfig,
 void ParametrizedSubtractor::setupGeometryMap(edm::Event& iEvent,const edm::EventSetup& iSetup){
    LogDebug("PileUpSubtractor")<<"The subtractor setting up geometry...\n";
 
+   // The function below that is commented out was deleted from
+   // DataFormats/HeavyIonEvent/src/Centrality.cc
+   // in June 2015. See comments associated with that commit.
    //   if(!cbins_) getCentralityBinsFromDB(iSetup);
 
    edm::Handle<reco::Centrality> cent;


### PR DESCRIPTION
Remove function getCentralityBinsFromDB
because it uses getProcessParameterSet.
getProcessParameterSet is a Framework function
being removed from CMSSW because it does
not work in SubProcesses and causes issues
for multithreading. Note that
getCentralityBinsFromDB is being removed
instead of being repaired to use an alternative
for the following reasons.

First, nothing in the release calls it. The
only thing that references it is one commented
out line of code.

The function is in a DataFormats package and
accesses the EventSetup. This dependence is
not allowed.

The function is used in modules and pulls
configuration parameters from the top level
parameter set instead of from the parameter
set of the module that uses it. This is only
allowed in very special cases. If this function
was to be repaired in the future it should be
redesigned to get its configuration parameters
from the module in some way.

Also made related fixes to the header includes.
