### PR TITLE
Try converting RecoParticleFlow/PFTracking to GBRForest + GlobalCache

### DIFF
--- a/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
+++ b/RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h
@@ -47,20 +47,20 @@ class PFEnergyCalibration
   double energyEm(const reco::PFCluster& clusterEcal,
 		  std::vector<double> &EclustersPS1,
 		  std::vector<double> &EclustersPS2,
-		  bool crackCorrection = true);
+		  bool crackCorrection = true) const;
   double energyEm(const reco::PFCluster& clusterEcal,
 		  double ePS1,  double ePS2,
-		  bool crackCorrection = true);
+		  bool crackCorrection = true) const;
 
   double energyEm(const reco::PFCluster& clusterEcal,
 		  std::vector<double> &EclustersPS1,
 		  std::vector<double> &EclustersPS2,
 		  double &ps1,double&ps2,
-		  bool crackCorrection=true);
+		  bool crackCorrection=true) const;
   double energyEm(const reco::PFCluster& clusterEcal,
 		  double ePS1, double ePS2,
 		  double &ps1,double&ps2,
-		  bool crackCorrection=true);
+		  bool crackCorrection=true) const;
 
   // ECAL+HCAL (abc) calibration, with E and eta dependent coefficients, for hadrons
   void energyEmHad(double t, double& e, double&h, double eta, double phi) const;
@@ -97,22 +97,22 @@ class PFEnergyCalibration
 
  private:
   
-  double minimum(double a,double b);
-  double dCrackPhi(double phi, double eta);
-  double CorrPhi(double phi, double eta);
-  double CorrEta(double eta);
-  double CorrBarrel(double E, double eta);
-  double Alpha(double eta);
-  double Beta(double E, double eta);
-  double Gamma(double etaEcal);
-  double EcorrBarrel(double E, double eta, double phi, bool crackCorrection=true);
-  double EcorrZoneBeforePS(double E, double eta);
-  double EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal);
-  double EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal,double&, double&);
-  double EcorrPS_ePSNil(double eEcal,double eta);
-  double EcorrZoneAfterPS(double E, double eta);
-  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,bool crackCorrection=true);
-  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double&,double&,bool crackCorrection=true);
+  double minimum(double a,double b) const;
+  double dCrackPhi(double phi, double eta) const;
+  double CorrPhi(double phi, double eta) const;
+  double CorrEta(double eta) const;
+  double CorrBarrel(double E, double eta) const;
+  double Alpha(double eta) const;
+  double Beta(double E, double eta) const;
+  double Gamma(double etaEcal) const;
+  double EcorrBarrel(double E, double eta, double phi, bool crackCorrection=true) const;
+  double EcorrZoneBeforePS(double E, double eta) const;
+  double EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal) const;
+  double EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal,double&, double&) const;
+  double EcorrPS_ePSNil(double eEcal,double eta) const;
+  double EcorrZoneAfterPS(double E, double eta) const;
+  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,bool crackCorrection=true) const;
+  double Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double&,double&,bool crackCorrection=true) const;
 
   // The calibration functions
   double aBarrel(double x) const;

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
@@ -385,7 +385,7 @@ double
 PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
 			      std::vector<double> &EclustersPS1,
 			      std::vector<double> &EclustersPS2,
