### PR TITLE
FWLite MultiChainEvent: avoid crash on empty files

### DIFF
--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -310,7 +310,7 @@ ChainEvent::atEnd() const
 Long64_t
 ChainEvent::size() const
 {
-  return accumulatedSize_.back();
+  return accumulatedSize_.empty() ? 0 : accumulatedSize_.back();
 }
 
 edm::TriggerNames const&

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -199,6 +199,7 @@ ChainEvent::to(edm::RunNumber_t run, edm::EventNumber_t event)
 ChainEvent const&
 ChainEvent::toBegin()
 {
+   if (!size()) return *this;
    if (eventIndex_ != 0)
    {
       switchToFile(0);
@@ -301,6 +302,7 @@ ChainEvent::operator bool() const
 bool
 ChainEvent::atEnd() const
 {
+  if (!size()) return true;
   if (eventIndex_ == static_cast<Long64_t>(fileNames_.size())-1) {
     return event_->atEnd();
   }

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -77,8 +77,15 @@ private:
 
   getter_ = std::shared_ptr<internal::MultiProductGetter>(new internal::MultiProductGetter(this));
 
-  event1_->setGetter(getter_);
-  event2_->setGetter(getter_);
+  if (event1_->size() == 0) {
+    std::cout << "------------------------------------------------------------------------" << std::endl;
+    std::cout << "WARNING! MultiChainEvent: all primary files have zero events."        << std::endl;
+    std::cout << "Trying to access the events may lead to a crash.  "  << std::endl;
+    std::cout << "------------------------------------------------------------------------" << std::endl;
+  } else {
+    event1_->setGetter(getter_);
+    event2_->setGetter(getter_);
+  }
 
   useSecFileMapSorted_ = useSecFileMapSorted;
 

--- a/DataFormats/FWLite/test/pyroot_multichain.py
+++ b/DataFormats/FWLite/test/pyroot_multichain.py
@@ -1,0 +1,14 @@
+#! /usr/bin/env python
+import ROOT
+from DataFormats.FWLite import Events, Handle
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis')
+options.parseArguments()
+events = Events(options)
+
+print "In total there are %d events" % events.size()
+print "Trying an event loop"
+for i,event in enumerate(events):
+    print "I am processing an event"
+    if i > 10: break
+print "Done with the event loops"

--- a/DataFormats/FWLite/test/run_all_t.sh
+++ b/DataFormats/FWLite/test/run_all_t.sh
@@ -23,6 +23,8 @@ ${LOCAL_TEST_DIR}/VIPTest.sh || die 'Failed to create file' $?
 root -b -n -q ${LOCAL_TEST_DIR}/vector_int_cint.C || die 'Failed in vector_int_cint.C' $?
 
 python ${LOCAL_TEST_DIR}/pyroot_handle_reuse.py || die 'Failed in pyroot_handle_reuse.py' $?
+python ${LOCAL_TEST_DIR}/pyroot_multichain.py inputFiles=file:prodmerge.root secondaryInputFiles=file:prod1.root,file:prod2.root || die 'Failed in pyroot_multichain.py (non-empty files)' $?
+python ${LOCAL_TEST_DIR}/pyroot_multichain.py inputFiles=file:empty_a.root secondaryInputFiles=file:good_a.root  || die 'Failed in pyroot_multichain.py (empty file)' $?
 
 #NOTE: ROOT has a bug which keeps the AssociationVector from running its ioread rule and therefore it never clears its cache
 #test AssociationVector reading


### PR DESCRIPTION
When creating a MultiChainEvent when the primary list of files have zero events, the `Event` object of the `ChainEvent` is not initialized, since zero-event files are skipped and 
https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/DataFormats/FWLite/src/ChainEvent.cc#L57-L68
and this leads to a crash when setting the product getter
   https://github.com/cms-sw/cmssw/blob/CMSSW_7_4_X/DataFormats/FWLite/src/MultiChainEvent.cc#L80-L81
This PR avoids the crash by not setting the product getter, which should probably be ok since if there's no events, valid code should never end up querying the product getter for anything.
I also implemented `toBegin()` and `atEnd()` so that they don't crash if there's no non-empty files. This way, an event loop will just do nothing, as it should, if there's no events to loop on.

You can use the script below to test this fix:
- Run with a non-empty input file
  `python poc.py root://eoscms//eos/cms/store/data/Run2015B/SingleMuon/MINIAOD/PromptReco-v1/000/251/251/00000/EEBF2AF4-8D27-E511-91F7-02163E014527.root root://eoscms//eos/cms/store/data/Run2015B/SingleMuon/RAW/v1/000/251/251/00000/02E8B556-CA25-E511-A441-02163E011BB9.root  root://eoscms//eos/cms/store/data/Run2015B/SingleMuon/RAW/v1/000/251/251/00000/0691B06D-CA25-E511-8FBD-02163E0133B6.root  root://eoscms//eos/cms/store/data/Run2015B/SingleMuon/RAW/v1/000/251/251/00000/4CD4166A-CA25-E511-A474-02163E011D4A.root  root://eoscms//eos/cms/store/data/Run2015B/SingleMuon/RAW/v1/000/251/251/00000/9E73A652-CA25-E511-B232-02163E0133ED.root`
- Run with an empty input file
  `python poc.py root://eoscms//eos/cms/store/data/Run2015B/SingleElectron/MINIAOD/PromptReco-v1/000/251/781/00000/662647FF-9B2C-E511-85C5-02163E012965.root root://eoscms//eos/cms/store/data/Run2015B/SingleElectron/RAW/v1/000/251/781/00000/32256686-A02A-E511-BEBE-02163E014437.root`

```
from sys import argv
argv.append( '-b-' )
import ROOT
ROOT.gROOT.SetBatch(True)
argv.remove( '-b-' )

ROOT.gSystem.Load("libFWCoreFWLite.so");
ROOT.gSystem.Load("libDataFormatsFWLite.so");
ROOT.AutoLibraryLoader.enable()

from DataFormats.FWLite import Handle, Events
from optparse import Values
options = Values()
options.inputFiles = [ argv[1] ]
options.secondaryInputFiles = argv[2:] 
options.maxEvents = -1
events = Events([],options=options)

print "In total there are %d events" % events.size()
print "Trying an event loop"
for i,event in enumerate(events):
    print "I am processing an event"
    if i > 10: break
print "Done with the event loops"

```
