### PR TITLE
Updated Method3 with new time slew parametrization and response correction for data and MC

### DIFF
--- a/CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h
+++ b/CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h
@@ -19,13 +19,13 @@ class HcalTimeSlew {
  public:
   enum ParaSource { TestStand=0, Data=1, MC=2, InputPars=3 };
   enum BiasSetting { Slow=0, Medium=1, Fast=2 };
-  static constexpr double tspar[2] = {9.27638, -2.05585};
+  static constexpr double tspar[3] = {12.2999, -2.19142,0};
   
   /** \brief Returns the amount (ns) by which a pulse of the given
    number of fC will be delayed by the timeslew effect, for the
    specified bias setting. */
   static double delay(double fC, BiasSetting bias=Medium);
-  static double delay(double fC, ParaSource source=TestStand, BiasSetting bias=Medium, double par0=tspar[0], double par1=tspar[1]);
+  static double delay(double fC, ParaSource source=InputPars, BiasSetting bias=Medium, double par0=tspar[0], double par1=tspar[1], double par2=tspar[2]);
 };
 
 #endif

--- a/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
+++ b/CalibCalorimetry/HcalAlgos/src/HcalTimeSlew.cc
@@ -5,24 +5,25 @@ static const double tzero[3]= {23.960177, 13.307784, 9.109694};
 static const double slope[3] = {-3.178648,  -1.556668, -1.075824 };
 static const double tmax[3] = {16.00, 10.00, 6.25 };
 static const double cap = 6.0;
-static const double tspar0[2] = {10.2627, 9.27638};
-static const double tspar1[2] = {-2.41281,-2.05585};
+static const double tspar0[2] = {15.5, 12.2999};
+static const double tspar1[2] = {-3.2,-2.19142};
+static const double tspar2[2] = {32,0};
 
 double HcalTimeSlew::delay(double fC, BiasSetting bias) {
   double rawDelay=tzero[bias]+slope[bias]*log(fC);
   return (rawDelay<0)?(0):((rawDelay>tmax[bias])?(tmax[bias]):(rawDelay));			   
 }
 
