### PR TITLE
track association update only for valid indices

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -233,7 +233,8 @@ void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::Eve
 
     // Fix track association for sorted candidates
     for(size_t i=0,ntk=mappingTk.size();i<ntk;i++){
-        mappingTk[i]=reverseOrder[mappingTk[i]]; 
+        int origInd = mappingTk[i];
+        if (origInd>=0 ) mappingTk[i]=reverseOrder[origInd]; 
     }
 
     for(size_t i=0,ntk=mappingPuppi.size();i<ntk;i++){


### PR DESCRIPTION
fixes crash reported in 
https://hypernews.cern.ch/HyperNews/CMS/get/recoDevelopment/1375.html
