### PR TITLE
Important-> EDM IDs update, Fixed typo in effective areas.

### DIFF
--- a/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
+++ b/PhysicsTools/PatAlgos/python/slimming/miniAOD_tools.py
@@ -173,6 +173,7 @@ def miniAOD_customizeCommon(process):
 
     #VID Electron IDs
     electron_ids = ['RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_PHYS14_PU20bx25_V2_cff',
+                    'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_25ns_V1_cff',
                     'RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_Spring15_50ns_V1_cff',
                     'RecoEgamma.ElectronIdentification.Identification.heepElectronID_HEEPV60_cff',
                     'RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff']
@@ -187,7 +188,7 @@ def miniAOD_customizeCommon(process):
     #VID Photon IDs
     photon_ids = ['RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_PHYS14_PU20bx25_V2_cff',
                   'RecoEgamma.PhotonIdentification.Identification.cutBasedPhotonID_Spring15_50ns_V1_cff',
-                  'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V0_cff',
+                  'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V2_cff',
                   'RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_50ns_nonTrig_V2_cff']
     switchOnVIDPhotonIdProducer(process,DataFormat.MiniAOD) 
     process.egmPhotonIDs.physicsObjectSrc = \

--- a/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
+++ b/RecoEgamma/EgammaTools/python/egammaObjectModificationsInMiniAOD_cff.py
@@ -4,7 +4,7 @@ import FWCore.ParameterSet.Config as cms
 import RecoEgamma.ElectronIdentification.Identification.mvaElectronID_Spring15_25ns_nonTrig_V1_cff as ele_spring15_nt
 
 #photon mva ids
-import RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V0_cff as pho_spring15_25_nt
+import RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V2_cff as pho_spring15_25_nt
 import RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_50ns_nonTrig_V2_cff as pho_spring15_50_nt
 
 ele_mva_prod_name = 'electronMVAValueMapProducer'

--- a/RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt
+++ b/RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt
@@ -5,7 +5,7 @@
 #    https://indico.cern.ch/event/369239/contribution/4/attachments/1134761/1623262/talk_effective_areas_25ns.pdf
 #
 # |eta| min   |eta| max   effective area
-0.0000         0.8000        0.1752
+0.0000         1.0000        0.1752
 1.0000         1.4790        0.1862
 1.4790         2.0000        0.1411
 2.0000         2.2000        0.1534

