### PR TITLE
Hotfix to make the HcalCalPedestals run in 74X

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -3,33 +3,55 @@ import FWCore.ParameterSet.Config as cms
 #------------------------------------------------
 #AlCaReco filtering for HCAL minbias:
 #------------------------------------------------
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+hcalDigiAlCaPedestals = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone()
+hcalDigiAlCaPedestals.InputLabel = 'hltHcalCalibrationRaw'
 
-from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalMinBias_cff import *
-hcalDigiAlCaMB.InputLabel = 'hltHcalCalibrationRaw'
-#from EventFilter.HcalRawToDigi.HcalRawToDigi_cfi import *
-#hcalDigis.InputLabel = 'hltHcalCalibrationRaw'
-from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi
+hbherecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi.hbheprereco.clone()
 
-hbherecoMB.firstSample = 0
-hbherecoMB.samplesToAdd = 4
-hbherecoMB.digiLabel = 'hcalDigiAlCaMB'
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi
+hfrecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi.hfreco.clone()
 
-hfrecoMB.firstSample = 0
-hfrecoMB.samplesToAdd = 2
-hfrecoMB.digiLabel = 'hcalDigiAlCaMB'
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi
+horecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_ho_cfi.horeco.clone()
 
-horecoMB.firstSample = 0
-horecoMB.samplesToAdd = 4
-horecoMB.digiLabel = 'hcalDigiAlCaMB'
+#add GT digi:
+import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
+gtDigisAlCaPedestals = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
 
+hbherecoPedestals.firstSample = 0
+hbherecoPedestals.samplesToAdd = 4
+hbherecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
+
+hfrecoPedestals.firstSample = 0
+hfrecoPedestals.samplesToAdd = 2
+hfrecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
+
+horecoPedestals.firstSample = 0
+horecoPedestals.samplesToAdd = 4
+horecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
+
+# switch off "Hcal ZS in reco":
+hbherecoPedestals.dropZSmarkedPassed = cms.bool(False)
+hfrecoPedestals.dropZSmarkedPassed = cms.bool(False)
+horecoPedestals.dropZSmarkedPassed = cms.bool(False)
+
+hcalLocalRecoSequencePedestals = cms.Sequence(hbherecoPedestals*hfrecoPedestals*horecoPedestals) 
 
 import EventFilter.HcalRawToDigi.HcalCalibTypeFilter_cfi
 hcalCalibPedestal = EventFilter.HcalRawToDigi.HcalCalibTypeFilter_cfi.hcalCalibTypeFilter.clone(
-#  InputLabel = cms.string('rawDataCollector'), 
-  InputLabel = cms.string('hltHcalCalibrationRaw::HLT'),
-#  InputLabel = cms.InputTag("hltEcalCalibrationRaw","","HLT"),
-  CalibTypes    = cms.vint32( 1 ),
-  FilterSummary = cms.untracked.bool( False )
-)
+    #  InputLabel = cms.string('rawDataCollector'), 
+    InputLabel = cms.string('hltHcalCalibrationRaw::HLT'),
+    #  InputLabel = cms.InputTag("hltEcalCalibrationRaw","","HLT"),
+    CalibTypes    = cms.vint32( 1 ),
+    FilterSummary = cms.untracked.bool( False )
+    )
 
-seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestal*hcalDigiAlCaMB*gtDigisAlCaMB*hcalLocalRecoSequenceNZS*hbherecoNoise*hfrecoNoise*horecoNoise)
+seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestal*
+                                          hcalDigiAlCaPedestals*
+                                          gtDigisAlCaPedestals*
+                                          hcalLocalRecoSequencePedestals*
+                                          hbherecoPedestals*
+                                          hfrecoPedestals*
+                                          horecoPedestals)

--- a/Configuration/EventContent/python/AlCaRecoOutput_cff.py
+++ b/Configuration/EventContent/python/AlCaRecoOutput_cff.py
@@ -67,6 +67,7 @@ from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalIterativePhiSym_Output_cff
 # HCAL calibration with min.bias
 from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalMinBias_Output_cff import *
 from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalMinBiasHI_Output_cff import *
+from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_Output_cff import * 
 # HCAL calibration with Zmuu (HO)
 #  include "Calibration/HcalAlCaRecoProducers/data/ALCARECOHcalCalZMuMu_Output.cff"
 from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalHO_Output_cff import *

--- a/Configuration/StandardSequences/python/AlCaRecoStream_Specials_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStream_Specials_cff.py
@@ -27,7 +27,6 @@ ALCARECOStreamEcalCalEtaCalib = cms.FilteredStream(
 
 # ECAL calibration with pi0
 from Calibration.EcalAlCaRecoProducers.ALCARECOEcalCalPi0Calib_cff import *
-from DQMOffline.Configuration.AlCaRecoDQM_cff import *
 
 pathALCARECOEcalCalPi0Calib = cms.Path(seqALCARECOEcalCalPi0Calib*ALCARECOEcalCalPi0CalibDQM)
 
@@ -45,8 +44,6 @@ ALCARECOStreamEcalCalPi0Calib = cms.FilteredStream(
 # HCAL calibration with min.bias
 from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalMinBias_cff import *
 
-from DQMOffline.Configuration.AlCaRecoDQM_cff import *
-
 pathALCARECOHcalCalMinBias = cms.Path(seqALCARECOHcalCalMinBias*ALCARECOHcalCalPhisymDQM)
 
 from Configuration.EventContent.AlCaRecoOutput_cff import *
@@ -60,7 +57,21 @@ ALCARECOStreamHcalCalMinBias = cms.FilteredStream(
         dataTier = cms.untracked.string('ALCARECO')
         )
 
+# HCAL Pedestals
+from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_cff import *
 
+pathALCARECOHcalCalPedestal = cms.Path(seqALCARECOHcalCalPedestal*ALCARECOHcalCalPhisymDQM)
+
+from Configuration.EventContent.AlCaRecoOutput_cff import *
+
+ALCARECOStreamHcalCalPedestal = cms.FilteredStream(
+        responsible = 'Olga Kodolova',
+        name = 'ALCARECOHcalCalPedestal',
+        paths  = (pathALCARECOHcalCalPedestal),
+        content = OutALCARECOHcalCalPedestal.outputCommands,
+        selectEvents = OutALCARECOHcalCalPedestal.SelectEvents,
+        dataTier = cms.untracked.string('ALCARECO')
+        )
 
 # AlCaReco for LumiPixel stream
 from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixels_cff import *

--- a/EventFilter/HcalRawToDigi/plugins/HcalCalibTypeFilter.cc
+++ b/EventFilter/HcalRawToDigi/plugins/HcalCalibTypeFilter.cc
@@ -97,6 +97,10 @@ HcalCalibTypeFilter::filter(edm::Event& iEvent, const edm::EventSetup& iSetup)
   edm::Handle<FEDRawDataCollection> rawdata;  
   iEvent.getByToken(tok_data_,rawdata);
   
+  if(!rawdata.isValid()){
+     return false;
+  }
+
   // checking FEDs for calibration information
   int calibType = -1 ; int numEmptyFEDs = 0 ; 
   std::vector<int> calibTypeCounter(8,0) ; 


### PR DESCRIPTION
This is needed to make the HCalCalPedestals run in the AlCaReco matrix for 50ns data.
Profiting of this I cleaned also `AlCaRecoOutput_cff.py` for multiple inclusions of AlcaReco DQM instances. 
This is due to non complete backport of #8350 within #9162. @kodolova @bsunanda @diguida you might want to follow this.
