### PR TITLE
MiniAOD reprocessing (74X, BTV): Removing CSV+SL and adding SL taggers to the default PAT jet configuration

### DIFF
--- a/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
+++ b/PhysicsTools/PatAlgos/python/producersLayer1/jetProducer_cfi.py
@@ -45,7 +45,8 @@ patJets = cms.EDProducer("PATJetProducer",
         cms.InputTag("pfSimpleSecondaryVertexHighPurBJetTags"),
         cms.InputTag("pfCombinedSecondaryVertexV2BJetTags"),
         cms.InputTag("pfCombinedInclusiveSecondaryVertexV2BJetTags"),
-        cms.InputTag("pfCombinedSecondaryVertexSoftLeptonBJetTags"),
+        cms.InputTag("softPFMuonBJetTags"),
+        cms.InputTag("softPFElectronBJetTags"),
         cms.InputTag("pfCombinedMVABJetTags")
     ),
     # clone tag infos ATTENTION: these take lots of space!


### PR DESCRIPTION
Backport of #10157

This PR is part of preparations for possible MiniAOD reprocessing of the Spring15 MC and 50ns Run2012B Data in 74X. More info at the following links:
- https://hypernews.cern.ch/HyperNews/CMS/get/physics-validation/2445.html
- https://twiki.cern.ch/twiki/bin/view/CMS/MiniAODSpring15pass2#BTV
