### PR TITLE
Updated HLTTau validation to include legs X in tau+X triggers

### DIFF
--- a/DQMOffline/Trigger/interface/HLTTauDQML1Plotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQML1Plotter.h
@@ -8,6 +8,8 @@
 
 #include "DataFormats/L1Trigger/interface/L1JetParticle.h"
 #include "DataFormats/L1Trigger/interface/L1JetParticleFwd.h"
+#include "DataFormats/L1Trigger/interface/L1EtMissParticle.h"
+#include "DataFormats/L1Trigger/interface/L1EtMissParticleFwd.h"
 
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 
@@ -25,12 +27,17 @@ private:
     //The filters
     edm::InputTag l1ExtraTaus_;
     edm::EDGetTokenT<l1extra::L1JetParticleCollection> l1ExtraTausToken_;
+    edm::InputTag l1ExtraIsoTaus_;
+    edm::EDGetTokenT<l1extra::L1JetParticleCollection> l1ExtraIsoTausToken_;
     edm::InputTag l1ExtraJets_;
     edm::EDGetTokenT<l1extra::L1JetParticleCollection> l1ExtraJetsToken_;
+    edm::InputTag l1ExtraMET_;
+    edm::EDGetTokenT<l1extra::L1EtMissParticleCollection> l1ExtraMETToken_;
 
     const bool doRefAnalysis_;
     const double matchDeltaR_;
     double l1JetMinEt_;
+    double l1ETMMin_;
 
     const double maxPt_;
     const double maxHighPt_;
@@ -44,12 +51,20 @@ private:
     MonitorElement* l1tauEta_;
     MonitorElement* l1tauPhi_;
 
+    MonitorElement* l1isotauEt_;
+    MonitorElement* l1isotauEta_;
+    MonitorElement* l1isotauPhi_;
+
     MonitorElement* l1jetEt_;
     MonitorElement* l1jetEta_;
     MonitorElement* l1jetPhi_;
 
+    MonitorElement* l1etmEt_;
+    MonitorElement* l1etmPhi_;
+
     //Monitor Elements for matching
     MonitorElement* l1tauEtRes_;
+    MonitorElement* l1isotauEtRes_;
     MonitorElement* l1jetEtRes_;
 
     MonitorElement* l1tauEtEffNum_;
@@ -63,6 +78,18 @@ private:
 
     MonitorElement* l1tauPhiEffNum_;
     MonitorElement* l1tauPhiEffDenom_;
+
+    MonitorElement* l1isotauEtEffNum_;
+    MonitorElement* l1isotauEtEffDenom_;
+    
+    MonitorElement* l1isotauHighEtEffNum_;
+    MonitorElement* l1isotauHighEtEffDenom_;
+    
+    MonitorElement* l1isotauEtaEffNum_;
+    MonitorElement* l1isotauEtaEffDenom_;
+    
+    MonitorElement* l1isotauPhiEffNum_;
+    MonitorElement* l1isotauPhiEffDenom_;
 
     MonitorElement* l1jetEtEffNum_;
     MonitorElement* l1jetEtEffDenom_;
@@ -83,5 +110,8 @@ private:
     MonitorElement* secondTauEt_;
     MonitorElement* secondTauEta_;
     MonitorElement* secondTauPhi_;
+
+    MonitorElement* l1etmEtEffNum_;
+    MonitorElement* l1etmEtEffDenom_;
 };
 #endif

--- a/DQMOffline/Trigger/interface/HLTTauDQMPath.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPath.h
@@ -4,9 +4,9 @@
 
 #include "DataFormats/Math/interface/LorentzVector.h"
 
-#include<tuple>
-#include<vector>
-#include<string>
+#include <tuple>
+#include <vector>
+#include <string>
 
 class HLTConfigProvider;
 namespace edm {
@@ -23,10 +23,11 @@ class HLTTauDQMPath {
 public:
   typedef math::XYZTLorentzVectorD LV;
   typedef std::vector<LV> LVColl;
-  typedef std::tuple<std::string, size_t> FilterIndex;
+  typedef std::tuple<std::string, std::string, size_t> FilterIndex;
 
   constexpr static size_t kName = 0;
-  constexpr static size_t kModuleIndex = 1;
+  constexpr static size_t kType = 1;
+  constexpr static size_t kModuleIndex = 2;
   constexpr static size_t kInvalidIndex = std::numeric_limits<size_t>::max();
 
   struct Object {
@@ -50,19 +51,42 @@ public:
 
   size_t filtersSize() const { return filterIndices_.size(); }
   const std::string& getFilterName(size_t i) const { return std::get<kName>(filterIndices_[i]); }
-  int getFilterNTaus(size_t i) const { return filterTauN_[i]; }
-  int getFilterNElectrons(size_t i) const {return filterElectronN_[i]; }
-  int getFilterNMuons(size_t i) const {return filterMuonN_[i]; }
+  const std::string& getFilterType(size_t i) const { return std::get<kType>(filterIndices_[i]); }
+  int getFilterNTaus(size_t i) const { if(i < filterTauN_.size()) return filterTauN_[i]; else return 0;}
+  int getFilterNElectrons(size_t i) const {if(i < filterElectronN_.size()) return filterElectronN_[i]; else return 0;}
+  int getFilterNMuons(size_t i) const {if(i < filterMuonN_.size()) return filterMuonN_[i]; else return 0;}
+  int getFilterMET(size_t i) const {if(i < filterMET_.size()) return filterMET_[i]; else return 0;}
+  int getFilterLevel(size_t i) const {if(i < filterLevel_.size()) return filterLevel_[i]; else return 0;}
 
   bool isFirstFilterL1Seed() const { return isFirstL1Seed_; }
   const std::string& getLastFilterName() const { return std::get<kName>(filterIndices_.back()); }
 
   bool hasL2Taus() const { return lastL2TauFilterIndex_ != kInvalidIndex; }
   bool hasL3Taus() const { return lastL3TauFilterIndex_ != kInvalidIndex; }
+  bool hasL2Electrons() const { return lastL2ElectronFilterIndex_ != kInvalidIndex; }  
+  bool hasL3Electrons() const { return lastL3ElectronFilterIndex_ != kInvalidIndex; }  
+  bool hasL2Muons() const { return lastL2MuonFilterIndex_ != kInvalidIndex; }
+  bool hasL3Muons() const { return lastL3MuonFilterIndex_ != kInvalidIndex; }
+  bool hasL2CaloMET() const { return lastL2METFilterIndex_ != kInvalidIndex; }
   size_t getLastFilterBeforeL2TauIndex() const { return lastFilterBeforeL2TauIndex_; }
   size_t getLastL2TauFilterIndex() const { return lastL2TauFilterIndex_; }
   size_t getLastFilterBeforeL3TauIndex() const { return lastFilterBeforeL3TauIndex_; }
   size_t getLastL3TauFilterIndex() const { return lastL3TauFilterIndex_; }
+
+  size_t getLastFilterBeforeL2ElectronIndex() const { return lastFilterBeforeL2ElectronIndex_; }
+  size_t getLastL2ElectronFilterIndex() const { return lastL2ElectronFilterIndex_; }
+  size_t getLastFilterBeforeL3ElectronIndex() const { return lastFilterBeforeL3ElectronIndex_; }
+  size_t getLastL3ElectronFilterIndex() const { return lastL3ElectronFilterIndex_; }
+
+  size_t getLastFilterBeforeL2MuonIndex() const { return lastFilterBeforeL2MuonIndex_; }
+  size_t getLastL2MuonFilterIndex() const { return lastL2MuonFilterIndex_; }
+  size_t getLastFilterBeforeL3MuonIndex() const { return lastFilterBeforeL3MuonIndex_; }
+  size_t getLastL3MuonFilterIndex() const { return lastL3MuonFilterIndex_; }
+
+  size_t getLastFilterBeforeL2CaloMETIndex() const { return lastFilterBeforeL2METIndex_; }
+  size_t getLastL2CaloMETFilterIndex() const { return lastL2METFilterIndex_; }
+  size_t getFirstFilterBeforeL2CaloMETIndex() const { return firstFilterBeforeL2METIndex_; }
+  size_t getFirstL2CaloMETFilterIndex() const { return firstL2METFilterIndex_; }
 
   // index (to edm::TriggerResults) of a filter
   size_t getFilterIndex(size_t i) const { return std::get<kModuleIndex>(filterIndices_[i]); }
@@ -83,12 +107,26 @@ private:
   std::vector<int> filterTauN_;
   std::vector<int> filterElectronN_;
   std::vector<int> filterMuonN_;
+  std::vector<int> filterMET_;
+  std::vector<int> filterLevel_;
   const std::string pathName_;
   const unsigned int pathIndex_;
   size_t lastFilterBeforeL2TauIndex_;
   size_t lastL2TauFilterIndex_;
   size_t lastFilterBeforeL3TauIndex_;
   size_t lastL3TauFilterIndex_;
+  size_t lastFilterBeforeL2ElectronIndex_;
+  size_t lastL2ElectronFilterIndex_;
+  size_t lastFilterBeforeL3ElectronIndex_;
+  size_t lastL3ElectronFilterIndex_;
+  size_t lastFilterBeforeL2MuonIndex_;
+  size_t lastL2MuonFilterIndex_;
+  size_t lastFilterBeforeL3MuonIndex_;
+  size_t lastL3MuonFilterIndex_;
+  size_t lastFilterBeforeL2METIndex_;
+  size_t lastL2METFilterIndex_;
+  size_t firstFilterBeforeL2METIndex_;
+  size_t firstL2METFilterIndex_;
   bool isFirstL1Seed_;
   bool isValid_;
 };

--- a/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPathPlotter.h
@@ -52,6 +52,14 @@ private:
   MonitorElement *hTrigTauEt_;
   MonitorElement *hTrigTauEta_;
   MonitorElement *hTrigTauPhi_;
+  MonitorElement *hTrigMuonEt_;
+  MonitorElement *hTrigMuonEta_;
+  MonitorElement *hTrigMuonPhi_;
+  MonitorElement *hTrigElectronEt_;
+  MonitorElement *hTrigElectronEta_;
+  MonitorElement *hTrigElectronPhi_;
+  MonitorElement *hTrigMETEt_;
+  MonitorElement *hTrigMETPhi_;
   MonitorElement *hMass_;
 
   MonitorElement *hL2TrigTauEtEffNum_;
@@ -71,6 +79,37 @@ private:
   MonitorElement *hL3TrigTauEtaEffDenom_;
   MonitorElement *hL3TrigTauPhiEffNum_;
   MonitorElement *hL3TrigTauPhiEffDenom_;
+
+  MonitorElement *hL2TrigElectronEtEffNum_;
+  MonitorElement *hL2TrigElectronEtEffDenom_;
+  MonitorElement *hL2TrigElectronEtaEffNum_;
+  MonitorElement *hL2TrigElectronEtaEffDenom_;
+  MonitorElement *hL2TrigElectronPhiEffNum_;
+  MonitorElement *hL2TrigElectronPhiEffDenom_;
+
+  MonitorElement *hL3TrigElectronEtEffNum_;
+  MonitorElement *hL3TrigElectronEtEffDenom_;
+  MonitorElement *hL3TrigElectronEtaEffNum_;
+  MonitorElement *hL3TrigElectronEtaEffDenom_;
+  MonitorElement *hL3TrigElectronPhiEffNum_;
+  MonitorElement *hL3TrigElectronPhiEffDenom_;
+
+  MonitorElement *hL2TrigMuonEtEffNum_;
+  MonitorElement *hL2TrigMuonEtEffDenom_;
+  MonitorElement *hL2TrigMuonEtaEffNum_;
+  MonitorElement *hL2TrigMuonEtaEffDenom_;
+  MonitorElement *hL2TrigMuonPhiEffNum_;
+  MonitorElement *hL2TrigMuonPhiEffDenom_;
+  
+  MonitorElement *hL3TrigMuonEtEffNum_;
+  MonitorElement *hL3TrigMuonEtEffDenom_;
+  MonitorElement *hL3TrigMuonEtaEffNum_;
+  MonitorElement *hL3TrigMuonEtaEffDenom_;
+  MonitorElement *hL3TrigMuonPhiEffNum_;
+  MonitorElement *hL3TrigMuonPhiEffDenom_;
+
+  MonitorElement *hL2TrigMETEtEffNum_;
+  MonitorElement *hL2TrigMETEtEffDenom_;
 };
 
 #endif

--- a/DQMOffline/Trigger/interface/HLTTauDQMPlotter.h
+++ b/DQMOffline/Trigger/interface/HLTTauDQMPlotter.h
@@ -21,10 +21,12 @@ struct HLTTauDQMOfflineObjects {
     electrons.clear();
     muons.clear();
     taus.clear();
+    met.clear();
   };
   std::vector<LV> electrons;
   std::vector<LV> muons;
   std::vector<LV> taus;
+  std::vector<LV> met;
 };
 
 //Virtual base class for HLT-Tau-DQM Plotters

