### PR TITLE
forward port of dataProcessing changes for 25ns

### DIFF
--- a/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
+++ b/Configuration/DataProcessing/python/Impl/ppRun2at50ns.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppRun2at50ns_
+
+Scenario supporting proton collisions
+
+"""
+
+import os
+import sys
+
+from Configuration.DataProcessing.Reco import Reco
+import FWCore.ParameterSet.Config as cms
+
+class ppRun2at50ns(Reco):
+    def __init__(self):
+        self.recoSeq=''
+        self.cbSc='pp'
+    """
+    _ppRun2at50ns_
+
+    Implement configuration building for data processing for proton
+    collision data taking for Run2
+
+    """
+
+
+    def promptReco(self, globalTag, **args):
+        """
+        _promptReco_
+
+        Proton collision data taking prompt reco
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForPrompt']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customisePromptRun2_50ns']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customisePromptRun2_50ns')
+
+        process = Reco.promptReco(self,globalTag, **args)
+
+        return process
+
+
+    def expressProcessing(self, globalTag, **args):
+        """
+        _expressProcessing_
+
+        Proton collision data taking express processing
+
+        """
+        if not 'skims' in args:
+            args['skims']=['@allForExpress']
+
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns')
+
+        process = Reco.expressProcessing(self,globalTag, **args)
+        
+        return process
+
+    def visualizationProcessing(self, globalTag, **args):
+        """
+        _visualizationProcessing_
+
+        Proton collision data taking visualization processing
+
+        """
+        if not 'customs' in args:
+            args['customs']=['Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns']
+        else:
+            args['customs'].append('Configuration/DataProcessing/RecoTLR.customiseExpressRun2_50ns')
+
+        process = Reco.visualizationProcessing(self,globalTag, **args)
+        
+        return process
+
+    def alcaHarvesting(self, globalTag, datasetName, **args):
+        """
+        _alcaHarvesting_
+
+        Proton collisions data taking AlCa Harvesting
+
+        """
+
+
+        if not 'skims' in args and not 'alcapromptdataset' in args:
+            args['skims']=['BeamSpotByRun',
+                           'BeamSpotByLumi',
+                           'SiStripQuality']
+            
+        return Reco.alcaHarvesting(self, globalTag, datasetName, **args)
+

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -41,8 +41,8 @@ def customiseDataRun2Common(process):
     if hasattr(process,'valCsctfTrackDigis'):
         process.valCsctfTrackDigis.gangedME1a = cms.untracked.bool(False)
 
-    from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForStage1
-    process = customiseSimL1EmulatorForStage1(process)
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
+    process=customiseL1RecoForStage1(process)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_Reco,customise_RawToDigi,customise_DQM
     if hasattr(process,'RawToDigi'):

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -41,9 +41,6 @@ def customiseDataRun2Common(process):
     if hasattr(process,'valCsctfTrackDigis'):
         process.valCsctfTrackDigis.gangedME1a = cms.untracked.bool(False)
 
-    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
-    process=customiseL1RecoForStage1(process)
-
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_Reco,customise_RawToDigi,customise_DQM
     if hasattr(process,'RawToDigi'):
         process=customise_RawToDigi(process)
@@ -55,18 +52,24 @@ def customiseDataRun2Common(process):
     return process
 
 ##############################################################################
-# common+25ns
+# common+ "25ns" Use this for data daking starting from runs in 2015C (>= 253256 )
 def customiseDataRun2Common_25ns(process):
     process = customiseDataRun2Common(process)
+
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
+    process=customiseL1RecoForStage1(process)
 
     from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
     if hasattr(process,'dqmoffline_step'):
         process=customise_DQM_25ns(process)
     return process
 
-# common+50ns. Needed only for runs >= 253000
+# common+50ns. Needed only for runs >= 253000 if taken with 50ns
 def customiseDataRun2Common_50nsRunsAfter253000(process):
     process = customiseDataRun2Common(process)
