### PR TITLE
Capabilities libraries are obsolete

### DIFF
--- a/FWCore/Framework/src/ProductRegistryHelper.cc
+++ b/FWCore/Framework/src/ProductRegistryHelper.cc
@@ -7,7 +7,6 @@
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "TClass.h"
@@ -25,13 +24,12 @@ namespace edm {
                                        ModuleDescription const& iDesc,
                                        ProductRegistry& iReg,
                                        bool iIsListener) {
-    std::string const& prefix = dictionaryPlugInPrefix();
     for(TypeLabelList::const_iterator p = iBegin; p != iEnd; ++p) {
       // This should load the dictionary if not already loaded.
       TClass::GetClass(p->typeID_.typeInfo());
       if(!hasDictionary(p->typeID_.typeInfo())) {
         // a second attempt to load
-        edmplugin::PluginCapabilities::get()->tryToLoad(prefix + p->typeID_.userClassName());
+        TypeWithDict::byName(p->typeID_.userClassName());
       }
       if(!hasDictionary(p->typeID_.typeInfo())) {
         throw Exception(errors::DictionaryNotFound)

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -7,7 +7,6 @@
 #include "FWCore/PluginManager/interface/PluginCapabilities.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
@@ -272,7 +271,7 @@ namespace edm {
 
       // Load the library containing dictionaries for std:: classes, if not already loaded.
       if (!hasDictionary(typeid(std::vector<std::vector<unsigned int> >))) {
-         edmplugin::PluginCapabilities::get()->load(dictionaryPlugInPrefix() + "std::vector<std::vector<unsigned int> >");
+         TypeWithDict::byName("std::vector<std::vector<unsigned int> >");
       }
 
       int debugLevel = pset.getUntrackedParameter<int>("DebugLevel");

--- a/FWCore/Utilities/interface/DictionaryTools.h
+++ b/FWCore/Utilities/interface/DictionaryTools.h
@@ -30,9 +30,6 @@ TypeSet& missingTypes();
 
 void public_base_classes(TypeWithDict const& type,
                          std::vector<TypeWithDict>& baseTypes);
-
-std::string const& dictionaryPlugInPrefix();
-
 } // namespace edm
 
 #endif // FWCore_Utilities_DictionaryTools_h

--- a/FWCore/Utilities/src/DictionaryTools.cc
+++ b/FWCore/Utilities/src/DictionaryTools.cc
@@ -20,12 +20,6 @@
 
 namespace edm {
 
-  std::string const&
-  dictionaryPlugInPrefix() {
-    static std::string const prefix("LCGReflex/");
-    return prefix;
-  }
-
   static TypeSet missingTypes_;
 
   TypeSet&

--- a/IOPool/Streamer/src/ClassFiller.cc
+++ b/IOPool/Streamer/src/ClassFiller.cc
@@ -4,8 +4,7 @@
 #include "FWCore/Utilities/interface/DebugMacros.h"
 #include "FWCore/Utilities/interface/DictionaryTools.h"
 #include "FWCore/Utilities/interface/TypeID.h"
-#include "FWCore/PluginManager/interface/PluginCapabilities.h"
-
+#include "FWCore/Utilities/interface/TypeWithDict.h"
 
 #include "TClass.h"
 
@@ -26,7 +25,10 @@ namespace edm {
 
   void loadCap(std::string const& name) {
     FDEBUG(1) << "Loading dictionary for " << name << "\n";
-    edmplugin::PluginCapabilities::get()->load(dictionaryPlugInPrefix() + name);
+    TypeWithDict typedict = TypeWithDict::byName(name);
+    if (!typedict) {
+      throw cms::Exception("DictionaryMissingClass") << "The dictionary of class '" << name << "' is missing!";
+    }
     TClass* cl = TClass::GetClass(name.c_str());
     loadType(TypeID(*cl->GetTypeInfo()));
   }


### PR DESCRIPTION
This pull request  makes the necessary changes to the framework due to the fact that capabilities libraries are obsolete.
This PR includes the changes that are in #9857 (dependency), so there is no need to merge that PR also, although it should be harmless to do so.
