### PR TITLE
pull request subject 

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.cc
@@ -44,6 +44,9 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
+#include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
+
 #include <string>
 
 using namespace reco ;
@@ -83,6 +86,14 @@ ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
      maxHEndcaps_=conf_.getParameter<double>("maxHEndcaps") ;
    }
 
+  applySigmaIEtaIEtaCut_ = conf_.getParameter<bool>("applySigmaIEtaIEtaCut");
+
+  if (applySigmaIEtaIEtaCut_ == true)
+    {
+      maxSigmaIEtaIEtaBarrel_ = conf_.getParameter<double>("maxSigmaIEtaIEtaBarrel");
+      maxSigmaIEtaIEtaEndcaps_ = conf_.getParameter<double>("maxSigmaIEtaIEtaEndcaps");
+    }
+
   edm::ParameterSet rpset = conf_.getParameter<edm::ParameterSet>("RegionPSet");
   filterVtxTag_ = consumes<std::vector<reco::Vertex> >(rpset.getParameter<edm::InputTag> ("VertexProducer"));
 
@@ -94,6 +105,12 @@ ElectronSeedProducer::ElectronSeedProducer( const edm::ParameterSet& iConfig )
   matcher_ = new ElectronSeedGenerator(conf_,esg_tokens) ;
 
   //  get collections from config'
+
+  if (applySigmaIEtaIEtaCut_ == true) {
+    ebRecHitCollection_ = consumes<EcalRecHitCollection> (iConfig.getParameter<edm::InputTag>("ebRecHitCollection"));
+    eeRecHitCollection_ = consumes<EcalRecHitCollection> (iConfig.getParameter<edm::InputTag>("eeRecHitCollection"));
+  }
+
   superClusters_[0]=
     consumes<reco::SuperClusterCollection>(iConfig.getParameter<edm::InputTag>("barrelSuperClusters")) ;
   superClusters_[1]=
@@ -177,7 +194,7 @@ void ElectronSeedProducer::produce(edm::Event& e, const edm::EventSetup& iSetup)
     e.getByToken(superClusters_[i],clusters);
     SuperClusterRefVector clusterRefs ;
     std::vector<float> hoe1s, hoe2s ;
-    filterClusters(*theBeamSpot,clusters,/*mhbhe_,*/clusterRefs,hoe1s,hoe2s);
+    filterClusters(*theBeamSpot,clusters,/*mhbhe_,*/clusterRefs,hoe1s,hoe2s, e, iSetup);
     if ((fromTrackerSeeds_) && (prefilteredSeeds_))
       { filterSeeds(e,iSetup,clusterRefs) ; }
     matcher_->run(e,iSetup,clusterRefs,hoe1s,hoe2s,theInitialSeedColl,*seeds);
@@ -211,8 +228,12 @@ void ElectronSeedProducer::filterClusters
  ( const reco::BeamSpot & bs,
    const edm::Handle<reco::SuperClusterCollection> & superClusters,
    SuperClusterRefVector & sclRefs,
-   std::vector<float> & hoe1s, std::vector<float> & hoe2s )
+   std::vector<float> & hoe1s, std::vector<float> & hoe2s,
+   edm::Event & event, const edm::EventSetup & setup)
  {
+   std::vector<float> sigmaIEtaIEtaEB_;
+   std::vector<float> sigmaIEtaIEtaEE_;
+
   for (unsigned int i=0;i<superClusters->size();++i)
    {
     const SuperCluster & scl = (*superClusters)[i] ;
@@ -247,6 +268,16 @@ void ElectronSeedProducer::filterClusters
          hoe2s.push_back(std::numeric_limits<float>::infinity()) ;
         }
      }
+
+    if (applySigmaIEtaIEtaCut_ == true)
+      {
+	noZS::EcalClusterLazyTools lazyTool_noZS(event, setup, ebRecHitCollection_, eeRecHitCollection_);
+	std::vector<float> vCov = lazyTool_noZS.localCovariances(*(scl.seed()));
+        int detector = scl.seed()->hitsAndFractions()[0].first.subdetId() ;
+        if (detector==EcalBarrel) sigmaIEtaIEtaEB_ .push_back(isnan(vCov[0]) ? 0. : sqrt(vCov[0]));
+        if (detector==EcalEndcap) sigmaIEtaIEtaEE_ .push_back(isnan(vCov[0]) ? 0. : sqrt(vCov[0]));
+      }
+
    }
   LogDebug("ElectronSeedProducer")<<"Filtered out "<<sclRefs.size()<<" superclusters from "<<superClusters->size() ;
  }
