### PR TITLE
SKIMS in Conf data processing 74

### DIFF
--- a/Calibration/Hotline/python/hotlineSkims_cff.py
+++ b/Calibration/Hotline/python/hotlineSkims_cff.py
@@ -209,7 +209,7 @@ htFilter = cms.EDFilter(
 seqHotlineSkimHT = cms.Sequence(htMht * htSelector * htFilter)
 
 #high-mass dileptons
-dimuons = cms.EDProducer(
+dimuonsHotLine = cms.EDProducer(
     "CandViewShallowCloneCombiner",
     decay = cms.string("muons muons"),
     checkCharge = cms.bool(False),
@@ -229,7 +229,7 @@ diEMu = cms.EDProducer(
 )
 dimuonMassFilter = cms.EDFilter(
     "CandViewCountFilter",
-    src = cms.InputTag("dimuons"),
+    src = cms.InputTag("dimuonsHotLine"),
     minNumber = cms.uint32(1)
 )
 dielectronMassFilter = cms.EDFilter(
@@ -243,12 +243,12 @@ diEMuMassFilter = cms.EDFilter(
     minNumber = cms.uint32(1)
 )
 
-seqHotlineSkimMassiveDimuon = cms.Sequence(dimuons * dimuonMassFilter)
+seqHotlineSkimMassiveDimuon = cms.Sequence(dimuonsHotLine * dimuonMassFilter)
 seqHotlineSkimMassiveDielectron = cms.Sequence(dielectrons * dielectronMassFilter)
 seqHotlineSkimMassiveEMu = cms.Sequence(diEMu * diEMuMassFilter)
 
 ## select events with at least one good PV
-pvFilter = cms.EDFilter(
+pvFilterHotLine = cms.EDFilter(
     "VertexSelector",
     src = cms.InputTag("offlinePrimaryVertices"),
     cut = cms.string("!isFake && ndof > 4 && abs(z) <= 24 && position.Rho <= 2"),
@@ -260,64 +260,64 @@ from CommonTools.RecoAlgos.HBHENoiseFilter_cfi import HBHENoiseFilter
 from CommonTools.RecoAlgos.HBHENoiseFilterResultProducer_cfi import HBHENoiseFilterResultProducer
 
 ## select events with high pfMET
-pfMETSelector = cms.EDFilter(
+pfMETSelectorHotLine = cms.EDFilter(
     "CandViewSelector",
     src = cms.InputTag("pfMet"),
     cut = cms.string( "pt()>"+str(pfMetCut) )
 )
 
-pfMETCounter = cms.EDFilter(
+pfMETCounterHotLine = cms.EDFilter(
     "CandViewCountFilter",
-    src = cms.InputTag("pfMETSelector"),
+    src = cms.InputTag("pfMETSelectorHotLine"),
     minNumber = cms.uint32(1),
 )
 
 seqHotlineSkimPFMET = cms.Sequence(
-   pvFilter*
+   pvFilterHotLine*
    HBHENoiseFilterResultProducer*
    HBHENoiseFilter*
-   pfMETSelector*
-   pfMETCounter
+   pfMETSelectorHotLine*
+   pfMETCounterHotLine
 )
 
 ## select events with high caloMET
-caloMETSelector = cms.EDFilter(
+caloMETSelectorHotLine = cms.EDFilter(
     "CandViewSelector",
     src = cms.InputTag("caloMetM"),
     cut = cms.string( "pt()>"+str(caloMetCut) )
 )
 
-caloMETCounter = cms.EDFilter(
+caloMETCounterHotLine = cms.EDFilter(
     "CandViewCountFilter",
-    src = cms.InputTag("caloMETSelector"),
+    src = cms.InputTag("caloMETSelectorHotLine"),
     minNumber = cms.uint32(1),
 )
 
 seqHotlineSkimCaloMET = cms.Sequence(
-   pvFilter*
+   pvFilterHotLine*
    HBHENoiseFilterResultProducer*
    HBHENoiseFilter*
-   caloMETSelector*
-   caloMETCounter
+   caloMETSelectorHotLine*
+   caloMETCounterHotLine
 )
 
 ## select events with extreme PFMET/CaloMET ratio
-CondMETSelector = cms.EDProducer(
+CondMETSelectorHotLine = cms.EDProducer(
    "CandViewShallowCloneCombiner",
    decay = cms.string("pfMet caloMetM"),
    cut = cms.string("(daughter(0).pt/daughter(1).pt > "+str(PFOverCaloRatioCut)+" && daughter(1).pt > "+str(condCaloMetCut)+") || (daughter(1).pt/daughter(0).pt > "+str(caloOverPFRatioCut)+" && daughter(0).pt > "+str(condPFMetCut)+" )  " )
 )
 
-CondMETCounter = cms.EDFilter(
+CondMETCounterHotLine = cms.EDFilter(
     "CandViewCountFilter",
-    src = cms.InputTag("CondMETSelector"),
+    src = cms.InputTag("CondMETSelectorHotLine"),
     minNumber = cms.uint32(1),
 )
 
 seqHotlineSkimCondMET = cms.Sequence(
-   pvFilter*
+   pvFilterHotLine*
    HBHENoiseFilterResultProducer*
    HBHENoiseFilter*
-   CondMETSelector*
-   CondMETCounter
+   CondMETSelectorHotLine*
+   CondMETCounterHotLine
 )

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -34,6 +34,8 @@ class ppRun2(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
+        if not 'PhysicsSkims' in args:
+            args['PhysicsSkims']=['']
 
         if not 'customs' in args:
             args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']

--- a/Configuration/DataProcessing/python/Impl/ppRun2.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2.py
@@ -34,8 +34,6 @@ class ppRun2(Reco):
         """
         if not 'skims' in args:
             args['skims']=['@allForPrompt']
-        if not 'PhysicsSkims' in args:
-            args['PhysicsSkims']=['']
 
         if not 'customs' in args:
             args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2']

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -34,7 +34,9 @@ class Reco(Scenario):
 
         """
         step = stepALCAPRODUCER(args['skims'])
-        PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
+        PhysicsSkimStep = ''
+        if (args.has_key("PhysicsSkims")) :
+            PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
         dqmStep= dqmSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
@@ -263,7 +265,6 @@ class Reco(Scenario):
         """
         skims = []
         if 'skims' in args:
-            print 'here'
             skims = args['skims']
 
 

--- a/Configuration/DataProcessing/python/Reco.py
+++ b/Configuration/DataProcessing/python/Reco.py
@@ -10,7 +10,7 @@ import os
 import sys
 
 from Configuration.DataProcessing.Scenario import *
-from Configuration.DataProcessing.Utils import stepALCAPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
+from Configuration.DataProcessing.Utils import stepALCAPRODUCER,stepSKIMPRODUCER,addMonitoring,dictIO,dqmIOSource,harvestingMode,dqmSeq,gtNameAndConnect
 import FWCore.ParameterSet.Config as cms
 from Configuration.DataProcessing.RecoTLR import customisePrompt,customiseExpress
 
@@ -34,6 +34,7 @@ class Reco(Scenario):
 
         """
         step = stepALCAPRODUCER(args['skims'])
+        PhysicsSkimStep = stepSKIMPRODUCER(args['PhysicsSkims'])
         dqmStep= dqmSeq(args,'')
         options = Options()
         options.__dict__.update(defaultOptions.__dict__)
@@ -56,7 +57,7 @@ class Reco(Scenario):
         if self.cbSc == 'pp':
             eiStep=',EI'
 
-        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+miniAODStep+',DQM'+dqmStep+',ENDJOB'
+        options.step = 'RAW2DIGI,L1Reco,RECO'+self.recoSeq+eiStep+step+PhysicsSkimStep+miniAODStep+',DQM'+dqmStep+',ENDJOB'
 
 
         dictIO(options,args)

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -20,6 +20,21 @@ def stepALCAPRODUCER(skims):
         step = ',ALCAPRODUCER:'+('+'.join(skims))
     return step
 
+
+def stepSKIMPRODUCER(PhysicsSkims):
+    """
+    _stepSKIMPRODUCER_
+
+    Creates and returns the configuration string for the SKIM step
+    starting from the list of skims to be run.
+
+    """
+
+    step = ''
+    if (len(PhysicsSkims)>0 ) & ( PhysicsSkims!=[''] ) :
+        step = ',SKIM:'+('+'.join(PhysicsSkims))
+    return step
+
 def addMonitoring(process):
     """
     _addMonitoring_

--- a/Configuration/DataProcessing/python/Utils.py
+++ b/Configuration/DataProcessing/python/Utils.py
@@ -31,7 +31,7 @@ def stepSKIMPRODUCER(PhysicsSkims):
     """
 
     step = ''
-    if (len(PhysicsSkims)>0 ) & ( PhysicsSkims!=[''] ) :
+    if len(PhysicsSkims) >0 :
         step = ',SKIM:'+('+'.join(PhysicsSkims))
     return step
 

--- a/Configuration/DataProcessing/test/RunPromptReco.py
+++ b/Configuration/DataProcessing/test/RunPromptReco.py
@@ -27,6 +27,7 @@ class RunPromptReco:
         self.globalTag = None
         self.inputLFN = None
         self.alcaRecos = None
+        self.PhysicsSkims = None
 
     def __call__(self):
         if self.scenario == None:
@@ -85,6 +86,8 @@ class RunPromptReco:
 
                 if self.alcaRecos:
                     kwds['skims'] = self.alcaRecos
+                if self.PhysicsSkims:
+                    kwds['PhysicsSkims'] = self.PhysicsSkims
 
             process = scenario.promptReco(self.globalTag, **kwds)
 
@@ -112,7 +115,7 @@ class RunPromptReco:
 
 if __name__ == '__main__':
     valid = ["scenario=", "reco", "aod", "miniaod","dqm", "dqmio", "no-output",
-             "global-tag=", "lfn=", "alcarecos=" ]
+             "global-tag=", "lfn=", "alcarecos=", "PhysicsSkims=" ]
     usage = \
 """
 RunPromptReco.py <options>
@@ -127,13 +130,16 @@ Where options are:
  --no-output (create config with no output, overrides other settings)
  --global-tag=GlobalTag
  --lfn=/store/input/lfn
- --alcarecos=plus_seprated_list
+ --alcarecos=alcareco_plus_seprated_list
+ --PhysicsSkims=skim_plus_seprated_list
 
 Example:
 
 python RunPromptReco.py --scenario=cosmics --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlCosmics0T+MuAlGlobalCosmics
 
 python RunPromptReco.py --scenario=pp --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias
+
+python RunPromptReco.py --scenario=ppRun2 --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever --alcarecos=TkAlMinBias+SiStripCalMinBias --PhysicsSkims=@SingleMuon
 
 """
     try:
@@ -167,5 +173,7 @@ python RunPromptReco.py --scenario=pp --reco --aod --dqmio --global-tag GLOBALTA
             recoinator.inputLFN = arg
         if opt == "--alcarecos":
             recoinator.alcaRecos = [ x for x in arg.split('+') if len(x) > 0 ]
+        if opt == "--PhysicsSkims":
+            recoinator.PhysicsSkims = [ x for x in arg.split('+') if len(x) > 0 ]
 
     recoinator()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -26,6 +26,7 @@ declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixel
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
 

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -26,7 +26,6 @@ declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixel
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
-     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
 
@@ -41,6 +40,7 @@ declare -a arr=("ppRun2" "ppRun2B0T")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
+     runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias --PhysicsSkim=@SingleMuon"
 done
 
 


### PR DESCRIPTION
FW port of #10226

Includes a new key (PhysicsSkims) to allow inclusion of SKIM: in the prompt processing, in the same step as RECO
added a new test which probes such new key for "ppRun2" "ppRun2B0T" scenarios
@cerminar

@hufnagel : can you please take a look and comment ? The integration with T0 needs to follow the same logic of the ALCA, using the skim matrix with @PRIMARYDATASET syntax. The committed example in run_CfgTest.sh demostrates the principle

@sextonkennedy : we spoke about this, do you have comments ?
