### PR TITLE
Complete fix for HcalCalPedestal AlCaReco (75X)

### DIFF
--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_Output_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_Output_cff.py
@@ -1,6 +1,6 @@
 import FWCore.ParameterSet.Config as cms
 
-# output block for alcastream HCAL Min Bias
+# output block for alcastream HCAL Pedestal
 # output module 
 #  module alcastreamHcalMinbiasOutput = PoolOutputModule
 
@@ -9,14 +9,10 @@ OutALCARECOHcalCalPedestal_noDrop = cms.PSet(
         SelectEvents = cms.vstring('pathALCARECOHcalCalPedestal')
     ),
     outputCommands = cms.untracked.vstring(
-	'keep *_gtDigisAlCaMB_*_*',
-        'keep HBHERecHitsSorted_hbherecoMB_*_*',
-        'keep HORecHitsSorted_horecoMB_*_*',
-        'keep HFRecHitsSorted_hfrecoMB_*_*',
-        'keep HFRecHitsSorted_hfrecoMBspecial_*_*',
-        'keep HBHERecHitsSorted_hbherecoNoise_*_*',
-        'keep HORecHitsSorted_horecoNoise_*_*',
-        'keep HFRecHitsSorted_hfrecoNoise_*_*')
+        'keep *_gtDigisAlCaPedestal_*_*',
+        'keep HBHERecHitsSorted_hbherecoPedestal_*_*',
+        'keep HORecHitsSorted_horecoPedestal_*_*',
+        'keep HFRecHitsSorted_hfrecoPedestal_*_*')
 )
 
 import copy

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -3,33 +3,55 @@ import FWCore.ParameterSet.Config as cms
 #------------------------------------------------
 #AlCaReco filtering for HCAL minbias:
 #------------------------------------------------
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+hcalDigiAlCaPedestals = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone()
+hcalDigiAlCaPedestals.InputLabel = 'hltHcalCalibrationRaw'
 
-from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalMinBias_cff import *
-hcalDigiAlCaMB.InputLabel = 'hltHcalCalibrationRaw'
-#from EventFilter.HcalRawToDigi.HcalRawToDigi_cfi import *
-#hcalDigis.InputLabel = 'hltHcalCalibrationRaw'
-from RecoLocalCalo.Configuration.hcalLocalRecoNZS_cff import *
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi
+hbherecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi.hbheprereco.clone()
 
-hbherecoMB.firstSample = 0
-hbherecoMB.samplesToAdd = 4
-hbherecoMB.digiLabel = 'hcalDigiAlCaMB'
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi
+hfrecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi.hfreco.clone()
 
-hfrecoMB.firstSample = 0
-hfrecoMB.samplesToAdd = 2
-hfrecoMB.digiLabel = 'hcalDigiAlCaMB'
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi
+horecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_ho_cfi.horeco.clone()
 
-horecoMB.firstSample = 0
-horecoMB.samplesToAdd = 4
-horecoMB.digiLabel = 'hcalDigiAlCaMB'
+#add GT digi:
+import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
+gtDigisAlCaPedestals = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
 
+hbherecoPedestals.firstSample = 0
+hbherecoPedestals.samplesToAdd = 4
+hbherecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
+
+hfrecoPedestals.firstSample = 0
+hfrecoPedestals.samplesToAdd = 2
+hfrecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
+
+horecoPedestals.firstSample = 0
+horecoPedestals.samplesToAdd = 4
+horecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
+
+# switch off "Hcal ZS in reco":
+hbherecoPedestals.dropZSmarkedPassed = cms.bool(False)
+hfrecoPedestals.dropZSmarkedPassed = cms.bool(False)
+horecoPedestals.dropZSmarkedPassed = cms.bool(False)
+
+hcalLocalRecoSequencePedestals = cms.Sequence(hbherecoPedestals*hfrecoPedestals*horecoPedestals) 
 
 import EventFilter.HcalRawToDigi.HcalCalibTypeFilter_cfi
 hcalCalibPedestal = EventFilter.HcalRawToDigi.HcalCalibTypeFilter_cfi.hcalCalibTypeFilter.clone(
-#  InputLabel = cms.string('rawDataCollector'), 
-  InputLabel = cms.string('hltHcalCalibrationRaw::HLT'),
-#  InputLabel = cms.InputTag("hltEcalCalibrationRaw","","HLT"),
-  CalibTypes    = cms.vint32( 1 ),
-  FilterSummary = cms.untracked.bool( False )
-)
+    #  InputLabel = cms.string('rawDataCollector'), 
+    InputLabel = cms.string('hltHcalCalibrationRaw::HLT'),
+    #  InputLabel = cms.InputTag("hltEcalCalibrationRaw","","HLT"),
+    CalibTypes    = cms.vint32( 1 ),
+    FilterSummary = cms.untracked.bool( False )
+    )
 
-seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestal*hcalDigiAlCaMB*gtDigisAlCaMB*hcalLocalRecoSequenceNZS*hbherecoNoise*hfrecoNoise*horecoNoise)
+seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestal*
+                                          hcalDigiAlCaPedestals*
+                                          gtDigisAlCaPedestals*
+                                          hcalLocalRecoSequencePedestals*
+                                          hbherecoPedestals*
+                                          hfrecoPedestals*
+                                          horecoPedestals)

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -51,7 +51,4 @@ hcalCalibPedestal = EventFilter.HcalRawToDigi.HcalCalibTypeFilter_cfi.hcalCalibT
 seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestal*
                                           hcalDigiAlCaPedestals*
                                           gtDigisAlCaPedestals*
-                                          hcalLocalRecoSequencePedestals*
-                                          hbherecoPedestals*
-                                          hfrecoPedestals*
-                                          horecoPedestals)
+                                          hcalLocalRecoSequencePedestals)

--- a/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
+++ b/Calibration/HcalAlCaRecoProducers/python/ALCARECOHcalCalPedestal_cff.py
@@ -1,54 +1,52 @@
 import FWCore.ParameterSet.Config as cms
 
 #------------------------------------------------
-#AlCaReco filtering for HCAL minbias:
+#AlCaReco filtering for HCAL pedestal:
 #------------------------------------------------
-import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
-hcalDigiAlCaPedestals = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone()
-hcalDigiAlCaPedestals.InputLabel = 'hltHcalCalibrationRaw'
-
-import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi
-hbherecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi.hbheprereco.clone()
-
-import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi
-hfrecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi.hfreco.clone()
-
-import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi
-horecoPedestals = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_ho_cfi.horeco.clone()
-
-#add GT digi:
-import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
-gtDigisAlCaPedestals = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
-
-hbherecoPedestals.firstSample = 0
-hbherecoPedestals.samplesToAdd = 4
-hbherecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
-
-hfrecoPedestals.firstSample = 0
-hfrecoPedestals.samplesToAdd = 2
-hfrecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
-
-horecoPedestals.firstSample = 0
-horecoPedestals.samplesToAdd = 4
-horecoPedestals.digiLabel = 'hcalDigiAlCaPedestals'
-
-# switch off "Hcal ZS in reco":
-hbherecoPedestals.dropZSmarkedPassed = cms.bool(False)
-hfrecoPedestals.dropZSmarkedPassed = cms.bool(False)
-horecoPedestals.dropZSmarkedPassed = cms.bool(False)
-
-hcalLocalRecoSequencePedestals = cms.Sequence(hbherecoPedestals*hfrecoPedestals*horecoPedestals) 
 
 import EventFilter.HcalRawToDigi.HcalCalibTypeFilter_cfi
 hcalCalibPedestal = EventFilter.HcalRawToDigi.HcalCalibTypeFilter_cfi.hcalCalibTypeFilter.clone(
-    #  InputLabel = cms.string('rawDataCollector'), 
+    #  InputLabel = cms.string('rawDataCollector'),
     InputLabel = cms.string('hltHcalCalibrationRaw::HLT'),
     #  InputLabel = cms.InputTag("hltEcalCalibrationRaw","","HLT"),
     CalibTypes    = cms.vint32( 1 ),
     FilterSummary = cms.untracked.bool( False )
     )
 
