### PR TITLE
FastSim: make matched hits aware of order of components (75X, BUGFIX)

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
@@ -17,6 +17,7 @@ public:
                          pixelMultiplicityAlpha_(), 
                          pixelMultiplicityBeta_(),
                          isMatched_(), 
+                         stereoHitFirst_(false),
                          componentMono_(),
                          componentStereo_() {}
   
@@ -59,10 +60,13 @@ public:
   const bool& isMatched()  const { return isMatched_;}
   const SiTrackerGSRecHit2D *monoHit() const { return &componentMono_;}
   const SiTrackerGSRecHit2D *stereoHit() const { return &componentStereo_;}
+  const SiTrackerGSRecHit2D *firstHit() const { return stereoHitFirst_ ? &componentStereo_ : &componentMono_;}
+  const SiTrackerGSRecHit2D *secondHit() const { return stereoHitFirst_ ? &componentMono_ : &componentStereo_;}
 
  ClusterRef const& cluster() const { return cluster_;}
   void setClusterRef(const ClusterRef &ref) { cluster_  = ref; }
- 
+  void setStereoLayerFirst(bool stereoHitFirst = true){stereoHitFirst_ = stereoHitFirst;}
+
   void setEeId(uint32_t eeId){eeId_ = eeId;}
 
   virtual bool sharesInput( const TrackingRecHit* other, SharedInputType what) const;
@@ -75,6 +79,7 @@ private:
   int const pixelMultiplicityAlpha_;
   int const pixelMultiplicityBeta_;
   bool isMatched_;
+  bool stereoHitFirst_;
 
   SiTrackerGSRecHit2D componentMono_;
   SiTrackerGSRecHit2D componentStereo_;

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
@@ -19,6 +19,7 @@ SiTrackerGSMatchedRecHit2D::SiTrackerGSMatchedRecHit2D( const LocalPoint& pos, c
   pixelMultiplicityAlpha_(pixelMultiplicityX), 
   pixelMultiplicityBeta_(pixelMultiplicityY), 
   isMatched_(isMatched), 
+  stereoHitFirst_(false),
   componentMono_(*rMono), 
   componentStereo_(*rStereo)
 {}
@@ -39,6 +40,7 @@ SiTrackerGSMatchedRecHit2D::SiTrackerGSMatchedRecHit2D( const LocalPoint& pos, c
   pixelMultiplicityAlpha_(pixelMultiplicityX), 
   pixelMultiplicityBeta_(pixelMultiplicityY), 
   isMatched_(0), 
+  stereoHitFirst_(false),
   componentMono_(), 
   componentStereo_()
 {}

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -9,7 +9,8 @@
    <version ClassVersion="11" checksum="1613493049"/>
    <version ClassVersion="10" checksum="877294307"/>
   </class>
-  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="13">
+  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="14">
+   <version ClassVersion="14" checksum="1823455267"/>
    <version ClassVersion="13" checksum="1553184391"/>
    <version ClassVersion="12" checksum="2874379530"/>
    <version ClassVersion="11" checksum="1553184391"/>

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -139,15 +139,15 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	if( recHitCandidates[index].matchedHit()->monoHit()->simhitId() < recHitCandidates[index].matchedHit()->stereoHit()->simhitId() )
+	if( recHitCandidates[index].matchedHit()->firstHit()->simhitId() < recHitCandidates[index].matchedHit()->secondHit()->simhitId() )
 	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->firstHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->secondHit()->clone());
 	  }
 	else
 	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->secondHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->firstHit()->clone());
 	  }
       }
       else {

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -139,8 +139,16 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
-	trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
+	if( recHitCandidates[index].matchedHit()->monoHit()->simhitId() < recHitCandidates[index].matchedHit()->stereoHit()->simhitId() )
+	  {
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
+	  }
+	else
+	  {
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
+	  }
       }
       else {
 	trackRecHits.push_back(recHitCandidates[index].hit()->clone());

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -139,16 +139,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	if( recHitCandidates[index].matchedHit()->firstHit()->simhitId() < recHitCandidates[index].matchedHit()->secondHit()->simhitId() )
-	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->firstHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->secondHit()->clone());
-	  }
-	else
-	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->secondHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->firstHit()->clone());
-	  }
+	trackRecHits.push_back(recHitCandidates[index].matchedHit()->firstHit()->clone());
+	trackRecHits.push_back(recHitCandidates[index].matchedHit()->secondHit()->clone());
       }
       else {
 	trackRecHits.push_back(recHitCandidates[index].hit()->clone());

--- a/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
@@ -1329,8 +1329,9 @@ SiTrackerGaussianSmearingRecHitConverter::matchHits(
       	    }
 
 	    if(partnersFound == 1) {
-	      SiTrackerGSMatchedRecHit2D * theMatchedHit =GSRecHitMatcher().match( &(*partner),  &(*rit),  gluedDet  , gluedsimtrackdir );
-
+	      SiTrackerGSMatchedRecHit2D * theMatchedHit = GSRecHitMatcher().match( &(*partner),  &(*rit),  gluedDet  , gluedsimtrackdir );
+	      if(partner == partnerNext)
+		theMatchedHit->setStereoLayerFirst();
 
 	      //	      std::cout << "Matched  hit: isMatched =\t" << theMatchedHit->isMatched() << ", "
 	      //	<<  theMatchedHit->monoHit() << ", " <<  theMatchedHit->stereoHit() << std::endl;

--- a/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
@@ -1329,7 +1329,7 @@ SiTrackerGaussianSmearingRecHitConverter::matchHits(
       	    }
 
 	    if(partnersFound == 1) {
-	      SiTrackerGSMatchedRecHit2D * theMatchedHit = GSRecHitMatcher().match( &(*partner),  &(*rit),  gluedDet  , gluedsimtrackdir );
+	      SiTrackerGSMatchedRecHit2D * theMatchedHit =GSRecHitMatcher().match( &(*partner),  &(*rit),  gluedDet  , gluedsimtrackdir );
 	      if(partner == partnerNext)
 		theMatchedHit->setStereoLayerFirst();
 


### PR DESCRIPTION
Fixes low efficiency for high purity tracks observed in validation of 750pre6, introduced in #9595 

Expected changes:
FullSim: none
FastSim: increased tracking efficiency, especially for high purity 
