### PR TITLE
fix of pede job submission issue

### DIFF
--- a/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
+++ b/Alignment/MillePedeAlignmentAlgorithm/scripts/mps_runPede_rfcp_template.sh
@@ -7,6 +7,10 @@
 #temporary fix (?):
 #unset PYTHONHOME
 
+cd $CMSSW_BASE/src
+eval `scramv1 runtime -sh`
+cd -
+
 # these defaults will be overwritten by MPS
 RUNDIR=$HOME/scratch0/some/path
 MSSDIR=/castor/cern.ch/user/u/username/another/path


### PR DESCRIPTION
There was an issue in the submission of the Pede job due to a conflict in the use of environment variables set by CMSSW and needed for cmsStageIn/xrdcp. This can be fixed by resetting the CMSSW environment inside of the bash script executed by the Pede job.
