### PR TITLE
migrate modules used by the HLT menu to multithreading (L1) (76x)

### DIFF
--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.cc
@@ -18,13 +18,22 @@
 #include "CondFormats/DataRecord/interface/L1JetEtScaleRcd.h"
 #include "CondFormats/DataRecord/interface/L1EmEtScaleRcd.h"
 #include "FWCore/Framework/interface/ESHandle.h"
-using namespace edm;
+
 using namespace std;
+using namespace edm;
 using namespace l1t;
 
 L1TCaloUpgradeToGCTConverter::L1TCaloUpgradeToGCTConverter(const ParameterSet& iConfig):
-    bxMin_(iConfig.getParameter<int>("bxMin")),
-    bxMax_(iConfig.getParameter<int>("bxMax"))
+    // register what you consume and keep token for later access:
+    EGammaToken_(   consumes<EGammaBxCollection>(iConfig.getParameter<InputTag>("InputCollection")) ),
+    RlxTauToken_(   consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputRlxTauCollection")) ),
+    IsoTauToken_(   consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputIsoTauCollection")) ),
+    JetToken_(      consumes<JetBxCollection>(iConfig.getParameter<InputTag>("InputCollection")) ),
+    EtSumToken_(    consumes<EtSumBxCollection>(iConfig.getParameter<InputTag>("InputCollection")) ),
+    HfSumsToken_(   consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFSumsCollection")) ),
+    HfCountsToken_( consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFCountsCollection")) ),
+    bxMin_(         iConfig.getParameter<int>("bxMin") ),
+    bxMax_(         iConfig.getParameter<int>("bxMax") )
 {
   produces<L1GctEmCandCollection>("isoEm");
   produces<L1GctEmCandCollection>("nonIsoEm");
@@ -41,28 +50,12 @@ L1TCaloUpgradeToGCTConverter::L1TCaloUpgradeToGCTConverter(const ParameterSet& i
   produces<L1GctInternHtMissCollection>();
   produces<L1GctHFBitCountsCollection>();
   produces<L1GctHFRingEtSumsCollection>();
-
-  // register what you consume and keep token for later access:
-  EGammaToken_ = consumes<EGammaBxCollection>(iConfig.getParameter<InputTag>("InputCollection"));
-  RlxTauToken_ = consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputRlxTauCollection"));
-  IsoTauToken_ = consumes<TauBxCollection>(iConfig.getParameter<InputTag>("InputIsoTauCollection"));
-  JetToken_ = consumes<JetBxCollection>(iConfig.getParameter<InputTag>("InputCollection"));
-  EtSumToken_ = consumes<EtSumBxCollection>(iConfig.getParameter<InputTag>("InputCollection"));
-  HfSumsToken_ = consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFSumsCollection"));
-  HfCountsToken_ = consumes<CaloSpareBxCollection>(iConfig.getParameter<edm::InputTag>("InputHFCountsCollection"));
 }
-
-
-L1TCaloUpgradeToGCTConverter::~L1TCaloUpgradeToGCTConverter()
-{
-}
-
-
 
 
 // ------------ method called to produce the data ------------
 void
-L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
+L1TCaloUpgradeToGCTConverter::produce(StreamID, Event& e, const EventSetup& es) const
 {
   LogDebug("l1t|stage 1 Converter") << "L1TCaloUpgradeToGCTConverter::produce function called...\n";
 
@@ -349,31 +342,6 @@ L1TCaloUpgradeToGCTConverter::produce(Event& e, const EventSetup& es)
   e.put(internalEtSumResult);
   e.put(internalHtMissResult);
 }
-
-// ------------ method called once each job just before starting event loop ------------
-void
-L1TCaloUpgradeToGCTConverter::beginJob()
-{
-}
-
-// ------------ method called once each job just after ending the event loop ------------
-void
-L1TCaloUpgradeToGCTConverter::endJob() {
-}
-
-// ------------ method called when starting to processes a run ------------
-
-void
-L1TCaloUpgradeToGCTConverter::beginRun(Run const&iR, EventSetup const&iE){
-
-}
-
-// ------------ method called when ending the processing of a run ------------
-void
-L1TCaloUpgradeToGCTConverter::endRun(Run const& iR, EventSetup const& iE){
-
-}
-
 
 // ------------ method fills 'descriptions' with the allowed parameters for the module ------------
 void

--- a/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.h
+++ b/L1Trigger/L1TCalorimeter/plugins/L1TCaloUpgradeToGCTConverter.h
@@ -18,7 +18,7 @@
 
 #include "FWCore/Framework/interface/EventSetup.h"
 #include "FWCore/Framework/interface/Frameworkfwd.h"
-#include "FWCore/Framework/interface/EDProducer.h"
+#include "FWCore/Framework/interface/global/EDProducer.h"
 #include "FWCore/Framework/interface/ESHandle.h"
 #include "FWCore/Framework/interface/Event.h"
 #include "FWCore/Framework/interface/MakerMacros.h"
@@ -43,35 +43,29 @@
 #include <vector>
 
 
+
 //
 // class declaration
 //
 
-  class L1TCaloUpgradeToGCTConverter : public edm::EDProducer {
-  public:
-    explicit L1TCaloUpgradeToGCTConverter(const edm::ParameterSet&);
-    ~L1TCaloUpgradeToGCTConverter();
+class L1TCaloUpgradeToGCTConverter : public edm::global::EDProducer<> {
+public:
+  explicit L1TCaloUpgradeToGCTConverter(const edm::ParameterSet&);
+  static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
-    static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
+private:
+  virtual void produce(edm::StreamID, edm::Event&, edm::EventSetup const&) const override;
 
-  private:
-    virtual void produce(edm::Event&, edm::EventSetup const&) override;
-    virtual void beginJob();
-    virtual void endJob();
-    virtual void beginRun(edm::Run const&iR, edm::EventSetup const&iE);
-    virtual void endRun(edm::Run const& iR, edm::EventSetup const& iE);
+  const edm::EDGetToken EGammaToken_;
+  const edm::EDGetToken RlxTauToken_;
+  const edm::EDGetToken IsoTauToken_;
+  const edm::EDGetToken JetToken_;
+  const edm::EDGetToken EtSumToken_;
+  const edm::EDGetToken HfSumsToken_;
+  const edm::EDGetToken HfCountsToken_;
 
-    edm::EDGetToken EGammaToken_;
-    edm::EDGetToken RlxTauToken_;
-    edm::EDGetToken IsoTauToken_;
-    edm::EDGetToken JetToken_;
-    edm::EDGetToken EtSumToken_;
-    edm::EDGetToken HfSumsToken_;
-    edm::EDGetToken HfCountsToken_;
-
-    int bxMin_;
-    int bxMax_;
-
-  };
+  const int bxMin_;
+  const int bxMax_;
+};
 
 #endif


### PR DESCRIPTION
- change all configuration parameters into const members
- initialise them in the member initializer list
- remove unused methods and member variables
- remove "using namespace" from header file
- change into a global::EDProducer
