### PR TITLE
Update tracking MC validation scripts

### DIFF
--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -582,27 +582,6 @@ class PlotGroup:
         self._name = name
         self._plots = plots
 
-        if len(self._plots) <= 2:
-            self._canvas = ROOT.TCanvas(self._name, self._name, 1000, 500)
-        elif len(self._plots) <= 4:
-            self._canvas = ROOT.TCanvas(self._name, self._name, 1000, 1050)
-        elif len(self._plots) <= 6:
-            self._canvas = ROOT.TCanvas(self._name, self._name, 1000, 1400)
-        elif len(self._plots) <= 8:
-            self._canvas = ROOT.TCanvas(self._name, self._name, 1000, 1750)
-        elif len(self._plots) <= 10:
-            self._canvas = ROOT.TCanvas(self._name, self._name, 1000, 2100)
-        else:
-            self._canvas = ROOT.TCanvas(self._name, self._name, 1000, 2450)
-
-        self._canvasSingle = ROOT.TCanvas(self._name+"Single", self._name, 500, 500)
-        # from TDRStyle
-        self._canvasSingle.SetTopMargin(0.05)
-        self._canvasSingle.SetBottomMargin(0.13)
-        self._canvasSingle.SetLeftMargin(0.16)
-        self._canvasSingle.SetRightMargin(0.05)
-
-
         def _set(attr, default):
             setattr(self, "_"+attr, kwargs.get(attr, default))
 
@@ -635,15 +614,31 @@ class PlotGroup:
         if separate:
             return self._drawSeparate(algo, legendLabels, prefix, saveFormat)
 
-        self._canvas.Divide(2, int((len(self._plots)+1)/2)) # this should work also for odd n
+        cwidth = 1000
+        if len(self._plots) <= 2:
+            cheight = 500
+        elif len(self._plots) <= 4:
+            cheight = 1050
+        elif len(self._plots) <= 6:
+            cheight = 1400
+        elif len(self._plots) <= 8:
+            cheight = 1750
+        elif len(self._plots) <= 10:
+            cheight = 2100
+        else:
+            cheight = 2450
+
+        canvas = ROOT.TCanvas(self._name, self._name, cwidth, cheight)
+
+        canvas.Divide(2, int((len(self._plots)+1)/2)) # this should work also for odd n
 
         # Draw plots to canvas
         for i, plot in enumerate(self._plots):
-            self._canvas.cd(i+1)
+            canvas.cd(i+1)
             plot.draw(algo)
 
         # Setup legend
-        self._canvas.cd()
+        canvas.cd()
         if len(self._plots) <= 4:
             lx1 = 0.2
             lx2 = 0.9
@@ -667,9 +662,17 @@ class PlotGroup:
         plot = max(self._plots, key=lambda p: p.getNumberOfHistograms())
         legend = self._createLegend(plot, legendLabels, lx1, ly1, lx2, ly2)
 
-        return self._save(self._canvas, saveFormat, prefix=prefix)
+        return self._save(canvas, saveFormat, prefix=prefix)
 
     def _drawSeparate(self, algo, legendLabels, prefix, saveFormat):
+        canvas = ROOT.TCanvas(self._name+"Single", self._name, 500, 500)
+        # from TDRStyle
+        canvas.SetTopMargin(0.05)
+        canvas.SetBottomMargin(0.13)
+        canvas.SetLeftMargin(0.16)
+        canvas.SetRightMargin(0.05)
+
+
         lx1def = 0.6
         lx2def = 0.95
         ly1def = 0.85
@@ -679,7 +682,7 @@ class PlotGroup:
 
         for plot in self._plots:
             # Draw plot to canvas
-            self._canvasSingle.cd()
+            canvas.cd()
             plot.draw(algo)
 
             # Setup legend
@@ -701,7 +704,7 @@ class PlotGroup:
 
             legend = self._createLegend(plot, legendLabels, lx1, ly1, lx2, ly2, textSize=0.03)
 
-            ret.extend(self._save(self._canvasSingle, saveFormat, prefix=prefix, postfix="_"+plot.getName()))
+            ret.extend(self._save(canvas, saveFormat, prefix=prefix, postfix="_"+plot.getName()))
         return ret
 
     def _createLegend(self, plot, legendLabels, lx1, ly1, lx2, ly2, textSize=0.016):

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -448,6 +448,7 @@ class Plot:
         ratioYmax    -- Float for y axis maximum in ratio pad (default 1.1)
         ratioUncertainty -- Plot uncertainties on ratio? (default True)
         histogramModifier -- Function to be called in create() to modify the histograms (default None)
+        ignoreIfMissing -- If this plot is missing from DQM file, ignoring this plot is safe regardless of the global missingOk setting (default False)
         """
         self._name = name
 
@@ -502,6 +503,8 @@ class Plot:
 
         _set("histogramModifier", None)
 
+        _set("ignoreIfMissing", False)
+
         self._histograms = []
 
     def getNumberOfHistograms(self):
@@ -528,7 +531,7 @@ class Plot:
         # Check the histogram exists
         if th1 == None:
             print "Did not find {histo} from {dir}".format(histo=self._name, dir=tdir.GetPath())
-            if missingOk:
+            if missingOk or self._ignoreIfMissing:
                 return None
             else:
                 sys.exit(1)

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -228,6 +228,168 @@ class AggregateHistos:
 _plotStylesColor = [4, 2, ROOT.kBlack, ROOT.kOrange+7, ROOT.kMagenta-3]
 _plotStylesMarker = [21, 20, 22, 34, 33]
 
+def _drawFrame(pad, bounds, xbinlabels=None, xbinlabelsize=None, xbinlabeloption=None, suffix=""):
+    if xbinlabels is None:
+        frame = pad.DrawFrame(*bounds)
+    else:
+        # Special form needed if want to set x axis bin labels
+        nbins = len(xbinlabels)
+        frame = ROOT.TH1F("hframe"+suffix, "", nbins, bounds[0], bounds[2])
+        frame.SetBit(ROOT.TH1.kNoStats)
+        frame.SetBit(ROOT.kCanDelete)
+        frame.SetMinimum(bounds[1])
+        frame.SetMaximum(bounds[3])
+        frame.GetYaxis().SetLimits(bounds[1], bounds[3])
+        frame.Draw("")
+
+        xaxis = frame.GetXaxis()
+        for i in xrange(nbins):
+            xaxis.SetBinLabel(i+1, xbinlabels[i])
+        if xbinlabelsize is not None:
+            xaxis.SetLabelSize(xbinlabelsize)
+        if xbinlabeloption is not None:
+            frame.LabelsOption(xbinlabeloption)
+
+    return frame
+
+class Frame:
+    def __init__(self, pad, bounds, nrows, xbinlabels=None, xbinlabelsize=None, xbinlabeloption=None):
+        self._pad = pad
+        self._frame = _drawFrame(pad, bounds, xbinlabels, xbinlabelsize, xbinlabeloption)
+
+        yoffsetFactor = 1
+        xoffsetFactor = 1
+        if nrows == 2:
+            yoffsetFactor *= 2
+            xoffsetFactor *= 2
+        elif nrows == 3:
+            yoffsetFactor *= 4
+            xoffsetFactor *= 3
+
+        self._frame.GetYaxis().SetTitleOffset(self._frame.GetYaxis().GetTitleOffset()*yoffsetFactor)
+        self._frame.GetXaxis().SetTitleOffset(self._frame.GetXaxis().GetTitleOffset()*xoffsetFactor)
+
+
+    def setLogx(self, log):
+        self._pad.SetLogx(log)
+
+    def setLogy(self, log):
+        self._pad.SetLogy(log)
+
+    def setGridx(self, grid):
+        self._pad.SetGridx(grid)
+
+    def setGridy(self, grid):
+        self._pad.SetGridy(grid)
+
+    def setTitle(self, title):
+        self._frame.SetTitle(title)
+
+    def setXTitle(self, title):
+        self._frame.GetXaxis().SetTitle(title)
+
+    def setYTitle(self, title):
+        self._frame.GetYaxis().SetTitle(title)
+
+    def setYTitleSize(self, size):
+        self._frame.GetYaxis().SetTitleSize(size)
+
+    def setYTitleOffset(self, offset):
+        self._frame.GetYaxis().SetTitleSize(offset)
+
+    def redrawAxis(self):
+        self._pad.RedrawAxis()
+
+class FrameRatio:
+    def __init__(self, pad, bounds, ratioBounds, ratioFactor, nrows, xbinlabels=None, xbinlabelsize=None, xbinlabeloption=None):
+        self._parentPad = pad
+        self._pad = pad.cd(1)
+        if xbinlabels is not None:
+            self._frame = _drawFrame(self._pad, bounds, [""]*len(xbinlabels))
+        else:
+            self._frame = _drawFrame(self._pad, bounds)
+        self._padRatio = pad.cd(2)
+        self._frameRatio = _drawFrame(self._padRatio, ratioBounds, xbinlabels, xbinlabelsize, xbinlabeloption)
+
+        self._frame.GetXaxis().SetLabelSize(0)
+        self._frame.GetXaxis().SetTitleSize(0)
+
+        yoffsetFactor = ratioFactor
+        divisionPoint = 1-1/ratioFactor
+        xoffsetFactor = 1/divisionPoint #* 0.6
+
+        if nrows == 1:
+            xoffsetFactor *= 0.6
+        elif nrows == 2:
+            yoffsetFactor *= 2
+            xoffsetFactor *= 1.5
+        elif nrows == 3:
+            yoffsetFactor *= 4
+            xoffsetFactor *= 2
+
+        self._frame.GetYaxis().SetTitleOffset(self._frameRatio.GetYaxis().GetTitleOffset()*yoffsetFactor)
+        self._frameRatio.GetYaxis().SetLabelSize(int(self._frameRatio.GetYaxis().GetLabelSize()*0.8))
+        self._frameRatio.GetYaxis().SetTitleOffset(self._frameRatio.GetYaxis().GetTitleOffset()*yoffsetFactor)
+        self._frameRatio.GetXaxis().SetTitleOffset(self._frameRatio.GetXaxis().GetTitleOffset()*xoffsetFactor)
+
+        self._frameRatio.GetYaxis().SetNdivisions(4, 5, 0)
+
+        self._frameRatio.GetYaxis().SetTitle("Ratio")
+
+    def setLogx(self, log):
+        self._pad.SetLogx(log)
+        self._padRatio.SetLogx(log)
+
+    def setLogy(self, log):
+        self._pad.SetLogy(log)
+
+    def setGridx(self, grid):
+        self._pad.SetGridx(grid)
+        self._padRatio.SetGridx(grid)
+
+    def setGridy(self, grid):
+        self._pad.SetGridy(grid)
+        self._padRatio.SetGridy(grid)
+
+    def setTitle(self, title):
+        self._frame.SetTitle(title)
+
+    def setXTitle(self, title):
+        self._frameRatio.GetXaxis().SetTitle(title)
+
+    def setYTitle(self, title):
+        self._frame.GetYaxis().SetTitle(title)
+
+    def setYTitleRatio(self, title):
+        self._frameRatio.GetYaxis().SetTitle(title)
+
+    def setYTitleSize(self, size):
+        self._frame.GetYaxis().SetTitleSize(size)
+        self._frameRatio.GetYaxis().SetTitleSize(size)
+
+    def setYTitleOffset(self, offset):
+        self._frame.GetYaxis().SetTitleSize(offset)
+        self._frameRatio.GetYaxis().SetTitleSize(offset)
+
+    def redrawAxis(self):
+        self._padRatio.RedrawAxis()
+        self._pad.RedrawAxis()
+
+        self._parentPad.cd()
+
+        # pad to hide the lowest y axis label of the main pad
+        xmin=0.065
+        ymin=0.285
+        xmax=0.128
+        ymax=0.33
+        self._coverPad = ROOT.TPad("coverpad", "coverpad", xmin, ymin, xmax, ymax)
+        self._coverPad.SetBorderMode(0)
+        self._coverPad.Draw()
+
+        self._pad.cd()
+        self._pad.Pop() # Move the first pad on top
+
+
 class Plot:
     """Represents one plot, comparing one or more histograms."""
     def __init__(self, name, **kwargs):
@@ -269,6 +431,8 @@ class Plot:
         legendDy     -- Float for moving TLegend in y direction for separate=True (default None)
         legendDw     -- Float for changing TLegend width for separate=True (default None)
         legendDh     -- Float for changing TLegend height for separate=True (default None)
+        ratioYmin    -- Float for y axis minimum in ratio pad (default 0.9)
+        ratioYmax    -- Float for y axis maximum in ratio pad (default 1.1)
         histogramModifier -- Function to be called in create() to modify the histograms (default None)
         """
         self._name = name
