### PR TITLE
ioread rule to initialize elementsInBlocks_, needed for fwlite, 74x version

### DIFF
--- a/DataFormats/ParticleFlowCandidate/src/classes_def.xml
+++ b/DataFormats/ParticleFlowCandidate/src/classes_def.xml
@@ -16,6 +16,9 @@
   <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="getter_">
     <![CDATA[edm::EDProductGetter::assignEDProductGetter(getter_); ]]>
   </ioread>
+  <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="" target="elementsInBlocks_">
+    <![CDATA[elementsInBlocks_ = nullptr; ]]>
+  </ioread>
   <ioread sourceClass = "reco::PFCandidate" version="[1-]" targetClass="reco::PFCandidate" source="std::vector<unsigned long long> refsInfo_" target="refsCollectionCache_">
     <![CDATA[refsCollectionCache_.clear();refsCollectionCache_.resize(onfile.refsInfo_.size(),0); ]]>
   </ioread>


### PR DESCRIPTION
Adds an ioread rule to initialize the transient member to nullptr on read, 74x version of PR#10076 (probably 10076 should be held, this one accepted, and see if the automatic forward porting works).
