### PR TITLE
Improve LHEReader IO (and optimize skipping events)

### DIFF
--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -477,11 +477,6 @@ LHEReader::~LHEReader()
       XMLHandler::Object event = handler->gotObject;
       handler->gotObject = XMLHandler::kNone;
     
-      std::istringstream data;
-      if (event != XMLHandler::kNone) {
-        data.str(handler->buffer);
-        handler->buffer.clear();
-      }
         
       switch(event) {
       case XMLHandler::kNone:
@@ -496,6 +491,11 @@ LHEReader::~LHEReader()
         break;
         
       case XMLHandler::kInit:
+	{
+	std::istringstream data;
+	data.str(handler->buffer);
+	handler->buffer.clear();
+
         curRunInfo.reset(new LHERunInfo(data));
 		
         std::for_each(handler->headers.begin(),
@@ -503,12 +503,14 @@ LHEReader::~LHEReader()
                       boost::bind(&LHERunInfo::addHeader,
                                   curRunInfo.get(), _1));
         handler->headers.clear();
+	}
         break;
         
       case XMLHandler::kComment:
         break;
         
       case XMLHandler::kEvent:
+	{
         if (!curRunInfo.get())
           throw cms::Exception("InvalidState")
             << "Got LHE event without"
@@ -523,6 +525,10 @@ LHEReader::~LHEReader()
           return boost::shared_ptr<LHEEvent>();
         else if (maxEvents > 0)
           maxEvents--;
+
+	std::istringstream data;
+	data.str(handler->buffer);
+	handler->buffer.clear();
 
 	boost::shared_ptr<LHEEvent> lheevent;
 	lheevent.reset(new LHEEvent(curRunInfo, data));
@@ -539,6 +545,7 @@ LHEReader::~LHEReader()
           lheevent->setScales(handler->scales);
         }
         return lheevent;
+	}
       }
     }
     

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.cc
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <memory>
 #include <string>
+#include <vector>
 #include <cstring>
 
 #include "FWCore/Concurrency/interface/Xerces.h"
@@ -10,6 +11,7 @@
 #include <xercesc/sax2/XMLReaderFactory.hpp>
 
 #include "FWCore/Utilities/interface/Exception.h"
+#include "FWCore/Utilities/interface/EDMException.h"
 
 #include "Utilities/StorageFactory/interface/IOTypes.h"
 #include "Utilities/StorageFactory/interface/Storage.h"
@@ -206,11 +208,9 @@ StorageInputStream::StorageInputStream(StorageWrap &in) :
 	in(in),
         lstr(LZMA_STREAM_INIT),
         compression_(false),
-        lasttotal_(0),
-	buffLoc_(0),
-	buffTotal_(0)
-
+        lasttotal_(0)
 {
+   buffer_.reserve(bufferSize_);
   // Check the kind of file.
   char header[6];
   /*unsigned int s = */ in->read(header, 6);
@@ -245,71 +245,67 @@ StorageInputStream::~StorageInputStream()
   lzma_end(&(lstr));
 }
 
