### PR TITLE
Migrate HitPattern to use TrackerTopology

### DIFF
--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -1,6 +1,6 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
-#include "DataFormats/SiPixelDetId/interface/PXBDetId.h"
-#include "DataFormats/SiStripDetId/interface/TIBDetId.h"
+#include "DataFormats/SiPixelDetId/interface/PixelSubdetector.h"
+#include "DataFormats/SiStripDetId/interface/StripSubdetector.h"
 #include "DataFormats/PatCandidates/interface/libminifloat.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
@@ -151,15 +151,15 @@ void pat::PackedCandidate::unpackTrk() const {
     track_ = reco::Track(normalizedChi2_*ndof,ndof,vertex_,math::XYZVector(p3.x(),p3.y(),p3.z()),charge(),m,reco::TrackBase::undefAlgorithm,reco::TrackBase::loose);
     
     if(innerLost == validHitInFirstPixelBarrelLayer){
-        track_.appendHitPattern(PXBDetId(1, 0, 0), TrackingRecHit::valid); 
+        track_.appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::valid); 
         i++; 
     }
     for(;i<numberOfPixelHits_; i++) {
-       track_.appendHitPattern(PXBDetId(i > 1 ? 3 : 2, 0, 0), TrackingRecHit::valid); 
+       track_.appendTrackerHitPattern(PixelSubdetector::PixelBarrel, i > 1 ? 3 : 2, 0, TrackingRecHit::valid); 
     }
     
     for(;i<numberOfHits_;i++) {
-	   track_.appendHitPattern(TIBDetId(1, 0, 0, 1, 1, 0), TrackingRecHit::valid); 
+          track_.appendTrackerHitPattern(StripSubdetector::TIB, 1, 1, TrackingRecHit::valid);
     }
 
     switch (innerLost) {
@@ -168,11 +168,11 @@ void pat::PackedCandidate::unpackTrk() const {
         case noLostInnerHits:
             break;
         case oneLostInnerHit:
-            track_.appendHitPattern(PXBDetId(1, 0, 0), TrackingRecHit::missing_inner);
+            track_.appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::missing_inner);
             break;
         case moreLostInnerHits:
-            track_.appendHitPattern(PXBDetId(1, 0, 0), TrackingRecHit::missing_inner);
-            track_.appendHitPattern(PXBDetId(2, 0, 0), TrackingRecHit::missing_inner);
+            track_.appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 1, 0, TrackingRecHit::missing_inner);
+            track_.appendTrackerHitPattern(PixelSubdetector::PixelBarrel, 2, 0, TrackingRecHit::missing_inner);
             break;
     };
 

