### PR TITLE
revise GEN release validation samples

### DIFF
--- a/Configuration/Generator/python/BulkG_M1200_narrow_2L2Q_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/BulkG_M1200_narrow_2L2Q_LHE_13TeV_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards:
+# https://github.com/cms-sw/genproductions/tree/91ab3ea30e3c2280e4c31fdd7072a47eb2e5bdaa/bin/MadGraph5_aMCatNLO/cards/production/13TeV/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/BulkGraviton_ZZ_ZlepZhad_narrow_M1200
+
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.2.2/exo_diboson/Spin-2/BulkGraviton_ZZ_ZlepZhad/narrow/v2/BulkGraviton_ZZ_ZlepZhad_narrow_M1200_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)

--- a/Configuration/Generator/python/DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards:
+# https://github.com/cms-sw/genproductions/tree/e30fc9c7d9226a2c96869c0ddbe5e65884afd013/bin/MadGraph5_aMCatNLO/cards/production/13TeV/dyellell012j_5f_NLO_FXFX
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.2.2/dyellell012j_5f_NLO_FXFX/v1/dyellell012j_5f_NLO_FXFX_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)

--- a/Configuration/Generator/python/GGToH_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/GGToH_Pow_LHE_13TeV_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards:
+# https://github.com/cms-sw/genproductions/blob/6718f234d90e34ac43b683e323a3edd6e8aa72e2/bin/Powheg/production/V2/13TeV/Higgs/gg_H_quark-mass-effects_NNPDF30_13TeV/gg_H_quark-mass-effects_NNPDF30_13TeV_M125.input
+
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/gg_H_quark-mass-effects_NNPDF30_13TeV_M125/v2/gg_H_quark-mass-effects_NNPDF30_13TeV_M125_tarball.tar.gz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 1', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+                '25:onMode = off',
+                '25:onIfMatch = 22 22',
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_cff.py
@@ -1,0 +1,31 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 3', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+                '25:onMode = off',
+                '25:onIfAny = 15',
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola_cff.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         ExternalDecays = cms.PSet(
+               Tauola = cms.untracked.PSet(
+                  TauolaPolar,
+                  TauolaDefaultInputCards
+                ),
+               parameterSets = cms.vstring('Tauola')
+             ),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 3', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+                '25:onMode = off',
+                '25:onIfAny = 15',
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola_cff.py
@@ -1,4 +1,6 @@
 import FWCore.ParameterSet.Config as cms
+from GeneratorInterface.ExternalDecays.TauolaSettings_cff import *
+
 from Configuration.Generator.Pythia8CommonSettings_cfi import *
 from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
 from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 3', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+                '25:onMode = off',
