### PR TITLE
Update for GEN infos in 75X 

### DIFF
--- a/MuonAnalysis/MomentumScaleCalibration/bin/TreeFromDump.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/TreeFromDump.cc
@@ -73,7 +73,7 @@ int main(int argc, char* argv[])
 	ss >> value[i];
 	// std::cout << "value["<<i<<"] = " << value[i] << std::endl;
       }
-      pairVector.push_back(MuonPair(fromPtEtaPhiToPxPyPz(value), fromPtEtaPhiToPxPyPz(&(value[3])), MuScleFitEvent(0,0,0,0,0)) );
+      pairVector.push_back(MuonPair(fromPtEtaPhiToPxPyPz(value), fromPtEtaPhiToPxPyPz(&(value[3])), MuScleFitEvent(0,0,0,0,0,0)) );
       if( genInfo ) {
 	for( int i=0; i<6; ++i ) {
 	  ss >> genValue[i];

--- a/MuonAnalysis/MomentumScaleCalibration/bin/ZntupleToTreeConverter.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/bin/ZntupleToTreeConverter.cc
@@ -142,7 +142,7 @@ int main(int argc, char* argv[])
       double muon2[3] = {(*muon2pt)[i], (*muon2eta)[i], (*muon2phi)[i]};
 
       // pairVector.push_back( std::make_pair( fromPtEtaPhiToPxPyPz(muon1), fromPtEtaPhiToPxPyPz(muon2) ) );
-      pairVector.push_back( MuonPair(fromPtEtaPhiToPxPyPz(muon1), fromPtEtaPhiToPxPyPz(muon2), MuScleFitEvent(0,0,0,0,0)) );
+      pairVector.push_back( MuonPair(fromPtEtaPhiToPxPyPz(muon1), fromPtEtaPhiToPxPyPz(muon2), MuScleFitEvent(0,0,0,0,0,0)) );
     }
   }
   size_t namePos = fileName.find_last_of("/");

--- a/MuonAnalysis/MomentumScaleCalibration/interface/Event.h
+++ b/MuonAnalysis/MomentumScaleCalibration/interface/Event.h
@@ -9,14 +9,16 @@ class MuScleFitEvent : public TObject
    MuScleFitEvent() :
      fRun(0),
      fEvent(0),
+     fMCWeight(0),
      fTrueNumPUvtx(0),
      fTrueNumInteractions(0),
      fNpv(0)
        {}
 
-     MuScleFitEvent(const unsigned int initRun, const unsigned long long initEvent, const int initNPUvtx, const float initTrueNI, const int initNpv) :
+    MuScleFitEvent(const unsigned int initRun, const unsigned long long initEvent, const double initMCWeight, const int initNPUvtx, const float initTrueNI, const int initNpv) :
        fRun(initRun),
        fEvent(initEvent),
+       fMCWeight(initMCWeight),
        fTrueNumPUvtx(initNPUvtx),
        fTrueNumInteractions(initTrueNI),
        fNpv(initNpv)
@@ -25,6 +27,7 @@ class MuScleFitEvent : public TObject
     // Getters
        UInt_t run() const {return fRun;}
        ULong64_t event() const {return fEvent;}
+       Double_t MCweight() const {return fMCWeight;}
        Int_t nPUvtx() const {return fTrueNumPUvtx;}
        Float_t nTrueInteractions() const {return fTrueNumInteractions;}
        UInt_t npv() const {return fNpv;}
@@ -32,6 +35,7 @@ class MuScleFitEvent : public TObject
 
      UInt_t fRun;
      ULong64_t fEvent;
+     Double_t fMCWeight;
      Int_t fTrueNumPUvtx;
      Float_t fTrueNumInteractions;
      UInt_t fNpv;

--- a/MuonAnalysis/MomentumScaleCalibration/interface/MuonPair.h
+++ b/MuonAnalysis/MomentumScaleCalibration/interface/MuonPair.h
@@ -17,7 +17,7 @@ class MuonPair : public TObject
     //initialize 2 object of class muon
     mu1(lorentzVector(0,0,0,0),-1),
     mu2(lorentzVector(0,0,0,0),1),
-    event(0,0,0,0,0)
+    event(0,0,0,0,0,0)
       {}
     
     MuonPair(const MuScleFitMuon & initMu1, const MuScleFitMuon & initMu2, const MuScleFitEvent & initMuEvt) : 
