### PR TITLE
Fix index increment in MultiTrackValidator for the presence of continues in loop body

### DIFF
--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -423,7 +423,7 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
 
   int w=0; //counter counting the number of sets of histograms
   for (unsigned int ww=0;ww<associators.size();ww++){
-    for (unsigned int www=0;www<label.size();www++){
+    for (unsigned int www=0;www<label.size();www++, w++){ // need to increment w here, since there are many continues in the loop body
       //
       //get collections from the event
       //
@@ -737,8 +737,6 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
                                  << "Total Reconstructed: " << rT << "\n"
                                  << "Total Associated (recoToSim): " << at << "\n"
                                  << "Total Fakes: " << rT-at << "\n";
-
-      w++;
     } // End of  for (unsigned int www=0;www<label.size();www++){
   } //END of for (unsigned int ww=0;ww<associators.size();ww++){
 


### PR DESCRIPTION
This PR fixes a bug in MultiTrackValidator whose effect became enhanced in #10219. The innermost loop over track collections increments the index to histograms at the very end of the loop body. However, the there are `continue` statements within the body (one of them getting enabled in #10219), which prevent the index being increased. The effect is that histograms for other track collection get filled. The bug is fixed by moving the index increment inside the `for(;;)` clause.

Tested in CMSSW_7_6_X_2015-07-25-2300, expecting changes under `TrackAllTPEffic` folder (migration of tracks from `generalTracks` histograms to `cutsRecoHp` histograms that were empty before).

@rovere @VinInn 
