### PR TITLE
Fix bug preventing the use of a local cache

### DIFF
--- a/Utilities/StorageFactory/src/StorageFactory.cc
+++ b/Utilities/StorageFactory/src/StorageFactory.cc
@@ -274,7 +274,7 @@ StorageFactory::wrapNonLocalFile (Storage *s,
       {
         m_lfs.issueWarning();
       }
-      else if (path.empty() || m_lfs.isLocalPath(path))
+      else if ( (not path.empty()) and m_lfs.isLocalPath(path))
       {
         // For now, issue no warning - otherwise, we'd always warn on local input files.
       }


### PR DESCRIPTION
The last change to the logic of when a local cache could be used had
an error which accidently disabled any use of a local cache. This change
corrects the logic and a quick test shows that local caching is working
again.
