### PR TITLE
Pixel cluster splitting and jet core iteration for HI Tracking

### DIFF
--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -33,20 +33,26 @@ from RecoHI.HiEgammaAlgos.HiElectronSequence_cff import *
 from RecoLuminosity.LumiProducer.lumiProducer_cff import *
 #--------------------------------------------------------------------------
 
+from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
+siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(
+    src = 'siPixelClustersPreSplitting'
+    )
+
 caloReco = cms.Sequence(ecalLocalRecoSequence*hcalLocalRecoSequence)
 hbhereco = hbheprereco.clone()
 hcalLocalRecoSequence.replace(hbheprereco,hbhereco)
-muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEvent+siPixelClusterShapeCache+muonlocalreco)
+#muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEvent+siPixelClusterShapeCache+muonlocalreco)
+muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEventPreSplitting+siPixelClusterShapeCachePreSplitting+muonlocalreco)
 localReco = cms.Sequence(offlineBeamSpot*muonReco*caloReco*castorreco)
 
 #hbherecoMB = hbheprerecoMB.clone()
 #hcalLocalRecoSequenceNZS.replace(hbheprerecoMB,hbherecoMB)
+
 caloRecoNZS = cms.Sequence(caloReco+hcalLocalRecoSequenceNZS)
 localReco_HcalNZS = cms.Sequence(offlineBeamSpot*muonReco*caloRecoNZS)
 
 #--------------------------------------------------------------------------
 # Main Sequence
-
 reconstruct_PbPb = cms.Sequence(localReco*globalRecoPbPb*CastorFullReco)
 reconstructionHeavyIons = cms.Sequence(reconstruct_PbPb)
 

