### PR TITLE
Thread safety SetDirectory(0) fixes

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -27,6 +27,7 @@
 #include <iostream>
 
 // ROOT includes
+#include "TDirectory.h"
 #include "TH1.h"
 #include "TH2.h"
 #include "TProfile.h"
@@ -314,8 +315,11 @@ template <> TH1* TrackerOfflineValidation::DirectoryWrapper::make<TProfile>(cons
   if(dqmMode){
     theDbe->setCurrentFolder(directoryString);
     //DQM profile requires y-bins for construction... using TProfile creator by hand...
-    TProfile *tmpProfile=new TProfile(name,title,nBinX,xBins);
-    tmpProfile->SetDirectory(0);
+    TProfile *tmpProfile;
+    {
+      TDirectory::TContext(nullptr);
+      tmpProfile=new TProfile(name,title,nBinX,xBins);
+    }
     return theDbe->bookProfile(name,tmpProfile)->getTH1();
   }
   else{return tfd->make<TProfile>(name,title,nBinX,xBins);}
@@ -325,8 +329,11 @@ template <> TH1* TrackerOfflineValidation::DirectoryWrapper::make<TProfile>(cons
   if(dqmMode){
     theDbe->setCurrentFolder(directoryString);
     //DQM profile requires y-bins for construction... using TProfile creator by hand...
-    TProfile *tmpProfile=new TProfile(name,title,nBinX,minBinX,maxBinX);
-    tmpProfile->SetDirectory(0);
+    TProfile *tmpProfile;
+    {
+      TDirectory::TContext(nullptr);
+      tmpProfile = new TProfile(name,title,nBinX,minBinX,maxBinX);
+    }
     return theDbe->bookProfile(name,tmpProfile)->getTH1();
   }
   else{return tfd->make<TProfile>(name,title,nBinX,minBinX,maxBinX);}

--- a/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
@@ -38,6 +38,8 @@
 
 
 #include <vector>
+
+#include "TDirectory.h"
 #include "TLine.h"
 
  
@@ -1424,77 +1426,36 @@ void EcalCosmicsHists::initHists(int FED)
   string name1 = "SeedEnergyFED";
   name1.append(intToString(FED));
   int numBins = 200;//(int)round(histRangeMax_-histRangeMin_)+1;
-  TH1F* hist = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndHists_[FED] = hist;
-  FEDsAndHists_[FED]->SetDirectory(0);
-  
-  TH1F* E2hist = new TH1F(Form("E2_FED_%d",FED),Form("E2_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndE2Hists_[FED] = E2hist;
-  FEDsAndE2Hists_[FED]->SetDirectory(0);
-  
-  TH1F* energyhist = new TH1F(Form("Energy_FED_%d",FED),Form("Energy_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndenergyHists_[FED] = energyhist;
-  FEDsAndenergyHists_[FED]->SetDirectory(0);
-  
-  TH2F* E2vsE1hist = new TH2F(Form("E2vsE1_FED_%d",FED),Form("E2vsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
-  FEDsAndE2vsE1Hists_[FED] = E2vsE1hist;
-  FEDsAndE2vsE1Hists_[FED]->SetDirectory(0);
-  
-  TH2F* energyvsE1hist = new TH2F(Form("EnergyvsE1_FED_%d",FED),Form("EnergyvsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
-  FEDsAndenergyvsE1Hists_[FED] = energyvsE1hist;
-  FEDsAndenergyvsE1Hists_[FED]->SetDirectory(0);
-  
-  title1 = "Time for ";
-  title1.append(fedMap_->getSliceFromFed(FED));
-  title1.append(";Relative Time (1 clock = 25ns);Events");
-  name1 = "TimeFED";
-  name1.append(intToString(FED));
-  TH1F* timingHist = new TH1F(name1.c_str(),title1.c_str(),78,-7,7);
-  FEDsAndTimingHists_[FED] = timingHist;
-  FEDsAndTimingHists_[FED]->SetDirectory(0);
-  
-  TH1F* freqHist = new TH1F(Form("Frequency_FED_%d",FED),Form("Frequency for FED %d;Event Number",FED),100,0.,100000);
-  FEDsAndFrequencyHists_[FED] = freqHist;
-  FEDsAndFrequencyHists_[FED]->SetDirectory(0);
-  
-  TH1F* iphiProfileHist = new TH1F(Form("iPhi_Profile_FED_%d",FED),Form("iPhi Profile for FED %d",FED),360,1.,361);
-  FEDsAndiPhiProfileHists_[FED] = iphiProfileHist;
-  FEDsAndiPhiProfileHists_[FED]->SetDirectory(0);
-  
-  TH1F* ietaProfileHist = new TH1F(Form("iEta_Profile_FED_%d",FED),Form("iEta Profile for FED %d",FED),172,-86,86);
-  FEDsAndiEtaProfileHists_[FED] = ietaProfileHist;
-  FEDsAndiEtaProfileHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsFreq = new TH2F(Form("timeVsFreqFED_%d",FED),Form("time Vs Freq FED %d",FED),78,-7,7,100,0.,100000);
-  FEDsAndTimingVsFreqHists_[FED] = timingHistVsFreq;
-  FEDsAndTimingVsFreqHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsAmp = new TH2F(Form("timeVsAmpFED_%d",FED),Form("time Vs Amp FED %d",FED),78,-7,7,numBins,histRangeMin_,histRangeMax_);
-  FEDsAndTimingVsAmpHists_[FED] = timingHistVsAmp;
-  FEDsAndTimingVsAmpHists_[FED]->SetDirectory(0);
-  
-  TH1F* numXtalInClusterHist = new TH1F(Form("NumXtalsInCluster_FED_%d",FED),Form("Num active Xtals In Cluster for FED %d;Num Active Xtals",FED),25,0,25);
-  FEDsAndNumXtalsInClusterHists_[FED] = numXtalInClusterHist;
-  FEDsAndNumXtalsInClusterHists_[FED]->SetDirectory(0);
-  
-  TH2F* OccupHist = new TH2F(Form("occupFED_%d",FED),Form("Occupancy FED %d;i#eta;i#phi",FED),85,1,86,20,1,21);
-  FEDsAndOccupancyHists_[FED] = OccupHist;
-  FEDsAndOccupancyHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsPhi = new TH2F(Form("timeVsPhiFED_%d",FED),Form("time Vs Phi FED %d;Relative Time (1 clock = 25ns);i#phi",FED),78,-7,7,20,1,21);
-  FEDsAndTimingVsPhiHists_[FED] = timingHistVsPhi;
-  FEDsAndTimingVsPhiHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsModule = new TH2F(Form("timeVsModuleFED_%d",FED),Form("time Vs Module FED %d;Relative Time (1 clock = 25ns);i#eta",FED),78,-7,7,4,1,86);
-  FEDsAndTimingVsModuleHists_[FED] = timingHistVsModule;
-  FEDsAndTimingVsModuleHists_[FED]->SetDirectory(0);
 
-  TH2F* dccRuntypeVsBxFED = new TH2F(Form("DCCRuntypeVsBxFED_%d",FED),Form("DCC Runtype vs. BX FED %d",FED),3600,0,3600,24,0,24);
-  FEDsAndDCCRuntypeVsBxHists_[FED] = dccRuntypeVsBxFED;
-  FEDsAndDCCRuntypeVsBxHists_[FED]->SetDirectory(0); 
-  
+  {
+    TDirectory::TContext(nullptr);
+
+    FEDsAndHists_[FED] = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
+    FEDsAndE2Hists_[FED] = new TH1F(Form("E2_FED_%d",FED),Form("E2_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
+    FEDsAndenergyHists_[FED] = new TH1F(Form("Energy_FED_%d",FED),Form("Energy_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
+    FEDsAndE2vsE1Hists_[FED] = new TH2F(Form("E2vsE1_FED_%d",FED),Form("E2vsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
+    FEDsAndenergyvsE1Hists_[FED] = new TH2F(Form("EnergyvsE1_FED_%d",FED),Form("EnergyvsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
+
+    title1 = "Time for ";
+    title1.append(fedMap_->getSliceFromFed(FED));
+    title1.append(";Relative Time (1 clock = 25ns);Events");
+    name1 = "TimeFED";
+    name1.append(intToString(FED));
+    FEDsAndTimingHists_[FED] = new TH1F(name1.c_str(),title1.c_str(),78,-7,7);
+
+    FEDsAndFrequencyHists_[FED] = new TH1F(Form("Frequency_FED_%d",FED),Form("Frequency for FED %d;Event Number",FED),100,0.,100000);
+    FEDsAndiPhiProfileHists_[FED] = new TH1F(Form("iPhi_Profile_FED_%d",FED),Form("iPhi Profile for FED %d",FED),360,1.,361);
+    FEDsAndiEtaProfileHists_[FED] = new TH1F(Form("iEta_Profile_FED_%d",FED),Form("iEta Profile for FED %d",FED),172,-86,86);
+    FEDsAndTimingVsFreqHists_[FED] = new TH2F(Form("timeVsFreqFED_%d",FED),Form("time Vs Freq FED %d",FED),78,-7,7,100,0.,100000);
+    FEDsAndTimingVsAmpHists_[FED] = new TH2F(Form("timeVsAmpFED_%d",FED),Form("time Vs Amp FED %d",FED),78,-7,7,numBins,histRangeMin_,histRangeMax_);
+
+    FEDsAndNumXtalsInClusterHists_[FED] = new TH1F(Form("NumXtalsInCluster_FED_%d",FED),Form("Num active Xtals In Cluster for FED %d;Num Active Xtals",FED),25,0,25);
+    FEDsAndOccupancyHists_[FED] = new TH2F(Form("occupFED_%d",FED),Form("Occupancy FED %d;i#eta;i#phi",FED),85,1,86,20,1,21);
+    FEDsAndTimingVsPhiHists_[FED] = new TH2F(Form("timeVsPhiFED_%d",FED),Form("time Vs Phi FED %d;Relative Time (1 clock = 25ns);i#phi",FED),78,-7,7,20,1,21);
+    FEDsAndTimingVsModuleHists_[FED] = new TH2F(Form("timeVsModuleFED_%d",FED),Form("time Vs Module FED %d;Relative Time (1 clock = 25ns);i#eta",FED),78,-7,7,4,1,86);
+    FEDsAndDCCRuntypeVsBxHists_[FED] = new TH2F(Form("DCCRuntypeVsBxFED_%d",FED),Form("DCC Runtype vs. BX FED %d",FED),3600,0,3600,24,0,24);
+  }
 }
-
 // ------------ method called once each job just before starting event loop  ------------
 void 
 EcalCosmicsHists::beginRun(edm::Run const &, edm::EventSetup const & eventSetup)

--- a/CaloOnlineTools/EcalTools/plugins/EcalPedHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPedHists.cc
@@ -297,12 +297,13 @@ void EcalPedHists::initHists(int FED)
     title3.append(chnl);
     string name3 = "Cry";
     name3.append(chnl+"Gain12");
-    histMap.insert(make_pair(name1,new TH1F(name1.c_str(),title1.c_str(),75,175.0,250.0)));
-    histMap[name1]->SetDirectory(0);
-    histMap.insert(make_pair(name2,new TH1F(name2.c_str(),title2.c_str(),75,175.0,250.0)));
-    histMap[name2]->SetDirectory(0);
-    histMap.insert(make_pair(name3,new TH1F(name3.c_str(),title3.c_str(),75,175.0,250.0)));
-    histMap[name3]->SetDirectory(0);
+    {
+      TDirectory::TContext(nullptr);
+
+      histMap.insert(make_pair(name1,new TH1F(name1.c_str(),title1.c_str(),75,175.0,250.0)));
+      histMap.insert(make_pair(name2,new TH1F(name2.c_str(),title2.c_str(),75,175.0,250.0)));
+      histMap.insert(make_pair(name3,new TH1F(name3.c_str(),title3.c_str(),75,175.0,250.0)));
+    }
   }
   FEDsAndHistMaps_.insert(make_pair(FED,histMap));
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.cc
@@ -18,6 +18,8 @@
 
 #include "CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.h"
 
+#include "TDirectory.h"
+
 using namespace cms;
 using namespace edm;
 using namespace std;
@@ -200,17 +202,18 @@ void EcalURecHitHists::initHists(int FED)
   string name1 = "URecHitsFED";
   name1.append(intToString(FED));
   int numBins = (int)round(histRangeMax_-histRangeMin_)+1;
-  TH1F* hist = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndHists_[FED] = hist;
-  FEDsAndHists_[FED]->SetDirectory(0);
+
+  {
+    TDirectory::TContext(nullptr);
+
+    FEDsAndHists_[FED] = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
   
-  title1 = "Jitter for ";
-  title1.append(fedMap_->getSliceFromFed(FED));
-  name1 = "JitterFED";
-  name1.append(intToString(FED));
-  TH1F* timingHist = new TH1F(name1.c_str(),title1.c_str(),14,-7,7);
-  FEDsAndTimingHists_[FED] = timingHist;
-  FEDsAndTimingHists_[FED]->SetDirectory(0);
+    title1 = "Jitter for ";
+    title1.append(fedMap_->getSliceFromFed(FED));
+    name1 = "JitterFED";
+    name1.append(intToString(FED));
+    FEDsAndTimingHists_[FED]  = new TH1F(name1.c_str(),title1.c_str(),14,-7,7);
+  }
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/DPGAnalysis/SiStripTools/src/CommonAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/src/CommonAnalyzer.cc
@@ -129,9 +129,10 @@ TH1F* CommonAnalyzer::getBinomialRatio(const CommonAnalyzer& denom, const char* 
       denreb = (TH1F*)den->Rebin(rebin,"denrebinned");
       numreb = (TH1F*)num->Rebin(rebin,"numrebinned");
     }
-    
-    ratio = new TH1F(*numreb);
-    ratio->SetDirectory(0);
+    {
+      TDirectory::TContext(nullptr);
+      ratio = new TH1F(*numreb);
+    }
     ratio->Reset();
     ratio->Sumw2();
     ratio->Divide(numreb,denreb,1,1,"B");

--- a/DQM/EcalPreshowerMonitorClient/interface/ESClient.h
+++ b/DQM/EcalPreshowerMonitorClient/interface/ESClient.h
@@ -6,6 +6,8 @@
 #include "DQMServices/Core/interface/MonitorElement.h"
 #include "DQMServices/Core/interface/DQMStore.h"
 
+#include "TDirectory.h"
+
 namespace edm {
   class ParameterSet;
 }
@@ -50,8 +52,10 @@ ESClient::getHisto(MonitorElement* _me, bool _clone/* = false*/, T* _current/* =
 
   if(_clone){
     delete _current;
-    _current = dynamic_cast<T*>(obj->Clone(("ME " + _me->getName()).c_str()));
-    if(_current) _current->SetDirectory(0);
+    {
+      TDirectory::TContext(nullptr);
+      _current = dynamic_cast<T*>(obj->Clone(("ME " + _me->getName()).c_str()));
+    }
     return _current;
   }
   else

--- a/DQM/HcalMonitorClient/interface/HcalClientUtils.h
+++ b/DQM/HcalMonitorClient/interface/HcalClientUtils.h
@@ -5,6 +5,8 @@
 #include "TH1.h"
 #include "TH2F.h"
 #include "TCanvas.h"
+#include "TDirectory.h"
+
 #include <string>
 #include "DQMServices/Core/interface/DQMStore.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
@@ -41,9 +43,9 @@ class HcalUtilsClient
             delete ret;
           }
           std::string s = "ME " + me->getName();
-          ret = dynamic_cast<T>(ob->Clone(s.c_str())); 
-          if( ret ) {
-            ret->SetDirectory(0);
+          {
+            TDirectory::TContext(nullptr);
+            ret = dynamic_cast<T>(ob->Clone(s.c_str()));
           }
         } else {
           ret = dynamic_cast<T>(ob); 

--- a/DQM/Physics/src/QcdLowPtDQM.cc
+++ b/DQM/Physics/src/QcdLowPtDQM.cc
@@ -26,6 +26,7 @@
 #include <TH1F.h>
 #include <TH2F.h>
 #include <TH3F.h>
+#include "TDirectory.h"
 
 using namespace std;
 using namespace edm;
@@ -1216,11 +1217,12 @@ void QcdLowPtDQM::yieldAlphaHistogram(int which) {
     double VzBins[nVzBin + 1];
     for (int i = 0; i <= nVzBin; i++)
       VzBins[i] = (double)i * 20.0 / (double)nVzBin - 10.0;
-
-    AlphaTracklets12_ = new TH3F(
+    {
+      TDirectory::TContext(nullptr);
+      AlphaTracklets12_ = new TH3F(
         "hAlphaTracklets12", "Alpha for tracklets12;#eta;#hits;vz [cm]",
         nEtaBin, EtaBins, nHitBin, HitBins, nVzBin, VzBins);
-    AlphaTracklets12_->SetDirectory(0);
+    }
 
     AlphaTracklets12_->SetBinContent(2, 1, 7, 3.55991);
     AlphaTracklets12_->SetBinContent(2, 1, 8, 2.40439);
@@ -2471,10 +2473,12 @@ void QcdLowPtDQM::yieldAlphaHistogram(int which) {
     for (int i = 0; i <= nVzBin; i++)
       VzBins[i] = (double)i * 20.0 / (double)nVzBin - 10.0;
 
-    AlphaTracklets13_ = new TH3F(
+    {
+      TDirectory::TContext(nullptr);
+      AlphaTracklets13_ = new TH3F(
         "hAlphaTracklets13", "Alpha for tracklets13;#eta;#hits;vz [cm]",
         nEtaBin, EtaBins, nHitBin, HitBins, nVzBin, VzBins);
-    AlphaTracklets13_->SetDirectory(0);
+    }
 
     AlphaTracklets13_->SetBinContent(3, 1, 5, 3.29862);
     AlphaTracklets13_->SetBinContent(3, 1, 6, 2.40246);
@@ -3501,10 +3505,12 @@ void QcdLowPtDQM::yieldAlphaHistogram(int which) {
     for (int i = 0; i <= nVzBin; i++)
       VzBins[i] = (double)i * 20.0 / (double)nVzBin - 10.0;
 
-    AlphaTracklets23_ = new TH3F(
+    {
+      TDirectory::TContext(nullptr);
+      AlphaTracklets23_ = new TH3F(
         "hAlphaTracklets23", "Alpha for tracklets23;#eta;#hits;vz [cm]",
         nEtaBin, EtaBins, nHitBin, HitBins, nVzBin, VzBins);
-    AlphaTracklets23_->SetDirectory(0);
+    }
 
     AlphaTracklets23_->SetBinContent(3, 1, 5, 3.38308);
     AlphaTracklets23_->SetBinContent(3, 1, 6, 2.34772);

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -645,22 +645,22 @@ class DQMStore
                                      const std::string &name,
                                      const char *context);
   template <class HISTO, class COLLATE>
-  MonitorElement *              book(const std::string &dir, const std::string &name,
-                                     const char *context, int kind,
-                                     HISTO *h, COLLATE collate);
+  MonitorElement *              bookHisto(const std::string &dir, const std::string &name,
+                                          const char *context, int kind,
+                                          HISTO *h, COLLATE collate);
 
   MonitorElement *              bookInt(const std::string &dir, const std::string &name);
   MonitorElement *              bookFloat(const std::string &dir, const std::string &name);
   MonitorElement *              bookString(const std::string &dir, const std::string &name, const std::string &value);
-  MonitorElement *              book1D(const std::string &dir, const std::string &name, TH1F *h);
-  MonitorElement *              book1S(const std::string &dir, const std::string &name, TH1S *h);
-  MonitorElement *              book1DD(const std::string &dir, const std::string &name, TH1D *h);
-  MonitorElement *              book2D(const std::string &dir, const std::string &name, TH2F *h);
-  MonitorElement *              book2S(const std::string &dir, const std::string &name, TH2S *h);
-  MonitorElement *              book2DD(const std::string &dir, const std::string &name, TH2D *h);
-  MonitorElement *              book3D(const std::string &dir, const std::string &name, TH3F *h);
-  MonitorElement *              bookProfile(const std::string &dir, const std::string &name, TProfile *h);
-  MonitorElement *              bookProfile2D(const std::string &folder, const std::string &name, TProfile2D *h);
+  MonitorElement *              book1DHisto(const std::string &dir, const std::string &name, TH1F *h);
+  MonitorElement *              book1SHisto(const std::string &dir, const std::string &name, TH1S *h);
+  MonitorElement *              book1DDHisto(const std::string &dir, const std::string &name, TH1D *h);
+  MonitorElement *              book2DHisto(const std::string &dir, const std::string &name, TH2F *h);
+  MonitorElement *              book2SHisto(const std::string &dir, const std::string &name, TH2S *h);
+  MonitorElement *              book2DDHisto(const std::string &dir, const std::string &name, TH2D *h);
+  MonitorElement *              book3DHisto(const std::string &dir, const std::string &name, TH3F *h);
+  MonitorElement *              bookProfileHisto(const std::string &dir, const std::string &name, TProfile *h);
+  MonitorElement *              bookProfile2DHisto(const std::string &folder, const std::string &name, TProfile2D *h);
 
   static bool                   checkBinningMatches(MonitorElement *me, TH1 *h, unsigned verbose);
 

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -789,18 +789,15 @@ DQMStore::dirExists(const std::string &path) const
 //////////////////////////////////////////////////////////////////////
 template <class HISTO, class COLLATE>
 MonitorElement *
-DQMStore::book(const std::string &dir, const std::string &name,
-               const char *context, int kind,
-               HISTO *h, COLLATE collate)
+DQMStore::bookHisto(const std::string &dir, const std::string &name,
+                    const char *context, int kind,
+                    HISTO *h, COLLATE collate)
 {
   assert(name.find('/') == std::string::npos);
   if (verbose_ > 3)
     print_trace(dir, name);
   std::string path;
   mergePath(path, dir, name);
-
-  // Put us in charge of h.
-  h->SetDirectory(0);
 
   // Check if the request monitor element already exists.
   MonitorElement *me = findObject(dir, name, run_, 0, streamId_, moduleId_);
@@ -982,23 +979,23 @@ DQMStore::bookString(const std::string &name, const std::string &value)
 // -------------------------------------------------------------------
 /// Book 1D histogram based on TH1F.
 MonitorElement *
-DQMStore::book1D(const std::string &dir, const std::string &name, TH1F *h)
+DQMStore::book1DHisto(const std::string &dir, const std::string &name, TH1F *h)
 {
-  return book(dir, name, "book1D", MonitorElement::DQM_KIND_TH1F, h, collate1D);
+  return bookHisto(dir, name, "book1D", MonitorElement::DQM_KIND_TH1F, h, collate1D);
 }
 
 /// Book 1D histogram based on TH1S.
 MonitorElement *
-DQMStore::book1S(const std::string &dir, const std::string &name, TH1S *h)
+DQMStore::book1SHisto(const std::string &dir, const std::string &name, TH1S *h)
 {
-  return book(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S);
+  return bookHisto(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S);
 }
 
 /// Book 1D histogram based on TH1D.
 MonitorElement *
-DQMStore::book1DD(const std::string &dir, const std::string &name, TH1D *h)
+DQMStore::book1DDHisto(const std::string &dir, const std::string &name, TH1D *h)
 {
-  return book(dir, name, "book1DD", MonitorElement::DQM_KIND_TH1D, h, collate1DD);
+  return bookHisto(dir, name, "book1DD", MonitorElement::DQM_KIND_TH1D, h, collate1DD);
 }
 
 /// Book 1D histogram.
@@ -1006,7 +1003,12 @@ MonitorElement *
 DQMStore::book1D(const char *name, const char *title,
                  int nchX, double lowX, double highX)
 {
-  return book1D(pwd_, name, new TH1F(name, title, nchX, lowX, highX));
+  TH1F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1F(name, title, nchX, lowX, highX);
+  }
+  return book1DHisto(pwd_, name, h);
 }
 
 /// Book 1D histogram.
@@ -1014,7 +1016,12 @@ MonitorElement *
 DQMStore::book1D(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX)
 {
-  return book1D(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, lowX, highX));
+  TH1F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1F(name.c_str(), title.c_str(), nchX, lowX, highX);
+  }
+  return book1DHisto(pwd_, name, h);
 }
 
 /// Book 1S histogram.
@@ -1022,7 +1029,12 @@ MonitorElement *
 DQMStore::book1S(const char *name, const char *title,
                  int nchX, double lowX, double highX)
 {
-  return book1S(pwd_, name, new TH1S(name, title, nchX, lowX, highX));
+  TH1S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1S(name, title, nchX, lowX, highX);
+  }
+  return book1SHisto(pwd_, name, h);
 }
 
 /// Book 1S histogram.
@@ -1030,7 +1042,12 @@ MonitorElement *
 DQMStore::book1S(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX)
 {
-  return book1S(pwd_, name, new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX));
+  TH1S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX);
+  }
+  return book1SHisto(pwd_, name, h);
 }
 
 /// Book 1S histogram.
@@ -1038,7 +1055,12 @@ MonitorElement *
 DQMStore::book1DD(const char *name, const char *title,
                   int nchX, double lowX, double highX)
 {
-  return book1DD(pwd_, name, new TH1D(name, title, nchX, lowX, highX));
+  TH1D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1D(name, title, nchX, lowX, highX);
+  }
+  return book1DDHisto(pwd_, name, h);
 }
 
 /// Book 1S histogram.
@@ -1046,7 +1068,12 @@ MonitorElement *
 DQMStore::book1DD(const std::string &name, const std::string &title,
                   int nchX, double lowX, double highX)
 {
-  return book1DD(pwd_, name, new TH1D(name.c_str(), title.c_str(), nchX, lowX, highX));
+  TH1D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1D(name.c_str(), title.c_str(), nchX, lowX, highX);
+  }
+  return book1DDHisto(pwd_, name, h);
 }
 
 /// Book 1D variable bin histogram.
@@ -1054,7 +1081,12 @@ MonitorElement *
 DQMStore::book1D(const char *name, const char *title,
                  int nchX, const float *xbinsize)
 {
-  return book1D(pwd_, name, new TH1F(name, title, nchX, xbinsize));
+  TH1F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1F(name, title, nchX, xbinsize);
+  }
+  return book1DHisto(pwd_, name, h);
 }
 
 /// Book 1D variable bin histogram.
@@ -1062,71 +1094,106 @@ MonitorElement *
 DQMStore::book1D(const std::string &name, const std::string &title,
                  int nchX, const float *xbinsize)
 {
-  return book1D(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, xbinsize));
+  TH1F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH1F(name.c_str(), title.c_str(), nchX, xbinsize);
+  }
+  return book1DHisto(pwd_, name, h);
 }
 
 /// Book 1D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1D(const char *name, TH1F *source)
 {
-  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name)));
+  TH1F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH1F *>(source->Clone(name));
+  }
+  return book1DHisto(pwd_, name, h);
 }
 
 /// Book 1D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1D(const std::string &name, TH1F *source)
 {
-  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name.c_str())));
+  TH1F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH1F *>(source->Clone(name.c_str()));
+  }
+  return book1DHisto(pwd_, name, h);
 }
 
 /// Book 1S histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1S(const char *name, TH1S *source)
 {
-  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name)));
+  TH1S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH1S *>(source->Clone(name));
+  }
+  return book1SHisto(pwd_, name, h);
 }
 
 /// Book 1S histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1S(const std::string &name, TH1S *source)
 {
-  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name.c_str())));
+  TH1S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH1S *>(source->Clone(name.c_str()));
+  }
+  return book1SHisto(pwd_, name, h);
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1DD(const char *name, TH1D *source)
 {
-  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name)));
+  TH1D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH1D *>(source->Clone(name));
+  }
+  return book1DDHisto(pwd_, name, h);
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1DD(const std::string &name, TH1D *source)
 {
-  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name.c_str())));
+  TH1D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH1D *>(source->Clone(name.c_str()));
+  }
+  return book1DDHisto(pwd_, name, h);
 }
 
 // -------------------------------------------------------------------
 /// Book 2D histogram based on TH2F.
 MonitorElement *
-DQMStore::book2D(const std::string &dir, const std::string &name, TH2F *h)
+DQMStore::book2DHisto(const std::string &dir, const std::string &name, TH2F *h)
 {
-  return book(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D);
+  return bookHisto(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D);
 }
 
 /// Book 2D histogram based on TH2S.
 MonitorElement *
-DQMStore::book2S(const std::string &dir, const std::string &name, TH2S *h)
+DQMStore::book2SHisto(const std::string &dir, const std::string &name, TH2S *h)
 {
-  return book(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S);
+  return bookHisto(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S);
 }
 
 /// Book 2D histogram based on TH2D.
 MonitorElement *
-DQMStore::book2DD(const std::string &dir, const std::string &name, TH2D *h)
+DQMStore::book2DDHisto(const std::string &dir, const std::string &name, TH2D *h)
 {
-  return book(dir, name, "book2DD", MonitorElement::DQM_KIND_TH2D, h, collate2DD);
+  return bookHisto(dir, name, "book2DD", MonitorElement::DQM_KIND_TH2D, h, collate2DD);
 }
 
 /// Book 2D histogram.
@@ -1135,9 +1202,14 @@ DQMStore::book2D(const char *name, const char *title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2D(pwd_, name, new TH2F(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2F(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2DHisto(pwd_, name, h);
 }
 
 /// Book 2D histogram.
@@ -1146,9 +1218,14 @@ DQMStore::book2D(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2D(pwd_, name, new TH2F(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2F(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2DHisto(pwd_, name, h);
 }
 
 /// Book 2S histogram.
@@ -1157,9 +1234,14 @@ DQMStore::book2S(const char *name, const char *title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2S(pwd_, name, new TH2S(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2S(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2SHisto(pwd_, name, h);
 }
 
 /// Book 2S histogram.
@@ -1168,9 +1250,14 @@ DQMStore::book2S(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2S(pwd_, name, new TH2S(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2S(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2SHisto(pwd_, name, h);
 }
 
 /// Book 2D double histogram.
@@ -1179,9 +1266,14 @@ DQMStore::book2DD(const char *name, const char *title,
                   int nchX, double lowX, double highX,
                   int nchY, double lowY, double highY)
 {
-  return book2DD(pwd_, name, new TH2D(name, title,
-                                      nchX, lowX, highX,
-                                      nchY, lowY, highY));
+  TH2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2D(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2DDHisto(pwd_, name, h);
 }
 
 /// Book 2S histogram.
@@ -1190,9 +1282,14 @@ DQMStore::book2DD(const std::string &name, const std::string &title,
                   int nchX, double lowX, double highX,
                   int nchY, double lowY, double highY)
 {
-  return book2DD(pwd_, name, new TH2D(name.c_str(), title.c_str(),
-                                      nchX, lowX, highX,
-                                      nchY, lowY, highY));
+  TH2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2D(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2DDHisto(pwd_, name, h);
 }
 
 /// Book 2D variable bin histogram.
@@ -1200,8 +1297,13 @@ MonitorElement *
 DQMStore::book2D(const char *name, const char *title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2D(pwd_, name, new TH2F(name, title,
-                                     nchX, xbinsize, nchY, ybinsize));
+  TH2F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2F(name, title,
+                 nchX, xbinsize, nchY, ybinsize);
+  }
+  return book2DHisto(pwd_, name, h);
 }
 
 /// Book 2D variable bin histogram.
@@ -1209,58 +1311,93 @@ MonitorElement *
 DQMStore::book2D(const std::string &name, const std::string &title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2D(pwd_, name, new TH2F(name.c_str(), title.c_str(),
-                                     nchX, xbinsize, nchY, ybinsize));
+  TH2F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH2F(name.c_str(), title.c_str(),
+                 nchX, xbinsize, nchY, ybinsize);
+  }
+  return book2DHisto(pwd_, name, h);
 }
 
 /// Book 2D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2D(const char *name, TH2F *source)
 {
-  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name)));
+  TH2F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH2F *>(source->Clone(name));
+  }
+  return book2DHisto(pwd_, name, h);
 }
 
 /// Book 2D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2D(const std::string &name, TH2F *source)
 {
-  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name.c_str())));
+  TH2F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH2F *>(source->Clone(name.c_str()));
+  }
+  return book2DHisto(pwd_, name, h);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2S(const char *name, TH2S *source)
 {
-  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name)));
+  TH2S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH2S *>(source->Clone(name));
+  }
+  return book2SHisto(pwd_, name, h);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2S(const std::string &name, TH2S *source)
 {
-  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name.c_str())));
+  TH2S* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH2S *>(source->Clone(name.c_str()));
+  }
+  return book2SHisto(pwd_, name, h);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2DD(const char *name, TH2D *source)
 {
-  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name)));
+  TH2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH2D *>(source->Clone(name));
+  }
+  return book2DDHisto(pwd_, name, h);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2DD(const std::string &name, TH2D *source)
 {
-  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name.c_str())));
+  TH2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH2D *>(source->Clone(name.c_str()));
+  }
+  return book2DDHisto(pwd_, name, h);
 }
 
 // -------------------------------------------------------------------
 /// Book 3D histogram based on TH3F.
 MonitorElement *
-DQMStore::book3D(const std::string &dir, const std::string &name, TH3F *h)
+DQMStore::book3DHisto(const std::string &dir, const std::string &name, TH3F *h)
 {
-  return book(dir, name, "book3D", MonitorElement::DQM_KIND_TH3F, h, collate3D);
+  return bookHisto(dir, name, "book3D", MonitorElement::DQM_KIND_TH3F, h, collate3D);
 }
 
 /// Book 3D histogram.
@@ -1270,10 +1407,15 @@ DQMStore::book3D(const char *name, const char *title,
                  int nchY, double lowY, double highY,
                  int nchZ, double lowZ, double highZ)
 {
-  return book3D(pwd_, name, new TH3F(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY,
-                                     nchZ, lowZ, highZ));
+  TH3F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH3F(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY,
+                 nchZ, lowZ, highZ);
+  }
+  return book3DHisto(pwd_, name, h);
 }
 
 /// Book 3D histogram.
@@ -1283,32 +1425,47 @@ DQMStore::book3D(const std::string &name, const std::string &title,
                  int nchY, double lowY, double highY,
                  int nchZ, double lowZ, double highZ)
 {
-  return book3D(pwd_, name, new TH3F(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY,
-                                     nchZ, lowZ, highZ));
+  TH3F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TH3F(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY,
+                 nchZ, lowZ, highZ);
+  }
+  return book3DHisto(pwd_, name, h);
 }
 
 /// Book 3D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book3D(const char *name, TH3F *source)
 {
-  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name)));
+  TH3F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH3F *>(source->Clone(name));
+  }
+  return book3DHisto(pwd_, name, h);
 }
 
 /// Book 3D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book3D(const std::string &name, TH3F *source)
 {
-  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name.c_str())));
+  TH3F* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TH3F *>(source->Clone(name.c_str()));
+  }
+  return book3DHisto(pwd_, name, h);
 }
 
 // -------------------------------------------------------------------
 /// Book profile histogram based on TProfile.
 MonitorElement *
-DQMStore::bookProfile(const std::string &dir, const std::string &name, TProfile *h)
+DQMStore::bookProfileHisto(const std::string &dir, const std::string &name, TProfile *h)
 {
-  return book(dir, name, "bookProfile",
+  return bookHisto(dir, name, "bookProfile",
               MonitorElement::DQM_KIND_TPROFILE,
               h, collateProfile);
 }
@@ -1322,10 +1479,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name, title,
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1337,10 +1499,15 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1352,10 +1519,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name, title,
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1367,10 +1539,15 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1382,10 +1559,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name, title,
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1397,10 +1579,15 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1412,10 +1599,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name, title,
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1427,32 +1619,47 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book TProfile by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile(const char *name, TProfile *source)
 {
-  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name)));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TProfile *>(source->Clone(name));
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 /// Book TProfile by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile(const std::string &name, TProfile *source)
 {
-  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name.c_str())));
+  TProfile* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TProfile *>(source->Clone(name.c_str()));
+  }
+  return bookProfileHisto(pwd_, name, h);
 }
 
 // -------------------------------------------------------------------
 /// Book 2D profile histogram based on TProfile2D.
 MonitorElement *
-DQMStore::bookProfile2D(const std::string &dir, const std::string &name, TProfile2D *h)
+DQMStore::bookProfile2DHisto(const std::string &dir, const std::string &name, TProfile2D *h)
 {
-  return book(dir, name, "bookProfile2D",
+  return bookHisto(dir, name, "bookProfile2D",
               MonitorElement::DQM_KIND_TPROFILE2D,
               h, collateProfile2D);
 }
@@ -1467,11 +1674,16 @@ DQMStore::bookProfile2D(const char *name, const char *title,
                         int /* nchZ */, double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name, title,
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile2D(name, title,
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2DHisto(pwd_, name, h);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1484,11 +1696,16 @@ DQMStore::bookProfile2D(const std::string &name, const std::string &title,
                         int /* nchZ */, double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile2D(name.c_str(), title.c_str(),
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2DHisto(pwd_, name, h);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1501,11 +1718,16 @@ DQMStore::bookProfile2D(const char *name, const char *title,
                         double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name, title,
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile2D(name, title,
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2DHisto(pwd_, name, h);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1518,25 +1740,40 @@ DQMStore::bookProfile2D(const std::string &name, const std::string &title,
                         double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = new TProfile2D(name.c_str(), title.c_str(),
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2DHisto(pwd_, name, h);
 }
 
 /// Book TProfile2D by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile2D(const char *name, TProfile2D *source)
 {
-  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name)));
+  TProfile2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TProfile2D *>(source->Clone(name));
+  }
+  return bookProfile2DHisto(pwd_, name, h);
 }
 
 /// Book TProfile2D by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile2D(const std::string &name, TProfile2D *source)
 {
-  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name.c_str())));
+  TProfile2D* h;
+  {
+    TDirectory::TContext(nullptr);
+    h = static_cast<TProfile2D *>(source->Clone(name.c_str()));
+  }
+  return bookProfile2DHisto(pwd_, name, h);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2136,9 +2373,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   if (TProfile *h = dynamic_cast<TProfile *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = bookProfile(dir, h->GetName(), (TProfile *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TProfile *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TProfile *) h->Clone();
+      }
+      me = bookProfileHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collateProfile(me, h, verbose_);
@@ -2147,9 +2389,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TProfile2D *h = dynamic_cast<TProfile2D *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = bookProfile2D(dir, h->GetName(), (TProfile2D *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TProfile2D *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TProfile2D *) h->Clone();
+      }
+      me = bookProfile2DHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collateProfile2D(me, h, verbose_);
@@ -2158,9 +2405,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TH1F *h = dynamic_cast<TH1F *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = book1D(dir, h->GetName(), (TH1F *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TH1F *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TH1F *) h->Clone();
+      }
+      me = book1DHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate1D(me, h, verbose_);
@@ -2169,9 +2421,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TH1S *h = dynamic_cast<TH1S *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = book1S(dir, h->GetName(), (TH1S *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TH1S *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TH1S *) h->Clone();
+      }
+      me = book1SHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate1S(me, h, verbose_);
@@ -2180,9 +2437,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TH1D *h = dynamic_cast<TH1D *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = book1DD(dir, h->GetName(), (TH1D *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TH1D *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TH1D *) h->Clone();
+      }
+      me = book1DDHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate1DD(me, h, verbose_);
@@ -2191,9 +2453,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TH2F *h = dynamic_cast<TH2F *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = book2D(dir, h->GetName(), (TH2F *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TH2F *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TH2F *) h->Clone();
+      }
+      me = book2DHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate2D(me, h, verbose_);
@@ -2202,9 +2469,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TH2S *h = dynamic_cast<TH2S *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = book2S(dir, h->GetName(), (TH2S *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TH2S *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TH2S *) h->Clone();
+      }
+      me = book2SHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate2S(me, h, verbose_);
@@ -2213,9 +2485,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TH2D *h = dynamic_cast<TH2D *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = book2DD(dir, h->GetName(), (TH2D *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TH2D *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TH2D *) h->Clone();
+      }
+      me = book2DDHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate2DD(me, h, verbose_);
@@ -2224,9 +2501,14 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   else if (TH3F *h = dynamic_cast<TH3F *>(obj))
   {
     MonitorElement *me = findObject(dir, h->GetName());
-    if (! me)
-      me = book3D(dir, h->GetName(), (TH3F *) h->Clone());
-    else if (overwrite)
+    if (! me) {
+      TH3F *histo;
+      {
+        TDirectory::TContext(nullptr);
+        histo = (TH3F *) h->Clone();
+      }
+      me = book3DHisto(dir, h->GetName(), histo);
+    } else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
       collate3D(me, h, verbose_);

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -4,6 +4,7 @@
 #include "DQMServices/Core/interface/QTest.h"
 #include "DQMServices/Core/src/DQMError.h"
 #include "TClass.h"
+#include "TDirectory.h"
 #include "TMath.h"
 #include "TList.h"
 #include "THashList.h"
@@ -1026,8 +1027,10 @@ MonitorElement::softReset(void)
     TH1F *r = static_cast<TH1F *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TH1F*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TH1F*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1040,8 +1043,10 @@ MonitorElement::softReset(void)
     TH1S *r = static_cast<TH1S *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TH1S*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TH1S*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1054,8 +1059,10 @@ MonitorElement::softReset(void)
     TH1D *r = static_cast<TH1D *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TH1D*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TH1D*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1068,8 +1075,10 @@ MonitorElement::softReset(void)
     TH2F *r = static_cast<TH2F *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TH2F*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TH2F*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1082,8 +1091,10 @@ MonitorElement::softReset(void)
     TH2S *r = static_cast<TH2S *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TH2S*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TH2S*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1096,8 +1107,10 @@ MonitorElement::softReset(void)
     TH2D *r = static_cast<TH2D *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TH2D*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TH2D*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1110,8 +1123,10 @@ MonitorElement::softReset(void)
     TH3F *r = static_cast<TH3F *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TH3F*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TH3F*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1124,8 +1139,10 @@ MonitorElement::softReset(void)
     TProfile *r = static_cast<TProfile *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TProfile*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TProfile*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 
@@ -1138,8 +1155,10 @@ MonitorElement::softReset(void)
     TProfile2D *r = static_cast<TProfile2D *>(refvalue_);
     if (! r)
     {
-      refvalue_ = r = (TProfile2D*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
-      r->SetDirectory(0);
+      {
+        TDirectory::TContext(nullptr);
+        refvalue_ = r = (TProfile2D*)orig->Clone((std::string(orig->GetName()) + "_ref").c_str());
+      }
       r->Reset();
     }
 

--- a/EventFilter/EcalRawToDigi/test/stubs/EcalMatacqHist2.cc
+++ b/EventFilter/EcalRawToDigi/test/stubs/EcalMatacqHist2.cc
@@ -1,5 +1,6 @@
 #include "EcalMatacqHist2.h"
 
+#include "TDirectory.h"
 #include "TH1D.h"
 #include "TProfile.h"
 #include <sstream>
@@ -107,13 +108,15 @@ EcalMatacqHist2:: analyze( const edm::Event & e, const  edm::EventSetup& c){
 		<< " profile";
       std::stringstream profileName;
       profileName << "matacq" << digis.chId();
-      profiles.push_back(TProfile(profileName.str().c_str(),
-				  profTitle.str().c_str(),
-				  digis.size(),
-				  -.5,
-				  -.5+digis.size(),
-				  "I"));
-      profiles.back().SetDirectory(0);//mem. management done by std::vector
+      {
+        TDirectory::TContext(nullptr);//mem. management done by std::vector
+        profiles.emplace_back(profileName.str().c_str(),
+                              profTitle.str().c_str(),
+                              digis.size(),
+                              -.5,
+                              -.5+digis.size(),
+                              "I");
+      }
       profChId.push_back(digis.chId());
     }
     

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
@@ -1,5 +1,6 @@
 #include "EcalMatacqHist.h"
 
+#include "TDirectory.h"
 #include "TProfile.h"
 #include <sstream>
 #include <iostream>
@@ -91,13 +92,15 @@ EcalMatacqHist:: analyze( const edm::Event & e, const  edm::EventSetup& c){
 		<< " profile";
       std::stringstream profileName;
       profileName << "matacq" << digis.chId();
-      profiles.push_back(TProfile(profileName.str().c_str(),
-				  profTitle.str().c_str(),
-				  digis.size(),
-				  -.5,
-				  -.5+digis.size(),
-				  "I"));
-      profiles.back().SetDirectory(0);//mem. management done by std::vector
+      {
+        TDirectory::TContext(nullptr);//mem. management done by std::vector
+        profiles.emplace_back(profileName.str().c_str(),
+                              profTitle.str().c_str(),
+                              digis.size(),
+                              -.5,
+                              -.5+digis.size(),
+                              "I");
+      }
       profChId.push_back(digis.chId());
     }
     

--- a/FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.cc
+++ b/FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.cc
@@ -10,6 +10,7 @@
 
 #include "FastSimulation/ForwardDetectors/plugins/AcceptanceTableHelper.h"
 
+#include "TDirectory.h"
 #include <iostream>
 #include <math.h>
 
@@ -22,9 +23,13 @@ void AcceptanceTableHelper::Init(TFile& f, const std::string basename)
 
   if (h != NULL)
   {
-    h_log10t_log10Xi_Phi = (TH3F*)h->Clone();
+    {
+      // secure it from deleting if the file is eventually closed
+      TDirectory::TContext(nullptr);
+
+      h_log10t_log10Xi_Phi = (TH3F*)h->Clone();
+    }
     std::cout << "Read ";
-    h_log10t_log10Xi_Phi->SetDirectory(0); // secure it from deleting if the file is eventually closed
     h_log10t_log10Xi_Phi->Print();
   } else {
     std::cout << "Warning: could not get acceptance table " << basename << std::endl;
@@ -36,8 +41,12 @@ void AcceptanceTableHelper::Init(TFile& f, const std::string basename)
 
   if (h != NULL)
   {
-    h_t_log10Xi_Phi = (TH3F*)h->Clone();
-    h_t_log10Xi_Phi->SetDirectory(0); // secure it from deleting if the file is eventually closed
+    {
+      // secure it from deleting if the file is eventually closed
+      TDirectory::TContext(nullptr);
+
+      h_t_log10Xi_Phi = (TH3F*)h->Clone();
+    }
     std::cout << "Read ";
     h_t_log10Xi_Phi->Print();
   } else {

--- a/Fireworks/Core/src/FWMagField.cc
+++ b/Fireworks/Core/src/FWMagField.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "TDirectory.h"
 #include "TH1F.h"
 #include "Fireworks/Core/interface/FWMagField.h"
 #include "Fireworks/Core/interface/fwLog.h"
@@ -24,9 +25,11 @@ FWMagField::FWMagField() :
    m_updateFieldEstimate(true),
    m_guessedField(0)
 {
-   m_guessValHist = new TH1F("FieldEstimations", "Field estimations from tracks and muons",
-                             200, -4.5, 4.5);
-   m_guessValHist->SetDirectory(0);
+   {
+      TDirectory::TContext(nullptr);
+      m_guessValHist = new TH1F("FieldEstimations", "Field estimations from tracks and muons",
+                                200, -4.5, 4.5);
+   }
 }
 
 FWMagField::~FWMagField()

--- a/Fireworks/Tracks/plugins/FWTrackResidualDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackResidualDetailView.cc
@@ -1,4 +1,5 @@
 
+#include "TDirectory.h"
 #include "TVector3.h"
 #include "TH2.h"
 #include "TLine.h"
@@ -116,7 +117,11 @@ FWTrackResidualDetailView::build (const FWModelId &id, const reco::Track* track)
    // draw histogram
    m_viewCanvas->cd();
    m_viewCanvas->SetHighLightColor(-1);
-   TH2F* h_res = new TH2F("h_resx","h_resx",10,-5.5,5.5,m_ndet,0,m_ndet);
+   TH2F* h_res;
+   {
+      TDirectory::TContext(nullptr);
+      h_res = new TH2F("h_resx","h_resx",10,-5.5,5.5,m_ndet,0,m_ndet);
+   }
    TPad* padX = new TPad("pad1","pad1", 0.2, 0., 0.8, 0.99);
    padX->SetBorderMode(0);
    padX->SetLeftMargin(0.2);
@@ -124,7 +129,6 @@ FWTrackResidualDetailView::build (const FWModelId &id, const reco::Track* track)
    padX->cd();
    padX->SetFrameLineWidth(0);
    padX->Modified();
-   h_res->SetDirectory(0);
    h_res->SetStats(kFALSE);
    h_res->SetTitle("");
    h_res->SetXTitle("residual");

--- a/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
@@ -2,6 +2,7 @@
 #include "HtrXmlPatternToolParameters.h"
 #include "HtrXmlPatternSet.h"
 #include "HtrXmlPatternWriter.h"
+#include "TDirectory.h"
 #include "TFile.h"
 #include "TH1.h"
 #include <iostream>
@@ -216,18 +217,21 @@ void HtrXmlPatternTool::createHists() {
 	for (int chan=1; chan<=24; chan++) {
 	  ChannelPattern* cp=hd->getPattern(chan);
 	  char hname[128];
-	  sprintf(hname,"Exact fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* hp=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(0);
-	  sprintf(hname,"Quantized fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* hq=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(0);
-	  sprintf(hname,"Encoded fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* ha=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  ha->SetDirectory(0);
+          TH1* hp;
+          TH1* hq;
+          TH1* ha;
+          {
+            TDirectory::TContext(nullptr);
+            sprintf(hname,"Exact fC Cr%d,%d%s-%d",crate,slot,
+                    ((tb==1)?("t"):("b")),chan);
+            hp=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
+            sprintf(hname,"Quantized fC Cr%d,%d%s-%d",crate,slot,
+                    ((tb==1)?("t"):("b")),chan);
+            hq=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
+            sprintf(hname,"Encoded fC Cr%d,%d%s-%d",crate,slot,
+                    ((tb==1)?("t"):("b")),chan);
+            ha=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
+          }
 	  for (int i=0; i<ChannelPattern::SAMPLES; i++) {
 	    hp->Fill(i*1.0,(*cp)[i]);
 	    hq->Fill(i*1.0,cp->getQuantized(i));

--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -2,6 +2,7 @@
 #include <stdexcept>
 //#include "TagProbeFitter.h"
 
+#include "TDirectory.h"
 #include "TROOT.h"
 #include "TFile.h"
 #include "TPad.h"
@@ -781,7 +782,11 @@ void TagProbeFitter::makeEfficiencyPlot1D(RooDataSet& eff, RooRealVar& v, const 
     p->SetPointError(j, -vi.getAsymErrorLo(), vi.getAsymErrorHi(), -ei.getAsymErrorLo(), ei.getAsymErrorHi() );
   }
   TCanvas canvas(plotName);
-  TH1F *frame = new TH1F("frame", "Efficiency of "+effName, 1, v.getMin(), v.getMax()); frame->SetDirectory(0);
+  TH1F *frame;
+  {
+    TDirectory::TContext(nullptr);
+    frame = new TH1F("frame", "Efficiency of "+effName, 1, v.getMin(), v.getMax());
+  }
   p->SetNameTitle(Form("hxy_%s", eff.GetName()), "Efficiency of "+effName);
   p->GetXaxis()->SetTitle(strlen(v.getUnit()) ? Form("%s (%s)", v.GetName(), v.getUnit()) : v.GetName());
   p->GetYaxis()->SetTitle("Efficiency of "+effName);

--- a/PhysicsTools/Utilities/src/SideBandSubtraction.cc
+++ b/PhysicsTools/Utilities/src/SideBandSubtraction.cc
@@ -26,6 +26,7 @@
 #include <TString.h>
 #include <TKey.h>
 #include <TClass.h>
+#include "TDirectory.h"
 
 // RooFit includes
 #include <RooFitResult.h>
@@ -85,10 +86,18 @@ int SideBandSubtract::doSubtraction(RooRealVar* variable, Double_t stsratio,Int_
       cerr << "ERROR: Data or SeparationVariable is NULL returning now!\n";
       return -1;
     }
-  TH1F* SideBandHist = (TH1F*)BaseHistos[index]->Clone();
+  TH1F* SideBandHist;
+  {
+    // TDirectory::TContext(nullptr);
+    SideBandHist = (TH1F*)BaseHistos[index]->Clone();
+  }
   setHistOptions(SideBandHist,(string)variable->GetName()+"Sideband",(string)SideBandHist->GetTitle() + " Sideband",(string)variable->getUnit());
 
-  TH1F* SignalHist = (TH1F*)BaseHistos[index]->Clone();
+  TH1F* SignalHist;
+  {
+    // TDirectory::TContext(nullptr);
+    SignalHist = (TH1F*)BaseHistos[index]->Clone();
+  }
   setHistOptions(SignalHist,(string)variable->GetName()+"SignalHist",(string)SignalHist->GetTitle() + " Raw Signal",(string)variable->getUnit());
 
   //Begin a loop over the data to fill our histograms. I should figure
@@ -125,7 +134,6 @@ int SideBandSubtract::doSubtraction(RooRealVar* variable, Double_t stsratio,Int_
     }
   //Save pre-subtracted histo
   SignalHist->Sumw2(); SideBandHist->Sumw2(); 
-  //SignalHist->SetDirectory(0); SideBandHist->SetDirectory(0);
   RawHistos.push_back(*SignalHist);
 
   SignalHist->Add(SideBandHist, -stsratio);
@@ -388,9 +396,11 @@ SideBandSubtract::SideBandSubtract(RooAbsPdf *model_shape,
       //we own the data this points to so we need to delete it at the end...
       assert(variable!=NULL);
       string title = "base_"+(string)variable->GetName();
-      base_histo = (TH1F*)Data->createHistogram(title.c_str(), *variable, Binning(variable->getBinning("default",verb,kTRUE)) );
+      {
+        // TDirectory::TContext(nullptr);
+        base_histo = (TH1F*)Data->createHistogram(title.c_str(), *variable, Binning(variable->getBinning("default",verb,kTRUE)) );
+      }
       //cout <<"Made histo with name: "<<base_histo->GetName()<<endl;
-      //base_histo->SetDirectory(0);
       BaseHistos.push_back(*base_histo);
       cout <<"Added histo to BaseHistos!\n Deleting local copy...";
       if(base_histo) delete base_histo;

--- a/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
@@ -42,6 +42,8 @@
 // useful utilities collected in the second base
 #include "RecoJets/FFTJetProducers/interface/FFTJetInterface.h"
 
+#include "TDirectory.h"
+
 using namespace fftjetcms;
 
 //
@@ -225,13 +227,17 @@ void FFTJetEFlowSmoother::produce(
     const double bin0edge = g.phiBin0Edge();
 
     // We will fill the following histo
-    std::auto_ptr<TH3F> pTable(
+    std::auto_ptr<TH3F> pTable;
+    {
+      TDirectory::TContext(nullptr);
+
+      pTable.reset(
         new TH3F("FFTJetEFlowSmoother", "FFTJetEFlowSmoother",
                  nScales+1U, -1.5, nScales-0.5,
                  nEta, g.etaMin(), g.etaMax(),
                  nPhi, bin0edge, bin0edge+2.0*M_PI));
+    }
     TH3F* h = pTable.get();
-    h->SetDirectory(0);
     h->GetXaxis()->SetTitle("Scale");
     h->GetYaxis()->SetTitle("Eta");
     h->GetZaxis()->SetTitle("Phi");

--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/src/EcalDeadChannelRecoveryNN.cc
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/src/EcalDeadChannelRecoveryNN.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
 #include <iostream>
+#include "TDirectory.h"
 #include <TMath.h>
 
 template <typename T>
@@ -42,8 +43,11 @@ template <typename T>
 void EcalDeadChannelRecoveryNN<T>::load_file(MultiLayerPerceptronContext& ctx, std::string fn) {
   std::string path = edm::FileInPath(fn).fullPath();
 
-  TTree *t = new TTree("t", "dummy MLP tree");
-  t->SetDirectory(0);
+  TTree *t;
+  {
+    TDirectory::TContext(nullptr);
+    t = new TTree("t", "dummy MLP tree");
+  }
 
   t->Branch("z1", &(ctx.tmp[0]), "z1/D");
   t->Branch("z2", &(ctx.tmp[1]), "z2/D");

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <stdexcept>
 
+#include "TDirectory.h"
 #include <TFile.h>
 #include <TH1F.h>
 #include <TProfile.h>
@@ -47,22 +48,17 @@ MaterialAccountingGroup::MaterialAccountingGroup( const std::string & name, cons
   m_boundingbox.grow(s_tolerance);
 
   // initialize the histograms 
-  m_dedx_spectrum   = new TH1F((m_name + "_dedx_spectrum").c_str(),     "Energy loss spectrum",       1000,    0,   1);
-  m_radlen_spectrum = new TH1F((m_name + "_radlen_spectrum").c_str(),   "Radiation lengths spectrum", 1000,    0,   1);
-  m_dedx_vs_eta     = new TProfile((m_name + "_dedx_vs_eta").c_str(),   "Energy loss vs. eta",         600,   -3,   3);
-  m_dedx_vs_z       = new TProfile((m_name + "_dedx_vs_z").c_str(),     "Energy loss vs. Z",          6000, -300, 300);
-  m_dedx_vs_r       = new TProfile((m_name + "_dedx_vs_r").c_str(),     "Energy loss vs. R",          1200,    0, 120);
-  m_radlen_vs_eta   = new TProfile((m_name + "_radlen_vs_eta").c_str(), "Radiation lengths vs. eta",   600,   -3,   3);
-  m_radlen_vs_z     = new TProfile((m_name + "_radlen_vs_z").c_str(),   "Radiation lengths vs. Z",    6000, -300, 300);
-  m_radlen_vs_r     = new TProfile((m_name + "_radlen_vs_r").c_str(),   "Radiation lengths vs. R",    1200,    0, 120);
-  m_dedx_spectrum->SetDirectory( 0 );
-  m_radlen_spectrum->SetDirectory( 0 );
-  m_dedx_vs_eta->SetDirectory( 0 );
-  m_dedx_vs_z->SetDirectory( 0 );
-  m_dedx_vs_r->SetDirectory( 0 );
-  m_radlen_vs_eta->SetDirectory( 0 );
-  m_radlen_vs_z->SetDirectory( 0 );
-  m_radlen_vs_r->SetDirectory( 0 );
+  {
+    TDirectory::TContext(nullptr);
+    m_dedx_spectrum   = new TH1F((m_name + "_dedx_spectrum").c_str(),     "Energy loss spectrum",       1000,    0,   1);
+    m_radlen_spectrum = new TH1F((m_name + "_radlen_spectrum").c_str(),   "Radiation lengths spectrum", 1000,    0,   1);
+    m_dedx_vs_eta     = new TProfile((m_name + "_dedx_vs_eta").c_str(),   "Energy loss vs. eta",         600,   -3,   3);
+    m_dedx_vs_z       = new TProfile((m_name + "_dedx_vs_z").c_str(),     "Energy loss vs. Z",          6000, -300, 300);
+    m_dedx_vs_r       = new TProfile((m_name + "_dedx_vs_r").c_str(),     "Energy loss vs. R",          1200,    0, 120);
+    m_radlen_vs_eta   = new TProfile((m_name + "_radlen_vs_eta").c_str(), "Radiation lengths vs. eta",   600,   -3,   3);
+    m_radlen_vs_z     = new TProfile((m_name + "_radlen_vs_z").c_str(),   "Radiation lengths vs. Z",    6000, -300, 300);
+    m_radlen_vs_r     = new TProfile((m_name + "_radlen_vs_r").c_str(),   "Radiation lengths vs. R",    1200,    0, 120);
+  }
 }
 
 MaterialAccountingGroup::~MaterialAccountingGroup(void)


### PR DESCRIPTION
This change should yield identical behavior
and remove a thread safety issue.

In ROOT, when a histogram is created, a reference
to it is automatically added to the list of in-memory
objects for the current file or directory.
Calling SetDirectory with a null argument
then removes this reference. This creates a
thread safety issue because multiple threads
could be creating histograms in the same
TFile or directory. In this case, it is all
unnecessary because the SetDirectory call then
removes this reference.

An alternative is to create a TContext object
with a nullptr argument. Then the link is never
created in the first place. This is supposed to
yield identical behavior without the thread
safety problem. It is probably insignificant, but
it likely slightly improves performance as it
eliminates the unnecessary setting and unsetting
of the context references. When the TContext object
goes out of scope the context returns to whatever
it was before the TContext object was created.
