### PR TITLE
SimGeneralAOD doesn't belong in AODEventContent (backport of #10727)

### DIFF
--- a/Configuration/EventContent/python/EventContent_cff.py
+++ b/Configuration/EventContent/python/EventContent_cff.py
@@ -463,7 +463,6 @@ AODEventContent.outputCommands.extend(MEtoEDMConverterAOD.outputCommands)
 AODEventContent.outputCommands.extend(EvtScalersAOD.outputCommands)
 AODEventContent.outputCommands.extend(TcdsEventContent.outputCommands)
 AODEventContent.outputCommands.extend(CommonEventContent.outputCommands)
-AODEventContent.outputCommands.extend(SimGeneralAOD.outputCommands)
 AODEventContent.outputCommands.extend(EITopPAGEventContent.outputCommands)
 
 RAWSIMEventContent.outputCommands.extend(RAWEventContent.outputCommands)


### PR DESCRIPTION
use AODSIMEventContent to get SIM-specific products.

``` python
'keep PileupSummaryInfos_*_*_*',
'keep int_*_bunchSpacing_*'
```

in SimGeneralAOD is also against the emerging policy of having no wildcards in the module names at least in the unscheduled (unscheduleable) workflows.

The change was triggered by broken prompt reco data processing while testing in 76X after #10617 is added (... while that PR better be fixed as well, this PR corrects the event content)

No changes are expected in appropriately setup workflows.
