### PR TITLE
Backport of #10194 :Add shower-shape cut capability to electron seed producer

### DIFF
--- a/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
+++ b/RecoEgamma/EgammaElectronProducers/plugins/ElectronSeedProducer.h
@@ -36,6 +36,7 @@ namespace edm
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "DataFormats/Common/interface/Handle.h"
 
+#include "RecoEcal/EgammaCoreTools/interface/EcalClusterLazyTools.h"
 
 class ElectronSeedProducer : public edm::stream::EDProducer<>
  {
@@ -57,13 +58,15 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
       ( const reco::BeamSpot & bs,
 	const edm::Handle<reco::SuperClusterCollection> & superClusters,
 	reco::SuperClusterRefVector &sclRefs,
-	std::vector<float> & hoe1s, std::vector<float> & hoe2s ) ;
+	std::vector<float> & hoe1s, std::vector<float> & hoe2s, edm::Event& e, const edm::EventSetup& setup ) ;
     void filterSeeds(edm::Event& e, const edm::EventSetup& setup, reco::SuperClusterRefVector &sclRefs);
     
     edm::EDGetTokenT<reco::SuperClusterCollection> superClusters_[2] ;
     edm::EDGetTokenT<TrajectorySeedCollection> initialSeeds_ ;
     edm::EDGetTokenT<std::vector<reco::Vertex> > filterVtxTag_;
     edm::EDGetTokenT<reco::BeamSpot> beamSpotTag_ ;
+    edm::EDGetTokenT<EcalRecHitCollection> ebRecHitCollection_;
+    edm::EDGetTokenT<EcalRecHitCollection> eeRecHitCollection_;
 
     edm::ParameterSet conf_ ;
     ElectronSeedGenerator * matcher_ ;
@@ -94,6 +97,10 @@ class ElectronSeedProducer : public edm::stream::EDProducer<>
     //  double hOverEHFMinE_;
     // super cluster Et cut
     double SCEtCut_;
+
+    bool applySigmaIEtaIEtaCut_;
+    double maxSigmaIEtaIEtaBarrel_;
+    double maxSigmaIEtaIEtaEndcaps_;
 
     bool fromTrackerSeeds_;
     bool prefilteredSeeds_;

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeedsParameters_cff.py
@@ -34,7 +34,12 @@ ecalDrivenElectronSeedsParameters = cms.PSet(
     # H/E towers
     hcalTowers = cms.InputTag("towerMaker"),
     hOverEPtMin = cms.double(0.),
-    
+
+    # sigma_ietaieta
+    applySigmaIEtaIEtaCut = cms.bool(False),
+    maxSigmaIEtaIEtaBarrel = cms.double(0.5),
+    maxSigmaIEtaIEtaEndcaps = cms.double(0.5),    
+
     # r/z windows
     nSigmasDeltaZ1 = cms.double(5.), ## in case beam spot is used for the matching
     deltaZ1WithVertex = cms.double(25.), ## in case reco vertex is used for the matching

--- a/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cfi.py
+++ b/RecoEgamma/EgammaElectronProducers/python/ecalDrivenElectronSeeds_cfi.py
@@ -9,6 +9,8 @@ from RecoEgamma.EgammaElectronProducers.ecalDrivenElectronSeedsParameters_cff im
 ecalDrivenElectronSeeds = cms.EDProducer("ElectronSeedProducer",
     barrelSuperClusters = cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel"),
     endcapSuperClusters = cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower"),
+    #ebRecHitCollection  = cms.InputTag("ecalRecHit", "EcalRecHitsEB"),
+    #eeRecHitCollection  = cms.InputTag("ecalRecHit", "EcalRecHitsEE"),
     SeedConfiguration = cms.PSet(
         ecalDrivenElectronSeedsParameters,
 #        OrderedHitsFactoryPSet = cms.PSet(


### PR DESCRIPTION
This is a backport of PR #10194 to 7_5_X, and it will add shower-shape cut capability to the electron seed producer.

This supersedes PRs #10349 and #10331 which @doanhien was handling, but she is at a conference now and I will handle the PR. You can close those two PRs.

This PR makes the new cut default to OFF, so no changes are expected to occur. A follow-up PR which enables this cut along with others for Heavy-Ion workflows will follow later this week.

This PR passes matrices 5.1 and 140.53, and I can include the log output if requested.
