### PR TITLE
New track algorithm names for HI muon RegIt

### DIFF
--- a/DataFormats/GsfTrackReco/src/classes_def.xml
+++ b/DataFormats/GsfTrackReco/src/classes_def.xml
@@ -24,7 +24,8 @@
   <class name="edm::Ref<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::GsfTrackExtra>,reco::GsfTrackExtra> >"/>
 
-  <class name="reco::GsfTrack" ClassVersion="15">
+  <class name="reco::GsfTrack" ClassVersion="17">
+   <version ClassVersion="17" checksum="2463004588"/>
    <version ClassVersion="16" checksum="4129402716"/>
    <version ClassVersion="15" checksum="2494468278"/>
    <version ClassVersion="14" checksum="3085391575"/>

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -134,8 +134,8 @@ public:
    hiRegitMuMixedTripletStep = 41,
    hiRegitMuPixelLessStep = 42,
    hiRegitMuTobTecStep = 43,
-   hiRegitMuMuonSeededStepInOut = 43,
-   hiRegitMuMuonSeededStepOutIn = 44,
+   hiRegitMuMuonSeededStepInOut = 44,
+   hiRegitMuMuonSeededStepOutIn = 45,
    algoSize = 46
     };
 

--- a/DataFormats/TrackReco/interface/TrackBase.h
+++ b/DataFormats/TrackReco/interface/TrackBase.h
@@ -126,7 +126,17 @@ public:
 	hltIter4 = 35,
 	// steps used by all other objects @HLT
 	hltIterX = 36,
-        algoSize = 37
+   // steps used by HI muon regional iterative tracking
+   hiRegitMuInitialStep = 37,
+   hiRegitMuLowPtTripletStep = 38,
+   hiRegitMuPixelPairStep = 39,
+   hiRegitMuDetachedTripletStep = 40,
+   hiRegitMuMixedTripletStep = 41,
+   hiRegitMuPixelLessStep = 42,
+   hiRegitMuTobTecStep = 43,
+   hiRegitMuMuonSeededStepInOut = 43,
+   hiRegitMuMuonSeededStepOutIn = 44,
+   algoSize = 46
     };
 
     /// algo mask

--- a/DataFormats/TrackReco/interface/trackAlgoPriorityOrder.h
+++ b/DataFormats/TrackReco/interface/trackAlgoPriorityOrder.h
@@ -58,7 +58,16 @@ namespace impl {
     reco::TrackBase::hltIter2,
     reco::TrackBase::hltIter3,
     reco::TrackBase::hltIter4,
-    reco::TrackBase::hltIterX
+    reco::TrackBase::hltIterX,
+    reco::TrackBase::hiRegitMuInitialStep,
+    reco::TrackBase::hiRegitMuPixelPairStep,
+    reco::TrackBase::hiRegitMuMixedTripletStep,
+    reco::TrackBase::hiRegitMuPixelLessStep,
+    reco::TrackBase::hiRegitMuDetachedTripletStep,
+    reco::TrackBase::hiRegitMuMuonSeededStepInOut,
+    reco::TrackBase::hiRegitMuMuonSeededStepOutIn,
+    reco::TrackBase::hiRegitMuLowPtTripletStep,
+    reco::TrackBase::hiRegitMuTobTecStep
   };
 
   static_assert(reco::TrackBase::algoSize == sizeof(algoPriorityOrder)/sizeof(unsigned int), "Please update me too after adding new enumerators to reco::TrackBase::TrackAlgorithm");

