### PR TITLE
No direct sim info for seed and track now

### DIFF
--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -85,7 +85,7 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   edm::ESHandle<Propagator>             propagator;
   es.get<TrackingComponentsRecord>().get(propagatorLabel,propagator);
-  Propagator* thePropagator = propagator.product()->clone();
+  //  Propagator* thePropagator = propagator.product()->clone();
 
   // get products
   edm::Handle<edm::View<TrajectorySeed> > seeds;
@@ -182,8 +182,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     //---------------------------------------------------------------------------------------------------------
     //backPropagate seedState to front recHit and get a new initial TSOS at front recHit//---------------------
     const GeomDet* initialLayer = trackerGeometry->idToDet(trackRecHits.front().geographicalId());
-    thePropagator->setPropagationDirection(oppositeToMomentum);
-    const TrajectoryStateOnSurface initialTSOS = thePropagator->propagate(seedTSOS,initialLayer->surface()) ;
+    //thePropagator->setPropagationDirection(oppositeToMomentum);
+    const TrajectoryStateOnSurface initialTSOS = propagator->propagate(seedTSOS,initialLayer->surface()) ;
     //---------------------------------------------------------------------------------------------------------
     //Check if the TSOS is valid .
     if (!initialTSOS.isValid()) continue; 

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -9,8 +9,8 @@
 #include "DataFormats/Common/interface/OwnVector.h"
 #include "DataFormats/TrackCandidate/interface/TrackCandidateCollection.h"
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
-#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2DCollection.h" 
-#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2DCollection.h" 
+#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2DCollection.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 #include "DataFormats/TrackReco/interface/TrackExtraFwd.h"
 
@@ -41,10 +41,10 @@
 #include "TrackingTools/MaterialEffects/interface/PropagatorWithMaterial.h"
 
 TrackCandidateProducer::TrackCandidateProducer(const edm::ParameterSet& conf)
