### PR TITLE
Castor fs noncompensation 7 6 0 pre1

### DIFF
--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -99,24 +99,27 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
   if (aStep == NULL) 
     return 0;
 
+  // Get theTrack 
+  G4Track*        theTrack = aStep->GetTrack();
+
   // preStepPoint information *********************************************
   
   G4StepPoint*       preStepPoint = aStep->GetPreStepPoint();
   G4VPhysicalVolume* currentPV    = preStepPoint->GetPhysicalVolume();
   G4LogicalVolume*   currentLV    = currentPV->GetLogicalVolume();
+
+#ifdef debugLog
   G4String           name   = currentPV->GetName();
   std::string        nameVolume;
   nameVolume.assign(name,0,4);
-  
-#ifdef debugLog
+
   G4SteppingControl  stepControlFlag = aStep->GetControlFlag();
   if (aStep->IsFirstStepInVolume()) 
     LogDebug("ForwardSim") << "CastorSD::getEnergyDeposit:"
 			   << "\n IsFirstStepInVolume " ; 
 #endif
+
     
-  // Get theTrack 
-  G4Track*        theTrack = aStep->GetTrack();
     
 #ifdef debugLog
   if (useShowerLibrary && currentLV==lvCAST) {
@@ -226,28 +229,32 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
     //        G4Material*        mat   = lv->GetMaterial();
     //        G4double           rad   = mat->GetRadlen();
     
-    
+   
+#ifdef debugLog
     // postStepPoint information *********************************************
     G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
     G4VPhysicalVolume* postPV    = postStepPoint->GetPhysicalVolume();
+
     G4String           postname   = postPV->GetName();
     std::string        postnameVolume;
     postnameVolume.assign(postname,0,4);
-    
+
     // theTrack information  *************************************************
     // G4Track*        theTrack = aStep->GetTrack();   
     //G4double        entot    = theTrack->GetTotalEnergy();
     G4ThreeVector   vert_mom = theTrack->GetVertexMomentumDirection();
-    
+        
     G4ThreeVector  localPoint = theTrack->GetTouchable()->GetHistory()->
       GetTopTransform().TransformPoint(hitPoint);
-    
+
+    G4String       particleType = theTrack->GetDefinition()->GetParticleName();
+
     // calculations...       *************************************************
     double phi = -100.;
     if (vert_mom.x() != 0) phi = atan2(vert_mom.y(),vert_mom.x()); 
     if (phi < 0.) phi += twopi;
-    G4String       particleType = theTrack->GetDefinition()->GetParticleName();
-#ifdef debugLog
+
+
     double costheta =vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
 				      vert_mom.y()*vert_mom.y()+
 				      vert_mom.z()*vert_mom.z());
