### PR TITLE
Implement a well-behaved stacktrace printer.

### DIFF
--- a/FWCore/Services/plugins/Module.cc
+++ b/FWCore/Services/plugins/Module.cc
@@ -30,7 +30,7 @@ typedef edm::serviceregistry::NoArgsMaker<PrintLoadingPlugins> PrintLoadingPlugi
 DEFINE_FWK_SERVICE_MAKER(PrintLoadingPlugins, PrintLoadingPluginsMaker);
 typedef edm::serviceregistry::ParameterSetMaker<edm::SiteLocalConfig,SiteLocalConfigService> SiteLocalConfigMaker;
 DEFINE_FWK_SERVICE_MAKER(SiteLocalConfigService,SiteLocalConfigMaker);
-typedef edm::serviceregistry::ParameterSetMaker<edm::RootHandlers,InitRootHandlers> RootHandlersMaker;
+typedef edm::serviceregistry::AllArgsMaker<edm::RootHandlers,InitRootHandlers> RootHandlersMaker;
 DEFINE_FWK_SERVICE_MAKER(InitRootHandlers, RootHandlersMaker);
 typedef edm::serviceregistry::ParameterSetMaker<UnixSignalService> UnixSignalMaker;
 DEFINE_FWK_SERVICE_MAKER(UnixSignalService, UnixSignalMaker);

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -1,5 +1,6 @@
 #include "FWCore/Services/src/InitRootHandlers.h"
 
+#include "FWCore/ServiceRegistry/interface/ActivityRegistry.h"
 #include "DataFormats/Common/interface/RefCoreStreamer.h"
 #include "FWCore/MessageLogger/interface/ELseverityLevel.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -11,6 +12,7 @@
 #include "FWCore/Utilities/interface/TypeWithDict.h"
 #include "FWCore/Utilities/interface/UnixSignalHandlers.h"
 
+#include <sys/wait.h>
 #include <sstream>
 #include <string.h>
 
@@ -26,6 +28,12 @@
 
 #include "TThread.h"
 #include "TClassTable.h"
