### PR TITLE
SKIMS in Conf data processing 76

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -34,6 +34,8 @@ class ppRun2(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
+        if not 'PhysicsSkims' in args:
+            args['PhysicsSkims']=['']
 
         if not 'customs' in args:
             args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -34,8 +34,6 @@ class ppRun2(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
-        if not 'PhysicsSkims' in args:
-            args['PhysicsSkims']=['']
 
         if not 'customs' in args:
             args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -34,7 +34,9 @@ class Reco(Scenario):
 
         """
         step = stepALCAPRODUCER(args['skims'])
-        PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
+        PhysicsSkimStep = ''
+        if (args.has_key("PhysicsSkims")) :
+            PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
         dqmStep= dqmSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
@@ -263,7 +265,6 @@ class Reco(Scenario):
         """
         skims = []
         if 'skims' in args:
-            print 'here'
             skims = args['skims']
 
 

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
@@ -34,6 +34,7 @@ class Reco(Scenario):
 
         """
         step = stepALCAPRODUCER(args['skims'])
+        PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
         dqmStep= dqmSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
@@ -56,7 +57,7 @@ class Reco(Scenario):
         if self.cbSc == 'pp':
             eiStep=',EI'
 
-        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+miniAODStep+',DQM'+dqmStep+',ENDJOB'
+        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+PhysicsSkimStep+miniAODStep+',DQM'+dqmStep+',ENDJOB'
 
 
         dictIO(options,args)

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -20,6 +20,21 @@ def stepALCAPRODUCER(skims):
         step = ',ALCAPRODUCER:'+('+'.join(skims))
     return step
 
+
+def stepSKIMPRODUCER(PhysicsSkims):
+    """
+    _stepSKIMPRODUCER_
+
+    Creates and returns the configuration string for the SKIM step
+    starting from the list of skims to be run.
+
+    """
+
+    step = ''
+    if (len(PhysicsSkims)>0 ) & ( PhysicsSkims!=[''] ) :
+        step = ',SKIM:'+('+'.join(PhysicsSkims))
+    return step
+
 def addMonitoring(process):
     """
     _addMonitoring_

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -31,7 +31,7 @@ def stepSKIMPRODUCER(PhysicsSkims):
     """
 
     step = ''
-    if (len(PhysicsSkims)>0 ) & ( PhysicsSkims!=[''] ) :
+    if len(PhysicsSkims) >0 :
         step = ',SKIM:'+('+'.join(PhysicsSkims))
     return step
 

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -27,6 +27,7 @@ class RunPromptReco:
         self.globalTag = None
         self.inputLFN = None
         self.alcaRecos = None
+        self.PhysicsSkims = None
 
     def __call__(self):
         if self.scenario == None:
@@ -85,6 +86,8 @@ class RunPromptReco:
 
                 if self.alcaRecos:
                     kwds['skims'] = self.alcaRecos
+                if self.PhysicsSkims:
+                    kwds['PhysicsSkims'] = self.PhysicsSkims
 
             process = scenario.promptReco(self.globalTag, **kwds)
 
@@ -112,7 +115,7 @@ class RunPromptReco:
 
 if __name__ == '__main__':
     valid = ["scenario=", "reco", "aod", "miniaod","dqm", "dqmio", "no-output",
-             "global-tag=", "lfn=", "alcarecos=" ]
+             "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=" ]
     usage = \
 """
 RunPromptReco.py <options>
@@ -127,13 +130,16 @@ Where options are:
  --no-output (create config with no output, overrides other settings)
  --global-tag=GlobalTag
  --lfn=/store/input/lfn
- --alcarecos=plus_seprated_list
+ --alcarecos=alcareco_plus_seprated_list
+ --PhysicsSkims=skim_plus_seprated_list
 
 Example:
 
 python RunPromptReco.py --scenario=cosmics --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlCosmics0T+MuAlGlobalCosmics
 
 python RunPromptReco.py --scenario=pp --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias
+
+python RunPromptReco.py --scenario=ppRun2 --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias --PhysicsSkims=@SingleMuon
 
 """
     try:
@@ -167,5 +173,7 @@ python RunPromptReco.py --scenario=pp --reco --aod --dqmio --global-tag GLOBALTA
             recoinator.inputLFN = arg
         if opt == "--alcarecos":
             recoinator.alcaRecos = [ x for x in arg.split('+') if len(x) > 0 ]
+        if opt == "--PhysicsSkims":
+            recoinator.PhysicsSkims = [ x for x in arg.split('+') if len(x) > 0 ]
 
     recoinator()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -26,6 +26,7 @@ declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixel
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
 

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -26,7 +26,6 @@ declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixel
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
-     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
 
@@ -41,6 +40,7 @@ declare -a arr=("ppRun2" "ppRun2B0T")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
 


### PR DESCRIPTION
- Includes a new key (PhysicsSkims) to allow inclusion of SKIM: in the prompt processing, in the same step as RECO
- added a new test which probes such new key for "ppRun2" "ppRun2B0T" scenarios

@cerminar

@hufnagel  : can you please take a look and comment ? The integration with T0 needs to follow the same logic of the ALCA, using the skim matrix with @PRIMARYDATASET syntax. The committed example in run_CfgTest.sh demostrates the principle

@sextonkennedy : we spoke about this, do you haev comments ? 