@@ -315,6 +479,9 @@ class Plot:
         _set("legendDy", None)
         _set("legendDw", None)
         _set("legendDh", None)
+
+        _set("ratioYmin", 0.9)
+        _set("ratioYmax", 1.1)
 
         _set("histogramModifier", None)
 
@@ -398,7 +565,7 @@ class Plot:
         def _doStats(h, col, dy):
             if h is None:
                 return
-            h.SetStats(1)
+            h.SetStats(True)
 
             if self._fit:
                 h.Fit("gaus", "Q")
@@ -439,7 +606,7 @@ class Plot:
                 continue
             h.Scale(1.0/i)
 
-    def draw(self, algo):
+    def draw(self, algo, pad, ratio, ratioFactor, nrows):
         """Draw the histograms using values for a given algorithm."""
         if self._normalizeToUnitArea:
             self._normalize()
@@ -476,12 +643,6 @@ class Plot:
             print "No histograms for plot {name}".format(name=self._name)
             return
 
-        # Set log and grid
-        ROOT.gPad.SetLogx(self._xlog)
-        ROOT.gPad.SetLogy(self._ylog)
-        ROOT.gPad.SetGridx(self._xgrid)
-        ROOT.gPad.SetGridy(self._ygrid)
-
         # Return value if number, or algo-specific value if AlgoOpt
         def _getVal(val):
             if hasattr(val, "value"):
@@ -494,6 +655,11 @@ class Plot:
 
         # Create bounds before stats in order to have the
         # SetRangeUser() calls made before the fit
+        #
+        # stats is better to be called before frame, otherwise get
+        # mess in the plot (that frame creation cleans up)
+        if ratio:
+            pad.cd(1)
         self._setStats(self._statx, self._staty)
 
         xbinlabels = self._xbinlabels
@@ -504,37 +670,31 @@ class Plot:
                     xbinlabels.append(histos[0].GetXaxis().GetBinLabel(i))
 
         # Create frame
-        if xbinlabels is None:
-            frame = ROOT.gPad.DrawFrame(*bounds)
+        if ratio:
+            ratioBounds = (bounds[0], self._ratioYmin, bounds[2], self._ratioYmax)
+            frame = FrameRatio(pad, bounds, ratioBounds, ratioFactor, nrows, self._xbinlabels, self._xbinlabelsize, self._xbinlabeloption)
         else:
-            # Special form needed if want to set x axis bin labels
-            nbins = len(xbinlabels)
-            frame = ROOT.TH1F("hframe", "hframe", nbins, bounds[0], bounds[2])
-            frame.SetBit(ROOT.TH1.kNoStats)
-            frame.SetBit(ROOT.kCanDelete)
-            frame.SetMinimum(bounds[1])
-            frame.SetMaximum(bounds[3])
-            frame.GetYaxis().SetLimits(bounds[1], bounds[3])
-            frame.Draw("")
+            frame = Frame(pad, bounds, nrows, self._xbinlabels, self._xbinlabelsize, self._xbinlabeloption)
 
-            xaxis = frame.GetXaxis()
-            for i in xrange(nbins):
-                xaxis.SetBinLabel(i+1, xbinlabels[i])
-            if self._xbinlabelsize is not None:
-                xaxis.SetLabelSize(self._xbinlabelsize)
-            if self._xbinlabeloption is not None:
-                frame.LabelsOption(self._xbinlabeloption)
+        # Set log and grid
+        frame.setLogx(self._xlog)
+        frame.setLogy(self._ylog)
+        frame.setGridx(self._xgrid)
+        frame.setGridy(self._ygrid)
 
         # Set properties of frame
-        frame.SetTitle(histos[0].GetTitle())
+        frame.setTitle(histos[0].GetTitle())
         if self._xtitle is not None:
-            frame.GetXaxis().SetTitle(self._xtitle)
+            frame.setXTitle(self._xtitle)
         if self._ytitle is not None:
-            frame.GetYaxis().SetTitle(self._ytitle)
+            frame.setYTitle(self._ytitle)
         if self._ytitlesize is not None:
-            frame.GetYaxis().SetTitleSize(self._ytitlesize)
+            frame.setYTitleSize(self._ytitlesize)
         if self._ytitleoffset is not None:
-            frame.GetYaxis().SetTitleOffset(self._ytitleoffset)
+            frame.setTitleOffset(self._ytitleoffset)
+
+        if ratio:
+            frame._pad.cd()
 
         # Draw histograms
         opt = "sames" # s for statbox or something?
@@ -545,10 +705,30 @@ class Plot:
             ds = self._drawCommand
         if len(ds) > 0:
             opt += " "+ds
+
+        if ratio:
+            frame._pad.cd()
+
         for h in histos:
             h.Draw(opt)
 
-        ROOT.gPad.RedrawAxis()
+        # Draw ratios
+        if ratio and len(histos) > 0:
+            frame._padRatio.cd()
+            self._ratios = self._calculateRatios(histos) # need to keep these in memory too ...
+#            self._ratios[0]._ratio.SetFillStyle(1001)
+#            self._ratios[0]._ratio.SetFillColor(ROOT.kGray)
+#            self._ratios[0]._ratio.SetLineColor(ROOT.kGray)
+#            self._ratios[0]._ratio.SetMarkerColor(ROOT.kGray)
+#            self._ratios[0]._ratio.SetMarkerSize(0)
+#            self._ratios[0].draw("E2")
+            for r in self._ratios[1:]:
+                r.draw()
+
+            ref = histos[0]
+            refDraw = ref.Clone(ref.GetName()+"_reference")
+
+        frame.redrawAxis()
         self._frame = frame # keep the frame in memory for sure
 
     def addToLegend(self, legend, legendLabels):