@@ -39,7 +39,7 @@ class MuonPair : public TObject
       MuScleFitMuon mu2;
       MuScleFitEvent event;
       
-      ClassDef(MuonPair, 3)
+      ClassDef(MuonPair, 4)
 	};
 ClassImp(MuonPair)
    

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/BuildFile.xml
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/BuildFile.xml
@@ -15,6 +15,7 @@
 <use   name="SimGeneral/HepPDTRecord"/>
 <use   name="SimDataFormats/Track"/>
 <use   name="SimDataFormats/Vertex"/>
+<use   name="SimDataFormats/GeneratorProducts"/>
 <use   name="root"/>
 <use   name="clhep"/>
 <use   name="heppdt"/>

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFit.cc
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFit.cc
@@ -155,9 +155,9 @@
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 #include "SimDataFormats/GeneratorProducts/interface/HepMCProduct.h"
 
-
 #include "DataFormats/VertexReco/interface/Vertex.h"
 #include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+#include "SimDataFormats/GeneratorProducts/interface/GenEventInfoProduct.h"
 
 #include "TFile.h"
 #include "TTree.h"
@@ -940,9 +940,16 @@ void MuScleFit::selectMuons(const edm::Event & event)
     }
   }
 
+  // get the MC event weight
+  edm::Handle<GenEventInfoProduct> genEvtInfo;
+  event.getByLabel("generator", genEvtInfo);
+  double the_genEvtweight = 1.; 
+  if ( genEvtInfo.isValid() ) {
+    the_genEvtweight = genEvtInfo->weight();
+  }
 
   muonPairs_.push_back(MuonPair(MuScleFitUtils::SavedPairMuScleFitMuons.back().first, MuScleFitUtils::SavedPairMuScleFitMuons.back().second,
-				MuScleFitEvent(event.run(), event.id().event(), the_numPUvtx, the_TrueNumInteractions, the_NVtx)
+				MuScleFitEvent(event.run(), event.id().event(), the_genEvtweight, the_numPUvtx, the_TrueNumInteractions, the_NVtx)
 				));
   // Fill the internal genPair tree from the external one
   if( MuScleFitUtils::speedup == false ) {
@@ -1036,7 +1043,7 @@ void MuScleFit::selectMuons(const int maxEvents, const TString & treeFileName)
 
     //FIXME: we loose the additional information besides the 4-momenta
     muonPairs_.push_back(MuonPair(MuScleFitMuon(it->first,-1), MuScleFitMuon(it->second,+1),
-				  MuScleFitEvent((*evtRunIt).first, (*evtRunIt).second, 0, 0, 0) ) // FIXME: order of event and run number mixed up!
+				  MuScleFitEvent((*evtRunIt).first, (*evtRunIt).second, 0, 0, 0, 0) ) // FIXME: order of event and run number mixed up!
 				  );
 
 

--- a/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.h
+++ b/MuonAnalysis/MomentumScaleCalibration/plugins/MuScleFitMuonSelector.h
@@ -47,8 +47,11 @@ class MuScleFitMuonSelector
   {}
   ~MuScleFitMuonSelector() {}
 
-  //Method to get the muon after FSR (status 1 muon) starting from status 3 muon which is daughter of the Z
+  //Method to get the muon after FSR (status 1 muon in PYTHIA6) starting from status 3 muon which is daughter of the Z
   const reco::Candidate* getStatus1Muon(const reco::Candidate* status3Muon);
+
+  //Method to get the muon before FSR (status 3 muon in PYTHIA6) starting from status 3 muon which is daughter of the Z
+  const reco::Candidate* getStatus3Muon(const reco::Candidate* status3Muon);
   
   /// Main method used to select muons of type specified by muonType_ from the collection specified by muonLabel_ and PATmuons_
   void selectMuons(const edm::Event & event, std::vector<MuScleFitMuon> & muons,


### PR DESCRIPTION
This is essentially the forward porting of PR  #10477 (but is starts from PR #10072 which was already included in CMSSW_75X).
The current PR includes the first round of modifications to fill properly the GEN level infos from pythia8 and NLO Monte Carlo generators.
RECO is not affected.
@maralxplus, @mabarrio This can be of interest for you as well as it affects the format of the trees created by MuScleFit as it includes an event weight useful for NLO MC,
