### PR TITLE
Fix eta-dependent pileup jet ID

### DIFF
--- a/DQM/PhysicsHWW/src/MVAJetIdMaker.cc
+++ b/DQM/PhysicsHWW/src/MVAJetIdMaker.cc
@@ -14,7 +14,7 @@ MVAJetIdMaker::MVAJetIdMaker(const edm::ParameterSet& iConfig, edm::ConsumesColl
   theRhoCollection_    = iCollector.consumes<double>(iConfig.getParameter<edm::InputTag>("rhoInputTag"));
   jetCorrectorToken_   = iCollector.consumes<reco::JetCorrector>(iConfig.getParameter<edm::InputTag>("jetCorrector"));
 
-  fPUJetIdAlgo = new PileupJetIdAlgo(iConfig.getParameter<edm::ParameterSet>("puJetIDParams"));
+  fPUJetIdAlgo = new PileupJetIdAlgo(iConfig.getParameter<edm::ParameterSet>("puJetIDParams"),true);
 
 }
 
@@ -96,7 +96,7 @@ void MVAJetIdMaker::SetVars(HWW& hww, const edm::Event& iEvent, const edm::Event
 		  // calculate mva value only when there are good vertices 
 		  // otherwise store -999
 		  if( lGoodVertices.size()>0 ) {
-		  	PileupJetIdentifier lPUJetId =  fPUJetIdAlgo->computeIdVariables(pCJet,lJec,&lGoodVertices[0],lGoodVertices,lrho,true);
+		  	PileupJetIdentifier lPUJetId =  fPUJetIdAlgo->computeIdVariables(pCJet,lJec,&lGoodVertices[0],lGoodVertices,lrho);
 		   	hww.pfjets_mvavalue() .push_back( lPUJetId.mva()              );
         hww.pfjets_JEC() .push_back( lJec ); 
 		  

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -29,13 +29,12 @@ public:
 	enum version_t { USER=-1, PHILv0=0 };
 	
 	PileupJetIdAlgo(int version=PHILv0, const std::string & tmvaWeight="", const std::string & tmvaMethod="", 
-			Float_t impactParTkThreshod_=1., const std::vector<std::string> & tmvaVariables= std::vector<std::string>());
-	PileupJetIdAlgo(const edm::ParameterSet & ps); 
+			Float_t impactParTkThreshod_=1., const std::vector<std::string> & tmvaVariables= std::vector<std::string>(), bool runMvas=true);
+	PileupJetIdAlgo(const edm::ParameterSet & ps, bool runMvas); 
 	~PileupJetIdAlgo(); 
 	
 	PileupJetIdentifier computeIdVariables(const reco::Jet * jet, 
-					       float jec, const reco::Vertex *, const reco::VertexCollection &, double rho,
-					       bool calculateMva=false);
+					       float jec, const reco::Vertex *, const reco::VertexCollection &, double rho);
 
 	void set(const PileupJetIdentifier &);
 	PileupJetIdentifier computeMva();
@@ -57,7 +56,7 @@ protected:
 
 	void setup(); 
 	void runMva(); 
-	void bookReader(float jetEta);	
+	void bookReader();	
 	void resetVariables();
 	void initVariables();
 
@@ -65,9 +64,9 @@ protected:
 	PileupJetIdentifier internalId_;
 	variables_list_t variables_;
 
-	TMVA::Reader * reader_;
+	TMVA::Reader *reader_, *reader_jteta_0_2_, *reader_jteta_2_2p5_, *reader_jteta_2p5_3_, *reader_jteta_3_5_;
 	std::string    tmvaWeights_, tmvaWeights_jteta_0_2_, tmvaWeights_jteta_2_2p5_, tmvaWeights_jteta_2p5_3_, tmvaWeights_jteta_3_5_, tmvaMethod_; 
