### PR TITLE
Add combMVA to bTag DQM

### DIFF
--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -103,7 +103,7 @@ bTagCommonBlock = cms.PSet(
         ),
         cms.PSet(
             bTagGenericAnalysisBlock,
-            label = cms.InputTag("combinedMVABJetTags"),
+            label = cms.InputTag("pfCombinedMVABJetTags"),
             folder = cms.string("combMVA")
         ),
         cms.PSet(

--- a/DQMOffline/RecoB/python/bTagCommon_cff.py
+++ b/DQMOffline/RecoB/python/bTagCommon_cff.py
@@ -102,6 +102,11 @@ bTagCommonBlock = cms.PSet(
             folder = cms.string("CSVv2")
         ),
         cms.PSet(
+            bTagGenericAnalysisBlock,
+            label = cms.InputTag("combinedMVABJetTags"),
+            folder = cms.string("combMVA")
+        ),
+        cms.PSet(
             bTagSoftLeptonAnalysisBlock,
             label = cms.InputTag("softPFMuonBJetTags"),
             folder = cms.string("SMT")


### PR DESCRIPTION
combMVA will be one of the POG supported taggers for Run 2 possible changes
between releases have to be monitored. Because the bTagGenericAnalysisBlock config
is used only a python configuration has to be modified.

I run several tests (FullSim, Data and FastSim) with the runTheMatrix.py script and everything
seem to work as expected.

This changes have to be backported to 75X and 74X as soon as possible. 
