### PR TITLE
backport of #9242: Add the list of the N modules with the largest occupancy from tracker maps

### DIFF
--- a/DQM/SiStripMonitorClient/README.md
+++ b/DQM/SiStripMonitorClient/README.md
@@ -8,3 +8,26 @@ This script produces a root file and png files of the occupancy plots of the mod
 https://cmsweb.cern.ch/dqm/offline/data/browse/ROOT/OfflineData/
 
 To access the DQM file a valid certificate and key has to be provided to the script
+
+#### TkMap_ script_ automatic_DB
+`TkMap_script_automatic_DB.sh <Dataset_type> <runNumber>`
+
+The script produces a set of png trackerMaps, a list of the bad components found by the prompt calibration loop as well as lists of the modules which are BAD from quality tests and modules with the largest digi, cluster, off trackcluster occupancy for the `<Dataset_type>`specified by `<runNumber>`. The `<Dataset_type>`and `<runNumber>`must match the names used in this site:	https://cmsweb.cern.ch/dqm/offline/data/browse/ROOT/OfflineData/
+
+##SiStripOfflineDQM 
+
+Configure the TrackerMaps to be created by the SiStrip Offline DQM Client using `"TkMapOptions"`. VPSet. The clientloops over the entries of ` "TkMapOptions" ` and generates the trackerMap specified by the string `mapName`. The  mapName menu is:  
+ 
+        -QTestAlarm 
+        -FractionOfBadChannels
+        -NumberOfCluster
+        -NumberOfDigi
+        -NumberOfOfffTrackCluster
+        -NumberOfOnTrackCluster
+        -StoNCorrOnTrack
+        -NApvShots
+        -MedianChargeApvShots
+
+In case `mapName=QTestAlarm`, the client fills the tracker Map with QTest Alarms and SiStripQuality bad modules, it also produces a text file with the number of bad modules and a list of bad modules per partition. In all other cases the tracker Map is filled from Histograms.
+
+Create a sorted list of the N modules with the largest digi, cluster, off track cluster occupancy when the corresponding tracker maps are produced by setting `TopModules` as True in the corresponding entry in `"TkMapOptions"`. To choose the number of modules to be sort use int parameter `numberTopModules`.

--- a/DQM/SiStripMonitorClient/data/index_template_TKMap.html
+++ b/DQM/SiStripMonitorClient/data/index_template_TKMap.html
@@ -24,7 +24,8 @@
       <LI><A href="QTestAlarm.png">Modules which are BAD from quality tests</a> (<A href="QTestAlarm_fed.png">FED view</a>, <A href="fedmap.html">interactive</a>) (<A href="QTestAlarm_psu.png">PSU view</a>, <A href="psumap.html">interactive</a>)
       <LI><A href="QualityTest_runRunNumber.txt">List of Modules which are BAD from quality tests</a> 
       (<A href="QualityTestOBSOLETE_runRunNumber.txt">obsolete version</a>)
-      <LI><A href="ModuleDifference_RunNumber.txt">Difference in the list of bad modules compared with previous run - text</a> 
+      <LI><A href="ModuleDifference_RunNumber.txt">Difference in the list of bad modules compared with previous run - text</a>
+      <LI><A href="TopModulesList.log">List of the modules with the highest values</a> 
       <LI><A href="FractionOfBadChannels.png">FED errors per modules</a>
       <LI><A href="NumberOfDigi.png">Number of digis per module</a>
       <LI><A href="NumberOfCluster.png">Number of clusters per module</a>

--- a/DQM/SiStripMonitorClient/data/index_template_TKMap_cosmics.html
+++ b/DQM/SiStripMonitorClient/data/index_template_TKMap_cosmics.html
@@ -25,6 +25,7 @@
       <LI><A href="QualityTest_runRunNumber.txt">List of Modules which are BAD from quality tests</a>
        (<A href="QualityTestOBSOLETE_runRunNumber.txt">obsolete version</a>)
      <LI><A href="ModuleDifference_RunNumber.txt">Difference in the list of bad modules compared with previous run - text</a>