-			      bool crackCorrection ){
+			      bool crackCorrection ) const {
   double ePS1(std::accumulate(EclustersPS1.begin(), EclustersPS1.end(), 0.0));
   double ePS2(std::accumulate(EclustersPS2.begin(), EclustersPS2.end(), 0.0));
   return energyEm(clusterEcal, ePS1, ePS2, crackCorrection);
@@ -395,7 +395,7 @@ double
 PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
 			      double ePS1,
 			      double ePS2,
-			      bool crackCorrection ){
+			      bool crackCorrection ) const {
   double eEcal = clusterEcal.energy();
   //temporaty ugly fix
   reco::PFCluster myPFCluster=clusterEcal;
@@ -412,7 +412,7 @@ double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
 				     std::vector<double> &EclustersPS1,
 				     std::vector<double> &EclustersPS2,
 				     double& ps1,double& ps2,
-				     bool crackCorrection){
+				     bool crackCorrection) const {
   double ePS1(std::accumulate(EclustersPS1.begin(), EclustersPS1.end(), 0.0));
   double ePS2(std::accumulate(EclustersPS2.begin(), EclustersPS2.end(), 0.0));
   return energyEm(clusterEcal, ePS1, ePS2, ps1, ps2, crackCorrection);
@@ -420,7 +420,7 @@ double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
 double PFEnergyCalibration::energyEm(const reco::PFCluster& clusterEcal,
 				     double ePS1, double ePS2,
 				     double& ps1,double& ps2,
-				     bool crackCorrection){
+				     bool crackCorrection) const {
   double eEcal = clusterEcal.energy();
   //temporaty ugly fix
   reco::PFCluster myPFCluster=clusterEcal;
@@ -514,7 +514,7 @@ std::ostream& operator<<(std::ostream& out,
 
 //useful to compute the signed distance to the closest crack in the barrel
 double
-PFEnergyCalibration::minimum(double a,double b){
+PFEnergyCalibration::minimum(double a,double b) const {
   if(TMath::Abs(b)<TMath::Abs(a)) a=b;
   return a;
 }
@@ -538,7 +538,7 @@ namespace {
 
 //compute the unsigned distance to the closest phi-crack in the barrel
 double
-PFEnergyCalibration::dCrackPhi(double phi, double eta){
+PFEnergyCalibration::dCrackPhi(double phi, double eta) const {
 
   
   //Shift of this location if eta<0
@@ -580,7 +580,7 @@ PFEnergyCalibration::dCrackPhi(double phi, double eta){
 
 // corrects the effect of phi-cracks
 double
-PFEnergyCalibration::CorrPhi(double phi, double eta) {
+PFEnergyCalibration::CorrPhi(double phi, double eta) const {
 
   // we use 3 gaussians to correct the phi-cracks effect
   constexpr double p1=   5.59379e-01;
@@ -606,7 +606,7 @@ PFEnergyCalibration::CorrPhi(double phi, double eta) {
 
 // corrects the effect of  |eta|-cracks
 double
-PFEnergyCalibration::CorrEta(double eta){
+PFEnergyCalibration::CorrEta(double eta) const {
   
   // we use a gaussian with a screwness for each of the 5 |eta|-cracks
   constexpr double a[] = {6.13349e-01, 5.08146e-01, 4.44480e-01, 3.3487e-01, 7.65627e-01}; // amplitude
@@ -624,7 +624,7 @@ PFEnergyCalibration::CorrEta(double eta){
 
 //corrects the global behaviour in the barrel
 double
-PFEnergyCalibration::CorrBarrel(double E, double eta) {
+PFEnergyCalibration::CorrBarrel(double E, double eta) const {
 
   //Energy dependency
   /*
@@ -670,7 +670,7 @@ PFEnergyCalibration::CorrBarrel(double E, double eta) {
 // Etot = Beta*eEcal + Gamma*(ePS1 + Alpha*ePS2) 
 
 double
-PFEnergyCalibration::Alpha(double eta) {
+PFEnergyCalibration::Alpha(double eta) const {
 
   //Energy dependency
   constexpr double p0 = 5.97621e-01;
@@ -688,7 +688,7 @@ PFEnergyCalibration::Alpha(double eta) {
 }
 
 double
-PFEnergyCalibration::Beta(double E, double eta) {
+PFEnergyCalibration::Beta(double E, double eta) const {
 
  //Energy dependency
   constexpr double p0 = 0.032;
@@ -709,7 +709,7 @@ PFEnergyCalibration::Beta(double E, double eta) {
 
 
 double
-PFEnergyCalibration::Gamma(double etaEcal) {
+PFEnergyCalibration::Gamma(double etaEcal) const {
 
  //Energy dependency
   constexpr double p0 = 2.49752e-02;
@@ -739,7 +739,7 @@ PFEnergyCalibration::Gamma(double etaEcal) {
 // Global Behaviour, phi and eta cracks are taken into account
 double
 PFEnergyCalibration::EcorrBarrel(double E, double eta, double phi,
-				 bool crackCorrection ){
+				 bool crackCorrection ) const {
 
   // double result = E*CorrBarrel(E,eta)*CorrEta(eta)*CorrPhi(phi,eta);
   double correction = crackCorrection ? std::max(CorrEta(eta),CorrPhi(phi,eta)) : 1.;
@@ -751,7 +751,7 @@ PFEnergyCalibration::EcorrBarrel(double E, double eta, double phi,
 
 // returns the corrected energy in the area between the barrel and the PS (1.48,1.65)
 double
-PFEnergyCalibration::EcorrZoneBeforePS(double E, double eta){
+PFEnergyCalibration::EcorrZoneBeforePS(double E, double eta) const {
 
  //Energy dependency
   constexpr double p0 =1; 
@@ -777,7 +777,7 @@ PFEnergyCalibration::EcorrZoneBeforePS(double E, double eta){
 // returns the corrected energy in the PS (1.65,2.6)
 // only when (ePS1>0)||(ePS2>0)
 double
-PFEnergyCalibration::EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal) {
+PFEnergyCalibration::EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal) const {
 
   // gives the good weights to each subdetector
   double E = Beta(1.0155*eEcal+0.025*(ePS1+0.5976*ePS2)/9e-5,etaEcal)*eEcal+Gamma(etaEcal)*(ePS1+Alpha(etaEcal)*ePS2)/9e-5 ;
@@ -797,7 +797,7 @@ PFEnergyCalibration::EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal
 // returns the corrected energy in the PS (1.65,2.6)
 // only when (ePS1>0)||(ePS2>0)
 double
-PFEnergyCalibration::EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal,double & outputPS1, double & outputPS2) {
+PFEnergyCalibration::EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal,double & outputPS1, double & outputPS2) const {
 
   // gives the good weights to each subdetector
   double gammaprime=Gamma(etaEcal)/9e-5;
@@ -824,7 +824,7 @@ PFEnergyCalibration::EcorrPS(double eEcal,double ePS1,double ePS2,double etaEcal
 // returns the corrected energy in the PS (1.65,2.6)
 // only when (ePS1=0)&&(ePS2=0)
 double 
-PFEnergyCalibration::EcorrPS_ePSNil(double eEcal,double eta){
+PFEnergyCalibration::EcorrPS_ePSNil(double eEcal,double eta) const {
 
   //Energy dependency
   constexpr double p0= 1.02;
@@ -847,7 +847,7 @@ PFEnergyCalibration::EcorrPS_ePSNil(double eEcal,double eta){
 
 // returns the corrected energy in the area between the end of the PS and the end of the endcap (2.6,2.98)
 double
-PFEnergyCalibration::EcorrZoneAfterPS(double E, double eta){
+PFEnergyCalibration::EcorrZoneAfterPS(double E, double eta) const {
 
   //Energy dependency
   constexpr double p0 =1; 
@@ -882,7 +882,7 @@ PFEnergyCalibration::EcorrZoneAfterPS(double E, double eta){
 double
 PFEnergyCalibration::Ecorr(double eEcal,double ePS1,double ePS2,
 			   double eta,double phi,
-			   bool crackCorrection ) {
+			   bool crackCorrection ) const {
 
   constexpr double endBarrel=1.48;
   constexpr double beginingPS=1.65;
@@ -910,7 +910,7 @@ PFEnergyCalibration::Ecorr(double eEcal,double ePS1,double ePS2,
 // returns the corrected energy everywhere
 // this work should be improved between 1.479 and 1.52 (junction barrel-endcap)
 double
-PFEnergyCalibration::Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double& ps1,double&ps2,bool crackCorrection)  {
+PFEnergyCalibration::Ecorr(double eEcal,double ePS1,double ePS2,double eta,double phi,double& ps1,double&ps2,bool crackCorrection)  const {
 
   constexpr double endBarrel=1.48;
   constexpr double beginingPS=1.65;

--- a/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
+++ b/RecoParticleFlow/PFClusterTools/src/PFEnergyCalibration.cc
@@ -164,7 +164,7 @@ PFEnergyCalibration::energyEmHad(double t, double& e, double&h, double eta, doub
     etaCorrE = 1. + aEtaBarrel(t) + 2.2*bEtaBarrel(t)*std::abs(eta)*std::abs(eta);
     etaCorrH = 1.;
     // etaCorr = 1.;
-    t = max(tt, thresh+etaCorrE*a*e+etaCorrH*b*h);
+    //t = max(tt, thresh+etaCorrE*a*e+etaCorrH*b*h);
 
     if ( e > 0. && thresh > 0. ) 
       e = h > 0. ? threshE-threshH + etaCorrE * a * e : threshE + etaCorrE * a * e;
@@ -196,7 +196,7 @@ PFEnergyCalibration::energyEmHad(double t, double& e, double&h, double eta, doub
     etaCorrE = 1. + aEtaEndcap(t) + 0.1*bEtaEndcap(t)*etaPow;
     etaCorrH = 1. + aEtaEndcap(t) + bEtaEndcap(t)*etaPow;
     
-    t = min(999.9,max(tt, thresh + etaCorrE*a*e + etaCorrH*b*h));
+    //t = min(999.9,max(tt, thresh + etaCorrE*a*e + etaCorrH*b*h));
 
     if ( e > 0. && thresh > 0. ) 
       e = h > 0. ? threshE-threshH + etaCorrE * a * e : threshE + etaCorrE * a * e;

--- a/RecoParticleFlow/PFTracking/BuildFile.xml
+++ b/RecoParticleFlow/PFTracking/BuildFile.xml
@@ -30,6 +30,7 @@
 <use   name="RecoVertex/AdaptiveVertexFit"/>
 <use   name="TrackingTools/IPTools"/>
 <use   name="DataFormats/VertexReco"/>
+<use   name="CondFormats/EgammaObjects"/>
 <use   name="rootcore"/>
 <use   name="roottmva"/>
 <export>

--- a/RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h
+++ b/RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h
@@ -11,13 +11,13 @@ namespace convbremhelpers {
   class HeavyObjectCache {
   public:
     HeavyObjectCache(const edm::ParameterSet&);
-    std::unique_ptr<GBRForest> gbrBarrelLowPt_;
-    std::unique_ptr<GBRForest> gbrBarrelHighPt_;
-    std::unique_ptr<GBRForest> gbrEndcapsLowPt_;
-    std::unique_ptr<GBRForest> gbrEndcapsHighPt_;
-    std::unique_ptr<PFEnergyCalibration> pfcalib_;
+    std::unique_ptr<const GBRForest> gbrBarrelLowPt_;
+    std::unique_ptr<const GBRForest> gbrBarrelHighPt_;
+    std::unique_ptr<const GBRForest> gbrEndcapsLowPt_;
+    std::unique_ptr<const GBRForest> gbrEndcapsHighPt_;
+    std::unique_ptr<const PFEnergyCalibration> pfcalib_;
   private:
-    std::unique_ptr<GBRForest> setupMVA(const std::string&);
+    std::unique_ptr<const GBRForest> setupMVA(const std::string&);
     // for variable binding
     float secR, sTIP, nHITS1, Epout, detaBremKF, ptRatioGsfKF;
   };

--- a/RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h
+++ b/RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h
@@ -1,0 +1,26 @@
+#ifndef __RecoParticleFlow_PFTracking_convbremhelpersHeavyObjectCache_h__
+#define __RecoParticleFlow_PFTracking_convbremhelpersHeavyObjectCache_h__
+
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"
+#include <memory>
+
+namespace convbremhelpers {
+  class HeavyObjectCache {
+  public:
+    HeavyObjectCache(const edm::ParameterSet&);
+    std::unique_ptr<GBRForest> gbrBarrelLowPt_;
+    std::unique_ptr<GBRForest> gbrBarrelHighPt_;
+    std::unique_ptr<GBRForest> gbrEndcapsLowPt_;
+    std::unique_ptr<GBRForest> gbrEndcapsHighPt_;
+    std::unique_ptr<PFEnergyCalibration> pfcalib_;
+  private:
+    std::unique_ptr<GBRForest> setupMVA(const std::string&);
+    // for variable binding
+    float secR, sTIP, nHITS1, Epout, detaBremKF, ptRatioGsfKF;
+  };
+}
+
+#endif

--- a/RecoParticleFlow/PFTracking/interface/ConvBremPFTrackFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/ConvBremPFTrackFinder.h
@@ -25,6 +25,9 @@
 #include "DataFormats/ParticleFlowReco/interface/PFV0.h"
 #include "TMVA/Reader.h"
 
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include <memory>
+
 class PFEnergyCalibration;
 
 class ConvBremPFTrackFinder {
@@ -82,16 +85,20 @@ class ConvBremPFTrackFinder {
   TransientTrackBuilder builder_;
   double mvaBremConvCutBarrelLowPt_,mvaBremConvCutBarrelHighPt_,mvaBremConvCutEndcapsLowPt_,mvaBremConvCutEndcapsHighPt_;
   std::string mvaWeightFileConvBremBarrelLowPt_, mvaWeightFileConvBremBarrelHighPt_,mvaWeightFileConvBremEndcapsLowPt_,mvaWeightFileConvBremEndcapsHighPt_;
-  TMVA::Reader    *tmvaReaderBarrelLowPt_;
-  TMVA::Reader    *tmvaReaderBarrelHighPt_;
-  TMVA::Reader    *tmvaReaderEndcapsLowPt_;
-  TMVA::Reader    *tmvaReaderEndcapsHighPt_;  
+  std::unique_ptr<TMVA::Reader> tmvaReaderBarrelLowPt_;
+  std::unique_ptr<TMVA::Reader> tmvaReaderBarrelHighPt_;
+  std::unique_ptr<TMVA::Reader> tmvaReaderEndcapsLowPt_;
+  std::unique_ptr<TMVA::Reader> tmvaReaderEndcapsHighPt_;  
+  std::unique_ptr<GBRForest> gbrBarrelLowPt_;
+  std::unique_ptr<GBRForest> gbrBarrelHighPt_;
+  std::unique_ptr<GBRForest> gbrEndcapsLowPt_;
+  std::unique_ptr<GBRForest> gbrEndcapsHighPt_;  
 
   std::vector<reco::PFRecTrackRef> pfRecTrRef_vec_;
   float secR,secPout,ptRatioGsfKF,sTIP,Epout,detaBremKF,secPin;
   //int nHITS1;
   float nHITS1;
 
-  PFEnergyCalibration* pfcalib_;
+  std::unique_ptr<PFEnergyCalibration> pfcalib_;
 
 };

--- a/RecoParticleFlow/PFTracking/interface/ConvBremPFTrackFinder.h
+++ b/RecoParticleFlow/PFTracking/interface/ConvBremPFTrackFinder.h
@@ -28,6 +28,8 @@
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 #include <memory>
 
+#include "RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h"
+
 class PFEnergyCalibration;
 
 class ConvBremPFTrackFinder {
@@ -37,12 +39,7 @@ class ConvBremPFTrackFinder {
 			double mvaBremConvCutBarrelLowPt,
 			double mvaBremConvCutBarrelHighPt,
 			double mvaBremConvCutEndcapsLowPt,	     
-			double mvaBremConvCutEndcapsHighPt,
-			std::string mvaWeightFileConvBremBarrelLowPt,
-			std::string mvaWeightFileConvBremBarrelHighPt,
-			std::string mvaWeightFileConvBremEndcapsLowPt,
-			std::string mvaWeightFileConvBremEndcapsHighPt
-			);
+			double mvaBremConvCutEndcapsHighPt);
   ~ConvBremPFTrackFinder();
   
   bool foundConvBremPFRecTrack(const edm::Handle<reco::PFRecTrackCollection>& thePfRecTrackCol,
@@ -50,6 +47,7 @@ class ConvBremPFTrackFinder {
 			       const edm::Handle<reco::PFDisplacedTrackerVertexCollection>& pfNuclears,
 			       const edm::Handle<reco::PFConversionCollection >& pfConversions,
 			       const edm::Handle<reco::PFV0Collection >& pfV0,
+                               const convbremhelpers::HeavyObjectCache* cache,
 			       bool useNuclear,
 			       bool useConversions,
 			       bool useV0,
@@ -59,7 +57,7 @@ class ConvBremPFTrackFinder {
     found_ = false;
     runConvBremFinder(thePfRecTrackCol,primaryVertex,
 		      pfNuclears,pfConversions,
-		      pfV0,useNuclear,
+		      pfV0,cache,useNuclear,
 		      useConversions,useV0,
 		      theEClus,gsfpfrectk);
     return found_;};
@@ -73,6 +71,7 @@ class ConvBremPFTrackFinder {
 			 const edm::Handle<reco::PFDisplacedTrackerVertexCollection>& pfNuclears,
 			 const edm::Handle<reco::PFConversionCollection >& pfConversions,
 			 const edm::Handle<reco::PFV0Collection >& pfV0,
+                         const convbremhelpers::HeavyObjectCache* cache,
 			 bool useNuclear,
 			 bool useConversions,
 			 bool useV0,
@@ -84,21 +83,10 @@ class ConvBremPFTrackFinder {
   bool found_;
   TransientTrackBuilder builder_;
   double mvaBremConvCutBarrelLowPt_,mvaBremConvCutBarrelHighPt_,mvaBremConvCutEndcapsLowPt_,mvaBremConvCutEndcapsHighPt_;
-  std::string mvaWeightFileConvBremBarrelLowPt_, mvaWeightFileConvBremBarrelHighPt_,mvaWeightFileConvBremEndcapsLowPt_,mvaWeightFileConvBremEndcapsHighPt_;
-  std::unique_ptr<TMVA::Reader> tmvaReaderBarrelLowPt_;
-  std::unique_ptr<TMVA::Reader> tmvaReaderBarrelHighPt_;
-  std::unique_ptr<TMVA::Reader> tmvaReaderEndcapsLowPt_;
-  std::unique_ptr<TMVA::Reader> tmvaReaderEndcapsHighPt_;  
-  std::unique_ptr<GBRForest> gbrBarrelLowPt_;
-  std::unique_ptr<GBRForest> gbrBarrelHighPt_;
-  std::unique_ptr<GBRForest> gbrEndcapsLowPt_;
-  std::unique_ptr<GBRForest> gbrEndcapsHighPt_;  
-
+  
   std::vector<reco::PFRecTrackRef> pfRecTrRef_vec_;
   float secR,secPout,ptRatioGsfKF,sTIP,Epout,detaBremKF,secPin;
   //int nHITS1;
   float nHITS1;
-
-  std::unique_ptr<PFEnergyCalibration> pfcalib_;
 
 };

--- a/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
+++ b/RecoParticleFlow/PFTracking/interface/PFElecTkProducer.h
@@ -25,6 +25,8 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/ParticleFlowReco/interface/PFDisplacedTrackerVertex.h"
 
+#include "RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h"
+
 class PFTrackTransformer;
 class GsfTrack;
 class MagneticField;
@@ -41,11 +43,22 @@ class ConvBremPFTrackFinder;
  and transform them in PFGsfRecTracks.
 */
 
-class PFElecTkProducer final : public edm::stream::EDProducer<> {
+
+
+class PFElecTkProducer final : public edm::stream::EDProducer<edm::GlobalCache<convbremhelpers::HeavyObjectCache> > {
  public:
   
      ///Constructor
-     explicit PFElecTkProducer(const edm::ParameterSet&);
+  explicit PFElecTkProducer(const edm::ParameterSet&, const convbremhelpers::HeavyObjectCache*);
+
+
+  static std::unique_ptr<convbremhelpers::HeavyObjectCache> 
+    initializeGlobalCache( const edm::ParameterSet& conf ) {
+       return std::unique_ptr<convbremhelpers::HeavyObjectCache>(new convbremhelpers::HeavyObjectCache(conf));
+   }
+  
+  static void globalEndJob(convbremhelpers::HeavyObjectCache const* ) {
+  }
 
      ///Destructor
      ~PFElecTkProducer();
@@ -120,10 +133,10 @@ class PFElecTkProducer final : public edm::stream::EDProducer<> {
       double dphiCutGsfClean_;
 
       ///PFTrackTransformer
-      PFTrackTransformer *pfTransformer_;     
+      std::unique_ptr<PFTrackTransformer> pfTransformer_;     
       const MultiTrajectoryStateMode *mtsMode_;
       MultiTrajectoryStateTransform  mtsTransform_;
-      ConvBremPFTrackFinder *convBremFinder_;
+      std::unique_ptr<ConvBremPFTrackFinder> convBremFinder_;
 
 
       ///Trajectory of GSfTracks in the event?

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -33,6 +33,7 @@
 #include <string>
 #include "TMath.h"
 #include "Math/VectorUtil.h"
+#include "TMVA/MethodBDT.h"
 
 using namespace edm;
 using namespace std;
@@ -400,8 +401,9 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	      eta=tketa;
 	      pt=tkpt;
 	      eP=EP;
-	  
-	      float Ytmva=reader[ipteta]->EvaluateMVA( method_ );
+              float vars[10] = { nhit, chikfred, dpt, eP, chiRatio, chired, trk_ecalDeta, trk_ecalDphi, pt, eta};
+              
+	      float Ytmva=gbr[ipteta]->GetClassifier( vars );
 	      
 	      float BDTcut=thr[ibin+5]; 
 	      if ( Ytmva>BDTcut) GoodTkId=true;
@@ -505,6 +507,7 @@ GoodSeedProducer::beginRun(const edm::Run & run,
 
     for(UInt_t j = 0; j < 9; ++j){
       reader[j].reset( new TMVA::Reader("!Color:Silent"));
+
       
       reader[j]->AddVariable("NHits", &nhit);
       reader[j]->AddVariable("NormChi", &chikfred);
@@ -526,6 +529,9 @@ GoodSeedProducer::beginRun(const edm::Run & run,
       if(j==6) reader[j]->BookMVA(method_, Weigths7.fullPath().c_str());
       if(j==7) reader[j]->BookMVA(method_, Weigths8.fullPath().c_str());
       if(j==8) reader[j]->BookMVA(method_, Weigths9.fullPath().c_str());
+
+      gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader[j]->FindMVA(method_) ) ) );
+      reader[j].reset();
     }    
   }
   //read threshold

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -507,7 +507,7 @@ namespace goodseedhelpers {
         reader.AddVariable("pt", &pt);
         reader.AddVariable("eta", &eta);
         
-        reader.BookMVA(method_, weights[j].fullPath().c_str());
+        std::unique_ptr<TMVA::IMethod> temp( reader.BookMVA(method_, weights[j].fullPath().c_str()) );
         
         gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA(method_) ) ) );
       }    

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -483,33 +483,33 @@ namespace goodseedhelpers {
     
     if( useTmva ) {
       const std::string method_ = conf.getParameter<string>("TMVAMethod");
-      std::array<edm::FileInPath,9> weights = {{ edm::FileInPath(conf.getParameter<string>("Weights1")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights2")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights3")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights4")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights5")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights6")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights7")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights8")),
-                                                 edm::FileInPath(conf.getParameter<string>("Weights9")) }};
+      std::array<edm::FileInPath,kMaxWeights> weights = {{ edm::FileInPath(conf.getParameter<string>("Weights1")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights2")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights3")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights4")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights5")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights6")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights7")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights8")),
+                                                           edm::FileInPath(conf.getParameter<string>("Weights9")) }};
             
-      for(UInt_t j = 0; j < 9; ++j){
-        std::unique_ptr<TMVA::Reader> reader( new TMVA::Reader("!Color:Silent"));
+      for(UInt_t j = 0; j < gbr.size(); ++j){
+        TMVA::Reader reader("!Color:Silent");
                 
-        reader->AddVariable("NHits", &nhit);
-        reader->AddVariable("NormChi", &chikfred);
-        reader->AddVariable("dPtGSF", &dpt);
-        reader->AddVariable("EoP", &eP);
-        reader->AddVariable("ChiRatio", &chiRatio);
-        reader->AddVariable("RedChi", &chired);
-        reader->AddVariable("EcalDEta", &trk_ecalDeta);
-        reader->AddVariable("EcalDPhi", &trk_ecalDphi);
-        reader->AddVariable("pt", &pt);
-        reader->AddVariable("eta", &eta);
+        reader.AddVariable("NHits", &nhit);
+        reader.AddVariable("NormChi", &chikfred);
+        reader.AddVariable("dPtGSF", &dpt);
+        reader.AddVariable("EoP", &eP);
+        reader.AddVariable("ChiRatio", &chiRatio);
+        reader.AddVariable("RedChi", &chired);
+        reader.AddVariable("EcalDEta", &trk_ecalDeta);
+        reader.AddVariable("EcalDPhi", &trk_ecalDphi);
+        reader.AddVariable("pt", &pt);
+        reader.AddVariable("eta", &eta);
         
-        reader->BookMVA(method_, weights[j].fullPath().c_str());
+        reader.BookMVA(method_, weights[j].fullPath().c_str());
         
-        gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader->FindMVA(method_) ) ) );
+        gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA(method_) ) ) );
       }    
     }
   }

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.cc
@@ -39,7 +39,7 @@ using namespace edm;
 using namespace std;
 using namespace reco;
 
-GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig):
+GoodSeedProducer::GoodSeedProducer(const ParameterSet& iConfig, const goodseedhelpers::HeavyObjectCache*):
   pfTransformer_(nullptr),
   conf_(iConfig),
   resMapEtaECAL_(nullptr),
@@ -403,7 +403,7 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
 	      eP=EP;
               float vars[10] = { nhit, chikfred, dpt, eP, chiRatio, chired, trk_ecalDeta, trk_ecalDphi, pt, eta};
               
-	      float Ytmva=gbr[ipteta]->GetClassifier( vars );
+	      float Ytmva = globalCache()->gbr[ipteta]->GetClassifier( vars );
 	      
 	      float BDTcut=thr[ibin+5]; 
 	      if ( Ytmva>BDTcut) GoodTkId=true;
@@ -474,6 +474,47 @@ GoodSeedProducer::produce(Event& iEvent, const EventSetup& iSetup)
   // clear temporary maps
   refMap_.clear();
 }
+
+// intialize the cross-thread cache to hold gbr trees and resolution maps
+namespace goodseedhelpers {
+  HeavyObjectCache::HeavyObjectCache( const edm::ParameterSet& conf) {    
+    // mvas
+    const bool useTmva = conf.getUntrackedParameter<bool>("UseTMVA",false);
+    
+    if( useTmva ) {
+      const std::string method_ = conf.getParameter<string>("TMVAMethod");
+      std::array<edm::FileInPath,9> weights = {{ edm::FileInPath(conf.getParameter<string>("Weights1")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights2")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights3")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights4")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights5")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights6")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights7")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights8")),
+                                                 edm::FileInPath(conf.getParameter<string>("Weights9")) }};
+            
+      for(UInt_t j = 0; j < 9; ++j){
+        std::unique_ptr<TMVA::Reader> reader( new TMVA::Reader("!Color:Silent"));
+                
+        reader->AddVariable("NHits", &nhit);
+        reader->AddVariable("NormChi", &chikfred);
+        reader->AddVariable("dPtGSF", &dpt);
+        reader->AddVariable("EoP", &eP);
+        reader->AddVariable("ChiRatio", &chiRatio);
+        reader->AddVariable("RedChi", &chired);
+        reader->AddVariable("EcalDEta", &trk_ecalDeta);
+        reader->AddVariable("EcalDPhi", &trk_ecalDphi);
+        reader->AddVariable("pt", &pt);
+        reader->AddVariable("eta", &eta);
+        
+        reader->BookMVA(method_, weights[j].fullPath().c_str());
+        
+        gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader->FindMVA(method_) ) ) );
+      }    
+    }
+  }
+}
+
 // ------------ method called once each job just before starting event loop  ------------
 void 
 GoodSeedProducer::beginRun(const edm::Run & run,
@@ -488,52 +529,11 @@ GoodSeedProducer::beginRun(const edm::Run & run,
   pfTransformer_->OnlyProp();
   
   //Resolution maps
-  FileInPath ecalEtaMap(conf_.getParameter<string>("EtaMap"));
-  FileInPath ecalPhiMap(conf_.getParameter<string>("PhiMap"));
-  resMapEtaECAL_.reset( new PFResolutionMap("ECAL_eta",ecalEtaMap.fullPath().c_str()) );
-  resMapPhiECAL_.reset( new PFResolutionMap("ECAL_phi",ecalPhiMap.fullPath().c_str()) );
+    FileInPath ecalEtaMap(conf_.getParameter<string>("EtaMap"));
+    FileInPath ecalPhiMap(conf_.getParameter<string>("PhiMap"));
+    resMapEtaECAL_.reset( new PFResolutionMap("ECAL_eta",ecalEtaMap.fullPath().c_str()) );
+    resMapPhiECAL_.reset( new PFResolutionMap("ECAL_phi",ecalPhiMap.fullPath().c_str()) );
 
-  if(useTmva_){
-    method_ = conf_.getParameter<string>("TMVAMethod");
-    FileInPath Weigths1(conf_.getParameter<string>("Weights1"));
-    FileInPath Weigths2(conf_.getParameter<string>("Weights2"));
-    FileInPath Weigths3(conf_.getParameter<string>("Weights3"));
-    FileInPath Weigths4(conf_.getParameter<string>("Weights4"));
-    FileInPath Weigths5(conf_.getParameter<string>("Weights5"));
-    FileInPath Weigths6(conf_.getParameter<string>("Weights6"));
-    FileInPath Weigths7(conf_.getParameter<string>("Weights7"));
-    FileInPath Weigths8(conf_.getParameter<string>("Weights8"));
-    FileInPath Weigths9(conf_.getParameter<string>("Weights9"));
-
-    for(UInt_t j = 0; j < 9; ++j){
-      reader[j].reset( new TMVA::Reader("!Color:Silent"));
-
-      
-      reader[j]->AddVariable("NHits", &nhit);
-      reader[j]->AddVariable("NormChi", &chikfred);
-      reader[j]->AddVariable("dPtGSF", &dpt);
-      reader[j]->AddVariable("EoP", &eP);
-      reader[j]->AddVariable("ChiRatio", &chiRatio);
-      reader[j]->AddVariable("RedChi", &chired);
-      reader[j]->AddVariable("EcalDEta", &trk_ecalDeta);
-      reader[j]->AddVariable("EcalDPhi", &trk_ecalDphi);
-      reader[j]->AddVariable("pt", &pt);
-      reader[j]->AddVariable("eta", &eta);
-      
-      if(j==0) reader[j]->BookMVA(method_, Weigths1.fullPath().c_str());
-      if(j==1) reader[j]->BookMVA(method_, Weigths2.fullPath().c_str());
-      if(j==2) reader[j]->BookMVA(method_, Weigths3.fullPath().c_str());
-      if(j==3) reader[j]->BookMVA(method_, Weigths4.fullPath().c_str());
-      if(j==4) reader[j]->BookMVA(method_, Weigths5.fullPath().c_str());
-      if(j==5) reader[j]->BookMVA(method_, Weigths6.fullPath().c_str());
-      if(j==6) reader[j]->BookMVA(method_, Weigths7.fullPath().c_str());
-      if(j==7) reader[j]->BookMVA(method_, Weigths8.fullPath().c_str());
-      if(j==8) reader[j]->BookMVA(method_, Weigths9.fullPath().c_str());
-
-      gbr[j].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader[j]->FindMVA(method_) ) ) );
-      reader[j].reset();
-    }    
-  }
   //read threshold
   FileInPath parFile(conf_.getParameter<string>("ThresholdFile"));
   ifstream ifs(parFile.fullPath().c_str());

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
@@ -23,6 +23,8 @@
 #include "TrackingTools/PatternTools/interface/Trajectory.h"
 #include "RecoParticleFlow/PFTracking/interface/PFGeometry.h"
 
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+
 #include "RecoTracker/TransientTrackingRecHit/interface/TkTransientTrackingRecHitBuilder.h"
 
 /// \brief Abstract
