### PR TITLE
ngrenz Strip Validation Package Optimization

### DIFF
--- a/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
+++ b/Validation/TrackerRecHits/interface/SiStripRecHitsValid.h
@@ -211,9 +211,9 @@ class SiStripRecHitsValid : public DQMEDAnalyzer {
 
   /* static const int MAXHIT = 1000; */
 
-  std::vector<RecHitProperties> rechitrphi;
-  std::vector<RecHitProperties> rechitstereo;
-  std::vector<RecHitProperties> rechitmatched;
+//  std::vector<RecHitProperties> rechitrphi;
+//  std::vector<RecHitProperties> rechitstereo;
+//  std::vector<RecHitProperties> rechitmatched;
   RecHitProperties rechitpro;
 
   void rechitanalysis(SiStripRecHit2D const rechit,const StripTopology &topol, TrackerHitAssociator& associate);

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -198,15 +198,9 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   e.getByToken(stereoRecHitsToken_, rechitsstereo);
 
   //Variables in order to count total num of rechitrphi,rechitstereo, rechitmatched in subdetectors
-  //std::map<std::string, std::vector<int> > totnumrechitrphi;
-  //std::map<std::string, std::vector<int> > totnumrechitstereo;
-  //std::map<std::string, std::vector<int> > totnumrechitmatched;
   std::map<std::string, int > totnumrechitrphi;
   std::map<std::string, int > totnumrechitstereo;
   std::map<std::string, int > totnumrechitmatched;
-  //totnumrechitrphi.clear();
-  //totnumrechitstereo.clear();
-  //totnumrechitmatched.clear();
   int totrechitrphi =0;
   int totrechitstereo =0;
   int totrechitmatched =0;
@@ -220,7 +214,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   SiStripHistoId hidmanager;
   SiStripFolderOrganizer fold_organ;
 
-  // start loops over DetIds
+  // start loops over detectors with detected rechitsrphi
   for (auto it = rechitsrphi->begin(), itEnd = rechitsrphi->end(); it != itEnd; ++it) {
     DetId detid = (*it).detId();
     uint32_t myid = detid.rawId();       
@@ -232,13 +226,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     std::pair<std::string,int32_t> det_lay_pair = fold_organ.GetSubDetAndLayer(myid,tTopo,true);
 
     totnumrechitrphi[det_lay_pair.first] = totnumrechitrphi[det_lay_pair.first] + detsetIter->size();
-
-  //  totnumrechitrphi[det_lay_pair.first].push_back(detsetIter->size());
-  //  totnumrechitstereo[det_lay_pair.first].push_back(0);
-  //  totnumrechitmatched[det_lay_pair.first].push_back(0);
-
     //loop over rechits-rphi in the same subdetector
-    // SiStripRecHit2DCollection::DetSet::const_iterator iterrphi
     if(iLayerME != LayerMEsMap.end()){
       for(auto iterrphi= detsetIter->begin(), iterEnd = detsetIter->end(); iterrphi != iterEnd; ++iterrphi){	
         const GeomDetUnit *  det = tracker.idToDetUnit(detid);
@@ -247,7 +235,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
         SiStripRecHit2D const rechit=*iterrphi;
         //analyze RecHits 
         rechitanalysis(rechit,topol,associate);
-
+        // fill the result in a histogram
         fillME(iLayerME->second.meWclusrphi,rechitpro.clusiz);
         fillME(iLayerME->second.meAdcrphi,rechitpro.cluchg);
         fillME(iLayerME->second.mePosxrphi,rechitpro.x);
@@ -265,18 +253,10 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
           fillME(iLayerME->second.meChi2rphi,rechitpro.chi2);
         }
       }
-    }/*else{//ngrenz: probably not needed
-      for(auto iterrphi= deetIter->begin(), iterEnd = detsetIter->end(); iterrphi != iterEnd; ++iterrphi){	
-        const GeomDetUnit *  det = tracker.idToDetUnit(detid);
-        const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
-        const StripTopology &topol=(StripTopology&)stripdet->topology();
-        SiStripRecHit2D const rechit=*iterrphi;
-        //analyze RecHits 
-        rechitanalysis(rechit,topol,associate);
-      }
-    }*/
+    }
   }
 
