### PR TITLE
Fixing of bunchspacing handling in the SipixelDigitizer Dynamic Inefficiency in 75X

### DIFF
--- a/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
+++ b/SimGeneral/DataMixingModule/plugins/DataMixingSiPixelMCDigiWorker.cc
@@ -217,9 +217,7 @@ namespace edm
 void DataMixingSiPixelMCDigiWorker::init_DynIneffDB(const edm::EventSetup& es, const unsigned int& bunchspace){
   if (AddPixelInefficiency&&!pixelEff_.FromConfig) {
     if (bunchspace == 50) es.get<SiPixelDynamicInefficiencyRcd>().get("50ns",SiPixelDynamicInefficiency_);
-    else if (bunchspace == 25 || bunchspace == 450) es.get<SiPixelDynamicInefficiencyRcd>().get(SiPixelDynamicInefficiency_);
-    //bunchspace == 450 is the default value for mixNoPU case
-    else throw cms::Exception("Database")<<"SiPixelDigitizerAlgorithm encountered unknown bunchspacing configuration: bunchspace = "<<bunchspace;
+    else es.get<SiPixelDynamicInefficiencyRcd>().get(SiPixelDynamicInefficiency_);
     pixelEff_.init_from_db(pDD, SiPixelDynamicInefficiency_);
   }
 }

--- a/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
+++ b/SimTracker/SiPixelDigitizer/plugins/SiPixelDigitizerAlgorithm.cc
@@ -483,9 +483,7 @@ SiPixelDigitizerAlgorithm::PixelEfficiencies::PixelEfficiencies(const edm::Param
 void SiPixelDigitizerAlgorithm::init_DynIneffDB(const edm::EventSetup& es, const unsigned int& bunchspace){
   if (AddPixelInefficiency&&!pixelEfficiencies_.FromConfig) {
     if (bunchspace == 50) es.get<SiPixelDynamicInefficiencyRcd>().get("50ns",SiPixelDynamicInefficiency_);
-    else if (bunchspace == 25 || bunchspace == 450) es.get<SiPixelDynamicInefficiencyRcd>().get(SiPixelDynamicInefficiency_);
-    //bunchspace == 450 is the default value for mixNoPU case
-    else throw cms::Exception("Database")<<"SiPixelDigitizerAlgorithm encountered unknown bunchspacing configuration: bunchspace = "<<bunchspace;
+    else es.get<SiPixelDynamicInefficiencyRcd>().get(SiPixelDynamicInefficiency_);
     pixelEfficiencies_.init_from_db(geom_, SiPixelDynamicInefficiency_);
   }
 }


### PR DESCRIPTION
Fixing the code of treating every bunchspace value as default (25ns) except when bunchspace == 50ns. The problem came up with the HI configurations where they use "bunchspace = 1". For the HI global tag @diguida and @mmusich will upload a trivial (flat) inefficiency payload.

A similar PR is done in 76X.
