### PR TITLE
seed state back propagated to first rechit and then instead of sim info, seed state info is used

### DIFF
--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -85,7 +85,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   edm::ESHandle<Propagator>             propagator;
   es.get<TrackingComponentsRecord>().get(propagatorLabel,propagator);
-    
+  Propagator* thePropagator = propagator.product()->clone();
+
   // get products
   edm::Handle<edm::View<TrajectorySeed> > seeds;
   e.getByToken(seedToken,seeds);
@@ -172,24 +173,19 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::reverse(recHitCandidates.begin(),recHitCandidates.end());
     }
     
-    // initial track candidate parameters parameters
-    int32_t simTrackId = recHitCombination.back().simTrackId(0);
-    int vertexIndex = simTracks->at(simTrackId).vertIndex();
-    GlobalPoint  position(simVertices->at(vertexIndex).position().x(),
-			  simVertices->at(vertexIndex).position().y(),
-			  simVertices->at(vertexIndex).position().z());
-    GlobalVector momentum( simTracks->at(simTrackId).momentum().x() , 
-			   simTracks->at(simTrackId).momentum().y() , 
-			   simTracks->at(simTrackId).momentum().z() );
-    float        charge   = simTracks->at(simTrackId).charge();
-    GlobalTrajectoryParameters initialParams(position,momentum,(int)charge,magneticField.product());
-    AlgebraicSymMatrix55 errorMatrix= AlgebraicMatrixID();    
-    CurvilinearTrajectoryError initialError(errorMatrix);
-    FreeTrajectoryState initialFTS(initialParams, initialError);      
-
     // create track candidate
+
+    //Get seedTSOS from seed PTSOD//---------------------------------------------------------------------------
+    DetId seedDetId(seed.startingState().detId());
+    const GeomDet* gdet = trackerGeometry->idToDet(seedDetId);
+    TrajectoryStateOnSurface seedTSOS = trajectoryStateTransform::transientState(seed.startingState(), &(gdet->surface()),magneticField.product());
+    //---------------------------------------------------------------------------------------------------------
+    //backPropagate seedState to front recHit and get a new initial TSOS at front recHit//---------------------
     const GeomDet* initialLayer = trackerGeometry->idToDet(trackRecHits.front().geographicalId());
-    const TrajectoryStateOnSurface initialTSOS = propagator->propagate(initialFTS,initialLayer->surface()) ;
+    thePropagator->setPropagationDirection(oppositeToMomentum);
+    const TrajectoryStateOnSurface initialTSOS = thePropagator->propagate(seedTSOS,initialLayer->surface()) ;
+    //---------------------------------------------------------------------------------------------------------
+    //Check if the TSOS is valid .
     if (!initialTSOS.isValid()) continue; 
     PTrajectoryStateOnDet PTSOD = trajectoryStateTransform::persistentState(initialTSOS,trackRecHits.front().geographicalId().rawId()); 
     TrackCandidate newTrackCandidate(trackRecHits,seed,PTSOD,edm::RefToBase<TrajectorySeed>(seeds,seednr));

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
-    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
+    ("DQM_CMSSW_7_6_X_2015-07-31-2300_AfterSeedStateBackPropagation.root", "Changed_FastSim_7_6_X_AfterSeedStateBackPropagation"),
+    ("DQM_V0001_R000000001__RelValTTbar_13__CMSSW_7_5_0_pre3-MCRUN2_74_V7_FastSim-v1__DQMIO.root", "StandardFastSim_7_5_0_pre3"),
 ]
 
 outputDir = "plots"

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_1.root", "DQM 1 details"),
-    ("DQM_2.root", "DQM 2 details"),
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
 ]
 
 outputDir = "plots"

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_CMSSW_7_6_X_2015-07-31-2300_AfterSeedStateBackPropagation.root", "Changed_FastSim_7_6_X_AfterSeedStateBackPropagation"),
-    ("DQM_V0001_R000000001__RelValTTbar_13__CMSSW_7_5_0_pre3-MCRUN2_74_V7_FastSim-v1__DQMIO.root", "StandardFastSim_7_5_0_pre3"),
+    ("DQM_1.root", "DQM 1 details"),
+    ("DQM_2.root", "DQM 2 details"),
 ]
 
 outputDir = "plots"


### PR DESCRIPTION
In the process of Syncing fastsim and full sim , a major step will be to remove any direct use of sim-info. As a part of this, in this branch , the track candidate in the (Track Candidate Producer) is initialized using the seed state info instead of the previously used sim-info. The important part to note is that seed state is defined at the last hit of the seed, whereas a track candidate should be initialized with the state at the first hit, so the seed state is first back propagated to the first hit and then used as  initial state for  the track candidate.
