### PR TITLE
Improved handling of slimmedGenJets in JetFlavour and GenHFHadronMatcher

### DIFF
--- a/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
+++ b/PhysicsTools/JetMCAlgos/plugins/JetFlavourClustering.cc
@@ -301,6 +301,10 @@ JetFlavourClustering::produce(edm::Event& iEvent, const edm::EventSetup& iSetup)
      for( m = constituents.begin(); m != constituents.end(); ++m )
      {
        reco::CandidatePtr constit = *m;
+       if(!constit.isNonnull() || !constit.isAvailable()) {
+         edm::LogError("MissingJetConstituent") << "Jet constituent required for jet reclustering is missing. Reclustered jets are not guaranteed to reproduce the original jets!";
+         continue;
+       }
        if(constit->pt() == 0)
        {
          edm::LogWarning("NullTransverseMomentum") << "dropping input candidate with pt=0";

--- a/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.py
+++ b/PhysicsTools/JetMCAlgos/test/matchGenHFHadrons.py
@@ -26,7 +26,7 @@ process.options = cms.untracked.PSet(
 ## configure message logger
 process.load("FWCore.MessageLogger.MessageLogger_cfi")
 process.MessageLogger.cerr.threshold = 'INFO'
-process.MessageLogger.cerr.FwkReport.reportEvery = 1000
+process.MessageLogger.cerr.FwkReport.reportEvery = 100
 
 ## define input
 if options.runOnAOD:
@@ -58,30 +58,30 @@ process.maxEvents = cms.untracked.PSet(
     input = cms.untracked.int32(1000)
 )
 
-# Setting input particle collections to be used by the tools
+# Setting input particle/jet collections to be used by the tools
 genParticleCollection = ''
-genJetInputParticleCollection = ''
 genJetCollection = 'ak4GenJetsCustom'
+
 if options.runOnAOD:
     genParticleCollection = 'genParticles'
-    genJetInputParticleCollection = 'genParticlesForJets'
-    ## producing a subset of genParticles to be used for jet clustering in AOD
-    from RecoJets.Configuration.GenJetParticles_cff import genParticlesForJets
-    process.genParticlesForJets = genParticlesForJets.clone()
+    ## producing a subset of genParticles to be used for jet reclustering
+    from RecoJets.Configuration.GenJetParticles_cff import genParticlesForJetsNoNu
+    process.genParticlesForJetsCustom = genParticlesForJetsNoNu.clone(
+        src = genParticleCollection
+    )
+    # Producing own jets for testing purposes
+    from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
+    process.ak4GenJetsCustom = ak4GenJets.clone(
+        src = 'genParticlesForJetsCustom',
+        rParam = cms.double(0.4),
+        jetAlgorithm = cms.string("AntiKt")
+    )
 else:
     genParticleCollection = 'prunedGenParticles'
-    genJetInputParticleCollection = 'packedGenParticles'
+    genJetCollection = 'slimmedGenJets'
 
 # Supplies PDG ID to real name resolution of MC particles
 process.load("SimGeneral.HepPDTESSource.pythiapdt_cfi")
-
-# Producing own jets for testing purposes
-from RecoJets.JetProducers.ak4GenJets_cfi import ak4GenJets
-process.ak4GenJetsCustom = ak4GenJets.clone(
-    src = genJetInputParticleCollection,
-    rParam = cms.double(0.4),
-    jetAlgorithm = cms.string("AntiKt")
-)
 
 # Ghost particle collection used for Hadron-Jet association 
 # MUST use proper input particle collection
@@ -98,7 +98,6 @@ from PhysicsTools.JetMCAlgos.AK4PFJetsMCFlavourInfos_cfi import ak4JetFlavourInf
 process.genJetFlavourInfos = ak4JetFlavourInfos.clone(
     jets = genJetCollection,
 )
-
 
 # Plugin for analysing B hadrons
 # MUST use the same particle collection as in selectedHadronsAndPartons


### PR DESCRIPTION
- Protected **JetFlavour** tool against missing jet constituents in **miniAOD**. No crashes any more.
- Switched off jet reclustering in the test configuration of **GenHFHadronMatcher** in **miniAOD**.
  - Excluded neutrinos from reclustered jets in **AOD** to match the ones in **miniAOD**.
