### PR TITLE
Migrate leftover modules

### DIFF
--- a/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
+++ b/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
@@ -11,7 +11,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"

--- a/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
+++ b/CommonTools/UtilAlgos/interface/ProductFromFwdPtrProducer.h
@@ -25,7 +25,7 @@ namespace edm {
 
 
   template < class T, class H = ProductFromFwdPtrFactory<T> >
-  class ProductFromFwdPtrProducer : public edm::EDProducer {
+    class ProductFromFwdPtrProducer : public edm::global::EDProducer<> {
   public :
     explicit ProductFromFwdPtrProducer( edm::ParameterSet const & params ) :
       srcToken_   ( consumes< std::vector<edm::FwdPtr<T> > >( params.getParameter<edm::InputTag>("src") ) )
@@ -35,7 +35,7 @@ namespace edm {
 
     ~ProductFromFwdPtrProducer() {}
 
-    virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override {
+  virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override {
 
       edm::Handle< std::vector<edm::FwdPtr<T> > > hSrc;
       iEvent.getByToken( srcToken_, hSrc );
@@ -55,7 +55,7 @@ namespace edm {
     }
 
   protected :
-    edm::EDGetTokenT< std::vector<edm::FwdPtr<T> > > srcToken_;
+    const edm::EDGetTokenT< std::vector<edm::FwdPtr<T> > > srcToken_;
   };
 }
 

--- a/RecoEcal/EgammaClusterProducers/interface/CleanAndMergeProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/CleanAndMergeProducer.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -14,7 +14,7 @@
 #include "RecoEcal/EgammaCoreTools/interface/ClusterShapeAlgo.h"
 
 
-class CleanAndMergeProducer : public edm::EDProducer 
+class CleanAndMergeProducer : public edm::stream::EDProducer<>
 {
   
   public:

--- a/RecoEcal/EgammaClusterProducers/interface/CosmicClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/CosmicClusterProducer.h
@@ -6,7 +6,7 @@
 #include <vector> //TEMP JHAUPT 4-27
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -24,7 +24,7 @@
 //
 
 
-class CosmicClusterProducer : public edm::EDProducer 
+class CosmicClusterProducer : public edm::stream::EDProducer<>
 {
   public:
 

--- a/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdFromSuperClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/InterestingDetIdFromSuperClusterProducer.h
@@ -31,7 +31,7 @@ The following classes of "interesting id" are considered
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -44,7 +44,7 @@ The following classes of "interesting id" are considered
 class CaloTopology;
 class EcalSeverityLevelAlgo;
 
-class InterestingDetIdFromSuperClusterProducer : public edm::EDProducer {
+class InterestingDetIdFromSuperClusterProducer : public edm::stream::EDProducer<> {
    public:
       //! ctor
       explicit InterestingDetIdFromSuperClusterProducer(const edm::ParameterSet&);

--- a/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/PreshowerClusterProducer.h
@@ -3,7 +3,7 @@
 
 #include <memory>
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -18,7 +18,7 @@
 #include "CondFormats/ESObjects/interface/ESMissingEnergyCalibration.h"
 #include "CondFormats/ESObjects/interface/ESChannelStatus.h"
 
-class PreshowerClusterProducer : public edm::EDProducer {
+class PreshowerClusterProducer : public edm::stream::EDProducer<> {
 
  public:
 

--- a/RecoEcal/EgammaClusterProducers/interface/RecHitFilter.h
+++ b/RecoEcal/EgammaClusterProducers/interface/RecHitFilter.h
@@ -10,14 +10,14 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 
-class RecHitFilter : public edm::EDProducer {
+class RecHitFilter : public edm::global::EDProducer<> {
 
   public:
 
@@ -25,14 +25,14 @@ class RecHitFilter : public edm::EDProducer {
 
       ~RecHitFilter();
 
-      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
 
    private:
 
-      double        noiseEnergyThreshold_;
-      double        noiseChi2Threshold_;
-      std::string   reducedHitCollection_;
-      edm::EDGetTokenT<EcalRecHitCollection> hitCollection_;
+      const double        noiseEnergyThreshold_;
+      const double        noiseChi2Threshold_;
+      const std::string   reducedHitCollection_;
+      const edm::EDGetTokenT<EcalRecHitCollection> hitCollection_;
 
 
 };

--- a/RecoEcal/EgammaClusterProducers/interface/UncleanSCRecoveryProducer.h
+++ b/RecoEcal/EgammaClusterProducers/interface/UncleanSCRecoveryProducer.h
@@ -4,7 +4,7 @@
 #include <memory>
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 
@@ -14,25 +14,25 @@
 
 
 
-class UncleanSCRecoveryProducer : public edm::EDProducer 
+class UncleanSCRecoveryProducer : public edm::global::EDProducer<> 
 {
   
   public:
 
       UncleanSCRecoveryProducer(const edm::ParameterSet& ps);
 
-      virtual void produce(edm::Event&, const edm::EventSetup&);
+      virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
       
   private:
       // the clean collection      
-      edm::EDGetTokenT<reco::BasicClusterCollection>  cleanBcCollection_; 
-      edm::EDGetTokenT<reco::SuperClusterCollection>  cleanScCollection_; 
+      const edm::EDGetTokenT<reco::BasicClusterCollection>  cleanBcCollection_; 
+      const edm::EDGetTokenT<reco::SuperClusterCollection>  cleanScCollection_; 
       // the uncleaned collection
-      edm::EDGetTokenT<reco::BasicClusterCollection>  uncleanBcCollection_;
-      edm::EDGetTokenT<reco::SuperClusterCollection>  uncleanScCollection_;
+      const edm::EDGetTokenT<reco::BasicClusterCollection>  uncleanBcCollection_;
+      const edm::EDGetTokenT<reco::SuperClusterCollection>  uncleanScCollection_;
       // the names of the products to be produced:
-      std::string  bcCollection_;     
-      std::string  scCollection_;     
+      const std::string  bcCollection_;     
+      const std::string  scCollection_;     
 
 
 };

--- a/RecoEcal/EgammaClusterProducers/src/RecHitFilter.cc
+++ b/RecoEcal/EgammaClusterProducers/src/RecHitFilter.cc
@@ -25,15 +25,12 @@
 #include "RecoEcal/EgammaClusterProducers/interface/RecHitFilter.h"
 
 
-RecHitFilter::RecHitFilter(const edm::ParameterSet& ps)
+RecHitFilter::RecHitFilter(const edm::ParameterSet& ps):
+  noiseEnergyThreshold_(ps.getParameter<double>("noiseEnergyThreshold")),
+  noiseChi2Threshold_(ps.getParameter<double>("noiseChi2Threshold")),
+  reducedHitCollection_(ps.getParameter<std::string>("reducedHitCollection")),
+  hitCollection_(consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("hitCollection")))  
 {
-
-  noiseEnergyThreshold_  = ps.getParameter<double>("noiseEnergyThreshold");
-  noiseChi2Threshold_    = ps.getParameter<double>("noiseChi2Threshold");
-  hitCollection_         = 
-	  consumes<EcalRecHitCollection>(ps.getParameter<edm::InputTag>("hitCollection"));
-  reducedHitCollection_  = ps.getParameter<std::string>("reducedHitCollection");
-
   produces< EcalRecHitCollection >(reducedHitCollection_);
 }
 
@@ -43,7 +40,7 @@ RecHitFilter::~RecHitFilter()
 }
 
 
-void RecHitFilter::produce(edm::Event& evt, const edm::EventSetup& es)
+void RecHitFilter::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const
 {
   // get the hit collection from the event:
   edm::Handle<EcalRecHitCollection> rhcHandle;

--- a/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
+++ b/RecoEcal/EgammaClusterProducers/src/UncleanSCRecoveryProducer.cc
@@ -35,37 +35,22 @@ many thanks to David Wardrope, Shahram Rahatlou and Federico Ferri
 */
 
 
-UncleanSCRecoveryProducer::UncleanSCRecoveryProducer(const edm::ParameterSet& ps)
+UncleanSCRecoveryProducer::UncleanSCRecoveryProducer(const edm::ParameterSet& ps):
+  cleanBcCollection_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("cleanBcCollection"))),
+  cleanScCollection_(consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScCollection"))),
+  uncleanBcCollection_(consumes<reco::BasicClusterCollection>(ps.getParameter<edm::InputTag>("uncleanBcCollection"))),
+  uncleanScCollection_(consumes<reco::SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScCollection"))),
+  bcCollection_(ps.getParameter<std::string>("bcCollection")),
+  scCollection_(ps.getParameter<std::string>("scCollection"))
 {
-
-	    using  reco::BasicClusterCollection;
-	    using  reco::SuperClusterCollection;
-
-        // get the parameters
-        // the cleaned collection:
-	    cleanBcCollection_ = 
-			consumes<BasicClusterCollection>(ps.getParameter<edm::InputTag>("cleanBcCollection"));
-        cleanScCollection_ = 
-			consumes<SuperClusterCollection>(ps.getParameter<edm::InputTag>("cleanScCollection"));
- 
-        // the uncleaned collection
-        uncleanBcCollection_ = 
-			consumes<BasicClusterCollection>(ps.getParameter<edm::InputTag>("uncleanBcCollection"));
-        uncleanScCollection_ = 
-			consumes<SuperClusterCollection>(ps.getParameter<edm::InputTag>("uncleanScCollection"));
-        // the names of the products to be produced:
-        bcCollection_ = ps.getParameter<std::string>("bcCollection");
-        scCollection_ = ps.getParameter<std::string>("scCollection");
         // the products:
         produces< reco::BasicClusterCollection >(bcCollection_);
         produces< reco::SuperClusterCollection >(scCollection_);
-
-
 }
 
 
-void UncleanSCRecoveryProducer::produce(edm::Event& evt, 
-                                        const edm::EventSetup& es)
+void UncleanSCRecoveryProducer::produce(edm::StreamID, edm::Event& evt, 
+                                        const edm::EventSetup& es) const
 {
         // __________________________________________________________________________
         //

--- a/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCollectionMerger.cc
+++ b/RecoParticleFlow/PFClusterProducer/plugins/PFClusterCollectionMerger.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -13,7 +13,7 @@
 #include "DataFormats/ParticleFlowReco/interface/PFCluster.h"
 #include "DataFormats/ParticleFlowReco/interface/PFClusterFwd.h"
 
-class PFClusterCollectionMerger : public edm::EDProducer {
+class PFClusterCollectionMerger : public edm::global::EDProducer<> {
 public: 
   PFClusterCollectionMerger(const edm::ParameterSet& conf) {
     const std::vector<edm::InputTag>& inputs = 
@@ -24,7 +24,7 @@ public:
     produces<reco::PFClusterCollection>();
   }
 
-  virtual void produce(edm::Event& e, const edm::EventSetup& es) {
+  virtual void produce(edm::StreamID, edm::Event& e, const edm::EventSetup& es) const {
     std::auto_ptr<reco::PFClusterCollection> output;
     output.reset(new reco::PFClusterCollection);
     for( const auto& input : _inputs ) {

--- a/RecoParticleFlow/PFClusterTools/interface/CalibratableTest.h
+++ b/RecoParticleFlow/PFClusterTools/interface/CalibratableTest.h
@@ -6,7 +6,7 @@
 #include <vector>
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -54,7 +54,7 @@
  * General details about the usage of Calibratable may be found at,
  * 		https://twiki.cern.ch/twiki/bin/view/CMS/PFClusterToolsPackage
  */
-class CalibratableTest : public edm::EDAnalyzer {
+class CalibratableTest : public edm::one::EDAnalyzer<> {
 public:
 	explicit CalibratableTest(const edm::ParameterSet&);
 	~CalibratableTest();
@@ -70,7 +70,7 @@ private:
 	 * The usual EDAnalyzer methods
 	 */
 	virtual void beginJob();
-	virtual void analyze(const edm::Event&, const edm::EventSetup&);
+	virtual void analyze(const edm::Event&, const edm::EventSetup&) override;
 	virtual void endJob();
 
 	/*


### PR DESCRIPTION
Migrate some leftover modules to the threaded framework.
Most seem to be deprecated.
