### PR TITLE
Back out ROOT6 specific change from ROOT 5 release

### DIFF
--- a/DPGAnalysis/SiStripTools/bin/DPGAnalysisSiStripToolsMacrosLinkDef.h
+++ b/DPGAnalysis/SiStripTools/bin/DPGAnalysisSiStripToolsMacrosLinkDef.h
@@ -52,5 +52,5 @@
 #pragma link C++ function ComputeOOTFractionvsFill;
 #pragma link C++ class OOTResult;
 #pragma link C++ class OOTSummary;
-#pragma link C++ function BSvsBPIX;
+#pragma link C++ function BSvsBPIXPlot;
 #endif

--- a/DPGAnalysis/SiStripTools/plugins/L1ABCDebugger.cc
+++ b/DPGAnalysis/SiStripTools/plugins/L1ABCDebugger.cc
@@ -155,11 +155,11 @@ L1ABCDebugger::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   }
   if(m_horboffvsorb && *m_horboffvsorb) {
     (*m_horboffvsorb)->GetXaxis()->SetTitle("Orbit");    (*m_horboffvsorb)->GetYaxis()->SetTitle("#Delta orbit (SCAL-Event)");
-    (*m_horboffvsorb)->SetCanExtend(TH1::kXaxis);
+    (*m_horboffvsorb)->SetBit(TH1::kCanRebin);
   }
   if(m_hbxoffvsorb && *m_hbxoffvsorb) {
     (*m_hbxoffvsorb)->GetXaxis()->SetTitle("Orbit");    (*m_hbxoffvsorb)->GetYaxis()->SetTitle("#Delta BX (SCAL-Event)");
-    (*m_hbxoffvsorb)->SetCanExtend(TH1::kXaxis);
+    (*m_hbxoffvsorb)->SetBit(TH1::kCanRebin);
   }
 
 


### PR DESCRIPTION
This PR fixes the compilation errors in  DPGAnalysis/SiStripTools in CMSSW_7_5_ROOT5_X.
It backs out a ROOT6 specific change, and corrects the name of a misspelled function.
