### PR TITLE
New steps for HI muon RegIt

### DIFF
--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonDetachedTripletStep_cff.py
@@ -20,8 +20,9 @@ from RecoTracker.IterativeTracking.DetachedTripletStep_cff import *
 
 # NEW CLUSTERS (remove previously used clusters)
 hiRegitMuDetachedTripletStepClusters = RecoTracker.IterativeTracking.DetachedTripletStep_cff.detachedTripletStepClusters.clone(
-    trajectories          = cms.InputTag("hiRegitMuInitialStepTracks"),
-    overrideTrkQuals      = cms.InputTag('hiRegitMuInitialStepSelector','hiRegitMuInitialStep'),
+    trajectories          = cms.InputTag("hiRegitMuPixelLessStepTracks"),
+    overrideTrkQuals      = cms.InputTag('hiRegitMuPixelLessStepSelector','hiRegitMuPixelLessStep'),
+    trackClassifier       = cms.InputTag(''),
     TrackQuality          = cms.string('tight')
 )
 

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -12,8 +12,9 @@ hiEarlyGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.track
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
                       cms.InputTag('hiRegitMuPixelLessStepTracks'),
+                      cms.InputTag('hiRegitMuDetachedTripletStepTracks')
                      ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1,1),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
@@ -23,8 +24,9 @@ hiEarlyGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.track
     cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
     cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
     cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
+    cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep")
     ),                    
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7), pQual=cms.bool(True)),  # should this be False?
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8), pQual=cms.bool(True)),  # should this be False?
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -8,25 +8,27 @@ hiEarlyGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.track
                       cms.InputTag('hiDetachedTripletStepTracks'),
                       cms.InputTag('hiLowPtTripletStepTracks'),
                       cms.InputTag('hiPixelPairGlobalPrimTracks'),
+                      cms.InputTag('hiJetCoreRegionalStepTracks'),
                       cms.InputTag('hiRegitMuInitialStepTracks'),
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
                       cms.InputTag('hiRegitMuPixelLessStepTracks'),
                       cms.InputTag('hiRegitMuDetachedTripletStepTracks')
                      ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
     cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
     cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
