### PR TITLE
Adjusting trigger paths for B2G DQM

### DIFF
--- a/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
+++ b/HLTriggerOffline/B2G/python/b2gHadronicHLTEventValidation_cfi.py
@@ -11,7 +11,12 @@ b2gSingleJetHLTValidation = cms.EDAnalyzer('B2GHadronicHLTValidation',
         minJets      = cms.untracked.uint32(1),
         # Trigger
         sTrigger     = cms.untracked.string("TriggerResults"),
-        vsPaths      = cms.untracked.vstring(['HLT_AK8PFJet360_TrimMass30']),
+        vsPaths      = cms.untracked.vstring(['HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45',
+                                              'HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45',
+                                              'HLT_AK8PFJet360_TrimMass30',
+                                              'HLT_AK8PFHT700_TrimR0p1PT0p03Mass50',
+                                              'HLT_AK8PFHT650_TrimR0p1PT0p03Mass50',
+                                              'HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45']),
 )
 
 b2gDiJetHLTValidation = cms.EDAnalyzer('B2GHadronicHLTValidation',
@@ -25,5 +30,10 @@ b2gDiJetHLTValidation = cms.EDAnalyzer('B2GHadronicHLTValidation',
         minJets      = cms.untracked.uint32(2),
         # Trigger
         sTrigger     = cms.untracked.string("TriggerResults"),
-        vsPaths      = cms.untracked.vstring(['HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45']),
+        vsPaths      = cms.untracked.vstring(['HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45',
+                                              'HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45',
+                                              'HLT_AK8PFJet360_TrimMass30',
+                                              'HLT_AK8PFHT700_TrimR0p1PT0p03Mass50',
+                                              'HLT_AK8PFHT650_TrimR0p1PT0p03Mass50',
+                                              'HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45']),
 )


### PR DESCRIPTION
Adding trigger paths for B2GDQM. Now the list of monitored paths is

'HLT_AK8DiPFJet280_200_TrimMass30_BTagCSV0p45',
'HLT_AK8DiPFJet250_200_TrimMass30_BTagCSV0p45',
'HLT_AK8PFJet360_TrimMass30',
'HLT_AK8PFHT700_TrimR0p1PT0p03Mass50',
'HLT_AK8PFHT650_TrimR0p1PT0p03Mass50',
'HLT_AK8PFHT600_TrimR0p1PT0p03Mass50_BTagCSV0p45'
