### PR TITLE
Fix DQM/PhysicsHWW by just ignoring jets with invalid parameters (76x)

### DIFF
--- a/DQM/PhysicsHWW/src/analysisSelections.cc
+++ b/DQM/PhysicsHWW/src/analysisSelections.cc
@@ -280,6 +280,9 @@ namespace HWWFunctions {
       vector <float> fixedpfjetmva_analobj; getGoodMVAs(hww, fixedpfjetmva_analobj, "mvavalue"); 
 
               for ( unsigned int i=0; i < hww.pfjets_p4().size(); ++i) {
+                  if (i >= hww.pfjets_JEC().size())
+                    break;
+
                   double jec = hww.pfjets_JEC().at(i);
 
                   if ( (hww.pfjets_p4().at(i).pt() * jec) < etThreshold ) continue;
@@ -879,6 +882,8 @@ namespace HWWFunctions {
       vector <float> fixedpfjetmva_analsel; getGoodMVAs(hww, fixedpfjetmva_analsel, "mvavalue"); 
 
               for ( unsigned int i=0; i < hww.pfjets_p4().size(); ++i) {
+                  if (i >= hww.pfjets_JEC().size())
+                    break;
                   
                   if ( hww.pfjets_p4().at(i).pt() < minPt ) continue;
                   bool ignoreJet = false;


### PR DESCRIPTION
Fixes (silences) exceptions in relvals for 76x.

https://hypernews.cern.ch/HyperNews/CMS/get/relval/3992.html
https://hypernews.cern.ch/HyperNews/CMS/get/relval/3999.html

This module needs to be rewritten (or removed).
The code currently has no maintainer and it's in a pretty bad state.

In this particular case both hww.pfjets_p4 and hww.pfjets_JEC are filled
separately (and can have different sizes), even though
array index represents the same jet. This is definitely an error.