+#add GT digi:
+import EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi
+gtDigisAlCaPedestal = EventFilter.L1GlobalTriggerRawToDigi.l1GtUnpack_cfi.l1GtUnpack.clone()
+
+import EventFilter.HcalRawToDigi.HcalRawToDigi_cfi
+hcalDigiAlCaPedestal = EventFilter.HcalRawToDigi.HcalRawToDigi_cfi.hcalDigis.clone()
+hcalDigiAlCaPedestal.InputLabel = cms.InputTag('hltHcalCalibrationRaw')
+
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi
+hbherecoPedestal = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hbhe_cfi.hbheprereco.clone()
+hbherecoPedestal.digiLabel = cms.InputTag('hcalDigiAlCaPedestal')
+hbherecoPedestal.firstSample = cms.int32(0)
+hbherecoPedestal.samplesToAdd = cms.int32(4)
+
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi
+hfrecoPedestal = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_hf_cfi.hfreco.clone()
+hfrecoPedestal.digiLabel = cms.InputTag('hcalDigiAlCaPedestal')
+hfrecoPedestal.firstSample = cms.int32(0)
+hfrecoPedestal.samplesToAdd = cms.int32(2)
+
+import RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_ho_cfi
+horecoPedestal = RecoLocalCalo.HcalRecProducers.HcalSimpleReconstructor_ho_cfi.horeco.clone()
+horecoPedestal.digiLabel = cms.InputTag('hcalDigiAlCaPedestal')
+horecoPedestal.firstSample = cms.int32(0)
+horecoPedestal.samplesToAdd = cms.int32(4)
+
+# switch off "Hcal ZS in reco":
+hbherecoPedestal.dropZSmarkedPassed = cms.bool(False)
+hfrecoPedestal.dropZSmarkedPassed = cms.bool(False)
+horecoPedestal.dropZSmarkedPassed = cms.bool(False)
+
+hcalLocalRecoSequencePedestal = cms.Sequence(hbherecoPedestal*hfrecoPedestal*horecoPedestal) 
+
 seqALCARECOHcalCalPedestal = cms.Sequence(hcalCalibPedestal*
-                                          hcalDigiAlCaPedestals*
-                                          gtDigisAlCaPedestals*
-                                          hcalLocalRecoSequencePedestals)
+                                          hcalDigiAlCaPedestal*
+                                          gtDigisAlCaPedestal*
+                                          hcalLocalRecoSequencePedestal)

--- a/Calibration/HcalAlCaRecoProducers/test/HCalCalPedestal_ALCA_run251252_Run2015B_data.py
+++ b/Calibration/HcalAlCaRecoProducers/test/HCalCalPedestal_ALCA_run251252_Run2015B_data.py
@@ -1,0 +1,84 @@
+# Auto generated configuration file
+# using: 
+# Revision: 1.19 
+# Source: /local/reps/CMSSW/CMSSW/Configuration/Applications/python/ConfigBuilder.py,v 
+# with command line options: HCalCalPedestal -s ALCA:HcalCalPedestal --data --scenario=pp --conditions auto:run2_data_FULL -n -1 --customise=SLHCUpgradeSimulations/Configuration/postLS1Customs.customisePostLS1 --magField AutoFromDBCurrent --processName=USER --filein root://eoscms//eos/cms/store/data/Run2015B/TestEnablesEcalHcal/RAW/v1/000/251/252/00000/82A5CE77-D025-E511-8EC3-02163E0136E2.root
+import FWCore.ParameterSet.Config as cms
+
+process = cms.Process('USER')
+
+# import of standard configurations
+process.load('Configuration.StandardSequences.Services_cff')
+process.load('SimGeneral.HepPDTESSource.pythiapdt_cfi')
+process.load('FWCore.MessageService.MessageLogger_cfi')
+process.load('Configuration.EventContent.EventContent_cff')
+process.load('Configuration.StandardSequences.GeometryRecoDB_cff')
+process.load('Configuration.StandardSequences.MagneticField_AutoFromDBCurrent_cff')
+process.load('Configuration.StandardSequences.AlCaRecoStreams_cff')
+process.load('Configuration.StandardSequences.EndOfProcess_cff')
+process.load('Configuration.StandardSequences.FrontierConditions_GlobalTag_condDBv2_cff')
+
+process.maxEvents = cms.untracked.PSet(
+    input = cms.untracked.int32(-1)
+)
+
+# Input source
+process.source = cms.Source("PoolSource",
+    fileNames = cms.untracked.vstring('root://eoscms//eos/cms/store/data/Run2015B/TestEnablesEcalHcal/RAW/v1/000/251/252/00000/82A5CE77-D025-E511-8EC3-02163E0136E2.root'),
+    secondaryFileNames = cms.untracked.vstring()
+)
+
+process.options = cms.untracked.PSet(
+
+)
+
+# Production Info
+process.configurationMetadata = cms.untracked.PSet(
+    annotation = cms.untracked.string('HCalCalPedestal nevts:-1'),
+    name = cms.untracked.string('Applications'),
+    version = cms.untracked.string('$Revision: 1.19 $')
+)
+
+# Output definition
+
+
+# Additional output definition
+process.ALCARECOStreamHcalCalPedestal = cms.OutputModule("PoolOutputModule",
+    SelectEvents = cms.untracked.PSet(
+        SelectEvents = cms.vstring('pathALCARECOHcalCalPedestal')
+    ),
+    dataset = cms.untracked.PSet(
+        dataTier = cms.untracked.string('ALCARECO'),
+        filterName = cms.untracked.string('ALCARECOHcalCalPedestal')
+    ),
+    eventAutoFlushCompressedSize = cms.untracked.int32(5242880),
+    fileName = cms.untracked.string('ALCARECOHcalCalPedestal.root'),
+    outputCommands = cms.untracked.vstring('drop *', 
+        'keep *_gtDigisAlCaPedestal_*_*', 
+        'keep HBHERecHitsSorted_hbherecoPedestal_*_*', 
+        'keep HORecHitsSorted_horecoPedestal_*_*', 
+        'keep HFRecHitsSorted_hfrecoPedestal_*_*')
+)
+
+# Other statements
+process.ALCARECOEventContent.outputCommands.extend(process.OutALCARECOHcalCalPedestal_noDrop.outputCommands)
+from Configuration.AlCa.GlobalTag_condDBv2 import GlobalTag
+process.GlobalTag = GlobalTag(process.GlobalTag, 'auto:run2_data_FULL', '')
+
+# Path and EndPath definitions
+process.endjob_step = cms.EndPath(process.endOfProcess)
+process.ALCARECOStreamHcalCalPedestalOutPath = cms.EndPath(process.ALCARECOStreamHcalCalPedestal)
+
+# Schedule definition
+process.schedule = cms.Schedule(process.pathALCARECOHcalCalPedestal,process.endjob_step,process.ALCARECOStreamHcalCalPedestalOutPath)
+
+# customisation of the process.
+
+# Automatic addition of the customisation function from SLHCUpgradeSimulations.Configuration.postLS1Customs
+from SLHCUpgradeSimulations.Configuration.postLS1Customs import customisePostLS1 
+
+#call to customisation function customisePostLS1 imported from SLHCUpgradeSimulations.Configuration.postLS1Customs
+process = customisePostLS1(process)
+
+# End of customisation functions
+

