### PR TITLE
metadata JSON files produced for empty lumisections in DAQ (74X)

### DIFF
--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -710,7 +710,7 @@ DQMFileSaver::globalEndLuminosityBlock(const edm::LuminosityBlock & iLS, const e
     // by testing the pointer to FastMonitoringService: if not null, i.e. in real FU mode,
     // we check that the events are not 0; otherwise, we skip the test, so we store at every lumi transition. 
     // TODO(diguida): allow fake FU mode to skip file creation at empty lumi sections.
-    if (convention_ == FilterUnit)
+    if (convention_ == FilterUnit && (fms_ ? !fms_->getAbortFlagForLumi(ilumi) : !fms_))
     {
       char rewrite[128];
       sprintf(rewrite, "\\1Run %d/\\2/By Lumi Section %d-%d", irun, ilumi, ilumi);

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -278,19 +278,23 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, c
   int nProcessed = fms ? (fms->getEventsProcessedForLumi(lumi)) : -1;
 
   // Stat the data file: if not there, throw
+  std::string dataFileName;
   struct stat dataFileStat;
-  if (stat(dataFilePathName.c_str(), &dataFileStat) != 0)
-    throw cms::Exception("fillJson")
-          << "Internal error, cannot get data file: "
-          << dataFilePathName;
-  // Extract only the data file name from the full path
-  std::string dataFileName = bfs::path(dataFilePathName).filename().string();
+  dataFileStat.st_size=0;
+  if (nProcessed) {
+    if (stat(dataFilePathName.c_str(), &dataFileStat) != 0)
+      throw cms::Exception("fillJson")
+            << "Internal error, cannot get data file: "
+            << dataFilePathName;
+    // Extract only the data file name from the full path
+    dataFileName = bfs::path(dataFilePathName).filename().string();
+  }
   // The availability test of the FastMonitoringService was done in the ctor.
   bpt::ptree data;
   bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination;
 
   processedEvents.put("", nProcessed); // Processed events
-  acceptedEvents.put("", fms ? (fms->getEventsProcessedForLumi(lumi)) : -1); // Accepted events, same as processed for our purposes
+  acceptedEvents.put("", nProcessed); // Accepted events, same as processed for our purposes
 
   errorEvents.put("", 0); // Error events
   bitmask.put("", 0); // Bitmask of abs of CMSSW return code
@@ -364,13 +368,14 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
     }
   }
 
