### PR TITLE
Option for DAS query in ConfigBuilder 76X

### DIFF
--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -137,10 +137,10 @@ def filesFromDASQuery(query,option="",s=None):
 			print 'Sleeping, then retrying DAS'
 			time.sleep(100)
 		p = Popen('das_client.py %s --query "%s"'%(option,query), stdout=PIPE,shell=True)
+                pipe=p.stdout.read()
 		tupleP = os.waitpid(p.pid, 0)
 		eC=tupleP[1]
 		count=count+1
-		pipe=p.stdout.read()
 	if eC==0:
 		print "DAS succeeded after",count,"attempts",eC
 	else:

--- a/Configuration/Applications/python/ConfigBuilder.py
+++ b/Configuration/Applications/python/ConfigBuilder.py
@@ -21,6 +21,7 @@ defaultOptions.isData=True
 defaultOptions.step=''
 defaultOptions.pileup='NoPileUp'
 defaultOptions.pileup_input = None
+defaultOptions.pileup_dasoption = ''
 defaultOptions.geometry = 'SimDB'
 defaultOptions.geometryExtendedOptions = ['ExtendedGFlash','Extended','NoCastor']
 defaultOptions.magField = ''
@@ -36,6 +37,7 @@ defaultOptions.name = "NO NAME GIVEN"
 defaultOptions.evt_type = ""
 defaultOptions.filein = ""
 defaultOptions.dasquery=""
+defaultOptions.dasoption=""
 defaultOptions.secondfilein = ""
 defaultOptions.customisation_file = []
 defaultOptions.customisation_file_unsch = []
@@ -122,7 +124,7 @@ def filesFromList(fileName,s=None):
 		print "found parent files:",sec
 	return (prim,sec)
 	
-def filesFromDASQuery(query,s=None):
+def filesFromDASQuery(query,option="",s=None):
 	import os,time
 	import FWCore.ParameterSet.Config as cms
 	prim=[]
@@ -134,7 +136,7 @@ def filesFromDASQuery(query,s=None):
 		if count!=0:
 			print 'Sleeping, then retrying DAS'
 			time.sleep(100)
-		p = Popen('das_client.py --query "%s"'%(query), stdout=PIPE,shell=True)
+		p = Popen('das_client.py %s --query "%s"'%(option,query), stdout=PIPE,shell=True)
 		tupleP = os.waitpid(p.pid, 0)
 		eC=tupleP[1]
 		count=count+1
@@ -383,7 +385,7 @@ class ConfigBuilder(object):
 			if entry.startswith("filelist:"):
 				filesFromList(entry[9:],self.process.source)
 			elif entry.startswith("dbs:") or entry.startswith("das:"):
-				filesFromDASQuery('file dataset = %s'%(entry[4:]),self.process.source)
+				filesFromDASQuery('file dataset = %s'%(entry[4:]),self._options.dasoption,self.process.source)
 			else:
 				self.process.source.fileNames.append(self._options.dirin+entry)
 		if self._options.secondfilein:
@@ -394,7 +396,7 @@ class ConfigBuilder(object):
 				if entry.startswith("filelist:"):
 					self.process.source.secondaryFileNames.extend((filesFromList(entry[9:]))[0])
 				elif entry.startswith("dbs:") or entry.startswith("das:"):
-					self.process.source.secondaryFileNames.extend((filesFromDASQuery('file dataset = %s'%(entry[4:])))[0])
+					self.process.source.secondaryFileNames.extend((filesFromDASQuery('file dataset = %s'%(entry[4:]),self._options.dasoption))[0])
 				else:
 					self.process.source.secondaryFileNames.append(self._options.dirin+entry)
 
@@ -441,7 +443,7 @@ class ConfigBuilder(object):
 
 	if self._options.dasquery!='':
                self.process.source=cms.Source("PoolSource", fileNames = cms.untracked.vstring(),secondaryFileNames = cms.untracked.vstring())
-	       filesFromDASQuery(self._options.dasquery,self.process.source)
+	       filesFromDASQuery(self._options.dasquery,self._options.dasoption,self.process.source)
 
 	##drop LHEXMLStringProduct on input to save memory if appropriate
 	if 'GEN' in self.stepMap.keys():
@@ -705,7 +707,7 @@ class ConfigBuilder(object):
 		if not "DATAMIX" in self.stepMap.keys(): # when DATAMIX is present, pileup_input refers to pre-mixed GEN-RAW
 			if self._options.pileup_input:
 				if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
-					mixingDict['F']=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],))[0]
+					mixingDict['F']=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
 				else:
 					mixingDict['F']=self._options.pileup_input.split(',')
 			specialization=defineMixing(mixingDict)
@@ -1501,7 +1503,7 @@ class ConfigBuilder(object):
 	    if self._options.pileup_input:
 		    theFiles=''
 		    if self._options.pileup_input.startswith('dbs:') or self._options.pileup_input.startswith('das:'):
-			    theFiles=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],))[0]
+			    theFiles=filesFromDASQuery('file dataset = %s'%(self._options.pileup_input[4:],),self._options.pileup_dasoption)[0]
 		    elif self._options.pileup_input.startswith("filelist:"):
 			    theFiles= (filesFromList(self._options.pileup_input[9:]))[0]
 		    else:

--- a/Configuration/Applications/python/Options.py
+++ b/Configuration/Applications/python/Options.py
@@ -206,6 +206,11 @@ expertSettings.add_option("--pileup_input",
                           default=None,
                           dest="pileup_input")
 
+expertSettings.add_option("--pileup_dasoption",
+                          help="Additional option for DAS query of pile up",
+                          default="",
+                          dest="pileup_dasoption")
+
 expertSettings.add_option("--datamix",
                   help="What datamix config to use. Default=DataOnSim.",
                   default=defaultOptions.datamix,
@@ -266,6 +271,11 @@ expertSettings.add_option("--dasquery",
                           help="Allow to define the source.fileNames from the das search command",
                           default='',
                           dest="dasquery")
+
+expertSettings.add_option("--dasoption",
+                          help="Additional option for DAS query",
+                          default='',
+                          dest="dasoption")
 
 expertSettings.add_option("--dbsquery",
                           help="Deprecated. Please use dasquery option. Functions for backward compatibility",


### PR DESCRIPTION
Two options added in order to pass options to DAS query, separately for main input and pile-up.
Initially needed in order to add larger sample when mixing (das_client.py --limit 0), however instead of coding this option in, a  more generic flexibility was suggested ( @franzoni ).
One problem is if the dataset is too large (i.e. more than 600 files), the line:
https://github.com/yetkinyilmaz/cmssw/blob/das_query_76X_03/Configuration/Applications/python/ConfigBuilder.py#L140
gets stuck. This has to be fixed independently afterwards by more expert developers.