--- a/DQMOffline/Trigger/interface/HLTTauRefProducer.h
+++ b/DQMOffline/Trigger/interface/HLTTauRefProducer.h
@@ -42,6 +42,10 @@ in Offline Trigger DQM etc
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 #include "DataFormats/EgammaCandidates/interface/PhotonFwd.h"
 
+//MET Includes
+#include "DataFormats/METReco/interface/CaloMET.h"
+#include "DataFormats/METReco/interface/CaloMETCollection.h"
+
 #include <vector>
 #include <string>
 
@@ -100,6 +104,10 @@ public:
   double ptMinTower_;
   double towerIsol_;
 
+  edm::EDGetTokenT<reco::CaloMETCollection> MET_;
+  bool doMET_;
+  double ptMinMET_;
+
   double etaMax;
 
   void doPFTaus(edm::Event&,const edm::EventSetup&);
@@ -110,7 +118,7 @@ public:
   void doJets(edm::Event&,const edm::EventSetup&);
   void doPhotons(edm::Event&,const edm::EventSetup&);
   void doTowers(edm::Event&,const edm::EventSetup&);
-
+  void doMET(edm::Event&,const edm::EventSetup&);
 };
 
 #endif

--- a/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauDQMOffline_cfi.py
@@ -29,31 +29,38 @@ TauRefProducer = cms.EDProducer("HLTTauRefProducer",
                             lipMinTrack = cms.untracked.double(0.2),
                             IdCollection = cms.untracked.InputTag("elecIDext")
                             ),
