### PR TITLE
fix BE5DPixel10DCoolingDefect and BE5DPixel10DDefect

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10DCoolingDefect.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10DCoolingDefect.py
@@ -1270,7 +1270,7 @@ def customise_Reco(process,pileup):
     return process
 
 def customise_condOverRides(process):
-    process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_BarrelEndcap5DPixel10DLHCC_cff')
+    process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_BarrelEndcap5DPixel10D_cff')
     process.trackerNumberingSLHCGeometry.layerNumberPXB = cms.uint32(20)
     process.trackerTopologyConstants.pxb_layerStartBit = cms.uint32(20)
     process.trackerTopologyConstants.pxb_ladderStartBit = cms.uint32(12)

--- a/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10DDefect.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase2TkCustomsBE5DPixel10DDefect.py
@@ -1837,7 +1837,7 @@ def customise_Reco(process,pileup):
     return process
 
 def customise_condOverRides(process):
-    process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_BarrelEndcap5DPixel10DLHCC_cff')
+    process.load('SLHCUpgradeSimulations.Geometry.fakeConditions_BarrelEndcap5DPixel10D_cff')
     process.trackerNumberingSLHCGeometry.layerNumberPXB = cms.uint32(20)
     process.trackerTopologyConstants.pxb_layerStartBit = cms.uint32(20)
     process.trackerTopologyConstants.pxb_ladderStartBit = cms.uint32(12)


### PR DESCRIPTION
Fix the fake conditions as noticed by @mark-grimes  in PR#9932 
It should remove the 'SiPixelLorentzAngle for DetID 312492036 is not stored' message from the logs
