### PR TITLE
Test AdaBoost conversion to GBRForest

### DIFF
--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h
@@ -53,6 +53,7 @@ class EcalClusterFunctionBaseClass ;
 #include <list>
 #include <string>
 
+#include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h"
 
 class GsfElectronAlgo {
 
@@ -219,14 +220,15 @@ class GsfElectronAlgo {
     void beginEvent( edm::Event & ) ;
     void displayInternalElectrons( const std::string & title ) const ;
     void clonePreviousElectrons() ;
-    void completeElectrons() ; // do not redo cloned electrons done previously
+    void completeElectrons(const gsfAlgoHelpers::HeavyObjectCache*) ; // do not redo cloned electrons done previously
     void addPflowInfo() ; // now deprecated
     void setAmbiguityData( bool ignoreNotPreselected = true ) ;
     void removeNotPreselectedElectrons() ;
     void removeAmbiguousElectrons() ;
     void copyElectrons( reco::GsfElectronCollection & ) ;
     void setMVAInputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaInput> & mvaInputs)  ;
-    void setMVAOutputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs) ;
+    void setMVAOutputs(const gsfAlgoHelpers::HeavyObjectCache*,
+                       const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs) ;
     void endEvent() ;
 
   private :
@@ -241,7 +243,7 @@ class GsfElectronAlgo {
     EventData * eventData_ ;
     ElectronData * electronData_ ;
 
-    void createElectron() ;
+    void createElectron(const gsfAlgoHelpers::HeavyObjectCache*) ;
 
     void setMVAepiBasedPreselectionFlag(reco::GsfElectron * ele);
     void setCutBasedPreselectionFlag( reco::GsfElectron * ele, const reco::BeamSpot & ) ;

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h
@@ -1,0 +1,16 @@
+#ifndef __RecoEgamma_GsfElectronAlgos_gsfAlgoHelpsHeavyObjectCache_h__
+#define __RecoEgamma_GsfElectronAlgos_gsfAlgoHelpsHeavyObjectCache_h__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h"
+#include <memory>
+
+namespace gsfAlgoHelpers {
+  class HeavyObjectCache {
+  public:
+    HeavyObjectCache(const edm::ParameterSet&);
+    std::unique_ptr<const SoftElectronMVAEstimator> sElectronMVAEstimator;
+  };
+}
+
+#endif

--- a/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h
+++ b/RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h
@@ -2,6 +2,7 @@
 #define __RecoEgamma_GsfElectronAlgos_gsfAlgoHelpsHeavyObjectCache_h__
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h"
 #include "RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h"
 #include <memory>
 
@@ -10,6 +11,7 @@ namespace gsfAlgoHelpers {
   public:
     HeavyObjectCache(const edm::ParameterSet&);
     std::unique_ptr<const SoftElectronMVAEstimator> sElectronMVAEstimator;
+    std::unique_ptr<const ElectronMVAEstimator> iElectronMVAEstimator;
   };
 }
 

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -87,8 +87,8 @@ struct GsfElectronAlgo::GeneralData
   ElectronHcalHelper * hcalHelper, * hcalHelperPflow ;
   EcalClusterFunctionBaseClass * superClusterErrorFunction ;
   EcalClusterFunctionBaseClass * crackCorrectionFunction ;
-  SoftElectronMVAEstimator *sElectronMVAEstimator;
-  ElectronMVAEstimator *iElectronMVAEstimator;
+  //SoftElectronMVAEstimator *sElectronMVAEstimator;
+  //ElectronMVAEstimator *iElectronMVAEstimator;
   const RegressionHelper::Configuration regCfg;
   RegressionHelper * regHelper;
  } ;
@@ -104,9 +104,8 @@ struct GsfElectronAlgo::GeneralData
    const EcalRecHitsConfiguration & recHitsConfig,
    EcalClusterFunctionBaseClass * superClusterErrorFunc,
    EcalClusterFunctionBaseClass * crackCorrectionFunc,
-   const SoftElectronMVAEstimator::Configuration & mva_NIso_Config,
-   const ElectronMVAEstimator::Configuration & mva_Iso_Config,
-
+   const SoftElectronMVAEstimator::Configuration & /*mva_NIso_Config*/,
+   const ElectronMVAEstimator::Configuration & /*mva_Iso_Config*/,
    const RegressionHelper::Configuration & regConfig
    )
  : inputCfg(inputConfig),
@@ -119,8 +118,8 @@ struct GsfElectronAlgo::GeneralData
    hcalHelperPflow(new ElectronHcalHelper(hcalConfigPflow)),
    superClusterErrorFunction(superClusterErrorFunc),
    crackCorrectionFunction(crackCorrectionFunc),
-   sElectronMVAEstimator(new SoftElectronMVAEstimator(mva_NIso_Config)),
-   iElectronMVAEstimator(new ElectronMVAEstimator(mva_Iso_Config)),
+   //sElectronMVAEstimator(new SoftElectronMVAEstimator(mva_NIso_Config)),
+   //iElectronMVAEstimator(new ElectronMVAEstimator(mva_Iso_Config)),
    regCfg(regConfig),
    regHelper(new RegressionHelper(regConfig))
   {}
@@ -129,8 +128,8 @@ GsfElectronAlgo::GeneralData::~GeneralData()
  {
   delete hcalHelper ;
   delete hcalHelperPflow ;
-  delete sElectronMVAEstimator;
-  delete iElectronMVAEstimator;
+  //delete sElectronMVAEstimator;
+  //delete iElectronMVAEstimator;
   delete regHelper;
  }
 
