### PR TITLE
New GT for all supported scenarios

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '75X_mcRun1_design_v2',
+    'run1_design'       :   '76X_mcRun1_design_v0',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '75X_mcRun1_realistic_v2',
+    'run1_mc'           :   '76X_mcRun1_realistic_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '76X_mcRun1_HeavyIon_v0',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '75X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '76X_mcRun1_pA_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v2',
+    'run2_design'       :   '76X_mcRun2_design_v0',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '75X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '76X_mcRun2_startup_v0',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v2',
+    'run2_mc'           :   '76X_mcRun2_asymptotic_v0',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '76X_mcRun2_HeavyIon_v0',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v3',
+    'run1_data'         :   '76X_dataRun1_v0',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v3',
+    'run2_data'         :   '76X_dataRun2_v0',
     # GlobalTag for Run1 HLT: it points to the online GT
-    'run1_hlt'          :   '75X_dataRun1_HLT_v2',
+    'run1_hlt'          :   '76X_dataRun1_HLT_frozen_v0',
     # GlobalTag for Run2 HLT: it points to the online GT
-    'run2_hlt'          :   '75X_dataRun2_HLT_v2',
+    'run2_hlt'          :   '76X_dataRun2_HLT_frozen_v0',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  '75X_upgrade2017_design_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of changes
## Run1 simulation
- Ideal: [76X_mcRun1_design_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun1_design_v0): As [75X_mcRun1_design_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun1_design_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun1_design_v0/75X_mcRun1_design_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Removed unsupported Run1 SIM geometries;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included.
- Realistic: [76X_mcRun1_realistic_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun1_realistic_v0): As [75X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun1_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun1_realistic_v0/75X_mcRun1_realistic_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Removed unsupported Run1 SIM geometries;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included.
- Heavy Ion: [76X_mcRun1_HeavyIon_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun1_HeavyIon_v0): As [75X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun1_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun1_HeavyIon_v0/75X_mcRun1_HeavyIon_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Removed unsupported Run1 SIM geometries;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included.
- Proton Lead: [76X_mcRun1_pA_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun1_pA_v0): As [75X_mcRun1_pA_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun1_pA_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun1_pA_v0/75X_mcRun1_pA_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Removed unsupported Run1 SIM geometries;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included.
## Run1 data
- Offline: [76X_dataRun1_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_dataRun1_v0): As [75X_dataRun1_v4](https://cms-conddb.cern.ch/browser/#list/gts/75X_dataRun1_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_dataRun1_v0/75X_dataRun1_v4):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction.
- HLT: [76X_dataRun1_HLT_frozen_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_dataRun1_HLT_frozen_v0): As [75X_dataRun1_HLT_v2], snapshot time set to 2015-08-13 15:09:30 UTC, (https://cms-conddb.cern.ch/browser/#list/gts/75X_dataRun1_HLT_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_dataRun1_HLT_v0/75X_dataRun1_HLT_v2):
  - New HCAL parameters for HCAL topology (deprecated old record).
## Run2 simulation
- Ideal: [76X_mcRun2_design_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun2_design_v0): As [75X_mcRun2_design_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun2_design_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun2_design_v0/75X_mcRun2_design_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included;
  - Updated L1T menu for Stage1.
- Startup: [76X_mcRun2_startup_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun2_startup_v0): As [75X_mcRun2_startup_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun2_startup_v0/75X_mcRun2_startup_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included.
- Asymptotic: [76X_mcRun2_asymptotic_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun2_asymptotic_v0): As [75X_mcRun2_asymptotic_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun2_asymptotic_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun2_asymptotic_v0/75X_mcRun2_asymptotic_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included;
  - Updated L1T menu for Stage1.
- Heavy Ion: [76X_mcRun2_HeavyIon_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_mcRun2_HeavyIon_v0): As [75X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/gts/75X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_mcRun2_HeavyIon_v0/75X_mcRun2_HeavyIon_v2):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction;
  - Updated detector description in the SIM geometries: the geometry in these tags is unchanged, only Hcal parameters are included.
## Run2 data
- Offline: [76X_dataRun2_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_dataRun2_v0): As [75X_dataRun2_v4](https://cms-conddb.cern.ch/browser/#list/gts/75X_dataRun2_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_dataRun2_v0/75X_dataRun2_v4):
  - New HCAL parameters for HCAL topology (deprecated old record);
  - New Egamma regressions based on ECAL multifit reconstruction.
- HLT: [76X_dataRun2_HLT_frozen_v0](https://cms-conddb.cern.ch/browser/#list/gts/76X_dataRun1_HLT_frozen_v0): As [75X_dataRun2_HLT_v2], snapshot time set to 2015-08-13 15:09:30 UTC, (https://cms-conddb.cern.ch/browser/#list/gts/75X_dataRun2_HLT_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/gts/76X_dataRun2_HLT_v0/75X_dataRun2_HLT_v2):
  - New HCAL parameters for HCAL topology (deprecated old record).
