### PR TITLE
Prototype of payload inspector modules for V2

### DIFF
--- a/CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc
+++ b/CondCore/BeamSpotPlugins/plugins/BeamSpot_PayloadInspector.cc
@@ -1,0 +1,120 @@
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/JsonPrinter.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/CondDB/interface/PayloadReader.h"
+
+#include "CondFormats/BeamSpotObjects/interface/BeamSpotObjects.h"
+
+#include <sstream>
+
+namespace {
+
+  class BeamSpotPlot_x {
+  public:
+    BeamSpotPlot_x(){
+    }
+
+    // return the type-name of the objects we handle, so the PayloadInspector can find corresponding tags
+    std::string objectType() {
+      return "BeamSpotObjects";
+    }
+
+    // return a title string to be used in the PayloadInspector
+    std::string title() {
+      return "x vs run number";
+    }
+
+    std::string info() {
+      return title();
+    }
+
+    std::string data( const boost::python::list& iovs ){
+      cond::persistency::PayloadReader reader;
+      // TO DO: add try /catch block                                                                                                                                                   
+      cond::utilities::JsonPrinter jprint("Run","x");
+      for( int i=0; i< len( iovs ); i++ ) {
+	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
+	boost::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
+	jprint.append(boost::lexical_cast<std::string>( iov.since ),
+		      boost::lexical_cast<std::string>( obj->GetX() ),
+		      boost::lexical_cast<std::string>( obj->GetXError() ) );
+      }
+      return jprint.print();
+    }
+  };
+
+  class BeamSpotPlot_y {
+  public:
+    BeamSpotPlot_y(){
+    }
+
+    // return the type-name of the objects we handle, so the PayloadInspector can find corresponding tags
+    std::string objectType() {
+      return "BeamSpotObjects";
+    }
+
+    // return a title string to be used in the PayloadInspector
+    std::string title() {
+      return "y vs run number";
+    }
+
+    std::string info() {
+      return title();
+    }
+
+    std::string data( const boost::python::list& iovs ){
+      cond::persistency::PayloadReader reader;
+      // TO DO: add try /catch block                                                                                                                                                   
+      cond::utilities::JsonPrinter jprint("Run","y");
+      for( int i=0; i< len( iovs ); i++ ) {
+	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
+	boost::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
+	jprint.append(boost::lexical_cast<std::string>( iov.since ),
+		      boost::lexical_cast<std::string>( obj->GetY() ),
+		      boost::lexical_cast<std::string>( obj->GetYError() ) );
+      }
+      return jprint.print();
+    }
+  };
+
+  class BeamSpotPlot_xy {
+  public:
+    BeamSpotPlot_xy(){
+    }
+
+    // return the type-name of the objects we handle, so the PayloadInspector can find corresponding tags
+    std::string objectType() {
+      return "BeamSpotObjects";
+    }
+
+    // return a title string to be used in the PayloadInspector
+    std::string title() {
+      return "BeamSpot x vs y";
+    }
+
+    std::string info() {
+      return title();
+    }
+
+    std::string data( const boost::python::list& iovs ){
+      cond::persistency::PayloadReader reader;
+      // TO DO: add try /catch block                                                                                                                                                   
+      cond::utilities::JsonPrinter jprint("x","y");
+      for( int i=0; i< len( iovs ); i++ ) {
+	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
+	boost::shared_ptr<BeamSpotObjects> obj = reader.fetch<BeamSpotObjects>( iov.payloadId );
+	jprint.append(boost::lexical_cast<std::string>( obj->GetX() ), 
+		      boost::lexical_cast<std::string>( obj->GetY() ) );
+      }
+      return jprint.print();
+    }
+  };
+
+
+}
+
+PAYLOAD_INSPECTOR_MODULE( BeamSpot ){
+  PAYLOAD_INSPECTOR_CLASS( BeamSpotPlot_x );
+  PAYLOAD_INSPECTOR_CLASS( BeamSpotPlot_y );
+  PAYLOAD_INSPECTOR_CLASS( BeamSpotPlot_xy );
+}

--- a/CondCore/BeamSpotPlugins/plugins/BuildFile.xml
+++ b/CondCore/BeamSpotPlugins/plugins/BuildFile.xml
@@ -10,10 +10,9 @@
   <flags   EDM_PLUGIN="1"/>
 </library>
 
