### PR TITLE
Adding L1 menu and Hcal Negative energy filter in GT

### DIFF
--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,25 +2,25 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_74_V6',
+    'run1_design'       :   'DESRUN1_74_V7',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_74_V6',
+    'run1_mc'           :   'MCRUN1_74_V7',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_74_V6',
+    'run1_mc_hi'        :   'MCHI1_74_V7',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_74_V6',
+    'run1_mc_pa'        :   'MCPA1_74_V7',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_74_V4',
+    'run2_design'       :   'DESRUN2_74_V5',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_74_V8',
+    'run2_mc_50ns'      :   'MCRUN2_74_V10',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_74_V9',
+    'run2_mc'           :   'MCRUN2_74_V11',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   'MCHI2_74_V5',
+    'run2_mc_hi'        :   'MCHI2_74_V6',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_74_V12A',
+    'run1_data'         :   'GR_R_74_V14A',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_74_V13A',
+    'run2_data'         :   'GR_R_74_V15A',
     # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
     'run1_hlt'          :   'GR_H_V57A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
     # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline

--- a/PhysicsTools/PatAlgos/python/patTemplate_cfg.py
+++ b/PhysicsTools/PatAlgos/python/patTemplate_cfg.py
@@ -17,8 +17,9 @@ process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
 
 ## Geometry and Detector Conditions (needed for a few patTuple production steps)
 process.load("Configuration.Geometry.GeometryRecoDB_cff")
-process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
-from Configuration.AlCa.GlobalTag import GlobalTag
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc')
 process.load("Configuration.StandardSequences.MagneticField_cff")
 


### PR DESCRIPTION
## List of Changes
- Run1 ideal simulation: as `DESRUN1_74_V6` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/DESRUN1_74_V7/DESRUN1_74_V6))  with:
  - new HCAL negative energy filter.
- Run1 realistic simulation: as `MCRUN1_74_V6` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/MCRUN1_74_V7/MCRUN1_74_V6)) with:
  - new HCAL negative energy filter.
- Run1 Heavy Ion simulation: as `MCHI1_74_V6` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/MCHI1_74_V7/MCHI1_74_V6)) with:
  - new HCAL negative energy filter.
- Run1 proton-lead simulation: as`MCPA1_74_V6` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/MCPA1_74_V7/MCPA1_74_V6)) with:
  - new HCAL negative energy filter.
- Run2 design simulation: as `DESRUN2_74_V4` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/DESRUN2_74_V5/DESRUN2_74_V4)) with:
  - new HCAL negative energy filter.
  - updated L1T menu for 25 ns collisions: `Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030` (already in release as XML file consumed via customise function).
- Run2 startup simulation: as `MCRUN2_74_V8` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/MCRUN2_74_V10/MCRUN2_74_V8)) with:
  - new HCAL negative energy filter.
  - updated L1T menu for 50 ns collisions: `Collisions2015_50nsGct_v1_L1T_Scales_20141121_Imp0_0x1030` (already in release as XML file consumed via customise function).
- Run2 asymptotic simulation: as `MCRUN2_74_V9` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/MCRUN2_74_V11/MCRUN2_74_V9))  with:
  - new HCAL negative energy filter.
  - updated L1T menu for 25 ns collisions: `Collisions2015_25ns_v2_L1T_Scales_20141121_Imp0_0x1030` (already in release as XML file consumed via customise function).
- Run2 Heavy Ion simulation: as `MCHI2_74_V5` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/MCHI2_74_V6/MCHI2_74_V5)) with:
  - new HCAL negative energy filter.
  - updated L1T menu for Heavy Ion collisions `CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1` (already in release as XML file consumed via customise function)
- Run1 Data processing: as `GR_R_74_V12` ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/GR_R_74_V14/GR_R_74_V12)) with:
  - new HCAL negative energy filter.
- Run2 Data processing: as `GR_R_74_V13`  ([browser](https://cms-conddb.cern.ch/browser/#diff/gts/GR_R_74_V15/GR_R_74_V13)) with:
  - new HCAL negative energy filter.

---

No changes in HLT run1 and run2 data processing
