### PR TITLE
Use anonymous namespaces to avoid duplicate symbols

### DIFF
--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromDB.cc
@@ -181,11 +181,13 @@ EGExtraInfoModifierFromDB::EGExtraInfoModifierFromDB(const edm::ParameterSet& co
   }
 }
 
-template<typename T>
-inline void get_product(const edm::Event& evt,
-                        const edm::EDGetTokenT<edm::ValueMap<T> >& tok,
-                        std::unordered_map<unsigned, edm::Handle<edm::ValueMap<T> > >& map) {
-  evt.getByToken(tok,map[tok.index()]);
+namespace {
+  template<typename T>
+  inline void get_product(const edm::Event& evt,
+                          const edm::EDGetTokenT<edm::ValueMap<T> >& tok,
+                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<T> > >& map) {
+    evt.getByToken(tok,map[tok.index()]);
+  }
 }
 
 void EGExtraInfoModifierFromDB::setEvent(const edm::Event& evt) {
@@ -307,16 +309,18 @@ void EGExtraInfoModifierFromDB::setEventContent(const edm::EventSetup& evs) {
   }
 }
 
-template<typename T, typename U, typename V>
-inline void make_consumes(T& tag,U& tok,V& sume) { 
-  if(!(empty_tag == tag)) 
-    tok = sume.template consumes<edm::ValueMap<float> >(tag); 
-}
+namespace {
+  template<typename T, typename U, typename V>
+  inline void make_consumes(T& tag,U& tok,V& sume) { 
+    if(!(empty_tag == tag)) 
+      tok = sume.template consumes<edm::ValueMap<float> >(tag); 
+  }
 
-template<typename T, typename U, typename V>
-inline void make_int_consumes(T& tag,U& tok,V& sume) { 
-  if(!(empty_tag == tag)) 
-    tok = sume.template consumes<edm::ValueMap<int> >(tag); 
+  template<typename T, typename U, typename V>
+  inline void make_int_consumes(T& tag,U& tok,V& sume) { 
+    if(!(empty_tag == tag)) 
+      tok = sume.template consumes<edm::ValueMap<int> >(tag); 
+  }
 }
 
 void EGExtraInfoModifierFromDB::setConsumes(edm::ConsumesCollector& sumes) {
@@ -360,9 +364,11 @@ void EGExtraInfoModifierFromDB::setConsumes(edm::ConsumesCollector& sumes) {
   }  
 }
 
-template<typename T, typename U, typename V, typename Z>
-inline void assignValue(const T& ptr, const U& tok, const V& map, Z& value) {
-  if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+namespace {
+  template<typename T, typename U, typename V, typename Z>
+  inline void assignValue(const T& ptr, const U& tok, const V& map, Z& value) {
+    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+  }
 }
 
 void EGExtraInfoModifierFromDB::modifyObject(pat::Electron& ele) const {

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromFloatValueMaps.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromFloatValueMaps.cc
@@ -87,10 +87,12 @@ EGExtraInfoModifierFromFloatValueMaps(const edm::ParameterSet& conf) :
   ele_idx = pho_idx = 0;
 }
 
-inline void get_product(const edm::Event& evt,
-                        const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
-                        std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
-  evt.getByToken(tok,map[tok.index()]);
+namespace {
+  inline void get_product(const edm::Event& evt,
+                          const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
+                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
+    evt.getByToken(tok,map[tok.index()]);
+  }
 }
 
 void EGExtraInfoModifierFromFloatValueMaps::
@@ -135,8 +137,10 @@ void EGExtraInfoModifierFromFloatValueMaps::
 setEventContent(const edm::EventSetup& evs) {
 }
 
-template<typename T, typename U, typename V>
-inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+namespace {
+  template<typename T, typename U, typename V>
+  inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+}
 
 void EGExtraInfoModifierFromFloatValueMaps::
 setConsumes(edm::ConsumesCollector& sumes) {
@@ -155,9 +159,11 @@ setConsumes(edm::ConsumesCollector& sumes) {
   }
 }
 
-template<typename T, typename U, typename V>
-inline void assignValue(const T& ptr, const U& tok, const V& map, float& value) {
-  if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+namespace {
+  template<typename T, typename U, typename V>
+  inline void assignValue(const T& ptr, const U& tok, const V& map, float& value) {
+    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+  }
 }
 
 void EGExtraInfoModifierFromFloatValueMaps::

--- a/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromIntValueMaps.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGExtraInfoModifierFromIntValueMaps.cc
@@ -87,10 +87,12 @@ EGExtraInfoModifierFromIntValueMaps(const edm::ParameterSet& conf) :
   ele_idx = pho_idx = 0;
 }
 
-inline void get_product(const edm::Event& evt,
-                        const edm::EDGetTokenT<edm::ValueMap<int> >& tok,
-                        std::unordered_map<unsigned, edm::Handle<edm::ValueMap<int> > >& map) {
-  evt.getByToken(tok,map[tok.index()]);
+namespace {
+  inline void get_product(const edm::Event& evt,
+                          const edm::EDGetTokenT<edm::ValueMap<int> >& tok,
+                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<int> > >& map) {
+    evt.getByToken(tok,map[tok.index()]);
+  }
 }
 
 void EGExtraInfoModifierFromIntValueMaps::
@@ -135,8 +137,10 @@ void EGExtraInfoModifierFromIntValueMaps::
 setEventContent(const edm::EventSetup& evs) {
 }
 
-template<typename T, typename U, typename V>
-inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<int> >(tag); }
+namespace {
+  template<typename T, typename U, typename V>
+  inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<int> >(tag); }
+}
 
 void EGExtraInfoModifierFromIntValueMaps::
 setConsumes(edm::ConsumesCollector& sumes) {
@@ -155,9 +159,11 @@ setConsumes(edm::ConsumesCollector& sumes) {
   }
 }
 
-template<typename T, typename U, typename V>
-inline void assignValue(const T& ptr, const U& tok, const V& map, int& value) {
-  if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+namespace {
+  template<typename T, typename U, typename V>
+  inline void assignValue(const T& ptr, const U& tok, const V& map, int& value) {
+    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+  }
 }
 
 void EGExtraInfoModifierFromIntValueMaps::

--- a/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGFull5x5ShowerShapeModifier.cc
@@ -130,10 +130,12 @@ EGFull5x5ShowerShapeModifierFromValueMaps(const edm::ParameterSet& conf) :
   ele_idx = pho_idx = 0;
 }
 
-inline void get_product(const edm::Event& evt,
-                        const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
-                        std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
-  if( !tok.isUninitialized() ) evt.getByToken(tok,map[tok.index()]);
+namespace {
+  inline void get_product(const edm::Event& evt,
+                          const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
+                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
+    if( !tok.isUninitialized() ) evt.getByToken(tok,map[tok.index()]);
+  }
 }
 
 void EGFull5x5ShowerShapeModifierFromValueMaps::
@@ -195,8 +197,10 @@ void EGFull5x5ShowerShapeModifierFromValueMaps::
 setEventContent(const edm::EventSetup& evs) {
 }
 
-template<typename T, typename U, typename V>
-inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+namespace {
+  template<typename T, typename U, typename V>
+  inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+}
 
 void EGFull5x5ShowerShapeModifierFromValueMaps::
 setConsumes(edm::ConsumesCollector& sumes) {
@@ -229,9 +233,11 @@ setConsumes(edm::ConsumesCollector& sumes) {
   make_consumes(ph_conf.hcalDepth2OverEcalBc,ph_conf.tok_hcalDepth2OverEcalBc,sumes);   
 }
 
-template<typename T, typename U, typename V>
-inline void assignValue(const T& ptr, const U& tok, const V& map, float& value) {
-  if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+namespace {
+  template<typename T, typename U, typename V>
+  inline void assignValue(const T& ptr, const U& tok, const V& map, float& value) {
+    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+  }
 }
 
 void EGFull5x5ShowerShapeModifierFromValueMaps::

--- a/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
+++ b/RecoEgamma/EgammaTools/plugins/EGPfIsolationModifier.cc
@@ -100,10 +100,12 @@ EGPfIsolationModifierFromValueMaps(const edm::ParameterSet& conf) :
   ele_idx = pho_idx = 0;
 }
 
-inline void get_product(const edm::Event& evt,
-                        const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
-                        std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
-  if( !tok.isUninitialized() ) evt.getByToken(tok,map[tok.index()]);
+namespace {
+  inline void get_product(const edm::Event& evt,
+                          const edm::EDGetTokenT<edm::ValueMap<float> >& tok,
+                          std::unordered_map<unsigned, edm::Handle<edm::ValueMap<float> > >& map) {
+    if( !tok.isUninitialized() ) evt.getByToken(tok,map[tok.index()]);
+  }
 }
 
 void EGPfIsolationModifierFromValueMaps::
@@ -152,8 +154,10 @@ void EGPfIsolationModifierFromValueMaps::
 setEventContent(const edm::EventSetup& evs) {
 }
 
-template<typename T, typename U, typename V>
-inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+namespace {
+  template<typename T, typename U, typename V>
+  inline void make_consumes(T& tag,U& tok,V& sume) { if( !(empty_tag == tag) ) tok = sume.template consumes<edm::ValueMap<float> >(tag); }
+}
 
 void EGPfIsolationModifierFromValueMaps::
 setConsumes(edm::ConsumesCollector& sumes) {
@@ -178,12 +182,14 @@ setConsumes(edm::ConsumesCollector& sumes) {
   }   
 }
 
-template<typename T, typename U, typename V>
-inline void assignValue(const T& ptr, const U& input_map, const std::string& name, const V& map, float& value) {
-  auto itr = input_map.find(name);
-  if( itr == input_map.end() ) return;
-  const auto& tok = std::get<1>(itr->second);
-  if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+namespace {
+  template<typename T, typename U, typename V>
+  inline void assignValue(const T& ptr, const U& input_map, const std::string& name, const V& map, float& value) {
+    auto itr = input_map.find(name);
+    if( itr == input_map.end() ) return;
+    const auto& tok = std::get<1>(itr->second);
+    if( !tok.isUninitialized() ) value = map.find(tok.index())->second->get(ptr.id(),ptr.key());
+  }
 }
 
 void EGPfIsolationModifierFromValueMaps::


### PR DESCRIPTION
Bug fix. Totally technical.
Can be backported to 7_5_X if requested.
In RecoEgamma/EgammaTools/plugins, there are free function templates in different files that have the same signature. These are violations of the ODR (one definition rule).
The reason this problem has not yet been seen before is that the function templates in question are declared "inline". However, "inline" is only a suggestion to the compiler. When compiled in debug mode (-O0), in-lining was apparently turned off. This did not cause a link error, as function templates are not instantiated until run time. However, it caused the wrong function to be called in several cases, causing relvals 4.53, 135.4, and 1330.0 to fail.
The fix is to put the templates inside an anonymous namespace, so each template is not seen outside the compilation unit. This fixes the failing relvals.
