### PR TITLE
Simplify class stucture of hit generators

### DIFF
--- a/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
+++ b/RecoPixelVertexing/PixelLowPtUtilities/interface/PixelTripletLowPtGenerator.h
@@ -7,7 +7,6 @@
     provided Layers
  */
 
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -28,31 +27,22 @@ class   PixelTripletLowPtGenerator :
  public:
    PixelTripletLowPtGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
-   virtual ~PixelTripletLowPtGenerator() { delete thePairGenerator; delete theFilter; }
+  virtual ~PixelTripletLowPtGenerator();
 
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) override;
-
-  void init( const HitPairGenerator & pairs, LayerCacheType* layerCache) override;
-
-   virtual void hitTriplets(const TrackingRegion& region, OrderedHitTriplets & trs,  const edm::Event & ev, const edm::EventSetup& es);
-
-   const HitPairGenerator & pairGenerator() const { return *thePairGenerator; }
+  virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
+                            const edm::Event & ev, const edm::EventSetup& es,
+                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
  private:
   void getTracker (const edm::EventSetup& es);
   GlobalPoint getGlobalPosition(const TrackingRecHit* recHit);
 
   const TrackerGeometry * theTracker;
-  TripletFilter * theFilter;
+  std::unique_ptr<TripletFilter> theFilter;
 
-  edm::ParameterSet         ps;
-  HitPairGenerator * thePairGenerator;
-  std::vector<SeedingLayerSetsHits::SeedingLayer> theLayers;
-  LayerCacheType * theLayerCache;
 
   edm::EDGetTokenT<SiPixelClusterShapeCache> theClusterShapeCacheToken;
-
   double nSigMultipleScattering;
   double rzTolerance;
   double maxAngleRatio;

--- a/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
+++ b/RecoPixelVertexing/PixelLowPtUtilities/src/PixelTripletLowPtGenerator.cc
@@ -91,8 +91,7 @@ void PixelTripletLowPtGenerator::hitTriplets(
 
   // Generate pairs
   OrderedHitPairs pairs; pairs.reserve(30000);
-  thePairGenerator->setSeedingLayers(pairLayers);
-  thePairGenerator->hitPairs(region,pairs,ev,es);
+  thePairGenerator->hitPairs(region,pairs,ev,es, pairLayers);
 
   if (pairs.size() == 0) return;
 

--- a/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGenerator.h
@@ -2,7 +2,7 @@
 #define CosmicHitTripletGenerator_H
 
 #include <vector>
-#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
 #include "RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGeneratorFromLayerTriplet.h"
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -11,16 +11,15 @@ class LayerWithHits;
 class DetLayer;
 class TrackingRegion;
 class CosmicLayerTriplets;
-class HitTripletGeneratorFromLayerTriplet;
 
 
 /** \class CosmicHitTripletGenerator
  * Hides set of HitTripletGeneratorFromLayerTriplet generators.
  */
 
-class CosmicHitTripletGenerator : public HitTripletGenerator{
+class CosmicHitTripletGenerator {
 
-  typedef std::vector<CosmicHitTripletGeneratorFromLayerTriplet *>   Container;
+  typedef std::vector<std::unique_ptr<CosmicHitTripletGeneratorFromLayerTriplet> >   Container;
 
 public:
   CosmicHitTripletGenerator(CosmicLayerTriplets& layers, const edm::EventSetup& iSetup);
@@ -35,19 +34,10 @@ public:
 	      const LayerWithHits* middle,
 	      const LayerWithHits* outer,
 	      const edm::EventSetup& iSetup);
-  /// form base class
-  virtual void hitTriplets( const TrackingRegion& reg, 
-			 OrderedHitTriplets & prs, 
-			 const edm::EventSetup& iSetup);
 
-  virtual void hitTriplets( const TrackingRegion& reg, 
-			 OrderedHitTriplets & prs, 
-                   const edm::Event& ev,
-			 const edm::EventSetup& iSetup) { }
-
-  /// from base class
-  virtual CosmicHitTripletGenerator * clone() const 
-    { return new CosmicHitTripletGenerator(*this); }
+  void hitTriplets( const TrackingRegion& reg,
+                    OrderedHitTriplets & prs,
+                    const edm::EventSetup& iSetup);
 
 private:
 

--- a/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGeneratorFromLayerTriplet.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/CosmicHitTripletGeneratorFromLayerTriplet.h
@@ -1,7 +1,7 @@
 #ifndef CosmicHitTripletGeneratorFromLayerTriplet_h
 #define CosmicHitTripletGeneratorFromLayerTriplet_h
 
-#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
 #include "RecoTracker/TkHitPairs/interface/LayerWithHits.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "Geometry/TrackerGeometryBuilder/interface/TrackerGeometry.h"
@@ -14,7 +14,7 @@ class TrackingRegion;
 class LayerWithHits;
 
 
-class CosmicHitTripletGeneratorFromLayerTriplet : public HitTripletGenerator {
+class CosmicHitTripletGeneratorFromLayerTriplet {
 
 public:
 
@@ -24,17 +24,10 @@ public:
 				const LayerWithHits* middle, 
 				const LayerWithHits* outer, 
 				const edm::EventSetup& iSetup);
-  virtual ~CosmicHitTripletGeneratorFromLayerTriplet() { }
+  ~CosmicHitTripletGeneratorFromLayerTriplet() { }
 
-  virtual void hitTriplets( const TrackingRegion& ar, OrderedHitTriplets & ap, const edm::EventSetup& iSetup);
+  void hitTriplets( const TrackingRegion& ar, OrderedHitTriplets & ap, const edm::EventSetup& iSetup);
 
-  virtual void hitTriplets( const TrackingRegion& ar, OrderedHitTriplets & ap, const edm::Event& ev, const edm::EventSetup& iSetup) {}
-
-  virtual CosmicHitTripletGeneratorFromLayerTriplet* clone() const {
-    return new CosmicHitTripletGeneratorFromLayerTriplet(*this);
-  }
-  void init( const HitPairGenerator & pairs,
-	     const std::vector<const LayerWithHits*>& layers ){}
   const LayerWithHits* innerLayer() const { return theInnerLayer; }
   const LayerWithHits* middleLayer() const { return theMiddleLayer; }
   const LayerWithHits* outerLayer() const { return theOuterLayer; }

--- a/RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h
+++ b/RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h
@@ -7,25 +7,36 @@
     provided Layers
  */
 
-#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
+#include "RecoPixelVertexing/PixelTriplets/interface/OrderedHitTriplets.h"
 #include <vector>
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 
-namespace edm { class ConsumesCollector; }
+namespace edm { class ParameterSet; class Event; class EventSetup; class ConsumesCollector; }
+class TrackingRegion;
+class HitPairGeneratorFromLayerPair;
 
-class HitTripletGeneratorFromPairAndLayers : public HitTripletGenerator {
+class HitTripletGeneratorFromPairAndLayers {
 
 public:
   typedef LayerHitMapCache  LayerCacheType;
 
-  virtual ~HitTripletGeneratorFromPairAndLayers() {}
+  explicit HitTripletGeneratorFromPairAndLayers(unsigned int maxElement=0);
+  explicit HitTripletGeneratorFromPairAndLayers(const edm::ParameterSet& pset);
+  virtual ~HitTripletGeneratorFromPairAndLayers();
 
-  virtual void init( const HitPairGenerator & pairs, LayerCacheType* layerCache) = 0;
+  void init( std::unique_ptr<HitPairGeneratorFromLayerPair>&& pairs, LayerCacheType* layerCache);
 
-  virtual void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                                std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) = 0;
+  const HitPairGeneratorFromLayerPair& pairGenerator() const { return *thePairGenerator; }
+
+  virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
+                            const edm::Event & ev, const edm::EventSetup& es,
+                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) = 0;
+protected:
+  std::unique_ptr<HitPairGeneratorFromLayerPair> thePairGenerator;
+  LayerCacheType *theLayerCache;
+  const unsigned int theMaxElement;
 };
 #endif
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/CombinedHitTripletGenerator.cc
@@ -14,7 +14,7 @@ CombinedHitTripletGenerator::CombinedHitTripletGenerator(const edm::ParameterSet
   edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
   std::string       generatorName = generatorPSet.getParameter<std::string>("ComponentName");
   theGenerator.reset(HitTripletGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet, iC));
-  theGenerator->init(HitPairGeneratorFromLayerPair(0, 1, &theLayerCache), &theLayerCache);
+  theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
 }
 
 CombinedHitTripletGenerator::~CombinedHitTripletGenerator() {}
@@ -31,8 +31,7 @@ void CombinedHitTripletGenerator::hitTriplets(
 
   std::vector<LayerTriplets::LayerSetAndLayers> trilayers = LayerTriplets::layers(layers);
   for(const auto& setAndLayers: trilayers) {
-    theGenerator->setSeedingLayers(setAndLayers.first, setAndLayers.second);
-    theGenerator->hitTriplets( region, result, ev, es);
+    theGenerator->hitTriplets( region, result, ev, es, setAndLayers.first, setAndLayers.second);
   }
   theLayerCache.clear();
 }

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -1,4 +1,5 @@
 #include "RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h"
+#include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
 
 #include "ThirdHitPredictionFromInvParabola.h"
 #include "ThirdHitRZPrediction.h"
@@ -30,15 +31,13 @@ using namespace std;
 using namespace ctfseeding;
 
 PixelTripletHLTGenerator:: PixelTripletHLTGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
-  : thePairGenerator(0),
-    theLayerCache(0),
+  : HitTripletGeneratorFromPairAndLayers(cfg),
     useFixedPreFiltering(cfg.getParameter<bool>("useFixedPreFiltering")),
     extraHitRZtolerance(cfg.getParameter<double>("extraHitRZtolerance")),
     extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")),
     useMScat(cfg.getParameter<bool>("useMultScattering")),
     useBend(cfg.getParameter<bool>("useBending"))
 {
-  theMaxElement=cfg.getParameter<unsigned int>("maxElement");
   dphi =  (useFixedPreFiltering) ?  cfg.getParameter<double>("phiPreFiltering") : 0;
   
   edm::ParameterSet comparitorPSet =
@@ -49,31 +48,19 @@ PixelTripletHLTGenerator:: PixelTripletHLTGenerator(const edm::ParameterSet& cfg
   }
 }
 
-PixelTripletHLTGenerator::~PixelTripletHLTGenerator() { 
-  delete thePairGenerator;
-}
-
-void PixelTripletHLTGenerator::init( const HitPairGenerator & pairs,
-				     LayerCacheType* layerCache)
-{
-  thePairGenerator = pairs.clone();
-  theLayerCache = layerCache;
-}
-
-void PixelTripletHLTGenerator::setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                                                std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) {
-  thePairGenerator->setSeedingLayers(pairLayers);
-  theLayers = thirdLayers;
-}
+PixelTripletHLTGenerator::~PixelTripletHLTGenerator() {}
 
 void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region, 
 					   OrderedHitTriplets & result,
 					   const edm::Event & ev,
