### PR TITLE
Improved handling of customized GT via toGet

### DIFF
--- a/CondCore/ESSources/test/python/loadall_from_gt_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_gt_cfg.py
@@ -41,19 +41,12 @@ process.GlobalTag = cms.ESSource("PoolDBESSource",
 
 process.GlobalTag.globaltag = options.globalTag
 process.GlobalTag.DumpStat =  True
-# 'GR09_P_V6::All'
-#'CRAFT09_R_V9::All'
-#'MC_31X_V9::All'
-#'GR09_31X_V5P::All'
-#process.GlobalTag.pfnPrefix = "frontier://FrontierArc/"
-#process.GlobalTag.pfnPostfix = "_0911"
-#process.GlobalTag.toGet = cms.VPSet()
-#process.GlobalTag.toGet.append(
-#   cms.PSet(record = cms.string("BeamSpotObjectsRcd"),
-#            tag = cms.string("firstcollisions"),
-#             connect = cms.untracked.string("frontier://PromptProd/CMS_COND_31X_BEAMSPOT")
-#           )
-#)
+process.GlobalTag.toGet = cms.VPSet()
+process.GlobalTag.toGet.append(
+   cms.PSet(record = cms.string("BeamSpotObjectsRcd"),
+            snapshotTime = cms.string('2014-01-01 00:00:00.000'),
+           )
+)
 
 
 

--- a/CondCore/ESSources/test/python/loadall_from_prodglobaltag_cfg.py
+++ b/CondCore/ESSources/test/python/loadall_from_prodglobaltag_cfg.py
@@ -16,8 +16,6 @@ options.parseArguments()
 
 process = cms.Process("TEST")
 
-#process.add_(cms.Service("PrintEventSetupDataRetrieval", printProviders=cms.untracked.bool(True)))
-
 process.load("Configuration.StandardSequences.FrontierConditions_GlobalTag_cfi")
 process.GlobalTag.globaltag = options.globalTag
 process.GlobalTag.RefreshEachRun=cms.untracked.bool(False)
@@ -26,19 +24,12 @@ process.GlobalTag.pfnPrefix=cms.untracked.string('')
 process.GlobalTag.pfnPostfix=cms.untracked.string('')
 
 
-# 'GR09_P_V6::All'
-#'CRAFT09_R_V9::All'
-#'MC_31X_V9::All'
-#'GR09_31X_V5P::All'
-#process.GlobalTag.pfnPrefix = "frontier://FrontierArc/"
-#process.GlobalTag.pfnPostfix = "_0911"
-#process.GlobalTag.toGet = cms.VPSet()
-#process.GlobalTag.toGet.append(
-#   cms.PSet(record = cms.string("BeamSpotObjectsRcd"),
-#            tag = cms.string("firstcollisions"),
-#             connect = cms.untracked.string("frontier://PromptProd/CMS_COND_31X_BEAMSPOT")
-#           )
-#)
+process.GlobalTag.toGet = cms.VPSet()
+process.GlobalTag.toGet.append(
+   cms.PSet(record = cms.string("BeamSpotObjectsRcd"),
+            tag = cms.string("firstcollisions"),
+           )
+)
 
 
 


### PR DESCRIPTION
The handling of parameters set with the toGet in the cfg file has been cleaned up.
The default value for the snapshotTime value in the toGet entry is now infinity. This allows to overwrite a tag in the GT in use with a 'private' tag ( from a sqlite file or a service-based db ), considering the entire iov set with no snapshot selection ( unless explicitly set in the toGet entry ).
