### PR TITLE
new methods for D filters -- backports of  #10822

### DIFF
--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.cc
@@ -1,0 +1,207 @@
+#include <iostream>
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerRefsCollections.h"
+
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+
+#include "DataFormats/Math/interface/Error.h"
+#include "DataFormats/Math/interface/Point3D.h"
+#include "DataFormats/GeometryVector/interface/GlobalPoint.h"
+#include "DataFormats/GeometryCommonDetAlgo/interface/GlobalError.h"
+
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "HLTrigger/btau/src/HLTDisplacedtktkFilter.h"
+#include "TMath.h"
+
+//
+// constructors and destructor
+//
+HLTDisplacedtktkFilter::HLTDisplacedtktkFilter(const edm::ParameterSet& iConfig) :
+  HLTFilter(iConfig),
+  fastAccept_ (iConfig.getParameter<bool>("FastAccept")),
+  minLxySignificance_ (iConfig.getParameter<double>("MinLxySignificance")),
+  maxLxySignificance_ (iConfig.getParameter<double>("MaxLxySignificance")),
+  maxNormalisedChi2_ (iConfig.getParameter<double>("MaxNormalisedChi2")),
+  minVtxProbability_ (iConfig.getParameter<double>("MinVtxProbability")),
+  minCosinePointingAngle_ (iConfig.getParameter<double>("MinCosinePointingAngle")),
+  triggerTypeDaughters_(iConfig.getParameter<int>("triggerTypeDaughters")),
+  DisplacedVertexTag_(iConfig.getParameter<edm::InputTag>("DisplacedVertexTag")),
+  DisplacedVertexToken_(consumes<reco::VertexCollection>(DisplacedVertexTag_)),
+  beamSpotTag_ (iConfig.getParameter<edm::InputTag> ("BeamSpotTag")),
+  beamSpotToken_(consumes<reco::BeamSpot>(beamSpotTag_)),
+  TrackTag_ (iConfig.getParameter<edm::InputTag>("TrackTag")),
+  TrackToken_(consumes<reco::RecoChargedCandidateCollection>(TrackTag_))
+{
+}
+
+
+HLTDisplacedtktkFilter::~HLTDisplacedtktkFilter()
+{
+
+}
+
+void HLTDisplacedtktkFilter::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  makeHLTFilterDescription(desc);
+  desc.add<bool>("FastAccept",false);
+  desc.add<double>("MinLxySignificance",0.0);
+  desc.add<double>("MaxLxySignificance",0.0);
+  desc.add<double>("MaxNormalisedChi2",10.0);
+  desc.add<double>("MinVtxProbability",0.0);
+  desc.add<double>("MinCosinePointingAngle",-2.0);
+  desc.add<int>("triggerTypeDaughters",0);
+  desc.add<edm::InputTag>("DisplacedVertexTag",edm::InputTag("hltDisplacedtktkVtx"));
+  desc.add<edm::InputTag>("BeamSpotTag",edm::InputTag("hltOnlineBeamSpot"));
+  desc.add<edm::InputTag>("TrackTag",edm::InputTag("hltL3MuonCandidates"));
+  descriptions.add("hltDisplacedtktkFilter", desc);
+ }
+
+// ------------ method called once each job just before starting event loop  ------------
+void HLTDisplacedtktkFilter::beginJob()
+{
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void HLTDisplacedtktkFilter::endJob()
+{
+ 	
+}
+
+// ------------ method called on each new Event  ------------
+bool HLTDisplacedtktkFilter::hltFilter(edm::Event& iEvent, const edm::EventSetup& iSetup, trigger::TriggerFilterObjectWithRefs & filterproduct) const
+{
+
+
+  // get beam spot
+  reco::BeamSpot vertexBeamSpot;
+  edm::Handle<reco::BeamSpot> recoBeamSpotHandle;
+  iEvent.getByToken(beamSpotToken_,recoBeamSpotHandle);
+  vertexBeamSpot = *recoBeamSpotHandle;
+
+
+  // get displaced vertices
+  reco::VertexCollection displacedVertexColl;
+  edm::Handle<reco::VertexCollection> displacedVertexCollHandle;
+  bool foundVertexColl = iEvent.getByToken(DisplacedVertexToken_, displacedVertexCollHandle);
+  if(foundVertexColl) displacedVertexColl = *displacedVertexCollHandle;
+
+
+  // get track collection
+  edm::Handle<reco::RecoChargedCandidateCollection> trackcands;
+  iEvent.getByToken(TrackToken_,trackcands);
+
+  // All HLT filters must create and fill an HLT filter object,
+  // recording any reconstructed physics objects satisfying (or not)
+  // this HLT filter, and place it in the Event.
+
+
+  // Ref to Candidate object to be recorded in filter object
+  reco::RecoChargedCandidateRef ref1;
+  reco::RecoChargedCandidateRef ref2;
+
+  if (saveTags()) filterproduct.addCollectionTag(TrackTag_);
+
+  bool triggered = false;
+
+  // loop over vertex collection
+  for(reco::VertexCollection::iterator it = displacedVertexColl.begin(); it!= displacedVertexColl.end(); it++){
+          reco::Vertex displacedVertex = *it;
+
+          // check if the vertex actually consists of exactly two track tracks, reject the event if not
+          if(displacedVertex.tracksSize() != 2){
+            edm::LogError("HLTDisplacedtktkFilter") << "HLTDisplacedtktkFilter: ERROR: the Jpsi vertex must have exactly two tracks by definition. It now has n tracks = "<< displacedVertex.tracksSize() << std::endl;
+            return false;
+          } 
+
+          float normChi2 = displacedVertex.normalizedChi2();
+	  if (normChi2 > maxNormalisedChi2_) continue;
+
+	  double vtxProb = 0.0;
+	  if( (displacedVertex.chi2()>=0.0) && (displacedVertex.ndof()>0) ) vtxProb = TMath::Prob(displacedVertex.chi2(), displacedVertex.ndof() );
+	  if (vtxProb < minVtxProbability_) continue;
+
+          // get the two tracks from the vertex
+          reco::Vertex::trackRef_iterator trackIt =  displacedVertex.tracks_begin();
+          reco::TrackRef vertextkRef1 =  (*trackIt).castTo<reco::TrackRef>() ;
+          // the second one
+          trackIt++;
+          reco::TrackRef vertextkRef2 =  (*trackIt).castTo<reco::TrackRef>();
+
+	  // first find these two tracks in the track collection
+	  reco::RecoChargedCandidateCollection::const_iterator cand1;
+	  reco::RecoChargedCandidateCollection::const_iterator cand2;	
+
+	  int iFoundRefs = 0;
+	  for (reco::RecoChargedCandidateCollection::const_iterator cand=trackcands->begin(); cand!=trackcands->end(); cand++) {
+	    reco::TrackRef tkRef = cand->get<reco::TrackRef>();
+	    if(tkRef == vertextkRef1) {cand1 = cand; iFoundRefs++;}
+	    if(tkRef == vertextkRef2) {cand2 = cand; iFoundRefs++;}
+	  }
+	  
+	  if(iFoundRefs != 2){
+            edm::LogError("HLTDisplacedtktkFilter") << "HLTDisplacedtktkFilter: ERROR: the Jpsi vertex must have exactly two tracks by definition."  << std::endl;
+            return false;
+          } 	
+          // calculate two-track transverse momentum
+          math::XYZVector pperp(cand1->px() + cand2->px(),
+        			  cand1->py() + cand2->py(),
+        			  0.);
+
+
+	  reco::Vertex::Point vpoint=displacedVertex.position();
+	  //translate to global point, should be improved
+	  GlobalPoint secondaryVertex (vpoint.x(), vpoint.y(), vpoint.z());
+
+	  reco::Vertex::Error verr = displacedVertex.error();
+	  // translate to global error, should be improved
+	  GlobalError err(verr.At(0,0), verr.At(1,0), verr.At(1,1), verr.At(2,0), verr.At(2,1), verr.At(2,2) );
+
+	  GlobalPoint displacementFromBeamspot( -1*((vertexBeamSpot.x0() -  secondaryVertex.x()) +  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dxdz()),
+        					  -1*((vertexBeamSpot.y0() - secondaryVertex.y())+  (secondaryVertex.z() - vertexBeamSpot.z0()) * vertexBeamSpot.dydz()), 0);
+
+          float lxy = displacementFromBeamspot.perp();
+          float lxyerr = sqrt(err.rerr(displacementFromBeamspot));
+
+
+          //calculate the angle between the decay length and the tktk momentum
+	  reco::Vertex::Point vperp(displacementFromBeamspot.x(),displacementFromBeamspot.y(),0.);
+
+          float cosAlpha = vperp.Dot(pperp)/(vperp.R()*pperp.R());
+
+          // check thresholds
+          if (cosAlpha < minCosinePointingAngle_) continue;
+          if (minLxySignificance_ > 0. && lxy/lxyerr < minLxySignificance_) continue;
+	  if (maxLxySignificance_ > 0. && lxy/lxyerr > maxLxySignificance_) continue;
+	  triggered = true;
+
+	  // now add the tracks that passed to the filter object
+	
+	  ref1=reco::RecoChargedCandidateRef( edm::Ref<reco::RecoChargedCandidateCollection> 	(trackcands,distance(trackcands->begin(), cand1)));
+	  filterproduct.addObject(triggerTypeDaughters_,ref1);
+	
+	  ref2=reco::RecoChargedCandidateRef( edm::Ref<reco::RecoChargedCandidateCollection> (trackcands,distance(trackcands->begin(),cand2 )));
+	  filterproduct.addObject(triggerTypeDaughters_,ref2);
+  }
+
+  LogDebug("HLTDisplacedtktkFilter") << " >>>>> Result of HLTDisplacedtktkFilter is "<< triggered <<std::endl;
+
+  return triggered;
+}

--- a/HLTrigger/btau/src/HLTDisplacedtktkFilter.h
+++ b/HLTrigger/btau/src/HLTDisplacedtktkFilter.h
@@ -1,0 +1,39 @@
+#ifndef HLTDisplacedtktkFilter_h
+#define HLTDisplacedtktkFilter_h
+
+#include "HLTrigger/HLTcore/interface/HLTFilter.h"
+namespace edm {
+  class ConfigurationDescriptions;
+}
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/BeamSpot/interface/BeamSpot.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+
+class HLTDisplacedtktkFilter : public HLTFilter {
+
+  public:
+    explicit HLTDisplacedtktkFilter(const edm::ParameterSet&);
+    ~HLTDisplacedtktkFilter();
+    static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);	
+    virtual void beginJob() ;
+    virtual bool hltFilter(edm::Event&, const edm::EventSetup&, trigger::TriggerFilterObjectWithRefs & filterproduct) const override;
+    virtual void endJob() ;
+
+  private:
+    bool fastAccept_;
+    double minLxySignificance_;
+    double maxLxySignificance_;
+    double maxNormalisedChi2_;
+    double minVtxProbability_;
+    double minCosinePointingAngle_;
+    const int triggerTypeDaughters_;  
+
+    edm::InputTag                            DisplacedVertexTag_;
+    edm::EDGetTokenT<reco::VertexCollection> DisplacedVertexToken_;
+    edm::InputTag                            beamSpotTag_;
+    edm::EDGetTokenT<reco::BeamSpot>         beamSpotToken_;
+    edm::InputTag                                          TrackTag_;
+    edm::EDGetTokenT<reco::RecoChargedCandidateCollection> TrackToken_;
+
+};
+#endif

