### PR TITLE
Fix checksum error caused by incomplete merge from 7_5_X

### DIFF
--- a/DataFormats/TrackerRecHit2D/src/classes_def.xml
+++ b/DataFormats/TrackerRecHit2D/src/classes_def.xml
@@ -9,7 +9,9 @@
    <version ClassVersion="11" checksum="1613493049"/>
    <version ClassVersion="10" checksum="877294307"/>
   </class>
-  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="11">
+  <class name="SiTrackerGSMatchedRecHit2D" ClassVersion="14">
+   <version ClassVersion="14" checksum="1823455267"/>
+   <version ClassVersion="13" checksum="1553184391"/>
    <version ClassVersion="12" checksum="2874379530"/>
    <version ClassVersion="11" checksum="1553184391"/>
    <version ClassVersion="10" checksum="3741285161"/>


### PR DESCRIPTION
This trivial, technical PR fixes the build error in package DataFormats/TrackerRecHit2D in 7_5_ROOT5_X due to a bad checksum.
This particular problem was caused by an incorrect merge from 7_5_X, so the new checksum is already in 7_5_X.  So there is no need for any change whatever to 7_5_X.
Please expedite, as this PR fixes a build error and is about as trivial as things get.
