### PR TITLE
Improved performance of c-hadron origin identification (backport to 7_5_X)

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/GenHFHadronMatcher.cc
@@ -22,6 +22,7 @@
 // system include files
 #include <memory>
 #include <utility>
+#include <vector>
 #include <algorithm>
 
 
@@ -41,6 +42,7 @@
 #include "DataFormats/HepMCCandidate/interface/GenParticle.h"
 
 #include "DataFormats/JetReco/interface/GenJet.h"
+#include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
 #include "SimDataFormats/JetMatching/interface/JetFlavourInfoMatching.h"
@@ -63,41 +65,46 @@ public:
 
 private:
     virtual void beginJob() ;
-    virtual void produce ( edm::Event&, const edm::EventSetup& );
+    virtual void produce( edm::Event&, const edm::EventSetup& );
     virtual void endJob() ;
 
-    virtual void beginRun ( edm::Run&, edm::EventSetup const& );
-    virtual void endRun ( edm::Run&, edm::EventSetup const& );
-    virtual void beginLuminosityBlock ( edm::LuminosityBlock&, edm::EventSetup const& );
-    virtual void endLuminosityBlock ( edm::LuminosityBlock&, edm::EventSetup const& );
+    virtual void beginRun( edm::Run&, edm::EventSetup const& );
+    virtual void endRun( edm::Run&, edm::EventSetup const& );
+    virtual void beginLuminosityBlock( edm::LuminosityBlock&, edm::EventSetup const& );
+    virtual void endLuminosityBlock( edm::LuminosityBlock&, edm::EventSetup const& );
 
-    std::vector<int> findHadronJets ( const reco::GenParticleCollection* genParticles, const reco::JetFlavourInfoMatchingCollection* jetFlavourInfos,
-                                      std::vector<int> &hadIndex, std::vector<reco::GenParticle> &hadMothersGenPart, 
-                                      std::vector<std::vector<int> > &hadMothersIndices, std::vector<int> &hadLeptonIndex, 
-                                      std::vector<int> &hadLeptonHadIndex, std::vector<int> &hadLeptonViaTau, 
-                                      std::vector<int> &hadFlavour, std::vector<int> &hadFromTopWeakDecay, std::vector<int> &hadBHadronId );
-    int analyzeMothers ( const reco::Candidate* thisParticle, int& topDaughterQId, int& topBarDaughterQId, 
-                         std::vector<const reco::Candidate*> &hadMothers, std::vector<std::vector<int> > &hadMothersIndices, 
-                         std::set<const reco::Candidate*> *analyzedParticles, const int prevPartIndex );
-    bool putMotherIndex ( std::vector<std::vector<int> > &hadMothersIndices, int partIndex, int mothIndex );
-    bool isHadron ( const int flavour, const reco::Candidate* thisParticle );
-    bool isHadronPdgId ( const int flavour, const int pdgId );
-    bool hasHadronDaughter ( const int flavour, const reco::Candidate* thisParticle );
-    int isInList ( std::vector<const reco::Candidate*> particleList, const reco::Candidate* particle );
-    int isInList ( std::vector<int> list, const int value );
-    int findInMothers ( int idx, std::vector<int> &mothChains, std::vector<std::vector<int> > &hadMothersIndices, 
-                        std::vector<reco::GenParticle> &hadMothers, int status, int pdgId, bool pdgAbs, int stopId, int firstLast, bool verbose );
-    bool isNeutralPdg ( int pdgId );
+    std::vector<int> findHadronJets( const reco::GenParticleCollection* genParticles, const reco::JetFlavourInfoMatchingCollection* jetFlavourInfos,
+                                     std::vector<int> &hadIndex, std::vector<reco::GenParticle> &hadMothersGenPart, 
+                                     std::vector<std::vector<int> > &hadMothersIndices, std::vector<int> &hadLeptonIndex, 
+                                     std::vector<int> &hadLeptonHadIndex, std::vector<int> &hadLeptonViaTau, 
+                                     std::vector<int> &hadFlavour, std::vector<int> &hadFromTopWeakDecay, std::vector<int> &hadBHadronId );
+    int analyzeMothers( const reco::Candidate* thisParticle, int& topDaughterQId, int& topBarDaughterQId, 
+                        std::vector<const reco::Candidate*> &hadMothers, std::vector<std::vector<int> > &hadMothersIndices, 
+                        std::set<const reco::Candidate*> *analyzedParticles, const int prevPartIndex );
+    bool putMotherIndex( std::vector<std::vector<int> > &hadMothersIndices, int partIndex, int mothIndex );
+    bool isHadron( const int flavour, const reco::Candidate* thisParticle );
+    bool isHadronPdgId( const int flavour, const int pdgId );
+    bool isMesonPdgId( const int flavour, const int pdgId );
+    bool isBaryonPdgId( const int flavour, const int pdgId );
+    int flavourSign( const int pdgId );
+    bool hasHadronDaughter( const int flavour, const reco::Candidate* thisParticle );
+    int idInList( std::vector<const reco::Candidate*> particleList, const reco::Candidate* particle );
+    int idInList( std::vector<int> list, const int value );
+    int findInMothers( int idx, std::vector<int> &mothChains, const std::vector<std::vector<int> > &hadMothersIndices,
+                       const std::vector<reco::GenParticle> &hadMothers, int status, int pdgId, bool pdgAbs,
+                       int stopId, int firstLast, bool verbose );
+    bool isNeutralPdg( int pdgId );
 
-    bool checkForLoop ( std::vector<const reco::Candidate*> &particleChain, const reco::Candidate* particle );
-    std::string getParticleName ( int id ) const;
+    bool checkForLoop( std::vector<const reco::Candidate*> &particleChain, const reco::Candidate* particle );
+    std::string getParticleName( int id ) const;
 
-    bool fixExtraSameFlavours(const unsigned int hadId, const std::vector<int> &hadIndices, const std::vector<reco::GenParticle> &hadMothers, 
-                              const std::vector<std::vector<int> > &hadMothersIndices, const std::vector<int> &isFromTopWeakDecay, 
-                              const std::vector<std::vector<int> > &LastQuarkIds, const std::vector<std::vector<int> > &LastQuarkMotherIds, 
-                              std::vector<int> &lastQuarkIndices, std::vector<int> &hadronFlavour, std::set<int> &checkedHadronIds, const int lastQuarkIndex);
+    bool fixExtraSameFlavours( const unsigned int hadId, const std::vector<int> &hadIndices, 
+                               const std::vector<reco::GenParticle> &hadMothers, const std::vector<std::vector<int> > &hadMothersIndices, 
+                               const std::vector<int> &isFromTopWeakDecay, const std::vector<std::vector<int> > &LastQuarkIds, 
+                               const std::vector<std::vector<int> > &LastQuarkMotherIds, std::vector<int> &lastQuarkIndices, 
+                               std::vector<int> &hadronFlavour, std::set<int> &checkedHadronIds, const int lastQuarkIndex );
 
-// ----------member data ---------------------------
+    // ----------member data ---------------------------
     edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
     edm::EDGetTokenT<reco::JetFlavourInfoMatchingCollection> jetFlavourInfosToken_;
     int flavour_;