+
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseL1RecoForStage1
+    process=customiseL1RecoForStage1(process)
 
     if hasattr(process,'particleFlowClusterECAL'):
         process.particleFlowClusterECAL.energyCorrector.autoDetectBunchSpacing = False
@@ -80,7 +83,7 @@ def customiseDataRun2Common_50nsRunsAfter253000(process):
 ##############################################################################
 def customiseCosmicDataRun2(process):
     process = customiseCosmicData(process)
-    process = customiseDataRun2Common(process)
+    process = customiseDataRun2Common_25ns(process)
     return process
 
 
@@ -100,8 +103,8 @@ def customiseVALSKIM(process):
 def customiseExpress(process):
     process= customisePPData(process)
 
-    import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-    process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
     
     return process
 
@@ -128,7 +131,7 @@ def customisePrompt(process):
     #add the lumi producer in the prompt reco only configuration
     if not hasattr(process,'lumiProducer'):
         #unscheduled..
-        from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
         process.lumiProducer=lumiProducer
     process.reconstruction_step+=process.lumiProducer
 
@@ -161,8 +164,8 @@ def customisePromptRun2B0T(process):
 def customiseExpressHI(process):
     #deprecated process= customiseCommonHI(process)
 
-    import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-    process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
     
     return process
 
@@ -170,13 +173,13 @@ def customiseExpressHI(process):
 def customisePromptHI(process):
     #deprecated process= customiseCommonHI(process)
 
-    import RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi
-    process.offlineBeamSpot = RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi.onlineBeamSpotProducer.clone()
+    from RecoVertex.BeamSpotProducer.BeamSpotOnline_cfi import onlineBeamSpotProducer
+    process.offlineBeamSpot = onlineBeamSpotProducer.clone()
 
      #add the lumi producer in the prompt reco only configuration
     if not hasattr(process,'lumiProducer'):
         #unscheduled..
-        from RecoLuminosity.LumiProducer.lumiProducer_cff import *
+        from RecoLuminosity.LumiProducer.lumiProducer_cff import lumiProducer,LumiDBService
         process.lumiProducer=lumiProducer
     process.reconstruction_step+=process.lumiProducer
         

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -1,6 +1,5 @@
 import FWCore.ParameterSet.Config as cms
 
-from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_Reco,customise_RawToDigi,customise_DQM
 from RecoTracker.Configuration.customiseForRunI import customiseForRunI
 #gone with the fact that there is no difference between production and development sequence
 #def customiseCommon(process):
@@ -42,12 +41,39 @@ def customiseDataRun2Common(process):
     if hasattr(process,'valCsctfTrackDigis'):
         process.valCsctfTrackDigis.gangedME1a = cms.untracked.bool(False)
 
+    from L1Trigger.L1TCommon.customsPostLS1 import customiseSimL1EmulatorForStage1
+    process = customiseSimL1EmulatorForStage1(process)
+
+    from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_Reco,customise_RawToDigi,customise_DQM
     if hasattr(process,'RawToDigi'):
         process=customise_RawToDigi(process)
     if hasattr(process,'reconstruction'):
         process=customise_Reco(process)
     if hasattr(process,'dqmoffline_step'):
         process=customise_DQM(process)
+
+    return process
+
+##############################################################################
+# common+25ns
+def customiseDataRun2Common_25ns(process):
+    process = customiseDataRun2Common(process)
+
+    from SLHCUpgradeSimulations.Configuration.postLS1Customs import customise_DQM_25ns
+    if hasattr(process,'dqmoffline_step'):
+        process=customise_DQM_25ns(process)
+    return process
+
+# common+50ns. Needed only for runs >= 253000
+def customiseDataRun2Common_50ns(process):
+    process = customiseDataRun2Common(process)
+
+    if hasattr(process,'particleFlowClusterECAL'):
+        process.particleFlowClusterECAL.energyCorrector.autoDetectBunchSpacing = False
+        process.particleFlowClusterECAL.energyCorrector.bunchSpacing = cms.int32(50)
+    if hasattr(process,'ecalMultiFitUncalibRecHit'):
+        process.ecalMultiFitUncalibRecHit.algoPSet.useLumiInfoRunHeader = False
+        process.ecalMultiFitUncalibRecHit.algoPSet.bunchSpacing = cms.int32(50)
 
     return process
 
