### PR TITLE
Data scouting classes and producers (76X)

### DIFF
--- a/DataFormats/Scouting/BuildFile.xml
+++ b/DataFormats/Scouting/BuildFile.xml
@@ -1,0 +1,5 @@
+<use   name="FWCore/Utilities"/>
+<use   name="DataFormats/Common"/>
+<export>
+  <lib   name="1"/>
+</export>

--- a/DataFormats/Scouting/interface/ScoutingCaloJet.h
+++ b/DataFormats/Scouting/interface/ScoutingCaloJet.h
@@ -1,0 +1,66 @@
+#ifndef DataFormats_ScoutingCaloJet_h
+#define DataFormats_ScoutingCaloJet_h
+
+#include <vector>
+
+//class for holding calo jet information, for use in data scouting 
+//IMPORTANT: the content of this class should be changed only in backwards compatible ways!
+class ScoutingCaloJet
+{
+    public: 
+        //constructor with values for all data fields
+        ScoutingCaloJet(float pt, float eta, float phi, float m,
+                float jetArea, float maxEInEmTowers, float maxEInHadTowers,
+                float hadEnergyInHB, float hadEnergyInHE, float hadEnergyInHF,
+                float emEnergyInEB, float emEnergyInEE, float emEnergyInHF,
+                float towersArea, float mvaDiscriminator):
+            pt_(pt), eta_(eta), phi_(phi), m_(m),
+            jetArea_(jetArea), maxEInEmTowers_(maxEInEmTowers), maxEInHadTowers_(maxEInHadTowers), 
+            hadEnergyInHB_(hadEnergyInHB), hadEnergyInHE_(hadEnergyInHE), hadEnergyInHF_(hadEnergyInHF),
+            emEnergyInEB_(emEnergyInEB), emEnergyInEE_(emEnergyInEE), emEnergyInHF_(emEnergyInHF),
+            towersArea_(towersArea), mvaDiscriminator_(mvaDiscriminator){ }
+        //default constructor
+        ScoutingCaloJet():pt_(0), eta_(0), phi_(0), m_(0), 
+        jetArea_(0), maxEInEmTowers_(0), maxEInHadTowers_(0), 
+        hadEnergyInHB_(0), hadEnergyInHE_(0), hadEnergyInHF_(0),
+        emEnergyInEB_(0), emEnergyInEE_(0), emEnergyInHF_(0),
+        towersArea_(0), mvaDiscriminator_(0) { }
+
+        //accessor functions
+        float pt() const { return pt_; }
+        float eta() const { return eta_; }
+        float phi() const { return phi_; }
+        float m() const { return m_; }
+        float jetArea() const { return jetArea_; }
+        float maxEInEmTowers() const { return maxEInEmTowers_; }
+        float maxEInHadTowers() const { return maxEInHadTowers_; }
+        float hadEnergyInHB() const { return hadEnergyInHB_; }
+        float hadEnergyInHE() const { return hadEnergyInHE_; }
+        float hadEnergyInHF() const { return hadEnergyInHF_; }
+        float emEnergyInEB() const { return emEnergyInEB_; }
+        float emEnergyInEE() const { return emEnergyInEE_; }
+        float emEnergyInHF() const { return emEnergyInHF_; }
+        float towersArea() const { return towersArea_; }
+        float mvaDiscriminator() const { return mvaDiscriminator_; }
+
+    private:
+        float pt_;
+        float eta_;
+        float phi_;
+        float m_;
+        float jetArea_;
+        float maxEInEmTowers_;
+        float maxEInHadTowers_;
+        float hadEnergyInHB_;
+        float hadEnergyInHE_;
+        float hadEnergyInHF_;
+        float emEnergyInEB_;
+        float emEnergyInEE_;
+        float emEnergyInHF_;
+        float towersArea_;
+        float mvaDiscriminator_;
+};
+
+typedef std::vector<ScoutingCaloJet> ScoutingCaloJetCollection;
+
+#endif

