### PR TITLE
Restore functionality of Geant4 geometry overlap check

### DIFF
--- a/SimG4Core/Application/interface/RunManager.h
+++ b/SimG4Core/Application/interface/RunManager.h
@@ -135,6 +135,7 @@ private:
   edm::ParameterSet m_pStackingAction;
   edm::ParameterSet m_pTrackingAction;
   edm::ParameterSet m_pSteppingAction;
+  edm::ParameterSet m_g4overlap;
   std::vector<std::string> m_G4Commands;
   edm::ParameterSet m_p;
 

--- a/SimG4Core/Application/interface/RunManagerMT.h
+++ b/SimG4Core/Application/interface/RunManagerMT.h
@@ -123,6 +123,7 @@ private:
   edm::ParameterSet m_pField;
   edm::ParameterSet m_pPhysics; 
   edm::ParameterSet m_pRunAction;      
+  edm::ParameterSet m_g4overlap;
   std::vector<std::string> m_G4Commands;
 
   std::unique_ptr<DDDWorld> m_world;

--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -50,7 +50,10 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     StorePhysicsTables = cms.bool(False),
     RestorePhysicsTables = cms.bool(False),
     CheckOverlap = cms.untracked.bool(False),
-    G4Commands = cms.vstring(''),
+    G4CheckOverlap = cms.PSet(
+        NodeNames = cms.vstring()
+    ),
+    G4Commands = cms.vstring(),
     FileNameField = cms.untracked.string(''),
     FileNameGDML = cms.untracked.string(''),
     FileNameRegions = cms.untracked.string(''),

--- a/SimG4Core/Application/src/RunManager.cc
+++ b/SimG4Core/Application/src/RunManager.cc
@@ -31,6 +31,8 @@
 #include "SimG4Core/Notification/interface/BeginOfJob.h"
 #include "SimG4Core/Notification/interface/CurrentG4Track.h"
 
+#include "SimG4Core/Geometry/interface/G4CheckOverlap.h"
+
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/ESTransientHandle.h"
@@ -123,6 +125,7 @@ RunManager::RunManager(edm::ParameterSet const & p)
       m_pStackingAction(p.getParameter<edm::ParameterSet>("StackingAction")),
       m_pTrackingAction(p.getParameter<edm::ParameterSet>("TrackingAction")),
       m_pSteppingAction(p.getParameter<edm::ParameterSet>("SteppingAction")),
+      m_g4overlap(p.getParameter<edm::ParameterSet>("G4CheckOverlap")),
       m_G4Commands(p.getParameter<std::vector<std::string> >("G4Commands")),
       m_p(p), m_fieldBuilder(0), m_chordFinderSetter(nullptr),
       m_theLHCTlinkTag(p.getParameter<edm::InputTag>("theLHCTlinkTag"))
@@ -188,7 +191,7 @@ void RunManager::initG4(const edm::EventSetup & es)
    
   G4LogicalVolumeToDDLogicalPartMap map_;
   SensitiveDetectorCatalog catalog_;
-  const DDDWorld * world = new DDDWorld(&(*pDD), map_, catalog_, m_check);
+  const DDDWorld * world = new DDDWorld(&(*pDD), map_, catalog_, false);
   m_registry.dddWorldSignal_(world);
 
   if (m_pUseMagneticField)
@@ -305,6 +308,8 @@ void RunManager::initG4(const edm::EventSetup & es)
     G4RegionReporter rrep;
     rrep.ReportRegions(m_RegionFile);
   }
+
+  if(m_check) { G4CheckOverlap check(m_g4overlap); }
 
   // If the Geant4 particle table is needed, decomment the lines below
   //

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -24,6 +24,7 @@
 #include "SimG4Core/Notification/interface/CurrentG4Track.h"
 #include "SimG4Core/Application/interface/G4RegionReporter.h"
 #include "SimG4Core/Application/interface/CMSGDMLWriteStructure.h"
+#include "SimG4Core/Geometry/interface/G4CheckOverlap.h"
 
 #include "DetectorDescription/Core/interface/DDCompactView.h"
 
@@ -45,6 +46,9 @@
 #include "G4Field.hh"
 #include "G4FieldManager.hh"
 #include "G4CascadeInterface.hh"
+//#include "G4LogicalVolumeStore.hh"
+//#include "G4PhysicalVolumeStore.hh"
+
 
 #include "G4GDMLParser.hh"
 #include "G4SystemOfUnits.hh"
@@ -65,7 +69,8 @@ RunManagerMT::RunManagerMT(edm::ParameterSet const & p):
       m_RestorePhysicsTables(p.getParameter<bool>("RestorePhysicsTables")),
       m_pField(p.getParameter<edm::ParameterSet>("MagneticField")),
       m_pPhysics(p.getParameter<edm::ParameterSet>("Physics")),
