### PR TITLE
Change to appropriate function name for 76X

### DIFF
--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -118,5 +118,5 @@ def customiseHLTforCMSSW(process,menuType="GRun",fastSim=False):
         process = customiseFor10087(process)
         process = customizeHLTforNewJetCorrectors(process)
     if cmsswVersion >= "CMSSW_7_4":
-        process = customiseFor10234(process)
+        process = customiseFor10087(process)
     return process


### PR DESCRIPTION
Appears to be the same function with different PR number.
Right now this stops the RECO step from functioning in 76X IBs.
Older releases are OK.

@mulhearn You may want to double check what happened here.

Since this is for 76X and not any other cmssw (as for 74X and 75X...) I don't really see the need for the if statements in this customization function to begin with.