-<library   file="BeamSpotObjects_toXML.cc" name="BeamSpotObjects_toXML">
+<library   file="BeamSpot_PayloadInspector.cc" name="BeamSpot_PayloadInspector">
   <use   name="CondCore/Utilities"/>
   <use   name="CondCore/CondDB"/>
   <use   name="CondFormats/Common"/>
   <use   name="boost_python"/>
 </library>
-

--- a/CondCore/CondDB/interface/PayloadReader.h
+++ b/CondCore/CondDB/interface/PayloadReader.h
@@ -1,0 +1,75 @@
+#ifndef CondCore_CondDB_PayloadReader_h
+#define CondCore_CondDB_PyloadReader_h
+//
+// Package:     CondDB
+// Class  :     PayloadReader
+// 
+/**\class PayloadReader PayloadReader.h CondCore/CondDB/interface/PayloadReader.h
+   Description: service for accessing conditions payloads from DB.  
+*/
+//
+// Author:      Giacomo Govi
+// Created:     Jul 2015
+//
+
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+
+#include <memory>
+
+namespace cond {
+
+  namespace persistency {
+
+    class PayloadReader {
+    public:
+
+      //static constexpr const char* const PRODUCTION_DB = "oracle://cms_orcon_adg/CMS_CONDITIONS";
+      static constexpr const char* const PRODUCTION_DB = "oracle://cms_orcoff_prep/CMS_CONDITIONS_002";
+
+    public:
+
+      // default constructor
+      PayloadReader();
+      
+      // 
+      PayloadReader( const PayloadReader& rhs );
+      
+      // 
+      virtual ~PayloadReader();
+      
+      //
+      PayloadReader& operator=( const PayloadReader& rhs );
+
+      //
+      ConnectionPool& connection();
+
+      //
+      void open( const std::string& connectionString );
+
+      //
+      void open();
+      
+      // 
+      void close();
+      
+      //
+      template <typename T> boost::shared_ptr<T> fetch( const cond::Hash& payloadHash );
+      
+   private:
+      
+      std::shared_ptr<ConnectionPool> m_connection;
+      Session m_session;
+    };
+        
+    template <typename T> inline boost::shared_ptr<T> PayloadReader::fetch( const cond::Hash& payloadHash ){
+      boost::shared_ptr<T> ret;
+      if(m_session.connectionString().empty()) open( PRODUCTION_DB );
+      m_session.transaction().start( true );
+      ret = m_session.fetchPayload<T>( payloadHash );
+      m_session.transaction().commit();
+      return ret;
+    }
+
+  }
+}
+#endif

