### PR TITLE
QQH1352TINPUT: '/RelValQQH1352T/' --> '/RelValQQH1352T_Tauola/'

### DIFF
--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -420,7 +420,7 @@ steps['ZMMINPUT']={'INPUT':InputInfo(dataSet='/RelValZMM/%s/GEN-SIM'%(baseDataSe
 steps['ZTTINPUT']={'INPUT':InputInfo(dataSet='/RelValZTT/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['H130GGgluonfusionINPUT']={'INPUT':InputInfo(dataSet='/RelValH130GGgluonfusion/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['PhotonJets_Pt_10INPUT']={'INPUT':InputInfo(dataSet='/RelValPhotonJets_Pt_10/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
-steps['QQH1352TINPUT']={'INPUT':InputInfo(dataSet='/RelValQQH1352T/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
+steps['QQH1352TINPUT']={'INPUT':InputInfo(dataSet='/RelValQQH1352T_Tauola/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['ADDMonoJet_d3MD3INPUT']={'INPUT':InputInfo(dataSet='/RelValADDMonoJet_d3MD3/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['WpMINPUT']={'INPUT':InputInfo(dataSet='/RelValWpM/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}
 steps['ZpMMINPUT']={'INPUT':InputInfo(dataSet='/RelValZpMM/%s/GEN-SIM'%(baseDataSetRelease[0],),location='STD')}


### PR DESCRIPTION
**204.0 QQH1352T** workflow in CMSSW_7_6_X IBs are failing due to
missing input files. It is looking for

```
/RelValQQH1352T/CMSSW_7_1_0_pre7-PRE_STA71_V3-v1/GEN-SIM
```

which is not available, but the following is:

```
/RelValQQH1352T_Tauola/CMSSW_7_1_0_pre7-PRE_STA71_V3-v1/GEN-SIM
```

I assume that a typo was made while adding `QQH1352TINPUT`.

Could someone verify this?

I am launching Jenkins tests with 204.0 included.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
