### PR TITLE
GBRForest in TMVAEvaluator + SoftLepton taggers using GBRForest

### DIFF
--- a/CommonTools/Utils/BuildFile.xml
+++ b/CommonTools/Utils/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/MessageLogger"/>
+<use   name="CondFormats/EgammaObjects"/>
 <use   name="boost"/>
 <use   name="roothistmatrix"/>
 <use   name="roottmva"/>

--- a/CommonTools/Utils/BuildFile.xml
+++ b/CommonTools/Utils/BuildFile.xml
@@ -1,5 +1,6 @@
 <use   name="FWCore/Utilities"/>
 <use   name="FWCore/MessageLogger"/>
+<use   name="CondFormats/DataRecord"/>
 <use   name="CondFormats/EgammaObjects"/>
 <use   name="boost"/>
 <use   name="roothistmatrix"/>

--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -18,20 +18,21 @@ class TMVAEvaluator {
     ~TMVAEvaluator();
 
     void initialize(const std::string & options, const std::string & method, const std::string & weightFile,
-                    const std::vector<std::string> & variables, const std::vector<std::string> & spectators, const bool useGBRForest=true);
-    float evaluate(const std::map<std::string,float> & inputs, const bool useSpectators=false);
+                    const std::vector<std::string> & variables, const std::vector<std::string> & spectators, bool useGBRForest=false, bool useAdaBoost=false);
+    float evaluate(const std::map<std::string,float> & inputs, bool useSpectators=false);
 
   private:
     bool mIsInitialized;
     bool mUsingGBRForest;
+    bool mUseAdaBoost;
 
     std::string mMethod;
     std::unique_ptr<TMVA::Reader> mReader;
     std::unique_ptr<TMVA::IMethod> mIMethod;
     std::unique_ptr<const GBRForest> mGBRForest;
 
-    std::map<std::string,float> mVariables;
-    std::map<std::string,float> mSpectators;
+    std::map<std::string,std::pair<size_t,float>> mVariables;
+    std::map<std::string,std::pair<size_t,float>> mSpectators;
 };
 
 #endif // CommonTools_Utils_TMVAEvaluator_h

--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -7,6 +7,8 @@
 #include <map>
 
 #include "TMVA/Reader.h"
