### PR TITLE
First version of a "unit-test" like regression test for conditions

### DIFF
--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -1,24 +1,31 @@
-<flags   GENREFLEX_ARGS="--"/>
+<flags CXXFLAGS="-g -std=c++11"/>
 
 <use   name="CondCore/CondDB"/>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
-<library   name="testCondDBDict" file="">
+
+<library   name="testCondDBDict" file="*.cc">
 </library>
-<bin   file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">
-  <lib   name="testCondDBDict"/>
+
+<bin file="testReadWritePayloads.cpp" name="testReadWritePayloads">
+  <lib name="testCondDBDict"/>
 </bin>
-<bin   file="testConditionDatabase_1.cpp" name="testConditionDatabase_1">
+
+<bin file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">
+  <lib name="testCondDBDict"/>
 </bin>
-<bin   file="testConditionDatabase_2.cpp" name="testConditionDatabase_2">
+
+<bin file="testConditionDatabase_1.cpp" name="testConditionDatabase_1"></bin>
+<bin file="testConditionDatabase_2.cpp" name="testConditionDatabase_2"></bin>
+
+<bin file="testRootStreaming.cpp" name="testRootStreaming">
+  <lib name="testCondDBDict"/>
 </bin>
-<bin   file="testRootStreaming.cpp" name="testRootStreaming">
-  <lib   name="testCondDBDict"/>
+
+<bin file="testPayloadProxy.cpp" name="testPayloadProxy">
+  <lib name="testCondDBDict"/>
 </bin>
-<bin   file="testPayloadProxy.cpp" name="testPayloadProxy">
-  <lib   name="testCondDBDict"/>
-</bin>
-<bin   file="testFrontier.cpp" name="testFrontier">
-</bin>
+
+<bin file="testFrontier.cpp" name="testFrontier"></bin>

--- a/CondCore/CondDB/test/condTestRegression.py
+++ b/CondCore/CondDB/test/condTestRegression.py
@@ -52,6 +52,7 @@ class CondRegressionTester(object):
           if not os.path.exists(self.logDir): os.makedirs(self.logDir)
 
           # add the IB/release itself:
+	  self.regTestSrcDir = os.path.join( os.environ['LOCALRT'], 'src', 'CondCore', 'CondDB', 'test' )
           self.rel = os.environ['CMSSW_VERSION']
           self.arch = os.environ['SCRAM_ARCH']
 	  self.dbName = 'self-%s-%s.db' % (self.rel, self.arch)
@@ -93,9 +94,9 @@ class CondRegressionTester(object):
           cmd = 'cd %s/%s/src; eval `scram run -sh`; ' % (self.topDir, rel, )
           cmd += 'git cms-addpkg CondCore/CondDB 2>&1; cd CondCore/CondDB/test; '
 	  if not os.path.exists( os.path.join( self.topDir, rel, 'src', 'CondCore/CondDB/test/testReadWritePayloads.cpp') ):
-             print "copying over test source ... "
-	     cmd += 'cp /afs/cern.ch/user/a/andreasp/public/BuildFile.xml .;'
-             cmd += 'cp /afs/cern.ch/user/a/andreasp/public/testReadWritePayloads.cpp .;'
+             print "copying over test source and BuildFile from devArea/IB ... "
+	     cmd += 'cp %s/BuildFile.xml .;' % (self.regTestSrcDir,)
+             cmd += 'cp %s/testReadWritePayloads.cpp .;' % (self.regTestSrcDir,)
           cmd += 'scram b -j 10 2>&1 ;'
           res = check_output(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
 

--- a/CondCore/CondDB/test/condTestRegression.py
+++ b/CondCore/CondDB/test/condTestRegression.py
@@ -178,6 +178,8 @@ class CondRegressionTester(object):
                   'CMSSW_7_5_1'        : [ 'slc6_amd64_gcc491', 'ref751-s6491.db'],
                   'CMSSW_7_4_9'        : [ 'slc6_amd64_gcc491', 'ref749-s6491.db'],
                   'CMSSW_7_3_6_patch1' : [ 'slc6_amd64_gcc491', 'ref736p1-s6491.db'],
+		  'CMSSW_7_2_5'       : [ 'slc6_amd64_gcc481', 'ref729-s6481.db'],
+		  'CMSSW_7_1_19'       : [ 'slc6_amd64_gcc481', 'ref7119-s6481.db'],
           }
 
           # set up the devel areas for the various reference releases

