### PR TITLE
Fix return type in vid::CutFlowResult accessor

### DIFF
--- a/DataFormats/PatCandidates/interface/VIDCutFlowResult.h
+++ b/DataFormats/PatCandidates/interface/VIDCutFlowResult.h
@@ -103,7 +103,7 @@ namespace vid {
       return (bool)(0x1&(bitmap_>>idx)); 
     }
 
-    bool getCutValue(const unsigned idx) const {
+    double getCutValue(const unsigned idx) const {
       return values_[idx];
     } 
   };


### PR DESCRIPTION
Fixes a bug pointed out by Peter Hansen.
