### PR TITLE
Add valid,lost,missing inner/outer hits 2d-histos

### DIFF
--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -134,6 +134,21 @@ class TrackAnalyzer
 	    , NumberOfValidRecHitsPerTrackVsEta(NULL)
 	    , NumberOfValidRecHitVsPhiVsEtaPerTrack(NULL)
 
+            , NumberOfLostRecHitsPerTrackVsPhi(NULL)
+            , NumberOfLostRecHitsPerTrackVsTheta(NULL)
+            , NumberOfLostRecHitsPerTrackVsEta(NULL)
+            , NumberOfLostRecHitVsPhiVsEtaPerTrack(NULL)
+
+            , NumberOfMIRecHitsPerTrackVsPhi(NULL)
+            , NumberOfMIRecHitsPerTrackVsTheta(NULL)
+            , NumberOfMIRecHitsPerTrackVsEta(NULL)
+            , NumberOfMIRecHitVsPhiVsEtaPerTrack(NULL)
+
+            , NumberOfMORecHitsPerTrackVsPhi(NULL)
+            , NumberOfMORecHitsPerTrackVsTheta(NULL)
+            , NumberOfMORecHitsPerTrackVsEta(NULL)
+            , NumberOfMORecHitVsPhiVsEtaPerTrack(NULL)
+    
 	    , NumberOfLayersPerTrackVsPhi(NULL)
 	    , NumberOfLayersPerTrackVsTheta(NULL)
 	    , NumberOfLayersPerTrackVsEta(NULL)
@@ -181,6 +196,21 @@ class TrackAnalyzer
 	  MonitorElement* NumberOfValidRecHitsPerTrackVsEta;
 	  MonitorElement* NumberOfValidRecHitVsPhiVsEtaPerTrack;
 
+          MonitorElement* NumberOfLostRecHitsPerTrackVsPhi;
+          MonitorElement* NumberOfLostRecHitsPerTrackVsTheta;
+          MonitorElement* NumberOfLostRecHitsPerTrackVsEta;
+          MonitorElement* NumberOfLostRecHitVsPhiVsEtaPerTrack;
+
+          MonitorElement* NumberOfMIRecHitsPerTrackVsPhi;
+          MonitorElement* NumberOfMIRecHitsPerTrackVsTheta;
+          MonitorElement* NumberOfMIRecHitsPerTrackVsEta;
+          MonitorElement* NumberOfMIRecHitVsPhiVsEtaPerTrack;
+
+          MonitorElement* NumberOfMORecHitsPerTrackVsPhi;
+          MonitorElement* NumberOfMORecHitsPerTrackVsTheta;
+          MonitorElement* NumberOfMORecHitsPerTrackVsEta;
+          MonitorElement* NumberOfMORecHitVsPhiVsEtaPerTrack;
+
 	  MonitorElement* NumberOfLayersPerTrackVsPhi;
 	  MonitorElement* NumberOfLayersPerTrackVsTheta;
 	  MonitorElement* NumberOfLayersPerTrackVsEta;
@@ -200,16 +230,36 @@ class TrackAnalyzer
 	MonitorElement* NumberOfRecHitsPerTrack;
 	MonitorElement* NumberOfValidRecHitsPerTrack;
 	MonitorElement* NumberOfLostRecHitsPerTrack;
+        MonitorElement* NumberOfMIRecHitsPerTrack = nullptr;
+        MonitorElement* NumberOfMORecHitsPerTrack = nullptr;
+
 	
-	MonitorElement* NumberOfRecHitsPerTrackVsPhi;
-	MonitorElement* NumberOfRecHitsPerTrackVsTheta;
-	MonitorElement* NumberOfRecHitsPerTrackVsEta;
-	MonitorElement* NumberOfRecHitVsPhiVsEtaPerTrack;
+	MonitorElement* NumberOfRecHitsPerTrackVsPhi = nullptr;
+	MonitorElement* NumberOfRecHitsPerTrackVsTheta = nullptr;
+	MonitorElement* NumberOfRecHitsPerTrackVsEta = nullptr;
+	MonitorElement* NumberOfRecHitVsPhiVsEtaPerTrack = nullptr;
 	