--- a/CondCore/CondDB/test/condTestRegression.py
+++ b/CondCore/CondDB/test/condTestRegression.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-import os
+import sys, os
 import time
 import subprocess
 
@@ -141,12 +141,14 @@ class CondRegressionTester(object):
                   'CMSSW_7_4_9'      : [ 'slc6_amd64_gcc491', 'ref749-s6491.db'],
           }
 
+          # set up the devel areas for the various reference releases
           print '='*80
           print "going to set up areas ..."
           for rel, info in map.items():
              arch, dbName = info
              self.setup(rel, arch)
           
+          # write all DBs (including the one from this IB/devArea)
           print '='*80
           print "going to write DBs ..."
           self.runSelf('write')
@@ -154,7 +156,7 @@ class CondRegressionTester(object):
              arch, dbName = info
              self.run(rel, arch, 'write', dbName)
           
-
+          # now try to read back with all reference releases all the DBs written before ...
           print '='*80
           print "going to read back DBs ..."
           for rel, info in map.items():
@@ -165,6 +167,8 @@ class CondRegressionTester(object):
                     self.status['%s-%s-%s' % (rel,arch,item)] = True
                  except:
                     self.status['%s-%s-%s' % (rel,arch,item)] = False
+
+          # ... and also with this IB/devArea
           for item in self.dbNameList: # for any given rel/arch we check all written DBs
              try:
                 self.runSelf('read', item)
@@ -176,5 +180,12 @@ class CondRegressionTester(object):
 
 crt = CondRegressionTester()
 crt.runAll()
-print "\n==> overall status: ", crt.summary(verbose=True)
+status = crt.summary(verbose=True)
+print "\n==> overall status: ", status
+
+# return the overall result to the caller:
+if status: 
+   sys.exit(0)
+else:
+   sys.exit(-1)
 

--- a/CondCore/CondDB/test/condTestRegression.py
+++ b/CondCore/CondDB/test/condTestRegression.py
@@ -95,6 +95,10 @@ class CondRegressionTester(object):
 
           overall = True
           for k,v in self.status.items():
+              # do not take results from 7.1.X into the overall status as this release can not 
+	      # read more recent data until the corresponding boost 1.57 version is backported:
+              if 'CMSSW_7_1_' in k: continue
+
               if not v : overall = False
 
           return overall
@@ -224,7 +228,7 @@ class CondRegressionTester(object):
 crt = CondRegressionTester()
 crt.runAll()
 status = crt.summary(verbose=True)
-print "\n==> overall status: ", status
+print "\n==> overall status (ignoring results from 7.1.X): ", status
 
 # return the overall result to the caller:
 if status: 