--- a/DataFormats/Scouting/interface/ScoutingPFJet.h
+++ b/DataFormats/Scouting/interface/ScoutingPFJet.h
@@ -1,0 +1,89 @@
+#ifndef DataFormats_ScoutingPFJet_h
+#define DataFormats_ScoutingPFJet_h
+
+#include <vector>
+
+//class for holding PF jet information, for use in data scouting 
+//IMPORTANT: the content of this class should be changed only in backwards compatible ways!
+class ScoutingPFJet
+{
+    public:
+        //constructor with values for all data fields
+        ScoutingPFJet(float pt, float eta, float phi, float m, float jetArea, 
+                float chargedHadronEnergy, float neutralHadronEnergy, float photonEnergy,
+                float electronEnergy, float muonEnergy, float HFHadronEnergy, float HFEMEnergy,
+                int chargedHadronMultiplicity, int neutralHadronMultiplicity, int photonMultiplicity,
+                int electronMultiplicity, int muonMultiplicity,
+                int HFHadronMultiplicity, int HFEMMultiplicity,
+                float HOEnergy, float csv, float mvaDiscriminator, std::vector<int> constituents):
+            pt_(pt), eta_(eta), phi_(phi), m_(m), jetArea_(jetArea), 
+            chargedHadronEnergy_(chargedHadronEnergy), neutralHadronEnergy_(neutralHadronEnergy),
+            photonEnergy_(photonEnergy), electronEnergy_(electronEnergy), muonEnergy_(muonEnergy),
+            HFHadronEnergy_(HFHadronEnergy), HFEMEnergy_(HFEMEnergy), 
+            chargedHadronMultiplicity_(chargedHadronMultiplicity), neutralHadronMultiplicity_(neutralHadronMultiplicity),
+            photonMultiplicity_(photonMultiplicity), electronMultiplicity_(electronMultiplicity),
+            muonMultiplicity_(muonMultiplicity), HFHadronMultiplicity_(HFHadronMultiplicity),
+            HFEMMultiplicity_(HFEMMultiplicity), HOEnergy_(HOEnergy), csv_(csv), mvaDiscriminator_(mvaDiscriminator),
+            constituents_(constituents) {}
+        //default constructor
+        ScoutingPFJet():pt_(0), eta_(0), phi_(0), m_(0), 
+        jetArea_(0), chargedHadronEnergy_(0), neutralHadronEnergy_(0),
+        photonEnergy_(0), electronEnergy_(0), muonEnergy_(0), HFHadronEnergy_(0), HFEMEnergy_(0),
+        chargedHadronMultiplicity_(0), neutralHadronMultiplicity_(0), photonMultiplicity_(0),
+        electronMultiplicity_(0), muonMultiplicity_(0), HFHadronMultiplicity_(0), 
+        HFEMMultiplicity_(0), HOEnergy_(0), csv_(0), mvaDiscriminator_(0), constituents_(std::vector<int>()) {}
+
+        //accessor functions
+        float pt() const { return pt_; }
+        float eta() const { return eta_; }
+        float phi() const { return phi_; }
+        float m() const { return m_; }
+        float jetArea() const { return jetArea_; }
+        float chargedHadronEnergy() const { return chargedHadronEnergy_; }
+        float neutralHadronEnergy() const { return neutralHadronEnergy_; }
+        float photonEnergy() const { return photonEnergy_; }
+        float electronEnergy() const { return electronEnergy_; }
+        float muonEnergy() const { return muonEnergy_; }
+        float HFHadronEnergy() const { return HFHadronEnergy_; }
+        float HFEMEnergy() const { return HFEMEnergy_; }
+        int chargedHadronMultiplicity() const { return chargedHadronMultiplicity_; }
+        int neutralHadronMultiplicity() const { return neutralHadronMultiplicity_; }
+        int photonMultiplicity() const { return photonMultiplicity_; }
+        int electronMultiplicity() const { return electronMultiplicity_; }
+        int muonMultiplicity() const { return muonMultiplicity_; }
+        int HFHadronMultiplicity() const { return HFHadronMultiplicity_; }
+        int HFEMMultiplicity() const { return HFEMMultiplicity_; }
+        float HOEnergy() const { return HOEnergy_; }
+        float csv() const { return csv_; }
+        float mvaDiscriminator() const { return mvaDiscriminator_; }
+        std::vector<int> constituents() const { return constituents_; }
+
+    private:
+        float pt_;
+        float eta_;
+        float phi_;
+        float m_;
+        float jetArea_;
+        float chargedHadronEnergy_;
+        float neutralHadronEnergy_;
+        float photonEnergy_;
+        float electronEnergy_;
+        float muonEnergy_;
+        float HFHadronEnergy_;
+        float HFEMEnergy_;
+        int chargedHadronMultiplicity_;
+        int neutralHadronMultiplicity_;
+        int photonMultiplicity_;
+        int electronMultiplicity_;
+        int muonMultiplicity_;
+        int HFHadronMultiplicity_;
+        int HFEMMultiplicity_;
+        float HOEnergy_;
+        float csv_;
+        float mvaDiscriminator_;
+        std::vector<int> constituents_;
+};
+
+typedef std::vector<ScoutingPFJet> ScoutingPFJetCollection;
+
+#endif

