### PR TITLE
Thread safety SetDirectory(0) fixes

### DIFF
--- a/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
+++ b/Alignment/OfflineValidation/plugins/TrackerOfflineValidation.cc
@@ -27,6 +27,7 @@
 #include <iostream>
 
 // ROOT includes
+#include "TDirectory.h"
 #include "TH1.h"
 #include "TH2.h"
 #include "TProfile.h"
@@ -314,8 +315,11 @@ template <> TH1* TrackerOfflineValidation::DirectoryWrapper::make<TProfile>(cons
   if(dqmMode){
     theDbe->setCurrentFolder(directoryString);
     //DQM profile requires y-bins for construction... using TProfile creator by hand...
-    TProfile *tmpProfile=new TProfile(name,title,nBinX,xBins);
-    tmpProfile->SetDirectory(0);
+    TProfile *tmpProfile;
+    {
+      TDirectory::TContext context(nullptr);
+      tmpProfile=new TProfile(name,title,nBinX,xBins);
+    }
     return theDbe->bookProfile(name,tmpProfile)->getTH1();
   }
   else{return tfd->make<TProfile>(name,title,nBinX,xBins);}
@@ -325,8 +329,11 @@ template <> TH1* TrackerOfflineValidation::DirectoryWrapper::make<TProfile>(cons
   if(dqmMode){
     theDbe->setCurrentFolder(directoryString);
     //DQM profile requires y-bins for construction... using TProfile creator by hand...
-    TProfile *tmpProfile=new TProfile(name,title,nBinX,minBinX,maxBinX);
-    tmpProfile->SetDirectory(0);
+    TProfile *tmpProfile;
+    {
+      TDirectory::TContext context(nullptr);
+      tmpProfile = new TProfile(name,title,nBinX,minBinX,maxBinX);
+    }
     return theDbe->bookProfile(name,tmpProfile)->getTH1();
   }
   else{return tfd->make<TProfile>(name,title,nBinX,minBinX,maxBinX);}

--- a/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalCosmicsHists.cc
@@ -38,6 +38,8 @@
 
 
 #include <vector>
+
+#include "TDirectory.h"
 #include "TLine.h"
 
  
@@ -1424,77 +1426,36 @@ void EcalCosmicsHists::initHists(int FED)
   string name1 = "SeedEnergyFED";
   name1.append(intToString(FED));
   int numBins = 200;//(int)round(histRangeMax_-histRangeMin_)+1;
-  TH1F* hist = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndHists_[FED] = hist;
-  FEDsAndHists_[FED]->SetDirectory(0);
-  
-  TH1F* E2hist = new TH1F(Form("E2_FED_%d",FED),Form("E2_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndE2Hists_[FED] = E2hist;
-  FEDsAndE2Hists_[FED]->SetDirectory(0);
-  
-  TH1F* energyhist = new TH1F(Form("Energy_FED_%d",FED),Form("Energy_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndenergyHists_[FED] = energyhist;
-  FEDsAndenergyHists_[FED]->SetDirectory(0);
-  
-  TH2F* E2vsE1hist = new TH2F(Form("E2vsE1_FED_%d",FED),Form("E2vsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
-  FEDsAndE2vsE1Hists_[FED] = E2vsE1hist;
-  FEDsAndE2vsE1Hists_[FED]->SetDirectory(0);
-  
-  TH2F* energyvsE1hist = new TH2F(Form("EnergyvsE1_FED_%d",FED),Form("EnergyvsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
-  FEDsAndenergyvsE1Hists_[FED] = energyvsE1hist;
-  FEDsAndenergyvsE1Hists_[FED]->SetDirectory(0);
-  
-  title1 = "Time for ";
-  title1.append(fedMap_->getSliceFromFed(FED));
-  title1.append(";Relative Time (1 clock = 25ns);Events");
-  name1 = "TimeFED";
-  name1.append(intToString(FED));
-  TH1F* timingHist = new TH1F(name1.c_str(),title1.c_str(),78,-7,7);
-  FEDsAndTimingHists_[FED] = timingHist;
-  FEDsAndTimingHists_[FED]->SetDirectory(0);
-  
-  TH1F* freqHist = new TH1F(Form("Frequency_FED_%d",FED),Form("Frequency for FED %d;Event Number",FED),100,0.,100000);
-  FEDsAndFrequencyHists_[FED] = freqHist;
-  FEDsAndFrequencyHists_[FED]->SetDirectory(0);
-  
-  TH1F* iphiProfileHist = new TH1F(Form("iPhi_Profile_FED_%d",FED),Form("iPhi Profile for FED %d",FED),360,1.,361);
-  FEDsAndiPhiProfileHists_[FED] = iphiProfileHist;
-  FEDsAndiPhiProfileHists_[FED]->SetDirectory(0);
-  
-  TH1F* ietaProfileHist = new TH1F(Form("iEta_Profile_FED_%d",FED),Form("iEta Profile for FED %d",FED),172,-86,86);
-  FEDsAndiEtaProfileHists_[FED] = ietaProfileHist;
-  FEDsAndiEtaProfileHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsFreq = new TH2F(Form("timeVsFreqFED_%d",FED),Form("time Vs Freq FED %d",FED),78,-7,7,100,0.,100000);
-  FEDsAndTimingVsFreqHists_[FED] = timingHistVsFreq;
-  FEDsAndTimingVsFreqHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsAmp = new TH2F(Form("timeVsAmpFED_%d",FED),Form("time Vs Amp FED %d",FED),78,-7,7,numBins,histRangeMin_,histRangeMax_);
-  FEDsAndTimingVsAmpHists_[FED] = timingHistVsAmp;
-  FEDsAndTimingVsAmpHists_[FED]->SetDirectory(0);
-  
-  TH1F* numXtalInClusterHist = new TH1F(Form("NumXtalsInCluster_FED_%d",FED),Form("Num active Xtals In Cluster for FED %d;Num Active Xtals",FED),25,0,25);
-  FEDsAndNumXtalsInClusterHists_[FED] = numXtalInClusterHist;
-  FEDsAndNumXtalsInClusterHists_[FED]->SetDirectory(0);
-  
-  TH2F* OccupHist = new TH2F(Form("occupFED_%d",FED),Form("Occupancy FED %d;i#eta;i#phi",FED),85,1,86,20,1,21);
-  FEDsAndOccupancyHists_[FED] = OccupHist;
-  FEDsAndOccupancyHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsPhi = new TH2F(Form("timeVsPhiFED_%d",FED),Form("time Vs Phi FED %d;Relative Time (1 clock = 25ns);i#phi",FED),78,-7,7,20,1,21);
-  FEDsAndTimingVsPhiHists_[FED] = timingHistVsPhi;
-  FEDsAndTimingVsPhiHists_[FED]->SetDirectory(0);
-  
-  TH2F* timingHistVsModule = new TH2F(Form("timeVsModuleFED_%d",FED),Form("time Vs Module FED %d;Relative Time (1 clock = 25ns);i#eta",FED),78,-7,7,4,1,86);
-  FEDsAndTimingVsModuleHists_[FED] = timingHistVsModule;
-  FEDsAndTimingVsModuleHists_[FED]->SetDirectory(0);
 
-  TH2F* dccRuntypeVsBxFED = new TH2F(Form("DCCRuntypeVsBxFED_%d",FED),Form("DCC Runtype vs. BX FED %d",FED),3600,0,3600,24,0,24);
-  FEDsAndDCCRuntypeVsBxHists_[FED] = dccRuntypeVsBxFED;
-  FEDsAndDCCRuntypeVsBxHists_[FED]->SetDirectory(0); 
-  
+  {
+    TDirectory::TContext context(nullptr);
+
+    FEDsAndHists_[FED] = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
+    FEDsAndE2Hists_[FED] = new TH1F(Form("E2_FED_%d",FED),Form("E2_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
+    FEDsAndenergyHists_[FED] = new TH1F(Form("Energy_FED_%d",FED),Form("Energy_FED_%d",FED), numBins, histRangeMin_, histRangeMax_);
+    FEDsAndE2vsE1Hists_[FED] = new TH2F(Form("E2vsE1_FED_%d",FED),Form("E2vsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
+    FEDsAndenergyvsE1Hists_[FED] = new TH2F(Form("EnergyvsE1_FED_%d",FED),Form("EnergyvsE1_FED_%d",FED), numBins, histRangeMin_, histRangeMax_, numBins, histRangeMin_, histRangeMax_);
+
+    title1 = "Time for ";
+    title1.append(fedMap_->getSliceFromFed(FED));
+    title1.append(";Relative Time (1 clock = 25ns);Events");
+    name1 = "TimeFED";
+    name1.append(intToString(FED));
+    FEDsAndTimingHists_[FED] = new TH1F(name1.c_str(),title1.c_str(),78,-7,7);
+
+    FEDsAndFrequencyHists_[FED] = new TH1F(Form("Frequency_FED_%d",FED),Form("Frequency for FED %d;Event Number",FED),100,0.,100000);
+    FEDsAndiPhiProfileHists_[FED] = new TH1F(Form("iPhi_Profile_FED_%d",FED),Form("iPhi Profile for FED %d",FED),360,1.,361);
+    FEDsAndiEtaProfileHists_[FED] = new TH1F(Form("iEta_Profile_FED_%d",FED),Form("iEta Profile for FED %d",FED),172,-86,86);
+    FEDsAndTimingVsFreqHists_[FED] = new TH2F(Form("timeVsFreqFED_%d",FED),Form("time Vs Freq FED %d",FED),78,-7,7,100,0.,100000);
+    FEDsAndTimingVsAmpHists_[FED] = new TH2F(Form("timeVsAmpFED_%d",FED),Form("time Vs Amp FED %d",FED),78,-7,7,numBins,histRangeMin_,histRangeMax_);
+
+    FEDsAndNumXtalsInClusterHists_[FED] = new TH1F(Form("NumXtalsInCluster_FED_%d",FED),Form("Num active Xtals In Cluster for FED %d;Num Active Xtals",FED),25,0,25);
+    FEDsAndOccupancyHists_[FED] = new TH2F(Form("occupFED_%d",FED),Form("Occupancy FED %d;i#eta;i#phi",FED),85,1,86,20,1,21);
+    FEDsAndTimingVsPhiHists_[FED] = new TH2F(Form("timeVsPhiFED_%d",FED),Form("time Vs Phi FED %d;Relative Time (1 clock = 25ns);i#phi",FED),78,-7,7,20,1,21);
+    FEDsAndTimingVsModuleHists_[FED] = new TH2F(Form("timeVsModuleFED_%d",FED),Form("time Vs Module FED %d;Relative Time (1 clock = 25ns);i#eta",FED),78,-7,7,4,1,86);
+    FEDsAndDCCRuntypeVsBxHists_[FED] = new TH2F(Form("DCCRuntypeVsBxFED_%d",FED),Form("DCC Runtype vs. BX FED %d",FED),3600,0,3600,24,0,24);
+  }
 }
-
 // ------------ method called once each job just before starting event loop  ------------
 void 
 EcalCosmicsHists::beginRun(edm::Run const &, edm::EventSetup const & eventSetup)

--- a/CaloOnlineTools/EcalTools/plugins/EcalPedHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalPedHists.cc
@@ -297,12 +297,13 @@ void EcalPedHists::initHists(int FED)
     title3.append(chnl);
     string name3 = "Cry";
     name3.append(chnl+"Gain12");
-    histMap.insert(make_pair(name1,new TH1F(name1.c_str(),title1.c_str(),75,175.0,250.0)));
-    histMap[name1]->SetDirectory(0);
-    histMap.insert(make_pair(name2,new TH1F(name2.c_str(),title2.c_str(),75,175.0,250.0)));
-    histMap[name2]->SetDirectory(0);
-    histMap.insert(make_pair(name3,new TH1F(name3.c_str(),title3.c_str(),75,175.0,250.0)));
-    histMap[name3]->SetDirectory(0);
+    {
+      TDirectory::TContext context(nullptr);
+
+      histMap.insert(make_pair(name1,new TH1F(name1.c_str(),title1.c_str(),75,175.0,250.0)));
+      histMap.insert(make_pair(name2,new TH1F(name2.c_str(),title2.c_str(),75,175.0,250.0)));
+      histMap.insert(make_pair(name3,new TH1F(name3.c_str(),title3.c_str(),75,175.0,250.0)));
+    }
   }
   FEDsAndHistMaps_.insert(make_pair(FED,histMap));
 }

--- a/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.cc
+++ b/CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.cc
@@ -18,6 +18,8 @@
 
 #include "CaloOnlineTools/EcalTools/plugins/EcalURecHitHists.h"
 
+#include "TDirectory.h"
+
 using namespace cms;
 using namespace edm;
 using namespace std;
@@ -200,17 +202,18 @@ void EcalURecHitHists::initHists(int FED)
   string name1 = "URecHitsFED";
   name1.append(intToString(FED));
   int numBins = (int)round(histRangeMax_-histRangeMin_)+1;
-  TH1F* hist = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
-  FEDsAndHists_[FED] = hist;
-  FEDsAndHists_[FED]->SetDirectory(0);
+
+  {
+    TDirectory::TContext context(nullptr);
+
+    FEDsAndHists_[FED] = new TH1F(name1.c_str(),title1.c_str(), numBins, histRangeMin_, histRangeMax_);
   
-  title1 = "Jitter for ";
-  title1.append(fedMap_->getSliceFromFed(FED));
-  name1 = "JitterFED";
-  name1.append(intToString(FED));
-  TH1F* timingHist = new TH1F(name1.c_str(),title1.c_str(),14,-7,7);
-  FEDsAndTimingHists_[FED] = timingHist;
-  FEDsAndTimingHists_[FED]->SetDirectory(0);
+    title1 = "Jitter for ";
+    title1.append(fedMap_->getSliceFromFed(FED));
+    name1 = "JitterFED";
+    name1.append(intToString(FED));
+    FEDsAndTimingHists_[FED]  = new TH1F(name1.c_str(),title1.c_str(),14,-7,7);
+  }
 }
 
 // ------------ method called once each job just before starting event loop  ------------

--- a/DPGAnalysis/SiStripTools/src/CommonAnalyzer.cc
+++ b/DPGAnalysis/SiStripTools/src/CommonAnalyzer.cc
@@ -129,9 +129,10 @@ TH1F* CommonAnalyzer::getBinomialRatio(const CommonAnalyzer& denom, const char* 
       denreb = (TH1F*)den->Rebin(rebin,"denrebinned");
       numreb = (TH1F*)num->Rebin(rebin,"numrebinned");
     }
-    
-    ratio = new TH1F(*numreb);
-    ratio->SetDirectory(0);
+    {
+      TDirectory::TContext context(nullptr);
+      ratio = new TH1F(*numreb);
+    }
     ratio->Reset();
     ratio->Sumw2();
     ratio->Divide(numreb,denreb,1,1,"B");

--- a/DQM/Physics/src/QcdLowPtDQM.cc
+++ b/DQM/Physics/src/QcdLowPtDQM.cc
@@ -26,6 +26,7 @@
 #include <TH1F.h>
 #include <TH2F.h>
 #include <TH3F.h>
+#include "TDirectory.h"
 
 using namespace std;
 using namespace edm;
@@ -1216,11 +1217,12 @@ void QcdLowPtDQM::yieldAlphaHistogram(int which) {
     double VzBins[nVzBin + 1];
     for (int i = 0; i <= nVzBin; i++)
       VzBins[i] = (double)i * 20.0 / (double)nVzBin - 10.0;
-
-    AlphaTracklets12_ = new TH3F(
+    {
+      TDirectory::TContext context(nullptr);
+      AlphaTracklets12_ = new TH3F(
         "hAlphaTracklets12", "Alpha for tracklets12;#eta;#hits;vz [cm]",
         nEtaBin, EtaBins, nHitBin, HitBins, nVzBin, VzBins);
-    AlphaTracklets12_->SetDirectory(0);
+    }
 
     AlphaTracklets12_->SetBinContent(2, 1, 7, 3.55991);
     AlphaTracklets12_->SetBinContent(2, 1, 8, 2.40439);
@@ -2471,10 +2473,12 @@ void QcdLowPtDQM::yieldAlphaHistogram(int which) {
     for (int i = 0; i <= nVzBin; i++)
       VzBins[i] = (double)i * 20.0 / (double)nVzBin - 10.0;
 
-    AlphaTracklets13_ = new TH3F(
+    {
+      TDirectory::TContext context(nullptr);
+      AlphaTracklets13_ = new TH3F(
         "hAlphaTracklets13", "Alpha for tracklets13;#eta;#hits;vz [cm]",
         nEtaBin, EtaBins, nHitBin, HitBins, nVzBin, VzBins);
-    AlphaTracklets13_->SetDirectory(0);
+    }
 
     AlphaTracklets13_->SetBinContent(3, 1, 5, 3.29862);
     AlphaTracklets13_->SetBinContent(3, 1, 6, 2.40246);
@@ -3501,10 +3505,12 @@ void QcdLowPtDQM::yieldAlphaHistogram(int which) {
     for (int i = 0; i <= nVzBin; i++)
       VzBins[i] = (double)i * 20.0 / (double)nVzBin - 10.0;
 
-    AlphaTracklets23_ = new TH3F(
+    {
+      TDirectory::TContext context(nullptr);
+      AlphaTracklets23_ = new TH3F(
         "hAlphaTracklets23", "Alpha for tracklets23;#eta;#hits;vz [cm]",
         nEtaBin, EtaBins, nHitBin, HitBins, nVzBin, VzBins);
-    AlphaTracklets23_->SetDirectory(0);
+    }
 
     AlphaTracklets23_->SetBinContent(3, 1, 5, 3.38308);
     AlphaTracklets23_->SetBinContent(3, 1, 6, 2.34772);

--- a/DQMServices/Core/interface/DQMStore.h
+++ b/DQMServices/Core/interface/DQMStore.h
@@ -647,20 +647,20 @@ class DQMStore
   template <class HISTO, class COLLATE>
   MonitorElement *              book(const std::string &dir, const std::string &name,
                                      const char *context, int kind,
-                                     HISTO *h, COLLATE collate);
+                                     HISTO *h, COLLATE collate, bool setDirNull);
 
   MonitorElement *              bookInt(const std::string &dir, const std::string &name);
   MonitorElement *              bookFloat(const std::string &dir, const std::string &name);
   MonitorElement *              bookString(const std::string &dir, const std::string &name, const std::string &value);
-  MonitorElement *              book1D(const std::string &dir, const std::string &name, TH1F *h);
-  MonitorElement *              book1S(const std::string &dir, const std::string &name, TH1S *h);
-  MonitorElement *              book1DD(const std::string &dir, const std::string &name, TH1D *h);
-  MonitorElement *              book2D(const std::string &dir, const std::string &name, TH2F *h);
-  MonitorElement *              book2S(const std::string &dir, const std::string &name, TH2S *h);
-  MonitorElement *              book2DD(const std::string &dir, const std::string &name, TH2D *h);
-  MonitorElement *              book3D(const std::string &dir, const std::string &name, TH3F *h);
-  MonitorElement *              bookProfile(const std::string &dir, const std::string &name, TProfile *h);
-  MonitorElement *              bookProfile2D(const std::string &folder, const std::string &name, TProfile2D *h);
+  MonitorElement *              book1D(const std::string &dir, const std::string &name, TH1F *h, bool setDirNull);
+  MonitorElement *              book1S(const std::string &dir, const std::string &name, TH1S *h, bool setDirNull);
+  MonitorElement *              book1DD(const std::string &dir, const std::string &name, TH1D *h, bool setDirNull);
+  MonitorElement *              book2D(const std::string &dir, const std::string &name, TH2F *h, bool setDirNull);
+  MonitorElement *              book2S(const std::string &dir, const std::string &name, TH2S *h, bool setDirNull);
+  MonitorElement *              book2DD(const std::string &dir, const std::string &name, TH2D *h, bool setDirNull);
+  MonitorElement *              book3D(const std::string &dir, const std::string &name, TH3F *h, bool setDirNull);
+  MonitorElement *              bookProfile(const std::string &dir, const std::string &name, TProfile *h, bool setDirNull);
+  MonitorElement *              bookProfile2D(const std::string &folder, const std::string &name, TProfile2D *h, bool setDirNull);
 
   static bool                   checkBinningMatches(MonitorElement *me, TH1 *h, unsigned verbose);
 

--- a/DQMServices/Core/src/DQMStore.cc
+++ b/DQMServices/Core/src/DQMStore.cc
@@ -791,7 +791,7 @@ template <class HISTO, class COLLATE>
 MonitorElement *
 DQMStore::book(const std::string &dir, const std::string &name,
                const char *context, int kind,
-               HISTO *h, COLLATE collate)
+               HISTO *h, COLLATE collate, bool setDirNull)
 {
   assert(name.find('/') == std::string::npos);
   if (verbose_ > 3)
@@ -799,8 +799,10 @@ DQMStore::book(const std::string &dir, const std::string &name,
   std::string path;
   mergePath(path, dir, name);
 
-  // Put us in charge of h.
-  h->SetDirectory(0);
+  if(setDirNull) {
+    // Put us in charge of h.
+    h->SetDirectory(0);
+  }
 
   // Check if the request monitor element already exists.
   MonitorElement *me = findObject(dir, name, run_, 0, streamId_, moduleId_);
@@ -982,23 +984,23 @@ DQMStore::bookString(const std::string &name, const std::string &value)
 // -------------------------------------------------------------------
 /// Book 1D histogram based on TH1F.
 MonitorElement *
-DQMStore::book1D(const std::string &dir, const std::string &name, TH1F *h)
+DQMStore::book1D(const std::string &dir, const std::string &name, TH1F *h, bool setDirNull)
 {
-  return book(dir, name, "book1D", MonitorElement::DQM_KIND_TH1F, h, collate1D);
+  return book(dir, name, "book1D", MonitorElement::DQM_KIND_TH1F, h, collate1D, setDirNull);
 }
 
 /// Book 1D histogram based on TH1S.
 MonitorElement *
-DQMStore::book1S(const std::string &dir, const std::string &name, TH1S *h)
+DQMStore::book1S(const std::string &dir, const std::string &name, TH1S *h, bool setDirNull)
 {
-  return book(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S);
+  return book(dir, name, "book1S", MonitorElement::DQM_KIND_TH1S, h, collate1S, setDirNull);
 }
 
 /// Book 1D histogram based on TH1D.
 MonitorElement *
-DQMStore::book1DD(const std::string &dir, const std::string &name, TH1D *h)
+DQMStore::book1DD(const std::string &dir, const std::string &name, TH1D *h, bool setDirNull)
 {
-  return book(dir, name, "book1DD", MonitorElement::DQM_KIND_TH1D, h, collate1DD);
+  return book(dir, name, "book1DD", MonitorElement::DQM_KIND_TH1D, h, collate1DD, setDirNull);
 }
 
 /// Book 1D histogram.
@@ -1006,7 +1008,12 @@ MonitorElement *
 DQMStore::book1D(const char *name, const char *title,
                  int nchX, double lowX, double highX)
 {
-  return book1D(pwd_, name, new TH1F(name, title, nchX, lowX, highX));
+  TH1F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1F(name, title, nchX, lowX, highX);
+  }
+  return book1D(pwd_, name, h, false);
 }
 
 /// Book 1D histogram.
@@ -1014,7 +1021,12 @@ MonitorElement *
 DQMStore::book1D(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX)
 {
-  return book1D(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, lowX, highX));
+  TH1F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1F(name.c_str(), title.c_str(), nchX, lowX, highX);
+  }
+  return book1D(pwd_, name, h, false);
 }
 
 /// Book 1S histogram.
@@ -1022,7 +1034,12 @@ MonitorElement *
 DQMStore::book1S(const char *name, const char *title,
                  int nchX, double lowX, double highX)
 {
-  return book1S(pwd_, name, new TH1S(name, title, nchX, lowX, highX));
+  TH1S* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1S(name, title, nchX, lowX, highX);
+  }
+  return book1S(pwd_, name, h, false);
 }
 
 /// Book 1S histogram.
@@ -1030,7 +1047,12 @@ MonitorElement *
 DQMStore::book1S(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX)
 {
-  return book1S(pwd_, name, new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX));
+  TH1S* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1S(name.c_str(), title.c_str(), nchX, lowX, highX);
+  }
+  return book1S(pwd_, name, h, false);
 }
 
 /// Book 1S histogram.
@@ -1038,7 +1060,12 @@ MonitorElement *
 DQMStore::book1DD(const char *name, const char *title,
                   int nchX, double lowX, double highX)
 {
-  return book1DD(pwd_, name, new TH1D(name, title, nchX, lowX, highX));
+  TH1D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1D(name, title, nchX, lowX, highX);
+  }
+  return book1DD(pwd_, name, h, false);
 }
 
 /// Book 1S histogram.
@@ -1046,7 +1073,12 @@ MonitorElement *
 DQMStore::book1DD(const std::string &name, const std::string &title,
                   int nchX, double lowX, double highX)
 {
-  return book1DD(pwd_, name, new TH1D(name.c_str(), title.c_str(), nchX, lowX, highX));
+  TH1D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1D(name.c_str(), title.c_str(), nchX, lowX, highX);
+  }
+  return book1DD(pwd_, name, h, false);
 }
 
 /// Book 1D variable bin histogram.
@@ -1054,7 +1086,12 @@ MonitorElement *
 DQMStore::book1D(const char *name, const char *title,
                  int nchX, const float *xbinsize)
 {
-  return book1D(pwd_, name, new TH1F(name, title, nchX, xbinsize));
+  TH1F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1F(name, title, nchX, xbinsize);
+  }
+  return book1D(pwd_, name, h, false);
 }
 
 /// Book 1D variable bin histogram.
@@ -1062,71 +1099,76 @@ MonitorElement *
 DQMStore::book1D(const std::string &name, const std::string &title,
                  int nchX, const float *xbinsize)
 {
-  return book1D(pwd_, name, new TH1F(name.c_str(), title.c_str(), nchX, xbinsize));
+  TH1F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH1F(name.c_str(), title.c_str(), nchX, xbinsize);
+  }
+  return book1D(pwd_, name, h, false);
 }
 
 /// Book 1D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1D(const char *name, TH1F *source)
 {
-  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name)));
+  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name)), true);
 }
 
 /// Book 1D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1D(const std::string &name, TH1F *source)
 {
-  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name.c_str())));
+  return book1D(pwd_, name, static_cast<TH1F *>(source->Clone(name.c_str())), true);
 }
 
 /// Book 1S histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1S(const char *name, TH1S *source)
 {
-  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name)));
+  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name)), true);
 }
 
 /// Book 1S histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1S(const std::string &name, TH1S *source)
 {
-  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name.c_str())));
+  return book1S(pwd_, name, static_cast<TH1S *>(source->Clone(name.c_str())), true);
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1DD(const char *name, TH1D *source)
 {
-  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name)));
+  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name)), true);
 }
 
 /// Book 1D double histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book1DD(const std::string &name, TH1D *source)
 {
-  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name.c_str())));
+  return book1DD(pwd_, name, static_cast<TH1D *>(source->Clone(name.c_str())), true);
 }
 
 // -------------------------------------------------------------------
 /// Book 2D histogram based on TH2F.
 MonitorElement *
