### PR TITLE
remove L1Menu from postLS1 customization

### DIFF
--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -101,9 +101,10 @@ def customiseSimL1EmulatorForPostLS1_25ns(process):
     process = L1Menu_Collisions2015_25ns_v2(process)
     return process
 
-def customiseSimL1EmulatorForPostLS1_HI(process):
-    # load the Stage 1 configuration
-    process = customiseSimL1EmulatorForStage1(process)
+# additional customizations needed for HI:
+# -> no L1 Menu added here
+# -> common post LS1 customizations not called here
+def customiseSimL1EmulatorForPostLS1_Additional_HI(process):
     # set the Stage 1 heavy ions-specific parameters
     # all of these should eventually end up in a GT
     if hasattr(process,'RCTConfigProducers'):
@@ -118,8 +119,6 @@ def customiseSimL1EmulatorForPostLS1_HI(process):
         process.caloStage1Params.regionPUSType = cms.string("zeroWall")
     if hasattr(process,'caloConfig'):
         process.caloConfig.fwVersionLayer2 = cms.uint32(1)
-    # move to the heavy ions draft L1 menu once the HLT has been updated accordingly
-    process = L1Menu_CollisionsHeavyIons2015_v0(process)
     return process
 
 # This (UNTESTED/UNUSED) should allow for unpacking RAW data created with legacy 74X MC.

--- a/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
+++ b/SLHCUpgradeSimulations/Configuration/python/postLS1Customs.py
@@ -83,12 +83,16 @@ def customisePostLS1_50ns(process):
 
 def customisePostLS1_HI(process):
 
-    # deal with L1 Emulation separately
-    from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_HI
-    process = customiseSimL1EmulatorForPostLS1_HI(process)
-
     # common customisation
     process = customisePostLS1_Common(process)
+
+    # HI Specific additional customizations:
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForPostLS1_Additional_HI
+    process = customiseSimL1EmulatorForPostLS1_Additional_HI(process)
+
+    # HI L1Menu:
+    from L1Trigger.Configuration.customise_overwriteL1Menu import L1Menu_CollisionsHeavyIons2015_v0
+    process = L1Menu_CollisionsHeavyIons2015_v0(process)
 
     return process
 


### PR DESCRIPTION
This PR changes the postLS1 customizations to call only the common L1T post LS1 customizations, which do not include override of the L1Menu via XML file.  Now the L1Menu should come from the GT, even when the postLS1 customization is called.
