### PR TITLE
Keep all TriggerResults in MiniAOD event content (75X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimming_cff.py
@@ -60,7 +60,7 @@ MicroEventContent = cms.PSet(
         'keep *_l1extraParticles_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_HLT',
-        'keep *_TriggerResults_*_PAT', # for MET filters
+        'keep *_TriggerResults_*_*', # for MET filters (a catch all for the moment, but ideally it should be only the current process)
         'keep patPackedCandidates_lostTracks_*_*',
         'keep HcalNoiseSummary_hcalnoise__*',
         'keep *_caTopTagInfosPAT_*_*'


### PR DESCRIPTION
Keep all TriggerResults, to be sure we will have the one containing the MET filters whatever CMSSW process name is used to run MiniAOD.
A better solution would be to keep only the one of the current process (plus the HLT one), but that would require a bit more study to make sure the configuration ends up correct in all workflows.
( cherry-pick of #10022 into 74X )
