### PR TITLE
New Scenarios for SD: HGCAL ee18 without Tracker Extension

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -1101,9 +1101,10 @@ defaultDataSets['Extended2023HGCalMuon']='CMSSW_6_2_0_SLHC20_patch1-DES23_62_V1_
 defaultDataSets['Extended2023HGCalMuonPandora']=defaultDataSets['Extended2023HGCalMuon'] # Geometry is the same, only reco is different
 defaultDataSets['Extended2023SHCalNoTaper']='CMSSW_6_2_0_SLHC20_patch1-DES23_62_V1_refSHNoTaper-v'
 defaultDataSets['2019WithGEMAging']='CMSSW_6_2_0_SLHC20-DES19_62_V8_UPG2019withGEM-v'
-defaultDataSets['Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12']=defaultDataSets['Extended2023HGCalMuon']
-defaultDataSets['Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11']=defaultDataSets['Extended2023HGCalMuon']
-defaultDataSets['Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9']=defaultDataSets['Extended2023HGCalMuon']
+defaultDataSets['Extended2023HGCalScopeDoc_ee28_fh12']=defaultDataSets['Extended2023HGCalMuon']
+defaultDataSets['Extended2023HGCalScopeDoc_ee24_fh11']=defaultDataSets['Extended2023HGCalMuon']
+defaultDataSets['Extended2023HGCalScopeDoc_ee18_fh9']=defaultDataSets['Extended2023HGCalMuon']
+defaultDataSets['Extended2023HGCalNoExtPix_ee18']=defaultDataSets['Extended2023HGCalMuon']
 keys=defaultDataSets.keys()
 for key in keys:
   defaultDataSets[key+'PU']=defaultDataSets[key]

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -142,7 +142,7 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'BE5DPixel10DLHCCNoDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DLHCCNoDefect',
                  'BE5DPixel10DDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DDefect',
                  'BE5DPixel10DCoolingDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DCoolingDefect',
