### PR TITLE
Fix MultiTrackValidator "doPlotsOnlyForTruePV" mode

### DIFF
--- a/Validation/RecoTrack/plugins/MultiTrackValidator.cc
+++ b/Validation/RecoTrack/plugins/MultiTrackValidator.cc
@@ -270,10 +270,23 @@ void MultiTrackValidator::analyze(const edm::Event& event, const edm::EventSetup
     if(!(pvPtr->isFake() || pvPtr->ndof() < 0)) { // skip junk vertices
       auto pvFound = v_r2s.find(pvPtr);
       if(pvFound != v_r2s.end()) {
-        if(doPVAssociationPlots_) {
-          thePVposition = &(pvPtr->position());
-          theSimPVPosition = &(pvFound->val[0].first->position());
+        int simPVindex = -1;
+        int i=0;
+        for(const auto& vertexRefQuality: pvFound->val) {
+          const TrackingVertex& tv = *(vertexRefQuality.first);
+          if(tv.eventId().event() == 0 && tv.eventId().bunchCrossing() == 0) {
+            simPVindex = i;
+          }
+          ++i;
         }
+        if(simPVindex >= 0) {
+          if(doPVAssociationPlots_) {
+            thePVposition = &(pvPtr->position());
+            theSimPVPosition = &(pvFound->val[simPVindex].first->position());
+          }
+        }
+        else if(doPlotsOnlyForTruePV_)
+          return;
       }
       else if(doPlotsOnlyForTruePV_)
         return;


### PR DESCRIPTION
This PR fixes MultiTrackValidator for `doPlotsOnlyForTruePV=True` mode. Before it was enough (by mistake) that the reco PV was matched to some sim vertex that was not necessarily the sim PV. Now it is required that the reco PV is matched to the sim PV (=the "hard scatter" one).

Tested in CMSSW_7_6_X_2015-08-10-2300, expecting small changes in histograms in `TrackFromPV` and `TrackFromPVAllTP` folders and in the histograms controlled by `doPVAssociationPlots` flag (i.e. `*_dzpv*cut*`) on RelVal-level number of events, on IB-level could be that there are no changes.

@rovere @VinInn 
