### PR TITLE
Improve message from NoRecordException

### DIFF
--- a/FWCore/Framework/interface/EventSetup.h
+++ b/FWCore/Framework/interface/EventSetup.h
@@ -40,6 +40,7 @@ namespace edm {
       class EventSetupProvider;
       class EventSetupRecord;
       template<class T> struct data_default_record_trait;
+      class EventSetupKnownRecordsSupplier;
    }
 class EventSetup
 {
@@ -103,7 +104,10 @@ class EventSetup
       
       ///clears the oToFill vector and then fills it with the keys for all available records
       void fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>& oToFill) const;
-      
+  
+      ///returns true if the Record is provided by a Source or a Producer
+      /// a value of true does not mean this EventSetup object holds such a record
+      bool recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& ) const;
       // ---------- static member functions --------------------
 
       // ---------- member functions ---------------------------
@@ -115,6 +119,9 @@ class EventSetup
    protected:
       //Only called by EventSetupProvider
       void setIOVSyncValue(const IOVSyncValue&);
+      void setKnownRecordsSupplier(eventsetup::EventSetupKnownRecordsSupplier const* iSupplier) {
+        knownRecords_ = iSupplier;
+      }
 
       void add(const eventsetup::EventSetupRecord& iRecord);
       
@@ -135,6 +142,7 @@ class EventSetup
       
       //NOTE: the records are not owned
       std::map<eventsetup::EventSetupRecordKey, eventsetup::EventSetupRecord const *> recordMap_;
+      eventsetup::EventSetupKnownRecordsSupplier const* knownRecords_;
 };
 
 }

--- a/FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h
+++ b/FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h
@@ -1,0 +1,51 @@
+#ifndef FWCore_Framework_EventSetupKnownRecordsSupplier_h
+#define FWCore_Framework_EventSetupKnownRecordsSupplier_h
+// -*- C++ -*-
+//
+// Package:     Framework
+// Class:      EventSetupKnownRecordsSupplier
+//
+/**\class EventSetupKnownRecordsSupplier EventSetupKnownRecordsSupplier.h FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h
+
+ Description: Interface for determining if an EventSetup Record is known to the framework
+
+ Usage:
+    <usage>
+
+*/
+//
+// Author:      Chris Jones
+// Created:     Thu Mar 24 14:10:07 EST 2005
+//
+
+// user include files
+
+// system include files
+
+
+// forward declarations
+namespace edm {
+
+   namespace eventsetup {
+      class EventSetupRecordKey;
+
+class EventSetupKnownRecordsSupplier {
+
+   public:
+
+      EventSetupKnownRecordsSupplier() = default;
+      virtual ~EventSetupKnownRecordsSupplier() = default;
+
+      // ---------- const member functions ---------------------
+      virtual bool isKnown(EventSetupRecordKey const&) const = 0;
+
+   private:
+      EventSetupKnownRecordsSupplier(EventSetupKnownRecordsSupplier const&) = delete;
+
+      EventSetupKnownRecordsSupplier const& operator=(EventSetupKnownRecordsSupplier const&) = delete;
+
+};
+
+   }
+}
+#endif

--- a/FWCore/Framework/interface/EventSetupProvider.h
+++ b/FWCore/Framework/interface/EventSetupProvider.h
@@ -20,6 +20,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h"
 
 // system include files
 #include "boost/shared_ptr.hpp"
