### PR TITLE
Added IOVSyncValue information to NoRecordException

### DIFF
--- a/FWCore/Framework/interface/DependentRecordImplementation.h
+++ b/FWCore/Framework/interface/DependentRecordImplementation.h
@@ -21,6 +21,7 @@
 // system include files
 #include "boost/mpl/begin_end.hpp"
 #include "boost/mpl/find.hpp"
+#include <sstream>
 
 // user include files
 #include "FWCore/Framework/interface/EventSetupRecordImplementation.h"
@@ -51,12 +52,10 @@ class DependentRecordImplementation : public EventSetupRecordImplementation<Reco
         try {
           EventSetup const& eventSetupT = this->eventSetup();
           return eventSetupT.get<DepRecordT>();
-        } catch(NoRecordException<DepRecordT>&) {
-          //rethrow but this time with dependent information.
-          throw NoRecordException<DepRecordT>(this->key());
         } catch(cms::Exception& e) {
-          e<<"Exception occurred while getting dependent record from record \""<<
-          this->key().type().name()<<"\""<<std::endl;
+          std::ostringstream sstrm;
+          sstrm <<"While getting dependent Record from Record "<<this->key().type().name();
+          e.addContext(sstrm.str());
           throw;
         }
       }

--- a/FWCore/Framework/interface/NoRecordException.h
+++ b/FWCore/Framework/interface/NoRecordException.h
@@ -35,26 +35,25 @@
 
 // forward declarations
 namespace edm {
+   class IOVSyncValue;
+   class EventSetup;
    namespace eventsetup {
       class EventSetupRecordKey;
-      void no_record_exception_message_builder(cms::Exception&,const char*);
-      void no_dependent_record_exception_message_builder(cms::Exception&, const EventSetupRecordKey&, const char*);
+      void no_record_exception_message_builder(cms::Exception&,const char*, IOVSyncValue const&);
+      IOVSyncValue const& iovSyncValueFrom( edm::EventSetup const& );
+
 //NOTE: when EDM gets own exception hierarchy, will need to change inheritance
 template <class T>
 class NoRecordException : public cms::Exception
 {
  public:
   // ---------- Constructors and destructor ----------------
-  NoRecordException():cms::Exception("NoRecord")
+  explicit NoRecordException(IOVSyncValue const& iValue )
+  :cms::Exception("NoRecord")
   {
-    no_record_exception_message_builder(*this,heterocontainer::className<T>());
+    no_record_exception_message_builder(*this,heterocontainer::className<T>(), iValue);
   }
 
-
-  NoRecordException(const EventSetupRecordKey& iKey):cms::Exception("NoRecordFromDependentRecord")
-  {
-    no_dependent_record_exception_message_builder(*this,iKey,heterocontainer::className<T>());
-  }
       virtual ~NoRecordException() throw() {}
 
       // ---------- const member functions ---------------------

--- a/FWCore/Framework/interface/eventSetupGetImplementation.h
+++ b/FWCore/Framework/interface/eventSetupGetImplementation.h
@@ -31,7 +31,7 @@ namespace edm {
       inline void eventSetupGetImplementation(EventSetup const& iEventSetup, T const*& iValue) {
          T const* temp = heterocontainer::find<EventSetupRecordKey, T const>(iEventSetup);
          if(0 == temp) {
-            throw NoRecordException<T>();
+            throw NoRecordException<T>(iovSyncValueFrom(iEventSetup));
          }
          iValue = temp;
       }

--- a/FWCore/Framework/src/NoRecordException.cc
+++ b/FWCore/Framework/src/NoRecordException.cc
@@ -15,23 +15,25 @@
 // user include files
 #include "FWCore/Framework/interface/NoRecordException.h"
 #include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/IOVSyncValue.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/Exception.h"
 
-
-void
-edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException,const char* iName) {
-   oException
-   << "No \"" 
-   << iName
-   << "\" record found in the EventSetup.\n Please add an ESSource or ESProducer that delivers such a record.\n";
-}   
-
-void
-edm::eventsetup::no_dependent_record_exception_message_builder(cms::Exception& oException, const EventSetupRecordKey& iKey, const char* iName) {
-   oException
-   << "No \"" 
-   << iName
-   << "\" record found in the dependent record \""<<iKey.type().name()
-   << "\".\n Please add an ESSource or ESProducer that delivers the \""
-   << iName<<"\" record.";
+edm::IOVSyncValue const&
+edm::eventsetup::iovSyncValueFrom( EventSetup const& iES) {
+    return iES.iovSyncValue();
 }
+
+
+void
+edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException,const char* iName, IOVSyncValue const& iValue) {
+   oException
+   << "No \"" 
+   << iName
+   << "\" record found in the EventSetup for IOV\n"
+   << "Run: "<<iValue.eventID().run()
+   <<" LuminosityBlock: "<<iValue.luminosityBlockNumber()
+   <<" Event: "<<iValue.eventID().event()
+   <<" Time: "<<iValue.time().value()
+   <<"\n Please add an ESSource or ESProducer that delivers such a record.\n";
+}   


### PR DESCRIPTION
Added the printout of the present IOVSuncValue to the NoRecordException message to help diagnose cases where there is a problem with the IOVSyncValue being used which causes a Record to not have a valid IOV.