-      m_pRunAction(p.getParameter<edm::ParameterSet>("RunAction")),      
+      m_pRunAction(p.getParameter<edm::ParameterSet>("RunAction")),
+      m_g4overlap(p.getParameter<edm::ParameterSet>("G4CheckOverlap")),
       m_G4Commands(p.getParameter<std::vector<std::string> >("G4Commands")),
       m_fieldBuilder(nullptr)
 {    
@@ -97,7 +102,7 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
   
   // DDDWorld: get the DDCV from the ES and use it to build the World
   G4LogicalVolumeToDDLogicalPartMap map_;
-  m_world.reset(new DDDWorld(pDD, map_, m_catalog, m_check));
+  m_world.reset(new DDDWorld(pDD, map_, m_catalog, false));
   m_registry.dddWorldSignal_(m_world.get());
 
   // setup the magnetic field
@@ -178,15 +183,21 @@ void RunManagerMT::initG4(const DDCompactView *pDD, const MagneticField *pMF,
       G4UImanager::GetUIpointer()->ApplyCommand(m_G4Commands[it]);
     }
   }
+
+  // geometry dump
   if("" != m_WriteFile) {
     G4GDMLParser gdml(new G4GDMLReadStructure(), new CMSGDMLWriteStructure());
     gdml.Write(m_WriteFile, m_world->GetWorldVolume(), true);
   }
 
+  // G4Region dump
   if("" != m_RegionFile) {
     G4RegionReporter rrep;
     rrep.ReportRegions(m_RegionFile);
   }
+
+  // Intersection check
+  if(m_check) { G4CheckOverlap check(m_g4overlap); }
 
   // If the Geant4 particle table is needed, decomment the lines below
   //

--- a/SimG4Core/Application/src/RunManagerMT.cc
+++ b/SimG4Core/Application/src/RunManagerMT.cc
@@ -46,9 +46,6 @@
 #include "G4Field.hh"
 #include "G4FieldManager.hh"
 #include "G4CascadeInterface.hh"
-//#include "G4LogicalVolumeStore.hh"
-//#include "G4PhysicalVolumeStore.hh"
-
 
 #include "G4GDMLParser.hh"
 #include "G4SystemOfUnits.hh"

--- a/SimG4Core/Geometry/interface/G4CheckOverlap.h
+++ b/SimG4Core/Geometry/interface/G4CheckOverlap.h
@@ -1,0 +1,15 @@
+#ifndef SimG4Core_G4CheckOverlap_H
+#define SimG4Core_G4CheckOverlap_H
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+class G4CheckOverlap {
+
+public:
+
+  G4CheckOverlap(edm::ParameterSet const & p);
+  ~G4CheckOverlap();
+
+};
+
+#endif

--- a/SimG4Core/Geometry/src/G4CheckOverlap.cc
+++ b/SimG4Core/Geometry/src/G4CheckOverlap.cc
@@ -1,0 +1,47 @@
+#include "SimG4Core/Geometry/interface/G4CheckOverlap.h"
+
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "G4PhysicalVolumeStore.hh"
+#include "G4VPhysicalVolume.hh"
+#include "G4GeomTestVolume.hh"
+#include "globals.hh"
+#include "G4SystemOfUnits.hh"
+
+#include <string>
+
+G4CheckOverlap::G4CheckOverlap(const edm::ParameterSet &p) {
+
+  std::vector<std::string> nodeNames 
+    = p.getParameter<std::vector<std::string> >("NodeNames");
+  double tolerance 
+    = p.getUntrackedParameter<double>("Tolerance", 0.0)*CLHEP::mm;
+  int nPoints = p.getUntrackedParameter<int>("Resolution", 10000);
+  bool verbose = p.getUntrackedParameter<bool>("Verbose", true);
+  int nPrints = p.getUntrackedParameter<int>("ErrorThreshold", 1);
+  int level = p.getUntrackedParameter<int>("Level", 0);
+  int depth = p.getUntrackedParameter<int>("Depth", -1);
+
+  unsigned int nn = nodeNames.size();
+  G4cout << "Initialised with " 
+	 << nodeNames.size() << " nodes; " << " nPoints= " << nPoints
+	 << "; tolerance= " << tolerance/mm << " mm; verbose: " 
+	 << verbose << G4endl;
+  const G4PhysicalVolumeStore * pvs = G4PhysicalVolumeStore::GetInstance();
+  if(0 < nn) { 
+    for (unsigned int ii=0; ii<nn; ++ii) {
+      if("" == nodeNames[ii] || "world" == nodeNames[ii] 
+	 || "World" == nodeNames[ii] ) { 
+	nodeNames[ii] = "DDDWorld"; 
+      }
+      G4cout << "Check overlaps for Node[" << ii << "] : " << nodeNames[ii] << G4endl; 
+      G4VPhysicalVolume* pv = pvs->GetVolume((G4String)nodeNames[ii]);
+      G4GeomTestVolume test(pv, tolerance, nPoints, verbose);
+      test.SetErrorsThreshold(nPrints);
+      test.TestRecursiveOverlap(level, depth);
+    }
+  }
+}
+
+G4CheckOverlap::~G4CheckOverlap() {}
+  


### PR DESCRIPTION
Restore functionality of geant4 geometry overlap check for MT mode using Geant4 tool only. Added new options allowing fully explore this Geant4 tool. 

Should not affect any MC production.