-unsigned int StorageInputStream::readBytes(XMLByte* const buf,
-                                           const unsigned int size)
+
+unsigned int StorageInputStream::readBytes(XMLByte* const buf, const unsigned int size)
 {
-  // Simple read-in write-out in case
-  if (!compression_)
-  {
-    void *rawBuf = reinterpret_cast<void*>(buf);
-    unsigned int bytes = size * sizeof(XMLByte);
-    unsigned int readBytes = in->read(rawBuf, bytes);
+        // Compression code is not able to handle sizeof(XMLByte) > 1.
+    assert(sizeof(XMLByte) == sizeof(unsigned char));
 
-    unsigned int read = (unsigned int)(readBytes / sizeof(XMLByte));
-    unsigned int rest = (unsigned int)(readBytes % sizeof(XMLByte));
-    if (rest)
-      in->position(-(IOOffset)rest, Storage::CURRENT);
-
-    /*for (unsigned int i = 0; i < read; ++i){
-      std::cout << buf[i] ;
-    }*/
- 
-    pos += read;
-    return read;
-  }
-  // Compressed case. 
-  // We simply read as many bytes as we can and we 
-  // uncompress them in the output buffer.
-  // We never decompress more bytes we were asked by
-  // xerces. 
-  // In case we read from file more bytes than needed 
-  // we simply rollback by the (hopefully) correct amount.
-  // If we don't read enough bytes, we simply return
-  // the amount of bytes read and we wait for being called
-  // again by xerces.
-  unsigned int bytes = size * sizeof(XMLByte);
-  if ( !( buffLoc_<buffTotal_)) {
-
-    unsigned int rd = in->read((void*)bufferCom_, sizeof(bufferCom_));
-    lstr.next_in = bufferCom_;
-    lstr.avail_in = rd;
-    lstr.next_out = bufferUnc_;
-    lstr.avail_out = sizeof(bufferUnc_);//bytes;
-    buffLoc_=0;
-
-    int ret = lzma_code(&lstr, LZMA_RUN);
-    if(ret != LZMA_OK && ret != LZMA_STREAM_END) {  /* decompression error */
-      lzma_end(&lstr);
-      throw cms::Exception("IO") << "Error while reading compressed LHE file";
+    if (! (buffLoc_ < buffTotal_) )
+    {
+        int rd = in->read((void*)&buffer_[0], buffer_.capacity());
+             // Storage layer is supposed to throw exceptions instead of returning errors; just-in-case
+        if (rd < 0)
+        {
+            edm::Exception ex(edm::errors::FileReadError);
+            ex << "Error while reading buffered LHE file";
+            throw ex;
+        }
+        buffLoc_=0;
+        buffTotal_=rd;
+        std::cout << "Total buffer data read: " << buffTotal_ << std::endl;
+        if (buffTotal_ == 0)
+        {
+            return 0;
+        }
     }
-  // If we did not consume everything we put it back.
-//  std::cout << "lstr.avail_in " << lstr.avail_in << " lstr.total_in " << lstr.total_in << std::endl;
-//  std::cout << "lstr.avail_out " << lstr.avail_out << " lstr.total_out " << lstr.total_out << std::endl;
-    if (lstr.avail_in){
-//    std::cout << "rolling back" << std::endl;
-      in->position(-(IOOffset)(lstr.avail_in), Storage::CURRENT);    
-    }  
-    pos = lstr.total_out;
-    buffTotal_= lstr.total_out - lasttotal_;
-    lasttotal_ = lstr.total_out;
-    buffLoc_=0;
-  }
-  //now return whats needed
-  unsigned int read=std::min(buffTotal_-buffLoc_,bytes);
-  void *rawBuf = reinterpret_cast<void*>(buf);
-  memcpy(rawBuf,&bufferUnc_[buffLoc_],bytes);
-  buffLoc_+=read;
-  return read;
+    unsigned int dataRead;
+    if (!compression_)
+    {
+        dataRead = std::min(buffTotal_-buffLoc_, size);
+        memcpy(buf, &buffer_[buffLoc_], dataRead);
+        buffLoc_ += dataRead;
+    }
+    else
+    {
+        dataRead = buffTotal_-buffLoc_;
+        lstr.next_in = &buffer_[buffLoc_];
+        lstr.avail_in = dataRead;
+        lstr.next_out = buf;
+        lstr.avail_out = size;
+        int ret = lzma_code(&lstr, LZMA_RUN);
+        if(ret != LZMA_OK && ret != LZMA_STREAM_END)
+        {  /* decompression error */
+            lzma_end(&lstr);
+            throw cms::Exception("IO") << "Error while reading compressed LHE file (error code " << ret << ")";
+        }
+        dataRead -= lstr.avail_in;
+        buffLoc_ += dataRead;
+            // Decoder was unable to make progress; reset stream and try again.
+            // If this becomes problematic, we can make the buffer circular.
+        if (!dataRead)
+        {
+            std::cout << "Unable to decompress any bytes." << std::endl;
+                // NOTE: lstr.avail_in == buffTotal-buffLoc_
+            in->position(-(IOOffset)(lstr.avail_in), Storage::CURRENT);
+            buffLoc_ = 0;
+            buffTotal_ = 0;
+            return readBytes(buf, size);
+        }
+        dataRead = (size - lstr.avail_out);
+    }
+    //std::cout << "Read " << dataRead << " bytes into output buffer." << std::endl;
+    return dataRead;
 }
 
 } // namespace lhef

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.cc
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.cc
@@ -263,7 +263,6 @@ unsigned int StorageInputStream::readBytes(XMLByte* const buf, const unsigned in
         }
         buffLoc_=0;
         buffTotal_=rd;
