### PR TITLE
Jet corrector parameters update for l1 residuals

### DIFF
--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -116,7 +116,8 @@ class JetCorrectorParametersCollection {
   enum Level_t { L1Offset=0,
 		 L1JPTOffset=7,
                  L1FastJet = 10,
-                 L1Residual=38,
+                 L1RC=38,
+                 L1Residual=39,
 		 L2Relative=1,
 		 L3Absolute=2,
 		 L2L3Residual=8,
@@ -152,7 +153,7 @@ class JetCorrectorParametersCollection {
 		 UncertaintyAux2=35,
 		 UncertaintyAux3=36,
 		 UncertaintyAux4=37,
-		 N_LEVELS=39
+		 N_LEVELS=40
   };
 
 

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -116,8 +116,8 @@ class JetCorrectorParametersCollection {
   enum Level_t { L1Offset=0,
 		 L1JPTOffset=7,
                  L1FastJet = 10,
-                 L1RC=38,
-                 L1Residual=39,
+                 L1RC=36,
+                 L1Residual=37,
 		 L2Relative=1,
 		 L3Absolute=2,
 		 L2L3Residual=8,
@@ -151,9 +151,7 @@ class JetCorrectorParametersCollection {
 		 UncertaintyPileUpJetRate=26,
 		 UncertaintyAux1=34,
 		 UncertaintyAux2=35,
-		 UncertaintyAux3=36,
-		 UncertaintyAux4=37,
-		 N_LEVELS=40
+		 N_LEVELS=38
   };
 
 

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -116,8 +116,6 @@ class JetCorrectorParametersCollection {
   enum Level_t { L1Offset=0,
 		 L1JPTOffset=7,
                  L1FastJet = 10,
-                 L1RC=36,
-                 L1Residual=37,
 		 L2Relative=1,
 		 L3Absolute=2,
 		 L2L3Residual=8,
@@ -149,8 +147,10 @@ class JetCorrectorParametersCollection {
 		 UncertaintyPileUpPtHF=33, 
 		 UncertaintyPileUpBias=25, 
 		 UncertaintyPileUpJetRate=26,
-		 UncertaintyAux1=34,
-		 UncertaintyAux2=35,
+		 L1RC=34,
+		 L1Residual=35,
+		 UncertaintyAux3=36,
+		 UncertaintyAux4=37,
 		 N_LEVELS=38
   };
 

--- a/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
+++ b/CondFormats/JetMETObjects/interface/JetCorrectorParameters.h
@@ -116,6 +116,7 @@ class JetCorrectorParametersCollection {
   enum Level_t { L1Offset=0,
 		 L1JPTOffset=7,
                  L1FastJet = 10,
+                 L1Residual=38,
 		 L2Relative=1,
 		 L3Absolute=2,
 		 L2L3Residual=8,
@@ -151,7 +152,7 @@ class JetCorrectorParametersCollection {
 		 UncertaintyAux2=35,
 		 UncertaintyAux3=36,
 		 UncertaintyAux4=37,
-		 N_LEVELS=38
+		 N_LEVELS=39
   };
 
 

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -364,8 +364,6 @@ const std::vector<std::string> labels_ = {
   "UncertaintyPileUpPtHF",
   "UncertaintyAux1",
   "UncertaintyAux2",
-  "UncertaintyAux3",
-  "UncertaintyAux4",
   "L1RC",
   "L1Residual",
 };

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -366,6 +366,7 @@ const std::vector<std::string> labels_ = {
   "UncertaintyAux2",
   "UncertaintyAux3",
   "UncertaintyAux4",
+  "L1Residual",
 };
 
 const std::vector<std::string> l5Flavors_ = {

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -362,10 +362,10 @@ const std::vector<std::string> labels_ = {
   "UncertaintyRelativeSample",
   "UncertaintyPileUpPtEC",
   "UncertaintyPileUpPtHF",
-  "UncertaintyAux1",
-  "UncertaintyAux2",
   "L1RC",
   "L1Residual",
+  "UncertaintyAux3",
+  "UncertaintyAux4",
 };
 
 const std::vector<std::string> l5Flavors_ = {

--- a/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
+++ b/CondFormats/JetMETObjects/src/JetCorrectorParameters.cc
@@ -366,6 +366,7 @@ const std::vector<std::string> labels_ = {
   "UncertaintyAux2",
   "UncertaintyAux3",
   "UncertaintyAux4",
+  "L1RC",
   "L1Residual",
 };
 


### PR DESCRIPTION
The JERC group would like to rename two of the empty UncertaintyAux correction levels. This will allow us to include 1-2 new correction levels in the future. These are files/corrections that are being used and/or created in the JERC group now, and may become part of the recommended workflow in the future. Given that we are simply renaming two empty levels we do not foresee any forward/backward compatibility issues. @rappoccio @blinkseb