+                '25:onIfAny = 15',
+                '15:onMode = off',
+                '15:onIfMatch = 16 -211'
+
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         ExternalDecays = cms.PSet(
+               Tauola = cms.untracked.PSet(
+                 UseTauolaPolarization = cms.bool(True),
+                    InputCards = cms.PSet(
+                        mdtau = cms.int32(0),
+                        pjak2 = cms.int32(3),
+                        pjak1 = cms.int32(3)
+                   )
+                ),
+               parameterSets = cms.vstring('Tauola')
+             ),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 3', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+                '25:onMode = off',
+                '25:onIfAny = 15',
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_cff.py
@@ -1,0 +1,34 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 3', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+                '25:onMode = off',
+                '25:onIfAny = 15',
+                '15:onMode = off',
+                '15:onIfMatch = 16 -211 111'
+
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola_cff.py
@@ -1,0 +1,42 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         ExternalDecays = cms.PSet(
+               Tauola = cms.untracked.PSet(
+                 UseTauolaPolarization = cms.bool(True),
+                    InputCards = cms.PSet(
+                        mdtau = cms.int32(0),
+                        pjak2 = cms.int32(4),
+                        pjak1 = cms.int32(4)
+                   )
+                ),
+               parameterSets = cms.vstring('Tauola')
+             ),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 3', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+                '25:onMode = off',
+                '25:onIfAny = 15',
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8_cff.py
@@ -1,0 +1,38 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 30.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 10.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+            'TimeShower:mMaxGamma = 4.0',
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_evtgen_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_evtgen_cff.py
@@ -1,0 +1,46 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8aMCatNLOSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+    maxEventsToPrint = cms.untracked.int32(1),
+    pythiaPylistVerbosity = cms.untracked.int32(1),
+    filterEfficiency = cms.untracked.double(1.0),
+    pythiaHepMCVerbosity = cms.untracked.bool(False),
+    comEnergy = cms.double(13000.),
+    ExternalDecays = cms.PSet(
+        EvtGen130 = cms.untracked.PSet(
+            decay_table = cms.string('GeneratorInterface/EvtGenInterface/data/DECAY_2010.DEC'),
+            particle_property_file = cms.FileInPath('GeneratorInterface/EvtGenInterface/data/evt.pdl'),
+            list_forced_decays = cms.vstring(),
+            operates_on_particles = cms.vint32()
+            ),
+        parameterSets = cms.vstring('EvtGen130')
+        ),
+    PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        pythia8aMCatNLOSettingsBlock,
+        processParameters = cms.vstring(
+            'JetMatching:setMad = off',
+            'JetMatching:scheme = 1',
+            'JetMatching:merge = on',
+            'JetMatching:jetAlgorithm = 2',
+            'JetMatching:etaJetMax = 999.',
+            'JetMatching:coneRadius = 1.',
+            'JetMatching:slowJetPower = 1',
+            'JetMatching:qCut = 40.', #this is the actual merging scale
+            'JetMatching:doFxFx = on',
+            'JetMatching:qCutME = 20.',#this must match the ptj cut in the lhe generation step
+            'JetMatching:nQmatch = 5', #4 corresponds to 4-flavour scheme (no matching of b-quarks), 5 for 5-flavour scheme
+            'JetMatching:nJetMax = 2', #number of partons in born matrix element for highest multiplicity
+        ),
+        parameterSets = cms.vstring('pythia8CommonSettings',
+                                    'pythia8CUEP8M1Settings',
+                                    'pythia8aMCatNLOSettings',
+                                    'processParameters',
+                                    )
+    )
+)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto2p_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto2p_pythia8_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 2', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                'TimeShower:mMaxGamma = 1.0'
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8_cff.py
+++ b/Configuration/Generator/python/Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+from Configuration.Generator.Pythia8CommonSettings_cfi import *
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import *
+from Configuration.Generator.Pythia8PowhegEmissionVetoSettings_cfi import *
+
+generator = cms.EDFilter("Pythia8HadronizerFilter",
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         filterEfficiency = cms.untracked.double(1.0),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         comEnergy = cms.double(13000.),
+                         PythiaParameters = cms.PSet(
+             pythia8CommonSettingsBlock,
+             pythia8CUEP8M1SettingsBlock,
+             pythia8PowhegEmissionVetoSettingsBlock,
+             processParameters = cms.vstring(
+                'POWHEG:nFinal = 3', ## Number of final state particles
+                                     ## (BEFORE THE DECAYS) in the LHE
+                                     ## other than emitted extra parton
+                '25:m0 = 125.0',
+              ),
+             parameterSets = cms.vstring('pythia8CommonSettings',
+                                         'pythia8CUEP8M1Settings',
+                                         'pythia8PowhegEmissionVetoSettings',
+                                         'processParameters'
+                                         )
+             )
+                            )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/TT_weight_NNPDF3.0/TT_weight_NNPDF3.0_tarball.tar.gz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/c41ab29f3d86c9e53df8b0d76c12cd519adbf013/bin/Powheg/production/TT_hdamp_NNPDF30_13TeV

--- a/Configuration/Generator/python/VBFToH_Pow_JHU4l_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/VBFToH_Pow_JHU4l_LHE_13TeV_cff.py
@@ -1,0 +1,13 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards:
+# https://github.com/cms-sw/genproductions/blob/060e6d3363a78ecfae90f7f5c46c968992820a56/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/VBF_H_M125_NNPDF30_13TeV.input
+# https://github.com/cms-sw/genproductions/blob/060e6d3363a78ecfae90f7f5c46c968992820a56/bin/Powheg/production/V2/13TeV/Higgs/VBF_H_JHUGen_HZZ4L_NNPDF30_13TeV/JHUGen_VBF_H_ZZ4L.input
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/VBF_H_NNPDF30_13TeV_M125_JHUGen_HZZ4L/v1/VBF_H_NNPDF30_13TeV_M125_JHUGen_HZZ4L_tarball.tar.gz'),
+    nEvents = cms.untracked.uint32(1000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)

