### PR TITLE
Fix use-after-free in DynamicTruncation::preliminaryFit (backport of 75X #9282 )

### DIFF
--- a/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
+++ b/RecoMuon/GlobalTrackingTools/src/DynamicTruncation.cc
@@ -388,7 +388,7 @@ void DynamicTruncation::preliminaryFit(map<int, vector<DetId> > compatibleIds, m
     }
   }
   if (!prelFitMeas.empty()) prelFitMeas.pop_back();
-  for (ConstRecHitContainer::const_iterator imrh = prelFitMeas.end(); imrh != prelFitMeas.begin(); imrh-- ) {
+  for (auto imrh = prelFitMeas.rbegin(); imrh != prelFitMeas.rend(); ++imrh) {
     DetId id = (*imrh)->geographicalId(); 
     TrajectoryStateOnSurface tmp = propagatorPF->propagate(prelFitState, theG->idToDet(id)->surface());
     if (tmp.isValid()) prelFitState = tmp; 


### PR DESCRIPTION
From 75X #9282 message 

On the first iteration we used end() of STL container. end() returns
a pointer after the last element in container. In this case, we were
starting iteration from the last **removed** `TrackingRecHit`.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
# 

Somewhat anecdotal addendum:
I stumbled across this one while following up on a crash reported in 
https://hypernews.cern.ch/HyperNews/CMS/get/tier0-Ops/1010/1/1/1/1/1/1/1/1/1/1/1/1/1/2/1/1/1/1/1/1/1/1/1/1/1/1/1/2/2/1/1/1/1/1.html
The FSQDiJetAve config had a crash in this part of DYT code when running with random memory allocation pattern

```
 export MALLOC_CHECK_=3 
 export MALLOC_PERTURB_=$(($RANDOM % 255 + 1))
cmsRunGlibC PSet.py
```

the crash on this event, however is not on the same event ("6578th record") nor in the same module as the one in the tier0-Ops.