@@ -82,7 +108,12 @@ def customiseExpress(process):
 ##############################################################################
 def customiseExpressRun2(process):
     process = customiseExpress(process)
-    process = customiseDataRun2Common(process)
+    process = customiseDataRun2Common_25ns(process)
+    return process
+
+def customiseExpressRun2_50ns(process):
+    process = customiseExpress(process)
+    process = customiseDataRun2Common_50ns(process)
     return process
 
 def customiseExpressRun2B0T(process):
@@ -106,7 +137,7 @@ def customisePrompt(process):
 ##############################################################################
 def customisePromptRun2(process):
     process = customisePrompt(process)
-    process = customiseDataRun2Common(process)
+    process = customiseDataRun2Common_25ns(process)
     return process
 
 def customisePromptRun2B0T(process):
@@ -148,72 +179,3 @@ def customisePromptHI(process):
     return process
 
 ##############################################################################
-
-def planBTracking(process):
-
-    # stuff from LowPtTripletStep_cff
-    process.lowPtTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin=0.3
-
-    # stuff from PixelLessStep_cff
-    process.pixelLessStepClusters.oldClusterRemovalInfo=cms.InputTag("tobTecStepClusters")
-    process.pixelLessStepClusters.trajectories= cms.InputTag("tobTecStepTracks")
-    process.pixelLessStepClusters.overrideTrkQuals=cms.InputTag('tobTecStepSelector','tobTecStep')
-    process.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 0.7
-    process.pixelLessStepSeeds.RegionFactoryPSet.RegionPSet.originRadius = 1.5
-
-    # stuff from PixelPairStep_cff
-    process.pixelPairStepSeeds.RegionFactoryPSet.RegionPSet.ptMin = 0.6
-
-    # stuff from TobTecStep_cff
-    process.tobTecStepClusters.oldClusterRemovalInfo=cms.InputTag("detachedTripletStepClusters")
-    process.tobTecStepClusters.trajectories= cms.InputTag("detachedTripletStepTracks")
-    process.tobTecStepClusters.overrideTrkQuals=cms.InputTag('detachedTripletStep')
-    process.tobTecStepSeeds.RegionFactoryPSet.RegionPSet.originRadius = 5.0
-
-    # stuff from DetachedTripletStep_cff
-    process.detachedTripletStepSeeds.RegionFactoryPSet.RegionPSet.ptMin=0.35
-
-    # stuff from iterativeTk_cff
-    process.iterTracking = cms.Sequence(process.InitialStep*
-                                        process.LowPtTripletStep*
-                                        process.PixelPairStep*
-                                        process.DetachedTripletStep*
-                                        process.TobTecStep*
-                                        process.PixelLessStep*
-                                        process.generalTracks*
-                                        process.ConvStep*
-                                        process.conversionStepTracks
-                                        )
-    
-    
-    # stuff from RecoTracker_cff
-    process.newCombinedSeeds.seedCollections=cms.VInputTag(
-        cms.InputTag('initialStepSeeds'),
-        cms.InputTag('pixelPairStepSeeds'),
-    #    cms.InputTag('mixedTripletStepSeeds'),
-        cms.InputTag('pixelLessStepSeeds')
-        )
-
-    # stuff from Kevin's fragment
-    process.generalTracks.TrackProducers = (cms.InputTag('initialStepTracks'),
-                                            cms.InputTag('lowPtTripletStepTracks'),
-                                            cms.InputTag('pixelPairStepTracks'),
-                                            cms.InputTag('detachedTripletStepTracks'),
-                                            cms.InputTag('pixelLessStepTracks'),
-                                            cms.InputTag('tobTecStepTracks'))
-    process.generalTracks.hasSelector=cms.vint32(1,1,1,1,1,1)
-    process.generalTracks.selectedTrackQuals = cms.VInputTag(cms.InputTag("initialStepSelector","initialStep"),
-                                                             cms.InputTag("lowPtTripletStepSelector","lowPtTripletStep"),
-                                                             cms.InputTag("pixelPairStepSelector","pixelPairStep"),
-                                                             cms.InputTag("detachedTripletStep"),
-                                                             cms.InputTag("pixelLessStepSelector","pixelLessStep"),
-                                                             cms.InputTag("tobTecStepSelector","tobTecStep")
-                                                             )
-    process.generalTracks.setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True) ) )
-
-
-    if hasattr(process,'dqmoffline_step'):
-        process.dqmoffline_step.remove(process.TrackMonStep4)
-        #process.dqmoffline_step.remove(process.TrackMonStep5)
-        
-    return process

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -65,7 +65,7 @@ def customiseDataRun2Common_25ns(process):
     return process
 
 # common+50ns. Needed only for runs >= 253000
