### PR TITLE
Update the default relval for the recoMET tests

### DIFF
--- a/RecoMET/METProducers/python/testInputFiles_cff.py
+++ b/RecoMET/METProducers/python/testInputFiles_cff.py
@@ -5,9 +5,9 @@ from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 recoMETtestInputFiles = pickRelValInputFiles(
     useDAS = True,
     cmsswVersion = 'CMSSW_7_5_0',
-    dataTier = 'GEN-SIM-RECO',
+    dataTier = 'GEN-SIM-DIGI-RECO',
     relVal = 'RelValTTbar_13',
-    globalTag = 'PU25ns_75X_mcRun2_asymptotic_v1',
+    globalTag = '75X_mcRun2_asymptotic_v1_FastSim',
     maxVersions = 2
     )
 

--- a/RecoMET/METProducers/python/testInputFiles_cff.py
+++ b/RecoMET/METProducers/python/testInputFiles_cff.py
@@ -4,10 +4,10 @@ import FWCore.ParameterSet.Config as cms
 from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 recoMETtestInputFiles = pickRelValInputFiles(
     useDAS = True,
-    cmsswVersion = 'CMSSW_7_2_0_pre1',
+    cmsswVersion = 'CMSSW_7_5_0',
     dataTier = 'GEN-SIM-RECO',
     relVal = 'RelValTTbar_13',
-    globalTag = 'PU50ns_POSTLS172_V2',
+    globalTag = 'PU25ns_75X_mcRun2_asymptotic_v1',
     maxVersions = 2
     )
 

--- a/RecoMET/METProducers/test/recoMET_pfClusterMet_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_pfClusterMet_cfg.py
@@ -34,8 +34,12 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 ##____________________________________________________________________________||
 process.p = cms.Path(
+    process.particleFlowClusterHF*
+    process.particleFlowClusterHO*
     process.pfClusterRefsForJetsHCAL*
     process.pfClusterRefsForJetsECAL*
+    process.pfClusterRefsForJetsHF*
+    process.pfClusterRefsForJetsHO*
     process.pfClusterRefsForJets *
     process.pfClusterMet
     )


### PR DESCRIPTION
Update of the relval files used in the recoMET tests. 
Don't have any impact on the framework.
