### PR TITLE
Fix thread-safety issue with StreamerInputSource

### DIFF
--- a/IOPool/Streamer/interface/StreamerInputSource.h
+++ b/IOPool/Streamer/interface/StreamerInputSource.h
@@ -98,7 +98,8 @@ namespace edm {
     std::vector<unsigned char> dest_;
     TBufferFile xbuf_;
     std::unique_ptr<SendEvent> sendEvent_;
-    EventPrincipalHolder eventPrincipalHolder_;
+    std::unique_ptr<EventPrincipalHolder> eventPrincipalHolder_;
+    std::vector<std::unique_ptr<EventPrincipalHolder>> streamToEventPrincipalHolders_;
     bool adjustEventToNewProductRegistry_;
 
     std::string processName_;


### PR DESCRIPTION
The previous way StreamerInputSource handled reading back RefCores
lead to the probability that when dereferenced the RefCore would read
from the wrong EventPrincipal when the job was using multiple streams
becuase it was reusing the same EventPrincipalHolder for each event.
The code has now been changed to make a new EventPrincipalHolder for
each event.