+    cms.InputTag("hiJetCoreRegionalStepSelector","hiJetCoreRegionalStep"),
     cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
     cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
     cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
     cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
     cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep")
     ),                    
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8), pQual=cms.bool(True)),  # should this be False?
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8,9), pQual=cms.bool(True)),  # should this be False?
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -1,0 +1,129 @@
+import FWCore.ParameterSet.Config as cms
+from RecoTracker.IterativeTracking.MuonSeededStep_cff import *
+
+###### Muon reconstruction module #####
+import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
+hiEarlyGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
+    TrackProducers = (cms.InputTag('hiGlobalPrimTracks'),
+                      cms.InputTag('hiDetachedTripletStepTracks'),
+                      cms.InputTag('hiLowPtTripletStepTracks'),
+                      cms.InputTag('hiPixelPairGlobalPrimTracks'),
+                      cms.InputTag('hiRegitMuInitialStepTracks'),
+                      cms.InputTag('hiRegitMuPixelPairStepTracks'),
+                      cms.InputTag('hiRegitMuMixedTripletStepTracks'),
+                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
+                     ),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1),
+    selectedTrackQuals = cms.VInputTag(
+    cms.InputTag("hiInitialStepSelector","hiInitialStep"),
+    cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
+    cms.InputTag("hiLowPtTripletStepSelector","hiLowPtTripletStep"),
+    cms.InputTag("hiPixelPairStepSelector","hiPixelPairStep"),
+    cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
+    cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
+    cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
+    cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
+    ),                    
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7), pQual=cms.bool(True)),  # should this be False?
+                             ),
+    copyExtras = True,
+    makeReKeyedSeeds = cms.untracked.bool(False)
+    )
+
+hiEarlyMuons = earlyMuons.clone(
+      inputCollectionLabels = cms.VInputTag(cms.InputTag("hiEarlyGeneralTracks"),cms.InputTag("standAloneMuons","UpdatedAtVtx"))
+      )
+
+###### SEEDER MODELS ######
+import RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi
+import RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi
+hiRegitMuonSeededSeedsOutIn = RecoTracker.SpecialSeedGenerators.outInSeedsFromStandaloneMuons_cfi.outInSeedsFromStandaloneMuons.clone(
+      src = "hiEarlyMuons",
+      )
+hiRegitMuonSeededSeedsInOut = RecoTracker.SpecialSeedGenerators.inOutSeedsFromTrackerMuons_cfi.inOutSeedsFromTrackerMuons.clone(
+      src = "hiEarlyMuons",
+      )
+
+hiRegitMuonSeededTrackCandidatesInOut = muonSeededTrackCandidatesInOut.clone(
+      src = cms.InputTag("hiRegitMuonSeededSeedsInOut")
+      )
+hiRegitMuonSeededTrackCandidatesOutIn = muonSeededTrackCandidatesOutIn.clone(
+      src = cms.InputTag("hiRegitMuonSeededSeedsOutIn")
+      )
+
+hiRegitMuonSeededTracksOutIn = muonSeededTracksOutIn.clone(
+      src = cms.InputTag("hiRegitMuonSeededTrackCandidatesOutIn"),
+      AlgorithmName = cms.string('hiRegitMuMuonSeededStepOutIn') 
+      )
+hiRegitMuonSeededTracksInOut = muonSeededTracksInOut.clone(
+      src = cms.InputTag("hiRegitMuonSeededTrackCandidatesInOut"),
+      AlgorithmName = cms.string('hiRegitMuMuonSeededStepInOut') 
+      )
+
+import RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi
+import RecoHI.HiTracking.hiMultiTrackSelector_cfi
+hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
+      src='hiRegitMuonSeededTracksInOut',
+      vertices            = cms.InputTag("hiSelectedVertex"),
+      useAnyMVA = cms.bool(True),
+      GBRForestLabel = cms.string('HIMVASelectorIter7'),
+      GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
+      trackSelectors= cms.VPSet(
+         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'hiRegitMuonSeededTracksInOutLoose',
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuonSeededTracksInOutTight',
+            preFilterName = 'hiRegitMuonSeededTracksInOutLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuonSeededTracksInOutHighPurity',
+            preFilterName = 'hiRegitMuonSeededTracksInOutTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
+            ),
+         ) #end of vpset
+      ) #end of clone
+
+hiRegitMuonSeededTracksOutInSelector = RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiMultiTrackSelector.clone(
+      src='hiRegitMuonSeededTracksOutIn',
+      vertices            = cms.InputTag("hiSelectedVertex"),
+      useAnyMVA = cms.bool(True),
+      GBRForestLabel = cms.string('HIMVASelectorIter7'),
+      GBRForestVars = cms.vstring(['chi2perdofperlayer', 'nhits', 'nlayers', 'eta']),
+      trackSelectors= cms.VPSet(
+         RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
+            name = 'hiRegitMuonSeededTracksOutInLoose',
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
+            name = 'hiRegitMuonSeededTracksOutInTight',
+            preFilterName = 'hiRegitMuonSeededTracksOutInLoose',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.2)
+            ),
+         RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
+            name = 'hiRegitMuonSeededTracksOutInHighPurity',
+            preFilterName = 'hiRegitMuonSeededTracksOutInTight',
+            useMVA = cms.bool(True),
+            minMVA = cms.double(-0.09)
+            ),
+         ) #end of vpset
+      ) #end of clone
+
+hiRegitMuonSeededStepCore = cms.Sequence(
+      hiRegitMuonSeededSeedsInOut + hiRegitMuonSeededTrackCandidatesInOut + hiRegitMuonSeededTracksInOut +
+      hiRegitMuonSeededSeedsOutIn + hiRegitMuonSeededTrackCandidatesOutIn + hiRegitMuonSeededTracksOutIn 
+      )
+hiRegitMuonSeededStepExtra = cms.Sequence(
+      hiRegitMuonSeededTracksInOutSelector +
+      hiRegitMuonSeededTracksOutInSelector
+      )
+
+hiRegitMuonSeededStep = cms.Sequence(
+      hiEarlyGeneralTracks +
+      hiEarlyMuons +
+      hiRegitMuonSeededStepCore +
+      hiRegitMuonSeededStepExtra 
+      )

--- a/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
+++ b/RecoHI/HiMuonAlgos/python/HiRegitMuonSeededStep_cff.py
@@ -73,16 +73,19 @@ hiRegitMuonSeededTracksInOutSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
       trackSelectors= cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'hiRegitMuonSeededTracksInOutLoose',