-DQMStore::book2D(const std::string &dir, const std::string &name, TH2F *h)
+DQMStore::book2D(const std::string &dir, const std::string &name, TH2F *h, bool setDirNull)
 {
-  return book(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D);
+  return book(dir, name, "book2D", MonitorElement::DQM_KIND_TH2F, h, collate2D, setDirNull);
 }
 
 /// Book 2D histogram based on TH2S.
 MonitorElement *
-DQMStore::book2S(const std::string &dir, const std::string &name, TH2S *h)
+DQMStore::book2S(const std::string &dir, const std::string &name, TH2S *h, bool setDirNull)
 {
-  return book(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S);
+  return book(dir, name, "book2S", MonitorElement::DQM_KIND_TH2S, h, collate2S, setDirNull);
 }
 
 /// Book 2D histogram based on TH2D.
 MonitorElement *
-DQMStore::book2DD(const std::string &dir, const std::string &name, TH2D *h)
+DQMStore::book2DD(const std::string &dir, const std::string &name, TH2D *h, bool setDirNull)
 {
-  return book(dir, name, "book2DD", MonitorElement::DQM_KIND_TH2D, h, collate2DD);
+  return book(dir, name, "book2DD", MonitorElement::DQM_KIND_TH2D, h, collate2DD, setDirNull);
 }
 
 /// Book 2D histogram.