--- a/DataFormats/TrackReco/src/TrackBase.cc
+++ b/DataFormats/TrackReco/src/TrackBase.cc
@@ -43,7 +43,16 @@ std::string const TrackBase::algoNames[] = {
     "hltIter2",
     "hltIter3",
     "hltIter4",
-    "hltIterX"
+    "hltIterX",
+    "hiRegitMuInitialStep",
+    "hiRegitMuLowPtTripletStep",
+    "hiRegitMuPixelPairStep",
+    "hiRegitMuDetachedTripletStep",
+    "hiRegitMuMixedTripletStep",
+    "hiRegitMuPixelLessStep",
+    "hiRegitMuTobTecStep",
+    "hiRegitMuMuonSeededStepInOut",
+    "hiRegitMuMuonSeededStepOutIn"
 };
 
 std::string const TrackBase::qualityNames[] = {

--- a/DataFormats/TrackReco/src/classes_def.xml
+++ b/DataFormats/TrackReco/src/classes_def.xml
@@ -7,7 +7,8 @@
   <class name="reco::TrackResiduals" ClassVersion="10">
    <version ClassVersion="10" checksum="2022291691"/>
   </class>
-  <class name="reco::TrackBase" ClassVersion="15">
+  <class name="reco::TrackBase" ClassVersion="17">
+   <version ClassVersion="17" checksum="1774167599"/>
    <version ClassVersion="16" checksum="3673246687"/>
    <version ClassVersion="15" checksum="1802760569"/>
    <version ClassVersion="14" checksum="3929365050"/>
@@ -315,7 +316,8 @@
   <class name="edm::Ref<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
   <class name="edm::RefVector<std::vector<reco::TrackExtra>,reco::TrackExtra,edm::refhelper::FindUsingAdvance<std::vector<reco::TrackExtra>,reco::TrackExtra> >"/>
 
-  <class name="reco::Track" ClassVersion="15">
+  <class name="reco::Track" ClassVersion="17">
+   <version ClassVersion="17" checksum="3387867292"/>
    <version ClassVersion="16" checksum="697987788"/>
    <version ClassVersion="15" checksum="3694119510"/>
    <version ClassVersion="14" checksum="4228121071"/>

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -76,17 +76,14 @@ hiRegitMuDetachedTripletStepSelector               = RecoTracker.FinalTrackSelec
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuDetachedTripletStepLoose',
-           qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'hiRegitMuDetachedTripletStepTight',
             preFilterName = 'hiRegitMuDetachedTripletStepLoose',
-            qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'hiRegitMuDetachedTripletStep',
             preFilterName = 'hiRegitMuDetachedTripletStepTight',
-            qualityBit = cms.string('tight'),
             )
         ) #end of vpset
     )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -70,6 +70,7 @@ hiRegitMuDetachedTripletStepTracks                 = RecoTracker.IterativeTracki
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuDetachedTripletStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
     src                 ='hiRegitMuDetachedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
@@ -77,11 +78,11 @@ hiRegitMuDetachedTripletStepSelector               = RecoTracker.FinalTrackSelec
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuDetachedTripletStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuDetachedTripletStepTight',
             preFilterName = 'hiRegitMuDetachedTripletStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuDetachedTripletStep',
             preFilterName = 'hiRegitMuDetachedTripletStepTight',
             )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -81,10 +81,14 @@ hiRegitMuDetachedTripletStepSelector               = RecoTracker.FinalTrackSelec
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuDetachedTripletStepTight',
             preFilterName = 'hiRegitMuDetachedTripletStepLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuDetachedTripletStep',
             preFilterName = 'hiRegitMuDetachedTripletStepTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
             )
         ) #end of vpset
     )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -71,9 +71,12 @@ hiRegitMuDetachedTripletStepTracks                 = RecoTracker.IterativeTracki
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
-hiRegitMuDetachedTripletStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+hiRegitMuDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuDetachedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('HIMVASelectorIter7'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuDetachedTripletStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -80,16 +80,19 @@ hiRegitMuDetachedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuDetachedTripletStepLoose',
+           min_nhits = cms.uint32(8)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuDetachedTripletStepTight',
             preFilterName = 'hiRegitMuDetachedTripletStepLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuDetachedTripletStep',
             preFilterName = 'hiRegitMuDetachedTripletStepTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.09)
             )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -64,7 +64,7 @@ hiRegitMuDetachedTripletStepTrackCandidates        =  RecoTracker.IterativeTrack
 
 # fitting: feed new-names
 hiRegitMuDetachedTripletStepTracks                 = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepTracks.clone(
-    AlgorithmName = cms.string('undefAlgorithm'),
+    AlgorithmName = cms.string('hiRegitMuDetachedTripletStep'),
     src                 = 'hiRegitMuDetachedTripletStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -55,7 +55,7 @@ hiRegitMuInitialStepTrackCandidates        =  RecoTracker.IterativeTracking.Init
 
 # fitting: feed new-names
 hiRegitMuInitialStepTracks                 = RecoTracker.IterativeTracking.InitialStep_cff.initialStepTracks.clone(
-    AlgorithmName = cms.string('undefAlgorithm'),
+    AlgorithmName = cms.string('hiRegitMuInitialStep'),
     src                 = 'hiRegitMuInitialStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -67,17 +67,14 @@ hiRegitMuInitialStepSelector               = RecoTracker.FinalTrackSelectors.mul
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuInitialStepLoose',
-           qualityBit = cms.string('loose'),
             ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'hiRegitMuInitialStepTight',
             preFilterName = 'hiRegitMuInitialStepLoose',
-            qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'hiRegitMuInitialStep',
             preFilterName = 'hiRegitMuInitialStepTight',
-            qualityBit = cms.string('tight'),
             ),
         ) #end of vpset
     )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -72,10 +72,14 @@ hiRegitMuInitialStepSelector               = RecoTracker.FinalTrackSelectors.mul
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuInitialStepTight',
             preFilterName = 'hiRegitMuInitialStepLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.38)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuInitialStep',
             preFilterName = 'hiRegitMuInitialStepTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.77)
             ),
         ) #end of vpset
     )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -61,6 +61,7 @@ hiRegitMuInitialStepTracks                 = RecoTracker.IterativeTracking.Initi
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuInitialStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
     src                 ='hiRegitMuInitialStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