-double HcalTimeSlew::delay(double fC, ParaSource source, BiasSetting bias, double par0, double par1) {
+double HcalTimeSlew::delay(double fC, ParaSource source, BiasSetting bias, double par0, double par1, double par2) {
 
   if (source==TestStand) {
     return HcalTimeSlew::delay(fC, bias);
   }
   else if (source==InputPars) {
-    return std::min(cap, par0 + par1*log(fC));
+    return std::min(cap, par0 + par1*log(fC+par2));
   }
   else if (source==Data || source==MC){
-    return std::min(cap,tspar0[source-1]+tspar1[source-1]*log(fC));
+    return std::min(cap,tspar0[source-1]+tspar1[source-1]*log(fC+tspar2[source-1]));
   }
   return 0;
 }

--- a/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
+++ b/HLTrigger/Configuration/python/customizeHLTforCMSSW.py
@@ -128,6 +128,14 @@ def customiseFor10927(process):
             process.DTObjectMapESProducer = cms.ESProducer( 'DTObjectMapESProducer' )
     return process
 
+# update Method3 with new time slew parametrization and response correction for data and MC (PR #11091)
+def customizeFor11091(process):
+    if hasattr(process, 'hltHbhereco'):
+        process.hltHbhereco.timeSlewParsType = cms.int32( 3 )
+        process.hltHbhereco.timeSlewPars     = cms.vdouble( 15.5, -3.2, 32, 15.5, -3.2, 32, 15.5, -3.2, 32 )
+        process.hltHbhereco.respCorrM3       = cms.double( 0.95 )
+    return process
+
 # CMSSW version specific customizations
 def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
     import os
@@ -144,6 +152,7 @@ def customiseHLTforCMSSW(process, menuType="GRun", fastSim=False):
         process = customiseFor7794(process)
         process = customiseFor10087(process)
         process = customizeHLTforNewJetCorrectors(process)
+        process = customizeFor11091(process)
     if cmsswVersion >= "CMSSW_7_4":
         process = customiseFor10234(process)
 

--- a/HLTrigger/Configuration/python/customizeHLTforMC.py
+++ b/HLTrigger/Configuration/python/customizeHLTforMC.py
@@ -18,6 +18,13 @@ def customizeHLTforMC(process,_fastSim=False):
     process.hltParticleFlowRecHitHCAL.ApplyPulseDPG      = cms.bool(False)
     process.hltParticleFlowRecHitHCAL.LongShortFibre_Cut = cms.double(1000000000.0)
 
+  # customise hltHbhereco to use the Method 3 parametrisation for Monte Carlo (see #11091)
+  if 'hltHbhereco' in process.__dict__:
+    process.hltHbhereco.timeSlewParsType = cms.int32( 3 )
+    process.hltHbhereco.timeSlewPars     = cms.vdouble( 12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0 )
+    process.hltHbhereco.respCorrM3       = cms.double( 0.95 )
+
+
   if _fastSim:
 
     fastsim = cms.ProcessFragment( process.name_() )

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
@@ -7,18 +7,10 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/PedestalSub.h"
 
-//#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoder.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
-//#include "DataFormats/HcalDigi/interface/HcalUpgradeDataFrame.h"
-//#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
-//#include "DataFormats/HcalDigi/interface/HFDataFrame.h"
-//#include "DataFormats/HcalDigi/interface/HODataFrame.h"
-//#include "DataFormats/HcalDigi/interface/ZDCDataFrame.h"
-//#include "DataFormats/HcalDigi/interface/HcalCalibDataFrame.h"
-
 
 class HcalDeterministicFit {
  public:

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h
@@ -7,26 +7,26 @@
 #include "CalibCalorimetry/HcalAlgos/interface/HcalTimeSlew.h"
 #include "RecoLocalCalo/HcalRecAlgos/interface/PedestalSub.h"
 
-#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
+//#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
 #include "DataFormats/HcalDetId/interface/HcalDetId.h"
 #include "CalibCalorimetry/HcalAlgos/interface/HcalPulseShapes.h"
 #include "CalibFormats/HcalObjects/interface/HcalCoder.h"
 #include "CalibFormats/HcalObjects/interface/HcalCalibrations.h"
-#include "DataFormats/HcalDigi/interface/HcalUpgradeDataFrame.h"
-#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
-#include "DataFormats/HcalDigi/interface/HFDataFrame.h"
-#include "DataFormats/HcalDigi/interface/HODataFrame.h"
-#include "DataFormats/HcalDigi/interface/ZDCDataFrame.h"
-#include "DataFormats/HcalDigi/interface/HcalCalibDataFrame.h"
+//#include "DataFormats/HcalDigi/interface/HcalUpgradeDataFrame.h"
+//#include "DataFormats/HcalDigi/interface/HBHEDataFrame.h"
+//#include "DataFormats/HcalDigi/interface/HFDataFrame.h"
+//#include "DataFormats/HcalDigi/interface/HODataFrame.h"
+//#include "DataFormats/HcalDigi/interface/ZDCDataFrame.h"
+//#include "DataFormats/HcalDigi/interface/HcalCalibDataFrame.h"
 
 
 class HcalDeterministicFit {
  public:
-  enum NegStrategy {DoNothing=0, ReqPos=1, FromGreg=2};  
+  enum NegStrategy {DoNothing=0, MoveCharge=1, MoveTiming=2};  
   HcalDeterministicFit();
   ~HcalDeterministicFit();
 
-  void init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, NegStrategy nStrat, PedestalSub pedSubFxn_, std::vector<double> pars);
+  void init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, NegStrategy nStrat, PedestalSub pedSubFxn_, std::vector<double> pars, double respCorr);
 
   // This is the CMSSW Implementation of the apply function
   template<class Digi>
@@ -39,13 +39,15 @@ class HcalDeterministicFit {
   NegStrategy fNegStrat;
   PedestalSub fPedestalSubFxn_;
 
-  double fpars[6];
+  double fpars[9];
+  double frespCorr;
  
   static constexpr int HcalRegion[2] = {16, 17};
-  static constexpr int tswidth = 25;
-  static constexpr float negthre[2] = {-3., 15.};
+  static constexpr int tsWidth = 25;
+  static constexpr float negThresh[2] = {-3., 15.};
   static constexpr float invGpar[3] = {-13.11, 11.29, 5.133};
-  static constexpr float landauFrac[] {0, 7.6377e-05, 0.000418655, 0.00153692, 0.00436844, 0.0102076, 
+  static constexpr float rCorr[2] = {0.95, 0.95};
+  static constexpr float landauFrac[] = {0, 7.6377e-05, 0.000418655, 0.00153692, 0.00436844, 0.0102076, 
   0.0204177, 0.0360559, 0.057596, 0.0848493, 0.117069, 0.153152, 0.191858, 0.23198, 0.272461, 0.312438, 
   0.351262, 0.388476, 0.423788, 0.457036, 0.488159, 0.517167, 0.54412, 0.569112, 0.592254, 0.613668, 
   0.633402, 0.651391, 0.667242, 0.680131, 0.688868, 0.692188, 0.689122, 0.67928, 0.662924, 0.64087, 
@@ -67,6 +69,7 @@ void HcalDeterministicFit::apply(const CaloSamples & cs, const std::vector<int> 
   std::vector<double> inputCharge;
   std::vector<double> inputPedestal;
   double gainCorr = 0;
+  double respCorr = 0;
 
   for(int ip=0; ip<cs.size(); ip++){
     const int capid = capidvec[ip];
@@ -81,68 +84,77 @@ void HcalDeterministicFit::apply(const CaloSamples & cs, const std::vector<int> 
   fPedestalSubFxn_.calculate(inputCharge, inputPedestal, corrCharge);
 
   const HcalDetId& cell = digi.id();
-  double fpar0, fpar1;
+  double fpar0, fpar1, fpar2;
   if(std::abs(cell.ieta())<HcalRegion[0]){
     fpar0 = fpars[0];
     fpar1 = fpars[1];
+    fpar2 = fpars[2];
   }else if(std::abs(cell.ieta())==HcalRegion[0]||std::abs(cell.ieta())==HcalRegion[1]){
-    fpar0 = fpars[2];
-    fpar1 = fpars[3];
+    fpar0 = fpars[3];
+    fpar1 = fpars[4];
+    fpar2 = fpars[5];
   }else{
-    fpar0 = fpars[4];
-    fpar1 = fpars[5];
+    fpar0 = fpars[6];
+    fpar1 = fpars[7];
+    fpar2 = fpars[8];
   }
 
-  float tsShift3=HcalTimeSlew::delay(inputCharge[3],fTimeSlew,fTimeSlewBias, fpar0, fpar1);
-  float tsShift4=HcalTimeSlew::delay(inputCharge[4],fTimeSlew,fTimeSlewBias, fpar0, fpar1);
-  float tsShift5=HcalTimeSlew::delay(inputCharge[5],fTimeSlew,fTimeSlewBias, fpar0, fpar1);
+  if (fTimeSlew==0)respCorr=1.0;
+  else if (fTimeSlew==1)respCorr=rCorr[0];
+  else if (fTimeSlew==2)respCorr=rCorr[1];
+  else if (fTimeSlew==3)respCorr=frespCorr;
+  
+
+  float tsShift3=HcalTimeSlew::delay(inputCharge[3],fTimeSlew,fTimeSlewBias, fpar0, fpar1 ,fpar2);
+  float tsShift4=HcalTimeSlew::delay(inputCharge[4],fTimeSlew,fTimeSlewBias, fpar0, fpar1 ,fpar2);
+  float tsShift5=HcalTimeSlew::delay(inputCharge[5],fTimeSlew,fTimeSlewBias, fpar0, fpar1 ,fpar2);
 
   float i3=0;
-  getLandauFrac(-tsShift3,-tsShift3+tswidth,i3);
+  getLandauFrac(-tsShift3,-tsShift3+tsWidth,i3);
   float n3=0;
-  getLandauFrac(-tsShift3+tswidth,-tsShift3+tswidth*2,n3);
+  getLandauFrac(-tsShift3+tsWidth,-tsShift3+tsWidth*2,n3);
   float nn3=0;
-  getLandauFrac(-tsShift3+tswidth*2,-tsShift3+tswidth*3,nn3);
+  getLandauFrac(-tsShift3+tsWidth*2,-tsShift3+tsWidth*3,nn3);
 
   float i4=0;
-  getLandauFrac(-tsShift4,-tsShift4+tswidth,i4);
+  getLandauFrac(-tsShift4,-tsShift4+tsWidth,i4);
   float n4=0;
-  getLandauFrac(-tsShift4+tswidth,-tsShift4+tswidth*2,n4);
+  getLandauFrac(-tsShift4+tsWidth,-tsShift4+tsWidth*2,n4);
 
   float i5=0;
-  getLandauFrac(-tsShift5,-tsShift5+tswidth,i5);
+  getLandauFrac(-tsShift5,-tsShift5+tsWidth,i5);
   float n5=0;
-  getLandauFrac(-tsShift5+tswidth,-tsShift5+tswidth*2,n5);
+  getLandauFrac(-tsShift5+tsWidth,-tsShift5+tsWidth*2,n5);
 
   float ch3=corrCharge[3]/i3;
   float ch4=(i3*corrCharge[4]-n3*corrCharge[3])/(i3*i4);
   float ch5=(n3*n4*corrCharge[3]-i4*nn3*corrCharge[3]-i3*n4*corrCharge[4]+i3*i4*corrCharge[5])/(i3*i4*i5);
 
-  if (ch3<negthre[0] && fNegStrat==HcalDeterministicFit::ReqPos) {
-    ch3=negthre[0];
+  if (ch3<negThresh[0] && fNegStrat==HcalDeterministicFit::MoveCharge) {
+    ch3=negThresh[0];
     ch4=corrCharge[4]/i4;
     ch5=(i4*corrCharge[5]-n4*corrCharge[4])/(i4*i5);
   }
 
-  if (ch5<negthre[0] && fNegStrat==HcalDeterministicFit::ReqPos) {
-    ch4=ch4+(ch5-negthre[0]);
-    ch5=negthre[0];
+  if (ch5<negThresh[0] && fNegStrat==HcalDeterministicFit::MoveCharge) {
+    ch4=ch4+(ch5-negThresh[0]);
+    ch5=negThresh[0];
   }
 
-  if (fNegStrat==HcalDeterministicFit::FromGreg) {
-    if (ch3<negthre[0]) {
-      ch3=negthre[0];
+  if (fNegStrat==HcalDeterministicFit::MoveTiming) {
+    if (ch3<negThresh[0]) {
+      ch3=negThresh[0];
       ch4=corrCharge[4]/i4;
       ch5=(i4*corrCharge[5]-n4*corrCharge[4])/(i4*i5);
     }
-    if (ch5<negthre[0] && ch4>negthre[1]) {
-      double ratio = (corrCharge[4]-ch3*i3)/(corrCharge[5]-negthre[0]*i5);
+    if (ch5<negThresh[0] && ch4>negThresh[1]) {
+      double ratio = (corrCharge[4]-ch3*i3)/(corrCharge[5]-negThresh[0]*i5);
       if (ratio < 5 && ratio > 0.5) {
         double invG = invGpar[0]+invGpar[1]*std::sqrt(2*std::log(invGpar[2]/ratio));
         float iG=0;
-        getLandauFrac(-invG,-invG+tswidth,iG);
+        getLandauFrac(-invG,-invG+tsWidth,iG);
         ch4=(corrCharge[4]-ch3*n3)/(iG);
-        ch5=negthre[0];
+        ch5=negThresh[0];
         tsShift4=invG;
       }
     }
@@ -158,7 +170,7 @@ void HcalDeterministicFit::apply(const CaloSamples & cs, const std::vector<int> 
     ch5=0;
   }
   Output.clear();
-  Output.push_back(ch4*gainCorr);// amplitude 
+  Output.push_back(ch4*gainCorr*respCorr);// amplitude 
   Output.push_back(tsShift4); // time shift of in-time pulse
   Output.push_back(ch5); // whatever
 

--- a/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
+++ b/RecoLocalCalo/HcalRecAlgos/interface/HcalSimpleRecAlgo.h
@@ -87,7 +87,7 @@ public:
 		       double iTS4Min, double iTS4Max, double iPulseJitter,double iTimeMean,double iTimeSig,double iPedMean,double iPedSig,
 		       double iNoise,double iTMin,double iTMax,
 		       double its3Chi2,double its4Chi2,double its345Chi2,double iChargeThreshold, int iFitTimes); 
-  void setMeth3Params(int iPedSubMethod, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars);
+  void setMeth3Params(int iPedSubMethod, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3);
                
   std::auto_ptr<PedestalSub> pedSubFxn_= std::auto_ptr<PedestalSub>(new PedestalSub());
   

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalDeterministicFit.cc
@@ -3,10 +3,6 @@
 #include <climits>
 #include "RecoLocalCalo/HcalRecAlgos/interface/HcalDeterministicFit.h"
 
-constexpr float HcalDeterministicFit::invGpar[3];
-constexpr float HcalDeterministicFit::negthre[2];
-constexpr int HcalDeterministicFit::HcalRegion[2];
-
 using namespace std;
 
 HcalDeterministicFit::HcalDeterministicFit() {
@@ -15,8 +11,8 @@ HcalDeterministicFit::HcalDeterministicFit() {
 HcalDeterministicFit::~HcalDeterministicFit() { 
 }
 
-void HcalDeterministicFit::init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, NegStrategy nStrat, PedestalSub pedSubFxn_, std::vector<double> pars) {
-  for(int fi=0; fi<6; fi++){
+void HcalDeterministicFit::init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::BiasSetting bias, NegStrategy nStrat, PedestalSub pedSubFxn_, std::vector<double> pars, double respCorr) {
+  for(int fi=0; fi<9; fi++){
 	fpars[fi] = pars.at(fi);
   }
 
@@ -24,6 +20,7 @@ void HcalDeterministicFit::init(HcalTimeSlew::ParaSource tsParam, HcalTimeSlew::
   fTimeSlewBias=bias;
   fNegStrat=nStrat;
   fPedestalSubFxn_=pedSubFxn_;
+  frespCorr=respCorr;
 }
 
 constexpr float HcalDeterministicFit::landauFrac[];
@@ -33,10 +30,10 @@ constexpr float HcalDeterministicFit::landauFrac[];
 // normalized to 1 on [0,10000]
 void HcalDeterministicFit::getLandauFrac(float tStart, float tEnd, float &sum) const{
 
-  if (std::abs(tStart-tEnd-tswidth)<0.1) {
+  if (std::abs(tStart-tEnd-tsWidth)<0.1) {
     sum=0;
     return;
   }
-  sum= landauFrac[int(ceil(tStart+tswidth))];
+  sum= landauFrac[int(ceil(tStart+tsWidth))];
   return;
 }

--- a/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
+++ b/RecoLocalCalo/HcalRecAlgos/src/HcalSimpleRecAlgo.cc
@@ -70,10 +70,10 @@ void HcalSimpleRecAlgo::setpuCorrParams(bool   iPedestalConstraint, bool iTimeCo
 //  psFitOOTpuCorr_->setPulseShapeTemplate(theHcalPulseShapes_.getShape(shapeNum));
 }
 
-void HcalSimpleRecAlgo::setMeth3Params(int iPedSubMethod, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars) {
+void HcalSimpleRecAlgo::setMeth3Params(int iPedSubMethod, float iPedSubThreshold, int iTimeSlewParsType, std::vector<double> iTimeSlewPars, double irespCorrM3) {
 
   pedSubFxn_->init(((PedestalSub::Method)iPedSubMethod), 0, iPedSubThreshold, 0.0);
-  hltOOTpuCorr_->init((HcalTimeSlew::ParaSource)iTimeSlewParsType, HcalTimeSlew::Medium, (HcalDeterministicFit::NegStrategy)2, *pedSubFxn_, iTimeSlewPars);
+  hltOOTpuCorr_->init((HcalTimeSlew::ParaSource)iTimeSlewParsType, HcalTimeSlew::Medium, (HcalDeterministicFit::NegStrategy)2, *pedSubFxn_, iTimeSlewPars,irespCorrM3);
 }
 
 void HcalSimpleRecAlgo::setForData (int runnum) { 

--- a/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
+++ b/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py
@@ -130,9 +130,10 @@ hbheprereco = cms.EDProducer(
     ts345chi2             = cms.double(100.), #chi2 (not used)
     chargeMax             = cms.double(6.),    #Charge cut (fC) for uncstrianed Fit 
     fitTimes              = cms.int32(1),       # -1 means no constraint on number of fits per channel
-    # add some of the Method 3 parameters here
+    # Configuration parameters for Method 3
     pedestalSubtractionType = cms.int32(1),
     pedestalUpperLimit      = cms.double(2.7),
-    timeSlewParsType        = cms.int32(3), # 0: TestStand, 1:Data, 2:MC, 3:InputPars. Parametrization function is par0 + par1*log(fC). Default value is par0 = 9.27638, par1 = -2.05585.
-    timeSlewPars            = cms.vdouble(9.27638, -2.05585, 9.27638, -2.05585, 9.27638, -2.05585)# HB par0, HB par1, BE par0, BE par1, HE par0, HEpar1
+    timeSlewParsType        = cms.int32(1), # 0: TestStand, 1:Data, 2:MC, 3:InputPars. Parametrization function is par0 + par1*log(fC+par2).
+    timeSlewPars            = cms.vdouble(15.5, -3.2, 32, 15.5, -3.2, 32, 15.5, -3.2, 32),# HB par0, HB par1, HB par2, BE par0, BE par1, BE par2, HE par0, HE par1, HE par2
+    respCorrM3              = cms.double(0.95)# This factor is used to align the the Method3 with the Method2 response
     )

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -275,21 +275,13 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
               conf.getParameter<int>     ("pedestalSubtractionType"),
               conf.getParameter<double>  ("pedestalUpperLimit"),
               conf.getParameter<int>     ("timeSlewParsType"),
-              conf.getParameter<std::vector<double> >("timeSlewPars")
+              conf.getParameter<std::vector<double> >("timeSlewPars"),
+	      conf.getParameter<double>  ("respCorrM3")
               );
   }
 
 }
 
-void HcalHitReconstructor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
-  edm::ParameterSetDescription desc;
-  desc.setAllowAnything();
-  desc.add<int>("pedestalSubtractionType", 1); 
-  desc.add<double>("pedestalUpperLimit", 2.7); 
-  desc.add<int>("timeSlewParsType",3);
-  desc.add<std::vector<double>>("timeSlewPars", {9.27638, -2.05585, 9.27638, -2.05585, 9.27638, -2.05585});
-  descriptions.add("hltHbhereco",desc);
-}
 
 HcalHitReconstructor::~HcalHitReconstructor() {
   delete hbheFlagSetter_;

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.cc
@@ -282,6 +282,17 @@ HcalHitReconstructor::HcalHitReconstructor(edm::ParameterSet const& conf):
 
 }
 
+void HcalHitReconstructor::fillDescriptions(edm::ConfigurationDescriptions& descriptions) {
+  edm::ParameterSetDescription desc;
+  desc.setAllowAnything();
+  desc.add<int>("pedestalSubtractionType", 1); 
+  desc.add<double>("pedestalUpperLimit", 2.7); 
+  desc.add<int>("timeSlewParsType",3);
+  desc.add<std::vector<double>>("timeSlewPars", {15.5, -3.2, 32, 15.5, -3.2, 32, 15.5, -3.2, 32});
+  desc.add<double>("respCorrM3", 0.95);
+  descriptions.add("hltHbhereco",desc);
+}
+
 
 HcalHitReconstructor::~HcalHitReconstructor() {
   delete hbheFlagSetter_;

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
@@ -51,6 +51,7 @@ class HcalTopology;
       virtual void beginRun(edm::Run const&r, edm::EventSetup const & es) override final;
       virtual void endRun(edm::Run const&r, edm::EventSetup const & es) override final;
       virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
+      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
 
     private:      
       typedef void (HcalSimpleRecAlgo::*SetCorrectionFcn)(boost::shared_ptr<AbsOOTPileupCorrection>);

--- a/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
+++ b/RecoLocalCalo/HcalRecProducers/src/HcalHitReconstructor.h
@@ -52,7 +52,6 @@ class HcalTopology;
       virtual void endRun(edm::Run const&r, edm::EventSetup const & es) override final;
       virtual void produce(edm::Event& e, const edm::EventSetup& c) override;
 
-      static void fillDescriptions(edm::ConfigurationDescriptions& descriptions);
     private:      
       typedef void (HcalSimpleRecAlgo::*SetCorrectionFcn)(boost::shared_ptr<AbsOOTPileupCorrection>);
 


### PR DESCRIPTION
As agreed at the "2015 early Physics Commissioning" Task Force, see minutes of the meeting https://indico.cern.ch/event/442070/, Method3 has been updated with 
- new time slew parametrization for data (now calculated from data, previously the MC parametrization has been used)
- new time slew parametrization for MC to account for the differences due to the new time slew simulation, see PR#11071 (https://github.com/cms-sw/cmssw/pull/11071)
- response correction factors for data and MC to account for the differences between Method2 and Method3
  For details see:
  https://indico.cern.ch/event/442269/attachments/1148344/1647233/2015_09_02_newTimeSlew_m3m2.pdf

This PR is expected to fail the tests

@fwyzard 
please include the new parameters which have been added to HBHE local reco configuration https://github.com/kfiekas/cmssw/blob/Method3TimeSlewParUpdate/RecoLocalCalo/HcalRecProducers/python/HcalHitReconstructor_hbhe_cfi.py#L136-L138 to the HLT configuration

For data the parameters have to be set to:

timeSlewParsType = cms.int32(3)
timeSlewPars = cms.vdouble(15.5, -3.2, 32, 15.5, -3.2, 32, 15.5, -3.2, 32)
respCorrM3 = cms.double(0.95)

for MC  the parameters have to be set to:
timeSlewParsType = cms.int32(3)
timeSlewPars = cms.vdouble(12.2999, -2.19142, 0, 12.2999, -2.19142, 0, 12.2999, -2.19142, 0)
respCorrM3 = cms.double(0.95)
