### PR TITLE
Pileup summary info slimmer for MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PileupSummaryInfoSlimmer.cc
@@ -1,0 +1,76 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+
+#include "SimDataFormats/PileupSummaryInfo/interface/PileupSummaryInfo.h"
+
+#include <iostream>
+
+class PileupSummaryInfoSlimmer : public edm::global::EDProducer<> {
+public:
+  PileupSummaryInfoSlimmer(const edm::ParameterSet& conf) :
+    src_(consumes<std::vector<PileupSummaryInfo> >(conf.getParameter<edm::InputTag>("src"))),
+    keepDetailedInfoFor_(conf.getParameter<std::vector<int32_t> >("keepDetailedInfoFor")) {
+    produces<std::vector<PileupSummaryInfo> >();
+  }
+
+  void produce(edm::StreamID, edm::Event &, edm::EventSetup const &) const override final;
+
+private:
+  const edm::EDGetTokenT<std::vector<PileupSummaryInfo> > src_;
+  const std::vector<int> keepDetailedInfoFor_;
+};
+
+void PileupSummaryInfoSlimmer::produce(edm::StreamID, 
+                                       edm::Event& evt,
+                                       const edm::EventSetup& es ) const {
+  edm::Handle<std::vector<PileupSummaryInfo> > input;
+  std::auto_ptr<std::vector<PileupSummaryInfo> > output( new std::vector<PileupSummaryInfo> );
+
+  evt.getByToken(src_,input);
+  
+  for( const auto& psu : *input ) {
+    const int bunchCrossing = psu.getBunchCrossing();
+    const int bunchSpacing = psu.getBunchSpacing();
+    const int num_PU_vertices = psu.getPU_NumInteractions();
+    const float TrueNumInteractions = psu.getTrueNumInteractions();
+    
+    std::vector<float> zpositions;
+    std::vector<float> sumpT_lowpT;
+    std::vector<float> sumpT_highpT;
+    std::vector<int> ntrks_lowpT;
+    std::vector<int> ntrks_highpT;
+    std::vector<edm::EventID> eventInfo;
+    std::vector<float> pT_hats;
+
+    const bool keep_details = std::find(keepDetailedInfoFor_.begin(),
+                                        keepDetailedInfoFor_.end(),
+                                        bunchCrossing) != keepDetailedInfoFor_.end();
+    
+    if( keep_details ) {
+      zpositions   = psu.getPU_zpositions();
+      sumpT_lowpT  = psu.getPU_sumpT_lowpT();
+      sumpT_highpT = psu.getPU_sumpT_highpT();
+      ntrks_lowpT  = psu.getPU_ntrks_lowpT();
+      ntrks_highpT = psu.getPU_ntrks_highpT();
+      eventInfo    = psu.getPU_EventID();
+      pT_hats      = psu.getPU_pT_hats();
+    }
+    // insert the slimmed vertex info
+    output->emplace_back(num_PU_vertices,
+                         zpositions,
+                         sumpT_lowpT, sumpT_highpT,
+                         ntrks_lowpT, ntrks_highpT,
+                         eventInfo,
+                         pT_hats,
+                         bunchCrossing,
+                         TrueNumInteractions,
+                         bunchSpacing);
+  }
+
+  evt.put(output);
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(PileupSummaryInfoSlimmer);

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -57,7 +57,7 @@ MicroEventContentMC.outputCommands += [
         'keep patPackedGenParticles_packedGenParticles_*_*',
         'keep recoGenParticles_prunedGenParticles_*_*',
         'keep LHEEventProduct_*_*_*',
-        'keep PileupSummaryInfos_*_*_*',
+        'keep PileupSummaryInfos_slimmedAddPileupInfo_*_*',
         'keep GenFilterInfo_*_*_*',
         'keep GenLumiInfoProduct_*_*_*',
         'keep GenEventInfoProduct_generator_*_*',

--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -3,6 +3,9 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.SelectorUtils.tools.vid_id_tools import *
 
 def miniAOD_customizeCommon(process):
+    #slimmed pileup information
+    process.load('PhysicsTools.PatAlgos.slimming.slimmedAddPileupInfo_cfi')
+
     process.patMuons.isoDeposits = cms.PSet()
     process.patElectrons.isoDeposits = cms.PSet()
     process.patTaus.isoDeposits = cms.PSet()

--- a/PhysicsTools/PatAlgos/python/slimming/slimmedAddPileupInfo_cfi.py
+++ b/PhysicsTools/PatAlgos/python/slimming/slimmedAddPileupInfo_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+slimmedAddPileupInfo = cms.EDProducer(
+    'PileupSummaryInfoSlimmer',
+    src = cms.InputTag('addPileupInfo'),
+    keepDetailedInfoFor = cms.vint32(0)
+)


### PR DESCRIPTION
Per a line of investigation in the flashgg group I took a look at slimming the PileupSummaryInfos.
The results are quite nice when keeping the details only for the in-time bunch crossing, and then zeroing out all the vectors of track pTs and such for all others.

Bunch spacing, number of interactions, and true pileup mean are kept for all crossings.

You can see the benchmarking info here:
https://github.com/cms-analysis/flashgg/issues/269#issuecomment-128082635

It would seem a good idea just to include this in MiniAOD already since it saves 4.5kb/ev on TTBar 25ns (calculated from 100 events). Can only get better for more complex things.

@gpetruc @arizzi 
