### PR TITLE
Thread safe StorageAccounting

### DIFF
--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -331,21 +331,21 @@ CondorStatusService::updateImpl(time_t sinceLastUpdate)
         if (storage.first == "tstoragefile") {continue;}
         for (const auto & counter : storage.second)
         {
-            if (counter.first == "read")
+            if (counter.first == static_cast<int>(StorageAccount::Operation::read))
             {
                 readOps += counter.second.successes;
                 readSegs++;
                 readBytes += counter.second.amount;
                 readTimeTotal += counter.second.timeTotal;
             }
-            else if (counter.first == "readv")
+            else if (counter.first == static_cast<int>(StorageAccount::Operation::readv))
             {
                 readVOps += counter.second.successes;
                 readSegs += counter.second.vector_count;
                 readBytes += counter.second.amount;
                 readTimeTotal += counter.second.timeTotal;
             }
-            else if ((counter.first == "write") || (counter.first == "writev"))
+            else if ((counter.first == static_cast<int>(StorageAccount::Operation::write)) || (counter.first == static_cast<int>(StorageAccount::Operation::writev)))
             {
                 writeBytes += counter.second.amount;
                 writeTimeTotal += counter.second.timeTotal;

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -322,13 +322,14 @@ CondorStatusService::updateImpl(time_t sinceLastUpdate)
     uint64_t readTimeTotal = 0;
     uint64_t writeBytes = 0;
     uint64_t writeTimeTotal = 0;
+    const auto token = StorageAccount::tokenForStorageClassName("tstoragefile");
     for (const auto & storage : stats)
     {
         // StorageAccount records statistics for both the TFile layer and the
         // StorageFactory layer.  However, the StorageFactory statistics tend to
         // be more accurate as various backends may alter the incoming read requests
         // (such as when lazy-download is used).
-        if (storage.first == "tstoragefile") {continue;}
+        if (storage.first == token.value()) {continue;}
         for (const auto & counter : storage.second)
         {
             if (counter.first == static_cast<int>(StorageAccount::Operation::read))

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -329,7 +329,7 @@ CondorStatusService::updateImpl(time_t sinceLastUpdate)
         // be more accurate as various backends may alter the incoming read requests
         // (such as when lazy-download is used).
         if (storage.first == "tstoragefile") {continue;}
-        for (const auto & counter : *(storage.second))
+        for (const auto & counter : storage.second)
         {
             if (counter.first == "read")
             {

--- a/FWCore/Services/plugins/CondorStatusUpdater.cc
+++ b/FWCore/Services/plugins/CondorStatusUpdater.cc
@@ -314,7 +314,7 @@ CondorStatusService::updateImpl(time_t sinceLastUpdate)
     }
 
     // Update storage account information
-    StorageAccount::StorageStatsSentry stats = StorageAccount::summaryLocked();
+    auto const& stats = StorageAccount::summary();
     uint64_t readOps = 0;
     uint64_t readVOps = 0;
     uint64_t readSegs = 0;
@@ -322,7 +322,7 @@ CondorStatusService::updateImpl(time_t sinceLastUpdate)
     uint64_t readTimeTotal = 0;
     uint64_t writeBytes = 0;
     uint64_t writeTimeTotal = 0;
-    for (const auto & storage : *stats)
+    for (const auto & storage : stats)
     {
         // StorageAccount records statistics for both the TFile layer and the
         // StorageFactory layer.  However, the StorageFactory statistics tend to

--- a/GeneratorInterface/LHEInterface/src/LHEReader.cc
+++ b/GeneratorInterface/LHEInterface/src/LHEReader.cc
@@ -51,7 +51,7 @@ class LHEReader::FileSource : public LHEReader::Source {
     public:
 	FileSource(const std::string &fileURL)
 	{
-		Storage *storage =
+		auto storage =
 			StorageFactory::get()->open(fileURL,
 			                            IOFlags::OpenRead);
 
@@ -61,7 +61,7 @@ class LHEReader::FileSource : public LHEReader::Source {
 				<< fileURL << "\" for reading"
 				<< std::endl;
 
-		fileStream.reset(new StorageWrap(storage));
+		fileStream.reset(new StorageWrap(std::move(storage)));
 	}
 
 	~FileSource() {}

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.cc
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.cc
@@ -22,8 +22,8 @@ XERCES_CPP_NAMESPACE_USE
 
 namespace lhef {
 
-StorageWrap::StorageWrap(Storage *storage) :
-	storage(storage)
+StorageWrap::StorageWrap(std::unique_ptr<Storage> storage) :
+	storage(std::move(storage))
 {
 }
 

--- a/GeneratorInterface/LHEInterface/src/XMLUtils.h
+++ b/GeneratorInterface/LHEInterface/src/XMLUtils.h
@@ -22,14 +22,14 @@ namespace lhef {
 
 class StorageWrap {
     public:
-	StorageWrap(Storage *storage);
+	StorageWrap(std::unique_ptr<Storage> storage);
 	~StorageWrap();
 
 	Storage *operator -> () { return storage.get(); }
 	const Storage *operator -> () const { return storage.get(); }
 
     private:
-	std::auto_ptr<Storage>	storage;
+	std::unique_ptr<Storage>	storage;
 };
 
 class XMLDocument {

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -263,7 +263,7 @@ namespace edm {
         usedFallback_ = true;
         std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? new InputSource::FileOpenSentry(*input, lfn_, usedFallback_) : nullptr);
         std::string fallbackFullName = gSystem->ExpandPathName(fallbackFileName().c_str());
-        StorageFactory *factory = StorageFactory::get();
+        StorageFactory *factory = StorageFactory::getToModify();
         if (factory) {factory->activateTimeout(fallbackFullName);}
         filePtr.reset(new InputFile(fallbackFullName.c_str(), "  Fallback request to file ", inputType));
       }

--- a/IOPool/Input/src/RootInputFileSequence.cc
+++ b/IOPool/Input/src/RootInputFileSequence.cc
@@ -263,8 +263,6 @@ namespace edm {
         usedFallback_ = true;
         std::unique_ptr<InputSource::FileOpenSentry> sentry(input ? new InputSource::FileOpenSentry(*input, lfn_, usedFallback_) : nullptr);
         std::string fallbackFullName = gSystem->ExpandPathName(fallbackFileName().c_str());
-        StorageFactory *factory = StorageFactory::getToModify();
-        if (factory) {factory->activateTimeout(fallbackFullName);}
         filePtr.reset(new InputFile(fallbackFullName.c_str(), "  Fallback request to file ", inputType));
       }
       catch (cms::Exception const& e) {

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -63,7 +63,7 @@ namespace edm {
     std::string branchesMustMatch = pset.getUntrackedParameter<std::string>("branchesMustMatch", std::string("permissive"));
     if(branchesMustMatch == std::string("strict")) branchesMustMatch_ = BranchDescription::Strict;
 
-    StorageFactory *factory = StorageFactory::get();
+    StorageFactory *factory = StorageFactory::getToModify();
 
     // Prestage the files
     for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {

--- a/IOPool/Input/src/RootPrimaryFileSequence.cc
+++ b/IOPool/Input/src/RootPrimaryFileSequence.cc
@@ -63,12 +63,9 @@ namespace edm {
     std::string branchesMustMatch = pset.getUntrackedParameter<std::string>("branchesMustMatch", std::string("permissive"));
     if(branchesMustMatch == std::string("strict")) branchesMustMatch_ = BranchDescription::Strict;
 
-    StorageFactory *factory = StorageFactory::getToModify();
-
     // Prestage the files
     for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {
-      factory->activateTimeout(fileName());
-      factory->stagein(fileName());
+      StorageFactory::get()->stagein(fileName());
     }
     // Open the first file.
     for (setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -50,7 +50,7 @@ namespace edm {
       enablePrefetching_ = pSLC->enablePrefetching();
     }
 
-    StorageFactory *factory = StorageFactory::get();
+    StorageFactory *factory = StorageFactory::getToModify();
 
     // Prestage the files
     //NOTE: we do not want to stage in all secondary files since we can be given a list of

--- a/IOPool/Input/src/RootSecondaryFileSequence.cc
+++ b/IOPool/Input/src/RootSecondaryFileSequence.cc
@@ -50,15 +50,12 @@ namespace edm {
       enablePrefetching_ = pSLC->enablePrefetching();
     }
 
-    StorageFactory *factory = StorageFactory::getToModify();
-
     // Prestage the files
     //NOTE: we do not want to stage in all secondary files since we can be given a list of
     // thousands of files and prestaging all those files can cause a site to fail.
     // So, we stage in the first secondary file only.
     setAtFirstFile();
-    factory->activateTimeout(fileName());
-    factory->stagein(fileName());
+    StorageFactory::get()->stagein(fileName());
 
     // Open the first file.
     for(setAtFirstFile(); !noMoreFiles(); setAtNextFile()) {

--- a/IOPool/Streamer/interface/StreamerInputFile.h
+++ b/IOPool/Streamer/interface/StreamerInputFile.h
@@ -75,7 +75,7 @@ namespace edm {
 
     bool newHeader_;
 
-    std::shared_ptr<Storage> storage_;
+    std::unique_ptr<Storage> storage_;
 
     bool endOfFile_;
   };

--- a/IOPool/Streamer/src/StreamerInputFile.cc
+++ b/IOPool/Streamer/src/StreamerInputFile.cc
@@ -74,8 +74,8 @@ namespace edm {
     IOOffset size = -1;
     if(StorageFactory::get()->check(name.c_str(), &size)) {
       try {
-        storage_.reset(StorageFactory::get()->open(name.c_str(),
-                                                   IOFlags::OpenRead));
+        storage_ =StorageFactory::get()->open(name.c_str(),
+                                                   IOFlags::OpenRead);
       }
       catch(cms::Exception& e) {
         Exception ex(errors::FileOpenError, "", e);

--- a/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
+++ b/IOPool/TFileAdaptor/interface/TStorageFactoryFile.h
@@ -2,6 +2,7 @@
 # define TFILE_ADAPTOR_TSTORAGE_FACTORY_FILE_H
 
 # include <vector>
+# include <memory>
 
 # include "TFile.h"
 
@@ -53,7 +54,7 @@ private:
 
   TStorageFactoryFile(void);
 
-  Storage		*storage_;		//< Real underlying storage
+  std::unique_ptr<Storage>	storage_;		//< Real underlying storage
 };
 
 #endif // TFILE_ADAPTOR_TSTORAGE_FACTORY_FILE_H

--- a/IOPool/TFileAdaptor/src/TFileAdaptor.cc
+++ b/IOPool/TFileAdaptor/src/TFileAdaptor.cc
@@ -91,7 +91,7 @@
     if (!(enabled_ = pset.getUntrackedParameter<bool> ("enable", enabled_)))
       return;
 
-    StorageFactory* f = StorageFactory::get();
+    StorageFactory* f = StorageFactory::getToModify();
     doStats_ = pset.getUntrackedParameter<bool> ("stats", doStats_);
 
     // values set in the site local config or in SiteLocalConfigService override

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -87,16 +87,16 @@ static StorageAccount::Counter *s_statsXWrite = 0;
 
 
 static inline StorageAccount::Counter &
-storageCounter(StorageAccount::Counter *&c, const char *label)
+storageCounter(StorageAccount::Counter *&c, StorageAccount::Operation operation)
 {
-  if (! c) c = &StorageAccount::counter("tstoragefile", label);
+  if (! c) c = &StorageAccount::counter("tstoragefile", operation);
   return *c;
 }
 
 TStorageFactoryFile::TStorageFactoryFile(void)
   : storage_()
 {
-  StorageAccount::Stamp stats(storageCounter(s_statsCtor, "construct"));
+  StorageAccount::Stamp stats(storageCounter(s_statsCtor, StorageAccount::Operation::construct));
   stats.tick(0);
 }
 
@@ -138,7 +138,7 @@ void
 TStorageFactoryFile::Initialize(const char *path,
                                 Option_t *option /* = "" */)
 {
-  StorageAccount::Stamp stats(storageCounter(s_statsCtor, "construct"));
+  StorageAccount::Stamp stats(storageCounter(s_statsCtor, StorageAccount::Operation::construct));
 
   // Enable AsyncReading.
   // This was the default for 5.27, but turned off by default for 5.32.
@@ -263,7 +263,7 @@ TStorageFactoryFile::ReadBuffer(char *buf, Int_t len)
   // cache, "readu" indicates how much we failed to read from the
   // cache (excluding those recursive reads), and "readx" counts
   // the amount actually passed to read from the storage object.
-  StorageAccount::Stamp stats(storageCounter(s_statsRead, "read"));
+  StorageAccount::Stamp stats(storageCounter(s_statsRead, StorageAccount::Operation::read));
 
   // If we have a cache, read from there first.  This returns 0
   // if the block hasn't been prefetched, 1 if it was in cache,
@@ -274,8 +274,8 @@ TStorageFactoryFile::ReadBuffer(char *buf, Int_t len)
     Bool_t   async = c->IsAsyncReading();
 
     StorageAccount::Stamp cstats(async
-                                 ? storageCounter(s_statsCPrefetch, "readPrefetchToCache")
-                                 : storageCounter(s_statsCRead, "readViaCache"));
+                                 ? storageCounter(s_statsCPrefetch, StorageAccount::Operation::readPrefetchToCache)
+                                 : storageCounter(s_statsCRead, StorageAccount::Operation::readViaCache));
 
     Int_t st = ReadBufferViaCache(async ? 0 : buf, len);
 
@@ -299,7 +299,7 @@ TStorageFactoryFile::ReadBuffer(char *buf, Int_t len)
   // if (! st) storage_->caching(true, -1, s_readahead);
 
   // A real read
-  StorageAccount::Stamp xstats(storageCounter(s_statsXRead, "readActual"));
+  StorageAccount::Stamp xstats(storageCounter(s_statsXRead, StorageAccount::Operation::readActual));
   IOSize n = storage_->xread(buf, len);
   xstats.tick(n);
   stats.tick(n);
@@ -322,7 +322,7 @@ TStorageFactoryFile::ReadBufferAsync(Long64_t off, Int_t len)
     return kTRUE;
   }
 
-  StorageAccount::Stamp stats(storageCounter(s_statsARead, "readAsync"));
+  StorageAccount::Stamp stats(storageCounter(s_statsARead, StorageAccount::Operation::readAsync));
 
   // If asynchronous reading is disabled, bail out now, regardless
   // whether the underlying storage supports prefetching.  If it is
@@ -405,7 +405,7 @@ TStorageFactoryFile::ReadBuffersSync(char *buf, Long64_t *pos, Int_t *len, Int_t
     IOSize io_buffer_used = repacker.bufferUsed();
 
     // Issue readv, then unpack buffers.
-    StorageAccount::Stamp xstats(storageCounter(s_statsXRead, "readActual"));
+    StorageAccount::Stamp xstats(storageCounter(s_statsXRead, StorageAccount::Operation::readActual));
     std::vector<IOPosBuffer> &iov = repacker.iov();
     IOSize result = storage_->readv(&iov[0], iov.size());
     if (result != io_buffer_used) {
@@ -465,7 +465,7 @@ TStorageFactoryFile::ReadBuffers(char *buf, Long64_t *pos, Int_t *len, Int_t nbu
 
   // Null buffer means asynchronous reads into I/O system's cache.
   bool success;
-  StorageAccount::Stamp astats(storageCounter(s_statsARead, "readAsync"));
+  StorageAccount::Stamp astats(storageCounter(s_statsARead, StorageAccount::Operation::readAsync));
   // Synchronise low-level cache with the supposed cache in TFile.
   // storage_->caching(true, -1, 0);
   success = storage_->prefetch(&iov[0], nbuf);
@@ -497,8 +497,8 @@ TStorageFactoryFile::WriteBuffer(const char *buf, Int_t len)
     return kTRUE;
   }
 
-  StorageAccount::Stamp stats(storageCounter(s_statsWrite, "write"));
-  StorageAccount::Stamp cstats(storageCounter(s_statsCWrite, "writeViaCache"));
+  StorageAccount::Stamp stats(storageCounter(s_statsWrite, StorageAccount::Operation::write));
+  StorageAccount::Stamp cstats(storageCounter(s_statsCWrite, StorageAccount::Operation::writeViaCache));
 
   // Try first writing via a cache, and if that's not possible, directly.
   Int_t st;
@@ -507,7 +507,7 @@ TStorageFactoryFile::WriteBuffer(const char *buf, Int_t len)
   case 0:
     // Actual write.
     {
-      StorageAccount::Stamp xstats(storageCounter(s_statsXWrite, "writeActual"));
+      StorageAccount::Stamp xstats(storageCounter(s_statsXWrite, StorageAccount::Operation::writeActual));
       IOSize n = storage_->xwrite(buf, len);
       xstats.tick(n);
       stats.tick(n);
@@ -541,7 +541,7 @@ TStorageFactoryFile::WriteBuffer(const char *buf, Int_t len)
 Int_t
 TStorageFactoryFile::SysOpen(const char *pathname, Int_t flags, UInt_t /* mode */)
 {
-  StorageAccount::Stamp stats(storageCounter(s_statsOpen, "open"));
+  StorageAccount::Stamp stats(storageCounter(s_statsOpen, StorageAccount::Operation::open));
 
   if (storage_)
   {
@@ -572,7 +572,7 @@ TStorageFactoryFile::SysOpen(const char *pathname, Int_t flags, UInt_t /* mode *
 Int_t
 TStorageFactoryFile::SysClose(Int_t /* fd */)
 {
-  StorageAccount::Stamp stats(storageCounter(s_statsClose, "close"));
+  StorageAccount::Stamp stats(storageCounter(s_statsClose, StorageAccount::Operation::close));
 
   if (storage_)
   {
@@ -587,7 +587,7 @@ TStorageFactoryFile::SysClose(Int_t /* fd */)
 Long64_t
 TStorageFactoryFile::SysSeek(Int_t /* fd */, Long64_t offset, Int_t whence)
 {
-  StorageAccount::Stamp stats(storageCounter(s_statsSeek, "seek"));
+  StorageAccount::Stamp stats(storageCounter(s_statsSeek, StorageAccount::Operation::seek));
   Storage::Relative rel = (whence == SEEK_SET ? Storage::SET
                                : whence == SEEK_CUR ? Storage::CURRENT
                                : Storage::END);
@@ -600,7 +600,7 @@ TStorageFactoryFile::SysSeek(Int_t /* fd */, Long64_t offset, Int_t whence)
 Int_t
 TStorageFactoryFile::SysSync(Int_t /* fd */)
 {
-  StorageAccount::Stamp stats(storageCounter(s_statsFlush, "flush"));
+  StorageAccount::Stamp stats(storageCounter(s_statsFlush, StorageAccount::Operation::flush));
   storage_->flush();
   stats.tick();
   return 0;
@@ -610,7 +610,7 @@ Int_t
 TStorageFactoryFile::SysStat(Int_t /* fd */, Long_t *id, Long64_t *size,
                              Long_t *flags, Long_t *modtime)
 {
-  StorageAccount::Stamp stats(storageCounter(s_statsStat, "stat"));
+  StorageAccount::Stamp stats(storageCounter(s_statsStat, StorageAccount::Operation::stat));
   // FIXME: Most of this is unsupported or makes no sense with Storage
   *id = ::Hash(fRealName);
   *size = storage_->size();

--- a/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
+++ b/IOPool/TFileAdaptor/src/TStorageFactoryFile.cc
@@ -89,7 +89,8 @@ static StorageAccount::Counter *s_statsXWrite = 0;
 static inline StorageAccount::Counter &
 storageCounter(StorageAccount::Counter *&c, StorageAccount::Operation operation)
 {
-  if (! c) c = &StorageAccount::counter("tstoragefile", operation);
+  static const auto token = StorageAccount::tokenForStorageClassName("tstoragefile");
+  if (! c) c = &StorageAccount::counter(token, operation);
   return *c;
 }
 

--- a/IORawData/SiPixelInputSources/src/PixelSLinkDataInputSource.cc
+++ b/IORawData/SiPixelInputSources/src/PixelSLinkDataInputSource.cc
@@ -135,7 +135,7 @@ PixelSLinkDataInputSource::PixelSLinkDataInputSource(const edm::ParameterSet& ps
   m_fileindex++;
   // reading both castor and other ('normal'/dcap) files.
   IOOffset size = -1;
-  StorageFactory::get()->enableAccounting(true);
+  StorageFactory::getToModify()->enableAccounting(true);
     
   edm::LogInfo("PixelSLinkDataInputSource") << " unsigned long int size = " << sizeof(unsigned long int) <<"\n unsigned long size = " << sizeof(unsigned long)<<"\n unsigned long long size = " << sizeof(unsigned long long) <<  "\n uint32_t size = " << sizeof(uint32_t) << "\n uint64_t size = " << sizeof(uint64_t) << std::endl;
 
@@ -148,7 +148,7 @@ PixelSLinkDataInputSource::PixelSLinkDataInputSource(const edm::ParameterSet& ps
     return;
   }
   // now open the file stream:
-  storage.reset(StorageFactory::get()->open(currentfilename.c_str()));
+  storage =StorageFactory::get()->open(currentfilename.c_str());
   // (throw if storage is 0)
 
   // check run number by opening up data file...

--- a/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
+++ b/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
@@ -29,11 +29,11 @@ public:
 
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode) override
   {
-    StorageFactory *f = StorageFactory::get();
+    const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
     StorageFactory::CacheHint cacheHint = f->cacheHint();
 
@@ -43,8 +43,8 @@ public:
     else
       mode |= IOFlags::OpenUnbuffered;
 
-    Storage *file = new DCacheFile(normalise(proto, path), mode);
-    return f->wrapNonLocalFile(file, proto, std::string(), mode);
+    auto file = std::make_unique<DCacheFile>(normalise(proto, path), mode);
+    return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
   }
 
   virtual void stagein (const std::string &proto,

--- a/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
+++ b/Utilities/DCacheAdaptor/plugins/DCacheStorageMaker.cc
@@ -31,8 +31,10 @@ public:
       @a mode bits.  No temporary files are downloaded.  */
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
-			 int mode) override
+			 int mode,
+       AuxSettings const& aux) const override
   {
+    setTimeout(aux.timeout);
     const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
     StorageFactory::CacheHint cacheHint = f->cacheHint();
@@ -48,8 +50,10 @@ public:
   }
 
   virtual void stagein (const std::string &proto,
-		        const std::string &path) override
+		        const std::string &path,
+            const AuxSettings& aux) const override
   {
+    setTimeout(aux.timeout);
     std::string npath = normalise(proto, path);
     if (dc_stage(npath.c_str(), 0, 0) != 0) {
       cms::Exception ex("FileStageInError");
@@ -63,8 +67,10 @@ public:
 
   virtual bool check (const std::string &proto,
 		      const std::string &path,
-		      IOOffset *size = 0) override
+          const AuxSettings& aux,
+		      IOOffset *size = 0) const override
   {
+    setTimeout(aux.timeout);
     std::string testpath (normalise (proto, path));
     if (dc_access (testpath.c_str (), R_OK) != 0)
       return false;
@@ -80,8 +86,10 @@ public:
 
     return true;
   }
+      
+  private:
 
-  virtual void setTimeout(unsigned int timeout) override {
+  void setTimeout(unsigned int timeout) const {
     if (timeout != 0) dc_setOpenTimeout(timeout);
   }
 };

--- a/Utilities/LStoreAdaptor/plugins/LStoreStorageMaker.cc
+++ b/Utilities/LStoreAdaptor/plugins/LStoreStorageMaker.cc
@@ -14,7 +14,8 @@ class LStoreStorageMaker : public StorageMaker
       @a mode bits.  No temporary files are downloaded.  */
   virtual std::unique_ptr<Storage> open (const std::string &proto,
              const std::string &path,
-             int mode) override
+             int mode,
+             const AuxSettings&) const override
   {
 	std::string fullpath = proto + ":" + path;
     return std::make_unique<LStoreFile> (fullpath, mode);
@@ -36,7 +37,8 @@ class LStoreStorageMaker : public StorageMaker
 
   virtual bool check (const std::string &proto,
               const std::string &path,
-              IOOffset *size = 0) override
+              const AuxSettings&,
+              IOOffset *size = 0) const override
   {
 	std::string fullpath = proto + ":" + path;
 	try {

--- a/Utilities/LStoreAdaptor/plugins/LStoreStorageMaker.cc
+++ b/Utilities/LStoreAdaptor/plugins/LStoreStorageMaker.cc
@@ -12,12 +12,12 @@ class LStoreStorageMaker : public StorageMaker
   public:
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
              const std::string &path,
              int mode) override
   {
 	std::string fullpath = proto + ":" + path;
-    return new LStoreFile (fullpath, mode);
+    return std::make_unique<LStoreFile> (fullpath, mode);
   }
 
 /* I don't think this is necessary - Melo

--- a/Utilities/RFIOAdaptor/interface/RFIOFile.h
+++ b/Utilities/RFIOAdaptor/interface/RFIOFile.h
@@ -6,7 +6,7 @@
 # include <string>
 
 /** RFIO #Storage object.  */
-class RFIOFile : public Storage
+class RFIOFile final : public Storage
 {
 public:
   RFIOFile (void);
@@ -15,31 +15,31 @@ public:
   RFIOFile (const std::string &name, int flags = IOFlags::OpenRead, int perms = 0666);
   ~RFIOFile (void);
 
-  virtual void		create (const char *name,
+   void		create (const char *name,
 				bool exclusive = false,
-				int perms = 0666);
-  virtual void		create (const std::string &name,
+				int perms = 0666) ;
+   void		create (const std::string &name,
 				bool exclusive = false,
-				int perms = 0666);
-  virtual void		open (const char *name,
+				int perms = 0666) ;
+   void		open (const char *name,
 			      int flags = IOFlags::OpenRead,
-			      int perms = 0666);
-  virtual void		open (const std::string &name,
+			      int perms = 0666) ;
+   void		open (const std::string &name,
 			      int flags = IOFlags::OpenRead,
-			      int perms = 0666);
+			      int perms = 0666) ;
 
   using Storage::read;
   using Storage::readv;
   using Storage::write;
   using Storage::position;
 
-  virtual IOSize	read (void *into, IOSize n);
-  virtual IOSize	readv (IOPosBuffer *into, IOSize buffers);
-  virtual IOSize	write (const void *from, IOSize n);
-  virtual IOOffset	position (IOOffset offset, Relative whence = SET);
-  virtual void		resize (IOOffset size);
-  virtual void		close (void);
-  virtual void		abort (void);
+  virtual IOSize	read (void *into, IOSize n) override;
+  virtual IOSize	readv (IOPosBuffer *into, IOSize buffers) override;
+  virtual IOSize	write (const void *from, IOSize n) override;
+  virtual IOOffset	position (IOOffset offset, Relative whence = SET) override;
+  virtual void		resize (IOOffset size) override;
+  virtual void		close (void) override;
+  void		abort (void) ;
 
 /*
  * Note: we used to implement prefetch for RFIOFile, but it never got used in

--- a/Utilities/RFIOAdaptor/plugins/RFIOStorageMaker.cc
+++ b/Utilities/RFIOAdaptor/plugins/RFIOStorageMaker.cc
@@ -16,7 +16,7 @@ class RFIOStorageMaker : public StorageMaker
   /** Normalise new RFIO TURL style.  Handle most obvious mis-spellings
       like excess '/' characters and /dpm vs. /castor syntax
       differences.  */
-  std::string normalise (const std::string &path)
+  std::string normalise (const std::string &path) const
   {
     std::string prefix;
     // look for options
@@ -99,7 +99,8 @@ public:
 
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 		         const std::string &path,
-			 int mode) override
+			       int mode,
+             const AuxSettings&) const override
   {
     const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
@@ -116,7 +117,8 @@ public:
   }
 
   virtual void stagein (const std::string &proto,
-		        const std::string &path) override
+		        const std::string &path,
+            const AuxSettings&) const override
   {
     std::string npath = normalise(path);
     size_t castor = npath.find("?path=/castor/");
@@ -167,7 +169,8 @@ public:
 
   virtual bool check (const std::string &/*proto*/,
 		      const std::string &path,
-		      IOOffset *size = 0) override
+          const AuxSettings&,
+		      IOOffset *size = 0) const override
   {
     std::string npath = normalise(path);
     if (rfio_access(npath.c_str (), R_OK) != 0)

--- a/Utilities/RFIOAdaptor/plugins/RFIOStorageMaker.cc
+++ b/Utilities/RFIOAdaptor/plugins/RFIOStorageMaker.cc
@@ -97,11 +97,11 @@ public:
     Cthread_init();
   }
 
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 		         const std::string &path,
 			 int mode) override
   {
-    StorageFactory *f = StorageFactory::get();
+    const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
     StorageFactory::CacheHint cacheHint = f->cacheHint();
 
@@ -111,8 +111,8 @@ public:
     else
       mode |= IOFlags::OpenUnbuffered;
 
-    Storage *file = new RFIOFile(normalise(path), mode);
-    return f->wrapNonLocalFile(file, proto, std::string(), mode);
+    auto file = std::make_unique<RFIOFile>(normalise(path), mode);
+    return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
   }
 
   virtual void stagein (const std::string &proto,

--- a/Utilities/StorageFactory/BuildFile.xml
+++ b/Utilities/StorageFactory/BuildFile.xml
@@ -4,6 +4,7 @@
 <use   name="FWCore/ServiceRegistry"/>
 <use   name="boost"/>
 <use   name="openssl"/>
+<use   name="tbb"/>
 <flags   cppflags="-D_FILE_OFFSET_BITS=64"/>
 <export>
   <lib   name="1"/>

--- a/Utilities/StorageFactory/bin/anycp.cpp
+++ b/Utilities/StorageFactory/bin/anycp.cpp
@@ -228,20 +228,20 @@ int main (int argc, char **argv) try
   }
 
   std::shared_ptr<Storage>			is;
-  std::vector<std::shared_ptr<Storage> >	os(argc-2);
+  std::vector<std::unique_ptr<Storage> >	os(argc-2);
   std::vector<std::thread> threads;
   bool						readThreadActive = true;
   bool						writeThreadActive = true;
   IOOffset					size = -1;
 
-  StorageFactory::get ()->enableAccounting(true);
-  bool exists = StorageFactory::get ()->check(argv [1], &size);
+  StorageFactory::getToModify ()->enableAccounting(true);
+  bool exists = StorageFactory::getToModify ()->check(argv [1], &size);
   std::cerr << "input file exists = " << exists << ", size = " << size << "\n";
   if (! exists) return EXIT_SUCCESS;
 
   try
   {
-    is.reset(StorageFactory::get ()->open (argv [1]));
+    is = StorageFactory::getToModify ()->open (argv [1]);
     if (readThreadActive) 
       threads.emplace_back(&readThread,is.get());
   }
@@ -256,10 +256,10 @@ int main (int argc, char **argv) try
   for (int i=0; i < argc-2; i++)
     try
     {
-      os[i].reset(StorageFactory::get ()->open (argv[i+2],
+      os[i]= StorageFactory::getToModify ()->open (argv[i+2],
 						IOFlags::OpenWrite
 						| IOFlags::OpenCreate
-						| IOFlags::OpenTruncate));
+						| IOFlags::OpenTruncate);
     if (writeThreadActive) 
       threads.emplace_back(&writeThread,os[i].get());
   }

--- a/Utilities/StorageFactory/bin/anycp.cpp
+++ b/Utilities/StorageFactory/bin/anycp.cpp
@@ -306,7 +306,7 @@ int main (int argc, char **argv) try
     }
   }
 
-  std::cout << StorageAccount::summaryXML () << std::endl;
+  std::cout << StorageAccount::summaryText(true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/interface/File.h
+++ b/Utilities/StorageFactory/interface/File.h
@@ -34,7 +34,9 @@ public:
   virtual void		attach (IOFD fd);
 
   using Storage::read;
+  using Storage::readv;
   using Storage::write;
+  using Storage::writev;
   using Storage::position;
 
   virtual bool		prefetch (const IOPosBuffer *what, IOSize n);

--- a/Utilities/StorageFactory/interface/LocalCacheFile.h
+++ b/Utilities/StorageFactory/interface/LocalCacheFile.h
@@ -5,12 +5,13 @@
 # include "Utilities/StorageFactory/interface/File.h"
 # include <vector>
 # include <string>
+# include <memory>
 
 /** Proxy class to copy a file locally in large chunks. */
 class LocalCacheFile : public Storage
 {
 public:
-  LocalCacheFile (Storage *base, const std::string &tmpdir = "");
+  LocalCacheFile (std::unique_ptr<Storage> base, const std::string &tmpdir = "");
   ~LocalCacheFile (void);
 
   using Storage::read;
@@ -36,8 +37,8 @@ private:
 
   IOOffset		image_;
   std::vector<char>	present_;
-  File			*file_;
-  Storage		*storage_;
+  std::unique_ptr<File>	file_;
+  std::unique_ptr<Storage>	storage_;
   bool                  closedFile_;
   unsigned int          cacheCount_;
   unsigned int          cacheTotal_;

--- a/Utilities/StorageFactory/interface/LocalFileSystem.h
+++ b/Utilities/StorageFactory/interface/LocalFileSystem.h
@@ -2,6 +2,7 @@
 # define STORAGE_FACTORY_LOCAL_FILE_SYSTEM_H
 # include <vector>
 # include <string>
+#include <utility>
 
 struct stat;
 struct statfs;
@@ -14,20 +15,18 @@ public:
   LocalFileSystem(void);
   ~LocalFileSystem(void);
 
-  bool		isLocalPath(const std::string &path);
-  std::string	findCachePath(const std::vector<std::string> &paths, double minFreeSpace);
-  void          issueWarning();
+  bool		isLocalPath(const std::string &path) const;
+  std::pair<std::string, std::string>	findCachePath(const std::vector<std::string> &paths, double minFreeSpace) const;
 
 private:
   int		readFSTypes(void);
   FSInfo *	initFSInfo(void *p);
   int		initFSList(void);
-  int		statFSInfo(FSInfo *i);
-  FSInfo *	findMount(const char *path, struct statfs *sfs, struct stat *s, std::vector<std::string> &);
+  int		statFSInfo(FSInfo *i) const;
+  FSInfo *	findMount(const char *path, struct statfs *sfs, struct stat *s, std::vector<std::string> &) const;
 
   std::vector<FSInfo *> fs_;
   std::vector<std::string> fstypes_;
-  std::string unusable_dir_warnings_;
 
   // undefined, no semantics
   LocalFileSystem(LocalFileSystem &);

--- a/Utilities/StorageFactory/interface/RemoteFile.h
+++ b/Utilities/StorageFactory/interface/RemoteFile.h
@@ -3,6 +3,7 @@
 
 # include "Utilities/StorageFactory/interface/File.h"
 # include <string>
+#include <memory>
 
 class RemoteFile : protected File
 {
@@ -10,7 +11,7 @@ public:
   ~RemoteFile (void) { remove (); }
 
   static int local (const std::string &tmpdir, std::string &temp);
-  static Storage *get (int localfd, const std::string &name,
+  static std::unique_ptr<Storage> get (int localfd, const std::string &name,
 		       char **cmd, int mode);
 
 protected:

--- a/Utilities/StorageFactory/interface/StatisticsSenderService.h
+++ b/Utilities/StorageFactory/interface/StatisticsSenderService.h
@@ -36,7 +36,6 @@ namespace edm {
             ssize_t m_read_vector_square;
             ssize_t m_read_vector_count_sum;
             ssize_t m_read_vector_count_square;
-            ssize_t m_read_bytes_at_close;
             time_t  m_start_time;
         };
 

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -35,7 +35,7 @@ public:
   };
 
   typedef std::map<std::string, Counter> OperationStats;
-  typedef std::map<std::string, boost::shared_ptr<OperationStats> > StorageStats;
+  typedef std::map<std::string, OperationStats > StorageStats;
 
   class StorageStatsSentry {
     friend class StorageAccount;

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -11,6 +11,32 @@
 
 class StorageAccount {
 public:
+  
+  enum class Operation {
+    check,
+    close,
+    construct,
+    destruct,
+    flush,
+    open,
+    position,
+    prefetch,
+    read,
+    readActual,
+    readAsync,
+    readPrefetchToCache,
+    readViaCache,
+    readv,
+    resize,
+    seek,
+    stagein,
+    stat,
+    write,
+    writeActual,
+    writeViaCache,
+    writev
+  };
+  
   struct Counter {
     Counter():
     attempts{0},
@@ -77,14 +103,16 @@ public:
     std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
   };
 
-  typedef tbb::concurrent_unordered_map<std::string, Counter> OperationStats;
+  typedef tbb::concurrent_unordered_map<int, Counter> OperationStats;
   typedef tbb::concurrent_unordered_map<std::string, OperationStats > StorageStats;
 
+  static char const* operationName(Operation operation);
+  
   static const StorageStats& summary(void);
   static std::string         summaryText(bool banner=false);
   static void                fillSummary(std::map<std::string, std::string> &summary);
   static Counter&            counter (const std::string &storageClass,
-                                      const std::string &operation);
+                                      Operation operation);
 
 private:
   static StorageStats m_stats;

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -55,7 +55,6 @@ public:
 
   static StorageStatsSentry&& summaryLocked() {return std::move(StorageStatsSentry());}
   static const StorageStats& summary(void);
-  static std::string         summaryXML(void);
   static std::string         summaryText(bool banner=false);
   static void                fillSummary(std::map<std::string, std::string> &summary);
   static Counter&            counter (const std::string &storageClass,

--- a/Utilities/StorageFactory/interface/StorageAccount.h
+++ b/Utilities/StorageFactory/interface/StorageAccount.h
@@ -103,15 +103,31 @@ public:
     std::chrono::time_point<std::chrono::high_resolution_clock> m_start;
   };
 
+  class StorageClassToken {
+  public:
+    StorageClassToken(StorageClassToken const&) = default;
+    int value() const { return m_value;}
+
+    friend class StorageAccount;
+  private:
+    StorageClassToken() = delete;
+    explicit StorageClassToken(int iValue) : m_value{iValue} {}
+
+    int m_value;
+    
+  };
+  
   typedef tbb::concurrent_unordered_map<int, Counter> OperationStats;
-  typedef tbb::concurrent_unordered_map<std::string, OperationStats > StorageStats;
+  typedef tbb::concurrent_unordered_map<int, OperationStats > StorageStats;
 
   static char const* operationName(Operation operation);
+  static StorageClassToken tokenForStorageClassName( std::string const& iName);
+  static const std::string& nameForToken( StorageClassToken);
   
   static const StorageStats& summary(void);
   static std::string         summaryText(bool banner=false);
   static void                fillSummary(std::map<std::string, std::string> &summary);
-  static Counter&            counter (const std::string &storageClass,
+  static Counter&            counter (StorageClassToken token,
                                       Operation operation);
 
 private:

--- a/Utilities/StorageFactory/interface/StorageAccountProxy.h
+++ b/Utilities/StorageFactory/interface/StorageAccountProxy.h
@@ -39,9 +39,9 @@ public:
   virtual void		close (void);
 
 protected:
-  std::string		m_storageClass;
   std::unique_ptr<Storage> m_baseStorage;
 
+  StorageAccount::StorageClassToken m_token;
   StorageAccount::Counter &m_statsRead;
   StorageAccount::Counter &m_statsReadV;
   StorageAccount::Counter &m_statsWrite;

--- a/Utilities/StorageFactory/interface/StorageAccountProxy.h
+++ b/Utilities/StorageFactory/interface/StorageAccountProxy.h
@@ -4,6 +4,7 @@
 # include "Utilities/StorageFactory/interface/StorageAccount.h"
 # include "Utilities/StorageFactory/interface/Storage.h"
 # include <string>
+#include <memory>
 
 /** Proxy class that wraps SEAL's #Storage class with one that ticks
     #StorageAccount counters for significant operations.  The returned
@@ -16,7 +17,7 @@
 class StorageAccountProxy : public Storage
 {
 public:
-  StorageAccountProxy (const std::string &storageClass, Storage *baseStorage);
+  StorageAccountProxy (const std::string &storageClass, std::unique_ptr<Storage> baseStorage);
   ~StorageAccountProxy (void);
 
   using Storage::read;
@@ -39,7 +40,7 @@ public:
 
 protected:
   std::string		m_storageClass;
-  Storage		*m_baseStorage;
+  std::unique_ptr<Storage> m_baseStorage;
 
   StorageAccount::Counter &m_statsRead;
   StorageAccount::Counter &m_statsReadV;

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -82,6 +82,7 @@ private:
   double	m_tempfree;
   std::string	m_temppath;
   std::string	m_tempdir;
+  std::string m_unusableDirWarnings;
   unsigned int  m_timeout;
   unsigned int  m_debugLevel;
   LocalFileSystem m_lfs;

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -28,7 +28,9 @@ public:
     READ_HINT_AUTO
   };
 
-  static StorageFactory *get (void);
+  static const StorageFactory *get (void);
+  static StorageFactory *getToModify (void);
+
   ~StorageFactory (void);
 
   // implicit copy constructor
@@ -54,28 +56,28 @@ public:
   std::string	tempPath (void) const;
   double	tempMinFree (void) const;
 
-  void		stagein (const std::string &url);
-  Storage *	open (const std::string &url,
-	    	      int mode = IOFlags::OpenRead);
+  void		stagein (const std::string &url) const;
+  std::unique_ptr<Storage>	open (const std::string &url,
+	    	      int mode = IOFlags::OpenRead) const;
   bool		check (const std::string &url,
-	    	       IOOffset *size = 0);
+	    	       IOOffset *size = 0) const;
   void		activateTimeout (const std::string &url);
 
-  Storage *	wrapNonLocalFile (Storage *s,
+  std::unique_ptr<Storage>	wrapNonLocalFile (std::unique_ptr<Storage> s,
 				  const std::string &proto,
 				  const std::string &path,
-				  int mode);
+				  int mode) const;
 
 private:
   typedef tbb::concurrent_unordered_map<std::string, std::shared_ptr<StorageMaker>> MakerTable;
 
   StorageFactory (void);
-  StorageMaker *getMaker (const std::string &proto);
+  StorageMaker *getMaker (const std::string &proto) const;
   StorageMaker *getMaker (const std::string &url,
 			  std::string &protocol,
-			  std::string &rest);
+			  std::string &rest) const;
   
-  MakerTable	m_makers;
+  mutable MakerTable	m_makers;
   CacheHint	m_cacheHint;
   ReadHint	m_readHint;
   bool		m_accounting;

--- a/Utilities/StorageFactory/interface/StorageFactory.h
+++ b/Utilities/StorageFactory/interface/StorageFactory.h
@@ -61,7 +61,6 @@ public:
 	    	      int mode = IOFlags::OpenRead) const;
   bool		check (const std::string &url,
 	    	       IOOffset *size = 0) const;
-  void		activateTimeout (const std::string &url);
 
   std::unique_ptr<Storage>	wrapNonLocalFile (std::unique_ptr<Storage> s,
 				  const std::string &proto,

--- a/Utilities/StorageFactory/interface/StorageMaker.h
+++ b/Utilities/StorageFactory/interface/StorageMaker.h
@@ -9,21 +9,37 @@ class Storage;
 class StorageMaker
 {
 public:
-  StorageMaker(void);
-  virtual ~StorageMaker (void);
+  struct AuxSettings {
+    unsigned int timeout = 0;
+    unsigned int debugLevel = 0;
+    
+    AuxSettings& setDebugLevel(unsigned int iLevel) {
+      debugLevel = iLevel;
+      return *this;
+    }
+    
+    AuxSettings& setTimeout(unsigned int iTime) {
+      timeout = iTime;
+      return *this;
+    }
+  };
+  
+  StorageMaker() = default;
+  virtual ~StorageMaker () = default;
   // implicit copy constructor
   // implicit assignment operator
 
   virtual void		stagein (const std::string &proto,
-				 const std::string &path);
+				 const std::string &path,
+         const AuxSettings& aux) const;
   virtual std::unique_ptr<Storage>	open (const std::string &proto,
 			      const std::string &path,
-			      int mode) = 0;
+			      int mode,
+            const AuxSettings& aux) const = 0;
   virtual bool		check (const std::string &proto,
 			       const std::string &path,
-			       IOOffset *size = 0);
-  virtual void		setTimeout (unsigned int timeout);
-  virtual void          setDebugLevel (unsigned int debugLevel);
+             const AuxSettings& aux,
+			       IOOffset *size = 0) const;
 };
 
 #endif // STORAGE_FACTORY_STORAGE_MAKER_H

--- a/Utilities/StorageFactory/interface/StorageMaker.h
+++ b/Utilities/StorageFactory/interface/StorageMaker.h
@@ -3,6 +3,7 @@
 
 # include "Utilities/StorageFactory/interface/IOTypes.h"
 # include <string>
+#include <memory>
 
 class Storage;
 class StorageMaker
@@ -15,7 +16,7 @@ public:
 
   virtual void		stagein (const std::string &proto,
 				 const std::string &path);
-  virtual Storage *	open (const std::string &proto,
+  virtual std::unique_ptr<Storage>	open (const std::string &proto,
 			      const std::string &path,
 			      int mode) = 0;
   virtual bool		check (const std::string &proto,

--- a/Utilities/StorageFactory/plugins/GsiFTPStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/GsiFTPStorageMaker.cc
@@ -8,7 +8,8 @@ class GsiFTPStorageMaker : public StorageMaker
 public:
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
-			 int mode) override
+			 int mode,
+       const AuxSettings&) const override
   {
     std::string    temp;
     const StorageFactory *f = StorageFactory::get();

--- a/Utilities/StorageFactory/plugins/GsiFTPStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/GsiFTPStorageMaker.cc
@@ -6,12 +6,12 @@
 class GsiFTPStorageMaker : public StorageMaker
 {
 public:
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode) override
   {
     std::string    temp;
-    StorageFactory *f = StorageFactory::get();
+    const StorageFactory *f = StorageFactory::get();
     int            localfd = RemoteFile::local (f->tempDir(), temp);
     std::string    lurl = "file://" + temp;
     std::string    newurl ((proto == "sfn" ? "gsiftp" : proto) + ":" + path);

--- a/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
@@ -6,12 +6,12 @@
 class HttpStorageMaker : public StorageMaker
 {
 public:
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode) override
   {
     std::string    temp;
-    StorageFactory *f = StorageFactory::get();
+    const StorageFactory *f = StorageFactory::get();
     int            localfd = RemoteFile::local (f->tempDir(), temp);
     std::string    newurl ((proto == "web" ? "http" : proto) + ":" + path);
     const char     *curlopts [] = {

--- a/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/HttpStorageMaker.cc
@@ -8,7 +8,8 @@ class HttpStorageMaker : public StorageMaker
 public:
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
-			 int mode) override
+			 int mode,
+       const AuxSettings&) const override
   {
     std::string    temp;
     const StorageFactory *f = StorageFactory::get();

--- a/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
@@ -11,11 +11,11 @@
 class LocalStorageMaker : public StorageMaker
 {
 public:
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode) override
     {
-      StorageFactory *f = StorageFactory::get();
+      const StorageFactory *f = StorageFactory::get();
       StorageFactory::ReadHint readHint = f->readHint();
       StorageFactory::CacheHint cacheHint = f->cacheHint();
 
@@ -25,8 +25,8 @@ public:
       else
 	mode |= IOFlags::OpenUnbuffered;
 
-      File *file = new File (path, mode);
-      return f->wrapNonLocalFile (file, proto, path, mode);
+      auto file = std::make_unique<File> (path, mode);
+      return f->wrapNonLocalFile (std::move(file), proto, path, mode);
     }
 
   virtual bool check (const std::string &/*proto*/,

--- a/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/LocalStorageMaker.cc
@@ -13,7 +13,8 @@ class LocalStorageMaker : public StorageMaker
 public:
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
-			 int mode) override
+			 int mode,
+       const AuxSettings&) const override
     {
       const StorageFactory *f = StorageFactory::get();
       StorageFactory::ReadHint readHint = f->readHint();
@@ -31,7 +32,8 @@ public:
 
   virtual bool check (const std::string &/*proto*/,
 		      const std::string &path,
-		      IOOffset *size = 0) override
+          const AuxSettings&,
+		      IOOffset *size = 0) const override
     {
       struct stat st;
       if (stat (path.c_str(), &st) != 0)

--- a/Utilities/StorageFactory/plugins/StormLCGStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/StormLCGStorageMaker.cc
@@ -55,11 +55,11 @@ class StormLcgGtStorageMaker : public StorageMaker
 
 
 public:
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &surl,
 			 int mode) override
   {
-    StorageFactory *f = StorageFactory::get();
+    const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
     StorageFactory::CacheHint cacheHint = f->cacheHint();
 
@@ -70,8 +70,8 @@ public:
       mode |= IOFlags::OpenUnbuffered;
 
     std::string path = getTURL(surl);
-    File *file = new File (path, mode); 
-    return f->wrapNonLocalFile (file, proto, path, mode);
+    auto file = std::make_unique<File> (path, mode);
+    return f->wrapNonLocalFile (std::move(file), proto, path, mode);
   }
 
   virtual bool check (const std::string &/*proto*/,

--- a/Utilities/StorageFactory/plugins/StormLCGStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/StormLCGStorageMaker.cc
@@ -12,7 +12,7 @@
 class StormLcgGtStorageMaker : public StorageMaker
 {
   /* getTURL: Executes lcg-gt and extracts the physical file path */
-  std::string getTURL (const std::string &surl)
+  std::string getTURL (const std::string &surl) const
   {
     // PrepareToGet timeout  
     std::string timeout("300");
@@ -57,7 +57,8 @@ class StormLcgGtStorageMaker : public StorageMaker
 public:
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &surl,
-			 int mode) override
+			 int mode,
+       const AuxSettings& ) const override
   {
     const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
@@ -76,7 +77,8 @@ public:
 
   virtual bool check (const std::string &/*proto*/,
 		      const std::string &path,
-		      IOOffset *size = 0) override
+          const AuxSettings&,
+		      IOOffset *size = 0) const override
   {
     struct stat st;
     if (stat (getTURL(path).c_str(), &st) != 0)

--- a/Utilities/StorageFactory/plugins/StormStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/StormStorageMaker.cc
@@ -12,7 +12,7 @@
 class StormStorageMaker : public StorageMaker
 {
   /* getTURL: Executes a prepare to get script and extracts the physical file path */
-  std::string getTURL (const std::string &surl)
+  std::string getTURL (const std::string &surl) const
   {
     std::string client;
     if (char *p = getenv("CMS_STORM_PTG_CLIENT"))
@@ -56,7 +56,8 @@ class StormStorageMaker : public StorageMaker
 public:
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &surl,
-			 int mode) override
+			 int mode,
+       const AuxSettings&) const override
   {
     const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
@@ -75,7 +76,8 @@ public:
 
   virtual bool check (const std::string &/*proto*/,
 		      const std::string &path,
-		      IOOffset *size = 0) override
+          const AuxSettings&,
+		      IOOffset *size = 0) const override
   {
     struct stat st;
     if (stat (getTURL(path).c_str(), &st) != 0)

--- a/Utilities/StorageFactory/plugins/StormStorageMaker.cc
+++ b/Utilities/StorageFactory/plugins/StormStorageMaker.cc
@@ -54,11 +54,11 @@ class StormStorageMaker : public StorageMaker
 
 
 public:
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &surl,
 			 int mode) override
   {
-    StorageFactory *f = StorageFactory::get();
+    const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
     StorageFactory::CacheHint cacheHint = f->cacheHint();
 
@@ -69,8 +69,8 @@ public:
       mode |= IOFlags::OpenUnbuffered;
 
     std::string path = getTURL(surl);
-    File *file = new File (path, mode); 
-    return f->wrapNonLocalFile (file, proto, path, mode);
+    auto file = std::make_unique<File> (path, mode);
+    return f->wrapNonLocalFile (std::move(file), proto, path, mode);
   }
 
   virtual bool check (const std::string &/*proto*/,

--- a/Utilities/StorageFactory/src/LocalCacheFile.cc
+++ b/Utilities/StorageFactory/src/LocalCacheFile.cc
@@ -21,10 +21,10 @@ nowrite(const std::string &why)
 }
 
 
-LocalCacheFile::LocalCacheFile(Storage *base, const std::string &tmpdir /* = "" */)
+LocalCacheFile::LocalCacheFile(std::unique_ptr<Storage> base, const std::string &tmpdir /* = "" */)
   : image_(base->size()),
-    file_(0),
-    storage_(base),
+    file_(),
+    storage_(std::move(base)),
     closedFile_(false),
     cacheCount_(0),
     cacheTotal_((image_ + CHUNK_SIZE - 1) / CHUNK_SIZE)
@@ -50,14 +50,12 @@ LocalCacheFile::LocalCacheFile(Storage *base, const std::string &tmpdir /* = "" 
   }
 
   unlink(&temp[0]);
-  file_ = new File(fd);
+  file_ = std::make_unique<File>(fd);
   file_->resize(image_);
 }
 
 LocalCacheFile::~LocalCacheFile(void)
 {
-  delete file_;
-  delete storage_;
 }
 
 void

--- a/Utilities/StorageFactory/src/RemoteFile.cc
+++ b/Utilities/StorageFactory/src/RemoteFile.cc
@@ -86,7 +86,7 @@ RemoteFile::local (const std::string &tmpdir, std::string &temp)
   return fd;
 }
 
-Storage *
+std::unique_ptr<Storage>
 RemoteFile::get (int localfd, const std::string &name, char **cmd, int mode)
 {
   // FIXME: On write, create a temporary local file open for write;
@@ -119,7 +119,7 @@ RemoteFile::get (int localfd, const std::string &name, char **cmd, int mode)
   }
 
   if (WIFEXITED(rc) && WEXITSTATUS(rc) == 0)
-    return new RemoteFile (localfd, name);
+    return std::unique_ptr<Storage> ( static_cast<Storage*>( new RemoteFile(localfd, name) ) );
   else
   {
     ::close (localfd);

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -42,7 +42,6 @@ StatisticsSenderService::FileStatistics::FileStatistics() :
   m_read_vector_square(0),
   m_read_vector_count_sum(0),
   m_read_vector_count_square(0),
-  m_read_bytes_at_close(0),
   m_start_time(time(NULL))
 {}
 

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -61,7 +61,7 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
     if (i->first == "tstoragefile") {
       continue;
     }
-    for (StorageAccount::OperationStats::const_iterator j = i->second->begin(); j != i->second->end(); ++j) {
+    for (StorageAccount::OperationStats::const_iterator j = i->second.begin(); j != i->second.end(); ++j) {
       if (j->first == "readv") {
         read_vector_operations += j->second.attempts;
         read_vector_bytes += j->second.amount;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -62,13 +62,13 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
       continue;
     }
     for (StorageAccount::OperationStats::const_iterator j = i->second.begin(); j != i->second.end(); ++j) {
-      if (j->first == "readv") {
+      if (j->first == static_cast<int>(StorageAccount::Operation::readv)) {
         read_vector_operations += j->second.attempts;
         read_vector_bytes += j->second.amount;
         read_vector_count_square += j->second.vector_square;
         read_vector_square += j->second.amount_square;
         read_vector_count_sum += j->second.vector_count;
-      } else if (j->first == "read") {
+      } else if (j->first == static_cast<int>(StorageAccount::Operation::read)) {
         read_single_operations += j->second.attempts;
         read_single_bytes += j->second.amount;
         read_single_square += j->second.amount_square;

--- a/Utilities/StorageFactory/src/StatisticsSenderService.cc
+++ b/Utilities/StorageFactory/src/StatisticsSenderService.cc
@@ -57,8 +57,9 @@ StatisticsSenderService::FileStatistics::fillUDP(std::ostringstream &os) {
   ssize_t read_vector_square = 0;
   ssize_t read_vector_count_sum = 0;
   ssize_t read_vector_count_square = 0;
+  auto token = StorageAccount::tokenForStorageClassName("tstoragefile");
   for (StorageAccount::StorageStats::const_iterator i = stats.begin (); i != stats.end(); ++i) {
-    if (i->first == "tstoragefile") {
+    if (i->first == token.value()) {
       continue;
     }
     for (StorageAccount::OperationStats::const_iterator j = i->second.begin(); j != i->second.end(); ++j) {

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -4,7 +4,6 @@
 #include <unistd.h>
 #include <sys/time.h>
 
-std::mutex StorageAccount::m_mutex;
 StorageAccount::StorageStats StorageAccount::m_stats;
 
 static std::string i2str(int i) {
@@ -64,7 +63,6 @@ StorageAccount::summary (void)
 
 StorageAccount::Counter&
 StorageAccount::counter (const std::string &storageClass, const std::string &operation) {
-  std::lock_guard<std::mutex> lock (m_mutex);
   auto &opstats = m_stats [storageClass];
 
   return opstats[operation];

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -40,24 +40,6 @@ StorageAccount::summaryText (bool banner /*=false*/) {
   return os.str ();
 }
 
-std::string
-StorageAccount::summaryXML (void) {
-  std::ostringstream os;
-  os << "<storage-timing-summary>\n";
-  for (StorageStats::iterator i = m_stats.begin (); i != m_stats.end(); ++i)
-    for (OperationStats::iterator j = i->second->begin (); j != i->second->end (); ++j)
-      os << " <counter-value subsystem='" << i->first
-         << "' counter-name='" << j->first
-         << "' num-operations='" << j->second.attempts
-         << "' num-successful-operations='" << j->second.successes
-         << "' total-megabytes='" << (static_cast<double>(j->second.amount) / 1024 / 1024)
-         << "' total-msecs='" << (static_cast<double>(j->second.timeTotal) / 1000 / 1000)
-         << "' min-msecs='" << (static_cast<double>(j->second.timeMin) / 1000 / 1000)
-         << "' max-msecs='" << (static_cast<double>(j->second.timeMax) / 1000 / 1000) << "'/>\n";
-  os << "</storage-timing-summary>";
-  return os.str ();
-}
-
 void
 StorageAccount::fillSummary(std::map<std::string, std::string>& summary) {
   int const oneM = 1000 * 1000;

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -60,7 +60,7 @@ StorageAccount::StorageClassToken StorageAccount::tokenForStorageClassName( std:
   }
   int value = s_nextTokenValue++;
   
-  auto ret = s_nameToToken.emplace(iName, value);
+  auto ret = s_nameToToken.insert(std::make_pair(iName, value));
   
   //don't use value since another thread may have beaten us to here
   return StorageClassToken(ret.second);

--- a/Utilities/StorageFactory/src/StorageAccount.cc
+++ b/Utilities/StorageFactory/src/StorageAccount.cc
@@ -26,7 +26,7 @@ StorageAccount::summaryText (bool banner /*=false*/) {
   if (banner)
     os << "stats: class/operation/attempts/successes/amount/time-total/time-min/time-max\n";
   for (StorageStats::iterator i = m_stats.begin (); i != m_stats.end(); ++i)
-    for (OperationStats::iterator j = i->second->begin (); j != i->second->end (); ++j, first = false)
+    for (OperationStats::iterator j = i->second.begin (); j != i->second.end (); ++j, first = false)
       os << (first ? "" : "; ")
          << i->first << '/'
          << j->first << '='
@@ -45,7 +45,7 @@ StorageAccount::fillSummary(std::map<std::string, std::string>& summary) {
   int const oneM = 1000 * 1000;
   int const oneMeg = 1024 * 1024;
   for (StorageStats::iterator i = m_stats.begin (); i != m_stats.end(); ++i) {
-    for (OperationStats::iterator j = i->second->begin(); j != i->second->end(); ++j) {
+    for (OperationStats::iterator j = i->second.begin(); j != i->second.end(); ++j) {
       std::ostringstream os;
       os << "Timing-" << i->first << "-" << j->first << "-";
       summary.insert(std::make_pair(os.str() + "numOperations", i2str(j->second.attempts)));
@@ -65,13 +65,12 @@ StorageAccount::summary (void)
 StorageAccount::Counter&
 StorageAccount::counter (const std::string &storageClass, const std::string &operation) {
   std::lock_guard<std::mutex> lock (m_mutex);
-  boost::shared_ptr<OperationStats> &opstats = m_stats [storageClass];
-  if (!opstats) opstats.reset(new OperationStats);
+  auto &opstats = m_stats [storageClass];
 
-  OperationStats::iterator pos = opstats->find (operation);
-  if (pos == opstats->end ()) {
+  OperationStats::iterator pos = opstats.find (operation);
+  if (pos == opstats.end ()) {
     Counter x = { 0, 0, 0, 0, 0, 0, 0 };
-    pos = opstats->insert (OperationStats::value_type (operation, x)).first;
+    pos = opstats.insert (OperationStats::value_type (operation, x)).first;
   }
 
   return pos->second;

--- a/Utilities/StorageFactory/src/StorageAccountProxy.cc
+++ b/Utilities/StorageFactory/src/StorageAccountProxy.cc
@@ -2,22 +2,22 @@
 
 StorageAccountProxy::StorageAccountProxy (const std::string &storageClass,
                                           std::unique_ptr<Storage> baseStorage)
-  : m_storageClass (storageClass),
-    m_baseStorage (std::move(baseStorage)),
-    m_statsRead (StorageAccount::counter (m_storageClass, StorageAccount::Operation::read)),
-    m_statsReadV (StorageAccount::counter (m_storageClass, StorageAccount::Operation::readv)),
-    m_statsWrite (StorageAccount::counter (m_storageClass, StorageAccount::Operation::write)),
-    m_statsWriteV (StorageAccount::counter (m_storageClass, StorageAccount::Operation::writev)),
-    m_statsPosition (StorageAccount::counter (m_storageClass, StorageAccount::Operation::position)),
-    m_statsPrefetch (StorageAccount::counter (m_storageClass, StorageAccount::Operation::prefetch))
+  : m_baseStorage (std::move(baseStorage)),
+    m_token(StorageAccount::tokenForStorageClassName(storageClass)),
+    m_statsRead (StorageAccount::counter (m_token, StorageAccount::Operation::read)),
+    m_statsReadV (StorageAccount::counter (m_token, StorageAccount::Operation::readv)),
+    m_statsWrite (StorageAccount::counter (m_token, StorageAccount::Operation::write)),
+    m_statsWriteV (StorageAccount::counter (m_token, StorageAccount::Operation::writev)),
+    m_statsPosition (StorageAccount::counter (m_token, StorageAccount::Operation::position)),
+    m_statsPrefetch (StorageAccount::counter (m_token, StorageAccount::Operation::prefetch))
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::construct));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_token, StorageAccount::Operation::construct));
   stats.tick ();
 }
 
 StorageAccountProxy::~StorageAccountProxy (void)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::destruct));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_token, StorageAccount::Operation::destruct));
   m_baseStorage.release();
   stats.tick ();
 }
@@ -106,7 +106,7 @@ StorageAccountProxy::position (IOOffset offset, Relative whence)
 void
 StorageAccountProxy::resize (IOOffset size)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::resize));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_token, StorageAccount::Operation::resize));
   m_baseStorage->resize (size);
   stats.tick ();
 }
@@ -114,7 +114,7 @@ StorageAccountProxy::resize (IOOffset size)
 void
 StorageAccountProxy::flush (void)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::flush));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_token, StorageAccount::Operation::flush));
   m_baseStorage->flush ();
   stats.tick ();
 }
@@ -122,7 +122,7 @@ StorageAccountProxy::flush (void)
 void
 StorageAccountProxy::close (void)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::close));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_token, StorageAccount::Operation::close));
   m_baseStorage->close ();
   stats.tick ();
 }

--- a/Utilities/StorageFactory/src/StorageAccountProxy.cc
+++ b/Utilities/StorageFactory/src/StorageAccountProxy.cc
@@ -1,9 +1,9 @@
 #include "Utilities/StorageFactory/interface/StorageAccountProxy.h"
 
 StorageAccountProxy::StorageAccountProxy (const std::string &storageClass,
-					  Storage *baseStorage)
+                                          std::unique_ptr<Storage> baseStorage)
   : m_storageClass (storageClass),
-    m_baseStorage (baseStorage),
+    m_baseStorage (std::move(baseStorage)),
     m_statsRead (StorageAccount::counter (m_storageClass, "read")),
     m_statsReadV (StorageAccount::counter (m_storageClass, "readv")),
     m_statsWrite (StorageAccount::counter (m_storageClass, "write")),
@@ -18,7 +18,7 @@ StorageAccountProxy::StorageAccountProxy (const std::string &storageClass,
 StorageAccountProxy::~StorageAccountProxy (void)
 {
   StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, "destruct"));
-  delete m_baseStorage;
+  m_baseStorage.release();
   stats.tick ();
 }
 

--- a/Utilities/StorageFactory/src/StorageAccountProxy.cc
+++ b/Utilities/StorageFactory/src/StorageAccountProxy.cc
@@ -4,20 +4,20 @@ StorageAccountProxy::StorageAccountProxy (const std::string &storageClass,
                                           std::unique_ptr<Storage> baseStorage)
   : m_storageClass (storageClass),
     m_baseStorage (std::move(baseStorage)),
-    m_statsRead (StorageAccount::counter (m_storageClass, "read")),
-    m_statsReadV (StorageAccount::counter (m_storageClass, "readv")),
-    m_statsWrite (StorageAccount::counter (m_storageClass, "write")),
-    m_statsWriteV (StorageAccount::counter (m_storageClass, "writev")),
-    m_statsPosition (StorageAccount::counter (m_storageClass, "position")),
-    m_statsPrefetch (StorageAccount::counter (m_storageClass, "prefetch"))
+    m_statsRead (StorageAccount::counter (m_storageClass, StorageAccount::Operation::read)),
+    m_statsReadV (StorageAccount::counter (m_storageClass, StorageAccount::Operation::readv)),
+    m_statsWrite (StorageAccount::counter (m_storageClass, StorageAccount::Operation::write)),
+    m_statsWriteV (StorageAccount::counter (m_storageClass, StorageAccount::Operation::writev)),
+    m_statsPosition (StorageAccount::counter (m_storageClass, StorageAccount::Operation::position)),
+    m_statsPrefetch (StorageAccount::counter (m_storageClass, StorageAccount::Operation::prefetch))
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, "construct"));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::construct));
   stats.tick ();
 }
 
 StorageAccountProxy::~StorageAccountProxy (void)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, "destruct"));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::destruct));
   m_baseStorage.release();
   stats.tick ();
 }
