### PR TITLE
Corrected electron response for CASTOR

### DIFF
--- a/SimG4Core/Application/python/g4SimHits_cfi.py
+++ b/SimG4Core/Application/python/g4SimHits_cfi.py
@@ -361,7 +361,7 @@ g4SimHits = cms.EDProducer("OscarMTProducer",
     CastorSD = cms.PSet(
         useShowerLibrary               = cms.bool(True),
         minEnergyInGeVforUsingSLibrary = cms.double(1.0),
-        nonCompensationFactor          = cms.double(0.85),
+        nonCompensationFactor          = cms.double(0.817),
         Verbosity                      = cms.untracked.int32(0)
     ),
     CastorShowerLibrary =  cms.PSet(

--- a/SimGeneral/MixingModule/python/castorDigitizer_cfi.py
+++ b/SimGeneral/MixingModule/python/castorDigitizer_cfi.py
@@ -9,7 +9,7 @@ castorDigitizer = cms.PSet(
     castor = cms.PSet(
         readoutFrameSize = cms.int32(6),
         binOfMaximum = cms.int32(5),
-        samplingFactor = cms.double(0.060135), ## GeV/pe
+        samplingFactor = cms.double(0.062577), ## GeV/pe
 
         doPhotoStatistics = cms.bool(True),
         photoelectronsToAnalog = cms.double(4.009),


### PR DESCRIPTION
Increased **sampling factor** of CASTOR by multiplying it with **a correction factor 1.04061** and divided the **noncompensation factor** of CASTOR with the same factor. As a result, the energy response of CASTOR to electromagnetic particles is increased, while the hadronic response stays unchanged. 

The reason for this change is that the electromagnetic response of CASTOR was too low from CMSSW_7_X upwards. The correction factor was chosen so that in simulations of electron particle beams the reconstructed response (E_REC) divided by the generated energy (E_GEN) becomes 1. In these simulations the dead material in front of CASTOR was disabled, because this corresponds to the test beam data used for the CASTOR calibration. 

That means that in the plot shown below, which was created in CMSSW_7_1_0 without the changes introduced by this commit, the  magenta points (corresponding to the test beam) should be at E_REC/E_GEN =1. With the changes introduced by this commit, this is the case.
![electron_response_diff_cmssw_labelled](https://cloud.githubusercontent.com/assets/5121824/8854620/0979d45c-3161-11e5-96ba-20aee1f4df31.png)
