### PR TITLE
Update L1 configuration in Run 2 eras to match customisation functions

### DIFF
--- a/L1Trigger/Configuration/python/L1Reco_cff.py
+++ b/L1Trigger/Configuration/python/L1Reco_cff.py
@@ -35,6 +35,16 @@ from Configuration.StandardSequences.Eras import eras
 # A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
 modifyL1TriggerConfigurationL1RecoForRun2_ = eras.run2_common.makeProcessModifier( _loadMenuFromXML )
 
+#
+# If the Stage 1 trigger is running, there is also some different configuration than
+# the general Run 2 stuff.
+#
+def _customiseForStage1( processObject ) :
+    processObject.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
+    processObject.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
+# Again, a unique name is required so I'll use "modify<python filename>ForStage1Trigger_"
+modifyL1TriggerConfigurationL1RecoForStage1Trigger_ = eras.stage1L1Trigger.makeProcessModifier( _customiseForStage1 )
+
 # conditions in edm
 import EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi
 conditionsInEdm = EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi.conditionDumperInEdm.clone()

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -165,6 +165,7 @@ def _extendForStage1Trigger( theProcess ) :
     ProcessModifier that loads config fragments required for Run 2 into the process object.
     Also switches the GCT digis for the Stage1 digis in the SimL1Emulator sequence
     """
+    theProcess.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
     theProcess.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
     # Note that this function is applied before the objects in this file are added
     # to the process. So things declared in this file should be used "bare", i.e.


### PR DESCRIPTION
Title says it all.  Has no change whatsoever unless one of the Run 2 eras is active.

I'm about to put in another request on the same lines, but I've split it off to limit the number of signatures required.  I'll note the PR number here once it's been submitted.
