### PR TITLE
No direct sim info for seed and track

### DIFF
--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -85,7 +85,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   edm::ESHandle<Propagator>             propagator;
   es.get<TrackingComponentsRecord>().get(propagatorLabel,propagator);
-    
+  Propagator* thePropagator = propagator.product()->clone();
+
   // get products
   edm::Handle<edm::View<TrajectorySeed> > seeds;
   e.getByToken(seedToken,seeds);
@@ -172,24 +173,19 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::reverse(recHitCandidates.begin(),recHitCandidates.end());
     }
     
-    // initial track candidate parameters parameters
-    int32_t simTrackId = recHitCombination.back().simTrackId(0);
-    int vertexIndex = simTracks->at(simTrackId).vertIndex();
-    GlobalPoint  position(simVertices->at(vertexIndex).position().x(),
-			  simVertices->at(vertexIndex).position().y(),
-			  simVertices->at(vertexIndex).position().z());
-    GlobalVector momentum( simTracks->at(simTrackId).momentum().x() , 
-			   simTracks->at(simTrackId).momentum().y() , 
-			   simTracks->at(simTrackId).momentum().z() );
-    float        charge   = simTracks->at(simTrackId).charge();
-    GlobalTrajectoryParameters initialParams(position,momentum,(int)charge,magneticField.product());
-    AlgebraicSymMatrix55 errorMatrix= AlgebraicMatrixID();    
-    CurvilinearTrajectoryError initialError(errorMatrix);
-    FreeTrajectoryState initialFTS(initialParams, initialError);      
-
     // create track candidate
+
+    //Get seedTSOS from seed PTSOD//---------------------------------------------------------------------------
+    DetId seedDetId(seed.startingState().detId());
+    const GeomDet* gdet = trackerGeometry->idToDet(seedDetId);
+    TrajectoryStateOnSurface seedTSOS = trajectoryStateTransform::transientState(seed.startingState(), &(gdet->surface()),magneticField.product());
+    //---------------------------------------------------------------------------------------------------------
+    //backPropagate seedState to front recHit and get a new initial TSOS at front recHit//---------------------
     const GeomDet* initialLayer = trackerGeometry->idToDet(trackRecHits.front().geographicalId());
-    const TrajectoryStateOnSurface initialTSOS = propagator->propagate(initialFTS,initialLayer->surface()) ;
+    thePropagator->setPropagationDirection(oppositeToMomentum);
+    const TrajectoryStateOnSurface initialTSOS = thePropagator->propagate(seedTSOS,initialLayer->surface()) ;
+    //---------------------------------------------------------------------------------------------------------
+    //Check if the TSOS is valid .
     if (!initialTSOS.isValid()) continue; 
     PTrajectoryStateOnDet PTSOD = trajectoryStateTransform::persistentState(initialTSOS,trackRecHits.front().geographicalId().rawId()); 
     TrackCandidate newTrackCandidate(trackRecHits,seed,PTSOD,edm::RefToBase<TrajectorySeed>(seeds,seednr));

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -62,12 +62,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
     // The name of the TrajectorySeed Collection
     produces<TrajectorySeedCollection>();
     //Regions regions;
-    const edm::ParameterSet& simTrackSelectionConfig = conf.getParameter<edm::ParameterSet>("simTrackSelection");
-    // The smallest pT,dxy,dz for a simtrack
-    simTrack_pTMin = simTrackSelectionConfig.getParameter<double>("pTMin");
-    simTrack_maxD0 = simTrackSelectionConfig.getParameter<double>("maxD0");
-    simTrack_maxZ0 = simTrackSelectionConfig.getParameter<double>("maxZ0");
-
+    
 
     hitMasks_exists = conf.exists("hitMasks");
     if (hitMasks_exists){

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -51,14 +51,6 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
     trackerTopology(nullptr),
     theRegionProducer(nullptr)
 {
-
-  /*
-    testBeamspotCompatibility(false),
-    beamSpot(nullptr),
-    testPrimaryVertexCompatibility(false),
-    primaryVertices(nullptr)
-    {  */
-
     // The name of the TrajectorySeed Collection
     produces<TrajectorySeedCollection>();
     //Regions regions;
@@ -75,11 +67,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
       edm::InputTag hitCombinationMasksTag = conf.getParameter<edm::InputTag> ("hitCombinationMasks");   
       hitCombinationMasksToken = consumes<std::vector<bool> >(hitCombinationMasksTag);
     }
-    /*
-    std::vector<edm::InputTag> skipSimTrackTags = simTrackSelectionConfig.getParameter<std::vector<edm::InputTag> >("skipSimTrackIds");
-    for ( unsigned int k=0; k<skipSimTrackTags.size(); ++k){
-      skipSimTrackIdTokens.push_back(consumes<std::vector<unsigned int> >(skipSimTrackTags[k]));}
-    */
+
     // The smallest number of hits for a track candidate
     minLayersCrossed = conf.getParameter<unsigned int>("minLayersCrossed");
 
@@ -272,15 +260,6 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
     e.getByToken(hitCombinationMasksToken,hitCombinationMasks);	
   }
 
