### PR TITLE
switch to ak8GenJetsNoNu in MiniAOD (ONLY IF MiniAOD reprocessing happnes in 74X)

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedGenJets_cfi.py
@@ -10,7 +10,7 @@ slimmedGenJets = cms.EDProducer("PATGenJetSlimmer",
 
 
 slimmedGenJetsAK8 = cms.EDProducer("PATGenJetSlimmer",
-    src = cms.InputTag("ak8GenJets"),
+    src = cms.InputTag("ak8GenJetsNoNu"),
     packedGenParticles = cms.InputTag("packedGenParticles"),
     cut = cms.string("pt > 150"),
     clearDaughters = cms.bool(False), #False means rekeying


### PR DESCRIPTION
Backport of #9121 in case MiniAOD reprocessing happens in 74X.
