### PR TITLE
move stage1 only to methods to be used in 2015C data

### DIFF
--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -30,11 +30,15 @@ def customiseCosmicData(process):
 ##############################################################################
 # this is supposed to be added on top of other (Run1) data customs
 def customiseDataRun2Common(process):
-    process.CSCGeometryESModule.useGangedStripsInME1a = cms.bool(False)
-    process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
-    process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
-    process.csc2DRecHits.readBadChannels = cms.bool(False)
-    process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
+    if hasattr(process,'CSCGeometryESModule'):
+        process.CSCGeometryESModule.useGangedStripsInME1a = cms.bool(False)
+    if hasattr(process,'CSCIndexerESProducer'):
+        process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
+    if hasattr(process,'CSCChannelMapperESProducer'):
+        process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
+    if hasattr(process,'csc2DRecHits'):
+        process.csc2DRecHits.readBadChannels = cms.bool(False)
+        process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
     if hasattr(process,'valCscTriggerPrimitiveDigis'):
         #this is not doing anything at the moment
         process.valCscTriggerPrimitiveDigis.commonParam.gangedME1a = cms.untracked.bool(False)

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -41,9 +41,6 @@ def customiseDataRun2Common(process):
     if hasattr(process,'valCsctfTrackDigis'):
         process.valCsctfTrackDigis.gangedME1a = cms.untracked.bool(False)
 
-    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
-    process=customiseL1RecoForStage1(process)
-
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_Reco,customise_RawToDigi,customise_DQM
     if hasattr(process,'RawToDigi'):
         process=customise_RawToDigi(process)
@@ -55,18 +52,24 @@ def customiseDataRun2Common(process):
     return process
 
 ##############################################################################
-# common+25ns
+# common+ "25ns" Use this for data daking starting from runs in 2015C (>= 253256 )
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common(process)
+
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
+    process=customiseL1RecoForStage1(process)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):
         process=customise_DQM_25ns(process)
     return process
 
-# common+50ns. Needed only for runs >= 253000
+# common+50ns. Needed only for runs >= 253000 if taken with 50ns
 def customiseDataRun2Common_50nsRunsAfter253000(process):
     process = customiseDataRun2Common(process)
+
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
+    process=customiseL1RecoForStage1(process)
 
     if hasattr(process,'particleFlowClusterECAL'):
         process.particleFlowClusterECAL.energyCorrector.autoDetectBunchSpacing = False
@@ -80,7 +83,7 @@ def customiseDataRun2Common_50nsRunsAfter253000(process):
 ##############################################################################
 def customiseCosmicDataRun2(process):
     process = customiseCosmicData(process)
-    process = customiseDataRun2Common(process)
+    process = customiseDataRun2Common_25ns(process)
     return process
 
 
@@ -100,8 +103,8 @@ def customiseVALSKIM(process):
 def customiseExpress(process):
     process= customisePPData(process)
 
-    import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-    process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
     
     return process
 
@@ -128,7 +131,7 @@ def customisePrompt(process):
     #add the lumi producer in the prompt reco only configuration
     if not hasattr(process,'lumiProducer'):
         #unscheduled..
-        from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
         process.lumiProducer=lumiProducer
     process.reconstruction_step+=process.lumiProducer
 
@@ -161,8 +164,8 @@ def customisePromptRun2B0T(process):
 def customiseExpressHI(process):
     #deprecated process= customiseCommonHI(process)
 
-    import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-    process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
     
     return process
 
@@ -170,13 +173,13 @@ def customiseExpressHI(process):
 def customisePromptHI(process):
     #deprecated process= customiseCommonHI(process)
 
-    import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-    process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
 
      #add the lumi producer in the prompt reco only configuration
     if not hasattr(process,'lumiProducer'):
         #unscheduled..
-        from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
         process.lumiProducer=lumiProducer
     process.reconstruction_step+=process.lumiProducer
         


### PR DESCRIPTION
- move stage1 only to methods to be used in 2015C data (removed it from RecoTLR.customiseDataRun2Common, which is recommended for 2015A and 2015B reprocessing):
  - customiseDataRun2Common_25ns
  - customiseDataRun2Common_50nsRunsAfter253000
- added hasattr to modifiers in RecoTLR.customiseDataRun2Common so that it can be used directly at runTheMatrix level
- also, cleaned up import statements which begin to give warnings in 75X/76X

tested by comparing parsed/expanded configs in pp, ppRun2, cosmicsRun2, HeavyIons:
- only cosmicsRun2 now picks up the Hcal noise config that's in customiseDataRun2Common_25ns

tested by comparing step3 parsed/expanded  config in 4.53 with RecoTLR.customiseDataRun2Common applied to emulate a data reprocessing configuration: changes are as expected: 
- caloStage1Digis, caloStage1LegacyFormatDigis are gone
- dqmL1ExtraParticles, l1extraParticles switch to using gctDigis

@mulhearn 