-	MonitorElement* NumberOfValidRecHitsPerTrackVsPhi;
-	MonitorElement* NumberOfValidRecHitsPerTrackVsTheta;
-	MonitorElement* NumberOfValidRecHitsPerTrackVsEta;
-	MonitorElement* NumberOfValidRecHitVsPhiVsEtaPerTrack;
+	MonitorElement* NumberOfValidRecHitsPerTrackVsPhi = nullptr;
+	MonitorElement* NumberOfValidRecHitsPerTrackVsTheta = nullptr;
+	MonitorElement* NumberOfValidRecHitsPerTrackVsEta = nullptr;
+	MonitorElement* NumberOfValidRecHitVsPhiVsEtaPerTrack = nullptr;
+
+          MonitorElement* NumberOfLostRecHitsPerTrackVsPhi = nullptr;
+          MonitorElement* NumberOfLostRecHitsPerTrackVsTheta = nullptr;
+          MonitorElement* NumberOfLostRecHitsPerTrackVsEta = nullptr;
+          MonitorElement* NumberOfLostRecHitVsPhiVsEtaPerTrack = nullptr;
+
+          MonitorElement* NumberOfMIRecHitsPerTrackVsPhi = nullptr;
+          MonitorElement* NumberOfMIRecHitsPerTrackVsTheta = nullptr;
+          MonitorElement* NumberOfMIRecHitsPerTrackVsEta = nullptr;
+          MonitorElement* NumberOfMIRecHitVsPhiVsEtaPerTrack = nullptr;
+
+          MonitorElement* NumberOfMORecHitsPerTrackVsPhi = nullptr;
+          MonitorElement* NumberOfMORecHitsPerTrackVsTheta = nullptr;
+          MonitorElement* NumberOfMORecHitsPerTrackVsEta = nullptr;
+          MonitorElement* NumberOfMORecHitVsPhiVsEtaPerTrack = nullptr;
+
+
 	
 	MonitorElement* NumberOfLayersPerTrack;
 	

--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -252,7 +252,7 @@ class TrackAnalyzer
 	MonitorElement* zPointOfClosestApproach;
 	MonitorElement* zPointOfClosestApproachToPV;
 	MonitorElement* zPointOfClosestApproachVsPhi;
-	MonitorElement* algorithm;
+	MonitorElement *algorithm, *oriAlgo;
 	// TESTING MEs
 	MonitorElement* TESTDistanceOfClosestApproachToBS;
 	MonitorElement* TESTDistanceOfClosestApproachToBSVsPhi;

--- a/DQM/TrackingMonitor/interface/TrackAnalyzer.h
+++ b/DQM/TrackingMonitor/interface/TrackAnalyzer.h
@@ -261,13 +261,13 @@ class TrackAnalyzer
 
 
 	
-	MonitorElement* NumberOfLayersPerTrack;
+	MonitorElement* NumberOfLayersPerTrack[4] = {nullptr,nullptr,nullptr,nullptr};
 	
 	MonitorElement* NumberOfLayersPerTrackVsPhi;
 	MonitorElement* NumberOfLayersPerTrackVsTheta;
 	MonitorElement* NumberOfLayersPerTrackVsEta;
 
-	MonitorElement* NumberOfLayersVsPhiVsEtaPerTrack;
+	MonitorElement* NumberOfLayersVsPhiVsEtaPerTrack[4]= {nullptr,nullptr,nullptr,nullptr};
 
 	MonitorElement* Chi2;
 	MonitorElement* Chi2Prob;

--- a/DQM/TrackingMonitor/interface/TrackingMonitor.h
+++ b/DQM/TrackingMonitor/interface/TrackingMonitor.h
@@ -128,7 +128,7 @@ class TrackingMonitor : public DQMEDAnalyzer
 	MonitorElement* NumberOfRecHitsPerTrackVsLS;
 
 	// Monitoring PU
-	MonitorElement* NumberOfTracksVsGoodPVtx;
+	MonitorElement *NumberOfTracksVsGoodPVtx, *NumberOfTracksVsPUPVtx;
 	MonitorElement* NumberOfTracksVsBXlumi;
 
 	// add in order to deal with LS transitions