@@ -1192,7 +1191,7 @@ void GsfElectronAlgo::setMVAOutputs(const gsfAlgoHelpers::HeavyObjectCache* hoc,
     {
 	if(generalData_->strategyCfg.gedElectronMode==true){
                 float mva_NIso_Value=	hoc->sElectronMVAEstimator->mva( *(*el), *(eventData_->vertices));
-		float mva_Iso_Value =   generalData_->iElectronMVAEstimator->mva( *(*el), eventData_->vertices->size() );
+		float mva_Iso_Value =   hoc->iElectronMVAEstimator->mva( *(*el), eventData_->vertices->size() );
 	        GsfElectron::MvaOutput mvaOutput ;
 	        mvaOutput.mva_e_pi = mva_NIso_Value ;
 		mvaOutput.mva_Isolated = mva_Iso_Value ;

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgo.cc
@@ -868,7 +868,7 @@ void GsfElectronAlgo::displayInternalElectrons( const std::string & title ) cons
   LogTrace("GsfElectronAlgo") << "=================================================";
  }
 
-void GsfElectronAlgo::completeElectrons()
+void GsfElectronAlgo::completeElectrons(const gsfAlgoHelpers::HeavyObjectCache* hoc)
  {
   if (electronData_!=0)
    { throw cms::Exception("GsfElectronAlgo|InternalError")<<"unexpected electron data" ; }
@@ -903,7 +903,7 @@ void GsfElectronAlgo::completeElectrons()
     // calculate and check Trajectory StatesOnSurface....
     if ( !electronData_->calculateTSOS( eventSetupData_->mtsTransform, eventSetupData_->constraintAtVtx ) ) continue ;
 
-    createElectron() ;
+    createElectron(hoc) ;
 
    } // loop over tracks
 
@@ -1181,7 +1181,8 @@ void GsfElectronAlgo::setMVAInputs(const std::map<reco::GsfTrackRef,reco::GsfEle
     }
 }
 
-void GsfElectronAlgo::setMVAOutputs(const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs)
+void GsfElectronAlgo::setMVAOutputs(const gsfAlgoHelpers::HeavyObjectCache* hoc,
+                                    const std::map<reco::GsfTrackRef,reco::GsfElectron::MvaOutput> & mvaOutputs)
 {
   GsfElectronPtrCollection::iterator el ;
   for
@@ -1190,7 +1191,7 @@ void GsfElectronAlgo::setMVAOutputs(const std::map<reco::GsfTrackRef,reco::GsfEl
       el++ )
     {
 	if(generalData_->strategyCfg.gedElectronMode==true){
-		float mva_NIso_Value=	generalData_->sElectronMVAEstimator->mva( *(*el),*(eventData_->event));
+                float mva_NIso_Value=	hoc->sElectronMVAEstimator->mva( *(*el), *(eventData_->vertices));
 		float mva_Iso_Value =   generalData_->iElectronMVAEstimator->mva( *(*el), eventData_->vertices->size() );
 	        GsfElectron::MvaOutput mvaOutput ;
 	        mvaOutput.mva_e_pi = mva_NIso_Value ;
@@ -1204,7 +1205,7 @@ void GsfElectronAlgo::setMVAOutputs(const std::map<reco::GsfTrackRef,reco::GsfEl
     }
 }
 
-void GsfElectronAlgo::createElectron()
+void GsfElectronAlgo::createElectron(const gsfAlgoHelpers::HeavyObjectCache* hoc)
  {
   // eventually check ctf track
   if (generalData_->strategyCfg.ctfTracksCheck)
@@ -1475,7 +1476,7 @@ void GsfElectronAlgo::createElectron()
   //this is for GedGsfElectrons, GsfElectrons (ie old pre 7X std reco) resets this later on
   //in the function "addPfInfo"
   //yes this is awful, we'll fix it once we work out how to...
-  float mvaValue=generalData_->sElectronMVAEstimator->mva( *(ele),*(eventData_->event));
+  float mvaValue = hoc->sElectronMVAEstimator->mva( *(ele),*(eventData_->vertices));
   ele->setPassMvaPreselection(mvaValue>generalData_->strategyCfg.PreSelectMVA);
 
   //====================================================

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
@@ -8,9 +8,11 @@ namespace gsfAlgoHelpers {
       conf.getParameter<std::vector<std::string> >("SoftElecMVAFilesString");
     sElectronMVAEstimator.reset(new SoftElectronMVAEstimator(sconfig));
     // isolated electron MVA
+    std::cout << "building iso ele mva" << std::endl;
     ElectronMVAEstimator::Configuration iconfig;
     iconfig.vweightsfiles  =
       conf.getParameter<std::vector<std::string> >("ElecMVAFilesString");
     iElectronMVAEstimator.reset(new ElectronMVAEstimator(iconfig));    
+    std::cout << "built iso ele mva" << std::endl;
   }
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
@@ -8,11 +8,9 @@ namespace gsfAlgoHelpers {
       conf.getParameter<std::vector<std::string> >("SoftElecMVAFilesString");
     sElectronMVAEstimator.reset(new SoftElectronMVAEstimator(sconfig));
     // isolated electron MVA
-    std::cout << "building iso ele mva" << std::endl;
     ElectronMVAEstimator::Configuration iconfig;
     iconfig.vweightsfiles  =
       conf.getParameter<std::vector<std::string> >("ElecMVAFilesString");
     iElectronMVAEstimator.reset(new ElectronMVAEstimator(iconfig));    
-    std::cout << "built iso ele mva" << std::endl;
   }
 }

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
@@ -1,0 +1,10 @@
+#include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h"
+
+namespace gsfAlgoHelpers {
+  HeavyObjectCache::HeavyObjectCache(const edm::ParameterSet& conf) {
+    SoftElectronMVAEstimator::Configuration config;
+    config.vweightsfiles = 
+      conf.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
+    sElectronMVAEstimator.reset(new SoftElectronMVAEstimator(config));
+  }
+}

--- a/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
+++ b/RecoEgamma/EgammaElectronAlgos/src/GsfElectronAlgoHeavyObjectCache.cc
@@ -2,9 +2,15 @@
 
 namespace gsfAlgoHelpers {
   HeavyObjectCache::HeavyObjectCache(const edm::ParameterSet& conf) {
-    SoftElectronMVAEstimator::Configuration config;
-    config.vweightsfiles = 
-      conf.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
-    sElectronMVAEstimator.reset(new SoftElectronMVAEstimator(config));
+    // soft electron MVA
+    SoftElectronMVAEstimator::Configuration sconfig;
+    sconfig.vweightsfiles = 
+      conf.getParameter<std::vector<std::string> >("SoftElecMVAFilesString");
+    sElectronMVAEstimator.reset(new SoftElectronMVAEstimator(sconfig));
+    // isolated electron MVA
+    ElectronMVAEstimator::Configuration iconfig;
+    iconfig.vweightsfiles  =
+      conf.getParameter<std::vector<std::string> >("ElecMVAFilesString");
+    iElectronMVAEstimator.reset(new ElectronMVAEstimator(iconfig));    
   }
 }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.cc
@@ -28,8 +28,8 @@
 
 using namespace reco;
 
-GEDGsfElectronProducer::GEDGsfElectronProducer( const edm::ParameterSet & cfg )
- : GsfElectronBaseProducer(cfg)
+GEDGsfElectronProducer::GEDGsfElectronProducer( const edm::ParameterSet & cfg, const gsfAlgoHelpers::HeavyObjectCache* hoc )
+  : GsfElectronBaseProducer(cfg,hoc)
  {
    egmPFCandidateCollection_ = consumes<reco::PFCandidateCollection>(cfg.getParameter<edm::InputTag>("egmPFCandidatesTag"));
    outputValueMapLabel_ = cfg.getParameter<std::string>("outputEGMPFValueMap");
@@ -45,8 +45,8 @@ void GEDGsfElectronProducer::produce( edm::Event & event, const edm::EventSetup 
  {
   beginEvent(event,setup) ;
   matchWithPFCandidates(event);
-  algo_->completeElectrons() ;
-  algo_->setMVAOutputs(gsfMVAOutputMap_);
+  algo_->completeElectrons(globalCache()) ;
+  algo_->setMVAOutputs(globalCache(),gsfMVAOutputMap_);
   algo_->setMVAInputs(gsfMVAInputMap_);
   fillEvent(event) ;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GEDGsfElectronProducer.h
@@ -12,7 +12,7 @@ class GEDGsfElectronProducer : public GsfElectronBaseProducer
 
     //static void fillDescriptions( edm::ConfigurationDescriptions & ) ;
 
-    explicit GEDGsfElectronProducer( const edm::ParameterSet & ) ;
+   explicit GEDGsfElectronProducer( const edm::ParameterSet &, const gsfAlgoHelpers::HeavyObjectCache* ) ;
     virtual ~GEDGsfElectronProducer() ;
     virtual void produce( edm::Event &, const edm::EventSetup & ) ;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.cc
@@ -25,7 +25,7 @@
 
 using namespace reco;
 
-void GsfElectronBaseProducer::fillDescription( edm::ParameterSetDescription & desc )
+void GsfElectronBaseProducer::fillDescription( edm::ParameterSetDescription & desc)
  {
   // input collections
   desc.add<edm::InputTag>("previousGsfElectronsTag",edm::InputTag("ecalDrivenGsfElectrons")) ;
@@ -152,7 +152,7 @@ void GsfElectronBaseProducer::fillDescription( edm::ParameterSetDescription & de
   desc.add<std::string>("crackCorrectionFunction","EcalClusterCrackCorrection") ;
  }
 
-GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg )
+GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg, const gsfAlgoHelpers::HeavyObjectCache* )
  : ecalSeedingParametersChecked_(false)
  {
   produces<GsfElectronCollection>();
@@ -366,7 +366,6 @@ GsfElectronBaseProducer::GsfElectronBaseProducer( const edm::ParameterSet& cfg )
 
 
    mva_NIso_Cfg_.vweightsfiles = cfg.getParameter<std::vector<std::string>>("SoftElecMVAFilesString");
-   mva_NIso_Cfg_.vtxCollection = consumes<reco::VertexCollection>(cfg.getParameter<edm::InputTag>("vtxTag"));
    mva_Iso_Cfg_.vweightsfiles  = cfg.getParameter<std::vector<std::string>>("ElecMVAFilesString");
   // create algo
   algo_ = new GsfElectronAlgo

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronBaseProducer.h
@@ -3,6 +3,7 @@
 #define GsfElectronBaseProducer_h
 
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h"
+#include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgoHeavyObjectCache.h"
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectronFwd.h"
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
@@ -25,15 +26,22 @@ namespace edm
 #include "RecoEgamma/EgammaElectronAlgos/interface/GsfElectronAlgo.h"
 #include "DataFormats/Common/interface/Handle.h"
 
-class GsfElectronBaseProducer : public edm::stream::EDProducer<>
+class GsfElectronBaseProducer : public edm::stream::EDProducer< edm::GlobalCache<gsfAlgoHelpers::HeavyObjectCache> >
  {
   public:
 
     static void fillDescription( edm::ParameterSetDescription & ) ;
 
-    explicit GsfElectronBaseProducer( const edm::ParameterSet & ) ;
+    explicit GsfElectronBaseProducer( const edm::ParameterSet &, const gsfAlgoHelpers::HeavyObjectCache* ) ;
     virtual ~GsfElectronBaseProducer() ;
 
+    static std::unique_ptr<gsfAlgoHelpers::HeavyObjectCache> 
+    initializeGlobalCache( const edm::ParameterSet& conf ) {
+       return std::unique_ptr<gsfAlgoHelpers::HeavyObjectCache>(new gsfAlgoHelpers::HeavyObjectCache(conf));
+   }
+  
+  static void globalEndJob(gsfAlgoHelpers::HeavyObjectCache const* ) {
+  }
 
   protected:
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.cc
@@ -61,8 +61,8 @@ using namespace reco;
   descriptions.add("produceEcalDrivenGsfElectrons",desc) ;
  }
  */
-GsfElectronEcalDrivenProducer::GsfElectronEcalDrivenProducer( const edm::ParameterSet & cfg )
- : GsfElectronBaseProducer(cfg)
+GsfElectronEcalDrivenProducer::GsfElectronEcalDrivenProducer( const edm::ParameterSet & cfg, const gsfAlgoHelpers::HeavyObjectCache* hoc )
+  : GsfElectronBaseProducer(cfg,hoc)
  {}
 
 GsfElectronEcalDrivenProducer::~GsfElectronEcalDrivenProducer()
@@ -72,7 +72,7 @@ GsfElectronEcalDrivenProducer::~GsfElectronEcalDrivenProducer()
 void GsfElectronEcalDrivenProducer::produce( edm::Event & event, const edm::EventSetup & setup )
  {
   beginEvent(event,setup) ;
-  algo_->completeElectrons() ;
+  algo_->completeElectrons(globalCache()) ;
   fillEvent(event) ;
   endEvent() ;
  }

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronEcalDrivenProducer.h
@@ -10,7 +10,7 @@ class GsfElectronEcalDrivenProducer : public GsfElectronBaseProducer
 
     //static void fillDescriptions( edm::ConfigurationDescriptions & ) ;
 
-    explicit GsfElectronEcalDrivenProducer( const edm::ParameterSet & ) ;
+    explicit GsfElectronEcalDrivenProducer( const edm::ParameterSet &, const gsfAlgoHelpers::HeavyObjectCache* ) ;
     virtual ~GsfElectronEcalDrivenProducer() ;
     virtual void produce( edm::Event &, const edm::EventSetup & ) ;
 

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.cc
@@ -79,8 +79,8 @@ using namespace reco;
   descriptions.add("produceGsfElectrons",desc) ;
  }
  */
-GsfElectronProducer::GsfElectronProducer( const edm::ParameterSet & cfg )
- : GsfElectronBaseProducer(cfg), pfTranslatorParametersChecked_(false)
+GsfElectronProducer::GsfElectronProducer( const edm::ParameterSet & cfg, const gsfAlgoHelpers::HeavyObjectCache* hoc )
+  : GsfElectronBaseProducer(cfg,hoc), pfTranslatorParametersChecked_(false)
  {}
 
 GsfElectronProducer::~GsfElectronProducer()
@@ -92,7 +92,7 @@ void GsfElectronProducer::produce( edm::Event & event, const edm::EventSetup & s
   algo_->clonePreviousElectrons() ;
   // don't add pflow only electrons if one so wish
   if (strategyCfg_.addPflowElectrons)
-   { algo_->completeElectrons() ; }
+    { algo_->completeElectrons(globalCache()) ; }
   algo_->addPflowInfo() ;
   fillEvent(event) ;
   endEvent() ;

--- a/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/GsfElectronProducer.h
@@ -10,7 +10,7 @@ class GsfElectronProducer : public GsfElectronBaseProducer
 
     //static void fillDescriptions( edm::ConfigurationDescriptions & ) ;
 
-    explicit GsfElectronProducer( const edm::ParameterSet & ) ;
+    explicit GsfElectronProducer( const edm::ParameterSet &, const gsfAlgoHelpers::HeavyObjectCache* ) ;
     virtual ~GsfElectronProducer();
     virtual void produce( edm::Event &, const edm::EventSetup & ) ;
 

--- a/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gedGsfElectrons_cfi.py
@@ -163,7 +163,10 @@ gedGsfElectronsTmp = cms.EDProducer("GEDGsfElectronProducer",
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
  ElecMVAFilesString = cms.vstring(
-     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_10_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_12_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_20_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_22_17Feb2011.weights.xml"
                                  ),
 )
 

--- a/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/gsfElectrons_cfi.py
@@ -161,7 +161,10 @@ ecalDrivenGsfElectrons = cms.EDProducer("GsfElectronEcalDrivenProducer",
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_9Dec2013.weights.xml"
                                 ), 
   ElecMVAFilesString = cms.vstring(
-     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_10_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_12_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_20_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_22_17Feb2011.weights.xml"
                                  ),
 
 )
@@ -335,7 +338,10 @@ gsfElectrons = cms.EDProducer("GsfElectronProducer",
     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSoftElectrons_7Feb2014.weights.xml"
                                 ),
    ElecMVAFilesString = cms.vstring(
-     "RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml"
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_10_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_12_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_20_17Feb2011.weights.xml",
+     "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_22_17Feb2011.weights.xml"
                                  ),
 )
 

--- a/RecoEgamma/ElectronIdentification/BuildFile.xml
+++ b/RecoEgamma/ElectronIdentification/BuildFile.xml
@@ -1,6 +1,7 @@
 <use   name="FWCore/Framework"/>
 <use   name="DataFormats/EgammaReco"/>
 <use   name="Geometry/CaloGeometry"/>
+<use   name="CondFormats/EgammaObjects"/>
 <use   name="RecoEcal/EgammaCoreTools"/>
 <use   name="DataFormats/TrackReco"/>
 <use   name="MagneticField/Records"/>

--- a/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
@@ -22,7 +22,7 @@ class ElectronMVAEstimator {
   const Configuration cfg_;
   void bindVariables(float vars[18]) const;
   
-  std::unique_ptr<const GBRForest> gbr;
+  std::vector<std::unique_ptr<const GBRForest> > gbr;
   
   Float_t       fbrem;      //0
   Float_t       detain;     //1

--- a/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimator.h
@@ -1,9 +1,11 @@
-#ifndef ElectronMVA_H
-#define ElectronMVA_H
+#ifndef __RecoEgamma_ElectronIdentification_ElectronMVAEstimator_H__
+#define __RecoEgamma_ElectronIdentification_ElectronMVAEstimator_H__
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
-#include "TMVA/Reader.h"
-#include<string>
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+
+#include <memory>
+#include <string>
 
 class ElectronMVAEstimator {
  public:
@@ -14,40 +16,32 @@ class ElectronMVAEstimator {
   ElectronMVAEstimator(std::string fileName);
   ElectronMVAEstimator(const Configuration & );
   ~ElectronMVAEstimator() {;}
-  double mva(const reco::GsfElectron& myElectron, int nvertices=0);
+  double mva(const reco::GsfElectron& myElectron, int nvertices=0) const;
 
  private:
   const Configuration cfg_;
-  void bindVariables();
-  void init(std::string fileName);
-
- private:
-  TMVA::Reader    *tmvaReader_;
+  void bindVariables(float vars[18]) const;
   
-  Float_t       fbrem;
-  Float_t       detain;
-  Float_t       dphiin; 
-  Float_t       sieie;
-  Float_t       hoe;
-  Float_t       eop;
-  Float_t       e1x5e5x5;
-  Float_t       eleopout;
-  Float_t       detaeleout;
-  Float_t       kfchi2;
-  Float_t       dist;
-  Float_t       dcot;
-  Float_t       eta;
-  Float_t       pt;
-  Int_t         kfhits;
-  Int_t         mishits;
-  Int_t         ecalseed;
-  Int_t         Nvtx;
-
-  Float_t       absdist;
-  Float_t       absdcot;
-  Float_t       mykfhits;
-  Float_t       mymishits;
-  Float_t       myNvtx;
+  std::unique_ptr<const GBRForest> gbr;
+  
+  Float_t       fbrem;      //0
+  Float_t       detain;     //1
+  Float_t       dphiin;     //2
+  Float_t       sieie;      //3
+  Float_t       hoe;        //4
+  Float_t       eop;        //5
+  Float_t       e1x5e5x5;   //6
+  Float_t       eleopout;   //7
+  Float_t       detaeleout; //8
+  Float_t       kfchi2;     //9
+  Float_t       mykfhits;   //10
+  Float_t       mymishits;  //11
+  Float_t       absdist;    //12
+  Float_t       absdcot;    //13
+  Float_t       myNvtx;     //14
+  Float_t       eta;        //15
+  Float_t       pt;         //16
+  Int_t         ecalseed;   //17
 };
 
 #endif

--- a/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
+++ b/RecoEgamma/ElectronIdentification/interface/SoftElectronMVAEstimator.h
@@ -6,28 +6,30 @@
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
-#include "TMVA/Reader.h"
-#include<string>
+
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include <memory>
+#include <string>
 
 class SoftElectronMVAEstimator {
  public:
+  constexpr static unsigned int ExpectedNBins = 1;
+
   struct Configuration{
     std::vector<std::string> vweightsfiles;
-    edm::EDGetTokenT<reco::VertexCollection> vtxCollection;
   };
   SoftElectronMVAEstimator(const Configuration & );
   ~SoftElectronMVAEstimator() ;
-  double mva(const reco::GsfElectron& myElectron,const edm::Event & evt);
+  double mva(const reco::GsfElectron& myElectron,
+             const reco::VertexCollection&) const;
   UInt_t   GetMVABin(int pu,double eta,double pt ) const;
  private:
-  void bindVariables();
+  void bindVariables(float vars[25]) const ;
   void init();
 
  private:
     const Configuration cfg_;
-    std::vector<std::string> mvaWeightFiles_;
-    std::vector<TMVA::Reader*> fmvaReader;
-    TMVA::Reader*    tmvaReader_;
+    std::array<std::unique_ptr<const GBRForest>, ExpectedNBins> gbr;
     
     Float_t                    fbrem;
     Float_t                    EtotOvePin;

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
@@ -39,26 +39,48 @@
 
 using namespace std;
 using namespace reco;
-class ElectronIdMVABased : public edm::stream::EDFilter<> {
-	public:
-		explicit ElectronIdMVABased(const edm::ParameterSet&);
-		~ElectronIdMVABased();
 
-	private:
-		virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+namespace {
+  class HeavyObjectCache {
+  public:
+    HeavyObjectCache(const edm::ParameterSet& config) {
+      std::vector<std::string> mvaWeightFileEleID = 
+        config.getParameter<std::vector<std::string> >("HZZmvaWeightFile");
+      ElectronMVAEstimator::Configuration cfg;
+      cfg.vweightsfiles = mvaWeightFileEleID;
+      mvaID_.reset( new ElectronMVAEstimator(cfg) );
+    }
+    std::unique_ptr<const ElectronMVAEstimator> mvaID_;
+  };
+}
 
-
-		// ----------member data ---------------------------
-		edm::EDGetTokenT<reco::VertexCollection> vertexToken;
-		edm::EDGetTokenT<reco::GsfElectronCollection> electronToken;
-                string mvaWeightFileEleID;
-                string path_mvaWeightFileEleID;
-		double thresholdBarrel;
-		double thresholdEndcap;
-                double thresholdIsoBarrel;
-                double thresholdIsoEndcap;
-
-		ElectronMVAEstimator *mvaID_;
+class ElectronIdMVABased : public edm::stream::EDFilter< edm::GlobalCache<HeavyObjectCache> > {
+public:
+  explicit ElectronIdMVABased(const edm::ParameterSet&, const HeavyObjectCache*);
+  ~ElectronIdMVABased();
+  
+  
+  static std::unique_ptr<HeavyObjectCache> 
+  initializeGlobalCache( const edm::ParameterSet& conf ) {
+    return std::unique_ptr<HeavyObjectCache>(new HeavyObjectCache(conf));
+  }
+  
+  static void globalEndJob(HeavyObjectCache const* ) {
+  }
+  
+private:
+  virtual bool filter(edm::Event&, const edm::EventSetup&) override;
+  
+  
+  // ----------member data ---------------------------
+  edm::EDGetTokenT<reco::VertexCollection> vertexToken;
+  edm::EDGetTokenT<reco::GsfElectronCollection> electronToken;
+  std::vector<string> mvaWeightFileEleID;
+  string path_mvaWeightFileEleID;
+  double thresholdBarrel;
+  double thresholdEndcap;
+  double thresholdIsoBarrel;
+  double thresholdIsoEndcap;
 };
 
 //
@@ -72,36 +94,20 @@ class ElectronIdMVABased : public edm::stream::EDFilter<> {
 //
 // constructors and destructor
 //
-ElectronIdMVABased::ElectronIdMVABased(const edm::ParameterSet& iConfig) {
-	vertexToken = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexTag"));
-	electronToken = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electronTag"));
-	mvaWeightFileEleID = iConfig.getParameter<string>("HZZmvaWeightFile");
-	thresholdBarrel = iConfig.getParameter<double>("thresholdBarrel");
-	thresholdEndcap = iConfig.getParameter<double>("thresholdEndcap");
-	thresholdIsoBarrel = iConfig.getParameter<double>("thresholdIsoDR03Barrel");
-	thresholdIsoEndcap = iConfig.getParameter<double>("thresholdIsoDR03Endcap");
-
-	produces<reco::GsfElectronCollection>();
-	path_mvaWeightFileEleID = edm::FileInPath ( mvaWeightFileEleID.c_str() ).fullPath();
-	FILE * fileEleID = fopen(path_mvaWeightFileEleID.c_str(), "r");
-	if (fileEleID) {
-	  fclose(fileEleID);
-	}
-	else {
-	  string err = "ElectronIdMVABased: cannot open weight file '";
-	  err += path_mvaWeightFileEleID;
-	  err += "'";
-	  throw invalid_argument( err );
-	}
-
-	mvaID_ = new ElectronMVAEstimator(path_mvaWeightFileEleID);
+ElectronIdMVABased::ElectronIdMVABased(const edm::ParameterSet& iConfig, const HeavyObjectCache*) {
+  vertexToken = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexTag"));
+  electronToken = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electronTag"));
+  thresholdBarrel = iConfig.getParameter<double>("thresholdBarrel");
+  thresholdEndcap = iConfig.getParameter<double>("thresholdEndcap");
+  thresholdIsoBarrel = iConfig.getParameter<double>("thresholdIsoDR03Barrel");
+  thresholdIsoEndcap = iConfig.getParameter<double>("thresholdIsoDR03Endcap");
+  
+  produces<reco::GsfElectronCollection>();
 }
 
 
 ElectronIdMVABased::~ElectronIdMVABased()
 {
-
-  delete mvaID_;
    // do anything here that needs to be done at desctruction time
    // (e.g. close files, deallocate resources etc.)
 
@@ -114,41 +120,38 @@ ElectronIdMVABased::~ElectronIdMVABased()
 
 // ------------ method called on each new Event  ------------
 bool ElectronIdMVABased::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
-	using namespace edm;
-
-	std::auto_ptr<reco::GsfElectronCollection> mvaElectrons(new reco::GsfElectronCollection);
-
-	Handle<reco::VertexCollection>  vertexCollection;
-	iEvent.getByToken(vertexToken, vertexCollection);
-	int nVtx = vertexCollection->size();
-
-	Handle<reco::GsfElectronCollection> egCollection;
-	iEvent.getByToken(electronToken,egCollection);
-	const reco::GsfElectronCollection egCandidates = (*egCollection.product());
-	for ( reco::GsfElectronCollection::const_iterator egIter = egCandidates.begin(); egIter != egCandidates.end(); ++egIter) {
-	  double mvaVal = mvaID_->mva( *egIter, nVtx );
-	  double isoDr03 = egIter->dr03TkSumPt() + egIter->dr03EcalRecHitSumEt() + egIter->dr03HcalTowerSumEt();
-	  double eleEta = fabs(egIter->eta());
-	  if (eleEta <= 1.485 && mvaVal > thresholdBarrel && isoDr03 < thresholdIsoBarrel) {
-	    mvaElectrons->push_back( *egIter );
-	    reco::GsfElectron::MvaOutput myMvaOutput;
-	    myMvaOutput.mva_Isolated = mvaVal;
-	    mvaElectrons->back().setMvaOutput(myMvaOutput);
-	  }
-	  else if (eleEta > 1.485 && mvaVal > thresholdEndcap  && isoDr03 < thresholdIsoEndcap) {
-	    mvaElectrons->push_back( *egIter );
-	    reco::GsfElectron::MvaOutput myMvaOutput;
-	    myMvaOutput.mva_Isolated = mvaVal;
-	    mvaElectrons->back().setMvaOutput(myMvaOutput);
-	  }
-
-
-	}
-
-
-	iEvent.put(mvaElectrons);
-
-	return true;
+  using namespace edm;
+  
+  std::auto_ptr<reco::GsfElectronCollection> mvaElectrons(new reco::GsfElectronCollection);
+  
+  Handle<reco::VertexCollection>  vertexCollection;
+  iEvent.getByToken(vertexToken, vertexCollection);
+  int nVtx = vertexCollection->size();
+  
+  Handle<reco::GsfElectronCollection> egCollection;
+  iEvent.getByToken(electronToken,egCollection);
+  const reco::GsfElectronCollection egCandidates = (*egCollection.product());
+  for ( reco::GsfElectronCollection::const_iterator egIter = egCandidates.begin(); egIter != egCandidates.end(); ++egIter) {
+    double mvaVal = globalCache()->mvaID_->mva( *egIter, nVtx );
+    double isoDr03 = egIter->dr03TkSumPt() + egIter->dr03EcalRecHitSumEt() + egIter->dr03HcalTowerSumEt();
+    double eleEta = fabs(egIter->eta());
+    if (eleEta <= 1.485 && mvaVal > thresholdBarrel && isoDr03 < thresholdIsoBarrel) {
+      mvaElectrons->push_back( *egIter );
+      reco::GsfElectron::MvaOutput myMvaOutput;
+      myMvaOutput.mva_Isolated = mvaVal;
+      mvaElectrons->back().setMvaOutput(myMvaOutput);
+    }
+    else if (eleEta > 1.485 && mvaVal > thresholdEndcap  && isoDr03 < thresholdIsoEndcap) {
+      mvaElectrons->push_back( *egIter );
+      reco::GsfElectron::MvaOutput myMvaOutput;
+      myMvaOutput.mva_Isolated = mvaVal;
+      mvaElectrons->back().setMvaOutput(myMvaOutput);
+    }
+  }
+    
+  iEvent.put(mvaElectrons);
+  
+  return true;
 }
 
 //define this as a plug-in

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
@@ -121,6 +121,8 @@ ElectronIdMVABased::~ElectronIdMVABased()
 // ------------ method called on each new Event  ------------
 bool ElectronIdMVABased::filter(edm::Event& iEvent, const edm::EventSetup& iSetup) {
   using namespace edm;
+
+  constexpr double etaEBEE = 1.485;
   
   std::auto_ptr<reco::GsfElectronCollection> mvaElectrons(new reco::GsfElectronCollection);
   
@@ -135,13 +137,13 @@ bool ElectronIdMVABased::filter(edm::Event& iEvent, const edm::EventSetup& iSetu
     double mvaVal = globalCache()->mvaID_->mva( *egIter, nVtx );
     double isoDr03 = egIter->dr03TkSumPt() + egIter->dr03EcalRecHitSumEt() + egIter->dr03HcalTowerSumEt();
     double eleEta = fabs(egIter->eta());
-    if (eleEta <= 1.485 && mvaVal > thresholdBarrel && isoDr03 < thresholdIsoBarrel) {
+    if (eleEta <= etaEBEE && mvaVal > thresholdBarrel && isoDr03 < thresholdIsoBarrel) {
       mvaElectrons->push_back( *egIter );
       reco::GsfElectron::MvaOutput myMvaOutput;
       myMvaOutput.mva_Isolated = mvaVal;
       mvaElectrons->back().setMvaOutput(myMvaOutput);
     }
-    else if (eleEta > 1.485 && mvaVal > thresholdEndcap  && isoDr03 < thresholdIsoEndcap) {
+    else if (eleEta > etaEBEE && mvaVal > thresholdEndcap  && isoDr03 < thresholdIsoEndcap) {
       mvaElectrons->push_back( *egIter );
       reco::GsfElectron::MvaOutput myMvaOutput;
       myMvaOutput.mva_Isolated = mvaVal;

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronIdMVABased.cc
@@ -40,7 +40,7 @@
 using namespace std;
 using namespace reco;
 
-namespace {
+namespace gsfidhelper {
   class HeavyObjectCache {
   public:
     HeavyObjectCache(const edm::ParameterSet& config) {
@@ -54,18 +54,18 @@ namespace {
   };
 }
 
-class ElectronIdMVABased : public edm::stream::EDFilter< edm::GlobalCache<HeavyObjectCache> > {
+class ElectronIdMVABased : public edm::stream::EDFilter< edm::GlobalCache<gsfidhelper::HeavyObjectCache> > {
 public:
-  explicit ElectronIdMVABased(const edm::ParameterSet&, const HeavyObjectCache*);
+  explicit ElectronIdMVABased(const edm::ParameterSet&, const gsfidhelper::HeavyObjectCache*);
   ~ElectronIdMVABased();
   
   
-  static std::unique_ptr<HeavyObjectCache> 
+  static std::unique_ptr<gsfidhelper::HeavyObjectCache> 
   initializeGlobalCache( const edm::ParameterSet& conf ) {
-    return std::unique_ptr<HeavyObjectCache>(new HeavyObjectCache(conf));
+    return std::unique_ptr<gsfidhelper::HeavyObjectCache>(new gsfidhelper::HeavyObjectCache(conf));
   }
   
-  static void globalEndJob(HeavyObjectCache const* ) {
+  static void globalEndJob(gsfidhelper::HeavyObjectCache const* ) {
   }
   
 private:
@@ -94,7 +94,7 @@ private:
 //
 // constructors and destructor
 //
-ElectronIdMVABased::ElectronIdMVABased(const edm::ParameterSet& iConfig, const HeavyObjectCache*) {
+ElectronIdMVABased::ElectronIdMVABased(const edm::ParameterSet& iConfig, const gsfidhelper::HeavyObjectCache*) {
   vertexToken = consumes<reco::VertexCollection>(iConfig.getParameter<edm::InputTag>("vertexTag"));
   electronToken = consumes<reco::GsfElectronCollection>(iConfig.getParameter<edm::InputTag>("electronTag"));
   thresholdBarrel = iConfig.getParameter<double>("thresholdBarrel");

--- a/RecoEgamma/ElectronIdentification/python/electronIdMVABased_cfi.py
+++ b/RecoEgamma/ElectronIdentification/python/electronIdMVABased_cfi.py
@@ -3,7 +3,12 @@ import FWCore.ParameterSet.Config as cms
 mvaElectrons = cms.EDFilter("ElectronIdMVABased",
                             vertexTag = cms.InputTag('offlinePrimaryVertices'),
                             electronTag = cms.InputTag('gedGsfElectrons'),
-                            HZZmvaWeightFile = cms.string('RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml'),
+                            HZZmvaWeightFile = cms.vstring(
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_10_17Feb2011.weights.xml",
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_12_17Feb2011.weights.xml",
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_20_17Feb2011.weights.xml",
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_22_17Feb2011.weights.xml"
+        ),
                             thresholdBarrel = cms.double( -0.1875 ),
                             thresholdEndcap = cms.double( -0.1075 ),
                             thresholdIsoDR03Barrel = cms.double( 10.0 ),

--- a/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/ElectronMVAEstimator.cc
@@ -5,6 +5,13 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
+#include "TMVA/Reader.h"
+#include "TMVA/MethodBDT.h"
+
+namespace {
+  constexpr char ele_mva_name[] = "BDTSimpleCat";
+}
+
 ElectronMVAEstimator::ElectronMVAEstimator():
   cfg_{}
 {}
@@ -12,31 +19,32 @@ ElectronMVAEstimator::ElectronMVAEstimator():
 ElectronMVAEstimator::ElectronMVAEstimator(std::string fileName):
   cfg_{} 
 {
-  tmvaReader_ = new TMVA::Reader("!Color:Silent");
-  tmvaReader_->AddVariable("fbrem",&fbrem);
-  tmvaReader_->AddVariable("detain", &detain);
-  tmvaReader_->AddVariable("dphiin", &dphiin);
-  tmvaReader_->AddVariable("sieie", &sieie);
-  tmvaReader_->AddVariable("hoe", &hoe);
-  tmvaReader_->AddVariable("eop", &eop);
-  tmvaReader_->AddVariable("e1x5e5x5", &e1x5e5x5);
-  tmvaReader_->AddVariable("eleopout", &eleopout);
-  tmvaReader_->AddVariable("detaeleout", &detaeleout);
-  tmvaReader_->AddVariable("kfchi2", &kfchi2);
-  tmvaReader_->AddVariable("kfhits", &mykfhits);
-  tmvaReader_->AddVariable("mishits",&mymishits);
-  tmvaReader_->AddVariable("dist", &absdist);
-  tmvaReader_->AddVariable("dcot", &absdcot);
-  tmvaReader_->AddVariable("nvtx", &myNvtx);
+  TMVA::Reader tmvaReader("!Color:Silent");
+  tmvaReader.AddVariable("fbrem",&fbrem);
+  tmvaReader.AddVariable("detain", &detain);
+  tmvaReader.AddVariable("dphiin", &dphiin);
+  tmvaReader.AddVariable("sieie", &sieie);
+  tmvaReader.AddVariable("hoe", &hoe);
+  tmvaReader.AddVariable("eop", &eop);
+  tmvaReader.AddVariable("e1x5e5x5", &e1x5e5x5);
+  tmvaReader.AddVariable("eleopout", &eleopout);
+  tmvaReader.AddVariable("detaeleout", &detaeleout);
+  tmvaReader.AddVariable("kfchi2", &kfchi2);
+  tmvaReader.AddVariable("kfhits", &mykfhits);
+  tmvaReader.AddVariable("mishits",&mymishits);
+  tmvaReader.AddVariable("dist", &absdist);
+  tmvaReader.AddVariable("dcot", &absdcot);
+  tmvaReader.AddVariable("nvtx", &myNvtx);
 
-  tmvaReader_->AddSpectator("eta",&eta);
-  tmvaReader_->AddSpectator("pt",&pt);
-  tmvaReader_->AddSpectator("ecalseed",&ecalseed);
+  tmvaReader.AddSpectator("eta",&eta);
+  tmvaReader.AddSpectator("pt",&pt);
+  tmvaReader.AddSpectator("ecalseed",&ecalseed);
   
   // Taken from Daniele (his mail from the 30/11)
-  //  tmvaReader_->BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
+  //  tmvaReader.BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
   // training of the 7/12 with Nvtx added
-  tmvaReader_->BookMVA("BDTSimpleCat",fileName.c_str());
+  std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA(ele_mva_name,fileName.c_str()) );
+  gbr.reset(new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA(ele_mva_name) ) ) );
 }
 
 ElectronMVAEstimator::ElectronMVAEstimator(const Configuration & cfg):cfg_(cfg){
@@ -46,44 +54,47 @@ ElectronMVAEstimator::ElectronMVAEstimator(const Configuration & cfg):cfg_(cfg){
     path_mvaWeightFileEleID = edm::FileInPath ( cfg_.vweightsfiles[ifile].c_str() ).fullPath();
     weightsfiles.push_back(path_mvaWeightFileEleID);
   }
-  tmvaReader_ = new TMVA::Reader("!Color:Silent");
-  tmvaReader_->AddVariable("fbrem",&fbrem);
-  tmvaReader_->AddVariable("detain", &detain);
-  tmvaReader_->AddVariable("dphiin", &dphiin);
-  tmvaReader_->AddVariable("sieie", &sieie);
-  tmvaReader_->AddVariable("hoe", &hoe);
-  tmvaReader_->AddVariable("eop", &eop);
-  tmvaReader_->AddVariable("e1x5e5x5", &e1x5e5x5);
-  tmvaReader_->AddVariable("eleopout", &eleopout);
-  tmvaReader_->AddVariable("detaeleout", &detaeleout);
-  tmvaReader_->AddVariable("kfchi2", &kfchi2);
-  tmvaReader_->AddVariable("kfhits", &mykfhits);
-  tmvaReader_->AddVariable("mishits",&mymishits);
-  tmvaReader_->AddVariable("dist", &absdist);
-  tmvaReader_->AddVariable("dcot", &absdcot);
-  tmvaReader_->AddVariable("nvtx", &myNvtx);
+  TMVA::Reader tmvaReader("!Color:Silent");
+  tmvaReader.AddVariable("fbrem",&fbrem);
+  tmvaReader.AddVariable("detain", &detain);
+  tmvaReader.AddVariable("dphiin", &dphiin);
+  tmvaReader.AddVariable("sieie", &sieie);
+  tmvaReader.AddVariable("hoe", &hoe);
+  tmvaReader.AddVariable("eop", &eop);
+  tmvaReader.AddVariable("e1x5e5x5", &e1x5e5x5);
+  tmvaReader.AddVariable("eleopout", &eleopout);
+  tmvaReader.AddVariable("detaeleout", &detaeleout);
+  tmvaReader.AddVariable("kfchi2", &kfchi2);
+  tmvaReader.AddVariable("kfhits", &mykfhits);
+  tmvaReader.AddVariable("mishits",&mymishits);
+  tmvaReader.AddVariable("dist", &absdist);
+  tmvaReader.AddVariable("dcot", &absdcot);
+  tmvaReader.AddVariable("nvtx", &myNvtx);
 
-  tmvaReader_->AddSpectator("eta",&eta);
-  tmvaReader_->AddSpectator("pt",&pt);
-  tmvaReader_->AddSpectator("ecalseed",&ecalseed);
+  tmvaReader.AddSpectator("eta",&eta);
+  tmvaReader.AddSpectator("pt",&pt);
+  tmvaReader.AddSpectator("ecalseed",&ecalseed);
   
   // Taken from Daniele (his mail from the 30/11)
-  //  tmvaReader_->BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
+  //  tmvaReader.BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
   // training of the 7/12 with Nvtx added
 
-  tmvaReader_->BookMVA("BDTSimpleCat",weightsfiles[0]);
+  std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA(ele_mva_name,weightsfiles[0]) );
+  gbr.reset(new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA(ele_mva_name) ) ) );
 }
 
-double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nvertices )  {
-  fbrem = myElectron.fbrem();
-  detain = myElectron.deltaEtaSuperClusterTrackAtVtx();
-  dphiin = myElectron.deltaPhiSuperClusterTrackAtVtx();
-  sieie = myElectron.sigmaIetaIeta();
-  hoe = myElectron.hcalOverEcal();
-  eop = myElectron.eSuperClusterOverP();
-  e1x5e5x5 = (myElectron.e5x5()) !=0. ? 1.-(myElectron.e1x5()/myElectron.e5x5()) : -1. ;
-  eleopout = myElectron.eEleClusterOverPout();
-  detaeleout = myElectron.deltaEtaEleClusterTrackAtCalo();
+double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nvertices ) const {
+  float vars[18];
+
+  vars[0] = myElectron.fbrem();
+  vars[1] = std::abs(myElectron.deltaEtaSuperClusterTrackAtVtx());
+  vars[2] = std::abs(myElectron.deltaPhiSuperClusterTrackAtVtx());
+  vars[3] = myElectron.sigmaIetaIeta();
+  vars[4] = myElectron.hcalOverEcal();
+  vars[5] = myElectron.eSuperClusterOverP();
+  vars[6] = (myElectron.e5x5()) !=0. ? 1.-(myElectron.e1x5()/myElectron.e5x5()) : -1. ;
+  vars[7] = myElectron.eEleClusterOverPout();
+  vars[8] = std::abs(myElectron.deltaEtaEleClusterTrackAtCalo());
   
   bool validKF= false;
 
@@ -91,99 +102,77 @@ double ElectronMVAEstimator::mva(const reco::GsfElectron& myElectron, int nverti
   validKF = (myTrackRef.isAvailable());
   validKF = (myTrackRef.isNonnull());  
 
-  kfchi2 = (validKF) ? myTrackRef->normalizedChi2() : 0 ;
-  kfhits = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.; 
-  dist = myElectron.convDist();
-  dcot = myElectron.convDcot();
-  eta = myElectron.eta();
-  pt = myElectron.pt();
+  vars[9] = (validKF) ? myTrackRef->normalizedChi2() : 0 ;
+  vars[10] = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1.; 
+  vars[11] = myElectron.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
+  vars[12] = std::abs(myElectron.convDist());
+  vars[13] = std::abs(myElectron.convDcot());
+  vars[14] = nvertices;
+  vars[15] = myElectron.eta();
+  vars[16] = myElectron.pt();
+  vars[17] = myElectron.ecalDrivenSeed();
   
-  mishits = myElectron.gsfTrack()->hitPattern().numberOfLostHits(reco::HitPattern::MISSING_INNER_HITS);
-  ecalseed = myElectron.ecalDrivenSeed();
-  
-  Nvtx = nvertices;
-
-  bindVariables();
-  double result =  tmvaReader_->EvaluateMVA("BDTSimpleCat");
+  bindVariables(vars);
+  double result =  gbr->GetAdaBoostClassifier(vars);
 //  
-//  std::cout << "fbrem" <<fbrem << std::endl;
-//  std::cout << "detain"<< detain << std::endl;
-//  std::cout << "dphiin"<< dphiin << std::endl;
-//  std::cout << "sieie"<< sieie << std::endl;
-//  std::cout << "hoe"<< hoe << std::endl;
-//  std::cout << "eop"<< eop << std::endl;
-//  std::cout << "e1x5e5x5"<< e1x5e5x5 << std::endl;
-//  std::cout << "eleopout"<< eleopout << std::endl;
-//  std::cout << "detaeleout"<< detaeleout << std::endl;
-//  std::cout << "kfchi2"<< kfchi2 << std::endl;
-//  std::cout << "kfhits"<< mykfhits << std::endl;
-//  std::cout << "mishits"<<mymishits << std::endl;
-//  std::cout << "dist"<< absdist << std::endl;
-//  std::cout << "dcot"<< absdcot << std::endl;
-//
-//  std::cout << "eta"<<eta << std::endl;
-//  std::cout << "pt"<<pt << std::endl;
-//  std::cout << "ecalseed"<<ecalseed << std::endl;
+//  std::cout << "fbrem" << vars[0] << std::endl;
+//  std::cout << "detain"<< vars[1] << std::endl;
+//  std::cout << "dphiin"<< vars[2] << std::endl;
+//  std::cout << "sieie"<< vars[3] << std::endl;
+//  std::cout << "hoe"<< vars[4] << std::endl;
+//  std::cout << "eop"<< vars[5] << std::endl;
+//  std::cout << "e1x5e5x5"<< vars[6] << std::endl;
+//  std::cout << "eleopout"<< vars[7] << std::endl;
+//  std::cout << "detaeleout"<< vars[8] << std::endl;
+//  std::cout << "kfchi2"<< vars[9] << std::endl;
+//  std::cout << "kfhits"<< vars[10] << std::endl;
+//  std::cout << "mishits"<<vars[11] << std::endl;
+//  std::cout << "dist"<< vars[12] << std::endl;
+//  std::cout << "dcot"<< vars[13] << std::endl;
+//  std::cout << "nvtx"<< vars[14] << std::endl;
+//  std::cout << "eta"<< vars[15] << std::endl;
+//  std::cout << "pt"<< vars[16] << std::endl;
+//  std::cout << "ecalseed"<< vars[17] << std::endl;
 //
 //  std::cout << " MVA " << result << std::endl;
   return result;
 }
 
 
-void ElectronMVAEstimator::bindVariables() {
-  if(fbrem < -1.)
-    fbrem = -1.;  
+void ElectronMVAEstimator::bindVariables(float vars[18]) const {
+  if(vars[0] < -1.)
+    vars[1] = -1.;  
   
-  detain = fabs(detain);
-  if(detain > 0.06)
-    detain = 0.06;
+  if(vars[1] > 0.06)
+    vars[1] = 0.06;
+    
+  if(vars[2] > 0.6)
+    vars[2] = 0.6;
   
+  if(vars[5] > 20.)
+    vars[5] = 20.;
+    
+  if(vars[7] > 20.)
+    vars[7] = 20;
   
-  dphiin = fabs(dphiin);
-  if(dphiin > 0.6)
-    dphiin = 0.6;
+  if(vars[8] > 0.2)
+    vars[8] = 0.2;
+  
+  if(vars[9] < 0.)
+    vars[9] = 0.;
+  
+  if(vars[9] > 15.)
+    vars[9] = 15.;
+    
+  if(vars[6] < -1.)
+    vars[6] = -1;
 
-  
-  if(eop > 20.)
-    eop = 20.;
-  
-  
-  if(eleopout > 20.)
-    eleopout = 20;
-  
-  detaeleout = fabs(detaeleout);
-  if(detaeleout > 0.2)
-    detaeleout = 0.2;
-  
-  mykfhits = float(kfhits);
-  mymishits = float(mishits);
-  
-  if(kfchi2 < 0.)
-    kfchi2 = 0.;
-  
-  if(kfchi2 > 15.)
-    kfchi2 = 15.;
-  
-  
-  if(e1x5e5x5 < -1.)
-    e1x5e5x5 = -1;
-
-  if(e1x5e5x5 > 2.)
-    e1x5e5x5 = 2.; 
-  
-  
-  if(dist > 15.)
-    dist = 15.;
-  if(dist < -15.)
-    dist = -15.;
-  
-  if(dcot > 3.)
-    dcot = 3.;
-  if(dcot < -3.)
-    dcot = -3.;
-  
-  absdist = fabs(dist);
-  absdcot = fabs(dcot);
-  myNvtx = float(Nvtx);
-
+  if(vars[6] > 2.)
+    vars[6] = 2.; 
+    
+  if(vars[12] > 15.)
+    vars[12] = 15.;
+    
+  if(vars[13] > 3.)
+    vars[13] = 3.;
 }

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -61,7 +61,7 @@ SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cf
     
     // Taken from Daniele (his mail from the 30/11)    
     // training of the 7/12 with Nvtx added
-    tmvaReader.BookMVA("BDT",weightsfiles[i]);
+    std::unique_ptr<TMVA::IMethod> temp( tmvaReader.BookMVA("BDT",weightsfiles[i]) );
     gbr[i].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA("BDT") ) ) );
   }
 }

--- a/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
+++ b/RecoEgamma/ElectronIdentification/src/SoftElectronMVAEstimator.cc
@@ -4,6 +4,8 @@
 #include "DataFormats/GsfTrackReco/interface/GsfTrack.h"
 #include "DataFormats/GsfTrackReco/interface/GsfTrackFwd.h"
 #include "FWCore/ParameterSet/interface/FileInPath.h"
+#include "TMVA/Reader.h"
+#include "TMVA/MethodBDT.h"
 
 SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cfg_(cfg){
   std::vector<std::string> weightsfiles;
@@ -12,15 +14,9 @@ SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cf
     path_mvaWeightFileEleID = edm::FileInPath ( cfg_.vweightsfiles[ifile].c_str() ).fullPath();
     weightsfiles.push_back(path_mvaWeightFileEleID);
   }
-
-  for (unsigned int i=0;i<fmvaReader.size(); ++i) {
-    if (fmvaReader[i]) delete fmvaReader[i];
-  }
-  fmvaReader.clear();
-
+  
   //initialize
   //Define expected number of bins
-  UInt_t ExpectedNBins = 1;
 
   //Check number of weight files given
   if (ExpectedNBins != cfg_.vweightsfiles.size() ) {
@@ -32,56 +28,47 @@ SoftElectronMVAEstimator::SoftElectronMVAEstimator(const Configuration & cfg):cf
 
 
   for (unsigned int i=0;i<ExpectedNBins; ++i) {
-    tmvaReader_ = new TMVA::Reader("!Color:Silent");
-    tmvaReader_->AddVariable("fbrem",                   &fbrem);
-    tmvaReader_->AddVariable("EtotOvePin",                      &EtotOvePin);
-    tmvaReader_->AddVariable("EClusOverPout",                   &eleEoPout);
-    tmvaReader_->AddVariable("EBremOverDeltaP",                 &EBremOverDeltaP);
-    tmvaReader_->AddVariable("logSigmaEtaEta",                  &logSigmaEtaEta);
-    tmvaReader_->AddVariable("DeltaEtaTrackEcalSeed",           &DeltaEtaTrackEcalSeed);
-    tmvaReader_->AddVariable("HoE",                             &HoE);
-    tmvaReader_->AddVariable("gsfchi2",                         &gsfchi2);
-    tmvaReader_->AddVariable("kfchi2",                          &kfchi2);
-    tmvaReader_->AddVariable("kfhits",                          &kfhits);
-    tmvaReader_->AddVariable("SigmaPtOverPt",                   &SigmaPtOverPt);
-    tmvaReader_->AddVariable("deta",                            &deta);
-    tmvaReader_->AddVariable("dphi",                            &dphi);
-    tmvaReader_->AddVariable("detacalo",                        &detacalo);
-    tmvaReader_->AddVariable("see",                             &see);
-    tmvaReader_->AddVariable("spp",                             &spp); 	
-    tmvaReader_->AddVariable("R9",                             	&R9);
-    tmvaReader_->AddVariable("etawidth",                        &etawidth);
-    tmvaReader_->AddVariable("phiwidth",                        &phiwidth);
-    tmvaReader_->AddVariable("e1x5e5x5",                        &OneMinusE1x5E5x5);
-    tmvaReader_->AddVariable("IoEmIoP",				&IoEmIoP);
-    tmvaReader_->AddVariable("PreShowerOverRaw",		&PreShowerOverRaw);
-    tmvaReader_->AddVariable("nPV",                		&nPV);
+    TMVA::Reader tmvaReader("!Color:Silent");
+    tmvaReader.AddVariable("fbrem",                   &fbrem);
+    tmvaReader.AddVariable("EtotOvePin",                      &EtotOvePin);
+    tmvaReader.AddVariable("EClusOverPout",                   &eleEoPout);
+    tmvaReader.AddVariable("EBremOverDeltaP",                 &EBremOverDeltaP);
+    tmvaReader.AddVariable("logSigmaEtaEta",                  &logSigmaEtaEta);
+    tmvaReader.AddVariable("DeltaEtaTrackEcalSeed",           &DeltaEtaTrackEcalSeed);
+    tmvaReader.AddVariable("HoE",                             &HoE);
+    tmvaReader.AddVariable("gsfchi2",                         &gsfchi2);
+    tmvaReader.AddVariable("kfchi2",                          &kfchi2);
+    tmvaReader.AddVariable("kfhits",                          &kfhits);
+    tmvaReader.AddVariable("SigmaPtOverPt",                   &SigmaPtOverPt);
+    tmvaReader.AddVariable("deta",                            &deta);
+    tmvaReader.AddVariable("dphi",                            &dphi);
+    tmvaReader.AddVariable("detacalo",                        &detacalo);
+    tmvaReader.AddVariable("see",                             &see);
+    tmvaReader.AddVariable("spp",                             &spp); 	
+    tmvaReader.AddVariable("R9",                             	&R9);
+    tmvaReader.AddVariable("etawidth",                        &etawidth);
+    tmvaReader.AddVariable("phiwidth",                        &phiwidth);
+    tmvaReader.AddVariable("e1x5e5x5",                        &OneMinusE1x5E5x5);
+    tmvaReader.AddVariable("IoEmIoP",				&IoEmIoP);
+    tmvaReader.AddVariable("PreShowerOverRaw",		&PreShowerOverRaw);
+    tmvaReader.AddVariable("nPV",                		&nPV);
 
-    tmvaReader_->AddVariable( "pt",                            &pt);
-    tmvaReader_->AddVariable( "eta",                           &eta);
+    tmvaReader.AddVariable( "pt",                            &pt);
+    tmvaReader.AddVariable( "eta",                           &eta);
 
-    tmvaReader_->AddSpectator( "pt",                            &pt);
-    tmvaReader_->AddSpectator( "eta",                           &eta);
-
-//    tmvaReader_->AddSpectator( "nPV",                           &nPV);
-
-    // Taken from Daniele (his mail from the 30/11)
-    //  tmvaReader_->BookMVA("BDTSimpleCat","../Training/weights_Root527b_3Depth_DanVarConvRej_2PtBins_10Pt_800TPrune5_Min100Events_NoBjets_half/TMVA_BDTSimpleCat.weights.xm");
+    tmvaReader.AddSpectator( "pt",                            &pt);
+    tmvaReader.AddSpectator( "eta",                           &eta);
+    
+    // Taken from Daniele (his mail from the 30/11)    
     // training of the 7/12 with Nvtx added
-    tmvaReader_->BookMVA("BDT",weightsfiles[i]);
-    fmvaReader.push_back(tmvaReader_);
-//    delete tmvaReader_;
-
+    tmvaReader.BookMVA("BDT",weightsfiles[i]);
+    gbr[i].reset( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmvaReader.FindMVA("BDT") ) ) );
   }
 }
 
 
 SoftElectronMVAEstimator::~SoftElectronMVAEstimator()
-{
-  for (unsigned int i=0;i<fmvaReader.size(); ++i) {
-    if (fmvaReader[i]) delete fmvaReader[i];
-  }
-}
+{ }
 
 
 UInt_t SoftElectronMVAEstimator::GetMVABin(int pu, double eta, double pt) const {
@@ -111,45 +98,45 @@ UInt_t SoftElectronMVAEstimator::GetMVABin(int pu, double eta, double pt) const 
 
 
 
-double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron,const edm::Event & evt)  {
+double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron,
+                                     const reco::VertexCollection& pvc) const {
+  float vars[25];
 
- edm::Handle<reco::VertexCollection> FullprimaryVertexCollection;
- evt.getByToken(cfg_.vtxCollection, FullprimaryVertexCollection);
- const reco::VertexCollection pvc = *(FullprimaryVertexCollection.product());
- 
-  fbrem                 	=myElectron.fbrem();
-  EtotOvePin            	=myElectron.eSuperClusterOverP();
-  eleEoPout             	=myElectron.eEleClusterOverPout();
-  float etot                    =myElectron.eSuperClusterOverP()*myElectron.trackMomentumAtVtx().R();
-  float eEcal                   =myElectron.eEleClusterOverPout()*myElectron.trackMomentumAtEleClus().R();
-  float dP                      =myElectron.trackMomentumAtVtx().R()-myElectron.trackMomentumAtEleClus().R();
-  EBremOverDeltaP       	=(etot-eEcal)/dP;
-  logSigmaEtaEta        	=log(myElectron.sigmaEtaEta());
-  DeltaEtaTrackEcalSeed 	=myElectron.deltaEtaEleClusterTrackAtCalo();
-  HoE                   	=myElectron.hcalOverEcalBc();
+  vars[0]  = myElectron.fbrem();// fbrem
+  vars[1]  = myElectron.eSuperClusterOverP(); //EtotOvePin
+  vars[2]   = myElectron.eEleClusterOverPout(); //eleEoPout 
+  
+  float etot  = myElectron.eSuperClusterOverP()*myElectron.trackMomentumAtVtx().R();
+  float eEcal = myElectron.eEleClusterOverPout()*myElectron.trackMomentumAtEleClus().R();
+  float dP    = myElectron.trackMomentumAtVtx().R()-myElectron.trackMomentumAtEleClus().R();
+  vars[3]  = (etot-eEcal)/dP; //EBremOverDeltaP
+  vars[4]  = std::log(myElectron.sigmaEtaEta()); //logSigmaEtaEta
+  vars[5]  = myElectron.deltaEtaEleClusterTrackAtCalo(); //DeltaEtaTrackEcalSeed
+  vars[6]  = myElectron.hcalOverEcalBc(); //HoE  
 
   bool validKF= false;
   reco::TrackRef myTrackRef     = myElectron.closestCtfTrackRef();
   validKF                       = (myTrackRef.isAvailable() && myTrackRef.isNonnull());
-  kfchi2                	=(validKF) ? myTrackRef->normalizedChi2() : 0 ;
-  kfhits                	=(validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1. ;
-  gsfchi2               	=myElectron.gsfTrack()->normalizedChi2();
-  SigmaPtOverPt         	=myElectron.gsfTrack().get()->ptModeError()/myElectron.gsfTrack().get()->ptMode() ;
-  deta                  	=myElectron.deltaEtaSuperClusterTrackAtVtx();
-  dphi                  	=myElectron.deltaPhiSuperClusterTrackAtVtx();
-  detacalo              	=myElectron.deltaEtaSeedClusterTrackAtCalo();
-  see                   	=myElectron.sigmaIetaIeta();
-  spp				=myElectron.sigmaIphiIphi();
-  R9                    =myElectron.r9();
-  IoEmIoP               =  (1.0/myElectron.ecalEnergy()) - (1.0 / myElectron.p());
-  etawidth              	=myElectron.superCluster()->etaWidth();
-  phiwidth              	=myElectron.superCluster()->phiWidth();
-  OneMinusE1x5E5x5      	=(myElectron.e5x5()) !=0. ? 1.-(myElectron.e1x5()/myElectron.e5x5()) : -1. ;
-  pt                    	=myElectron.pt();
-  eta                   	=myElectron.eta();
-  nPV=pvc.size();
-  PreShowerOverRaw=myElectron.superCluster()->preshowerEnergy() / myElectron.superCluster()->rawEnergy();
-
+  vars[7]  = myElectron.gsfTrack()->normalizedChi2(); //gsfchi2
+  vars[8]  = (validKF) ? myTrackRef->normalizedChi2() : 0 ; //kfchi2
+  vars[9]  = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1. ; //kfhits
+  
+  vars[10] = myElectron.gsfTrack().get()->ptModeError()/myElectron.gsfTrack().get()->ptMode() ; //SigmaPtOverPt 
+  vars[11]  = myElectron.deltaEtaSuperClusterTrackAtVtx(); //deta
+  vars[12]  = myElectron.deltaPhiSuperClusterTrackAtVtx(); //dphi
+  vars[13]  = myElectron.deltaEtaSeedClusterTrackAtCalo(); //detacalo 
+  vars[14]  = myElectron.sigmaIetaIeta(); //see
+  vars[15]  = myElectron.sigmaIphiIphi(); //spp
+  vars[16]  = myElectron.r9(); //R9
+  vars[17]  = myElectron.superCluster()->etaWidth(); //etawidth
+  vars[18]  = myElectron.superCluster()->phiWidth(); //phiwidth
+  vars[19]  = (myElectron.e5x5()) !=0. ? 1.-(myElectron.e1x5()/myElectron.e5x5()) : -1. ; //OneMinusE1x5E5x5
+  vars[20]  = (1.0/myElectron.ecalEnergy()) - (1.0 / myElectron.p()); // IoEmIoP
+  vars[21]  = myElectron.superCluster()->preshowerEnergy() / myElectron.superCluster()->rawEnergy(); //PreShowerOverRaw
+  vars[22]  = pvc.size(); // nPV
+  vars[23]  = myElectron.pt(); //pt
+  vars[24]  = myElectron.eta(); //eta
+  
 /*
   std::cout<<"fbrem "<<fbrem<<std::endl;
   std::cout<<"EtotOvePin "<<EtotOvePin<<std::endl;
@@ -174,52 +161,46 @@ double SoftElectronMVAEstimator::mva(const reco::GsfElectron& myElectron,const e
   std::cout<<"OneMinusE1x5E5x5 "<<OneMinusE1x5E5x5<<std::endl;
   std::cout<<"PreShowerOverRaw "<<PreShowerOverRaw<<std::endl;
 */
-  bindVariables();
-//  double result= fmvaReader[GetMVABin(nPV,eta,pt)]->EvaluateMVA("BDT");
-  double result= fmvaReader[0]->EvaluateMVA("BDT");
-//  double result =  tmvaReader_->EvaluateMVA("BDT");
+  bindVariables(vars);
+
+  double result= gbr[0]->GetClassifier(vars);
+
   return result;
 }
 
 
-void SoftElectronMVAEstimator::bindVariables() {
-  if(fbrem < -1.)
-    fbrem = -1.;
+void SoftElectronMVAEstimator::bindVariables(float vars[25]) const {
+  if( vars[0] < -1.) //fbrem
+    vars[0] = -1.;
 
-  deta = fabs(deta);
-  if(deta > 0.06)
-    deta = 0.06;
+  vars[11] = std::abs(vars[11]); // deta
+  if(vars[11] > 0.06)
+    vars[11] = 0.06;
 
-
-  dphi = fabs(dphi);
-  if(dphi > 0.6)
-    dphi = 0.6;
-
+  vars[12] = std::abs(vars[12]);
+  if(vars[12] > 0.6)
+    vars[12] = 0.6;
 
   //if(EoP > 20.)
   //  EoP = 20.;
 
-  if(eleEoPout > 20.)
-    eleEoPout = 20.;
+  if(vars[2] > 20.) //eleEoPout
+    vars[2] = 20.;
+  
+  vars[13] = std::abs(vars[13]); //detacalo
+  if(vars[13] > 0.2)
+    vars[13] = 0.2;
 
+  if( vars[19] < -1.) //OneMinusE1x5E5x5
+    vars[19] = -1;
 
-  detacalo = fabs(detacalo);
-  if(detacalo > 0.2)
-    detacalo = 0.2;
+  if( vars[19] > 2.) //OneMinusE1x5E5x5
+    vars[19] = 2.;
 
-  if(OneMinusE1x5E5x5 < -1.)
-    OneMinusE1x5E5x5 = -1;
-
-  if(OneMinusE1x5E5x5 > 2.)
-    OneMinusE1x5E5x5 = 2.;
-
-
-
-  if(gsfchi2 > 200.)
-    gsfchi2 = 200;
-
-
-  if(kfchi2 > 10.)
-    kfchi2 = 10.;
+  if( vars[7] > 200.) //gsfchi2
+    vars[7] = 200;
+  
+  if( vars[8] > 10.) //kfchi2
+    vars[8]  = 10.;
 
 }

--- a/RecoParticleFlow/PFProducer/python/pfGsfElectronMVASelector_cfi.py
+++ b/RecoParticleFlow/PFProducer/python/pfGsfElectronMVASelector_cfi.py
@@ -10,7 +10,12 @@ electronsWithPresel = cms.EDFilter("GsfElectronSelector",
 mvaElectrons = cms.EDFilter("ElectronIdMVABased",
                             vertexTag = cms.InputTag('offlinePrimaryVertices'),
                             electronTag = cms.InputTag('electronsWithPresel'),
-                            HZZmvaWeightFile = cms.string('RecoEgamma/ElectronIdentification/data/TMVA_BDTSimpleCat_17Feb2011.weights.xml'),
+                            HZZmvaWeightFile = cms.vstring(
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_10_17Feb2011.weights.xml",
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_12_17Feb2011.weights.xml",
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_20_17Feb2011.weights.xml",
+        "RecoEgamma/ElectronIdentification/data/TMVA_Category_BDTSimpleCat_22_17Feb2011.weights.xml"
+        ),
                             thresholdBarrel = cms.double( -0.1875 ),
                             thresholdEndcap = cms.double( -0.1075 ),
                             thresholdIsoDR03Barrel = cms.double( 10.0 ),

--- a/RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h
+++ b/RecoParticleFlow/PFTracking/interface/ConvBremHeavyObjectCache.h
@@ -1,7 +1,6 @@
 #ifndef __RecoParticleFlow_PFTracking_convbremhelpersHeavyObjectCache_h__
 #define __RecoParticleFlow_PFTracking_convbremhelpersHeavyObjectCache_h__
 
-
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
 #include "RecoParticleFlow/PFClusterTools/interface/PFEnergyCalibration.h"


### PR DESCRIPTION
Move GsfElectronAlgo / Producers to use edm::GlobalCache object + GBRForest.

This pull request features a few AdaBoost BDTs that are converted to GBRForest, using the functionality from #10275.

No physics changes expected beyond jitter.

cms-data PR here: https://github.com/cms-data/RecoEgamma-ElectronIdentification/pull/3
