### PR TITLE
Enhancements to GBRForest/Tree for converting TMVA classifiers

### DIFF
--- a/CondFormats/EgammaObjects/interface/GBRForest.h
+++ b/CondFormats/EgammaObjects/interface/GBRForest.h
@@ -36,7 +36,11 @@
        virtual ~GBRForest();
        
        double GetResponse(const float* vector) const;
-       double GetClassifier(const float* vector) const;
+       double GetGradBoostClassifier(const float* vector) const;
+       double GetAdaBoostClassifier(const float* vector) const { return GetResponse(vector); }
+       
+       //for backwards-compatibility
+       double GetClassifier(const float* vector) const { return GetGradBoostClassifier(vector); }
        
        void SetInitialResponse(double response) { fInitialResponse = response; }
        
@@ -61,7 +65,7 @@ inline double GBRForest::GetResponse(const float* vector) const {
 }
 
 //_______________________________________________________________________
-inline double GBRForest::GetClassifier(const float* vector) const {
+inline double GBRForest::GetGradBoostClassifier(const float* vector) const {
   double response = GetResponse(vector);
   return 2.0/(1.0+exp(-2.0*response))-1; //MVA output between -1 and 1
 }

--- a/CondFormats/EgammaObjects/interface/GBRTree.h
+++ b/CondFormats/EgammaObjects/interface/GBRTree.h
@@ -38,7 +38,7 @@
     public:
 
        GBRTree();
-       explicit GBRTree(const TMVA::DecisionTree *tree);
+       explicit GBRTree(const TMVA::DecisionTree *tree, double scale, bool useyesnoleaf, bool adjustboundary);
        virtual ~GBRTree();
        
        double GetResponse(const float* vector) const;
@@ -65,7 +65,7 @@
         unsigned int CountIntermediateNodes(const TMVA::DecisionTreeNode *node);
         unsigned int CountTerminalNodes(const TMVA::DecisionTreeNode *node);
       
-        void AddNode(const TMVA::DecisionTreeNode *node);
+        void AddNode(const TMVA::DecisionTreeNode *node, double scale, bool isregression, bool useyesnoleaf, bool adjustboundary);
         
 	std::vector<unsigned char> fCutIndices;
 	std::vector<float> fCutVals;


### PR DESCRIPTION
add support for adaboost bdt classifiers, and add workaround for inconsistent behaviour of TMVA decision tree evaluation in different root versions

Note that TMVA "category" functionality is still not supported.

Any BDT which has been trained in CMSSW 74x or later and which has been converted to GBRForest using an earlier version of the code should be converted again to make sure > vs >= is treated consistently.

Older BDT's do not need to be reconverted as they will already have the correct behaviour when evaluated using GBRForest (but may have small numerical differences when evaluating using recent versions of root/tmva directly)