--- a/DQM/TrackingMonitor/python/TrackerCollisionTrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackerCollisionTrackingMonitor_cfi.py
@@ -47,9 +47,9 @@ TrackerCollisionTrackMon.doRecHitVsPhiVsEtaPerTrack          = cms.bool(True)
 TrackerCollisionTrackMon.doGoodTrackRecHitVsPhiVsEtaPerTrack = cms.bool(True)
 TrackerCollisionTrackMon.doLayersVsPhiVsEtaPerTrack          = cms.bool(True)
 TrackerCollisionTrackMon.doGoodTrackLayersVsPhiVsEtaPerTrack = cms.bool(True)
-#TrackerCollisionTrackMon.doPUmonitoring                      = cms.bool(True)
-#TrackerCollisionTrackMon.doPlotsVsBXlumi                     = cms.bool(True)
-#TrackerCollisionTrackMon.doPlotsVsGoodPVtx                   = cms.bool(True)
+TrackerCollisionTrackMon.doPUmonitoring                      = cms.bool(False)
+TrackerCollisionTrackMon.doPlotsVsBXlumi                     = cms.bool(False)
+TrackerCollisionTrackMon.doPlotsVsGoodPVtx                   = cms.bool(True)
 
 # LS analysis
 TrackerCollisionTrackMon.doLumiAnalysis       = cms.bool(True)     

--- a/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
+++ b/DQM/TrackingMonitor/python/TrackingMonitor_cfi.py
@@ -74,7 +74,7 @@ TrackMon = cms.EDAnalyzer("TrackingMonitor",
     doTrackPxPyPlots                    = cms.bool(False),
     doPUmonitoring                      = cms.bool(False),
     doPlotsVsBXlumi                     = cms.bool(False),
-    doPlotsVsGoodPVtx                   = cms.bool(False),
+    doPlotsVsGoodPVtx                   = cms.bool(True),
     doHIPlots                           = cms.bool(False),                              
     qualityString = cms.string("highPurity"),                      
     #which seed plots to do

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -235,6 +235,17 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
       NumberOfLostRecHitsPerTrack->setAxisTitle("Number of lost RecHits for each Track");
       NumberOfLostRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
 
+      histname = "NumberOfMissingInnerRecHitsPerTrack_";
+      NumberOfMIRecHitsPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, 10, -0.5, 9.5);
+      NumberOfMIRecHitsPerTrack->setAxisTitle("Number of missing-inner RecHits for each Track");
+      NumberOfMIRecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+
+      histname = "NumberOfMissingOuterRecHitsPerTrack_";
+      NumberOfMORecHitsPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, 10, -0.5, 9.5);
+      NumberOfMORecHitsPerTrack->setAxisTitle("Number of missing-outer RecHits for each Track");
+      NumberOfMORecHitsPerTrack->setAxisTitle("Number of Tracks", 2);
+
+
       histname = "NumberOfLayersPerTrack_";
       NumberOfLayersPerTrack = ibooker.book1D(histname+CategoryName, histname+CategoryName, TKLayBin, TKLayMin, TKLayMax);
       NumberOfLayersPerTrack->setAxisTitle("Number of Layers of each Track", 1);
@@ -243,11 +254,32 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 
       if ( doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_ ){
 	
-	histname = "NumberOfRecHitVsPhiVsEtaPerTrack_";
-	NumberOfRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
+	histname = "NumberOfValidRecHitVsPhiVsEtaPerTrack_";
+	NumberOfValidRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName, 
 								    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 40., "");