-					   const edm::EventSetup& es)
+					   const edm::EventSetup& es,
+					   SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+					   const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 {
 
   if (theComparitor) theComparitor->init(ev, es);
   
+  thePairGenerator->setSeedingLayers(pairLayers);
   auto const & doublets = thePairGenerator->doublets(region,ev,es);
   
   if (doublets.empty()) return;
@@ -84,7 +71,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   // std::cout << "pairs " << doublets.size() << std::endl;
   
   float regOffset = region.origin().perp(); //try to take account of non-centrality (?)
-  int size = theLayers.size();
+  int size = thirdLayers.size();
   
   #ifdef __clang__
   std::vector<ThirdHitRZPrediction<PixelRecoLineRZ>> preds(size);
@@ -110,10 +97,10 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
   
   // fill the prediction vector
   for (int il=0; il!=size; ++il) {
-    thirdHitMap[il] = &(*theLayerCache)(theLayers[il], region, ev, es);
+    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
     auto const & hits = *thirdHitMap[il];
     ThirdHitRZPrediction<PixelRecoLineRZ> & pred = preds[il];
-    pred.initLayer(theLayers[il].detLayer());
+    pred.initLayer(thirdLayers[il].detLayer());
     pred.initTolerance(extraHitRZtolerance);
     
     layerTree.clear();
@@ -136,7 +123,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
     //add fudge factors in case only one hit and also for floating-point inaccuracy
     hitTree[il].build(layerTree, phiZ); // make KDtree
     rzError[il] = maxErr; //save error
-    // std::cout << "layer " << theLayers[il].detLayer()->seqNum() << " " << layerTree.size() << std::endl; 
+    // std::cout << "layer " << thirdLayers[il].detLayer()->seqNum() << " " << layerTree.size() << std::endl; 
   }
   
   float imppar = region.originRBound();
@@ -172,7 +159,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
       
       auto const & hits = *thirdHitMap[il];
       
-      const DetLayer * layer = theLayers[il].detLayer();
+      const DetLayer * layer = thirdLayers[il].detLayer();
       auto barrelLayer = layer->isBarrel();
 
       ThirdHitCorrection correction(es, region.ptMin(), layer, line, point2, outSeq, useMScat, useBend); 
@@ -265,7 +252,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 	  hitTree[il].search(phiZ, foundNodes);
 	}
 
-      // std::cout << ip << ": " << theLayers[il].detLayer()->seqNum() << " " << foundNodes.size() << " " << prmin << " " << prmax << std::endl;
+      // std::cout << ip << ": " << thirdLayers[il].detLayer()->seqNum() << " " << foundNodes.size() << " " << prmin << " " << prmax << std::endl;
 
 
       // int kk=0;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.cc
@@ -60,8 +60,7 @@ void PixelTripletHLTGenerator::hitTriplets(const TrackingRegion& region,
 
   if (theComparitor) theComparitor->init(ev, es);
   
-  thePairGenerator->setSeedingLayers(pairLayers);
-  auto const & doublets = thePairGenerator->doublets(region,ev,es);
+  auto const & doublets = thePairGenerator->doublets(region,ev,es, pairLayers);
   
   if (doublets.empty()) return;
 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletHLTGenerator.h
@@ -7,8 +7,6 @@
     provided Layers
  */
 
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
 #include "CombinedHitTripletGenerator.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -28,15 +26,10 @@ public:
 
   virtual ~PixelTripletHLTGenerator();
 
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) override;
-
-  void init( const HitPairGenerator & pairs, LayerCacheType* layerCache) override;
-
-  virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs, 
-      const edm::Event & ev, const edm::EventSetup& es);
-
-  const HitPairGenerator & pairGenerator() const { return *thePairGenerator; }
+  virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
+                            const edm::Event & ev, const edm::EventSetup& es,
+                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:
   bool checkPhiInRange(float phi, float phi1, float phi2) const;
@@ -44,10 +37,6 @@ private:
       const std::pair<float,float> &r1, const std::pair<float,float> &r2) const; 
 
 private:
-  HitPairGenerator * thePairGenerator;
-  std::vector<SeedingLayerSetsHits::SeedingLayer> theLayers;
-  LayerCacheType * theLayerCache;
-
   bool useFixedPreFiltering;
   float extraHitRZtolerance;
   float extraHitRPhitolerance;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -1,4 +1,5 @@
 #include "RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h"
+#include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
 
 #include "RecoPixelVertexing/PixelTriplets/interface/ThirdHitPredictionFromCircle.h"
 #include "ThirdHitRZPrediction.h"
@@ -42,30 +43,18 @@ constexpr double nSigmaPhi = 3.;
 static const float fnSigmaRZ = std::sqrt(12.f);
 
 PixelTripletLargeTipGenerator::PixelTripletLargeTipGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
-  : thePairGenerator(0),
-    theLayerCache(0),
+  : HitTripletGeneratorFromPairAndLayers(cfg),
     useFixedPreFiltering(cfg.getParameter<bool>("useFixedPreFiltering")),
     extraHitRZtolerance(cfg.getParameter<double>("extraHitRZtolerance")),
     extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")),
     useMScat(cfg.getParameter<bool>("useMultScattering")),
     useBend(cfg.getParameter<bool>("useBending"))