+            min_nhits = cms.uint32(8)
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuonSeededTracksInOutTight',
             preFilterName = 'hiRegitMuonSeededTracksInOutLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.2)
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuonSeededTracksInOutHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksInOutTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.09)
             ),
@@ -98,16 +101,19 @@ hiRegitMuonSeededTracksOutInSelector = RecoHI.HiTracking.hiMultiTrackSelector_cf
       trackSelectors= cms.VPSet(
          RecoTracker.FinalTrackSelectors.multiTrackSelector_cfi.looseMTS.clone(
             name = 'hiRegitMuonSeededTracksOutInLoose',
+            min_nhits = cms.uint32(8)
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiTightMTS.clone(
             name = 'hiRegitMuonSeededTracksOutInTight',
             preFilterName = 'hiRegitMuonSeededTracksOutInLoose',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.2)
             ),
          RecoHI.HiTracking.hiMultiTrackSelector_cfi.hiHighpurityMTS.clone(
             name = 'hiRegitMuonSeededTracksOutInHighPurity',
             preFilterName = 'hiRegitMuonSeededTracksOutInTight',
+            min_nhits = cms.uint32(8),
             useMVA = cms.bool(True),
             minMVA = cms.double(-0.09)
             ),

--- a/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
+++ b/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
@@ -4,21 +4,26 @@ from RecoHI.HiMuonAlgos.HiRegitMuonInitialStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonPixelPairStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonMixedTripletStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonPixelLessStep_cff import *
+from RecoHI.HiMuonAlgos.HiRegitMuonSeededStep_cff import *
 
 import RecoTracker.FinalTrackSelectors.trackListMerger_cfi
 hiGeneralAndRegitMuTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListMerger.clone(
     TrackProducers = (cms.InputTag('hiRegitMuInitialStepTracks'),
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
-                      cms.InputTag('hiRegitMuPixelLessStepTracks')
+                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
+                      cms.InputTag('hiRegitMuonSeededTracksOutIn'),
+                      cms.InputTag('hiRegitMuonSeededTracksInOut')
                       ),
     selectedTrackQuals = cms.VInputTag(cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
                                        cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
                                        cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
-                                       cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep")
+                                       cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
+                                       cms.InputTag("hiRegitMuonSeededTracksOutInSelector","hiRegitMuonSeededTracksOutInHighPurity"),
+                                       cms.InputTag("hiRegitMuonSeededTracksInOutSelector","hiRegitMuonSeededTracksInOutHighPurity")
                                        ),
-    hasSelector=cms.vint32(1,1,1,1),
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3), pQual=cms.bool(True))),
+    hasSelector=cms.vint32(1,1,1,1,1,1),
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True))),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
@@ -27,6 +32,7 @@ hiRegitMuTracking = cms.Sequence(hiRegitMuonInitialStep
                                  *hiRegitMuonPixelPairStep
                                  *hiRegitMuonMixedTripletStep
                                  *hiRegitMuonPixelLessStep
+                                 *hiRegitMuonSeededStep
                                  )
 
 # Standalone muons

--- a/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
+++ b/RecoHI/HiMuonAlgos/python/hiMuonIterativeTk_cff.py
@@ -2,6 +2,7 @@ import FWCore.ParameterSet.Config as cms
 
 from RecoHI.HiMuonAlgos.HiRegitMuonInitialStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonPixelPairStep_cff import *
+from RecoHI.HiMuonAlgos.HiRegitMuonDetachedTripletStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonMixedTripletStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonPixelLessStep_cff import *
 from RecoHI.HiMuonAlgos.HiRegitMuonSeededStep_cff import *
@@ -12,6 +13,7 @@ hiGeneralAndRegitMuTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
                       cms.InputTag('hiRegitMuPixelLessStepTracks'),
+                      cms.InputTag('hiRegitMuDetachedTripletStepTracks'),
                       cms.InputTag('hiRegitMuonSeededTracksOutIn'),
                       cms.InputTag('hiRegitMuonSeededTracksInOut')
                       ),
@@ -19,11 +21,12 @@ hiGeneralAndRegitMuTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.
                                        cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
                                        cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
                                        cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