-	NumberOfRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
-	NumberOfRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+	NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+	NumberOfValidRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+        histname = "NumberOfLostRecHitVsPhiVsEtaPerTrack_";
+        NumberOfLostRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
+                                                                    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 5., "");
+        NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+        NumberOfLostRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+
+        histname = "NumberMIRecHitVsPhiVsEtaPerTrack_";
+        NumberOfMIRecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
+                                                                    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 15., "");
+        NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+        NumberOfMIRecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+        histname = "NumberMORecHitVsPhiVsEtaPerTrack_";
+        NumberOfMORecHitVsPhiVsEtaPerTrack = ibooker.bookProfile2D(histname+CategoryName, histname+CategoryName,
+                                                                    EtaBin, EtaMin, EtaMax, PhiBin, PhiMin, PhiMax, 0, 15., "");
+        NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #eta ", 1);
+        NumberOfMORecHitVsPhiVsEtaPerTrack->setAxisTitle("Track #phi ", 2);
+
+
       }
 
       if ( doLayersVsPhiVsEtaPerTrack_ || doAllPlots_ ){
@@ -665,6 +697,8 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
   int nRecHits      = track.hitPattern().numberOfHits(reco::HitPattern::TRACK_HITS);
   int nValidRecHits = track.numberOfValidHits();
   int nLostRecHits  = track.numberOfLostHits();
+  int nLostIn =      track.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_INNER_HITS);
+  int nLostOut =     track.hitPattern().numberOfLostTrackerHits(reco::HitPattern::MISSING_OUTER_HITS);
 
   double chi2     = track.chi2();
   double chi2prob = TMath::Prob(track.chi2(),(int)track.ndof());
@@ -675,11 +709,15 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     NumberOfRecHitsPerTrack     -> Fill(nRecHits);
     NumberOfValidRecHitsPerTrack-> Fill(nValidRecHits);
     NumberOfLostRecHitsPerTrack -> Fill(nLostRecHits);
+    NumberOfMIRecHitsPerTrack -> Fill(nLostIn);
+    NumberOfMORecHitsPerTrack -> Fill(nLostOut);
 
     // 2D plots    
-    if ( doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_ )
-      NumberOfRecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nRecHits);
-    
+    if ( doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_ ) {
+      NumberOfValidRecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nValidRecHits);
+      NumberOfLostRecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nLostRecHits);
+    }
+
     int nLayers = track.hitPattern().trackerLayersWithMeasurement();
     // layers
     NumberOfLayersPerTrack->Fill(nLayers);

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -354,7 +354,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 
 
       
-      if (doDCAPlots_) {
+      if(doDCAPlots_ || doPVPlots_ || doSIPPlots_ || doAllPlots_)  {
 	histname = "xPointOfClosestApproach_";
 	xPointOfClosestApproach = ibooker.book1D(histname+CategoryName, histname+CategoryName, VXBin, VXMin, VXMax);
 	xPointOfClosestApproach->setAxisTitle("x component of Track PCA to beam line (cm)",1);

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -372,7 +372,7 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
 	zPointOfClosestApproach->setAxisTitle("Number of Tracks",2);
 	
 	histname = "xPointOfClosestApproachToPV_";
-	xPointOfClosestApproachToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, VXBin, VXMin, VXMax);
+        xPointOfClosestApproachToPV = ibooker.book1D(histname+CategoryName, histname+CategoryName, VXBin, VXMin, VXMax);
 	xPointOfClosestApproachToPV->setAxisTitle("x component of Track PCA to pv (cm)",1);
 	xPointOfClosestApproachToPV->setAxisTitle("Number of Tracks",2);
 	
@@ -806,7 +806,9 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
         }
 
 
-
+      xPointOfClosestApproachToPV->Fill(track.vx()-pv.position().x());
+      yPointOfClosestApproachToPV->Fill(track.vy()-pv.position().y());
+      zPointOfClosestApproachToPV->Fill(track.dz(pv.position()));
       DistanceOfClosestApproachToPV      -> Fill(track.dxy(pv.position()));
       DistanceOfClosestApproachToPVVsPhi -> Fill(track.phi(), track.dxy(pv.position()));
       xPointOfClosestApproachVsZ0wrtPV   -> Fill(track.dz(pv.position()),(track.vx()-pv.position().x()));

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -716,6 +716,8 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
     if ( doRecHitVsPhiVsEtaPerTrack_ || doAllPlots_ ) {
       NumberOfValidRecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nValidRecHits);
       NumberOfLostRecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nLostRecHits);
