### PR TITLE
Add automatic time wrap for muon systems to simulate long-lived neutrons

### DIFF
--- a/SimGeneral/MixingModule/plugins/Adjuster.cc
+++ b/SimGeneral/MixingModule/plugins/Adjuster.cc
@@ -3,7 +3,7 @@
 
 namespace edm {
 namespace detail {
-void doTheOffset(int bunchSpace, int bcr, std::vector<SimTrack>& simtracks, unsigned int evtNr, int vertexOffset) { 
+  void doTheOffset(int bunchSpace, int bcr, std::vector<SimTrack>& simtracks, unsigned int evtNr, int vertexOffset, bool wrap) { 
 
   EncodedEventId id(bcr,evtNr);
   for (auto& item : simtracks) {
@@ -14,7 +14,7 @@ void doTheOffset(int bunchSpace, int bcr, std::vector<SimTrack>& simtracks, unsi
   }
 }
 
-void doTheOffset(int bunchSpace, int bcr, std::vector<SimVertex>& simvertices, unsigned int evtNr, int vertexOffset) { 
+  void doTheOffset(int bunchSpace, int bcr, std::vector<SimVertex>& simvertices, unsigned int evtNr, int vertexOffset, bool wrap) { 
 
   int timeOffset = bcr * bunchSpace;
   EncodedEventId id(bcr,evtNr);
@@ -24,17 +24,32 @@ void doTheOffset(int bunchSpace, int bcr, std::vector<SimVertex>& simvertices, u
   }
 }
 
-void doTheOffset(int bunchSpace, int bcr, std::vector<PSimHit>& simhits, unsigned int evtNr, int vertexOffset) { 
+  void doTheOffset(int bunchSpace, int bcr, std::vector<PSimHit>& simhits, unsigned int evtNr, int vertexOffset, bool wrap) { 
 
   int timeOffset = bcr * bunchSpace;
   EncodedEventId id(bcr,evtNr);
-  for (auto& item : simhits) {
-    item.setEventId(id);
-    item.setTof(item.timeOfFlight() + timeOffset);
+
+  if(wrap) { // wrap time for long-lived hits into one beam crossing
+    for (auto& item : simhits) {
+      item.setEventId(id);
+
+      float Tfloor = floor(item.timeOfFlight());
+      float digits = item.timeOfFlight() - Tfloor;
+      int remainder = int(Tfloor) % bunchSpace;
+
+      item.setTof(float(remainder) + digits + timeOffset);
+    }
   }
+  else {
+    for (auto& item : simhits) {
+      item.setEventId(id);
+      item.setTof(item.timeOfFlight() + timeOffset);
+    }
+  }
+
 }
 
-void doTheOffset(int bunchSpace, int bcr, std::vector<PCaloHit>& calohits, unsigned int evtNr, int vertexOffset) { 
+  void doTheOffset(int bunchSpace, int bcr, std::vector<PCaloHit>& calohits, unsigned int evtNr, int vertexOffset, bool wrap) { 
 
   int timeOffset = bcr * bunchSpace;
   EncodedEventId id(bcr,evtNr);

--- a/SimGeneral/MixingModule/plugins/Adjuster.h
+++ b/SimGeneral/MixingModule/plugins/Adjuster.h
@@ -13,6 +13,8 @@
 #include "boost/shared_ptr.hpp"
 
 #include <vector>
+#include <string>
+#include <iostream>
 
 namespace edm {
   class AdjusterBase {
@@ -41,6 +43,7 @@ namespace edm {
 
    private:
     InputTag tag_;
+    bool WrapT_;
   };
 
   //==============================================================================
@@ -48,23 +51,28 @@ namespace edm {
   //==============================================================================
 
   namespace detail {
-    void doTheOffset(int bunchspace, int bcr, std::vector<SimTrack>& product, unsigned int eventNr, int vertexOffset);
-    void doTheOffset(int bunchspace, int bcr, std::vector<SimVertex>& product, unsigned int eventNr, int vertexOffset);
-    void doTheOffset(int bunchspace, int bcr, std::vector<PCaloHit>& product, unsigned int eventNr, int vertexOffset);
-    void doTheOffset(int bunchspace, int bcr, std::vector<PSimHit>& product, unsigned int eventNr, int vertexOffset);
+    void doTheOffset(int bunchspace, int bcr, std::vector<SimTrack>& product, unsigned int eventNr, int vertexOffset, bool wraptimes);
+    void doTheOffset(int bunchspace, int bcr, std::vector<SimVertex>& product, unsigned int eventNr, int vertexOffset, bool wrapti\
+mes);
+    void doTheOffset(int bunchspace, int bcr, std::vector<PCaloHit>& product, unsigned int eventNr, int vertexOffset, bool wrapti\
+mes);
+    void doTheOffset(int bunchspace, int bcr, std::vector<PSimHit>& product, unsigned int eventNr, int vertexOffset, bool wrapti\
+mes);
   }
 
   template<typename T>
-  void  Adjuster<T>::doOffset(int bunchspace, int bcr, const EventPrincipal &ep, unsigned int eventNr, int vertexOffset) {
+    void  Adjuster<T>::doOffset(int bunchspace, int bcr, const EventPrincipal &ep, unsigned int eventNr, int vertexOffset) {
     boost::shared_ptr<Wrapper<std::vector<T> > const> shPtr = getProductByTag<std::vector<T> >(ep, tag_);
     if (shPtr) {
       std::vector<T>& product = const_cast<std::vector<T>&>(*shPtr->product());
-      detail::doTheOffset(bunchspace, bcr, product, eventNr, vertexOffset);
+      detail::doTheOffset(bunchspace, bcr, product, eventNr, vertexOffset, WrapT_);
     }
   }
 
   template<typename T>
   Adjuster<T>::Adjuster(InputTag const& tag) : tag_(tag) {
+    std::string Musearch = tag_.instance();
+    if(Musearch.find("Muon") == 0) WrapT_ = true; // wrap time for neutrons in Muon system subdetectors
   }
 }
 


### PR DESCRIPTION
For muon systems, the Adjuster function is modified so that all out-of-time hits are "wrapped" so that their times stay within the same bunch crossing.  This ensures that one can simulate long-lived neutrons, as long as one makes the assumptions that (a) the neutron direction and location is random and (b) that the probability that every neutron that interacts in the detector will be observed is 1.0.