-def customiseDataRun2Common_50ns(process):
+def customiseDataRun2Common_50nsRunsAfter253000(process):
     process = customiseDataRun2Common(process)
 
     if hasattr(process,'particleFlowClusterECAL'):
@@ -113,7 +113,7 @@ def customiseExpressRun2(process):
 
 def customiseExpressRun2_50ns(process):
     process = customiseExpress(process)
-    process = customiseDataRun2Common_50ns(process)
+    process = customiseDataRun2Common_50nsRunsAfter253000(process)
     return process
 
 def customiseExpressRun2B0T(process):
@@ -138,6 +138,11 @@ def customisePrompt(process):
 def customisePromptRun2(process):
     process = customisePrompt(process)
     process = customiseDataRun2Common_25ns(process)
+    return process
+
+def customisePromptRun2_50ns(process):
+    process = customisePrompt(process)
+    process = customiseDataRun2Common_50nsRunsAfter253000(process)
     return process
 
 def customisePromptRun2B0T(process):

--- a/Configuration/DataProcessing/python/RecoTLR.py
+++ b/Configuration/DataProcessing/python/RecoTLR.py
@@ -30,11 +30,15 @@ def customiseCosmicData(process):
 ##############################################################################
 # this is supposed to be added on top of other (Run1) data customs
 def customiseDataRun2Common(process):
-    process.CSCGeometryESModule.useGangedStripsInME1a = cms.bool(False)
-    process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
-    process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
-    process.csc2DRecHits.readBadChannels = cms.bool(False)
-    process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
+    if hasattr(process,'CSCGeometryESModule'):
+        process.CSCGeometryESModule.useGangedStripsInME1a = cms.bool(False)
+    if hasattr(process,'CSCIndexerESProducer'):
+        process.CSCIndexerESProducer.AlgoName=cms.string("CSCIndexerPostls1")
+    if hasattr(process,'CSCChannelMapperESProducer'):
+        process.CSCChannelMapperESProducer.AlgoName=cms.string("CSCChannelMapperPostls1")
+    if hasattr(process,'csc2DRecHits'):
+        process.csc2DRecHits.readBadChannels = cms.bool(False)
+        process.csc2DRecHits.CSCUseGasGainCorrections = cms.bool(False)
     if hasattr(process,'valCscTriggerPrimitiveDigis'):
         #this is not doing anything at the moment
         process.valCscTriggerPrimitiveDigis.commonParam.gangedME1a = cms.bool(False)