--- a/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
+++ b/Configuration/StandardSequences/python/ReconstructionHeavyIons_cff.py
@@ -41,7 +41,6 @@ siPixelClusterShapeCachePreSplitting = siPixelClusterShapeCache.clone(
 caloReco = cms.Sequence(ecalLocalRecoSequence*hcalLocalRecoSequence)
 hbhereco = hbheprereco.clone()
 hcalLocalRecoSequence.replace(hbheprereco,hbhereco)
-#muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEvent+siPixelClusterShapeCache+muonlocalreco)
 muonReco = cms.Sequence(trackerlocalreco+MeasurementTrackerEventPreSplitting+siPixelClusterShapeCachePreSplitting+muonlocalreco)
 localReco = cms.Sequence(offlineBeamSpot*muonReco*caloReco*castorreco)
 

--- a/RecoHI/Configuration/python/Reconstruction_HI_cff.py
+++ b/RecoHI/Configuration/python/Reconstruction_HI_cff.py
@@ -17,7 +17,7 @@ ecalDrivenGsfElectrons.minSCEtEndcaps = cms.double(15.0)
 from RecoHI.HiJetAlgos.HiRecoJets_cff import *
 
 # Muon Reco
-from RecoHI.HiMuonAlgos.HiRecoMuon_cff import *
+from RecoHI.HiMuonAlgos.HiRecoMuon_cff import * 
 # keep regit seperate for the moment
 from RecoHI.HiMuonAlgos.HiRegionalRecoMuon_cff import *
 
@@ -33,12 +33,12 @@ from RecoMET.METProducers.hcalnoiseinfoproducer_cfi import *
 hcalnoise.trackCollName = 'hiGeneralTracks'
 
 # Global + High-Level Reco Sequence
-globalRecoPbPb = cms.Sequence(hiTracking
+globalRecoPbPb = cms.Sequence(hiTracking_wSplitting
                               * hiParticleFlowLocalReco
                               * hiEcalClusters
                               * hiRecoJets
                               * muonRecoPbPb
-                              * hiElectronSequence
+                              * hiElectronSequence 
                               * hiEgammaSequence
                               * hiParticleFlowReco
                               * hiCentrality
@@ -62,9 +62,10 @@ globalRecoPbPb_wConformalPixel = cms.Sequence(hiTracking_wConformalPixel
                                               )
 
 #--------------------------------------------------------------------------
-# Full sequence (LOCAL RECO + HIGH LEVEL RECO)
+# Full sequence (LOCAL RECO + HIGH LEVEL RECO) 
 # in Configuration.StandardSequences.ReconstructionHeavyIons_cff
 
 # Modify zero-suppression sequence here
 from RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi import *
 siStripZeroSuppression.storeCM = cms.bool(True)
+

--- a/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
@@ -1,0 +1,18 @@
+import FWCore.ParameterSet.Config as cms
+
+#from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets
+from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import calotowermaker
+from RecoHI.HiJetAlgos.HiRecoJets_cff import akPu4CaloJets
+from JetMETCorrections.Configuration.DefaultJEC_cff import *
+
+hiCaloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbhereco'))
+akPu4CaloJetsForTrk = akPu4CaloJets.clone( srcPVs = cms.InputTag('hiSelectedVertex'), src= cms.InputTag('hiCaloTowerForTrk'))
+#srcPVs would be change in hiJetCoreRegionalStep
+
+
+akPu4CaloJetsCorrected  = ak4CaloJetsL2L3.clone(
+    src = cms.InputTag("akPu4CaloJetsForTrk")
+)
+
+
+hiCaloJetsForTrk = cms.Sequence(hiCaloTowerForTrk*akPu4CaloJetsForTrk*akPu4CaloJetsCorrected)

--- a/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
@@ -12,5 +12,10 @@ akPu4CaloJetsCorrected  = ak4CaloJetsL2L3.clone(
     src = cms.InputTag("akPu4CaloJetsForTrk")
 )
 
+akPu4CaloJetsSelected = cms.EDFilter( "LargestEtCaloJetSelector",
+    src = cms.InputTag( "akPu4CaloJetsCorrected" ),
+    filter = cms.bool( False ),
+    maxNumber = cms.uint32( 4 )
+)
 
-hiCaloJetsForTrk = cms.Sequence(hiCaloTowerForTrk*akPu4CaloJetsForTrk*akPu4CaloJetsCorrected)
+hiCaloJetsForTrk = cms.Sequence(hiCaloTowerForTrk*akPu4CaloJetsForTrk*akPu4CaloJetsCorrected*akPu4CaloJetsSelected)

--- a/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
+++ b/RecoHI/HiJetAlgos/python/hiCaloJetsForTrk_cff.py
@@ -1,13 +1,11 @@
 import FWCore.ParameterSet.Config as cms
 
-#from RecoJets.JetProducers.ak4CaloJets_cfi import ak4CaloJets
 from RecoLocalCalo.CaloTowersCreator.calotowermaker_cfi import calotowermaker
 from RecoHI.HiJetAlgos.HiRecoJets_cff import akPu4CaloJets
 from JetMETCorrections.Configuration.DefaultJEC_cff import *
 
 hiCaloTowerForTrk = calotowermaker.clone(hbheInput=cms.InputTag('hbhereco'))
 akPu4CaloJetsForTrk = akPu4CaloJets.clone( srcPVs = cms.InputTag('hiSelectedVertex'), src= cms.InputTag('hiCaloTowerForTrk'))
-#srcPVs would be change in hiJetCoreRegionalStep
 
 
 akPu4CaloJetsCorrected  = ak4CaloJetsL2L3.clone(

--- a/RecoHI/HiTracking/python/HIInitialJetCoreClusterSplitting_cff.py
+++ b/RecoHI/HiTracking/python/HIInitialJetCoreClusterSplitting_cff.py
@@ -13,8 +13,10 @@ hiAkPu4CaloJetsForTrkPreSplitting = akPu4CaloJetsForTrk.clone(
     srcPVs = 'hiSelectedVertexPreSplitting')
 hiAkPu4CaloJetsCorrectedPreSplitting = akPu4CaloJetsCorrected.clone(
     src = 'hiAkPu4CaloJetsForTrkPreSplitting')
-hiJetsForCoreTrackingPreSplitting = hiJetsForCoreTracking.clone(
+hiAkPu4CaloJetsSelectedPreSplitting = akPu4CaloJetsSelected.clone(
     src = 'hiAkPu4CaloJetsCorrectedPreSplitting')
+hiJetsForCoreTrackingPreSplitting = hiJetsForCoreTracking.clone(
+    src = 'hiAkPu4CaloJetsSelectedPreSplitting')
 
 
 from RecoLocalTracker.SubCollectionProducers.jetCoreClusterSplitter_cfi import jetCoreClusterSplitter
@@ -34,6 +36,7 @@ hiInitialJetCoreClusterSplitting = cms.Sequence(
                                 * hiCaloTowerForTrkPreSplitting
                                 * hiAkPu4CaloJetsForTrkPreSplitting
 								* hiAkPu4CaloJetsCorrectedPreSplitting
+				* hiAkPu4CaloJetsSelectedPreSplitting
                                 * hiJetsForCoreTrackingPreSplitting
 				* siPixelClusters
                                 * siPixelRecHits

--- a/RecoHI/HiTracking/python/HIInitialJetCoreClusterSplitting_cff.py
+++ b/RecoHI/HiTracking/python/HIInitialJetCoreClusterSplitting_cff.py
@@ -1,0 +1,41 @@
+import FWCore.ParameterSet.Config as cms
+
+### pixel primary vertices
+from RecoHI.HiTracking.HIPixelVerticesPreSplitting_cff import *
+
+#Jet Core emulation to identify jet-tracks
+#modify the original hiAk4CaloJetsForTrkPreSplitting to hiAkPu4CaloJetsForTrkPreSplitting from HIJET reco
+from RecoHI.HiJetAlgos.hiCaloJetsForTrk_cff import *
+from RecoHI.HiTracking.hiJetCoreRegionalStep_cff import hiJetsForCoreTracking
+hiCaloTowerForTrkPreSplitting = hiCaloTowerForTrk.clone()
+hiAkPu4CaloJetsForTrkPreSplitting = akPu4CaloJetsForTrk.clone(
+    src = 'hiCaloTowerForTrkPreSplitting',
+    srcPVs = 'hiSelectedVertexPreSplitting')
+hiAkPu4CaloJetsCorrectedPreSplitting = akPu4CaloJetsCorrected.clone(
+    src = 'hiAkPu4CaloJetsForTrkPreSplitting')
+hiJetsForCoreTrackingPreSplitting = hiJetsForCoreTracking.clone(
+    src = 'hiAkPu4CaloJetsCorrectedPreSplitting')
+
+
+from RecoLocalTracker.SubCollectionProducers.jetCoreClusterSplitter_cfi import jetCoreClusterSplitter
+siPixelClusters = jetCoreClusterSplitter.clone(
+    pixelClusters = cms.InputTag('siPixelClustersPreSplitting'),
+    vertices      = 'hiSelectedVertexPreSplitting',
+    cores         = 'hiJetsForCoreTrackingPreSplitting',
+    deltaRmax     = cms.double(0.1),
+    ptMin = cms.double(50)
+)
+
+from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import siPixelRecHits
+from RecoTracker.MeasurementDet.MeasurementTrackerEventProducer_cfi import MeasurementTrackerEvent
+from RecoPixelVertexing.PixelLowPtUtilities.siPixelClusterShapeCache_cfi import *
+hiInitialJetCoreClusterSplitting = cms.Sequence(
+                                hiPixelVerticesPreSplitting
+                                * hiCaloTowerForTrkPreSplitting
+                                * hiAkPu4CaloJetsForTrkPreSplitting
+								* hiAkPu4CaloJetsCorrectedPreSplitting
+                                * hiJetsForCoreTrackingPreSplitting
+				* siPixelClusters
+                                * siPixelRecHits
+                                * MeasurementTrackerEvent
+                                * siPixelClusterShapeCache)

--- a/RecoHI/HiTracking/python/HIPixelVerticesPreSplitting_cff.py
+++ b/RecoHI/HiTracking/python/HIPixelVerticesPreSplitting_cff.py
@@ -1,0 +1,37 @@
+import FWCore.ParameterSet.Config as cms
+
+from RecoHI.HiTracking.HIPixelVertices_cff import *
+
+hiPixelClusterVertexPreSplitting = hiPixelClusterVertex.clone( pixelRecHits=cms.string("siPixelRecHitsPreSplitting") )
+hiPixel3ProtoTracksPreSplitting = hiPixel3ProtoTracks.clone()
+hiPixel3ProtoTracksPreSplitting.RegionFactoryPSet.RegionPSet.siPixelRecHits = cms.InputTag( "siPixelRecHitsPreSplitting" )
+hiPixel3ProtoTracksPreSplitting.RegionFactoryPSet.RegionPSet.VertexCollection = cms.InputTag( "hiPixelClusterVertexPreSplitting" )
+hiPixel3ProtoTracksPreSplitting.FilterPSet.siPixelRecHits = cms.InputTag( "siPixelRecHitsPreSplitting" )
+hiPixel3ProtoTracksPreSplitting.OrderedHitsFactoryPSet.SeedingLayers = cms.InputTag( "PixelLayerTripletsPreSplitting" )
+
+hiPixelMedianVertexPreSplitting = hiPixelMedianVertex.clone( TrackCollection = cms.InputTag('hiPixel3ProtoTracksPreSplitting') )
+hiSelectedProtoTracksPreSplitting = hiSelectedProtoTracks.clone(
+  src = cms.InputTag("hiPixel3ProtoTracksPreSplitting"),
+  VertexCollection = cms.InputTag("hiPixelMedianVertexPreSplitting")
+)
+hiPixelAdaptiveVertexPreSplitting = hiPixelAdaptiveVertex.clone(
+  TrackLabel = cms.InputTag("hiSelectedProtoTracksPreSplitting")
+)
+hiBestAdaptiveVertexPreSplitting = hiBestAdaptiveVertex.clone( src = cms.InputTag("hiPixelAdaptiveVertexPreSplitting") ) 
+hiSelectedVertexPreSplitting = hiSelectedVertex.clone( 
+  adaptiveVertexCollection = cms.InputTag("hiBestAdaptiveVertexPreSplitting"),
+  medianVertexCollection = cms.InputTag("hiPixelMedianVertexPreSplitting")
+)
+bestHiVertexPreSplitting = cms.Sequence( hiBestAdaptiveVertexPreSplitting * hiSelectedVertexPreSplitting )
+
+PixelLayerTripletsPreSplitting = PixelLayerTriplets.clone()
+PixelLayerTripletsPreSplitting.FPix.HitProducer = 'siPixelRecHitsPreSplitting'
+PixelLayerTripletsPreSplitting.BPix.HitProducer = 'siPixelRecHitsPreSplitting'
+
+hiPixelVerticesPreSplitting = cms.Sequence(hiPixelClusterVertexPreSplitting
+                                * PixelLayerTripletsPreSplitting
+                                * hiPixel3ProtoTracksPreSplitting
+                                * hiPixelMedianVertexPreSplitting
+                                * hiSelectedProtoTracksPreSplitting
+                                * hiPixelAdaptiveVertexPreSplitting
+                                * bestHiVertexPreSplitting )

--- a/RecoHI/HiTracking/python/HiTracking_cff.py
+++ b/RecoHI/HiTracking/python/HiTracking_cff.py
@@ -1,16 +1,31 @@
-
 from RecoHI.HiTracking.hiMergedConformalPixelTracking_cff import *
+from RecoHI.HiTracking.HIInitialJetCoreClusterSplitting_cff import *
 from RecoHI.HiTracking.LowPtTracking_PbPb_cff import *
 from RecoHI.HiTracking.hiLowPtTripletStep_cff import *
 from RecoHI.HiTracking.hiMixedTripletStep_cff import *
 from RecoHI.HiTracking.hiPixelPairStep_cff import *
 from RecoHI.HiTracking.hiDetachedTripletStep_cff import *
+from RecoHI.HiTracking.hiJetCoreRegionalStep_cff import *
 from RecoHI.HiTracking.MergeTrackCollectionsHI_cff import *
 
 from RecoHI.HiMuonAlgos.hiMuonIterativeTk_cff import *
 
+hiJetsForCoreTracking.cut = cms.string("pt > 100 && abs(eta) < 2.4")
+hiJetCoreRegionalStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = cms.double( 10. )
+hiJetCoreRegionalStepTrajectoryFilter.minPt = 10.0
+siPixelClusters.ptMin = cms.double(100)
+siPixelClusters.deltaRmax = cms.double(0.1)
+
 hiTracking_noRegitMu = cms.Sequence(
     hiBasicTracking
+    *hiDetachedTripletStep
+    *hiLowPtTripletStep
+    *hiPixelPairStep
+    )
+
+hiTracking_noRegitMu_wSplitting = cms.Sequence(
+    hiInitialJetCoreClusterSplitting
+    *hiBasicTracking
     *hiDetachedTripletStep
     *hiLowPtTripletStep
     *hiPixelPairStep
@@ -22,8 +37,14 @@ hiTracking = cms.Sequence(
     *hiGeneralTracks
     )
 
+hiTracking_wSplitting = cms.Sequence(
+    hiTracking_noRegitMu_wSplitting
+    *hiJetCoreRegionalStep 
+    *hiRegitMuTrackingAndSta
+    *hiGeneralTracks
+    )
+
 hiTracking_wConformalPixel = cms.Sequence(
     hiTracking
     *hiMergedConformalPixelTracking 
     )
-

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -5,9 +5,10 @@ hiGeneralTracksNoRegitMu = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.t
     TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
                       cms.InputTag('hiDetachedTripletStepTracks'),
                       cms.InputTag('hiLowPtTripletStepTracks'),
-                      cms.InputTag('hiPixelPairGlobalPrimTracks')
+                      cms.InputTag('hiPixelPairGlobalPrimTracks'),
+                      cms.InputTag('hiJetCoreRegionalStepTracks')
                      ),
-    hasSelector=cms.vint32(1,1,1,1),
+    hasSelector=cms.vint32(1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
@@ -25,17 +26,19 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
                       cms.InputTag('hiDetachedTripletStepTracks'),
                       cms.InputTag('hiLowPtTripletStepTracks'),
                       cms.InputTag('hiPixelPairGlobalPrimTracks'),
+                      cms.InputTag('hiJetCoreRegionalStepTracks'),
                       cms.InputTag('hiRegitMuInitialStepTracks'),
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
                       cms.InputTag('hiRegitMuPixelLessStepTracks')
-                     ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1,1),
+                     ), 
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
     cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
     cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
+    cms.InputTag("hiJetCoreRegionalStepSelector","hiJetCoreRegionalStep"),
     cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
     cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
     cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -1,0 +1,177 @@
+import FWCore.ParameterSet.Config as cms
+
+# This step runs over all clusters
+
+# run only if there are high pT jets
+from RecoJets.JetProducers.TracksForJets_cff import trackRefsForJets
+hiInitialStepTrackRefsForJets = trackRefsForJets.clone(src = cms.InputTag('hiGlobalPrimTracks'))
+#from RecoJets.JetProducers.caloJetsForTrk_cff import *
+
+#change this to import Bkg substracted Heavy Ion jets:
+from RecoHI.HiJetAlgos.hiCaloJetsForTrk_cff import *
+
+hiJetsForCoreTracking = cms.EDFilter("CandPtrSelector", src = cms.InputTag("akPu4CaloJetsCorrected"), cut = cms.string("pt > 30 && abs(eta) < 2.5"))
+
+# care only at tracks from main PV
+hiFirstStepGoodPrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",
+     filterParams = cms.PSet(
+     	     minNdof = cms.double(25.0),
+             maxZ = cms.double(15.0),
+             maxRho = cms.double(2.0)
+     ),
+     src=cms.InputTag('hiSelectedVertex')
+)
+
+# SEEDING LAYERS
+hiJetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
+#    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
+#                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
+#                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
+#                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
+#                            #'BPix2+TIB1','BPix2+TIB2',
+#                            'BPix3+TIB1','BPix3+TIB2'
+#),
+    layerList = cms.vstring('BPix1+BPix2+BPix3', 
+    'BPix1+BPix2+FPix1_pos', 
+    'BPix1+BPix2+FPix1_neg', 
+    'BPix1+FPix1_pos+FPix2_pos', 
+    'BPix1+FPix1_neg+FPix2_neg',
+    'BPix1+BPix2+TIB1', 
+    'BPix1+BPix3+TIB1', 
+    'BPix2+BPix3+TIB1', 
+),
+    TIB = cms.PSet(
+        matchedRecHits = cms.InputTag("siStripMatchedRecHits","matchedRecHit"),
+        TTRHBuilder = cms.string('WithTrackAngle'), clusterChargeCut = cms.PSet(refToPSet_ = cms.string('SiStripClusterChargeCutNone'))
+    ),
+    BPix = cms.PSet(
+        useErrorsFromParam = cms.bool(True),
+        hitErrorRPhi = cms.double(0.0027),
+        hitErrorRZ = cms.double(0.006),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+        #skipClusters = cms.InputTag('jetCoreRegionalStepClusters')
+    ),
+    FPix = cms.PSet(
+        useErrorsFromParam = cms.bool(True),
+        hitErrorRPhi = cms.double(0.0051),
+        hitErrorRZ = cms.double(0.0036),
+        TTRHBuilder = cms.string('WithTrackAngle'),
+        HitProducer = cms.string('siPixelRecHits'),
+        #skipClusters = cms.InputTag('jetCoreRegionalStepClusters')
+    )
+)
+
+# SEEDS
+#import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
+#hiJetCoreRegionalStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff.globalSeedsFromPairsWithVertices.clone()
+import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
+hiJetCoreRegionalStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
+hiJetCoreRegionalStepSeeds.RegionFactoryPSet = cms.PSet(
+      ComponentName = cms.string( "TauRegionalPixelSeedGenerator" ),#not so nice to depend on RecoTau...
+      RegionPSet = cms.PSet(
+        precise = cms.bool( True ),
+        originRadius = cms.double( 0.2 ),
+        ptMin = cms.double( 15. ),
+        originHalfLength = cms.double( 0.2 ),
+        deltaPhiRegion = cms.double( 0.30 ), 
+        deltaEtaRegion = cms.double( 0.30 ), 
+        JetSrc = cms.InputTag( "hiJetsForCoreTracking" ),
+#       JetSrc = cms.InputTag( "ak5CaloJets" ),
+        vertexSrc = cms.InputTag( "hiFirstStepGoodPrimaryVertices" ),
+        measurementTrackerName = cms.string( "MeasurementTrackerEvent" ),
+        howToUseMeasurementTracker = cms.double( -1.0 )
+      )
+)
+hiJetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'hiJetCoreRegionalStepSeedLayers'
+#hiJetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(100000000) 
+hiJetCoreRegionalStepSeeds.SeedComparitorPSet = cms.PSet(
+        ComponentName = cms.string('none'),
+#PixelClusterShapeSeedComparitor'),
+#        FilterAtHelixStage = cms.bool(True),
+#        FilterPixelHits = cms.bool(True),
+#        FilterStripHits = cms.bool(False),
+#       ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter')
+    )
+hiJetCoreRegionalStepSeeds.SeedCreatorPSet.forceKinematicWithRegionDirection = cms.bool( True )
+hiJetCoreRegionalStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool( False )
+
+# QUALITY CUTS DURING TRACK BUILDING
+import TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff
+hiJetCoreRegionalStepTrajectoryFilter = TrackingTools.TrajectoryFiltering.TrajectoryFilter_cff.CkfBaseTrajectoryFilter_block.clone(
+    minimumNumberOfHits = 6,
+    minPt = 10.0
+)
+
+import TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi
+hiJetCoreRegionalStepChi2Est = TrackingTools.KalmanUpdators.Chi2MeasurementEstimatorESProducer_cfi.Chi2MeasurementEstimator.clone(
+    ComponentName = cms.string('hiJetCoreRegionalStepChi2Est'),
+    nSigma = cms.double(3.0),
+    MaxChi2 = cms.double(30.0)
+)
+
+# TRACK BUILDING
+import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
+hiJetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
+    MeasurementTrackerName = '',
+    trajectoryFilter = cms.PSet(refToPSet_ = cms.string('hiJetCoreRegionalStepTrajectoryFilter')),
+    #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
+    maxCand = 50,
+    estimator = cms.string('hiJetCoreRegionalStepChi2Est'),
+    maxDPhiForLooperReconstruction = cms.double(2.0),
+    maxPtForLooperReconstruction = cms.double(0.7)
+    )
+
+# MAKING OF TRACK CANDIDATES
+import RecoTracker.CkfPattern.CkfTrackCandidates_cfi
+hiJetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates_cfi.ckfTrackCandidates.clone(
+    src = cms.InputTag('hiJetCoreRegionalStepSeeds'),
+    maxSeedsBeforeCleaning = cms.uint32(10000),
+    TrajectoryBuilderPSet = cms.PSet( refToPSet_ = cms.string('hiJetCoreRegionalStepTrajectoryBuilder')),
+    NavigationSchool = cms.string('SimpleNavigationSchool'),
+    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
+    #numHitsForSeedCleaner = cms.int32(50),
+    #onlyPixelHitsForSeedCleaner = cms.bool(True),
+)
+
+
+# TRACK FITTING
+import RecoTracker.TrackProducer.TrackProducer_cfi
+hiJetCoreRegionalStepTracks = RecoTracker.TrackProducer.TrackProducer_cfi.TrackProducer.clone(
+    AlgorithmName = cms.string('jetCoreRegionalStep'),
+    src = 'hiJetCoreRegionalStepTrackCandidates',
+    Fitter = cms.string('FlexibleKFFittingSmoother')
+    )
+
+# Final selection
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
+hiJetCoreRegionalStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
+    src='hiJetCoreRegionalStepTracks',
+    vertices = cms.InputTag("hiFirstStepGoodPrimaryVertices"),
+    trackSelectors= cms.VPSet(
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiLooseMTS.clone(
+            name = 'hiJetCoreRegionalStepLoose',
+            ), #end of pset
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiJetCoreRegionalStepTight',
+            preFilterName = 'hiJetCoreRegionalStepLoose',
+            ),
+        RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiJetCoreRegionalStep',
+            preFilterName = 'hiJetCoreRegionalStepTight',
+            min_nhits = 14
+            ),
+        ) #end of vpset
+    ) #end of clone
+
+# Final sequence
+hiJetCoreRegionalStep = cms.Sequence(
+#                                   hiInitialStepTrackRefsForJets*
+                                   hiCaloJetsForTrk*hiJetsForCoreTracking*
+                                   hiFirstStepGoodPrimaryVertices*
+                                   #jetCoreRegionalStepClusters*
+                                   hiJetCoreRegionalStepSeedLayers*
+                                   hiJetCoreRegionalStepSeeds*
+                                   hiJetCoreRegionalStepTrackCandidates*
+                                   hiJetCoreRegionalStepTracks*
+                                   hiJetCoreRegionalStepSelector)

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -9,7 +9,7 @@ hiInitialStepTrackRefsForJets = trackRefsForJets.clone(src = cms.InputTag('hiGlo
 #change this to import Bkg substracted Heavy Ion jets:
 from RecoHI.HiJetAlgos.hiCaloJetsForTrk_cff import *
 
-hiJetsForCoreTracking = cms.EDFilter("CandPtrSelector", src = cms.InputTag("akPu4CaloJetsCorrected"), cut = cms.string("pt > 30 && abs(eta) < 2.5"))
+hiJetsForCoreTracking = cms.EDFilter("CandPtrSelector", src = cms.InputTag("akPu4CaloJetsSelected"), cut = cms.string("pt > 30 && abs(eta) < 2.5"))
 
 # care only at tracks from main PV
 hiFirstStepGoodPrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",

--- a/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
+++ b/RecoHI/HiTracking/python/hiJetCoreRegionalStep_cff.py
@@ -5,7 +5,6 @@ import FWCore.ParameterSet.Config as cms
 # run only if there are high pT jets
 from RecoJets.JetProducers.TracksForJets_cff import trackRefsForJets
 hiInitialStepTrackRefsForJets = trackRefsForJets.clone(src = cms.InputTag('hiGlobalPrimTracks'))
-#from RecoJets.JetProducers.caloJetsForTrk_cff import *
 
 #change this to import Bkg substracted Heavy Ion jets:
 from RecoHI.HiJetAlgos.hiCaloJetsForTrk_cff import *
@@ -24,13 +23,6 @@ hiFirstStepGoodPrimaryVertices = cms.EDFilter("PrimaryVertexObjectFilter",
 
 # SEEDING LAYERS
 hiJetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
-#    layerList = cms.vstring('BPix1+BPix2', 'BPix1+BPix3', 'BPix2+BPix3', 
-#                            'BPix1+FPix1_pos', 'BPix1+FPix1_neg', 
-#                            'BPix2+FPix1_pos', 'BPix2+FPix1_neg', 
-#                            'FPix1_pos+FPix2_pos', 'FPix1_neg+FPix2_neg',
-#                            #'BPix2+TIB1','BPix2+TIB2',
-#                            'BPix3+TIB1','BPix3+TIB2'
-#),
     layerList = cms.vstring('BPix1+BPix2+BPix3', 
     'BPix1+BPix2+FPix1_pos', 
     'BPix1+BPix2+FPix1_neg', 
@@ -50,7 +42,6 @@ hiJetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         hitErrorRZ = cms.double(0.006),
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),
-        #skipClusters = cms.InputTag('jetCoreRegionalStepClusters')
     ),
     FPix = cms.PSet(
         useErrorsFromParam = cms.bool(True),
@@ -58,13 +49,10 @@ hiJetCoreRegionalStepSeedLayers = cms.EDProducer("SeedingLayersEDProducer",
         hitErrorRZ = cms.double(0.0036),
         TTRHBuilder = cms.string('WithTrackAngle'),
         HitProducer = cms.string('siPixelRecHits'),
-        #skipClusters = cms.InputTag('jetCoreRegionalStepClusters')
     )
 )
 
 # SEEDS
-#import RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff
-#hiJetCoreRegionalStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromPairsWithVertices_cff.globalSeedsFromPairsWithVertices.clone()
 import RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff
 hiJetCoreRegionalStepSeeds = RecoTracker.TkSeedGenerator.GlobalSeedsFromTriplets_cff.globalSeedsFromTriplets.clone()
 hiJetCoreRegionalStepSeeds.RegionFactoryPSet = cms.PSet(
@@ -77,21 +65,14 @@ hiJetCoreRegionalStepSeeds.RegionFactoryPSet = cms.PSet(
         deltaPhiRegion = cms.double( 0.30 ), 
         deltaEtaRegion = cms.double( 0.30 ), 
         JetSrc = cms.InputTag( "hiJetsForCoreTracking" ),
-#       JetSrc = cms.InputTag( "ak5CaloJets" ),
         vertexSrc = cms.InputTag( "hiFirstStepGoodPrimaryVertices" ),
         measurementTrackerName = cms.string( "MeasurementTrackerEvent" ),
         howToUseMeasurementTracker = cms.double( -1.0 )
       )
 )
 hiJetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.SeedingLayers = 'hiJetCoreRegionalStepSeedLayers'
-#hiJetCoreRegionalStepSeeds.OrderedHitsFactoryPSet.maxElement = cms.uint32(100000000) 
 hiJetCoreRegionalStepSeeds.SeedComparitorPSet = cms.PSet(
         ComponentName = cms.string('none'),
-#PixelClusterShapeSeedComparitor'),
-#        FilterAtHelixStage = cms.bool(True),
-#        FilterPixelHits = cms.bool(True),
-#        FilterStripHits = cms.bool(False),
-#       ClusterShapeHitFilterName = cms.string('ClusterShapeHitFilter')
     )
 hiJetCoreRegionalStepSeeds.SeedCreatorPSet.forceKinematicWithRegionDirection = cms.bool( True )
 hiJetCoreRegionalStepSeeds.ClusterCheckPSet.doClusterCheck = cms.bool( False )
@@ -115,7 +96,6 @@ import RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi
 hiJetCoreRegionalStepTrajectoryBuilder = RecoTracker.CkfPattern.GroupedCkfTrajectoryBuilder_cfi.GroupedCkfTrajectoryBuilder.clone(
     MeasurementTrackerName = '',
     trajectoryFilter = cms.PSet(refToPSet_ = cms.string('hiJetCoreRegionalStepTrajectoryFilter')),
-    #clustersToSkip = cms.InputTag('jetCoreRegionalStepClusters'),
     maxCand = 50,
     estimator = cms.string('hiJetCoreRegionalStepChi2Est'),
     maxDPhiForLooperReconstruction = cms.double(2.0),
@@ -129,9 +109,6 @@ hiJetCoreRegionalStepTrackCandidates = RecoTracker.CkfPattern.CkfTrackCandidates
     maxSeedsBeforeCleaning = cms.uint32(10000),
     TrajectoryBuilderPSet = cms.PSet( refToPSet_ = cms.string('hiJetCoreRegionalStepTrajectoryBuilder')),
     NavigationSchool = cms.string('SimpleNavigationSchool'),
-    ### these two parameters are relevant only for the CachingSeedCleanerBySharedInput
-    #numHitsForSeedCleaner = cms.int32(50),
-    #onlyPixelHitsForSeedCleaner = cms.bool(True),
 )
 
 
@@ -166,10 +143,8 @@ hiJetCoreRegionalStepSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMul
 
 # Final sequence
 hiJetCoreRegionalStep = cms.Sequence(
-#                                   hiInitialStepTrackRefsForJets*
                                    hiCaloJetsForTrk*hiJetsForCoreTracking*
                                    hiFirstStepGoodPrimaryVertices*
-                                   #jetCoreRegionalStepClusters*
                                    hiJetCoreRegionalStepSeedLayers*
                                    hiJetCoreRegionalStepSeeds*
                                    hiJetCoreRegionalStepTrackCandidates*

--- a/RecoLocalTracker/Configuration/python/RecoLocalTrackerHeavyIons_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTrackerHeavyIons_cff.py
@@ -9,12 +9,14 @@ from RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitMatcher_cfi import *
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEfromTrackAngle_cfi import *
 from RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi import *
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterizer_cfi import *
-from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import *
+#from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import *
+from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi import *
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import *
 from RecoLocalTracker.SubCollectionProducers.clustersummaryproducer_cfi import *
 
-pixeltrackerlocalreco = cms.Sequence(siPixelClusters*siPixelRecHits)
+#pixeltrackerlocalreco = cms.Sequence(siPixelClusters*siPixelRecHits)
+#striptrackerlocalreco = cms.Sequence(siStripZeroSuppression*siStripClusters*siStripMatchedRecHits)
+#trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducerNoSplitting)
+pixeltrackerlocalreco = cms.Sequence(siPixelClustersPreSplitting*siPixelRecHitsPreSplitting)
 striptrackerlocalreco = cms.Sequence(siStripZeroSuppression*siStripClusters*siStripMatchedRecHits)
-trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducerNoSplitting)
-
-
+trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducer)

--- a/RecoLocalTracker/Configuration/python/RecoLocalTrackerHeavyIons_cff.py
+++ b/RecoLocalTracker/Configuration/python/RecoLocalTrackerHeavyIons_cff.py
@@ -9,14 +9,10 @@ from RecoLocalTracker.SiStripRecHitConverter.SiStripRecHitMatcher_cfi import *
 from RecoLocalTracker.SiStripRecHitConverter.StripCPEfromTrackAngle_cfi import *
 from RecoLocalTracker.SiStripZeroSuppression.SiStripZeroSuppression_cfi import *
 from RecoLocalTracker.SiStripClusterizer.SiStripClusterizer_cfi import *
-#from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizer_cfi import *
 from RecoLocalTracker.SiPixelClusterizer.SiPixelClusterizerPreSplitting_cfi import *
 from RecoLocalTracker.SiPixelRecHits.SiPixelRecHits_cfi import *
 from RecoLocalTracker.SubCollectionProducers.clustersummaryproducer_cfi import *
 
-#pixeltrackerlocalreco = cms.Sequence(siPixelClusters*siPixelRecHits)
-#striptrackerlocalreco = cms.Sequence(siStripZeroSuppression*siStripClusters*siStripMatchedRecHits)
-#trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducerNoSplitting)
 pixeltrackerlocalreco = cms.Sequence(siPixelClustersPreSplitting*siPixelRecHitsPreSplitting)
 striptrackerlocalreco = cms.Sequence(siStripZeroSuppression*siStripClusters*siStripMatchedRecHits)
 trackerlocalreco = cms.Sequence(pixeltrackerlocalreco*striptrackerlocalreco*clusterSummaryProducer)


### PR DESCRIPTION
Pixel cluster splitting and jet core iteration as it is in done in pp tracking is implemented in HI tracking. The difference is the jet collection, jets used in heavy ions have iterative Pu background subtraction.

Latest related presentations in HI Tracking meetings:
https://indico.cern.ch/event/438299/

Same as PR 10775 for CMSSW_7_6_X.
