### PR TITLE
fixing memory leak in EgammaHLTNxNClusterProducer :76X

### DIFF
--- a/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
+++ b/RecoEgamma/EgammaHLTProducers/src/EgammaHLTNxNClusterProducer.cc
@@ -22,6 +22,8 @@
 #include "RecoEgamma/EgammaHLTProducers/interface/EgammaHLTNxNClusterProducer.h"
 #include "TVector3.h"
 
+#include <memory>
+
 EgammaHLTNxNClusterProducer::EgammaHLTNxNClusterProducer(const edm::ParameterSet& ps):
   doBarrel_               (ps.getParameter<bool>("doBarrel")),
   doEndcaps_              (ps.getParameter<bool>("doEndcaps")),
@@ -179,13 +181,13 @@ void EgammaHLTNxNClusterProducer::makeNxNClusters(edm::Event &evt, const edm::Ev
   es.get<CaloGeometryRecord>().get(geoHandle);
   
   const CaloSubdetectorGeometry *geometry_p;
-  CaloSubdetectorTopology *topology_p;
+  std::unique_ptr<CaloSubdetectorTopology> topology_p;
   if (detector == reco::CaloID::DET_ECAL_BARREL) {
     geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalBarrel);
-    topology_p = new EcalBarrelTopology(geoHandle);
+    topology_p.reset(new EcalBarrelTopology(geoHandle));
   }else {
     geometry_p = geoHandle->getSubdetectorGeometry(DetId::Ecal, EcalEndcap);
-    topology_p = new EcalEndcapTopology(geoHandle); 
+    topology_p.reset(new EcalEndcapTopology(geoHandle)); 
   }
   
   const CaloSubdetectorGeometry *geometryES_p;


### PR DESCRIPTION
This pull request fixes a memory leak in EgammaHLTNxNClusterProducer and is an absolutely urgent and necessary fix for 25ns data taking. 

As this is so urgent, I'm submitting this before final testing just so Martin is aware of my change and can review it. I'll comment again as soon as I've re-run my validation on it which will take a few hours. The 74X and 75X are ready to go and I'll submit those pull requests as soon as I have validated the changes (and that it completely fixes the memory issue). 
