### PR TITLE
Back out ROOT6 specific changes to fix build errors

### DIFF
--- a/DPGAnalysis/SiStripTools/bin/MultiplicityPlotMacros.cc
+++ b/DPGAnalysis/SiStripTools/bin/MultiplicityPlotMacros.cc
@@ -103,7 +103,7 @@ TH1D* AverageRunMultiplicity(TFile& ff, const char* module, const bool excludeLa
   CommonAnalyzer camult(&ff,"",module);
 
   TH1D* clusmult = new TH1D("clusmult","Average Multiplicity vs run",10,0.,10.);
-  clusmult->SetCanExtend(TH1::kXaxis);
+  clusmult->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = camult.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/DPGAnalysis/SiStripTools/bin/OOTMultiplicityPlotMacros.h
+++ b/DPGAnalysis/SiStripTools/bin/OOTMultiplicityPlotMacros.h
@@ -35,13 +35,13 @@ class OOTSummary {
   TH1F* hngoodbx;
   OOTSummary() {
     hootfrac = new TH1F("ootfrac","OOT fraction vs fill/run",10,0.,10.);
-    hootfrac->SetCanExtend(TH1::kXaxis);
+    hootfrac->SetBit(TH1::kCanRebin);
 
     hootfracsum = new TH1F("ootfracsum","OOT summed fraction vs fill/run",10,0.,10.);
-    hootfracsum->SetCanExtend(TH1::kXaxis);
+    hootfracsum->SetBit(TH1::kCanRebin);
   
     hngoodbx = new TH1F("ngoodbx","Number of good BX pairs vs fill/run",10,0.,10.);
-    hngoodbx->SetCanExtend(TH1::kXaxis);
+    hngoodbx->SetBit(TH1::kCanRebin);
     
   }
   ~OOTSummary() {

--- a/DPGAnalysis/SiStripTools/bin/SiStripQualityHistoryPlots.cc
+++ b/DPGAnalysis/SiStripTools/bin/SiStripQualityHistoryPlots.cc
@@ -20,7 +20,7 @@ TH1D* AverageRunBadChannels(TFile& ff, const char* module, const char* histo, co
   CommonAnalyzer camult(&ff,"",module);
 
   TH1D* badchannels = new TH1D("badchannels","Average Number of Bad Channels vs run",10,0.,10.);
-  badchannels->SetCanExtend(TH1::kXaxis);
+  badchannels->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = camult.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/DPGAnalysis/SiStripTools/bin/StatisticsPlots.cc
+++ b/DPGAnalysis/SiStripTools/bin/StatisticsPlots.cc
@@ -144,7 +144,7 @@ TH1D* SummaryHisto(TFile& ff, const char* module) {
   CommonAnalyzer castat(&ff,"",module);
   
   TH1D* nevents = new TH1D("nevents","Number of events vs run",10,0.,10.);
-  nevents->SetCanExtend(TH1::kXaxis);
+  nevents->SetBit(TH1::kCanRebin);
   
   std::vector<unsigned int> runs = castat.getRunList();
   std::sort(runs.begin(),runs.end());
@@ -277,7 +277,7 @@ void StatisticsPlots(const char* fullname, const char* module, const char* label
   // Summary histograms
 
   TH1D* nevents = new TH1D("nevents","Number of events vs run",10,0.,10.);
-  nevents->SetCanExtend(TH1::kXaxis);
+  nevents->SetBit(TH1::kCanRebin);
 
 
   std::vector<unsigned int> runs = castat.getRunList();

--- a/DPGAnalysis/SiStripTools/interface/DigiBXCorrHistogramMaker.h
+++ b/DPGAnalysis/SiStripTools/interface/DigiBXCorrHistogramMaker.h
@@ -326,7 +326,7 @@ void DigiBXCorrHistogramMaker<T>::beginRun(const unsigned int nrun) {
     if(m_runHisto) {
       if(m_ndigivscycletime[i]) {
 	(*m_ndigivscycletime[i])->GetXaxis()->SetTitle("Event 1 BX mod(70)"); (*m_ndigivscycletime[i])->GetYaxis()->SetTitle("time [Orb#]");
-	(*m_ndigivscycletime[i])->SetCanExtend(TH1::kAllAxes);
+	(*m_ndigivscycletime[i])->SetBit(TH1::kCanRebin);
       }
     }
   }

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseDebuggerFromL1TS.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseDebuggerFromL1TS.cc
@@ -161,32 +161,32 @@ APVCyclePhaseDebuggerFromL1TS::beginRun(const edm::Run& iRun, const edm::EventSe
   
   if(_hlresync && *_hlresync) {
     (*_hlresync)->GetXaxis()->SetTitle("Orbit");     (*_hlresync)->GetYaxis()->SetTitle("Events");
-    (*_hlresync)->SetCanExtend(TH1::kXaxis);
+    (*_hlresync)->SetBit(TH1::kCanRebin);
   }
   
   if(_hlOC0 && *_hlOC0) {
     (*_hlOC0)->GetXaxis()->SetTitle("Orbit");     (*_hlOC0)->GetYaxis()->SetTitle("Events");
-    (*_hlOC0)->SetCanExtend(TH1::kXaxis);
+    (*_hlOC0)->SetBit(TH1::kCanRebin);
   }
   
   if(_hlTE && *_hlTE) {
     (*_hlTE)->GetXaxis()->SetTitle("Orbit");     (*_hlTE)->GetYaxis()->SetTitle("Events");
-    (*_hlTE)->SetCanExtend(TH1::kXaxis);
+    (*_hlTE)->SetBit(TH1::kCanRebin);
   }
   
   if(_hlstart && *_hlstart) {
     (*_hlstart)->GetXaxis()->SetTitle("Orbit");     (*_hlstart)->GetYaxis()->SetTitle("Events");
-    (*_hlstart)->SetCanExtend(TH1::kXaxis);
+    (*_hlstart)->SetBit(TH1::kCanRebin);
   }
   
   if(_hlEC0 && *_hlEC0) {
     (*_hlEC0)->GetXaxis()->SetTitle("Orbit");     (*_hlEC0)->GetYaxis()->SetTitle("Events");
-    (*_hlEC0)->SetCanExtend(TH1::kXaxis);
+    (*_hlEC0)->SetBit(TH1::kCanRebin);
   }
   
   if(_hlHR && *_hlHR) {
     (*_hlHR)->GetXaxis()->SetTitle("Orbit");     (*_hlHR)->GetYaxis()->SetTitle("Events");
-    (*_hlHR)->SetCanExtend(TH1::kXaxis);
+    (*_hlHR)->SetBit(TH1::kCanRebin);
   }
   
   if(_hdlec0lresync && *_hdlec0lresync) {

--- a/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseMonitor.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVCyclePhaseMonitor.cc
@@ -185,7 +185,7 @@ APVCyclePhaseMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
        sprintf(hname,"phasevsorbit_%s",phase->first.c_str());
        edm::LogInfo("TProfileBeingBooked") << "TProfile " << hname << " being booked" ;
        _hphasevsorbit[phase->first] = subrun.make<TProfile>(hname,hname,m_LSfrac*m_maxLS,0,m_maxLS*262144);
-       _hphasevsorbit[phase->first]->SetCanExtend(TH1::kXaxis);
+       _hphasevsorbit[phase->first]->SetBit(TH1::kCanRebin);
        _hphasevsorbit[phase->first]->GetXaxis()->SetTitle("time [orbit#]"); _hphasevsorbit[phase->first]->GetYaxis()->SetTitle("Phase");
 
      }
@@ -242,7 +242,7 @@ APVCyclePhaseMonitor::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   }
   for(std::map<std::string,TProfile**>::const_iterator prof=_hselectedphasevsorbit.begin();prof!=_hselectedphasevsorbit.end();++prof) {
     if(*(prof->second)) {
-      (*(prof->second))->SetCanExtend(TH1::kXaxis);
+      (*(prof->second))->SetBit(TH1::kCanRebin);
       (*(prof->second))->GetXaxis()->SetTitle("time [orbit#]");
       (*(prof->second))->GetYaxis()->SetTitle("Phase");
     }
@@ -259,7 +259,7 @@ APVCyclePhaseMonitor::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   }
   for(std::map<std::string,TProfile**>::const_iterator prof=_hselectedphasevectorvsorbit.begin();prof!=_hselectedphasevectorvsorbit.end();++prof) {
     if(*(prof->second)) {
-      (*(prof->second))->SetCanExtend(TH1::kXaxis);
+      (*(prof->second))->SetBit(TH1::kCanRebin);
       (*(prof->second))->GetXaxis()->SetTitle("time [orbit#]");
       (*(prof->second))->GetYaxis()->SetTitle("Phase");
     }

--- a/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/plugins/APVShotsAnalyzer.cc
@@ -405,7 +405,7 @@ APVShotsAnalyzer::beginRun(const edm::Run& iRun, const edm::EventSetup&)
 
   if(_nShotsVsTimerun && *_nShotsVsTimerun) {
     (*_nShotsVsTimerun)->GetXaxis()->SetTitle("Orbit");  (*_nShotsVsTimerun)->GetYaxis()->SetTitle("Number of Shots");
-    (*_nShotsVsTimerun)->SetCanExtend(TH1::kXaxis);
+    (*_nShotsVsTimerun)->SetBit(TH1::kCanRebin);
   }
 
   if(_whichAPVrun && *_whichAPVrun) {

--- a/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
+++ b/DPGAnalysis/SiStripTools/plugins/DuplicateRecHits.cc
@@ -111,7 +111,7 @@ DuplicateRecHits::DuplicateRecHits(const edm::ParameterSet& iConfig):
 
   m_nduplicate = tfserv->make<TH1F>("nduplicate","Number of duplicated clusters per track",10,-0.5,9.5);
   m_nduplmod = tfserv->make<TH1F>("nduplmod","Number of duplicated clusters per module",10,-0.5,9.5);
-  m_nduplmod->SetCanExtend(TH1::kXaxis);
+  m_nduplmod->SetBit(TH1::kCanRebin);
 }
 
 

--- a/DPGAnalysis/SiStripTools/plugins/EventTimeDistribution.cc
+++ b/DPGAnalysis/SiStripTools/plugins/EventTimeDistribution.cc
@@ -235,7 +235,7 @@ EventTimeDistribution::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   if(*_bxincycle) {  (*_bxincycle)->GetXaxis()->SetTitle("Event BX mod(70)"); }
 
   if(*_orbit) {
-    (*_orbit)->SetCanExtend(TH1::kXaxis);
+    (*_orbit)->SetBit(TH1::kCanRebin);
     (*_orbit)->GetXaxis()->SetTitle("time [Orb#]");
   }
 
@@ -252,7 +252,7 @@ EventTimeDistribution::beginRun(const edm::Run& iRun, const edm::EventSetup&)
   }
 
   if(_orbitvsbxincycle && *_orbitvsbxincycle) {
-    (*_orbitvsbxincycle)->SetCanExtend(TH1::kYaxis);
+    (*_orbitvsbxincycle)->SetBit(TH1::kCanRebin);
     (*_orbitvsbxincycle)->GetXaxis()->SetTitle("Event BX mod(70)"); (*_orbitvsbxincycle)->GetYaxis()->SetTitle("time [Orb#]");
   }
 

--- a/DPGAnalysis/SiStripTools/plugins/FEDBadModuleFilter.cc
+++ b/DPGAnalysis/SiStripTools/plugins/FEDBadModuleFilter.cc
@@ -175,7 +175,7 @@ FEDBadModuleFilter::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup
 
     m_rhm.beginRun(iRun);
     if(*m_nbadvsorbrun) {
-      (*m_nbadvsorbrun)->SetCanExtend(TH1::kXaxis);
+      (*m_nbadvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_nbadvsorbrun)->GetXaxis()->SetTitle("time [Orb#]");
       (*m_nbadvsorbrun)->GetYaxis()->SetTitle("Bad Channels");
     }

--- a/DPGAnalysis/SiStripTools/plugins/SiPixelQualityHistory.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SiPixelQualityHistory.cc
@@ -199,7 +199,7 @@ SiPixelQualityHistory::beginRun(const edm::Run& iRun, const edm::EventSetup& iSe
 
     if(m_badmodrun.find(name)!=m_badmodrun.end()) {
       if(m_badmodrun[name] && *m_badmodrun[name]) {
-	(*m_badmodrun[name])->SetCanExtend(TH1::kXaxis);
+	(*m_badmodrun[name])->SetBit(TH1::kCanRebin);
 	(*m_badmodrun[name])->GetXaxis()->SetTitle("time [Orb#]"); (*m_badmodrun[name])->GetYaxis()->SetTitle("bad components");
       }
     }

--- a/DPGAnalysis/SiStripTools/plugins/SiStripQualityHistory.cc
+++ b/DPGAnalysis/SiStripTools/plugins/SiStripQualityHistory.cc
@@ -207,7 +207,7 @@ SiStripQualityHistory::beginRun(const edm::Run& iRun, const edm::EventSetup& iSe
 
     if(m_badmodrun.find(name)!=m_badmodrun.end()) {
       if(m_badmodrun[name] && *m_badmodrun[name]) {
-	(*m_badmodrun[name])->SetCanExtend(TH1::kXaxis);
+	(*m_badmodrun[name])->SetBit(TH1::kCanRebin);
 	(*m_badmodrun[name])->GetXaxis()->SetTitle("time [Orb#]"); (*m_badmodrun[name])->GetYaxis()->SetTitle("bad components");
       }
     }

--- a/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
+++ b/DPGAnalysis/SiStripTools/plugins/TrackCount.cc
@@ -364,7 +364,7 @@ TrackCount::beginRun(const edm::Run& iRun, const edm::EventSetup&)
 
   if(m_runHisto) {
     (*m_ntrkvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");    (*m_ntrkvsorbrun)->GetYaxis()->SetTitle("Ntracks");
-    (*m_ntrkvsorbrun)->SetCanExtend(TH1::kXaxis);
+    (*m_ntrkvsorbrun)->SetBit(TH1::kCanRebin);
   }
 }
 

--- a/DPGAnalysis/SiStripTools/src/DigiInvestigatorHistogramMaker.cc
+++ b/DPGAnalysis/SiStripTools/src/DigiInvestigatorHistogramMaker.cc
@@ -149,7 +149,7 @@ void DigiInvestigatorHistogramMaker::beginRun(const edm::Run& iRun) {
     if(_runHisto) {
       if(*_nmultvsorbrun[i]) {
 	(*_nmultvsorbrun[i])->GetXaxis()->SetTitle("time [orbit#]");    (*_nmultvsorbrun[i])->GetYaxis()->SetTitle("Hits");
-	(*_nmultvsorbrun[i])->SetCanExtend(TH1::kXaxis);
+	(*_nmultvsorbrun[i])->SetBit(TH1::kCanRebin);
       }
       if(*_nmultvsbxrun[i]) {
 	(*_nmultvsbxrun[i])->GetXaxis()->SetTitle("BX#");  (*_nmultvsbxrun[i])->GetYaxis()->SetTitle("Mean Number of Hits"); 

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -161,7 +161,7 @@ void BeamMonitor::beginJob() {
 
   h_vx_vy = dbe_->book2D("trk_vx_vy","Vertex (PCA) position of selected tracks",vxBin,vxMin,vxMax,vxBin,vxMin,vxMax);
   h_vx_vy->getTH2F()->SetOption("COLZ");
-  //   h_vx_vy->getTH1()->SetCanExtend(TH1::kAllAxes);
+  //   h_vx_vy->getTH1()->SetBit(TH1::kCanRebin);
   h_vx_vy->setAxisTitle("x coordinate of input track at PCA (cm)",1);
   h_vx_vy->setAxisTitle("y coordinate of input track at PCA (cm)",2);
 
@@ -244,7 +244,7 @@ void BeamMonitor::beginJob() {
 	histName += "_all";
 	histTitle += " all";
 	hs[histName] = dbe_->book1D(histName,histTitle,40,0.5,40.5);
-	hs[histName]->getTH1()->SetCanExtend(TH1::kAllAxes);
+	hs[histName]->getTH1()->SetBit(TH1::kCanRebin);
 	hs[histName]->setAxisTitle(xtitle,1);
 	hs[histName]->setAxisTitle(ytitle,2);
 	hs[histName]->getTH1()->SetOption("E1");
@@ -272,27 +272,27 @@ void BeamMonitor::beginJob() {
 
   h_x0 = dbe_->book1D("BeamMonitorFeedBack_x0","x coordinate of beam spot (Fit)",100,-0.01,0.01);
   h_x0->setAxisTitle("x_{0} (cm)",1);
-  h_x0->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_x0->getTH1()->SetBit(TH1::kCanRebin);
 
   h_y0 = dbe_->book1D("BeamMonitorFeedBack_y0","y coordinate of beam spot (Fit)",100,-0.01,0.01);
   h_y0->setAxisTitle("y_{0} (cm)",1);
-  h_y0->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_y0->getTH1()->SetBit(TH1::kCanRebin);
 
   h_z0 = dbe_->book1D("BeamMonitorFeedBack_z0","z coordinate of beam spot (Fit)",dzBin,dzMin,dzMax);
   h_z0->setAxisTitle("z_{0} (cm)",1);
-  h_z0->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_z0->getTH1()->SetBit(TH1::kCanRebin);
 
   h_sigmaX0 = dbe_->book1D("BeamMonitorFeedBack_sigmaX0","sigma x0 of beam spot (Fit)",100,0,0.05);
   h_sigmaX0->setAxisTitle("#sigma_{X_{0}} (cm)",1);
-  h_sigmaX0->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_sigmaX0->getTH1()->SetBit(TH1::kCanRebin);
 
   h_sigmaY0 = dbe_->book1D("BeamMonitorFeedBack_sigmaY0","sigma y0 of beam spot (Fit)",100,0,0.05);
   h_sigmaY0->setAxisTitle("#sigma_{Y_{0}} (cm)",1);
-  h_sigmaY0->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_sigmaY0->getTH1()->SetBit(TH1::kCanRebin);
 
   h_sigmaZ0 = dbe_->book1D("BeamMonitorFeedBack_sigmaZ0","sigma z0 of beam spot (Fit)",100,0,10);
   h_sigmaZ0->setAxisTitle("#sigma_{Z_{0}} (cm)",1);
-  h_sigmaZ0->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_sigmaZ0->getTH1()->SetBit(TH1::kCanRebin);
 
   // Histograms of all reco tracks (without cuts):
   h_trkPt=dbe_->book1D("trkPt","p_{T} of all reco'd tracks (no selection)",200,0.,50.);
@@ -331,22 +331,22 @@ void BeamMonitor::beginJob() {
   // Monitor only the PV with highest sum pt of assoc. trks:
   h_PVx[0] = dbe_->book1D("PVX","x coordinate of Primary Vtx",50,-0.01,0.01);
   h_PVx[0]->setAxisTitle("PVx (cm)",1);
-  h_PVx[0]->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_PVx[0]->getTH1()->SetBit(TH1::kCanRebin);
 
   h_PVy[0] = dbe_->book1D("PVY","y coordinate of Primary Vtx",50,-0.01,0.01);
   h_PVy[0]->setAxisTitle("PVy (cm)",1);
-  h_PVy[0]->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_PVy[0]->getTH1()->SetBit(TH1::kCanRebin);
 
   h_PVz[0] = dbe_->book1D("PVZ","z coordinate of Primary Vtx",dzBin,dzMin,dzMax);
   h_PVz[0]->setAxisTitle("PVz (cm)",1);
 
   h_PVx[1] = dbe_->book1D("PVXFit","x coordinate of Primary Vtx (Last Fit)",50,-0.01,0.01);
   h_PVx[1]->setAxisTitle("PVx (cm)",1);
-  h_PVx[1]->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_PVx[1]->getTH1()->SetBit(TH1::kCanRebin);
 
   h_PVy[1] = dbe_->book1D("PVYFit","y coordinate of Primary Vtx (Last Fit)",50,-0.01,0.01);
   h_PVy[1]->setAxisTitle("PVy (cm)",1);
-  h_PVy[1]->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_PVy[1]->getTH1()->SetBit(TH1::kCanRebin);
 
   h_PVz[1] = dbe_->book1D("PVZFit","z coordinate of Primary Vtx (Last Fit)",dzBin,dzMin,dzMax);
   h_PVz[1]->setAxisTitle("PVz (cm)",1);

--- a/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitorBx.cc
@@ -294,7 +294,7 @@ void BeamMonitorBx::BookTrendHistos(bool plotPV,int nBx,map<string,string> & vMa
       if (createHisto) {
 	edm::LogInfo("BX|BeamMonitorBx") << "histName = " << histName << "; histTitle = " << histTitle << std::endl;
 	hst[histName] = dbe_->book1D(histName,histTitle,40,0.5,40.5);
-	hst[histName]->getTH1()->SetCanExtend(TH1::kAllAxes);
+	hst[histName]->getTH1()->SetBit(TH1::kCanRebin);
 	hst[histName]->setAxisTitle(xtitle,1);
 	hst[histName]->setAxisTitle(ytitle,2);
 	hst[histName]->getTH1()->SetOption("E1");
@@ -321,7 +321,7 @@ void BeamMonitorBx::BookTrendHistos(bool plotPV,int nBx,map<string,string> & vMa
 
   hst[histName] = dbe_->book1D(histName,"Number of Good Reconstructed Vertices",40,0.5,40.5);
   hst[histName]->setAxisTitle(xtitle,1);
-  hst[histName]->getTH1()->SetCanExtend(TH1::kAllAxes);
+  hst[histName]->getTH1()->SetBit(TH1::kCanRebin);
   hst[histName]->getTH1()->SetOption("E1");
 
 }

--- a/DQM/BeamMonitor/plugins/BeamSpotProblemMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamSpotProblemMonitor.cc
@@ -118,7 +118,7 @@ void BeamSpotProblemMonitor::beginJob() {
         histName += "_all";
         histTitle += " all";
         hs[histName] = dbe_->book1D(histName,histTitle,40,0.5,40.5);
-        hs[histName]->getTH1()->SetCanExtend(TH1::kAllAxes);
+        hs[histName]->getTH1()->SetBit(TH1::kCanRebin);
         hs[histName]->setAxisTitle(xtitle,1);
         hs[histName]->setAxisTitle(ytitle,2);
 

--- a/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
+++ b/DQM/SiStripMonitorCluster/src/SiStripMonitorCluster.cc
@@ -375,7 +375,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
     ibooker.setCurrentFolder(topFolderName_+"/MechanicalView/");
       std::string HistoName = "BPTX rate";
       BPTXrateTrend = ibooker.bookProfile(HistoName,HistoName, LSBin, LSMin, LSMax, 0, 10000.,"");
-      BPTXrateTrend->getTH1()->SetCanExtend(TH1::kAllAxes);
+      BPTXrateTrend->getTH1()->SetBit(TH1::kCanRebin);
       BPTXrateTrend->setAxisTitle("#Lumi section",1);
       BPTXrateTrend->setAxisTitle("Number of BPTX events per LS",2);
     }
@@ -415,7 +415,7 @@ void SiStripMonitorCluster::createMEs(const edm::EventSetup& es , DQMStore::IBoo
 						       ParametersNclusVsCycleTimeProf2D.getParameter<double>("ymin"),
 						       ParametersNclusVsCycleTimeProf2D.getParameter<double>("ymax"),
 						       0 , 0 );
-      if (NclusVsCycleTimeProf2D->kind() == MonitorElement::DQM_KIND_TPROFILE2D) NclusVsCycleTimeProf2D->getTH1()->SetCanExtend(TH1::kAllAxes);
+      if (NclusVsCycleTimeProf2D->kind() == MonitorElement::DQM_KIND_TPROFILE2D) NclusVsCycleTimeProf2D->getTH1()->SetBit(TH1::kCanRebin);
     }
 
     if (ClusterHisto_){
@@ -1014,7 +1014,7 @@ void SiStripMonitorCluster::createSubDetMEs(std::string label , DQMStore::IBooke
 							 Parameters.getParameter<double>("xmax"),
 							 0 , 0 , "" );
     subdetMEs.SubDetTotClusterProf->setAxisTitle(Parameters.getParameter<std::string>("xaxis"),1);
-    if (subdetMEs.SubDetTotClusterProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotClusterProf->getTH1()->SetCanExtend(TH1::kAllAxes);
+    if (subdetMEs.SubDetTotClusterProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotClusterProf->getTH1()->SetBit(TH1::kCanRebin);
   }
 
   // Total Number of Cluster vs APV cycle - Profile
@@ -1169,7 +1169,7 @@ MonitorElement* SiStripMonitorCluster::bookMETrend(const char* HistoName , DQMSt
 					   0 , 0 , "" );
   if(!me) return me;
   me->setAxisTitle(ParametersTrend.getParameter<std::string>("xaxis"),1);
-  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetCanExtend(TH1::kAllAxes);
+  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetBit(TH1::kCanRebin);
   return me;
 }
 

--- a/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
+++ b/DQM/SiStripMonitorDigi/src/SiStripMonitorDigi.cc
@@ -452,7 +452,7 @@ void SiStripMonitorDigi::createMEs(DQMStore::IBooker & ibooker , const edm::Even
 						    "" );
       ShotsVsTimeApvShotsGlobal->setAxisTitle("Time (s)",1);
       ShotsVsTimeApvShotsGlobal->setAxisTitle("# Apv Shots",2);
-      if (ShotsVsTimeApvShotsGlobal->kind() == MonitorElement::DQM_KIND_TPROFILE) ShotsVsTimeApvShotsGlobal->getTH1()->SetCanExtend(TH1::kAllAxes);
+      if (ShotsVsTimeApvShotsGlobal->kind() == MonitorElement::DQM_KIND_TPROFILE) ShotsVsTimeApvShotsGlobal->getTH1()->SetBit(TH1::kCanRebin);
     }
 
     //cumulative number of Strips in APV shots
@@ -887,7 +887,7 @@ MonitorElement* SiStripMonitorDigi::bookMETrend(DQMStore::IBooker & ibooker , co
   if(!me) return me;
 
   me->setAxisTitle("Event Time in Seconds",1);
-  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetCanExtend(TH1::kAllAxes);
+  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetBit(TH1::kCanRebin);
   return me;
 }
 
@@ -1071,7 +1071,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker & ibooker , std::stri
 						    Parameters.getParameter<double>("ymax"),
 						    "" );
     subdetMEs.SubDetTotDigiProf->setAxisTitle("Event Time in Seconds",1);
-    if (subdetMEs.SubDetTotDigiProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotDigiProf->getTH1()->SetCanExtend(TH1::kAllAxes);
+    if (subdetMEs.SubDetTotDigiProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetTotDigiProf->getTH1()->SetBit(TH1::kCanRebin);
   }
   
   // Number of Digi vs Bx - Profile
@@ -1177,7 +1177,7 @@ void SiStripMonitorDigi::createSubDetMEs(DQMStore::IBooker & ibooker , std::stri
 						      "" );
     subdetMEs.SubDetNApvShotsProf->setAxisTitle("Time (s)",1);
     subdetMEs.SubDetNApvShotsProf->setAxisTitle("# Apv Shots",2);
-    if (subdetMEs.SubDetNApvShotsProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetNApvShotsProf->getTH1()->SetCanExtend(TH1::kAllAxes);
+    if (subdetMEs.SubDetNApvShotsProf->kind() == MonitorElement::DQM_KIND_TPROFILE) subdetMEs.SubDetNApvShotsProf->getTH1()->SetBit(TH1::kCanRebin);
   }
 
 

--- a/DQM/SiStripMonitorHardware/src/HistogramBase.cc
+++ b/DQM/SiStripMonitorHardware/src/HistogramBase.cc
@@ -232,6 +232,6 @@ void HistogramBase::bookProfile(DQMStore::IBooker & ibooker , HistogramConfig & 
 	      yAxisTitle);
 
   //automatically set the axis range: will accomodate new values keeping the same number of bins.
-  if (aConfig.monitorEle) aConfig.monitorEle->getTProfile()->SetCanExtend(TH1::kAllAxes);
+  if (aConfig.monitorEle) aConfig.monitorEle->getTProfile()->SetBit(TH1::kCanRebin);
 }
  

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -576,7 +576,7 @@ MonitorElement* SiStripMonitorTrack::bookMETrend(DQMStore::IBooker & ibooker , c
 					   ParametersTrend.getParameter<double>("xmin"),
 					   ParametersTrend.getParameter<double>("xmax"),
 					   0 , 0 , "" );
-  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetCanExtend(TH1::kAllAxes);
+  if (me->kind() == MonitorElement::DQM_KIND_TPROFILE) me->getTH1()->SetBit(TH1::kCanRebin);
 
   if(!me) return me;
   me->setAxisTitle("Lumisection",1);

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -479,7 +479,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
       
       histname = "DistanceOfClosestApproachToBSVsPhi_";
       DistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-      DistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      DistanceOfClosestApproachToBSVsPhi->getTH1()->SetBit(TH1::kCanRebin);
       DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi",1);
       DistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
       
@@ -540,7 +540,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
       
       histname = "DistanceOfClosestApproachToPVVsPhi_";
       DistanceOfClosestApproachToPVVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-      DistanceOfClosestApproachToPVVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      DistanceOfClosestApproachToPVVsPhi->getTH1()->SetBit(TH1::kCanRebin);
       DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track #phi",1);
       DistanceOfClosestApproachToPVVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
       
@@ -574,7 +574,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
 	
 	histname = "TESTDistanceOfClosestApproachToBSVsPhi_";
 	TESTDistanceOfClosestApproachToBSVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyBin, DxyMin, DxyMax,"");
-	TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+	TESTDistanceOfClosestApproachToBSVsPhi->getTH1()->SetBit(TH1::kCanRebin);
 	TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track #phi",1);
 	TESTDistanceOfClosestApproachToBSVsPhi->setAxisTitle("Track d_{xy} wrt beam spot (cm)",2);
 	
@@ -625,7 +625,7 @@ void TrackAnalyzer::bookHistosForBeamSpot(DQMStore::IBooker & ibooker) {
 	
 	histname = "DistanceOfClosestApproachVsPhi_";
 	DistanceOfClosestApproachVsPhi = ibooker.bookProfile(histname+CategoryName,histname+CategoryName, PhiBin, PhiMin, PhiMax, DxyMin,DxyMax,"");
-	DistanceOfClosestApproachVsPhi->getTH1()->SetCanExtend(TH1::kAllAxes);
+	DistanceOfClosestApproachVsPhi->getTH1()->SetBit(TH1::kCanRebin);
 	DistanceOfClosestApproachVsPhi->setAxisTitle("Track #phi",1);
 	DistanceOfClosestApproachVsPhi->setAxisTitle("Track d_{xy} wrt (0,0,0) (cm)",2);
       }

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -260,20 +260,20 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
   
      histname = "NumberOfTracksVsLS_"+ CategoryName;
      NumberOfTracksVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax, TKNoMin, (TKNoMax+0.5)*3.-0.5,"");
-     NumberOfTracksVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+     NumberOfTracksVsLS->getTH1()->SetBit(TH1::kCanRebin);
      NumberOfTracksVsLS->setAxisTitle("#Lumi section",1);
      NumberOfTracksVsLS->setAxisTitle("Number of  Tracks",2);
   
      histname = "NumberOfRecHitsPerTrackVsLS_" + CategoryName;
      NumberOfRecHitsPerTrackVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,0.,40.,"");
-     NumberOfRecHitsPerTrackVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+     NumberOfRecHitsPerTrackVsLS->getTH1()->SetBit(TH1::kCanRebin);
      NumberOfRecHitsPerTrackVsLS->setAxisTitle("#Lumi section",1);
      NumberOfRecHitsPerTrackVsLS->setAxisTitle("Mean number of RecHits per track",2);
   
      if (doFractionPlot_) {
        histname = "GoodTracksFractionVsLS_"+ CategoryName;
        GoodTracksFractionVsLS = ibooker.bookProfile(histname,histname, LSBin,LSMin,LSMax,0,1.1,"");
-       GoodTracksFractionVsLS->getTH1()->SetCanExtend(TH1::kAllAxes);
+       GoodTracksFractionVsLS->getTH1()->SetBit(TH1::kCanRebin);
        GoodTracksFractionVsLS->setAxisTitle("#Lumi section",1);
        GoodTracksFractionVsLS->setAxisTitle("Fraction of Good Tracks",2);
      }
@@ -297,7 +297,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
     
        histname = "NumberOfTracksVsGoodPVtx";
        NumberOfTracksVsGoodPVtx = ibooker.bookProfile(histname,histname,GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,TKNoMin, (TKNoMax+0.5)*3.-0.5,"");
-       NumberOfTracksVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfTracksVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
        NumberOfTracksVsGoodPVtx->setAxisTitle("Number of PV",1);
        NumberOfTracksVsGoodPVtx->setAxisTitle("Mean number of Tracks per Event",2);
     
@@ -312,7 +312,7 @@ void TrackingMonitor::bookHistograms(DQMStore::IBooker & ibooker,
     
        histname = "NumberOfTracksVsBXlumi_"+ CategoryName;
        NumberOfTracksVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax, TKNoMin, TKNoMax,"");
-       NumberOfTracksVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
+       NumberOfTracksVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
        NumberOfTracksVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
        NumberOfTracksVsBXlumi->setAxisTitle("Mean number of Tracks",2);
     

--- a/DQM/TrackingMonitor/src/VertexMonitor.cc
+++ b/DQM/TrackingMonitor/src/VertexMonitor.cc
@@ -233,37 +233,37 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "NumberOfPVtxVsBXlumi_" + label_;
       NumberOfPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,60.,"");
-      NumberOfPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      NumberOfPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
       NumberOfPVtxVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       NumberOfPVtxVsBXlumi->setAxisTitle("Mean number of PV",2);
 
       histname = "NumberOfGoodPVtxVsBXlumi_" + label_;
       NumberOfGoodPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,60.,"");
-      NumberOfGoodPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      NumberOfGoodPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
       NumberOfGoodPVtxVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       NumberOfGoodPVtxVsBXlumi->setAxisTitle("Mean number of PV",2);
 
       histname = "FractionOfGoodPVtxVsBXlumi_" + label_;
       FractionOfGoodPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,1.5,"");
-      FractionOfGoodPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      FractionOfGoodPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
       FractionOfGoodPVtxVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       FractionOfGoodPVtxVsBXlumi->setAxisTitle("Mean number of PV",2);
 
       histname = "NumberOfBADndofPVtxVsBXlumi_" + label_;
       NumberOfBADndofPVtxVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,60.,"");
-      NumberOfBADndofPVtxVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      NumberOfBADndofPVtxVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
       NumberOfBADndofPVtxVsBXlumi->setAxisTitle("BADndof #PV",1);
       NumberOfBADndofPVtxVsBXlumi->setAxisTitle("Number of Events",2);
     
       histname = "GoodPVtxSumPtVsBXlumi_" + label_;
       GoodPVtxSumPtVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,500.,"");
-      GoodPVtxSumPtVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxSumPtVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxSumPtVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxSumPtVsBXlumi->setAxisTitle("Mean pv #Sum p_{T}^{2} [GeV^{2}/c]^{2}",2);
       
       histname = "GoodPVtxNumberOfTracksVsBXlumi_" + label_;
       GoodPVtxNumberOfTracksVsBXlumi = ibooker.bookProfile(histname,histname, BXlumiBin,BXlumiMin,BXlumiMax,0.,100.,"");
-      GoodPVtxNumberOfTracksVsBXlumi->getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxNumberOfTracksVsBXlumi->getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxNumberOfTracksVsBXlumi->setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxNumberOfTracksVsBXlumi->setAxisTitle("Mean pv number of tracks",2);
 
@@ -276,25 +276,25 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "Chi2oNDFVsBXlumi_" + label_;
       Chi2oNDFVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2NDFMin,Chi2NDFMax,"");
-      Chi2oNDFVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
+      Chi2oNDFVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
       Chi2oNDFVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       Chi2oNDFVsBXlumi -> setAxisTitle("Mean #chi^{2}/ndof",2);
 
       histname = "Chi2ProbVsBXlumi_" + label_;
       Chi2ProbVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2ProbMin,Chi2ProbMax,"");
-      Chi2ProbVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
+      Chi2ProbVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
       Chi2ProbVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       Chi2ProbVsBXlumi -> setAxisTitle("Mean #chi^{2}/prob",2);
 
       histname = "GoodPVtxChi2oNDFVsBXlumi_" + label_;
       GoodPVtxChi2oNDFVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2NDFMin,Chi2NDFMax,"");
-      GoodPVtxChi2oNDFVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxChi2oNDFVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxChi2oNDFVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxChi2oNDFVsBXlumi -> setAxisTitle("Mean PV #chi^{2}/ndof",2);
 
       histname = "GoodPVtxChi2ProbVsBXlumi_" + label_;
       GoodPVtxChi2ProbVsBXlumi  = ibooker.bookProfile(histname,histname,BXlumiBin, BXlumiMin,BXlumiMax,Chi2ProbMin,Chi2ProbMax,"");
-      GoodPVtxChi2ProbVsBXlumi -> getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxChi2ProbVsBXlumi -> getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxChi2ProbVsBXlumi -> setAxisTitle("lumi BX [10^{30}Hzcm^{-2}]",1);
       GoodPVtxChi2ProbVsBXlumi -> setAxisTitle("Mean PV #chi^{2}/prob",2);
     }
@@ -305,37 +305,37 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "NumberOfPVtxVsGoodPVtx_" + label_;
       NumberOfPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      NumberOfPVtxVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+      NumberOfPVtxVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
       NumberOfPVtxVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       NumberOfPVtxVsGoodPVtx->setAxisTitle("Mean number of PV",2);
 
       histname = "FractionOfGoodPVtxVsGoodPVtx_" + label_;
       FractionOfGoodPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      FractionOfGoodPVtxVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+      FractionOfGoodPVtxVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
       FractionOfGoodPVtxVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       FractionOfGoodPVtxVsGoodPVtx->setAxisTitle("Mean fraction of Good PV",2);
 
       histname = "FractionOfGoodPVtxVsPVtx_" + label_;
       FractionOfGoodPVtxVsPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      FractionOfGoodPVtxVsPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+      FractionOfGoodPVtxVsPVtx->getTH1()->SetBit(TH1::kCanRebin);
       FractionOfGoodPVtxVsPVtx->setAxisTitle("Number of Good PV",1);
       FractionOfGoodPVtxVsPVtx->setAxisTitle("Mean number of Good PV",2);
 
       histname = "NumberOfBADndofPVtxVsGoodPVtx_" + label_;
       NumberOfBADndofPVtxVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,60.,"");
-      NumberOfBADndofPVtxVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+      NumberOfBADndofPVtxVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
       NumberOfBADndofPVtxVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       NumberOfBADndofPVtxVsGoodPVtx->setAxisTitle("Mean Number of BAD PV",2);
     
       histname = "GoodPVtxSumPtVsGoodPVtx_" + label_;
       GoodPVtxSumPtVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,500.,"");
-      GoodPVtxSumPtVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxSumPtVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxSumPtVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       GoodPVtxSumPtVsGoodPVtx->setAxisTitle("Mean pv #Sum p_{T}^{2} [GeV^{2}/c]^{2}",2);
       
       histname = "GoodPVtxNumberOfTracksVsGoodPVtx_" + label_;
       GoodPVtxNumberOfTracksVsGoodPVtx = ibooker.bookProfile(histname,histname, GoodPVtxBin,GoodPVtxMin,GoodPVtxMax,0.,100.,"");
-      GoodPVtxNumberOfTracksVsGoodPVtx->getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxNumberOfTracksVsGoodPVtx->getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxNumberOfTracksVsGoodPVtx->setAxisTitle("Number of Good PV",1);
       GoodPVtxNumberOfTracksVsGoodPVtx->setAxisTitle("Mean pv number of tracks",2);
       
@@ -348,13 +348,13 @@ VertexMonitor::initHisto(DQMStore::IBooker & ibooker)
 
       histname = "GoodPVtxChi2oNDFVsGoodPVtx_" + label_;
       GoodPVtxChi2oNDFVsGoodPVtx  = ibooker.bookProfile(histname,histname,GoodPVtxBin, GoodPVtxMin,GoodPVtxMax,Chi2NDFMin,Chi2NDFMax,"");
-      GoodPVtxChi2oNDFVsGoodPVtx -> getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxChi2oNDFVsGoodPVtx -> getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxChi2oNDFVsGoodPVtx -> setAxisTitle("Number of Good PV",1);
       GoodPVtxChi2oNDFVsGoodPVtx -> setAxisTitle("Mean PV #chi^{2}/ndof",2);
 
       histname = "GoodPVtxChi2ProbVsGoodPVtx_" + label_;
       GoodPVtxChi2ProbVsGoodPVtx  = ibooker.bookProfile(histname,histname,GoodPVtxBin, GoodPVtxMin,GoodPVtxMax,Chi2ProbMin,Chi2ProbMax,"");
-      GoodPVtxChi2ProbVsGoodPVtx -> getTH1()->SetCanExtend(TH1::kAllAxes);
+      GoodPVtxChi2ProbVsGoodPVtx -> getTH1()->SetBit(TH1::kCanRebin);
       GoodPVtxChi2ProbVsGoodPVtx -> setAxisTitle("Number of Good PV",1);
       GoodPVtxChi2ProbVsGoodPVtx -> setAxisTitle("Mean PV #chi^{2}/prob",2);
 

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -384,17 +384,8 @@ void DQMStore::mergeAndResetMEsRunSummaryCache(uint32_t run,
 
       //don't take any action if the ME is an INT || FLOAT || STRING
       if(me->kind() >= MonitorElement::DQM_KIND_TH1F)
-	{
-	  if(me->getTH1()->CanExtendAllAxes() && i->getTH1()->CanExtendAllAxes()) {
-	    TList list;
-	    list.Add(i->getTH1());
-	    if( -1 == me->getTH1()->Merge(&list)) {
-	      std::cout << "mergeAndResetMEsRunSummaryCache: Failed to merge DQM element "<<me->getFullname();
-	    }
-	  }
-	  else
-	    me->getTH1()->Add(i->getTH1());
-	}
+        me->getTH1()->Add(i->getTH1());
+
     } else {
       if (verbose_ > 1)
         std::cout << "No global Object found. " << std::endl;
@@ -449,18 +440,8 @@ void DQMStore::mergeAndResetMEsLuminositySummaryCache(uint32_t run,
 	      std::cout << "Found global Object, using it --> " << me->getFullname() << std::endl;
 
       //don't take any action if the ME is an INT || FLOAT || STRING
-      if(me->kind() >= MonitorElement::DQM_KIND_TH1F)
-	{
-	  if(me->getTH1()->CanExtendAllAxes() && i->getTH1()->CanExtendAllAxes()) {
-	    TList list;
-	    list.Add(i->getTH1());
-	    if( -1 == me->getTH1()->Merge(&list)) {
-	      std::cout << "mergeAndResetMEsLuminositySummaryCache: Failed to merge DQM element "<<me->getFullname();
-	    }
-	  }
-	  else
-	    me->getTH1()->Add(i->getTH1());
-	}
+      if (me->kind() >= MonitorElement::DQM_KIND_TH1F)
+        me->getTH1()->Add(i->getTH1());
     } else {
       if (verbose_ > 1)
         std::cout << "No global Object found. " << std::endl;

--- a/DQMServices/FwkIO/plugins/DQMRootSource.cc
+++ b/DQMServices/FwkIO/plugins/DQMRootSource.cc
@@ -72,7 +72,7 @@ namespace {
   }
   //NOTE: the merge logic comes from DataFormats/Histograms/interface/MEtoEDMFormat.h
   void mergeTogether(TH1* iOriginal,TH1* iToAdd) {
-    if(iOriginal->CanExtendAllAxes() && iToAdd->CanExtendAllAxes()) {
+    if(iOriginal->TestBit(TH1::kCanRebin)==true && iToAdd->TestBit(TH1::kCanRebin) ==true) {
       TList list;
       list.Add(iToAdd);
       if( -1 == iOriginal->Merge(&list)) {

--- a/DataFormats/Common/interface/RefCoreGet.h
+++ b/DataFormats/Common/interface/RefCoreGet.h
@@ -44,7 +44,11 @@ namespace edm {
     if (ref.isTransient()) {
       ref.nullPointerForTransientException(typeid(T));
     }
+#ifndef __GCCXML__
     auto productGetter = ref.productGetter();
+#else
+    EDProductGetter const* productGetter = ref.productGetter();
+#endif
     if(nullptr == productGetter) {
       p =static_cast<T const*>(ref.productPtr());
       if(p != nullptr) {

--- a/DataFormats/Common/interface/RefItemGet.h
+++ b/DataFormats/Common/interface/RefItemGet.h
@@ -28,7 +28,11 @@ namespace edm {
         if(item != nullptr) {
           return item;
         }
+#ifndef __GCCXML__
         auto prodGetter = product.productGetter();
+#else
+        EDProductGetter* prodGetter = product.productGetter();
+#endif
         if(nullptr == prodGetter) {
           item = static_cast<T const*>(product.productPtr());
           if(item != nullptr) {
@@ -56,9 +60,17 @@ namespace edm {
         if(item != nullptr) {
           return item;
         }
+#ifndef __GCCXML__
         auto getter = product.productGetter();
+#else
+        EDProductGetter const* getter = product.productGetter();
+#endif
         if(getter == nullptr) {
+#ifndef __GCCXML__
           auto prod = product.productPtr();
+#else
+          void const* prod = product.productPtr();
+#endif
           if(prod != nullptr) {
             //another thread updated the value since we last checked.
             return static_cast<T const*>(prod);
@@ -104,7 +116,11 @@ namespace edm {
         if (ref.isTransient()) {
           return false;
         }
+#ifndef __GCCXML__
         auto getter = ref.productGetter();
+#else
+        EDProductGetter const* getter = ref.productGetter();
+#endif
         if(getter != nullptr) {
           return ref.isThinnedAvailable(key,getter);
         }

--- a/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
+++ b/DataFormats/GEMRecHit/interface/GEMCSCSegment.h
@@ -77,7 +77,7 @@ public:
 
     CSCDetId cscDetId() const { return  geographicalId(); }
     
-    void print() const;		
+    //void print() const;		
     
  private:
     std::vector<GEMRecHit> theGEMRecHits;      // store GEM Rechits

--- a/DataFormats/PatCandidates/interface/EventHypothesis.h
+++ b/DataFormats/PatCandidates/interface/EventHypothesis.h
@@ -7,7 +7,9 @@
 #include <boost/shared_ptr.hpp>
 #include <typeinfo>
 #include <iostream>
+#ifndef __GCCXML__
 #include <type_traits>
+#endif
 #include <cxxabi.h>
 
 namespace pat {
@@ -146,6 +148,7 @@ namespace pat {
    std::string
    EventHypothesis::createExceptionMessage(const CandRefType &ref) const {
      std::stringstream message;
+#ifndef __GCCXML__
      char *currentType = getDemangledSymbol(typeid(std::remove_reference<decltype(ref)>::type::value_type).name());
      char *targetType = getDemangledSymbol(typeid(T).name());
      if (currentType != nullptr && targetType != nullptr) {
@@ -156,6 +159,7 @@ namespace pat {
        message << "You can't convert a '" << typeid(ref).name() << "' to a '" << typeid(T).name() << "'" << std::endl;
        message << "Note: you can use 'c++filt -t' command to convert the above in human readable types." << std::endl;
      }
+#endif
      return message.str();
    }
 

--- a/FWCore/FWLite/src/AutoLibraryLoader.cc
+++ b/FWCore/FWLite/src/AutoLibraryLoader.cc
@@ -11,8 +11,11 @@
 //
 
 // system include files
-
 #include <iostream>
+#include "TROOT.h"
+#include "TInterpreter.h"
+#include "TApplication.h"
+
 // user include files
 #include "FWCore/FWLite/interface/AutoLibraryLoader.h"
 #include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"
@@ -29,11 +32,13 @@
 // static data member definitions
 //
 
+bool AutoLibraryLoader::enabled_(false);
 
 //
 // constructors and destructor
 //
-AutoLibraryLoader::AutoLibraryLoader() {
+AutoLibraryLoader::AutoLibraryLoader()
+{
 }
 
 

--- a/FWCore/FWLite/src/FWLiteEnabler.cc
+++ b/FWCore/FWLite/src/FWLiteEnabler.cc
@@ -19,6 +19,7 @@
 #include "FWCore/FWLite/src/BareRootProductGetter.h"
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/RootAutoLibraryLoader/interface/RootAutoLibraryLoader.h"
 
 #include "FWCore/FWLite/interface/setRefStreamer.h"
 
@@ -53,6 +54,7 @@
 
    edmplugin::PluginManager::configure(edmplugin::standard::config());
    static BareRootProductGetter s_getter;
+   edm::RootAutoLibraryLoader::enable();
    //this function must be called
    // so that the TClass we need will be available
    fwlite::setRefStreamer(&s_getter);

--- a/Fireworks/Core/src/FWSimpleRepresentationChecker.cc
+++ b/Fireworks/Core/src/FWSimpleRepresentationChecker.cc
@@ -76,12 +76,6 @@ bool FWSimpleRepresentationChecker::inheritsFrom(const edm::TypeWithDict& iChild
                          const std::string& iParentTypeName,
                          unsigned int& distance) {
                            
-   if (iChild.getClass()) {
-      if (iChild.getClass()->GetTypeInfo() == 0) {
-         return false;
-      }
-   }
-                           
    if(iChild.typeInfo().name() == iParentTypeName) {
       return true;
    }

--- a/Fireworks/Core/src/classes.h
+++ b/Fireworks/Core/src/classes.h
@@ -30,6 +30,7 @@
 #include "Fireworks/Core/interface/FWTSelectorToEventList.h"
 #include "Fireworks/Core/src/FWEveDigitSetScalableMarker.h"
 #include "Fireworks/Core/src/FW3DViewDistanceMeasureTool.h"
+#include "Fireworks/Core/interface/FWPartialConfig.h"
 namespace Fireworks_Core {
    struct Fireworks_Core {
       //add 'dummy' Wrapper variable for each class type you put into the Event

--- a/Fireworks/Core/src/classes_def.xml
+++ b/Fireworks/Core/src/classes_def.xml
@@ -33,4 +33,7 @@
   <class name="FWEveDigitSetScalableMarker"/>
   <class name="FWEveDigitSetScalableMarkerGL"/>
   <class name="FW3DViewDistanceMeasureTool"/>
+  <class name="FWPartialConfigGUI"/>
+  <class name="FWPartialConfigLoadGUI"/>
+  <class name="FWPartialConfigSaveGUI"/>
 </lcgdict>

--- a/IOPool/TFileAdaptor/plugins/BuildFile.xml
+++ b/IOPool/TFileAdaptor/plugins/BuildFile.xml
@@ -1,1 +1,0 @@
-<use name="IOPool/TFileAdaptor"/>

--- a/IOPool/TFileAdaptor/plugins/module.cc
+++ b/IOPool/TFileAdaptor/plugins/module.cc
@@ -1,6 +1,0 @@
-#include "IOPool/TFileAdaptor/src/TFileAdaptor.h"
-#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
-
-typedef TFileAdaptor AdaptorConfig;
-
-DEFINE_FWK_SERVICE(AdaptorConfig);

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -6,6 +6,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/ServiceRegistry/interface/ServiceMaker.h"
 #include "FWCore/Utilities/interface/EDMException.h"
 #include "Utilities/StorageFactory/interface/StorageAccount.h"
 #include "Utilities/StorageFactory/interface/StorageFactory.h"
@@ -290,3 +291,7 @@ TFileAdaptorUI::~TFileAdaptorUI() {}
 void TFileAdaptorUI::stats() const {
   me->stats(std::cout); std::cout << std::endl;
 }
+
+typedef TFileAdaptor AdaptorConfig;
+
+DEFINE_FWK_SERVICE(AdaptorConfig);

--- a/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
+++ b/PhysicsTools/HepMCCandAlgos/interface/MCTruthHelper.h
@@ -6,6 +6,9 @@
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 #include "DataFormats/HepMCCandidate/interface/GenStatusFlags.h"
 
+#ifndef __GCCXML__
+#include <unordered_set>
+#endif
 
 #include <iostream>
 
@@ -179,7 +182,11 @@ public:
   void fillGenStatusFlags(const P &p, reco::GenStatusFlags &statusFlags);
   
 protected:
+#ifndef __GCCXML__
   std::unordered_set<const P*> dupCheck_;
+#else
+  std::set<const P*> dupCheck_;
+#endif
 
 };
   

--- a/Validation/RecoVertex/bin/BSvsPVPlots.cc
+++ b/Validation/RecoVertex/bin/BSvsPVPlots.cc
@@ -168,17 +168,17 @@ void BSvsPVPlots(const char* fullname,const char* module, const char* label, con
 
   // Summary histograms
   TH1D* deltaxsum = new TH1D("deltaxsum","(PV-BS) Fitted X position vs run",10,0.,10.);
-  deltaxsum->SetCanExtend(TH1::kAllAxes);
+  deltaxsum->SetBit(TH1::kCanRebin);
   TH1D* deltaysum = new TH1D("deltaysum","(PV-BS) Fitted Y position vs run",10,0.,10.);
-  deltaysum->SetCanExtend(TH1::kAllAxes);
+  deltaysum->SetBit(TH1::kCanRebin);
 
   TH1D* deltaxmeansum = new TH1D("deltaxmeansum","(PV-BS) Mean X position vs run",10,0.,10.);
-  deltaxmeansum->SetCanExtend(TH1::kAllAxes);
+  deltaxmeansum->SetBit(TH1::kCanRebin);
   TH1D* deltaymeansum = new TH1D("deltaymeansum","(PV-BS) Mean Y position vs run",10,0.,10.);
-  deltaymeansum->SetCanExtend(TH1::kAllAxes);
+  deltaymeansum->SetBit(TH1::kCanRebin);
 
   TH1D* deltazmeansum = new TH1D("deltazmeansum","(PV-BS) Mean Z position vs run",10,0.,10.);
-  deltazmeansum->SetCanExtend(TH1::kAllAxes);
+  deltazmeansum->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = castat.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/Validation/RecoVertex/bin/PrimaryVertexPlots.cc
+++ b/Validation/RecoVertex/bin/PrimaryVertexPlots.cc
@@ -346,21 +346,21 @@ void PrimaryVertexPlots(const char* fullname,const char* module, const char* pos
   // Summary histograms
   /*
   TH1D* vtxxsum = new TH1D("vtxxsum","(BS-PV) Fitted X position vs run",10,0.,10.);
-  vtxxsum->SetCanExtend(TH1::kAllAxes);
+  vtxxsum->SetBit(TH1::kCanRebin);
   TH1D* vtxysum = new TH1D("vtxysum","(BS-PV) Fitted Y position vs run",10,0.,10.);
-  vtxysum->SetCanExtend(TH1::kAllAxes);
+  vtxysum->SetBit(TH1::kCanRebin);
   TH1D* vtxzsum = new TH1D("vtxzsum","(BS-PV) Fitted Y position vs run",10,0.,10.);
-  vtxzsum->SetCanExtend(TH1::kAllAxes);
+  vtxzsum->SetBit(TH1::kCanRebin);
   */
 
   TH1D* vtxxmeansum = new TH1D("vtxxmeansum","PV mean X position vs run",10,0.,10.);
-  vtxxmeansum->SetCanExtend(TH1::kAllAxes);
+  vtxxmeansum->SetBit(TH1::kCanRebin);
   TH1D* vtxymeansum = new TH1D("vtxymeansum","PV mean Y position vs run",10,0.,10.);
-  vtxymeansum->SetCanExtend(TH1::kAllAxes);
+  vtxymeansum->SetBit(TH1::kCanRebin);
   TH1D* vtxzmeansum = new TH1D("vtxzmeansum","PV mean Z position vs run",10,0.,10.);
-  vtxzmeansum->SetCanExtend(TH1::kAllAxes);
+  vtxzmeansum->SetBit(TH1::kCanRebin);
   TH1D* vtxzsigmasum = new TH1D("vtxzsigmasum","PV sigma Z position vs run",10,0.,10.);
-  vtxzsigmasum->SetCanExtend(TH1::kAllAxes);
+  vtxzsigmasum->SetBit(TH1::kCanRebin);
 
   std::vector<unsigned int> runs = castat.getRunList();
   std::sort(runs.begin(),runs.end());

--- a/Validation/RecoVertex/bin/multibsvspvplots.cc
+++ b/Validation/RecoVertex/bin/multibsvspvplots.cc
@@ -37,17 +37,17 @@ void multibsvspvplots(const char* module, const char* label, const char* postfix
 
   // Summary histograms
   TH1D* deltaxsum = new TH1D("deltaxsum","(PV-BS) Fitted X position vs run",10,0.,10.);
-  deltaxsum->SetCanExtend(TH1::kAllAxes);
+  deltaxsum->SetBit(TH1::kCanRebin);
   TH1D* deltaysum = new TH1D("deltaysum","(PV-BS) Fitted Y position vs run",10,0.,10.);
-  deltaysum->SetCanExtend(TH1::kAllAxes);
+  deltaysum->SetBit(TH1::kCanRebin);
 
   TH1D* deltaxmeansum = new TH1D("deltaxmeansum","(PV-BS) Mean X position vs run",10,0.,10.);
-  deltaxmeansum->SetCanExtend(TH1::kAllAxes);
+  deltaxmeansum->SetBit(TH1::kCanRebin);
   TH1D* deltaymeansum = new TH1D("deltaymeansum","(PV-BS) Mean Y position vs run",10,0.,10.);
-  deltaymeansum->SetCanExtend(TH1::kAllAxes);
+  deltaymeansum->SetBit(TH1::kCanRebin);
 
   TH1D* deltazmeansum = new TH1D("deltazmeansum","(PV-BS) Mean Z position vs run",10,0.,10.);
-  deltazmeansum->SetCanExtend(TH1::kAllAxes);
+  deltazmeansum->SetBit(TH1::kCanRebin);
 
   TF1* fdoubleg = new TF1("doubleg","[1]*exp(-0.5*((x-[0])/[2])**2)+[3]*exp(-0.5*((x-[0])/[4])**2)+[5]*exp(sqrt((x-[0])**2)*[6])",-.2,.2);
   fdoubleg->SetLineColor(kRed);

--- a/Validation/RecoVertex/src/BSvsPVHistogramMaker.cc
+++ b/Validation/RecoVertex/src/BSvsPVHistogramMaker.cc
@@ -164,11 +164,11 @@ void BSvsPVHistogramMaker::beginRun(const unsigned int nrun) {
 
     if(_runHistoProfile) {
       (*_hdeltaxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hdeltaxvsorbrun)->GetYaxis()->SetTitle("#Delta(X) [cm]");
-      (*_hdeltaxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*_hdeltaxvsorbrun)->SetBit(TH1::kCanRebin);
       (*_hdeltayvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hdeltayvsorbrun)->GetYaxis()->SetTitle("#Delta(Y) [cm]");
-      (*_hdeltayvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*_hdeltayvsorbrun)->SetBit(TH1::kCanRebin);
       (*_hdeltazvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hdeltazvsorbrun)->GetYaxis()->SetTitle("#Delta(Z) [cm]");
-      (*_hdeltazvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*_hdeltazvsorbrun)->SetBit(TH1::kCanRebin);
     }
     if(_runHistoBXProfile) {
       (*_hdeltaxvsbxrun)->GetXaxis()->SetTitle("BX");   (*_hdeltaxvsbxrun)->GetYaxis()->SetTitle("#Delta(X) [cm]");

--- a/Validation/RecoVertex/src/BeamSpotHistogramMaker.cc
+++ b/Validation/RecoVertex/src/BeamSpotHistogramMaker.cc
@@ -98,17 +98,17 @@ void BeamSpotHistogramMaker::beginRun(const unsigned int nrun) {
   (*_hbssigmazrun)->GetXaxis()->SetTitle("sigmaZ [cm]");   (*_hbssigmazrun)->GetYaxis()->SetTitle("Events");
 
   (*_hbsxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbsxvsorbrun)->GetYaxis()->SetTitle("X [cm]");
-  (*_hbsxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbsxvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbsyvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbsyvsorbrun)->GetYaxis()->SetTitle("Y [cm]");
-  (*_hbsyvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbsyvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbszvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbszvsorbrun)->GetYaxis()->SetTitle("Z [cm]");
-  (*_hbszvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbszvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbssigmaxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbssigmaxvsorbrun)->GetYaxis()->SetTitle("sigmaX [cm]");
-  (*_hbssigmaxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbssigmaxvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbssigmayvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbssigmayvsorbrun)->GetYaxis()->SetTitle("sigmaY [cm]");
-  (*_hbssigmayvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbssigmayvsorbrun)->SetBit(TH1::kCanRebin);
   (*_hbssigmazvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*_hbssigmazvsorbrun)->GetYaxis()->SetTitle("sigmaZ [cm]");
-  (*_hbssigmazvsorbrun)->SetCanExtend(TH1::kAllAxes);
+  (*_hbssigmazvsorbrun)->SetBit(TH1::kCanRebin);
 
 
 }

--- a/Validation/RecoVertex/src/VertexHistogramMaker.cc
+++ b/Validation/RecoVertex/src/VertexHistogramMaker.cc
@@ -217,13 +217,13 @@ void VertexHistogramMaker::beginRun(const edm::Run& iRun) {
 
     if(m_runHistoProfile) {
       (*m_hvtxxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hvtxxvsorbrun)->GetYaxis()->SetTitle("X [cm]");
-      (*m_hvtxxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hvtxxvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hvtxyvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hvtxyvsorbrun)->GetYaxis()->SetTitle("Y [cm]");
-      (*m_hvtxyvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hvtxyvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hvtxzvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hvtxzvsorbrun)->GetYaxis()->SetTitle("Z [cm]");
-      (*m_hvtxzvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hvtxzvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hnvtxvsorbrun)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hnvtxvsorbrun)->GetYaxis()->SetTitle("Nvertices");
-      (*m_hnvtxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hnvtxvsorbrun)->SetBit(TH1::kCanRebin);
     }
 
     if(m_runHistoBXProfile) {
@@ -243,9 +243,9 @@ void VertexHistogramMaker::beginRun(const edm::Run& iRun) {
 
     if(m_runHisto2D) {
       (*m_hnvtxvsbxvsorbrun)->GetXaxis()->SetTitle("BX#"); (*m_hnvtxvsbxvsorbrun)->GetYaxis()->SetTitle("time [orbit#]");
-      (*m_hnvtxvsbxvsorbrun)->SetCanExtend(TH1::kAllAxes);
+      (*m_hnvtxvsbxvsorbrun)->SetBit(TH1::kCanRebin);
       (*m_hnvtxvsorbrun2D)->GetXaxis()->SetTitle("time [orbit#]");   (*m_hnvtxvsorbrun2D)->GetYaxis()->SetTitle("Nvertices");
-      (*m_hnvtxvsorbrun2D)->SetCanExtend(TH1::kAllAxes);
+      (*m_hnvtxvsorbrun2D)->SetBit(TH1::kCanRebin);
     }
   }
 }


### PR DESCRIPTION
This PR backs out many changes automatically merged from CMSSW_7_5_X that are incompatible with a release based on ROOT5.  This should fix virtually all (if not all) of the 1138 build errors in CMSSW_7_5_ROOT5_X.
Please expedite this technical PR, as CMSSW_7_5_ROOT5_X is currently useless without this.