-{  
+{
   // products
   produces<TrackCandidateCollection>();
-  
+
   // general parameters
   minNumberOfCrossedLayers = conf.getParameter<unsigned int>("MinNumberOfCrossedLayers");
   rejectOverlaps = conf.getParameter<bool>("OverlapCleaning");
@@ -66,12 +66,12 @@ TrackCandidateProducer::TrackCandidateProducer(const edm::ParameterSet& conf)
 
   edm::InputTag recHitLabel = conf.getParameter<edm::InputTag>("recHits");
   recHitToken = consumes<FastTMRecHitCombinations>(recHitLabel);
-  
+
   propagatorLabel = conf.getParameter<std::string>("propagator");
 }
-  
-void 
-TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {        
+
+void
+TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   // get services
   edm::ESHandle<MagneticField>          magneticField;
@@ -107,13 +107,13 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     edm::Handle<std::vector<bool> > hitMasks;
     e.getByToken(hitMasksToken,hitMasks);
   }
-  
+
   // output collection
-  std::auto_ptr<TrackCandidateCollection> output(new TrackCandidateCollection);    
+  std::auto_ptr<TrackCandidateCollection> output(new TrackCandidateCollection);
 
   // loop over the seeds
   for (unsigned seednr = 0; seednr < seeds->size(); ++seednr){
-    
+
     const BasicTrajectorySeed seed = seeds->at(seednr);
     if(seed.nHits()==0){
       edm::LogError("TrackCandidateProducer") << "empty trajectory seed in TrajectorySeedCollection" << std::endl;
@@ -127,11 +127,11 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     // Count number of crossed layers, apply overlap rejection
     std::vector<TrajectorySeedHitCandidate> recHitCandidates;
     TrajectorySeedHitCandidate recHitCandidate;
-    unsigned numberOfCrossedLayers = 0;      
+    unsigned numberOfCrossedLayers = 0;
     for (const auto & _hit : recHitCombination) {
 
       if(hitMasks_exists
-	 && size_t(_hit.id()) < hitMasks->size() 
+	 && size_t(_hit.id()) < hitMasks->size()
 	 && hitMasks->at(_hit.id()))
 	{
 	  continue;
@@ -172,7 +172,7 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       LogDebug("FastTracking")<<"reversing the order of the hits";
       std::reverse(recHitCandidates.begin(),recHitCandidates.end());
     }
-    
+
     // create track candidate
 
     //Get seedTSOS from seed PTSOD//---------------------------------------------------------------------------
@@ -186,15 +186,15 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
     const TrajectoryStateOnSurface initialTSOS = propagator->propagate(seedTSOS,initialLayer->surface()) ;
     //---------------------------------------------------------------------------------------------------------
     //Check if the TSOS is valid .
-    if (!initialTSOS.isValid()) continue; 
-    PTrajectoryStateOnDet PTSOD = trajectoryStateTransform::persistentState(initialTSOS,trackRecHits.front().geographicalId().rawId()); 
+    if (!initialTSOS.isValid()) continue;
+    PTrajectoryStateOnDet PTSOD = trajectoryStateTransform::persistentState(initialTSOS,trackRecHits.front().geographicalId().rawId());
     TrackCandidate newTrackCandidate(trackRecHits,seed,PTSOD,edm::RefToBase<TrajectorySeed>(seeds,seednr));
 
     // add track candidate to output collection
     output->push_back(newTrackCandidate);
-    
+
   }
-  
+
   // Save the track candidates
   e.put(output);
 }

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.cc
@@ -85,7 +85,8 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
 
   edm::ESHandle<Propagator>             propagator;
   es.get<TrackingComponentsRecord>().get(propagatorLabel,propagator);
-    
+  Propagator* thePropagator = propagator.product()->clone();
+
   // get products
   edm::Handle<edm::View<TrajectorySeed> > seeds;
   e.getByToken(seedToken,seeds);
@@ -172,24 +173,19 @@ TrackCandidateProducer::produce(edm::Event& e, const edm::EventSetup& es) {
       std::reverse(recHitCandidates.begin(),recHitCandidates.end());
     }
     
-    // initial track candidate parameters parameters
-    int32_t simTrackId = recHitCombination.back().simTrackId(0);
-    int vertexIndex = simTracks->at(simTrackId).vertIndex();
-    GlobalPoint  position(simVertices->at(vertexIndex).position().x(),
-			  simVertices->at(vertexIndex).position().y(),
-			  simVertices->at(vertexIndex).position().z());
-    GlobalVector momentum( simTracks->at(simTrackId).momentum().x() , 
-			   simTracks->at(simTrackId).momentum().y() , 
-			   simTracks->at(simTrackId).momentum().z() );
-    float        charge   = simTracks->at(simTrackId).charge();
-    GlobalTrajectoryParameters initialParams(position,momentum,(int)charge,magneticField.product());
-    AlgebraicSymMatrix55 errorMatrix= AlgebraicMatrixID();    
-    CurvilinearTrajectoryError initialError(errorMatrix);
-    FreeTrajectoryState initialFTS(initialParams, initialError);      
-
     // create track candidate
+
+    //Get seedTSOS from seed PTSOD//---------------------------------------------------------------------------
+    DetId seedDetId(seed.startingState().detId());
+    const GeomDet* gdet = trackerGeometry->idToDet(seedDetId);
+    TrajectoryStateOnSurface seedTSOS = trajectoryStateTransform::transientState(seed.startingState(), &(gdet->surface()),magneticField.product());
+    //---------------------------------------------------------------------------------------------------------
+    //backPropagate seedState to front recHit and get a new initial TSOS at front recHit//---------------------
     const GeomDet* initialLayer = trackerGeometry->idToDet(trackRecHits.front().geographicalId());
-    const TrajectoryStateOnSurface initialTSOS = propagator->propagate(initialFTS,initialLayer->surface()) ;
+    thePropagator->setPropagationDirection(oppositeToMomentum);
+    const TrajectoryStateOnSurface initialTSOS = thePropagator->propagate(seedTSOS,initialLayer->surface()) ;
+    //---------------------------------------------------------------------------------------------------------
+    //Check if the TSOS is valid .
     if (!initialTSOS.isValid()) continue; 
     PTrajectoryStateOnDet PTSOD = trajectoryStateTransform::persistentState(initialTSOS,trackRecHits.front().geographicalId().rawId()); 
     TrackCandidate newTrackCandidate(trackRecHits,seed,PTSOD,edm::RefToBase<TrajectorySeed>(seeds,seednr));

--- a/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
+++ b/FastSimulation/Tracking/plugins/TrackCandidateProducer.h
@@ -18,13 +18,13 @@ class TrackerGeometry;
 class TrajectoryStateOnSurface;
 class PropagatorWithMaterial;
 
-namespace edm { 
+namespace edm {
   class ParameterSet;
   class Event;
   class EventSetup;
 }
 
-namespace reco { 
+namespace reco {
   class Track;
 }
 
@@ -36,13 +36,13 @@ class TrackingRecHit;
 class TrackCandidateProducer : public edm::stream::EDProducer <>
 {
  public:
-  
+
   explicit TrackCandidateProducer(const edm::ParameterSet& conf);
-  
+
   virtual ~TrackCandidateProducer(){;}
-  
+
   virtual void produce(edm::Event& e, const edm::EventSetup& es) override;
-  
+
  private:
 
   unsigned int minNumberOfCrossedLayers;
@@ -51,7 +51,7 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   bool rejectOverlaps;
   bool splitHits;
   bool hitMasks_exists;
- 
+
   edm::InputTag simTracks_;
 
   // tokens & labels
@@ -61,7 +61,7 @@ class TrackCandidateProducer : public edm::stream::EDProducer <>
   edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
   edm::EDGetTokenT<std::vector<bool> > hitMasksToken;
   std::string propagatorLabel;
-  
+
 };
 
 #endif

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -52,13 +52,6 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
     theRegionProducer(nullptr)
 {
 
-  /*
-    testBeamspotCompatibility(false),
-    beamSpot(nullptr),
-    testPrimaryVertexCompatibility(false),
-    primaryVertices(nullptr)
-    {  */
-
     // The name of the TrajectorySeed Collection
     produces<TrajectorySeedCollection>();
     //Regions regions;
@@ -75,11 +68,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
       edm::InputTag hitCombinationMasksTag = conf.getParameter<edm::InputTag> ("hitCombinationMasks");   
       hitCombinationMasksToken = consumes<std::vector<bool> >(hitCombinationMasksTag);
     }
-    /*
-    std::vector<edm::InputTag> skipSimTrackTags = simTrackSelectionConfig.getParameter<std::vector<edm::InputTag> >("skipSimTrackIds");
-    for ( unsigned int k=0; k<skipSimTrackTags.size(); ++k){
-      skipSimTrackIdTokens.push_back(consumes<std::vector<unsigned int> >(skipSimTrackTags[k]));}
-    */
+
     // The smallest number of hits for a track candidate
     minLayersCrossed = conf.getParameter<unsigned int>("minLayersCrossed");
 
@@ -273,14 +262,6 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
   }
 
     
-    // SimTracks and SimVertices
-  /*
-    edm::Handle<edm::SimTrackContainer> theSimTracks;
-    e.getByToken(simTrackToken,theSimTracks);
-    
-    edm::Handle<edm::SimVertexContainer> theSimVtx;
-    e.getByToken(simVertexToken,theSimVtx);
-  */
     edm::Handle<FastTMRecHitCombinations> recHitCombinations;
     e.getByToken(recHitTokens, recHitCombinations);
 
@@ -362,18 +343,18 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
 
 bool
   TrajectorySeedProducer::testWithRegions(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const{
-  //std::cout<<"Inside:testWithRegions1"<<std::endl;
+  
   const DetLayer * innerLayer = measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(innerHit.hit()->det()->geographicalId());
   const DetLayer * outerLayer = measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(outerHit.hit()->det()->geographicalId());
   typedef PixelRecoRange<float> Range;
-  //std::cout<<"Inside:testWithRegions1"<<std::endl;
+  
   for(Regions::const_iterator ir=regions.begin(); ir < regions.end(); ++ir){
-    //std::cout<<"Inside:testWithRegions1"<<std::endl;
+    
     auto const & gs = outerHit.hit()->globalState();
     auto loc = gs.position-(*ir)->origin().basicVector();
     const HitRZCompatibility * checkRZ = (*ir)->checkRZ(innerLayer, outerHit.hit(), *es_, outerLayer,
 							loc.perp(),gs.position.z(),gs.errorR,gs.errorZ);
-    //std::cout<<"Inside:testWithRegions1"<<std::endl;
+    
     float u = innerLayer->isBarrel() ? loc.perp() : gs.position.z();
     float v = innerLayer->isBarrel() ? gs.position.z() : loc.perp();
     float dv = innerLayer->isBarrel() ? gs.errorZ : gs.errorR;
@@ -382,18 +363,15 @@ bool
     float vErr = nSigmaRZ * dv;
     Range hitRZ(v-vErr, v+vErr);
     Range crossRange = allowed.intersection(hitRZ);
-    //std::cout<<"Inside:testWithRegions1"<<std::endl;
+    
     if( ! crossRange.empty()){
-      //std::cout<<"Inside:testWithRegions1"<<std::endl;
       std::cout << "init seed creator"<< std::endl;
       std::cout << "ptmin: " << (**ir).ptMin() << std::endl;
       std::cout << "" << std::endl;
       seedCreator->init(**ir,*es_,0);
       std::cout << "done" << std::endl;
       return true;}
-    //std::cout<<"Line485"<<std::endl;
-    //seedCreator->init(**ir,*es_,0);
-    //std::cout<<"Line487"<<std::endl;  
+    
   }
   return false;
 }

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -97,6 +97,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
         _seedingTree.insert(trackingLayerList);
         seedingLayers.push_back(std::move(trackingLayerList));
     }
+    if(conf.exists("RegionFactoryPSet")){
       edm::ParameterSet regfactoryPSet = conf.getParameter<edm::ParameterSet>("RegionFactoryPSet");
       std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
       theRegionProducer.reset(TrackingRegionProducerFactory::get()->create(regfactoryName,regfactoryPSet, consumesCollector()));
@@ -104,6 +105,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
       const edm::ParameterSet & seedCreatorPSet = conf.getParameter<edm::ParameterSet>("SeedCreatorPSet");
       std::string seedCreatorName = seedCreatorPSet.getParameter<std::string>("ComponentName");
       seedCreator.reset(SeedCreatorFactory::get()->create( seedCreatorName, seedCreatorPSet));
+    }
 }
 void
 TrajectorySeedProducer::beginRun(edm::Run const&, const edm::EventSetup & es) 

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -62,12 +62,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
     // The name of the TrajectorySeed Collection
     produces<TrajectorySeedCollection>();
     //Regions regions;
-    const edm::ParameterSet& simTrackSelectionConfig = conf.getParameter<edm::ParameterSet>("simTrackSelection");
-    // The smallest pT,dxy,dz for a simtrack
-    simTrack_pTMin = simTrackSelectionConfig.getParameter<double>("pTMin");
-    simTrack_maxD0 = simTrackSelectionConfig.getParameter<double>("maxD0");
-    simTrack_maxZ0 = simTrackSelectionConfig.getParameter<double>("maxZ0");
-
+    
 
     hitMasks_exists = conf.exists("hitMasks");
     if (hitMasks_exists){

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -1,4 +1,3 @@
-
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
@@ -45,126 +44,126 @@ template class SeedingTree<TrackingLayer>;
 template class SeedingNode<TrackingLayer>;
 
 TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
-    magneticField(nullptr),
-    magneticFieldMap(nullptr),
-    trackerGeometry(nullptr),
-    trackerTopology(nullptr),
-    theRegionProducer(nullptr)
+  magneticField(nullptr),
+  magneticFieldMap(nullptr),
+  trackerGeometry(nullptr),
+  trackerTopology(nullptr),
+  theRegionProducer(nullptr)
 {
 
-    // The name of the TrajectorySeed Collection
-    produces<TrajectorySeedCollection>();
-    //Regions regions;
+  // The name of the TrajectorySeed Collection
+  produces<TrajectorySeedCollection>();
+  //Regions regions;
 
 
-    hitMasks_exists = conf.exists("hitMasks");
-    if (hitMasks_exists){
-      edm::InputTag hitMasksTag = conf.getParameter<edm::InputTag>("hitMasks");
-      hitMasksToken = consumes<std::vector<bool> >(hitMasksTag);
-    }
+  hitMasks_exists = conf.exists("hitMasks");
+  if (hitMasks_exists){
+    edm::InputTag hitMasksTag = conf.getParameter<edm::InputTag>("hitMasks");
+    hitMasksToken = consumes<std::vector<bool> >(hitMasksTag);
+  }
 
-    hitCombinationMasks_exists = conf.exists("hitCombinationMasks");
-    if (hitCombinationMasks_exists){
-      edm::InputTag hitCombinationMasksTag = conf.getParameter<edm::InputTag> ("hitCombinationMasks");
-      hitCombinationMasksToken = consumes<std::vector<bool> >(hitCombinationMasksTag);
-    }
+  hitCombinationMasks_exists = conf.exists("hitCombinationMasks");
+  if (hitCombinationMasks_exists){
+    edm::InputTag hitCombinationMasksTag = conf.getParameter<edm::InputTag> ("hitCombinationMasks");
+    hitCombinationMasksToken = consumes<std::vector<bool> >(hitCombinationMasksTag);
+  }
 
-    // The smallest number of hits for a track candidate
-    minLayersCrossed = conf.getParameter<unsigned int>("minLayersCrossed");
+  // The smallest number of hits for a track candidate
+  minLayersCrossed = conf.getParameter<unsigned int>("minLayersCrossed");
 
-    edm::InputTag beamSpotTag = conf.getParameter<edm::InputTag>("beamSpot");
+  edm::InputTag beamSpotTag = conf.getParameter<edm::InputTag>("beamSpot");
 
-    // The name of the hit producer
-    edm::InputTag recHitTag = conf.getParameter<edm::InputTag>("recHits");
-    recHitTokens = consumes<FastTMRecHitCombinations>(recHitTag);
+  // The name of the hit producer
+  edm::InputTag recHitTag = conf.getParameter<edm::InputTag>("recHits");
+  recHitTokens = consumes<FastTMRecHitCombinations>(recHitTag);
 
-    // read Layers
-    std::vector<std::string> layerStringList = conf.getParameter<std::vector<std::string>>("layerList");
-    for(auto it=layerStringList.cbegin(); it < layerStringList.cend(); ++it)
+  // read Layers
+  std::vector<std::string> layerStringList = conf.getParameter<std::vector<std::string>>("layerList");
+  for(auto it=layerStringList.cbegin(); it < layerStringList.cend(); ++it)
     {
-	std::vector<TrackingLayer> trackingLayerList;
-	std::string line = *it;
-	std::string::size_type pos=0;
-	while (pos != std::string::npos)
+      std::vector<TrackingLayer> trackingLayerList;
+      std::string line = *it;
+      std::string::size_type pos=0;
+      while (pos != std::string::npos)
 	{
-	    pos=line.find("+");
-	    std::string layer = line.substr(0, pos);
-	    TrackingLayer layerSpec = TrackingLayer::createFromString(layer);
+	  pos=line.find("+");
+	  std::string layer = line.substr(0, pos);
+	  TrackingLayer layerSpec = TrackingLayer::createFromString(layer);
 
-	    trackingLayerList.push_back(layerSpec);
-	    line=line.substr(pos+1,std::string::npos);
+	  trackingLayerList.push_back(layerSpec);
+	  line=line.substr(pos+1,std::string::npos);
 	}
-	_seedingTree.insert(trackingLayerList);
-	seedingLayers.push_back(std::move(trackingLayerList));
+      _seedingTree.insert(trackingLayerList);
+      seedingLayers.push_back(std::move(trackingLayerList));
     }
-    if(conf.exists("RegionFactoryPSet")){
-      edm::ParameterSet regfactoryPSet = conf.getParameter<edm::ParameterSet>("RegionFactoryPSet");
-      std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
-      theRegionProducer.reset(TrackingRegionProducerFactory::get()->create(regfactoryName,regfactoryPSet, consumesCollector()));
-      measurementTrackerEventToken = consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"));
-      const edm::ParameterSet & seedCreatorPSet = conf.getParameter<edm::ParameterSet>("SeedCreatorPSet");
-      std::string seedCreatorName = seedCreatorPSet.getParameter<std::string>("ComponentName");
-      seedCreator.reset(SeedCreatorFactory::get()->create( seedCreatorName, seedCreatorPSet));
-    }
+  if(conf.exists("RegionFactoryPSet")){
+    edm::ParameterSet regfactoryPSet = conf.getParameter<edm::ParameterSet>("RegionFactoryPSet");
+    std::string regfactoryName = regfactoryPSet.getParameter<std::string>("ComponentName");
+    theRegionProducer.reset(TrackingRegionProducerFactory::get()->create(regfactoryName,regfactoryPSet, consumesCollector()));
+    measurementTrackerEventToken = consumes<MeasurementTrackerEvent>(conf.getParameter<edm::InputTag>("MeasurementTrackerEvent"));
+    const edm::ParameterSet & seedCreatorPSet = conf.getParameter<edm::ParameterSet>("SeedCreatorPSet");
+    std::string seedCreatorName = seedCreatorPSet.getParameter<std::string>("ComponentName");
+    seedCreator.reset(SeedCreatorFactory::get()->create( seedCreatorName, seedCreatorPSet));
+  }
 }
 void
 TrajectorySeedProducer::beginRun(edm::Run const&, const edm::EventSetup & es)
 {
-    edm::ESHandle<MagneticField> magneticFieldHandle;
-    edm::ESHandle<TrackerGeometry> trackerGeometryHandle;
-    edm::ESHandle<MagneticFieldMap> magneticFieldMapHandle;
-    edm::ESHandle<TrackerTopology> trackerTopologyHandle;
+  edm::ESHandle<MagneticField> magneticFieldHandle;
+  edm::ESHandle<TrackerGeometry> trackerGeometryHandle;
+  edm::ESHandle<MagneticFieldMap> magneticFieldMapHandle;
+  edm::ESHandle<TrackerTopology> trackerTopologyHandle;
 
-    es.get<IdealMagneticFieldRecord>().get(magneticFieldHandle);
-    es.get<TrackerDigiGeometryRecord>().get(trackerGeometryHandle);
-    es.get<MagneticFieldMapRecord>().get(magneticFieldMapHandle);
-    es.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
+  es.get<IdealMagneticFieldRecord>().get(magneticFieldHandle);
+  es.get<TrackerDigiGeometryRecord>().get(trackerGeometryHandle);
+  es.get<MagneticFieldMapRecord>().get(magneticFieldMapHandle);
+  es.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
 
-    magneticField = &(*magneticFieldHandle);
-    trackerGeometry = &(*trackerGeometryHandle);
-    magneticFieldMap = &(*magneticFieldMapHandle);
-    trackerTopology = &(*trackerTopologyHandle);
+  magneticField = &(*magneticFieldHandle);
+  trackerGeometry = &(*trackerGeometryHandle);
+  magneticFieldMap = &(*magneticFieldMapHandle);
+  trackerTopology = &(*trackerTopologyHandle);
 
-    thePropagator = std::make_shared<PropagatorWithMaterial>(alongMomentum,0.105,magneticField);
+  thePropagator = std::make_shared<PropagatorWithMaterial>(alongMomentum,0.105,magneticField);
 }
 
 bool
 TrajectorySeedProducer::pass2HitsCuts(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const
 {
   if(theRegionProducer){
-  const DetLayer * innerLayer =
-    measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(innerHit.hit()->det()->geographicalId());
-  const DetLayer * outerLayer =
-    measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(outerHit.hit()->det()->geographicalId());
+    const DetLayer * innerLayer =
+      measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(innerHit.hit()->det()->geographicalId());
+    const DetLayer * outerLayer =
+      measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(outerHit.hit()->det()->geographicalId());
 
-typedef PixelRecoRange<float> Range;
+    typedef PixelRecoRange<float> Range;
 
-  for(Regions::const_iterator ir=regions.begin(); ir < regions.end(); ++ir){
+    for(Regions::const_iterator ir=regions.begin(); ir < regions.end(); ++ir){
 
-    auto const & gs = outerHit.hit()->globalState();
-    auto loc = gs.position-(*ir)->origin().basicVector();
-    const HitRZCompatibility * checkRZ = (*ir)->checkRZ(innerLayer, outerHit.hit(), *es_, outerLayer,
-							loc.perp(),gs.position.z(),gs.errorR,gs.errorZ);
+      auto const & gs = outerHit.hit()->globalState();
+      auto loc = gs.position-(*ir)->origin().basicVector();
+      const HitRZCompatibility * checkRZ = (*ir)->checkRZ(innerLayer, outerHit.hit(), *es_, outerLayer,
+							  loc.perp(),gs.position.z(),gs.errorR,gs.errorZ);
 
-    float u = innerLayer->isBarrel() ? loc.perp() : gs.position.z();
-    float v = innerLayer->isBarrel() ? gs.position.z() : loc.perp();
-    float dv = innerLayer->isBarrel() ? gs.errorZ : gs.errorR;
-    constexpr float nSigmaRZ = 3.46410161514f;
-    Range allowed = checkRZ->range(u);
-    float vErr = nSigmaRZ * dv;
-    Range hitRZ(v-vErr, v+vErr);
-    Range crossRange = allowed.intersection(hitRZ);
+      float u = innerLayer->isBarrel() ? loc.perp() : gs.position.z();
+      float v = innerLayer->isBarrel() ? gs.position.z() : loc.perp();
+      float dv = innerLayer->isBarrel() ? gs.errorZ : gs.errorR;
+      constexpr float nSigmaRZ = 3.46410161514f;
+      Range allowed = checkRZ->range(u);
+      float vErr = nSigmaRZ * dv;
+      Range hitRZ(v-vErr, v+vErr);
+      Range crossRange = allowed.intersection(hitRZ);
 
-    if( ! crossRange.empty()){
-      std::cout << "init seed creator"<< std::endl;
-      std::cout << "ptmin: " << (**ir).ptMin() << std::endl;
-      std::cout << "" << std::endl;
-      seedCreator->init(**ir,*es_,0);
-      std::cout << "done" << std::endl;
-      return true;}
+      if( ! crossRange.empty()){
+	std::cout << "init seed creator"<< std::endl;
+	std::cout << "ptmin: " << (**ir).ptMin() << std::endl;
+	std::cout << "" << std::endl;
+	seedCreator->init(**ir,*es_,0);
+	std::cout << "done" << std::endl;
+	return true;}
 
-  }
-  return false;
+    }
+    return false;
   }
   else
     {
@@ -211,7 +210,7 @@ const SeedingNode<TrackingLayer>* TrajectorySeedProducer::insertHit(
 	    }
 	}
     }
-    return nullptr;
+  return nullptr;
 }
 
 
@@ -293,24 +292,24 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
   }
 
 
-    edm::Handle<FastTMRecHitCombinations> recHitCombinations;
-    e.getByToken(recHitTokens, recHitCombinations);
+  edm::Handle<FastTMRecHitCombinations> recHitCombinations;
+  e.getByToken(recHitTokens, recHitCombinations);
 
-    std::auto_ptr<TrajectorySeedCollection> output{new TrajectorySeedCollection()};
+  std::auto_ptr<TrajectorySeedCollection> output{new TrajectorySeedCollection()};
 
-    for ( unsigned icomb=0; icomb<recHitCombinations->size(); ++icomb)
-      {
-	if(hitCombinationMasks_exists
-	   && icomb < hitCombinationMasks->size()
-	   && hitCombinationMasks->at(icomb))	    {
-	  continue;
-	}
+  for ( unsigned icomb=0; icomb<recHitCombinations->size(); ++icomb)
+    {
+      if(hitCombinationMasks_exists
+	 && icomb < hitCombinationMasks->size()
+	 && hitCombinationMasks->at(icomb))	    {
+	continue;
+      }
 
-	FastTMRecHitCombination recHitCombination = recHitCombinations->at(icomb);
+      FastTMRecHitCombination recHitCombination = recHitCombinations->at(icomb);
 
-	TrajectorySeedHitCandidate previousTrackerHit;
-	TrajectorySeedHitCandidate currentTrackerHit;
-	unsigned int layersCrossed=0;
+      TrajectorySeedHitCandidate previousTrackerHit;
+      TrajectorySeedHitCandidate currentTrackerHit;
+      unsigned int layersCrossed=0;
 
 
       std::vector<TrajectorySeedHitCandidate> trackerRecHits;
@@ -368,6 +367,6 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
 
       std::vector<unsigned int> seedHitNumbers = iterateHits(0,trackerRecHits,hitIndicesInTree,true);
       if (seedHitNumbers.size()>0){seedCreator->makeSeed(*output,SeedingHitSet(trackerRecHits[seedHitNumbers[0]].hit(),trackerRecHits[seedHitNumbers[1]].hit(),seedHitNumbers.size()>=3?trackerRecHits[seedHitNumbers[2]].hit():nullptr,seedHitNumbers.size()>=4?trackerRecHits[seedHitNumbers[3]].hit():nullptr));}
-      }//end loop over simtracks
-    e.put(output);
+    }//end loop over simtracks
+  e.put(output);
 }

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.cc
@@ -55,17 +55,17 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
     // The name of the TrajectorySeed Collection
     produces<TrajectorySeedCollection>();
     //Regions regions;
-    
+
 
     hitMasks_exists = conf.exists("hitMasks");
     if (hitMasks_exists){
-      edm::InputTag hitMasksTag = conf.getParameter<edm::InputTag>("hitMasks");   
+      edm::InputTag hitMasksTag = conf.getParameter<edm::InputTag>("hitMasks");
       hitMasksToken = consumes<std::vector<bool> >(hitMasksTag);
     }
-    
+
     hitCombinationMasks_exists = conf.exists("hitCombinationMasks");
     if (hitCombinationMasks_exists){
-      edm::InputTag hitCombinationMasksTag = conf.getParameter<edm::InputTag> ("hitCombinationMasks");   
+      edm::InputTag hitCombinationMasksTag = conf.getParameter<edm::InputTag> ("hitCombinationMasks");
       hitCombinationMasksToken = consumes<std::vector<bool> >(hitCombinationMasksTag);
     }
 
@@ -73,29 +73,29 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
     minLayersCrossed = conf.getParameter<unsigned int>("minLayersCrossed");
 
     edm::InputTag beamSpotTag = conf.getParameter<edm::InputTag>("beamSpot");
-    
+
     // The name of the hit producer
     edm::InputTag recHitTag = conf.getParameter<edm::InputTag>("recHits");
     recHitTokens = consumes<FastTMRecHitCombinations>(recHitTag);
 
     // read Layers
     std::vector<std::string> layerStringList = conf.getParameter<std::vector<std::string>>("layerList");
-    for(auto it=layerStringList.cbegin(); it < layerStringList.cend(); ++it) 
+    for(auto it=layerStringList.cbegin(); it < layerStringList.cend(); ++it)
     {
-        std::vector<TrackingLayer> trackingLayerList;
-        std::string line = *it;
-        std::string::size_type pos=0;
-        while (pos != std::string::npos) 
-        {
-            pos=line.find("+");
-            std::string layer = line.substr(0, pos);
-            TrackingLayer layerSpec = TrackingLayer::createFromString(layer);
+	std::vector<TrackingLayer> trackingLayerList;
+	std::string line = *it;
+	std::string::size_type pos=0;
+	while (pos != std::string::npos)
+	{
+	    pos=line.find("+");
+	    std::string layer = line.substr(0, pos);
+	    TrackingLayer layerSpec = TrackingLayer::createFromString(layer);
 
-            trackingLayerList.push_back(layerSpec);
-            line=line.substr(pos+1,std::string::npos); 
-        }
-        _seedingTree.insert(trackingLayerList);
-        seedingLayers.push_back(std::move(trackingLayerList));
+	    trackingLayerList.push_back(layerSpec);
+	    line=line.substr(pos+1,std::string::npos);
+	}
+	_seedingTree.insert(trackingLayerList);
+	seedingLayers.push_back(std::move(trackingLayerList));
     }
     if(conf.exists("RegionFactoryPSet")){
       edm::ParameterSet regfactoryPSet = conf.getParameter<edm::ParameterSet>("RegionFactoryPSet");
@@ -108,7 +108,7 @@ TrajectorySeedProducer::TrajectorySeedProducer(const edm::ParameterSet& conf):
     }
 }
 void
