### PR TITLE
changes for data reco processing with 25ns

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppRun2at50ns_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+
+class ppRun2at50ns(Reco):
+    def __init__(self):
+        self.recoSeq=''
+        self.cbSc='pp'
+    """
+    _ppRun2at50ns_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """
+
+
+    def promptReco(self, globalTag, **args):
+        """
+        _promptReco_
+
+        Proton collision data taking prompt reco
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForPrompt']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2_50ns']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2_50ns')
+
+        process = Reco.promptReco(self,globalTag, **args)
+
+        return process
+
+
+    def expressProcessing(self, globalTag, **args):
+        """
+        _expressProcessing_
+
+        Proton collision data taking express processing
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForExpress']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns')
+
+        process = Reco.expressProcessing(self,globalTag, **args)
+        
+        return process
+
+    def visualizationProcessing(self, globalTag, **args):
+        """
+        _visualizationProcessing_
+
+        Proton collision data taking visualization processing
+
+        """
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns')
+
+        process = Reco.visualizationProcessing(self,globalTag, **args)
+        
+        return process
+
+    def alcaHarvesting(self, globalTag, datasetName, **args):
+        """
+        _alcaHarvesting_
+
+        Proton collisions data taking AlCa Harvesting
+
+        """
+
+
+        if not 'skims' in args and not 'alcapromptdataset' in args:
+            args['skims']=['BeamSpotByRun',
+                           'BeamSpotByLumi',
+                           'SiStripQuality']
+            
+        return Reco.alcaHarvesting(self, globalTag, datasetName, **args)
+

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -41,8 +41,8 @@ def customiseDataRun2Common(process):
     if hasattr(process,'valCsctfTrackDigis'):
         process.valCsctfTrackDigis.gangedME1a = cms.untracked.bool(False)
 
-    from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForStage1
-    process = customiseSimL1EmulatorForStage1(process)
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
+    process=customiseL1RecoForStage1(process)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_Reco,customise_RawToDigi,customise_DQM
     if hasattr(process,'RawToDigi'):

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -65,7 +65,7 @@ def customiseDataRun2Common_25ns(process):
     return process
 
 # common+50ns. Needed only for runs >= 253000
-def customiseDataRun2Common_50ns(process):
+def customiseDataRun2Common_50nsRunsAfter253000(process):
     process = customiseDataRun2Common(process)
 
     if hasattr(process,'particleFlowClusterECAL'):
@@ -113,7 +113,7 @@ def customiseExpressRun2(process):
 
 def customiseExpressRun2_50ns(process):
     process = customiseExpress(process)
-    process = customiseDataRun2Common_50ns(process)
+    process = customiseDataRun2Common_50nsRunsAfter253000(process)
     return process
 
 def customiseExpressRun2B0T(process):
@@ -138,6 +138,11 @@ def customisePrompt(process):
 def customisePromptRun2(process):
     process = customisePrompt(process)
     process = customiseDataRun2Common_25ns(process)
+    return process
+
+def customisePromptRun2_50ns(process):
+    process = customisePrompt(process)
+    process = customiseDataRun2Common_50nsRunsAfter253000(process)
     return process
 
 def customisePromptRun2B0T(process):

