### PR TITLE
Utilities/StaticAnalyzers: update for Clang 3.7.0

### DIFF
--- a/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ArgSizeChecker.cpp
@@ -99,9 +99,9 @@ void ArgSizeChecker::checkPreStmt(const CXXConstructExpr *E, CheckerContext &ctx
 			   		clang::ento::PathDiagnosticLocation::createBegin(PVD, ctx.getSourceManager());
 
 				BugType * BT = new BugType(this,"Function parameter copied by value with size > max","ArgSize");
-				BugReport *report = new BugReport(*BT, os.str() , DLoc);
+				std::unique_ptr<BugReport> report = llvm::make_unique<BugReport>(*BT, os.str() , DLoc);
 				report->addRange(PVD->getSourceRange());
-	 			ctx.emitReport(report);
+	 			ctx.emitReport(std::move(report));
 				}	
 			}
 	}
@@ -164,8 +164,8 @@ void ArgSizeChecker::checkASTDecl(const CXXMethodDecl *MD, AnalysisManager& mgr,
 //		if ( fname.substr(0,oname.length()) == oname ) continue;
 
 		BugType * BT = new BugType(this,"Function parameter with size > max", "ArgSize");
-	  	BugReport *report = new BugReport(*BT, os.str() , DLoc);
-	  	BR.emitReport(report);
+	  	std::unique_ptr<BugReport> report = llvm::make_unique<BugReport>(*BT, os.str() , DLoc);
+	  	BR.emitReport(std::move(report));
 	}
 } 
 

--- a/Utilities/StaticAnalyzers/src/ClassChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ClassChecker.cpp
@@ -323,8 +323,8 @@ void WalkAST::VisitCXXConstCastExpr(clang::CXXConstCastExpr *CCE) {
      std::string tolog = "data class '"+pname+"' const function '" + mname + "' Warning: "+os.str()+".";
      writeLog(tolog);
      BugType * BT = new BugType(Checker,"const_cast used in const function ","Data Class Const Correctness");
-     BugReport * R = new BugReport(*BT,tolog,CELoc);
-     BR.emitReport(R);
+     std::unique_ptr<BugReport> R = llvm::make_unique <BugReport>(*BT,tolog,CELoc);
+     BR.emitReport(std::move(R));
      return;
 }
 
@@ -365,8 +365,8 @@ void WalkAST::ReportDeclRef( const clang::DeclRefExpr * DRE) {
           std::string tolog = "data class '"+pname+"' const function '" + mname + "' Warning: "+os.str();
           writeLog(tolog);
           BugType * BT = new BugType(Checker,"ClassChecker : non-const static local variable accessed","Data Class Const Correctness");
-          BugReport * R = new BugReport(*BT,os.str(),CELoc);
-          BR.emitReport(R);
+          std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
+          BR.emitReport(std::move(R));
           return;
      }
 
@@ -384,8 +384,8 @@ void WalkAST::ReportDeclRef( const clang::DeclRefExpr * DRE) {
           std::string tolog = "data class '"+pname+"' const function '" + mname + "' Warning: "+os.str();
           writeLog(tolog);
           BugType * BT = new BugType(Checker,"Non-const static member variable accessed","Data Class Const Correctness");
-          BugReport * R = new BugReport(*BT,os.str(),CELoc);
-          BR.emitReport(R);
+          std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
+          BR.emitReport(std::move(R));
          return;
      }
 
@@ -408,8 +408,8 @@ void WalkAST::ReportDeclRef( const clang::DeclRefExpr * DRE) {
           std::string tolog = "data class '"+pname+"' const function '" + mname + "' Warning: "+os.str();
           writeLog(tolog);
           BugType * BT = new BugType(Checker,"Non-const global static variable accessed","Data Class Const Correctness");
-          BugReport * R = new BugReport(*BT,os.str(),CELoc);
-          BR.emitReport(R);
+          std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
+          BR.emitReport(std::move(R));
          return;
      
      }
@@ -536,8 +536,8 @@ void WalkAST::ReportCall(const clang::CXXMemberCallExpr *CE) {
   if ( support::isSafeClassName(support::getQualifiedName(*MD)) ) return;
   writeLog(tolog);
   BugType * BT = new BugType(Checker,"Non-const member function could modify member data object","Data Class Const Correctness");
-  BugReport * R = new BugReport(*BT,os.str(),CELoc);
-  BR.emitReport(R);
+  std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
+  BR.emitReport(std::move(R));
   
 
 }
@@ -564,8 +564,8 @@ void WalkAST::ReportCast(const clang::ExplicitCastExpr *CE) {
 
   writeLog(tolog);
   BugType * BT = new BugType(Checker,"Const cast away from member data in const function","Data Class Const Correctness");
-  BugReport * R = new BugReport(*BT,os.str(),CELoc);
-  BR.emitReport(R);
+  std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
+  BR.emitReport(std::move(R));
 
 
 }
