### PR TITLE
Run "high level muon reconstruction" for heavy ions

### DIFF
--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -42,6 +42,7 @@ globalRecoPbPb = cms.Sequence(hiTracking
                               * hiClusterCompatibility
                               * hiEvtPlane
                               * hcalnoise
+                              * muonRecoHighLevelPbPb
                               )
 
 globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
@@ -56,6 +57,7 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               * hiClusterCompatibility
                                               * hiEvtPlane
                                               * hcalnoise
+                                              * muonRecoHighLevelPbPb
                                               )
 
 #--------------------------------------------------------------------------

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -42,7 +42,7 @@ particleFlowBlock.elementImporters = cms.VPSet(
     # all secondary track importers
     cms.PSet( importerName = cms.string("GeneralTracksImporter"),
               source = cms.InputTag("pfTrack"),
-              muonSrc = cms.InputTag("muons"),
+              muonSrc = cms.InputTag("hiMuons1stStep"),
               useIterativeTracking = cms.bool(False),
               DPtOverPtCuts_byTrackAlgo = cms.vdouble(-1.0,-1.0,-1.0,
                                                        1.0,1.0),
@@ -66,7 +66,7 @@ particleFlowBlock.elementImporters = cms.VPSet(
 particleFlowTmp.postMuonCleaning = cms.bool(False)
 particleFlowTmp.vertexCollection = cms.InputTag("hiSelectedVertex")
 particleFlowTmp.usePFElectrons = cms.bool(True)
-particleFlowTmp.muons = cms.InputTag("muons")
+particleFlowTmp.muons = cms.InputTag("hiMuons1stStep")
 particleFlowTmp.usePFConversions = cms.bool(False)
 
 

--- a/RecoHI/Configuration/python/customise_PF.py
+++ b/RecoHI/Configuration/python/customise_PF.py
@@ -13,7 +13,7 @@ def customise(process):
     process.pfTrack.TrackQuality = cms.string('highPurity')   
     process.pfTrack.TkColList = cms.VInputTag("hiGeneralTracks")  
     process.pfTrack.PrimaryVertexLabel = cms.InputTag("hiSelectedVertex")
-    process.pfTrack.MuColl = cms.InputTag("muons")
+    process.pfTrack.MuColl = cms.InputTag("hiMuons1stStep")
     process.pfTrack.GsfTracksInEvents = cms.bool(False)
     
     # run a trimmed down PF sequence with heavy-ion vertex, no conversions, nucl int, etc.
@@ -26,7 +26,7 @@ def customise(process):
 
     process.particleFlowTmp.vertexCollection = cms.InputTag("hiSelectedVertex")
     process.particleFlowTmp.usePFElectrons = cms.bool(False)
-    process.particleFlowTmp.muons = cms.InputTag("muons")
+    process.particleFlowTmp.muons = cms.InputTag("hiMuons1stStep")
     process.particleFlowTmp.usePFConversions = cms.bool(False)
 
     process.electronsCiCLoose.verticesCollection = cms.InputTag("hiSelectedVertex")

--- a/RecoHI/HiEgammaAlgos/python/HiElectronSequence_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiElectronSequence_cff.py
@@ -34,7 +34,7 @@ pfTrack.UseQuality = cms.bool(True)
 pfTrack.TrackQuality = cms.string('highPurity')
 pfTrack.TkColList = cms.VInputTag("hiGeneralTracks")
 pfTrack.PrimaryVertexLabel = cms.InputTag("hiSelectedVertex")
-pfTrack.MuColl = cms.InputTag("muons")
+pfTrack.MuColl = cms.InputTag("hiMuons1stStep")
 
 from RecoParticleFlow.PFTracking.pfTrackElec_cfi import *
 pfTrackElec.applyGsfTrackCleaning = cms.bool(True)

--- a/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
@@ -5,6 +5,9 @@ from RecoMuon.Configuration.RecoMuonPPonly_cff import *
 hiTracks = 'hiGeneralTracks' #heavy ion track label
 
 # replace with heavy ion track label
+# IMPORTANT
+# for now we clone muons1stStep into muons, and the final muon collection is named muonHL.
+# for something final we'll need to clone muons1stStep into something like muons, and the final collection will have to be named muons.
 muons = muons1stStep.clone()
 muons.inputCollectionLabels = [hiTracks, 'globalMuons', 'standAloneMuons:UpdatedAtVtx','tevMuons:firstHit','tevMuons:picky','tevMuons:dyt']
 muons.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks','tev firstHit', 'tev picky', 'tev dyt']
@@ -35,6 +38,36 @@ muons.JetExtractorPSet.JetCollectionLabel = cms.InputTag("iterativeConePu5CaloJe
 
 # turn off calo muons for timing considerations
 muons.minPCaloMuon = cms.double( 1.0E9 )
+
+# high level reco
+from RecoMuon.MuonIdentification.muons_cfi import muons as muonsHL
+muonsHL.InputMuons = cms.InputTag("muons")
+muonsHL.PFCandidates = cms.InputTag("particleFlowTmp")
+muonsHL.FillDetectorBasedIsolation = cms.bool(False)
+muonsHL.FillPFIsolation = cms.bool(False)
+muonsHL.FillSelectorMaps = cms.bool(True)
+muonsHL.FillShoweringInfo = cms.bool(False)
+muonsHL.FillCosmicsIdMap = cms.bool(False)
+muidTrackerMuonArbitrated.inputMuonCollection = cms.InputTag("muons")
+muidAllArbitrated.inputMuonCollection = cms.InputTag("muons")
+muidGlobalMuonPromptTight.inputMuonCollection = cms.InputTag("muons")
+muidTMLastStationLoose.inputMuonCollection = cms.InputTag("muons")
+muidTMLastStationTight.inputMuonCollection = cms.InputTag("muons")
+muidTM2DCompatibilityLoose.inputMuonCollection = cms.InputTag("muons")
+muidTM2DCompatibilityTight.inputMuonCollection = cms.InputTag("muons")
+muidTMOneStationLoose.inputMuonCollection = cms.InputTag("muons")
+muidTMOneStationTight.inputMuonCollection = cms.InputTag("muons")
+muidTMLastStationOptimizedLowPtLoose.inputMuonCollection = cms.InputTag("muons")
+muidTMLastStationOptimizedLowPtTight.inputMuonCollection = cms.InputTag("muons")
+muidGMTkChiCompatibility.inputMuonCollection = cms.InputTag("muons")
+muidGMStaChiCompatibility.inputMuonCollection = cms.InputTag("muons")
+muidGMTkKinkTight.inputMuonCollection = cms.InputTag("muons")
+muidTMLastStationAngLoose.inputMuonCollection = cms.InputTag("muons")
+muidTMLastStationAngTight.inputMuonCollection = cms.InputTag("muons")
+muidTMOneStationAngLoose.inputMuonCollection = cms.InputTag("muons")
+muidTMOneStationAngTight.inputMuonCollection = cms.InputTag("muons")
+muidRPCMuLoose.inputMuonCollection = cms.InputTag("muons")
+muonRecoHighLevelPbPb = cms.Sequence(muonSelectionTypeSequence+muonsHL)
 
 # HI muon sequence (passed to RecoHI.Configuration.Reconstruction_HI_cff)
 

--- a/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRecoMuon_cff.py
@@ -5,69 +5,47 @@ from RecoMuon.Configuration.RecoMuonPPonly_cff import *
 hiTracks = 'hiGeneralTracks' #heavy ion track label
 
 # replace with heavy ion track label
-# IMPORTANT
-# for now we clone muons1stStep into muons, and the final muon collection is named muonHL.
-# for something final we'll need to clone muons1stStep into something like muons, and the final collection will have to be named muons.
-muons = muons1stStep.clone()
-muons.inputCollectionLabels = [hiTracks, 'globalMuons', 'standAloneMuons:UpdatedAtVtx','tevMuons:firstHit','tevMuons:picky','tevMuons:dyt']
-muons.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks','tev firstHit', 'tev picky', 'tev dyt']
-muons.TrackExtractorPSet.inputTrackCollection = hiTracks
-muons.minPt = cms.double(0.8)
-#muons.fillGlobalTrackRefits = False
-muonEcalDetIds.inputCollection = "muons"
+hiMuons1stStep = muons1stStep.clone()
+hiMuons1stStep.inputCollectionLabels = [hiTracks, 'globalMuons', 'standAloneMuons:UpdatedAtVtx','tevMuons:firstHit','tevMuons:picky','tevMuons:dyt']
+hiMuons1stStep.inputCollectionTypes = ['inner tracks', 'links', 'outer tracks','tev firstHit', 'tev picky', 'tev dyt']
+hiMuons1stStep.TrackExtractorPSet.inputTrackCollection = hiTracks
+hiMuons1stStep.minPt = cms.double(0.8)
+#hiMuons1stStep.fillGlobalTrackRefits = False
+muonEcalDetIds.inputCollection = "hiMuons1stStep"
 
 calomuons.inputTracks = hiTracks
-calomuons.inputCollection = 'muons'
-calomuons.inputMuons = 'muons'
-muIsoDepositTk.inputTags = cms.VInputTag(cms.InputTag("muons:tracker"))
-muIsoDepositJets. inputTags = cms.VInputTag(cms.InputTag("muons:jets"))
-muIsoDepositCalByAssociatorTowers.inputTags = cms.VInputTag(cms.InputTag("muons:ecal"), cms.InputTag("muons:hcal"), cms.InputTag("muons:ho"))
+calomuons.inputCollection = 'hiMuons1stStep'
+calomuons.inputMuons = 'hiMuons1stStep'
+muIsoDepositTk.inputTags = cms.VInputTag(cms.InputTag("hiMuons1stStep:tracker"))
+muIsoDepositJets. inputTags = cms.VInputTag(cms.InputTag("hiMuons1stStep:jets"))
+muIsoDepositCalByAssociatorTowers.inputTags = cms.VInputTag(cms.InputTag("hiMuons1stStep:ecal"), cms.InputTag("hiMuons1stStep:hcal"), cms.InputTag("hiMuons1stStep:ho"))
 
-muonShowerInformation.muonCollection = "muons"
+muonShowerInformation.muonCollection = "hiMuons1stStep"
 
 #don't modify somebody else's sequence, create a new one if needed
 #standalone muon tracking is already done... so remove standalonemuontracking from muontracking
 muonreco_plus_isolation_PbPb = muonreco_plus_isolation.copyAndExclude(standalonemuontracking._seq._collection + displacedGlobalMuonTracking._seq._collection)
-muonreco_plus_isolation_PbPb.replace(muons1stStep, muons)
+muonreco_plus_isolation_PbPb.replace(muons1stStep, hiMuons1stStep)
 
 
 globalMuons.TrackerCollectionLabel = hiTracks
 
 # replace with heavy ion jet label
-muons.JetExtractorPSet.JetCollectionLabel = cms.InputTag("iterativeConePu5CaloJets")
+hiMuons1stStep.JetExtractorPSet.JetCollectionLabel = cms.InputTag("iterativeConePu5CaloJets")
 
 # turn off calo muons for timing considerations
-muons.minPCaloMuon = cms.double( 1.0E9 )
+hiMuons1stStep.minPCaloMuon = cms.double( 1.0E9 )
 
 # high level reco
-from RecoMuon.MuonIdentification.muons_cfi import muons as muonsHL
-muonsHL.InputMuons = cms.InputTag("muons")
-muonsHL.PFCandidates = cms.InputTag("particleFlowTmp")
-muonsHL.FillDetectorBasedIsolation = cms.bool(False)
-muonsHL.FillPFIsolation = cms.bool(False)
-muonsHL.FillSelectorMaps = cms.bool(True)
-muonsHL.FillShoweringInfo = cms.bool(False)
-muonsHL.FillCosmicsIdMap = cms.bool(False)
-muidTrackerMuonArbitrated.inputMuonCollection = cms.InputTag("muons")
-muidAllArbitrated.inputMuonCollection = cms.InputTag("muons")
-muidGlobalMuonPromptTight.inputMuonCollection = cms.InputTag("muons")
-muidTMLastStationLoose.inputMuonCollection = cms.InputTag("muons")
-muidTMLastStationTight.inputMuonCollection = cms.InputTag("muons")
-muidTM2DCompatibilityLoose.inputMuonCollection = cms.InputTag("muons")
-muidTM2DCompatibilityTight.inputMuonCollection = cms.InputTag("muons")
-muidTMOneStationLoose.inputMuonCollection = cms.InputTag("muons")
-muidTMOneStationTight.inputMuonCollection = cms.InputTag("muons")
-muidTMLastStationOptimizedLowPtLoose.inputMuonCollection = cms.InputTag("muons")
-muidTMLastStationOptimizedLowPtTight.inputMuonCollection = cms.InputTag("muons")
-muidGMTkChiCompatibility.inputMuonCollection = cms.InputTag("muons")
-muidGMStaChiCompatibility.inputMuonCollection = cms.InputTag("muons")
-muidGMTkKinkTight.inputMuonCollection = cms.InputTag("muons")
-muidTMLastStationAngLoose.inputMuonCollection = cms.InputTag("muons")
-muidTMLastStationAngTight.inputMuonCollection = cms.InputTag("muons")
-muidTMOneStationAngLoose.inputMuonCollection = cms.InputTag("muons")
-muidTMOneStationAngTight.inputMuonCollection = cms.InputTag("muons")
-muidRPCMuLoose.inputMuonCollection = cms.InputTag("muons")
-muonRecoHighLevelPbPb = cms.Sequence(muonSelectionTypeSequence+muonsHL)
+from RecoMuon.MuonIdentification.muons_cfi import muons
+muons.InputMuons = cms.InputTag("hiMuons1stStep")
+muons.PFCandidates = cms.InputTag("particleFlowTmp")
+muons.FillDetectorBasedIsolation = cms.bool(False)
+muons.FillPFIsolation = cms.bool(False)
+muons.FillSelectorMaps = cms.bool(False)
+muons.FillShoweringInfo = cms.bool(False)
+muons.FillCosmicsIdMap = cms.bool(False)
+muonRecoHighLevelPbPb = cms.Sequence(muons)
 
 # HI muon sequence (passed to RecoHI.Configuration.Reconstruction_HI_cff)
 


### PR DESCRIPTION
The purpose of this PR is to run a MuonProducer at the end of reconstruction, with the main goal to fill the isPFMuon() flag. This also involves changing some collection tags, as the formerly defined "muons" collection is now transient and called "hiMuons1stStep".
