### PR TITLE
CSC Beam Halo filter: keep AOD info + bug fix

### DIFF
--- a/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
+++ b/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
@@ -64,7 +64,7 @@ RecoMETAOD = cms.PSet(
                                            'drop recoHcalNoiseRBXs_*_*_*',
                                            'keep HcalNoiseSummary_hcalnoise_*_*',
                                            'keep *GlobalHaloData_*_*_*',
-                                           'keep *CSCHaloData_*_*_*',
+                                           'keep recoCSCHaloData_CSCHaloData_*_*',
                                            'keep *BeamHaloSummary_BeamHaloSummary_*_*'
                                            )
     )

--- a/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
+++ b/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
@@ -64,6 +64,7 @@ RecoMETAOD = cms.PSet(
                                            'drop recoHcalNoiseRBXs_*_*_*',
                                            'keep HcalNoiseSummary_hcalnoise_*_*',
                                            'keep *GlobalHaloData_*_*_*',
+                                           'keep *CSCHaloData_*_*_*',
                                            'keep *BeamHaloSummary_BeamHaloSummary_*_*'
                                            )
     )

--- a/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/CSCHaloAlgo.cc
@@ -552,7 +552,7 @@ reco::CSCHaloData CSCHaloAlgo::Calculate(const CSCGeometry& TheCSCGeometry,
          jSegment != TheCSCSegments->end();
          jSegment++) {
 	 if (jSegment == iSegment) continue;
-
+	 SegmentIsGood=true;
 	 LocalPoint jLocalPosition = jSegment->localPosition();
 	 LocalVector jLocalDirection = jSegment->localDirection();
 	 CSCDetId jCscDetID = jSegment->cscDetId();


### PR DESCRIPTION
Bug fix in CSCHaloAlgo.cc: a boolean was not properly reinitialized in a loop. 
Also asking to keep the CSCHaloData class in AOD. (size: 128 bytes/62 per evt before/after compression) 
