### PR TITLE
Forward originalAlgo and algoMask in TrackRefitter

### DIFF
--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
@@ -52,6 +52,7 @@ public:
   /// Constructor
   TrackProducerAlgorithm(const edm::ParameterSet& conf) : 
     algo_(reco::TrackBase::algoByName(conf.getParameter<std::string>("AlgorithmName"))),
+    originalAlgo_(reco::TrackBase::undefAlgorithm),
     reMatchSplitHits_(false),
     usePropagatorForPCA_(false)
       {
@@ -134,6 +135,8 @@ public:
 
  private:
   reco::TrackBase::TrackAlgorithm algo_;
+  reco::TrackBase::TrackAlgorithm originalAlgo_;
+  reco::TrackBase::AlgoMask algoMask_;
   bool reMatchSplitHits_;
   bool geometricInnerState_;
   bool usePropagatorForPCA_;

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.h
@@ -51,18 +51,16 @@ public:
 
   /// Constructor
   TrackProducerAlgorithm(const edm::ParameterSet& conf) : 
-    conf_(conf),
-    algoName_(conf_.getParameter<std::string>( "AlgorithmName" )),
-    algo_(reco::TrackBase::algoByName(algoName_)),
+    algo_(reco::TrackBase::algoByName(conf.getParameter<std::string>("AlgorithmName"))),
     reMatchSplitHits_(false),
     usePropagatorForPCA_(false)
       {
-        geometricInnerState_ = (conf_.exists("GeometricInnerState") ?
-	  conf_.getParameter<bool>( "GeometricInnerState" ) : true);
-	if (conf_.exists("reMatchSplitHits"))
-	  reMatchSplitHits_=conf_.getParameter<bool>("reMatchSplitHits");
-        if (conf_.exists("usePropagatorForPCA"))
-          usePropagatorForPCA_ = conf_.getParameter<bool>("usePropagatorForPCA");
+        geometricInnerState_ = (conf.exists("GeometricInnerState") ?
+	  conf.getParameter<bool>( "GeometricInnerState" ) : true);
+	if (conf.exists("reMatchSplitHits"))
+	  reMatchSplitHits_=conf.getParameter<bool>("reMatchSplitHits");
+        if (conf.exists("usePropagatorForPCA"))
+          usePropagatorForPCA_ = conf.getParameter<bool>("usePropagatorForPCA");
       }
 
   /// Destructor
@@ -135,8 +133,6 @@ public:
 
 
  private:
-  edm::ParameterSet conf_;  
-  std::string algoName_;
   reco::TrackBase::TrackAlgorithm algo_;
   bool reMatchSplitHits_;
   bool geometricInnerState_;

--- a/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
+++ b/RecoTracker/TrackProducer/interface/TrackProducerAlgorithm.icc
@@ -171,6 +171,8 @@ TrackProducerAlgorithm<T>::runWithTrack(const TrackingGeometry * theG,
 
 	//set the algo_ member in order to propagate the old alog name
 	algo_=theT->algo();	
+	originalAlgo_ = theT->originalAlgo();
+	algoMask_ = theT->algoMask();
 
 	//=====  the hits are in the same order as they were in the track::extra.
         FitterCloner fc(theFitter,builder);        

--- a/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
+++ b/RecoTracker/TrackProducer/src/TrackProducerAlgorithm.cc
@@ -211,6 +211,8 @@ std::cout << algo_ << ": " <<  hits.size() <<'|' <<theTraj->measurements().size(
 			     tscbl.trackStateAtPCA().curvilinearError(),
 			     algo_);
   
+  if(originalAlgo_ != reco::TrackBase::undefAlgorithm) theTrack->setOriginalAlgorithm(originalAlgo_);
+  if(algoMask_.any())                                  theTrack->setAlgoMask(algoMask_);
   theTrack->setQualityMask(qualityMask);
   theTrack->setNLoops(nLoops);
   
@@ -340,6 +342,8 @@ TrackProducerAlgorithm<reco::GsfTrack>::buildTrack (const TrajectoryFitter * the
 				//			       theTraj->lostHits(),//FIXME to be fixed in Trajectory.h
 				pos, mom, tscbl.trackStateAtPCA().charge(), tscbl.trackStateAtPCA().curvilinearError());    
   theTrack->setAlgorithm(algo_);
+  if(originalAlgo_ != reco::TrackBase::undefAlgorithm) theTrack->setOriginalAlgorithm(originalAlgo_);
+  if(algoMask_.any())                                  theTrack->setAlgoMask(algoMask_);
   
   LogDebug("GsfTrackProducer") <<"track done\n";
   


### PR DESCRIPTION
This PR adds forwarding of originalAlgo and algoMask for TrackRefitter to the TrackProducerAlgorithm. The PR also includes minor cleanup of unnecessary members in TrackProducerAlgorithm.

Tested in 760pre4, no changes in RECO expected.

@rovere @VinInn 