-                 'Extended2023HGCalNoExtPix_ee18' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalNoExtPix_ee18_fh9'#XXX
+                 'Extended2023HGCalNoExtPix_ee18' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalNoExtPix_ee18_fh9'
                  }
 
 upgradeFragments=['FourMuPt_1_200_cfi','SingleElectronPt10_cfi',

--- a/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
+++ b/Configuration/PyReleaseValidation/python/upgradeWorkflowComponents.py
@@ -13,16 +13,16 @@ upgradeKeys=['2017',
              'Extended2023',
              'Extended2023HGCalMuon',
              'Extended2023SHCal',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12',
+             'Extended2023HGCalScopeDoc_ee28_fh12',
              'Extended2023TTI',
              'Extended2023Muon',
              'Extended2023HGCalV6Muon',
              'Extended2023SHCalNoTaperNoExtPix',
              'Extended2023Pixel',
              'Extended2023SHCalNoTaper',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11',
+             'Extended2023HGCalScopeDoc_ee24_fh11',
              'Extended2023HGCal',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9',
+             'Extended2023HGCalScopeDoc_ee18_fh9',
              'BE5DPixel10DLHCC',
              'Extended2023HGCalV4',
              'Extended2023HGCalMuonPU',
@@ -35,9 +35,12 @@ upgradeKeys=['2017',
              'BE5DPixel10DLHCCNoDefect',
              'BE5DPixel10DDefect',
              'BE5DPixel10DCoolingDefect',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12PU',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11PU',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9PU'
+             'Extended2023HGCalScopeDoc_ee28_fh12PU',
+             'Extended2023HGCalScopeDoc_ee24_fh11PU',
+             'Extended2023HGCalScopeDoc_ee18_fh9PU',
+             'Extended2023HGCalNoExtPix_ee18',
+             'Extended2023HGCalNoExtPix_ee18PU'
+	     
          ]
 
 
@@ -54,7 +57,7 @@ upgradeGeoms={ '2017' : 'Extended2017',
                'Extended2023' : 'Extended2023,Extended2023Reco',
                'Extended2023HGCalMuon' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
                'Extended2023SHCal' : 'Extended2023SHCal,Extended2023SHCalReco',
-               'Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
+               'Extended2023HGCalScopeDoc_ee28_fh12' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
                'Extended2023TTI' : 'Extended2023TTI,Extended2023TTIReco',
                'Extended2023Muon' : 'Extended2023Muon,Extended2023MuonReco',
                'BE5DPixel10DLHCC' : 'ExtendedPhase2TkBE5DPixel10DLHCC',
@@ -62,16 +65,18 @@ upgradeGeoms={ '2017' : 'Extended2017',
                'Extended2023SHCalNoTaperNoExtPix' : 'Extended2023SHCalNoTaperNoExtPix',
                'Extended2023Pixel' : 'Extended2023Pixel,Extended2023PixelReco',
                'Extended2023SHCalNoTaper' : 'Extended2023SHCalNoTaper,Extended2023SHCalNoTaperReco',
-               'Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
+               'Extended2023HGCalScopeDoc_ee24_fh11' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
                'Extended2023HGCal' : 'Extended2023HGCal,Extended2023HGCalReco',
-               'Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
+               'Extended2023HGCalScopeDoc_ee18_fh9' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
                'Extended2023HGCalV4' : 'Extended2023HGCalV4Muon,Extended2023HGCalV4MuonReco',
                'Extended2023HGCalMuonPandora' : 'Extended2023HGCalMuon,Extended2023HGCalMuonReco',
                'Extended2023SHCalNoTaperFast' : 'Extended2023SHCalNoTaper,Extended2023SHCalNoTaperReco',
                'Extended2023HGCalNoExtPix' : 'Extended2023HGCalNoExtPix',
                'BE5DPixel10DLHCCNoDefect' : 'ExtendedPhase2TkBE5DPixel10DLHCC',
                'BE5DPixel10DDefect' : 'ExtendedPhase2TkBE5DPixel10D',
-               'BE5DPixel10DCoolingDefect' : 'ExtendedPhase2TkBE5DPixel10D'
+               'BE5DPixel10DCoolingDefect' : 'ExtendedPhase2TkBE5DPixel10D',
+               'Extended2023HGCalNoExtPix_ee18' : 'Extended2023HGCalNoExtPix'
+	       
                }
 upgradeGTs={ '2017' : 'auto:upgrade2017',
              '2019' : 'auto:upgrade2019',
@@ -86,7 +91,7 @@ upgradeGTs={ '2017' : 'auto:upgrade2017',
              'Extended2023' : 'auto:upgradePLS3',
              'Extended2023HGCalMuon' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
              'Extended2023SHCal' : 'auto:upgradePLS3',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
+             'Extended2023HGCalScopeDoc_ee28_fh12' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
              'Extended2023TTI' : 'auto:upgradePLS3',
              'Extended2023Muon' : 'auto:upgradePLS3',
              'BE5DPixel10DLHCC' : 'auto:upgradePLS3',
@@ -94,16 +99,17 @@ upgradeGTs={ '2017' : 'auto:upgrade2017',
              'Extended2023SHCalNoTaperNoExtPix' : 'auto:upgradePLS3',
              'Extended2023Pixel' : 'auto:upgradePLS3',
              'Extended2023SHCalNoTaper' : 'PH2_1K_FB_V6::All',#EB aged at 1000fb-1
-             'Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
+             'Extended2023HGCalScopeDoc_ee24_fh11' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
              'Extended2023HGCal' : 'auto:upgradePLS3',
-             'Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
+             'Extended2023HGCalScopeDoc_ee18_fh9' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
              'Extended2023HGCalV4' : 'auto:upgradePLS3',
              'Extended2023HGCalMuonPandora' : 'PH2_1K_FB_V6::All', #EB aged at 1000fb-1
              'Extended2023SHCalNoTaperFast' : 'auto:upgradePLS3',
              'Extended2023HGCalNoExtPix' : 'auto:upgradePLS3',
              'BE5DPixel10DLHCCNoDefect' : 'auto:upgradePLS3',
              'BE5DPixel10DDefect' : 'auto:upgradePLS3',
-             'BE5DPixel10DCoolingDefect' : 'auto:upgradePLS3'
+             'BE5DPixel10DCoolingDefect' : 'auto:upgradePLS3',
+             'Extended2023HGCalNoExtPix_ee18' : 'PH2_1K_FB_V6::All' #EB aged at 1000fb-1
              }
 upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2017',
                  '2019' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2019',
@@ -118,7 +124,7 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'Extended2023' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023',
                  'Extended2023HGCalMuon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon',
                  'Extended2023SHCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023SHCal',
-                 'Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuonScopeDoc_ee28_fh12',
+                 'Extended2023HGCalScopeDoc_ee28_fh12' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuonScopeDoc_ee28_fh12',
                  'Extended2023TTI' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023TTI',
                  'Extended2023Muon' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Muon',
                  'BE5DPixel10DLHCC' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DLHCC',
@@ -126,16 +132,17 @@ upgradeCustoms={ '2017' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.
                  'Extended2023SHCalNoTaperNoExtPix' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023SHCalNoExtPix',
                  'Extended2023Pixel' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023Pixel',
                  'Extended2023SHCalNoTaper' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023SHCal',
-                 'Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuonScopeDoc_ee24_fh11',
+                 'Extended2023HGCalScopeDoc_ee24_fh11' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuonScopeDoc_ee24_fh11',
                  'Extended2023HGCal' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCal',
-                 'Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuonScopeDoc_ee18_fh9',
+                 'Extended2023HGCalScopeDoc_ee18_fh9' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuonScopeDoc_ee18_fh9',
                  'Extended2023HGCalV4' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalMuon',
                  'Extended2023HGCalMuonPandora' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalPandoraMuon',
                  'Extended2023SHCalNoTaperFast' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023SHCalTime',
                  'Extended2023HGCalNoExtPix' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_2023HGCalPandoraMuonNoExtPix',
                  'BE5DPixel10DLHCCNoDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DLHCCNoDefect',
                  'BE5DPixel10DDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DDefect',
-                 'BE5DPixel10DCoolingDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DCoolingDefect'
+                 'BE5DPixel10DCoolingDefect' : 'SLHCUpgradeSimulations/Configuration/combinedCustoms.cust_phase2_BE5DPixel10DCoolingDefect',
+                 'Extended2023HGCalNoExtPix_ee18' : 'RecoParticleFlow/PandoraTranslator/customizeHGCalPandora_cff.cust_2023HGCalNoExtPix_ee18_fh9'#XXX
                  }
 
 upgradeFragments=['FourMuPt_1_200_cfi','SingleElectronPt10_cfi',
@@ -196,7 +203,7 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCalMuon':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
                    'Extended2023SHCal':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
-                   'Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
+                   'Extended2023HGCalScopeDoc_ee28_fh12':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
                    'Extended2023TTI':['GenSimHLBeamSpotFull','DigiTrkTrigFull'], ##no need to go beyond local reco
                    'Extended2023Muon':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'BE5DPixel10DLHCC':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
@@ -204,9 +211,9 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023SHCalNoTaperNoExtPix':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023Pixel':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023SHCalNoTaper':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
-                   'Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
+                   'Extended2023HGCalScopeDoc_ee24_fh11':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
                    'Extended2023HGCal':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
-                   'Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
+                   'Extended2023HGCalScopeDoc_ee18_fh9':['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
                    'Extended2023HGCalV4' : ['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'Extended2023HGCalMuonPU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
                    'Extended2023SHCalNoTaperPU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPU','HARVESTFullPU'],
@@ -218,9 +225,11 @@ upgradeScenToRun={ '2017':['GenSimFull','DigiFull','RecoFull','HARVESTFull'],
                    'BE5DPixel10DLHCCNoDefect':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'BE5DPixel10DDefect':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
                    'BE5DPixel10DCoolingDefect':['GenSimHLBeamSpotFull','DigiFull','RecoFull','HARVESTFull'],
-                   'Extended2023HGCalPandoraMuonScopeDoc_ee28_fh12PU': ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
-                   'Extended2023HGCalPandoraMuonScopeDoc_ee24_fh11PU': ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
-                   'Extended2023HGCalPandoraMuonScopeDoc_ee18_fh9PU': ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL']
+                   'Extended2023HGCalScopeDoc_ee28_fh12PU': ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
+                   'Extended2023HGCalScopeDoc_ee24_fh11PU': ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
+                   'Extended2023HGCalScopeDoc_ee18_fh9PU': ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL'],
+                   'Extended2023HGCalNoExtPix_ee18' : ['GenSimHLBeamSpotFull','DigiFull','RecoFullHGCAL'],
+                   'Extended2023HGCalNoExtPix_ee18PU' : ['GenSimHLBeamSpotFull','DigiFullPU','RecoFullPUHGCAL']
                    }
 
 from  Configuration.PyReleaseValidation.relval_steps import Kby

--- a/RecoParticleFlow/PandoraTranslator/python/customizeHGCalPandora_cff.py
+++ b/RecoParticleFlow/PandoraTranslator/python/customizeHGCalPandora_cff.py
@@ -332,22 +332,22 @@ def cust_2023HGCalPandoraMuonScopeDoc_ee18_fh9(process):
     
     return process
 
-#def cust_2023HGCalNoExtPix_ee18_fh9(process):
-#    layer_mask = {}
-#    layer_mask['EE']  = [1 for x in range(30)]
-#    layer_mask['HEF'] = [1 for x in range(12)]
-#    layer_mask['HEB'] = [1 for x in range(12)] 
-#    
-#    masked_layers = {}
-#    masked_layers['EE']  = [2, 4, 6, 8, 11, 13, 16, 19, 21, 24, 26, 28]
-#    masked_layers['HEF'] = [7, 9, 11]
-#    masked_layers['HEB'] = []
-#    
-#    mask_layers(layer_mask,masked_layers)
-#    
-#    process = cust_2023HGCalPandoraNoExtPix_common(process)
-#    process = customise_me0(process)
-#    if hasattr(process,'reconstruction_step'):
-#        process = propagate_layerdropping(process,layer_mask)
-#    
-#    return process
+def cust_2023HGCalNoExtPix_ee18_fh9(process):
+    layer_mask = {}
+    layer_mask['EE']  = [1 for x in range(30)]
+    layer_mask['HEF'] = [1 for x in range(12)]
+    layer_mask['HEB'] = [1 for x in range(12)] 
+    
+    masked_layers = {}
+    masked_layers['EE']  = [2, 4, 6, 8, 11, 13, 16, 19, 21, 24, 26, 28]
+    masked_layers['HEF'] = [7, 9, 11]
+    masked_layers['HEB'] = []
+    
+    mask_layers(layer_mask,masked_layers)
+    
+    process = cust_2023HGCalPandoraNoExtPix_common(process)
+    process = customise_me0(process)
+    if hasattr(process,'reconstruction_step'):
+        process = propagate_layerdropping(process,layer_mask)
+    
+    return process

--- a/RecoParticleFlow/PandoraTranslator/python/customizeHGCalPandora_cff.py
+++ b/RecoParticleFlow/PandoraTranslator/python/customizeHGCalPandora_cff.py
@@ -140,6 +140,114 @@ def cust_2023HGCalPandora_common(process):
         process.RECOSIMEventContent.outputCommands.append('keep *_pandorapfanew_*_*')
     return process
 
+def cust_2023HGCalPandoraNoExtPix_common(process):
+    process=customisePostLS1(process)
+    process=customiseBE5D(process)
+    process=customise_HcalPhase2(process)
+    process=customise_ev_BE5D(process)
+    process=customise_gem2023(process)
+    process=customise_rpc(process)
+    process=jetCustoms.customise_jets(process)
+    if hasattr(process,'L1simulation_step'):
+    	process.simEcalTriggerPrimitiveDigis.BarrelOnly = cms.bool(True)
+    if hasattr(process,'digitisation_step'):
+    	process.mix.digitizers.ecal.accumulatorType = cms.string('EcalPhaseIIDigiProducer')
+        process.load('SimGeneral.MixingModule.hgcalDigitizer_cfi')
+        process.mix.digitizers.hgceeDigitizer=process.hgceeDigitizer
+        process.mix.digitizers.hgchebackDigitizer=process.hgchebackDigitizer
+        process.mix.digitizers.hgchefrontDigitizer=process.hgchefrontDigitizer
+        # Also need to tell the MixingModule to make the correct collections available from
+        # the pileup, even if not creating CrossingFrames.
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgceeDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchebackDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.input.append( cms.InputTag("g4SimHits",process.hgchefrontDigitizer.hitCollection.value()) )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgceeDigitizer.hitCollection.value() )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgchebackDigitizer.hitCollection.value() )
+        process.mix.mixObjects.mixCH.subdets.append( process.hgchefrontDigitizer.hitCollection.value() )
+    if hasattr(process,'raw2digi_step'):
+        process.ecalDigis.FEDs = cms.vint32(
+            # EE-:
+            #601, 602, 603, 604, 605,
+            #606, 607, 608, 609,
+            # EB-:
+            610, 611, 612, 613, 614, 615,
+            616, 617, 618, 619, 620, 621,
+            622, 623, 624, 625, 626, 627,
+            # EB+:
+            628, 629, 630, 631, 632, 633,
+            634, 635, 636, 637, 638, 639,
+            640, 641, 642, 643, 644, 645,
+            # EE+:
+            #646, 647, 648, 649, 650,
+            #651, 652, 653, 654
+            )
+        print "RAW2DIGI only for EB FEDs"
+    if hasattr(process,'reconstruction_step'):
+        process.particleFlowRecHitHGCNoEB = cms.Sequence(process.particleFlowRecHitHGCEE+process.particleFlowRecHitHGCHEF)
+        process.particleFlowClusterHGCNoEB = cms.Sequence(process.particleFlowClusterHGCEE+process.particleFlowClusterHGCHEF)
+        process.particleFlowCluster += process.particleFlowRecHitHGCNoEB
+        process.particleFlowCluster += process.particleFlowClusterHGCNoEB
+        if hasattr(process,'particleFlowSuperClusterECAL'):
+            process.particleFlowSuperClusterHGCEE = process.particleFlowSuperClusterECAL.clone()
+            process.particleFlowSuperClusterHGCEE.useHGCEmPreID = cms.bool(True)
+            process.particleFlowSuperClusterHGCEE.PFClusters = cms.InputTag('particleFlowClusterHGCEE')
+            process.particleFlowSuperClusterHGCEE.use_preshower = cms.bool(False)
+            process.particleFlowSuperClusterHGCEE.PFSuperClusterCollectionEndcapWithPreshower = cms.string('')
+            process.particleFlowCluster += process.particleFlowSuperClusterHGCEE
+            if hasattr(process,'ecalDrivenElectronSeeds'):
+                process.ecalDrivenElectronSeeds.endcapSuperClusters = cms.InputTag('particleFlowSuperClusterHGCEE')
+                process.ecalDrivenElectronSeeds.SeedConfiguration.endcapHCALClusters = cms.InputTag('particleFlowClusterHGCHEF')
+                process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEMethodEndcap = cms.int32(3)
+                process.ecalDrivenElectronSeeds.SeedConfiguration.hOverEConeSizeEndcap = cms.double(0.087)
+                process.ecalDrivenElectronSeeds.SeedConfiguration.maxHOverEEndcaps = cms.double(0.1) 
+                process.ecalDrivenElectronSeeds.SeedConfiguration.z2MinB = cms.double(-0.15)
+                process.ecalDrivenElectronSeeds.SeedConfiguration.z2MaxB = cms.double(0.15)
+                if hasattr(process,'ecalDrivenGsfElectrons'):
+                    process.ecalDrivenGsfElectrons.hOverEMethodEndcap = cms.int32(3)
+                    process.ecalDrivenGsfElectrons.hOverEConeSizeEndcap = cms.double(0.087)
+                    process.ecalDrivenGsfElectrons.maxDeltaEtaEndcaps = cms.double(0.015)
+                    process.ecalDrivenGsfElectrons.hcalEndcapClusters = cms.InputTag('particleFlowClusterHGCHEF')
+                    if hasattr(process,'gsfElectrons'):
+                        process.gsfElectrons.hOverEMethodEndcap = cms.int32(3)
+                        process.gsfElectrons.hOverEConeSizeEndcap = cms.double(0.087)
+                        process.gsfElectrons.maxDeltaEtaEndcaps = cms.double(0.015)
+                        process.gsfElectrons.hcalEndcapClusters = cms.InputTag('particleFlowClusterHGCHEF')  
+        # load pandora customization (note we have removed HGC clusters entirely from standard ParticleFlow
+        # doing this)                
+        process.load('RecoParticleFlow.PandoraTranslator.HGCalTrackCollection_cfi')
+        process.load('RecoParticleFlow.PandoraTranslator.runPandora_cfi')
+        process.pandorapfanew.pf_electron_output_col = process.particleFlowTmp.pf_electron_output_col
+        process.particleFlowBlock.elementImporters[5].source = cms.InputTag('HGCalTrackCollection:TracksNotInHGCal')
+        process.pandoraSequence = cms.Sequence(process.HGCalTrackCollection*
+                                               process.particleFlowBlock*
+                                               process.pandorapfanew)
+        process.particleFlowReco.replace(process.particleFlowBlock,process.pandoraSequence)
+        process.particleFlowBarrel = process.particleFlowTmp.clone()        
+        process.particleFlowTmp = cms.EDProducer(
+            "PFCandidateListMerger",
+            src = cms.VInputTag("particleFlowBarrel",
+                                "pandorapfanew"),
+            src1 = cms.VInputTag("particleFlowBarrel:"+str(process.particleFlowTmp.pf_electron_output_col),
+                                 "pandorapfanew:"+str(process.particleFlowTmp.pf_electron_output_col)),
+            label1 = process.particleFlowTmp.pf_electron_output_col
+
+            )
+        process.mergedParticleFlowSequence = cms.Sequence(process.particleFlowBarrel*process.particleFlowTmp)
+        process.particleFlowReco.replace(process.particleFlowTmp,process.mergedParticleFlowSequence)
+
+    #mod event content
+    process.load('RecoLocalCalo.Configuration.hgcalLocalReco_EventContent_cff')
+    if hasattr(process,'FEVTDEBUGHLTEventContent'):
+        process.FEVTDEBUGHLTEventContent.outputCommands.extend(process.hgcalLocalRecoFEVT.outputCommands)
+        process.FEVTDEBUGHLTEventContent.outputCommands.append('keep *_particleFlowSuperClusterHGCEE_*_*')
+        process.FEVTDEBUGHLTEventContent.outputCommands.append('keep *_pandorapfanew_*_*')
+        
+    if hasattr(process,'RECOSIMEventContent'):
+        process.RECOSIMEventContent.outputCommands.extend(process.hgcalLocalRecoFEVT.outputCommands)
+        process.RECOSIMEventContent.outputCommands.append('keep *_particleFlowSuperClusterHGCEE_*_*')
+        process.RECOSIMEventContent.outputCommands.append('keep *_pandorapfanew_*_*')
+    return process
+
 def cust_2023HGCalPandoraMuon(process):
     process = cust_2023HGCalPandora_common(process)
     process = customise_me0(process)
@@ -223,3 +331,23 @@ def cust_2023HGCalPandoraMuonScopeDoc_ee18_fh9(process):
         process = propagate_layerdropping(process,layer_mask)
     
     return process
+
+#def cust_2023HGCalNoExtPix_ee18_fh9(process):
+#    layer_mask = {}
+#    layer_mask['EE']  = [1 for x in range(30)]
+#    layer_mask['HEF'] = [1 for x in range(12)]
+#    layer_mask['HEB'] = [1 for x in range(12)] 
+#    
+#    masked_layers = {}
+#    masked_layers['EE']  = [2, 4, 6, 8, 11, 13, 16, 19, 21, 24, 26, 28]
+#    masked_layers['HEF'] = [7, 9, 11]
+#    masked_layers['HEB'] = []
+#    
+#    mask_layers(layer_mask,masked_layers)
+#    
+#    process = cust_2023HGCalPandoraNoExtPix_common(process)
+#    process = customise_me0(process)
+#    if hasattr(process,'reconstruction_step'):
+#        process = propagate_layerdropping(process,layer_mask)
+#    
+#    return process


### PR DESCRIPTION
As requested for the Scope Document, I created a new scenario which corresponds to 
the scope scenario HGCAL version ee18 but where the tracker is not extended at high eta .
This PR can only work with #10152 

the New scenario are 
No PU  -->  -l 176XX
PU  -->  -l 178XX
(the latter cannot work yet, we need MinBias which this new geometry which will be generated with the next set of relvals ) 

NB at the same time , I reduced the length of the name for the already existing  hgcal descope scenario, the string length was preventing the workflows to be injected in relvals production..  
