### PR TITLE
adding stage1 specific run keys for online dqm in 74x

### DIFF
--- a/DQM/Integration/python/test/PlaybackInstall.patch
+++ b/DQM/Integration/python/test/PlaybackInstall.patch
@@ -13,3 +13,15 @@ index 86d7bda..f2e3ab2 100644
                    filter = cms.untracked.string('')
                    )
  
+diff --git a/DQM/Integration/python/test/hlt_dqm_clientPB-live_cfg.py b/DQM/Integration/python/test/hlt_dqm_clientPB-live_cfg.py
+index 49b2d0b..c780650 100644
+--- a/DQM/Integration/python/test/hlt_dqm_clientPB-live_cfg.py
++++ b/DQM/Integration/python/test/hlt_dqm_clientPB-live_cfg.py
+@@ -13,6 +13,6 @@ process.load("DQM.Integration.test.pbsource_cfi")
+ #----------------------------
+ process.load("DQM.Integration.test.environment_cfi")
+ process.dqmEnv.subSystemFolder = 'HLTpb'
+-process.dqmEnv.eventInfoFolder = 'EventInfo'
++process.dqmEnv.eventInfoFolder = 'EventInfo/Random'
+ process.dqmSaver.dirName = './HLT'
+ #-----------------------------

--- a/DQM/Integration/python/test/beam_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/beam_dqm_sourceclient-live_cfg.py
@@ -122,7 +122,7 @@ process.BeamSpotProblemModule = cms.Sequence( process.qTester
                                             )
 
 #make it off for cosmic run
-if ( process.runType.getRunType() == process.runType.cosmic_run):
+if ( process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
     process.dqmBeamSpotProblemMonitor.AlarmOFFThreshold = 5       #Should be < AlalrmONThreshold 
 #-----------------------------------------------------------
 
@@ -135,7 +135,9 @@ process = customise(process)
 # Proton-Proton Stuff
 #--------------------------
 
-if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.hpu_run):
+if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.pp_run_stage1 or
+    process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1 or 
+    process.runType.getRunType() == process.runType.hpu_run):
 
     print "[beam_dqm_sourceclient-live_cfg]:: Running pp"
 

--- a/DQM/Integration/python/test/beampixel_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/beampixel_dqm_sourceclient-live_cfg.py
@@ -49,7 +49,9 @@ process = customise(process)
 #----------------------------
 # Proton-Proton Specific Part
 #----------------------------
-if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.hpu_run):
+if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.pp_run_stage1 or 
+    process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1 or 
+    process.runType.getRunType() == process.runType.hpu_run):
     print "[beampixel_dqm_sourceclient-live_cfg]::running pp"
 
     process.castorDigis.InputLabel           = cms.InputTag("rawDataCollector")

--- a/DQM/Integration/python/test/dqmPythonTypes.py
+++ b/DQM/Integration/python/test/dqmPythonTypes.py
@@ -2,7 +2,7 @@
 from FWCore.ParameterSet.Types import PSet
 import FWCore.ParameterSet.Config as cms
 class RunType(PSet):
-  def __init__(self,types=['pp_run','cosmic_run','hi_run','hpu_run']):
+  def __init__(self,types=['pp_run','pp_run_stage1','cosmic_run','cosmic_run_stage1','hi_run','hpu_run']):
     PSet.__init__(self)
     self.__runTypesDict = {}
     t=[(x,types.index(x)) for x in types ]

