### PR TITLE
Fix of the 76X recoMET tests

### DIFF
--- a/RecoMET/METProducers/python/testInputFiles_cff.py
+++ b/RecoMET/METProducers/python/testInputFiles_cff.py
@@ -5,9 +5,9 @@ from PhysicsTools.PatAlgos.tools.cmsswVersionTools import pickRelValInputFiles
 recoMETtestInputFiles = pickRelValInputFiles(
     useDAS = True,
     cmsswVersion = 'CMSSW_7_6_0_pre3',
-    dataTier = 'GEN-SIM-RECO',
+    dataTier = 'GEN-SIM-DIGI-RECO',
     relVal = 'RelValTTbar_13',
-    globalTag = '75X_mcRun2_asymptotic_v1_FastSim',
+    globalTag = '75X_mcRun2_asymptotic_v2_FastSim',
     maxVersions = 2
     )
 

--- a/RecoMET/METProducers/test/recoMET_pfClusterMet_cfg.py
+++ b/RecoMET/METProducers/test/recoMET_pfClusterMet_cfg.py
@@ -34,8 +34,12 @@ process.maxEvents = cms.untracked.PSet(input = cms.untracked.int32(10))
 
 ##____________________________________________________________________________||
 process.p = cms.Path(
+    process.particleFlowClusterHF*
+    process.particleFlowClusterHO*
     process.pfClusterRefsForJetsHCAL*
     process.pfClusterRefsForJetsECAL*
+    process.pfClusterRefsForJetsHF*
+    process.pfClusterRefsForJetsHO*
     process.pfClusterRefsForJets *
     process.pfClusterMet
     )


### PR DESCRIPTION
The MET tests were bypassed due to the use of wrong relval files.
Follow up of merged #10766 , similar to #10765 which has been updated similarly for 75X