+#include "TMVA/IMethod.h"
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
 
 
 class TMVAEvaluator {
@@ -16,14 +18,17 @@ class TMVAEvaluator {
     ~TMVAEvaluator();
 
     void initialize(const std::string & options, const std::string & method, const std::string & weightFile,
-                    const std::vector<std::string> & variables, const std::vector<std::string> & spectators);
+                    const std::vector<std::string> & variables, const std::vector<std::string> & spectators, const bool useGBRForest=true);
     float evaluate(const std::map<std::string,float> & inputs, const bool useSpectators=false);
 
   private:
     bool mIsInitialized;
+    bool mUsingGBRForest;
 
     std::string mMethod;
     std::unique_ptr<TMVA::Reader> mReader;
+    std::unique_ptr<TMVA::IMethod> mIMethod;
+    std::unique_ptr<const GBRForest> mGBRForest;
 
     std::map<std::string,float> mVariables;
     std::map<std::string,float> mSpectators;

--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -9,6 +9,7 @@
 #include "TMVA/Reader.h"
 #include "TMVA/IMethod.h"
 #include "CondFormats/EgammaObjects/interface/GBRForest.h"
+#include "FWCore/Framework/interface/EventSetup.h"
 
 
 class TMVAEvaluator {
@@ -19,12 +20,17 @@ class TMVAEvaluator {
 
     void initialize(const std::string & options, const std::string & method, const std::string & weightFile,
                     const std::vector<std::string> & variables, const std::vector<std::string> & spectators, bool useGBRForest=false, bool useAdaBoost=false);
+    void initializeGBRForest(const GBRForest* gbrForest, const std::vector<std::string> & variables,
+                             const std::vector<std::string> & spectators, bool useAdaBoost=false);
+    void initializeGBRForest(const edm::EventSetup &iSetup, const std::string & label,
+                             const std::vector<std::string> & variables, const std::vector<std::string> & spectators, bool useAdaBoost=false);
     float evaluate(const std::map<std::string,float> & inputs, bool useSpectators=false);
 
   private:
     bool mIsInitialized;
     bool mUsingGBRForest;
     bool mUseAdaBoost;
+    bool mReleaseAtEnd;
 
     std::string mMethod;
     std::unique_ptr<TMVA::Reader> mReader;

--- a/CommonTools/Utils/interface/TMVAEvaluator.h
+++ b/CommonTools/Utils/interface/TMVAEvaluator.h
@@ -25,6 +25,8 @@ class TMVAEvaluator {
                              const std::vector<std::string> & spectators, bool useAdaBoost=false);
     void initializeGBRForest(const edm::EventSetup &iSetup, const std::string & label,
                              const std::vector<std::string> & variables, const std::vector<std::string> & spectators, bool useAdaBoost=false);
+    float evaluateTMVA(const std::map<std::string,float> & inputs, bool useSpectators) const;
+    float evaluateGBRForest(const std::map<std::string,float> & inputs) const;
     float evaluate(const std::map<std::string,float> & inputs, bool useSpectators=false) const;
 
   private:

--- a/CommonTools/Utils/interface/TMVAZipReader.h
+++ b/CommonTools/Utils/interface/TMVAZipReader.h
@@ -24,6 +24,7 @@
 #define TMVAZIPREADER_7RXIGO70
 
 #include "TMVA/Reader.h"
+#include "TMVA/IMethod.h"
 #include <string>
 
 namespace reco {
@@ -32,7 +33,7 @@ namespace reco {
     bool hasEnding(std::string const &fullString, std::string const &ending);
     char* readGzipFile(const std::string& weightFile);
 
-    void loadTMVAWeights(TMVA::Reader* reader, const std::string& method,
+    TMVA::IMethod* loadTMVAWeights(TMVA::Reader* reader, const std::string& method,
       const std::string& weightFile, bool verbose=false);
 
 

--- a/CommonTools/Utils/src/TMVAEvaluator.cc
+++ b/CommonTools/Utils/src/TMVAEvaluator.cc
@@ -2,17 +2,21 @@
 
 #include "CommonTools/Utils/interface/TMVAZipReader.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
+#include "FWCore/Framework/interface/ESHandle.h"
 #include "TMVA/MethodBDT.h"
 
 
 TMVAEvaluator::TMVAEvaluator() :
-  mIsInitialized(false), mUsingGBRForest(false), mUseAdaBoost(false)
+  mIsInitialized(false), mUsingGBRForest(false), mUseAdaBoost(false), mReleaseAtEnd(false)
 {
 }
 
 
 TMVAEvaluator::~TMVAEvaluator()
 {
+  if (mReleaseAtEnd)
+    mGBRForest.release();
 }
 
 
@@ -54,6 +58,37 @@ void TMVAEvaluator::initialize(const std::string & options, const std::string & 
   }
 
   mIsInitialized = true;
+}
+
+
+void TMVAEvaluator::initializeGBRForest(const GBRForest* gbrForest, const std::vector<std::string> & variables,
+                                        const std::vector<std::string> & spectators, bool useAdaBoost)
+{
+  // add input variables
+  for(std::vector<std::string>::const_iterator it = variables.begin(); it!=variables.end(); ++it)
+    mVariables.insert( std::make_pair( *it, std::make_pair( it - variables.begin(), 0. ) ) );
+
+  // add spectator variables
+  for(std::vector<std::string>::const_iterator it = spectators.begin(); it!=spectators.end(); ++it)
+    mSpectators.insert( std::make_pair( *it, std::make_pair( it - spectators.begin(), 0. ) ) );
+
+  mGBRForest.reset( gbrForest );
+
+  mIsInitialized = true;
+  mUsingGBRForest = true;
+  mUseAdaBoost = useAdaBoost;
+  mReleaseAtEnd = true; // need to release ownership at the end if getting GBRForest from an external source
+}
+
+
+void TMVAEvaluator::initializeGBRForest(const edm::EventSetup &iSetup, const std::string & label,
+                                        const std::vector<std::string> & variables, const std::vector<std::string> & spectators, bool useAdaBoost)
+{
+  edm::ESHandle<GBRForest> gbrForestHandle;
+
+  iSetup.get<GBRWrapperRcd>().get(label.c_str(), gbrForestHandle);
+
+  initializeGBRForest(gbrForestHandle.product(), variables, spectators, useAdaBoost);
 }
 
 

--- a/CommonTools/Utils/src/TMVAEvaluator.cc
+++ b/CommonTools/Utils/src/TMVAEvaluator.cc
@@ -92,7 +92,7 @@ void TMVAEvaluator::initializeGBRForest(const edm::EventSetup &iSetup, const std
 }
 
 
-float TMVAEvaluator::evaluate(const std::map<std::string,float> & inputs, bool useSpectators)
+float TMVAEvaluator::evaluate(const std::map<std::string,float> & inputs, bool useSpectators) const
 {
   // default value
   float value = -99.;
@@ -102,6 +102,10 @@ float TMVAEvaluator::evaluate(const std::map<std::string,float> & inputs, bool u
     edm::LogError("InitializationError") << "TMVAEvaluator not properly initialized.";
     return value;
   }
+
+  // TMVA::Reader is not thread safe
+  if (!mUsingGBRForest)
+    std::lock_guard<std::mutex> lock(m_mutex);
 
   if( useSpectators && inputs.size() < ( mVariables.size() + mSpectators.size() ) )
   {

--- a/CommonTools/Utils/src/TMVAEvaluator.cc
+++ b/CommonTools/Utils/src/TMVAEvaluator.cc
@@ -134,7 +134,7 @@ float TMVAEvaluator::evaluateGBRForest(const std::map<std::string,float> & input
   // default value
   float value = -99.;
 
-  float * vars = new float[mVariables.size()]; // allocate n floats
+  std::unique_ptr<float[]> vars(new float[mVariables.size()]); // allocate n floats
 
   // set the input variable values
   for(auto it = mVariables.begin(); it!=mVariables.end(); ++it)
@@ -147,11 +147,9 @@ float TMVAEvaluator::evaluateGBRForest(const std::map<std::string,float> & input
 
   // evaluate the MVA
   if (mUseAdaBoost)
-    value = mGBRForest->GetAdaBoostClassifier(vars);
+    value = mGBRForest->GetAdaBoostClassifier(vars.get());
   else
-    value = mGBRForest->GetGradBoostClassifier(vars);
-
-  delete [] vars;  // when done, free memory pointed to by vars
+    value = mGBRForest->GetGradBoostClassifier(vars.get());
 
   return value;
 }

--- a/CommonTools/Utils/src/TMVAZipReader.cc
+++ b/CommonTools/Utils/src/TMVAZipReader.cc
@@ -54,8 +54,11 @@ char* reco::details::readGzipFile(const std::string& weightFile)
   return buffer;
 }
 
-void reco::details::loadTMVAWeights(TMVA::Reader* reader, const std::string& method,
+TMVA::IMethod* reco::details::loadTMVAWeights(TMVA::Reader* reader, const std::string& method,
     const std::string& weightFile, bool verbose) {
+
+  TMVA::IMethod* ptr = nullptr;
+
   verbose = false;
   if (verbose)
     std::cout << "Booking TMVA Reader with " << method << " and weight file: " << weightFile
@@ -65,7 +68,7 @@ void reco::details::loadTMVAWeights(TMVA::Reader* reader, const std::string& met
     if (verbose)
       std::cout << "Weight file is pure xml." << std::endl;
     // Let TMVA read the file
-    reader->BookMVA(method, weightFile);
+    ptr = reader->BookMVA(method, weightFile);
   } else if (reco::details::hasEnding(weightFile, ".gz") || reco::details::hasEnding(weightFile, ".gzip")) {
     if (verbose)
       std::cout << "Unzipping file." << std::endl;
@@ -86,7 +89,7 @@ void reco::details::loadTMVAWeights(TMVA::Reader* reader, const std::string& met
     close(fdToUselessFile);
     if (verbose)
       std::cout << "Booking MvA" << std::endl;
-    reader->BookMVA(method, weight_file_name);
+    ptr = reader->BookMVA(method, weight_file_name);
     if (verbose)
       std::cout << "Cleaning up" << std::endl;
     remove(weight_file_name.c_str());
@@ -103,4 +106,6 @@ void reco::details::loadTMVAWeights(TMVA::Reader* reader, const std::string& met
       << "I don't understand the extension on the filename: "
       << weightFile << ", it should be .xml, .gz, or .gzip" << std::endl;
   }
+
+  return ptr;
 }

--- a/RecoBTag/SoftLepton/interface/ElectronTagger.h
+++ b/RecoBTag/SoftLepton/interface/ElectronTagger.h
@@ -18,11 +18,17 @@ class ElectronTagger : public JetTagComputer {
 public:
 
   /// explicit ctor 
- ElectronTagger(const edm::ParameterSet & );
+  ElectronTagger(const edm::ParameterSet & );
+  void initialize(const JetTagComputerRecord &) override;
   virtual float discriminator(const TagInfoHelper & tagInfo) const override;
 
 private:
-  btag::LeptonSelector m_selector;
+  const btag::LeptonSelector m_selector;
+  const std::string m_gbrForestLabel;
+  const edm::FileInPath m_weightFile;
+  const bool m_useGBRForest;
+  const bool m_useAdaBoost;
+
   mutable std::mutex m_mutex;
   [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVAEvaluator> mvaID;
 };

--- a/RecoBTag/SoftLepton/interface/ElectronTagger.h
+++ b/RecoBTag/SoftLepton/interface/ElectronTagger.h
@@ -5,7 +5,6 @@
 #include "CommonTools/Utils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
-#include <mutex>
 
 /** \class ElectronTagger
  *
@@ -29,8 +28,7 @@ private:
   const bool m_useGBRForest;
   const bool m_useAdaBoost;
 
-  mutable std::mutex m_mutex;
-  [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVAEvaluator> mvaID;
+  std::unique_ptr<TMVAEvaluator> mvaID;
 };
 
 #endif

--- a/RecoBTag/SoftLepton/interface/ElectronTagger.h
+++ b/RecoBTag/SoftLepton/interface/ElectronTagger.h
@@ -23,6 +23,7 @@ public:
 
 private:
   const btag::LeptonSelector m_selector;
+  const bool m_useCondDB;
   const std::string m_gbrForestLabel;
   const edm::FileInPath m_weightFile;
   const bool m_useGBRForest;

--- a/RecoBTag/SoftLepton/interface/MuonTagger.h
+++ b/RecoBTag/SoftLepton/interface/MuonTagger.h
@@ -17,12 +17,16 @@ class MuonTagger : public JetTagComputer {
   public:
   
     MuonTagger(const edm::ParameterSet&);
-    
+    void initialize(const JetTagComputerRecord &) override;
     virtual float discriminator(const TagInfoHelper& tagInfo) const override;
     
   private:
-    
     btag::LeptonSelector m_selector;
+    const std::string m_gbrForestLabel;
+    const edm::FileInPath m_weightFile;
+    const bool m_useGBRForest;
+    const bool m_useAdaBoost;
+
     mutable std::mutex m_mutex;
     [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVAEvaluator> mvaID;
 };

--- a/RecoBTag/SoftLepton/interface/MuonTagger.h
+++ b/RecoBTag/SoftLepton/interface/MuonTagger.h
@@ -21,6 +21,7 @@ class MuonTagger : public JetTagComputer {
     
   private:
     btag::LeptonSelector m_selector;
+    const bool m_useCondDB;
     const std::string m_gbrForestLabel;
     const edm::FileInPath m_weightFile;
     const bool m_useGBRForest;

--- a/RecoBTag/SoftLepton/interface/MuonTagger.h
+++ b/RecoBTag/SoftLepton/interface/MuonTagger.h
@@ -9,7 +9,6 @@
 #include "CommonTools/Utils/interface/TMVAEvaluator.h"
 #include "RecoBTau/JetTagComputer/interface/JetTagComputer.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
-#include <mutex>
 #include <memory>
 
 class MuonTagger : public JetTagComputer {
@@ -27,8 +26,7 @@ class MuonTagger : public JetTagComputer {
     const bool m_useGBRForest;
     const bool m_useAdaBoost;
 
-    mutable std::mutex m_mutex;
-    [[cms::thread_guard("m_mutex")]] std::unique_ptr<TMVAEvaluator> mvaID;
+    std::unique_ptr<TMVAEvaluator> mvaID;
 };
 
 #endif

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
@@ -1,14 +1,16 @@
 import FWCore.ParameterSet.Config as cms
 
 softPFElectronCommon = cms.PSet(
-    #gbrForestLabel = cms.string("btag_SoftPFElectron_TMVA420_BDT_74X_v1"),
+    useCondDB = cms.bool(False),
+    gbrForestLabel = cms.string("btag_SoftPFElectron_TMVA420_BDT_74X_v1"),
     weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(False)
 )
 
 softPFMuonCommon = cms.PSet(
-    #gbrForestLabel = cms.string("btag_SoftPFMuon_TMVA420_BDT_74X_v1"),
+    useCondDB = cms.bool(False),
+    gbrForestLabel = cms.string("btag_SoftPFMuon_TMVA420_BDT_74X_v1"),
     weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz'),
     useGBRForest = cms.bool(True),
     useAdaBoost = cms.bool(True)

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
@@ -1,28 +1,35 @@
 import FWCore.ParameterSet.Config as cms
 
+softPFElectronCommon = cms.PSet(
+    #gbrForestLabel = cms.string("btag_SoftPFElectron_TMVA420_BDT_74X_v1"),
+    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz'),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(False)
+)
+
 softPFElectronBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFElectronComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
 softPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
+    softPFElectronCommon,
     ipSign = cms.string("any"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz')
 )
 negativeSoftPFElectronBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFElectronComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
 negativeSoftPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
-    ipSign = cms.string("negative"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz')
+    softPFElectronCommon,
+    ipSign = cms.string("negative")
 )
 positiveSoftPFElectronBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFElectronComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
 )
 positiveSoftPFElectronComputer = cms.ESProducer("ElectronTaggerESProducer",
-    ipSign = cms.string("positive"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFElectron_BDT.weights.xml.gz')
+    softPFElectronCommon,
+    ipSign = cms.string("positive")
 )
 softPFMuonBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFMuonComputer'),

--- a/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
+++ b/RecoBTag/SoftLepton/python/SoftLeptonByMVA_cff.py
@@ -7,6 +7,13 @@ softPFElectronCommon = cms.PSet(
     useAdaBoost = cms.bool(False)
 )
 
+softPFMuonCommon = cms.PSet(
+    #gbrForestLabel = cms.string("btag_SoftPFMuon_TMVA420_BDT_74X_v1"),
+    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz'),
+    useGBRForest = cms.bool(True),
+    useAdaBoost = cms.bool(True)
+)
+
 softPFElectronBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('softPFElectronComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFElectronsTagInfos"))
@@ -36,22 +43,22 @@ softPFMuonBJetTags = cms.EDProducer("JetTagProducer",
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
 softPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
-    ipSign = cms.string("any"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz')
+    softPFMuonCommon,
+    ipSign = cms.string("any")
 )
 negativeSoftPFMuonBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('negativeSoftPFMuonComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
 negativeSoftPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
-    ipSign = cms.string("negative"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz')
+    softPFMuonCommon,
+    ipSign = cms.string("negative")
 )
 positiveSoftPFMuonBJetTags = cms.EDProducer("JetTagProducer",
     jetTagComputer = cms.string('positiveSoftPFMuonComputer'),
     tagInfos = cms.VInputTag(cms.InputTag("softPFMuonsTagInfos"))
 )
 positiveSoftPFMuonComputer = cms.ESProducer("MuonTaggerESProducer",
-    ipSign = cms.string("positive"),
-    weightFile = cms.FileInPath('RecoBTag/SoftLepton/data/SoftPFMuon_BDT.weights.xml.gz')
+    softPFMuonCommon,
+    ipSign = cms.string("positive")
 )

--- a/RecoBTag/SoftLepton/src/ElectronTagger.cc
+++ b/RecoBTag/SoftLepton/src/ElectronTagger.cc
@@ -13,6 +13,7 @@
 
 ElectronTagger::ElectronTagger(const edm::ParameterSet & cfg):
     m_selector(cfg),
+    m_useCondDB(cfg.getParameter<bool>("useCondDB")),
     m_gbrForestLabel(cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""),
     m_weightFile(cfg.existsAs<edm::FileInPath>("weightFile") ? cfg.getParameter<edm::FileInPath>("weightFile") : edm::FileInPath()),
     m_useGBRForest(cfg.existsAs<bool>("useGBRForest") ? cfg.getParameter<bool>("useGBRForest") : false),
@@ -28,12 +29,11 @@ void ElectronTagger::initialize(const JetTagComputerRecord & record)
 	std::vector<std::string> variables({"sip3d", "sip2d", "ptRel", "deltaR", "ratio", "mva_e_pi"});
 	std::vector<std::string> spectators;
 	
-	if (m_gbrForestLabel!="")
+	if (m_useCondDB)
 	{
 		const GBRWrapperRcd & gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
 		
 		edm::ESHandle<GBRForest> gbrForestHandle;
-
 		gbrWrapperRecord.get(m_gbrForestLabel.c_str(), gbrForestHandle);
 
 		mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, m_useAdaBoost);

--- a/RecoBTag/SoftLepton/src/ElectronTagger.cc
+++ b/RecoBTag/SoftLepton/src/ElectronTagger.cc
@@ -51,8 +51,6 @@ float ElectronTagger::discriminator(const TagInfoHelper & tagInfo) const {
   std::mt19937_64 random;
   std::uniform_real_distribution<float> dist(0.f,1.f);
 
-  // TMVAEvaluator is not thread safe
-  std::lock_guard<std::mutex> lock(m_mutex);
   // if there are multiple leptons, look for the highest tag result
   for (unsigned int i = 0; i < info.leptons(); i++) {
     const reco::SoftLeptonProperties & properties = info.properties(i);

--- a/RecoBTag/SoftLepton/src/ElectronTagger.cc
+++ b/RecoBTag/SoftLepton/src/ElectronTagger.cc
@@ -1,25 +1,46 @@
 #include <limits>
 #include <random>
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
+#include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 #include "DataFormats/BTauReco/interface/SoftLeptonTagInfo.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
 #include "RecoBTag/SoftLepton/interface/ElectronTagger.h"
 #include "DataFormats/BTauReco/interface/CandSoftLeptonTagInfo.h"
 #include <iostream>
 
-ElectronTagger::ElectronTagger(const edm::ParameterSet & configuration):
-    m_selector(configuration)
+ElectronTagger::ElectronTagger(const edm::ParameterSet & cfg):
+    m_selector(cfg),
+    m_gbrForestLabel(cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""),
+    m_weightFile(cfg.existsAs<edm::FileInPath>("weightFile") ? cfg.getParameter<edm::FileInPath>("weightFile") : edm::FileInPath()),
+    m_useGBRForest(cfg.existsAs<bool>("useGBRForest") ? cfg.getParameter<bool>("useGBRForest") : false),
+    m_useAdaBoost(cfg.existsAs<bool>("useAdaBoost") ? cfg.getParameter<bool>("useAdaBoost") : false)
   {
 	uses("seTagInfos");
-	edm::FileInPath WeightFile=configuration.getParameter<edm::FileInPath>("weightFile");
 	mvaID.reset(new TMVAEvaluator());
-	
-	// variable order needs to be the same as in the training
+  }
+
+void ElectronTagger::initialize(const JetTagComputerRecord & record)
+{
+	// variable names and order need to be the same as in the training
 	std::vector<std::string> variables({"sip3d", "sip2d", "ptRel", "deltaR", "ratio", "mva_e_pi"});
 	std::vector<std::string> spectators;
 	
-	mvaID->initialize("Color:Silent:Error", "BDT", WeightFile.fullPath(), variables, spectators);
-  }
+	if (m_gbrForestLabel!="")
+	{
+		const GBRWrapperRcd & gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
+		
+		edm::ESHandle<GBRForest> gbrForestHandle;
+
+		gbrWrapperRecord.get(m_gbrForestLabel.c_str(), gbrForestHandle);
+
+		mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, m_useAdaBoost);
+	}
+	else
+		mvaID->initialize("Color:Silent:Error", "BDT", m_weightFile.fullPath(), variables, spectators, m_useGBRForest, m_useAdaBoost);
+}
 
 /// b-tag a jet based on track-to-jet parameters in the extened info collection
 float ElectronTagger::discriminator(const TagInfoHelper & tagInfo) const {

--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -17,6 +17,7 @@
 
 MuonTagger::MuonTagger(const edm::ParameterSet& cfg):
   m_selector(cfg),
+  m_useCondDB(cfg.getParameter<bool>("useCondDB")),
   m_gbrForestLabel(cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""),
   m_weightFile(cfg.existsAs<edm::FileInPath>("weightFile") ? cfg.getParameter<edm::FileInPath>("weightFile") : edm::FileInPath()),
   m_useGBRForest(cfg.existsAs<bool>("useGBRForest") ? cfg.getParameter<bool>("useGBRForest") : false),
@@ -32,12 +33,11 @@ void MuonTagger::initialize(const JetTagComputerRecord & record)
   std::vector<std::string> variables({"TagInfo1.sip3d", "TagInfo1.sip2d", "TagInfo1.ptRel", "TagInfo1.deltaR", "TagInfo1.ratio"});
   std::vector<std::string> spectators;
 
-  if (m_gbrForestLabel!="")
+  if (m_useCondDB)
   {
      const GBRWrapperRcd & gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
 
      edm::ESHandle<GBRForest> gbrForestHandle;
-
      gbrWrapperRecord.get(m_gbrForestLabel.c_str(), gbrForestHandle);
 
      mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, m_useAdaBoost);

--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -5,24 +5,46 @@
 #include <limits>
 #include <random>
 
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "CondFormats/DataRecord/interface/BTauGenericMVAJetTagComputerRcd.h"
+#include "CondFormats/DataRecord/interface/GBRWrapperRcd.h"
+#include "RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h"
 #include "DataFormats/BTauReco/interface/SoftLeptonTagInfo.h"
 #include "DataFormats/BTauReco/interface/CandSoftLeptonTagInfo.h"
 #include "RecoBTag/SoftLepton/interface/LeptonSelector.h"
 #include "RecoBTag/SoftLepton/interface/MuonTagger.h"
 
 
-MuonTagger::MuonTagger(const edm::ParameterSet& conf): m_selector(conf) {
+MuonTagger::MuonTagger(const edm::ParameterSet& cfg):
+  m_selector(cfg),
+  m_gbrForestLabel(cfg.existsAs<std::string>("gbrForestLabel") ? cfg.getParameter<std::string>("gbrForestLabel") : ""),
+  m_weightFile(cfg.existsAs<edm::FileInPath>("weightFile") ? cfg.getParameter<edm::FileInPath>("weightFile") : edm::FileInPath()),
+  m_useGBRForest(cfg.existsAs<bool>("useGBRForest") ? cfg.getParameter<bool>("useGBRForest") : false),
+  m_useAdaBoost(cfg.existsAs<bool>("useAdaBoost") ? cfg.getParameter<bool>("useAdaBoost") : false)
+{
   uses("smTagInfos");
-  edm::FileInPath WeightFile=conf.getParameter<edm::FileInPath>("weightFile");
   mvaID.reset(new TMVAEvaluator());
+}
 
-  // variable order needs to be the same as in the training
+void MuonTagger::initialize(const JetTagComputerRecord & record)
+{
+  // variable names and order need to be the same as in the training
   std::vector<std::string> variables({"TagInfo1.sip3d", "TagInfo1.sip2d", "TagInfo1.ptRel", "TagInfo1.deltaR", "TagInfo1.ratio"});
   std::vector<std::string> spectators;
 
-  mvaID->initialize("Color:Silent:Error", "BDT", WeightFile.fullPath(), variables, spectators);
-}
+  if (m_gbrForestLabel!="")
+  {
+     const GBRWrapperRcd & gbrWrapperRecord = record.getRecord<GBRWrapperRcd>();
 
+     edm::ESHandle<GBRForest> gbrForestHandle;
+
+     gbrWrapperRecord.get(m_gbrForestLabel.c_str(), gbrForestHandle);
+
+     mvaID->initializeGBRForest(gbrForestHandle.product(), variables, spectators, m_useAdaBoost);
+  }
+  else
+    mvaID->initialize("Color:Silent:Error", "BDT", m_weightFile.fullPath(), variables, spectators, m_useGBRForest, m_useAdaBoost);
+}
 
 // b-tag a jet based on track-to-jet parameters in the extened info collection
 float MuonTagger::discriminator(const TagInfoHelper& tagInfo) const {

--- a/RecoBTag/SoftLepton/src/MuonTagger.cc
+++ b/RecoBTag/SoftLepton/src/MuonTagger.cc
@@ -55,9 +55,6 @@ float MuonTagger::discriminator(const TagInfoHelper& tagInfo) const {
   std::mt19937_64 random;
   std::uniform_real_distribution<float> dist(0.f,1.f);
 
-  // TMVAEvaluator is not thread safe
-  std::lock_guard<std::mutex> lock(m_mutex);
-  
   // If there are multiple leptons, look for the highest tag result
   for (unsigned int i=0; i<info.leptons(); i++) {
     const reco::SoftLeptonProperties& properties = info.properties(i);

--- a/RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h
+++ b/RecoBTau/JetTagComputer/interface/JetTagComputerRecord.h
@@ -5,10 +5,11 @@
 #include <boost/mpl/vector.hpp>
 
 class BTauGenericMVAJetTagComputerRcd;
+class GBRWrapperRcd;
 
 class JetTagComputerRecord :
   public edm::eventsetup::DependentRecordImplementation<
     JetTagComputerRecord,
-    boost::mpl::vector<BTauGenericMVAJetTagComputerRcd> > {};
+    boost::mpl::vector<BTauGenericMVAJetTagComputerRcd, GBRWrapperRcd> > {};
 
 #endif


### PR DESCRIPTION
This PR add GBRForest forest use in the TMVAEvaluator and switches SoftLepton taggers to using the GBRForest.

This is only the first step in switching the SoftLepton taggers to GBRForest. Next, we need to figure out how to add the GBRForest payloads to the CondDB and then we can complete the switch.
