### PR TITLE
Prefetch mayConsumes to avoid deadlocks

### DIFF
--- a/FWCore/Framework/src/EDConsumerBase.cc
+++ b/FWCore/Framework/src/EDConsumerBase.cc
@@ -187,6 +187,9 @@ EDConsumerBase::updateLookup(BranchType iBranchType,
 
   if(iBranchType == InEvent) {
     itemsToGet(iBranchType, itemsToGetFromEvent_);
+    //Temporary: until we release resources on Event::getBy* calls
+    // we need to prefetch mayConsumes as well
+    itemsMayGet(iBranchType, itemsToGetFromEvent_);
   }
 }
 


### PR DESCRIPTION
We must prefetch even data products which are mayConsumes in order
to avoid deadlocks for the case where another thread has locked a
resource needed by the unscheduled module. This will go away once
resources are released when a module calls 'Event::getBy*'.
