### PR TITLE
Fix r45Fraction_ calculation

### DIFF
--- a/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalNoiseAlgo.cc
@@ -33,10 +33,13 @@ CommonHcalNoiseRBXData::CommonHcalNoiseRBXData(const reco::HcalNoiseRBX& rbx, do
 
   // Rechit-wide R45
   int rbxHitCount = rbx.numRecHits(minRBXRechitR45E);
+  r45Count_ = 0;
+  r45Fraction_ = 0;
+  r45EnergyFraction_ = 0;
   if(rbxHitCount > 0)
   {
      r45Count_ = rbx.numRecHitsFailR45(minRBXRechitR45E);
-     r45Fraction_ = r45Count_ / rbxHitCount;
+     r45Fraction_ = (double)(r45Count_) / (double)(rbxHitCount);
      r45EnergyFraction_ = rbx.recHitEnergyFailR45(minRBXRechitR45E) / rbx.recHitEnergy(minRBXRechitR45E);
   }
 


### PR DESCRIPTION
This is a simple bug-fix for the noisy hit fraction (r45Fraction_ ) calculation in CommonHcalNoiseRBXData. 
