### PR TITLE
Add 15GeV cut to electron seeds for HI workflow

### DIFF
--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -9,12 +9,15 @@ from RecoHI.HiTracking.HiTracking_cff import *    # two additional steps
 # Egamma
 from RecoHI.HiEgammaAlgos.HiEgamma_cff import *
 from RecoHI.HiEgammaAlgos.HiElectronSequence_cff import *
+ecalDrivenElectronSeeds.SeedConfiguration.SCEtCut = cms.double(15.0)
+ecalDrivenGsfElectrons.minSCEtBarrel = cms.double(15.0)
+ecalDrivenGsfElectrons.minSCEtEndcaps = cms.double(15.0)
 
 # Jet Reconstruction
 from RecoHI.HiJetAlgos.HiRecoJets_cff import *
 
 # Muon Reco
-from RecoHI.HiMuonAlgos.HiRecoMuon_cff import * 
+from RecoHI.HiMuonAlgos.HiRecoMuon_cff import *
 # keep regit seperate for the moment
 from RecoHI.HiMuonAlgos.HiRegionalRecoMuon_cff import *
 
@@ -35,7 +38,7 @@ globalRecoPbPb = cms.Sequence(hiTracking
                               * hiEcalClusters
                               * hiRecoJets
                               * muonRecoPbPb
-                              * hiElectronSequence 
+                              * hiElectronSequence
                               * hiEgammaSequence
                               * hiParticleFlowReco
                               * hiCentrality
@@ -59,10 +62,9 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               )
 
 #--------------------------------------------------------------------------
-# Full sequence (LOCAL RECO + HIGH LEVEL RECO) 
+# Full sequence (LOCAL RECO + HIGH LEVEL RECO)
 # in Configuration.StandardSequences.ReconstructionHeavyIons_cff
 
 # Modify zero-suppression sequence here
 from RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi import *
 siStripZeroSuppression.storeCM = cms.bool(True)
-

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -10,6 +10,8 @@ particleFlowEGamma.vertexCollection = cms.InputTag("hiSelectedVertex")
 gedGsfElectronCores.ctfTracks = cms.InputTag("hiGeneralTracks")
 gedGsfElectronsTmp.ctfTracksTag = cms.InputTag("hiGeneralTracks")
 gedGsfElectronsTmp.vtxTag = cms.InputTag("hiSelectedVertex")
+gedGsfElectronsTmp.minSCEtBarrel = cms.double(15.0)
+gedGsfElectronsTmp.minSCEtEndcaps = cms.double(15.0)
 gedPhotonsTmp.primaryVertexProducer = cms.InputTag("hiSelectedVertex")
 gedPhotonsTmp.regressionConfig.vertexCollection = cms.InputTag("hiSelectedVertex")
 gedPhotonsTmp.isolationSumsCalculatorSet.trackProducer = cms.InputTag("hiGeneralTracks")
@@ -30,7 +32,7 @@ particleFlowBlock.elementImporters = cms.VPSet(
     cms.PSet( importerName = cms.string("GSFTrackImporter"),
               source = cms.InputTag("pfTrackElec"),
               gsfsAreSecondary = cms.bool(False),
-              superClustersArePF = cms.bool(True) ),        
+              superClustersArePF = cms.bool(True) ),
     cms.PSet( importerName = cms.string("SuperClusterImporter"),
                   source_eb = cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALBarrel"),
                   source_ee = cms.InputTag("particleFlowSuperClusterECAL:particleFlowSuperClusterECALEndcapWithPreshower"),
@@ -47,7 +49,7 @@ particleFlowBlock.elementImporters = cms.VPSet(
               DPtOverPtCuts_byTrackAlgo = cms.vdouble(-1.0,-1.0,-1.0,
                                                        1.0,1.0),
               NHitCuts_byTrackAlgo = cms.vuint32(3,3,3,3,3)
-              ),        
+              ),
     # to properly set SC based links you need to run ECAL importer
     # after you've imported all SCs to the block
     cms.PSet( importerName = cms.string("ECALClusterImporter"),


### PR DESCRIPTION
Heavy Ions has seen some fake PF jets which have most of the their energy coming from a single PF electron candidate. Usually this candidate had a low Et ecal seed and a high-pt (fake) track. While this did not seem to hurt our jet energy resolution, it does mess up spectra measurements, where high pT fake jets really change the measurement.

@doanhien has been studying ways to reduce these fake PF electrons, and an easy cut we can add is a 15GeV cut on electron seeds. This significantly reduces the number of fake jets without significantly changing analysis-level electrons.

This PR should not change any pp workflows at all, only HI workflows. It will be followed up by a backport to 75X as well.

The cuts added to ecalDrivenGsfElectrons and gedGsfElectronsTmp are simply to silence a warning about inconsistent cuts at seed and ElectronProducer level, and make no physics difference in addition to the ecalDrivenElectronSeeds cut.

Some further plots and cross-checks:
1) Robustness of JER to cuts: https://twiki.cern.ch/twiki/pub/CMS/PhotonAnalyses2015/JERJES_pT80_PbPb_PFElecComp.pdf

2) Reduction of fake jets with this cut: https://hypernews.cern.ch/HyperNews/CMS/get/hi-general/2248/1/1.html

3) Analysis-level effects of these cuts: https://twiki.cern.ch/twiki/bin/view/CMS/PhotonAnalyses2015#2015_07_21_13_30_CET
