### PR TITLE
Fixing Errors due to LA in PixelPhase1

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -186,7 +186,7 @@ def customise_Reco(process,pileup):
     #use with latest pixel geometry
     process.ClusterShapeHitFilterESProducer.PixelShapeFile = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par')
     # Need this line to stop error about missing siPixelDigis.
-    process.MeasurementTracker.inactivePixelDetectorLabels = cms.VInputTag()
+    process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
 
     # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
     process.PixelLayerTriplets.layerList = cms.vstring( 'BPix1+BPix2+BPix3',
@@ -364,7 +364,14 @@ def customise_Reco(process,pileup):
     process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
     process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
     process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
-
-
+    process.templates.DoLorentz=False
+    process.templates.LoadTemplatesFromDB = cms.bool(False)
+    process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
+    process.GlobalTag.toGet = cms.VPSet(
+        cms.PSet(record = cms.string("SiPixelLorentzAngleRcd"),
+                 tag = cms.string("SiPixelLorentzAngle_0_106_612_slhc1_mc"),
+                 connect = cms.string("frontier://FrontierProd/CMS_COND_31X_PIXEL")
+                 )
+        )
 
     return process


### PR DESCRIPTION
This PR is fixing the errors related to the LorentzAngle in Phase1 WF (2017 scenario) noticed in the step3 of  runTheMatrix.py -w upgrade -l 10000.0 
Even this PR can be merged independently (also not affecting any of the run1/run2 workflows) , the previous command can run only once PR #10353 is merged 
@mmusich, @diguida :  Note that we are included 'manually' the DB tag for LA in a custom python file  as long as we do not have a working GT

Last comment:  even if it cures a crash in step3, the PR doesn't fix completely the phase1 workflow as I still do observed another crash  in the reconstruction (which seems a priori to be related to tracking reconstruction and will be adressed to the relevant parties) 
@venturia @mark-grimes , FYI