-TrajectorySeedProducer::beginRun(edm::Run const&, const edm::EventSetup & es) 
+TrajectorySeedProducer::beginRun(edm::Run const&, const edm::EventSetup & es)
 {
     edm::ESHandle<MagneticField> magneticFieldHandle;
     edm::ESHandle<TrackerGeometry> trackerGeometryHandle;
@@ -119,7 +119,7 @@ TrajectorySeedProducer::beginRun(edm::Run const&, const edm::EventSetup & es)
     es.get<TrackerDigiGeometryRecord>().get(trackerGeometryHandle);
     es.get<MagneticFieldMapRecord>().get(magneticFieldMapHandle);
     es.get<TrackerTopologyRcd>().get(trackerTopologyHandle);
-    
+
     magneticField = &(*magneticFieldHandle);
     trackerGeometry = &(*trackerGeometryHandle);
     magneticFieldMap = &(*magneticFieldMapHandle);
@@ -132,11 +132,11 @@ bool
 TrajectorySeedProducer::pass2HitsCuts(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const
 {
   if(theRegionProducer){
-  const DetLayer * innerLayer = 
+  const DetLayer * innerLayer =
     measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(innerHit.hit()->det()->geographicalId());
-  const DetLayer * outerLayer = 
+  const DetLayer * outerLayer =
     measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(outerHit.hit()->det()->geographicalId());
-  
+
 typedef PixelRecoRange<float> Range;
 
   for(Regions::const_iterator ir=regions.begin(); ir < regions.end(); ++ir){
@@ -144,7 +144,7 @@ typedef PixelRecoRange<float> Range;
     auto const & gs = outerHit.hit()->globalState();
     auto loc = gs.position-(*ir)->origin().basicVector();
     const HitRZCompatibility * checkRZ = (*ir)->checkRZ(innerLayer, outerHit.hit(), *es_, outerLayer,
-                                                        loc.perp(),gs.position.z(),gs.errorR,gs.errorZ);
+							loc.perp(),gs.position.z(),gs.errorR,gs.errorZ);
 
     float u = innerLayer->isBarrel() ? loc.perp() : gs.position.z();
     float v = innerLayer->isBarrel() ? gs.position.z() : loc.perp();
@@ -182,34 +182,34 @@ const SeedingNode<TrackingLayer>* TrajectorySeedProducer::insertHit(
   if (!node->getParent() || hitIndicesInTree[node->getParent()->getIndex()]>=0)
     {
       if (hitIndicesInTree[node->getIndex()]<0)
-        {
+	{
 	  const TrajectorySeedHitCandidate& currentTrackerHit = trackerRecHits[trackerHit];
 	  if (!isHitOnLayer(currentTrackerHit,node->getData()))
-            {
+	    {
 	      return nullptr;
-            }
+	    }
 	  if (!passHitTuplesCuts(*node,trackerRecHits,hitIndicesInTree,currentTrackerHit))
-            {
+	    {
 	      return nullptr;
-            }
+	    }
 	  hitIndicesInTree[node->getIndex()]=trackerHit;
 	  if (node->getChildrenSize()==0)
-            {
+	    {
 	      return node;
-            }
+	    }
 	  return nullptr;
-        }
+	}
       else
-        {
+	{
 	  for (unsigned int ichild = 0; ichild<node->getChildrenSize(); ++ichild)
-            {
+	    {
 	      const SeedingNode<TrackingLayer>* seed = insertHit(trackerRecHits,hitIndicesInTree,node->getChild(ichild),trackerHit);
 	      if (seed)
-                {
+		{
 		  return seed;
-                }
-            }
-        }
+		}
+	    }
+	}
     }
     return nullptr;
 }
@@ -225,9 +225,9 @@ std::vector<unsigned int> TrajectorySeedProducer::iterateHits(
   for (unsigned int irecHit = start; irecHit<trackerRecHits.size(); ++irecHit)
     {
       unsigned int currentHitIndex=irecHit;
-      
+
       for (unsigned int inext=currentHitIndex+1; inext< trackerRecHits.size(); ++inext)
-        {
+	{
 	  //if multiple hits are on the same layer -> follow all possibilities by recusion
 	  if (trackerRecHits[currentHitIndex].getTrackingLayer()==trackerRecHits[inext].getTrackingLayer())
 	    {
@@ -243,18 +243,18 @@ std::vector<unsigned int> TrajectorySeedProducer::iterateHits(
 		  if (seedHits.size()>0)
 		    {
 		      return seedHits;
-                    }
-                }
-	      irecHit+=1; 
-            }
+		    }
+		}
+	      irecHit+=1;
+	    }
 	  else
 	    {
 	      break;
 	    }
-        }
-      
+	}
+
       processSkippedHits=true;
-      
+
       const SeedingNode<TrackingLayer>* seedNode = nullptr;
       for (unsigned int iroot=0; seedNode==nullptr && iroot<_seedingTree.numberOfRoots(); ++iroot)
 	{
@@ -270,63 +270,63 @@ std::vector<unsigned int> TrajectorySeedProducer::iterateHits(
 	    }
 	  return seedIndices;
 	}
-	
+
     }
-  
+
   return std::vector<unsigned int>();
-  
+
 }
 
-void 
-TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es) 
-{        
+void
+TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
+{
 
   // the tracks to be skipped
   edm::Handle<std::vector<bool> > hitMasks;
-  if (hitMasks_exists){  
+  if (hitMasks_exists){
     e.getByToken(hitMasksToken,hitMasks);
   }
 
   edm::Handle<std::vector<bool> > hitCombinationMasks;
-  if (hitCombinationMasks_exists){ 
-    e.getByToken(hitCombinationMasksToken,hitCombinationMasks);	
+  if (hitCombinationMasks_exists){
+    e.getByToken(hitCombinationMasksToken,hitCombinationMasks);
   }
 
-    
+
     edm::Handle<FastTMRecHitCombinations> recHitCombinations;
     e.getByToken(recHitTokens, recHitCombinations);
 
     std::auto_ptr<TrajectorySeedCollection> output{new TrajectorySeedCollection()};
-    
+
     for ( unsigned icomb=0; icomb<recHitCombinations->size(); ++icomb)
       {
 	if(hitCombinationMasks_exists
-	   && icomb < hitCombinationMasks->size() 
+	   && icomb < hitCombinationMasks->size()
 	   && hitCombinationMasks->at(icomb))	    {
 	  continue;
 	}
-	
+
 	FastTMRecHitCombination recHitCombination = recHitCombinations->at(icomb);
 
 	TrajectorySeedHitCandidate previousTrackerHit;
 	TrajectorySeedHitCandidate currentTrackerHit;
 	unsigned int layersCrossed=0;
-	
+
 
       std::vector<TrajectorySeedHitCandidate> trackerRecHits;
       for (const auto & _hit : recHitCombination )
 	{
 	  if(hitMasks_exists
-	     && size_t(_hit.id()) < hitMasks->size() 
+	     && size_t(_hit.id()) < hitMasks->size()
 	     && hitMasks->at(_hit.id()))
 	    {
 	      continue;
 	    }
-	  
+
 	  previousTrackerHit=currentTrackerHit;
-	  
+
 	  currentTrackerHit = TrajectorySeedHitCandidate(&_hit,trackerGeometry,trackerTopology);
-	  
+
 	  if (!currentTrackerHit.isOnTheSameLayer(previousTrackerHit))
 	    {
 	      ++layersCrossed;
@@ -337,12 +337,12 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
 	      trackerRecHits.push_back(std::move(currentTrackerHit));
 	    }
 	}
-      
+
       if ( layersCrossed < minLayersCrossed)
-        {
+	{
 	  continue;
-        }
-      
+	}
+
       std::vector<int> hitIndicesInTree(_seedingTree.numberOfNodes(),-1);
       //A SeedingNode is associated by its index to this list. The list stores the indices of the hits in 'trackerRecHits'
       /* example
@@ -353,7 +353,7 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
 	 index=  2:   --  -- [BPix3]     | hitIndicesInTree[2] (=4)  | trackerRecHits[4]
 	 index=  3:   --  -- [FPix1_pos] | hitIndicesInTree[3] (=6)  | trackerRecHits[6]
 	 index=  4:   --  -- [FPix1_neg] | hitIndicesInTree[4] (=7)  | trackerRecHits[7]
-	 
+
 	 The implementation has been chosen such that the tree only needs to be build once upon construction.
       */
       //Regions regions;
@@ -371,39 +371,3 @@ TrajectorySeedProducer::produce(edm::Event& e, const edm::EventSetup& es)
       }//end loop over simtracks
     e.put(output);
 }
-/*
-bool
-  TrajectorySeedProducer::testWithRegions(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const{
-  
-  const DetLayer * innerLayer = measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(innerHit.hit()->det()->geographicalId());
-  const DetLayer * outerLayer = measurementTrackerEvent->measurementTracker().geometricSearchTracker()->detLayer(outerHit.hit()->det()->geographicalId());
-  typedef PixelRecoRange<float> Range;
-  
-  for(Regions::const_iterator ir=regions.begin(); ir < regions.end(); ++ir){
-    
-    auto const & gs = outerHit.hit()->globalState();
-    auto loc = gs.position-(*ir)->origin().basicVector();
-    const HitRZCompatibility * checkRZ = (*ir)->checkRZ(innerLayer, outerHit.hit(), *es_, outerLayer,
-							loc.perp(),gs.position.z(),gs.errorR,gs.errorZ);
-    
-    float u = innerLayer->isBarrel() ? loc.perp() : gs.position.z();
-    float v = innerLayer->isBarrel() ? gs.position.z() : loc.perp();
-    float dv = innerLayer->isBarrel() ? gs.errorZ : gs.errorR;
-    constexpr float nSigmaRZ = 3.46410161514f;
-    Range allowed = checkRZ->range(u);
-    float vErr = nSigmaRZ * dv;
-    Range hitRZ(v-vErr, v+vErr);
-    Range crossRange = allowed.intersection(hitRZ);
-    
-    if( ! crossRange.empty()){
-      std::cout << "init seed creator"<< std::endl;
-      std::cout << "ptmin: " << (**ir).ptMin() << std::endl;
-      std::cout << "" << std::endl;
-      seedCreator->init(**ir,*es_,0);
-      std::cout << "done" << std::endl;
-      return true;}
-    
-  }
-  return false;
-}
-*/

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -23,6 +23,7 @@
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 	 //#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 	 //#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegion.h"
 #include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include <memory>
 #include <vector>
@@ -203,7 +204,8 @@ class TrajectorySeedProducer:
             unsigned int trackerHit
     ) const;
     
-    typedef std::vector<TrackingRegion* > Regions;
+    //    typedef std::vector<TrackingRegion* > Regions;
+    typedef std::vector<std::unique_ptr<TrackingRegion> > Regions;
     Regions regions;
     //TrackingRegionProducer* theRegionProducer;
 

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -9,18 +9,21 @@
 #include "DataFormats/VertexReco/interface/VertexFwd.h"
 
 #include "FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h"
-
+#include "RecoTracker/TkSeedGenerator/interface/SeedCreatorFactory.h"
+#include "RecoTracker/TkSeedGenerator/interface/SeedCreator.h"
 #include "SimDataFormats/Track/interface/SimTrackContainer.h"
 #include "SimDataFormats/Vertex/interface/SimVertexContainer.h"
 #include "FastSimulation/Tracking/interface/TrajectorySeedHitCandidate.h"
 
 #include "DataFormats/TrajectorySeed/interface/TrajectorySeedCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSRecHit2DCollection.h"
+#include "DataFormats/TrackerRecHit2D/interface/SiTrackerGSMatchedRecHit2DCollection.h"
 
 #include "FastSimulation/Tracking/interface/SeedingTree.h"
 #include "FastSimulation/Tracking/interface/TrackingLayer.h"
 	 //#include "DataFormats/BeamSpot/interface/BeamSpot.h"
 	 //#include "DataFormats/TrackReco/interface/TrackFwd.h"
-
+#include "RecoTracker/TkTrackingRegions/interface/TrackingRegionProducer.h"
 #include <memory>
 #include <vector>
 #include <sstream>
@@ -30,6 +33,7 @@ class MagneticField;
 class MagneticFieldMap;
 class TrackerGeometry;
 class PropagatorWithMaterial;
+class MeasurementTrackerEvent;
 
 class TrajectorySeedProducer:
     public edm::stream::EDProducer<>
@@ -47,11 +51,11 @@ class TrajectorySeedProducer:
         double simTrack_pTMin;
         double simTrack_maxD0;
         double simTrack_maxZ0;
-        
+	std::unique_ptr<SeedCreator> seedCreator;
         unsigned int minLayersCrossed;
 
         std::vector<std::vector<TrackingLayer>> seedingLayers;
-
+	std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
         double originRadius;
         double ptMin;
         double originHalfLength;
@@ -191,12 +195,22 @@ class TrajectorySeedProducer:
     \param trackerHit hit which is tested.
     \return pointer if this hit is inserted at a leaf which means that a seed has been found. Returns 'nullptr' otherwise.
     */
+    bool testWithRegions(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const;
     const SeedingNode<TrackingLayer>* insertHit(
             const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
             std::vector<int>& hitIndicesInTree,
             const SeedingNode<TrackingLayer>* node, 
             unsigned int trackerHit
     ) const;
+    
+    typedef std::vector<TrackingRegion* > Regions;
+    Regions regions;
+    //TrackingRegionProducer* theRegionProducer;
+
+    std::unique_ptr<TrackingRegionProducer> theRegionProducer;
+    edm::EDGetTokenT<MeasurementTrackerEvent> measurementTrackerEventToken;
+    const MeasurementTrackerEvent * measurementTrackerEvent;
+    const edm::EventSetup * es_;
 
 
 };

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -56,7 +56,7 @@ class TrajectorySeedProducer:
         unsigned int minLayersCrossed;
 
         std::vector<std::vector<TrackingLayer>> seedingLayers;
-	std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
+	//std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
         double originRadius;
         double ptMin;
         double originHalfLength;
@@ -70,8 +70,8 @@ class TrajectorySeedProducer:
         const reco::VertexCollection* primaryVertices;
         // tokens
         edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
-        edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
-        edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
+        //edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
+        //edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
         edm::EDGetTokenT<FastTMRecHitCombinations> recHitTokens;
         edm::EDGetTokenT<FastTMRecHitCombination> recHitToken;
         edm::EDGetTokenT<reco::VertexCollection> recoVertexToken;
@@ -94,7 +94,7 @@ class TrajectorySeedProducer:
     \param theSimVertex the associated SimVertex of the SimTrack.
     \return true if a track fulfills the requirements.
     */
-    virtual bool passSimTrackQualityCuts(const SimTrack& theSimTrack, const SimVertex& theSimVertex) const;
+    //virtual bool passSimTrackQualityCuts(const SimTrack& theSimTrack, const SimVertex& theSimVertex) const;
 
     //! method checks if a TrajectorySeedHitCandidate fulfills the quality requirements.
     /*!

--- a/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
+++ b/FastSimulation/Tracking/plugins/TrajectorySeedProducer.h
@@ -40,47 +40,47 @@ class TrajectorySeedProducer:
     public edm::stream::EDProducer<>
 {
     private:
-        SeedingTree<TrackingLayer> _seedingTree;
+	SeedingTree<TrackingLayer> _seedingTree;
 
-        const MagneticField* magneticField;
-        const MagneticFieldMap* magneticFieldMap;
-        const TrackerGeometry* trackerGeometry;
-        const TrackerTopology* trackerTopology;
+	const MagneticField* magneticField;
+	const MagneticFieldMap* magneticFieldMap;
+	const TrackerGeometry* trackerGeometry;
+	const TrackerTopology* trackerTopology;
 
-        std::shared_ptr<PropagatorWithMaterial> thePropagator;
+	std::shared_ptr<PropagatorWithMaterial> thePropagator;
 
-        double simTrack_pTMin;
-        double simTrack_maxD0;
-        double simTrack_maxZ0;
+	double simTrack_pTMin;
+	double simTrack_maxD0;
+	double simTrack_maxZ0;
 	std::unique_ptr<SeedCreator> seedCreator;
-        unsigned int minLayersCrossed;
+	unsigned int minLayersCrossed;
 
-        std::vector<std::vector<TrackingLayer>> seedingLayers;
+	std::vector<std::vector<TrackingLayer>> seedingLayers;
 	//std::vector<edm::EDGetTokenT<std::vector<unsigned int> > > skipSimTrackIdTokens;
-        double originRadius;
-        double ptMin;
-        double originHalfLength;
-        double nSigmaZ;
+	double originRadius;
+	double ptMin;
+	double originHalfLength;
+	double nSigmaZ;
 
 	bool hitMasks_exists;
 	bool hitCombinationMasks_exists;
-        bool testBeamspotCompatibility;
-        const reco::BeamSpot* beamSpot;
-        bool testPrimaryVertexCompatibility;
-        const reco::VertexCollection* primaryVertices;
-        // tokens
-        edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
-        //edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
-        //edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
-        edm::EDGetTokenT<FastTMRecHitCombinations> recHitTokens;
-        edm::EDGetTokenT<FastTMRecHitCombination> recHitToken;
-        edm::EDGetTokenT<reco::VertexCollection> recoVertexToken;
-	edm::EDGetTokenT<std::vector<bool> > hitMasksToken;        
-        edm::EDGetTokenT<std::vector<bool> > hitCombinationMasksToken;
+	bool testBeamspotCompatibility;
+	const reco::BeamSpot* beamSpot;
+	bool testPrimaryVertexCompatibility;
+	const reco::VertexCollection* primaryVertices;
+	// tokens
+	edm::EDGetTokenT<reco::BeamSpot> beamSpotToken;
+	//edm::EDGetTokenT<edm::SimTrackContainer> simTrackToken;
+	//edm::EDGetTokenT<edm::SimVertexContainer> simVertexToken;
+	edm::EDGetTokenT<FastTMRecHitCombinations> recHitTokens;
+	edm::EDGetTokenT<FastTMRecHitCombination> recHitToken;
+	edm::EDGetTokenT<reco::VertexCollection> recoVertexToken;
+	edm::EDGetTokenT<std::vector<bool> > hitMasksToken;
+	edm::EDGetTokenT<std::vector<bool> > hitCombinationMasksToken;
     public:
 
     TrajectorySeedProducer(const edm::ParameterSet& conf);
-    
+
     virtual ~TrajectorySeedProducer()
     {
     }
@@ -98,97 +98,97 @@ class TrajectorySeedProducer:
 
     //! method checks if a TrajectorySeedHitCandidate fulfills the quality requirements.
     /*!
-    \param seedingNode tree node at which the hit will be inserted. 
+    \param seedingNode tree node at which the hit will be inserted.
     \param trackerRecHits list of all TrackerRecHits.
     \param hitIndicesInTree hit indices which translates the tree node to the hits in \e trackerRecHits.
     \param currentTrackerHit hit which is tested.
     \return true if a hit fulfills the requirements.
     */
     inline bool passHitTuplesCuts(
-            const SeedingNode<TrackingLayer>& seedingNode,
-            const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
-            const std::vector<int>& hitIndicesInTree,
-            const TrajectorySeedHitCandidate& currentTrackerHit
-        ) const
+	    const SeedingNode<TrackingLayer>& seedingNode,
+	    const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
+	    const std::vector<int>& hitIndicesInTree,
+	    const TrajectorySeedHitCandidate& currentTrackerHit
+	) const
     {
-        switch (seedingNode.getDepth())
-        {
-            case 0:
-            {
-                return true;
-                /* example for 1 hits
-                const TrajectorySeedHitCandidate& hit1 = currentTrackerHit;
-                return pass1HitsCuts(hit1,trackingAlgorithmId);
-                */
-            }
+	switch (seedingNode.getDepth())
+	{
+	    case 0:
+	    {
+		return true;
+		/* example for 1 hits
+		const TrajectorySeedHitCandidate& hit1 = currentTrackerHit;
+		return pass1HitsCuts(hit1,trackingAlgorithmId);
+		*/
+	    }
 
-            case 1:
-            {
-                const SeedingNode<TrackingLayer>* parentNode = &seedingNode;
-                parentNode = parentNode->getParent();
-                const TrajectorySeedHitCandidate& hit1 = trackerRecHits[hitIndicesInTree[parentNode->getIndex()]];
-                const TrajectorySeedHitCandidate& hit2 = currentTrackerHit;
+	    case 1:
+	    {
+		const SeedingNode<TrackingLayer>* parentNode = &seedingNode;
+		parentNode = parentNode->getParent();
+		const TrajectorySeedHitCandidate& hit1 = trackerRecHits[hitIndicesInTree[parentNode->getIndex()]];
+		const TrajectorySeedHitCandidate& hit2 = currentTrackerHit;
 
-                return pass2HitsCuts(hit1,hit2);
-            }
-            case 2:
-            {
-                return true;
-                /* example for 3 hits
-                const SeedingNode<LayerSpec>* parentNode = &seedingNode;
-                parentNode = parentNode->getParent();
-                const TrajectorySeedHitCandidate& hit2 = trackerRecHits[hitIndicesInTree[parentNode->getIndex()]];
-                parentNode = parentNode->getParent();
-                const TrajectorySeedHitCandidate& hit1 = trackerRecHits[hitIndicesInTree[parentNode->getIndex()]];
-                const TrajectorySeedHitCandidate& hit3 = currentTrackerHit;
-                return pass3HitsCuts(hit1,hit2,hit3,trackingAlgorithmId);
-                */
-            }
-        }
-        return true;
+		return pass2HitsCuts(hit1,hit2);
+	    }
+	    case 2:
+	    {
+		return true;
+		/* example for 3 hits
+		const SeedingNode<LayerSpec>* parentNode = &seedingNode;
+		parentNode = parentNode->getParent();
+		const TrajectorySeedHitCandidate& hit2 = trackerRecHits[hitIndicesInTree[parentNode->getIndex()]];
+		parentNode = parentNode->getParent();
+		const TrajectorySeedHitCandidate& hit1 = trackerRecHits[hitIndicesInTree[parentNode->getIndex()]];
+		const TrajectorySeedHitCandidate& hit3 = currentTrackerHit;
+		return pass3HitsCuts(hit1,hit2,hit3,trackingAlgorithmId);
+		*/
+	    }
+	}
+	return true;
     }
 
     bool pass2HitsCuts(const TrajectorySeedHitCandidate& hit1, const TrajectorySeedHitCandidate& hit2) const;
 
     //! method tries to insert all hits into the tree structure.
     /*!
-    \param start index where to begin insertion. Important for recursion. 
+    \param start index where to begin insertion. Important for recursion.
     \param trackerRecHits list of all TrackerRecHits.
     \param hitIndicesInTree hit indices which translates the tree node to the hits in \e trackerRecHits.
     \param currentTrackerHit hit which is tested.
     \return list of hit indices which form a found seed. Returns empty list if no seed was found.
     */
     virtual std::vector<unsigned int> iterateHits(
-            unsigned int start,
-            const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
-            std::vector<int> hitIndicesInTree,
-            bool processSkippedHits
-        ) const;
+	    unsigned int start,
+	    const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
+	    std::vector<int> hitIndicesInTree,
+	    bool processSkippedHits
+	) const;
 
     inline bool isHitOnLayer(const TrajectorySeedHitCandidate& trackerRecHit, const TrackingLayer& layer) const
     {
-        return layer==trackerRecHit.getTrackingLayer();
+	return layer==trackerRecHit.getTrackingLayer();
     }
 
     /// Check that the seed is compatible with a track coming from within
     /// a cylinder of radius originRadius, with a decent pT.
     bool compatibleWithBeamSpot(
-            const GlobalPoint& gpos1, 
-            const GlobalPoint& gpos2,
-            double error,
-            bool forward
+	    const GlobalPoint& gpos1,
+	    const GlobalPoint& gpos2,
+	    double error,
+	    bool forward
     ) const;
 
     /// Check that the seed is compatible with a track coming from within
     /// a cylinder of radius originRadius, with a decent pT.
     bool compatibleWithPrimaryVertex(
-            const GlobalPoint& gpos1,
-            const GlobalPoint& gpos2,
-            double error,
-            bool forward
+	    const GlobalPoint& gpos1,
+	    const GlobalPoint& gpos2,
+	    double error,
+	    bool forward
     ) const;
 