-	std::vector<std::string>  tmvaVariables_;
+	std::vector<std::string>  tmvaVariables_, tmvaVariables_jteta_0_3_, tmvaVariables_jteta_3_5_;
 	std::vector<std::string>  tmvaSpectators_;
 	std::map<std::string,std::string>  tmvaNames_;
 	
@@ -75,6 +74,7 @@ protected:
 	Float_t impactParTkThreshod_;
 	bool    cutBased_; 
 	bool    etaBinnedWeights_;
+	bool runMvas_;
 	Float_t mvacut_     [3][4][4]; //Keep the array fixed
 	Float_t rmsCut_     [3][4][4]; //Keep the array fixed
 	Float_t betaStarCut_[3][4][4]; //Keep the array fixed

--- a/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
+++ b/RecoJets/JetProducers/interface/PileupJetIdAlgo.h
@@ -64,7 +64,7 @@ protected:
 	PileupJetIdentifier internalId_;
 	variables_list_t variables_;
 
-	TMVA::Reader *reader_, *reader_jteta_0_2_, *reader_jteta_2_2p5_, *reader_jteta_2p5_3_, *reader_jteta_3_5_;
+	std::unique_ptr<TMVA::Reader> reader_, reader_jteta_0_2_, reader_jteta_2_2p5_, reader_jteta_2p5_3_, reader_jteta_3_5_;
 	std::string    tmvaWeights_, tmvaWeights_jteta_0_2_, tmvaWeights_jteta_2_2p5_, tmvaWeights_jteta_2p5_3_, tmvaWeights_jteta_3_5_, tmvaMethod_; 
 	std::vector<std::string>  tmvaVariables_, tmvaVariables_jteta_0_3_, tmvaVariables_jteta_3_5_;
 	std::vector<std::string>  tmvaSpectators_;

