### PR TITLE
Add a "fastSim" era to configure FastSim modules

### DIFF
--- a/Configuration/Applications/python/cmsDriverOptions.py
+++ b/Configuration/Applications/python/cmsDriverOptions.py
@@ -258,6 +258,13 @@ def OptionsFromItems(items):
         for eraName in requestedEras : # Same loop, but had to make sure all the names existed first
             if eras.internalUseEras.count(getattr(eras,eraName)) > 0 :
                 print "WARNING: You have explicitly set '"+eraName+"' with the '--era' command. That is usually reserved for internal use only."
+    # If the "--fast" option was supplied automatically enable the fastSim era
+    if options.fast :
+        if options.era:
+            options.era+=",fastSim"
+        else :
+            options.era="fastSim"
+
 
     return options
 

--- a/Configuration/StandardSequences/python/Eras.py
+++ b/Configuration/StandardSequences/python/Eras.py
@@ -13,6 +13,10 @@ class Eras (object):
         self.run2_HI_specific = cms.Modifier()
         self.stage1L1Trigger = cms.Modifier()
         
+        # This era should not be set by the user with the "--era" command, it's
+        # activated automatically if the "--fast" command is used.
+        self.fastSim = cms.Modifier()
+        
         # These are the eras that the user should specify
         self.Run2_25ns = cms.ModifierChain( self.run2_common, self.run2_25ns_specific, self.stage1L1Trigger )
         self.Run2_50ns = cms.ModifierChain( self.run2_common, self.run2_50ns_specific )
@@ -24,6 +28,6 @@ class Eras (object):
         # message of available values when an invalid era is specified.
         self.internalUseEras = [self.run2_common, self.run2_25ns_specific,
                                 self.run2_50ns_specific, self.run2_HI_specific,
-                                self.stage1L1Trigger]
+                                self.stage1L1Trigger, self.fastSim ]
 
 eras=Eras()


### PR DESCRIPTION
As discussed in the simulation meeting on 21/Aug/2015, this introduces a new "fastSim" era for FastSim specific changes.

It is automatically added by cmsDriver if the `--fast` option is used.  If the user tries to add it explicitly with the `--era` option then there is a warning that it is for internal use, but it is added anyway.

If a user wants to enable it in their own config file, not created with cmsDriver, then they have to create the `process` object with:

```
from Configuration.StandardSequences.Eras import eras
process = cms.Process('HLT',eras.fastSim)
```

@lveldere, I'll email you privately with examples of how to use in configuration files.
