### PR TITLE
Convert all remaining MiniAOD modules to threaded FW (74X)

### DIFF
--- a/CommonTools/ParticleFlow/plugins/TopProjector.h
+++ b/CommonTools/ParticleFlow/plugins/TopProjector.h
@@ -8,7 +8,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -134,7 +134,7 @@ template < class Top, class Bottom>
 };
 
 template< class Top, class Bottom, class Matcher = TopProjectorFwdPtrOverlap<Top,Bottom> >
-class TopProjector : public edm::EDProducer {
+class TopProjector : public edm::stream::EDProducer<> {
 
  public:
 
@@ -199,8 +199,8 @@ TopProjector< Top, Bottom, Matcher>::TopProjector(const edm::ParameterSet& iConf
 
 
 template< class Top, class Bottom, class Matcher >
-void TopProjector< Top, Bottom, Matcher >::produce(edm::Event& iEvent,
-					  const edm::EventSetup& iSetup) {
+void TopProjector< Top, Bottom, Matcher >::produce( edm::Event& iEvent,
+                                                    const edm::EventSetup& iSetup) {
   // get the various collections
 
   // Access the masking collection

--- a/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
+++ b/CommonTools/RecoAlgos/plugins/JetDeltaRValueMapProducer.cc
@@ -16,7 +16,7 @@
  */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "DataFormats/JetReco/interface/Jet.h"
 #include "DataFormats/JetReco/interface/PFJet.h"
@@ -29,7 +29,7 @@
 #include "DataFormats/Math/interface/deltaR.h"
 
 template < class T >
-class JetDeltaRValueMapProducer : public edm::EDProducer {
+class JetDeltaRValueMapProducer : public edm::global::EDProducer<> {
 
 public:
 
@@ -47,7 +47,7 @@ public:
   {
     if( value_!="" )
     {
-      evaluationMap_.insert( std::make_pair( value_, StringObjectFunction<T>( value_, lazyParser_ ) ) );
+      evaluationMap_.insert( std::make_pair( value_, std::unique_ptr<StringObjectFunction<T> >( new StringObjectFunction<T>( value_, lazyParser_ ) ) ) );
       produces< JetValueMap >();
     }
 
@@ -58,7 +58,7 @@ public:
         multiValue_ = true;
         for( size_t i=0; i<valueLabels_.size(); ++i)
         {
-          evaluationMap_.insert( std::make_pair( valueLabels_[i], StringObjectFunction<T>( values_[i], lazyParser_ ) ) );
+          evaluationMap_.insert( std::make_pair( valueLabels_[i], std::unique_ptr<StringObjectFunction<T> >( new StringObjectFunction<T>( values_[i], lazyParser_ ) ) ) );
           produces< JetValueMap >(valueLabels_[i]);
         }
       }
@@ -74,7 +74,7 @@ private:
   virtual void beginJob() override {}
   virtual void endJob() override {}
 
-  virtual void produce(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+  virtual void produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
 
     edm::Handle< typename edm::View<T> > h_jets1;
     iEvent.getByToken( srcToken_, h_jets1 );
@@ -121,11 +121,11 @@ private:
         {
           jets1_locks.at(matched_index) = true;
           if( value_!="" )
-            values.at(matched_index) = (evaluationMap_.at(value_))(*ijet);
+            values.at(matched_index) = (*(evaluationMap_.at(value_)))(*ijet);
           if( multiValue_ )
           {
             for( size_t i=0; i<valueLabels_.size(); ++i)
-              valuesMap.at(valueLabels_[i]).at(matched_index) = (evaluationMap_.at(valueLabels_[i]))(*ijet);
+              valuesMap.at(valueLabels_[i]).at(matched_index) = (*(evaluationMap_.at(valueLabels_[i])))(*ijet);
           }
         }
       }
@@ -166,7 +166,7 @@ private:
   const std::vector<std::string>                   valueLabels_;
   const bool                                       lazyParser_;
   bool                                             multiValue_;
-  std::map<std::string, StringObjectFunction<T> >  evaluationMap_;
+  std::map<std::string, std::unique_ptr<const StringObjectFunction<T> > >  evaluationMap_;
 };
 
 typedef JetDeltaRValueMapProducer<reco::Jet> RecoJetDeltaRValueMapProducer;

--- a/CommonTools/UtilAlgos/interface/PhysObjectMatcher.h
+++ b/CommonTools/UtilAlgos/interface/PhysObjectMatcher.h
@@ -10,7 +10,7 @@
  *  (3) the ranking of several matches.
  *
  */
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/UtilAlgos/interface/DeltaR.h"
@@ -60,7 +60,7 @@ namespace reco {
 					       typename C2::value_type>,
 					C1, C2 >
   >
-  class PhysObjectMatcher : public edm::EDProducer {
+  class PhysObjectMatcher : public edm::stream::EDProducer<> {
   public:
     PhysObjectMatcher(const edm::ParameterSet & cfg);
     ~PhysObjectMatcher();

--- a/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/CorrectedMETProducerT.h
@@ -18,7 +18,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -61,7 +61,7 @@ namespace CorrectedMETProducer_namespace
 }
 
 template<typename T>
-class CorrectedMETProducerT : public edm::EDProducer  
+class CorrectedMETProducerT : public edm::stream::EDProducer<>  
 {
   typedef std::vector<T> METCollection;
 
@@ -95,7 +95,7 @@ class CorrectedMETProducerT : public edm::EDProducer
 	  rawMEt != rawMEtCollection->end(); ++rawMEt ) {
       CorrMETData correction = algorithm_->compMETCorrection(evt, es);
       
-      static CorrectedMETProducer_namespace::CorrectedMETFactoryT<T> correctedMET_factory;
+      CorrectedMETProducer_namespace::CorrectedMETFactoryT<T> correctedMET_factory;
       T correctedMEt = correctedMET_factory(*rawMEt, correction);
 
       correctedMEtCollection->push_back(correctedMEt);

--- a/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
+++ b/JetMETCorrections/Type1MET/interface/PFJetMETcorrInputProducerT.h
@@ -16,7 +16,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -67,7 +67,7 @@ namespace PFJetMETcorrInputProducer_namespace
 }
 
 template <typename T, typename Textractor>
-class PFJetMETcorrInputProducerT : public edm::EDProducer
+class PFJetMETcorrInputProducerT : public edm::stream::EDProducer<>
 {
  public:
 
@@ -151,13 +151,13 @@ class PFJetMETcorrInputProducerT : public edm::EDProducer
     for ( int jetIndex = 0; jetIndex < numJets; ++jetIndex ) {
       const T& rawJet = jets->at(jetIndex);
 
-      static PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType;
+      PFJetMETcorrInputProducer_namespace::InputTypeCheckerT<T, Textractor> checkInputType;
       checkInputType(rawJet);
 
       double emEnergyFraction = rawJet.chargedEmEnergyFraction() + rawJet.neutralEmEnergyFraction();
       if ( skipEM_ && emEnergyFraction > skipEMfractionThreshold_ ) continue;
 
-      static PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
+      PFJetMETcorrInputProducer_namespace::RawJetExtractorT<T> rawJetExtractor;
       reco::Candidate::LorentzVector rawJetP4 = rawJetExtractor(rawJet);
       if ( skipMuons_ ) {
 	const std::vector<reco::CandidatePtr> & cands = rawJet.daughterPtrVector();

--- a/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.cc
+++ b/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.cc
@@ -12,29 +12,25 @@ PFCandMETcorrInputProducer::PFCandMETcorrInputProducer(const edm::ParameterSet& 
     vParameterSet cfgBinning = cfg.getParameter<vParameterSet>("binning");
     for ( vParameterSet::const_iterator cfgBinningEntry = cfgBinning.begin();
 	  cfgBinningEntry != cfgBinning.end(); ++cfgBinningEntry ) {
-      binning_.push_back(new binningEntryType(*cfgBinningEntry));
+      binning_.emplace_back(new binningEntryType(*cfgBinningEntry));
     }
   } else {
-    binning_.push_back(new binningEntryType());
+    binning_.emplace_back(new binningEntryType());
   }
   
-  for ( std::vector<binningEntryType*>::const_iterator binningEntry = binning_.begin();
+  for ( auto binningEntry = binning_.begin();
 	binningEntry != binning_.end(); ++binningEntry ) {
     produces<CorrMETData>((*binningEntry)->binLabel_);
   }
 }
 
 PFCandMETcorrInputProducer::~PFCandMETcorrInputProducer()
-{
-  for ( std::vector<binningEntryType*>::const_iterator it = binning_.begin();
-	it != binning_.end(); ++it ) {
-    delete (*it);
-  }
+{  
 }
 
 void PFCandMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
 {
-  for ( std::vector<binningEntryType*>::iterator binningEntry = binning_.begin();
+  for ( auto binningEntry = binning_.begin();
 	binningEntry != binning_.end(); ++binningEntry ) {
     (*binningEntry)->binUnclEnergySum_ = CorrMETData();
   }
@@ -45,7 +41,7 @@ void PFCandMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup&
   
   for ( edm::View<reco::Candidate>::const_iterator cand = cands->begin();
 	cand != cands->end(); ++cand ) {
-    for ( std::vector<binningEntryType*>::iterator binningEntry = binning_.begin();
+    for ( auto binningEntry = binning_.begin();
 	  binningEntry != binning_.end(); ++binningEntry ) {
       if ( !(*binningEntry)->binSelection_ || (*(*binningEntry)->binSelection_)(cand->p4()) ) {
 	(*binningEntry)->binUnclEnergySum_.mex   += cand->px();
@@ -56,8 +52,8 @@ void PFCandMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup&
   }
 
 //--- add momentum sum of PFCandidates not within jets ("unclustered energy") to the event
-  for ( std::vector<binningEntryType*>::const_iterator binningEntry = binning_.begin();
-	binningEntry != binning_.end(); ++binningEntry ) {
+  for ( auto binningEntry = binning_.cbegin();
+	binningEntry != binning_.cend(); ++binningEntry ) {
     evt.put(std::auto_ptr<CorrMETData>(new CorrMETData((*binningEntry)->binUnclEnergySum_)), (*binningEntry)->binLabel_);
   }
 }

--- a/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
+++ b/JetMETCorrections/Type1MET/plugins/PFCandMETcorrInputProducer.h
@@ -14,7 +14,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -27,7 +27,7 @@
 
 #include <string>
 
-class PFCandMETcorrInputProducer : public edm::EDProducer  
+class PFCandMETcorrInputProducer : public edm::stream::EDProducer<>
 {
  public:
 
@@ -46,21 +46,20 @@ class PFCandMETcorrInputProducer : public edm::EDProducer
   {
     binningEntryType()
       : binLabel_(""),
-        binSelection_(0)
+        binSelection_(nullptr)
     {}
     binningEntryType(const edm::ParameterSet& cfg)
     : binLabel_(cfg.getParameter<std::string>("binLabel")),
       binSelection_(new StringCutObjectSelector<reco::Candidate::LorentzVector>(cfg.getParameter<std::string>("binSelection")))
     {}
     ~binningEntryType() 
-    {
-      delete binSelection_;
+    {      
     }
-    std::string binLabel_;
-    StringCutObjectSelector<reco::Candidate::LorentzVector>* binSelection_;
+    const std::string binLabel_;
+    std::unique_ptr<const StringCutObjectSelector<reco::Candidate::LorentzVector> > binSelection_;
     CorrMETData binUnclEnergySum_;
   };
-  std::vector<binningEntryType*> binning_;
+  std::vector<std::unique_ptr<binningEntryType> > binning_;
 };
 
 #endif

--- a/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
+++ b/PhysicsTools/HepMCCandAlgos/plugins/GenParticlePruner.cc
@@ -1,4 +1,4 @@
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -19,7 +19,7 @@ namespace helper {
   };
 }
 
-class GenParticlePruner : public edm::EDProducer {
+class GenParticlePruner : public edm::stream::EDProducer<> {
 public:
   GenParticlePruner(const edm::ParameterSet&);
 private:

--- a/PhysicsTools/JetCharge/plugins/JetChargeProducer.cc
+++ b/PhysicsTools/JetCharge/plugins/JetChargeProducer.cc
@@ -6,7 +6,7 @@ algo_(cfg) {
     produces<JetChargeCollection>();
 }
 
-void JetChargeProducer::produce(edm::Event &iEvent, const edm::EventSetup &iSetup) {
+void JetChargeProducer::produce(edm::StreamID, edm::Event &iEvent, const edm::EventSetup &iSetup) const {
     edm::Handle<reco::JetTracksAssociationCollection> hJTAs;
     iEvent.getByToken(srcToken_, hJTAs);
     typedef reco::JetTracksAssociationCollection::const_iterator IT;

--- a/PhysicsTools/JetCharge/plugins/JetChargeProducer.h
+++ b/PhysicsTools/JetCharge/plugins/JetChargeProducer.h
@@ -1,5 +1,5 @@
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -10,15 +10,15 @@
 
 #include "PhysicsTools/JetCharge/interface/JetCharge.h"
 
-class JetChargeProducer : public edm::EDProducer {
+class JetChargeProducer : public edm::global::EDProducer<> {
     public:
         typedef reco::JetFloatAssociation::Container JetChargeCollection;
 
         explicit JetChargeProducer(const edm::ParameterSet &cfg) ;
-        virtual void produce(edm::Event&, const edm::EventSetup&);
+        virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
     private:
-        edm::EDGetTokenT<reco::JetTracksAssociationCollection> srcToken_;
-        JetCharge     algo_;
+        const edm::EDGetTokenT<reco::JetTracksAssociationCollection> srcToken_;
+        const JetCharge     algo_;
 };
 
 

--- a/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/HadronAndPartonSelector.cc
@@ -46,7 +46,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -76,7 +76,7 @@ typedef boost::shared_ptr<BasePartonSelector> PartonSelectorPtr;
 // class declaration
 //
 
-class HadronAndPartonSelector : public edm::EDProducer {
+class HadronAndPartonSelector : public edm::stream::EDProducer<> {
    public:
       explicit HadronAndPartonSelector(const edm::ParameterSet&);
       ~HadronAndPartonSelector();
@@ -84,15 +84,8 @@ class HadronAndPartonSelector : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() ;
       virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
-
-      virtual void beginRun(edm::Run&, edm::EventSetup const&);
-      virtual void endRun(edm::Run&, edm::EventSetup const&);
-      virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-      virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-
+  
       // ----------member data ---------------------------
       const edm::EDGetTokenT<GenEventInfoProduct>         srcToken_;        // To get handronizer module type
       const edm::EDGetTokenT<reco::GenParticleCollection> particlesToken_;  // Input GenParticle collection
@@ -256,41 +249,6 @@ HadronAndPartonSelector::produce(edm::Event& iEvent, const edm::EventSetup& iSet
    iEvent.put( cHadrons, "cHadrons" );
    iEvent.put( partons,  "partons" );
    iEvent.put( leptons,  "leptons" );
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void
-HadronAndPartonSelector::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void
-HadronAndPartonSelector::endJob() {
-}
-
-// ------------ method called when starting to processes a run  ------------
-void
-HadronAndPartonSelector::beginRun(edm::Run&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when ending the processing of a run  ------------
-void
-HadronAndPartonSelector::endRun(edm::Run&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void
-HadronAndPartonSelector::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void
-HadronAndPartonSelector::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -79,7 +79,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -136,7 +136,7 @@ class GhostInfo : public fastjet::PseudoJet::UserInfoBase{
     int m_type;
 };
 
-class JetFlavourClustering : public edm::EDProducer {
+class JetFlavourClustering : public edm::stream::EDProducer<> {
    public:
       explicit JetFlavourClustering(const edm::ParameterSet&);
       ~JetFlavourClustering();
@@ -144,15 +144,8 @@ class JetFlavourClustering : public edm::EDProducer {
       static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
    private:
-      virtual void beginJob() ;
       virtual void produce(edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
-
-      virtual void beginRun(edm::Run&, edm::EventSetup const&);
-      virtual void endRun(edm::Run&, edm::EventSetup const&);
-      virtual void beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-      virtual void endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&);
-
+  
       void insertGhosts(const edm::Handle<reco::GenParticleRefVector>& particles,
                         const double ghostRescaling,
                         const bool isHadron, const bool isbHadron, const bool isParton, const bool isLepton,
@@ -707,41 +700,6 @@ JetFlavourClustering::assignToSubjets(const reco::GenParticleRefVector& clustere
 
      assignedParticles.at(closestSubjetIdx).push_back( *it );
    }
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void
-JetFlavourClustering::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void
-JetFlavourClustering::endJob() {
-}
-
-// ------------ method called when starting to processes a run  ------------
-void
-JetFlavourClustering::beginRun(edm::Run&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when ending the processing of a run  ------------
-void
-JetFlavourClustering::endRun(edm::Run&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when starting to processes a luminosity block  ------------
-void
-JetFlavourClustering::beginLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
-}
-
-// ------------ method called when ending the processing of a luminosity block  ------------
-void
-JetFlavourClustering::endLuminosityBlock(edm::LuminosityBlock&, edm::EventSetup const&)
-{
 }
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module  ------------

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.cc
@@ -16,26 +16,21 @@ using namespace std;
 using namespace edm;
 using namespace reco;
 
-TauGenJetProducer::TauGenJetProducer(const edm::ParameterSet& iConfig)
+TauGenJetProducer::TauGenJetProducer(const edm::ParameterSet& iConfig) :
+  inputTagGenParticles_(iConfig.getParameter<InputTag>("GenParticles")),
+  tokenGenParticles_(consumes<GenParticleCollection>(inputTagGenParticles_)),
+  includeNeutrinos_(iConfig.getParameter<bool>("includeNeutrinos")),
+  verbose_(iConfig.getUntrackedParameter<bool>("verbose",false))
 {
-  inputTagGenParticles_
-    = iConfig.getParameter<InputTag>("GenParticles");
-  tokenGenParticles_
-    = consumes<GenParticleCollection>(inputTagGenParticles_);
-
-  includeNeutrinos_
-    = iConfig.getParameter<bool>("includeNeutrinos");
-
-  verbose_ =
-    iConfig.getUntrackedParameter<bool>("verbose",false);
+  
 
   produces<GenJetCollection>();
 }
 
 TauGenJetProducer::~TauGenJetProducer() { }
 
-void TauGenJetProducer::produce(Event& iEvent,
-				const EventSetup& iSetup) {
+void TauGenJetProducer::produce(edm::StreamID, Event& iEvent,
+				const EventSetup& iSetup) const {
 
   Handle<GenParticleCollection> genParticles;
 

--- a/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
+++ b/PhysicsTools/JetMCAlgos/plugins/TauGenJetProducer.h
@@ -22,26 +22,26 @@
 \author Colin Bernet
 \date   february 2008
 */
-class TauGenJetProducer : public edm::EDProducer {
+class TauGenJetProducer : public edm::global::EDProducer<> {
  public:
 
   explicit TauGenJetProducer(const edm::ParameterSet&);
 
   ~TauGenJetProducer();
 
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
  private:
 
   /// Input PFCandidates
-  edm::InputTag   inputTagGenParticles_;
-  edm::EDGetTokenT<reco::GenParticleCollection>   tokenGenParticles_;
+  const edm::InputTag   inputTagGenParticles_;
+  const edm::EDGetTokenT<reco::GenParticleCollection>   tokenGenParticles_;
 
   /// if yes, neutrinos will be included, for debug purposes
-  bool   includeNeutrinos_;
+  const bool   includeNeutrinos_;
 
   /// verbose ?
-  bool   verbose_;
+  const bool   verbose_;
 
 };
 

--- a/PhysicsTools/PatAlgos/interface/EfficiencyLoader.h
+++ b/PhysicsTools/PatAlgos/interface/EfficiencyLoader.h
@@ -25,7 +25,7 @@ class EfficiencyLoader {
         bool enabled() const { return !names_.empty(); }
 
         /// To be called for each new event, reads in the ValueMaps for efficiencies
-        void newEvent(const edm::Event &event) const ;
+        void newEvent(const edm::Event &event);
 
         /// Sets the efficiencies for this object, using the reference to the original objects
         template<typename T, typename R>
@@ -34,7 +34,7 @@ class EfficiencyLoader {
     private:
         std::vector<std::string>   names_;
         std::vector<edm::EDGetTokenT<edm::ValueMap<pat::LookupTableRecord> > > tokens_;
-        mutable std::vector<edm::Handle< edm::ValueMap<pat::LookupTableRecord> > > handles_;
+        std::vector<edm::Handle< edm::ValueMap<pat::LookupTableRecord> > > handles_;
 }; // class
 
 template<typename T, typename R>

--- a/PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h
+++ b/PhysicsTools/PatAlgos/interface/KinResolutionsLoader.h
@@ -27,7 +27,7 @@ class KinResolutionsLoader {
         bool enabled() const { return !patlabels_.empty(); }
      
         /// To be called for each new event, reads in the EventSetup object 
-        void newEvent(const edm::Event &event, const edm::EventSetup &setup) const ;
+        void newEvent(const edm::Event &event, const edm::EventSetup &setup);
 
         /// Sets the efficiencies for this object, using the reference to the original objects
         template<typename T>
@@ -41,7 +41,7 @@ class KinResolutionsLoader {
         /// Labels of the KinematicResolutionProvider in the EventSetup
         std::vector<std::string>   eslabels_;
         /// Handles to the EventSetup
-        mutable std::vector<edm::ESHandle<KinematicResolutionProvider> > handles_;
+        std::vector<edm::ESHandle<KinematicResolutionProvider> > handles_;
 }; // class
 
 template<typename T>

--- a/PhysicsTools/PatAlgos/plugins/CandidateSummaryTable.cc
+++ b/PhysicsTools/PatAlgos/plugins/CandidateSummaryTable.cc
@@ -12,65 +12,87 @@
 */
 
 
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/stream/EDAnalyzer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
 #include <iomanip>
+#include <atomic>
 
 #include "DataFormats/Common/interface/View.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 
-namespace pat {
-  class CandidateSummaryTable : public edm::EDAnalyzer {
-    public:
-      explicit CandidateSummaryTable(const edm::ParameterSet & iConfig);
-      ~CandidateSummaryTable();
-
-      virtual void analyze(const edm::Event & iEvent, const edm::EventSetup& iSetup) override;
-      virtual void endJob() override;
-
-    private:
-      struct Record {
-        edm::InputTag src;
-        edm::EDGetTokenT<edm::View<reco::Candidate> > srcToken;
-        size_t present, empty, min, max, total;
-        Record(edm::InputTag tag, edm::ConsumesCollector && iC) : src(tag), srcToken(iC.consumes<edm::View<reco::Candidate> >(tag)), present(0), empty(0), min(0), max(0), total(0) {}
-
-        void update(const edm::View<reco::Candidate> &items) {
-            present++;
-            size_t size = items.size();
-            if (size == 0) {
-                empty++;
-            } else  {
-                if (min > size) min = size;
-                if (max < size) max = size;
-            }
-            total += size;
-        }
-      };
-      std::vector<Record> collections_;
-      size_t totalEvents_;
-      bool perEvent_, perJob_;
-      std::string self_, logName_;
-      bool dumpItems_;
+namespace pathelpers {
+  struct Record {
+    const edm::InputTag src;
+    std::atomic<size_t> present, empty, min, max, total;
+    Record(const edm::InputTag& tag) : src(tag), present(0), empty(0), min(0), max(0), total(0) {}
+    Record(const Record& other) : src(other.src), 
+                                  present(other.present.load()), 
+                                  empty(other.empty.load()), 
+                                  min(other.min.load()), 
+                                  max(other.max.load()), 
+                                  total(other.total.load()) {}
+    void update(const edm::View<reco::Candidate> &items) {
+      present++;
+      const size_t size = items.size();
+      if (size == 0) {
+        empty++;
+      } else  {
+        if (min > size) min = size;
+        if (max < size) max = size;
+      }
+      total += size;
+    }
   };
 
+  struct RecordCache { 
+    RecordCache(const edm::ParameterSet& iConfig) : 
+      perEvent_(iConfig.getUntrackedParameter<bool>("perEvent", false)),
+      perJob_(iConfig.getUntrackedParameter<bool>("perJob", true)),
+      self_(iConfig.getParameter<std::string>("@module_label")),
+      logName_(iConfig.getUntrackedParameter<std::string>("logName")),
+      dumpItems_(iConfig.getUntrackedParameter<bool>("dumpItems", false)),
+      totalEvents_(0) {
+      const std::vector<edm::InputTag>& tags  = iConfig.getParameter<std::vector<edm::InputTag> >("candidates");
+      for( const auto& tag : tags ) {
+        collections_.emplace_back( tag );
+      }
+    }
+    const bool perEvent_, perJob_;
+    const std::string self_, logName_;
+    const bool dumpItems_;
+    mutable std::atomic<size_t> totalEvents_;
+    mutable std::vector<Record> collections_; // size of vector is never altered later! (atomics are in the class below)
+  };  
+
+}
+
+namespace pat {
+  class CandidateSummaryTable : public edm::stream::EDAnalyzer<edm::GlobalCache<pathelpers::RecordCache> > {
+  public:
+    explicit CandidateSummaryTable(const edm::ParameterSet & iConfig, const pathelpers::RecordCache*);
+    ~CandidateSummaryTable();
+    
+    static std::unique_ptr<pathelpers::RecordCache> initializeGlobalCache(edm::ParameterSet const& conf) {
+      return std::unique_ptr<pathelpers::RecordCache>(new pathelpers::RecordCache(conf));
+    }
+
+    virtual void analyze(const edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+
+    static void globalEndJob(const pathelpers::RecordCache*);
+    
+  private:    
+    std::vector<std::pair<edm::InputTag,edm::EDGetTokenT<edm::View<reco::Candidate> > > > srcTokens;
+  };
 } // namespace
 
-pat::CandidateSummaryTable::CandidateSummaryTable(const edm::ParameterSet & iConfig) :
-    totalEvents_(0),
-    perEvent_(iConfig.getUntrackedParameter<bool>("perEvent", false)),
-    perJob_(iConfig.getUntrackedParameter<bool>("perJob", true)),
-    self_(iConfig.getParameter<std::string>("@module_label")),
-    logName_(iConfig.getUntrackedParameter<std::string>("logName")),
-    dumpItems_(iConfig.getUntrackedParameter<bool>("dumpItems", false))
-{
-    std::vector<edm::InputTag> inputs = iConfig.getParameter<std::vector<edm::InputTag> >("candidates");
-    for (std::vector<edm::InputTag>::const_iterator it = inputs.begin(); it != inputs.end(); ++it) {
-        collections_.push_back(Record(*it, consumesCollector()));
+pat::CandidateSummaryTable::CandidateSummaryTable(const edm::ParameterSet & iConfig, const pathelpers::RecordCache*) {
+    const std::vector<edm::InputTag>& inputs = iConfig.getParameter<std::vector<edm::InputTag> >("candidates");
+    for (std::vector<edm::InputTag>::const_iterator it = inputs.begin(); it != inputs.end(); ++it) {      
+      srcTokens.emplace_back(*it, consumes<edm::View<reco::Candidate> >(*it));
     }
 }
 
@@ -83,17 +105,20 @@ pat::CandidateSummaryTable::analyze(const edm::Event & iEvent, const edm::EventS
   using std::setw; using std::left; using std::right; using std::setprecision;
 
   Handle<View<reco::Candidate> > candidates;
-  if (perEvent_) {
-        LogInfo(logName_) << "Per Event Table " << logName_ <<
-                             " (" << self_ << ", run:event " << iEvent.id().run() << ":" << iEvent.id().event() << ")";
+  if (globalCache()->perEvent_) {
+    LogInfo(globalCache()->logName_) << "Per Event Table " << globalCache()->logName_ 
+                                     << " (" << globalCache()->self_ << ", run:event " 
+                                     << iEvent.id().run() << ":" << iEvent.id().event() << ")";
   }
-  totalEvents_++;
-  for (std::vector<Record>::iterator it = collections_.begin(), ed = collections_.end(); it != ed; ++it) {
-    iEvent.getByToken(it->srcToken, candidates);
+  ++(globalCache()->totalEvents_);
+  auto& collections = globalCache()->collections_;
+  auto tags = srcTokens.cbegin();
+  for (auto it = collections.begin(), ed = collections.end(); it != ed; ++it, ++tags) {
+    iEvent.getByToken(tags->second, candidates);
     if (!candidates.failedToGet()) it->update(*candidates);
-    if (perEvent_) {
-        LogVerbatim(logName_) << "    " << setw(30) << left  << it->src.encode() << right;
-        if (dumpItems_) {
+    if (globalCache()->perEvent_) {
+        LogVerbatim(globalCache()->logName_) << "    " << setw(30) << left  << it->src.encode() << right;
+        if (globalCache()->dumpItems_) {
             size_t i = 0;
             std::ostringstream oss;
             for (View<reco::Candidate>::const_iterator cand = candidates->begin(), endc = candidates->end(); cand != endc; ++cand, ++i) {
@@ -107,31 +132,31 @@ pat::CandidateSummaryTable::analyze(const edm::Event & iEvent, const edm::EventS
                         "  id "     << setw(7) << cand->pdgId() <<
                         "  st "     << setw(7) << cand->status() << "\n";
             }
-            LogVerbatim(logName_) << oss.str();
+            LogVerbatim(globalCache()->logName_) << oss.str();
         }
     }
   }
-  if (perEvent_) LogInfo(logName_) << "" ;  // add an empty line
+  if (globalCache()->perEvent_) LogInfo(globalCache()->logName_) << "" ;  // add an empty line
 }
 
 
 void
-pat::CandidateSummaryTable::endJob() {
+pat::CandidateSummaryTable::globalEndJob(const pathelpers::RecordCache* rcd) {
     using std::setw; using std::left; using std::right; using std::setprecision;
-    if (perJob_) {
+    if (rcd->perJob_) {
         std::ostringstream oss;
-        oss << "Summary Table " << logName_ << " (" << self_ << ", events total " << totalEvents_ << ")\n";
-        for (std::vector<Record>::iterator it = collections_.begin(), ed = collections_.end(); it != ed; ++it) {
+        oss << "Summary Table " << rcd->logName_ << " (" << rcd->self_ << ", events total " << rcd->totalEvents_ << ")\n";
+        for (auto it = rcd->collections_.cbegin(), ed = rcd->collections_.cend(); it != ed; ++it) {
             oss << "    " << setw(30) << left  << it->src.encode() << right <<
-                "  present " << setw(7) << it->present << " (" << setw(4) << setprecision(3) << (it->present*100.0/totalEvents_) << "%)" <<
-                "  empty "   << setw(7) << it->empty   << " (" << setw(4) << setprecision(3) << (it->empty*100.0/totalEvents_)   << "%)" <<
+                "  present " << setw(7) << it->present << " (" << setw(4) << setprecision(3) << (it->present*100.0/rcd->totalEvents_) << "%)" <<
+                "  empty "   << setw(7) << it->empty   << " (" << setw(4) << setprecision(3) << (it->empty*100.0/rcd->totalEvents_)   << "%)" <<
                 "  min "     << setw(7) << it->min     <<
                 "  max "     << setw(7) << it->max     <<
                 "  total "   << setw(7) << it->total   <<
-                "  avg "     << setw(5) << setprecision(3) << (it->total/double(totalEvents_)) << "\n";
+                "  avg "     << setw(5) << setprecision(3) << (it->total/double(rcd->totalEvents_)) << "\n";
         }
         oss << "\n";
-        edm::LogVerbatim(logName_) << oss.str();
+        edm::LogVerbatim(rcd->logName_) << oss.str();
     }
 }
 

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.cc
@@ -148,7 +148,7 @@ JetCorrFactorsProducer::params(const JetCorrectorParametersCollection& parameter
 float
 JetCorrFactorsProducer::evaluate(edm::View<reco::Jet>::const_iterator& jet, const JetCorrFactors::Flavor& flavor, int level)
 {
-  std::shared_ptr<FactorizedJetCorrector>& corrector = correctors_.find(flavor)->second;
+  std::unique_ptr<FactorizedJetCorrector>& corrector = correctors_.find(flavor)->second;
   // add parameters for JPT corrections
   const reco::JPTJet* jpt = dynamic_cast<reco::JPTJet const *>( &*jet );
   if( jpt ){
@@ -200,11 +200,11 @@ JetCorrFactorsProducer::produce(edm::Event& event, const edm::EventSetup& setup)
     setup.get<JetCorrectionsRecord>().get(payload(), parameters);
     // initialize jet correctors
     for(FlavorCorrLevelMap::const_iterator flavor=levels_.begin(); flavor!=levels_.end(); ++flavor){
-      correctors_[flavor->first] = std::shared_ptr<FactorizedJetCorrector>( new FactorizedJetCorrector(params(*parameters, flavor->second)) );
+      correctors_[flavor->first].reset( new FactorizedJetCorrector(params(*parameters, flavor->second)) );
     }
     // initialize extra jet corrector for jpt if needed
     if(!extraJPTOffset_.empty()){
-      extraJPTOffsetCorrector_ = std::shared_ptr<FactorizedJetCorrector>( new FactorizedJetCorrector(params(*parameters, extraJPTOffset_)) );
+      extraJPTOffsetCorrector_.reset( new FactorizedJetCorrector(params(*parameters, extraJPTOffset_)) );
     }
     cacheId_ = rec.cacheIdentifier();
   }

--- a/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/JetCorrFactorsProducer.h
@@ -45,7 +45,7 @@
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "DataFormats/Common/interface/ValueMap.h"
@@ -56,7 +56,7 @@
 
 namespace pat {
 
-  class JetCorrFactorsProducer : public edm::EDProducer {
+  class JetCorrFactorsProducer : public edm::stream::EDProducer<> {
   public:
     /// value map for JetCorrFactors (to be written into the event)
     typedef edm::ValueMap<pat::JetCorrFactors> JetCorrFactorsMap;
@@ -126,9 +126,9 @@ namespace pat {
     /// cache identifier for JetCorrectionsRecord
     unsigned long long cacheId_;
     /// cache container for jet corrections
-    std::map<JetCorrFactors::Flavor, std::shared_ptr<FactorizedJetCorrector> > correctors_;
+    std::map<JetCorrFactors::Flavor, std::unique_ptr<FactorizedJetCorrector> > correctors_;
     /// cache container for JPTOffset jet corrections
-    std::shared_ptr<FactorizedJetCorrector> extraJPTOffsetCorrector_;
+    std::unique_ptr<FactorizedJetCorrector> extraJPTOffsetCorrector_;
   };
 
   inline int

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.cc
@@ -18,29 +18,23 @@ using namespace std;
 using namespace edm;
 
 PATCompositeCandidateProducer::PATCompositeCandidateProducer(const ParameterSet & iConfig) :
-  userDataHelper_( iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector() )
+  srcToken_(consumes<edm::View<reco::CompositeCandidate> >(iConfig.getParameter<InputTag>( "src" ))),
+  useUserData_(iConfig.exists("userData")),
+  userDataHelper_( iConfig.getParameter<edm::ParameterSet>("userData"), consumesCollector() ),
+  addEfficiencies_(iConfig.getParameter<bool>("addEfficiencies")),  
+  addResolutions_(iConfig.getParameter<bool>("addResolutions"))
 {
-  // initialize the configurables
-  srcToken_ = consumes<edm::View<reco::CompositeCandidate> >(iConfig.getParameter<InputTag>( "src" ));
-
-  useUserData_ = false;
-  if ( iConfig.exists("userData") ) {
-    useUserData_ = true;
-  }
-
+ 
   // Efficiency configurables
-  addEfficiencies_ = iConfig.getParameter<bool>("addEfficiencies");
   if (addEfficiencies_) {
      efficiencyLoader_ = pat::helper::EfficiencyLoader(iConfig.getParameter<edm::ParameterSet>("efficiencies"), consumesCollector());
   }
 
   // Resolution configurables
-  addResolutions_ = iConfig.getParameter<bool>("addResolutions");
   if (addResolutions_) {
      resolutionLoader_ = pat::helper::KinResolutionsLoader(iConfig.getParameter<edm::ParameterSet>("resolutions"));
   }
-
-
+  
   // produces vector of particles
   produces<vector<pat::CompositeCandidate> >();
 

--- a/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATCompositeCandidateProducer.h
@@ -16,7 +16,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -37,7 +37,7 @@
 
 namespace pat {
 
-  class PATCompositeCandidateProducer : public edm::EDProducer {
+  class PATCompositeCandidateProducer : public edm::stream::EDProducer<> {
 
     public:
 
@@ -49,15 +49,15 @@ namespace pat {
     private:
 
       // configurables
-      edm::EDGetTokenT<edm::View<reco::CompositeCandidate> > srcToken_;     // list of reco::CompositeCandidates
+      const edm::EDGetTokenT<edm::View<reco::CompositeCandidate> > srcToken_;     // list of reco::CompositeCandidates
 
-      bool useUserData_;
+      const bool useUserData_;
       pat::PATUserDataHelper<pat::CompositeCandidate> userDataHelper_;
 
-      bool addEfficiencies_;
+      const bool addEfficiencies_;
       pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      bool addResolutions_;
+      const bool addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATConversionProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATConversionProducer.cc
@@ -43,16 +43,12 @@ using namespace pat;
 using namespace std;
 
 
-PATConversionProducer::PATConversionProducer(const edm::ParameterSet & iConfig){
-
-  // general configurables
-  electronToken_    = consumes<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ));
-  bsToken_          = consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"));
-  conversionsToken_ = consumes<reco::ConversionCollection>(edm::InputTag("allConversions"));
-
+PATConversionProducer::PATConversionProducer(const edm::ParameterSet & iConfig) :
+  electronToken_(consumes<edm::View<reco::GsfElectron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ))),
+  bsToken_(consumes<reco::BeamSpot>(edm::InputTag("offlineBeamSpot"))),
+  conversionsToken_(consumes<reco::ConversionCollection>(edm::InputTag("allConversions"))) {
   // produces vector of muons
   produces<std::vector<Conversion> >();
-
 }
 
 
@@ -60,7 +56,7 @@ PATConversionProducer::~PATConversionProducer() {
 }
 
 
-void PATConversionProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void PATConversionProducer::produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 
   // Get the collection of electrons from the event
   edm::Handle<edm::View<reco::GsfElectron> > electrons;

--- a/PhysicsTools/PatAlgos/plugins/PATConversionProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATConversionProducer.h
@@ -4,7 +4,7 @@
 #ifndef PhysicsTools_PatAlgos_PATConversionProducer_h
 #define PhysicsTools_PatAlgos_PATConversionProducer_h
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -34,21 +34,21 @@
 namespace pat {
 
 
-  class PATConversionProducer : public edm::EDProducer {
+  class PATConversionProducer : public edm::global::EDProducer<> {
 
     public:
 
       explicit PATConversionProducer(const edm::ParameterSet & iConfig);
       ~PATConversionProducer();
 
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+      virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
 
     private:
 
       // configurables
-      edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
-      edm::EDGetTokenT<reco::BeamSpot>                bsToken_;
-      edm::EDGetTokenT<reco::ConversionCollection>    conversionsToken_;
+      const edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
+      const edm::EDGetTokenT<reco::BeamSpot>                bsToken_;
+      const edm::EDGetTokenT<reco::ConversionCollection>    conversionsToken_;
 
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATElectronProducer.h
@@ -15,7 +15,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -51,7 +51,7 @@ namespace pat {
   class LeptonLRCalc;
 
 
-  class PATElectronProducer : public edm::EDProducer {
+  class PATElectronProducer : public edm::stream::EDProducer<> {
 
     public:
 
@@ -65,46 +65,46 @@ namespace pat {
     private:
 
       // configurables
-      edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
-      edm::EDGetTokenT<reco::ConversionCollection> hConversionsToken_;
-      bool          embedGsfElectronCore_;
-      bool          embedGsfTrack_;
-      bool          embedSuperCluster_;
-      bool          embedPflowSuperCluster_;
-      bool          embedSeedCluster_;
-      bool          embedBasicClusters_;
-      bool          embedPreshowerClusters_;
-      bool          embedPflowBasicClusters_;
-      bool          embedPflowPreshowerClusters_;
-      bool          embedTrack_;
-      bool          addGenMatch_;
-      bool          embedGenMatch_;
-      bool          embedRecHits_;
+      const edm::EDGetTokenT<edm::View<reco::GsfElectron> > electronToken_;
+      const edm::EDGetTokenT<reco::ConversionCollection> hConversionsToken_;
+      const bool          embedGsfElectronCore_;
+      const bool          embedGsfTrack_;
+      const bool          embedSuperCluster_;
+      const bool          embedPflowSuperCluster_;
+      const bool          embedSeedCluster_;
+      const bool          embedBasicClusters_;
+      const bool          embedPreshowerClusters_;
+      const bool          embedPflowBasicClusters_;
+      const bool          embedPflowPreshowerClusters_;
+      const bool          embedTrack_;
+      bool                addGenMatch_;
+      bool                embedGenMatch_;
+      const bool          embedRecHits_;
 
       typedef std::vector<edm::Handle<edm::Association<reco::GenParticleCollection> > > GenAssociations;
 
       std::vector<edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> > > genMatchTokens_;
 
       /// pflow specific
-      bool          useParticleFlow_;
-      edm::EDGetTokenT<reco::PFCandidateCollection> pfElecToken_;
-      edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr> > pfCandidateMapToken_;
-      bool          embedPFCandidate_;
+      const bool          useParticleFlow_;
+      const edm::EDGetTokenT<reco::PFCandidateCollection> pfElecToken_;
+      const edm::EDGetTokenT<edm::ValueMap<reco::PFCandidatePtr> > pfCandidateMapToken_;
+      const bool          embedPFCandidate_;
 
       /// mva input variables
-      edm::InputTag reducedBarrelRecHitCollection_;
-      edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
-      edm::InputTag reducedEndcapRecHitCollection_;
-      edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
+      const edm::InputTag reducedBarrelRecHitCollection_;
+      const edm::EDGetTokenT<EcalRecHitCollection> reducedBarrelRecHitCollectionToken_;
+      const edm::InputTag reducedEndcapRecHitCollection_;
+      const edm::EDGetTokenT<EcalRecHitCollection> reducedEndcapRecHitCollectionToken_;
       
-      bool addPFClusterIso_;
-      edm::EDGetTokenT<edm::ValueMap<float> > ecalPFClusterIsoT_;
-      edm::EDGetTokenT<edm::ValueMap<float> > hcalPFClusterIsoT_;
+      const bool addPFClusterIso_;
+      const edm::EDGetTokenT<edm::ValueMap<float> > ecalPFClusterIsoT_;
+      const edm::EDGetTokenT<edm::ValueMap<float> > hcalPFClusterIsoT_;
 
       /// embed high level selection variables?
-      bool          embedHighLevelSelection_;
-      edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
-      edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
+      const bool          embedHighLevelSelection_;
+      const edm::EDGetTokenT<reco::BeamSpot> beamLineToken_;
+      const edm::EDGetTokenT<std::vector<reco::Vertex> > pvToken_;
 
       typedef edm::RefToBase<reco::GsfElectron> ElectronBaseRef;
       typedef std::vector< edm::Handle< edm::ValueMap<IsoDeposit> > > IsoDepositMaps;
@@ -147,15 +147,15 @@ namespace pat {
       template<typename T> void readIsolationLabels( const edm::ParameterSet & iConfig,
 				                     const char* psetName,
 				                     IsolationLabels& labels,
-					             std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens);
+					             std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens) const;
 
-      bool          addElecID_;
+      const bool          addElecID_;
       typedef std::pair<std::string, edm::InputTag> NameTag;
       std::vector<NameTag> elecIDSrcs_;
       std::vector<edm::EDGetTokenT<edm::ValueMap<float> > > elecIDTokens_;
 
       // tools
-      GreaterByPt<Electron>       pTComparator_;
+      const GreaterByPt<Electron>       pTComparator_;
 
       pat::helper::MultiIsolator isolator_;
       pat::helper::MultiIsolator::IsolationValuePairs isolatorTmpStorage_; // better here than recreate at each event
@@ -166,13 +166,13 @@ namespace pat {
       IsolationLabels isolationValueLabelsNoPFId_;
       std::vector<edm::EDGetTokenT<edm::ValueMap<double> > > isolationValueNoPFIdTokens_;
 
-      bool addEfficiencies_;
+      const bool addEfficiencies_;
       pat::helper::EfficiencyLoader efficiencyLoader_;
 
-      bool addResolutions_;
+      const bool addResolutions_;
       pat::helper::KinResolutionsLoader resolutionLoader_;
 
-      bool useUserData_;
+      const bool useUserData_;
       pat::PATUserDataHelper<pat::Electron>      userDataHelper_;
 
       const CaloTopology * ecalTopology_;
@@ -190,7 +190,7 @@ template<typename T>
 void PATElectronProducer::readIsolationLabels( const edm::ParameterSet & iConfig,
 					       const char* psetName,
 					       IsolationLabels& labels,
-					       std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens) {
+					       std::vector<edm::EDGetTokenT<edm::ValueMap<T> > > & tokens) const {
 
   labels.clear();
 

--- a/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenCandsFromSimTracksProducer.cc
@@ -26,38 +26,37 @@
 #include <ext/algorithm>
 
 namespace pat {
-class PATGenCandsFromSimTracksProducer : public edm::EDProducer {
-public:
-  explicit PATGenCandsFromSimTracksProducer(const edm::ParameterSet&);
-  ~PATGenCandsFromSimTracksProducer() {}
-
-private:
-  virtual void produce(edm::Event&, const edm::EventSetup&) override;
-  virtual void endJob() override {}
-
-  bool firstEvent_;
-  edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
-  edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken_;
-  int setStatus_;
-  std::set<int>         pdgIds_; // these are the ones we really use
-  std::vector<PdtEntry> pdts_;   // these are needed before we get the EventSetup
-  std::set<int>         motherPdgIds_; // these are the ones we really use
-  std::vector<PdtEntry> motherPdts_;   // these are needed before we get the EventSetup
-
-  typedef StringCutObjectSelector<reco::GenParticle> StrFilter;
-  std::auto_ptr<StrFilter> filter_;
-
-  /// If true, I'll try to make a link from the GEANT particle to a GenParticle
-  bool makeMotherLink_;
-  /// If true, I'll save GenParticles corresponding to the ancestors of this GEANT particle. Common ancestors are only written once.
-  bool writeAncestors_;
-
-  /// Collection of GenParticles I need to make refs to. It must also have its associated vector<int> of barcodes, aligned with them.
-  edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
-  edm::EDGetTokenT<std::vector<int> > genBarcodesToken_;
-
+  class PATGenCandsFromSimTracksProducer : public edm::stream::EDProducer<> {
+  public:
+    explicit PATGenCandsFromSimTracksProducer(const edm::ParameterSet&);
+    ~PATGenCandsFromSimTracksProducer() {}
+    
+  private:
+    virtual void produce(edm::Event&, const edm::EventSetup&) override;
+    
+    bool firstEvent_;
+    edm::EDGetTokenT<edm::SimTrackContainer> simTracksToken_;
+    edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken_;
+    int setStatus_;
+    std::set<int>         pdgIds_; // these are the ones we really use
+    std::vector<PdtEntry> pdts_;   // these are needed before we get the EventSetup
+    std::set<int>         motherPdgIds_; // these are the ones we really use
+    std::vector<PdtEntry> motherPdts_;   // these are needed before we get the EventSetup
+    
+    typedef StringCutObjectSelector<reco::GenParticle> StrFilter;
+    const StrFilter filter_;
+    
+    /// If true, I'll try to make a link from the GEANT particle to a GenParticle
+    bool makeMotherLink_;
+    /// If true, I'll save GenParticles corresponding to the ancestors of this GEANT particle. Common ancestors are only written once.
+    bool writeAncestors_;
+    
+    /// Collection of GenParticles I need to make refs to. It must also have its associated vector<int> of barcodes, aligned with them.
+    edm::EDGetTokenT<reco::GenParticleCollection> genParticlesToken_;
+    edm::EDGetTokenT<std::vector<int> > genBarcodesToken_;
+    
   /// Global context for all recursive methods
-  struct GlobalContext {
+    struct GlobalContext {
       GlobalContext(const edm::SimTrackContainer &simtks1,
                     const edm::SimVertexContainer &simvtxs1,
                     const edm::Handle<reco::GenParticleCollection> &gens1,
@@ -65,9 +64,9 @@ private:
                     bool                                            barcodesAreSorted1,
                     reco::GenParticleCollection                     & output1,
                     const edm::RefProd<reco::GenParticleCollection> & refprod1) :
-          simtks(simtks1), simvtxs(simvtxs1),
-          gens(gens1), genBarcodes(genBarcodes1), barcodesAreSorted(barcodesAreSorted1),
-          output(output1), refprod(refprod1), simTksProcessed() {}
+        simtks(simtks1), simvtxs(simvtxs1),
+        gens(gens1), genBarcodes(genBarcodes1), barcodesAreSorted(barcodesAreSorted1),
+        output(output1), refprod(refprod1), simTksProcessed() {}
       // GEANT info
       const edm::SimTrackContainer &simtks;
       const edm::SimVertexContainer &simvtxs;
@@ -80,34 +79,33 @@ private:
       const edm::RefProd<reco::GenParticleCollection> & refprod;
       // BOOK-KEEPING
       std::map<unsigned int,int> simTksProcessed; // key = sim track id;
-                                         // val = 0: not processed;
-                                         //       i>0:  (index+1) in my output
-                                         //       i<0: -(index+1) in pythia [NOT USED]
+      // val = 0: not processed;
+      //       i>0:  (index+1) in my output
+      //       i<0: -(index+1) in pythia [NOT USED]
+    };
+    
+    /// Find the mother of a given GEANT track (or NULL if it can't be found).
+    const SimTrack * findGeantMother(const SimTrack &tk, const GlobalContext &g) const ;
+    /// Find the GenParticle reference for a given GEANT or PYTHIA track.
+    ///  - if the track corresponds to a PYTHIA particle, return a ref to that particle
+    ///  - otherwise, if this simtrack has no mother simtrack, return a null ref
+    ///  - otherwise, if writeAncestors is true,  make a GenParticle for it and return a ref to it
+    ///  - otherwise, if writeAncestors is false, return the ref to the GEANT mother of this track
+    edm::Ref<reco::GenParticleCollection> findRef(const SimTrack &tk, GlobalContext &g) const ;
+    
+    /// Used by findRef if the track is a PYTHIA particle
+    edm::Ref<reco::GenParticleCollection> generatorRef_(const SimTrack &tk, const GlobalContext &g) const ;
+    /// Make a GenParticle for this SimTrack, with a given mother
+    reco::GenParticle makeGenParticle_(const SimTrack &tk, const edm::Ref<reco::GenParticleCollection> & mother, const GlobalContext &g) const ;
+    
+    
+    
+    struct LessById {
+      bool operator()(const SimTrack &tk1, const SimTrack &tk2) const { return tk1.trackId() < tk2.trackId(); }
+      bool operator()(const SimTrack &tk1, unsigned int    id ) const { return tk1.trackId() < id;            }
+      bool operator()(unsigned int     id, const SimTrack &tk2) const { return id            < tk2.trackId(); }
+    };    
   };
-
-  /// Find the mother of a given GEANT track (or NULL if it can't be found).
-  const SimTrack * findGeantMother(const SimTrack &tk, const GlobalContext &g) const ;
-  /// Find the GenParticle reference for a given GEANT or PYTHIA track.
-  ///  - if the track corresponds to a PYTHIA particle, return a ref to that particle
-  ///  - otherwise, if this simtrack has no mother simtrack, return a null ref
-  ///  - otherwise, if writeAncestors is true,  make a GenParticle for it and return a ref to it
-  ///  - otherwise, if writeAncestors is false, return the ref to the GEANT mother of this track
-  edm::Ref<reco::GenParticleCollection> findRef(const SimTrack &tk, GlobalContext &g) const ;
-
-  /// Used by findRef if the track is a PYTHIA particle
-  edm::Ref<reco::GenParticleCollection> generatorRef_(const SimTrack &tk, const GlobalContext &g) const ;
-  /// Make a GenParticle for this SimTrack, with a given mother
-  reco::GenParticle makeGenParticle_(const SimTrack &tk, const edm::Ref<reco::GenParticleCollection> & mother, const GlobalContext &g) const ;
-
-
-
-  struct LessById {
-    bool operator()(const SimTrack &tk1, const SimTrack &tk2) const { return tk1.trackId() < tk2.trackId(); }
-    bool operator()(const SimTrack &tk1, unsigned int    id ) const { return tk1.trackId() < id;            }
-    bool operator()(unsigned int     id, const SimTrack &tk2) const { return id            < tk2.trackId(); }
-  };
-
-};
 }
 
 using namespace std;
@@ -120,6 +118,7 @@ PATGenCandsFromSimTracksProducer::PATGenCandsFromSimTracksProducer(const Paramet
   simTracksToken_(consumes<SimTrackContainer>(cfg.getParameter<InputTag>("src"))),            // source sim tracks
   simVertexToken_(consumes<SimVertexContainer>(cfg.getParameter<InputTag>("src"))),            // source sim  vertices
   setStatus_(cfg.getParameter<int32_t>("setStatus")), // set status of GenParticle to this code
+  filter_( cfg.existsAs<string>("filter") ? cfg.getParameter<string>("filter") : std::string("1 == 1") ),
   makeMotherLink_(cfg.existsAs<bool>("makeMotherLink") ? cfg.getParameter<bool>("makeMotherLink") : false),
   writeAncestors_(cfg.existsAs<bool>("writeAncestors") ? cfg.getParameter<bool>("writeAncestors") : false),
   genParticlesToken_(mayConsume<GenParticleCollection>(cfg.getParameter<InputTag>("genParticles"))),
@@ -132,15 +131,7 @@ PATGenCandsFromSimTracksProducer::PATGenCandsFromSimTracksProducer(const Paramet
     if (cfg.exists("motherTypes")) {
         motherPdts_ = cfg.getParameter<vector<PdtEntry> >("motherTypes");
     }
-
-    // Possibly allow a string cut
-    if (cfg.existsAs<string>("filter")) {
-        string filter = cfg.getParameter<string>("filter");
-        if (!filter.empty()) {
-            filter_ = auto_ptr<StrFilter>(new StrFilter(filter));
-        }
-    }
-
+    
     if (writeAncestors_ && !makeMotherLink_) {
         edm::LogWarning("Configuration") << "PATGenCandsFromSimTracksProducer: " <<
             "you have set 'writeAncestors' to 'true' and 'makeMotherLink' to false;" <<
@@ -228,7 +219,7 @@ PATGenCandsFromSimTracksProducer::makeGenParticle_(const SimTrack &tk, const edm
 
 
 void PATGenCandsFromSimTracksProducer::produce(Event& event,
-					    const EventSetup& iSetup) {
+                                               const EventSetup& iSetup) {
 
   if (firstEvent_){
     if (!pdts_.empty()) {
@@ -301,9 +292,8 @@ void PATGenCandsFromSimTracksProducer::produce(Event& event,
       GenParticle genp = makeGenParticle_(*isimtrk, Ref<GenParticleCollection>(), globals);
 
       // Maybe apply filter on the particle
-      if (filter_.get() != 0) {
-        if (!(*filter_)(genp)) continue;
-      }
+      if (!(filter_(genp))) continue;
+
 
       if (!motherPdgIds_.empty()) {
            const SimTrack *motherSimTk = findGeantMother(*isimtrk, globals);

--- a/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATGenJetSlimmer.cc
@@ -11,7 +11,7 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
@@ -22,23 +22,23 @@
 
 namespace pat {
 
-  class PATGenJetSlimmer : public edm::EDProducer {
-    public:
-      explicit PATGenJetSlimmer(const edm::ParameterSet & iConfig);
-      virtual ~PATGenJetSlimmer() { }
-
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup & iSetup);
-
-    private:
-      edm::EDGetTokenT<edm::View<reco::GenJet> > src_;
-      edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp_;
-
-      StringCutObjectSelector<reco::GenJet> cut_;
-      
-      /// reset daughters to an empty vector
-      bool clearDaughters_;
-      /// drop the specific
-      bool dropSpecific_;
+  class PATGenJetSlimmer : public edm::global::EDProducer<> {
+  public:
+    explicit PATGenJetSlimmer(const edm::ParameterSet & iConfig);
+    virtual ~PATGenJetSlimmer() { }
+    
+    virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const;
+    
+  private:
+    const edm::EDGetTokenT<edm::View<reco::GenJet> > src_;
+    const edm::EDGetTokenT<edm::Association<std::vector<pat::PackedGenParticle> > > gp2pgp_;
+    
+    const StringCutObjectSelector<reco::GenJet> cut_;
+    
+    /// reset daughters to an empty vector
+    const bool clearDaughters_;
+    /// drop the specific
+    const bool dropSpecific_;
   };
 
 } // namespace
@@ -54,7 +54,7 @@ pat::PATGenJetSlimmer::PATGenJetSlimmer(const edm::ParameterSet & iConfig) :
 }
 
 void 
-pat::PATGenJetSlimmer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+pat::PATGenJetSlimmer::produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
     using namespace edm;
     using namespace std;
 

--- a/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATGenericParticleProducer.h
@@ -16,7 +16,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -39,7 +39,7 @@
 
 namespace pat {
 
-  class PATGenericParticleProducer : public edm::EDProducer {
+  class PATGenericParticleProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATHeavyIonProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATHeavyIonProducer.cc
@@ -24,7 +24,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -43,23 +43,20 @@ using namespace std;
 // class decleration
 //
 
-class PATHeavyIonProducer : public edm::EDProducer {
-   public:
-      explicit PATHeavyIonProducer(const edm::ParameterSet&);
-      ~PATHeavyIonProducer();
-
-   private:
-      virtual void beginJob() override ;
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() override ;
-      
-      // ----------member data ---------------------------
-
-   bool doMC_;
-   bool doReco_;
-   std::vector<std::string> hepmcSrc_;
-   edm::InputTag centSrc_;
-   edm::InputTag evtPlaneSrc_;
+class PATHeavyIonProducer : public edm::global::EDProducer<> {
+public:
+  explicit PATHeavyIonProducer(const edm::ParameterSet&);
+  ~PATHeavyIonProducer();
+  
+private:
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  // ----------member data ---------------------------
+  
+  const bool doMC_;
+  const bool doReco_;
+  const std::vector<std::string> hepmcSrc_;
+  const edm::InputTag centSrc_;
+  const edm::InputTag evtPlaneSrc_;
 
 };
 
@@ -75,23 +72,15 @@ class PATHeavyIonProducer : public edm::EDProducer {
 //
 // constructors and destructor
 //
-PATHeavyIonProducer::PATHeavyIonProducer(const edm::ParameterSet& iConfig)
+PATHeavyIonProducer::PATHeavyIonProducer(const edm::ParameterSet& iConfig) :
+  doMC_(iConfig.getParameter<bool>("doMC")),
+  doReco_(iConfig.getParameter<bool>("doReco")),
+  hepmcSrc_( doMC_ ? iConfig.getParameter<std::vector<std::string> >("generators") : std::vector<std::string>() ),
+  centSrc_( doReco_ ? iConfig.getParameter<edm::InputTag>("centrality") : edm::InputTag() ),
+  evtPlaneSrc_(doReco_ ? iConfig.getParameter<edm::InputTag>("evtPlane") : edm::InputTag() )
 {
    //register your products
-   produces<pat::HeavyIon>();
-
-   //now do what ever other initialization is needed
-   doReco_ = iConfig.getParameter<bool>("doReco");
-   if(doReco_){
-      centSrc_ = iConfig.getParameter<edm::InputTag>("centrality");
-      evtPlaneSrc_ = iConfig.getParameter<edm::InputTag>("evtPlane");
-   }
-
-   doMC_ = iConfig.getParameter<bool>("doMC");
-   if(doMC_){
-      hepmcSrc_ = iConfig.getParameter<std::vector<std::string> >("generators");
-   }
-  
+   produces<pat::HeavyIon>();   
 }
 
 
@@ -110,20 +99,8 @@ PATHeavyIonProducer::~PATHeavyIonProducer()
 
 // ------------ method called to produce the data  ------------
 void
-PATHeavyIonProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
+PATHeavyIonProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
-}
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-PATHeavyIonProducer::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-PATHeavyIonProducer::endJob() {
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.cc
@@ -96,75 +96,79 @@ PATHemisphereProducer::~PATHemisphereProducer()
 
 // ------------ method called to produce the data  ------------
 void
-PATHemisphereProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
-{
-   using namespace edm;
-   using namespace std;
+PATHemisphereProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
+  using namespace edm;
+  using namespace std;
+  
+  std::vector<float> vPx, vPy, vPz, vE;
+  std::vector<float> vA1, vA2;
+  std::vector<int> vgroups;
+  std::vector<reco::CandidatePtr> componentPtrs;
 
-   //Jets
-   Handle<reco::CandidateView> pJets;
-   iEvent.getByToken(_patJetsToken,pJets);
+  //Jets
+  Handle<reco::CandidateView> pJets;
+  iEvent.getByToken(_patJetsToken,pJets);
 
-   //Muons
-   Handle<reco::CandidateView> pMuons;
-   iEvent.getByToken(_patMuonsToken,pMuons);
-
-   //Electrons
-   Handle<reco::CandidateView> pElectrons;
-   iEvent.getByToken(_patElectronsToken,pElectrons);
-
-   //Photons
-   Handle<reco::CandidateView> pPhotons;
-   iEvent.getByToken(_patPhotonsToken,pPhotons);
-
-   //Taus
-   Handle<reco::CandidateView> pTaus;
-   iEvent.getByToken(_patTausToken,pTaus);
-
-
-   //fill e,p vector with information from all objects (hopefully cleaned before)
-   for(int i = 0; i < (int) (*pJets).size() ; i++){
-     if((*pJets)[i].pt() <  _minJetEt || fabs((*pJets)[i].eta()) >  _maxJetEta) continue;
-
-     componentPtrs_.push_back(pJets->ptrAt(i));
-   }
-
-   for(int i = 0; i < (int) (*pMuons).size() ; i++){
-     if((*pMuons)[i].pt() <  _minMuonEt || fabs((*pMuons)[i].eta()) >  _maxMuonEta) continue;
-
-     componentPtrs_.push_back(pMuons->ptrAt(i));
-   }
-
-   for(int i = 0; i < (int) (*pElectrons).size() ; i++){
-     if((*pElectrons)[i].pt() <  _minElectronEt || fabs((*pElectrons)[i].eta()) >  _maxElectronEta) continue;
-
-     componentPtrs_.push_back(pElectrons->ptrAt(i));
-   }
-
-   for(int i = 0; i < (int) (*pPhotons).size() ; i++){
-     if((*pPhotons)[i].pt() <  _minPhotonEt || fabs((*pPhotons)[i].eta()) >  _maxPhotonEta) continue;
-
-     componentPtrs_.push_back(pPhotons->ptrAt(i));
-   }
-
-   //aren't taus included in jets?
-   for(int i = 0; i < (int) (*pTaus).size() ; i++){
-     if((*pTaus)[i].pt() <  _minTauEt || fabs((*pTaus)[i].eta()) >  _maxTauEta) continue;
-
-     componentPtrs_.push_back(pTaus->ptrAt(i));
-   }
-
-   // create product
-   std::auto_ptr< std::vector<Hemisphere> > hemispheres(new std::vector<Hemisphere>);;
-   hemispheres->reserve(2);
-
+  //Muons
+  Handle<reco::CandidateView> pMuons;
+  iEvent.getByToken(_patMuonsToken,pMuons);
+  
+  //Electrons
+  Handle<reco::CandidateView> pElectrons;
+  iEvent.getByToken(_patElectronsToken,pElectrons);
+  
+  //Photons
+  Handle<reco::CandidateView> pPhotons;
+  iEvent.getByToken(_patPhotonsToken,pPhotons);
+  
+  //Taus
+  Handle<reco::CandidateView> pTaus;
+  iEvent.getByToken(_patTausToken,pTaus);
+  
+  
+  //fill e,p vector with information from all objects (hopefully cleaned before)
+  for(int i = 0; i < (int) (*pJets).size() ; i++){
+    if((*pJets)[i].pt() <  _minJetEt || fabs((*pJets)[i].eta()) >  _maxJetEta) continue;
+    
+    componentPtrs.push_back(pJets->ptrAt(i));
+  }
+  
+  for(int i = 0; i < (int) (*pMuons).size() ; i++){
+    if((*pMuons)[i].pt() <  _minMuonEt || fabs((*pMuons)[i].eta()) >  _maxMuonEta) continue;
+    
+    componentPtrs.push_back(pMuons->ptrAt(i));
+  }
+  
+  for(int i = 0; i < (int) (*pElectrons).size() ; i++){
+    if((*pElectrons)[i].pt() <  _minElectronEt || fabs((*pElectrons)[i].eta()) >  _maxElectronEta) continue;
+    
+    componentPtrs.push_back(pElectrons->ptrAt(i));
+  }
+  
+  for(int i = 0; i < (int) (*pPhotons).size() ; i++){
+    if((*pPhotons)[i].pt() <  _minPhotonEt || fabs((*pPhotons)[i].eta()) >  _maxPhotonEta) continue;
+    
+    componentPtrs.push_back(pPhotons->ptrAt(i));
+  }
+  
+  //aren't taus included in jets?
+  for(int i = 0; i < (int) (*pTaus).size() ; i++){
+    if((*pTaus)[i].pt() <  _minTauEt || fabs((*pTaus)[i].eta()) >  _maxTauEta) continue;
+    
+    componentPtrs.push_back(pTaus->ptrAt(i));
+  }
+  
+  // create product
+  std::auto_ptr< std::vector<Hemisphere> > hemispheres(new std::vector<Hemisphere>);;
+  hemispheres->reserve(2);
+  
   //calls HemiAlgorithm for seed method 3 (transv. inv. Mass) and association method 3 (Lund algo)
-  HemisphereAlgo myHemi(componentPtrs_,_seedMethod,_combinationMethod);
-
+  HemisphereAlgo myHemi(componentPtrs,_seedMethod,_combinationMethod);
+  
   //get Hemisphere Axis
   vA1 = myHemi.getAxis1();
   vA2 = myHemi.getAxis2();
-
+  
   reco::Particle::LorentzVector p1(vA1[0]*vA1[3],vA1[1]*vA1[3],vA1[2]*vA1[3],vA1[4]);
   hemispheres->push_back(Hemisphere(p1));
 
@@ -176,32 +180,15 @@ PATHemisphereProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup
 
   for ( unsigned int i=0; i<vgroups.size(); ++i ) {
     if ( vgroups[i]==1 ) {
-      (*hemispheres)[0].addDaughter(componentPtrs_[i]);
+      (*hemispheres)[0].addDaughter(componentPtrs[i]);
     }
     else {
-      (*hemispheres)[1].addDaughter(componentPtrs_[i]);
+      (*hemispheres)[1].addDaughter(componentPtrs[i]);
     }
   }
-
-
-  iEvent.put(hemispheres);
-
-  //clean up
-
-    vPx.clear();
-    vPy.clear();
-    vPz.clear();
-    vE.clear();
-    vgroups.clear();
-    componentPtrs_.clear();
-}
-
-
-
-// ------------ method called once each job just after ending the event loop  ------------
-void
-PATHemisphereProducer::endJob() {
-
+  
+  
+  iEvent.put(hemispheres);  
 }
 
 //define this as a plug-in

--- a/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATHemisphereProducer.h
@@ -37,52 +37,39 @@
 // class decleration
 //
 
-class PATHemisphereProducer : public edm::EDProducer {
-   public:
-      explicit PATHemisphereProducer(const edm::ParameterSet&);
-      ~PATHemisphereProducer();
-
-   private:
-      virtual void produce(edm::Event&, const edm::EventSetup&) override;
-      virtual void endJob() ;
-
-      // ----------member data ---------------------------
-      /// Input: All PAT objects that are to cross-clean  or needed for that
-      edm::EDGetTokenT<reco::CandidateView> _patJetsToken;
-//       edm::EDGetTokenT<reco::CandidateView> _patMetsToken;
-      edm::EDGetTokenT<reco::CandidateView> _patMuonsToken;
-      edm::EDGetTokenT<reco::CandidateView> _patElectronsToken;
-      edm::EDGetTokenT<reco::CandidateView> _patPhotonsToken;
-      edm::EDGetTokenT<reco::CandidateView> _patTausToken;
-
-  float _minJetEt;
-  float _minMuonEt;
-  float _minElectronEt;
-  float _minTauEt;
-  float _minPhotonEt;
-
-  float _maxJetEta;
-  float _maxMuonEta;
-  float _maxElectronEta;
-  float _maxTauEta;
-  float _maxPhotonEta;
-
-      int _seedMethod;
-      int _combinationMethod;
-
-      HemisphereAlgo* myHemi;
-
-      std::vector<float> vPx, vPy, vPz, vE;
-      std::vector<float> vA1, vA2;
-      std::vector<int> vgroups;
-  std::vector<reco::CandidatePtr> componentPtrs_;
-
-
+class PATHemisphereProducer : public edm::global::EDProducer<> {
+public:
+  explicit PATHemisphereProducer(const edm::ParameterSet&);
+  ~PATHemisphereProducer();
+  
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  
+private:  
+  // ----------member data ---------------------------
+  /// Input: All PAT objects that are to cross-clean  or needed for that
+  const edm::EDGetTokenT<reco::CandidateView> _patJetsToken;
+  //       edm::EDGetTokenT<reco::CandidateView> _patMetsToken;
+  const edm::EDGetTokenT<reco::CandidateView> _patMuonsToken;
+  const edm::EDGetTokenT<reco::CandidateView> _patElectronsToken;
+  const edm::EDGetTokenT<reco::CandidateView> _patPhotonsToken;
+  const edm::EDGetTokenT<reco::CandidateView> _patTausToken;
+  
+  const float _minJetEt;
+  const float _minMuonEt;
+  const float _minElectronEt;
+  const float _minTauEt;
+  const float _minPhotonEt;
+  
+  const float _maxJetEta;
+  const float _maxMuonEta;
+  const float _maxElectronEta;
+  const float _maxTauEta;
+  const float _maxPhotonEta;
+  
+  const int _seedMethod;
+  const int _combinationMethod;
+  
   typedef std::vector<float> HemiAxis;
-
-
-
-
 };
 
 #endif

--- a/PhysicsTools/PatAlgos/plugins/PATJetProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetProducer.h
@@ -16,7 +16,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -44,7 +44,7 @@ class JetFlavourIdentifier;
 
 namespace pat {
 
-  class PATJetProducer : public edm::EDProducer {
+  class PATJetProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSelector.h
@@ -4,7 +4,7 @@
 #ifndef PhysicsTools_PatAlgos_PATJetSelector_h
 #define PhysicsTools_PatAlgos_PATJetSelector_h
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "DataFormats/Common/interface/RefVector.h"
 
@@ -21,15 +21,14 @@
 
 namespace pat {
 
-  class PATJetSelector : public edm::EDFilter {
+  class PATJetSelector : public edm::global::EDFilter<> {
   public:
 
 
   PATJetSelector( edm::ParameterSet const & params ) :
-    edm::EDFilter( ),
       srcToken_(consumes<edm::View<pat::Jet> >( params.getParameter<edm::InputTag>("src") )),
       cut_( params.getParameter<std::string>("cut") ),
-      filter_(false),
+      filter_( params.exists("filter") ? params.getParameter<bool>("filter") : false ),
       selector_( cut_ )
       {
 	produces< std::vector<pat::Jet> >();
@@ -37,10 +36,6 @@ namespace pat {
 	produces<std::vector<CaloTower>  > ("caloTowers");
 	produces<reco::PFCandidateCollection > ("pfCandidates");
 	produces<edm::OwnVector<reco::BaseTagInfo> > ("tagInfos");
-
-	if ( params.exists("filter") ) {
-	  filter_ = params.getParameter<bool>("filter");
-	}
       }
 
     virtual ~PATJetSelector() {}
@@ -48,7 +43,7 @@ namespace pat {
     virtual void beginJob() {}
     virtual void endJob() {}
 
-    virtual bool filter(edm::Event& iEvent, const edm::EventSetup& iSetup) override {
+    virtual bool filter(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const override {
 
       std::auto_ptr< std::vector<Jet> > patJets ( new std::vector<Jet>() );
 
@@ -196,10 +191,10 @@ namespace pat {
     }
 
   protected:
-    edm::EDGetTokenT<edm::View<pat::Jet> > srcToken_;
-    std::string                    cut_;
-    bool                           filter_;
-    StringCutObjectSelector<Jet>   selector_;
+    const edm::EDGetTokenT<edm::View<pat::Jet> > srcToken_;
+    const std::string                    cut_;
+    const bool                           filter_;
+    const StringCutObjectSelector<Jet>   selector_;
   };
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATJetSlimmer.cc
@@ -11,7 +11,7 @@
 
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
@@ -23,7 +23,7 @@
 
 namespace pat {
 
-  class PATJetSlimmer : public edm::EDProducer {
+  class PATJetSlimmer : public edm::stream::EDProducer<> {
     public:
       explicit PATJetSlimmer(const edm::ParameterSet & iConfig);
       virtual ~PATJetSlimmer() { }
@@ -32,10 +32,10 @@ namespace pat {
       virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) override final;
 
     private:
-      edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
-      edm::EDGetTokenT<edm::View<pat::Jet> >  jets_;
-      StringCutObjectSelector<pat::Jet> dropJetVars_,dropDaughters_,rekeyDaughters_,dropTrackRefs_,dropSpecific_,dropTagInfos_;
-      bool modifyJet_;
+      const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
+      const edm::EDGetTokenT<edm::View<pat::Jet> >  jets_;
+      const StringCutObjectSelector<pat::Jet> dropJetVars_,dropDaughters_,rekeyDaughters_,dropTrackRefs_,dropSpecific_,dropTagInfos_;
+      const bool modifyJet_;
       std::unique_ptr<pat::ObjectModifier<pat::Jet> > jetModifier_;
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATJetUpdater.h
+++ b/PhysicsTools/PatAlgos/plugins/PATJetUpdater.h
@@ -16,7 +16,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -31,7 +31,7 @@
 
 namespace pat {
 
-  class PATJetUpdater : public edm::EDProducer {
+  class PATJetUpdater : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.cc
@@ -9,15 +9,16 @@
 using namespace pat;
 
 
-PATLeptonCountFilter::PATLeptonCountFilter(const edm::ParameterSet & iConfig) {
-  electronToken_  = mayConsume<edm::View<Electron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ));
-  muonToken_      = mayConsume<edm::View<Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ));
-  tauToken_       = mayConsume<edm::View<Tau> >(iConfig.getParameter<edm::InputTag>( "tauSource" ));
-  countElectrons_ = iConfig.getParameter<bool>         ( "countElectrons" );
-  countMuons_     = iConfig.getParameter<bool>         ( "countMuons" );
-  countTaus_      = iConfig.getParameter<bool>         ( "countTaus" );
-  minNumber_      = iConfig.getParameter<unsigned int> ( "minNumber" );
-  maxNumber_      = iConfig.getParameter<unsigned int> ( "maxNumber" );
+PATLeptonCountFilter::PATLeptonCountFilter(const edm::ParameterSet & iConfig) :
+  electronToken_(mayConsume<edm::View<Electron> >(iConfig.getParameter<edm::InputTag>( "electronSource" ))),
+  muonToken_(mayConsume<edm::View<Muon> >(iConfig.getParameter<edm::InputTag>( "muonSource" ))),
+  tauToken_(mayConsume<edm::View<Tau> >(iConfig.getParameter<edm::InputTag>( "tauSource" ))),
+  countElectrons_(iConfig.getParameter<bool>         ( "countElectrons" )),
+  countMuons_(iConfig.getParameter<bool>         ( "countMuons" )),
+  countTaus_(iConfig.getParameter<bool>         ( "countTaus" )),
+  minNumber_(iConfig.getParameter<unsigned int> ( "minNumber" )),
+  maxNumber_(iConfig.getParameter<unsigned int> ( "maxNumber" )) {
+  
 }
 
 
@@ -25,7 +26,7 @@ PATLeptonCountFilter::~PATLeptonCountFilter() {
 }
 
 
-bool PATLeptonCountFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+bool PATLeptonCountFilter::filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
   edm::Handle<edm::View<Electron> > electrons;
   if (countElectrons_) iEvent.getByToken(electronToken_, electrons);
   edm::Handle<edm::View<Muon> > muons;

--- a/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.h
+++ b/PhysicsTools/PatAlgos/plugins/PATLeptonCountFilter.h
@@ -4,7 +4,7 @@
 #ifndef PhysicsTools_PatAlgos_PATLeptonCountFilter_h
 #define PhysicsTools_PatAlgos_PATLeptonCountFilter_h
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -19,7 +19,7 @@
 namespace pat {
 
 
-  class PATLeptonCountFilter : public edm::EDFilter {
+  class PATLeptonCountFilter : public edm::global::EDFilter<> {
 
     public:
 
@@ -28,18 +28,18 @@ namespace pat {
 
     private:
 
-      virtual bool filter(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+      virtual bool filter(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
 
     private:
 
-      edm::EDGetTokenT<edm::View<Electron> > electronToken_;
-      edm::EDGetTokenT<edm::View<Muon> > muonToken_;
-      edm::EDGetTokenT<edm::View<Tau> > tauToken_;
-      bool          countElectrons_;
-      bool          countMuons_;
-      bool          countTaus_;
-      unsigned int  minNumber_;
-      unsigned int  maxNumber_;
+      const edm::EDGetTokenT<edm::View<Electron> > electronToken_;
+      const edm::EDGetTokenT<edm::View<Muon> > muonToken_;
+      const edm::EDGetTokenT<edm::View<Tau> > tauToken_;
+      const bool          countElectrons_;
+      const bool          countMuons_;
+      const bool          countTaus_;
+      const unsigned int  minNumber_;
+      const unsigned int  maxNumber_;
 
   };
 

--- a/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATLostTracks.cc
@@ -9,7 +9,7 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Common/interface/Association.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/Common/interface/View.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -26,24 +26,24 @@
 
 
 namespace pat {
-    class PATLostTracks : public edm::EDProducer {
-        public:
-            explicit PATLostTracks(const edm::ParameterSet&);
-            ~PATLostTracks();
-
-            virtual void produce(edm::Event&, const edm::EventSetup&);
-
-        private:
-            edm::EDGetTokenT<reco::PFCandidateCollection>    Cands_;
-            edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
-            edm::EDGetTokenT<reco::TrackCollection>         Tracks_;
-            edm::EDGetTokenT<reco::VertexCollection>         Vertices_;
-            edm::EDGetTokenT<reco::VertexCollection>         PV_;
-            edm::EDGetTokenT<reco::VertexCollection>         PVOrigs_;
-            double minPt_;
-            double minHits_;
-            double minPixelHits_;
-    };
+  class PATLostTracks : public edm::global::EDProducer<> {
+  public:
+    explicit PATLostTracks(const edm::ParameterSet&);
+    ~PATLostTracks();
+    
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+    
+  private:
+    const edm::EDGetTokenT<reco::PFCandidateCollection>    Cands_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
+    const edm::EDGetTokenT<reco::TrackCollection>         Tracks_;
+    const edm::EDGetTokenT<reco::VertexCollection>         Vertices_;
+    const edm::EDGetTokenT<reco::VertexCollection>         PV_;
+    const edm::EDGetTokenT<reco::VertexCollection>         PVOrigs_;
+    const double minPt_;
+    const double minHits_;
+    const double minPixelHits_;
+  };
 }
 
 pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
@@ -60,12 +60,11 @@ pat::PATLostTracks::PATLostTracks(const edm::ParameterSet& iConfig) :
   produces< std::vector<reco::Track> > ();
   produces< std::vector<pat::PackedCandidate> > ();
   produces< edm::Association<pat::PackedCandidateCollection> > ();
-
 }
 
 pat::PATLostTracks::~PATLostTracks() {}
 
-void pat::PATLostTracks::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void pat::PATLostTracks::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
     edm::Handle<reco::PFCandidateCollection> cands;
     iEvent.getByToken( Cands_, cands );

--- a/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMETProducer.h
@@ -16,7 +16,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -33,7 +33,7 @@
 
 namespace pat {
 
-  class PATMETProducer : public edm::EDProducer {
+  class PATMETProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMHTProducer.cc
@@ -45,6 +45,8 @@ pat::PATMHTProducer::PATMHTProducer(const edm::ParameterSet & iConfig){
   towerEtThreshold_ = iConfig.getParameter<double>( "towerEtThreshold") ;
   useHO_ = iConfig.getParameter<bool>("useHO");
 
+  setUncertaintyParameters();
+  
   produces<pat::MHTCollection>();
 
 }
@@ -52,13 +54,6 @@ pat::PATMHTProducer::PATMHTProducer(const edm::ParameterSet & iConfig){
 
 pat::PATMHTProducer::~PATMHTProducer() {
 }
-
-void pat::PATMHTProducer::beginJob() {
-  setUncertaintyParameters();
-}
-void pat::PATMHTProducer::endJob() {
-}
-
 
 void
 pat::PATMHTProducer::produce(edm::Event & iEvent, const edm::EventSetup & iSetup)
@@ -385,63 +380,63 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
   //-- Ecal Uncertainty Functions ------------------------------------//
   //-- From: FastSimulation/Calorimetry/data/HcalResponse.cfi --//
   //-- Ecal Barrel --//
-  ecalEBUncertainty.etUncertainty = new TF1("ecalEBEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  ecalEBUncertainty.etUncertainty.reset( new TF1("ecalEBEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   ecalEBUncertainty.etUncertainty->SetParameter(0,0.2);
   ecalEBUncertainty.etUncertainty->SetParameter(1,0.03);
   ecalEBUncertainty.etUncertainty->SetParameter(2,0.005);
 
-  ecalEBUncertainty.phiUncertainty = new TF1("ecalEBphiFunc","[0]*x",1);
+  ecalEBUncertainty.phiUncertainty.reset( new TF1("ecalEBphiFunc","[0]*x",1) );
   ecalEBUncertainty.phiUncertainty->SetParameter(0,0.0174);
 
   //-- Ecal Endcap --//
-  ecalEEUncertainty.etUncertainty = new TF1("ecalEEEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  ecalEEUncertainty.etUncertainty.reset( new TF1("ecalEEEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   ecalEEUncertainty.etUncertainty->SetParameter(0,0.2);
   ecalEEUncertainty.etUncertainty->SetParameter(1,0.03);
   ecalEEUncertainty.etUncertainty->SetParameter(2,0.005);
 
-  ecalEEUncertainty.phiUncertainty = new TF1("ecalEEphiFunc","[0]*x",1);
+  ecalEEUncertainty.phiUncertainty.reset( new TF1("ecalEEphiFunc","[0]*x",1) );
   ecalEEUncertainty.phiUncertainty->SetParameter(0,0.087);
 
   //-- Hcal Uncertainty Functions --------------------------------------//
   //-- From: FastSimulation/Calorimetry/data/HcalResponse.cfi --//
   //-- Hcal Barrel --//
-  hcalHBUncertainty.etUncertainty = new TF1("hcalHBEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  hcalHBUncertainty.etUncertainty.reset( new TF1("hcalHBEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   hcalHBUncertainty.etUncertainty->SetParameter(0,0.);
   hcalHBUncertainty.etUncertainty->SetParameter(1,1.22);
   hcalHBUncertainty.etUncertainty->SetParameter(2,0.05);
 
-  hcalHBUncertainty.phiUncertainty = new TF1("ecalHBphiFunc","[0]*x",1);
+  hcalHBUncertainty.phiUncertainty.reset( new TF1("ecalHBphiFunc","[0]*x",1) );
   hcalHBUncertainty.phiUncertainty->SetParameter(0,0.087);
 
   //-- Hcal Endcap --//
-  hcalHEUncertainty.etUncertainty = new TF1("hcalHEEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  hcalHEUncertainty.etUncertainty.reset( new TF1("hcalHEEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   hcalHEUncertainty.etUncertainty->SetParameter(0,0.);
   hcalHEUncertainty.etUncertainty->SetParameter(1,1.3);
   hcalHEUncertainty.etUncertainty->SetParameter(2,0.05);
 
-  hcalHEUncertainty.phiUncertainty = new TF1("ecalHEphiFunc","[0]*x",1);
+  hcalHEUncertainty.phiUncertainty.reset( new TF1("ecalHEphiFunc","[0]*x",1) );
   hcalHEUncertainty.phiUncertainty->SetParameter(0,0.087);
 
   //-- Hcal Outer --//
-  hcalHOUncertainty.etUncertainty = new TF1("hcalHOEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  hcalHOUncertainty.etUncertainty.reset( new TF1("hcalHOEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   hcalHOUncertainty.etUncertainty->SetParameter(0,0.);
   hcalHOUncertainty.etUncertainty->SetParameter(1,1.82);
   hcalHOUncertainty.etUncertainty->SetParameter(2,0.09);
 
-  hcalHOUncertainty.phiUncertainty = new TF1("ecalHOphiFunc","[0]*x",1);
+  hcalHOUncertainty.phiUncertainty.reset( new TF1("ecalHOphiFunc","[0]*x",1) );
   hcalHOUncertainty.phiUncertainty->SetParameter(0,0.087);
 
   //-- Hcal Forward --//
-  hcalHFUncertainty.etUncertainty = new TF1("hcalHFEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  hcalHFUncertainty.etUncertainty.reset( new TF1("hcalHFEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   hcalHFUncertainty.etUncertainty->SetParameter(0,0.);
   hcalHFUncertainty.etUncertainty->SetParameter(1,1.82);
   hcalHFUncertainty.etUncertainty->SetParameter(2,0.09);
 
-  hcalHFUncertainty.phiUncertainty = new TF1("ecalHFphiFunc","[0]*x",1);
+  hcalHFUncertainty.phiUncertainty.reset( new TF1("ecalHFphiFunc","[0]*x",1) );
   hcalHFUncertainty.phiUncertainty->SetParameter(0,0.174);
 
   //--- Jet Uncertainty Functions --------------------------------------//
-  jetUncertainty.etUncertainty = new TF1("jetEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  jetUncertainty.etUncertainty.reset( new TF1("jetEtFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   //-- values from PTDR 1, ch 11.4 --//
   jetUncertainty.etUncertainty->SetParameter(0, jetEtUncertaintyParameter0_);
   jetUncertainty.etUncertainty->SetParameter(1, jetEtUncertaintyParameter1_);
@@ -449,12 +444,12 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
 
 
   //-- phi value from our own fits --//
-  //jetUncertainty.phiUncertainty = new TF1("jetPhiFunc","[0]*x",1);
+  //jetUncertainty.phiUncertainty.reset( new TF1("jetPhiFunc","[0]*x",1) );
   //jetUncertainty.phiUncertainty->SetParameter(0, jetPhiUncertaintyParameter0_);
 
   //-- phi Functions and values from
   // http://indico.cern.ch/getFile.py/access?contribId=9&sessionId=0&resId=0&materialId=slides&confId=46394
-  jetUncertainty.phiUncertainty = new TF1("jetPhiFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3);
+  jetUncertainty.phiUncertainty.reset( new TF1("jetPhiFunc","x*sqrt(([0]*[0]/(x*x))+([1]*[1]/x)+([2]*[2]))",3) );
   jetUncertainty.phiUncertainty->SetParameter(0, jetPhiUncertaintyParameter0_);
   jetUncertainty.phiUncertainty->SetParameter(1, jetPhiUncertaintyParameter1_);
   jetUncertainty.phiUncertainty->SetParameter(2, jetPhiUncertaintyParameter2_);
@@ -462,9 +457,9 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
 
 
   //-- Jet corrections are assumed not to have an error --//
-  /*jetCorrUncertainty.etUncertainty = new TF1("jetCorrEtFunc","[0]*x",1);
+  /*jetCorrUncertainty.etUncertainty.reset( new TF1("jetCorrEtFunc","[0]*x",1) );
   jetCorrUncertainty.etUncertainty->SetParameter(0,0.0);
-  jetCorrUncertainty.phiUncertainty = new TF1("jetCorrPhiFunc","[0]*x",1);
+  jetCorrUncertainty.phiUncertainty.reset( new TF1("jetCorrPhiFunc","[0]*x",1) );
   jetCorrUncertainty.phiUncertainty->SetParameter(0,0.0*(3.14159/180.));*/
 
 
@@ -474,29 +469,29 @@ void pat::PATMHTProducer::setUncertaintyParameters(){
   // https://twiki.cern.ch/twiki/bin/view/CMS/EgammaCMSSWVal
   // electron resolution in energy is around 3.4%, measured for 10 < pT < 50 at realistic events with pile-up.
 
-  eleUncertainty.etUncertainty = new TF1("eleEtFunc","[0] * x",1);
+  eleUncertainty.etUncertainty.reset( new TF1("eleEtFunc","[0] * x",1) );
   //  eleUncertainty.etUncertainty->SetParameter(0,0.034);
   eleUncertainty.etUncertainty->SetParameter(0, eleEtUncertaintyParameter0_);
 
 
-  eleUncertainty.phiUncertainty = new TF1("elePhiFunc","[0] * x",1);
+  eleUncertainty.phiUncertainty.reset( new TF1("elePhiFunc","[0] * x",1) );
   //  eleUncertainty.phiUncertainty->SetParameter(0,1*(3.14159/180.));
   eleUncertainty.phiUncertainty->SetParameter(0, elePhiUncertaintyParameter0_);
 
   //--- Muon Uncertainty Functions ------------------------------------//
   // and ambiguious values for the muons...
 
-  muonUncertainty.etUncertainty = new TF1("muonEtFunc","[0] * x",1);
+  muonUncertainty.etUncertainty.reset( new TF1("muonEtFunc","[0] * x",1) );
   //  muonUncertainty.etUncertainty->SetParameter(0,0.01);
   muonUncertainty.etUncertainty->SetParameter(0, muonEtUncertaintyParameter0_);
-  muonUncertainty.phiUncertainty = new TF1("muonPhiFunc","[0] * x",1);
+  muonUncertainty.phiUncertainty.reset( new TF1("muonPhiFunc","[0] * x",1) );
   //  muonUncertainty.phiUncertainty->SetParameter(0,1*(3.14159/180.));
   muonUncertainty.phiUncertainty->SetParameter(0, muonPhiUncertaintyParameter0_);
 
   //-- Muon calo deposites are assumed not to have an error --//
-  /*muonCorrUncertainty.etUncertainty = new TF1("muonCorrEtFunc","[0] * x",1);
+  /*muonCorrUncertainty.etUncertainty.reset( new TF1("muonCorrEtFunc","[0] * x",1) );
   muonCorrUncertainty.etUncertainty->SetParameter(0,0.0);
-  muonCorrUncertainty.phiUncertainty = new TF1("muonCorrPhiFunc","[0] * x",1);
+  muonCorrUncertainty.phiUncertainty.reset( new TF1("muonCorrPhiFunc","[0] * x",1) );
   muonCorrUncertainty.phiUncertainty->SetParameter(0,0.0*(3.14159/180.)); */
 
 }

--- a/PhysicsTools/PatAlgos/plugins/PATMHTProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMHTProducer.h
@@ -27,7 +27,7 @@
 // user include files
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
 
@@ -61,15 +61,13 @@
 //
 
 namespace pat {
-  class PATMHTProducer : public edm::EDProducer {
+  class PATMHTProducer : public edm::stream::EDProducer<> {
   public:
     explicit PATMHTProducer(const edm::ParameterSet&);
     ~PATMHTProducer();
 
   private:
-    virtual void beginJob() ;
     virtual void produce(edm::Event&, const edm::EventSetup&) override;
-    virtual void endJob() ;
 
     double getJets(edm::Event&, const edm::EventSetup&);
     double getElectrons(edm::Event&, const edm::EventSetup&);
@@ -99,8 +97,8 @@ namespace pat {
 
     class uncertaintyFunctions{
     public:
-      TF1 *etUncertainty;
-      TF1 *phiUncertainty;
+      std::unique_ptr<TF1> etUncertainty;
+      std::unique_ptr<TF1> phiUncertainty;
     };
 
     void setUncertaintyParameters();// fills the following uncertaintyFunctions objects:

--- a/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonProducer.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "DataFormats/PatCandidates/interface/Muon.h"
 #include "CommonTools/Utils/interface/PtComparator.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -39,7 +39,7 @@ namespace pat {
   class CaloIsolationEnergy;
 
   /// class definition
-  class PATMuonProducer : public edm::EDProducer {
+  class PATMuonProducer : public edm::stream::EDProducer<> {
 
   public:
     /// default constructir

--- a/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATMuonSlimmer.cc
@@ -5,7 +5,7 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -22,7 +22,7 @@
 
 namespace pat {
   
-  class PATMuonSlimmer : public edm::EDProducer {
+  class PATMuonSlimmer : public edm::stream::EDProducer<> {
   public:
     explicit PATMuonSlimmer(const edm::ParameterSet & iConfig);
     virtual ~PATMuonSlimmer() { }
@@ -31,12 +31,12 @@ namespace pat {
     virtual void beginLuminosityBlock(const edm::LuminosityBlock&, const  edm::EventSetup&) override final;
     
   private:
-    edm::EDGetTokenT<pat::MuonCollection> src_;
-    edm::EDGetTokenT<reco::PFCandidateCollection> pf_;
-    edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
-    bool linkToPackedPF_;
-    StringCutObjectSelector<pat::Muon> saveTeVMuons_;
-    bool modifyMuon_;
+    const edm::EDGetTokenT<pat::MuonCollection> src_;
+    const edm::EDGetTokenT<reco::PFCandidateCollection> pf_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection>> pf2pc_;
+    const bool linkToPackedPF_;
+    const StringCutObjectSelector<pat::Muon> saveTeVMuons_;
+    const bool modifyMuon_;
     std::unique_ptr<pat::ObjectModifier<pat::Muon> > muonModifier_;
   };
 
@@ -44,6 +44,8 @@ namespace pat {
 
 pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet & iConfig) :
     src_(consumes<pat::MuonCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+    pf_(mayConsume<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandidates"))),
+    pf2pc_(mayConsume<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
     linkToPackedPF_(iConfig.getParameter<bool>("linkToPackedPFCandidates")),
     saveTeVMuons_(iConfig.getParameter<std::string>("saveTeVMuons")),
     modifyMuon_(iConfig.getParameter<bool>("modifyMuons"))
@@ -57,10 +59,6 @@ pat::PATMuonSlimmer::PATMuonSlimmer(const edm::ParameterSet & iConfig) :
       muonModifier_.reset(nullptr);
     }
     produces<std::vector<pat::Muon> >();
-    if (linkToPackedPF_) {
-        pf_    = consumes<reco::PFCandidateCollection>(iConfig.getParameter<edm::InputTag>("pfCandidates"));
-        pf2pc_ = consumes<edm::Association<pat::PackedCandidateCollection>>(iConfig.getParameter<edm::InputTag>("packedPFCandidates"));
-    }
 }
 
 void 

--- a/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPFParticleProducer.h
@@ -16,7 +16,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -40,7 +40,7 @@ namespace pat {
 
   class LeptonLRCalc;
 
-  class PATPFParticleProducer : public edm::EDProducer {
+  class PATPFParticleProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedCandidateProducer.cc
@@ -9,7 +9,7 @@
 #include "DataFormats/PatCandidates/interface/PackedCandidate.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Common/interface/Association.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/Common/interface/View.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -30,58 +30,58 @@
 //#define CRAZYSORT 
 
 namespace pat {
-    ///conversion map from quality flags used in PV association and miniAOD one
-    static int qualityMap[8]  = {1,0,1,1,4,4,5,6};
-
-    class PATPackedCandidateProducer : public edm::EDProducer {
-        public:
-            explicit PATPackedCandidateProducer(const edm::ParameterSet&);
-            ~PATPackedCandidateProducer();
-
-            virtual void produce(edm::Event&, const edm::EventSetup&);
-
-            //sorting of cands to maximize the zlib compression
-            bool candsOrdering(pat::PackedCandidate i,pat::PackedCandidate j) {
-                if (std::abs(i.charge()) == std::abs(j.charge())) {
-                    if(i.charge()!=0){
-                        if(i.pt() > minPtForTrackProperties_ and j.pt() <= minPtForTrackProperties_ ) return true;
-                        if(i.pt() <= minPtForTrackProperties_ and j.pt() > minPtForTrackProperties_ ) return false;
-                  }
-                   if(i.vertexRef() == j.vertexRef()) 
-                      return i.eta() > j.eta();
-                   else 
-                      return i.vertexRef().key() < j.vertexRef().key();
-                }
-                return std::abs(i.charge()) > std::abs(j.charge());
-            }
-            template <typename T>
-            std::vector<size_t> sort_indexes(const std::vector<T> &v ) {
-              std::vector<size_t> idx(v.size());
-              for (size_t i = 0; i != idx.size(); ++i) idx[i] = i;
-              std::sort(idx.begin(), idx.end(),[&v,this](size_t i1, size_t i2) { return candsOrdering(v[i1],v[i2]);});
-              return idx;
-           }
-
-        private:
-            edm::EDGetTokenT<reco::PFCandidateCollection>    Cands_;
-            edm::EDGetTokenT<reco::VertexCollection>         PVs_;
-            edm::EDGetTokenT<edm::Association<reco::VertexCollection> > PVAsso_;
-            edm::EDGetTokenT<edm::ValueMap<int> >            PVAssoQuality_;
-            edm::EDGetTokenT<reco::VertexCollection>         PVOrigs_;
-            edm::EDGetTokenT<reco::TrackCollection>          TKOrigs_;
-            edm::EDGetTokenT< edm::ValueMap<float> >         PuppiWeight_;
-            edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr> >    PuppiCandsMap_;
-            edm::EDGetTokenT<std::vector< reco::PFCandidate >  >    PuppiCands_;
-
-            double minPtForTrackProperties_;
-            // for debugging
-            float calcDxy(float dx, float dy, float phi) {
-                return - dx * std::sin(phi) + dy * std::cos(phi);
-            }
-            float calcDz(reco::Candidate::Point p, reco::Candidate::Point v, const reco::Candidate &c) {
-                return p.Z()-v.Z() - ((p.X()-v.X()) * c.px() + (p.Y()-v.Y())*c.py()) * c.pz()/(c.pt()*c.pt());
-            }
-    };
+  ///conversion map from quality flags used in PV association and miniAOD one
+  static int qualityMap[8]  = {1,0,1,1,4,4,5,6};
+  
+  class PATPackedCandidateProducer : public edm::global::EDProducer<> {
+  public:
+    explicit PATPackedCandidateProducer(const edm::ParameterSet&);
+    ~PATPackedCandidateProducer();
+    
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
+    
+    //sorting of cands to maximize the zlib compression
+    bool candsOrdering(pat::PackedCandidate i,pat::PackedCandidate j) const {
+      if (std::abs(i.charge()) == std::abs(j.charge())) {
+        if(i.charge()!=0){
+          if(i.pt() > minPtForTrackProperties_ and j.pt() <= minPtForTrackProperties_ ) return true;
+          if(i.pt() <= minPtForTrackProperties_ and j.pt() > minPtForTrackProperties_ ) return false;
+        }
+        if(i.vertexRef() == j.vertexRef()) 
+          return i.eta() > j.eta();
+        else 
+          return i.vertexRef().key() < j.vertexRef().key();
+      }
+      return std::abs(i.charge()) > std::abs(j.charge());
+    }
+    template <typename T>
+    std::vector<size_t> sort_indexes(const std::vector<T> &v ) const {
+      std::vector<size_t> idx(v.size());
+      for (size_t i = 0; i != idx.size(); ++i) idx[i] = i;
+      std::sort(idx.begin(), idx.end(),[&v,this](size_t i1, size_t i2) { return candsOrdering(v[i1],v[i2]);});
+      return idx;
+    }
+    
+  private:
+    const edm::EDGetTokenT<reco::PFCandidateCollection>    Cands_;
+    const edm::EDGetTokenT<reco::VertexCollection>         PVs_;
+    const edm::EDGetTokenT<edm::Association<reco::VertexCollection> > PVAsso_;
+    const edm::EDGetTokenT<edm::ValueMap<int> >            PVAssoQuality_;
+    const edm::EDGetTokenT<reco::VertexCollection>         PVOrigs_;
+    const edm::EDGetTokenT<reco::TrackCollection>          TKOrigs_;
+    const edm::EDGetTokenT< edm::ValueMap<float> >         PuppiWeight_;
+    const edm::EDGetTokenT<edm::ValueMap<reco::CandidatePtr> >    PuppiCandsMap_;
+    const edm::EDGetTokenT<std::vector< reco::PFCandidate >  >    PuppiCands_;
+    
+    const double minPtForTrackProperties_;
+    // for debugging
+    float calcDxy(float dx, float dy, float phi) const {
+      return - dx * std::sin(phi) + dy * std::cos(phi);
+    }
+    float calcDz(reco::Candidate::Point p, reco::Candidate::Point v, const reco::Candidate &c) const {
+      return p.Z()-v.Z() - ((p.X()-v.X()) * c.px() + (p.Y()-v.Y())*c.py()) * c.pz()/(c.pt()*c.pt());
+    }
+  };
 }
 
 pat::PATPackedCandidateProducer::PATPackedCandidateProducer(const edm::ParameterSet& iConfig) :
@@ -105,7 +105,7 @@ pat::PATPackedCandidateProducer::~PATPackedCandidateProducer() {}
 
 
 
-void pat::PATPackedCandidateProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void pat::PATPackedCandidateProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
     edm::Handle<reco::PFCandidateCollection> cands;
     iEvent.getByToken( Cands_, cands );

--- a/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATPackedGenParticleProducer.cc
@@ -9,7 +9,7 @@
 #include "DataFormats/PatCandidates/interface/PackedGenParticle.h"
 #include "DataFormats/PatCandidates/interface/Jet.h"
 #include "DataFormats/Common/interface/Association.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "DataFormats/Common/interface/View.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -37,21 +37,21 @@
 
 
 namespace pat {
-    class PATPackedGenParticleProducer : public edm::EDProducer {
-        public:
-            explicit PATPackedGenParticleProducer(const edm::ParameterSet&);
-            ~PATPackedGenParticleProducer();
-
-            virtual void produce(edm::Event&, const edm::EventSetup&);
-
-        private:
-            edm::EDGetTokenT<reco::GenParticleCollection>    Cands_;
-            edm::EDGetTokenT<reco::GenParticleCollection>    GenOrigs_;
-            edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> >    Asso_;
-            edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> >    AssoOriginal_;
-            edm::EDGetTokenT<reco::VertexCollection>         PVs_;
-            double maxRapidity_;
-    };
+  class PATPackedGenParticleProducer : public edm::global::EDProducer<> {
+  public:
+    explicit PATPackedGenParticleProducer(const edm::ParameterSet&);
+    ~PATPackedGenParticleProducer();
+    
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
+    
+  private:
+    const edm::EDGetTokenT<reco::GenParticleCollection>    Cands_;
+    const edm::EDGetTokenT<reco::GenParticleCollection>    GenOrigs_;
+    const edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> >    Asso_;
+    const edm::EDGetTokenT<edm::Association<reco::GenParticleCollection> >    AssoOriginal_;
+    const edm::EDGetTokenT<reco::VertexCollection>         PVs_;
+    const double maxRapidity_;
+  };
 }
 
 pat::PATPackedGenParticleProducer::PATPackedGenParticleProducer(const edm::ParameterSet& iConfig) :
@@ -64,12 +64,11 @@ pat::PATPackedGenParticleProducer::PATPackedGenParticleProducer(const edm::Param
 {
   produces< std::vector<pat::PackedGenParticle> > ();
   produces< edm::Association< std::vector<pat::PackedGenParticle> > >();
-
 }
 
 pat::PATPackedGenParticleProducer::~PATPackedGenParticleProducer() {}
 
-void pat::PATPackedGenParticleProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void pat::PATPackedGenParticleProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
 
     edm::Handle<reco::GenParticleCollection> cands;

--- a/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATPhotonProducer.h
@@ -16,7 +16,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -50,7 +50,7 @@
 
 namespace pat {
 
-  class PATPhotonProducer : public edm::EDProducer {
+  class PATPhotonProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATSecondaryVertexSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATSecondaryVertexSlimmer.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "FWCore/Framework/interface/Event.h"
@@ -15,32 +15,32 @@
 #include "DataFormats/Common/interface/RefToPtr.h"
 
 namespace pat {
-    class PATSecondaryVertexSlimmer : public edm::EDProducer {
-        public:
-            explicit PATSecondaryVertexSlimmer(const edm::ParameterSet&);
-            ~PATSecondaryVertexSlimmer();
-
-            virtual void produce(edm::Event&, const edm::EventSetup&);
-        private:
-            edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection> src_;
-            edm::EDGetTokenT<std::vector<reco::Vertex> > srcLegacy_;
-            edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
-            edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map2_;
+  class PATSecondaryVertexSlimmer : public edm::global::EDProducer<> {
+  public:
+    explicit PATSecondaryVertexSlimmer(const edm::ParameterSet&);
+    ~PATSecondaryVertexSlimmer();
+    
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
+  private:
+    const edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection> src_;
+    const edm::EDGetTokenT<std::vector<reco::Vertex> > srcLegacy_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map_;
+    const edm::EDGetTokenT<edm::Association<pat::PackedCandidateCollection> > map2_;
     };
 }
 
 pat::PATSecondaryVertexSlimmer::PATSecondaryVertexSlimmer(const edm::ParameterSet& iConfig) :
-    src_(mayConsume<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
-    srcLegacy_(mayConsume<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("src"))),
-    map_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
-    map2_(mayConsume<edm::Association<pat::PackedCandidateCollection> >(iConfig.existsAs<edm::InputTag>("lostTracksCandidates") ? iConfig.getParameter<edm::InputTag>("lostTracksCandidates") : edm::InputTag("lostTracks") ))
+  src_(consumes<reco::VertexCompositePtrCandidateCollection>(iConfig.getParameter<edm::InputTag>("src"))),
+  srcLegacy_(mayConsume<std::vector<reco::Vertex> >(iConfig.getParameter<edm::InputTag>("src"))),
+  map_(consumes<edm::Association<pat::PackedCandidateCollection> >(iConfig.getParameter<edm::InputTag>("packedPFCandidates"))),
+  map2_(mayConsume<edm::Association<pat::PackedCandidateCollection> >(iConfig.existsAs<edm::InputTag>("lostTracksCandidates") ? iConfig.getParameter<edm::InputTag>("lostTracksCandidates") : edm::InputTag("lostTracks") ))
 {
   produces< reco::VertexCompositePtrCandidateCollection >();
 }
 
 pat::PATSecondaryVertexSlimmer::~PATSecondaryVertexSlimmer() {}
 
-void pat::PATSecondaryVertexSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void pat::PATSecondaryVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 
     std::auto_ptr<reco::VertexCompositePtrCandidateCollection> outPtr(new reco::VertexCompositePtrCandidateCollection);
  

--- a/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
+++ b/PhysicsTools/PatAlgos/plugins/PATSingleVertexSelector.h
@@ -12,18 +12,20 @@
   \version  $Id: PATSingleVertexSelector.h,v 1.5 2011/06/15 11:47:25 friis Exp $
 */
 
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "CommonTools/Utils/interface/StringCutObjectSelector.h"
 
 #include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
 
 namespace pat {
 
-  class PATSingleVertexSelector : public edm::EDFilter {
+  class PATSingleVertexSelector : public edm::stream::EDFilter<> {
 
     public:
 
@@ -37,7 +39,8 @@ namespace pat {
       typedef StringCutObjectSelector<reco::Vertex>    VtxSel;
       typedef StringCutObjectSelector<reco::Candidate> CandSel;
 
-      static Mode parseMode(const std::string &name) ;
+      Mode parseMode(const std::string &name) const;
+      
       std::auto_ptr<std::vector<reco::Vertex> >
         filter_(Mode mode, const edm::Event & iEvent, const edm::EventSetup & iSetup);
       bool hasMode_(Mode mode) const ;
@@ -45,12 +48,12 @@ namespace pat {
       std::vector<Mode> modes_; // mode + optional fallbacks
       edm::EDGetTokenT<std::vector<reco::Vertex> > verticesToken_;
       std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > candidatesToken_;
-      std::auto_ptr<VtxSel > vtxPreselection_;
-      std::auto_ptr<CandSel> candPreselection_;
+      const VtxSel vtxPreselection_;
+      const CandSel candPreselection_;
       edm::EDGetTokenT<reco::BeamSpot> beamSpotToken_;
       // transient data. meaningful while 'filter()' is on the stack
-      std::vector<const reco::Vertex *> selVtxs_;
-      const reco::Candidate *           bestCand_;
+      std::vector<reco::VertexRef> selVtxs_;
+      reco::CandidatePtr           bestCand_;
 
       // flag to enable/disable EDFilter functionality:
       // if set to false, PATSingleVertexSelector selects the "one" event vertex,

--- a/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTauProducer.h
@@ -15,7 +15,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -43,7 +43,7 @@
 typedef edm::AssociationVector<reco::PFTauRefProd, std::vector<reco::PFTauTransverseImpactParameterRef> > PFTauTIPAssociationByRef;
 namespace pat {
 
-  class PATTauProducer : public edm::EDProducer {
+  class PATTauProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerEventProducer.h
@@ -29,7 +29,7 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/GetterOfProducts.h"
 
 #include <string>
@@ -47,7 +47,7 @@
 
 namespace pat {
 
-  class PATTriggerEventProducer : public edm::EDProducer {
+  class PATTriggerEventProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerMatchEmbedder.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerMatchEmbedder.cc
@@ -21,7 +21,7 @@
 #include "FWCore/Utilities/interface/transform.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -39,12 +39,12 @@
 namespace pat {
 
   template< class PATObjectType >
-  class PATTriggerMatchEmbedder : public edm::EDProducer {
+  class PATTriggerMatchEmbedder : public edm::global::EDProducer<> {
 
-      edm::InputTag src_;
-      edm::EDGetTokenT< edm::View< PATObjectType > > srcToken_;
-      std::vector< edm::InputTag > matches_;
-      std::vector< edm::EDGetTokenT< TriggerObjectStandAloneMatch > > matchesTokens_;
+      const edm::InputTag src_;
+      const edm::EDGetTokenT< edm::View< PATObjectType > > srcToken_;
+      const std::vector< edm::InputTag > matches_;
+      const std::vector< edm::EDGetTokenT< TriggerObjectStandAloneMatch > > matchesTokens_;
 
     public:
 
@@ -53,7 +53,7 @@ namespace pat {
 
     private:
 
-      virtual void produce( edm::Event & iEvent, const edm::EventSetup& iSetup) override;
+    virtual void produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
 
   };
 
@@ -81,7 +81,7 @@ PATTriggerMatchEmbedder< PATObjectType >::PATTriggerMatchEmbedder( const edm::Pa
 }
 
 template< class PATObjectType >
-void PATTriggerMatchEmbedder< PATObjectType >::produce( edm::Event & iEvent, const edm::EventSetup& iSetup)
+void PATTriggerMatchEmbedder< PATObjectType >::produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const
 {
   std::auto_ptr< std::vector< PATObjectType > > output( new std::vector< PATObjectType >() );
 

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneUnpacker.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerObjectStandAloneUnpacker.cc
@@ -14,7 +14,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,23 +24,23 @@
 #include "DataFormats/Common/interface/TriggerResults.h"
 
 namespace pat {
-
-  class PATTriggerObjectStandAloneUnpacker : public edm::EDProducer {
-
-    public:
-
-      explicit PATTriggerObjectStandAloneUnpacker( const edm::ParameterSet & iConfig );
-      ~PATTriggerObjectStandAloneUnpacker() {};
-
-    private:
-
-      virtual void produce( edm::Event & iEvent, const edm::EventSetup& iSetup) override;
-
-      edm::EDGetTokenT< TriggerObjectStandAloneCollection > patTriggerObjectsStandAloneToken_;
-      edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
-
+  
+  class PATTriggerObjectStandAloneUnpacker : public edm::global::EDProducer<> {
+    
+  public:
+    
+    explicit PATTriggerObjectStandAloneUnpacker( const edm::ParameterSet & iConfig );
+    ~PATTriggerObjectStandAloneUnpacker() {};
+    
+  private:
+    
+    virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
+    
+    const edm::EDGetTokenT< TriggerObjectStandAloneCollection > patTriggerObjectsStandAloneToken_;
+    const edm::EDGetTokenT< edm::TriggerResults > triggerResultsToken_;
+    
   };
-
+  
 }
 
 
@@ -54,7 +54,7 @@ PATTriggerObjectStandAloneUnpacker::PATTriggerObjectStandAloneUnpacker( const ed
   produces< TriggerObjectStandAloneCollection >();
 }
 
-void PATTriggerObjectStandAloneUnpacker::produce( edm::Event & iEvent, const edm::EventSetup& iSetup)
+void PATTriggerObjectStandAloneUnpacker::produce( edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const
 {
   edm::Handle< TriggerObjectStandAloneCollection > patTriggerObjectsStandAlone;
   iEvent.getByToken( patTriggerObjectsStandAloneToken_, patTriggerObjectsStandAlone );

--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.h
@@ -37,7 +37,7 @@
 
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/GetterOfProducts.h"
 
 #include <string>
@@ -55,7 +55,7 @@
 
 namespace pat {
 
-  class PATTriggerProducer : public edm::EDProducer {
+  class PATTriggerProducer : public edm::stream::EDProducer<> {
 
     public:
 

--- a/PhysicsTools/PatAlgos/plugins/PATVertexSlimmer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATVertexSlimmer.cc
@@ -3,7 +3,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/ValueMap.h"
 
@@ -14,17 +14,17 @@
 #include "DataFormats/PatCandidates/interface/libminifloat.h"
 
 namespace pat {
-    class PATVertexSlimmer : public edm::EDProducer {
-        public:
-            explicit PATVertexSlimmer(const edm::ParameterSet&);
-            ~PATVertexSlimmer();
-
-            virtual void produce(edm::Event&, const edm::EventSetup&);
-        private:
-            edm::EDGetTokenT<std::vector<reco::Vertex> > src_;
-            edm::EDGetTokenT<edm::ValueMap<float> > score_;
-            bool rekeyScores_;
-    };
+  class PATVertexSlimmer : public edm::global::EDProducer<> {
+  public:
+    explicit PATVertexSlimmer(const edm::ParameterSet&);
+    ~PATVertexSlimmer();
+    
+    virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
+  private:
+    const edm::EDGetTokenT<std::vector<reco::Vertex> > src_;
+    const edm::EDGetTokenT<edm::ValueMap<float> > score_;
+    const bool rekeyScores_;
+  };
 }
 
 pat::PATVertexSlimmer::PATVertexSlimmer(const edm::ParameterSet& iConfig) :
@@ -38,7 +38,7 @@ pat::PATVertexSlimmer::PATVertexSlimmer(const edm::ParameterSet& iConfig) :
 
 pat::PATVertexSlimmer::~PATVertexSlimmer() {}
 
-void pat::PATVertexSlimmer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void pat::PATVertexSlimmer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
     edm::Handle<std::vector<reco::Vertex> > vertices;
     iEvent.getByToken(src_, vertices);
     std::auto_ptr<std::vector<reco::Vertex> > outPtr(new std::vector<reco::Vertex>());

--- a/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
+++ b/PhysicsTools/PatAlgos/plugins/TauJetCorrFactorsProducer.h
@@ -17,7 +17,7 @@
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "CondFormats/JetMETObjects/interface/FactorizedJetCorrector.h"
@@ -35,7 +35,7 @@
 
 namespace pat {
 
-  class TauJetCorrFactorsProducer : public edm::EDProducer
+  class TauJetCorrFactorsProducer : public edm::stream::EDProducer<>
   {
    public:
     /// value map for JetCorrFactors (to be written into the event)

--- a/PhysicsTools/PatAlgos/plugins/TrackAndVertexUnpacker.cc
+++ b/PhysicsTools/PatAlgos/plugins/TrackAndVertexUnpacker.cc
@@ -6,7 +6,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -24,26 +24,26 @@
 
 
 namespace pat {
-
-  class PATTrackAndVertexUnpacker : public edm::EDProducer {
-
-
-    public:
-
-      explicit PATTrackAndVertexUnpacker(const edm::ParameterSet & iConfig);
-      ~PATTrackAndVertexUnpacker();
-
-      virtual void produce(edm::Event & iEvent, const edm::EventSetup& iSetup) override;
-
-    private:
-      typedef std::vector<edm::InputTag> VInputTag;
-      // configurables
-      edm::EDGetTokenT< std::vector<pat::PackedCandidate> >    Cands_;
-      edm::EDGetTokenT<reco::VertexCollection>         PVs_;
-      edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection>         SVs_;
-      edm::EDGetTokenT<std::vector<pat::PackedCandidate> >         AdditionalTracks_;
-//////    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > particlesTokens_;
-
+  
+  class PATTrackAndVertexUnpacker : public edm::global::EDProducer<> {
+    
+    
+  public:
+    
+    explicit PATTrackAndVertexUnpacker(const edm::ParameterSet & iConfig);
+    ~PATTrackAndVertexUnpacker();
+    
+    virtual void produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup& iSetup) const override;
+    
+  private:
+    typedef std::vector<edm::InputTag> VInputTag;
+    // configurables
+    const edm::EDGetTokenT<std::vector<pat::PackedCandidate> >    Cands_;
+    const edm::EDGetTokenT<reco::VertexCollection>         PVs_;
+    const edm::EDGetTokenT<reco::VertexCompositePtrCandidateCollection>         SVs_;
+    const edm::EDGetTokenT<std::vector<pat::PackedCandidate> >         AdditionalTracks_;
+    //////    std::vector<edm::EDGetTokenT<edm::View<reco::Candidate> > > particlesTokens_;
+    
   };
 
 }
@@ -66,7 +66,7 @@ PATTrackAndVertexUnpacker::~PATTrackAndVertexUnpacker() {
 }
 
 
-void PATTrackAndVertexUnpacker::produce(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+void PATTrackAndVertexUnpacker::produce(edm::StreamID, edm::Event & iEvent, const edm::EventSetup & iSetup) const {
 	using namespace edm; using namespace std; using namespace reco;
 	Handle<std::vector<pat::PackedCandidate> > cands;
 	iEvent.getByToken(Cands_, cands);

--- a/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/VertexAssociationProducer.cc
@@ -13,7 +13,7 @@
 */
 
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
@@ -26,7 +26,7 @@
 
 namespace pat {
 
-  class PATVertexAssociationProducer : public edm::EDProducer {
+  class PATVertexAssociationProducer : public edm::stream::EDProducer<> {
 
     typedef edm::ValueMap<pat::VertexAssociation> VertexAssociationMap;
 

--- a/PhysicsTools/PatAlgos/src/EfficiencyLoader.cc
+++ b/PhysicsTools/PatAlgos/src/EfficiencyLoader.cc
@@ -20,7 +20,7 @@ EfficiencyLoader::EfficiencyLoader(const edm::ParameterSet &iConfig, edm::Consum
 }
 
 void
-EfficiencyLoader::newEvent(const edm::Event &iEvent) const {
+EfficiencyLoader::newEvent(const edm::Event &iEvent) {
     for (size_t i = 0, n = names_.size(); i < n; ++i) {
         iEvent.getByToken(tokens_[i], handles_[i]);
     }

--- a/PhysicsTools/PatAlgos/src/KinResolutionsLoader.cc
+++ b/PhysicsTools/PatAlgos/src/KinResolutionsLoader.cc
@@ -25,7 +25,7 @@ KinResolutionsLoader::KinResolutionsLoader(const edm::ParameterSet &iConfig)
 }
 
 void
-KinResolutionsLoader::newEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) const {
+KinResolutionsLoader::newEvent(const edm::Event &iEvent, const edm::EventSetup &iSetup) {
     for (size_t i = 0, n = patlabels_.size(); i < n; ++i) {
         iSetup.get<KinematicResolutionRcd>().get(eslabels_[i], handles_[i]);
         handles_[i]->setup(iSetup);

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.cc
@@ -12,7 +12,7 @@ ShiftedParticleMETcorrInputProducer::~ShiftedParticleMETcorrInputProducer()
 // nothing to be done yet...
 }
 
-void ShiftedParticleMETcorrInputProducer::produce(edm::Event& evt, const edm::EventSetup& es)
+void ShiftedParticleMETcorrInputProducer::produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const
 {
   edm::Handle<CandidateView> originalParticles;
   evt.getByToken(srcOriginalToken_, originalParticles);

--- a/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h
+++ b/PhysicsTools/PatUtils/plugins/ShiftedParticleMETcorrInputProducer.h
@@ -11,7 +11,7 @@
  *
  */
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -24,7 +24,7 @@
 #include <string>
 #include <vector>
 
-class ShiftedParticleMETcorrInputProducer : public edm::EDProducer
+class ShiftedParticleMETcorrInputProducer : public edm::global::EDProducer<>
 {
  public:
 
@@ -34,10 +34,10 @@ class ShiftedParticleMETcorrInputProducer : public edm::EDProducer
  private:
   typedef edm::View<reco::Candidate> CandidateView;
 
-  void produce(edm::Event&, const edm::EventSetup&);
+  void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const;
 
-  edm::EDGetTokenT<CandidateView> srcOriginalToken_;
-  edm::EDGetTokenT<CandidateView> srcShiftedToken_;
+  const edm::EDGetTokenT<CandidateView> srcOriginalToken_;
+  const edm::EDGetTokenT<CandidateView> srcShiftedToken_;
 };
 
 #endif

--- a/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
+++ b/RecoEgamma/EgammaPhotonProducers/interface/ReducedEGProducer.h
@@ -44,29 +44,29 @@
 
 
 // ReducedEGProducer inherits from EDProducer, so it can be a module:
-class ReducedEGProducer : public edm::EDProducer {
+class ReducedEGProducer : public edm::global::EDProducer<> {
 
  public:
 
   ReducedEGProducer (const edm::ParameterSet& ps);
   ~ReducedEGProducer();
 
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  virtual void produce(edm::StreamID, edm::Event& evt, const edm::EventSetup& es) const override final;
 
  private: 
   
  //tokens for input collections
- edm::EDGetTokenT<reco::PhotonCollection> photonT_;
- edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronT_; 
- edm::EDGetTokenT<reco::ConversionCollection> conversionT_;
- edm::EDGetTokenT<reco::ConversionCollection> singleConversionT_;
+ const edm::EDGetTokenT<reco::PhotonCollection> photonT_;
+ const edm::EDGetTokenT<reco::GsfElectronCollection> gsfElectronT_; 
+ const edm::EDGetTokenT<reco::ConversionCollection> conversionT_;
+ const edm::EDGetTokenT<reco::ConversionCollection> singleConversionT_;
  
- edm::EDGetTokenT<EcalRecHitCollection> barrelEcalHits_;
- edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHits_;
- edm::EDGetTokenT<EcalRecHitCollection> preshowerEcalHits_;
+ const edm::EDGetTokenT<EcalRecHitCollection> barrelEcalHits_;
+ const edm::EDGetTokenT<EcalRecHitCollection> endcapEcalHits_;
+ const edm::EDGetTokenT<EcalRecHitCollection> preshowerEcalHits_;
  
- edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > photonPfCandMapT_;
- edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > gsfElectronPfCandMapT_;
+ const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > photonPfCandMapT_;
+ const edm::EDGetTokenT<edm::ValueMap<std::vector<reco::PFCandidateRef> > > gsfElectronPfCandMapT_;
  
  std::vector<edm::EDGetTokenT<edm::ValueMap<bool> > > photonIdTs_;
  std::vector<edm::EDGetTokenT<edm::ValueMap<float> > > gsfElectronIdTs_;
@@ -75,34 +75,31 @@ class ReducedEGProducer : public edm::EDProducer {
  std::vector<edm::EDGetTokenT<edm::ValueMap<float> > > gsfElectronPFClusterIsoTs_;
 
  //names for output collections
- std::string outPhotons_;
- std::string outPhotonCores_;
- std::string outGsfElectrons_;
- std::string outGsfElectronCores_;
- std::string outConversions_;
- std::string outSingleConversions_;
- std::string outSuperClusters_;
- std::string outEBEEClusters_;
- std::string outESClusters_;
- std::string outEBRecHits_;
- std::string outEERecHits_;
- std::string outESRecHits_;
- std::string outPhotonPfCandMap_;
- std::string outGsfElectronPfCandMap_;
- std::vector<std::string> outPhotonIds_;
- std::vector<std::string> outGsfElectronIds_;
- std::vector<std::string> outPhotonPFClusterIsos_;
- std::vector<std::string> outGsfElectronPFClusterIsos_;
+ const std::string outPhotons_;
+ const std::string outPhotonCores_;
+ const std::string outGsfElectrons_;
+ const std::string outGsfElectronCores_;
+ const std::string outConversions_;
+ const std::string outSingleConversions_;
+ const std::string outSuperClusters_;
+ const std::string outEBEEClusters_;
+ const std::string outESClusters_;
+ const std::string outEBRecHits_;
+ const std::string outEERecHits_;
+ const std::string outESRecHits_;
+ const std::string outPhotonPfCandMap_;
+ const std::string outGsfElectronPfCandMap_;
+ const std::vector<std::string> outPhotonIds_;
+ const std::vector<std::string> outGsfElectronIds_;
+ const std::vector<std::string> outPhotonPFClusterIsos_;
+ const std::vector<std::string> outGsfElectronPFClusterIsos_;
  
- StringCutObjectSelector<reco::Photon> keepPhotonSel_;
- StringCutObjectSelector<reco::Photon> slimRelinkPhotonSel_; 
- StringCutObjectSelector<reco::Photon> relinkPhotonSel_;
- StringCutObjectSelector<reco::GsfElectron> keepGsfElectronSel_;
- StringCutObjectSelector<reco::GsfElectron> slimRelinkGsfElectronSel_;
- StringCutObjectSelector<reco::GsfElectron> relinkGsfElectronSel_; 
- 
- 
-
+ const StringCutObjectSelector<reco::Photon> keepPhotonSel_;
+ const StringCutObjectSelector<reco::Photon> slimRelinkPhotonSel_; 
+ const StringCutObjectSelector<reco::Photon> relinkPhotonSel_;
+ const StringCutObjectSelector<reco::GsfElectron> keepGsfElectronSel_;
+ const StringCutObjectSelector<reco::GsfElectron> slimRelinkGsfElectronSel_;
+ const StringCutObjectSelector<reco::GsfElectron> relinkGsfElectronSel_; 
 };
 #endif
 

--- a/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
+++ b/RecoEgamma/EgammaPhotonProducers/src/ReducedEGProducer.cc
@@ -1,6 +1,7 @@
 #include <iostream>
 #include <vector>
 #include <memory>
+#include <unordered_set>
 
 // Framework
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -43,70 +44,74 @@
 
 #include "RecoEgamma/EgammaTools/interface/ConversionTools.h"
 
+namespace std {
+  template<> 
+  struct hash<DetId> {
+    size_t operator()(const DetId& id) const {
+      return std::hash<uint32_t>()(id.rawId());
+    }
+  };  
+}
+
 ReducedEGProducer::ReducedEGProducer(const edm::ParameterSet& config) :
+  photonT_(consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"))),
+  gsfElectronT_(consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"))),
+  conversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"))),
+  singleConversionT_(consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("singleConversions"))),
+  barrelEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("barrelEcalHits"))),
+  endcapEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("endcapEcalHits"))),
+  preshowerEcalHits_(consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("preshowerEcalHits"))),
+  photonPfCandMapT_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(config.getParameter<edm::InputTag>("photonsPFValMap"))),  
+  gsfElectronPfCandMapT_(consumes<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(config.getParameter<edm::InputTag>("gsfElectronsPFValMap"))),
+  //output collections    
+  outPhotons_("reducedGedPhotons"),
+  outPhotonCores_("reducedGedPhotonCores"),
+  outGsfElectrons_("reducedGedGsfElectrons"),
+  outGsfElectronCores_("reducedGedGsfElectronCores"),
+  outConversions_("reducedConversions"),
+  outSingleConversions_("reducedSingleLegConversions"),
+  outSuperClusters_("reducedSuperClusters"),
+  outEBEEClusters_("reducedEBEEClusters"),
+  outESClusters_("reducedESClusters"),
+  outEBRecHits_("reducedEBRecHits"),
+  outEERecHits_("reducedEERecHits"),
+  outESRecHits_("reducedESRecHits"),
+  outPhotonPfCandMap_("reducedPhotonPfCandMap"),
+  outGsfElectronPfCandMap_("reducedGsfElectronPfCandMap"),
+  outPhotonIds_(config.getParameter<std::vector<std::string> >("photonIDOutput")),
+  outGsfElectronIds_(config.getParameter<std::vector<std::string> >("gsfElectronIDOutput")),
+  outPhotonPFClusterIsos_(config.getParameter<std::vector<std::string> >("photonPFClusterIsoOutput")),
+  outGsfElectronPFClusterIsos_(config.getParameter<std::vector<std::string> >("gsfElectronPFClusterIsoOutput")),
   keepPhotonSel_(config.getParameter<std::string>("keepPhotons")),
   slimRelinkPhotonSel_(config.getParameter<std::string>("slimRelinkPhotons")),
   relinkPhotonSel_(config.getParameter<std::string>("relinkPhotons")),
   keepGsfElectronSel_(config.getParameter<std::string>("keepGsfElectrons")),
   slimRelinkGsfElectronSel_(config.getParameter<std::string>("slimRelinkGsfElectrons")),
   relinkGsfElectronSel_(config.getParameter<std::string>("relinkGsfElectrons"))
-{
-
-
-  photonT_ = consumes<reco::PhotonCollection>(config.getParameter<edm::InputTag>("photons"));
-  gsfElectronT_ = consumes<reco::GsfElectronCollection>(config.getParameter<edm::InputTag>("gsfElectrons"));
-  conversionT_ = consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("conversions"));
-  singleConversionT_ = consumes<reco::ConversionCollection>(config.getParameter<edm::InputTag>("singleConversions"));
-  
-  barrelEcalHits_   = 
-    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("barrelEcalHits"));
-  endcapEcalHits_   = 
-    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("endcapEcalHits"));
-  preshowerEcalHits_   = 
-    consumes<EcalRecHitCollection>(config.getParameter<edm::InputTag>("preshowerEcalHits"));
-
-  photonPfCandMapT_ = consumes<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(config.getParameter<edm::InputTag>("photonsPFValMap"));
-  gsfElectronPfCandMapT_ = consumes<edm::ValueMap<std::vector<reco::PFCandidateRef> > >(config.getParameter<edm::InputTag>("gsfElectronsPFValMap"));
-
-  std::vector<edm::InputTag> photonidinputs(config.getParameter<std::vector<edm::InputTag> >("photonIDSources"));
-  for (edm::InputTag &tag : photonidinputs) {
+{  
+  const std::vector<edm::InputTag>& photonidinputs = 
+    config.getParameter<std::vector<edm::InputTag> >("photonIDSources");
+  for (const edm::InputTag &tag : photonidinputs) {
     photonIdTs_.emplace_back(consumes<edm::ValueMap<bool> >(tag));
   }
   
-  std::vector<edm::InputTag> gsfelectronidinputs(config.getParameter<std::vector<edm::InputTag> >("gsfElectronIDSources"));
-  for (edm::InputTag &tag : gsfelectronidinputs) {
+  const std::vector<edm::InputTag>& gsfelectronidinputs = 
+    config.getParameter<std::vector<edm::InputTag> >("gsfElectronIDSources");
+  for (const edm::InputTag &tag : gsfelectronidinputs) {
     gsfElectronIdTs_.emplace_back(consumes<edm::ValueMap<float> >(tag));
   }  
   
-  std::vector<edm::InputTag> photonpfclusterisoinputs(config.getParameter<std::vector<edm::InputTag> >("photonPFClusterIsoSources"));
-  for (edm::InputTag &tag : photonpfclusterisoinputs) {
+  const std::vector<edm::InputTag>&  photonpfclusterisoinputs = 
+    config.getParameter<std::vector<edm::InputTag> >("photonPFClusterIsoSources");
+  for (const edm::InputTag &tag : photonpfclusterisoinputs) {
     photonPFClusterIsoTs_.emplace_back(consumes<edm::ValueMap<float> >(tag));
   }  
 
-  std::vector<edm::InputTag> gsfelectronpfclusterisoinputs(config.getParameter<std::vector<edm::InputTag> >("gsfElectronPFClusterIsoSources"));
-  for (edm::InputTag &tag : gsfelectronpfclusterisoinputs) {
+  const std::vector<edm::InputTag>& gsfelectronpfclusterisoinputs = 
+    config.getParameter<std::vector<edm::InputTag> >("gsfElectronPFClusterIsoSources");
+  for (const edm::InputTag &tag : gsfelectronpfclusterisoinputs) {
     gsfElectronPFClusterIsoTs_.emplace_back(consumes<edm::ValueMap<float> >(tag));
   }  
-
-  //output collections    
-  outPhotons_ = "reducedGedPhotons";
-  outPhotonCores_ = "reducedGedPhotonCores";
-  outGsfElectrons_ = "reducedGedGsfElectrons";
-  outGsfElectronCores_ = "reducedGedGsfElectronCores";
-  outConversions_ = "reducedConversions";
-  outSingleConversions_ = "reducedSingleLegConversions";
-  outSuperClusters_ = "reducedSuperClusters";
-  outEBEEClusters_ = "reducedEBEEClusters";
-  outESClusters_ = "reducedESClusters";
-  outEBRecHits_ = "reducedEBRecHits";
-  outEERecHits_ = "reducedEERecHits";
-  outESRecHits_ = "reducedESRecHits";
-  outPhotonPfCandMap_ = "reducedPhotonPfCandMap";
-  outGsfElectronPfCandMap_ = "reducedGsfElectronPfCandMap";
-  outPhotonIds_ = config.getParameter<std::vector<std::string> >("photonIDOutput");
-  outGsfElectronIds_ = config.getParameter<std::vector<std::string> >("gsfElectronIDOutput");
-  outPhotonPFClusterIsos_ = config.getParameter<std::vector<std::string> >("photonPFClusterIsoOutput");
-  outGsfElectronPFClusterIsos_ = config.getParameter<std::vector<std::string> >("gsfElectronPFClusterIsoOutput");
   
   produces< reco::PhotonCollection >(outPhotons_);
   produces< reco::PhotonCoreCollection >(outPhotonCores_);
@@ -143,7 +148,7 @@ ReducedEGProducer::~ReducedEGProducer()
 
 
 
-void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
+void ReducedEGProducer::produce(edm::StreamID, edm::Event& theEvent, const edm::EventSetup& theEventSetup) const {
 
   //get input collections
   
@@ -195,8 +200,6 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
     theEvent.getByToken(photonPFClusterIsoTs_[itok],photonPFClusterIsoHandles[itok]);
   }  
   
- 
-
   edm::ESHandle<CaloTopology> theCaloTopology;
   theEventSetup.get<CaloTopologyRecord>().get(theCaloTopology);  
   const CaloTopology *caloTopology = & (*theCaloTopology);  
@@ -245,13 +248,13 @@ void ReducedEGProducer::produce(edm::Event& theEvent, const edm::EventSetup& the
   std::map<reco::SuperClusterRef, unsigned int> superClusterMap;
   std::map<reco::CaloClusterPtr, unsigned int> ebeeClusterMap;
   std::map<reco::CaloClusterPtr, unsigned int> esClusterMap;
-  std::set<DetId> rechitMap;
+  std::unordered_set<DetId> rechitMap;
   
-  std::set<unsigned int> superClusterFullRelinkMap;
+  std::unordered_set<unsigned int> superClusterFullRelinkMap;
   
   //vectors for pfcandidate valuemaps
-  std::vector<std::vector<reco::PFCandidateRef>> pfCandIsoPairVecPho;  
-  std::vector<std::vector<reco::PFCandidateRef>> pfCandIsoPairVecEle;
+  std::vector<std::vector<reco::PFCandidateRef> > pfCandIsoPairVecPho;  
+  std::vector<std::vector<reco::PFCandidateRef> > pfCandIsoPairVecEle;
   
   //vectors for id valuemaps
   std::vector<std::vector<bool> > photonIdVals(photonIds.size());

--- a/RecoJets/JetProducers/interface/NjettinessAdder.h
+++ b/RecoJets/JetProducers/interface/NjettinessAdder.h
@@ -4,7 +4,7 @@
 #include <memory>
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "DataFormats/JetReco/interface/Jet.h"
@@ -12,7 +12,7 @@
 #include "fastjet/contrib/Njettiness.hh"
 
 
-class NjettinessAdder : public edm::EDProducer { 
+class NjettinessAdder : public edm::stream::EDProducer<> { 
  public:
 
     enum MeasureDefinition_t {

--- a/RecoJets/JetProducers/plugins/CATopJetTagger.cc
+++ b/RecoJets/JetProducers/plugins/CATopJetTagger.cc
@@ -21,12 +21,10 @@ CATopJetTagger::CATopJetTagger(const edm::ParameterSet& iConfig):
   src_(iConfig.getParameter<InputTag>("src") ),
   TopMass_(iConfig.getParameter<double>("TopMass") ),
   WMass_(iConfig.getParameter<double>("WMass") ),
-  verbose_(iConfig.getParameter<bool>("verbose") )
+  verbose_(iConfig.getParameter<bool>("verbose") ),
+  input_jet_token_(consumes<edm::View<reco::Jet> >(src_))
 {
   produces<CATopJetTagInfoCollection>();
-  
-  input_jet_token_ = consumes<edm::View<reco::Jet> >(src_);
-
 }
 
 
@@ -41,7 +39,7 @@ CATopJetTagger::~CATopJetTagger()
 
 // ------------ method called to for each event  ------------
 void
-CATopJetTagger::produce( edm::Event& iEvent, const edm::EventSetup& iSetup)
+CATopJetTagger::produce( edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
 
   // Set up output list
@@ -78,19 +76,6 @@ CATopJetTagger::produce( edm::Event& iEvent, const edm::EventSetup& iSetup)
   iEvent.put( tagInfos );
  
   return;   
-}
-
-
-// ------------ method called once each job just before starting event loop  ------------
-void 
-CATopJetTagger::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop  ------------
-void 
-CATopJetTagger::endJob() {
-
 }
 
 //define this as a plug-in

--- a/RecoJets/JetProducers/plugins/CATopJetTagger.h
+++ b/RecoJets/JetProducers/plugins/CATopJetTagger.h
@@ -34,7 +34,7 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -62,26 +62,24 @@
 // class decleration
 //
 
-class CATopJetTagger : public edm::EDProducer {
-   public:
-      explicit CATopJetTagger(const edm::ParameterSet&);
-      ~CATopJetTagger();
+class CATopJetTagger : public edm::global::EDProducer<> {
+ public:
+  explicit CATopJetTagger(const edm::ParameterSet&);
+  ~CATopJetTagger();
+  
+  
+ private:
+  virtual void produce( edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
+  
+  // ----------member data ---------------------------
+  
+  const edm::InputTag   src_;
+  
+  const double      TopMass_;
+  const double      WMass_;
+  const bool        verbose_;
 
-
-   private:
-      virtual void beginJob() ;
-      virtual void produce( edm::Event&, const edm::EventSetup&);
-      virtual void endJob() ;
-
-      // ----------member data ---------------------------
-
-  edm::InputTag   src_;
-
-  double      TopMass_;
-  double      WMass_;
-  bool        verbose_;
-
-  edm::EDGetTokenT<edm::View<reco::Jet> > input_jet_token_;
+  const edm::EDGetTokenT<edm::View<reco::Jet> > input_jet_token_;
 
 };
 

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.h
@@ -46,7 +46,7 @@ Implementation:
 #include "FWCore/ParameterSet/interface/FileInPath.h"
 
 // ------------------------------------------------------------------------------------------
-class PileupJetIdProducer : public edm::EDProducer {
+class PileupJetIdProducer : public edm::stream::EDProducer<> {
 public:
 	explicit PileupJetIdProducer(const edm::ParameterSet&);
 	~PileupJetIdProducer();


### PR DESCRIPTION
This PR converts all modules used in MiniAOD to the threaded framework.

Short matrix passed for both single and multithreaded jobs. Thread efficiency looked good, MiniAOD job was pegged at ~200% for a 2 core test.

Once we are done examining the various changes I will squash the commits down to something less sprawling.

Forward ports to 76X and 75X after everyone gets a look at the changes.

@Dr15Jones 