--- a/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
+++ b/RecoJets/JetProducers/plugins/PileupJetIdProducer.cc
@@ -45,7 +45,7 @@ PileupJetIdProducer::PileupJetIdProducer(const edm::ParameterSet& iConfig)
 	}
 	for(std::vector<edm::ParameterSet>::iterator it=algos.begin(); it!=algos.end(); ++it) {
 		std::string label = it->getParameter<std::string>("label");
-		algos_.push_back( std::make_pair(label,new PileupJetIdAlgo(*it)) );
+		algos_.push_back( std::make_pair(label,new PileupJetIdAlgo(*it, runMvas_)) );
 		if( runMvas_ ) {
 			produces<edm::ValueMap<float> > (label+"Discriminant");
 			produces<edm::ValueMap<int> > (label+"Id");
@@ -159,7 +159,7 @@ PileupJetIdProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
 		PileupJetIdentifier puIdentifier;
 		if( produceJetIds_ ) {
 		        // Compute the input variables
-		        puIdentifier = ialgo->computeIdVariables(theJet, jec,  &(*vtx), vertexes, rho, runMvas_);
+		        puIdentifier = ialgo->computeIdVariables(theJet, jec,  &(*vtx), vertexes, rho);
 			ids.push_back( puIdentifier );
 		} else {
 		        // Or read it from the value map

--- a/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
+++ b/RecoJets/JetProducers/python/PileupJetIDParams_cfi.py
@@ -12,7 +12,7 @@ full_74x_chs = cms.PSet(
  tmvaWeights_jteta_3_5 = cms.string("RecoJets/JetProducers/data/TMVAClassificationCategory_BDTG.weights_jteta_3_5.xml.gz"),
  tmvaMethod  = cms.string("JetIDMVAHighPt"),
  version = cms.int32(-1),
- tmvaVariables = cms.vstring(
+ tmvaVariables_jteta_0_3 = cms.vstring(
     "DRweighted"     ,
     "rho"       ,
     "nTot"     ,
@@ -29,6 +29,20 @@ full_74x_chs = cms.PSet(
     "min(pull,0.1)"   ,
     "jetR"   ,
     "jetRchg"   ,
+    ),
+ tmvaVariables_jteta_3_5 = cms.vstring(
+    "DRweighted"     ,
+    "rho"       ,
+    "nTot"     ,
+    "axisMajor" ,
+    "axisMinor",
+    "fRing0"  ,
+    "fRing1"      ,
+    "fRing2"   ,
+    "fRing3"   ,
+    "ptD"   ,
+    "min(pull,0.1)"   ,
+    "jetR"   ,
     ),
  tmvaSpectators = cms.vstring(
     "p4.fCoordinates.fPt"   ,

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -46,7 +46,6 @@ PileupJetIdAlgo::PileupJetIdAlgo(const edm::ParameterSet & ps, bool runMvas)
 	    version_             = ps.getParameter<int>("version");
 	  }
         else version_ = USER;
-	reader_              = nullptr;
 	edm::ParameterSet jetConfig = ps.getParameter<edm::ParameterSet>("JetIdParams");
 	for(int i0 = 0; i0 < 3; i0++) { 
 	  std::string lCutType                            = "Tight";
@@ -101,7 +100,6 @@ PileupJetIdAlgo::PileupJetIdAlgo(int version,
 	tmvaVariables_       = tmvaVariables;
 	version_             = version;
 	
-	reader_              = nullptr;
 	runMvas_=runMvas;
 	
 	setup();
@@ -203,16 +201,6 @@ void PileupJetIdAlgo::setup()
 // ------------------------------------------------------------------------------------------
 PileupJetIdAlgo::~PileupJetIdAlgo() 
 {
-	if( reader_ )
-		delete reader_;
-	if( reader_jteta_0_2_ )
-		delete reader_jteta_0_2_;
-	if( reader_jteta_2_2p5_ )
-		delete reader_jteta_2_2p5_;
-	if( reader_jteta_2p5_3_ )
-		delete reader_jteta_2p5_3_;
-	if( reader_jteta_3_5_ )
-		delete reader_jteta_3_5_;
 }
 
 // ------------------------------------------------------------------------------------------
@@ -236,12 +224,12 @@ void setPtEtaPhi(const reco::Candidate & p, float & pt, float & eta, float &phi 
 void PileupJetIdAlgo::bookReader()
 {
 	if(etaBinnedWeights_){
-		reader_jteta_0_2_ = new TMVA::Reader("!Color:Silent");
-		reader_jteta_2_2p5_ = new TMVA::Reader("!Color:Silent");
-		reader_jteta_2p5_3_ = new TMVA::Reader("!Color:Silent");
-		reader_jteta_3_5_ = new TMVA::Reader("!Color:Silent");
+		reader_jteta_0_2_ = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
+		reader_jteta_2_2p5_ = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
+		reader_jteta_2p5_3_ = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
+		reader_jteta_3_5_ = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
 	} else {
-		reader_ = new TMVA::Reader("!Color:Silent");
+		reader_ = std::unique_ptr<TMVA::Reader>(new TMVA::Reader("!Color:Silent"));
 	}
 	if(etaBinnedWeights_){
 	  for(std::vector<std::string>::iterator it=tmvaVariables_jteta_0_3_.begin(); it!=tmvaVariables_jteta_0_3_.end(); ++it) {
@@ -280,12 +268,12 @@ void PileupJetIdAlgo::bookReader()
 		}
 	}
 	if(etaBinnedWeights_){
-		reco::details::loadTMVAWeights(reader_jteta_0_2_,  tmvaMethod_.c_str(), tmvaWeights_jteta_0_2_.c_str() ); 
-		reco::details::loadTMVAWeights(reader_jteta_2_2p5_,  tmvaMethod_.c_str(), tmvaWeights_jteta_2_2p5_.c_str() ); 
-		reco::details::loadTMVAWeights(reader_jteta_2p5_3_,  tmvaMethod_.c_str(), tmvaWeights_jteta_2p5_3_.c_str() ); 
-		reco::details::loadTMVAWeights(reader_jteta_3_5_,  tmvaMethod_.c_str(), tmvaWeights_jteta_3_5_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_0_2_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_0_2_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_2_2p5_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_2_2p5_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_2p5_3_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_2p5_3_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_3_5_.get(),  tmvaMethod_.c_str(), tmvaWeights_jteta_3_5_.c_str() ); 
 	} else {
-		reco::details::loadTMVAWeights(reader_,  tmvaMethod_.c_str(), tmvaWeights_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_.get(),  tmvaMethod_.c_str(), tmvaWeights_.c_str() ); 
 	}
 }
 

--- a/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
+++ b/RecoJets/JetProducers/src/PileupJetIdAlgo.cc
@@ -15,11 +15,12 @@
 const float large_val = std::numeric_limits<float>::max();
 
 // ------------------------------------------------------------------------------------------
-PileupJetIdAlgo::PileupJetIdAlgo(const edm::ParameterSet & ps) 
+PileupJetIdAlgo::PileupJetIdAlgo(const edm::ParameterSet & ps, bool runMvas) 
 {
 	impactParTkThreshod_ = 1.;/// ps.getParameter<double>("impactParTkThreshod");
 	cutBased_ = false;
 	etaBinnedWeights_ = false;
+	runMvas_=runMvas;
 	//std::string label    = ps.getParameter<std::string>("label");
 	cutBased_ =  ps.getParameter<bool>("cutBased");
 	if(!cutBased_) 
@@ -35,7 +36,12 @@ PileupJetIdAlgo::PileupJetIdAlgo(const edm::ParameterSet & ps)
 	      tmvaWeights_                  = edm::FileInPath(ps.getParameter<std::string>("tmvaWeights")).fullPath();  
 	    }
 	    tmvaMethod_          = ps.getParameter<std::string>("tmvaMethod");
-	    tmvaVariables_       = ps.getParameter<std::vector<std::string> >("tmvaVariables");
+	    if(etaBinnedWeights_){
+	    	tmvaVariables_jteta_0_3_       = ps.getParameter<std::vector<std::string> >("tmvaVariables_jteta_0_3");
+	    	tmvaVariables_jteta_3_5_       = ps.getParameter<std::vector<std::string> >("tmvaVariables_jteta_3_5");
+	    } else {
+		tmvaVariables_       = ps.getParameter<std::vector<std::string> >("tmvaVariables");
+	    }
 	    tmvaSpectators_      = ps.getParameter<std::vector<std::string> >("tmvaSpectators");
 	    version_             = ps.getParameter<int>("version");
 	  }
@@ -85,7 +91,8 @@ PileupJetIdAlgo::PileupJetIdAlgo(int version,
 				 const std::string & tmvaWeights, 
 				 const std::string & tmvaMethod, 
 				 Float_t impactParTkThreshod,
-				 const std::vector<std::string> & tmvaVariables
+				 const std::vector<std::string> & tmvaVariables,
+				 bool runMvas
 	) 
 {
 	impactParTkThreshod_ = impactParTkThreshod;
@@ -95,6 +102,7 @@ PileupJetIdAlgo::PileupJetIdAlgo(int version,
 	version_             = version;
 	
 	reader_              = nullptr;
+	runMvas_=runMvas;
 	
 	setup();
 }
@@ -187,16 +195,24 @@ void PileupJetIdAlgo::setup()
 		tmvaNames_["drch_1"] = "dRMeanCh";
 
 	} else if( ! cutBased_ ){
-		assert( tmvaMethod_.empty() || (! tmvaVariables_.empty() && version_ == USER) );
+		assert( tmvaMethod_.empty() || ((! tmvaVariables_.empty() || ( !tmvaVariables_jteta_0_3_.empty() && !tmvaVariables_jteta_3_5_.empty() )) && version_ == USER) );
 	}
+	if(( ! cutBased_ ) && (runMvas_)) { bookReader();}
 }
 
 // ------------------------------------------------------------------------------------------
 PileupJetIdAlgo::~PileupJetIdAlgo() 
 {
-	if( reader_ ) {
+	if( reader_ )
 		delete reader_;
-	}
+	if( reader_jteta_0_2_ )
+		delete reader_jteta_0_2_;
+	if( reader_jteta_2_2p5_ )
+		delete reader_jteta_2_2p5_;
+	if( reader_jteta_2p5_3_ )
+		delete reader_jteta_2p5_3_;
+	if( reader_jteta_3_5_ )
+		delete reader_jteta_3_5_;
 }
 
 // ------------------------------------------------------------------------------------------
@@ -217,30 +233,60 @@ void setPtEtaPhi(const reco::Candidate & p, float & pt, float & eta, float &phi 
 }
 
 // ------------------------------------------------------------------------------------------
-void PileupJetIdAlgo::bookReader(float jetEta)
+void PileupJetIdAlgo::bookReader()
 {
-	reader_ = new TMVA::Reader("!Color:Silent");
 	if(etaBinnedWeights_){
-	  if(abs(jetEta)<=2.) tmvaWeights_ = tmvaWeights_jteta_0_2_;
-	  else if(abs(jetEta)<=2.5) tmvaWeights_ = tmvaWeights_jteta_2_2p5_;
-	  else if(abs(jetEta)<=3.) tmvaWeights_ = tmvaWeights_jteta_2p5_3_;
-	  else tmvaWeights_ = tmvaWeights_jteta_3_5_; //eta > 5?
+		reader_jteta_0_2_ = new TMVA::Reader("!Color:Silent");
+		reader_jteta_2_2p5_ = new TMVA::Reader("!Color:Silent");
+		reader_jteta_2p5_3_ = new TMVA::Reader("!Color:Silent");
+		reader_jteta_3_5_ = new TMVA::Reader("!Color:Silent");
+	} else {
+		reader_ = new TMVA::Reader("!Color:Silent");
 	}
-
-	assert( ! tmvaMethod_.empty() && !  tmvaWeights_.empty() );
-	for(std::vector<std::string>::iterator it=tmvaVariables_.begin(); it!=tmvaVariables_.end(); ++it) {
+	if(etaBinnedWeights_){
+	  for(std::vector<std::string>::iterator it=tmvaVariables_jteta_0_3_.begin(); it!=tmvaVariables_jteta_0_3_.end(); ++it) {
+		if(  tmvaNames_[*it].empty() ) { 
+			tmvaNames_[*it] = *it;
+		}
+		reader_jteta_0_2_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+		reader_jteta_2_2p5_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+		reader_jteta_2p5_3_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+	  }
+	  for(std::vector<std::string>::iterator it=tmvaVariables_jteta_3_5_.begin(); it!=tmvaVariables_jteta_3_5_.end(); ++it) {
+		if(  tmvaNames_[*it].empty() ) { 
+			tmvaNames_[*it] = *it;
+		}
+		reader_jteta_3_5_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+	  }
+	} else {
+	  for(std::vector<std::string>::iterator it=tmvaVariables_.begin(); it!=tmvaVariables_.end(); ++it) {
 		if(  tmvaNames_[*it].empty() ) { 
 			tmvaNames_[*it] = *it;
 		}
 		reader_->AddVariable( *it, variables_[ tmvaNames_[*it] ].first );
+	  }
 	}
 	for(std::vector<std::string>::iterator it=tmvaSpectators_.begin(); it!=tmvaSpectators_.end(); ++it) {
 		if(  tmvaNames_[*it].empty() ) { 
 			tmvaNames_[*it] = *it;
 		}
-		reader_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+		if(etaBinnedWeights_){
+			reader_jteta_0_2_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+			reader_jteta_2_2p5_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+			reader_jteta_2p5_3_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+			reader_jteta_3_5_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+		} else {
+			reader_->AddSpectator( *it, variables_[ tmvaNames_[*it] ].first );
+		}
 	}
-	reco::details::loadTMVAWeights(reader_,  tmvaMethod_.c_str(), tmvaWeights_.c_str() ); 
+	if(etaBinnedWeights_){
+		reco::details::loadTMVAWeights(reader_jteta_0_2_,  tmvaMethod_.c_str(), tmvaWeights_jteta_0_2_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_2_2p5_,  tmvaMethod_.c_str(), tmvaWeights_jteta_2_2p5_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_2p5_3_,  tmvaMethod_.c_str(), tmvaWeights_jteta_2p5_3_.c_str() ); 
+		reco::details::loadTMVAWeights(reader_jteta_3_5_,  tmvaMethod_.c_str(), tmvaWeights_jteta_3_5_.c_str() ); 
+	} else {
+		reco::details::loadTMVAWeights(reader_,  tmvaMethod_.c_str(), tmvaWeights_.c_str() ); 
+	}
 }
 
 // ------------------------------------------------------------------------------------------
@@ -255,9 +301,18 @@ void PileupJetIdAlgo::runMva()
   	if( cutBased_ ) {
 		internalId_.idFlag_ = computeCutIDflag(internalId_.betaStarClassic_,internalId_.dR2Mean_,internalId_.nvtx_,internalId_.jetPt_,internalId_.jetEta_);
 	} else {
-	        if( ! reader_ ) { bookReader(internalId_.jetEta_);}
-		if(std::abs(internalId_.jetEta_) <  5.0) internalId_.mva_ = reader_->EvaluateMVA( tmvaMethod_.c_str() );
-		if(std::abs(internalId_.jetEta_) >= 5.0) internalId_.mva_ = -2.;
+		if(std::abs(internalId_.jetEta_) >= 5.0) {
+			internalId_.mva_ = -2.;
+		} else {
+			if(etaBinnedWeights_){
+			  if(std::abs(internalId_.jetEta_)<=2.) internalId_.mva_ = reader_jteta_0_2_->EvaluateMVA( tmvaMethod_.c_str() );
+			  else if(std::abs(internalId_.jetEta_)<=2.5) internalId_.mva_ = reader_jteta_2_2p5_->EvaluateMVA( tmvaMethod_.c_str() );
+			  else if(std::abs(internalId_.jetEta_)<=3.) internalId_.mva_ = reader_jteta_2p5_3_->EvaluateMVA( tmvaMethod_.c_str() );
+			  else internalId_.mva_ = reader_jteta_3_5_->EvaluateMVA( tmvaMethod_.c_str() );
+			} else {
+			  internalId_.mva_ = reader_->EvaluateMVA( tmvaMethod_.c_str() );
+			}
+		}
 		internalId_.idFlag_ = computeIDflag(internalId_.mva_,internalId_.jetPt_,internalId_.jetEta_);
 	}
 }
@@ -323,8 +378,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeMva()
 
 // ------------------------------------------------------------------------------------------
 PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, float jec, const reco::Vertex * vtx,
-							const reco::VertexCollection & allvtx, double rho,
-							bool calculateMva) 
+							const reco::VertexCollection & allvtx, double rho) 
 {
 
 	static std::atomic<int> printWarning{10};
@@ -613,7 +667,7 @@ PileupJetIdentifier PileupJetIdAlgo::computeIdVariables(const reco::Jet * jet, f
 		assert( internalId_.beta_ == 0. && internalId_.betaStar_ == 0.&& internalId_.betaClassic_ == 0. && internalId_.betaStarClassic_ == 0. );
 	}
 
-	if( calculateMva ) {
+	if( runMvas_ ) {
 		runMva();
 	}
 	


### PR DESCRIPTION
Pileup jet ID was trained separately in bins of eta, with separate weight files.
Thus 4 TMVA readers need to be created in the constructor.
The previous version #10398 created only one reader and was using the wrong weight files for different eta bins.