@@ -106,7 +106,7 @@ StorageAccountProxy::position (IOOffset offset, Relative whence)
 void
 StorageAccountProxy::resize (IOOffset size)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, "resize"));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::resize));
   m_baseStorage->resize (size);
   stats.tick ();
 }
@@ -114,7 +114,7 @@ StorageAccountProxy::resize (IOOffset size)
 void
 StorageAccountProxy::flush (void)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, "flush"));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::flush));
   m_baseStorage->flush ();
   stats.tick ();
 }
@@ -122,7 +122,7 @@ StorageAccountProxy::flush (void)
 void
 StorageAccountProxy::close (void)
 {
-  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, "close"));
+  StorageAccount::Stamp stats (StorageAccount::counter (m_storageClass, StorageAccount::Operation::close));
   m_baseStorage->close ();
   stats.tick ();
 }

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -176,12 +176,11 @@ StorageFactory::open (const std::string &url, int mode /* = IOFlags::OpenRead */
   std::unique_ptr<StorageAccount::Stamp> stats;
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
-    maker->setDebugLevel(m_debugLevel);
     if (m_accounting)
       stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, "open")));
     try
     {
-      if (auto storage = maker->open (protocol, rest, mode))
+      if (auto storage = maker->open (protocol, rest, mode, StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout)))
       {
 	if (dynamic_cast<LocalCacheFile *>(storage.get()))
 	  protocol = "local-cache";
@@ -220,7 +219,7 @@ StorageFactory::stagein (const std::string &url) const
       stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, "stagein")));
     try
     {
-      maker->stagein (protocol, rest);
+      maker->stagein (protocol, rest,StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout));
       if (stats) stats->tick();
     }
     catch (cms::Exception &err)
