### PR TITLE
CSCHaloData kept in AOD

### DIFF
--- a/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
+++ b/RecoMET/Configuration/python/RecoMET_EventContent_cff.py
@@ -64,6 +64,7 @@ RecoMETAOD = cms.PSet(
                                            'drop recoHcalNoiseRBXs_*_*_*',
                                            'keep HcalNoiseSummary_hcalnoise_*_*',
                                            'keep *GlobalHaloData_*_*_*',
+                                           'keep recoCSCHaloData_CSCHaloData_*_*',
                                            'keep *BeamHaloSummary_BeamHaloSummary_*_*'
                                            )
     )


### PR DESCRIPTION
Request to keep the CSCHaloData class content in AOD. 
Size of the class: 128 bytes (62 compressed)
