### PR TITLE
hcal strip filter

### DIFF
--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -17,6 +17,9 @@
 #include "DataFormats/METReco/interface/HcalHaloData.h" 
 #include "DataFormats/METReco/interface/GlobalHaloData.h" 
 
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
+
 namespace reco {
   class BeamHaloInfoProducer;
   
@@ -70,6 +73,12 @@ namespace reco {
     std::vector<int>& GetGlobaliPhiSuspects() { return GlobaliPhiSuspects ;}
     const std::vector<int>& GetGlobaliPhiSuspects() const { return GlobaliPhiSuspects ;}
 
+    std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips() { return ProblematicStrips ;}
+    const std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips() const { return ProblematicStrips ;}
+
+    const std::vector<float> & GetProblematicStripsHadEt() const {return ProblematicStripHadEt;}
+    std::vector<float> & GetProblematicStripsHadEt() {return ProblematicStripHadEt;}
+
   private: 
     std::vector<char>  HcalHaloReport;
     std::vector<char>  EcalHaloReport;
@@ -79,6 +88,9 @@ namespace reco {
     std::vector<int>  HcaliPhiSuspects;
     std::vector<int>  EcaliPhiSuspects;
     std::vector<int>  GlobaliPhiSuspects;
+
+    std::vector<std::vector<std::pair<char, CaloTowerDetId> > > ProblematicStrips;
+    std::vector<float> ProblematicStripHadEt;
 
   };
   

--- a/DataFormats/METReco/interface/BeamHaloSummary.h
+++ b/DataFormats/METReco/interface/BeamHaloSummary.h
@@ -73,11 +73,8 @@ namespace reco {
     std::vector<int>& GetGlobaliPhiSuspects() { return GlobaliPhiSuspects ;}
     const std::vector<int>& GetGlobaliPhiSuspects() const { return GlobaliPhiSuspects ;}
 
-    std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips() { return ProblematicStrips ;}
-    const std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips() const { return ProblematicStrips ;}
-
-    const std::vector<float> & GetProblematicStripsHadEt() const {return ProblematicStripHadEt;}
-    std::vector<float> & GetProblematicStripsHadEt() {return ProblematicStripHadEt;}
+    std::vector<HaloTowerStrip>& getProblematicStrips() { return problematicStrips ;}
+    const std::vector<HaloTowerStrip>& getProblematicStrips() const { return problematicStrips ;}
 
   private: 
     std::vector<char>  HcalHaloReport;
@@ -89,8 +86,7 @@ namespace reco {
     std::vector<int>  EcaliPhiSuspects;
     std::vector<int>  GlobaliPhiSuspects;
 
-    std::vector<std::vector<std::pair<char, CaloTowerDetId> > > ProblematicStrips;
-    std::vector<float> ProblematicStripHadEt;
+    std::vector<HaloTowerStrip> problematicStrips;
 
   };
   

--- a/DataFormats/METReco/interface/HcalHaloData.h
+++ b/DataFormats/METReco/interface/HcalHaloData.h
@@ -8,6 +8,8 @@
 */
 #include <vector>
 #include "DataFormats/METReco/interface/PhiWedge.h"
+#include "DataFormats/DetId/interface/DetId.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
 namespace reco {
   class HcalHaloData {
@@ -20,9 +22,19 @@ namespace reco {
     // Return collection of 5-degree Phi Wedges built from Hcal RecHits
     const std::vector<PhiWedge>& GetPhiWedges() const {return PhiWedgeCollection;}
     std::vector<PhiWedge>& GetPhiWedges()  {return PhiWedgeCollection;}
-    
+
+    // Return collection of problematic strips (pairs of # of problematic HCAL cells and CaloTowerDetId)
+    const std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips() const {return ProblematicStripCollection;}
+    std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips()  {return ProblematicStripCollection;}
+
+    // Total energies of problematic strips (HCAL)
+    const std::vector<float> & GetProblematicStripsHadEt() const {return ProblematicStripHadEt;}
+    std::vector<float> & GetProblematicStripsHadEt() {return ProblematicStripHadEt;}
+
   private:
     std::vector<PhiWedge> PhiWedgeCollection;
+    std::vector<std::vector<std::pair<char, CaloTowerDetId> > > ProblematicStripCollection;
+    std::vector<float> ProblematicStripHadEt;
     
   };
 }

--- a/DataFormats/METReco/interface/HcalHaloData.h
+++ b/DataFormats/METReco/interface/HcalHaloData.h
@@ -12,17 +12,29 @@
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
 struct HaloTowerStrip {
-    std::vector<std::pair<char, CaloTowerDetId> > cellTowerIds;
+    std::vector<std::pair<uint8_t, CaloTowerDetId> > cellTowerIds;
     float hadEt;
+    HaloTowerStrip() {
+        hadEt = 0.0;
+        cellTowerIds.clear();
+    }
+    HaloTowerStrip(const HaloTowerStrip& strip) {
+        cellTowerIds = strip.cellTowerIds;
+        hadEt = strip.hadEt;
+    }
 };
 
 namespace reco {
+
   class HcalHaloData {
+
   public:
     //constructor
     HcalHaloData();
     //destructor
     ~HcalHaloData(){}
+
+
     
     // Return collection of 5-degree Phi Wedges built from Hcal RecHits
     const std::vector<PhiWedge>& GetPhiWedges() const {return PhiWedgeCollection;}

--- a/DataFormats/METReco/interface/HcalHaloData.h
+++ b/DataFormats/METReco/interface/HcalHaloData.h
@@ -11,6 +11,11 @@
 #include "DataFormats/DetId/interface/DetId.h"
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
 
+struct HaloTowerStrip {
+    std::vector<std::pair<char, CaloTowerDetId> > cellTowerIds;
+    float hadEt;
+};
+
 namespace reco {
   class HcalHaloData {
   public:
@@ -24,17 +29,12 @@ namespace reco {
     std::vector<PhiWedge>& GetPhiWedges()  {return PhiWedgeCollection;}
 
     // Return collection of problematic strips (pairs of # of problematic HCAL cells and CaloTowerDetId)
-    const std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips() const {return ProblematicStripCollection;}
-    std::vector<std::vector<std::pair<char, CaloTowerDetId> > >& GetProblematicStrips()  {return ProblematicStripCollection;}
-
-    // Total energies of problematic strips (HCAL)
-    const std::vector<float> & GetProblematicStripsHadEt() const {return ProblematicStripHadEt;}
-    std::vector<float> & GetProblematicStripsHadEt() {return ProblematicStripHadEt;}
+    const std::vector<HaloTowerStrip>& getProblematicStrips() const {return problematicStripCollection;}
+    std::vector<HaloTowerStrip>& getProblematicStrips()  {return problematicStripCollection;}
 
   private:
     std::vector<PhiWedge> PhiWedgeCollection;
-    std::vector<std::vector<std::pair<char, CaloTowerDetId> > > ProblematicStripCollection;
-    std::vector<float> ProblematicStripHadEt;
+    std::vector<HaloTowerStrip> problematicStripCollection;
     
   };
 }

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -164,8 +164,8 @@
   </class>
   <class name="edm::Wrapper<reco::EcalHaloData>"/>
 
-  <class name="reco::HcalHaloData" ClassVersion="10">
-   <version ClassVersion="10" checksum="3928363167"/>
+  <class name="reco::HcalHaloData" ClassVersion="11">
+   <version ClassVersion="11" checksum="624180652"/>
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
@@ -179,8 +179,8 @@
   </class>
   <class name="edm::Wrapper<reco::GlobalHaloData>"/>
 
-  <class name="reco::BeamHaloSummary" ClassVersion="10">
-   <version ClassVersion="10" checksum="1514181401"/>
+  <class name="reco::BeamHaloSummary" ClassVersion="11">
+   <version ClassVersion="11" checksum="2109605555"/>
   </class>
   <class name="edm::Wrapper<reco::BeamHaloSummary>"/>
 

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -170,6 +170,9 @@
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
+  <class name="std::vector<HaloTowerStrip>"/>
+  <class name="edm::Wrapper<std::vector<HaloTowerStrip> >"/>
+
   <class name="reco::CSCHaloData" ClassVersion="10">
    <version ClassVersion="10" checksum="3522217120"/>
   </class>

--- a/DataFormats/METReco/src/classes_def.xml
+++ b/DataFormats/METReco/src/classes_def.xml
@@ -165,7 +165,8 @@
   <class name="edm::Wrapper<reco::EcalHaloData>"/>
 
   <class name="reco::HcalHaloData" ClassVersion="11">
-   <version ClassVersion="11" checksum="624180652"/>
+   <version ClassVersion="10" checksum="3928363167"/>
+   <version ClassVersion="11" checksum="3305429659"/>
   </class>
   <class name="edm::Wrapper<reco::HcalHaloData>"/>
 
@@ -180,7 +181,8 @@
   <class name="edm::Wrapper<reco::GlobalHaloData>"/>
 
   <class name="reco::BeamHaloSummary" ClassVersion="11">
-   <version ClassVersion="11" checksum="2109605555"/>
+   <version ClassVersion="10" checksum="1514181401"/>
+   <version ClassVersion="11" checksum="146570384"/>
   </class>
   <class name="edm::Wrapper<reco::BeamHaloSummary>"/>
 

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -2,7 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 ## We don't use "import *" because the cff contains some modules for which the C++ class doesn't exist
 ## and this triggers an error under unscheduled mode
-from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, CSCTightHaloFilter, hcalLaserEventFilter, EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter, primaryVertexFilter 
+from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, CSCTightHaloFilter, HcalStripHaloFilter, hcalLaserEventFilter, EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter, primaryVertexFilter 
 from RecoMET.METFilters.metFilters_cff import goodVertices, trackingFailureFilter, trkPOGFilters, manystripclus53X, toomanystripclus53X, logErrorTooManyClusters
 from RecoMET.METFilters.metFilters_cff import metFilters
 
@@ -10,6 +10,7 @@ from RecoMET.METFilters.metFilters_cff import metFilters
 Flag_HBHENoiseFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseFilter)
 Flag_HBHENoiseIsoFilter = cms.Path(HBHENoiseFilterResultProducer * HBHENoiseIsoFilter)
 Flag_CSCTightHaloFilter = cms.Path(CSCTightHaloFilter)
+Flag_HcalStripHaloFilter = cms.Path(HcalStripHaloFilter)
 Flag_hcalLaserEventFilter = cms.Path(hcalLaserEventFilter)
 Flag_EcalDeadCellTriggerPrimitiveFilter = cms.Path(EcalDeadCellTriggerPrimitiveFilter)
 Flag_EcalDeadCellBoundaryEnergyFilter = cms.Path(EcalDeadCellBoundaryEnergyFilter)
@@ -28,7 +29,7 @@ Flag_trkPOG_logErrorTooManyClusters = cms.Path(~logErrorTooManyClusters)
 Flag_METFilters = cms.Path(metFilters)
 
 #add your new path here!!
-allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
+allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','HcalStripHaloFilter','hcalLaserEventFilter','EcalDeadCellTriggerPrimitiveFilter','EcalDeadCellBoundaryEnergyFilter','goodVertices','eeBadScFilter',
                    'ecalLaserCorrFilter','trkPOGFilters','trkPOG_manystripclus53X','trkPOG_toomanystripclus53X','trkPOG_logErrorTooManyClusters','METFilters']
 
        

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -35,7 +35,7 @@ allMetFilterPaths=['HBHENoiseFilter','HBHENoiseIsoFilter','CSCTightHaloFilter','
        
 def miniAOD_customizeMETFiltersFastSim(process):
     """Replace some MET filters that don't work in FastSim with trivial bools"""
-    for X in 'CSCTightHaloFilter', 'HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer':
+    for X in 'CSCTightHaloFilter', 'HBHENoiseFilter', 'HBHENoiseIsoFilter', 'HBHENoiseFilterResultProducer', 'HcalStripHaloFilter':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(True)))
     for X in 'manystripclus53X', 'toomanystripclus53X', 'logErrorTooManyClusters':
         process.globalReplace(X, cms.EDFilter("HLTBool", result=cms.bool(False)))

--- a/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
+++ b/PhysicsTools/PatAlgos/python/slimming/metFilterPaths_cff.py
@@ -2,7 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 ## We don't use "import *" because the cff contains some modules for which the C++ class doesn't exist
 ## and this triggers an error under unscheduled mode
-from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, CSCTightHaloFilter, HcalStripHaloFilter, hcalLaserEventFilter, EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter, primaryVertexFilter 
+from RecoMET.METFilters.metFilters_cff import HBHENoiseFilterResultProducer, HBHENoiseFilter, HBHENoiseIsoFilter, hcalLaserEventFilter
+from RecoMET.METFilters.metFilters_cff import EcalDeadCellTriggerPrimitiveFilter, eeBadScFilter, ecalLaserCorrFilter, EcalDeadCellBoundaryEnergyFilter
+from RecoMET.METFilters.metFilters_cff import primaryVertexFilter, CSCTightHaloFilter, HcalStripHaloFilter
+
 from RecoMET.METFilters.metFilters_cff import goodVertices, trackingFailureFilter, trkPOGFilters, manystripclus53X, toomanystripclus53X, logErrorTooManyClusters
 from RecoMET.METFilters.metFilters_cff import metFilters
 

--- a/RecoMET/METAlgorithms/interface/HcalHaloAlgo.h
+++ b/RecoMET/METAlgorithms/interface/HcalHaloAlgo.h
@@ -23,6 +23,9 @@
 #include "DataFormats/HcalRecHit/interface/HORecHit.h"
 #include "DataFormats/HcalRecHit/interface/HcalRecHitCollections.h"
 #include "DataFormats/CaloRecHit/interface/CaloRecHit.h"
+#include "DataFormats/CaloTowers/interface/CaloTower.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 
 class HcalHaloAlgo{
  public:
@@ -32,6 +35,8 @@ class HcalHaloAlgo{
   ~HcalHaloAlgo(){}
   
   // run algorithm
+  reco::HcalHaloData Calculate(const CaloGeometry& TheCaloGeometry, edm::Handle<HBHERecHitCollection>& TheHBHERecHits, edm::Handle<CaloTowerCollection>& TheCaloTowers);
+
   reco::HcalHaloData Calculate(const CaloGeometry& TheCaloGeometry, edm::Handle<HBHERecHitCollection>& TheHBHERecHits);
   
   // Set RecHit Energy Thresholds

--- a/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
@@ -13,6 +13,9 @@ using namespace reco;
 
 #include <iomanip>
 bool CompareTime(const HBHERecHit* x, const HBHERecHit* y ){ return x->time() < y->time() ;}
+bool CompareTowers(const CaloTower* x, const CaloTower* y ){ 
+  return x->iphi()*1000 + x->ieta() < y->iphi()*1000 + y->ieta();
+}
 
 HcalHaloAlgo::HcalHaloAlgo()
 {
@@ -22,7 +25,12 @@ HcalHaloAlgo::HcalHaloAlgo()
   NHitsThreshold = 0;
 }
 
-HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::Handle<HBHERecHitCollection>& TheHBHERecHits)
+HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::Handle<HBHERecHitCollection>& TheHBHERecHits) {
+    edm::Handle<CaloTowerCollection> TheCaloTowers;
+    return Calculate(TheCaloGeometry, TheHBHERecHits, TheCaloTowers);
+}
+
+HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::Handle<HBHERecHitCollection>& TheHBHERecHits, edm::Handle<CaloTowerCollection>& TheCaloTowers)
 {
   HcalHaloData TheHcalHaloData;
   
@@ -119,6 +127,66 @@ HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::H
 	  TheHcalHaloData.GetPhiWedges().push_back( wedge );
 	}
     }
+
+  // Don't use HF.
+  int maxAbsIEta = 29;
+  std::vector<const CaloTower*> SortedCaloTowers;
+  for(CaloTowerCollection::const_iterator tower = TheCaloTowers->begin(); tower != TheCaloTowers->end(); tower++) {
+    if(abs(tower->ieta()) <= maxAbsIEta && tower->numProblematicHcalCells() > 0)
+      SortedCaloTowers.push_back(&(*tower));
+  }
+
+  // Sort towers such that lowest iphi and ieta are first, highest last, and towers
+  // with same iphi value are consecutive. Then we can do everything else in one loop.
+  std::sort(SortedCaloTowers.begin(), SortedCaloTowers.end(), CompareTowers);
+
+  std::vector<std::pair<char, CaloTowerDetId> > problematicStrip;
+  float stripHadEt = 0.0;
+
+  int prevIEta = -99, prevIPhi = -99;
+  float prevHadEt = 0.0;
+  std::pair<char, CaloTowerDetId> prevPair, towerPair;
+  bool wasContiguous = true;
+  // Loop through and store a vector of pairs (problematicCells, DetId) for each contiguous strip we find
+  for(unsigned int i = 0; i < SortedCaloTowers.size(); i++) {
+    const CaloTower* tower = SortedCaloTowers.at(i);
+    int problematicCells = tower->numProblematicHcalCells();
+
+    towerPair = std::make_pair((char)problematicCells, tower->id());
+
+    bool newIPhi = (tower->iphi()-1 == prevIPhi) || (i == 0);
+    bool isContiguous = tower->ieta() == 1 ? tower->ieta() - 2 == prevIEta : tower->ieta() - 1 == prevIEta;
+
+    isContiguous = isContiguous || (tower->ieta() == -maxAbsIEta);
+    if(newIPhi) isContiguous = false;
+
+    if(!wasContiguous && isContiguous) {
+      problematicStrip.push_back(prevPair);
+      problematicStrip.push_back(towerPair);
+      stripHadEt += prevHadEt + tower->hadEt();
+    }
+
+    if(wasContiguous && isContiguous) {
+      problematicStrip.push_back(towerPair);
+      stripHadEt += tower->hadEt();
+    }
+
+    if((wasContiguous && !isContiguous) || i == SortedCaloTowers.size()-1) { //ended the strip, so flush it
+      if(problematicStrip.size() > 2) {
+        TheHcalHaloData.GetProblematicStrips().push_back( problematicStrip );
+        TheHcalHaloData.GetProblematicStripsHadEt().push_back( stripHadEt );
+      }
+      problematicStrip.clear();
+      stripHadEt = 0.0;
+    }
+
+    wasContiguous = isContiguous;
+    prevPair = towerPair;
+    prevIPhi = tower->iphi();
+    prevIEta = tower->ieta();
+    prevHadEt = tower->hadEt();
+  }
+
   return TheHcalHaloData;
   
 }

--- a/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
+++ b/RecoMET/METAlgorithms/src/HcalHaloAlgo.cc
@@ -141,17 +141,16 @@ HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::H
   std::sort(sortedCaloTowers.begin(), sortedCaloTowers.end(), CompareTowers);
 
   HaloTowerStrip strip;
-  strip.hadEt = 0.0;
 
   int prevIEta = -99, prevIPhi = -99;
-  float prevHadEt = 0.0;
-  std::pair<char, CaloTowerDetId> prevPair, towerPair;
+  float prevHadEt = 0.;
+  std::pair<uint8_t, CaloTowerDetId> prevPair, towerPair;
   bool wasContiguous = true;
   // Loop through and store a vector of pairs (problematicCells, DetId) for each contiguous strip we find
   for(unsigned int i = 0; i < sortedCaloTowers.size(); i++) {
     const CaloTower* tower = sortedCaloTowers[i];
 
-    towerPair = std::make_pair((char)tower->numProblematicHcalCells(), tower->id());
+    towerPair = std::make_pair((uint8_t)tower->numProblematicHcalCells(), tower->id());
 
     bool newIPhi = tower->iphi() != prevIPhi;
     bool isContiguous = tower->ieta() == 1 ? tower->ieta() - 2 == prevIEta : tower->ieta() - 1 == prevIEta;
@@ -174,8 +173,7 @@ HcalHaloData HcalHaloAlgo::Calculate(const CaloGeometry& TheCaloGeometry, edm::H
       if(strip.cellTowerIds.size() > 2) {
         TheHcalHaloData.getProblematicStrips().push_back( strip );
       }
-      strip.cellTowerIds.clear();
-      strip.hadEt = 0.0;
+      strip = HaloTowerStrip();
     }
 
     wasContiguous = isContiguous;

--- a/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
+++ b/RecoMET/METFilters/plugins/HcalStripHaloFilter.cc
@@ -1,0 +1,57 @@
+#include "FWCore/Framework/interface/Frameworkfwd.h"
+#include "FWCore/Framework/interface/EDFilter.h"
+#include "FWCore/Framework/interface/Event.h"
+#include "FWCore/ParameterSet/interface/ParameterSet.h"
+#include "DataFormats/METReco/interface/BeamHaloSummary.h"
+
+class HcalStripHaloFilter : public edm::EDFilter {
+
+  public:
+
+    explicit HcalStripHaloFilter(const edm::ParameterSet & iConfig);
+    ~HcalStripHaloFilter() {}
+
+  private:
+
+    virtual bool filter(edm::Event & iEvent, const edm::EventSetup & iSetup) override;
+
+    const bool taggingMode_;
+    const int maxWeightedStripLength_;
+    edm::EDGetTokenT<reco::BeamHaloSummary> beamHaloSummaryToken_;
+};
+
+HcalStripHaloFilter::HcalStripHaloFilter(const edm::ParameterSet & iConfig)
+  : taggingMode_     (iConfig.getParameter<bool> ("taggingMode"))
+  , maxWeightedStripLength_   (iConfig.getParameter<int>("maxWeightedStripLength"))
+  , beamHaloSummaryToken_(consumes<reco::BeamHaloSummary>(edm::InputTag("BeamHaloSummary")))
+{
+  produces<bool>();
+}
+
+bool HcalStripHaloFilter::filter(edm::Event & iEvent, const edm::EventSetup & iSetup) {
+
+  edm::Handle<reco::BeamHaloSummary> beamHaloSummary;
+  iEvent.getByToken(beamHaloSummaryToken_ , beamHaloSummary);
+
+  bool pass = true;
+  std::vector<std::vector<std::pair<char, CaloTowerDetId> > > problematicStrips = beamHaloSummary->GetProblematicStrips();
+  // std::vector<float> problematicStripsHadEt = beamHaloSummary->GetProblematicStripsHadEt();
+  for (unsigned int iStrip = 0; iStrip < problematicStrips.size(); iStrip++) {
+    int numContiguousCells = 0;
+    std::vector<std::pair<char, CaloTowerDetId> > problematicStrip = problematicStrips.at(iStrip);
+    for (unsigned int iTower = 0; iTower < problematicStrip.size(); iTower++) {
+      numContiguousCells += (int)problematicStrip.at(iTower).first;
+    }
+    if(numContiguousCells > maxWeightedStripLength_) {
+      pass = false;
+      break;
+    }
+  }
+
+  iEvent.put( std::auto_ptr<bool>(new bool(pass)) );
+
+  return taggingMode_ || pass;  // return false if it is a beamhalo event
+}
+
+#include "FWCore/Framework/interface/MakerMacros.h"
+DEFINE_FWK_MODULE(HcalStripHaloFilter);

--- a/RecoMET/METFilters/python/HcalStripHaloFilter_cfi.py
+++ b/RecoMET/METFilters/python/HcalStripHaloFilter_cfi.py
@@ -1,0 +1,7 @@
+import FWCore.ParameterSet.Config as cms
+
+HcalStripHaloFilter = cms.EDFilter(
+  "HcalStripHaloFilter",
+  taggingMode = cms.bool(False),
+  maxWeightedStripLength = cms.int32(9) # values higher than this are rejected
+)

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -59,7 +59,7 @@ metFilters = cms.Sequence(
    HBHENoiseFilterResultProducer *
    HBHENoiseFilter *
 #   HBHENoiseIsoFilter*
-   HcalStripHaloFilter *
+#   HcalStripHaloFilter *
    primaryVertexFilter*
    CSCTightHaloFilter *
 #   hcalLaserEventFilter *

--- a/RecoMET/METFilters/python/metFilters_cff.py
+++ b/RecoMET/METFilters/python/metFilters_cff.py
@@ -7,6 +7,9 @@ from CommonTools.RecoAlgos.HBHENoiseFilter_cfi import *
 ## The CSC beam halo tight filter ____________________________________________||
 from RecoMET.METFilters.CSCTightHaloFilter_cfi import *
 
+## The hcal problematic strip halo filter ____________________________________________||
+from RecoMET.METFilters.HcalStripHaloFilter_cfi import *
+
 ## The HCAL laser filter _____________________________________________________||
 from RecoMET.METFilters.hcalLaserEventFilter_cfi import *
 
@@ -56,6 +59,7 @@ metFilters = cms.Sequence(
    HBHENoiseFilterResultProducer *
    HBHENoiseFilter *
 #   HBHENoiseIsoFilter*
+   HcalStripHaloFilter *
    primaryVertexFilter*
    CSCTightHaloFilter *
 #   hcalLaserEventFilter *

--- a/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
+++ b/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
@@ -102,6 +102,8 @@ namespace reco
     int T_HcalPhiWedgeConstituents;
     float T_HcalPhiWedgeToF;
     float T_HcalPhiWedgeConfidence;
+    
+    int ProblematicStripMinLength;
   };
 }
 

--- a/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
+++ b/RecoMET/METProducers/interface/BeamHaloSummaryProducer.h
@@ -103,7 +103,7 @@ namespace reco
     float T_HcalPhiWedgeToF;
     float T_HcalPhiWedgeConfidence;
     
-    int ProblematicStripMinLength;
+    int problematicStripMinLength;
   };
 }
 

