### PR TITLE
Add additional MultiTrackValidator instances to validation

### DIFF
--- a/CommonTools/RecoAlgos/plugins/RecoChargedRefCandidateToTrackRefProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoChargedRefCandidateToTrackRefProducer.cc
@@ -1,0 +1,13 @@
+#include "CommonTools/RecoAlgos/src/RecoChargedRefCandidateToTrackRef.h"
+#include "CommonTools/RecoAlgos/src/CandidateProducer.h"
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+
+typedef CandidateProducer<
+  edm::View<reco::RecoChargedRefCandidate>,
+  reco::TrackRefVector,
+  AnySelector,
+  converter::RecoChargedRefCandidateToTrackRef
+  > RecoChargedRefCandidateToTrackRefProducer;
+
+DEFINE_FWK_MODULE(RecoChargedRefCandidateToTrackRefProducer);

--- a/CommonTools/RecoAlgos/python/recoChargedRefCandidateToTrackRefProducer_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoChargedRefCandidateToTrackRefProducer_cfi.py
@@ -1,0 +1,5 @@
+import FWCore.ParameterSet.Config as cms
+
+recoChargedRefCandidateToTrackRefProducer = cms.EDProducer("RecoChargedRefCandidateToTrackRefProducer",
+    src = cms.InputTag('trackRefsForJets')
+)

--- a/CommonTools/RecoAlgos/src/RecoChargedRefCandidateToTrackRef.h
+++ b/CommonTools/RecoAlgos/src/RecoChargedRefCandidateToTrackRef.h
@@ -1,0 +1,23 @@
+#ifndef CommonTools_RecoAlgos_TrackToRefCandidate_h
+#define CommonTools_RecoAlgos_TrackToRefCandidate_h
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedRefCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedRefCandidateFwd.h"
+
+namespace edm { class EventSetup; class ParameterSet; }
+
+namespace converter {
+  struct RecoChargedRefCandidateToTrackRef {
+    typedef reco::RecoChargedRefCandidate value_type;
+    typedef reco::RecoChargedRefCandidateCollection Components;
+    typedef reco::TrackRef Candidate;
+    RecoChargedRefCandidateToTrackRef(const edm::ParameterSet & cfg) {}
+    void beginFirstRun(const edm::EventSetup&) {}
+    void convert(const reco::RecoChargedRefCandidateRef& c, reco::TrackRef& trkRef) const {
+      trkRef = c->track();
+    }  
+  };
+}
+
+#endif

--- a/Validation/RecoTrack/interface/MultiTrackValidator.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidator.h
@@ -10,7 +10,7 @@
 #include "DQMServices/Core/interface/DQMEDAnalyzer.h"
 #include "Validation/RecoTrack/interface/MultiTrackValidatorBase.h"
 #include "Validation/RecoTrack/interface/MTVHistoProducerAlgo.h"
