### PR TITLE
Fix clang error in Fireworks (76X)

### DIFF
--- a/Fireworks/Core/src/FWGUIManager.cc
+++ b/Fireworks/Core/src/FWGUIManager.cc
@@ -661,9 +661,9 @@ FWGUIManager::open3DRegion()
       reco::parser::Grammar grammar(tmpPtr,type);
       edm::ObjectWithDict o(type, (void*)id.item()->modelData(id.index()));
       try {
-         parse("theta()", grammar.use_parser<1>() >> end_p, space_p).full;
+         if(parse("theta()", grammar.use_parser<1>() >> end_p, space_p).full) {}
          eta =  tmpPtr->value(o);
-         parse("phi()", grammar.use_parser<1>() >> end_p, space_p).full;
+         if(parse("phi()", grammar.use_parser<1>() >> end_p, space_p).full) {}
          phi =  tmpPtr->value(o);
 
          ViewMap_i it = createView( "3D Tower", m_viewSecPack->NewSlot());


### PR DESCRIPTION
Put non-assigned parse() inside if statement to clear clang error.

This should not affect the logic in FWGUIManager in any way, but removed the clang error:

```
/afs/cern.ch/cms/sw/ReleaseCandidates/vol1/slc6_amd64_gcc493/external/boost/1.57.0/include/boost/spirit/home/classic/error_handling/exceptions.hpp:143:51: warning: unused typedef 'iterator_t' [-Wunused-local-typedef]

            typedef typename ScannerT::iterator_t iterator_t;

                                                  ^

5 warnings generated.

>> Compiling  /tmp/cmsbuild/workspace/ib-any-integration/CMSSW_7_6_X_2015-08-10-1100/src/Fireworks/Core/src/FWHFView.cc 

/tmp/cmsbuild/workspace/ib-any-integration/CMSSW_7_6_X_2015-08-10-1100/src/Fireworks/Core/src/FWGUIManager.cc:664:70: error: expression result unused [-Werror,-Wunused-value]

         parse("theta()", grammar.use_parser<1>() >> end_p, space_p).full;

         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~~~

/tmp/cmsbuild/workspace/ib-any-integration/CMSSW_7_6_X_2015-08-10-1100/src/Fireworks/Core/src/FWGUIManager.cc:666:68: error: expression result unused [-Werror,-Wunused-value]

         parse("phi()", grammar.use_parser<1>() >> end_p, space_p).full;

         ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ ^~~~
```
