### PR TITLE
Fix MultiTrackValidator efficiency summary plot

### DIFF
--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -50,11 +50,12 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
   TrackingParticleSelector tpSelector;				      
   CosmicTrackingParticleSelector cosmictpSelector;
   TrackingParticleSelector dRtpSelector;				      
+  TrackingParticleSelector dRtpSelectorNoPtCut;
 
   edm::EDGetTokenT<SimHitTPAssociationProducer::SimHitTPAssociationList> _simHitTpMapTag;
   edm::EDGetTokenT<edm::View<reco::Track> > labelTokenForDrCalculation;
 
-  std::vector<MonitorElement *> h_reco_coll, h_assoc_coll, h_assoc2_coll, h_simul_coll, h_looper_coll, h_pileup_coll;
+  std::vector<MonitorElement *> h_reco_coll, h_assoc_coll, h_assoc2_coll, h_simul_coll, h_looper_coll, h_pileup_coll; std::vector<MonitorElement *> h_assoc_coll_allPt, h_simul_coll_allPt;
 };
 
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -514,10 +514,13 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
         int nSimStripMonoAndStereoLayers = nStripMonoAndStereoLayers_tPCeff[tpr];
         histoProducerAlgo_->fill_recoAssociated_simTrack_histos(w,tp,momentumTP,vertexTP,dxySim,dzSim,nSimHits,nSimLayers,nSimPixelLayers,nSimStripMonoAndStereoLayers,matchedTrackPointer,puinfo.getPU_NumInteractions(), dR);
           sts++;
-          h_simul_coll[ww]->Fill(www);
-          if (matchedTrackPointer) {
+          if(matchedTrackPointer)
             asts++;
-            h_assoc_coll[ww]->Fill(www);
+          if(dRtpSelector(tp)) {
+            h_simul_coll[ww]->Fill(www);
+            if (matchedTrackPointer) {
+              h_assoc_coll[ww]->Fill(www);
+            }
           }
 
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -97,6 +97,17 @@ MultiTrackValidator::MultiTrackValidator(const edm::ParameterSet& pset):
 					  psetVsEta.getParameter<bool>("stableOnly"),
 					  psetVsEta.getParameter<std::vector<int> >("pdgId"));
 
+  dRtpSelectorNoPtCut = TrackingParticleSelector(0.0,
+                                                 psetVsEta.getParameter<double>("minRapidity"),
+                                                 psetVsEta.getParameter<double>("maxRapidity"),
+                                                 psetVsEta.getParameter<double>("tip"),
+                                                 psetVsEta.getParameter<double>("lip"),
+                                                 psetVsEta.getParameter<int>("minHit"),
+                                                 psetVsEta.getParameter<bool>("signalOnly"),
+                                                 psetVsEta.getParameter<bool>("chargedOnly"),
+                                                 psetVsEta.getParameter<bool>("stableOnly"),
+                                                 psetVsEta.getParameter<std::vector<int> >("pdgId"));
+
   useGsf = pset.getParameter<bool>("useGsf");
 
   _simHitTpMapTag = mayConsume<SimHitTPAssociationProducer::SimHitTPAssociationList>(pset.getParameter<edm::InputTag>("simHitTpMapTag"));
@@ -144,6 +155,9 @@ void MultiTrackValidator::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     h_simul_coll.push_back(binLabels( ibook.book1D("num_simul_coll", "N of simulated tracks vs track collection", nintColl, minColl, maxColl) ));
     h_looper_coll.push_back(binLabels( ibook.book1D("num_duplicate_coll", "N of associated (recoToSim) looper tracks vs track collection", nintColl, minColl, maxColl) ));
     h_pileup_coll.push_back(binLabels( ibook.book1D("num_pileup_coll", "N of associated (recoToSim) pileup tracks vs track collection", nintColl, minColl, maxColl) ));
+
+    h_assoc_coll_allPt.push_back(binLabels( ibook.book1D("num_assoc(simToReco)_coll_allPt", "N of associated (simToReco) tracks vs track collection", nintColl, minColl, maxColl) ));
+    h_simul_coll_allPt.push_back(binLabels( ibook.book1D("num_simul_coll_allPt", "N of simulated tracks vs track collection", nintColl, minColl, maxColl) ));
 
     for (unsigned int www=0;www<label.size();www++){
       ibook.cd();
@@ -516,10 +530,17 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
           sts++;
           if(matchedTrackPointer)
             asts++;
-          if(dRtpSelector(tp)) {
-            h_simul_coll[ww]->Fill(www);
+          if(dRtpSelectorNoPtCut(tp)) {
+            h_simul_coll_allPt[ww]->Fill(www);
             if (matchedTrackPointer) {
-              h_assoc_coll[ww]->Fill(www);
+              h_assoc_coll_allPt[ww]->Fill(www);
+            }
+
+            if(dRtpSelector(tp)) {
+              h_simul_coll[ww]->Fill(www);
+              if (matchedTrackPointer) {
+                h_assoc_coll[ww]->Fill(www);
+              }
             }
           }
 

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -106,6 +106,7 @@ postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
     subDirs = cms.untracked.vstring("Tracking/Track"),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
+    "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",
     "duplicatesRate_coll 'Duplicates Rate vs track collection' num_duplicate_coll num_reco_coll",
     "pileuprate_coll 'Pileup rate vs track collection' num_pileup_coll num_reco_coll",
     "fakerate_vs_coll 'Fake rate vs track collection' num_assoc(recoToSim)_coll num_reco_coll fake",


### PR DESCRIPTION
The recently (#9201) added efficiency summary plot (average efficiency for each input track collection) has a bug in putting also out-of-time TrackingParticles to the denominator. This PR fixes that by using the same TP selector as for TP DeltaR calculation (being the same as efficiency vs. eta), i.e. essentially requiring that the TP comes from the hard scatter and has pT > 0.9 GeV. In addition, another version of the efficiency summary plot is included without the TP pT cut.

Tested in 750pre6, expecting changes only in `effic_vs_coll`, `num_simul_coll`, `num_assoc(simToReco)_coll`, and `globalEfficiencies` under `Tracking/Track` folder. In noPU samples the efficiency plots should change like (black=old, red=new)
![image](https://cloud.githubusercontent.com/assets/33993/8374446/b28d6e54-1bf5-11e5-8770-7d5375aca394.png)

and in pileup samples like
![image](https://cloud.githubusercontent.com/assets/33993/8374430/8ce7f2c8-1bf5-11e5-97c1-7308acd3d9a7.png)

@rovere @VinInn 