--- a/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Spring15_25ns_V1_cff.py
+++ b/RecoEgamma/ElectronIdentification/python/Identification/cutBasedElectronID_Spring15_25ns_V1_cff.py
@@ -1,0 +1,186 @@
+from PhysicsTools.SelectorUtils.centralIDRegistry import central_id_registry
+
+# Common functions and classes for ID definition are imported here:
+from RecoEgamma.ElectronIdentification.Identification.cutBasedElectronID_tools import *
+
+#
+# This is the first round of Spring15 25ns cuts, optimized on  Spring15 25ns samples. 
+#
+# The ID cuts below are optimized IDs for Spring15 Scenario with 25ns bunch spacing
+# The cut values are taken from the twiki:
+#       https://twiki.cern.ch/twiki/bin/view/CMS/CutBasedElectronIdentificationRun2
+#       (where they may not stay, if a newer version of cuts becomes available for these
+#        conditions)
+# See also the presentation explaining these working points (this will not change):
+#        https://indico.cern.ch/event/370507/contribution/1/attachments/1140657/1633761/Rami_eleCB_ID_25ns.pdf
+#
+# First, define cut values
+#
+
+# Veto working point Barrel and Endcap
+idName = "cutBasedElectronID-Spring15-25ns-V1-standalone-veto"
+WP_Veto_EB = EleWorkingPoint_V2(
+    idName   , # idName
+    0.0152  , # dEtaInCut
+    0.216   , # dPhiInCut
+    0.0114  , # full5x5_sigmaIEtaIEtaCut
+    0.181   , # hOverECut
+    0.0564  , # dxyCut
+    0.472   , # dzCut
+    0.207   , # absEInverseMinusPInverseCut
+    0.126   , # relCombIsolationWithEALowPtCut
+    0.126   , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    2          # missingHitsCut
+    )
+
+WP_Veto_EE = EleWorkingPoint_V2(
+    idName   , # idName
+    0.0113  , # dEtaInCut
+    0.237   , # dPhiInCut
+    0.0352  , # full5x5_sigmaIEtaIEtaCut
+    0.116   , # hOverECut
+    0.222   , # dxyCut
+    0.921   , # dzCut
+    0.174   , # absEInverseMinusPInverseCut
+    0.144   , # relCombIsolationWithEALowPtCut
+    0.144   , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    3          # missingHitsCut
+    )
+
+# Loose working point Barrel and Endcap
+idName = "cutBasedElectronID-Spring15-25ns-V1-standalone-loose"
+WP_Loose_EB = EleWorkingPoint_V2(
+    idName   , # idName
+    0.0105  , # dEtaInCut
+    0.115   , # dPhiInCut
+    0.0103  , # full5x5_sigmaIEtaIEtaCut
+    0.104   , # hOverECut
+    0.0261  , # dxyCut
+    0.41    , # dzCut
+    0.102   , # absEInverseMinusPInverseCut
+    0.0893  , # relCombIsolationWithEALowPtCut
+    0.0893  , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    2          # missingHitsCut
+    )
+
+WP_Loose_EE = EleWorkingPoint_V2(
+    idName   , # idName
+    0.00814 , # dEtaInCut
+    0.182   , # dPhiInCut
+    0.0301  , # full5x5_sigmaIEtaIEtaCut
+    0.0897  , # hOverECut
+    0.118   , # dxyCut
+    0.822   , # dzCut
+    0.126   , # absEInverseMinusPInverseCut
+    0.121   , # relCombIsolationWithEALowPtCut
+    0.121   , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    1          # missingHitsCut
+    )
+
+# Medium working point Barrel and Endcap
+idName = "cutBasedElectronID-Spring15-25ns-V1-standalone-medium"
+WP_Medium_EB = EleWorkingPoint_V2(
+    idName   , # idName
+    0.0103 , # dEtaInCut
+    0.0336 , # dPhiInCut
+    0.0101 , # full5x5_sigmaIEtaIEtaCut
+    0.0876 , # hOverECut
+    0.0118 , # dxyCut
+    0.373  , # dzCut
+    0.0174 , # absEInverseMinusPInverseCut
+    0.0766 , # relCombIsolationWithEALowPtCut
+    0.0766 , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    2          # missingHitsCut
+    )
+
+WP_Medium_EE = EleWorkingPoint_V2(
+    idName   , # idName
+    0.00733 , # dEtaInCut
+    0.114   , # dPhiInCut
+    0.0283  , # full5x5_sigmaIEtaIEtaCut
+    0.0678  , # hOverECut
+    0.0739  , # dxyCut
+    0.602   , # dzCut
+    0.0898  , # absEInverseMinusPInverseCut
+    0.0678  , # relCombIsolationWithEALowPtCut
+    0.0678  , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    1          # missingHitsCut
+    )
+
+# Tight working point Barrel and Endcap
+idName = "cutBasedElectronID-Spring15-25ns-V1-standalone-tight"
+WP_Tight_EB = EleWorkingPoint_V2(
+    idName   , # idName
+    0.00926   , # dEtaInCut
+    0.0336    , # dPhiInCut
+    0.0101    , # full5x5_sigmaIEtaIEtaCut
+    0.0597    , # hOverECut
+    0.0111    , # dxyCut
+    0.0466    , # dzCut
+    0.012     , # absEInverseMinusPInverseCut
+    0.0354    , # relCombIsolationWithEALowPtCut
+    0.0354    , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    2          # missingHitsCut
+    )
+
+WP_Tight_EE = EleWorkingPoint_V2(
+    idName   , # idName
+    0.00724 , # dEtaInCut
+    0.0918  , # dPhiInCut
+    0.0279  , # full5x5_sigmaIEtaIEtaCut
+    0.0615  , # hOverECut
+    0.0351  , # dxyCut
+    0.417   , # dzCut
+    0.00999 , # absEInverseMinusPInverseCut
+    0.0646  , # relCombIsolationWithEALowPtCut
+    0.0646  , # relCombIsolationWithEAHighPtCut
+    # conversion veto cut needs no parameters, so not mentioned
+    1          # missingHitsCut
+    )
+
+# Second, define what effective areas to use for pile-up correction
+isoInputs = IsolationCutInputs_V2(
+    # phoIsolationEffAreas
+    "RecoEgamma/ElectronIdentification/data/Spring15/effAreaElectrons_cone03_pfNeuHadronsAndPhotons_25ns.txt"
+)
+
+
+#
+# Set up VID configuration for all cuts and working points
+#
+
+cutBasedElectronID_Spring15_25ns_V1_standalone_veto = configureVIDCutBasedEleID_V2(WP_Veto_EB, WP_Veto_EE, isoInputs)
+cutBasedElectronID_Spring15_25ns_V1_standalone_loose = configureVIDCutBasedEleID_V2(WP_Loose_EB, WP_Loose_EE, isoInputs)
+cutBasedElectronID_Spring15_25ns_V1_standalone_medium = configureVIDCutBasedEleID_V2(WP_Medium_EB, WP_Medium_EE, isoInputs)
+cutBasedElectronID_Spring15_25ns_V1_standalone_tight = configureVIDCutBasedEleID_V2(WP_Tight_EB, WP_Tight_EE, isoInputs)
+
+
+# The MD5 sum numbers below reflect the exact set of cut variables
+# and values above. If anything changes, one has to 
+# 1) comment out the lines below about the registry, 
+# 2) run "calculateMD5 <this file name> <one of the VID config names just above>
+# 3) update the MD5 sum strings below and uncomment the lines again.
+#
+
+central_id_registry.register(cutBasedElectronID_Spring15_25ns_V1_standalone_veto.idName,
+                             '202030579ee3eec90fdc2d236ba3de7e')
+central_id_registry.register(cutBasedElectronID_Spring15_25ns_V1_standalone_loose.idName,
+                             '4fab9e4d09a2c1a36cbbd2279deb3627')
+central_id_registry.register(cutBasedElectronID_Spring15_25ns_V1_standalone_medium.idName,
+                             'aa291aba714c148fcba156544907c440')
+central_id_registry.register(cutBasedElectronID_Spring15_25ns_V1_standalone_tight.idName,
+                             '4e13b87c0573d3c8ebf91d446fa1d90f')
+
+
+### for now until we have a database...
+cutBasedElectronID_Spring15_25ns_V1_standalone_veto.isPOGApproved = cms.untracked.bool(True)
+cutBasedElectronID_Spring15_25ns_V1_standalone_loose.isPOGApproved = cms.untracked.bool(True)
+cutBasedElectronID_Spring15_25ns_V1_standalone_medium.isPOGApproved = cms.untracked.bool(True)
+cutBasedElectronID_Spring15_25ns_V1_standalone_tight.isPOGApproved = cms.untracked.bool(True)

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V2_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_25ns_nonTrig_V2_cff.py
@@ -10,7 +10,8 @@ import FWCore.ParameterSet.Config as cms
 #
 # The following MVA is derived for Spring15 MC samples for non-triggering photons.
 # See more documentation in this presentation:
