### PR TITLE
Fix bug in JetPlusTrackCorrections_cff.py: add JetVertexExtender

### DIFF
--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
@@ -42,7 +42,6 @@ JetPlusTrackZSPCorJetAntiKt4.JetSplitMerge = cms.int32(2)
 
 JetPlusTrackCorrectionsAntiKt4 = cms.Sequence(
     JPTeidTight*
-    #trackExtrapolator*
     ak4JetTracksAssociatorAtVertexJPT*
     ak4JetTracksAssociatorAtCaloFace*
     ak4JetExtenderJPT*

--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
@@ -5,8 +5,6 @@ from RecoJets.JetAssociationProducers.ak4JTA_cff import *
 ak4JetTracksAssociatorAtVertexJPT = ak4JetTracksAssociatorAtVertex.clone()
 ak4JetTracksAssociatorAtVertexJPT.useAssigned = cms.bool(True)
 ak4JetTracksAssociatorAtVertexJPT.pvSrc = cms.InputTag("offlinePrimaryVertices")
-ak4JetExtenderJPT  = ak4JetExtender.clone()
-ak4JetExtenderJPT.jet2TracksAtVX = cms.InputTag("ak4JetTracksAssociatorAtVertexJPT")
 
 # ---------- Tight Electron ID
 
@@ -44,7 +42,6 @@ JetPlusTrackCorrectionsAntiKt4 = cms.Sequence(
     JPTeidTight*
     ak4JetTracksAssociatorAtVertexJPT*
     ak4JetTracksAssociatorAtCaloFace*
-    ak4JetExtenderJPT*
     JetPlusTrackZSPCorJetAntiKt4
     )
 

--- a/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
+++ b/RecoJets/JetPlusTracks/python/JetPlusTrackCorrections_cff.py
@@ -5,7 +5,8 @@ from RecoJets.JetAssociationProducers.ak4JTA_cff import *
 ak4JetTracksAssociatorAtVertexJPT = ak4JetTracksAssociatorAtVertex.clone()
 ak4JetTracksAssociatorAtVertexJPT.useAssigned = cms.bool(True)
 ak4JetTracksAssociatorAtVertexJPT.pvSrc = cms.InputTag("offlinePrimaryVertices")
-
+ak4JetExtenderJPT  = ak4JetExtender.clone()
+ak4JetExtenderJPT.jet2TracksAtVX = cms.InputTag("ak4JetTracksAssociatorAtVertexJPT")
 
 # ---------- Tight Electron ID
 
@@ -41,7 +42,10 @@ JetPlusTrackZSPCorJetAntiKt4.JetSplitMerge = cms.int32(2)
 
 JetPlusTrackCorrectionsAntiKt4 = cms.Sequence(
     JPTeidTight*
+    #trackExtrapolator*
     ak4JetTracksAssociatorAtVertexJPT*
+    ak4JetTracksAssociatorAtCaloFace*
+    ak4JetExtenderJPT*
     JetPlusTrackZSPCorJetAntiKt4
     )
 


### PR DESCRIPTION
JetPlusTrack correction practically does not work and return calojet energy only without adding ak4JetExtender to the python configurator.