@@ -246,7 +245,7 @@ StorageFactory::check (const std::string &url, IOOffset *size /* = 0 */) const
       stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, "check")));
     try
     {
-      ret = maker->check (protocol, rest, size);
+      ret = maker->check (protocol, rest, StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout), size);
       if (stats) stats->tick();
     }
     catch (cms::Exception &err)

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -176,8 +176,10 @@ StorageFactory::open (const std::string &url, int mode /* = IOFlags::OpenRead */
   std::unique_ptr<StorageAccount::Stamp> stats;
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
-    if (m_accounting)
-      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, StorageAccount::Operation::open)));
+    if (m_accounting) {
+        auto token = StorageAccount::tokenForStorageClassName(protocol);
+        stats.reset(new StorageAccount::Stamp(StorageAccount::counter (token, StorageAccount::Operation::open)));
+    }
     try
     {
       if (auto storage = maker->open (protocol, rest, mode, StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout)))
@@ -215,8 +217,10 @@ StorageFactory::stagein (const std::string &url) const
   std::unique_ptr<StorageAccount::Stamp> stats;
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
-    if (m_accounting) 
-      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, StorageAccount::Operation::stagein)));
+    if (m_accounting) {
+      auto token = StorageAccount::tokenForStorageClassName(protocol);
+      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (token, StorageAccount::Operation::stagein)));
+    }
     try
     {
       maker->stagein (protocol, rest,StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout));
