### PR TITLE
Fixed invalid reference bug when # of tracks exceeds 32767

### DIFF
--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -790,7 +790,7 @@ TrackListMerger::~TrackListMerger() { }
 	TrajTrackAssociationCollection::const_iterator match = hTTAss1->find(trajRef);
 	if (match != hTTAss1->end()) {
 	  const edm::Ref<reco::TrackCollection> &trkRef = match->val;
-	  short oldKey = trackCollFirsts[ti]+static_cast<short>(trkRef.key());
+	  int oldKey = trackCollFirsts[ti]+static_cast<int>(trkRef.key());
 	  if (trackRefs[oldKey].isNonnull()) {
 	    outputTrajs->push_back( *trajRef );
 	    //if making extras and the seeds at the same time, change the seed ref on the trajectory

--- a/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
+++ b/RecoTracker/FinalTrackSelectors/plugins/TrackListMerger.cc
@@ -790,7 +790,7 @@ TrackListMerger::~TrackListMerger() { }
 	TrajTrackAssociationCollection::const_iterator match = hTTAss1->find(trajRef);
 	if (match != hTTAss1->end()) {
 	  const edm::Ref<reco::TrackCollection> &trkRef = match->val;
-	  int oldKey = trackCollFirsts[ti]+static_cast<int>(trkRef.key());
+	  uint32_t oldKey = trackCollFirsts[ti]+static_cast<uint32_t>(trkRef.key());
 	  if (trackRefs[oldKey].isNonnull()) {
 	    outputTrajs->push_back( *trajRef );
 	    //if making extras and the seeds at the same time, change the seed ref on the trajectory


### PR DESCRIPTION
The invalid reference bug was fixed using integer instead of short type for keys in track collection. Number of tracks can exceed 32767.
