### PR TITLE
Back out ROOT6 only code

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.cc
@@ -532,7 +532,7 @@ namespace cscdqm {
       if(checkHistoValue(p, "SetXLabels", s)) {
         std::map<int, std::string> labels;
         ParseAxisLabels(s, labels);
-        th->GetXaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
+        // th->GetXaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
         for (std::map<int, std::string>::iterator l_itr = labels.begin(); l_itr != labels.end(); ++l_itr) {
           th->GetXaxis()->SetBinLabel(l_itr->first, l_itr->second.c_str());
         }
@@ -540,7 +540,7 @@ namespace cscdqm {
       if(checkHistoValue(p, "SetYLabels", s)) {
         std::map<int, std::string> labels;
         ParseAxisLabels(s, labels);
-        th->GetYaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
+        // th->GetYaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
         for (std::map<int, std::string>::iterator l_itr = labels.begin(); l_itr != labels.end(); ++l_itr) {
           th->GetYaxis()->SetBinLabel(l_itr->first, l_itr->second.c_str());
         }


### PR DESCRIPTION
In a previous PR (#9902) I backed out ROOT6 specific changes causing build errors in CMSSW_7_5_ROOT5_X.  Unfortunately, I missed the ones in DQM/CSCMonitorModule.  This PR fixes the compilation errors in this package by commenting out two ROOT6 specific function calls.
Please expedite this purely technical  PR, as it fixes the remaining compilation errors in this release.

Note:  The FWLite unit test errors in this release are independent of this issue, and will be fixed in a separate PR.