@@ -137,7 +144,7 @@ jetFlavourInfosToken_(consumes<reco::JetFlavourInfoMatchingCollection>(cfg.getPa
     noBBbarResonances_ = cfg.getParameter<bool> ( "noBBbarResonances" );
     onlyJetClusteredHadrons_ = cfg.getParameter<bool> ( "onlyJetClusteredHadrons" );
     
-    flavour_ = abs ( flavour_ ); // Make flavour independent of sign given in configuration
+    flavour_ = std::abs( flavour_ ); // Make flavour independent of sign given in configuration
     if ( flavour_==5 ) {
         flavourStr_="B";
     } else if ( flavour_==4 ) {
@@ -157,7 +164,6 @@ jetFlavourInfosToken_(consumes<reco::JetFlavourInfoMatchingCollection>(cfg.getPa
     produces< std::vector<int> > ( "gen"+flavourStr_+"HadLeptonViaTau" ); // Whether lepton comes directly from hadron or via tau decay
     produces< std::vector<int> > ( "gen"+flavourStr_+"HadFromTopWeakDecay" ); // Tells whether the hadron appears in the chain after top decay
     produces< std::vector<int> > ( "gen"+flavourStr_+"HadBHadronId" ); // Index of a b-hadron which the current hadron comes from (for c-hadrons)
-
 }
 
 GenHFHadronMatcher::~GenHFHadronMatcher()
@@ -172,7 +178,6 @@ GenHFHadronMatcher::~GenHFHadronMatcher()
 */
 void GenHFHadronMatcher::fillDescriptions ( edm::ConfigurationDescriptions& descriptions )
 {
-
     edm::ParameterSetDescription desc;
     desc.add<edm::InputTag>("genParticles")->setComment( "Collection of GenParticle objects which contains all particles produced in the event" );
     desc.add<edm::InputTag>("jetFlavourInfos")->setComment( "Output from the JetFlavour tool. Contains information about partons/hadrons/leptons associated to jets" );
@@ -191,7 +196,6 @@ void GenHFHadronMatcher::fillDescriptions ( edm::ConfigurationDescriptions& desc
 // ------------ method called to produce the data  ------------
 void GenHFHadronMatcher::produce ( edm::Event& evt, const edm::EventSetup& setup )
 {
-
     setup.getData ( pdt_ );
 
     using namespace edm;
@@ -226,7 +230,7 @@ void GenHFHadronMatcher::produce ( edm::Event& evt, const edm::EventSetup& setup
     evt.put ( hadLeptonHadIndex,  "gen"+flavourStr_+"HadLeptonHadronIndex" );
     evt.put ( hadLeptonViaTau,    "gen"+flavourStr_+"HadLeptonViaTau" );
     evt.put ( hadFromTopWeakDecay,"gen"+flavourStr_+"HadFromTopWeakDecay" );
-    evt.put ( hadBHadronId,     "gen"+flavourStr_+"HadBHadronId" );
+    evt.put ( hadBHadronId,       "gen"+flavourStr_+"HadBHadronId" );
 }
 
 // ------------ method called once each job just before starting event loop  ------------
@@ -284,7 +288,8 @@ void GenHFHadronMatcher::endLuminosityBlock ( edm::LuminosityBlock&, edm::EventS
 * 
 * @returns vector of jet indices that were matched to each hadron [by the jet clustering algorithm]
 */
-std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCollection* genParticles, const reco::JetFlavourInfoMatchingCollection* jetFlavourInfos,
+std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCollection* genParticles, 
+                                                      const reco::JetFlavourInfoMatchingCollection* jetFlavourInfos,
                                                       std::vector<int> &hadIndex, 
                                                       std::vector<reco::GenParticle> &hadMothers, std::vector<std::vector<int> > &hadMothersIndices, 
                                                       std::vector<int> &hadLeptonIndex, std::vector<int> &hadLeptonHadIndex, 
@@ -295,9 +300,9 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
     std::vector<const reco::Candidate*> hadMothersCand;
 
     int topDaughterQId = -1;
-    int topBarDaughterQId= -1;
+    int topBarDaughterQId = -1;
     
-    // Looping over all jets to get hadrons belonging to it
+    // Looping over all jets to get hadrons associated to them
     for(reco::JetFlavourInfoMatchingCollection::const_iterator i_info  = jetFlavourInfos->begin(); i_info != jetFlavourInfos->end(); ++i_info){
         reco::JetFlavourInfo jetInfo = i_info->second;
         const int jetIndex = i_info - jetFlavourInfos->begin();
@@ -313,40 +318,9 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
             hadIndex.push_back ( hadronIndex );
             hadJetIndex.push_back ( jetIndex );  // Putting jet index to the result list
         }
-	// FIXME: Should be moved to a separate loop over jets after analysing all hadrons (in case leptons come from non-clustered hadrons)
-        // Looping over all leptons associated with the jet
-        const reco::GenParticleRefVector& leptonsInJet = jetInfo.getLeptons();
-        for(reco::GenParticleRefVector::const_iterator lepton = leptonsInJet.begin(); lepton != leptonsInJet.end(); ++lepton){
-            bool leptonViaTau = false;
-            // Skipping tau leptons
-            if(std::abs((*lepton)->pdgId()) == 15) continue;
-            const reco::Candidate* leptonMother = (*lepton)->mother();
-            if(!leptonMother) continue;
-            // Taking next mother if direct mother is a tau
-            if(std::abs(leptonMother->pdgId()) == 15) {
-                leptonViaTau = true;
-                leptonMother = leptonMother->mother();
-            }
-            // Skipping this lepton if its mother is not a proper hadron
-            if(!isHadron(flavour_, leptonMother)) continue;
-            // Finding the index of this hadron in the list of analysed particles
-            int leptonHadronParticleIndex = std::find(hadMothersCand.begin(), hadMothersCand.end(), leptonMother) - hadMothersCand.begin();
-            if(leptonHadronParticleIndex >= (int)hadMothersCand.size()) continue;
-            if(leptonHadronParticleIndex < 0) continue;
-            // Finding the actual hadron index among those that were found
-            int leptonHadronIndex = std::find(hadIndex.begin(), hadIndex.end(), leptonHadronParticleIndex) - hadIndex.begin();
-            if(leptonHadronIndex >= (int)hadIndex.size()) continue;
-            // Putting the lepton, its index and hadron index to the corresponding lists
-            hadMothersCand.push_back(&**lepton);
-            const int leptonIndex = hadMothersCand.size()-1;
-            hadLeptonIndex.push_back(leptonIndex);
-            hadLeptonViaTau.push_back((int)leptonViaTau);
-            hadLeptonHadIndex.push_back(leptonHadronIndex);
-        } 
     }       // End of loop over jets
     
-    
-    // Access all hadrons which are not associated with jets if requested
+    // Access all hadrons which are not associated with jets, if requested
     if(!onlyJetClusteredHadrons_) {
         for(reco::GenParticleCollection::const_iterator i_particle = genParticles->begin(); i_particle != genParticles->end(); ++i_particle){
             const reco::GenParticle* thisParticle = &*i_particle;
@@ -361,10 +335,41 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
             hadJetIndex.push_back ( -1 );  // Jet index undefined
         }
     }
-
-
-    for ( int i=0; i< ( int ) hadMothersCand.size(); i++ ) {
-        hadMothers.push_back ( ( *dynamic_cast<const reco::GenParticle*> ( hadMothersCand.at(i) ) ) );
+    
+    // Transfering Candidates to the list of processed particles for further analysis
+    for ( int i=0; i< (int)hadMothersCand.size(); i++ ) {
+        const reco::GenParticle* particle = dynamic_cast<const reco::GenParticle*>( hadMothersCand.at(i) );
+        hadMothers.push_back(*particle);
+    }
+    
+    // Adding leptons from hadron decays
+    for(reco::GenParticleCollection::const_iterator i_particle = genParticles->begin(); i_particle != genParticles->end(); ++i_particle){
+        const reco::GenParticle lepton = *i_particle;
+        const int pdg_abs = lepton.pdgId();
+        // Skipping if not a lepton: e/mu
+        if(pdg_abs != 11 && pdg_abs != 13) continue;
+        bool leptonViaTau = false;
+        const reco::Candidate* leptonMother = lepton.mother();
+        if(!leptonMother) continue;
+        // Taking next mother if direct mother is a tau
+        if(std::abs(leptonMother->pdgId()) == 15) {
+            leptonViaTau = 1;
+            leptonMother = leptonMother->mother();
+        }
+        // Skipping this lepton if its mother is not a proper hadron
+        if(!isHadron(flavour_, leptonMother)) continue;
+        // Finding the index of this hadron in the list of analysed particles
+        size_t leptonHadronParticleIndex = std::find(hadMothersCand.begin(), hadMothersCand.end(), leptonMother) - hadMothersCand.begin();
+        if(leptonHadronParticleIndex >= hadMothersCand.size()) continue;
+        // Finding the actual hadron index among those that were found
+        size_t leptonHadronIndex = std::find(hadIndex.begin(), hadIndex.end(), leptonHadronParticleIndex) - hadIndex.begin();
+        if(leptonHadronIndex >= hadIndex.size()) continue;
+        // Putting the lepton, its index and hadron index to the corresponding lists
+        hadMothers.push_back(lepton);
+        const int leptonIndex = hadMothersCand.size()-1;
+        hadLeptonIndex.push_back(leptonIndex);
+        hadLeptonViaTau.push_back(leptonViaTau);
+        hadLeptonHadIndex.push_back(leptonHadronIndex);
     }
 
     // Checking mothers of hadrons in order to assign flags (where the hadron comes from)
@@ -376,27 +381,30 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
 
     // Looping over all hadrons
     for ( unsigned int hadNum=0; hadNum<nHad; hadNum++ ) {
-        
         unsigned int hadIdx = hadIndex.at(hadNum);   // Index of hadron in the hadMothers
 
         std::vector <int> FirstQuarkId;
         std::vector <int> LastQuarkId;
         std::vector <int> LastQuarkMotherId;
 
-        int hadFlav = hadMothers.at(hadIdx).pdgId() <0?-1:1; // Charge of the hadron (-1,1)
-        if ( abs ( hadMothers.at(hadIdx).pdgId() ) /1000 < 1 ) {
-            hadFlav*=-1;    // Inverting flavour of hadron if it is a meson
-        }
+        const int hadronFlavourSign = flavourSign( hadMothers.at(hadIdx).pdgId() );
 
         // Searching only first quark in the chain with the same flavour as hadron
-        findInMothers ( hadIdx, FirstQuarkId, hadMothersIndices, hadMothers, 0, hadFlav*flavour_, false, -1, 1, false );
+        if(hadronFlavourSign != 0) {
+            findInMothers( hadIdx, FirstQuarkId, hadMothersIndices, hadMothers, 0, hadronFlavourSign*flavour_, false, -1, 1, false );
+        }
+        // Searching for quarks with both flavours since it is a bb/cc resonance
+        else {
+            findInMothers( hadIdx, FirstQuarkId, hadMothersIndices, hadMothers, 0, flavour_, false, -1, 1, false );
+            findInMothers( hadIdx, FirstQuarkId, hadMothersIndices, hadMothers, 0, -1*flavour_, false, -1, 1, false );
+        }
 
         // Finding last quark for each first quark
         for ( unsigned int qId=0; qId<FirstQuarkId.size(); qId++ ) {
             // Identifying the flavour of the first quark to find the last quark of the same flavour
-            int bQFlav = hadMothers.at(FirstQuarkId.at(qId)).pdgId() < 0?-1:1;
+            const int quarkFlavourSign = flavourSign( hadMothers.at(FirstQuarkId.at(qId)).pdgId() );
             // Finding last quark of the hadron starting from the first quark
-            findInMothers ( FirstQuarkId.at(qId), LastQuarkId, hadMothersIndices, hadMothers, 0, bQFlav*flavour_, false, -1, 2, false );
+            findInMothers( FirstQuarkId.at(qId), LastQuarkId, hadMothersIndices, hadMothers, 0, quarkFlavourSign*flavour_, false, -1, 2, false );
         }		// End of loop over all first quarks of the hadron
 
 
@@ -407,7 +415,7 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
         std::vector<std::pair<double, int> > lastQuark_dR_id_pairs;
 
         // Finding the closest quark in dR
-        for ( unsigned int qId=0; qId<LastQuarkId.size(); qId++ ) {
+        for ( unsigned int qId = 0; qId < LastQuarkId.size(); qId++ ) {
             int qIdx = LastQuarkId.at(qId);
             // Calculating the dR between hadron and quark
             float dR = deltaR ( hadMothers.at(hadIdx).eta(),hadMothers.at(hadIdx).phi(),hadMothers.at(qIdx).eta(),hadMothers.at(qIdx).phi() );
@@ -418,7 +426,7 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
 
         std::sort(lastQuark_dR_id_pairs.begin(), lastQuark_dR_id_pairs.end());
         
-        if(lastQuark_dR_id_pairs.size()>1) {
+        if(lastQuark_dR_id_pairs.size() > 1) {
             double dRratio = (lastQuark_dR_id_pairs.at(1).first - lastQuark_dR_id_pairs.at(0).first)/lastQuark_dR_id_pairs.at(1).first;
             int qIdx_closest = lastQuark_dR_id_pairs.at(0).second;
             LastQuarkId.clear();
@@ -426,8 +434,8 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
             else for(std::pair<double, int> qIdDrPair : lastQuark_dR_id_pairs) LastQuarkId.push_back(qIdDrPair.second);
         }
         for(int qIdx : LastQuarkId) {
-            int qmIdx = hadMothersIndices.at ( qIdx ).at(0);
-            LastQuarkMotherId.push_back( qmIdx );
+            int qmIdx = hadMothersIndices.at(qIdx).at(0);
+            LastQuarkMotherId.push_back(qmIdx);
         }
 
         if((int)LastQuarkId.size()>0) lastQuarkIndices.at(hadNum) = 0;     // Setting the first quark in array as a candidate if it exists
@@ -440,7 +448,7 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
             hadronFlavour = 0;
         } else {
             int qIdx = LastQuarkId.at( lastQuarkIndices.at(hadNum) );
-            int qFlav = ( hadMothers.at(qIdx).pdgId() < 0 ) ? -1 : 1;
+            int qFlav = flavourSign( hadMothers.at(qIdx).pdgId() );
             hadronFlavour = qFlav*std::abs( hadMothers.at( LastQuarkMotherId.at( lastQuarkIndices.at(hadNum) ) ).pdgId() );
         }
         hadFlavour.push_back(hadronFlavour);    // Adding hadron flavour to the list of flavours
@@ -448,11 +456,11 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
         // Checking whether hadron comes from the Top weak decay
         int isFromTopWeakDecay = 1;
         std::vector <int> checkedParticles;
-        if(hadFlavour.at(hadNum)!=0) {
+        if(hadFlavour.at(hadNum) != 0) {
             int lastQIndex = LastQuarkId.at(lastQuarkIndices.at(hadNum));
-            bool fromTB = topDaughterQId>=0?findInMothers( lastQIndex, checkedParticles, hadMothersIndices, hadMothers, -1, 0, false, topDaughterQId, 2, false ) >= 0 : false;
+            bool fromTB = topDaughterQId >= 0 ? findInMothers( lastQIndex, checkedParticles, hadMothersIndices, hadMothers, -1, 0, false, topDaughterQId, 2, false ) >= 0 : false;
             checkedParticles.clear();
-            bool fromTbarB = topBarDaughterQId>=0?findInMothers( lastQIndex, checkedParticles, hadMothersIndices, hadMothers, -1, 0, false, topBarDaughterQId, 2, false) >= 0:false;
+            bool fromTbarB = topBarDaughterQId >= 0 ? findInMothers( lastQIndex, checkedParticles, hadMothersIndices, hadMothers, -1, 0, false, topBarDaughterQId, 2, false) >= 0 : false;
             checkedParticles.clear();
             if(!fromTB && !fromTbarB) {
                 isFromTopWeakDecay = 0;
@@ -470,7 +478,6 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
         
     }	// End of loop over all hadrons
 
-
     return hadJetIndex;
 }
 
@@ -483,24 +490,20 @@ std::vector<int> GenHFHadronMatcher::findHadronJets ( const reco::GenParticleCol
 *
 * @returns the index of the particle in the list [-1 if particle not found]
 */
-int GenHFHadronMatcher::isInList ( std::vector<const reco::Candidate*> particleList, const reco::Candidate* particle )
+int GenHFHadronMatcher::idInList ( std::vector<const reco::Candidate*> particleList, const reco::Candidate* particle )
 {
-    for ( unsigned int i = 0; i<particleList.size(); i++ )
-        if ( particleList.at(i)==particle ) {
-            return i;
-        }
-
-    return -1;
+    const unsigned int position = std::find(particleList.begin(), particleList.end(), particle) - particleList.begin();
+    if( position >= particleList.size() ) return -1;
+    
+    return position;
 }
 
-int GenHFHadronMatcher::isInList ( std::vector<int> list, const int value )
+int GenHFHadronMatcher::idInList ( std::vector<int> list, const int value )
 {
-    for ( unsigned int i = 0; i<list.size(); i++ )
-        if ( list.at(i)==value ) {
-            return i;
-        }
-
-    return -1;
+    const unsigned int position = std::find(list.begin(), list.end(), value) - list.begin();
+    if( position >= list.size() ) return -1;
+    
+    return position;
 }
 
 
@@ -524,23 +527,76 @@ bool GenHFHadronMatcher::isHadron ( const int flavour, const reco::Candidate* th
 * @param[in] flavour flavour of a hadron that is being searched (5-B, 4-C)
 * @param[in] pdgId pdgId to be checked
 *
-* @returns if the pdgId represents a hadron of specified flavour
+* @returns true if the pdgId represents a hadron of specified flavour
 */
 bool GenHFHadronMatcher::isHadronPdgId ( const int flavour, const int pdgId )
 {
-    int flavour_abs = std::abs(flavour);
-    if(flavour_abs > 5 || flavour_abs < 1) return false;
-    int pdgId_abs = std::abs(pdgId);
+    if( isBaryonPdgId(flavour, pdgId) || isMesonPdgId(flavour, pdgId) ) return true;
+    
+    return false;
+}
 
-    if ( pdgId_abs / 1000 == flavour_abs // baryons
-            || ( pdgId_abs / 100 % 10 == flavour_abs // mesons
-                 && ! ( noBBbarResonances_ && pdgId_abs / 10 % 100 == 11*flavour_abs ) // but not a resonance
-               )
-       ) {
-        return true;
-    } else {
-        return false;
-    }
+
+/**
+* @brief Check the pdgId if it represents a meson of particular flavour
+*
+* @param[in] flavour flavour of a hadron that is being searched (5-B, 4-C)
+* @param[in] pdgId pdgId to be checked
+*
+* @returns true if the pdgId represents a meson of specified flavour
+*/
+bool GenHFHadronMatcher::isMesonPdgId ( const int flavour, const int pdgId )
+{
+    const int flavour_abs = std::abs(flavour);
+    if(flavour_abs != 5 && flavour_abs != 4) return false;
+    const int pdgId_abs = std::abs(pdgId);
+
+    if( pdgId_abs/100%10 != flavour_abs) return false;
+    // Excluding baryons
+    if ( pdgId_abs/1000 == flavour_abs) return false;
+    // Excluding bb/cc resonances if required
+    if ( noBBbarResonances_ && pdgId_abs/10%100 == 11*flavour_abs ) return false;
+    
+    return true;
+}
+
+
+/**
+* @brief Check the pdgId if it represents a baryon of particular flavour
+*
+* @param[in] flavour flavour of a hadron that is being searched (5-B, 4-C)
+* @param[in] pdgId pdgId to be checked
+*
+* @returns true if the pdgId represents a baryon of specified flavour
+*/
+bool GenHFHadronMatcher::isBaryonPdgId ( const int flavour, const int pdgId )
+{
+    const int flavour_abs = std::abs(flavour);
+    if(flavour_abs != 5 && flavour_abs != 4) return false;
+    const int pdgId_abs = std::abs(pdgId);
+
+    if ( pdgId_abs/1000 != flavour_abs) return false;
+    
+    return true;
+}
+
+
+/**
+* @brief Sign of the flavour (matter/antimatter)
+*
+* @param[in] pdgId pdgId to be checked
+*
+* @returns +1/-1/0  matter/antimatter/undefined
+*/
+int GenHFHadronMatcher::flavourSign ( const int pdgId )
+{
+    int flavourSign = pdgId / std::abs(pdgId);
+    // B mesons have opposite sign
+    if( isMesonPdgId(5, pdgId) ) flavourSign *= -1;
+    // Returning 0 for bb/cc resonances
+    if(pdgId % 1000 / 10 / 11 > 0) flavourSign = 0;
+    
+    return flavourSign;
 }
 
 
@@ -554,15 +610,16 @@ bool GenHFHadronMatcher::isHadronPdgId ( const int flavour, const int pdgId )
 */
 bool GenHFHadronMatcher::hasHadronDaughter ( const int flavour, const reco::Candidate* thisParticle )
 {
-// Looping through daughters of the particle
+    // Looping through daughters of the particle
     bool hasDaughter = false;
-    for ( int k=0; k< ( int ) thisParticle->numberOfDaughters(); k++ ) {
-        if ( !isHadron ( flavour, thisParticle->daughter ( k ) ) ) {
+    for ( int k=0; k< (int)thisParticle->numberOfDaughters(); k++ ) {
+        if ( !isHadron( flavour, thisParticle->daughter(k) ) ) {
             continue;
         }
         hasDaughter = true;
         break;
     }
+    
     return hasDaughter;
 }
 
@@ -586,10 +643,9 @@ bool GenHFHadronMatcher::hasHadronDaughter ( const int flavour, const reco::Cand
 */
 int GenHFHadronMatcher::analyzeMothers ( const reco::Candidate* thisParticle, int& topDaughterQId, int& topBarDaughterQId, std::vector<const reco::Candidate*> &hadMothers, std::vector<std::vector<int> > &hadMothersIndices, std::set<const reco::Candidate*> *analyzedParticles, const int prevPartIndex )
 {
-
     // Getting the index of the particle which is a hadron in the first call
     int hadronIndex=-1;	// Index of the hadron that is returned by this function
-    int index = isInList ( hadMothers, thisParticle );
+    int index = idInList( hadMothers, thisParticle );
     if ( index<0 ) { // If hadron is not in the list of mothers yet
         hadMothers.push_back ( thisParticle );
         hadronIndex=hadMothers.size()-1;
@@ -598,7 +654,7 @@ int GenHFHadronMatcher::analyzeMothers ( const reco::Candidate* thisParticle, in
     }
     
     int partIndex = -1;	  // Index of particle being checked in the list of mothers
-    partIndex = isInList ( hadMothers, thisParticle );
+    partIndex = idInList( hadMothers, thisParticle );
 
     // Checking whether this particle is already in the chain of analyzed particles in order to identify a loop
     bool isLoop = false;
@@ -625,7 +681,7 @@ int GenHFHadronMatcher::analyzeMothers ( const reco::Candidate* thisParticle, in
     // Putting the mothers to the list of mothers
     for ( size_t iMother = 0; iMother < thisParticle->numberOfMothers(); ++iMother ) {
         const reco::Candidate* mother = thisParticle->mother ( iMother );
-        int mothIndex = isInList ( hadMothers, mother );
+        int mothIndex = idInList( hadMothers, mother );
         if ( mothIndex == partIndex && partIndex>=0 ) {
             continue;		// Skipping the mother that is its own daughter
         }
@@ -661,10 +717,9 @@ int GenHFHadronMatcher::analyzeMothers ( const reco::Candidate* thisParticle, in
     }
 
     // Adding -1 to the list of mother indices for current particle if it has no mothers (for consistency between numbering of indices and mothers)
-    if ( ( int ) thisParticle->numberOfMothers() <=0) {
+    if ( (int)thisParticle->numberOfMothers() <=0) {
         putMotherIndex ( hadMothersIndices, partIndex, -1 );
     }
-
 
     return hadronIndex;
 
@@ -688,19 +743,19 @@ bool GenHFHadronMatcher::putMotherIndex ( std::vector<std::vector<int> > &hadMot
         return false;
     }
 
-    while ( ( int ) hadMothersIndices.size() <=partIndex ) { // If there is no list of mothers for current particle yet
+    while ( (int)hadMothersIndices.size() <= partIndex ) { // If there is no list of mothers for current particle yet
         std::vector<int> mothersIndices;
         hadMothersIndices.push_back ( mothersIndices );
     }
 
-    std::vector<int> *hadMotherIndices=&hadMothersIndices.at ( partIndex );
+    std::vector<int> *hadMotherIndices = &hadMothersIndices.at(partIndex);
     // Removing other mothers if particle must have no mothers
-    if ( mothIndex==-1 ) {
+    if ( mothIndex == -1 ) {
         hadMotherIndices->clear();
     } else {
-    // Checking if current mother is already in the list of theParticle's mothers
-        for ( int k=0; k< ( int ) hadMotherIndices->size(); k++ ) {
-            if ( hadMotherIndices->at ( k ) !=mothIndex && hadMotherIndices->at ( k ) !=-1 ) {
+        // Checking if current mother is already in the list of theParticle's mothers
+        for ( int k = 0; k < (int)hadMotherIndices->size(); k++ ) {
+            if ( hadMotherIndices->at(k) != mothIndex && hadMotherIndices->at(k) != -1 ) {
                 continue;
             }
             inList=true;
@@ -709,7 +764,7 @@ bool GenHFHadronMatcher::putMotherIndex ( std::vector<std::vector<int> > &hadMot
     }
     // Adding current mother to the list of mothers of this particle
     if ( !inList ) {
-        hadMotherIndices->push_back ( mothIndex );
+        hadMotherIndices->push_back(mothIndex);
     }
 
     return inList;
@@ -733,17 +788,14 @@ bool GenHFHadronMatcher::putMotherIndex ( std::vector<std::vector<int> > &hadMot
 * @returns index of the found particle in the hadMothers array [-1 if the specified particle not found]
 */
 
-int GenHFHadronMatcher::findInMothers ( int idx, std::vector<int> &mothChains, std::vector<std::vector<int> > &hadMothersIndices, std::vector<reco::GenParticle> &hadMothers, int status, int pdgId, bool pdgAbs=false, int stopId=-1, int firstLast=0, bool verbose=false)
+int GenHFHadronMatcher::findInMothers ( int idx, std::vector<int> &mothChains, const std::vector<std::vector<int> > &hadMothersIndices,
+                                        const std::vector<reco::GenParticle> &hadMothers, int status, int pdgId, bool pdgAbs=false, 
+                                        int stopId=-1, int firstLast=0, bool verbose=false)
 {
     int foundStopId = -1;
-    int pdg_1 = hadMothers.at ( idx ).pdgId();
-    int partCharge = ( hadMothers.at ( idx ).pdgId() >0 ) ?1:-1;
-// Inverting charge if mother is a b(c) meson
-    if ( abs ( hadMothers.at ( idx ).pdgId() ) /1000 < 1 && ( abs ( hadMothers.at ( idx ).pdgId() ) /100%10 == 4 || abs ( hadMothers.at ( idx ).pdgId() ) /100%10 == 5 ) ) {
-        partCharge*=-1;
-    }
+    int pdg_1 = hadMothers.at(idx).pdgId();
 
-    if ( ( int ) hadMothersIndices.size() <=idx ) {
+    if ( (int)hadMothersIndices.size() <= idx ) {
         if ( verbose ) {
             printf ( " Stopping checking particle %d. No mothers are stored.\n",idx );
         }
@@ -752,14 +804,14 @@ int GenHFHadronMatcher::findInMothers ( int idx, std::vector<int> &mothChains, s
     
     if(std::abs(hadMothers.at( idx ).pdgId()) > 10 &&  std::abs(hadMothers.at( idx ).pdgId()) < 19) printf("Lepton: %d\n", hadMothers.at( idx ).pdgId());
 
-    std::vector<int> mothers = hadMothersIndices.at ( idx );
+    std::vector<int> mothers = hadMothersIndices.at(idx);
     unsigned int nMothers = mothers.size();
     bool isCorrect=false;		// Whether current particle is what is being searched
     if ( verbose ) {
-        if ( abs ( hadMothers.at ( idx ).pdgId() ) ==2212 ) {
-            printf ( "Chk:  %d\tpdg: %d\tstatus: %d",idx, hadMothers.at ( idx ).pdgId(), hadMothers.at ( idx ).status() );
+        if ( std::abs( hadMothers.at(idx).pdgId() ) ==2212 ) {
+            printf ( "Chk:  %d\tpdg: %d\tstatus: %d",idx, hadMothers.at(idx).pdgId(), hadMothers.at(idx).status() );
         } else {
-            printf ( " Chk:  %d(%d mothers)\tpdg: %d\tstatus: %d\tPt: %.3f\tEta: %.3f",idx, nMothers, hadMothers.at ( idx ).pdgId(), hadMothers.at ( idx ).status(), hadMothers.at ( idx ).pt(),hadMothers.at ( idx ).eta() );
+            printf ( " Chk:  %d(%d mothers)\tpdg: %d\tstatus: %d\tPt: %.3f\tEta: %.3f",idx, nMothers, hadMothers.at(idx).pdgId(), hadMothers.at(idx).status(), hadMothers.at(idx).pt(),hadMothers.at(idx).eta() );
         }
     }
     bool hasCorrectMothers = true;
@@ -779,19 +831,16 @@ int GenHFHadronMatcher::findInMothers ( int idx, std::vector<int> &mothChains, s
     }
     
     // Checking whether current mother satisfies selection criteria
-    if ( ( ( hadMothers.at ( idx ).pdgId() == pdgId && pdgAbs==false )
-            || ( abs ( hadMothers.at ( idx ).pdgId() ) == abs ( pdgId ) && pdgAbs==true ) )
-            && ( hadMothers.at ( idx ).status() == status || status==0 )
+    if ( ( ( hadMothers.at(idx).pdgId() == pdgId && pdgAbs==false )
+            || ( std::abs( hadMothers.at(idx).pdgId() ) == std::abs( pdgId ) && pdgAbs==true ) )
+            && ( hadMothers.at(idx).status() == status || status==0 )
             && hasCorrectMothers ) {
         isCorrect=true;
-        bool inList=false;
-        for ( unsigned int k=0; k<mothChains.size(); k++ ) if ( mothChains[k]==idx ) {
-                inList=true;    // Checking whether isn't already in the list
-                break;
-            }
-        if ( !inList && mothers.at ( 0 ) >=0 && ( hadMothers.at ( idx ).pdgId() *pdgId>0 || !pdgAbs ) ) {		// If not in list and mother of this quark has correct charge
+        // Adding to the list of candidates if not there and if mother of this quark has correct flavour sign
+        const bool inList = std::find(mothChains.begin(), mothChains.end(), idx) != mothChains.end();
+        if ( !inList && mothers.at(0) >= 0 && ( hadMothers.at(idx).pdgId()*pdgId > 0 || !pdgAbs ) ) {
             if ( firstLast==0 || firstLast==1 ) {
-                mothChains.push_back ( idx );
+                mothChains.push_back(idx);
             }
             if ( verbose ) {
                 printf ( "   *" );
@@ -808,32 +857,32 @@ int GenHFHadronMatcher::findInMothers ( int idx, std::vector<int> &mothChains, s
     if ( isCorrect && firstLast==1 ) {
         return -1;   // Stopping if only the first particle in the chain is looked for
     }
-
-// Checking next level mothers
+    
+    // Checking next level mothers
     unsigned int nDifferingMothers = 0;
-    for ( unsigned int i=0; i<nMothers; i++ ) {
-        int idx2 = mothers[i];
-        if ( idx2<0 ) {
+    for ( unsigned int i = 0; i < nMothers; i++ ) {
+        int idx2 = mothers.at(i);
+        if ( idx2 < 0 ) {
 	    if(verbose) printf("^^^ Has no mother\n");
             continue;    // Skipping if mother's id is -1 (no mother), that means current particle is a proton
         }
-        if ( idx2==idx ) {
+        if ( idx2 == idx ) {
 	    if(verbose) printf("^^^ Stored as its own mother\n");
             continue;    // Skipping if particle is stored as its own mother
         }
         int pdg_2 = hadMothers[idx2].pdgId();
         // Inverting the flavour if bb oscillation detected
         if ( isHadronPdgId(pdgId, pdg_1) && isHadronPdgId(pdgId, pdg_2) &&  pdg_1*pdg_2 < 0 ) {
-            pdgId*=-1;
+            pdgId *= -1;
             if(verbose) printf("######### Inverting flavour of the hadron\n");
         }
 	// Counting how many mothers are different from this particle
-        if ( ( std::abs ( pdg_2 ) != abs ( pdgId ) && pdgAbs==true ) ||
-             ( pdg_2 != pdgId && pdgAbs==false ) ) {
+        if ( ( std::abs( pdg_2 ) != std::abs( pdgId ) && pdgAbs==true ) ||
+             ( pdg_2 != pdgId && pdgAbs == false ) ) {
 	    nDifferingMothers++;
         }
 
-// Checking next level mother
+        // Checking next level mother
         if ( verbose ) {
             printf ( "Checking mother %d out of %d mothers (%d -> %d), looking for pdgId: %d\n",i,nMothers,idx, idx2, pdgId );
         }
@@ -862,12 +911,11 @@ int GenHFHadronMatcher::findInMothers ( int idx, std::vector<int> &mothChains, s
 */
 bool GenHFHadronMatcher::isNeutralPdg ( int pdgId )
 {
-    const int max = 5;
-    int neutralPdgs[max]= {9,21,22,23,25};
-    for ( int i=0; i<max; i++ ) if ( abs ( pdgId ) ==neutralPdgs[i] ) {
-            return true;
-        }
-    return false;
+    const int neutralPdgs_array[] = {9, 21, 22, 23, 25};
+    const std::vector<int> neutralPdgs( neutralPdgs_array, neutralPdgs_array + sizeof(neutralPdgs_array) / sizeof(int) );
+    if( std::find( neutralPdgs.begin(), neutralPdgs.end(), std::abs(pdgId) ) == neutralPdgs.end() ) return false;
+    
+    return true;
 }
 
 

--- a/PhysicsTools/JetMCAlgos/python/GenHFHadronMatcher_cff.py
+++ b/PhysicsTools/JetMCAlgos/python/GenHFHadronMatcher_cff.py
@@ -1,25 +1,15 @@
 import FWCore.ParameterSet.Config as cms
 
-# Flavour info: jet collection with all associated ghosts
-from PhysicsTools.JetMCAlgos.AK5PFJetsMCFlavourInfos_cfi import ak5JetFlavourInfos
-genJetFlavourPlusLeptonInfos = ak5JetFlavourInfos.clone(
-    leptons = cms.InputTag("selectedHadronsAndPartons","leptons")
-)
-
-
 from PhysicsTools.JetMCAlgos.GenHFHadronMatcher_cfi import matchGenHFHadron
 
 
 # Configuration for matching B-hadrons ================================================================
 matchGenBHadron = matchGenHFHadron.clone(
-    jetFlavourInfos = cms.InputTag("genJetFlavourPlusLeptonInfos"),
     flavour = 5
 )
 
-
 # Configuration for matching C-hadrons =================================================================
 matchGenCHadron = matchGenHFHadron.clone(
-    jetFlavourInfos = cms.InputTag("genJetFlavourPlusLeptonInfos"),
     flavour = 4
 )
 

--- a/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.cc
+++ b/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.cc
@@ -31,8 +31,15 @@ class matchGenHFHadrons : public edm::EDAnalyzer {
     private:
         virtual void analyze(const edm::Event& event, const edm::EventSetup& setup);
         virtual void beginJob();
+        void bookHadronBranches(TTree* tree, const int flavour);
         void clearEventVariables();
-        void clearBHadronVariables();
+        void clearHadronVariables();
+        void fillHadronTree( TTree* tree, const int flavour, const reco::GenJetCollection& genJets,
+                             const std::vector<int>& genHadIndex, const std::vector<int>& genHadJetIndex,
+                             const std::vector<int>& genHadFlavour, const std::vector<int>& genHadFromTopWeakDecay,
+                             const std::vector<reco::GenParticle>& genHadPlusMothers, const std::vector<std::vector<int> >& genHadPlusMothersIndices,
+                             const std::vector<int>& genHadLeptonHadronIndex, const std::vector<int>& genHadLeptonViaTau,
+                             const std::vector<int>& genHadBHadronId = std::vector<int>(0) );
         // A recursive function that scans through the particle chain to find a particle with specific pdgId or abs(pdgId)
         void findAncestorParticles(const int startId, std::set<int>& resultIds, 
                                    const std::vector<reco::GenParticle>& genParticles, const std::vector<std::vector<int> >& motherIndices, 
@@ -59,10 +66,16 @@ class matchGenHFHadrons : public edm::EDAnalyzer {
         const edm::EDGetTokenT<std::vector<int> > genCHadFlavourToken_;
         const edm::EDGetTokenT<std::vector<int> > genCHadFromTopWeakDecayToken_;
         const edm::EDGetTokenT<std::vector<int> > genCHadBHadronIdToken_;
+        const edm::EDGetTokenT<std::vector<reco::GenParticle> > genCHadPlusMothersToken_;
+        const edm::EDGetTokenT<std::vector<std::vector<int> > > genCHadPlusMothersIndicesToken_;
+        const edm::EDGetTokenT<std::vector<int> > genCHadIndexToken_;
+        const edm::EDGetTokenT<std::vector<int> > genCHadLeptonHadronIndexToken_;
+        const edm::EDGetTokenT<std::vector<int> > genCHadLeptonViaTauToken_;
         
         // Output to be written to the trees
         TTree* tree_events_;
         TTree* tree_bHadrons_;
+        TTree* tree_cHadrons_;
         
         int nJets_;
         
@@ -81,19 +94,22 @@ class matchGenHFHadrons : public edm::EDAnalyzer {
         int additionalJetEventId_;
         
         // Additional performance information
-        int bHadron_flavour_;
-        int bHadron_nQuarksAll_;
-        int bHadron_nQuarksSameFlavour_;
+        int hadron_flavour_;
+        int hadron_nQuarksAll_;
+        int hadron_nQuarksSameFlavour_;
+        int hadron_fromTopWeakDecay_;
+        int hadron_bHadronId_;
         
-        double bHadron_quark1_dR_;
-        double bHadron_quark2_dR_;
-        double bHadron_quark1_ptRatio_;
-        double bHadron_quark2_ptRatio_;
+        double hadron_quark1_dR_;
+        double hadron_quark2_dR_;
+        double hadron_quark1_ptRatio_;
+        double hadron_quark2_ptRatio_;
         
-        int bHadron_nLeptonsAll_;
-        int bHadron_nLeptonsViaTau_;
+        int hadron_nLeptonsAll_;
+        int hadron_nLeptonsViaTau_;
         
-        double bHadron_jetPtRatio_;
+        double hadron_jetPtRatio_;
+        double hadron_jetDR_;
 };
 
 bool sort_pairs_second(const std::pair<int, double>& a, const std::pair<int, double>& b) 
@@ -116,7 +132,12 @@ matchGenHFHadrons::matchGenHFHadrons ( const edm::ParameterSet& config):
     genCHadJetIndexToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadJetIndex"))),
     genCHadFlavourToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadFlavour"))),
     genCHadFromTopWeakDecayToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadFromTopWeakDecay"))),
-    genCHadBHadronIdToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadBHadronId")))
+    genCHadBHadronIdToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadBHadronId"))),
+    genCHadPlusMothersToken_(consumes<std::vector<reco::GenParticle> >(config.getParameter<edm::InputTag>("genCHadPlusMothers"))),
+    genCHadPlusMothersIndicesToken_(consumes<std::vector<std::vector<int> > >(config.getParameter<edm::InputTag>("genCHadPlusMothersIndices"))),
+    genCHadIndexToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadIndex"))),
+    genCHadLeptonHadronIndexToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadLeptonHadronIndex"))),
+    genCHadLeptonViaTauToken_(consumes<std::vector<int> >(config.getParameter<edm::InputTag>("genCHadLeptonViaTau")))
 {
 
 }
@@ -167,6 +188,21 @@ void matchGenHFHadrons::analyze(const edm::Event& event, const edm::EventSetup& 
     
     edm::Handle<std::vector<int> > genCHadBHadronId;
     event.getByToken(genCHadBHadronIdToken_, genCHadBHadronId);
+
+    edm::Handle<std::vector<reco::GenParticle> > genCHadPlusMothers;
+    event.getByToken(genCHadPlusMothersToken_, genCHadPlusMothers);
+    
+    edm::Handle<std::vector<std::vector<int> > > genCHadPlusMothersIndices;
+    event.getByToken(genCHadPlusMothersIndicesToken_, genCHadPlusMothersIndices);
+    
+    edm::Handle<std::vector<int> > genCHadIndex;
+    event.getByToken(genCHadIndexToken_, genCHadIndex);
+    
+    edm::Handle<std::vector<int> > genCHadLeptonHadronIndex;
+    event.getByToken(genCHadLeptonHadronIndexToken_, genCHadLeptonHadronIndex);
+    
+    edm::Handle<std::vector<int> > genCHadLeptonViaTau;
+    event.getByToken(genCHadLeptonViaTauToken_, genCHadLeptonViaTau);
     
 
     // Counting number of jets of different flavours in the event
@@ -204,7 +240,7 @@ void matchGenHFHadrons::analyze(const edm::Event& event, const edm::EventSetup& 
     }
     
     // Map <jet index, number of specific hadrons in the jet>
-    // B jets with b hadrons directly from top quark decay
+    // B jets with b hadrons directly from top quark decay (including those not in acceptance)
     std::map<int, int> bJetFromTopIds_all;
     // B jets with b hadrons directly from top quark decay
     std::map<int, int> bJetFromTopIds;
@@ -221,6 +257,8 @@ void matchGenHFHadrons::analyze(const edm::Event& event, const edm::EventSetup& 
     for(size_t hadronId = 0; hadronId < genBHadIndex->size(); ++hadronId) {
         // Flavour of the hadron's origin
         const int flavour = genBHadFlavour->at(hadronId);
+        // Skipping b hadrons from W-boson decays (in semileptonic or full-hadronic channels)
+        if(std::abs(flavour) == 24) continue;
         // Whether hadron radiated before top quark decay
         const bool afterTopDecay = genBHadFromTopWeakDecay->at(hadronId) > 0 ? true : false;
         // Index of a jet associated to the hadron
@@ -259,6 +297,10 @@ void matchGenHFHadrons::analyze(const edm::Event& event, const edm::EventSetup& 
     for(size_t hadronId = 0; hadronId < genCHadJetIndex->size(); ++hadronId) {
         // Skipping c hadrons that are coming from b hadrons
         if(genCHadBHadronId->at(hadronId) >= 0) continue;
+        // Flavour of the hadron's origin
+        const int flavour = genCHadFlavour->at(hadronId);
+        // Skipping c hadrons from W-boson decays (in semileptonic or full-hadronic channels)
+        if(std::abs(flavour) == 24) continue;
         // Index of a jet associated to the hadron
         const int jetIndex = genCHadJetIndex->at(hadronId);
         // Whether hadron radiated after top quark decay
@@ -313,131 +355,72 @@ void matchGenHFHadrons::analyze(const edm::Event& event, const edm::EventSetup& 
         pseudoadditionalCJetIds.push_back(jetId);
     }
     
-    // Categorizing event based on number of additional b/c jets 
-    // and number of corresponding hadrons in each of them
+    // Categorizing event based on number of additional b/c jets and number of corresponding hadrons in each of them 
+    // Exclusively for dileptonic final states of the ttbar system (may be unapplicable for other decay channels)
     additionalJetEventId_ = bJetFromTopIds.size()*100;
     // tt + 1 additional b jet
     if (additionalBJetIds.size() == 1) {
         int nHadronsInJet = bJetBeforeTopIds[additionalBJetIds.at(0)];
         // tt + 1 additional b jet from 1 additional b hadron
-        if(nHadronsInJet == 1) additionalJetEventId_ = 51;
+        if(nHadronsInJet == 1) additionalJetEventId_ += 51;
         // tt + 1 additional b jet from >=2 additional b hadrons
-        else additionalJetEventId_ = 52;
+        else additionalJetEventId_ += 52;
     }
     // tt + 2 additional b jets
     else if (additionalBJetIds.size() > 1) {
         int nHadronsInJet1 = bJetBeforeTopIds[additionalBJetIds.at(0)];
         int nHadronsInJet2 = bJetBeforeTopIds[additionalBJetIds.at(1)];
         // tt + 2 additional b jets each from 1 additional b hadron
-        if(std::max(nHadronsInJet1, nHadronsInJet2) == 1) additionalJetEventId_ = 53;
+        if(std::max(nHadronsInJet1, nHadronsInJet2) == 1) additionalJetEventId_ += 53;
         // tt + 2 additional b jets one of which from >=2 overlapping additional b hadrons
-        else if(std::min(nHadronsInJet1, nHadronsInJet2) == 1 && std::max(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ = 54;
+        else if(std::min(nHadronsInJet1, nHadronsInJet2) == 1 && std::max(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ += 54;
         // tt + 2 additional b jets each from >=2 additional b hadrons
-        else if(std::min(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ = 55;
+        else if(std::min(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ += 55;
     }
     // tt + no additional b jets
     else if(additionalBJetIds.size() == 0) {
         // tt + >=1 pseudo-additional b jet with b hadrons after top quark decay
-        if(pseudoadditionalBJetIds.size() > 0) additionalJetEventId_ = 56;
+        if(pseudoadditionalBJetIds.size() > 0) additionalJetEventId_ += 56;
         // tt + 1 additional c jet
         else if(additionalCJetIds.size() == 1) {
             int nHadronsInJet = cJetBeforeTopIds[additionalCJetIds.at(0)];
             // tt + 1 additional c jet from 1 additional c hadron
-            if(nHadronsInJet == 1) additionalJetEventId_ = 41;
+            if(nHadronsInJet == 1) additionalJetEventId_ += 41;
             // tt + 1 additional c jet from >=2 overlapping additional c hadrons
-            else additionalJetEventId_ = 42;
+            else additionalJetEventId_ += 42;
         }
         // tt + >=2 additional c jets
         else if(additionalCJetIds.size() > 1) {
             int nHadronsInJet1 = cJetBeforeTopIds[additionalCJetIds.at(0)];
             int nHadronsInJet2 = cJetBeforeTopIds[additionalCJetIds.at(1)];
             // tt + 2 additional c jets each from 1 additional c hadron
-            if(std::max(nHadronsInJet1, nHadronsInJet2) == 1) additionalJetEventId_ = 43;
+            if(std::max(nHadronsInJet1, nHadronsInJet2) == 1) additionalJetEventId_ += 43;
             // tt + 2 additional c jets one of which from >=2 overlapping additional c hadrons
-            else if(std::min(nHadronsInJet1, nHadronsInJet2) == 1 && std::max(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ = 44;
+            else if(std::min(nHadronsInJet1, nHadronsInJet2) == 1 && std::max(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ += 44;
             // tt + 2 additional c jets each from >=2 additional c hadrons
-            else if(std::min(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ = 45;
+            else if(std::min(nHadronsInJet1, nHadronsInJet2) > 1) additionalJetEventId_ += 45;
         }
         // tt + no additional c jets
         else if(additionalCJetIds.size() == 0) {
             // tt + >=1 pseudo-additional c jet with c hadrons after top quark decay
-            if(pseudoadditionalCJetIds.size() > 0) additionalJetEventId_ = 46;
+            if(pseudoadditionalCJetIds.size() > 0) additionalJetEventId_ += 46;
             // tt + light jets
-            else additionalJetEventId_ = 0;
+            else additionalJetEventId_ += 0;
         }
     }
     
     
     // Performance information filled in a tree with entry for each b hadron #######################################
-    // Looping over all b hadrons
-    for(size_t hadronId = 0; hadronId < genBHadIndex->size(); ++hadronId) {
-        clearBHadronVariables();
-
-        const int hadronParticleId = genBHadIndex->at(hadronId);
-        if(hadronParticleId < 0) continue;
-        
-        // Calculating hadron/jet pt ratio
-        const int hadronJetId = genBHadJetIndex->at(hadronId);
-        if(hadronJetId >= 0) {
-            bHadron_jetPtRatio_ = genBHadPlusMothers->at(genBHadIndex->at(hadronId)).pt() / genJets->at(hadronJetId).pt();
-        }
-        
-        const int hadronParticlePdgId = genBHadPlusMothers->at(hadronParticleId).pdgId();
-        bHadron_flavour_ = genBHadFlavour->at(hadronId);
-        // Finding all b quark candidates
-        std::set<int> hadronLastQuarks;
-        findAncestorParticles(hadronParticleId, hadronLastQuarks, *genBHadPlusMothers, *genBHadPlusMothersIndices, 5, true, 1);
-        bHadron_nQuarksAll_ = hadronLastQuarks.size();
-        // Identifying flavour of the proper candidate quark
-        int quarkCandidateFlavourSign = hadronParticlePdgId > 0 ? 1 : -1;
-        // Inverting flavour if this is a b meson
-        if(hadronParticlePdgId / 1000 == 0) quarkCandidateFlavourSign *= -1;
-        // Selecting candidates that have proper flavour sign
-        std::vector<std::pair<int, double> > hadronLastQuarks_sameFlavour;
-        for(std::set<int>::iterator it=hadronLastQuarks.begin(); it!=hadronLastQuarks.end(); ++it) {
-            const int quarkParticleId = *it;
-            if(quarkParticleId < 0) continue;
-            const int quarkParticlePdgId = genBHadPlusMothers->at(quarkParticleId).pdgId();
-            // Skipping quarks that have opposite flavour sign
-            if(quarkParticlePdgId * quarkCandidateFlavourSign < 0) continue;
-            double hadron_quark_dR = ROOT::Math::VectorUtil::DeltaR(genBHadPlusMothers->at(hadronParticleId).polarP4(), genBHadPlusMothers->at(quarkParticleId).polarP4());
-            hadronLastQuarks_sameFlavour.push_back( std::pair<int, double>(quarkParticleId, hadron_quark_dR) );
-        }
-        bHadron_nQuarksSameFlavour_ = hadronLastQuarks_sameFlavour.size();
-        
-        // Sorting quarks with proper flavour by their dR
-        std::sort(hadronLastQuarks_sameFlavour.begin(), hadronLastQuarks_sameFlavour.end(), sort_pairs_second);
-        const int hadronQuark1ParticleId = hadronLastQuarks_sameFlavour.size() > 0 ? hadronLastQuarks_sameFlavour.at(0).first : -1;
-        const int hadronQuark2ParticleId = hadronLastQuarks_sameFlavour.size() > 1 ? hadronLastQuarks_sameFlavour.at(1).first : -1;
-        
-        if(hadronQuark1ParticleId >= 0) {
-            bHadron_quark1_dR_ = ROOT::Math::VectorUtil::DeltaR(genBHadPlusMothers->at(hadronParticleId).polarP4(), genBHadPlusMothers->at(hadronQuark1ParticleId).polarP4());
-            bHadron_quark1_ptRatio_ = genBHadPlusMothers->at(hadronParticleId).pt() / genBHadPlusMothers->at(hadronQuark1ParticleId).pt();
-        }
-        
-        if(hadronQuark2ParticleId >= 0) {
-            bHadron_quark2_dR_ = ROOT::Math::VectorUtil::DeltaR(genBHadPlusMothers->at(hadronParticleId).polarP4(), genBHadPlusMothers->at(hadronQuark2ParticleId).polarP4());
-            bHadron_quark2_ptRatio_ = genBHadPlusMothers->at(hadronParticleId).pt() / genBHadPlusMothers->at(hadronQuark2ParticleId).pt();
-        }
-        
-        // Counting number of leptons coming from the b hadron decay
-        for(size_t leptonId = 0; leptonId < genBHadLeptonHadronIndex->size(); ++leptonId) {
-            const size_t leptonHadronId = genBHadLeptonHadronIndex->at(leptonId);
-            // Skipping the lepton id doesn't come from the current b hadron
-            if(leptonHadronId != hadronId) continue;
-            bHadron_nLeptonsAll_++;
-            if(genBHadLeptonViaTau->at(leptonId) == 1) bHadron_nLeptonsViaTau_++;
-        }
-        
-        
-    tree_bHadrons_->Fill();
-    }
+    fillHadronTree(tree_bHadrons_, 5, *genJets, *genBHadIndex, *genBHadJetIndex, *genBHadFlavour, *genBHadFromTopWeakDecay, *genBHadPlusMothers, *genBHadPlusMothersIndices, *genBHadLeptonHadronIndex, *genBHadLeptonViaTau);
+    
+    // Performance information filled in a tree with entry for each c hadron #######################################
+    fillHadronTree(tree_cHadrons_, 4, *genJets, *genCHadIndex, *genCHadJetIndex, *genCHadFlavour, *genCHadFromTopWeakDecay, *genCHadPlusMothers, *genCHadPlusMothersIndices, *genCHadLeptonHadronIndex, *genCHadLeptonViaTau, *genCHadBHadronId);
     
     tree_events_->Fill();
 }
 
 
-void matchGenHFHadrons::findAncestorParticles(const int startId, std::set<int>& resultIds, 
+void matchGenHFHadrons::findAncestorParticles( const int startId, std::set<int>& resultIds, 
                                                const std::vector<reco::GenParticle>& genParticles, const std::vector<std::vector<int> >& motherIndices, 
                                                const int endPdgId, const bool endPdgIdIsAbs, const int firstAnyLast)
 {
@@ -503,6 +486,7 @@ void matchGenHFHadrons::beginJob()
     if(!fileService) throw edm::Exception(edm::errors::Configuration, "TFileService is not registered in cfg file");
     tree_events_ = fileService->make<TTree>("tree_events", "tree_events");
     tree_bHadrons_ = fileService->make<TTree>("tree_bHadrons", "tree_bHadrons");
+    tree_cHadrons_ = fileService->make<TTree>("tree_cHadrons", "tree_cHadrons");
     
     // Creating output branches
     tree_events_->Branch("nJets", &nJets_);
@@ -521,19 +505,30 @@ void matchGenHFHadrons::beginJob()
     tree_events_->Branch("nBHadronsHiggs", &nBHadronsHiggs_);
     tree_events_->Branch("additionalJetEventId", &additionalJetEventId_);
     
-    tree_bHadrons_->Branch("bHadron_flavour", &bHadron_flavour_);
-    tree_bHadrons_->Branch("bHadron_nQuarksAll", &bHadron_nQuarksAll_);
-    tree_bHadrons_->Branch("bHadron_nQuarksSameFlavour", &bHadron_nQuarksSameFlavour_);
+    bookHadronBranches(tree_bHadrons_, 5);
+    bookHadronBranches(tree_cHadrons_, 4);
+}
+
+
+void matchGenHFHadrons::bookHadronBranches(TTree* tree, const int flavour)
+{
+    tree->Branch("flavour", &hadron_flavour_);
+    tree->Branch("nQuarksAll", &hadron_nQuarksAll_);
+    tree->Branch("nQuarksSameFlavour", &hadron_nQuarksSameFlavour_);
+    tree->Branch("fromTopWeakDecay", &hadron_fromTopWeakDecay_);
     
-    tree_bHadrons_->Branch("bHadron_quark1_dR", &bHadron_quark1_dR_);
-    tree_bHadrons_->Branch("bHadron_quark2_dR", &bHadron_quark2_dR_);
-    tree_bHadrons_->Branch("bHadron_quark1_ptRatio", &bHadron_quark1_ptRatio_);
-    tree_bHadrons_->Branch("bHadron_quark2_ptRatio", &bHadron_quark2_ptRatio_);
+    tree->Branch("quark1_dR", &hadron_quark1_dR_);
+    tree->Branch("quark2_dR", &hadron_quark2_dR_);
+    tree->Branch("quark1_ptRatio", &hadron_quark1_ptRatio_);
+    tree->Branch("quark2_ptRatio", &hadron_quark2_ptRatio_);
     
-    tree_bHadrons_->Branch("bHadron_nLeptonsAll", &bHadron_nLeptonsAll_);
-    tree_bHadrons_->Branch("bHadron_nLeptonsViaTau", &bHadron_nLeptonsViaTau_);
+    tree->Branch("nLeptonsAll", &hadron_nLeptonsAll_);
+    tree->Branch("nLeptonsViaTau", &hadron_nLeptonsViaTau_);
     
-    tree_bHadrons_->Branch("bHadron_jetPtRatio", &bHadron_jetPtRatio_);
+    tree->Branch("jetPtRatio", &hadron_jetPtRatio_);
+    tree->Branch("jetDR", &hadron_jetDR_);
+    
+    if(flavour == 4) tree->Branch("bHadronId", &hadron_bHadronId_);
 }
 
 
@@ -553,28 +548,106 @@ void matchGenHFHadrons::clearEventVariables()
     nCHadronsPseudoadditional_ = 0;
     
     nBHadronsHiggs_ = 0;
-    additionalJetEventId_ = -1;
+    additionalJetEventId_ += -1;
 }
 
 
-void matchGenHFHadrons::clearBHadronVariables()
+void matchGenHFHadrons::clearHadronVariables()
 {
-    bHadron_flavour_ = 0;
-    bHadron_nQuarksAll_ = 0;
-    bHadron_nQuarksSameFlavour_ = 0;
+    hadron_flavour_ = 0;
+    hadron_nQuarksAll_ = 0;
+    hadron_nQuarksSameFlavour_ = 0;
+    hadron_fromTopWeakDecay_ = -1;
+    hadron_bHadronId_ = -1;
     
-    bHadron_quark1_dR_ = -0.1;
-    bHadron_quark2_dR_ = -0.1;
-    bHadron_quark1_ptRatio_ = -0.1;
-    bHadron_quark2_ptRatio_ = -0.1;
+    hadron_quark1_dR_ = -0.1;
+    hadron_quark2_dR_ = -0.1;
+    hadron_quark1_ptRatio_ = -0.1;
+    hadron_quark2_ptRatio_ = -0.1;
     
     
-    bHadron_nLeptonsAll_ = 0;
-    bHadron_nLeptonsViaTau_ = 0;
+    hadron_nLeptonsAll_ = 0;
+    hadron_nLeptonsViaTau_ = 0;
     
-    bHadron_jetPtRatio_ = -0.1;
+    hadron_jetPtRatio_ = -0.1;
+    hadron_jetDR_ = -0.1;
 }
 
+
+void matchGenHFHadrons::fillHadronTree( TTree* tree, const int flavour, const reco::GenJetCollection& genJets,
+                                        const std::vector<int>& genHadIndex, const std::vector<int>& genHadJetIndex,
+                                        const std::vector<int>& genHadFlavour, const std::vector<int>& genHadFromTopWeakDecay,
+                                        const std::vector<reco::GenParticle>& genHadPlusMothers, 
+                                        const std::vector<std::vector<int> >& genHadPlusMothersIndices,
+                                        const std::vector<int>& genHadLeptonHadronIndex, const std::vector<int>& genHadLeptonViaTau,
+                                        const std::vector<int>& genHadBHadronId )
+{
+    for(size_t hadronId = 0; hadronId < genHadIndex.size(); ++hadronId) {
+        clearHadronVariables();
+
+        const int hadronParticleId = genHadIndex.at(hadronId);
+        if(hadronParticleId < 0) continue;
+        
+        // Calculating hadron/jet pt ratio
+        const int hadronJetId = genHadJetIndex.at(hadronId);
+        if(hadronJetId >= 0) {
+            hadron_jetPtRatio_ = genHadPlusMothers.at(genHadIndex.at(hadronId)).pt() / genJets.at(hadronJetId).pt();
+            hadron_jetDR_ = ROOT::Math::VectorUtil::DeltaR(genHadPlusMothers.at(genHadIndex.at(hadronId)).polarP4(), genJets.at(hadronJetId).polarP4());
+        }
+        
+        if(genHadBHadronId.size() > 0) hadron_bHadronId_ = genHadBHadronId.at(hadronId);
+        hadron_fromTopWeakDecay_ = genHadFromTopWeakDecay.at(hadronId);
+        
+        const int hadronParticlePdgId = genHadPlusMothers.at(hadronParticleId).pdgId();
+        hadron_flavour_ = genHadFlavour.at(hadronId);
+        // Finding all b quark candidates
+        std::set<int> hadronLastQuarks;
+        findAncestorParticles(hadronParticleId, hadronLastQuarks, genHadPlusMothers, genHadPlusMothersIndices, flavour, true, 1);
+        hadron_nQuarksAll_ = hadronLastQuarks.size();
+        // Identifying flavour of the proper candidate quark
+        int quarkCandidateFlavourSign = hadronParticlePdgId / std::abs(hadronParticlePdgId);
+        // Inverting flavour if this is for a b meson
+        if(std::abs(hadronParticlePdgId)/100 == 5 && std::abs(hadronParticlePdgId)%1000/10/11 != 5) quarkCandidateFlavourSign *= -1;
+        // Selecting candidates that have proper flavour sign
+        std::vector<std::pair<int, double> > hadronLastQuarks_sameFlavour;
+        for(std::set<int>::iterator it=hadronLastQuarks.begin(); it!=hadronLastQuarks.end(); ++it) {
+            const int quarkParticleId = *it;
+            if(quarkParticleId < 0) continue;
+            const int quarkParticlePdgId = genHadPlusMothers.at(quarkParticleId).pdgId();
+            // Skipping quarks that have opposite flavour sign
+            if(quarkParticlePdgId * quarkCandidateFlavourSign < 0) continue;
+            double hadron_quark_dR = ROOT::Math::VectorUtil::DeltaR(genHadPlusMothers.at(hadronParticleId).polarP4(), genHadPlusMothers.at(quarkParticleId).polarP4());
+            hadronLastQuarks_sameFlavour.push_back( std::pair<int, double>(quarkParticleId, hadron_quark_dR) );
+        }
+        hadron_nQuarksSameFlavour_ = hadronLastQuarks_sameFlavour.size();
+        
+        // Sorting quarks with proper flavour by their dR
+        std::sort(hadronLastQuarks_sameFlavour.begin(), hadronLastQuarks_sameFlavour.end(), sort_pairs_second);
+        const int hadronQuark1ParticleId = hadronLastQuarks_sameFlavour.size() > 0 ? hadronLastQuarks_sameFlavour.at(0).first : -1;
+        const int hadronQuark2ParticleId = hadronLastQuarks_sameFlavour.size() > 1 ? hadronLastQuarks_sameFlavour.at(1).first : -1;
+        
+        if(hadronQuark1ParticleId >= 0) {
+            hadron_quark1_dR_ = ROOT::Math::VectorUtil::DeltaR(genHadPlusMothers.at(hadronParticleId).polarP4(), genHadPlusMothers.at(hadronQuark1ParticleId).polarP4());
+            hadron_quark1_ptRatio_ = genHadPlusMothers.at(hadronParticleId).pt() / genHadPlusMothers.at(hadronQuark1ParticleId).pt();
+        }
+        
+        if(hadronQuark2ParticleId >= 0) {
+            hadron_quark2_dR_ = ROOT::Math::VectorUtil::DeltaR(genHadPlusMothers.at(hadronParticleId).polarP4(), genHadPlusMothers.at(hadronQuark2ParticleId).polarP4());
+            hadron_quark2_ptRatio_ = genHadPlusMothers.at(hadronParticleId).pt() / genHadPlusMothers.at(hadronQuark2ParticleId).pt();
+        }
+        
+        // Counting number of leptons coming from the b hadron decay
+        for(size_t leptonId = 0; leptonId < genHadLeptonHadronIndex.size(); ++leptonId) {
+            const size_t leptonHadronId = genHadLeptonHadronIndex.at(leptonId);
+            // Skipping the lepton id doesn't come from the current b hadron
+            if(leptonHadronId != hadronId) continue;
+            hadron_nLeptonsAll_++;
+            if(genHadLeptonViaTau.at(leptonId) == 1) hadron_nLeptonsViaTau_++;
+        }
+        
+    tree->Fill();
+    }
+}
 
 
 

--- a/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.py
+++ b/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.py
@@ -19,26 +19,27 @@ if( hasattr(sys, "argv") ):
 
 ## enabling unscheduled mode for modules
 process.options = cms.untracked.PSet(
-    wantSummary = cms.untracked.bool(True),
+    wantSummary = cms.untracked.bool(False),
     allowUnscheduled = cms.untracked.bool(True),
 )
 
 ## configure message logger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'
-process.MessageLogger.cerr.FwkReport.reportEvery = 100
+process.MessageLogger.cerr.FwkReport.reportEvery = 1000
 
 ## define input
 if options.runOnAOD:
     process.source = cms.Source("PoolSource",
         fileNames = cms.untracked.vstring(    
           ## add your favourite AOD files here (1000+ events in each file defined below)
-#	  '/store/relval/CMSSW_7_2_0_pre7/RelValTTbar_13/GEN-SIM-RECO/PU50ns_PRE_LS172_V12-v1/00000/1267B7ED-2F4E-E411-A0B9-0025905964A6.root',
+	  '/store/mc/RunIISpring15DR74/ttHTobb_M125_13TeV_powheg_pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/00000/02203C96-2108-E511-B5C1-00266CFCC214.root',
+	  '/store/mc/RunIISpring15DR74/ttHTobb_M125_13TeV_powheg_pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/00000/02332898-9808-E511-81E8-3417EBE34BFD.root',
+	  '/store/mc/RunIISpring15DR74/ttHTobb_M125_13TeV_powheg_pythia8/AODSIM/Asympt25ns_MCRUN2_74_V9-v1/00000/060177B4-2E08-E511-83AD-3417EBE644DA.root',
 	  ## other AOD samples
-	  '/store/mc/Spring14dr/TTJets_MSDecaysCKM_central_Tune4C_13TeV-madgraph-tauola/AODSIM/PU_S14_POSTLS170_V6-v1/00000/00120F7A-84F5-E311-9FBE-002618943910.root',
-#	  '/store/mc/Spring14dr/TT_Tune4C_13TeV-pythia8-tauola/AODSIM/Flat20to50_POSTLS170_V5-v1/00000/023E1847-ADDC-E311-91A2-003048FFD754.root',
-#	  '/store/mc/Spring14dr/TTbarH_HToBB_M-125_13TeV_pythia6/AODSIM/PU20bx25_POSTLS170_V5-v1/00000/1CAB7E58-0BD0-E311-B688-00266CFFBC3C.root',
-#	  '/store/mc/Spring14dr/TTbarH_M-125_13TeV_amcatnlo-pythia8-tauola/AODSIM/PU20bx25_POSTLS170_V5-v1/00000/0E3D08A9-C610-E411-A862-0025B3E0657E.root',
+#	  '/store/mc/RunIISpring15DR74/TT_TuneCUETP8M1_13TeV-powheg-pythia8/AODSIM/Asympt50ns_MCRUN2_74_V9A-v4/10000/00199A75-540F-E511-8277-0002C92DB464.root',
+#	  '/store/mc/RunIISpring15DR74/TT_TuneCUETP8M1_13TeV-powheg-pythia8/AODSIM/Asympt50ns_MCRUN2_74_V9A-v4/10000/001B27B8-550F-E511-85CF-0025905A609A.root',
+#	  '/store/mc/RunIISpring15DR74/TT_TuneCUETP8M1_13TeV-powheg-pythia8/AODSIM/Asympt50ns_MCRUN2_74_V9A-v4/10000/007E116A-510F-E511-8D40-F04DA275C007.root',
         ),
 	skipEvents = cms.untracked.uint32(0)
     )
@@ -46,7 +47,8 @@ else:
     process.source = cms.Source("PoolSource",
         fileNames = cms.untracked.vstring(    
 	  # add your favourite miniAOD files here (1000+ events in each file defined below)
-	  '/store/cmst3/user/gpetrucc/miniAOD/v1/TTbarH_HToBB_M-125_13TeV_pythia6_PU_S14_PAT.root',
+	  '/store/mc/RunIISpring15DR74/ttHTobb_M125_13TeV_powheg_pythia8/MINIAODSIM/Asympt25ns_MCRUN2_74_V9-v1/00000/141B9915-1F08-E511-B9FF-001E675A6AB3.root',
+#	  '/store/mc/RunIISpring15DR74/TT_TuneCUETP8M1_13TeV-powheg-pythia8/MINIAODSIM/Asympt50ns_MCRUN2_74_V9A-v4/10000/00D2A247-2910-E511-9F3D-0CC47A4DEDD2.root',
 	),
 	skipEvents = cms.untracked.uint32(0)
     )
@@ -92,26 +94,26 @@ process.selectedHadronsAndPartons = selectedHadronsAndPartons.clone(
 # MUST use use proper input jet collection: the jets to which hadrons should be associated
 # rParam and jetAlgorithm MUST match those used for jets to be associated with hadrons
 # More details on the tool: https://twiki.cern.ch/twiki/bin/view/CMSPublic/SWGuideBTagMCTools#New_jet_flavour_definition
-from PhysicsTools.JetMCAlgos.sequences.GenHFHadronMatching_cff import genJetFlavourPlusLeptonInfos
-process.genJetFlavourPlusLeptonInfos = genJetFlavourPlusLeptonInfos.clone(
+from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInfos
+process.genJetFlavourInfos = ak4JetFlavourInfos.clone(
     jets = genJetCollection,
-    rParam = cms.double(0.4),
-    jetAlgorithm = cms.string("AntiKt")
 )
 
 
 # Plugin for analysing B hadrons
 # MUST use the same particle collection as in selectedHadronsAndPartons
-from PhysicsTools.JetMCAlgos.sequences.GenHFHadronMatching_cff import matchGenBHadron
+from PhysicsTools.JetMCAlgos.GenHFHadronMatcher_cff import matchGenBHadron
 process.matchGenBHadron = matchGenBHadron.clone(
-    genParticles = genParticleCollection
+    genParticles = genParticleCollection,
+    jetFlavourInfos = "genJetFlavourInfos"
 )
 
 # Plugin for analysing C hadrons
 # MUST use the same particle collection as in selectedHadronsAndPartons
-from PhysicsTools.JetMCAlgos.sequences.GenHFHadronMatching_cff import matchGenCHadron
+from PhysicsTools.JetMCAlgos.GenHFHadronMatcher_cff import matchGenCHadron
 process.matchGenCHadron = matchGenCHadron.clone(
-    genParticles = genParticleCollection
+    genParticles = genParticleCollection,
+    jetFlavourInfos = "genJetFlavourInfos"
 )
 
 
@@ -134,6 +136,11 @@ process.matchGenHFHadrons = cms.EDAnalyzer("matchGenHFHadrons",
     genCHadFlavour = cms.InputTag("matchGenCHadron", "genCHadFlavour"),
     genCHadFromTopWeakDecay = cms.InputTag("matchGenCHadron", "genCHadFromTopWeakDecay"),
     genCHadBHadronId = cms.InputTag("matchGenCHadron", "genCHadBHadronId"),
+    genCHadPlusMothers = cms.InputTag("matchGenCHadron", "genCHadPlusMothers"),
+    genCHadPlusMothersIndices = cms.InputTag("matchGenCHadron", "genCHadPlusMothersIndices"),
+    genCHadIndex = cms.InputTag("matchGenCHadron", "genCHadIndex"),
+    genCHadLeptonHadronIndex = cms.InputTag("matchGenCHadron", "genCHadLeptonHadronIndex"),
+    genCHadLeptonViaTau = cms.InputTag("matchGenCHadron", "genCHadLeptonViaTau"),
 )
 
 ## setting up output root file


### PR DESCRIPTION
C-hadrons performance as for b hadrons.
Example configuration extended by test of c harons.
Simpler configuration of the JetFlavour tool.