-    //! method inserts hit into the tree structure at an empty position. 
+    //! method inserts hit into the tree structure at an empty position.
     /*!
     \param trackerRecHits list of all TrackerRecHits.
     \param hitIndicesInTree hit indices which translates the tree node to the hits in \e trackerRecHits. Empty positions are identified with '-1'.
@@ -198,12 +198,12 @@ class TrajectorySeedProducer:
     */
     bool testWithRegions(const TrajectorySeedHitCandidate & innerHit,const TrajectorySeedHitCandidate & outerHit) const;
     const SeedingNode<TrackingLayer>* insertHit(
-            const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
-            std::vector<int>& hitIndicesInTree,
-            const SeedingNode<TrackingLayer>* node, 
-            unsigned int trackerHit
+	    const std::vector<TrajectorySeedHitCandidate>& trackerRecHits,
+	    std::vector<int>& hitIndicesInTree,
+	    const SeedingNode<TrackingLayer>* node,
+	    unsigned int trackerHit
     ) const;
-    
+
     //    typedef std::vector<TrackingRegion* > Regions;
     typedef std::vector<std::unique_ptr<TrackingRegion> > Regions;
     Regions regions;

--- a/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
@@ -6,9 +6,11 @@ import RecoTracker.IterativeTracking.DetachedTripletStep_cff as _detachedTriplet
 # fast tracking mask producer
 import FastSimulation.Tracking.FastTrackingMaskProducer_cfi
 detachedTripletStepMasks = FastSimulation.Tracking.FastTrackingMaskProducer_cfi.fastTrackingMaskProducer.clone(
-    trackCollection = _detachedTripletStep.detachedTripletStepClusters.trajectories,
+    trackCollection = cms.InputTag("initialStepTracks"),
     TrackQuality = _detachedTripletStep.detachedTripletStepClusters.TrackQuality,
-    overrideTrkQuals = cms.InputTag('initialStep',"QualityMasks")
+#_detachedTripletStep.detachedTripletStepClusters.TrackQuality,
+    maxChi2 = _detachedTripletStep.detachedTripletStepClusters.maxChi2,
+    overrideTrkQuals =  cms.InputTag('initialStep')
 )
 
 # trajectory seeds
@@ -20,25 +22,17 @@ detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.tr
         maxZ0 = 1
         ),
     minLayersCrossed = 3,
-layerList = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeedLayers.layerList.value(),
-    RegionFactoryPSet = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeeds.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-    #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("detachedTripletStepMasks","hitCombinationMasks"),
-    ptMin = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = _detachedTripletStep.detachedTripletStepSeedLayers.layerList.value()
-'''
+    layerList = _detachedTripletStep.detachedTripletStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
     )
 
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 detachedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
     src = cms.InputTag("detachedTripletStepSeeds"),
-    MinNumberOfCrossedLayers = 3    
-#hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
+    MinNumberOfCrossedLayers = 3
+    #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
     )
 
 # tracks 
@@ -50,11 +44,16 @@ detachedTripletStepTracks = _detachedTripletStep.detachedTripletStepTracks.clone
 )
 
 #final selection
+#detachedTripletStepSelector = _detachedTripletStep.detachedTripletStepSelector.clone()
+
+#detachedTripletStepSelector.vertices = "firstStepPrimaryVerticesBeforeMixing"
+#detachedTripletStep = _detachedTripletStep.detachedTripletStep.clone() 
+
 detachedTripletStepClassifier1 = _detachedTripletStep.detachedTripletStepClassifier1.clone()
 detachedTripletStepClassifier1.vertices = "firstStepPrimaryVerticesBeforeMixing"
 detachedTripletStepClassifier2 = _detachedTripletStep.detachedTripletStepClassifier2.clone()
 detachedTripletStepClassifier2.vertices = "firstStepPrimaryVerticesBeforeMixing"
-detachedTripletStep = _detachedTripletStep.detachedTripletStep.clone() 
+detachedTripletStep = _detachedTripletStep.detachedTripletStep.clone()
 
 # Final sequence 
 DetachedTripletStep = cms.Sequence(detachedTripletStepMasks

--- a/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
@@ -15,25 +15,30 @@ detachedTripletStepMasks = FastSimulation.Tracking.FastTrackingMaskProducer_cfi.
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.02,
-        maxD0 = 30.0,
-        maxZ0 = 50
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = 1
         ),
     minLayersCrossed = 3,
+layerList = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
     #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("detachedTripletStepMasks","hitCombinationMasks"),
     ptMin = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
     originHalfLength = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
     originRadius = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
     layerList = _detachedTripletStep.detachedTripletStepSeedLayers.layerList.value()
+'''
     )
 
 # track candidates
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 detachedTripletStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
     src = cms.InputTag("detachedTripletStepSeeds"),
-    MinNumberOfCrossedLayers = 3
-    #hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
+    MinNumberOfCrossedLayers = 3    
+#hitMasks = cms.InputTag("detachedTripletStepMasks","hitMasks"),
     )
 
 # tracks 

--- a/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/DetachedTripletStep_cff.py
@@ -6,21 +6,20 @@ import RecoTracker.IterativeTracking.DetachedTripletStep_cff as _detachedTriplet
 # fast tracking mask producer
 import FastSimulation.Tracking.FastTrackingMaskProducer_cfi
 detachedTripletStepMasks = FastSimulation.Tracking.FastTrackingMaskProducer_cfi.fastTrackingMaskProducer.clone(
-    trackCollection = cms.InputTag("initialStepTracks"),
-    TrackQuality = _detachedTripletStep.detachedTripletStepClusters.TrackQuality,
+   # trackCollection = cms.InputTag("initialStepTracks"),
+   # TrackQuality = _detachedTripletStep.detachedTripletStepClusters.TrackQuality,
 #_detachedTripletStep.detachedTripletStepClusters.TrackQuality,
-    maxChi2 = _detachedTripletStep.detachedTripletStepClusters.maxChi2,
-    overrideTrkQuals =  cms.InputTag('initialStep')
+  #  maxChi2 = _detachedTripletStep.detachedTripletStepClusters.maxChi2,
+ #   overrideTrkQuals =  cms.InputTag('initialStep')
+# detachedTripletStepMasks = FastSimulation.Tracking.FastTrackingMaskProducer_cfi.fastTrackingMaskProducer.clone(
+trackCollection = _detachedTripletStep.detachedTripletStepClusters.trajectories,
+TrackQuality = _detachedTripletStep.detachedTripletStepClusters.TrackQuality,
+overrideTrkQuals = cms.InputTag('initialStep',"QualityMasks")
 )
 
 # trajectory seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 detachedTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0,
-        maxD0 = -1,
-        maxZ0 = 1
-        ),
     minLayersCrossed = 3,
     layerList = _detachedTripletStep.detachedTripletStepSeedLayers.layerList.value(),
     RegionFactoryPSet = _detachedTripletStep.detachedTripletStepSeeds.RegionFactoryPSet,

--- a/FastSimulation/Tracking/python/GlobalMixedTracking_cff.py
+++ b/FastSimulation/Tracking/python/GlobalMixedTracking_cff.py
@@ -17,4 +17,3 @@ globalMixedWithMaterialTracks.src = 'globalMixedTrackCandidates'
 globalMixedWithMaterialTracks.TTRHBuilder = 'WithoutRefit'
 globalMixedWithMaterialTracks.Fitter = 'KFFittingSmootherWithOutlierRejection'
 globalMixedWithMaterialTracks.Propagator = 'PropagatorWithMaterial'
-

--- a/FastSimulation/Tracking/python/InitialStep_cff.py
+++ b/FastSimulation/Tracking/python/InitialStep_cff.py
@@ -6,16 +6,10 @@ import RecoTracker.IterativeTracking.InitialStep_cff
 # trajectory seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 initialStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.4,
-        maxD0 = 1.0,
-        maxZ0 = -1,
-        ),
     minLayersCrossed = 3,
-    nSigmaZ = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeeds.RegionFactoryPSet.RegionPSet.nSigmaZ,
-    ptMin = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeedLayers.layerList.value()
+layerList = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
     )
 
 # track candidates

--- a/FastSimulation/Tracking/python/LowPtTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/LowPtTripletStep_cff.py
@@ -18,18 +18,11 @@ lowPtTripletStepMasks = _fastTrackingMaskProducer.clone(
 # trajectory seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 lowPtTripletStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.1,
-        maxD0 = 5.0,
-        maxZ0 = 50
-    ),
     minLayersCrossed = 3,
     #hitMasks = cms.InputTag("lowPtTripletStepMasks","hitMasks"),
-    hitCombinationMasks = cms.InputTag("lowPtTripletStepMasks","hitCombinationMasks"),
-    nSigmaZ = RecoTracker.IterativeTracking.LowPtTripletStep_cff.lowPtTripletStepSeeds.RegionFactoryPSet.RegionPSet.nSigmaZ,
-    ptMin = RecoTracker.IterativeTracking.LowPtTripletStep_cff.lowPtTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.LowPtTripletStep_cff.lowPtTripletStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.LowPtTripletStep_cff.lowPtTripletStepSeedLayers.layerList.value()
+    layerList = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.InitialStep_cff.initialStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
 )
 
 # track candidates

