### PR TITLE
Updates the Run2 era to match recent changes in the customisations

### DIFF
--- a/FastSimulation/Configuration/python/L1Reco_cff.py
+++ b/FastSimulation/Configuration/python/L1Reco_cff.py
@@ -1,7 +1,12 @@
 import FWCore.ParameterSet.Config as cms
 
 # the only thing FastSim runs from L1Reco is l1extraParticles
-from L1Trigger.Configuration.L1Reco_cff import l1extraParticles
+from L1Trigger.Configuration.L1Reco_cff import l1extraParticles, _customiseForStage1
+
+# These next few lines copy the L1 era changes to FastSim
+from Configuration.StandardSequences.Eras import eras
+# A unique name is required so I'll use "modify<python filename>ForStage1Trigger_"
+modifyFastSimulationConfigurationL1RecoForStage1Trigger_ = eras.stage1L1Trigger.makeProcessModifier( _customiseForStage1 )
 
 # some collections have different labels
 l1extraParticles.isolatedEmSource    = cms.InputTag("simGctDigis","isoEm")

--- a/L1Trigger/Configuration/python/L1Reco_cff.py
+++ b/L1Trigger/Configuration/python/L1Reco_cff.py
@@ -35,6 +35,16 @@ from Configuration.StandardSequences.Eras import eras
 # A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
 modifyL1TriggerConfigurationL1RecoForRun2_ = eras.run2_common.makeProcessModifier( _loadMenuFromXML )
 
+#
+# If the Stage 1 trigger is running, there is also some different configuration than
+# the general Run 2 stuff.
+#
+def _customiseForStage1( processObject ) :
+    processObject.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
+    processObject.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
+# Again, a unique name is required so I'll use "modify<python filename>ForStage1Trigger_"
+modifyL1TriggerConfigurationL1RecoForStage1Trigger_ = eras.stage1L1Trigger.makeProcessModifier( _customiseForStage1 )
+
 # conditions in edm
 import EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi
 conditionsInEdm = EventFilter.L1GlobalTriggerRawToDigi.conditionDumperInEdm_cfi.conditionDumperInEdm.clone()

--- a/L1Trigger/Configuration/python/L1Reco_cff.py
+++ b/L1Trigger/Configuration/python/L1Reco_cff.py
@@ -18,22 +18,6 @@ from EventFilter.L1GlobalTriggerRawToDigi.l1GtRecord_cfi import *
 
 # L1GtTriggerMenuLite
 from EventFilter.L1GlobalTriggerRawToDigi.l1GtTriggerMenuLite_cfi import *
-#
-# If this is Run 2 then the trigger menu needs to be loaded from XML
-# instead of using l1GtTriggerMenuLite
-#
-def _loadMenuFromXML( processObject ) :
-    """
-    Imports the required producer to load the L1 menu from XML and creates an
-    ESPrefer to prefer that. The actual filename of the menu is specified in
-    era customisations within these imports.
-    """
-    processObject.load( 'L1TriggerConfig.L1GtConfigProducers.l1GtTriggerMenuXml_cfi' )
-    processObject.load( 'L1TriggerConfig.L1GtConfigProducers.L1GtTriggerMenuConfig_cff' )
-    processObject.es_prefer_l1GtParameters = cms.ESPrefer( 'L1GtTriggerMenuXmlProducer', 'l1GtTriggerMenuXml' )
-from Configuration.StandardSequences.Eras import eras
-# A unique name is required for this object, so I'll call it "modify<python filename>ForRun2_"
-modifyL1TriggerConfigurationL1RecoForRun2_ = eras.run2_common.makeProcessModifier( _loadMenuFromXML )
 
 #
 # If the Stage 1 trigger is running, there is also some different configuration than
@@ -42,7 +26,8 @@ modifyL1TriggerConfigurationL1RecoForRun2_ = eras.run2_common.makeProcessModifie
 def _customiseForStage1( processObject ) :
     processObject.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
     processObject.load('L1Trigger.L1TCalorimeter.caloConfigStage1PP_cfi')
-# Again, a unique name is required so I'll use "modify<python filename>ForStage1Trigger_"
+# A unique name is required so I'll use "modify<python filename>ForStage1Trigger_"
+from Configuration.StandardSequences.Eras import eras
 modifyL1TriggerConfigurationL1RecoForStage1Trigger_ = eras.stage1L1Trigger.makeProcessModifier( _customiseForStage1 )
 
 # conditions in edm

--- a/L1Trigger/Configuration/python/SimL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/SimL1Emulator_cff.py
@@ -165,6 +165,7 @@ def _extendForStage1Trigger( theProcess ) :
     ProcessModifier that loads config fragments required for Run 2 into the process object.
     Also switches the GCT digis for the Stage1 digis in the SimL1Emulator sequence
     """
+    theProcess.load('L1Trigger.L1TCalorimeter.caloStage1Params_cfi')
     theProcess.load('L1Trigger.L1TCalorimeter.L1TCaloStage1_cff')
     # Note that this function is applied before the objects in this file are added
     # to the process. So things declared in this file should be used "bare", i.e.


### PR DESCRIPTION
Copies the L1 trigger era updates from FullSim to FastSim.  Has no effect whatsoever unless one of the Run 2 eras is active.

EDIT since opening - since the L1 FullSim changes were requires for this PR, I included them here and closed the other separate PR.