-{    theMaxElement=cfg.getParameter<unsigned int>("maxElement");
+{
   if (useFixedPreFiltering)
     dphi = cfg.getParameter<double>("phiPreFiltering");
 }
 
-void PixelTripletLargeTipGenerator::init(const HitPairGenerator & pairs,
-					 LayerCacheType *layerCache)
-{
-  thePairGenerator = pairs.clone();
-  theLayerCache = layerCache;
-}
-
-void PixelTripletLargeTipGenerator::setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                                                     std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) {
-  thePairGenerator->setSeedingLayers(pairLayers);
-  theLayers = thirdLayers;
-}
+PixelTripletLargeTipGenerator::~PixelTripletLargeTipGenerator() {}
 
 namespace {
   inline
@@ -84,7 +73,9 @@ namespace {
 void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region, 
 						OrderedHitTriplets & result,
 						const edm::Event & ev,
-						const edm::EventSetup& es)
+						const edm::EventSetup& es,
+						SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+						const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 { 
   edm::ESHandle<TrackerGeometry> tracker;
   es.get<TrackerDigiGeometryRecord>().get(tracker);
@@ -94,6 +85,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   es.get<TrackerTopologyRcd>().get(tTopoHand);
   const TrackerTopology *tTopo=tTopoHand.product();
 
+  thePairGenerator->setSeedingLayers(pairLayers);
   auto const & doublets = thePairGenerator->doublets(region,ev,es);
   
   if (doublets.empty()) return;
@@ -101,7 +93,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   auto outSeq =  doublets.detLayer(HitDoublets::outer)->seqNum();
 
 
-  int size = theLayers.size();
+  int size = thirdLayers.size();
 
 
   using NodeInfo = KDTreeNodeInfo<unsigned int>;
@@ -123,10 +115,10 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   const RecHitsSortedInPhi * thirdHitMap[size];
 
   for(int il = 0; il < size; il++) {
-    thirdHitMap[il] = &(*theLayerCache)(theLayers[il], region, ev, es);
+    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
     auto const & hits = *thirdHitMap[il];
  
-    const DetLayer *layer = theLayers[il].detLayer();
+    const DetLayer *layer = thirdLayers[il].detLayer();
     LayerRZPredictions &predRZ = mapPred[il];
     predRZ.line.initLayer(layer);
     predRZ.helix1.initLayer(layer);
@@ -181,7 +173,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
 
     for(int il = 0; il < size; il++) {
       if (hitTree[il].empty()) continue; // Don't bother if no hits
-      const DetLayer *layer = theLayers[il].detLayer();
+      const DetLayer *layer = thirdLayers[il].detLayer();
       bool barrelLayer = layer->isBarrel();
       
       Range curvature = generalCurvature;
@@ -308,7 +300,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
       MatchedHitRZCorrectionFromBending l2rzFixup(doublets.hit(ip,HitDoublets::outer)->det()->geographicalId(), tTopo);
       MatchedHitRZCorrectionFromBending l3rzFixup = predRZ.rzPositionFixup;
 
-      thirdHitMap[il] = &(*theLayerCache)(theLayers[il], region, ev, es);
+      thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
       auto const & hits = *thirdHitMap[il];
       for (auto KDdata : foundNodes) {
 	GlobalPoint p3 = hits.gp(KDdata); 

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.cc
@@ -85,8 +85,7 @@ void PixelTripletLargeTipGenerator::hitTriplets(const TrackingRegion& region,
   es.get<TrackerTopologyRcd>().get(tTopoHand);
   const TrackerTopology *tTopo=tTopoHand.product();
 
-  thePairGenerator->setSeedingLayers(pairLayers);
-  auto const & doublets = thePairGenerator->doublets(region,ev,es);
+  auto const & doublets = thePairGenerator->doublets(region,ev,es, pairLayers);
   
   if (doublets.empty()) return;
    

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletLargeTipGenerator.h
@@ -7,8 +7,6 @@
     provided Layers
  */
 
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
-#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGenerator.h"
 #include "CombinedHitTripletGenerator.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -25,17 +23,12 @@ typedef CombinedHitTripletGenerator::LayerCacheType       LayerCacheType;
 public:
   PixelTripletLargeTipGenerator( const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
-  virtual ~PixelTripletLargeTipGenerator() { delete thePairGenerator; }
+  virtual ~PixelTripletLargeTipGenerator();
 
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) override;
-
-  void init( const HitPairGenerator & pairs, LayerCacheType* layerCache) override;
-
-  virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs, 
-      const edm::Event & ev, const edm::EventSetup& es);
-
-  const HitPairGenerator & pairGenerator() const { return *thePairGenerator; }
+  virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
+                            const edm::Event & ev, const edm::EventSetup& es,
+                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:
 
@@ -45,10 +38,6 @@ private:
 
 
 private:
-  HitPairGenerator * thePairGenerator;
-  std::vector<SeedingLayerSetsHits::SeedingLayer> theLayers;
-  LayerCacheType * theLayerCache;
-
   bool useFixedPreFiltering;
   float extraHitRZtolerance;
   float extraHitRPhitolerance;

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
@@ -55,8 +55,7 @@ void PixelTripletNoTipGenerator::hitTriplets(
 
   OrderedHitPairs pairs; pairs.reserve(30000);
   OrderedHitPairs::const_iterator ip;
-  thePairGenerator->setSeedingLayers(pairLayers);
-  thePairGenerator->hitPairs(region,pairs,ev,es);
+  thePairGenerator->hitPairs(region,pairs,ev,es, pairLayers);
 
   if (pairs.size() ==0) return;
 
@@ -67,8 +66,8 @@ void PixelTripletNoTipGenerator::hitTriplets(
      thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
   }
 
-  const DetLayer * firstLayer = thePairGenerator->innerLayer().detLayer();
-  const DetLayer * secondLayer = thePairGenerator->outerLayer().detLayer();
+  const DetLayer * firstLayer = thePairGenerator->innerLayer(pairLayers).detLayer();
+  const DetLayer * secondLayer = thePairGenerator->outerLayer(pairLayers).detLayer();
   if (!firstLayer || !secondLayer) return;
 
   MultipleScatteringParametrisation sigma1RPhi( firstLayer, es);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.cc
@@ -22,8 +22,7 @@ template<class T> T sqr(T t) { return t * t;}
 using namespace std;
 
 PixelTripletNoTipGenerator:: PixelTripletNoTipGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
-    : thePairGenerator(0),
-      theLayerCache(0),
+    : HitTripletGeneratorFromPairAndLayers(cfg),
       extraHitRZtolerance(cfg.getParameter<double>("extraHitRZtolerance")),
       extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")),
       extraHitPhiToleranceForPreFiltering(cfg.getParameter<double>("extraHitPhiToleranceForPreFiltering")), 
@@ -31,24 +30,15 @@ PixelTripletNoTipGenerator:: PixelTripletNoTipGenerator(const edm::ParameterSet&
       theChi2Cut(cfg.getParameter<double>("chi2Cut"))
 { }
 
-void PixelTripletNoTipGenerator::init( const HitPairGenerator & pairs,
-      LayerCacheType* layerCache)
-{
-  thePairGenerator = pairs.clone();
-  theLayerCache = layerCache;
-}
-
-void PixelTripletNoTipGenerator::setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                                                  std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) {
-  thePairGenerator->setSeedingLayers(pairLayers);
-  theLayers = thirdLayers;
-}
+PixelTripletNoTipGenerator::~PixelTripletNoTipGenerator() {}
 
 void PixelTripletNoTipGenerator::hitTriplets(
     const TrackingRegion& region,
     OrderedHitTriplets & result,
     const edm::Event & ev,
-    const edm::EventSetup& es)
+    const edm::EventSetup& es,
+    SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+    const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers)
 {
 
 //
@@ -65,20 +55,20 @@ void PixelTripletNoTipGenerator::hitTriplets(
 
   OrderedHitPairs pairs; pairs.reserve(30000);
   OrderedHitPairs::const_iterator ip;
+  thePairGenerator->setSeedingLayers(pairLayers);
   thePairGenerator->hitPairs(region,pairs,ev,es);
 
   if (pairs.size() ==0) return;
 
-  int size = theLayers.size();
+  int size = thirdLayers.size();
 
   const RecHitsSortedInPhi **thirdHitMap = new const RecHitsSortedInPhi*[size];
   for (int il=0; il <=size-1; il++) {
-     thirdHitMap[il] = &(*theLayerCache)(theLayers[il], region, ev, es);
+     thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
   }
 
-  const HitPairGeneratorFromLayerPair * pairGen = dynamic_cast<const HitPairGeneratorFromLayerPair *>(thePairGenerator);
-  const DetLayer * firstLayer = pairGen->innerLayer().detLayer();
-  const DetLayer * secondLayer = pairGen->outerLayer().detLayer();
+  const DetLayer * firstLayer = thePairGenerator->innerLayer().detLayer();
+  const DetLayer * secondLayer = thePairGenerator->outerLayer().detLayer();
   if (!firstLayer || !secondLayer) return;
 
   MultipleScatteringParametrisation sigma1RPhi( firstLayer, es);
@@ -109,7 +99,7 @@ void PixelTripletNoTipGenerator::hitTriplets(
 
     for (int il=0; il <=size-1; il++) {
 
-      const DetLayer * layer = theLayers[il].detLayer();
+      const DetLayer * layer = thirdLayers[il].detLayer();
       bool barrelLayer = (layer->location() == GeomDetEnumerators::barrel);
       MultipleScatteringParametrisation sigma3RPhi( layer, es);
       double msRPhi3 = sigma3RPhi(pt_p1p2, line.cotLine(),point2);

--- a/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.h
+++ b/RecoPixelVertexing/PixelTriplets/plugins/PixelTripletNoTipGenerator.h
@@ -2,7 +2,6 @@
 #define PixelTripletNoTipGenerator_H
 
 #include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
 #include "CombinedHitTripletGenerator.h"
 
 namespace edm { class Event; class EventSetup; } 
@@ -16,22 +15,14 @@ typedef CombinedHitTripletGenerator::LayerCacheType       LayerCacheType;
 public:
   PixelTripletNoTipGenerator(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC);
 
-  virtual ~PixelTripletNoTipGenerator() { delete thePairGenerator; }
-
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) override;
-
-  void init( const HitPairGenerator & pairs, LayerCacheType* layerCache) override;
+  virtual ~PixelTripletNoTipGenerator();
 
   virtual void hitTriplets( const TrackingRegion& region, OrderedHitTriplets & trs,
-      const edm::Event & ev, const edm::EventSetup& es);
-
-  const HitPairGenerator & pairGenerator() const { return *thePairGenerator; }
+                            const edm::Event & ev, const edm::EventSetup& es,
+                            SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                            const std::vector<SeedingLayerSetsHits::SeedingLayer>& thirdLayers) override;
 
 private:
-  HitPairGenerator * thePairGenerator;
-  std::vector<SeedingLayerSetsHits::SeedingLayer> theLayers;
-  LayerCacheType * theLayerCache;
   float extraHitRZtolerance;
   float extraHitRPhitolerance;
   float extraHitPhiToleranceForPreFiltering;

--- a/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGenerator.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/CosmicHitTripletGenerator.cc
@@ -29,10 +29,6 @@ CosmicHitTripletGenerator::CosmicHitTripletGenerator(CosmicLayerTriplets& layers
 
 CosmicHitTripletGenerator::~CosmicHitTripletGenerator()
 {
-  Container::const_iterator it;
-  for (it = theGenerators.begin(); it!= theGenerators.end(); it++) {
-    delete (*it);
-  }
 }
 
 
@@ -42,8 +38,7 @@ void CosmicHitTripletGenerator::add(
 				   const LayerWithHits *outer,
 				   const edm::EventSetup& iSetup) 
 { 
-  theGenerators.push_back( 
-  			  new CosmicHitTripletGeneratorFromLayerTriplet( inner,middle, outer, iSetup));
+  theGenerators.push_back(std::make_unique<CosmicHitTripletGeneratorFromLayerTriplet>( inner,middle, outer, iSetup));
 }
 
 void CosmicHitTripletGenerator::hitTriplets(

--- a/RecoPixelVertexing/PixelTriplets/src/HitTripletGeneratorFromPairAndLayers.cc
+++ b/RecoPixelVertexing/PixelTriplets/src/HitTripletGeneratorFromPairAndLayers.cc
@@ -1,0 +1,19 @@
+#include "RecoPixelVertexing/PixelTriplets/interface/HitTripletGeneratorFromPairAndLayers.h"
+#include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+HitTripletGeneratorFromPairAndLayers::HitTripletGeneratorFromPairAndLayers(unsigned int maxElement):
+  theLayerCache(nullptr),
+  theMaxElement(maxElement)
+{}
+
+HitTripletGeneratorFromPairAndLayers::HitTripletGeneratorFromPairAndLayers(const edm::ParameterSet& pset):
+  HitTripletGeneratorFromPairAndLayers(pset.getParameter<unsigned int>("maxElement"))
+{}
+
+HitTripletGeneratorFromPairAndLayers::~HitTripletGeneratorFromPairAndLayers() {}
+
+void HitTripletGeneratorFromPairAndLayers::init(std::unique_ptr<HitPairGeneratorFromLayerPair>&& pairGenerator, LayerCacheType *layerCache) {
+  thePairGenerator = std::move(pairGenerator);
+  theLayerCache = layerCache;
+}

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitPairGeneratorForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitPairGeneratorForPhotonConversion.cc
@@ -38,11 +38,11 @@ void CombinedHitPairGeneratorForPhotonConversion::hitPairs(
 {
   edm::Handle<SeedingLayerSetsHits> hlayers;
   ev.getByToken(theSeedingLayerToken, hlayers);
-  assert(hlayers->numberOfLayersInSet() == 2);
+  const SeedingLayerSetsHits& layers = *hlayers;
+  assert(layers.numberOfLayersInSet() == 2);
 
-  for(SeedingLayerSetsHits::LayerSetIndex i=0; i<hlayers->size(); ++i) {
-    theGenerator->setSeedingLayers((*hlayers)[i]);
-    theGenerator->hitPairs( convRegion, region, result, ev, es);
+  for(SeedingLayerSetsHits::LayerSetIndex i=0; i<layers.size(); ++i) {
+    theGenerator->hitPairs( convRegion, region, result, layers[i], ev, es);
   }
 
 }

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.cc
@@ -5,25 +5,14 @@
 #include "DataFormats/Common/interface/Handle.h"
 
 CombinedHitQuadrupletGeneratorForPhotonConversion::CombinedHitQuadrupletGeneratorForPhotonConversion(const edm::ParameterSet& cfg, edm::ConsumesCollector& iC)
-  : theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers")))
+  : theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"))),
+    theMaxElement(cfg.getParameter<unsigned int>("maxElement"))
 {
-  theMaxElement = cfg.getParameter<unsigned int>("maxElement");
-  theGenerator.reset(new HitQuadrupletGeneratorFromLayerPairForPhotonConversion( 0, 1, &theLayerCache, 0, theMaxElement));
-}
-
-CombinedHitQuadrupletGeneratorForPhotonConversion::CombinedHitQuadrupletGeneratorForPhotonConversion(const CombinedHitQuadrupletGeneratorForPhotonConversion & cb)
-  : theSeedingLayerToken(cb.theSeedingLayerToken)
-{
-  theMaxElement = cb.theMaxElement;
-  theGenerator.reset(new HitQuadrupletGeneratorFromLayerPairForPhotonConversion( 0, 1, &theLayerCache, 0, theMaxElement));
+  theGenerator = std::make_unique<HitQuadrupletGeneratorFromLayerPairForPhotonConversion>( 0, 1, &theLayerCache, 0, theMaxElement);
 }
 
 
 CombinedHitQuadrupletGeneratorForPhotonConversion::~CombinedHitQuadrupletGeneratorForPhotonConversion() {}
-
-void CombinedHitQuadrupletGeneratorForPhotonConversion::setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet layers) {
-  assert(0 == "not implemented");
-}
 
 const OrderedHitPairs & CombinedHitQuadrupletGeneratorForPhotonConversion::run(const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
 {

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.cc
@@ -8,7 +8,7 @@ CombinedHitQuadrupletGeneratorForPhotonConversion::CombinedHitQuadrupletGenerato
   : theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers"))),
     theMaxElement(cfg.getParameter<unsigned int>("maxElement"))
 {
-  theGenerator = std::make_unique<HitQuadrupletGeneratorFromLayerPairForPhotonConversion>( 0, 1, &theLayerCache, 0, theMaxElement);
+  theGenerator = std::make_unique<HitQuadrupletGeneratorFromLayerPairForPhotonConversion>( 0, 1, &theLayerCache, theMaxElement);
 }
 
 
@@ -28,11 +28,12 @@ void CombinedHitQuadrupletGeneratorForPhotonConversion::hitPairs(const TrackingR
   size_t maxHitQuadruplets=1000000;
   edm::Handle<SeedingLayerSetsHits> hlayers;
   ev.getByToken(theSeedingLayerToken, hlayers);
-  assert(hlayers->numberOfLayersInSet() == 2);
+  const SeedingLayerSetsHits& layers = *hlayers;
+  assert(layers.numberOfLayersInSet() == 2);
+
 
   for(SeedingLayerSetsHits::LayerSetIndex i=0; i<hlayers->size() && result.size() < maxHitQuadruplets; ++i) {
-    theGenerator->setSeedingLayers((*hlayers)[i]);
-    theGenerator->hitPairs( region, result, ev, es);
+    theGenerator->hitPairs( region, result, layers[i], ev, es);
   }
   theLayerCache.clear();
 }

--- a/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/CombinedHitQuadrupletGeneratorForPhotonConversion.h
@@ -3,7 +3,7 @@
 
 #include <vector>
 #include <memory>
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
+#include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/EDGetToken.h"
@@ -12,7 +12,7 @@ class TrackingRegion;
 class OrderedHitPairs;
 class HitQuadrupletGeneratorFromLayerPairForPhotonConversion;
 class SeedingLayerSetsHits;
-namespace edm { class Event; class EventSetup; }
+namespace edm { class Event; class EventSetup; class ParameterSet; class ConsumesCollector;}
 
 #include "ConversionRegion.h"
 
@@ -20,22 +20,15 @@ namespace edm { class Event; class EventSetup; }
  * Hides set of HitQuadrupletGeneratorFromLayerPairForPhotonConversion generators.
  */
 
-class CombinedHitQuadrupletGeneratorForPhotonConversion : public HitPairGenerator {
+class CombinedHitQuadrupletGeneratorForPhotonConversion {
 public:
   typedef LayerHitMapCache LayerCacheType;
 
 public:
   CombinedHitQuadrupletGeneratorForPhotonConversion(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
-  virtual ~CombinedHitQuadrupletGeneratorForPhotonConversion();
+  ~CombinedHitQuadrupletGeneratorForPhotonConversion();
 
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet layers) override;
-
-  /// form base class
-  virtual void hitPairs(const TrackingRegion&, OrderedHitPairs&, const edm::Event&, const edm::EventSetup&);
-
-  /// from base class
-  virtual CombinedHitQuadrupletGeneratorForPhotonConversion * clone() const 
-    { return new CombinedHitQuadrupletGeneratorForPhotonConversion(*this); }
+  void hitPairs(const TrackingRegion&, OrderedHitPairs&, const edm::Event&, const edm::EventSetup&);
 
   const OrderedHitPairs & run(const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es);
 
@@ -47,7 +40,7 @@ private:
   CombinedHitQuadrupletGeneratorForPhotonConversion(const CombinedHitQuadrupletGeneratorForPhotonConversion & cb); 
 
   edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;
-
+  const unsigned int theMaxElement;
   LayerCacheType   theLayerCache;
 
   std::unique_ptr<HitQuadrupletGeneratorFromLayerPairForPhotonConversion> theGenerator;

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.cc
@@ -47,6 +47,7 @@ HitPairGeneratorFromLayerPairForPhotonConversion::HitPairGeneratorFromLayerPairF
 
 void HitPairGeneratorFromLayerPairForPhotonConversion::hitPairs(const ConversionRegion& convRegion,
 								const TrackingRegion & region, OrderedHitPairs & result,
+								const Layers& layers,
 								const edm::Event& event, const edm::EventSetup& es)
 {
  auto oldSize = result.size();
@@ -60,8 +61,8 @@ void HitPairGeneratorFromLayerPairForPhotonConversion::hitPairs(const Conversion
   typedef OrderedHitPair::OuterRecHit OuterHit;
   typedef RecHitsSortedInPhi::Hit Hit;
 
-  Layer innerLayerObj = innerLayer();
-  Layer outerLayerObj = outerLayer();
+  Layer innerLayerObj = layers[theInnerLayer];
+  Layer outerLayerObj = layers[theOuterLayer];
 
 #ifdef mydebug_Seed
   ss << "In " << innerLayerObj.name() << " Out " << outerLayerObj.name() << std::endl;

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitPairGeneratorFromLayerPairForPhotonConversion.h
@@ -26,23 +26,9 @@ public:
 
 //  virtual ~HitPairGeneratorFromLayerPairForPhotonConversion() { }
 
-  void setSeedingLayers(Layers layers)  { theSeedingLayers = layers; }
-
   void hitPairs( const ConversionRegion& convRegion, const TrackingRegion& reg, OrderedHitPairs & prs, 
+                 const Layers& layers,
 			 const edm::Event & ev,  const edm::EventSetup& es);
-
-/*
-  virtual void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs, 
-			 const edm::Event & ev,  const edm::EventSetup& es){};
-
-
-  virtual HitPairGeneratorFromLayerPairForPhotonConversion* clone() const {
-    return new HitPairGeneratorFromLayerPairForPhotonConversion(*this);
-  }
-*/
-
-  Layer innerLayer() const { return theSeedingLayers[theInnerLayer]; }
-  Layer outerLayer() const { return theSeedingLayers[theOuterLayer]; }
 
   float getLayerRadius(const DetLayer& layer);
   float getLayerZ(const DetLayer& layer);
@@ -58,7 +44,6 @@ private:
   double getCot(double dz, double dr);
   
   LayerCacheType & theLayerCache;
-  Layers theSeedingLayers;
   const unsigned int theOuterLayer;
   const unsigned int theInnerLayer;
   const unsigned int theMaxElement;

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.cc
@@ -36,16 +36,15 @@ HitQuadrupletGeneratorFromLayerPairForPhotonConversion::HitQuadrupletGeneratorFr
 							     unsigned int inner,
 							     unsigned int outer,
 							     LayerCacheType* layerCache,
-							     unsigned int nSize,
 							     unsigned int max)
-  : HitPairGenerator(nSize),
-    theLayerCache(*layerCache), theOuterLayer(outer), theInnerLayer(inner)
+  : theLayerCache(*layerCache), theOuterLayer(outer), theInnerLayer(inner),
+    theMaxElement(max)
 {
-  theMaxElement=max;
   ss = new std::stringstream;
 }
 
 void HitQuadrupletGeneratorFromLayerPairForPhotonConversion::hitPairs(const TrackingRegion & region, OrderedHitPairs & result,
+								      const Layers& layers,
 								      const edm::Event& event, const edm::EventSetup& es)
 {
 
@@ -55,8 +54,8 @@ void HitQuadrupletGeneratorFromLayerPairForPhotonConversion::hitPairs(const Trac
   typedef OrderedHitPair::OuterRecHit OuterHit;
   typedef RecHitsSortedInPhi::Hit Hit;
 
-  Layer innerLayerObj = innerLayer();
-  Layer outerLayerObj = outerLayer();
+  Layer innerLayerObj = layers[theInnerLayer];
+  Layer outerLayerObj = layers[theOuterLayer];
 
   size_t totCountP2=0, totCountP1=0, totCountM2=0, totCountM1=0, selCount=0;
 #ifdef mydebug_QSeed

--- a/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.h
+++ b/RecoTracker/ConversionSeedGenerators/plugins/HitQuadrupletGeneratorFromLayerPairForPhotonConversion.h
@@ -1,8 +1,8 @@
 #ifndef HitQuadrupletGeneratorFromLayerPairForPhotonConversion_h
 #define HitQuadrupletGeneratorFromLayerPairForPhotonConversion_h
 
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
-#include "RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h"
+#include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "ConversionRegion.h"
@@ -10,33 +10,24 @@
 class DetLayer;
 class TrackingRegion;
 
-class HitQuadrupletGeneratorFromLayerPairForPhotonConversion : public HitPairGenerator {
+class HitQuadrupletGeneratorFromLayerPairForPhotonConversion {
 
 public:
 
-  typedef CombinedHitPairGenerator::LayerCacheType       LayerCacheType;
+  typedef LayerHitMapCache LayerCacheType;
   typedef SeedingLayerSetsHits::SeedingLayerSet Layers;
   typedef SeedingLayerSetsHits::SeedingLayer Layer;
  
   HitQuadrupletGeneratorFromLayerPairForPhotonConversion(unsigned int inner,
                                 unsigned int outer,
 				LayerCacheType* layerCache,
-				unsigned int nSize=30000,
 				unsigned int max=0);
 
-  virtual ~HitQuadrupletGeneratorFromLayerPairForPhotonConversion() { }
+  ~HitQuadrupletGeneratorFromLayerPairForPhotonConversion() { }
 
-  void setSeedingLayers(Layers layers) override { theSeedingLayers = layers; }
-
-  virtual void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs, 
-			 const edm::Event & ev,  const edm::EventSetup& es);
-
-  virtual HitQuadrupletGeneratorFromLayerPairForPhotonConversion* clone() const {
-    return new HitQuadrupletGeneratorFromLayerPairForPhotonConversion(*this);
-  }
-
-  Layer innerLayer() const { return theSeedingLayers[theInnerLayer]; }
-  Layer outerLayer() const { return theSeedingLayers[theOuterLayer]; }
+  void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs,
+                 const Layers& layers,
+                 const edm::Event & ev,  const edm::EventSetup& es);
 
   bool failCheckRZCompatibility(const RecHitsSortedInPhi::Hit & hit, const DetLayer& layer, const HitRZCompatibility *checkRZ, const TrackingRegion & region);
   //void checkPhiRange(double phi1, double phi2);
@@ -54,9 +45,9 @@ public:
 private:
   
   LayerCacheType & theLayerCache;
-  Layers theSeedingLayers;
   const unsigned int theOuterLayer;
   const unsigned int theInnerLayer;
+  const unsigned int theMaxElement;
 
   std::stringstream *ss;
 

--- a/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
@@ -28,8 +28,6 @@ public:
   CombinedHitPairGenerator(const edm::ParameterSet & cfg, edm::ConsumesCollector& iC);
   virtual ~CombinedHitPairGenerator();
 
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet layers) override;
-
   /// form base class
   virtual void hitPairs( const TrackingRegion& reg, 
       OrderedHitPairs & result, const edm::Event& ev, const edm::EventSetup& es);

--- a/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h
@@ -32,10 +32,6 @@ public:
   virtual void hitPairs( const TrackingRegion& reg, 
       OrderedHitPairs & result, const edm::Event& ev, const edm::EventSetup& es);
 
-  /// from base class
-  virtual CombinedHitPairGenerator * clone() const 
-    { return new CombinedHitPairGenerator(*this); }
-
 private:
   CombinedHitPairGenerator(const CombinedHitPairGenerator & cb); 
 

--- a/RecoTracker/TkHitPairs/interface/CosmicHitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicHitPairGenerator.h
@@ -2,7 +2,6 @@
 #define CosmicHitPairGenerator_H
 
 #include <vector>
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
 #include "RecoTracker/TkHitPairs/interface/CosmicHitPairGeneratorFromLayerPair.h"
 #include "DataFormats/Common/interface/RangeMap.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -10,16 +9,15 @@ class SeedLayerPairs;
 class LayerWithHits;
 class DetLayer;
 class TrackingRegion;
-class HitPairGeneratorFromLayerPair;
 
 
 /** \class CosmicHitPairGenerator
  * Hides set of HitPairGeneratorFromLayerPair generators.
  */
 
-class CosmicHitPairGenerator : public HitPairGenerator{
+class CosmicHitPairGenerator {
 
-  typedef std::vector<CosmicHitPairGeneratorFromLayerPair *>   Container;
+  typedef std::vector<std::unique_ptr<CosmicHitPairGeneratorFromLayerPair> >   Container;
 
 public:
   CosmicHitPairGenerator(SeedLayerPairs& layers, const edm::EventSetup& iSetup);
@@ -28,26 +26,15 @@ public:
 
   ~CosmicHitPairGenerator();
 
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet layers) override {}
-
   /// add generators based on layers
     //  void  add(const DetLayer* inner, const DetLayer* outer);
     void  add(const LayerWithHits* inner, 
 	      const LayerWithHits* outer,
 	      const edm::EventSetup& iSetup);
   /// form base class
-  virtual void hitPairs( const TrackingRegion& reg, 
-			 OrderedHitPairs & prs, 
-			 const edm::EventSetup& iSetup);
-  virtual void hitPairs( const TrackingRegion& reg, 
-			 OrderedHitPairs & prs, 
-                   const edm::Event & ev,
-			 const edm::EventSetup& iSetup) {}
-
-  /// from base class
-  virtual CosmicHitPairGenerator * clone() const 
-    { return new CosmicHitPairGenerator(*this); }
-
+  void hitPairs( const TrackingRegion& reg,
+		 OrderedHitPairs & prs,
+		 const edm::EventSetup& iSetup);
 private:
 
 

--- a/RecoTracker/TkHitPairs/interface/CosmicHitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/CosmicHitPairGeneratorFromLayerPair.h
@@ -1,7 +1,7 @@
 #ifndef CosmicHitPairGeneratorFromLayerPair_h
 #define CosmicHitPairGeneratorFromLayerPair_h
 
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
+#include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
 #include "RecoTracker/TkHitPairs/interface/LayerWithHits.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -37,7 +37,7 @@ class LayerWithHits;
  private:
    edm::ESHandle<TrackerGeometry> tracker;
  };
-class CosmicHitPairGeneratorFromLayerPair : public HitPairGenerator {
+class CosmicHitPairGeneratorFromLayerPair {
 
 public:
 
@@ -46,20 +46,12 @@ public:
 				const LayerWithHits* inner, 
 				const LayerWithHits* outer, 
 				const edm::EventSetup& iSetup);
-  virtual ~CosmicHitPairGeneratorFromLayerPair() { }
-
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet layers) override {}
+  ~CosmicHitPairGeneratorFromLayerPair();
 
 //  virtual OrderedHitPairs hitPairs( const TrackingRegion& region,const edm::EventSetup& iSetup ) {
 //    return HitPairGenerator::hitPairs(region, iSetup);
 //  }
-  virtual void hitPairs( const TrackingRegion& ar, OrderedHitPairs & ap, const edm::EventSetup& iSetup);
-
-  virtual void hitPairs( const TrackingRegion& ar, OrderedHitPairs & ap, const edm::Event & ev, const edm::EventSetup& iSetup) {}
-
-  virtual CosmicHitPairGeneratorFromLayerPair* clone() const {
-    return new CosmicHitPairGeneratorFromLayerPair(*this);
-  }
+  void hitPairs( const TrackingRegion& ar, OrderedHitPairs & ap, const edm::EventSetup& iSetup);
 
   const LayerWithHits* innerLayer() const { return theInnerLayer; }
   const LayerWithHits* outerLayer() const { return theOuterLayer; }

--- a/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
@@ -28,21 +28,8 @@ public:
   virtual const OrderedHitPairs & run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es);
 
-  // temporary interface for backward compatibility only
-  virtual void hitPairs( 
-    const TrackingRegion& reg, OrderedHitPairs & prs, const edm::EventSetup& es) {}
-
-  // new interface with no temphits copy
-  virtual HitDoublets doublets( const TrackingRegion& reg, 
-			     const edm::Event & ev,  const edm::EventSetup& es) {
-    assert(0=="not implemented");
-  }
-
-
   virtual void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs, 
       const edm::Event & ev,  const edm::EventSetup& es) = 0;
-
-  virtual HitPairGenerator* clone() const = 0;
 
   virtual void clear() final;
 

--- a/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGenerator.h
@@ -25,8 +25,6 @@ public:
 
   virtual ~HitPairGenerator() { }
 
-  virtual void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet layers) = 0;
-
   virtual const OrderedHitPairs & run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es);
 

--- a/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
+++ b/RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h
@@ -1,48 +1,42 @@
 #ifndef HitPairGeneratorFromLayerPair_h
 #define HitPairGeneratorFromLayerPair_h
 
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
-#include "RecoTracker/TkHitPairs/interface/CombinedHitPairGenerator.h"
+#include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
+#include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
+#include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 
 class DetLayer;
 class TrackingRegion;
 
-class HitPairGeneratorFromLayerPair : public HitPairGenerator {
+class HitPairGeneratorFromLayerPair {
 
 public:
 
-  typedef CombinedHitPairGenerator::LayerCacheType       LayerCacheType;
+  typedef LayerHitMapCache LayerCacheType;
   typedef SeedingLayerSetsHits::SeedingLayerSet Layers;
   typedef SeedingLayerSetsHits::SeedingLayer Layer;
 
   HitPairGeneratorFromLayerPair(unsigned int inner,
                                 unsigned int outer,
                                 LayerCacheType* layerCache,
-				unsigned int nSize=30000,
 				unsigned int max=0);
 
-  virtual ~HitPairGeneratorFromLayerPair() { }
+  ~HitPairGeneratorFromLayerPair();
 
-  void setSeedingLayers(Layers layers) override { theSeedingLayers = layers; }
+  HitDoublets doublets( const TrackingRegion& reg,
+                        const edm::Event & ev,  const edm::EventSetup& es, Layers layers);
 
-  virtual HitDoublets doublets( const TrackingRegion& reg,
-			     const edm::Event & ev,  const edm::EventSetup& es);
+  void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs,
+                 const edm::Event & ev,  const edm::EventSetup& es, Layers layers);
 
-  virtual void hitPairs( const TrackingRegion& reg, OrderedHitPairs & prs,
-      const edm::Event & ev,  const edm::EventSetup& es);
-
-  virtual HitPairGeneratorFromLayerPair* clone() const {
-    return new HitPairGeneratorFromLayerPair(*this);
-  }
-
-  Layer innerLayer() const { return theSeedingLayers[theInnerLayer]; }
-  Layer outerLayer() const { return theSeedingLayers[theOuterLayer]; }
+  Layer innerLayer(const Layers& layers) const { return layers[theInnerLayer]; }
+  Layer outerLayer(const Layers& layers) const { return layers[theOuterLayer]; }
 
 private:
   LayerCacheType & theLayerCache;
-  Layers theSeedingLayers;
   const unsigned int theOuterLayer;
   const unsigned int theInnerLayer;
+  const unsigned int theMaxElement;
 };
 
 #endif

--- a/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/CombinedHitPairGenerator.cc
@@ -8,21 +8,17 @@ CombinedHitPairGenerator::CombinedHitPairGenerator(const edm::ParameterSet& cfg,
   theSeedingLayerToken(iC.consumes<SeedingLayerSetsHits>(cfg.getParameter<edm::InputTag>("SeedingLayers")))
 {
   theMaxElement = cfg.getParameter<unsigned int>("maxElement");
-  theGenerator.reset(new HitPairGeneratorFromLayerPair(0, 1, &theLayerCache, 0, theMaxElement));
+  theGenerator = std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, theMaxElement);
 }
 
 CombinedHitPairGenerator::CombinedHitPairGenerator(const CombinedHitPairGenerator& cb):
   theSeedingLayerToken(cb.theSeedingLayerToken),
-  theGenerator(new HitPairGeneratorFromLayerPair(0, 1, &theLayerCache, 0, cb.theMaxElement))
+  theGenerator(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache, cb.theMaxElement))
 {
   theMaxElement = cb.theMaxElement;
 }
 
 CombinedHitPairGenerator::~CombinedHitPairGenerator() {}
-
-void CombinedHitPairGenerator::setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet layers) {
-  assert(0 == "not implemented");
-}
 
 void CombinedHitPairGenerator::hitPairs(
    const TrackingRegion& region, OrderedHitPairs  & result,
@@ -35,8 +31,7 @@ void CombinedHitPairGenerator::hitPairs(
     throw cms::Exception("Configuration") << "CombinedHitPairGenerator expects SeedingLayerSetsHits::numberOfLayersInSet() to be 2, got " << layers.numberOfLayersInSet();
 
   for(SeedingLayerSetsHits::SeedingLayerSet layerSet: layers) {
-    theGenerator->setSeedingLayers(layerSet);
-    theGenerator->hitPairs( region, result, ev, es);
+    theGenerator->hitPairs( region, result, ev, es, layerSet);
   }
 
   theLayerCache.clear();

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGenerator.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGenerator.cc
@@ -23,10 +23,6 @@ CosmicHitPairGenerator::CosmicHitPairGenerator(SeedLayerPairs& layers,
 
 CosmicHitPairGenerator::~CosmicHitPairGenerator()
 {
-  Container::const_iterator it;
-  for (it = theGenerators.begin(); it!= theGenerators.end(); it++) {
-    delete (*it);
-  }
 }
 
 
@@ -34,8 +30,7 @@ void CosmicHitPairGenerator::add(
 				   const LayerWithHits *inner, const LayerWithHits *outer,
 				   const edm::EventSetup& iSetup) 
 { 
-  theGenerators.push_back( 
-			  new CosmicHitPairGeneratorFromLayerPair( inner, outer, iSetup));
+  theGenerators.push_back(std::make_unique<CosmicHitPairGeneratorFromLayerPair>( inner, outer, iSetup));
 }
 
 void CosmicHitPairGenerator::hitPairs(

--- a/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/CosmicHitPairGeneratorFromLayerPair.cc
@@ -2,7 +2,6 @@
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "TrackingTools/DetLayers/interface/DetLayer.h"
 #include "RecoTracker/TkHitPairs/interface/OrderedHitPair.h"
-#include "RecoTracker/TkHitPairs/interface/OrderedHitPairs.h"
 #include "Geometry/Records/interface/TrackerDigiGeometryRecord.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "TrackingTools/DetLayers/interface/BarrelDetLayer.h"
@@ -26,6 +25,7 @@ CosmicHitPairGeneratorFromLayerPair::CosmicHitPairGeneratorFromLayerPair(const L
   iSetup.get<TrackerDigiGeometryRecord>().get(tracker);
   trackerGeometry = tracker.product();
 }
+CosmicHitPairGeneratorFromLayerPair::~CosmicHitPairGeneratorFromLayerPair() {}
 void CosmicHitPairGeneratorFromLayerPair::hitPairs(
   const TrackingRegion & region, OrderedHitPairs & result,
   const edm::EventSetup& iSetup)

--- a/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
+++ b/RecoTracker/TkHitPairs/src/HitPairGeneratorFromLayerPair.cc
@@ -33,14 +33,12 @@ HitPairGeneratorFromLayerPair::HitPairGeneratorFromLayerPair(
 							     unsigned int inner,
 							     unsigned int outer,
 							     LayerCacheType* layerCache,
-							     unsigned int nSize,
 							     unsigned int max)
-  : HitPairGenerator(nSize),
-    theLayerCache(*layerCache), theOuterLayer(outer), theInnerLayer(inner)
+  : theLayerCache(*layerCache), theOuterLayer(outer), theInnerLayer(inner), theMaxElement(max)
 {
-  theMaxElement=max;
 }
 
+HitPairGeneratorFromLayerPair::~HitPairGeneratorFromLayerPair() {}
 
 // devirtualizer
 #include<tuple>
@@ -76,9 +74,9 @@ namespace {
 
 void HitPairGeneratorFromLayerPair::hitPairs(
 					     const TrackingRegion & region, OrderedHitPairs & result,
-					     const edm::Event& iEvent, const edm::EventSetup& iSetup) {
+					     const edm::Event& iEvent, const edm::EventSetup& iSetup, Layers layers) {
 
-  auto const & ds = doublets(region, iEvent, iSetup);
+  auto const & ds = doublets(region, iEvent, iSetup, layers);
   for (std::size_t i=0; i!=ds.size(); ++i) {
     result.push_back( OrderedHitPair( ds.hit(i,HitDoublets::inner),ds.hit(i,HitDoublets::outer) ));
   }
@@ -90,14 +88,14 @@ void HitPairGeneratorFromLayerPair::hitPairs(
 
 
 HitDoublets HitPairGeneratorFromLayerPair::doublets( const TrackingRegion& region,
-						    const edm::Event & iEvent, const edm::EventSetup& iSetup) {
+						    const edm::Event & iEvent, const edm::EventSetup& iSetup, Layers layers) {
 
   typedef OrderedHitPair::InnerRecHit InnerHit;
   typedef OrderedHitPair::OuterRecHit OuterHit;
   typedef RecHitsSortedInPhi::Hit Hit;
 
-  Layer innerLayerObj = innerLayer();
-  Layer outerLayerObj = outerLayer();
+  Layer innerLayerObj = innerLayer(layers);
+  Layer outerLayerObj = outerLayer(layers);
 
   const RecHitsSortedInPhi & innerHitsMap = theLayerCache(innerLayerObj, region, iEvent, iSetup);
   if (innerHitsMap.empty()) return HitDoublets(innerHitsMap,innerHitsMap);

--- a/RecoTracker/TkSeedGenerator/BuildFile.xml
+++ b/RecoTracker/TkSeedGenerator/BuildFile.xml
@@ -18,7 +18,7 @@
 <use   name="TrackingTools/MaterialEffects"/>
 <use   name="TrackingTools/Records"/>
 <use   name="CommonTools/Utils"/>
-
+<use   name="RecoTracker/TkHitPairs"/>
 <export>
   <lib   name="1"/>
 </export>

--- a/RecoTracker/TkSeedGenerator/interface/MultiHitGenerator.h
+++ b/RecoTracker/TkSeedGenerator/interface/MultiHitGenerator.h
@@ -42,9 +42,6 @@ private:
   OrderedMultiHits theHitSets;
 
 protected:
-  using cacheHitPointer = std::unique_ptr<BaseTrackerRecHit>;
-  using cacheHits=std::vector<cacheHitPointer>;
-  cacheHits cache; // ownes what is by reference above...
   edm::RunningAverage localRA;
 };
 

--- a/RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h
+++ b/RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h
@@ -8,26 +8,43 @@
  */
 
 #include <vector>
-#include "RecoTracker/TkSeedGenerator/interface/MultiHitGenerator.h"
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
+#include "RecoTracker/TkSeedingLayers/interface/OrderedMultiHits.h"
 #include "TrackingTools/TransientTrackingRecHit/interface/SeedingLayerSetsHits.h"
 #include "RecoTracker/TkHitPairs/interface/LayerHitMapCache.h"
 
-namespace edm { class EventSetup; }
+namespace edm { class ParameterSet; class Event; class EventSetup; }
+class TrackingRegion;
+class HitPairGeneratorFromLayerPair;
 
-class MultiHitGeneratorFromPairAndLayers : public MultiHitGenerator {
+class MultiHitGeneratorFromPairAndLayers {
 
 public:
   typedef LayerHitMapCache  LayerCacheType;
 
-  virtual ~MultiHitGeneratorFromPairAndLayers() {}
-
-  virtual void init( const HitPairGenerator & pairs, LayerCacheType* layerCache) = 0; 
+  explicit MultiHitGeneratorFromPairAndLayers(const edm::ParameterSet& pset);
+  virtual ~MultiHitGeneratorFromPairAndLayers();
 
   virtual void initES(const edm::EventSetup& es) = 0; 
 
-  virtual void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                                std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) = 0;
+  void init(std::unique_ptr<HitPairGeneratorFromLayerPair>&& pairGenerator, LayerCacheType *layerCache);
+
+  virtual void hitSets( const TrackingRegion& region, OrderedMultiHits & trs,
+                        const edm::Event & ev, const edm::EventSetup& es,
+                        SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) = 0;
+
+  const HitPairGeneratorFromLayerPair& pairGenerator() const { return *thePairGenerator; }
+
+  void clear();
+
+protected:
+  using cacheHitPointer = std::unique_ptr<BaseTrackerRecHit>;
+  using cacheHits=std::vector<cacheHitPointer>;
+  cacheHits cache; // ownes what is by reference above...
+
+  std::unique_ptr<HitPairGeneratorFromLayerPair> thePairGenerator;
+  LayerCacheType *theLayerCache;
+  const unsigned int theMaxElement;
 };
 #endif
 

--- a/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.cc
@@ -14,7 +14,7 @@ CombinedMultiHitGenerator::CombinedMultiHitGenerator(const edm::ParameterSet& cf
   edm::ParameterSet generatorPSet = cfg.getParameter<edm::ParameterSet>("GeneratorPSet");
   std::string       generatorName = generatorPSet.getParameter<std::string>("ComponentName");
   theGenerator.reset(MultiHitGeneratorFromPairAndLayersFactory::get()->create(generatorName, generatorPSet));
-  theGenerator->init(HitPairGeneratorFromLayerPair( 0, 1, &theLayerCache), &theLayerCache);
+  theGenerator->init(std::make_unique<HitPairGeneratorFromLayerPair>(0, 1, &theLayerCache), &theLayerCache);
 }
 
 CombinedMultiHitGenerator::~CombinedMultiHitGenerator() {}
@@ -33,8 +33,7 @@ void CombinedMultiHitGenerator::hitSets(
 
   std::vector<LayerTriplets::LayerSetAndLayers> trilayers = LayerTriplets::layers(layers);
   for(const auto& setAndLayers: trilayers) {
-    theGenerator->setSeedingLayers(setAndLayers.first, setAndLayers.second);
-    theGenerator->hitSets( region, result, ev, es);
+    theGenerator->hitSets( region, result, ev, es, setAndLayers.first, setAndLayers.second);
   }
   theLayerCache.clear();
 }

--- a/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.h
+++ b/RecoTracker/TkSeedGenerator/plugins/CombinedMultiHitGenerator.h
@@ -35,9 +35,10 @@ public:
   virtual void hitSets( const TrackingRegion& reg, OrderedMultiHits & result,
       const edm::Event & ev,  const edm::EventSetup& es);
 
-   virtual void clear() override {
-      theGenerator->clear(); 
-   }
+  virtual void clear() override {
+    MultiHitGenerator::clear();
+    theGenerator->clear();
+  }
 
 private:
   edm::EDGetTokenT<SeedingLayerSetsHits> theSeedingLayerToken;

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -134,18 +134,16 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 					SeedingLayerSetsHits::SeedingLayerSet pairLayers,
 					std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers)
 { 
-  thePairGenerator->setSeedingLayers(pairLayers);
-
   unsigned int debug_Id0 = detIdsToDebug[0];
   unsigned int debug_Id1 = detIdsToDebug[1];
   unsigned int debug_Id2 = detIdsToDebug[2];
 
-  if (debug) cout << "pair: " << thePairGenerator->innerLayer().name() << "+" <<  thePairGenerator->outerLayer().name() << " 3rd lay size: " << thirdLayers.size() << endl;
+  if (debug) cout << "pair: " << thePairGenerator->innerLayer(pairLayers).name() << "+" <<  thePairGenerator->outerLayer(pairLayers).name() << " 3rd lay size: " << thirdLayers.size() << endl;
 
   //gc: first get the pairs
   OrderedHitPairs pairs;
   pairs.reserve(30000);
-  thePairGenerator->hitPairs(region,pairs,ev,es);
+  thePairGenerator->hitPairs(region,pairs,ev,es, pairLayers);
   if (debug) cout << endl;
   if (pairs.empty()) {
     //cout << "empy pairs" << endl;

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.cc
@@ -48,8 +48,7 @@ namespace {
 }
 
 MultiHitGeneratorFromChi2::MultiHitGeneratorFromChi2(const edm::ParameterSet& cfg)
-  : thePairGenerator(0),
-    theLayerCache(0),
+  : MultiHitGeneratorFromPairAndLayers(cfg),
     useFixedPreFiltering(cfg.getParameter<bool>("useFixedPreFiltering")),
     extraHitRZtolerance(cfg.getParameter<double>("extraHitRZtolerance")),//extra window in ThirdHitRZPrediction range 
     extraHitRPhitolerance(cfg.getParameter<double>("extraHitRPhitolerance")),//extra window in ThirdHitPredictionFromCircle range (divide by R to get phi) 
@@ -66,7 +65,6 @@ MultiHitGeneratorFromChi2::MultiHitGeneratorFromChi2(const edm::ParameterSet& cf
     useSimpleMF_(false),
     mfName_("")
 {    
-  theMaxElement=cfg.getParameter<unsigned int>("maxElement");
   if (useFixedPreFiltering)
     dphi = cfg.getParameter<double>("phiPreFiltering");
   if (chi2VsPtCut) {
@@ -94,13 +92,7 @@ MultiHitGeneratorFromChi2::MultiHitGeneratorFromChi2(const edm::ParameterSet& cf
   nomField = -1.;
 }
 
-void MultiHitGeneratorFromChi2::init(const HitPairGenerator & pairs,
-				     LayerCacheType *layerCache)
-{
-  thePairGenerator = pairs.clone();
-  theLayerCache = layerCache;
-}
-
+MultiHitGeneratorFromChi2::~MultiHitGeneratorFromChi2() {}
 void MultiHitGeneratorFromChi2::initES(const edm::EventSetup& es) 
 {
 
@@ -120,11 +112,6 @@ void MultiHitGeneratorFromChi2::initES(const edm::EventSetup& es)
   cloner = (*builder).cloner();
 }
 
-void MultiHitGeneratorFromChi2::setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                                                 std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) {
-  thePairGenerator->setSeedingLayers(pairLayers);
-  theLayers = thirdLayers;
-}
 
 namespace {
   inline
@@ -143,14 +130,17 @@ namespace {
 void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region, 
 					OrderedMultiHits & result,
 					const edm::Event & ev,
-					const edm::EventSetup& es)
+					const edm::EventSetup& es,
+					SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+					std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers)
 { 
+  thePairGenerator->setSeedingLayers(pairLayers);
 
   unsigned int debug_Id0 = detIdsToDebug[0];
   unsigned int debug_Id1 = detIdsToDebug[1];
   unsigned int debug_Id2 = detIdsToDebug[2];
 
-  if (debug) cout << "pair: " << ((HitPairGeneratorFromLayerPair*) thePairGenerator)->innerLayer().name() << "+" <<  ((HitPairGeneratorFromLayerPair*) thePairGenerator)->outerLayer().name() << " 3rd lay size: " << theLayers.size() << endl;
+  if (debug) cout << "pair: " << thePairGenerator->innerLayer().name() << "+" <<  thePairGenerator->outerLayer().name() << " 3rd lay size: " << thirdLayers.size() << endl;
 
   //gc: first get the pairs
   OrderedHitPairs pairs;
@@ -163,7 +153,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
   }
   
   //gc: these are all the layers compatible with the layer pairs (as defined in the config file)
-  int size = theLayers.size();
+  int size = thirdLayers.size();
 
 
   //gc: initialize a KDTree per each 3rd layer
@@ -183,10 +173,10 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
 
   //gc: loop over each layer
   for(int il = 0; il < size; il++) {
-    thirdHitMap[il] = &(*theLayerCache)(theLayers[il], region, ev, es);
-    if (debug) cout << "considering third layer: " << theLayers[il].name() << " with hits: " << thirdHitMap[il]->all().second-thirdHitMap[il]->all().first << endl;
-    const DetLayer *layer = theLayers[il].detLayer();
-    LayerRZPredictions &predRZ = mapPred[theLayers[il].name()];
+    thirdHitMap[il] = &(*theLayerCache)(thirdLayers[il], region, ev, es);
+    if (debug) cout << "considering third layer: " << thirdLayers[il].name() << " with hits: " << thirdHitMap[il]->all().second-thirdHitMap[il]->all().first << endl;
+    const DetLayer *layer = thirdLayers[il].detLayer();
+    LayerRZPredictions &predRZ = mapPred[thirdLayers[il].name()];
     predRZ.line.initLayer(layer);
     predRZ.line.initTolerance(extraHitRZtolerance);
 
@@ -195,7 +185,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
     layerTree.clear();
     double minz=999999.0, maxz= -999999.0; // Initialise to extreme values in case no hits
     float maxErr=0.0f;
-    bool barrelLayer = (theLayers[il].detLayer()->location() == GeomDetEnumerators::barrel);
+    bool barrelLayer = (thirdLayers[il].detLayer()->location() == GeomDetEnumerators::barrel);
     if (hitRange.first != hitRange.second)
       { minz = barrelLayer? hitRange.first->hit()->globalPosition().z() : hitRange.first->hit()->globalPosition().perp();
 	maxz = minz; //In case there's only one hit on the layer
@@ -334,7 +324,7 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
     for(int il = 0; (il < size) & (!usePair); il++) {
 
       if (debugPair) 
-	cout << "cosider layer: " << theLayers[il].name() << " for this pair. Location: " << theLayers[il].detLayer()->location() << endl;
+	cout << "cosider layer: " << thirdLayers[il].name() << " for this pair. Location: " << thirdLayers[il].detLayer()->location() << endl;
 
       if (hitTree[il].empty()) {
 	if (debugPair) {
@@ -346,10 +336,10 @@ void MultiHitGeneratorFromChi2::hitSets(const TrackingRegion& region,
       cacheHitPointer bestL2;
       float chi2FromThisLayer = std::numeric_limits<float>::max();
 
-      const DetLayer *layer = theLayers[il].detLayer();
+      const DetLayer *layer = thirdLayers[il].detLayer();
       bool barrelLayer = layer->location() == GeomDetEnumerators::barrel;
 
-      LayerRZPredictions &predRZ = mapPred.find(theLayers[il].name())->second;
+      LayerRZPredictions &predRZ = mapPred.find(thirdLayers[il].name())->second;
       predRZ.line.initPropagator(&line);
       
       //gc: this takes the z at R-thick/2 and R+thick/2 according to 

--- a/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
+++ b/RecoTracker/TkSeedGenerator/plugins/MultiHitGeneratorFromChi2.h
@@ -7,7 +7,6 @@
     provided Layers
  */
 
-#include "RecoTracker/TkHitPairs/interface/HitPairGenerator.h"
 #include "RecoTracker/TkSeedGenerator/interface/MultiHitGenerator.h"
 #include "CombinedMultiHitGenerator.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -23,27 +22,23 @@
 #include <utility>
 #include <vector>
 
+class HitPairGeneratorFromLayerPair;
 
 class dso_hidden MultiHitGeneratorFromChi2 final : public MultiHitGeneratorFromPairAndLayers {
 
 typedef CombinedMultiHitGenerator::LayerCacheType       LayerCacheType;
 
 public:
-  MultiHitGeneratorFromChi2( const edm::ParameterSet& cfg);
+  MultiHitGeneratorFromChi2(const edm::ParameterSet& cfg);
 
-  virtual ~MultiHitGeneratorFromChi2() { delete thePairGenerator; }
-
-  void init( const HitPairGenerator & pairs, LayerCacheType* layerCache) override;
+  virtual ~MultiHitGeneratorFromChi2();
 
   void initES(const edm::EventSetup& es) override; 
 
-  void setSeedingLayers(SeedingLayerSetsHits::SeedingLayerSet pairLayers,
-                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers) override;
-
   virtual void hitSets( const TrackingRegion& region, OrderedMultiHits & trs, 
-			const edm::Event & ev, const edm::EventSetup& es);
-
-  const HitPairGenerator & pairGenerator() const { return *thePairGenerator; }
+                        const edm::Event & ev, const edm::EventSetup& es,
+                        SeedingLayerSetsHits::SeedingLayerSet pairLayers,
+                        std::vector<SeedingLayerSetsHits::SeedingLayer> thirdLayers);
 
 private:
   using HitOwnPtr = mayown_ptr<BaseTrackerRecHit>;
@@ -67,9 +62,6 @@ private:
 		  float nomField, bool isDebug);
   */
 private:
-  HitPairGenerator * thePairGenerator;
-  std::vector<SeedingLayerSetsHits::SeedingLayer> theLayers;
-  LayerCacheType * theLayerCache;
   const ClusterShapeHitFilter* filter;
   TkTransientTrackingRecHitBuilder const * builder;
   TkClonerImpl cloner;

--- a/RecoTracker/TkSeedGenerator/src/MultiHitGenerator.cc
+++ b/RecoTracker/TkSeedGenerator/src/MultiHitGenerator.cc
@@ -5,11 +5,9 @@
 const OrderedMultiHits & MultiHitGenerator::run(
     const TrackingRegion& region, const edm::Event & ev, const edm::EventSetup& es)
 {
-  // std::cout << "MultiHitGenerator cache b " << cache.size() << std::endl;
   theHitSets.clear(); // called multiple time for the same seed collection
   theHitSets.reserve(localRA.upper());
   hitSets(region, theHitSets, ev, es);
-  // std::cout << "MultiHitGenerator cache	a " << cache.size() << std::endl;
   theHitSets.shrink_to_fit();
   localRA.update(theHitSets.size());
   return theHitSets;
@@ -18,8 +16,5 @@ const OrderedMultiHits & MultiHitGenerator::run(
 void MultiHitGenerator::clear() 
 {
   theHitSets.clear(); theHitSets.shrink_to_fit();
-  //std::cout << "MultiHitGenerator " << typeid(*this).name()
-  //           <<" cache c " << cache.size() << ' ' << cache.capacity() << std::endl;
-  cache.clear();
 }
 

--- a/RecoTracker/TkSeedGenerator/src/MultiHitGeneratorFromPairAndLayers.cc
+++ b/RecoTracker/TkSeedGenerator/src/MultiHitGeneratorFromPairAndLayers.cc
@@ -1,0 +1,19 @@
+#include "RecoTracker/TkSeedGenerator/interface/MultiHitGeneratorFromPairAndLayers.h"
+#include "RecoTracker/TkHitPairs/interface/HitPairGeneratorFromLayerPair.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+MultiHitGeneratorFromPairAndLayers::MultiHitGeneratorFromPairAndLayers(const edm::ParameterSet& pset):
+  theLayerCache(nullptr),
+  theMaxElement(pset.getParameter<unsigned int>("maxElement"))
+{}
+
+MultiHitGeneratorFromPairAndLayers::~MultiHitGeneratorFromPairAndLayers() {}
+
+void MultiHitGeneratorFromPairAndLayers::init(std::unique_ptr<HitPairGeneratorFromLayerPair>&& pairGenerator, LayerCacheType *layerCache) {
+  thePairGenerator = std::move(pairGenerator);
+  theLayerCache = layerCache;
+}
+
+void MultiHitGeneratorFromPairAndLayers::clear() {
+  cache.clear();
+}


### PR DESCRIPTION
Current inheritance chain of the hit generators is somewhat messy, and in some parts does not serve the current usage of the classes. This PR removes unnecessary inheritances and does some further cleanup allowed by the removal.

Essentially, the inheritance from HitPairGenerator is removed from
- HitPairGeneratorFromLayerPair
- CombinedHitQuadrupletGeneratorForPhotonConversion
- HitQuadrupletGeneratorFromLayerPairForPhotonConversion
- CosmicHitPairGenerator
- CosmicHitPairGeneratorFromLayerPair,

the inheritance from HitTripletGenerator from
- HitTripletGeneratorFromPairAndLayers
- CosmicHitTripletGenerator
- CosmicHitTripletGeneratorFromLayerTriplet,

and the inheritance from MultiHitGenerator from
- MultiHitGeneratorFromPairAndLayers.

(Most of the developments were actually done already more than a year ago, but for some reason I didn't push them for integration and they got buried under other stuff)

Tested in 750pre5, no changes expected in results.

@rovere @VinInn 
