### PR TITLE
Call public, not private, ctor of Ptr

### DIFF
--- a/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
+++ b/PhysicsTools/SelectorUtils/interface/VersionedSelector.h
@@ -28,6 +28,7 @@
 #endif
 
 #include "PhysicsTools/SelectorUtils/interface/Selector.h"
+#include "DataFormats/Provenance/interface/ProductID.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "PhysicsTools/SelectorUtils/interface/CandidateCut.h"
 #include "PhysicsTools/SelectorUtils/interface/CutApplicatorBase.h"
@@ -113,12 +114,12 @@ class VersionedSelector : public Selector<T> {
 
   /* VID BY VALUE */
   bool operator()( typename T::value_type const & t ) {
-    const T temp(&t,0); // assuming T is edm::Ptr
+    const T temp(edm::ProductID(),&t,0); // assuming T is edm::Ptr
     return this->operator()(temp);
   }
 
   bool operator()( typename T::value_type const & t, edm::EventBase const & e) {
-    const T temp(&t,0);
+    const T temp(edm::ProductID(),&t,0);
     return this->operator()(temp,e);
   }
   


### PR DESCRIPTION
Bug fix:  Two of the new templated "operator()" functions of class VersionedSelector call a constructor of Ptr that is private in CMSSW_7_4_X.  (That constructor in public in 7_5_X, so there is no issue in 7_5_X).
This does not cause a build error in 7_4_X because the function templates are never instantiated.
It is nonetheless a bug, as the functions will cause a compilation error if they are ever called.
In fact, in CMSSW_7_4_ROOT5_X, these functions are instantiated through the ROOT5 dictionary of class VersionedSelector, which causes three packages to fail to compile.
So this PR fixes all the current compilation errors in 7_4_ROOT5_X.  Since the same bug affects 7_4_X, this fix is being submitted for 7_4_X.