-    
-    // SimTracks and SimVertices
-  /*
-    edm::Handle<edm::SimTrackContainer> theSimTracks;
-    e.getByToken(simTrackToken,theSimTracks);
-    
-    edm::Handle<edm::SimVertexContainer> theSimVtx;
-    e.getByToken(simVertexToken,theSimVtx);
-  */
     edm::Handle<FastTMRecHitCombinations> recHitCombinations;
     e.getByToken(recHitTokens, recHitCombinations);
 
@@ -362,18 +341,14 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
 
 bool
   TrajectorySeedProducer::testWithRegions(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const{
-  //std::cout<<"Inside:testWithRegions1"<<std::endl;
   const DetLayer * innerLayer = measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(innerHit.hit()->det()->geographicalId());
   const DetLayer * outerLayer = measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(outerHit.hit()->det()->geographicalId());
   typedef PixelRecoRange<float> Range;
-  //std::cout<<"Inside:testWithRegions1"<<std::endl;
   for(Regions::const_iterator ir=regions.begin(); ir < regions.end(); ++ir){
-    //std::cout<<"Inside:testWithRegions1"<<std::endl;
     auto const & gs = outerHit.hit()->globalState();
     auto loc = gs.position-(*ir)->origin().basicVector();
     const HitRZCompatibility * checkRZ = (*ir)->checkRZ(innerLayer, outerHit.hit(), *es_, outerLayer,
 							loc.perp(),gs.position.z(),gs.errorR,gs.errorZ);
-    //std::cout<<"Inside:testWithRegions1"<<std::endl;
     float u = innerLayer->isBarrel() ? loc.perp() : gs.position.z();
     float v = innerLayer->isBarrel() ? gs.position.z() : loc.perp();
     float dv = innerLayer->isBarrel() ? gs.errorZ : gs.errorR;
@@ -382,18 +357,13 @@ bool
     float vErr = nSigmaRZ * dv;
     Range hitRZ(v-vErr, v+vErr);
     Range crossRange = allowed.intersection(hitRZ);
-    //std::cout<<"Inside:testWithRegions1"<<std::endl;
     if( ! crossRange.empty()){
-      //std::cout<<"Inside:testWithRegions1"<<std::endl;
       std::cout << "init seed creator"<< std::endl;
       std::cout << "ptmin: " << (**ir).ptMin() << std::endl;
       std::cout << "" << std::endl;
       seedCreator->init(**ir,*es_,0);
       std::cout << "done" << std::endl;
       return true;}
-    //std::cout<<"Line485"<<std::endl;
-    //seedCreator->init(**ir,*es_,0);
-    //std::cout<<"Line487"<<std::endl;  
   }
   return false;
 }

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -23,6 +23,7 @@
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 	 //#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 	 //#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include <memory>
 #include <vector>
@@ -203,7 +204,8 @@ class TrajectorySeedProducer:
             unsigned int trackerHit
     ) const;
     
-    typedef std::vector<TrackingRegion* > Regions;
+    //    typedef std::vector<TrackingRegion* > Regions;
+    typedef std::vector<std::unique_ptr<TrackingRegion> > Regions;
     Regions regions;
     //TrackingRegionProducer* theRegionProducer;
 

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -9,18 +9,21 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h"
-
+#include "RecoTracker/TkSeedGenerator/interface/SeedCreatorFactory.h"
+#include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 #include "FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2DCollection.h"
 
 #include "FastSimulation/Tracking/interface/SeedingTree.h"
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 	 //#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 	 //#include "DataFormats/TrackReco/interface/TrackFwd.h"
-
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include <memory>
 #include <vector>
 #include <sstream>
