### PR TITLE
Add ObjectSelectorStreamProducer template and use it for RecoTrackViewRefSelector

### DIFF
--- a/CommonTools/RecoAlgos/interface/RecoTrackViewRefSelector.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackViewRefSelector.h
@@ -1,0 +1,38 @@
+#ifndef CommonTools_RecoAlgos_RecoTrackViewRefSelector_h
+#define CommonTools_RecoAlgos_RecoTrackViewRefSelector_h
+
+#include "CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h"
+#include "DataFormats/Common/interface/RefToBaseVector.h"
+
+class RecoTrackViewRefSelector : public RecoTrackSelectorBase {
+ public:
+  typedef edm::View<reco::Track> collection;
+  typedef edm::RefToBaseVector<reco::Track> ref_container;
+  typedef ref_container::const_iterator const_ref_iterator;
+
+  /// Constructors
+  RecoTrackViewRefSelector() {}
+
+  RecoTrackViewRefSelector ( const edm::ParameterSet & cfg, edm::ConsumesCollector && iC ) : RecoTrackSelectorBase(cfg, iC) {}
+
+  const_ref_iterator begin() const { return ref_selected_.begin(); }
+  const_ref_iterator end() const { return ref_selected_.end(); }
+
+  void select( const edm::Handle<collection>& c, const edm::Event & event, const edm::EventSetup&es) {
+    init(event, es);
+    ref_selected_.clear();
+    for (unsigned int i = 0; i < c->size(); i++) {
+      auto trk = c->refAt(i);
+      if ( operator()(*trk) ) {
+	ref_selected_.push_back( trk );
+      }
+    }
+  }
+
+  size_t size() const { return ref_selected_.size(); }
+
+ private:
+  ref_container ref_selected_;
+};
+
+#endif

--- a/CommonTools/RecoAlgos/plugins/RecoTrackViewRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoTrackViewRefSelector.cc
@@ -1,0 +1,8 @@
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h"
+#include "CommonTools/RecoAlgos/interface/RecoTrackViewRefSelector.h"
+
+namespace reco {
+  typedef ObjectSelectorStreamProducer<RecoTrackViewRefSelector, edm::RefToBaseVector<reco::Track>> RecoTrackViewRefSelector;
+  DEFINE_FWK_MODULE(RecoTrackViewRefSelector);
+}

--- a/CommonTools/RecoAlgos/python/recoTrackViewRefSelector_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackViewRefSelector_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from CommonTools.RecoAlgos.recoTrackSelectorPSet_cfi import recoTrackSelectorPSet as _recoTrackSelectorPSet
+
+recoTrackViewRefSelector = cms.EDProducer("RecoTrackViewRefSelector",
+    _recoTrackSelectorPSet
+)

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
@@ -1,0 +1,68 @@
+#ifndef CommonTools_UtilAlgos_ObjectSelectorProducer_h
+#define CommonTools_UtilAlgos_ObjectSelectorProducer_h
+
+#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
+#include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
+#include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
+#include "CommonTools/UtilAlgos/interface/NullPostProcessor.h"
+#include "CommonTools/UtilAlgos/interface/EventSetupInitTrait.h"
+#include <utility>
+#include <vector>
+#include <memory>
+#include <algorithm>
+
+/**
+ * This class template is like ObjectSelector, but it is an EDProducer
+ * instead of EDFilter. Use case is that when the filter decisions are
+ * ignored (cms.ignore in configuration or EDFilter returns always
+ * true), EDProducers are better for the unscheduled mode than
+ * EDFilters.
+ */
+template<typename Selector,
+         typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
+         typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDProducer>,
+         typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDProducer>::type,
+         typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDProducer>::base,
+         typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
+         >
+class ObjectSelectorProducer : public Base {
+public:
+  /// constructor
+  explicit ObjectSelectorProducer(const edm::ParameterSet & cfg) :
+    Base(cfg),
+    srcToken_( this-> template consumes<typename Selector::collection>(cfg.template getParameter<edm::InputTag>("src"))),
+    selector_(cfg, this->consumesCollector()),
+    postProcessor_(cfg, this->consumesCollector()) {
+    postProcessor_.init(* this);
+   }
+  /// destructor
+  virtual ~ObjectSelectorProducer() { }
+
+private:
+  /// process one event
+  void produce(edm::Event& evt, const edm::EventSetup& es) override {
+    Init::init(selector_, evt, es);
+    using namespace std;
+    edm::Handle<typename Selector::collection> source;
+    evt.getByToken(srcToken_, source);
+    StoreManager manager(source);
+    selector_.select(source, evt, es);
+    manager.cloneAndStore(selector_.begin(), selector_.end(), evt);
+    edm::OrphanHandle<OutputCollection> filtered = manager.put(evt);
+    postProcessor_.process(filtered, evt);
+  }
+  /// source collection label
+  edm::EDGetTokenT<typename Selector::collection> srcToken_;
+  /// Object collection selector
+  Selector selector_;
+  /// post processor
+  PostProcessor postProcessor_;
+};
+
+
+#endif

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h
@@ -1,12 +1,10 @@
 #ifndef CommonTools_UtilAlgos_ObjectSelectorProducer_h
 #define CommonTools_UtilAlgos_ObjectSelectorProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "CommonTools/UtilAlgos/interface/ParameterAdapter.h"
 #include "CommonTools/UtilAlgos/interface/StoreManagerTrait.h"
 #include "CommonTools/UtilAlgos/interface/SelectedOutputCollectionTrait.h"
 #include "CommonTools/UtilAlgos/interface/NullPostProcessor.h"
