### PR TITLE
runTheMatrix.py: misc cleanups; make --showMatrix consistent

### DIFF
--- a/Configuration/PyReleaseValidation/python/MatrixReader.py
+++ b/Configuration/PyReleaseValidation/python/MatrixReader.py
@@ -1,7 +1,7 @@
- 
-import sys
+import sys, os
 
 from Configuration.PyReleaseValidation.WorkFlow import WorkFlow
+from Configuration.PyReleaseValidation.MatrixUtil import InputInfo
 
 # ================================================================================
 
@@ -391,14 +391,29 @@ class MatrixReader(object):
             outFile.close()
             print "wrote ",writtenWF, ' workflow'+('s' if (writtenWF!=1) else ''),' to ', outFile.name
         return 
-                    
 
-    def showWorkFlows(self, selected=None, extended=True):
+    def workFlowsByLocation(self, cafVeto=True):
+        # Check if we are on CAF
+        onCAF = False
+        if 'cms/caf/cms' in os.environ['CMS_PATH']:
+            onCAF = True
+
+        workflows = []
+        for workflow in self.workFlows:
+            if isinstance(workflow.cmds[0], InputInfo):
+                if cafVeto and (workflow.cmds[0].location == 'CAF' and not onCAF):
+                    continue
+            workflows.append(workflow)
+
+        return workflows
+
+    def showWorkFlows(self, selected=None, extended=True, cafVeto=True):
         if selected: selected = map(float,selected)
+        wfs = self.workFlowsByLocation(cafVeto)
         maxLen = 100 # for summary, limit width of output
         fmt1   = "%-6s %-35s [1]: %s ..."
         fmt2   = "       %35s [%d]: %s ..."
-        print "\nfound a total of ", len(self.workFlows), ' workflows:'
+        print "\nfound a total of ", len(wfs), ' workflows:'
         if selected:
             print "      of which the following", len(selected), 'were selected:'
         #-ap for now:
@@ -407,7 +422,7 @@ class MatrixReader(object):
         fmt2   = "       %35s [%d]: %s"
 
         N=[]
-        for wf in self.workFlows:
+        for wf in wfs:
             if selected and float(wf.numId) not in selected: continue
             if extended: print ''
             #pad with zeros
@@ -479,9 +494,9 @@ class MatrixReader(object):
                 raise
             
                 
-    def show(self, selected=None, extended=True):    
+    def show(self, selected=None, extended=True, cafVeto=True):
 
-        self.showWorkFlows(selected,extended)
+        self.showWorkFlows(selected, extended, cafVeto)
         print '\n','-'*80,'\n'
 
 

--- a/Configuration/PyReleaseValidation/python/MatrixUtil.py
+++ b/Configuration/PyReleaseValidation/python/MatrixUtil.py
@@ -68,7 +68,7 @@ def selectedLS(list_runs=[],maxNum=-1,l_json=data_json):
             # print "run %s is there"%(run)
             runNumber = run
             for LSsegment in l_json[str(run)] :
-                print LSsegment
+                # print LSsegment
                 ls_count += (LSsegment[-1] - LSsegment[0] + 1)
                 if (ls_count > maxNum) & (maxNum != -1):
                     break

--- a/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
+++ b/Configuration/PyReleaseValidation/scripts/runTheMatrix.py
@@ -23,7 +23,7 @@ def runSelected(opt):
 
     ret = 0
     if opt.show:
-        mrd.show(opt.testList,opt.extended)
+        mrd.show(opt.testList, opt.extended, opt.cafVeto)
         if opt.testList : print 'testListected items:', opt.testList
     else:
         mRunnerHi = MatrixRunner(mrd.workFlows, opt.nProcs, opt.nThreads)


### PR DESCRIPTION
The main goal of this PR is to make `--showMatrix` consistent compared to what actually matrix executes. `--showMatrix` is also showing CAF-only workflows, which are not executed at CERN. The patch filters out CAF-only workflows in `--showMatrix` output to match executed workflows.
