### PR TITLE
Introduce slim track validation sequences 

### DIFF
--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -340,3 +340,23 @@ tracksValidationStandalone = cms.Sequence(
     trackValidatorAllTPEfficStandalone
 )
 
+# 'slim' sequences that only depend on track and tracking particle collections
+tracksValidationSelectorsSlim = tracksValidationSelectors.copyAndExclude([cutsRecoTracksBtvLike,ak4JetTracksAssociatorAtVertexPFAll,cutsRecoTracksAK4PFJets])
+
+tracksPreValidationSlim = cms.Sequence(
+    tracksValidationSelectorsSlim +
+    tracksValidationTruth +
+    tracksValidationTruthSignal
+)
+
+trackValidatorSlim = trackValidator.clone(
+    doPVAssociationPlots = cms.untracked.bool(False),
+    dodEdxPlots = False
+)
+for _label in [cms.InputTag("cutsRecoTracksBtvLike"),cms.InputTag("cutsRecoTracksAK4PFJets")]:
+    trackValidatorSlim.label.remove(_label)
+
+tracksValidationSlim = cms.Sequence(
+    tracksPreValidationSlim+
+    trackValidatorSlim
+)

--- a/Validation/RecoTrack/python/TrackValidation_cff.py
+++ b/Validation/RecoTrack/python/TrackValidation_cff.py
@@ -345,8 +345,7 @@ tracksValidationSelectorsSlim = tracksValidationSelectors.copyAndExclude([cutsRe
 
 tracksPreValidationSlim = cms.Sequence(
     tracksValidationSelectorsSlim +
-    tracksValidationTruth +
-    tracksValidationTruthSignal
+    tracksValidationTruth
 )
 
 trackValidatorSlim = trackValidator.clone(

--- a/Validation/RecoTrack/python/TrajectorySeedValidation_cff.py
+++ b/Validation/RecoTrack/python/TrajectorySeedValidation_cff.py
@@ -44,3 +44,16 @@ tracksAndTrajectorySeedsValidationStandalone = cms.Sequence(
     tracksValidationStandalone +
     trajectorySeedValidation
 )
+
+
+# 'slim' sequences that only depend on track, seed, and tracking particle collections
+trajectorySeedValidatorSlim = trajectorySeedValidator.clone(
+    doPVAssociationPlots = cms.untracked.bool(False),
+)
+trajectorySeedValidationSlim = trajectorySeedValidation.copy()
+trajectorySeedValidationSlim.replace(trajectorySeedValidator,trajectorySeedValidatorSlim)
+
+tracksAndTrajectorySeedsValidationSlim = cms.Sequence(
+    tracksValidationSlim +
+    trajectorySeedValidationSlim
+)


### PR DESCRIPTION
These sequences only depend on the output of iterative tracking and on tracking particles.

For e.g. FastSim these sequences can be run by calling cmsDriver.py with the following steps options:
-s RECOBEFMIX,DIGI:pdigi_valid,VALIDATION:tracksValidationSlim
-s RECOBEFMIX,DIGI:pdigi_valid,VALIDATION:tracksAndTrajectorySeedsValidationSlim

@makortel 
Please let me know if you think this is a bad idea, or needs changes.
For FastSim this is definitely very useful.