@@ -147,6 +149,7 @@ class GoodSeedProducer final : public edm::stream::EDProducer<> {
 	
       ///READER FOR TMVA
       std::array<std::unique_ptr<TMVA::Reader>,9> reader{};
+      std::array<std::unique_ptr<GBRForest>,9> gbr;
 
       ///VARIABLES NEEDED FOR TMVA
       float eP,eta,pt,nhit,dpt,chired,chiRatio;

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
@@ -50,12 +50,31 @@ class TrajectorySmoother;
 class TrackerGeometry;
 class TrajectoryStateOnSurface;
 
+namespace goodseedhelpers {
+  class HeavyObjectCache {
+  public:
+    HeavyObjectCache(const edm::ParameterSet& conf);
+    std::array<std::unique_ptr<GBRForest>,9> gbr;    
+  private:
+    // for temporary variable binding while reading
+    float eP,eta,pt,nhit,dpt,chired,chiRatio;
+    float chikfred,trk_ecalDeta,trk_ecalDphi;    
+  };
+}
 
-class GoodSeedProducer final : public edm::stream::EDProducer<> {
+class GoodSeedProducer final : public edm::stream::EDProducer<edm::GlobalCache<goodseedhelpers::HeavyObjectCache> > {
   typedef TrajectoryStateOnSurface TSOS;
-   public:
-      explicit GoodSeedProducer(const edm::ParameterSet&);
+ public:
+  explicit GoodSeedProducer(const edm::ParameterSet&, const goodseedhelpers::HeavyObjectCache*);
   
+  static std::unique_ptr<goodseedhelpers::HeavyObjectCache> 
+    initializeGlobalCache( const edm::ParameterSet& conf ) {
+       return std::unique_ptr<goodseedhelpers::HeavyObjectCache>(new goodseedhelpers::HeavyObjectCache(conf));
+   }
+  
+  static void globalEndJob(goodseedhelpers::HeavyObjectCache const* ) {
+  }
+
    private:
       virtual void beginRun(const edm::Run & run,const edm::EventSetup&) override;
       virtual void produce(edm::Event&, const edm::EventSetup&) override;

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
@@ -168,11 +168,7 @@ class GoodSeedProducer final : public edm::stream::EDProducer<edm::GlobalCache<g
       ///TRACK QUALITY
       bool useQuality_;
       reco::TrackBase::TrackQuality trackQuality_;
-	
-      ///READER FOR TMVA
-      std::array<std::unique_ptr<TMVA::Reader>,9> reader{};
-      std::array<std::unique_ptr<GBRForest>,9> gbr;
-
+      
       ///VARIABLES NEEDED FOR TMVA
       float eP,eta,pt,nhit,dpt,chired,chiRatio;
       float chikfred,trk_ecalDeta,trk_ecalDphi;                      

--- a/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
+++ b/RecoParticleFlow/PFTracking/plugins/GoodSeedProducer.h
@@ -50,11 +50,14 @@ class TrajectorySmoother;
 class TrackerGeometry;
 class TrajectoryStateOnSurface;
 
+
+
 namespace goodseedhelpers {
   class HeavyObjectCache {
+    constexpr static unsigned int kMaxWeights = 9;
   public:
     HeavyObjectCache(const edm::ParameterSet& conf);
-    std::array<std::unique_ptr<GBRForest>,9> gbr;    
+    std::array<std::unique_ptr<const GBRForest>,kMaxWeights> gbr;    
   private:
     // for temporary variable binding while reading
     float eP,eta,pt,nhit,dpt,chired,chiRatio;

--- a/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
@@ -45,7 +45,7 @@ namespace convbremhelpers {
     reader.AddVariable("kftrack_Epout",&Epout);
     reader.AddVariable("kftrack_detaBremKF",&detaBremKF);
     reader.AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
-    reader.BookMVA("BDT", weights.c_str());
+    std::unique_ptr<TMVA::IMethod> temp( reader.BookMVA("BDT", weights.c_str()) );
     return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA("BDT") ) ) );
   }  
 }

--- a/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
@@ -37,15 +37,15 @@ namespace convbremhelpers {
     }
   }
 
