### PR TITLE
Migrate HitPattern to use TrackerTopology (62X_SLHCDEV)

### DIFF
--- a/DataFormats/TrackReco/BuildFile.xml
+++ b/DataFormats/TrackReco/BuildFile.xml
@@ -5,6 +5,7 @@
 <use   name="DataFormats/SiPixelDetId"/>
 <use   name="DataFormats/SiStripDetId"/>
 <use   name="DataFormats/TrackingRecHit"/>
+<use   name="DataFormats/TrackerCommon"/>
 <use   name="FWCore/Utilities"/>
 <use   name="clhepheader"/>
 <use   name="rootrflx"/>

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -118,6 +118,7 @@
 #include <algorithm>
 #include <ostream>
 
+class TrackerTopology;
 
 namespace reco {
   class HitPattern {
@@ -138,7 +139,7 @@ namespace reco {
 
     // constructor from iterator (begin, end) pair
     template<typename I>
-    HitPattern(const I & begin, const I & end) { set(begin, end); }
+    HitPattern(const I & begin, const I & end, const TrackerTopology& ttopo) { set(begin, end, ttopo); }
 
     // constructor from hit collection
     template<typename C>
@@ -148,12 +149,12 @@ namespace reco {
     // init hit pattern array as 0x00000000, ..., 0x00000000
     // loop over the hits and set hit pattern
     template<typename I>
-    void set(const I & begin, const I & end) {
+    void set(const I & begin, const I & end, const TrackerTopology& ttopo) {
       for (int i=0; i<PatternSize; i++) hitPattern_[i] = 0;
       unsigned int counter = 0;
       for (I hit=begin; hit!=end && counter<32*PatternSize/HitSize;
 	   hit++, counter++)
-	set(*hit, counter);
+	set(*hit, counter, ttopo);
     }
 
 
@@ -204,10 +205,10 @@ namespace reco {
     void print (std::ostream &stream = std::cout) const;
 
     // set the pattern of the i-th hit
-    void set(const TrackingRecHit &hit, unsigned int i){setHitPattern(i, encode(hit,i));}
+    void set(const TrackingRecHit &hit, unsigned int i, const TrackerTopology& ttopo){setHitPattern(i, encode(hit,i, ttopo));}
     
     // append a hit to the hit pattern
-    void appendHit(const TrackingRecHit & hit);
+    void appendHit(const TrackingRecHit & hit, const TrackerTopology& ttopo);
 
     // get the pattern of the position-th hit
     uint32_t getHitPattern(int position) const; 
@@ -415,13 +416,13 @@ namespace reco {
     void setHitPattern(int position, uint32_t pattern);
 
     // set pattern for i-th hit passing a reference
-    void set(const TrackingRecHitRef & ref, unsigned int i) { set(* ref, i); }
+    void set(const TrackingRecHitRef & ref, unsigned int i, const TrackerTopology& ttopo) { set(* ref, i, ttopo); }
 
     // detector side for tracker modules (mono/stereo)
-    static uint32_t isStereo (DetId);
+    static uint32_t isStereo (DetId, const TrackerTopology& ttopo);
 
     // encoder for pattern
-    uint32_t encode(const TrackingRecHit &,unsigned int);
+    uint32_t encode(const TrackingRecHit &,unsigned int, const TrackerTopology& ttopo);
   };
 
   // inline function

--- a/DataFormats/TrackReco/interface/HitPattern.h
+++ b/DataFormats/TrackReco/interface/HitPattern.h
@@ -141,10 +141,6 @@ namespace reco {
     template<typename I>
     HitPattern(const I & begin, const I & end, const TrackerTopology& ttopo) { set(begin, end, ttopo); }
 
-    // constructor from hit collection
-    template<typename C>
-    HitPattern(const C & c) { set(c); }
-
     // set pattern from iterator (begin, end) pair
     // init hit pattern array as 0x00000000, ..., 0x00000000
     // loop over the hits and set hit pattern

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -243,24 +243,24 @@ namespace reco {
     }
     /// set hit patterns from vector of hit references
     template<typename C>
-    void setHitPattern( const C & c ) { hitPattern_.set( c.begin(), c.end() ); }
+    void setHitPattern( const C & c, const TrackerTopology& ttopo ) { hitPattern_.set( c.begin(), c.end(), ttopo ); }
     template<typename C>
-    void setTrackerExpectedHitsInner( const C & c ) { trackerExpectedHitsInner_.set( c.begin(), c.end() ); }
+    void setTrackerExpectedHitsInner( const C & c, const TrackerTopology& ttopo ) { trackerExpectedHitsInner_.set( c.begin(), c.end(), ttopo ); }
     template<typename C>
-    void setTrackerExpectedHitsOuter( const C & c ) { trackerExpectedHitsOuter_.set( c.begin(), c.end() ); }
+    void setTrackerExpectedHitsOuter( const C & c, const TrackerTopology& ttopo ) { trackerExpectedHitsOuter_.set( c.begin(), c.end(), ttopo ); }
     
     template<typename I>
-    void setHitPattern( const I & begin, const I & end ) { hitPattern_.set( begin, end ); }
+    void setHitPattern( const I & begin, const I & end, const TrackerTopology& ttopo ) { hitPattern_.set( begin, end, ttopo ); }
     template<typename I>
-    void setTrackerExpectedHitsInner( const I & begin, const I & end ) { trackerExpectedHitsInner_.set( begin, end ); }
+    void setTrackerExpectedHitsInner( const I & begin, const I & end, const TrackerTopology& ttopo ) { trackerExpectedHitsInner_.set( begin, end, ttopo ); }
     template<typename I>
-    void setTrackerExpectedHitsOuter( const I & begin, const I & end ) { trackerExpectedHitsOuter_.set( begin, end ); }
+    void setTrackerExpectedHitsOuter( const I & begin, const I & end, const TrackerTopology& ttopo ) { trackerExpectedHitsOuter_.set( begin, end, ttopo ); }
 
     /// set hit pattern for specified hit
-    void setHitPattern( const TrackingRecHit & hit, size_t i ) { hitPattern_.set( hit, i ); }
-    void appendHitPattern( const TrackingRecHit & hit) { hitPattern_.appendHit( hit); }
-    void setTrackerExpectedHitsInner( const TrackingRecHit & hit, size_t i ) { trackerExpectedHitsInner_.set( hit, i ); }
-    void setTrackerExpectedHitsOuter( const TrackingRecHit & hit, size_t i ) { trackerExpectedHitsOuter_.set( hit, i ); }
+    void setHitPattern( const TrackingRecHit & hit, size_t i, const TrackerTopology& ttopo ) { hitPattern_.set( hit, i, ttopo ); }
+    void appendHitPattern( const TrackingRecHit & hit, const TrackerTopology& ttopo) { hitPattern_.appendHit( hit, ttopo ); }
+    void setTrackerExpectedHitsInner( const TrackingRecHit & hit, size_t i, const TrackerTopology& ttopo ) { trackerExpectedHitsInner_.set( hit, i, ttopo ); }
+    void setTrackerExpectedHitsOuter( const TrackingRecHit & hit, size_t i, const TrackerTopology& ttopo ) { trackerExpectedHitsOuter_.set( hit, i, ttopo ); }
 
     /// set hitPattern from pre-defined hitPattern
     void setHitPattern( const HitPattern& hitP) {hitPattern_ = hitP;}

--- a/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
+++ b/FastSimulation/Tracking/plugins/PixelTracksProducer.cc
@@ -28,6 +28,10 @@
 #include "DataFormats/Common/interface/OrphanHandle.h"
 #include <vector>
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 using namespace pixeltrackfitting;
 
 PixelTracksProducer::PixelTracksProducer(const edm::ParameterSet& conf) : 
@@ -90,7 +94,11 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     e.put(trackExtras);
     return;
   }
-  
+
+  edm::ESHandle<TrackerTopology> httopo;
+  es.get<IdealGeometryRecord>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
+
   //only one region Global, but it is called at every event...
   //maybe there is a smarter way to set it only once
   //NEED TO FIX
@@ -139,7 +147,7 @@ PixelTracksProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     
     for (unsigned int k = 0; k < hits.size(); k++) {
       TrackingRecHit *hit = (hits.at(k))->clone();
-      track->setHitPattern(*hit, k);
+      track->setHitPattern(*hit, k, ttopo);
       recHits->push_back(hit);
     }
 

--- a/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/TrackProducerWithSCAssociation.h
@@ -47,7 +47,8 @@ private:
 		std::auto_ptr<reco::TrackCollection>& selTracks,
 		std::auto_ptr<reco::TrackExtraCollection>& selTrackExtras,
 		std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
-		AlgoProductCollection& algoResults);
+		AlgoProductCollection& algoResults,
+                const TrackerTopology *ttopo);
 };
 
 #endif

--- a/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/TrackProducerWithSCAssociation.cc
@@ -80,7 +80,9 @@ void TrackProducerWithSCAssociation::produce(edm::Event& theEvent, const edm::Ev
   edm::ESHandle<MeasurementTracker> theMeasTk;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
- 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<IdealGeometryRecord>().get(httopo);
+  const TrackerTopology *ttopo = httopo.product();
 
   //
   //declare and get TrackColection to be retrieved from the event
@@ -172,7 +174,7 @@ void TrackProducerWithSCAssociation::produce(edm::Event& theEvent, const edm::Ev
     //put everything in the event
     // we copy putInEvt to get OrphanHandle filled...
     putInEvt(theEvent,thePropagator.product(),theMeasTk.product(), 
-	     outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults);
+	     outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults, ttopo);
     
     // now construct associationmap and put it in the  event
     if (  validTrackCandidateSCAssociationInput_ ) {    
@@ -255,7 +257,8 @@ std::vector<reco::TransientTrack> TrackProducerWithSCAssociation::getTransient(e
 					       std::auto_ptr<reco::TrackCollection>& selTracks,
 					       std::auto_ptr<reco::TrackExtraCollection>& selTrackExtras,
 					       std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
-					       AlgoProductCollection& algoResults)
+					       AlgoProductCollection& algoResults,
+                                               const TrackerTopology *ttopo)
 {
 
 TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
@@ -325,7 +328,7 @@ TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
     if (theSchool.isValid())
       {
 	NavigationSetter setter( *theSchool );
-	setSecondHitPattern(theTraj,track,thePropagator,theMeasTk);
+	setSecondHitPattern(theTraj,track,thePropagator,theMeasTk, ttopo);
       }
     //==============================================================
 
@@ -345,7 +348,7 @@ TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
            j != transHits.end(); j ++ ) {
         if ((**j).hit()!=0){
           TrackingRecHit * hit = (**j).hit()->clone();
-          track.setHitPattern( * hit, k++ );
+          track.setHitPattern( * hit, k++, *ttopo );
           selHits->push_back( hit );
           tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
         }
@@ -355,7 +358,7 @@ TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
            j != transHits.begin()-1; --j ) {
         if ((**j).hit()!=0){
           TrackingRecHit * hit = (**j).hit()->clone();
-          track.setHitPattern( * hit, k++ );
+          track.setHitPattern( * hit, k++, *ttopo );
           selHits->push_back( hit );
         tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
         }

--- a/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/CosmicMuonProducer.cc
@@ -86,5 +86,5 @@ CosmicMuonProducer::produce(Event& iEvent, const EventSetup& iSetup)
   
   // Update the services
   theService->update(iSetup);
-  theTrackFinder->reconstruct(seeds,iEvent);
+  theTrackFinder->reconstruct(seeds,iEvent, iSetup);
 }

--- a/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
+++ b/RecoMuon/CosmicMuonProducer/src/GlobalCosmicMuonProducer.cc
@@ -101,7 +101,7 @@ GlobalCosmicMuonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSe
     MuonTrajectoryBuilder::TrackCand cosCand = MuonTrajectoryBuilder::TrackCand((Trajectory*)(0),cosTrackRef);
     cosTrackCands.push_back(cosCand); 
   }
-  theTrackFinder->reconstruct(cosTrackCands,iEvent);
+  theTrackFinder->reconstruct(cosTrackCands,iEvent, iSetup);
   LogTrace(metname)<<"Event loaded";
 
 }

--- a/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/GlobalMuonProducer.cc
@@ -146,7 +146,7 @@ void GlobalMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
     }
   }
     
