### PR TITLE
Fix miniAOD validation for MET : 75X

### DIFF
--- a/Configuration/StandardSequences/python/Validation_cff.py
+++ b/Configuration/StandardSequences/python/Validation_cff.py
@@ -18,6 +18,7 @@ from HLTriggerOffline.Common.HLTValidation_cff import *
 
 from Validation.RecoMET.METRelValForDQM_cff import *
 from Validation.RecoJets.JetValidation_cff import *
+from JetMETCorrections.Type1MET.pfMETCorrectionType0_cfi import *
 from Validation.TrackingMCTruth.trackingTruthValidation_cfi import *
 from Validation.RecoTrack.TrackValidation_cff import *
 from Validation.RecoMuon.muonValidation_cff import *
@@ -31,7 +32,7 @@ from Validation.RecoParticleFlow.miniAODValidation_cff import *
 prevalidation = cms.Sequence( globalPrevalidation * hltassociation * metPreValidSeq * jetPreValidSeq )
 prevalidationLiteTracking = cms.Sequence( prevalidation )
 prevalidationLiteTracking.replace(globalPrevalidation,globalPrevalidationLiteTracking)
-prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * JetValidationMiniAOD )
+prevalidationMiniAOD = cms.Sequence( genParticles1 * miniAODValidationSequence * JetValidationMiniAOD * type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD )
 
 
 validation = cms.Sequence(cms.SequencePlaceholder("mix")

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.cc
@@ -25,11 +25,12 @@ int MultShiftMETcorrInputProducer::translateTypeToAbsPdgId( reco::PFCandidate::P
 
 
 MultShiftMETcorrInputProducer::MultShiftMETcorrInputProducer(const edm::ParameterSet& cfg):
-  pflow_ ( cfg.getParameter< edm::InputTag >("srcPFlow") ),
-  vertices_ ( cfg.getParameter< edm::InputTag >("vertexCollection") ),
   moduleLabel_(cfg.getParameter<std::string>("@module_label"))
 {
   
+  pflow_ = consumes<edm::View<reco::Candidate> >(cfg.getParameter< edm::InputTag >("srcPFlow") );
+  vertices_ = consumes<edm::View<reco::Vertex> >( cfg.getParameter< edm::InputTag >("vertexCollection") );
+
   cfgCorrParameters_ = cfg.getParameter<std::vector<edm::ParameterSet> >("parameters");
   etaMin_.clear(); 
   etaMax_.clear();
@@ -68,7 +69,7 @@ void MultShiftMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSet
   //get primary vertices
   edm::Handle<edm::View<reco::Vertex> > hpv;
   try {
-    evt.getByLabel( vertices_, hpv );
+    evt.getByToken( vertices_, hpv );
   } catch ( cms::Exception & e ) {
     std::cout <<"[MultShiftMETcorrInputProducer] error: " << e.what() << std::endl;
   }
@@ -85,7 +86,7 @@ void MultShiftMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSet
   for (unsigned i=0;i<sumPt_.size();i++) sumPt_[i]=0.;
 
   edm::Handle<edm::View<reco::Candidate> > particleFlow;
-  evt.getByLabel(pflow_, particleFlow);
+  evt.getByToken(pflow_, particleFlow);
   for (unsigned i = 0; i < particleFlow->size(); ++i) {
     const reco::Candidate& c = particleFlow->at(i);
     for (unsigned j=0; j<type_.size(); j++) {

--- a/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/MultShiftMETcorrInputProducer.h
@@ -41,8 +41,8 @@ class MultShiftMETcorrInputProducer : public edm::stream::EDProducer<>
   static int translateTypeToAbsPdgId( reco::PFCandidate::ParticleType type );
 
 
-  edm::InputTag pflow_;
-  edm::InputTag vertices_;
+  edm::EDGetTokenT<edm::View<reco::Candidate> > pflow_;
+  edm::EDGetTokenT<edm::View<reco::Vertex>> vertices_;
   std::string moduleLabel_;
 
   std::vector<edm::ParameterSet> cfgCorrParameters_;

--- a/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
+++ b/JetMETCorrections/Type1MET/python/pfMETCorrectionType0_cfi.py
@@ -61,6 +61,14 @@ type0PFMEtCorrectionPFCandToVertexAssociationForValidation = cms.Sequence(
    * pfCandidateToVertexAssociation
 )
 
+
+type0PFMEtCorrectionPFCandToVertexAssociationForValidationMiniAOD = cms.Sequence(
+    selectedVerticesForPFMEtCorrType0
+   * selectedPrimaryVertexHighestPtTrackSumForPFMEtCorrType0
+   * particleFlowDisplacedVertex
+   * pfCandidateToVertexAssociation
+)
+
 type0PFMEtCorrection = cms.Sequence(
     type0PFMEtCorrectionPFCandToVertexAssociation
    * pfMETcorrType0


### PR DESCRIPTION
Following the issue of workflow 11325 noticed after the integration of #9117 , this PR contains the corresponding fix.
Also fixed the remaining GetBylabel functions in the met correction tool.

@davidlange6