@@ -562,6 +742,106 @@ class Plot:
             if h is None:
                 continue
             legend.AddEntry(h, label, "LP")
+
+    def _calculateRatios(self, histos):
+        def _divideOrZero(numerator, denominator):
+            if denominator == 0:
+                return 0
+            return numerator/denominator
+        class WrapTH1:
+            def __init__(self, th1):
+                self._th1 = th1
+                self._ratio = th1.Clone()
+            def draw(self, style="EP"):
+                self._ratio.Draw("same "+style)
+            def begin(self):
+                return 1
+            def end(self):
+                return self._th1.GetNbinsX()+1
+            def xvalues(self, bin):
+                xval = self._th1.GetBinCenter(bin)
+                xlow = xval-self._th1.GetXaxis().GetBinLowEdge(bin)
+                xhigh = self._th1.GetXaxis().GetBinUpEdge(bin)-xval
+                return (xval, xlow, xhigh)
+            def yvalues(self, bin):
+                yval = self._th1.GetBinContent(bin)
+                yerr = self._th1.GetBinError(bin)
+                return (yval, yerr, yerr)
+            def y(self, bin):
+                return self._th1.GetBinContent(bin)
+            def divide(self, bin, scale, xcenter):
+                self._ratio.SetBinContent(bin, _divideOrZero(self._th1.GetBinContent(bin), scale))
+                self._ratio.SetBinError(bin, _divideOrZero(self._th1.GetBinError(bin), scale))
+
+        class WrapTGraph:
+            def __init__(self, gr):
+                self._gr = gr
+                self._xvalues = []
+                self._xerrslow = []
+                self._xerrshigh = []
+                self._yvalues = []
+                self._yerrshigh = []
+                self._yerrslow = []
+                self._binOffset = 0
+            def draw(self, style="PZ"):
+                if len(self.xvalues) == 0:
+                    return
+                self._ratio = ROOT.TGraphAsymmErrors(len(self.xvalues), array.array("d", self.xvalues), array.array("d", self.yvalues),
+                                                     array.array("d", self.xerrslow), array.array("d", self.xerrshigh), 
+                                                     array.array("d", self.yerrslow), array.array("d", self.yerrshigh))
+                self._ratio.Draw("same "+style)
+            def begin(self):
+                return 0
+            def end(self):
+                return self._gr.GetN()
+            def xvalues(self, bin):
+                return (self._gr.GetX()[bin], self._gr.GetErrorXlow(bin), self._gr.GetErrorXhigh(bin))
+            def yvalues(self, bin):
+                return (self._gr.GetY()[bin], self._gr.GetErrorYlow(bin), self._gr.GetErrorYhigh(bin))
+            def y(self, bin):
+                return self._gr.GetY()[bin]
+            def divide(self, bin, scale, xcenter):
+                # Ignore bin if denominator is zero
+                if scale == 0:
+                    return
+                # No more items in the numerator
+                if bin >= self._gr.GetN():
+                    return
+                # denominator is missing an item
+                trueBin = bin + self.binOffset
+                xval = self._gr.GetX()[trueBin]
+                epsilon = 1e-3 * xval # to allow floating-point difference between TGraph and TH1
+                if xval+epsilon < xcenter:
+                    self.binOffset -= 1
+                    return
+                # numerator is missing an item
+                elif xval-epsilon > xcenter:
+                    self.binOffset += 1
+                    return
+
+                self.xvalues.append(xval)
+                self.xerrslow.append(self._gr.GetErrorXlow(trueBin))
+                self.xerrshigh.append(self._gr.GetErrorXhigh(trueBin))
+                self.yvalues.append(self._gr.GetY()[trueBin] / scale)
+                self.yerrslow.append(self._gr.GetErrorYlow(trueBin) / scale)
+                self.yerrshigh.append(self._gr.GetErrorYhigh(trueBin) / scale)
+
+        def wrap(o):
+            if isinstance(o, ROOT.TH1):
+                return WrapTH1(o)
+            elif isinstance(o, ROOT.TGrapgh):
+                return WrapTGraph(o)
+
+        wrappers = [wrap(h) for h in histos]
+        ref = wrappers[0]
+
+        for bin in xrange(ref.begin(), ref.end()):
+            (scale, ylow, yhigh) = ref.yvalues(bin)
+            (xval, xlow, xhigh) = ref.xvalues(bin)
+            for w in wrappers:
+                w.divide(bin, scale, xval)
+
+        return wrappers
 
 class PlotGroup:
     """Group of plots, results a TCanvas"""
@@ -592,12 +872,14 @@ class PlotGroup:
 
         _set("overrideLegendLabels", None)
 
+        self._ratioFactor = 1.25
+
     def create(self, tdirectories):
         """Create histograms from a list of TDirectories."""
         for plot in self._plots:
             plot.create(tdirectories)
 
-    def draw(self, algo, legendLabels, prefix=None, separate=False, saveFormat=".pdf"):
+    def draw(self, algo, legendLabels, prefix=None, separate=False, saveFormat=".pdf", ratio=False):
         """Draw the histograms using values for a given algorithm.
 
         Arguments:
@@ -606,36 +888,34 @@ class PlotGroup:
         prefix        -- Optional string for file name prefix (default None)
         separate      -- Save the plots of a group to separate files instead of a file per group (default False)
         saveFormat   -- String specifying the plot format (default '.pdf')
+        ratio        -- Add ratio to the plot (default False)
         """
 
         if self._overrideLegendLabels is not None:
             legendLabels = self._overrideLegendLabels
 
         if separate:
-            return self._drawSeparate(algo, legendLabels, prefix, saveFormat)
+            return self._drawSeparate(algo, legendLabels, prefix, saveFormat, ratio)
 
         cwidth = 1000
-        if len(self._plots) <= 2:
-            cheight = 500
-        elif len(self._plots) <= 4:
-            cheight = 1050
-        elif len(self._plots) <= 6:
-            cheight = 1400
-        elif len(self._plots) <= 8:
-            cheight = 1750
-        elif len(self._plots) <= 10:
-            cheight = 2100
-        else:
-            cheight = 2450
+        nrows = int((len(self._plots)+1)/2) # this should work also for odd n
+        cheight = 500 * nrows
+
+        if ratio:
+            cheight = int(cheight*self._ratioFactor)
 
         canvas = ROOT.TCanvas(self._name, self._name, cwidth, cheight)
 
-        canvas.Divide(2, int((len(self._plots)+1)/2)) # this should work also for odd n
+        canvas.Divide(2, nrows)
+        if ratio:
+            for i in xrange(0, len(self._plots)):
+                pad = canvas.cd(i+1)
+                self._modifyPadForRatio(pad)
 
         # Draw plots to canvas
         for i, plot in enumerate(self._plots):
-            canvas.cd(i+1)
-            plot.draw(algo)
+            pad = canvas.cd(i+1)
+            plot.draw(algo, pad, ratio, self._ratioFactor, nrows)
 
         # Setup legend
         canvas.cd()
@@ -664,14 +944,18 @@ class PlotGroup:
 
         return self._save(canvas, saveFormat, prefix=prefix)
 
-    def _drawSeparate(self, algo, legendLabels, prefix, saveFormat):
-        canvas = ROOT.TCanvas(self._name+"Single", self._name, 500, 500)
+    def _drawSeparate(self, algo, legendLabels, prefix, saveFormat, ratio):
+        width = 500
+        height = 500
+        if ratio:
+            height = int(height*self._ratioFactor)
+
+        canvas = ROOT.TCanvas(self._name+"Single", self._name, width, height)
         # from TDRStyle
         canvas.SetTopMargin(0.05)
         canvas.SetBottomMargin(0.13)
         canvas.SetLeftMargin(0.16)
         canvas.SetRightMargin(0.05)
-
 
         lx1def = 0.6
         lx2def = 0.95
@@ -681,9 +965,14 @@ class PlotGroup:
         ret = []
 
         for plot in self._plots:
+            if ratio:
+                canvas.cd()
+                self._modifyPadForRatio(canvas)
+
             # Draw plot to canvas
             canvas.cd()
-            plot.draw(algo)
+            plot.draw(algo, canvas, ratio, self._ratioFactor, 1)
+
 
             # Setup legend
             lx1 = lx1def
@@ -702,10 +991,40 @@ class PlotGroup:
             if plot._legendDh is not None:
                 ly1 -= plot._legendDh
 
+            canvas.cd()
             legend = self._createLegend(plot, legendLabels, lx1, ly1, lx2, ly2, textSize=0.03)
 
