### PR TITLE
Remove function getProcessParameterSet

### DIFF
--- a/FWCore/Framework/interface/EventProcessor.h
+++ b/FWCore/Framework/interface/EventProcessor.h
@@ -116,6 +116,8 @@ namespace edm {
     std::vector<ModuleDescription const*>
     getAllModuleDescriptions() const;
 
+    ProcessConfiguration const& processConfiguration() const { return *processConfiguration_; }
+
     /// Return the number of events this EventProcessor has tried to process
     /// (inclues both successes and failures, including failures due
     /// to exceptions during processing).

--- a/FWCore/Framework/src/Schedule.cc
+++ b/FWCore/Framework/src/Schedule.cc
@@ -17,7 +17,6 @@
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/Utilities/interface/Algorithms.h"
 #include "FWCore/Utilities/interface/ConvertException.h"
 #include "FWCore/Utilities/interface/ExceptionCollector.h"
@@ -421,7 +420,6 @@ namespace edm {
                        outputModulePathPositions);
     processEDAliases(proc_pset, processConfiguration->processName(), preg);
     proc_pset.registerIt();
-    pset::setProcessParameterSetID(proc_pset.id());
     processConfiguration->setParameterSetID(proc_pset.id());
     processConfiguration->setProcessConfigurationID();
 

--- a/FWCore/Framework/test/eventprocessor_t.cppunit.cc
+++ b/FWCore/Framework/test/eventprocessor_t.cppunit.cc
@@ -584,7 +584,8 @@ testeventprocessor::serviceConfigSaveTest() {
                              "process.p1 = cms.Path(process.m1)\n");
 
    edm::EventProcessor proc(configuration, true);
-   edm::ParameterSet topPset(edm::getProcessParameterSet());
+   edm::ProcessConfiguration const& processConfiguration = proc.processConfiguration();
+   edm::ParameterSet const& topPset(edm::getParameterSet(processConfiguration.parameterSetID()));
    CPPUNIT_ASSERT(topPset.existsAs<edm::ParameterSet>("DummyStoreConfigService", true));
 }
 

--- a/FWCore/Integration/test/PathAnalyzer.cc
+++ b/FWCore/Integration/test/PathAnalyzer.cc
@@ -46,13 +46,6 @@ namespace edmtest
   PathAnalyzer::beginJob()
   {
     dumpTriggerNamesServiceInfo("beginJob");
-
-    // Make sure we can get a the process parameter set. This test
-    // doesn't really belong here, but I had to stick it somewhere
-    // quickly...
-
-    edm::ParameterSet ppset = edm::getProcessParameterSet();
-    assert (ppset.id().isValid());
   }
 
   void

--- a/FWCore/ParameterSet/interface/Registry.h
+++ b/FWCore/ParameterSet/interface/Registry.h
@@ -89,19 +89,7 @@ namespace edm {
       map_type m_map;
     };
 
-    /// Associated free functions.
-
-    /// Save the ParameterSetID of the top-level ParameterSet.
-    void setProcessParameterSetID(ParameterSetID const& id);
-
-    /// Return the ParameterSetID of the top-level ParameterSet.
-    /// Note the the returned ParameterSetID may be invalid;
-    /// this will happen if the Registry has not yet been filled.
-    ParameterSetID getProcessParameterSetID();
   }  // namespace pset
-
-  ParameterSet const& getProcessParameterSet();
-
 }  // namespace edm
 
 #endif

--- a/FWCore/ParameterSet/src/Registry.cc
+++ b/FWCore/ParameterSet/src/Registry.cc
@@ -2,15 +2,11 @@
 // ----------------------------------------------------------------------
 
 #include <ostream>
-#include <mutex>
 
 #include "FWCore/ParameterSet/interface/Registry.h"
-#include "FWCore/Utilities/interface/EDMException.h"
 
 namespace edm {
   namespace pset {
-    static std::mutex s_mutex;
-    [[cms::thread_guard("s_mutex")]] static ParameterSetID s_ProcessParameterSetID;
 
     Registry*
     Registry::instance() {
@@ -61,52 +57,5 @@ namespace edm {
         os << item.first << " " << item.second << '\n';
       }
     }
-
-    ParameterSetID
-    getProcessParameterSetID() {
-      std::lock_guard<std::mutex> guard(s_mutex);
-      if (!s_ProcessParameterSetID.isValid()) {
-        throw edm::Exception(errors::LogicError)
-          << "Illegal attempt to access the process top level parameter set ID\n"
-          << "before that parameter set has been frozen and registered.\n"
-          << "The parameter set can be changed during module validation,\n"
-          << "which occurs concurrently with module construction.\n"
-          << "It is illegal to access the parameter set before it is frozen.\n";
-      }
-      return s_ProcessParameterSetID;
-    }
-
-    void setProcessParameterSetID(ParameterSetID const& id) {
-      pset::s_ProcessParameterSetID = id;
-    }
-
   } // namespace pset
-
-  ParameterSet const& getProcessParameterSet() {
-    ParameterSetID p;
-    {
-      std::lock_guard<std::mutex> guard(pset::s_mutex);
-      p = pset::s_ProcessParameterSetID;
-    }
-    
-    if (!p.isValid()) {
-      throw edm::Exception(errors::LogicError)
-        << "Illegal attempt to access the process top level parameter set ID\n"
-        << "before that parameter set has been frozen and registered.\n"
-        << "The parameter set can be changed during module validation,\n"
-        << "which occurs concurrently with module construction.\n"
-        << "It is illegal to access the parameter set before it is frozen.\n";
-    }
-
-    pset::Registry const& reg = *pset::Registry::instance();
-    ParameterSet const* result;
-    if (nullptr == (result = reg.getMapped(p))) {
-      throw edm::Exception(errors::EventCorruption, "Unknown ParameterSetID")
-        << "Unable to find the ParameterSet for id: "
-        << p
-        << ";\nthis was supposed to be the process ParameterSet\n";
-    }
-    return *result;
-  }
-
 } // namespace edm

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -5,13 +5,13 @@
 #include "IOPool/Streamer/interface/EventMsgBuilder.h"
 #include "FWCore/Framework/interface/EventPrincipal.h"
 #include "FWCore/Framework/interface/EventSelector.h"
-#include "FWCore/ParameterSet/interface/Registry.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
 #include "FWCore/Utilities/interface/DebugMacros.h"
 //#include "FWCore/Utilities/interface/Digest.h"
 #include "FWCore/Version/interface/GetReleaseVersion.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
+#include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/ParameterSetID.h"
 
 #include <iostream>
@@ -153,7 +153,7 @@ namespace edm {
     uint32 run = 1;
 
     //Get the Process PSet ID
-    ParameterSetID toplevel = pset::getProcessParameterSetID();
+    ParameterSetID toplevel = moduleDescription().mainParameterSetID();
 
     //In case we need to print it
     //  cms::Digest dig(toplevel.compactForm());


### PR DESCRIPTION
Remove the function getProcessParameterSet
from CMSSW. Previous PRs removed most of the
places where this function was used. This
PR gets a few minor uses that were left in
the Framework code. Also removes setProcessParameterSetID
and getProcessParameterSetID.

This function is being removed because it does not work
with SubProcesses and caused threading issues requiring
the use of a mutex.
