### PR TITLE
Adjust ak8 jet threshold in MiniAOD

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -25,7 +25,7 @@ def applySubstructure( process ) :
                      genJetCollection = cms.InputTag('slimmedGenJetsAK8')
                      )
     process.patJetsAK8.userData.userFloats.src = [] # start with empty list of user floats
-    process.selectedPatJetsAK8.cut = cms.string("pt > 200")
+    process.selectedPatJetsAK8.cut = cms.string("pt > 170")
 
 
 
@@ -77,7 +77,7 @@ def applySubstructure( process ) :
         fatJets=cms.InputTag('ak8PFJetsCHS'),             # needed for subjet flavor clustering
         groomedFatJets=cms.InputTag('ak8PFJetsCHSSoftDrop') # needed for subjet flavor clustering
     )
-    process.selectedPatJetsAK8PFCHSSoftDrop.cut = cms.string("pt > 200")
+    process.selectedPatJetsAK8PFCHSSoftDrop.cut = cms.string("pt > 170")
     
     process.slimmedJetsAK8PFCHSSoftDropSubjets = cms.EDProducer("PATJetSlimmer",
         src = cms.InputTag("selectedPatJetsAK8PFCHSSoftDropSubjets"),
@@ -108,7 +108,7 @@ def applySubstructure( process ) :
         genJetCollection = cms.InputTag('slimmedGenJetsAK8'), 
         getJetMCFlavour = False #
         )
-    process.selectedPatJetsCMSTopTagCHS.cut = cms.string("pt > 200")
+    process.selectedPatJetsCMSTopTagCHS.cut = cms.string("pt > 350")
 
     addJetCollection(
         process,

--- a/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/applySubstructure_cff.py
@@ -108,7 +108,7 @@ def applySubstructure( process ) :
         genJetCollection = cms.InputTag('slimmedGenJetsAK8'), 
         getJetMCFlavour = False #
         )
-    process.selectedPatJetsCMSTopTagCHS.cut = cms.string("pt > 350")
+    process.selectedPatJetsCMSTopTagCHS.cut = cms.string("pt > 200")
 
     addJetCollection(
         process,


### PR DESCRIPTION
backport of #10783

This allows re-applying JEC on top of MiniAOD and still keep the analysis cut at 200 GeV.

edmEventSize on 1700 ttbar events:
patJets_slimmedJetsAK8PFCHSSoftDropPacked_SubJets_PAT. 1451.14 274.862 patJets_slimmedJetsAK8__PAT. 1248.34 262.22

with "pt>170" instead of "pt>200" everywhere in applySubstructure_cff.
patJets_slimmedJetsAK8PFCHSSoftDropPacked_SubJets_PAT. 1793.97 308.641 patJets_slimmedJetsAK8__PAT. 1459.09 291.008
