### PR TITLE
Fix jet ordering in MvaMEtUtilities class

### DIFF
--- a/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
+++ b/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
@@ -80,8 +80,7 @@ reco::Candidate::LorentzVector MvaMEtUtilities::jetP4(const std::vector<reco::PU
   reco::Candidate::LorentzVector retVal(0.,0.,0.,0.);
   if ( idx < jets.size() ) {
     std::vector<reco::PUSubMETCandInfo> jets_sorted = jets;
-    std::sort(jets_sorted.begin(), jets_sorted.end()); //from lower pt to larger pt
-    std::reverse(jets_sorted.begin(), jets_sorted.end()); //from larger pt to lower pt
+    std::sort(jets_sorted.rbegin(), jets_sorted.rend()); //from lower pt to larger pt
     retVal = jets_sorted[idx].p4();
   }
   return retVal;

--- a/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
+++ b/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
@@ -80,7 +80,8 @@ reco::Candidate::LorentzVector MvaMEtUtilities::jetP4(const std::vector<reco::PU
   reco::Candidate::LorentzVector retVal(0.,0.,0.,0.);
   if ( idx < jets.size() ) {
     std::vector<reco::PUSubMETCandInfo> jets_sorted = jets;
-    std::sort(jets_sorted.begin(), jets_sorted.end()); 
+    std::sort(jets_sorted.begin(), jets_sorted.end()); //from lower pt to larger pt
+    std::reverse(jets_sorted.begin(), jets_sorted.end()); //from larger pt to lower pt
     retVal = jets_sorted[idx].p4();
   }
   return retVal;

--- a/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
+++ b/RecoMET/METPUSubtraction/src/MvaMEtUtilities.cc
@@ -80,7 +80,7 @@ reco::Candidate::LorentzVector MvaMEtUtilities::jetP4(const std::vector<reco::PU
   reco::Candidate::LorentzVector retVal(0.,0.,0.,0.);
   if ( idx < jets.size() ) {
     std::vector<reco::PUSubMETCandInfo> jets_sorted = jets;
-    std::sort(jets_sorted.rbegin(), jets_sorted.rend()); //from lower pt to larger pt
+    std::sort(jets_sorted.rbegin(), jets_sorted.rend());
     retVal = jets_sorted[idx].p4();
   }
   return retVal;


### PR DESCRIPTION
Fix the jet ordering in the mva met utility class, improves slightly the MVA MET performances and makes results consistents

This PR does not impact the standard sequences, no changes expected at all in the tests.
