### PR TITLE
kCanRebin is not supported in ROOT6

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
+++ b/Alignment/MillePedeAlignmentAlgorithm/src/MillePedeMonitor.cc
@@ -241,7 +241,7 @@ bool MillePedeMonitor::init(TDirectory *directory)
     (new TH2F("derivativesVsPhi", 
               "derivatives vs. #phi;#phi(geomDet);#partial(x/y)_{local}/#partial(param)",
 	      50, -TMath::Pi(), TMath::Pi(), 101, -300., 300.));
-  //  myTrajectoryHists2D.back()->SetBit(TH1::kCanRebin);
+  //  myTrajectoryHists2D.back()->SetCanExtend(TH1::kAllAxes);
 
   TDirectory *dirTraject = directory->mkdir("refTrajectoryHists", "ReferenceTrajectory's");
   this->addToDirectory(myTrajectoryHists2D, dirTraject);
@@ -344,12 +344,12 @@ bool MillePedeMonitor::init(TDirectory *directory)
   // Here for x-measurements:
   std::vector<TH1*> allResidHistsX;
   allResidHistsX.push_back(new TH1F("resid", "hit residuals;residuum [cm]", 101,-.5,.5));//51,-.05, .05));
-  //allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  //allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("sigma", "hit uncertainties;#sigma [cm]", 100,0.,1.));//50, 0., .02));
-  //allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  //allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("reduResid", "reduced hit residuals;res./#sigma",
 				    101, -10., 10.));//51, -3., 3.));
-  //  allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  //  allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("angle", "#phi_{tr} wrt normal (sens. plane);#phi_{n}^{sens}",
 				    50, 0., TMath::PiOver2()));
   allResidHistsX.push_back(new TH2F("residVsAngle",
@@ -366,23 +366,23 @@ bool MillePedeMonitor::init(TDirectory *directory)
   allResidHistsX.push_back(new TH1F("residGt45",
 				    "hit residuals (#phi_{n}^{sens}>45#circ);residuum [cm]",
 				    101, -.5, .5));//51, -.05, .05));
-  // allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  // allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("sigmaGt45",
 				    "hit uncertainties(#phi_{n}^{sens}>45#circ);#sigma [cm]",
 				     100, 0., 1.));//50, 0., .02));
-  // allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  // allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("reduResidGt45",
 				    "reduced hit residuals(#phi_{n}^{sens}>45#circ);res./#sigma",
                                     101, -10., 10.));//51,-3.,3.));
-  // allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  // allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("residLt45",
 				    "hit residuals (#phi_{n}^{sens}<45#circ);residuum [cm]",
 				    101, -.5, .5));//51, -.15, .15));
-  // allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  // allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("sigmaLt45",
 				    "hit uncertainties(#phi_{n}^{sens}<45#circ);#sigma [cm]",
 				    100, 0., 1.));//50, 0., .01));
-  // allResidHistsX.back()->SetBit(TH1::kCanRebin);
+  // allResidHistsX.back()->SetCanExtend(TH1::kAllAxes);
   allResidHistsX.push_back(new TH1F("reduResidLt45",
 				    "reduced hit residuals(#phi_{n}^{sens}<45#circ);res./#sigma",
 				    101, -10., 10.));//51,-3.,3.));
@@ -445,12 +445,12 @@ bool MillePedeMonitor::init(TDirectory *directory)
         (new TH2F(Form("frame2framePhi%d%d", i, j),
                   Form("frame to frame derivatives, %d%d;#phi(aliDet);deriv",i,j),
                   51, -TMath::Pi(), TMath::Pi(), 10, 0., 1.));
-      myFrame2FrameHists2D.back()->SetBit(TH1::kCanRebin);
+      myFrame2FrameHists2D.back()->SetCanExtend(TH1::kAllAxes);
       myFrame2FrameHists2D.push_back
         (new TH2F(Form("frame2frameR%d%d", i, j),
                   Form("frame to frame derivatives, %d%d;r(aliDet);deriv",i,j),
                   51, 0., 110., 10, 0., 1.));