--- a/DataFormats/Scouting/interface/ScoutingParticle.h
+++ b/DataFormats/Scouting/interface/ScoutingParticle.h
@@ -1,0 +1,35 @@
+#ifndef DataFormats_ScoutingParticle_h
+#define DataFormats_ScoutingParticle_h
+
+#include <vector>
+
+//class for holding PF candidate information, for use in data scouting 
+//IMPORTANT: the content of this class should be changed only in backwards compatible ways!
+class ScoutingParticle
+{
+    public:
+        //constructor with values for all data fields
+        ScoutingParticle(float pt, float eta, float phi, float m, 
+                int pdgId):
+            pt_(pt), eta_(eta), phi_(phi), m_(m), pdgId_(pdgId) {}
+        //default constructor
+        ScoutingParticle():pt_(0), eta_(0), phi_(0), m_(0), pdgId_(0) {}
+
+        //accessor functions
+        float pt() const { return pt_; }
+        float eta() const { return eta_; }
+        float phi() const { return phi_; }
+        float m() const { return m_; }
+        int pdgId() const { return pdgId_; }
+
+    private:
+        float pt_;
+        float eta_;
+        float phi_;
+        float m_;
+        int pdgId_;
+};
+
+typedef std::vector<ScoutingParticle> ScoutingParticleCollection;
+
+#endif

--- a/DataFormats/Scouting/interface/ScoutingVertex.h
+++ b/DataFormats/Scouting/interface/ScoutingVertex.h
@@ -1,0 +1,32 @@
+#ifndef DataFormats_ScoutingVertex_h
+#define DataFormats_ScoutingVertex_h
+
+#include <vector>
+
+//class for holding vertex information, for use in data scouting 
+//IMPORTANT: the content of this class should be changed only in backwards compatible ways!
+class ScoutingVertex
+{
+    public:
+        //constructor with values for all data fields
+        ScoutingVertex(float x, float y, float z, float zError):
+            x_(x), y_(y), z_(z), zError_(zError) {}
+        //default constructor
+        ScoutingVertex(): x_(0), y_(0), z_(0), zError_(0) {}
+
+        //accessor functions
+        float x() const { return x_; }
+        float y() const { return y_; }
+        float z() const { return z_; }
+        float zError() const { return zError_; }
+
+    private:
+        float x_;
+        float y_;
+        float z_;
+        float zError_;
+};
+
+typedef std::vector<ScoutingVertex> ScoutingVertexCollection;
+
+#endif

--- a/DataFormats/Scouting/src/classes.h
+++ b/DataFormats/Scouting/src/classes.h
@@ -1,0 +1,16 @@
+#include "DataFormats/Scouting/interface/ScoutingCaloJet.h"
+#include "DataFormats/Scouting/interface/ScoutingPFJet.h"
+#include "DataFormats/Scouting/interface/ScoutingParticle.h"
+#include "DataFormats/Scouting/interface/ScoutingVertex.h"
+#include "DataFormats/Common/interface/Wrapper.h"
+#include "DataFormats/Common/interface/Ref.h"
+
+
+namespace DataFormats_Scouting {
+  struct dictionary {
+    edm::Wrapper<ScoutingCaloJetCollection> sc1;
+    edm::Wrapper<ScoutingParticleCollection> sc2;
+    edm::Wrapper<ScoutingPFJetCollection> sc3;
+    edm::Wrapper<ScoutingVertexCollection> sc4;
+  };
+}

