### PR TITLE
migrate modules used by the HLT menu to multithreading

### DIFF
--- a/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
+++ b/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.cc
@@ -1,10 +1,12 @@
 #include "LaserAlignmentEventFilter.h"
 
-#include <FWCore/Framework/interface/Event.h> 
-#include <FWCore/Framework/interface/EventSetup.h> 
-#include <FWCore/Framework/interface/MakerMacros.h>
-#include <FWCore/Framework/interface/EventSetupRecordKey.h>
-#include <FWCore/Framework/interface/ESHandle.h>
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/Framework/interface/EventSetup.h"
+#include "FWCore/Framework/interface/EventSetupRecordKey.h"
+#include "FWCore/Framework/interface/ESHandle.h"
+#include "FWCore/Framework/interface/MakerMacros.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/MessageLogger/interface/MessageLogger.h"
 
 #include "CondFormats/SiStripObjects/interface/SiStripFedCabling.h"
 #include "CondFormats/DataRecord/interface/SiStripFedCablingRcd.h"
@@ -12,39 +14,25 @@
 
 #include <algorithm>
 
+// make a sorted copy of a vector, optionally of a different type
+template <typename T, typename U>
+std::vector<T> copy_and_sort_vector(std::vector<U> const & input)
+{
+  std::vector<T> copy(input.begin(), input.end());
+  std::sort(copy.begin(), copy.end());
+  return copy;
+}
+
 ///
 /// constructors and destructor
 ///
 LaserAlignmentEventFilter::LaserAlignmentEventFilter( const edm::ParameterSet& iConfig ) :
-  FED_collection(iConfig.getParameter<edm::InputTag>("FedInputTag")),
-  signal_filter(true),
-  single_channel_thresh(11),
-  channel_count_thresh(4),
-  LAS_event_count(0),
-  cabling(0),
-  cacheId_(0)
+  FED_collection_token( consumes<FEDRawDataCollection>(iConfig.getParameter<edm::InputTag>("FedInputTag")) ),
+  las_fed_ids(          copy_and_sort_vector<uint16_t>(iConfig.getParameter<std::vector<int>>("FED_IDs")) ),
+  las_signal_ids(       copy_and_sort_vector<uint32_t>(iConfig.getParameter<std::vector<int>>("SIGNAL_IDs")) ),
+  single_channel_thresh(iConfig.getParameter<unsigned>("SINGLE_CHANNEL_THRESH") ),
+  channel_count_thresh( iConfig.getParameter<unsigned>("CHANNEL_COUNT_THRESH") )
 {
-
-  FED_collection_token = consumes<FEDRawDataCollection>(FED_collection);
-
-  // Read in Filter Lists
-  std::vector<int> FED_IDs = iConfig.getParameter<std::vector<int> >("FED_IDs");
-  set_las_fed_ids(FED_IDs);
-
-  std::vector<int> SIGNAL_IDs = iConfig.getParameter<std::vector<int> >("SIGNAL_IDs");
-  set_las_signal_ids(SIGNAL_IDs);
-
-  // Read in Filter Flags
-  signal_filter = iConfig.getParameter<bool>("SIGNAL_Filter");
-
-  // Read in Filter Parameters
-  single_channel_thresh =  iConfig.getParameter<unsigned>("SINGLE_CHANNEL_THRESH");
-  channel_count_thresh = iConfig.getParameter<unsigned>("CHANNEL_COUNT_THRESH");
-
-  edm::LogInfo("LasFilterConstructor") << "\n" 
-				       << "\nSIGNAL_Filter: " << (signal_filter ? "true" : "false")
-				       << ", SIGNLE_CHANNEL_THRESH: " << single_channel_thresh 
-				       << ", CHANNEL_COUNT_THRESH: " << channel_count_thresh;
 }
 
 ///
