### PR TITLE
Fix for PoolDBESSource_cfi - properly moved to V2

### DIFF
--- a/CondCore/CondDB/python/CondDB_cfi.py
+++ b/CondCore/CondDB/python/CondDB_cfi.py
@@ -7,7 +7,6 @@ CondDB = cms.PSet(
         messageLevel = cms.untracked.int32(0),
     ),
     connect = cms.string(''), 
-    snapshotTime = cms.string(''),
     dbFormat = cms.untracked.int32(0)
 )
 

--- a/CondCore/ESSources/python/PoolDBESSource_cfi.py
+++ b/CondCore/ESSources/python/PoolDBESSource_cfi.py
@@ -3,13 +3,13 @@ import FWCore.ParameterSet.Config as cms
 from CondCore.CondDB.CondDB_cfi import *
 
 GlobalTag = cms.ESSource("PoolDBESSource",
-    CondDBSetup,
+    CondDB,
+    globaltag = cms.string(''),
+    snapshotTime = cms.string(''),
     RefreshAlways    = cms.untracked.bool(False),
     RefreshOpenIOVs  = cms.untracked.bool(False),
     RefreshEachRun   = cms.untracked.bool(False),
     ReconnectEachRun = cms.untracked.bool(False),
-    snapshotTime = cms.string(''),
-    connect = cms.string('frontier://FrontierProd/CMS_CONDITIONS'),
-    globaltag = cms.string(''),
+    DumpStat=cms.untracked.bool(False),
     toGet = cms.VPSet( )   # hook to override or add single payloads
 )


### PR DESCRIPTION
This fix complete the move to V2 for the cfg files provided with CondCore/ESSources package (76X version)
