### PR TITLE
Appy event filter before data prefetching for OutputModules

### DIFF
--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -25,6 +25,8 @@ output stream.
 
 #include "FWCore/ParameterSet/interface/ParameterSetfwd.h"
 
+#include "FWCore/Utilities/interface/EDGetToken.h"
+
 #include <array>
 #include <memory>
 #include <string>
@@ -94,7 +96,7 @@ namespace edm {
     // need to clean up the use of Event and EventPrincipal, to avoid
     // creation of multiple Event objects when handling a single
     // event.
-    Trig getTriggerResults(EventPrincipal const& ep, ModuleCallingContext const*) const;
+    Trig getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventPrincipal const& ep, ModuleCallingContext const*) const;
 
     ModuleDescription const& description() const;
     ModuleDescription const& moduleDescription() const { return moduleDescription_;

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -104,7 +104,7 @@ namespace edm {
 
     ParameterSetID selectorConfig() const { return selector_config_id_; }
 
-    void doPreallocate(PreallocationConfiguration const&) {}
+    void doPreallocate(PreallocationConfiguration const&);
 
     void doBeginJob();
     void doEndJob();
@@ -158,9 +158,10 @@ namespace edm {
     ModuleDescription moduleDescription_;
 
     bool wantAllEvents_;
-    mutable detail::TriggerResultsBasedEventSelector selectors_;
+    std::vector<detail::TriggerResultsBasedEventSelector> selectors_;
     // ID of the ParameterSet that configured the event selector
     // subsystem.
+    ParameterSet selectEvents_;
     ParameterSetID selector_config_id_;
 
     // needed because of possible EDAliases.

--- a/FWCore/Framework/interface/OutputModule.h
+++ b/FWCore/Framework/interface/OutputModule.h
@@ -209,6 +209,8 @@ namespace edm {
     virtual void reallyCloseFile();
 
     void registerProductsAndCallbacks(OutputModule const*, ProductRegistry const*) {}
+    
+    bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
 
     /// Ask the OutputModule if we should end the current file.
     virtual bool shouldWeCloseFile() const {return false;}

--- a/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
+++ b/FWCore/Framework/interface/TriggerResultsBasedEventSelector.h
@@ -75,8 +75,6 @@ namespace edm
 
       bool wantEvent(EventPrincipal const& e, ModuleCallingContext const*);
 
-      handle_t getOneTriggerResults(EventPrincipal const& e, ModuleCallingContext const*);
-
       // Clear the cache
       void clear();
 
@@ -87,10 +85,6 @@ namespace edm
       // interested in.
       size_type fill(EventPrincipal const& ev, ModuleCallingContext const*);
       
-      // If we have only one handle cached, return it; otherwise throw.
-      handle_t returnOneHandleOrThrow();
-
-
       bool        fillDone_;
       size_type   numberFound_;
       selectors_t selectors_;

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -61,8 +61,6 @@ namespace edm {
 
   namespace one {
     
-    typedef detail::TriggerResultsBasedEventSelector::handle_t Trig;
-    
     class OutputModuleBase : public EDConsumerBase {
     public:
       template <typename U> friend class edm::maker::ModuleHolderT;
@@ -108,8 +106,6 @@ namespace edm {
         return moduleDescription_;
       }
     protected:
-      
-      Trig getTriggerResults(EventPrincipal const& ep, ModuleCallingContext const*) const;
       
       ModuleDescription const& description() const;
       

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -215,6 +215,7 @@ namespace edm {
       
       void registerProductsAndCallbacks(OutputModuleBase const*, ProductRegistry const*) {}
 
+      bool prePrefetchSelection(StreamID id, EventPrincipal const&, ModuleCallingContext const*);
       
       // Do the end-of-file tasks; this is only called internally, after
       // the appropriate tests have been done.

--- a/FWCore/Framework/interface/one/OutputModuleBase.h
+++ b/FWCore/Framework/interface/one/OutputModuleBase.h
@@ -111,7 +111,7 @@ namespace edm {
       
       ParameterSetID selectorConfig() const { return selector_config_id_; }
 
-      void doPreallocate(PreallocationConfiguration const&) {}
+      void doPreallocate(PreallocationConfiguration const&);
 
       void doBeginJob();
       void doEndJob();
@@ -165,7 +165,8 @@ namespace edm {
       ModuleDescription moduleDescription_;
       
       bool wantAllEvents_;
-      mutable detail::TriggerResultsBasedEventSelector selectors_;
+      std::vector<detail::TriggerResultsBasedEventSelector> selectors_;
+      ParameterSet selectEvents_;
       // ID of the ParameterSet that configured the event selector
       // subsystem.
       ParameterSetID selector_config_id_;

--- a/FWCore/Framework/src/OutputModule.cc
+++ b/FWCore/Framework/src/OutputModule.cc
@@ -16,6 +16,7 @@
 #include "FWCore/Framework/interface/OutputModuleDescription.h"
 #include "FWCore/Framework/interface/TriggerNamesService.h"
 #include "FWCore/Framework/src/EventSignalsSentry.h"
+#include "FWCore/Framework/interface/PrincipalGetAdapter.h"
 #include "FWCore/ParameterSet/interface/ConfigurationDescriptions.h"
 #include "FWCore/ParameterSet/interface/ParameterSet.h"
 #include "FWCore/ParameterSet/interface/ParameterSetDescription.h"
@@ -182,10 +183,14 @@ namespace edm {
   }
 
 
-  Trig OutputModule::getTriggerResults(EventPrincipal const& ep, ModuleCallingContext const* mcc) const {
-    return selectors_.getOneTriggerResults(ep, mcc);  }
-
-  namespace {
+  Trig OutputModule::getTriggerResults(EDGetTokenT<TriggerResults> const& token, EventPrincipal const& ep, ModuleCallingContext const* mcc) const {
+    //This cast is safe since we only call const functions of the EventPrincipal after this point
+    PrincipalGetAdapter adapter(const_cast<EventPrincipal&>(ep), moduleDescription_);
+    adapter.setConsumer(this);
+    Trig result;
+    auto bh = adapter.getByToken_(TypeID(typeid(TriggerResults)),PRODUCT_TYPE, token, mcc);
+    convert_handle(std::move(bh), result);
+    return result;
   }
 
   bool

--- a/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
+++ b/FWCore/Framework/src/TriggerResultsBasedEventSelector.cc
@@ -187,13 +187,6 @@ namespace edm
 	}
     }
 
-    TriggerResultsBasedEventSelector::handle_t
-    TriggerResultsBasedEventSelector::getOneTriggerResults(EventPrincipal const& ev, ModuleCallingContext const* mcc)
-    {
-      fill(ev, mcc);
-      return returnOneHandleOrThrow();
-    }
-
     bool
     TriggerResultsBasedEventSelector::wantEvent(EventPrincipal const& ev, ModuleCallingContext const* mcc)
     {
@@ -219,30 +212,6 @@ namespace edm
       return match_found;
     }
     
-    TriggerResultsBasedEventSelector::handle_t
-    TriggerResultsBasedEventSelector::returnOneHandleOrThrow()
-    {
-      switch (numberFound_)
-	{
-	case 0:
-	  throw edm::Exception(edm::errors::ProductNotFound,
-			       "TooFewProducts")
-	    << "TriggerResultsBasedEventSelector::returnOneHandleOrThrow: "
-	    << " too few products found, "
-	    << "exepcted one, got zero\n";
-	case 1:
-
-	  break;
-	default:
-	  throw edm::Exception(edm::errors::ProductNotFound,
-			       "TooManyMatches")
-	    << "TriggerResultsBasedEventSelector::returnOneHandleOrThrow: "
-	    << "too many products found, "
-	    << "expected one, got " << numberFound_ << '\n';
-	}
-      return selectors_[0].product();
-    }
-
     TriggerResultsBasedEventSelector::size_type
     TriggerResultsBasedEventSelector::fill(EventPrincipal const& ev, ModuleCallingContext const* mcc)
     {

--- a/FWCore/Framework/src/WorkerT.cc
+++ b/FWCore/Framework/src/WorkerT.cc
@@ -122,6 +122,33 @@ namespace edm{
   template<typename T>
   inline
   bool
+  WorkerT<T>::implDoPrePrefetchSelection(StreamID id,
+                                          EventPrincipal& ep,
+                                         ModuleCallingContext const* mcc) {
+    return true;
+  }
+
+  template<>
+  inline
+  bool
+  WorkerT<OutputModule>::implDoPrePrefetchSelection(StreamID id,
+                                         EventPrincipal& ep,
+                                         ModuleCallingContext const* mcc) {
+    return module_->prePrefetchSelection(id,ep,mcc);
+  }
+
+  template<>
+  inline
+  bool
+  WorkerT<edm::one::OutputModuleBase>::implDoPrePrefetchSelection(StreamID id,
+                                                    EventPrincipal& ep,
+                                                    ModuleCallingContext const* mcc) {
+    return module_->prePrefetchSelection(id,ep,mcc);
+  }
+  
+  template<typename T>
+  inline
+  bool
   WorkerT<T>::implDoBegin(RunPrincipal& rp, EventSetup const& c, ModuleCallingContext const* mcc) {
     module_->doBeginRun(rp, c, mcc);
     return true;

--- a/FWCore/Framework/src/WorkerT.h
+++ b/FWCore/Framework/src/WorkerT.h
@@ -78,6 +78,9 @@ namespace edm {
   private:
     virtual bool implDo(EventPrincipal& ep, EventSetup const& c,
                         ModuleCallingContext const* mcc) override;
+    virtual bool implDoPrePrefetchSelection(StreamID id,
+                                            EventPrincipal& ep,
+                                            ModuleCallingContext const* mcc) override;
     virtual bool implDoBegin(RunPrincipal& rp, EventSetup const& c,
                              ModuleCallingContext const* mcc) override;
     virtual bool implDoStreamBegin(StreamID id, RunPrincipal& rp, EventSetup const& c,

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -189,11 +189,6 @@ namespace edm {
       endJob();
     }
     
-    
-    Trig OutputModuleBase::getTriggerResults(EventPrincipal const& ep,
-                                             ModuleCallingContext const* mcc) const {
-      return selectors_.getOneTriggerResults(ep, mcc);  }
-    
     bool
     OutputModuleBase::doEvent(EventPrincipal const& ep,
                               EventSetup const&,

--- a/FWCore/Framework/src/one/OutputModuleBase.cc
+++ b/FWCore/Framework/src/one/OutputModuleBase.cc
@@ -212,6 +212,14 @@ namespace edm {
       endJob();
     }
     
+    bool OutputModuleBase::prePrefetchSelection(StreamID id, EventPrincipal const& ep, ModuleCallingContext const* mcc) {
+      
+      auto& s = selectors_[id.value()];
+      detail::TRBESSentry products_sentry(s);
+      
+      return wantAllEvents_ or s.wantEvent(ep,mcc);
+    }
+    
     bool
     OutputModuleBase::doEvent(EventPrincipal const& ep,
                               EventSetup const&,
@@ -219,13 +227,6 @@ namespace edm {
                               ModuleCallingContext const* mcc) {
       
       {
-        auto& s = selectors_[ep.streamID().value()];
-        detail::TRBESSentry products_sentry(s);
-        if(!wantAllEvents_) {
-          if(!s.wantEvent(ep, mcc)) {
-            return true;
-          }
-        }
         std::lock_guard<std::mutex> guard(mutex_);
         {
           std::lock_guard<SharedResourcesAcquirer> guard(resourcesAcquirer_);

--- a/FWCore/Framework/test/stubs/TestOutputModule.cc
+++ b/FWCore/Framework/test/stubs/TestOutputModule.cc
@@ -74,6 +74,7 @@ namespace edmtest
     int bitMask_;
     std::vector<unsigned char> hltbits_;
     bool expectTriggerResults_;
+    edm::EDGetTokenT<edm::TriggerResults> resultsToken_;
   };
 
   // -----------------------------------------------------------------
@@ -83,7 +84,8 @@ namespace edmtest
     name_(ps.getParameter<std::string>("name")),
     bitMask_(ps.getParameter<int>("bitMask")),
     hltbits_(0),
-    expectTriggerResults_(ps.getUntrackedParameter<bool>("expectTriggerResults",true))
+    expectTriggerResults_(ps.getUntrackedParameter<bool>("expectTriggerResults",true)),
+  resultsToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults")))
   {
   }
     
@@ -114,7 +116,7 @@ namespace edmtest
     if (!expectTriggerResults_) {
 
       try {
-        prod = getTriggerResults(e, mcc);
+        prod = getTriggerResults(resultsToken_, e, mcc);
         //throw doesn't happen until we dereference
         *prod;
       }
@@ -131,7 +133,7 @@ namespace edmtest
     // Now deal with the other case where we expect the object
     // to be present.
 
-    prod = getTriggerResults(e, mcc);
+    prod = getTriggerResults(resultsToken_, e, mcc);
 
     std::vector<unsigned char> vHltState;
 

--- a/IOPool/Streamer/interface/StreamerOutputModuleBase.h
+++ b/IOPool/Streamer/interface/StreamerOutputModuleBase.h
@@ -2,6 +2,7 @@
 #define IOPool_Streamer_StreamerOutputModuleBase_h
 
 #include "FWCore/Framework/interface/OutputModule.h"
+#include "FWCore/Utilities/interface/EDGetToken.h"
 #include "IOPool/Streamer/interface/MsgTools.h"
 #include "IOPool/Streamer/interface/StreamSerializer.h"
 #include <memory>
@@ -61,6 +62,7 @@ namespace edm {
     uint32 origSize_;
     char host_name_[255];
 
+    edm::EDGetTokenT<edm::TriggerResults> trToken_;
     Strings hltTriggerSelections_;
     uint32 outputModuleId_;
   }; //end-of-class-def

--- a/IOPool/Streamer/src/StreamerOutputModuleBase.cc
+++ b/IOPool/Streamer/src/StreamerOutputModuleBase.cc
@@ -69,6 +69,7 @@ namespace edm {
     hltbits_(0),
     origSize_(0),
     host_name_(),
+    trToken_(consumes<edm::TriggerResults>(edm::InputTag("TriggerResults"))),
     hltTriggerSelections_(),
     outputModuleId_(0) {
     // no compression as default value - we need this!
@@ -198,7 +199,7 @@ namespace edm {
 
     hltbits_.clear();  // If there was something left over from last event
 
-    Handle<TriggerResults> const& prod = getTriggerResults(e, mcc);
+    Handle<TriggerResults> const& prod = getTriggerResults(trToken_,e, mcc);
     //Trig const& prod = getTrigMask(e);
     std::vector<unsigned char> vHltState;
 


### PR DESCRIPTION
This is a backport of #10202. There was a request from analysis users for this to be backported to 7_4 but we need full testing in 7_5 before we can allow this large of a change.