--- a/Configuration/StandardSequences/python/AlCaRecoStream_Specials_cff.py
+++ b/Configuration/StandardSequences/python/AlCaRecoStream_Specials_cff.py
@@ -27,7 +27,6 @@ ALCARECOStreamEcalCalEtaCalib = cms.FilteredStream(
 
 # ECAL calibration with pi0
 from Calibration.EcalAlCaRecoProducers.ALCARECOEcalCalPi0Calib_cff import *
-from DQMOffline.Configuration.AlCaRecoDQM_cff import *
 
 pathALCARECOEcalCalPi0Calib = cms.Path(seqALCARECOEcalCalPi0Calib*ALCARECOEcalCalPi0CalibDQM)
 
@@ -45,8 +44,6 @@ ALCARECOStreamEcalCalPi0Calib = cms.FilteredStream(
 # HCAL calibration with min.bias
 from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalMinBias_cff import *
 
-from DQMOffline.Configuration.AlCaRecoDQM_cff import *
-
 pathALCARECOHcalCalMinBias = cms.Path(seqALCARECOHcalCalMinBias*ALCARECOHcalCalPhisymDQM)
 
 from Configuration.EventContent.AlCaRecoOutput_cff import *
@@ -63,8 +60,6 @@ ALCARECOStreamHcalCalMinBias = cms.FilteredStream(
 # HCAL Pedestals
 from Calibration.HcalAlCaRecoProducers.ALCARECOHcalCalPedestal_cff import *
 
-from DQMOffline.Configuration.AlCaRecoDQM_cff import *
-
 pathALCARECOHcalCalPedestal = cms.Path(seqALCARECOHcalCalPedestal*ALCARECOHcalCalPhisymDQM)
 
 from Configuration.EventContent.AlCaRecoOutput_cff import *
@@ -77,8 +72,6 @@ ALCARECOStreamHcalCalPedestal = cms.FilteredStream(
         selectEvents = OutALCARECOHcalCalPedestal.SelectEvents,
         dataTier = cms.untracked.string('ALCARECO')
         )
-
-
 
 # AlCaReco for LumiPixel stream
 from Calibration.TkAlCaRecoProducers.ALCARECOLumiPixels_cff import *


### PR DESCRIPTION
This is needed to make the `HCalCalPedestal` producer run in the AlCaReco matrix for data.

Concerning changes of #10054 : 
- https://github.com/mmusich/cmssw/commit/05d53c5a1e63039906a1a74e22ae22eb6b9b5d46 is already included by #8350 apart from the cleanup of `Configuration/StandardSequences/python/AlCaRecoStream_Specials_cff.py` for multiple inclusions of AlcaReco DQM instances.
- https://github.com/mmusich/cmssw/commit/54cfd3a88aac8be11cacb01b1af77125a6cb5c70 is cherry-picked.

The three commits of the final fix for `HcalCalPedestal` in #10498 (featuring a fix of the module names in the AlCaReco and the selection of the correct output collections, as well as a test cfg) are cherry-picked.