--- a/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.cc
+++ b/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.cc
@@ -1,0 +1,209 @@
+#include <iostream>
+
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
+#include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
+
+#include "DataFormats/Candidate/interface/CandidateFwd.h"
+#include "DataFormats/RecoCandidate/interface/RecoCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidate.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/Candidate/interface/Candidate.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerRefsCollections.h"
+
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/TrackReco/interface/Track.h"
+#include "TrackingTools/TransientTrack/interface/TransientTrackBuilder.h"
+#include "TrackingTools/Records/interface/TransientTrackRecord.h"
+
+#include "RecoVertex/KalmanVertexFit/interface/KalmanVertexFitter.h"
+#include "RecoVertex/VertexPrimitives/interface/TransientVertex.h"
+#include "DataFormats/VertexReco/interface/Vertex.h"
+#include "DataFormats/VertexReco/interface/VertexFwd.h"
+#include "DataFormats/Common/interface/RefToBase.h"
+
+#include "HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.h"
+
+using namespace edm;
+using namespace reco;
+using namespace std; 
+using namespace trigger;
+//
+// constructors and destructor
+//
+HLTDisplacedtktkVtxProducer::HLTDisplacedtktkVtxProducer(const edm::ParameterSet& iConfig):	
+	srcTag_ (iConfig.getParameter<edm::InputTag>("Src")),
+	srcToken_(consumes<reco::RecoChargedCandidateCollection>(srcTag_)),
+    previousCandTag_(iConfig.getParameter<edm::InputTag>("PreviousCandTag")),
+	previousCandToken_(consumes<trigger::TriggerFilterObjectWithRefs>(previousCandTag_)),
+	maxEta_ (iConfig.getParameter<double>("MaxEta")),
+	minPt_ (iConfig.getParameter<double>("MinPt")),
+	minPtPair_ (iConfig.getParameter<double>("MinPtPair")),
+	minInvMass_ (iConfig.getParameter<double>("MinInvMass")),
+	maxInvMass_ (iConfig.getParameter<double>("MaxInvMass")),
+	massParticle1_ (iConfig.getParameter<double>("massParticle1")),
+	massParticle2_ (iConfig.getParameter<double>("massParticle2")),
+	chargeOpt_ (iConfig.getParameter<int>("ChargeOpt")),
+    triggerTypeDaughters_(iConfig.getParameter<int>("triggerTypeDaughters"))
+
+{
+	produces<VertexCollection>();
+}
+
+
+HLTDisplacedtktkVtxProducer::~HLTDisplacedtktkVtxProducer()
+{
+
+}
+
+void
+HLTDisplacedtktkVtxProducer::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.add<edm::InputTag>("Src",edm::InputTag("hltL3MuonCandidates"));
+  desc.add<edm::InputTag>("PreviousCandTag",edm::InputTag(""));
+  desc.add<double>("MaxEta",2.5);
+  desc.add<double>("MinPt",0.0);
+  desc.add<double>("MinPtPair",0.0);
+  desc.add<double>("MinInvMass",1.0);
+  desc.add<double>("MaxInvMass",20.0);
+  desc.add<double>("massParticle1",0.1396);
+  desc.add<double>("massParticle2",0.4937);
+  desc.add<int>("ChargeOpt",-1);
+  desc.add<int>("triggerTypeDaughters",0);
+
+  descriptions.add("hltDisplacedtktkVtxProducer", desc);
+}
+
+// ------------ method called once each job just before starting event loop  ------------
+void HLTDisplacedtktkVtxProducer::beginJob()
+{
+
+}
+
+// ------------ method called once each job just after ending the event loop  ------------
+void HLTDisplacedtktkVtxProducer::endJob() 
+{
+ 	
+}
+
+// ------------ method called on each new Event  ------------
+void HLTDisplacedtktkVtxProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
+{
+	double const firstTrackMass = massParticle1_;
+	double const firstTrackMass2 = firstTrackMass*firstTrackMass;
+	double const secondTrackMass = massParticle2_;
+	double const secondTrackMass2 = secondTrackMass*secondTrackMass;
+
+	// get hold of track trks
+	Handle<RecoChargedCandidateCollection> trackcands;
+	iEvent.getByToken(srcToken_,trackcands);
+	
+	//get the transient track builder:
+	edm::ESHandle<TransientTrackBuilder> theB;
+	iSetup.get<TransientTrackRecord>().get("TransientTrackBuilder",theB);
+
+	std::auto_ptr<VertexCollection> vertexCollection(new VertexCollection());
+
+	// look at all trackcands,  check cuts and make vertices
+	double e1,e2;
+	Particle::LorentzVector p,p1,p2;
+	
+	RecoChargedCandidateCollection::const_iterator cand1;
+	RecoChargedCandidateCollection::const_iterator cand2;
+	
+	// get the objects passing the previous filter
+	Handle<TriggerFilterObjectWithRefs> previousCands;
+	iEvent.getByToken(previousCandToken_,previousCands);
+
+	vector<RecoChargedCandidateRef> vPrevCands;
+	previousCands->getObjects(triggerTypeDaughters_,vPrevCands);
+	
+	for (cand1=trackcands->begin(); cand1!=trackcands->end(); cand1++) {
+	       TrackRef tk1 = cand1->get<TrackRef>();
+	       LogDebug("HLTDisplacedtktkVtxProducer") << " 1st track in loop: q*pt= " << cand1->charge()*cand1->pt() << ", eta= " << cand1->eta() << ", hits= " << tk1->numberOfValidHits();
+	     
+	       //first check if this track passed the previous filter
+	       if( ! checkPreviousCand( tk1, vPrevCands) ) continue;
+ 	
+	       // cuts
+	       if (abs(cand1->eta())>maxEta_) continue;
+	       if (cand1->pt() < minPt_) continue;
+	    
+	    
+	    cand2=trackcands->begin();
+	    if(massParticle1_==massParticle2_){cand2 = cand1+1;}
+
+	    for (; cand2!=trackcands->end(); cand2++) {
+		     
+		     TrackRef tk2 = cand2->get<TrackRef>();
+		     if(tk1==tk2) continue;
+		 
+			 // eta cut
+			 LogDebug("HLTDisplacedtktkVtxProducer") << " 2nd track in loop: q*pt= " << cand2->charge()*cand2->pt() << ", eta= " << cand2->eta() << ", hits= " << tk2->numberOfValidHits() << ", d0= " << tk2->d0();
+			 //first check if this track passed the previous filter
+			 if( ! checkPreviousCand( tk2, vPrevCands) ) continue;
+			 
+			 // cuts
+			 if (abs(cand2->eta())>maxEta_) continue;
+			 if (cand2->pt() < minPt_) continue;
+			 
+			 // opposite sign or same sign
+			 if (chargeOpt_<0) {
+			   if (cand1->charge()*cand2->charge()>0) continue;
+			 } else if (chargeOpt_>0) {
+			   if (cand1->charge()*cand2->charge()<0) continue;
+			 }
+			 
+			 // Combined ditrack system
+			 e1 = sqrt(cand1->momentum().Mag2()+firstTrackMass2);
+			 e2 = sqrt(cand2->momentum().Mag2()+secondTrackMass2);
+			 p1 = Particle::LorentzVector(cand1->px(),cand1->py(),cand1->pz(),e1);
+			 p2 = Particle::LorentzVector(cand2->px(),cand2->py(),cand2->pz(),e2);
+			 p = p1+p2;
+			 
+			 
+			 if (p.pt()<minPtPair_) continue;
+			 
+			 double invmass = abs(p.mass());
+			 LogDebug("HLTDisplacedtktkVtxProducer") << " ... 1-2 invmass= " << invmass;
+			 
+			 if (invmass<minInvMass_) continue;
+			 if (invmass>maxInvMass_) continue;
+			 
+			 // do the vertex fit
+			 vector<TransientTrack> t_tks;
+			 TransientTrack ttkp1 = (*theB).build(&tk1);
+			 TransientTrack ttkp2 = (*theB).build(&tk2);
+			 t_tks.push_back(ttkp1);
+			 t_tks.push_back(ttkp2);
+			 
+		
+			 if (t_tks.size()!=2) continue;
+			
+			 KalmanVertexFitter kvf;
+			 TransientVertex tv = kvf.vertex(t_tks);
+
+			 if (!tv.isValid()) continue;
+			 
+			 Vertex vertex = tv;
+
+			 // put vertex in the event
+			 vertexCollection->push_back(vertex);
+	       }
+	}
+   	iEvent.put(vertexCollection);
+}
+
+
+
+bool HLTDisplacedtktkVtxProducer::checkPreviousCand(const TrackRef& trackref, vector<RecoChargedCandidateRef> & refVect){
+  bool ok=false;
+  for (unsigned int i=0; i<refVect.size(); i++) {
+    if ( refVect[i]->get<TrackRef>() == trackref ) {
+      ok=true;
+      break;
+    }
+  }
+  return ok;
+}

