### PR TITLE
Adding e/gamma regression from Ecal Multifit in Run1/Run2 GTs (74X)

### DIFF
--- a/Configuration/AlCa/python/autoCond_condDBv2.py
+++ b/Configuration/AlCa/python/autoCond_condDBv2.py
@@ -2,29 +2,29 @@ autoCond = {
 
     ### NEW KEYS ###
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run1
-    'run1_design'       :   'DESRUN1_74_V7',
+    'run1_design'       :   '74X_mcRun1_design_v1',
     # GlobalTag for MC production (pp collisions) with realistic alignment and calibrations for Run1
-    'run1_mc'           :   'MCRUN1_74_V7',
+    'run1_mc'           :   '74X_mcRun1_realistic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_hi'        :   'MCHI1_74_V7',
+    'run1_mc_hi'        :   '74X_mcRun1_HeavyIon_v1',
     # GlobalTag for MC production (p-Pb collisions) with realistic alignment and calibrations for Run1
-    'run1_mc_pa'        :   'MCPA1_74_V7',
+    'run1_mc_pa'        :   '74X_mcRun1_pA_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Run2
-    'run2_design'       :   'DESRUN2_74_V5',
+    'run2_design'       :   '74X_mcRun2_design_v1',
     # GlobalTag for MC production with pessimistic alignment and calibrations for Run2
-    'run2_mc_50ns'      :   'MCRUN2_74_V10',
+    'run2_mc_50ns'      :   '74X_mcRun2_startup_v1',
     #GlobalTag for MC production with optimistic alignment and calibrations for Run2
-    'run2_mc'           :   'MCRUN2_74_V11',
+    'run2_mc'           :   '74X_mcRun2_asymptotic_v1',
     # GlobalTag for MC production (Heavy Ions collisions) with optimistic alignment and calibrations for Run2
-    'run2_mc_hi'        :   'MCHI2_74_V6',
+    'run2_mc_hi'        :   '74X_mcRun2_HeavyIon_v1',
     # GlobalTag for Run1 data reprocessing
-    'run1_data'         :   'GR_R_74_V14A',
+    'run1_data'         :   '74X_dataRun1_v1',
     # GlobalTag for Run2 data reprocessing
-    'run2_data'         :   'GR_R_74_V15A',
-    # GlobalTag for Run1 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run1_hlt'          :   'GR_H_V57A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
-    # GlobalTag for Run2 HLT: it points to the online GT and overrides the connection string and pfnPrefix for use offline
-    'run2_hlt'          :   'GR_H_V58A,frontier://FrontierProd/CMS_CONDITIONS,frontier://FrontierProd/',
+    'run2_data'         :   '74X_dataRun2_v1',
+    # GlobalTag for Run1 HLT
+    'run1_hlt'          :   '74X_dataRun1_HLT_frozen_v1',
+    # GlobalTag for Run2 HLT
+    'run2_hlt'          :   '74X_dataRun2_HLT_frozen_v1',
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2017
     'phase1_2017_design' :  'DES17_70_V2', # placeholder (GT not meant for standard RelVal)
     # GlobalTag for MC production with perfectly aligned and calibrated detector for Phase1 2019


### PR DESCRIPTION
# Summary of changes
## Run1 simulation
- Ideal: [74X_mcRun1_design_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_design_v1) : As [DESRUN1_74_V7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/DESRUN1_74_V7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_design_v1/DESRUN1_74_V7):
  - New Egamma regressions based on ECAL multifit reconstruction.
- Realistic: [74X_mcRun1_realistic_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_realistic_v1): As [MCRUN1_74_V7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/MCRUN1_74_V7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_realistic_v4/MCRUN1_74_V7):
  - New Egamma regressions based on ECAL multifit reconstruction.
- Heavy Ion: [74X_mcRun1_HeavyIon_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_HeavyIon_v1): As [MCHI1_74_V7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/MCHI1_74_V7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_HeavyIon_v1/MCHI1_74_V7):
  - New Egamma regressions based on ECAL multifit reconstruction.
- Proton Lead: [74X_mcRun1_pA_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun1_pA_v1): As [MCPA1_74_V7](https://cms-conddb.cern.ch/browser/#list/Prod/gts/MCPA1_74_V7) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun1_pA_v1/MCPA1_74_V7):
  - New Egamma regressions based on ECAL multifit reconstruction.
## Run1 data
- Offline: [74X_dataRun1_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_v1): As [GR_R_74_V14A](https://cms-conddb.cern.ch/browser/#list/Prod/gts/GR_R_74_V14A) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun1_v1/GR_R_74_V14A):
  - New Egamma regressions based on ECAL multifit reconstruction;
  - removing RelVal customized tags for L1; 
  - taxonomy change of `SiPixelGenErrorDBObjectRcd` tag.
- HLT: [74X_dataRun1_HLT_frozen_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun1_HLT_frozen_v1): As [GR_H_V57A](https://cms-conddb.cern.ch/browser/#list/Prod/gts/GR_H_V57A) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun1_HLT_frozen_v1/GR_H_V57A):
  - Removing customized tags for L1;
  - a snapshot time: 2015-08-20 12:10:16,000000.
## Run2 simulation
- Ideal: [74X_mcRun2_design_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_design_v1): As [DESRUN2_74_V5](https://cms-conddb.cern.ch/browser/#list/Prod/gts/DESRUN2_74_V5) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_design_v1/DESRUN2_74_V5):
  - New Egamma regressions based on ECAL multifit reconstruction;
  - fixing the `PFCalibration` version from v0 to v2.
- Startup: [74X_mcRun2_startup_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_startup_v1): As [MCRUN2_74_V10](https://cms-conddb.cern.ch/browser/#list/Prod/gts/MCRUN2_74_V10) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_startup_v1/MCRUN2_74_V10):
  - New Egamma regressions based on ECAL multifit reconstruction.
- Asymptotic: [74X_mcRun2_asymptotic_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_asymptotic_v1): As [MCRUN2_74_V11](https://cms-conddb.cern.ch/browser/#list/Prod/gts/MCRUN2_74_V11) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_asymptotic_v1/MCRUN2_74_V11):
  - New Egamma regressions based on ECAL multifit reconstruction.
- Heavy Ion: [74X_mcRun2_HeavyIon_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_mcRun2_HeavyIon_v1): As [MCHI2_74_V6](https://cms-conddb.cern.ch/browser/#list/Prod/gts/MCHI2_74_V6) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_mcRun2_HeavyIon_v1/MCHI2_74_V6):
  - New Egamma regressions based on ECAL multifit reconstruction.
## Run2 data
- Offline: [74X_dataRun2_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v1): As [GR_R_74_V15A](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_v4) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun2_v1/GR_R_74_V15A):
  - New Egamma regressions based on ECAL multifit reconstruction;
  - taxonomy change of `SiPixelGenErrorDBObjectRcd` tag;
  - removing RelVal customized tags for L1.
- HLT: [74X_dataRun2_HLT_frozen_v1](https://cms-conddb.cern.ch/browser/#list/Prod/gts/74X_dataRun2_HLT_frozen_v1): As [GR_H_V58A](https://cms-conddb.cern.ch/browser/#list/Prod/gts/GR_H_V58A) with the following [changes](https://cms-conddb.cern.ch/browser/#diff/Prod/gts/74X_dataRun2_HLT_frozen_v1/GR_H_V58A):
  - Removing customized tags for L1;
  - taxonomy change of `EcalClusterLocalContCorrParametersRcd` tag;
  - adding label full for `HcalElectronicsMapRcd`;
  - adding negative energy filter payload; 
  - a snapshot time: 2015-08-20 12:10:16,000000.
