### PR TITLE
Fixed clang compiler warnings

### DIFF
--- a/CommonTools/Utils/src/ComparisonStack.h
+++ b/CommonTools/Utils/src/ComparisonStack.h
@@ -15,7 +15,7 @@
 
 namespace reco {
   namespace parser {
-    class ComparisonBase;
+    struct ComparisonBase;
     typedef std::vector<boost::shared_ptr<ComparisonBase> > ComparisonStack;
   }
 }

--- a/CommonTools/Utils/src/ExpressionSetter.h
+++ b/CommonTools/Utils/src/ExpressionSetter.h
@@ -1,5 +1,5 @@
 #ifndef CommonTools_Utils_ExpressionSetter_h
-#define CommoTools_Utils_ExpressionSetter_h
+#define CommonTools_Utils_ExpressionSetter_h
 /* \class reco::parser::ExpressionSetter
  *
  * Expression setter


### PR DESCRIPTION
Clang complained about a struct being forward declared as a class in
ComparisonStack.h as well as in improperly named include guard in
ExpressionSetter.