-  std::unique_ptr<GBRForest> HeavyObjectCache::setupMVA(const std::string& weights) {
-    std::unique_ptr<TMVA::Reader> reader( new TMVA::Reader("!Color:Silent") );
-    reader->AddVariable("kftrack_secR",&secR);
-    reader->AddVariable("kftrack_sTIP",&sTIP);
-    reader->AddVariable("kftrack_nHITS1",&nHITS1);
-    reader->AddVariable("kftrack_Epout",&Epout);
-    reader->AddVariable("kftrack_detaBremKF",&detaBremKF);
-    reader->AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
-    reader->BookMVA("BDT", weights.c_str());
-    return std::unique_ptr<GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader->FindMVA("BDT") ) ) );
+  std::unique_ptr<const GBRForest> HeavyObjectCache::setupMVA(const std::string& weights) {
+    TMVA::Reader reader("!Color:Silent");
+    reader.AddVariable("kftrack_secR",&secR);
+    reader.AddVariable("kftrack_sTIP",&sTIP);
+    reader.AddVariable("kftrack_nHITS1",&nHITS1);
+    reader.AddVariable("kftrack_Epout",&Epout);
+    reader.AddVariable("kftrack_detaBremKF",&detaBremKF);
+    reader.AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
+    reader.BookMVA("BDT", weights.c_str());
+    return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader.FindMVA("BDT") ) ) );
   }  
 }

