### PR TITLE
Comment out ROOT6 specific call in ROOT5 release

### DIFF
--- a/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.cc
+++ b/DQM/CSCMonitorModule/plugins/CSCDQM_Collection.cc
@@ -532,7 +532,7 @@ namespace cscdqm {
       if(checkHistoValue(p, "SetXLabels", s)) {
         std::map<int, std::string> labels;
         ParseAxisLabels(s, labels);
-        th->GetXaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
+        // th->GetXaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
         for (std::map<int, std::string>::iterator l_itr = labels.begin(); l_itr != labels.end(); ++l_itr) {
           th->GetXaxis()->SetBinLabel(l_itr->first, l_itr->second.c_str());
         }
@@ -540,7 +540,7 @@ namespace cscdqm {
       if(checkHistoValue(p, "SetYLabels", s)) {
         std::map<int, std::string> labels;
         ParseAxisLabels(s, labels);
-        th->GetYaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
+        // th->GetYaxis()->SetNoAlphanumeric(); // For ROOT6 to prevent getting zero means values
         for (std::map<int, std::string>::iterator l_itr = labels.begin(); l_itr != labels.end(); ++l_itr) {
           th->GetYaxis()->SetBinLabel(l_itr->first, l_itr->second.c_str());
         }


### PR DESCRIPTION
Trivial and technical.
This PR fixes the compilation error in CMSSW_7_4_ROOT5_X by commenting out two calls to a ROOT6 specific function, undoing a change that was automatically merged from CMSSW_7_4_X.