-  theTrackFinder->reconstruct(staTrackCands, event);      
+  theTrackFinder->reconstruct(staTrackCands, event, eventSetup);
   
   
   LogTrace(metname)<<"Event loaded"

--- a/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
+++ b/RecoMuon/GlobalMuonProducer/src/TevMuonProducer.cc
@@ -145,7 +145,7 @@ void TevMuonProducer::produce(Event& event, const EventSetup& eventSetup) {
 	miniMap.push_back(thisPair);
       }
     }
-    theTrackLoader->loadTracks(trajectories,event,miniMap,theRefits[ww]);
+    theTrackLoader->loadTracks(trajectories,event,miniMap, *tTopo, theRefits[ww]);
   }
     
   LogTrace(metname) << "Done." << endl;    

--- a/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
+++ b/RecoMuon/L2MuonProducer/src/L2MuonProducer.cc
@@ -109,7 +109,7 @@ void L2MuonProducer::produce(Event& event, const EventSetup& eventSetup){
   
   // Reconstruct 
   LogTrace(metname)<<"Track Reconstruction"<<endl;
-  theTrackFinder->reconstruct(seeds,event);
+  theTrackFinder->reconstruct(seeds,event, eventSetup);
   
   LogTrace(metname)<<"Event loaded"
 		   <<"================================"

--- a/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
+++ b/RecoMuon/L3MuonProducer/src/L3MuonProducer.cc
@@ -146,7 +146,7 @@ void L3MuonProducer::produce(Event& event, const EventSetup& eventSetup) {
     L2TrackCands.push_back(L2Cand);
   }
   
-  theTrackFinder->reconstruct(L2TrackCands, event);      
+  theTrackFinder->reconstruct(L2TrackCands, event, eventSetup);
   
   LogTrace(metname)<<"Event loaded"
                    <<"================================"

--- a/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
+++ b/RecoMuon/StandAloneMuonProducer/src/StandAloneMuonProducer.cc
@@ -117,7 +117,7 @@ void StandAloneMuonProducer::produce(Event& event, const EventSetup& eventSetup)
 
   // Reconstruct 
   LogTrace(metname)<<"Track Reconstruction"<<endl;
-  theTrackFinder->reconstruct(seeds,event);
+  theTrackFinder->reconstruct(seeds,event, eventSetup);
  
   LogTrace(metname)<<"Event loaded"
 		   <<"================================"

--- a/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackFinder.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 namespace edm {class ParameterSet; class Event; class EventSetup;}
+class TrackerTopology;
 
 class MuonTrajectoryBuilder;
 class MuonTrajectoryCleaner;
@@ -49,12 +50,13 @@ class MuonTrackFinder {
   
     /// reconstruct standalone tracks starting from a collection of seeds
     edm::OrphanHandle<reco::TrackCollection> reconstruct(const edm::Handle<edm::View<TrajectorySeed> >&,
-							 edm::Event&);
+							 edm::Event&,
+                                                         const edm::EventSetup&);
 
     /// reconstruct global tracks starting from a collection of
     /// standalone tracks and one of trakectories. If the latter
     /// is invalid, trajectories are refitted.
-    void reconstruct(const std::vector<TrackCand>&, edm::Event&);
+    void reconstruct(const std::vector<TrackCand>&, edm::Event&, const edm::EventSetup&);
     
  private:
     
@@ -62,10 +64,10 @@ class MuonTrackFinder {
     void setEvent(const edm::Event&);
 
     /// convert the trajectories into tracks and load them in to the event
-    edm::OrphanHandle<reco::TrackCollection> load(const TrajectoryContainer&, edm::Event&);
+    edm::OrphanHandle<reco::TrackCollection> load(const TrajectoryContainer&, edm::Event&, const TrackerTopology& ttopo);
 
     /// convert the trajectories into tracks and load them in to the event
-    void load(const CandidateContainer&, edm::Event&);
+    void load(const CandidateContainer&, edm::Event&, const TrackerTopology &ttopo);
 
   private:
 

--- a/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
+++ b/RecoMuon/TrackingTools/interface/MuonTrackLoader.h
@@ -32,6 +32,7 @@ class MuonUpdatorAtVertex;
 class TrajectorySmoother;
 class ForwardDetLayer;
 class BarrelDetLayer;
+class TrackerTopology;
 
 class MuonTrackLoader {
   public:
@@ -47,24 +48,29 @@ class MuonTrackLoader {
    
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
-                                                        edm::Event&,const std::string& = "", 
+                                                        edm::Event&,
+                                                        const TrackerTopology& ttopo,
+                                                        const std::string& = "", 
 							bool = true);
 
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
                                                         edm::Event&, std::vector<bool>&,
+                                                        const TrackerTopology& ttopo,
 							const std::string& = "", 
 							bool = true);
 
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::TrackCollection> loadTracks(const TrajectoryContainer&, 
                                                         edm::Event&,const std::vector<std::pair<Trajectory*, reco::TrackRef> >&, 
+                                                        const TrackerTopology& ttopo,
 							const std::string& = "", 
 							bool = true);
 
     /// Convert the trajectories into tracks and load the tracks in the event
     edm::OrphanHandle<reco::MuonTrackLinksCollection> loadTracks(const CandidateContainer&,
-								 edm::Event&); 
+								 edm::Event&,
+                                                                 const TrackerTopology& ttopo);
   
   private:
  

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.cc
@@ -13,6 +13,9 @@
 #include <TrackingTools/TrajectoryState/interface/FreeTrajectoryState.h>
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 MuonErrorMatrixAdjuster::MuonErrorMatrixAdjuster(const edm::ParameterSet& iConfig)
 {
   theCategory="MuonErrorMatrixAdjuster";
@@ -136,7 +139,8 @@ reco::TrackExtra * MuonErrorMatrixAdjuster::makeTrackExtra(const reco::Track & r
 bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track & recotrack_orig,
 				       reco::Track & recotrack,
 				       reco::TrackExtra & trackextra,
-				       TrackingRecHitCollection& RHcol){
+				       TrackingRecHitCollection& RHcol,
+                                       const TrackerTopology& ttopo){
   //loop over the hits of the original track
   trackingRecHit_iterator recHit = recotrack_orig.recHitsBegin();
   unsigned int irh=0;
@@ -145,7 +149,7 @@ bool MuonErrorMatrixAdjuster::attachRecHits(const reco::Track & recotrack_orig,
     TrackingRecHit * hit = (*recHit)->clone();
     
     //put it on the new track
-    recotrack.setHitPattern(*hit,irh++);
+    recotrack.setHitPattern(*hit,irh++, ttopo);
     //copy them in the new collection
     RHcol.push_back(hit);
     //do something with the trackextra 
@@ -171,7 +175,11 @@ MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSet
   
   //get the mag field
   iSetup.get<IdealMagneticFieldRecord>().get( theField);
-  
+
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<IdealGeometryRecord>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
+
   //prepare the output collection
   std::auto_ptr<reco::TrackCollection> Toutput(new reco::TrackCollection());
   std::auto_ptr<TrackingRecHitCollection> TRHoutput(new TrackingRecHitCollection());
@@ -208,7 +216,7 @@ MuonErrorMatrixAdjuster::produce(edm::Event& iEvent, const edm::EventSetup& iSet
 	continue;}
       
       //attach the collection of rechits
-      if (!attachRecHits(recotrack_orig,recotrackref,*extra,*TRHoutput)){
+      if (!attachRecHits(recotrack_orig,recotrackref,*extra,*TRHoutput, ttopo)){
 	edm::LogError( theCategory)<<"cannot attach any rechits on this track";
 	//pop the inserted track
 	Toutput->pop_back();

--- a/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
+++ b/RecoMuon/TrackingTools/plugins/MuonErrorMatrixAdjuster.h
@@ -80,7 +80,8 @@ class MuonErrorMatrixAdjuster : public edm::EDProducer {
   bool attachRecHits(const reco::Track & recotrack_orig,
 		     reco::Track & recotrack,
 		     reco::TrackExtra & trackextra,
-		     TrackingRecHitCollection& RHcol);
+		     TrackingRecHitCollection& RHcol,
+                     const TrackerTopology& ttopo);
       
   // ----------member data ---------------------------
   /// log category: MuonErrorMatrixAdjuster

--- a/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
+++ b/RecoMuon/TrackingTools/src/MuonTrackLoader.cc
@@ -77,14 +77,15 @@ MuonTrackLoader::~MuonTrackLoader(){
 
 OrphanHandle<reco::TrackCollection> 
 MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
-			    Event& event, const string& instance, bool reallyDoSmoothing) {
+			    Event& event, const TrackerTopology& ttopo, const string& instance, bool reallyDoSmoothing) {
   std::vector<bool> dummyVecBool;
-  return loadTracks(trajectories, event, dummyVecBool, instance, reallyDoSmoothing);
+  return loadTracks(trajectories, event, dummyVecBool, ttopo, instance, reallyDoSmoothing);
 }
   
 OrphanHandle<reco::TrackCollection> 
 MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
 			    Event& event,  std::vector<bool>& tkBoolVec, 
+                            const TrackerTopology& ttopo,
 			    const string& instance, bool reallyDoSmoothing) {
   
   const bool doSmoothing = theSmoothingStep && reallyDoSmoothing;
@@ -228,8 +229,8 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
     for (Trajectory::RecHitContainer::const_iterator recHit = transHits.begin();
 	 recHit != transHits.end(); ++recHit) {
       TrackingRecHit *singleHit = (**recHit).hit()->clone();
-      track.appendHitPattern( *singleHit);
-      if(theUpdatingAtVtx && updateResult.first) updateResult.second.appendHitPattern(*singleHit);
+      track.appendHitPattern( *singleHit, ttopo);
+      if(theUpdatingAtVtx && updateResult.first) updateResult.second.appendHitPattern(*singleHit, ttopo);
       recHitCollection->push_back( singleHit );  
       // set the TrackingRecHitRef (persitent reference of the tracking rec hits)
       trackExtra.add(TrackingRecHitRef(recHitCollectionRefProd, recHitsIndex++ ));
@@ -290,7 +291,8 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
 
 OrphanHandle<reco::MuonTrackLinksCollection> 
 MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
-			    Event& event) {
+			    Event& event,
+                            const TrackerTopology& ttopo) {
 
   const string metname = "Muon|RecoMuon|MuonTrackLoader";
   
@@ -311,7 +313,7 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
     if(thePutTkTrackFlag){
       //will take care of putting nothing in the event but the empty collection
       TrajectoryContainer trackerTrajs;
-      loadTracks(trackerTrajs, event, theL2SeededTkLabel, theSmoothTkTrackFlag);
+      loadTracks(trackerTrajs, event, ttopo, theL2SeededTkLabel, theSmoothTkTrackFlag);
     } 
 
     return event.put(trackLinksCollection);
@@ -343,14 +345,14 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
   // FIXME: could this be done one track at a time in the previous loop?
   LogTrace(metname) << "Build combinedTracks";
   std::vector<bool> combTksVec(combinedTrajs.size(), false); 
-  OrphanHandle<reco::TrackCollection> combinedTracks = loadTracks(combinedTrajs, event, combTksVec);
+  OrphanHandle<reco::TrackCollection> combinedTracks = loadTracks(combinedTrajs, event, combTksVec, ttopo);
 
   OrphanHandle<reco::TrackCollection> trackerTracks;
   std::vector<bool> trackerTksVec(trackerTrajs.size(), false); 
   if(thePutTkTrackFlag) {
     LogTrace(metname) << "Build trackerTracks: "
 		      << trackerTrajs.size();
-    trackerTracks = loadTracks(trackerTrajs, event, trackerTksVec, theL2SeededTkLabel, theSmoothTkTrackFlag);
+    trackerTracks = loadTracks(trackerTrajs, event, trackerTksVec, ttopo, theL2SeededTkLabel, theSmoothTkTrackFlag);
   } else {
     for (TrajectoryContainer::iterator it = trackerTrajs.begin(); it != trackerTrajs.end(); ++it) {
         if(*it) delete *it;
@@ -406,7 +408,7 @@ MuonTrackLoader::loadTracks(const CandidateContainer& muonCands,
 
 OrphanHandle<reco::TrackCollection> 
 MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
-			    Event& event, const std::vector<std::pair<Trajectory*,reco::TrackRef> >& miniMap, const string& instance, bool reallyDoSmoothing) {
+			    Event& event, const std::vector<std::pair<Trajectory*,reco::TrackRef> >& miniMap, const TrackerTopology& ttopo, const string& instance, bool reallyDoSmoothing) {
   
   const bool doSmoothing = theSmoothingStep && reallyDoSmoothing;
   
@@ -536,8 +538,8 @@ MuonTrackLoader::loadTracks(const TrajectoryContainer& trajectories,
     for (Trajectory::RecHitContainer::const_iterator recHit = transHits.begin();
 	 recHit != transHits.end(); ++recHit) {
 	TrackingRecHit *singleHit = (**recHit).hit()->clone();
-	track.appendHitPattern( *singleHit);
-	if(theUpdatingAtVtx && updateResult.first) updateResult.second.appendHitPattern( *singleHit); // i was already incremented
+	track.appendHitPattern( *singleHit, ttopo);
+	if(theUpdatingAtVtx && updateResult.first) updateResult.second.appendHitPattern( *singleHit, ttopo); // i was already incremented
 	recHitCollection->push_back( singleHit );  
 	// set the TrackingRecHitRef (persitent reference of the tracking rec hits)
 	trackExtra.add(TrackingRecHitRef(recHitCollectionRefProd, recHitsIndex++ ));

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.cc
@@ -10,6 +10,10 @@
 #include "DataFormats/TrackReco/interface/TrackExtra.h"
 #include "DataFormats/Common/interface/OrphanHandle.h"
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 #include <vector>
 
 using namespace pixeltrackfitting;
@@ -43,11 +47,14 @@ void PixelTrackProducer::produce(edm::Event& ev, const edm::EventSetup& es)
   TracksWithTTRHs tracks;
   theReconstruction.run(tracks,ev,es);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  es.get<IdealGeometryRecord>().get(httopo);
+
   // store tracks
-  store(ev, tracks);
+  store(ev, tracks, *httopo);
 }
 
-void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWithHits)
+void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWithHits, const TrackerTopology& ttopo)
 {
   std::auto_ptr<reco::TrackCollection> tracks(new reco::TrackCollection());
   std::auto_ptr<TrackingRecHitCollection> recHits(new TrackingRecHitCollection());
@@ -64,7 +71,7 @@ void PixelTrackProducer::store(edm::Event& ev, const TracksWithTTRHs& tracksWith
     {
       TrackingRecHit *hit = hits[k]->hit()->clone();
 
-      track->setHitPattern(*hit, k);
+      track->setHitPattern(*hit, k, ttopo);
       recHits->push_back(hit);
     }
     tracks->push_back(*track);

--- a/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
+++ b/RecoPixelVertexing/PixelTrackFitting/plugins/PixelTrackProducer.h
@@ -6,6 +6,7 @@
 #include "RecoPixelVertexing/PixelTrackFitting/interface/PixelTrackReconstruction.h"
 
 namespace edm { class Event; class EventSetup; class ParameterSet; }
+class TrackerTopology;
 
 class PixelTrackProducer :  public edm::EDProducer {
 
@@ -19,7 +20,7 @@ public:
   virtual void produce(edm::Event& ev, const edm::EventSetup& es) override;
 
 private:
-  void store(edm::Event& ev, const pixeltrackfitting::TracksWithTTRHs& selectedTracks);
+  void store(edm::Event& ev, const pixeltrackfitting::TracksWithTTRHs& selectedTracks, const TrackerTopology& ttopo);
   PixelTrackReconstruction theReconstruction;
 };
 #endif

--- a/RecoTracker/DebugTools/src/FixTrackHitPattern.cc
+++ b/RecoTracker/DebugTools/src/FixTrackHitPattern.cc
@@ -25,6 +25,9 @@
 #include "TrackingTools/Records/interface/TransientTrackRecord.h"
 #include "DataFormats/Math/interface/deltaPhi.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 #include "FWCore/Utilities/interface/Exception.h"
 
 FixTrackHitPattern::Result FixTrackHitPattern::analyze(const edm::EventSetup& iSetup, const reco::Track& track) 
@@ -55,6 +58,10 @@ FixTrackHitPattern::Result FixTrackHitPattern::analyze(const edm::EventSetup& iS
   edm::ESHandle<MagneticField> magField;
   iSetup.get<IdealMagneticFieldRecord>().get(magField);
   AnalyticalPropagator  propagator(&(*magField), alongMomentum);
+
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<IdealGeometryRecord>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
 
   // This is used to check if a track is compatible with crossing a sensor.
   // Use +3.0 rather than default -3.0 here, so hit defined as inside acceptance if 
@@ -119,7 +126,7 @@ FixTrackHitPattern::Result FixTrackHitPattern::analyze(const edm::EventSetup& iS
 	    // Hence record that the track should have produced a hit here, but did not.
 	    // Store the information in a HitPattern.
 	    InvalidTrackingRecHit  tmpHit(id, TrackingRecHit::missing);
-	    newHitPattern.set(tmpHit, counter);      
+	    newHitPattern.set(tmpHit, counter, ttopo);
             counter++; 
 	  } else {
 	    // Missing hit expected here, since sensor was not functioning.

--- a/RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/GsfTrackProducerBase.h
@@ -43,7 +43,7 @@ public:
 			std::auto_ptr<reco::GsfTrackExtraCollection>&,
 			std::auto_ptr<std::vector<Trajectory> >&,
 			AlgoProductCollection&,
-			const reco::BeamSpot&);
+			const reco::BeamSpot&, const TrackerTopology *ttopo);
 
 
 protected:

--- a/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/KfTrackProducerBase.h
@@ -30,7 +30,8 @@ public:
 			std::auto_ptr<reco::TrackCollection>&,
 			std::auto_ptr<reco::TrackExtraCollection>&,
 			std::auto_ptr<std::vector<Trajectory> >&,
-			AlgoProductCollection&);
+			AlgoProductCollection&,
+                        const TrackerTopology *ttopo);
 
 
   //  void setSecondHitPattern(Trajectory* traj, reco::Track& track);

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.h
@@ -84,7 +84,8 @@ public:
   }
 
   void setSecondHitPattern(Trajectory* traj, T& track, 
-			   const Propagator* prop, const MeasurementTracker* measTk );
+			   const Propagator* prop, const MeasurementTracker* measTk,
+                           const TrackerTopology* ttopo);
 
   const edm::ParameterSet& getConf() const {return conf_;}
  private:

--- a/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerBase.icc
@@ -134,7 +134,8 @@ TrackProducerBase<T>::getFromEvt(edm::Event& theEvent,edm::Handle<TrackCollectio
 
 template <class T> void
 TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track, 
-					  const Propagator* prop, const MeasurementTracker* measTk){
+					  const Propagator* prop, const MeasurementTracker* measTk,
+                                          const TrackerTopology *ttopo){
   using namespace std;
   /// have to clone the propagator in order to change its propagation direction. Have to remember to delete the clone!!
   Propagator* localProp = prop->clone();
@@ -208,7 +209,7 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
       //if(measDet->isActive() && !measDet->hasBadComponents(detWithState.front().second)){	
       if(measDet->isActive()){	  
 	InvalidTrackingRecHit  tmpHit(id,TrackingRecHit::missing);
-	track.setTrackerExpectedHitsInner(tmpHit,counter); counter++;
+	track.setTrackerExpectedHitsInner(tmpHit,counter, *ttopo); counter++;
 	//cout << "WARNING: this hit is marked as lost because the detector was marked as active" << endl;
       }else{
 	//cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;
@@ -232,7 +233,7 @@ TrackProducerBase<T>::setSecondHitPattern(Trajectory* traj, T& track,
       //if(measDet->isActive() && !measDet->hasBadComponents(detWithState.front().second)){	
       if(measDet->isActive()){	  
 	InvalidTrackingRecHit  tmpHit(id,TrackingRecHit::missing);
-	track.setTrackerExpectedHitsOuter(tmpHit,counter); counter++;
+	track.setTrackerExpectedHitsOuter(tmpHit,counter, *ttopo); counter++;
 	//cout << "WARNING: this hit is marked as lost because the detector was marked as active" << endl;
       }else{
 	//cout << "WARNING: this hit is NOT marked as lost because the detector was marked as inactive" << endl;

--- a/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
+++ b/RecoTracker/TrackProducer/plugins/FakeTrackProducers.cc
@@ -35,6 +35,8 @@
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "MagneticField/Records/interface/IdealMagneticFieldRecord.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 
 template<class T>
@@ -82,6 +84,10 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
     iSetup.get<TrackerDigiGeometryRecord>().get(theGeometry);
     iSetup.get<IdealMagneticFieldRecord>().get(theMagField);
 
+    edm::ESHandle<TrackerTopology> httopo;
+    iSetup.get<IdealGeometryRecord>().get(httopo);
+    const TrackerTopology& ttopo = *httopo;
+
     Handle<vector<T> > src;
     iEvent.getByLabel(src_, src);
 
@@ -107,7 +113,7 @@ FakeTrackProducer<T>::produce(edm::Event & iEvent, const edm::EventSetup & iSetu
         int charge = state.localParameters().charge();
         out->push_back(reco::Track(1.0,1.0,x,p,charge,reco::Track::CovarianceMatrix()));
         TrajectorySeed::range hits = getHits(mu);
-        out->back().setHitPattern(hits.first, hits.second);
+        out->back().setHitPattern(hits.first, hits.second, ttopo);
         // Now Track Extra
         const TrackingRecHit *hit0 =  &*hits.first;
         const TrackingRecHit *hit1 = &*(hits.second-1);

--- a/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackProducer.cc
@@ -14,6 +14,8 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackExtra.h"
 #include "DataFormats/GsfTrackReco/interface/GsfComponent5D.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 GsfTrackProducer::GsfTrackProducer(const edm::ParameterSet& iConfig):
   GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
@@ -59,6 +61,9 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<IdealGeometryRecord>().get(httopo);
+
   //
   //declare and get TrackColection to be retrieved from the event
   //
@@ -78,7 +83,7 @@ void GsfTrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setu
   //
   //put everything in the event
   putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputGsfTEColl,
-	   outputTrajectoryColl, algoResults, bs);
+	   outputTrajectoryColl, algoResults, bs, httopo.product());
   LogDebug("GsfTrackProducer") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/GsfTrackRefitter.cc
@@ -11,6 +11,8 @@
 #include "TrackingTools/GsfTracking/interface/TrajGsfTrackAssociation.h"
 #include "TrackingTools/GsfTracking/interface/GsfTrackConstraintAssociation.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 GsfTrackRefitter::GsfTrackRefitter(const edm::ParameterSet& iConfig):
   GsfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
@@ -66,6 +68,9 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<IdealGeometryRecord>().get(httopo);
+
   //
   //declare and get TrackCollection to be retrieved from the event
   //
@@ -106,7 +111,7 @@ void GsfTrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setu
   
   //put everything in th event
   putInEvt(theEvent, thePropagator.product(), theMeasTk.product(),
-	   outputRHColl, outputTColl, outputTEColl, outputGsfTEColl, outputTrajectoryColl, algoResults, bs);
+	   outputRHColl, outputTColl, outputTEColl, outputGsfTEColl, outputTrajectoryColl, algoResults, bs, httopo.product());
   LogDebug("GsfTrackRefitter") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/plugins/TrackProducer.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackProducer.cc
@@ -11,6 +11,8 @@
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 TrackProducer::TrackProducer(const edm::ParameterSet& iConfig):
   KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
@@ -58,6 +60,9 @@ void TrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
 
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<IdealGeometryRecord>().get(httopo);
+
   //
   //declare and get TrackColection to be retrieved from the event
   //
@@ -77,7 +82,7 @@ void TrackProducer::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   }
   
   //put everything in the event
-  putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults);
+  putInEvt(theEvent, thePropagator.product(),theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults, httopo.product());
   LogDebug("TrackProducer") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
+++ b/RecoTracker/TrackProducer/plugins/TrackRefitter.cc
@@ -9,6 +9,8 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "TrackingTools/PatternTools/interface/TrajTrackAssociation.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
 
 TrackRefitter::TrackRefitter(const edm::ParameterSet& iConfig):
   KfTrackProducerBase(iConfig.getParameter<bool>("TrajectoryInEvent"),
@@ -61,6 +63,9 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
   edm::ESHandle<MeasurementTracker>  theMeasTk;
   edm::ESHandle<TransientTrackingRecHitBuilder> theBuilder;
   getFromES(setup,theG,theMF,theFitter,thePropagator,theMeasTk,theBuilder);
+
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<IdealGeometryRecord>().get(httopo);
 
   //
   //declare and get TrackCollection to be retrieved from the event
@@ -138,7 +143,7 @@ void TrackRefitter::produce(edm::Event& theEvent, const edm::EventSetup& setup)
 
   
   //put everything in th event
-  putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults);
+  putInEvt(theEvent, thePropagator.product(), theMeasTk.product(), outputRHColl, outputTColl, outputTEColl, outputTrajectoryColl, algoResults, httopo.product());
   LogDebug("TrackRefitter") << "end" << "\n";
 }
 

--- a/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/GsfTrackProducerBase.cc
@@ -33,7 +33,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
 			       std::auto_ptr<reco::GsfTrackExtraCollection>& selGsfTrackExtras,
 			       std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
 			       AlgoProductCollection& algoResults,
-			       const reco::BeamSpot& bs)
+			       const reco::BeamSpot& bs, const TrackerTopology *ttopo)
 {
 
   TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
@@ -107,7 +107,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
     if (theSchool.isValid())
       {
 	NavigationSetter setter( *theSchool );
-	setSecondHitPattern(theTraj,track,prop,measTk);
+	setSecondHitPattern(theTraj,track,prop,measTk, ttopo);
       }
     //==============================================================
     
@@ -128,7 +128,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
 	   j != transHits.end(); j ++ ) {
 	if ((**j).hit()!=0){
 	  TrackingRecHit * hit = (**j).hit()->clone();
-	  track.setHitPattern( * hit, ih ++ );
+	  track.setHitPattern( * hit, ih ++, *ttopo );
 	  selHits->push_back( hit );
 	  tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
 	}
@@ -138,7 +138,7 @@ GsfTrackProducerBase::putInEvt(edm::Event& evt,
 	   j != transHits.begin()-1; --j ) {
 	if ((**j).hit()!=0){
 	  TrackingRecHit * hit = (**j).hit()->clone();
-	  track.setHitPattern( * hit, ih ++ );
+	  track.setHitPattern( * hit, ih ++, *ttopo );
 	  selHits->push_back( hit );
 	tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
 	}

--- a/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
+++ b/RecoTracker/TrackProducer/src/KfTrackProducerBase.cc
@@ -23,7 +23,8 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
 				   std::auto_ptr<reco::TrackCollection>& selTracks,
 				   std::auto_ptr<reco::TrackExtraCollection>& selTrackExtras,
 				   std::auto_ptr<std::vector<Trajectory> >&   selTrajectories,
-				   AlgoProductCollection& algoResults)
+				   AlgoProductCollection& algoResults,
+                                   const TrackerTopology *ttopo)
 {
 
   TrackingRecHitRefProd rHits = evt.getRefBeforePut<TrackingRecHitCollection>();
@@ -100,7 +101,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
     if (theSchool.isValid())
       {
 	NavigationSetter setter( *theSchool );
-	setSecondHitPattern(theTraj,track,prop,measTk);
+	setSecondHitPattern(theTraj,track,prop,measTk, ttopo);
       }
     //==============================================================
     
@@ -120,7 +121,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
 	   j != transHits.end(); j ++ ) {
 	if ((**j).hit()!=0){
 	  TrackingRecHit * hit = (**j).hit()->clone();
-	  track.setHitPattern( * hit, ih ++ );
+	  track.setHitPattern( * hit, ih ++, *ttopo );
 	  selHits->push_back( hit );
 	  tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
 	}
@@ -130,7 +131,7 @@ void KfTrackProducerBase::putInEvt(edm::Event& evt,
 	   j != transHits.begin()-1; --j ) {
 	if ((**j).hit()!=0){
 	  TrackingRecHit * hit = (**j).hit()->clone();
-	  track.setHitPattern( * hit, ih ++ );
+	  track.setHitPattern( * hit, ih ++, *ttopo );
 	  selHits->push_back( hit );
 	tx.add( TrackingRecHitRef( rHits, hidx ++ ) );
 	}

--- a/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
+++ b/SimMuon/MCTruth/plugins/MuonTrackProducer.cc
@@ -12,6 +12,10 @@
 #include "DataFormats/MuonReco/interface/MuonSelectors.h"
 #include <sstream>
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 MuonTrackProducer::MuonTrackProducer(const edm::ParameterSet& parset) :
   muonsTag(parset.getParameter< edm::InputTag >("muonsTag")),
   inputDTRecSegment4DCollection_(parset.getParameter<edm::InputTag>("inputDTRecSegment4DCollection")),
@@ -34,6 +38,10 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
   iEvent.getByLabel(muonsTag,muonCollectionH);
   iEvent.getByLabel(inputDTRecSegment4DCollection_, dtSegmentCollectionH_);
   iEvent.getByLabel(inputCSCSegmentCollection_, cscSegmentCollectionH_);
+
+  edm::ESHandle<TrackerTopology> httopo;
+  iSetup.get<IdealGeometryRecord>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
   
   std::auto_ptr<reco::TrackCollection> selectedTracks(new reco::TrackCollection);
   std::auto_ptr<reco::TrackExtraCollection> selectedTrackExtras( new reco::TrackExtraCollection() );
@@ -252,7 +260,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = phiHits.begin();
 		      ihit != phiHits.end(); ++ihit) {
 		    TrackingRecHit* seghit = (*ihit)->clone();
-		    newTrk->setHitPattern( *seghit, index_hit);
+		    newTrk->setHitPattern( *seghit, index_hit, ttopo);
 		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		    index_hit++;
@@ -267,7 +275,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		  for(std::vector<const TrackingRecHit*>::const_iterator ihit = zedHits.begin();
 		      ihit != zedHits.end(); ++ihit) {
 		    TrackingRecHit* seghit = (*ihit)->clone();
-		    newTrk->setHitPattern( *seghit, index_hit);
+		    newTrk->setHitPattern( *seghit, index_hit, ttopo);
 		    //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		    //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		    index_hit++;
@@ -295,7 +303,7 @@ void MuonTrackProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetu
 		for(std::vector<const TrackingRecHit*>::const_iterator ihit = hits.begin();
 		    ihit != hits.end(); ++ihit) {
 		  TrackingRecHit* seghit = (*ihit)->clone();
-		  newTrk->setHitPattern( *seghit, index_hit);
+		  newTrk->setHitPattern( *seghit, index_hit, ttopo);
 		  //		    edm::LogVerbatim("MuonTrackProducer")<<"hit pattern for position "<<index_hit<<" set to:";
 		  //		    newTrk->hitPattern().printHitPattern(index_hit, std::cout);
 		  index_hit++;

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -26,6 +26,9 @@
 #include "SimDataFormats/EncodedEventId/interface/EncodedEventId.h"
 #include "SimTracker/TrackAssociation/plugins/ParametersDefinerForTPESProducer.h"
 
+#include "DataFormats/TrackerCommon/interface/TrackerTopology.h"
+#include "Geometry/Records/interface/IdealGeometryRecord.h"
+
 #include <TF1.h>
 
 using namespace std;
@@ -123,6 +126,10 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
   
   edm::ESHandle<ParametersDefinerForTP> parametersDefinerTP; 
   setup.get<TrackAssociatorRecord>().get(parametersDefiner,parametersDefinerTP);    
+
+  edm::ESHandle<TrackerTopology> httopo;
+  setup.get<IdealGeometryRecord>().get(httopo);
+  const TrackerTopology& ttopo = *httopo;
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
   event.getByLabel(label_tp_effic,TPCollectionHeff);
@@ -259,7 +266,7 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 	  //GlobalPoint vSeed(vSeed1.x()-bs.x0(),vSeed1.y()-bs.y0(),vSeed1.z()-bs.z0());
 	  PerigeeTrajectoryError seedPerigeeErrors = PerigeeConversions::ftsToPerigeeError(tsAtClosestApproachSeed.trackStateAtPCA());
 	  matchedTrackPointer = new reco::Track(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
-	  matchedTrackPointer->setHitPattern(matchedSeedPointer->recHits().first,matchedSeedPointer->recHits().second);
+	  matchedTrackPointer->setHitPattern(matchedSeedPointer->recHits().first,matchedSeedPointer->recHits().second, ttopo);
 	}
 
 	histoProducerAlgo_->fill_recoAssociated_simTrack_histos(w,*tp,tp->momentum(),tp->vertex(),dxySim,dzSim,nSimHits,
@@ -306,7 +313,7 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
 
 	//fixme
 	reco::Track* trackFromSeed = new reco::Track(0.,0., vSeed1, pSeed, 1, seedPerigeeErrors.covarianceMatrix());
-	trackFromSeed->setHitPattern(seed->recHits().first,seed->recHits().second);
+	trackFromSeed->setHitPattern(seed->recHits().first,seed->recHits().second, ttopo);
 
 	bool isSigSimMatched(false);
 	bool isSimMatched(false);


### PR DESCRIPTION
Backport of #9959: This PR migrates HitPattern to use TrackerTopology instead of the tracker DetId classes. In contrast to 76X/#9959, here in 62X HitPattern is always filled from DetIds from hits, so it was enough to percolate TrackerTopology to all places where HitPattern is filled.

Tested in CMSSW_6_2_SLHCDEV_X_2015-06-23-2300 with wfs 10000, 10200, 10400, 11200, 11400, 11600, 12000, 13000. I have the alternative-comparisons' results here (black=old, red=new)
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_10000.pdf
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_10200.pdf
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_10400.pdf
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_11200.pdf
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_11400.pdf
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_11600.pdf
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_12000.pdf
- https://mkortela.web.cern.ch/mkortela/tracking/trackerTopologyHitPattern_slhcdev_result_13000.pdf

Of these, 10000, 10200, 11200, 11600 give equal results, and 10400, 11400, 12000, 13000 show differences. I haven't taken too deep look on the geometry differences between the workflows, but maybe in the latter 4 the changes are expected?

@rovere @VinInn @boudoul @venturia 