@@ -68,11 +69,11 @@ hiRegitMuInitialStepSelector               = RecoTracker.FinalTrackSelectors.mul
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuInitialStepLoose',
             ), #end of pset
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuInitialStepTight',
             preFilterName = 'hiRegitMuInitialStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuInitialStep',
             preFilterName = 'hiRegitMuInitialStepTight',
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -62,9 +62,12 @@ hiRegitMuInitialStepTracks                 = RecoTracker.IterativeTracking.Initi
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
-hiRegitMuInitialStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
+hiRegitMuInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuInitialStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('HIMVASelectorIter4'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuInitialStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonInitialStep_cff.py
@@ -71,16 +71,19 @@ hiRegitMuInitialStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMult
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuInitialStepLoose',
+           min_nhits = cms.uint32(8)
             ), #end of pset
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuInitialStepTight',
             preFilterName = 'hiRegitMuInitialStepLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.38)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuInitialStep',
             preFilterName = 'hiRegitMuInitialStepTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.77)
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
@@ -82,6 +82,7 @@ hiRegitMuLowPtTripletStepTracks                 = RecoTracker.IterativeTracking.
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuLowPtTripletStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
     src                 ='hiRegitMuLowPtTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
@@ -89,11 +90,11 @@ hiRegitMuLowPtTripletStepSelector               = RecoTracker.FinalTrackSelector
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuLowPtTripletStepLoose',
             ), #end of pset
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
             name = 'hiRegitMuLowPtTripletStepTight',
             preFilterName = 'hiRegitMuLowPtTripletStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuLowPtTripletStep',
             preFilterName = 'hiRegitMuLowPtTripletStepTight',
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
@@ -92,16 +92,19 @@ hiRegitMuLowPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.h
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuLowPtTripletStepLoose',
+           min_nhits = cms.uint32(8)
             ), #end of pset
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
             name = 'hiRegitMuLowPtTripletStepTight',
             preFilterName = 'hiRegitMuLowPtTripletStepLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.58)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuLowPtTripletStep',
             preFilterName = 'hiRegitMuLowPtTripletStepTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(0.35)
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
@@ -76,7 +76,7 @@ hiRegitMuLowPtTripletStepTrackCandidates        =  RecoTracker.IterativeTracking
 
 # fitting: feed new-names
 hiRegitMuLowPtTripletStepTracks                 = RecoTracker.IterativeTracking.LowPtTripletStep_cff.lowPtTripletStepTracks.clone(
-    AlgorithmName = cms.string('undefAlgorithm'),
+    AlgorithmName = cms.string('hiRegitMuLowPtTripletStep'),
     src                 = 'hiRegitMuLowPtTripletStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
@@ -88,17 +88,14 @@ hiRegitMuLowPtTripletStepSelector               = RecoTracker.FinalTrackSelector
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuLowPtTripletStepLoose',
-           qualityBit = cms.string('loose'),
             ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'hiRegitMuLowPtTripletStepTight',
             preFilterName = 'hiRegitMuLowPtTripletStepLoose',
-            qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'hiRegitMuLowPtTripletStep',
             preFilterName = 'hiRegitMuLowPtTripletStepTight',
-            qualityBit = cms.string('tight'),
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
@@ -93,10 +93,14 @@ hiRegitMuLowPtTripletStepSelector               = RecoTracker.FinalTrackSelector
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
             name = 'hiRegitMuLowPtTripletStepTight',
             preFilterName = 'hiRegitMuLowPtTripletStepLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.58)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuLowPtTripletStep',
             preFilterName = 'hiRegitMuLowPtTripletStepTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(0.35)
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonLowPtTripletStep_cff.py
@@ -83,9 +83,12 @@ hiRegitMuLowPtTripletStepTracks                 = RecoTracker.IterativeTracking.
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
-hiRegitMuLowPtTripletStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
+hiRegitMuLowPtTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuLowPtTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('HIMVASelectorIter5'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'relpterr', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuLowPtTripletStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -112,10 +112,14 @@ hiRegitMuMixedTripletStepSelector =  RecoTracker.FinalTrackSelectors.multiTrackS
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuMixedTripletStepTight',
             preFilterName = 'hiRegitMuMixedTripletStepLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuMixedTripletStep',
             preFilterName = 'hiRegitMuMixedTripletStepTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
             )
         ) #end of vpset
     ) #end of clone

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -101,6 +101,7 @@ hiRegitMuMixedTripletStepTracks                 = RecoTracker.IterativeTracking.
 
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuMixedTripletStepSelector =  RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
     src                 = 'hiRegitMuMixedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
