### PR TITLE
more cleanup of RecoLocalMuon/RPCRecHit

### DIFF
--- a/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/CSCSegtoRPC.h
@@ -7,14 +7,16 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
+#include <memory>
+
 class CSCSegtoRPC {
 public:
-  explicit CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent, bool debug, double eyr);
+  CSCSegtoRPC(CSCSegmentCollection const* allCSCSegments, edm::EventSetup const& iSetup, bool debug, double eyr);
   ~CSCSegtoRPC();
-  RPCRecHitCollection* thePoints(){return _ThePoints;}
+  std::unique_ptr<RPCRecHitCollection> && thePoints(){ return std::move(_ThePoints); }
    
 private:
-  RPCRecHitCollection* _ThePoints; 
+  std::unique_ptr<RPCRecHitCollection> _ThePoints; 
   edm::OwnVector<RPCRecHit> RPCPointVector;
   bool inclcsc;
   double MaxD;

--- a/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/DTSegtoRPC.h
@@ -7,14 +7,16 @@
 #include "DataFormats/RPCRecHit/interface/RPCRecHit.h"
 #include "DataFormats/RPCRecHit/interface/RPCRecHitCollection.h"
 
+#include <memory>
+
 class DTSegtoRPC {
 public:
-  explicit DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, double eyr);
+  DTSegtoRPC(DTRecSegment4DCollection const* all4DSegments, edm::EventSetup const& iSetup, bool debug, double eyr);
   ~DTSegtoRPC();
-  RPCRecHitCollection* thePoints(){return _ThePoints;}
+  std::unique_ptr<RPCRecHitCollection> && thePoints(){ return std::move(_ThePoints); }
    
 private:
-  RPCRecHitCollection* _ThePoints; 
+  std::unique_ptr<RPCRecHitCollection> _ThePoints; 
   edm::OwnVector<RPCRecHit> RPCPointVector;
   bool incldt;
   bool incldtMB4;

--- a/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
+++ b/RecoLocalMuon/RPCRecHit/interface/TracktoRPC.h
@@ -50,6 +50,7 @@
 #include "TrackingTools/TrackRefitter/interface/TrackTransformerBase.h"
 #include "TrackingTools/TrackRefitter/interface/TrackTransformer.h"
 
+#include <memory>
 
 using reco::MuonCollection;
 using reco::TrackCollection;
@@ -57,16 +58,14 @@ typedef std::vector<Trajectory> Trajectories;
 
 class TracktoRPC {
 public:
-
-
-  explicit TracktoRPC(edm::Handle<reco::TrackCollection> alltracks,const edm::EventSetup& iSetup, const edm::Event& iEvent,bool debug, const edm::ParameterSet& iConfig, const edm::InputTag & tracklabel);
-
+  TracktoRPC(reco::TrackCollection const* alltracks, edm::EventSetup const& iSetup, bool debug, const edm::ParameterSet& iConfig, const edm::InputTag & tracklabel);
   ~TracktoRPC();
-  RPCRecHitCollection* thePoints(){return _ThePoints;}
-  bool ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::EventSetup& iSetup);
+  std::unique_ptr<RPCRecHitCollection> && thePoints(){ return std::move(_ThePoints); }
 
 private:
-  RPCRecHitCollection* _ThePoints;
+  bool ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::EventSetup& iSetup);
+
+  std::unique_ptr<RPCRecHitCollection> _ThePoints;
   edm::OwnVector<RPCRecHit> RPCPointVector;
   double MaxD;
 

--- a/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/CSCSegtoRPC.cc
@@ -12,7 +12,7 @@
 #include "RecoLocalMuon/RPCRecHit/src/CSCStationIndex.h"
 #include "RecoLocalMuon/RPCRecHit/src/CSCObjectMap.h"
 