+      <LI><A href="TopModulesList.log">List of the modules with the highest values</a> 
       <LI><A href="FractionOfBadChannels.png">FED errors per module</a>
       <LI><A href="NumberOfDigi.png">Number of digis per module</a>
       <LI><A href="NumberOfCluster.png">Number of clusters per module</a>

--- a/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
+++ b/DQM/SiStripMonitorClient/interface/SiStripTrackerMapCreator.h
@@ -39,13 +39,14 @@ class SiStripTrackerMapCreator {
 
   void paintTkMapFromAlarm(uint32_t det_id, const TrackerTopology* tTopo,
                            DQMStore* dqm_store, bool isBad=false, std::map<unsigned int,std::string>* badmodmap=0);
-  void paintTkMapFromHistogram(DQMStore* dqm_store, MonitorElement* me, std::string& map_type);
-  void setTkMapFromHistogram(DQMStore* dqm_store, std::string& htype);
+  void paintTkMapFromHistogram(DQMStore* dqm_store, MonitorElement* me, std::string& map_type, std::vector<std::pair<float,uint32_t> >* topNmodVec);
+  void setTkMapFromHistogram(DQMStore* dqm_store, std::string& htype, const edm::EventSetup& eSetup);
   void setTkMapFromAlarm(DQMStore* dqm_store,  const edm::EventSetup& eSetup);
   void setTkMapRange(std::string& map_type);
   void setTkMapRangeOffline();
   uint16_t getDetectorFlagAndComment(DQMStore* dqm_store, uint32_t det_id, const TrackerTopology* tTopo, std::ostringstream& comment);
   void printBadModuleList(std::map<unsigned int,std::string>* badmodmap, const edm::EventSetup& eSetup);
+  void printTopModules(std::vector<std::pair<float,uint32_t> >* topNmodVec, const edm::EventSetup& eSetup);
 
   TrackerMap* trackerMap_;
   std::string tkMapName_;
@@ -64,5 +65,8 @@ class SiStripTrackerMapCreator {
   uint32_t cached_detid;
   int16_t cached_layer;
   TkLayerMap::XYbin cached_XYbin;
+  bool topModules;
+  int32_t numTopModules;
+  std::string topModLabel;
 };
 #endif

--- a/DQM/SiStripMonitorClient/scripts/TkMap_script_automatic_DB.sh
+++ b/DQM/SiStripMonitorClient/scripts/TkMap_script_automatic_DB.sh
@@ -192,8 +192,9 @@ do
     rm -f *.xml
     rm -f *svg
 
-#    mkdir -p /data/users/event_display/${DataLocalDir}/${dest}/${nnn}/${Run_numb}/$thisDataset 2> /dev/null
+#    mkdir -p /data/users/event_display/${DataLocalDir}/${dest}/${nnn}/${Run_numb}/$thisDataset #2> /dev/null
 #    cp -r ${Run_numb}/$thisDataset /data/users/event_display/Data2011/${dest}/${nnn}/${Run_numb}/
+#    cp -r ${Run_numb}/$thisDataset /data/users/event_display/${DataLocalDir}/${dest}/${nnn}/${Run_numb}/$thisDataset 
     ssh cctrack@vocms061 "mkdir -p /data/users/event_display/${DataLocalDir}/${dest}/${nnn}/${Run_numb}/$thisDataset 2> /dev/null"
     scp -r * cctrack@vocms061:/data/users/event_display/${DataLocalDir}/${dest}/${nnn}/${Run_numb}/$thisDataset
 

--- a/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
+++ b/DQM/SiStripMonitorClient/test/SiStripDQM_OfflineTkMap_Template_cfg_DB.py
@@ -27,12 +27,13 @@ options.register ('runNumber',
 options.parseArguments()
 
 process.MessageLogger = cms.Service("MessageLogger",
-    destinations = cms.untracked.vstring('cout','cerr','PCLBadComponents','QTBadModules'), #Reader, cout
+    destinations = cms.untracked.vstring('cout','cerr','PCLBadComponents','QTBadModules','TopModulesList'), #Reader, cout
     categories = cms.untracked.vstring('SiStripQualityStatistics',
                                        'BadModuleList',
                                        'TkMapParameters',
                                        'TkMapToBeSaved',
-                                       'PSUMapToBeSaved'), #Reader, cout
+                                       'PSUMapToBeSaved',
+				       'TopModules'), #Reader, cout
     debugModules = cms.untracked.vstring('siStripDigis', 
                                          'siStripClusters', 
                                          'siStripZeroSuppression', 
@@ -53,7 +54,11 @@ process.MessageLogger = cms.Service("MessageLogger",
     QTBadModules = cms.untracked.PSet(threshold = cms.untracked.string('INFO'),
                                 default = cms.untracked.PSet(limit=cms.untracked.int32(0)),
                                 BadModuleList = cms.untracked.PSet(limit=cms.untracked.int32(100000))
-                                )
+                                ),
+    TopModulesList = cms.untracked.PSet(threshold = cms.untracked.string('INFO'),
+				default = cms.untracked.PSet(limit=cms.untracked.int32(0)),
+				TopModules = cms.untracked.PSet(limit=cms.untracked.int32(100000))
+				)
                                     
 )
 
@@ -73,7 +78,6 @@ process.maxEvents = cms.untracked.PSet(
 process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
 process.GlobalTag = GlobalTag(process.GlobalTag, options.globalTag, '')
-
 # loading TrackerTopologyEP via GeometryDB (since 62x)
 process.load('Configuration.StandardSequences.GeometryDB_cff')
     
@@ -103,9 +107,9 @@ process.siStripOfflineAnalyser = cms.EDAnalyzer("SiStripOfflineDQM",
        TkMapOptions             = cms.untracked.VPSet(
     cms.PSet(mapName=cms.untracked.string('QTestAlarm'),fedMap=cms.untracked.bool(True),useSSQuality=cms.untracked.bool(True),ssqLabel=cms.untracked.string(""),psuMap=cms.untracked.bool(True),loadLVCabling=cms.untracked.bool(True),mapMax=cms.untracked.double(1.)),
     cms.PSet(mapName=cms.untracked.string('FractionOfBadChannels'),mapMax=cms.untracked.double(-1.),logScale=cms.untracked.bool(True)),
-    cms.PSet(mapName=cms.untracked.string('NumberOfCluster')),
-    cms.PSet(mapName=cms.untracked.string('NumberOfDigi')),
-    cms.PSet(mapName=cms.untracked.string('NumberOfOfffTrackCluster')),
+    cms.PSet(mapName=cms.untracked.string('NumberOfCluster'),TopModules=cms.untracked.bool(True),numberTopModules=cms.untracked.int32(20)),
+    cms.PSet(mapName=cms.untracked.string('NumberOfDigi'),TopModules=cms.untracked.bool(True)),
+    cms.PSet(mapName=cms.untracked.string('NumberOfOfffTrackCluster'),TopModules=cms.untracked.bool(True)),
     cms.PSet(mapName=cms.untracked.string('NumberOfOfffTrackCluster'),mapSuffix=cms.untracked.string("_autoscale"),mapMax=cms.untracked.double(-1.)),
     cms.PSet(mapName=cms.untracked.string('NumberOfOnTrackCluster')),
     cms.PSet(mapName=cms.untracked.string('StoNCorrOnTrack')),


### PR DESCRIPTION
back port of the 75X PR #9242 
The possibility to produce a sorted list of the N modules with the largest digi, cluster, off track cluster occupancy when the corresponding tracker maps are produced is added