--- a/DQM/Integration/python/test/ecal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/ecal_dqm_sourceclient-live_cfg.py
@@ -184,9 +184,9 @@ process.schedule = cms.Schedule(process.ecalMonitorPath,process.ecalClientPath,p
 
 referenceFileName = process.DQMStore.referenceFileName.pythonValue()
 runTypeName = process.runType.getRunTypeName()
-if runTypeName == 'pp_run':
+if (runTypeName == 'pp_run' or runTypeName == 'pp_run_stage1'):
     process.DQMStore.referenceFileName = referenceFileName.replace('.root', '_pp.root')
-elif runTypeName == 'cosmic_run':
+elif (runTypeName == 'cosmic_run' or runTypeName == 'cosmic_run_stage1'):
     process.DQMStore.referenceFileName = referenceFileName.replace('.root', '_cosmic.root')
 #    process.dqmEndPath.remove(process.dqmQTest)
     process.ecalMonitorTask.workers = ['EnergyTask', 'IntegrityTask', 'OccupancyTask', 'RawDataTask', 'TimingTask', 'TrigPrimTask', 'PresampleTask', 'SelectiveReadoutTask']

--- a/DQM/Integration/python/test/hcal_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/hcal_dqm_sourceclient-live_cfg.py
@@ -190,7 +190,7 @@ if (HEAVYION):
     process.hcalHotCellMonitor.ETThreshold = cms.untracked.double(10.0)
     process.hcalHotCellMonitor.ETThreshold_HF  = cms.untracked.double(10.0)
     
-if process.runType.getRunType() == process.runType.cosmic_run:
+if (process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
     process.hcalDetDiagTimingMonitor.CosmicsCorr=True
 
 

--- a/DQM/Integration/python/test/hlt_dqm_clientPB-live_cfg.py
+++ b/DQM/Integration/python/test/hlt_dqm_clientPB-live_cfg.py
@@ -12,8 +12,8 @@ process.load("DQM.Integration.test.pbsource_cfi")
 #### DQM Environment
 #----------------------------
 process.load("DQM.Integration.test.environment_cfi")
-process.dqmEnv.subSystemFolder = 'HLT'
-process.dqmEnv.eventInfoFolder = 'EventInfo/HLTfromPBfile'
+process.dqmEnv.subSystemFolder = 'HLTpb'
+process.dqmEnv.eventInfoFolder = 'EventInfo'
 process.dqmSaver.dirName = './HLT'
 #-----------------------------
 

--- a/DQM/Integration/python/test/l1t_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/l1t_dqm_sourceclient-live_cfg.py
@@ -78,6 +78,10 @@ process.RawToDigi.remove("castorDigis")
 # for GCT, unpack all five samples
 process.gctDigis.numberOfGctSamplesToUnpack = cms.uint32(5)
 
+if ( process.runType.getRunType() == process.runType.pp_run_stage1 or process.runType.getRunType() == process.runType.cosmic_run_stage1):
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(809)
+else:
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(813)
 # 
 process.l1tMonitorPath = cms.Path(process.l1tMonitorOnline)
 

--- a/DQM/Integration/python/test/l1temulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/l1temulator_dqm_sourceclient-live_cfg.py
@@ -70,6 +70,11 @@ process.RawToDigi.remove("siStripDigis")
 process.RawToDigi.remove("scalersRawToDigi")
 process.RawToDigi.remove("castorDigis")
 
+if ( process.runType.getRunType() == process.runType.pp_run_stage1 or process.runType.getRunType() == process.runType.cosmic_run_stage1):
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(809)
+else:
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(813)
+
 # L1HvVal + emulator monitoring path
 process.l1HwValEmulatorMonitorPath = cms.Path(process.l1HwValEmulatorMonitor)
 

--- a/DQM/Integration/python/test/l1tstage1_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/l1tstage1_dqm_sourceclient-live_cfg.py
@@ -78,7 +78,10 @@ process.RawToDigi.remove("castorDigis")
 # for GCT, unpack all five samples
 process.gctDigis.numberOfGctSamplesToUnpack = cms.uint32(5)
 
-process.gtDigis.DaqGtFedId = cms.untracked.int32(809)
+if (process.runType.getRunType() == process.runType.pp_run_stage1 or process.runType.getRunType() == process.runType.cosmic_run_stage1):
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(813)
+else:
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(809)
 # 
 
 # separate L1TSync path due to the use of the HltHighLevel filter

--- a/DQM/Integration/python/test/l1tstage1emulator_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/l1tstage1emulator_dqm_sourceclient-live_cfg.py
@@ -71,7 +71,10 @@ process.RawToDigi.remove("siStripDigis")
 process.RawToDigi.remove("scalersRawToDigi")
 process.RawToDigi.remove("castorDigis")
 
-process.gtDigis.DaqGtFedId = cms.untracked.int32(809)
+if ( process.runType.getRunType() == process.runType.pp_run_stage1 or process.runType.getRunType() == process.runType.cosmic_run_stage1):
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(813)
+else:
+    process.gtDigis.DaqGtFedId = cms.untracked.int32(809)
 
 # L1HvVal + emulator monitoring path
 process.l1HwValEmulatorMonitorPath = cms.Path(process.l1Stage1HwValEmulatorMonitor)

--- a/DQM/Integration/python/test/pbsource_cfi.py
+++ b/DQM/Integration/python/test/pbsource_cfi.py
@@ -27,7 +27,7 @@ options.register('skipFirstLumis',
 # Parameters for runType
 
 options.register ('runkey',
-          'cosmic_run',
+          'pp_run',
           VarParsing.VarParsing.multiplicity.singleton,
           VarParsing.VarParsing.varType.string,
           "Run Keys of CMS")
@@ -52,7 +52,7 @@ source = cms.Source("DQMProtobufReader",
     streamLabel = cms.untracked.string('streamDQMHistograms'),
 
     delayMillis = cms.untracked.uint32(500),
-    nextLumiTimeoutMillis = cms.untracked.int32(30000),
+    nextLumiTimeoutMillis = cms.untracked.int32(120000),
     skipFirstLumis = cms.untracked.bool(options.skipFirstLumis),
     deleteDatFiles = cms.untracked.bool(False),
     endOfRunKills  = cms.untracked.bool(True),

--- a/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/sistrip_dqm_sourceclient-live_cfg.py
@@ -113,7 +113,7 @@ process.load("Configuration.StandardSequences.RawToDigi_Data_cff")
 #process.siStripDigis.UnpackBadChannels = cms.bool(True)
 
 ## Cosmic Track Reconstruction
-if (process.runType.getRunType() == process.runType.cosmic_run):
+if (process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
     process.load("RecoTracker.Configuration.RecoTrackerP5_cff")
     process.load("Configuration.StandardSequences.ReconstructionCosmics_cff")
 else:
@@ -228,9 +228,9 @@ process.RecoForDQM_LocalReco     = cms.Sequence(process.siPixelDigis*process.siS
 process.SiStripMonitorDigi.TotalNumberOfDigisFailure.subdetswitchon = cms.bool(False)
 
 ### COSMIC RUN SETTING
-if (process.runType.getRunType() == process.runType.cosmic_run):
+if (process.runType.getRunType() == process.runType.cosmic_run or process.runType.getRunType() == process.runType.cosmic_run_stage1):
     # event selection for cosmic data
-    process.source.SelectEvents = cms.untracked.vstring('HLT*SingleMu*','HLT_L1*')
+    if (process.runType.getRunType() == process.runType.cosmic_run): process.source.SelectEvents = cms.untracked.vstring('HLT*SingleMu*','HLT_L1*')
     # Reference run for cosmic
     process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/sistrip_reference_cosmic.root'
     # Source config for cosmic data
@@ -288,14 +288,16 @@ if (process.runType.getRunType() == process.runType.cosmic_run):
 
 #else :
 ### pp COLLISION SETTING
-if (process.runType.getRunType() == process.runType.pp_run):
+if (process.runType.getRunType() == process.runType.pp_run or process.runType.getRunType() == process.runType.pp_run_stage1):
     #event selection for pp collisions
-    process.source.SelectEvents = cms.untracked.vstring(
-        'HLT_L1*',
-        'HLT_Jet*',
-        'HLT_Physics*',
-        'HLT_ZeroBias*'
-        )
+    if (process.runType.getRunType() == process.runType.pp_run):
+        process.source.SelectEvents = cms.untracked.vstring(
+            'HLT_L1*',
+            'HLT_Jet*',
+            'HLT_Physics*',
+            'HLT_ZeroBias*'
+            )
+
     process.DQMStore.referenceFileName = '/dqmdata/dqm/reference/sistrip_reference_pp.root'
     # Source and Client config for pp collisions
 

--- a/DQM/Integration/python/test/visualization-live-secondInstance_cfg.py
+++ b/DQM/Integration/python/test/visualization-live-secondInstance_cfg.py
@@ -8,7 +8,8 @@ Example configuration for online reconstruction meant for visualization clients.
 from DQM.Integration.test.inputsource_cfi import options,runType,source
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
-scenarios = {'pp_run': 'ppRun2','cosmic_run':'cosmicsRun2','hi_run':'HeavyIons'}
+#scenarios = {'pp_run': 'ppRun2','cosmic_run':'cosmicsRun2','hi_run':'HeavyIons'}
+scenarios = {'pp_run': 'ppRun2','pp_run_stage1': 'ppRun2','cosmic_run':'cosmicsRun2','cosmic_run_stage1':'cosmicsRun2','hi_run':'HeavyIons'}
 
 if not runType.getRunTypeName() in scenarios.keys():
     msg = "Error getting the scenario out of the 'runkey', no mapping for: %s\n"%runType.getRunTypeName()

--- a/DQM/Integration/python/test/visualization-live_cfg.py
+++ b/DQM/Integration/python/test/visualization-live_cfg.py
@@ -8,7 +8,8 @@ Example configuration for online reconstruction meant for visualization clients.
 from DQM.Integration.test.inputsource_cfi import options,runType,source
 
 # this is needed to map the names of the run-types chosen by DQM to the scenarios, ideally we could converge to the same names
-scenarios = {'pp_run': 'ppRun2','cosmic_run':'cosmicsRun2','hi_run':'HeavyIons'}
+#scenarios = {'pp_run': 'ppRun2','cosmic_run':'cosmicsRun2','hi_run':'HeavyIons'}
+scenarios = {'pp_run': 'ppRun2','pp_run_stage1': 'ppRun2','cosmic_run':'cosmicsRun2','cosmic_run_stage1':'cosmicsRun2','hi_run':'HeavyIons'}
 
 if not runType.getRunTypeName() in scenarios.keys():
     msg = "Error getting the scenario out of the 'runkey', no mapping for: %s\n"%runType.getRunTypeName()


### PR DESCRIPTION
Creating two new run keys needed for customizations within online DQM configurations during the l1stage1 tests. A few other minor fixes are also included.