-CSCSegtoRPC::CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments, const edm::EventSetup& iSetup,const edm::Event& iEvent, bool debug, double eyr){
+CSCSegtoRPC::CSCSegtoRPC(const CSCSegmentCollection * allCSCSegments, const edm::EventSetup& iSetup, bool debug, double eyr){
   
   edm::ESHandle<RPCGeometry> rpcGeo;
   edm::ESHandle<CSCGeometry> cscGeo;
@@ -26,7 +26,7 @@ CSCSegtoRPC::CSCSegtoRPC(edm::Handle<CSCSegmentCollection> allCSCSegments, const
 
   if(debug) std::cout<<"CSC \t Number of CSC Segments in this event = "<<allCSCSegments->size()<<std::endl;
 
-  _ThePoints = new RPCRecHitCollection();
+  _ThePoints.reset(new RPCRecHitCollection());
 
   if(allCSCSegments->size()==0){
     if(debug) std::cout<<"CSC 0 segments skiping event"<<std::endl;

--- a/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/DTSegtoRPC.cc
@@ -31,7 +31,7 @@ int distwheel(int wheel1,int wheel2){
   return distance;
 }
 
-DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, const edm::EventSetup& iSetup,const edm::Event& iEvent,bool debug,double eyr){
+DTSegtoRPC::DTSegtoRPC(const DTRecSegment4DCollection * all4DSegments, const edm::EventSetup& iSetup, bool debug,double eyr){
 
   /*
   MinCosAng=iConfig.getUntrackedParameter<double>("MinCosAng",0.95);
@@ -61,7 +61,7 @@ DTSegtoRPC::DTSegtoRPC(edm::Handle<DTRecSegment4DCollection> all4DSegments, cons
     clock_gettime(CLOCK_REALTIME, &start_time);
   */
 
-  _ThePoints = new RPCRecHitCollection();
+  _ThePoints.reset(new RPCRecHitCollection());
 
   if(all4DSegments->size()>8){
     if(debug) std::cout<<"Too many segments in this event we are not doing the extrapolation"<<std::endl;

--- a/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
+++ b/RecoLocalMuon/RPCRecHit/src/RPCPointProducer.cc
@@ -50,9 +50,8 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     edm::Handle<DTRecSegment4DCollection> all4DSegments;
     iEvent.getByToken(dt4DSegments, all4DSegments);
     if(all4DSegments.isValid()){
-      DTSegtoRPC DTClass(all4DSegments,iSetup,iEvent,debug,ExtrapolatedRegion);
-      std::auto_ptr<RPCRecHitCollection> TheDTPoints(DTClass.thePoints());     
-      iEvent.put(TheDTPoints,"RPCDTExtrapolatedPoints"); 
+      DTSegtoRPC DTClass(all4DSegments.product(), iSetup, debug, ExtrapolatedRegion);
+      iEvent.put(DTClass.thePoints(), "RPCDTExtrapolatedPoints"); 
     }else{
       if(debug) std::cout<<"RPCHLT Invalid DTSegments collection"<<std::endl;
     }
@@ -62,9 +61,8 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     edm::Handle<CSCSegmentCollection> allCSCSegments;
     iEvent.getByToken(cscSegments, allCSCSegments);
     if(allCSCSegments.isValid()){
-      CSCSegtoRPC CSCClass(allCSCSegments,iSetup,iEvent,debug,ExtrapolatedRegion);
-      std::auto_ptr<RPCRecHitCollection> TheCSCPoints(CSCClass.thePoints());  
-      iEvent.put(TheCSCPoints,"RPCCSCExtrapolatedPoints"); 
+      CSCSegtoRPC CSCClass(allCSCSegments.product(), iSetup, debug, ExtrapolatedRegion);
+      iEvent.put(CSCClass.thePoints(), "RPCCSCExtrapolatedPoints"); 
     }else{
       if(debug) std::cout<<"RPCHLT Invalid CSCSegments collection"<<std::endl;
     }
@@ -73,11 +71,10 @@ void RPCPointProducer::produce(edm::StreamID, edm::Event& iEvent, const edm::Eve
     edm::Handle<reco::TrackCollection> alltracks;
     iEvent.getByToken(tracks,alltracks);
     if(!(alltracks->empty())){
-      TracktoRPC TrackClass(alltracks,iSetup,iEvent,debug,trackTransformerParam,tracks_);
-      std::auto_ptr<RPCRecHitCollection> TheTrackPoints(TrackClass.thePoints());
-      iEvent.put(TheTrackPoints,"RPCTrackExtrapolatedPoints");
+      TracktoRPC TrackClass(alltracks.product(), iSetup, debug, trackTransformerParam, tracks_);
+      iEvent.put(TrackClass.thePoints(), "RPCTrackExtrapolatedPoints");
     }else{
-      std::cout<<"RPCHLT Invalid Tracks collection"<<std::endl;
+      if(debug) std::cout<<"RPCHLT Invalid Tracks collection"<<std::endl;
     }
   }
  

--- a/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
+++ b/RecoLocalMuon/RPCRecHit/src/TracktoRPC.cc
@@ -51,9 +51,9 @@ bool TracktoRPC::ValidRPCSurface(RPCDetId rpcid, LocalPoint LocalP, const edm::E
    } else return false;
 }
 
-TracktoRPC::TracktoRPC(edm::Handle<reco::TrackCollection> alltracks, const edm::EventSetup& iSetup,const edm::Event& iEvent,bool debug,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel){ 
+TracktoRPC::TracktoRPC(const reco::TrackCollection * alltracks, const edm::EventSetup& iSetup, bool debug,const edm::ParameterSet& iConfig, const edm::InputTag& tracklabel){ 
 
- _ThePoints = new RPCRecHitCollection();
+ _ThePoints.reset(new RPCRecHitCollection());
 // if(alltracks->empty()) return;
 
  if(tracklabel.label().find("cosmic")==0) theTrackTransformer = new TrackTransformerForCosmicMuons(iConfig);


### PR DESCRIPTION
- pass collections by const T\* instead of by edm::Handle<T>
- return values as std::unique_ptr<T> instead of T*
- remove unused function parameters 
