### PR TITLE
make PFJetId-calculation configurable with maxEta parameter, set defa…

### DIFF
--- a/HLTrigger/JetMET/interface/HLTPFJetIDProducer.h
+++ b/HLTrigger/JetMET/interface/HLTPFJetIDProducer.h
@@ -34,6 +34,7 @@ class HLTPFJetIDProducer : public edm::stream::EDProducer<> {
 
   private:
     double minPt_;
+    double maxEta_;
     double CHF_;              ///< charged hadron fraction
     double NHF_;              ///< neutral hadron fraction
     double CEF_;              ///< charged EM fraction

--- a/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
@@ -17,6 +17,7 @@
 // Constructor
 HLTPFJetIDProducer::HLTPFJetIDProducer(const edm::ParameterSet& iConfig) :
   minPt_    (iConfig.getParameter<double>("minPt")),
+  maxEta_   (iConfig.getParameter<double>("maxEta")),
   CHF_      (iConfig.getParameter<double>("CHF")),
   NHF_      (iConfig.getParameter<double>("NHF")),
   CEF_      (iConfig.getParameter<double>("CEF")),
@@ -37,6 +38,7 @@ HLTPFJetIDProducer::~HLTPFJetIDProducer() {}
 void HLTPFJetIDProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<double>("minPt", 20.);
+    desc.add<double>("maxEta", 5.2);
     desc.add<double>("CHF", -99.);
     desc.add<double>("NHF", 99.);
     desc.add<double>("CEF", 99.);
@@ -66,8 +68,8 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
         if (pt < minPt_) {
             pass = true;
 
-        //} else if (std::abs(eta) >= 2.4) {
-        //    pass = true;
+        } else if (std::abs(eta) >= maxEta_) {
+            pass = true;
 
         } else {
             double chf  = j->chargedHadronEnergyFraction();
@@ -81,7 +83,7 @@ void HLTPFJetIDProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSet
             pass = true;
             pass = pass && (ntot > NTOT_);
             pass = pass && (nef < NEF_);
-            pass = pass && (nhf < NHF_);
+            pass = pass && (nhf < NHF_); //to be revisited if PF-reconstruction at HLT changes to be in line with offline code
             pass = pass && (cef < CEF_ || std::abs(eta) >= 2.4);
             pass = pass && (chf > CHF_ || std::abs(eta) >= 2.4);
             pass = pass && (nch > NCH_ || std::abs(eta) >= 2.4);

--- a/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
+++ b/HLTrigger/JetMET/src/HLTPFJetIDProducer.cc
@@ -38,7 +38,7 @@ HLTPFJetIDProducer::~HLTPFJetIDProducer() {}
 void HLTPFJetIDProducer::fillDescriptions(edm::ConfigurationDescriptions & descriptions) {
     edm::ParameterSetDescription desc;
     desc.add<double>("minPt", 20.);
-    desc.add<double>("maxEta", 5.2);
+    desc.add<double>("maxEta", 1e99);
     desc.add<double>("CHF", -99.);
     desc.add<double>("NHF", 99.);
     desc.add<double>("CEF", 99.);


### PR DESCRIPTION
…ult to eta 5.2

This is to have the flexibility to restrict the eta-range in which the PFJetId is applied online (e.g. in case of problems with the definition of the JetId as experienced recently offline due to PF-changes in the HF)
