### PR TITLE
Remove vestigial (and huge) GBRForest when running with PFEGAlgo

### DIFF
--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.cc
@@ -207,7 +207,9 @@ PFEGammaProducer::beginRun(const edm::Run & run,
                      const edm::EventSetup & es) 
 {
 
+  /* // kept for historical reasons
   if(useRegressionFromDB_) {
+    
     edm::ESHandle<GBRForest> readerPFLCEB;
     edm::ESHandle<GBRForest> readerPFLCEE;    
     edm::ESHandle<GBRForest> readerPFGCEB;
@@ -227,11 +229,11 @@ PFEGammaProducer::beginRun(const edm::Run & run,
     es.get<GBRWrapperRcd>().get("PFEcalResolution",readerPFRes);
     ReaderEcalRes_=readerPFRes.product();
 
-    /*
+    
     LogDebug("PFEGammaProducer")<<"setting regressions from DB "<<std::endl;
-    */
+    
   } 
-
+  */
 
   //pfAlgo_->setPFPhotonRegWeights(ReaderLC_, ReaderGC_, ReaderRes_);
     

--- a/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
+++ b/RecoParticleFlow/PFProducer/plugins/PFEGammaProducer.h
@@ -81,12 +81,12 @@ class PFEGammaProducer : public edm::stream::EDProducer<> {
   const GBRForest* ReaderGC_;
   const GBRForest* ReaderLC_;
   const GBRForest* ReaderRes_;
-  const GBRForest* ReaderLCEB_;
-  const GBRForest* ReaderLCEE_;
-  const GBRForest* ReaderGCBarrel_;
-  const GBRForest* ReaderGCEndCapHighr9_;
-  const GBRForest* ReaderGCEndCapLowr9_;
-  const GBRForest* ReaderEcalRes_;
+  //const GBRForest* ReaderLCEB_;
+  //const GBRForest* ReaderLCEE_;
+  //const GBRForest* ReaderGCBarrel_;
+  //const GBRForest* ReaderGCEndCapHighr9_;
+  //const GBRForest* ReaderGCEndCapLowr9_;
+  //const GBRForest* ReaderEcalRes_;
   // what about e/g electrons ?
   bool useEGammaElectrons_;
 

--- a/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
+++ b/RecoParticleFlow/PFProducer/plugins/PFProducer.cc
@@ -454,7 +454,7 @@ PFProducer::beginRun(const edm::Run & run,
   }
   */
   
-  if(useRegressionFromDB_) {
+  if(usePFPhotons_ && useRegressionFromDB_) {
     edm::ESHandle<GBRForest> readerPFLCEB;
     edm::ESHandle<GBRForest> readerPFLCEE;    
     edm::ESHandle<GBRForest> readerPFGCEB;


### PR DESCRIPTION
Saves ~100MB of memory overhead according to igprof MEM_LIVE after first event.

No changes to physics output expected.

Old:

```
10.5    140'818'407         77'153  clang::Parser::ParseDeclOrFunctionDefInternal(clang::Parser::ParsedAttributesWithRange&, clang::ParsingDeclSpec&, clang::AccessSpecifier) [105]
10.0    134'139'135        199'426  edm::eventsetup::DataProxyTemplate<GBRWrapperRcd, GBRForest>::getImpl(edm::eventsetup::EventSetupRecord const&, edm::eventsetup::DataKey const&) [108]
```

New:

```
11.4    140'085'223         77'146  clang::Parser::ParseDeclOrFunctionDefInternal(clang::Parser::ParsedAttributesWithRange&, clang::ParsingDeclSpec&, clang::AccessSpecifier) [107]
2.4     29'917'165        139'396  edm::eventsetup::DataProxyTemplate<GBRWrapperRcd, GBRForest>::getImpl(edm::eventsetup::EventSetupRecord const&, edm::eventsetup::DataKey const&) [359]
```
