### PR TITLE
Add possibility to select tracks by originalAlgo or algoMask to RecoTrackSelectors

### DIFF
--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -35,6 +35,8 @@ public:
         algorithm_.push_back(reco::TrackBase::algoByName(algorithm));
       for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("originalAlgorithm"))
         originalAlgorithm_.push_back(reco::TrackBase::algoByName(algorithm));
+      for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("algorithmMaskContains"))
+        algorithmMask_.push_back(reco::TrackBase::algoByName(algorithm));
     }
 
   void init(const edm::Event& event, const edm::EventSetup& es) {
@@ -66,6 +68,11 @@ public:
     }
     if (!originalAlgorithm_.empty() && algo_ok) {
       if (std::find(originalAlgorithm_.begin(), originalAlgorithm_.end(), t.originalAlgo()) == originalAlgorithm_.end()) algo_ok = false;
+    }
+    if(!algorithmMask_.empty() && algo_ok) {
+      if(std::find_if(algorithmMask_.begin(), algorithmMask_.end(), [&](reco::TrackBase::TrackAlgorithm algo) -> bool { // for some reason I have to either explicitly give the return type, or use static_cast<bool>()
+            return t.algoMask()[algo];
+          }) == algorithmMask_.end()) algo_ok = false;
     }
     return
       (
@@ -103,6 +110,7 @@ private:
   std::vector<reco::TrackBase::TrackQuality> quality_;
   std::vector<reco::TrackBase::TrackAlgorithm> algorithm_;
   std::vector<reco::TrackBase::TrackAlgorithm> originalAlgorithm_;
+  std::vector<reco::TrackBase::TrackAlgorithm> algorithmMask_;
 
   reco::Track::Point vertex_;
 };

--- a/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
+++ b/CommonTools/RecoAlgos/interface/RecoTrackSelectorBase.h
@@ -33,6 +33,8 @@ public:
         quality_.push_back(reco::TrackBase::qualityByName(quality));
       for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("algorithm"))
         algorithm_.push_back(reco::TrackBase::algoByName(algorithm));
+      for(const std::string& algorithm: cfg.getParameter<std::vector<std::string> >("originalAlgorithm"))
+        originalAlgorithm_.push_back(reco::TrackBase::algoByName(algorithm));
     }
 
   void init(const edm::Event& event, const edm::EventSetup& es) {
@@ -61,6 +63,9 @@ public:
     bool algo_ok = true;
     if (algorithm_.size()!=0) {
       if (std::find(algorithm_.begin(),algorithm_.end(),t.algo())==algorithm_.end()) algo_ok = false;
+    }
+    if (!originalAlgorithm_.empty() && algo_ok) {
+      if (std::find(originalAlgorithm_.begin(), originalAlgorithm_.end(), t.originalAlgo()) == originalAlgorithm_.end()) algo_ok = false;
     }
     return
       (
@@ -97,6 +102,7 @@ private:
 
   std::vector<reco::TrackBase::TrackQuality> quality_;
   std::vector<reco::TrackBase::TrackAlgorithm> algorithm_;
+  std::vector<reco::TrackBase::TrackAlgorithm> originalAlgorithm_;
 
   reco::Track::Point vertex_;
 };

--- a/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
@@ -10,6 +10,7 @@ recoTrackSelectorPSet = cms.PSet(
     maxRapidity = cms.double(5.0),
     quality = cms.vstring('loose'),
     algorithm = cms.vstring(),
+    originalAlgorithm = cms.vstring(),
     minLayer = cms.int32(3),
     min3DLayer = cms.int32(0),
     minHit = cms.int32(0),

--- a/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackSelectorPSet_cfi.py
@@ -11,6 +11,7 @@ recoTrackSelectorPSet = cms.PSet(
     quality = cms.vstring('loose'),
     algorithm = cms.vstring(),
     originalAlgorithm = cms.vstring(),
+    algorithmMaskContains = cms.vstring(),
     minLayer = cms.int32(3),
     min3DLayer = cms.int32(0),
     minHit = cms.int32(0),

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -112,12 +112,19 @@ def customiseFor10234(process):
             delattr(process.hltCaloStage1Digis, 'FedId')
     return process
 
+# upgrade RecoTrackSelector to allow selection on originalAlgo (PR #10418)
+def customiseFor10418(process):
+    if hasattr(process,'hltBSoftMuonMu5L3') :
+       setattr(process.hltBSoftMuonMu5L3,'originalAlgorithm', cms.vstring())
+    return process
 
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process,menuType="GRun",fastSim=False):
     import os
     cmsswVersion = os.environ['CMSSW_VERSION']
 
+    if cmsswVersion >= "CMSSW_7_6":
+        process = customiseFor10418(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor9232(process)
         process = customiseFor8679(process)

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -116,6 +116,7 @@ def customiseFor10234(process):
 def customiseFor10418(process):
     if hasattr(process,'hltBSoftMuonMu5L3') :
        setattr(process.hltBSoftMuonMu5L3,'originalAlgorithm', cms.vstring())
+       setattr(process.hltBSoftMuonMu5L3,'algorithmMaskContains', cms.vstring())
     return process
 
 # CMSSW version specific customizations

--- a/PhysicsTools/RecoAlgos/python/btvTracks_cfi.py
+++ b/PhysicsTools/RecoAlgos/python/btvTracks_cfi.py
@@ -1,22 +1,19 @@
 import FWCore.ParameterSet.Config as cms
 
-_content = cms.PSet(
-    src = cms.InputTag("generalTracks"),
-    maxChi2 = cms.double(5.0),
-    tip = cms.double(0.2),
-    minRapidity = cms.double(-9.0),
-    lip = cms.double(17.0),
-    ptMin = cms.double(1.0),
-    maxRapidity = cms.double(9.0),
-    quality = cms.vstring(),
-    algorithm = cms.vstring(),
-    minLayer = cms.int32(0),
-    min3DLayer = cms.int32(0),
-    minHit = cms.int32(8),
-    minPixelHit = cms.int32(2),
-    beamSpot = cms.InputTag("offlineBeamSpot"),
-    usePV = cms.bool(True),
-    vertexTag = cms.InputTag('offlinePrimaryVertices'),
+import CommonTools.RecoAlgos.recoTrackSelectorPSet_cfi as _recoTrackSelectorPSet_cfi
+
+_content = _recoTrackSelectorPSet_cfi.recoTrackSelectorPSet.clone(
+    maxChi2 = 5.0,
+    tip = 0.2,
+    minRapidity = -9.0,
+    lip = 17.0,
+    ptMin = 1.0,
+    maxRapidity = 9.0,
+    quality = [],
+    minLayer = 0,
+    minHit = 8,
+    minPixelHit = 2,
+    usePV = True,
 )
 
 btvTracks = cms.EDProducer("RecoTrackSelector",


### PR DESCRIPTION
This PR adds a possibility to select tracks by originalAlgo or algoMask in RecoTrackSelectors. We are considering to switch the offline tracking validation to select per-iteration tracks by either of them (to be done later, ease of validation of that pre-release will be ensured), and will make use of them (+ current `algo`) in private studies.

Tested in CMSSW_7_6_X_2015-07-27-1800, no changes expected in results.

@rovere @VinInn