--- a/Configuration/Generator/python/VHToH_Pow_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/VHToH_Pow_LHE_13TeV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+# link to cards:
+# https://github.com/cms-sw/genproductions/blob/329fda9f8d07c2d4d4e75c9a00279dcd6e78cda7/bin/Powheg/production/VH_from_Hbb/HWplusJ_HanythingJ_NNPDF30_13TeV_M125.input
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/powheg/V2/HWplusJ_HanythingJ_NNPDF30_13TeV_M125/v2_folding/HWplusJ_HanythingJ_NNPDF30_13TeV_M125_tarball.tar.gz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)

--- a/Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
+++ b/Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py
@@ -1,0 +1,12 @@
+import FWCore.ParameterSet.Config as cms
+
+externalLHEProducer = cms.EDProducer("ExternalLHEProducer",
+    args = cms.vstring('/cvmfs/cms.cern.ch/phys_generator/gridpacks/slc6_amd64_gcc481/13TeV/madgraph/V5_2.2.2/WJets_HT_LO_MLM/WJetsToLNu_HT-incl/V1/WJetsToLNu_HT-incl_tarball.tar.xz'),
+    nEvents = cms.untracked.uint32(5000),
+    numberOfParameters = cms.uint32(1),
+    outputFile = cms.string('cmsgrid_final.lhe'),
+    scriptName = cms.FileInPath('GeneratorInterface/LHEInterface/data/run_generic_tarball_cvmfs.sh')
+)
+
+#Link to datacards:
+#https://github.com/cms-sw/genproductions/tree/b9f934265b462f4f3bbb8919799fa20668bb6fce/bin/MadGraph5_aMCatNLO/cards/production/13TeV/WJets_HT_LO_MLM/WJetsToLNu_HT-0toInf

--- a/Configuration/Generator/python/WprimeTolNu_M3000_13TeV_pythia8_cff.py
+++ b/Configuration/Generator/python/WprimeTolNu_M3000_13TeV_pythia8_cff.py
@@ -1,0 +1,28 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import * 
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import * 
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         comEnergy = cms.double(13000.0),
+                         crossSection = cms.untracked.double(0.013),
+                         filterEfficiency = cms.untracked.double(1),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'NewGaugeBoson:ffbar2Wprime = on',
+            '34:m0 = 3000',
+            '34:onMode = off',
+            '34:onIfAny = 11 13 15',
+            ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CUEP8M1Settings',
+            'processParameters')
+        )
+                         )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/Generator/python/ZprimeToll_M3000_13TeV_pythia8_cff.py
+++ b/Configuration/Generator/python/ZprimeToll_M3000_13TeV_pythia8_cff.py
@@ -1,0 +1,29 @@
+import FWCore.ParameterSet.Config as cms
+
+from Configuration.Generator.Pythia8CommonSettings_cfi import * 
+from Configuration.Generator.Pythia8CUEP8M1Settings_cfi import * 
+
+generator = cms.EDFilter("Pythia8GeneratorFilter",
+                         comEnergy = cms.double(13000.0),
+                         crossSection = cms.untracked.double(0.013),
+                         filterEfficiency = cms.untracked.double(1),
+                         maxEventsToPrint = cms.untracked.int32(1),
+                         pythiaHepMCVerbosity = cms.untracked.bool(False),
+                         pythiaPylistVerbosity = cms.untracked.int32(1),
+                         PythiaParameters = cms.PSet(
+        pythia8CommonSettingsBlock,
+        pythia8CUEP8M1SettingsBlock,
+        processParameters = cms.vstring(
+            'NewGaugeBoson:ffbar2gmZZprime = on',
+            'Zprime:gmZmode = 3',
+            '32:m0 = 3000',
+            '32:onMode = off',
+            '32:onIfAny = 11 13 15',
+            ),
+        parameterSets = cms.vstring(
+            'pythia8CommonSettings',
+            'pythia8CUEP8M1Settings',
+            'processParameters')
+        )
+                         )
+ProductionFilterSequence = cms.Sequence(generator)

--- a/Configuration/PyReleaseValidation/python/relval_extendedgen.py
+++ b/Configuration/PyReleaseValidation/python/relval_extendedgen.py
@@ -25,6 +25,15 @@ workflows[510]=['',['SoftQCDinelastic_13TeV_pythia8','HARVESTGEN']]
 workflows[534]=['',['sherpa_ZtoEE_0j_OpenLoops_13TeV_MASTER','HARVESTGEN']]
 
 # Hadronization (LHE Generation + Hadronization)