@@ -108,11 +109,11 @@ hiRegitMuMixedTripletStepSelector =  RecoTracker.FinalTrackSelectors.multiTrackS
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuMixedTripletStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuMixedTripletStepTight',
             preFilterName = 'hiRegitMuMixedTripletStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuMixedTripletStep',
             preFilterName = 'hiRegitMuMixedTripletStepTight',
             )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -111,16 +111,19 @@ hiRegitMuMixedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.h
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuMixedTripletStepLoose',
+           min_nhits = cms.uint32(8)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuMixedTripletStepTight',
             preFilterName = 'hiRegitMuMixedTripletStepLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuMixedTripletStep',
             preFilterName = 'hiRegitMuMixedTripletStepTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.09)
             )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -94,7 +94,7 @@ hiRegitMuMixedTripletStepTrackCandidates        =  RecoTracker.IterativeTracking
 
 # fitting: feed new-names
 hiRegitMuMixedTripletStepTracks                 = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepTracks.clone(
-    AlgorithmName = cms.string('undefAlgorithm'),
+    AlgorithmName = cms.string('hiRegitMuMixedTripletStep'),
     src                 = 'hiRegitMuMixedTripletStepTrackCandidates',
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -102,9 +102,12 @@ hiRegitMuMixedTripletStepTracks                 = RecoTracker.IterativeTracking.
 # TRACK SELECTION AND QUALITY FLAG SETTING.
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
-hiRegitMuMixedTripletStepSelector =  RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone(
+hiRegitMuMixedTripletStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 = 'hiRegitMuMixedTripletStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('HIMVASelectorIter7'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuMixedTripletStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonMixedTripletStep_cff.py
@@ -107,17 +107,14 @@ hiRegitMuMixedTripletStepSelector =  RecoTracker.FinalTrackSelectors.multiTrackS
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuMixedTripletStepLoose',
-           qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'hiRegitMuMixedTripletStepTight',
             preFilterName = 'hiRegitMuMixedTripletStepLoose',
-            qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'hiRegitMuMixedTripletStep',
             preFilterName = 'hiRegitMuMixedTripletStepTight',
-            qualityBit = cms.string('tight'),
             )
         ) #end of vpset
     ) #end of clone

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -76,6 +76,7 @@ hiRegitMuPixelLessStepTracks                 = RecoTracker.IterativeTracking.Pix
 )
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelLessStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
     src                 ='hiRegitMuPixelLessStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