@@ -127,6 +128,7 @@ class EventSetupProvider {
       EventSetup eventSetup_;
       typedef std::map<EventSetupRecordKey, boost::shared_ptr<EventSetupRecordProvider> > Providers;
       Providers providers_;
+      std::unique_ptr<EventSetupKnownRecordsSupplier> knownRecordsSupplier_;
       bool mustFinishConfiguration_;
       unsigned subProcessIndex_;
 

--- a/FWCore/Framework/interface/NoRecordException.h
+++ b/FWCore/Framework/interface/NoRecordException.h
@@ -39,8 +39,9 @@ namespace edm {
    class EventSetup;
    namespace eventsetup {
       class EventSetupRecordKey;
-      void no_record_exception_message_builder(cms::Exception&,const char*, IOVSyncValue const&);
+      void no_record_exception_message_builder(cms::Exception&,const char*, IOVSyncValue const&, bool iKnownRecord);
       IOVSyncValue const& iovSyncValueFrom( edm::EventSetup const& );
+     bool recordDoesExist( edm::EventSetup const& , edm::eventsetup::EventSetupRecordKey const&);
 
 //NOTE: when EDM gets own exception hierarchy, will need to change inheritance
 template <class T>
@@ -48,10 +49,10 @@ class NoRecordException : public cms::Exception
 {
  public:
   // ---------- Constructors and destructor ----------------
-  explicit NoRecordException(IOVSyncValue const& iValue )
+  explicit NoRecordException(IOVSyncValue const& iValue, bool iKnownRecord )
   :cms::Exception("NoRecord")
   {
-    no_record_exception_message_builder(*this,heterocontainer::className<T>(), iValue);
+    no_record_exception_message_builder(*this,heterocontainer::className<T>(), iValue, iKnownRecord);
   }
 
       virtual ~NoRecordException() throw() {}

--- a/FWCore/Framework/interface/eventSetupGetImplementation.h
+++ b/FWCore/Framework/interface/eventSetupGetImplementation.h
@@ -31,7 +31,7 @@ namespace edm {
       inline void eventSetupGetImplementation(EventSetup const& iEventSetup, T const*& iValue) {
          T const* temp = heterocontainer::find<EventSetupRecordKey, T const>(iEventSetup);
          if(0 == temp) {
-            throw NoRecordException<T>(iovSyncValueFrom(iEventSetup));
+            throw NoRecordException<T>(iovSyncValueFrom(iEventSetup), recordDoesExist(iEventSetup, EventSetupRecordKey::makeKey<T>()));
          }
          iValue = temp;
       }

--- a/FWCore/Framework/src/EventSetup.cc
+++ b/FWCore/Framework/src/EventSetup.cc
@@ -17,6 +17,7 @@
 // user include files
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/EventSetupRecord.h"
+#include "FWCore/Framework/interface/EventSetupKnownRecordsSupplier.h"
 
 namespace edm {
 //
@@ -109,6 +110,12 @@ EventSetup::fillAvailableRecordKeys(std::vector<eventsetup::EventSetupRecordKey>
       ++it) {
     oToFill.push_back(it->first);
   }
+}
+
+bool
+EventSetup::recordIsProvidedByAModule( eventsetup::EventSetupRecordKey const& iKey) const
+{
+  return knownRecords_->isKnown(iKey);
 }
 
 //

--- a/FWCore/Framework/src/NoRecordException.cc
+++ b/FWCore/Framework/src/NoRecordException.cc
@@ -24,16 +24,28 @@ edm::eventsetup::iovSyncValueFrom( EventSetup const& iES) {
     return iES.iovSyncValue();
 }
 
+bool
+edm::eventsetup::recordDoesExist( EventSetup const& iES, EventSetupRecordKey const& iKey) {
+  return iES.recordIsProvidedByAModule(iKey);
+}
+
 
 void
-edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException,const char* iName, IOVSyncValue const& iValue) {
+edm::eventsetup::no_record_exception_message_builder(cms::Exception& oException,const char* iName, IOVSyncValue const& iValue, bool iKnownRecord) {
    oException
    << "No \"" 
    << iName
-   << "\" record found in the EventSetup for IOV\n"
+   << "\" record found in the EventSetup for synchronization value\n"
    << "Run: "<<iValue.eventID().run()
    <<" LuminosityBlock: "<<iValue.luminosityBlockNumber()
    <<" Event: "<<iValue.eventID().event()
-   <<" Time: "<<iValue.time().value()
-   <<"\n Please add an ESSource or ESProducer that delivers such a record.\n";
-}   
+   <<" Time: "<<iValue.time().value();
+  if(iKnownRecord) {
+   oException<<"\n The Record is delivered by an ESSource or ESProducer but there is no valid IOV for the synchronizatio value.\n"
+    " Please check \n"
+    "   a) if the synchronization value is reasonable and report to the hypernews if it is not.\n"
+    "   b) else check that all ESSources have been properly configured. \n";
+  } else {
+   oException <<"\n Please add an ESSource or ESProducer that delivers such a record.\n";
+  }
+}


### PR DESCRIPTION
Message now distinguishes between a Record being missing because no Source provides it from no valid IOV for the given sync value.
