### PR TITLE
Removing cout from HcalSimHitsClient.cc

### DIFF
--- a/Validation/HcalHits/src/HcalSimHitsClient.cc
+++ b/Validation/HcalHits/src/HcalSimHitsClient.cc
@@ -211,7 +211,6 @@ int HcalSimHitsClient::SimHitsEndjob(const std::vector<MonitorElement*> &hcalMEs
   
   for (int itime=0; itime<nTime; itime++) {
     for (unsigned int det=0; det<divisions.size();det++) {
-      std::cout<<"itime:"<<itime<<"det:"<<det<<std::endl;
       int ny= Occupancy_map[itime][det]->getNbinsY();
       int nx= Occupancy_map[itime][det]->getNbinsX(); 
 


### PR DESCRIPTION
@bsunanda , this cout is causing huge number of lines in logs when producing relval samples with SLHC releases, I'm removing it as it's not there in the 76X version of this file.