@@ -30,6 +33,7 @@ class MagneticField;
 class MagneticFieldMap;
 class TrackerGeometry;
 class PropagatorWithMaterial;
+class MeasurementTrackerEvent;
 
 class TrajectorySeedProducer:
     public edm::stream::EDProducer<>
@@ -47,11 +51,11 @@ class TrajectorySeedProducer:
         double simTrack_pTMin;
         double simTrack_maxD0;
         double simTrack_maxZ0;
-        
+	std::unique_ptr<SeedCreator> seedCreator;
         unsigned int minLayersCrossed;
 
         std::vector<std::vector<TrackingLayer>> seedingLayers;
-
+	std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
         double originRadius;
         double ptMin;
         double originHalfLength;
@@ -191,12 +195,22 @@ class TrajectorySeedProducer:
     \param trackerHit hit which is tested.
     \return pointer if this hit is inserted at a leaf which means that a seed has been found. Returns 'nullptr' otherwise.
     */
+    bool testWithRegions(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const;
     const SeedingNode<TrackingLayer>* insertHit(
             const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
             std::vector<int>& hitIndicesInTree,
             const SeedingNode<TrackingLayer>* node, 
             unsigned int trackerHit
     ) const;
+    
+    typedef std::vector<TrackingRegion* > Regions;
+    Regions regions;
+    //TrackingRegionProducer* theRegionProducer;
+
+    std::unique_ptr<TrackingRegionProducer> theRegionProducer;
+    edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerEventToken;
+    const MeasurementTrackerEvent * measurementTrackerEvent;
+    const edm::EventSetup * es_;
 
 
 };

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -56,7 +56,7 @@ class TrajectorySeedProducer:
         unsigned int minLayersCrossed;
 
         std::vector<std::vector<TrackingLayer>> seedingLayers;
-	std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
+	//std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
         double originRadius;
         double ptMin;
         double originHalfLength;
@@ -70,8 +70,8 @@ class TrajectorySeedProducer:
         const reco::VertexCollection* primaryVertices;
         // tokens
         edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
-        edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
-        edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
+        //edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
+        //edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
         edm::EDGetTokenT<FastTMRecHitCombinations> recHitTokens;
         edm::EDGetTokenT<FastTMRecHitCombination> recHitToken;
         edm::EDGetTokenT<reco::VertexCollection> recoVertexToken;
@@ -94,7 +94,7 @@ class TrajectorySeedProducer:
     \param theSimVertex the associated SimVertex of the SimTrack.
     \return true if a track fulfills the requirements.
     */
-    virtual bool passSimTrackQualityCuts(const SimTrack& theSimTrack, const SimVertex& theSimVertex) const;
+    //virtual bool passSimTrackQualityCuts(const SimTrack& theSimTrack, const SimVertex& theSimVertex) const;
 
     //! method checks if a TrajectorySeedHitCandidate fulfills the quality requirements.
     /*!

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -56,7 +56,7 @@ class TrajectorySeedProducer:
         unsigned int minLayersCrossed;
 
         std::vector<std::vector<TrackingLayer>> seedingLayers;
-	//std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
+
         double originRadius;
         double ptMin;
         double originHalfLength;
@@ -70,8 +70,6 @@ class TrajectorySeedProducer:
         const reco::VertexCollection* primaryVertices;
         // tokens
         edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
-        //edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
-        //edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
         edm::EDGetTokenT<FastTMRecHitCombinations> recHitTokens;
         edm::EDGetTokenT<FastTMRecHitCombination> recHitToken;
         edm::EDGetTokenT<reco::VertexCollection> recoVertexToken;
@@ -88,22 +86,6 @@ class TrajectorySeedProducer:
     virtual void beginRun(edm::Run const& run, const edm::EventSetup & es);
     virtual void produce(edm::Event& e, const edm::EventSetup& es);
 
-    //! method checks if a SimTrack fulfills the quality requirements.
-    /*!
-    \param theSimTrack the SimTrack to be tested.
-    \param theSimVertex the associated SimVertex of the SimTrack.
-    \return true if a track fulfills the requirements.
-    */
-    //virtual bool passSimTrackQualityCuts(const SimTrack& theSimTrack, const SimVertex& theSimVertex) const;
-
-    //! method checks if a TrajectorySeedHitCandidate fulfills the quality requirements.
-    /*!
-    \param seedingNode tree node at which the hit will be inserted. 
-    \param trackerRecHits list of all TrackerRecHits.
-    \param hitIndicesInTree hit indices which translates the tree node to the hits in \e trackerRecHits.
-    \param currentTrackerHit hit which is tested.
-    \return true if a hit fulfills the requirements.
-    */
     inline bool passHitTuplesCuts(
             const SeedingNode<TrackingLayer>& seedingNode,
             const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,

--- a/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
@@ -6,9 +6,11 @@ import RecoTracker.IterativeTracking.DetachedTripletStep_cff as _detachedTriplet
 # fast tracking mask producer
 import FastSimulation.Tracking.FastTrackingMaskProducer_cfi
 detachedTripletStepMasks = FastSimulation.Tracking.FastTrackingMaskProducer_cfi.fastTrackingMaskProducer.clone(
-    trackCollection = _detachedTripletStep.detachedTripletStepClusters.trajectories,
+    trackCollection = cms.InputTag("initialStepTracks"),
     TrackQuality = _detachedTripletStep.detachedTripletStepClusters.TrackQuality,
-    overrideTrkQuals = cms.InputTag('initialStep',"QualityMasks")
+#_detachedTripletStep.detachedTripletStepClusters.TrackQuality,
+    maxChi2 = _detachedTripletStep.detachedTripletStepClusters.maxChi2,
+    overrideTrkQuals =  cms.InputTag('initialStep')
 )
 
 # trajectory seeds
@@ -20,25 +22,17 @@ detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.tr
         maxZ0 = 1
         ),
     minLayersCrossed = 3,
