### PR TITLE
kCanRebin is not supported in ROOT6

### DIFF
--- a/DQMServices/Components/plugins/EDMtoMEConverter.cc
+++ b/DQMServices/Components/plugins/EDMtoMEConverter.cc
@@ -123,7 +123,7 @@ namespace {
       MonitorElement *me = dbe->get(dir+"/"+metoedmobject->GetName());
       if(me) {
         auto histo = HistoTraits<T>::get(me);
-        if(histo && me->getTH1F()->TestBit(TH1::kCanRebin) == true) {
+        if(histo && me->getTH1F()->CanExtendAllAxes()) {
           TList list;
           list.Add(metoedmobject);
           if (histo->Merge(&list) == -1)


### PR DESCRIPTION
For ROOT histograms, kCanRebin is not supported in ROOT6. This PR
replaces all remaining uses of kCanRebin with the ROOT6 equivalents.

See PR #10200

I noticed this one after updated ROOT 6.04 in DEVEL IBs. Changed based on #10200 and compile tested on CMSSW_7_6_DEVEL_X_2015-08-03-2300.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
