### PR TITLE
Removing CSV+SL and adding SL taggers to the default PAT jet configuration

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -45,7 +45,8 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("pfSimpleSecondaryVertexHighPurBJetTags"),
         cms.InputTag("pfCombinedSecondaryVertexV2BJetTags"),
         cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-        cms.InputTag("pfCombinedSecondaryVertexSoftLeptonBJetTags"),
+        cms.InputTag("softPFMuonBJetTags"),
+        cms.InputTag("softPFElectronBJetTags"),
         cms.InputTag("pfCombinedMVABJetTags")
     ),
     # clone tag infos ATTENTION: these take lots of space!


### PR DESCRIPTION
Given the fact that the CombinedMVA tagger uses SL tagger discriminators as input, it would be beneficial to also have SL taggers stored in MiniAOD to speed up and simplify any future retrainings of ''supercombined" taggers.

@pvmulder @imarches @acaudron 