-layerList = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeedLayers.layerList.value(),
-    RegionFactoryPSet = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeeds.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-    #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("detachedTripletStepMasks","hitCombinationMasks"),
-    ptMin = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = _detachedTripletStep.detachedTripletStepSeedLayers.layerList.value()
-'''
+    layerList = _detachedTripletStep.detachedTripletStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
     )
 
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 detachedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
     src = cms.InputTag("detachedTripletStepSeeds"),
-    MinNumberOfCrossedLayers = 3    
-#hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
+    MinNumberOfCrossedLayers = 3
+    #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
     )
 
 # tracks 
@@ -50,11 +44,16 @@ detachedTripletStepTracks = _detachedTripletStep.detachedTripletStepTracks.clone
 )
 
 #final selection
+#detachedTripletStepSelector = _detachedTripletStep.detachedTripletStepSelector.clone()
+
+#detachedTripletStepSelector.vertices = "firstStepPrimaryVerticesBeforeMixing"
+#detachedTripletStep = _detachedTripletStep.detachedTripletStep.clone() 
+
 detachedTripletStepClassifier1 = _detachedTripletStep.detachedTripletStepClassifier1.clone()
 detachedTripletStepClassifier1.vertices = "firstStepPrimaryVerticesBeforeMixing"
 detachedTripletStepClassifier2 = _detachedTripletStep.detachedTripletStepClassifier2.clone()
 detachedTripletStepClassifier2.vertices = "firstStepPrimaryVerticesBeforeMixing"
-detachedTripletStep = _detachedTripletStep.detachedTripletStep.clone() 
+detachedTripletStep = _detachedTripletStep.detachedTripletStep.clone()
 
 # Final sequence 
 DetachedTripletStep = cms.Sequence(detachedTripletStepMasks

--- a/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
@@ -15,25 +15,30 @@ detachedTripletStepMasks = FastSimulation.Tracking.FastTrackingMaskProducer_cfi.
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.02,
-        maxD0 = 30.0,
-        maxZ0 = 50
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = 1
         ),
     minLayersCrossed = 3,
+layerList = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
     #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("detachedTripletStepMasks","hitCombinationMasks"),
     ptMin = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
     originHalfLength = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
     originRadius = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
     layerList = _detachedTripletStep.detachedTripletStepSeedLayers.layerList.value()
+'''
     )
 
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 detachedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
     src = cms.InputTag("detachedTripletStepSeeds"),
-    MinNumberOfCrossedLayers = 3
-    #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
+    MinNumberOfCrossedLayers = 3    
+#hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
     )
 
 # tracks 

--- a/FastSimulation/Tracking/python/GlobalMixedTracking_cff.py
+++ b/FastSimulation/Tracking/python/GlobalMixedTracking_cff.py
@@ -17,4 +17,3 @@ globalMixedWithMaterialTracks.src = 'globalMixedTrackCandidates'
 globalMixedWithMaterialTracks.TTRHBuilder = 'WithoutRefit'
 globalMixedWithMaterialTracks.Fitter = 'KFFittingSmootherWithOutlierRejection'
 globalMixedWithMaterialTracks.Propagator = 'PropagatorWithMaterial'