-            ret.extend(self._save(canvas, saveFormat, prefix=prefix, postfix="_"+plot.getName()))
+            ret.extend(self._save(canvas, saveFormat, prefix=prefix, postfix="_"+plot.getName(), single=True))
         return ret
+
+    def _modifyPadForRatio(self, pad):
+        pad.Divide(1, 2)
+
+        divisionPoint = 1-1/self._ratioFactor
+
+        topMargin = pad.GetTopMargin()
+        bottomMargin = pad.GetBottomMargin()
+        divisionPoint += (1-divisionPoint)*bottomMargin # correct for (almost-)zeroing bottom margin of pad1
+        divisionPointForPad1 = 1-( (1-divisionPoint) / (1-0.02) ) # then correct for the non-zero bottom margin, but for pad1 only
+
+        # Set the lower point of the upper pad to divisionPoint
+        pad1 = pad.cd(1)
+        yup = 1.0
+        ylow = divisionPointForPad1
+        xup = 1.0
+        xlow = 0.0
+        pad1.SetPad(xlow, ylow, xup, yup)
+        pad1.SetFillStyle(4000) # transparent
+        pad1.SetBottomMargin(0.02) # need some bottom margin here for eps/pdf output (at least in ROOT 5.34)
+
+        # Set the upper point of the lower pad to divisionPoint
+        pad2 = pad.cd(2)
+        yup = divisionPoint
+        ylow = 0.0
+        pad2.SetPad(xlow, ylow, xup, yup)
+        pad2.SetFillStyle(4000) # transparent
+        pad2.SetTopMargin(0.0)
+        pad2.SetBottomMargin(bottomMargin/(self._ratioFactor*divisionPoint))
 
     def _createLegend(self, plot, legendLabels, lx1, ly1, lx2, ly2, textSize=0.016):
         l = ROOT.TLegend(lx1, ly1, lx2, ly2)
@@ -720,7 +1039,7 @@ class PlotGroup:
         l.Draw()
         return l
 
-    def _save(self, canvas, saveFormat, prefix=None, postfix=None):
+    def _save(self, canvas, saveFormat, prefix=None, postfix=None, single=False):
         # Save the canvas to file and clear
         name = self._name
         if prefix is not None:
@@ -728,7 +1047,12 @@ class PlotGroup:
         if postfix is not None:
             name = name+postfix
         canvas.SaveAs(name+saveFormat)
-        canvas.Clear()
+        if single:
+            canvas.Clear()
+            canvas.SetLogx(False)
+            canvas.SetLogy(False)
+        else:
+            canvas.Clear("D") # keep subpads
 
         return [name+saveFormat]
 
@@ -747,16 +1071,30 @@ class Plotter:
         self._plotGroups = plotGroups
         self._saveFormat = saveFormat
 
+        _absoluteSize = True
+        if _absoluteSize:
+            font = 43
+            titleSize = 22
+            labelSize = 22
+            statSize = 14
+        else:
+            font = 42
+            titleSize = 0.05
+            labelSize = 0.05
+            statSize = 0.025
+
         ROOT.gROOT.SetStyle("Plain")
         ROOT.gStyle.SetPadRightMargin(0.07)
         ROOT.gStyle.SetPadLeftMargin(0.13)
-        ROOT.gStyle.SetTitleFont(42, "XYZ")
-        ROOT.gStyle.SetTitleSize(0.05, "XYZ")
+        ROOT.gStyle.SetTitleFont(font, "XYZ")
+        ROOT.gStyle.SetTitleSize(titleSize, "XYZ")
         ROOT.gStyle.SetTitleOffset(1.2, "Y")
         #ROOT.gStyle.SetTitleFontSize(0.05)
-        ROOT.gStyle.SetLabelFont(42, "XYZ")
-        ROOT.gStyle.SetLabelSize(0.05, "XYZ")
-        ROOT.gStyle.SetTextSize(0.05)
+        ROOT.gStyle.SetLabelFont(font, "XYZ")
+        ROOT.gStyle.SetLabelSize(labelSize, "XYZ")
+        ROOT.gStyle.SetTextSize(labelSize)
+        ROOT.gStyle.SetStatFont(font)
+        ROOT.gStyle.SetStatFontSize(statSize)
 
         ROOT.TH1.AddDirectory(False)
 
@@ -825,7 +1163,7 @@ class Plotter:
         for pg in self._plotGroups:
             pg.create(dirs)
 
-    def draw(self, algo, prefix=None, separate=False, saveFormat=None):
+    def draw(self, algo, prefix=None, separate=False, saveFormat=None, ratio=False):
         """Draw and save all plots using settings of a given algorithm.
 
         Arguments:
@@ -833,6 +1171,7 @@ class Plotter:
         prefix   -- Optional string for file name prefix (default None)
         separate -- Save the plots of a group to separate files instead of a file per group (default False)
         saveFormat -- If given, overrides the saveFormat
+        ratio    -- Add ratio to the plot (default False)
         """
         ret = []
 
@@ -841,6 +1180,6 @@ class Plotter:
             sf = saveFormat
 
         for pg in self._plotGroups:
-            ret.extend(pg.draw(algo, self._labels, prefix=prefix, separate=separate, saveFormat=sf))
+            ret.extend(pg.draw(algo, self._labels, prefix=prefix, separate=separate, saveFormat=sf, ratio=ratio))
         return ret
 

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -432,6 +432,7 @@ class Plot:
         normalizeToUnitArea -- Normalize histograms to unit area? (default False)
         profileX     -- Take histograms via ProfileX()? (default False)
         fitSlicesY   -- Take histograms via FitSlicesY() (default False)
+        rebinX       -- rebin x axis (default None)
         scale        -- Scale histograms by a number (default None)
         xbinlabels   -- List of x axis bin labels (if given, default None)
         xbinlabelsize -- Size of x axis bin labels (default None)
@@ -479,6 +480,8 @@ class Plot:
         _set("normalizeToUnitArea", False)
         _set("profileX", False)
         _set("fitSlicesY", False)
+        _set("rebinX", None)
+
         _set("scale", None)
         _set("xbinlabels", None)
         _set("xbinlabelsize", None)
@@ -631,6 +634,10 @@ class Plot:
 
         if self._normalizeToUnitArea:
             self._normalize()
+
+        if self._rebinX is not None:
+            for h in self._histograms:
+                h.Rebin(self._rebinX)
 
         def _styleMarker(h, msty, col):
             h.SetMarkerStyle(msty)

--- a/Validation/RecoTrack/python/plotting/plotting.py
+++ b/Validation/RecoTrack/python/plotting/plotting.py
@@ -716,12 +716,13 @@ class Plot:
         if ratio and len(histos) > 0:
             frame._padRatio.cd()
             self._ratios = self._calculateRatios(histos) # need to keep these in memory too ...
