### PR TITLE
Don't declare undefined functions

### DIFF
--- a/DataFormats/PatCandidates/interface/MET.h
+++ b/DataFormats/PatCandidates/interface/MET.h
@@ -78,9 +78,10 @@ namespace pat {
 
 
       // ---- methods for uncorrected MET ----
-      float uncorrectedPt() const;
-      float uncorrectedPhi() const;
-      float uncorrectedSumEt() const;
+      // Methods not yet defined
+      //float uncorrectedPt() const;
+      //float uncorrectedPhi() const;
+      //float uncorrectedSumEt() const;
 
       // ---- methods to know what the pat::MET was constructed from ----
       /// True if this pat::MET was made from a reco::CaloMET


### PR DESCRIPTION
Undefined member functions were declared in class MET.  This causes the ROOT dictionary in CMSSW_7_5_ROOT5_X to fail to compile.  David Lange wanted me to remove or comment out the declarations in the mainstream ROOT6 release as well, so here it is.
Please expedite.
