### PR TITLE
Example of a payload-to-XML C++ plugin 

### DIFF
--- a/CondCore/BeamSpotPlugins/plugins/BeamSpotObjects_toXML.cc
+++ b/CondCore/BeamSpotPlugins/plugins/BeamSpotObjects_toXML.cc
@@ -1,0 +1,55 @@
+
+#include <iostream>
+#include <string>
+#include <memory>
+
+#include <boost/python/class.hpp>
+#include <boost/python/module.hpp>
+#include <boost/python/init.hpp>
+#include <boost/python/def.hpp>
+#include <iostream>
+#include <string>
+#include <sstream>
+
+#include "boost/archive/xml_oarchive.hpp"
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/Serialization/interface/Archive.h"
+
+#include "CondCore/Utilities/src/CondFormats.h"
+
+namespace { // Avoid cluttering the global namespace.
+
+
+  void initpluginBeamSpotObjects_toXML() {}
+
+  std::string payload2xml( const std::string &payloadData, const std::string &payloadType ) { 
+
+      // now to convert
+      std::unique_ptr< BeamSpotObjects > payload;
+
+      std::stringbuf sdataBuf;
+      sdataBuf.pubsetbuf( const_cast<char *> ( payloadData.c_str() ), payloadData.size() );
+
+      std::istream inBuffer( &sdataBuf );
+      eos::portable_iarchive ia( inBuffer );
+      payload.reset( new BeamSpotObjects );
+      ia >> (*payload);
+
+      // now we have the object in memory, convert it to xml in a string and return it
+     
+      std::ostringstream outBuffer;
+      boost::archive::xml_oarchive xmlResult( outBuffer );
+      xmlResult << boost::serialization::make_nvp( "cmsCondPayload", *payload );
+
+      return outBuffer.str();
+  }
+
+} // end namespace
+
+
+BOOST_PYTHON_MODULE( pluginBeamSpotObjects_toXML )
+{
+    using namespace boost::python;
+    def ("payload2xml", payload2xml);
+
+}

--- a/CondCore/BeamSpotPlugins/plugins/BuildFile.xml
+++ b/CondCore/BeamSpotPlugins/plugins/BuildFile.xml
@@ -9,3 +9,11 @@
   <use   name="rootgraphics"/>
   <flags   EDM_PLUGIN="1"/>
 </library>
+
+<library   file="BeamSpotObjects_toXML.cc" name="BeamSpotObjects_toXML">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="boost_python"/>
+</library>
+

--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -3,6 +3,8 @@ import os
 import shutil
 import sys
 import time
+import glob
+import importlib
 
 # as we need to load the shared lib from here, make sure it's in our path:
 if os.path.join( os.environ['CMSSW_BASE'], 'src') not in sys.path:
@@ -127,6 +129,30 @@ class CondXmlProcessor(object):
            os.unlink( os.path.join( os.environ['CMSSW_BASE'], 'src', './pl2xmlComp.so') )
         return 
 
+    def discover(self, payloadType):
+
+        # first search in developer area:
+	libDir = os.path.join( os.environ["CMSSW_BASE"], 'lib', os.environ["SCRAM_ARCH"] )
+	pluginList = glob.glob( libDir + '/plugin%s_toXML.so' % payloadType )
+
+        # if nothing found there, check release:
+        if not pluginList:
+	   libDir = os.path.join( os.environ["CMSSW_RELEASE_BASE"], 'lib', os.environ["SCRAM_ARCH"] )
+	   pluginList = glob.glob( libDir + '/plugin%s_toXML.so' % payloadType )
+
+	# print "found plugin for %s (in %s) : %s " % (payloadType, libDir, pluginList)
+
+	xmlConverter = None
+	if len(pluginList) > 0:
+           dirPath, libName = os.path.split( pluginList[0] )
+	   sys.path.append(dirPath)
+	   # print "going to import %s from %s" % (libName, dirPath)
+	   xmlConverter = importlib.import_module( libName.replace('.so', '') )
+	   # print "found : ", dir(xmlConverter)
+	   self.doCleanup = False
+
+	return xmlConverter
+
     def prepPayload2xml(self, session, payload):
 
     	startTime = time.time()
@@ -139,6 +165,9 @@ class CondXmlProcessor(object):
         	     'plType' : plType,
     	    }
     
+        converter = self.discover(plType)
+	if converter: return converter
+
         code = payload2xmlCodeTemplate % info
     
         tmpDir = self._pl2xml_tmpDir
@@ -169,22 +198,29 @@ class CondXmlProcessor(object):
 	buildTime = time.time()-startTime
 	print >> sys.stderr, "buillding done in ", buildTime, 'sec., return code from build: ', ret
 
-        return (ret == 0)
+	if (ret != 0):
+           return None
+
+        return importlib.import_module( 'pl2xmlComp' )
     
     def payload2xml(self, session, payload):
     
         if not self._pl2xml_isPrepared:
-           if not self.prepPayload2xml(session, payload):
+	   xmlConverter = self.prepPayload2xml(session, payload)
+           if not xmlConverter:
               msg = "Error preparing code for "+payload
               raise Exception(msg)
            self._pl2xml_isPrepared = True
+
     
         # get payload from DB:
         result = session.query(self.conddb.Payload.data, self.conddb.Payload.object_type).filter(self.conddb.Payload.hash == payload).one()
         data, plType = result
     
         sys.path.append('.')
-        import pl2xmlComp
-        resultXML = pl2xmlComp.payload2xml( str(data), str(plType) )
+
+	func = getattr(xmlConverter, 'payload2xml')
+    	resultXML = func( str(data), str(plType) )
+
         print resultXML    
     


### PR DESCRIPTION
Example of a payload-to-XML C++ plugin
Once this is built, it will be called from the cond2xml.py python class used in the conddb dump command.
This speeds up the conversion to XML significantly as no compilation is needed any more.