--- a/RecoMET/METProducers/interface/HcalHaloDataProducer.h
+++ b/RecoMET/METProducers/interface/HcalHaloDataProducer.h
@@ -35,6 +35,7 @@
 #include "RecoMET/METAlgorithms/interface/HcalHaloAlgo.h"
 //Included Classes (semi-alphabetical)
 #include "DataFormats/CaloTowers/interface/CaloTowerDetId.h"
+#include "DataFormats/CaloTowers/interface/CaloTowerCollection.h"
 #include "DataFormats/Candidate/interface/CandidateFwd.h"
 #include "DataFormats/Candidate/interface/Candidate.h"
 #include "DataFormats/CLHEP/interface/AlgebraicObjects.h"
@@ -97,9 +98,11 @@ namespace reco
     edm::InputTag IT_HBHERecHit;
     edm::InputTag IT_HORecHit;
     edm::InputTag IT_HFRecHit;
+    edm::InputTag IT_CaloTowers;
 
     edm::EDGetTokenT<HBHERecHitCollection> hbherechit_token_;
     edm::EDGetTokenT<HFRecHitCollection> hfrechit_token_;
+    edm::EDGetTokenT<CaloTowerCollection> calotower_token_;
 
     float HBRecHitEnergyThreshold;
     float HERecHitEnergyThreshold;

