### PR TITLE
SiStripRecHitMatcher.h: remove non-POD VLA

### DIFF
--- a/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
+++ b/RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h
@@ -185,7 +185,7 @@ void SiStripRecHitMatcher::doubleMatch(MonoIterator monoRHiter, MonoIterator mon
   
   
   
-  StereoInfo cache[std::distance(seconditer,seconditerend)];
+  std::vector<StereoInfo> cache(std::distance(seconditer,seconditerend));
   //iterate on stereo rechits
   // fill cache with relevant info
   int  cacheSize=0;


### PR DESCRIPTION
Clang 3.7.0 will reject non-POD VLAs:

```
RecoLocalTracker/SiStripRecHitConverter/interface/SiStripRecHitMatcher.h:188:19:
error: variable length array of non-POD element type
'matcherDetails::StereoInfo'
```

Unknown why this is not triggered in ~3.6.0. Have not checked if `SiStripRecHitMatcher::doubleMatch` performance changed. I could run IgProf if someone could provide workflow number.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