@@ -53,141 +41,75 @@ LaserAlignmentEventFilter::LaserAlignmentEventFilter( const edm::ParameterSet& i
 LaserAlignmentEventFilter::~LaserAlignmentEventFilter() {
 }
 
-///
-///
-///
-void LaserAlignmentEventFilter::beginRun( const edm::EventSetup& iSetup) {
-  updateCabling( iSetup );
-}
-
-///
 /// Checks for Laser Signals in specific modules
 /// For Accessing FED Data see also EventFilter/SiStripRawToDigi/src/SiStripRawToDigiUnpacker.cc and related files
-
-bool LaserAlignmentEventFilter::filter( edm::Event& iEvent, const edm::EventSetup& iSetup ) 
+bool LaserAlignmentEventFilter::filter(edm::StreamID sid, edm::Event& iEvent, const edm::EventSetup& iSetup) const
 {
-  updateCabling( iSetup );
-  unsigned int det_ctr=0; // Count how many modules are tested for signal
-  unsigned int sig_ctr=0; // Count how many modules have signal
-  unsigned long buffer_sum=0; // Sum of buffer sizes
+  //unsigned int  det_ctr = 0;      // count how many modules are tested for signal
+  unsigned int  sig_ctr = 0;      // count how many modules have signal
+  //unsigned long buffer_sum = 0;   // sum of buffer sizes
 
-  // Retrieve FED raw data (by label, which is "source" by default)
+  // retrieve FED raw data (by label, which is "source" by default)
   edm::Handle<FEDRawDataCollection> buffers;
-  iEvent.getByToken( FED_collection_token, buffers ); 
+  iEvent.getByToken( FED_collection_token, buffers );
 
+  // read the cabling map from the EventSetup
+  edm::ESHandle<SiStripFedCabling> cabling;
+  iSetup.get<SiStripFedCablingRcd>().get( cabling );
 
   std::vector<uint16_t>::const_iterator ifed = las_fed_ids.begin();
   for ( ; ifed != las_fed_ids.end(); ifed++ ) {
-    // Retrieve FED raw data for given FED 
+    // Retrieve FED raw data for given FED
     const FEDRawData& input = buffers->FEDData( static_cast<int>(*ifed) );
-    LogDebug("LaserAlignmentEventFilter") << "Examining FED " << *ifed; 
+    LogDebug("LaserAlignmentEventFilter") << "Examining FED " << *ifed;
 
-     // Check on FEDRawData pointer
-     if ( !input.data() ) {
-       continue;
-     }	
-    
-     // Check on FEDRawData size
-     if ( !input.size() ) {
-       continue;
-     }
+    // check on FEDRawData pointer
+    if (not input.data())
+      continue;
 
-     // get the cabling connections for this FED
-     auto conns = cabling->fedConnections(*ifed);
+    // check on FEDRawData size
+    if (not input.size())
+      continue;
 
-     // construct FEDBuffer
-     std::auto_ptr<sistrip::FEDBuffer> buffer;
-     try {
-       buffer.reset(new sistrip::FEDBuffer(input.data(),input.size()));
-       if (!buffer->doChecks()) {
- 	throw cms::Exception("FEDBuffer") << "FED Buffer check fails for FED ID " << *ifed << ". (BW)";
-	if(buffer->daqEventType() != sistrip::DAQ_EVENT_TYPE_CALIBRATION){
-	  edm::LogWarning("LaserAlignmentEventFilter") << "Event is not calibration type";
-	  return false;
-	}
-       }
-     }
-     catch (const cms::Exception& e) { 
-       if ( edm::isDebugEnabled() ) {
- 	edm::LogWarning("LaserAlignmentEventFilter") << "Exception caught when creating FEDBuffer object for FED " << *ifed << ": " << e.what();
-       }
-       continue;
-     }
+    // construct FEDBuffer
+    sistrip::FEDBuffer buffer(input.data(), input.size());
+    if (not buffer.doChecks()) {
+      edm::LogWarning("LaserAlignmentEventFilter") << "FED Buffer check fails for FED ID " << *ifed << ".";
+      continue;
+    }
+
+    // get the cabling connections for this FED
+    auto const & conns = cabling->fedConnections(*ifed);
 
     // Iterate through FED channels, extract payload and create Digis
     std::vector<FedChannelConnection>::const_iterator iconn = conns.begin();
     for ( ; iconn != conns.end(); iconn++ ) {
-
-      if(signal_filter){
-	if ( std::binary_search(las_signal_ids.begin(), las_signal_ids.end(), iconn->detId())){ 
-	  LogDebug("LaserAlignmentEventFilter")
-	    << " Found LAS signal module in FED " 
-	    << *ifed
-	    << "  DetId: " 
-	    << iconn->detId() << "\n"
-	    << "buffer->channel(iconn->fedCh()).size(): " << buffer->channel(iconn->fedCh()).length();
-	  buffer_size.push_back(buffer->channel(iconn->fedCh()).length());
-	  det_ctr ++;
-	  if(buffer->channel(iconn->fedCh()).length() > single_channel_thresh) sig_ctr++;
-	  buffer_sum += buffer->channel(iconn->fedCh()).length();
-	  if(sig_ctr > channel_count_thresh){
-	    LAS_event_count ++;
-	    LogDebug("LaserAlignmentEventFilter") << "Event identified as LAS";
-	    return true;
-	  }
-	}
+      if (std::binary_search(las_signal_ids.begin(), las_signal_ids.end(), iconn->detId())) {
+        LogDebug("LaserAlignmentEventFilter")
+          << " Found LAS signal module in FED "
+          << *ifed
+          << "  DetId: "
+          << iconn->detId() << "\n"
+          << "buffer.channel(iconn->fedCh()).size(): " << buffer.channel(iconn->fedCh()).length();
+        //++det_ctr;
+        if (buffer.channel(iconn->fedCh()).length() > single_channel_thresh)
+          ++sig_ctr;
+        //buffer_sum += buffer.channel(iconn->fedCh()).length();
+        if (sig_ctr > channel_count_thresh){
+          LogDebug("LaserAlignmentEventFilter") << "Event identified as LAS";
+          return true;
+        }
       }
     } // channel loop
   } // FED loop
-  
-//   LogDebug("LaserAlignmentEventFilter") << det_ctr << " channels were tested for signal\n" 
+
+//   LogDebug("LaserAlignmentEventFilter") << det_ctr << " channels were tested for signal\n"
 // 			    <<sig_ctr << " channels have signal\n"
 // 			    << "Sum of buffer sizes: " << buffer_sum;
 
 
   return false;
 }
-
-
-///
-///
-///
-void LaserAlignmentEventFilter::endJob() {
-  //edm::LogInfo("LaserAlignmentEventFilter") << "found " << LAS_event_count << " LAS events";
-}
-
-// Create the table of FEDs that contain LAS Modules
-void LaserAlignmentEventFilter::set_las_fed_ids(const std::vector<int>& las_feds)
-{
-  // Convert the std::vector to a std::set
-  las_fed_ids = std::vector<uint16_t>(las_feds.begin(), las_feds.end());
-  // Sort for binary search
-  std::sort(las_fed_ids.begin(), las_fed_ids.end());
-}
-
-// Create table of modules to be tested for signals
-void LaserAlignmentEventFilter::set_las_signal_ids(const std::vector<int>& las_signal)
-{
-  // Convert the std::vector to a std::set
-  las_signal_ids = std::vector<uint32_t>(las_signal.begin(), las_signal.end());
-  // Sort for binary search
-  std::sort(las_signal_ids.begin(), las_signal_ids.end());
-}
-
-
-// This method was copied from EventFilter/SiStripRawToDigi/plugin/SiStripRawToDigiModule
-void LaserAlignmentEventFilter::updateCabling( const edm::EventSetup& setup ) {
-
-  uint32_t cache_id = setup.get<SiStripFedCablingRcd>().cacheIdentifier();
-
-  if ( cacheId_ != cache_id ) {
-   edm::ESHandle<SiStripFedCabling> c;
-   setup.get<SiStripFedCablingRcd>().get( c );
-   cabling = c.product();
-   cacheId_ = cache_id;
-  }
-}
-
 
 //define this as a plug-in
 DEFINE_FWK_MODULE(LaserAlignmentEventFilter);

--- a/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.h
+++ b/Alignment/LaserAlignment/plugins/LaserAlignmentEventFilter.h
@@ -1,51 +1,26 @@
 #include "FWCore/Utilities/interface/InputTag.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/global/EDFilter.h"
 
 #include "DataFormats/FEDRawData/interface/FEDRawDataCollection.h"
 
 class SiStripFedCabling;
 
-class LaserAlignmentEventFilter : public edm::EDFilter {
+class LaserAlignmentEventFilter : public edm::global::EDFilter<> {
 
- public:
+public:
   explicit LaserAlignmentEventFilter(const edm::ParameterSet&);
   ~LaserAlignmentEventFilter();
 
- private:
+private:
+  virtual bool filter(edm::StreamID, edm::Event &, edm::EventSetup const&) const override;
 
-  // Name of the FED collection
-  const edm::InputTag FED_collection;
-  edm::EDGetTokenT<FEDRawDataCollection> FED_collection_token;
+  // FED RAW data input collection
+  const edm::EDGetTokenT<FEDRawDataCollection> FED_collection_token;
 
-  // Map the std::vector<int> that is returned by edm::ParameterSet::getParameter() to internal representations (which are optimized for the Filter)
-  void set_las_fed_ids(const std::vector<int>& las_feds);
-  //void set_las_det_ids(const std::vector<int>& las_dets);
-  void set_las_signal_ids(const std::vector<int>& las_signal);
-  
-  virtual void beginRun(const edm::EventSetup&) ;
-  virtual bool filter(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
+  // filter settings
+  const std::vector<uint16_t> las_fed_ids;      // list of FEDs used by LAS
+  const std::vector<uint32_t> las_signal_ids;   // list of DetIds to probe for signal
 
-  // Filter Settings
-  //bool fed_filter; // Discard unused FEDs
-  //bool det_id_filter; // Discard unused DetIds
-  bool signal_filter; // Check for LAS Signals
-
-  std::vector<uint16_t> las_fed_ids; // List of FEDs used by LAS
-  //std::vector<uint32_t> las_det_ids; // List of DetIds used by LAS
-  std::vector<uint32_t> las_signal_ids; // List of DetIds to probe for signal
-
-  uint16_t single_channel_thresh; // Signal threshold for a single channel
-  uint16_t channel_count_thresh; // Nr. of channels that have to contain signal for LAS event
- 
-  // Debug output variables
-  std::vector<uint16_t> buffer_size;
-  std::vector<uint32_t> buffer_size_sum;
-  uint32_t LAS_event_count;
-
-  // Handling of FED Cabling
-  void updateCabling( const edm::EventSetup& );
-  const SiStripFedCabling* cabling;
-  uint32_t cacheId_;
-    
+  const uint16_t single_channel_thresh;         // signal threshold for a single channel
+  const uint16_t channel_count_thresh;          // nr. of channels that have to contain signal for LAS event
 };

--- a/Alignment/LaserAlignment/python/LaserAlignmentEventFilter_cfi.py
+++ b/Alignment/LaserAlignment/python/LaserAlignmentEventFilter_cfi.py
@@ -23,7 +23,6 @@ LaserAlignmentEventFilter.DET_IDs.extend(DET_AT_TIB)
 LaserAlignmentEventFilter.DET_IDs.extend(DET_AT_TECp)
 LaserAlignmentEventFilter.DET_IDs.extend(DET_AT_TECm)
 
-
 LaserAlignmentEventFilter.SIGNAL_IDs = cms.vint32()
 LaserAlignmentEventFilter.SIGNAL_IDs.extend(SIGNAL_IDs_TECp_R4)
 LaserAlignmentEventFilter.SIGNAL_IDs.extend(SIGNAL_IDs_TECp_R6)
@@ -33,10 +32,6 @@ LaserAlignmentEventFilter.SIGNAL_IDs.extend(SIGNAL_IDs_AT_TOB)
 LaserAlignmentEventFilter.SIGNAL_IDs.extend(SIGNAL_IDs_AT_TIB)
 LaserAlignmentEventFilter.SIGNAL_IDs.extend(SIGNAL_IDs_AT_TECp)
 LaserAlignmentEventFilter.SIGNAL_IDs.extend(SIGNAL_IDs_AT_TECm)
-
-LaserAlignmentEventFilter.FED_Filter = cms.bool(True)
-LaserAlignmentEventFilter.DET_ID_Filter = cms.bool(True)
-LaserAlignmentEventFilter.SIGNAL_Filter = cms.bool(True)
 
 LaserAlignmentEventFilter.SINGLE_CHANNEL_THRESH = cms.uint32(11);
 LaserAlignmentEventFilter.CHANNEL_COUNT_THRESH = cms.uint32(8);

--- a/Calibration/HcalIsolatedTrackReco/interface/IPTCorrector.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IPTCorrector.h
@@ -7,33 +7,26 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
-#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
-
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "DataFormats/Common/interface/Ref.h"
-
-//#include "DataFormats/Common/interface/Provenance.h"
-
 #include "DataFormats/TrackReco/interface/Track.h"
 #include "DataFormats/HcalIsolatedTrack/interface/IsolatedPixelTrackCandidate.h"
 #include "DataFormats/HLTReco/interface/TriggerFilterObjectWithRefs.h"
 
-class IPTCorrector : public edm::EDProducer {
-
- public:
-
+class IPTCorrector : public edm::global::EDProducer<>
+{
+public:
   IPTCorrector (const edm::ParameterSet& ps);
-  ~IPTCorrector();
 
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  virtual void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
- private:
-	
-  edm::EDGetTokenT<reco::TrackCollection> tok_cor_;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_uncor_;
-  double assocCone_;
+private:
+  const edm::EDGetTokenT<reco::TrackCollection> tok_cor_;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_uncor_;
+  const double assocCone_;
 };
 
 

--- a/Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h
@@ -2,7 +2,7 @@
 #define Calibration_IsolatedEcalPixelTrackCandidateProducer_h
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -17,24 +17,22 @@
 // class decleration
 //
 
-class IsolatedEcalPixelTrackCandidateProducer : public edm::EDProducer {
+class IsolatedEcalPixelTrackCandidateProducer : public edm::global::EDProducer<> {
 
 public:
   explicit IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet&);
   ~IsolatedEcalPixelTrackCandidateProducer();
 
 private:
+  virtual void produce(edm::StreamID, edm::Event&, const edm::EventSetup&) const override;
 
-  virtual void beginJob() ;
-  virtual void produce(edm::Event&, const edm::EventSetup&);
-  virtual void endJob() ;
-
-  double coneSizeEta0_, coneSizeEta1_;
-  double hitCountEthr_;
-  double hitEthr_;
-  edm::EDGetTokenT<EcalRecHitCollection> tok_ee;
-  edm::EDGetTokenT<EcalRecHitCollection> tok_eb;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_trigcand;
+  const edm::EDGetTokenT<EcalRecHitCollection> tok_ee;
+  const edm::EDGetTokenT<EcalRecHitCollection> tok_eb;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_trigcand;
+  const double coneSizeEta0_;
+  const double coneSizeEta1_;
+  const double hitCountEthr_;
+  const double hitEthr_;
 };
 
 #endif

--- a/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h
+++ b/Calibration/HcalIsolatedTrackReco/interface/IsolatedPixelTrackCandidateProducer.h
@@ -7,7 +7,7 @@
  */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -38,7 +38,7 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapFwd.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMap.h"
 
-class IsolatedPixelTrackCandidateProducer : public edm::EDProducer {
+class IsolatedPixelTrackCandidateProducer : public edm::stream::EDProducer<> {
 
 public:
 
@@ -46,42 +46,40 @@ public:
   ~IsolatedPixelTrackCandidateProducer();
   
 
-  virtual void beginJob ();
-  virtual void beginRun(const edm::Run&, const edm::EventSetup&);
-  virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+  virtual void beginRun(const edm::Run&, const edm::EventSetup&) override;
+  virtual void produce(edm::Event& evt, const edm::EventSetup& es) override;
   
   double getDistInCM(double eta1, double phi1, double eta2, double phi2);
   std::pair<double, double> GetEtaPhiAtEcal(double etaIP, double phiIP, double pT, int charge, double vtxZ);
 
 private:
   struct seedAtEC {
-    seedAtEC(unsigned int i, bool f, double et, double fi) {index=i; ok=f;
-      eta=et; phi=fi;}
+    seedAtEC(unsigned int i, bool f, double et, double fi) : index(i), ok(f), eta(et), phi(fi) { }
     unsigned int index;
     bool         ok;
     double       eta, phi;
   };
-  std::vector<edm::InputTag> pixelTracksSources_;
-  edm::ParameterSet parameters;
-  edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
-  edm::EDGetTokenT<l1extra::L1JetParticleCollection> tok_l1_;
-  edm::EDGetTokenT<reco::VertexCollection> tok_vert_;
 
-  std::vector<edm::EDGetTokenT<reco::TrackCollection> > toks_pix_;
+  const edm::EDGetTokenT<trigger::TriggerFilterObjectWithRefs> tok_hlt_;
+  const edm::EDGetTokenT<l1extra::L1JetParticleCollection> tok_l1_;
+  const edm::EDGetTokenT<reco::VertexCollection> tok_vert_;
+  const std::vector<edm::EDGetTokenT<reco::TrackCollection> > toks_pix_;
 
-  double prelimCone_;
-  double pixelIsolationConeSizeAtEC_;
-  double vtxCutSeed_;
-  double vtxCutIsol_;
-  double tauAssocCone_;
-  double tauUnbiasCone_;
-  std::string bfield_;
-  double minPTrackValue_;
-  double maxPForIsolationValue_;
+  const std::string bfield_;
+  const double prelimCone_;
+  const double pixelIsolationConeSizeAtEC_;
+  const double vtxCutSeed_;
+  const double vtxCutIsol_;
+  const double tauAssocCone_;
+  const double tauUnbiasCone_;
+  const double minPTrackValue_;
+  const double maxPForIsolationValue_;
+  const double ebEtaBoundary_;
+
+  // these are read from the EventSetup, cannot be const
   double rEB_;
   double zEE_;
-  double ebEtaBoundary_;
-  double bfVal;
+  double bfVal_;
 };
 
 

--- a/Calibration/HcalIsolatedTrackReco/src/IPTCorrector.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IPTCorrector.cc
@@ -18,21 +18,17 @@
 #include "Math/GenVector/PxPyPzE4D.h"
 #include "DataFormats/Math/interface/deltaR.h"
 
-IPTCorrector::IPTCorrector(const edm::ParameterSet& config) {
-  
-  tok_cor_ = consumes<reco::TrackCollection>(config.getParameter<edm::InputTag>("corTracksLabel"));
-  tok_uncor_ = consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("filterLabel"));
-  assocCone_=config.getParameter<double>("associationCone");
-
-  // Register the product
+IPTCorrector::IPTCorrector(const edm::ParameterSet& config) :
+  tok_cor_(   consumes<reco::TrackCollection>(config.getParameter<edm::InputTag>("corTracksLabel")) ),
+  tok_uncor_( consumes<trigger::TriggerFilterObjectWithRefs>(config.getParameter<edm::InputTag>("filterLabel")) ),
+  assocCone_( config.getParameter<double>("associationCone") )
+{  
+  // register the product
   produces< reco::IsolatedPixelTrackCandidateCollection >();
-
 }
 
-IPTCorrector::~IPTCorrector() {}
 
-
-void IPTCorrector::produce(edm::Event& theEvent, const edm::EventSetup& theEventSetup) {
+void IPTCorrector::produce(edm::StreamID, edm::Event& theEvent, edm::EventSetup const&) const {
 
   reco::IsolatedPixelTrackCandidateCollection * trackCollection=new reco::IsolatedPixelTrackCandidateCollection;
 

--- a/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
+++ b/Calibration/HcalIsolatedTrackReco/src/IsolatedEcalPixelTrackCandidateProducer.cc
@@ -34,24 +34,23 @@
 
 #include "Calibration/HcalIsolatedTrackReco/interface/IsolatedEcalPixelTrackCandidateProducer.h"
 
-IsolatedEcalPixelTrackCandidateProducer::IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet& conf) {
-
-  coneSizeEta0_    = conf.getParameter<double>("EcalConeSizeEta0");
-  coneSizeEta1_    = conf.getParameter<double>("EcalConeSizeEta1");
-  hitCountEthr_    = conf.getParameter<double>("ECHitCountEnergyThreshold");
-  hitEthr_         = conf.getParameter<double>("ECHitEnergyThreshold");
-  tok_trigcand = consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("filterLabel"));
-  tok_eb = consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EBRecHitSource"));
-  tok_ee = consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EERecHitSource"));
-
-   //register your products
+IsolatedEcalPixelTrackCandidateProducer::IsolatedEcalPixelTrackCandidateProducer(const edm::ParameterSet& conf) :
+  tok_ee(        consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EERecHitSource")) ),
+  tok_eb(        consumes<EcalRecHitCollection>(conf.getParameter<edm::InputTag>("EBRecHitSource")) ),
+  tok_trigcand(  consumes<trigger::TriggerFilterObjectWithRefs>(conf.getParameter<edm::InputTag>("filterLabel")) ),
+  coneSizeEta0_( conf.getParameter<double>("EcalConeSizeEta0") ),
+  coneSizeEta1_( conf.getParameter<double>("EcalConeSizeEta1") ),
+  hitCountEthr_( conf.getParameter<double>("ECHitCountEnergyThreshold") ),
+  hitEthr_(      conf.getParameter<double>("ECHitEnergyThreshold") )
+{
+  // register the products
   produces< reco::IsolatedPixelTrackCandidateCollection >();
 }
 
 IsolatedEcalPixelTrackCandidateProducer::~IsolatedEcalPixelTrackCandidateProducer() { }
 
 // ------------ method called to produce the data  ------------
-void IsolatedEcalPixelTrackCandidateProducer::produce(edm::Event& iEvent, const edm::EventSetup& iSetup) {
+void IsolatedEcalPixelTrackCandidateProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::EventSetup& iSetup) const {
 #ifdef DebugLog
   edm::LogInfo("HcalIsoTrack") << "==============Inside IsolatedEcalPixelTrackCandidateProducer";
 #endif
@@ -135,8 +134,3 @@ void IsolatedEcalPixelTrackCandidateProducer::produce(edm::Event& iEvent, const 
   std::auto_ptr<reco::IsolatedPixelTrackCandidateCollection> outCollection(iptcCollection);
   iEvent.put(outCollection);
 }
-// ------------ method called once each job just before starting event loop  ------------
-void IsolatedEcalPixelTrackCandidateProducer::beginJob() { }
-
-// ------------ method called once each job just after ending the event loop  ------------
-void IsolatedEcalPixelTrackCandidateProducer::endJob() { }

--- a/HLTrigger/HLTcore/interface/TriggerExpressionData.h
+++ b/HLTrigger/HLTcore/interface/TriggerExpressionData.h
@@ -8,15 +8,14 @@
 #include "DataFormats/Provenance/interface/EventID.h"
 #include "DataFormats/Common/interface/TriggerResults.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutRecord.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 
 namespace edm {
   class Event;
   class EventSetup;
   class TriggerNames;
 }
-
-class L1GtTriggerMenu;
-class L1GtTriggerMask;
 
 namespace triggerExpression {
 
@@ -34,15 +33,15 @@ public:
     m_l1techIgnorePrescales(false),
     m_throw(true),
     // l1 values and status
-    m_l1tResults(0),
-    m_l1tMenu(0),
-    m_l1tAlgoMask(0),
-    m_l1tTechMask(0),
+    m_l1tResults(nullptr),
+    m_l1tMenu(nullptr),
+    m_l1tAlgoMask(nullptr),
+    m_l1tTechMask(nullptr),
     m_l1tCacheID(),
     m_l1tUpdated(false),
     // hlt values and status
-    m_hltResults(0),
-    m_hltMenu(0),
+    m_hltResults(nullptr),
+    m_hltMenu(nullptr),
     m_hltCacheID(),
     m_hltUpdated(false),
     // event values
@@ -61,15 +60,15 @@ public:
     m_l1techIgnorePrescales(config.getParameter<bool>("l1techIgnorePrescales")),
     m_throw(config.getParameter<bool>("throw")),
     // l1 values and status
-    m_l1tResults(0),
-    m_l1tMenu(0),
-    m_l1tAlgoMask(0),
-    m_l1tTechMask(0),
+    m_l1tResults(nullptr),
+    m_l1tMenu(nullptr),
+    m_l1tAlgoMask(nullptr),
+    m_l1tTechMask(nullptr),
     m_l1tCacheID(),
     m_l1tUpdated(false),
     // hlt values and status
-    m_hltResults(0),
-    m_hltMenu(0),
+    m_hltResults(nullptr),
+    m_hltMenu(nullptr),
     m_hltCacheID(),
     m_hltUpdated(false),
     // event values
@@ -98,15 +97,15 @@ public:
     m_l1techIgnorePrescales(l1techIgnorePrescales),
     m_throw(doThrow),
     // l1 values and status
-    m_l1tResults(0),
-    m_l1tMenu(0),
-    m_l1tAlgoMask(0),
-    m_l1tTechMask(0),
+    m_l1tResults(nullptr),
+    m_l1tMenu(nullptr),
+    m_l1tAlgoMask(nullptr),
+    m_l1tTechMask(nullptr),
     m_l1tCacheID(),
     m_l1tUpdated(false),
     // hlt values and status
-    m_hltResults(0),
-    m_hltMenu(0),
+    m_hltResults(nullptr),
+    m_hltMenu(nullptr),
     m_hltCacheID(),
     m_hltUpdated(false),
     // event values
@@ -224,7 +223,7 @@ private:
 
   // l1 values and status
   const L1GlobalTriggerReadoutRecord  * m_l1tResults;
-  const L1GtTriggerMenu               * m_l1tMenu;
+  std::unique_ptr<L1GtTriggerMenu>      m_l1tMenu;
   const L1GtTriggerMask               * m_l1tAlgoMask;
   const L1GtTriggerMask               * m_l1tTechMask;
   unsigned long long                    m_l1tCacheID;

--- a/HLTrigger/HLTcore/src/TriggerExpressionData.cc
+++ b/HLTrigger/HLTcore/src/TriggerExpressionData.cc
@@ -12,8 +12,6 @@
 #include "CondFormats/DataRecord/interface/L1GtTriggerMenuRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskAlgoTrigRcd.h"
 #include "CondFormats/DataRecord/interface/L1GtTriggerMaskTechTrigRcd.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMask.h"
-#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 
 namespace triggerExpression {
@@ -61,8 +59,8 @@ bool Data::setEvent(const edm::Event & event, const edm::EventSetup & setup) {
     if (m_l1tCacheID == l1tCacheID) {
       m_l1tUpdated = false;
     } else {
-      m_l1tMenu = get<L1GtTriggerMenuRcd, L1GtTriggerMenu>(setup);
-      (const_cast<L1GtTriggerMenu *>(m_l1tMenu))->buildGtConditionMap();
+      m_l1tMenu.reset(new L1GtTriggerMenu(* get<L1GtTriggerMenuRcd, L1GtTriggerMenu>(setup)));
+      m_l1tMenu->buildGtConditionMap();
       m_l1tCacheID = l1tCacheID;
       m_l1tUpdated = true;
     }

--- a/HLTrigger/HLTfilters/interface/HLTLevel1GTSeed.h
+++ b/HLTrigger/HLTfilters/interface/HLTLevel1GTSeed.h
@@ -112,7 +112,7 @@ private:
     // cached stuff
 
     /// trigger menu
-    L1GtTriggerMenu * m_l1GtMenu;
+    std::unique_ptr<L1GtTriggerMenu> m_l1GtMenu;
     unsigned long long m_l1GtMenuCacheID;
 
     /// logic parser for m_l1SeedsLogicalExpression

--- a/HLTrigger/HLTfilters/interface/TriggerResultsFilter.h
+++ b/HLTrigger/HLTfilters/interface/TriggerResultsFilter.h
@@ -19,7 +19,7 @@
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
@@ -36,7 +36,8 @@ namespace triggerExpression {
 // class declaration
 //
 
-class TriggerResultsFilter : public edm::EDFilter {
+class TriggerResultsFilter : public edm::stream::EDFilter<>
+{
 public:
   explicit TriggerResultsFilter(const edm::ParameterSet &);
   ~TriggerResultsFilter();

--- a/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
+++ b/HLTrigger/HLTfilters/interface/TriggerResultsFilterFromDB.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "FWCore/Framework/interface/ESWatcher.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "CondFormats/DataRecord/interface/AlCaRecoTriggerBitsRcd.h"
 #include "HLTrigger/HLTcore/interface/TriggerExpressionData.h"
 
@@ -35,7 +35,8 @@ namespace triggerExpression {
 // class declaration
 //
 
-class TriggerResultsFilterFromDB : public edm::EDFilter {
+class TriggerResultsFilterFromDB : public edm::stream::EDFilter<>
+{
 public:
   explicit TriggerResultsFilterFromDB(const edm::ParameterSet &);
   ~TriggerResultsFilterFromDB();

--- a/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
+++ b/HLTrigger/HLTfilters/src/HLTLevel1GTSeed.cc
@@ -74,7 +74,11 @@
 
 // constructors
 HLTLevel1GTSeed::HLTLevel1GTSeed(const edm::ParameterSet& parSet) : HLTStreamFilter(parSet),
-            //    seeding done via L1 trigger object maps, with objects that fired
+            // initialize the cache
+            m_l1GtMenu( nullptr ),
+            m_l1GtMenuCacheID( 0ULL ),
+
+            // seeding done via L1 trigger object maps, with objects that fired
             m_l1UseL1TriggerObjectMaps(parSet.getParameter<bool> (
                     "L1UseL1TriggerObjectMaps")),
 
@@ -180,10 +184,6 @@ HLTLevel1GTSeed::HLTLevel1GTSeed(const edm::ParameterSet& parSet) : HLTStreamFil
             << m_l1CollectionsTag << " \n"
             << "Input tag for L1 muon  collections:            "
             << m_l1MuonCollectionTag << " \n" << std::endl;
-
-    // initialize cache
-    m_l1GtMenu = nullptr;
-    m_l1GtMenuCacheID = 0ULL;
 }
 
 // destructor
@@ -348,9 +348,8 @@ bool HLTLevel1GTSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSet
 
         edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
         evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
-        // make a copy of the L1GtTriggerMenu in order to call buildGtConditionMap() (FIXME - is this really needed ?)
-        delete m_l1GtMenu;
-        m_l1GtMenu = new L1GtTriggerMenu(* l1GtMenu.product());
+        // make a copy of the L1GtTriggerMenu in order to call buildGtConditionMap()
+        m_l1GtMenu.reset(new L1GtTriggerMenu(* l1GtMenu.product()));
         m_l1GtMenu->buildGtConditionMap();
         m_l1GtMenuCacheID = l1GtMenuCacheID;
 
@@ -366,9 +365,9 @@ bool HLTLevel1GTSeed::hltFilter(edm::Event& iEvent, const edm::EventSetup& evSet
 
         // update also the tokenNumber members (holding the bit numbers) from m_l1AlgoLogicParser
         if (m_l1UseAliasesForSeeding) {
-            updateAlgoLogicParser(m_l1GtMenu, algorithmAliasMap);
+            updateAlgoLogicParser(m_l1GtMenu.get(), algorithmAliasMap);
         } else {
-            updateAlgoLogicParser(m_l1GtMenu, algorithmMap);
+            updateAlgoLogicParser(m_l1GtMenu.get(), algorithmMap);
         }
     }
 

--- a/HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h
+++ b/HLTrigger/special/interface/HLTRegionalEcalResonanceFilter.h
@@ -15,7 +15,7 @@ Description: Producer for EcalRecHits to be used for pi0/eta ECAL calibration.
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/stream/EDFilter.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ESHandle.h"
@@ -71,7 +71,8 @@ namespace edm {
   class ConfigurationDescriptions;
 }
 
-class HLTRegionalEcalResonanceFilter : public edm::EDFilter {
+class HLTRegionalEcalResonanceFilter : public edm::stream::EDFilter<> 
+{
    public:
       explicit HLTRegionalEcalResonanceFilter(const edm::ParameterSet&);
       ~HLTRegionalEcalResonanceFilter();

--- a/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
+++ b/L1Trigger/GlobalTrigger/interface/L1GlobalTriggerGTL.h
@@ -25,19 +25,17 @@
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerReadoutSetup.h"
 #include "DataFormats/L1GlobalTrigger/interface/L1GlobalTriggerObjectMapRecord.h"
 #include "L1Trigger/GlobalTrigger/interface/L1GtAlgorithmEvaluation.h"
-
-
 #include "DataFormats/L1GlobalMuonTrigger/interface/L1MuGMTCand.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Utilities/interface/InputTag.h"
-
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/ConsumesCollector.h"
+#include "FWCore/Utilities/interface/InputTag.h"
+
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 
 // forward declarations
 class L1GlobalTriggerPSB;
-class L1GtTriggerMenu;
 class L1CaloGeometry;
 class L1MuTriggerScales;
 class L1GtEtaPhiConversions;
@@ -116,7 +114,7 @@ private:
     // cached stuff
 
     // trigger menu
-    const L1GtTriggerMenu* m_l1GtMenu;
+    std::unique_ptr<L1GtTriggerMenu> m_l1GtMenu;
     unsigned long long m_l1GtMenuCacheID;
 
     // L1 scales (phi, eta) for Mu, Calo and EnergySum objects

--- a/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
+++ b/L1Trigger/GlobalTrigger/plugins/L1GlobalTrigger.h
@@ -31,7 +31,7 @@
 #include "CondFormats/L1TObjects/interface/L1GtBoard.h"
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -52,7 +52,7 @@ class L1GtPrescaleFactors;
 class L1GtTriggerMask;
 
 // class declaration
-class L1GlobalTrigger : public edm::EDProducer
+class L1GlobalTrigger : public edm::stream::EDProducer<>
 {
 
 public:
@@ -164,39 +164,36 @@ private:
     std::vector<unsigned int> m_triggerMaskVetoAlgoTrig;
     std::vector<unsigned int> m_triggerMaskVetoTechTrig;
 
-private:
-
-
     L1GlobalTriggerPSB* m_gtPSB;
     L1GlobalTriggerGTL* m_gtGTL;
     L1GlobalTriggerFDL* m_gtFDL;
 
     /// input tag for muon collection from GMT
-    edm::InputTag m_muGmtInputTag;
+    const edm::InputTag m_muGmtInputTag;
 
     /// input tag for calorimeter collections from GCT
-    edm::InputTag m_caloGctInputTag;
+    const edm::InputTag m_caloGctInputTag;
 
     /// input tag for CASTOR record
-    edm::InputTag m_castorInputTag;
+    const edm::InputTag m_castorInputTag;
 
     /// input tag for technical triggers
-    std::vector<edm::InputTag> m_technicalTriggersInputTags;
+    const std::vector<edm::InputTag> m_technicalTriggersInputTags;
 
     /// logical flag to produce the L1 GT DAQ readout record
-    bool m_produceL1GtDaqRecord;
+    const bool m_produceL1GtDaqRecord;
 
     /// logical flag to produce the L1 GT EVM readout record
-    bool m_produceL1GtEvmRecord;
+    const bool m_produceL1GtEvmRecord;
 
     /// logical flag to produce the L1 GT object map record
-    bool m_produceL1GtObjectMapRecord;
+    const bool m_produceL1GtObjectMapRecord;
 
     /// logical flag to write the PSB content in the  L1 GT DAQ record
-    bool m_writePsbL1GtDaqRecord;
+    const bool m_writePsbL1GtDaqRecord;
 
     /// logical flag to read the technical trigger records
-    bool m_readTechnicalTriggerRecords;
+    const bool m_readTechnicalTriggerRecords;
 
     /// number of "bunch crossing in the event" (BxInEvent) to be emulated
     /// symmetric around L1Accept (BxInEvent = 0):
@@ -207,47 +204,44 @@ private:
     /// number of BXs in the event corresponding to alternative 0 and 1 in altNrBxBoard()
     /// EmulateBxInEvent >= max(RecordLength[0], RecordLength[1])
     /// negative values: take the numbers from event setup, from L1GtParameters
-    std::vector<int> m_recordLength;
+    const std::vector<int> m_recordLength;
 
     /// alternative for number of BX per active board in GT DAQ record: 0 or 1
     /// the position is identical with the active board bit
-    unsigned int m_alternativeNrBxBoardDaq;
+    const unsigned int m_alternativeNrBxBoardDaq;
 
     /// alternative for number of BX per active board in GT EVM record: 0 or 1
     /// the position is identical with the active board bit
-    unsigned int m_alternativeNrBxBoardEvm;
+    const unsigned int m_alternativeNrBxBoardEvm;
 
     /// length of BST record (in bytes) from parameter set
-    int m_psBstLengthBytes;
+    const int m_psBstLengthBytes;
 
     /// run algorithm triggers
     ///     if true, unprescaled (all prescale factors 1)
     ///     will overwrite the event setup
-    bool m_algorithmTriggersUnprescaled;
+    const bool m_algorithmTriggersUnprescaled;
 
     ///     if true, unmasked - all enabled (all trigger masks set to 0)
     ///     will overwrite the event setup
-    bool m_algorithmTriggersUnmasked;
+    const bool m_algorithmTriggersUnmasked;
 
     /// run technical triggers
     ///     if true, unprescaled (all prescale factors 1)
     ///     will overwrite the event setup
-    bool m_technicalTriggersUnprescaled;
+    const bool m_technicalTriggersUnprescaled;
 
     ///     if true, unmasked - all enabled (all trigger masks set to 0)
     ///     will overwrite the event setup
-    bool m_technicalTriggersUnmasked;
+    const bool m_technicalTriggersUnmasked;
 
     ///     if true, veto unmasked - all enabled (all trigger veto masks set to 0)
     ///     will overwrite the event setup
-    bool m_technicalTriggersVetoUnmasked;
-
-
-private:
+    const bool m_technicalTriggersVetoUnmasked;
 
     /// verbosity level
-    int m_verbosity;
-    bool m_isDebugEnabled;
+    const int m_verbosity;
+    const bool m_isDebugEnabled;
 
 };
 

--- a/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
+++ b/L1Trigger/GlobalTrigger/src/L1GlobalTriggerGTL.cc
@@ -194,13 +194,12 @@ void L1GlobalTriggerGTL::run(
 
     if (m_l1GtMenuCacheID != l1GtMenuCacheID) {
 
-        edm::ESHandle< L1GtTriggerMenu> l1GtMenu;
-        evSetup.get< L1GtTriggerMenuRcd>().get(l1GtMenu) ;
-        m_l1GtMenu =  l1GtMenu.product();
-        (const_cast<L1GtTriggerMenu*>(m_l1GtMenu))->buildGtConditionMap();
+        edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
+        evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
+        m_l1GtMenu.reset(new L1GtTriggerMenu(*l1GtMenu));
+        m_l1GtMenu->buildGtConditionMap();
 
         m_l1GtMenuCacheID = l1GtMenuCacheID;
-
     }
 
     const std::vector<ConditionMap>& conditionMap = m_l1GtMenu->gtConditionMap();

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
@@ -19,11 +19,21 @@
 #include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 
+using namespace std;
+using namespace edm;
 using namespace l1t;
 
 L1TCaloUpgradeToGCTConverter::L1TCaloUpgradeToGCTConverter(const ParameterSet& iConfig):
-    bxMin_(iConfig.getParameter<int>("bxMin")),
-    bxMax_(iConfig.getParameter<int>("bxMax"))
+    // register what you consume and keep token for later access:
+    EGammaToken_(   consumes<EGammaBxCollection>(iConfig.getParameter<InputTag>("InputCollection")) ),
+    RlxTauToken_(   consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputRlxTauCollection")) ),
+    IsoTauToken_(   consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputIsoTauCollection")) ),
+    JetToken_(      consumes<JetBxCollection>(iConfig.getParameter<InputTag>("InputCollection")) ),
+    EtSumToken_(    consumes<EtSumBxCollection>(iConfig.getParameter<InputTag>("InputCollection")) ),
+    HfSumsToken_(   consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFSumsCollection")) ),
+    HfCountsToken_( consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFCountsCollection")) ),
+    bxMin_(         iConfig.getParameter<int>("bxMin") ),
+    bxMax_(         iConfig.getParameter<int>("bxMax") )
 {
   produces<L1GctEmCandCollection>("isoEm");
   produces<L1GctEmCandCollection>("nonIsoEm");
@@ -40,28 +50,12 @@ L1TCaloUpgradeToGCTConverter::L1TCaloUpgradeToGCTConverter(const ParameterSet& i
   produces<L1GctInternHtMissCollection>();
   produces<L1GctHFBitCountsCollection>();
   produces<L1GctHFRingEtSumsCollection>();
-
-  // register what you consume and keep token for later access:
-  EGammaToken_ = consumes<EGammaBxCollection>(iConfig.getParameter<InputTag>("InputCollection"));
-  RlxTauToken_ = consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputRlxTauCollection"));
-  IsoTauToken_ = consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputIsoTauCollection"));
-  JetToken_ = consumes<JetBxCollection>(iConfig.getParameter<InputTag>("InputCollection"));
-  EtSumToken_ = consumes<EtSumBxCollection>(iConfig.getParameter<InputTag>("InputCollection"));
-  HfSumsToken_ = consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFSumsCollection"));
-  HfCountsToken_ = consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFCountsCollection"));
 }
-
-
-L1TCaloUpgradeToGCTConverter::~L1TCaloUpgradeToGCTConverter()
-{
-}
-
-
 
 
 // ------------ method called to produce the data ------------
 void
-L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
+L1TCaloUpgradeToGCTConverter::produce(StreamID, Event& e, const EventSetup& es) const
 {
   LogDebug("l1t|stage 1 Converter") << "L1TCaloUpgradeToGCTConverter::produce function called...\n";
 
@@ -345,31 +339,6 @@ L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
   e.put(internalEtSumResult);
   e.put(internalHtMissResult);
 }
-
-// ------------ method called once each job just before starting event loop ------------
-void
-L1TCaloUpgradeToGCTConverter::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop ------------
-void
-L1TCaloUpgradeToGCTConverter::endJob() {
-}
-
-// ------------ method called when starting to processes a run ------------
-
-void
-L1TCaloUpgradeToGCTConverter::beginRun(Run const&iR, EventSetup const&iE){
-
-}
-
-// ------------ method called when ending the processing of a run ------------
-void
-L1TCaloUpgradeToGCTConverter::endRun(Run const& iR, EventSetup const& iE){
-
-}
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.h
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.h
@@ -18,7 +18,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -42,39 +42,30 @@
 
 #include <vector>
 
-using namespace std;
-using namespace edm;
 
 
 //
 // class declaration
 //
 
-  class L1TCaloUpgradeToGCTConverter : public EDProducer {
-  public:
-    explicit L1TCaloUpgradeToGCTConverter(const ParameterSet&);
-    ~L1TCaloUpgradeToGCTConverter();
+class L1TCaloUpgradeToGCTConverter : public edm::global::EDProducer<> {
+public:
+  explicit L1TCaloUpgradeToGCTConverter(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    static void fillDescriptions(ConfigurationDescriptions& descriptions);
+private:
+  virtual void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
-  private:
-    virtual void produce(Event&, EventSetup const&) override;
-    virtual void beginJob();
-    virtual void endJob();
-    virtual void beginRun(Run const&iR, EventSetup const&iE);
-    virtual void endRun(Run const& iR, EventSetup const& iE);
+  const edm::EDGetToken EGammaToken_;
+  const edm::EDGetToken RlxTauToken_;
+  const edm::EDGetToken IsoTauToken_;
+  const edm::EDGetToken JetToken_;
+  const edm::EDGetToken EtSumToken_;
+  const edm::EDGetToken HfSumsToken_;
+  const edm::EDGetToken HfCountsToken_;
 
-    EDGetToken EGammaToken_;
-    EDGetToken RlxTauToken_;
-    EDGetToken IsoTauToken_;
-    EDGetToken JetToken_;
-    EDGetToken EtSumToken_;
-    EDGetToken HfSumsToken_;
-    EDGetToken HfCountsToken_;
-
-    int bxMin_;
-    int bxMax_;
-
-  };
+  const int bxMin_;
+  const int bxMax_;
+};
 
 #endif

--- a/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuTester.h
+++ b/L1TriggerConfig/L1GtConfigProducers/interface/L1GtTriggerMenuTester.h
@@ -30,6 +30,7 @@
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
 #include "CondFormats/L1TObjects/interface/L1GtAlgorithm.h"
+#include "CondFormats/L1TObjects/interface/L1GtTriggerMenu.h"
 #include "CondFormats/L1TObjects/interface/L1GtTriggerMenuFwd.h"
 
 #include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
@@ -38,7 +39,6 @@
 class L1GtStableParameters;
 class L1GtPrescaleFactors;
 class L1GtTriggerMask;
-class L1GtTriggerMenu;
 
 // class declaration
 class L1GtTriggerMenuTester: public edm::EDAnalyzer {
@@ -160,7 +160,7 @@ private:
     const std::vector<unsigned int>* m_triggerMaskVetoTechTrig;
 
     // trigger menu
-    const L1GtTriggerMenu* m_l1GtMenu;
+    std::unique_ptr<L1GtTriggerMenu> m_l1GtMenu;
 
     const AlgorithmMap* m_algorithmMap;
     const AlgorithmMap* m_algorithmAliasMap;

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuTester.cc
@@ -228,13 +228,12 @@ void L1GtTriggerMenuTester::retrieveL1EventSetup(const edm::EventSetup& evSetup)
     // get / update the trigger menu from the EventSetup
 
     edm::ESHandle<L1GtTriggerMenu> l1GtMenu;
-    evSetup.get<L1GtTriggerMenuRcd> ().get(l1GtMenu);
-    m_l1GtMenu = l1GtMenu.product();
-    (const_cast<L1GtTriggerMenu*> (m_l1GtMenu))->buildGtConditionMap();
+    evSetup.get<L1GtTriggerMenuRcd>().get(l1GtMenu);
+    m_l1GtMenu.reset(new L1GtTriggerMenu(*l1GtMenu));
+    m_l1GtMenu->buildGtConditionMap();
 
-    m_algorithmMap = &(m_l1GtMenu->gtAlgorithmMap());
-    m_algorithmAliasMap = &(m_l1GtMenu->gtAlgorithmAliasMap());
-
+    m_algorithmMap        = &(m_l1GtMenu->gtAlgorithmMap());
+    m_algorithmAliasMap   = &(m_l1GtMenu->gtAlgorithmAliasMap());
     m_technicalTriggerMap = &(m_l1GtMenu->gtTechnicalTriggerMap());
 
 }

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtTriggerMenuXmlParser.cc
@@ -2178,7 +2178,7 @@ bool L1GtTriggerMenuXmlParser::parseJetCounts(XERCES_CPP_NAMESPACE::DOMNode* nod
 
     // get countIndex value and fill into structure
     // they are expressed in  base 10  (values: 0 - m_numberL1JetCounts)
-    char* endPtr = const_cast<char*>(type.c_str());
+    char* endPtr = nullptr;
     long int typeInt = strtol(type.c_str(), &endPtr, 10); // base = 10
 
     if (*endPtr != 0) {
@@ -2426,7 +2426,7 @@ bool L1GtTriggerMenuXmlParser::parseHfBitCounts(XERCES_CPP_NAMESPACE::DOMNode* n
 
     // get countIndex value and fill into structure
     // they are expressed in  base 10
-    char* endPtr = const_cast<char*>(type.c_str());
+    char* endPtr = nullptr;
     long int typeInt = strtol(type.c_str(), &endPtr, 10); // base = 10
 
     if (*endPtr != 0) {
@@ -2558,7 +2558,7 @@ bool L1GtTriggerMenuXmlParser::parseHfRingEtSums(XERCES_CPP_NAMESPACE::DOMNode* 
 
     // get etSumIndex value and fill into structure
     // they are expressed in  base 10
-    char* endPtr = const_cast<char*>(type.c_str());
+    char* endPtr = nullptr;
     long int typeInt = strtol(type.c_str(), &endPtr, 10); // base = 10
 
     if (*endPtr != 0) {

--- a/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc
+++ b/L1TriggerConfig/L1GtConfigProducers/src/L1GtVhdlWriterCore.cc
@@ -847,18 +847,14 @@ bool L1GtVhdlWriterCore::processAlgorithmMap(std::vector< std::map<int, std::str
             std::ostringstream newExpr;
             
             // look for the condition on correct chip
-           
-            std::vector<ConditionMap> * conditionMapCp = const_cast< std::vector<ConditionMap>* >(conditionMap_);
-            
-            L1GtCondition* cond = (*conditionMapCp).at((algoIter->second).algoChipNumber())[conditions.at(i)];
+            ConditionMap  const& chip = conditionMap_->at(algoIter->second.algoChipNumber());
+            L1GtCondition const* cond = (chip.find(conditions.at(i)) == chip.end()) ? nullptr : chip.at(conditions.at(i));
 
             // check weather condition exists
             if (cond!=NULL)
             {
-                newExpr<<objType2Str_[(cond->objectType()).at(0)];
-
-                newExpr <<"_" << condType2Str_[cond->condType()] << "(";
-
+                newExpr << objType2Str_[(cond->objectType()).at(0)];
+                newExpr << "_" << condType2Str_[cond->condType()] << "(";
                 newExpr << conditionToIntegerMap_[conditions.at(i)] << ")";
                 dummy.findAndReplaceString(logicalExpr, conditions.at(i),
                         newExpr.str());

--- a/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTNxNClusterProducer.h
+++ b/RecoEgamma/EgammaHLTProducers/interface/EgammaHLTNxNClusterProducer.h
@@ -10,7 +10,7 @@ Description: simple NxN ( 3x3 etc) clustering ,( for low energy photon reconstru
 */
 
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/stream/EDProducer.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/MessageLogger/interface/MessageLogger.h"
@@ -44,7 +44,7 @@ class ecalRecHitSort : public std::binary_function<EcalRecHit, EcalRecHit, bool>
 };
 
 
-class EgammaHLTNxNClusterProducer : public edm::EDProducer {
+class EgammaHLTNxNClusterProducer : public edm::stream::EDProducer<> {
  public:
 
   EgammaHLTNxNClusterProducer(const edm::ParameterSet& ps);

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecalibRecHitProducer.cc
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecalibRecHitProducer.cc
@@ -31,37 +31,26 @@
 
 
 
-EcalRecalibRecHitProducer::EcalRecalibRecHitProducer(const edm::ParameterSet& ps) {
+EcalRecalibRecHitProducer::EcalRecalibRecHitProducer(const edm::ParameterSet& ps) :
+   EBRecHitCollection_(        ps.getParameter<edm::InputTag>("EBRecHitCollection") ),
+   EERecHitCollection_(        ps.getParameter<edm::InputTag>("EERecHitCollection") ),
+   EBRecHitToken_(             (not EBRecHitCollection_.label().empty()) ? consumes<EBRecHitCollection>(EBRecHitCollection_) : edm::EDGetTokenT<EBRecHitCollection>() ),
+   EERecHitToken_(             (not EERecHitCollection_.label().empty()) ? consumes<EERecHitCollection>(EERecHitCollection_) : edm::EDGetTokenT<EERecHitCollection>() ),
+   EBRecalibRecHitCollection_( ps.getParameter<std::string>("EBRecalibRecHitCollection") ),
+   EERecalibRecHitCollection_( ps.getParameter<std::string>("EERecalibRecHitCollection") ),
+   doEnergyScale_(             ps.getParameter<bool>("doEnergyScale") ),
+   doIntercalib_(              ps.getParameter<bool>("doIntercalib") ),
+   doLaserCorrections_(        ps.getParameter<bool>("doLaserCorrections") ),
 
-   EBRecHitCollection_ = ps.getParameter<edm::InputTag>("EBRecHitCollection");
-   EERecHitCollection_ = ps.getParameter<edm::InputTag>("EERecHitCollection");
-   EBRecHitToken_ = consumes<EBRecHitCollection>(EBRecHitCollection_);
-   EERecHitToken_ = consumes<EBRecHitCollection>(EERecHitCollection_);
-   EBRecalibRecHitCollection_        = ps.getParameter<std::string>("EBRecalibRecHitCollection");
-   EERecalibRecHitCollection_        = ps.getParameter<std::string>("EERecalibRecHitCollection");
-   doEnergyScale_             = ps.getParameter<bool>("doEnergyScale");
-   doIntercalib_              = ps.getParameter<bool>("doIntercalib");
-   doLaserCorrections_        = ps.getParameter<bool>("doLaserCorrections");
-
-   doEnergyScaleInverse_             = ps.getParameter<bool>("doEnergyScaleInverse");
-   doIntercalibInverse_ = ps.getParameter<bool>("doIntercalibInverse");
-   doLaserCorrectionsInverse_        = ps.getParameter<bool>("doLaserCorrectionsInverse");
-
-   EBalgo_ = new EcalRecHitSimpleAlgo();
-   EEalgo_ = new EcalRecHitSimpleAlgo();
-
+   doEnergyScaleInverse_(      ps.getParameter<bool>("doEnergyScaleInverse") ),
+   doIntercalibInverse_(       ps.getParameter<bool>("doIntercalibInverse") ),
+   doLaserCorrectionsInverse_( ps.getParameter<bool>("doLaserCorrectionsInverse") )
+{
    produces< EBRecHitCollection >(EBRecalibRecHitCollection_);
    produces< EERecHitCollection >(EERecalibRecHitCollection_);
 }
 
-EcalRecalibRecHitProducer::~EcalRecalibRecHitProducer() {
-
-  if (EBalgo_) delete EBalgo_;
-  if (EEalgo_) delete EEalgo_;
-
-}
-
-void EcalRecalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& es)
+void EcalRecalibRecHitProducer::produce(edm::StreamID sid, edm::Event& evt, const edm::EventSetup& es) const
 {
         using namespace edm;
         Handle< EBRecHitCollection > pEBRecHits;
@@ -70,11 +59,11 @@ void EcalRecalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& 
         const EBRecHitCollection*  EBRecHits = 0;
         const EERecHitCollection*  EERecHits = 0; 
 
-	if ( EBRecHitCollection_.label() != "" ) {
+	if (not EBRecHitCollection_.label().empty()) {
 	  evt.getByToken( EBRecHitToken_, pEBRecHits);
 	  EBRecHits = pEBRecHits.product(); // get a ptr to the product
 	}
-	if ( EERecHitCollection_.label() != "" ) { 
+	if (not EERecHitCollection_.label().empty()) { 
 	  evt.getByToken( EERecHitToken_, pEERecHits);
 	  EERecHits = pEERecHits.product(); // get a ptr to the product
 	}
@@ -174,10 +163,6 @@ void EcalRecalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& 
                                 lasercalib = pLaser->getLaserCorrection( EEDetId(it->id()), evt.time() );
                         }
 
-                        // make the rechit and put in the output collection
-                        // must implement op= for EcalRecHit
-                        //EcalRecHit aHit( EEalgo_->makeRecHit(*it, icalconst * lasercalib) );
-
 			if(doIntercalibInverse_){
 			  icalconst = 1.0/icalconst;
 			}
@@ -185,6 +170,7 @@ void EcalRecalibRecHitProducer::produce(edm::Event& evt, const edm::EventSetup& 
 			  lasercalib = 1.0/lasercalib;
 			}
 			
+                        // make the rechit and put in the output collection
                         EcalRecHit aHit( (*it).id(), (*it).energy() * agc_ee * icalconst * lasercalib, (*it).time() );
                         EERecalibRecHits->push_back( aHit );
                 }

--- a/RecoLocalCalo/EcalRecProducers/plugins/EcalRecalibRecHitProducer.h
+++ b/RecoLocalCalo/EcalRecProducers/plugins/EcalRecalibRecHitProducer.h
@@ -7,7 +7,7 @@
  *
  **/
 
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/EventSetup.h"
@@ -17,31 +17,26 @@
 
 
 
-class EcalRecalibRecHitProducer : public edm::EDProducer {
+class EcalRecalibRecHitProducer : public edm::global::EDProducer<> {
 
         public:
                 explicit EcalRecalibRecHitProducer(const edm::ParameterSet& ps);
-                ~EcalRecalibRecHitProducer();
-                virtual void produce(edm::Event& evt, const edm::EventSetup& es);
+                virtual void produce(edm::StreamID sid, edm::Event& evt, const edm::EventSetup& es) const override;
 
         private:
-
-		edm::InputTag EBRecHitCollection_;
-		edm::InputTag EERecHitCollection_;
-		edm::EDGetTokenT<EBRecHitCollection> EBRecHitToken_;
-		edm::EDGetTokenT<EERecHitCollection> EERecHitToken_;
+		const edm::InputTag EBRecHitCollection_;
+		const edm::InputTag EERecHitCollection_;
+		const edm::EDGetTokenT<EBRecHitCollection> EBRecHitToken_;
+		const edm::EDGetTokenT<EERecHitCollection> EERecHitToken_;
 		  
-                std::string EBRecalibRecHitCollection_; // secondary name to be given to EB collection of hits
-                std::string EERecalibRecHitCollection_; // secondary name to be given to EE collection of hits
+                const std::string EBRecalibRecHitCollection_; // secondary name to be given to EB collection of hits
+                const std::string EERecalibRecHitCollection_; // secondary name to be given to EE collection of hits
 
-                bool doEnergyScale_;
-                bool doIntercalib_;
-                bool doLaserCorrections_;
-		bool doEnergyScaleInverse_;
-		bool doIntercalibInverse_;
-                bool doLaserCorrectionsInverse_;
-
-                EcalRecHitAbsAlgo* EBalgo_;
-                EcalRecHitAbsAlgo* EEalgo_;
+                const bool doEnergyScale_;
+                const bool doIntercalib_;
+                const bool doLaserCorrections_;
+		const bool doEnergyScaleInverse_;
+		const bool doIntercalibInverse_;
+                const bool doLaserCorrectionsInverse_;
 };
 #endif


### PR DESCRIPTION
migrate the following modules to be `stream` or `global` modules:
- EcalRecalibRecHitProducer
- EgammaHLTNxNClusterProducer
- HLTRegionalEcalResonanceFilter
- IPTCorrector
- IsolatedEcalPixelTrackCandidateProducer
- IsolatedPixelTrackCandidateProducer
- L1GlobalTrigger
- L1TCaloUpgradeToGCTConverter
- LaserAlignmentEventFilter
- TriggerResultsFilter
- TriggerResultsFilterFromDB