--- a/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.h
+++ b/HLTrigger/btau/src/HLTDisplacedtktkVtxProducer.h
@@ -1,0 +1,63 @@
+#ifndef HLTDisplacedtktkVtxProducer_h
+#define HLTDisplacedtktkVtxProducer_h
+
+/** \class HLTDisplacedtktkVtxProducer_h
+ *
+ *  
+ *  produces kalman vertices from di-track
+ *  takes track candidates as input
+ *  configurable cuts on pt, eta, pair pt, inv. mass
+ *  the two tracks have to be both tracks or both muons
+ *
+ *  \author Alexander.Schmidt@cern.ch
+ *  \date   3. Feb. 2011
+ *  \adapted for D Gian.Michele.Innocenti@cern.ch
+ *  \date   5. Aug. 2015
+ *
+ */
+
+
+
+#include "FWCore/Framework/interface/stream/EDProducer.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "DataFormats/RecoCandidate/interface/RecoChargedCandidateFwd.h"
+#include "DataFormats/TrackReco/interface/TrackFwd.h"
+#include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
+#include "DataFormats/HLTReco/interface/TriggerRefsCollections.h"
+#include <vector>
+
+namespace edm {
+  class ConfigurationDescriptions;
+}
+
+class HLTDisplacedtktkVtxProducer : public edm::stream::EDProducer<> {
+ public:
+  explicit HLTDisplacedtktkVtxProducer(const edm::ParameterSet&);
+  ~HLTDisplacedtktkVtxProducer();
+  static void fillDescriptions(edm::ConfigurationDescriptions & descriptions);  
+  virtual void beginJob();
+  virtual void produce(edm::Event&, const edm::EventSetup&);
+  virtual void endJob();
+
+ private:  
+  bool checkPreviousCand(const reco::TrackRef& trackref, std::vector<reco::RecoChargedCandidateRef>& ref2);
+
+  const edm::InputTag                                          srcTag_;
+  const edm::EDGetTokenT<reco::RecoChargedCandidateCollection> srcToken_;
+  const edm::InputTag                                          previousCandTag_;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> previousCandToken_;
+  const double maxEta_;
+  const double minPt_;
+  const double minPtPair_;
+  const double minInvMass_;
+  const double maxInvMass_;
+  const double massParticle1_;
+  const double massParticle2_;
+  const int chargeOpt_;
+  const int triggerTypeDaughters_;  
+
+};
+
+#endif

--- a/HLTrigger/btau/src/modules.cc
+++ b/HLTrigger/btau/src/modules.cc
@@ -12,6 +12,12 @@ DEFINE_FWK_MODULE(HLTDisplacedmumuFilter);
 #include "HLTDisplacedmumuVtxProducer.h"
 DEFINE_FWK_MODULE(HLTDisplacedmumuVtxProducer);
 
+#include "HLTDisplacedtktkFilter.h"
+DEFINE_FWK_MODULE(HLTDisplacedtktkFilter);
+
+#include "HLTDisplacedtktkVtxProducer.h"
+DEFINE_FWK_MODULE(HLTDisplacedtktkVtxProducer);
+
 #include "HLTDisplacedmumumuFilter.h"
 DEFINE_FWK_MODULE(HLTDisplacedmumumuFilter);
 


### PR DESCRIPTION
We added one track-track producer and one filter in analogy with the displaced mumu producer and filters. The vertex producer allows to set the mass of the two particles, and to set the trigger type of the daughters in order to be used for both track-track and muon-muon displaced vertices. 

Below, the link to the TSG discussion:

https://indico.cern.ch/event/433045/#preview:1627730

Gian Michele
