### PR TITLE
Add HF Minimum Bias algorithm to Stage1 Emulator

### DIFF
--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
@@ -310,6 +310,9 @@ L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
   bxCounter = 0;
   for(int itBX=HfCounts->getFirstBX(); itBX<=HfCounts->getLastBX(); ++itBX){
 
+    if (itBX<bxMin_) continue;
+    if (itBX>bxMax_) continue;
+
     bxCounter++;
     L1GctHFBitCounts count = L1GctHFBitCounts::fromGctEmulator(itBX,
 							       0,


### PR DESCRIPTION
Due to changes in how the minimum bias bits are handled with respect to legacy, the Layer2 emulator needs to handle the minimum bias bits which are transmitted on the HF Bit Counts fiber. 

This PR adds the required changes to the Layer2, but because of an upsteam issue with the HCAL digis, only real-data will have non-zero values for this. MC requires a near-future PR to have non-zero Minimum bias bits.

This algorithm was tested against the currently running L1 Firmware by Ben Kreis and I. 

@mulhearn You should probably sign off on this.

Expect to see backport PRs for 75X and 74X shortly.
