### PR TITLE
Remove unnecessary error message in Arbor

### DIFF
--- a/RecoParticleFlow/PFClusterProducer/plugins/cluster_algos/SimpleArborClusterizer.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/cluster_algos/SimpleArborClusterizer.cc
@@ -89,7 +89,7 @@ buildClusters(const edm::Handle<reco::PFRecHitCollection>& input,
 	<< "Made cluster: " << current << std::endl;
     }
   }
-  edm::LogError("ArborInfo") << "Made " << output.size() << " clusters!";
+  edm::LogInfo("ArborInfo") << "Made " << output.size() << " clusters!";
   //clean up arbor mem use
   arbor::ArborFreeMem();
 }


### PR DESCRIPTION
Currently the Arbor cluster maker prints an error every event stating how many clusters were found.  This changes that to an info message.

@lgray