@@ -24,11 +22,11 @@
  * EDFilters.
  */
 template<typename Selector,
-         typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
-         typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::EDProducer>,
-         typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDProducer>::type,
-         typename Base = typename ::helper::StoreManagerTrait<OutputCollection, edm::EDProducer>::base,
-         typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
+         typename OutputCollection,
+         typename PostProcessor,
+         typename StoreManager,
+         typename Base,
+         typename Init
          >
 class ObjectSelectorProducer : public Base {
 public:

--- a/CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h
+++ b/CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h
@@ -1,0 +1,15 @@
+#ifndef CommonTools_UtilAlgos_ObjectSelectorStreamProducer_h
+#define CommonTools_UtilAlgos_ObjectSelectorStreamProducer_h
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorProducer.h"
+
+template<typename Selector,
+         typename OutputCollection = typename ::helper::SelectedOutputCollectionTrait<typename Selector::collection>::type,
+         typename PostProcessor = ::helper::NullPostProcessor<OutputCollection, edm::stream::EDProducer<>>,
+         typename StoreManager = typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDProducer<>>::type,
+         typename Init = typename ::reco::modules::EventSetupInit<Selector>::type
+         >
+  using ObjectSelectorStreamProducer = ObjectSelectorProducer<Selector, OutputCollection, PostProcessor, StoreManager, typename ::helper::StoreManagerTrait<OutputCollection, edm::stream::EDProducer<>>::base, Init>;
+
+#endif

--- a/DataFormats/TrackReco/interface/TrackFwd.h
+++ b/DataFormats/TrackReco/interface/TrackFwd.h
@@ -6,6 +6,7 @@
 #include "DataFormats/Common/interface/RefProd.h"
 #include "DataFormats/Common/interface/RefVector.h"
 #include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/Common/interface/RefToBaseVector.h"
 
 namespace reco
 {
@@ -29,6 +30,9 @@ typedef TrackRefVector::iterator track_iterator;
 
 /// persistent reference to a Track, using views
 typedef edm::RefToBase<reco::Track> TrackBaseRef;
+
+/// vector of persistent references to a Track, using views
+typedef edm::RefToBaseVector<reco::Track> TrackBaseRefVector;
 
 } // namespace reco
 

--- a/DataFormats/TrackReco/src/classes.h
+++ b/DataFormats/TrackReco/src/classes.h
@@ -90,6 +90,9 @@ namespace DataFormats_TrackReco {
     edm::reftobase::Holder<reco::Track, reco::TrackRef> h_tk_tkr;
     std::vector< edm::RefToBase<reco::Track> >		rtb_tk_vect;
 
+    reco::TrackBaseRefVector tbrv;
+    edm::Wrapper<reco::TrackBaseRefVector> wtbrv;
+
     edm::RefToBaseProd<reco::Track> aaaaaa;
     std::vector<std::pair<edm::RefToBase<reco::Track>,double> > aaaaaaaaaa;
     std::pair<edm::RefToBase<reco::Track>,double> aaaaaaaaaaaa;

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -439,6 +439,9 @@
      <class name="std::pair<edm::RefToBase<reco::Track>,double>" />
      <class name="std::vector<std::pair<edm::RefToBase<reco::Track>,double> >" />
 
+     <class name="reco::TrackBaseRefVector"/>
+     <class name="edm::Wrapper<reco::TrackBaseRefVector>"/>
+
      <!-- RefToBaseProd<reco::Track> -->
      <class name="edm::RefToBaseProd<reco::Track>" />
 

--- a/PhysicsTools/RecoAlgos/python/btvTracks_cfi.py
+++ b/PhysicsTools/RecoAlgos/python/btvTracks_cfi.py
@@ -25,7 +25,7 @@ btvTracks = cms.EDProducer("RecoTrackSelector",
     copyTrajectories = cms.untracked.bool(False) # don't set this to true on AOD!
 )
 
-btvTrackRefs = cms.EDFilter("RecoTrackRefSelector",
+btvTrackRefs = cms.EDProducer("RecoTrackViewRefSelector",
     _content
 )
 

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -139,28 +139,28 @@ trackValidator.dodEdxPlots = True
 
 # the track selectors
 tracksValidationSelectors = cms.Sequence(
-    cms.ignore(cutsRecoTracksHp)*
-    cms.ignore(cutsRecoTracksInitialStep)*
-    cms.ignore(cutsRecoTracksInitialStepHp)*
-    cms.ignore(cutsRecoTracksLowPtTripletStep)*
-    cms.ignore(cutsRecoTracksLowPtTripletStepHp)*
-    cms.ignore(cutsRecoTracksPixelPairStep)*
-    cms.ignore(cutsRecoTracksPixelPairStepHp)*
-    cms.ignore(cutsRecoTracksDetachedTripletStep)*
-    cms.ignore(cutsRecoTracksDetachedTripletStepHp)*
-    cms.ignore(cutsRecoTracksMixedTripletStep)*
-    cms.ignore(cutsRecoTracksMixedTripletStepHp)*
-    cms.ignore(cutsRecoTracksPixelLessStep)*
-    cms.ignore(cutsRecoTracksPixelLessStepHp)*
-    cms.ignore(cutsRecoTracksTobTecStep)*
-    cms.ignore(cutsRecoTracksTobTecStepHp)*
-    cms.ignore(cutsRecoTracksJetCoreRegionalStep)*
-    cms.ignore(cutsRecoTracksJetCoreRegionalStepHp)*
-    cms.ignore(cutsRecoTracksMuonSeededStepInOut)*
-    cms.ignore(cutsRecoTracksMuonSeededStepInOutHp)*
-    cms.ignore(cutsRecoTracksMuonSeededStepOutIn)*
-    cms.ignore(cutsRecoTracksMuonSeededStepOutInHp)*
-    cms.ignore(cutsRecoTracksBtvLike)*
+    cutsRecoTracksHp*
+    cutsRecoTracksInitialStep*
+    cutsRecoTracksInitialStepHp*
+    cutsRecoTracksLowPtTripletStep*
+    cutsRecoTracksLowPtTripletStepHp*
+    cutsRecoTracksPixelPairStep*
+    cutsRecoTracksPixelPairStepHp*
+    cutsRecoTracksDetachedTripletStep*
+    cutsRecoTracksDetachedTripletStepHp*
+    cutsRecoTracksMixedTripletStep*
+    cutsRecoTracksMixedTripletStepHp*
+    cutsRecoTracksPixelLessStep*
+    cutsRecoTracksPixelLessStepHp*
+    cutsRecoTracksTobTecStep*
+    cutsRecoTracksTobTecStepHp*
+    cutsRecoTracksJetCoreRegionalStep*
+    cutsRecoTracksJetCoreRegionalStepHp*
+    cutsRecoTracksMuonSeededStepInOut*
+    cutsRecoTracksMuonSeededStepInOutHp*
+    cutsRecoTracksMuonSeededStepOutIn*
+    cutsRecoTracksMuonSeededStepOutInHp*
+    cutsRecoTracksBtvLike*
     ak4JetTracksAssociatorAtVertexPFAll*
     cutsRecoTracksAK4PFJets
 )

--- a/Validation/RecoTrack/python/cutsRecoTracks_cfi.py
+++ b/Validation/RecoTrack/python/cutsRecoTracks_cfi.py
@@ -1,4 +1,4 @@
 import FWCore.ParameterSet.Config as cms
 
-import CommonTools.RecoAlgos.recoTrackRefSelector_cfi
-cutsRecoTracks = CommonTools.RecoAlgos.recoTrackRefSelector_cfi.recoTrackRefSelector.clone()
+import CommonTools.RecoAlgos.recoTrackViewRefSelector_cfi
+cutsRecoTracks = CommonTools.RecoAlgos.recoTrackViewRefSelector_cfi.recoTrackViewRefSelector.clone()


### PR DESCRIPTION
Here is an attempt to address @Dr15Jones' comment (https://github.com/cms-sw/cmssw/pull/9201#issuecomment-109273147) about ignored EDFilters (in tracking validation sequence). Basically the PR adds new `ObjectSelector(Stream)Producer` templates similar to current `ObjectSelector(Stream)` but being EDProducers (I'm not sure if the legacy-default is still "needed", I decided to include it only to have similar code structure as `ObjectSelector(Stream)`).

As a use case I added RecoTrackViewRefSelector (existing RecoTrack(Ref)Selectors take `vector<Track>` as an input, and I'll soon need anyway a version reading the input via `View`), and switched the tracking MC validation sequence to use it.

Tested in CMSSW_7_6_X_2015-06-24-2300, no changes expected in results.

@rovere @VinInn 
