### PR TITLE
recover event interpretation step in Tier0 processing

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -52,7 +52,11 @@ class Reco(Scenario):
         if 'customs' in args:
             options.customisation_file=args['customs']
 
-        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+step+miniAODStep+',DQM'+dqmStep+',ENDJOB'
+        eiStep=''
+        if self.cbSc == 'pp':
+            eiStep=',EI'
+
+        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+miniAODStep+',DQM'+dqmStep+',ENDJOB'
 
 
         dictIO(options,args)
@@ -90,7 +94,12 @@ class Reco(Scenario):
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
         options.scenario = self.cbSc
-        options.step = 'RAW2DIGI,L1Reco,RECO'+step+',DQM'+dqmStep+',ENDJOB'
+
+        eiStep=''
+        if self.cbSc == 'pp':
+            eiStep=',EI'
+
+        options.step = 'RAW2DIGI,L1Reco,RECO'+eiStep+step+',DQM'+dqmStep+',ENDJOB'
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
         options.filein = 'tobeoverwritten.xyz'
@@ -124,7 +133,11 @@ class Reco(Scenario):
         if 'preFilter' in args:
             options.step +='FILTER:'+args['preFilter']+','
 
-        options.step += 'RAW2DIGI,L1Reco,RECO,ENDJOB'
+        eiStep=''
+        if self.cbSc == 'pp':
+            eiStep=',EI'
+
+        options.step += 'RAW2DIGI,L1Reco,RECO'+eiStep+',ENDJOB'
 
 
         dictIO(options,args)


### PR DESCRIPTION
the event interpretation sequence was a part of RECO in 53X.
It was split into a separate EI step in 620pre8. However, this was never propagated to T0 processing.
This PR adds the EI step to T0 processing scenarios deriving from pp ConfigBuilder scenario (as done in the matrix workflows)

tested in CMSSW_7_4_6_patch6 as a baseline.
Considered all scenarios available in Configuration/DataProcessing/test/run_CfgTest.sh
As expected, the EI modules show up in the following configurations:

```
RunExpressProcessing pp
RunExpressProcessing ppRun2
RunExpressProcessing ppRun2B0T
RunPromptReco hcalnzs
RunPromptReco pp
RunPromptReco ppRun2
RunPromptReco ppRun2B0T
RunPromptReco ppRun2B0T withMiniAOD
RunPromptReco ppRun2 withMiniAOD
RunVisualizationProcessing pp
RunVisualizationProcessing ppRun2
RunVisualizationProcessing ppRun2B0T
```

tested on dataset=/SingleMu/Run2015A-v1/RAW run=246951 lumi=101 file /store/data/Run2015A/SingleMu/RAW/v1/000/246/951/00000/BA6E1A15-A20A-E511-B6DD-02163E014569.root
with prompt, express, and visualization processing, using just the default 10 events: 
- all jobs completed
- EI products appear in the output files as expected
