### PR TITLE
Make sure static members are initialized.

### DIFF
--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -78,6 +78,9 @@ namespace edm {
 
 using namespace edm::service;
 
+const unsigned int CondorStatusService::m_defaultUpdateInterval;
+const float CondorStatusService::m_defaultEmaInterval;
+
 CondorStatusService::CondorStatusService(ParameterSet const& pset, edm::ActivityRegistry& ar)
   :
     m_debug(false),

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -79,7 +79,7 @@ namespace edm {
 using namespace edm::service;
 
 const unsigned int CondorStatusService::m_defaultUpdateInterval;
-const float CondorStatusService::m_defaultEmaInterval;
+constexpr float CondorStatusService::m_defaultEmaInterval;
 
 CondorStatusService::CondorStatusService(ParameterSet const& pset, edm::ActivityRegistry& ar)
   :


### PR DESCRIPTION
When linking prior code with clang, it barfed because it claimed
m_defaultUpdateInterval was not defined.  It appears that a compiler
pass thought it had inlined all references and removed the symbols.

Weird.  This works for a float member of the same class.
