### PR TITLE
ioread rule to initialize elementsInBlocks_, needed for fwlite

### DIFF
--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -16,6 +16,9 @@
   <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="getter_">
     <![CDATA[edm::EDProductGetter::assignEDProductGetter(getter_); ]]>
   </ioread>
+  <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="elementsInBlocks_">
+    <![CDATA[elementsInBlocks_ = nullptr; ]]>
+  </ioread>
   <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="std::vector<unsigned long long> refsInfo_" target="refsCollectionCache_">
     <![CDATA[refsCollectionCache_.clear();refsCollectionCache_.resize(onfile.refsInfo_.size(),0); ]]>
   </ioread>


### PR DESCRIPTION
reco::PFCandidate::elementsInBlocks_ needs to be initialized to nullptr each event, as PFCandidate::elementsInBlocks() uses that as a flag to fill the values.  Current code relies on the constructor to set the value.  This doesn't work in FWLite, as it reuses objects (the ROOT way) instead of constructing them every event.  This PR adds an ioread rule to initialize the transient member to nullptr on read.  Details in this HN thread:

https://hypernews.cern.ch/HyperNews/CMS/get/sw-develtools/2315.html

This should be backported to 74x.
