### PR TITLE
Update pythia8 settings for lhapdf6

### DIFF
--- a/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
+++ b/Configuration/Generator/python/Pythia8CommonSettings_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 pythia8CommonSettingsBlock = cms.PSet(
     pythia8CommonSettings = cms.vstring(
+      'Tune:preferLHAPDF = 2',
       'Main:timesAllowErrors = 10000',
       'Check:epTolErr = 0.01',
       'Beams:setProductionScalesFromLHEF = off',


### PR DESCRIPTION
Add line to common config fragment so that tunes which implicitly load non-default pdf's will correctly use lhapdf6.

n.b. CUETP8M1 tune used as default for run2 does not use lhapdf at all, but rather uses the internal pythia8 implementation of nnpdf23lo1, just as the pythia8-default Monash tune.