@@ -1135,9 +1177,14 @@ DQMStore::book2D(const char *name, const char *title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2D(pwd_, name, new TH2F(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2F(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2D(pwd_, name, h, false);
 }
 
 /// Book 2D histogram.
@@ -1146,9 +1193,14 @@ DQMStore::book2D(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2D(pwd_, name, new TH2F(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2F(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2D(pwd_, name, h, false);
 }
 
 /// Book 2S histogram.
@@ -1157,9 +1209,14 @@ DQMStore::book2S(const char *name, const char *title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2S(pwd_, name, new TH2S(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2S* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2S(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2S(pwd_, name, h, false);
 }
 
 /// Book 2S histogram.
@@ -1168,9 +1225,14 @@ DQMStore::book2S(const std::string &name, const std::string &title,
                  int nchX, double lowX, double highX,
                  int nchY, double lowY, double highY)
 {
-  return book2S(pwd_, name, new TH2S(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY));
+  TH2S* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2S(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2S(pwd_, name, h, false);
 }
 
 /// Book 2D double histogram.
@@ -1179,9 +1241,14 @@ DQMStore::book2DD(const char *name, const char *title,
                   int nchX, double lowX, double highX,
                   int nchY, double lowY, double highY)
 {
-  return book2DD(pwd_, name, new TH2D(name, title,
-                                      nchX, lowX, highX,
-                                      nchY, lowY, highY));
+  TH2D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2D(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2DD(pwd_, name, h, false);
 }
 
 /// Book 2S histogram.
@@ -1190,9 +1257,14 @@ DQMStore::book2DD(const std::string &name, const std::string &title,
                   int nchX, double lowX, double highX,
                   int nchY, double lowY, double highY)
 {
-  return book2DD(pwd_, name, new TH2D(name.c_str(), title.c_str(),
-                                      nchX, lowX, highX,
-                                      nchY, lowY, highY));
+  TH2D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2D(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY);
+  }
+  return book2DD(pwd_, name, h, false);
 }
 
 /// Book 2D variable bin histogram.
@@ -1200,8 +1272,13 @@ MonitorElement *
 DQMStore::book2D(const char *name, const char *title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2D(pwd_, name, new TH2F(name, title,
-                                     nchX, xbinsize, nchY, ybinsize));
+  TH2F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2F(name, title,
+                 nchX, xbinsize, nchY, ybinsize);
+  }
+  return book2D(pwd_, name, h, false);
 }
 
 /// Book 2D variable bin histogram.
@@ -1209,58 +1286,63 @@ MonitorElement *
 DQMStore::book2D(const std::string &name, const std::string &title,
                  int nchX, const float *xbinsize, int nchY, const float *ybinsize)
 {
-  return book2D(pwd_, name, new TH2F(name.c_str(), title.c_str(),
-                                     nchX, xbinsize, nchY, ybinsize));
+  TH2F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH2F(name.c_str(), title.c_str(),
+                 nchX, xbinsize, nchY, ybinsize);
+  }
+  return book2D(pwd_, name, h, false);
 }
 
 /// Book 2D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2D(const char *name, TH2F *source)
 {
-  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name)));
+  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name)), true);
 }
 
 /// Book 2D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2D(const std::string &name, TH2F *source)
 {
-  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name.c_str())));
+  return book2D(pwd_, name, static_cast<TH2F *>(source->Clone(name.c_str())), true);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2S(const char *name, TH2S *source)
 {
-  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name)));
+  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name)), true);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2S(const std::string &name, TH2S *source)
 {
-  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name.c_str())));
+  return book2S(pwd_, name, static_cast<TH2S *>(source->Clone(name.c_str())), true);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2DD(const char *name, TH2D *source)
 {
-  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name)));
+  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name)), true);
 }
 
 /// Book 2DS histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book2DD(const std::string &name, TH2D *source)
 {
-  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name.c_str())));
+  return book2DD(pwd_, name, static_cast<TH2D *>(source->Clone(name.c_str())), true);
 }
 
 // -------------------------------------------------------------------
 /// Book 3D histogram based on TH3F.
 MonitorElement *
