### PR TITLE
Replace getProcessParameterSet

### DIFF
--- a/HLTrigger/HLTanalyzers/interface/HLTAnalyzer.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTAnalyzer.h
@@ -18,8 +18,6 @@
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
-#include "FWCore/ParameterSet/interface/Registry.h"
-
 #include "Geometry/Records/interface/IdealGeometryRecord.h"
 #include "Geometry/CaloEventSetup/interface/CaloTopologyRecord.h"  
 

--- a/HLTrigger/HLTanalyzers/src/HLTAnalyzer.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTAnalyzer.cc
@@ -6,6 +6,7 @@
 
 #include "HLTrigger/HLTanalyzers/interface/HLTAnalyzer.h"
 #include "HLTMessages.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 typedef std::pair<const char *, const edm::InputTag *> MissingCollectionInfo;
 
@@ -905,7 +906,7 @@ void HLTAnalyzer::endJob() {
     if (m_file)
         m_file->cd();
     
-    const edm::ParameterSet &thepset = edm::getProcessParameterSet();   
+    const edm::ParameterSet &thepset = edm::getProcessParameterSetContainingModule(moduleDescription());
     TList *list = HltTree->GetUserInfo();   
     list->Add(new TObjString(thepset.dump().c_str()));   
     

--- a/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
+++ b/HLTrigger/HLTcore/plugins/HLTPrescaleRecorder.cc
@@ -18,7 +18,6 @@
 
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 
 #include <sys/time.h>
 #include "DataFormats/Provenance/interface/Timestamp.h"
@@ -119,9 +118,9 @@ void HLTPrescaleRecorder::beginRun(edm::Run const& iRun, const edm::EventSetup& 
 
   if (src_==-1) {
     /// From PrescaleTable tracked PSet
-    ParameterSet pPSet(getProcessParameterSet());
+    ParameterSet const& pPSet(getProcessParameterSetContainingModule(moduleDescription()));
     ParameterSet iPS(pPSet.getParameter<ParameterSet>(psetName_));
-
+  
     string defaultLabel(iPS.getParameter<std::string>("lvl1DefaultLabel"));
     vector<string> labels(iPS.getParameter<std::vector<std::string> >("lvl1Labels"));
     vector<ParameterSet> vpTable(iPS.getParameter<std::vector<ParameterSet> >("prescaleTable"));

--- a/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/ProbeTreeProducer.cc
@@ -24,7 +24,6 @@
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "PhysicsTools/TagAndProbe/interface/BaseTreeFiller.h"
 #include <set>
-#include "FWCore/ParameterSet/interface/Registry.h"
 
 class ProbeTreeProducer : public edm::EDFilter {
   public:
@@ -98,7 +97,7 @@ bool ProbeTreeProducer::filter(edm::Event& iEvent, const edm::EventSetup& iSetup
 
 void ProbeTreeProducer::endJob(){
     // ask to write the current PSet info into the TTree header
-    probeFiller_->writeProvenance(edm::getProcessParameterSet());
+    probeFiller_->writeProvenance(edm::getProcessParameterSetContainingModule(moduleDescription()));
 }
 
 //define this as a plug-in

--- a/PhysicsTools/TagAndProbe/plugins/TagProbeFitTreeProducer.cc
+++ b/PhysicsTools/TagAndProbe/plugins/TagProbeFitTreeProducer.cc
@@ -41,8 +41,6 @@
 
 #include <set>
 
-#include "FWCore/ParameterSet/interface/Registry.h"
-
 //
 // class decleration
 //
@@ -217,7 +215,7 @@ TagProbeFitTreeProducer::checkMother(const reco::GenParticleRef &ref) const {
 void
 TagProbeFitTreeProducer::endJob() {
     // ask to write the current PSet info into the TTree header
-    treeFiller_->writeProvenance(edm::getProcessParameterSet());
+    treeFiller_->writeProvenance(edm::getProcessParameterSetContainingModule(moduleDescription()));
 }
 
 //define this as a plug-in


### PR DESCRIPTION
Replace the function getProcessParameterSet
in HLTrigger and PhysicsTools. This function
is being removed from the CMSSW Framework
because it does not work properly with SubProcesses
and causes issues with multithreading. The
replacement should yield identical behavior
to what was originally there (except now it
works in a SubProcess job).