--- a/DataFormats/TrackReco/BuildFile.xml
+++ b/DataFormats/TrackReco/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="DataFormats/TrackingRecHit"/>
+<use   name="DataFormats/TrackerCommon"/>
 <use   name="FWCore/Utilities"/>
 <use   name="clhepheader"/>
 

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -222,6 +222,14 @@ public:
     bool appendHit(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
     bool appendHit(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
 
+    /**
+     * This is meant to be used only in cases where the an
+     * already-packed hit information is re-interpreted in terms of
+     * HitPattern (i.e. MiniAOD PackedCandidate, and the IO rule for
+     * reading old versions of HitPattern)
+     */
+    bool appendTrackerHit(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType);
+
     // get the pattern of the position-th hit
     uint16_t getHitPattern(HitCategory category, int position) const;
 
@@ -401,6 +409,7 @@ private:
     static uint16_t encode(const TrackingRecHit &hit, const TrackerTopology& ttopo);
     static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
     static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
+    static uint16_t encode(uint16_t det, uint16_t subdet, uint16_t layer, uint16_t side, TrackingRecHit::Type hitType);
 
     // generic count methods
     typedef bool filterType(uint16_t);
@@ -415,6 +424,7 @@ private:
     bool insertExpectedInnerHit(const uint16_t pattern);
     bool insertExpectedOuterHit(const uint16_t pattern);
     void insertHit(const uint16_t pattern);
+    bool appendHit(const uint16_t pattern, TrackingRecHit::Type hitType);
 
     uint16_t getHitPatternByAbsoluteIndex(int position) const;
 

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -220,7 +220,6 @@ public:
     bool appendHit(const TrackingRecHit &hit, const TrackerTopology& ttopo);
     bool appendHit(const TrackingRecHitRef &ref, const TrackerTopology& ttopo);
     bool appendHit(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
-    bool appendHit(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
 
     /**
      * This is meant to be used only in cases where the an
@@ -411,12 +410,10 @@ private:
 
     // detector side for tracker modules (mono/stereo)
     static uint16_t isStereo(DetId i, const TrackerTopology& ttopo);
-    static uint16_t isStereo(DetId i); // DEPRECATED, to be removed
     static bool stripSubdetectorHitFilter(uint16_t pattern, StripSubdetector::SubDetector substructure);
 
     static uint16_t encode(const TrackingRecHit &hit, const TrackerTopology& ttopo);
     static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
-    static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
     static uint16_t encode(uint16_t det, uint16_t subdet, uint16_t layer, uint16_t side, TrackingRecHit::Type hitType);
 
     // generic count methods

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -129,6 +129,8 @@
 #include <ostream>
 #include <memory>
 
+class TrackerTopology;
+
 namespace reco
 {
 
@@ -214,10 +216,11 @@ public:
     HitPattern &operator=(const HitPattern &other);
 
     template<typename I>
-    bool appendHits(const I &begin, const I &end);
-    bool appendHit(const TrackingRecHit &hit);
-    bool appendHit(const TrackingRecHitRef &ref);
-    bool appendHit(const DetId &id, TrackingRecHit::Type hitType);
+    bool appendHits(const I &begin, const I &end, const TrackerTopology& ttopo);
+    bool appendHit(const TrackingRecHit &hit, const TrackerTopology& ttopo);
+    bool appendHit(const TrackingRecHitRef &ref, const TrackerTopology& ttopo);
+    bool appendHit(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
+    bool appendHit(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
 
     // get the pattern of the position-th hit
     uint16_t getHitPattern(HitCategory category, int position) const;
@@ -391,11 +394,13 @@ private:
 
 
     // detector side for tracker modules (mono/stereo)
-    static uint16_t isStereo(DetId i);
+    static uint16_t isStereo(DetId i, const TrackerTopology& ttopo);
+    static uint16_t isStereo(DetId i); // DEPRECATED, to be removed
     static bool stripSubdetectorHitFilter(uint16_t pattern, StripSubdetector::SubDetector substructure);
 
-    static uint16_t encode(const TrackingRecHit &hit);
-    static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType);
+    static uint16_t encode(const TrackingRecHit &hit, const TrackerTopology& ttopo);
+    static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
+    static uint16_t encode(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
 
     // generic count methods
     typedef bool filterType(uint16_t);
@@ -443,10 +448,10 @@ inline std::pair<uint8_t, uint8_t> HitPattern::getCategoryIndexRange(HitCategory
 }
 
 template<typename I>
-bool HitPattern::appendHits(const I &begin, const I &end)
+bool HitPattern::appendHits(const I &begin, const I &end, const TrackerTopology& ttopo)
 {
     for (I hit = begin; hit != end; hit++) {
-        if unlikely((!appendHit(*hit))) {
+      if unlikely((!appendHit(*hit, ttopo))) {
             return false;
         }
     }

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -230,6 +230,14 @@ public:
      */
     bool appendTrackerHit(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType);
 
+    /**
+     * This is meant to be used only in cases where the an
+     * already-packed hit information is re-interpreted in terms of
+     * HitPattern (i.e. the IO rule for reading old versions of
+     * HitPattern)
+     */
+    bool appendMuonHit(const DetId& id, TrackingRecHit::Type hitType);
+
     // get the pattern of the position-th hit
     uint16_t getHitPattern(HitCategory category, int position) const;
 

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -323,6 +323,14 @@ public:
     bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
     bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
 
+    /**
+     * This is meant to be used only in cases where the an
+     * already-packed hit information is re-interpreted in terms of
+     * HitPattern (i.e. MiniAOD PackedCandidate, and the IO rule for
+     * reading old versions of HitPattern)
+     */
+    bool appendTrackerHitPattern(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType);
+
     /// Sets HitPattern as empty
     void resetHitPattern();
 
@@ -427,6 +435,10 @@ inline bool TrackBase::appendHitPattern(const DetId &id, TrackingRecHit::Type hi
 inline bool TrackBase::appendHitPattern(const TrackingRecHit &hit, const TrackerTopology& ttopo)
 {
     return hitPattern_.appendHit(hit, ttopo);
+}
+
+inline bool TrackBase::appendTrackerHitPattern(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType) {
+    return hitPattern_.appendTrackerHit(subdet, layer, stereo, hitType);
 }
 
 inline void TrackBase::resetHitPattern()

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -331,6 +331,14 @@ public:
      */
     bool appendTrackerHitPattern(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType);
 
+    /**
+     * This is meant to be used only in cases where the an
+     * already-packed hit information is re-interpreted in terms of
+     * HitPattern (i.e. the IO rule for reading old versions of
+     * HitPattern)
+     */
+    bool appendMuonHitPattern(const DetId& id, TrackingRecHit::Type hitType);
+
     /// Sets HitPattern as empty
     void resetHitPattern();
 
@@ -439,6 +447,10 @@ inline bool TrackBase::appendHitPattern(const TrackingRecHit &hit, const Tracker
 
 inline bool TrackBase::appendTrackerHitPattern(uint16_t subdet, uint16_t layer, uint16_t stereo, TrackingRecHit::Type hitType) {
     return hitPattern_.appendTrackerHit(subdet, layer, stereo, hitType);
+}
+
+inline bool TrackBase::appendMuonHitPattern(const DetId& id, TrackingRecHit::Type hitType) {
+    return hitPattern_.appendMuonHit(id, hitType);
 }
 
 inline void TrackBase::resetHitPattern()

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -313,14 +313,15 @@ public:
 
     /// append hit patterns from vector of hit references
     template<typename C>
-    bool appendHits(const C &c);
+    bool appendHits(const C &c, const TrackerTopology& ttopo);
 
     template<typename I>
-    bool appendHits(const I &begin, const I &end);
+    bool appendHits(const I &begin, const I &end, const TrackerTopology& ttopo);
 
     /// append a single hit to the HitPattern
-    bool appendHitPattern(const TrackingRecHit &hit);
-    bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType);
+    bool appendHitPattern(const TrackingRecHit &hit, const TrackerTopology& ttopo);
+    bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
+    bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
 
     /// Sets HitPattern as empty
     void resetHitPattern();
@@ -418,9 +419,14 @@ inline bool TrackBase::appendHitPattern(const DetId &id, TrackingRecHit::Type hi
     return hitPattern_.appendHit(id, hitType);
 }
 
-inline bool TrackBase::appendHitPattern(const TrackingRecHit &hit)
+inline bool TrackBase::appendHitPattern(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo)
 {
-    return hitPattern_.appendHit(hit);
+    return hitPattern_.appendHit(id, hitType, ttopo);
+}
+
+inline bool TrackBase::appendHitPattern(const TrackingRecHit &hit, const TrackerTopology& ttopo)
+{
+    return hitPattern_.appendHit(hit, ttopo);
 }
 
 inline void TrackBase::resetHitPattern()
@@ -429,15 +435,15 @@ inline void TrackBase::resetHitPattern()
 }
 
 template<typename I>
-bool TrackBase::appendHits(const I &begin, const I &end)
+bool TrackBase::appendHits(const I &begin, const I &end, const TrackerTopology& ttopo)
 {
-    return hitPattern_.appendHits(begin, end);
+    return hitPattern_.appendHits(begin, end, ttopo);
 }
 
 template<typename C>
-bool TrackBase::appendHits(const C &c)
+bool TrackBase::appendHits(const C &c, const TrackerTopology& ttopo)
 {
-    return setHitPattern(c.begin(), c.end());
+    return hitPattern_.appendHits(c.begin(), c.end(), ttopo);
 }
 
 inline TrackBase::index TrackBase::covIndex(index i, index j)

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -321,7 +321,6 @@ public:
     /// append a single hit to the HitPattern
     bool appendHitPattern(const TrackingRecHit &hit, const TrackerTopology& ttopo);
     bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo);
-    bool appendHitPattern(const DetId &id, TrackingRecHit::Type hitType); // DEPRECATED, to be removed
 
     /**
      * This is meant to be used only in cases where the an
@@ -428,11 +427,6 @@ private:
 inline const HitPattern & TrackBase::hitPattern() const
 {
     return hitPattern_;
-}
-
-inline bool TrackBase::appendHitPattern(const DetId &id, TrackingRecHit::Type hitType)
-{
-    return hitPattern_.appendHit(id, hitType);
 }
 
 inline bool TrackBase::appendHitPattern(const DetId &id, TrackingRecHit::Type hitType, const TrackerTopology& ttopo)

--- a/DataFormats/TrackReco/src/HitPattern.cc
+++ b/DataFormats/TrackReco/src/HitPattern.cc
@@ -130,24 +130,7 @@ uint16_t HitPattern::encode(const DetId &id, TrackingRecHit::Type hitType, const
     if (detid == DetId::Tracker) {
         layer = ttopo.layer(id);
     } else if (detid == DetId::Muon) {
-        switch (subdet) {
-        case MuonSubdetId::DT:
-            layer = ((DTLayerId(id.rawId()).station() - 1) << 2);
-            layer |= DTLayerId(id.rawId()).superLayer();
-            break;
-        case MuonSubdetId::CSC:
-            layer = ((CSCDetId(id.rawId()).station() - 1) << 2);
-            layer |= (CSCDetId(id.rawId()).ring() - 1);
-            break;
-        case MuonSubdetId::RPC: 
-            {
-                RPCDetId rpcid(id.rawId());
-                layer = ((rpcid.station() - 1) << 2);
-                layer |= (rpcid.station() <= 2) ? ((rpcid.layer() - 1) << 1) : 0x0;
-                layer |= abs(rpcid.region());
-            }
-            break;
-        }
+        layer = encodeMuonLayer(id);
     }
 
     // adding mono/stereo bit
@@ -174,83 +157,6 @@ uint16_t HitPattern::encode(uint16_t det, uint16_t subdet, uint16_t layer, uint1
     pattern |= (layer & LayerMask) << LayerOffset;
 
     // adding mono/stereo bit
-    pattern |= (side & SideMask) << SideOffset;
-
-    TrackingRecHit::Type patternHitType = (hitType == TrackingRecHit::missing_inner ||
-                                           hitType == TrackingRecHit::missing_outer) ? TrackingRecHit::missing : hitType;
-
-    pattern |= (patternHitType & HitTypeMask) << HitTypeOffset;
-
-    return pattern;
-}
-
-uint16_t HitPattern::encode(const DetId &id, TrackingRecHit::Type hitType)
-{
-    uint16_t pattern = HitPattern::EMPTY_PATTERN;
-
-    uint16_t detid = id.det();
-
-    // adding tracker/muon detector bit
-    pattern |= (detid & SubDetectorMask) << SubDetectorOffset;
-
-    // adding substructure (PXB, PXF, TIB, TID, TOB, TEC, or DT, CSC, RPC) bits
-    uint16_t subdet = id.subdetId();
-    pattern |= (subdet & SubstrMask) << SubstrOffset;
-
-    // adding layer/disk/wheel bits
-    uint16_t layer = 0x0;
-    if (detid == DetId::Tracker) {
-        switch (subdet) {
-        case PixelSubdetector::PixelBarrel:
-            layer = PXBDetId(id).layer();
-            break;
-        case PixelSubdetector::PixelEndcap:
-            layer = PXFDetId(id).disk();
-            break;
-        case StripSubdetector::TIB:
-            layer = TIBDetId(id).layer();
-            break;
-        case StripSubdetector::TID:
-            layer = TIDDetId(id).wheel();
-            break;
-        case StripSubdetector::TOB:
-            layer = TOBDetId(id).layer();
-            break;
-        case StripSubdetector::TEC:
-            layer = TECDetId(id).wheel();
-            break;
-        }
-    } else if (detid == DetId::Muon) {
-        switch (subdet) {
-        case MuonSubdetId::DT:
-            layer = ((DTLayerId(id.rawId()).station() - 1) << 2);
-            layer |= DTLayerId(id.rawId()).superLayer();
-            break;
-        case MuonSubdetId::CSC:
-            layer = ((CSCDetId(id.rawId()).station() - 1) << 2);
-            layer |= (CSCDetId(id.rawId()).ring() - 1);
-            break;
-        case MuonSubdetId::RPC: 
-            {
-                RPCDetId rpcid(id.rawId());
-                layer = ((rpcid.station() - 1) << 2);
-                layer |= (rpcid.station() <= 2) ? ((rpcid.layer() - 1) << 1) : 0x0;
-                layer |= abs(rpcid.region());
-            }
-            break;
-        }
-    }
-
-    pattern |= (layer & LayerMask) << LayerOffset;
-
-    // adding mono/stereo bit
-    uint16_t side = 0x0;
-    if (detid == DetId::Tracker) {
-        side = isStereo(id);
-    } else if (detid == DetId::Muon) {
-        side = 0x0;
-    }
-
     pattern |= (side & SideMask) << SideOffset;
 
     TrackingRecHit::Type patternHitType = (hitType == TrackingRecHit::missing_inner ||
@@ -354,67 +260,6 @@ bool HitPattern::appendMuonHit(const DetId& id, TrackingRecHit::Type hitType) {
     uint16_t detid = id.det();
     uint16_t subdet = id.subdetId();
     return appendHit(encode(detid, subdet, encodeMuonLayer(id), 0, hitType), hitType);
-}
-
-bool HitPattern::appendHit(const DetId &id, TrackingRecHit::Type hitType)
-{
-    //if HitPattern is full, journey ends no matter what.
-    if unlikely((hitCount == HitPattern::MaxHits)) {
-        return false;
-    }
-
-    uint16_t pattern = HitPattern::encode(id, hitType);
-
-    switch (hitType) {
-    case TrackingRecHit::valid:
-    case TrackingRecHit::missing:
-    case TrackingRecHit::inactive:
-    case TrackingRecHit::bad:
-        // hitCount != endT => we are not inserting T type of hits but of T'
-        // 0 != beginT || 0 != endT => we already have hits of T type
-        // so we already have hits of T in the vector and we don't want to
-        // mess them with T' hits.
-        if unlikely(((hitCount != endTrackHits) && (0 != beginTrackHits || 0 != endTrackHits))) {
-            cms::Exception("HitPattern")
-                    << "TRACK_HITS"
-                    << " were stored on this object before hits of some other category were inserted "
-                    << "but hits of the same category should be inserted in a row. "
-                    << "Please rework the code so it inserts all "
-                    << "TRACK_HITS"
-                    << " in a row.";
-            return false;
-        }
-        return insertTrackHit(pattern);
-        break;
-    case TrackingRecHit::missing_inner:
-        if unlikely(((hitCount != endInner) && (0 != beginInner || 0 != endInner))) {
-            cms::Exception("HitPattern")
-                    << "MISSING_INNER_HITS"
-                    << " were stored on this object before hits of some other category were inserted "
-                    << "but hits of the same category should be inserted in a row. "
-                    << "Please rework the code so it inserts all "
-                    << "MISSING_INNER_HITS"
-                    << " in a row.";
-            return false;
-        }
-        return insertExpectedInnerHit(pattern);
-        break;
-    case TrackingRecHit::missing_outer:
-        if unlikely(((hitCount != endOuter) && (0 != beginOuter || 0 != endOuter))) {
-            cms::Exception("HitPattern")
-                    << "MISSING_OUTER_HITS"
-                    << " were stored on this object before hits of some other category were inserted "
-                    << "but hits of the same category should be inserted in a row. "
-                    << "Please rework the code so it inserts all "
-                    << "MISSING_OUTER_HITS"
-                    << " in a row.";
-            return false;
-        }
-        return insertExpectedOuterHit(pattern);
-        break;
-    }
-
-    return false;
 }
 
 uint16_t HitPattern::getHitPatternByAbsoluteIndex(int position) const
@@ -1040,37 +885,6 @@ uint16_t HitPattern::isStereo(DetId i, const TrackerTopology& ttopo)
         return ttopo.tobIsStereo(i);
     case StripSubdetector::TEC:
         return ttopo.tecIsStereo(i);
-    default:
-        return 0;
-    }
-}
-
-uint16_t HitPattern::isStereo(DetId i)
-{
-    if (i.det() != DetId::Tracker) {
-        return 0;
-    }
-
-    switch (i.subdetId()) {
-    case PixelSubdetector::PixelBarrel:
-    case PixelSubdetector::PixelEndcap:
-        return 0;
-    case StripSubdetector::TIB: {
-        TIBDetId id = i;
-        return id.isStereo();
-    }
-    case StripSubdetector::TID: {
-        TIDDetId id = i;
-        return id.isStereo();
-    }
-    case StripSubdetector::TOB: {
-        TOBDetId id = i;
-        return id.isStereo();
-    }
-    case StripSubdetector::TEC: {
-        TECDetId id = i;
-        return id.isStereo();
-    }
     default:
         return 0;
     }

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -51,7 +51,7 @@
                 }
             };
 
-            auto oldHitPatternToTrackingRecHitPair = [&](const uint32_t pattern) {
+            auto appendOldHitPattern = [&](const uint32_t pattern) {
                 // value used for those parameters needed by XXXDetId constructors
                 // but that we do not care about because they are not stored in the
                 // HitPattern.
@@ -107,26 +107,7 @@
 
                 DetId detId;
                 if (detector == DetId::Tracker) {
-                    switch (subdet) {
-                    case PixelSubdetector::PixelBarrel:
-                        detId = PXBDetId(layer, DONT_CARE, DONT_CARE);
-                        break;
-                    case PixelSubdetector::PixelEndcap:
-                        detId = PXFDetId(DONT_CARE, layer, DONT_CARE, DONT_CARE, DONT_CARE);
-                        break;
-                    case StripSubdetector::TIB:
-                        detId = TIBDetId(layer, DONT_CARE, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    case StripSubdetector::TID:
-                        detId = TIDDetId(DONT_CARE, layer, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    case StripSubdetector::TOB:
-                        detId = TOBDetId(layer, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    case StripSubdetector::TEC:
-                        detId = TECDetId(DONT_CARE, layer, DONT_CARE, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    }
+                    return newObj->appendTrackerHit(subdet, layer, stereo, hitType);
                 } else if (detector == DetId::Muon) {
                     switch (subdet) {
                     case MuonSubdetId::DT: {
@@ -149,8 +130,9 @@
                     }
                     break;
                     }
+                    return newObj->appendMuonHit(detId, hitType);
                 }
-                return std::pair<DetId, TrackingRecHit::Type>(detId, hitType);
+                return false;
             };
 
             auto fillNewHitPatternWithOldHitPattern = [&](const uint32_t oldHitPattern[]) {
@@ -160,8 +142,7 @@
                     if (pattern == 0) {
                         break;
                     }
-                    std::pair<DetId, TrackingRecHit::Type> hitInfo = oldHitPatternToTrackingRecHitPair(pattern);
-                    if (!newObj->appendHit(hitInfo.first, hitInfo.second)) {
+                    if(!appendOldHitPattern(pattern)) {
                         return false;
                     }
                 }
@@ -183,7 +164,7 @@
       <![CDATA[
             using namespace reco;
 
-            auto newHitPatternToPair = [&](const uint16_t pattern, const HitPattern::HitCategory category) {
+            auto appendNewHitPattern = [&](const uint16_t pattern, const HitPattern::HitCategory category) {
                 // value used for those parameters needed by XXXDetId constructors
                 // but that we do not care about.
                 const uint8_t DONT_CARE = 1;
@@ -241,28 +222,15 @@
                     break;
                 }
 
+                if (category == HitPattern::MISSING_INNER_HITS) {
+                    hitType = TrackingRecHit::missing_inner;
+                } else if (category == HitPattern::MISSING_OUTER_HITS) {
+                    hitType = TrackingRecHit::missing_outer;
+                }
+
                 DetId detId;
                 if (detector == DetId::Tracker) {
-                    switch (subdet) {
-                    case PixelSubdetector::PixelBarrel:
-                        detId = PXBDetId(layer, DONT_CARE, DONT_CARE);
-                        break;
-                    case PixelSubdetector::PixelEndcap:
-                        detId = PXFDetId(DONT_CARE, layer, DONT_CARE, DONT_CARE, DONT_CARE);
-                        break;
-                    case StripSubdetector::TIB:
-                        detId = TIBDetId(layer, DONT_CARE, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    case StripSubdetector::TID:
-                        detId = TIDDetId(DONT_CARE, layer, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    case StripSubdetector::TOB:
-                        detId = TOBDetId(layer, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    case StripSubdetector::TEC:
-                        detId = TECDetId(DONT_CARE, layer, DONT_CARE, DONT_CARE, DONT_CARE, DONT_CARE, stereo);
-                        break;
-                    }
+                    return newObj->appendTrackerHitPattern(subdet, layer, stereo, hitType);
                 } else if (detector == DetId::Muon) {
                     switch (subdet) {
                     case MuonSubdetId::DT: {
@@ -285,23 +253,16 @@
                     }
                     break;
                     }
+                    return newObj->appendMuonHitPattern(detId, hitType);
                 }
-
-                if (category == HitPattern::MISSING_INNER_HITS) {
-                    hitType = TrackingRecHit::missing_inner;
-                } else if (category == HitPattern::MISSING_OUTER_HITS) {
-                    hitType = TrackingRecHit::missing_outer;
-                }
-
-                return std::pair<DetId, TrackingRecHit::Type>(detId, hitType);
+                return false;
             };
 
             auto fillNewHitPatternFromNewHitPattern = [&](const HitPattern hitPattern, const HitPattern::HitCategory category) {
                 uint8_t hitCount = hitPattern.numberOfHits(HitPattern::TRACK_HITS);
                 for (int i = 0; i < hitCount; i++) {
                     uint16_t pattern = hitPattern.getHitPattern(HitPattern::TRACK_HITS, i);
-                    std::pair<DetId, TrackingRecHit::Type> hitInfo = newHitPatternToPair(pattern, category);
-                    if (!newObj->appendHitPattern(hitInfo.first, hitInfo.second)) {
+                    if(!appendNewHitPattern(pattern, category)) {
                         return false;
                     }
                 }

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -4,11 +4,15 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 
 #include "DataFormats/Common/interface/Handle.h"
 #include "DataFormats/Common/interface/OwnVector.h"
 
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 //Pixel Specific stuff
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
@@ -82,6 +86,10 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
   
   TracksWithRecHits pixeltracks;
   TracksWithRecHits cleanedTracks;
+
+  edm::ESHandle<TrackerTopology> httopo;
+  es.get<TrackerTopologyRcd>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
   
   edm::Handle<TrajectorySeedCollection> theSeeds;
   e.getByToken(seedProducerToken,theSeeds);
@@ -142,7 +150,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     
     for (unsigned int k = 0; k < hits.size(); k++) {
       TrackingRecHit *hit = (hits.at(k))->clone();
-      track->appendHitPattern(*hit);
+      track->appendHitPattern(*hit, ttopo);
       recHits->push_back(hit);
     }
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
@@ -48,7 +48,8 @@ private:
 		std::auto_ptr<reco::TrackCollection>& selTracks,
 		std::auto_ptr<reco::TrackExtraCollection>& selTrackExtras,
 		std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
-		AlgoProductCollection& algoResults, TransientTrackingRecHitBuilder const * hitBuilder);
+		AlgoProductCollection& algoResults, TransientTrackingRecHitBuilder const * hitBuilder,
+                const TrackerTopology *ttopo);
 };
 
 #endif

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
@@ -86,5 +86,5 @@ CosmicMuonProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   // Update the services
   theService->update(iSetup);
-  theTrackFinder->reconstruct(seeds,iEvent);
+  theTrackFinder->reconstruct(seeds,iEvent,iSetup);
 }

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
@@ -98,7 +98,7 @@ GlobalCosmicMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     MuonTrajectoryBuilder::TrackCand cosCand = MuonTrajectoryBuilder::TrackCand((Trajectory*)(0),cosTrackRef);
     cosTrackCands.push_back(cosCand); 
   }
-  theTrackFinder->reconstruct(cosTrackCands,iEvent);
+  theTrackFinder->reconstruct(cosTrackCands,iEvent,iSetup);
   LogTrace(metname)<<"Event loaded";
 
 }

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
@@ -143,7 +143,7 @@ void GlobalMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
     }
   }
     
-  theTrackFinder->reconstruct(staTrackCands, event);      
+  theTrackFinder->reconstruct(staTrackCands, event, eventSetup);
   
   
   LogTrace(metname)<<"Event loaded"

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
@@ -148,7 +148,7 @@ void TevMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
 	miniMap.push_back(thisPair);
       }
     }
-    theTrackLoader->loadTracks(trajectories,event,miniMap,glbMuons,theRefits[ww]);
+    theTrackLoader->loadTracks(trajectories,event,miniMap,glbMuons, *tTopo, theRefits[ww]);
   }
 
   filler.insert(glbMuons, dytTmp.begin(), dytTmp.end());

--- a/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
@@ -119,7 +119,7 @@ void L2MuonProducer::produce(Event& event, const EventSetup& eventSetup){
   
   // Reconstruct 
   LogTrace(metname)<<"Track Reconstruction"<<endl;
-  theTrackFinder->reconstruct(seeds,event);
+  theTrackFinder->reconstruct(seeds,event, eventSetup);
   
   LogTrace(metname)<<"Event loaded"
 		   <<"================================"

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -145,7 +145,7 @@ void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
     L2TrackCands.push_back(L2Cand);
   }
   
-  theTrackFinder->reconstruct(L2TrackCands, event);      
+  theTrackFinder->reconstruct(L2TrackCands, event, eventSetup);
   
   LogTrace(metname)<<"Event loaded"
                    <<"================================"

--- a/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
+++ b/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
@@ -119,7 +119,7 @@ void StandAloneMuonProducer::produce(Event& event, const EventSetup& eventSetup)
 
   // Reconstruct 
   LogTrace(metname)<<"Track Reconstruction"<<endl;
-  theTrackFinder->reconstruct(seeds,event);
+  theTrackFinder->reconstruct(seeds,event, eventSetup);
  
   LogTrace(metname)<<"Event loaded"
 		   <<"================================"

--- a/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
+class TrackerTopology;
 
 class MuonTrajectoryBuilder;
 class MuonTrajectoryCleaner;
@@ -47,12 +48,13 @@ class MuonTrackFinder {
   
     /// reconstruct standalone tracks starting from a collection of seeds
     edm::OrphanHandle<reco::TrackCollection> reconstruct(const edm::Handle<edm::View<TrajectorySeed> >&,
-							 edm::Event&);
+                                                         edm::Event&,
+                                                         const edm::EventSetup&);
 
     /// reconstruct global tracks starting from a collection of
     /// standalone tracks and one of trakectories. If the latter
     /// is invalid, trajectories are refitted.
-    void reconstruct(const std::vector<TrackCand>&, edm::Event&);
+    void reconstruct(const std::vector<TrackCand>&, edm::Event&, const edm::EventSetup&);
     
  private:
     
@@ -60,10 +62,10 @@ class MuonTrackFinder {
     void setEvent(const edm::Event&);
 
     /// convert the trajectories into tracks and load them in to the event
-    edm::OrphanHandle<reco::TrackCollection> load(const TrajectoryContainer&, edm::Event&);
+    edm::OrphanHandle<reco::TrackCollection> load(const TrajectoryContainer&, edm::Event&, const TrackerTopology &ttopo);
 
     /// convert the trajectories into tracks and load them in to the event
-    void load(const CandidateContainer&, edm::Event&);
+    void load(const CandidateContainer&, edm::Event&, const TrackerTopology &ttopo);
 
   private:
 

--- a/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
@@ -35,6 +35,7 @@ class MuonUpdatorAtVertex;
 class TrajectorySmoother;
 class ForwardDetLayer;
 class BarrelDetLayer;
+class TrackerTopology;
 
 class MuonTrackLoader {
   public:
@@ -50,25 +51,30 @@ class MuonTrackLoader {
    
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
-                                                        edm::Event&,const std::string& = "", 
+                                                        edm::Event&,
+                                                        const TrackerTopology& ttopo,
+                                                        const std::string& = "", 
 							bool = true);
 
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
                                                         edm::Event&, std::vector<bool>&,
-							const std::string& = "", 
+                                                        const TrackerTopology& ttopo,
+							const std::string& = "",
 							bool = true);
 
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
                                                         edm::Event&,const std::vector<std::pair<Trajectory*, reco::TrackRef> >&,
                                                         edm::Handle<reco::TrackCollection> const& trackHandle,
+                                                        const TrackerTopology& ttopo,
 							const std::string& = "", 
 							bool = true);
 
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::MuonTrackLinksCollection> loadTracks(const CandidateContainer&,
-								 edm::Event&); 
+                                                                 edm::Event&,
+                                                                 const TrackerTopology& ttopo);
   
   private:
     static std::vector<const TrackingRecHit*> unpackHit(const TrackingRecHit &hit);

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
@@ -13,6 +13,9 @@
 #include <TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h>
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 MuonErrorMatrixAdjuster::MuonErrorMatrixAdjuster(const edm::ParameterSet& iConfig)
 {
   theCategory="MuonErrorMatrixAdjuster";
@@ -136,7 +139,8 @@ reco::TrackExtra * MuonErrorMatrixAdjuster::makeTrackExtra(const reco::Track & r
 bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track & recotrack_orig,
 				       reco::Track & recotrack,
 				       reco::TrackExtra & trackextra,
-				       TrackingRecHitCollection& RHcol){
+                                       TrackingRecHitCollection& RHcol,
+                                       const TrackerTopology& ttopo){
   //loop over the hits of the original track
   trackingRecHit_iterator recHit = recotrack_orig.recHitsBegin();
   auto const firstHitIndex = theRHi;
@@ -145,7 +149,7 @@ bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track & recotrack_orig,
     TrackingRecHit * hit = (*recHit)->clone();
     
     //put it on the new track
-    recotrack.appendHitPattern(*hit);
+    recotrack.appendHitPattern(*hit, ttopo);
     //copy them in the new collection
     RHcol.push_back(hit);
     ++theRHi;
@@ -172,7 +176,11 @@ MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   
   //get the mag field
   iSetup.get<IdealMagneticFieldRecord>().get( theField);
-  
+
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
+
   //prepare the output collection
   std::auto_ptr<reco::TrackCollection> Toutput(new reco::TrackCollection());
   std::auto_ptr<TrackingRecHitCollection> TRHoutput(new TrackingRecHitCollection());
@@ -209,7 +217,7 @@ MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	continue;}
       
       //attach the collection of rechits
-      if (!attachRecHits(recotrack_orig,recotrackref,*extra,*TRHoutput)){
+      if (!attachRecHits(recotrack_orig,recotrackref,*extra,*TRHoutput, ttopo)){
 	edm::LogError( theCategory)<<"cannot attach any rechits on this track";
 	//pop the inserted track
 	Toutput->pop_back();

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
@@ -78,7 +78,8 @@ class MuonErrorMatrixAdjuster : public edm::EDProducer {
   bool attachRecHits(const reco::Track & recotrack_orig,
 		     reco::Track & recotrack,
 		     reco::TrackExtra & trackextra,
-		     TrackingRecHitCollection& RHcol);
+		     TrackingRecHitCollection& RHcol,
+                     const TrackerTopology& ttopo);
       
   // ----------member data ---------------------------
   /// log category: MuonErrorMatrixAdjuster

--- a/RecoMuon/TrackingTools/src/MuonTrackFinder.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackFinder.cc
@@ -22,6 +22,9 @@
 #include "TrackingTools/GeomPropagators/interface/Propagator.h"
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 using namespace std;
 using namespace edm;
 
@@ -60,30 +63,36 @@ void MuonTrackFinder::setEvent(const Event& event) {
 // convert the trajectories into tracks and load them in to the event
 edm::OrphanHandle<reco::TrackCollection>  
 MuonTrackFinder::load(const TrajectoryContainer& trajectories, 
-		      edm::Event& event) {
+		      edm::Event& event,
+                      const TrackerTopology& ttopo) {
   
-  return theTrackLoader->loadTracks(trajectories, event);
+  return theTrackLoader->loadTracks(trajectories, event, ttopo);
 }
 
 // convert the trajectories into tracks and load them in to the event
 void MuonTrackFinder::load(const CandidateContainer& muonCands,
-			   Event& event) {
+			   Event& event,
+                           const TrackerTopology& ttopo) {
                            
-    theTrackLoader->loadTracks(muonCands, event);
+  theTrackLoader->loadTracks(muonCands, event, ttopo);
 
 }
 
 // reconstruct trajectories
 edm::OrphanHandle<reco::TrackCollection>
 MuonTrackFinder::reconstruct(const edm::Handle<edm::View<TrajectorySeed> >& seeds,
-			     edm::Event& event){
+			     edm::Event& event,
+                             const edm::EventSetup& es){
   
   const string metname = "Muon|RecoMuon|MuonTrackFinder";
   LogTrace(metname)<<"SA Recostruction starting from: "<<seeds->size()<<endl;  
   
   // Percolate the event 
   setEvent(event);
-  
+
+  edm::ESHandle<TrackerTopology> httopo;
+  es.get<TrackerTopologyRcd>().get(httopo);
+
   // Trajectory container
   TrajectoryContainer muonTrajectories;
   TrajectorySeedCollection::size_type nSeed = 0;
@@ -107,19 +116,23 @@ MuonTrackFinder::reconstruct(const edm::Handle<edm::View<TrajectorySeed> >& seed
   // convert the trajectories into tracks and load them in to the event
   LogTrace(metname)
     <<"Convert the trajectories into tracks and load them in to the event"<<endl;
-  return load(muonTrajectories,event);
+  return load(muonTrajectories,event, *httopo);
   
 }
 
 
 // reconstruct trajectories
 void MuonTrackFinder::reconstruct(const std::vector<TrackCand>& staCandColl,
-				  Event& event){
+				  Event& event,
+                                  const edm::EventSetup& es){
 
   const string metname = "Muon|RecoMuon|MuonTrackFinder";
 
   // percolate the event 
   setEvent(event);
+
+  edm::ESHandle<TrackerTopology> httopo;
+  es.get<TrackerTopologyRcd>().get(httopo);
 
   // Muon Candidate container
   CandidateContainer muonCandidates;
@@ -135,6 +148,6 @@ void MuonTrackFinder::reconstruct(const std::vector<TrackCand>& staCandColl,
 
   // convert the trajectories into staTracks and load them into the event
   LogTrace(metname)<<"Load Muon Candidates into the event"<<endl;
-  load(muonCandidates,event);
+  load(muonCandidates,event, *httopo);
 
 }

--- a/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
@@ -123,14 +123,15 @@ MuonTrackLoader::~MuonTrackLoader(){
 
 OrphanHandle<reco::TrackCollection> 
 MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
-			    Event& event, const string& instance, bool reallyDoSmoothing) {
+			    Event& event, const TrackerTopology& ttopo, const string& instance, bool reallyDoSmoothing) {
   std::vector<bool> dummyVecBool;
-  return loadTracks(trajectories, event, dummyVecBool, instance, reallyDoSmoothing);
+  return loadTracks(trajectories, event, dummyVecBool, ttopo, instance, reallyDoSmoothing);
 }
   
 OrphanHandle<reco::TrackCollection> 
 MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
 			    Event& event,  std::vector<bool>& tkBoolVec, 
+                            const TrackerTopology& ttopo,
 			    const string& instance, bool reallyDoSmoothing) {
   
   const bool doSmoothing = theSmoothingStep && reallyDoSmoothing;
@@ -285,7 +286,7 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
       TrackingRecHit *singleHit = (**recHit).hit()->clone();
       std::vector<const TrackingRecHit*> hits = MuonTrackLoader::unpackHit(*singleHit);
       for (std::vector<const TrackingRecHit*>::const_iterator it = hits.begin(); it != hits.end(); ++it) {
-          if unlikely(!track.appendHitPattern(**it)){
+          if unlikely(!track.appendHitPattern(**it, ttopo)){
               break;
           }
       }
@@ -293,7 +294,7 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
       if(theUpdatingAtVtx && updateResult.first){
           std::vector<const TrackingRecHit*> hits = MuonTrackLoader::unpackHit(*singleHit);
           for (std::vector<const TrackingRecHit*>::const_iterator it = hits.begin(); it != hits.end(); ++it) {
-              if unlikely(!updateResult.second.appendHitPattern(**it)){
+              if unlikely(!updateResult.second.appendHitPattern(**it, ttopo)){
                   break;
               }
           }
@@ -364,7 +365,8 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
 
 OrphanHandle<reco::MuonTrackLinksCollection> 
 MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
-			    Event& event) {
+			    Event& event,
+                            const TrackerTopology& ttopo) {
 
   const string metname = "Muon|RecoMuon|MuonTrackLoader";
   
@@ -385,7 +387,7 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
     if(thePutTkTrackFlag){
       //will take care of putting nothing in the event but the empty collection
       TrajectoryContainer trackerTrajs;
-      loadTracks(trackerTrajs, event, theL2SeededTkLabel, theSmoothTkTrackFlag);
+      loadTracks(trackerTrajs, event, ttopo, theL2SeededTkLabel, theSmoothTkTrackFlag);
     } 
 
     return event.put(trackLinksCollection);
@@ -417,14 +419,14 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
   // FIXME: could this be done one track at a time in the previous loop?
   LogTrace(metname) << "Build combinedTracks";
   std::vector<bool> combTksVec(combinedTrajs.size(), false); 
-  OrphanHandle<reco::TrackCollection> combinedTracks = loadTracks(combinedTrajs, event, combTksVec);
+  OrphanHandle<reco::TrackCollection> combinedTracks = loadTracks(combinedTrajs, event, combTksVec, ttopo);
 
   OrphanHandle<reco::TrackCollection> trackerTracks;
   std::vector<bool> trackerTksVec(trackerTrajs.size(), false); 
   if(thePutTkTrackFlag) {
     LogTrace(metname) << "Build trackerTracks: "
 		      << trackerTrajs.size();
-    trackerTracks = loadTracks(trackerTrajs, event, trackerTksVec, theL2SeededTkLabel, theSmoothTkTrackFlag);
+    trackerTracks = loadTracks(trackerTrajs, event, trackerTksVec, ttopo, theL2SeededTkLabel, theSmoothTkTrackFlag);
   } else {
     for (TrajectoryContainer::iterator it = trackerTrajs.begin(); it != trackerTrajs.end(); ++it) {
         if(*it) delete *it;
@@ -480,7 +482,7 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
 
 OrphanHandle<reco::TrackCollection> 
 MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
-			    Event& event, const std::vector<std::pair<Trajectory*,reco::TrackRef> >& miniMap, Handle<reco::TrackCollection> const& trackHandle, const string& instance, bool reallyDoSmoothing) {
+			    Event& event, const std::vector<std::pair<Trajectory*,reco::TrackRef> >& miniMap, Handle<reco::TrackCollection> const& trackHandle, const TrackerTopology& ttopo, const string& instance, bool reallyDoSmoothing) {
   
   const bool doSmoothing = theSmoothingStep && reallyDoSmoothing;
   
@@ -627,7 +629,7 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
     
     std::vector<const TrackingRecHit*> hits = MuonTrackLoader::unpackHit(*singleHit);
     for (std::vector<const TrackingRecHit*>::const_iterator it = hits.begin(); it != hits.end(); ++it) {
-        if unlikely(!track.appendHitPattern(**it)){
+        if unlikely(!track.appendHitPattern(**it, ttopo)){
             break;
         }
     }
@@ -635,7 +637,7 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
     if(theUpdatingAtVtx && updateResult.first){
         std::vector<const TrackingRecHit*> hits = MuonTrackLoader::unpackHit(*singleHit);
         for (std::vector<const TrackingRecHit*>::const_iterator it = hits.begin(); it != hits.end(); ++it) {
-            if unlikely(!updateResult.second.appendHitPattern(**it)){
+            if unlikely(!updateResult.second.appendHitPattern(**it, ttopo)){
                 break;
             }
         }

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -2,6 +2,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -9,6 +10,9 @@
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
+
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 #include <vector>
 
@@ -43,11 +47,14 @@ void PixelTrackProducer::produce(edm::Event& ev, const edm::EventSetup& es)
   TracksWithTTRHs tracks;
   theReconstruction.run(tracks,ev,es);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  es.get<TrackerTopologyRcd>().get(httopo);
+
   // store tracks
-  store(ev, tracks);
+  store(ev, tracks, *httopo);
 }
 
-void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWithHits)
+void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWithHits, const TrackerTopology& ttopo)
 {
   std::auto_ptr<reco::TrackCollection> tracks(new reco::TrackCollection());
   std::auto_ptr<TrackingRecHitCollection> recHits(new TrackingRecHitCollection());
@@ -64,7 +71,7 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
     {
       TrackingRecHit *hit = hits[k]->hit()->clone();
 
-      track->appendHitPattern(*hit);
+      track->appendHitPattern(*hit, ttopo);
       recHits->push_back(hit);
     }
     tracks->push_back(*track);

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
@@ -6,6 +6,7 @@
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h"
 
 namespace edm { class Event; class EventSetup; class ParameterSet; }
+class TrackerTopology;
 
 class PixelTrackProducer :  public edm::stream::EDProducer<> {
 
@@ -19,7 +20,7 @@ public:
   virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
 
 private:
-  void store(edm::Event& ev, const pixeltrackfitting::TracksWithTTRHs& selectedTracks);
+  void store(edm::Event& ev, const pixeltrackfitting::TracksWithTTRHs& selectedTracks, const TrackerTopology& ttopo);
   PixelTrackReconstruction theReconstruction;
 };
 #endif

--- a/RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h
@@ -41,7 +41,7 @@ public:
 			std::auto_ptr<reco::GsfTrackExtraCollection>&,
 			std::auto_ptr<std::vector<Trajectory> >&,
 			AlgoProductCollection&, TransientTrackingRecHitBuilder const*,
-			const reco::BeamSpot&);
+			const reco::BeamSpot&, const TrackerTopology *ttopo);
 
 
 protected:

--- a/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
@@ -29,6 +29,7 @@ public:
 			std::auto_ptr<reco::TrackExtraCollection>&,
 			std::auto_ptr<std::vector<Trajectory> >&,
 			AlgoProductCollection&, TransientTrackingRecHitBuilder const*,
+                        const TrackerTopology *ttopo,
 			//allow to fill different tracks collections if necessary ::
 			//0: not needed
 			//1: Before DAF

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -84,7 +84,8 @@ public:
   }
 
   void setSecondHitPattern(Trajectory* traj, T& track, 
-			   const Propagator* prop, const MeasurementTrackerEvent* measTk );
+			   const Propagator* prop, const MeasurementTrackerEvent* measTk,
+                           const TrackerTopology* ttopo);
 
   const edm::ParameterSet& getConf() const {return conf_;}
  private:

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -155,7 +155,8 @@ TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,edm::Handle<TrackCollectio
 
 template <class T> void
 TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track, 
-					  const Propagator* prop, const MeasurementTrackerEvent* measTk){
+					  const Propagator* prop, const MeasurementTrackerEvent* measTk,
+                                          const TrackerTopology* ttopo){
   using namespace std;
   /// have to clone the propagator in order to change its propagation direction. Have to remember to delete the clone!!
   Propagator* localProp = prop->clone();
@@ -227,7 +228,7 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
         //if(measDet->isActive() && !measDet->hasBadComponents(detWithState.front().second)){
         if(measDet.isActive()){ 
 	        InvalidTrackingRecHit tmpHit(*detWithState.front().first, TrackingRecHit::missing_inner);
-	        track.appendHitPattern(tmpHit);
+	        track.appendHitPattern(tmpHit, *ttopo);
 	        //cout << "WARNING: this hit is marked as lost because the detector was marked as active" << endl;
         }else{
 	        //cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;
@@ -249,7 +250,7 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
       //if(measDet->isActive() && !measDet->hasBadComponents(detWithState.front().second)){	
       if(measDet.isActive()){
           InvalidTrackingRecHit tmpHit(*detWithState.front().first,TrackingRecHit::missing_outer);
-          track.appendHitPattern(tmpHit);
+          track.appendHitPattern(tmpHit, *ttopo);
 	      //cout << "WARNING: this hit is marked as lost because the detector was marked as active" << endl;
       }else{
 	      //cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;

--- a/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/DAFTrackProducer.cc
@@ -14,6 +14,8 @@
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "TrackingTools/Records/interface/TrackingComponentsRecord.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 
 
 DAFTrackProducer::DAFTrackProducer(const edm::ParameterSet& iConfig):
@@ -74,6 +76,9 @@ void DAFTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<TrackerTopologyRcd>().get(httopo);
+
   //get additional es_modules needed by the DAF	
   edm::ESHandle<MultiRecHitCollector> measurementCollectorHandle;
   std::string measurementCollectorName = getConf().getParameter<std::string>("MeasurementCollector");
@@ -119,16 +124,16 @@ void DAFTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   //put everything in the event
   putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), 
            outputRHColl, outputTColl, outputTEColl, 
-           outputTrajectoryColl, algoResults, theBuilder.product());
+           outputTrajectoryColl, algoResults, theBuilder.product(), httopo.product());
   putInEvtTrajAnn(theEvent, trajannResults, outputTrajAnnColl);
 
   //put in theEvent before and after DAF tracks collections
   putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), 
            outputRHCollBeforeDAF, outputTCollBeforeDAF, outputTECollBeforeDAF, 
-           outputTrajectoryCollBeforeDAF, algoResultsBeforeDAF, theBuilder.product(), 1);
+           outputTrajectoryCollBeforeDAF, algoResultsBeforeDAF, theBuilder.product(), httopo.product(), 1);
   putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), 
            outputRHCollAfterDAF, outputTCollAfterDAF, outputTECollAfterDAF, 
-           outputTrajectoryCollAfterDAF, algoResultsAfterDAF, theBuilder.product(), 2);
+           outputTrajectoryCollAfterDAF, algoResultsAfterDAF, theBuilder.product(), httopo.product(), 2);
 
   LogDebug("DAFTrackProducer") << "end the DAF algorithm." << "\n";
 }

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -20,6 +20,7 @@
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidate.h"
 #include "DataFormats/TrackingRecHit/interface/TrackingRecHit.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateTransform.h"
 #include "TrackingTools/TrajectoryState/interface/TrajectoryStateOnSurface.h"
@@ -31,6 +32,7 @@
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
 
@@ -77,6 +79,9 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry);
     edm::ESHandle<MagneticField>   theMagField;
     iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
+    edm::ESHandle<TrackerTopology> httopo;
+    iSetup.get<TrackerTopologyRcd>().get(httopo);
+    const TrackerTopology& ttopo = *httopo;
 
     Handle<vector<T> > src;
     iEvent.getByToken(src_, src);
@@ -103,7 +108,7 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
         int charge = state.localParameters().charge();
         out->push_back(reco::Track(1.0,1.0,x,p,charge,reco::Track::CovarianceMatrix()));
         TrajectorySeed::range hits = getHits(mu);
-        out->back().appendHits(hits.first, hits.second);
+        out->back().appendHits(hits.first, hits.second, ttopo);
         // Now Track Extra
         const TrackingRecHit *hit0 =  &*hits.first;
         const TrackingRecHit *hit1 = &*(hits.second-1);

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -49,10 +49,6 @@ class FakeTrackProducer : public edm::stream::EDProducer<> {
       /// Muon selection
       //StringCutObjectSelector<T> selector_;
 
-      // EventSetup
-      edm::ESHandle<TrackerGeometry> theGeometry;
-      edm::ESHandle<MagneticField>   theMagField;
-
       const PTrajectoryStateOnDet & getState(const TrajectorySeed &seed) const { return seed.startingState(); }
       const PTrajectoryStateOnDet & getState(const TrackCandidate &seed) const { return seed.trajectoryStateOnDet(); }
       TrajectorySeed::range  getHits (const TrajectorySeed &seed) const { return seed.recHits(); }
@@ -77,7 +73,9 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     using namespace std;
 
 
+    edm::ESHandle<TrackerGeometry> theGeometry;
     iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry);
+    edm::ESHandle<MagneticField>   theMagField;
     iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
     Handle<vector<T> > src;

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
@@ -15,6 +15,9 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtra.h"
 #include "DataFormats/GsfTrackReco/interface/GsfComponent5D.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig):
   GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
 		       iConfig.getParameter<bool>("useHitsSplitting")),
@@ -61,6 +64,9 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<TrackerTopologyRcd>().get(httopo);
+
   //
   //declare and get TrackColection to be retrieved from the event
   //
@@ -80,7 +86,7 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   //
   //put everything in the event
   putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputGsfTEColl,
-	   outputTrajectoryColl, algoResults, theBuilder.product(), bs);
+	   outputTrajectoryColl, algoResults, theBuilder.product(), bs, httopo.product());
   LogDebug("GsfTrackProducer") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
@@ -12,6 +12,9 @@
 #include "TrackingTools/GsfTracking/interface/GsfTrackConstraintAssociation.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig):
   GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
 		       iConfig.getParameter<bool>("useHitsSplitting")),
@@ -68,6 +71,9 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<TrackerTopologyRcd>().get(httopo);
+
   //
   //declare and get TrackCollection to be retrieved from the event
   //
@@ -108,7 +114,7 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   
   //put everything in th event
   putInEvt(theEvent, thePropagator.product(), theMeasTk.product(),
-	   outputRHColl, outputTColl, outputTEColl, outputGsfTEColl, outputTrajectoryColl, algoResults, theBuilder.product(), bs);
+	   outputRHColl, outputTColl, outputTEColl, outputGsfTEColl, outputTrajectoryColl, algoResults, theBuilder.product(), bs, httopo.product());
   LogDebug("GsfTrackRefitter") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.cc
@@ -12,6 +12,9 @@
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 TrackProducer::TrackProducer(const edm::ParameterSet& iConfig):
   KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
 		      iConfig.getParameter<bool>("useHitsSplitting")),
@@ -60,6 +63,9 @@ void TrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<TrackerTopologyRcd>().get(httopo);
+
   //
   //declare and get TrackColection to be retrieved from the event
   //
@@ -79,7 +85,7 @@ void TrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   }
   
   //put everything in the event
-  putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults, theBuilder.product());
+  putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults, theBuilder.product(), httopo.product());
   LogDebug("TrackProducer") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
@@ -10,6 +10,9 @@
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 TrackRefitter::TrackRefitter(const edm::ParameterSet& iConfig):
   KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
 		      iConfig.getParameter<bool>("useHitsSplitting")),
@@ -63,6 +66,9 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   edm::ESHandle<MeasurementTracker>  theMeasTk;
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
+
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<TrackerTopologyRcd>().get(httopo);
 
   //
   //declare and get TrackCollection to be retrieved from the event
@@ -149,7 +155,7 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
 
   
   //put everything in th event
-  putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults,theBuilder.product());
+  putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults,theBuilder.product(), httopo.product());
   LogDebug("TrackRefitter") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -35,7 +35,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
 			       std::auto_ptr<reco::GsfTrackExtraCollection>& selGsfTrackExtras,
 			       std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
 			       AlgoProductCollection& algoResults, TransientTrackingRecHitBuilder const * hitBuilder,
-			       const reco::BeamSpot& bs)
+			       const reco::BeamSpot& bs, const TrackerTopology *ttopo)
 {
 
   TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
@@ -109,7 +109,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
         edm::Handle<MeasurementTrackerEvent> mte;
         evt.getByToken(mteSrc_, mte);
 	// NavigationSetter setter( *theSchool );
-	setSecondHitPattern(theTraj,track,prop,&*mte);
+	setSecondHitPattern(theTraj,track,prop,&*mte, ttopo);
       }
     //==============================================================
     
@@ -131,7 +131,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
     unsigned int nHitsAdded = 0;
     for (;ih<ie; ++ih) {
       auto const & hit = (*selHits)[ih];
-      track.appendHitPattern(hit);
+      track.appendHitPattern(hit, *ttopo);
       ++nHitsAdded;
     }
     tx.setHits(rHits, hidx, nHitsAdded);
@@ -146,7 +146,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
                 j != transHits.end(); j++) {
             if ((**j).hit() != 0){
                 TrackingRecHit *hit = (**j).hit()->clone();
-                track.appendHitPattern(*hit);
+                track.appendHitPattern(*hit, *ttopo);
                 selHits->push_back(hit);
                 tx.add(TrackingRecHitRef(rHits, hidx++));
             }
@@ -156,7 +156,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
                 j != transHits.begin() - 1; --j) {
             if ((**j).hit() != 0){
                 TrackingRecHit *hit = (**j).hit()->clone();
-                track.appendHitPattern(*hit);
+                track.appendHitPattern(*hit, *ttopo);
                 selHits->push_back(hit);
                 tx.add(TrackingRecHitRef(rHits, hidx++));
             }

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -26,7 +26,9 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
 				   std::auto_ptr<reco::TrackCollection>& selTracks,
 				   std::auto_ptr<reco::TrackExtraCollection>& selTrackExtras,
 				   std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
-				   AlgoProductCollection& algoResults, TransientTrackingRecHitBuilder const * hitBuilder, int BeforeOrAfter)
+				   AlgoProductCollection& algoResults, TransientTrackingRecHitBuilder const * hitBuilder,
+                                   const TrackerTopology *ttopo,
+                                   int BeforeOrAfter)
 {
 
   TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
@@ -107,7 +109,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
         edm::Handle<MeasurementTrackerEvent> mte;
         evt.getByToken(mteSrc_, mte);
 	// NavigationSetter setter( *theSchool );
-	setSecondHitPattern(theTraj,track,prop,&*mte);
+	setSecondHitPattern(theTraj,track,prop,&*mte, ttopo);
       }
     //==============================================================
     
@@ -127,7 +129,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
     tx.setHits(rHits,ih,ie-ih);
     for (;ih<ie; ++ih) {
       auto const & hit = (*selHits)[ih];
-      track.appendHitPattern(hit);
+      track.appendHitPattern(hit, *ttopo);
     }
     
     // ----

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -12,6 +12,10 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include <sstream>
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 MuonTrackProducer::MuonTrackProducer(const edm::ParameterSet& parset) :
   muonsToken(consumes<reco::MuonCollection>(parset.getParameter< edm::InputTag >("muonsTag"))),
   inputDTRecSegment4DToken_(consumes<DTRecSegment4DCollection>(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection"))),
@@ -34,7 +38,11 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   iEvent.getByToken(muonsToken,muonCollectionH);
   iEvent.getByToken(inputDTRecSegment4DToken_, dtSegmentCollectionH_);
   iEvent.getByToken(inputCSCSegmentToken_, cscSegmentCollectionH_);
-  
+
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<TrackerTopologyRcd>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
+
   std::auto_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
   std::auto_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
   std::auto_ptr<TrackingRecHitCollection> selectedTrackHits( new TrackingRecHitCollection() );
@@ -252,7 +260,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = phiHits.begin();
 		      ihit != phiHits.end(); ++ihit) {
 		    TrackingRecHit* seghit = (*ihit)->clone();
-             newTrk->appendHitPattern(*seghit);
+		    newTrk->appendHitPattern(*seghit, ttopo);
 		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		    selectedTrackHits->push_back( seghit );
@@ -269,7 +277,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = zedHits.begin();
 		      ihit != zedHits.end(); ++ihit) {
 		    TrackingRecHit* seghit = (*ihit)->clone();
-            newTrk->appendHitPattern(*seghit);
+		    newTrk->appendHitPattern(*seghit, ttopo);
 		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		    selectedTrackHits->push_back( seghit );
@@ -299,7 +307,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		for(std::vector<const TrackingRecHit*>::const_iterator ihit = hits.begin();
 		    ihit != hits.end(); ++ihit) {
 		  TrackingRecHit* seghit = (*ihit)->clone();
-          newTrk->appendHitPattern(*seghit);
+		  newTrk->appendHitPattern(*seghit, ttopo);
 		  //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		  //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		  selectedTrackHits->push_back( seghit );

--- a/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/SeedToTrackProducer.cc
@@ -22,6 +22,10 @@
 
 #include "SeedToTrackProducer.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
+
 //
 // class declaration
 //
@@ -92,6 +96,10 @@ SeedToTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
     iSetup.get<IdealMagneticFieldRecord>().get(theMGField);
     iSetup.get<GlobalTrackingGeometryRecord>().get(theTrackingGeometry);
 
+    edm::ESHandle<TrackerTopology> httopo;
+    iSetup.get<TrackerTopologyRcd>().get(httopo);
+    const TrackerTopology& ttopo = *httopo;
+
     // now read the L2 seeds collection :
     edm::Handle<TrajectorySeedCollection> L2seedsCollection;
     iEvent.getByToken(L2seedsTagT_,L2seedsCollection);
@@ -144,7 +152,7 @@ SeedToTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
         unsigned int nHitsAdded = 0;
         for(TrajectorySeed::recHitContainer::const_iterator itRecHits=(L2seeds->at(i)).recHits().first; itRecHits!=(L2seeds->at(i)).recHits().second; ++itRecHits, ++countRH) {
             TrackingRecHit* hit = (itRecHits)->clone();
-            theTrack.appendHitPattern(*hit);
+            theTrack.appendHitPattern(*hit, ttopo);
             selectedTrackHits->push_back(hit);
             nHitsAdded++;
         }

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -26,6 +26,9 @@
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/TrackerTopologyRcd.h"
+
 #include <TF1.h>
 
 using namespace std;
@@ -115,6 +118,10 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 
   edm::ESHandle<ParametersDefinerForTP> parametersDefinerTP;
   setup.get<TrackAssociatorRecord>().get(parametersDefiner,parametersDefinerTP);
+
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<TrackerTopologyRcd>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
   event.getByToken(label_tp_effic,TPCollectionHeff);
@@ -266,7 +273,7 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 	  //GlobalPoint vSeed(vSeed1.x()-bs.x0(),vSeed1.y()-bs.y0(),vSeed1.z()-bs.z0());
 	  PerigeeTrajectoryError seedPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tsAtClosestApproachSeed.trackStateAtPCA());
 	  matchedTrackPointer = new reco::Track(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
-	  matchedTrackPointer->appendHits(matchedSeedPointer->recHits().first,matchedSeedPointer->recHits().second);
+	  matchedTrackPointer->appendHits(matchedSeedPointer->recHits().first,matchedSeedPointer->recHits().second, ttopo);
 	}
 
 	double dR=0;//fixme: plots vs dR not implemented for now
@@ -316,7 +323,7 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 
 	//fixme
 	reco::Track* trackFromSeed = new reco::Track(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
-	trackFromSeed->appendHits(seed->recHits().first,seed->recHits().second);
+	trackFromSeed->appendHits(seed->recHits().first,seed->recHits().second, ttopo);
 
 	bool isSigSimMatched(false);
 	bool isSimMatched(false);


### PR DESCRIPTION
This PR migrates HitPattern to use TrackerTopology instead of the tracker DetId classes. There were two kind of use-cases for filling HitPattern from DetIds:
1. DetId originates from a hit
2. DetId is constructed on the fly from another packed HitPattern-like format
   1. Old HitPattern (pre-#4455)
   2. PackedCandidate

Case 1 was straightforward to solve by percolating TrackerTopology to all necessary places to be passed to HitPattern.

Case 2 was more tricky, as it was not possible/practical to percolate TrackerTopology. Instead, I decided to skip the creation of a "dummy" DetId altogether, and added a new function to deliver the required information (subdet, layer, stereo bit) to HitPattern (`appendTrackerHit()` for tracker, corresponding `appendMuonHit()` still employs DetId to encode the information as that seemed to be the simplest solution for now).

Tested for 1 and 2.ii in CMSSW_7_5_X_2015-06-14-2300 + #9630 with wf 11325 (#9630/#9801 needed to verify 2.ii, i.e. CMSSW_7_6_X_2015-06-29-1100 or later). Case 2.i was tested separately with a file from /RelValTTbar_13/CMSSW_7_1_0-POSTLS171_V15-v1/GEN-SIM-RECO (predating #4455 so that the iorule is activated) by printing out all properties of HitPattern first in the IB, then in the IB+this branch, and finally making a diff of the two printouts (showing no differences).

@rovere @VinInn 
