### PR TITLE
Rivet consumes migration backport to 75X

### DIFF
--- a/GeneratorInterface/RivetInterface/interface/RivetAnalyzer.h
+++ b/GeneratorInterface/RivetInterface/interface/RivetAnalyzer.h
@@ -2,27 +2,20 @@
 #define GeneratorInterface_RivetInterface_RivetAnalyzer
 
 #include "FWCore/Framework/interface/EDAnalyzer.h"
-#include "FWCore/Utilities/interface/InputTag.h"
 #include "Rivet/AnalysisHandler.hh"
 
 //DQM services
 #include "DQMServices/Core/interface/DQMStore.h"
-#include "FWCore/ServiceRegistry/interface/Service.h"
 #include "DQMServices/Core/interface/MonitorElement.h"
 
-#include "Rivet/Tools/RivetYODA.hh"
-#include "YODA/ROOTCnv.h"
+#include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
+#include "Rivet/Tools/RivetYODA.hh"
+//#include "YODA/ROOTCnv.h"
 
 #include <vector>
 #include <string>
-
-namespace edm{
-  class ParameterSet;
-  class Event;
-  class EventSetup;
-  class InputTag;
-}
 
 class RivetAnalyzer : public edm::EDAnalyzer
 {
@@ -31,23 +24,23 @@ class RivetAnalyzer : public edm::EDAnalyzer
 
   virtual ~RivetAnalyzer();
 
-  virtual void beginJob();
+  virtual void beginJob() override;
 
-  virtual void endJob();  
+  virtual void endJob() override;
 
-  virtual void analyze(const edm::Event&, const edm::EventSetup&);
+  virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
 
-  virtual void endRun(const edm::Run&, const edm::EventSetup&);
+  virtual void endRun(const edm::Run&, const edm::EventSetup&) override;
   
   private:
 
   void normalizeTree();
 
-  edm::InputTag            _hepmcCollection;
+  edm::EDGetTokenT<edm::HepMCProduct> _hepmcCollection;
   bool                     _useExternalWeight;
-  edm::InputTag            _genEventInfoCollection;
+  edm::EDGetTokenT<GenEventInfoProduct> _genEventInfoCollection;
   Rivet::AnalysisHandler   _analysisHandler;   
   bool                     _isFirstEvent;
   std::string              _outFileName;

--- a/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
+++ b/GeneratorInterface/RivetInterface/plugins/GenParticles2HepMCConverter.cc
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -25,20 +25,20 @@
 
 using namespace std;
 
-class GenParticles2HepMCConverter : public edm::EDProducer
+class GenParticles2HepMCConverter : public edm::stream::EDProducer<>
 {
 public:
   explicit GenParticles2HepMCConverter(const edm::ParameterSet& pset);
   ~GenParticles2HepMCConverter() {};
 
-  void beginRun(edm::Run& run, const edm::EventSetup& eventSetup);
-  void produce(edm::Event& event, const edm::EventSetup& eventSetup);
+  //void beginRun(const edm::Run& run, const edm::EventSetup& eventSetup) override;
+  void produce(edm::Event& event, const edm::EventSetup& eventSetup) override;
 
 private:
-//  edm::InputTag lheEventLabel_;
-  edm::InputTag genParticlesLabel_;
-//  edm::InputTag genRunInfoLabel_;
-  edm::InputTag genEventInfoLabel_;
+//  edm::InputTag lheEventToken_;
+  edm::EDGetTokenT<reco::CandidateView> genParticlesToken_;
+//  edm::InputTag genRunInfoToken_;
+  edm::EDGetTokenT<GenEventInfoProduct> genEventInfoToken_;
   edm::ESHandle<ParticleDataTable> pTable_;
 
 private:
@@ -58,36 +58,36 @@ private:
 
 GenParticles2HepMCConverter::GenParticles2HepMCConverter(const edm::ParameterSet& pset)
 {
-//  lheEventLabel_ = pset.getParameter<edm::InputTag>("lheEvent");
-  genParticlesLabel_ = pset.getParameter<edm::InputTag>("genParticles");
-  //genRunInfoLabel_ = pset.getParameter<edm::InputTag>("genRunInfo");
-  genEventInfoLabel_ = pset.getParameter<edm::InputTag>("genEventInfo");
+//  lheEventToken_ = pset.getParameter<edm::InputTag>("lheEvent");
+  genParticlesToken_ = consumes<reco::CandidateView>(pset.getParameter<edm::InputTag>("genParticles"));
+  //genRunInfoToken_ = pset.getParameter<edm::InputTag>("genRunInfo");
+  genEventInfoToken_ = consumes<GenEventInfoProduct>(pset.getParameter<edm::InputTag>("genEventInfo"));
 
   produces<edm::HepMCProduct>();
 }
 
-void GenParticles2HepMCConverter::beginRun(edm::Run& run, const edm::EventSetup& eventSetup)
-{
+//void GenParticles2HepMCConverter::beginRun(edm::Run& run, const edm::EventSetup& eventSetup)
+//{
   //edm::Handle<GenRunInfoProduct> genRunInfoHandle;
-  //event.getByLabel(genRunInfoLabel_, genRunInfoHandle);
+  //event.getByToken(genRunInfoToken_, genRunInfoHandle);
   // const double xsecIn = genRunInfoHandle->internalXSec().value();
   // const double xsecInErr = genRunInfoHandle->internalXSec().error();
   // const double xsecLO = genRunInfoHandle->externalXSecLO().value();
   // const double xsecLOErr = genRunInfoHandle->externalXSecLO().error();
   // const double xsecNLO = genRunInfoHandle->externalXSecNLO().value();
   // const double xsecNLOErr = genRunInfoHandle->externalXSecNLO().error();
-}
+//}
 
 void GenParticles2HepMCConverter::produce(edm::Event& event, const edm::EventSetup& eventSetup)
 {
 //  edm::Handle<LHEEventProduct> lheEventHandle;
-//  event.getByLabel(lheEventLabel_, lheEventHandle);
+//  event.getByToken(lheEventToken_, lheEventHandle);
 
   edm::Handle<reco::CandidateView> genParticlesHandle;
-  event.getByLabel(genParticlesLabel_, genParticlesHandle);
+  event.getByToken(genParticlesToken_, genParticlesHandle);
 
   edm::Handle<GenEventInfoProduct> genEventInfoHandle;
-  event.getByLabel(genEventInfoLabel_, genEventInfoHandle);
+  event.getByToken(genEventInfoToken_, genEventInfoHandle);
 
   eventSetup.getData(pTable_);
 

--- a/GeneratorInterface/RivetInterface/python/genParticles2HepMC_cfi.py
+++ b/GeneratorInterface/RivetInterface/python/genParticles2HepMC_cfi.py
@@ -2,5 +2,5 @@ import FWCore.ParameterSet.Config as cms
 
 generator = cms.EDProducer("GenParticles2HepMCConverter",
     genParticles = cms.InputTag("genParticles"),
-    genEventInfo = cms.InputTag("generator"),
+    genEventInfo = cms.InputTag("generator", "", "SIM"),
 )


### PR DESCRIPTION
This is backport of #10320 and #10311 
RivetAnalyzer and GenParticles2HepMCConverter modules were not migrated to the consumes() getByToken.

These are technical changes. No change in physics.
