### PR TITLE
bug fix for stage1 dqm

### DIFF
--- a/DQM/Integration/python/test/l1tstage1_dqm_sourceclient-live_cfg.py
+++ b/DQM/Integration/python/test/l1tstage1_dqm_sourceclient-live_cfg.py
@@ -88,25 +88,6 @@ process.l1tSyncPath = cms.Path(process.l1tSyncHltFilter+process.l1tSync)
 
 process.l1tMonitorPath = cms.Path(process.l1tMonitorStage1Online)
 process.l1tMonitorClientPath = cms.Path(process.l1tMonitorStage1Client)
-# Update HfRing thresholds to accomodate di-iso tau trigger thresholds
-from L1TriggerConfig.L1ScalesProducers.l1CaloScales_cfi import l1CaloScales
-l1CaloScales.L1HfRingThresholds = cms.vdouble(0.0, 24.0, 28.0, 32.0, 36.0, 40.0, 44.0, 48.0)
-l1CaloScales.L1HtMissThresholds = cms.vdouble(
-    0.00, 0.01, 0.02, 0.03, 0.04, 0.05, 0.06, 0.07, 0.08, 0.09,
-    0.10, 0.11, 0.12, 0.13, 0.14, 0.15, 0.16, 0.17, 0.18, 0.19,
-    0.20, 0.21, 0.22, 0.23, 0.24, 0.25, 0.26, 0.27, 0.28, 0.29,
-    0.30, 0.31, 0.32, 0.33, 0.34, 0.35, 0.36, 0.37, 0.38, 0.39,
-    0.40, 0.41, 0.42, 0.43, 0.44, 0.45, 0.46, 0.47, 0.48, 0.49,
-    0.50, 0.51, 0.52, 0.53, 0.54, 0.55, 0.56, 0.57, 0.58, 0.59,
-    0.60, 0.61, 0.62, 0.63, 0.64, 0.65, 0.66, 0.67, 0.68, 0.69,
-    0.70, 0.71, 0.72, 0.73, 0.74, 0.75, 0.76, 0.77, 0.78, 0.79,
-    0.80, 0.81, 0.82, 0.83, 0.84, 0.85, 0.86, 0.87, 0.88, 0.89,
-    0.90, 0.91, 0.92, 0.93, 0.94, 0.95, 0.96, 0.97, 0.98, 0.99,
-    1.00, 1.01, 1.02, 1.03, 1.04, 1.05, 1.06, 1.07, 1.08, 1.09,
-    1.10, 1.11, 1.12, 1.13, 1.14, 1.15, 1.16, 1.17, 1.18, 1.19,
-    1.20, 1.21, 1.22, 1.23, 1.24, 1.25, 1.26, 1.27
-    )
-
 #
 process.l1tMonitorEndPath = cms.EndPath(process.l1tMonitorEndPathSeq)
 
@@ -180,7 +161,7 @@ process.l1s.dqmFolder = cms.untracked.string("L1TStage1/L1Stage1Scalers_SM")
 
 process.l1tMonitorStage1Client.remove(process.l1TriggerQualityTests)
 
-process.l1tStage1Layer2Client.monitorDir = cms.untracked.string('L1TStage1/stage1layer2')
+process.l1tStage1Layer2Client.monitorDir = cms.untracked.string('L1TStage1/L1TStage1Layer2')
 
 process.l1tsClient.dqmFolder = cms.untracked.string("L1TStage1/L1Stage1Scalers_SM")
 