--- a/DataFormats/Scouting/src/classes_def.xml
+++ b/DataFormats/Scouting/src/classes_def.xml
@@ -1,0 +1,22 @@
+<lcgdict>
+  <class name="ScoutingCaloJet" ClassVersion="2">
+      <version ClassVersion="2" checksum="2705685116"/>
+  </class>
+  <class name="ScoutingPFJet" ClassVersion="2">
+      <version ClassVersion="2" checksum="2507658732"/>
+  </class>
+  <class name="ScoutingParticle" ClassVersion="2">
+      <version ClassVersion="2" checksum="2803573918"/>
+  </class>
+  <class name="ScoutingVertex" ClassVersion="2">
+      <version ClassVersion="2" checksum="2969738609"/>
+  </class>
+  <class name="std::vector<ScoutingCaloJet>"/>
+  <class name="std::vector<ScoutingPFJet>"/>
+  <class name="std::vector<ScoutingParticle>"/>
+  <class name="std::vector<ScoutingVertex>"/>
+  <class name="edm::Wrapper<std::vector<ScoutingCaloJet> >"/>
+  <class name="edm::Wrapper<std::vector<ScoutingPFJet> >"/>
+  <class name="edm::Wrapper<std::vector<ScoutingParticle> >"/>
+  <class name="edm::Wrapper<std::vector<ScoutingVertex> >"/>
+</lcgdict>

--- a/HLTrigger/JetMET/BuildFile.xml
+++ b/HLTrigger/JetMET/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="DataFormats/HcalRecHit"/>
 <use   name="DataFormats/JetReco"/>
 <use   name="DataFormats/METReco"/>
+<use   name="DataFormats/Scouting"/>
 <use   name="DataFormats/Math"/>
 <use   name="Geometry/Records"/>
 <use   name="Geometry/CaloTopology"/>

--- a/HLTrigger/JetMET/plugins/BuildFile.xml
+++ b/HLTrigger/JetMET/plugins/BuildFile.xml
@@ -4,6 +4,7 @@
   <use   name="DataFormats/HcalRecHit"/>
   <use   name="DataFormats/JetReco"/>
   <use   name="DataFormats/METReco"/>
+  <use   name="DataFormats/Scouting"/>
   <use   name="DataFormats/Math"/>
   <use   name="Geometry/Records"/>
   <use   name="Geometry/CaloTopology"/>

