### PR TITLE
Add vertex smearing parameters as measured during Run2015A (0T) and Run2015B (3.8T)

### DIFF
--- a/Configuration/StandardSequences/python/VtxSmeared.py
+++ b/Configuration/StandardSequences/python/VtxSmeared.py
@@ -39,6 +39,7 @@ VtxSmeared = {
     'NominalCollision2015'  :        'IOMC.EventVertexGenerators.VtxSmearedNominalCollision2015_cfi',
     'NominalHICollision2015':      'IOMC.EventVertexGenerators.VtxSmearedNominalHICollision2015_cfi',
     'ZeroTeslaRun247324Collision'  : 'IOMC.EventVertexGenerators.VtxSmearedZeroTeslaRun247324Collision_cfi',
+    'Realistic50ns13TeVCollisionZeroTesla': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollisionZeroTesla_cfi',
     'Realistic50ns13TeVCollision': 'IOMC.EventVertexGenerators.VtxSmearedRealistic50ns13TeVCollision_cfi',
 
 }

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -439,6 +439,29 @@ Realistic50ns13TeVCollisionZeroTeslaVtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.16973),
     Z0 = cms.double(-1.223)
 )
+
+# From 2015B 3.8T data
+# Centroid absolute positions extracted from fill 4008:
+# X =  0.07798 cm
+# Y =  0.09714 cm
+# Z = -1.610   cm
+#
+# BPIX absolute position extracted from PCL-like alignment run after magnet ramp-up:
+# X = -0.026837  cm
+# Y = -0.0715252 cm
+# Z = -0.511453  cm
+Realistic50ns13TeVCollisionVtxSmearingParameters = cms.PSet(
+    Phi = cms.double(0.0),
+    BetaStar = cms.double(65.0),
+    Emittance = cms.double(5.411e-08),
+    Alpha = cms.double(0.0),
+    SigmaZ = cms.double(5.3),
+    TimeOffset = cms.double(0.0),
+    X0 = cms.double(0.10482),
+    Y0 = cms.double(0.16867),
+    Z0 = cms.double(-1.0985)
+)
+
 # Test HF offset
 ShiftedCollision2015VtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -417,7 +417,18 @@ ZeroTeslaRun247324CollisionVtxSmearingParameters = cms.PSet(
     Y0 = cms.double(0.1657),
     Z0 = cms.double(-1.688)
 )
-Realistic50ns13TeVCollisionVtxSmearingParameters = cms.PSet(
+
+# From 2015A 0T data
+# Centroid absolute positions extracted from fills:
+# X = 0.059395  cm
+# Y = 0.099686  cm
+# Z = -1.722240 cm
+#
+# BPIX absolute position extracted from first collision alignment:
+# X = -0.0259503 cm
+# Y = -0.07004   cm
+# Z = -0.498917  cm
+Realistic50ns13TeVCollisionZeroTeslaVtxSmearingParameters = cms.PSet(
     Phi = cms.double(0.0),
     BetaStar = cms.double(65.0),
     Emittance = cms.double(5.411e-08),

--- a/IOMC/EventVertexGenerators/python/VtxSmearedRealistic50ns13TeVCollisionZeroTesla_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedRealistic50ns13TeVCollisionZeroTesla_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+from IOMC.EventVertexGenerators.VtxSmearedParameters_cfi import *
+VtxSmeared = cms.EDProducer("BetafuncEvtVtxGenerator",
+    Realistic50ns13TeVCollisionZeroTeslaVtxSmearingParameters,
+    VtxSmearedCommon
+)


### PR DESCRIPTION
This PR adds two sets of vertex smearing parameters:
- `Realistic50ns13TeVCollisionZeroTesla`: it contains the values computed from Run2015A luminous region with 0T data and alignment for first collisions (see #10222 );
- `Realistic50ns13TeVCollision`: it contains the values computed from Run2015B luminous region with 3.8T data and PCL-like alignment (see #10384 ). The `sigmaZ` value is still set to the "original" value of 5.3 cm, while 2015B data indicate that it is actually shrunk to ~4.3 cm: it is pending discussion with LHC OP.