@@ -528,7 +535,6 @@ int CastorSD::setTrackID (G4Step* aStep) {
 
   theTrack     = aStep->GetTrack();
 
-  double etrack = preStepPoint->GetKineticEnergy();
   TrackInformation * trkInfo = (TrackInformation *)(theTrack->GetUserInformation());
   int      primaryID = trkInfo->getIDonCaloSurface();
   if (primaryID == 0) {
@@ -539,8 +545,10 @@ int CastorSD::setTrackID (G4Step* aStep) {
     primaryID = theTrack->GetTrackID();
   }
 
-  if (primaryID != previousID.trackID())
+  if (primaryID != previousID.trackID()) {
+    double etrack = preStepPoint->GetKineticEnergy();
     resetForNewPrimary(preStepPoint->GetPosition(), etrack);
+  }
 
   return primaryID;
 }

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -94,7 +94,7 @@ void CastorSD::initRun(){
 
 double CastorSD::getEnergyDeposit(G4Step * aStep) {
   
-  float NCherPhot = 0.;
+  double NCherPhot = 0.;
 
   if (aStep == NULL) 
     return 0;
@@ -243,16 +243,16 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
       GetTopTransform().TransformPoint(hitPoint);
     
     // calculations...       *************************************************
-    float phi = -100.;
+    double phi = -100.;
     if (vert_mom.x() != 0) phi = atan2(vert_mom.y(),vert_mom.x()); 
     if (phi < 0.) phi += twopi;
     G4String       particleType = theTrack->GetDefinition()->GetParticleName();
 #ifdef debugLog
-    float costheta =vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
+    double costheta =vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
 				      vert_mom.y()*vert_mom.y()+
 				      vert_mom.z()*vert_mom.z());
-    float theta = acos(std::min(std::max(costheta,float(-1.)),float(1.)));
-    float eta = -log(tan(theta/2));
+    double theta = acos(std::min(std::max(costheta,double(-1.)),double(1.)));
+    double eta = -log(tan(theta/2));
     G4int          primaryID    = theTrack->GetTrackID();
     // *************************************************
     
@@ -286,12 +286,12 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 	currentLV == lvC4HF) {
       //      if(nameVolume == "C3EF" || nameVolume == "C4EF" || nameVolume == "C3HF" || nameVolume == "C4HF") {
       
-      float bThreshold = 0.67;
-      float nMedium = 1.4925;
-      //     float photEnSpectrDL = (1./400.nm-1./700.nm)*10000000.cm/nm; /* cm-1  */
-      //     float photEnSpectrDL = 10714.285714;
+      double bThreshold = 0.67;
+      double nMedium = 1.4925;
+      //     double photEnSpectrDL = (1./400.nm-1./700.nm)*10000000.cm/nm; /* cm-1  */
+      //     double photEnSpectrDL = 10714.285714;
       
-      float photEnSpectrDE = 1.24;    /* see below   */
+      double photEnSpectrDE = 1.24;    /* see below   */
       /*     E = 2pi*(1./137.)*(eV*cm/370.)/lambda  =     */
       /*       = 12.389184*(eV*cm)/lambda                 */
       /*     Emax = 12.389184*(eV*cm)/400nm*10-7cm/nm  = 3.01 eV     */
@@ -300,29 +300,29 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
       /*   */
       /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
       
-      float thFullRefl = 23.;  /* 23.dergee */
-      float thFullReflRad = thFullRefl*pi/180.;
+      double thFullRefl = 23.;  /* 23.dergee */
+      double thFullReflRad = thFullRefl*pi/180.;
       
       /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
-      float thFibDir = 45.;  /* .dergee */
+      double thFibDir = 45.;  /* .dergee */
       /* for test HF geometry volumes:   
 	 if(nameVolume == "GF2Q" || nameVolume == "GFNQ" ||
 	 nameVolume == "GR2Q" || nameVolume == "GRNQ")
 	 thFibDir = 0.0; // .dergee
       */
-      float thFibDirRad = thFibDir*pi/180.;
+      double thFibDirRad = thFibDir*pi/180.;
       /*   */
       /*   */
       
       // at which theta the point is located:
-      //     float th1    = hitPoint.theta();
+      //     double th1    = hitPoint.theta();
       
       // theta of charged particle in LabRF(hit momentum direction):
-      float costh =hit_mom.z()/sqrt(hit_mom.x()*hit_mom.x()+
+      double costh =hit_mom.z()/sqrt(hit_mom.x()*hit_mom.x()+
 				    hit_mom.y()*hit_mom.y()+
 				    hit_mom.z()*hit_mom.z());
       if (zint < 0) costh = -costh;
-      float th = acos(std::min(std::max(costh,float(-1.)),float(1.)));
+      double th = acos(std::min(std::max(costh,double(-1.)),double(1.)));
       
       // just in case (can do bot use):
       if (th < 0.) th += twopi;
@@ -330,26 +330,26 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
       
       
       // theta of cone with Cherenkov photons w.r.t.direction of charged part.:
-      float costhcher =1./(nMedium*beta);
-      float thcher = acos(std::min(std::max(costhcher,float(-1.)),float(1.)));
+      double costhcher =1./(nMedium*beta);
+      double thcher = acos(std::min(std::max(costhcher,double(-1.)),double(1.)));
       
       // diff thetas of charged part. and quartz direction in LabRF:
-      float DelFibPart = fabs(th - thFibDirRad);
+      double DelFibPart = fabs(th - thFibDirRad);
       
       // define real distances:
-      float d = fabs(tan(th)-tan(thFibDirRad));   
+      double d = fabs(tan(th)-tan(thFibDirRad));   
       
-      //       float a = fabs(tan(thFibDirRad)-tan(thFibDirRad+thFullReflRad));   
-      //       float r = fabs(tan(th)-tan(th+thcher));   
+      //       double a = fabs(tan(thFibDirRad)-tan(thFibDirRad+thFullReflRad));   
+      //       double r = fabs(tan(th)-tan(th+thcher));   
       
-      float a = tan(thFibDirRad)+tan(fabs(thFibDirRad-thFullReflRad));   
-      float r = tan(th)+tan(fabs(th-thcher));   
+      double a = tan(thFibDirRad)+tan(fabs(thFibDirRad-thFullReflRad));   
+      double r = tan(th)+tan(fabs(th-thcher));   
       
       
       // define losses d_qz in cone of full reflection inside quartz direction
-      float d_qz;
+      double d_qz;
 #ifdef debugLog
-      float variant;
+      double variant;
 #endif
       if(DelFibPart > (thFullReflRad + thcher) ) {
 	d_qz = 0.; 
@@ -388,11 +388,11 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 	    
 	    // use crossed length of circles(cone projection)
 	    // dC1/dC2 : 
-	    float arg_arcos = 0.;
-	    float tan_arcos = 2.*a*d;
+	    double arg_arcos = 0.;
+	    double tan_arcos = 2.*a*d;
 	    if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
 	    arg_arcos = fabs(arg_arcos);
-	    float th_arcos = acos(std::min(std::max(arg_arcos,float(-1.)),float(1.)));
+	    double th_arcos = acos(std::min(std::max(arg_arcos,double(-1.)),double(1.)));
 	    d_qz = th_arcos/pi/2.;
 	    d_qz = fabs(d_qz);
 	    
@@ -425,16 +425,16 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
 	
 	if(poissNCherPhot < 0) poissNCherPhot = 0;
 	
-	float effPMTandTransport = 0.19;
+	double effPMTandTransport = 0.19;
 	double ReflPower = 0.1;
 	double proba = d_qz + (1-d_qz)*ReflPower;
 	NCherPhot = poissNCherPhot*effPMTandTransport*proba*0.307;
 	
 	
 #ifdef debugLog
-	float thgrad = th*180./pi;
-	float thchergrad = thcher*180./pi;
-	float DelFibPartgrad = DelFibPart*180./pi;
+	double thgrad = th*180./pi;
+	double thchergrad = thcher*180./pi;
+	double DelFibPartgrad = DelFibPart*180./pi;
 	LogDebug("ForwardSim") << " ==============================> start all "
 			       << "information:<========= \n" << " =====> for "
 			       << "test:<===  \n" << " variant = " << variant  
@@ -556,10 +556,10 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
 // ==============================================================
   
   // Get 'track' phi:
-  float   trackPhi = track->GetPosition().phi(); 
+  double   trackPhi = track->GetPosition().phi(); 
   if(trackPhi<0) trackPhi += 2*M_PI ;
   // Get phi from primary that gave rise to SL 'shower':
-  float  showerPhi = shower.getPrimPhi(); 
+  double  showerPhi = shower.getPrimPhi(); 
   if(showerPhi<0) showerPhi += 2*M_PI ;
   // Delta phi:
   
@@ -577,7 +577,7 @@ uint32_t CastorSD::rotateUnitID(uint32_t unitID, G4Track* track, const CastorSho
   //                            << "\n  complement = " << complement ; 
   
   // Get 'track' z:
-  float   trackZ = track->GetPosition().z();
+  double   trackZ = track->GetPosition().z();
   
   int aux ;
   int dSec = 2*(trackOctSector - showerOctSector) ;

--- a/SimG4CMS/Forward/src/CastorSD.cc
+++ b/SimG4CMS/Forward/src/CastorSD.cc
@@ -217,316 +217,318 @@ double CastorSD::getEnergyDeposit(G4Step * aStep) {
     
     // track is killed in getFromLibrary...
 
-  } else {
-    
-    // remember primary particle hitting the CASTOR detector
-    
-    TrackInformationExtractor TIextractor;
-    TrackInformation& trkInfo = TIextractor(theTrack);
-    if (!trkInfo.hasCastorHit()) {
-      trkInfo.setCastorHitPID(parCode);
-    }
-    const int castorHitPID = trkInfo.getCastorHitPID();
-    
-    // Check whether castor hit track is HAD
-    const bool isHad = !(castorHitPID==emPDG || castorHitPID==epPDG || castorHitPID==gammaPDG || castorHitPID == mupPDG || castorHitPID == mumPDG);
-    
-    
-    // Usual calculations
-    // G4ThreeVector      hitPoint = preStepPoint->GetPosition();	
-    // G4ThreeVector      hit_mom = preStepPoint->GetMomentumDirection();
-    G4double           stepl    = aStep->GetStepLength()/cm;
-    G4double           beta     = preStepPoint->GetBeta();
-    G4double           charge   = preStepPoint->GetCharge();
-    //        G4VProcess*        curprocess   = preStepPoint->GetProcessDefinedStep();
-    //        G4String           namePr   = preStepPoint->GetProcessDefinedStep()->GetProcessName();
-    //        std::string nameProcess;
-    //        nameProcess.assign(namePr,0,4);
-    
-    //        G4LogicalVolume*   lv    = currentPV->GetLogicalVolume();
-    //        G4Material*        mat   = lv->GetMaterial();
-    //        G4double           rad   = mat->GetRadlen();
-    
-   
-#ifdef debugLog
-    // postStepPoint information *********************************************
-    G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
-    G4VPhysicalVolume* postPV= postStepPoint->GetPhysicalVolume();
-
-    G4String           postname   = postPV->GetName();
-    std::string        postnameVolume;
-    postnameVolume.assign(postname,0,4);
-
-    // theTrack information  *************************************************
-    // G4Track*        theTrack = aStep->GetTrack();   
-    //G4double        entot    = theTrack->GetTotalEnergy();
-    G4ThreeVector   vert_mom = theTrack->GetVertexMomentumDirection();
-        
-    G4ThreeVector  localPoint = theTrack->GetTouchable()->GetHistory()->
-      GetTopTransform().TransformPoint(hitPoint);
-
-    G4String       particleType = theTrack->GetDefinition()->GetParticleName();
-
-    // calculations...       *************************************************
-    double phi = -100.;
-    if (vert_mom.x() != 0) phi = atan2(vert_mom.y(),vert_mom.x()); 
-    if (phi < 0.) phi += twopi;
-
-
-    double costheta =vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
-				      vert_mom.y()*vert_mom.y()+
-				      vert_mom.z()*vert_mom.z());
-    double theta = acos(std::min(std::max(costheta,double(-1.)),double(1.)));
-    double eta = -log(tan(theta/2));
-    G4int          primaryID    = theTrack->GetTrackID();
-    // *************************************************
-    
-    
-    // *************************************************
-    double edep   = aStep->GetTotalEnergyDeposit();
-#endif
-
-    // *************************************************
-    
-    
-    // *************************************************
-    // take into account light collection curve for plate
-    //      double weight = curve_Castor(nameVolume, preStepPoint);
-    //      double edep   = aStep->GetTotalEnergyDeposit() * weight;
-    // *************************************************
-    
-    
-    // *************************************************
-    /*    comments for sensitive volumes:      
-	  C001 ...-... CP06,CBU1 ...-...CALM --- > fibres and bundle 
-	  for first release of CASTOR
-	  CASF  --- > quartz plate  for first and second releases of CASTOR  
-	  GF2Q, GFNQ, GR2Q, GRNQ 
-	  for tests with my own test geometry of HF (on ask of Gavrilov)
-	  C3TF, C4TF - for third release of CASTOR
-    */
-    double meanNCherPhot=0;
-    
-    if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
-	currentLV == lvC4HF) {
-      //      if(nameVolume == "C3EF" || nameVolume == "C4EF" || nameVolume == "C3HF" || nameVolume == "C4HF") {
-      
-      double bThreshold = 0.67;
-      double nMedium = 1.4925;
-      //     double photEnSpectrDL = (1./400.nm-1./700.nm)*10000000.cm/nm; /* cm-1  */
-      //     double photEnSpectrDL = 10714.285714;
-      
-      double photEnSpectrDE = 1.24;    /* see below   */
-      /*     E = 2pi*(1./137.)*(eV*cm/370.)/lambda  =     */
-      /*       = 12.389184*(eV*cm)/lambda                 */
-      /*     Emax = 12.389184*(eV*cm)/400nm*10-7cm/nm  = 3.01 eV     */
-      /*     Emin = 12.389184*(eV*cm)/700nm*10-7cm/nm  = 1.77 eV     */
-      /*     delE = Emax - Emin = 1.24 eV  --> */
-      /*   */
-      /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
-      
-      double thFullRefl = 23.;  /* 23.dergee */
-      double thFullReflRad = thFullRefl*pi/180.;
-      
-      /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
-      double thFibDir = 45.;  /* .dergee */
-      /* for test HF geometry volumes:   
-	 if(nameVolume == "GF2Q" || nameVolume == "GFNQ" ||
-	 nameVolume == "GR2Q" || nameVolume == "GRNQ")
-	 thFibDir = 0.0; // .dergee
-      */
-      double thFibDirRad = thFibDir*pi/180.;
-      /*   */
-      /*   */
-      
-      // at which theta the point is located:
-      //     double th1    = hitPoint.theta();
-      
-      // theta of charged particle in LabRF(hit momentum direction):
-      double costh =hit_mom.z()/sqrt(hit_mom.x()*hit_mom.x()+
-				    hit_mom.y()*hit_mom.y()+
-				    hit_mom.z()*hit_mom.z());
-      if (zint < 0) costh = -costh;
-      double th = acos(std::min(std::max(costh,double(-1.)),double(1.)));
-      
-      // just in case (can do bot use):
-      if (th < 0.) th += twopi;
-      
-      
-      
-      // theta of cone with Cherenkov photons w.r.t.direction of charged part.:
-      double costhcher =1./(nMedium*beta);
-      double thcher = acos(std::min(std::max(costhcher,double(-1.)),double(1.)));
-      
-      // diff thetas of charged part. and quartz direction in LabRF:
-      double DelFibPart = fabs(th - thFibDirRad);
-      
-      // define real distances:
-      double d = fabs(tan(th)-tan(thFibDirRad));   
-      
-      //       double a = fabs(tan(thFibDirRad)-tan(thFibDirRad+thFullReflRad));   
-      //       double r = fabs(tan(th)-tan(th+thcher));   
-      
-      double a = tan(thFibDirRad)+tan(fabs(thFibDirRad-thFullReflRad));   
-      double r = tan(th)+tan(fabs(th-thcher));   
-      
-      
-      // define losses d_qz in cone of full reflection inside quartz direction
-      double d_qz;
-#ifdef debugLog
-      double variant;
-#endif
-      if(DelFibPart > (thFullReflRad + thcher) ) {
-	d_qz = 0.; 
-#ifdef debugLog
-	variant=0.;
-#endif
-      }
-      // if(d > (r+a) ) {d_qz = 0.; variant=0.;}
-      else {
-	if((th + thcher) < (thFibDirRad+thFullReflRad) && 
-	   (th - thcher) > (thFibDirRad-thFullReflRad)) {
-	  d_qz = 1.; 
-#ifdef debugLog
-	  variant=1.;
-#endif
-	}
-	// if((DelFibPart + thcher) < thFullReflRad ) {d_qz = 1.; variant=1.;}
-	// if((d+r) < a ) {d_qz = 1.; variant=1.;}
-	else {
-	  if((thFibDirRad + thFullReflRad) < (th + thcher) && 
-	     (thFibDirRad - thFullReflRad) > (th - thcher) ) {
-	    // if((thcher - DelFibPart ) > thFullReflRad ) 
-	    // if((r-d ) > a ) 
-	    d_qz = 0.; 
-#ifdef debugLog
-	    variant=2.;
-#endif
-	  } else {
-	    // if((thcher + DelFibPart ) > thFullReflRad && 
-	    //    thcher < (DelFibPart+thFullReflRad) ) 
-	    //      {
-	    d_qz = 0.; 
-#ifdef debugLog
-	    variant=3.;
-#endif
-	    
-	    // use crossed length of circles(cone projection)
-	    // dC1/dC2 : 
-	    double arg_arcos = 0.;
-	    double tan_arcos = 2.*a*d;
-	    if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
-	    arg_arcos = fabs(arg_arcos);
-	    double th_arcos = acos(std::min(std::max(arg_arcos,double(-1.)),double(1.)));
-	    d_qz = th_arcos/pi/2.;
-	    d_qz = fabs(d_qz);
-	    
-	    
-	    
-	    //	    }
-	    //             else
-	    //  	     {
-	    //                d_qz = 0.; variant=4.;
-	    //#ifdef debugLog
-	    // std::cout <<" ===============>variant 4 information: <===== " <<std::endl;
-	    // std::cout <<" !!!!!!!!!!!!!!!!!!!!!!  variant = " << variant  <<std::endl;
-	    //#endif 
-	    //
-	    // 	     }
-	  }
-	}
-      }
-
-
-      // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-      
-      if(charge != 0. && beta > bThreshold )  {
-	
-	meanNCherPhot = 370.*charge*charge*
-	  ( 1. - 1./(nMedium*nMedium*beta*beta) )*
-	  photEnSpectrDE*stepl;
-	
-	const double scale = (isHad ? non_compensation_factor : 1.0);
-	G4int poissNCherPhot = (G4int) G4Poisson(meanNCherPhot * scale);
-	
-	if(poissNCherPhot < 0) poissNCherPhot = 0;
-	
-	double effPMTandTransport = 0.19;
-	double ReflPower = 0.1;
-	double proba = d_qz + (1-d_qz)*ReflPower;
-	NCherPhot = poissNCherPhot*effPMTandTransport*proba*0.307;
-	
-	
-#ifdef debugLog
-	double thgrad = th*180./pi;
-	double thchergrad = thcher*180./pi;
-	double DelFibPartgrad = DelFibPart*180./pi;
-	LogDebug("ForwardSim") << " ==============================> start all "
-			       << "information:<========= \n" << " =====> for "
-			       << "test:<===  \n" << " variant = " << variant  
-			       << "\n thgrad = " << thgrad  << "\n thchergrad "
-			       << "= " << thchergrad  << "\n DelFibPartgrad = "
-			       << DelFibPartgrad << "\n d_qz = " << d_qz  
-			       << "\n =====> Start Step Information <===  \n"
-			       << " ===> calo preStepPoint info <===  \n" 
-			       << " hitPoint = " << hitPoint  << "\n"
-			       << " hitMom = " << hit_mom  << "\n"
-			       << " stepControlFlag = " << stepControlFlag 
-	  // << "\n curprocess = " << curprocess << "\n"
-	  // << " nameProcess = " << nameProcess 
-			       << "\n charge = " << charge << "\n"
-			       << " beta = " << beta << "\n"
-			       << " bThreshold = " << bThreshold << "\n"
-			       << " thgrad =" << thgrad << "\n"
-			       << " effPMTandTransport=" << effPMTandTransport 
-	  // << "\n volume = " << name 
-			       << "\n nameVolume = " << nameVolume << "\n"
-			       << " nMedium = " << nMedium << "\n"
-	  //  << " rad length = " << rad << "\n"
-	  //  << " material = " << mat << "\n"
-			       << " stepl = " << stepl << "\n"
-			       << " photEnSpectrDE = " << photEnSpectrDE <<"\n"
-			       << " edep = " << edep << "\n"
-			       << " ===> calo theTrack info <=== " << "\n"
-			       << " particleType = " << particleType << "\n"
-			       << " primaryID = " << primaryID << "\n"
-			       << " entot= " << theTrack->GetTotalEnergy() << "\n"
-			       << " vert_eta= " << eta  << "\n"
-			       << " vert_phi= " << phi << "\n"
-			       << " vert_mom= " << vert_mom  << "\n"
-			       << " ===> calo hit preStepPointinfo <=== "<<"\n"
-			       << " local point = " << localPoint << "\n"
-			       << " ==============================> final info"
-			       << ":  <=== \n" 
-			       << " meanNCherPhot = " << meanNCherPhot << "\n"
-			       << " poissNCherPhot = " << poissNCherPhot <<"\n"
-			       << " NCherPhot = " << NCherPhot;
-#endif 
-	
-	// Included by WC
-	//	     std::cout << "\n volume = "         << name 
-	//	          << "\n nameVolume = "     << nameVolume << "\n"
-	//	          << "\n postvolume = "     << postname 
-	//	          << "\n postnameVolume = " << postnameVolume << "\n"
-	//	          << "\n particleType = "   << particleType 
-	//	          << "\n primaryID = "      << primaryID << "\n";
-	
-      }
-    }
-    
-    
-#ifdef debugLog
-    LogDebug("ForwardSim") << "CastorSD:: " << nameVolume 
-      //      << " Light Collection Efficiency " << weight
-			   << " Weighted Energy Deposit " << edep/MeV 
-			   << " MeV\n";
-#endif
-    // Temporary member for testing purpose only...
-    // unit_id = setDetUnitId(aStep);
-    // if(NCherPhot != 0) std::cout << "\n  UnitID = " << unit_id << "  ;  NCherPhot = " << NCherPhot ;
-    
+    return 0;
   }
+  
 
+  // Full - Simulation starts here
+
+  double meanNCherPhot=0;
+    
+  // remember primary particle hitting the CASTOR detector
+    
+  TrackInformationExtractor TIextractor;
+  TrackInformation& trkInfo = TIextractor(theTrack);
+  if (!trkInfo.hasCastorHit()) {
+    trkInfo.setCastorHitPID(parCode);
+  }
+  const int castorHitPID = trkInfo.getCastorHitPID();
+  
+  // Check whether castor hit track is HAD
+  const bool isHad = !(castorHitPID==emPDG || castorHitPID==epPDG || castorHitPID==gammaPDG || castorHitPID == mupPDG || castorHitPID == mumPDG);
+  
+  
+  // Usual calculations
+  // G4ThreeVector      hitPoint = preStepPoint->GetPosition();	
+  // G4ThreeVector      hit_mom = preStepPoint->GetMomentumDirection();
+  G4double           stepl    = aStep->GetStepLength()/cm;
+  G4double           beta     = preStepPoint->GetBeta();
+  G4double           charge   = preStepPoint->GetCharge();
+  //        G4VProcess*        curprocess   = preStepPoint->GetProcessDefinedStep();
+  //        G4String           namePr   = preStepPoint->GetProcessDefinedStep()->GetProcessName();
+  //        std::string nameProcess;
+  //        nameProcess.assign(namePr,0,4);
+  
+  //        G4LogicalVolume*   lv    = currentPV->GetLogicalVolume();
+  //        G4Material*        mat   = lv->GetMaterial();
+  //        G4double           rad   = mat->GetRadlen();
+  
+  
+#ifdef debugLog
+  // postStepPoint information *********************************************
+  G4StepPoint* postStepPoint= aStep->GetPostStepPoint();   
+  G4VPhysicalVolume* postPV= postStepPoint->GetPhysicalVolume();
+  
+  G4String           postname   = postPV->GetName();
+  std::string        postnameVolume;
+  postnameVolume.assign(postname,0,4);
+  
+  // theTrack information  *************************************************
+  // G4Track*        theTrack = aStep->GetTrack();   
+  //G4double        entot    = theTrack->GetTotalEnergy();
+  G4ThreeVector   vert_mom = theTrack->GetVertexMomentumDirection();
+  
+  G4ThreeVector  localPoint = theTrack->GetTouchable()->GetHistory()->
+    GetTopTransform().TransformPoint(hitPoint);
+  
+  G4String       particleType = theTrack->GetDefinition()->GetParticleName();
+  
+  // calculations...       *************************************************
+  double phi = -100.;
+  if (vert_mom.x() != 0) phi = atan2(vert_mom.y(),vert_mom.x()); 
+  if (phi < 0.) phi += twopi;
+  
+  
+  double costheta =vert_mom.z()/sqrt(vert_mom.x()*vert_mom.x()+
+				     vert_mom.y()*vert_mom.y()+
+				     vert_mom.z()*vert_mom.z());
+  double theta = acos(std::min(std::max(costheta,double(-1.)),double(1.)));
+  double eta = -log(tan(theta/2));
+  G4int          primaryID    = theTrack->GetTrackID();
+  // *************************************************
+    
+  
+  // *************************************************
+  double edep   = aStep->GetTotalEnergyDeposit();
+#endif
+  
+  // *************************************************
+  
+  
+  // *************************************************
+  // take into account light collection curve for plate
+  //      double weight = curve_Castor(nameVolume, preStepPoint);
+  //      double edep   = aStep->GetTotalEnergyDeposit() * weight;
+  // *************************************************
+  
+  
+  // *************************************************
+  /*    comments for sensitive volumes:      
+	C001 ...-... CP06,CBU1 ...-...CALM --- > fibres and bundle 
+	for first release of CASTOR
+	CASF  --- > quartz plate  for first and second releases of CASTOR  
+	GF2Q, GFNQ, GR2Q, GRNQ 
+	for tests with my own test geometry of HF (on ask of Gavrilov)
+	C3TF, C4TF - for third release of CASTOR
+  */  
+  if (currentLV == lvC3EF || currentLV == lvC4EF || currentLV == lvC3HF ||
+      currentLV == lvC4HF) {
+    //      if(nameVolume == "C3EF" || nameVolume == "C4EF" || nameVolume == "C3HF" || nameVolume == "C4HF") {
+    
+    double bThreshold = 0.67;
+    double nMedium = 1.4925;
+    //     double photEnSpectrDL = (1./400.nm-1./700.nm)*10000000.cm/nm; /* cm-1  */
+    //     double photEnSpectrDL = 10714.285714;
+    
+    double photEnSpectrDE = 1.24;    /* see below   */
+    /*     E = 2pi*(1./137.)*(eV*cm/370.)/lambda  =     */
+    /*       = 12.389184*(eV*cm)/lambda                 */
+    /*     Emax = 12.389184*(eV*cm)/400nm*10-7cm/nm  = 3.01 eV     */
+    /*     Emin = 12.389184*(eV*cm)/700nm*10-7cm/nm  = 1.77 eV     */
+    /*     delE = Emax - Emin = 1.24 eV  --> */
+    /*   */
+    /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
+    
+    double thFullRefl = 23.;  /* 23.dergee */
+    double thFullReflRad = thFullRefl*pi/180.;
+    
+    /* default for Castor nameVolume  == "CASF" or (C3TF & C4TF)  */
+    double thFibDir = 45.;  /* .dergee */
+    /* for test HF geometry volumes:   
+       if(nameVolume == "GF2Q" || nameVolume == "GFNQ" ||
+       nameVolume == "GR2Q" || nameVolume == "GRNQ")
+       thFibDir = 0.0; // .dergee
+    */
+    double thFibDirRad = thFibDir*pi/180.;
+    /*   */
+    /*   */
+    
+    // at which theta the point is located:
+    //     double th1    = hitPoint.theta();
+    
+    // theta of charged particle in LabRF(hit momentum direction):
+    double costh =hit_mom.z()/sqrt(hit_mom.x()*hit_mom.x()+
+				   hit_mom.y()*hit_mom.y()+
+				   hit_mom.z()*hit_mom.z());
+    if (zint < 0) costh = -costh;
+    double th = acos(std::min(std::max(costh,double(-1.)),double(1.)));
+    
+    // just in case (can do bot use):
+    if (th < 0.) th += twopi;
+    
+    
+    
+    // theta of cone with Cherenkov photons w.r.t.direction of charged part.:
+    double costhcher =1./(nMedium*beta);
+    double thcher = acos(std::min(std::max(costhcher,double(-1.)),double(1.)));
+    
+    // diff thetas of charged part. and quartz direction in LabRF:
+    double DelFibPart = fabs(th - thFibDirRad);
+    
+    // define real distances:
+    double d = fabs(tan(th)-tan(thFibDirRad));   
+    
+    //       double a = fabs(tan(thFibDirRad)-tan(thFibDirRad+thFullReflRad));   
+    //       double r = fabs(tan(th)-tan(th+thcher));   
+    
+    double a = tan(thFibDirRad)+tan(fabs(thFibDirRad-thFullReflRad));   
+    double r = tan(th)+tan(fabs(th-thcher));   
+    
+    
+    // define losses d_qz in cone of full reflection inside quartz direction
+    double d_qz;
+#ifdef debugLog
+    double variant;
+#endif
+    if(DelFibPart > (thFullReflRad + thcher) ) {
+      d_qz = 0.; 
+#ifdef debugLog
+      variant=0.;
+#endif
+    }
+    // if(d > (r+a) ) {d_qz = 0.; variant=0.;}
+    else {
+      if((th + thcher) < (thFibDirRad+thFullReflRad) && 
+	 (th - thcher) > (thFibDirRad-thFullReflRad)) {
+	d_qz = 1.; 
+#ifdef debugLog
+	variant=1.;
+#endif
+      }
+      // if((DelFibPart + thcher) < thFullReflRad ) {d_qz = 1.; variant=1.;}
+      // if((d+r) < a ) {d_qz = 1.; variant=1.;}
+      else {
+	if((thFibDirRad + thFullReflRad) < (th + thcher) && 
+	   (thFibDirRad - thFullReflRad) > (th - thcher) ) {
+	  // if((thcher - DelFibPart ) > thFullReflRad ) 
+	  // if((r-d ) > a ) 
+	  d_qz = 0.; 
+#ifdef debugLog
+	  variant=2.;
+#endif
+	} else {
+	  // if((thcher + DelFibPart ) > thFullReflRad && 
+	  //    thcher < (DelFibPart+thFullReflRad) ) 
+	  //      {
+	  d_qz = 0.; 
+#ifdef debugLog
+	  variant=3.;
+#endif
+	  
+	  // use crossed length of circles(cone projection)
+	  // dC1/dC2 : 
+	  double arg_arcos = 0.;
+	  double tan_arcos = 2.*a*d;
+	  if(tan_arcos != 0.) arg_arcos =(r*r-a*a-d*d)/tan_arcos; 
+	  arg_arcos = fabs(arg_arcos);
+	  double th_arcos = acos(std::min(std::max(arg_arcos,double(-1.)),double(1.)));
+	  d_qz = th_arcos/pi/2.;
+	  d_qz = fabs(d_qz);
+	  
+	  
+	  
+	  //	    }
+	  //             else
+	  //  	     {
+	  //                d_qz = 0.; variant=4.;
+	  //#ifdef debugLog
+	  // std::cout <<" ===============>variant 4 information: <===== " <<std::endl;
+	  // std::cout <<" !!!!!!!!!!!!!!!!!!!!!!  variant = " << variant  <<std::endl;
+	  //#endif 
+	  //
+	  // 	     }
+	}
+      }
+    }
+    
+    
+    // !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+    
+    if(charge != 0. && beta > bThreshold )  {
+      
+      meanNCherPhot = 370.*charge*charge*
+	( 1. - 1./(nMedium*nMedium*beta*beta) )*
+	photEnSpectrDE*stepl;
+      
+      const double scale = (isHad ? non_compensation_factor : 1.0);
+      G4int poissNCherPhot = (G4int) G4Poisson(meanNCherPhot * scale);
+      
+      if(poissNCherPhot < 0) poissNCherPhot = 0;
+      
+      double effPMTandTransport = 0.19;
+      double ReflPower = 0.1;
+      double proba = d_qz + (1-d_qz)*ReflPower;
+      NCherPhot = poissNCherPhot*effPMTandTransport*proba*0.307;
+      
+      
+#ifdef debugLog
+      double thgrad = th*180./pi;
+      double thchergrad = thcher*180./pi;
+      double DelFibPartgrad = DelFibPart*180./pi;
+      LogDebug("ForwardSim") << " ==============================> start all "
+			     << "information:<========= \n" << " =====> for "
+			     << "test:<===  \n" << " variant = " << variant  
+			     << "\n thgrad = " << thgrad  << "\n thchergrad "
+			     << "= " << thchergrad  << "\n DelFibPartgrad = "
+			     << DelFibPartgrad << "\n d_qz = " << d_qz  
+			     << "\n =====> Start Step Information <===  \n"
+			     << " ===> calo preStepPoint info <===  \n" 
+			     << " hitPoint = " << hitPoint  << "\n"
+			     << " hitMom = " << hit_mom  << "\n"
+			     << " stepControlFlag = " << stepControlFlag 
+	// << "\n curprocess = " << curprocess << "\n"
+	// << " nameProcess = " << nameProcess 
+			     << "\n charge = " << charge << "\n"
+			     << " beta = " << beta << "\n"
+			     << " bThreshold = " << bThreshold << "\n"
+			     << " thgrad =" << thgrad << "\n"
+			     << " effPMTandTransport=" << effPMTandTransport 
+	// << "\n volume = " << name 
+			     << "\n nameVolume = " << nameVolume << "\n"
+			     << " nMedium = " << nMedium << "\n"
+	//  << " rad length = " << rad << "\n"
+	//  << " material = " << mat << "\n"
+			     << " stepl = " << stepl << "\n"
+			     << " photEnSpectrDE = " << photEnSpectrDE <<"\n"
+			     << " edep = " << edep << "\n"
+			     << " ===> calo theTrack info <=== " << "\n"
+			     << " particleType = " << particleType << "\n"
+			     << " primaryID = " << primaryID << "\n"
+			     << " entot= " << theTrack->GetTotalEnergy() << "\n"
+			     << " vert_eta= " << eta  << "\n"
+			     << " vert_phi= " << phi << "\n"
+			     << " vert_mom= " << vert_mom  << "\n"
+			     << " ===> calo hit preStepPointinfo <=== "<<"\n"
+			     << " local point = " << localPoint << "\n"
+			     << " ==============================> final info"
+			     << ":  <=== \n" 
+			     << " meanNCherPhot = " << meanNCherPhot << "\n"
+			     << " poissNCherPhot = " << poissNCherPhot <<"\n"
+			     << " NCherPhot = " << NCherPhot;
+#endif 
+      
+      // Included by WC
+      //	     std::cout << "\n volume = "         << name 
+      //	          << "\n nameVolume = "     << nameVolume << "\n"
+      //	          << "\n postvolume = "     << postname 
+      //	          << "\n postnameVolume = " << postnameVolume << "\n"
+      //	          << "\n particleType = "   << particleType 
+      //	          << "\n primaryID = "      << primaryID << "\n";
+      
+    }
+  }
+    
+  
+#ifdef debugLog
+  LogDebug("ForwardSim") << "CastorSD:: " << nameVolume 
+    //      << " Light Collection Efficiency " << weight
+			 << " Weighted Energy Deposit " << edep/MeV 
+			 << " MeV\n";
+#endif
+  // Temporary member for testing purpose only...
+  // unit_id = setDetUnitId(aStep);
+  // if(NCherPhot != 0) std::cout << "\n  UnitID = " << unit_id << "  ;  NCherPhot = " << NCherPhot ;
+  
   return NCherPhot;
 }
 

--- a/SimG4Core/Notification/interface/TrackInformation.h
+++ b/SimG4Core/Notification/interface/TrackInformation.h
@@ -52,6 +52,12 @@ public:
   double genParticleP() const              { return genParticleP_; }
   void   setGenParticleP(double p)         { genParticleP_ = p; }
 
+  // remember the PID of particle entering the CASTOR detector. This is needed
+  // in order to scale the hadronic response
+  bool hasCastorHit() const { return hasCastorHit_; }
+  void setCastorHitPID(const int pid) { hasCastorHit_=true; castorHitPID_ = pid; }
+  int getCastorHitPID() const { return castorHitPID_; }
+
   virtual void Print() const;
 private:
   bool   storeTrack_;    
@@ -67,12 +73,16 @@ private:
   int    genParticlePID_, caloSurfaceParticlePID_;
   double genParticleP_, caloSurfaceParticleP_;
 
+  bool hasCastorHit_;
+  int castorHitPID_;
+
   // Restrict construction to friends
   TrackInformation() :G4VUserTrackInformation(),storeTrack_(false),isPrimary_(false),
     hasHits_(false),isGeneratedSecondary_(false),isInHistory_(false),
     flagAncestor_(false),idOnCaloSurface_(0),idCaloVolume_(-1),
     idLastVolume_(-1),caloIDChecked_(false), genParticlePID_(-1),
-    caloSurfaceParticlePID_(0), genParticleP_(0), caloSurfaceParticleP_(0) {}
+    caloSurfaceParticlePID_(0), genParticleP_(0), caloSurfaceParticleP_(0),
+    hasCastorHit_(false), castorHitPID_(0) {}
     friend class NewTrackAction;
 };
 

--- a/SimG4Core/Notification/src/NewTrackAction.cc
+++ b/SimG4Core/Notification/src/NewTrackAction.cc
@@ -46,6 +46,8 @@ void NewTrackAction::addUserInfoToPrimary(G4Track * aTrack) const {
 
 void NewTrackAction::addUserInfoToSecondary(G4Track * aTrack,const TrackInformation & motherInfo, int flag) const {
 
+  // ralf.ulrich@kit.edu: it is more efficient to use the constructor to copy all data and modify later only when needed
+
   TrackInformation * trkInfo = new TrackInformation();
 //  LogDebug("SimG4CoreApplication") << "NewTrackAction called for "
 //				   << aTrack->GetTrackID()
@@ -79,5 +81,10 @@ void NewTrackAction::addUserInfoToSecondary(G4Track * aTrack,const TrackInformat
 				motherInfo.caloSurfaceParticlePID(),
 				motherInfo.caloSurfaceParticleP());
   }
+  
+  if (motherInfo.hasCastorHit()) {
+    trkInfo->setCastorHitPID(motherInfo.getCastorHitPID());
+  }
+
   aTrack->SetUserInformation(trkInfo);  
 }


### PR DESCRIPTION
This code change is related to the non-compensation simulation of the CASTOR calorimeter. In general, the method can be used easily for any calorimeter, however, is used so far only for CASTOR.

There is a study to validate the code with particle gun simulations, which has been presented here:

https://indico.cern.ch/event/406099/session/5/contribution/5/attachments/812726/1113869/fs_noncompensation_and_cmssw7_electron_response.pdf

This is needed for Run2 detector simulations for detector unfolding. We need the code in the respective CMSSW versions used for MC productions. This is most probably at least CMSSW_7_5_X , thus, we will need a back-port to this. 

This pull request is identical to the ones #10195 (CMSSW_7_1_X) and  #10196 (CMSSW_7_4_X).

Best regards,
R. Ulrich