--- a/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremHeavyObjectCache.cc
@@ -1,0 +1,51 @@
+#include "RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h"
+#include "TMVA/Reader.h"
+#include "TMVA/MethodBDT.h"
+
+
+namespace convbremhelpers {
+  HeavyObjectCache::HeavyObjectCache(const edm::ParameterSet& conf) {
+
+    pfcalib_.reset( new PFEnergyCalibration() );
+
+    const bool useConvBremFinder_ = conf.getParameter<bool>("useConvBremFinder");
+
+    if(useConvBremFinder_) {
+      const std::string& mvaWeightFileConvBremBarrelLowPt  = 
+        conf.getParameter<std::string>("pf_convBremFinderID_mvaWeightFileBarrelLowPt");
+      const std::string mvaWeightFileConvBremBarrelHighPt  = 
+        conf.getParameter<std::string>("pf_convBremFinderID_mvaWeightFileBarrelHighPt");
+      const std::string mvaWeightFileConvBremEndcapsLowPt  = 
+        conf.getParameter<std::string>("pf_convBremFinderID_mvaWeightFileEndcapsLowPt");
+      const std::string mvaWeightFileConvBremEndcapsHighPt = 
+        conf.getParameter<std::string>("pf_convBremFinderID_mvaWeightFileEndcapsHighPt");
+  
+      const std::string path_mvaWeightFileConvBremBarrelLowPt  = 
+        edm::FileInPath( mvaWeightFileConvBremBarrelLowPt.c_str() ).fullPath();
+      const std::string path_mvaWeightFileConvBremBarrelHighPt  = 
+        edm::FileInPath( mvaWeightFileConvBremBarrelHighPt.c_str() ).fullPath();
+      const std::string path_mvaWeightFileConvBremEndcapsLowPt  = 
+        edm::FileInPath( mvaWeightFileConvBremEndcapsLowPt.c_str() ).fullPath();
+      const std::string path_mvaWeightFileConvBremEndcapsHighPt = 
+        edm::FileInPath( mvaWeightFileConvBremEndcapsHighPt.c_str() ).fullPath();
+      
+      gbrBarrelLowPt_   = setupMVA(path_mvaWeightFileConvBremBarrelLowPt);
+      gbrBarrelHighPt_  = setupMVA(path_mvaWeightFileConvBremBarrelHighPt);
+      gbrEndcapsLowPt_  = setupMVA(path_mvaWeightFileConvBremEndcapsLowPt);
+      gbrEndcapsHighPt_ = setupMVA(path_mvaWeightFileConvBremEndcapsHighPt);
+
+    }
+  }
+
+  std::unique_ptr<GBRForest> HeavyObjectCache::setupMVA(const std::string& weights) {
+    std::unique_ptr<TMVA::Reader> reader( new TMVA::Reader("!Color:Silent") );
+    reader->AddVariable("kftrack_secR",&secR);
+    reader->AddVariable("kftrack_sTIP",&sTIP);
+    reader->AddVariable("kftrack_nHITS1",&nHITS1);
+    reader->AddVariable("kftrack_Epout",&Epout);
+    reader->AddVariable("kftrack_detaBremKF",&detaBremKF);
+    reader->AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
+    reader->BookMVA("BDT", weights.c_str());
+    return std::unique_ptr<GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( reader->FindMVA("BDT") ) ) );
+  }  
+}

