### PR TITLE
make EcalRingCalibrationTools thread safe (75x)

### DIFF
--- a/Calibration/Tools/interface/EcalRingCalibrationTools.h
+++ b/Calibration/Tools/interface/EcalRingCalibrationTools.h
@@ -11,6 +11,8 @@
  ***************************************/
 
 #include <vector>
+#include <mutex>
+#include <atomic>
 #include "DataFormats/EcalDetId/interface/EBDetId.h"
 #include "DataFormats/EcalDetId/interface/EEDetId.h"
 
@@ -33,21 +35,23 @@ class EcalRingCalibrationTools
   static std::vector<DetId> getDetIdsInModule(short int);  
   static std::vector<DetId> getDetIdsInECAL();  
 
-  static const short N_RING_TOTAL = 248;
-  static const short N_RING_BARREL = 170 ;
-  static const short N_RING_ENDCAP = 78;
+  static const short N_RING_TOTAL  = 248;
+  static const short N_RING_BARREL = 170;
+  static const short N_RING_ENDCAP =  78;
 
   static const short N_MODULES_BARREL = 144;
 
-  static void setCaloGeometry(const CaloGeometry* geometry) { caloGeometry_ = geometry; };
+  static void setCaloGeometry(const CaloGeometry* geometry);
 
  private:
-
-  static void initializeFromGeometry(); //needed only for the endcap
+  static void initializeFromGeometry(CaloGeometry const* geometry); // needed only for the endcap
   
-  static bool isInitializedFromGeometry_;
-  static short endcapRingIndex_[EEDetId::IX_MAX][EEDetId::IY_MAX]; //array needed only for the endcaps 
-  static const CaloGeometry* caloGeometry_;
+  static std::atomic<bool> isInitializedFromGeometry_;
+
+  [[cms::thread_guard("isInitializedFromGeometry_")]]
+  static short endcapRingIndex_[EEDetId::IX_MAX][EEDetId::IY_MAX];  // array needed only for the endcaps
+
+  static std::once_flag once_;
 
 };
 #endif

--- a/HLTrigger/special/src/HLTEcalPhiSymFilter.cc
+++ b/HLTrigger/special/src/HLTEcalPhiSymFilter.cc
@@ -80,7 +80,7 @@ HLTEcalPhiSymFilter::filter(edm::StreamID, edm::Event & event, const edm::EventS
   //Get iRing-geometry 
   edm::ESHandle<CaloGeometry> geoHandle;
   setup.get<CaloGeometryRecord>().get(geoHandle);
-  EcalRingCalibrationTools::setCaloGeometry(&(*geoHandle)); 
+  EcalRingCalibrationTools::setCaloGeometry(geoHandle.product()); 
   EcalRingCalibrationTools CalibRing;
 
   static const short N_RING_BARREL = EcalRingCalibrationTools::N_RING_BARREL;


### PR DESCRIPTION
Implement a minimal set of changes to EcalRingCalibrationTools to make its initialisation and usage thead-safe.
In particular, this should make HLTEcalPhiSymFilter thread-safe again.

Note that EcalRingCalibrationTools is still non-compliant with the CMS coding rules, and should be rewritten either as an ESProducer, or as a non-static data member of an EDProducer.
