### PR TITLE
Input tag for L1GlobalTriggerReadoutRecord from provenance.

### DIFF
--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtils.h
@@ -61,7 +61,7 @@ public:
     // Using this constructor will cause it to look for valid InputTags in
     // the following ways in the specified order until they are found.
     //   1. The configuration
-    //   2. Search all products from the RECO process for the required type
+    //   2. Search all products from the preferred input tags for the required type
     //   3. Search all products from any other process for the required type
     template <typename T>
     L1GtUtils(edm::ParameterSet const& pset,
@@ -79,7 +79,7 @@ public:
     // the following ways in the specified order until they are found.
     //   1. The constructor arguments
     //   2. The configuration
-    //   3. Search all products from the RECO process for the required type
+    //   3. Search all products from the preferred input tags for the required type
     //   4. Search all products from any other process for the required type
     template <typename T>
     L1GtUtils(edm::ParameterSet const& pset,

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtUtilsHelper.h
@@ -46,7 +46,7 @@ public:
   // Using this constructor will cause it to look for valid InputTags in
   // the following ways in the specified order until they are found.
   //   1. The configuration
-  //   2. Search all products from the RECO process for the required type
+  //   2. Search all products from the preferred input tags for the required type
   //   3. Search all products from any other process for the required type
   template <typename T>
   L1GtUtilsHelper(edm::ParameterSet const& pset,
@@ -58,7 +58,7 @@ public:
   // the following ways in the specified order until they are found.
   //   1. The constructor arguments
   //   2. The configuration
-  //   3. Search all products from the RECO process for the required type
+  //   3. Search all products from the preferred input tags for the required type
   //   4. Search all products from any other process for the required type
   template <typename T>
   L1GtUtilsHelper(edm::ParameterSet const& pset,
@@ -101,9 +101,19 @@ private:
   bool m_findReadoutRecord;
   bool m_findMenuLite;
 
-  bool m_foundRECORecord;
-  bool m_foundRECOReadoutRecord;
-  bool m_foundRECOMenuLite;
+  bool m_foundPreferredRecord;
+  bool m_foundPreferredReadoutRecord;
+  bool m_foundPreferredMenuLite;
+
+  bool m_foundMultipleL1GtRecord;
+  bool m_foundMultipleL1GtReadoutRecord;
+  bool m_foundMultipleL1GtMenuLite;
+
+  // use vector here, InputTag has no '<' operator to use std::set
+  std::vector<edm::InputTag> m_inputTagsL1GtRecord;
+  std::vector<edm::InputTag> m_inputTagsL1GtReadoutRecord;
+  std::vector<edm::InputTag> m_inputTagsL1GtMenuLite;
+
 };
 
 template <typename T>
@@ -133,9 +143,13 @@ L1GtUtilsHelper::L1GtUtilsHelper(edm::ParameterSet const& pset,
   m_findReadoutRecord(false),
   m_findMenuLite(false),
 
-  m_foundRECORecord(false),
-  m_foundRECOReadoutRecord(false),
-  m_foundRECOMenuLite(false) {
+  m_foundPreferredRecord(false),
+  m_foundPreferredReadoutRecord(false),
+  m_foundPreferredMenuLite(false),
+
+  m_foundMultipleL1GtRecord(false),
+  m_foundMultipleL1GtReadoutRecord(false),
+  m_foundMultipleL1GtMenuLite(false) {
 
   // If the InputTags are not set to valid values by the arguments, then
   // try to set them from the configuration.

--- a/L1Trigger/GlobalTriggerAnalyzer/python/UserOptions_cff.py
+++ b/L1Trigger/GlobalTriggerAnalyzer/python/UserOptions_cff.py
@@ -15,7 +15,7 @@ import sys
 
 # number of events to be run (-1 for all)
 maxNumberEvents = 10
-#maxNumberEvents = -1
+maxNumberEvents = -1
 
 # useRelValSample: choose the type of sample used:
 #   True to use MC RelVal
@@ -30,40 +30,42 @@ useRelValSample = False
 
 if useRelValSample == False :
     
-    # choose the global tag type  
+    # choose the global tag type 
+    # WARNING: global mess in global tag management, 
+    #      must be chosen per sample
+    #      must be checked in the release
     #  
-    globalTag = 'auto:com10'        # GR_R_*
-    #globalTag = 'auto:hltonline'   # GR_H_*
+    globalTag = '75X_dataRun2_HLT_v2'
     
     # choose one sample identifier from the list of data samples 
     #
-    sampleIdentifier = '165633-CAFDQM'
+    sampleIdentifier = '251162'
+    #sampleIdentifier = '165633-CAFDQM'
     #sampleIdentifier = '191833_RAW'
     #sampleIdentifier = '205666.A.storageManager'
 
 else :
-
-    # choose the global tag type  
+    # choose the global tag type 
+    # WARNING: global mess in global tag management, 
+    #      must be chosen per sample
+    #      must be checked in the release
     #  
-    #globalTag = 'auto:mc'
-    globalTag = 'auto:startup'
-    #globalTag = 'auto:starthi'
+    globalTag = 'auto:run1_mc'
+    #globalTag = 'auto:MCRUN2_72_V3A'
+    #globalTag = 'auto:run1_mc_hi'
     
     # choose (pre)release used to produce the RelVal samples
-    #
-    sampleFromRelease = 'CMSSW_5_2_3'
+    sampleFromRelease = 'CMSSW_7_5_0'
 
-   # RelVals samples - add the "short name" of the dataset e.g. /RelValLM1_sfts/...
+    # RelVals samples - add the "short name" of the dataset e.g. /RelValLM1_sfts/...
     #
     #dataset = 'RelValMinBias'
-    #dataset = 'RelValTTbar'
-    #dataset = 'RelValQCD_Pt_80_120'
-    dataset = 'RelValLM1_sfts'
+    dataset = 'RelValTTbar'
     
     # data type
     #
-    #dataType = 'RAW'
-    dataType = 'RECO'
+    dataType = 'RAW'
+    #dataType = 'RECO'
         
 # change to True to use local files
 #     the type of file must be matched by hand
@@ -93,7 +95,6 @@ selectedLumis= cms.untracked.VLuminosityBlockRange()
 
 if (useRelValSample == True) and (useLocalFiles == False) :
     
-    # end of data samples 
     #            
 
     print "   Release:   ", sampleFromRelease
@@ -125,6 +126,7 @@ if (useRelValSample == True) and (useLocalFiles == False) :
         else :
             gTag =''  
         
+        datasetName = ''
         for line in datasets.readlines() :
             if dataset in line :
               if sampleFromRelease in line :
@@ -137,6 +139,7 @@ if (useRelValSample == True) and (useLocalFiles == False) :
         # print datasetName
         
         if datasetName == '' :
+            print "\n   No dataset found."
             errorUserOptions = True 
 
         if not errorUserOptions :
@@ -180,6 +183,15 @@ elif (useRelValSample == False) and (useLocalFiles == False) :
                                     '191833:256674',
                                     '191833:588211'
                                     )
+        
+    elif sampleIdentifier == '251162' :
+        runNumber = '251162'
+        dataset = '/Run2015B/DoubleMuon/RAW'
+        dataType = 'RAW'
+        useDAS = False
+        readFiles.extend( [
+                '/store/data/Run2015B/DoubleMuon/RAW/v1/000/251/162/00000/9A6A3CB4-AD25-E511-84E5-02163E01264D.root'       
+                ] );
         
 
     elif sampleIdentifier == '191833_RECO' :
@@ -374,15 +386,16 @@ else :
             ])
 
     print 'Local file(s)', readFiles
-    
+
 if overrideGlobalTag == True :
     globalTag = myGlobalTag
   
 if globalTag.count('auto') :
-    from Configuration.AlCa.autoCond import autoCond
+    from Configuration.AlCa.autoCond_condDBv2 import autoCond
     useGlobalTag = autoCond[globalTag.replace('auto:', '')]
 else :
-    useGlobalTag = globalTag+'::All'    
+    useGlobalTag = globalTag   
     
 print "\n   Using global tag ", useGlobalTag, "\n"
+    
         

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtUtilsHelper.cc
@@ -4,99 +4,346 @@
 #include "FWCore/Utilities/interface/BranchType.h"
 #include "FWCore/Utilities/interface/TypeID.h"
 
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+
 L1GtUtilsHelper::L1GtUtilsHelper(edm::ParameterSet const& pset,
-                                 edm::ConsumesCollector& iC,
-                                 bool useL1GtTriggerMenuLite) :
-  m_consumesCollector(std::move(iC)),
-  m_l1GtRecordInputTag(pset.getParameter<edm::InputTag>("l1GtRecordInputTag")),
-  m_l1GtReadoutRecordInputTag(pset.getParameter<edm::InputTag>("l1GtReadoutRecordInputTag")),
-  m_l1GtTriggerMenuLiteInputTag(pset.getParameter<edm::InputTag>("l1GtTriggerMenuLiteInputTag")),
-  m_findRecord(false),
-  m_findReadoutRecord(false),
-  m_findMenuLite(false),
-  m_foundRECORecord(false),
-  m_foundRECOReadoutRecord(false),
-  m_foundRECOMenuLite(false)
-{
-  m_l1GtRecordToken = iC.consumes<L1GlobalTriggerRecord>(m_l1GtRecordInputTag);
-  m_l1GtReadoutRecordToken = iC.consumes<L1GlobalTriggerReadoutRecord>(m_l1GtReadoutRecordInputTag);
-  if(useL1GtTriggerMenuLite) {
-    m_l1GtTriggerMenuLiteToken = iC.consumes<L1GtTriggerMenuLite,edm::InRun>(m_l1GtTriggerMenuLiteInputTag);
-  }
+        edm::ConsumesCollector& iC,
+        bool useL1GtTriggerMenuLite) :
+            m_consumesCollector(std::move(iC)),
+            m_l1GtRecordInputTag(pset.getParameter<edm::InputTag>("l1GtRecordInputTag")),
+            m_l1GtReadoutRecordInputTag(pset.getParameter<edm::InputTag>("l1GtReadoutRecordInputTag")),
+            m_l1GtTriggerMenuLiteInputTag(pset.getParameter<edm::InputTag>("l1GtTriggerMenuLiteInputTag")),
+            m_findRecord(false),
+            m_findReadoutRecord(false),
+            m_findMenuLite(false),
+            m_foundPreferredRecord(false),
+            m_foundPreferredReadoutRecord(false),
+            m_foundPreferredMenuLite(false) {
+
+    m_l1GtRecordToken = iC.consumes<L1GlobalTriggerRecord>(
+            m_l1GtRecordInputTag);
+    m_l1GtReadoutRecordToken = iC.consumes<L1GlobalTriggerReadoutRecord>(
+            m_l1GtReadoutRecordInputTag);
+    if (useL1GtTriggerMenuLite) {
+        m_l1GtTriggerMenuLiteToken =
+                iC.consumes<L1GtTriggerMenuLite, edm::InRun>(
+                        m_l1GtTriggerMenuLiteInputTag);
+    }
 }
 
 void L1GtUtilsHelper::fillDescription(edm::ParameterSetDescription & desc) {
-  desc.add<edm::InputTag>("l1GtRecordInputTag", edm::InputTag());
-  desc.add<edm::InputTag>("l1GtReadoutRecordInputTag", edm::InputTag());
-  desc.add<edm::InputTag>("l1GtTriggerMenuLiteInputTag", edm::InputTag());
+    desc.add<edm::InputTag>("l1GtRecordInputTag", edm::InputTag());
+    desc.add<edm::InputTag>("l1GtReadoutRecordInputTag", edm::InputTag());
+    desc.add<edm::InputTag>("l1GtTriggerMenuLiteInputTag", edm::InputTag());
 }
 
-void L1GtUtilsHelper::operator()(edm::BranchDescription const& branchDescription) {
+void L1GtUtilsHelper::operator()(
+        edm::BranchDescription const& branchDescription) {
 
-  // This is only used if required InputTags were not specified already.
-  // This is called early in the process, once for each product in the ProductRegistry.
-  // The callback is registered when callWhenNewProductsRegistered is called.
-  // It finds products by type and sets the token so that it can be used
-  // later when getting the product.
-  // This code assumes there is at most one product from the RECO process
-  // and at most one product from some other process.  It selects a product
-  // from the RECO process if it is present and a product from some other process
-  // if it is not. This is a bit unsafe because if there is more than one from
-  // RECO or none from RECO and more than one from other processes it is somewhat
-  // arbitrary which one is selected. I'm leaving this behavior in to maintain
-  // consistency with the previous behavior. It is supposed to not happen and if
-  // it does the products might be identical anyway. To avoid this risk or select
-  // different products, specify the InputTags either in the configuration or the
-  // arguments to the constructor.
+    // This is only used if required InputTags were not specified already.
+    // This is called early in the process, once for each product in the ProductRegistry.
+    // The callback is registered when callWhenNewProductsRegistered is called.
+    // It finds products by type and sets the token so that it can be used
+    // later when getting the product.
 
-  if (m_findRecord &&
-      !m_foundRECORecord &&
-      branchDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerRecord)) &&
-      branchDescription.branchType() == edm::InEvent) {
-    edm::InputTag tag{branchDescription.moduleLabel(),
-                      branchDescription.productInstanceName(),
-                      branchDescription.processName()};
-    if(branchDescription.processName() == "RECO") {
-      m_l1GtRecordInputTag = tag;
-      m_l1GtRecordToken = m_consumesCollector.consumes<L1GlobalTriggerRecord>(tag);
-      m_foundRECORecord = true;
-    } else if (m_l1GtRecordToken.isUninitialized()) {
-      m_l1GtRecordInputTag = tag;
-      m_l1GtRecordToken = m_consumesCollector.consumes<L1GlobalTriggerRecord>(tag);
+    // The code will look for the corresponding product in ProductRegistry.
+    // If the product is found, it checks the product label in
+    // a vector of preferred input tags (hardwired now to "gtDigis" and
+    // "hltGtDigis"). The first input tag from the vector of preferred input tags, with the
+    // same label as the input tag found from provenance, is kept as input tag, if there are no
+    // multiple products with the same label.
+
+    // If multiple products are found and no one has a label in the vector of preferred input tags,
+    // or if multiple products are found with the label in the vector of preferred input tags
+    // (with different instance or process) the input tag is set to empty input tag, and L1GtUtil
+    // will produce an error, as it is not possible to safely choose a product. In this case, one must
+    // provide explicitly the correct input tag via configuration or in the constructor.
+
+    // TODO decide if the preferred input tags must be given as input parameters
+    // or stay hardwired
+
+    std::vector<edm::InputTag> preferredL1GtRecordInputTag = { edm::InputTag(
+            "gtDigis"), edm::InputTag("hltGtDigis") };
+
+    std::vector<edm::InputTag> preferredL1GtReadoutRecordInputTag = {
+            edm::InputTag("gtDigis"), edm::InputTag("hltGtDigis") };
+
+    std::vector<edm::InputTag> preferredL1GtTriggerMenuLiteInputTag = {
+            edm::InputTag("gtDigis"), edm::InputTag("hltGtDigis") };
+
+    // L1GlobalTriggerRecord
+
+    if (m_findRecord && (!m_foundMultipleL1GtRecord)
+            && (branchDescription.unwrappedTypeID()
+                    == edm::TypeID(typeid(L1GlobalTriggerRecord)))
+            && (branchDescription.branchType() == edm::InEvent)) {
+
+        edm::InputTag tag { branchDescription.moduleLabel(),
+                branchDescription.productInstanceName(),
+                branchDescription.processName() };
+
+        if (m_foundPreferredRecord) {
+
+            // check if a preferred input tag was already found and compare it with the actual tag
+            // if the instance or the process names are different, one has incompatible tags - set
+            // the tag to empty input tag and indicate that multiple preferred input tags are found
+            // so it is not possibly to choose safely an input tag
+
+            if ((m_l1GtRecordInputTag.label() == branchDescription.moduleLabel())
+                    && ((m_l1GtRecordInputTag.instance()
+                            != branchDescription.productInstanceName())
+                            || (m_l1GtRecordInputTag.process()
+                                    != branchDescription.processName()))) {
+
+                edm::LogWarning("L1GtUtils")
+                        << "\nWARNING: Found multiple preferred input tags for L1GlobalTriggerRecord product, "
+                        << "\nwith different instaces or processes."
+                        << "\nInput tag already found: "
+                        << (m_l1GtRecordInputTag) << "\nActual tag: " << (tag)
+                        << "\nInput tag set to empty tag." << std::endl;
+
+                m_foundMultipleL1GtRecord = true;
+                m_l1GtRecordInputTag = edm::InputTag();
+            }
+        } else {
+            // no preferred input tag found yet, check now with the actual tag
+
+            for (std::vector<edm::InputTag>::const_iterator itPrefTag =
+                    preferredL1GtRecordInputTag.begin(), itPrefTagEnd =
+                    preferredL1GtRecordInputTag.end();
+                    itPrefTag != itPrefTagEnd; ++itPrefTag) {
+
+                if (branchDescription.moduleLabel() == itPrefTag->label()) {
+                    m_l1GtRecordInputTag = tag;
+                    m_l1GtRecordToken = m_consumesCollector.consumes<
+                            L1GlobalTriggerRecord>(tag);
+                    m_foundPreferredRecord = true;
+                    m_inputTagsL1GtRecord.push_back(tag);
+
+                    edm::LogWarning("L1GtUtils")
+                            << "\nWARNING: Input tag for L1GlobalTriggerRecord product set to preferred input tag"
+                            << (tag) << std::endl;
+                    break;
+                }
+            }
+        }
+
+        if (!m_foundPreferredRecord) {
+
+            // check if other input tag was found - if true, there are multiple input tags in the event,
+            // none in the preferred input tags, so it is not possibly to choose safely an input tag
+
+            if (m_inputTagsL1GtRecord.size() > 1) {
+
+                edm::LogWarning("L1GtUtils")
+                        << "\nWARNING: Found multiple input tags for L1GlobalTriggerRecord product."
+                        << "\nNone is in the preferred input tags - no safe choice."
+                        << "\nInput tag already found: "
+                        << (m_l1GtRecordInputTag) << "\nActual tag: " << (tag)
+                        << "\nInput tag set to empty tag." << std::endl;
+                m_l1GtRecordInputTag = edm::InputTag();
+                m_foundMultipleL1GtRecord = true;
+
+            } else {
+                if (m_l1GtRecordToken.isUninitialized()) {
+
+                    m_l1GtRecordInputTag = tag;
+                    m_inputTagsL1GtRecord.push_back(tag);
+                    m_l1GtRecordToken = m_consumesCollector.consumes<
+                            L1GlobalTriggerRecord>(tag);
+
+                    edm::LogWarning("L1GtUtils")
+                            << "\nWARNING: No preferred input tag found for L1GlobalTriggerReadoutRecord product."
+                            << "\nInput tag set to " << (tag) << std::endl;
+                }
+            }
+        }
     }
-  }
 
-  if (m_findReadoutRecord &&
-      !m_foundRECOReadoutRecord &&
-      branchDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GlobalTriggerReadoutRecord)) &&
-      branchDescription.branchType() == edm::InEvent) {
-    edm::InputTag tag{branchDescription.moduleLabel(),
-                      branchDescription.productInstanceName(),
-                      branchDescription.processName()};
-    if(branchDescription.processName() == "RECO") {
-      m_l1GtReadoutRecordInputTag = tag;
-      m_l1GtReadoutRecordToken = m_consumesCollector.consumes<L1GlobalTriggerReadoutRecord>(tag);
-      m_foundRECOReadoutRecord = true;
-    } else if (m_l1GtReadoutRecordToken.isUninitialized()) {
-      m_l1GtReadoutRecordInputTag = tag;
-      m_l1GtReadoutRecordToken = m_consumesCollector.consumes<L1GlobalTriggerReadoutRecord>(tag);
-    }
-  }
 
-  if (m_findMenuLite &&
-      !m_foundRECOMenuLite &&
-      branchDescription.branchType() == edm::InRun &&
-      branchDescription.unwrappedTypeID() == edm::TypeID(typeid(L1GtTriggerMenuLite))) {
-    edm::InputTag tag{branchDescription.moduleLabel(),
-                      branchDescription.productInstanceName(),
-                      branchDescription.processName()};
-    if(branchDescription.processName() == "RECO") {
-      m_l1GtTriggerMenuLiteInputTag = tag;
-      m_l1GtTriggerMenuLiteToken = m_consumesCollector.consumes<L1GtTriggerMenuLite,edm::InRun>(tag);
-      m_foundRECOMenuLite = true;
-    } else if (m_l1GtTriggerMenuLiteToken.isUninitialized()) {
-      m_l1GtTriggerMenuLiteInputTag = tag;
-      m_l1GtTriggerMenuLiteToken = m_consumesCollector.consumes<L1GtTriggerMenuLite,edm::InRun>(tag);
+    // L1GlobalTriggerReadoutRecord
+
+    if (m_findReadoutRecord && (!m_foundMultipleL1GtReadoutRecord)
+            && (branchDescription.unwrappedTypeID()
+                    == edm::TypeID(typeid(L1GlobalTriggerReadoutRecord)))
+            && (branchDescription.branchType() == edm::InEvent)) {
+
+        edm::InputTag tag { branchDescription.moduleLabel(),
+                branchDescription.productInstanceName(),
+                branchDescription.processName() };
+
+        if (m_foundPreferredReadoutRecord) {
+
+            // check if a preferred input tag was already found and compare it with the actual tag
+            // if the instance or the process names are different, one has incompatible tags - set
+            // the tag to empty input tag and indicate that multiple preferred input tags are found
+            // so it is not possibly to choose safely an input tag
+
+            if ((m_l1GtReadoutRecordInputTag.label()
+                    == branchDescription.moduleLabel())
+                    && ((m_l1GtReadoutRecordInputTag.instance()
+                            != branchDescription.productInstanceName())
+                            || (m_l1GtReadoutRecordInputTag.process()
+                                    != branchDescription.processName()))) {
+
+                edm::LogWarning("L1GtUtils")
+                        << "\nWARNING: Found multiple preferred input tags for L1GlobalTriggerReadoutRecord product, "
+                        << "\nwith different instaces or processes."
+                        << "\nInput tag already found: "
+                        << (m_l1GtReadoutRecordInputTag) << "\nActual tag: "
+                        << (tag) << "\nInput tag set to empty tag."
+                        << std::endl;
+
+                m_foundMultipleL1GtReadoutRecord = true;
+                m_l1GtReadoutRecordInputTag = edm::InputTag();
+            }
+        } else {
+            // no preferred input tag found yet, check now with the actual tag
+
+            for (std::vector<edm::InputTag>::const_iterator itPrefTag =
+                    preferredL1GtReadoutRecordInputTag.begin(), itPrefTagEnd =
+                    preferredL1GtReadoutRecordInputTag.end();
+                    itPrefTag != itPrefTagEnd; ++itPrefTag) {
+
+                if (branchDescription.moduleLabel() == itPrefTag->label()) {
+                    m_l1GtReadoutRecordInputTag = tag;
+                    m_l1GtReadoutRecordToken = m_consumesCollector.consumes<
+                            L1GlobalTriggerReadoutRecord>(tag);
+                    m_foundPreferredReadoutRecord = true;
+                    m_inputTagsL1GtReadoutRecord.push_back(tag);
+
+                    edm::LogWarning("L1GtUtils")
+                            << "\nWARNING: Input tag for L1GlobalTriggerReadoutRecord product set to preferred input tag"
+                            << (tag) << std::endl;
+                    break;
+                }
+            }
+        }
+
+        if (!m_foundPreferredReadoutRecord) {
+
+            // check if other input tag was found - if true, there are multiple input tags in the event,
+            // none in the preferred input tags, so it is not possibly to choose safely an input tag
+
+            if (m_inputTagsL1GtReadoutRecord.size() > 1) {
+
+                edm::LogWarning("L1GtUtils")
+                        << "\nWARNING: Found multiple input tags for L1GlobalTriggerReadoutRecord product."
+                        << "\nNone is in the preferred input tags - no safe choice."
+                        << "\nInput tag already found: "
+                        << (m_l1GtReadoutRecordInputTag) << "\nActual tag: "
+                        << (tag) << "\nInput tag set to empty tag."
+                        << std::endl;
+                m_l1GtReadoutRecordInputTag = edm::InputTag();
+                m_foundMultipleL1GtReadoutRecord = true;
+
+            } else {
+                if (m_l1GtReadoutRecordToken.isUninitialized()) {
+
+                    m_l1GtReadoutRecordInputTag = tag;
+                    m_inputTagsL1GtReadoutRecord.push_back(tag);
+                    m_l1GtReadoutRecordToken = m_consumesCollector.consumes<
+                            L1GlobalTriggerReadoutRecord>(tag);
+
+                    edm::LogWarning("L1GtUtils")
+                            << "\nWARNING: No preferred input tag found for L1GlobalTriggerReadoutRecord product."
+                            << "\nInput tag set to " << (tag) << std::endl;
+                }
+            }
+        }
     }
-  }
+
+
+
+
+    // L1GtTriggerMenuLite
+
+    if (m_findMenuLite && (!m_foundMultipleL1GtMenuLite)
+            && (branchDescription.unwrappedTypeID()
+                    == edm::TypeID(typeid(L1GtTriggerMenuLite)))
+            && (branchDescription.branchType() == edm::InEvent)) {
+
+        edm::InputTag tag { branchDescription.moduleLabel(),
+                branchDescription.productInstanceName(),
+                branchDescription.processName() };
+
+        if (m_foundPreferredMenuLite) {
+
+            // check if a preferred input tag was already found and compare it with the actual tag
+            // if the instance or the process names are different, one has incompatible tags - set
+            // the tag to empty input tag and indicate that multiple preferred input tags are found
+            // so it is not possibly to choose safely an input tag
+
+            if ((m_l1GtTriggerMenuLiteInputTag.label()
+                    == branchDescription.moduleLabel())
+                    && ((m_l1GtTriggerMenuLiteInputTag.instance()
+                            != branchDescription.productInstanceName())
+                            || (m_l1GtTriggerMenuLiteInputTag.process()
+                                    != branchDescription.processName()))) {
+
+                edm::LogWarning("L1GtUtils")
+                        << "\nWARNING: Found multiple preferred input tags for L1GtTriggerMenuLite product, "
+                        << "\nwith different instaces or processes."
+                        << "\nInput tag already found: "
+                        << (m_l1GtTriggerMenuLiteInputTag) << "\nActual tag: " << (tag)
+                        << "\nInput tag set to empty tag." << std::endl;
+
+                m_foundMultipleL1GtMenuLite = true;
+                m_l1GtTriggerMenuLiteInputTag = edm::InputTag();
+            }
+        } else {
+            // no preferred input tag found yet, check now with the actual tag
+
+            for (std::vector<edm::InputTag>::const_iterator itPrefTag =
+                    preferredL1GtTriggerMenuLiteInputTag.begin(), itPrefTagEnd =
+                    preferredL1GtTriggerMenuLiteInputTag.end();
+                    itPrefTag != itPrefTagEnd; ++itPrefTag) {
+
+                if (branchDescription.moduleLabel() == itPrefTag->label()) {
+                    m_l1GtTriggerMenuLiteInputTag = tag;
+                    m_l1GtTriggerMenuLiteToken = m_consumesCollector.consumes<
+                            L1GtTriggerMenuLite>(tag);
+                    m_foundPreferredMenuLite = true;
+                    m_inputTagsL1GtMenuLite.push_back(tag);
+
+                    edm::LogWarning("L1GtUtils")
+                            << "\nWARNING: Input tag for L1GtTriggerMenuLite product set to preferred input tag"
+                            << (tag) << std::endl;
+                    break;
+                }
+            }
+        }
+
+        if (!m_foundPreferredMenuLite) {
+
+            // check if other input tag was found - if true, there are multiple input tags in the event,
+            // none in the preferred input tags, so it is not possibly to choose safely an input tag
+
+            if (m_inputTagsL1GtMenuLite.size() > 1) {
+
+                edm::LogWarning("L1GtUtils")
+                        << "\nWARNING: Found multiple input tags for L1GtTriggerMenuLite product."
+                        << "\nNone is in the preferred input tags - no safe choice."
+                        << "\nInput tag already found: "
+                        << (m_l1GtTriggerMenuLiteInputTag) << "\nActual tag: " << (tag)
+                        << "\nInput tag set to empty tag." << std::endl;
+                m_l1GtTriggerMenuLiteInputTag = edm::InputTag();
+                m_foundMultipleL1GtMenuLite = true;
+
+            } else {
+                if (m_l1GtTriggerMenuLiteToken.isUninitialized()) {
+
+                    m_l1GtTriggerMenuLiteInputTag = tag;
+                    m_inputTagsL1GtMenuLite.push_back(tag);
+                    m_l1GtTriggerMenuLiteToken = m_consumesCollector.consumes<
+                            L1GtTriggerMenuLite>(tag);
+
+                    edm::LogWarning("L1GtUtils")
+                            << "\nWARNING: No preferred input tag found for L1GtTriggerMenuLite product."
+                            << "\nInput tag set to " << (tag) << std::endl;
+                }
+            }
+        }
+    }
 }

--- a/L1Trigger/GlobalTriggerAnalyzer/test/L1GtAnalyzer_cfg.py
+++ b/L1Trigger/GlobalTriggerAnalyzer/test/L1GtAnalyzer_cfg.py
@@ -11,7 +11,7 @@ process = cms.Process("L1GtAnalyzer")
 print '\n'
 from L1Trigger.GlobalTriggerAnalyzer.UserOptions_cff import *
 if errorUserOptions == True :
-    print '\nError returned by UserOptions_cff\n'
+    print '\nError returned by UserOptions_cff. Script stops here.\n'
     sys.exit()
 
 
@@ -41,7 +41,7 @@ process.maxEvents = cms.untracked.PSet(
 # https://twiki.cern.ch/twiki/bin/view/CMS/SWGuideFrontierConditions
 
 process.load('Configuration.StandardSequences.GeometryDB_cff')
-process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
 
 process.GlobalTag.globaltag = useGlobalTag
 
@@ -176,7 +176,7 @@ process.MessageLogger.L1GtAnalyzer_debug = cms.untracked.PSet(
         WARNING = cms.untracked.PSet( limit = cms.untracked.int32(0) ),
         ERROR = cms.untracked.PSet( limit = cms.untracked.int32(0) ),
         L1GtAnalyzer = cms.untracked.PSet( limit = cms.untracked.int32(0) ), 
-        L1GtUtils = cms.untracked.PSet( limit = cms.untracked.int32(0) ), 
+        L1GtUtils = cms.untracked.PSet( limit = cms.untracked.int32(-1) ), 
         L1GtTrigReport = cms.untracked.PSet( limit = cms.untracked.int32(0) ) 
         )
 
@@ -186,7 +186,7 @@ process.MessageLogger.L1GtAnalyzer_info = cms.untracked.PSet(
         WARNING = cms.untracked.PSet( limit = cms.untracked.int32(0) ),
         ERROR = cms.untracked.PSet( limit = cms.untracked.int32(0) ),
         L1GtAnalyzer = cms.untracked.PSet( limit = cms.untracked.int32(-1) ), 
-        L1GtUtils = cms.untracked.PSet( limit = cms.untracked.int32(0) ), 
+        L1GtUtils = cms.untracked.PSet( limit = cms.untracked.int32(-1) ), 
         L1GtTrigReport = cms.untracked.PSet( limit = cms.untracked.int32(-1) ) 
         )
 

--- a/L1Trigger/GlobalTriggerAnalyzer/test/L1GtEmulTrigReport_cfg.py
+++ b/L1Trigger/GlobalTriggerAnalyzer/test/L1GtEmulTrigReport_cfg.py
@@ -11,6 +11,7 @@ import sys
 
 process = cms.Process("L1GtEmulTrigReport")
 
+# import number of events, sample and global tag 
 print '\n'
 from L1Trigger.GlobalTriggerAnalyzer.UserOptions_cff import *
 if errorUserOptions == True :


### PR DESCRIPTION
Remove the arbitrariness of choosing the input tag for
L1GlobalTriggerReadoutRecord product when the input tag is retrieved
from provenance and more products of this type exist, with different
input tags. 

The code will look for the corresponding product in ProductRegistry.
If the product is found, it checks the product label in a vector of
preferred input tags (hardwired now to "gtDigis" and "hltGtDigis"). 

The first input tag from the vector of preferred input tags, with the
same label as the input tag found from provenance, is kept as input tag,
if there are no multiple products with the same label.

If multiple products are found and no one has a label in the vector of
preferred input tags, or if multiple products are found with the label
in the vector of preferred input tags (with different instance or
process) the input tag is set to empty input tag, and L1GtUtil will
produce an error, as it is not possible to safely choose a product. In
this case, one must provide explicitly the correct input tag via
configuration or in the constructor.

The same treatment is applied to L1GlobalTriggerRecord and
L1GtTriggerMenuLite.
