### PR TITLE
New GTs for 75X: adding V4 stage1 L1 menu + rolling back 75X BTV training

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,31 +2,31 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '75X_mcRun1_design_v3',
+    'run1_design'       :   '75X_mcRun1_design_v2',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '75X_mcRun1_realistic_v3',
+    'run1_mc'           :   '75X_mcRun1_realistic_v2',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v3',
+    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v2',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '75X_mcRun1_pA_v3',
+    'run1_mc_pa'        :   '75X_mcRun1_pA_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v3',
+    'run2_design'       :   '75X_mcRun2_design_v4',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '75X_mcRun2_startup_v3',
+    'run2_mc_50ns'      :   '75X_mcRun2_startup_v2',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v3',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v3',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v2',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v2',
+    'run1_data'         :   '75X_dataRun1_v4',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v2',
+    'run2_data'         :   '75X_dataRun2_v4',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '75X_dataRun1_HLT_v1',
+    'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v2',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '75X_dataRun2_HLT_v1',
+    'run2_hlt'          :   '75X_dataRun2_HLT_frozen_v2',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
-    'phase1_2017_design' :  '75X_upgrade2017_design_v0',
+    'phase1_2017_design' :  '75X_upgrade2017_design_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019
     'phase1_2019_design' :  'DES19_70_V2', # placeholder (GT not meant for standard RelVal) 
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase2


### PR DESCRIPTION
# List of Changes
- Run1 Ideal Simulation `75X_mcRun1_design_v2`: as [75X_mcRun1_design_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun1_design_v3/75X_mcRun1_design_v2) with:
  - updated training of b-tagging discriminators.
- Run1 Realistic Simulation `75X_mcRun1_realistic_v2` as: [75X_mcRun1_realistic_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun1_realistic_v3/75X_mcRun1_realistic_v2) with:
  - updated training of b-tagging discriminators.
- Run1 Heavy Simulation `75X_mcRun1_HeavyIon_v2` as: [75X_mcRun1_HeavyIon_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun1_HeavyIon_v3/75X_mcRun1_HeavyIon_v2) with:
  - updated training of b-tagging discriminators.
- Run1 proton-Lead Simulation `75X_mcRun1_pA_v2`: as [75X_mcRun1_pA_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun1_pA_v3/75X_mcRun1_pA_v2) with:
  - updated training of b-tagging discriminators.
- Run2 startup Simulation `75X_mcRun2_startup_v2`: as  [75X_mcRun1_startup_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun2_startup_v2/75X_mcRun2_startup_v3) with:
  - updated training of b-tagging discriminators.
- Run2 Ideal Simulation `75X_mcRun2_design_v4`: as [75X_mcRun2_design_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun2_design_v4/75X_mcRun2_design_v3) with:
  - updated training of b-tagging discriminators;
  - updated v4 version of  25ns stage1 L1 menu.
- Run2 asymptotic Simulation `75X_mcRun2_asymptotic_v4`: as [75X_mcRun1_asymptotic_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun2_asymptotic_v4/75X_mcRun2_asymptotic_v3) with:
  - updated training of b-tagging discriminators;
  - updated v4 version of  25ns stage1 L1 menu.
- Run2 Heavy Ion Simulation `75X_mcRun2_HeavyIon_v2`: as [75X_mcRun1_HeavyIon_v3](https://cms-conddb.cern.ch/browser/#diff/gts/75X_mcRun2_HeavyIon_v3/75X_mcRun2_HeavyIon_v2) with: 
  - updated training of b-tagging discriminators.
- Run2 data HLT processing `75X_dataRun2_HLT_frozen_v2`: as [75X_dataRun2_HLT_v1](https://cms-conddb.cern.ch/browser/#diff/gts/75X_dataRun2_HLT_frozen_v2/75X_dataRun2_HLT_v1) with:
  - updated training of b-tagging discriminators.
  - **features closed snapshot time** (as is meant for relvals)
- Run1 data HLT processing `75X_dataRun1_HLT_frozen_v2`: as [75X_dataRun1_HLT_v1](https://cms-conddb.cern.ch/browser/#diff/gts/75X_dataRun1_HLT_frozen_v2/75X_dataRun1_HLT_v1) with:
  - updated training of b-tagging discriminators;
  - **features closed snapshot time** (as is meant for relvals)
- Run2 data offline processing `75X_dataRun2_v4`: as [75X_dataRun2_v2](https://cms-conddb.cern.ch/browser/#diff/gts/75X_dataRun2_v4/75X_dataRun2_v2) with:
  - updated training of b-tagging discriminators.
  - taxonomy change of the SiPixelGenErrorDBObject for 3.8T tag;
  - different snapshot time to make changes to CSC conditions to be visible.
- Run1 data offline processing `75X_dataRun1_v4`: as [75X_dataRun1_v2](https://cms-conddb.cern.ch/browser/#diff/gts/75X_dataRun1_v4/75X_dataRun1_v2) with:
  - updated training of b-tagging discriminators;
  - taxonomy change of the SiPixelGenErrorDBObject for 3.8T tag;
  - different snapshot time to make changes to CSC conditions to be visible.
- Phase-I 2017 simulation scenario `75X_upgrade2017_design_v1`: as [75X_upgrade2017_design_v0](https://cms-conddb.cern.ch/browser/#diff/gts/75X_upgrade2017_design_v1/75X_upgrade2017_design_v0)
  - updated training of b-tagging discriminators.`
