### PR TITLE
Fix alignment track selector multi threaded friendly for 76X (fwdport of #9906)

### DIFF
--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCBeamHaloSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCBeamHaloSelectorModule.cc
@@ -1,7 +1,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentCSCBeamHaloSelector.h"
 
 // the following include is necessary to clone all track branches
@@ -42,6 +42,6 @@ private:
   AlignmentCSCBeamHaloSelector theSelector;
 };
 
-typedef ObjectSelector<CSCBeamHaloConfigSelector>  AlignmentCSCBeamHaloSelectorModule;
+typedef ObjectSelectorStream<CSCBeamHaloConfigSelector>  AlignmentCSCBeamHaloSelectorModule;
 
 DEFINE_FWK_MODULE( AlignmentCSCBeamHaloSelectorModule );

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCOverlapSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCOverlapSelectorModule.cc
@@ -1,7 +1,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentCSCOverlapSelector.h"
 
 // the following include is necessary to clone all track branches
@@ -40,6 +40,6 @@ private:
   AlignmentCSCOverlapSelector theSelector;
 };
 
-typedef ObjectSelector<CSCOverlapConfigSelector>  AlignmentCSCOverlapSelectorModule;
+typedef ObjectSelectorStream<CSCOverlapConfigSelector>  AlignmentCSCOverlapSelectorModule;
 
 DEFINE_FWK_MODULE( AlignmentCSCOverlapSelectorModule );

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCTrackSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentCSCTrackSelectorModule.cc
@@ -1,7 +1,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 
 //the selectores used to select the tracks
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentCSCTrackSelector.h"
@@ -41,6 +41,6 @@ struct CSCTrackConfigSelector {
       AlignmentCSCTrackSelector theBaseSelector;
 };
 
-typedef ObjectSelector<CSCTrackConfigSelector>  AlignmentCSCTrackSelectorModule;
+typedef ObjectSelectorStream<CSCTrackConfigSelector>  AlignmentCSCTrackSelectorModule;
 
 DEFINE_FWK_MODULE( AlignmentCSCTrackSelectorModule );

--- a/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
+++ b/Alignment/CommonAlignmentProducer/plugins/AlignmentTrackSelectorModule.cc
@@ -1,7 +1,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 
 //the selectores used to select the tracks
 #include "Alignment/CommonAlignmentProducer/interface/AlignmentTrackSelector.h"
@@ -65,6 +65,6 @@ private:
 
 };
 
-typedef ObjectSelector<TrackConfigSelector>  AlignmentTrackSelectorModule;
+typedef ObjectSelectorStream<TrackConfigSelector>  AlignmentTrackSelectorModule;
 
 DEFINE_FWK_MODULE( AlignmentTrackSelectorModule );

--- a/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorModule.cc
+++ b/Calibration/TkAlCaRecoProducers/plugins/CalibrationTrackSelectorModule.cc
@@ -1,7 +1,7 @@
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelector.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
 
 //the selectores used to select the tracks
 #include "Calibration/TkAlCaRecoProducers/interface/CalibrationTrackSelector.h"
@@ -54,6 +54,6 @@ private:
 
 };
 
-typedef ObjectSelector<SiStripCalTrackConfigSelector>  CalibrationTrackSelectorModule;
+typedef ObjectSelectorStream<SiStripCalTrackConfigSelector>  CalibrationTrackSelectorModule;
 
 DEFINE_FWK_MODULE( CalibrationTrackSelectorModule );


### PR DESCRIPTION
Forward port of #9906. Hotfix to recover AlCaReco content after change to thread-safe conversion of      `CommonTools/RecoAlgos/interface/TrackSelector.h` in #9081 
