### PR TITLE
Hotfix for Run2015A+B 0T luminous region centroid positions (76X)

### DIFF
--- a/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
+++ b/IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py
@@ -435,9 +435,9 @@ Realistic50ns13TeVCollisionZeroTeslaVtxSmearingParameters = cms.PSet(
     Alpha = cms.double(0.0),
     SigmaZ = cms.double(5.3),
     TimeOffset = cms.double(0.0),
-    X0 = cms.double(0.10482), # from fill 4008, absolute coordinates X0 =  0.07798 [cm]. BPix position, absolute coordinates -0.026837  [cm]. Final position  0.10482 [cm].
-    Y0 = cms.double(0.16867), # from fill 4008, absolute coordinates Y0 =  0.09714 [cm]. BPix position, absolute coordinates -0.0715252 [cm]. Final position  0.16867 [cm]. 
-    Z0 = cms.double(-1.0985)  # from fill 4008, absolute coordinates Z0 = -1.610   [cm]. BPix position, absolute coordinates -0.511453  [cm]. Final position -1.0985  [cm].
+    X0 = cms.double(0.08533),
+    Y0 = cms.double(0.16973),
+    Z0 = cms.double(-1.2230)
 )
 
 # From 2015B 3.8T data


### PR DESCRIPTION
This is due to conflicting changes by #10384 (in particular commit https://github.com/cms-sw/cmssw/commit/a43a0399ca5af7bf06c3cdc2b36452ac72ed18d9 ) and #10435 (in particular commit https://github.com/cms-sw/cmssw/commit/b4701d4296f61f7781d878adcce672273090a06a ) for `IOMC/EventVertexGenerators/python/VtxSmearedParameters_cfi.py`.

This does not jeopardise the 3.8T vertex smearing definitions, but the 0T position of the luminous region centroid was left artificially in the same position, while we know that the 150 um shift in X is due to magnetic field effects on the beam.