--- a/Configuration/DataProcessing/test/ppRun2at50ns_t.py
+++ b/Configuration/DataProcessing/test/ppRun2at50ns_t.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""
+_ppRun2at50ns_
+
+Test for Collision Scenario implementation
+
+"""
+
+
+import unittest
+import FWCore.ParameterSet.Config as cms
+from Configuration.DataProcessing.GetScenario import getScenario
+
+
+
+def writePSetFile(name, process):
+    """
+    _writePSetFile_
+
+    Util to dump the process to a file
+
+    """
+    handle = open(name, 'w')
+    handle.write(process.dumpPython())
+    handle.close()
+
+
+class ppRun2at50nsScenarioTest(unittest.TestCase):
+    """
+    unittest for ppRun2at50ns collisions scenario
+
+    """
+
+    def testA(self):
+        """get the scenario"""
+        try:
+            scenario = getScenario("ppRun2at50ns")
+        except Exception, ex:
+            msg = "Failed to get ppRun2at50ns scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testPromptReco(self):
+        """test promptReco method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.promptReco("GLOBALTAG::ALL")
+            writePSetFile("testPromptReco.py", process)
+        except Exception, ex:
+            msg = "Failed to create Prompt Reco configuration\n"
+            msg += "for ppRun2at50ns Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testExpressProcessing(self):
+        """ test expressProcessing method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.expressProcessing("GLOBALTAG::ALL")
+            writePSetFile("testExpressProcessing.py", process)
+        except Exception, ex:
+            msg = "Failed to create Express Processing configuration\n"
+            msg += "for ppRun2at50ns Scenario\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+    def testAlcaSkim(self):
+        """ test alcaSkim method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.alcaSkim(["MuAlCalIsolatedMu"])
+            writePSetFile("testAlcaReco.py", process)
+        except Exception, ex:
+           msg = "Failed to create Alca Skimming configuration\n"
+           msg += "for ppRun2at50ns Scenario\n"
+           msg += str(ex)
+           self.fail(msg)
+
+
+    def testDQMHarvesting(self):
+        """test dqmHarvesting  method"""
+        scenario = getScenario("ppRun2at50ns")
+        try:
+            process = scenario.dqmHarvesting("dataset", 123456,
+                                             "GLOBALTAG::ALL")
+            writePSetFile("testDQMHarvesting.py", process)
+        except Exception, ex:
+            msg = "Failed to create DQM Harvesting configuration "
+            msg += "for ppRun2at50ns scenario:\n"
+            msg += str(ex)
+            self.fail(msg)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Configuration/DataProcessing/test/run_CfgTest.sh
+++ b/Configuration/DataProcessing/test/run_CfgTest.sh
@@ -13,7 +13,7 @@ function runTest { echo $1 ; python $1 || die "Failure for configuration: $1" $?
 
 runTest "${LOCAL_TEST_DIR}/RunRepack.py --select-events HLT:path1,HLT:path2 --lfn /store/whatever"
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "HeavyIons")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "ppRun2B0T" "HeavyIons" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunExpressProcessing.py --scenario $scenario --global-tag GLOBALTAG --lfn /store/whatever --fevt --dqmio  --alcareco TkAlMinBias+SiStripCalMinBias "
@@ -22,21 +22,21 @@ do
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "hcalnzsRun2")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "AlCaTestEnable" "hcalnzs" "ppRun2B0T" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"
 done
 
 
-declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "ppRun2B0T")
+declare -a arr=("cosmics" "pp" "cosmicsRun2" "ppRun2" "HeavyIons" "AlCaLumiPixels" "ppRun2B0T" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunAlcaSkimming.py --scenario $scenario --lfn=/store/whatever --global-tag GLOBALTAG --skims SiStripCalZeroBias,SiStripCalMinBias,PromptCalibProd"
      runTest "${LOCAL_TEST_DIR}/RunDQMHarvesting.py --scenario $scenario --lfn /store/whatever --run 12345 --dataset /A/B/C --global-tag GLOBALTAG"
 done
 
-declare -a arr=("ppRun2" "ppRun2B0T")
+declare -a arr=("ppRun2" "ppRun2B0T" "ppRun2at50ns")
 for scenario in "${arr[@]}"
 do
      runTest "${LOCAL_TEST_DIR}/RunPromptReco.py --scenario $scenario --reco --aod --miniaod --dqmio --global-tag GLOBALTAG --lfn=/store/whatever  --alcareco TkAlMinBias+SiStripCalMinBias"

--- a/L1Trigger/L1TCommon/python/customsPostLS1.py
+++ b/L1Trigger/L1TCommon/python/customsPostLS1.py
@@ -77,6 +77,49 @@ def customiseSimL1EmulatorForStage1(process):
     return process
 
 
+# customization of run L1 emulator for 2015 Stage 1 configuration
+def customiseL1RecoForStage1(process):
+
+    process.load("L1Trigger.L1TCommon.l1tRawToDigi_cfi")
+    process.load("L1Trigger.L1TCommon.caloStage1LegacyFormatDigis_cfi")
+
+    if hasattr(process, 'RawToDigi'):
+        process.L1RawToDigiSeq = cms.Sequence(process.gctDigis+process.caloStage1Digis+process.caloStage1LegacyFormatDigis)
+        process.RawToDigi.replace(process.gctDigis, process.L1RawToDigiSeq)
+
+    blist=['l1extraParticles','recoL1extraParticles','dqmL1ExtraParticles']
+    for b in blist:
+        if hasattr(process,b):
+            if (getattr(process, b).centralJetSource == cms.InputTag("simGctDigis","cenJets")):
+                getattr(process, b).etTotalSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).nonIsolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","nonIsoEm")
+                getattr(process, b).etMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).htMissSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).forwardJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","forJets")
+                getattr(process, b).centralJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","cenJets")
+                getattr(process, b).tauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","tauJets")
+                getattr(process, b).isoTauJetSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoTauJets")
+                getattr(process, b).isolatedEmSource = cms.InputTag("simCaloStage1LegacyFormatDigis","isoEm")
+                getattr(process, b).etHadSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingEtSumsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingBitCountsSource = cms.InputTag("simCaloStage1LegacyFormatDigis")
+            else:
+                getattr(process, b).etTotalSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).nonIsolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","nonIsoEm")
+                getattr(process, b).etMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).htMissSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).forwardJetSource = cms.InputTag("caloStage1LegacyFormatDigis","forJets")
+                getattr(process, b).centralJetSource = cms.InputTag("caloStage1LegacyFormatDigis","cenJets")
+                getattr(process, b).tauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","tauJets")
+                getattr(process, b).isoTauJetSource = cms.InputTag("caloStage1LegacyFormatDigis","isoTauJets")
+                getattr(process, b).isolatedEmSource = cms.InputTag("caloStage1LegacyFormatDigis","isoEm")
+                getattr(process, b).etHadSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingEtSumsSource = cms.InputTag("caloStage1LegacyFormatDigis")
+                getattr(process, b).hfRingBitCountsSource = cms.InputTag("caloStage1LegacyFormatDigis")
+
+    return process
+
+
 from L1Trigger.Configuration.customise_overwriteL1Menu import *
 
 def customiseSimL1EmulatorForPostLS1_lowPU(process):

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -620,6 +620,7 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
  psd.addNode(edm::ParameterDescription<std::vector<int>>("activeBXs", {-5,-4,-3,-2,-1,0,1,2,3,4}, true) and
 	      edm::ParameterDescription<bool>("ampErrorCalculation", true, true) and
 	      edm::ParameterDescription<bool>("useLumiInfoRunHeader", true, true) and
+	      edm::ParameterDescription<int>("bunchSpacing", 0, true) and
 	      edm::ParameterDescription<bool>("doPrefitEB", false, true) and
 	      edm::ParameterDescription<bool>("doPrefitEE", false, true) and
 	      edm::ParameterDescription<double>("prefitMaxChiSqEB", 25., true) and
@@ -655,8 +656,6 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
 	      edm::ParameterDescription<double>("chi2ThreshEB_", 65.0, true) and
 	      edm::ParameterDescription<double>("chi2ThreshEE_", 50.0, true) and
 	      edm::ParameterDescription<edm::ParameterSetDescription>("EcalPulseShapeParameters", psd0, true));
