### PR TITLE
Add L1 prescales to the miniAOD (75X port of #10895)

### DIFF
--- a/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
+++ b/PhysicsTools/PatAlgos/plugins/PATTriggerProducer.cc
@@ -197,6 +197,8 @@ PATTriggerProducer::PATTriggerProducer( const ParameterSet & iConfig ) :
   }
   if (packPrescales_) {
     produces< PackedTriggerPrescales >();
+    produces< PackedTriggerPrescales >("l1max");
+    produces< PackedTriggerPrescales >("l1min");
   }
   produces< TriggerObjectStandAloneCollection >();
 
@@ -317,7 +319,7 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
 
   std::auto_ptr< TriggerObjectCollection > triggerObjects( new TriggerObjectCollection() );
   std::auto_ptr< TriggerObjectStandAloneCollection > triggerObjectsStandAlone( new TriggerObjectStandAloneCollection() );
-  std::auto_ptr< PackedTriggerPrescales > packedPrescales;
+  std::auto_ptr< PackedTriggerPrescales > packedPrescales, packedPrescalesL1min, packedPrescalesL1max;
 
   // HLT
   HLTConfigProvider const&  hltConfig = hltPrescaleProvider_.hltConfigProvider();
@@ -564,11 +566,32 @@ void PATTriggerProducer::produce( Event& iEvent, const EventSetup& iSetup )
 
     if (packPrescales_) {
         packedPrescales.reset(new PackedTriggerPrescales(handleTriggerResults)); 
+        packedPrescalesL1min.reset(new PackedTriggerPrescales(handleTriggerResults)); 
+        packedPrescalesL1max.reset(new PackedTriggerPrescales(handleTriggerResults)); 
         const edm::TriggerNames & names = iEvent.triggerNames(*handleTriggerResults);
+        //std::cout << "Run " << iEvent.id().run() << ", LS " << iEvent.id().luminosityBlock() << ": pset " << set << std::endl;
         for (unsigned int i = 0, n = names.size(); i < n; ++i) {
-            packedPrescales->addPrescaledTrigger(i, hltConfig.prescaleValue(set, names.triggerName(i)));
+            auto pvdet = hltPrescaleProvider_.prescaleValuesInDetail( iEvent, iSetup, names.triggerName(i) );
+            //int hltprescale = hltConfig_.prescaleValue(set, names.triggerName(i));
+            if (pvdet.first.empty()) {
+                packedPrescalesL1max->addPrescaledTrigger(i, 1);
+                packedPrescalesL1min->addPrescaledTrigger(i, 1);
+            } else {
+                int pmin = -1, pmax = -1;
+                for (const auto & p : pvdet.first) {
+                    pmax = std::max(pmax, p.second);
+                    if (p.second > 0 && (pmin == -1 || pmin > p.second)) pmin = p.second;
+                }
+                packedPrescalesL1max->addPrescaledTrigger(i, pmax);
+                packedPrescalesL1min->addPrescaledTrigger(i, pmin);
+                //std::cout << "\tTrigger " << names.triggerName(i) << ", L1 ps " << pmin << "-" << pmax << ", HLT ps " << hltprescale << std::endl;
+            }
+            packedPrescales->addPrescaledTrigger(i, pvdet.second);
+            //assert( hltprescale == pvdet.second );
         }
         iEvent.put( packedPrescales );
+        iEvent.put( packedPrescalesL1max, "l1max" );
+        iEvent.put( packedPrescalesL1min, "l1min" );
     }
 
   } // if ( goodHlt )

--- a/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/MicroEventContent_cff.py
@@ -40,6 +40,8 @@ MicroEventContent = cms.PSet(
 
         'keep *_selectedPatTrigger_*_*',
         'keep patPackedTriggerPrescales_patTrigger__*',
+        'keep patPackedTriggerPrescales_patTrigger_l1max_*',
+        'keep patPackedTriggerPrescales_patTrigger_l1min_*',
         'keep *_l1extraParticles_*_*',
         'keep L1GlobalTriggerReadoutRecord_gtDigis_*_*',
         'keep *_TriggerResults_*_HLT',


### PR DESCRIPTION
Add L1 prescales to the miniAOD (75X port of #10895)
Tested with Matrix 135.4,1330.0,4.53,134.71
Note that 1000.0 and 1001.0 DAS failures in the Matrix seem to be legitimate, i.e. that Run2011A RAW data seems not to be at  T2_CH_CERN anymore.
