### PR TITLE
Tightened timing cut for 25ns runs. Relaxed Pedestal RMS qT threshold

### DIFF
--- a/DQM/EcalMonitorClient/python/PedestalClient_cfi.py
+++ b/DQM/EcalMonitorClient/python/PedestalClient_cfi.py
@@ -7,7 +7,7 @@ from DQM.EcalMonitorTasks.PedestalTask_cfi import ecalPedestalTask
 minChannelEntries = 3
 expectedMean = 200.
 toleranceMean = 25.
-toleranceRMS = [1., 1.2, 2.] # [G1, G6, G12]
+toleranceRMS = [1., 1.5, 3.] # [G1, G6, G12]
 expectedPNMean = 750.
 tolerancePNMean = 100.
 tolerancePNRMS = [20., 20.] # [G1, G16]

--- a/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
+++ b/DQM/EcalMonitorTasks/python/TimingTask_cfi.py
@@ -6,7 +6,7 @@ for i in range(50) :
 
 energyThresholdEE = 3.
 energyThresholdEB = 1.
-timeWindow = 25.
+timeWindow = 12.5
 summaryTimeWindow = 7.
 
 ecalTimingTask = cms.untracked.PSet(


### PR DESCRIPTION
-Tightened EE/EB rechit timing cut for 25 ns runs. 
-Relaxed EE/EB RMS quality threshold for Pedestal Gain6 and Gain12.