--- a/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
+++ b/RecoParticleFlow/PFTracking/src/ConvBremPFTrackFinder.cc
@@ -24,72 +24,13 @@ ConvBremPFTrackFinder::ConvBremPFTrackFinder(const TransientTrackBuilder& builde
 					     double mvaBremConvCutBarrelLowPt,
 					     double mvaBremConvCutBarrelHighPt,
 					     double mvaBremConvCutEndcapsLowPt,	     
-					     double mvaBremConvCutEndcapsHighPt,
-					     string mvaWeightFileConvBremBarrelLowPt,
-					     string mvaWeightFileConvBremBarrelHighPt,
-					     string mvaWeightFileConvBremEndcapsLowPt,
-					     string mvaWeightFileConvBremEndcapsHighPt
-					     ):
+					     double mvaBremConvCutEndcapsHighPt):
   builder_(builder),
   mvaBremConvCutBarrelLowPt_(mvaBremConvCutBarrelLowPt), 
   mvaBremConvCutBarrelHighPt_(mvaBremConvCutBarrelHighPt), 
   mvaBremConvCutEndcapsLowPt_(mvaBremConvCutEndcapsLowPt), 
-  mvaBremConvCutEndcapsHighPt_(mvaBremConvCutEndcapsHighPt), 
-  mvaWeightFileConvBremBarrelLowPt_(mvaWeightFileConvBremBarrelLowPt),
-  mvaWeightFileConvBremBarrelHighPt_(mvaWeightFileConvBremBarrelHighPt),
-  mvaWeightFileConvBremEndcapsLowPt_(mvaWeightFileConvBremEndcapsLowPt),
-  mvaWeightFileConvBremEndcapsHighPt_(mvaWeightFileConvBremEndcapsHighPt)
- 
-{
- 
-  tmvaReaderBarrelLowPt_.reset( new TMVA::Reader("!Color:Silent") );
-  tmvaReaderBarrelLowPt_->AddVariable("kftrack_secR",&secR);
-  tmvaReaderBarrelLowPt_->AddVariable("kftrack_sTIP",&sTIP);
-  tmvaReaderBarrelLowPt_->AddVariable("kftrack_nHITS1",&nHITS1);
-  tmvaReaderBarrelLowPt_->AddVariable("kftrack_Epout",&Epout);
-  tmvaReaderBarrelLowPt_->AddVariable("kftrack_detaBremKF",&detaBremKF);
-  tmvaReaderBarrelLowPt_->AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
-  tmvaReaderBarrelLowPt_->BookMVA("BDT", mvaWeightFileConvBremBarrelLowPt.c_str());
-  gbrBarrelLowPt_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReaderBarrelLowPt_->FindMVA("BDT") ) ) );
-  tmvaReaderBarrelLowPt_.reset();
-
-  tmvaReaderBarrelHighPt_.reset( new TMVA::Reader("!Color:Silent") );
-  tmvaReaderBarrelHighPt_->AddVariable("kftrack_secR",&secR);
-  tmvaReaderBarrelHighPt_->AddVariable("kftrack_sTIP",&sTIP);
-  tmvaReaderBarrelHighPt_->AddVariable("kftrack_nHITS1",&nHITS1);
-  tmvaReaderBarrelHighPt_->AddVariable("kftrack_Epout",&Epout);
-  tmvaReaderBarrelHighPt_->AddVariable("kftrack_detaBremKF",&detaBremKF);
-  tmvaReaderBarrelHighPt_->AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
-  tmvaReaderBarrelHighPt_->BookMVA("BDT", mvaWeightFileConvBremBarrelHighPt.c_str());
-  gbrBarrelHighPt_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReaderBarrelHighPt_->FindMVA("BDT") ) ) );
-  tmvaReaderBarrelHighPt_.reset();
-
-  tmvaReaderEndcapsLowPt_.reset( new TMVA::Reader("!Color:Silent") );
-  tmvaReaderEndcapsLowPt_->AddVariable("kftrack_secR",&secR);
-  tmvaReaderEndcapsLowPt_->AddVariable("kftrack_sTIP",&sTIP);
-  tmvaReaderEndcapsLowPt_->AddVariable("kftrack_nHITS1",&nHITS1);
-  tmvaReaderEndcapsLowPt_->AddVariable("kftrack_Epout",&Epout);
-  tmvaReaderEndcapsLowPt_->AddVariable("kftrack_detaBremKF",&detaBremKF);
-  tmvaReaderEndcapsLowPt_->AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
-  tmvaReaderEndcapsLowPt_->BookMVA("BDT", mvaWeightFileConvBremEndcapsLowPt.c_str());
-  gbrEndcapsLowPt_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReaderEndcapsLowPt_->FindMVA("BDT") ) ) );
-  tmvaReaderEndcapsLowPt_.reset();
-
-  tmvaReaderEndcapsHighPt_.reset( new TMVA::Reader("!Color:Silent") );
-  tmvaReaderEndcapsHighPt_->AddVariable("kftrack_secR",&secR);
-  tmvaReaderEndcapsHighPt_->AddVariable("kftrack_sTIP",&sTIP);
-  tmvaReaderEndcapsHighPt_->AddVariable("kftrack_nHITS1",&nHITS1);
-  tmvaReaderEndcapsHighPt_->AddVariable("kftrack_Epout",&Epout);
-  tmvaReaderEndcapsHighPt_->AddVariable("kftrack_detaBremKF",&detaBremKF);
-  tmvaReaderEndcapsHighPt_->AddVariable("kftrack_ptRatioGsfKF",&ptRatioGsfKF);
-  tmvaReaderEndcapsHighPt_->BookMVA("BDT", mvaWeightFileConvBremEndcapsHighPt.c_str());
-  gbrEndcapsHighPt_.reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReaderEndcapsHighPt_->FindMVA("BDT") ) ) );
-  tmvaReaderEndcapsHighPt_.reset();
-
-
-  pfcalib_.reset( new PFEnergyCalibration() );
-
-}
+  mvaBremConvCutEndcapsHighPt_(mvaBremConvCutEndcapsHighPt) 
+{ }
 ConvBremPFTrackFinder::~ConvBremPFTrackFinder(){ }
 
 void
