### PR TITLE
Add vtx smearing parameters: nominal beam parameters, realistic centroid

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -38,7 +38,9 @@ VtxSmeared = {
     'Shifted15mmCollision2015'  :    'IOMC.EventVertexGenerators.VtxSmearedShifted15mmCollision2015_cfi',
     'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi',
     'NominalHICollision2015':      'IOMC.EventVertexGenerators.VtxSmearedNominalHICollision2015_cfi',
-    'ZeroTeslaRun247324Collision'  : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaRun247324Collision_cfi'
+    'ZeroTeslaRun247324Collision'  : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaRun247324Collision_cfi',
+    'RealisticCentroidNominalEmittance13TeVCollision': 'IOMC.EventVertexGenerators.RealisticCentroidNominalEmittance13TeVCollision_cfi',
+
 }
 VtxSmearedDefaultKey='NominalCollision2015'
 VtxSmearedHIDefaultKey='NominalHICollision2015'

--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -39,7 +39,7 @@ VtxSmeared = {
     'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi',
     'NominalHICollision2015':      'IOMC.EventVertexGenerators.VtxSmearedNominalHICollision2015_cfi',
     'ZeroTeslaRun247324Collision'  : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaRun247324Collision_cfi',
-    'RealisticCentroidNominalEmittance13TeVCollision': 'IOMC.EventVertexGenerators.RealisticCentroidNominalEmittance13TeVCollision_cfi',
+    'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',
 
 }
 VtxSmearedDefaultKey='NominalCollision2015'

--- a/IOMC/EventVertexGenerators/python/VtxSmeareRealisticCentroidNominalEmittance13TeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmeareRealisticCentroidNominalEmittance13TeVCollision_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    RealisticCentroidNominalEmittance13TeVCollisionVtxSmearingParameters,
+    VtxSmearedCommon
+)

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -417,7 +417,7 @@ ZeroTeslaRun247324CollisionVtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.1657),
     Z0 = cms.double(-1.688)
 )
-RealisticCentroidNominalEmittance13TeVCollisionVtxSmearingParameters = cms.PSet(
+Realistic50ns13TeVCollisionVtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),
     BetaStar = cms.double(65.0),
     Emittance = cms.double(5.411e-08),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -417,6 +417,17 @@ ZeroTeslaRun247324CollisionVtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.1657),
     Z0 = cms.double(-1.688)
 )
+RealisticCentroidNominalEmittance13TeVCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(65.0),
+    Emittance = cms.double(5.411e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.3),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.06006),
+    Y0 = cms.double(0.10007),
+    Z0 = cms.double(-1.708)
+)
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic50ns13TeVCollision_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic50ns13TeVCollision_cfi.py
@@ -2,6 +2,6 @@ import FWCore.ParameterSet.Config as cms
 
 from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
 VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
-    RealisticCentroidNominalEmittance13TeVCollisionVtxSmearingParameters,
+    Realistic50ns13TeVCollisionVtxSmearingParameters,
     VtxSmearedCommon
 )


### PR DESCRIPTION
back port of https://github.com/cms-sw/cmssw/pull/10048