+workflows[555]=['DYTollJets_NLO_Mad_13TeV_py8',['DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8','HARVESTGEN2']]     # ALWAYS RUN
+workflows[513]=['WTolNuJets_LO_Mad_13TeV_py8',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]     # ALWAYS RUN
+workflows[551]=['TTbar012Jets_NLO_Mad_13TeV_py8',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8','HARVESTGEN2']]     # ALWAYS RUN
+workflows[556]=['TTbar_NLO_Pow_13TeV_py8',['TTbar_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto2p_pythia8','HARVESTGEN2']]     # ALWAYS RUN
+workflows[514]=['GGToHgg_NLO_Pow_13TeV_py8',['GGToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8','HARVESTGEN2']]     # ALWAYS RUN
+workflows[552]=['VHToHtt_NLO_Pow_13TeV_py8',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8','HARVESTGEN2']]     # ALWAYS RUN
+workflows[554]=['VBFToH4l_NLO_Pow_JHU_13TeV_py8',['VBFToH_Pow_JHU4l_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8','HARVESTGEN2']]     # ALWAYS RUN
+
+
 workflows[515]=['DYTollJets_LO_Mad_13TeV_py8_taupinu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taupinu','HARVESTGEN2']]
 workflows[516]=['WTolNuJets_LO_Mad_13TeV_py8_taupinu',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taupinu','HARVESTGEN2']]
 workflows[517]=['VHToHtt_NLO_Pow_13TeV_py8_taupinu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8','HARVESTGEN2']]
@@ -33,6 +42,12 @@ workflows[519]=['WTolNuJets_LO_Mad_13TeV_py8_taurhonu',['WTolNu01234Jets_5f_LO_M
 workflows[520]=['VHToHtt_NLO_Pow_13TeV_py8_taurhonu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8','HARVESTGEN2']]
 
 # External Decays
+
+workflows[521]=['WTolNuJets_LO_Mad_13TeV_py8_Ta',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]     # ALWAYS RUN
+workflows[522]=['DYTollJets_LO_Mad_13TeV_py8_Ta',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]     # ALWAYS RUN
+workflows[523]=['TTbar012Jets_NLO_Mad_13TeV_py8_Evt',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_evtgen','HARVESTGEN2']]     # ALWAYS RUN
+workflows[524]=['VHToHtt_NLO_Pow_13TeV_py8_Ta',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola','HARVESTGEN2']]     # ALWAYS RUN
+
 workflows[527]=['VHToHtt_NLO_Pow_13TeV_py8_Ta_taupinu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola','HARVESTGEN2']]
 workflows[529]=['DYTollJets_LO_Mad_13TeV_py8_Ta_taurhonu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taurhonu','HARVESTGEN2']]
 workflows[530]=['VHToHtt_NLO_Pow_13TeV_py8_Ta_taurhonu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola','HARVESTGEN2']]

--- a/Configuration/PyReleaseValidation/python/relval_extendedgen.py
+++ b/Configuration/PyReleaseValidation/python/relval_extendedgen.py
@@ -20,28 +20,32 @@ workflows[508]=['',['SoftQCDnonDiffractive_13TeV_pythia8','HARVESTGEN']]
 workflows[509]=['',['SoftQCDelastic_13TeV_pythia8','HARVESTGEN']]
 workflows[510]=['',['SoftQCDinelastic_13TeV_pythia8','HARVESTGEN']]
 
-# Matrix Element Generations (LHE Generation)
+# Matrix Element Generations (scerpa)
+#workflows[533]=['',['sherpa_ZtoEE_0j_BlackHat_13TeV_MASTER','HARVESTGEN']]
+workflows[534]=['',['sherpa_ZtoEE_0j_OpenLoops_13TeV_MASTER','HARVESTGEN']]
 
 # Hadronization (LHE Generation + Hadronization)
-workflows[514]=['',['GGToH_13TeV_pythia8','HARVESTGEN']]
 workflows[515]=['DYTollJets_LO_Mad_13TeV_py8_taupinu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taupinu','HARVESTGEN2']]
-workflows[516]=['',['WJetsLNutaupinu_13TeV_madgraph-pythia8','HARVESTGEN']]
-
-workflows[517]=['',['GGToHtaupinu_13TeV_pythia8','HARVESTGEN']]
+workflows[516]=['WTolNuJets_LO_Mad_13TeV_py8_taupinu',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taupinu','HARVESTGEN2']]
+workflows[517]=['VHToHtt_NLO_Pow_13TeV_py8_taupinu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8','HARVESTGEN2']]
 workflows[518]=['DYTollJets_LO_Mad_13TeV_py8_taurhonu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taurhonu','HARVESTGEN2']]
