### PR TITLE
Better fix to handle the error in the PVsorting

### DIFF
--- a/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
@@ -47,9 +47,12 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
 	sumPtErr2+=ptErr*ptErr;
     }
     auto p4 = LorentzVector( pj.px(), pj.py(), pj.pz(), pj.e() ) ;
-    if(p4.pt()*p4.pt() > sumPtErr2) sumPt2+=(p4.pt()*p4.pt()-sumPtErr2)*0.8*0.8;
-    met+=p4;
-    sumEt+=p4.pt();
+    if(p4.pt()*p4.pt() > sumPtErr2)
+      {
+         sumPt2+=(p4.pt()*p4.pt()-sumPtErr2)*0.8*0.8;
+         met+=p4;
+         sumEt+=p4.pt()+sumPtErr2;
+      }
   }
   float metAbove = met.pt() - 2*sqrt(sumEt);
   if(metAbove > 0 and useMet) {

--- a/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
+++ b/CommonTools/RecoAlgos/src/PrimaryVertexSorting.cc
@@ -23,36 +23,31 @@ float PrimaryVertexSorting::score(const reco::Vertex & pv,const  std::vector<con
   fjInputs_.clear();
   for (size_t i = 0 ; i < cands.size(); i++) {
     const reco::Candidate * c= cands[i];
+    float scale=1.;
+    if(c->bestTrack() != 0)
+      {
+        scale=(c->pt()-c->bestTrack()->ptError())/c->pt();
+        if(scale<0) scale=0;
+      }
+
     int absId=abs(c->pdgId());
     if(absId==13 or absId == 11) {
-      float pt =c->pt();
-      float ptErr = (c->bestTrack() != 0)?c->bestTrack()->ptError() :0;
-      if(pt > ptErr) pt-=ptErr; else pt=0;
+      float pt =c->pt()*scale;
       sumPt2+=pt*pt;
-      met+=c->p4();
-      sumEt+=c->pt();
+      met+=c->p4()*scale;
+      sumEt+=c->pt()*scale;
     } else {
-      fjInputs_.push_back(fastjet::PseudoJet(c->px(),c->py(),c->pz(),c->p4().E()));
-      fjInputs_.back().set_user_index(i);
+      fjInputs_.push_back(fastjet::PseudoJet(c->px()*scale,c->py()*scale,c->pz()*scale,c->p4().E()*scale));
+//      fjInputs_.back().set_user_index(i);
     }
   }
   fastjet::ClusterSequence sequence( fjInputs_, JetDefinition(antikt_algorithm, 0.4));
   auto jets = fastjet::sorted_by_pt(sequence.inclusive_jets(0));
   for (const auto & pj : jets) {
-    float sumPtErr2=0;
-    std::vector<fastjet::PseudoJet> constituents = pj.constituents();
-    for (unsigned j = 0; j < constituents.size(); j++) {
-	const reco::Candidate * c = cands[constituents[j].user_index()];
-        float ptErr = (c->bestTrack() != 0)?c->bestTrack()->ptError() :0;
-	sumPtErr2+=ptErr*ptErr;
-    }
     auto p4 = LorentzVector( pj.px(), pj.py(), pj.pz(), pj.e() ) ;
-    if(p4.pt()*p4.pt() > sumPtErr2)
-      {
-         sumPt2+=(p4.pt()*p4.pt()-sumPtErr2)*0.8*0.8;
-         met+=p4;
-         sumEt+=p4.pt()+sumPtErr2;
-      }
+    sumPt2+=(p4.pt()*p4.pt())*0.8*0.8;
+    met+=p4;
+    sumEt+=p4.pt();
   }
   float metAbove = met.pt() - 2*sqrt(sumEt);
   if(metAbove > 0 and useMet) {

--- a/CommonTools/RecoAlgos/test/pvSorting.py
+++ b/CommonTools/RecoAlgos/test/pvSorting.py
@@ -5,18 +5,21 @@ process.load("Configuration.StandardSequences.MagneticField_cff")
 process.load("Configuration.Geometry.GeometryIdeal_cff")
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cff")
 process.load("Configuration.StandardSequences.Reconstruction_cff")
-process.GlobalTag.globaltag = 'POSTLS172_V4::All'
-
+from Configuration.AlCa.GlobalTag import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_mc', '')
 
 process.source = cms.Source("PoolSource",
+#   skipEvents=cms.untracked.uint32(0),
     fileNames = cms.untracked.vstring(
-     'file:8A676D55-1186-E411-921D-02163E0104B8.root'
+#'root://xrootd.ba.infn.it//store/mc/RunIISpring15DR74/WprimeToWZToLLQQ_M-4000_TuneCUETP8M1_13TeV-pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/10000/126A3AFB-9607-E511-A527-90B11C12EA74.root'
+    'root://xrootd.ba.infn.it//store/mc/RunIISpring15DR74/WprimeToMuNu_M-5800_TuneCUETP8M1_13TeV-pythia8/AODSIM/Asympt50ns_MCRUN2_74_V9A-v2/10000/580F0D5E-760C-E511-A9D6-047D7B881D62.root'
+#     'file:../../../00387B2C-4A1C-E511-A4E0-0026189438B3.root'
     )
 )
 
 
 process.options   = cms.untracked.PSet( wantSummary = cms.untracked.bool(True))
-process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(100) )
+process.maxEvents = cms.untracked.PSet( input = cms.untracked.int32(500) )
 process.load("Configuration.EventContent.EventContent_cff")
 process.out = cms.OutputModule(
     "PoolOutputModule",
@@ -31,9 +34,22 @@ process.load("CommonTools.RecoAlgos.sortedPrimaryVertices_cfi")
 process.load("CommonTools.RecoAlgos.sortedPFPrimaryVertices_cfi")
 
 process.sortedPrimaryVertices.jets = "ak4CaloJets"
-process.sortedPFPrimaryVerticesNoMET = process.sortedPFPrimaryVertices.clone(usePVMET=False)
-process.sortedPrimaryVerticesNoMET = process.sortedPrimaryVertices.clone(usePVMET=False,jets="ak4CaloJets")
-process.p = cms.Path(process.sortedPFPrimaryVertices*process.sortedPrimaryVertices*process.sortedPFPrimaryVerticesNoMET*process.sortedPrimaryVerticesNoMET)
+#process.sortedPFPrimaryVerticesNoMET = process.sortedPFPrimaryVertices.clone(usePVMET=False)
+#process.sortedPrimaryVerticesNoMET = process.sortedPrimaryVertices.clone(usePVMET=False,jets="ak4CaloJets")
+#process.p = cms.Path(process.sortedPFPrimaryVertices*process.sortedPrimaryVertices*process.sortedPFPrimaryVerticesNoMET*process.sortedPrimaryVerticesNoMET)
+
+from CommonTools.RecoAlgos.TrackWithVertexRefSelector_cfi import *
+from RecoJets.JetProducers.TracksForJets_cff import *
+from CommonTools.RecoAlgos.sortedPrimaryVertices_cfi import *
+from RecoJets.JetProducers.caloJetsForTrk_cff import *
+
+process.trackWithVertexRefSelectorBeforeSorting = trackWithVertexRefSelector.clone(vertexTag="offlinePrimaryVertices")
+process.trackWithVertexRefSelectorBeforeSorting.ptMax=9e99
+process.trackWithVertexRefSelectorBeforeSorting.ptErrorCut=9e99
+process.trackRefsForJetsBeforeSorting = trackRefsForJets.clone(src="trackWithVertexRefSelectorBeforeSorting")
+process.sortedPrimaryVertices.particles="trackRefsForJetsBeforeSorting"
+
+process.p = cms.Path(process.trackWithVertexRefSelectorBeforeSorting+process.trackRefsForJetsBeforeSorting+process.sortedPrimaryVertices)
 
 process.endpath = cms.EndPath(
     process.out


### PR DESCRIPTION
This implements p4 scaling as a way to subtract the pt uncertainty in the PV sorting. Using the scaling also MET variable is protected against high pt / high error tracks.

This should also fix the Zmumu issue reported by @battibass

@slava77 

this same branch can be used for 76X PR
