### PR TITLE
Vtx smearing parameters for realistic 50ns collisions 13 TeV

### DIFF
--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -424,9 +424,9 @@ Realistic50ns13TeVCollisionVtxSmearingParameters = cms.PSet(
     Alpha = cms.double(0.0),
     SigmaZ = cms.double(5.3),
     TimeOffset = cms.double(0.0),
-    X0 = cms.double(0.06006),
-    Y0 = cms.double(0.10007),
-    Z0 = cms.double(-1.708)
+    X0 = cms.double(0.08535),
+    Y0 = cms.double(0.16973),
+    Z0 = cms.double(-1.223)
 )
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(


### PR DESCRIPTION
Fix vtx smearing parameters for realistic 50ns collisions 13 TeV. Proper pixel offset applied.
In the previous iteration (https://github.com/cms-sw/cmssw/pull/10048), the wrong translation accounting for the Pixel Barrel position was applied.
Now fixed.

BS absolute position
X = 0.059395  [cm]
Y = 0.099686  [cm]
Z = -1.722240 [cm]

Pix Barrel position
X = -0.0259503  [cm]
Y = -0.07004      [cm]
Z = -0.498917    [cm]

Resulting position
X = 0.059395  + 0.0259503 = 0.0853453 [cm]
Y = 0.099686  + 0.07004     = 0.169726   [cm]
Z = -1.722240 + 0.498917   = -1.223323  [cm]
