### PR TITLE
Switch to latest pileup jet id in DQM

### DIFF
--- a/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
+++ b/DQMOffline/JetMET/python/jetAnalyzer_cfi.py
@@ -59,9 +59,9 @@ jetDQMAnalyzerAk4CaloUncleaned = cms.EDAnalyzer("JetAnalyzer",
     JetIDVersion               = cms.string("PURE09"),
     #
     #actually done only for PFJets at the moment
-    InputMVAPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","full53xDiscriminant"),
+    InputMVAPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","fullDiscriminant"),
     InputCutPUIDDiscriminant = cms.InputTag("pileupJetIdEvaluatorDQM","cutbasedDiscriminant"),
-    InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","full53xId"),
+    InputMVAPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","fullId"),
     InputCutPUIDValue = cms.InputTag("pileupJetIdEvaluatorDQM","cutbasedId"),
 
     InputQGMultiplicity = cms.InputTag("QGTagger", "mult"),

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSourceMC_cff.py
@@ -20,7 +20,6 @@ pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
 pileupJetIdEvaluatorDQM=pileupJetIdEvaluator.clone(
     jets = cms.InputTag("ak4PFJets"),
     jetids = cms.InputTag("pileupJetIdCalculatorDQM"),
-    algos = cms.VPSet(cms.VPSet(full_53x,cutbased)),
     jec = cms.string("AK4PF"),
     applyJec = cms.bool(True),
     inputIsCorrected = cms.bool(False)
@@ -33,7 +32,6 @@ pileupJetIdCalculatorCHSDQM=pileupJetIdCalculator.clone(
 
 pileupJetIdEvaluatorCHSDQM=pileupJetIdEvaluator.clone(
     jetids = cms.InputTag("pileupJetIdCalculatorCHSDQM"),
-    algos = cms.VPSet(cms.VPSet(full_53x_chs,cutbased)),
     applyJec = cms.bool(True),
     inputIsCorrected = cms.bool(False)
     )

--- a/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
+++ b/DQMOffline/JetMET/python/jetMETDQMOfflineSource_cff.py
@@ -19,7 +19,6 @@ pileupJetIdCalculatorDQM=pileupJetIdCalculator.clone(
 pileupJetIdEvaluatorDQM=pileupJetIdEvaluator.clone(
     jets = cms.InputTag("ak4PFJets"),
     jetids = cms.InputTag("pileupJetIdCalculatorDQM"),
-    algos = cms.VPSet(cms.VPSet(full_53x,cutbased)),
     jec = cms.string("AK4PF"),
     applyJec = cms.bool(True),
     inputIsCorrected = cms.bool(False)
@@ -32,7 +31,6 @@ pileupJetIdCalculatorCHSDQM=pileupJetIdCalculator.clone(
 
 pileupJetIdEvaluatorCHSDQM=pileupJetIdEvaluator.clone(
     jetids = cms.InputTag("pileupJetIdCalculatorCHSDQM"),
-    algos = cms.VPSet(cms.VPSet(full_53x_chs,cutbased)),
     applyJec = cms.bool(True),
     inputIsCorrected = cms.bool(False)
     )


### PR DESCRIPTION
Switch DQM to validate the latest available pileup jet ID training instead of the 53X training.
