### PR TITLE
Comment out undefined functions to fix build errors

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -78,9 +78,9 @@ namespace pat {
 
 
       // ---- methods for uncorrected MET ----
-      float uncorrectedPt() const;
-      float uncorrectedPhi() const;
-      float uncorrectedSumEt() const;
+      //float uncorrectedPt() const;
+      //float uncorrectedPhi() const;
+      //float uncorrectedSumEt() const;
 
       // ---- methods to know what the pat::MET was constructed from ----
       /// True if this pat::MET was made from a reco::CaloMET


### PR DESCRIPTION
This PR fixes all (hopefully) the new build errors in CMSSW_7_5_ROOT5_X.  The errors were caused by a merge from 7_5_X in which a class with a dictionary acquired undefined member functions, which is harmless in C++ and ROOT6, but in ROOT 5 causes the generated dictionary  to fail to compile.
This PR simply comments out the declarations of the undefined functions.
Please expedite this purely technical PR.