+      NumberOfMIRecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nLostIn);
+      NumberOfMORecHitVsPhiVsEtaPerTrack->Fill(eta,phi,nLostOut);
     }
 
     int nLayers = track.hitPattern().trackerLayersWithMeasurement();

--- a/DQM/TrackingMonitor/src/TrackAnalyzer.cc
+++ b/DQM/TrackingMonitor/src/TrackAnalyzer.cc
@@ -57,71 +57,73 @@ TrackAnalyzer::TrackAnalyzer(const edm::ParameterSet& iConfig, edm::ConsumesColl
 
 void TrackAnalyzer::initHistos()
 {
-  Chi2 = NULL;
-  Chi2Prob = NULL;
-  Chi2ProbVsPhi = NULL;
-  Chi2ProbVsEta = NULL;
-  Chi2oNDF = NULL;
-  Chi2oNDFVsEta = NULL;
-  Chi2oNDFVsPhi = NULL;
-  Chi2oNDFVsTheta = NULL;
-  Chi2oNDFVsTheta = NULL;
-  Chi2oNDFVsPhi = NULL;
-  Chi2oNDFVsEta = NULL;
+  Chi2 = nullptr;
+  Chi2Prob = nullptr;
+  Chi2ProbVsPhi = nullptr;
+  Chi2ProbVsEta = nullptr;
+  Chi2oNDF = nullptr;
+  Chi2oNDFVsEta = nullptr;
+  Chi2oNDFVsPhi = nullptr;
+  Chi2oNDFVsTheta = nullptr;
+  Chi2oNDFVsTheta = nullptr;
+  Chi2oNDFVsPhi = nullptr;
+  Chi2oNDFVsEta = nullptr;
   	    
-  NumberOfRecHitsPerTrack = NULL;
-  NumberOfValidRecHitsPerTrack = NULL;
-  NumberOfLostRecHitsPerTrack = NULL;
+  NumberOfRecHitsPerTrack = nullptr;
+  NumberOfValidRecHitsPerTrack = nullptr;
+  NumberOfLostRecHitsPerTrack = nullptr;
 
-  NumberOfRecHitsPerTrackVsPhi = NULL;
-  NumberOfRecHitsPerTrackVsTheta = NULL;
-  NumberOfRecHitsPerTrackVsEta = NULL;
+  NumberOfRecHitsPerTrackVsPhi = nullptr;
+  NumberOfRecHitsPerTrackVsTheta = nullptr;
+  NumberOfRecHitsPerTrackVsEta = nullptr;
 
-  NumberOfRecHitVsPhiVsEtaPerTrack = NULL;
+  NumberOfRecHitVsPhiVsEtaPerTrack = nullptr;
 
-  NumberOfValidRecHitsPerTrackVsPhi = NULL;
-  NumberOfValidRecHitsPerTrackVsEta = NULL;
+  NumberOfValidRecHitsPerTrackVsPhi = nullptr;
+  NumberOfValidRecHitsPerTrackVsEta = nullptr;
 
-  NumberOfLayersPerTrack = NULL;
-  NumberOfLayersVsPhiVsEtaPerTrack = NULL;
+  NumberOfLayersPerTrack = nullptr;
+  NumberOfLayersVsPhiVsEtaPerTrack = nullptr;
 
-  DistanceOfClosestApproach = NULL;
-  DistanceOfClosestApproachToBS = NULL;
-  DistanceOfClosestApproachVsTheta = NULL;
-  DistanceOfClosestApproachVsPhi = NULL;
-  DistanceOfClosestApproachToBSVsPhi = NULL;
-  DistanceOfClosestApproachVsEta = NULL;
-  xPointOfClosestApproach = NULL;
-  xPointOfClosestApproachVsZ0wrt000 = NULL;
-  xPointOfClosestApproachVsZ0wrtBS = NULL;
-  yPointOfClosestApproach = NULL;
-  yPointOfClosestApproachVsZ0wrt000 = NULL;
-  yPointOfClosestApproachVsZ0wrtBS = NULL;
-  zPointOfClosestApproach = NULL;
-  zPointOfClosestApproachVsPhi = NULL;
-  algorithm = NULL;
+  DistanceOfClosestApproach = nullptr;
+  DistanceOfClosestApproachToBS = nullptr;
+  DistanceOfClosestApproachVsTheta = nullptr;
+  DistanceOfClosestApproachVsPhi = nullptr;
+  DistanceOfClosestApproachToBSVsPhi = nullptr;
+  DistanceOfClosestApproachVsEta = nullptr;
+  xPointOfClosestApproach = nullptr;
+  xPointOfClosestApproachVsZ0wrt000 = nullptr;
+  xPointOfClosestApproachVsZ0wrtBS = nullptr;
+  yPointOfClosestApproach = nullptr;
+  yPointOfClosestApproachVsZ0wrt000 = nullptr;
+  yPointOfClosestApproachVsZ0wrtBS = nullptr;
+  zPointOfClosestApproach = nullptr;
+  zPointOfClosestApproachVsPhi = nullptr;
+  algorithm = nullptr;
+  oriAlgo = nullptr;
+
     // TESTING
-  TESTDistanceOfClosestApproachToBS = NULL;
-  TESTDistanceOfClosestApproachToBSVsPhi = NULL;
+  TESTDistanceOfClosestApproachToBS = nullptr;
+  TESTDistanceOfClosestApproachToBSVsPhi = nullptr;
 
 // by Mia in order to deal w/ LS transitions
-  Chi2oNDF_lumiFlag = NULL;
-  NumberOfRecHitsPerTrack_lumiFlag = NULL;
+  Chi2oNDF_lumiFlag = nullptr;
+  NumberOfRecHitsPerTrack_lumiFlag = nullptr;
 
   ////////////////////////////////////////////////////////////                                                                                                                                             
   //special Plots for HI DQM  //SHOULD I ADD THE BOOL HERE??                                                                                                                                               
   ////////////////////////////////////////////////////////////                                                                                                                                             
-  LongDCASig = NULL;
-  TransDCASig = NULL;
+  LongDCASig = nullptr;
+  TransDCASig = nullptr;
 
 
   // IP significance
-  sipDxyToBS = NULL;
-  sipDzToBS = NULL;
-  sip3dToPV = NULL;
-  sip2dToPV = NULL;
-  sipDxyToPV = NULL;
-  sipDzToPV = NULL;
+  sipDxyToBS = nullptr;
+  sipDzToBS = nullptr;
+  sip3dToPV = nullptr;
+  sip2dToPV = nullptr;
+  sipDxyToPV = nullptr;
+  sipDzToPV = nullptr;
 
 }
 
@@ -359,8 +361,15 @@ void TrackAnalyzer::bookHistosForHitProperties(DQMStore::IBooker & ibooker) {
       algorithm = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize));
       algorithm->setAxisTitle("Tracking algorithm",1);
       algorithm->setAxisTitle("Number of Tracks",2);
