### PR TITLE
Updated TimeSlewSim (HCAL Digitization)  for 76X

### DIFF
--- a/SimCalorimetry/HcalSimAlgos/src/HcalTimeSlewSim.cc
+++ b/SimCalorimetry/HcalSimAlgos/src/HcalTimeSlewSim.cc
@@ -30,12 +30,12 @@ double HcalTimeSlewSim::charge(const CaloSamples & samples) const
 }
 
 
-void HcalTimeSlewSim::delay(CaloSamples & samples, CLHEP::HepRandomEngine* engine) const
+void HcalTimeSlewSim::delay(CaloSamples & cs, CLHEP::HepRandomEngine* engine) const
 {
   // HO goes slow, HF shouldn't be used at all
   //ZDC not used for the moment
 
-  DetId detId(samples.id());
+  DetId detId(cs.id());
   if(detId.det()==DetId::Calo && detId.subdetId()==HcalZDCDetId::SubdetectorId) return;
   HcalDetId hcalDetId(detId);
 
@@ -45,17 +45,19 @@ void HcalTimeSlewSim::delay(CaloSamples & samples, CLHEP::HepRandomEngine* engin
       HcalTimeSlew::Slow :
       HcalTimeSlew::Medium;
 
-    // double totalCharge = charge(samples); 
+    // double totalCharge = charge(cs); // old TS... 
 
-    int maxbin =  samples.size();
+    int maxbin = cs.size();
     CaloSamples data(detId, maxbin);   // for a temporary copy 
-    data =  samples;  
+    data = cs;  
 
     // smearing
-    double eps = 1.e-6;
+    int    soi          = cs.presamples();
+    double eps          = 1.e-6;
     double scale_factor = 0.6;  
-    double scale = data[4] / scale_factor;      
-    double smearns = 0.;
+    double scale        = cs[soi] / scale_factor;      
+    double smearns      = 0.;
+    double cut          = 5.; // fC (above mean) for signal to be delayed
 
     const HcalSimParameters& params =
       static_cast<const HcalSimParameters&>(theParameterMap->simParameters(detId));
@@ -66,25 +68,59 @@ void HcalTimeSlewSim::delay(CaloSamples & samples, CLHEP::HepRandomEngine* engin
 				  << scale << " rms " << rms 
 				  << " smearns " << smearns;
     }
-    
-    for(int i = 0; i < samples.size()-1; ++i) {
-      double totalCharge = data[i]/scale_factor;   
-      // until we get more precise/reliable QIE8 simulation...  
 
-      double delay = smearns;
-      if(totalCharge <= 0.) totalCharge = eps; // protecion against negaive v.
-      delay += HcalTimeSlew::delay(totalCharge, biasSetting);      
-      if(delay <= 0.) delay = eps;
+    // cycle over TS',  it - current TS index
+    for(int it = 0; it < maxbin-1; ) {
+ 
+      double datai = cs[it];
+      int    nts  = 0;
+      if ((datai > cut) && ( it == 0 || (datai > cs[it-1]))) {
+	// number of TS affected by current move depends on the signal shape:
+	// rising or peaking
+        nts = 2;  // rising
+	if(datai > cs[it+1]) nts = 3; // peaking
 
-      double t = i*25. - delay;
-      int firstbin = floor(t/25.);
-      double f = t/25. - firstbin;
-      int nextbin = firstbin + 1;
-      double v2 = (nextbin < 0  || nextbin  >= maxbin) ? 0. : data[nextbin];
-      data[i] = v2*f;
-      data[i+1] = data[i+1] + (v2 - data[i]);
+	// until we get more precise/reliable QIE8 simulation...  
+	double totalCharge = datai/scale_factor;   
+
+	double tshift = smearns;
+	if(totalCharge <= 0.) totalCharge = eps; // protecion against negaive v.
+	tshift += HcalTimeSlew::delay(totalCharge, biasSetting);      
+	if(tshift <= 0.) tshift = eps;
+
+	// 1 or 2 TS to move from here, 
+	// 2d or 3d TS gets leftovers to preserve the sum
+        for (int j = it; j < it+nts && j < maxbin; ++j) {   
+ 
+	  // snippet borrowed from  CaloSamples::offsetTime(offset)
+	  // CalibFormats/CaloObjects/src/CaloSamples.cc
+	  double t = j*25. - tshift;
+	  int firstbin = floor(t/25.);
+	  double f = t/25. - firstbin;
+	  int nextbin = firstbin + 1;
+	  double v1 = (firstbin < 0 || firstbin >= maxbin) ? 0. : cs[firstbin];
+	  double v2 = (nextbin  < 0 || nextbin  >= maxbin) ? 0. : cs[nextbin];
+          
+	  // Keeping the overal sum intact
+	  if(nts == 2) {
+            if(j == it) data[j] = v2*f; 
+            else data[j] =  v1*(1.-f) + v2;
+	  }
+          else { // nts = 3
+	    if(j == it)       data[j] = v2*f;
+            if(j == it+1)     data[j] = v1*(1.-f) + v2*f;
+	    if(j == it+nts-1) data[j] = v1*(1.-f) + v2;
+	  }
+
+	} // end of local move of TS', now update...
+        cs = data;
+
+      } // end of rising edge or peak finding
+      if(nts < 3) it++; 
+      else it +=2;
     }
 
-    samples = data;
+    // final update of the shifted TS array 
+    cs = data;
   }
 }


### PR DESCRIPTION
NB: requires corresponding MC conditions update, an inclusion of new  HcalRespCorrs_v5.00_mc (instead of current v4.00) ,  a request is submitted to AlCa.

NB: "Bundled" with https://github.com/cms-sw/cmssw/pull/11100

This is an item from the list of HCAL updates agreed on at the "2015 early Physics Commissioning" Task Force,  see minites of the meeting
https://indico.cern.ch/event/442269/
"- digitization code"

Tests:
(1) Phil Harris' plots at https://indico.cern.ch/event/440669/
show improvements in MC (Method 2) fit comarison with data.

(2) single-pion Calorimetry scan comparison shows virtually unchnaged energy scale for
(i) new TimeSlewSim + reduced (HcalRespCorrs_v5.00_mc) HBHE scale in 760pre4 vs
(ii) regular 7_4_8 :

https://cms-cpt-software.web.cern.ch/cms-cpt-software/General/Validation/SVSuite/HCAL/calo_scan_single_pi/TimeSlewSim/760pre4_newTS_M2_RespCorr_v5_vs_748_fullGeom_postLS1_SinglePi/RecHitsTask_emean_vs_ieta_EH.gif