+  // start loops over detectors with detected rechitsstereo
   for (auto it = rechitsstereo->begin(), itEnd = rechitsstereo->end(); it != itEnd; ++it) {
     DetId detid = (*it).detId();
     uint32_t myid= detid.rawId();       
@@ -288,11 +268,6 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     std::pair<std::string,int32_t> det_lay_pair = fold_organ.GetSubDetAndLayer(myid,tTopo,true);
    
     totnumrechitstereo[det_lay_pair.first] = totnumrechitstereo[det_lay_pair.first] + detsetIter->size();
-
-   // totnumrechitrphi[det_lay_pair.first].push_back(0);
-   // totnumrechitstereo[det_lay_pair.first].push_back(detsetIter->size());
-   // totnumrechitmatched[det_lay_pair.first].push_back(0);
-
     //loop over rechits-stereo in the same subdetector
     if(iStereoAndMatchedME != StereoAndMatchedMEsMap.end()){
       for(auto iterstereo=detsetIter->begin(), iterEnd = detsetIter->end(); iterstereo!=iterEnd; ++iterstereo){
@@ -302,7 +277,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
         SiStripRecHit2D const rechit=*iterstereo;
         //analyze RecHits
         rechitanalysis(rechit,topol,associate);
-
+        // fill the result in a histogram
         fillME(iStereoAndMatchedME->second.meWclusStereo,rechitpro.clusiz);
         fillME(iStereoAndMatchedME->second.meAdcStereo,rechitpro.cluchg);
         fillME(iStereoAndMatchedME->second.mePosxStereo,rechitpro.x);
@@ -320,17 +295,10 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
           fillME(iStereoAndMatchedME->second.meChi2Stereo,rechitpro.chi2);
         }
       }
-    }/* else {
-    for(auto iterstereo=detsetIter->begin(), iterEnd = detsetIter->end(); iterstereo!=iterEnd; ++iterstereo){
-      const GeomDetUnit *  det = tracker.idToDetUnit(detid);
-      const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
-      const StripTopology &topol=(StripTopology&)stripdet->topology();
-      SiStripRecHit2D const rechit=*iterstereo;
-      //analyze RecHits
-      rechitanalysis(rechit,topol,associate);
-    }*/
+    }
   }
 
+  // start loops over detectors with detected rechitmatched
   for (auto it = rechitsmatched->begin(), itEnd = rechitsmatched->end(); it != itEnd; ++it) {
     DetId detid = (*it).detId();
     uint32_t myid = detid.rawId();       
@@ -342,11 +310,6 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     std::pair<std::string,int32_t> det_lay_pair = fold_organ.GetSubDetAndLayer(myid,tTopo,true);
    
     totnumrechitmatched[det_lay_pair.first] = totnumrechitmatched[det_lay_pair.first] + detsetIter->size();
-
-   // totnumrechitrphi[det_lay_pair.first].push_back(0);
-   // totnumrechitstereo[det_lay_pair.first].push_back(0);
-   // totnumrechitmatched[det_lay_pair.first].push_back(detsetIter->size());
-
     //loop over rechits-matched in the same subdetector
     if(iStereoAndMatchedME != StereoAndMatchedMEsMap.end()){
       for(auto itermatched=detsetIter->begin(), iterEnd = detsetIter->end(); itermatched!=iterEnd; ++itermatched){
@@ -354,7 +317,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
         const GluedGeomDet* gluedDet = (const GluedGeomDet*)tracker.idToDet(rechit.geographicalId());
         //analyze RecHits 
         rechitanalysis_matched(rechit, gluedDet, associate);
-
+        // fill the result in a histogram
         fillME(iStereoAndMatchedME->second.mePosxMatched,rechitpro.x);
         fillME(iStereoAndMatchedME->second.mePosyMatched,rechitpro.y);
         fillME(iStereoAndMatchedME->second.meResolxMatched,sqrt(rechitpro.resolxx));
@@ -371,23 +334,12 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
           fillME(iStereoAndMatchedME->second.meChi2Matched,rechitpro.chi2);
         }
       }
-    }/* else {
-      for(auto itermatched=detsetIter->begin(), iterEnd = detsetIter->end(); itermatched!=iterEnd; ++itermatched){
-        SiStripMatchedRecHit2D const rechit=*itermatched;
-        const GluedGeomDet* gluedDet = (const GluedGeomDet*)tracker.idToDet(rechit.geographicalId());
-        //analyze RecHits 
-        rechitanalysis_matched(rechit, gluedDet, associate);
-        rechitmatched.push_back(rechitpro);
-      }
-    }*/
+    }
   }//End of loops over detectors
   
   //now fill the cumulative histograms of the hits
   for (std::vector<std::string>::iterator iSubdet  = SubDetList_.begin(); iSubdet != SubDetList_.end(); ++iSubdet){
     std::map<std::string, SubDetMEs>::iterator iSubDetME  = SubDetMEsMap.find((*iSubdet));
- //   fillME(iSubDetME->second.meNumrphi,std::accumulate(totnumrechitrphi[(*iSubdet)].rbegin(), totnumrechitrphi[(*iSubdet)].rend(), 0));
- //   fillME(iSubDetME->second.meNumStereo,std::accumulate(totnumrechitstereo[(*iSubdet)].rbegin(), totnumrechitstereo[(*iSubdet)].rend(), 0));
- //   fillME(iSubDetME->second.meNumMatched,std::accumulate(totnumrechitmatched[(*iSubdet)].rbegin(), totnumrechitmatched[(*iSubdet)].rend(), 0));
     fillME(iSubDetME->second.meNumrphi,totnumrechitrphi[(*iSubdet)]);
     fillME(iSubDetME->second.meNumStereo,totnumrechitstereo[(*iSubdet)]);
     fillME(iSubDetME->second.meNumMatched,totnumrechitmatched[(*iSubdet)]);
@@ -396,7 +348,6 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
   fillME(totalMEs.meNumTotrphi,totrechitrphi);
   fillME(totalMEs.meNumTotStereo,totrechitstereo);
   fillME(totalMEs.meNumTotMatched,totrechitmatched);
- 
 }
 
   