-workflows[519]=['',['WJetsLNutaurhonu_13TeV_madgraph-pythia8','HARVESTGEN']]
-workflows[520]=['',['GGToHtaurhonu_13TeV_pythia8','HARVESTGEN']]
+workflows[519]=['WTolNuJets_LO_Mad_13TeV_py8_taurhonu',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taurhonu','HARVESTGEN2']]
+workflows[520]=['VHToHtt_NLO_Pow_13TeV_py8_taurhonu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8','HARVESTGEN2']]
 
 # External Decays
-workflows[524]=['',['GGToH_13TeV_pythia8-tauola','HARVESTGEN']]
-workflows[525]=['',['WToLNutaupinu_13TeV_pythia8-tauola','HARVESTGEN']]
-workflows[526]=['DYTollJets_LO_Mad_13TeV_py8_Ta_taupinu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taupinu','HARVESTGEN2']]
-workflows[527]=['',['GGToHtaupinu_13TeV_pythia8-tauola','HARVESTGEN']]
-workflows[528]=['',['WToLNutaurhonu_13TeV_pythia8-tauola','HARVESTGEN']]
+workflows[527]=['VHToHtt_NLO_Pow_13TeV_py8_Ta_taupinu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola','HARVESTGEN2']]
 workflows[529]=['DYTollJets_LO_Mad_13TeV_py8_Ta_taurhonu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taurhonu','HARVESTGEN2']]
