### PR TITLE
 recover event interpretation step in Tier0 processing (forward port of 74X #10060 )

### DIFF
--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -52,7 +52,11 @@ class Reco(Scenario):
         if 'customs' in args:
             options.customisation_file=args['customs']
 
-        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+step+miniAODStep+',DQM'+dqmStep+',ENDJOB'
+        eiStep=''
+        if self.cbSc == 'pp':
+            eiStep=',EI'
+
+        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+miniAODStep+',DQM'+dqmStep+',ENDJOB'
 
 
         dictIO(options,args)
@@ -90,7 +94,12 @@ class Reco(Scenario):
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
         options.scenario = self.cbSc
-        options.step = 'RAW2DIGI,L1Reco,RECO'+step+',DQM'+dqmStep+',ENDJOB'
+
+        eiStep=''
+        if self.cbSc == 'pp':
+            eiStep=',EI'
+
+        options.step = 'RAW2DIGI,L1Reco,RECO'+eiStep+step+',DQM'+dqmStep+',ENDJOB'
         dictIO(options,args)
         options.conditions = gtNameAndConnect(globalTag, args)
         options.filein = 'tobeoverwritten.xyz'
@@ -124,7 +133,11 @@ class Reco(Scenario):
         if 'preFilter' in args:
             options.step +='FILTER:'+args['preFilter']+','
 
-        options.step += 'RAW2DIGI,L1Reco,RECO,ENDJOB'
+        eiStep=''
+        if self.cbSc == 'pp':
+            eiStep=',EI'
+
+        options.step += 'RAW2DIGI,L1Reco,RECO'+eiStep+',ENDJOB'
 
 
         dictIO(options,args)


### PR DESCRIPTION
the event interpretation sequence was a part of RECO in 53X.
It was split into a separate EI step in 620pre8. However, this was never propagated to T0 processing.
This PR adds the EI step to T0 processing scenarios deriving from pp ConfigBuilder scenario (as done in the matrix workflows)

tested in CMSSW_7_4_6_patch6 as a baseline as described in #10060
