### PR TITLE
fix SingleTrackVertexConstraint class for the B=0T case

### DIFF
--- a/RecoVertex/KalmanVertexFit/src/SingleTrackVertexConstraint.cc
+++ b/RecoVertex/KalmanVertexFit/src/SingleTrackVertexConstraint.cc
@@ -37,8 +37,8 @@ SingleTrackVertexConstraint::BTFtuple SingleTrackVertexConstraint::constrain(
   typedef VertexTrack<5>::RefCountedLinearizedTrackState RefCountedLinearizedTrackState;
 
   double field  = track.field()->inInverseGeV(track.impactPointState().globalPosition()).z();
-  double field0  = track.field()->inTesla(GlobalPoint(0.,0.,0.)).z();
-  if ((fabs(field) < 1e-4)&&(fabs(field0)>0.1)) { //protection for the case where the magnet is off
+  int  nominalBfield  = track.field()->nominalValue();
+  if ((fabs(field) < 1e-4)&&(fabs(nominalBfield)!=0)) { //protection for the case where the magnet is off
       LogDebug("RecoVertex/SingleTrackVertexConstraint") 
 	 << "Initial state is very far, field is close to zero (<1e-4): " << field << "\n";
       return BTFtuple(false, TransientTrack(), 0.);

--- a/RecoVertex/KalmanVertexFit/src/SingleTrackVertexConstraint.cc
+++ b/RecoVertex/KalmanVertexFit/src/SingleTrackVertexConstraint.cc
@@ -37,7 +37,8 @@ SingleTrackVertexConstraint::BTFtuple SingleTrackVertexConstraint::constrain(
   typedef VertexTrack<5>::RefCountedLinearizedTrackState RefCountedLinearizedTrackState;
 
   double field  = track.field()->inInverseGeV(track.impactPointState().globalPosition()).z();
-  if (fabs(field) < 1e-4) {
+  double field0  = track.field()->inTesla(GlobalPoint(0.,0.,0.)).z();
+  if ((fabs(field) < 1e-4)&&(fabs(field0)>0.1)) { //protection for the case where the magnet is off
       LogDebug("RecoVertex/SingleTrackVertexConstraint") 
 	 << "Initial state is very far, field is close to zero (<1e-4): " << field << "\n";
       return BTFtuple(false, TransientTrack(), 0.);


### PR DESCRIPTION
In case magnet is off, the `SingleTrackVertexConstraint` always returns a dummy transient track which makes the update at vertex of STA/L2 muons to fail.
This PR add a protection against that, in case the magnet is on, the code behavior is unchanged

Will be backported in 75X, is it still possible to backport in 74X ? 