-

--- a/FastSimulation/Tracking/python/MixedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/MixedTripletStep_cff.py
@@ -25,14 +25,6 @@ mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer_cfi.traj
 layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet,
     MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-    #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
-    ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originRadius,
-    originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originHalfLength,
-    layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value()
-'''
 )
 
 ###
@@ -46,15 +38,7 @@ mixedTripletStepSeedsB = FastSimulation.Tracking.TrajectorySeedProducer_cfi.traj
     minLayersCrossed = 3,
 layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),   
- #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
-    ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originRadius,
-    originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originHalfLength,
-    layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value()
-'''
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
 )
 
 mixedTripletStepSeeds = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeeds.clone()

--- a/FastSimulation/Tracking/python/MixedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/MixedTripletStep_cff.py
@@ -17,17 +17,22 @@ mixedTripletStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.15,
-        maxD0 = 10.0,
-        maxZ0 = 30
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = -1
         ),
     minLayersCrossed = 3,
+layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
     #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
     ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.ptMin,
     originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originRadius,
     originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originHalfLength,
     layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value()
+'''
 )
 
 ###
@@ -39,12 +44,17 @@ mixedTripletStepSeedsB = FastSimulation.Tracking.TrajectorySeedProducer_cfi.traj
         maxZ0 = 30
         ),
     minLayersCrossed = 3,
-    #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
+layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),   
+ #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
     ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.ptMin,
     originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originRadius,
     originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originHalfLength,
     layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value()
+'''
 )
 
 mixedTripletStepSeeds = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeeds.clone()

--- a/FastSimulation/Tracking/python/PixelLessStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelLessStep_cff.py
@@ -17,17 +17,22 @@ pixelLessStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-       pTMin = 0.3,
+       pTMin = 0,
         maxD0 = -1,
         maxZ0 = -1
         ),
     minLayersCrossed = 3,
+layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
     #hitMasks = cms.InputTag("pixelLessStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("pixelLessStepMasks","hitCombinationMasks"),
     ptMin = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
     originHalfLength = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
     originRadius = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
     layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value()
+'''
 )
 
 # track candidates

--- a/FastSimulation/Tracking/python/PixelLessStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelLessStep_cff.py
@@ -24,15 +24,7 @@ pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajecto
     minLayersCrossed = 3,
 layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-    #hitMasks = cms.InputTag("pixelLessStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("pixelLessStepMasks","hitCombinationMasks"),
-    ptMin = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value()
-'''
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
 )
 
 # track candidates

--- a/FastSimulation/Tracking/python/PixelPairStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelPairStep_cff.py
@@ -24,15 +24,7 @@ pixelPairStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajecto
     minLayersCrossed = 2,
 layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-'''
-    nSigmaZ = 3,
-    #hitMasks = cms.InputTag("pixelPairStepMasks","hitMasks"),
-    hitCombinationMasks = cms.InputTag("pixelPairStepMasks","hitCombinationMasks"), 
-    ptMin = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value()
-'''
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
 )
 pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = cms.InputTag("firstStepPrimaryVerticesBeforeMixing")
 # track candidate 

--- a/FastSimulation/Tracking/python/PixelPairStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelPairStep_cff.py
@@ -17,19 +17,24 @@ pixelPairStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 pixelPairStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.3,
-        maxD0 = 5.0,
-        maxZ0 = 50
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = -1
         ),
     minLayersCrossed = 2,
+layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
+'''
     nSigmaZ = 3,
     #hitMasks = cms.InputTag("pixelPairStepMasks","hitMasks"),
     hitCombinationMasks = cms.InputTag("pixelPairStepMasks","hitCombinationMasks"), 
     ptMin = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
     originRadius = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
     layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value()
+'''
 )
-
+pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = cms.InputTag("firstStepPrimaryVerticesBeforeMixing")
 # track candidate 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 pixelPairStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(

--- a/FastSimulation/Tracking/python/TobTecStep_cff.py
+++ b/FastSimulation/Tracking/python/TobTecStep_cff.py
@@ -2,15 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 # import the full tracking equivalent of this file
 import RecoTracker.IterativeTracking.TobTecStep_cff
