### PR TITLE
MiniAOD reprocessing (74X, BTV): Enable CSVv2 in combinedMVA instead of CSV

### DIFF
--- a/RecoBTau/JetTagComputer/python/candidateCombinedMVAComputer_cfi.py
+++ b/RecoBTau/JetTagComputer/python/candidateCombinedMVAComputer_cfi.py
@@ -12,7 +12,7 @@ candidateCombinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('candidateCombinedSecondaryVertexComputer')
+			jetTagComputer = cms.string('candidateCombinedSecondaryVertexV2Computer')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),

--- a/RecoBTau/JetTagComputer/python/combinedMVAComputer_cfi.py
+++ b/RecoBTau/JetTagComputer/python/combinedMVAComputer_cfi.py
@@ -12,7 +12,7 @@ combinedMVAComputer = cms.ESProducer("CombinedMVAJetTagESProducer",
 		cms.PSet(
 			discriminator = cms.bool(True),
 			variables = cms.bool(False),
-			jetTagComputer = cms.string('combinedSecondaryVertexComputer')
+			jetTagComputer = cms.string('combinedSecondaryVertexV2Computer')
 		),
 		cms.PSet(
 			discriminator = cms.bool(True),


### PR DESCRIPTION
Backport of #9208

This PR is part of preparations for possible MiniAOD reprocessing of the Spring15 MC and 50ns Run2012B Data in 74X. More info at the following links:
- https://hypernews.cern.ch/HyperNews/CMS/get/physics-validation/2445.html
- https://twiki.cern.ch/twiki/bin/view/CMS/MiniAODSpring15pass2#BTV
