### PR TITLE
Migrate VID BDTs to GlobalCache + GBRForest

### DIFF
--- a/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h
+++ b/RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h
@@ -13,27 +13,33 @@ class AnyMVAEstimatorRun2Base {
 
  public:
   // Constructor, destructor
- AnyMVAEstimatorRun2Base(const edm::ParameterSet& conf) : _conf(conf){};
+ AnyMVAEstimatorRun2Base(const edm::ParameterSet& conf) : _conf(conf) {}
   virtual ~AnyMVAEstimatorRun2Base(){};
-
+  
   // Functions that must be provided in derived classes
   // These function should work on electrons or photons
   // of the reco or pat type
 
-  virtual float mvaValue( const edm::Ptr<reco::Candidate>& particle) = 0;
+  virtual float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const = 0;
  
   // A specific implementation of MVA is expected to have data members
   // that will contain particle's quantities on which the MVA operates.
   // This function fill their value for a given particle.
-  virtual void fillMVAVariables(const edm::Ptr<reco::Candidate>& particle) = 0;
+  virtual std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const = 0;
   // A specific implementation of MVA is expected to have one or more categories
   // defined with respect to eta, pt, etc.
   // This function determines the category for a given particle.
-  virtual int findCategory( const edm::Ptr<reco::Candidate>& particle) = 0;
-  virtual int getNCategories() = 0;
+  virtual int findCategory( const edm::Ptr<reco::Candidate>& particle) const = 0;
+  virtual int getNCategories() const = 0;
   // The name is a unique name associated with a particular MVA implementation,
   // it is found as a const data member in a derived class.
-  virtual const std::string getName() = 0;
+  virtual const std::string& getName() const = 0;
+
+  // fills a vector of floats in the order that arguments are provided
+  template<typename... Args>
+  std::vector<float> packMVAVariables(const Args... args) const {
+    return std::vector<float>({ args... });
+  }
 
   //
   // Extra event content - if needed.
@@ -41,10 +47,12 @@ class AnyMVAEstimatorRun2Base {
   // Some MVA implementation may require direct access to event content.
   // Implement these methods only if needed in the derived classes (use "override"
   // for certainty).
+
+  // DEPRECATED
   // This method needs to be used only once after this MVA estimator is constructed
-  virtual void setConsumes(edm::ConsumesCollector &&cc){};
+  virtual void setConsumes(edm::ConsumesCollector &&cc) const {};
   // This method needs to be called for each event
-  virtual void getEventContent(const edm::Event& iEvent){};
+  virtual void getEventContent(const edm::Event& iEvent) const final {};
 
   //
   // Data members

--- a/RecoEgamma/EgammaTools/interface/MVAObjectCache.h
+++ b/RecoEgamma/EgammaTools/interface/MVAObjectCache.h
@@ -1,0 +1,30 @@
+#ifndef __RecoEgamma_EgammaTools_MVAObjectCache_H__
+#define __RecoEgamma_EgammaTools_MVAObjectCache_H__
+
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h"
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+namespace egamma {
+
+  class MVAObjectCache {    
+  public:
+    typedef std::unique_ptr<const AnyMVAEstimatorRun2Base> MVAPtr;
+    
+    MVAObjectCache(const edm::ParameterSet& conf);
+
+    const MVAPtr& getMVA(const std::string& mva) const;
+
+    const std::unordered_map<std::string,MVAPtr>& allMVAs() const {
+      return mvas_;
+    }
+  private:
+    std::unordered_map<std::string,MVAPtr> mvas_;   
+  };
+
+}
+#endif

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -1,3 +1,6 @@
+#ifndef __RecoEgamma_EgammaTools_MVAValueMapProducer_H__
+#define __RecoEgamma_EgammaTools_MVAValueMapProducer_H__
+
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/stream/EDProducer.h"
 
@@ -10,18 +13,27 @@
 #include "DataFormats/Common/interface/View.h"
 
 #include "RecoEgamma/EgammaTools/interface/AnyMVAEstimatorRun2Base.h"
+#include "RecoEgamma/EgammaTools/interface/MVAObjectCache.h"
 
 #include <memory>
 #include <vector>
 
 template <class ParticleType> 
-class MVAValueMapProducer : public edm::stream::EDProducer<> {
+class MVAValueMapProducer : public edm::stream::EDProducer< edm::GlobalCache<egamma::MVAObjectCache> > {
 
   public:
   
-  explicit MVAValueMapProducer(const edm::ParameterSet&);
+  MVAValueMapProducer(const edm::ParameterSet&, const egamma::MVAObjectCache*);
   ~MVAValueMapProducer();
   
+  static std::unique_ptr<egamma::MVAObjectCache>
+  initializeGlobalCache(const edm::ParameterSet& conf) {
+    return std::unique_ptr<egamma::MVAObjectCache>(new egamma::MVAObjectCache(conf));
+   }
+
+  static void globalEndJob(const egamma::MVAObjectCache * ) {
+  }
+
   static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
   
   private:
@@ -50,7 +62,8 @@ class MVAValueMapProducer : public edm::stream::EDProducer<> {
 };
 
 template <class ParticleType>
-MVAValueMapProducer<ParticleType>::MVAValueMapProducer(const edm::ParameterSet& iConfig) 
+MVAValueMapProducer<ParticleType>::MVAValueMapProducer(const edm::ParameterSet& iConfig,
+                                                       const egamma::MVAObjectCache* mva_cache) 
 {
 
   //
@@ -60,54 +73,30 @@ MVAValueMapProducer<ParticleType>::MVAValueMapProducer(const edm::ParameterSet& 
   srcMiniAOD_ = mayConsume<edm::View<ParticleType> >(iConfig.getParameter<edm::InputTag>("srcMiniAOD"));
 
   // Loop over the list of MVA configurations passed here from python and
-  // construct all requested MVA esimtators.
-  const std::vector<edm::ParameterSet>& mvaEstimatorConfigs
-    = iConfig.getParameterSetVector("mvaConfigurations");
-  for( auto &imva : mvaEstimatorConfigs ){
-
-    std::unique_ptr<AnyMVAEstimatorRun2Base> thisEstimator;
-    thisEstimator.reset(NULL);
-    if( !imva.empty() ) {
-      const std::string& pName = imva.getParameter<std::string>("mvaName");
-      // The factory below constructs the MVA of the appropriate type based
-      // on the "mvaName" which is the name of the derived MVA class (plugin)
-      AnyMVAEstimatorRun2Base *estimator = AnyMVAEstimatorRun2Factory::get()->create(pName, imva);
-      // Declare all event content, such as ValueMaps produced upstream or other,
-      // original event data pieces, that is needed (if any is implemented in the specific
-      // MVA classes)
-      //edm::ConsumesCollector &cc = consumesCollector();
-      estimator->setConsumes( consumesCollector() );
-
-      thisEstimator.reset(estimator);
-      
-    } else 
-      throw cms::Exception(" MVA configuration not found: ")
-	<< " failed to find proper configuration for one of the MVAs in the main python script " << std::endl;
-
-    // The unique pointer control is passed to the vector in the line below.
-    // Don't use thisEstimator pointer beyond the next line.
-    mvaEstimators_.emplace_back( thisEstimator.release() );
-
+  // construct all requested MVA esimtators.  
+  const auto& all_mvas = mva_cache->allMVAs();
+  for( auto mvaItr = all_mvas.begin(); mvaItr != all_mvas.end(); ++mvaItr ) {
+    // set the consumes
+    mvaItr->second->setConsumes(consumesCollector());
     //
     // Compose and save the names of the value maps to be produced
     //
-    const auto& currentEstimator = mvaEstimators_.back();
-    std::string thisValueMapName = currentEstimator->getName() + "Values";
-    std::string thisCategoriesMapName = currentEstimator->getName() + "Categories";
+    const auto& currentEstimator = mvaItr->second;
+    const std::string thisValueMapName = mvaItr->first + "Values";
+    const std::string thisCategoriesMapName = mvaItr->first + "Categories";
     mvaValueMapNames_.push_back( thisValueMapName );
     mvaCategoriesMapNames_.push_back( thisCategoriesMapName );
 
     // Declare the maps to the framework
     produces<edm::ValueMap<float> >(thisValueMapName);  
-    produces<edm::ValueMap<int> >(thisCategoriesMapName);  
-
+    produces<edm::ValueMap<int> >(thisCategoriesMapName);
   }
 
 
 }
 
 template <class ParticleType>
-  MVAValueMapProducer<ParticleType>::~MVAValueMapProducer() {
+MVAValueMapProducer<ParticleType>::~MVAValueMapProducer() {
 }
 
 template <class ParticleType>
@@ -130,27 +119,27 @@ void MVAValueMapProducer<ParticleType>::produce(edm::Event& iEvent, const edm::E
 
  
   // Loop over MVA estimators
-  for( unsigned iEstimator = 0; iEstimator < mvaEstimators_.size(); iEstimator++ ){
-    
+  const auto& all_mvas = globalCache()->allMVAs();
+  for( auto mva_itr = all_mvas.begin(); mva_itr != all_mvas.end(); ++mva_itr ){
+    const int iEstimator = std::distance(all_mvas.begin(),mva_itr);
+
     // Set up all event content, such as ValueMaps produced upstream or other,
     // original event data pieces, that is needed (if any is implemented in the specific
     // MVA classes)
-    mvaEstimators_[iEstimator]->getEventContent( iEvent );
+    //mvaEstimators_[iEstimator]->getEventContent( iEvent );
 
     std::vector<float> mvaValues;
     std::vector<int> mvaCategories;
-
+    
     // Loop over particles
     for (size_t i = 0; i < src->size(); ++i){
-      auto iCand = src->ptrAt(i);
-      
-      mvaValues.push_back( mvaEstimators_[iEstimator]->mvaValue(  iCand ) );
-      mvaCategories.push_back( mvaEstimators_[iEstimator]->findCategory(  iCand ) );
+      auto iCand = src->ptrAt(i);      
+      mvaValues.push_back( mvaEstimators_[iEstimator]->mvaValue( iCand, iEvent ) );
+      mvaCategories.push_back( mvaEstimators_[iEstimator]->findCategory( iCand ) );
     } // end loop over particles
 
     writeValueMap(iEvent, src, mvaValues, mvaValueMapNames_[iEstimator] );  
-    writeValueMap(iEvent, src, mvaCategories, mvaCategoriesMapNames_[iEstimator] );  
-
+    writeValueMap(iEvent, src, mvaCategories, mvaCategoriesMapNames_[iEstimator] );
   } // end loop over estimators
   
 
@@ -158,9 +147,9 @@ void MVAValueMapProducer<ParticleType>::produce(edm::Event& iEvent, const edm::E
 
 template<class ParticleType> template<typename T>
 void MVAValueMapProducer<ParticleType>::writeValueMap(edm::Event &iEvent,
-							const edm::Handle<edm::View<ParticleType> > & handle,
-							const std::vector<T> & values,
-							const std::string    & label) const 
+                                                      const edm::Handle<edm::View<ParticleType> > & handle,
+                                                      const std::vector<T> & values,
+                                                      const std::string    & label) const 
 {
   using namespace edm; 
   using namespace std;
@@ -180,3 +169,4 @@ template <class ParticleType>
   descriptions.addDefault(desc);
 }
 
+#endif

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -52,9 +52,8 @@ class MVAValueMapProducer : public edm::stream::EDProducer< edm::GlobalCache<ega
   // for miniAOD case
   edm::EDGetToken srcMiniAOD_;
 
-  // MVA estimator
-  std::vector<std::unique_ptr<AnyMVAEstimatorRun2Base>> mvaEstimators_;
-
+  // MVA estimators are now stored in MVAObjectCache!
+  
   // Value map names
   std::vector <std::string> mvaValueMapNames_;
   std::vector <std::string> mvaCategoriesMapNames_;
@@ -120,13 +119,13 @@ void MVAValueMapProducer<ParticleType>::produce(edm::Event& iEvent, const edm::E
  
   // Loop over MVA estimators
   const auto& all_mvas = globalCache()->allMVAs();
-  for( auto mva_itr = all_mvas.begin(); mva_itr != all_mvas.end(); ++mva_itr ){
+  for( auto mva_itr = all_mvas.begin(); mva_itr != all_mvas.end(); ++mva_itr ){    
     const int iEstimator = std::distance(all_mvas.begin(),mva_itr);
 
     // Set up all event content, such as ValueMaps produced upstream or other,
     // original event data pieces, that is needed (if any is implemented in the specific
     // MVA classes)
-    //mvaEstimators_[iEstimator]->getEventContent( iEvent );
+    const auto& thisEstimator = mva_itr->second;
 
     std::vector<float> mvaValues;
     std::vector<int> mvaCategories;
@@ -134,8 +133,8 @@ void MVAValueMapProducer<ParticleType>::produce(edm::Event& iEvent, const edm::E
     // Loop over particles
     for (size_t i = 0; i < src->size(); ++i){
       auto iCand = src->ptrAt(i);      
-      mvaValues.push_back( mvaEstimators_[iEstimator]->mvaValue( iCand, iEvent ) );
-      mvaCategories.push_back( mvaEstimators_[iEstimator]->findCategory( iCand ) );
+      mvaValues.push_back( thisEstimator->mvaValue( iCand, iEvent ) );
+      mvaCategories.push_back( thisEstimator->findCategory( iCand ) );
     } // end loop over particles
 
     writeValueMap(iEvent, src, mvaValues, mvaValueMapNames_[iEstimator] );  

--- a/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
+++ b/RecoEgamma/EgammaTools/interface/MVAValueMapProducer.h
@@ -80,7 +80,7 @@ MVAValueMapProducer<ParticleType>::MVAValueMapProducer(const edm::ParameterSet& 
     //
     // Compose and save the names of the value maps to be produced
     //
-    const auto& currentEstimator = mvaItr->second;
+    //const auto& currentEstimator = mvaItr->second;
     const std::string thisValueMapName = mvaItr->first + "Values";
     const std::string thisCategoriesMapName = mvaItr->first + "Categories";
     mvaValueMapNames_.push_back( thisValueMapName );

--- a/RecoEgamma/EgammaTools/src/MVAObjectCache.cc
+++ b/RecoEgamma/EgammaTools/src/MVAObjectCache.cc
@@ -1,0 +1,44 @@
+#include "RecoEgamma/EgammaTools/interface/MVAObjectCache.h"
+
+using namespace egamma;
+
+MVAObjectCache::MVAObjectCache(const edm::ParameterSet& conf) {
+  const std::vector<edm::ParameterSet>& mvaEstimatorConfigs
+    = conf.getParameterSetVector("mvaConfigurations");
+  
+  for( auto &imva : mvaEstimatorConfigs ){
+    // building the mva class is now done in the ObjectCache, 
+    // so we loop over what's in that.
+    std::unique_ptr<AnyMVAEstimatorRun2Base> thisEstimator;
+    thisEstimator.reset(nullptr);
+    if( !imva.empty() ) {
+      const std::string& pName = imva.getParameter<std::string>("mvaName");
+      // The factory below constructs the MVA of the appropriate type based
+      // on the "mvaName" which is the name of the derived MVA class (plugin)      
+      const AnyMVAEstimatorRun2Base *estimator = AnyMVAEstimatorRun2Factory::get()->create( pName, imva );
+      // Declare all event content, such as ValueMaps produced upstream or other,
+      // original event data pieces, that is needed (if any is implemented in the specific
+      // MVA classes)
+      auto diditwork = mvas_.emplace(estimator->getName(), MVAPtr(estimator) );
+      if( !diditwork.second ) {
+        throw cms::Exception("MVA configured twice: ")
+          <<  "Tried already to make an mva of name: " << estimator->getName()
+          << " please ensure that the name of the MVA is unique!" << std::endl;
+      }
+    } else {
+      throw cms::Exception(" MVA configuration not found: ")
+	<< " failed to find proper configuration for "
+        <<"one of the MVAs in the main python script " << std::endl;
+    }
+  }
+}
+
+const MVAObjectCache::MVAPtr& 
+MVAObjectCache::getMVA(const std::string& mva) const {
+  auto itr = mvas_.find(mva);
+  if( itr == mvas_.end() ) {
+    throw cms::Exception("InvalidMVAName")
+      << mva << " is not managed by this evaluator!";
+  }
+  return itr->second;
+}

--- a/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2Phys14NonTrig.h
+++ b/RecoEgamma/ElectronIdentification/interface/ElectronMVAEstimatorRun2Phys14NonTrig.h
@@ -5,12 +5,16 @@
 
 #include "DataFormats/EgammaCandidates/interface/GsfElectron.h"
 
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+
 #include <vector>
 #include <string>
+#include <memory>
 #include <TROOT.h>
 #include "TMVA/Factory.h"
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
+#include "TMVA/MethodBDT.h"
 
 class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   
@@ -18,7 +22,7 @@ class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
 
   // Define here the number and the meaning of the categories
   // for this specific MVA
-  const int nCategories = 6;
+  static constexpr int nCategories = 6;
   enum mvaCategories {
     UNDEFINED = -1,
     CAT_EB1_PT5to10  = 0,
@@ -31,34 +35,34 @@ class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
 
   // Define the struct that contains all necessary for MVA variables
   struct AllVariables {
-    float kfhits;
+    float kfhits; // 0
     // Pure ECAL -> shower shapes
-    float see;
-    float spp;
-    float OneMinusE1x5E5x5;
-    float R9;
-    float etawidth;
-    float phiwidth;
-    float HoE;
+    float see; // 1
+    float spp; // 2
+    float OneMinusE1x5E5x5; // 3
+    float R9; // 4
+    float etawidth; // 5
+    float phiwidth; // 6
+    float HoE; // 7
     // Endcap only variables
-    float PreShowerOverRaw;
+    float PreShowerOverRaw; // 8
     //Pure tracking variables
-    float kfchi2;
-    float gsfchi2;
+    float kfchi2; // 9 
+    float gsfchi2; // 10
     // Energy matching
-    float fbrem;
-    float EoP;
-    float eleEoPout;
-    float IoEmIoP;
+    float fbrem; // 11
+    float EoP; // 12
+    float eleEoPout; // 13
+    float IoEmIoP; // 14
     // Geometrical matchings
-    float deta;
-    float dphi;
-    float detacalo;
+    float deta; // 15
+    float dphi; // 16
+    float detacalo; // 17 
     // Spectator variables  
-    float pt;
-    float isBarrel;
-    float isEndcap;
-    float SCeta;
+    float pt; // 18
+    float isBarrel; // 19
+    float isEndcap; // 20
+    float SCeta; // 21
   };
   
   // Constructor and destructor
@@ -66,22 +70,22 @@ class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   ~ElectronMVAEstimatorRun2Phys14NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue( const edm::Ptr<reco::Candidate>& particle);
+  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& evt) const;
  
   // Utility functions
-  TMVA::Reader *createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
+  std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile) ;
 
-  inline int getNCategories(){return nCategories;};
-  bool isEndcapCategory( int category );
-  const inline std::string getName(){return name_;};
+  virtual int getNCategories() const override final { return nCategories; }
+  bool isEndcapCategory( int category ) const;
+  const std::string& getName() const override { return name_; }
 
   // Functions that should work on both pat and reco electrons
   // (use the fact that pat::Electron inherits from reco::GsfElectron)
-  void fillMVAVariables(const edm::Ptr<reco::Candidate>& particle);
-  int findCategory( const edm::Ptr<reco::Candidate>& particle);
+  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
+  int findCategory(const edm::Ptr<reco::Candidate>& particle) const;
   // The function below ensures that the variables passed to MVA are 
   // within reasonable bounds
-  void constrainMVAVariables();
+  void constrainMVAVariables(AllVariables& vars) const;
   
  private:
 
@@ -91,7 +95,7 @@ class ElectronMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   const std::string name_ = "ElectronMVAEstimatorRun2Phys14NonTrig";
 
   // Data members
-  std::vector< std::unique_ptr<TMVA::Reader> > _tmvaReaders;
+  std::vector< std::unique_ptr<const GBRForest> > _gbrForests;
 
   // All variables needed by this MVA
   std::string _MethodName;

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
@@ -41,7 +41,7 @@ mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& evt) cons
   
   const int iCategory = findCategory( particle );
   const std::vector<float> vars = std::move( fillMVAVariables( particle, evt ) );  
-  const float result = _gbrForests.at(iCategory)->GetGradBoostClassifier(vars.data());
+  const float result = _gbrForests.at(iCategory)->GetClassifier(vars.data());
 
   constexpr bool debug = false;
   if(debug) {

--- a/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/ElectronIdentification/plugins/ElectronMVAEstimatorRun2Phys14NonTrig.cc
@@ -8,7 +8,7 @@
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
 ElectronMVAEstimatorRun2Phys14NonTrig::ElectronMVAEstimatorRun2Phys14NonTrig(const edm::ParameterSet& conf):
-  AnyMVAEstimatorRun2Base(conf){
+  AnyMVAEstimatorRun2Base(conf) {
 
   const std::vector <std::string> weightFileNames
     = conf.getParameter<std::vector<std::string> >("weightFileNames");
@@ -17,7 +17,7 @@ ElectronMVAEstimatorRun2Phys14NonTrig::ElectronMVAEstimatorRun2Phys14NonTrig(con
     throw cms::Exception("MVA config failure: ")
       << "wrong number of weightfiles" << std::endl;
 
-  _tmvaReaders.clear();
+  _gbrForests.clear();
   _MethodName = "BDTG method";
   // Create a TMVA reader object for each category
   for(int i=0; i<nCategories; i++){
@@ -26,7 +26,7 @@ ElectronMVAEstimatorRun2Phys14NonTrig::ElectronMVAEstimatorRun2Phys14NonTrig(con
     // when the vector clear() is called in the destructor
 
     edm::FileInPath weightFile( weightFileNames[i] );
-    _tmvaReaders.push_back( std::unique_ptr<TMVA::Reader> ( createSingleReader(i, weightFile ) ) );
+    _gbrForests.push_back( createSingleReader(i, weightFile ) );
 
   }
 
@@ -34,50 +34,50 @@ ElectronMVAEstimatorRun2Phys14NonTrig::ElectronMVAEstimatorRun2Phys14NonTrig(con
 
 ElectronMVAEstimatorRun2Phys14NonTrig::
 ~ElectronMVAEstimatorRun2Phys14NonTrig(){
-  
-  _tmvaReaders.clear();
 }
 
 float ElectronMVAEstimatorRun2Phys14NonTrig::
-mvaValue( const edm::Ptr<reco::Candidate>& particle){
+mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& evt) const {
   
-  int iCategory = findCategory( particle );
-  fillMVAVariables( particle );  
-  constrainMVAVariables();
-  float result = _tmvaReaders.at(iCategory)->EvaluateMVA(_MethodName);
+  const int iCategory = findCategory( particle );
+  const std::vector<float> vars = std::move( fillMVAVariables( particle, evt ) );  
+  const float result = _gbrForests.at(iCategory)->GetGradBoostClassifier(vars.data());
 
-  bool debug = false;
+  constexpr bool debug = false;
   if(debug) {
     std::cout << " *** Inside the class _MethodName " << _MethodName << std::endl;
     std::cout << " bin " << iCategory
-	      << " fbrem " <<  _allMVAVars.fbrem
-         << " kfchi2 " << _allMVAVars.kfchi2
-         << " mykfhits " << _allMVAVars.kfhits
-         << " gsfchi2 " << _allMVAVars.gsfchi2
-         << " deta " <<  _allMVAVars.deta
-         << " dphi " << _allMVAVars.dphi
-         << " detacalo " << _allMVAVars.detacalo
-         << " see " << _allMVAVars.see
-         << " spp " << _allMVAVars.spp
-         << " etawidth " << _allMVAVars.etawidth
-         << " phiwidth " << _allMVAVars.phiwidth
-         << " OneMinusE1x5E5x5 " << _allMVAVars.OneMinusE1x5E5x5
-         << " R9 " << _allMVAVars.R9
-         << " HoE " << _allMVAVars.HoE
-         << " EoP " << _allMVAVars.EoP
-         << " IoEmIoP " << _allMVAVars.IoEmIoP
-         << " eleEoPout " << _allMVAVars.eleEoPout
+	      << " fbrem "    << vars[11]  //_allMVAVars.fbrem
+              << " kfchi2 "   << vars[9]  //_allMVAVars.kfchi2
+              << " mykfhits " << vars[0]  //_allMVAVars.kfhits
+              << " gsfchi2 "  << vars[10]  //_allMVAVars.gsfchi2
+              << " deta "     << vars[15]  //_allMVAVars.deta
+              << " dphi "     << vars[16]  //_allMVAVars.dphi
+              << " detacalo " << vars[17]  //_allMVAVars.detacalo
+              << " see "      << vars[1]  //_allMVAVars.see
+              << " spp "      << vars[2]  //_allMVAVars.spp
+              << " etawidth " << vars[5]  //_allMVAVars.etawidth
+              << " phiwidth " << vars[6] // _allMVAVars.phiwidth
+              << " OneMinusE1x5E5x5 " << vars[3] //_allMVAVars.OneMinusE1x5E5x5
+              << " R9 "        << vars[4] //_allMVAVars.R9
+              << " HoE "       << vars[7] //_allMVAVars.HoE
+              << " EoP "       << vars[12] //_allMVAVars.EoP
+              << " IoEmIoP "   << vars[14] //_allMVAVars.IoEmIoP
+              << " eleEoPout " << vars[13] // _allMVAVars.eleEoPout
       //<< " d0 " << _allMVAVars.d0
       //   << " ip3d " << _allMVAVars.ip3d
-         << " eta " << _allMVAVars.SCeta
-	      << " pt " << _allMVAVars.pt << std::endl;
+              << " eta "       << vars[21] //_allMVAVars.SCeta
+              << " isBarrel "  << vars[19] //_allMVAVars.isBarrel
+              << " isEndcap "  << vars[20] //_allMVAVars.isEndcap
+	      << " pt "        << vars[18] //_allMVAVars.pt
+              << std::endl;
     std::cout << " ### MVA " << result << std::endl;
   }
 
   return result;
 }
 
-int ElectronMVAEstimatorRun2Phys14NonTrig::findCategory( const edm::Ptr<reco::Candidate>& particle){
+int ElectronMVAEstimatorRun2Phys14NonTrig::findCategory(const edm::Ptr<reco::Candidate>& particle) const {
   
   // Try to cast the particle into a reco particle.
   // This should work for both reco and pat.
@@ -87,16 +87,16 @@ int ElectronMVAEstimatorRun2Phys14NonTrig::findCategory( const edm::Ptr<reco::Ca
       << " given particle is expected to be reco::GsfElectron or pat::Electron," << std::endl
       << " but appears to be neither" << std::endl;
 
-  float pt = eleRecoPtr->pt();
-  float eta = eleRecoPtr->superCluster()->eta();
+  const float pt = eleRecoPtr->pt();
+  const float eta = eleRecoPtr->superCluster()->eta();
 
   //
   // Determine the category
   //
   int  iCategory = UNDEFINED;
-  const float ptSplit = 10;   // we have above and below 10 GeV categories
-  const float ebSplit = 0.800;// barrel is split into two regions
-  const float ebeeSplit = 1.479; // division between barrel and endcap
+  constexpr float ptSplit = 10;   // we have above and below 10 GeV categories
+  constexpr float ebSplit = 0.800;// barrel is split into two regions
+  constexpr float ebeeSplit = 1.479; // division between barrel and endcap
 
   if (pt < ptSplit && std::abs(eta) < ebSplit)  
     iCategory = CAT_EB1_PT5to10;
@@ -120,7 +120,7 @@ int ElectronMVAEstimatorRun2Phys14NonTrig::findCategory( const edm::Ptr<reco::Ca
 }
 
 bool ElectronMVAEstimatorRun2Phys14NonTrig::
-isEndcapCategory(int category ){
+isEndcapCategory(int category ) const {
 
   bool isEndcap = false;
   if( category == CAT_EE_PT5to10 || category == CAT_EE_PT10plus )
@@ -130,64 +130,67 @@ isEndcapCategory(int category ){
 }
 
 
-TMVA::Reader *ElectronMVAEstimatorRun2Phys14NonTrig::
-createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
+std::unique_ptr<const GBRForest>
+ElectronMVAEstimatorRun2Phys14NonTrig::
+createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
 
   //
   // Create the reader  
   //
-  TMVA::Reader *tmpTMVAReader = new TMVA::Reader( "!Color:Silent:Error" );
+  TMVA::Reader tmpTMVAReader( "!Color:Silent:Error" );
 
   //
   // Configure all variables and spectators. Note: the order and names
   // must match what is found in the xml weights file!
   //
 
-  tmpTMVAReader->AddVariable("ele_kfhits",           &_allMVAVars.kfhits);
+  tmpTMVAReader.AddVariable("ele_kfhits",           &_allMVAVars.kfhits);
   
   // Pure ECAL -> shower shapes
-  tmpTMVAReader->AddVariable("ele_oldsigmaietaieta", &_allMVAVars.see);
-  tmpTMVAReader->AddVariable("ele_oldsigmaiphiiphi", &_allMVAVars.spp);
-  tmpTMVAReader->AddVariable("ele_oldcircularity",   &_allMVAVars.OneMinusE1x5E5x5);
-  tmpTMVAReader->AddVariable("ele_oldr9",            &_allMVAVars.R9);
-  tmpTMVAReader->AddVariable("ele_scletawidth",      &_allMVAVars.etawidth);
-  tmpTMVAReader->AddVariable("ele_sclphiwidth",      &_allMVAVars.phiwidth);
-  tmpTMVAReader->AddVariable("ele_he",               &_allMVAVars.HoE);
+  tmpTMVAReader.AddVariable("ele_oldsigmaietaieta", &_allMVAVars.see);
+  tmpTMVAReader.AddVariable("ele_oldsigmaiphiiphi", &_allMVAVars.spp);
+  tmpTMVAReader.AddVariable("ele_oldcircularity",   &_allMVAVars.OneMinusE1x5E5x5);
+  tmpTMVAReader.AddVariable("ele_oldr9",            &_allMVAVars.R9);
+  tmpTMVAReader.AddVariable("ele_scletawidth",      &_allMVAVars.etawidth);
+  tmpTMVAReader.AddVariable("ele_sclphiwidth",      &_allMVAVars.phiwidth);
+  tmpTMVAReader.AddVariable("ele_he",               &_allMVAVars.HoE);
   // Endcap only variables
   if( isEndcapCategory(iCategory) )
-    tmpTMVAReader->AddVariable("ele_psEoverEraw",    &_allMVAVars.PreShowerOverRaw);
+    tmpTMVAReader.AddVariable("ele_psEoverEraw",    &_allMVAVars.PreShowerOverRaw);
   
   //Pure tracking variables
-  tmpTMVAReader->AddVariable("ele_kfchi2",           &_allMVAVars.kfchi2);
-  tmpTMVAReader->AddVariable("ele_chi2_hits",        &_allMVAVars.gsfchi2);
+  tmpTMVAReader.AddVariable("ele_kfchi2",           &_allMVAVars.kfchi2);
+  tmpTMVAReader.AddVariable("ele_chi2_hits",        &_allMVAVars.gsfchi2);
 
   // Energy matching
-  tmpTMVAReader->AddVariable("ele_fbrem",           &_allMVAVars.fbrem);
-  tmpTMVAReader->AddVariable("ele_ep",              &_allMVAVars.EoP);
-  tmpTMVAReader->AddVariable("ele_eelepout",        &_allMVAVars.eleEoPout);
-  tmpTMVAReader->AddVariable("ele_IoEmIop",         &_allMVAVars.IoEmIoP);
+  tmpTMVAReader.AddVariable("ele_fbrem",           &_allMVAVars.fbrem);
+  tmpTMVAReader.AddVariable("ele_ep",              &_allMVAVars.EoP);
+  tmpTMVAReader.AddVariable("ele_eelepout",        &_allMVAVars.eleEoPout);
+  tmpTMVAReader.AddVariable("ele_IoEmIop",         &_allMVAVars.IoEmIoP);
   
   // Geometrical matchings
-  tmpTMVAReader->AddVariable("ele_deltaetain",      &_allMVAVars.deta);
-  tmpTMVAReader->AddVariable("ele_deltaphiin",      &_allMVAVars.dphi);
-  tmpTMVAReader->AddVariable("ele_deltaetaseed",    &_allMVAVars.detacalo);
+  tmpTMVAReader.AddVariable("ele_deltaetain",      &_allMVAVars.deta);
+  tmpTMVAReader.AddVariable("ele_deltaphiin",      &_allMVAVars.dphi);
+  tmpTMVAReader.AddVariable("ele_deltaetaseed",    &_allMVAVars.detacalo);
   
   // Spectator variables  
-  tmpTMVAReader->AddSpectator("ele_pT",             &_allMVAVars.pt);
-  tmpTMVAReader->AddSpectator("ele_isbarrel",       &_allMVAVars.isBarrel);
-  tmpTMVAReader->AddSpectator("ele_isendcap",       &_allMVAVars.isEndcap);
-  tmpTMVAReader->AddSpectator("scl_eta",            &_allMVAVars.SCeta);
+  tmpTMVAReader.AddSpectator("ele_pT",             &_allMVAVars.pt);
+  tmpTMVAReader.AddSpectator("ele_isbarrel",       &_allMVAVars.isBarrel);
+  tmpTMVAReader.AddSpectator("ele_isendcap",       &_allMVAVars.isEndcap);
+  tmpTMVAReader.AddSpectator("scl_eta",            &_allMVAVars.SCeta);
 
   //
   // Book the method and set up the weights file
   //
-  tmpTMVAReader->BookMVA(_MethodName , weightFile.fullPath() );
-
-  return tmpTMVAReader;
+  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
+  
+  return std::unique_ptr<const GBRForest> ( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
 }
 
 // A function that should work on both pat and reco objects
-void ElectronMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const edm::Ptr<reco::Candidate>& particle){
+std::vector<float> 
+ElectronMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const edm::Ptr<reco::Candidate>& particle,
+                                                        const edm::Event& ) const {
 
   // Try to cast the particle into a reco particle.
   // This should work for both reco and pat.
@@ -196,6 +199,9 @@ void ElectronMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const edm::Ptr<reco
     throw cms::Exception("MVA failure: ")
       << " given particle is expected to be reco::GsfElectron or pat::Electron," << std::endl
       << " but appears to be neither" << std::endl;
+
+  // the instance of the variables that we will manipulate
+  AllVariables allMVAVars;
 
   // Both pat and reco particles have exactly the same accessors, so we use a reco ptr 
   // throughout the code, with a single exception as of this writing, handled separately below.
@@ -213,85 +219,130 @@ void ElectronMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const edm::Ptr<reco
     myTrackRef = elePatPtr->closestCtfTrackRef();
   validKF = (myTrackRef.isAvailable() && (myTrackRef.isNonnull()) );  
 
-  _allMVAVars.kfhits         = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1. ;
+  allMVAVars.kfhits         = (validKF) ? myTrackRef->hitPattern().trackerLayersWithMeasurement() : -1. ;
   // Pure ECAL -> shower shapes
-  _allMVAVars.see            = eleRecoPtr->full5x5_sigmaIetaIeta();
-  _allMVAVars.spp            = eleRecoPtr->full5x5_sigmaIphiIphi();
-  _allMVAVars.OneMinusE1x5E5x5 = 1. - eleRecoPtr->full5x5_e1x5() / eleRecoPtr->full5x5_e5x5();
-  _allMVAVars.R9             = eleRecoPtr->full5x5_r9();
-  _allMVAVars.etawidth       = superCluster->etaWidth();
-  _allMVAVars.phiwidth       = superCluster->phiWidth();
-  _allMVAVars.HoE            = eleRecoPtr->hadronicOverEm();
+  allMVAVars.see            = eleRecoPtr->full5x5_sigmaIetaIeta();
+  allMVAVars.spp            = eleRecoPtr->full5x5_sigmaIphiIphi();
+  allMVAVars.OneMinusE1x5E5x5 = 1. - eleRecoPtr->full5x5_e1x5() / eleRecoPtr->full5x5_e5x5();
+  allMVAVars.R9             = eleRecoPtr->full5x5_r9();
+  allMVAVars.etawidth       = superCluster->etaWidth();
+  allMVAVars.phiwidth       = superCluster->phiWidth();
+  allMVAVars.HoE            = eleRecoPtr->hadronicOverEm();
   // Endcap only variables
-  _allMVAVars.PreShowerOverRaw  = superCluster->preshowerEnergy() / superCluster->rawEnergy();
+  allMVAVars.PreShowerOverRaw  = superCluster->preshowerEnergy() / superCluster->rawEnergy();
   //Pure tracking variables
-  _allMVAVars.kfchi2          = (validKF) ? myTrackRef->normalizedChi2() : 0;
-  _allMVAVars.gsfchi2         = eleRecoPtr->gsfTrack()->normalizedChi2();
+  allMVAVars.kfchi2          = (validKF) ? myTrackRef->normalizedChi2() : 0;
+  allMVAVars.gsfchi2         = eleRecoPtr->gsfTrack()->normalizedChi2();
   // Energy matching
-  _allMVAVars.fbrem           = eleRecoPtr->fbrem();
-  _allMVAVars.EoP             = eleRecoPtr->eSuperClusterOverP();
-  _allMVAVars.eleEoPout       = eleRecoPtr->eEleClusterOverPout();
-  _allMVAVars.IoEmIoP         = (1.0/eleRecoPtr->ecalEnergy()) - (1.0 / eleRecoPtr->p());
+  allMVAVars.fbrem           = eleRecoPtr->fbrem();
+  allMVAVars.EoP             = eleRecoPtr->eSuperClusterOverP();
+  allMVAVars.eleEoPout       = eleRecoPtr->eEleClusterOverPout();
+  allMVAVars.IoEmIoP         = (1.0/eleRecoPtr->ecalEnergy()) - (1.0 / eleRecoPtr->p());
   // Geometrical matchings
-  _allMVAVars.deta            = eleRecoPtr->deltaEtaSuperClusterTrackAtVtx();
-  _allMVAVars.dphi            = eleRecoPtr->deltaPhiSuperClusterTrackAtVtx();
-  _allMVAVars.detacalo        = eleRecoPtr->deltaEtaSeedClusterTrackAtCalo();
+  allMVAVars.deta            = eleRecoPtr->deltaEtaSuperClusterTrackAtVtx();
+  allMVAVars.dphi            = eleRecoPtr->deltaPhiSuperClusterTrackAtVtx();
+  allMVAVars.detacalo        = eleRecoPtr->deltaEtaSeedClusterTrackAtCalo();
   // Spectator variables  
-  _allMVAVars.pt              = eleRecoPtr->pt();
-  float scEta = superCluster->eta();
-  _allMVAVars.isBarrel        = ( std::abs(scEta) < 1.479 );
-  _allMVAVars.isEndcap        = ( std::abs(scEta) >= 1.479);
-  _allMVAVars.SCeta           = scEta;
+  allMVAVars.pt              = eleRecoPtr->pt();
+  const float scEta = superCluster->eta();
+  allMVAVars.isBarrel        = ( std::abs(scEta) < 1.479 );
+  allMVAVars.isEndcap        = ( std::abs(scEta) >= 1.479);
+  allMVAVars.SCeta           = scEta;
 
+  constrainMVAVariables(allMVAVars);
 
+  std::vector<float> vars;
+
+  if( isEndcapCategory( findCategory(particle) ) ) {
+    vars = std::move( packMVAVariables( allMVAVars.kfhits,
+                                        allMVAVars.see,
+                                        allMVAVars.spp,
+                                        allMVAVars.OneMinusE1x5E5x5,
+                                        allMVAVars.R9,
+                                        allMVAVars.etawidth,
+                                        allMVAVars.phiwidth,
+                                        allMVAVars.HoE,
+                                        allMVAVars.PreShowerOverRaw,
+                                        allMVAVars.kfchi2,
+                                        allMVAVars.gsfchi2,
+                                        allMVAVars.fbrem,
+                                        allMVAVars.EoP,
+                                        allMVAVars.eleEoPout,
+                                        allMVAVars.IoEmIoP,
+                                        allMVAVars.deta,
+                                        allMVAVars.dphi,
+                                        allMVAVars.detacalo,
+                                        allMVAVars.pt,
+                                        allMVAVars.isBarrel,
+                                        allMVAVars.isEndcap,
+                                        allMVAVars.SCeta )
+                      );
+  } else {
+    vars = std::move( packMVAVariables( allMVAVars.kfhits,
+                                        allMVAVars.see,
+                                        allMVAVars.spp,
+                                        allMVAVars.OneMinusE1x5E5x5,
+                                        allMVAVars.R9,
+                                        allMVAVars.etawidth,
+                                        allMVAVars.phiwidth,
+                                        allMVAVars.HoE,
+                                        allMVAVars.kfchi2,
+                                        allMVAVars.gsfchi2,
+                                        allMVAVars.fbrem,
+                                        allMVAVars.EoP,
+                                        allMVAVars.eleEoPout,
+                                        allMVAVars.IoEmIoP,
+                                        allMVAVars.deta,
+                                        allMVAVars.dphi,
+                                        allMVAVars.detacalo,
+                                        allMVAVars.pt,
+                                        allMVAVars.isBarrel,
+                                        allMVAVars.isEndcap,
+                                        allMVAVars.SCeta )
+                      );
+  }
+
+  return vars;
 }
 
-void ElectronMVAEstimatorRun2Phys14NonTrig::constrainMVAVariables(){
+void ElectronMVAEstimatorRun2Phys14NonTrig::constrainMVAVariables(AllVariables& vars) const {
 
   // Check that variables do not have crazy values
 
-  if(_allMVAVars.fbrem < -1.)
-    _allMVAVars.fbrem = -1.;
+  if(vars.fbrem < -1.)
+    vars.fbrem = -1.;
   
-  _allMVAVars.deta = fabs(_allMVAVars.deta);
-  if(_allMVAVars.deta > 0.06)
-    _allMVAVars.deta = 0.06;
+  vars.deta = std::abs(vars.deta);
+  if(vars.deta > 0.06)
+    vars.deta = 0.06;
   
+  vars.dphi = std::abs(vars.dphi);
+  if(vars.dphi > 0.6)
+    vars.dphi = 0.6;
   
-  _allMVAVars.dphi = fabs(_allMVAVars.dphi);
-  if(_allMVAVars.dphi > 0.6)
-    _allMVAVars.dphi = 0.6;
+  if(vars.EoP > 20.)
+    vars.EoP = 20.;
   
-
-  if(_allMVAVars.EoP > 20.)
-    _allMVAVars.EoP = 20.;
+  if(vars.eleEoPout > 20.)
+    vars.eleEoPout = 20.;
+    
+  vars.detacalo = std::abs(vars.detacalo);
+  if(vars.detacalo > 0.2)
+    vars.detacalo = 0.2;
   
-  if(_allMVAVars.eleEoPout > 20.)
-    _allMVAVars.eleEoPout = 20.;
+  if(vars.OneMinusE1x5E5x5 < -1.)
+    vars.OneMinusE1x5E5x5 = -1;
   
+  if(vars.OneMinusE1x5E5x5 > 2.)
+    vars.OneMinusE1x5E5x5 = 2.; 
+    
+  if(vars.R9 > 5)
+    vars.R9 = 5;
   
-  _allMVAVars.detacalo = fabs(_allMVAVars.detacalo);
-  if(_allMVAVars.detacalo > 0.2)
-    _allMVAVars.detacalo = 0.2;
-  
-  if(_allMVAVars.OneMinusE1x5E5x5 < -1.)
-    _allMVAVars.OneMinusE1x5E5x5 = -1;
-  
-  if(_allMVAVars.OneMinusE1x5E5x5 > 2.)
-    _allMVAVars.OneMinusE1x5E5x5 = 2.; 
-  
-  
-  
-  if(_allMVAVars.R9 > 5)
-    _allMVAVars.R9 = 5;
-  
-  if(_allMVAVars.gsfchi2 > 200.)
-    _allMVAVars.gsfchi2 = 200;
-  
-  
-  if(_allMVAVars.kfchi2 > 10.)
-    _allMVAVars.kfchi2 = 10.;
-  
-
+  if(vars.gsfchi2 > 200.)
+    vars.gsfchi2 = 200;
+    
+  if(vars.kfchi2 > 10.)
+    vars.kfchi2 = 10.;
 }
 

--- a/RecoEgamma/PhotonIdentification/interface/PhotonMVAEstimatorRun2Phys14NonTrig.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonMVAEstimatorRun2Phys14NonTrig.h
@@ -9,6 +9,8 @@
 
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+
 #include <vector>
 #include <string>
 #include <TROOT.h>
@@ -16,7 +18,7 @@
 #include "TMVA/Tools.h"
 #include "TMVA/Reader.h"
 
-class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
+class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base {
   
  public:
 
@@ -30,8 +32,7 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   };
 
   // Define the struct that contains all necessary for MVA variables
-  struct AllVariables {
-    
+  struct AllVariables {    
     float varPhi;
     float varR9;
     float varSieie;
@@ -62,29 +63,31 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   ~PhotonMVAEstimatorRun2Phys14NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue( const edm::Ptr<reco::Candidate>& particle);
+  float mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
  
   // Utility functions
-  TMVA::Reader *createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
+  std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile) ;
 
-  inline int getNCategories(){return nCategories;};
-  bool isEndcapCategory( int category );
-  const inline std::string getName(){return name_;};
+  int getNCategories() const override { return nCategories; }
+  bool isEndcapCategory( int category ) const;
+  const std::string& getName() const override { return name_; }
 
   // Functions that should work on both pat and reco electrons
   // (use the fact that pat::Electron inherits from reco::GsfElectron)
-  void fillMVAVariables(const edm::Ptr<reco::Candidate>& particle);
-  int findCategory( const edm::Ptr<reco::Candidate>& particle);
+  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const override;
+  int findCategory(const edm::Ptr<reco::Candidate>& particle) const;
   // The function below ensures that the variables passed to MVA are 
   // within reasonable bounds
-  void constrainMVAVariables();
+  void constrainMVAVariables(AllVariables& vars) const;
 
   // Call this function once after the constructor to declare
   // the needed event content pieces to the framework
-  void setConsumes(edm::ConsumesCollector&&) override;
+  // DEPRECATED
+  void setConsumes(edm::ConsumesCollector&&) const override;
   // Call this function once per event to retrieve all needed
   // event content pices
-  void getEventContent(const edm::Event& iEvent) override;
+  // DEPRECATED
+  // void getEventContent(const edm::Event& iEvent) const override;
 
   
  private:
@@ -95,10 +98,10 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   const std::string name_ = "PhotonMVAEstimatorRun2Phys14NonTrig";
 
   // Data members
-  std::vector< std::unique_ptr<TMVA::Reader> > _tmvaReaders;
+  std::vector<std::unique_ptr<const GBRForest> > _gbrForests;
 
   // All variables needed by this MVA
-  std::string _MethodName;
+  const std::string _MethodName;
   AllVariables _allMVAVars;
   
   // This MVA implementation relies on several ValueMap objects
@@ -108,37 +111,19 @@ class PhotonMVAEstimatorRun2Phys14NonTrig : public AnyMVAEstimatorRun2Base{
   // Declare all tokens that will be needed to retrieve misc
   // data from the event content required by this MVA
   //
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5SigmaIEtaIEtaMapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5SigmaIEtaIPhiMapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E1x3MapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E2x2MapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E2x5MaxMapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E5x5MapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _esEffSigmaRRMapToken; 
+  const edm::InputTag _full5x5SigmaIEtaIEtaMapLabel; 
+  const edm::InputTag _full5x5SigmaIEtaIPhiMapLabel; 
+  const edm::InputTag _full5x5E1x3MapLabel; 
+  const edm::InputTag _full5x5E2x2MapLabel; 
+  const edm::InputTag _full5x5E2x5MaxMapLabel; 
+  const edm::InputTag _full5x5E5x5MapLabel; 
+  const edm::InputTag _esEffSigmaRRMapLabel; 
   //
-  edm::EDGetTokenT<edm::ValueMap<float> > _phoChargedIsolationToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _phoPhotonIsolationToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _phoWorstChargedIsolationToken; 
-
-  // 
-  // Declare all value maps corresponding to the above tokens
-  //
-  edm::Handle<edm::ValueMap<float> > _full5x5SigmaIEtaIEtaMap;
-  edm::Handle<edm::ValueMap<float> > _full5x5SigmaIEtaIPhiMap;
-  edm::Handle<edm::ValueMap<float> > _full5x5E1x3Map;
-  edm::Handle<edm::ValueMap<float> > _full5x5E2x2Map;
-  edm::Handle<edm::ValueMap<float> > _full5x5E2x5MaxMap;
-  edm::Handle<edm::ValueMap<float> > _full5x5E5x5Map;
-  edm::Handle<edm::ValueMap<float> > _esEffSigmaRRMap;
-  //
-  edm::Handle<edm::ValueMap<float> > _phoChargedIsolationMap;
-  edm::Handle<edm::ValueMap<float> > _phoPhotonIsolationMap;
-  edm::Handle<edm::ValueMap<float> > _phoWorstChargedIsolationMap;
-
-  // Rho will be pulled from the event content
-  edm::EDGetTokenT<double> _rhoToken;
-  edm::Handle<double> _rho;
-
+  const edm::InputTag _phoChargedIsolationLabel; 
+  const edm::InputTag _phoPhotonIsolationLabel; 
+  const edm::InputTag _phoWorstChargedIsolationLabel; 
+  // token for rho
+  const edm::InputTag _rhoLabel;
 };
 
 DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,

--- a/RecoEgamma/PhotonIdentification/interface/PhotonMVAEstimatorRun2Spring15NonTrig.h
+++ b/RecoEgamma/PhotonIdentification/interface/PhotonMVAEstimatorRun2Spring15NonTrig.h
@@ -9,6 +9,8 @@
 
 #include "DataFormats/EgammaCandidates/interface/Photon.h"
 
+#include "CondFormats/EgammaObjects/interface/GBRForest.h"
+
 #include <vector>
 #include <string>
 #include <TROOT.h>
@@ -54,7 +56,6 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
     // Spectators
     float varPt;
     float varEta;
-
   };
   
   // Constructor and destructor
@@ -62,29 +63,29 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   ~PhotonMVAEstimatorRun2Spring15NonTrig();
 
   // Calculation of the MVA value
-  float mvaValue( const edm::Ptr<reco::Candidate>& particle);
+  float mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event&) const;
  
   // Utility functions
-  TMVA::Reader *createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
+  std::unique_ptr<const GBRForest> createSingleReader(const int iCategory, const edm::FileInPath &weightFile);
 
-  inline int getNCategories(){return nCategories;};
-  bool isEndcapCategory( int category );
-  const inline std::string getName(){return name_;};
+  int getNCategories() const override { return nCategories; }
+  bool isEndcapCategory( int category ) const;
+  const std::string& getName() const override { return name_; }
 
   // Functions that should work on both pat and reco electrons
   // (use the fact that pat::Electron inherits from reco::GsfElectron)
-  void fillMVAVariables(const edm::Ptr<reco::Candidate>& particle);
-  int findCategory( const edm::Ptr<reco::Candidate>& particle);
+  std::vector<float> fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const override;
+  int findCategory( const edm::Ptr<reco::Candidate>& particle ) const override;
   // The function below ensures that the variables passed to MVA are 
   // within reasonable bounds
-  void constrainMVAVariables();
+  void constrainMVAVariables(AllVariables&) const;
 
   // Call this function once after the constructor to declare
   // the needed event content pieces to the framework
-  void setConsumes(edm::ConsumesCollector&&) override;
+  void setConsumes(edm::ConsumesCollector&&) const override;
   // Call this function once per event to retrieve all needed
   // event content pices
-  void getEventContent(const edm::Event& iEvent) override;
+  //void getEventContent(const edm::Event& iEvent) override;
 
   
  private:
@@ -95,10 +96,10 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   const std::string name_ = "PhotonMVAEstimatorRun2Spring15NonTrig";
 
   // Data members
-  std::vector< std::unique_ptr<TMVA::Reader> > _tmvaReaders;
+  std::vector< std::unique_ptr<const GBRForest> > _gbrForests;
 
   // All variables needed by this MVA
-  std::string _MethodName;
+  const std::string _MethodName;
   AllVariables _allMVAVars;
   
   // This MVA implementation relies on several ValueMap objects
@@ -108,37 +109,18 @@ class PhotonMVAEstimatorRun2Spring15NonTrig : public AnyMVAEstimatorRun2Base{
   // Declare all tokens that will be needed to retrieve misc
   // data from the event content required by this MVA
   //
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5SigmaIEtaIEtaMapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5SigmaIEtaIPhiMapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E1x3MapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E2x2MapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E2x5MaxMapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _full5x5E5x5MapToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _esEffSigmaRRMapToken; 
+  const edm::InputTag _full5x5SigmaIEtaIEtaMapLabel; 
+  const edm::InputTag _full5x5SigmaIEtaIPhiMapLabel; 
+  const edm::InputTag _full5x5E1x3MapLabel; 
+  const edm::InputTag _full5x5E2x2MapLabel; 
+  const edm::InputTag _full5x5E2x5MaxMapLabel; 
+  const edm::InputTag _full5x5E5x5MapLabel; 
+  const edm::InputTag _esEffSigmaRRMapLabel; 
   //
-  edm::EDGetTokenT<edm::ValueMap<float> > _phoChargedIsolationToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _phoPhotonIsolationToken; 
-  edm::EDGetTokenT<edm::ValueMap<float> > _phoWorstChargedIsolationToken; 
-
-  // 
-  // Declare all value maps corresponding to the above tokens
-  //
-  edm::Handle<edm::ValueMap<float> > _full5x5SigmaIEtaIEtaMap;
-  edm::Handle<edm::ValueMap<float> > _full5x5SigmaIEtaIPhiMap;
-  edm::Handle<edm::ValueMap<float> > _full5x5E1x3Map;
-  edm::Handle<edm::ValueMap<float> > _full5x5E2x2Map;
-  edm::Handle<edm::ValueMap<float> > _full5x5E2x5MaxMap;
-  edm::Handle<edm::ValueMap<float> > _full5x5E5x5Map;
-  edm::Handle<edm::ValueMap<float> > _esEffSigmaRRMap;
-  //
-  edm::Handle<edm::ValueMap<float> > _phoChargedIsolationMap;
-  edm::Handle<edm::ValueMap<float> > _phoPhotonIsolationMap;
-  edm::Handle<edm::ValueMap<float> > _phoWorstChargedIsolationMap;
-
-  // Rho will be pulled from the event content
-  edm::EDGetTokenT<double> _rhoToken;
-  edm::Handle<double> _rho;
-
+  const edm::InputTag _phoChargedIsolationLabel; 
+  const edm::InputTag _phoPhotonIsolationLabel; 
+  const edm::InputTag _phoWorstChargedIsolationLabel; 
+  const edm::InputTag _rhoLabel;
 };
 
 DEFINE_EDM_PLUGIN(AnyMVAEstimatorRun2Factory,

--- a/RecoEgamma/PhotonIdentification/plugins/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/plugins/BuildFile.xml
@@ -6,12 +6,12 @@
 <use   name="CondFormats/PhysicsToolsObjects"/>
 <use   name="Geometry/CaloGeometry"/>
 <use   name="PhysicsTools/SelectorUtils"/>
-<use   name="RecoEgamma/EgammaTools"/>
 <library   name="RecoEgammaPhotonIdentificationPlugins" file="*.cc">
   <use   name="RecoEgamma/PhotonIdentification"/>
   <use   name="RecoEgamma/EgammaTools"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
 <library name="RecoEgammaPhotonIdentificationPlugins_cuts" file="cuts/*.cc">
-   <flags   EDM_PLUGIN="1"/>
+  <use   name="RecoEgamma/EgammaTools"/>
+  <flags   EDM_PLUGIN="1"/>
 </library>

--- a/RecoEgamma/PhotonIdentification/plugins/BuildFile.xml
+++ b/RecoEgamma/PhotonIdentification/plugins/BuildFile.xml
@@ -9,6 +9,7 @@
 <use   name="RecoEgamma/EgammaTools"/>
 <library   name="RecoEgammaPhotonIdentificationPlugins" file="*.cc">
   <use   name="RecoEgamma/PhotonIdentification"/>
+  <use   name="RecoEgamma/EgammaTools"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
 <library name="RecoEgammaPhotonIdentificationPlugins_cuts" file="cuts/*.cc">

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
@@ -50,7 +50,7 @@ mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) c
   
   const int iCategory = findCategory( particle );
   const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );  
-  const float result = _gbrForests.at(iCategory)->GetGradBoostClassifier(vars.data());
+  const float result = _gbrForests.at(iCategory)->GetClassifier(vars.data());
 
   // DEBUG
   constexpr bool debug = false;

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Phys14NonTrig.cc
@@ -2,10 +2,26 @@
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
-PhotonMVAEstimatorRun2Phys14NonTrig::PhotonMVAEstimatorRun2Phys14NonTrig(const edm::ParameterSet& conf):
-  AnyMVAEstimatorRun2Base(conf)
-{
+#include "TMVA/MethodBDT.h"
 
+PhotonMVAEstimatorRun2Phys14NonTrig::PhotonMVAEstimatorRun2Phys14NonTrig(const edm::ParameterSet& conf) :
+  AnyMVAEstimatorRun2Base(conf),
+  // The method name is just a key to retrieve this method later, it is not
+  // a control parameter for a reader (the full definition of the MVA type and
+  // everything else comes from the xml weight files).
+  _MethodName("BDTG method"),
+  _full5x5SigmaIEtaIEtaMapLabel(conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIEtaMap")), 
+  _full5x5SigmaIEtaIPhiMapLabel(conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIPhiMap")), 
+  _full5x5E1x3MapLabel(conf.getParameter<edm::InputTag>("full5x5E1x3Map")), 
+  _full5x5E2x2MapLabel(conf.getParameter<edm::InputTag>("full5x5E2x2Map")), 
+  _full5x5E2x5MaxMapLabel(conf.getParameter<edm::InputTag>("full5x5E2x5MaxMap")), 
+  _full5x5E5x5MapLabel(conf.getParameter<edm::InputTag>("full5x5E5x5Map")), 
+  _esEffSigmaRRMapLabel(conf.getParameter<edm::InputTag>("esEffSigmaRRMap")), 
+  _phoChargedIsolationLabel(conf.getParameter<edm::InputTag>("phoChargedIsolation")), 
+  _phoPhotonIsolationLabel(conf.getParameter<edm::InputTag>("phoPhotonIsolation")), 
+  _phoWorstChargedIsolationLabel(conf.getParameter<edm::InputTag>("phoWorstChargedIsolation")), 
+  _rhoLabel(conf.getParameter<edm::InputTag>("rho"))
+{
   //
   // Construct the MVA estimators
   //
@@ -16,177 +32,90 @@ PhotonMVAEstimatorRun2Phys14NonTrig::PhotonMVAEstimatorRun2Phys14NonTrig(const e
     throw cms::Exception("MVA config failure: ")
       << "wrong number of weightfiles" << std::endl;
 
-  _tmvaReaders.clear();
-  // The method name is just a key to retrieve this method later, it is not
-  // a control parameter for a reader (the full definition of the MVA type and
-  // everything else comes from the xml weight files).
-  _MethodName = "BDTG method"; 
   // Create a TMVA reader object for each category
   for(int i=0; i<nCategories; i++){
-
-    // Use unique_ptr so that all readers are properly cleaned up
-    // when the vector clear() is called in the destructor
-
+    // Use unique_ptr so that all MVAs are properly cleaned up
+    // in the destructor
     edm::FileInPath weightFile( weightFileNames[i] );
-    _tmvaReaders.push_back( std::unique_ptr<TMVA::Reader> 
-			    ( createSingleReader(i, weightFile ) ) );
-
+    _gbrForests.push_back( createSingleReader(i, weightFile ) );
   }
-
 }
 
 PhotonMVAEstimatorRun2Phys14NonTrig::
-~PhotonMVAEstimatorRun2Phys14NonTrig(){
-  
-  _tmvaReaders.clear();
+~PhotonMVAEstimatorRun2Phys14NonTrig() {
 }
-
-void PhotonMVAEstimatorRun2Phys14NonTrig::setConsumes(edm::ConsumesCollector&& cc){
-
-  // All tokens for event content needed by this MVA
-  // Cluster shapes
-  _full5x5SigmaIEtaIEtaMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIEtaMap"));
-
-  _full5x5SigmaIEtaIPhiMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIPhiMap"));
-
-  _full5x5E1x3MapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E1x3Map"));
-
-  _full5x5E2x2MapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E2x2Map"));
-
-  _full5x5E2x5MaxMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E2x5MaxMap"));
-
-  _full5x5E5x5MapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E5x5Map"));
-
-  _esEffSigmaRRMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("esEffSigmaRRMap"));
-
-  // Isolations
-  _phoChargedIsolationToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("phoChargedIsolation"));
-
-  _phoPhotonIsolationToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("phoPhotonIsolation"));
-
-  _phoWorstChargedIsolationToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("phoWorstChargedIsolation"));
-
-  // Pileup
-  _rhoToken = cc.consumes<double> (_conf.getParameter<edm::InputTag>("rho"));
-  
-}
-
-void PhotonMVAEstimatorRun2Phys14NonTrig::getEventContent(const edm::Event& iEvent){
-
-  // Get the full5x5 and ES maps
-  iEvent.getByToken(_full5x5SigmaIEtaIEtaMapToken, _full5x5SigmaIEtaIEtaMap);
-  iEvent.getByToken(_full5x5SigmaIEtaIPhiMapToken, _full5x5SigmaIEtaIPhiMap);
-  iEvent.getByToken(_full5x5E1x3MapToken, _full5x5E1x3Map);
-  iEvent.getByToken(_full5x5E2x2MapToken, _full5x5E2x2Map);
-  iEvent.getByToken(_full5x5E2x5MaxMapToken, _full5x5E2x5MaxMap);
-  iEvent.getByToken(_full5x5E5x5MapToken, _full5x5E5x5Map);
-  iEvent.getByToken(_esEffSigmaRRMapToken, _esEffSigmaRRMap);
-
-  // Get the isolation maps
-  iEvent.getByToken(_phoChargedIsolationToken, _phoChargedIsolationMap);
-  iEvent.getByToken(_phoPhotonIsolationToken, _phoPhotonIsolationMap);
-  iEvent.getByToken(_phoWorstChargedIsolationToken, _phoWorstChargedIsolationMap);
-
-  // Get rho
-  iEvent.getByToken(_rhoToken,_rho);
-
-  // Make sure everything is retrieved successfully
-  if(! (_full5x5SigmaIEtaIEtaMap.isValid()
-	&& _full5x5SigmaIEtaIPhiMap.isValid()
-	&& _full5x5E1x3Map.isValid()
-	&& _full5x5E2x2Map.isValid()
-	&& _full5x5E2x5MaxMap.isValid()
-	&& _full5x5E5x5Map.isValid()
-	&& _esEffSigmaRRMap.isValid()
-	&& _phoChargedIsolationMap.isValid()
-	&& _phoPhotonIsolationMap.isValid()
-	&& _phoWorstChargedIsolationMap.isValid()
-	&& _rho.isValid() ) )
-    throw cms::Exception("MVA failure: ")
-      << "Failed to retrieve event content needed for this MVA" 
-      << std::endl
-      << "Check python MVA configuration file and make sure all needed"
-      << std::endl
-      << "producers are running upstream" << std::endl;
-}
-
 
 float PhotonMVAEstimatorRun2Phys14NonTrig::
-mvaValue( const edm::Ptr<reco::Candidate>& particle){
+mvaValue( const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const {
   
-  int iCategory = findCategory( particle );
-  fillMVAVariables( particle );  
-  constrainMVAVariables();
-  float result = _tmvaReaders.at(iCategory)->EvaluateMVA(_MethodName);
+  const int iCategory = findCategory( particle );
+  const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );  
+  const float result = _gbrForests.at(iCategory)->GetGradBoostClassifier(vars.data());
 
   // DEBUG
-  const bool debug = false;
+  constexpr bool debug = false;
   if( debug ){
     printf("Printout of the photon variable inputs for MVA:\n");
-    printf("  varPhi_           %f\n", _allMVAVars.varPhi         );
-    printf("  varR9_            %f\n", _allMVAVars.varR9          ); 
-    printf("  varSieie_         %f\n", _allMVAVars.varSieie       );
-    printf("  varSieip_         %f\n", _allMVAVars.varSieip       ); 
-    printf("  varE1x3overE5x5_  %f\n", _allMVAVars.varE1x3overE5x5); 
-    printf("  varE2x2overE5x5_  %f\n", _allMVAVars.varE2x2overE5x5); 
-    printf("  varE2x5overE5x5_  %f\n", _allMVAVars.varE2x5overE5x5); 
-    printf("  varSCEta_         %f\n", _allMVAVars.varSCEta       ); 
-    printf("  varRawE_          %f\n", _allMVAVars.varRawE        ); 
-    printf("  varSCEtaWidth_    %f\n", _allMVAVars.varSCEtaWidth  ); 
-    printf("  varSCPhiWidth_    %f\n", _allMVAVars.varSCPhiWidth  ); 
-    printf("  varRho_           %f\n", _allMVAVars.varRho         );
-    printf("  varPhoIsoRaw_     %f\n", _allMVAVars.varPhoIsoRaw   );
-    printf("  varChIsoRaw_      %f\n", _allMVAVars.varChIsoRaw    ); 
-    printf("  varWorstChRaw_    %f\n", _allMVAVars.varWorstChRaw  );
-    printf("  varESEnOverRawE_  %f\n", _allMVAVars.varESEnOverRawE); // for endcap MVA only
-    printf("  varESEffSigmaRR_  %f\n", _allMVAVars.varESEffSigmaRR); // for endcap MVA only
-    // The spectators
-    printf("  varPt_    %f\n", _allMVAVars.varPt          ); 
-    printf("  varEta_  %f\n", _allMVAVars.varEta         );
+    printf("  varPhi_           %f\n", vars[0]   );
+    printf("  varR9_            %f\n", vars[1]   ); 
+    printf("  varSieie_         %f\n", vars[2]   );
+    printf("  varSieip_         %f\n", vars[3]   ); 
+    printf("  varE1x3overE5x5_  %f\n", vars[4]   ); 
+    printf("  varE2x2overE5x5_  %f\n", vars[5]   ); 
+    printf("  varE2x5overE5x5_  %f\n", vars[6]   ); 
+    printf("  varSCEta_         %f\n", vars[7]   ); 
+    printf("  varRawE_          %f\n", vars[8]   ); 
+    printf("  varSCEtaWidth_    %f\n", vars[9]   ); 
+    printf("  varSCPhiWidth_    %f\n", vars[10]  ); 
+    printf("  varRho_           %f\n", vars[11]  );
+    printf("  varPhoIsoRaw_     %f\n", vars[12]  );
+    printf("  varChIsoRaw_      %f\n", vars[13]  ); 
+    printf("  varWorstChRaw_    %f\n", vars[14]  );
+    if( isEndcapCategory( iCategory ) ) {
+      printf("  varESEnOverRawE_  %f\n", vars[15]  ); // for endcap MVA only
+      printf("  varESEffSigmaRR_  %f\n", vars[16]  ); // for endcap MVA only
+      // The spectators
+      printf("  varPt_    %f\n", vars[17]          ); 
+      printf("  varEta_  %f\n",  vars[18]          );
+    } else {
+      // The spectators
+      printf("  varPt_    %f\n", vars[15]          ); 
+      printf("  varEta_  %f\n",  vars[16]          );
+    }    
   }
 
   return result;
 }
 
-int PhotonMVAEstimatorRun2Phys14NonTrig::findCategory( const edm::Ptr<reco::Candidate>& particle){
+int PhotonMVAEstimatorRun2Phys14NonTrig::findCategory( const edm::Ptr<reco::Candidate>& particle) const {
   
   // Try to cast the particle into a reco particle.
   // This should work for both reco and pat.
-  const edm::Ptr<reco::Photon> phoRecoPtr = ( edm::Ptr<reco::Photon> )particle;
+  const edm::Ptr<reco::Photon> phoRecoPtr(particle);
   if( phoRecoPtr.isNull() )
     throw cms::Exception("MVA failure: ")
       << " given particle is expected to be reco::Photon or pat::Photon," << std::endl
       << " but appears to be neither" << std::endl;
 
-  float eta = phoRecoPtr->superCluster()->eta();
+  const float eta = phoRecoPtr->superCluster()->eta();
 
   //
   // Determine the category
   //
   int  iCategory = UNDEFINED;
-  const float ebeeSplit = 1.479; // division between barrel and endcap
+  constexpr float ebeeSplit = 1.479; // division between barrel and endcap
 
-  if ( std::abs(eta) < ebeeSplit)  
+  if( std::abs(eta) < ebeeSplit )  
     iCategory = CAT_EB;
 
-  if (std::abs(eta) >= ebeeSplit) 
+  if( std::abs(eta) >= ebeeSplit ) 
     iCategory = CAT_EE;
 
   return iCategory;
 }
 
 bool PhotonMVAEstimatorRun2Phys14NonTrig::
-isEndcapCategory(int category ){
+isEndcapCategory(int category ) const {
 
   // For this specific MVA the function is trivial, but kept for possible
   // future evolution to an MVA with more categories in eta
@@ -198,63 +127,116 @@ isEndcapCategory(int category ){
 }
 
 
-TMVA::Reader *PhotonMVAEstimatorRun2Phys14NonTrig::
-createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
+std::unique_ptr<const GBRForest> PhotonMVAEstimatorRun2Phys14NonTrig::
+createSingleReader(const int iCategory, const edm::FileInPath &weightFile) {
 
   //
   // Create the reader  
   //
-  TMVA::Reader *tmpTMVAReader = new TMVA::Reader( "!Color:Silent:Error" );
+  TMVA::Reader tmpTMVAReader( "!Color:Silent:Error" );
 
   //
   // Configure all variables and spectators. Note: the order and names
   // must match what is found in the xml weights file!
   //
-
-  tmpTMVAReader->AddVariable("recoPhi"   , &_allMVAVars.varPhi);
-  tmpTMVAReader->AddVariable("r9"        , &_allMVAVars.varR9);
-  tmpTMVAReader->AddVariable("sieie_2012", &_allMVAVars.varSieie);
-  tmpTMVAReader->AddVariable("sieip_2012", &_allMVAVars.varSieip);
-  tmpTMVAReader->AddVariable("e1x3_2012/e5x5_2012"        , &_allMVAVars.varE1x3overE5x5);
-  tmpTMVAReader->AddVariable("e2x2_2012/e5x5_2012"        , &_allMVAVars.varE2x2overE5x5);
-  tmpTMVAReader->AddVariable("e2x5_2012/e5x5_2012"        , &_allMVAVars.varE2x5overE5x5);
-  tmpTMVAReader->AddVariable("recoSCEta" , &_allMVAVars.varSCEta);
-  tmpTMVAReader->AddVariable("rawE"      , &_allMVAVars.varRawE);
-  tmpTMVAReader->AddVariable("scEtaWidth", &_allMVAVars.varSCEtaWidth);
-  tmpTMVAReader->AddVariable("scPhiWidth", &_allMVAVars.varSCPhiWidth);
+  tmpTMVAReader.AddVariable("recoPhi"   , &_allMVAVars.varPhi);
+  tmpTMVAReader.AddVariable("r9"        , &_allMVAVars.varR9);
+  tmpTMVAReader.AddVariable("sieie_2012", &_allMVAVars.varSieie);
+  tmpTMVAReader.AddVariable("sieip_2012", &_allMVAVars.varSieip);
+  tmpTMVAReader.AddVariable("e1x3_2012/e5x5_2012"        , &_allMVAVars.varE1x3overE5x5);
+  tmpTMVAReader.AddVariable("e2x2_2012/e5x5_2012"        , &_allMVAVars.varE2x2overE5x5);
+  tmpTMVAReader.AddVariable("e2x5_2012/e5x5_2012"        , &_allMVAVars.varE2x5overE5x5);
+  tmpTMVAReader.AddVariable("recoSCEta" , &_allMVAVars.varSCEta);
+  tmpTMVAReader.AddVariable("rawE"      , &_allMVAVars.varRawE);
+  tmpTMVAReader.AddVariable("scEtaWidth", &_allMVAVars.varSCEtaWidth);
+  tmpTMVAReader.AddVariable("scPhiWidth", &_allMVAVars.varSCPhiWidth);
 
   // Endcap only variables
   if( isEndcapCategory(iCategory) ){
-    tmpTMVAReader->AddVariable("esEn/rawE" , &_allMVAVars.varESEnOverRawE);
-    tmpTMVAReader->AddVariable("esRR"      , &_allMVAVars.varESEffSigmaRR);
+    tmpTMVAReader.AddVariable("esEn/rawE" , &_allMVAVars.varESEnOverRawE);
+    tmpTMVAReader.AddVariable("esRR"      , &_allMVAVars.varESEffSigmaRR);
   }
 
   // Pileup
-  tmpTMVAReader->AddVariable("rho"       , &_allMVAVars.varRho);
+  tmpTMVAReader.AddVariable("rho"       , &_allMVAVars.varRho);
 
   // Isolations
-  tmpTMVAReader->AddVariable("phoIsoRaw" , &_allMVAVars.varPhoIsoRaw);
-  tmpTMVAReader->AddVariable("chIsoRaw"  , &_allMVAVars.varChIsoRaw);
-  tmpTMVAReader->AddVariable("chWorstRaw", &_allMVAVars.varWorstChRaw);
+  tmpTMVAReader.AddVariable("phoIsoRaw" , &_allMVAVars.varPhoIsoRaw);
+  tmpTMVAReader.AddVariable("chIsoRaw"  , &_allMVAVars.varChIsoRaw);
+  tmpTMVAReader.AddVariable("chWorstRaw", &_allMVAVars.varWorstChRaw);
 
   // Spectators
-  tmpTMVAReader->AddSpectator("recoPt" , &_allMVAVars.varPt);
-  tmpTMVAReader->AddSpectator("recoEta", &_allMVAVars.varEta);
+  tmpTMVAReader.AddSpectator("recoPt" , &_allMVAVars.varPt);
+  tmpTMVAReader.AddSpectator("recoEta", &_allMVAVars.varEta);
 
   //
   // Book the method and set up the weights file
   //
-  tmpTMVAReader->BookMVA(_MethodName , weightFile.fullPath() );
+  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
 
-  return tmpTMVAReader;
+  return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
 }
 
 // A function that should work on both pat and reco objects
-void PhotonMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const edm::Ptr<reco::Candidate>& particle){
+std::vector<float> PhotonMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const {
+  // 
+  // Declare all value maps corresponding to the above tokens
+  //
+  edm::Handle<edm::ValueMap<float> > full5x5SigmaIEtaIEtaMap;
+  edm::Handle<edm::ValueMap<float> > full5x5SigmaIEtaIPhiMap;
+  edm::Handle<edm::ValueMap<float> > full5x5E1x3Map;
+  edm::Handle<edm::ValueMap<float> > full5x5E2x2Map;
+  edm::Handle<edm::ValueMap<float> > full5x5E2x5MaxMap;
+  edm::Handle<edm::ValueMap<float> > full5x5E5x5Map;
+  edm::Handle<edm::ValueMap<float> > esEffSigmaRRMap;
+  //
+  edm::Handle<edm::ValueMap<float> > phoChargedIsolationMap;
+  edm::Handle<edm::ValueMap<float> > phoPhotonIsolationMap;
+  edm::Handle<edm::ValueMap<float> > phoWorstChargedIsolationMap;
+
+  // Rho will be pulled from the event content  
+  edm::Handle<double> rho;
+  
+  // Get the full5x5 and ES maps
+  iEvent.getByLabel(_full5x5SigmaIEtaIEtaMapLabel, full5x5SigmaIEtaIEtaMap);
+  iEvent.getByLabel(_full5x5SigmaIEtaIPhiMapLabel, full5x5SigmaIEtaIPhiMap);
+  iEvent.getByLabel(_full5x5E1x3MapLabel, full5x5E1x3Map);
+  iEvent.getByLabel(_full5x5E2x2MapLabel, full5x5E2x2Map);
+  iEvent.getByLabel(_full5x5E2x5MaxMapLabel, full5x5E2x5MaxMap);
+  iEvent.getByLabel(_full5x5E5x5MapLabel, full5x5E5x5Map);
+  iEvent.getByLabel(_esEffSigmaRRMapLabel, esEffSigmaRRMap);
+
+  // Get the isolation maps
+  iEvent.getByLabel(_phoChargedIsolationLabel, phoChargedIsolationMap);
+  iEvent.getByLabel(_phoPhotonIsolationLabel, phoPhotonIsolationMap);
+  iEvent.getByLabel(_phoWorstChargedIsolationLabel, phoWorstChargedIsolationMap);
+
+  // Get rho
+  iEvent.getByLabel(_rhoLabel,rho);
+
+  // Make sure everything is retrieved successfully
+  if(! (full5x5SigmaIEtaIEtaMap.isValid()
+	&& full5x5SigmaIEtaIPhiMap.isValid()
+	&& full5x5E1x3Map.isValid()
+	&& full5x5E2x2Map.isValid()
+	&& full5x5E2x5MaxMap.isValid()
+	&& full5x5E5x5Map.isValid()
+	&& esEffSigmaRRMap.isValid()
+	&& phoChargedIsolationMap.isValid()
+	&& phoPhotonIsolationMap.isValid()
+	&& phoWorstChargedIsolationMap.isValid()
+	&& rho.isValid() ) )
+    throw cms::Exception("MVA failure: ")
+      << "Failed to retrieve event content needed for this MVA" 
+      << std::endl
+      << "Check python MVA configuration file and make sure all needed"
+      << std::endl
+      << "producers are running upstream" << std::endl;
 
   // Try to cast the particle into a reco particle.
   // This should work for both reco and pat.
   const edm::Ptr<reco::Photon> phoRecoPtr = ( edm::Ptr<reco::Photon> )particle;
+  AllVariables allMVAVars;
   if( phoRecoPtr.isNull() )
     throw cms::Exception("MVA failure: ")
       << " given particle is expected to be reco::Photon or pat::Photon," << std::endl
@@ -264,35 +246,83 @@ void PhotonMVAEstimatorRun2Phys14NonTrig::fillMVAVariables(const edm::Ptr<reco::
   auto superCluster = phoRecoPtr->superCluster();
   // Full 5x5 cluster shapes. We could take some of this directly from
   // the photon object, but some of these are not available.
-  float e1x3 = (*_full5x5E1x3Map   )[ phoRecoPtr ];
-  float e2x2 = (*_full5x5E2x2Map   )[ phoRecoPtr ];
-  float e2x5 = (*_full5x5E2x5MaxMap)[ phoRecoPtr ];
-  float e5x5 = (*_full5x5E5x5Map   )[ phoRecoPtr ];
+  float e1x3 = (*full5x5E1x3Map   )[ phoRecoPtr ];
+  float e2x2 = (*full5x5E2x2Map   )[ phoRecoPtr ];
+  float e2x5 = (*full5x5E2x5MaxMap)[ phoRecoPtr ];
+  float e5x5 = (*full5x5E5x5Map   )[ phoRecoPtr ];
 
-  _allMVAVars.varPhi          = phoRecoPtr->phi();
-  _allMVAVars.varR9           = phoRecoPtr->r9() ;
-  _allMVAVars.varSieie        = (*_full5x5SigmaIEtaIEtaMap)[ phoRecoPtr ]; // in principle, in the photon object as well
-  _allMVAVars.varSieip        = (*_full5x5SigmaIEtaIPhiMap)[ phoRecoPtr ]; // not in the photon object
-  _allMVAVars.varE1x3overE5x5 = e1x3/e5x5;
-  _allMVAVars.varE2x2overE5x5 = e2x2/e5x5;
-  _allMVAVars.varE2x5overE5x5 = e2x5/e5x5;
-  _allMVAVars.varSCEta        = superCluster->eta(); 
-  _allMVAVars.varRawE         = superCluster->rawEnergy(); 
-  _allMVAVars.varSCEtaWidth   = superCluster->etaWidth(); 
-  _allMVAVars.varSCPhiWidth   = superCluster->phiWidth(); 
-  _allMVAVars.varESEnOverRawE = superCluster->preshowerEnergy() / superCluster->rawEnergy();
-  _allMVAVars.varESEffSigmaRR = (*_esEffSigmaRRMap)[ phoRecoPtr ];
-  _allMVAVars.varRho          = *_rho; 
-  _allMVAVars.varPhoIsoRaw    = (*_phoPhotonIsolationMap)[phoRecoPtr];  
-  _allMVAVars.varChIsoRaw     = (*_phoChargedIsolationMap)[phoRecoPtr];
-  _allMVAVars.varWorstChRaw   = (*_phoWorstChargedIsolationMap)[phoRecoPtr];
+  allMVAVars.varPhi          = phoRecoPtr->phi();
+  allMVAVars.varR9           = phoRecoPtr->r9() ;
+  allMVAVars.varSieie        = (*full5x5SigmaIEtaIEtaMap)[ phoRecoPtr ]; // in principle, in the photon object as well
+  allMVAVars.varSieip        = (*full5x5SigmaIEtaIPhiMap)[ phoRecoPtr ]; // not in the photon object
+  allMVAVars.varE1x3overE5x5 = e1x3/e5x5;
+  allMVAVars.varE2x2overE5x5 = e2x2/e5x5;
+  allMVAVars.varE2x5overE5x5 = e2x5/e5x5;
+  allMVAVars.varSCEta        = superCluster->eta(); 
+  allMVAVars.varRawE         = superCluster->rawEnergy(); 
+  allMVAVars.varSCEtaWidth   = superCluster->etaWidth(); 
+  allMVAVars.varSCPhiWidth   = superCluster->phiWidth(); 
+  allMVAVars.varESEnOverRawE = superCluster->preshowerEnergy() / superCluster->rawEnergy();
+  allMVAVars.varESEffSigmaRR = (*esEffSigmaRRMap)[ phoRecoPtr ];
+  allMVAVars.varRho          = *rho; 
+  allMVAVars.varPhoIsoRaw    = (*phoPhotonIsolationMap)[phoRecoPtr];  
+  allMVAVars.varChIsoRaw     = (*phoChargedIsolationMap)[phoRecoPtr];
+  allMVAVars.varWorstChRaw   = (*phoWorstChargedIsolationMap)[phoRecoPtr];
   // Declare spectator vars
-  _allMVAVars.varPt = phoRecoPtr->pt(); 
-  _allMVAVars.varEta = phoRecoPtr->eta();
+  allMVAVars.varPt = phoRecoPtr->pt(); 
+  allMVAVars.varEta = phoRecoPtr->eta();
 
+  constrainMVAVariables(allMVAVars);
+
+  std::vector<float> vars;
+  if( isEndcapCategory( findCategory( particle ) ) ) {
+    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+                                       allMVAVars.varR9,
+                                       allMVAVars.varSieie,
+                                       allMVAVars.varSieip,
+                                       allMVAVars.varE1x3overE5x5,
+                                       allMVAVars.varE2x2overE5x5,
+                                       allMVAVars.varE2x5overE5x5,
+                                       allMVAVars.varSCEta,
+                                       allMVAVars.varRawE,
+                                       allMVAVars.varSCEtaWidth,
+                                       allMVAVars.varSCPhiWidth,
+                                       allMVAVars.varESEnOverRawE,
+                                       allMVAVars.varESEffSigmaRR,
+                                       allMVAVars.varRho,
+                                       allMVAVars.varPhoIsoRaw,
+                                       allMVAVars.varChIsoRaw,
+                                       allMVAVars.varWorstChRaw,
+                                       // Declare spectator vars
+                                       allMVAVars.varPt,
+                                       allMVAVars.varEta) 
+                      ); 
+  } else {
+    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+                                       allMVAVars.varR9,
+                                       allMVAVars.varSieie,
+                                       allMVAVars.varSieip,
+                                       allMVAVars.varE1x3overE5x5,
+                                       allMVAVars.varE2x2overE5x5,
+                                       allMVAVars.varE2x5overE5x5,
+                                       allMVAVars.varSCEta,
+                                       allMVAVars.varRawE,
+                                       allMVAVars.varSCEtaWidth,
+                                       allMVAVars.varSCPhiWidth,
+                                       allMVAVars.varRho,
+                                       allMVAVars.varPhoIsoRaw,
+                                       allMVAVars.varChIsoRaw,
+                                       allMVAVars.varWorstChRaw,
+                                       // Declare spectator vars
+                                       allMVAVars.varPt,
+                                       allMVAVars.varEta) 
+                      );
+  }
+
+  return vars;
 }
 
-void PhotonMVAEstimatorRun2Phys14NonTrig::constrainMVAVariables(){
+void PhotonMVAEstimatorRun2Phys14NonTrig::constrainMVAVariables(AllVariables&) const {
 
   // Check that variables do not have crazy values
   
@@ -302,3 +332,16 @@ void PhotonMVAEstimatorRun2Phys14NonTrig::constrainMVAVariables(){
 
 }
 
+void PhotonMVAEstimatorRun2Phys14NonTrig::setConsumes(edm::ConsumesCollector&& cc) const {
+  cc.consumes<edm::ValueMap<float> >(_full5x5SigmaIEtaIEtaMapLabel);
+  cc.consumes<edm::ValueMap<float> >(_full5x5SigmaIEtaIPhiMapLabel); 
+  cc.consumes<edm::ValueMap<float> >(_full5x5E1x3MapLabel); 
+  cc.consumes<edm::ValueMap<float> >(_full5x5E2x2MapLabel);
+  cc.consumes<edm::ValueMap<float> >(_full5x5E2x5MaxMapLabel);
+  cc.consumes<edm::ValueMap<float> >(_full5x5E5x5MapLabel);
+  cc.consumes<edm::ValueMap<float> >(_esEffSigmaRRMapLabel);
+  cc.consumes<edm::ValueMap<float> >(_phoChargedIsolationLabel);
+  cc.consumes<edm::ValueMap<float> >(_phoPhotonIsolationLabel);
+  cc.consumes<edm::ValueMap<float> >( _phoWorstChargedIsolationLabel);
+  cc.consumes<double>(_rhoLabel);
+}

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
@@ -2,8 +2,22 @@
 
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
+#include "TMVA/MethodBDT.h"
+
 PhotonMVAEstimatorRun2Spring15NonTrig::PhotonMVAEstimatorRun2Spring15NonTrig(const edm::ParameterSet& conf):
-  AnyMVAEstimatorRun2Base(conf)
+  AnyMVAEstimatorRun2Base(conf),
+  _MethodName("BDTG method"),
+  _full5x5SigmaIEtaIEtaMapLabel(conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIEtaMap")), 
+  _full5x5SigmaIEtaIPhiMapLabel(conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIPhiMap")), 
+  _full5x5E1x3MapLabel(conf.getParameter<edm::InputTag>("full5x5E1x3Map")), 
+  _full5x5E2x2MapLabel(conf.getParameter<edm::InputTag>("full5x5E2x2Map")), 
+  _full5x5E2x5MaxMapLabel(conf.getParameter<edm::InputTag>("full5x5E2x5MaxMap")), 
+  _full5x5E5x5MapLabel(conf.getParameter<edm::InputTag>("full5x5E5x5Map")), 
+  _esEffSigmaRRMapLabel(conf.getParameter<edm::InputTag>("esEffSigmaRRMap")), 
+  _phoChargedIsolationLabel(conf.getParameter<edm::InputTag>("phoChargedIsolation")), 
+  _phoPhotonIsolationLabel(conf.getParameter<edm::InputTag>("phoPhotonIsolation")), 
+  _phoWorstChargedIsolationLabel(conf.getParameter<edm::InputTag>("phoWorstChargedIsolation")), 
+  _rhoLabel(conf.getParameter<edm::InputTag>("rho"))
 {
 
   //
@@ -16,11 +30,11 @@ PhotonMVAEstimatorRun2Spring15NonTrig::PhotonMVAEstimatorRun2Spring15NonTrig(con
     throw cms::Exception("MVA config failure: ")
       << "wrong number of weightfiles" << std::endl;
 
-  _tmvaReaders.clear();
+  _gbrForests.clear();
   // The method name is just a key to retrieve this method later, it is not
   // a control parameter for a reader (the full definition of the MVA type and
   // everything else comes from the xml weight files).
-  _MethodName = "BDTG method"; 
+   
   // Create a TMVA reader object for each category
   for(int i=0; i<nCategories; i++){
 
@@ -28,8 +42,7 @@ PhotonMVAEstimatorRun2Spring15NonTrig::PhotonMVAEstimatorRun2Spring15NonTrig(con
     // when the vector clear() is called in the destructor
 
     edm::FileInPath weightFile( weightFileNames[i] );
-    _tmvaReaders.push_back( std::unique_ptr<TMVA::Reader> 
-			    ( createSingleReader(i, weightFile ) ) );
+    _gbrForests.push_back( createSingleReader(i, weightFile ) );
 
   }
 
@@ -37,128 +50,52 @@ PhotonMVAEstimatorRun2Spring15NonTrig::PhotonMVAEstimatorRun2Spring15NonTrig(con
 
 PhotonMVAEstimatorRun2Spring15NonTrig::
 ~PhotonMVAEstimatorRun2Spring15NonTrig(){
-  
-  _tmvaReaders.clear();
 }
-
-void PhotonMVAEstimatorRun2Spring15NonTrig::setConsumes(edm::ConsumesCollector&& cc){
-
-  // All tokens for event content needed by this MVA
-  // Cluster shapes
-  _full5x5SigmaIEtaIEtaMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIEtaMap"));
-
-  _full5x5SigmaIEtaIPhiMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5SigmaIEtaIPhiMap"));
-
-  _full5x5E1x3MapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E1x3Map"));
-
-  _full5x5E2x2MapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E2x2Map"));
-
-  _full5x5E2x5MaxMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E2x5MaxMap"));
-
-  _full5x5E5x5MapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("full5x5E5x5Map"));
-
-  _esEffSigmaRRMapToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("esEffSigmaRRMap"));
-
-  // Isolations
-  _phoChargedIsolationToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("phoChargedIsolation"));
-
-  _phoPhotonIsolationToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("phoPhotonIsolation"));
-
-  _phoWorstChargedIsolationToken = cc.consumes <edm::ValueMap<float> >
-    (_conf.getParameter<edm::InputTag>("phoWorstChargedIsolation"));
-
-  // Pileup
-  _rhoToken = cc.consumes<double> (_conf.getParameter<edm::InputTag>("rho"));
-  
-}
-
-void PhotonMVAEstimatorRun2Spring15NonTrig::getEventContent(const edm::Event& iEvent){
-
-  // Get the full5x5 and ES maps
-  iEvent.getByToken(_full5x5SigmaIEtaIEtaMapToken, _full5x5SigmaIEtaIEtaMap);
-  iEvent.getByToken(_full5x5SigmaIEtaIPhiMapToken, _full5x5SigmaIEtaIPhiMap);
-  iEvent.getByToken(_full5x5E1x3MapToken, _full5x5E1x3Map);
-  iEvent.getByToken(_full5x5E2x2MapToken, _full5x5E2x2Map);
-  iEvent.getByToken(_full5x5E2x5MaxMapToken, _full5x5E2x5MaxMap);
-  iEvent.getByToken(_full5x5E5x5MapToken, _full5x5E5x5Map);
-  iEvent.getByToken(_esEffSigmaRRMapToken, _esEffSigmaRRMap);
-
-  // Get the isolation maps
-  iEvent.getByToken(_phoChargedIsolationToken, _phoChargedIsolationMap);
-  iEvent.getByToken(_phoPhotonIsolationToken, _phoPhotonIsolationMap);
-  iEvent.getByToken(_phoWorstChargedIsolationToken, _phoWorstChargedIsolationMap);
-
-  // Get rho
-  iEvent.getByToken(_rhoToken,_rho);
-
-  // Make sure everything is retrieved successfully
-  if(! (_full5x5SigmaIEtaIEtaMap.isValid()
-	&& _full5x5SigmaIEtaIPhiMap.isValid()
-	&& _full5x5E1x3Map.isValid()
-	&& _full5x5E2x2Map.isValid()
-	&& _full5x5E2x5MaxMap.isValid()
-	&& _full5x5E5x5Map.isValid()
-	&& _esEffSigmaRRMap.isValid()
-	&& _phoChargedIsolationMap.isValid()
-	&& _phoPhotonIsolationMap.isValid()
-	&& _phoWorstChargedIsolationMap.isValid()
-	&& _rho.isValid() ) )
-    throw cms::Exception("MVA failure: ")
-      << "Failed to retrieve event content needed for this MVA" 
-      << std::endl
-      << "Check python MVA configuration file and make sure all needed"
-      << std::endl
-      << "producers are running upstream" << std::endl;
-}
-
 
 float PhotonMVAEstimatorRun2Spring15NonTrig::
-mvaValue( const edm::Ptr<reco::Candidate>& particle){
+mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const {  
+
+  const int iCategory = findCategory( particle );
+  const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );  
   
-  int iCategory = findCategory( particle );
-  fillMVAVariables( particle );  
-  constrainMVAVariables();
-  float result = _tmvaReaders.at(iCategory)->EvaluateMVA(_MethodName);
+  const float result = _gbrForests.at(iCategory)->GetGradBoostClassifier(vars.data());
 
   // DEBUG
   const bool debug = false;
   if( debug ){
     printf("Printout of the photon variable inputs for MVA:\n");
-    printf("  varPhi_           %f\n", _allMVAVars.varPhi         );
-    printf("  varR9_            %f\n", _allMVAVars.varR9          ); 
-    printf("  varSieie_         %f\n", _allMVAVars.varSieie       );
-    printf("  varSieip_         %f\n", _allMVAVars.varSieip       ); 
-    printf("  varE1x3overE5x5_  %f\n", _allMVAVars.varE1x3overE5x5); 
-    printf("  varE2x2overE5x5_  %f\n", _allMVAVars.varE2x2overE5x5); 
-    printf("  varE2x5overE5x5_  %f\n", _allMVAVars.varE2x5overE5x5); 
-    printf("  varSCEta_         %f\n", _allMVAVars.varSCEta       ); 
-    printf("  varRawE_          %f\n", _allMVAVars.varRawE        ); 
-    printf("  varSCEtaWidth_    %f\n", _allMVAVars.varSCEtaWidth  ); 
-    printf("  varSCPhiWidth_    %f\n", _allMVAVars.varSCPhiWidth  ); 
-    printf("  varRho_           %f\n", _allMVAVars.varRho         );
-    printf("  varPhoIsoRaw_     %f\n", _allMVAVars.varPhoIsoRaw   );
-    printf("  varChIsoRaw_      %f\n", _allMVAVars.varChIsoRaw    ); 
-    printf("  varWorstChRaw_    %f\n", _allMVAVars.varWorstChRaw  );
-    printf("  varESEnOverRawE_  %f\n", _allMVAVars.varESEnOverRawE); // for endcap MVA only
-    printf("  varESEffSigmaRR_  %f\n", _allMVAVars.varESEffSigmaRR); // for endcap MVA only
-    // The spectators
-    printf("  varPt_    %f\n", _allMVAVars.varPt          ); 
-    printf("  varEta_  %f\n", _allMVAVars.varEta         );
+    printf("  varPhi_           %f\n", vars[0]   );
+    printf("  varR9_            %f\n", vars[1]   ); 
+    printf("  varSieie_         %f\n", vars[2]   );
+    printf("  varSieip_         %f\n", vars[3]   ); 
+    printf("  varE1x3overE5x5_  %f\n", vars[4]   ); 
+    printf("  varE2x2overE5x5_  %f\n", vars[5]   ); 
+    printf("  varE2x5overE5x5_  %f\n", vars[6]   ); 
+    printf("  varSCEta_         %f\n", vars[7]   ); 
+    printf("  varRawE_          %f\n", vars[8]   ); 
+    printf("  varSCEtaWidth_    %f\n", vars[9]   ); 
+    printf("  varSCPhiWidth_    %f\n", vars[10]  ); 
+    printf("  varRho_           %f\n", vars[11]  );
+    printf("  varPhoIsoRaw_     %f\n", vars[12]  );
+    printf("  varChIsoRaw_      %f\n", vars[13]  ); 
+    printf("  varWorstChRaw_    %f\n", vars[14]  );
+    if( isEndcapCategory( iCategory ) ) {
+      printf("  varESEnOverRawE_  %f\n", vars[15]  ); // for endcap MVA only
+      printf("  varESEffSigmaRR_  %f\n", vars[16]  ); // for endcap MVA only
+      // The spectators
+      printf("  varPt_    %f\n", vars[17]          ); 
+      printf("  varEta_  %f\n",  vars[18]          );
+    } else {
+      // The spectators
+      printf("  varPt_    %f\n", vars[15]          ); 
+      printf("  varEta_  %f\n",  vars[16]          );
+    }    
   }
-
+  
   return result;
 }
 
-int PhotonMVAEstimatorRun2Spring15NonTrig::findCategory( const edm::Ptr<reco::Candidate>& particle){
+int PhotonMVAEstimatorRun2Spring15NonTrig::findCategory( const edm::Ptr<reco::Candidate>& particle) const {
   
   // Try to cast the particle into a reco particle.
   // This should work for both reco and pat.
@@ -186,7 +123,7 @@ int PhotonMVAEstimatorRun2Spring15NonTrig::findCategory( const edm::Ptr<reco::Ca
 }
 
 bool PhotonMVAEstimatorRun2Spring15NonTrig::
-isEndcapCategory(int category ){
+isEndcapCategory(int category) const {
 
   // For this specific MVA the function is trivial, but kept for possible
   // future evolution to an MVA with more categories in eta
@@ -198,63 +135,118 @@ isEndcapCategory(int category ){
 }
 
 
-TMVA::Reader *PhotonMVAEstimatorRun2Spring15NonTrig::
+std::unique_ptr<const GBRForest> PhotonMVAEstimatorRun2Spring15NonTrig::
 createSingleReader(const int iCategory, const edm::FileInPath &weightFile){
 
   //
   // Create the reader  
   //
-  TMVA::Reader *tmpTMVAReader = new TMVA::Reader( "!Color:Silent:Error" );
+  TMVA::Reader tmpTMVAReader( "!Color:Silent:Error" );
 
   //
   // Configure all variables and spectators. Note: the order and names
   // must match what is found in the xml weights file!
   //
 
-  tmpTMVAReader->AddVariable("recoPhi"   , &_allMVAVars.varPhi);
-  tmpTMVAReader->AddVariable("r9"        , &_allMVAVars.varR9);
-  tmpTMVAReader->AddVariable("sieieFull5x5", &_allMVAVars.varSieie);
-  tmpTMVAReader->AddVariable("sieipFull5x5", &_allMVAVars.varSieip);
-  tmpTMVAReader->AddVariable("e1x3Full5x5/e5x5Full5x5"        , &_allMVAVars.varE1x3overE5x5);
-  tmpTMVAReader->AddVariable("e2x2Full5x5/e5x5Full5x5"        , &_allMVAVars.varE2x2overE5x5);
-  tmpTMVAReader->AddVariable("e2x5Full5x5/e5x5Full5x5"        , &_allMVAVars.varE2x5overE5x5);
-  tmpTMVAReader->AddVariable("recoSCEta" , &_allMVAVars.varSCEta);
-  tmpTMVAReader->AddVariable("rawE"      , &_allMVAVars.varRawE);
-  tmpTMVAReader->AddVariable("scEtaWidth", &_allMVAVars.varSCEtaWidth);
-  tmpTMVAReader->AddVariable("scPhiWidth", &_allMVAVars.varSCPhiWidth);
+  tmpTMVAReader.AddVariable("recoPhi"   , &_allMVAVars.varPhi);
+  tmpTMVAReader.AddVariable("r9"        , &_allMVAVars.varR9);
+  tmpTMVAReader.AddVariable("sieieFull5x5", &_allMVAVars.varSieie);
+  tmpTMVAReader.AddVariable("sieipFull5x5", &_allMVAVars.varSieip);
+  tmpTMVAReader.AddVariable("e1x3Full5x5/e5x5Full5x5", &_allMVAVars.varE1x3overE5x5);
+  tmpTMVAReader.AddVariable("e2x2Full5x5/e5x5Full5x5", &_allMVAVars.varE2x2overE5x5);
+  tmpTMVAReader.AddVariable("e2x5Full5x5/e5x5Full5x5", &_allMVAVars.varE2x5overE5x5);
+  tmpTMVAReader.AddVariable("recoSCEta" , &_allMVAVars.varSCEta);
+  tmpTMVAReader.AddVariable("rawE"      , &_allMVAVars.varRawE);
+  tmpTMVAReader.AddVariable("scEtaWidth", &_allMVAVars.varSCEtaWidth);
+  tmpTMVAReader.AddVariable("scPhiWidth", &_allMVAVars.varSCPhiWidth);
 
   // Endcap only variables
   if( isEndcapCategory(iCategory) ){
-    tmpTMVAReader->AddVariable("esEn/rawE" , &_allMVAVars.varESEnOverRawE);
-    tmpTMVAReader->AddVariable("esRR"      , &_allMVAVars.varESEffSigmaRR);
+    tmpTMVAReader.AddVariable("esEn/rawE" , &_allMVAVars.varESEnOverRawE);
+    tmpTMVAReader.AddVariable("esRR"      , &_allMVAVars.varESEffSigmaRR);
   }
 
   // Pileup
-  tmpTMVAReader->AddVariable("rho"       , &_allMVAVars.varRho);
+  tmpTMVAReader.AddVariable("rho"       , &_allMVAVars.varRho);
 
   // Isolations
-  tmpTMVAReader->AddVariable("phoIsoRaw" , &_allMVAVars.varPhoIsoRaw);
-  tmpTMVAReader->AddVariable("chIsoRaw"  , &_allMVAVars.varChIsoRaw);
-  tmpTMVAReader->AddVariable("chWorstRaw", &_allMVAVars.varWorstChRaw);
+  tmpTMVAReader.AddVariable("phoIsoRaw" , &_allMVAVars.varPhoIsoRaw);
+  tmpTMVAReader.AddVariable("chIsoRaw"  , &_allMVAVars.varChIsoRaw);
+  tmpTMVAReader.AddVariable("chWorstRaw", &_allMVAVars.varWorstChRaw);
 
   // Spectators
-  tmpTMVAReader->AddSpectator("recoPt" , &_allMVAVars.varPt);
-  tmpTMVAReader->AddSpectator("recoEta", &_allMVAVars.varEta);
+  tmpTMVAReader.AddSpectator("recoPt" , &_allMVAVars.varPt);
+  tmpTMVAReader.AddSpectator("recoEta", &_allMVAVars.varEta);
 
   //
   // Book the method and set up the weights file
   //
-  tmpTMVAReader->BookMVA(_MethodName , weightFile.fullPath() );
+  std::unique_ptr<TMVA::IMethod> temp( tmpTMVAReader.BookMVA(_MethodName , weightFile.fullPath() ) );
 
-  return tmpTMVAReader;
+  return std::unique_ptr<const GBRForest>( new GBRForest( dynamic_cast<TMVA::MethodBDT*>( tmpTMVAReader.FindMVA(_MethodName) ) ) );
+
 }
 
 // A function that should work on both pat and reco objects
-void PhotonMVAEstimatorRun2Spring15NonTrig::fillMVAVariables(const edm::Ptr<reco::Candidate>& particle){
+std::vector<float> PhotonMVAEstimatorRun2Spring15NonTrig::fillMVAVariables(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) const {
+  
+  // 
+  // Declare all value maps corresponding to the above tokens
+  //
+  edm::Handle<edm::ValueMap<float> > full5x5SigmaIEtaIEtaMap;
+  edm::Handle<edm::ValueMap<float> > full5x5SigmaIEtaIPhiMap;
+  edm::Handle<edm::ValueMap<float> > full5x5E1x3Map;
+  edm::Handle<edm::ValueMap<float> > full5x5E2x2Map;
+  edm::Handle<edm::ValueMap<float> > full5x5E2x5MaxMap;
+  edm::Handle<edm::ValueMap<float> > full5x5E5x5Map;
+  edm::Handle<edm::ValueMap<float> > esEffSigmaRRMap;
+  //
+  edm::Handle<edm::ValueMap<float> > phoChargedIsolationMap;
+  edm::Handle<edm::ValueMap<float> > phoPhotonIsolationMap;
+  edm::Handle<edm::ValueMap<float> > phoWorstChargedIsolationMap;
+
+  // Rho will be pulled from the event content
+  edm::Handle<double> rho;
+
+  // Get the full5x5 and ES maps
+  iEvent.getByLabel(_full5x5SigmaIEtaIEtaMapLabel, full5x5SigmaIEtaIEtaMap);
+  iEvent.getByLabel(_full5x5SigmaIEtaIPhiMapLabel, full5x5SigmaIEtaIPhiMap);
+  iEvent.getByLabel(_full5x5E1x3MapLabel, full5x5E1x3Map);
+  iEvent.getByLabel(_full5x5E2x2MapLabel, full5x5E2x2Map);
+  iEvent.getByLabel(_full5x5E2x5MaxMapLabel, full5x5E2x5MaxMap);
+  iEvent.getByLabel(_full5x5E5x5MapLabel, full5x5E5x5Map);
+  iEvent.getByLabel(_esEffSigmaRRMapLabel, esEffSigmaRRMap);
+
+  // Get the isolation maps
+  iEvent.getByLabel(_phoChargedIsolationLabel, phoChargedIsolationMap);
+  iEvent.getByLabel(_phoPhotonIsolationLabel, phoPhotonIsolationMap);
+  iEvent.getByLabel(_phoWorstChargedIsolationLabel, phoWorstChargedIsolationMap);
+
+  // Get rho
+  iEvent.getByLabel(_rhoLabel,rho);
+
+  // Make sure everything is retrieved successfully
+  if(! (full5x5SigmaIEtaIEtaMap.isValid()
+	&& full5x5SigmaIEtaIPhiMap.isValid()
+	&& full5x5E1x3Map.isValid()
+	&& full5x5E2x2Map.isValid()
+	&& full5x5E2x5MaxMap.isValid()
+	&& full5x5E5x5Map.isValid()
+	&& esEffSigmaRRMap.isValid()
+	&& phoChargedIsolationMap.isValid()
+	&& phoPhotonIsolationMap.isValid()
+	&& phoWorstChargedIsolationMap.isValid()
+	&& rho.isValid() ) )
+    throw cms::Exception("MVA failure: ")
+      << "Failed to retrieve event content needed for this MVA" 
+      << std::endl
+      << "Check python MVA configuration file and make sure all needed"
+      << std::endl
+      << "producers are running upstream" << std::endl;
 
   // Try to cast the particle into a reco particle.
   // This should work for both reco and pat.
-  const edm::Ptr<reco::Photon> phoRecoPtr = ( edm::Ptr<reco::Photon> )particle;
+  const edm::Ptr<reco::Photon> phoRecoPtr(particle);
   if( phoRecoPtr.isNull() )
     throw cms::Exception("MVA failure: ")
       << " given particle is expected to be reco::Photon or pat::Photon," << std::endl
@@ -264,35 +256,84 @@ void PhotonMVAEstimatorRun2Spring15NonTrig::fillMVAVariables(const edm::Ptr<reco
   auto superCluster = phoRecoPtr->superCluster();
   // Full 5x5 cluster shapes. We could take some of this directly from
   // the photon object, but some of these are not available.
-  float e1x3 = (*_full5x5E1x3Map   )[ phoRecoPtr ];
-  float e2x2 = (*_full5x5E2x2Map   )[ phoRecoPtr ];
-  float e2x5 = (*_full5x5E2x5MaxMap)[ phoRecoPtr ];
-  float e5x5 = (*_full5x5E5x5Map   )[ phoRecoPtr ];
+  const float e1x3 = (*full5x5E1x3Map   )[ phoRecoPtr ];
+  const float e2x2 = (*full5x5E2x2Map   )[ phoRecoPtr ];
+  const float e2x5 = (*full5x5E2x5MaxMap)[ phoRecoPtr ];
+  const float e5x5 = (*full5x5E5x5Map   )[ phoRecoPtr ];
 
-  _allMVAVars.varPhi          = phoRecoPtr->phi();
-  _allMVAVars.varR9           = phoRecoPtr->r9() ;
-  _allMVAVars.varSieie        = (*_full5x5SigmaIEtaIEtaMap)[ phoRecoPtr ]; // in principle, in the photon object as well
-  _allMVAVars.varSieip        = (*_full5x5SigmaIEtaIPhiMap)[ phoRecoPtr ]; // not in the photon object
-  _allMVAVars.varE1x3overE5x5 = e1x3/e5x5;
-  _allMVAVars.varE2x2overE5x5 = e2x2/e5x5;
-  _allMVAVars.varE2x5overE5x5 = e2x5/e5x5;
-  _allMVAVars.varSCEta        = superCluster->eta(); 
-  _allMVAVars.varRawE         = superCluster->rawEnergy(); 
-  _allMVAVars.varSCEtaWidth   = superCluster->etaWidth(); 
-  _allMVAVars.varSCPhiWidth   = superCluster->phiWidth(); 
-  _allMVAVars.varESEnOverRawE = superCluster->preshowerEnergy() / superCluster->rawEnergy();
-  _allMVAVars.varESEffSigmaRR = (*_esEffSigmaRRMap)[ phoRecoPtr ];
-  _allMVAVars.varRho          = *_rho; 
-  _allMVAVars.varPhoIsoRaw    = (*_phoPhotonIsolationMap)[phoRecoPtr];  
-  _allMVAVars.varChIsoRaw     = (*_phoChargedIsolationMap)[phoRecoPtr];
-  _allMVAVars.varWorstChRaw   = (*_phoWorstChargedIsolationMap)[phoRecoPtr];
+  AllVariables allMVAVars;
+
+  allMVAVars.varPhi          = phoRecoPtr->phi();
+  allMVAVars.varR9           = phoRecoPtr->r9() ;
+  allMVAVars.varSieie        = (*full5x5SigmaIEtaIEtaMap)[ phoRecoPtr ]; // in principle, in the photon object as well
+  allMVAVars.varSieip        = (*full5x5SigmaIEtaIPhiMap)[ phoRecoPtr ]; // not in the photon object
+  allMVAVars.varE1x3overE5x5 = e1x3/e5x5;
+  allMVAVars.varE2x2overE5x5 = e2x2/e5x5;
+  allMVAVars.varE2x5overE5x5 = e2x5/e5x5;
+  allMVAVars.varSCEta        = superCluster->eta(); 
+  allMVAVars.varRawE         = superCluster->rawEnergy(); 
+  allMVAVars.varSCEtaWidth   = superCluster->etaWidth(); 
+  allMVAVars.varSCPhiWidth   = superCluster->phiWidth(); 
+  allMVAVars.varESEnOverRawE = superCluster->preshowerEnergy() / superCluster->rawEnergy();
+  allMVAVars.varESEffSigmaRR = (*esEffSigmaRRMap)[ phoRecoPtr ];
+  allMVAVars.varRho          = *rho; 
+  allMVAVars.varPhoIsoRaw    = (*phoPhotonIsolationMap)[phoRecoPtr];  
+  allMVAVars.varChIsoRaw     = (*phoChargedIsolationMap)[phoRecoPtr];
+  allMVAVars.varWorstChRaw   = (*phoWorstChargedIsolationMap)[phoRecoPtr];
   // Declare spectator vars
-  _allMVAVars.varPt = phoRecoPtr->pt(); 
-  _allMVAVars.varEta = phoRecoPtr->eta();
+  allMVAVars.varPt = phoRecoPtr->pt(); 
+  allMVAVars.varEta = phoRecoPtr->eta();
 
+  constrainMVAVariables(allMVAVars);
+
+  std::vector<float> vars;
+  if( isEndcapCategory( findCategory( particle ) ) ) {
+    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+                                       allMVAVars.varR9,
+                                       allMVAVars.varSieie,
+                                       allMVAVars.varSieip,
+                                       allMVAVars.varE1x3overE5x5,
+                                       allMVAVars.varE2x2overE5x5,
+                                       allMVAVars.varE2x5overE5x5,
+                                       allMVAVars.varSCEta,
+                                       allMVAVars.varRawE,
+                                       allMVAVars.varSCEtaWidth,
+                                       allMVAVars.varSCPhiWidth,
+                                       allMVAVars.varESEnOverRawE,
+                                       allMVAVars.varESEffSigmaRR,
+                                       allMVAVars.varRho,
+                                       allMVAVars.varPhoIsoRaw,
+                                       allMVAVars.varChIsoRaw,
+                                       allMVAVars.varWorstChRaw,
+                                       // Declare spectator vars
+                                       allMVAVars.varPt,
+                                       allMVAVars.varEta) 
+                      ); 
+  } else {
+    vars = std::move( packMVAVariables(allMVAVars.varPhi,
+                                       allMVAVars.varR9,
+                                       allMVAVars.varSieie,
+                                       allMVAVars.varSieip,
+                                       allMVAVars.varE1x3overE5x5,
+                                       allMVAVars.varE2x2overE5x5,
+                                       allMVAVars.varE2x5overE5x5,
+                                       allMVAVars.varSCEta,
+                                       allMVAVars.varRawE,
+                                       allMVAVars.varSCEtaWidth,
+                                       allMVAVars.varSCPhiWidth,
+                                       allMVAVars.varRho,
+                                       allMVAVars.varPhoIsoRaw,
+                                       allMVAVars.varChIsoRaw,
+                                       allMVAVars.varWorstChRaw,
+                                       // Declare spectator vars
+                                       allMVAVars.varPt,
+                                       allMVAVars.varEta) 
+                      );
+  }
+  return vars;
 }
 
-void PhotonMVAEstimatorRun2Spring15NonTrig::constrainMVAVariables(){
+void PhotonMVAEstimatorRun2Spring15NonTrig::constrainMVAVariables(AllVariables&)const {
 
   // Check that variables do not have crazy values
   
@@ -300,5 +341,19 @@ void PhotonMVAEstimatorRun2Spring15NonTrig::constrainMVAVariables(){
   // developed with restricting variables to specific physical ranges.
   return;
 
+}
+
+void PhotonMVAEstimatorRun2Spring15NonTrig::setConsumes(edm::ConsumesCollector&& cc) const {
+  cc.consumes<edm::ValueMap<float> >(_full5x5SigmaIEtaIEtaMapLabel);
+  cc.consumes<edm::ValueMap<float> >(_full5x5SigmaIEtaIPhiMapLabel); 
+  cc.consumes<edm::ValueMap<float> >(_full5x5E1x3MapLabel); 
+  cc.consumes<edm::ValueMap<float> >(_full5x5E2x2MapLabel);
+  cc.consumes<edm::ValueMap<float> >(_full5x5E2x5MaxMapLabel);
+  cc.consumes<edm::ValueMap<float> >(_full5x5E5x5MapLabel);
+  cc.consumes<edm::ValueMap<float> >(_esEffSigmaRRMapLabel);
+  cc.consumes<edm::ValueMap<float> >(_phoChargedIsolationLabel);
+  cc.consumes<edm::ValueMap<float> >(_phoPhotonIsolationLabel);
+  cc.consumes<edm::ValueMap<float> >( _phoWorstChargedIsolationLabel);
+  cc.consumes<double>(_rhoLabel);
 }
 

--- a/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
+++ b/RecoEgamma/PhotonIdentification/plugins/PhotonMVAEstimatorRun2Spring15NonTrig.cc
@@ -58,7 +58,7 @@ mvaValue(const edm::Ptr<reco::Candidate>& particle, const edm::Event& iEvent) co
   const int iCategory = findCategory( particle );
   const std::vector<float> vars = std::move( fillMVAVariables( particle, iEvent ) );  
   
-  const float result = _gbrForests.at(iCategory)->GetGradBoostClassifier(vars.data());
+  const float result = _gbrForests.at(iCategory)->GetClassifier(vars.data());
 
   // DEBUG
   const bool debug = false;


### PR DESCRIPTION
Typical GBRForest + GlobalCache conversion, should see a nice memory reduction when running RECO+MiniAOD (but only in 75X and later, since there are no MVAs in the present 74X default VID).
This time for EGM MVA IDs, saw about 40MB reduction in RSS per converted BDT.

Validated locally that for all MVA IDs the results before and after were the same.

@gpetruc The PR for the IDs will come later today.
@ikrav @cmkuo