-                                                                                                                                                                                                                                                              
-# fast tracking mask producer 
-from FastSimulation.Tracking.FastTrackingMaskProducer_cfi import fastTrackingMaskProducer as _fastTrackingMaskProducer                                                   
-tobTecStepMasks = _fastTrackingMaskProducer.clone(                                                                                                                                                                                                 
+ 
+from FastSimulation.Tracking.FastTrackingMaskProducer_cfi import fastTrackingMaskProducer as _fastTrackingMaskProducer                             
+
+
+tobTecStepMasks = _fastTrackingMaskProducer.clone(                                                                                                 
     trackCollection = cms.InputTag("pixelLessStepTracks"),
     TrackQuality = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepClusters.TrackQuality,
-    overrideTrkQuals = cms.InputTag('pixelLessStep',"QualityMasks"),  
+    overrideTrkQuals = cms.InputTag('pixelLessStep',"QualityMasks"),
     oldHitCombinationMasks = cms.InputTag("pixelLessStepMasks","hitCombinationMasks"),
     oldHitMasks = cms.InputTag("pixelLessStepMasks","hitMasks")
+
 )
 
 # trajectory seeds 
@@ -18,43 +20,42 @@ tobTecStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.3,
+#        pTMin = 0.3,
+ #       maxD0 = -1,
+  #      maxZ0 = -1
+        pTMin = 0,
         maxD0 = -1,
         maxZ0 = -1
     ),
     minLayersCrossed = 4,
-    #hitMasks = cms.InputTag("tobTecStepMasks","hitMasks"),
-    hitCombinationMasks = cms.InputTag("tobTecStepMasks","hitCombinationMasks"),
-    ptMin = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersTripl.layerList.value()
-)
+    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersTripl.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
+    )
 #pair seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 tobTecStepSeedsPair = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.3,
-        maxD0 = 99.0,
-        maxZ0 = 99
+  #      pTMin = 0.3,
+ #       maxD0 = 99.0,
+#        maxZ0 = 99
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = -1,
     ),
     minLayersCrossed = 4,
-    #hitMasks = cms.InputTag("tobTecStepMasks","hitMasks"),
-    hitCombinationMasks = cms.InputTag("tobTecStepMasks","hitCombinationMasks"),
-    ptMin = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersPair.layerList.value()
-)
+    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersPair.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
+    )
 #
 tobTecStepSeeds = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeeds.clone()
 
 # track candidate
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 tobTecStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    src = cms.InputTag("tobTecStepSeeds"),
+    SeedProducer = cms.InputTag("tobTecStepSeeds"),
     MinNumberOfCrossedLayers = 3
-    #hitMasks = cms.InputTag("tobTecStepMasks","hitMasks"),
 )
 
 # tracks 
@@ -77,10 +78,9 @@ tobTecStep = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStep.clone()
 # Final sequence 
 TobTecStep = cms.Sequence(tobTecStepMasks
                           +tobTecStepSeedsTripl
-                          +tobTecStepSeedsPair
-                          +tobTecStepSeeds
-                          +tobTecStepTrackCandidates
-                          +tobTecStepTracks
-                          +tobTecStepClassifier1*tobTecStepClassifier2
-                          +tobTecStep
-                      )
+                           +tobTecStepSeedsPair
+                           +tobTecStepSeeds
+                           +tobTecStepTrackCandidates
+                           +tobTecStepTracks
+                               +tobTecStepClassifier1*tobTecStepClassifier2                           +tobTecStep
+                       )