-#            self._ratios[0]._ratio.SetFillStyle(1001)
-#            self._ratios[0]._ratio.SetFillColor(ROOT.kGray)
-#            self._ratios[0]._ratio.SetLineColor(ROOT.kGray)
-#            self._ratios[0]._ratio.SetMarkerColor(ROOT.kGray)
-#            self._ratios[0]._ratio.SetMarkerSize(0)
-#            self._ratios[0].draw("E2")
+            self._ratios[0]._ratio.SetFillStyle(1001)
+            self._ratios[0]._ratio.SetFillColor(ROOT.kGray)
+            self._ratios[0]._ratio.SetLineColor(ROOT.kGray)
+            self._ratios[0]._ratio.SetMarkerColor(ROOT.kGray)
+            self._ratios[0]._ratio.SetMarkerSize(0)
+            self._ratios[0].draw("E2")
+            frame._padRatio.RedrawAxis("G") # redraw grid on top of the uncertainty of denominator
             for r in self._ratios[1:]:
                 r.draw()
 

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -54,7 +54,8 @@ _effvspos = PlotGroup("effvspos", [
                       legendDy=-0.025
 )
 
-_common = {"stat": True, "drawStyle": "hist"}
+# These don't exist in FastSim
+_common = {"stat": True, "drawStyle": "hist", "ignoreIfMissing": True}
 _dedx = PlotGroup("dedx", [
     Plot("h_dedx_estim1", normalizeToUnitArea=True, xtitle="dE/dx, harm2", **_common),
     Plot("h_dedx_estim2", normalizeToUnitArea=True, xtitle="dE/dx, trunc40", **_common),

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -8,9 +8,9 @@ _effandfake1 = PlotGroup("effandfake1", [
     Plot("effic", xtitle="#eta", ytitle="efficiency vs #eta", ymax=_maxEff),
     Plot(FakeDuplicate("fakeduprate_vs_eta", assoc="num_assoc(recoToSim)_eta", dup="num_duplicate_eta", reco="num_reco_eta", title="fake+duplicates vs #eta"),
          xtitle="#eta", ytitle="fake+duplicates vs #eta", ymax=_maxFake),
-    Plot("efficPt", title="", xtitle="p_{t}", ytitle="efficiency vs p_{t}", xmax=300, xlog=True),
+    Plot("efficPt", title="", xtitle="p_{t}", ytitle="efficiency vs p_{t}", xlog=True),
     Plot(FakeDuplicate("fakeduprate_vs_pT", assoc="num_assoc(recoToSim)_pT", dup="num_duplicate_pT", reco="num_reco_pT", title=""),
-         xtitle="p_{t}", ytitle="fake+duplicates rate vs p_{t}", ymax=_maxFake, xmin=0.2, xmax=300, xlog=True),
+         xtitle="p_{t}", ytitle="fake+duplicates rate vs p_{t}", ymax=_maxFake, xlog=True),
     Plot("effic_vs_hit", xtitle="hits", ytitle="efficiency vs hits"),
     Plot(FakeDuplicate("fakeduprate_vs_hit", assoc="num_assoc(recoToSim)_hit", dup="num_duplicate_hit", reco="num_reco_hit", title="fake+duplicates vs hit"),
          xtitle="hits", ytitle="fake+duplicates rate vs hits", ymax=_maxFake),
@@ -30,8 +30,8 @@ _effandfake2 = PlotGroup("effandfake2", [
 _dupandfake1 = PlotGroup("dupandfake1", [
     Plot("fakerate", xtitle="#eta", ytitle="fakerate vs #eta", ymax=_maxFake),
     Plot("duplicatesRate", xtitle="#eta", ytitle="duplicates rate vs #eta", ymax=_maxFake),
-    Plot("fakeratePt", xtitle="p_{t}", ytitle="fakerate vs p_{t}", xmax=300, xlog=True, ymax=_maxFake),
-    Plot("duplicatesRate_Pt", title="", xtitle="p_{t}", ytitle="duplicates rate vs p_{t}", xmin=0.2, xmax=300, ymax=_maxFake, xlog=True),
+    Plot("fakeratePt", xtitle="p_{t}", ytitle="fakerate vs p_{t}", xlog=True, ymax=_maxFake),
+    Plot("duplicatesRate_Pt", title="", xtitle="p_{t}", ytitle="duplicates rate vs p_{t}", ymax=_maxFake, xlog=True),
     Plot("fakerate_vs_hit", xtitle="hits", ytitle="fakerate vs hits", ymax=_maxFake),
     Plot("duplicatesRate_hit", xtitle="hits", ytitle="duplicates rate vs hits", ymax=_maxFake)
 ])
@@ -95,12 +95,12 @@ _ntracks = PlotGroup("ntracks", [
                             legendDy=-0.02, legendDh=-0.01
 )
 _tuning = PlotGroup("tuning", [
-    Plot("chi2", stat=True, normalizeToUnitArea=True, ylog=True, ymin=1e-6, ymax=[0.1, 0.2, 0.5, 1.0001], drawStyle="hist", xtitle="#chi^{2}"),
-    Plot("chi2_prob", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="Prob(#chi^{2})"),
+    Plot("chi2", stat=True, normalizeToUnitArea=True, ylog=True, ymin=1e-6, ymax=[0.1, 0.2, 0.5, 1.0001], drawStyle="hist", xtitle="#chi^{2}", ratioUncertainty=False),
+    Plot("chi2_prob", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="Prob(#chi^{2})", ratioUncertainty=False),
     Plot("chi2_vs_eta", stat=True, profileX=True, title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymax=2.5),
     Plot("ptres_vs_eta_Mean", stat=True, scale=100, title="", xtitle="#eta", ytitle="< #delta p_{t} / p_{t} > [%]", ymin=-1.5, ymax=1.5)
 ])
-_common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -10, "xmax": 10, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025]}
+_common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -10, "xmax": 10, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025], "ratioUncertainty": False}
 _pulls = PlotGroup("pulls", [
     Plot("pullPt", **_common),
     Plot("pullQoverp", **_common),

--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -95,7 +95,7 @@ _ntracks = PlotGroup("ntracks", [
                             legendDy=-0.02, legendDh=-0.01
 )
 _tuning = PlotGroup("tuning", [
-    Plot("chi2", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="#chi^{2}"),
+    Plot("chi2", stat=True, normalizeToUnitArea=True, ylog=True, ymin=1e-6, ymax=[0.1, 0.2, 0.5, 1.0001], drawStyle="hist", xtitle="#chi^{2}"),
     Plot("chi2_prob", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="Prob(#chi^{2})"),
     Plot("chi2_vs_eta", stat=True, profileX=True, title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymax=2.5),
     Plot("ptres_vs_eta_Mean", stat=True, scale=100, title="", xtitle="#eta", ytitle="< #delta p_{t} / p_{t} > [%]", ymin=-1.5, ymax=1.5)

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -12,9 +12,11 @@ import plotting
 
 # Mapping from releases to GlobalTags
 _globalTags = {
+    "CMSSW_6_2_0": {"default": "PRE_ST62_V8"},
     "CMSSW_6_2_0_SLHC15": {"UPG2019withGEM": "DES19_62_V8", "UPG2023SHNoTaper": "DES23_62_V1"},
     "CMSSW_6_2_0_SLHC17": {"UPG2019withGEM": "DES19_62_V8", "UPG2023SHNoTaper": "DES23_62_V1"},
     "CMSSW_6_2_0_SLHC20": {"UPG2019withGEM": "DES19_62_V8", "UPG2023SHNoTaper": "DES23_62_V1"},
+    "CMSSW_7_0_0": {"default": "POSTLS170_V3", "fullsim_50ns": "POSTLS170_V4"},
     "CMSSW_7_0_0_AlcaCSA14": {"default": "POSTLS170_V5_AlcaCSA14", "fullsim_50ns": "POSTLS170_V6_AlcaCSA14"},
     "CMSSW_7_0_7_pmx": {"default": "PLS170_V7AN1", "fullsim_50ns": "PLS170_V6AN1"},
     "CMSSW_7_0_9_patch3": {"default": "PLS170_V7AN2", "fullsim_50ns": "PLS170_V6AN2"},
@@ -49,6 +51,7 @@ _globalTags = {
     "CMSSW_7_4_0_pre6": {"default": "MCRUN2_74_V1", "fullsim_50ns": "MCRUN2_74_V0"},
     "CMSSW_7_4_0_pre6_pmx": {"default": "MCRUN2_74_V1", "fullsim_50ns": "MCRUN2_74_V0"},
     "CMSSW_7_4_0_pre8": {"default": "MCRUN2_74_V7", "fullsim_25ns": "MCRUN2_74_V5_AsympMinGT", "fullsim_50ns": "MCRUN2_74_V4_StartupMinGT"},
+    "CMSSW_7_4_0_pre8_minimal": {"default": "MCRUN2_74_V5_MinGT", "fullsim_25ns": "MCRUN2_74_V5_AsympMinGT", "fullsim_50ns": "MCRUN2_74_V4_StartupMinGT"},
     "CMSSW_7_4_0_pre8_25ns_asymptotic": {"default": "MCRUN2_74_V7"},
     "CMSSW_7_4_0_pre8_50ns_startup":    {"default": "MCRUN2_74_V6"},
     "CMSSW_7_4_0_pre8_50ns_asympref":   {"default": "MCRUN2_74_V5A_AsympMinGT"}, # for reference of 50ns asymptotic
@@ -56,10 +59,36 @@ _globalTags = {
     "CMSSW_7_4_0_pre8_ROOT6": {"default": "MCRUN2_74_V7"},
     "CMSSW_7_4_0_pre8_pmx": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
     "CMSSW_7_4_0_pre8_pmx_v2": {"default": "MCRUN2_74_V7_gs_pre7", "fullsim_50ns": "MCRUN2_74_V6_gs_pre7"},
+    "CMSSW_7_4_0_pre8_pmx_v3": {"default": "MCRUN2_74_V7_bis", "fullsim_50ns": "MCRUN2_74_V6_bis"},
+    "CMSSW_7_4_0_pre9": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_4_0_pre9_ROOT6": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_4_0_pre9_ROOT6_pmx": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_4_0_pre9_extended": {"default": "MCRUN2_74_V7_extended"},
+    "CMSSW_7_4_0": {"default": "MCRUN2_74_V7_gensim_740pre7", "fullsim_50ns": "MCRUN2_74_V6_gensim_740pre7", "fastsim": "MCRUN2_74_V7"},
+    "CMSSW_7_4_0_71XGENSIM": {"default": "MCRUN2_74_V7_GENSIM_7_1_15", "fullsim_50ns": "MCRUN2_74_V6_GENSIM_7_1_15"},
+    "CMSSW_7_4_0_71XGENSIM_PU": {"default": "MCRUN2_74_V7_gs7115_puProd", "fullsim_50ns": "MCRUN2_74_V6_gs7115_puProd"},
+    "CMSSW_7_4_0_71XGENSIM_PXworst": {"default": "MCRUN2_74_V7C_pxWorst_gs7115", "fullsim_50ns": "MCRUN2_74_V6A_pxWorst_gs7115"},
+    "CMSSW_7_4_0_71XGENSIM_PXbest": {"default": "MCRUN2_74_V7D_pxBest_gs7115", "fullsim_50ns": "MCRUN2_74_V6B_pxBest_gs7115"},
+    "CMSSW_7_4_0_pmx": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_4_1": {"default": "MCRUN2_74_V9_gensim_740pre7", "fullsim_50ns": "MCRUN2_74_V8_gensim_740pre7", "fastsim": "MCRUN2_74_V9"},
+    "CMSSW_7_4_1_71XGENSIM": {"default": "MCRUN2_74_V9_gensim71X", "fullsim_50ns": "MCRUN2_74_V8_gensim71X"},
+    "CMSSW_7_4_1_extended": {"default": "MCRUN2_74_V9_extended"},
+    "CMSSW_7_4_3": {"default": "MCRUN2_74_V9", "fullsim_50ns": "MCRUN2_74_V8", "fastsim": "MCRUN2_74_V9", "fastsim_25ns": "MCRUN2_74_V9_fixMem"},
+    "CMSSW_7_4_3_extended": {"default": "MCRUN2_74_V9_ext","fastsim": "MCRUN2_74_V9_fixMem"},
+    "CMSSW_7_4_3_pmx": {"default": "MCRUN2_74_V9_ext", "fullsim_50ns": "MCRUN2_74_V8", "fastsim": "MCRUN2_74_V9_fixMem"},
+    "CMSSW_7_4_3_patch1_unsch": {"default": "MCRUN2_74_V9_unsch", "fullsim_50ns": "MCRUN2_74_V8_unsch"},
+    "CMSSW_7_4_4": {"default": "MCRUN2_74_V9_38Tbis", "fullsim_50ns": "MCRUN2_74_V8_38Tbis"},
+    "CMSSW_7_4_4_0T": {"default": "MCRUN2_740TV1_0Tv2", "fullsim_50ns": "MCRUN2_740TV0_0TV2", "fullsim_25ns": "MCRUN2_740TV1_0TV2"},
+    "CMSSW_7_5_0_pre1": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_5_0_pre2": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_5_0_pre3": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_5_0_pre3_pmx": {"default": "MCRUN2_74_V7", "fullsim_50ns": "MCRUN2_74_V6"},
+    "CMSSW_7_5_0_pre4": {"default": "MCRUN2_75_V1", "fullsim_50ns": "MCRUN2_75_V0"},
+    "CMSSW_7_5_0_pre4_pmx": {"default": "MCRUN2_75_V1", "fullsim_50ns": "MCRUN2_75_V0"},
 }
 
-_releasePostfixes = ["_AlcaCSA14", "_PHYS14", "_TEST", "_pmx_v2", "_pmx", "_Fall14DR", "_71XGENSIM_FIXGT", "_71XGENSIM", "_73XGENSIM", "_BS", "_GenSim_7113",
-                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic"]
+_releasePostfixes = ["_AlcaCSA14", "_PHYS14", "_TEST", "_pmx_v2", "_pmx_v3", "_pmx", "_Fall14DR", "_71XGENSIM_FIXGT", "_71XGENSIM_PU", "_71XGENSIM_PXbest", "_71XGENSIM_PXworst", "_71XGENSIM", "_73XGENSIM", "_BS", "_GenSim_7113", "_extended",
+                     "_25ns_asymptotic", "_50ns_startup", "_50ns_asympref", "_50ns_asymptotic", "_minimal", "_0T", "_unsch"]
 def _stripRelease(release):
     for pf in _releasePostfixes:
         if pf in release:
@@ -85,11 +114,17 @@ def _getGlobalTag(sample, release):
     if sample.fullsim():
         if sample.hasScenario():
             return gtmap[sample.scenario()]
-        if sample.pileupType() == "50ns":
-            return gtmap.get("fullsim_50ns", gtmap["default"])
-        if sample.pileupType() == "25ns":
-            return gtmap.get("fullsim_25ns", gtmap["default"])
+        if sample.hasPileup():
+            puType = sample.pileupType()
+            if "50ns" in puType:
+                return gtmap.get("fullsim_50ns", gtmap["default"])
+            if "25ns" in puType:
+                return gtmap.get("fullsim_25ns", gtmap["default"])
     if sample.fastsim():
+        if sample.hasPileup():
+            puType = sample.pileupType()
+            if "25ns" in puType:
+                return gtmap.get("fastsim_25ns", gtmap["default"])
         return gtmap.get("fastsim", gtmap["default"])
     return gtmap["default"]
 
@@ -101,6 +136,7 @@ _relvalUrls = {
     "7_2_X": "https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/CMSSW_7_2_x/",
     "7_3_X": "https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/CMSSW_7_3_x/",
     "7_4_X": "https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/CMSSW_7_4_x/",
+    "7_5_X": "https://cmsweb.cern.ch/dqm/relval/data/browse/ROOT/RelVal/CMSSW_7_5_x/",
 }
 
 def _getRelValUrl(release):
@@ -429,8 +465,12 @@ class Validation:
         refSelection = refGlobalTag+tmp
         newSelection = newGlobalTag+tmp
         if sample.hasPileup() and not sample.fastsim():
-            refSelection += "_"+sample.pileupType(self._refRelease)
-            newSelection += "_"+sample.pileupType(self._newRelease)
+            refPu = sample.pileupType(self._refRelease)
+            if refPu != "":
+                refSelection += "_"+refPu
+            newPu = sample.pileupType(self._newRelease)
+            if newPu != "":
+                newSelection += "_"+newPu
 
         # Check that the new DQM file exists
         harvestedfile = sample.filename(self._newRelease)

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -743,7 +743,10 @@ class SimpleValidation:
 
         subdir = None
         if self._algoDirMap is not None:
-            subdir = self._algoDirMap[quality][algo]
+            if hasattr(self._algoDirMap, "__call__"):
+                subdir = self._algoDirMap(algo, quality)
+            else:
+                subdir = self._algoDirMap[quality][algo]
         self._plotter.create(openFiles, self._labels, subdir=subdir)
         fileList = self._plotter.draw(algo, **self._plotterDrawArgs)
 

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -647,7 +647,7 @@ def _copySubDir(oldfile, newfile, basenames, dirname):
         if dirold:
             break
     if not dirold:
-        raise Exception("Did not find any of %s directories from file %s" % (",".join(basenames, oldfile)))
+        raise Exception("Did not find any of %s directories from file %s" % (",".join(basenames), oldfile))
     if dirname:
         d = dirold.Get(dirname)
         if not d:

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+
+import os
+import argparse
+
+import Validation.RecoTrack.plotting.plotting as plotting
+from Validation.RecoTrack.plotting.validation import SimpleValidation
+import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
+
+Algos= ['ootb', 'initialStep', 'lowPtTripletStep', 'pixelPairStep', 'detachedTripletStep', 'mixedTripletStep', 'pixelLessStep', 'tobTecStep', 'jetCoreRegionalStep', 'muonSeededStepInOut', 'muonSeededStepOutIn']
+Qualities=['', 'highPurity']
+
+def newdirname(algo, quality):
+    ret = ""
+    if quality != "":
+        ret += "_"+quality
+    if not (algo == "ootb" and quality != ""):
+        ret += "_"+algo
+
+    if ret != "" and ret[0] == "_":
+        ret = ret[1:]
+
+    return ret
+
+def main(opts):
+    files = opts.files
+    labels = [f.replace(".root", "") for f in files]
+
+    drawArgs={}
+    if opts.ratio:
+        drawArgs["ratio"] = True
+    if opts.separate:
+        drawArgs["separate"] = True
+    if opts.png:
+        drawArgs["saveFormat"] = ".png"
+
+    val = SimpleValidation(files, labels, opts.outputDir)
+    val.doPlots(Algos, Qualities, trackingPlots.plotter, algoDirMap=trackingPlots._tracks_map, newdirFunc=newdirname,
+                plotterDrawArgs=drawArgs)
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Create standard set of tracking validation plots from one or more DQM files")
+    parser.add_argument("files", metavar="file", type=str, nargs="+",
+                        help="DQM file to plot the validation plots from")
+    parser.add_argument("-o", "--outputDir", type=str, default="plots",
+                        help="Plot output directory (default: 'plots')")
+    parser.add_argument("--ratio", action="store_true",
+                        help="Create ratio pads")
+    parser.add_argument("--separate", action="store_true",
+                        help="Save all plots separately instead of grouping them")
+    parser.add_argument("--png", action="store_true",
+                        help="Save plots in PNG instead of PDF")
+
+    opts = parser.parse_args()
+    for f in opts.files:
+        if not os.path.exists(f):
+            parser.error("DQM file %s does not exist" % f)
+
+    main(opts)

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -22,6 +22,16 @@ Algos= ['ootb', 'initialStep', 'lowPtTripletStep','pixelPairStep','detachedTripl
 #Algos= ['ootb']
 Qualities=['', 'highPurity']
 
+def newdirname(algo, quality):
+    ret = ""
+    if quality != "":
+        ret += "_"+quality
+    if not (algo == "ootb" and quality != ""):
+        ret += "_"+algo
+
+    return ret
+
+
 val = SimpleValidation([x[0] for x in filesLabels], [x[1] for x in filesLabels], outputDir)
-val.doPlots(Algos, Qualities, trackingPlots.plotter, algoDirMap=trackingPlots._tracks_map)
+val.doPlots(Algos, Qualities, trackingPlots.plotter, algoDirMap=trackingPlots._tracks_map, newdirFunc=newdirname)
 

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -63,7 +63,7 @@ fastsimstartupsamples = [
 ]
 
 pileupfastsimstartupsamples = [
-#    Sample('RelValTTbar', putype="AVE20", midfix="13", fastsim=True, fastsimCorrespondingFullsimPileup="50ns")
+    Sample('RelValTTbar', putype="25ns", midfix="13_PU25", fastsim=True)
 ]
 
 ### Track algorithm name and quality. Can be a list.

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -8,10 +8,10 @@ import Validation.RecoTrack.plotting.validation as validation
 ########### User Defined Variables (BEGIN) ##############
 
 ### Reference release
-RefRelease='CMSSW_7_4_0_pre6'
+RefRelease='CMSSW_7_5_0_pre3'
 
 ### Relval release (set if different from $CMSSW_VERSION)
-NewRelease='CMSSW_7_4_0_pre8'
+NewRelease='CMSSW_7_5_0_pre4'
 
 #import Validation.RecoTrack.plotting.plotting as plotting
 #plotting.missingOk = True

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -93,11 +93,12 @@ val.doPlots(algos=Algos, qualities=Qualities, refRelease=RefRelease,
 #             refRepository=RefRepository, newRepository=NewRepository, plotter=trackingPlots.timePlotter,
 #             algos=None, qualities=None)
 
-val3 = validation.Validation(
-    fullsimSamples = startupsamples + pileupstartupsamples + upgradesamples,
-    fastsimSamples=[], newRelease=NewRelease,
-    selectionName="_tp")
-val3.download()
-val3.doPlots(algos=None, qualities=None, refRelease=RefRelease,
-             refRepository=RefRepository, newRepository=NewRepository, plotter=trackingPlots.tpPlotter)
+# TrackingParticle plots
+#val3 = validation.Validation(
+#    fullsimSamples = startupsamples + pileupstartupsamples + upgradesamples,
+#    fastsimSamples=[], newRelease=NewRelease,
+#    selectionName="_tp")
+#val3.download()
+#val3.doPlots(algos=None, qualities=None, refRelease=RefRelease,
+#             refRepository=RefRepository, newRepository=NewRepository, plotter=trackingPlots.tpPlotter)
 

--- a/Validation/RecoTrack/test/trackingPerformanceValidation.py
+++ b/Validation/RecoTrack/test/trackingPerformanceValidation.py
@@ -83,7 +83,9 @@ val = trackingPlots.TrackingValidation(
 )
 val.download()
 val.doPlots(algos=Algos, qualities=Qualities, refRelease=RefRelease,
-                   refRepository=RefRepository, newRepository=NewRepository, plotter=trackingPlots.plotter)
+            refRepository=RefRepository, newRepository=NewRepository, plotter=trackingPlots.plotter,
+            plotterDrawArgs={"ratio": True}
+)
 
 # Timing plots
 #val2 = validation.Validation(

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -15,7 +15,7 @@ _recovsgen = PlotGroup("recovsgen", [
                        legendDy=-0.025
 )
 _pvtagging = PlotGroup("pvtagging", [
-    Plot("TruePVLocationIndexCumulative", xtitle="Signal PV status in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, xbinlabels=["Not reconstructed", "Reco and identified", "Reco, not identified"], xbinlabelsize=0.045, xbinlabeloption="h", xgrid=False, ylog=True, ymin=1e-3),
+    Plot("TruePVLocationIndexCumulative", xtitle="Signal PV status in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, xbinlabels=["Not reconstructed", "Reco and identified", "Reco, not identified"], xbinlabelsize=15, xbinlabeloption="h", xgrid=False, ylog=True, ymin=1e-3),
     Plot("TruePVLocationIndex", xtitle="Index of signal PV in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, ylog=True, ymin=1e-5),
     Plot("MisTagRate_vs_PU", xtitle="PU", ytitle="Mistag rate vs. PU", title="", xmax=_maxPU, ymax=_maxFake),
     Plot("MisTagRate_vs_sum-pt2", xtitle="#Sigmap_{T}^{2}", ytitle="Mistag rate vs. #Sigmap_{T}^{2}", title="", xlog=True, ymax=_maxFake),

--- a/Validation/RecoVertex/python/plotting/vertexPlots.py
+++ b/Validation/RecoVertex/python/plotting/vertexPlots.py
@@ -4,17 +4,24 @@ import Validation.RecoTrack.plotting.validation as validation
 _maxPU = 80
 _maxVtx = 60
 _maxEff = 1.025
-_maxFake = [0.05, 0.1, 0.2, 0.5, 1.025]
+_maxFake = [0.05, 0.1, 0.2, 0.5, 0.7, 1.025]
 
 _common = {"xlabel": "Pileup interactions", "xmax": _maxPU, "ymax": _maxVtx}
 _recovsgen = PlotGroup("recovsgen", [
     Plot("RecoVtx_vs_GenVtx", ytitle="Reco vertices", **_common),
     Plot("MatchedRecoVtx_vs_GenVtx", ytitle="Matched reco vertices", **_common),
     Plot("merged_vs_ClosestVertexInZ", xtitle="Closest distance in Z (cm)", ytitle="Merge rate", xlog=True),
-    Plot("TruePVLocationIndexCumulative", xtitle="Signal PV status in Reco collection", ytitle="Fraction of events", title="", drawStyle="hist", normalizeToUnitArea=True, xbinlabels=["Not reconstructed", "Reco and identified", "Reco, not identified"], xbinlabelsize=0.045, xbinlabeloption="h", xgrid=False, ylog=True, ymin=1e-3),
-    Plot("MisTagRate_vs_PU", xtitle="PU", ytitle="Mistag rate vs. PU", xmax=_maxPU, ymax=_maxFake),
-    Plot("MisTagRate_vs_sum-pt2", xtitle="#Sigmap_{T}^{2}", ytitle="Mistag rate vs. #Sigmap_{T}^{2}", xlog=True, ymax=_maxFake)
-])
+],
+                       legendDy=-0.025
+)
+_pvtagging = PlotGroup("pvtagging", [
+    Plot("TruePVLocationIndexCumulative", xtitle="Signal PV status in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, xbinlabels=["Not reconstructed", "Reco and identified", "Reco, not identified"], xbinlabelsize=0.045, xbinlabeloption="h", xgrid=False, ylog=True, ymin=1e-3),
+    Plot("TruePVLocationIndex", xtitle="Index of signal PV in reco collection", ytitle="Fraction of events", drawStyle="hist", normalizeToUnitArea=True, ylog=True, ymin=1e-5),
+    Plot("MisTagRate_vs_PU", xtitle="PU", ytitle="Mistag rate vs. PU", title="", xmax=_maxPU, ymax=_maxFake),
+    Plot("MisTagRate_vs_sum-pt2", xtitle="#Sigmap_{T}^{2}", ytitle="Mistag rate vs. #Sigmap_{T}^{2}", title="", xlog=True, ymax=_maxFake),
+],
+                       legendDy=-0.025
+)
 _effandfake = PlotGroup("effandfake", [
     Plot("effic_vs_NumVertices", xtitle="Reco vertices", ytitle="Efficiency vs. N vertices", xmax=_maxVtx, ymax=_maxEff),
     Plot("fakerate_vs_PU", xtitle="Pileup interactions", ytitle="Fake rate vs. PU", xmax=_maxPU, ymax=_maxFake),
@@ -23,6 +30,42 @@ _effandfake = PlotGroup("effandfake", [
     Plot("effic_vs_Pt2", xtitle="Sum p_{T}^{2}    ", ytitle="Efficiency vs. sum p_{T}^{2}", xlog=True, ymax=_maxEff),
     Plot("fakerate_vs_Pt2", xtitle="Sum p_{T}^{2}    ", ytitle="Fake rate vs. sum p_{T}^{2}", xlog=True, ymax=_maxFake),
 ])
+_common = {"title": "", "xtitle": "Number of tracks", "scale": 1e4, "ylog": True, "ymin": 5, "ymax": 500}
+_resolution = PlotGroup("resolution", [
+    Plot("RecoAllAssoc2GenMatched_ResolX_vs_NumTracks_Sigma", ytitle="Resolution in x (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolX_vs_NumTracks_Sigma", ytitle="Resolution in x for merged vertices (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatched_ResolY_vs_NumTracks_Sigma", ytitle="Resolution in y (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolY_vs_NumTracks_Sigma", ytitle="Resolution in y for merged vertices (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatched_ResolZ_vs_NumTracks_Sigma", ytitle="Resolution in z (#mum)", **_common),
+    Plot("RecoAllAssoc2GenMatchedMerged_ResolZ_vs_NumTracks_Sigma", ytitle="Resolution in z for merged vertices (#mum)", **_common),
+])
+_common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -6, "xmax": 6, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025]}
+_pull = PlotGroup("pull", [
+    Plot("RecoAllAssoc2GenMatched_PullX", xtitle="x", ytitle="Pull vs. x", **_common),
+    Plot("RecoAllAssoc2GenMatched_PullY", xtitle="y", ytitle="Pull vs. y", **_common),
+    Plot("RecoAllAssoc2GenMatched_PullZ", xtitle="z", ytitle="Pull vs. z", **_common),
+],
+                  legendDy=-0.025
+)
+_common={"drawStyle": "HIST", "normalizeToUnitArea": True}
+_puritymissing = PlotGroup("puritymissing", [
+    Plot("RecoPVAssoc2GenPVMatched_Purity", xtitle="Purity", ytitle="Number of reco PVs matched to gen PVs", ylog=True, ymin=1e-4, **_common),
+    Plot("RecoPVAssoc2GenPVNotMatched_Purity", xtitle="Purity", ytitle="Number of reco PVs not matcched to gen PVs", ylog=True, ymin=1e-3, **_common),
+    Plot("RecoPVAssoc2GenPVMatched_Missing", xtitle="Fraction of reco p_{T} associated to gen PV \"missing\" from reco PV", ytitle="Number of reco PVs matched to gen PVs", ylog=True, ymin=1e-4, **_common),
+    Plot("RecoPVAssoc2GenPVNotMatched_Missing", xtitle="Fraction of reco p_{T} associated to gen PV \"missing\" from reco PV", ytitle="Number of reco PVs not matcched to gen PVs", ylog=True, ymin=1e-3, **_common),
+#    Plot("fakerate_vs_Purity", xtitle="Purity", ytitle="Fake rate", ymax=_maxFake),
+])
+# "xgrid": False, "ygrid": False,
+_common={"drawStyle": "HIST", "xlog": True, "ylog": True, "ymin": 0.5}
+_sumpt2 = PlotGroup("sumpt2", [
+    Plot("RecoAssoc2GenPVMatched_Pt2", xtitle="#sum^{}p_{T}^{2}", ytitle="Reco vertices matched to gen PV", **_common),
+    Plot("RecoAssoc2GenPVMatchedNotHighest_Pt2", xtitle="#sum^{}p_{T}^{2}", ytitle="Reco non-PV-vertices matched to gen PV", **_common),
+    Plot("RecoAssoc2GenPVNotMatched_Pt2", xtitle="#sum^{}p_{T}^{2}", ytitle="Reco vertices not matched to gen PV", **_common),
+    Plot("RecoAssoc2GenPVNotMatched_GenPVTracksRemoved_Pt2", xtitle="#sum^{}p_{T}^{2}, gen PV tracks removed", ytitle="Reco vertices not matched to gen PV", **_common),
+],
+                    legendDy=-0.025
+)
+
 _common = {"drawStyle": "HIST"}
 _genpos = PlotGroup("genpos", [
     Plot("GenAllV_X", xtitle="Gen AllV pos x", ytitle="N", **_common),
@@ -40,7 +83,12 @@ plotter = Plotter([
     "DQMData/Vertexing/PrimaryVertexV",
 ],[
     _recovsgen,
+    _pvtagging,
     _effandfake,
+    _resolution,
+    _pull,
+    _puritymissing,
+    _sumpt2
 ])
 plotterGen = Plotter([
     "DQMData/Run 1/Vertexing/Run summary/PrimaryVertex",

--- a/Validation/RecoVertex/test/vertexCompare.py
+++ b/Validation/RecoVertex/test/vertexCompare.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python
+
+# This is an example of plotting the standard vertex validation
+# plots from an explicit set of DQM root files.
+
+import Validation.RecoTrack.plotting.plotting as plotting
+from Validation.RecoTrack.plotting.validation import SimpleValidation
+import Validation.RecoVertex.plotting.vertexPlots as vertexPlots
+
+
+# Example of file - label pairs
+filesLabels = [
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
+]
+
+outputDir = "plots"
+
+### Track algorithm name and quality. Can be a list.
+Collections = ["offlinePrimaryVertices", "selectedOfflinePrimaryVertices"]
+Qualities=None
+
+def newdirname(algo, quality):
+    ret = ""
+    if algo is not None:
+        ret += "_"+algo
+    return ret
+
+
+val = SimpleValidation([x[0] for x in filesLabels], [x[1] for x in filesLabels], outputDir)
+val.doPlots(Collections, Qualities, vertexPlots.plotter, algoDirMap=lambda a, q: a, newdirFunc=newdirname)

--- a/Validation/RecoVertex/test/vertexPerformanceValidation.py
+++ b/Validation/RecoVertex/test/vertexPerformanceValidation.py
@@ -18,7 +18,7 @@ NewRelease='CMSSW_7_5_0_pre4'
 ### This is the list of IDEAL-conditions relvals 
 startupsamples= [
 #    Sample('RelValMinBias', midfix="13"),
-    Sample('RelValTTbar', midfix="13"),
+#    Sample('RelValTTbar', midfix="13"),
 #    Sample('RelValQCD_Pt_3000_3500', midfix="13"),
 #    Sample('RelValQCD_Pt_600_800', midfix="13"),
 #    Sample('RelValSingleElectronPt35', midfix="UP15"),
@@ -50,10 +50,10 @@ validation.download()
 validation.doPlots(algos=Collections, qualities=Qualities, refRelease=RefRelease,
                    refRepository=RefRepository, newRepository=NewRepository, plotter=vertexPlots.plotter)
 
-validation2 = vertexPlots.VertexValidation(
-    fullsimSamples = startupsamples + pileupstartupsamples,
-    fastsimSamples=[], newRelease=NewRelease)
-validation2.download()
-validation2.doPlots(algos=None, qualities=Qualities, refRelease=RefRelease,
-                    refRepository=RefRepository, newRepository=NewRepository, plotter=vertexPlots.plotterGen)
+#validation2 = vertexPlots.VertexValidation(
+#    fullsimSamples = startupsamples + pileupstartupsamples,
+#    fastsimSamples=[], newRelease=NewRelease)
+#validation2.download()
+#validation2.doPlots(algos=None, qualities=Qualities, refRelease=RefRelease,
+#                    refRepository=RefRepository, newRepository=NewRepository, plotter=vertexPlots.plotterGen)
 

--- a/Validation/RecoVertex/test/vertexPerformanceValidation.py
+++ b/Validation/RecoVertex/test/vertexPerformanceValidation.py
@@ -29,7 +29,7 @@ startupsamples= [
 
 pileupstartupsamples = [
     Sample('RelValTTbar', putype="25ns", midfix="13"),
-    Sample('RelValTTbar', putype="50ns", midfix="13")
+    Sample('RelValTTbar', putype="50ns", midfix="13"),
     Sample('RelValZMM', putype="25ns", midfix="13"),
     Sample('RelValZMM', putype="50ns", midfix="13")
 ]

--- a/Validation/RecoVertex/test/vertexPerformanceValidation.py
+++ b/Validation/RecoVertex/test/vertexPerformanceValidation.py
@@ -48,7 +48,9 @@ validation = vertexPlots.VertexValidation(
     fastsimSamples=[], newRelease=NewRelease)
 validation.download()
 validation.doPlots(algos=Collections, qualities=Qualities, refRelease=RefRelease,
-                   refRepository=RefRepository, newRepository=NewRepository, plotter=vertexPlots.plotter)
+                   refRepository=RefRepository, newRepository=NewRepository, plotter=vertexPlots.plotter,
+                   plotterDrawArgs={"ratio": True}
+)
 
 #validation2 = vertexPlots.VertexValidation(
 #    fullsimSamples = startupsamples + pileupstartupsamples,

--- a/Validation/RecoVertex/test/vertexPerformanceValidation.py
+++ b/Validation/RecoVertex/test/vertexPerformanceValidation.py
@@ -10,10 +10,10 @@ import Validation.RecoVertex.plotting.vertexPlots as vertexPlots
 #plotting.missingOk = True
 
 ### Reference release
-RefRelease='CMSSW_7_4_0_pre6'
+RefRelease='CMSSW_7_5_0_pre3'
 
 ### Relval release (set if different from $CMSSW_VERSION)
-NewRelease='CMSSW_7_4_0_pre8'
+NewRelease='CMSSW_7_5_0_pre4'
 
 ### This is the list of IDEAL-conditions relvals 
 startupsamples= [


### PR DESCRIPTION
This PR integrates the developments on tracking MC validation scripts of the past few months. The developments consist of new plots, tuning of existing plots, and adding a ratio pad. In addition there are two new scripts: `vertexCompare.py` being similar to existing `trackingCompare.py` but for vertex plots, and `makeTrackValidationPlots.py` being similar to `trackingCompare.py` but being simpler to use by taking the list of DQM files via command line arguments (requested by @lveldere).

Rebased on top of 7_5_0_pre4, should have no effect on central workflows.

@rovere @VinInn 
