### PR TITLE
FastSim bug fix: make matched hits aware of order of components (76X, take 3)

### DIFF
--- a/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
+++ b/DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h
@@ -12,6 +12,7 @@ class SiTrackerGSMatchedRecHit2D : public GSSiTrackerRecHit2DLocalPos{
  SiTrackerGSMatchedRecHit2D()
    : GSSiTrackerRecHit2DLocalPos()
     , isMatched_(false)
+    , stereoHitFirst_(false)
     , componentMono_() 
     , componentStereo_()
     {}
@@ -24,6 +25,7 @@ class SiTrackerGSMatchedRecHit2D : public GSSiTrackerRecHit2DLocalPos{
 			      int32_t id)
     : GSSiTrackerRecHit2DLocalPos(pos,err,idet,id,trackerHitRTTI::gsMatch)
     , isMatched_(false)
+    , stereoHitFirst_(false)
     , componentMono_() 
     , componentStereo_()
     {};
@@ -37,6 +39,7 @@ class SiTrackerGSMatchedRecHit2D : public GSSiTrackerRecHit2DLocalPos{
 			      const SiTrackerGSRecHit2D & rStereo) 
     : GSSiTrackerRecHit2DLocalPos(pos,err,idet,id,trackerHitRTTI::gsMatch)
     , isMatched_(isMatched)
+    , stereoHitFirst_(false)
     , componentMono_(rMono) 
     , componentStereo_(rStereo)
     {};
@@ -47,10 +50,14 @@ class SiTrackerGSMatchedRecHit2D : public GSSiTrackerRecHit2DLocalPos{
   const bool &                  isMatched()              const { return isMatched_;}
   const SiTrackerGSRecHit2D &   monoHit()                const { return componentMono_;}
   const SiTrackerGSRecHit2D &   stereoHit()              const { return componentStereo_;}
+  const SiTrackerGSRecHit2D &   firstHit()               const { return stereoHitFirst_ ? componentStereo_ : componentMono_;}
+  const SiTrackerGSRecHit2D &   secondHit()              const { return stereoHitFirst_ ? componentMono_ : componentStereo_;}
+  void setStereoLayerFirst(bool stereoHitFirst = true){stereoHitFirst_ = stereoHitFirst;}
 
  private:
   
   bool isMatched_;
+  bool stereoHitFirst_;
   SiTrackerGSRecHit2D componentMono_;
   SiTrackerGSRecHit2D componentStereo_;
 };

--- a/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
+++ b/DataFormats/TrackerRecHit2D/src/SiTrackerGSMatchedRecHit2D.cc
@@ -1,3 +1,1 @@
-
 #include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2D.h"
-

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -12,7 +12,7 @@
    <version ClassVersion="10" checksum="877294307"/>
   </class>
   <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="15">
-   <version ClassVersion="15" checksum="3882739671"/>
+   <version ClassVersion="15" checksum="3518158739"/>
    <version ClassVersion="14" checksum="1823455267"/>
    <version ClassVersion="13" checksum="1553184391"/>
    <version ClassVersion="12" checksum="2874379530"/>

--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -11,12 +11,13 @@
    <version ClassVersion="11" checksum="1613493049"/>
    <version ClassVersion="10" checksum="877294307"/>
   </class>
-  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="14">
-    <version ClassVersion="14" checksum="3882739671"/>
-    <version ClassVersion="13" checksum="1553184391"/>
-    <version ClassVersion="12" checksum="2874379530"/>
-    <version ClassVersion="11" checksum="1553184391"/>
-    <version ClassVersion="10" checksum="3741285161"/>
+  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="15">
+   <version ClassVersion="15" checksum="3882739671"/>
+   <version ClassVersion="14" checksum="1823455267"/>
+   <version ClassVersion="13" checksum="1553184391"/>
+   <version ClassVersion="12" checksum="2874379530"/>
+   <version ClassVersion="11" checksum="1553184391"/>
+   <version ClassVersion="10" checksum="3741285161"/>
   </class>
 
 

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -137,16 +137,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	if( recHitCandidates[index].matchedHit().firstHit()->simhitId() < recHitCandidates[index].matchedHit().secondHit()->simhitId() )
-	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit().firstHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit().secondHit()->clone());
-	  }
-	else
-	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit().secondHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit().firstHit()->clone());
-	  }
+	trackRecHits.push_back(recHitCandidates[index].matchedHit().firstHit()->clone());
+	trackRecHits.push_back(recHitCandidates[index].matchedHit().secondHit()->clone());
       }
       else {
 	trackRecHits.push_back(recHitCandidates[index].hit()->clone());

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -137,15 +137,15 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	if( recHitCandidates[index].matchedHit()->monoHit()->simhitId() < recHitCandidates[index].matchedHit()->stereoHit()->simhitId() )
+	if( recHitCandidates[index].matchedHit().firstHit()->simhitId() < recHitCandidates[index].matchedHit().secondHit()->simhitId() )
 	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit().firstHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit().secondHit()->clone());
 	  }
 	else
 	  {
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
-	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit().secondHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit().firstHit()->clone());
 	  }
       }
       else {

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -137,8 +137,16 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit().clone());
-	trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit().clone());
+	if( recHitCandidates[index].matchedHit()->monoHit()->simhitId() < recHitCandidates[index].matchedHit()->stereoHit()->simhitId() )
+	  {
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
+	  }
+	else
+	  {
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->stereoHit()->clone());
+	    trackRecHits.push_back(recHitCandidates[index].matchedHit()->monoHit()->clone());
+	  }
       }
       else {
 	trackRecHits.push_back(recHitCandidates[index].hit()->clone());

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -137,8 +137,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::OwnVector<TrackingRecHit> trackRecHits;
     for ( unsigned index = 0; index<recHitCandidates.size(); ++index ) {
       if(splitHits && recHitCandidates[index].matchedHit()->isMatched()){
-	trackRecHits.push_back(recHitCandidates[index].matchedHit().firstHit()->clone());
-	trackRecHits.push_back(recHitCandidates[index].matchedHit().secondHit()->clone());
+	trackRecHits.push_back(recHitCandidates[index].matchedHit()->firstHit().clone());
+	trackRecHits.push_back(recHitCandidates[index].matchedHit()->secondHit().clone());
       }
       else {
 	trackRecHits.push_back(recHitCandidates[index].hit()->clone());

--- a/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
@@ -1217,7 +1217,7 @@ SiTrackerGaussianSmearingRecHitConverter::matchHits(
 	    if(partnersFound == 1) {
 	      SiTrackerGSMatchedRecHit2D theMatchedHit = GSRecHitMatcher().match( &(*partner),  &(*rit),  gluedDet  , gluedsimtrackdir );
 	      if(partner == partnerNext)
-		theMatchedHit->setStereoLayerFirst();
+		theMatchedHit.setStereoLayerFirst();
 
 	      //	      std::cout << "Matched  hit: isMatched =\t" << theMatchedHit->isMatched() << ", "
 	      //	<<  theMatchedHit->monoHit() << ", " <<  theMatchedHit->stereoHit() << std::endl;

--- a/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
+++ b/FastSimulation/TrackingRecHitProducer/plugins/SiTrackerGaussianSmearingRecHitConverter.cc
@@ -1216,7 +1216,8 @@ SiTrackerGaussianSmearingRecHitConverter::matchHits(
 
 	    if(partnersFound == 1) {
 	      SiTrackerGSMatchedRecHit2D theMatchedHit = GSRecHitMatcher().match( &(*partner),  &(*rit),  gluedDet  , gluedsimtrackdir );
-
+	      if(partner == partnerNext)
+		theMatchedHit->setStereoLayerFirst();
 
 	      //	      std::cout << "Matched  hit: isMatched =\t" << theMatchedHit->isMatched() << ", "
 	      //	<<  theMatchedHit->monoHit() << ", " <<  theMatchedHit->stereoHit() << std::endl;


### PR DESCRIPTION
replaces #10111 ...
