### PR TITLE
CondFormats/MFObjects: use correct path for headers.h

### DIFF
--- a/CondFormats/MFObjects/src/classes.h
+++ b/CondFormats/MFObjects/src/classes.h
@@ -1,4 +1,4 @@
-#include "headers.h"
+#include "CondFormats/MFObjects/src/headers.h"
 
 namespace CondFormats_MFObjects {
   struct dictionary {


### PR DESCRIPTION
ROOT6 run-time complains that `headers.h` is not found. This is valid,
because the path (`CondFormats/MFObjects/src`) is not in
ROOT_INCLUDE_PATH. This happens for `MagFieldConfig` type.

This would cause run-time failure if `AutoParse` is called because of
`MagFieldConfig` type as run-time would not be able to locate the
header.

There might be a patch by Axel in master branch (6.04.05) in near
future, which would cause a run-time warning/error for such cases.

Only `CondFormats/MFObjects` didn't include `headers.h` correctly:

```
% grep -i -n -R 'headers.h' * | grep -v '/test/' | grep CondFormats | grep -v '\.py'
CondFormats/BTauObjects/src/classes.h:1:#include "CondFormats/BTauObjects/src/headers.h"
CondFormats/BeamSpotObjects/src/classes.h:1:#include "CondFormats/BeamSpotObjects/src/headers.h"
CondFormats/CSCObjects/src/classes.h:1:#include "CondFormats/CSCObjects/src/headers.h"
CondFormats/Calibration/src/classes.h:1:#include "CondFormats/Calibration/src/headers.h"
CondFormats/CastorObjects/src/classes.h:1:#include "CondFormats/CastorObjects/src/headers.h"
CondFormats/Common/src/classes.h:1:#include "CondFormats/Common/src/headers.h"
CondFormats/DQMObjects/src/classes.h:1:#include "CondFormats/DQMObjects/src/headers.h"
CondFormats/DTObjects/src/classes.h:1:#include "CondFormats/DTObjects/src/headers.h"
CondFormats/EgammaObjects/src/classes.h:1:#include "CondFormats/EgammaObjects/src/headers.h"
CondFormats/HIObjects/src/classes.h:1:#include "CondFormats/HIObjects/src/headers.h"
CondFormats/HcalObjects/src/classes.h:1:#include "CondFormats/HcalObjects/src/headers.h"
CondFormats/JetMETObjects/src/classes.h:1:#include "CondFormats/JetMETObjects/src/headers.h"
CondFormats/Luminosity/src/classes.h:1:#include "CondFormats/Luminosity/src/headers.h"
CondFormats/MFObjects/src/classes.h:1:#include "headers.h"
CondFormats/OptAlignObjects/src/classes.h:1:#include "CondFormats/OptAlignObjects/src/headers.h"
CondFormats/PhysicsToolsObjects/src/classes.h:1:#include "CondFormats/PhysicsToolsObjects/src/headers.h"
CondFormats/RPCObjects/src/classes.h:1:#include "CondFormats/RPCObjects/src/headers.h"
CondFormats/RecoMuonObjects/src/classes.h:1:#include "CondFormats/RecoMuonObjects/src/headers.h"
CondFormats/RunInfo/src/classes.h:1:#include "CondFormats/RunInfo/src/headers.h"
CondFormats/SiStripObjects/src/classes.h:1:#include "CondFormats/SiStripObjects/src/headers.h"
```

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
