### PR TITLE
74x Fireworks: auto-detect configuration after opening first file

### DIFF
--- a/Fireworks/Core/interface/FWGUIManager.h
+++ b/Fireworks/Core/interface/FWGUIManager.h
@@ -115,6 +115,7 @@ public:
    void addTo(FWConfiguration&) const;
    void setFrom(const FWConfiguration&);
    void setWindowInfoFrom(const FWConfiguration& iFrom, TGMainFrame* iFrame);
+   void initEmpty();
 
    TGVerticalFrame* createList(TGCompositeFrame *p);
    void createViews(TEveWindowSlot *slot);

--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -297,7 +297,7 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
    AutoLibraryLoader::enable();
 
    TEveManager::Create(kFALSE, eveMode ? "FIV" : "FI");
- 
+
    if(vm.count(kExpertCommandOpt)) 
    {
       m_context->setHidePFBuilders(false);
@@ -333,8 +333,6 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
    f=boost::bind(&CmsShowMainBase::setupViewManagers,this);
    startupTasks()->addTask(f);
 
-
-
    if(vm.count(kLiveCommandOpt))
    {
       f = boost::bind(&CmsShowMain::setLiveMode, this);
@@ -347,18 +345,16 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
       m_context->getField()->setUserField(vm[kFieldCommandOpt].as<double>());
    }
 
-   if ( m_inputFiles.empty()) {
-      f=boost::bind(&CmsShowMainBase::setupConfiguration,this);
-      startupTasks()->addTask(f);
-      f=boost::bind(&CmsShowMain::setupDataHandling,this);
-      startupTasks()->addTask(f);
+   if(vm.count(kExpertCommandOpt)) 
+   {
+      m_context->setHidePFBuilders(false);
    }
    else {
-      f=boost::bind(&CmsShowMain::setupDataHandling,this);
-      startupTasks()->addTask(f);
-      f=boost::bind(&CmsShowMainBase::setupConfiguration,this);
-      startupTasks()->addTask(f);
+      m_context->setHidePFBuilders(true);
    }
+
+   f=boost::bind(&CmsShowMain::setupDataHandling,this);
+   startupTasks()->addTask(f);
   
    if (vm.count(kLoopOpt))
       setPlayLoop();
@@ -525,7 +521,8 @@ void CmsShowMain::openData()
    guiManager()->updateStatus("loading file ...");
    if (fi.fFilename) {
       m_navigator->openFile(fi.fFilename);
-      m_loadedAnyInputFile = true;
+
+      setLoadedAnyInputFileAfterStartup();
       m_navigator->firstEvent();
       checkPosition();
       draw();
@@ -549,7 +546,7 @@ void CmsShowMain::appendData()
    guiManager()->updateStatus("loading file ...");
    if (fi.fFilename) {
       m_navigator->appendFile(fi.fFilename, false, false);
-      m_loadedAnyInputFile = true;
+      setLoadedAnyInputFileAfterStartup();
       checkPosition();
       draw();
       guiManager()->titleChanged(m_navigator->frameTitle());
@@ -571,7 +568,7 @@ CmsShowMain::openDataViaURL()
    if(!chosenFile.empty()) {
       guiManager()->updateStatus("loading file ...");
       if(m_navigator->openFile(chosenFile.c_str())) {
-         m_loadedAnyInputFile = true;
+         setLoadedAnyInputFileAfterStartup();
          m_navigator->firstEvent();
          checkPosition();
          draw();
@@ -660,7 +657,6 @@ CmsShowMain::setupDataHandling()
 {
    guiManager()->updateStatus("Setting up data handling...");
 
-
    // navigator filtering  ->
    m_navigator->fileChanged_.connect(boost::bind(&CmsShowMain::fileChangedSlot, this, _1));
    m_navigator->editFiltersExternally_.connect(boost::bind(&FWGUIManager::updateEventFilterEnable, guiManager(), _1));
@@ -695,8 +691,7 @@ CmsShowMain::setupDataHandling()
       }
       else
       {
-         m_loadedAnyInputFile = true;
-
+         m_loadedAnyInputFile = true; 
       }
    }
 
@@ -705,15 +700,35 @@ CmsShowMain::setupDataHandling()
       m_navigator->firstEvent();
       checkPosition();
       draw();
+      setupConfiguration();
    }
-   else if (m_monitor.get() == 0 && (configurationManager()->getIgnore() == false) )
-   {
-      if (m_inputFiles.empty())
-         openDataViaURL();
-      else
-         openData();
+   else {
+      if (configFilename()[0] == '\0') {
+         guiManager()->initEmpty();
+      }
+      else {
+         setupConfiguration();
+      }
+
+      if (m_monitor.get() == 0 && (configurationManager()->getIgnore() == false)) {
+         if (m_inputFiles.empty())
+            openDataViaURL();
+         else
+            openData();
+      }
    }
 }
+
+void
+CmsShowMain::setLoadedAnyInputFileAfterStartup()
+{
+   if (m_loadedAnyInputFile == false) {
+      m_loadedAnyInputFile = true;
+      if ((configFilename()[0] == '\0') && (configurationManager()->getIgnore() == false))
+         setupConfiguration();
+   }
+}
+
 
 void
 CmsShowMain::setupSocket(unsigned int iSocket)

--- a/Fireworks/Core/src/CmsShowMain.cc
+++ b/Fireworks/Core/src/CmsShowMain.cc
@@ -345,14 +345,6 @@ CmsShowMain::CmsShowMain(int argc, char *argv[])
       m_context->getField()->setUserField(vm[kFieldCommandOpt].as<double>());
    }
 
-   if(vm.count(kExpertCommandOpt)) 
-   {
-      m_context->setHidePFBuilders(false);
-   }
-   else {
-      m_context->setHidePFBuilders(true);
-   }
-
    f=boost::bind(&CmsShowMain::setupDataHandling,this);
    startupTasks()->addTask(f);
   

--- a/Fireworks/Core/src/CmsShowMain.h
+++ b/Fireworks/Core/src/CmsShowMain.h
@@ -93,6 +93,7 @@ private:
    void setupDataHandling();
    void setupSocket(unsigned int);
    void connectSocket();
+   void setLoadedAnyInputFileAfterStartup();
 
    virtual void autoLoadNewEvent();
    virtual void checkPosition();

--- a/Fireworks/Core/src/CmsShowMainBase.cc
+++ b/Fireworks/Core/src/CmsShowMainBase.cc
@@ -375,57 +375,39 @@ CmsShowMainBase::setupConfiguration()
 {
    m_guiManager->updateStatus("Setting up configuration...");
 
-   if(m_configurationManager->getIgnore()) {
-      fwLog(fwlog::kInfo) << "no configuration is loaded." << std::endl;
-      m_configFileName = "newconfig.fwc";
-   }
-   else {
-       try
-       { 
-           gEve->DisableRedraw();
-           if (m_configFileName.empty())
-           {
-               m_configFileName = m_configurationManager->guessAndReadFromFile(m_metadataManagerPtr);
-           }
-           else
-           {
-               char* whereConfig = gSystem->Which(TROOT::GetMacroPath(), m_configFileName.c_str(), kReadPermission);
-               m_configFileName = whereConfig;
-               delete [] whereConfig;
-               m_configurationManager->readFromFile(m_configFileName);
-           }
-           gEve->EnableRedraw();
-       }
-      catch (SimpleSAXParser::ParserError &e)
+   try
+   { 
+      gEve->DisableRedraw();
+      if (m_configFileName.empty())
       {
-         fwLog(fwlog::kError) <<"Unable to load configuration file '" 
-                              << m_configFileName 
-                              << "': " 
-                              << e.error()
-                              << std::endl;
-         exit(1);
+         m_configFileName = m_configurationManager->guessAndReadFromFile(m_metadataManagerPtr);
       }
-      catch (std::runtime_error &e)
+      else
       {
-         fwLog(fwlog::kError) <<"Unable to load configuration file '" 
-                              << m_configFileName 
-                              << "' which was specified on command line. Quitting." 
-                              << std::endl;
-         exit(1);
+         char* whereConfig = gSystem->Which(TROOT::GetMacroPath(), m_configFileName.c_str(), kReadPermission);
+         m_configFileName = whereConfig;
+         delete [] whereConfig;
+         m_configurationManager->readFromFile(m_configFileName);
       }
-
-       
+      gEve->EnableRedraw();
    }
-
-   // case configuration does not contain GUI Manager entry
-   if ( !m_guiManager->getMainFrame()->IsMapped()) {
-
-       m_guiManager->getMainFrame()->MapSubwindows();
-       m_guiManager->getMainFrame()->Layout();
-       m_guiManager->getMainFrame()->MapRaised();
-       m_guiManager->createView("Rho Phi"); 
-       m_guiManager->createView("Rho Z"); 
+   catch (SimpleSAXParser::ParserError &e)
+   {
+      fwLog(fwlog::kError) <<"Unable to load configuration file '" 
+                           << m_configFileName 
+                           << "': " 
+                           << e.error()
+                           << std::endl;
+      exit(1);
    }
+   catch (std::runtime_error &e)
+   {
+      fwLog(fwlog::kError) <<"Unable to load configuration file '" 
+                           << m_configFileName 
+                           << "' which was specified on command line. Quitting." 
+                           << std::endl;
+      exit(1);
+   }       
 }
 
 

--- a/Fireworks/Core/src/FWGUIManager.cc
+++ b/Fireworks/Core/src/FWGUIManager.cc
@@ -135,21 +135,11 @@ FWGUIManager::FWGUIManager(fireworks::Context* ctx,
    TEveCompositeFrame::SetupFrameMarkup(foo, 20, 4, false);
 
    {
-      //NOTE: by making sure we defaultly open to a fraction of the full screen size we avoid
-      // causing the program to go into full screen mode under default SL4 window manager
-      UInt_t width = gClient->GetDisplayWidth();
-      UInt_t height = static_cast<UInt_t>(gClient->GetDisplayHeight()*.8);
-      //try to deal with multiple horizontally placed monitors.  Since present monitors usually
-      // have less than 2000 pixels horizontally, when we see more it is a good indicator that
-      // we are dealing with more than one monitor.
-      while(width > 2000) {
-         width /= 2;
-      }
-      width = static_cast<UInt_t>(width*.8);
       m_cmsShowMainFrame = new CmsShowMainFrame(gClient->GetRoot(),
-                                                width,
-                                                height,
+                                                950,
+                                                750,
                                                 this);
+     
       m_cmsShowMainFrame->SetCleanup(kDeepCleanup);
     
       /*
@@ -1537,4 +1527,20 @@ void
 FWGUIManager::resetWMOffsets()
 {
    m_WMOffsetX = m_WMOffsetY = m_WMDecorH = 0;
+}
+
+void
+FWGUIManager::initEmpty()
+{   
+   int x = 150 + m_WMOffsetX ;
+   int y = 50 +  m_WMOffsetY;
+   m_cmsShowMainFrame->Move(x, y);
+   m_cmsShowMainFrame->SetWMPosition(x, y < m_WMDecorH ? m_WMDecorH : y);
+  
+   createView("Rho Phi"); 
+   createView("Rho Z"); 
+
+   m_cmsShowMainFrame->MapSubwindows();
+   m_cmsShowMainFrame->Layout();
+   m_cmsShowMainFrame->MapRaised();
 }


### PR DESCRIPTION
Change behaviour when there is no data input file and no configuration specified command line. In this case the configuration file was set of aod.fwc.
Now, Fireworks is started with an empty configuration (no collections and only RhoZ and RhoPhi views). If user selects file after that, the configuration will be loaded based on that file.
