### PR TITLE
Updating Global Tags with latest requests by L1, Pixel, Geometry and BTV (as in #10285)

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '75X_mcRun1_design_v1',
+    'run1_design'       :   '75X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '75X_mcRun1_realistic_v1',
+    'run1_mc'           :   '75X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v1',
+    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '75X_mcRun1_pA_v1',
+    'run1_mc_pa'        :   '75X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v1',
+    'run2_design'       :   '75X_mcRun2_design_v2',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '75X_mcRun2_startup_v1',
+    'run2_mc_50ns'      :   '75X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v1',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v1',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v2',
+    'run1_data'         :   '75X_dataRun1_v3',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v2',
+    'run2_data'         :   '75X_dataRun2_v3',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '75X_dataRun1_HLT_v1',
+    'run1_hlt'          :   '75X_dataRun1_HLT_v2',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '75X_dataRun2_HLT_v1',
+    'run2_hlt'          :   '75X_dataRun2_HLT_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# List of Changes
- Run1 Ideal Simulation `75X_mcRun1_design_v2`: as `75X_mcRun1_design_v1` with
  - updated training of b-tagging discriminators 
  - updated HCAL spec pars, adding extra constants and regexps for selection (no changes in geometry). 
- Run1 Realistic Simulation `75X_mcRun1_realistic_v2` as: `75X_mcRun1_realistic_v1` with
  - updated training of b-tagging discriminators 
  - updated HCAL spec pars, adding extra constants and regexps for selection (no changes in geometry). 
- Run1 Heavy Simulation `75X_mcRun1_HeavyIon_v2` as: `75X_mcRun1_HeavyIon_v1` with
  - updated training of b-tagging discriminators 
  - updated HCAL spec pars, adding extra constants and regexps for selection (no changes in geometry). 
- Run1 proton-Lead Simulation `75X_mcRun1_pA_v2`: as `75X_mcRun1_pA_v1` with
  - updated training of b-tagging discriminators 
    *updated HCAL spec pars, adding extra constants and regexps for selection (no changes in geometry). 
- Run2 startup Simulation `75X_mcRun2_startup_v2`: as  `75X_mcRun1_startup_v1` with
  - updated training of b-tagging discriminators 
  - updated HCAL spec pars, adding extra constants and regexps for selection (no changes in geometry) in all supported scenario (including dev) 
  - updated L1 Global Trigger Menu (v4) 
  - updated Global Muon Trigger parameter 
  - updated Pixel dead channels map from 3.8T 2015B collisions.  
- Run2 asymptotic Simulation `75X_mcRun2_asymptotic_v2`: as `75X_mcRun1_asymptotic_v1` with
  - updated training of b-tagging discriminators 
  - updated HCAL spec pars, adding extra constants and regexps for selection (no changes in geometry) in all supported scenario (including dev) 
  - updated Global Muon Trigger parameter 
  - updated Pixel dead channels map from 3.8T 2015B collisions.  
- Run2 Heavy Ion Simulation `75X_mcRun2_HeavyIon_v2`: as `75X_mcRun1_HeavyIon_v1` with 
  - updated training of b-tagging discriminators 
  - updated HCAL spec pars, adding extra constants and regexps for selection (no changes in geometry) in all supported scenario (including dev)  
  - updated Global Muon Trigger parameter 
  - updated Pixel dead channels map from 3.8T 2015B collisions 
  - updated L1 Global Trigger Menu (`CollisionsHeavyIons2011_v0_nobsc_notau_centrality_q2_singletrack.v1`)  
  - fixed SiPixelDynamic inefficiency to use flat .999 efficiency payload.  
- Run2 data HLT processing `75X_dataRun2_HLT_v2`:  as `75X_dataRun2_HLT_v1` with
  - updated training of b-tagging discriminators. 
- Run1 data HLT processing `75X_dataRun1_HLT_v2` as `75X_dataRun1_HLT_v1` with 
  - updated training of b-tagging discriminators. 
- Run2 data offline processing `75X_dataRun2_v3` as `75X_dataRun2_v2` with
  - updated training of b-tagging discriminators. 
- Run1 data offline processing `75X_dataRun1_v3` as `75X_dataRun1_v2` with 
  - updated training of b-tagging discriminators. 