--- a/FastSimulation/Tracking/python/MixedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/MixedTripletStep_cff.py
@@ -25,14 +25,6 @@ mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer_cfi.traj
 layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet,
     MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-    #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
-    ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originRadius,
-    originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originHalfLength,
-    layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value()
-'''
 )
 
 ###
@@ -46,15 +38,7 @@ mixedTripletStepSeedsB = FastSimulation.Tracking.TrajectorySeedProducer_cfi.traj
     minLayersCrossed = 3,
 layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),   
- #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
-    ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originRadius,
-    originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originHalfLength,
-    layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value()
-'''
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
 )
 
 mixedTripletStepSeeds = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeeds.clone()

--- a/FastSimulation/Tracking/python/MixedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/MixedTripletStep_cff.py
@@ -16,11 +16,6 @@ mixedTripletStepMasks = _fastTrackingMaskProducer.clone(
 # trajectory seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0,
-        maxD0 = -1,
-        maxZ0 = -1
-        ),
     minLayersCrossed = 3,
 layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet,
@@ -30,11 +25,6 @@ layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepS
 ###
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 mixedTripletStepSeedsB = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.15,
-        maxD0 = 10.0,
-        maxZ0 = 30
-        ),
     minLayersCrossed = 3,
 layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet,

--- a/FastSimulation/Tracking/python/MixedTripletStep_cff.py
+++ b/FastSimulation/Tracking/python/MixedTripletStep_cff.py
@@ -17,17 +17,22 @@ mixedTripletStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 mixedTripletStepSeedsA = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.15,
-        maxD0 = 10.0,
-        maxZ0 = 30
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = -1
         ),
     minLayersCrossed = 3,
+layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
     #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
     ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.ptMin,
     originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originRadius,
     originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsA.RegionFactoryPSet.RegionPSet.originHalfLength,
     layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersA.layerList.value()
+'''
 )
 
 ###
@@ -39,12 +44,17 @@ mixedTripletStepSeedsB = FastSimulation.Tracking.TrajectorySeedProducer_cfi.traj
         maxZ0 = 30
         ),
     minLayersCrossed = 3,
-    #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
+layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),   
+ #hitMasks = cms.InputTag("mixedTripletStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("mixedTripletStepMasks","hitCombinationMasks"),
     ptMin =  RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.ptMin,
     originRadius = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originRadius,
     originHalfLength = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedsB.RegionFactoryPSet.RegionPSet.originHalfLength,
     layerList = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeedLayersB.layerList.value()
+'''
 )
 
 mixedTripletStepSeeds = RecoTracker.IterativeTracking.MixedTripletStep_cff.mixedTripletStepSeeds.clone()

--- a/FastSimulation/Tracking/python/PixelLessStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelLessStep_cff.py
@@ -17,17 +17,22 @@ pixelLessStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-       pTMin = 0.3,
+       pTMin = 0,
         maxD0 = -1,
         maxZ0 = -1
         ),
     minLayersCrossed = 3,
+layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
     #hitMasks = cms.InputTag("pixelLessStepMasks","hitMasks"),
+'''
     hitCombinationMasks = cms.InputTag("pixelLessStepMasks","hitCombinationMasks"),
     ptMin = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
     originHalfLength = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
     originRadius = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
     layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value()
+'''
 )
 
 # track candidates

--- a/FastSimulation/Tracking/python/PixelLessStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelLessStep_cff.py
@@ -16,11 +16,6 @@ pixelLessStepMasks = _fastTrackingMaskProducer.clone(
 # trajectory seeds 
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-       pTMin = 0,
-        maxD0 = -1,
-        maxZ0 = -1
-        ),
     minLayersCrossed = 3,
 layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet,

--- a/FastSimulation/Tracking/python/PixelLessStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelLessStep_cff.py
@@ -24,15 +24,7 @@ pixelLessStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajecto
     minLayersCrossed = 3,
 layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-    #hitMasks = cms.InputTag("pixelLessStepMasks","hitMasks"),
-'''
-    hitCombinationMasks = cms.InputTag("pixelLessStepMasks","hitCombinationMasks"),
-    ptMin = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.PixelLessStep_cff.pixelLessStepSeedLayers.layerList.value()
-'''
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
 )
 
 # track candidates

--- a/FastSimulation/Tracking/python/PixelPairStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelPairStep_cff.py
@@ -16,11 +16,6 @@ pixelPairStepMasks = _fastTrackingMaskProducer.clone(
 # trajectory seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 pixelPairStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0,
-        maxD0 = -1,
-        maxZ0 = -1
-        ),
     minLayersCrossed = 2,
 layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet,

--- a/FastSimulation/Tracking/python/PixelPairStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelPairStep_cff.py
@@ -24,15 +24,7 @@ pixelPairStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajecto
     minLayersCrossed = 2,
 layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet,
-    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
-'''
-    nSigmaZ = 3,
-    #hitMasks = cms.InputTag("pixelPairStepMasks","hitMasks"),
-    hitCombinationMasks = cms.InputTag("pixelPairStepMasks","hitCombinationMasks"), 
-    ptMin = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
-    originRadius = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value()
-'''
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent")
 )
 pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = cms.InputTag("firstStepPrimaryVerticesBeforeMixing")
 # track candidate 

--- a/FastSimulation/Tracking/python/PixelPairStep_cff.py
+++ b/FastSimulation/Tracking/python/PixelPairStep_cff.py
@@ -17,19 +17,24 @@ pixelPairStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 pixelPairStepSeeds = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.3,
-        maxD0 = 5.0,
-        maxZ0 = 50
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = -1
         ),
     minLayersCrossed = 2,
+layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
+'''
     nSigmaZ = 3,
     #hitMasks = cms.InputTag("pixelPairStepMasks","hitMasks"),
     hitCombinationMasks = cms.InputTag("pixelPairStepMasks","hitCombinationMasks"), 
     ptMin = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin,
     originRadius = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.originRadius,
     layerList = RecoTracker.IterativeTracking.PixelPairStep_cff.pixelPairStepSeedLayers.layerList.value()
+'''
 )
-
+pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.VertexCollection = cms.InputTag("firstStepPrimaryVerticesBeforeMixing")
 # track candidate 
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 pixelPairStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(

--- a/FastSimulation/Tracking/python/TobTecStep_cff.py
+++ b/FastSimulation/Tracking/python/TobTecStep_cff.py
@@ -2,15 +2,17 @@ import FWCore.ParameterSet.Config as cms
 
 # import the full tracking equivalent of this file
 import RecoTracker.IterativeTracking.TobTecStep_cff
-                                                                                                                                                                                                                                                              
-# fast tracking mask producer 
-from FastSimulation.Tracking.FastTrackingMaskProducer_cfi import fastTrackingMaskProducer as _fastTrackingMaskProducer                                                   
-tobTecStepMasks = _fastTrackingMaskProducer.clone(                                                                                                                                                                                                 
+ 
+from FastSimulation.Tracking.FastTrackingMaskProducer_cfi import fastTrackingMaskProducer as _fastTrackingMaskProducer                             
+
+
+tobTecStepMasks = _fastTrackingMaskProducer.clone(                                                                                                 
     trackCollection = cms.InputTag("pixelLessStepTracks"),
     TrackQuality = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepClusters.TrackQuality,
-    overrideTrkQuals = cms.InputTag('pixelLessStep',"QualityMasks"),  
+    overrideTrkQuals = cms.InputTag('pixelLessStep',"QualityMasks"),
     oldHitCombinationMasks = cms.InputTag("pixelLessStepMasks","hitCombinationMasks"),
     oldHitMasks = cms.InputTag("pixelLessStepMasks","hitMasks")
+
 )
 
 # trajectory seeds 
@@ -18,43 +20,42 @@ tobTecStepMasks = _fastTrackingMaskProducer.clone(
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.3,
+#        pTMin = 0.3,
+ #       maxD0 = -1,
+  #      maxZ0 = -1
+        pTMin = 0,
         maxD0 = -1,
         maxZ0 = -1
     ),
     minLayersCrossed = 4,
-    #hitMasks = cms.InputTag("tobTecStepMasks","hitMasks"),
-    hitCombinationMasks = cms.InputTag("tobTecStepMasks","hitCombinationMasks"),
-    ptMin = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersTripl.layerList.value()
-)
+    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersTripl.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
+    )
 #pair seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 tobTecStepSeedsPair = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
     simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-        pTMin = 0.3,
-        maxD0 = 99.0,
-        maxZ0 = 99
+  #      pTMin = 0.3,
+ #       maxD0 = 99.0,
+#        maxZ0 = 99
+        pTMin = 0,
+        maxD0 = -1,
+        maxZ0 = -1,
     ),
     minLayersCrossed = 4,
-    #hitMasks = cms.InputTag("tobTecStepMasks","hitMasks"),
-    hitCombinationMasks = cms.InputTag("tobTecStepMasks","hitCombinationMasks"),
-    ptMin = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.ptMin,
-    originHalfLength = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.originHalfLength,
-    originRadius = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet.RegionPSet.originRadius,
-    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersPair.layerList.value()
-)
+    layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersPair.layerList.value(),
+    RegionFactoryPSet = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet,
+    MeasurementTrackerEvent = cms.InputTag("MeasurementTrackerEvent"),
+    )
 #
 tobTecStepSeeds = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeeds.clone()
 
 # track candidate
 import FastSimulation.Tracking.TrackCandidateProducer_cfi
 tobTecStepTrackCandidates = FastSimulation.Tracking.TrackCandidateProducer_cfi.trackCandidateProducer.clone(
-    src = cms.InputTag("tobTecStepSeeds"),
+    SeedProducer = cms.InputTag("tobTecStepSeeds"),
     MinNumberOfCrossedLayers = 3
-    #hitMasks = cms.InputTag("tobTecStepMasks","hitMasks"),
 )
 
 # tracks 
@@ -77,10 +78,9 @@ tobTecStep = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStep.clone()
 # Final sequence 
 TobTecStep = cms.Sequence(tobTecStepMasks
                           +tobTecStepSeedsTripl
-                          +tobTecStepSeedsPair
-                          +tobTecStepSeeds
-                          +tobTecStepTrackCandidates
-                          +tobTecStepTracks
-                          +tobTecStepClassifier1*tobTecStepClassifier2
-                          +tobTecStep
-                      )
+                           +tobTecStepSeedsPair
+                           +tobTecStepSeeds
+                           +tobTecStepTrackCandidates
+                           +tobTecStepTracks
+                               +tobTecStepClassifier1*tobTecStepClassifier2                           +tobTecStep
+                       )

--- a/FastSimulation/Tracking/python/TobTecStep_cff.py
+++ b/FastSimulation/Tracking/python/TobTecStep_cff.py
@@ -19,14 +19,6 @@ tobTecStepMasks = _fastTrackingMaskProducer.clone(
 #triplet seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-#        pTMin = 0.3,
- #       maxD0 = -1,
-  #      maxZ0 = -1
-        pTMin = 0,
-        maxD0 = -1,
-        maxZ0 = -1
-    ),
     minLayersCrossed = 4,
     layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersTripl.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsTripl.RegionFactoryPSet,
