### PR TITLE
Factorise PreSplitting configuration from InitialStep

### DIFF
--- a/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
+++ b/RecoTracker/IterativeTracking/python/InitialStepPreSplitting_cff.py
@@ -49,8 +49,8 @@ initialStepTrajectoryFilterPreSplitting = cms.PSet(
 )
 
 import RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorESProducer_cfi
-initialStepChi2Est = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(
-    ComponentName = cms.string('initialStepChi2Est'),
+initialStepChi2EstPreSplitting = RecoTracker.MeasurementDet.Chi2ChargeMeasurementEstimatorESProducer_cfi.Chi2ChargeMeasurementEstimator.clone(
+    ComponentName = cms.string('initialStepChi2EstPreSplitting'),
     nSigma = cms.double(3.0),
     MaxChi2 = cms.double(30.0),
     clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutLoose')),

--- a/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
+++ b/RecoTracker/IterativeTracking/python/iterativeTk_cff.py
@@ -1,7 +1,7 @@
 import FWCore.ParameterSet.Config as cms
 
-from RecoTracker.IterativeTracking.InitialStep_cff import *
 from RecoTracker.IterativeTracking.InitialStepPreSplitting_cff import *
+from RecoTracker.IterativeTracking.InitialStep_cff import *
 from RecoTracker.IterativeTracking.DetachedTripletStep_cff import *
 from RecoTracker.IterativeTracking.LowPtTripletStep_cff import *
 from RecoTracker.IterativeTracking.PixelPairStep_cff import *


### PR DESCRIPTION
Completely factorise PreSplitting from InitialStep configuration, so  that they can be tuned independently. Fix order of python import logic. No regression expected.