-DQMStore::book3D(const std::string &dir, const std::string &name, TH3F *h)
+DQMStore::book3D(const std::string &dir, const std::string &name, TH3F *h, bool setDirNull)
 {
-  return book(dir, name, "book3D", MonitorElement::DQM_KIND_TH3F, h, collate3D);
+  return book(dir, name, "book3D", MonitorElement::DQM_KIND_TH3F, h, collate3D, setDirNull);
 }
 
 /// Book 3D histogram.
@@ -1270,10 +1352,15 @@ DQMStore::book3D(const char *name, const char *title,
                  int nchY, double lowY, double highY,
                  int nchZ, double lowZ, double highZ)
 {
-  return book3D(pwd_, name, new TH3F(name, title,
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY,
-                                     nchZ, lowZ, highZ));
+  TH3F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH3F(name, title,
+                 nchX, lowX, highX,
+                 nchY, lowY, highY,
+                 nchZ, lowZ, highZ);
+  }
+  return book3D(pwd_, name, h, false);
 }
 
 /// Book 3D histogram.
@@ -1283,34 +1370,39 @@ DQMStore::book3D(const std::string &name, const std::string &title,
                  int nchY, double lowY, double highY,
                  int nchZ, double lowZ, double highZ)
 {
-  return book3D(pwd_, name, new TH3F(name.c_str(), title.c_str(),
-                                     nchX, lowX, highX,
-                                     nchY, lowY, highY,
-                                     nchZ, lowZ, highZ));
+  TH3F* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TH3F(name.c_str(), title.c_str(),
+                 nchX, lowX, highX,
+                 nchY, lowY, highY,
+                 nchZ, lowZ, highZ);
+  }
+  return book3D(pwd_, name, h, false);
 }
 
 /// Book 3D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book3D(const char *name, TH3F *source)
 {
-  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name)));
+  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name)), true);
 }
 
 /// Book 3D histogram by cloning an existing histogram.
 MonitorElement *
 DQMStore::book3D(const std::string &name, TH3F *source)
 {
-  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name.c_str())));
+  return book3D(pwd_, name, static_cast<TH3F *>(source->Clone(name.c_str())), true);
 }
 
 // -------------------------------------------------------------------
 /// Book profile histogram based on TProfile.
 MonitorElement *