@@ -35,14 +27,6 @@ tobTecStepSeedsTripl = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajec
 #pair seeds
 import FastSimulation.Tracking.TrajectorySeedProducer_cfi
 tobTecStepSeedsPair = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.clone(
-    simTrackSelection = FastSimulation.Tracking.TrajectorySeedProducer_cfi.trajectorySeedProducer.simTrackSelection.clone(
-  #      pTMin = 0.3,
- #       maxD0 = 99.0,
-#        maxZ0 = 99
-        pTMin = 0,
-        maxD0 = -1,
-        maxZ0 = -1,
-    ),
     minLayersCrossed = 4,
     layerList = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedLayersPair.layerList.value(),
     RegionFactoryPSet = RecoTracker.IterativeTracking.TobTecStep_cff.tobTecStepSeedsPair.RegionFactoryPSet,

--- a/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
@@ -15,7 +15,7 @@ trackCandidateProducer = cms.EDProducer(
     SplitHits = cms.bool(True),
     simTracks = cms.InputTag('famosSimHits'),
     
-    propagator = cms.string('PropagatorWithMaterial')
+    propagator = cms.string('PropagatorWithMaterialOpposite')
 )
 
 

--- a/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrackCandidateProducer_cfi.py
@@ -6,7 +6,7 @@ trackCandidateProducer = cms.EDProducer(
     # The smallest number of crossed layers to make a candidate
     MinNumberOfCrossedLayers = cms.uint32(5),
 
-    src = cms.InputTag("globalPixelSeeds"),
+    src = cms.InputTag("tobTecStepSeeds"),
 
     # Reject overlapping hits? (GroupedTracking from 170pre2 onwards)
     OverlapCleaning = cms.bool(False),

--- a/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
@@ -1,7 +1,7 @@
-*import FWCore.ParameterSet.Config as cms
+import FWCore.ParameterSet.Config as cms
 
 from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
-from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import 
+from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import *
 
 trajectorySeedProducer = cms.EDProducer("TrajectorySeedProducer",
                                         

--- a/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
@@ -1,4 +1,7 @@
-import FWCore.ParameterSet.Config as cms
+*import FWCore.ParameterSet.Config as cms
+
+from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
+from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import 
 
 trajectorySeedProducer = cms.EDProducer("TrajectorySeedProducer",
                                         
@@ -9,26 +12,27 @@ trajectorySeedProducer = cms.EDProducer("TrajectorySeedProducer",
          #skipSimTrackIds = cms.VInputTag(),
          maxZ0 = cms.double(-1),
          maxD0 = cms.double(-1),
-    ),
-    # minimum number of layer crossed (with hits on them) by the simtrack
-    minLayersCrossed = cms.uint32(0),
-    
-    #if empty, BS compatibility is skipped
-    beamSpot = cms.InputTag("offlineBeamSpot"),
-    #if empty, PV compatibility is skipped
-    primaryVertex = cms.InputTag(""),
-    
-    nSigmaZ = cms.double(-1),
-    originHalfLength= cms.double(-1),
-    
-    originRadius = cms.double(-1),
-    ptMin = cms.double(-1),
-
-    # Inputs: tracker rechits, beam spot position.
-    recHits = cms.InputTag("siTrackerGaussianSmearingRecHits"),
-    #hitMasks = cms.InputTag("hitMasks"),
-    #hitCombinationMasks = cms.InputTag("hitCombinationMasks"),
-        
-    layerList = cms.vstring(),
-)
+         ),
+                                        SeedCreatorPSet = cms.PSet(SeedFromConsecutiveHitsCreator.clone(TTRHBuilder = cms.string("WithoutRefit"))),
+                                        # minimum number of layer crossed (with hits on them) by the simtrack
+                                        minLayersCrossed = cms.uint32(0),
+                                        
+                                        #if empty, BS compatibility is skipped
+                                        beamSpot = cms.InputTag("offlineBeamSpot"),
+                                        #if empty, PV compatibility is skipped
+                                        primaryVertex = cms.InputTag(""),
+                                        
+                                        nSigmaZ = cms.double(-1),
+                                        originHalfLength= cms.double(-1),
+                                        
+                                        originRadius = cms.double(-1),
+                                        ptMin = cms.double(-1),
+                                        
+                                        # Inputs: tracker rechits, beam spot position.
+                                        recHits = cms.InputTag("siTrackerGaussianSmearingRecHits"),
+                                        #hitMasks = cms.InputTag("hitMasks"),
+                                        #hitCombinationMasks = cms.InputTag("hitCombinationMasks"),
+                                        
+                                        layerList = cms.vstring(),
+                                        )
 

--- a/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
+++ b/FastSimulation/Tracking/python/TrajectorySeedProducer_cfi.py
@@ -4,15 +4,6 @@ from RecoTracker.TkTrackingRegions.GlobalTrackingRegionFromBeamSpot_cfi import *
 from RecoTracker.TkSeedGenerator.SeedFromConsecutiveHitsCreator_cfi import *
 
 trajectorySeedProducer = cms.EDProducer("TrajectorySeedProducer",
-                                        
-    simTrackSelection = cms.PSet(
-         # The smallest pT (in GeV) to create a track candidate 
-         pTMin = cms.double(-1),
-         # skip SimTracks processed in previous iterations
-         #skipSimTrackIds = cms.VInputTag(),
-         maxZ0 = cms.double(-1),
-         maxD0 = cms.double(-1),
-         ),
                                         SeedCreatorPSet = cms.PSet(SeedFromConsecutiveHitsCreator.clone(TTRHBuilder = cms.string("WithoutRefit"))),
                                         # minimum number of layer crossed (with hits on them) by the simtrack
                                         minLayersCrossed = cms.uint32(0),

--- a/FastSimulation/Tracking/python/iterativeTk_cff.py
+++ b/FastSimulation/Tracking/python/iterativeTk_cff.py
@@ -4,7 +4,7 @@
 ##############################
 
 import FWCore.ParameterSet.Config as cms
-
+from TrackingTools.MaterialEffects.MaterialPropagatorParabolicMf_cff import *
 from FastSimulation.Tracking.InitialStep_cff import *
 from FastSimulation.Tracking.DetachedTripletStep_cff import *
 from FastSimulation.Tracking.LowPtTripletStep_cff import *

--- a/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
@@ -3,8 +3,8 @@
  * Description:  see SiPixelGaussianSmearingRecHitConverterAlgorithm.h
  * Authors:  R. Ranieri (CERN), M. Galanti
  * History: Oct 11, 2006 -  initial version
- * 
- * New Pixel Resolution Parameterization 
+ *
+ * New Pixel Resolution Parameterization
  * Introduce SiPixelTemplate Object to Assign Pixel Errors
  * by G. Hu
  * ---------------------------------------------------------------------
@@ -53,7 +53,7 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
   if( thePixelPart == GeomDetEnumerators::PixelBarrel ) {
      isForward = false;
      thePixelResolutionFileName1 = pset_.getParameter<string>( "NewPixelBarrelResolutionFile1" );
-     thePixelResolutionFile1 = new 
+     thePixelResolutionFile1 = new
        TFile( edm::FileInPath( thePixelResolutionFileName1 ).fullPath().c_str()  ,"READ");
      thePixelResolutionFileName2 =  pset_.getParameter<string>( "NewPixelBarrelResolutionFile2" );
      thePixelResolutionFile2 = new
@@ -65,7 +65,7 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
      initializeBarrel();
      tempId = pset_.getParameter<int> ( "templateIdBarrel" );
      if( ! SiPixelTemplate::pushfile(tempId, thePixelTemp_) )
-         throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
+	 throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
 	 	<<"SiPixel Barrel Template Not Loaded Correctly!"<<endl;
 #ifdef  FAMOS_DEBUG
      cout<<"The Barrel map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
@@ -84,8 +84,8 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
      initializeForward();
      tempId = pset_.getParameter<int> ( "templateIdForward" );
      if( ! SiPixelTemplate::pushfile(tempId, thePixelTemp_) )
-         throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
-	        <<"SiPixel Forward Template Not Loaded Correctly!"<<endl;
+	 throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
+		<<"SiPixel Forward Template Not Loaded Correctly!"<<endl;
 #ifdef  FAMOS_DEBUG
      cout<<"The Forward map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
 #endif
@@ -108,7 +108,7 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
 
 SiPixelGaussianSmearingRecHitConverterAlgorithm::~SiPixelGaussianSmearingRecHitConverterAlgorithm()
 {
-  
+
   std::map<unsigned,const SimpleHistogramGenerator*>::const_iterator it;
   for ( it=theXHistos.begin(); it!=theXHistos.end(); ++it )
     delete it->second;
@@ -129,7 +129,7 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
 {
 
 #ifdef FAMOS_DEBUG
-  std::cout << " Pixel smearing in " << thePixelPart 
+  std::cout << " Pixel smearing in " << thePixelPart
 	    << std::endl;
 #endif
   //
@@ -154,8 +154,8 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
     if( cotbeta < 0 ) sign=-1.;
     cotbeta = sign*cotbeta;
   }
-  
-  
+
+
   //
 #ifdef FAMOS_DEBUG
   std::cout << " Local Direction " << simHit.localDirection()
@@ -163,7 +163,7 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
 	    << " cotbeta(y) = "  << cotbeta
 	    << std::endl;
 #endif
-  
+
   const PixelTopology* theSpecificTopology = &(detUnit->specificType().specificTopology());
   const RectangularPixelTopology *rectPixelTopology = static_cast<const RectangularPixelTopology*>(theSpecificTopology);
 
@@ -207,7 +207,7 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   if( ybin < 0 )    ybin = 0;
   if( ybin > 39 )   ybin = 39;
   if( xbin < 0 )    xbin = 0;
-  if( xbin > 39 )   xbin = 39; 
+  if( xbin > 39 )   xbin = 39;
 
   //Variables for SiPixelTemplate output
   //qBin -- normalized pixel charge deposition
@@ -224,8 +224,8 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   double ysizeProbability = random->flatShoot();
   bool hitbigx = rectPixelTopology->isItBigPixelInX( (int)mpx );
   bool hitbigy = rectPixelTopology->isItBigPixelInY( (int)mpy );
-  
-  if( hitbigx ) 
+
+  if( hitbigx )
     if( xsizeProbability < nx2_frac )  singlex = true;
     else singlex = false;
   else
@@ -238,7 +238,7 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   else
     if( ysizeProbability < ny1_frac )  singley = true;
     else singley = false;
-  
+
 
 
   // random multiplicity for alpha and beta
@@ -351,42 +351,42 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
       theErrorX = 31.0*microntocm;
       theErrorY = 90.0*microntocm;
     }
-    
-  }  
+
+  }
   else {
     if( singlex )
       if ( hitbigx )
-        theErrorX = sx2*microntocm;
+	theErrorX = sx2*microntocm;
       else
-        theErrorX = sx1*microntocm;
+	theErrorX = sx1*microntocm;
     else  theErrorX = sigmax*microntocm;
     if( singley )
       if( hitbigy )
-        theErrorY = sy2*microntocm;
+	theErrorY = sy2*microntocm;
       else
-        theErrorY = sy1*microntocm;
+	theErrorY = sy1*microntocm;
     else  theErrorY = sigmay*microntocm;
   }
   theErrorZ = 1e-8; // 1 um means zero
   theError = LocalError( theErrorX*theErrorX, 0., theErrorY*theErrorY);
-  // Local Error is 2D: (xx,xy,yy), square of sigma in first an third position 
+  // Local Error is 2D: (xx,xy,yy), square of sigma in first an third position
   // as for resolution matrix
   //
 #ifdef FAMOS_DEBUG
   std::cout << " Pixel Errors "
 	    << "\talpha(x) = " << theErrorX
 	    << "\tbeta(y) = "  << theErrorY
-	    << std::endl;	
+	    << std::endl;
 #endif
   // Generate position
   // get resolution histograms
   int cotalphaHistBin = (int)( ( cotalpha - rescotAlpha_binMin ) / rescotAlpha_binWidth + 1 );
   int cotbetaHistBin  = (int)( ( cotbeta  - rescotBeta_binMin )  / rescotBeta_binWidth + 1 );
   // protection against out-of-range (undeflows and overflows)
-  if( cotalphaHistBin < 1 ) cotalphaHistBin = 1; 
-  if( cotbetaHistBin  < 1 ) cotbetaHistBin  = 1; 
-  if( cotalphaHistBin > (int)rescotAlpha_binN ) cotalphaHistBin = (int)rescotAlpha_binN; 
-  if( cotbetaHistBin  > (int)rescotBeta_binN  ) cotbetaHistBin  = (int)rescotBeta_binN; 
+  if( cotalphaHistBin < 1 ) cotalphaHistBin = 1;
+  if( cotbetaHistBin  < 1 ) cotbetaHistBin  = 1;
+  if( cotalphaHistBin > (int)rescotAlpha_binN ) cotalphaHistBin = (int)rescotAlpha_binN;
+  if( cotbetaHistBin  > (int)rescotBeta_binN  ) cotbetaHistBin  = (int)rescotBeta_binN;
   //
   unsigned int theXHistN;
   unsigned int theYHistN;
@@ -395,7 +395,7 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
      if(edge)
      {
        theXHistN = cotalphaHistBin * 1000 + cotbetaHistBin * 10	 +  (nqbin+1);
-       theYHistN = theXHistN;	      
+       theYHistN = theXHistN;
      }
      else
      {
@@ -436,7 +436,7 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
      else
      {
        if( singlex )
-         if( hitbigx )
+	 if( hitbigx )
 	   theXHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
 	 else{
        	   theXHistN = cotbetaHistBin * 10 + cotalphaHistBin;
@@ -447,14 +447,14 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
 	     // theXHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
        }
        if( singley )
-         if( hitbigy )
+	 if( hitbigy )
 	   theYHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
 	 else{
  	   theYHistN = cotbetaHistBin * 10 + cotalphaHistBin;
        //  	   theYHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
 	 }
        else{
-	           	  theYHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 + (nqbin+1);
+			  theYHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 + (nqbin+1);
 			  //theYHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
        }
      }
@@ -470,42 +470,42 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
     //protect from empty resolution histograms
     //if( thePositionX > 0.0799 )  thePositionX = 0;
     //if( thePositionY > 0.0799 )  thePositionY = 0;
-    thePosition = 
-      Local3DPoint(simHit.localPosition().x() + thePositionX , 
-                   simHit.localPosition().y() + thePositionY , 
-                   simHit.localPosition().z() + thePositionZ );
+    thePosition =
+      Local3DPoint(simHit.localPosition().x() + thePositionX ,
+		   simHit.localPosition().y() + thePositionY ,
+		   simHit.localPosition().z() + thePositionZ );
 #ifdef FAMOS_DEBUG
     std::cout << " Detector bounds: "
-              << "\t\tx = " << boundX
-              << "\ty = " << boundY
-              << std::endl;
+	      << "\t\tx = " << boundX
+	      << "\ty = " << boundY
+	      << std::endl;
     std::cout << " Generated local position "
-              << "\tx = " << thePosition.x()
-              << "\ty = " << thePosition.y()
-              << std::endl;       
-#endif  
+	      << "\tx = " << thePosition.x()
+	      << "\ty = " << thePosition.y()
+	      << std::endl;
+#endif
     counter++;
     if(counter > 20) {
-      thePosition = Local3DPoint(simHit.localPosition().x(), 
-                                 simHit.localPosition().y(), 
-                                 simHit.localPosition().z());
+      thePosition = Local3DPoint(simHit.localPosition().x(),
+				 simHit.localPosition().y(),
+				 simHit.localPosition().z());
       break;
     }
   } while(fabs(thePosition.x()) > boundX  || fabs(thePosition.y()) > boundY);
 
 }
- 
+
 //-----------------------------------------------------------------------------
 // I COPIED FROM THE PixelCPEBase BECAUSE IT'S BETTER THAN REINVENT IT
 // The isFlipped() is a silly way to determine which detectors are inverted.
 // In the barrel for every 2nd ladder the E field direction is in the
 // global r direction (points outside from the z axis), every other
-// ladder has the E field inside. Something similar is in the 
+// ladder has the E field inside. Something similar is in the
 // forward disks (2 sides of the blade). This has to be recognised
 // because the charge sharing effect is different.
 //
 // The isFliped does it by looking and the relation of the local (z always
-// in the E direction) to global coordinates. There is probably a much 
+// in the E direction) to global coordinates. There is probably a much
 // better way.(PJ: And faster!)
 //-----------------------------------------------------------------------------
 bool SiPixelGaussianSmearingRecHitConverterAlgorithm::isFlipped(const PixelGeomDetUnit* theDet) const {
@@ -514,7 +514,7 @@ bool SiPixelGaussianSmearingRecHitConverterAlgorithm::isFlipped(const PixelGeomD
   float tmp2 = theDet->surface().toGlobal(Local3DPoint(0.,0.,1.)).perp();
   //  std::cout << " 1: " << tmp1 << " 2: " << tmp2 << std::endl;
   if ( tmp2<tmp1 ) return true;
-  else return false;    
+  else return false;
 }
 
 void SiPixelGaussianSmearingRecHitConverterAlgorithm::initializeBarrel()
@@ -533,61 +533,61 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::initializeBarrel()
   // Initialize the barrel histos once and for all, and prepare the random generation
   for ( unsigned cotalphaHistBin=1; cotalphaHistBin<=rescotAlpha_binN; ++cotalphaHistBin )
      for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )  {
-         unsigned int singleBigPixelHistN = 1 * 100000
-                                        + cotalphaHistBin * 100
-                                        + cotbetaHistBin ;
-         theXHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
-              (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singleBigPixelHistN ) ) );
-         theYHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
-              (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , singleBigPixelHistN ) ) );
+	 unsigned int singleBigPixelHistN = 1 * 100000
+					+ cotalphaHistBin * 100
+					+ cotbetaHistBin ;
+	 theXHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
+	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singleBigPixelHistN ) ) );
+	 theYHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
+	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , singleBigPixelHistN ) ) );
 	 /*         unsigned int singlePixelHistN = 1 * 100000 + 1 * 1000
-                                        + cotalphaHistBin * 100
-                                        + cotbetaHistBin ;
-         theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
-              (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singlePixelHistN ) ) );
-         theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+					+ cotalphaHistBin * 100
+					+ cotbetaHistBin ;
+	 theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singlePixelHistN ) ) );
+	 theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
 	 (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , singlePixelHistN ) ) );*/
 	 unsigned int singlePixelHistN = 1 * 10000
-                                       + cotbetaHistBin * 10
-	                               + cotalphaHistBin ;
-         theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+				       + cotbetaHistBin * 10
+				       + cotalphaHistBin ;
+	 theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
 	  (TH1F*) thePixelResolutionFile3->Get(  Form( "hx%u" , singlePixelHistN ) ) );
-         theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+	 theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
 	  (TH1F*) thePixelResolutionFile3->Get(  Form( "hy%u" , singlePixelHistN ) ) );
 