--- a/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
@@ -1,0 +1,167 @@
+// -*- C++ -*-
+//
+// Package:    HLTrigger/JetMET
+// Class:      HLTScoutingCaloProducer
+// 
+/**\class HLTScoutingCaloProducer HLTScoutingCaloProducer.cc HLTrigger/JetMET/plugins/HLTScoutingCaloProducer.cc
+
+Description: Producer for ScoutingCaloJets from reco::CaloJet objects
+
+*/
+//
+// Original Author:  Dustin James Anderson
+//         Created:  Fri, 12 Jun 2015 15:49:20 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/JetReco/interface/CaloJet.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/METReco/interface/CaloMETCollection.h"
+#include "DataFormats/METReco/interface/CaloMET.h"
+
+#include "DataFormats/Scouting/interface/ScoutingCaloJet.h"
+#include "DataFormats/Scouting/interface/ScoutingVertex.h"
+
+class HLTScoutingCaloProducer : public edm::global::EDProducer<> {
+    public:
+        explicit HLTScoutingCaloProducer(const edm::ParameterSet&);
+        ~HLTScoutingCaloProducer();
+
+        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    private:
+        virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const override final;
+
+        const edm::EDGetTokenT<reco::CaloJetCollection> caloJetCollection_;
+        const edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
+        const edm::EDGetTokenT<reco::CaloMETCollection> metCollection_;
+        const edm::EDGetTokenT<double> rho_;
+
+        const double caloJetPtCut;
+        const double caloJetEtaCut;
+
+        const bool doMet;
+};
+
+//
+// constructors and destructor
+//
+HLTScoutingCaloProducer::HLTScoutingCaloProducer(const edm::ParameterSet& iConfig):
+    caloJetCollection_(consumes<reco::CaloJetCollection>(iConfig.getParameter<edm::InputTag>("caloJetCollection"))),
+    vertexCollection_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
+    metCollection_(consumes<reco::CaloMETCollection>(iConfig.getParameter<edm::InputTag>("metCollection"))),
+    rho_(consumes<double>(iConfig.getParameter<edm::InputTag>("rho"))),
+    caloJetPtCut(iConfig.getParameter<double>("caloJetPtCut")),
+    caloJetEtaCut(iConfig.getParameter<double>("caloJetEtaCut")),
+    doMet(iConfig.getParameter<bool>("doMet"))
+{
+    //register products
+    produces<ScoutingCaloJetCollection>();
+    produces<ScoutingVertexCollection>();
+    produces<double>("rho");
+    produces<double>("caloMetPt");
+    produces<double>("caloMetPhi");
+}
+
+HLTScoutingCaloProducer::~HLTScoutingCaloProducer()
+{ }
+
+// ------------ method called to produce the data  ------------
+    void
+HLTScoutingCaloProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const
+{
+    using namespace edm;
+
+    //get calo jets
+    Handle<reco::CaloJetCollection> caloJetCollection;
+    if(!iEvent.getByToken(caloJetCollection_, caloJetCollection)){
+        edm::LogError ("HLTScoutingCaloProducer") << "invalid collection: caloJetCollection" << "\n";
+        return;
+    }
+
+    //get vertices
+    Handle<reco::VertexCollection> vertexCollection;
+    std::auto_ptr<ScoutingVertexCollection> outVertices(new ScoutingVertexCollection());
+    if(iEvent.getByToken(vertexCollection_, vertexCollection)){
+        //produce vertices (only if present; otherwise return an empty collection)
+        for(auto &vtx : *vertexCollection){
+            outVertices->emplace_back(
+                        vtx.x(), vtx.y(), vtx.z(), vtx.zError()
+                        );
+        }
+    }
+
+    //get rho
+    Handle<double>rho;
+    if(!iEvent.getByToken(rho_, rho)){
+        edm::LogError ("HLTScoutingCaloProducer") << "invalid collection: rho" << "\n";
+        return;
+    }
+    std::auto_ptr<double> outRho(new double(*rho));
+
+    //get MET 
+    Handle<reco::CaloMETCollection> metCollection;
+    if(doMet && !iEvent.getByToken(metCollection_, metCollection)){
+        edm::LogError ("HLTScoutingCaloProducer") << "invalid collection: metCollection" << "\n";
+        return;
+    }
+
+    //produce calo jets
+    std::auto_ptr<ScoutingCaloJetCollection> outCaloJets(new ScoutingCaloJetCollection());
+    for(auto &jet : *caloJetCollection){
+        if(jet.pt() > caloJetPtCut && fabs(jet.eta()) < caloJetEtaCut){
+            outCaloJets->emplace_back(
+                    jet.pt(), jet.eta(), jet.phi(), jet.mass(),
+                    jet.jetArea(), jet.maxEInEmTowers(), jet.maxEInHadTowers(),
+                    jet.hadEnergyInHB(), jet.hadEnergyInHE(), jet.hadEnergyInHF(),
+                    jet.emEnergyInEB(), jet.emEnergyInEE(), jet.emEnergyInHF(),
+                    jet.towersArea(), 0.0
+                    );
+        }
+    }
+
+    //produce MET
+    double metPt = -999;
+    double metPhi = -999;
+    if(doMet){
+        metPt = metCollection->front().pt();
+        metPhi = metCollection->front().phi();
+    }
+    std::auto_ptr<double> outMetPt(new double(metPt));
+    std::auto_ptr<double> outMetPhi(new double(metPhi));
+
+    //put output
+    iEvent.put(outCaloJets);
+    iEvent.put(outVertices);
+    iEvent.put(outRho, "rho");
+    iEvent.put(outMetPt, "caloMetPt");
+    iEvent.put(outMetPhi, "caloMetPhi");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void
+HLTScoutingCaloProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("caloJetCollection",edm::InputTag("hltAK4CaloJets"));
+    desc.add<edm::InputTag>("vertexCollection", edm::InputTag("hltPixelVertices"));
+    desc.add<edm::InputTag>("metCollection", edm::InputTag("hltMetCleanUsingJetID"));
+    desc.add<edm::InputTag>("rho", edm::InputTag("hltFixedGridRhoFastjetAllCalo"));
+    desc.add<double>("caloJetPtCut", 20.0);
+    desc.add<double>("caloJetEtaCut", 3.0);
+    desc.add<bool>("doMet", true);
+    descriptions.add("hltScoutingCaloProducer", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HLTScoutingCaloProducer);

--- a/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+++ b/HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
@@ -1,0 +1,249 @@
+// -*- C++ -*-
+//
+// Package:    HLTrigger/JetMET
+// Class:      HLTScoutingPFProducer
+// 
+/**\class HLTScoutingPFProducer HLTScoutingPFProducer.cc HLTrigger/JetMET/plugins/HLTScoutingPFProducer.cc
+
+Description: Producer for ScoutingPFJets from reco::PFJet objects, ScoutingVertexs from reco::Vertexs and ScoutingParticles from reco::PFCandidates
+
+*/
+//
+// Original Author:  Dustin James Anderson
+//         Created:  Fri, 12 Jun 2015 15:49:20 GMT
+//
+//
+
+// system include files
+#include <memory>
+
+// user include files
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "DataFormats/JetReco/interface/PFJet.h"
+#include "DataFormats/METReco/interface/MET.h"
+#include "DataFormats/METReco/interface/METCollection.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidateFwd.h"
+#include "DataFormats/ParticleFlowCandidate/interface/PFCandidate.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/BTauReco/interface/JetTag.h"
+
+#include "DataFormats/Scouting/interface/ScoutingPFJet.h"
+#include "DataFormats/Scouting/interface/ScoutingParticle.h"
+#include "DataFormats/Scouting/interface/ScoutingVertex.h"
+
+#include "DataFormats/Math/interface/deltaR.h"
+
+class HLTScoutingPFProducer : public edm::global::EDProducer<> {
+    public:
+        explicit HLTScoutingPFProducer(const edm::ParameterSet&);
+        ~HLTScoutingPFProducer();
+
+        static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+
+    private:
+        virtual void produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const override final;
+
+        const edm::EDGetTokenT<reco::PFJetCollection> pfJetCollection_;
+        const edm::EDGetTokenT<reco::JetTagCollection> pfJetTagCollection_;
+        const edm::EDGetTokenT<reco::PFCandidateCollection> pfCandidateCollection_;
+        const edm::EDGetTokenT<reco::VertexCollection> vertexCollection_;
+        const edm::EDGetTokenT<reco::METCollection> metCollection_;
+        const edm::EDGetTokenT<double> rho_;
+
+        const double pfJetPtCut;
+        const double pfJetEtaCut;
+        const double pfCandidatePtCut;
+
+        const bool doJetTags;
+        const bool doCandidates;
+        const bool doMet;
+};
+
+//
+// constructors and destructor
+//
+HLTScoutingPFProducer::HLTScoutingPFProducer(const edm::ParameterSet& iConfig):
+    pfJetCollection_(consumes<reco::PFJetCollection>(iConfig.getParameter<edm::InputTag>("pfJetCollection"))),
+    pfJetTagCollection_(consumes<reco::JetTagCollection>(iConfig.getParameter<edm::InputTag>("pfJetTagCollection"))),
+    pfCandidateCollection_(consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandidateCollection"))),
+    vertexCollection_(consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexCollection"))),
+    metCollection_(consumes<reco::METCollection>(iConfig.getParameter<edm::InputTag>("metCollection"))),
+    rho_(consumes<double>(iConfig.getParameter<edm::InputTag>("rho"))),
+    pfJetPtCut(iConfig.getParameter<double>("pfJetPtCut")),
+    pfJetEtaCut(iConfig.getParameter<double>("pfJetEtaCut")),
+    pfCandidatePtCut(iConfig.getParameter<double>("pfCandidatePtCut")),
+    doJetTags(iConfig.getParameter<bool>("doJetTags")),
+    doCandidates(iConfig.getParameter<bool>("doCandidates")),
+    doMet(iConfig.getParameter<bool>("doMet"))
+{
+    //register products
+    produces<ScoutingPFJetCollection>();
+    produces<ScoutingParticleCollection>();
+    produces<ScoutingVertexCollection>();
+    produces<double>("rho");
+    produces<double>("pfMetPt");
+    produces<double>("pfMetPhi");
+}
+
+HLTScoutingPFProducer::~HLTScoutingPFProducer()
+{ }
+
+// ------------ method called to produce the data  ------------
+void HLTScoutingPFProducer::produce(edm::StreamID sid, edm::Event & iEvent, edm::EventSetup const & setup) const
+{
+    using namespace edm;
+
+    //get PF jets
+    Handle<reco::PFJetCollection> pfJetCollection;
+    if(!iEvent.getByToken(pfJetCollection_, pfJetCollection)){
+        edm::LogError ("HLTScoutingPFProducer") << "invalid collection: pfJetCollection" << "\n";
+        return;
+    }
+    //get PF jet tags
+    Handle<reco::JetTagCollection> pfJetTagCollection;
+    if(doJetTags && !iEvent.getByToken(pfJetTagCollection_, pfJetTagCollection)){
+        edm::LogError ("HLTScoutingPFProducer") << "invalid collection: pfJetTagCollection" << "\n";
+        return;
+    }
+    //get PF candidates
+    Handle<reco::PFCandidateCollection> pfCandidateCollection;
+    if(doCandidates && !iEvent.getByToken(pfCandidateCollection_, pfCandidateCollection)){
+        edm::LogError ("HLTScoutingPFProducer") << "invalid collection: pfCandidateCollection" << "\n";
+        return;
+    }
+    //get vertices
+    Handle<reco::VertexCollection> vertexCollection;
+    if(!iEvent.getByToken(vertexCollection_, vertexCollection)){
+        edm::LogError ("HLTScoutingPFProducer") << "invalid collection: vertexCollection" << "\n";
+        return;
+    }
+    //get rho
+    Handle<double> rho;
+    if(!iEvent.getByToken(rho_, rho)){
+        edm::LogError ("HLTScoutingPFProducer") << "invalid collection: rho" << "\n";
+        return;
+    }
+    std::auto_ptr<double> outRho(new double(*rho));
+    //get MET
+    Handle<reco::METCollection> metCollection;
+    if(doMet && !iEvent.getByToken(metCollection_, metCollection)){
+        edm::LogError ("HLTScoutingPFProducer") << "invalid collection: metCollection" << "\n";
+        return;
+    }
+
+    //produce vertices
+    std::auto_ptr<ScoutingVertexCollection> outVertices(new ScoutingVertexCollection());
+    for(auto &vtx : *vertexCollection){
+        outVertices->emplace_back(
+                vtx.x(), vtx.y(), vtx.z(), vtx.zError()
+                );
+    }
+
+    //produce PF candidates
+    std::auto_ptr<ScoutingParticleCollection> outPFCandidates(new ScoutingParticleCollection());
+    if(doCandidates){
+        for(auto &cand : *pfCandidateCollection){
+            if(cand.pt() > pfCandidatePtCut){
+                outPFCandidates->emplace_back(
+                        cand.pt(), cand.eta(), cand.phi(), cand.mass(), cand.pdgId()
+                        );
+            }
+        }
+    }
+    
+    //produce PF jets
+    std::auto_ptr<ScoutingPFJetCollection> outPFJets(new ScoutingPFJetCollection());
+    for(auto &jet : *pfJetCollection){
+        if(jet.pt() < pfJetPtCut || fabs(jet.eta()) > pfJetEtaCut) continue;
+        //find the jet tag corresponding to the jet
+        float tagValue = -20;
+        float minDR2 = 0.01;
+        if(doJetTags){
+            for(auto &tag : *pfJetTagCollection){
+                float dR2 = reco::deltaR2(jet, *(tag.first));
+                if(dR2 < minDR2){
+                    minDR2 = dR2;
+                    tagValue = tag.second;
+                }
+            }
+        }
+        //get the PF constituents of the jet
+        std::vector<int> candIndices;
+        if(doCandidates){
+            for(auto &cand : jet.getPFConstituents()){
+                if(cand->pt() > pfCandidatePtCut){
+                    //search for the candidate in the collection
+                    float minDR2 = 0.0001;
+                    int matchIndex = -1;
+                    int outIndex = 0;
+                    for(auto &outCand : *outPFCandidates){
+                        float dR2 = pow(cand->eta() - outCand.eta(), 2) + pow(cand->phi() - outCand.phi(), 2);
+                        if(dR2 < minDR2){
+                            minDR2 = dR2;
+                            matchIndex = outIndex;
+                        }
+                        if(minDR2 == 0){
+                            break;
+                        }
+                        outIndex++;
+                    }
+                    candIndices.push_back(matchIndex);
+                }
+            }
+        }
+        outPFJets->emplace_back(
+                    jet.pt(), jet.eta(), jet.phi(), jet.mass(), jet.jetArea(),
+                    jet.chargedHadronEnergy(), jet.neutralHadronEnergy(), jet.photonEnergy(),
+                    jet.electronEnergy(), jet.muonEnergy(), jet.HFHadronEnergy(), jet.HFEMEnergy(),
+                    jet.chargedHadronMultiplicity(), jet.neutralHadronMultiplicity(), jet.photonMultiplicity(),
+                    jet.electronMultiplicity(), jet.muonMultiplicity(), 
+                    jet.HFHadronMultiplicity(), jet.HFEMMultiplicity(), 
+                    jet.hoEnergy(), tagValue, 0.0, candIndices
+                    );
+    }
+
+    double metPt = -999;
+    double metPhi = -999;
+    if(doMet){
+        metPt = metCollection->front().pt();
+        metPhi = metCollection->front().phi();
+    }
+    std::auto_ptr<double> outMetPt(new double(metPt));
+    std::auto_ptr<double> outMetPhi(new double(metPhi));
+
+
+    //put output
+    iEvent.put(outVertices);
+    iEvent.put(outPFCandidates);
+    iEvent.put(outPFJets);
+    iEvent.put(outRho, "rho");
+    iEvent.put(outMetPt, "pfMetPt");
+    iEvent.put(outMetPhi, "pfMetPhi");
+}
+
+// ------------ method fills 'descriptions' with the allowed parameters for the module  ------------
+void HLTScoutingPFProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+    edm::ParameterSetDescription desc;
+    desc.add<edm::InputTag>("pfJetCollection",edm::InputTag("hltAK4PFJets"));
+    desc.add<edm::InputTag>("pfJetTagCollection",edm::InputTag("hltCombinedSecondaryVertexBJetTagsPF"));
+    desc.add<edm::InputTag>("pfCandidateCollection", edm::InputTag("hltParticleFlow"));
+    desc.add<edm::InputTag>("vertexCollection", edm::InputTag("hltPixelVertices"));
+    desc.add<edm::InputTag>("metCollection", edm::InputTag("hltPFMETProducer"));
+    desc.add<edm::InputTag>("rho", edm::InputTag("hltFixedGridRhoFastjetAll"));
+    desc.add<double>("pfJetPtCut", 20.0);
+    desc.add<double>("pfJetEtaCut", 3.0);
+    desc.add<double>("pfCandidatePtCut", 0.6);
+    desc.add<bool>("doJetTags", true);
+    desc.add<bool>("doCandidates", true);
+    desc.add<bool>("doMet", true);
+    descriptions.add("hltScoutingPFProducer", desc);
+}
+
+//define this as a plug-in
+DEFINE_FWK_MODULE(HLTScoutingPFProducer);


### PR DESCRIPTION
-Adding a package DataFormats/DataScouting with new scouting object classes (ScoutingCaloJet, ScoutingPFJet, ScoutingParticle, ScoutingVertex)

-Adding a package HLTrigger/DataScouting with producers for the scouting objects (ScoutingPFProducer, ScoutingCaloProducer)