-  if (fileFormat == ROOT)
-  {
-    // Save the file with the full directory tree,
-    // modifying it according to @a rewrite,
-    // but not looking for MEs inside the DQMStore, as in the online case,
-    // nor filling new MEs, as in the offline case.
-    dbe_->save(openHistoFilePathName,
+  if (fms_ ? fms_->getEventsProcessedForLumi(lumi) : true) {
+    if (fileFormat == ROOT)
+    {
+      // Save the file with the full directory tree,
+      // modifying it according to @a rewrite,
+      // but not looking for MEs inside the DQMStore, as in the online case,
+      // nor filling new MEs, as in the offline case.
+      dbe_->save(openHistoFilePathName,
              "",
              "^(Reference/)?([^/]+)",
              rewrite,
@@ -380,23 +385,24 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
              saveReferenceQMin_,
              fileUpdate_ ? "UPDATE" : "RECREATE",
              true);
-  }
-  else if (fileFormat == PB)
-  {
-    // Save the file in the open directory.
-    dbe_->savePB(openHistoFilePathName,
+    }
+    else if (fileFormat == PB)
+    {
+      // Save the file in the open directory.
+      dbe_->savePB(openHistoFilePathName,
         filterName_,
         enableMultiThread_ ? run : 0,
         lumi,
         true);
-  }
-  else
-    throw cms::Exception("DQMFileSaver")
-      << "Internal error, can save files"
-      << " only in ROOT or ProtocolBuffer format.";
+    }
+    else
+      throw cms::Exception("DQMFileSaver")
+        << "Internal error, can save files"
+        << " only in ROOT or ProtocolBuffer format.";
 
-  // Now move the the data and json files into the output directory.
-  rename(openHistoFilePathName.c_str(), histoFilePathName.c_str());
+    // Now move the the data and json files into the output directory.
+    rename(openHistoFilePathName.c_str(), histoFilePathName.c_str());
+  }
 
   // Write the json file in the open directory.
   bpt::ptree pt = fillJson(run, lumi, histoFilePathName, transferDestination_, fms_);

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -716,7 +716,7 @@ DQMFileSaver::globalEndLuminosityBlock(const edm::LuminosityBlock & iLS, const e
     // by testing the pointer to FastMonitoringService: if not null, i.e. in real FU mode,
     // we check that the events are not 0; otherwise, we skip the test, so we store at every lumi transition. 
     // TODO(diguida): allow fake FU mode to skip file creation at empty lumi sections.
-    if (convention_ == FilterUnit && (fms_ ? !fms_->shouldWriteFiles(ilumi) : !fms_))
+    if (convention_ == FilterUnit && (fms_ ? fms_->shouldWriteFiles(ilumi) : !fms_))
     {
       char rewrite[128];
       sprintf(rewrite, "\\1Run %d/\\2/By Lumi Section %d-%d", irun, ilumi, ilumi);

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -716,7 +716,7 @@ DQMFileSaver::globalEndLuminosityBlock(const edm::LuminosityBlock & iLS, const e
     // by testing the pointer to FastMonitoringService: if not null, i.e. in real FU mode,
     // we check that the events are not 0; otherwise, we skip the test, so we store at every lumi transition. 
     // TODO(diguida): allow fake FU mode to skip file creation at empty lumi sections.
-    if (convention_ == FilterUnit && (fms_ ? !fms_->getAbortFlagForLumi(ilumi) : !fms_))
+    if (convention_ == FilterUnit && (fms_ ? !fms_->shouldWriteFiles(ilumi) : !fms_))
     {
       char rewrite[128];
       sprintf(rewrite, "\\1Run %d/\\2/By Lumi Section %d-%d", irun, ilumi, ilumi);

--- a/DQMServices/Components/src/DQMFileSaver.cc
+++ b/DQMServices/Components/src/DQMFileSaver.cc
@@ -275,19 +275,26 @@ DQMFileSaver::fillJson(int run, int lumi, const std::string& dataFilePathName, c
   std::ostringstream oss_pid;
   oss_pid << pid;
 
+  int nProcessed = fms ? (fms->getEventsProcessedForLumi(lumi)) : -1;
+
   // Stat the data file: if not there, throw
   struct stat dataFileStat;
-  if (stat(dataFilePathName.c_str(), &dataFileStat) != 0)
-    throw cms::Exception("fillJson")
-          << "Internal error, cannot get data file: "
-          << dataFilePathName;
+  if (nProcessed!=0)
+    if (stat(dataFilePathName.c_str(), &dataFileStat) != 0)
+      throw cms::Exception("fillJson")
+            << "Internal error, cannot get data file: "
+            << dataFilePathName;
+  else {
+    dataFilePathName = "";
+    dataFileStat.st_size=0;
+  }
   // Extract only the data file name from the full path
   std::string dataFileName = bfs::path(dataFilePathName).filename().string();
   // The availability test of the FastMonitoringService was done in the ctor.
   bpt::ptree data;
   bpt::ptree processedEvents, acceptedEvents, errorEvents, bitmask, fileList, fileSize, inputFiles, fileAdler32, transferDestination;
 
-  processedEvents.put("", fms ? (fms->getEventsProcessedForLumi(lumi)) : -1); // Processed events
+  processedEvents.put("", nProcessed); // Processed events
   acceptedEvents.put("", fms ? (fms->getEventsProcessedForLumi(lumi)) : -1); // Accepted events, same as processed for our purposes
 
   errorEvents.put("", 0); // Error events
@@ -361,14 +368,15 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
       histoFilePathName = edm::Service<evf::EvFDaqDirector>()->getProtocolBufferHistogramFilePath(lumi, stream_label_);
     }
   }
-
-  if (fileFormat == ROOT)
+  if (fms_ ? (fms_->getEventsProcessedForLumi(ilumi) > 0) : !fms_)
   {
-    // Save the file with the full directory tree,
-    // modifying it according to @a rewrite,
-    // but not looking for MEs inside the DQMStore, as in the online case,
-    // nor filling new MEs, as in the offline case.
-    dbe_->save(openHistoFilePathName,
+    if (fileFormat == ROOT)
+    {
+      // Save the file with the full directory tree,
+      // modifying it according to @a rewrite,
+      // but not looking for MEs inside the DQMStore, as in the online case,
+      // nor filling new MEs, as in the offline case.
+      dbe_->save(openHistoFilePathName,
                "",
                "^(Reference/)?([^/]+)",
                rewrite,
@@ -378,23 +386,26 @@ DQMFileSaver::saveForFilterUnit(const std::string& rewrite, int run, int lumi,  
                saveReferenceQMin_,
                fileUpdate_ ? "UPDATE" : "RECREATE",
                true);
-  }
-  else if (fileFormat == PB)
-  {
-    // Save the file in the open directory.
-    dbe_->savePB(openHistoFilePathName,
+    }
+    else if (fileFormat == PB)
+    {
+      // Save the file in the open directory.
+      dbe_->savePB(openHistoFilePathName,
                  filterName_,
     	           enableMultiThread_ ? run : 0,
                  lumi,
                  true);
-  }
-  else
-    throw cms::Exception("DQMFileSaver")
+    }
+    else
+      throw cms::Exception("DQMFileSaver")
           << "Internal error, can save files"
           << " only in ROOT or ProtocolBuffer format.";
 
-  // Now move the the data and json files into the output directory.
-  rename(openHistoFilePathName.c_str(), histoFilePathName.c_str());
+    // Now move the the data and json files into the output directory.
+    rename(openHistoFilePathName.c_str(), histoFilePathName.c_str());
+  }
+  //no file output for empty lumisections
+  else histoFilePathName = "";
 
   // Write the json file in the open directory.
   bpt::ptree pt = fillJson(run, lumi, histoFilePathName, transferDestination_, fms_);
@@ -708,7 +719,7 @@ DQMFileSaver::globalEndLuminosityBlock(const edm::LuminosityBlock & iLS, const e
     // by testing the pointer to FastMonitoringService: if not null, i.e. in real FU mode,
     // we check that the events are not 0; otherwise, we skip the test, so we store at every lumi transition. 
     // TODO(diguida): allow fake FU mode to skip file creation at empty lumi sections.
-    if (convention_ == FilterUnit && (fms_ ? (fms_->getEventsProcessedForLumi(ilumi) > 0) : !fms_))
+    if (convention_ == FilterUnit)
     {
       char rewrite[128];
       sprintf(rewrite, "\\1Run %d/\\2/By Lumi Section %d-%d", irun, ilumi, ilumi);

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -91,7 +91,6 @@ namespace evf{
       unsigned int getJumpLS() const { return jumpLS_; }
       unsigned int getJumpIndex() const { return jumpIndex_; }
       std::string getJumpFilePath() const { return bu_run_dir_ + "/" + fffnaming::inputRawFileName(getRunNumber(),jumpLS_,jumpIndex_); }
-      bool getTestModeNoBuilderUnit() { return testModeNoBuilderUnit_;}
       FILE * maybeCreateAndLockFileHeadForStream(unsigned int ls, std::string &stream);
       void unlockAndCloseMergeStream();
       void lockInitLock();
@@ -129,7 +128,6 @@ namespace evf{
       std::string eorFileName() const;
       int getNFilesFromEoLS(std::string BUEoLSFile);
 
-      bool testModeNoBuilderUnit_;
       std::string base_dir_;
       std::string bu_base_dir_;
       bool directorBu_;
@@ -164,7 +162,6 @@ namespace evf{
       DirManager dirManager_;
 
       unsigned long previousFileSize_;
-      unsigned int jumpLS_, jumpIndex_;
 
       struct flock bu_w_flk;
       struct flock bu_r_flk;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -113,6 +113,7 @@ namespace evf{
       }
       void checkTransferSystemPSet();
       std::string getStreamDestinations(std::string const& stream) const;
+      bool emptyLumisectionMode() const {return emptyLumisectionMode_;}
 
 
     private:
@@ -138,6 +139,7 @@ namespace evf{
       std::string selectedTransferMode_;
       std::string hltSourceDirectory_;
       unsigned int fuLockPollInterval_;
+      bool emptyLumisectionMode_;
 
       std::string hostname_;
       std::string run_string_;

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -88,9 +88,6 @@ namespace evf{
       FileStatus updateFuLock(unsigned int& ls, std::string& nextFile, uint32_t& fsize, uint64_t& lockWaitTime);
       void tryInitializeFuLockFile();
       unsigned int getRunNumber() const { return run_; }
-      unsigned int getJumpLS() const { return jumpLS_; }
-      unsigned int getJumpIndex() const { return jumpIndex_; }
-      std::string getJumpFilePath() const { return bu_run_dir_ + "/" + fffnaming::inputRawFileName(getRunNumber(),jumpLS_,jumpIndex_); }
       FILE * maybeCreateAndLockFileHeadForStream(unsigned int ls, std::string &stream);
       void unlockAndCloseMergeStream();
       void lockInitLock();

--- a/EventFilter/Utilities/interface/EvFDaqDirector.h
+++ b/EventFilter/Utilities/interface/EvFDaqDirector.h
@@ -105,6 +105,7 @@ namespace evf{
       void lockFULocal2();
       void unlockFULocal2();
       void createRunOpendirMaybe();
+      void createProcessingNotificationMaybe() const;
       int readLastLSEntry(std::string const& file);
       void setDeleteTracking( std::mutex* fileDeleteLock,std::list<std::pair<int,InputFile*>> *filesToDelete) {
         fileDeleteLockPtr_=fileDeleteLock;

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -151,7 +151,8 @@ namespace evf{
       void startedLookingForFile();
       void stoppedLookingForFile(unsigned int lumi);
       void reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount);
-      unsigned int getEventsProcessedForLumi(unsigned int lumi);
+      unsigned int getEventsProcessedForLumi(unsigned int lumi, bool * abortFlag=nullptr);
+      bool getAbortFlagForLumi(unsigned int lumi);
       std::string getRunDirName() const { return runDirectory_.stem().string(); }
 
     private:
@@ -231,7 +232,7 @@ namespace evf{
       std::map<unsigned int, std::pair<double,unsigned int>> lockStatsDuringLumi_;
 
       //for output module
-      std::map<unsigned int, unsigned int> processedEventsPerLumi_;
+      std::map<unsigned int, std::pair<unsigned int,bool>> processedEventsPerLumi_;
 
       //flag used to block EOL until event count is picked up by caches (not certain that this is really an issue)
       //to disable this behavior, set #ATOMIC_LEVEL 0 or 1 in DataPoint.h

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -153,11 +153,11 @@ namespace evf{
       void reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount);
       unsigned int getEventsProcessedForLumi(unsigned int lumi, bool * abortFlag=nullptr);
       bool getAbortFlagForLumi(unsigned int lumi);
-      bool shouldWriteFiles(unsigned int lumi, unsigned int& proc=nullptr) const 
+      bool shouldWriteFiles(unsigned int lumi, unsigned int* proc=nullptr)
       {
-        unsigned int processed = (getEventsProcessedForLumi(unsigned int lumi);
-        if (proc) proc = processed;
-        return !getAbortFlagForLumi(lumi) && (processed || emptyLumisectionMode_));
+        unsigned int processed = getEventsProcessedForLumi(lumi);
+        if (proc) *proc = processed;
+        return !getAbortFlagForLumi(lumi) && (processed || emptyLumisectionMode_);
       }
       std::string getRunDirName() const { return runDirectory_.stem().string(); }
 

--- a/EventFilter/Utilities/interface/FastMonitoringService.h
+++ b/EventFilter/Utilities/interface/FastMonitoringService.h
@@ -153,6 +153,12 @@ namespace evf{
       void reportLockWait(unsigned int ls, double waitTime, unsigned int lockCount);
       unsigned int getEventsProcessedForLumi(unsigned int lumi, bool * abortFlag=nullptr);
       bool getAbortFlagForLumi(unsigned int lumi);
+      bool shouldWriteFiles(unsigned int lumi, unsigned int& proc=nullptr) const 
+      {
+        unsigned int processed = (getEventsProcessedForLumi(unsigned int lumi);
+        if (proc) proc = processed;
+        return !getAbortFlagForLumi(lumi) && (processed || emptyLumisectionMode_));
+      }
       std::string getRunDirName() const { return runDirectory_.stem().string(); }
 
     private:
@@ -258,6 +264,7 @@ namespace evf{
       std::atomic<bool> monInit_;
       bool exception_detected_ = false;
       std::vector<unsigned int> exceptionInLS_;
+      bool emptyLumisectionMode_ = false;
     };
 
 }

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -195,7 +195,9 @@ bool FedRawDataInputSource::checkNextEvent()
     startupCv_.wait(lk);
   }
   //signal hltd to start event accounting
-  daqDirector_->createProcessingNotificationMaybe();
+  if (!currentLumiSection_)
+    daqDirector_->createProcessingNotificationMaybe();
+
   switch (nextEvent() ) {
     case evf::EvFDaqDirector::runEnded: {
 

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -195,7 +195,7 @@ bool FedRawDataInputSource::checkNextEvent()
     startupCv_.wait(lk);
   }
   //signal hltd to start event accounting
-  if (!currentLumiSection_)
+  if (!currentLumiSection_ && daqDirector_->emptyLumisectionMode())
     daqDirector_->createProcessingNotificationMaybe();
 
   switch (nextEvent() ) {

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -192,6 +192,8 @@ bool FedRawDataInputSource::checkNextEvent()
     startedSupervisorThread_=true;
     startupCv_.wait(lk);
   }
+  //signal hltd to start event accounting
+  daqDirector_->createProcessingNotificationMaybe();
   switch (nextEvent() ) {
     case evf::EvFDaqDirector::runEnded: {
 

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.cc
@@ -58,7 +58,7 @@ FedRawDataInputSource::FedRawDataInputSource(edm::ParameterSet const& pset,
   eventChunkSize_(pset.getUntrackedParameter<unsigned int> ("eventChunkSize",16)*1048576),
   eventChunkBlock_(pset.getUntrackedParameter<unsigned int> ("eventChunkBlock",eventChunkSize_/1048576)*1048576),
   numBuffers_(pset.getUntrackedParameter<unsigned int> ("numBuffers",1)),
-  maxOpenFiles_(pset.getUntrackedParameter<unsigned int> ("maxOpenFiles",2)),
+  maxBufferedFiles_(pset.getUntrackedParameter<unsigned int> ("maxBufferedFiles",2)),
   getLSFromFilename_(pset.getUntrackedParameter<bool> ("getLSFromFilename", true)),
   verifyAdler32_(pset.getUntrackedParameter<bool> ("verifyAdler32", true)),
   verifyChecksum_(pset.getUntrackedParameter<bool> ("verifyChecksum", true)),
@@ -881,7 +881,7 @@ void FedRawDataInputSource::readSupervisor()
 
     //wait for at least one free thread and chunk
     int counter=0;
-    while ((workerPool_.empty() && !singleBufferMode_) || freeChunks_.empty() || readingFilesCount_>=maxOpenFiles_)
+    while ((workerPool_.empty() && !singleBufferMode_) || freeChunks_.empty() || readingFilesCount_>=maxBufferedFiles_)
     {
       std::unique_lock<std::mutex> lkw(mWakeup_);
       //sleep until woken up by condition or a timeout

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -65,7 +65,6 @@ private:
   edm::Timestamp fillFEDRawDataCollection(FEDRawDataCollection&);
   void deleteFile(std::string const&);
   int grabNextJsonFile(boost::filesystem::path const&);
-  void renameToNextFree(std::string const& fileName) const;
 
   void readSupervisor();
   void readWorker(unsigned int tid);
@@ -94,7 +93,6 @@ private:
   const bool verifyAdler32_;
   const bool verifyChecksum_;
   const bool useL1EventID_;
-  const bool testModeNoBuilderUnit_;
 
   const edm::RunNumber_t runNumber_;
 

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -85,7 +85,9 @@ private:
   unsigned int eventChunkBlock_; // how much read(2) asks at the time
   unsigned int readBlocks_;
   unsigned int numBuffers_;
+  unsigned int maxOpenFiles_;
   unsigned int numConcurrentReads_;
+  std::atomic<unsigned int> readingFilesCount_;
 
   // get LS from filename instead of event header
   const bool getLSFromFilename_;

--- a/EventFilter/Utilities/plugins/FedRawDataInputSource.h
+++ b/EventFilter/Utilities/plugins/FedRawDataInputSource.h
@@ -85,7 +85,7 @@ private:
   unsigned int eventChunkBlock_; // how much read(2) asks at the time
   unsigned int readBlocks_;
   unsigned int numBuffers_;
-  unsigned int maxOpenFiles_;
+  unsigned int maxBufferedFiles_;
   unsigned int numConcurrentReads_;
   std::atomic<unsigned int> readingFilesCount_;
 

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.cc
@@ -34,9 +34,11 @@ RawEventFileWriterForBU::RawEventFileWriterForBU(edm::ParameterSet const& ps):
   rawJsonDef_.addLegendItem("NEvents","integer",DataPointDefinition::SUM);
 
   perFileEventCount_.setName("NEvents");
+  perFileSize_.setName("NBytes");
 
   fileMon_ = new FastMonitor(&rawJsonDef_,false);
   fileMon_->registerGlobalMonitorable(&perFileEventCount_,false,nullptr);
+  fileMon_->registerGlobalMonitorable(&perFileSize_,false,nullptr);
   fileMon_->commit(nullptr);
 
   //per-lumi JSD and FastMonitor
@@ -50,12 +52,14 @@ RawEventFileWriterForBU::RawEventFileWriterForBU(edm::ParameterSet const& ps):
   perLumiFileCount_.setName("NFiles");
   perLumiTotalEventCount_.setName("TotalEvents");
   perLumiLostEventCount_.setName("NLostEvents");
+  perLumiSize_.setName("NBytes");
 
   lumiMon_ = new FastMonitor(&eolJsonDef_,false);
   lumiMon_->registerGlobalMonitorable(&perLumiEventCount_,false,nullptr);
   lumiMon_->registerGlobalMonitorable(&perLumiFileCount_,false,nullptr);
   lumiMon_->registerGlobalMonitorable(&perLumiTotalEventCount_,false,nullptr);
   lumiMon_->registerGlobalMonitorable(&perLumiLostEventCount_,false,nullptr);
+  lumiMon_->registerGlobalMonitorable(&perLumiSize_,false,nullptr);
   lumiMon_->commit(nullptr);
 
 
@@ -115,6 +119,7 @@ void RawEventFileWriterForBU::doOutputEvent(FRDEventMsgView const& msg)
   // throttle event output
   usleep(microSleep_);
   perFileEventCount_.value()++;
+  perFileSize_.value()+=msg.size();
 
   //  cms::Adler32((const char*) msg.startAddress(), msg.size(), adlera_, adlerb_);
 }
@@ -182,6 +187,7 @@ void RawEventFileWriterForBU::initialize(std::string const& destinationDir, std:
   }
 
   perFileEventCount_.value() = 0;
+  perFileSize_.value() = 0;
 
 
   adlera_ = 1;
@@ -244,12 +250,14 @@ void RawEventFileWriterForBU::finishFileWrite(int ls)
     //there is a small chance that script gets interrupted while this isn't consistent (non-atomic)
     perLumiFileCount_.value()++;
     perLumiEventCount_.value()+=perFileEventCount_.value();
+    perLumiSize_.value()+=perFileSize_.value();
     perLumiTotalEventCount_.value()+=perFileEventCount_.value();
     //update open lumi value when first file is completed
     lumiOpen_ =  ls;
 
     edm::LogInfo("RawEventFileWriterForBU") << "Wrote JSON input file: " << path 
-					    << " with perFileEventCount = " << perFileEventCount_.value();
+					    << " with perFileEventCount = " << perFileEventCount_.value()
+                                            << " and size " << perFileSize_.value();
 
 }
 
@@ -279,6 +287,7 @@ void RawEventFileWriterForBU::endOfLS(int ls)
   perLumiEventCount_ = 0;
   perLumiFileCount_ = 0;
   perLumiTotalEventCount_ = 0;
+  perLumiSize_ = 0;
   lumiClosed_ =  ls;
 }
 

--- a/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
+++ b/EventFilter/Utilities/plugins/RawEventFileWriterForBU.h
@@ -62,8 +62,10 @@ class RawEventFileWriterForBU
   IntJ perLumiFileCount_;
   IntJ perLumiTotalEventCount_;
   IntJ perLumiLostEventCount_;
+  IntJ perLumiSize_;
 
   IntJ perFileEventCount_;
+  IntJ perFileSize_;
 
   FastMonitor* fileMon_ = nullptr;
   FastMonitor* lumiMon_ = nullptr;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -9,6 +9,7 @@
 #include <sstream>
 #include <iomanip>
 #include <boost/filesystem.hpp>
+#include <boost/algorithm/string.hpp>
 #include <zlib.h>
 
 #include "EventFilter/Utilities/interface/JsonMonitorable.h"
@@ -100,6 +101,14 @@ namespace evf {
       throw cms::Exception("RecoEventOutputModuleForFU")
         << "Underscore character is reserved can not be used for stream names in FFF, but was detected in stream name -: " << stream_label_;
     }
+
+
+    std::string stream_label_lo = stream_label_;
+    boost::algorithm::to_lower(stream_label_lo);
+    auto streampos = stream_label_lo.rfind("stream");
+    if (streampos !=0 && streampos!=std::string::npos)
+      throw cms::Exception("RecoEventOutputModuleForFU")
+        << "stream (case-insensitive) sequence was found in stream suffix. This is reserved and can not be used for names in FFF based HLT, but was detected in stream name";
 
     fms_ = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
     

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -318,7 +318,7 @@ namespace evf {
 
     } else {
       //return if not in empty lumisectio mode
-      if (!edm::Service<evf::EvFDaqDirector>()->emptyLumiSectionMode())
+      if (!edm::Service<evf::EvFDaqDirector>()->emptyLumisectionMode())
         return;
       filelist_ = "";
       fileAdler32_.value()=-1;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -317,12 +317,14 @@ namespace evf {
     filesize_=filesize;
 
     // output jsn file
-    if(processed_.value()!=0){
-	jsonMonitor_->snap(ls.luminosityBlock());
-	const std::string outputJsonNameStream =
-	  edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(ls.luminosityBlock(),stream_label_);
-	jsonMonitor_->outputFullJSON(outputJsonNameStream,ls.luminosityBlock());
+    if(processed_.value()==0)  {
+      filelist_ = "";
+      fileAdler32_.value()=-1;
     }
+    jsonMonitor_->snap(ls.luminosityBlock());
+    const std::string outputJsonNameStream =
+      edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(ls.luminosityBlock(),stream_label_);
+    jsonMonitor_->outputFullJSON(outputJsonNameStream,ls.luminosityBlock());
 
     // reset monitoring params
     accepted_.value() = 0;

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -245,8 +245,13 @@ namespace evf {
     long filesize=0;
     fileAdler32_.value() = c_->get_adler32();
     c_->closeOutputFile();
-    processed_.value() = fms_->getEventsProcessedForLumi(ls.luminosityBlock());
+    bool abortFlag = false;
+    processed_.value() = fms_->getEventsProcessedForLumi(ls.luminosityBlock(),&abortFlag);
 
+    if (abortFlag) {
+        edm::LogInfo("RecoEventOutputModuleForFU") << "output suppressed";
+        return;
+    }
 
     if(processed_.value()!=0){
 

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -94,7 +94,12 @@ namespace evf {
     //replace hltOutoputA with stream if the HLT menu uses this convention
     std::string testPrefix="hltOutput";
     if (stream_label_.find(testPrefix)==0) 
-            stream_label_=std::string("stream")+stream_label_.substr(testPrefix.size());
+      stream_label_=std::string("stream")+stream_label_.substr(testPrefix.size());
+
+    if (stream_label_.find("_")!=std::string::npos) {
+      throw cms::Exception("RecoEventOutputModuleForFU")
+        << "Underscore character is reserved can not be used for stream names in FFF, but was detected in stream name -: " << stream_label_;
+    }
 
     fms_ = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
     

--- a/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
+++ b/EventFilter/Utilities/plugins/RecoEventOutputModuleForFU.h
@@ -252,8 +252,8 @@ namespace evf {
         edm::LogInfo("RecoEventOutputModuleForFU") << "output suppressed";
         return;
     }
-
-    if(processed_.value()!=0){
+    
+    if(processed_.value()!=0) {
 
       //lock
       FILE *des = edm::Service<evf::EvFDaqDirector>()->maybeCreateAndLockFileHeadForStream(ls.luminosityBlock(),stream_label_);
@@ -316,16 +316,18 @@ namespace evf {
                                                            << openDatFilePath_.string() <<" in LS " << ls.luminosityBlock() << std::endl;
       }
 
+    } else {
+      //return if not in empty lumisectio mode
+      if (!edm::Service<evf::EvFDaqDirector>()->emptyLumiSectionMode())
+        return;
+      filelist_ = "";
+      fileAdler32_.value()=-1;
     }
+
     //remove file
     remove(openDatFilePath_.string().c_str());
     filesize_=filesize;
 
-    // output jsn file
-    if(processed_.value()==0)  {
-      filelist_ = "";
-      fileAdler32_.value()=-1;
-    }
     jsonMonitor_->snap(ls.luminosityBlock());
     const std::string outputJsonNameStream =
       edm::Service<evf::EvFDaqDirector>()->getOutputJsonFilePath(ls.luminosityBlock(),stream_label_);

--- a/EventFilter/Utilities/plugins/budef.jsd
+++ b/EventFilter/Utilities/plugins/budef.jsd
@@ -3,6 +3,11 @@
       {
          "name" : "NEvents",
          "operation" : "sum"
+      },
+      {
+         "name" : "NBytes",
+         "operation" : "sum"
       }  
+
    ]
 }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -53,7 +53,7 @@ namespace evf {
     selectedTransferMode_(pset.getUntrackedParameter<std::string>("selectedTransferMode","")),
     hltSourceDirectory_(pset.getUntrackedParameter<std::string>("hltSourceDirectory","")),
     fuLockPollInterval_(pset.getUntrackedParameter<unsigned int>("fuLockPollInterval",2000)),
-    emptyLumisectionMode_(pset.getUntrackedParameter<bool>("emptyLumisectionMode",false),
+    emptyLumisectionMode_(pset.getUntrackedParameter<bool>("emptyLumisectionMode",false)),
     hostname_(""),
     bu_readlock_fd_(-1),
     bu_writelock_fd_(-1),
@@ -114,7 +114,7 @@ namespace evf {
 
     char * emptyLumiModePtr = getenv("FFF_EMPTYLSMODE");
     if (emptyLumiModePtr) {
-        emptyLumisectionMode_ = true
+        emptyLumisectionMode_ = true;
         edm::LogInfo("Setting empty lumisection mode");
     }
  
@@ -673,7 +673,6 @@ namespace evf {
     else {
       std::string BUEoLSFile = getEoLSFilePathOnBU(ls);
       bool eolFound = (stat(BUEoLSFile.c_str(), &buf) == 0);
-      unsigned int startingLumi = ls;
       while (eolFound) {
 
         // recheck that no raw file appeared in the meantime

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -503,13 +503,37 @@ namespace evf {
 	fscanf(fu_rw_lock_stream, "%u %u", &readLs, &readIndex);
 	edm::LogInfo("EvFDaqDirector") << "Read fu.lock file file -: " << readLs << ":" << readIndex;
 
-	// try to bump
-	bool bumpedOk = bumpFile(readLs, readIndex, nextFile, fsize, stopFileLS);
-        unsigned int lastLs = ls;
-	ls = readLs;
-	// there is a new file to grab or lumisection ended
+        unsigned int currentLs = readLs;
+        bool bumpedOk = false;
+        //if next lumisection in a lock file is not +1 wrt. source, cycle through the next empty one, unless initial lumi not yet set
+        //no lock file write in this case
+        if (ls && ls+1 < currentLs) ls++;
+        else {
+	  // try to bump (look for new index or EoLS file)
+	  bumpedOk = bumpFile(readLs, readIndex, nextFile, fsize, stopFileLS);
+          //avoid 2 lumisections jump
+          if (ls && readLs>currentLs && currentLs > ls) {
+            ls++;
+            readLs=currentLs=ls;
+            readIndex=0;
+            bumpedOk=false;
+            //no write to lock file
+          }
+          else {
+            if (ls==0 && readLs>currentLs) {
+              //make sure to intialize always with LS found in the lock file, with possibility of grabbing index file immediately
+              //in this case there is no new file in the same LS
+              readLs=currentLs;
+              readIndex=0;
+              bumpedOk=false;
+              //no write to lock file
+            }
+            //update return LS value
+	    ls = readLs;
+          }
+        }
 	if (bumpedOk) {
-	  // write new data
+	  // there is a new index file to grab, lock file needs to be updated
 	  check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
 	  if (check == 0) {
 	    ftruncate(fu_readwritelock_fd_, 0);
@@ -524,8 +548,8 @@ namespace evf {
             throw cms::Exception("EvFDaqDirector") << "seek on fu read/write lock for updating failed with error " << strerror(errno);
           }
 	}
-        else if (lastLs < readLs)
-        {
+        else if (currentLs < readLs) {
+          //there is no new file in next LS (yet), but lock file can be updated to the next LS
 	  check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
 	  if (check == 0) {
 	    ftruncate(fu_readwritelock_fd_, 0);

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -954,4 +954,10 @@ namespace evf {
     return ret;
   }
 
+  void EvFDaqDirector::createProcessingNotificationMaybe() const {
+    std::string proc_flag = run_dir_ + "/processing";
+    int proc_flag_fd = open(proc_flag.c_str(), O_RDWR | O_CREAT, S_IRWXU | S_IWGRP | S_IRGRP | S_IWOTH | S_IROTH);
+    close(proc_flag_fd);
+  }
+
 }

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -57,6 +57,7 @@ namespace evf {
     selectedTransferMode_(pset.getUntrackedParameter<std::string>("selectedTransferMode","")),
     hltSourceDirectory_(pset.getUntrackedParameter<std::string>("hltSourceDirectory","")),
     fuLockPollInterval_(pset.getUntrackedParameter<unsigned int>("fuLockPollInterval",2000)),
+    emptyLumisectionMode_(pset.getUntrackedParameter<bool>("emptyLumisectionMode",false),
     hostname_(""),
     bu_readlock_fd_(-1),
     bu_writelock_fd_(-1),
@@ -117,6 +118,12 @@ namespace evf {
       catch (...) {edm::LogWarning("Unable to parse environment string: ") << std::string(fuLockPollIntervalPtr);}
     }
 
+    char * emptyLumiModePtr = getenv("FFF_EMPTYLSMODE");
+    if (emptyLumiModePtr) {
+        emptyLumisectionMode_ = true
+        edm::LogInfo("Setting empty lumisection mode");
+    }
+ 
     // check if base dir exists or create it accordingly
     int retval = mkdir(base_dir_.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (retval != 0 && errno != EEXIST) {

--- a/EventFilter/Utilities/src/EvFDaqDirector.cc
+++ b/EventFilter/Utilities/src/EvFDaqDirector.cc
@@ -38,10 +38,6 @@ namespace evf {
 
   EvFDaqDirector::EvFDaqDirector(const edm::ParameterSet &pset,
 				 edm::ActivityRegistry& reg) :
-    testModeNoBuilderUnit_(
-			   pset.getUntrackedParameter<bool> ("testModeNoBuilderUnit",
-							     false)
-			   ),
     base_dir_(
 	      pset.getUntrackedParameter<std::string> ("baseDir", "/data")
 	      ),
@@ -76,8 +72,6 @@ namespace evf {
     dirManager_(base_dir_),
 
     previousFileSize_(0),
-    jumpLS_(0),
-    jumpIndex_(0),
 
     bu_w_flk( make_flock( F_WRLCK, SEEK_SET, 0, 0, 0 )),
     bu_r_flk( make_flock( F_RDLCK, SEEK_SET, 0, 0, 0 )),
@@ -499,64 +493,58 @@ namespace evf {
 
     // if the stream is readable
     if (fu_rw_lock_stream != 0) {
-      unsigned int readLs, readIndex, jumpLs, jumpIndex;
+      unsigned int readLs, readIndex;
       int check = 0;
       // rewind the stream
       check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
       // if rewinded ok
       if (check == 0) {
 	// read its' values
-	if (testModeNoBuilderUnit_)
-	  fscanf(fu_rw_lock_stream, "%u %u %u %u", &readLs, &readIndex,
-		 &jumpLs, &jumpIndex);
-	else {
-	  fscanf(fu_rw_lock_stream, "%u %u", &readLs, &readIndex);
-	  edm::LogInfo("EvFDaqDirector") << "Read fu.lock file file -: " << readLs << ":" << readIndex;
-        }
+	fscanf(fu_rw_lock_stream, "%u %u", &readLs, &readIndex);
+	edm::LogInfo("EvFDaqDirector") << "Read fu.lock file file -: " << readLs << ":" << readIndex;
 
 	// try to bump
 	bool bumpedOk = bumpFile(readLs, readIndex, nextFile, fsize, stopFileLS);
         unsigned int lastLs = ls;
 	ls = readLs;
 	// there is a new file to grab or lumisection ended
-	if (bumpedOk || lastLs < readLs) {
+	if (bumpedOk) {
 	  // write new data
 	  check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
 	  if (check == 0) {
 	    ftruncate(fu_readwritelock_fd_, 0);
 	    // write next index in the file, which is the file the next process should take
-	    if (testModeNoBuilderUnit_) {
-	      fprintf(fu_rw_lock_stream, "%u %u %u %u", readLs,
-		      readIndex + 1, readLs + 2, readIndex + 1);
-	      jumpLS_ = readLs + 2;
-	      jumpIndex_ = readIndex;
-	    } else {
-	      fprintf(fu_rw_lock_stream, "%u %u", readLs,
-		      readIndex + 1);
-	    }
+	    fprintf(fu_rw_lock_stream, "%u %u", readLs, readIndex + 1);
 	    fflush(fu_rw_lock_stream);
 	    fsync(fu_readwritelock_fd_);
-
-            if (bumpedOk)
-	      fileStatus = newFile;
-
-	    if (testModeNoBuilderUnit_)
-	      edm::LogInfo("EvFDaqDirector") << "Written to file -: " << readLs << ":"
-			                     << readIndex + 1 << " --> " << readLs + 2
-			                     << ":" << readIndex + 1;
-	    else
-	      LogDebug("EvFDaqDirector") << "Written to file -: " << readLs << ":"
-			                     << readIndex + 1;
-
-	  } else
-	      throw cms::Exception("EvFDaqDirector") << "seek on fu read/write lock for updating failed with error "
-	                                             << strerror(errno);
+	    fileStatus = newFile;
+	    LogDebug("EvFDaqDirector") << "Written to file -: " << readLs << ":" << readIndex + 1;
+	  }
+          else {
+            throw cms::Exception("EvFDaqDirector") << "seek on fu read/write lock for updating failed with error " << strerror(errno);
+          }
 	}
-      } else
-	edm::LogError("EvFDaqDirector") << "seek on fu read/write lock for reading failed with error "
-					<< strerror(errno);
-    } else
+        else if (lastLs < readLs)
+        {
+	  check = fseek(fu_rw_lock_stream, 0, SEEK_SET);
+	  if (check == 0) {
+	    ftruncate(fu_readwritelock_fd_, 0);
+	    // in this case LS was bumped, but no new file. Thus readIndex is 0 (set by bumpFile)
+	    fprintf(fu_rw_lock_stream, "%u %u", readLs, readIndex);
+	    fflush(fu_rw_lock_stream);
+	    fsync(fu_readwritelock_fd_);
+	    LogDebug("EvFDaqDirector") << "Written to file -: " << readLs << ":" << readIndex;
+	  }
+          else {
+            throw cms::Exception("EvFDaqDirector") << "seek on fu read/write lock for updating failed with error " << strerror(errno);
+          }
+        }
+      } else {
+	edm::LogError("EvFDaqDirector") << "seek on fu read/write lock for reading failed with error " << strerror(errno);
+      }
+    } else {
       edm::LogError("EvFDaqDirector") << "fu read/write lock stream is invalid " << strerror(errno);
+    }
 
 #ifdef DEBUG
     timeval ts_preunlock;
@@ -720,21 +708,6 @@ namespace evf {
 	  // a new file was found at new lumisection, index 0
 	  previousFileSize_ = buf.st_size;
           fsize = buf.st_size;
-
-	  if (testModeNoBuilderUnit_) {
-	    // rename ended lumi to + 2
-            std::string sourceEol = getEoLSFilePathOnBU(startingLumi);
-
-	    std::string destEol = getEoLSFilePathOnBU(startingLumi+2);
-
-	    std::string cpCmd = "cp " + sourceEol + " " + destEol;
-	    edm::LogInfo("EvFDaqDirector") << " testmode: Running copy cmd -: " << cpCmd;
-	    int rc = system(cpCmd.c_str());
-	    if (rc != 0) {
-	      edm::LogError("EvFDaqDirector") << " testmode: COPY EOL FAILED!!!!! -: " << cpCmd;
-	    }
-	  }
-
 	  return true;
 	}
         else {
@@ -755,12 +728,8 @@ namespace evf {
 				      << strerror(errno);
     else {
       edm::LogInfo("EvFDaqDirector") << "Initializing FU LOCK FILE";
-      unsigned int readLs = 1, readIndex = 0, jumpLs = 3, jumpIndex = 0;
-      if (testModeNoBuilderUnit_)
-	fprintf(fu_rw_lock_stream, "%u %u %u %u", readLs, readIndex,
-		jumpLs, jumpIndex);
-      else
-	fprintf(fu_rw_lock_stream, "%u %u", readLs, readIndex);
+      unsigned int readLs = 1, readIndex = 0;
+      fprintf(fu_rw_lock_stream, "%u %u", readLs, readIndex);
     }
   }
 

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -111,6 +111,7 @@ namespace evf{
       throw cms::Exception("FastMonitoringService") << "EvFDaqDirector is not present";
     
     }
+    emptyLumisectionMode_ = edm::Service<evf::EvFDaqDirector>()->emptyLumisectionMode();
     boost::filesystem::path runDirectory(edm::Service<evf::EvFDaqDirector>()->baseRunDir());
     workingDirectory_ = runDirectory_ = runDirectory;
     workingDirectory_ /= "mon";

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -265,7 +265,7 @@ namespace evf{
 
     //build a map of modules keyed by their module description address
     //here we need to treat output modules in a special way so they can be easily singled out
-    if(desc.moduleName() == "Stream" || desc.moduleName() == "ShmStreamConsumer" ||
+    if(desc.moduleName() == "Stream" || desc.moduleName() == "ShmStreamConsumer" || desc.moduleName() == "EvFOutputModule" ||
        desc.moduleName() == "EventStreamFileWriter" || desc.moduleName() == "PoolOutputModule")
       encModule_.updateReserved((void*)&desc);
     else

--- a/EventFilter/Utilities/src/FastMonitoringService.cc
+++ b/EventFilter/Utilities/src/FastMonitoringService.cc
@@ -353,7 +353,7 @@ namespace evf{
 	  IntJ *lumiProcessedJptr = dynamic_cast<IntJ*>(fmt_.jsonMonitor_->getMergedIntJForLumi("Processed",lumi));
           if (!lumiProcessedJptr)
               throw cms::Exception("FastMonitoringService") << "Internal error: got null pointer from FastMonitor";
-	  processedEventsPerLumi_[lumi] = lumiProcessedJptr->value();
+	  processedEventsPerLumi_[lumi] = std::pair<unsigned int,bool>(lumiProcessedJptr->value(),false);
 
 	  {
 	    auto itr = sourceEventsReport_.find(lumi);
@@ -365,19 +365,20 @@ namespace evf{
 
               if (edm::shutdown_flag || exception_detected) {
                 edm::LogInfo("FastMonitoringService") << "Run interrupted. Skip writing EoL information -: "
-                                                      << processedEventsPerLumi_[lumi] << " events were processed in LUMI " << lumi;
+                                                      << processedEventsPerLumi_[lumi].first << " events were processed in LUMI " << lumi;
                 //this will prevent output modules from producing json file for possibly incomplete lumi
-                processedEventsPerLumi_[lumi]=0;
+                processedEventsPerLumi_[lumi].first=0;
+                processedEventsPerLumi_[lumi].second=true;
                 return;
               }
               //disable this exception, so service can be used standalone (will be thrown if output module asks for this information)
               //throw cms::Exception("FastMonitoringService") << "SOURCE did not send update for lumi block. LUMI -:" << lumi;
 	    }
 	    else {
-	      if (itr->second!=processedEventsPerLumi_[lumi]) {
+	      if (itr->second!=processedEventsPerLumi_[lumi].first) {
 		throw cms::Exception("FastMonitoringService") << "MISMATCH with SOURCE update. LUMI -: "
                                                               << lumi
-                                                              << ", events(processed):" << processedEventsPerLumi_[lumi]
+                                                              << ", events(processed):" << processedEventsPerLumi_[lumi].first
                                                               << " events(source):" << itr->second;
 	      }
 	      sourceEventsReport_.erase(itr);
@@ -597,12 +598,13 @@ namespace evf{
   }
 
   //for the output module
-  unsigned int FastMonitoringService::getEventsProcessedForLumi(unsigned int lumi) {
+  unsigned int FastMonitoringService::getEventsProcessedForLumi(unsigned int lumi, bool * abortFlag) {
     std::lock_guard<std::mutex> lock(fmt_.monlock_);
 
     auto it = processedEventsPerLumi_.find(lumi);
     if (it!=processedEventsPerLumi_.end()) {
-      unsigned int proc = it->second;
+      unsigned int proc = it->second.first;
+      if (abortFlag) *abortFlag=it->second.second;
       return proc;
     }
     else {
@@ -611,6 +613,20 @@ namespace evf{
     }
   }
 
+  //for the output module
+  bool FastMonitoringService::getAbortFlagForLumi(unsigned int lumi) {
+    std::lock_guard<std::mutex> lock(fmt_.monlock_);
+
+    auto it = processedEventsPerLumi_.find(lumi);
+    if (it!=processedEventsPerLumi_.end()) {
+      unsigned int abortFlag = it->second.second;
+      return abortFlag;
+    }
+    else {
+      throw cms::Exception("FastMonitoringService") << "output module wants already deleted (or never reported by SOURCE) lumisection status for LUMI -: "<<lumi;
+      return 0;
+    }
+  }
 
   void FastMonitoringService::doSnapshot(const unsigned int ls, const bool isGlobalEOL) {
     // update macrostate

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -531,22 +531,20 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
 void
 TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext, hltJson::lumiVars* iSummary)
 {
-<<<<<<< HEAD
 
   unsigned int iLs  = iLumi.luminosityBlock();
   unsigned int iRun = iLumi.run();
 
-  bool abortFlag=false;
-  bool writeDataFiles=true;
+  bool writeFiles=true;
   if (edm::Service<evf::MicroStateService>().isAvailable()) {
     evf::FastMonitoringService * fms = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
     if (fms) {
-      writeDataFiles = fms->getEventsProcessedForLumi(iLs)>0;
-      abortFlag = fms_->getAbortFlagForLumi(iLumi.luminosityBlock());
+      //writeFiles = !fms->getAbortFlagForLumi(iLumi.luminosityBlock()) && (fms->getEventsProcessedForLumi(iLs)>0 || fms->emptyLumiMode());
+      writeFiles = !fms->shouldWriteFiles(iLumi.luminosityBlock());
     }
   }
 
-  if (!abortFlag) {
+  if (writeFiles) {
     Json::StyledWriter writer;
 
     char hostname[33];
@@ -583,15 +581,21 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     ssHltJsnData <<  "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
     ssHltJsnData << "_streamHLTRates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsndata";
 
-    std::ofstream outHltJsnData( monPath + ssHltJsnData.str() );
-    outHltJsnData<<result;
-    outHltJsnData.close();
+    if (iSummary->processed->value().at(0)!=0) {
+      std::ofstream outHltJsnData( monPath + ssHltJsnData.str() );
+      outHltJsnData<<result;
+      outHltJsnData.close();
+    }
 
     //HLT jsn entries
     StringJ hltJsnFilelist;
-    hltJsnFilelist.update(ssHltJsnData.str());
-    IntJ hltJsnFilesize    = result.size();
-    IntJ hltJsnFileAdler32 = cms::Adler32(result.c_str(),result.size());
+    IntJ hltJsnFilesize    = 0;
+    IntJ hltJsnFileAdler32 = -1;
+    if (iSummary->processed->value().at(0)!=0) {
+      hltJsnFilelist.update(ssHltJsnData.str());
+      hltJsnFilesize    = result.size();
+      hltJsnFileAdler32 = cms::Adler32(result.c_str(),result.size());
+    }
     StringJ hltJsnInputFiles;
     hltJsnInputFiles.update("");
 
@@ -616,17 +620,25 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     ssL1JsnData << "run" << std::setfill('0') << std::setw(6) << iRun << "_ls" << std::setfill('0') << std::setw(4) << iLs;
     ssL1JsnData << "_streamL1Rates_pid" << std::setfill('0') << std::setw(5) << getpid() << ".jsndata";
 
-    std::ofstream outL1JsnData( monPath + "/" + ssL1JsnData.str() );
-    outL1JsnData<<result;
-    outL1JsnData.close();
+    if (iSummary->processed->value().at(0)!=0) {
+      std::ofstream outL1JsnData( monPath + "/" + ssL1JsnData.str() );
+      outL1JsnData<<result;
+      outL1JsnData.close();
+    }
 
+    //L1 jsn entries
     StringJ l1JsnFilelist;
-    l1JsnFilelist.update(ssL1JsnData.str());
-    IntJ l1JsnFilesize    = result.size();
-    IntJ l1JsnFileAdler32 = cms::Adler32(result.c_str(), result.size());
-    StringJ l1JsnInputFiles;               
+    IntJ l1JsnFilesize    = 0;
+    IntJ l1JsnFileAdler32 = -1;
+    if (iSummary->processed->value().at(0)!=0) {
+      l1JsnFilelist.update(ssHltJsnData.str());
+      l1JsnFilesize    = result.size();
+      l1JsnFileAdler32 = cms::Adler32(result.c_str(),result.size());
+    }
+    StringJ l1JsnInputFiles;
     l1JsnInputFiles.update("");
- 
+
+
     //Create special DAQ JSON file for L1 and HLT rates pseudo-streams
     //Only three variables are different between the files: 
     //the file list, the file size and the Adler32 value
@@ -660,7 +672,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     outHltDaqJsn<<result;
     outHltDaqJsn.close();
 
-    //write out HLT metadata jsn
+    //write out L1 metadata jsn
     Json::Value l1DaqJsn;
     l1DaqJsn[DataPoint::SOURCE] = sourceHost;
     l1DaqJsn[DataPoint::DEFINITION] = sOutDef.str();

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -589,7 +589,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     //HLT jsn entries
     StringJ hltJsnFilelist;
     IntJ hltJsnFilesize    = 0;
-    IntJ hltJsnFileAdler32 = -1;
+    unsigned int hltJsnFileAdler32 = 1;
     if (iSummary->processed->value().at(0)!=0) {
       hltJsnFilelist.update(ssHltJsnData.str());
       hltJsnFilesize    = result.size();
@@ -628,7 +628,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     //L1 jsn entries
     StringJ l1JsnFilelist;
     IntJ l1JsnFilesize    = 0;
-    IntJ l1JsnFileAdler32 = -1;
+    unsigned int l1JsnFileAdler32 = 1;
     if (iSummary->processed->value().at(0)!=0) {
       l1JsnFilelist.update(ssL1JsnData.str());
       l1JsnFilesize    = result.size();
@@ -658,7 +658,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     hltDaqJsn[DataPoint::DATA].append(hltJsnFilelist.value());
     hltDaqJsn[DataPoint::DATA].append((unsigned int)hltJsnFilesize.value());
     hltDaqJsn[DataPoint::DATA].append(hltJsnInputFiles.value());
-    hltDaqJsn[DataPoint::DATA].append((unsigned int)hltJsnFileAdler32.value());
+    hltDaqJsn[DataPoint::DATA].append(hltJsnFileAdler32);
     hltDaqJsn[DataPoint::DATA].append(iSummary->streamHLTDestination);
 
     result = writer.write(hltDaqJsn);
@@ -683,7 +683,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     l1DaqJsn[DataPoint::DATA].append(l1JsnFilelist.value());
     l1DaqJsn[DataPoint::DATA].append((unsigned int)l1JsnFilesize.value());
     l1DaqJsn[DataPoint::DATA].append(l1JsnInputFiles.value());
-    l1DaqJsn[DataPoint::DATA].append((unsigned int)l1JsnFileAdler32.value());
+    l1DaqJsn[DataPoint::DATA].append(l1JsnFileAdler32);
     l1DaqJsn[DataPoint::DATA].append(iSummary->streamL1Destination);
 
     result = writer.write(l1DaqJsn);

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -531,18 +531,22 @@ TriggerJSONMonitoring::endLuminosityBlockSummary(const edm::LuminosityBlock& iLu
 void
 TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBlock& iLumi, const edm::EventSetup& iSetup, const LuminosityBlockContext* iContext, hltJson::lumiVars* iSummary)
 {
+<<<<<<< HEAD
 
   unsigned int iLs  = iLumi.luminosityBlock();
   unsigned int iRun = iLumi.run();
 
-  bool writeFiles=true;
+  bool abortFlag=false;
+  bool writeDataFiles=true;
   if (edm::Service<evf::MicroStateService>().isAvailable()) {
     evf::FastMonitoringService * fms = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
-    if (fms)
-      writeFiles = fms->getEventsProcessedForLumi(iLs)>0;
+    if (fms) {
+      writeDataFiles = fms->getEventsProcessedForLumi(iLs)>0;
+      abortFlag = fms_->getAbortFlagForLumi(iLumi.luminosityBlock());
+    }
   }
 
-  if (iSummary->processed->value().at(0)!=0 && writeFiles) {
+  if (!abortFlag) {
     Json::StyledWriter writer;
 
     char hostname[33];

--- a/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
+++ b/HLTrigger/JSONMonitoring/plugins/TriggerJSONMonitoring.cc
@@ -539,8 +539,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
   if (edm::Service<evf::MicroStateService>().isAvailable()) {
     evf::FastMonitoringService * fms = (evf::FastMonitoringService *)(edm::Service<evf::MicroStateService>().operator->());
     if (fms) {
-      //writeFiles = !fms->getAbortFlagForLumi(iLumi.luminosityBlock()) && (fms->getEventsProcessedForLumi(iLs)>0 || fms->emptyLumiMode());
-      writeFiles = !fms->shouldWriteFiles(iLumi.luminosityBlock());
+      writeFiles = fms->shouldWriteFiles(iLumi.luminosityBlock());
     }
   }
 
@@ -631,7 +630,7 @@ TriggerJSONMonitoring::globalEndLuminosityBlockSummary(const edm::LuminosityBloc
     IntJ l1JsnFilesize    = 0;
     IntJ l1JsnFileAdler32 = -1;
     if (iSummary->processed->value().at(0)!=0) {
-      l1JsnFilelist.update(ssHltJsnData.str());
+      l1JsnFilelist.update(ssL1JsnData.str());
       l1JsnFilesize    = result.size();
       l1JsnFileAdler32 = cms::Adler32(result.c_str(),result.size());
     }


### PR DESCRIPTION
Implementation of JSON metadata output for each lumisection  in Filter Units and several other smaller changes and bugfixes:
- file distribution scheme in ramdisk previously allowed skipping lumisections with no data. This is now modified so that each process must transition through each lumisection starting from one first seen in lock file in BU ramdisk.
- correponding changes in DAQ (streamer) output module, and DQMHIstogram, L1/HLT rates stream producers to output metadata json for empty lumisections
- avoid casting -1 to uint32 in Trigger JSON module, which converts it in the valid range of the checksum (-1 is intended as true negative in JSON to signal that checksumming is disabled in particular cases)
- added "maxBufferedFiles" parameter which limits the number of currently open files (useful in case of more than two input buffers used)
- exception thrown when "_" (underscore) is used as stream name because this breaks file naming convention in DAQ (and breaks output merging by hltd)
- updated fake BU code with latest json format used by DAQ BU application
- removed old unused test mode code in input source and DaqDirector