-         for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
-             unsigned int edgePixelHistN = cotalphaHistBin * 1000
-                                        +  cotbetaHistBin * 10
-                                        +  qbinBin;
-             theXHistos[edgePixelHistN] = new SimpleHistogramGenerator(
-              (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hx0%u" ,edgePixelHistN ) ) );
-             theYHistos[edgePixelHistN] = new SimpleHistogramGenerator(
-              (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hy0%u" ,edgePixelHistN ) ) );
-             unsigned int multiPixelBigHistN = 1 * 1000000 + 1 * 100000
-                                           + cotalphaHistBin * 1000
-                                           + cotbetaHistBin * 10
-                                           + qbinBin;
-             theXHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
-              (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" ,multiPixelBigHistN ) ) );
-             theYHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
-              (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" ,multiPixelBigHistN ) ) );
+	 for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
+	     unsigned int edgePixelHistN = cotalphaHistBin * 1000
+					+  cotbetaHistBin * 10
+					+  qbinBin;
+	     theXHistos[edgePixelHistN] = new SimpleHistogramGenerator(
+	      (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hx0%u" ,edgePixelHistN ) ) );
+	     theYHistos[edgePixelHistN] = new SimpleHistogramGenerator(
+	      (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hy0%u" ,edgePixelHistN ) ) );
+	     unsigned int multiPixelBigHistN = 1 * 1000000 + 1 * 100000
+					   + cotalphaHistBin * 1000
+					   + cotbetaHistBin * 10
+					   + qbinBin;
+	     theXHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
+	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" ,multiPixelBigHistN ) ) );
+	     theYHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
+	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" ,multiPixelBigHistN ) ) );
 	     /*             unsigned int multiPixelHistN = 1 * 1000000 + 1 * 100000 + 1 * 10000
-                                           + cotalphaHistBin * 1000
-                                           + cotbetaHistBin * 10
-                                           + qbinBin;
-             theXHistos[multiPixelHistN] = new SimpleHistogramGenerator(
-             (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , multiPixelHistN ) ) );
-             theYHistos[multiPixelHistN] = new SimpleHistogramGenerator(
-             (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , multiPixelHistN ) ) );*/
+					   + cotalphaHistBin * 1000
+					   + cotbetaHistBin * 10
+					   + qbinBin;
+	     theXHistos[multiPixelHistN] = new SimpleHistogramGenerator(
+	     (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , multiPixelHistN ) ) );
+	     theYHistos[multiPixelHistN] = new SimpleHistogramGenerator(
+	     (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , multiPixelHistN ) ) );*/
 	     unsigned int multiPixelHistN = 1 * 100000 + 1 * 10000
-                                         + cotbetaHistBin * 100
-                                         + cotalphaHistBin * 10
-	                                 + qbinBin;
+					 + cotbetaHistBin * 100
+					 + cotalphaHistBin * 10
+					 + qbinBin;
 	     theXHistos[multiPixelHistN] = new SimpleHistogramGenerator(
 	      (TH1F*) thePixelResolutionFile3->Get(  Form( "hx%u" , multiPixelHistN ) ) );
 	     theYHistos[multiPixelHistN] = new SimpleHistogramGenerator(
 	      (TH1F*) thePixelResolutionFile3->Get(  Form( "hy%u" , multiPixelHistN ) ) );
-          } //end for qbinBin
+	  } //end for qbinBin
      }//end for cotalphaHistBin, cotbetaHistBin
 }
 
@@ -606,8 +606,8 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::initializeForward()
 
   // Initialize the forward histos once and for all, and prepare the random generation
   for ( unsigned cotalphaHistBin=1; cotalphaHistBin<=rescotAlpha_binN; ++cotalphaHistBin )
-     for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )  
-         for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
+     for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )
+	 for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
 	    unsigned int edgePixelHistN = cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  qbinBin;
 	    theXHistos[edgePixelHistN] = new SimpleHistogramGenerator(
 	    (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx0%u" ,edgePixelHistN ) ) );
@@ -623,7 +623,7 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::initializeForward()
 	     (TH1F*) thePixelResolutionFile2->Get(  Form( "hx0%u" ,PixelHistN ) ) );
 	    theYHistos[PixelHistN] = new SimpleHistogramGenerator(
 	     (TH1F*) thePixelResolutionFile2->Get(  Form( "hy0%u" ,PixelHistN ) ) );
-	  
+
 	 }//end cotalphaHistBin, cotbetaHistBin, qbinBin
 
   for ( unsigned cotalphaHistBin=1; cotalphaHistBin<=rescotAlpha_binN; ++cotalphaHistBin )

--- a/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
@@ -38,9 +38,9 @@ const double microntocm = 0.0001;
 using namespace std;
 
 SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitConverterAlgorithm(
-  const edm::ParameterSet& pset,
-  GeomDetType::SubDetector pixelPart)
-:
+												 const edm::ParameterSet& pset,
+												 GeomDetType::SubDetector pixelPart)
+  :
   pset_(pset),
   thePixelPart(pixelPart)
 {
@@ -51,48 +51,48 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
   thePixelResolutionFile2=0;
 
   if( thePixelPart == GeomDetEnumerators::PixelBarrel ) {
-     isForward = false;
-     thePixelResolutionFileName1 = pset_.getParameter<string>( "NewPixelBarrelResolutionFile1" );
-     thePixelResolutionFile1 = new
-       TFile( edm::FileInPath( thePixelResolutionFileName1 ).fullPath().c_str()  ,"READ");
-     thePixelResolutionFileName2 =  pset_.getParameter<string>( "NewPixelBarrelResolutionFile2" );
-     thePixelResolutionFile2 = new
-       TFile( edm::FileInPath( thePixelResolutionFileName2 ).fullPath().c_str()  ,"READ");
-     //ALICE
-     thePixelResolutionFileName3 = pset_.getParameter<string>( "NewPixelBarrelResolutionFile3" );
-     thePixelResolutionFile3 = new
-       TFile( edm::FileInPath( thePixelResolutionFileName3 ).fullPath().c_str()  ,"READ");
-     initializeBarrel();
-     tempId = pset_.getParameter<int> ( "templateIdBarrel" );
-     if( ! SiPixelTemplate::pushfile(tempId, thePixelTemp_) )
-	 throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
-	 	<<"SiPixel Barrel Template Not Loaded Correctly!"<<endl;
+    isForward = false;
+    thePixelResolutionFileName1 = pset_.getParameter<string>( "NewPixelBarrelResolutionFile1" );
+    thePixelResolutionFile1 = new
+      TFile( edm::FileInPath( thePixelResolutionFileName1 ).fullPath().c_str()  ,"READ");
+    thePixelResolutionFileName2 =  pset_.getParameter<string>( "NewPixelBarrelResolutionFile2" );
+    thePixelResolutionFile2 = new
+      TFile( edm::FileInPath( thePixelResolutionFileName2 ).fullPath().c_str()  ,"READ");
+    //ALICE
+    thePixelResolutionFileName3 = pset_.getParameter<string>( "NewPixelBarrelResolutionFile3" );
+    thePixelResolutionFile3 = new
+      TFile( edm::FileInPath( thePixelResolutionFileName3 ).fullPath().c_str()  ,"READ");
+    initializeBarrel();
+    tempId = pset_.getParameter<int> ( "templateIdBarrel" );
+    if( ! SiPixelTemplate::pushfile(tempId, thePixelTemp_) )
+      throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
+	<<"SiPixel Barrel Template Not Loaded Correctly!"<<endl;
 #ifdef  FAMOS_DEBUG
-     cout<<"The Barrel map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
+    cout<<"The Barrel map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
 #endif
   }
   else
-  if ( thePixelPart == GeomDetEnumerators::PixelEndcap ) {
-     isForward = true;
-     thePixelResolutionFileName1 = pset_.getParameter<string>( "NewPixelForwardResolutionFile" );
-     thePixelResolutionFile1 = new
-       TFile( edm::FileInPath( thePixelResolutionFileName1 ).fullPath().c_str()  ,"READ");
-     //ALICE
-     thePixelResolutionFileName2 = pset_.getParameter<string>( "NewPixelForwardResolutionFile2" );
-     thePixelResolutionFile2 = new
-       TFile( edm::FileInPath( thePixelResolutionFileName2 ).fullPath().c_str()  ,"READ");
-     initializeForward();
-     tempId = pset_.getParameter<int> ( "templateIdForward" );
-     if( ! SiPixelTemplate::pushfile(tempId, thePixelTemp_) )
-	 throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
-		<<"SiPixel Forward Template Not Loaded Correctly!"<<endl;
+    if ( thePixelPart == GeomDetEnumerators::PixelEndcap ) {
+      isForward = true;
+      thePixelResolutionFileName1 = pset_.getParameter<string>( "NewPixelForwardResolutionFile" );
+      thePixelResolutionFile1 = new
+	TFile( edm::FileInPath( thePixelResolutionFileName1 ).fullPath().c_str()  ,"READ");
+      //ALICE
+      thePixelResolutionFileName2 = pset_.getParameter<string>( "NewPixelForwardResolutionFile2" );
+      thePixelResolutionFile2 = new
+	TFile( edm::FileInPath( thePixelResolutionFileName2 ).fullPath().c_str()  ,"READ");
+      initializeForward();
+      tempId = pset_.getParameter<int> ( "templateIdForward" );
+      if( ! SiPixelTemplate::pushfile(tempId, thePixelTemp_) )
+	throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm:")
+	  <<"SiPixel Forward Template Not Loaded Correctly!"<<endl;
 #ifdef  FAMOS_DEBUG
-     cout<<"The Forward map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
+      cout<<"The Forward map size is "<<theXHistos.size()<<" and "<<theYHistos.size()<<endl;
 #endif
-  }
-  else
-     throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm :")
-       <<"Not a pixel detector"<<endl;
+    }
+    else
+      throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm :")
+	<<"Not a pixel detector"<<endl;
 
   if ( thePixelResolutionFile2) {
     thePixelResolutionFile2->Close();
@@ -121,11 +121,11 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::~SiPixelGaussianSmearingRecHitC
 }
 
 void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
-  const PSimHit& simHit,
-  const PixelGeomDetUnit* detUnit,
-  const double boundX,
-  const double boundY,
-  RandomEngineAndDistribution const* random)
+							       const PSimHit& simHit,
+							       const PixelGeomDetUnit* detUnit,
+							       const double boundX,
+							       const double boundY,
+							       RandomEngineAndDistribution const* random)
 {
 
 #ifdef FAMOS_DEBUG
@@ -244,8 +244,8 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   // random multiplicity for alpha and beta
   double qbinProbability = random->flatShoot();
   for(int i = 0; i<4; ++i) {
-     nqbin = i;
-     if(qbinProbability < qbin_frac[i]) break;
+    nqbin = i;
+    if(qbinProbability < qbin_frac[i]) break;
   }
 
   //Store interpolated pixel cluster profile
@@ -256,12 +256,12 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
 
   std::vector<double> ytemp(BYSIZE);
   for( int i=0; i<BYSIZE; ++i) {
-     ytemp[i]=(1.-yfrac)*ytempl[ybin][i]+yfrac*ytempl[ybin+1][i];
+    ytemp[i]=(1.-yfrac)*ytempl[ybin][i]+yfrac*ytempl[ybin+1][i];
   }
 
   std::vector<double> xtemp(BXSIZE);
   for(int i=0; i<BXSIZE; ++i) {
-     xtemp[i]=(1.-xfrac)*xtempl[xbin][i]+xfrac*xtempl[xbin+1][i];
+    xtemp[i]=(1.-xfrac)*xtempl[xbin][i]+xfrac*xtempl[xbin+1][i];
   }
 
   //Pixel readout threshold
@@ -274,21 +274,21 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   for( firstY = 0; firstY < BYSIZE; ++firstY ) {
     bool yCluster = ytemp[firstY] > qThreshold ;
     if( yCluster )
-    {
-      offsetY1 = BHY -firstY;
-      break;
-    }
+      {
+	offsetY1 = BHY -firstY;
+	break;
+      }
   }
   for( lastY = firstY; lastY < BYSIZE; ++lastY )
-  {
-    bool yCluster = ytemp[lastY] > qThreshold ;
-    if( !yCluster )
     {
-      lastY = lastY - 1;
-      offsetY2 = lastY - BHY;
-      break;
+      bool yCluster = ytemp[lastY] > qThreshold ;
+      if( !yCluster )
+	{
+	  lastY = lastY - 1;
+	  offsetY2 = lastY - BHY;
+	  break;
+	}
     }
-  }
 
   for( firstX = 0; firstX < BXSIZE; ++firstX )  {
     bool xCluster = xtemp[firstX] > qThreshold ;
@@ -347,10 +347,10 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
       theErrorY = 96.0*microntocm;
     }
     else
-    {
-      theErrorX = 31.0*microntocm;
-      theErrorY = 90.0*microntocm;
-    }
+      {
+	theErrorX = 31.0*microntocm;
+	theErrorY = 90.0*microntocm;
+      }
 
   }
   else {
@@ -392,73 +392,73 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   unsigned int theYHistN;
   //ALICE
   if( !isForward ) {
-     if(edge)
-     {
-       theXHistN = cotalphaHistBin * 1000 + cotbetaHistBin * 10	 +  (nqbin+1);
-       theYHistN = theXHistN;
-     }
-     else
-     {
-       if(singlex)
-       {
-	 if(hitbigx)  theXHistN = 1 * 100000 + cotalphaHistBin * 100 + cotbetaHistBin ;
-	 else   theXHistN = 1 * 10000 + cotbetaHistBin * 10 + cotalphaHistBin ;
-//else 	theXHistN = 1 * 100000 + 1 * 1000 + cotalphaHistBin * 100 + cotbetaHistBin ;
-       }
-       else
-       {
-	 if(hasBigPixelInX)  theXHistN = 1 * 1000000 + 1 * 100000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
-	 else   theXHistN = 1 * 100000 + 1 * 10000 + cotbetaHistBin * 100 + cotalphaHistBin * 10 + (nqbin+1);
-	 //else 	theXHistN = 1 * 1000000 + 1 * 100000 + 1 * 10000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
-       }
-       if(singley)
-       {
-	 if(hitbigy)  theYHistN = 1 * 100000 + cotalphaHistBin * 100 + cotbetaHistBin ;
-	 else   theYHistN = 1 * 10000 + cotbetaHistBin * 10 + cotalphaHistBin ;
-	 //	 else 	theYHistN = 1 * 100000 + 1 * 1000 + cotalphaHistBin * 100 + cotbetaHistBin ;
-       }
-       else
-       {
-	 if(hasBigPixelInY)  theYHistN = 1 * 1000000 + 1 * 100000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
-	 // else 	theYHistN = 1 * 1000000 + 1 * 100000 + 1 * 10000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
-	 else   theYHistN = 1 * 100000 + 1 * 10000 + cotbetaHistBin * 100 + cotalphaHistBin * 10 + (nqbin+1);
+    if(edge)
+      {
+	theXHistN = cotalphaHistBin * 1000 + cotbetaHistBin * 10	 +  (nqbin+1);
+	theYHistN = theXHistN;
+      }
+    else
+      {
+	if(singlex)
+	  {
+	    if(hitbigx)  theXHistN = 1 * 100000 + cotalphaHistBin * 100 + cotbetaHistBin ;
+	    else   theXHistN = 1 * 10000 + cotbetaHistBin * 10 + cotalphaHistBin ;
+	    //else 	theXHistN = 1 * 100000 + 1 * 1000 + cotalphaHistBin * 100 + cotbetaHistBin ;
+	  }
+	else
+	  {
+	    if(hasBigPixelInX)  theXHistN = 1 * 1000000 + 1 * 100000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
+	    else   theXHistN = 1 * 100000 + 1 * 10000 + cotbetaHistBin * 100 + cotalphaHistBin * 10 + (nqbin+1);
+	    //else 	theXHistN = 1 * 1000000 + 1 * 100000 + 1 * 10000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
+	  }
+	if(singley)
+	  {
+	    if(hitbigy)  theYHistN = 1 * 100000 + cotalphaHistBin * 100 + cotbetaHistBin ;
+	    else   theYHistN = 1 * 10000 + cotbetaHistBin * 10 + cotalphaHistBin ;
+	    //	 else 	theYHistN = 1 * 100000 + 1 * 1000 + cotalphaHistBin * 100 + cotbetaHistBin ;
+	  }
+	else
+	  {
+	    if(hasBigPixelInY)  theYHistN = 1 * 1000000 + 1 * 100000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
+	    // else 	theYHistN = 1 * 1000000 + 1 * 100000 + 1 * 10000 + cotalphaHistBin * 1000 + cotbetaHistBin * 10 + (nqbin+1);
+	    else   theYHistN = 1 * 100000 + 1 * 10000 + cotbetaHistBin * 100 + cotalphaHistBin * 10 + (nqbin+1);
 
-       }
-     }
+	  }
+      }
   }
   else
-  {
-     if(edge)
-     {
-       theXHistN = cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
-       theYHistN = theXHistN;
-     }
-     else
-     {
-       if( singlex )
-	 if( hitbigx )
-	   theXHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
-	 else{
-       	   theXHistN = cotbetaHistBin * 10 + cotalphaHistBin;
-       //	   theXHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
-	 }
-       else{
-	     theXHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 +  (nqbin+1);
-	     // theXHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
-       }
-       if( singley )
-	 if( hitbigy )
-	   theYHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
-	 else{
- 	   theYHistN = cotbetaHistBin * 10 + cotalphaHistBin;
-       //  	   theYHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
-	 }
-       else{
-			  theYHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 + (nqbin+1);
-			  //theYHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
-       }
-     }
-  }
+    {
+      if(edge)
+	{
+	  theXHistN = cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
+	  theYHistN = theXHistN;
+	}
+      else
+	{
+	  if( singlex )
+	    if( hitbigx )
+	      theXHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
+	    else{
+	      theXHistN = cotbetaHistBin * 10 + cotalphaHistBin;
+	      //	   theXHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
+	    }
+	  else{
+	    theXHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 +  (nqbin+1);
+	    // theXHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
+	  }
+	  if( singley )
+	    if( hitbigy )
+	      theYHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
+	    else{
+	      theYHistN = cotbetaHistBin * 10 + cotalphaHistBin;
+	      //  	   theYHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
+	    }
+	  else{
+	    theYHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 + (nqbin+1);
+	    //theYHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
+	  }
+	}
+    }
   unsigned int counter = 0;
   do {
     //
@@ -532,63 +532,63 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::initializeBarrel()
 
   // Initialize the barrel histos once and for all, and prepare the random generation
   for ( unsigned cotalphaHistBin=1; cotalphaHistBin<=rescotAlpha_binN; ++cotalphaHistBin )
-     for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )  {
-	 unsigned int singleBigPixelHistN = 1 * 100000
-					+ cotalphaHistBin * 100
-					+ cotbetaHistBin ;
-	 theXHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singleBigPixelHistN ) ) );
-	 theYHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , singleBigPixelHistN ) ) );
-	 /*         unsigned int singlePixelHistN = 1 * 100000 + 1 * 1000
-					+ cotalphaHistBin * 100
-					+ cotbetaHistBin ;
-	 theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singlePixelHistN ) ) );
-	 theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
-	 (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , singlePixelHistN ) ) );*/
-	 unsigned int singlePixelHistN = 1 * 10000
-				       + cotbetaHistBin * 10
-				       + cotalphaHistBin ;
-	 theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
-	  (TH1F*) thePixelResolutionFile3->Get(  Form( "hx%u" , singlePixelHistN ) ) );
-	 theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
-	  (TH1F*) thePixelResolutionFile3->Get(  Form( "hy%u" , singlePixelHistN ) ) );
+    for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )  {
+      unsigned int singleBigPixelHistN = 1 * 100000
+	+ cotalphaHistBin * 100
+	+ cotbetaHistBin ;
+      theXHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
+								     (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singleBigPixelHistN ) ) );
+      theYHistos[singleBigPixelHistN] = new SimpleHistogramGenerator(
+								     (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , singleBigPixelHistN ) ) );
+      /*         unsigned int singlePixelHistN = 1 * 100000 + 1 * 1000
+		 + cotalphaHistBin * 100
+		 + cotbetaHistBin ;
+		 theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+		 (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , singlePixelHistN ) ) );
+		 theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+		 (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , singlePixelHistN ) ) );*/
+      unsigned int singlePixelHistN = 1 * 10000
+	+ cotbetaHistBin * 10
+	+ cotalphaHistBin ;
+      theXHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+								  (TH1F*) thePixelResolutionFile3->Get(  Form( "hx%u" , singlePixelHistN ) ) );
+      theYHistos[singlePixelHistN] = new SimpleHistogramGenerator(
+								  (TH1F*) thePixelResolutionFile3->Get(  Form( "hy%u" , singlePixelHistN ) ) );
 