@@ -297,6 +328,8 @@ ElectronSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
     psd0.add<edm::InputTag>("hcalTowers",edm::InputTag("towerMaker"));
     psd0.add<double>("LowPtThreshold",5.0);
     psd0.add<double>("maxHOverEBarrel",0.15);
+    psd0.add<double>("maxSigmaIEtaIEtaBarrel", 0.5);
+    psd0.add<double>("maxSigmaIEtaIEtaEndcaps", 0.5);
     psd0.add<bool>("dynamicPhiRoad",true);
     psd0.add<double>("ePhiMax1",0.075);
     psd0.add<std::string>("measurementTrackerName","");
@@ -323,6 +356,10 @@ ElectronSeedProducer::fillDescriptions(edm::ConfigurationDescriptions& descripti
     psd0.add<edm::InputTag>("measurementTrackerEvent",edm::InputTag("MeasurementTrackerEvent"));
     psd0.add<edm::InputTag>("vertices",edm::InputTag("offlinePrimaryVerticesWithBS"));
     psd0.add<bool>("applyHOverECut",true);
+    psd0.add<edm::InputTag>("ebRecHitCollection", edm::InputTag("ecalRecHit", "EcalRecHitsEB"));
+    psd0.add<edm::InputTag>("eeRecHitCollection", edm::InputTag("ecalRecHit", "EcalRecHitsEE"));
+    psd0.add<bool>("applySigmaIEtaIEtaCut", false);
+
     psd0.add<double>("DeltaPhi2F",0.012);
     psd0.add<double>("PhiMin2F",-0.003);
     psd0.add<double>("hOverEHFMinE",0.8);

--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
@@ -36,6 +36,7 @@ namespace edm
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/Handle.h"
 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 
 class ElectronSeedProducer : public edm::stream::EDProducer<>
  {
@@ -57,13 +58,15 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
       ( const reco::BeamSpot & bs,
 	const edm::Handle<reco::SuperClusterCollection> & superClusters,
 	reco::SuperClusterRefVector &sclRefs,
-	std::vector<float> & hoe1s, std::vector<float> & hoe2s ) ;
+	std::vector<float> & hoe1s, std::vector<float> & hoe2s, edm::Event& e, const edm::EventSetup& setup ) ;
     void filterSeeds(edm::Event& e, const edm::EventSetup& setup, reco::SuperClusterRefVector &sclRefs);
     
     edm::EDGetTokenT<reco::SuperClusterCollection> superClusters_[2] ;
     edm::EDGetTokenT<TrajectorySeedCollection> initialSeeds_ ;
     edm::EDGetTokenT<std::vector<reco::Vertex> > filterVtxTag_;
     edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_ ;
+    edm::EDGetTokenT<EcalRecHitCollection> ebRecHitCollection_;
+    edm::EDGetTokenT<EcalRecHitCollection> eeRecHitCollection_;
 
     edm::ParameterSet conf_ ;
     ElectronSeedGenerator * matcher_ ;
@@ -94,6 +97,10 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
     //  double hOverEHFMinE_;
     // super cluster Et cut
     double SCEtCut_;
+
+    bool applySigmaIEtaIEtaCut_;
+    double maxSigmaIEtaIEtaBarrel_;
+    double maxSigmaIEtaIEtaEndcaps_;
 
     bool fromTrackerSeeds_;
     bool prefilteredSeeds_;

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -34,7 +34,12 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
     # H/E towers
     hcalTowers = cms.InputTag("towerMaker"),
     hOverEPtMin = cms.double(0.),
-    
+
+    # sigma_ietaieta
+    applySigmaIEtaIEtaCut = cms.bool(False),
+    maxSigmaIEtaIEtaBarrel = cms.double(0.5),
+    maxSigmaIEtaIEtaEndcaps = cms.double(0.5),
+
     # r/z windows
     nSigmasDeltaZ1 = cms.double(5.), ## in case beam spot is used for the matching
     deltaZ1WithVertex = cms.double(25.), ## in case reco vertex is used for the matching


### PR DESCRIPTION
@slava77 
This is the description of pull request:
Adding variable of sigma_ieta_ieta at seeding level for electron in HI reconstruction. The link to describe sigma_ieta_ieta cut is powerful to kill fake electron (which screw up the jet resolution in jet analysis) can be found here: https://twiki.cern.ch/twiki/pub/CMS/PhotonAnalyses2015/20150616.pdf. This variable was added and got PR successfully for 7_6_X. However, we would like to make a back port for 7_5_X since we will use 7_5_X for data taking in heavy ion
the number of the PR in 76X: #10194

Do I need to change the PR subject?
