### PR TITLE
Use C++ regex, not boost regex, in the framework where feasible.

### DIFF
--- a/FWCore/Catalog/interface/FileLocator.h
+++ b/FWCore/Catalog/interface/FileLocator.h
@@ -5,7 +5,7 @@
 #include <list>
 #include <map>
 #include <utility>
-#include <boost/regex.hpp>
+#include <regex>
 #include <xercesc/dom/DOM.hpp>
 
 namespace edm {
@@ -26,8 +26,8 @@ namespace edm {
     static int s_numberOfInstances;
 
     struct Rule {
-      boost::regex pathMatch;
-      boost::regex destinationMatch;
+      std::regex pathMatch;
+      std::regex destinationMatch;
       std::string result;
       std::string chain;
     };

--- a/FWCore/Catalog/src/FileLocator.cc
+++ b/FWCore/Catalog/src/FileLocator.cc
@@ -29,7 +29,7 @@ namespace {
   }
 
   std::string
-  replaceWithRegexp(boost::smatch const& matches,
+  replaceWithRegexp(std::smatch const& matches,
                     std::string const& outputFormat) {
     std::string result = outputFormat;
     std::stringstream str;
@@ -258,17 +258,17 @@ namespace edm {
 
     Rules const& rules = (*(rulesIterator)).second;
 
-    boost::smatch destinationMatches;
-    boost::smatch nameMatches;
+    std::smatch destinationMatches;
+    std::smatch nameMatches;
 
     /* Look up for a matching rule*/
     for (Rules::const_iterator i = rules.begin(); i != rules.end(); ++i) {
 
-      if (!boost::regex_match(destination, destinationMatches, i->destinationMatch)) {
+      if (!std::regex_match(destination, destinationMatches, i->destinationMatch)) {
         continue;
       }
 
-      if (!boost::regex_match(name, i->pathMatch)) {
+      if (!std::regex_match(name, i->pathMatch)) {
         continue;
       }
 
@@ -282,7 +282,7 @@ namespace edm {
         }
       }
 
-      boost::regex_match(name, nameMatches, i->pathMatch);
+      std::regex_match(name, nameMatches, i->pathMatch);
       name = replaceWithRegexp(nameMatches, i->result);
 
       if ((direct == false) && (chain != "")) {

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -23,7 +23,7 @@ Test of the EventProcessor class.
 
 #include "cppunit/extensions/HelperMacros.h"
 
-#include "boost/regex.hpp"
+#include <regex>
 
 #include <exception>
 #include <iostream>
@@ -454,7 +454,7 @@ testeventprocessor::activityRegistryTest() {
 static
 bool
 findModuleName(std::string const& iMessage) {
-  static boost::regex const expr("TestFailuresAnalyzer");
+  static std::regex const expr("TestFailuresAnalyzer");
   return regex_search(iMessage, expr);
 }
 
@@ -556,7 +556,7 @@ testeventprocessor::moduleFailureTest() {
 
         threw = false;
       } catch(cms::Exception const& iException) {
-        static boost::regex const expr("m1");
+        static std::regex const expr("m1");
         if(!regex_search(iException.explainSelf(), expr)) {
           std::cout << iException.explainSelf() << std::endl;
           CPPUNIT_ASSERT(0 == "module name not in exception message");

--- a/FWCore/Utilities/interface/RegexMatch.h
+++ b/FWCore/Utilities/interface/RegexMatch.h
@@ -1,8 +1,7 @@
 #ifndef FWCore_Utilities_RegexMatch_h
 #define FWCore_Utilities_RegexMatch_h
 
-#include <boost/regex_fwd.hpp>
-
+#include <regex>
 #include <string>
 #include <vector>
 
@@ -18,7 +17,7 @@ namespace edm {
   glob2reg(std::string const& pattern);
 
   std::vector<std::vector<std::string>::const_iterator>
-  regexMatch(std::vector<std::string> const& strings, boost::regex const& regexp);
+  regexMatch(std::vector<std::string> const& strings, std::regex const& regexp);
 
   std::vector<std::vector<std::string>::const_iterator>
   regexMatch(std::vector<std::string> const& strings, std::string const& pattern);

--- a/FWCore/Utilities/src/RegexMatch.cc
+++ b/FWCore/Utilities/src/RegexMatch.cc
@@ -3,7 +3,7 @@
 #include "FWCore/Utilities/interface/RegexMatch.h"
 
 #include <boost/algorithm/string.hpp>
-#include <boost/regex.hpp>
+#include <regex>
 
 namespace edm {
 
@@ -11,8 +11,8 @@ namespace edm {
   // Needed to satisfy Coverity.
   bool
   untaintString(char const* pattern, char const* regexp) {
-    boost::regex rexp(regexp);
-    return boost::regex_match(pattern, rexp);
+    std::regex rexp(regexp);
+    return std::regex_match(pattern, rexp);
   }
 
   bool is_glob(std::string const& pattern) {
@@ -27,10 +27,10 @@ namespace edm {
   }
 
   std::vector<std::vector<std::string>::const_iterator>
-  regexMatch(std::vector<std::string> const& strings, boost::regex const& regexp) {
+  regexMatch(std::vector<std::string> const& strings, std::regex const& regexp) {
     std::vector< std::vector<std::string>::const_iterator> matches;
     for (std::vector<std::string>::const_iterator i = strings.begin(), iEnd = strings.end(); i != iEnd; ++i) {
-      if (boost::regex_match((*i), regexp)) {
+      if (std::regex_match((*i), regexp)) {
         matches.push_back(i);
       }
     }
@@ -39,7 +39,7 @@ namespace edm {
 
   std::vector<std::vector<std::string>::const_iterator>
   regexMatch(std::vector<std::string> const& strings, std::string const& pattern) {
-    boost::regex regexp(glob2reg(pattern));
+    std::regex regexp(glob2reg(pattern));
     return regexMatch(strings, regexp);
   }
 

--- a/FWCore/Utilities/src/TypeDemangler.cc
+++ b/FWCore/Utilities/src/TypeDemangler.cc
@@ -1,7 +1,7 @@
 #include <cxxabi.h>
 #include <cctype>
 #include <string>
-#include "boost/regex.hpp"
+#include <regex>
 #include "FWCore/Utilities/interface/Exception.h"
 
 /********************************************************************
@@ -27,9 +27,9 @@
 namespace {
   void
   reformatter(std::string& input, char const* exp, char const* format) {
-    boost::regex regexp(exp, boost::regex::egrep);
-    while(boost::regex_match(input, regexp)) {
-      std::string newstring = boost::regex_replace(input, regexp, format);
+    std::regex regexp(exp, std::regex::egrep);
+    while(std::regex_match(input, regexp)) {
+      std::string newstring = std::regex_replace(input, regexp, format);
       input.swap(newstring);
     }
   }


### PR DESCRIPTION
std::regex is supported in gcc491, so we can use it instead of boost::regex in many cases.
boost::regex is used in the framework in six different places.  This PR replaces the use of boost::regex with std::regex in those four places in the framework where the replacement is trivial and obvious.
In the other two cases, boost::regex use is left alone because boost functions are used that have no obvious equivalent in the C++ standard library.