-
+#include "SimDataFormats/Associations/interface/VertexToTrackingVertexAssociator.h"
 
 class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorBase {
  public:
@@ -31,6 +31,7 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
   //these are used by MTVGenPs
   bool UseAssociators;
   const bool parametersDefinerIsCosmic_;
+  const bool doPlotsOnlyForTruePV_;
   const bool doSimPlots_;
   const bool doSimTrackPlots_;
   const bool doRecoTrackPlots_;
@@ -54,6 +55,8 @@ class MultiTrackValidator : public DQMEDAnalyzer, protected MultiTrackValidatorB
 
   edm::EDGetTokenT<SimHitTPAssociationProducer::SimHitTPAssociationList> _simHitTpMapTag;
   edm::EDGetTokenT<edm::View<reco::Track> > labelTokenForDrCalculation;
+  edm::EDGetTokenT<edm::View<reco::Vertex> > recoVertexToken_;
+  edm::EDGetTokenT<reco::VertexToTrackingVertexAssociator> vertexAssociatorToken_;
 
   std::vector<MonitorElement *> h_reco_coll, h_assoc_coll, h_assoc2_coll, h_simul_coll, h_looper_coll, h_pileup_coll;
   std::vector<MonitorElement *> h_assoc_coll_allPt, h_simul_coll_allPt;

--- a/Validation/RecoTrack/interface/MultiTrackValidatorBase.h
+++ b/Validation/RecoTrack/interface/MultiTrackValidatorBase.h
@@ -72,8 +72,6 @@ class MultiTrackValidatorBase {
   edm::EDGetTokenT<edm::ValueMap<reco::DeDxData> > m_dEdx1Tag;
   edm::EDGetTokenT<edm::ValueMap<reco::DeDxData> > m_dEdx2Tag;
 
-  edm::ESHandle<MagneticField> theMF;
-
   bool ignoremissingtkcollection_;
 };
 

--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -170,15 +170,20 @@ void MultiTrackValidator::bookHistograms(DQMStore::IBooker& ibook, edm::Run cons
     // FIXME: these need to be moved to a subdirectory whose name depends on the associator
     ibook.setCurrentFolder(dirName_);
 
-    h_reco_coll.push_back(binLabels( ibook.book1D("num_reco_coll", "N of reco track vs track collection", nintColl, minColl, maxColl) ));
-    h_assoc2_coll.push_back(binLabels( ibook.book1D("num_assoc(recoToSim)_coll", "N of associated (recoToSim) tracks vs track collection", nintColl, minColl, maxColl) ));
-    h_assoc_coll.push_back(binLabels( ibook.book1D("num_assoc(simToReco)_coll", "N of associated (simToReco) tracks vs track collection", nintColl, minColl, maxColl) ));
-    h_simul_coll.push_back(binLabels( ibook.book1D("num_simul_coll", "N of simulated tracks vs track collection", nintColl, minColl, maxColl) ));
-    h_looper_coll.push_back(binLabels( ibook.book1D("num_duplicate_coll", "N of associated (recoToSim) looper tracks vs track collection", nintColl, minColl, maxColl) ));
-    h_pileup_coll.push_back(binLabels( ibook.book1D("num_pileup_coll", "N of associated (recoToSim) pileup tracks vs track collection", nintColl, minColl, maxColl) ));
+    if(doSimTrackPlots_) {
+      h_assoc_coll.push_back(binLabels( ibook.book1D("num_assoc(simToReco)_coll", "N of associated (simToReco) tracks vs track collection", nintColl, minColl, maxColl) ));
+      h_simul_coll.push_back(binLabels( ibook.book1D("num_simul_coll", "N of simulated tracks vs track collection", nintColl, minColl, maxColl) ));
 
-    h_assoc_coll_allPt.push_back(binLabels( ibook.book1D("num_assoc(simToReco)_coll_allPt", "N of associated (simToReco) tracks vs track collection", nintColl, minColl, maxColl) ));
-    h_simul_coll_allPt.push_back(binLabels( ibook.book1D("num_simul_coll_allPt", "N of simulated tracks vs track collection", nintColl, minColl, maxColl) ));
+      h_assoc_coll_allPt.push_back(binLabels( ibook.book1D("num_assoc(simToReco)_coll_allPt", "N of associated (simToReco) tracks vs track collection", nintColl, minColl, maxColl) ));
+      h_simul_coll_allPt.push_back(binLabels( ibook.book1D("num_simul_coll_allPt", "N of simulated tracks vs track collection", nintColl, minColl, maxColl) ));
+
+    }
+    if(doRecoTrackPlots_) {
+      h_reco_coll.push_back(binLabels( ibook.book1D("num_reco_coll", "N of reco track vs track collection", nintColl, minColl, maxColl) ));
+      h_assoc2_coll.push_back(binLabels( ibook.book1D("num_assoc(recoToSim)_coll", "N of associated (recoToSim) tracks vs track collection", nintColl, minColl, maxColl) ));
+      h_looper_coll.push_back(binLabels( ibook.book1D("num_duplicate_coll", "N of associated (recoToSim) looper tracks vs track collection", nintColl, minColl, maxColl) ));
+      h_pileup_coll.push_back(binLabels( ibook.book1D("num_pileup_coll", "N of associated (recoToSim) pileup tracks vs track collection", nintColl, minColl, maxColl) ));
+    }
 
     for (unsigned int www=0;www<label.size();www++){
       ibook.cd();

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -152,10 +152,6 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
     }
   }
 
-  edm::Handle<TrackingVertexCollection> tvH;
-  event.getByToken(label_tv,tvH);
-  TrackingVertexCollection tv = *tvH;
-
   // Calculate the number of 3D layers for TPs
   //
   // I would have preferred to produce the ValueMap to Event and read

--- a/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
+++ b/Validation/RecoTrack/plugins/TrackerSeedValidator.cc
@@ -67,9 +67,6 @@ TrackerSeedValidator::TrackerSeedValidator(const edm::ParameterSet& pset):MultiT
 TrackerSeedValidator::~TrackerSeedValidator(){delete histoProducerAlgo_;}
 
 void TrackerSeedValidator::bookHistograms(DQMStore::IBooker& ibook, edm::Run const&, edm::EventSetup const& setup) {
-  setup.get<IdealMagneticFieldRecord>().get(theMF);
-  setup.get<TransientRecHitRecord>().get(builderName,theTTRHBuilder);
-
   {
     ibook.cd();
     ibook.setCurrentFolder(dirName_ + "simulation");
@@ -122,6 +119,12 @@ void TrackerSeedValidator::analyze(const edm::Event& event, const edm::EventSetu
   edm::ESHandle<TrackerTopology> httopo;
   setup.get<TrackerTopologyRcd>().get(httopo);
   const TrackerTopology& ttopo = *httopo;
+
+  edm::ESHandle<TransientTrackingRecHitBuilder> theTTRHBuilder;
+  setup.get<TransientRecHitRecord>().get(builderName,theTTRHBuilder);
+
+  edm::ESHandle<MagneticField> theMF;
+  setup.get<IdealMagneticFieldRecord>().get(theMF);
 
   edm::Handle<TrackingParticleCollection>  TPCollectionHeff ;
   event.getByToken(label_tp_effic,TPCollectionHeff);

--- a/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
+++ b/Validation/RecoTrack/python/MultiTrackValidator_cfi.py
@@ -68,6 +68,11 @@ multiTrackValidator = cms.EDAnalyzer(
     ### for fake rate vs dR ###
     trackCollectionForDrCalculation = cms.InputTag("generalTracks"),
 
+    ### Do plots only if first reco vertex is from hard scatter?
+    doPlotsOnlyForTruePV = cms.untracked.bool(False),
+    label_vertex = cms.untracked.InputTag("offlinePrimaryVertices"),
+    vertexAssociator = cms.untracked.InputTag("VertexAssociatorByPositionAndTracks"),
+
     ### Allow switching off particular histograms
     doSimPlots = cms.untracked.bool(True),
     doSimTrackPlots = cms.untracked.bool(True),

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track/*"),
+    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
     "efficPt 'Efficiency vs p_{T}' num_assoc(simToReco)_pT num_simul_pT",
@@ -103,7 +103,7 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
 )
 
 postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track"),
+    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV"),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",

--- a/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
+++ b/Validation/RecoTrack/python/PostProcessorTracker_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*"),
+    subDirs = cms.untracked.vstring("Tracking/Track/*", "Tracking/TrackFromPV/*", "Tracking/TrackFromPVAllTP/*", "Tracking/TrackAllTPEffic/*"),
     efficiency = cms.vstring(
     "effic 'Efficiency vs #eta' num_assoc(simToReco)_eta num_simul_eta",
     "efficPt 'Efficiency vs p_{T}' num_assoc(simToReco)_pT num_simul_pT",
@@ -103,7 +103,7 @@ postProcessorTrack = cms.EDAnalyzer("DQMGenericClient",
 )
 
 postProcessorTrackSummary = cms.EDAnalyzer("DQMGenericClient",
-    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV"),
+    subDirs = cms.untracked.vstring("Tracking/Track", "Tracking/TrackFromPV", "Tracking/TrackFromPVAllTP", "Tracking/TrackAllTPEffic"),
     efficiency = cms.vstring(
     "effic_vs_coll 'Efficiency vs track collection' num_assoc(simToReco)_coll num_simul_coll",
     "effic_vs_coll_allPt 'Efficiency vs track collection' num_assoc(simToReco)_coll_allPt num_simul_coll_allPt",

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -11,7 +11,11 @@ import cutsRecoTracks_cfi
 
 from SimTracker.TrackerHitAssociation.clusterTpAssociationProducer_cfi import *
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import *
+from PhysicsTools.RecoAlgos.trackingParticleSelector_cfi import trackingParticleSelector as _trackingParticleSelector
+from CommonTools.RecoAlgos.sortedPrimaryVertices_cfi import sortedPrimaryVertices as _sortedPrimaryVertices
+from CommonTools.RecoAlgos.recoChargedRefCandidateToTrackRefProducer_cfi import recoChargedRefCandidateToTrackRefProducer as _recoChargedRefCandidateToTrackRefProducer
 
+## Track selectors
 # Validation iterative steps
 cutsRecoTracksInitialStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["initialStep"])
 cutsRecoTracksLowPtTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["lowPtTripletStep"])
@@ -54,6 +58,73 @@ cutsRecoTracksAK4PFJets = jetTracksAssociationToTrackRefs_cfi.jetTracksAssociati
     correctedPtMin = 10,
 )
 
+
+## Select signal TrackingParticles, and do the corresponding associations
+trackingParticlesSignal = _trackingParticleSelector.clone(
+    signalOnly = True,
+    chargedOnly = False,
+    tip = 1e5,
+    lip = 1e5,
+    minRapidity = -10,
+    maxRapidity = 10,
+    ptMin = 0,
+)
+tpClusterProducerSignal = tpClusterProducer.clone(
+    trackingParticleSrc = "trackingParticlesSignal"
+)
+quickTrackAssociatorByHitsSignal = quickTrackAssociatorByHits.clone(
+    cluster2TPSrc = "tpClusterProducerSignal"
+)
+trackingParticleRecoTrackAsssociationSignal = trackingParticleRecoTrackAsssociation.clone(
+    label_tp = "trackingParticlesSignal",
+    associator = "quickTrackAssociatorByHitsSignal"
+)
+
+# select tracks from the PV
+# first convert to RecoChargedRefCandidates
+trackRefsForValidation = cms.EDProducer("ChargedRefCandidateProducer",
+    particleType = cms.string('pi+'),
+    src = cms.InputTag("generalTracks")
+)
+# then use the "PV sorting" module to select the candidates associated to PV
+trackRefsFromPV = _sortedPrimaryVertices.clone(
+    particles = "trackRefsForValidation",
+    produceAssociationToOriginalVertices = True,
+    produceNoPileUpCollection = True,
+    produceSortedVertices = False,
+    jets = "ak4CaloJets",
+    vertices = "offlinePrimaryVertices"
+)
+# and finally extract tracks from there
+generalTracksFromPV = _recoChargedRefCandidateToTrackRefProducer.clone(
+    src = cms.InputTag("trackRefsFromPV", "originalNoPileUp")
+)
+# and then the selectors
+cutsRecoTracksFromPVInitialStep         = cutsRecoTracksInitialStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVLowPtTripletStep    = cutsRecoTracksLowPtTripletStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVPixelPairStep       = cutsRecoTracksPixelPairStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVDetachedTripletStep = cutsRecoTracksDetachedTripletStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVMixedTripletStep    = cutsRecoTracksMixedTripletStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVPixelLessStep       = cutsRecoTracksPixelLessStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVTobTecStep          = cutsRecoTracksTobTecStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVJetCoreRegionalStep = cutsRecoTracksJetCoreRegionalStep.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVMuonSeededStepInOut = cutsRecoTracksMuonSeededStepInOut.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVMuonSeededStepOutIn = cutsRecoTracksMuonSeededStepOutIn.clone(src="generalTracksFromPV")
+# high purity
+cutsRecoTracksFromPVHp                    = cutsRecoTracksHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVInitialStepHp         = cutsRecoTracksInitialStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVLowPtTripletStepHp    = cutsRecoTracksLowPtTripletStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVPixelPairStepHp       = cutsRecoTracksPixelPairStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVDetachedTripletStepHp = cutsRecoTracksDetachedTripletStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVMixedTripletStepHp    = cutsRecoTracksMixedTripletStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVPixelLessStepHp       = cutsRecoTracksPixelLessStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVTobTecStepHp          = cutsRecoTracksTobTecStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVJetCoreRegionalStepHp = cutsRecoTracksJetCoreRegionalStepHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVMuonSeededStepInOutHp = cutsRecoTracksMuonSeededStepInOutHp.clone(src="generalTracksFromPV")
+cutsRecoTracksFromPVMuonSeededStepOutInHp = cutsRecoTracksMuonSeededStepOutInHp.clone(src="generalTracksFromPV")
+
+
+## MTV instances
 trackValidator= Validation.RecoTrack.MultiTrackValidator_cfi.multiTrackValidator.clone()
 
 trackValidator.label=cms.VInputTag(cms.InputTag("generalTracks"),
@@ -87,6 +158,38 @@ trackValidator.dodEdxPlots = True
 #trackValidator.maxpT = cms.double(3)
 #trackValidator.nintpT = cms.int32(40)
 
+trackValidatorFromPV = trackValidator.clone(
+    dirName = "Tracking/TrackFromPV/",
+    label = [
+        "generalTracksFromPV",
+        "cutsRecoTracksFromPVHp",
+        "cutsRecoTracksFromPVInitialStep",
+        "cutsRecoTracksFromPVInitialStepHp",
+        "cutsRecoTracksFromPVLowPtTripletStep",
+        "cutsRecoTracksFromPVLowPtTripletStepHp",
+        "cutsRecoTracksFromPVPixelPairStep",
+        "cutsRecoTracksFromPVPixelPairStepHp",
+        "cutsRecoTracksFromPVDetachedTripletStep",
+        "cutsRecoTracksFromPVDetachedTripletStepHp",
+        "cutsRecoTracksFromPVMixedTripletStep",
+        "cutsRecoTracksFromPVMixedTripletStepHp",
+        "cutsRecoTracksFromPVPixelLessStep",
+        "cutsRecoTracksFromPVPixelLessStepHp",
+        "cutsRecoTracksFromPVTobTecStep",
+        "cutsRecoTracksFromPVTobTecStepHp",
+        "cutsRecoTracksFromPVJetCoreRegionalStep",
+        "cutsRecoTracksFromPVJetCoreRegionalStepHp",
+        "cutsRecoTracksFromPVMuonSeededStepInOut",
+        "cutsRecoTracksFromPVMuonSeededStepInOutHp",
+        "cutsRecoTracksFromPVMuonSeededStepOutIn",
+        "cutsRecoTracksFromPVMuonSeededStepOutInHp",
+    ],
+    label_tp_effic = "trackingParticlesSignal",
+    label_tp_fake = "trackingParticlesSignal",
+    associators = ["trackingParticleRecoTrackAsssociationSignal"],
+    trackCollectionForDrCalculation = "generalTracksFromPV"
+)
+
 # the track selectors
 tracksValidationSelectors = cms.Sequence(
     cutsRecoTracksHp*
@@ -114,11 +217,43 @@ tracksValidationSelectors = cms.Sequence(
     ak4JetTracksAssociatorAtVertexPFAll*
     cutsRecoTracksAK4PFJets
 )
+tracksValidationSelectorsFromPV = cms.Sequence(
+    trackRefsForValidation*
+    trackRefsFromPV*
+    generalTracksFromPV*
+    cutsRecoTracksFromPVHp*
+    cutsRecoTracksFromPVInitialStep*
+    cutsRecoTracksFromPVInitialStepHp*
+    cutsRecoTracksFromPVLowPtTripletStep*
+    cutsRecoTracksFromPVLowPtTripletStepHp*
+    cutsRecoTracksFromPVPixelPairStep*
+    cutsRecoTracksFromPVPixelPairStepHp*
+    cutsRecoTracksFromPVDetachedTripletStep*
+    cutsRecoTracksFromPVDetachedTripletStepHp*
+    cutsRecoTracksFromPVMixedTripletStep*
+    cutsRecoTracksFromPVMixedTripletStepHp*
+    cutsRecoTracksFromPVPixelLessStep*
+    cutsRecoTracksFromPVPixelLessStepHp*
+    cutsRecoTracksFromPVTobTecStep*
+    cutsRecoTracksFromPVTobTecStepHp*
+    cutsRecoTracksFromPVJetCoreRegionalStep*
+    cutsRecoTracksFromPVJetCoreRegionalStepHp*
+    cutsRecoTracksFromPVMuonSeededStepInOut*
+    cutsRecoTracksFromPVMuonSeededStepInOutHp*
+    cutsRecoTracksFromPVMuonSeededStepOutIn*
+    cutsRecoTracksFromPVMuonSeededStepOutInHp
+)
 tracksValidationTruth = cms.Sequence(
     tpClusterProducer +
     quickTrackAssociatorByHits +
     trackingParticleRecoTrackAsssociation +
     VertexAssociatorByPositionAndTracks
+)
+tracksValidationTruthSignal = cms.Sequence(
+    cms.ignore(trackingParticlesSignal) +
+    tpClusterProducerSignal +
+    quickTrackAssociatorByHitsSignal +
+    trackingParticleRecoTrackAsssociationSignal
 )
 tracksValidationTruthFS = cms.Sequence(
     quickTrackAssociatorByHits +
@@ -127,7 +262,9 @@ tracksValidationTruthFS = cms.Sequence(
 
 tracksPreValidation = cms.Sequence(
     tracksValidationSelectors +
-    tracksValidationTruth
+    tracksValidationSelectorsFromPV +
+    tracksValidationTruth +
+    tracksValidationTruthSignal
 )
 tracksPreValidationFS = cms.Sequence(
     tracksValidationSelectors +
@@ -135,7 +272,7 @@ tracksPreValidationFS = cms.Sequence(
 )
 
 # selectors go into separate "prevalidation" sequence
-tracksValidation = cms.Sequence( trackValidator)
+tracksValidation = cms.Sequence( trackValidator + trackValidatorFromPV )
 tracksValidationFS = cms.Sequence( trackValidator )
 
 tracksValidationStandalone = cms.Sequence(

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -13,79 +13,29 @@ from SimTracker.TrackerHitAssociation.clusterTpAssociationProducer_cfi import *
 from SimTracker.VertexAssociation.VertexAssociatorByPositionAndTracks_cfi import *
 
 # Validation iterative steps
-cutsRecoTracksInitialStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksInitialStep.algorithm=cms.vstring("initialStep")
-
-cutsRecoTracksLowPtTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksLowPtTripletStep.algorithm=cms.vstring("lowPtTripletStep")
-
-cutsRecoTracksPixelPairStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksPixelPairStep.algorithm=cms.vstring("pixelPairStep")
-
-cutsRecoTracksDetachedTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksDetachedTripletStep.algorithm=cms.vstring("detachedTripletStep")
-
-cutsRecoTracksMixedTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksMixedTripletStep.algorithm=cms.vstring("mixedTripletStep")
-
-cutsRecoTracksPixelLessStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksPixelLessStep.algorithm=cms.vstring("pixelLessStep")
-
-cutsRecoTracksTobTecStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksTobTecStep.algorithm=cms.vstring("tobTecStep")
-
-cutsRecoTracksJetCoreRegionalStep = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksJetCoreRegionalStep.algorithm=cms.vstring("jetCoreRegionalStep")
-
-cutsRecoTracksMuonSeededStepInOut = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksMuonSeededStepInOut.algorithm=cms.vstring("muonSeededStepInOut")
-
-cutsRecoTracksMuonSeededStepOutIn = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksMuonSeededStepOutIn.algorithm=cms.vstring("muonSeededStepOutIn")
+cutsRecoTracksInitialStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["initialStep"])
+cutsRecoTracksLowPtTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["lowPtTripletStep"])
+cutsRecoTracksPixelPairStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["pixelPairStep"])
+cutsRecoTracksDetachedTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["detachedTripletStep"])
+cutsRecoTracksMixedTripletStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["mixedTripletStep"])
+cutsRecoTracksPixelLessStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["pixelLessStep"])
+cutsRecoTracksTobTecStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["tobTecStep"])
+cutsRecoTracksJetCoreRegionalStep = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["jetCoreRegionalStep"])
+cutsRecoTracksMuonSeededStepInOut = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["muonSeededStepInOut"])
+cutsRecoTracksMuonSeededStepOutIn = cutsRecoTracks_cfi.cutsRecoTracks.clone(algorithm=["muonSeededStepOutIn"])
 
 # high purity
-cutsRecoTracksHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksInitialStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksInitialStepHp.algorithm=cms.vstring("initialStep")
-cutsRecoTracksInitialStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksLowPtTripletStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksLowPtTripletStepHp.algorithm=cms.vstring("lowPtTripletStep")
-cutsRecoTracksLowPtTripletStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksPixelPairStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksPixelPairStepHp.algorithm=cms.vstring("pixelPairStep")
-cutsRecoTracksPixelPairStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksDetachedTripletStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksDetachedTripletStepHp.algorithm=cms.vstring("detachedTripletStep")
-cutsRecoTracksDetachedTripletStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksMixedTripletStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksMixedTripletStepHp.algorithm=cms.vstring("mixedTripletStep")
-cutsRecoTracksMixedTripletStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksPixelLessStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksPixelLessStepHp.algorithm=cms.vstring("pixelLessStep")
-cutsRecoTracksPixelLessStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksTobTecStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksTobTecStepHp.algorithm=cms.vstring("tobTecStep")
-cutsRecoTracksTobTecStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksJetCoreRegionalStepHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksJetCoreRegionalStepHp.algorithm=cms.vstring("jetCoreRegionalStep")
-cutsRecoTracksJetCoreRegionalStepHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksMuonSeededStepInOutHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksMuonSeededStepInOutHp.algorithm=cms.vstring("muonSeededStepInOut")
-cutsRecoTracksMuonSeededStepInOutHp.quality=cms.vstring("highPurity")
-
-cutsRecoTracksMuonSeededStepOutInHp = cutsRecoTracks_cfi.cutsRecoTracks.clone()
-cutsRecoTracksMuonSeededStepOutInHp.algorithm=cms.vstring("muonSeededStepOutIn")
-cutsRecoTracksMuonSeededStepOutInHp.quality=cms.vstring("highPurity")
+cutsRecoTracksHp = cutsRecoTracks_cfi.cutsRecoTracks.clone(quality=["highPurity"])
+cutsRecoTracksInitialStepHp = cutsRecoTracksInitialStep.clone(quality=["highPurity"])
+cutsRecoTracksLowPtTripletStepHp = cutsRecoTracksLowPtTripletStep.clone(quality=["highPurity"])
+cutsRecoTracksPixelPairStepHp = cutsRecoTracksPixelPairStep.clone(quality=["highPurity"])
+cutsRecoTracksDetachedTripletStepHp = cutsRecoTracksDetachedTripletStep.clone(quality=["highPurity"])
+cutsRecoTracksMixedTripletStepHp = cutsRecoTracksMixedTripletStep.clone(quality=["highPurity"])
+cutsRecoTracksPixelLessStepHp = cutsRecoTracksPixelLessStep.clone(quality=["highPurity"])
+cutsRecoTracksTobTecStepHp = cutsRecoTracksTobTecStep.clone(quality=["highPurity"])
+cutsRecoTracksJetCoreRegionalStepHp = cutsRecoTracksJetCoreRegionalStep.clone(quality=["highPurity"])
+cutsRecoTracksMuonSeededStepInOutHp = cutsRecoTracksMuonSeededStepInOut.clone(quality=["highPurity"])
+cutsRecoTracksMuonSeededStepOutInHp = cutsRecoTracksMuonSeededStepOutIn.clone(quality=["highPurity"])
 
 # BTV-like selection
 import PhysicsTools.RecoAlgos.btvTracks_cfi as btvTracks_cfi

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -158,6 +158,8 @@ trackValidator.dodEdxPlots = True
 #trackValidator.maxpT = cms.double(3)
 #trackValidator.nintpT = cms.int32(40)
 
+# For efficiency of signal TPs vs. signal tracks, and fake rate of
+# signal tracks vs. signal TPs
 trackValidatorFromPV = trackValidator.clone(
     dirName = "Tracking/TrackFromPV/",
     label = [
@@ -190,6 +192,31 @@ trackValidatorFromPV = trackValidator.clone(
     trackCollectionForDrCalculation = "generalTracksFromPV",
     doPlotsOnlyForTruePV = True
 )
+
+# For fake rate of signal tracks vs. all TPs, and pileup rate of
+# signal tracks vs. non-signal TPs
+trackValidatorFromPVAllTP = trackValidatorFromPV.clone(
+    dirName = "Tracking/TrackFromPVAllTP/",
+    label_tp_effic = trackValidator.label_tp_effic.value(),
+    label_tp_fake = trackValidator.label_tp_fake.value(),
+    associators = trackValidator.associators.value(),
+    doSimPlots = False,
+    doSimTrackPlots = False,
+)
+
+# For efficiency of all TPs vs. all tracks
+trackValidatorAllTPEffic = trackValidator.clone(
+    dirName = "Tracking/TrackAllTPEffic/",
+    doSimPlots = False,
+    doRecoTrackPlots = False, # Fake rate of all tracks vs. all TPs is already included in trackValidator
+)
+trackValidatorAllTPEffic.histoProducerAlgoBlock.generalTpSelector.signalOnly = False
+trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsEta.signalOnly = False
+trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi.signalOnly = False
+trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt.signalOnly = False
+trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR.signalOnly = False
+trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ.signalOnly = False
+
 
 # the track selectors
 tracksValidationSelectors = cms.Sequence(
@@ -273,7 +300,12 @@ tracksPreValidationFS = cms.Sequence(
 )
 
 # selectors go into separate "prevalidation" sequence
-tracksValidation = cms.Sequence( trackValidator + trackValidatorFromPV )
+tracksValidation = cms.Sequence(
+    trackValidator +
+    trackValidatorFromPV +
+    trackValidatorFromPVAllTP +
+    trackValidatorAllTPEffic
+)
 tracksValidationFS = cms.Sequence( trackValidator )
 
 tracksValidationStandalone = cms.Sequence(

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -165,26 +165,6 @@ trackValidatorFromPV = trackValidator.clone(
     label = [
         "generalTracksFromPV",
         "cutsRecoTracksFromPVHp",
-        "cutsRecoTracksFromPVInitialStep",
-        "cutsRecoTracksFromPVInitialStepHp",
-        "cutsRecoTracksFromPVLowPtTripletStep",
-        "cutsRecoTracksFromPVLowPtTripletStepHp",
-        "cutsRecoTracksFromPVPixelPairStep",
-        "cutsRecoTracksFromPVPixelPairStepHp",
-        "cutsRecoTracksFromPVDetachedTripletStep",
-        "cutsRecoTracksFromPVDetachedTripletStepHp",
-        "cutsRecoTracksFromPVMixedTripletStep",
-        "cutsRecoTracksFromPVMixedTripletStepHp",
-        "cutsRecoTracksFromPVPixelLessStep",
-        "cutsRecoTracksFromPVPixelLessStepHp",
-        "cutsRecoTracksFromPVTobTecStep",
-        "cutsRecoTracksFromPVTobTecStepHp",
-        "cutsRecoTracksFromPVJetCoreRegionalStep",
-        "cutsRecoTracksFromPVJetCoreRegionalStepHp",
-        "cutsRecoTracksFromPVMuonSeededStepInOut",
-        "cutsRecoTracksFromPVMuonSeededStepInOutHp",
-        "cutsRecoTracksFromPVMuonSeededStepOutIn",
-        "cutsRecoTracksFromPVMuonSeededStepOutInHp",
     ],
     label_tp_effic = "trackingParticlesSignal",
     label_tp_fake = "trackingParticlesSignal",
@@ -192,6 +172,29 @@ trackValidatorFromPV = trackValidator.clone(
     trackCollectionForDrCalculation = "generalTracksFromPV",
     doPlotsOnlyForTruePV = True
 )
+trackValidatorFromPVStandalone = trackValidatorFromPV.clone()
+trackValidatorFromPVStandalone.label.extend([
+    "cutsRecoTracksFromPVInitialStep",
+    "cutsRecoTracksFromPVInitialStepHp",
+    "cutsRecoTracksFromPVLowPtTripletStep",
+    "cutsRecoTracksFromPVLowPtTripletStepHp",
+    "cutsRecoTracksFromPVPixelPairStep",
+    "cutsRecoTracksFromPVPixelPairStepHp",
+    "cutsRecoTracksFromPVDetachedTripletStep",
+    "cutsRecoTracksFromPVDetachedTripletStepHp",
+    "cutsRecoTracksFromPVMixedTripletStep",
+    "cutsRecoTracksFromPVMixedTripletStepHp",
+    "cutsRecoTracksFromPVPixelLessStep",
+    "cutsRecoTracksFromPVPixelLessStepHp",
+    "cutsRecoTracksFromPVTobTecStep",
+    "cutsRecoTracksFromPVTobTecStepHp",
+    "cutsRecoTracksFromPVJetCoreRegionalStep",
+    "cutsRecoTracksFromPVJetCoreRegionalStepHp",
+    "cutsRecoTracksFromPVMuonSeededStepInOut",
+    "cutsRecoTracksFromPVMuonSeededStepInOutHp",
+    "cutsRecoTracksFromPVMuonSeededStepOutIn",
+    "cutsRecoTracksFromPVMuonSeededStepOutInHp",
+])
 
 # For fake rate of signal tracks vs. all TPs, and pileup rate of
 # signal tracks vs. non-signal TPs
@@ -203,10 +206,17 @@ trackValidatorFromPVAllTP = trackValidatorFromPV.clone(
     doSimPlots = False,
     doSimTrackPlots = False,
 )
+trackValidatorFromPVAllTPStandalone = trackValidatorFromPVAllTP.clone(
+    label = trackValidatorFromPVStandalone.label.value()
+)
 
 # For efficiency of all TPs vs. all tracks
 trackValidatorAllTPEffic = trackValidator.clone(
     dirName = "Tracking/TrackAllTPEffic/",
+    label = [
+        "generalTracks",
+        "cutsRecoTracksHp",
+    ],
     doSimPlots = False,
     doRecoTrackPlots = False, # Fake rate of all tracks vs. all TPs is already included in trackValidator
 )
@@ -216,6 +226,9 @@ trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPhi.sig
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsPt.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXR.signalOnly = False
 trackValidatorAllTPEffic.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ.signalOnly = False
+trackValidatorAllTPEfficStandalone = trackValidatorAllTPEffic.clone(
+    label = trackValidator.label.value()
+)
 
 
 # the track selectors
@@ -249,7 +262,9 @@ tracksValidationSelectorsFromPV = cms.Sequence(
     trackRefsForValidation*
     trackRefsFromPV*
     generalTracksFromPV*
-    cutsRecoTracksFromPVHp*
+    cutsRecoTracksFromPVHp
+)
+tracksValidationSelectorsFromPVStandalone = cms.Sequence(
     cutsRecoTracksFromPVInitialStep*
     cutsRecoTracksFromPVInitialStepHp*
     cutsRecoTracksFromPVLowPtTripletStep*
@@ -294,6 +309,10 @@ tracksPreValidation = cms.Sequence(
     tracksValidationTruth +
     tracksValidationTruthSignal
 )
+tracksPreValidationStandalone = cms.Sequence(
+    tracksPreValidation +
+    tracksValidationSelectorsFromPVStandalone
+)
 tracksPreValidationFS = cms.Sequence(
     tracksValidationSelectors +
     tracksValidationTruthFS
@@ -310,6 +329,9 @@ tracksValidationFS = cms.Sequence( trackValidator )
 
 tracksValidationStandalone = cms.Sequence(
     ak4PFL1FastL2L3CorrectorChain+
-    tracksPreValidation+
-    tracksValidation
+    tracksPreValidationStandalone+
+    trackValidator +
+    trackValidatorFromPVStandalone +
+    trackValidatorFromPVAllTPStandalone +
+    trackValidatorAllTPEfficStandalone
 )

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -187,7 +187,8 @@ trackValidatorFromPV = trackValidator.clone(
     label_tp_effic = "trackingParticlesSignal",
     label_tp_fake = "trackingParticlesSignal",
     associators = ["trackingParticleRecoTrackAsssociationSignal"],
-    trackCollectionForDrCalculation = "generalTracksFromPV"
+    trackCollectionForDrCalculation = "generalTracksFromPV",
+    doPlotsOnlyForTruePV = True
 )
 
 # the track selectors

--- a/Validation/RecoTrack/python/TrackerSeedValidator_cfi.py
+++ b/Validation/RecoTrack/python/TrackerSeedValidator_cfi.py
@@ -23,7 +23,6 @@ trackerSeedValidator = cms.EDAnalyzer("TrackerSeedValidator",
     ### sim input configuration ###
     label_tp_effic = cms.InputTag("mix","MergedTrackTruth"),
     label_tp_fake = cms.InputTag("mix","MergedTrackTruth"),
-    label_tv = cms.InputTag("mix","MergedTrackTruth"),
     label_pileupinfo = cms.InputTag("addPileupInfo"),
     sim = cms.VInputTag(
       cms.InputTag("g4SimHits", "TrackerHitsPixelBarrelHighTof"),

--- a/Validation/RecoTrack/src/MultiTrackValidatorBase.cc
+++ b/Validation/RecoTrack/src/MultiTrackValidatorBase.cc
@@ -6,7 +6,6 @@ MultiTrackValidatorBase::MultiTrackValidatorBase(const edm::ParameterSet& pset, 
   associators = pset.getUntrackedParameter< std::vector<edm::InputTag> >("associators");
   label_tp_effic = iC.consumes<TrackingParticleCollection>(pset.getParameter< edm::InputTag >("label_tp_effic"));
   label_tp_fake = iC.consumes<TrackingParticleCollection>(pset.getParameter< edm::InputTag >("label_tp_fake"));
-  label_tv = iC.mayConsume<TrackingVertexCollection>(pset.getParameter< edm::InputTag >("label_tv"));
   label_pileupinfo = iC.consumes<std::vector<PileupSummaryInfo> >(pset.getParameter< edm::InputTag >("label_pileupinfo"));
   for(const auto& tag: pset.getParameter<std::vector<edm::InputTag>>("sim")) {
     simHitTokens_.push_back(iC.consumes<std::vector<PSimHit>>(tag));


### PR DESCRIPTION
This PR adds three MultiTrackValidator instances to validation sequence
- `trackValidatorFromPV` (DQM folder "Tracking/TrackFromPV")
  - Monitors tracks associated to the reconstructed primary vertex wrt. TrackingParticles from the hard scatter event, only for events where the primary vertex is correctly identified (i.e. is matched to the generated one)
  - Track-PV association is produced with the same code as in miniAOD, the used association criteria corresponds to the "CompatibilityBTag" flag
  - Monitoring includes the full set of plots
    - Efficiency shows the fraction of hard-scatter TPs that are reconstructed and associated to PV
    - In fake rate the tracks from pileup are counted as fakes
- `trackValidatorFromPVAllTP` (DQM folder "Tracking/TrackFromPVAllTP")
  - Monitors the fake rate (and similar quantities) of PV-associated tracks wrt. all TrackingParticles, i.e. shows how much of the tracks associated to PV are fakes and how much from pileup
- `trackValidatorAllTPEffic` (DQM folder "Tracking/TrackAllTPEffic")
  - Monitors the efficiency of all tracks wrt. all TrackingParticles (in the existing `trackValidator` efficiency is defined wrt. hard-scatter TPs)
  - This quantity is not very interesting for tracking performance, but helps to check if there are differences in pileup simulation between releases (or between classical mixing and premixing)

For the standard validation sequence, the new MTV instances above are set to monitor only generalTracks and highPurity tracks in order to keep the memory use under control. The instances for the "standalone mode" (running MTV privately alone), also the individual iterations are monitored.

In addition the PR includes some cleanup, most notably the recently added summary plots (#9201) are created and filled according to the `doSimTrackPlots`/`doRecoTrackPlots` configuration flags.

Tested in CMSSW_7_6_X_2015-07-10-1100, no changes expected in existing histograms.

@rovere @VinInn 
