### PR TITLE
FastSim: remove import of non-existing cfg from START geometry

### DIFF
--- a/FastSimulation/Configuration/python/Geometries_START_cff.py
+++ b/FastSimulation/Configuration/python/Geometries_START_cff.py
@@ -2,12 +2,10 @@ import FWCore.ParameterSet.Config as cms
 
 from FastSimulation.Configuration.Geometries_cff import *
 
-from FastSimulation.Configuration.FamosSequences_cff import ecalRecHit,hbhereco,horeco,hfreco,famosSimHits
-
-from FastSimulation.CaloRecHitsProducer.CaloRecHits_cff import *
+import FastSimulation.EventProducer.FamosSimHits_cff
 
 # Apply Tracker and Muon misalignment
-famosSimHits.ApplyAlignment = True
+FastSimulation.EventProducer.FamosSimHits_cff.famosSimHits.ApplyAlignment = True
 misalignedTrackerGeometry.applyAlignment = True
 misalignedDTGeometry.applyAlignment = True
 misalignedCSCGeometry.applyAlignment = True


### PR DESCRIPTION
trivial fix