--- a/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
+++ b/Validation/TrackerRecHits/src/SiStripRecHitsValid.cc
@@ -221,6 +221,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     totrechitrphi += detsetIter->size();
     //loop over rechits-rphi in the same subdetector
     // SiStripRecHit2DCollection::DetSet::const_iterator iterrphi
+    rechitrphi.clear();
     for(auto iterrphi= detsetIter->begin(), iterEnd = detsetIter->end(); iterrphi != iterEnd; ++iterrphi){	
       const GeomDetUnit *  det = tracker.idToDetUnit(detid);
       const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
@@ -271,6 +272,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     auto detsetIter = rechitsstereo->find(detid);
     totrechitstereo += detsetIter->size();
     //loop over rechits-stereo in the same subdetector
+    rechitstereo.clear();
     for(auto iterstereo=detsetIter->begin(), iterEnd = detsetIter->end(); iterstereo!=iterEnd; ++iterstereo){
       const GeomDetUnit *  det = tracker.idToDetUnit(detid);
       const StripGeomDetUnit * stripdet=(const StripGeomDetUnit*)(det);
@@ -321,6 +323,7 @@ void SiStripRecHitsValid::analyze(const edm::Event& e, const edm::EventSetup& es
     auto detsetIter = rechitsmatched->find(detid);
     totrechitmatched += detsetIter->size();
     //loop over rechits-matched in the same subdetector
+    rechitmatched.clear();
     for(auto itermatched=detsetIter->begin(), iterEnd = detsetIter->end(); itermatched!=iterEnd; ++itermatched){
       SiStripMatchedRecHit2D const rechit=*itermatched;
       const GluedGeomDet* gluedDet = (const GluedGeomDet*)tracker.idToDet(rechit.geographicalId());


### PR DESCRIPTION
PR of a work intended to optimize gradually the performance of tracker validation code.
Here I tried to resolve the “FIXME: vector <DetId> is Suboptimal “.
Outputs are supposed to be unchanged.

The changes are:
-   Instead of one big loop over the DetIds, we have 3 loops over rechits-rphi, -stereo and -matched
  -    We do not need the vector for DetIds and we do not need to fill this vector
  -   The compute where we are in the vector is now unnecessary
-   The computing of rechitpro and the use with fillME is now in the same loops
  -   We do not need some vectors for the value transfers

Any comments and suggestions are welcome.
More optimizations will follow. 