-DQMStore::bookProfile(const std::string &dir, const std::string &name, TProfile *h)
+DQMStore::bookProfile(const std::string &dir, const std::string &name, TProfile *h, bool setDirNull)
 {
   return book(dir, name, "bookProfile",
               MonitorElement::DQM_KIND_TPROFILE,
-              h, collateProfile);
+              h, collateProfile, setDirNull);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1322,10 +1414,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name, title,
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1337,10 +1434,15 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1352,10 +1454,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name, title,
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1367,10 +1474,15 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, lowX, highX,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, lowX, highX,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1382,10 +1494,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name, title,
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1397,10 +1514,15 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       int /* nchY */, double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1412,10 +1534,15 @@ DQMStore::bookProfile(const char *name, const char *title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name, title,
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name, title,
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book variable bin profile.  Option is one of: " ", "s" (default), "i", "G" (see
@@ -1427,34 +1554,39 @@ DQMStore::bookProfile(const std::string &name, const std::string &title,
                       double lowY, double highY,
                       const char *option /* = "s" */)
 {
-  return bookProfile(pwd_, name, new TProfile(name.c_str(), title.c_str(),
-                                              nchX, xbinsize,
-                                              lowY, highY,
-                                              option));
+  TProfile* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile(name.c_str(), title.c_str(),
+                     nchX, xbinsize,
+                     lowY, highY,
+                     option);
+  }
+  return bookProfile(pwd_, name, h, false);
 }
 
 /// Book TProfile by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile(const char *name, TProfile *source)
 {
-  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name)));
+  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name)), true);
 }
 
 /// Book TProfile by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile(const std::string &name, TProfile *source)
 {
-  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name.c_str())));
+  return bookProfile(pwd_, name, static_cast<TProfile *>(source->Clone(name.c_str())), true);
 }
 
 // -------------------------------------------------------------------
 /// Book 2D profile histogram based on TProfile2D.
 MonitorElement *
