### PR TITLE
Fix a crash "withTopo" issue 

### DIFF
--- a/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
+++ b/CalibCalorimetry/HcalPlugins/src/HcalTextCalibrations.cc
@@ -56,7 +56,7 @@ HcalTextCalibrations::HcalTextCalibrations ( const edm::ParameterSet& iConfig )
       findingRecord <HcalQIEDataRcd> ();
     }
     else if (objectName == "ChannelQuality") {
-      setWhatProduced (this, &HcalTextCalibrations::produceChannelQuality);
+      setWhatProduced (this, &HcalTextCalibrations::produceChannelQuality, edm::es::Label("withTopo"));
       findingRecord <HcalChannelQualityRcd> ();
     }
     else if (objectName == "ZSThresholds") {


### PR DESCRIPTION
When checking the ChannelQuality record in the HcalTextCalibrations code, it crashes due to missing "withTopo" label. This is a fix for this issue.
