### PR TITLE
ngrenz: small optimization of Monitor Track inside the DQM

### DIFF
--- a/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
+++ b/DQM/SiStripMonitorTrack/interface/SiStripMonitorTrack.h
@@ -106,8 +106,8 @@ private:
   template <class T> void RecHitInfo(const T* tkrecHit, LocalVector LV, const edm::EventSetup&);
 
   // fill monitorables 
-  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, const uint32_t detid, const LocalVector LV);
-  void fillMEs(SiStripClusterInfo*,const uint32_t detid, float,enum ClusterFlags,  const LocalVector LV, const Det2MEs& MEs);
+//  void fillModMEs(SiStripClusterInfo* cluster,std::string name, float cos, const uint32_t detid, const LocalVector LV);
+//  void fillMEs(SiStripClusterInfo*,const uint32_t detid, float,enum ClusterFlags,  const LocalVector LV, const Det2MEs& MEs);
 
   inline void fillME(MonitorElement* ME,float value1){if (ME!=0)ME->Fill(value1);}
   inline void fillME(MonitorElement* ME,float value1,float value2){if (ME!=0)ME->Fill(value1,value2);}

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
@@ -963,7 +963,7 @@ void SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const Tra
           if (v_Edge_G[i].phi() > 0. ){
             if (v_Edge_G[i].eta() < clustgp.eta()){
               bot_left_G = v_Edge_G[i];
-            } else if (v_Edge_G[i].eta() > clustgp.eta()){
+            } else if (v_Edge_G[i].eta() != clustgp.eta()){
               bot_rightG = v_Edge_G[i];
             }
           } else if (v_Edge_G[i].phi() != 0. ){

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorMuonHLT.cc
@@ -78,7 +78,7 @@ SiStripMonitorMuonHLT::~SiStripMonitorMuonHLT ()
 
 float SiStripMonitorMuonHLT::GetEtaWeight(std::string label, GlobalPoint clustgp){
         float etaWeight = 1.;
-	for (unsigned int i = 0; i < m_BinEta[label].size() - 1; i++){                      
+	for (unsigned int i = 0, end = m_BinEta[label].size() - 1; i < end; ++i){                      
         	if (m_BinEta[label][i] < clustgp.eta() && clustgp.eta() < m_BinEta[label][i+1]){
                 	if (m_ModNormEta[label][i] > 0.1) etaWeight = 1./m_ModNormEta[label][i];
                 	else etaWeight = 1.;
@@ -89,7 +89,7 @@ float SiStripMonitorMuonHLT::GetEtaWeight(std::string label, GlobalPoint clustgp
 
 float SiStripMonitorMuonHLT::GetPhiWeight(std::string label, GlobalPoint clustgp){
         float phiWeight = 1.;
-	for (unsigned int i = 0; i < m_BinPhi[label].size() - 1; i++){                      
+	for (unsigned int i = 0, end = m_BinPhi[label].size() - 1; i < end; ++i){                      
         	if (m_BinPhi[label][i] < clustgp.phi() && clustgp.phi() < m_BinPhi[label][i+1]){
                 	if (m_ModNormPhi[label][i] > 0.1) phiWeight = 1./m_ModNormPhi[label][i];
                 	else phiWeight = 1.;
@@ -120,25 +120,25 @@ SiStripMonitorMuonHLT::analyze (const edm::Event & iEvent, const edm::EventSetup
   edm::Handle < reco::RecoChargedCandidateCollection > l3mucands;
   bool accessToL3Muons = true;
   iEvent.getByToken (l3collectionToken_, l3mucands);
-  reco::RecoChargedCandidateCollection::const_iterator cand;
+  reco::RecoChargedCandidateCollection::const_iterator cand, candEnd;
 
   //Access to clusters
   edm::Handle < edm::LazyGetter < SiStripCluster > >clusters;
   bool accessToClusters = true;
   iEvent.getByToken (clusterCollectionToken_, clusters);
-  edm::LazyGetter < SiStripCluster >::record_iterator clust;
+  edm::LazyGetter < SiStripCluster >::record_iterator clust, clustEnd;
  
   //Access to Tracks
   edm::Handle<reco::TrackCollection > trackCollection;
   bool accessToTracks = true;
   iEvent.getByToken (TrackCollectionToken_, trackCollection);
-  reco::TrackCollection::const_iterator track;
+  reco::TrackCollection::const_iterator track, trackEnd;
    /////////////////////////////////////////////////////
 
 
   if (runOnClusters_ && accessToClusters && !clusters.failedToGet () && clusters.isValid())
     {
-      for (clust = clusters->begin_record (); clust != clusters->end_record (); ++clust)
+      for (clust = clusters->begin_record (), clustEnd = clusters->end_record (); clust != clustEnd; ++clust)
 	{
 	  
 	  uint detID = 0; // zero since long time clust->geographicalId ();
@@ -167,7 +167,7 @@ SiStripMonitorMuonHLT::analyze (const edm::Event & iEvent, const edm::EventSetup
 
   if (runOnMuonCandidates_ && accessToL3Muons && !l3mucands.failedToGet () && l3mucands.isValid())
     {
-      for (cand = l3mucands->begin (); cand != l3mucands->end (); ++cand)
+      for (cand = l3mucands->begin (), candEnd = l3mucands->end (); cand != candEnd; ++cand)
 	{
 	  //TrackRef l3tk = cand->get < TrackRef > ();
 	  const reco::Track* l3tk = cand->get < reco::TrackRef > ().get();
@@ -176,7 +176,7 @@ SiStripMonitorMuonHLT::analyze (const edm::Event & iEvent, const edm::EventSetup
     }				//if l3seed
  
   if (runOnTracks_ && accessToTracks && !trackCollection.failedToGet() && trackCollection.isValid()){
-	for (track = trackCollection->begin (); track != trackCollection->end() ; ++ track)
+	for (track = trackCollection->begin (), trackEnd = trackCollection->end(); track != trackEnd; ++track)
 	  {
 	    const reco::Track* tk =  &(*track);
 	    analyzeOnTrackClusters(tk, theTracker, false);	
@@ -187,7 +187,7 @@ SiStripMonitorMuonHLT::analyze (const edm::Event & iEvent, const edm::EventSetup
 
 void SiStripMonitorMuonHLT::analyzeOnTrackClusters( const reco::Track* l3tk, const TrackerGeometry & theTracker,  bool isL3MuTrack ){
 
-	  for (size_t hit = 0; hit < l3tk->recHitsSize (); hit++)
+	  for (size_t hit = 0, end = l3tk->recHitsSize (); hit < end; ++hit)
 	    {
 	      //if hit is valid and in tracker say true
 	      if (l3tk->recHit (hit)->isValid () == true && l3tk->recHit (hit)->geographicalId ().det () == DetId::Tracker)
@@ -474,7 +474,8 @@ SiStripMonitorMuonHLT::createMEs (DQMStore::IBooker & ibooker , const edm::Event
       float * xbinsEta = new float[100];
 
       //TEC && TID && TOB && TIB
-      if (labelHisto_ID == "TEC" || labelHisto_ID == "TID" || labelHisto_ID == "TOB" || labelHisto_ID == "TIB"){
+       std::string tob = "TOB", tib = "TIB", tec = "TEC", tid = "TID";
+       if (labelHisto_ID == tec || labelHisto_ID == tid || labelHisto_ID == tob || labelHisto_ID == tib){
 
         // PHI BINNING
         //ADDING BORDERS
@@ -505,9 +506,9 @@ SiStripMonitorMuonHLT::createMEs (DQMStore::IBooker & ibooker , const edm::Event
         sort(v_BinEta_Prel.begin(),v_BinEta_Prel.end());
 
         //RECOMPUTE THE BINS BY TAKING THE HALF OF THE DISTANCE
-        for (unsigned int i = 0; i < v_BinEta_Prel.size(); i++){
-          if (i == 0) m_BinEta[labelHisto].push_back(v_BinEta_Prel[i] - 0.15);
-          if (i != 0) {
+        for (unsigned int i = 0, end = v_BinEta_Prel.size(); i < end; i++){
+          if (i == 0) { m_BinEta[labelHisto].push_back(v_BinEta_Prel[i] - 0.15);
+          } else {
             float shift = v_BinEta_Prel[i] - v_BinEta_Prel[i-1];
             m_BinEta[labelHisto].push_back(v_BinEta_Prel[i] - shift/2.);
           }
@@ -603,7 +604,7 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
 
   //Loop over DetIds
   //-----------------------------------------
-  for(std::vector<DetId>::const_iterator detid_iterator =  Dets.begin(); detid_iterator!=Dets.end(); ++detid_iterator){
+  for(std::vector<DetId>::const_iterator detid_iterator = Dets.begin(), end = Dets.end(); detid_iterator!=end; ++detid_iterator){
     uint32_t detid = (*detid_iterator)();
 
     if ( (*detid_iterator).null() == true) break;
@@ -659,17 +660,17 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
       }
 
       //TEC
-      if (detector == GeomDetEnumerators::TEC ){
-
-        
+      if (detector == GeomDetEnumerators::TEC ){ 
 
         //PHI BINNING
         //Select 7th ring
         if (tTopo->tecRing(detid) == 7){
-          //SELECT FP
-          if (tTopo->tecModule(detid) == 1 && tTopo->tecIsFrontPetal(detid) == true) m_BinPhi[mylabelHisto].push_back(clustgp.phi());
-          //SELECT BP
-          if (tTopo->tecModule(detid) == 1 && tTopo->tecIsBackPetal(detid) == true) m_BinPhi[mylabelHisto].push_back(clustgp.phi());
+          if (tTopo->tecModule(detid) == 1) { 
+            //SELECT FP
+            if (tTopo->tecIsFrontPetal(detid) == true) m_BinPhi[mylabelHisto].push_back(clustgp.phi());
+            //SELECT BP
+            if (tTopo->tecIsBackPetal(detid) == true) m_BinPhi[mylabelHisto].push_back(clustgp.phi());
+          }
         }
 
         //ETA BINNING
@@ -682,17 +683,17 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
       } //END TEC
 
       //TID
-      if (detector == GeomDetEnumerators::TID ){
-
-        
+      else if (detector == GeomDetEnumerators::TID ){
 
         //PHI BINNING
         //Select 1st ring
         if (tTopo->tecRing(detid) == 1){
-          //SELECT MONO
-          if (tTopo->tecIsFrontPetal(detid) == true && tTopo->tecIsStereo(detid) == false) m_BinPhi[mylabelHisto].push_back(clustgp.phi());
-          //SELECT STEREO
-          if (tTopo->tecIsFrontPetal(detid) == true && tTopo->tecIsStereo(detid) == true) m_BinPhi[mylabelHisto].push_back(clustgp.phi());
+	  if (tTopo->tecIsFrontPetal(detid) == true) {
+            //SELECT MONO
+            if (tTopo->tecIsStereo(detid) == false) m_BinPhi[mylabelHisto].push_back(clustgp.phi());
+            //SELECT STEREO
+            else m_BinPhi[mylabelHisto].push_back(clustgp.phi());
+          }
         }
 
         //ETA BINNING
@@ -705,8 +706,7 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
       } //END TID
 
       //TOB
-      if (detector == GeomDetEnumerators::TOB ){
-
+      else if (detector == GeomDetEnumerators::TOB ){
         
         //PHI BINNING
         //Select arbitrary line in phi (detid)ta fixed)
@@ -723,8 +723,7 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
           if (tTopo->tobIsZMinusSide(detid) == true){
             m_PhiStripMod_Eta[mylabelHisto][tTopo->tobModule(detid)-1] = m_PhiStripMod_Eta[mylabelHisto][tTopo->tobModule(detid)-1] + clustgp.eta();
             m_PhiStripMod_Nb[mylabelHisto][tTopo->tobModule(detid)-1]++;
-          }
-          if (tTopo->tobIsZMinusSide(detid) == false){
+          } else {
             m_PhiStripMod_Eta[mylabelHisto][tTopo->tobModule(detid)+5] = m_PhiStripMod_Eta[mylabelHisto][tTopo->tobModule(detid)+5] + clustgp.eta();
             m_PhiStripMod_Nb[mylabelHisto][tTopo->tobModule(detid)+5]++;
           }
@@ -733,9 +732,7 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
       } //END TOB
 
       //TIB
-      if (detector == GeomDetEnumerators::TIB ){
-
-        
+      else if (detector == GeomDetEnumerators::TIB ){
 
         //PHI BINNING
         //Select arbitrary line in phi (eta fixed)
@@ -753,18 +750,15 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
             if (tTopo->tibIsInternalString(detid) == true){
               m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)-1] = m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)-1] + clustgp.eta();
               m_PhiStripMod_Nb[mylabelHisto][tTopo->tibModule(detid)-1]++;
-            }
-            if (tTopo->tibIsInternalString(detid) == false){
+            } else {
               m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)+2] = m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)+2] + clustgp.eta();
               m_PhiStripMod_Nb[mylabelHisto][tTopo->tibModule(detid)+2]++;
             }
-          }
-          if (tTopo->tibIsZMinusSide(detid) == false){
+          } else {
             if (tTopo->tibIsInternalString(detid) == true){
               m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)+5] = m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)+5] + clustgp.eta();
               m_PhiStripMod_Nb[mylabelHisto][tTopo->tibModule(detid)+5]++;
-            }
-            if (tTopo->tibIsInternalString(detid) == false){
+            } else {
               m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)+8] = m_PhiStripMod_Eta[mylabelHisto][tTopo->tibModule(detid)+8] + clustgp.eta();
               m_PhiStripMod_Nb[mylabelHisto][tTopo->tibModule(detid)+8]++;
             }
@@ -780,15 +774,14 @@ SiStripMonitorMuonHLT::GeometryFromTrackGeom (const std::vector<DetId>& Dets,con
 
 
 
-void
-SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerGeometry & theTracker){
+void SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerGeometry & theTracker){
   
   
   std::vector<std::string> v_LabelHisto;
 
   //Loop over DetIds
   //-----------------------------------------
-  for(std::vector<DetId>::const_iterator detid_iterator =  Dets.begin(); detid_iterator!=Dets.end(); detid_iterator++){
+  for(std::vector<DetId>::const_iterator detid_iterator =  Dets.begin(), end = Dets.end(); detid_iterator!=end; ++detid_iterator){
     uint32_t detid = (*detid_iterator)();
     
     if ( (*detid_iterator).null() == true) break;
@@ -833,12 +826,12 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
 
         //INITIALIZE    
         // LOOPING ON ETA VECTOR
-        for (unsigned int i = 0; i < m_BinEta[mylabelHisto].size() -1; i++){
+        for (unsigned int i = 0, end = m_BinEta[mylabelHisto].size() -1; i < end; ++i){
           m_ModNormEta[mylabelHisto].push_back(0.);
         }
 
         // LOOPING ON PHI VECTOR
-        for (unsigned int i = 0; i < m_BinPhi[mylabelHisto].size() -1; i++){
+        for (unsigned int i = 0, end = m_BinPhi[mylabelHisto].size() -1; i < end; i++){
           m_ModNormPhi[mylabelHisto].push_back(0.);
         }
       }
@@ -871,7 +864,8 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
       float factor = 1.;
       
       //RECTANGULAR BOUNDS
-      if (labelHisto_ID == "TOB" || labelHisto_ID == "TIB"){
+      std::string tob = "TOB", tib = "TIB", tec = "TEC", tid = "TID";
+      if (labelHisto_ID == tob || labelHisto_ID == tib){
         const RectangularPlaneBounds *rectangularBound = dynamic_cast < const RectangularPlaneBounds * >(& bound);                                                  
         length = rectangularBound->length();
         width = rectangularBound->width();                                                                                                                        
@@ -879,14 +873,16 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
             
         //EDGES POINTS
         LocalPoint topleft(-width/2., length/2.);
-        LocalPoint topright(width/2., length/2.);                                                                                                                   LocalPoint botleft(-width/2., -length/2.);
+        LocalPoint topright(width/2., length/2.);
+        LocalPoint botleft(-width/2., -length/2.);
         LocalPoint botright(width/2., -length/2.);                                                                                                                                  
         v_Edge_G.push_back(theGeomDet->surface ().toGlobal (topleft));
         v_Edge_G.push_back(theGeomDet->surface ().toGlobal (topright));
-        v_Edge_G.push_back(theGeomDet->surface ().toGlobal (botleft));                                                                                              v_Edge_G.push_back(theGeomDet->surface ().toGlobal (botright));
+        v_Edge_G.push_back(theGeomDet->surface ().toGlobal (botleft));
+        v_Edge_G.push_back(theGeomDet->surface ().toGlobal (botright));
       }                                                                                                                                                            
       //TRAPEZOIDAL BOUNDS
-      if (labelHisto_ID == "TEC" || labelHisto_ID == "TID"){    
+      else if (labelHisto_ID == tec || labelHisto_ID == tid){    
         const TrapezoidalPlaneBounds *trapezoidalBound = dynamic_cast < const TrapezoidalPlaneBounds * >(& bound);
 
         length = trapezoidalBound->length();
@@ -918,23 +914,20 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
       v_Fill.push_back(false);
       v_Fill.push_back(false);
 
-      for (unsigned int i =0 ; i< v_Edge_G.size() ; i++){
+      for (unsigned int i =0, end = v_Edge_G.size(); i < end ; i++){
         if (v_Edge_G[i].eta() < clustgp.eta()){
           if (v_Edge_G[i].phi() < clustgp.phi()) {
             bot_left_G = v_Edge_G[i];
             v_Fill[0] = true;
-          }
-          if (v_Edge_G[i].phi() > clustgp.phi()){
+          } else if (v_Edge_G[i].phi() != clustgp.phi()){
             top_left_G = v_Edge_G[i];
             v_Fill[1] = true;
           }
-        }
-        if (v_Edge_G[i].eta() > clustgp.eta()){
+        } else if (v_Edge_G[i].eta() != clustgp.eta()){
           if (v_Edge_G[i].phi() < clustgp.phi()){
             bot_rightG = v_Edge_G[i];
             v_Fill[2] = true;
-          }
-          if (v_Edge_G[i].phi() > clustgp.phi()){
+          } else if (v_Edge_G[i].phi() != clustgp.phi()){
             top_rightG = v_Edge_G[i];
             v_Fill[3] = true;
           }
@@ -959,28 +952,24 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
         //WIDTH BETWEEN BL AND TL
         G_width = sqrt( (bot_left_G.x()-top_left_G.x())*(bot_left_G.x()-top_left_G.x()) + (bot_left_G.y()-top_left_G.y())*(bot_left_G.y()-top_left_G.y()) + (bot_left_G.z()-top_left_G.z())*(bot_left_G.z()-top_left_G.z()) );
 
-      }
-      else {
+      } else {
 
         // MODULE IN THE PHI BORDER (-PI,PI)
         flag_border = true;
 
         //SORT THE EDGES POINTS 
-        for (unsigned int i =0 ; i< v_Edge_G.size() ; i++){
+        for (unsigned int i =0, end = v_Edge_G.size(); i < end; ++i){
 
           if (v_Edge_G[i].phi() > 0. ){
             if (v_Edge_G[i].eta() < clustgp.eta()){
               bot_left_G = v_Edge_G[i];
-            }
-            if (v_Edge_G[i].eta() > clustgp.eta()){
+            } else if (v_Edge_G[i].eta() > clustgp.eta()){
               bot_rightG = v_Edge_G[i];
             }
-          }
-          if (v_Edge_G[i].phi() < 0. ){
+          } else if (v_Edge_G[i].phi() != 0. ){
             if (v_Edge_G[i].eta() < clustgp.eta()){
               top_left_G = v_Edge_G[i];
-            }
-            if (v_Edge_G[i].eta() > clustgp.eta()){
+            } else if (v_Edge_G[i].eta() != clustgp.eta()){
               top_rightG = v_Edge_G[i];
             }
           }
@@ -994,7 +983,7 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
 
       //ETA PLOTS
       //unsigned int LastBinEta = m_BinEta[mylabelHisto].size() - 2;
-      for (unsigned int i = 0; i < m_BinEta[mylabelHisto].size() - 1; i++){
+      for (unsigned int i = 0, end = m_BinEta[mylabelHisto].size() - 1; i < end; ++i){
         if (m_BinEta[mylabelHisto][i] <= clustgp.eta() && clustgp.eta() < m_BinEta[mylabelHisto][i+1]){
 
           // NO NEED TO DO CORRECTIONS FOR ETA
@@ -1005,7 +994,7 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
 
       //PHI PLOTS
       unsigned int LastBinPhi = m_BinPhi[mylabelHisto].size() - 2;
-      for (unsigned int i = 0; i < m_BinPhi[mylabelHisto].size() - 1; i++){
+      for (unsigned int i = 0, end = m_BinPhi[mylabelHisto].size() - 1; i < end; ++i){
         if (m_BinPhi[mylabelHisto][i] <= clustgp.phi() && clustgp.phi() < m_BinPhi[mylabelHisto][i+1]){
 
           // SCRIPT TO INTEGRATE THE SURFACE INTO PHI BIN
@@ -1055,9 +1044,7 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
             MidPoint_X_prev = (xStar1 + xStar2)/2.;
             MidPoint_Y_prev = (yStar1 + yStar2)/2.;
             MidPoint_Z_prev = (zStar1 + zStar2)/2.;
-          }
-
-          if (offlimit_prev == false){
+          } else {
             MidPoint_X_prev = (bot_left_G.x() + bot_rightG.x())/2.;
             MidPoint_Y_prev = (bot_left_G.y() + bot_rightG.y())/2.;
             MidPoint_Z_prev = (bot_left_G.z() + bot_rightG.z())/2.;
@@ -1089,9 +1076,7 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
             MidPoint_X_foll = (xStar1 + xStar2)/2.;
             MidPoint_Y_foll = (yStar1 + yStar2)/2.;
             MidPoint_Z_foll = (zStar1 + zStar2)/2.;
-          }
-
-          if (offlimit_foll == false){
+          } else {
             MidPoint_X_foll = (top_left_G.x() + top_rightG.x())/2.;
             MidPoint_Y_foll = (top_left_G.y() + top_rightG.y())/2.;
             MidPoint_Z_foll = (top_left_G.z() + top_rightG.z())/2.;
@@ -1117,10 +1102,10 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
             }
 
             // B) MODULE SPLITTED IN TWO
-            if (i == 0 || i == LastBinPhi){
+            else {
               float PhiBalance = 0.;
               if (clustgp.phi() > 0.) PhiBalance = clustgp.phi() - M_PI ;
-              if (clustgp.phi() < 0.) PhiBalance = clustgp.phi() + M_PI ;
+              else if (clustgp.phi() != 0.) PhiBalance = clustgp.phi() + M_PI ;
 
               // Average Phi width of a phi bin
               float Phi_Width = m_BinPhi[mylabelHisto][3] - m_BinPhi[mylabelHisto][2];
@@ -1131,18 +1116,14 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
               m_ModNormPhi[mylabelHisto][0] = m_ModNormPhi[mylabelHisto][0] + weight_FirstBin*(factor*G_length*G_width);
               m_ModNormPhi[mylabelHisto][LastBinPhi] = m_ModNormPhi[mylabelHisto][LastBinPhi] + weight_LastBin*(factor*G_length*G_width);
             }
-          }
-
-          if (flag_border == false){
-
+          } else {
             // A) SURFACE TOTALY CONTAINED IN THE BIN
             if (offlimit_prev == false && offlimit_foll == false){
               m_ModNormPhi[mylabelHisto][i] = m_ModNormPhi[mylabelHisto][i] + factor*G_length*G_width;
             }
 
             // B) SURFACE CONTAINED IN 2 BINS
-            if ((offlimit_prev == true && offlimit_foll == false)
-                ||(offlimit_prev == false && offlimit_foll == true) ){
+            else if (offlimit_prev != offlimit_foll) {
               float G_width_Out = fabs(G_width - G_width_Ins);
 
               //FILL INSIDE CELL            
@@ -1154,7 +1135,7 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
             }
 
             // C) SURFACE CONTAINED IN 3 BINS
-            if (offlimit_prev == true && offlimit_foll == true){
+            else {
 
               //COMPUTE OFF LIMITS LENGTHS
               float G_width_T =  sqrt( (MidPoint_X_foll-EdgePoint_X_T)*(MidPoint_X_foll-EdgePoint_X_T) + (MidPoint_Y_foll-EdgePoint_Y_T)*(MidPoint_Y_foll-EdgePoint_Y_T) + (MidPoint_Z_foll-EdgePoint_Z_T)*(MidPoint_Z_foll-EdgePoint_Z_T) );
@@ -1191,13 +1172,12 @@ SiStripMonitorMuonHLT::Normalizer (const std::vector<DetId>& Dets,const TrackerG
 
 
 
-void
-SiStripMonitorMuonHLT::PrintNormalization (const std::vector<std::string>& v_LabelHisto)
+void SiStripMonitorMuonHLT::PrintNormalization (const std::vector<std::string>& v_LabelHisto)
 {
   std::vector <TH1F *> h_ModNorm_Eta;
   std::vector <TH1F *> h_ModNorm_Phi;
 
-  for (unsigned int p = 0; p < v_LabelHisto.size(); p++){
+  for (unsigned int p = 0, end = v_LabelHisto.size(); p < end; ++p){
    
     std::string titleHistoEta = v_LabelHisto[p] + "_eta" ;    
     std::string titleHistoPhi = v_LabelHisto[p] + "_phi" ;  
@@ -1221,10 +1201,10 @@ SiStripMonitorMuonHLT::PrintNormalization (const std::vector<std::string>& v_Lab
     h_ModNorm_Eta.push_back(new TH1F (titleHistoEta.c_str(),titleHistoEta.c_str(),sizeEta - 1,xbinsEta));
     h_ModNorm_Phi.push_back(new TH1F (titleHistoPhi.c_str(),titleHistoPhi.c_str(),sizePhi - 1,xbinsPhi));
     
-    for (unsigned int i = 0; i < m_ModNormEta[labelHisto].size(); i++){
+    for (unsigned int i = 0, end = m_ModNormEta[labelHisto].size(); i < end; ++i){
       (*h_ModNorm_Eta[p]).SetBinContent(i+1,m_ModNormEta[labelHisto][i]);
     }
-    for (unsigned int i = 0; i < m_ModNormPhi[labelHisto].size(); i++){
+    for (unsigned int i = 0, end = m_ModNormPhi[labelHisto].size(); i < end; ++i){
       (*h_ModNorm_Phi[p]).SetBinContent(i+1,m_ModNormPhi[labelHisto][i]);
     }
 

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -842,19 +842,17 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
       hitStudy(es,projhit,matchedhit,hit2D,hit1D,localMomentum);
     }
     
-//ngrenz: Begin_____________code seems meaningless now__________________
-
     // hit pattern of the track
-    const reco::HitPattern & hitsPattern = track->hitPattern();
+   // const reco::HitPattern & hitsPattern = track->hitPattern();
     // loop over the hits of the track
     //    for (int i=0; i<hitsPattern.numberOfHits(); i++) {
-    for (int i=0; i<hitsPattern.numberOfHits(reco::HitPattern::TRACK_HITS); i++) {
-      uint32_t hit = hitsPattern.getHitPattern(reco::HitPattern::TRACK_HITS,i);
+   // for (int i=0; i<hitsPattern.numberOfHits(reco::HitPattern::TRACK_HITS); i++) {
+   //   uint32_t hit = hitsPattern.getHitPattern(reco::HitPattern::TRACK_HITS,i);
     
       // if the hit is valid and in pixel barrel, print out the layer
-      if (hitsPattern.validHitFilter(hit) && hitsPattern.pixelBarrelHitFilter(hit))
+   //   if (hitsPattern.validHitFilter(hit) && hitsPattern.pixelBarrelHitFilter(hit))
       
-      if (!hitsPattern.validHitFilter(hit)) continue;
+   //   if (!hitsPattern.validHitFilter(hit)) continue;
 //      if (hitsPattern.pixelHitFilter(hit))       std::cout << "pixel"        << std::endl;       // pixel
 //      if (hitsPattern.pixelBarrelHitFilter(hit)) std::cout << "pixel barrel" << std::endl; // pixel barrel
 //      if (hitsPattern.pixelEndcapHitFilter(hit)) std::cout << "pixel endcap" << std::endl; // pixel endcap
@@ -874,9 +872,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
 //        std::cout << bit;
 //      }
 //      std::cout << std::endl;
-    }
-//ngrenz: End_______________code seems meaningless now__________________
-
+   // }
   }
 }
 //------------------------------------------------------------------------

--- a/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
+++ b/DQM/SiStripMonitorTrack/src/SiStripMonitorTrack.cc
@@ -119,17 +119,26 @@ void SiStripMonitorTrack::analyze(const edm::Event& e, const edm::EventSetup& es
   //Summary Counts of clusters
   std::map<std::string, MonitorElement*>::iterator iME;
   std::map<std::string, LayerMEs>::iterator        iLayerME;
-
-  for (std::map<std::string, SubDetMEs>::iterator iSubDet = SubDetMEsMap.begin();
-       iSubDet != SubDetMEsMap.end(); iSubDet++) {
-    SubDetMEs subdet_mes = iSubDet->second;
-    if (subdet_mes.totNClustersOnTrack > 0) {
-      fillME(subdet_mes.nClustersOnTrack, subdet_mes.totNClustersOnTrack);
-    }
-    fillME(subdet_mes.nClustersOffTrack, subdet_mes.totNClustersOffTrack);
-    if (Trend_On_) {
+  
+  if (Trend_On_) {
+ // for (std::map<std::string, SubDetMEs>::iterator iSubDet = SubDetMEsMap.begin(), iterEnd=SubDetMEsMaps.end();
+ //      iSubDet != iterEnd; ++iSubDet) {
+    for (auto const &iSubDet : SubDetMEsMap) {
+      SubDetMEs subdet_mes = iSubDet.second;
+      if (subdet_mes.totNClustersOnTrack > 0) {
+        fillME(subdet_mes.nClustersOnTrack, subdet_mes.totNClustersOnTrack);
+      }
+      fillME(subdet_mes.nClustersOffTrack, subdet_mes.totNClustersOffTrack);
       fillME(subdet_mes.nClustersTrendOnTrack,iLumisection,subdet_mes.totNClustersOnTrack);
       fillME(subdet_mes.nClustersTrendOffTrack,iLumisection,subdet_mes.totNClustersOffTrack);
+    }
+  } else {
+    for (auto const &iSubDet : SubDetMEsMap) {
+      SubDetMEs subdet_mes = iSubDet.second;
+      if (subdet_mes.totNClustersOnTrack > 0) {
+        fillME(subdet_mes.nClustersOnTrack, subdet_mes.totNClustersOnTrack);
+      }
+      fillME(subdet_mes.nClustersOffTrack, subdet_mes.totNClustersOffTrack);
     }
   }
 }
@@ -150,58 +159,107 @@ void SiStripMonitorTrack::book(DQMStore::IBooker & ibooker , const TrackerTopolo
 
   std::vector<uint32_t> vdetId_;
   SiStripDetCabling_->addActiveDetectorsRawIds(vdetId_);
+  const char* tec = "TEC";
+  const char* tid = "TID";
   //Histos for each detector, layer and module
-  for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin();detid_iter!=vdetId_.end();detid_iter++){  //loop on all the active detid
-    uint32_t detid = *detid_iter;
+  SiStripHistoId hidmanager;
+ 
+  if(Mod_On_) {
+    for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin(),detid_end=vdetId_.end();detid_iter!=detid_end;++detid_iter){  //loop on all the active detid
+      uint32_t detid = *detid_iter;
 
-    if (detid < 1){
-      edm::LogError("SiStripMonitorTrack")<< "[" <<__PRETTY_FUNCTION__ << "] invalid detid " << detid<< std::endl;
-      continue;
-    }
-
-
-    std::string name;
-
-    // book Layer and RING plots
-    std::pair<std::string,int32_t> det_layer_pair = folder_organizer.GetSubDetAndLayer(detid,tTopo,false);
-    /*
-    std::string thickness;
-    std::pair<std::string,int32_t> det_layer_pair_test = folder_organizer.GetSubDetAndLayerThickness(detid,tTopo,thickness);
-    std::cout << "[SiStripMonitorTrack::book] det_layer_pair " << det_layer_pair.first << " " << det_layer_pair.second << " " << thickness << std::endl;
-    */
-
-    SiStripHistoId hidmanager;
-    std::string layer_id = hidmanager.getSubdetid(detid, tTopo, false);
-
-    std::map<std::string, LayerMEs>::iterator iLayerME  = LayerMEsMap.find(layer_id);
-    if(iLayerME==LayerMEsMap.end()){
-      folder_organizer.setLayerFolder(detid, tTopo, det_layer_pair.second, false);
-      bookLayerMEs(ibooker , detid, layer_id);
-    }
-
-    std::string subdet = det_layer_pair.first;
-    if ( subdet.find("TEC") != std::string::npos || subdet.find("TID") != std::string::npos ) {
-      std::pair<std::string,int32_t> det_ring_pair = folder_organizer.GetSubDetAndLayer(detid,tTopo,true);
-      std::string ring_id = hidmanager.getSubdetid(detid, tTopo, true);
-      std::map<std::string, RingMEs>::iterator iRingME  = RingMEsMap.find(ring_id);
-      if(iRingME==RingMEsMap.end()){
-	folder_organizer.setLayerFolder(detid, tTopo, det_ring_pair.second, true);
-	bookRingMEs(ibooker , detid, ring_id);
+      if (detid < 1){
+        edm::LogError("SiStripMonitorTrack")<< "[" <<__PRETTY_FUNCTION__ << "] invalid detid " << detid<< std::endl;
+        continue;
       }
-    }
 
-    // book sub-detector plots
-    std::pair<std::string,std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
-    if (SubDetMEsMap.find(sdet_pair.second) == SubDetMEsMap.end()){
-      ibooker.setCurrentFolder(sdet_pair.first);
-      bookSubDetMEs(ibooker , sdet_pair.second);
-    }
-    // book module plots
-    if(Mod_On_) {
+
+      //std::string name;
+
+      // book Layer and RING plots
+      std::pair<std::string,int32_t> det_layer_pair = folder_organizer.GetSubDetAndLayer(detid,tTopo,false);
+      /*
+      std::string thickness;
+      std::pair<std::string,int32_t> det_layer_pair_test = folder_organizer.GetSubDetAndLayerThickness(detid,tTopo,thickness);
+      std::cout << "[SiStripMonitorTrack::book] det_layer_pair " << det_layer_pair.first << " " << det_layer_pair.second << " " << thickness << std::endl;
+      */
+
+      std::string layer_id = hidmanager.getSubdetid(detid, tTopo, false);
+
+      std::map<std::string, LayerMEs>::iterator iLayerME  = LayerMEsMap.find(layer_id);
+      if(iLayerME==LayerMEsMap.end()){
+        folder_organizer.setLayerFolder(detid, tTopo, det_layer_pair.second, false);
+        bookLayerMEs(ibooker , detid, layer_id);
+      }
+
+      const char* subdet = det_layer_pair.first.c_str();
+      if ( std::strstr(subdet, tec) != NULL || std::strstr(subdet, tid) != NULL ) {
+        std::string ring_id = hidmanager.getSubdetid(detid, tTopo, true);
+        std::map<std::string, RingMEs>::iterator iRingME  = RingMEsMap.find(ring_id);
+        if(iRingME==RingMEsMap.end()){
+	  std::pair<std::string,int32_t> det_ring_pair = folder_organizer.GetSubDetAndLayer(detid,tTopo,true);
+	  folder_organizer.setLayerFolder(detid, tTopo, det_ring_pair.second, true);
+	  bookRingMEs(ibooker , detid, ring_id);
+        }
+      }
+
+      // book sub-detector plots
+      std::pair<std::string,std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+      if (SubDetMEsMap.find(sdet_pair.second) == SubDetMEsMap.end()){
+        ibooker.setCurrentFolder(sdet_pair.first);
+        bookSubDetMEs(ibooker , sdet_pair.second);
+      }
+      // book module plots
       folder_organizer.setDetectorFolder(detid,tTopo);
       bookModMEs(ibooker , *detid_iter);
-    }
-  }//end loop on detectors detid
+    }//end loop on detectors detid
+  } else {
+    for (std::vector<uint32_t>::const_iterator detid_iter=vdetId_.begin(),detid_end=vdetId_.end();detid_iter!=detid_end;++detid_iter){  //loop on all the active detid
+      uint32_t detid = *detid_iter;
+
+      if (detid < 1){
+        edm::LogError("SiStripMonitorTrack")<< "[" <<__PRETTY_FUNCTION__ << "] invalid detid " << detid<< std::endl;
+        continue;
+      }
+
+
+      //std::string name;
+
+      // book Layer and RING plots
+      std::pair<std::string,int32_t> det_layer_pair = folder_organizer.GetSubDetAndLayer(detid,tTopo,false);
+      /*
+      std::string thickness;
+      std::pair<std::string,int32_t> det_layer_pair_test = folder_organizer.GetSubDetAndLayerThickness(detid,tTopo,thickness);
+      std::cout << "[SiStripMonitorTrack::book] det_layer_pair " << det_layer_pair.first << " " << det_layer_pair.second << " " << thickness << std::endl;
+      */
+
+      std::string layer_id = hidmanager.getSubdetid(detid, tTopo, false);
+
+      std::map<std::string, LayerMEs>::iterator iLayerME  = LayerMEsMap.find(layer_id);
+      if(iLayerME==LayerMEsMap.end()){
+        folder_organizer.setLayerFolder(detid, tTopo, det_layer_pair.second, false);
+        bookLayerMEs(ibooker , detid, layer_id);
+      }  
+
+      const char* subdet = det_layer_pair.first.c_str();
+      if ( std::strstr(subdet, tec) != NULL || std::strstr(subdet, tid) != NULL ) {
+        std::string ring_id = hidmanager.getSubdetid(detid, tTopo, true);
+        std::map<std::string, RingMEs>::iterator iRingME  = RingMEsMap.find(ring_id);
+        if(iRingME==RingMEsMap.end()){
+	  std::pair<std::string,int32_t> det_ring_pair = folder_organizer.GetSubDetAndLayer(detid,tTopo,true);
+	  folder_organizer.setLayerFolder(detid, tTopo, det_ring_pair.second, true);
+	  bookRingMEs(ibooker , detid, ring_id);
+        }
+      }
+
+      // book sub-detector plots
+      std::pair<std::string,std::string> sdet_pair = folder_organizer.getSubDetFolderAndTag(detid, tTopo);
+      if (SubDetMEsMap.find(sdet_pair.second) == SubDetMEsMap.end()){
+        ibooker.setCurrentFolder(sdet_pair.first);
+        bookSubDetMEs(ibooker , sdet_pair.second);
+      }
+    }//end loop on detectors detid
+  }
 }
 
 //--------------------------------------------------------------------------------
@@ -512,7 +570,7 @@ void SiStripMonitorTrack::bookSubDetMEs(DQMStore::IBooker & ibooker , std::strin
 }
 //--------------------------------------------------------------------------------
 
-MonitorElement* SiStripMonitorTrack::bookME1D(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
+inline MonitorElement* SiStripMonitorTrack::bookME1D(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
 {
   Parameters =  conf_.getParameter<edm::ParameterSet>(ParameterSetLabel);
   return ibooker.book1D(HistoName,HistoName,
@@ -523,7 +581,7 @@ MonitorElement* SiStripMonitorTrack::bookME1D(DQMStore::IBooker & ibooker , cons
 }
 
 //--------------------------------------------------------------------------------
-MonitorElement* SiStripMonitorTrack::bookME2D(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
+inline MonitorElement* SiStripMonitorTrack::bookME2D(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
 {
   Parameters =  conf_.getParameter<edm::ParameterSet>(ParameterSetLabel);
   return ibooker.book2D(HistoName,HistoName,
@@ -537,7 +595,7 @@ MonitorElement* SiStripMonitorTrack::bookME2D(DQMStore::IBooker & ibooker , cons
 }
 
 //--------------------------------------------------------------------------------
-MonitorElement* SiStripMonitorTrack::bookME3D(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
+inline MonitorElement* SiStripMonitorTrack::bookME3D(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
 {
   Parameters =  conf_.getParameter<edm::ParameterSet>(ParameterSetLabel);
   return ibooker.book3D(HistoName,HistoName,
@@ -554,7 +612,7 @@ MonitorElement* SiStripMonitorTrack::bookME3D(DQMStore::IBooker & ibooker , cons
 }
 
 //--------------------------------------------------------------------------------
-MonitorElement* SiStripMonitorTrack::bookMEProfile(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
+inline MonitorElement* SiStripMonitorTrack::bookMEProfile(DQMStore::IBooker & ibooker , const char* ParameterSetLabel, const char* HistoName)
 {
     Parameters =  conf_.getParameter<edm::ParameterSet>(ParameterSetLabel);
     return ibooker.bookProfile(HistoName,HistoName,
@@ -585,12 +643,9 @@ MonitorElement* SiStripMonitorTrack::bookMETrend(DQMStore::IBooker & ibooker , c
 
 //------------------------------------------------------------------------------------------
 void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory> > traj, const edm::EventSetup& es) {
-
-
   const std::vector<TrajectoryMeasurement> & measurements = traj->measurements();
-  std::vector<TrajectoryMeasurement>::const_iterator traj_mes_iterator;
   for(std::vector<TrajectoryMeasurement>::const_iterator traj_mes_iterator= measurements.begin(), traj_mes_end=measurements.end();
-      traj_mes_iterator!=traj_mes_end;traj_mes_iterator++){//loop on measurements
+      traj_mes_iterator!=traj_mes_end;++traj_mes_iterator){//loop on measurements
     //trajectory local direction and position on detector
     LocalVector statedirection;
 
@@ -617,13 +672,13 @@ void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory>
       statedirection=monodet->toLocal(gtrkdirup);
       SiStripRecHit2D m = matchedhit->monoHit();
       //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,trackref,es);
-      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es);
+      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es);
       //stereo side
       const GeomDetUnit * stereodet=gdet->stereoDet();
       statedirection=stereodet->toLocal(gtrkdirup);
       SiStripRecHit2D s = matchedhit->stereoHit();
       //      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,trackref,es);
-      if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es);
+      if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es);
     }
     else if(projhit){
       LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found"<< std::endl;
@@ -638,21 +693,21 @@ void SiStripMonitorTrack::trajectoryStudy(const edm::Ref<std::vector<Trajectory>
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found  MONO"<< std::endl;
 	det=gdet->monoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
       }
       else{
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found STEREO"<< std::endl;
 	//stereo side
 	det=gdet->stereoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
       }
     }else if (hit2D){
       statedirection=updatedtsos.localMomentum();
-      if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es);
+      if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es);
     } else if (hit1D) {
       statedirection=updatedtsos.localMomentum();
-      if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es);
+      if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es);
     } else {
       LogDebug ("SiStripMonitorTrack")
 	<< " LocalMomentum: "<<statedirection
@@ -682,13 +737,13 @@ void SiStripMonitorTrack::hitStudy(const edm::EventSetup& es,
     const GeomDetUnit * monodet=gdet->monoDet();
     statedirection=monodet->toLocal(gtrkdirup);
     SiStripRecHit2D m = matchedhit->monoHit();
-    if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es);
+    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&m,statedirection,es);
 
     //stereo side
     const GeomDetUnit * stereodet=gdet->stereoDet();
     statedirection=stereodet->toLocal(gtrkdirup);
     SiStripRecHit2D s = matchedhit->stereoHit();
-    if(statedirection.mag() != 0)	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es);
+    if(statedirection.mag())	  RecHitInfo<SiStripRecHit2D>(&s,statedirection,es);
   }
   else if(projhit){    // type=Projected;
       LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found"<< std::endl;      
@@ -704,21 +759,21 @@ void SiStripMonitorTrack::hitStudy(const edm::EventSetup& es,
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found  MONO"<< std::endl;
 	det=gdet->monoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
       }
       else{
 	LogTrace("SiStripMonitorTrack")<<"\nProjected recHit found STEREO"<< std::endl;
 	//stereo side
 	det=gdet->stereoDet();
 	statedirection=det->toLocal(gtrkdirup);
-	if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
+	if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(&(originalhit),statedirection,es);
       }
   } else if (hit2D){ // type=2D
     statedirection=localMomentum;
-    if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es);
+    if(statedirection.mag()) RecHitInfo<SiStripRecHit2D>(hit2D,statedirection,es);
   } else if (hit1D) { // type=1D
     statedirection=localMomentum;
-    if(statedirection.mag() != 0) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es);
+    if(statedirection.mag()) RecHitInfo<SiStripRecHit1D>(hit1D,statedirection,es);
   } else {
     LogDebug ("SiStripMonitorTrack")
       << " LocalMomentum: "<<statedirection
@@ -747,14 +802,13 @@ using namespace reco;
     // track input
     edm::Handle<reco::TrackCollection > trackCollectionHandle;
     ev.getByToken(trackToken_, trackCollectionHandle);//takes the track collection
-    if (!trackCollectionHandle.isValid()){
+    if (trackCollectionHandle.isValid()){
+      trackStudyFromTrack(trackCollectionHandle,es);
+    } else {      
       edm::LogError("SiStripMonitorTrack")<<"also Track Collection is not valid !! " << TrackLabel_<<std::endl;
       return;
-    } else {
-      trackStudyFromTrack(trackCollectionHandle,es);
     }
   }
-
 }
 //------------------------------------------------------------------------
 void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection > trackCollectionHandle, const edm::EventSetup& es) {
@@ -788,7 +842,7 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
       hitStudy(es,projhit,matchedhit,hit2D,hit1D,localMomentum);
     }
     
-
+//ngrenz: Begin_____________code seems meaningless now__________________
 
     // hit pattern of the track
     const reco::HitPattern & hitsPattern = track->hitPattern();
@@ -821,6 +875,8 @@ void SiStripMonitorTrack::trackStudyFromTrack(edm::Handle<reco::TrackCollection 
 //      }
 //      std::cout << std::endl;
     }
+//ngrenz: End_______________code seems meaningless now__________________
+
   }
 }
 //------------------------------------------------------------------------
@@ -831,9 +887,9 @@ void SiStripMonitorTrack::trackStudyFromTrajectory(edm::Handle<TrajTrackAssociat
     const edm::Ref<std::vector<Trajectory> > traj_iterator = it->key;
 
     // Trajectory Map, extract Trajectory for this track
-    reco::TrackRef trackref = it->val;
+    //reco::TrackRef trackref = it->val;
     LogDebug("SiStripMonitorTrack")
-      << "Track number "<< i+1 << std::endl;
+      << "Track number "<< ++i << std::endl;
       //      << "\n\tmomentum: " << trackref->momentum()
       //      << "\n\tPT: " << trackref->pt()
       //      << "\n\tvertex: " << trackref->vertex()
@@ -842,7 +898,6 @@ void SiStripMonitorTrack::trackStudyFromTrajectory(edm::Handle<TrajTrackAssociat
       //      << "\n\tnormalizedChi2: " << trackref->normalizedChi2()
       //      <<"\n\tFrom EXTRA : "
       //      <<"\n\t\touter PT "<< trackref->outerPt()<<std::endl;
-    i++;
 
     //    trajectoryStudy(traj_iterator,trackref,es);
     trajectoryStudy(traj_iterator,es);
@@ -860,7 +915,7 @@ template <class T> void SiStripMonitorTrack::RecHitInfo(const T* tkrecHit, Local
     const uint32_t& detid = tkrecHit->geographicalId().rawId();
 
     LogTrace("SiStripMonitorTrack")
-      <<"\n\t\tRecHit on det "<<tkrecHit->geographicalId().rawId()
+      <<"\n\t\tRecHit on det "<<detid
       <<"\n\t\tRecHit in LP "<<tkrecHit->localPosition()
       <<"\n\t\tRecHit in GP "<<tkgeom_->idToDet(tkrecHit->geographicalId())->surface().toGlobal(tkrecHit->localPosition())
       <<"\n\t\tRecHit trackLocal vector "<<LV.x() << " " << LV.y() << " " << LV.z() <<std::endl;
@@ -899,34 +954,29 @@ void SiStripMonitorTrack::AllClusters(const edm::Event& ev, const edm::EventSetu
 
   edm::Handle< edmNew::DetSetVector<SiStripCluster> > siStripClusterHandle;
   ev.getByToken( clusterToken_, siStripClusterHandle);
-  if (!siStripClusterHandle.isValid()){
-    edm::LogError("SiStripMonitorTrack")<< "ClusterCollection is not valid!!" << std::endl;
-    return;
-  }
-  else
-  {
-    //Loop on Dets
-    for (edmNew::DetSetVector<SiStripCluster>::const_iterator DSViter=siStripClusterHandle->begin();
-         DSViter!=siStripClusterHandle->end();
-         DSViter++)
-    {
+  if (siStripClusterHandle.isValid()){
+      //Loop on Dets
+    for (edmNew::DetSetVector<SiStripCluster>::const_iterator DSViter=siStripClusterHandle->begin(), DSVEnd=siStripClusterHandle->end();
+         DSViter!=DSVEnd; ++DSViter) {
+
       uint32_t detid=DSViter->id();
       const Det2MEs MEs = findMEs(tTopo, detid);
 
       LogDebug("SiStripMonitorTrack") << "on detid "<< detid << " N Cluster= " << DSViter->size();
 
       //Loop on Clusters
-      for(edmNew::DetSet<SiStripCluster>::const_iterator ClusIter = DSViter->begin();
-          ClusIter!=DSViter->end();
-          ClusIter++)
-      {
-        if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end())
-        {
+      for(edmNew::DetSet<SiStripCluster>::const_iterator ClusIter = DSViter->begin(), ClusEnd = DSViter->end();
+          ClusIter!=ClusEnd; ++ClusIter) {
+
+        if (vPSiStripCluster.find(&*ClusIter) == vPSiStripCluster.end()) {
           SiStripClusterInfo SiStripClusterInfo_(*ClusIter,es,detid);
           clusterInfos(&SiStripClusterInfo_,detid,OffTrack,LV,MEs);
         }
       }
     }
+  } else {
+    edm::LogError("SiStripMonitorTrack")<< "ClusterCollection is not valid!!" << std::endl;
+    return;
   }
 }
 
@@ -962,6 +1012,7 @@ SiStripMonitorTrack::Det2MEs SiStripMonitorTrack::findMEs(const TrackerTopology*
 }
 
 //------------------------------------------------------------------------
+#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
 bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32_t detid, enum ClusterFlags flag, const LocalVector LV, const Det2MEs& MEs)
 {
 
@@ -974,102 +1025,14 @@ bool SiStripMonitorTrack::clusterInfos(SiStripClusterInfo* cluster, const uint32
        cluster->width() > widthUpperLimit_) ) return false;
   // start of the analysis
 
-  if (MEs.iSubdet != nullptr) {
-    if (flag == OnTrack) MEs.iSubdet->totNClustersOnTrack++;
-    else if (flag == OffTrack) MEs.iSubdet->totNClustersOffTrack++;
-  }
-
   float cosRZ = -2;
   LogDebug("SiStripMonitorTrack")<< "\n\tLV " << LV.x() << " " << LV.y() << " " << LV.z() << " " << LV.mag() << std::endl;
-  if (LV.mag()!=0){
+  if (LV.mag()){
     cosRZ= fabs(LV.z())/LV.mag();
     LogDebug("SiStripMonitorTrack")<< "\n\t cosRZ " << cosRZ << std::endl;
   }
-  std::string name;
 
   // Filling SubDet/Layer Plots (on Track + off Track)
-  fillMEs(cluster,detid,cosRZ,flag,LV,MEs);
-
-  //******** TkHistoMaps
-  if (TkHistoMap_On_) {
-    uint32_t adet=cluster->detId();
-    float noise = cluster->noiseRescaledByGain();
-    if(flag==OnTrack){
-      tkhisto_NumOnTrack->add(adet,1.);
-      if(noise > 0.0) tkhisto_StoNCorrOnTrack->fill(adet,cluster->signalOverNoise()*cosRZ);
-      if(noise == 0.0)
-	LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << noise << std::endl;
-    }
-    else if(flag==OffTrack){
-      tkhisto_NumOffTrack->add(adet,1.);
-      if(cluster->charge() > 250){
-	LogDebug("SiStripMonitorTrack") << "Module firing " << detid << " in Event " << eventNb << std::endl;
-      }
-    }
-  }
-
-  // Module plots filled only for onTrack Clusters
-  if(Mod_On_){
-    if(flag==OnTrack){
-      SiStripHistoId hidmanager2;
-      name =hidmanager2.createHistoId("","det",detid);
-      fillModMEs(cluster,name,cosRZ,detid,LV);
-    }
-  }
-  return true;
-}
-#include "DataFormats/SiStripCluster/interface/SiStripClusterTools.h"
-//--------------------------------------------------------------------------------
-void SiStripMonitorTrack::fillModMEs(SiStripClusterInfo* cluster,std::string name,float cos,const uint32_t detid, const LocalVector LV)
-{
-  std::map<std::string, ModMEs>::iterator iModME  = ModMEsMap.find(name);
-  if(iModME!=ModMEsMap.end()){
-
-    float    StoN     = cluster->signalOverNoise();
-    uint16_t charge   = cluster->charge();
-    uint16_t width    = cluster->width();
-    float    position = cluster->baryStrip();
-
-    // new dE/dx (chargePerCM)
-    // https://indico.cern.ch/event/342236/session/5/contribution/10/material/slides/0.pdf
-    float dQdx_fromTrack = siStripClusterTools::chargePerCM(detid, *cluster, LV);
-    // from straigth line origin-sensor centre
-    const StripGeomDetUnit* DetUnit = static_cast<const StripGeomDetUnit*>(tkgeom_->idToDetUnit(DetId(detid)));
-    LocalPoint locVtx = DetUnit->toLocal(GlobalPoint(0.0, 0.0, 0.0));
-    LocalVector locDir(locVtx.x(), locVtx.y(), locVtx.z());
-    float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, *cluster, locDir);
-    
-    float noise = cluster->noiseRescaledByGain();
-    if(noise > 0.0) fillME(iModME->second.ClusterStoNCorr ,StoN*cos);
-    if(noise == 0.0) LogDebug("SiStripMonitorTrack") << "Module " << name << " in Event " << eventNb << " noise " << noise << std::endl;
-    fillME(iModME->second.ClusterCharge,charge);
-
-    fillME(iModME->second.ClusterChargeCorr,charge*cos);
-
-    fillME(iModME->second.ClusterWidth ,width);
-    fillME(iModME->second.ClusterPos   ,position);
-
-    fillME(iModME->second.ClusterChargePerCMfromTrack,  dQdx_fromTrack);
-    fillME(iModME->second.ClusterChargePerCMfromOrigin, dQdx_fromOrigin);
-
-    //fill the PGV histo
-    float PGVmax = cluster->maxCharge();
-    int PGVposCounter = cluster->maxIndex();
-    for (int i= int(conf_.getParameter<edm::ParameterSet>("TProfileClusterPGV").getParameter<double>("xmin"));i<PGVposCounter;++i)
-      fillME(iModME->second.ClusterPGV, i,0.);
-    for (auto it=cluster->stripCharges().begin();it<cluster->stripCharges().end();++it) {
-      fillME(iModME->second.ClusterPGV, PGVposCounter++,(*it)/PGVmax);
-    }
-    for (int i= PGVposCounter;i<int(conf_.getParameter<edm::ParameterSet>("TProfileClusterPGV").getParameter<double>("xmax"));++i)
-      fillME(iModME->second.ClusterPGV, i,0.);
-    //end fill the PGV histo
-  }
-}
-
-
-//------------------------------------------------------------------------
-void SiStripMonitorTrack::fillMEs(SiStripClusterInfo* cluster, const uint32_t detid, float cos, enum ClusterFlags flag,  const LocalVector LV, const Det2MEs& MEs)
-{
   float    StoN     = cluster->signalOverNoise();
   float    noise    = cluster->noiseRescaledByGain();
   uint16_t charge   = cluster->charge();
@@ -1080,61 +1043,117 @@ void SiStripMonitorTrack::fillMEs(SiStripClusterInfo* cluster, const uint32_t de
   // https://indico.cern.ch/event/342236/session/5/contribution/10/material/slides/0.pdf
   float dQdx_fromTrack = siStripClusterTools::chargePerCM(detid, *cluster, LV);
   // from straigth line origin-sensor centre
-  const StripGeomDetUnit* DetUnit = (const StripGeomDetUnit*) tkgeom_->idToDetUnit(DetId(detid));
+  const StripGeomDetUnit* DetUnit = static_cast<const StripGeomDetUnit*>(tkgeom_->idToDetUnit(DetId(detid)));
   LocalPoint locVtx = DetUnit->toLocal(GlobalPoint(0.0, 0.0, 0.0));
   LocalVector locDir(locVtx.x(), locVtx.y(), locVtx.z());
   float dQdx_fromOrigin = siStripClusterTools::chargePerCM(detid, *cluster, locDir);
-  
-  // layerMEs
-  if (MEs.iLayer != nullptr) {
-    if(flag==OnTrack){
-      if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrOnTrack, StoN*cos);
+
+  if(flag==OnTrack){
+    if (MEs.iSubdet != nullptr) MEs.iSubdet->totNClustersOnTrack++;
+    // layerMEs
+    if (MEs.iLayer != nullptr) {
+      if(noise > 0.0) fillME(MEs.iLayer->ClusterStoNCorrOnTrack, StoN*cosRZ);
       if(noise == 0.0) LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << cluster->noiseRescaledByGain() << std::endl;
-      fillME(MEs.iLayer->ClusterChargeCorrOnTrack, charge*cos);
+      fillME(MEs.iLayer->ClusterChargeCorrOnTrack, charge*cosRZ);
       fillME(MEs.iLayer->ClusterChargeOnTrack, charge);
       fillME(MEs.iLayer->ClusterNoiseOnTrack, noise);
       fillME(MEs.iLayer->ClusterWidthOnTrack, width);
       fillME(MEs.iLayer->ClusterPosOnTrack, position);
       fillME(MEs.iLayer->ClusterChargePerCMfromTrack, dQdx_fromTrack);
       fillME(MEs.iLayer->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
-    } else {
+    }
+    // ringMEs
+    if (MEs.iRing != nullptr) {
+      if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrOnTrack, StoN*cosRZ);
+      if(noise == 0.0) LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << cluster->noiseRescaledByGain() << std::endl;
+      fillME(MEs.iRing->ClusterChargeCorrOnTrack, charge*cosRZ);
+      fillME(MEs.iRing->ClusterChargeOnTrack, charge);
+      fillME(MEs.iRing->ClusterNoiseOnTrack, noise);
+      fillME(MEs.iRing->ClusterWidthOnTrack, width);
+      fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
+      fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
+    }
+    // subdetMEs
+    if(MEs.iSubdet != nullptr){
+      fillME(MEs.iSubdet->ClusterChargeOnTrack,charge);
+      if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrOnTrack,StoN*cosRZ);
+      fillME(MEs.iSubdet->ClusterChargePerCMfromTrack,dQdx_fromTrack);
+      fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
+    }
+    //******** TkHistoMaps
+    if (TkHistoMap_On_) {
+      uint32_t adet=cluster->detId();
+      tkhisto_NumOnTrack->add(adet,1.);
+      if(noise > 0.0) tkhisto_StoNCorrOnTrack->fill(adet,cluster->signalOverNoise()*cosRZ);
+      if(noise == 0.0)
+	LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << noise << std::endl;
+    }
+    // Module plots filled only for onTrack Clusters
+    if(Mod_On_){
+      SiStripHistoId hidmanager2;
+      std::string name = hidmanager2.createHistoId("","det",detid);
+      //fillModMEs
+      std::map<std::string, ModMEs>::iterator iModME  = ModMEsMap.find(name);
+      if(iModME!=ModMEsMap.end()){
+        if(noise > 0.0) fillME(iModME->second.ClusterStoNCorr ,StoN*cosRZ);
+        if(noise == 0.0) LogDebug("SiStripMonitorTrack") << "Module " << name << " in Event " << eventNb << " noise " << noise << std::endl;
+        fillME(iModME->second.ClusterCharge,charge);
+
+        fillME(iModME->second.ClusterChargeCorr,charge*cosRZ);
+
+        fillME(iModME->second.ClusterWidth ,width);
+        fillME(iModME->second.ClusterPos   ,position);
+
+        fillME(iModME->second.ClusterChargePerCMfromTrack,  dQdx_fromTrack);
+        fillME(iModME->second.ClusterChargePerCMfromOrigin, dQdx_fromOrigin);
+
+        //fill the PGV histo
+        float PGVmax = cluster->maxCharge();
+        int PGVposCounter = cluster->maxIndex();
+        for (int i= int(conf_.getParameter<edm::ParameterSet>("TProfileClusterPGV").getParameter<double>("xmin"));i<PGVposCounter;++i)
+          fillME(iModME->second.ClusterPGV, i,0.);
+        for (auto it=cluster->stripCharges().begin();it<cluster->stripCharges().end();++it) {
+          fillME(iModME->second.ClusterPGV, PGVposCounter++,(*it)/PGVmax);
+        }
+        for (int i= PGVposCounter;i<int(conf_.getParameter<edm::ParameterSet>("TProfileClusterPGV").getParameter<double>("xmax"));++i)
+          fillME(iModME->second.ClusterPGV, i,0.);
+        //end fill the PGV histo
+      }
+    }
+  } else {
+    if (flag == OffTrack) {
+      if (MEs.iSubdet != nullptr) MEs.iSubdet->totNClustersOffTrack++;
+      //******** TkHistoMaps
+      if (TkHistoMap_On_) {
+        uint32_t adet=cluster->detId();
+        tkhisto_NumOffTrack->add(adet,1.);
+        if(charge > 250){
+	  LogDebug("SiStripMonitorTrack") << "Module firing " << detid << " in Event " << eventNb << std::endl;
+        }
+      }
+    }
+    // layerMEs
+    if (MEs.iLayer != nullptr) {
       fillME(MEs.iLayer->ClusterChargeOffTrack, charge);
       fillME(MEs.iLayer->ClusterNoiseOffTrack, noise);
       fillME(MEs.iLayer->ClusterWidthOffTrack, width);
       fillME(MEs.iLayer->ClusterPosOffTrack, position);
       fillME(MEs.iLayer->ClusterChargePerCMfromOriginOffTrack, dQdx_fromOrigin);
     }
-  }
-
-  // ringMEs
-  if (MEs.iRing != nullptr) {
-    if(flag==OnTrack){
-      if(noise > 0.0) fillME(MEs.iRing->ClusterStoNCorrOnTrack, StoN*cos);
-      if(noise == 0.0) LogDebug("SiStripMonitorTrack") << "Module " << detid << " in Event " << eventNb << " noise " << cluster->noiseRescaledByGain() << std::endl;
-      fillME(MEs.iRing->ClusterChargeCorrOnTrack, charge*cos);
-      fillME(MEs.iRing->ClusterChargeOnTrack, charge);
-      fillME(MEs.iRing->ClusterNoiseOnTrack, noise);
-      fillME(MEs.iRing->ClusterWidthOnTrack, width);
-      fillME(MEs.iRing->ClusterChargePerCMfromTrack, dQdx_fromTrack);
-      fillME(MEs.iRing->ClusterChargePerCMfromOriginOnTrack, dQdx_fromOrigin);
-    } else {
+    // ringMEs
+    if (MEs.iRing != nullptr) {
       fillME(MEs.iRing->ClusterChargeOffTrack, charge);
       fillME(MEs.iRing->ClusterNoiseOffTrack, noise);
       fillME(MEs.iRing->ClusterWidthOffTrack, width);
       fillME(MEs.iRing->ClusterChargePerCMfromOriginOffTrack, dQdx_fromOrigin);
     }
-  }
-  // subdetMEs
-  if(MEs.iSubdet != nullptr){
-    if(flag==OnTrack){
-      fillME(MEs.iSubdet->ClusterChargeOnTrack,charge);
-      if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNCorrOnTrack,StoN*cos);
-      fillME(MEs.iSubdet->ClusterChargePerCMfromTrack,dQdx_fromTrack);
-      fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOnTrack,dQdx_fromOrigin);
-    } else {
+    // subdetMEs
+    if(MEs.iSubdet != nullptr){
       fillME(MEs.iSubdet->ClusterChargeOffTrack,charge);
       if(noise > 0.0) fillME(MEs.iSubdet->ClusterStoNOffTrack,StoN);
       fillME(MEs.iSubdet->ClusterChargePerCMfromOriginOffTrack,dQdx_fromOrigin);
     }
   }
+  return true;
 }
+//--------------------------------------------------------------------------------


### PR DESCRIPTION
Work intended to optimize the performance of tracker validation code and code cleanup.

Changes:
- Combination of functions fillModMEs() and fillMEs() with clusterInfos() --> reduce code repetition
- use strstr() instead of find()
- prefer prefix
- inline of some book functions
- put unused code inside a comment

Outputs are supposed to be unchanged.
Any comments and suggestions are welcome.