-DQMStore::bookProfile2D(const std::string &dir, const std::string &name, TProfile2D *h)
+DQMStore::bookProfile2D(const std::string &dir, const std::string &name, TProfile2D *h, bool setDirNull)
 {
   return book(dir, name, "bookProfile2D",
               MonitorElement::DQM_KIND_TPROFILE2D,
-              h, collateProfile2D);
+              h, collateProfile2D, setDirNull);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1467,11 +1599,16 @@ DQMStore::bookProfile2D(const char *name, const char *title,
                         int /* nchZ */, double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name, title,
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile2D(name, title,
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2D(pwd_, name, h, false);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1484,11 +1621,16 @@ DQMStore::bookProfile2D(const std::string &name, const std::string &title,
                         int /* nchZ */, double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile2D(name.c_str(), title.c_str(),
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2D(pwd_, name, h, false);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1501,11 +1643,16 @@ DQMStore::bookProfile2D(const char *name, const char *title,
                         double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name, title,
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile2D(name, title,
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2D(pwd_, name, h, false);
 }
 
 /// Book 2-D profile.  Option is one of: " ", "s" (default), "i", "G"
@@ -1518,25 +1665,30 @@ DQMStore::bookProfile2D(const std::string &name, const std::string &title,
                         double lowZ, double highZ,
                         const char *option /* = "s" */)
 {
-  return bookProfile2D(pwd_, name, new TProfile2D(name.c_str(), title.c_str(),
-                                                  nchX, lowX, highX,
-                                                  nchY, lowY, highY,
-                                                  lowZ, highZ,
-                                                  option));
+  TProfile2D* h;
+  {
+    TDirectory::TContext context(nullptr);
+    h = new TProfile2D(name.c_str(), title.c_str(),
+                       nchX, lowX, highX,
+                       nchY, lowY, highY,
+                       lowZ, highZ,
+                       option);
+  }
+  return bookProfile2D(pwd_, name, h, false);
 }
 
 /// Book TProfile2D by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile2D(const char *name, TProfile2D *source)
 {
-  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name)));
+  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name)), true);
 }
 
 /// Book TProfile2D by cloning an existing profile.
 MonitorElement *
 DQMStore::bookProfile2D(const std::string &name, TProfile2D *source)
 {
-  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name.c_str())));
+  return bookProfile2D(pwd_, name, static_cast<TProfile2D *>(source->Clone(name.c_str())), true);
 }
 
 //////////////////////////////////////////////////////////////////////