-
- psd.addOptionalNode(edm::ParameterDescription<int>("bunchSpacing", 0, true), true);
 
  return psd;
 }

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -656,6 +656,8 @@ EcalUncalibRecHitWorkerMultiFit::getAlgoDescription() {
 	      edm::ParameterDescription<double>("chi2ThreshEE_", 50.0, true) and
 	      edm::ParameterDescription<edm::ParameterSetDescription>("EcalPulseShapeParameters", psd0, true));
 
+ psd.addOptionalNode(edm::ParameterDescription<int>("bunchSpacing", 0, true), true);
+
  return psd;
 }
 

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.cc
@@ -43,6 +43,9 @@ EcalUncalibRecHitWorkerMultiFit::EcalUncalibRecHitWorkerMultiFit(const edm::Para
   
   if (useLumiInfoRunHeader_) {
     bunchSpacing_ = c.consumes<int>(edm::InputTag("addPileupInfo","bunchSpacing"));
+    bunchSpacingManual_ = 0;
+  } else {
+    bunchSpacingManual_ = ps.getParameter<int>("bunchSpacing");
   }
 
   doPrefitEB_ = ps.getParameter<bool>("doPrefitEB");
@@ -127,10 +130,10 @@ void
 EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
 {
 
+  int bunchspacing = 450;
+
   if (useLumiInfoRunHeader_) {
 
-    int bunchspacing = 450;
-    
     if (evt.isRealData()) {
       edm::RunNumber_t run = evt.run();
       if (run == 178003 ||
@@ -143,8 +146,11 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
           run == 209151) {
         bunchspacing = 25;
       }
-      else {
+      else if (run < 253000) {
         bunchspacing = 50;
+      }
+      else {
+	bunchspacing = 25;
       }
     }
     else {
@@ -153,6 +159,12 @@ EcalUncalibRecHitWorkerMultiFit::set(const edm::Event& evt)
       bunchspacing = *bunchSpacingH;
     }
     
+  }
+  else {
+    bunchspacing = bunchSpacingManual_;
+  }
+
+  if (useLumiInfoRunHeader_ || bunchSpacingManual_ > 0){
     if (bunchspacing == 25) {
       activeBX.resize(10);
       activeBX << -5,-4,-3,-2,-1,0,1,2,3,4;

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalUncalibRecHitWorkerMultiFit.h
@@ -82,6 +82,7 @@ class EcalUncalibRecHitWorkerMultiFit : public EcalUncalibRecHitWorkerBaseClass 
                 bool useLumiInfoRunHeader_;
                 EcalUncalibRecHitMultiFitAlgo multiFitMethod_;
                 
+		int bunchSpacingManual_;
                 edm::EDGetTokenT<int> bunchSpacing_; 
 
                 // determine which of the samples must actually be used by ECAL local reco

--- a/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
+++ b/RecoParticleFlow/PFClusterProducer/src/PFClusterEMEnergyCorrector.cc
@@ -138,8 +138,11 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
           run == 209151) {
         bunchspacing = 25;
       }
-      else {
+      else if (run < 253000) {
         bunchspacing = 50;
+      } 
+      else {
+	bunchspacing = 25;
       }
     }
     else {
@@ -147,6 +150,9 @@ void PFClusterEMEnergyCorrector::correctEnergies(const edm::Event &evt, const ed
       evt.getByToken(bunchSpacing_,bunchSpacingH);
       bunchspacing = *bunchSpacingH;
     }
+  }
+  else {
+    bunchspacing = bunchSpacingManual_;
   }
   
   const std::vector<std::string> condnames_mean = (bunchspacing == 25) ? _condnames_mean_25ns : _condnames_mean_50ns;


### PR DESCRIPTION
Correcting the selection of 25ns vs 50ns for data processing, bringing the release in sync with 74X

This is a cherry pick of
- https://github.com/cms-sw/cmssw/pull/10518    dc5da96 
- to determine bunch spacing in data in PFClusterEMEnergyCorrector and  EcalUncalibRecHitWorkerMultiFit
  - use run 253000 as a maximum with 50 ns if auto-selection is enabled
  - fixup/add manual bunch spacing setting is the auto-selection is disabled
  - in RecoTLR (still using local customs implementation for run2 data processing)
    - add customise_DQM to the common customs (already in 75X/76X)
    - add customiseL1RecoForStage1 for stage1 unpackers and l1extra to use calo stage1 
    - add customiseDataRun2Common_25ns (since I couldn't figure out how to more transparently set a default to 25ns and then be able to customize that to 50ns); 
    - NB: the customiseDataRun2Common can still be used for Run2015B data processing as suggested in a few HN posts
    - add customiseDataRun2Common_50nsRunsAfter253000 function (it's in the name!) to force 50ns settings for runs after 253000, if we need it
    - remove outdated planBTracking
  - add ppRun2at50ns scenario in T0 processing setup
- https://github.com/cms-sw/cmssw/pull/10574    9510b4f
  - move stage1 only to methods to be used in 2015C data (removed it from RecoTLR.customiseDataRun2Common, which is recommended for 2015A and 2015B reprocessing):
    - customiseDataRun2Common_25ns
    - customiseDataRun2Common_50nsRunsAfter253000
  - added hasattr to modifiers in RecoTLR.customiseDataRun2Common so that it can be used directly at runTheMatrix level
  - also, cleaned up import statements which begin to give warnings in 75X/76X
- https://github.com/cms-sw/cmssw/pull/10509 7e0e8d9
  - adds a new hook for customizing L1Reco to unpack stage 1 from RAW

From 75X tests in CMSSW_7_5_X_2015-08-18-2300:
- runtests pass (includes parsing of various scenarios in TestConfigDP)
- compare ppRun2 results for run 251721 (DoubleMuon)   and 254231 (JetHT, 25ns fill with 3.8 T, 26 bunches colliding)
  - run 251721 (no diffs expected, except for the L1 calo-related)
    - ==> no changes in reco products
    - L1 plots change (red becomes stage1 inputs; not a default in this run) 
      ![wfdoublemuon251721-l1central_et](https://cloud.githubusercontent.com/assets/4676718/9371027/d41fdcb2-469a-11e5-9e6b-9da2779aa044.png)
  - run 254231 (diffs expected starting from ecal local reco: the baseline uses 50 ns setup in this case and the new version uses the correct 25 ns). The run is 25ns
    -  less ecal rechits reconstructed with non-zero energy (as expected) [log(0) = 0 on this plot]
      ![all_run2at25nsvsorig_jetht254231c_log10ecalrechitssorted_ecalrechit_ecalrechitsee_reco_obj_obj_energy](https://cloud.githubusercontent.com/assets/4676718/9369826/73ca1b6a-4691-11e5-9095-b73e3f8a3de3.png)
    - hit timing shows reduced/no contribution from the next 25ns
      ![wfjetht254231-ebtime](https://cloud.githubusercontent.com/assets/4676718/9370951/0f4a3c48-469a-11e5-9582-f083c885b004.png)
      ![wfjetht254231-eetime](https://cloud.githubusercontent.com/assets/4676718/9370952/1227b06c-469a-11e5-8443-61aa4eef0af4.png)
    - downstream, pf photons rate is smaller (charged hadrons are ~unchanged)
      ![all_run2at25nsvsorig_jetht254231c_log10recopfcandidates_particleflow__reco_obj_pt40](https://cloud.githubusercontent.com/assets/4676718/9370667/8d8995ac-4697-11e5-99bf-08c8a063b3eb.png)
    - L1 calo plots change (stage1 is now the default)
      ![wfjetht254231-l1central_et](https://cloud.githubusercontent.com/assets/4676718/9370962/2da7d790-469a-11e5-8b96-9b6125de59d5.png)
