### PR TITLE
Fixing Errors due to LA in PixelPhase1 with proper upgrade GT for 2017 design

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '75X_dataRun2_HLT_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v0',
+    'phase1_2017_design' :  '75X_upgrade2017_design_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -26,7 +26,7 @@ autoCond = {
     # GlobalTag for Run2 HLT: it points to the online GT
     'run2_hlt'          :   '75X_dataRun2_HLT_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
+    'phase1_2017_design' :  '75X_upgrade2017_design_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -186,7 +186,7 @@ def customise_Reco(process,pileup):
     #use with latest pixel geometry
     process.ClusterShapeHitFilterESProducer.PixelShapeFile = cms.string('RecoPixelVertexing/PixelLowPtUtilities/data/pixelShape_Phase1Tk.par')
     # Need this line to stop error about missing siPixelDigis.
-    process.MeasurementTracker.inactivePixelDetectorLabels = cms.VInputTag()
+    process.MeasurementTrackerEvent.inactivePixelDetectorLabels = cms.VInputTag()
 
     # new layer list (3/4 pixel seeding) in InitialStep and pixelTracks
     process.PixelLayerTriplets.layerList = cms.vstring( 'BPix1+BPix2+BPix3',
@@ -364,7 +364,14 @@ def customise_Reco(process,pileup):
     process.pixelTracks.FilterPSet.chi2 = cms.double(50.0)
     process.pixelTracks.FilterPSet.tipMax = cms.double(0.05)
     process.pixelTracks.RegionFactoryPSet.RegionPSet.originRadius =  cms.double(0.02)
-
-
+    process.templates.DoLorentz=False
+    process.templates.LoadTemplatesFromDB = cms.bool(False)
+    process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
+    process.GlobalTag.toGet = cms.VPSet(
+        cms.PSet(record = cms.string("SiPixelLorentzAngleRcd"),
+                 tag = cms.string("SiPixelLorentzAngle_0_106_612_slhc1_mc"),
+                 connect = cms.string("frontier://FrontierProd/CMS_COND_31X_PIXEL")
+                 )
+        )
 
     return process

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -367,11 +367,5 @@ def customise_Reco(process,pileup):
     process.templates.DoLorentz=False
     process.templates.LoadTemplatesFromDB = cms.bool(False)
     process.PixelCPEGenericESProducer.useLAWidthFromDB = cms.bool(False)
-    process.GlobalTag.toGet = cms.VPSet(
-        cms.PSet(record = cms.string("SiPixelLorentzAngleRcd"),
-                 tag = cms.string("SiPixelLorentzAngle_0_106_612_slhc1_mc"),
-                 connect = cms.string("frontier://FrontierProd/CMS_COND_31X_PIXEL")
-                 )
-        )
 
     return process


### PR DESCRIPTION
The autoCond key `phase1_2017_design` now contains a first version of the Global Tag for 2017 upgrade simulation with ideal conditions.

This PR is fixing the errors related to the LorentzAngle in Phase1 WF (2017 scenario) noticed in the step3 of `runTheMatrix.py -w upgrade -l 10000.0`
Even this PR can be merged independently (also not affecting any of the run1/run2 workflows) , the previous command can run only once PR #10353 is merged 

Last comment: even if it cures a crash in step3, the PR doesn't fix completely the phase1 workflow as I still do observed another crash in the reconstruction (which seems a priori to be related to tracking reconstruction and will be adressed to the relevant parties).
Originally in #10415