@@ -2137,7 +2289,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = bookProfile(dir, h->GetName(), (TProfile *) h->Clone());
+      me = bookProfile(dir, h->GetName(), (TProfile *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2148,7 +2300,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = bookProfile2D(dir, h->GetName(), (TProfile2D *) h->Clone());
+      me = bookProfile2D(dir, h->GetName(), (TProfile2D *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2159,7 +2311,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book1D(dir, h->GetName(), (TH1F *) h->Clone());
+      me = book1D(dir, h->GetName(), (TH1F *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2170,7 +2322,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book1S(dir, h->GetName(), (TH1S *) h->Clone());
+      me = book1S(dir, h->GetName(), (TH1S *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2181,7 +2333,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book1DD(dir, h->GetName(), (TH1D *) h->Clone());
+      me = book1DD(dir, h->GetName(), (TH1D *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2192,7 +2344,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book2D(dir, h->GetName(), (TH2F *) h->Clone());
+      me = book2D(dir, h->GetName(), (TH2F *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2203,7 +2355,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book2S(dir, h->GetName(), (TH2S *) h->Clone());
+      me = book2S(dir, h->GetName(), (TH2S *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2214,7 +2366,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book2DD(dir, h->GetName(), (TH2D *) h->Clone());
+      me = book2DD(dir, h->GetName(), (TH2D *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)
@@ -2225,7 +2377,7 @@ DQMStore::extract(TObject *obj, const std::string &dir,
   {
     MonitorElement *me = findObject(dir, h->GetName());
     if (! me)
-      me = book3D(dir, h->GetName(), (TH3F *) h->Clone());
+      me = book3D(dir, h->GetName(), (TH3F *) h->Clone(), true);
     else if (overwrite)
       me->copyFrom(h);
     else if (isCollateME(me) || collateHistograms)

--- a/EventFilter/EcalRawToDigi/test/stubs/EcalMatacqHist2.cc
+++ b/EventFilter/EcalRawToDigi/test/stubs/EcalMatacqHist2.cc
@@ -1,5 +1,6 @@
 #include "EcalMatacqHist2.h"
 
+#include "TDirectory.h"
 #include "TH1D.h"
 #include "TProfile.h"
 #include <sstream>
@@ -107,13 +108,15 @@ EcalMatacqHist2:: analyze( const edm::Event & e, const  edm::EventSetup& c){
 		<< " profile";
       std::stringstream profileName;
       profileName << "matacq" << digis.chId();
-      profiles.push_back(TProfile(profileName.str().c_str(),
-				  profTitle.str().c_str(),
-				  digis.size(),
-				  -.5,
-				  -.5+digis.size(),
-				  "I"));
-      profiles.back().SetDirectory(0);//mem. management done by std::vector
+      {
+        TDirectory::TContext context(nullptr);//mem. management done by std::vector
+        profiles.emplace_back(profileName.str().c_str(),
+                              profTitle.str().c_str(),
+                              digis.size(),
+                              -.5,
+                              -.5+digis.size(),
+                              "I");
+      }
       profChId.push_back(digis.chId());
     }
     

--- a/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
+++ b/EventFilter/EcalTBRawToDigi/test/stubs/EcalMatacqHist.cc
@@ -1,5 +1,6 @@
 #include "EcalMatacqHist.h"
 
+#include "TDirectory.h"
 #include "TProfile.h"
 #include <sstream>
 #include <iostream>
@@ -91,13 +92,15 @@ EcalMatacqHist:: analyze( const edm::Event & e, const  edm::EventSetup& c){
 		<< " profile";
       std::stringstream profileName;
       profileName << "matacq" << digis.chId();
-      profiles.push_back(TProfile(profileName.str().c_str(),
-				  profTitle.str().c_str(),
-				  digis.size(),
-				  -.5,
-				  -.5+digis.size(),
-				  "I"));
-      profiles.back().SetDirectory(0);//mem. management done by std::vector
+      {
+        TDirectory::TContext context(nullptr);//mem. management done by std::vector
+        profiles.emplace_back(profileName.str().c_str(),
+                              profTitle.str().c_str(),
+                              digis.size(),
+                              -.5,
+                              -.5+digis.size(),
+                              "I");
+      }
       profChId.push_back(digis.chId());
     }
     

--- a/Fireworks/Core/src/FWMagField.cc
+++ b/Fireworks/Core/src/FWMagField.cc
@@ -1,5 +1,6 @@
 #include <iostream>
 
+#include "TDirectory.h"
 #include "TH1F.h"
 #include "Fireworks/Core/interface/FWMagField.h"
 #include "Fireworks/Core/interface/fwLog.h"
@@ -24,9 +25,11 @@ FWMagField::FWMagField() :
    m_updateFieldEstimate(true),
    m_guessedField(0)
 {
-   m_guessValHist = new TH1F("FieldEstimations", "Field estimations from tracks and muons",
-                             200, -4.5, 4.5);
-   m_guessValHist->SetDirectory(0);
+   {
+      TDirectory::TContext context(nullptr);
+      m_guessValHist = new TH1F("FieldEstimations", "Field estimations from tracks and muons",
+                                200, -4.5, 4.5);
+   }
 }
 
 FWMagField::~FWMagField()

--- a/Fireworks/Tracks/plugins/FWTrackResidualDetailView.cc
+++ b/Fireworks/Tracks/plugins/FWTrackResidualDetailView.cc
@@ -1,4 +1,5 @@
 
+#include "TDirectory.h"
 #include "TVector3.h"
 #include "TH2.h"
 #include "TLine.h"
@@ -116,7 +117,11 @@ FWTrackResidualDetailView::build (const FWModelId &id, const reco::Track* track)
    // draw histogram
    m_viewCanvas->cd();
    m_viewCanvas->SetHighLightColor(-1);
-   TH2F* h_res = new TH2F("h_resx","h_resx",10,-5.5,5.5,m_ndet,0,m_ndet);
+   TH2F* h_res;
+   {
+      TDirectory::TContext context(nullptr);
+      h_res = new TH2F("h_resx","h_resx",10,-5.5,5.5,m_ndet,0,m_ndet);
+   }
    TPad* padX = new TPad("pad1","pad1", 0.2, 0., 0.8, 0.99);
    padX->SetBorderMode(0);
    padX->SetLeftMargin(0.2);
@@ -124,7 +129,6 @@ FWTrackResidualDetailView::build (const FWModelId &id, const reco::Track* track)
    padX->cd();
    padX->SetFrameLineWidth(0);
    padX->Modified();
-   h_res->SetDirectory(0);
    h_res->SetStats(kFALSE);
    h_res->SetTitle("");
    h_res->SetXTitle("residual");

--- a/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
+++ b/IORawData/CaloPatterns/src/HtrXmlPatternTool.cc
@@ -2,6 +2,7 @@
 #include "HtrXmlPatternToolParameters.h"
 #include "HtrXmlPatternSet.h"
 #include "HtrXmlPatternWriter.h"
+#include "TDirectory.h"
 #include "TFile.h"
 #include "TH1.h"
 #include <iostream>
@@ -216,18 +217,21 @@ void HtrXmlPatternTool::createHists() {
 	for (int chan=1; chan<=24; chan++) {
 	  ChannelPattern* cp=hd->getPattern(chan);
 	  char hname[128];
-	  sprintf(hname,"Exact fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* hp=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(0);
-	  sprintf(hname,"Quantized fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* hq=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  hp->SetDirectory(0);
-	  sprintf(hname,"Encoded fC Cr%d,%d%s-%d",crate,slot,
-		  ((tb==1)?("t"):("b")),chan);
-	  TH1* ha=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
-	  ha->SetDirectory(0);
+          TH1* hp;
+          TH1* hq;
+          TH1* ha;
+          {
+            TDirectory::TContext context(nullptr);
+            sprintf(hname,"Exact fC Cr%d,%d%s-%d",crate,slot,
+                    ((tb==1)?("t"):("b")),chan);
+            hp=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
+            sprintf(hname,"Quantized fC Cr%d,%d%s-%d",crate,slot,
+                    ((tb==1)?("t"):("b")),chan);
+            hq=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
+            sprintf(hname,"Encoded fC Cr%d,%d%s-%d",crate,slot,
+                    ((tb==1)?("t"):("b")),chan);
+            ha=new TH1F(hname,hname,ChannelPattern::SAMPLES,-0.5,ChannelPattern::SAMPLES-0.5);
+          }
 	  for (int i=0; i<ChannelPattern::SAMPLES; i++) {
 	    hp->Fill(i*1.0,(*cp)[i]);
 	    hq->Fill(i*1.0,cp->getQuantized(i));

--- a/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
+++ b/PhysicsTools/TagAndProbe/src/TagProbeFitter.cc
@@ -2,6 +2,7 @@
 #include <stdexcept>
 //#include "TagProbeFitter.h"
 
+#include "TDirectory.h"
 #include "TROOT.h"
 #include "TFile.h"
 #include "TPad.h"
@@ -781,7 +782,11 @@ void TagProbeFitter::makeEfficiencyPlot1D(RooDataSet& eff, RooRealVar& v, const 
     p->SetPointError(j, -vi.getAsymErrorLo(), vi.getAsymErrorHi(), -ei.getAsymErrorLo(), ei.getAsymErrorHi() );
   }
   TCanvas canvas(plotName);
-  TH1F *frame = new TH1F("frame", "Efficiency of "+effName, 1, v.getMin(), v.getMax()); frame->SetDirectory(0);
+  TH1F *frame;
+  {
+    TDirectory::TContext context(nullptr);
+    frame = new TH1F("frame", "Efficiency of "+effName, 1, v.getMin(), v.getMax());
+  }
   p->SetNameTitle(Form("hxy_%s", eff.GetName()), "Efficiency of "+effName);
   p->GetXaxis()->SetTitle(strlen(v.getUnit()) ? Form("%s (%s)", v.GetName(), v.getUnit()) : v.GetName());
   p->GetYaxis()->SetTitle("Efficiency of "+effName);

--- a/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
+++ b/RecoJets/FFTJetProducers/plugins/FFTJetEFlowSmoother.cc
@@ -42,6 +42,8 @@
 // useful utilities collected in the second base
 #include "RecoJets/FFTJetProducers/interface/FFTJetInterface.h"
 
+#include "TDirectory.h"
+
 using namespace fftjetcms;
 
 //
@@ -225,13 +227,17 @@ void FFTJetEFlowSmoother::produce(
     const double bin0edge = g.phiBin0Edge();
 
     // We will fill the following histo
-    std::auto_ptr<TH3F> pTable(
+    std::auto_ptr<TH3F> pTable;
+    {
+      TDirectory::TContext context(nullptr);
+
+      pTable.reset(
         new TH3F("FFTJetEFlowSmoother", "FFTJetEFlowSmoother",
                  nScales+1U, -1.5, nScales-0.5,
                  nEta, g.etaMin(), g.etaMax(),
                  nPhi, bin0edge, bin0edge+2.0*M_PI));
+    }
     TH3F* h = pTable.get();
-    h->SetDirectory(0);
     h->GetXaxis()->SetTitle("Scale");
     h->GetYaxis()->SetTitle("Eta");
     h->GetZaxis()->SetTitle("Phi");

--- a/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/src/EcalDeadChannelRecoveryNN.cc
+++ b/RecoLocalCalo/EcalDeadChannelRecoveryAlgos/src/EcalDeadChannelRecoveryNN.cc
@@ -4,6 +4,7 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
 #include <iostream>
+#include "TDirectory.h"
 #include <TMath.h>
 
 template <typename T>
@@ -42,8 +43,11 @@ template <typename T>
 void EcalDeadChannelRecoveryNN<T>::load_file(MultiLayerPerceptronContext& ctx, std::string fn) {
   std::string path = edm::FileInPath(fn).fullPath();
 
-  TTree *t = new TTree("t", "dummy MLP tree");
-  t->SetDirectory(0);
+  TTree *t;
+  {
+    TDirectory::TContext context(nullptr);
+    t = new TTree("t", "dummy MLP tree");
+  }
 
   t->Branch("z1", &(ctx.tmp[0]), "z1/D");
   t->Branch("z2", &(ctx.tmp[1]), "z2/D");

--- a/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
+++ b/SimTracker/TrackerMaterialAnalysis/plugins/MaterialAccountingGroup.cc
@@ -3,6 +3,7 @@
 #include <string>
 #include <stdexcept>
 
+#include "TDirectory.h"
 #include <TFile.h>
 #include <TH1F.h>
 #include <TProfile.h>
@@ -47,22 +48,17 @@ MaterialAccountingGroup::MaterialAccountingGroup( const std::string & name, cons
   m_boundingbox.grow(s_tolerance);
 
   // initialize the histograms 
-  m_dedx_spectrum   = new TH1F((m_name + "_dedx_spectrum").c_str(),     "Energy loss spectrum",       1000,    0,   1);
-  m_radlen_spectrum = new TH1F((m_name + "_radlen_spectrum").c_str(),   "Radiation lengths spectrum", 1000,    0,   1);
-  m_dedx_vs_eta     = new TProfile((m_name + "_dedx_vs_eta").c_str(),   "Energy loss vs. eta",         600,   -3,   3);
-  m_dedx_vs_z       = new TProfile((m_name + "_dedx_vs_z").c_str(),     "Energy loss vs. Z",          6000, -300, 300);
-  m_dedx_vs_r       = new TProfile((m_name + "_dedx_vs_r").c_str(),     "Energy loss vs. R",          1200,    0, 120);
-  m_radlen_vs_eta   = new TProfile((m_name + "_radlen_vs_eta").c_str(), "Radiation lengths vs. eta",   600,   -3,   3);
-  m_radlen_vs_z     = new TProfile((m_name + "_radlen_vs_z").c_str(),   "Radiation lengths vs. Z",    6000, -300, 300);
-  m_radlen_vs_r     = new TProfile((m_name + "_radlen_vs_r").c_str(),   "Radiation lengths vs. R",    1200,    0, 120);
-  m_dedx_spectrum->SetDirectory( 0 );
-  m_radlen_spectrum->SetDirectory( 0 );
-  m_dedx_vs_eta->SetDirectory( 0 );
-  m_dedx_vs_z->SetDirectory( 0 );
-  m_dedx_vs_r->SetDirectory( 0 );
-  m_radlen_vs_eta->SetDirectory( 0 );
-  m_radlen_vs_z->SetDirectory( 0 );
-  m_radlen_vs_r->SetDirectory( 0 );
+  {
+    TDirectory::TContext context(nullptr);
+    m_dedx_spectrum   = new TH1F((m_name + "_dedx_spectrum").c_str(),     "Energy loss spectrum",       1000,    0,   1);
+    m_radlen_spectrum = new TH1F((m_name + "_radlen_spectrum").c_str(),   "Radiation lengths spectrum", 1000,    0,   1);
+    m_dedx_vs_eta     = new TProfile((m_name + "_dedx_vs_eta").c_str(),   "Energy loss vs. eta",         600,   -3,   3);
+    m_dedx_vs_z       = new TProfile((m_name + "_dedx_vs_z").c_str(),     "Energy loss vs. Z",          6000, -300, 300);
+    m_dedx_vs_r       = new TProfile((m_name + "_dedx_vs_r").c_str(),     "Energy loss vs. R",          1200,    0, 120);
+    m_radlen_vs_eta   = new TProfile((m_name + "_radlen_vs_eta").c_str(), "Radiation lengths vs. eta",   600,   -3,   3);
+    m_radlen_vs_z     = new TProfile((m_name + "_radlen_vs_z").c_str(),   "Radiation lengths vs. Z",    6000, -300, 300);
+    m_radlen_vs_r     = new TProfile((m_name + "_radlen_vs_r").c_str(),   "Radiation lengths vs. R",    1200,    0, 120);
+  }
 }
 
 MaterialAccountingGroup::~MaterialAccountingGroup(void)


### PR DESCRIPTION
This change should yield identical behavior
and remove a thread safety issue.

In ROOT when a histogram is created, the default
behavior is to automatically add a reference to
the histogram to the list of in-memory
objects for the current file or directory.
In some cases in CMSSW, immediately after
creating the histogram, SetDirectory is called
with a null argument. This removes the reference.
This creates a thread safety issue because multiple
threads could be creating histograms in the
same TFile or TDirectory.

An alternative is to create a TContext object
with a nullptr argument whose lifetime includes
the creation of the histogram. Then the reference
is never created in the first place and the call
to SetDirectory can be deleted. The TContext object
is a sentry that sets the thread local gDirectory
pointer in ROOT. The histogram constructor looks
at gDirectory to decide whether to set the reference.
When the TContext object goes out of scope,
gDirectory is reset to its original value.