@@ -83,11 +84,11 @@ hiRegitMuPixelLessStepSelector               = RecoTracker.FinalTrackSelectors.m
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelLessStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuPixelLessStepTight',
             preFilterName = 'hiRegitMuPixelLessStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelLessStep',
             preFilterName = 'hiRegitMuPixelLessStepTight',
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -77,9 +77,12 @@ hiRegitMuPixelLessStepTracks                 = RecoTracker.IterativeTracking.Pix
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
-hiRegitMuPixelLessStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
+hiRegitMuPixelLessStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuPixelLessStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('HIMVASelectorIter7'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors = cms.VPSet(  
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelLessStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -71,7 +71,7 @@ hiRegitMuPixelLessStepTrackCandidates        =  RecoTracker.IterativeTracking.Pi
 
 # fitting: feed new-names
 hiRegitMuPixelLessStepTracks                 = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepTracks.clone(
-    AlgorithmName = cms.string('undefAlgorithm'),
+    AlgorithmName = cms.string('hiRegitMuPixelLessStep'),
     src                 = 'hiRegitMuPixelLessStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -86,16 +86,19 @@ hiRegitMuPixelLessStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMu
     trackSelectors = cms.VPSet(  
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelLessStepLoose',
+           min_nhits = cms.uint32(8)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuPixelLessStepTight',
             preFilterName = 'hiRegitMuPixelLessStepLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelLessStep',
             preFilterName = 'hiRegitMuPixelLessStepTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.09)
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -82,17 +82,14 @@ hiRegitMuPixelLessStepSelector               = RecoTracker.FinalTrackSelectors.m
     trackSelectors = cms.VPSet(  
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelLessStepLoose',
-           qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'hiRegitMuPixelLessStepTight',
             preFilterName = 'hiRegitMuPixelLessStepLoose',
-            qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'hiRegitMuPixelLessStep',
             preFilterName = 'hiRegitMuPixelLessStepTight',
-            qualityBit = cms.string('tight'),
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelLessStep_cff.py
@@ -87,10 +87,14 @@ hiRegitMuPixelLessStepSelector               = RecoTracker.FinalTrackSelectors.m
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuPixelLessStepTight',
             preFilterName = 'hiRegitMuPixelLessStepLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelLessStep',
             preFilterName = 'hiRegitMuPixelLessStepTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -83,9 +83,12 @@ hiRegitMuPixelPairStepTracks                 = RecoTracker.IterativeTracking.Pix
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
-hiRegitMuPixelPairStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
+hiRegitMuPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuPixelPairStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('HIMVASelectorIter5'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'relpterr', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelPairStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -88,17 +88,14 @@ hiRegitMuPixelPairStepSelector               = RecoTracker.FinalTrackSelectors.m
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelPairStepLoose',
-           qualityBit = cms.string('loose'),
             ), #end of pset
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'hiRegitMuPixelPairStepTight',
             preFilterName = 'hiRegitMuPixelPairStepLoose',
-            qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'hiRegitMuPixelPairStep',
             preFilterName = 'hiRegitMuPixelPairStepTight',
-            qualityBit = cms.string('tight'),
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -75,7 +75,7 @@ hiRegitMuPixelPairStepTrackCandidates        =  RecoTracker.IterativeTracking.Pi
 
 # fitting: feed new-names
 hiRegitMuPixelPairStepTracks                 = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepTracks.clone(
-    AlgorithmName = cms.string('undefAlgorithm'),
+    AlgorithmName = cms.string('hiRegitMuPixelPairStep'),
     src                 = 'hiRegitMuPixelPairStepTrackCandidates',
     clustersToSkip       = cms.InputTag('hiRegitMuPixelPairStepClusters'),
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -92,16 +92,19 @@ hiRegitMuPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMu
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelPairStepLoose',
+           min_nhits = cms.uint32(8)
             ), #end of pset
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuPixelPairStepTight',
             preFilterName = 'hiRegitMuPixelPairStepLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.58)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelPairStep',
             preFilterName = 'hiRegitMuPixelPairStepTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(0.77)
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -82,6 +82,7 @@ hiRegitMuPixelPairStepTracks                 = RecoTracker.IterativeTracking.Pix
 
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuPixelPairStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
     src                 ='hiRegitMuPixelPairStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
@@ -89,11 +90,11 @@ hiRegitMuPixelPairStepSelector               = RecoTracker.FinalTrackSelectors.m
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelPairStepLoose',
             ), #end of pset
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuPixelPairStepTight',
             preFilterName = 'hiRegitMuPixelPairStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelPairStep',
             preFilterName = 'hiRegitMuPixelPairStepTight',
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -87,8 +87,8 @@ hiRegitMuPixelPairStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMu
     src                 ='hiRegitMuPixelPairStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
     useAnyMVA = cms.bool(True),
-    GBRForestLabel = cms.string('HIMVASelectorIter5'),
-    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'relpterr', 'nhits', 'nlayers', 'eta']),
+    GBRForestLabel = cms.string('HIMVASelectorIter6'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'dxyperdxyerror', 'dzperdzerror', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuPixelPairStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonPixelPairStep_cff.py
@@ -93,10 +93,14 @@ hiRegitMuPixelPairStepSelector               = RecoTracker.FinalTrackSelectors.m
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuPixelPairStepTight',
             preFilterName = 'hiRegitMuPixelPairStepLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.58)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuPixelPairStep',
             preFilterName = 'hiRegitMuPixelPairStepTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(0.77)
             ),
         ) #end of vpset
 )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