--- a/DQM/L1TMonitor/python/L1TCSCTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TCSCTF_cfi.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
 l1tCsctf = cms.EDAnalyzer("L1TCSCTF",
-    gmtProducer = cms.InputTag("gtDigis"),
+    gmtProducer = cms.InputTag("l1GtUnpack"),
 
     statusProducer = cms.InputTag("csctfDigis"),
     outputFile = cms.untracked.string(''),

--- a/DQM/L1TMonitor/python/L1TDTTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TDTTF_cfi.py
@@ -8,7 +8,7 @@ l1tDttf = cms.EDAnalyzer("L1TDTTF",
     online = cms.untracked.bool(True),
     l1tInfoFolder = cms.untracked.string('L1T/EventInfo'),
     dttpgSource = cms.InputTag("dttfDigis"),
-    gmtSource = cms.InputTag("gtDigis"),
+    gmtSource = cms.InputTag("l1GtUnpack"),
     MuonCollection = cms.InputTag("muons")
 )
 

--- a/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TEmulatorMonitor_cff.py
@@ -27,7 +27,6 @@ valStage1GtDigis.AlgorithmTriggersUnprescaled = True
 valStage1GtDigis.TechnicalTriggersUnprescaled = True
 valStage1GtDigis.TechnicalTriggersVetoUnmasked = True
 
-
 # DQM modules
 from DQM.L1TMonitor.L1TDEMON_cfi import *
 
@@ -59,6 +58,12 @@ from L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi import *
 
 ############################################################
 
+# GMT unpack from Fed813 in legacy stage1 parallel running                                                                     
+from EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi import *
+l1GtUnpack.DaqGtInputTag = 'rawDataCollector'
+
+#############################################################                 
+
 
 l1TdeRCTSeq = cms.Sequence(
                     l1TdeRCT
@@ -73,20 +78,22 @@ l1ExpertDataVsEmulator = cms.Sequence(
 
 
 l1EmulatorMonitor = cms.Sequence(
+                            l1GtUnpack*
                             l1demon+
                             l1ExpertDataVsEmulator             
                             )
 
 # for use in processes where hardware validation is not run
 l1HwValEmulatorMonitor = cms.Sequence(
+                                l1GtUnpack*
                                 L1HardwareValidation*
                                 l1EmulatorMonitor
                                 )
 
 # for stage1
 l1ExpertDataVsEmulatorStage1 = cms.Sequence(
-    caloStage1Digis*
-    caloStage1LegacyFormatDigis*
+    #caloStage1Digis*
+    #caloStage1LegacyFormatDigis*
     l1TdeStage1Layer2 +
     l1TdeCSCTF +
     l1Stage1GtHwValidation +
@@ -94,8 +101,8 @@ l1ExpertDataVsEmulatorStage1 = cms.Sequence(
     )
 
 l1EmulatorMonitorStage1 = cms.Sequence(
-    caloStage1Digis*
-    caloStage1LegacyFormatDigis*    
+    #caloStage1Digis*
+    #caloStage1LegacyFormatDigis*    
     l1demonstage1+
     l1ExpertDataVsEmulatorStage1
     )
@@ -103,6 +110,7 @@ l1EmulatorMonitorStage1 = cms.Sequence(
 l1Stage1HwValEmulatorMonitor = cms.Sequence(
     caloStage1Digis*
     caloStage1LegacyFormatDigis*    
+    l1GtUnpack*
     L1HardwareValidationforStage1 +
     l1EmulatorMonitorStage1                            
     )

--- a/DQM/L1TMonitor/python/L1TGMT_cfi.py
+++ b/DQM/L1TMonitor/python/L1TGMT_cfi.py
@@ -3,7 +3,7 @@ import FWCore.ParameterSet.Config as cms
 l1tGmt = cms.EDAnalyzer("L1TGMT",
     disableROOToutput = cms.untracked.bool(True),
     verbose = cms.untracked.bool(False),
-    gmtSource = cms.InputTag("gtDigis"),
+    gmtSource = cms.InputTag("l1GtUnpack"),
     DQMStore = cms.untracked.bool(True)
 )
 

--- a/DQM/L1TMonitor/python/L1TMonitor_cff.py
+++ b/DQM/L1TMonitor/python/L1TMonitor_cff.py
@@ -84,9 +84,16 @@ from L1Trigger.L1TCommon.l1tRawToDigi_cfi import *
 # transfer stage1 format digis to legacy format digis
 
 from L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi import *
+caloStage1LegacyFormatDigis.bxMin = cms.int32(-2)
+caloStage1LegacyFormatDigis.bxMax = cms.int32(2)
 
 #################################################################
 
+# GMT digis in parallel running
+from EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi import *
+l1GtUnpack.DaqGtInputTag = 'rawDataCollector'
+
+#############################################################
 
 #
 # define sequences 
@@ -126,6 +133,7 @@ l1ExtraStage1DqmSeq = cms.Sequence(
 #     modules are independent, so the order is irrelevant 
 
 l1tMonitorOnline = cms.Sequence(
+                          l1GtUnpack*
                           bxTiming +
                           l1tDttf +
                           l1tCsctf + 
@@ -141,6 +149,7 @@ l1tMonitorOnline = cms.Sequence(
 
 l1tMonitorStage1Online = cms.Sequence(
                           bxTiming +
+                          l1GtUnpack*
                           l1tDttf +
                           l1tCsctf + 
                           l1tRpctf +

--- a/DQM/L1TMonitor/python/L1TRPCTF_cfi.py
+++ b/DQM/L1TMonitor/python/L1TRPCTF_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 l1tRpctf = cms.EDAnalyzer("L1TRPCTF",
     disableROOToutput = cms.untracked.bool(True),
-    rpctfSource = cms.InputTag("gtDigis"),
+    rpctfSource = cms.InputTag("l1GtUnpack"),
     rpctfRPCDigiSource = cms.InputTag("muonRPCDigis"),
     output_dir = cms.untracked.string('L1T/L1TRPCTF'),
     rateUpdateTime = cms.int32(20), # update after 20 seconds

--- a/DQM/L1TMonitorClient/python/L1TStage1Layer2Client_cfi.py
+++ b/DQM/L1TMonitorClient/python/L1TStage1Layer2Client_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 l1tStage1Layer2Client = cms.EDAnalyzer("L1TGCTClient",
     prescaleLS = cms.untracked.int32(-1),
-    monitorDir = cms.untracked.string('L1T/stage1layer2'),
+    monitorDir = cms.untracked.string('L1T/L1TStage1Layer2'),
     prescaleEvt = cms.untracked.int32(1),
     runInEventLoop=cms.untracked.bool(False),
     runInEndLumi=cms.untracked.bool(True),

--- a/DQM/L1TMonitorClient/src/L1TGCTClient.cc
+++ b/DQM/L1TMonitorClient/src/L1TGCTClient.cc
@@ -88,7 +88,7 @@ void L1TGCTClient::processHistograms(DQMStore::IGetter &igetter) {
     if(m_stage1_layer2_ ==false){
       InputDir = "L1T/L1TGCT/";
     } else{
-      InputDir = "L1T/stage1layer2/";
+      InputDir = "L1T/L1TStage1Layer2/";
     }
 
     Input = igetter.get(InputDir + "IsoEmOccEtaPhi");

--- a/L1Trigger/Configuration/python/ValL1Emulator_cff.py
+++ b/L1Trigger/Configuration/python/ValL1Emulator_cff.py
@@ -67,8 +67,9 @@ valCaloStage1LegacyFormatDigis.InputRlxTauCollection = cms.InputTag("simCaloStag
 valCaloStage1LegacyFormatDigis.InputIsoTauCollection = cms.InputTag("simCaloStage1Digis:isoTaus")
 valCaloStage1LegacyFormatDigis.InputHFSumsCollection = cms.InputTag("simCaloStage1Digis:HFRingSums")
 valCaloStage1LegacyFormatDigis.InputHFCountsCollection = cms.InputTag("simCaloStage1Digis:HFBitCounts")
+valCaloStage1LegacyFormatDigis.bxMin = cms.int32(0)
+valCaloStage1LegacyFormatDigis.bxMax = cms.int32(0)
 
-from L1Trigger.L1TCalorimeter.caloStage1Params_cfi import *
 
 # DT TP emulator
 from L1Trigger.DTTrigger.dtTriggerPrimitiveDigis_cfi import *
@@ -122,10 +123,10 @@ valRpcTriggerDigis.label = 'muonRPCDigis'
 import L1Trigger.GlobalMuonTrigger.gmtDigis_cfi
 valGmtDigis = L1Trigger.GlobalMuonTrigger.gmtDigis_cfi.gmtDigis.clone()
 #
-valGmtDigis.DTCandidates = cms.InputTag('gtDigis','DT')
-valGmtDigis.CSCCandidates = cms.InputTag('gtDigis','CSC')
-valGmtDigis.RPCbCandidates = cms.InputTag('gtDigis','RPCb')
-valGmtDigis.RPCfCandidates = cms.InputTag('gtDigis','RPCf')
+valGmtDigis.DTCandidates = cms.InputTag('l1GtUnpack','DT')
+valGmtDigis.CSCCandidates = cms.InputTag('l1GtUnpack','CSC')
+valGmtDigis.RPCbCandidates = cms.InputTag('l1GtUnpack','RPCb')
+valGmtDigis.RPCfCandidates = cms.InputTag('l1GtUnpack','RPCf')
 valGmtDigis.MipIsoData = 'gctDigis'
 
 # producers for technical triggers 
@@ -148,7 +149,7 @@ valHcalTechTrigDigis = SimCalorimetry.HcalTrigPrimProducers.hcalTTPRecord_cfi.si
 # Global Trigger emulator
 import L1Trigger.GlobalTrigger.gtDigis_cfi
 valGtDigis = L1Trigger.GlobalTrigger.gtDigis_cfi.gtDigis.clone()
-valGtDigis.GmtInputTag = 'gtDigis'
+valGtDigis.GmtInputTag = 'l1GtUnpack'
 valGtDigis.GctInputTag = 'gctDigis'
 valGtDigis.TechnicalTriggersInputTags = cms.VInputTag(
                                                     cms.InputTag('valRpcTechTrigDigis'),
@@ -157,7 +158,7 @@ valGtDigis.TechnicalTriggersInputTags = cms.VInputTag(
 # Global Trigger emulator for Stage1 
 import L1Trigger.GlobalTrigger.gtDigis_cfi
 valStage1GtDigis = L1Trigger.GlobalTrigger.gtDigis_cfi.gtDigis.clone()
-valStage1GtDigis.GmtInputTag = 'gtDigis'
+valStage1GtDigis.GmtInputTag = 'l1GtUnpack'
 valStage1GtDigis.GctInputTag = 'caloStage1LegacyFormatDigis'
 valStage1GtDigis.TechnicalTriggersInputTags = cms.VInputTag(
                                                     cms.InputTag('valRpcTechTrigDigis'),

--- a/L1Trigger/HardwareValidation/python/L1Comparator_cfi.py
+++ b/L1Trigger/HardwareValidation/python/L1Comparator_cfi.py
@@ -14,10 +14,10 @@ l1compare = cms.EDProducer("L1Comparator",
     DTFsourceData = cms.InputTag("dttfDigis"),
     DTFsourceEmul = cms.InputTag("valDttfDigis"),
     
-    RPCsourceData = cms.InputTag("gtDigis"),
+    RPCsourceData = cms.InputTag("l1GtUnpack"),
     RPCsourceEmul = cms.InputTag("valRpcTriggerDigis"),
     
-    GMTsourceData = cms.InputTag("gtDigis"),
+    GMTsourceData = cms.InputTag("l1GtUnpack"),
     GMTsourceEmul = cms.InputTag("valGmtDigis"),
     
     FEDsourceData = cms.untracked.InputTag("rawDataCollector"),
@@ -31,8 +31,8 @@ l1compare = cms.EDProducer("L1Comparator",
     
     # ECAL TPG (ETP), HCAL TPG (HTP), CSC TF (CTF) LTC, GT not supported - expert modules in DQM
     COMPARE_COLLS = cms.untracked.vuint32(
-       0,  0,  1,  1,  0,  1,  0,  0,  1,  0,  1, 0
-    # ETP,HTP,RCT,GCT,DTP,DTF,CTP,CTF,RPC,LTC,GMT,GT,
+        0,  0,  1,  1,   0,  1,  0,  0,  1,  0,  1, 0
+    # ETP,HTP,RCT,GCT, DTP,DTF,CTP,CTF,RPC,LTC,GMT,GT
     )
 )
 

--- a/L1Trigger/HardwareValidation/python/L1ComparatorforStage1_cfi.py
+++ b/L1Trigger/HardwareValidation/python/L1ComparatorforStage1_cfi.py
@@ -14,10 +14,10 @@ l1compareforstage1 = cms.EDProducer("L1Comparator",
     DTFsourceData = cms.InputTag("dttfDigis"),
     DTFsourceEmul = cms.InputTag("valDttfDigis"),
     
-    RPCsourceData = cms.InputTag("gtDigis"),
+    RPCsourceData = cms.InputTag("l1GtUnpack"),
     RPCsourceEmul = cms.InputTag("valRpcTriggerDigis"),
     
-    GMTsourceData = cms.InputTag("gtDigis"),
+    GMTsourceData = cms.InputTag("l1GtUnpack"),
     GMTsourceEmul = cms.InputTag("valGmtDigis"),
     
     FEDsourceData = cms.untracked.InputTag("rawDataCollector"),


### PR DESCRIPTION
Make a PR trying to fix:
Trying to fix 3 bugs for stage1 dqm:
1) change Stage1 Client histogram folder
2) make sure GMT fed will not be affected when swap GT fiber between stage1 and legacy
3) restrict layer2 to unpack only 1Bx for data emulator comparison

Similar to #10360 , But since #10360 have a lot of bugs, I made this new PR and together with #10442  will replace #10360. 
