### PR TITLE
Removed unused typedef from OwnVector

### DIFF
--- a/DataFormats/Common/interface/OwnVector.h
+++ b/DataFormats/Common/interface/OwnVector.h
@@ -414,7 +414,6 @@ namespace edm {
                                  std::vector<void const*>& pointers,
                                  FillViewHelperVector& helpers) const {
     typedef Ref<OwnVector>      ref_type ;
-    typedef reftobase::RefHolder<ref_type> holder_type;
 
     size_type numElements = this->size();
     pointers.reserve(numElements);


### PR DESCRIPTION
clang was complaining about a typedef inside a function which was never use.
