### PR TITLE
Account for ROOT5/ROOT6 differences in FWLite

### DIFF
--- a/FWCore/FWLite/interface/FWLiteEnabler.h
+++ b/FWCore/FWLite/interface/FWLiteEnabler.h
@@ -11,12 +11,12 @@ class DummyClassToStopCompilerWarning;
 class FWLiteEnabler {
   friend class DummyClassToStopCompilerWarning;
 public:
-  FWLiteEnabler(const FWLiteEnabler&) = delete; // stop default
-  FWLiteEnabler const& operator=(FWLiteEnabler const&) = delete; // stop default
   /// enable automatic library loading  
   static void enable();
 
 private:
+  FWLiteEnabler(const FWLiteEnabler&); // stop default
+  FWLiteEnabler const& operator=(FWLiteEnabler const&); // stop default
   static bool enabled_;
   FWLiteEnabler();
 };

--- a/FWCore/FWLite/src/FWCoreFWLiteLinkDef.h
+++ b/FWCore/FWLite/src/FWCoreFWLiteLinkDef.h
@@ -1,6 +1,8 @@
 #include "FWCore/FWLite/interface/AutoLibraryLoader.h"
+#include "FWCore/FWLite/interface/FWLiteEnabler.h"
 #include "FWCore/FWLite/src/branchToClass.h"
 #ifdef __CINT__
 #pragma link C++ class AutoLibraryLoader;
+#pragma link C++ class FWLiteEnabler;
 #pragma link C++ function branchToClass;
 #endif


### PR DESCRIPTION
Due to ROOT5/ROOT6 differences, a carry forward from CMSSW_7_5_X broke FWLite in CMSSW_7_5_ROOT5_X.  Pull request #9902 fixed this partially, but the fix was incomplete. This PR completes the fix of FWLite, so the unit tests no longer fail.