+                                       cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep"),
                                        cms.InputTag("hiRegitMuonSeededTracksOutInSelector","hiRegitMuonSeededTracksOutInHighPurity"),
                                        cms.InputTag("hiRegitMuonSeededTracksInOutSelector","hiRegitMuonSeededTracksInOutHighPurity")
                                        ),
-    hasSelector=cms.vint32(1,1,1,1,1,1),
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5), pQual=cms.bool(True))),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1),
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6), pQual=cms.bool(True))),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)
     )
@@ -32,6 +35,7 @@ hiRegitMuTracking = cms.Sequence(hiRegitMuonInitialStep
                                  *hiRegitMuonPixelPairStep
                                  *hiRegitMuonMixedTripletStep
                                  *hiRegitMuonPixelLessStep
+                                 *hiRegitMuonDetachedTripletStep
                                  *hiRegitMuonSeededStep
                                  )
 

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -30,9 +30,11 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
                       cms.InputTag('hiRegitMuInitialStepTracks'),
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
-                      cms.InputTag('hiRegitMuPixelLessStepTracks')
-                     ), 
-    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1),
+                      cms.InputTag('hiRegitMuPixelLessStepTracks'),
+                      cms.InputTag('hiRegitMuonSeededTracksOutIn'),
+                      cms.InputTag('hiRegitMuonSeededTracksInOut')
+                     ),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
@@ -42,9 +44,11 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
     cms.InputTag("hiRegitMuInitialStepSelector","hiRegitMuInitialStepLoose"),
     cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
     cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
-    cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep")
+    cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
+    cms.InputTag("hiRegitMuonSeededTracksOutInSelector","hiRegitMuonSeededTracksOutInHighPurity"),
+    cms.InputTag("hiRegitMuonSeededTracksInOutSelector","hiRegitMuonSeededTracksInOutHighPurity")
     ),                    
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7), pQual=cms.bool(True)),  # should this be False?
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8,9,10), pQual=cms.bool(True)),  # should this be False?
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)

--- a/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
+++ b/RecoHI/HiTracking/python/MergeTrackCollectionsHI_cff.py
@@ -31,10 +31,11 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
                       cms.InputTag('hiRegitMuPixelPairStepTracks'),
                       cms.InputTag('hiRegitMuMixedTripletStepTracks'),
                       cms.InputTag('hiRegitMuPixelLessStepTracks'),
+                      cms.InputTag('hiRegitMuDetachedTripletStepTracks'),
                       cms.InputTag('hiRegitMuonSeededTracksOutIn'),
                       cms.InputTag('hiRegitMuonSeededTracksInOut')
                      ),
-    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1,1,1),
+    hasSelector=cms.vint32(1,1,1,1,1,1,1,1,1,1,1,1),
     selectedTrackQuals = cms.VInputTag(
     cms.InputTag("hiInitialStepSelector","hiInitialStep"),
     cms.InputTag("hiDetachedTripletStepSelector","hiDetachedTripletStep"),
@@ -45,10 +46,11 @@ hiGeneralTracks = RecoTracker.FinalTrackSelectors.trackListMerger_cfi.trackListM
     cms.InputTag("hiRegitMuPixelPairStepSelector","hiRegitMuPixelPairStep"),
     cms.InputTag("hiRegitMuMixedTripletStepSelector","hiRegitMuMixedTripletStep"),
     cms.InputTag("hiRegitMuPixelLessStepSelector","hiRegitMuPixelLessStep"),
+    cms.InputTag("hiRegitMuDetachedTripletStepSelector","hiRegitMuDetachedTripletStep"),
     cms.InputTag("hiRegitMuonSeededTracksOutInSelector","hiRegitMuonSeededTracksOutInHighPurity"),
     cms.InputTag("hiRegitMuonSeededTracksInOutSelector","hiRegitMuonSeededTracksInOutHighPurity")
     ),                    
-    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8,9,10), pQual=cms.bool(True)),  # should this be False?
+    setsToMerge = cms.VPSet( cms.PSet( tLists=cms.vint32(0,1,2,3,4,5,6,7,8,9,10,11), pQual=cms.bool(True)),  # should this be False?
                              ),
     copyExtras = True,
     makeReKeyedSeeds = cms.untracked.bool(False)


### PR DESCRIPTION
Two steps are added to the regional iterative tracking (RegIt) for heavy ion muons: the detached triplet step, and the "muon-seeded step", based on the equivalent step from pp iterative tracking.
This PR is a 75X backport of #10952 
