### PR TITLE
Fix build errors

### DIFF
--- a/DPGAnalysis/SiStripTools/bin/DPGAnalysisSiStripToolsMacrosLinkDef.h
+++ b/DPGAnalysis/SiStripTools/bin/DPGAnalysisSiStripToolsMacrosLinkDef.h
@@ -47,5 +47,5 @@
 #pragma link C++ function ComputeOOTFractionvsFill;
 #pragma link C++ class OOTResult;
 #pragma link C++ class OOTSummary;
-#pragma link C++ function BSvsBPIX;
+#pragma link C++ function BSvsBPIXPlot;
 #endif

--- a/DPGAnalysis/SiStripTools/plugins/L1ABCDebugger.cc
+++ b/DPGAnalysis/SiStripTools/plugins/L1ABCDebugger.cc
@@ -155,11 +155,11 @@ L1ABCDebugger::beginRun(const edm::Run& iRun, const edm::EventSetup& iSetup) {
   }
   if(m_horboffvsorb && *m_horboffvsorb) {
     (*m_horboffvsorb)->GetXaxis()->SetTitle("Orbit");    (*m_horboffvsorb)->GetYaxis()->SetTitle("#Delta orbit (SCAL-Event)");
-    (*m_horboffvsorb)->SetCanExtend(TH1::kXaxis);
+    (*m_horboffvsorb)->SetBit(TH1::kCanRebin);
   }
   if(m_hbxoffvsorb && *m_hbxoffvsorb) {
     (*m_hbxoffvsorb)->GetXaxis()->SetTitle("Orbit");    (*m_hbxoffvsorb)->GetYaxis()->SetTitle("#Delta BX (SCAL-Event)");
-    (*m_hbxoffvsorb)->SetCanExtend(TH1::kXaxis);
+    (*m_hbxoffvsorb)->SetBit(TH1::kCanRebin);
   }
 
 

--- a/DQM/BeamMonitor/plugins/BeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/BeamMonitor.cc
@@ -161,7 +161,7 @@ void BeamMonitor::beginJob() {
   h_nVtx_lumi->setAxisTitle("Num of Vtx for Fit",2);
   
   h_nVtx_lumi_all=dbe_->book1D("nVtx_lumi_all","Num. of selected Vtx vs lumi (Fit) all",20,0.5,20.5);
-  h_nVtx_lumi_all->getTH1()->SetCanExtend(TH1::kAllAxes);
+  h_nVtx_lumi_all->getTH1()->SetBit(TH1::kCanRebin);
   h_nVtx_lumi_all->setAxisTitle("Lumisection",1);
   h_nVtx_lumi_all->setAxisTitle("Num of Vtx for Fit",2);
 


### PR DESCRIPTION
This PR fixes fatal build errors in CMSSW_7_4_ROOT5_X.
All but one of these were caused by ROOT6 specific calls being automatically merged from CMSSW_7_4_X.
One was caused by the use of an incorrect function name (i.e. the name of a nonexistent function) in a LinkDef.h fiile.  The name is replaced by the correct function name.
Please expedite this totally trivial and technical PR.
