### PR TITLE
Update Run 2 eras to match customisation functions

### DIFF
--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -15,7 +15,7 @@ class Eras (object):
         
         # These are the eras that the user should specify
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
-        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
+        self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific, self.stage1L1Trigger )
         self.Run2_HI = cms.ModifierChain( self.run2_common, self.run2_HI_specific, self.stage1L1Trigger )
         
         # The only thing this collection is used for is for cmsDriver to

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -12,6 +12,11 @@ class Eras (object):
         self.run2_50ns_specific = cms.Modifier()
         self.run2_HI_specific = cms.Modifier()
         self.stage1L1Trigger = cms.Modifier()
+        # Implementation note: When this was first started, stage1L1Trigger wasn't in all
+        # of the eras. Now that it is, it could in theory be dropped if all changes are
+        # converted to run2_common (i.e. a search and replace of "stage1L1Trigger" to
+        # "run2_common" over the whole python tree). In practice, I don't think it's worth
+        # it, and this also gives the flexibilty to take it out easily.
         
         # These are the eras that the user should specify
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )

--- a/Configuration/StandardSequences/python/RawToDigi_cff.py
+++ b/Configuration/StandardSequences/python/RawToDigi_cff.py
@@ -104,6 +104,9 @@ castorDigis.InputLabel = 'rawDataCollector'
 ##
 ## Make changes for Run 2
 ##
+def _modifyRawToDigiForRun2( RawToDigi_object ) :
+    RawToDigi_object.remove(gtEvmDigis)
+
 def _modifyRawToDigiForStage1Trigger( theProcess ) :
     """
     Modifies the RawToDigi sequence if using the Stage 1 L1 trigger
@@ -118,5 +121,6 @@ def _modifyRawToDigiForStage1Trigger( theProcess ) :
     L1RawToDigiSeq = cms.Sequence( gctDigis + theProcess.caloStage1Digis + theProcess.caloStage1LegacyFormatDigis)
     RawToDigi.replace( gctDigis, L1RawToDigiSeq )
 
+eras.run2_common.toModify( RawToDigi, func=_modifyRawToDigiForRun2 )
 # A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
 modifyConfigurationStandardSequencesRawToDigiForRun2_ = eras.stage1L1Trigger.makeProcessModifier( _modifyRawToDigiForStage1Trigger )


### PR DESCRIPTION
Brings the configurations from era and customisations mostly into line.  Has no effect unless eras are being used.

Complimentary to (but not dependant on) #10171.  Just split off by package to limit the number of signatures required.  Still another pull request for FastSim to come.