-      for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++)
+      histname = "originalAlgorithm_";
+      oriAlgo = ibooker.book1D(histname+CategoryName, histname+CategoryName, reco::TrackBase::algoSize, 0., double(reco::TrackBase::algoSize));
+      oriAlgo->setAxisTitle("Tracking algorithm",1);
+      oriAlgo->setAxisTitle("Number of Tracks",2);
+
+      for (size_t ibin=0; ibin<reco::TrackBase::algoSize-1; ibin++) {
 	algorithm->setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
+        oriAlgo->setBinLabel(ibin+1,reco::TrackBase::algoNames[ibin]);
+      }
     }
 
 }
@@ -702,6 +711,7 @@ void TrackAnalyzer::analyze(const edm::Event& iEvent, const edm::EventSetup& iSe
 
     // algorithm
     algorithm->Fill(static_cast<double>(track.algo()));
+    oriAlgo->Fill(static_cast<double>(track.originalAlgo()));
   }
 
   if ( doLumiAnalysis_ ) {

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -538,7 +538,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	
 	if ( numSelection_(*track) ) {
 	  numberOfTracks_num++;
-          if (pv0 && std::abs(track->dz(pv0->position()))<1.5) ++numberOfTracks_pv0;
+          if (pv0 && std::abs(track->dz(pv0->position()))<0.15) ++numberOfTracks_pv0;
         } 
 
 	if ( doProfilesVsLS_ || doAllPlots)
@@ -698,7 +698,7 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
 	    }
 	    
             NumberOfTracksVsGoodPVtx	   -> Fill( totalNumGoodPV, numberOfTracks	);
