### PR TITLE
[DQM/BeamMonitor] fix y-axis range to properly display d0-phi plot

### DIFF
--- a/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
+++ b/DQM/BeamMonitor/plugins/AlcaBeamMonitor.cc
@@ -200,7 +200,7 @@ void AlcaBeamMonitor::beginRun(const edm::Run& r, const EventSetup& context) {
   // create and cd into new folder
   dbe_->setCurrentFolder(monitorName_+"Validation");
   //Book histograms
-  hD0Phi0_ = dbe_->bookProfile("hD0Phi0","d_{0} vs. #phi_{0} (All Tracks)",63,-3.15,3.15,100,-0.1,0.1,"");
+  hD0Phi0_ = dbe_->bookProfile("hD0Phi0","d_{0} vs. #phi_{0} (All Tracks)",63,-3.15,3.15,100,-0.5,0.5,"");
   hD0Phi0_->setAxisTitle("#phi_{0} (rad)",1);
   hD0Phi0_->setAxisTitle("d_{0} (cm)",2);
 


### PR DESCRIPTION
We found y-axis range to be too narrow, causing the sinusoidal d0-phi distribution to be capped.
The attached plots show the effect of a too narrow y-axis range. 

![hd0phi0](https://cloud.githubusercontent.com/assets/5147955/9271310/1a976c44-4279-11e5-9b42-00fcfac4476e.png)
![hd0phi0_narrowrange](https://cloud.githubusercontent.com/assets/5147955/9271309/1a7be6fe-4279-11e5-85d3-88bed76fbccb.png)
