### PR TITLE
CMSSW_7_6_X DQM updates for AlphaT HLT paths (v2)

### DIFF
--- a/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
+++ b/HLTriggerOffline/SUSYBSM/interface/SUSY_HLT_alphaT.h
@@ -55,7 +55,7 @@ class SUSY_HLT_alphaT: public DQMEDAnalyzer{
   
   //variables from config file
   edm::EDGetTokenT<reco::PFJetCollection> thePfJetCollection_;
-  edm::EDGetTokenT<reco::CaloJetCollection> theCaloJetCollection_;
+  //edm::EDGetTokenT<reco::CaloJetCollection> theCaloJetCollection_;
   edm::EDGetTokenT<edm::TriggerResults> triggerResults_;
   edm::EDGetTokenT<trigger::TriggerEvent> theTrigSummary_;
 
@@ -72,17 +72,17 @@ class SUSY_HLT_alphaT: public DQMEDAnalyzer{
   double etaThrJet_;
   double pfAlphaTThrTurnon_;
   double pfHtThrTurnon_;
-  double caloAlphaTThrTurnon_;
-  double caloHtThrTurnon_;
+  /* double caloAlphaTThrTurnon_; */
+  /* double caloHtThrTurnon_; */
   
   // Histograms
-  MonitorElement* h_triggerCaloHt;
-  MonitorElement* h_triggerCaloAlphaT;
-  MonitorElement* h_triggerCaloAlphaT_triggerCaloHt;
-  MonitorElement* h_caloAlphaTTurnOn_num;
-  MonitorElement* h_caloAlphaTTurnOn_den;
-  MonitorElement* h_caloHtTurnOn_num;
-  MonitorElement* h_caloHtTurnOn_den;
+  /* MonitorElement* h_triggerCaloHt; */
+  /* MonitorElement* h_triggerCaloAlphaT; */
+  /* MonitorElement* h_triggerCaloAlphaT_triggerCaloHt; */
+  /* MonitorElement* h_caloAlphaTTurnOn_num; */
+  /* MonitorElement* h_caloAlphaTTurnOn_den; */
+  /* MonitorElement* h_caloHtTurnOn_num; */
+  /* MonitorElement* h_caloHtTurnOn_den; */
 
   MonitorElement* h_triggerPfHt;
   MonitorElement* h_triggerPfAlphaT;

--- a/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SUSYBSM_alphaT_cff.py
@@ -1,21 +1,133 @@
 import FWCore.ParameterSet.Config as cms
 
-SUSY_HLT_HT200_alphaT0p63 = cms.EDAnalyzer("SUSY_HLT_alphaT",
-  trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
+
+# Control trigger
+SUSY_HLT_HT200_alphaT0p51 = cms.EDAnalyzer("SUSY_HLT_alphaT",
+  trigSummary       = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
+  TriggerResults    = cms.InputTag('TriggerResults','','HLT'),        #to use with test sample
   caloJetCollection = cms.InputTag("ak4CaloJets"),
+  pfJetCollection   = cms.InputTag("ak4PFJetsCHS"),
+  HLTProcess                      = cms.string('HLT'),
+  TriggerPath                     = cms.string('HLT_PFHT200_PFAlphaT0p51_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter                = cms.InputTag('hltHT150CaloAlphaT0p51', '', 'HLT'),
+  TriggerFilter                   = cms.InputTag('hltPFHT200PFAlphaT0p51', '', 'HLT'),
+  PtThrJet            = cms.untracked.double(40.0),
+  EtaThrJet           = cms.untracked.double(3.0),
+  caloHtThrTurnon     = cms.untracked.double(200),
+  caloAlphaTThrTurnon = cms.untracked.double(0.53),
+  pfHtThrTurnon       = cms.untracked.double(225),
+  pfAlphaTThrTurnon   = cms.untracked.double(0.53),
+)
+
+# Primary triggers
+SUSY_HLT_HT200_alphaT0p57 = cms.EDAnalyzer("SUSY_HLT_alphaT",
+  trigSummary       = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
+  TriggerResults    = cms.InputTag('TriggerResults','','HLT'),        #to use with test sample
+  caloJetCollection = cms.InputTag("ak4CaloJets"),
+  pfJetCollection   = cms.InputTag("ak4PFJetsCHS"),
+  HLTProcess                      = cms.string('HLT'),
+  TriggerPath                     = cms.string('HLT_PFHT200_DiPFJetAve90_PFAlphaT0p57_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter                = cms.InputTag('hltHT150CaloAlphaT0p54', '', 'HLT'),
+  TriggerFilter                   = cms.InputTag('hltPFHT200PFAlphaT0p57', '', 'HLT'),
+  PtThrJet            = cms.untracked.double(40.0),
+  EtaThrJet           = cms.untracked.double(3.0),
+  caloHtThrTurnon     = cms.untracked.double(200),
+  caloAlphaTThrTurnon = cms.untracked.double(0.61),
+  pfHtThrTurnon       = cms.untracked.double(225),
+  pfAlphaTThrTurnon   = cms.untracked.double(0.65),
+)
+
+SUSY_HLT_HT250_alphaT0p55 = cms.EDAnalyzer("SUSY_HLT_alphaT",
+  trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
   pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  caloJetCollection = cms.InputTag("ak4CaloJets"),
   TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
   HLTProcess = cms.string('HLT'),
-  TriggerPath = cms.string('HLT_PFHT200_DiPFJetAve90_PFAlphaT0p63_v'),
+  TriggerPath = cms.string('HLT_PFHT250_DiPFJetAve90_PFAlphaT0p55_v'),
   TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
-  TriggerPreFilter = cms.InputTag('hltHT175CaloAlphaT0p59', '', 'HLT'),
-  TriggerFilter = cms.InputTag('hltPFHT200PFAlphaT0p63', '', 'HLT'),
+  TriggerPreFilter = cms.InputTag('hltHT225CaloAlphaT0p53', '', 'HLT'),
+  TriggerFilter    = cms.InputTag('hltPFHT250PFAlphaT0p55', '', 'HLT'),
   PtThrJet = cms.untracked.double(40.0),
   EtaThrJet = cms.untracked.double(3.0),
-  pfAlphaTThrTurnon = cms.untracked.double(0.65),
-  pfHtThrTurnon = cms.untracked.double(225),
+  pfAlphaTThrTurnon = cms.untracked.double(0.6),
+  pfHtThrTurnon = cms.untracked.double(275),
+  caloAlphaTThrTurnon = cms.untracked.double(0.57),
+  caloHtThrTurnon = cms.untracked.double(250),
+)
+
+SUSY_HLT_HT300_alphaT0p53 = cms.EDAnalyzer("SUSY_HLT_alphaT",
+  trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  caloJetCollection = cms.InputTag("ak4CaloJets"),
+  TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
+  HLTProcess = cms.string('HLT'),
+  TriggerPath = cms.string('HLT_PFHT300_DiPFJetAve90_PFAlphaT0p53_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT275CaloAlphaT0p525', '', 'HLT'), 
+  TriggerFilter    = cms.InputTag('hltPFHT300PFAlphaT0p53', '', 'HLT'),
+  PtThrJet = cms.untracked.double(40.0),
+  EtaThrJet = cms.untracked.double(3.0),
+  pfAlphaTThrTurnon = cms.untracked.double(0.56),
+  pfHtThrTurnon = cms.untracked.double(325),
+  caloAlphaTThrTurnon = cms.untracked.double(0.55),
+  caloHtThrTurnon = cms.untracked.double(300),
+)
+
+SUSY_HLT_HT350_alphaT0p52 = cms.EDAnalyzer("SUSY_HLT_alphaT",
+  trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),#ak4PFJetsCHS
+  caloJetCollection = cms.InputTag("ak4CaloJets"),
+  TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
+  HLTProcess = cms.string('HLT'),
+  TriggerPath = cms.string('HLT_PFHT350_DiPFJetAve90_PFAlphaT0p52_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT325CaloAlphaT0p515', '', 'HLT'),
+  TriggerFilter    = cms.InputTag('hltPFHT350PFAlphaT0p52', '', 'HLT'),
+  PtThrJet = cms.untracked.double(40.0),
+  EtaThrJet = cms.untracked.double(3.0),
+  pfAlphaTThrTurnon = cms.untracked.double(0.55),
+  pfHtThrTurnon = cms.untracked.double(375),
+  caloAlphaTThrTurnon = cms.untracked.double(0.53),
+  caloHtThrTurnon = cms.untracked.double(350),
+)
+
+SUSY_HLT_HT400_alphaT0p51 = cms.EDAnalyzer("SUSY_HLT_alphaT",
+  trigSummary = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
+  pfJetCollection = cms.InputTag("ak4PFJetsCHS"),
+  caloJetCollection = cms.InputTag("ak4CaloJets"),
+  TriggerResults = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
+  HLTProcess = cms.string('HLT'),
+  TriggerPath = cms.string('HLT_PFHT400_DiPFJetAve90_PFAlphaT0p51_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter = cms.InputTag('hltHT375CaloAlphaT0p51', '', 'HLT'),
+  TriggerFilter    = cms.InputTag('hltPFHT400PFAlphaT0p51', '', 'HLT'),
+  PtThrJet = cms.untracked.double(40.0),
+  EtaThrJet = cms.untracked.double(3.0),
+  pfAlphaTThrTurnon = cms.untracked.double(0.54),
+  pfHtThrTurnon = cms.untracked.double(425),
+  caloAlphaTThrTurnon = cms.untracked.double(0.53),
+  caloHtThrTurnon = cms.untracked.double(400),
+)
+
+# Backup triggers
+SUSY_HLT_HT200_alphaT0p63 = cms.EDAnalyzer("SUSY_HLT_alphaT",
+  trigSummary       = cms.InputTag("hltTriggerSummaryAOD",'', 'HLT'), #to use with test sample
+  TriggerResults    = cms.InputTag('TriggerResults','','HLT'), #to use with test sample
+  caloJetCollection = cms.InputTag("ak4CaloJets"),
+  pfJetCollection   = cms.InputTag("ak4PFJetsCHS"),
+  HLTProcess                      = cms.string('HLT'),
+  TriggerPath                     = cms.string('HLT_PFHT200_DiPFJetAve90_PFAlphaT0p63_v'),
+  TriggerPathAuxiliaryForHadronic = cms.string('HLT_IsoMu24_eta2p1_v'),
+  TriggerPreFilter                = cms.InputTag('hltHT175CaloAlphaT0p59', '', 'HLT'),
+  TriggerFilter                   = cms.InputTag('hltPFHT200PFAlphaT0p63', '', 'HLT'),
+  PtThrJet            = cms.untracked.double(40.0),
+  EtaThrJet           = cms.untracked.double(3.0),
+  caloHtThrTurnon     = cms.untracked.double(200),
   caloAlphaTThrTurnon = cms.untracked.double(0.61),
-  caloHtThrTurnon = cms.untracked.double(200),
+  pfHtThrTurnon       = cms.untracked.double(225),
+  pfAlphaTThrTurnon   = cms.untracked.double(0.65),
 )
 
 SUSY_HLT_HT250_alphaT0p58 = cms.EDAnalyzer("SUSY_HLT_alphaT",
@@ -92,6 +204,12 @@ SUSY_HLT_HT400_alphaT0p52 = cms.EDAnalyzer("SUSY_HLT_alphaT",
 
 SUSY_HLT_alphaT_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     subDirs        = cms.untracked.vstring(
+        "HLT/SUSYBSM/HLT_PFHT200_DiPFJetAve90_PFAlphaT0p51_v"
+        "HLT/SUSYBSM/HLT_PFHT200_DiPFJetAve90_PFAlphaT0p57_v",
+        "HLT/SUSYBSM/HLT_PFHT250_DiPFJetAve90_PFAlphaT0p55_v",
+        "HLT/SUSYBSM/HLT_PFHT300_DiPFJetAve90_PFAlphaT0p53_v",
+        "HLT/SUSYBSM/HLT_PFHT350_DiPFJetAve90_PFAlphaT0p52_v",
+        "HLT/SUSYBSM/HLT_PFHT400_DiPFJetAve90_PFAlphaT0p51_v",
         "HLT/SUSYBSM/HLT_PFHT200_DiPFJetAve90_PFAlphaT0p63_v",
         "HLT/SUSYBSM/HLT_PFHT250_DiPFJetAve90_PFAlphaT0p58_v",
         "HLT/SUSYBSM/HLT_PFHT300_DiPFJetAve90_PFAlphaT0p54_v",
@@ -104,7 +222,7 @@ SUSY_HLT_alphaT_POSTPROCESSING = cms.EDAnalyzer("DQMGenericClient",
     efficiency     = cms.vstring(
        "pfHtTurnOn_eff 'Turn-on vs PF HT; HT (GeV); #epsilon' pfHtTurnOn_num pfHtTurnOn_den",
        "pfAlphaTTurnOn_eff 'Turn-on vs PF alpha T; AlphaT (GeV); #epsilon' pfAlphaTTurnOn_num pfAlphaTTurnOn_den",
-       "caloHtTurnOn_eff 'Turn-on vs Calo HT; HT (GeV); #epsilon' caloHtTurnOn_num caloHtTurnOn_den",
-       "caloAlphaTTurnOn_eff 'Turn-on vs Calo alpha T; AlphaT (GeV); #epsilon' caloAlphaTTurnOn_num caloAlphaTTurnOn_den",
+       # "caloHtTurnOn_eff 'Turn-on vs Calo HT; HT (GeV); #epsilon' caloHtTurnOn_num caloHtTurnOn_den",
+       # "caloAlphaTTurnOn_eff 'Turn-on vs Calo alpha T; AlphaT (GeV); #epsilon' caloAlphaTTurnOn_num caloAlphaTTurnOn_den",
     )
 )

--- a/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
+++ b/HLTriggerOffline/SUSYBSM/python/SusyExoValidation_cff.py
@@ -32,25 +32,21 @@ from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_HT_MuEle_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Muon_BJet_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_Electron_BJet_cff import *
 from HLTriggerOffline.SUSYBSM.SUSYBSM_alphaT_cff import *
-from HLTriggerOffline.SUSYBSM.SUSYBSM_DiJet_MET_cff import *
-from HLTriggerOffline.SUSYBSM.SUSYBSM_HLT_VBF_Mu_cff import *
+
 
 HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_InclusiveHT +
                                 SUSY_HLT_InclusiveMET +
-                                SUSY_HLT_InclusiveMET_NoNoiseCleaning +
-                                SUSY_HLT_InclusiveMET_HBHECleaned +
-                                SUSY_HLT_InclusiveMET_JetIdCleaned +
                                 SUSY_HLT_MET_BTAG +
                                 SUSY_HLT_MET_MUON +
                                 SUSY_HLT_InclusiveHT_aux200 + 
-                                SUSY_HLT_InclusiveHT_aux250 + 
+                                SUSY_HLT_InclusiveHT_aux250 +
                                 SUSY_HLT_InclusiveHT_aux300 + 
                                 SUSY_HLT_InclusiveHT_aux350 + 
-                                SUSY_HLT_InclusiveHT_aux400 + 
+                                SUSY_HLT_InclusiveHT_aux400 +
                                 SUSY_HLT_InclusiveHT_aux475 + 
                                 SUSY_HLT_InclusiveHT_aux600 +
-                                SUSY_HLT_InclusiveHT_aux800 +
+                                SUSY_HLT_InclusiveHT_aux800 + 
                                 SUSY_HLT_Mu_HT_SingleLepton +
                                 SUSY_HLT_Mu_HT_MET_SingleLepton +
                                 SUSY_HLT_Mu_HT_BTag_SingleLepton +
@@ -85,13 +81,17 @@ HLTSusyExoValSeq = cms.Sequence(SUSY_HLT_HT_MET +
                                 SUSY_HLT_HT_MuEle +
                                 SUSY_HLT_Muon_BJet +
                                 SUSY_HLT_Electron_BJet +
+                                SUSY_HLT_HT200_alphaT0p51 +
+                                SUSY_HLT_HT200_alphaT0p57 +
+                                SUSY_HLT_HT250_alphaT0p55 +
+                                SUSY_HLT_HT300_alphaT0p53 +
+                                SUSY_HLT_HT350_alphaT0p52 +
+                                SUSY_HLT_HT400_alphaT0p51 +
                                 SUSY_HLT_HT200_alphaT0p63 +
                                 SUSY_HLT_HT250_alphaT0p58 +
                                 SUSY_HLT_HT300_alphaT0p54 +
                                 SUSY_HLT_HT350_alphaT0p53 +
-                                SUSY_HLT_HT400_alphaT0p52 + 
-                                SUSY_HLT_DiJet_MET +
-                                SUSY_HLT_Mu_VBF
+                                SUSY_HLT_HT400_alphaT0p52 
                                 )
 
 
@@ -141,6 +141,5 @@ HLTSusyExoValSeq_FastSim = cms.Sequence(SUSY_HLT_HT_MET_FASTSIM +
                                         SUSY_HLT_HT_DoubleEle_FASTSIM +
                                         SUSY_HLT_HT_MuEle_FASTSIM +
                                         SUSY_HLT_Muon_BJet_FASTSIM +
-                                        SUSY_HLT_Electron_BJet_FASTSIM + 
-                                        SUSY_HLT_Mu_VBF_FASTSIM )
+                                        SUSY_HLT_Electron_BJet_FASTSIM)
 

--- a/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_alphaT.cc
+++ b/HLTriggerOffline/SUSYBSM/src/SUSY_HLT_alphaT.cc
@@ -14,7 +14,7 @@ SUSY_HLT_alphaT::SUSY_HLT_alphaT(const edm::ParameterSet& ps)
   // Get parameters from configuration file
   theTrigSummary_ = consumes<trigger::TriggerEvent>(ps.getParameter<edm::InputTag>("trigSummary"));
   thePfJetCollection_ = consumes<reco::PFJetCollection>(ps.getParameter<edm::InputTag>("pfJetCollection"));
-  theCaloJetCollection_ = consumes<reco::CaloJetCollection>(ps.getParameter<edm::InputTag>("caloJetCollection"));
+  //theCaloJetCollection_ = consumes<reco::CaloJetCollection>(ps.getParameter<edm::InputTag>("caloJetCollection"));
   triggerResults_ = consumes<edm::TriggerResults>(ps.getParameter<edm::InputTag>("TriggerResults"));
   HLTProcess_ = ps.getParameter<std::string>("HLTProcess");
   triggerPath_ = ps.getParameter<std::string>("TriggerPath");
@@ -23,8 +23,8 @@ SUSY_HLT_alphaT::SUSY_HLT_alphaT(const edm::ParameterSet& ps)
   triggerPreFilter_ = ps.getParameter<edm::InputTag>("TriggerPreFilter");
   ptThrJet_ = ps.getUntrackedParameter<double>("PtThrJet");
   etaThrJet_ = ps.getUntrackedParameter<double>("EtaThrJet");
-  caloAlphaTThrTurnon_ = ps.getUntrackedParameter<double>("caloAlphaTThrTurnon");
-  caloHtThrTurnon_ = ps.getUntrackedParameter<double>("caloHtThrTurnon");
+  //caloAlphaTThrTurnon_ = ps.getUntrackedParameter<double>("caloAlphaTThrTurnon");
+  //caloHtThrTurnon_ = ps.getUntrackedParameter<double>("caloHtThrTurnon");
   pfAlphaTThrTurnon_ = ps.getUntrackedParameter<double>("pfAlphaTThrTurnon");
   pfHtThrTurnon_ = ps.getUntrackedParameter<double>("pfHtThrTurnon");
 }
@@ -106,17 +106,17 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
    edm::LogWarning ("SUSY_HLT_alphaT") << "invalid collection: PFJets" << "\n";
    return;
   }
-  edm::Handle<reco::CaloJetCollection> caloJetCollection;
-  e.getByToken (theCaloJetCollection_,caloJetCollection);
-  if ( !caloJetCollection.isValid() ){
-      edm::LogWarning ("SUSY_HLT_alphaT") << "invalid collection: CaloJets" << "\n";
-      return;
-  }
+  // edm::Handle<reco::CaloJetCollection> caloJetCollection;
+  // e.getByToken (theCaloJetCollection_,caloJetCollection);
+  // if ( !caloJetCollection.isValid() ){
+  //     edm::LogWarning ("SUSY_HLT_alphaT") << "invalid collection: CaloJets" << "\n";
+  //     return;
+  // }
 
   //get online objects
   //For now just get the jets and recalculate ht and alphaT
   size_t filterIndex = triggerSummary->filterIndex( triggerFilter_ );
-  size_t preFilterIndex = triggerSummary->filterIndex( triggerPreFilter_ );
+  //size_t preFilterIndex = triggerSummary->filterIndex( triggerPreFilter_ );
   trigger::TriggerObjectCollection triggerObjects = triggerSummary->getObjects();
 
   //Get the PF objects from the filter
@@ -138,24 +138,24 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
       }
   }
   
-  //Get the Calo objects from the prefilter
-  double hltCaloHt=0.;
-  std::vector<LorentzV> hltCaloJets;
-  if( !(preFilterIndex >= triggerSummary->sizeFilters()) ){
-      const trigger::Keys& keys = triggerSummary->filterKeys( preFilterIndex );
+  // //Get the Calo objects from the prefilter
+  // double hltCaloHt=0.;
+  // std::vector<LorentzV> hltCaloJets;
+  // if( !(preFilterIndex >= triggerSummary->sizeFilters()) ){
+  //     const trigger::Keys& keys = triggerSummary->filterKeys( preFilterIndex );
 
-      for( size_t j = 0; j < keys.size(); ++j ){
-          trigger::TriggerObject foundObject = triggerObjects[keys[j]];
+  //     for( size_t j = 0; j < keys.size(); ++j ){
+  //         trigger::TriggerObject foundObject = triggerObjects[keys[j]];
 
-          //  if(foundObject.id() == 85){ //It's a jet 
-          if(foundObject.pt()>ptThrJet_ && fabs(foundObject.eta()) < etaThrJet_){
-              hltCaloHt += foundObject.pt();
-              LorentzV JetLVec(foundObject.pt(),foundObject.eta(),foundObject.phi(),foundObject.mass());
-              hltCaloJets.push_back(JetLVec);
-          }
-          //   }
-      }
-  }
+  //         //  if(foundObject.id() == 85){ //It's a jet 
+  //         if(foundObject.pt()>ptThrJet_ && fabs(foundObject.eta()) < etaThrJet_){
+  //             hltCaloHt += foundObject.pt();
+  //             LorentzV JetLVec(foundObject.pt(),foundObject.eta(),foundObject.phi(),foundObject.mass());
+  //             hltCaloJets.push_back(JetLVec);
+  //         }
+  //         //   }
+  //     }
+  // }
 
   //Fill the alphaT and HT histograms
   if(hltPfJets.size()>0){
@@ -165,12 +165,12 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
       h_triggerPfAlphaT_triggerPfHt->Fill(hltPfHt, hltPfAlphaT);
   }
 
-  if(hltCaloJets.size()>0){
-      double hltCaloAlphaT = AlphaT(hltCaloJets,true).value();
-      h_triggerCaloAlphaT->Fill(hltCaloAlphaT);
-      h_triggerCaloHt->Fill(hltCaloHt);
-      h_triggerCaloAlphaT_triggerCaloHt->Fill(hltCaloHt, hltCaloAlphaT);
-  }
+  // if(hltCaloJets.size()>0){
+  //     double hltCaloAlphaT = AlphaT(hltCaloJets,true).value();
+  //     h_triggerCaloAlphaT->Fill(hltCaloAlphaT);
+  //     h_triggerCaloHt->Fill(hltCaloHt);
+  //     h_triggerCaloAlphaT_triggerCaloHt->Fill(hltCaloHt, hltCaloAlphaT);
+  // }
 
   bool hasFired = false;
   bool hasFiredAuxiliaryForHadronicLeg = false;
@@ -194,31 +194,31 @@ void SUSY_HLT_alphaT::analyze(edm::Event const& e, edm::EventSetup const& eSetup
        pfJets.push_back(JetLVec);
       }
 
-      //Make the gen Calo HT and AlphaT
-      float caloHT = 0.0;
-      std::vector<LorentzV> caloJets;
-      for (reco::CaloJetCollection::const_iterator i_calojet = caloJetCollection->begin(); i_calojet != caloJetCollection->end(); ++i_calojet){
-        if (i_calojet->pt() < ptThrJet_) continue;
-        if (fabs(i_calojet->eta()) > etaThrJet_) continue;
-        caloHT += i_calojet->pt();
-        LorentzV JetLVec(i_calojet->pt(),i_calojet->eta(),i_calojet->phi(),i_calojet->mass());
-        caloJets.push_back(JetLVec);
-      }
+      // //Make the gen Calo HT and AlphaT
+      // float caloHT = 0.0;
+      // std::vector<LorentzV> caloJets;
+      // for (reco::CaloJetCollection::const_iterator i_calojet = caloJetCollection->begin(); i_calojet != caloJetCollection->end(); ++i_calojet){
+      //   if (i_calojet->pt() < ptThrJet_) continue;
+      //   if (fabs(i_calojet->eta()) > etaThrJet_) continue;
+      //   caloHT += i_calojet->pt();
+      //   LorentzV JetLVec(i_calojet->pt(),i_calojet->eta(),i_calojet->phi(),i_calojet->mass());
+      //   caloJets.push_back(JetLVec);
+      // }
 
       //AlphaT aT = AlphaT(jets);
-      double caloAlphaT = AlphaT(caloJets).value();
+      //double caloAlphaT = AlphaT(caloJets).value();
       double pfAlphaT = AlphaT(pfJets).value();
 
       //Fill the turnons
       if(hasFired) {
-        if(caloHT>caloHtThrTurnon_) h_caloAlphaTTurnOn_num-> Fill(caloAlphaT);
-        if(caloAlphaT>caloAlphaTThrTurnon_) h_caloHtTurnOn_num-> Fill(caloHT);
+        // if(caloHT>caloHtThrTurnon_) h_caloAlphaTTurnOn_num-> Fill(caloAlphaT);
+        // if(caloAlphaT>caloAlphaTThrTurnon_) h_caloHtTurnOn_num-> Fill(caloHT);
 
         if(pfHT>pfHtThrTurnon_) h_pfAlphaTTurnOn_num-> Fill(pfAlphaT);
         if(pfAlphaT>pfAlphaTThrTurnon_) h_pfHtTurnOn_num-> Fill(pfHT);
       } 
-      if(caloHT>caloHtThrTurnon_) h_caloAlphaTTurnOn_den-> Fill(caloAlphaT);
-      if(caloAlphaT>caloAlphaTThrTurnon_) h_caloHtTurnOn_den-> Fill(caloHT);
+      // if(caloHT>caloHtThrTurnon_) h_caloAlphaTTurnOn_den-> Fill(caloAlphaT);
+      // if(caloAlphaT>caloAlphaTThrTurnon_) h_caloHtTurnOn_den-> Fill(caloHT);
 
       if(pfHT>pfHtThrTurnon_) h_pfAlphaTTurnOn_den-> Fill(pfAlphaT);
       if(pfAlphaT>pfAlphaTThrTurnon_) h_pfHtTurnOn_den-> Fill(pfHT);
@@ -245,19 +245,19 @@ void SUSY_HLT_alphaT::bookHistos(DQMStore::IBooker & ibooker_)
   //offline quantities
 
   //online quantities 
-  h_triggerCaloHt = ibooker_.book1D("triggerCaloHt", "Trigger Calo Ht; HT (GeV)", 60, 0.0, 1500.0);
-  h_triggerCaloAlphaT = ibooker_.book1D("triggerCaloAlphaT", "Trigger Calo AlphaT; AlphaT", 80, 0., 1.0);
-  h_triggerCaloAlphaT_triggerCaloHt = ibooker_.book2D("triggerCaloAlphaT_triggerCaloHt","Trigger Calo HT vs Trigger Calo AlphaT; HT (GeV); AlphaT", 60,0.0,1500.,80,0.,1.0);
+  // h_triggerCaloHt = ibooker_.book1D("triggerCaloHt", "Trigger Calo Ht; HT (GeV)", 60, 0.0, 1500.0);
+  // h_triggerCaloAlphaT = ibooker_.book1D("triggerCaloAlphaT", "Trigger Calo AlphaT; AlphaT", 80, 0., 1.0);
+  // h_triggerCaloAlphaT_triggerCaloHt = ibooker_.book2D("triggerCaloAlphaT_triggerCaloHt","Trigger Calo HT vs Trigger Calo AlphaT; HT (GeV); AlphaT", 60,0.0,1500.,80,0.,1.0);
   h_triggerPfHt = ibooker_.book1D("triggerPfHt", "Trigger PF Ht; HT (GeV)", 60, 0.0, 1500.0);
   h_triggerPfAlphaT = ibooker_.book1D("triggerPfAlphaT", "Trigger PF AlphaT; AlphaT", 80, 0., 1.0);
   h_triggerPfAlphaT_triggerPfHt = ibooker_.book2D("triggerPfAlphaT_triggerPfHt","Trigger PF HT vs Trigger PF AlphaT; HT (GeV); AlphaT", 60,0.0,1500.,80,0.,1.0);
 
 
   //num and den hists to be divided in harvesting step to make turn on curves
-  h_caloAlphaTTurnOn_num = ibooker_.book1D("caloAlphaTTurnOn_num", "Calo AlphaT Turn On Numerator; AlphaT", 40, 0.0, 1.0 );
-  h_caloAlphaTTurnOn_den = ibooker_.book1D("caloAlphaTTurnOn_den", "Calo AlphaT Turn OnDenominator; AlphaT", 40, 0.0, 1.0 );
-  h_caloHtTurnOn_num = ibooker_.book1D("caloHtTurnOn_num", "Calo HT Turn On Numerator; HT (GeV)", 30, 0.0, 1500.0 );
-  h_caloHtTurnOn_den = ibooker_.book1D("caloHtTurnOn_den", "Calo HT Turn On Denominator; HT (GeV)", 30, 0.0, 1500.0 );
+  // h_caloAlphaTTurnOn_num = ibooker_.book1D("caloAlphaTTurnOn_num", "Calo AlphaT Turn On Numerator; AlphaT", 40, 0.0, 1.0 );
+  // h_caloAlphaTTurnOn_den = ibooker_.book1D("caloAlphaTTurnOn_den", "Calo AlphaT Turn OnDenominator; AlphaT", 40, 0.0, 1.0 );
+  // h_caloHtTurnOn_num = ibooker_.book1D("caloHtTurnOn_num", "Calo HT Turn On Numerator; HT (GeV)", 30, 0.0, 1500.0 );
+  // h_caloHtTurnOn_den = ibooker_.book1D("caloHtTurnOn_den", "Calo HT Turn On Denominator; HT (GeV)", 30, 0.0, 1500.0 );
 
   h_pfAlphaTTurnOn_num = ibooker_.book1D("pfAlphaTTurnOn_num", "PF AlphaT Turn On Numerator; AlphaT", 40, 0.0, 1.0 );
   h_pfAlphaTTurnOn_den = ibooker_.book1D("pfAlphaTTurnOn_den", "PF AlphaT Turn OnDenominator; AlphaT", 40, 0.0, 1.0 );


### PR DESCRIPTION
Addition of DQM monitoring to new AlphaT path, supersedes https://github.com/cms-sw/cmssw/pull/10703

Addition of DQM monitoring for the following HLT paths:
- HLT_PFHT200_PFAlphaT0p51_v
- HLT_PFHT200_DiPFJetAve90_PFAlphaT0p57_v
- HLT_PFHT250_DiPFJetAve90_PFAlphaT0p55_v
- HLT_PFHT300_DiPFJetAve90_PFAlphaT0p53_v
- HLT_PFHT350_DiPFJetAve90_PFAlphaT0p52_v
- HLT_PFHT400_DiPFJetAve90_PFAlphaT0p51_v

Remove number of monitoring histograms