-	    if (totalNumGoodPV>1) NumberOfTracksVsGoodPVtx-> Fill( totalNumGoodPV-1, double(numberOfTracks-numberOfTracks_pv0)/double(totalNumGoodPV-1)      );
+	    if (totalNumGoodPV>1) NumberOfTracksVsPUPVtx-> Fill( totalNumGoodPV-1, double(numberOfTracks-numberOfTracks_pv0)/double(totalNumGoodPV-1)      );
 	  }
 
 	

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -104,15 +104,14 @@ TrackingMonitor::TrackingMonitor(const edm::ParameterSet& iConfig)
   Quality_  = conf_.getParameter<std::string>("Quality");
   AlgoName_ = conf_.getParameter<std::string>("AlgoName");
   
+  // get flag from the configuration
+  doPlotsVsBXlumi_   = conf_.getParameter<bool>("doPlotsVsBXlumi");   
+  if ( doPlotsVsBXlumi_ )
+      theLumiDetails_ = new GetLumi( iConfig.getParameter<edm::ParameterSet>("BXlumiSetup"), c );
+  doPlotsVsGoodPVtx_ = conf_.getParameter<bool>("doPlotsVsGoodPVtx");
+ 
 
   if ( doPUmonitoring_ ) {
-    
-    // get flag from the configuration
-    doPlotsVsBXlumi_   = conf_.getParameter<bool>("doPlotsVsBXlumi");
-    doPlotsVsGoodPVtx_ = conf_.getParameter<bool>("doPlotsVsGoodPVtx");
-    
-    if ( doPlotsVsBXlumi_ )
-      theLumiDetails_ = new GetLumi( iConfig.getParameter<edm::ParameterSet>("BXlumiSetup"), c );
     
     std::vector<edm::InputTag> primaryVertexInputTags    = conf_.getParameter<std::vector<edm::InputTag> >("primaryVertexInputTags");
     std::vector<edm::InputTag> selPrimaryVertexInputTags = conf_.getParameter<std::vector<edm::InputTag> >("selPrimaryVertexInputTags");

--- a/DQM/TrackingMonitor/src/TrackingMonitor.cc
+++ b/DQM/TrackingMonitor/src/TrackingMonitor.cc
@@ -515,12 +515,13 @@ void TrackingMonitor::analyze(const edm::Event& iEvent, const edm::EventSetup& i
     edm::Handle< reco::VertexCollection > pvHandle;
     iEvent.getByToken(pvSrcToken_, pvHandle );
     reco::Vertex const * pv0 = nullptr;  
-    if (pvHandle.isValid()) pv0 = &pvHandle->front();
-    //--- pv fake (the pv collection should have size==1 and the pv==beam spot)
-    if (   pv0->isFake() || pv0->tracksSize()==0
-    // definition of goodOfflinePrimaryVertex
-        || pv0->ndof() < 4. || pv0->z() > 24.)  pv0 = nullptr;
-
+    if (pvHandle.isValid()) {
+      pv0 = &pvHandle->front();
+      //--- pv fake (the pv collection should have size==1 and the pv==beam spot)
+      if (   pv0->isFake() || pv0->tracksSize()==0
+      // definition of goodOfflinePrimaryVertex
+          || pv0->ndof() < 4. || std::abs(pv0->z()) > 24.)  pv0 = nullptr;
+    }
 
 
     if (trackHandle.isValid()) {


### PR DESCRIPTION
add valid,lost,missing inner/outer hits 2d-histos to tracking dqm.
added Ntrack vs Nvtx as well

makes sense only if integrated in production before end of TS2

please refer to https://its.cern.ch/jira/browse/CMSTRACK-139
for more details