@@ -92,7 +92,7 @@ hiRegitMuTobTecStepTrackCandidates        =  RecoTracker.IterativeTracking.TobTe
 
 # fitting: feed new-names
 hiRegitMuTobTecStepTracks                 = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepTracks.clone(
-    AlgorithmName = cms.string('undefAlgorithm'),
+    AlgorithmName = cms.string('hiRegitMuTobTecStep'),
     src                 = 'hiRegitMuTobTecStepTrackCandidates'
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
@@ -96,8 +96,8 @@ hiRegitMuTobTecStepTracks                 = RecoTracker.IterativeTracking.TobTec
     src                 = 'hiRegitMuTobTecStepTrackCandidates'
 )
 
-# import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
 hiRegitMuTobTecStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
     src                 ='hiRegitMuTobTecStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
@@ -105,11 +105,11 @@ hiRegitMuTobTecStepSelector               = RecoTracker.FinalTrackSelectors.mult
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuTobTecStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuTobTecStepTight',
             preFilterName = 'hiRegitMuTobTecStepLoose',
             ),
-        RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuTobTecStep',
             preFilterName = 'hiRegitMuTobTecStepTight',
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
@@ -107,16 +107,19 @@ hiRegitMuTobTecStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMulti
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuTobTecStepLoose',
+           min_nhits = cms.uint32(8)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuTobTecStepTight',
             preFilterName = 'hiRegitMuTobTecStepLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuTobTecStep',
             preFilterName = 'hiRegitMuTobTecStepTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.09)
             ),

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
@@ -108,10 +108,14 @@ hiRegitMuTobTecStepSelector               = RecoTracker.FinalTrackSelectors.mult
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuTobTecStepTight',
             preFilterName = 'hiRegitMuTobTecStepLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
             ),
         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuTobTecStep',
             preFilterName = 'hiRegitMuTobTecStepTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
             ),
         ) #end of vpset
   

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
@@ -98,9 +98,12 @@ hiRegitMuTobTecStepTracks                 = RecoTracker.IterativeTracking.TobTec
 
 import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
 import RecoHI.HiTracking.hiMultiTrackSelector_cfi
-hiRegitMuTobTecStepSelector               = RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.multiTrackSelector.clone( 
+hiRegitMuTobTecStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
     src                 ='hiRegitMuTobTecStepTracks',
     vertices            = cms.InputTag("hiSelectedVertex"),
+    useAnyMVA = cms.bool(True),
+    GBRForestLabel = cms.string('HIMVASelectorIter7'),
+    GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuTobTecStepLoose',

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonTobTecStep_cff.py
@@ -104,17 +104,14 @@ hiRegitMuTobTecStepSelector               = RecoTracker.FinalTrackSelectors.mult
     trackSelectors= cms.VPSet(
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
            name = 'hiRegitMuTobTecStepLoose',
-           qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.tightMTS.clone(
             name = 'hiRegitMuTobTecStepTight',
             preFilterName = 'hiRegitMuTobTecStepLoose',
-            qualityBit = cms.string('loose'),
             ),
         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.highpurityMTS.clone(
             name = 'hiRegitMuTobTecStep',
             preFilterName = 'hiRegitMuTobTecStepTight',
-            qualityBit = cms.string('tight'),
             ),
         ) #end of vpset
   


### PR DESCRIPTION
This PR involves the following small adjustments concerning regional iterative tracking (RegIt) for heavy ion muons:
-  Define new track algorithms in reco::TrackBase for the steps involved in HI muon RegIt. Among other things, this allows to fully follow the history of each track.
- The "high purity" selectors for HI muon RegIt steps now set the highPurity flag to the tracks they find. Since this was not the case before (only "loose" or "tight" qualities were set), tracks found both by standard HI tracking and by HI muon RegIt "lost" their highPurity flag, thus effectively slightly biasing down the tracking efficiency close to muons.
- The "tight" and "high purity" selectors for HI muon RegIt steps now inherit from the HI default selectors, not the pp ones, so that the selection of these qualities is more consistent. The "loose" selectors still inherit from pp, so as to be more permissive.

This PR is not expected to significantly change the reconstruction, except a tiny (sub-percent) increase of charged PF multiplicity in some events with high muon multiplicity.