-        std::cout << "Total buffer data read: " << buffTotal_ << std::endl;
         if (buffTotal_ == 0)
         {
             return 0;
@@ -295,7 +294,6 @@ unsigned int StorageInputStream::readBytes(XMLByte* const buf, const unsigned in
             // If this becomes problematic, we can make the buffer circular.
         if (!dataRead)
         {
-            std::cout << "Unable to decompress any bytes." << std::endl;
                 // NOTE: lstr.avail_in == buffTotal-buffLoc_
             in->position(-(IOOffset)(lstr.avail_in), Storage::CURRENT);
             buffLoc_ = 0;
@@ -304,7 +302,6 @@ unsigned int StorageInputStream::readBytes(XMLByte* const buf, const unsigned in
         }
         dataRead = (size - lstr.avail_out);
     }
-    //std::cout << "Read " << dataRead << " bytes into output buffer." << std::endl;
     return dataRead;
 }
 

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.cc
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.cc
@@ -17,7 +17,6 @@
 #include "XMLUtils.h"
 
 XERCES_CPP_NAMESPACE_USE
-#define BUF_SIZE 8192 
 
 namespace lhef {
 
@@ -207,7 +206,10 @@ StorageInputStream::StorageInputStream(StorageWrap &in) :
 	in(in),
         lstr(LZMA_STREAM_INIT),
         compression_(false),
-        lasttotal_(0)
+        lasttotal_(0),
+	buffLoc_(0),
+	buffTotal_(0)
+
 {
   // Check the kind of file.
   char header[6];
@@ -276,33 +278,37 @@ unsigned int StorageInputStream::readBytes(XMLByte* const buf,
   // the amount of bytes read and we wait for being called
   // again by xerces.
   unsigned int bytes = size * sizeof(XMLByte);
-//  std::cout << "bites " << bytes << std::endl;
-  uint8_t inBuf[BUF_SIZE];
-  unsigned int rd = in->read((void*)inBuf, BUF_SIZE);
-  lstr.next_in = inBuf;
-  lstr.avail_in = rd;
-  lstr.next_out = buf;
-  lstr.avail_out = bytes;
-/*  for (unsigned int i = 0; i < size; ++i){
-    std::cout << buf[i] ;
-  }  
-  std::cout << std::endl;*/
+  if ( !( buffLoc_<buffTotal_)) {
 
-  int ret = lzma_code(&lstr, LZMA_RUN);
-  if(ret != LZMA_OK && ret != LZMA_STREAM_END) {  /* decompression error */
-    lzma_end(&lstr);
-    throw cms::Exception("IO") << "Error while reading compressed LHE file";
-  }
+    unsigned int rd = in->read((void*)bufferCom_, sizeof(bufferCom_));
+    lstr.next_in = bufferCom_;
+    lstr.avail_in = rd;
+    lstr.next_out = bufferUnc_;
+    lstr.avail_out = sizeof(bufferUnc_);//bytes;
+    buffLoc_=0;
+
+    int ret = lzma_code(&lstr, LZMA_RUN);
+    if(ret != LZMA_OK && ret != LZMA_STREAM_END) {  /* decompression error */
+      lzma_end(&lstr);
+      throw cms::Exception("IO") << "Error while reading compressed LHE file";
+    }
   // If we did not consume everything we put it back.
 //  std::cout << "lstr.avail_in " << lstr.avail_in << " lstr.total_in " << lstr.total_in << std::endl;
 //  std::cout << "lstr.avail_out " << lstr.avail_out << " lstr.total_out " << lstr.total_out << std::endl;
-  if (lstr.avail_in){
+    if (lstr.avail_in){
 //    std::cout << "rolling back" << std::endl;
-    in->position(-(IOOffset)(lstr.avail_in), Storage::CURRENT);    
-  }  
-  pos = lstr.total_out;
-  unsigned int read = lstr.total_out - lasttotal_;
-  lasttotal_ = lstr.total_out;
+      in->position(-(IOOffset)(lstr.avail_in), Storage::CURRENT);    
+    }  
+    pos = lstr.total_out;
+    buffTotal_= lstr.total_out - lasttotal_;
+    lasttotal_ = lstr.total_out;
+    buffLoc_=0;
+  }
+  //now return whats needed
+  unsigned int read=std::min(buffTotal_-buffLoc_,bytes);
+  void *rawBuf = reinterpret_cast<void*>(buf);
+  memcpy(rawBuf,&bufferUnc_[buffLoc_],bytes);
+  buffLoc_+=read;
   return read;
 }
 

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.h
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.h
@@ -185,9 +185,9 @@ class StorageInputStream :
         bool            compression_;
         unsigned int    lasttotal_;
 
-	uint8_t bufferCom_[16777216];
-	uint8_t bufferUnc_[134217728];
-	unsigned int buffLoc_,buffSize_,buffTotal_;
+        unsigned int buffLoc_ = 0,buffTotal_ = 0;
+        std::vector<uint8_t> buffer_;
+        static constexpr unsigned bufferSize_ = 16*1024*1024;
 };
 
 typedef XMLInputSourceWrapper<CBInputStream> CBInputSource;

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.h
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.h
@@ -15,6 +15,7 @@
 #include <xercesc/sax2/SAX2XMLReader.hpp>
 #include <lzma.h>
 
+
 class Storage;
 
 namespace lhef {
@@ -183,6 +184,10 @@ class StorageInputStream :
         lzma_stream     lstr;
         bool            compression_;
         unsigned int    lasttotal_;
+
+	uint8_t bufferCom_[16777216];
+	uint8_t bufferUnc_[134217728];
+	unsigned int buffLoc_,buffSize_,buffTotal_;
 };
 
 typedef XMLInputSourceWrapper<CBInputStream> CBInputSource;


### PR DESCRIPTION
This branch does two things:
1.  Buffers LHEReader IO along 16MB boundaries (both compressed and uncompressed cases).
2.  Skips parsing of events that will be skipped.

When testing (2), I found there was 1.8x speedup when reading compressed files and 1.9x speedup when reading uncompressed files.  This suggests, when there is efficient IO, we are dominated by XML parsing times (not decompression times).

@davidlange6 @bendavid 
