### PR TITLE
Adding e/gamma regression from Ecal Multifit in Run1/Run2 GTs

### DIFF
--- a/Configuration/AlCa/python/autoCond.py
+++ b/Configuration/AlCa/python/autoCond.py
@@ -2,25 +2,25 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   '75X_mcRun1_design_v2',
+    'run1_design'       :   '75X_mcRun1_design_v4',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   '75X_mcRun1_realistic_v2',
+    'run1_mc'           :   '75X_mcRun1_realistic_v4',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v2',
+    'run1_mc_hi'        :   '75X_mcRun1_HeavyIon_v4',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   '75X_mcRun1_pA_v2',
+    'run1_mc_pa'        :   '75X_mcRun1_pA_v4',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   '75X_mcRun2_design_v4',
+    'run2_design'       :   '75X_mcRun2_design_v5',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   '75X_mcRun2_startup_v2',
+    'run2_mc_50ns'      :   '75X_mcRun2_startup_v4',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   '75X_mcRun2_asymptotic_v4',
+    'run2_mc'           :   '75X_mcRun2_asymptotic_v5',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v2',
+    'run2_mc_hi'        :   '75X_mcRun2_HeavyIon_v4',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   '75X_dataRun1_v4',
+    'run1_data'         :   '75X_dataRun1_v5',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   '75X_dataRun2_v4',
+    'run2_data'         :   '75X_dataRun2_v5',
     # GlobalTag for Run1 HLT: it points to the online GT
     'run1_hlt'          :   '75X_dataRun1_HLT_frozen_v2',
     # GlobalTag for Run2 HLT: it points to the online GT


### PR DESCRIPTION
# Summary of changes
## Run1 simulation
- Ideal: [75X_mcRun1_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_design_v4) : As [75X_mcRun1_design_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_design_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_design_v4/75X_mcRun1_design_v2):
  - New Egamma regressions based on ECAL multifit reconstruction;
- Realistic: [75X_mcRun1_realistic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_realistic_v4): As [75X_mcRun1_realistic_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_realistic_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_realistic_v4/75X_mcRun1_realistic_v2):
  - New Egamma regressions based on ECAL multifit reconstruction;
- Heavy Ion: [75X_mcRun1_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_HeavyIon_v4): As [75X_mcRun1_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_HeavyIon_v4/75X_mcRun1_HeavyIon_v2):
  - New Egamma regressions based on ECAL multifit reconstruction;
- Proton Lead: [75X_mcRun1_pA_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_pA_v4): As [75X_mcRun1_pA_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun1_pA_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun1_pA_v4/75X_mcRun1_pA_v2):
  - New Egamma regressions based on ECAL multifit reconstruction;
## Run1 data
- Offline: [75X_dataRun1_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_v5): As [75X_dataRun1_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun1_v4]) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun1_v5/75X_dataRun1_v4):
  - New Egamma regressions based on ECAL multifit reconstruction.
## Run2 simulation
- Ideal: [75X_mcRun2_design_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_design_v5): As [75X_mcRun2_design_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_design_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_design_v5/75X_mcRun2_design_v4):
  - New Egamma regressions based on ECAL multifit reconstruction;
- Startup: [75X_mcRun2_startup_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_startup_v4): As [75X_mcRun2_startup_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_startup_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_startup_v4/75X_mcRun2_startup_v2):
  - New Egamma regressions based on ECAL multifit reconstruction;
- Asymptotic: [75X_mcRun2_asymptotic_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_asymptotic_v5): As [75X_mcRun2_asymptotic_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_asymptotic_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_asymptotic_v5/75X_mcRun2_asymptotic_v4):
  - New Egamma regressions based on ECAL multifit reconstruction;
- Heavy Ion: [75X_mcRun2_HeavyIon_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_HeavyIon_v4): As [75X_mcRun2_HeavyIon_v2](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_mcRun2_HeavyIon_v2) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_mcRun2_HeavyIon_v4/75X_mcRun2_HeavyIon_v2):
  - New Egamma regressions based on ECAL multifit reconstruction;
## Run2 data
- Offline: [75X_dataRun2_v5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_v5): As [75X_dataRun2_v4](https://cms-conddb.cern.ch/browser/#list/Prod/gts/75X_dataRun2_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/75X_dataRun2_v5/75X_dataRun2_v4):
  - New Egamma regressions based on ECAL multifit reconstruction.  
