### PR TITLE
update of the XML conversion in C++ 

### DIFF
--- a/CondCore/BeamSpotPlugins/plugins/BeamSpotObjects_toXML.cc
+++ b/CondCore/BeamSpotPlugins/plugins/BeamSpotObjects_toXML.cc
@@ -6,7 +6,7 @@
 namespace { // Avoid cluttering the global namespace.
 
   // converter methods
-  std::string BeamSpot2xml( std::string const &payloadData, std::string const &payloadType ) { 
+  std::string BeamSpotObjects2xml( std::string const &payloadData, std::string const &payloadType ) { 
     return cond::convertToXML<BeamSpotObjects> (payloadData, payloadType);
   }
 
@@ -16,6 +16,6 @@ namespace { // Avoid cluttering the global namespace.
 BOOST_PYTHON_MODULE( pluginBeamSpotObjects_toXML )
 {
     using namespace boost::python;
-    def ("BeamSpot2xml"   , &BeamSpot2xml);
+    def ("BeamSpotObjects2xml"   , &BeamSpotObjects2xml);
 
 }

--- a/CondCore/BeamSpotPlugins/plugins/BeamSpotObjects_toXML.cc
+++ b/CondCore/BeamSpotPlugins/plugins/BeamSpotObjects_toXML.cc
@@ -1,47 +1,13 @@
 
-#include <iostream>
-#include <string>
-#include <memory>
 
-#include <boost/python/class.hpp>
-#include <boost/python/module.hpp>
-#include <boost/python/init.hpp>
-#include <boost/python/def.hpp>
-#include <iostream>
-#include <string>
-#include <sstream>
-
-#include "boost/archive/xml_oarchive.hpp"
-#include "CondFormats/Serialization/interface/Serializable.h"
-#include "CondFormats/Serialization/interface/Archive.h"
-
+#include "CondCore/Utilities/interface/PayloadToXML.h"
 #include "CondCore/Utilities/src/CondFormats.h"
 
 namespace { // Avoid cluttering the global namespace.
 
-
-  void initpluginBeamSpotObjects_toXML() {}
-
-  std::string payload2xml( const std::string &payloadData, const std::string &payloadType ) { 
-
-      // now to convert
-      std::unique_ptr< BeamSpotObjects > payload;
-
-      std::stringbuf sdataBuf;
-      sdataBuf.pubsetbuf( const_cast<char *> ( payloadData.c_str() ), payloadData.size() );
-
-      std::istream inBuffer( &sdataBuf );
-      eos::portable_iarchive ia( inBuffer );
-      payload.reset( new BeamSpotObjects );
-      ia >> (*payload);
-
-      // now we have the object in memory, convert it to xml in a string and return it
-     
-      std::ostringstream outBuffer;
-      boost::archive::xml_oarchive xmlResult( outBuffer );
-      xmlResult << boost::serialization::make_nvp( "cmsCondPayload", *payload );
-
-      return outBuffer.str();
+  // converter methods
+  std::string BeamSpot2xml( std::string const &payloadData, std::string const &payloadType ) { 
+    return cond::convertToXML<BeamSpotObjects> (payloadData, payloadType);
   }
 
 } // end namespace
@@ -50,6 +16,6 @@ namespace { // Avoid cluttering the global namespace.
 BOOST_PYTHON_MODULE( pluginBeamSpotObjects_toXML )
 {
     using namespace boost::python;
-    def ("payload2xml", payload2xml);
+    def ("BeamSpot2xml"   , &BeamSpot2xml);
 
 }

--- a/CondCore/SiStripPlugins/plugins/BuildFile.xml
+++ b/CondCore/SiStripPlugins/plugins/BuildFile.xml
@@ -1,3 +1,5 @@
+<flags CXX_FLAGS="-Wno-unused-variable"/>
+
 <library   file="SiStripPedestalsPyWrapper.cc" name="SiStripPedestalsPyInterface">
   <use   name="CondCore/Utilities"/>
   <use   name="CondFormats/SiStripObjects"/>
@@ -168,4 +170,11 @@
   <use   name="boost_python"/>
   <use   name="boost_regex"/>
   <flags   EDM_PLUGIN="1"/>
+</library>
+
+<library   file="SiStripObjects_toXML.cc" name="SiStripObjects_toXML">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="boost_python"/>
 </library>

--- a/CondCore/SiStripPlugins/plugins/SiStripObjects_toXML.cc
+++ b/CondCore/SiStripPlugins/plugins/SiStripObjects_toXML.cc
@@ -1,0 +1,26 @@
+
+#include "CondCore/Utilities/interface/PayloadToXML.h"
+#include "CondCore/Utilities/src/CondFormats.h"
+
+namespace { // Avoid cluttering the global namespace.
+
+  // converter methods
+  std::string SiStripLatency2xml( std::string const &payloadData, std::string const &payloadType ) { 
+    return cond::convertToXML<SiStripLatency> (payloadData, payloadType);
+  }
+
+  std::string SiStripConfObject2xml( const std::string &payloadData, const std::string &payloadType ) { 
+    return cond::convertToXML<SiStripConfObject> (payloadData, payloadType);
+  }
+
+} // end namespace
+
+
+BOOST_PYTHON_MODULE( pluginSiStripObjects_toXML )
+{
+    using namespace boost::python;
+    def ("SiStripLatency2xml"   , &SiStripLatency2xml);
+    def ("SiStripConfObject2xml", &SiStripConfObject2xml);
+
+}
+

--- a/CondCore/Utilities/interface/PayloadToXML.h
+++ b/CondCore/Utilities/interface/PayloadToXML.h
@@ -1,0 +1,42 @@
+
+#include <iostream>
+#include <string>
+#include <memory>
+
+#include <boost/python/class.hpp>
+#include <boost/python/module.hpp>
+#include <boost/python/init.hpp>
+#include <boost/python/def.hpp>
+#include <iostream>
+#include <string>
+#include <sstream>
+
+#include "boost/archive/xml_oarchive.hpp"
+#include "CondFormats/Serialization/interface/Serializable.h"
+#include "CondFormats/Serialization/interface/Archive.h"
+
+namespace cond { 
+
+  template<typename T>
+  std::string convertToXML( const std::string &payloadData, const std::string &payloadType ) { 
+
+      std::unique_ptr< T > payload;
+      std::stringbuf sdataBuf;
+      sdataBuf.pubsetbuf( const_cast<char *> ( payloadData.c_str() ), payloadData.size() );
+
+      std::istream inBuffer( &sdataBuf );
+      eos::portable_iarchive ia( inBuffer );
+      payload.reset( new T );
+      ia >> (*payload);
+
+      // now we have the object in memory, convert it to xml in a string and return it
+     
+      std::ostringstream outBuffer;
+      boost::archive::xml_oarchive xmlResult( outBuffer );
+      xmlResult << boost::serialization::make_nvp( "cmsCondPayload", *payload );
+
+      return outBuffer.str();
+
+  }
+} // end namespace cond
+

--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -203,7 +203,7 @@ class CondXmlProcessor(object):
 
         return importlib.import_module( 'pl2xmlComp' )
     
-    def payload2xml(self, session, payload):
+    def payload2xml(self, session, payload, convFuncName='payload2xml'):
     
         if not self._pl2xml_isPrepared:
 	   xmlConverter = self.prepPayload2xml(session, payload)
@@ -219,7 +219,14 @@ class CondXmlProcessor(object):
     
         sys.path.append('.')
 
-	func = getattr(xmlConverter, 'payload2xml')
+        # see if we have a compiled module with different names:
+	try:
+	   func = getattr(xmlConverter, convFuncName)
+        except Exception, e:
+           # default name of functino (payload2xml) not found, take one of the ones which exist 
+	   # NOTE: this may change with time and is not guaranteed to be reproducible
+           first = [x for x in dir(xmlConverter) if x.endswith('2xml')][0]
+           func = getattr(xmlConverter, first)
     	resultXML = func( str(data), str(plType) )
 
         print resultXML    

--- a/CondCore/Utilities/python/cond2xml.py
+++ b/CondCore/Utilities/python/cond2xml.py
@@ -34,7 +34,7 @@ payload2xmlCodeTemplate = """
 
 namespace { // Avoid cluttering the global namespace.
 
-  std::string payload2xml( const std::string &payloadData, const std::string &payloadType ) { 
+  std::string %(plType)s2xml( const std::string &payloadData, const std::string &payloadType ) { 
 
       // now to convert
       std::unique_ptr< %(plType)s > payload;
@@ -62,7 +62,7 @@ namespace { // Avoid cluttering the global namespace.
 BOOST_PYTHON_MODULE(%(mdName)s)
 {
     using namespace boost::python;
-    def ("payload2xml", payload2xml);
+    def ("%(plType)s2xml", %(plType)s2xml);
 }
 
 """ 
@@ -203,7 +203,7 @@ class CondXmlProcessor(object):
 
         return importlib.import_module( 'pl2xmlComp' )
     
-    def payload2xml(self, session, payload, convFuncName='payload2xml'):
+    def payload2xml(self, session, payload):
     
         if not self._pl2xml_isPrepared:
 	   xmlConverter = self.prepPayload2xml(session, payload)
@@ -217,16 +217,9 @@ class CondXmlProcessor(object):
         result = session.query(self.conddb.Payload.data, self.conddb.Payload.object_type).filter(self.conddb.Payload.hash == payload).one()
         data, plType = result
     
+        convFuncName = plType+'2xml'
         sys.path.append('.')
-
-        # see if we have a compiled module with different names:
-	try:
-	   func = getattr(xmlConverter, convFuncName)
-        except Exception, e:
-           # default name of functino (payload2xml) not found, take one of the ones which exist 
-	   # NOTE: this may change with time and is not guaranteed to be reproducible
-           first = [x for x in dir(xmlConverter) if x.endswith('2xml')][0]
-           func = getattr(xmlConverter, first)
+	func = getattr(xmlConverter, convFuncName)
     	resultXML = func( str(data), str(plType) )
 
         print resultXML    

--- a/CondCore/Utilities/python/conddblib.py
+++ b/CondCore/Utilities/python/conddblib.py
@@ -397,3 +397,71 @@ def connect(database='pro', init=False, verbose=0):
 
     return Connection(url, init=init)
 
+
+def _exists(session, primary_key, value):
+    ret = None
+    try: 
+        ret = session.query(primary_key).\
+    	    filter(primary_key == value).\
+            count() != 0
+    except sqlalchemy.exc.OperationalError:
+        pass
+
+    return ret
+
+def _inserted_before(timestamp):
+    '''To be used inside filter().
+    '''
+
+    if timestamp is None:
+        # XXX: Returning None does not get optimized (skipped) by SQLAlchemy,
+        #      and returning True does not work in Oracle (generates "and 1"
+        #      which breaks Oracle but not SQLite). For the moment just use
+        #      this dummy condition.
+        return sqlalchemy.literal(True) == sqlalchemy.literal(True)
+
+    return conddb.IOV.insertion_time <= _parse_timestamp(timestamp)
+
+def listObject(session, name, snapshot=None):
+
+    is_tag = _exists(session, Tag.name, name)
+    result = {}
+    if is_tag:
+        result['type'] = 'Tag'
+        result['name'] = session.query(Tag).get(name).name
+	result['timeType'] = session.query(Tag.time_type).\
+				     filter(Tag.name == name).\
+            			     scalar()
+    
+        result['iovs'] = session.query(IOV.since, IOV.insertion_time, IOV.payload_hash, Payload.object_type).\
+                join(IOV.payload).\
+                filter(
+                    IOV.tag_name == name,
+                    _inserted_before(snapshot),
+                ).\
+                order_by(IOV.since.desc(), IOV.insertion_time.desc()).\
+                from_self().\
+                order_by(IOV.since, IOV.insertion_time).\
+                all()
+
+    try:
+        is_global_tag = _exists(session, GlobalTag.name, name)
+        if is_global_tag:
+            result['type'] = 'GlobalTag'
+	    result['name'] = session.query(GlobalTag).get(name)
+            result['tags'] = session.query(GlobalTagMap.record, GlobalTagMap.label, GlobalTagMap.tag_name).\
+                                     filter(GlobalTagMap.global_tag_name == name).\
+                    		     order_by(GlobalTagMap.record, GlobalTagMap.label).\
+                    		     all()
+    except sqlalchemy.exc.OperationalError:
+        sys.stderr.write("No table for GlobalTags found in DB.\n\n")
+
+    if not is_tag and not is_global_tag:
+        raise Exception('There is no tag or global tag named %s in the database.' % name)
+
+    return result
+
+def getPayload(session, hash):
+    # get payload from DB:
+    data, payloadType = session.query(Payload.data, Payload.object_type).filter(Payload.hash == hash).one()
+    return data


### PR DESCRIPTION
Update of the XML conversion in C++ with an improved, more flexible version.
The C++ module is now using a template function to do the work, which makes writing new converters simpler.
By convention the function name to convert should be "<ObjectTypeName>2xml" so that the dump subcommand of the conddb tool will find the correct function in the plugin of the module.
