### PR TITLE
Customisations and few fixes for online DQM (76x)

### DIFF
--- a/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
+++ b/DQM/Integration/python/config/FrontierCondition_GT_cfi.py
@@ -1,5 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 from Configuration.StandardSequences.FrontierConditions_GlobalTag_cff import * 
 GlobalTag.connect = "frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_CONDITIONS"
-GlobalTag.globaltag = "GR_H_V58C"
+GlobalTag.globaltag = "74X_dataRun2_HLT_v1"
 es_prefer_GlobalTag = cms.ESPrefer('PoolDBESSource','GlobalTag')

--- a/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
+++ b/RecoTauTag/Configuration/python/loadRecoTauTagMVAsFromPrepDB_cfi.py
@@ -1,3 +1,5 @@
+import socket
+
 '''Helper procedure that loads mva inputs from database'''
 from CondCore.DBCommon.CondDBSetup_cfi import *
 
@@ -9,6 +11,9 @@ loadRecoTauTagMVAsFromPrepDB = cms.ESSource("PoolDBESSource",
     connect = cms.string('frontier://FrontierProd/CMS_COND_PAT_000') # prod database
     #connect = cms.string('sqlite_file:/home/dqmdevlocal/CMSSW_7_4_2_official/src/DQM/Integration/python/test/RecoTauTag_MVAs_2014Jul07.db')
 )
+
+if socket.getfqdn().find('.cms') != -1:
+    loadRecoTauTagMVAsFromPrepDB.connect = cms.string('frontier://(proxyurl=http://localhost:3128)(serverurl=http://localhost:8000/FrontierOnProd)(serverurl=http://localhost:8000/FrontierOnProd)(retrieve-ziplevel=0)(failovertoserver=no)/CMS_COND_PAT_000')
 
 # register tau ID (= isolation) discriminator MVA
 tauIdDiscrMVA_trainings = {


### PR DESCRIPTION
this deprecates https://github.com/cms-sw/cmssw/pull/10563
forward port of https://github.com/cms-sw/cmssw/pull/10714

Small set of fixes for online DQM:
- fix the name of the online playback GUI host
- new online GT for DQM
- fix temporary connection string for Tau Tag high-level calibrations (ping to @diguida - oh, it's me! - and @mmusich )
