### PR TITLE
Degridifying unpacked phi to break degeneracies in angular separations for packed candidates: 74X

### DIFF
--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -61,9 +61,12 @@ void pat::PackedCandidate::packVtx(bool unpackAfterwards) {
 }
 
 void pat::PackedCandidate::unpack() const {
-    p4_ = PolarLorentzVector(MiniFloatConverter::float16to32(packedPt_),
+    float pt = MiniFloatConverter::float16to32(packedPt_);
+    double shift = (pt<1. ? 0.1*pt : 0.1/pt); // shift particle phi to break degeneracies in angular separations
+    double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + shift*3.2/std::numeric_limits<int16_t>::max();
+    p4_ = PolarLorentzVector(pt,
                              int16_t(packedEta_)*6.0f/std::numeric_limits<int16_t>::max(),
-                             int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max(),
+                             phi,
                              MiniFloatConverter::float16to32(packedM_));
     p4c_ = p4_;
     unpacked_ = true;

--- a/DataFormats/PatCandidates/src/PackedCandidate.cc
+++ b/DataFormats/PatCandidates/src/PackedCandidate.cc
@@ -63,7 +63,8 @@ void pat::PackedCandidate::packVtx(bool unpackAfterwards) {
 void pat::PackedCandidate::unpack() const {
     float pt = MiniFloatConverter::float16to32(packedPt_);
     double shift = (pt<1. ? 0.1*pt : 0.1/pt); // shift particle phi to break degeneracies in angular separations
-    double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + shift*3.2/std::numeric_limits<int16_t>::max();
+    double sign = ( ( int(pt*10) % 2 == 0 ) ? 1 : -1 ); // introduce a pseudo-random sign of the shift
+    double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + sign*shift*3.2/std::numeric_limits<int16_t>::max();
     p4_ = PolarLorentzVector(pt,
                              int16_t(packedEta_)*6.0f/std::numeric_limits<int16_t>::max(),
                              phi,

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -20,7 +20,8 @@ void pat::PackedGenParticle::unpack() const {
     float pz = std::tanh(y)*std::sqrt((m*m+pt*pt)/(1.-std::tanh(y)*std::tanh(y)));
     float eta = std::asinh(pz/pt);
     double shift = (pt<1. ? 0.1*pt : 0.1/pt); // shift particle phi to break degeneracies in angular separations
-    double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + shift*3.2/std::numeric_limits<int16_t>::max();
+    double sign = ( ( int(pt*10) % 2 == 0 ) ? 1 : -1 ); // introduce a pseudo-random sign of the shift
+    double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + sign*shift*3.2/std::numeric_limits<int16_t>::max();
     p4_ = PolarLorentzVector(pt,eta,phi,m);
     p4c_ = p4_;
     unpacked_ = true;

--- a/DataFormats/PatCandidates/src/PackedGenParticle.cc
+++ b/DataFormats/PatCandidates/src/PackedGenParticle.cc
@@ -19,7 +19,9 @@ void pat::PackedGenParticle::unpack() const {
     float m=MiniFloatConverter::float16to32(packedM_);
     float pz = std::tanh(y)*std::sqrt((m*m+pt*pt)/(1.-std::tanh(y)*std::tanh(y)));
     float eta = std::asinh(pz/pt);
-    p4_ = PolarLorentzVector(pt,eta,int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max(),m);
+    double shift = (pt<1. ? 0.1*pt : 0.1/pt); // shift particle phi to break degeneracies in angular separations
+    double phi = int16_t(packedPhi_)*3.2f/std::numeric_limits<int16_t>::max() + shift*3.2/std::numeric_limits<int16_t>::max();
+    p4_ = PolarLorentzVector(pt,eta,phi,m);
     p4c_ = p4_;
     unpacked_ = true;
 }


### PR DESCRIPTION
Backport of #9554
