### PR TITLE
migrate L1 and HLT summary modules to one::EDAnalyzer

### DIFF
--- a/HLTrigger/HLTanalyzers/interface/HLTrigReport.h
+++ b/HLTrigger/HLTanalyzers/interface/HLTrigReport.h
@@ -12,23 +12,22 @@
  *
  */
 
-#include "DataFormats/Common/interface/TriggerResults.h"
-
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
-#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
 #include "FWCore/Common/interface/TriggerNames.h"
-#include<vector>
-#include<string>
+#include "DataFormats/Common/interface/TriggerResults.h"
+#include "HLTrigger/HLTcore/interface/HLTConfigProvider.h"
+#include <vector>
+#include <string>
 
 //
 // class declaration
 //
 
-class HLTrigReport : public edm::EDAnalyzer {
+class HLTrigReport : public edm::one::EDAnalyzer<> {
    private:
       enum ReportEvery {
         NEVER       = 0,
@@ -104,10 +103,10 @@ class HLTrigReport : public edm::EDAnalyzer {
       unsigned int refIndex_;                                   // index of the reference path for rate calculation
       double refRate_;                                         // rate of the reference path, the rate of all other paths will be normalized to this
 
-      ReportEvery reportBy_;        // dump report for every never/event/lumi/run/job
-      ReportEvery resetBy_;         // reset counters  every never/event/lumi/run/job
-      ReportEvery serviceBy_;       // call to service every never/event/lumi/run/job
-      HLTConfigProvider hltConfig_; // to get configuration for L1s/Pre
+      const ReportEvery reportBy_;          // dump report for every never/event/lumi/run/job
+      const ReportEvery resetBy_;           // reset counters  every never/event/lumi/run/job
+      const ReportEvery serviceBy_;         // call to service every never/event/lumi/run/job
+      HLTConfigProvider hltConfig_;         // to get configuration for L1s/Pre
 };
 
 #endif //HLTrigReport_h

--- a/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
+++ b/HLTrigger/HLTanalyzers/src/HLTrigReport.cc
@@ -48,7 +48,8 @@ HLTrigReport::ReportEvery HLTrigReport::decode(const std::string & value) {
 // constructors and destructor
 //
 HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig) :
-  hlTriggerResults_ (iConfig.getParameter<edm::InputTag> ("HLTriggerResults")),
+  hlTriggerResults_(iConfig.getParameter<edm::InputTag> ("HLTriggerResults")),
+  hlTriggerResultsToken_(consumes<edm::TriggerResults>(hlTriggerResults_)),
   configured_(false),
   nEvents_(0),
   nWasRun_(0),
@@ -81,8 +82,6 @@ HLTrigReport::HLTrigReport(const edm::ParameterSet& iConfig) :
   serviceBy_(decode(iConfig.getUntrackedParameter<std::string>("serviceBy", "never")) ),
   hltConfig_()
 {
-  hlTriggerResultsToken_ = consumes<edm::TriggerResults>(hlTriggerResults_);
-
   const edm::ParameterSet customDatasets(iConfig.getUntrackedParameter<edm::ParameterSet>("CustomDatasets", edm::ParameterSet()));
   isCustomDatasets_ = (customDatasets != edm::ParameterSet());
   if (isCustomDatasets_) {

--- a/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReport.h
+++ b/L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReport.h
@@ -23,10 +23,9 @@
 
 // user include files
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDAnalyzer.h"
+#include "FWCore/Framework/interface/one/EDAnalyzer.h"
 
 #include "FWCore/Framework/interface/Event.h"
-#include "FWCore/Framework/interface/MakerMacros.h"
 
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 
@@ -43,7 +42,7 @@ class L1GtTriggerMenu;
 
 // class declaration
 
-class L1GtTrigReport : public edm::EDAnalyzer
+class L1GtTrigReport : public edm::one::EDAnalyzer<>
 {
 
 public:
@@ -119,19 +118,19 @@ private:
 private:
 
     /// boolean flag to select the input record
-    bool m_useL1GlobalTriggerRecord;
+    const bool m_useL1GlobalTriggerRecord;
 
     /// input tag for GT record (L1 GT DAQ record or L1 GT "lite" record):
-    edm::InputTag m_l1GtRecordInputTag;
+    const edm::InputTag m_l1GtRecordInputTag;
 
-    edm::EDGetTokenT<L1GlobalTriggerRecord> m_l1GtRecordInputToken1;
-    edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtRecordInputToken2;
+    const edm::EDGetTokenT<L1GlobalTriggerRecord> m_l1GtRecordInputToken1;
+    const edm::EDGetTokenT<L1GlobalTriggerReadoutRecord> m_l1GtRecordInputToken2;
 
     /// print verbosity
-    int m_printVerbosity;
+    const int m_printVerbosity;
 
     /// print output
-    int m_printOutput;
+    const int m_printOutput;
 
     /// counters
 
@@ -154,7 +153,7 @@ private:
     typedef std::list<L1GtTrigReportEntry*>::iterator ItEntry;
 
     /// index of physics DAQ partition
-    unsigned int m_physicsDaqPartition;
+    const unsigned int m_physicsDaqPartition;
 
 };
 

--- a/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
+++ b/L1Trigger/GlobalTriggerAnalyzer/src/L1GtTrigReport.cc
@@ -65,68 +65,68 @@
 #include "L1Trigger/GlobalTriggerAnalyzer/interface/L1GtTrigReportEntry.h"
 
 // constructor(s)
-L1GtTrigReport::L1GtTrigReport(const edm::ParameterSet& pSet) {
+L1GtTrigReport::L1GtTrigReport(const edm::ParameterSet& pSet) :
+
+    // initialize cached IDs
+
+    //
+    m_l1GtStableParCacheID( 0ULL ),
+
+    m_numberPhysTriggers( 0 ),
+    m_numberTechnicalTriggers( 0 ),
+    m_numberDaqPartitions( 0 ),
+    m_numberDaqPartitionsMax( 0 ),
+
+    //
+    m_l1GtPfAlgoCacheID( 0ULL ),
+    m_l1GtPfTechCacheID( 0ULL ),
+
+    m_l1GtTmAlgoCacheID( 0ULL ),
+    m_l1GtTmTechCacheID( 0ULL ),
+
+    m_l1GtTmVetoAlgoCacheID( 0ULL ),
+    m_l1GtTmVetoTechCacheID( 0ULL ),
+
+    //
+    m_l1GtMenuCacheID( 0ULL ),
 
     // boolean flag to select the input record
     // if true, it will use L1GlobalTriggerRecord
-    m_useL1GlobalTriggerRecord = pSet.getParameter<bool>("UseL1GlobalTriggerRecord");
+    m_useL1GlobalTriggerRecord( pSet.getParameter<bool>("UseL1GlobalTriggerRecord") ),
 
     /// input tag for GT record (L1 GT DAQ record or L1 GT "lite" record):
-    m_l1GtRecordInputTag = pSet.getParameter<edm::InputTag>("L1GtRecordInputTag");
+    m_l1GtRecordInputTag( pSet.getParameter<edm::InputTag>("L1GtRecordInputTag") ),
+    m_l1GtRecordInputToken1( m_useL1GlobalTriggerRecord
+        ? consumes<L1GlobalTriggerRecord>(m_l1GtRecordInputTag)
+        : edm::EDGetTokenT<L1GlobalTriggerRecord>() ),
+    m_l1GtRecordInputToken2( not m_useL1GlobalTriggerRecord
+        ? consumes<L1GlobalTriggerReadoutRecord>(m_l1GtRecordInputTag)
+        : edm::EDGetTokenT<L1GlobalTriggerReadoutRecord>() ),
 
     // print verbosity
-    m_printVerbosity = pSet.getUntrackedParameter<int>("PrintVerbosity", 2);
+    m_printVerbosity( pSet.getUntrackedParameter<int>("PrintVerbosity", 2) ),
 
     // print output
-    m_printOutput = pSet.getUntrackedParameter<int>("PrintOutput", 3);
+    m_printOutput( pSet.getUntrackedParameter<int>("PrintOutput", 3) ),
 
+    // initialize global counters
+
+    // number of events processed
+    m_totalEvents( 0 ),
+
+    //
+    m_entryList(),
+    m_entryListTechTrig(),
+
+    // set the index of physics DAQ partition TODO input parameter?
+    m_physicsDaqPartition( 0 )
+
+{
     LogDebug("L1GtTrigReport") << "\n  Use L1GlobalTriggerRecord:   " << m_useL1GlobalTriggerRecord
             << "\n   (if false: L1GtTrigReport uses L1GlobalTriggerReadoutRecord.)"
             << "\n  Input tag for L1 GT record:  " << m_l1GtRecordInputTag.label() << " \n"
             << "\n  Print verbosity level:           " << m_printVerbosity << " \n"
             << "\n  Print output:                    " << m_printOutput << " \n" << std::endl;
-
-    // initialize cached IDs
-
-    //
-    m_l1GtStableParCacheID = 0ULL;
-
-    m_numberPhysTriggers = 0;
-    m_numberTechnicalTriggers = 0;
-    m_numberDaqPartitions = 0;
-    m_numberDaqPartitionsMax = 0;
-
-    //
-    m_l1GtPfAlgoCacheID = 0ULL;
-    m_l1GtPfTechCacheID = 0ULL;
-
-    m_l1GtTmAlgoCacheID = 0ULL;
-    m_l1GtTmTechCacheID = 0ULL;
-
-    m_l1GtTmVetoAlgoCacheID = 0ULL;
-    m_l1GtTmVetoTechCacheID = 0ULL;
-
-    //
-    m_l1GtMenuCacheID = 0ULL;
-
-    // initialize global counters
-
-    // number of events processed
-    m_totalEvents = 0;
-
-    //
-    m_entryList.clear();
-    m_entryListTechTrig.clear();
-
-    // set the index of physics DAQ partition TODO input parameter?
-    m_physicsDaqPartition = 0;
-
-    if (m_useL1GlobalTriggerRecord) {
-      m_l1GtRecordInputToken1=consumes<L1GlobalTriggerRecord>(m_l1GtRecordInputTag);
-    }
-    else{
-      m_l1GtRecordInputToken2=consumes<L1GlobalTriggerReadoutRecord>(m_l1GtRecordInputTag);
-    }
 
 }
 


### PR DESCRIPTION
Migrate summary modules
- L1GtTrigReport
- HLTrigReport
  to one::EDAnalyzer. They could be migrated to global::EDAnalyzer, but since we do not run them online it's probably not worth it.
