### PR TITLE
forcing EE qT to be always true

### DIFF
--- a/DQM/EcalMonitorClient/src/TimingClient.cc
+++ b/DQM/EcalMonitorClient/src/TimingClient.cc
@@ -195,7 +195,7 @@ namespace ecaldqm
             quality = doMask ? kMGood : kGood;
         }
       }
-
+      if(tId.subdetId() == EcalEndcap) quality = doMask ? kMGood : kGood; // disable red flags
       qsItr->setBinContent(quality);
     }
   }


### PR DESCRIPTION
Patch to disable red flags in EE timing quality summary needed for DQM.