@@ -98,6 +39,7 @@ ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>& the
 					 const edm::Handle<reco::PFDisplacedTrackerVertexCollection>& pfNuclears,
 					 const edm::Handle<reco::PFConversionCollection >& pfConversions,
 					 const edm::Handle<reco::PFV0Collection >& pfV0,
+                                         const convbremhelpers::HeavyObjectCache* cache,
 					 bool useNuclear,
 					 bool useConversions,
 					 bool useV0,
@@ -359,7 +301,7 @@ ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>& the
 	  ps1=ps2=0.;
 	  if(dist < MinDist) {
 	    MinDist = dist;
-	    EE_calib = pfcalib_->energyEm(*clus,ps1Ene,ps2Ene,ps1,ps2,applyCrackCorrections);
+	    EE_calib = cache->pfcalib_->energyEm(*clus,ps1Ene,ps2Ene,ps1,ps2,applyCrackCorrections);
 	  }
 	}
       }
@@ -437,9 +379,6 @@ ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>& the
 	}
 	  
 	nHITS1 = tmp_sh;
-	
-
-
 
 	TString weightfilepath ="";
 	double mvaValue =  -10; 
@@ -447,20 +386,20 @@ ConvBremPFTrackFinder::runConvBremFinder(const Handle<PFRecTrackCollection>& the
 
         float vars[6] = {secR, sTIP, nHITS1, Epout, detaBremKF, ptRatioGsfKF};
 	if(refGsf->pt()<20 && fabs(refGsf->eta())<1.479 ){
-	  mvaValue = gbrBarrelLowPt_->GetClassifier(vars); 
-	  cutvalue =  mvaBremConvCutBarrelLowPt_; 
+	  mvaValue = cache->gbrBarrelLowPt_->GetClassifier(vars); 
+	  cutvalue = mvaBremConvCutBarrelLowPt_; 
 	}
 	if(refGsf->pt()>20 && fabs(refGsf->eta())<1.479 ){
-	  mvaValue = gbrBarrelHighPt_->GetClassifier(vars); 
-	  cutvalue =  mvaBremConvCutBarrelHighPt_;
+	  mvaValue = cache->gbrBarrelHighPt_->GetClassifier(vars); 
+	  cutvalue = mvaBremConvCutBarrelHighPt_;
 	}
 	if(refGsf->pt()<20 && fabs(refGsf->eta())>1.479 ){
-	  mvaValue = gbrEndcapsLowPt_->GetClassifier(vars);
-	  cutvalue =  mvaBremConvCutEndcapsLowPt_;
+	  mvaValue = cache->gbrEndcapsLowPt_->GetClassifier(vars);
+	  cutvalue = mvaBremConvCutEndcapsLowPt_;
 	}
 	if(refGsf->pt()>20 && fabs(refGsf->eta())>1.479 ){
-	  mvaValue = gbrEndcapsHighPt_->GetClassifier(vars);
-	  cutvalue =  mvaBremConvCutEndcapsHighPt_;
+	  mvaValue = cache->gbrEndcapsHighPt_->GetClassifier(vars);
+	  cutvalue = mvaBremConvCutEndcapsHighPt_;
 	}
 
 


### PR DESCRIPTION
Since things look OK on the surface from the DQM plots in #10142, I went ahead and moved all the GBRForest objects into edm::GlobalCaches since the BDTs are always read from the same files and don't depend on run. This should bring some memory usage improvements in multicore jobs.

Trial of converting a package that used TMVA::Reader to GBRForest + use edm::GlobalCache.
Underlying regression weights were gradient boosted, despite method name (read from xml).

At most, some jitter may be expected, otherwise expect no physics impact.
Also expect some reduction in RSS.

@bendavid 

@Dr15Jones You might be interested in this too if you want to look for thread safety issues. FYI GBRForest is threadsafe.