--- a/CondCore/CondDB/interface/Types.h
+++ b/CondCore/CondDB/interface/Types.h
@@ -45,6 +45,7 @@ namespace cond {
 
   // Basic element of the IOV sequence.
   struct Iov_t {
+    virtual ~Iov_t(){}
     virtual void clear();
     bool isValid() const;
     bool isValidFor( Time_t target ) const;

--- a/CondCore/CondDB/plugins/BuildFile.xml
+++ b/CondCore/CondDB/plugins/BuildFile.xml
@@ -1,0 +1,5 @@
+<library   file="CondDBPyWrappers.cc" name="CondDBV2PyInterface">
+  <use   name="CondCore/CondDB"/>
+  <use   name="boost_python"/>
+</library>
+

--- a/CondCore/CondDB/plugins/CondDBPyWrappers.cc
+++ b/CondCore/CondDB/plugins/CondDBPyWrappers.cc
@@ -1,0 +1,40 @@
+#include "CondCore/CondDB/interface/Types.h"
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+
+#include <boost/python.hpp>
+
+using namespace boost::python;
+
+namespace {
+
+  void CMSSWInit(){
+    edmplugin::PluginManager::Config config;
+    edmplugin::PluginManager::configure(edmplugin::standard::config());
+  }
+
+}
+
+namespace cond {
+
+  Iov_t makeIov( cond::Time_t since, const Hash& payloadId ){
+    Iov_t ret;
+    ret.since = since;
+    ret.payloadId = payloadId;
+    return ret;
+  }
+
+}
+
+BOOST_PYTHON_MODULE(pluginCondDBV2PyInterface) {
+
+  def("CMSSWInit",&CMSSWInit);
+
+  def("makeIov",&cond::makeIov);
+
+  class_<cond::Iov_t>("Iov", init<>()) 
+    .def_readwrite("since", &cond::Iov_t::since ) 
+    .def_readwrite("payloadId", &cond::Iov_t::payloadId )
+    ;
+
+}

--- a/CondCore/CondDB/src/PayloadReader.cc
+++ b/CondCore/CondDB/src/PayloadReader.cc
@@ -1,0 +1,42 @@
+#include "CondCore/CondDB/interface/PayloadReader.h"
+
+namespace cond {
+
+  namespace persistency {
+
+    PayloadReader::PayloadReader(){
+      m_connection.reset( new ConnectionPool );
+    }
+ 
+    PayloadReader::PayloadReader( const PayloadReader& rhs ):
+      m_connection( rhs.m_connection ),
+      m_session( rhs.m_session ){
+    }
+
+    PayloadReader::~PayloadReader(){
+    }
+    
+    PayloadReader& PayloadReader::operator=( const PayloadReader& rhs ){
+      m_connection = rhs.m_connection;
+      m_session = rhs.m_session;
+      return *this;
+    }
+
+    ConnectionPool& PayloadReader::connection(){
+      return *m_connection;
+    }
+
+    void PayloadReader::open( const std::string& connectionString ){
+      m_session = m_connection->createSession( connectionString );
+    }
+
+    void PayloadReader::open(){
+      open( PRODUCTION_DB );
+    }
+
+    void PayloadReader::close(){
+      m_session.close();
+    }
+
+  }
+}

--- a/CondCore/CondDB/test/BuildFile.xml
+++ b/CondCore/CondDB/test/BuildFile.xml
@@ -1,31 +1,24 @@
-<flags CXXFLAGS="-g -std=c++11"/>
+<flags   GENREFLEX_ARGS="--"/>
 
 <use   name="CondCore/CondDB"/>
 <use   name="CondFormats/Common"/>
 <use   name="DataFormats/StdDictionaries"/>
 <use   name="FWCore/PluginManager"/>
 <use   name="FWCore/Utilities"/>
-
-<library   name="testCondDBDict" file="*.cc">
+<library   name="testCondDBDict" file="">
 </library>
-
-<bin file="testReadWritePayloads.cpp" name="testReadWritePayloads">
-  <lib name="testCondDBDict"/>
+<bin   file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">
+  <lib   name="testCondDBDict"/>
 </bin>
-
-<bin file="testConditionDatabase_0.cpp" name="testConditionDatabase_0">
-  <lib name="testCondDBDict"/>
+<bin   file="testConditionDatabase_1.cpp" name="testConditionDatabase_1">
 </bin>
-
-<bin file="testConditionDatabase_1.cpp" name="testConditionDatabase_1"></bin>
-<bin file="testConditionDatabase_2.cpp" name="testConditionDatabase_2"></bin>
-
-<bin file="testRootStreaming.cpp" name="testRootStreaming">
-  <lib name="testCondDBDict"/>
+<bin   file="testConditionDatabase_2.cpp" name="testConditionDatabase_2">
 </bin>
-
-<bin file="testPayloadProxy.cpp" name="testPayloadProxy">
-  <lib name="testCondDBDict"/>
+<bin   file="testRootStreaming.cpp" name="testRootStreaming">
+  <lib   name="testCondDBDict"/>
 </bin>
-
-<bin file="testFrontier.cpp" name="testFrontier"></bin>
+<bin   file="testPayloadProxy.cpp" name="testPayloadProxy">
+  <lib   name="testCondDBDict"/>
+</bin>
+<bin   file="testFrontier.cpp" name="testFrontier">
+</bin>

--- a/CondCore/Utilities/interface/JsonPrinter.h
+++ b/CondCore/Utilities/interface/JsonPrinter.h
@@ -1,0 +1,34 @@
+#ifndef CondCore_Utilities_JsonPrinter_h
+#define CondCore_Utilities_JsonPrinter_h
+
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace cond {
+
+  namespace utilities {
+    
+    class JsonPrinter {
+    public:
+      JsonPrinter();
+      JsonPrinter( const std::string& xName, const std::string& yName );
+
+      virtual ~JsonPrinter(){}
+
+      void append( const std::string& xValue, const std::string& yValue, const std::string& yError );
+      void append( const std::string& xValue, const std::string& yValue );
+
+      std::string print();
+
+    private:
+      std::string m_xName = "X";
+      std::string m_yName = "Y";
+      std::vector<std::tuple<std::string,std::string,std::string> > m_values;
+    };
+  }
+
+}
+
+#endif
+

--- a/CondCore/Utilities/interface/PayloadInspectorModule.h
+++ b/CondCore/Utilities/interface/PayloadInspectorModule.h
@@ -1,0 +1,23 @@
+#include <boost/python/class.hpp>
+#include <boost/python/module.hpp>
+#include <boost/python/def.hpp>
+#include <boost/python/init.hpp>
+#include <boost/python/list.hpp>
+
+#define PPCAT_NX(A, B) A ## B
+#define PPCAT(A, B) PPCAT_NX(A, B)
+#define STRINGIZE_NX(A) #A
+#define STRINGIZE(A) STRINGIZE_NX(A)
+
+#define PAYLOAD_INSPECTOR_MODULE( PAYLOAD_TYPENAME ) BOOST_PYTHON_MODULE( plugin ## PAYLOAD_TYPENAME ## _PayloadInspector )
+
+#define PAYLOAD_INSPECTOR_CLASS( CLASS_NAME ) using namespace boost::python; \
+  class_< CLASS_NAME >( STRINGIZE(PPCAT(plot_,CLASS_NAME)), init<>()) \
+  .def("objectType",&CLASS_NAME::objectType ) \
+  .def("title",&CLASS_NAME::title ) \
+  .def("info",&CLASS_NAME::info ) \
+  .def("data",&CLASS_NAME::data ) \
+  ;
+
+#define PAYLOAD_INSPECTOR_FUNCTION( FUNCTION_NAME ) using namespace boost::python; \
+  def (STRINGIZE(PPCAT(plot_,FUNCTION_NAME)), FUNCTION_NAME)

--- a/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
+++ b/CondCore/Utilities/plugins/BasicP_PayloadInspector.cc
@@ -1,0 +1,79 @@
+#include "CondCore/Utilities/interface/PayloadInspectorModule.h"
+#include "CondCore/Utilities/interface/JsonPrinter.h"
+#include "CondFormats/Common/interface/BasicPayload.h"
+#include "CondCore/CondDB/interface/Time.h"
+#include "CondCore/CondDB/interface/PayloadReader.h"
+#include <sstream>
+
+namespace {
+
+  class BasicPayloadPlot_data0 {
+  public:
+    BasicPayloadPlot_data0(){
+    }
+
+    // return the type-name of the objects we handle, so the PayloadInspector can find corresponding tags
+    std::string objectType() {
+      return "BasicPayload";
+    }
+
+    // return a title string to be used in the PayloadInspector
+    std::string title() {
+      return "Data0 vs run number";
+    }
+
+    std::string info() {
+      return title();
+    }
+
+    std::string data( const boost::python::list& iovs ){
+      cond::persistency::PayloadReader reader;
+      // TO DO: add try /catch block                                                                                                                                                   
+      cond::utilities::JsonPrinter jprint("Run","data0");
+      for( int i=0; i< len( iovs ); i++ ) {
+	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
+	boost::shared_ptr<cond::BasicPayload> obj = reader.fetch<cond::BasicPayload>( iov.payloadId );
+	jprint.append(boost::lexical_cast<std::string>(iov.since),boost::lexical_cast<std::string>(obj->m_data0 ));
+      }
+      return jprint.print();
+    }
+  };
+
+  class BasicPayloadPlot_data1 {
+  public:
+    BasicPayloadPlot_data1(){
+    }
+
+    // return the type-name of the objects we handle, so the PayloadInspector can find corresponding tags
+    std::string objectType() {
+      return "BasicPayload";
+    }
+
+    // return a title string to be used in the PayloadInspector
+    std::string title() {
+      return "Data1 trend";
+    }
+
+    std::string info() {
+      return title();
+    }
+
+    std::string data( const boost::python::list& iovs ){
+      cond::persistency::PayloadReader reader;
+      // TO DO: add try /catch block                                                                                                                                                 
+      cond::utilities::JsonPrinter jprint("Run","data1");
+      for( int i=0; i< len( iovs ); i++ ) {
+	cond::Iov_t iov = boost::python::extract<cond::Iov_t>( iovs[i] );
+	boost::shared_ptr<cond::BasicPayload> obj = reader.fetch<cond::BasicPayload>( iov.payloadId );
+        jprint.append(boost::lexical_cast<std::string>(iov.since),boost::lexical_cast<std::string>(obj->m_data1 ));
+      }
+      return jprint.print();
+    }
+  };
+
+}
+
+PAYLOAD_INSPECTOR_MODULE( BasicPayload ){
+  PAYLOAD_INSPECTOR_CLASS( BasicPayloadPlot_data0 );
+  PAYLOAD_INSPECTOR_CLASS( BasicPayloadPlot_data1 );
+}

--- a/CondCore/Utilities/plugins/BuildFile.xml
+++ b/CondCore/Utilities/plugins/BuildFile.xml
@@ -9,3 +9,9 @@
   <use   name="CondCore/CondDB"/>
   <use   name="FWCore/Sources"/>
 </library>
+<library   file="BasicP_PayloadInspector.cc" name="BasicPayload_PayloadInspector">
+  <use   name="CondCore/Utilities"/>
+  <use   name="CondCore/CondDB"/>
+  <use   name="CondFormats/Common"/>
+  <use   name="boost_python"/>
+</library>

--- a/CondCore/Utilities/src/JsonPrinter.cc
+++ b/CondCore/Utilities/src/JsonPrinter.cc
@@ -1,0 +1,45 @@
+#include "CondCore/Utilities/interface/JsonPrinter.h"
+//
+#include <sstream>
+
+namespace cond {
+
+  namespace utilities {
+    
+    JsonPrinter::JsonPrinter():m_values(){}
+    
+    JsonPrinter::JsonPrinter( const std::string& xName, const std::string& yName ):
+      m_xName(xName),
+      m_yName(yName),
+      m_values(){
+    }
+
+    void JsonPrinter::append( const std::string& xValue, const std::string& yValue, const std::string& yError ){
+      m_values.push_back( std::make_tuple( xValue, yValue, yError ) );
+    }
+    
+    void JsonPrinter::append( const std::string& xValue, const std::string& yValue ){
+      m_values.push_back( std::make_tuple( xValue, yValue, "0" ) );
+    }
+
+    std::string JsonPrinter::print(){
+      std::stringstream ss;
+      ss<<" { [ ";
+      bool first = true;
+      for( auto iv : m_values ){
+	if(!first) ss << ",";
+        ss <<" { ";
+	ss <<" \""<<m_xName<<"\": "<<std::get<0>(iv)<<",";
+	ss <<" \""<<m_yName<<"\": "<<std::get<1>(iv)<<",";
+	ss <<" \""<<m_yName<<"_Error\": "<<std::get<2>(iv);
+        ss <<" } ";
+	first = false;
+      }
+      ss<<"] }";
+      return ss.str();
+    }
+
+  }
+
+}
+

--- a/CondCore/Utilities/test/BuildFile.xml
+++ b/CondCore/Utilities/test/BuildFile.xml
@@ -1,0 +1,6 @@
+<use   name="CondCore/CondDB"/>
+<use   name="CondFormats/Common"/>
+<use   name="FWCore/PluginManager"/>
+<use   name="FWCore/Utilities"/>
+<bin   file="testBasicPayload.cpp" name="testBasicPayload">
+</bin>

--- a/CondCore/Utilities/test/testBasicPayload.cpp
+++ b/CondCore/Utilities/test/testBasicPayload.cpp
@@ -1,0 +1,59 @@
+#include "FWCore/PluginManager/interface/PluginManager.h"
+#include "FWCore/PluginManager/interface/standard.h"
+#include "FWCore/PluginManager/interface/SharedLibrary.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/ServiceRegistry/interface/ServiceRegistry.h"
+//
+#include "CondCore/CondDB/interface/ConnectionPool.h"
+#include "CondFormats/Common/interface/BasicPayload.h"
+//
+#include <fstream>
+#include <iomanip>
+#include <cstdlib>
+#include <iostream>
+
+using namespace cond::persistency;
+
+int run( const std::string& connectionString ){
+  try{
+
+    //*************
+    std::cout <<"> Connecting with db in "<<connectionString<<std::endl;
+    ConnectionPool connPool;
+    connPool.setMessageVerbosity( coral::Debug );
+    Session session = connPool.createSession( connectionString, true, cond::COND_DB );
+    session.transaction().start( false );
+    IOVEditor editor;
+    if( !session.existsDatabase() || !session.existsIov( "BasicPayload_v0" ) ){
+      editor = session.createIov<cond::BasicPayload>( "BasicPayload_v0", cond::runnumber ); 
+      editor.setDescription("Test for timestamp selection");
+    }
+    for( int i=0;i<10;i++ ){
+      cond::BasicPayload  p( i*10.1, i+1. );
+      auto pid = session.storePayload( p );
+      editor.insert( i*100+1, pid );
+    }
+    editor.flush();
+    std::cout <<"> iov changes flushed..."<<std::endl;
+    session.transaction().commit();
+  } catch (const std::exception& e){
+    std::cout << "ERROR: " << e.what() << std::endl;
+    return -1;
+  } catch (...){
+    std::cout << "UNEXPECTED FAILURE." << std::endl;
+    return -1;
+  }
+  std::cout <<"## Run successfully completed."<<std::endl;
+  return 0;
+}
+
+int main (int argc, char** argv)
+{
+  int ret = 0;
+  edmplugin::PluginManager::Config config;
+  edmplugin::PluginManager::configure(edmplugin::standard::config());
+  std::string connectionString0("sqlite_file:BasicPayload_v0.db");
+  ret = run( connectionString0 );
+  return ret;
+}
+

--- a/CondFormats/Common/interface/BasicPayload.h
+++ b/CondFormats/Common/interface/BasicPayload.h
@@ -1,0 +1,26 @@
+#ifndef Cond_BasicPayload_h
+#define Cond_BasicPayload_h
+
+#include "CondFormats/Serialization/interface/Serializable.h"
+
+namespace cond {
+  
+  /** Test class for condition payload
+  */
+  class BasicPayload {
+  public:
+    
+    BasicPayload():m_data0(0.),m_data1(0.){}
+    BasicPayload( float d0, float d1):m_data0(d0),m_data1(d1){}
+    virtual ~BasicPayload(){}
+    
+  public:
+    float m_data0;
+    float m_data1;
+  
+  COND_SERIALIZABLE;
+};
+  
+}
+
+#endif

--- a/CondFormats/Common/src/headers.h
+++ b/CondFormats/Common/src/headers.h
@@ -8,6 +8,7 @@
 #include "CondFormats/Common/interface/ConfObject.h"
 
 #include "CondFormats/Common/interface/DropBoxMetadata.h"
+#include "CondFormats/Common/interface/BasicPayload.h"
 
 
 #include <vector>

--- a/CondFormats/Common/test/testSerializationCommon.cpp
+++ b/CondFormats/Common/test/testSerializationCommon.cpp
@@ -20,6 +20,7 @@ int main()
     testSerialization<cond::SmallWORMDict>();
     //testSerialization<cond::Summary>(); abstract
     testSerialization<cond::UpdateStamp>();
+    testSerialization<cond::BasicPayload>();
     //testSerialization<ora::OId>(); not used in the future
     //testSerialization<ora::PVector<cond::IOVElement>>(); not used in the future
     //testSerialization<ora::QueryableVector<cond::IOVElement>>(); not used in the future


### PR DESCRIPTION
In this PR, we add the CMSSW infrastructure for the payload inspector application implemented for the V2 database.
It includes:
A set of python utilities for the conddb related operations: intialization, iov manipulations
A set of macros for the definitions of payload inspectors functions/libraries
Two examples of usage: 1. A dummy BasicPayload class 2. Some BeamSpot related functions