--- a/RecoMET/METProducers/python/BeamHaloSummary_cfi.py
+++ b/RecoMET/METProducers/python/BeamHaloSummary_cfi.py
@@ -40,7 +40,10 @@ BeamHaloSummary = cms.EDProducer("BeamHaloSummaryProducer",
                                  t_HcalPhiWedgeEnergy = cms.double(25.),
                                  t_HcalPhiWedgeConstituents = cms.int32(8),
                                  t_HcalPhiWedgeToF = cms.double(-100.), ### needs to be tuned when absolute timing in  HB/HE is understood w.r.t LHC
-                                 t_HcalPhiWedgeConfidence = cms.double(0.9)
+                                 t_HcalPhiWedgeConfidence = cms.double(0.9),
+
+                                 # strips of problematic cells in HCAL min cut
+                                 problematicStripMinLength = cms.int32(6)
                                  
                                  )
 

--- a/RecoMET/METProducers/python/HcalHaloData_cfi.py
+++ b/RecoMET/METProducers/python/HcalHaloData_cfi.py
@@ -9,6 +9,8 @@ HcalHaloData = cms.EDProducer("HcalHaloDataProducer",
                               HBHERecHitLabel = cms.InputTag("hbhereco"),
                               HORecHitLabel  = cms.InputTag("horeco"),
                               HFRecHitLabel = cms.InputTag("hfreco"),
+
+                              caloTowerCollName = cms.InputTag('towerMaker'),
                               
                               HcalMinMatchingRadiusParam = cms.double(110.),
                               HcalMaxMatchingRadiusParam = cms.double(490.),

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -47,6 +47,8 @@ BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfi
   T_HcalPhiWedgeToF = (float)iConfig.getParameter<double>("t_HcalPhiWedgeToF");
   T_HcalPhiWedgeConfidence = (float)iConfig.getParameter<double>("t_HcalPhiWedgeConfidence");
 
+  ProblematicStripMinLength = (int)iConfig.getParameter<int>("problematicStripMinLength");
+
   cschalodata_token_ = consumes<CSCHaloData>(IT_CSCHaloData);
   ecalhalodata_token_ = consumes<EcalHaloData>(IT_EcalHaloData);
   hcalhalodata_token_ = consumes<HcalHaloData>(IT_HcalHaloData);
@@ -209,6 +211,17 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
     TheBeamHaloSummary->GetHcalHaloReport()[0] = 1;
   if( HcalTightId ) 
     TheBeamHaloSummary->GetHcalHaloReport()[1] = 1;
+
+
+  for( unsigned int i = 0 ; i < HcalData.GetProblematicStrips().size() ; i++ ) {
+    std::vector<std::pair<char, CaloTowerDetId> > ProblematicStrip = HcalData.GetProblematicStrips().at(i);
+    float ProblematicStripHadEt = HcalData.GetProblematicStripsHadEt().at(i);
+    if(ProblematicStrip.size() < (unsigned int)ProblematicStripMinLength) continue;
+
+    TheBeamHaloSummary->GetProblematicStrips().push_back(ProblematicStrip);
+    TheBeamHaloSummary->GetProblematicStripsHadEt().push_back(ProblematicStripHadEt);
+  }
+
 
   // Global Halo Data
   Handle<GlobalHaloData> TheGlobalHaloData;

--- a/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
+++ b/RecoMET/METProducers/src/BeamHaloSummaryProducer.cc
@@ -47,7 +47,7 @@ BeamHaloSummaryProducer::BeamHaloSummaryProducer(const edm::ParameterSet& iConfi
   T_HcalPhiWedgeToF = (float)iConfig.getParameter<double>("t_HcalPhiWedgeToF");
   T_HcalPhiWedgeConfidence = (float)iConfig.getParameter<double>("t_HcalPhiWedgeConfidence");
 
-  ProblematicStripMinLength = (int)iConfig.getParameter<int>("problematicStripMinLength");
+  problematicStripMinLength = (int)iConfig.getParameter<int>("problematicStripMinLength");
 
   cschalodata_token_ = consumes<CSCHaloData>(IT_CSCHaloData);
   ecalhalodata_token_ = consumes<EcalHaloData>(IT_EcalHaloData);
@@ -213,13 +213,11 @@ void BeamHaloSummaryProducer::produce(Event& iEvent, const EventSetup& iSetup)
     TheBeamHaloSummary->GetHcalHaloReport()[1] = 1;
 
 
-  for( unsigned int i = 0 ; i < HcalData.GetProblematicStrips().size() ; i++ ) {
-    std::vector<std::pair<char, CaloTowerDetId> > ProblematicStrip = HcalData.GetProblematicStrips().at(i);
-    float ProblematicStripHadEt = HcalData.GetProblematicStripsHadEt().at(i);
-    if(ProblematicStrip.size() < (unsigned int)ProblematicStripMinLength) continue;
+  for( unsigned int i = 0 ; i < HcalData.getProblematicStrips().size() ; i++ ) {
+    auto const& problematicStrip = HcalData.getProblematicStrips()[i];
+    if(problematicStrip.cellTowerIds.size() < (unsigned int)problematicStripMinLength) continue;
 
-    TheBeamHaloSummary->GetProblematicStrips().push_back(ProblematicStrip);
-    TheBeamHaloSummary->GetProblematicStripsHadEt().push_back(ProblematicStripHadEt);
+    TheBeamHaloSummary->getProblematicStrips().push_back(problematicStrip);
   }
 
 

--- a/RecoMET/METProducers/src/HcalHaloDataProducer.cc
+++ b/RecoMET/METProducers/src/HcalHaloDataProducer.cc
@@ -18,6 +18,7 @@ HcalHaloDataProducer::HcalHaloDataProducer(const edm::ParameterSet& iConfig)
   IT_HBHERecHit  = iConfig.getParameter<edm::InputTag>("HBHERecHitLabel");
   IT_HFRecHit    = iConfig.getParameter<edm::InputTag>("HFRecHitLabel");
   IT_HORecHit    = iConfig.getParameter<edm::InputTag>("HORecHitLabel");
+  IT_CaloTowers =  iConfig.getParameter<edm::InputTag>("caloTowerCollName");
 
   HBRecHitEnergyThreshold = (float)iConfig.getParameter<double>("HBRecHitEnergyThresholdParam");
   HERecHitEnergyThreshold = (float)iConfig.getParameter<double>("HERecHitEnergyThresholdParam");
@@ -26,6 +27,7 @@ HcalHaloDataProducer::HcalHaloDataProducer(const edm::ParameterSet& iConfig)
 
   hbherechit_token_ = consumes<HBHERecHitCollection>(IT_HBHERecHit);
   hfrechit_token_ = consumes<HFRecHitCollection>(IT_HFRecHit);
+  calotower_token_     = consumes<CaloTowerCollection>(IT_CaloTowers);
 
   produces<HcalHaloData>();
 }
@@ -35,6 +37,10 @@ void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   //Get CaloGeometry
   edm::ESHandle<CaloGeometry> TheCaloGeometry;
   iSetup.get<CaloGeometryRecord>().get(TheCaloGeometry);
+
+  //Get CaloTowers
+  edm::Handle<CaloTowerCollection> TheCaloTowers;
+  iEvent.getByToken(calotower_token_, TheCaloTowers);
   
   //Get HB/HE RecHits
   edm::Handle<HBHERecHitCollection> TheHBHERecHits;
@@ -54,8 +60,13 @@ void HcalHaloDataProducer::produce(Event& iEvent, const EventSetup& iSetup)
   HcalHaloData HcalData;
   if( TheCaloGeometry.isValid() && TheHBHERecHits.isValid() )
     {
-      std::auto_ptr<HcalHaloData> HcalData( new HcalHaloData( HcalAlgo.Calculate(*TheCaloGeometry, TheHBHERecHits)  ) ) ;
-      iEvent.put ( HcalData ) ;
+      if( TheCaloTowers.isValid() ) {
+        std::auto_ptr<HcalHaloData> HcalData( new HcalHaloData( HcalAlgo.Calculate(*TheCaloGeometry, TheHBHERecHits, TheCaloTowers)  ) ) ;
+        iEvent.put ( HcalData ) ;
+      } else {
+        std::auto_ptr<HcalHaloData> HcalData( new HcalHaloData( HcalAlgo.Calculate(*TheCaloGeometry, TheHBHERecHits)  ) ) ;
+        iEvent.put ( HcalData ) ;
+      }
     }
   else 
     {


### PR DESCRIPTION
Hcal problematic cell length filter added to BeamHaloSummary. Stored vector of problematic strips analogously to "PhiWedges" inside of HcalHaloData class.
- A description of the filter (+ motivation), along with application in Data/MC, is in the pair of slides in https://indico.cern.ch/event/438533/. 
- This adds ~130 bytes/evt to the reco BeamHaloSummary object
- As for CPU time impact, the main operation is just a single loop through all the calotowers. If this still requires timing information, I will run igprof and report on the results here