-      myFrame2FrameHists2D.back()->SetBit(TH1::kCanRebin);
+      myFrame2FrameHists2D.back()->SetCanExtend(TH1::kAllAxes);
 
       myFrame2FrameHists2D.push_back
         (new TH2F(Form("frame2framePhiLog%d%d", i, j),

--- a/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
+++ b/CalibTracker/SiStripChannelGain/plugins/SiStripGainCosmicCalculator.cc
@@ -282,9 +282,9 @@ SiStripApvGain * SiStripGainCosmicCalculator::getNewObject() {
 
   std::cout<<"total_nr_of_events="<<total_nr_of_events<<std::endl;
   // book some more histograms
-  TH1F *ChargeOfEachAPVPair = new TH1F("ChargeOfEachAPVPair","ChargeOfEachAPVPair",1,0,1); ChargeOfEachAPVPair->SetBit(TH1::kCanRebin);
-  TH1F *EntriesApvPairs = new TH1F("EntriesApvPairs","EntriesApvPairs",1,0,1); EntriesApvPairs->SetBit(TH1::kCanRebin);
-  TH1F * NrOfEntries = new TH1F("NrOfEntries","NrOfEntries",351,-0.5,350.5);// NrOfEntries->SetBit(TH1::kCanRebin);
+  TH1F *ChargeOfEachAPVPair = new TH1F("ChargeOfEachAPVPair","ChargeOfEachAPVPair",1,0,1); ChargeOfEachAPVPair->SetCanExtend(TH1::kAllAxes);
+  TH1F *EntriesApvPairs = new TH1F("EntriesApvPairs","EntriesApvPairs",1,0,1); EntriesApvPairs->SetCanExtend(TH1::kAllAxes);
+  TH1F * NrOfEntries = new TH1F("NrOfEntries","NrOfEntries",351,-0.5,350.5);// NrOfEntries->SetCanExtend(TH1::kAllAxes);
   TH1F * ModuleThickness = new TH1F("ModuleThickness","ModuleThickness",2,0.5,2.5); HlistOtherHistos->Add(ModuleThickness);
   ModuleThickness->GetXaxis()->SetBinLabel(1,"320mu"); ModuleThickness->GetXaxis()->SetBinLabel(2,"500mu"); ModuleThickness->SetYTitle("Nr APVPairs");
   TH1F * ModuleWidth = new TH1F("ModuleWidth","ModuleWidth",5,0.5,5.5); HlistOtherHistos->Add(ModuleWidth);
@@ -323,8 +323,8 @@ SiStripApvGain * SiStripGainCosmicCalculator::getNewObject() {
   MeanCharge = MeanCharge / NrOfApvPairs;
   // calculate correction
   TH1F* CorrectionOfEachAPVPair = (TH1F*) ChargeOfEachAPVPair->Clone("CorrectionOfEachAPVPair");
-  TH1F *ChargeOfEachAPVPairControlView = new TH1F("ChargeOfEachAPVPairControlView","ChargeOfEachAPVPairControlView",1,0,1); ChargeOfEachAPVPairControlView->SetBit(TH1::kCanRebin);
-TH1F *CorrectionOfEachAPVPairControlView = new TH1F("CorrectionOfEachAPVPairControlView","CorrectionOfEachAPVPairControlView",1,0,1); CorrectionOfEachAPVPairControlView->SetBit(TH1::kCanRebin);
+  TH1F *ChargeOfEachAPVPairControlView = new TH1F("ChargeOfEachAPVPairControlView","ChargeOfEachAPVPairControlView",1,0,1); ChargeOfEachAPVPairControlView->SetCanExtend(TH1::kAllAxes);
+TH1F *CorrectionOfEachAPVPairControlView = new TH1F("CorrectionOfEachAPVPairControlView","CorrectionOfEachAPVPairControlView",1,0,1); CorrectionOfEachAPVPairControlView->SetCanExtend(TH1::kAllAxes);
   std::ofstream APVPairTextOutput("apvpair_corrections.txt");
   APVPairTextOutput<<"# MeanCharge = "<<MeanCharge<<std::endl;
   APVPairTextOutput<<"# Nr. of APVPairs = "<<NrOfApvPairs<<std::endl;

--- a/CondCore/RPCPlugins/plugins/RPCObVmonPyWrapper.cc
+++ b/CondCore/RPCPlugins/plugins/RPCObVmonPyWrapper.cc
@@ -303,7 +303,7 @@ namespace cond {
     gStyle->SetPalette(1);
 
     TH1D *vDistr=new TH1D("vDistr","IOV-averaged HV Distribution;Average HV (V);Entries/0.2 #muA",100,5000.,10000.);
-    TH1D *rmsDistr=new TH1D("rmsDistr","RMS over IOV-HV Distribution;HV RMS (V);Entries/0.2 #muA",1000,0.,1000.);//rmsDistr->SetBit(TH1::kCanRebin);
+    TH1D *rmsDistr=new TH1D("rmsDistr","RMS over IOV-HV Distribution;HV RMS (V);Entries/0.2 #muA",1000,0.,1000.);//rmsDistr->SetCanExtend(TH1::kAllAxes);
 
     //BEGIN OF NEW DB-SESSION PART
     //hardcoded values

--- a/DQMServices/Components/plugins/EDMtoMEConverter.cc
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.cc
@@ -186,7 +186,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me1[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me1[i] && me1[i]->getTH1F() && me1[i]->getTH1F()->TestBit(TH1::kCanRebin) == true) {
+          if (me1[i] && me1[i]->getTH1F() && me1[i]->getTH1F()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me1[i]->getTH1F()->Merge(&list) == -1)
@@ -245,7 +245,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me1[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me1[i] && me1[i]->getTH1S() && me1[i]->getTH1S()->TestBit(TH1::kCanRebin) == true) {
+          if (me1[i] && me1[i]->getTH1S() && me1[i]->getTH1S()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me1[i]->getTH1S()->Merge(&list) == -1)
@@ -304,7 +304,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me1[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me1[i] && me1[i]->getTH1D() && me1[i]->getTH1D()->TestBit(TH1::kCanRebin) == true) {
+          if (me1[i] && me1[i]->getTH1D() && me1[i]->getTH1D()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me1[i]->getTH1D()->Merge(&list) == -1)
@@ -363,7 +363,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me2[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me2[i] && me2[i]->getTH2F() && me2[i]->getTH2F()->TestBit(TH1::kCanRebin) == true) {
+          if (me2[i] && me2[i]->getTH2F() && me2[i]->getTH2F()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me2[i]->getTH2F()->Merge(&list) == -1)
@@ -422,7 +422,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me2[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me2[i] && me2[i]->getTH2S() && me2[i]->getTH2S()->TestBit(TH1::kCanRebin) == true) {
+          if (me2[i] && me2[i]->getTH2S() && me2[i]->getTH2S()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me2[i]->getTH2S()->Merge(&list) == -1)
@@ -481,7 +481,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me2[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me2[i] && me2[i]->getTH2D() && me2[i]->getTH2D()->TestBit(TH1::kCanRebin) == true) {
+          if (me2[i] && me2[i]->getTH2D() && me2[i]->getTH2D()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me2[i]->getTH2D()->Merge(&list) == -1)
@@ -540,7 +540,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me3[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me3[i] && me3[i]->getTH3F() && me3[i]->getTH3F()->TestBit(TH1::kCanRebin) == true) {
+          if (me3[i] && me3[i]->getTH3F() && me3[i]->getTH3F()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me3[i]->getTH3F()->Merge(&list) == -1)
@@ -600,7 +600,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me4[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me4[i] && me4[i]->getTProfile() && me4[i]->getTProfile()->TestBit(TH1::kCanRebin) == true) {
+          if (me4[i] && me4[i]->getTProfile() && me4[i]->getTProfile()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me4[i]->getTProfile()->Merge(&list) == -1)
@@ -659,7 +659,7 @@ EDMtoMEConverter::getData(T& iGetFrom, bool iEndRun)
         // define new monitor element
         if (dbe) {
           me5[i] = dbe->get(dir+"/"+metoedmobject[i].object.GetName());
-          if (me5[i] && me5[i]->getTProfile2D() && me5[i]->getTProfile2D()->TestBit(TH1::kCanRebin) == true) {
+          if (me5[i] && me5[i]->getTProfile2D() && me5[i]->getTProfile2D()->CanExtendAllAxes()) {
             TList list;
             list.Add(&metoedmobject[i].object);
             if (me5[i]->getTProfile2D()->Merge(&list) == -1)

--- a/DQMServices/Components/src/DQMProvInfo.cc
+++ b/DQMServices/Components/src/DQMProvInfo.cc
@@ -85,14 +85,14 @@ DQMProvInfo::beginRun(const edm::Run& r, const edm::EventSetup &c ) {
   reportSummaryMap_->setBinLabel(28,"Stable B",2);
   reportSummaryMap_->setBinLabel(29,"Valid",2);
   reportSummaryMap_->setAxisTitle("Luminosity Section");
-  reportSummaryMap_->getTH2F()->SetBit(TH1::kCanRebin);
+  reportSummaryMap_->getTH2F()->SetCanExtend(TH1::kAllAxes);
 
   dbe_->cd();  
   dbe_->setCurrentFolder(subsystemname_ +"/LhcInfo/");
   hBeamMode_=dbe_->book1D("beamMode","beamMode",XBINS,1.,XBINS+1);
   hBeamMode_->getTH1F()->GetYaxis()->Set(21,0.5,21.5);
   hBeamMode_->getTH1F()->SetMaximum(21.5);
-  hBeamMode_->getTH1F()->SetBit(TH1::kCanRebin);
+  hBeamMode_->getTH1F()->SetCanExtend(TH1::kAllAxes);
 
   hBeamMode_->setAxisTitle("Luminosity Section",1);
   hBeamMode_->setBinLabel(1,"no mode",2);
@@ -121,20 +121,20 @@ DQMProvInfo::beginRun(const edm::Run& r, const edm::EventSetup &c ) {
 
   hLhcFill_=dbe_->book1D("lhcFill","LHC Fill Number",XBINS,1.,XBINS+1);
   hLhcFill_->setAxisTitle("Luminosity Section",1);
-  hLhcFill_->getTH1F()->SetBit(TH1::kCanRebin);
+  hLhcFill_->getTH1F()->SetCanExtend(TH1::kAllAxes);
   
   hMomentum_=dbe_->book1D("momentum","Beam Energy [GeV]",XBINS,1.,XBINS+1);
   hMomentum_->setAxisTitle("Luminosity Section",1);
-  hMomentum_->getTH1F()->SetBit(TH1::kCanRebin);
+  hMomentum_->getTH1F()->SetCanExtend(TH1::kAllAxes);
 
   hIntensity1_=dbe_->book1D("intensity1","Intensity Beam 1",XBINS,1.,XBINS+1);
   hIntensity1_->setAxisTitle("Luminosity Section",1);
   hIntensity1_->setAxisTitle("N [E10]",2);
-  hIntensity1_->getTH1F()->SetBit(TH1::kCanRebin);
+  hIntensity1_->getTH1F()->SetCanExtend(TH1::kAllAxes);
   hIntensity2_=dbe_->book1D("intensity2","Intensity Beam 2",XBINS,1.,XBINS+1);
   hIntensity2_->setAxisTitle("Luminosity Section",1);
   hIntensity2_->setAxisTitle("N [E10]",2);
-  hIntensity2_->getTH1F()->SetBit(TH1::kCanRebin);
+  hIntensity2_->getTH1F()->SetCanExtend(TH1::kAllAxes);
 
   dbe_->cd();  
   dbe_->setCurrentFolder(subsystemname_ +"/ProvInfo/");

--- a/DQMServices/Core/src/MonitorElement.cc
+++ b/DQMServices/Core/src/MonitorElement.cc
@@ -1201,8 +1201,8 @@ MonitorElement::addProfiles(TProfile *h1, TProfile *h2, TProfile *sum, float c1,
   Double_t stats2[NUM_STAT];
   Double_t stats3[NUM_STAT];
 
-  bool isRebinOn = sum->TestBit(TH1::kCanRebin);
-  sum->ResetBit(TH1::kCanRebin);
+  bool isRebinOn = sum->CanExtendAllAxes();
+  sum->SetCanExtend(TH1::kNoAxis);
 
   for (Int_t i = 0; i < NUM_STAT; ++i)
     stats1[i] = stats2[i] = stats3[i] = 0;
@@ -1234,7 +1234,7 @@ MonitorElement::addProfiles(TProfile *h1, TProfile *h2, TProfile *sum, float c1,
 
   sum->SetEntries(entries);
   sum->PutStats(stats3);
-  if (isRebinOn) sum->SetBit(TH1::kCanRebin);
+  if (isRebinOn) sum->SetCanExtend(TH1::kAllAxes);
 }
 
 // implementation: Giuseppe.Della-Ricca@ts.infn.it
@@ -1251,8 +1251,8 @@ MonitorElement::addProfiles(TProfile2D *h1, TProfile2D *h2, TProfile2D *sum, flo
   Double_t stats2[NUM_STAT];
   Double_t stats3[NUM_STAT];
 
-  bool isRebinOn = sum->TestBit(TH1::kCanRebin);
-  sum->ResetBit(TH1::kCanRebin);
+  bool isRebinOn = sum->CanExtendAllAxes();
+  sum->SetCanExtend(TH1::kNoAxis);
 
   for (Int_t i = 0; i < NUM_STAT; ++i)
     stats1[i] = stats2[i] = stats3[i] = 0;
@@ -1286,7 +1286,7 @@ MonitorElement::addProfiles(TProfile2D *h1, TProfile2D *h2, TProfile2D *sum, flo
     }
   sum->SetEntries(entries);
   sum->PutStats(stats3);
-  if (isRebinOn) sum->SetBit(TH1::kCanRebin);
+  if (isRebinOn) sum->SetCanExtend(TH1::kAllAxes);
 }
 
 void

--- a/DataFormats/Histograms/interface/MEtoEDMFormat.h
+++ b/DataFormats/Histograms/interface/MEtoEDMFormat.h
@@ -126,7 +126,7 @@ class MEtoEDM
        std::cout << "WARNING MEtoEDM::mergeProducts(): adding new histogram '" << name << "'" << std::endl;
 #endif
        MEtoEdmObject.push_back(newMEtoEDMObject[i]);
-     } else if (MEtoEdmObject[j].object.TestBit(TH1::kCanRebin) == true && newMEtoEDMObject[i].object.TestBit(TH1::kCanRebin) == true) {
+     } else if (MEtoEdmObject[j].object.CanExtendAllAxes() && newMEtoEDMObject[i].object.CanExtendAllAxes()) {
        TList list;
        list.Add((TObject*)&newMEtoEDMObject[i].object);
        if (MEtoEdmObject[j].object.Merge(&list) == -1) {

--- a/DataFormats/Histograms/test/metoedmformat_t.cc
+++ b/DataFormats/Histograms/test/metoedmformat_t.cc
@@ -312,7 +312,7 @@ namespace {
     const Axis* GetYaxis() const {return &Axis::dummy;}
     const Axis* GetZaxis() const {return &Axis::dummy;}
 
-    bool TestBit(unsigned int f) const{return false;}
+    bool CanExtendAllAxes() const{return false;}
     long long Merge(void *) {return -1;}
 
     int m_i;

--- a/FWCore/ROOTTests/test/tprofile_threaded_t.cc
+++ b/FWCore/ROOTTests/test/tprofile_threaded_t.cc
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
   for(int i=0; i<kNThreads; ++i) {
     std::ostringstream s;
     profiles.push_back(std::unique_ptr<TProfile>(new TProfile(s.str().c_str(),s.str().c_str(), 100,10,11,0,10)));
-    profiles.back()->SetBit(TH1::kCanRebin);
+    profiles.back()->SetCanExtend(TH1::kAllAxes);
     auto profile = profiles.back().get();
     threads.emplace_back([i,profile,&canStart]() {
         static thread_local TThread guard;

--- a/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
+++ b/FastSimulation/ParticleDecay/plugins/TestPythiaDecays.cc
@@ -179,7 +179,7 @@ TestPythiaDecays::TestPythiaDecays(const edm::ParameterSet& iConfig)
     strstr.str("");
     strstr << "br_" << pid;
     h_br[pid] = new TH1D(strstr.str().c_str(),strstr.str().c_str(),0,0,0);
-    h_br[pid]->SetBit(TH1::kCanRebin);
+    h_br[pid]->SetCanExtend(TH1::kAllAxes);
     h_br_ref[pid] = (TH1D*)(h_br[pid]->Clone(strstr.str().c_str()));
     h_br_ref[pid]->SetTitle(h_br_ref[pid]->GetName());
     knownDecayModes[pid] = vector<string>();

--- a/HLTriggerOffline/Egamma/macros/GetOptimization.C
+++ b/HLTriggerOffline/Egamma/macros/GetOptimization.C
@@ -612,7 +612,7 @@ void GetOptimization() {
   }
 
   TH1F *timingSig = new TH1F("timingSig", "Timing of Single Electron Filters in Signal Events", 6, 0, 6);
-  timingSig->SetBit(TH1::kCanRebin);
+  timingSig->SetCanExtend(TH1::kAllAxes);
   timingSig->SetStats(0);
   TTreeFormula *l1MatchTiming = new TTreeFormula("Timing","HLTTiming_hltCutVars_IsoTiming_EGAMMAHLT.obj.l1Match",sigEvents);
   TTreeFormula *EtTiming = new TTreeFormula("Timing","HLTTiming_hltCutVars_IsoTiming_EGAMMAHLT.obj.Et",sigEvents);
@@ -646,7 +646,7 @@ void GetOptimization() {
   timingSig->LabelsOption("v");
 
   TH1F *timingBkg = new TH1F("timingBkg", "Timing of Single Electron Filters in Background Events", 6, 0, 6);
-  timingBkg->SetBit(TH1::kCanRebin);
+  timingBkg->SetCanExtend(TH1::kAllAxes);
   timingBkg->SetStats(0);
   avgL1Match = 0.;
   avgEt = 0.;
@@ -693,7 +693,7 @@ void GetOptimization() {
   delete timingBkg;
 
   timingSig = new TH1F("timingSig", "Timing of Single Photon Filters in Signal Events", 6, 0, 6);
-  timingSig->SetBit(TH1::kCanRebin);
+  timingSig->SetCanExtend(TH1::kAllAxes);
   timingSig->SetStats(0);
   delete l1MatchTiming; l1MatchTiming = new TTreeFormula("Timing","HLTTiming_hltCutVars_IsoTiming_EGAMMAHLT.obj.l1Match",sigEvents);
   delete EtTiming; EtTiming = new TTreeFormula("Timing","HLTTiming_hltCutVars_IsoTiming_EGAMMAHLT.obj.Et",sigEvents);
@@ -723,7 +723,7 @@ void GetOptimization() {
   timingSig->LabelsOption("v");
 
   timingBkg = new TH1F("timingBkg", "Timing of Single Photon Filters in Background Events", 6, 0, 6);
-  timingBkg->SetBit(TH1::kCanRebin);
+  timingBkg->SetCanExtend(TH1::kAllAxes);
   timingBkg->SetStats(0);
   avgL1Match = 0.;
   avgEt = 0.;

--- a/HeavyIonsAnalysis/Configuration/macros/fwliteExample.C
+++ b/HeavyIonsAnalysis/Configuration/macros/fwliteExample.C
@@ -64,7 +64,7 @@ void fwliteExample(bool debug=false){
   TH1D *hL1TechBits = new TH1D("hL1TechBits","L1 technical trigger bits before mask",64,-0.5,63.5);
   TH2D *hHfTowers   = new TH2D("hHfTowers","Number of HF tower above threshold; positive side; negative side",80,-0.5,79.5,80,-0.5,79.5);
   TH1D *hHLTPaths   = new TH1D("hHLTPaths","HLT Paths",3,0,3);
-  hHLTPaths->SetBit(TH1::kCanRebin);
+  hHLTPaths->SetCanExtend(TH1::kAllAxes);
 
   // vtx hists
   outFile->cd(); outFile->mkdir("vtx"); outFile->cd("vtx");

--- a/PhysicsTools/FWLite/interface/Scanner.h
+++ b/PhysicsTools/FWLite/interface/Scanner.h
@@ -237,7 +237,7 @@ namespace fwlite {
                 if (hist == 0) {
                     if (strcmp(hname, "htemp") == 0) htempDelete();
                     hist = new TH1F(hname, "", gEnv->GetValue("Hist.Binning.1D.x",100), 0, 0);
-                    hist->SetBit(TH1::kCanRebin);
+                    hist->SetCanExtend(TH1::kAllAxes);
                 }
                 hist->SetTitle((strlen(cut) ? TString(expr)+"{"+cut+"}" : TString(expr)));
                 hist->GetXaxis()->SetTitle(expr);
@@ -322,7 +322,7 @@ namespace fwlite {
                 if (hist == 0) {
                     if (strcmp(hname, "htemp") == 0) htempDelete();
                     hist = new TProfile(hname, "", gEnv->GetValue("Hist.Binning.1D.x",100), 0., 0.);
-                    hist->SetBit(TProfile::kCanRebin);
+                    hist->SetCanExtend(TH1::kAllAxes);
                 }
                 return drawProf(xexpr, yexpr, cut, drawopt, hist);
             }

--- a/PhysicsTools/KinFitter/src/TSLToyGen.cc
+++ b/PhysicsTools/KinFitter/src/TSLToyGen.cc
@@ -425,7 +425,7 @@ void  TSLToyGen::createHists() {
 	TH1D* newhisto =  new TH1D( name, name, 100, arrmin[h], arrmax[h]) ; 
 	((TObjArray*) histarrays[h])->Add( newhisto );
 
-	//	newhisto->SetBit(TH1::kCanRebin);
+	//	newhisto->SetCanExtend(TH1::kAllAxes);
       }
     }
   }


### PR DESCRIPTION
For ROOT histograms, kCanRebin is not supported in ROOT6.  This PR replaces all remaining uses of kCanRebin with the ROOT6 equivalents.
A change has already been committed in both ROOT 6.02 and ROOT 6.04 so that kCanRebin will no longer compile, so this PR is neceessary.
