### PR TITLE
Transform RecoTrackRefSelector to stream::EDProducer

### DIFF
--- a/CommonTools/RecoAlgos/plugins/RecoTrackRefSelector.cc
+++ b/CommonTools/RecoAlgos/plugins/RecoTrackRefSelector.cc
@@ -10,12 +10,12 @@
  *
  */
 #include "FWCore/Framework/interface/MakerMacros.h"
-#include "CommonTools/UtilAlgos/interface/ObjectSelectorStream.h"
+#include "CommonTools/UtilAlgos/interface/ObjectSelectorStreamProducer.h"
 //#include "CommonTools/RecoAlgos/interface/TrackSelector.h"
 #include "CommonTools/RecoAlgos/interface/RecoTrackRefSelector.h"
 #include "DataFormats/TrackReco/interface/TrackFwd.h"
 
 namespace reco {
-  typedef ObjectSelectorStream<RecoTrackRefSelector,reco::TrackRefVector> RecoTrackRefSelector;
+  typedef ObjectSelectorStreamProducer<RecoTrackRefSelector,reco::TrackRefVector> RecoTrackRefSelector;
   DEFINE_FWK_MODULE(RecoTrackRefSelector);
 }

--- a/CommonTools/RecoAlgos/python/recoTrackRefSelector_cfi.py
+++ b/CommonTools/RecoAlgos/python/recoTrackRefSelector_cfi.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from CommonTools.RecoAlgos.recoTrackSelectorPSet_cfi import recoTrackSelectorPSet as _recoTrackSelectorPSet
 
-recoTrackRefSelector = cms.EDFilter("RecoTrackRefSelector",
+recoTrackRefSelector = cms.EDProducer("RecoTrackRefSelector",
     _recoTrackSelectorPSet
 )
 

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -128,6 +128,13 @@ def customiseFor10927(process):
             process.DTObjectMapESProducer = cms.ESProducer( 'DTObjectMapESProducer' )
     return process
 
+# change RecoTrackRefSelector to stream::EDProducer (PR #10911)
+def customiseFor10911(process):
+    if hasattr(process,'hltBSoftMuonMu5L3'):
+        # Switch module type from EDFilter to EDProducer
+        process.hltBSoftMuonMu5L3 = cms.EDProducer("RecoTrackRefSelector", **process.hltBSoftMuonMu5L3.parameters_())
+    return process
+
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     import os
@@ -135,6 +142,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
 
     if cmsswVersion >= "CMSSW_7_6":
         process = customiseFor10418(process)
+        process = customiseFor10911(process)
     if cmsswVersion >= "CMSSW_7_5":
         process = customiseFor10927(process)
         process = customiseFor9232(process)


### PR DESCRIPTION
This PR changes RecoTrackRefSelector to a stream::EDProducer (using ObjectSelectorStreamProducer introduced in #9904). (for history, the PR first contained only a simple transformation to stream::EDFilter, but was then extended to contain the change to producer as there we re no use cases for event filtering)

Tested in 7_6_0_pre3, no changes expected in results.

@rovere @VinInn @fwyzard 
