### PR TITLE
Put GED photons into HI event content and DQM pathways

### DIFF
--- a/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
+++ b/DQMOffline/Configuration/python/DQMOfflineHeavyIons_cff.py
@@ -43,7 +43,11 @@ triggerOfflineDQMSource.remove(jetMETHLTOfflineAnalyzer)
 #egammaDQMOffline.remove(electronAnalyzerSequence)
 egammaDQMOffline.remove(zmumugammaAnalysis)
 egammaDQMOffline.remove(zmumugammaOldAnalysis)
-egammaDQMOffline.remove(photonAnalysis)
+#egammaDQMOffline.remove(photonAnalysis)
+photonAnalysis.phoProducer = cms.InputTag("gedPhotonsTmp")
+photonAnalysis.isHeavyIon = True
+photonAnalysis.barrelRecHitProducer = cms.InputTag("ecalRecHit", "EcalRecHitsEB")
+photonAnalysis.endcapRecHitProducer = cms.InputTag("ecalRecHit", "EcalRecHitsEE")
 
 triggerOfflineDQMSource.remove(ak4PFL1FastL2L3CorrectorChain)
 from DQMOffline.Trigger.FSQHLTOfflineSource_cfi import getFSQHI
@@ -72,7 +76,7 @@ tightAnalyzer.inputTags.offlinePVs = cms.InputTag("hiSelectedVertex")
 looseAnalyzer.inputTags.offlinePVs = cms.InputTag("hiSelectedVertex")
 
 
-DQMOfflineHeavyIonsPrePOG = cms.Sequence( muonMonitors 
+DQMOfflineHeavyIonsPrePOG = cms.Sequence( muonMonitors
                                           * TrackMonDQMTier0_hi
                                           * jetMETDQMOfflineSource
                                           * egammaDQMOffline
@@ -88,5 +92,5 @@ DQMOfflineHeavyIonsPOG = cms.Sequence( DQMOfflineHeavyIonsPrePOG *
 DQMOfflineHeavyIons = cms.Sequence( DQMOfflineHeavyIonsPreDPG *
                                     DQMOfflineHeavyIonsPrePOG *
                                     DQMMessageLogger )
-    
+
 #DQMOfflineHeavyIonsPhysics = cms.Sequence( dqmPhysics )

--- a/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_hiPF_cff.py
@@ -15,7 +15,8 @@ gedGsfElectronsTmp.minSCEtEndcaps = cms.double(15.0)
 gedPhotonsTmp.primaryVertexProducer = cms.InputTag("hiSelectedVertex")
 gedPhotonsTmp.regressionConfig.vertexCollection = cms.InputTag("hiSelectedVertex")
 gedPhotonsTmp.isolationSumsCalculatorSet.trackProducer = cms.InputTag("hiGeneralTracks")
-
+from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducer
+photonIsolationHIProducerGED = photonIsolationHIProducer.clone(photonProducer=cms.InputTag("gedPhotonsTmp"))
 
 #These are set for consistency w/ HiElectronSequence, but these cuts need to be studied
 gedGsfElectronsTmp.maxHOverEBarrel = cms.double(0.25)
@@ -82,6 +83,7 @@ hiParticleFlowLocalReco = cms.Sequence(particleFlowCluster)
 hiParticleFlowReco = cms.Sequence( pfGsfElectronMVASelectionSequence
                                    * particleFlowBlock
                                    * particleFlowEGammaFull
+                                   * photonIsolationHIProducerGED
                                    * particleFlowTmp
                                    * hiRecoPFJets
                                    )

--- a/RecoHI/HiEgammaAlgos/python/HiEgamma_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/HiEgamma_cff.py
@@ -33,7 +33,6 @@ photons.isolationSumsCalculatorSet.trackProducer = isolationInputParameters.trac
 from RecoHI.HiEgammaAlgos.photonIsolationHIProducer_cfi import photonIsolationHIProducer
 hiPhotonSequence = cms.Sequence(photonSequence * photonIsolationHIProducer)
 
-
 # HI Ecal reconstruction
 hiEcalClusters = cms.Sequence(hiEcalClusteringSequence)
 hiEgammaSequence = cms.Sequence(hiPhotonSequence)

--- a/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
+++ b/RecoHI/HiEgammaAlgos/python/RecoHiEgamma_EventContent_cff.py
@@ -10,7 +10,9 @@ RecoHiEgammaFEVT = cms.PSet(
     "drop recoPFClusters_*_*_*",
     "keep recoElectronSeeds_*_*_*",
     "keep recoGsfElectrons_*_*_*",
-    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*'
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*',
+    'keep recoPhotons_gedPhotonsTmp_*_*',
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*'
     )
     )
 
@@ -24,7 +26,9 @@ RecoHiEgammaRECO = cms.PSet(
     "drop recoPFClusters_*_*_*",
     "keep recoElectronSeeds_*_*_*",
     "keep recoGsfElectrons_*_*_*",
-    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*'
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*',
+    'keep recoPhotons_gedPhotonsTmp_*_*',
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*'
     )
     )
 
@@ -34,6 +38,8 @@ RecoHiEgammaAOD = cms.PSet(
     'keep recoGsfElectrons_gedGsfElectronsTmp_*_*',
     'keep recoSuperClusters_correctedIslandBarrelSuperClusters_*_*',
     'keep recoSuperClusters_correctedIslandEndcapSuperClusters_*_*',
-    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*'
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducer_*_*',
+    'keep recoPhotons_gedPhotonsTmp_*_*',
+    'keep recoHIPhotonIsolationedmValueMap_photonIsolationHIProducerGED_*_*'
     )
     )


### PR DESCRIPTION
The Heavy Ion developers have decided to include the pp-style GED photons in the default HI RECO and DQM pathways. We plan to use GED photons as our main analysis workhorse for run2 data, using the legacy reconstruction as an aide in commissioning. Currently the GED photons are already run during RECO, but they are not saved in the event content or run through DQM. This PR adds them to the event content and the DQM pathways.

The first set of commissioning plots, comparing the legacy photon reco and the GED reco in HI MC can be found in this meeting:
https://twiki.cern.ch/twiki/bin/viewauth/CMS/PhotonAnalyses2015#2015_08_11_13_30_CET

This PR should not change any pp workflows. We expect event size to only increase slightly (the photon collections are generally not large). Local tests show that the GED DQM plots show up properly under the egamma heading.

We also will backport to 75X for datataking. @yetkinyilmaz , @mandrenguyen , and @yenjie are probably interested in this.
