### PR TITLE
resolve conflicts with both met filters and dependent paths in unscheduled

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1592,6 +1592,12 @@ class ConfigBuilder(object):
 	    #self.renameInputTagsInSequence(sequence)
             return
 
+    def prepare_PATFILTER(self, sequence=None):
+            self.load("PhysicsTools/PatAlgos/slimming/metFilterPaths_cff")
+	    from PhysicsTools.PatAlgos.slimming.metFilterPaths_cff import allMetFilterPaths
+	    for filt in allMetFilterPaths:
+		    self.schedule.append(getattr(self.process,'Flag_'+filt))
+
     def prepare_L1HwVal(self, sequence = 'L1HwVal'):
         ''' Enrich the schedule with L1 HW validation '''
         self.loadDefaultOrSpecifiedCFF(sequence,self.L1HwValDefaultCFF)
@@ -1660,6 +1666,7 @@ class ConfigBuilder(object):
 
     def prepare_PAT(self, sequence = "miniAOD"):
         ''' Enrich the schedule with PAT '''
+	self.prepare_PATFILTER(self)
         self.loadDefaultOrSpecifiedCFF(sequence,self.PATDefaultCFF,1) #this is unscheduled
 	if not self._options.runUnscheduled:	
 		raise Exception("MiniAOD production can only run in unscheduled mode, please run cmsDriver with --runUnscheduled")

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -1593,7 +1593,7 @@ class ConfigBuilder(object):
             return
 
     def prepare_PATFILTER(self, sequence=None):
-            self.load("PhysicsTools/PatAlgos/slimming/metFilterPaths_cff")
+            self.loadAndRemember("PhysicsTools/PatAlgos/slimming/metFilterPaths_cff")
 	    from PhysicsTools.PatAlgos.slimming.metFilterPaths_cff import allMetFilterPaths
 	    for filt in allMetFilterPaths:
 		    self.schedule.append(getattr(self.process,'Flag_'+filt))

--- a/FWCore/ParameterSet/python/Utilities.py
+++ b/FWCore/ParameterSet/python/Utilities.py
@@ -223,7 +223,7 @@ def cleanUnscheduled(proc):
   # If there is a schedule then it needs to point at
   # the new Path objects
   if proc.schedule:
-      proc._Process__schedule = None
+      proc.schedule = cms.Schedule([getattr(proc,p) for p in pathNamesInScheduled])
   return proc
 
 if __name__ == "__main__":

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -25,6 +25,11 @@ Flag_trkPOG_logErrorTooManyClusters = cms.Path(~logErrorTooManyClusters)
 # and the summary
 Flag_METFilters = cms.Path(metFilters)
 
+#add your new path here!!
+allMetFilterPaths=['HBHENoiseFilter','CSCTightHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','goodVertices','eeBadScFilter',
+                   'ecalLaserCorrFilter','trkPOGFilters','trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters','METFilters']
+
+       
 def miniAOD_customizeMETFiltersFastSim(process):
     """Replace some MET filters that don't work in FastSim with trivial bools"""
     for X in 'CSCTightHaloFilter', 'HBHENoiseFilter', 'HBHENoiseFilterResultProducer':


### PR DESCRIPTION
Forward port fixes added to 74x - this should allow unsched. relvals
