### PR TITLE
Generalize makeTrackValidationPlots.py script

### DIFF
--- a/Validation/RecoTrack/python/plotting/trackingPlots.py
+++ b/Validation/RecoTrack/python/plotting/trackingPlots.py
@@ -76,7 +76,7 @@ _chargemisid = PlotGroup("chargemisid", [
 _hitsAndPt = PlotGroup("hitsAndPt", [
     Plot("missing_inner_layers", stat=True, normalizeToUnitArea=True, drawStyle="hist"),
     Plot("missing_outer_layers", stat=True, normalizeToUnitArea=True, drawStyle="hist"),
-    Plot("nhits_vs_eta", stat=True, statx=0.38, profileX=True, xtitle="#eta", ytitle="<hits> vs #eta", ymin=8, ymax=24, statyadjust=[0,0,-0.15]),
+    Plot("hits_eta", stat=True, statx=0.38, xtitle="#eta", ytitle="<hits> vs #eta", ymin=8, ymax=24, statyadjust=[0,0,-0.15]),
     Plot("hits", stat=True, xtitle="hits", xmin=0, xmax=40, drawStyle="hist"),
     Plot("num_simul_pT", stat=True, normalizeToUnitArea=True, xtitle="p_{t}", xmin=0, xmax=10, drawStyle="hist"),
     Plot("num_reco_pT", stat=True, normalizeToUnitArea=True, xtitle="p_{t}", xmin=0, xmax=10, drawStyle="hist")
@@ -98,7 +98,7 @@ _ntracks = PlotGroup("ntracks", [
 _tuning = PlotGroup("tuning", [
     Plot("chi2", stat=True, normalizeToUnitArea=True, ylog=True, ymin=1e-6, ymax=[0.1, 0.2, 0.5, 1.0001], drawStyle="hist", xtitle="#chi^{2}", ratioUncertainty=False),
     Plot("chi2_prob", stat=True, normalizeToUnitArea=True, drawStyle="hist", xtitle="Prob(#chi^{2})", ratioUncertainty=False),
-    Plot("chi2_vs_eta", stat=True, profileX=True, title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymax=2.5),
+    Plot("chi2mean", stat=True, title="", xtitle="#eta", ytitle="< #chi^{2} / ndf >", ymax=2.5),
     Plot("ptres_vs_eta_Mean", stat=True, scale=100, title="", xtitle="#eta", ytitle="< #delta p_{t} / p_{t} > [%]", ymin=-1.5, ymax=1.5)
 ])
 _common = {"stat": True, "fit": True, "normalizeToUnitArea": True, "drawStyle": "hist", "drawCommand": "", "xmin": -10, "xmax": 10, "ylog": True, "ymin": 5e-5, "ymax": [0.01, 0.05, 0.1, 0.2, 0.5, 0.8, 1.025], "ratioUncertainty": False}

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -706,6 +706,13 @@ class SimpleValidation:
         self._newdirFunc = newdirFunc
         self._plotterDrawArgs = plotterDrawArgs
 
+        self._openFiles = []
+        for f in self._files:
+            if not os.path.exists(f):
+                print "File %s not found" % f
+                sys.exit(1)
+            self._openFiles.append(ROOT.TFile.Open(f))
+
         if qualities is None:
             qualities = [None]
         if algos is None:
@@ -713,45 +720,50 @@ class SimpleValidation:
 
         for q in qualities:
             for a in algos:
-                self._doPlots(a, q)
+                subdir = None
+                if self._algoDirMap is not None:
+                    if hasattr(self._algoDirMap, "__call__"):
+                        subdir = self._algoDirMap(a, q)
+                    else:
+                        subdir = self._algoDirMap[q][a]
+                self._doPlots(a, q, subdir)
 
-    def _doPlots(self, algo, quality):
-        openFiles = []
+        for tf in self._openFiles:
+            tf.Close()
+        self._openFiles = []
+
+    def doPlotsAuto(self, plotter, subdirToAlgoQuality, newdirFunc=None, plotterDrawArgs={}):
+        self._plotter = plotter
+        self._newdirFunc = newdirFunc
+        self._plotterDrawArgs = plotterDrawArgs
+
+        self._openFiles = []
         for f in self._files:
             if not os.path.exists(f):
                 print "File %s not found" % f
                 sys.exit(1)
-            openFiles.append(ROOT.TFile.Open(f))
+            self._openFiles.append(ROOT.TFile.Open(f))
 
-        # dirs = []
-        # for tf in openFiles:
-        #     theDir = None
-        #     for pd in self._plotter.getPossibleDirectoryNames():
-        #         theDir = tf.GetDirectory(pd)
-        #         if theDir:
-        #             break
-        #     if not theDir:
-        #         print "Did not find any of %s directories from file %s" % (",".join(self._plotter.getPossibleDirectoryNames()), tf.GetName())
-        #         sys.exit(1)
-        #     if self._algoDirMap is not None:
-        #         d = theDir.Get(self._algoDirMap[quality][algo])
-        #         if not theDir:
-        #             print "Did not find dir %s from %s" % (self._algoDirMap[quality][algo], theDir.GetPath())
-        #             sys.exit(1)
-        #         theDir = d
-        #     dirs.append(theDir)
+        theDir = None
+        for pd in self._plotter.getPossibleDirectoryNames():
+            theDir = self._openFiles[0].GetDirectory(pd)
+            if theDir:
+                break
+        if not theDir:
+            print "Did not find any of %s directories from file %s" % (",".join(self._plotter.getPossibleDirectoryNames()), tf.GetName())
+            sys.exit(1)
 
-        subdir = None
-        if self._algoDirMap is not None:
-            if hasattr(self._algoDirMap, "__call__"):
-                subdir = self._algoDirMap(algo, quality)
-            else:
-                subdir = self._algoDirMap[quality][algo]
-        self._plotter.create(openFiles, self._labels, subdir=subdir)
-        fileList = self._plotter.draw(algo, **self._plotterDrawArgs)
+        subdirs = [key.GetName() for key in theDir.GetListOfKeys()]
+        for s in subdirs:
+            self._doPlots(*subdirToAlgoQuality(s), subdir=s)
 
-        for tf in openFiles:
+        for tf in self._openFiles:
             tf.Close()
+        self._openFiles = []
+
+    def _doPlots(self, algo, quality, subdir):
+        self._plotter.create(self._openFiles, self._labels, subdir=subdir)
+        fileList = self._plotter.draw(algo, **self._plotterDrawArgs)
 
         newdir = self._newdir
         if self._newdirFunc is not None:

--- a/Validation/RecoTrack/python/plotting/validation.py
+++ b/Validation/RecoTrack/python/plotting/validation.py
@@ -753,7 +753,11 @@ class SimpleValidation:
             print "Did not find any of %s directories from file %s" % (",".join(self._plotter.getPossibleDirectoryNames()), tf.GetName())
             sys.exit(1)
 
-        subdirs = [key.GetName() for key in theDir.GetListOfKeys()]
+        subdirs = []
+        for key in theDir.GetListOfKeys():
+            if isinstance(key.ReadObj(), ROOT.TDirectory):
+                subdirs.append(key.GetName())
+
         for s in subdirs:
             self._doPlots(*subdirToAlgoQuality(s), subdir=s)
 

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -7,20 +7,11 @@ import Validation.RecoTrack.plotting.plotting as plotting
 from Validation.RecoTrack.plotting.validation import SimpleValidation
 import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
-Algos= ['ootb', 'initialStep', 'lowPtTripletStep', 'pixelPairStep', 'detachedTripletStep', 'mixedTripletStep', 'pixelLessStep', 'tobTecStep', 'jetCoreRegionalStep', 'muonSeededStepInOut', 'muonSeededStepOutIn']
-Qualities=['', 'highPurity']
-
 def newdirname(algo, quality):
-    ret = ""
-    if quality != "":
-        ret += "_"+quality
-    if not (algo == "ootb" and quality != ""):
-        ret += "_"+algo
+    return algo+"_"+quality
 
-    if ret != "" and ret[0] == "_":
-        ret = ret[1:]
-
-    return ret
+def subdirToAlgoQuality(subdir):
+    return subdir.split("_")
 
 def main(opts):
     files = opts.files
@@ -35,11 +26,10 @@ def main(opts):
         drawArgs["saveFormat"] = ".png"
 
     val = SimpleValidation(files, labels, opts.outputDir)
-    val.doPlots(Algos, Qualities, trackingPlots.plotter, algoDirMap=trackingPlots._tracks_map, newdirFunc=newdirname,
-                plotterDrawArgs=drawArgs)
+    val.doPlotsAuto(trackingPlots.plotter, subdirToAlgoQuality=subdirToAlgoQuality, newdirFunc=newdirname, plotterDrawArgs=drawArgs)
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Create standard set of tracking validation plots from one or more DQM files")
+    parser = argparse.ArgumentParser(description="Create standard set of tracking validation plots from one or more DQM files. Note that the output directory structure is not exactly the same as with test/trackingPerformanceValidation.py or test/trackingCompare.py")
     parser.add_argument("files", metavar="file", type=str, nargs="+",
                         help="DQM file to plot the validation plots from")
     parser.add_argument("-o", "--outputDir", type=str, default="plots",

--- a/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
+++ b/Validation/RecoTrack/scripts/makeTrackValidationPlots.py
@@ -17,6 +17,9 @@ def main(opts):
     files = opts.files
     labels = [f.replace(".root", "") for f in files]
 
+    if opts.ignoreMissing:
+        plotting.missingOk = True
+
     drawArgs={}
     if opts.ratio:
         drawArgs["ratio"] = True
@@ -34,6 +37,8 @@ if __name__ == "__main__":
                         help="DQM file to plot the validation plots from")
     parser.add_argument("-o", "--outputDir", type=str, default="plots",
                         help="Plot output directory (default: 'plots')")
+    parser.add_argument("--ignoreMissing", action="store_true",
+                        help="Ignore missing histograms and directories")
     parser.add_argument("--ratio", action="store_true",
                         help="Create ratio pads")
     parser.add_argument("--separate", action="store_true",


### PR DESCRIPTION
This PR generalizes the `makeTrackValidationPlots.py` script introduced in #9882 to make plots for all subfolders of "Tracking/Track" folder of the first of the DQM files given as command line arguments (feature requested by @lveldere). Add also `--ignoreMissing` command line flag to allow skipping missing histograms/subfolders.

In addition, switch the plotting to use the profile histograms in the DQM files instead of the 2D histograms nhits_vs_eta and chi2_vs_eta that were cleaned up in #9524.

There should be no effect on standard workflows.

@rovere @VinInn 
