### PR TITLE
Fix checksum error for ROOT5

### DIFF
--- a/DataFormats/PatCandidates/src/classes_def_objects.xml
+++ b/DataFormats/PatCandidates/src/classes_def_objects.xml
@@ -271,7 +271,9 @@
    <version ClassVersion="11" checksum="1239840459"/>
   </class>
 
-  <class name="pat::PackedCandidate" ClassVersion="19">
+  <class name="pat::PackedCandidate" ClassVersion="23">
+    <version ClassVersion="23" checksum="663492232"/>
+    <version ClassVersion="21" checksum="1075665714"/>
     <version ClassVersion="20" checksum="2078702780"/>
     <version ClassVersion="19" checksum="359155190"/>
     <version ClassVersion="18" checksum="4275117305"/>


### PR DESCRIPTION
Fix checksum error in the build of CMSSW_7_5_ROOT5_X.
Also make new ROOT6 checksum known to ROOT5.
Technical and trivial.
Please expedite.
The new ROOT5 checksum will be made known to CMSSW_7_5_X in a separate PR.