-	 for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
-	     unsigned int edgePixelHistN = cotalphaHistBin * 1000
-					+  cotbetaHistBin * 10
-					+  qbinBin;
-	     theXHistos[edgePixelHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hx0%u" ,edgePixelHistN ) ) );
-	     theYHistos[edgePixelHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hy0%u" ,edgePixelHistN ) ) );
-	     unsigned int multiPixelBigHistN = 1 * 1000000 + 1 * 100000
-					   + cotalphaHistBin * 1000
-					   + cotbetaHistBin * 10
-					   + qbinBin;
-	     theXHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" ,multiPixelBigHistN ) ) );
-	     theYHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" ,multiPixelBigHistN ) ) );
-	     /*             unsigned int multiPixelHistN = 1 * 1000000 + 1 * 100000 + 1 * 10000
-					   + cotalphaHistBin * 1000
-					   + cotbetaHistBin * 10
-					   + qbinBin;
-	     theXHistos[multiPixelHistN] = new SimpleHistogramGenerator(
-	     (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , multiPixelHistN ) ) );
-	     theYHistos[multiPixelHistN] = new SimpleHistogramGenerator(
-	     (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , multiPixelHistN ) ) );*/
-	     unsigned int multiPixelHistN = 1 * 100000 + 1 * 10000
-					 + cotbetaHistBin * 100
-					 + cotalphaHistBin * 10
-					 + qbinBin;
-	     theXHistos[multiPixelHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile3->Get(  Form( "hx%u" , multiPixelHistN ) ) );
-	     theYHistos[multiPixelHistN] = new SimpleHistogramGenerator(
-	      (TH1F*) thePixelResolutionFile3->Get(  Form( "hy%u" , multiPixelHistN ) ) );
-	  } //end for qbinBin
-     }//end for cotalphaHistBin, cotbetaHistBin
+      for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
+	unsigned int edgePixelHistN = cotalphaHistBin * 1000
+	  +  cotbetaHistBin * 10
+	  +  qbinBin;
+	theXHistos[edgePixelHistN] = new SimpleHistogramGenerator(
+								  (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hx0%u" ,edgePixelHistN ) ) );
+	theYHistos[edgePixelHistN] = new SimpleHistogramGenerator(
+								  (TH1F*) thePixelResolutionFile2->Get(  Form( "DQMData/clustBPIX/hy0%u" ,edgePixelHistN ) ) );
+	unsigned int multiPixelBigHistN = 1 * 1000000 + 1 * 100000
+	  + cotalphaHistBin * 1000
+	  + cotbetaHistBin * 10
+	  + qbinBin;
+	theXHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
+								      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" ,multiPixelBigHistN ) ) );
+	theYHistos[multiPixelBigHistN] = new SimpleHistogramGenerator(
+								      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" ,multiPixelBigHistN ) ) );
+	/*             unsigned int multiPixelHistN = 1 * 1000000 + 1 * 100000 + 1 * 10000
+		       + cotalphaHistBin * 1000
+		       + cotbetaHistBin * 10
+		       + qbinBin;
+		       theXHistos[multiPixelHistN] = new SimpleHistogramGenerator(
+		       (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hx%u" , multiPixelHistN ) ) );
+		       theYHistos[multiPixelHistN] = new SimpleHistogramGenerator(
+		       (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustBPIX/hy%u" , multiPixelHistN ) ) );*/
+	unsigned int multiPixelHistN = 1 * 100000 + 1 * 10000
+	  + cotbetaHistBin * 100
+	  + cotalphaHistBin * 10
+	  + qbinBin;
+	theXHistos[multiPixelHistN] = new SimpleHistogramGenerator(
+								   (TH1F*) thePixelResolutionFile3->Get(  Form( "hx%u" , multiPixelHistN ) ) );
+	theYHistos[multiPixelHistN] = new SimpleHistogramGenerator(
+								   (TH1F*) thePixelResolutionFile3->Get(  Form( "hy%u" , multiPixelHistN ) ) );
+      } //end for qbinBin
+    }//end for cotalphaHistBin, cotbetaHistBin
 }
 
 void SiPixelGaussianSmearingRecHitConverterAlgorithm::initializeForward()
@@ -606,44 +606,44 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::initializeForward()
 
   // Initialize the forward histos once and for all, and prepare the random generation
   for ( unsigned cotalphaHistBin=1; cotalphaHistBin<=rescotAlpha_binN; ++cotalphaHistBin )
-     for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )
-	 for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
-	    unsigned int edgePixelHistN = cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  qbinBin;
-	    theXHistos[edgePixelHistN] = new SimpleHistogramGenerator(
-	    (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx0%u" ,edgePixelHistN ) ) );
-	    theYHistos[edgePixelHistN] = new SimpleHistogramGenerator(
-	    (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy0%u" ,edgePixelHistN ) ) );
-	    /*	    	    	     	    unsigned int PixelHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  qbinBin;
-	    theXHistos[PixelHistN] = new SimpleHistogramGenerator(
-	    (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx%u" ,PixelHistN ) ) );
-	    theYHistos[PixelHistN] = new SimpleHistogramGenerator(
-	    (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy%u" ,PixelHistN ) ) );*/
-	     	    	    	    unsigned int PixelHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 +  qbinBin;
-	    theXHistos[PixelHistN] = new SimpleHistogramGenerator(
-	     (TH1F*) thePixelResolutionFile2->Get(  Form( "hx0%u" ,PixelHistN ) ) );
-	    theYHistos[PixelHistN] = new SimpleHistogramGenerator(
-	     (TH1F*) thePixelResolutionFile2->Get(  Form( "hy0%u" ,PixelHistN ) ) );
+    for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )
+      for( unsigned qbinBin=1;  qbinBin<=resqbin_binN; ++qbinBin )  {
+	unsigned int edgePixelHistN = cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  qbinBin;
+	theXHistos[edgePixelHistN] = new SimpleHistogramGenerator(
+								  (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx0%u" ,edgePixelHistN ) ) );
+	theYHistos[edgePixelHistN] = new SimpleHistogramGenerator(
+								  (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy0%u" ,edgePixelHistN ) ) );
+	/*	    	    	     	    unsigned int PixelHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  qbinBin;
+					    theXHistos[PixelHistN] = new SimpleHistogramGenerator(
+					    (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx%u" ,PixelHistN ) ) );
+					    theYHistos[PixelHistN] = new SimpleHistogramGenerator(
+					    (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy%u" ,PixelHistN ) ) );*/
+	unsigned int PixelHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 +  qbinBin;
+	theXHistos[PixelHistN] = new SimpleHistogramGenerator(
+							      (TH1F*) thePixelResolutionFile2->Get(  Form( "hx0%u" ,PixelHistN ) ) );
+	theYHistos[PixelHistN] = new SimpleHistogramGenerator(
+							      (TH1F*) thePixelResolutionFile2->Get(  Form( "hy0%u" ,PixelHistN ) ) );
 
-	 }//end cotalphaHistBin, cotbetaHistBin, qbinBin
+      }//end cotalphaHistBin, cotbetaHistBin, qbinBin
 
   for ( unsigned cotalphaHistBin=1; cotalphaHistBin<=rescotAlpha_binN; ++cotalphaHistBin )
     for ( unsigned cotbetaHistBin=1; cotbetaHistBin<=rescotBeta_binN; ++cotbetaHistBin )
-    {
-      unsigned int SingleBigPixelHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
-      theXHistos[SingleBigPixelHistN] = new SimpleHistogramGenerator(
-      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx%u" ,SingleBigPixelHistN ) ) );
-      theYHistos[SingleBigPixelHistN] = new SimpleHistogramGenerator(
-      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy%u" ,SingleBigPixelHistN ) ) );
-      /*      unsigned int SinglePixelHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
-      theXHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
-      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx%u" ,SinglePixelHistN ) ) );
-      theYHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
-      (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy%u" ,SinglePixelHistN ) ) );*/
-      unsigned int SinglePixelHistN = cotbetaHistBin * 10 + cotalphaHistBin;
-      theXHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
-								   (TH1F*) thePixelResolutionFile2->Get(  Form( "hx000%u" ,SinglePixelHistN ) ) );
-      theYHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
-      (TH1F*) thePixelResolutionFile2->Get(  Form( "hy000%u" ,SinglePixelHistN ) ) );
+      {
+	unsigned int SingleBigPixelHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
+	theXHistos[SingleBigPixelHistN] = new SimpleHistogramGenerator(
+								       (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx%u" ,SingleBigPixelHistN ) ) );
+	theYHistos[SingleBigPixelHistN] = new SimpleHistogramGenerator(
+								       (TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy%u" ,SingleBigPixelHistN ) ) );
+	/*      unsigned int SinglePixelHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
+		theXHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
+		(TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhx%u" ,SinglePixelHistN ) ) );
+		theYHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
+		(TH1F*) thePixelResolutionFile1->Get(  Form( "DQMData/clustFPIX/fhy%u" ,SinglePixelHistN ) ) );*/
+	unsigned int SinglePixelHistN = cotbetaHistBin * 10 + cotalphaHistBin;
+	theXHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
+								     (TH1F*) thePixelResolutionFile2->Get(  Form( "hx000%u" ,SinglePixelHistN ) ) );
+	theYHistos[SinglePixelHistN]  = new SimpleHistogramGenerator(
+								     (TH1F*) thePixelResolutionFile2->Get(  Form( "hy000%u" ,SinglePixelHistN ) ) );
 
-    }
+      }
 }

--- a/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
+++ b/FastSimulation/TrackingRecHitProducer/src/SiPixelGaussianSmearingRecHitConverterAlgorithm.cc
@@ -93,7 +93,6 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::SiPixelGaussianSmearingRecHitCo
     else
       throw cms::Exception("SiPixelGaussianSmearingRecHitConverterAlgorithm :")
 	<<"Not a pixel detector"<<endl;
-
   if ( thePixelResolutionFile2) {
     thePixelResolutionFile2->Close();
     delete thePixelResolutionFile2;
@@ -114,10 +113,9 @@ SiPixelGaussianSmearingRecHitConverterAlgorithm::~SiPixelGaussianSmearingRecHitC
     delete it->second;
   for ( it=theYHistos.begin(); it!=theYHistos.end(); ++it )
     delete it->second;
-
   theXHistos.clear();
   theYHistos.clear();
-
+  
 }
 
 void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
@@ -139,7 +137,6 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   float locx = localDir.x();
   float locy = localDir.y();
   float locz = localDir.z();
-
   // alpha: angle with respect to local x axis in local (x,z) plane
   float cotalpha = locx/locz;
   if ( isFlipped( detUnit ) ) { // &&& check for FPIX !!!
@@ -154,8 +151,6 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
     if( cotbeta < 0 ) sign=-1.;
     cotbeta = sign*cotbeta;
   }
-
-
   //
 #ifdef FAMOS_DEBUG
   std::cout << " Local Direction " << simHit.localDirection()
@@ -163,7 +158,6 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
 	    << " cotbeta(y) = "  << cotbeta
 	    << std::endl;
 #endif
-
   const PixelTopology* theSpecificTopology = &(detUnit->specificType().specificTopology());
   const RectangularPixelTopology *rectPixelTopology = static_cast<const RectangularPixelTopology*>(theSpecificTopology);
 
@@ -181,7 +175,6 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
 #ifdef FAMOS_DEBUG
   cout<<"Struck pixel center at pitch units x: "<<pixelCenterX<<" y: "<<pixelCenterY<<endl;
 #endif
-
   const MeasurementPoint mpCenter(pixelCenterX, pixelCenterY);
   //Transform the center of the struck pixel back into local position
   const Local3DPoint lpCenter = rectPixelTopology->localPosition( mpCenter );
@@ -190,7 +183,6 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
   cout<<"Struck pixel center at cm x: "<<lpCenter.x()<<" y: "<<lpCenter.y()<<endl;
   cout<<"The boundX is "<<boundX<<" boundY is "<<boundY<<endl;
 #endif
-
   //Get the relative position of struck point to the center of the struck pixel
   float xtrk = lp.x() - lpCenter.x();
   float ytrk = lp.y() - lpCenter.y();
@@ -440,18 +432,18 @@ void SiPixelGaussianSmearingRecHitConverterAlgorithm::smearHit(
 	      theXHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
 	    else{
 	      theXHistN = cotbetaHistBin * 10 + cotalphaHistBin;
-	      //	   theXHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
+	      //theXHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
 	    }
 	  else{
 	    theXHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 +  (nqbin+1);
-	    // theXHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
+	    //theXHistN = 100000 + 10000 + cotalphaHistBin * 1000 +  cotbetaHistBin * 10 +  (nqbin+1);
 	  }
 	  if( singley )
 	    if( hitbigy )
 	      theYHistN = 100000 + cotalphaHistBin * 100 + cotbetaHistBin;
 	    else{
 	      theYHistN = cotbetaHistBin * 10 + cotalphaHistBin;
-	      //  	   theYHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
+	      //theYHistN = 100000 + 1000 + cotalphaHistBin * 100 + cotbetaHistBin;
 	    }
 	  else{
 	    theYHistN = 10000 + cotbetaHistBin * 100 +  cotalphaHistBin * 10 + (nqbin+1);

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
-    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
+    ("DQM_CMSSW_7_6_X_2015-07-31-2300_AfterSeedStateBackPropagation.root", "Changed_FastSim_7_6_X_AfterSeedStateBackPropagation"),
+    ("DQM_V0001_R000000001__RelValTTbar_13__CMSSW_7_5_0_pre3-MCRUN2_74_V7_FastSim-v1__DQMIO.root", "StandardFastSim_7_5_0_pre3"),
 ]
 
 outputDir = "plots"

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_1.root", "DQM 1 details"),
-    ("DQM_2.root", "DQM 2 details"),
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_1.root", "Option 1"),
+    ("DQM_V0001_R000000001__Global__CMSSW_X_Y_Z__RECO_2.root", "Option 2"),
 ]
 
 outputDir = "plots"

--- a/Validation/RecoTrack/test/trackingCompare.py
+++ b/Validation/RecoTrack/test/trackingCompare.py
@@ -11,8 +11,8 @@ import Validation.RecoTrack.plotting.trackingPlots as trackingPlots
 
 # Example of file - label pairs
 filesLabels = [
-    ("DQM_CMSSW_7_6_X_2015-07-31-2300_AfterSeedStateBackPropagation.root", "Changed_FastSim_7_6_X_AfterSeedStateBackPropagation"),
-    ("DQM_V0001_R000000001__RelValTTbar_13__CMSSW_7_5_0_pre3-MCRUN2_74_V7_FastSim-v1__DQMIO.root", "StandardFastSim_7_5_0_pre3"),
+    ("DQM_1.root", "DQM 1 details"),
+    ("DQM_2.root", "DQM 2 details"),
 ]
 
 outputDir = "plots"


### PR DESCRIPTION
Got rid of all direct sim-info for creating seed and tracks. Instead fullsim global region and seed creator is used to create seeds. Moreover, track candidates are now initialized using back propagated seed state and not sim-track and sim-vertex information.