--- a/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
@@ -6,7 +6,7 @@ trackCandidateProducer = cms.EDProducer(
     # The smallest number of crossed layers to make a candidate
     MinNumberOfCrossedLayers = cms.uint32(5),
 
-    src = cms.InputTag("globalPixelSeeds"),
+    src = cms.InputTag("tobTecStepSeeds"),
 
     # Reject overlapping hits? (GroupedTracking from 170pre2 onwards)
     OverlapCleaning = cms.bool(False),

--- a/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
@@ -1,7 +1,7 @@
-*import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
-from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import 
+from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import *
 
 trajectorySeedProducer = cms.EDProducer("TrajectorySeedProducer",
                                         

--- a/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
@@ -1,4 +1,7 @@
-import FWCore.ParameterSet.Config as cms
+*import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
+from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import 
 
 trajectorySeedProducer = cms.EDProducer("TrajectorySeedProducer",
                                         
@@ -9,26 +12,27 @@ trajectorySeedProducer = cms.EDProducer("TrajectorySeedProducer",
          #skipSimTrackIds = cms.VInputTag(),
          maxZ0 = cms.double(-1),
          maxD0 = cms.double(-1),
-    ),
-    # minimum number of layer crossed (with hits on them) by the simtrack
-    minLayersCrossed = cms.uint32(0),
-    
-    #if empty, BS compatibility is skipped
-    beamSpot = cms.InputTag("offlineBeamSpot"),
-    #if empty, PV compatibility is skipped
-    primaryVertex = cms.InputTag(""),
-    
-    nSigmaZ = cms.double(-1),
-    originHalfLength= cms.double(-1),
-    
-    originRadius = cms.double(-1),
-    ptMin = cms.double(-1),
-
-    # Inputs: tracker rechits, beam spot position.
-    recHits = cms.InputTag("siTrackerGaussianSmearingRecHits"),
-    #hitMasks = cms.InputTag("hitMasks"),
-    #hitCombinationMasks = cms.InputTag("hitCombinationMasks"),
-        
-    layerList = cms.vstring(),
-)
+         ),
+                                        SeedCreatorPSet = cms.PSet(SeedFromConsecutiveHitsCreator.clone(TTRHBuilder = cms.string("WithoutRefit"))),
+                                        # minimum number of layer crossed (with hits on them) by the simtrack
+                                        minLayersCrossed = cms.uint32(0),
+                                        
+                                        #if empty, BS compatibility is skipped
+                                        beamSpot = cms.InputTag("offlineBeamSpot"),
+                                        #if empty, PV compatibility is skipped
+                                        primaryVertex = cms.InputTag(""),
+                                        
+                                        nSigmaZ = cms.double(-1),
+                                        originHalfLength= cms.double(-1),
+                                        
+                                        originRadius = cms.double(-1),
+                                        ptMin = cms.double(-1),
+                                        
+                                        # Inputs: tracker rechits, beam spot position.
+                                        recHits = cms.InputTag("siTrackerGaussianSmearingRecHits"),
+                                        #hitMasks = cms.InputTag("hitMasks"),
+                                        #hitCombinationMasks = cms.InputTag("hitCombinationMasks"),
+                                        
+                                        layerList = cms.vstring(),
+                                        )
 

--- a/FastSimulation/Tracking/python/iterativeTk_cff.py
+++ b/FastSimulation/Tracking/python/iterativeTk_cff.py
@@ -4,7 +4,7 @@
 ##############################
 
 import FWCore.ParameterSet.Config as cms
-
+from TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff import *
 from FastSimulation.Tracking.InitialStep_cff import *
 from FastSimulation.Tracking.DetachedTripletStep_cff import *
 from FastSimulation.Tracking.LowPtTripletStep_cff import *

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
-    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
+    ("DQM_CMSSW_7_6_X_2015-07-31-2300_AfterSeedStateBackPropagation.root", "Changed_FastSim_7_6_X_AfterSeedStateBackPropagation"),
+    ("DQM_V0001_R000000001__RelValTTbar_13__CMSSW_7_5_0_pre3-MCRUN2_74_V7_FastSim-v1__DQMIO.root", "StandardFastSim_7_5_0_pre3"),
 ]
 
 outputDir = "plots"

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_1.root", "DQM 1 details"),
-    ("DQM_2.root", "DQM 2 details"),
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
 ]
 
 outputDir = "plots"

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_CMSSW_7_6_X_2015-07-31-2300_AfterSeedStateBackPropagation.root", "Changed_FastSim_7_6_X_AfterSeedStateBackPropagation"),
-    ("DQM_V0001_R000000001__RelValTTbar_13__CMSSW_7_5_0_pre3-MCRUN2_74_V7_FastSim-v1__DQMIO.root", "StandardFastSim_7_5_0_pre3"),
+    ("DQM_1.root", "DQM 1 details"),
+    ("DQM_2.root", "DQM 2 details"),
 ]
 
 outputDir = "plots"


### PR DESCRIPTION
Got rid of all direct sim-info for creating seed and tracks. Instead fullsim global region and seed creator is used to create seeds. Moreover, track candidates are now initialized using back propagated seed state and not sim-track and sim-vertex information.