--- a/Configuration/DataProcessing/test/ppRun2at50ns_t.py
+++ b/Configuration/DataProcessing/test/ppRun2at50ns_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppRun2at50ns_
+
+Test for Collision Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class ppRun2at50nsScenarioTest(unittest.TestCase):
+    """
+    unittest for ppRun2at50ns collisions scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("ppRun2at50ns")
+        except Exception, ex:
+            msg = "Failed to get ppRun2at50ns scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception, ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for ppRun2at50ns Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception, ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for ppRun2at50ns Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception, ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for ppRun2at50ns Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception, ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for ppRun2at50ns scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "HeavyIons")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "HeavyIons" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,21 +22,21 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "ppRun2B0T")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppRun2" "ppRun2B0T")
+declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -620,6 +620,7 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
  psd.addNode(edm::ParameterDescription<std::vector<int>>("activeBXs", {-5,-4,-3,-2,-1,0,1,2,3,4}, true) and
 	      edm::ParameterDescription<bool>("ampErrorCalculation", true, true) and
 	      edm::ParameterDescription<bool>("useLumiInfoRunHeader", true, true) and
+	      edm::ParameterDescription<int>("bunchSpacing", 0, true) and
 	      edm::ParameterDescription<bool>("doPrefitEB", false, true) and
 	      edm::ParameterDescription<bool>("doPrefitEE", false, true) and
 	      edm::ParameterDescription<double>("prefitMaxChiSqEB", 25., true) and
@@ -655,8 +656,6 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
 	      edm::ParameterDescription<double>("chi2ThreshEB_", 65.0, true) and
 	      edm::ParameterDescription<double>("chi2ThreshEE_", 50.0, true) and
 	      edm::ParameterDescription<edm::ParameterSetDescription>("EcalPulseShapeParameters", psd0, true));
-
- psd.addOptionalNode(edm::ParameterDescription<int>("bunchSpacing", 0, true), true);
 
  return psd;
 }

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -656,6 +656,8 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
 	      edm::ParameterDescription<double>("chi2ThreshEE_", 50.0, true) and
 	      edm::ParameterDescription<edm::ParameterSetDescription>("EcalPulseShapeParameters", psd0, true));
 
+ psd.addOptionalNode(edm::ParameterDescription<int>("bunchSpacing", 0, true), true);
+
  return psd;
 }
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -43,6 +43,9 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   
   if (useLumiInfoRunHeader_) {
     bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+    bunchSpacingManual_ = 0;
+  } else {
+    bunchSpacingManual_ = ps.getParameter<int>("bunchSpacing");
   }
 
   doPrefitEB_ = ps.getParameter<bool>("doPrefitEB");
@@ -127,10 +130,10 @@ void
 EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
 {
 
+  int bunchspacing = 450;
+
   if (useLumiInfoRunHeader_) {
 
-    int bunchspacing = 450;
-    
     if (evt.isRealData()) {
       edm::RunNumber_t run = evt.run();
       if (run == 178003 ||
@@ -143,8 +146,11 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
           run == 209151) {
         bunchspacing = 25;
       }
-      else {
+      else if (run < 253000) {
         bunchspacing = 50;
+      }
+      else {
+	bunchspacing = 25;
       }
     }
     else {
@@ -153,6 +159,12 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
       bunchspacing = *bunchSpacingH;
     }
     
+  }
+  else {
+    bunchspacing = bunchSpacingManual_;
+  }
+
+  if (useLumiInfoRunHeader_ || bunchSpacingManual_ > 0){
     if (bunchspacing == 25) {
       activeBX.resize(10);
       activeBX << -5,-4,-3,-2,-1,0,1,2,3,4;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -82,6 +82,7 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 bool useLumiInfoRunHeader_;
                 EcalUncalibRecHitMultiFitAlgo multiFitMethod_;
                 
+		int bunchSpacingManual_;
                 edm::EDGetTokenT<int> bunchSpacing_; 
 
                 // determine which of the samples must actually be used by ECAL local reco

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -137,8 +137,11 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
           run == 209151) {
         bunchspacing = 25;
       }
-      else {
+      else if (run < 253000) {
         bunchspacing = 50;
+      } 
+      else {
+	bunchspacing = 25;
       }
     }
     else {
@@ -146,6 +149,9 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
       evt.getByToken(bunchSpacing_,bunchSpacingH);
       bunchspacing = *bunchSpacingH;
     }
+  }
+  else {
+    bunchspacing = bunchSpacingManual_;
   }
   
   const std::vector<std::string> condnames_mean = (bunchspacing == 25) ? _condnames_mean_25ns : _condnames_mean_50ns;


### PR DESCRIPTION
- to determine bunch spacing in data in PFClusterEMEnergyCorrector and  EcalUncalibRecHitWorkerMultiFit
  - use run 253000 as a maximum with 50 ns if auto-selection is enabled
  - fixup/add manual bunch spacing setting is the auto-selection is disabled
- in RecoTLR (still using local customs implementation for run2 data processing)
  - remove CCC override-to-OFF in prompt and express customizations
  - add customise_DQM to the common customs (already in 75X/76X)
  - add customiseL1RecoForStage1 for stage1 unpackers and l1extra to use calo stage1 
  - add customiseDataRun2Common_25ns (since I couldn't figure out how to more transparently set a default to 25ns and then be able to customize that to 50ns); 
  - NB: the customiseDataRun2Common can still be used for Run2015B data processing as suggested in a few HN posts
  - add customiseDataRun2Common_50nsRunsAfter253000 function (it's in the name!) to force 50ns settings for runs after 253000, if we need it
  - remove outdated planBTracking
- add ppRun2at50ns scenario in T0 processing setup

tested in CMSSW_7_4_X_2015-08-01-1100
Configs for T0 tested 
- with run_CfgTest.log
- by running ppRun2 and ppRun2at50ns with prompt reco (RunPromptReco.py) on /store/data/Run2015B/DoubleMuon/RAW/v1/000/251/721/00000/44C77595-412A-E511-930E-02163E012A2C.root. 

Changes are as expected, appear only in the run2 T0 workflow:
- there are less tracks with less hits and the cluster charge on track shows a cutoff due to CCC  (many plots downstream change as well consistent with CCC enabling)
  ![251721_tob_ontrack](https://cloud.githubusercontent.com/assets/4676718/9026858/9626312a-3904-11e5-860e-8199d2af0616.png)
  ![all_sign74xfor25ns-test50nsvsorig_doublemuon251721c_recotracks_generaltracks__reco_obj_found](https://cloud.githubusercontent.com/assets/4676718/9026853/62180462-3904-11e5-8507-3cefb15a8114.png)
- L1 plots changed quite a bit
  ![251721_l1cenjet](https://cloud.githubusercontent.com/assets/4676718/9026865/bd1b5d28-3904-11e5-84a9-0458c75c4bfd.png)
  ![251721_l1taujet](https://cloud.githubusercontent.com/assets/4676718/9026867/c0291384-3904-11e5-8956-49c869ae09c4.png)
  probably the only suspicious ones are based on HF: they are empty now
  ![251721_l1hf](https://cloud.githubusercontent.com/assets/4676718/9026870/cfb09bce-3904-11e5-806e-18ca0a41877f.png)
- no change is observed in running ppRun2at50ns and ppRun2 workflows on the run 251721 since the default bunch spacing detection in both cases falls to 50 ns setup.

In addition, tested the machinery with a run after 253000 /store/data/Run2015B/MinimumBias/RAW/v1/000/253/020/00000/BA19E72A-5B37-E511-B00F-02163E0134B5.root (the run is cosmics and has no tracker or muons included)
As expected, 
- ppRun2at50ns and ppRun2 show differences in the ECAL hit energies (previously constrained to 0 values now yield some results, as expected from the change in the multifit configuration)
  ![all_sign74xfor25ns-test50nsvssign74xfor25ns-test25ns_minimumbias253020c_ecalrechitssorted_ecalrechit_ecalrechitseb_reco_obj_obj_energy](https://cloud.githubusercontent.com/assets/4676718/9027144/09765d1c-390f-11e5-932f-c49ac65e62b7.png)
- the baseline and ppRun2at50ns in this case produce identical results in the reco products (there is no tracker in this run).
  - stage1 is not in this run and as a result, all related DQM plots are empty ... I'm assuming we will not be switching stage1 on and off once this all starts working next week @mulhearn @deguio @danduggan 
