### PR TITLE
Turn CCC off for Express and Prompt processing, for Run2 scenarios.

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -79,6 +79,8 @@ def customiseExpress(process):
 def customiseExpressRun2(process):
     process = customiseExpress(process)
     process = customiseDataRun2Common(process)
+    process.SiStripClusterChargeCutTight.value = -1.
+    process.SiStripClusterChargeCutLoose.value = -1.
     return process
 
 def customiseExpressRun2B0T(process):
@@ -103,6 +105,8 @@ def customisePrompt(process):
 def customisePromptRun2(process):
     process = customisePrompt(process)
     process = customiseDataRun2Common(process)
+    process.SiStripClusterChargeCutTight.value = -1.
+    process.SiStripClusterChargeCutLoose.value = -1.
     return process
 
 def customisePromptRun2B0T(process):

--- a/RecoTracker/Configuration/python/customiseNoCCC.py
+++ b/RecoTracker/Configuration/python/customiseNoCCC.py
@@ -1,0 +1,11 @@
+import FWCore.ParameterSet.Config as cms
+
+def customiseNoCCC(process):
+
+    # apply only in reco step
+    if not hasattr(process,'reconstruction'):
+        return process
+    process.SiStripClusterChargeCutTight.value = -1.
+    process.SiStripClusterChargeCutLoose.value = -1.
+
+    return process


### PR DESCRIPTION
The title says it all.
`scram b runtests` under Configuration/DataProcessing/test returns all successes.

@venturia @VinInn 
