### PR TITLE
Thread Safety: Remove unneeded state from TriggerResultsBasedEventSelector

### DIFF
--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -18,91 +18,50 @@
 #include "DataFormats/Common/interface/Handle.h"
 #include "FWCore/Utilities/interface/InputTag.h"
 
-namespace edm
-{
+namespace edm {
   class ModuleCallingContext;
 
-  namespace detail
-  {
+  namespace detail {
     typedef edm::Handle<edm::TriggerResults> handle_t;
 
-    class NamedEventSelector
-    {
+    class NamedEventSelector {
     public:
       NamedEventSelector(std::string const& n, EventSelector const& s) :
-	inputTag_("TriggerResults", "", n), 
-	eventSelector_(s), 
-	product_() 
+	inputTag_("TriggerResults", "", n),
+	eventSelector_(s)
       { }
 
-      void fill(EventPrincipal const& e, ModuleCallingContext const* mcc);
-
-      bool match()
-      {
-	return eventSelector_.acceptEvent(*product_);
+      bool match(TriggerResults const& product) {
+	return eventSelector_.acceptEvent(product);
       }
 
-      handle_t product() const
-      {
-	return product_;
+      InputTag const& inputTag() const {
+        return inputTag_;
       }
 
-      void clear()
-      {
-	product_ = handle_t();
-      }
-      
     private:
       InputTag            inputTag_;
       EventSelector       eventSelector_;
-      handle_t            product_;
     };
 
-    class TriggerResultsBasedEventSelector
-    {
+    class TriggerResultsBasedEventSelector {
     public:
       TriggerResultsBasedEventSelector();
       typedef detail::handle_t                    handle_t;
       typedef std::vector<NamedEventSelector>     selectors_t;
-      typedef selectors_t::size_type              size_type;
       typedef std::pair<std::string, std::string> parsed_path_spec_t;
 
       void setupDefault(std::vector<std::string> const& triggernames);
-      
+
       void setup(std::vector<parsed_path_spec_t> const& path_specs,
 		 std::vector<std::string> const& triggernames,
                  const std::string& process_name);
 
       bool wantEvent(EventPrincipal const& e, ModuleCallingContext const*);
 
-      // Clear the cache
-      void clear();
-
     private:
-      typedef selectors_t::iterator iter;
-
-      // Get all TriggerResults objects for the process names we're
-      // interested in.
-      size_type fill(EventPrincipal const& ev, ModuleCallingContext const*);
-      
-      bool        fillDone_;
-      size_type   numberFound_;
       selectors_t selectors_;
     };
-    
-    class  TRBESSentry {
-    public:
-      TRBESSentry(detail::TriggerResultsBasedEventSelector& prods) : p(prods) {}
-      ~TRBESSentry() {
-        p.clear();
-      }
-    private:
-      detail::TriggerResultsBasedEventSelector& p;
-      
-      TRBESSentry(TRBESSentry const&) = delete;
-      TRBESSentry& operator=(TRBESSentry const&) = delete;
-    };
-
 
     /** Handles the final initialization of the TriggerResutsBasedEventSelector
      \return true if all events will be selected

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -215,8 +215,6 @@ namespace edm {
   bool OutputModule::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
     
     auto& s = selectors_[id.value()];
-    detail::TRBESSentry products_sentry(s);
-
     return wantAllEvents_ or s.wantEvent(ep,mcc);
   }
 

--- a/FWCore/Framework/src/SubProcess.cc
+++ b/FWCore/Framework/src/SubProcess.cc
@@ -296,9 +296,6 @@ namespace edm {
   SubProcess::doEvent(EventPrincipal const& ep) {
     ServiceRegistry::Operate operate(serviceToken_);
     /* BEGIN relevant bits from OutputModule::doEvent */
-    detail::TRBESSentry products_sentry(selectors_);
-    
-    
     if(!wantAllEvents_) {
       // use module description and const_cast unless interface to
       // event is changed to just take a const EventPrincipal

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -13,25 +13,25 @@ namespace {
     s.erase(std::remove(s.begin(), s.end(), ' '), s.end());
     s.erase(std::remove(s.begin(), s.end(), '\t'), s.end());
   }
-  
+
   void test_remove_whitespace() {
     std::string a("noblanks");
     std::string b("\t   no   blanks    \t");
-    
+
     remove_whitespace(b);
     assert(a == b);
   }
-  
+
   //--------------------------------------------------------
   // Given a path-spec (std::string of the form "a:b", where the ":b" is
   // optional), return a parsed_path_spec_t containing "a" and "b".
-  
+
   typedef std::pair<std::string, std::string> parsed_path_spec_t;
   void parse_path_spec(std::string const& path_spec,
                        parsed_path_spec_t& output) {
     std::string trimmed_path_spec(path_spec);
     remove_whitespace(trimmed_path_spec);
-    
+
     std::string::size_type colon = trimmed_path_spec.find(":");
     if(colon == std::string::npos) {
       output.first = trimmed_path_spec;
@@ -41,7 +41,7 @@ namespace {
                                                trimmed_path_spec.size());
     }
   }
-  
+
   void test_parse_path_spec() {
     std::vector<std::string> paths;
     paths.push_back("a:p1");
@@ -49,12 +49,12 @@ namespace {
     paths.push_back("  c");
     paths.push_back("ddd\t:p3");
     paths.push_back("eee:  p4  ");
-    
+
     std::vector<parsed_path_spec_t> parsed(paths.size());
     for(size_t i = 0; i < paths.size(); ++i) {
       parse_path_spec(paths[i], parsed[i]);
     }
-    
+
     assert(parsed[0].first  == "a");
     assert(parsed[0].second == "p1");
     assert(parsed[1].first  == "b");
@@ -68,7 +68,7 @@ namespace {
   }
 }
 
-namespace edm 
+namespace edm
 {
   namespace test {
     void run_all_output_module_tests() {
@@ -79,7 +79,7 @@ namespace edm
 
   namespace detail
   {
-    
+
     bool configureEventSelector(edm::ParameterSet const& iPSet,
                                 std::string const& iProcessName,
                                 std::vector<std::string> const& iAllTriggerNames,
@@ -92,15 +92,15 @@ namespace edm
         oSelector.setupDefault(iAllTriggerNames);
         return true;
       }
-      
+
       std::vector<std::string> path_specs =
       iPSet.getParameter<std::vector<std::string> >("SelectEvents");
-      
+
       if(path_specs.empty()) {
         oSelector.setupDefault(iAllTriggerNames);
         return true;
       }
-      
+
       // If we get here, we have the possibility of having to deal with
       // path_specs that look at more than one process.
       std::vector<parsed_path_spec_t> parsed_paths(path_specs.size());
@@ -108,32 +108,18 @@ namespace edm
         parse_path_spec(path_specs[i], parsed_paths[i]);
       }
       oSelector.setup(parsed_paths, iAllTriggerNames, iProcessName);
-      
+
       return false;
     }
 
-    
-    void NamedEventSelector::fill(EventPrincipal const& e, ModuleCallingContext const* mcc) {
-      edm::BasicHandle h = e.getByLabel(PRODUCT_TYPE,
-                                        s_TrigResultsType,
-                                        inputTag_,
-                                        nullptr,
-                                        mcc);
-      convert_handle(std::move(h),product_);
-    }
-    
-    typedef detail::NamedEventSelector NES;
-
+    // typedef detail::NamedEventSelector NES;
 
     TriggerResultsBasedEventSelector::TriggerResultsBasedEventSelector() :
-      fillDone_(false),
-      numberFound_(0),
       selectors_()
     { }
 
     void
-    TriggerResultsBasedEventSelector::setupDefault(std::vector<std::string> const& triggernames)
-    {
+    TriggerResultsBasedEventSelector::setupDefault(std::vector<std::string> const& triggernames) {
 
       // Set up one NamedEventSelector, with default configuration
       std::vector<std::string> paths;
@@ -144,100 +130,53 @@ namespace edm
 
     void
     TriggerResultsBasedEventSelector::setup(std::vector<parsed_path_spec_t> const& path_specs,
-			  std::vector<std::string> const& triggernames,
-                          const std::string& process_name)
-    {
+                          std::vector<std::string> const& triggernames,
+                          const std::string& process_name) {
       // paths_for_process maps each PROCESS names to a sequence of
       // PATH names
       std::map<std::string, std::vector<std::string> > paths_for_process;
-      for (std::vector<parsed_path_spec_t>::const_iterator 
-	     i = path_specs.begin(), 
-	     e = path_specs.end();
- 	   i != e;
-	   ++i)
-	{
-          // Default to current process if none specified
-          if (i->second == "") {
-            paths_for_process[process_name].push_back(i->first);
-          }
-          else {
-            paths_for_process[i->second].push_back(i->first);
-          }
-	}
+      for (auto const& path_spec : path_specs) {
+        // Default to current process if none specified
+        if (path_spec.second == "") {
+          paths_for_process[process_name].push_back(path_spec.first);
+        }
+        else {
+          paths_for_process[path_spec.second].push_back(path_spec.first);
+        }
+      }
       // Now go through all the PROCESS names, and create a
       // NamedEventSelector for each.
-      for (std::map<std::string, std::vector<std::string> >::const_iterator
-	     i = paths_for_process.begin(),
-	     e = paths_for_process.end();
-	   i != e;
-	   ++i)
-	{
-          // For the current process we know the trigger names
-          // from the configuration file
-          if (i->first == process_name) {
-            selectors_.emplace_back(i->first, 
-				    EventSelector(i->second, 
-				    triggernames));
-          }
+      for (auto const& path : paths_for_process) {
+        // For the current process we know the trigger names
+        // from the configuration file
+        if (path.first == process_name) {
+          selectors_.emplace_back(path.first, EventSelector(path.second, triggernames));
+        } else {
           // For previous processes we do not know the trigger
           // names yet.
-          else {
-            selectors_.emplace_back(i->first, EventSelector(i->second));
-          }
-	}
+          selectors_.emplace_back(path.first, EventSelector(path.second));
+        }
+      }
     }
 
     bool
-    TriggerResultsBasedEventSelector::wantEvent(EventPrincipal const& ev, ModuleCallingContext const* mcc)
-    {
-      // We have to get all the TriggerResults objects before we test
-      // any for a match, because we have to deal with the possibility
-      // of multiple TriggerResults objects --- note that the presence
-      // of more than one TriggerResults object in the event is
-      // intended to lead to an exception throw *unless* either the
-      // configuration has been set to match all events, or the
-      // configuration is set to use specific process names.
-
-      fill(ev, mcc);
-
-      // Now we go through and see if anyone matches...
-      iter i = selectors_.begin();
-      iter e = selectors_.end();
-      bool match_found = false;
-      while (!match_found && (i!=e))
-	{
-	  match_found = i->match();
-	  ++i;
-	}
-      return match_found;
-    }
-    
-    TriggerResultsBasedEventSelector::size_type
-    TriggerResultsBasedEventSelector::fill(EventPrincipal const& ev, ModuleCallingContext const* mcc)
-    {
-      if (!fillDone_)
-	{
-	  fillDone_ = true;
-	  for (iter i = selectors_.begin(), e = selectors_.end(); 
-	       i != e; ++i)
-	    {
-	      i->fill(ev, mcc);     // fill might throw...
-	      ++numberFound_ ; // so numberFound_ might be less than expected
-	    }
-	}
-      return numberFound_;
+    TriggerResultsBasedEventSelector::wantEvent(EventPrincipal const& ev, ModuleCallingContext const* mcc) {
+      for(auto& selector : selectors_) {
+        edm::BasicHandle h = ev.getByLabel(PRODUCT_TYPE,
+                                          s_TrigResultsType,
+                                          selector.inputTag(),
+                                          nullptr,
+                                          mcc);
+        handle_t product;
+        convert_handle(std::move(h), product);
+        bool match = selector.match(*product);
+        if(match) {
+          return true;
+        }
+      }
+      return false;
     }
 
-    void
-    TriggerResultsBasedEventSelector::clear()
-    { 
-      for_all(selectors_, std::bind(&NamedEventSelector::clear, std::placeholders::_1));
-      fillDone_ = false;
-      numberFound_ = 0;
-    }
-
-
-    
     ParameterSetID
     registerProperSelectionInfo(edm::ParameterSet const& iInitial,
                                 std::string const& iLabel,
@@ -248,16 +187,15 @@ namespace edm
       selectEventsInfo.addParameter<bool>("InProcessHistory", anyProductProduced);
       std::vector<std::string> endPaths;
       std::vector<int> endPathPositions;
-      
+
       // The label will be empty if and only if this is a SubProcess
       // SubProcess's do not appear on any end path
       if (!iLabel.empty()) {
         std::map<std::string, std::vector<std::pair<std::string, int> > >::const_iterator iter = outputModulePathPositions.find(iLabel);
         assert(iter != outputModulePathPositions.end());
-        for (std::vector<std::pair<std::string, int> >::const_iterator i = iter->second.begin(), e = iter->second.end();
-             i != e; ++i) {
-          endPaths.push_back(i->first);
-          endPathPositions.push_back(i->second);
+        for(auto const& item : iter->second) {
+          endPaths.push_back(item.first);
+          endPathPositions.push_back(item.second);
         }
       }
       selectEventsInfo.addParameter<std::vector<std::string> >("EndPaths", endPaths);
@@ -266,10 +204,9 @@ namespace edm
         selectEventsInfo.addParameter<std::vector<std::string> >("SelectEvents", std::vector<std::string>());
       }
       selectEventsInfo.registerIt();
-      
+
       return selectEventsInfo.id();
     }
-    
 
   } // namespace detail
 } // namespace edm

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -212,8 +212,6 @@ namespace edm {
     bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
       
       auto& s = selectors_[id.value()];
-      detail::TRBESSentry products_sentry(s);
-      
       return wantAllEvents_ or s.wantEvent(ep,mcc);
     }
     


### PR DESCRIPTION
This is one more step toward a thread safe global::OutputModule base class. The related classes NamedEventSelector and TriggerResultsBasedEventSelector had unnecessary data members that could be modified during the processing an event. This PR removes the unnecessary data. It also, for maintainability and clarity, changes some iterator loops to range based for loops.
Note: Thread safety work also needs to be done on class EventSelector.  That will be a separate PR.
