### PR TITLE
FastSim : fix standalone track validation

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_fastsim_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_fastsim_cff.py
@@ -21,4 +21,6 @@ trackValidator.histoProducerAlgoBlock.TpSelectorForEfficiencyVsVTXZ.stableOnly =
 ###must be commented in normal running
 ###multiTrackValidator.outputFile='validationPlots.root'
 
-
+tracksValidationStandalone.remove(trackValidatorFromPVStandalone)
+tracksValidationStandalone.remove(trackValidatorFromPVAllTPStandalone)
+tracksValidationStandalone.remove(trackValidatorAllTPEfficStandalone)


### PR DESCRIPTION
The sequence tracksValidationStandalone was recently edited.
In the FastSim version of this sequence I remove those modules that don't run for FastSim.
This should be considered a temporary fix.