@@ -241,8 +245,10 @@ StorageFactory::check (const std::string &url, IOOffset *size /* = 0 */) const
   std::unique_ptr<StorageAccount::Stamp> stats;
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
-    if (m_accounting) 
-      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, StorageAccount::Operation::check)));
+    if (m_accounting) {
+      auto token = StorageAccount::tokenForStorageClassName(protocol);
+      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (token, StorageAccount::Operation::check)));
+    }
     try
     {
       ret = maker->check (protocol, rest, StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout), size);

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -177,7 +177,7 @@ StorageFactory::open (const std::string &url, int mode /* = IOFlags::OpenRead */
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
     if (m_accounting)
-      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, "open")));
+      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, StorageAccount::Operation::open)));
     try
     {
       if (auto storage = maker->open (protocol, rest, mode, StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout)))
@@ -216,7 +216,7 @@ StorageFactory::stagein (const std::string &url) const
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
     if (m_accounting) 
-      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, "stagein")));
+      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, StorageAccount::Operation::stagein)));
     try
     {
       maker->stagein (protocol, rest,StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout));
@@ -242,7 +242,7 @@ StorageFactory::check (const std::string &url, IOOffset *size /* = 0 */) const
   if (StorageMaker *maker = getMaker (url, protocol, rest))
   {
     if (m_accounting) 
-      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, "check")));
+      stats.reset(new StorageAccount::Stamp(StorageAccount::counter (protocol, StorageAccount::Operation::check)));
     try
     {
       ret = maker->check (protocol, rest, StorageMaker::AuxSettings{}.setDebugLevel(m_debugLevel).setTimeout(m_timeout), size);

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -7,7 +7,6 @@
 #include "FWCore/PluginManager/interface/PluginManager.h"
 #include "FWCore/PluginManager/interface/standard.h"
 #include "FWCore/Utilities/interface/Exception.h"
-#include <boost/shared_ptr.hpp>
 
 StorageFactory StorageFactory::s_instance;
 
@@ -106,7 +105,7 @@ StorageFactory::setTempDir(const std::string &s, double minFreeSpace)
 
   m_temppath = s;
   m_tempfree = minFreeSpace;
-  m_tempdir = m_lfs.findCachePath(dirs, minFreeSpace);
+  std::tie(m_tempdir, m_unusableDirWarnings) = m_lfs.findCachePath(dirs, minFreeSpace);
 
 #if 0
   std::cerr /* edm::LogInfo("StorageFactory") */

--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -291,16 +291,5 @@ StorageFactory::wrapNonLocalFile (std::unique_ptr<Storage> s,
   return s;
 }
 
-void
-StorageFactory::activateTimeout (const std::string &url)
-{
-  std::string protocol;
-  std::string rest;
-
-  if (StorageMaker *maker = getMaker (url, protocol, rest))
-  {
-    maker->setTimeout (m_timeout);
-  }
-}
 
 

--- a/Utilities/StorageFactory/src/StorageMaker.cc
+++ b/Utilities/StorageFactory/src/StorageMaker.cc
@@ -36,13 +36,12 @@ StorageMaker::check (const std::string &proto,
   // destructor or close method.
   bool found = false;
   int mode = IOFlags::OpenRead | IOFlags::OpenUnbuffered;
-  if (Storage *s = open (proto, path, mode))
+  if (auto s = open (proto, path, mode))
   {
     if (size)
       *size = s->size ();
 
     s->close ();
-    delete s;
 
     found = true;
   }

--- a/Utilities/StorageFactory/src/StorageMaker.cc
+++ b/Utilities/StorageFactory/src/StorageMaker.cc
@@ -3,29 +3,17 @@
 #include "Utilities/StorageFactory/interface/IOFlags.h"
 #include <cstdlib>
 
-StorageMaker::StorageMaker (void)
-{}
-
-StorageMaker::~StorageMaker (void)
-{}
-
 void
 StorageMaker::stagein (const std::string &/*proto*/,
-                       const std::string &/*path*/)
-{}
-
-void
-StorageMaker::setTimeout (unsigned int /*timeout*/)
-{}
-
-void
-StorageMaker::setDebugLevel (unsigned int /*level*/)
+                       const std::string &/*path*/,
+                       const AuxSettings& ) const
 {}
 
 bool
 StorageMaker::check (const std::string &proto,
 		     const std::string &path,
-		     IOOffset *size /* = 0 */)
+         const AuxSettings& aux,
+		     IOOffset *size /* = 0 */) const
 {
   // Fallback method is to open the file and check its
   // size.  Because grid jobs run in a directory where
@@ -36,7 +24,7 @@ StorageMaker::check (const std::string &proto,
   // destructor or close method.
   bool found = false;
   int mode = IOFlags::OpenRead | IOFlags::OpenUnbuffered;
-  if (auto s = open (proto, path, mode))
+  if (auto s = open (proto, path, mode, aux))
   {
     if (size)
       *size = s->size ();

--- a/Utilities/StorageFactory/test/Test.h
+++ b/Utilities/StorageFactory/test/Test.h
@@ -16,7 +16,7 @@ static void initTest(void)
   edmplugin::PluginManager::configure(edmplugin::standard::config());
 
   // Enable storage accounting
-  StorageFactory::get ()->enableAccounting (true);
+  StorageFactory::getToModify ()->enableAccounting (true);
 
   // This interface sucks but does the job, which is to silence
   // the message logger chatter about "info" or "debug" messages,

--- a/Utilities/StorageFactory/test/any.cpp
+++ b/Utilities/StorageFactory/test/any.cpp
@@ -19,7 +19,7 @@ int main (int argc, char **argv) try
   if (! exists) return EXIT_SUCCESS;
 
   static const int SIZE = 1048576;
-  Storage	*s = StorageFactory::get ()->open (argv [1]);
+  auto s = StorageFactory::get ()->open (argv [1]);
   char		*buf = (char *) malloc (SIZE);
   IOSize	n;
 
@@ -27,7 +27,6 @@ int main (int argc, char **argv) try
     std::cout.write (buf, n);
 
   s->close();
-  delete s;
   free (buf);
 
   std::cerr << StorageAccount::summaryXML () << std::endl;

--- a/Utilities/StorageFactory/test/any.cpp
+++ b/Utilities/StorageFactory/test/any.cpp
@@ -29,7 +29,7 @@ int main (int argc, char **argv) try
   s->close();
   free (buf);
 
-  std::cerr << StorageAccount::summaryXML () << std::endl;
+  std::cerr << StorageAccount::summaryText(true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/ftp.cpp
+++ b/Utilities/StorageFactory/test/ftp.cpp
@@ -10,7 +10,7 @@ int main (int, char **/*argv*/) try
     ("ftp://cmsdoc.cern.ch/WELCOME", &size);
 
   std::cout << "exists = " << exists << ", size = " << size << "\n";
-  std::cout << StorageAccount::summaryXML () << std::endl;
+  std::cout << StorageAccount::summaryText(true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/ftp2.cpp
+++ b/Utilities/StorageFactory/test/ftp2.cpp
@@ -10,7 +10,7 @@ int main (int, char **/*argv*/) try
     ("ftp://cmsdoc.cern.ch/non-existent", &size);
 
   std::cout << "exists = " << exists << ", size = " << size << "\n";
-  std::cout << StorageAccount::summaryXML () << std::endl;
+  std::cout << StorageAccount::summaryText (true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/http.cpp
+++ b/Utilities/StorageFactory/test/http.cpp
@@ -18,7 +18,7 @@ int main (int, char **/*argv*/) try
 
   s->close();
 
-  std::cerr << StorageAccount::summaryXML () << std::endl;
+  std::cerr << StorageAccount::summaryText (true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/http.cpp
+++ b/Utilities/StorageFactory/test/http.cpp
@@ -9,7 +9,7 @@ int main (int, char **/*argv*/) try
 
   IOSize	n;
   char		buf [1024];
-  Storage	*s = StorageFactory::get ()->open
+  auto s = StorageFactory::get ()->open
     ("http://home.web.cern.ch", IOFlags::OpenRead);
 
   assert (s);
@@ -17,7 +17,6 @@ int main (int, char **/*argv*/) try
     std::cout.write (buf, n);
 
   s->close();
-  delete s;
 
   std::cerr << StorageAccount::summaryXML () << std::endl;
   return EXIT_SUCCESS;

--- a/Utilities/StorageFactory/test/local.cpp
+++ b/Utilities/StorageFactory/test/local.cpp
@@ -6,7 +6,7 @@ int main (int, char **/*argv*/) try
 {
   initTest();
 
-  Storage	*s = StorageFactory::get ()->open ("/etc/passwd");
+  auto s = StorageFactory::get ()->open ("/etc/passwd");
   char		buf [1024];
   IOSize	n;
 
@@ -14,7 +14,6 @@ int main (int, char **/*argv*/) try
 	std::cout.write (buf, n);
 
   s->close();
-  delete s;
 
   std::cout << StorageAccount::summaryXML () << std::endl;
   return EXIT_SUCCESS;

--- a/Utilities/StorageFactory/test/local.cpp
+++ b/Utilities/StorageFactory/test/local.cpp
@@ -15,7 +15,7 @@ int main (int, char **/*argv*/) try
 
   s->close();
 
-  std::cout << StorageAccount::summaryXML () << std::endl;
+  std::cout << StorageAccount::summaryText (true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/randomread.cpp
+++ b/Utilities/StorageFactory/test/randomread.cpp
@@ -36,7 +36,7 @@ int main (int argc, char **argv) try
   if (sizes.empty())
     return EXIT_SUCCESS;
 
-  std::cout << "stats:\n" << StorageAccount::summaryXML () << std::endl;
+  std::cout << "stats:\n" << StorageAccount::summaryText (true) << std::endl;
 
   IOSize	n;
   char		buf [10000];
@@ -67,7 +67,7 @@ int main (int argc, char **argv) try
     storages[i]->close();
   }
 
-  std::cout << StorageAccount::summaryXML () << std::endl;
+  std::cout << StorageAccount::summaryText(true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/randomread.cpp
+++ b/Utilities/StorageFactory/test/randomread.cpp
@@ -15,8 +15,8 @@ int main (int argc, char **argv) try
     return EXIT_FAILURE;
   }
 
-  StorageFactory::get ()->enableAccounting(true);
-  std::vector<Storage *> storages;
+  StorageFactory::getToModify ()->enableAccounting(true);
+  std::vector<std::unique_ptr<Storage>> storages;
   std::vector<IOOffset> sizes;	
   for (int i = 1; i < argc; ++i)
   {
@@ -65,7 +65,6 @@ int main (int argc, char **argv) try
   for (size_t i = 0; i < sizes.size(); ++i) 
   {
     storages[i]->close();
-    delete storages[i];
   }
 
   std::cout << StorageAccount::summaryXML () << std::endl;

--- a/Utilities/StorageFactory/test/rfio2.cpp
+++ b/Utilities/StorageFactory/test/rfio2.cpp
@@ -11,7 +11,7 @@ int main (int, char **/*argv*/) try
      "ORCA_7_5_2/PoolFileCatalog.xml", &size);
 
   std::cout << "exists = " << exists << ", size = " << size << "\n";
-  std::cout << StorageAccount::summaryXML() << std::endl;
+  std::cout << StorageAccount::summaryText(true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/rfio3.cpp
+++ b/Utilities/StorageFactory/test/rfio3.cpp
@@ -10,7 +10,7 @@ int main (int, char **/*argv*/) try
      "ORCA_7_5_2/PoolFileCatalog.xmlx");
 
   std::cout << "exists = " << exists << "\n";
-  std::cout << StorageAccount::summaryXML() << std::endl;
+  std::cout << StorageAccount::summaryText(true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/t0Repack.cpp
+++ b/Utilities/StorageFactory/test/t0Repack.cpp
@@ -21,12 +21,12 @@ int main (int argc, char **argv) try
 
   int			 datasetN = ::atoi(argv [1]);
   std::string		 outputURL = argv[2];
-  Storage		 *outputFile = 0;
+  std::unique_ptr<Storage> outputFile = 0;
   IOSize		 totSize = 0;
-  std::vector<Storage *> indexFiles;
+  std::vector<std::unique_ptr<Storage >> indexFiles;
   std::vector<IOOffset>  indexSizes;
 
-  StorageFactory::get ()->enableAccounting(true);
+  StorageFactory::getToModify ()->enableAccounting(true);
   std::cerr << "write to file " << outputURL << " " << datasetN << " datasets\n";
 
   for (int i = 3; i < argc; ++i)
@@ -103,7 +103,7 @@ int main (int argc, char **argv) try
     }
     line1.erase(0,pos);
 
-    Storage	*s = 0; 
+    std::unique_ptr<Storage> s;
     IOOffset	size = 0;
     try
     {
@@ -187,11 +187,9 @@ int main (int argc, char **argv) try
     }
 
     s->close();
-    delete s;
   }
 
   outputFile->close();
-  delete outputFile;
 
   std::cout << "copied a total of " << totSize << " bytes" << std::endl;
   std::cout << StorageAccount::summaryXML () << std::endl;

--- a/Utilities/StorageFactory/test/t0Repack.cpp
+++ b/Utilities/StorageFactory/test/t0Repack.cpp
@@ -192,7 +192,7 @@ int main (int argc, char **argv) try
   outputFile->close();
 
   std::cout << "copied a total of " << totSize << " bytes" << std::endl;
-  std::cout << StorageAccount::summaryXML () << std::endl;
+  std::cout << StorageAccount::summaryText (true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/threadsafe.cpp
+++ b/Utilities/StorageFactory/test/threadsafe.cpp
@@ -29,7 +29,7 @@ int main (int, char **) try
     threads.create_thread(&dump);
   threads.join_all();
 
-  std::cout << StorageAccount::summaryXML () << std::endl;
+  std::cout << StorageAccount::summaryText (true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/write.cpp
+++ b/Utilities/StorageFactory/test/write.cpp
@@ -26,7 +26,7 @@ int main (int argc, char *argv[]) try
     input.close ();
     s->close ();
 
-  std::cout << StorageAccount::summaryXML() << std::endl;
+  std::cout << StorageAccount::summaryText(true) << std::endl;
   return EXIT_SUCCESS;
 } catch(cms::Exception const& e) {
   std::cerr << e.explainSelf() << std::endl;

--- a/Utilities/StorageFactory/test/write.cpp
+++ b/Utilities/StorageFactory/test/write.cpp
@@ -17,7 +17,7 @@ int main (int argc, char *argv[]) try
     IOSize		bytes;
     unsigned char	buf [4096];
     File		input ("/etc/profile");
-    Storage		*s = StorageFactory::get ()->open
+    auto s = StorageFactory::get ()->open
       (path.c_str (), IOFlags::OpenWrite|IOFlags::OpenCreate|IOFlags::OpenTruncate);
 
     while ((bytes = input.read (buf, sizeof (buf))))

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -22,7 +22,7 @@ public:
 
 };
 
-class XrdStorageMaker : public StorageMaker
+class XrdStorageMaker final : public StorageMaker
 {
 public:
   static const unsigned int XRD_DEFAULT_TIMEOUT = 3*60;
@@ -44,12 +44,12 @@ public:
 
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
-  virtual Storage *open (const std::string &proto,
+  virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
 			 int mode) override
   {
 
-    StorageFactory *f = StorageFactory::get();
+    const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
     StorageFactory::CacheHint cacheHint = f->cacheHint();
 
@@ -60,8 +60,8 @@ public:
       mode |=  IOFlags::OpenUnbuffered;
 
     std::string fullpath(proto + ":" + path);
-    Storage *file = new XrdFile (fullpath, mode);
-    return f->wrapNonLocalFile(file, proto, std::string(), mode);
+    auto file = std::make_unique<XrdFile>(fullpath, mode);
+    return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
   }
 
   virtual void stagein (const std::string &proto, const std::string &path) override

--- a/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
+++ b/Utilities/XrdAdaptor/plugins/XrdStorageMaker.cc
@@ -11,6 +11,9 @@
 #include "XrdCl/XrdClDefaultEnv.hh"
 #include "XrdNet/XrdNetUtils.hh"
 
+#include <atomic>
+#include <mutex>
+
 class MakerResponseHandler : public XrdCl::ResponseHandler
 {
 public:
@@ -27,7 +30,9 @@ class XrdStorageMaker final : public StorageMaker
 public:
   static const unsigned int XRD_DEFAULT_TIMEOUT = 3*60;
 
-  XrdStorageMaker()
+  XrdStorageMaker():
+  m_lastDebugLevel(1),//so that 0 will trigger change
+  m_lastTimeout(0)
   {
     // When CMSSW loads, both XrdCl and XrdClient end up being loaded
     // (ROOT loads XrdClient).  XrdClient forces IPv4-only.  Accordingly,
@@ -40,15 +45,19 @@ public:
     }
     XrdNetUtils::SetAuto(XrdNetUtils::prefAuto);
     setTimeout(XRD_DEFAULT_TIMEOUT);
+    setDebugLevel(0);
   }
 
   /** Open a storage object for the given URL (protocol + path), using the
       @a mode bits.  No temporary files are downloaded.  */
   virtual std::unique_ptr<Storage> open (const std::string &proto,
 			 const std::string &path,
-			 int mode) override
+			 int mode,
+       const AuxSettings& aux) const override
   {
-
+    setDebugLevel(aux.debugLevel);
+    setTimeout(aux.timeout);
+    
     const StorageFactory *f = StorageFactory::get();
     StorageFactory::ReadHint readHint = f->readHint();
     StorageFactory::CacheHint cacheHint = f->cacheHint();
@@ -64,8 +73,12 @@ public:
     return f->wrapNonLocalFile(std::move(file), proto, std::string(), mode);
   }
 
-  virtual void stagein (const std::string &proto, const std::string &path) override
+  virtual void stagein (const std::string &proto, const std::string &path,
+                        const AuxSettings& aux) const override
   {
+    setDebugLevel(aux.debugLevel);
+    setTimeout(aux.timeout);
+
     std::string fullpath(proto + ":" + path);
     XrdCl::URL url(fullpath);
     XrdCl::FileSystem fs(url);
@@ -75,8 +88,12 @@ public:
 
   virtual bool check (const std::string &proto,
 		      const std::string &path,
-		      IOOffset *size = 0) override
+          const AuxSettings& aux,
+		      IOOffset *size = 0) const override
   {
+    setDebugLevel(aux.debugLevel);
+    setTimeout(aux.timeout);
+
     std::string fullpath(proto + ":" + path);
     XrdCl::URL url(fullpath);
     XrdCl::FileSystem fs(url);
@@ -91,8 +108,18 @@ public:
     return true;
   }
 
-  virtual void setDebugLevel (unsigned int level) override
+  void setDebugLevel (unsigned int level) const
   {
+    auto oldLevel = m_lastDebugLevel.load();
+    if(level == oldLevel) {
+      return;
+    }
+    std::lock_guard<std::mutex> guard(m_envMutex);
+    if(oldLevel != m_lastDebugLevel) {
+      //another thread just changed this value
+      return;
+    }
+    
     // 'Error' is way too low of debug level - we have interest
     // in warning in the default
     switch (level)
@@ -118,11 +145,24 @@ public:
         ex.addContext("Calling XrdStorageMaker::setDebugLevel()");
         throw ex;
     }
+    m_lastDebugLevel = level;
   }
 
-  virtual void setTimeout(unsigned int timeout) override
+  void setTimeout(unsigned int timeout) const
   {
     timeout = timeout ? timeout : XRD_DEFAULT_TIMEOUT;
+
+    auto oldTimeout = m_lastTimeout.load();
+    if (oldTimeout == timeout) {
+      return;
+    }
+    
+    std::lock_guard<std::mutex> guard(m_envMutex);
+    if (oldTimeout != m_lastTimeout) {
+      //Another thread beat us to changing the value
+      return;
+    }
+    
     XrdCl::Env *env = XrdCl::DefaultEnv::GetEnv();
     if (env)
     {
@@ -136,10 +176,14 @@ public:
       env->PutInt("ConnectionWindow", timeout/6+1);
       env->PutInt("ConnectionRetry", 2);
     }
+    m_lastTimeout = timeout;
   }
 
 private:
-  MakerResponseHandler m_null_handler;
+  [[cms::thread_safe]] mutable MakerResponseHandler m_null_handler;
+  mutable std::mutex m_envMutex;
+  mutable std::atomic<unsigned int> m_lastDebugLevel;
+  mutable std::atomic<unsigned int> m_lastTimeout;
 };
 
 DEFINE_EDM_PLUGIN (StorageMakerFactory, XrdStorageMaker, "root");


### PR DESCRIPTION
Changed StorageAccounting so that all methods are thread-safe.
Also changed the iterface to avoid multiple lookups via strings.
