### PR TITLE
Fix phase1TkCustoms for recent changes to defaults

### DIFF
--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -137,7 +137,6 @@ def customise_Validation_Trackingonly(process):
     return process
 
 def customise_harvesting(process):
-    process.dqmHarvesting.remove(process.jetMETDQMOfflineClient)
     process.dqmHarvesting.remove(process.dataCertificationJetMET)
     #######process.dqmHarvesting.remove(process.sipixelEDAClient)
     process.sipixelEDAClient.isUpgrade = cms.untracked.bool(True)

--- a/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
+++ b/SLHCUpgradeSimulations/Configuration/python/phase1TkCustoms.py
@@ -219,13 +219,15 @@ def customise_Reco(process,pileup):
     process.reconstruction_fromRECO.remove(process.electronSeedsSeq)
     process.reconstruction_fromRECO.remove(process.initialStepSeedLayers)
     process.reconstruction_fromRECO.remove(process.initialStepSeeds)
-    process.reconstruction_fromRECO.remove(process.initialStepSelector)
+    process.reconstruction_fromRECO.remove(process.initialStepClassifier1)
+    process.reconstruction_fromRECO.remove(process.initialStepClassifier2)
+    process.reconstruction_fromRECO.remove(process.initialStepClassifier3)
     process.reconstruction_fromRECO.remove(initialStepTrackCandidates)
     process.reconstruction_fromRECO.remove(initialStepTracks)
     process.reconstruction_fromRECO.remove(lowPtTripletStepClusters)
     process.reconstruction_fromRECO.remove(lowPtTripletStepSeedLayers)
     process.reconstruction_fromRECO.remove(lowPtTripletStepSeeds)
-    process.reconstruction_fromRECO.remove(lowPtTripletStepSelector)
+    process.reconstruction_fromRECO.remove(lowPtTripletStep)
     process.reconstruction_fromRECO.remove(lowPtTripletStepTrackCandidates)
     process.reconstruction_fromRECO.remove(lowPtTripletStepTracks)
 
@@ -236,21 +238,24 @@ def customise_Reco(process,pileup):
     process.reconstruction_fromRECO.remove(mixedTripletStepSeeds)
     process.reconstruction_fromRECO.remove(mixedTripletStepSeedsA)
     process.reconstruction_fromRECO.remove(mixedTripletStepSeedsB)
-    process.reconstruction_fromRECO.remove(mixedTripletStepSelector)
+    process.reconstruction_fromRECO.remove(mixedTripletStepClassifier1)
+    process.reconstruction_fromRECO.remove(mixedTripletStepClassifier2)
     process.reconstruction_fromRECO.remove(mixedTripletStepTrackCandidates)
     process.reconstruction_fromRECO.remove(mixedTripletStepTracks)
 
     process.reconstruction_fromRECO.remove(pixelPairStepClusters)
     process.reconstruction_fromRECO.remove(pixelPairStepSeeds)
     process.reconstruction_fromRECO.remove(pixelPairStepSeedLayers)
-    process.reconstruction_fromRECO.remove(pixelPairStepSelector)
+    process.reconstruction_fromRECO.remove(pixelPairStep)
     process.reconstruction_fromRECO.remove(pixelPairStepTrackCandidates)
     process.reconstruction_fromRECO.remove(pixelPairStepTracks)
     
     process.reconstruction_fromRECO.remove(tobTecStepClusters)
     process.reconstruction_fromRECO.remove(tobTecStepSeeds)
     #process.reconstruction_fromRECO.remove(tobTecStepSeedLayers)
-    process.reconstruction_fromRECO.remove(tobTecStepSelector)
+    process.reconstruction_fromRECO.remove(tobTecStepClassifier1)
+    process.reconstruction_fromRECO.remove(tobTecStepClassifier2)
+    process.reconstruction_fromRECO.remove(tobTecStep)
     process.reconstruction_fromRECO.remove(tobTecStepTrackCandidates)
     process.reconstruction_fromRECO.remove(tobTecStepTracks)
 
@@ -348,9 +353,9 @@ def customise_Reco(process,pileup):
     process.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = "pixelVertices"
     process.pixelPairStepSelector.vertices = "pixelVertices"
     process.tobTecStepSelector.vertices = "pixelVertices"
-    process.muonSeededTracksInOutSelector.vertices = "pixelVertices"
-    process.muonSeededTracksOutInSelector.vertices = "pixelVertices"
-    process.duplicateTrackSelector.vertices = "pixelVertices"
+    process.muonSeededTracksInOutClassifier.vertices = "pixelVertices"
+    process.muonSeededTracksOutInClassifier.vertices = "pixelVertices"
+    process.duplicateTrackClassifier.vertices = "pixelVertices"
     process.convStepSelector.vertices = "pixelVertices"
     process.ak4CaloJetsForTrk.srcPVs = "pixelVertices"
     


### PR DESCRIPTION
This updates the Phase1 tracker customisations for recent changes to the default sequence, mostly coming in with #10373.  At the moment the Phase1 workflows don't even run with `--command="--no_exec"`, you'll get the error:

```
customising the process with cust_2017 from SLHCUpgradeSimulations/Configuration/combinedCustoms
Traceback (most recent call last):
  <snip>
  File "/afs/cern.ch/cms/sw/ReleaseCandidates/vol1/slc6_amd64_gcc493/cms/cmssw/CMSSW_7_6_X_2015-08-10-2300/python/SLHCUpgradeSimulations/Configuration/phase1TkCustoms.py", line 222, in customise_Reco
    process.reconstruction_fromRECO.remove(process.initialStepSelector)
AttributeError: 'Process' object has no attribute 'initialStepSelector'
```

...and no config file is generated.

Note that the Phase1 workflows (e.g. `runTheMatrix.py -w upgrade -l 10000.0`) don't actually run at the moment - this PR just allows the config files to be generated with the `--no_exec` command.  Pull request #10353 will get the workflows as far as reco.

I don't expect this to be the final version of the customisation functions, they will probably need a big overhaul[*] but at least this lets runTheMatrix run.  Having said that I've tried to keep the changes sensible.

[*] probably replaced with an upgrade era, the creation of which is actually how I ran into this problem.

@boudoul, @atricomi