-#    https://indico.cern.ch/event/369237/contribution/2/attachments/1128009/1611753/egamma-July17-2015.pdf
+#    
+#    https://indico.cern.ch/event/369241/contribution/1/attachments/1140148/1632879/egamma-Aug14-2015.pdf
 #
 
 # This MVA implementation class name
@@ -18,16 +19,16 @@ mvaSpring15NonTrigClassName = "PhotonMVAEstimatorRun2Spring15NonTrig"
 # The tag is an extra string attached to the names of the products
 # such as ValueMaps that needs to distinguish cases when the same MVA estimator
 # class is used with different tuning/weights
-mvaTag = "25nsV0"
+mvaTag = "25nsV2"
 
 # There are 2 categories in this MVA. They have to be configured in this strict order
 # (cuts and weight files order):
 #   0    barrel photons
 #   1    endcap photons
 
-mvaSpring15NonTrigWeightFiles_V0 = cms.vstring(
-    "RecoEgamma/PhotonIdentification/data/Spring15/photon_general_MVA_Spring15_25ns_EB_V0.weights.xml",
-    "RecoEgamma/PhotonIdentification/data/Spring15/photon_general_MVA_Spring15_25ns_EE_V0.weights.xml"
+mvaSpring15NonTrigWeightFiles_V2 = cms.vstring(
+    "RecoEgamma/PhotonIdentification/data/Spring15/photon_general_MVA_Spring15_25ns_EB_V2.weights.xml",
+    "RecoEgamma/PhotonIdentification/data/Spring15/photon_general_MVA_Spring15_25ns_EE_V2.weights.xml"
     )
 
 # Load some common definitions for MVA machinery
@@ -44,13 +45,13 @@ mvaCategoriesMapName   = mvaProducerModuleLabel + ":" + mvaSpring15NonTrigClassN
 # The working point for this MVA that is expected to have about 90% signal
 # efficiency in each category for photons with pt>30 GeV (somewhat lower
 # for lower pt photons).
-idName = "mvaPhoID-Spring15-25ns-nonTrig-V0-wp90"
+idName = "mvaPhoID-Spring15-25ns-nonTrig-V2-wp90"
 MVA_WP90 = PhoMVA_2Categories_WP(
     idName = idName,
     mvaValueMapName = mvaValueMapName,           # map with MVA values for all particles
     mvaCategoriesMapName = mvaCategoriesMapName, # map with category index for all particles
-    cutCategory0 = 0.302, # EB
-    cutCategory1 = 0.307  # EE
+    cutCategory0 = 0.374, # EB
+    cutCategory1 = 0.336  # EE
     )
 
 #
@@ -58,10 +59,10 @@ MVA_WP90 = PhoMVA_2Categories_WP(
 #
 
 # Create the PSet that will be fed to the MVA value map producer
-mvaPhoID_Spring15_25ns_nonTrig_V0_producer_config = cms.PSet( 
+mvaPhoID_Spring15_25ns_nonTrig_V2_producer_config = cms.PSet( 
     mvaName            = cms.string(mvaSpring15NonTrigClassName),
     mvaTag             = cms.string(mvaTag),
-    weightFileNames    = mvaSpring15NonTrigWeightFiles_V0,
+    weightFileNames    = mvaSpring15NonTrigWeightFiles_V2,
     #
     # All the event content needed for this MVA implementation follows
     #
@@ -84,7 +85,7 @@ mvaPhoID_Spring15_25ns_nonTrig_V0_producer_config = cms.PSet(
     rho                       = cms.InputTag("fixedGridRhoFastjetAll") 
     )
 # Create the VPset's for VID cuts
-mvaPhoID_Spring15_25ns_nonTrig_V0_wp90 = configureVIDMVAPhoID_V1( MVA_WP90 )
+mvaPhoID_Spring15_25ns_nonTrig_V2_wp90 = configureVIDMVAPhoID_V1( MVA_WP90 )
 
 # The MD5 sum numbers below reflect the exact set of cut variables
 # and values above. If anything changes, one has to 
@@ -93,7 +94,7 @@ mvaPhoID_Spring15_25ns_nonTrig_V0_wp90 = configureVIDMVAPhoID_V1( MVA_WP90 )
 # 3) update the MD5 sum strings below and uncomment the lines again.
 #
 
-central_id_registry.register( mvaPhoID_Spring15_25ns_nonTrig_V0_wp90.idName,
-                              '0db3574f257ba9082ffc4874ba6cee99')
+central_id_registry.register( mvaPhoID_Spring15_25ns_nonTrig_V2_wp90.idName,
+                              '8a6870b7182e5aeee51b71cdba3c3fce')
 
-mvaPhoID_Spring15_25ns_nonTrig_V0_wp90.isPOGApproved = cms.untracked.bool(False)
+mvaPhoID_Spring15_25ns_nonTrig_V2_wp90.isPOGApproved = cms.untracked.bool(True)

--- a/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V2_cff.py
+++ b/RecoEgamma/PhotonIdentification/python/Identification/mvaPhotonID_Spring15_50ns_nonTrig_V2_cff.py
@@ -12,7 +12,8 @@ import FWCore.ParameterSet.Config as cms
 # See more documentation in this presentation:
 #    https://indico.cern.ch/event/369237/contribution/2/attachments/1128009/1611753/egamma-July17-2015.pdf
 #    this also contains a minor update from email exchanges (thus move to V2)
-#
+#    Specific docs for V2 are in this final presentation:
+#    https://indico.cern.ch/event/369241/contribution/1/attachments/1140148/1632879/egamma-Aug14-2015.pdf
 
 # This MVA implementation class name
 mvaSpring15NonTrigClassName = "PhotonMVAEstimatorRun2Spring15NonTrig"

--- a/RecoEgamma/PhotonIdentification/python/PhotonMVAValueMapProducer_cfi.py
+++ b/RecoEgamma/PhotonIdentification/python/PhotonMVAValueMapProducer_cfi.py
@@ -13,8 +13,8 @@ mvaConfigsForPhoProducer.append( mvaPhoID_Spring15_50ns_nonTrig_V1_producer_conf
 from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_50ns_nonTrig_V2_cff import *
 mvaConfigsForPhoProducer.append( mvaPhoID_Spring15_50ns_nonTrig_V2_producer_config )
 
-from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V0_cff import *
-mvaConfigsForPhoProducer.append( mvaPhoID_Spring15_25ns_nonTrig_V0_producer_config )
+from RecoEgamma.PhotonIdentification.Identification.mvaPhotonID_Spring15_25ns_nonTrig_V2_cff import *
+mvaConfigsForPhoProducer.append( mvaPhoID_Spring15_25ns_nonTrig_V2_producer_config )
 
 photonMVAValueMapProducer = cms.EDProducer('PhotonMVAValueMapProducer',
                                            # The module automatically detects AOD vs miniAOD, so we configure both


### PR DESCRIPTION
Further additions to #10619.

This includes an updated 25ns Spring15 photon MVA ID and appropriate updates to MiniAOD steering.
Additionally, we include a first round of 25ns Spring15 cutbased IDs.

A notable thing here is fixing of a typo for effect areas.

Weight files are already in the cms-data area, and do not exist in the history of this PR.
