### PR TITLE
GEMCSCSegAlgoRR: initialize xe and ye

### DIFF
--- a/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
+++ b/RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc
@@ -214,7 +214,7 @@ std::vector<const TrackingRecHit*> GEMCSCSegAlgoRR::chainHitsToSegm(const CSCSeg
 	  auto rhLP_inSegmRef = cscChamber->toLocal(rhGP);
 	  // calculate the extrapolation of the CSC segment to the GEM plane (z-coord)
 	  // to get x- and y- coordinate 
-	  float xe, ye, ze = 0.0; 
+	  float xe = 0.0, ye = 0.0, ze = 0.0;
 	  if(segLD.z() != 0)
 	    {
 	      xe = segLP.x()+segLD.x()*rhLP_inSegmRef.z()/segLD.z();


### PR DESCRIPTION
```
DataFormats/GeometryVector/interface/extBasic3DVector.h:78:14: error:
'ye' may be used uninitialized in this function
[-Werror=maybe-uninitialized]
     v{x,y,z,w}{}
          ^
RecoLocalMuon/GEMCSCSegment/plugins/GEMCSCSegAlgoRR.cc:217:14: note:
'ye' was declared here
    float xe, ye, ze = 0.0;
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
