### PR TITLE
FWLite MultiChainEvent: avoid crash on empty files (75X)

### DIFF
--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -310,7 +310,7 @@ ChainEvent::atEnd() const
 Long64_t
 ChainEvent::size() const
 {
-  return accumulatedSize_.back();
+  return accumulatedSize_.empty() ? 0 : accumulatedSize_.back();
 }
 
 edm::TriggerNames const&

--- a/DataFormats/FWLite/src/ChainEvent.cc
+++ b/DataFormats/FWLite/src/ChainEvent.cc
@@ -199,6 +199,7 @@ ChainEvent::to(edm::RunNumber_t run, edm::EventNumber_t event)
 ChainEvent const&
 ChainEvent::toBegin()
 {
+   if (!size()) return *this;
    if (eventIndex_ != 0)
    {
       switchToFile(0);
@@ -301,6 +302,7 @@ ChainEvent::operator bool() const
 bool
 ChainEvent::atEnd() const
 {
+  if (!size()) return true;
   if (eventIndex_ == static_cast<Long64_t>(fileNames_.size())-1) {
     return event_->atEnd();
   }

--- a/DataFormats/FWLite/src/MultiChainEvent.cc
+++ b/DataFormats/FWLite/src/MultiChainEvent.cc
@@ -77,8 +77,15 @@ private:
 
   getter_ = std::shared_ptr<internal::MultiProductGetter>(new internal::MultiProductGetter(this));
 
-  event1_->setGetter(getter_);
-  event2_->setGetter(getter_);
+  if (event1_->size() == 0) {
+    std::cout << "------------------------------------------------------------------------" << std::endl;
+    std::cout << "WARNING! MultiChainEvent: all primary files have zero events."        << std::endl;
+    std::cout << "Trying to access the events may lead to a crash.  "  << std::endl;
+    std::cout << "------------------------------------------------------------------------" << std::endl;
+  } else {
+    event1_->setGetter(getter_);
+    event2_->setGetter(getter_);
+  }
 
   useSecFileMapSorted_ = useSecFileMapSorted;
 

--- a/DataFormats/FWLite/test/pyroot_multichain.py
+++ b/DataFormats/FWLite/test/pyroot_multichain.py
@@ -1,0 +1,14 @@
+#! /usr/bin/env python
+import ROOT
+from DataFormats.FWLite import Events, Handle
+import FWCore.ParameterSet.VarParsing as VarParsing
+options = VarParsing.VarParsing ('analysis')
+options.parseArguments()
+events = Events(options)
+
+print "In total there are %d events" % events.size()
+print "Trying an event loop"
+for i,event in enumerate(events):
+    print "I am processing an event"
+    if i > 10: break
+print "Done with the event loops"

--- a/DataFormats/FWLite/test/run_all_t.sh
+++ b/DataFormats/FWLite/test/run_all_t.sh
@@ -23,6 +23,8 @@ ${LOCAL_TEST_DIR}/VIPTest.sh || die 'Failed to create file' $?
 root -b -n -q ${LOCAL_TEST_DIR}/vector_int_cint.C || die 'Failed in vector_int_cint.C' $?
 
 python ${LOCAL_TEST_DIR}/pyroot_handle_reuse.py || die 'Failed in pyroot_handle_reuse.py' $?
+python ${LOCAL_TEST_DIR}/pyroot_multichain.py inputFiles=file:prodmerge.root secondaryInputFiles=file:prod1.root,file:prod2.root || die 'Failed in pyroot_multichain.py (non-empty files)' $?
+python ${LOCAL_TEST_DIR}/pyroot_multichain.py inputFiles=file:empty_a.root secondaryInputFiles=file:good_a.root  || die 'Failed in pyroot_multichain.py (empty file)' $?
 
 #NOTE: ROOT has a bug which keeps the AssociationVector from running its ioread rule and therefore it never clears its cache
 #test AssociationVector reading


### PR DESCRIPTION
Forward port of #10739. Tested in `CMSSW_7_5_X_2015-08-20-2300` (both that it is needed and that it works)