-workflows[530]=['',['GGToHtaurhonu_13TeV_pythia8-tauola','HARVESTGEN']]
+workflows[530]=['VHToHtt_NLO_Pow_13TeV_py8_Ta_taurhonu',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola','HARVESTGEN2']]
+workflows[526]=['DYTollJets_LO_Mad_13TeV_py8_Ta_taupinu',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taupinu','HARVESTGEN2']]
+workflows[525]=['WTolNuJets_LO_Mad_13TeV_py8_Ta_taupinu',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taupinu','HARVESTGEN2']]
+workflows[528]=['WTolNuJets_LO_Mad_13TeV_py8_Ta_taurhonu',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_taurhonu','HARVESTGEN2']]
 
 # Heavy Ion
 #workflows[532]=['',['Hijing_PPb_MinimumBias','HARVESTGEN']]
 
 # Miscellaneous
+workflows[560]=['',['ZprimeToll_M3000_13TeV_pythia8','HARVESTGEN']]
+workflows[561]=['',['WprimeTolNu_M3000_13TeV_pythia8','HARVESTGEN']]
+workflows[562]=['BulkG_ZZ_2L2Q_M1200_narrow_13TeV_pythia8',['BulkG_M1200_narrow_2L2Q_LHE_13TeV','Hadronizer_TuneCUETP8M1_Mad_pythia8','HARVESTGEN2']]
+
+

--- a/Configuration/PyReleaseValidation/python/relval_generator.py
+++ b/Configuration/PyReleaseValidation/python/relval_generator.py
@@ -25,21 +25,10 @@ workflows[506]=['',['WToLNu_13TeV_pythia8','HARVESTGEN']]
 
 # Matrix Element Generations & Hadronization (LHE Generation + Hadronization)
 workflows[512]=['DYTollJets_LO_Mad_13TeV_py8',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]
-workflows[555]=['DYTollJets_NLO_Mad_13TeV_py8',['DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8','HARVESTGEN2']]
-workflows[513]=['WTolNuJets_LO_Mad_13TeV_py8',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]
-workflows[551]=['TTbar012Jets_NLO_Mad_13TeV_py8',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8','HARVESTGEN2']]
-workflows[556]=['TTbar_NLO_Pow_13TeV_py8',['TTbar_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto2p_pythia8','HARVESTGEN2']]
-workflows[514]=['GGToHgg_NLO_Pow_13TeV_py8',['GGToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8','HARVESTGEN2']]
-workflows[552]=['VHToHtt_NLO_Pow_13TeV_py8',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8','HARVESTGEN2']]
-workflows[554]=['VBFToH4l_NLO_Pow_JHU_13TeV_py8',['VBFToH_Pow_JHU4l_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8','HARVESTGEN2']]
 
 # Matrix Element Generations & Hadronization (Sherpa)
 
 # External Decays
-workflows[521]=['WTolNuJets_LO_Mad_13TeV_py8_Ta',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]
-workflows[522]=['DYTollJets_LO_Mad_13TeV_py8_Ta',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]
-workflows[523]=['TTbar012Jets_NLO_Mad_13TeV_py8_Evt',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_evtgen','HARVESTGEN2']]
-workflows[524]=['VHToHtt_NLO_Pow_13TeV_py8_Ta',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola','HARVESTGEN2']]
 
 # Heavy Ion
 workflows[531]=['',['ReggeGribovPartonMC_EposLHC_5TeV_pPb','HARVESTGEN']]

--- a/Configuration/PyReleaseValidation/python/relval_generator.py
+++ b/Configuration/PyReleaseValidation/python/relval_generator.py
@@ -15,36 +15,39 @@ workflows = Matrix()
 # the two sets are exclusive
 
 # LO Generators
-workflows[501]=['',['MinBias_TuneZ2star_13TeV_pythia6','HARVESTGEN']]
-workflows[502]=['',['QCD_Pt-30_TuneZ2star_13TeV_pythia6','HARVESTGEN']]
+#workflows[501]=['',['MinBias_TuneZ2star_13TeV_pythia6','HARVESTGEN']]
+#workflows[502]=['',['QCD_Pt-30_TuneZ2star_13TeV_pythia6','HARVESTGEN']]
 workflows[503]=['',['MinBias_13TeV_pythia8','HARVESTGEN']]
 workflows[504]=['',['QCD_Pt-30_13TeV_pythia8','HARVESTGEN']]
 workflows[505]=['',['DYToLL_M-50_13TeV_pythia8','HARVESTGEN']]
 workflows[506]=['',['WToLNu_13TeV_pythia8','HARVESTGEN']]
-workflows[511]=['',['QCD_Pt-30_8TeV_herwigpp','HARVESTGEN']]
+#workflows[511]=['',['QCD_Pt-30_8TeV_herwigpp','HARVESTGEN']]
 
 # Matrix Element Generations & Hadronization (LHE Generation + Hadronization)
 workflows[512]=['DYTollJets_LO_Mad_13TeV_py8',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]
-workflows[513]=['',['WJetsLNu_13TeV_madgraph-pythia8','HARVESTGEN']]
+workflows[555]=['DYTollJets_NLO_Mad_13TeV_py8',['DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8','HARVESTGEN2']]
+workflows[513]=['WTolNuJets_LO_Mad_13TeV_py8',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]
+workflows[551]=['TTbar012Jets_NLO_Mad_13TeV_py8',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8','HARVESTGEN2']]
+workflows[514]=['GGToHgg_NLO_Pow_13TeV_py8',['GGToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8','HARVESTGEN2']]
+workflows[552]=['VHToHtt_NLO_Pow_13TeV_py8',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8','HARVESTGEN2']]
+workflows[554]=['VBFToH4l_NLO_Pow_JHU_13TeV_py8',['VBFToH_Pow_JHU4l_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8','HARVESTGEN2']]
 
 # Matrix Element Generations & Hadronization (Sherpa)
-workflows[533]=['',['sherpa_ZtoEE_0j_BlackHat_13TeV_MASTER','HARVESTGEN']]
-workflows[534]=['',['sherpa_ZtoEE_0j_OpenLoops_13TeV_MASTER','HARVESTGEN']]
 
 # External Decays
-workflows[521]=['',['TT_13TeV_pythia8-evtgen','HARVESTGEN']]
+workflows[521]=['WTolNuJets_LO_Mad_13TeV_py8_Ta',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]
 workflows[522]=['DYTollJets_LO_Mad_13TeV_py8_Ta',['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola','HARVESTGEN2']]
-workflows[523]=['',['WToLNu_13TeV_pythia8-tauola','HARVESTGEN']]
-workflows[524]=['TTbar012Jets_NLO_Mad_13TeV_py8',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8','HARVESTGEN2']]
+workflows[523]=['TTbar012Jets_NLO_Mad_13TeV_py8_Evt',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_evtgen','HARVESTGEN2']]
+workflows[524]=['VHToHtt_NLO_Pow_13TeV_py8_Ta',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola','HARVESTGEN2']]
 
 # Heavy Ion
 workflows[531]=['',['ReggeGribovPartonMC_EposLHC_5TeV_pPb','HARVESTGEN']]
 
-#B-physics
+# B-physics
 workflows[541]=['',['BuToKstarJPsiToMuMu_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
-workflows[542]=['',['Upsilon4swithBuToKstarJPsiToMuMu_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
-workflows[543]=['',['Upsilon4sBaBarExample_BpBm_Dstarpipi_D0Kpi_nonres_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
-workflows[544]=['',['LambdaBToLambdaMuMuToPPiMuMu_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
+#workflows[542]=['',['Upsilon4swithBuToKstarJPsiToMuMu_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
+#workflows[543]=['',['Upsilon4sBaBarExample_BpBm_Dstarpipi_D0Kpi_nonres_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
+#workflows[544]=['',['LambdaBToLambdaMuMuToPPiMuMu_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
 workflows[545]=['',['BsToMuMu_forSTEAM_13TeV_TuneCUETP8M1','HARVESTGEN']]
 
 # Miscellaneous

--- a/Configuration/PyReleaseValidation/python/relval_generator.py
+++ b/Configuration/PyReleaseValidation/python/relval_generator.py
@@ -28,6 +28,7 @@ workflows[512]=['DYTollJets_LO_Mad_13TeV_py8',['DYToll01234Jets_5f_LO_MLM_Madgra
 workflows[555]=['DYTollJets_NLO_Mad_13TeV_py8',['DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8','HARVESTGEN2']]
 workflows[513]=['WTolNuJets_LO_Mad_13TeV_py8',['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8','HARVESTGEN2']]
 workflows[551]=['TTbar012Jets_NLO_Mad_13TeV_py8',['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8','HARVESTGEN2']]
+workflows[556]=['TTbar_NLO_Pow_13TeV_py8',['TTbar_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto2p_pythia8','HARVESTGEN2']]
 workflows[514]=['GGToHgg_NLO_Pow_13TeV_py8',['GGToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8','HARVESTGEN2']]
 workflows[552]=['VHToHtt_NLO_Pow_13TeV_py8',['VHToH_Pow_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8','HARVESTGEN2']]
 workflows[554]=['VBFToH4l_NLO_Pow_JHU_13TeV_py8',['VBFToH_Pow_JHU4l_LHE_13TeV','Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8','HARVESTGEN2']]

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -590,6 +590,8 @@ def identityFS(wf):
 steps['SingleMuPt10FS_UP15_ID']=identityFS(steps['SingleMuPt10FS_UP15'])
 steps['TTbarFS_13_ID']=identityFS(steps['TTbarFS_13'])
 
+## GENERATORS
+
 step1GenDefaults=merge([{'-s':'GEN,VALIDATION:genvalid',
                          '--relval':'250000,20000',
                          '--eventcontent':'RAWSIM,DQM',
@@ -610,6 +612,13 @@ step1LHEDefaults=merge([{'-s':'LHE',
 
 steps['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
 steps['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
+steps['DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
+steps['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
+steps['GGToH_Pow_LHE_13TeV']=genvalid('Configuration/Generator/python/GGToH_Pow_LHE_13TeV_cff.py',step1LHEDefaults)
+steps['VHToH_Pow_LHE_13TeV']=genvalid('Configuration/Generator/python/VHToH_Pow_LHE_13TeV_cff.py',step1LHEDefaults)
+steps['VBFToH_Pow_JHU4l_LHE_13TeV']=genvalid('Configuration/Generator/python/VBFToH_Pow_JHU4l_LHE_13TeV_cff.py',step1LHEDefaults)
+
+steps['BulkG_M1200_narrow_2L2Q_LHE_13TeV']=genvalid('Configuration/Generator/python/BulkG_M1200_narrow_2L2Q_LHE_13TeV_cff.py',step1LHEDefaults)
 
 # all 6 workflows with root step 'DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV' will recycle the same dataset, from wf [512] of generator set
 # steps['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeVINPUT']={'INPUT':InputInfo(dataSet='/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_py8/CMSSW_7_4_0_pre0-MCRUN2_73_V5-v1/GEN',location='STD')}
@@ -629,6 +638,9 @@ steps['SoftQCDinelastic_13TeV_pythia8']=genvalid('SoftQCDinelastic_13TeV_pythia8
 
 steps['QCD_Pt-30_8TeV_herwigpp']=genvalid('QCD_Pt_30_8TeV_herwigpp_cff',step1GenDefaults)
 
+steps['ZprimeToll_M3000_13TeV_pythia8']=genvalid('ZprimeToll_M3000_13TeV_pythia8_cff',step1GenDefaults)
+steps['WprimeTolNu_M3000_13TeV_pythia8']=genvalid('WprimeTolNu_M3000_13TeV_pythia8_cff',step1GenDefaults)
+
 # Generator Hadronization (Hadronization of LHE)
 steps['WJetsLNu_13TeV_madgraph-pythia8']=genvalid('Hadronizer_MgmMatchTuneCUETP8M1_13TeV_madgraph_pythia8_cff',step1GenDefaults,dataSet='/WJetsToLNu_13TeV-madgraph/Fall13wmLHE-START62_V1-v1/GEN')
 steps['Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_cff',step1HadronizerDefaults)
@@ -642,12 +654,25 @@ steps['WJetsLNutaurhonu_13TeV_madgraph-pythia8']=genvalid('Hadronizer_MgmMatchTu
 steps['Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taurhonu']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_taurhonu_cff.py',step1HadronizerDefaults)
 steps['GGToHtaurhonu_13TeV_pythia8']=genvalid('GGToHtautau_13TeV_pythia8_taurhonu_cff',step1GenDefaults)
 
+steps['Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_evtgen']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_evtgen_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max0p_LHE_pythia8_cff',step1HadronizerDefaults)
+
+steps['Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Hgg_powhegEmissionVeto_pythia8_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8_cff',step1HadronizerDefaults)
+
+steps['Hadronizer_TuneCUETP8M1_Mad_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_generic_LHE_pythia8_cff',step1HadronizerDefaults)
+
 # Generator External Decays
 steps['TT_13TeV_pythia8-evtgen']=genvalid('Hadronizer_MgmMatchTuneCUETP8M1_13TeV_madgraph_pythia8_EvtGen_cff',step1GenDefaults,dataSet='/TTJets_MSDecaysCKM_central_13TeV-madgraph/Fall13wmLHE-START62_V1-v1/GEN')
 
 steps['Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_MLM_5f_max4j_LHE_pythia8_Tauola_cff',step1HadronizerDefaults)
-
-steps['Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_aMCatNLO_FXFX_5f_max2j_max1p_LHE_pythia8_cff',step1HadronizerDefaults)
 
 steps['WToLNu_13TeV_pythia8-tauola']=genvalid('Hadronizer_MgmMatchTuneCUETP8M1_13TeV_madgraph_pythia8_Tauola_cff',step1GenDefaults,dataSet='/WJetsToLNu_13TeV-madgraph/Fall13wmLHE-START62_V1-v1/GEN')
 steps['GGToH_13TeV_pythia8-tauola']=genvalid('GGToHtautau_13TeV_pythia8_Tauola_cff',step1GenDefaults)

--- a/Configuration/PyReleaseValidation/python/relval_steps.py
+++ b/Configuration/PyReleaseValidation/python/relval_steps.py
@@ -612,6 +612,7 @@ step1LHEDefaults=merge([{'-s':'LHE',
 
 steps['DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/DYToll01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
 steps['TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/TTbar012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
+steps['TTbar_Pow_LHE_13TeV']=genvalid('Configuration/Generator/python/TTbar_Pow_LHE_13TeV_cff.py',step1LHEDefaults)
 steps['DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/DYToll012Jets_5f_NLO_FXFX_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
 steps['WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV']=genvalid('Configuration/Generator/python/WTolNu01234Jets_5f_LO_MLM_Madgraph_LHE_13TeV_cff.py',step1LHEDefaults)
 steps['GGToH_Pow_LHE_13TeV']=genvalid('Configuration/Generator/python/GGToH_Pow_LHE_13TeV_cff.py',step1LHEDefaults)
@@ -666,6 +667,7 @@ steps['Hadronizer_TuneCUETP8M1_13TeV_Htt_powhegEmissionVeto_pythia8_tauola']=gen
 steps['Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Httpinu_powhegEmissionVeto_pythia8_tauola_cff',step1HadronizerDefaults)
 steps['Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_Httrhonu_powhegEmissionVeto_pythia8_tauola_cff',step1HadronizerDefaults)
 steps['Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto_pythia8_cff',step1HadronizerDefaults)
+steps['Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto2p_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_powhegEmissionVeto2p_pythia8_cff',step1HadronizerDefaults)
 
 steps['Hadronizer_TuneCUETP8M1_Mad_pythia8']=genvalid('Hadronizer_TuneCUETP8M1_13TeV_generic_LHE_pythia8_cff',step1HadronizerDefaults)
 


### PR DESCRIPTION
Proposal to revise GEN validation samples:
- Added more used LHE-based workflows (also testing aMCatNLO and Powheg) and others, spanning a wider range of MC generators used in CMS 
- removed old/redundant workflows, fixed duplicated workflow numbers 
- reordered samples in the way they should be 
  (generator = RelVal to be run for every release validation cycle
  extendedgen = RelVal to be run only for major changes and on demand)

Proposal to be discussed @bendavid @franzoni @mkiani