--- a/CondCore/CondDB/test/condTestRegression.py
+++ b/CondCore/CondDB/test/condTestRegression.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python
+
+import os
+import time
+import subprocess
+
+
+def check_output(*popenargs, **kwargs):
+    '''Mimics subprocess.check_output() in Python 2.6
+    '''
+
+    process = subprocess.Popen(*popenargs, **kwargs)
+    stdout, stderr = process.communicate()
+    returnCode = process.returncode
+
+    if returnCode:
+        print 'ERROR from process (ret=%s): ' %(str(returnCode),)
+	print '      stderr: %s' % (str(stderr),)
+	print '      stdout: %s' % (str(stdout),)
+        cmd = kwargs.get("args")
+        if cmd is None:
+            cmd = popenargs[0]
+        raise subprocess.CalledProcessError(returnCode, cmd)
+
+    return stdout
+
+
+# nice one from:
+# https://www.daniweb.com/software-development/python/code/216610/timing-a-function-python
+def print_timing(func):
+    def wrapper(*arg):
+        t1 = time.time()
+        res = func(*arg)
+        t2 = time.time()
+        print '\n%s(%s) took %0.3f ms\n' % (func.func_name, ','.join([str(x) for x in arg[1:]]), (t2-t1)*1000.0)
+        return res
+    return wrapper
+
+
+class CondRegressionTester(object):
+
+      @print_timing
+      def __init__(self):
+
+          self.topDir = '/tmp/cmsCondRegTst-2015-08-13-16-14' # +time.strftime('%Y-%m-%d-%H-%M')
+          if not os.path.exists(self.topDir): os.makedirs(self.topDir)
+          
+          self.dbDir = os.path.join( self.topDir, 'dbDir' )
+          if not os.path.exists(self.dbDir): os.makedirs(self.dbDir)
+          
+          self.logDir = os.path.join( self.topDir, 'logs' )
+          if not os.path.exists(self.logDir): os.makedirs(self.logDir)
+
+          # add the IB/release itself:
+          self.rel = os.environ['CMSSW_VERSION']
+          self.arch = os.environ['SCRAM_ARCH']
+	  self.dbName = 'self-%s-%s.db' % (self.rel, self.arch)
+
+          self.dbNameList = [ self.dbName ]
+
+	  self.status = {}
+          
+          return
+
+      def summary(self, verbose=False):
+          if verbose: 
+              import json
+              print json.dumps( self.status, sort_keys=True, indent=4 )
+
+          overall = True
+          for k,v in self.status.items():
+              if not v : overall = False
+
+          return overall
+
+
+      @print_timing
+      def setup(self, rel, arch):
+
+      	  # check if we need to do anything at all:
+      	  if os.path.exists( os.path.join( self.topDir, rel, 'test', arch, 'testReadWritePayloads' ) ): 
+             print "area for %s/%s already setup: found %s " % (rel, arch, os.path.join( self.topDir, rel, 'test', arch, 'testReadWritePayloads' ))
+          #    return
+
+          # prepare the devel area, if it does not yet exist:
+          if not os.path.exists( os.path.join( self.topDir, rel, 'src') ):
+             print "going to create devel area for %s/%s " % (rel, arch)
+             cmd = 'cd %s; export SCRAM_ARCH=%s; scram p CMSSW %s' % (self.topDir, arch, rel)
+             res = check_output(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+          
+          # check out the package and build the tests
+          print "going to build the test for %s/%s " % (rel, arch)
+          cmd = 'cd %s/%s/src; eval `scram run -sh`; ' % (self.topDir, rel, )
+          cmd += 'git cms-addpkg CondCore/CondDB 2>&1; cd CondCore/CondDB/test; '
+	  if not os.path.exists( os.path.join( self.topDir, rel, 'src', 'CondCore/CondDB/test/testReadWritePayloads.cpp') ):
+             print "copying over test source ... "
+	     cmd += 'cp /afs/cern.ch/user/a/andreasp/public/BuildFile.xml .;'
+             cmd += 'cp /afs/cern.ch/user/a/andreasp/public/testReadWritePayloads.cpp .;'
+          cmd += 'scram b -j 10 2>&1 ;'
+          res = check_output(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+          with open(os.path.join(self.logDir, rel+arch+'-build.log'), 'w') as logFile:
+             logFile.write( ''.join(res) )	
+
+      @print_timing
+      def run(self, rel, arch, readOrWrite, dbName):
+
+          cmd = 'cd %s/%s/src; eval `scram run -sh 2>/dev/null` ; ' % (self.topDir, rel, )
+          cmd += '../test/%s/testReadWritePayloads %s sqlite_file:///%s/%s ' % (arch, readOrWrite, self.dbDir, dbName)
+          
+          res = check_output(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+          with open(os.path.join(self.logDir, rel+arch+'-'+readOrWrite+'.log'), 'w') as logFile:
+             logFile.write( ''.join(res) )
+
+          if readOrWrite == 'write':
+              self.dbNameList.append( dbName )
+
+      @print_timing
+      def runSelf(self, readOrWrite, dbNameIn=None):
+
+          dbName = self.dbName # set the default
+          if dbNameIn : dbName = dbNameIn
+
+          # we run in the local environment, but need to make sure that we start "top-level" of the devel area
+          # and we assume that the test was already built 
+          cmd = 'cd %s/src; eval `scram run -sh 2>/dev/null` ; ' % (os.environ['CMSSW_BASE'], )
+          cmd += '../test/%s/testReadWritePayloads %s sqlite_file:///%s/%s ' % (self.arch, readOrWrite, self.dbDir, dbName)
+          
+          res = check_output(cmd, shell=True, stdin=subprocess.PIPE, stdout=subprocess.PIPE)
+
+          with open(os.path.join(self.logDir, self.rel+self.arch+'-'+readOrWrite+'.log'), 'w') as logFile:
+             logFile.write( ''.join(res) )
+
+
+      @print_timing
+      def runAll(self):
+
+          map = { 'CMSSW_7_6_0_pre2' : [ 'slc6_amd64_gcc493', 'ref76pre2-s6493.db'],
+                  'CMSSW_7_5_1'      : [ 'slc6_amd64_gcc491', 'ref751-s6491.db'],
+                  'CMSSW_7_4_9'      : [ 'slc6_amd64_gcc491', 'ref749-s6491.db'],
+          }
+
+          print '='*80
+          print "going to set up areas ..."
+          for rel, info in map.items():
+             arch, dbName = info
+             self.setup(rel, arch)
+          
+          print '='*80
+          print "going to write DBs ..."
+          self.runSelf('write')
+          for rel, info in map.items():
+             arch, dbName = info
+             self.run(rel, arch, 'write', dbName)
+          
+
+          print '='*80
+          print "going to read back DBs ..."
+          for rel, info in map.items():
+             arch, dbName = info
+             for item in self.dbNameList: # for any given rel/arch we check all written DBs
+                 try:
+                    self.run(rel, arch, 'read', item)
+                    self.status['%s-%s-%s' % (rel,arch,item)] = True
+                 except:
+                    self.status['%s-%s-%s' % (rel,arch,item)] = False
+          for item in self.dbNameList: # for any given rel/arch we check all written DBs
+             try:
+                self.runSelf('read', item)
+                self.status['%s-%s-%s' % (self.rel,self.arch,item)] = True
+             except:
+                self.status['%s-%s-%s' % (self.rel,self.arch,item)] = False
+
+          print '='*80
+
+crt = CondRegressionTester()
+crt.runAll()
+print "\n==> overall status: ", crt.summary(verbose=True)
+

--- a/CondCore/CondDB/test/testReadWritePayloads.cpp
+++ b/CondCore/CondDB/test/testReadWritePayloads.cpp
@@ -1,0 +1,271 @@
+
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+//
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+//
+#include "CondCore/DBCommon/interface/DbConnection.h"
+#include "CondCore/DBCommon/interface/DbTransaction.h"
+#include "CondCore/DBCommon/interface/DbSession.h"
+#include "MyTestData.h"
+// #include "ArrayPayload.h"
+// #include "SimplePayload.h"
+//
+#include <fstream>
+#include <iomanip>
+#include <cstdlib>
+#include <iostream>
+
+using namespace cond::persistency;
+
+// define values here, so we can check them after reading back ...
+const int iVal0( 18); // 17
+const int iVal1(909); // 999
+const std::string sVal("7890abcd"); // "abcd1234"
+
+
+int doWrite( const std::string& connectionString ){
+  try{
+
+    //*************
+    std::cout <<"> Connecting for writing with db in "<<connectionString<<std::endl;
+    ConnectionPool connPool;
+    connPool.setMessageVerbosity( coral::Debug );
+    Session session = connPool.createSession( connectionString, true, cond::COND_DB );
+    session.transaction().start( false );
+
+    MyTestData d0( iVal0 );
+    MyTestData d1( iVal1 );
+    std::cout <<"> Storing payload ptr=" << &d0 << std::endl;
+    cond::Hash p0 = session.storePayload( d0, boost::posix_time::microsec_clock::universal_time() );
+    cond::Hash p1 = session.storePayload( d1, boost::posix_time::microsec_clock::universal_time() );
+
+    std::string d(sVal);
+    cond::Hash p3 = session.storePayload( d, boost::posix_time::microsec_clock::universal_time() );
+
+    // ArrayPayload arrayPl( );
+    // cond::Hash ap0 = session.storePayload( arrayPl, boost::posix_time::microsec_clock::universal_time() );
+
+    // SimplePayload simplePl( 43 );
+    // cond::Hash sp0 = session.storePayload( simplePl, boost::posix_time::microsec_clock::universal_time() );
+
+    IOVEditor editor;
+    if( !session.existsIov( "MyNewIOV" ) ){
+      editor = session.createIov<MyTestData>( "MyNewIOV", cond::runnumber ); 
+      editor.setDescription("Test with MyTestData class");
+      editor.insert( 1, p0 );
+      editor.insert( 100, p1 );
+      std::cout <<"> inserted 2 iovs..."<<std::endl;
+      editor.flush();
+      std::cout <<"> iov changes flushed..."<<std::endl;
+    }
+
+    if( !session.existsIov( "StringData" ) ){
+      editor = session.createIov<std::string>( "StringData", cond::timestamp );
+      editor.setDescription("Test with std::string class");
+      editor.insert( 1000000, p3 );
+      editor.insert( 2000000, p3 );
+      editor.flush();
+    }
+
+//     if( !session.existsIov( "ArrayData" ) ){
+//       editor = session.createIov<ArrayPayload>( "ArrayData", cond::timestamp );
+//       editor.setDescription("Test with ArrayPayload class");
+//       editor.insert( 1000000, ap0 );
+//       editor.insert( 2000000, ap0 );
+//       editor.flush();
+//     }
+// 
+//     if( !session.existsIov( "SimpleData" ) ){
+//       editor = session.createIov<SimplePayload>( "SimpleData", cond::timestamp );
+//       editor.setDescription("Test with SimplePayload class");
+//       editor.insert( 1000000, sp0 );
+//       editor.insert( 2000000, sp0 );
+//       editor.flush();
+//     }
+
+    session.transaction().commit();
+    std::cout <<"> iov changes committed!..."<<std::endl;
+
+    session.transaction().commit();
+  } catch (const std::exception& e){
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return -1;
+  } catch (...){
+    std::cout << "UNEXPECTED FAILURE." << std::endl;
+    return -1;
+  }
+  std::cout <<"## Run successfully completed."<<std::endl;
+  return 0;
+}
+
+int doRead( const std::string& connectionString ){
+
+  int nFail = 0;
+  try{
+
+    //*************
+    std::cout <<"> Connecting for reading with db in "<<connectionString<<std::endl;
+    ConnectionPool connPool;
+    connPool.setMessageVerbosity( coral::Debug );
+    Session session = connPool.createSession( connectionString, true, cond::COND_DB );
+    session.transaction().start( false );
+
+    session.transaction().start();
+
+    IOVProxy proxy = session.readIov( "MyNewIOV" );
+    std::cout <<"> iov loaded size="<<proxy.loadedSize()<<std::endl;
+    std::cout <<"> iov sequence size="<<proxy.sequenceSize()<<std::endl;
+    IOVProxy::Iterator iovIt = proxy.find( 57 );
+    if( iovIt == proxy.end() ){
+      std::cout <<">[0] not found!"<<std::endl;
+    } else {
+      cond::Iov_t val = *iovIt;
+      std::cout <<"#[0] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+      boost::shared_ptr<MyTestData> pay0 = session.fetchPayload<MyTestData>( val.payloadId );
+      pay0->print();
+      if ( *pay0 != MyTestData(iVal0) ){
+	nFail++;
+	std::cout << "ERROR, pay0 found to be wrong, expected : " << iVal0 << " IOV: " << val.since << std::endl;
+      }
+      iovIt++;
+    }
+    if(iovIt == proxy.end() ){
+      std::cout<<"#[1] not found!"<<std::endl;
+    } else {
+      cond::Iov_t val =*iovIt;
+      std::cout <<"#[1] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+      boost::shared_ptr<MyTestData> pay1 = session.fetchPayload<MyTestData>( val.payloadId );
+      pay1->print();
+      if ( *pay1 != MyTestData(iVal1) ){
+	nFail++;
+	std::cout << "ERROR, pay1 found to be wrong, expected : " << iVal1 << " IOV: " << val.since << std::endl;
+      }
+    }
+    iovIt = proxy.find( 176 );
+    if( iovIt == proxy.end() ){
+      std::cout <<"#[2] not found!"<<std::endl;
+    } else {
+      cond::Iov_t val = *iovIt;
+      std::cout <<"#[2] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+      boost::shared_ptr<MyTestData> pay2 = session.fetchPayload<MyTestData>( val.payloadId );
+      pay2->print();
+      if ( *pay2 != MyTestData(iVal1) ){
+	nFail++;
+	std::cout << "ERROR, pay2 found to be wrong, expected : " << iVal1 << " IOV: " << val.since << std::endl;
+      }
+      iovIt++;
+    }
+    if(iovIt == proxy.end() ){
+      std::cout<<"#[3] not found!"<<std::endl;
+    } else {
+      cond::Iov_t val =*iovIt;
+      std::cout <<"#[3] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+      boost::shared_ptr<MyTestData> pay3 = session.fetchPayload<MyTestData>( val.payloadId );
+      pay3->print();
+      if ( *pay3 != MyTestData(iVal1) ){
+	nFail++;
+	std::cout << "ERROR, pay3 found to be wrong, expected : " << iVal1 << " IOV: " << val.since << std::endl;
+      }
+    }
+
+    proxy = session.readIov( "StringData" ); 
+    auto iov2It = proxy.find( 1000022 );
+    if(iov2It == proxy.end() ){
+      std::cout<<"#[4] not found!"<<std::endl;
+    } else {
+      cond::Iov_t val =*iov2It;
+      std::cout <<"#[4] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+      boost::shared_ptr<std::string> pay4 = session.fetchPayload<std::string>( val.payloadId );
+      std::cout <<"#pay4="<<*pay4<<std::endl;
+      if ( *pay4 != sVal ){
+	nFail++;
+	std::cout << "ERROR, pay4 found to be " << *pay4 << " expected : " << sVal << " IOV: " << val.since << std::endl;
+      }
+    }
+
+//     proxy = session.readIov( "ArrayData" ); 
+//     auto iov3It = proxy.find( 1000022 );
+//     if(iov3It == proxy.end() ){
+//       std::cout<<"#[5] not found!"<<std::endl;
+//     } else {
+//       cond::Iov_t val =*iov3It;
+//       std::cout <<"#[5] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+//       boost::shared_ptr<ArrayPayload> pay5 = session.fetchPayload<ArrayPayload>( val.payloadId );
+//       // std::cout << "#pay5=" << (*pay5==arrayPl ? "OK" : "NOT OK") << std::endl;
+//     }
+// 
+//     proxy = session.readIov( "SimpleData" ); 
+//     auto iov4It = proxy.find( 1000022 );
+//     if(iov4It == proxy.end() ){
+//       std::cout<<"#[6] not found!"<<std::endl;
+//     } else {
+//       cond::Iov_t val =*iov4It;
+//       std::cout <<"#[6] iov since="<<val.since<<" till="<<val.till<<" pid="<<val.payloadId<<std::endl;
+//       boost::shared_ptr<SimplePayload> pay5 = session.fetchPayload<SimplePayload>( val.payloadId );
+//       // std::cout << "#pay6=" << (*pay6==simplePl ? "OK" : "NOT OK") << std::endl;
+//     }
+
+
+    session.transaction().commit();
+  } catch (const std::exception& e){
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return -1;
+  } catch (...){
+    std::cout << "UNEXPECTED FAILURE." << std::endl;
+    return -1;
+  }
+  if (nFail == 0) {
+    std::cout << "## Run successfully completed." << std::endl;
+  } else {
+    std::cout << "## Run completed with ERRORS. nFail = " << nFail << std::endl;
+  }
+
+  return nFail;
+}
+
+int run( const std::string& connectionString ){
+
+  int ret = doWrite( connectionString ); 
+  if ( ret != 0 ) return ret;
+
+  ::sleep(2);
+  ret = doRead ( connectionString );
+
+  return ret;
+}
+
+
+int main (int argc, char** argv)
+{
+  int ret = 0;
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+  std::cout <<"## Running with CondDBV2 format..."<<std::endl;
+
+  if (argc < 3) {
+    std::cout << "Error: not enough arguments. " << std::endl;
+    std::cout << "expected: (write|read) <dbName> " << std::endl;
+    return -1;
+  }
+
+  std::string connectionString0("sqlite_file:cms_conditions_v2.db");
+  if ( std::string(argv[2]).size() > 3 ) {
+    connectionString0 = std::string( argv[2] );
+  }
+
+
+  if (std::string(argv[1]) == "write") {
+    ret = doWrite( connectionString0 );
+  } else if (std::string(argv[1]) == "read") {
+    ret = doRead ( connectionString0 );
+  } else {
+    ret = run( connectionString0 );
+  }
+
+  return ret;
+}
+

--- a/CondCore/CondDB/test/testReadWritePayloads.cpp
+++ b/CondCore/CondDB/test/testReadWritePayloads.cpp
@@ -247,9 +247,10 @@ int main (int argc, char** argv)
   std::cout <<"## Running with CondDBV2 format..."<<std::endl;
 
   if (argc < 3) {
-    std::cout << "Error: not enough arguments. " << std::endl;
-    std::cout << "expected: (write|read) <dbName> " << std::endl;
-    return -1;
+    std::cout << "Not enough arguments given, assuming automatic run in unit-tests. Will not do anything. " << std::endl;
+    std::cout << "If you did not expect this, please run it with the arguments as follows:" << std::endl;
+    std::cout << "testReadWritePayloads (write|read) <dbName> " << std::endl;
+    return 0;
   }
 
   std::string connectionString0("sqlite_file:cms_conditions_v2.db");


### PR DESCRIPTION
This PR contains the code for a "unit-test" like regression test for conditions. 
The core testing code is in the "test/testReadWritePayloads.cpp" file, while the main/controlling script is "test/condTestRegression.py". The controlling script creates a directory in /tmp/ (which will be re-used by later invocations on the same machine), there sets up development areas for the "reference releases", 
if needed, copies over (from the IB/devArea) and builds the core code, then invokes the core script to write some conditions into a database for each reference release and the actual IB/devArea. Once the (sqlite) DBs are written, the script loops over all releases (reference and actual IB/devArea) and reads all existing DBs. If any error is found, it exits with -1, otherwise with 0.