@@ -629,16 +629,16 @@ void WalkAST::ReportCallReturn(const clang::ReturnStmt * RS) {
   if ( (RTy->isPointerType() || RTy->isReferenceType() ) ) {
      if( !support::isConst(RTy) ) {
           BugType * BT = new BugType(Checker,"Const function returns pointer or reference to non-const member data object","Data Class Const Correctness");
-          BugReport * R = new BugReport(*BT,os.str(),CELoc);
-          BR.emitReport(R);
+          std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
+          BR.emitReport(std::move(R));
      }
   }
   std::string svname = "const class std::vector<";
   std::string rtname = RTy.getAsString();
   if (  (RTy->isReferenceType() || RTy ->isRecordType() ) && support::isConst(RTy) && rtname.substr(0,svname.length()) == svname ) {
      BugType * BT = new BugType(Checker,"Const function returns member data object of type const std::vector<*> or const std::vector<*>&","Data Class Const Correctness");
-     BugReport * R = new BugReport(*BT,os.str(),CELoc);
-     BR.emitReport(R);
+     std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
+     BR.emitReport(std::move(R));
   }
 
  

--- a/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastAwayChecker.cpp
@@ -39,12 +39,12 @@ void ConstCastAwayChecker::checkPreStmt(const clang::ExplicitCastExpr *CE,
 		if ( clang::ento::ExplodedNode *errorNode = C.generateSink()) {
 			if (!BT)
 				BT.reset(new clang::ento::BugType(this,"const cast away","ThreadSafety"));
-			clang::ento::BugReport *R = new clang::ento::BugReport(*BT, 
+			std::unique_ptr<clang::ento::BugReport> R = llvm::make_unique<clang::ento::BugReport>(*BT, 
 					"const qualifier was removed via a cast, this may result in thread-unsafe code.", errorNode);
 			R->addRange(CE->getSourceRange());
 		   	if ( ! m_exception.reportConstCastAway( *R, C ) )
 				return;
-			C.emitReport(R);
+			C.emitReport(std::move(R));
 		}
 	}
 }

--- a/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ConstCastChecker.cpp
@@ -29,12 +29,12 @@ void ConstCastChecker::checkPreStmt(const clang::CXXConstCastExpr *CE,
 	}
 	if (clang::ento::ExplodedNode *errorNode = C.generateSink()) {
 		if (!BT) BT.reset(new clang::ento::BugType(this,"const_cast used on a pointer to a data class ", "ThreadSafety"));
-		clang::ento::BugReport *R = new clang::ento::BugReport(*BT,
+		std::unique_ptr<clang::ento::BugReport> R = llvm::make_unique<clang::ento::BugReport>(*BT,
 					"const_cast was used on a pointer to a data class ", errorNode);
 		R->addRange(CE->getSourceRange());
 	   	if ( ! m_exception.reportConstCast( *R, C ) )
 			return;
-		C.emitReport(R);
+		C.emitReport(std::move(R));
 	}
 
 }

--- a/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
+++ b/Utilities/StaticAnalyzers/src/FiniteMathChecker.cc
@@ -8,6 +8,7 @@
 
 #include "CmsSupport.h"
 #include <iostream>
+#include <utility>
 
 namespace clangcms {
 
@@ -36,9 +37,9 @@ void FiniteMathChecker::checkPreStmt(const clang::CallExpr *CE, clang::ento::Che
   if (!BT)
     BT.reset(new clang::ento::BugType(this,"std::isnan / std::isinf does not work when fast-math is used. Please use edm::isNotFinite from 'FWCore/Utilities/interface/isNotFinite.h'", "fastmath plugin"));
 
-  clang::ento::BugReport *report = new clang::ento::BugReport(*BT, BT->getName(), N);
+  std::unique_ptr<clang::ento::BugReport> report = llvm::make_unique<clang::ento::BugReport>(*BT, BT->getName(), N);
   report->addRange(Callee->getSourceRange());
-  ctx.emitReport(report);
+  ctx.emitReport(std::move(report));
 }
 }
 

--- a/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/ThrUnsafeFCallChecker.cpp
@@ -50,10 +50,10 @@ void TUFWalker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 		os << "Known thread unsafe function " << mname << " is called in function " << pname;
 		PathDiagnosticLocation CELoc = PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
  		BugType * BT = new BugType(Checker, "known thread unsafe function called","ThreadSafety");
-		BugReport * R = new BugReport(*BT,os.str(),CELoc);
+		std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
 		R->setDeclWithIssue(AC->getDecl());
 		R->addRange(CE->getSourceRange());
-		BR.emitReport(R);
+		BR.emitReport(std::move(R));
 		std::string tname = "function-checker.txt.unsorted";
 		std::string ostring =  "function '"+ pname + "' known thread unsafe function '" + mname + "'.\n";
 		support::writeLog(ostring,tname);

--- a/Utilities/StaticAnalyzers/src/getByChecker.cpp
+++ b/Utilities/StaticAnalyzers/src/getByChecker.cpp
@@ -108,9 +108,9 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 			PathDiagnosticLocation CELoc = 
 				PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
 			BugType * BT = new BugType(Checker,"edm::getByLabel or edm::getManyByType called","optional") ;
-			BugReport * R = new BugReport(*BT,os.str(),CELoc);
+			std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
 			R->addRange(CE->getSourceRange());
-			BR.emitReport(R);
+			BR.emitReport(std::move(R));
 	} 
 	else {
 		for (auto I=CE->arg_begin(), E=CE->arg_end(); I != E; ++I) {
@@ -133,9 +133,9 @@ void Walker::VisitCXXMemberCallExpr( CXXMemberCallExpr *CE ) {
 				PathDiagnosticLocation CELoc = 
 					PathDiagnosticLocation::createBegin(CE, BR.getSourceManager(),AC);
  				BugType * BT = new BugType(Checker,"function call with argument of type edm::Event","optional");
-				BugReport * R = new BugReport(*BT,os.str(),CELoc);
+				std::unique_ptr<BugReport> R = llvm::make_unique<BugReport>(*BT,os.str(),CELoc);
 				R->addRange(CE->getSourceRange());
-				BR.emitReport(R);
+				BR.emitReport(std::move(R));
 				}
 		}
 	}


### PR DESCRIPTION
The changes are required for Clang 3.7.0 and are not backward compatible
with other revisions.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
