### PR TITLE
Move parentage code out of the OutputModule base class

### DIFF
--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -8,10 +8,8 @@ output stream.
 
 ----------------------------------------------------------------------*/
 
-#include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
-#include "DataFormats/Provenance/interface/ParentageID.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 
@@ -81,8 +79,6 @@ namespace edm {
     static void fillDescriptions(ConfigurationDescriptions& descriptions);
     static const std::string& baseType();
     static void prevalidate(ConfigurationDescriptions& );
-
-    BranchChildren const& branchChildren() const {return branchChildren_;}
 
     bool wantAllEvents() const {return wantAllEvents_;}
 
@@ -173,11 +169,6 @@ namespace edm {
     std::unique_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
     std::map<BranchID, bool> keepAssociation_;
 
-    typedef std::map<BranchID, std::set<ParentageID> > BranchParents;
-    BranchParents branchParents_;
-
-    BranchChildren branchChildren_;
-
     SharedResourcesAcquirer resourceAcquirer_;
     std::mutex mutex_;
 
@@ -241,9 +232,6 @@ namespace edm {
     void setModuleDescription(ModuleDescription const& md) {
       moduleDescription_ = md;
     }
-
-    void updateBranchParents(EventPrincipal const& ep);
-    void fillDependencyGraph();
 
     bool limitReached() const {return remainingEvents_ == 0;}
   };

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -28,10 +28,8 @@
 #include <mutex>
 
 // user include files
-#include "DataFormats/Provenance/interface/BranchChildren.h"
 #include "DataFormats/Provenance/interface/BranchID.h"
 #include "DataFormats/Provenance/interface/BranchIDList.h"
-#include "DataFormats/Provenance/interface/ParentageID.h"
 #include "DataFormats/Provenance/interface/ModuleDescription.h"
 #include "DataFormats/Provenance/interface/SelectedProducts.h"
 
@@ -93,8 +91,6 @@ namespace edm {
       static void fillDescriptions(ConfigurationDescriptions& descriptions);
       static const std::string& baseType();
       static void prevalidate(ConfigurationDescriptions& );
-      
-      BranchChildren const& branchChildren() const {return branchChildren_;}
       
       bool wantAllEvents() const {return wantAllEvents_;}
       
@@ -180,11 +176,6 @@ namespace edm {
       std::unique_ptr<ThinnedAssociationsHelper> thinnedAssociationsHelper_;
       std::map<BranchID, bool> keepAssociation_;
 
-      typedef std::map<BranchID, std::set<ParentageID> > BranchParents;
-      BranchParents branchParents_;
-      
-      BranchChildren branchChildren_;
-      
       SharedResourcesAcquirer resourcesAcquirer_;
       std::mutex mutex_;
 
@@ -251,9 +242,6 @@ namespace edm {
       void setModuleDescription(ModuleDescription const& md) {
         moduleDescription_ = md;
       }
-      
-      void updateBranchParents(EventPrincipal const& ep);
-      void fillDependencyGraph();
       
       bool limitReached() const {return remainingEvents_ == 0;}
     };

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -8,7 +8,6 @@
 #include "DataFormats/Common/interface/ThinnedAssociation.h"
 #include "DataFormats/Provenance/interface/BranchDescription.h"
 #include "DataFormats/Provenance/interface/BranchKey.h"
-#include "DataFormats/Provenance/interface/ParentageRegistry.h"
 #include "DataFormats/Provenance/interface/ProductRegistry.h"
 #include "DataFormats/Provenance/interface/ThinnedAssociationsHelper.h"
 #include "FWCore/Framework/interface/Event.h"
@@ -47,9 +46,7 @@ namespace edm {
     droppedBranchIDToKeptBranchID_(),
     branchIDLists_(new BranchIDLists),
     origBranchIDLists_(nullptr),
-    thinnedAssociationsHelper_(new ThinnedAssociationsHelper),
-    branchParents_(),
-    branchChildren_() {
+    thinnedAssociationsHelper_(new ThinnedAssociationsHelper) {
 
     hasNewlyDroppedBranch_.fill(false);
 
@@ -239,7 +236,6 @@ namespace edm {
         EventSignalsSentry signals(act,mcc);
         write(ep, mcc);
       }
-      updateBranchParents(ep);
     }
     if(remainingEvents_ > 0) {
       --remainingEvents_;
@@ -340,10 +336,7 @@ namespace edm {
 
   void OutputModule::doCloseFile() {
     if(isFileOpen()) {
-      fillDependencyGraph();
       reallyCloseFile();
-      branchParents_.clear();
-      branchChildren_.clear();
     }
   }
 
@@ -416,39 +409,5 @@ namespace edm {
                                       description().moduleLabel(),
                                                       outputModulePathPositions,
                                                       anyProductProduced);
-  }
-
-  void
-  OutputModule::updateBranchParents(EventPrincipal const& ep) {
-    for(EventPrincipal::const_iterator i = ep.begin(), iEnd = ep.end(); i != iEnd; ++i) {
-      if((*i) && (*i)->productProvenancePtr() != 0) {
-        BranchID const& bid = (*i)->branchDescription().branchID();
-        BranchParents::iterator it = branchParents_.find(bid);
-        if(it == branchParents_.end()) {
-          it = branchParents_.insert(std::make_pair(bid, std::set<ParentageID>())).first;
-        }
-        it->second.insert((*i)->productProvenancePtr()->parentageID());
-        branchChildren_.insertEmpty(bid);
-      }
-    }
-  }
-
-  void
-  OutputModule::fillDependencyGraph() {
-    for(BranchParents::const_iterator i = branchParents_.begin(), iEnd = branchParents_.end();
-        i != iEnd; ++i) {
-      BranchID const& child = i->first;
-      std::set<ParentageID> const& eIds = i->second;
-      for(std::set<ParentageID>::const_iterator it = eIds.begin(), itEnd = eIds.end();
-          it != itEnd; ++it) {
-        Parentage entryDesc;
-        ParentageRegistry::instance()->getMapped(*it, entryDesc);
-        std::vector<BranchID> const& parents = entryDesc.parents();
-        for(std::vector<BranchID>::const_iterator j = parents.begin(), jEnd = parents.end();
-          j != jEnd; ++j) {
-          branchChildren_.insertChild(*j, child);
-        }
-      }
-    }
   }
 }

--- a/IOPool/Output/interface/PoolOutputModule.h
+++ b/IOPool/Output/interface/PoolOutputModule.h
@@ -17,6 +17,8 @@
 #include "IOPool/Common/interface/RootServiceChecker.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/one/OutputModule.h"
+#include "DataFormats/Provenance/interface/BranchChildren.h"
+#include "DataFormats/Provenance/interface/ParentageID.h"
 
 class TTree;
 namespace edm {
@@ -99,6 +101,8 @@ namespace edm {
 
     OutputItemListArray const& selectedOutputItemList() const {return selectedOutputItemList_;}
 
+    BranchChildren const& branchChildren() const {return branchChildren_;}
+
   protected:
     ///allow inheriting classes to override but still be able to call this method in the overridden version
     virtual bool shouldWeCloseFile() const override;
@@ -117,6 +121,10 @@ namespace edm {
     virtual void reallyOpenFile() override;
     virtual void reallyCloseFile() override;
     virtual void beginJob() override;
+
+    typedef std::map<BranchID, std::set<ParentageID> > BranchParents;
+    void updateBranchParents(EventPrincipal const& ep);
+    void fillDependencyGraph();
 
     void startEndFile();
     void writeFileFormatVersion();
@@ -156,6 +164,8 @@ namespace edm {
     int inputFileCount_;
     unsigned int childIndex_;
     unsigned int numberOfDigitsInIndex_;
+    BranchParents branchParents_;
+    BranchChildren branchChildren_;
     bool overrideInputFileSplitLevels_;
     std::unique_ptr<RootOutputFile> rootOutputFile_;
     std::string statusFileName_;
@@ -163,3 +173,4 @@ namespace edm {
 }
 
 #endif
+


### PR DESCRIPTION
This simple PR is a small first step on the road to a global::OutputModule for thread safety. The data in OutputModule containing parentage information is currently incompatible with a "global" thread safe module. Fortunately, this data and the corresponding functions are needed only by one output module, namely PoolOutputModule. This PR moves this information from the base class into the only derived class that needs it. The thread safety of the derived class will be addressed later.