+
+namespace edm {
+  namespace service {
+    int cmssw_stacktrace(void *);
+  }
+}
 
 namespace {
   enum class SeverityLevel {
@@ -176,11 +184,31 @@ namespace {
   }
 
   extern "C" {
-    void sig_dostack_then_abort(int sig,siginfo_t*,void*) {
-      if (gSystem) {
-        const char* signalname = "unknown";
-        switch (sig) {
-          case SIGBUS:
+
+    static int full_cerr_write(const char *text)
+    {
+      const char *buffer = text;
+      size_t count = strlen(text);
+      ssize_t written = 0;
+      while (count)
+      {
+        written = write(2, buffer, count);
+        if (written == -1) 
+        {
+          if (errno == EINTR) {continue;}
+          else {return -errno;}
+        }
+        count -= written;
+        buffer += written;
+      }
+      return 0;
+    }
+
+    void sig_dostack_then_abort(int sig, siginfo_t*, void*) {
+
+      const char* signalname = "unknown";
+      switch (sig) {
+        case SIGBUS:
             signalname = "bus error";
             break;
           case SIGSEGV:
@@ -190,15 +218,42 @@ namespace {
             signalname = "illegal instruction"; 
           default:
             break;
-        }
-        edm::LogError("FatalSystemSignal")<<"A fatal system signal has occurred: "<<signalname;
-        std::cerr<< "\n\nA fatal system signal has occurred: "<<signalname<<"\n"
-                 <<"The following is the call stack containing the origin of the signal.\n"
-                 <<"NOTE:The first few functions on the stack are artifacts of processing the signal and can be ignored\n\n";
-        
-        gSystem->StackTrace();
-        std::cerr<<"\nA fatal system signal has occurred: "<<signalname<<"\n";
       }
+      full_cerr_write("\n\nA fatal system signal has occurred: ");
+      full_cerr_write(signalname);
+      full_cerr_write("\nThe following is the call stack containing the origin of the signal.\n"
+        "NOTE:The first few functions on the stack are artifacts of processing the signal and can be ignored\n\n");
+
+      char child_stack[4*1024];
+      char *child_stack_ptr = child_stack + 4*1024;
+        // On Linux, we currently use jemalloc.  This registers pthread_atfork handlers; these
+        // handlers are *not* async-signal safe.  Hence, a deadlock is possible if we invoke
+        // fork() from our signal handlers.  Accordingly, we use clone (not POSIX, but AS-safe)
+        // as that is closer to the 'raw metal' syscall and avoids pthread_atfork handlers.
+      int pid = 
+#ifdef __linux__
+        clone(edm::service::cmssw_stacktrace, child_stack_ptr, CLONE_VFORK|CLONE_VM|CLONE_FS|SIGCHLD, nullptr);
+#else
+        fork();
+      if (child_stack_ptr) {} // Suppress 'unused variable' warning on non-Linux
+      if (pid == 0) {edm::service::cmssw_stacktrace(nullptr); ::abort();}
+#endif
+      if (pid == -1)
+      {
+        full_cerr_write("(Attempt to perform stack dump failed.)\n");
+      }
+      else
+      {
+        int status;
+        if (waitpid(pid, &status, 0) == -1)
+        {
+          full_cerr_write("(Failed to wait on stack dump output.)\n");
+        }
+      }
+
+      full_cerr_write("\nA fatal system signal has occurred: ");
+      full_cerr_write(signalname);
+      full_cerr_write("\n");
       ::abort();
     }
     
@@ -210,7 +265,20 @@ namespace {
 
 namespace edm {
   namespace service {
-    InitRootHandlers::InitRootHandlers (ParameterSet const& pset)
+
+    int cmssw_stacktrace(void * /*arg*/)
+    {
+      char *const *argv = edm::service::InitRootHandlers::getPstackArgv();
+      execv("/usr/bin/pstack", argv);
+      ::abort();
+      return 1;
+    }
+
+    static char pstackName[] = "pstack";
+    char InitRootHandlers::pidString_[InitRootHandlers::pidStringLength_] = {};
+    char * const InitRootHandlers::pstackArgv_[3] = {pstackName, InitRootHandlers::pidString_, nullptr};
+
+    InitRootHandlers::InitRootHandlers (ParameterSet const& pset, ActivityRegistry& iReg)
       : RootHandlers(),
         unloadSigHandler_(pset.getUntrackedParameter<bool> ("UnloadRootSigHandler")),
         resetErrHandler_(pset.getUntrackedParameter<bool> ("ResetRootErrHandler")),
@@ -231,6 +299,8 @@ namespace edm {
         gSystem->ResetSignal(kSigFloatingException);
         gSystem->ResetSignal(kSigWindowChanged);
       } else if(pset.getUntrackedParameter<bool>("AbortOnSignal")){
+        cachePidInfo();
+
         //NOTE: ROOT can also be told to abort on these kinds of problems BUT
         // it requires an TApplication to be instantiated which causes problems
         gSystem->ResetSignal(kSigBus);
@@ -248,6 +318,7 @@ namespace edm {
         sigIllHandler_ = std::shared_ptr<const void>(nullptr,[](void*) {
           installCustomHandler(SIGILL,sig_abort);
         });
+        iReg.watchPostForkReacquireResources(this, &InitRootHandlers::cachePidInfoHandler);
       }
 
       if(resetErrHandler_) {
@@ -327,6 +398,11 @@ namespace edm {
       descriptions.add("InitRootHandlers", desc);
     }
 
+    char *const *
+    InitRootHandlers::getPstackArgv() {
+      return pstackArgv_;
+    }
+
     void
     InitRootHandlers::enableWarnings_() {
       s_ignoreWarnings =false;
@@ -335,6 +411,12 @@ namespace edm {
     void
     InitRootHandlers::ignoreWarnings_() {
       s_ignoreWarnings = true;
+    }
+
+    void
+    InitRootHandlers::cachePidInfo()
+    {
+      assert(snprintf(pidString_, pidStringLength_-1, "%d", getpid()) < pidStringLength_);
     }
 
   }  // end of namespace service

--- a/FWCore/Services/src/InitRootHandlers.cc
+++ b/FWCore/Services/src/InitRootHandlers.cc
@@ -417,13 +417,19 @@ namespace edm {
     void
     InitRootHandlers::cachePidInfo()
     {
-      assert(snprintf(pidString_, pidStringLength_-1, "gdb -quiet -p %d 2>&1 <<EOF |\n"
+      if (snprintf(pidString_, pidStringLength_-1, "gdb -quiet -p %d 2>&1 <<EOF |\n"
         "set width 0\n"
         "set height 0\n"
         "set pagination no\n"
         "thread apply all bt\n"
         "EOF\n"
-        "/bin/sed -n -e 's/^\\((gdb) \\)*//' -e '/^#/p' -e '/^Thread/p'", getpid()) < pidStringLength_);
+        "/bin/sed -n -e 's/^\\((gdb) \\)*//' -e '/^#/p' -e '/^Thread/p'", getpid()) >= pidStringLength_)
+      {
+        std::ostringstream sstr;
+        sstr << "Unable to pre-allocate stacktrace handler information";
+        edm::Exception except(edm::errors::OtherCMS, sstr.str());
+        throw except;
+      }
     }
 
   }  // end of namespace service

--- a/FWCore/Services/src/InitRootHandlers.h
+++ b/FWCore/Services/src/InitRootHandlers.h
@@ -30,9 +30,9 @@ namespace edm {
       void cachePidInfoHandler(unsigned int, unsigned int) {cachePidInfo();}
       void cachePidInfo();
 
-      static const int pidStringLength_ = 50;
+      static const int pidStringLength_ = 200;
       static char pidString_[pidStringLength_];
-      static char * const pstackArgv_[3];
+      static char * const pstackArgv_[];
       bool unloadSigHandler_;
       bool resetErrHandler_;
       bool loadAllDictionaries_;

--- a/FWCore/Services/src/InitRootHandlers.h
+++ b/FWCore/Services/src/InitRootHandlers.h
@@ -7,22 +7,32 @@
 namespace edm {
   class ConfigurationDescriptions;
   class ParameterSet;
+  class ActivityRegistry;
 
   namespace service {
     class InitRootHandlers : public RootHandlers {
 
+      friend int cmssw_stacktrace(void *);
+
     public:
-      explicit InitRootHandlers(ParameterSet const& pset);
+      explicit InitRootHandlers(ParameterSet const& pset, ActivityRegistry& iReg);
       virtual ~InitRootHandlers();
 
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
 
     private:
+      static char *const *getPstackArgv();
       virtual void enableWarnings_() override;
       virtual void ignoreWarnings_() override;
       virtual void willBeUsingThreads() override;
       virtual void initializeThisThreadForUse() override;
 
+      void cachePidInfoHandler(unsigned int, unsigned int) {cachePidInfo();}
+      void cachePidInfo();
+
+      static const int pidStringLength_ = 50;
+      static char pidString_[pidStringLength_];
+      static char * const pstackArgv_[3];
       bool unloadSigHandler_;
       bool resetErrHandler_;
       bool loadAllDictionaries_;


### PR DESCRIPTION
This implements a stack trace printer which is safe to call
from a signal handler (ROOT's stack trace printer is not async-signal
safe; see 'man 7 signal' for more information about async-signal
safety).

Further, on Linux, this utilizes the clone library call directly;
clone has the advantage of avoiding the pthread_atfork handlers.
We have observed that jemalloc currently registers AS-unsafe atfork
handlers, which would cause a deadlock if we use fork().

The commit addresses real deadlocks observed in the Tier-0.