-                   Jets = cms.untracked.PSet(
+                    Jets = cms.untracked.PSet(
                             JetCollection = cms.untracked.InputTag("ak4PFJetsCHS"),
                             etMin = cms.untracked.double(15.0),
                             doJets = cms.untracked.bool(False)
                             ),
-                   Towers = cms.untracked.PSet(
+                    Towers = cms.untracked.PSet(
                             TowerCollection = cms.untracked.InputTag("towerMaker"),
                             etMin = cms.untracked.double(10.0),
                             doTowers = cms.untracked.bool(False),
                             towerIsolation = cms.untracked.double(5.0)
                             ),
 
-                   Muons = cms.untracked.PSet(
+                    Muons = cms.untracked.PSet(
                             doMuons = cms.untracked.bool(True),
                             MuonCollection = cms.untracked.InputTag("muons"),
                             ptMin = cms.untracked.double(15.0)
                             ),
 
-                   Photons = cms.untracked.PSet(
+                    Photons = cms.untracked.PSet(
                             doPhotons = cms.untracked.bool(False),
                             PhotonCollection = cms.untracked.InputTag("gedPhotons"),
                             etMin = cms.untracked.double(15.0),
                             ECALIso = cms.untracked.double(3.0)
                             ),
-                  EtaMax = cms.untracked.double(2.3)
+
+                    MET = cms.untracked.PSet(
+                            doMET = cms.untracked.bool(True),
+                            METCollection = cms.untracked.InputTag("caloMet"), 
+                            ptMin = cms.untracked.double(0.0)
+                            ),
+
+                    EtaMax = cms.untracked.double(2.3)
                   )
 
 #----------------------------------MONITORS--------------------------------------------------------------------------
@@ -66,8 +73,11 @@ hltTauOfflineMonitor_PFTaus = cms.EDAnalyzer("HLTTauDQMOfflineSource",
     L1Plotter = cms.untracked.PSet(
         DQMFolder             = cms.untracked.string('L1'),
         L1Taus                = cms.untracked.InputTag("l1extraParticles", "Tau"),
+        L1IsoTaus             = cms.untracked.InputTag("l1extraParticles", "IsoTau"),
         L1Jets                = cms.untracked.InputTag("l1extraParticles", "Central"),
         L1JetMinEt            = cms.untracked.double(40), # FIXME: this value is arbitrary at the moment
+        L1ETM                 = cms.untracked.InputTag("l1extraParticles", "MET"),
+        L1ETMMin              = cms.untracked.double(50),
     ),
     Paths = cms.untracked.string("PFTau"),
     PathSummaryPlotter = cms.untracked.PSet(
@@ -87,6 +97,10 @@ hltTauOfflineMonitor_PFTaus = cms.EDAnalyzer("HLTTauDQMOfflineSource",
                                     cms.untracked.PSet(
                                         FilterName        = cms.untracked.InputTag("TauRefProducer","Muons"),
                                         matchObjectID     = cms.untracked.int32(13),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("TauRefProducer","MET"),
+					matchObjectID     = cms.untracked.int32(0),
                                     ),
                                 ),
     ),

--- a/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
+++ b/DQMOffline/Trigger/python/HLTTauPostProcessor_cfi.py
@@ -33,23 +33,36 @@ def makePFTauAnalyzer(monitorModule):
             title = "%s %s %s efficiency%s" % (level, titleObject, titleLabel, postfix)
             m1.efficiencyProfile.append("%s '%s' helpers/%sNum helpers/%sDenom" % (name, title, name, name))
 
-
     _addEfficiencies("L1", [("Et", "E_{T}"),
                             ("Eta", "#eta"),
                             ("Phi", "#phi")], "%sTau%sEff")
     _addEfficiencies("L1", [("HighEt", "E_{T}")], "%sTau%sEff", postfix="(high E_{T})")
 
+    _addEfficiencies("L1", [("Et", "E_{T}"),
+                            ("Eta", "#eta"),
+                            ("Phi", "#phi")], "%sIsoTau%sEff")
+    _addEfficiencies("L1", [("HighEt", "E_{T}")], "%sIsoTau%sEff", postfix="(high E_{T})")
+
     _addEfficiencies("L1", [("Et", "E_{T}")], "%sJet%sEff")
     _addEfficiencies("L1", [("HighEt", "E_{T}")], "%sJet%sEff", "central jet", postfix="(high E_{T})")
     _addEfficiencies("L1", [("Eta", "#eta"),
                             ("Phi", "#phi")], "%sJet%sEff", "central jet", "(E_{T} > %.1f)" % monitorModule.L1Plotter.L1JetMinEt.value())
+    _addEfficiencies("L1", [("Et", "E_{T}")], "%sETM%sEff", "ETM")
+
+    _addEfficiencies("L2", [("Et", "E_{T}"),
+                            ("Phi", "#phi")], "%sTrigMET%sEff", "MET")
 
     for level in ["L2", "L3"]:
         _addEfficiencies(level, [("Et", "p_{T}"),
                                  ("Eta", "#eta"),
                                  ("Phi", "#phi")], "%sTrigTau%sEff")
         _addEfficiencies(level, [("HighEt", "p_{T}")], "%sTrigTau%sEff", postfix="(high p_{T})")
-
+        _addEfficiencies(level, [("Et", "p_{T}"),
+                                 ("Eta", "#eta"),
+                                 ("Phi", "#phi")], "%sTrigElectron%sEff", "electron")
+        _addEfficiencies(level, [("Et", "p_{T}"),
+                                 ("Eta", "#eta"),
+                                 ("Phi", "#phi")], "%sTrigMuon%sEff", "muon")
     return (m1, m2)
 
 

--- a/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQML1Plotter.cc
@@ -31,9 +31,14 @@ HLTTauDQML1Plotter::HLTTauDQML1Plotter(const edm::ParameterSet& ps, edm::Consume
   //Process PSet
   l1ExtraTaus_      = ps.getUntrackedParameter<edm::InputTag>("L1Taus");
   l1ExtraTausToken_ = cc.consumes<l1extra::L1JetParticleCollection>(l1ExtraTaus_);
+  l1ExtraIsoTaus_      = ps.getUntrackedParameter<edm::InputTag>("L1IsoTaus");
+  l1ExtraIsoTausToken_ = cc.consumes<l1extra::L1JetParticleCollection>(l1ExtraIsoTaus_);
   l1ExtraJets_      = ps.getUntrackedParameter<edm::InputTag>("L1Jets");
   l1ExtraJetsToken_ = cc.consumes<l1extra::L1JetParticleCollection>(l1ExtraJets_);
+  l1ExtraMET_       = ps.getUntrackedParameter<edm::InputTag>("L1ETM");
+  l1ExtraMETToken_  = cc.consumes<l1extra::L1EtMissParticleCollection>(l1ExtraMET_);
   l1JetMinEt_       = ps.getUntrackedParameter<double>("L1JetMinEt");
+  l1ETMMin_         = ps.getUntrackedParameter<double>("L1ETMMin");
   configValid_ = true;
 }
 
@@ -56,12 +61,19 @@ void HLTTauDQML1Plotter::bookHistograms(DQMStore::IBooker &iBooker) {
   l1tauEt_ = iBooker.book1D("L1TauEt","L1 #tau E_{T};L1 #tau E_{T};entries",binsEt_,0,maxPt_);
   l1tauEta_ = iBooker.book1D("L1TauEta","L1 #tau #eta;L1 #tau #eta;entries",binsEta_,-maxEta_,maxEta_);
   l1tauPhi_ = iBooker.book1D("L1TauPhi","L1 #tau #phi;L1 #tau #phi;entries",binsPhi_,minPhi,maxPhi);
+
+  l1isotauEt_ = iBooker.book1D("L1IsoTauEt","L1 iso#tau E_{T};L1 iso#tau E_{T};entries",binsEt_,0,maxPt_);
+  l1isotauEta_ = iBooker.book1D("L1IsoTauEta","L1 iso#tau #eta;L1 iso#tau #eta;entries",binsEta_,-maxEta_,maxEta_);
+  l1isotauPhi_ = iBooker.book1D("L1IsoTauPhi","L1 iso#tau #phi;L1 iso#tau #phi;entries",binsPhi_,minPhi,maxPhi);
         
   l1jetEt_ = iBooker.book1D("L1JetEt","L1 central jet E_{T};L1 jet E_{T};entries",binsEt_,0,maxPt_);
   snprintf(buffer, BUFMAX, "L1 central jet #eta (E_{T} > %.1f);L1 jet #eta;entries", l1JetMinEt_);
   l1jetEta_ = iBooker.book1D("L1JetEta", buffer, binsEta_, -maxEta_, maxEta_);
   snprintf(buffer, BUFMAX, "L1 central jet #phi (E_{T} > %.1f);L1 jet #phi;entries", l1JetMinEt_);
   l1jetPhi_ = iBooker.book1D("L1JetPhi", buffer, binsPhi_, minPhi, maxPhi);
+
+  l1etmEt_  = iBooker.book1D("L1ETM","L1 ETM E_{T};L1 ETM E_{T};entries",binsEt_,0,maxPt_);
+  l1etmPhi_ = iBooker.book1D("L1ETMPhi","L1 ETM #phi;L1 ETM #phi;entries",binsPhi_,minPhi,maxPhi);
         
   snprintf(buffer, BUFMAX, "L1 leading (#tau OR central jet E_{T} > %.1f) E_{T};L1 (#tau or central jet) E_{T};entries", l1JetMinEt_);
   firstTauEt_ = iBooker.book1D("L1LeadTauEt", buffer, binsEt_, 0, maxPt_);
@@ -79,6 +91,7 @@ void HLTTauDQML1Plotter::bookHistograms(DQMStore::IBooker &iBooker) {
         
   if (doRefAnalysis_) {
     l1tauEtRes_ = iBooker.book1D("L1TauEtResol","L1 #tau E_{T} resolution;[L1 #tau E_{T}-Ref #tau E_{T}]/Ref #tau E_{T};entries",60,-1,4);
+    l1isotauEtRes_ = iBooker.book1D("L1IsoTauEtResol","L1 iso#tau E_{T} resolution;[L1 iso#tau E_{T}-Ref iso#tau E_{T}]/Ref iso#tau E_{T};entries",60,-1,4);
     snprintf(buffer, BUFMAX, "L1 central jet E_{T} resolution (E_{T} > %.1f);[L1 jet E_{T}-Ref #tau E_{T}]/Ref #tau E_{T};entries", l1JetMinEt_);
     l1jetEtRes_ = iBooker.book1D("L1JetEtResol", buffer, 60, -1, 4);
             
@@ -95,6 +108,18 @@ void HLTTauDQML1Plotter::bookHistograms(DQMStore::IBooker &iBooker) {
             
     l1tauPhiEffNum_ = iBooker.book1D("L1TauPhiEffNum","L1 #tau #phi Efficiency;Ref #tau #phi;entries",binsPhi_,minPhi,maxPhi);
     l1tauPhiEffDenom_ = iBooker.book1D("L1TauPhiEffDenom","L1 #tau #phi Denominator;Ref #tau #phi;Efficiency",binsPhi_,minPhi,maxPhi);
+
+    l1isotauEtEffNum_ = iBooker.book1D("L1IsoTauEtEffNum","L1 iso#tau E_{T} Efficiency;Ref iso#tau E_{T};entries",binsEt_,0,maxPt_);                                                                        
+    l1isotauHighEtEffNum_ = iBooker.book1D("L1IsoTauHighEtEffNum","L1 iso#tau E_{T} Efficiency (high E_{T});Ref iso#tau E_{T};entries",binsEt_,0,maxHighPt_);                                               
+                                                                                                                                                                                                
+    l1isotauEtEffDenom_ = iBooker.book1D("L1IsoTauEtEffDenom","L1 iso#tau E_{T} Denominator;Ref iso#tau E_{T};entries",binsEt_,0,maxPt_);                                                                   
+    l1isotauHighEtEffDenom_ = iBooker.book1D("L1IsoTauHighEtEffDenom","L1 iso#tau E_{T} Denominator (high E_{T});Ref iso#tau E_{T};Efficiency",binsEt_,0,maxHighPt_);                                       
+                                                                                                                                                                                                
+    l1isotauEtaEffNum_ = iBooker.book1D("L1IsoTauEtaEffNum","L1 iso#tau #eta Efficiency;Ref iso#tau #eta;entries",binsEta_,-maxEta_,maxEta_);                                                               
+    l1isotauEtaEffDenom_ = iBooker.book1D("L1IsoTauEtaEffDenom","L1 iso#tau #eta Denominator;Ref iso#tau #eta;entries",binsEta_,-maxEta_,maxEta_);                                                          
+                                                                                                                                                                                                
+    l1isotauPhiEffNum_ = iBooker.book1D("L1IsoTauPhiEffNum","L1 iso#tau #phi Efficiency;Ref iso#tau #phi;entries",binsPhi_,minPhi,maxPhi);                                                                  
+    l1isotauPhiEffDenom_ = iBooker.book1D("L1IsoTauPhiEffDenom","L1 iso#tau #phi Denominator;Ref iso#tau #phi;Efficiency",binsPhi_,minPhi,maxPhi);
             
     l1jetEtEffNum_ = iBooker.book1D("L1JetEtEffNum","L1 central jet E_{T} Efficiency;Ref #tau E_{T};entries",binsEt_,0,maxPt_);
     l1jetHighEtEffNum_ = iBooker.book1D("L1JetHighEtEffNum","L1 central jet E_{T} Efficiency (high E_{T});Ref #tau E_{T};entries",binsEt_,0,maxHighPt_);
@@ -113,6 +138,9 @@ void HLTTauDQML1Plotter::bookHistograms(DQMStore::IBooker &iBooker) {
             
     snprintf(buffer, BUFMAX, "L1 central jet #phi Efficiency (E_{T} > %.1f);Ref #tau #phi;Efficiency", l1JetMinEt_);
     l1jetPhiEffDenom_ = iBooker.book1D("L1JetPhiEffDenom", buffer, binsPhi_, minPhi, maxPhi);
+
+    l1etmEtEffNum_ = iBooker.book1D("L1ETMEtEffNum", "L1 ETM Efficiency;Ref MET;entries",binsEt_, 0, maxPt_);
+    l1etmEtEffDenom_ = iBooker.book1D("L1ETMEtEffDenom","L1 ETM Denominator;Ref MET;entries",binsEt_,0,maxPt_);
   }
 }
 
@@ -129,29 +157,40 @@ void HLTTauDQML1Plotter::analyze( const edm::Event& iEvent, const edm::EventSetu
         //Tau reference
         for ( LVColl::const_iterator iter = refC.taus.begin(); iter != refC.taus.end(); ++iter ) {
             l1tauEtEffDenom_->Fill(iter->pt());
+            l1isotauEtEffDenom_->Fill(iter->pt());
             l1jetEtEffDenom_->Fill(iter->pt());
             l1tauHighEtEffDenom_->Fill(iter->pt());
+            l1isotauHighEtEffDenom_->Fill(iter->pt());
             l1jetHighEtEffDenom_->Fill(iter->pt());
             
             l1tauEtaEffDenom_->Fill(iter->eta());
+            l1isotauEtaEffDenom_->Fill(iter->eta());
             l1jetEtaEffDenom_->Fill(iter->eta());
             
             l1tauPhiEffDenom_->Fill(iter->phi());
+            l1isotauPhiEffDenom_->Fill(iter->phi());
             l1jetPhiEffDenom_->Fill(iter->phi());
         }
+	if(refC.met.size() > 0) l1etmEtEffDenom_->Fill(refC.met[0].pt());
     }
     
     //Analyze L1 Objects (Tau+Jets)
     edm::Handle<l1extra::L1JetParticleCollection> taus;
+    edm::Handle<l1extra::L1JetParticleCollection> isotaus;
     edm::Handle<l1extra::L1JetParticleCollection> jets;
+    edm::Handle<l1extra::L1EtMissParticleCollection> met;
     iEvent.getByToken(l1ExtraTausToken_, taus);
+    iEvent.getByToken(l1ExtraIsoTausToken_, isotaus);
     iEvent.getByToken(l1ExtraJetsToken_, jets);
+    iEvent.getByToken(l1ExtraMETToken_, met);
     
     LVColl pathTaus;
     
     //Set Variables for the threshold plot
     LVColl l1taus;
+    LVColl l1isotaus;
     LVColl l1jets;
+    LVColl l1met;
 
     if(taus.isValid()) {
       for(l1extra::L1JetParticleCollection::const_iterator i = taus->begin(); i != taus->end(); ++i) {
@@ -166,6 +205,21 @@ void HLTTauDQML1Plotter::analyze( const edm::Event& iEvent, const edm::EventSetu
     }
     else {
       edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 tau collection " << l1ExtraTaus_.encode();
+    }
+
+    if(isotaus.isValid()) {
+      for(l1extra::L1JetParticleCollection::const_iterator i = isotaus->begin(); i != isotaus->end(); ++i) {
+        l1isotaus.push_back(i->p4());
+        if(!doRefAnalysis_) {
+          l1isotauEt_->Fill(i->et());
+          l1isotauEta_->Fill(i->eta());
+          l1isotauPhi_->Fill(i->phi());
+          pathTaus.push_back(i->p4());
+        }
+      }
+    }
+    else {
+      edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 isotau collection " << l1ExtraIsoTaus_.encode();
     }
 
     if(jets.isValid()) {
@@ -184,7 +238,16 @@ void HLTTauDQML1Plotter::analyze( const edm::Event& iEvent, const edm::EventSetu
     else {
       edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 jet collection " << l1ExtraJets_.encode();
     }
-    
+
+    if(met.isValid()) {
+      if(!doRefAnalysis_) {
+	if( met.product()->begin()->et() > l1ETMMin_) l1etmEt_->Fill(met.product()->begin()->et());
+      }
+    }
+    else {
+      edm::LogWarning("HLTTauDQMOffline") << "HLTTauDQML1Plotter::analyze: unable to read L1 met collection " << l1ExtraMET_.encode();
+    }
+
     //Now do the efficiency matching
     if ( doRefAnalysis_ ) {
         for ( LVColl::const_iterator i = refC.taus.begin(); i != refC.taus.end(); ++i ) {
@@ -206,6 +269,24 @@ void HLTTauDQML1Plotter::analyze( const edm::Event& iEvent, const edm::EventSetu
         }
         
         for ( LVColl::const_iterator i = refC.taus.begin(); i != refC.taus.end(); ++i ) {
+            std::pair<bool,LV> m = match(*i,l1isotaus,matchDeltaR_);
+            if ( m.first ) {
+                l1isotauEt_->Fill(m.second.pt());
+                l1isotauEta_->Fill(m.second.eta());  
+                l1isotauPhi_->Fill(m.second.phi());  
+         
+                l1isotauEtEffNum_->Fill(i->pt());
+                l1isotauHighEtEffNum_->Fill(i->pt());
+                l1isotauEtaEffNum_->Fill(i->eta());
+                l1isotauPhiEffNum_->Fill(i->phi());
+             
+                l1isotauEtRes_->Fill((m.second.pt()-i->pt())/i->pt());
+    
+                pathTaus.push_back(m.second);
+            }
+        }
+
+        for ( LVColl::const_iterator i = refC.taus.begin(); i != refC.taus.end(); ++i ) {
             std::pair<bool,LV> m = match(*i,l1jets,matchDeltaR_);
             if ( m.first ) {
                 l1jetEt_->Fill(m.second.pt());
@@ -224,6 +305,15 @@ void HLTTauDQML1Plotter::analyze( const edm::Event& iEvent, const edm::EventSetu
                 }
             }
         }
+
+	if(met.isValid()) {
+          l1etmEt_->Fill(met.product()->begin()->et());
+          l1etmPhi_->Fill(met.product()->begin()->phi());
+
+	  if( met.product()->begin()->et() > l1ETMMin_){
+            l1etmEtEffNum_->Fill(met.product()->begin()->et());
+	  }
+	}
     }
     
     

--- a/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMOfflineSource.cc
@@ -148,6 +148,9 @@ void HLTTauDQMOfflineSource::analyze(const Event& iEvent, const EventSetup& iSet
             else if(refObj.objID == 15) {
               refC.taus.insert(refC.taus.end(), collHandle->begin(), collHandle->end());
             }
+            else if(refObj.objID == 0) {
+              refC.met.insert(refC.met.end(), collHandle->begin(), collHandle->end());
+            }
           }
         }
         

--- a/DQMOffline/Trigger/src/HLTTauDQMPath.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPath.cc
@@ -8,6 +8,10 @@
 #include "DataFormats/HLTReco/interface/TriggerEvent.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
+#include "FWCore/Common/interface/TriggerNames.h"
+#include "FWCore/ServiceRegistry/interface/Service.h"
+#include "FWCore/Framework/interface/TriggerNamesService.h"
+
 #include<cstdio>
 #include<sstream>
 #include<algorithm>
@@ -23,11 +27,13 @@ namespace {
     typedef HLTTauDQMPath::FilterIndex FilterIndex;
     typedef std::tuple<typename std::tuple_element<0, FilterIndex>::type,
                        typename std::tuple_element<1, FilterIndex>::type,
+                       typename std::tuple_element<2, FilterIndex>::type,
                        bool> FilterIndexSave;
 
     constexpr static size_t kName = HLTTauDQMPath::kName;
+    constexpr static size_t kType = HLTTauDQMPath::kType;
     constexpr static size_t kModuleIndex = HLTTauDQMPath::kModuleIndex;
-    constexpr static size_t kSaveTags = 2;
+    constexpr static size_t kSaveTags = 3;
 
     std::vector<FilterIndex> interestingFilters(const HLTConfigProvider& HLTCP, bool doRefAnalysis) {
       const std::vector<std::string>& moduleLabels = HLTCP.moduleLabels(name_);
@@ -48,9 +54,9 @@ namespace {
           continue;
         if(type == "HLT2PhotonPFTau" || type == "HLT2ElectronPFTau" || type == "HLT2MuonPFTau" || type == "HLT2PhotonTau" || type == "HLT2ElectronTau" || type == "HLT2MuonTau")
           leptonTauFilters.emplace_back(*iLabel);
-        else if(type.find("Electron") != std::string::npos || type.find("Egamma") != std::string::npos || type.find("Muon") != std::string::npos)
-          continue;
-        allInterestingFilters_.emplace_back(*iLabel, iLabel-moduleLabels.begin(), HLTCP.saveTags(*iLabel));
+//        else if(type.find("Electron") != std::string::npos || type.find("Egamma") != std::string::npos || type.find("Muon") != std::string::npos)
+//          continue;
+        allInterestingFilters_.emplace_back(*iLabel, type, iLabel-moduleLabels.begin(), HLTCP.saveTags(*iLabel));
       }
 
       // Insert the last filters of lepton legs
@@ -60,16 +66,18 @@ namespace {
         std::string input2 = pset.getParameter<edm::InputTag>("inputTag2").label();
         unsigned idx1 = HLTCP.moduleIndex(name_, input1);
         unsigned idx2 = HLTCP.moduleIndex(name_, input2);
+        std::string type = "dummy";//HLTCP.moduleType(name_);
 
         auto func = [&](const FilterIndexSave& a, unsigned idxb) {
           return std::get<kModuleIndex>(a) < idxb;
         };
+
         std::vector<FilterIndexSave>::iterator found = std::lower_bound(allInterestingFilters_.begin(), allInterestingFilters_.end(), idx1, func);
         if(found == allInterestingFilters_.end() || std::get<kModuleIndex>(*found) != idx1)
-          allInterestingFilters_.emplace(found, input1, idx1, HLTCP.saveTags(input1));
+          allInterestingFilters_.emplace(found, input1, type, idx1, HLTCP.saveTags(input1));
         found = std::lower_bound(allInterestingFilters_.begin(), allInterestingFilters_.end(), idx2, func);
         if(found == allInterestingFilters_.end() || std::get<kModuleIndex>(*found) != idx2)
-          allInterestingFilters_.emplace(found, input2, idx2, HLTCP.saveTags(input1));
+          allInterestingFilters_.emplace(found, input2, type, idx2, HLTCP.saveTags(input1));
       }
 
       std::vector<FilterIndex> selectedFilters;
@@ -77,8 +85,9 @@ namespace {
       // However, they are needed a bit later to find the position of the
       // first L3 tau filter.
       for(const auto& item: allInterestingFilters_) {
-        if(!doRefAnalysis || (doRefAnalysis && std::get<kSaveTags>(item)))
-          selectedFilters.emplace_back(std::get<kName>(item), std::get<kModuleIndex>(item));
+        if(!doRefAnalysis || (doRefAnalysis && std::get<kSaveTags>(item))){
+          selectedFilters.emplace_back(std::get<kName>(item), std::get<kType>(item), std::get<kModuleIndex>(item));
+	}
       }
 
       return selectedFilters;
@@ -88,6 +97,24 @@ namespace {
       const std::string type = HLTCP.moduleType(producerLabel);
       if(type == "PFRecoTauProducer" || type == "RecoTauPiZeroUnembedder") {
         LogDebug("HLTTauDQMOffline") << "Found tau producer " << type << " with label " << producerLabel << " from path " << name_;
+        return true;
+      }
+      return false;
+    }
+
+    bool isL3ElectronProducer(const HLTConfigProvider& HLTCP, const std::string& producerLabel) const {
+      const std::string type = HLTCP.moduleType(producerLabel);
+      if(type == "EgammaHLTPixelMatchElectronProducers") {
+        LogDebug("HLTTauDQMOffline") << "Found electron producer " << type << " with label " << producerLabel << " from path " << name_;
+        return true;
+      }
+      return false;
+    }
+
+    bool isL3MuonProducer(const HLTConfigProvider& HLTCP, const std::string& producerLabel) const {
+      const std::string type = HLTCP.moduleType(producerLabel);
+      if(type == "L3MuonCandidateProducer" || type == "L3MuonCombinedRelativeIsolationProducer") {
+        LogDebug("HLTTauDQMOffline") << "Found muon producer " << type << " with label " << producerLabel << " from path " << name_;   
         return true;
       }
       return false;
@@ -104,11 +131,53 @@ namespace {
       return false;
     }
 
+    bool isL3ElectronFilter(const HLTConfigProvider& HLTCP, const std::string& filterLabel) const {
+      const edm::ParameterSet& pset = HLTCP.modulePSet(filterLabel);
+      if(pset.exists("inputTag"))
+        return isL3ElectronProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag").label());
+      if(pset.exists("inputTag1"))
+        return isL3ElectronProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag1").label());
+      if(pset.exists("inputTag2"))
+        return isL3ElectronProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag2").label());
+      return false;
+    }
+
+    bool isL3MuonFilter(const HLTConfigProvider& HLTCP, const std::string& filterLabel) const {   
+      const edm::ParameterSet& pset = HLTCP.modulePSet(filterLabel);
+      if(pset.exists("inputTag"))
+        return isL3MuonProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag").label());   
+      if(pset.exists("inputTag1"))
+        return isL3MuonProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag1").label());   
+      if(pset.exists("inputTag2"))
+        return isL3MuonProducer(HLTCP, pset.getParameter<edm::InputTag>("inputTag2").label());   
+      return false;
+    }
+
     size_t firstL3TauFilterIndex(const HLTConfigProvider& HLTCP) const {
       // Loop over filters and check if a filter uses L3 tau producer
       // output.
       for(const auto& filter: allInterestingFilters_) {
         if(isL3TauFilter(HLTCP, std::get<kName>(filter)))
+          return std::get<kModuleIndex>(filter);
+      }
+      return HLTTauDQMPath::kInvalidIndex;
+    }
+
+    size_t firstL3ElectronFilterIndex(const HLTConfigProvider& HLTCP) const {
+      // Loop over filters and check if a filter uses L3 tau producer
+      // output.
+      for(const auto& filter: allInterestingFilters_) {
+        if(isL3ElectronFilter(HLTCP, std::get<kName>(filter)))
+          return std::get<kModuleIndex>(filter);
+      }
+      return HLTTauDQMPath::kInvalidIndex;
+    }
+
+    size_t firstL3MuonFilterIndex(const HLTConfigProvider& HLTCP) const {   
+      // Loop over filters and check if a filter uses L3 tau producer
+      // output.
+      for(const auto& filter: allInterestingFilters_) {
+        if(isL3MuonFilter(HLTCP, std::get<kName>(filter)))   
           return std::get<kModuleIndex>(filter);
       }
       return HLTTauDQMPath::kInvalidIndex;
@@ -133,15 +202,18 @@ namespace {
   }
 
   struct TauLeptonMultiplicity {
-    TauLeptonMultiplicity(): tau(0), electron(0), muon(0) {}
+    TauLeptonMultiplicity(): tau(0), electron(0), muon(0), met(0), level(0) {}
     int tau;
     int electron;
     int muon;
+    int met;
+    int level;
   };
   TauLeptonMultiplicity inferTauLeptonMultiplicity(const HLTConfigProvider& HLTCP, const std::string& filterName, const std::string& moduleType, const std::string& pathName) {
     TauLeptonMultiplicity n;
-
+//std::cout << "check menu " << HLTCP.tableName() << std::endl;
     if(moduleType == "HLTLevel1GTSeed") {
+      n.level = 1;
       if(filterName.find("Single") != std::string::npos) {
 	if(filterName.find("Mu") != std::string::npos) {
 	  n.muon = 1;
@@ -153,16 +225,33 @@ namespace {
       else if(filterName.find("Double") != std::string::npos && filterName.find("Tau") != std::string::npos) {
         n.tau = 2;
       }
-      else if(filterName.find("Mu") != std::string::npos && filterName.find("Tau") != std::string::npos) { 
+//      else if(filterName.find("Mu") != std::string::npos && filterName.find("Tau") != std::string::npos) {
+      if(filterName.find("Mu") != std::string::npos) { 
 	n.muon = 1;
 	//n.tau = 1;
       }
-      else if(filterName.find("EG") != std::string::npos && filterName.find("Tau") != std::string::npos) { 
+      if(filterName.find("EG") != std::string::npos && filterName.find("Tau") != std::string::npos) { 
 	n.electron = 1;
 	//n.tau = 1;
       }
+      if(filterName.find("ETM") != std::string::npos) {
+	n.met = 1;
+      }
     }
-    else if(moduleType == "HLT1CaloJet" || moduleType == "HLT1PFJet") {
+    else if(moduleType == "HLT1CaloMET") {
+      n.level = 2;
+      if(getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerMET) {
+        n.met = 1;
+      }
+    }
+    else if(moduleType == "HLT1CaloJet") {
+      n.level = 2;
+      if(getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerTau) {
+        n.tau = getParameterSafe(HLTCP, filterName, "MinN");
+      }
+    }
+    else if(moduleType == "HLT1PFJet") {
+      n.level = 3;
       //const edm::ParameterSet& pset = HLTCP.modulePSet(filterName);
       //pset.getParameter<int>("triggerType") == trigger::TriggerTau) {
       if(getParameterSafe(HLTCP, filterName, "triggerType") == trigger::TriggerTau) {
@@ -171,6 +260,7 @@ namespace {
       }
     }
     else if(moduleType == "HLTCaloJetTag") {
+      n.level = 2;
       //const edm::ParameterSet& pset = HLTCP.modulePSet(filterName);
       //if(pset.getParameter<int>("triggerType") == trigger::TriggerTau) {
       if(getParameterSafe(HLTCP, filterName, "TriggerType") == trigger::TriggerTau) {
@@ -179,39 +269,56 @@ namespace {
       }
     }
     else if(moduleType == "HLT1Tau" || moduleType == "HLT1PFTau") {
+      n.level = 3;
       //n.tau = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
       n.tau = getParameterSafe(HLTCP, filterName, "MinN");
     }
     else if(moduleType == "HLTPFTauPairDzMatchFilter") {
+      n.level = 3;
       n.tau = 2;
     }
-    else if(moduleType == "HLTElectronGenericFilter" || moduleType == "HLTEgammaGenericFilter") {
+    else if(moduleType == "HLTEgammaGenericFilter") {
+      n.level = 3;
+      n.electron = getParameterSafe(HLTCP, filterName, "ncandcut");
+    }
+    else if(moduleType == "HLTElectronGenericFilter") {
+      n.level = 3;
       //n.electron = HLTCP.modulePSet(filterName).getParameter<int>("ncandcut");
       n.electron = getParameterSafe(HLTCP, filterName, "ncandcut");
     }
-    else if(moduleType == "HLTMuonIsoFilter" || moduleType == "HLTMuonL3PreFilter") {
+    else if(moduleType == "HLTMuonL2PreFilter") {
+      n.level = 2;
       //n.muon = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
       n.muon = getParameterSafe(HLTCP, filterName, "MinN");
     }
+    else if(moduleType == "HLTMuonIsoFilter" || moduleType == "HLTMuonL3PreFilter") {
+      n.level = 3;
+      n.muon = getParameterSafe(HLTCP, filterName, "MinN");
+    }
+    else if(moduleType == "HLTMuonGenericFilter") {
+      n.level = 3;
+      n.muon = 1;
+    }
     else if(moduleType == "HLT2ElectronTau" || moduleType == "HLT2ElectronPFTau" || moduleType == "HLT2PhotonTau" || moduleType == "HLT2PhotonPFTau") {
+      n.level = 3;
       //int num = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
       int num = getParameterSafe(HLTCP, filterName, "MinN");
       n.tau = num;
       n.electron = num;
     }
     else if(moduleType == "HLT2MuonTau" || moduleType == "HLT2MuonPFTau") {
+      n.level = 3;
       //int num = HLTCP.modulePSet(filterName).getParameter<int>("MinN");
       int num = getParameterSafe(HLTCP, filterName, "MinN");
       n.tau = num;
       n.muon = num;
     }
-    else if(moduleType == "HLTPrescaler" || moduleType == "HLT1CaloMET") {
+    else if(moduleType == "HLTPrescaler"){// || moduleType == "HLT1CaloMET") {
       // ignore
     }
     else {
       edm::LogWarning("HLTTauDQMOfflineSource") << "HLTTauDQMPath.cc, inferTauLeptonMultiplicity(): module type '" << moduleType << "' not recognized, filter '" << filterName << "' in path '" << pathName << "' will be ignored for offline matching." << std::endl;
     }
-
     return n;
   }
 
@@ -248,6 +355,11 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
   pathIndex_(HLTCP.triggerIndex(pathName_)),
   lastFilterBeforeL2TauIndex_(0), lastL2TauFilterIndex_(0),
   lastFilterBeforeL3TauIndex_(0), lastL3TauFilterIndex_(0),
+  lastFilterBeforeL2ElectronIndex_(0), lastL2ElectronFilterIndex_(0),
+  lastFilterBeforeL2MuonIndex_(0), lastL2MuonFilterIndex_(0),   
+  lastFilterBeforeL2METIndex_(0), lastL2METFilterIndex_(0), 
+  firstFilterBeforeL2METIndex_(0), firstL2METFilterIndex_(0),
+
   isFirstL1Seed_(false),
   isValid_(false)
 {
@@ -255,7 +367,6 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
   std::stringstream ss;
   ss << "HLTTauDQMPath: " << pathName_ << "\n";
 #endif
-
   // Get the filters
   HLTPath thePath(pathName_);
   filterIndices_ = thePath.interestingFilters(HLTCP, doRefAnalysis_);
@@ -271,9 +382,12 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
   filterTauN_.clear();
   filterElectronN_.clear();
   filterMuonN_.clear();
+  filterMET_.clear();
   filterTauN_.reserve(filterIndices_.size());
   filterElectronN_.reserve(filterIndices_.size());
   filterMuonN_.reserve(filterIndices_.size());
+  filterMET_.reserve(filterIndices_.size());
+  filterLevel_.reserve(filterIndices_.size());
   for(size_t i=0; i<filterIndices_.size(); ++i) {
     const std::string& filterName = std::get<kName>(filterIndices_[i]);
     const std::string& moduleType = HLTCP.moduleType(filterName);
@@ -282,21 +396,21 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
     filterTauN_.push_back(n.tau);
     filterElectronN_.push_back(n.electron);
     filterMuonN_.push_back(n.muon);
+    filterMET_.push_back(n.met);
+    filterLevel_.push_back(n.level);
 
 #ifdef EDM_ML_DEBUG
-    ss << "\n    " << std::get<kModuleIndex>(filterIndices_[i])
+    ss << "\n    " << i << " " << std::get<kModuleIndex>(filterIndices_[i])
        << " " << filterName
        << " " << moduleType
        << " ntau " << n.tau
        << " nele " << n.electron
        << " nmu " << n.muon;
 #endif
-
   }
 #ifdef EDM_ML_DEBUG
   LogDebug("HLTTauDQMOffline") << ss.str();
 #endif
-
 
   // Find the position of tau producer, use filters with taus before
   // it for L2 tau efficiency, and filters with taus after it for L3
@@ -308,11 +422,32 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
   if(firstL3TauFilterIndex == kInvalidIndex) {
     edm::LogInfo("HLTTauDQMOffline") << "Did not find a filter with L3 tau producer as input in path " << pathName_;
   }
+  const size_t firstL3ElectronFilterIndex = thePath.firstL3ElectronFilterIndex(HLTCP);
+  if(firstL3ElectronFilterIndex == kInvalidIndex) {
+    edm::LogInfo("HLTTauDQMOffline") << "Did not find a filter with L3 electron producer as input in path " << pathName_;
+  }
+  const size_t firstL3MuonFilterIndex = thePath.firstL3MuonFilterIndex(HLTCP);   
+  if(firstL3MuonFilterIndex == kInvalidIndex) {   
+    edm::LogInfo("HLTTauDQMOffline") << "Did not find a filter with L3 muon producer as input in path " << pathName_;  
+  }
 
   lastFilterBeforeL2TauIndex_ = 0;
   lastL2TauFilterIndex_ = kInvalidIndex;
   lastFilterBeforeL3TauIndex_ = 0;
   lastL3TauFilterIndex_ = kInvalidIndex;
+  lastFilterBeforeL2ElectronIndex_ = 0;
+  lastL2ElectronFilterIndex_ = kInvalidIndex;
+  lastFilterBeforeL3ElectronIndex_ = 0;
+  lastL3ElectronFilterIndex_ = kInvalidIndex;
+  lastFilterBeforeL2MuonIndex_ = 0;
+  lastL2MuonFilterIndex_ = kInvalidIndex;
+  lastFilterBeforeL3MuonIndex_ = 0;
+  lastL3MuonFilterIndex_ = kInvalidIndex;
+  lastFilterBeforeL2METIndex_ = 0;
+  lastL2METFilterIndex_ = kInvalidIndex;
+  firstFilterBeforeL2METIndex_ = 0;
+  firstL2METFilterIndex_ = kInvalidIndex;
+/*
   size_t i = 0;
   for(; i<filtersSize() && getFilterIndex(i) < firstL3TauFilterIndex; ++i) {
     if(lastL2TauFilterIndex_ == kInvalidIndex && getFilterNTaus(i) == 0)
@@ -327,6 +462,68 @@ HLTTauDQMPath::HLTTauDQMPath(const std::string& pathName, const std::string& hlt
     if(getFilterNTaus(i) > 0 && getFilterNElectrons(i) == 0 && getFilterNMuons(i) == 0)
       lastL3TauFilterIndex_ = i;
   }
+*/
+  for(size_t i = 0; i<filtersSize(); ++i) {
+    // Tau
+    if(getFilterLevel(i) == 2 && getFilterNTaus(i) > 0 && getFilterNElectrons(i) == 0 && getFilterNMuons(i) == 0)
+      lastL2TauFilterIndex_ = i;
+    if(lastL2TauFilterIndex_ == kInvalidIndex)
+      lastFilterBeforeL2TauIndex_ = i;
+
+//    if(lastFilterBeforeL3TauIndex_ < 2 && lastL3TauFilterIndex_ == kInvalidIndex && getFilterNTaus(i) == 0)
+//      lastFilterBeforeL3TauIndex_ = i;
+    if(getFilterLevel(i) == 3 && getFilterNTaus(i) > 0 && getFilterNElectrons(i) == 0 && getFilterNMuons(i) == 0)
+      lastL3TauFilterIndex_ = i;
+    if(lastL3TauFilterIndex_ == kInvalidIndex)
+      lastFilterBeforeL3TauIndex_ = i;
+
+    // Electron
+    if(lastL2ElectronFilterIndex_ == kInvalidIndex && getFilterNElectrons(i) == 0)
+      lastFilterBeforeL2ElectronIndex_ = i;
+    if(getFilterLevel(i) == 2 && getFilterNElectrons(i) > 0 && getFilterNTaus(i) == 0 && getFilterNMuons(i) == 0)
+      lastL2ElectronFilterIndex_ = i;
+    
+    if(getFilterLevel(i) == 3 && getFilterNElectrons(i) > 0 && getFilterNTaus(i) == 0 && getFilterNMuons(i) == 0)
+      lastL3ElectronFilterIndex_ = i;
+    if(lastL3ElectronFilterIndex_ == kInvalidIndex)
+      lastFilterBeforeL3ElectronIndex_ = i;
+/*
+    if(lastL2ElectronFilterIndex_ == kInvalidIndex && getFilterNElectrons(i) == 0)
+      lastFilterBeforeL2ElectronIndex_ = i;
+    if(getFilterNElectrons(i) > 0 && getFilterNTaus(i) == 0 && getFilterNMuons(i) == 0)
+      lastL2ElectronFilterIndex_ = i;
+    
+    if(lastFilterBeforeL3ElectronIndex_ == 0 && lastL3ElectronFilterIndex_ == kInvalidIndex && getFilterNElectrons(i) == 0)
+      lastFilterBeforeL3ElectronIndex_ = i;
+    if(getFilterNElectrons(i) > 0 && getFilterNTaus(i) == 0 && getFilterNMuons(i) == 0)
+      lastL3ElectronFilterIndex_ = i;
+*/
+    // Muon
+    if(lastL2MuonFilterIndex_ == kInvalidIndex && getFilterNMuons(i) == 0)   
+      lastFilterBeforeL2MuonIndex_ = i;
+    if(getFilterLevel(i) == 2 && getFilterNMuons(i) > 0 && getFilterNTaus(i) == 0 && getFilterNElectrons(i) == 0)         
+      lastL2MuonFilterIndex_ = i;
+
+    if(getFilterLevel(i) == 3 && getFilterNMuons(i) > 0 && getFilterNTaus(i) == 0 && getFilterNElectrons(i) == 0)        
+      lastL3MuonFilterIndex_ = i;
+    if(lastL3MuonFilterIndex_ == kInvalidIndex)
+      lastFilterBeforeL3MuonIndex_ = i;
+
+
+    // MET
+    if(lastL2METFilterIndex_ == kInvalidIndex && getFilterMET(i) == 0)
+      lastFilterBeforeL2METIndex_ = i;
+    if(getFilterMET(i) > 0 && getFilterNElectrons(i) == 0 && getFilterNMuons(i) == 0)
+      lastL2METFilterIndex_ = i;
+
+    if(firstL2METFilterIndex_ == kInvalidIndex && getFilterMET(i) == 0)
+      firstFilterBeforeL2METIndex_ = i;
+    if(firstL2METFilterIndex_ == kInvalidIndex && getFilterMET(i) > 0 && getFilterNElectrons(i) == 0 && getFilterNMuons(i) == 0)
+      firstL2METFilterIndex_ = i;  
+  }
+//  lastFilterBeforeL3TauIndex_      = firstL3TauFilterIndex - 1;
+// lastFilterBeforeL3ElectronIndex_ = firstL3ElectronFilterIndex - 1;
+//  lastFilterBeforeL3MuonIndex_     = firstL3MuonFilterIndex - 1;
   LogDebug("HLTTauDQMOffline") << "lastFilterBeforeL2 " << lastFilterBeforeL2TauIndex_
                                    << " lastL2TauFilter " << lastL2TauFilterIndex_
                                    << " lastFilterBeforeL3 " << lastFilterBeforeL3TauIndex_
@@ -342,6 +539,7 @@ bool HLTTauDQMPath::fired(const edm::TriggerResults& triggerResults) const {
 }
 
 int HLTTauDQMPath::lastPassedFilter(const edm::TriggerResults& triggerResults) const {
+
   if(fired(triggerResults)) {
     //std::cout << "Event passed" << std::endl;
     return filterIndices_.size()-1;
@@ -367,11 +565,9 @@ void HLTTauDQMPath::getFilterObjects(const trigger::TriggerEvent& triggerEvent, 
     const trigger::Keys& keys = triggerEvent.filterKeys(filterIndex);
     const trigger::Vids& ids = triggerEvent.filterIds(filterIndex);
     const trigger::TriggerObjectCollection& triggerObjects = triggerEvent.getObjects();
-    //std::cout << "Filter name " << getFilterName(i) << std::endl;
     for(size_t i=0; i<keys.size(); ++i) {
       const trigger::TriggerObject& object = triggerObjects[keys[i]];
       retval.emplace_back(Object{object, ids[i]});
-      //std::cout << "  object id " <<  object.id() << std::endl;
     }
   }
 }
@@ -379,7 +575,7 @@ void HLTTauDQMPath::getFilterObjects(const trigger::TriggerEvent& triggerEvent, 
 bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& triggerObjects, const HLTTauDQMOfflineObjects& offlineObjects, double dR, std::vector<Object>& matchedTriggerObjects, HLTTauDQMOfflineObjects& matchedOfflineObjects) const {
   bool isL1 = (i==0 && isFirstL1Seed_);
   std::vector<bool> offlineMask;
-  if(filterTauN_[i] > 0) {
+  if(filterLevel_[i] == 3 && filterTauN_[i] > 0) {
     int matchedObjects = 0;
     offlineMask.resize(offlineObjects.taus.size());
     std::fill(offlineMask.begin(), offlineMask.end(), true);
@@ -391,12 +587,14 @@ bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& trigger
       if(deltaRmatch(trgObj.object, offlineObjects.taus, dR, offlineMask, matchedOfflineObjects.taus)) {
         ++matchedObjects;
         matchedTriggerObjects.emplace_back(trgObj);
+      //std::cout << "trigger object DR match" << std::endl;
       }
     }
-    if(matchedObjects < filterTauN_[i])
+////    if(matchedObjects < filterTauN_[i])
+    if(matchedObjects == 0)
       return false;
   }
-  if(filterElectronN_[i] > 0) {
+  if(filterLevel_[i] == 3 && filterElectronN_[i] > 0) {
     int matchedObjects = 0;
     offlineMask.resize(offlineObjects.electrons.size());
     std::fill(offlineMask.begin(), offlineMask.end(), true);
@@ -413,7 +611,7 @@ bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& trigger
     if(matchedObjects < filterElectronN_[i])
       return false;
   }
-  if(filterMuonN_[i] > 0) {
+  if(filterLevel_[i] == 3 && filterMuonN_[i] > 0) {
     int matchedObjects = 0;
     offlineMask.resize(offlineObjects.muons.size());
     std::fill(offlineMask.begin(), offlineMask.end(), true);
@@ -430,11 +628,27 @@ bool HLTTauDQMPath::offlineMatching(size_t i, const std::vector<Object>& trigger
     if(matchedObjects < filterMuonN_[i])
       return false;
   }
+  if(filterMET_[i] > 0) {
+    int matchedObjects = 0;
+    offlineMask.resize(offlineObjects.met.size());
+    std::fill(offlineMask.begin(), offlineMask.end(), true);
+    for(const Object& trgObj: triggerObjects) {
+      if(! ((isL1 && trgObj.id == trigger::TriggerL1ETM)
+            || trgObj.id == trigger::TriggerMET) )
+        continue;
+      ++matchedObjects;
+      matchedTriggerObjects.emplace_back(trgObj);
+    }
+    if(matchedObjects < filterMET_[i]){
+      return false;
+    }
+  }
+
   // Sort offline objects by pt
   std::sort(matchedOfflineObjects.taus.begin(), matchedOfflineObjects.taus.end(), [](const LV& a, const LV&b) { return a.pt() > b.pt();});
   std::sort(matchedOfflineObjects.electrons.begin(), matchedOfflineObjects.electrons.end(), [](const LV& a, const LV&b) { return a.pt() > b.pt();});
   std::sort(matchedOfflineObjects.muons.begin(), matchedOfflineObjects.muons.end(), [](const LV& a, const LV&b) { return a.pt() > b.pt();});
-
+  matchedOfflineObjects.met = offlineObjects.met;
   return true;
 }
 

--- a/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
+++ b/DQMOffline/Trigger/src/HLTTauDQMPathPlotter.cc
@@ -31,6 +31,7 @@ HLTTauDQMPathPlotter::HLTTauDQMPathPlotter(const std::string& pathName, const HL
   configValid_ = configValid_ && hltPath_.isValid();
 }
 
+#include <algorithm>
 void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker &iBooker) {
   if(!isValid())
     return;
@@ -42,10 +43,6 @@ void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker &iBooker) {
   for(size_t i=0; i<hltPath_.filtersSize(); ++i) {
     hAcceptedEvents_->setBinLabel(i+1, hltPath_.getFilterName(i));
   }
-
-  hTrigTauEt_ = iBooker.book1D("TrigTauEt",   "Triggered #tau p_{T};#tau p_{T};entries", ptbins_,     0, ptmax_);
-  hTrigTauEta_ = iBooker.book1D("TrigTauEta", "Triggered #tau #eta;#tau #eta;entries",  etabins_, -2.5, 2.5);
-  hTrigTauPhi_ = iBooker.book1D("TrigTauPhi", "Triggered #tau #phi;#tau #phi;entries",  phibins_, -3.2, 3.2);
 
   // Efficiency helpers
   if(doRefAnalysis_) {
@@ -71,6 +68,48 @@ void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker &iBooker) {
       hL3TrigTauHighEtEffNum_    = iBooker.book1D("L3TrigTauHighEtEffNum",    "L3 #tau p_{T} efficiency (high p_{T});Ref #tau p_{T};entries", ptbins_, 0, highptmax_);
       hL3TrigTauHighEtEffDenom_  = iBooker.book1D("L3TrigTauHighEtEffDenom",  "L3 #tau p_{T} denominator (high p_{T});Ref #tau p_{T};Efficiency", ptbins_, 0, highptmax_);
     }
+
+    if(hltPath_.hasL2Electrons()) {
+      hL2TrigElectronEtEffNum_    = iBooker.book1D("L2TrigElectronEtEffNum",    "L2 electron p_{T} efficiency;Ref electron p_{T};entries", ptbins_, 0, ptmax_);
+      hL2TrigElectronEtEffDenom_  = iBooker.book1D("L2TrigElectronEtEffDenom",  "L2 electron p_{T} denominator;Ref electron p_{T};Efficiency", ptbins_, 0, ptmax_);
+      hL2TrigElectronEtaEffNum_   = iBooker.book1D("L2TrigElectronEtaEffNum",   "L2 electron #eta efficiency;Ref electron #eta;entries", etabins_, -2.5, 2.5);
+      hL2TrigElectronEtaEffDenom_ = iBooker.book1D("L2TrigElectronEtaEffDenom", "L2 electron #eta denominator;Ref electron #eta;Efficiency", etabins_, -2.5, 2.5);
+      hL2TrigElectronPhiEffNum_   = iBooker.book1D("L2TrigElectronPhiEffNum",   "L2 electron #phi efficiency;Ref electron #phi;entries", phibins_, -3.2, 3.2);
+      hL2TrigElectronPhiEffDenom_ = iBooker.book1D("L2TrigElectronPhiEffDenom", "L2 electron #phi denominator;Ref electron #phi;Efficiency", phibins_, -3.2, 3.2);
+    }
+  
+    if(hltPath_.hasL3Electrons()) {
+      hL3TrigElectronEtEffNum_    = iBooker.book1D("L3TrigElectronEtEffNum",    "L3 electron p_{T} efficiency;Ref electron p_{T};entries", ptbins_, 0, ptmax_);
+      hL3TrigElectronEtEffDenom_  = iBooker.book1D("L3TrigElectronEtEffDenom",  "L3 electron p_{T} denominator;Ref electron p_{T};Efficiency", ptbins_, 0, ptmax_);
+      hL3TrigElectronEtaEffNum_   = iBooker.book1D("L3TrigElectronEtaEffNum",   "L3 electron #eta efficiency;Ref electron #eta;entries", etabins_, -2.5, 2.5);
+      hL3TrigElectronEtaEffDenom_ = iBooker.book1D("L3TrigElectronEtaEffDenom", "L3 electron #eta denominator;Ref electron #eta;Efficiency", etabins_, -2.5, 2.5);
+      hL3TrigElectronPhiEffNum_   = iBooker.book1D("L3TrigElectronPhiEffNum",   "L3 electron #phi efficiency;Ref electron #phi;entries", phibins_, -3.2, 3.2);
+      hL3TrigElectronPhiEffDenom_ = iBooker.book1D("L3TrigElectronPhiEffDenom", "L3 electron #phi denominator;Ref electron #phi;Efficiency", phibins_, -3.2, 3.2);
+    }
+
+    if(hltPath_.hasL2Muons()) {                                                                                                                                 
+      hL2TrigMuonEtEffNum_    = iBooker.book1D("L2TrigMuonEtEffNum",    "L2 muon p_{T} efficiency;Ref muon p_{T};entries", ptbins_, 0, ptmax_);     
+      hL2TrigMuonEtEffDenom_  = iBooker.book1D("L2TrigMuonEtEffDenom",  "L2 muon p_{T} denominator;Ref muon p_{T};Efficiency", ptbins_, 0, ptmax_); 
+      hL2TrigMuonEtaEffNum_   = iBooker.book1D("L2TrigMuonEtaEffNum",   "L2 muon #eta efficiency;Ref muon #eta;entries", etabins_, -2.5, 2.5);
+      hL2TrigMuonEtaEffDenom_ = iBooker.book1D("L2TrigMuonEtaEffDenom", "L2 muon #eta denominator;Ref muon #eta;Efficiency", etabins_, -2.5, 2.5);
+      hL2TrigMuonPhiEffNum_   = iBooker.book1D("L2TrigMuonPhiEffNum",   "L2 muon #phi efficiency;Ref muon #phi;entries", phibins_, -3.2, 3.2);
+      hL2TrigMuonPhiEffDenom_ = iBooker.book1D("L2TrigMuonPhiEffDenom", "L2 muon #phi denominator;Ref muon #phi;Efficiency", phibins_, -3.2, 3.2);
+    }
+                                                                                                                                                                    
+    if(hltPath_.hasL3Muons()) {
+      hL3TrigMuonEtEffNum_    = iBooker.book1D("L3TrigMuonEtEffNum",    "L3 muon p_{T} efficiency;Ref muon p_{T};entries", ptbins_, 0, ptmax_);     
+      hL3TrigMuonEtEffDenom_  = iBooker.book1D("L3TrigMuonEtEffDenom",  "L3 muon p_{T} denominator;Ref muon p_{T};Efficiency", ptbins_, 0, ptmax_); 
+      hL3TrigMuonEtaEffNum_   = iBooker.book1D("L3TrigMuonEtaEffNum",   "L3 muon #eta efficiency;Ref muon #eta;entries", etabins_, -2.5, 2.5);
+      hL3TrigMuonEtaEffDenom_ = iBooker.book1D("L3TrigMuonEtaEffDenom", "L3 muon #eta denominator;Ref muon #eta;Efficiency", etabins_, -2.5, 2.5);
+      hL3TrigMuonPhiEffNum_   = iBooker.book1D("L3TrigMuonPhiEffNum",   "L3 muon #phi efficiency;Ref muon #phi;entries", phibins_, -3.2, 3.2);
+      hL3TrigMuonPhiEffDenom_ = iBooker.book1D("L3TrigMuonPhiEffDenom", "L3 muon #phi denominator;Ref muon #phi;Efficiency", phibins_, -3.2, 3.2);
+    }
+
+    if(hltPath_.hasL2CaloMET()) {
+      hL2TrigMETEtEffNum_    = iBooker.book1D("L2TrigMETEtEffNum",    "L2 MET efficiency;Ref MET;entries", ptbins_, 0, ptmax_);
+      hL2TrigMETEtEffDenom_  = iBooker.book1D("L2TrigMETEtEffDenom",  "L2 MET denominator;Ref MET;Efficiency", ptbins_, 0, ptmax_);
+    }
+
     iBooker.setCurrentFolder(triggerTag());
   }
 
@@ -79,22 +118,46 @@ void HLTTauDQMPathPlotter::bookHistograms(DQMStore::IBooker &iBooker) {
   if(doRefAnalysis_) {
     const int lastFilter = hltPath_.filtersSize()-1;
     const int ntaus = hltPath_.getFilterNTaus(lastFilter);
-    const int neles = hltPath_.getFilterNElectrons(lastFilter);
-    const int nmus = hltPath_.getFilterNMuons(lastFilter);
-    auto create = [&](const std::string& name) {
-      this->hMass_ = iBooker.book1D("ReferenceMass", "Invariant mass of reference "+name+";Reference invariant mass;entries", 100, 0, 500);
-    };
+    const int neles = hltPath_.getFilterNElectrons(hltPath_.getLastL3ElectronFilterIndex());
+    const int nmus = hltPath_.getFilterNMuons(hltPath_.getLastL3MuonFilterIndex());
 
-    LogDebug("HLTTauDQMOffline") << "Path " << hltPath_.getPathName() << " number of taus " << ntaus << " electrons " << neles << " muons " << nmus;
-
-    if(ntaus == 2)
-      create("di-tau");
-    else if(ntaus == 1) {
-      if(neles == 1)
-        create("electron-tau");
-      else if(nmus == 1)
-        create("muon-tau");
+    int nmet = 0;
+    int lastMatchedMETFilter = -1;
+    for(size_t i = 0; i < hltPath_.filtersSize(); ++i){
+        if(hltPath_.getFilterName(i).find("hltMET") < hltPath_.getFilterName(i).length()) lastMatchedMETFilter = i;
     }
+    if(lastMatchedMETFilter >= 0) nmet = hltPath_.getFilterMET(lastMatchedMETFilter);
+    auto create = [&](const std::string& name) {
+      if(name == "tau-met"){
+	this->hMass_ = iBooker.book1D("ReferenceMass", "Transverse mass of reference "+name+";Reference transverse mass;entries", 100, 0, 500);
+      }else{
+	this->hMass_ = iBooker.book1D("ReferenceMass", "Invariant mass of reference "+name+";Reference invariant mass;entries", 100, 0, 500);
+      }
+    };
+    LogDebug("HLTTauDQMOffline") << "Path " << hltPath_.getPathName() << " number of taus " << ntaus << " electrons " << neles << " muons " << nmus;
+    if(ntaus > 0) {
+      hTrigTauEt_ = iBooker.book1D("TrigTauEt",   "Triggered #tau p_{T};#tau p_{T};entries", ptbins_,     0, ptmax_);
+      hTrigTauEta_ = iBooker.book1D("TrigTauEta", "Triggered #tau #eta;#tau #eta;entries",  etabins_, -2.5, 2.5);
+      hTrigTauPhi_ = iBooker.book1D("TrigTauPhi", "Triggered #tau #phi;#tau #phi;entries",  phibins_, -3.2, 3.2);
+    }
+    if(neles > 0) {
+      hTrigElectronEt_ = iBooker.book1D("TrigElectronEt",   "Triggered electron p_{T};electron p_{T};entries", ptbins_,     0, ptmax_);
+      hTrigElectronEta_ = iBooker.book1D("TrigElectronEta", "Triggered electron #eta;electron #eta;entries",  etabins_, -2.5, 2.5);
+      hTrigElectronPhi_ = iBooker.book1D("TrigElectronPhi", "Triggered electron #phi;electron #phi;entries",  phibins_, -3.2, 3.2);
+    }
+    if(nmus > 0) {   
+      hTrigMuonEt_ = iBooker.book1D("TrigMuonEt",   "Triggered muon p_{T};muon p_{T};entries", ptbins_,     0, ptmax_);
+      hTrigMuonEta_ = iBooker.book1D("TrigMuonEta", "Triggered muon #eta;muon #eta;entries",  etabins_, -2.5, 2.5);
+      hTrigMuonPhi_ = iBooker.book1D("TrigMuonPhi", "Triggered muon #phi;muon #phi;entries",  phibins_, -3.2, 3.2);    
+    }
+    if(nmet > 0) {
+      hTrigMETEt_ = iBooker.book1D("TrigMETEt",   "Triggered MET E_{T};MET E_{T};entries", ptbins_,     0, ptmax_);
+      hTrigMETPhi_ = iBooker.book1D("TrigMETPhi", "Triggered MET #phi;MET #phi;entries",  phibins_, -3.2, 3.2);
+    }
+    if(ntaus == 2 && neles == 0 && nmus == 0 && nmet == 0) create("di-tau");
+    if(ntaus == 1 && neles == 1 && nmus == 0 && nmet == 0) create("electron-tau");
+    if(ntaus == 1 && neles == 0 && nmus == 1 && nmet == 0) create("muon-tau");
+    if(ntaus == 1 && neles == 0 && nmus == 0 && nmet == 1) create("tau-met");      
   }
 }
 
@@ -110,7 +173,12 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults, co
   // Events per filter
   const int lastPassedFilter = hltPath_.lastPassedFilter(triggerResults);
   int lastMatchedFilter = -1;
-  //std::cout << "Last passed filter " << lastPassedFilter << " " << (lastPassedFilter >= 0 ? hltPath_.getFilterName(lastPassedFilter) : "") << std::endl;
+  int lastMatchedMETFilter = -1;
+  int lastMatchedElectronFilter = -1;
+  int lastMatchedMuonFilter = -1;
+  int lastMatchedTauFilter = -1;
+  int firstMatchedMETFilter = -1;
+
   if(doRefAnalysis_) {
     double matchDr = hltPath_.isFirstFilterL1Seed() ? l1MatchDr_ : hltMatchDr_;
     for(int i=0; i<=lastPassedFilter; ++i) {
@@ -118,15 +186,21 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults, co
       matchedTriggerObjs.clear();
       matchedOfflineObjs.clear();
       hltPath_.getFilterObjects(triggerEvent, i, triggerObjs);
-      //std::cout << "Filter name " << hltPath_.getFilterName(i) << " nobjs " << triggerObjs.size() << std::endl;
+      //std::cout << "Filter name " << hltPath_.getFilterName(i) << " nobjs " << triggerObjs.size() << " " << "ref size " << refCollection.taus.size() << std::endl;
       bool matched = hltPath_.offlineMatching(i, triggerObjs, refCollection, matchDr, matchedTriggerObjs, matchedOfflineObjs);
-      //std::cout << "  offline matching: " << matched << std::endl;
+      //std::cout << "  offline matching: " << matched << " " << matchedTriggerObjs.size() << std::endl;
       matchDr = hltMatchDr_;
       if(!matched)
         break;
 
       hAcceptedEvents_->Fill(i+0.5);
       lastMatchedFilter = i;
+      if(hltPath_.getFilterName(i).find("hltMET") < hltPath_.getFilterName(i).length())      lastMatchedMETFilter = i;
+      if(hltPath_.getFilterType(i) == "HLTMuonL3PreFilter" || hltPath_.getFilterType(i) == "HLTMuonIsoFilter") lastMatchedMuonFilter = i;
+      if(hltPath_.getFilterName(i).find("hltEle") < hltPath_.getFilterName(i).length()) lastMatchedElectronFilter = i;
+      if(hltPath_.getFilterName(i).find("hltPFTau") < hltPath_.getFilterName(i).length() || 
+         hltPath_.getFilterName(i).find("hltDoublePFTau") < hltPath_.getFilterName(i).length())    lastMatchedTauFilter = i;
+      if(firstMatchedMETFilter < 0 && hltPath_.getFilterName(i).find("hltMET") < hltPath_.getFilterName(i).length()) firstMatchedMETFilter = i;
     }
   }
   else {
@@ -196,20 +270,158 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults, co
         }
       }
     }
+
+    // L2 Electrons
+    if(hltPath_.hasL2Electrons()) {
+      // Denominators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL2ElectronIndex()) {
+        for(const LV& electron: refCollection.electrons) {
+          hL2TrigElectronEtEffDenom_->Fill(electron.pt());
+          hL2TrigElectronEtaEffDenom_->Fill(electron.eta());
+          hL2TrigElectronPhiEffDenom_->Fill(electron.phi());
+        }
+      }                                                                                                                                                                                                                                  
+
+      // Numerators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL2ElectronFilterIndex()) {
+        triggerObjs.clear();
+        matchedTriggerObjs.clear();
+        matchedOfflineObjs.clear();
+        hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL2ElectronFilterIndex(), triggerObjs);
+        bool matched = hltPath_.offlineMatching(hltPath_.getLastL2ElectronFilterIndex(), triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs);
+        if(matched) {
+          for(const LV& electron: matchedOfflineObjs.electrons) {
+            hL2TrigElectronEtEffNum_->Fill(electron.pt());
+            hL2TrigElectronEtaEffNum_->Fill(electron.eta());
+            hL2TrigElectronPhiEffNum_->Fill(electron.phi());
+          }
+        }
+      }
+    }
+
+    // L3 electron
+    if(hltPath_.hasL3Electrons()) {
+      // Denominators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL3ElectronIndex()) {
+        for(const LV& electron: refCollection.electrons) {
+          hL3TrigElectronEtEffDenom_->Fill(electron.pt());
+          hL3TrigElectronEtaEffDenom_->Fill(electron.eta());  
+          hL3TrigElectronPhiEffDenom_->Fill(electron.phi());
+        }
+      }  
+       
+      // Numerators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL3ElectronFilterIndex()) {
+        triggerObjs.clear();
+        matchedTriggerObjs.clear();
+        matchedOfflineObjs.clear();
+        hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL3ElectronFilterIndex(), triggerObjs);
+        bool matched = hltPath_.offlineMatching(hltPath_.getLastL3ElectronFilterIndex(), triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs);
+        if(matched) {
+          for(const LV& electron: matchedOfflineObjs.electrons) {
+            hL3TrigElectronEtEffNum_->Fill(electron.pt());
+            hL3TrigElectronEtaEffNum_->Fill(electron.eta());  
+            hL3TrigElectronPhiEffNum_->Fill(electron.phi());
+          }
+        }  
+      }  
+    }
+
+    // L2 Muons
+    if(hltPath_.hasL2Muons()) {
+      // Denominators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL2MuonIndex()) {
+        for(const LV& muon: refCollection.muons) {                                             
+          hL2TrigMuonEtEffDenom_->Fill(muon.pt());                                             
+          hL2TrigMuonEtaEffDenom_->Fill(muon.eta());
+          hL2TrigMuonPhiEffDenom_->Fill(muon.phi());
+        }                                             
+      }
+
+      // Numerators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL2MuonFilterIndex()) {
+        triggerObjs.clear();
+        matchedTriggerObjs.clear();
+        matchedOfflineObjs.clear();
+        hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL2MuonFilterIndex(), triggerObjs);
+        bool matched = hltPath_.offlineMatching(hltPath_.getLastL2MuonFilterIndex(), triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs);
+        if(matched) {
+          for(const LV& muon: matchedOfflineObjs.muons) {
+            hL2TrigMuonEtEffNum_->Fill(muon.pt());
+            hL2TrigMuonEtaEffNum_->Fill(muon.eta());
+            hL2TrigMuonPhiEffNum_->Fill(muon.phi());
+          }
+        }
+      }
+    }
+ 
+    // L3 muon
+    if(hltPath_.hasL3Muons()) {   
+      // Denominators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastFilterBeforeL3MuonIndex()) {   
+        for(const LV& muon: refCollection.muons) {
+          hL3TrigMuonEtEffDenom_->Fill(muon.pt());   
+          hL3TrigMuonEtaEffDenom_->Fill(muon.eta());
+          hL3TrigMuonPhiEffDenom_->Fill(muon.phi());
+        }
+      }  
+          
+      // Numerators
+      if(static_cast<size_t>(lastMatchedFilter) >= hltPath_.getLastL3MuonFilterIndex()) {
+        triggerObjs.clear();
+        matchedTriggerObjs.clear();
+        matchedOfflineObjs.clear();
+        hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL3MuonFilterIndex(), triggerObjs);
+        bool matched = hltPath_.offlineMatching(hltPath_.getLastL3MuonFilterIndex(), triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs);
+        if(matched) {
+          for(const LV& muon: matchedOfflineObjs.muons) {
+            hL3TrigMuonEtEffNum_->Fill(muon.pt());
+            hL3TrigMuonEtaEffNum_->Fill(muon.eta());
+            hL3TrigMuonPhiEffNum_->Fill(muon.phi());   
+          }
+        }  
+      }    
+    }
+
+    // L2 CaloMET
+    if(hltPath_.hasL2CaloMET()) {
+      // Denominators
+      if(static_cast<size_t>(firstMatchedMETFilter) >= hltPath_.getFirstFilterBeforeL2CaloMETIndex()) {
+        hL2TrigMETEtEffDenom_->Fill(refCollection.met[0].pt());
+      }
+
+      // Numerators
+      if(static_cast<size_t>(lastMatchedMETFilter) >= hltPath_.getLastL2CaloMETFilterIndex()) {
+        triggerObjs.clear();
+        matchedTriggerObjs.clear(); 
+        matchedOfflineObjs.clear();
+        hltPath_.getFilterObjects(triggerEvent, hltPath_.getLastL2CaloMETFilterIndex(), triggerObjs);
+        bool matched = hltPath_.offlineMatching(hltPath_.getLastL2CaloMETFilterIndex(), triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs);
+	if(matched) {
+          hL2TrigMETEtEffNum_->Fill(matchedOfflineObjs.met[0].pt());
+        }
+      }
+    }
   }
 
   if(hltPath_.fired(triggerResults)) {
     triggerObjs.clear();
     matchedTriggerObjs.clear();
     matchedOfflineObjs.clear();
-    hltPath_.getFilterObjects(triggerEvent, lastPassedFilter, triggerObjs);
+
+    if(lastMatchedMETFilter >= 0) hltPath_.getFilterObjects(triggerEvent, lastMatchedMETFilter, triggerObjs);
+    if(lastMatchedMuonFilter >= 0) hltPath_.getFilterObjects(triggerEvent, lastMatchedMuonFilter, triggerObjs);
+    if(lastMatchedElectronFilter >= 0) hltPath_.getFilterObjects(triggerEvent, lastMatchedElectronFilter, triggerObjs);
+
+    if(lastMatchedTauFilter >= 0) hltPath_.getFilterObjects(triggerEvent, lastMatchedTauFilter, triggerObjs);    
+
     if(doRefAnalysis_) {
       bool matched = hltPath_.offlineMatching(lastPassedFilter, triggerObjs, refCollection, hltMatchDr_, matchedTriggerObjs, matchedOfflineObjs);
       if(matched) {
         // Di-object invariant mass
         if(hMass_) {
           const int ntaus = hltPath_.getFilterNTaus(lastPassedFilter);
-          if(ntaus == 2) {
+          if(ntaus == 2 && hltPath_.getFilterNElectrons(lastMatchedElectronFilter) == 0 && hltPath_.getFilterNMuons(lastMatchedMuonFilter) == 0) {
             // Di-tau (matchedOfflineObjs are already sorted)
             hMass_->Fill( (matchedOfflineObjs.taus[0]+matchedOfflineObjs.taus[1]).M() );
           }
@@ -221,22 +433,41 @@ void HLTTauDQMPathPlotter::analyze(const edm::TriggerResults& triggerResults, co
           else if(ntaus == 1 && hltPath_.getFilterNMuons(lastPassedFilter) == 1) {
             hMass_->Fill( (matchedOfflineObjs.taus[0]+matchedOfflineObjs.muons[0]).M() );
           }
+	  // Tau+MET
+          if(hltPath_.getFilterNTaus(lastPassedFilter) == 1 && hltPath_.getFilterMET(lastMatchedMETFilter) == 1) {
+	    double taupt  = matchedOfflineObjs.taus[0].Pt();
+	    double tauphi = matchedOfflineObjs.taus[0].Phi();
+	    double met    = matchedOfflineObjs.met[0].Pt();
+            double metphi = matchedOfflineObjs.met[0].Phi();
+	    double mT = sqrt( 2 * taupt * met * (1-cos(tauphi-metphi)) );
+
+            hMass_->Fill( mT );
+          }
         }
       }
-
-      if(matched)
-        triggerObjs.swap(matchedTriggerObjs);
-      else
-        triggerObjs.clear();
     }
 
-    // Triggered tau kinematics
+    // Triggered object kinematics
     for(const HLTTauDQMPath::Object& obj: triggerObjs) {
-      if(obj.id != trigger::TriggerTau)
-        continue;
-      hTrigTauEt_->Fill(obj.object.pt());
-      hTrigTauEta_->Fill(obj.object.eta());
-      hTrigTauPhi_->Fill(obj.object.phi());
+      if(obj.id == trigger::TriggerTau){
+	hTrigTauEt_->Fill(obj.object.pt());
+	hTrigTauEta_->Fill(obj.object.eta());
+	hTrigTauPhi_->Fill(obj.object.phi());
+      }
+      if(obj.id == trigger::TriggerElectron || obj.id == trigger::TriggerPhoton){
+        hTrigElectronEt_->Fill(obj.object.pt());
+        hTrigElectronEta_->Fill(obj.object.eta());
+        hTrigElectronPhi_->Fill(obj.object.phi());
+      }
+      if(obj.id == trigger::TriggerMuon){   
+        hTrigMuonEt_->Fill(obj.object.pt());   
+        hTrigMuonEta_->Fill(obj.object.eta());
+        hTrigMuonPhi_->Fill(obj.object.phi());
+      }
+      if(obj.id == trigger::TriggerMET){
+        hTrigMETEt_->Fill(obj.object.pt());
+        hTrigMETPhi_->Fill(obj.object.phi());
+      }
     }
   }
 }

--- a/DQMOffline/Trigger/src/HLTTauRefProducer.cc
+++ b/DQMOffline/Trigger/src/HLTTauRefProducer.cc
@@ -84,6 +84,11 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig)
   ptMinPhoton_= photons.getUntrackedParameter<double>("etMin");
   photonEcalIso_= photons.getUntrackedParameter<double>("ECALIso");
 
+  ParameterSet  met = iConfig.getUntrackedParameter<edm::ParameterSet>("MET");
+  MET_ = consumes<reco::CaloMETCollection>(met.getUntrackedParameter<InputTag>("METCollection"));
+  doMET_ = met.getUntrackedParameter<bool>("doMET",false);
+  ptMinMET_= met.getUntrackedParameter<double>("ptMin",15.);
+
 
   etaMax = iConfig.getUntrackedParameter<double>("EtaMax",2.5);
   
@@ -95,6 +100,7 @@ HLTTauRefProducer::HLTTauRefProducer(const edm::ParameterSet& iConfig)
   produces<LorentzVectorCollection>("Jets");
   produces<LorentzVectorCollection>("Photons");
   produces<LorentzVectorCollection>("Towers");
+  produces<LorentzVectorCollection>("MET");
 
 }
 
@@ -114,7 +120,8 @@ void HLTTauRefProducer::produce(edm::Event& iEvent, const edm::EventSetup& iES)
     doPhotons(iEvent,iES);
   if(doTowers_)
     doTowers(iEvent,iES);
-
+  if(doMET_)
+    doMET(iEvent,iES);
 }
 
 void 
@@ -310,5 +317,21 @@ HLTTauRefProducer::doPhotons(edm::Event& iEvent,const edm::EventSetup& iES)
 	      }
 	}
       iEvent.put(product_Gammas,"Photons");
+}
+
+void
+HLTTauRefProducer::doMET(edm::Event& iEvent,const edm::EventSetup& iES)
+{
+  auto_ptr<LorentzVectorCollection> product_MET(new LorentzVectorCollection);
+  //Retrieve the collection
+  edm::Handle<reco::CaloMETCollection> met;
+  if(iEvent.getByToken(MET_,met)){
+    double px = met->front().p4().Px();
+    double py = met->front().p4().Py();
+    double pt = met->front().p4().Pt();
+    LorentzVector vec(px,py,0,pt);
+    product_MET->push_back(vec);
+  }
+  iEvent.put(product_MET,"MET");  
 }
 

--- a/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
+++ b/HLTriggerOffline/Tau/interface/HLTTauMCProducer.h
@@ -20,6 +20,9 @@ in Offline Trigger DQM etc
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/Math/interface/LorentzVector.h"
 #include "HepMC/GenEvent.h"
+#include "DataFormats/METReco/interface/GenMET.h"
+#include "DataFormats/METReco/interface/GenMETCollection.h"
+
 #include <vector>
 #include <string>
 #include "TLorentzVector.h"
@@ -46,6 +49,7 @@ public:
 		      kOther, kUndefined};
 
   edm::EDGetTokenT<reco::GenParticleCollection> MC_;
+  edm::EDGetTokenT<reco::GenMETCollection> MCMET_;
   double ptMinMCTau_;
   double ptMinMCElectron_;
   double ptMinMCMuon_;

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauReferences_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauReferences_cfi.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 TauMCProducer  = cms.EDProducer("HLTTauMCProducer",
                               GenParticles  = cms.untracked.InputTag("genParticles"),
+			      GenMET        = cms.untracked.InputTag("genMetTrue"),
                               ptMinTau      = cms.untracked.double(15),
                               ptMinMuon     = cms.untracked.double(15),
                               ptMinElectron = cms.untracked.double(15),
@@ -48,19 +49,22 @@ TauRelvalRefProducer = cms.EDProducer("HLTTauRefProducer",
                                         doTowers = cms.untracked.bool(True),
                                         towerIsolation = cms.untracked.double(5.0)
                                 ),
-                                
                                 Muons = cms.untracked.PSet(
                                        doMuons = cms.untracked.bool(True),
                                        MuonCollection = cms.untracked.InputTag("muons"),
                                        ptMin = cms.untracked.double(15.0)
                                 ),
-                                
                                 Photons = cms.untracked.PSet(
                                           doPhotons = cms.untracked.bool(True),
                                           PhotonCollection = cms.untracked.InputTag("photons"),
                                           etMin = cms.untracked.double(10.0),
                                           ECALIso = cms.untracked.double(3.0)
                                           ),
+                                MET = cms.untracked.PSet(
+                                          doMET = cms.untracked.bool(True),
+                                          METCollection = cms.untracked.InputTag("caloMet"),
+                                          ptMin = cms.untracked.double(15.0)
+                                ),
                                 EtaMax = cms.untracked.double(2.5)
 )
 

--- a/HLTriggerOffline/Tau/python/Validation/HLTTauValidation_cfi.py
+++ b/HLTriggerOffline/Tau/python/Validation/HLTTauValidation_cfi.py
@@ -10,8 +10,11 @@ hltTauValIdealMonitorMC = cms.EDAnalyzer("HLTTauDQMOfflineSource",
     L1Plotter = cms.untracked.PSet(
         DQMFolder             = cms.untracked.string('L1'),
         L1Taus                = cms.untracked.InputTag("l1extraParticles", "Tau"),
+	L1IsoTaus             = cms.untracked.InputTag("l1extraParticles", "IsoTau"),
         L1Jets                = cms.untracked.InputTag("l1extraParticles", "Central"),
         L1JetMinEt            = cms.untracked.double(40), # this value is arbitrary at the moment
+        L1ETM                 = cms.untracked.InputTag("l1extraParticles", "MET"),
+        L1ETMMin              = cms.untracked.double(50),
     ),
     Paths = cms.untracked.string("PFTau"),
     PathSummaryPlotter = cms.untracked.PSet(
@@ -31,6 +34,10 @@ hltTauValIdealMonitorMC = cms.EDAnalyzer("HLTTauDQMOfflineSource",
                                     cms.untracked.PSet(
                                         FilterName        = cms.untracked.InputTag("TauMCProducer","LeptonicTauMuons"),
                                         matchObjectID     = cms.untracked.int32(13),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("TauMCProducer","MET"),
+                                        matchObjectID     = cms.untracked.int32(0),
                                     ),
                                 ),
     ),
@@ -52,6 +59,10 @@ hltTauValIdealMonitorPF = hltTauValIdealMonitorMC.clone(
                                     cms.untracked.PSet(
                                         FilterName        = cms.untracked.InputTag("TauMCProducer","LeptonicTauMuons"),
                                         matchObjectID     = cms.untracked.int32(13),
+                                    ),
+                                    cms.untracked.PSet(
+                                        FilterName        = cms.untracked.InputTag("TauMCProducer","MET"),
+                                        matchObjectID     = cms.untracked.int32(0),
                                     ),
                                 ),
     ),


### PR DESCRIPTION
This update adds legs X from tau+X trigger into validation. This is continuing PR #9533, which I could not modify due to missing release top.
The last comment of PR #9533 is now fixed, changed getByLabel -> getByToken. PR #9533 can now be dropped.
